### PR TITLE
Add ability to skip files in UglifyJs via user-defined function

### DIFF
--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -15,12 +15,12 @@ function UglifyJsPlugin(options) {
 	this.options = options;
 }
 module.exports = UglifyJsPlugin;
+
 UglifyJsPlugin.prototype.apply = function(compiler) {
 	var options = this.options;
-	var skipFile = options.skipFile || function(filename) {
-		// UglifyJs only applies to javascript
-		return !/\.js($|\?)/i.test(filename);
-	};
+	var that = this;
+	options.test = options.test || /\.js($|\?)/i;
+
 	var requestShortener = new RequestShortener(compiler.context);
 	compiler.plugin("compilation", function(compilation) {
 		compilation.plugin("build-module", function(module) {
@@ -37,10 +37,8 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 			compilation.additionalChunkAssets.forEach(function(file) {
 				files.push(file);
 			});
+			files = files.filter(that.matchObject.bind(that, options));
 			files.forEach(function(file) {
-				if(skipFile(file)) {
-					return;
-				}
 				var oldWarnFunction = uglify.AST_Node.warn_function;
 				var warnings = [];
 				try {
@@ -120,4 +118,31 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 			context.minimize = true;
 		});
 	});
+};
+
+function asRegExp(test) {
+	if(typeof test == "string") test = new RegExp("^"+test.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"));
+	return test;
+}
+
+UglifyJsPlugin.prototype.matchPart = function matchPart(str, test) {
+	if(!test) return true;
+	test = asRegExp(test);
+	if(Array.isArray(test)) {
+		return test.map(asRegExp).filter(function(regExp) {
+			return regExp.test(str);
+		}).length > 0;
+	} else {
+		return test.test(str);
+	}
+};
+
+UglifyJsPlugin.prototype.matchObject = function matchObject(obj, str) {
+	if(obj.test)
+		if(!this.matchPart(str, obj.test)) return false;
+	if(obj.include)
+		if(!this.matchPart(str, obj.include)) return false;
+	if(obj.exclude)
+		if(this.matchPart(str, obj.exclude)) return false;
+	return true;
 };


### PR DESCRIPTION
Use case: User has some legacy library that breaks when treated with UglifyJs.
This change gives user a ability to exclude some of the files by conveniently providing custom function (via options) that will decide if a particular file should be skipped. 
