### PR TITLE
Function name cannot contain -

### DIFF
--- a/lib/JsonpChunkTemplatePlugin.js
+++ b/lib/JsonpChunkTemplatePlugin.js
@@ -3,6 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 var ConcatSource = require("webpack-core/lib/ConcatSource");
+var Template = require("./Template");
 
 function JsonpChunkTemplatePlugin() {
 }
@@ -10,7 +11,7 @@ module.exports = JsonpChunkTemplatePlugin;
 
 JsonpChunkTemplatePlugin.prototype.apply = function(chunkTemplate) {
 	chunkTemplate.plugin("render", function(modules, chunk) {
-		var jsonpFunction = this.outputOptions.jsonpFunction || ("webpackJsonp" + (this.outputOptions.library || ""));
+		var jsonpFunction = this.outputOptions.jsonpFunction || Template.toIdentifier("webpackJsonp" + (this.outputOptions.library || ""));
 		var source = new ConcatSource();
 		source.add(jsonpFunction + "(" + JSON.stringify(chunk.ids) + ",");
 		source.add(modules);

--- a/lib/JsonpHotUpdateChunkTemplatePlugin.js
+++ b/lib/JsonpHotUpdateChunkTemplatePlugin.js
@@ -3,6 +3,8 @@
 	Author Tobias Koppers @sokra
 */
 var ConcatSource = require("webpack-core/lib/ConcatSource");
+var Template = require("./Template");
+
 
 function JsonpHotUpdateChunkTemplatePlugin() {
 }
@@ -10,7 +12,7 @@ module.exports = JsonpHotUpdateChunkTemplatePlugin;
 
 JsonpHotUpdateChunkTemplatePlugin.prototype.apply = function(hotUpdateChunkTemplate) {
 	hotUpdateChunkTemplate.plugin("render", function(modulesSource, modules, hash, id) {
-		var jsonpFunction = this.outputOptions.hotUpdateFunction || ("webpackHotUpdate" + (this.outputOptions.library || "").replace('-','_'));
+		var jsonpFunction = this.outputOptions.hotUpdateFunction || Template.toIdentifier("webpackHotUpdate" + (this.outputOptions.library || ""));
 		var source = new ConcatSource();
 		source.add(jsonpFunction + "(" + JSON.stringify(id) + ",");
 		source.add(modulesSource);

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -72,7 +72,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 	});
 	mainTemplate.plugin("bootstrap", function(source, chunk, hash) {
 		if(chunk.chunks.length > 0) {
-			var jsonpFunction = this.outputOptions.jsonpFunction || ("webpackJsonp" + (this.outputOptions.library || ""));
+			var jsonpFunction = this.outputOptions.jsonpFunction || Template.toIdentifier("webpackJsonp" + (this.outputOptions.library || ""));
 			return this.asString([
 				source,
 				"",
@@ -114,7 +114,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 	mainTemplate.plugin("hot-bootstrap", function(source, chunk, hash) {
 		var hotUpdateChunkFilename = this.outputOptions.hotUpdateChunkFilename;
 		var hotUpdateMainFilename = this.outputOptions.hotUpdateMainFilename;
-		var hotUpdateFunction = this.outputOptions.hotUpdateFunction || ("webpackHotUpdate" + (this.outputOptions.library || "").replace('-','_'));
+		var hotUpdateFunction = this.outputOptions.hotUpdateFunction || Template.toIdentifier("webpackHotUpdate" + (this.outputOptions.library || ""));
 		var currentHotUpdateChunkFilename = JSON.stringify(hotUpdateChunkFilename)
 			.replace(Template.REGEXP_HASH, "\" + " + this.renderCurrentHashCode(hash) + " + \"")
 			.replace(Template.REGEXP_ID, "\" + chunkId + \"");

--- a/lib/Template.js
+++ b/lib/Template.js
@@ -98,3 +98,7 @@ Template.prototype.renderChunkModules = function(chunk, moduleTemplate, dependen
 Template.getFunctionContent = function(fn) {
 	return fn.toString().replace(/^function\s?\(\)\s?\{\n?|\n?\}$/g, "").replace(/^\t/mg, "");
 };
+
+Template.toIdentifier = function(str) {
+	return str.replace(/^[^a-zA-Z$_]/,"_").replace(/[^a-zA-Z0-9$_]/g, '_');
+}

--- a/lib/node/NodeMainTemplatePlugin.js
+++ b/lib/node/NodeMainTemplatePlugin.js
@@ -95,7 +95,7 @@ NodeMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 	mainTemplate.plugin("hot-bootstrap", function(source, chunk, hash) {
 		var hotUpdateChunkFilename = this.outputOptions.hotUpdateChunkFilename;
 		var hotUpdateMainFilename = this.outputOptions.hotUpdateMainFilename;
-		var hotUpdateFunction = this.outputOptions.hotUpdateFunction || ("webpackHotUpdate" + (this.outputOptions.library || ""));
+		var hotUpdateFunction = this.outputOptions.hotUpdateFunction || Template.toIdentifier("webpackHotUpdate" + (this.outputOptions.library || ""));
 		var currentHotUpdateChunkFilename = JSON.stringify(hotUpdateChunkFilename)
 			.replace(Template.REGEXP_HASH, "\" + " + this.renderCurrentHashCode(hash) + " + \"")
 			.replace(Template.REGEXP_ID, "\" + chunkId + \"");

--- a/lib/webworker/WebWorkerChunkTemplatePlugin.js
+++ b/lib/webworker/WebWorkerChunkTemplatePlugin.js
@@ -3,6 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 var ConcatSource = require("webpack-core/lib/ConcatSource");
+var Template = require("../Template");
 
 function WebWorkerChunkTemplatePlugin() {
 }
@@ -10,7 +11,7 @@ module.exports = WebWorkerChunkTemplatePlugin;
 
 WebWorkerChunkTemplatePlugin.prototype.apply = function(chunkTemplate) {
 	chunkTemplate.plugin("render", function(modules, chunk) {
-		var chunkCallbackName = this.outputOptions.chunkCallbackName || ("webpackChunk" + (this.outputOptions.library || ""));
+		var chunkCallbackName = this.outputOptions.chunkCallbackName || Template.toIdentifier("webpackChunk" + (this.outputOptions.library || ""));
 		var source = new ConcatSource();
 		source.add(chunkCallbackName + "(" + JSON.stringify(chunk.ids) + ",");
 		source.add(modules);

--- a/lib/webworker/WebWorkerMainTemplatePlugin.js
+++ b/lib/webworker/WebWorkerMainTemplatePlugin.js
@@ -47,7 +47,7 @@ WebWorkerMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 	});
 	mainTemplate.plugin("bootstrap", function(source, chunk, hash) {
 		if(chunk.chunks.length > 0) {
-			var chunkCallbackName = this.outputOptions.chunkCallbackName || ("webpackChunk" + (this.outputOptions.library || ""));
+			var chunkCallbackName = this.outputOptions.chunkCallbackName || Template.toIdentifier("webpackChunk" + (this.outputOptions.library || ""));
 			return this.asString([
 				source,
 				"this[" + JSON.stringify(chunkCallbackName) + "] = function webpackChunkCallback(chunkIds, moreModules) {",

--- a/test/Template.test.js
+++ b/test/Template.test.js
@@ -1,0 +1,10 @@
+ould = require("should");
+var path = require("path");
+
+var template = require("../lib/Template");
+
+describe("Template", function() {
+  it("should generate valid identifiers", function() {
+    template.toIdentifier("0abc-def9").should.equal("_abc_def9");
+  });
+});


### PR DESCRIPTION
When output.library contains a - the generated function name is not
valid.  Replace - with _ to create valid function name.
