### PR TITLE
Require ensure error handler plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,80 @@
 [![webpack](http://webpack.github.io/assets/logo.png)](http://webpack.github.io)
 
+# This fork adds support for split point error handling
+
+## Usage
+
+```javascript
+var JsonpErrorHandlerPlugin = require('webpack/lib/JsonpErrorHandlerPlugin');
+var RequireEnsureErrorHandlerPlugin = require('webpack/lib/dependencies/RequireEnsureErrorHandlerPlugin');
+var AMDRequireErrorHandlerPlugin = require('webpack/lib/dependencies/AMDRequireErrorHandlerPlugin');
+
+{
+	plugins: [
+		new JsonpErrorHandlerPlugin(),
+        new RequireEnsureErrorHandlerPlugin(),
+        new AMDRequireErrorHandlerPlugin()
+	]
+}
+```
+
+## JsonpErrorHandlerPlugin
+Adds an error callback to the jsonp transport method that is called when a chunk fails to load.
+
+## RequireEnsureErrorHandlerPlugin
+Adds support for the following signatures:
+
+```javascript
+require.ensure(['a'], function() {
+    // success
+}, function() {
+    // error
+}, 'a');
+
+require.ensure(['b'], function() {
+    // success
+}, function() {
+    // error
+});
+
+require.ensure(['c'], function() {
+    // success
+}, 'c');
+
+require.ensure(['d'], function() {
+    // success
+});
+```
+
+## AMDRequireErrorHandlerPlugin
+Adds support for the following signatures:
+
+```javascript
+require(['a']);
+
+require(['b'], function() {
+	// success
+});
+
+require(['c'], function() {
+	// success
+}, function() {
+	// error
+});
+```
+
+## Related
+- https://github.com/webpack/webpack/issues/758
+- https://github.com/webpack/webpack/pull/692
+- https://github.com/webpack/webpack/pull/763
+
+
+## Todo
+- [ ] Add support for named chunks using AMD, i.e. require(name?, deps, successCallback?, errorCallback?)
+- [ ] Update `bundle-loader` to support new `require.ensure` syntax.
+- [ ] Move out into separate plugin repo.
+- [ ] *Remove hacks* required to get this to work by, potentially, requesting changes to webpack to make it easier to hook in.
+
 [![NPM version](https://badge.fury.io/js/webpack.png)](http://badge.fury.io/js/webpack) [![Gitter chat](http://img.shields.io/gitter/webpack/webpack.png)](https://gitter.im/webpack/webpack) [![Gittip donate button](http://img.shields.io/gittip/sokra.png)](https://www.gittip.com/sokra/)
 
 [documentation](http://webpack.github.io/docs/?utm_source=github&utm_medium=readme&utm_campaign=top)
@@ -65,7 +140,7 @@ webpack can do many optimizations to **reduce the output size**. It also can mak
 // webpack is a module bundler
 // This means webpack takes modules with dependencies
 //   and emits static assets representing those modules.
- 
+
 // dependencies can be written in CommonJs
 var commonjs = require("./commonjs");
 // or in AMD
@@ -83,8 +158,8 @@ define(["amd-module", "../file"], function(amdModule, file) {
 		//  of the AMD require
 	});
 });
- 
- 
+
+
 require("coffee!./cup.coffee");
 // "Loaders" can be used to preprocess files.
 // They can be prefixed in the require call
@@ -92,8 +167,8 @@ require("coffee!./cup.coffee");
 require("./cup");
 // This does the same when you add ".coffee" to the extensions
 //  and configure the "coffee" loader for /\.coffee$/
- 
- 
+
+
 function loadTemplate(name) {
 	return require("./templates/" + name + ".jade");
 	// many expressions are supported in require calls
@@ -102,11 +177,11 @@ function loadTemplate(name) {
 	//  /\.jade$/ should be included in the bundle, as it
 	//  can be required.
 }
- 
- 
+
+
 // ... and you can combine everything
 function loadTemplateAsync(name, callback) {
-	require(["bundle?lazy!./templates/" + name + ".jade"], 
+	require(["bundle?lazy!./templates/" + name + ".jade"],
 	  function(templateBundle) {
 		templateBundle(callback);
 	});

--- a/lib/JsonpErrorHandlerPlugin.js
+++ b/lib/JsonpErrorHandlerPlugin.js
@@ -1,6 +1,7 @@
 /*
 	MIT License http://www.opensource.org/licenses/mit-license.php
-	Author Richard Scarrott @richardscarrott
+	Author Tobias Koppers @sokra
+	Modified by Richard Scarrott @richardscarrott
 */
 
 var JsonpMainTemplatePlugin = require("./JsonpMainTemplatePlugin");

--- a/lib/JsonpErrorHandlerPlugin.js
+++ b/lib/JsonpErrorHandlerPlugin.js
@@ -71,6 +71,7 @@ JsonpErrorHandlerPlugin.prototype._apply = function(mainTemplate) {
 			"};", // HACK: the requireEnsure signature is defined in the mainTemplate so need to override it here...
 			this.requireFn + ".e = function requireEnsure(chunkId, successCallback, errorCallback) {",
 			this.indent([
+				"errorCallback = errorCallback || function() {};",
 				"// \"0\" is the signal for \"already loaded\"",
 				"if (installedChunks[chunkId] === 0)",
 				this.indent("return successCallback.call(null, " + this.requireFn + ");"),

--- a/lib/JsonpErrorHandlerPlugin.js
+++ b/lib/JsonpErrorHandlerPlugin.js
@@ -1,0 +1,293 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Richard Scarrott @richardscarrott
+*/
+
+var JsonpMainTemplatePlugin = require("./JsonpMainTemplatePlugin");
+var Template = require('./Template');
+
+/**
+ * Patches the `JsonpMainTemplatePlugin` with jsonp error handling logic.
+ * WARNING: This mutates the `JsonpMainTemplatePlugin` module.
+ */
+function JsonpErrorHandlerPlugin() {
+}
+
+module.exports = JsonpErrorHandlerPlugin;
+
+/**
+ * Indicates whether the `JsonpMainTemplatePlugin` has been patched.
+ * @type {Boolean}
+ */
+JsonpErrorHandlerPlugin.prototype.patched = false;
+
+/**
+ * Applies the patch.
+ */
+JsonpErrorHandlerPlugin.prototype.apply = function() {
+	if (!this.patched) {
+		this.patchJsonpMainTemplatePlugin();
+	}
+};
+
+/**
+ * Patches the `JsonpMainTemplatePlugin` with jsonp error handling logic.
+ */
+JsonpErrorHandlerPlugin.prototype.patchJsonpMainTemplatePlugin = function() {
+	JsonpMainTemplatePlugin.prototype.apply = this._apply;
+	JsonpErrorHandlerPlugin.prototype.patched = true;
+};
+
+/**
+ * Adds the error handling logic by tapping into the main template plugin hooks.
+ * This is mostly taken from 'webpack/lib/JsonpMainTemplatePlugin'.
+ * @param  {MainTemplate} mainTemplate The main template.
+ */
+JsonpErrorHandlerPlugin.prototype._apply = function(mainTemplate) {
+	mainTemplate.plugin("local-vars", function(source, chunk, hash) {
+		if(chunk.chunks.length > 0) {
+			return this.asString([
+				source,
+				"",
+				"// object to store loaded and loading chunks",
+				'// "0" means "already loaded"',
+				'// Array means "loading", array contains callbacks',
+				"var installedChunks = {",
+				this.indent(
+					chunk.ids.map(function(id) {
+						return id + ":0"
+					}).join(",\n")
+				),
+				"};"
+			]);
+		}
+		return source;
+	});
+	mainTemplate.plugin("require-ensure", function(_, chunk, hash) {
+		var filename = this.outputOptions.filename || "bundle.js";
+		var chunkFilename = this.outputOptions.chunkFilename || "[id]." + filename;
+		var chunkMaps = chunk.getChunkMaps();
+		return this.asString([
+			"};", // HACK: the requireEnsure signature is defined in the mainTemplate so need to override it here...
+			this.requireFn + ".e = function requireEnsure(chunkId, successCallback, errorCallback) {",
+			this.indent([
+				"// \"0\" is the signal for \"already loaded\"",
+				"if (installedChunks[chunkId] === 0)",
+				this.indent("return successCallback.call(null, " + this.requireFn + ");"),
+				"",
+				"// an array means \"currently loading\".",
+				"if (installedChunks[chunkId] !== undefined) {",
+				this.indent([
+					"installedChunks[chunkId].push({",
+					this.indent([
+						"success: successCallback,",
+						"error: errorCallback"
+					]),
+					"});",
+				]),
+				"} else {",
+				this.indent([
+					"// start chunk loading",
+					"installedChunks[chunkId] = [{",
+					this.indent([
+						"success: successCallback,",
+						"error: errorCallback"
+					]),
+					"}];",
+					"loadChunk(chunkId)"
+				]),
+				"}"
+			])
+		]);
+	});
+	mainTemplate.plugin("bootstrap", function(source, chunk, hash) {
+		if(chunk.chunks.length > 0) {
+			var jsonpFunction = this.outputOptions.jsonpFunction || Template.toIdentifier("webpackJsonp" + (this.outputOptions.library || ""));
+			var filename = this.outputOptions.filename || "bundle.js";
+			var chunkFilename = this.outputOptions.chunkFilename || "[id]." + filename;
+			var chunkMaps = chunk.getChunkMaps();
+			return this.asString([
+				source,
+				"",
+				"// install a JSONP callback for chunk loading",
+				"var parentJsonpFunction = window[" + JSON.stringify(jsonpFunction) + "];",
+				"window[" + JSON.stringify(jsonpFunction) + "] = function webpackJsonpCallback(chunkIds, moreModules) {",
+				this.indent([
+					'// add "moreModules" to the modules object,',
+					'// then flag all "chunkIds" as loaded and fire callback',
+					"var moduleId, chunkId, i = 0, callbacks = [];",
+					"for(;i < chunkIds.length; i++) {",
+					this.indent([
+						"chunkId = chunkIds[i];",
+						"if(installedChunks[chunkId])",
+						this.indent("callbacks.push.apply(callbacks, installedChunks[chunkId]);"),
+						"installedChunks[chunkId] = 0;"
+					]),
+					"}",
+					"for(moduleId in moreModules) {",
+					this.indent(this.renderAddModule(hash, chunk, "moduleId", "moreModules[moduleId]")),
+					"}",
+					"if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules);",
+					"while(callbacks.length)",
+					this.indent("callbacks.shift().success.call(null, " + this.requireFn + ");"),
+					(this.entryPointInChildren(chunk) ? [
+						"if(moreModules[0]) {",
+						this.indent([
+							"installedModules[0] = 0;",
+							"return " + this.requireFn + "(0);"
+						]),
+						"}"
+					] : "")
+				]),
+				"};",
+				"",
+				"// load chunk",
+				"function loadChunk(chunkId) {",
+				this.indent([
+					"var head = document.getElementsByTagName('head')[0];",
+					"var script = document.createElement('script');",
+					"script.type = 'text/javascript';",
+					"script.charset = 'utf-8';",
+					"script.async = true;",
+					"function onComplete(error) {",
+						this.indent([
+							"// avoid mem leaks in IE.",
+							"script.onerror = script.onload = script.onreadystatechange = null;",
+							"if (error) {",
+							this.indent([
+								"var callbacks = installedChunks[chunkId];",
+								"// set chunkId to undefined so subsequent require's try again",
+								"delete installedChunks[chunkId];",
+								"if (callbacks) {",
+								this.indent([
+									"while(callbacks.length) {",
+										this.indent([
+											"callbacks.shift().error.call(null, __webpack_require__);",
+										]),
+									"}"
+								]),
+								'}',
+							]),
+							'}',
+							"// success callbacks will be called by webpackJsonpCallback handler"
+						]),
+					"}",
+					"script.onerror = script.onload = script.onreadystatechange = function() {",
+					this.indent([
+						"// cover buggy onerror / readystate implementations by checking whether the chunk is actually installed",
+						"onComplete(installedChunks[chunkId] !== 0);"
+					]),
+					"};",
+					"script.src = " + this.requireFn + ".p + " +
+					this.applyPluginsWaterfall("asset-path", JSON.stringify(chunkFilename), {
+						hash: "\" + " + this.renderCurrentHashCode(hash) + " + \"",
+						hashWithLength: function(length) {
+							return "\" + " + this.renderCurrentHashCode(hash, length) + " + \"";
+						}.bind(this),
+						chunk: {
+							id: "\" + chunkId + \"",
+							hash: "\" + " + JSON.stringify(chunkMaps.hash) + "[chunkId] + \"",
+							hashWithLength: function(length) {
+								var shortChunkHashMap = {};
+								Object.keys(chunkMaps.hash).forEach(function(chunkId) {
+									if(typeof chunkMaps.hash[chunkId] === "string")
+										shortChunkHashMap[chunkId] = chunkMaps.hash[chunkId].substr(0, length);
+								});
+								return "\" + " + JSON.stringify(shortChunkHashMap) + "[chunkId] + \"";
+							},
+							name: "\" + (" + JSON.stringify(chunkMaps.name) + "[chunkId]||chunkId) + \""
+						}
+					}) + ";",
+					"head.appendChild(script);"
+				]),
+				"}"
+			]);
+		}
+		return source;
+	});
+	mainTemplate.plugin("hot-bootstrap", function(source, chunk, hash) {
+		var hotUpdateChunkFilename = this.outputOptions.hotUpdateChunkFilename;
+		var hotUpdateMainFilename = this.outputOptions.hotUpdateMainFilename;
+		var hotUpdateFunction = this.outputOptions.hotUpdateFunction || Template.toIdentifier("webpackHotUpdate" + (this.outputOptions.library || ""));
+		var currentHotUpdateChunkFilename = this.applyPluginsWaterfall("asset-path", JSON.stringify(hotUpdateChunkFilename), {
+			hash: "\" + " + this.renderCurrentHashCode(hash) + " + \"",
+			hashWithLength: function(length) {
+				return "\" + " + this.renderCurrentHashCode(hash, length) + " + \"";
+			}.bind(this),
+			chunk: {
+				id: "\" + chunkId + \""
+			}
+		});
+		var currentHotUpdateMainFilename = this.applyPluginsWaterfall("asset-path", JSON.stringify(hotUpdateMainFilename), {
+			hash: "\" + " + this.renderCurrentHashCode(hash) + " + \"",
+			hashWithLength: function(length) {
+				return "\" + " + this.renderCurrentHashCode(hash, length) + " + \"";
+			}.bind(this)
+		});
+		return source + "\n"+
+			"var parentHotUpdateCallback = this[" + JSON.stringify(hotUpdateFunction) + "];\n" +
+			"this[" + JSON.stringify(hotUpdateFunction) + "] = " + Template.getFunctionContent(function() {
+			function webpackHotUpdateCallback(chunkId, moreModules) {
+				hotAddUpdateChunk(chunkId, moreModules);
+				if(parentHotUpdateCallback) parentHotUpdateCallback(chunkId, moreModules);
+			}
+
+			function hotDownloadUpdateChunk(chunkId) {
+				var head = document.getElementsByTagName('head')[0];
+				var script = document.createElement('script');
+				script.type = 'text/javascript';
+				script.charset = 'utf-8';
+				script.src = $require$.p + $hotChunkFilename$;
+				head.appendChild(script);
+			}
+
+			function hotDownloadManifest(callback) {
+				if(typeof XMLHttpRequest === "undefined")
+					return callback(new Error("No browser support"));
+				try {
+					var request = new XMLHttpRequest();
+					var requestPath = $require$.p + $hotMainFilename$;
+					request.open("GET", requestPath, true);
+					request.timeout = 10000;
+					request.send(null);
+				} catch(err) {
+					return callback(err);
+				}
+				request.onreadystatechange = function() {
+					if(request.readyState !== 4) return;
+					if(request.status === 0) {
+						// timeout
+						callback(new Error("Manifest request to " + requestPath + " timed out."));
+					} else if(request.status === 404) {
+						// no update available
+						callback();
+					} else if(request.status !== 200 && request.status !== 304) {
+						// other failure
+						callback(new Error("Manifest request to " + requestPath + " failed."));
+					} else {
+						// success
+						try {
+							var update = JSON.parse(request.responseText);
+						} catch(e) {
+							callback(e);
+							return;
+						}
+						callback(null, update);
+					}
+				};
+			}
+		})
+			.replace(/\$require\$/g, this.requireFn)
+			.replace(/\$hotMainFilename\$/g, currentHotUpdateMainFilename)
+			.replace(/\$hotChunkFilename\$/g, currentHotUpdateChunkFilename)
+			.replace(/\$hash\$/g, JSON.stringify(hash))
+	});
+	mainTemplate.plugin("hash", function(hash) {
+		hash.update("jsonp");
+		hash.update("4");
+		hash.update(this.outputOptions.filename + "");
+		hash.update(this.outputOptions.chunkFilename + "");
+		hash.update(this.outputOptions.jsonpFunction + "");
+		hash.update(this.outputOptions.library + "");
+	});
+};

--- a/lib/dependencies/AMDRequireDependenciesBlock.js
+++ b/lib/dependencies/AMDRequireDependenciesBlock.js
@@ -1,6 +1,7 @@
 /*
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
+	Modified by Richard Scarrott @richardscarrott
 */
 var AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
 var AMDRequireDependency = require("./AMDRequireDependency");

--- a/lib/dependencies/AMDRequireDependency.js
+++ b/lib/dependencies/AMDRequireDependency.js
@@ -1,6 +1,7 @@
 /*
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
+	Modified by Richard Scarrott @richardscarrott
 */
 var NullDependency = require("./NullDependency");
 var DepBlockHelpers = require("./DepBlockHelpers");

--- a/lib/dependencies/AMDRequireErrorHandlerDependenciesBlock.js
+++ b/lib/dependencies/AMDRequireErrorHandlerDependenciesBlock.js
@@ -1,0 +1,25 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author        Tobias Koppers @sokra
+	Modified by   Richard Scarrott @richardscarrott
+*/
+var AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
+var AMDRequireErrorHandlerDependency = require("./AMDRequireErrorHandlerDependency");
+
+function AMDRequireErrorHandlerDependenciesBlock(expr, arrayRange, successCallbackRange, errorCallbackRange, module, loc) {
+	AsyncDependenciesBlock.call(this, null, module, loc);
+	this.expr = expr;
+	this.outerRange = expr.range;
+	this.arrayRange = arrayRange;
+	this.successCallbackRange = successCallbackRange;
+	this.errorCallbackRange = errorCallbackRange;
+	this.range = arrayRange && successCallbackRange ? [arrayRange[0], successCallbackRange[1]] :
+		arrayRange ? arrayRange :
+		successCallbackRange ? successCallbackRange :
+		expr.range;
+	this.addDependency(new AMDRequireErrorHandlerDependency(this));
+}
+module.exports = AMDRequireErrorHandlerDependenciesBlock;
+
+AMDRequireErrorHandlerDependenciesBlock.prototype = Object.create(AsyncDependenciesBlock.prototype);
+

--- a/lib/dependencies/AMDRequireErrorHandlerDependenciesBlock.js
+++ b/lib/dependencies/AMDRequireErrorHandlerDependenciesBlock.js
@@ -1,7 +1,7 @@
 /*
 	MIT License http://www.opensource.org/licenses/mit-license.php
-	Author        Tobias Koppers @sokra
-	Modified by   Richard Scarrott @richardscarrott
+	Author Tobias Koppers @sokra
+	Modified by Richard Scarrott @richardscarrott
 */
 var AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
 var AMDRequireErrorHandlerDependency = require("./AMDRequireErrorHandlerDependency");

--- a/lib/dependencies/AMDRequireErrorHandlerDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/AMDRequireErrorHandlerDependenciesBlockParserPlugin.js
@@ -1,6 +1,7 @@
 /*
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
+	Modified by Richard Scarrott @richardscarrott
 */
 
 // a) require(['a']);

--- a/lib/dependencies/AMDRequireErrorHandlerDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/AMDRequireErrorHandlerDependenciesBlockParserPlugin.js
@@ -1,0 +1,76 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+// a) require(['a']);
+// b) require(['a'], successCallback);
+// c) require(['a'], successCallback, errorCallback);
+
+var AMDRequireItemDependency = require("./AMDRequireItemDependency");
+var AMDRequireArrayDependency = require("./AMDRequireArrayDependency");
+var AMDRequireContextDependency = require("./AMDRequireContextDependency");
+var AMDRequireErrorHandlerDependenciesBlock = require("./AMDRequireErrorHandlerDependenciesBlock");
+var LocalModuleDependency = require("./LocalModuleDependency");
+var ContextDependencyHelpers = require("./ContextDependencyHelpers");
+var LocalModulesHelpers = require("./LocalModulesHelpers");
+
+function AMDRequireErrorHandlerDependenciesBlockParserPlugin(options) {
+	this.options = options;
+}
+
+module.exports = AMDRequireErrorHandlerDependenciesBlockParserPlugin;
+
+AMDRequireErrorHandlerDependenciesBlockParserPlugin.prototype.apply = function(parser) {
+	var options = this.options;
+	parser.plugin("call require", function(expr) {
+		switch(expr.arguments.length) {
+		case 1:
+			var param = this.evaluateExpression(expr.arguments[0]);
+			var result;
+			var dep = new AMDRequireErrorHandlerDependenciesBlock(expr, param.range, null, null, this.state.module, expr.loc);
+			var old = this.state.current;
+			this.state.current = dep;
+			this.inScope([], function() {
+				result = this.applyPluginsBailResult("call require:amd:array", expr, param);
+			}.bind(this));
+			this.state.current = old;
+			if(!result) return;
+			this.state.current.addBlock(dep);
+			return true;
+		case 2:
+		case 3:
+			var param = this.evaluateExpression(expr.arguments[0]);
+			var successCallback = expr.arguments[1];
+			var errorCallback = expr.arguments[2] || {};
+			var dep = new AMDRequireErrorHandlerDependenciesBlock(expr, param.range, successCallback.range, errorCallback.range, this.state.module, expr.loc);
+			dep.loc = expr.loc;
+			var old = this.state.current;
+			this.state.current = dep;
+			try {
+				var result;
+				this.inScope([], function() {
+					result = this.applyPluginsBailResult("call require:amd:array", expr, param);
+				}.bind(this));
+				if(!result) return;
+				[successCallback, errorCallback].forEach(function(callback) {
+					if (callback.type === "FunctionExpression") {
+						this.inScope(callback.params.filter(function(i) {
+							return ["require", "module", "exports"].indexOf(i.name) < 0;
+						}), function() {
+							if(callback.body.type === "BlockStatement")
+								this.walkStatement(callback.body);
+							else
+								this.walkExpression(callback.body);
+						}.bind(this));
+					}
+				}.bind(this));
+			} finally {
+				this.state.current = old;
+				this.state.current.addBlock(dep);
+			}
+			return true;
+		}
+	});
+};
+

--- a/lib/dependencies/AMDRequireErrorHandlerDependency.js
+++ b/lib/dependencies/AMDRequireErrorHandlerDependency.js
@@ -1,6 +1,7 @@
 /*
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
+	Modified by Richard Scarrott @richardscarrott
 */
 var NullDependency = require("./NullDependency");
 var DepBlockHelpers = require("./DepBlockHelpers");
@@ -11,10 +12,6 @@ function AMDRequireDependency(block) {
 	this.block = block;
 }
 module.exports = AMDRequireDependency;
-
-// a) require(['a']);
-// b) require(['a'], successCallback);
-// c) require(['a'], successCallback, errorCallback);
 
 AMDRequireDependency.prototype = Object.create(NullDependency.prototype);
 

--- a/lib/dependencies/AMDRequireErrorHandlerDependency.js
+++ b/lib/dependencies/AMDRequireErrorHandlerDependency.js
@@ -1,0 +1,71 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var NullDependency = require("./NullDependency");
+var DepBlockHelpers = require("./DepBlockHelpers");
+
+function AMDRequireDependency(block) {
+	NullDependency.call(this);
+	this.Class = AMDRequireDependency;
+	this.block = block;
+}
+module.exports = AMDRequireDependency;
+
+// a) require(['a']);
+// b) require(['a'], successCallback);
+// c) require(['a'], successCallback, errorCallback);
+
+AMDRequireDependency.prototype = Object.create(NullDependency.prototype);
+
+AMDRequireDependency.Template = function AMDRequireDependencyTemplate() {};
+
+AMDRequireDependency.Template.prototype.apply = function(dep, source, outputOptions, requestShortener) {
+	var depBlock = dep.block;
+	var wrapper = DepBlockHelpers.getLoadDepBlockWrapper(depBlock, outputOptions, requestShortener, "require");
+
+	if(depBlock.arrayRange && !depBlock.successCallbackRange) {
+		if(wrapper) {
+			source.replace(depBlock.outerRange[0], depBlock.arrayRange[0]-1,
+				wrapper[0] + "function() {");
+			source.replace(depBlock.arrayRange[1], depBlock.outerRange[1]-1, ";}" + wrapper[1]);
+		} else {
+			source.replace(depBlock.outerRange[0], depBlock.arrayRange[0]-1,
+				"!/* require */(" + asComment(depBlock.chunkReason));
+			source.replace(depBlock.arrayRange[1], depBlock.outerRange[1]-1, ")");
+		}
+	} else if(!depBlock.arrayRange && depBlock.successCallbackRange) {
+		if(wrapper) {
+			source.replace(depBlock.outerRange[0], depBlock.successCallbackRange[0]-1,
+				wrapper[0] + "function(__webpack_require__) {(");
+			source.replace(depBlock.successCallbackRange[1], depBlock.outerRange[1]-1, ".call(exports, __webpack_require__, exports, module));}" + wrapper[1]);
+		} else {
+			source.replace(depBlock.outerRange[0], depBlock.successCallbackRange[0]-1,
+				"!/* require */(" + asComment(depBlock.chunkReason));
+			source.replace(depBlock.successCallbackRange[1], depBlock.outerRange[1]-1, ".call(exports, __webpack_require__, exports, module))");
+		}
+	} else if(depBlock.arrayRange && depBlock.successCallbackRange) {
+		if(wrapper) {
+			source.replace(depBlock.outerRange[0], depBlock.arrayRange[0]-1,
+				wrapper[0] + "function(__webpack_require__) { ");
+			source.insert(depBlock.arrayRange[0] + 0.9, "var __WEBPACK_AMD_REQUIRE_ARRAY__ = ");
+			source.replace(depBlock.arrayRange[1], depBlock.successCallbackRange[0]-1, "; (");
+			source.insert(depBlock.successCallbackRange[1], ".apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__));}");
+			var start = depBlock.errorCallbackRange ? depBlock.errorCallbackRange[1] : depBlock.successCallbackRange[1];
+			source.replace(start, depBlock.outerRange[1]-1, wrapper[1]);
+		} else {
+			source.replace(depBlock.outerRange[0], depBlock.arrayRange[0]-1,
+				"!/* require */(" + asComment(depBlock.chunkReason) + "function() { ");
+			source.insert(depBlock.arrayRange[0] + 0.9, "var __WEBPACK_AMD_REQUIRE_ARRAY__ = ");
+			source.replace(depBlock.arrayRange[1], depBlock.successCallbackRange[0]-1, "; (");
+			source.insert(depBlock.successCallbackRange[1], ".apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__));}");
+			var start = depBlock.errorCallbackRange ? depBlock.errorCallbackRange[1] : depBlock.successCallbackRange[1];
+			source.replace(start, depBlock.outerRange[1]-1, wrapper[1]);
+		}
+	}
+};
+
+function asComment(str) {
+	if(!str) return "";
+	return "/* " + str + " */";
+}

--- a/lib/dependencies/AMDRequireErrorHandlerPlugin.js
+++ b/lib/dependencies/AMDRequireErrorHandlerPlugin.js
@@ -1,0 +1,26 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+var AMDRequireErrorHandlerDependency = require("./AMDRequireErrorHandlerDependency");
+var NullFactory = require("../NullFactory");
+var AMDRequireErrorHandlerDependenciesBlockParserPlugin = require("./AMDRequireErrorHandlerDependenciesBlockParserPlugin");
+
+function AMDErrorHandlerPlugin(options) {
+	this.options = options;
+}
+module.exports = AMDErrorHandlerPlugin;
+
+AMDErrorHandlerPlugin.prototype.apply = function(compiler) {
+
+	compiler.plugin("compilation", function(compilation, params) {
+		compilation.dependencyFactories.set(AMDRequireErrorHandlerDependency, new NullFactory());
+		compilation.dependencyTemplates.set(AMDRequireErrorHandlerDependency, new AMDRequireErrorHandlerDependency.Template());
+	});
+
+	compiler.parser.apply(
+		new AMDRequireErrorHandlerDependenciesBlockParserPlugin(this.options)
+	);
+
+};

--- a/lib/dependencies/AMDRequireErrorHandlerPlugin.js
+++ b/lib/dependencies/AMDRequireErrorHandlerPlugin.js
@@ -1,6 +1,7 @@
 /*
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
+	Modified by Richard Scarrott @richardscarrott
 */
 
 var AMDRequireErrorHandlerDependency = require("./AMDRequireErrorHandlerDependency");

--- a/lib/dependencies/RequireEnsureErrorHandlerDependenciesBlock.js
+++ b/lib/dependencies/RequireEnsureErrorHandlerDependenciesBlock.js
@@ -1,0 +1,28 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
+var RequireEnsureErrorHandlerDependency = require("./RequireEnsureErrorHandlerDependency");
+
+function RequireEnsureDependenciesBlock(expr, successCallback, errorCallback, chunkName, chunkNameRange, module, loc) {
+	AsyncDependenciesBlock.call(this, chunkName, module, loc);
+	this.expr = expr;
+	var successCallbackRange = successCallback && successCallback.body && successCallback.body.range;
+	var errorCallbackRange = errorCallback && errorCallback.body && errorCallback.body.range;
+	this.range = null;
+	if (errorCallback) {
+		debugger;
+	}
+	if (successCallbackRange && errorCallbackRange) {
+		this.range = [successCallbackRange[0] + 1, errorCallbackRange[1] - 1];
+	} else if (successCallbackRange) {
+		this.range = [successCallbackRange[0] + 1, successCallbackRange[1] - 1];
+	}
+	this.chunkNameRange = chunkNameRange;
+	this.addDependency(new RequireEnsureErrorHandlerDependency(this));
+}
+module.exports = RequireEnsureDependenciesBlock;
+
+RequireEnsureDependenciesBlock.prototype = Object.create(AsyncDependenciesBlock.prototype);
+

--- a/lib/dependencies/RequireEnsureErrorHandlerDependenciesBlock.js
+++ b/lib/dependencies/RequireEnsureErrorHandlerDependenciesBlock.js
@@ -1,6 +1,7 @@
 /*
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
+	Modified by Richard Scarrott @richardscarrott
 */
 var AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
 var RequireEnsureErrorHandlerDependency = require("./RequireEnsureErrorHandlerDependency");

--- a/lib/dependencies/RequireEnsureErrorHandlerDependenciesBlock.js
+++ b/lib/dependencies/RequireEnsureErrorHandlerDependenciesBlock.js
@@ -5,24 +5,12 @@
 var AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
 var RequireEnsureErrorHandlerDependency = require("./RequireEnsureErrorHandlerDependency");
 
-function RequireEnsureDependenciesBlock(expr, successCallback, errorCallback, chunkName, chunkNameRange, module, loc) {
+function RequireEnsureErrorHandlerDependenciesBlock(expr, chunkName, module, loc) {
 	AsyncDependenciesBlock.call(this, chunkName, module, loc);
 	this.expr = expr;
-	var successCallbackRange = successCallback && successCallback.body && successCallback.body.range;
-	var errorCallbackRange = errorCallback && errorCallback.body && errorCallback.body.range;
-	this.range = null;
-	if (errorCallback) {
-		debugger;
-	}
-	if (successCallbackRange && errorCallbackRange) {
-		this.range = [successCallbackRange[0] + 1, errorCallbackRange[1] - 1];
-	} else if (successCallbackRange) {
-		this.range = [successCallbackRange[0] + 1, successCallbackRange[1] - 1];
-	}
-	this.chunkNameRange = chunkNameRange;
 	this.addDependency(new RequireEnsureErrorHandlerDependency(this));
 }
-module.exports = RequireEnsureDependenciesBlock;
+module.exports = RequireEnsureErrorHandlerDependenciesBlock;
 
-RequireEnsureDependenciesBlock.prototype = Object.create(AsyncDependenciesBlock.prototype);
+RequireEnsureErrorHandlerDependenciesBlock.prototype = Object.create(AsyncDependenciesBlock.prototype);
 

--- a/lib/dependencies/RequireEnsureErrorHandlerDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/RequireEnsureErrorHandlerDependenciesBlockParserPlugin.js
@@ -1,6 +1,7 @@
 /*
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
+	Modified by Richard Scarrott @richardscarrott
 */
 
 // a) require.ensure(['deps'], successCallback, errorCallback, name);

--- a/lib/dependencies/RequireEnsureErrorHandlerDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/RequireEnsureErrorHandlerDependenciesBlockParserPlugin.js
@@ -37,7 +37,6 @@ module.exports = AbstractPlugin.create({
 		if (chunkName) {
 			chunkNameExpr = this.evaluateExpression(chunkName);
 			if (chunkNameExpr.isString()) {
-				var chunkNameRange = chunkNameExpr.range;
 				chunkName = chunkNameExpr.string;
 			}
 		}

--- a/lib/dependencies/RequireEnsureErrorHandlerDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/RequireEnsureErrorHandlerDependenciesBlockParserPlugin.js
@@ -2,76 +2,59 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+
+// a) require.ensure(['deps'], successCallback, errorCallback, name);
+// b) require.ensure(['deps'], successCallback, errorCallback);
+// c) require.ensure(['deps'], successCallback, name);
+// d) require.ensure(['deps'], successCallback);
+
 var AbstractPlugin = require("../AbstractPlugin");
 var RequireEnsureErrorHandlerDependenciesBlock = require("./RequireEnsureErrorHandlerDependenciesBlock");
 var RequireEnsureItemDependency = require("./RequireEnsureItemDependency");
 var getFunctionExpression = require("./getFunctionExpression");
 
-
-// a) require.ensure(['dpes'], successCallback, errorCallback, name);
-// b) require.ensure(['dpes'], successCallback, errorCallback);
-// c) require.ensure(['dpes'], successCallback, name);
-// d) require.ensure(['dpes'], successCallback);
-
-
 module.exports = AbstractPlugin.create({
 	"call require.ensure": function(expr) {
-
-		if (!expr.arguments.length) {
-			return;
-		}
 
 		var dependencies = expr.arguments[0],
 			successCallback = expr.arguments[1],
 			errorCallback = expr.arguments[2],
 			chunkName = expr.arguments[3],
+			dependenciesExpr = null,
+			successCallbackExpr = null,
 			errorCallbackExpr = null,
-			chunkNameExpr = null,
-			chunkNameRange = null;
+			chunkNameExpr = null;
 
 		if (errorCallback) {
-			debugger;
-			errorCallbackExpr = this.evaluateExpression(errorCallback);
-		}
-
-		if (errorCallbackExpr && errorCallbackExpr.isString()) {
-			chunkName = errorCallback;
-			chunkNameExpr = errorCallbackExpr;
-			errorCallback = errorCallbackExpr = null;
-		} else {
-			if (errorCallback) {
-				errorCallbackExpr = getFunctionExpression(errorCallback);
-			}
-			if (chunkName) {
-				chunkNameExpr = this.evaluateExpression(chunkName);
+			errorCallbackExpr = getFunctionExpression(errorCallback);
+			// if `errorCallback` isn't a function then shuffle arguments.
+			if (!errorCallbackExpr) {
+				chunkName = errorCallback;
+				errorCallback = errorCallbackExpr = null;
 			}
 		}
 
-		if (chunkNameExpr && chunkNameExpr.isString()) {
-			chunkNameRange = chunkNameExpr.range;
-			chunkName = chunkNameExpr.string;
+		if (chunkName) {
+			chunkNameExpr = this.evaluateExpression(chunkName);
+			if (chunkNameExpr.isString()) {
+				var chunkNameRange = chunkNameExpr.range;
+				chunkName = chunkNameExpr.string;
+			}
 		}
 
-		var dependenciesExpr = this.evaluateExpression(dependencies);
+		dependenciesExpr = this.evaluateExpression(dependencies);
 		var dependenciesItems = dependenciesExpr.isArray() ? dependenciesExpr.items : [dependenciesExpr];
-		var successCallbackExpr = getFunctionExpression(successCallback);
+		successCallbackExpr = getFunctionExpression(successCallback);
 
 		if (successCallbackExpr) {
 			this.walkExpressions(successCallbackExpr.expressions);
 		}
 
 		if (errorCallbackExpr) {
-			debugger;
 			this.walkExpressions(errorCallbackExpr.expressions);
 		}
 
-		if (chunkName === 'myburberry') {
-			debugger;
-		}
-
-		var old = this.state.current;
-
-		var dep = new RequireEnsureErrorHandlerDependenciesBlock(expr, (successCallbackExpr ? successCallbackExpr.fn : successCallback), (errorCallbackExpr ? errorCallbackExpr.fn : errorCallback), chunkName, chunkNameRange, this.state.module, expr.loc);
+		var dep = new RequireEnsureErrorHandlerDependenciesBlock(expr, chunkName, this.state.module, expr.loc);
 		var old = this.state.current;
 		this.state.current = dep;
 		try {
@@ -79,6 +62,8 @@ module.exports = AbstractPlugin.create({
 			this.inScope([], function() {
 				dependenciesItems.forEach(function(ee) {
 					if(ee.isString()) {
+						// TODO: work out what RequireEnsureItemDependency is for
+						// and if it needs to be extended for the errorhandling plugin.
 						var edep = new RequireEnsureItemDependency(ee.string, ee.range);
 						edep.loc = dep.loc;
 						dep.addDependency(edep);
@@ -113,20 +98,6 @@ module.exports = AbstractPlugin.create({
 			this.walkExpression(errorCallback);
 		}
 		return true;
-
-
-
-		// switch(expr.arguments.length) {
-		// case 3:
-		// 	var chunkNameExpr = this.evaluateExpression(expr.arguments[2]);
-		// 	if(!chunkNameExpr.isString()) return;
-		// 	chunkNameRange = chunkNameExpr.range;
-		// 	chunkName = chunkNameExpr.string;
-		// 	// fall through
-		// case 2:
-		// 	var dependencies = null;
-
-		// }
 	}
 });
 

--- a/lib/dependencies/RequireEnsureErrorHandlerDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/RequireEnsureErrorHandlerDependenciesBlockParserPlugin.js
@@ -1,0 +1,132 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var AbstractPlugin = require("../AbstractPlugin");
+var RequireEnsureErrorHandlerDependenciesBlock = require("./RequireEnsureErrorHandlerDependenciesBlock");
+var RequireEnsureItemDependency = require("./RequireEnsureItemDependency");
+var getFunctionExpression = require("./getFunctionExpression");
+
+
+// a) require.ensure(['dpes'], successCallback, errorCallback, name);
+// b) require.ensure(['dpes'], successCallback, errorCallback);
+// c) require.ensure(['dpes'], successCallback, name);
+// d) require.ensure(['dpes'], successCallback);
+
+
+module.exports = AbstractPlugin.create({
+	"call require.ensure": function(expr) {
+
+		if (!expr.arguments.length) {
+			return;
+		}
+
+		var dependencies = expr.arguments[0],
+			successCallback = expr.arguments[1],
+			errorCallback = expr.arguments[2],
+			chunkName = expr.arguments[3],
+			errorCallbackExpr = null,
+			chunkNameExpr = null,
+			chunkNameRange = null;
+
+		if (errorCallback) {
+			debugger;
+			errorCallbackExpr = this.evaluateExpression(errorCallback);
+		}
+
+		if (errorCallbackExpr && errorCallbackExpr.isString()) {
+			chunkName = errorCallback;
+			chunkNameExpr = errorCallbackExpr;
+			errorCallback = errorCallbackExpr = null;
+		} else {
+			if (errorCallback) {
+				errorCallbackExpr = getFunctionExpression(errorCallback);
+			}
+			if (chunkName) {
+				chunkNameExpr = this.evaluateExpression(chunkName);
+			}
+		}
+
+		if (chunkNameExpr && chunkNameExpr.isString()) {
+			chunkNameRange = chunkNameExpr.range;
+			chunkName = chunkNameExpr.string;
+		}
+
+		var dependenciesExpr = this.evaluateExpression(dependencies);
+		var dependenciesItems = dependenciesExpr.isArray() ? dependenciesExpr.items : [dependenciesExpr];
+		var successCallbackExpr = getFunctionExpression(successCallback);
+
+		if (successCallbackExpr) {
+			this.walkExpressions(successCallbackExpr.expressions);
+		}
+
+		if (errorCallbackExpr) {
+			debugger;
+			this.walkExpressions(errorCallbackExpr.expressions);
+		}
+
+		if (chunkName === 'myburberry') {
+			debugger;
+		}
+
+		var old = this.state.current;
+
+		var dep = new RequireEnsureErrorHandlerDependenciesBlock(expr, (successCallbackExpr ? successCallbackExpr.fn : successCallback), (errorCallbackExpr ? errorCallbackExpr.fn : errorCallback), chunkName, chunkNameRange, this.state.module, expr.loc);
+		var old = this.state.current;
+		this.state.current = dep;
+		try {
+			var failed = false;
+			this.inScope([], function() {
+				dependenciesItems.forEach(function(ee) {
+					if(ee.isString()) {
+						var edep = new RequireEnsureItemDependency(ee.string, ee.range);
+						edep.loc = dep.loc;
+						dep.addDependency(edep);
+					} else {
+						failed = true;
+					}
+				});
+			});
+			if(failed) {
+				return;
+			}
+			if(successCallbackExpr) {
+				if(successCallbackExpr.fn.body.type === "BlockStatement")
+					this.walkStatement(successCallbackExpr.fn.body);
+				else
+					this.walkExpression(successCallbackExpr.fn.body);
+			}
+			if(errorCallbackExpr) {
+				if(errorCallbackExpr.fn.body.type === "BlockStatement")
+					this.walkStatement(errorCallbackExpr.fn.body);
+				else
+					this.walkExpression(errorCallbackExpr.fn.body);
+			}
+			old.addBlock(dep);
+		} finally {
+			this.state.current = old;
+		}
+		if(!successCallbackExpr) {
+			this.walkExpression(successCallback);
+		}
+		if(!errorCallbackExpr && errorCallback) {
+			this.walkExpression(errorCallback);
+		}
+		return true;
+
+
+
+		// switch(expr.arguments.length) {
+		// case 3:
+		// 	var chunkNameExpr = this.evaluateExpression(expr.arguments[2]);
+		// 	if(!chunkNameExpr.isString()) return;
+		// 	chunkNameRange = chunkNameExpr.range;
+		// 	chunkName = chunkNameExpr.string;
+		// 	// fall through
+		// case 2:
+		// 	var dependencies = null;
+
+		// }
+	}
+});
+

--- a/lib/dependencies/RequireEnsureErrorHandlerDependency.js
+++ b/lib/dependencies/RequireEnsureErrorHandlerDependency.js
@@ -1,6 +1,7 @@
 /*
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
+	Modified by Richard Scarrott @richardscarrott
 */
 var NullDependency = require("./NullDependency");
 var DepBlockHelpers = require("./DepBlockHelpers");
@@ -25,20 +26,10 @@ RequireEnsureErrorHandlerDependency.Template.prototype.apply = function(dep, sou
 		"(__webpack_require__))"
 	];
 	source.replace(depBlock.expr.range[0], depBlock.expr.arguments[1].range[0]-1, wrapper[0]);
-	// maybe use arguments.length - 1?
-	// source.replace(depBlock.range[1]+1, depBlock.expr.range[1]-1, wrapper[1]);
 	if (depBlock.chunkName) {
 		source.replace(depBlock.expr.arguments[depBlock.expr.arguments.length-2].range[1], depBlock.expr.range[1]-1, wrapper[1]);
 	} else {
 		source.replace(depBlock.expr.arguments[depBlock.expr.arguments.length-1].range[1], depBlock.expr.range[1]-1, wrapper[1]);
 	}
-
-
-
-	// source.replace(depBlock.expr.range[0], depBlock.expr.arguments[1].range[0]-1, wrapper[0]);
-	// source.replace(depBlock.expr.arguments[1].range[1], depBlock.expr.range[1]-1, wrapper[1]);
-
-	// source.replace(depBlock.range[0], depBlock.expr.arguments[1].range[0]-1, wrapper[0]);
-	// source.replace(depBlock.expr.arguments[1].range[1], depBlock.expr.range[1]-1, wrapper[1]);
 };
 

--- a/lib/dependencies/RequireEnsureErrorHandlerDependency.js
+++ b/lib/dependencies/RequireEnsureErrorHandlerDependency.js
@@ -1,0 +1,44 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var NullDependency = require("./NullDependency");
+var DepBlockHelpers = require("./DepBlockHelpers");
+
+function RequireEnsureErrorHandlerDependency(block) {
+	NullDependency.call(this);
+	this.Class = RequireEnsureErrorHandlerDependency;
+	this.block = block;
+}
+module.exports = RequireEnsureErrorHandlerDependency;
+
+RequireEnsureErrorHandlerDependency.prototype = Object.create(NullDependency.prototype);
+RequireEnsureErrorHandlerDependency.prototype.type = "require.ensure";
+
+RequireEnsureErrorHandlerDependency.Template = function RequireEnsureErrorHandlerDependencyTemplate() {};
+
+RequireEnsureErrorHandlerDependency.Template.prototype.apply = function(dep, source, outputOptions, requestShortener) {
+	var depBlock = dep.block;
+	var wrapper = DepBlockHelpers.getLoadDepBlockWrapper(depBlock, outputOptions, requestShortener, /*require.e*/"nsure");
+	if(!wrapper) wrapper = [
+		"!/* require.ensure */(",
+		"(__webpack_require__))"
+	];
+	source.replace(depBlock.expr.range[0], depBlock.expr.arguments[1].range[0]-1, wrapper[0]);
+	// maybe use arguments.length - 1?
+	// source.replace(depBlock.range[1]+1, depBlock.expr.range[1]-1, wrapper[1]);
+	if (depBlock.chunkName) {
+		source.replace(depBlock.expr.arguments[depBlock.expr.arguments.length-2].range[1], depBlock.expr.range[1]-1, wrapper[1]);
+	} else {
+		source.replace(depBlock.expr.arguments[depBlock.expr.arguments.length-1].range[1], depBlock.expr.range[1]-1, wrapper[1]);
+	}
+
+
+
+	// source.replace(depBlock.expr.range[0], depBlock.expr.arguments[1].range[0]-1, wrapper[0]);
+	// source.replace(depBlock.expr.arguments[1].range[1], depBlock.expr.range[1]-1, wrapper[1]);
+
+	// source.replace(depBlock.range[0], depBlock.expr.arguments[1].range[0]-1, wrapper[0]);
+	// source.replace(depBlock.expr.arguments[1].range[1], depBlock.expr.range[1]-1, wrapper[1]);
+};
+

--- a/lib/dependencies/RequireEnsureErrorHandlerPlugin.js
+++ b/lib/dependencies/RequireEnsureErrorHandlerPlugin.js
@@ -1,9 +1,8 @@
 /*
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
+	Modified by Richard Scarrott @richardscarrott
 */
-
-// NOTE: don't know what `RequireEnsureItemDepedency` is for so just using the one from `RequireEnsurePlugin`...
 
 var RequireEnsureItemDependency = require("./RequireEnsureItemDependency");
 var RequireEnsureErrorHandlerDependency = require("./RequireEnsureErrorHandlerDependency");

--- a/lib/dependencies/RequireEnsureErrorHandlerPlugin.js
+++ b/lib/dependencies/RequireEnsureErrorHandlerPlugin.js
@@ -1,0 +1,42 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+// NOTE: don't know what `RequireEnsureItemDepedency` is for so just using the one from `RequireEnsurePlugin`...
+
+var RequireEnsureItemDependency = require("./RequireEnsureItemDependency");
+var RequireEnsureErrorHandlerDependency = require("./RequireEnsureErrorHandlerDependency");
+var ConstDependency = require("./ConstDependency");
+
+var NullFactory = require("../NullFactory");
+
+var RequireEnsureErrorHandlerDependenciesBlockParserPlugin = require("./RequireEnsureErrorHandlerDependenciesBlockParserPlugin");
+
+var BasicEvaluatedExpression = require("../BasicEvaluatedExpression");
+
+function RequireEnsureErrorHandlerPlugin() {
+}
+module.exports = RequireEnsureErrorHandlerPlugin;
+
+RequireEnsureErrorHandlerPlugin.prototype.apply = function(compiler) {
+	compiler.plugin("compilation", function(compilation, params) {
+		var normalModuleFactory = params.normalModuleFactory;
+
+		compilation.dependencyFactories.set(RequireEnsureItemDependency, normalModuleFactory);
+		compilation.dependencyTemplates.set(RequireEnsureItemDependency, new RequireEnsureItemDependency.Template());
+
+		compilation.dependencyFactories.set(RequireEnsureErrorHandlerDependency, new NullFactory());
+		compilation.dependencyTemplates.set(RequireEnsureErrorHandlerDependency, new RequireEnsureErrorHandlerDependency.Template());
+	});
+	new RequireEnsureErrorHandlerDependenciesBlockParserPlugin().apply(compiler.parser);
+	compiler.parser.plugin("evaluate typeof require.ensure", function(expr) {
+		return new BasicEvaluatedExpression().setString("function").setRange(expr.range);
+	});
+	compiler.parser.plugin("typeof require.ensure", function(expr) {
+		var dep = new ConstDependency("'function'", expr.range);
+		dep.loc = expr.loc;
+		this.state.current.addDependency(dep);
+		return true;
+	});
+};


### PR DESCRIPTION
I've taken a stab at creating a `RequireEnsureErrorHandlerPlugin` which is designed to replace the `RequireEnsurePlugin` with support for the following signatures:

```javascript
require.ensure(['a'], function() {
    // success
}, function() {
    // error
}, 'a');

require.ensure(['b'], function() {
    // success
}, function() {
    // error
});

require.ensure(['c'], function() {
    // success
}, 'c');

require.ensure(['d'], function() {
    // success
});
```

NOTE: I didn't follow AMD exactly as it would be a breaking change to move name to the first argument.

Usage:
```javascript
var RequireEnsureErrorHandlerPlugin = require('webpack/lib/dependencies/RequireEnsureErrorHandlerPlugin');

{
    plugins: [
        new RequireEnsureErrorHandlerPlugin()
    ]
}
```

It's all based on the `RequireEnsurePlugin` however there were a few things I didn't really understand such as the `RequireEnsureItemDependency` class so it definitely could do with a review / feedback.

The idea would be to then combine it with the [`JsonpErrorHandlingPlugin `](https://github.com/webpack/webpack/pull/692) if that were to update the `__webpack_require__.e` signature to `__webpack_require__.e(chunkId, successCallback, errorCallback?)`.