### PR TITLE
Don't persist sourcemap changes between steps.

### DIFF
--- a/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
+++ b/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
@@ -2,6 +2,8 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+var clone = require("clone");
+
 var RawSource = require("webpack-core/lib/RawSource");
 var ModuleFilenameHelpers = require("./ModuleFilenameHelpers");
 
@@ -16,7 +18,9 @@ EvalSourceMapDevToolModuleTemplatePlugin.prototype.apply = function(moduleTempla
 	var self = this;
 	moduleTemplate.plugin("module", function(source, module, chunk) {
 		var content = source.source();
-		var sourceMap = source.map();
+
+		// Clone the sourcemap to ensure that the mutations below do not persist.
+		var sourceMap = clone(source.map());
 		if(!sourceMap) {
 			return source;
 		}


### PR DESCRIPTION
Currently, if 'eval-source-map' is enabled and you have multiple chunks with the same module in them, `EvalSourceMapDevToolModuleTemplatePlugin` runs its 'module' handler multiple times for the shared modules, and since it mutates the sourcemap, the mutations can be applied twice. This is mostly visible in 'sources', where it results in weird URLs. For example:

```
webpack:///[resource-path]
```

becomes

```
webpack:///webpack:///[resource-path]
```
