### PR TITLE
Hmr dispose error message

### DIFF
--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -443,8 +443,8 @@ var hotInitCode = Template.getFunctionContent(function() {
 					var parentId = module.parents[i];
 					var parent = installedModules[parentId];
 					if(!parent){
-            return new Error("Aborted because of missing module: "+parentId+" (parent of "+moduleId+"). Please require this module in your module.hot.accept()");
-          }
+						return new Error("Aborted because of missing module: "+parentId+" (parent of "+moduleId+"). Please require this module in your module.hot.accept()");
+					}
 					if(parent.hot._declinedDependencies[moduleId]) {
 						return new Error("Aborted because of declined dependency: " + moduleId + " in " + parentId);
 					}


### PR DESCRIPTION
You're not allowed to re-use a require after a hot update:

``` js
var context = require.context(...);
var allTemplates = context.keys().map(context);
module.hot.accept(context.id, function() {
  // You are not allowed to reuse the context!
  allTemplates = context.keys().map(context);
});
```

When you hot-update twice, this will throw an error:

In the browser, on the second hot module replacement, I get an error:

```
    Uncaught TypeError: Cannot read property 'hot' of undefined
```

The error is thrown (in the browser) on this line:

```
   if(parent.hot._declinedDependencies[moduleId]) { 
```

So I've added an error to describe what happened. (A disposed parent was not re-installed after a hot code push. Hot update should re-install every diposed module!)
