### PR TITLE
Fixed a bug where finishChunkLoading() was accidentally called twice

### DIFF
--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -216,7 +216,6 @@ var hotInitCode = function() {
 				} finally {
 					finishChunkLoading();
 				}
-				finishChunkLoading();
 				function finishChunkLoading() {
 					hotChunksLoading--;
 					if(hotStatus === "prepare") {


### PR DESCRIPTION
HCR wasn't working in my project because `hotChunksLoading` was below `0`. Then I figured out that `finishChunkLoading()` was called twice.

With that fix HCR is working like a charm :+1: 

Please bump the version and publish if possible.
