### PR TITLE
Support any UglifyJS OutputStream option {output: {...}}

### DIFF
--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -75,11 +75,14 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 						file: file,
 						root: ""
 					});
-					var stream = uglify.OutputStream({
-						comments: options.comments || /^\**!|@preserve|@license/,
-						beautify: options.beautify,
-						source_map: map
-					});
+					var output = {};
+					output.comments = options.comments || /^\**!|@preserve|@license/;
+					output.beautify = options.beautify;
+					for(var k in options.output) {
+						output[k] = options.output[k];
+					}
+					output.source_map = map;
+					var stream = uglify.OutputStream(output);
 					ast.print(stream);
 					map = map + "";
 					stream = stream + "";


### PR DESCRIPTION
I found myself wanting to use `preserve_line` and similar options for `OutputStream` but the bundled UglifyJS lib does not provide any means to do so.

This PR enables the use of any current and future options to be used and is fully backwards-compatible.
