### PR TITLE
DefinePlugin: allow undefined values within objects to be defined at runtime as-is

### DIFF
--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -74,7 +74,8 @@ DefinePlugin.prototype.apply = function(compiler) {
 	function applyObjectDefine(key, obj) {
 		var code = "{" + Object.keys(obj).map(function(key) {
 			var code = obj[key];
-			if(typeof code !== "string" && code.toString) code = code.toString();
+			if(typeof code === "undefined") code = undefined;
+			else if(typeof code !== "string" && code.toString) code = code.toString();
 			else if(typeof code !== "string") code = code + "";
 			return JSON.stringify(key) + ":" + code;
 		}).join(",") + "}";


### PR DESCRIPTION
Instead of crashing trying to access (undefined).toString.

Use-case: allows us to define variables simpler, and have the value reflected more accurately in runtime environment:
```js
new webpack.DefinePlugin({ 
  'BUILD_ENV': {
    'PORT': JSON.stringify(process.env['PORT']) 
  }
})
```
...
```js
console.log(typeof BUILD_ENV['PORT']); // => "undefined"
```