### PR TITLE
Support callbacks in newResource

### DIFF
--- a/lib/NormalModuleReplacementPlugin.js
+++ b/lib/NormalModuleReplacementPlugin.js
@@ -16,14 +16,22 @@ NormalModuleReplacementPlugin.prototype.apply = function(compiler) {
 		nmf.plugin("before-resolve", function(result, callback) {
 			if(!result) return callback();
 			if(resourceRegExp.test(result.request)) {
-				result.request = newResource;
+				if (typeof newResource === 'function') {
+					newResource(result);
+				} else {
+					result.request = newResource;
+				}
 			}
 			return callback(null, result);
 		});
 		nmf.plugin("after-resolve", function(result, callback) {
 			if(!result) return callback();
 			if(resourceRegExp.test(result.resource)) {
-				result.resource = path.resolve(path.dirname(result.resource), newResource);
+				if (typeof newResource === 'function') {
+					newResource(result);
+				} else {
+					result.resource = path.resolve(path.dirname(result.resource), newResource);
+				}
 			}
 			return callback(null, result);
 		});


### PR DESCRIPTION
Provides a feature which is explained here https://github.com/webpack/webpack/issues/541

``` javascript
...
            plugins: [
                new webpack.NormalModuleReplacementPlugin(
                    /\.css$/,
                    function (request) {
                        request.context = path.join(
                            buildSettings.destPath,
                            path.relative(buildSettings.sourcePath, request.context)
                        );
                    }
                )
            ]
...
```
