### PR TITLE
Improve size output readability

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -339,6 +339,11 @@ Stats.jsonToString = function jsonToString(obj, useColors) {
 			newline();
 		}
 	}
+	function formatSize(size) {
+		return String(size)
+			.split(/(?=(?:...)*$)/)
+			.join(",");
+	}
 
 	if(obj.hash) {
 		normal("Hash: ");
@@ -361,7 +366,7 @@ Stats.jsonToString = function jsonToString(obj, useColors) {
 		obj.assets.forEach(function(asset) {
 			t.push([
 				asset.name,
-				asset.size,
+				formatSize(asset.size),
 				asset.chunks.join(", "),
 				asset.emitted ? "[emitted]" : "",
 				asset.chunkNames.join(", ")
@@ -424,7 +429,7 @@ Stats.jsonToString = function jsonToString(obj, useColors) {
 	}
 	function processModuleAttributes(module) {
 		normal(" ");
-		normal(module.size);
+		normal(formatSize(module.size));
 		if(module.chunks) {
 			module.chunks.forEach(function(chunk) {
 				normal(" {");
@@ -467,7 +472,7 @@ Stats.jsonToString = function jsonToString(obj, useColors) {
 				normal(")");
 			}
 			normal(" ");
-			normal(chunk.size);
+			normal(formatSize(chunk.size));
 			chunk.parents.forEach(function(id) {
 				normal(" {");
 				yellow(id);


### PR DESCRIPTION
  * use commas as thousands delimiter

Before merging see https://github.com/webpack/webpack/issues/741#issuecomment-77099289. Thanks!

### Example output:

``` bash
Hash: 25346570a3942f210b46
Version: webpack 1.7.1
Time: 5285ms
                                Asset       Size  Chunks             Chunk Names
 7ad17c6085dee9a33787bac28fb23d46.eot     20,335          [emitted]
68ed1dac06bf0409c18ae7bc62889170.woff     23,320          [emitted]
 e49d52e74b7689a0727def99da31f3eb.ttf     41,280          [emitted]
 32941d6330044744c02493835b799e90.svg     62,927          [emitted]
                            bundle.js  1,161,559       0  [emitted]  main
 [206] ../webpack/buildin/amd-define.js 84 {0} [built]
    + 219 hidden modules
```

Resolves #741 