### PR TITLE
Add assets to module stats

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -124,6 +124,7 @@ Stats.prototype.toJson = function toJson(options, forToString) {
 			chunks: module.chunks.map(function(chunk) {
 				return chunk.id;
 			}),
+			assets: Object.keys(module.assets || {}),
 			issuer: module.issuer,
 			profile: module.profile,
 			failed: !!module.error,


### PR DESCRIPTION
When requiring assets (`require('file!./image.jpg')`), you can rely on webpack to have rewritten the require statements to find the right assets at run time on the client. If you want to use that same asset on the server, though, you need some way to discover how that asset was emitted. This PR solves that use case by simply adding the emitted assets to each module's stats.
