### PR TITLE
Update CaseSensitiveModulesWarning.js

### DIFF
--- a/lib/CaseSensitiveModulesWarning.js
+++ b/lib/CaseSensitiveModulesWarning.js
@@ -6,7 +6,7 @@ function CaseSensitiveModulesWarning(module) {
 	Error.call(this);
 	Error.captureStackTrace(this, CaseSensitiveModulesWarning);
 	this.name = "CaseSensitiveModulesWarning";
-	this.message = "There is another module with a equal name when case is ignored.\n" +
+	this.message = "There is another module with an equal name when case is ignored.\n" +
 		"This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.\n" +
 		"Rename module if multiple modules are expected or use equal casing if one module is expected.";
 	this.origin = this.module = module;


### PR DESCRIPTION
I believe this should be "an equal" instead of "a equal"
