### PR TITLE
Remove unused variable from HotModuleReplacementPlugin.js

### DIFF
--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -331,7 +331,6 @@ var hotInitCode = Template.getFunctionContent(function() {
 	var hotStatus = "idle";
 
 	function hotSetStatus(newStatus) {
-		var oldStatus = hotStatus;
 		hotStatus = newStatus;
 		for(var i = 0; i < hotStatusHandlers.length; i++)
 			hotStatusHandlers[i].call(null, newStatus);


### PR DESCRIPTION
oldStatus throws an error on every refresh "Dropping unused variable oldStatus" with minification.
