### PR TITLE
Added support for --quiet and --silent flags

### DIFF
--- a/bin/config-optimist.js
+++ b/bin/config-optimist.js
@@ -1,89 +1,99 @@
 module.exports = function(optimist) {
 	optimist
 
-	.boolean("help").alias("help", "h").alias("help", "?").describe("help")
+	// Alphabetized order
+
+	.boolean("bail").describe("bail")
+
+	.boolean("cache").describe("cache").default("cache", true)
+
+	.boolean("colors").alias("colors", "c").describe("colors")
 
 	.string("config").describe("config")
 
 	.string("context").describe("context")
 
-	.string("entry").describe("entry")
-
-	.string("module-bind").describe("module-bind")
-
-	.string("module-bind-post").describe("module-bind-post")
-
-	.string("module-bind-pre").describe("module-bind-pre")
-
-	.string("output-path").describe("output-path")
-
-	.string("output-file").describe("output-file")
-
-	.string("output-chunk-file").describe("output-chunk-file")
-
-	.string("output-named-chunk-file").describe("output-named-chunk-file")
-
-	.string("output-source-map-file").describe("output-source-map-file")
-
-	.string("output-public-path").describe("output-public-path")
-
-	.string("output-jsonp-function").describe("output-jsonp-function")
-
-	.boolean("output-pathinfo").describe("output-pathinfo")
-
-	.string("output-library").describe("output-library")
-
-	.string("output-library-target").describe("output-library-target")
-
-	.string("records-input-path").describe("records-input-path")
-
-	.string("records-output-path").describe("records-output-path")
-
-	.string("records-path").describe("records-path")
+	.boolean("debug").describe("debug")
 
 	.string("define").describe("define")
 
-	.string("target").describe("target")
+	.string("devtool").describe("devtool")
 
-	.boolean("cache").describe("cache").default("cache", true)
+	.boolean("display-cached").describe("display-cached")
+	.boolean("display-cached-assets").describe("display-cached-assets")
+	.boolean("display-chunks").describe("display-chunks")
+	.boolean("display-error-details").describe("display-error-details")
 
-	.boolean("watch").alias("watch", "w").describe("watch")
+	.string("display-exclude").describe("display-exclude")
+	.boolean("display-modules").describe("display-modules")
+	.boolean("display-origins").describe("display-origins")
+	.boolean("display-reasons").alias("display-reasons", "verbose").alias("display-reasons", "v").describe("display-reasons")
+
+	.string("entry").describe("entry")
+
+	.boolean("help").alias("help", "h").alias("help", "?").describe("help")
+
+	.boolean("hide-modules").describe("hide-modules")
 
 	.boolean("hot").alias("hot", "h").describe("hot")
 
-	.boolean("debug").describe("debug")
-
-	.string("devtool").describe("devtool")
-
-	.boolean("progress").describe("progress")
-
-	.string("resolve-alias").describe("resolve-alias")
-
-	.string("resolve-loader-alias").describe("resolve-loader-alias")
-
-	.describe("optimize-max-chunks")
-
-	.describe("optimize-min-chunk-size")
-
-	.boolean("optimize-minimize").describe("optimize-minimize")
-
-	.boolean("optimize-occurence-order").describe("optimize-occurence-order")
-
-	.boolean("optimize-dedupe").describe("optimize-dedupe")
-
-	.string("prefetch").describe("prefetch")
-
-	.string("provide").describe("provide")
+	.boolean("json").alias("json", "j").describe("json")
 
 	.boolean("labeled-modules").describe("labeled-modules")
 
+	.string("module-bind").describe("module-bind")
+	.string("module-bind-post").describe("module-bind-post")
+	.string("module-bind-pre").describe("module-bind-pre")
+
+	.boolean("optimize-dedupe").describe("optimize-dedupe")
+
+	.describe("optimize-max-chunks")
+	.describe("optimize-min-chunk-size")
+	.boolean("optimize-minimize").describe("optimize-minimize")
+	.boolean("optimize-occurence-order").describe("optimize-occurence-order")
+
+	.string("output-chunk-file").describe("output-chunk-file")
+	.string("output-file").describe("output-file")
+	.string("output-jsonp-function").describe("output-jsonp-function")
+	.string("output-library").describe("output-library")
+	.string("output-library-target").describe("output-library-target")
+	.string("output-named-chunk-file").describe("output-named-chunk-file")
+	.string("output-path").describe("output-path")
+	.boolean("output-pathinfo").describe("output-pathinfo")
+	.string("output-public-path").describe("output-public-path")
+	.string("output-source-map-file").describe("output-source-map-file")
+
 	.string("plugin").describe("plugin")
 
-	.boolean("bail").describe("bail")
+	.string("prefetch").describe("prefetch")
 
 	.boolean("profile").describe("profile")
+
+	.boolean("progress").describe("progress")
+
+	.string("provide").describe("provide")
+
+	.string("records-input-path").describe("records-input-path")
+	.string("records-output-path").describe("records-output-path")
+	.string("records-path").describe("records-path")
+	.string("resolve-alias").describe("resolve-alias")
+	.string("resolve-loader-alias").describe("resolve-loader-alias")
+
+	.boolean("silent").alias("silent", "s").describe("silent")
+
+	.string("sort-assets-by").describe("sort-assets-by")
+	.string("sort-chunks-by").describe("sort-chunks-by")
+
+	.string("sort-modules-by").describe("sort-modules-by")
+
+	.string("target").describe("target")
+
+	.boolean("watch").alias("watch", "w").describe("watch")
+
+	.boolean("quiet").alias("quiet", "q").describe("quiet")
 
 	.boolean("d").describe("d", "shortcut for --debug --devtool sourcemap --output-pathinfo")
 
 	.boolean("p").describe("p", "shortcut for --optimize-minimize");
+	
 };

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -60,6 +60,14 @@ module.exports = function(optimist, argv, convertOptions) {
 		options.watchDelay = +argv["watch-delay"];
 	}
 
