### PR TITLE
use correct npm package for uglify-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"dependencies": {
 		"esprima": "0.9.x",
 		"optimist": "0.2.x",
-		"uglify-js2": "2.1.x",
+		"uglify-js": "2.1.x",
 		"sprintf": "0.1.x",
 		"enhanced-require": "0.4.x",
 		"enhanced-resolve": "0.4.x",


### PR DESCRIPTION
The `uglify-js2` npm package should now be installed as `uglify-js` since it was re-named.  The `uglify-js2` package is deprecated.
