### PR TITLE
Make source map generated filenames configurable and use [name]?[loaders] by default

### DIFF
--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -8,14 +8,16 @@ var Template = require("./Template");
 var ConcatSource = require("webpack-core/lib/ConcatSource");
 var RawSource = require("webpack-core/lib/RawSource");
 
-function SourceMapDevToolPlugin(sourceMapFilename, sourceMappingURLComment) {
+function SourceMapDevToolPlugin(sourceMapFilename, sourceMappingURLComment, moduleFilename) {
 	this.sourceMapFilename = sourceMapFilename;
 	this.sourceMappingURLComment = sourceMappingURLComment || "\n//# sourceMappingURL=[url]";
+	this.moduleFilename = moduleFilename || "[name]?[loaders]";
 }
 module.exports = SourceMapDevToolPlugin;
 SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 	var sourceMapFilename = this.sourceMapFilename;
 	var sourceMappingURLComment = this.sourceMappingURLComment;
+	var moduleFilename = this.moduleFilename;
 	var requestShortener = new RequestShortener(compiler.context);
 	compiler.plugin("compilation", function(compilation) {
 		compilation.plugin("build-module", function(module) {
@@ -36,14 +38,19 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 					if(sourceMap) {
 						for(var i = 0; i < sourceMap.sources.length; i++) {
 							var source = sourceMap.sources[i];
-							var str;
+							var str, name, loaders;
 							var module = compilation.findModule(source);
 							if(module)
 								str = module.readableIdentifier(requestShortener);
 							else
 								str = requestShortener.shorten(source);
 							str = str.split("!");
-							str = str.pop() + (str.length > 0 ? " " + str.join("!") : "");
+							name = str.pop();
+							loaders = str.join("!");
+							str = moduleFilename
+								.replace(/\[name\]/gi, name)
+								.replace(/\[loaders\]/gi, loaders)
+								.replace(/\[id\]/gi, module && module.id || '');
 							var idx;
 							while((idx = sourceMap.sources.indexOf(str)) && (idx >= 0) && (idx < i)) {
 								str += "*";


### PR DESCRIPTION
This allows more configurability (I can use it to implement [this](https://github.com/webpack/webpack/issues/363) without touching core).

Also, this changes default from `[name] [loaders]` to `[name]?[loaders]` so DevTools display the correct filename.
