### PR TITLE
Fix: setConstant and setModuleConstant now function correctly again.

### DIFF
--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -21,17 +21,17 @@ NodeStuffPlugin.prototype.apply = function(compiler) {
 		compilation.dependencyTemplates.set(ConstDependency, new ConstDependency.Template());
 	});
 	function ignore() { return true; }
-	function setConstant(expr, value) {
-		compiler.parser.plugin("expression " + expr, function(expr) {
-			this.state.current.addVariable(expr, JSON.stringify(value));
+	function setConstant(expressionName, value) {
+		compiler.parser.plugin("expression " + expressionName, function(expr) {
+			this.state.current.addVariable(expressionName, JSON.stringify(value));
 			return true;
-		});	
+		});
 	}
-	function setModuleConstant(expr, fn) {
-		compiler.parser.plugin("expression " + expr, function(expr) {
-			this.state.current.addVariable(expr, JSON.stringify(fn(this.state.module)));
+	function setModuleConstant(expressionName, fn) {
+		compiler.parser.plugin("expression " + expressionName, function(expr) {
+			this.state.current.addVariable(expressionName, JSON.stringify(fn(this.state.module)));
 			return true;
-		});	
+		});
 	}
 	var context = compiler.context;
 	if(this.options.__filename === "mock") {


### PR DESCRIPTION
Fixes GH-343

Previously, __filename, __dirname, and other constants were broken. This was due to
the refactor of setConstant and setModuleConstant, and the reuse of the variable name "expr"

Fixes a bug introduced in: commit https://github.com/webpack/webpack/commit/d80cdcefac9aa6ee697985a6dbb86d2f3242c561#diff-3e392a298aac97e71e5ecb5dfa287f98

When using __filename I was getting errors like this:

```
Fatal error: Not a string or buffer
TypeError: Not a string or buffer
  at Hash.update (crypto.js:209:17)
  at DependenciesBlockVariable.updateHash (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/DependenciesBlockVariable.js:16:7)
  at /vagrant_host/clean/ynab_web/node_modules/webpack/lib/DependenciesBlock.js:39:5
  at Array.forEach (native)
  at DependenciesBlock.updateHash (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/DependenciesBlock.js:38:17)
  at DependenciesBlock.Module.updateHash (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/Module.js:60:41)
  at DependenciesBlock.NormalModule.updateHash (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/NormalModule.js:184:30)
  at /vagrant_host/clean/ynab_web/node_modules/webpack/lib/Chunk.js:166:5
  at Array.forEach (native)
  at Chunk.updateHash (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/Chunk.js:165:15)
  at Tapable.createHash (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:629:9)
  at Tapable.<anonymous> (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:466:8)
  at Tapable.applyPluginsAsync (/vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/tapable/lib/Tapable.js:60:69)
  at Tapable.seal (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:445:7)
  at Tapable.<anonymous> (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compiler.js:380:15)
  at /vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/tapable/lib/Tapable.js:107:11
  at Tapable.<anonymous> (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:415:10)
  at Tapable.<anonymous> (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:388:12)
  at /vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:310:10
  at done (/vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/async/lib/async.js:135:19)
  at /vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/async/lib/async.js:32:16
  at /vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:310:10
  at done (/vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/async/lib/async.js:135:19)
  at /vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/async/lib/async.js:32:16
  at /vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:310:10
  at done (/vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/async/lib/async.js:135:19)
  at /vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/async/lib/async.js:32:16
  at /vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:310:10
  at done (/vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/async/lib/async.js:135:19)
  at /vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/async/lib/async.js:32:16
  at /vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:310:10
  at done (/vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/async/lib/async.js:135:19)
  at /vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/async/lib/async.js:32:16
  at /vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:310:10
  at done (/vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/async/lib/async.js:135:19)
  at /vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/async/lib/async.js:32:16
  at Tapable.<anonymous> (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:215:12)
  at NullFactory.create (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/NullFactory.js:10:9)
  at Tapable.<anonymous> (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:198:11)
  at /vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/async/lib/async.js:125:13
  at Array.forEach (native)
  at _each (/vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/async/lib/async.js:46:24)
  at Object.async.each (/vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/async/lib/async.js:124:9)
  at Tapable.Compilation.addModuleDependencies (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:168:8)
  at Tapable.Compilation.processModuleDependencies (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:156:7)
  at Tapable.<anonymous> (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:298:11)
  at /vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:112:4
  at Array.forEach (native)
  at callback (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:111:12)
  at Tapable.<anonymous> (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/Compilation.js:128:10)
  at DependenciesBlock.<anonymous> (/vagrant_host/clean/ynab_web/node_modules/webpack/lib/NormalModule.js:96:10)
  at DependenciesBlock.onModuleBuild (/vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:281:10)
  at nextLoader (/vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:252:25)
  at Storage.finished (/vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:38:16)
  at fs.js:266:14
  at /vagrant_host/clean/ynab_web/node_modules/webpack/node_modules/enhanced-resolve/node_modules/graceful-fs/graceful-fs.js:104:5
  at Object.oncomplete (fs.js:107:15)
```

This was due to the use of the variable name "expr" in two separate contexts. In the inner most context, "expr" was no longer a string, but was instead an expression object.
