### PR TITLE
Require externals plugin for node-webkit target.

### DIFF
--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -101,6 +101,7 @@ WebpackOptionsApply.prototype.process = function(options, compiler) {
 		case "node-webkit":
 			var JsonpTemplatePlugin = require("./JsonpTemplatePlugin");
 			var NodeTargetPlugin = require("./node/NodeTargetPlugin");
+			var ExternalsPlugin = require("./ExternalsPlugin");
 			compiler.apply(
 				new JsonpTemplatePlugin(options.output),
 				new FunctionModulePlugin(options.output),


### PR DESCRIPTION
I was getting `Warning: undefined is not a function Use --force to continue.` when trying to use `target:'node-webkit'`. This fixes the problem.
