### PR TITLE
use absolute paths for hot-reload requests

### DIFF
--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -148,7 +148,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 				var script = document.createElement('script');
 				script.type = 'text/javascript';
 				script.charset = 'utf-8';
-				script.src = $require$.p + $hotChunkFilename$;
+				script.src = "/" + $require$.p + $hotChunkFilename$;
 				head.appendChild(script);
 			}
 
@@ -157,7 +157,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 					return callback(new Error("No browser support"));
 				try {
 					var request = new XMLHttpRequest();
-					var requestPath = $require$.p + $hotMainFilename$;
+					var requestPath = "/" + $require$.p + $hotMainFilename$;
 					request.open("GET", requestPath, true);
 					request.timeout = 10000;
 					request.send(null);


### PR DESCRIPTION
I encountered an issue when working on a page that was in `localhost:3000/posts/cat/title.html`

as I updated the files, the hot update gave me 404 errors on `/localhost:3000/posts/cat/[hash]-hot-update.json`

this PR fixes this issue by using absolute paths in the requests