### PR TITLE
Normalize sourceRoot values to null

### DIFF
--- a/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
+++ b/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
@@ -38,7 +38,7 @@ EvalSourceMapDevToolModuleTemplatePlugin.prototype.apply = function(moduleTempla
 				return content + "\n\n\n" + ModuleFilenameHelpers.createFooter(modules[i], this.requestShortener);
 			}, this);
 		}
-		sourceMap.sourceRoot = "";
+		sourceMap.sourceRoot = null;
 		sourceMap.file = module.id + ".js";
 		var footer = self.sourceMapComment.replace(/\[url\]/g, "data:application/json;base64," + new Buffer(JSON.stringify(sourceMap)).toString("base64"));
 		return new RawSource("eval(" + JSON.stringify(content + footer) + ");" );

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -97,7 +97,7 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 						return content + "\n\n\n" + ModuleFilenameHelpers.createFooter(modules[i], requestShortener);
 					});
 				}
-				sourceMap.sourceRoot = "";
+				sourceMap.sourceRoot = null;
 				sourceMap.file = file;
 				asset.__SourceMapDevTool_Data = {};
 				if(sourceMapFilename) {


### PR DESCRIPTION
source-map>=0.1.35 will make sourceFile paths relative if sourceRoot is non-null (including the empty string).

This is necessary for webpack/core#5.
