### PR TITLE
Add 'id' attribute to require.context (so HMR can accept a context)

### DIFF
--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -93,7 +93,7 @@ ContextModule.prototype.source = function(dependencyTemplates, outputOptions, re
 			"function webpackContextResolve(req) {\n",
 			"\treturn map[req] || (function() { throw new Error(\"Cannot find module '\" + req + \"'.\") }());\n",
 			"};\n",
-			"webpackContext.id = "+this.id+"\n",
+			"webpackContext.id = "+this.id+";\n",
 			"webpackContext.keys = function webpackContextKeys() {\n",
 			"\treturn Object.keys(map);\n",
 			"};\n",


### PR DESCRIPTION
### Use case: I want to hot-module-reload templates.

In have created a `require.context` in my `Router.js` for all `jade` templates.
#### Example HMR update
1. I save a template. 
2. Template module is invalid. Propagates to parent.
3. Require Context module is invalid. Propagetes to parent.
4. Router accepts and re-renders template.

So, the `Router.js` has a `module.accept` call which needs the invalidated Require Context `moduleId`. I've added this as an attribute to the Require Context.

(PS. I first thought HMR should work if I accept all grandchildren. I thought: I just have to "catch" the invalidation when it bubbles up, and then HMR will work. However, the child could have side effects that make a HMR impossible, that is why **HMR can only accept direct children!!!!**. This is a huge insight and should be documented somewhere!!!!)
