### PR TITLE
Indicate missing configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /examples/*/js
 /coverage
 .DS_Store
+*.swp

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -32,6 +32,9 @@ module.exports = function(optimist, argv, convertOptions) {
 		var configPath = path.resolve("webpack.config.js");
 		if(fs.existsSync(configPath)) {
 			options = require(configPath);
+		} else {
+			console.log("No config file found. For options see: webpack --help");
+			process.exit(-1);
 		}
 	}
 	if(typeof options !== "object" || options === null) {


### PR DESCRIPTION
  * Show user missing configuration message
  * Ignore swap files

Fixes #738. Tests are currently breaking in `master`, due to `webpack-core` being out of date. See https://github.com/webpack/webpack/commit/d80cf1cddd369ffafe046f39a1ef9c7584b3d876.