### PR TITLE
Test against iojs on Travis and Appveyor.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - "0.10"
   - "0.11"
+  - "iojs"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,11 @@ init:
 # what combinations to test
 environment:
   matrix:
+    # node.js
     - nodejs_version: 0.10
     - nodejs_version: 0.11
+    # io.js
+    - nodejs_version: 1.04
 
 # combinations having this can fail
 matrix:


### PR DESCRIPTION
Travis and Appveyor both support iojs now, and tests pass locally here. This adds listings to their respective configs.