### PR TITLE
Replace window.onmessage with window.addEventListener

### DIFF
--- a/hot/dev-server.js
+++ b/hot/dev-server.js
@@ -36,7 +36,10 @@ if(module.hot) {
 
 		});
 	}
-	window.addEventListener("message", function(event) {
+	var addEventListener = window.addEventListener || function (eventName, listener) {
+	  return attachEvent('on' + eventName, listener);
+	};
+	addEventListener("message", function(event) {
 		if(typeof event.data === "string" && event.data.indexOf("webpackHotUpdate") === 0) {
 			lastData = event.data;
 			if(!upToDate() && module.hot.status() === "idle") {

--- a/hot/only-dev-server.js
+++ b/hot/only-dev-server.js
@@ -60,7 +60,10 @@ if(module.hot) {
 			});
 		});
 	}
-	window.addEventListener("message", function(event) {
+	var addEventListener = window.addEventListener || function (eventName, listener) {
+	  return attachEvent('on' + eventName, listener);
+	};
+	addEventListener("message", function(event) {
 		if(typeof event.data === "string" && event.data.indexOf("webpackHotUpdate") === 0) {
 			lastData = event.data;
 			if(!upToDate() && module.hot.status() === "idle") {


### PR DESCRIPTION
When having multiple bundles that use hot module replacement loaded in the page, `window.onmessage` got overwritten by the last loaded bundle, making it the only one receiving the message. Changed it with `window.addEventListener` so it gets handled by all the bundles. See discussion here: https://github.com/webpack/extract-text-webpack-plugin/issues/30
