### PR TITLE
Improve error handling of hot manifest requests

### DIFF
--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -140,14 +140,17 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 				try {
 					var request = new XMLHttpRequest();
 					request.open("GET", $require$.p + $hotMainFilename$, true);
+					request.timeout = 10000;
 					request.send(null);
 				} catch(err) {
 					return callback(err);
 				}
 				request.onreadystatechange = function() {
 					if(request.readyState !== 4) return;
-					if(request.status !== 200 && request.status !== 304) {
-						callback();
+					if(request.status === 0) {
+						callback(new Error("Manifest request to " + $require$.p + $hotMainFilename$ + " timed out.\nIs output.publicPath correct?"));
+					} else if(request.status !== 200 && request.status !== 304) {
+						callback(new Error("Manifest request to " + $require$.p + $hotMainFilename$ + " ended with " + request.status + " instead of 200 or 304"));
 					} else {
 						try {
 							var update = JSON.parse(request.responseText);


### PR DESCRIPTION
Until now request errors while fetching the hot manifest have been handled at all. This pull-request adds descriptive errors.