### PR TITLE
Compiler fails under Windows

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -2,6 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+var path = require("path");
 var clone = require("clone");
 var Tapable = require("tapable");
 
@@ -235,9 +236,9 @@ Compiler.prototype.emitAssets = function(compilation, callback) {
 			if(queryStringIdx >= 0) {
 				targetFile = targetFile.substr(0, queryStringIdx);
 			}
-			if(targetFile.indexOf("/") >= 0) {
-				var idx = targetFile.lastIndexOf("/");
-				var dir = targetFile.substr(0, idx);
+
+			if(targetFile.match(/\/|\\/)) {
+				var dir = path.dirname(targetFile);
 				this.outputFileSystem.mkdirp(this.outputFileSystem.join(outputPath, dir), writeOut.bind(this));
 			} else writeOut.call(this);
 			function writeOut(err) {


### PR DESCRIPTION
When the `output.filename` contains directory and file (for example `build\assets\js\app.js`), the compilation under Windows will fail with "Path does not exist" error. That happens because the compiler expects UNIX slash (`/`) in the path, and gets Windows slash (`\`) instead.

The [test](https://github.com/corporateanon/webpack/commit/65079e966c69858cdd57d0c34d69a5152c14d0bf), added in this PR, will fail (under Windows only) when run without the fix.