### PR TITLE
Resolves #727: Resolve AMD module dependencies relative to named modules being defined

### DIFF
--- a/lib/dependencies/AMDDefineDependencyParserPlugin.js
+++ b/lib/dependencies/AMDDefineDependencyParserPlugin.js
@@ -106,7 +106,7 @@ AMDDefineDependencyParserPlugin.prototype.apply = function(parser) {
 		if(array) {
 			var identifiers = {};
 			var param = this.evaluateExpression(array);
-			var result = this.applyPluginsBailResult("call define:amd:array", expr, param, identifiers);
+			var result = this.applyPluginsBailResult("call define:amd:array", expr, param, identifiers, namedModule);
 			if(!result) return;
 			if(fnParams) fnParams = fnParams.slice(fnParamsOffset).filter(function(param, idx) {
 				if(identifiers[idx]) {
@@ -160,12 +160,12 @@ AMDDefineDependencyParserPlugin.prototype.apply = function(parser) {
 		this.state.current.addDependency(dep);
 		return true;
 	});
-	parser.plugin("call define:amd:array", function(expr, param, identifiers) {
+	parser.plugin("call define:amd:array", function(expr, param, identifiers, namedModule) {
 		if(param.isArray()) {
 			param.items.forEach(function(param, idx) {
 				if(param.isString() && ["require", "module", "exports"].indexOf(param.string) >= 0)
 					identifiers[idx] = param.string;
-				var result = this.applyPluginsBailResult("call define:amd:item", expr, param);
+				var result = this.applyPluginsBailResult("call define:amd:item", expr, param, namedModule);
 				if(result === undefined) {
 					this.applyPluginsBailResult("call define:amd:context", expr, param);
 				}
@@ -200,7 +200,7 @@ AMDDefineDependencyParserPlugin.prototype.apply = function(parser) {
 			return true;
 		}
 	});
-	parser.plugin("call define:amd:item", function(expr, param) {
+	parser.plugin("call define:amd:item", function(expr, param, namedModule) {
 		if(param.isConditional()) {
 			param.options.forEach(function(param) {
 				var result = this.applyPluginsBailResult("call define:amd:item", expr, param);
@@ -215,7 +215,7 @@ AMDDefineDependencyParserPlugin.prototype.apply = function(parser) {
 				dep = new ConstDependency("__webpack_require__", param.range);
 			} else if(["require", "exports", "module"].indexOf(param.string) >= 0) {
 				dep = new ConstDependency(param.string, param.range);
-			} else if(localModule = LocalModulesHelpers.getLocalModule(this.state, param.string)) {
+			} else if(localModule = LocalModulesHelpers.getLocalModule(this.state, param.string, namedModule)) {
 				dep = new LocalModuleDependency(localModule, param.range);
 			} else {
 				dep = new AMDRequireItemDependency(param.string, param.range);

--- a/lib/dependencies/LocalModulesHelpers.js
+++ b/lib/dependencies/LocalModulesHelpers.js
@@ -2,6 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+var path = require('path')
 var LocalModule = require("./LocalModule");
 
 var LocalModulesHelpers = exports;
@@ -13,11 +14,19 @@ LocalModulesHelpers.addLocalModule = function(state, name) {
 	return m;
 };
 
-LocalModulesHelpers.getLocalModule = function(state, name) {
+LocalModulesHelpers.getLocalModule = function(state, name, namedModule) {
 	if(!state.localModules) return null;
+	if(namedModule && isRelative(name)) {
+		// resolve dependency name relative to the defining named module
+		name = path.join(path.dirname(namedModule), name);
+	}
 	for(var i = 0; i < state.localModules.length; i++) {
 		if(state.localModules[i].name === name)
 			return state.localModules[i];
 	}
 	return null;
 };
+
+function isRelative(name) {
+  return name[0] === '.';
+}

--- a/lib/dependencies/LocalModulesHelpers.js
+++ b/lib/dependencies/LocalModulesHelpers.js
@@ -2,7 +2,6 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var path = require('path')
 var LocalModule = require("./LocalModule");
 
 var LocalModulesHelpers = exports;
@@ -16,9 +15,9 @@ LocalModulesHelpers.addLocalModule = function(state, name) {
 
 LocalModulesHelpers.getLocalModule = function(state, name, namedModule) {
 	if(!state.localModules) return null;
-	if(namedModule && isRelative(name)) {
+	if(namedModule) {
 		// resolve dependency name relative to the defining named module
-		name = path.join(path.dirname(namedModule), name);
+		name = lookup(namedModule, name);
 	}
 	for(var i = 0; i < state.localModules.length; i++) {
 		if(state.localModules[i].name === name)
@@ -27,6 +26,19 @@ LocalModulesHelpers.getLocalModule = function(state, name, namedModule) {
 	return null;
 };
 
-function isRelative(name) {
-  return name[0] === '.';
+function lookup(parent, mod) {
+	if ('.' != mod.charAt(0)) return mod;
+
+	var path = parent.split('/')
+		, segs = mod.split('/');
+	path.pop();
+
+	for (var i = 0; i < segs.length; i++) {
+		var seg = segs[i];
+		if ('..' == seg) path.pop();
+		else if ('.' != seg) path.push(seg);
+	}
+
+	return path.join('/');
 }
+

--- a/test/cases/parsing/local-modules/index.js
+++ b/test/cases/parsing/local-modules/index.js
@@ -43,16 +43,16 @@ it("should define and require a local module with deps", function() {
 });
 
 it("should define and require a local module that is relative", function () {
-  define("my-dir/my-module3", function(dep) {
-    return 1234;
-  });
-  define("my-dir/my-other-dir/my-module4", function(dep) {
-    return 2345;
-  });
-  define("my-dir/my-other-dir/my-module5", ["./my-module4", "../my-module3"], function(myModule4, myModule3) {
-    myModule3.should.be.eql(1234);
-    myModule4.should.be.eql(2345);
-    return 3456;
-  });
-  require("my-dir/my-other-dir/my-module5").should.be.eql(3456);
+	define("my-dir/my-module3", function() {
+		return 1234;
+	});
+	define("my-dir/my-other-dir/my-module4", function() {
+		return 2345;
+	});
+	define("my-dir/my-other-dir/my-module5", ["./my-module4", "../my-module3"], function(myModule4, myModule3) {
+		myModule3.should.be.eql(1234);
+		myModule4.should.be.eql(2345);
+		return 3456;
+	});
+	require("my-dir/my-other-dir/my-module5").should.be.eql(3456);
 })

--- a/test/cases/parsing/local-modules/index.js
+++ b/test/cases/parsing/local-modules/index.js
@@ -41,3 +41,18 @@ it("should define and require a local module with deps", function() {
 	require("my-module3").should.be.eql(1234);
 	require("my-module4").should.be.eql(2345);
 });
+
+it("should define and require a local module that is relative", function () {
+  define("my-dir/my-module3", function(dep) {
+    return 1234;
+  });
+  define("my-dir/my-other-dir/my-module4", function(dep) {
+    return 2345;
+  });
+  define("my-dir/my-other-dir/my-module5", ["./my-module4", "../my-module3"], function(myModule4, myModule3) {
+    myModule3.should.be.eql(1234);
+    myModule4.should.be.eql(2345);
+    return 3456;
+  });
+  require("my-dir/my-other-dir/my-module5").should.be.eql(3456);
+})


### PR DESCRIPTION
This implements the minimum necessary to pass the tests I sent in for #727, allowing `getLocalModule` to optionally take a namedModule in the case of such AMD defines. Let me know if you have any better ideas for getting the name of the module into the helper, or if there's a better approach for determining if we should resolve the module relatively.

Thanks again for webpack!
Will