### PR TITLE
Trigger the system bell on compile errors

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -146,6 +146,9 @@ var compiler = webpack(options, function(err, stats) {
 		process.stdout.write(JSON.stringify(stats.toJson(outputOptions), null, 2) + "\n");
 	} else if(stats.hash !== lastHash) {
 		lastHash = stats.hash;
-		process.stdout.write(stats.toString(outputOptions) + "\n");
+		// Triggers the system bell when there is an error
+		// (on OS X it makes the Terminal.app's icon bounce in the dock)
+		var bell = stats.hasErrors() ? "\u0007" : "";
+		process.stdout.write(bell + stats.toString(outputOptions) + "\n");
 	}
 });


### PR DESCRIPTION
This is a small pull request that automatically triggers the system bell when an error message is printed after a compilation error. This can be really helpful if your terminal notifies you about this even when it is in the background (by bouncing/blinking the icon in the dock/task bar). This should not have any negative effects because most terminal emulators have an option to ignore the system bell character.

Fixes #388
