### PR TITLE
Add node-independent shim for global setImmediate()

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -42,7 +42,7 @@ function WebpackOptionsDefaulter() {
 	this.set("node.console", false);
 	this.set("node.process", true);
 	this.set("node.global", true);
-	this.set("node.buffer", true);
+	this.set("node.Buffer", true);
 	this.set("node.__filename", "mock");
 	this.set("node.__dirname", "mock");
 

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -43,6 +43,7 @@ function WebpackOptionsDefaulter() {
 	this.set("node.process", true);
 	this.set("node.global", true);
 	this.set("node.Buffer", true);
+	this.set("node.setImmediate", true);
 	this.set("node.__filename", "mock");
 	this.set("node.__dirname", "mock");
 

--- a/lib/node/NodeSourcePlugin.js
+++ b/lib/node/NodeSourcePlugin.js
@@ -48,6 +48,15 @@ NodeSourcePlugin.prototype.apply = function(compiler) {
 			return ModuleParserHelpers.addParsedVariable(this, "Buffer", "require(" + JSON.stringify(getPathToModule("buffer", bufferType)) + ").Buffer");
 		});
 	}
+	if(this.options.setImmediate) {
+		var setImmediateType = this.options.setImmediate;
+		compiler.parser.plugin("expression setImmediate", function(expr) {
+			return ModuleParserHelpers.addParsedVariable(this, "setImmediate", "require(" + JSON.stringify(getPathToModule("timers", setImmediateType)) + ").setImmediate");
+		});
+		compiler.parser.plugin("expression clearImmediate", function(expr) {
+			return ModuleParserHelpers.addParsedVariable(this, "clearImmediate", "require(" + JSON.stringify(getPathToModule("timers", setImmediateType)) + ").clearImmediate");
+		});
+	}
 	var options = this.options;
 	compiler.plugin("after-resolvers", function(compiler) {
 		var alias = {};

--- a/lib/node/NodeSourcePlugin.js
+++ b/lib/node/NodeSourcePlugin.js
@@ -42,8 +42,8 @@ NodeSourcePlugin.prototype.apply = function(compiler) {
 			return ModuleParserHelpers.addParsedVariable(this, "console", "require(" + JSON.stringify(getPathToModule("console", consoleType)) + ")");
 		});
 	}
-	if(this.options.buffer) {
-		var bufferType = this.options.buffer;
+	if(this.options.Buffer) {
+		var bufferType = this.options.Buffer;
 		compiler.parser.plugin("expression Buffer", function(expr) {
 			return ModuleParserHelpers.addParsedVariable(this, "Buffer", "require(" + JSON.stringify(getPathToModule("buffer", bufferType)) + ").Buffer");
 		});

--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -55,7 +55,7 @@ describe("ConfigTestCases", function() {
 								var p = path.join(outputDirectory, module);
 								var fn;
 								if (options.target === "web") {
-									fn = vm.runInNewContext("(function(require, module, exports, __dirname, __filename, it) {" + fs.readFileSync(p, "utf-8") + "\n})", p);
+									fn = vm.runInNewContext("(function(require, module, exports, __dirname, __filename, it) {" + fs.readFileSync(p, "utf-8") + "\n})", {}, p);
 								} else {
 									fn = vm.runInThisContext("(function(require, module, exports, __dirname, __filename, it) {" + fs.readFileSync(p, "utf-8") + "\n})", p);
 								}

--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -53,7 +53,12 @@ describe("ConfigTestCases", function() {
 						function _require(module) {
 							if(module.substr(0, 2) === "./") {
 								var p = path.join(outputDirectory, module);
-								var fn = vm.runInThisContext("(function(require, module, exports, __dirname, __filename, it) {" + fs.readFileSync(p, "utf-8") + "\n})", p);
+								var fn;
+								if (options.target === "web") {
+									fn = vm.runInNewContext("(function(require, module, exports, __dirname, __filename, it) {" + fs.readFileSync(p, "utf-8") + "\n})", p);
+								} else {
+									fn = vm.runInThisContext("(function(require, module, exports, __dirname, __filename, it) {" + fs.readFileSync(p, "utf-8") + "\n})", p);
+								}
 								var module = { exports: {} };
 								fn.call(module.exports, _require, module, module.exports, outputDirectory, p, _it);
 								return module.exports;

--- a/test/configCases/target/web/index.js
+++ b/test/configCases/target/web/index.js
@@ -1,0 +1,95 @@
+require("should");
+
+// shimming global window object so the http-module is happy.
+// window is assigned without var on purpose.
+window = {
+	XMLHttpRequest: function() {}
+};
+
+it("should provide a global Buffer constructor", function() {
+	Buffer.should.be.a.Function;
+});
+
+// Webpack is not providing a console shim by default
+// @see lib/WebpackOptionsDefaulter.js
+// Uncomment this when defaults are changed
+//it("should provide a global console shim", function () {
+//	console.should.be.an.Object;
+//	console.time.should.be.a.Function;
+//});
+
+it("should provide a global process shim", function () {
+	process.should.be.an.Object;
+});
+
+it("should provide a global setImmediate shim", function () {
+	setImmediate.should.be.a.Function;
+});
+
+it("should provide a global clearImmediate shim", function () {
+	clearImmediate.should.be.a.Function;
+});
+
+it("should provide an assert shim", function () {
+	require("assert").should.be.a.Function;
+});
+
+it("should provide a buffer shim", function () {
+	require("buffer").should.be.an.Object;
+});
+
+it("should provide a crypto shim", function () {
+	require("crypto").should.be.an.Object;
+});
+
+it("should provide a domain shim", function () {
+	require("domain").should.be.an.Object;
+});
+
+it("should provide an events shim", function () {
+	require("events").should.be.a.Function;
+});
+
+it("should provide an http shim", function () {
+	require("http").should.be.an.Object;
+});
+
+it("should provide an https shim", function () {
+	require("https").should.be.an.Object;
+});
+
+it("should provide an os shim", function () {
+	require("os").should.be.an.Object;
+});
+
+it("should provide a path shim", function () {
+	require("path").should.be.an.Object;
+});
+
+it("should provide a punycode shim", function () {
+	require("punycode").should.be.an.Object;
+});
+
+it("should provide a stream shim", function () {
+	require("stream").should.be.a.Function;
+});
+
+it("should provide a tty shim", function () {
+	require("tty").should.be.an.Object;
+});
+
+it("should provide a url shim", function () {
+	require("url").should.be.an.Object;
+});
+
+it("should provide a util shim", function () {
+	require("util").should.be.an.Object;
+});
+
+it("should provide a vm shim", function () {
+	require("vm").should.be.an.Object;
+});
+
+it("should provide a zlib shim", function () {
+	require("zlib").should.be.an.Object;
+});

--- a/test/configCases/target/web/webpack.config.js
+++ b/test/configCases/target/web/webpack.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	target: "web"
+};


### PR DESCRIPTION
As discussed in #419

Btw: Why is the console shim deactivated by default?