### PR TITLE
JsonpExportMainTemplatePlugin has no method 'applyPluginsWaterfall'

### DIFF
--- a/lib/JsonpExportMainTemplatePlugin.js
+++ b/lib/JsonpExportMainTemplatePlugin.js
@@ -10,7 +10,7 @@ function JsonpExportMainTemplatePlugin(name) {
 module.exports = JsonpExportMainTemplatePlugin;
 JsonpExportMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 	mainTemplate.plugin("render", function(source, chunk, hash) {
-		var name = this.applyPluginsWaterfall("asset-path", this.name || "", {
+		var name = mainTemplate.applyPluginsWaterfall("asset-path", this.name || "", {
 			hash: hash,
 			chunk: chunk
 		});


### PR DESCRIPTION
Fix:

`TypeError: Object #<JsonpExportMainTemplatePlugin> has no method 'applyPluginsWaterfall'`

This is the same bug as was fixed in https://github.com/webpack/webpack/commit/614891e
