### PR TITLE
Change watchDelay default value

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -154,7 +154,7 @@ Compiler.Watching = Watching;
 Compiler.prototype.watch = function(watchDelay, handler) {
 	this.fileTimestamps = {};
 	this.contextTimestamps = {};
-	var watching = new Watching(this, handler, watchDelay || 0);
+	var watching = new Watching(this, handler, watchDelay || 1);
 	return watching;
 };
 


### PR DESCRIPTION
Fixed multiple calls applyPlugins("done", stats) by changing a default value of watchDelay to 1. May be need to change watchDelay to 200 as said in the documentation  (http://webpack.github.io/docs/configuration.html#watchdelay).