### PR TITLE
Add a semi-colon at the end of the UMD template

### DIFF
--- a/lib/UmdMainTemplatePlugin.js
+++ b/lib/UmdMainTemplatePlugin.js
@@ -91,7 +91,7 @@ UmdMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 			"		for(var i in a) (typeof exports === 'object' ? exports : root)[i] = a[i];\n" +
 			"	}\n"
 			) +
-			"})(this, function(" + externalsArguments + ") {\nreturn ", "webpack/universalModuleDefinition"), source, "\n})\n");
+			"})(this, function(" + externalsArguments + ") {\nreturn ", "webpack/universalModuleDefinition"), source, "\n});\n");
 	}.bind(this));
 	mainTemplate.plugin("global-hash", function(chunk) {
 		if(Template.REGEXP_HASH.test([].concat(this.name || "").join("|")))


### PR DESCRIPTION
Rationale: the missing semi-colon can cause bugs in some edge cases where webpack is used to generate a library that will be concatenated in dependent project.
