### PR TITLE
Ensure `require.ensure` callback is always async

### DIFF
--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -34,9 +34,9 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 		var chunkFilename = this.outputOptions.chunkFilename || "[id]." + filename;
 		var chunkMaps = chunk.getChunkMaps();
 		return this.asString([
-			"// \"0\" is the signal for \"already loaded\"",
+			"// \"0\" is the signal for \"already loaded\", do callback async",
 			"if(installedChunks[chunkId] === 0)",
-			this.indent("return callback.call(null, " + this.requireFn + ");"),
+			this.indent("return setTimeout(function() { callback(" + this.requireFn + ") }, 0);"),
 			"",
 			"// an array means \"currently loading\".",
 			"if(installedChunks[chunkId] !== undefined) {",

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -36,7 +36,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 		return this.asString([
 			"// \"0\" is the signal for \"already loaded\", do callback async",
 			"if(installedChunks[chunkId] === 0)",
-			this.indent("return setTimeout(function() { callback(" + this.requireFn + ") }, 0);"),
+			this.indent("return (window.setImmediate || setTimeout)(function() { callback(" + this.requireFn + ") }, 0);"),
 			"",
 			"// an array means \"currently loading\".",
 			"if(installedChunks[chunkId] !== undefined) {",

--- a/lib/node/NodeMainTemplatePlugin.js
+++ b/lib/node/NodeMainTemplatePlugin.js
@@ -40,7 +40,8 @@ NodeMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 		];
 		if(self.asyncChunkLoading) {
 			return this.asString([
-				"if(installedChunks[chunkId] === 1) callback.call(null, " + this.requireFn + ");",
+				"if(installedChunks[chunkId] === 1)",
+				this.indent("setImmediate(function() { callback(" + this.requireFn + "); });"),
 				"else if(!installedChunks[chunkId]) {",
 				this.indent([
 					"installedChunks[chunkId] = [callback];",


### PR DESCRIPTION
Use `setTimeout` to force the callback to always be called
asynchronously so that `require.ensure` will always return
immediately.

Also, there is no need to pass in `requireFn` as a parameter
because the callbacks will just use the closure's `requireFn`.