### PR TITLE
Fix #412 - Support for holes inside Arrays

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -310,7 +310,7 @@ Parser.prototype.initializeEvaluating = function() {
 	});
 	this.plugin("evaluate ArrayExpression", function(expr) {
 		var items = expr.elements.map(function(element) {
-			return this.evaluateExpression(element);
+			return element !== null && this.evaluateExpression(element);
 		}, this);
 		if(items.filter(function(i) { return !i; }).length > 0) return;
 		return new BasicEvaluatedExpression().setItems(items).setRange(expr.range);


### PR DESCRIPTION
An array with a hole such as `[,'foo']` is parsed by Esprima as null.
Skip its evaluation.

Reference: https://code.google.com/p/esprima/issues/detail?id=525#c18

```
According to
https://developer.mozilla.org/en-US/docs/SpiderMonkey/Parser_API#Expressions:

  interface ArrayExpression <: Expression {
    type: "ArrayExpression";
    elements: [ Expression | null ];
  }
```