+	if(argv["quiet"]) {
+		options.quiet = true;
+	}
+
+	if(argv["silent"]) {
+		options.silent = true;
+	}
+
 	function processOptions(options) {
 		function ifArg(name, fn, init, finalize) {
 			if(Array.isArray(argv[name])) {
@@ -266,6 +274,9 @@ module.exports = function(optimist, argv, convertOptions) {
 		ifArg("watch-delay", function(value) {
 			options.watchDelay = value;
 		});
+
+		mapArgToBoolean("silent");
+		mapArgToBoolean("quiet");
 
 		ifBooleanArg("hot", function() {
 			ensureArray(options, "plugins");

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -19,37 +19,6 @@ var optimist = require("optimist")
 		"Usage: http://webpack.github.io/docs/cli.html")
 	
 require("./config-optimist")(optimist);
-
-optimist
-
-	.boolean("json").alias("json", "j").describe("json")
-	
-	.boolean("colors").alias("colors", "c").describe("colors")
-
-	.string("sort-modules-by").describe("sort-modules-by")
-
-	.string("sort-chunks-by").describe("sort-chunks-by")
-
-	.string("sort-assets-by").describe("sort-assets-by")
-
-	.boolean("hide-modules").describe("hide-modules")
-
-	.string("display-exclude").describe("display-exclude")
-
-	.boolean("display-modules").describe("display-modules")
-
-	.boolean("display-chunks").describe("display-chunks")
-
-	.boolean("display-error-details").describe("display-error-details")
-
-	.boolean("display-origins").describe("display-origins")
-
-	.boolean("display-cached").describe("display-cached")
-
-	.boolean("display-cached-assets").describe("display-cached-assets")
-
-	.boolean("display-reasons").alias("display-reasons", "verbose").alias("display-reasons", "v").describe("display-reasons");
-
 	
 var argv = optimist.argv;
 
@@ -65,8 +34,6 @@ function ifArg(name, fn, init) {
 	}
 }
 
-
-
 var outputOptions = {
 	cached: false,
 	cachedAssets: false,
@@ -79,6 +46,14 @@ ifArg("json", function(bool) {
 
 ifArg("colors", function(bool) {
 	outputOptions.colors = bool;
+});
+
+ifArg("silent", function(bool) {
+	outputOptions.silent = bool;
+});
+
+ifArg("quiet", function(bool) {
+	outputOptions.quiet = bool;
 });
 
 ifArg("sort-modules-by", function(value) {
@@ -163,6 +138,7 @@ var compiler = webpack(options, function(err, stats) {
 		}
 		return;
 	}
+	if (outputOptions.silent) return;
 	if(outputOptions.json) {
 		process.stdout.write(JSON.stringify(stats.toJson(outputOptions), null, 2) + "\n");
 	} else if(stats.hash !== lastHash) {

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -37,6 +37,7 @@ Stats.prototype.toJson = function toJson(options, forToString) {
 	var showChildren = d(options.children, true);
 	var showSource = d(options.source, !forToString);
 	var showErrorDetails = d(options.errorDetails, !forToString);
+	var quiet = d(options.quiet, false);
 	var excludeModules = [].concat(d(options.exclude, [])).map(function(str) {
 		if(typeof str !== "string") return str;
 		return new RegExp("[\\\\/]" + str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&") + "([\\\\/]|$|!|\\?)");
@@ -96,6 +97,8 @@ Stats.prototype.toJson = function toJson(options, forToString) {
 		errors: compilation.errors.map(formatError),
 		warnings: compilation.warnings.map(formatError)
 	};
+
+	if (quiet) return obj;
 
 	if(showVersion) {
 		obj.version = require("../package.json").version;
@@ -242,14 +245,15 @@ Stats.prototype.toJson = function toJson(options, forToString) {
 Stats.prototype.toString = function toString(options) {
 	if(!options) options = {};
 	function d(v, d) { return v === undefined ? d : v }
+	var quiet = d(options.quiet, false);
 	var useColors = d(options.colors, false);
 
 	var obj = this.toJson(options, true);
 
-	return Stats.jsonToString(obj, useColors);
+	return Stats.jsonToString(obj, useColors, quiet);
 };
 
-Stats.jsonToString = function jsonToString(obj, useColors) {
+Stats.jsonToString = function jsonToString(obj, useColors, quiet) {
 	var buf = [];
 	function normal(str) {
 		buf.push(str);
@@ -576,16 +580,18 @@ Stats.jsonToString = function jsonToString(obj, useColors) {
 	}
 	if(obj.warnings) {
 		obj.warnings.forEach(function(warning) {
-			newline();
+			if (!quiet) newline();
 			yellow("WARNING in " + warning);
 			newline();
+			if (quiet) newline();
 		});
 	}
 	if(obj.errors) {
 		obj.errors.forEach(function(error) {
-			newline();
+			if (!quiet) newline();
 			red("ERROR in " + error);
 			newline();
+			if (quiet) newline();
 		});
 	}
 	if(obj.children) {


### PR DESCRIPTION
Added two flags to work like npm. Fixes #490
```
--quiet will only output warnings and errors.
--silent will suppress all output.
```

Also alphabetized the flags when using help to give a better overview of the options.