### PR TITLE
bugfix HMR module.accept: resolve multiple deps to module ids

### DIFF
--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -176,18 +176,18 @@ HotModuleReplacementPlugin.prototype.apply = function(compiler) {
 		if(!this.state.compilation.hotUpdateChunkTemplate) return false;
 		if(expr.arguments.length > 1) {
 			var arg = this.evaluateExpression(expr.arguments[0]);
-      var params = [];
-      if(arg.isString()) {
-        params = [arg];
-      }
-      if(arg.isArray()){
-        params = arg.items;
-      }
-      params.forEach(function(param){
-        var dep = new ModuleHotAcceptDependency(param.string, param.range);
-        dep.optional = true;
-        this.state.module.addDependency(dep);
-      }.bind(this));
+			var params = [];
+			if(arg.isString()) {
+				params = [arg];
+			}
+			if(arg.isArray()){
+				params = arg.items;
+			}
+			params.forEach(function(param){
+				var dep = new ModuleHotAcceptDependency(param.string, param.range);
+				dep.optional = true;
+				this.state.module.addDependency(dep);
+			}.bind(this));
 		}
 	});
 	compiler.parser.plugin("call module.hot.decline", function(expr) {


### PR DESCRIPTION
The HMR plugin replaces the require string with a module id.

However, this was only implemented for a single dependency.

I've added support for an array of dependencies, as is documented on the website.

Fixes issue #465 .
