### PR TITLE
Add node-independent shim for global setImmediate()

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -43,6 +43,7 @@ function WebpackOptionsDefaulter() {
 	this.set("node.process", true);
 	this.set("node.global", true);
 	this.set("node.buffer", true);
+	this.set("node.setimmediate", true);
 	this.set("node.__filename", "mock");
 	this.set("node.__dirname", "mock");
 

--- a/lib/node/NodeSourcePlugin.js
+++ b/lib/node/NodeSourcePlugin.js
@@ -48,6 +48,12 @@ NodeSourcePlugin.prototype.apply = function(compiler) {
 			return ModuleParserHelpers.addParsedVariable(this, "Buffer", "require(" + JSON.stringify(getPathToModule("buffer", bufferType)) + ").Buffer");
 		});
 	}
+	if(this.options.setimmediate) {
+		var setimmediate = this.options.setimmediate;
+		compiler.parser.plugin("expression setImmediate", function(expr) {
+			return ModuleParserHelpers.addParsedVariable(this, "setImmediate", "require(" + JSON.stringify(getPathToModule("setimmediate", setimmediate)) + ") && setImmediate");
+		});
+	}
 	var options = this.options;
 	compiler.plugin("after-resolvers", function(compiler) {
 		var alias = {};


### PR DESCRIPTION
This pull-request requires https://github.com/webpack/node-libs-browser/pull/13 to be merged in.
