### PR TITLE
Added EnvPlugin.

### DIFF
--- a/lib/EnvPlugin.js
+++ b/lib/EnvPlugin.js
@@ -1,0 +1,32 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Simen Brekken @simenbrekken
+*/
+var DefinePlugin = require("./DefinePlugin");
+
+function EnvPlugin(keys) {
+	this.keys = Array.isArray(keys) ? keys : Array.prototype.slice.call(arguments);
+}
+module.exports = EnvPlugin;
+
+EnvPlugin.prototype.apply = function(compiler) {
+	compiler.apply(new DefinePlugin(getDefinitions(this.keys)));
+
+	function getDefinitions(keys) {
+		return keys.reduce(function(definitions, key) {
+			var value = process.env[key];
+
+			if (value === undefined) {
+				compiler.plugin("compilation", function(compilation) {
+					var error = new Error(key + " environment variable is undefined.");
+					error.name = "EnvVariableNotDefinedError";
+					compilation.warnings.push(error);
+				});
+			}
+
+			definitions["process.env." + key] = value ? JSON.stringify(value) : "undefined";
+
+			return definitions;
+		}, {});
+	}
+};

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -77,6 +77,7 @@ exportPlugins(exports, ".", [
 	"UmdMainTemplatePlugin",
 	"NoErrorsPlugin",
 	"NewWatchingPlugin",
+	"EnvPlugin"
 ]);
 exportPlugins(exports.optimize = {}, "./optimize", [
 	"AggressiveMergingPlugin",

--- a/test/configCases/plugins/env-plugin/index.js
+++ b/test/configCases/plugins/env-plugin/index.js
@@ -1,0 +1,12 @@
+it("should import a single process.env var", function() {
+  process.env.AAA.should.be.eql("aaa");
+});
+
+it("should import multiple process.env vars", function() {
+  process.env.BBB.should.be.eql("bbb");
+  process.env.CCC.should.be.eql("123");
+});
+
+it("should warn when a process.env variable is undefined", function() {
+  (process.env.DDD === undefined).should.be.true;
+});

--- a/test/configCases/plugins/env-plugin/warnings.js
+++ b/test/configCases/plugins/env-plugin/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[/DDD/, /environment variable is undefined/]
+];

--- a/test/configCases/plugins/env-plugin/webpack.config.js
+++ b/test/configCases/plugins/env-plugin/webpack.config.js
@@ -1,0 +1,17 @@
+var EnvPlugin = require("../../../../lib/EnvPlugin");
+process.env.AAA = "aaa";
+process.env.BBB = "bbb";
+process.env.CCC = "123";
+module.exports = [{
+  plugins: [
+    new EnvPlugin("AAA")
+  ]
+}, {
+  plugins: [
+    new EnvPlugin("BBB", "CCC")
+  ]
+}, {
+  plugins: [
+    new EnvPlugin("DDD")
+  ]
+}];


### PR DESCRIPTION
This adds a convenience plugin that uses `DefinePlugin` to import environment variables. It also warns if you've forgotten to define a variable.

Example:

**app.js**
```javascript
if (process.env.NODE_ENV === 'production') {
  // Do something only in production mode
}
```

**webpack.config.js**
```javascript
var webpack = require('webpack')

module.exports = {
  // ...

  plugins: [
    new webpack.EnvPlugin('NODE_ENV', 'API_URL')
  ]
}
```

This will output the following warning:
```
[EnvPlugin] Warning: API_URL environment variable is undefined.
```

And result in the following javascript output:

```javascript
if (('production') === 'production') {
  // Do something only in production mode
}
```