### PR TITLE
CachePlugin: Continue when file is deleted

### DIFF
--- a/lib/CachePlugin.js
+++ b/lib/CachePlugin.js
@@ -19,7 +19,10 @@ CachePlugin.prototype.apply = function(compiler) {
 		fileTs = compiler.fileTimestamps = {};
 		async.forEach(compiler._lastCompilationFileDependencies, function(file, callback) {
 			fs.stat(file, function(err, stat) {
-				if(err) return callback(err);
+				if(err) {
+					if(err.code === 'ENOENT') return callback();
+					return callback(err);
+				}
 				
 				fileTs[file] = stat.mtime || Infinity;
 				callback();


### PR DESCRIPTION
With the CachePlugin, if a file is deleted it displays this error:

```
>> Error: ENOENT, stat '/Users/Kyle/Documents/www/ynab/ynab_web/src/components/deleteme.coffee'
```

After that, subsequent compilations fail requiring you to restart the watch.

This PR will ignore any files that don't exist in the cache and allow subsequent compilations to run.
