### PR TITLE
Load extra JSONP chunks with async script tags

### DIFF
--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -59,6 +59,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 				"var script = document.createElement('script');",
 				"script.type = 'text/javascript';",
 				"script.charset = 'utf-8';",
+				"script.async = true;",
 				"script.src = " + this.requireFn + ".p + " +
 					this.applyPluginsWaterfall("asset-path", JSON.stringify(chunkFilename), {
 						hash: "\" + " + this.renderCurrentHashCode(hash) + " + \"",


### PR DESCRIPTION
If requests are made while other chunks are loading, it can cause blocking
requests to load the additional chunks. Code splitting should ensure that
you can load these chunks completely async, and so we should.
