### PR TITLE
Fix: "*" was being appended to sources too often

### DIFF
--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -44,7 +44,7 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 							str = str.split("!");
 							str = str.pop() + (str.length > 0 ? " " + str.join("!") : "");
 							var idx;
-							while((idx = sourceMap.sources.indexOf(str) >= 0) && (idx < i)) {
+							while ((idx = sourceMap.sources.indexOf(str)) && (idx >= 0) && (idx < i)) {
 								str += "*";
 							}
 							sourceMap.sources[i] = str;


### PR DESCRIPTION
The while loop construction was actually yielding false positives due to the placement of parentheses, and would append an "*" to sources even when unnecessary.

In the previous construction of the while loop, idx was being assigned the boolean value true or false, and NOT the index of the string. The comparison happened first, and then the assignment. So, unrolled, it looked like this before:

idx = (sourceMap.sources.indexof(str) >= 0);
//idx will now be true or false
//Now we'll compare true to our current index, which will always be true for i > 1.
if (idx < i){
...
}

This was causing the sourcemap dev tool to append "*" unnecessarily to some of my sources.
This same construct is also found in the other SourceMapDevTool plugins I believe. 
