### PR TITLE
Deref dedupe template module when module fn is called.

### DIFF
--- a/lib/optimize/DedupePlugin.js
+++ b/lib/optimize/DedupePlugin.js
@@ -155,10 +155,10 @@ DedupePlugin.prototype.apply = function(compiler) {
 					"// Module can be created from a template",
 					"modules[" + varModuleId + "] = (function(_m) {",
 					this.indent([
-						"var args = _m.slice(1), fn = modules[_m[0]];",
+						"var args = _m.slice(1), templateId = _m[0];",
 						"return function (a,b,c) {",
 						this.indent([
-							"fn.apply(this, [a,b,c].concat(args));"
+							"modules[templateId].apply(this, [a,b,c].concat(args));"
 						]),
 						"};"
 					]),


### PR DESCRIPTION
From what I can tell the `DedupePlugin` is templating a module and using a template module that isn't in `modules` yet resulting in an undefined function that it tries to call.
