### PR TITLE
Use "supports-color" to detect if terminal supports colors

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -77,9 +77,7 @@ ifArg("json", function(bool) {
 	outputOptions.json = bool;
 });
 
-ifArg("colors", function(bool) {
-	outputOptions.colors = bool;
-});
+outputOptions.colors = require("supports-color");
 
 ifArg("sort-modules-by", function(value) {
 	outputOptions.modulesSort = value;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"webpack-core": "~0.4.8",
 		"node-libs-browser": "~0.4.0",
 		"watchpack": "^0.2.1",
-		"tapable": "~0.1.8"
+		"tapable": "~0.1.8",
+		"supports-color": "^1.2.0"
 	},
 	"licenses": [
 		{


### PR DESCRIPTION
This solution still supports "--colors" and "--no-colors" for overriding the detected ability.

see https://github.com/sindresorhus/supports-color