### PR TITLE
Bug fix:  template.apply() expects dependencyTemplates arg

### DIFF
--- a/lib/DependenciesBlockVariable.js
+++ b/lib/DependenciesBlockVariable.js
@@ -25,7 +25,7 @@ DependenciesBlockVariable.prototype.expressionSource = function(dependencyTempla
 	this.dependencies.forEach(function(dep) {
 		var template = dependencyTemplates.get(dep.Class);
 		if(!template) throw new Error("No template for dependency: " + dep.Class.name);
-		template.apply(dep, source, outputOptions, requestShortener);
+		template.apply(dep, source, outputOptions, requestShortener, dependencyTemplates);
 	});
 	return source;
 };


### PR DESCRIPTION
Prototype method template.apply() defined at `/lib/dependencies/TemplateArgumentDependency.js:21` expects a 5th argument.  This fixes a crash I was experiencing running webpack for production.

```
var template = dependencyTemplates.get(d.Class);
TypeError: Cannot call method 'get' of undefined
```
