### PR TITLE
Added enclose option in the Uuglifyjs plugin

### DIFF
--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -60,6 +60,18 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 					var ast = uglify.parse(input, {
 						filename: file
 					});
+					
+					if(options.enclose) {
+						var enclose = options.enclose;
+						if(!Array.isArray(enclose)) {
+							enclose = [];
+							for (var name in options.enclose) {
+								enclose.push(name + ':' + options.enclose[name]);
+							}
+						}
+						ast = ast.wrap_enclose(enclose);
+					}
+					
 					ast.figure_out_scope()
 					if(options.compress !== false) {
 						var compress = uglify.Compressor(options.compress);


### PR DESCRIPTION
Added support for the `enclose` option of UglifyJs. Useful way to get even higher compression rates!
Supports receiving objects and arrays;

````js
new webpack.optimize.UglifyJsPlugin({
   enclose: {
      'window':'window',
      'document':'document'
   }
});
````

````js
new webpack.optimize.UglifyJsPlugin({
    enclose: ['window:window', 'document:document']
});
````