### PR TITLE
Added semicolon after output

### DIFF
--- a/lib/MainTemplate.js
+++ b/lib/MainTemplate.js
@@ -27,7 +27,7 @@ function MainTemplate(outputOptions) {
 		source.add("/******/ (");
 		var modules = this.renderChunkModules(chunk, moduleTemplate, dependencyTemplates, "/******/ ");
 		source.add(this.applyPluginsWaterfall("modules", modules, chunk, hash, moduleTemplate, dependencyTemplates));
-		source.add(")");
+		source.add(");");
 		return source;
 	});
 	this.plugin("local-vars", function(source, chunk, hash) {


### PR DESCRIPTION
This fixes #789. However, @sokra mentioned that dependencies should just be bundled together instead of trying to concat bundles.