### PR TITLE
Show error messages from UglifyJs

### DIFF
--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -118,6 +118,8 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 						} else {
 							compilation.errors.push(new Error(file + " from UglifyJs\n" + err.message + " [" + file + ":" + err.line + "," + err.col + "]"));
 						}
+					} else if (err.msg) {
+						compilation.errors.push(new Error(file + " from UglifyJs\n" + err.msg));
 					} else
 						compilation.errors.push(new Error(file + " from UglifyJs\n" + err.stack));
 				} finally {


### PR DESCRIPTION
Print out err.msg if it's available. Previously these error messages were ignored and it printed unhelpful "undefined"

Errors of this type are created here: https://github.com/mishoo/UglifyJS2/blob/master/lib/utils.js#L84

I had a situation where I was getting an error output like this:
```
ERROR in jsx.js from UglifyJs
undefined
```

After this change the error is:
```
ERROR in jsx.js from UglifyJs
`inline_scripts` is not a supported option
```

The error was a typo in the option. It is supposed to be `inline_script`, not `inline_scripts`. See appsforartists/ambidex#9