### PR TITLE
Validate module.hot.accept(): Are all disposed modules reinstalled?

### DIFF
--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -442,6 +442,9 @@ var hotInitCode = Template.getFunctionContent(function() {
 				for(var i = 0; i < module.parents.length; i++) {
 					var parentId = module.parents[i];
 					var parent = installedModules[parentId];
+					if(!parent){
+						return new Error("Aborted because of missing module: "+parentId+" (parent of "+moduleId+"). Please require this module in your module.hot.accept()");
+					}
 					if(parent.hot._declinedDependencies[moduleId]) {
 						return new Error("Aborted because of declined dependency: " + moduleId + " in " + parentId);
 					}
@@ -513,6 +516,7 @@ var hotInitCode = Template.getFunctionContent(function() {
 		// Now in "dispose" phase
 		hotSetStatus("dispose");
 		var queue = outdatedModules.slice();
+		var uninstalledModules = [];
 		while(queue.length > 0) {
 			var moduleId = queue.pop();
 			var module = installedModules[moduleId];
@@ -530,6 +534,7 @@ var hotInitCode = Template.getFunctionContent(function() {
 
 			// remove module from cache
 			delete installedModules[moduleId];
+			uninstalledModules.push(moduleId);
 
 			// remove "parents" references from all children
 			for(var j = 0; j < module.children.length; j++) {
@@ -614,6 +619,18 @@ var hotInitCode = Template.getFunctionContent(function() {
 				} else if(!error)
 					error = err;
 			}
+		}
+
+		// After an accept(), all disposed modules should be re-installed.
+		for(var i = uninstalledModules.length-1; i >= 0; i--){
+			// If installed, remove from the 'uninstalled' list.
+			if(installedModules[uninstalledModules[i]]) {
+				uninstalledModules.splice(i,1);
+			}
+		}
+		// If there still are disposed modules uninstalled, throw error.
+		if(uninstalledModules.length > 0){
+			error = new Error("Accept did not re-require modules: "+uninstalledModules.join(','));
 		}
 
 		// handle errors in accept handlers and self accepted module load


### PR DESCRIPTION
If I am not mistaken, a `module.hot.accept()` should re-install all disposed modules.

Otherwise, when a new hot-update arrives, it might bubble up to uninstalled parents and cause an error.

More info:
- [the error message](https://github.com/webpack/webpack/pull/479)
- [the original HMR dispose "bugfix" discussion](https://github.com/webpack/webpack/pull/468)
