### PR TITLE
If module compilation fails, then do not record updates for HMR

### DIFF
--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -33,7 +33,14 @@ HotModuleReplacementPlugin.prototype.apply = function(compiler) {
 		compilation.dependencyFactories.set(ModuleHotDeclineDependency, normalModuleFactory);
 		compilation.dependencyTemplates.set(ModuleHotDeclineDependency, new ModuleHotDeclineDependency.Template());
 
+		var failed = false;
+    
+		compilation.plugin("failed-module", function(module) {
+			failed = true;
+		});
+    
 		compilation.plugin("record", function(compilation, records) {
+			if(failed) return;
 			if(records.hash === this.hash) return;
 			records.hash = compilation.hash;
 			records.moduleHashs = {};
@@ -53,6 +60,7 @@ HotModuleReplacementPlugin.prototype.apply = function(compiler) {
 			});
 		});
 		compilation.plugin("after-hash", function() {
+			if(failed) return;
 			var records = this.records;
 			if(!records) return;
 			var lastHash = records.hash || "x";
@@ -67,6 +75,7 @@ HotModuleReplacementPlugin.prototype.apply = function(compiler) {
 			this.modifyHash(records.prepreHash);
 		});
 		compilation.plugin("additional-chunk-assets", function() {
+			if(failed) return;
 			var records = this.records;
 			if(records.hash === this.hash) return;
 			if(!records.moduleHashs || !records.chunkHashs || !records.chunkModuleIds) return;


### PR DESCRIPTION
Fixes https://github.com/webpack/webpack-dev-server/issues/42, makes #418 unneeded.

Works fine with style-loader, react-hot-loader as-is. 

Allows module compilation errors to occur without disrupting hot module reloading. When a previously failed module compilation succeeds, hot module reloading continues working as normal, without any special code needed in the HMR handlers.
