### PR TITLE
Add test failure for after-resolve async

### DIFF
--- a/test/Integration.test.js
+++ b/test/Integration.test.js
@@ -70,7 +70,9 @@ describe("Integration", function() {
 					this.plugin("normal-module-factory", function(nmf) {
 						nmf.plugin("after-resolve", function(data, callback) {
 							data.resource = data.resource.replace(/extra\.js/, "extra2.js");
-							callback(null, data);
+							setTimeout(function() {
+								callback(null, data);
+							}, 50);
 						});
 					});
 				}


### PR DESCRIPTION
Implementing actual async after-resolve handlers causes the _currentPluginApply field to become corrupted.

Failing test pull request.