### PR TITLE
Alternative improve size output readability

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -339,6 +339,15 @@ Stats.jsonToString = function jsonToString(obj, useColors) {
 			newline();
 		}
 	}
+	function formatSize(size) {
+		if(size <= 0) return "0 bytes";
+
+		var abbreviations = ["bytes", "kB", "MB", "GB"];
+		var index = Math.floor(Math.log(size) / Math.log(1000));
+
+		return +(size / Math.pow(1000, index))
+			.toPrecision(3) + ' ' + abbreviations[index];
+	}
 
 	if(obj.hash) {
 		normal("Hash: ");
@@ -361,7 +370,7 @@ Stats.jsonToString = function jsonToString(obj, useColors) {
 		obj.assets.forEach(function(asset) {
 			t.push([
 				asset.name,
-				asset.size,
+				formatSize(asset.size),
 				asset.chunks.join(", "),
 				asset.emitted ? "[emitted]" : "",
 				asset.chunkNames.join(", ")
@@ -424,7 +433,7 @@ Stats.jsonToString = function jsonToString(obj, useColors) {
 	}
 	function processModuleAttributes(module) {
 		normal(" ");
-		normal(module.size);
+		normal(formatSize(module.size));
 		if(module.chunks) {
 			module.chunks.forEach(function(chunk) {
 				normal(" {");
@@ -467,7 +476,7 @@ Stats.jsonToString = function jsonToString(obj, useColors) {
 				normal(")");
 			}
 			normal(" ");
-			normal(chunk.size);
+			normal(formatSize(chunk.size));
 			chunk.parents.forEach(function(id) {
 				normal(" {");
 				yellow(id);


### PR DESCRIPTION
  * abbreviate bytes with appropriate multiples

Before merging see https://github.com/webpack/webpack/issues/741#issuecomment-77099289. Thanks!

### Example output:

``` bash
Hash: cfa436b4ea300482822c
Version: webpack 1.7.1
Time: 5542ms
                                Asset     Size  Chunks             Chunk Names
 7ad17c6085dee9a33787bac28fb23d46.eot  20.3 kB          [emitted]
68ed1dac06bf0409c18ae7bc62889170.woff  23.3 kB          [emitted]
 e49d52e74b7689a0727def99da31f3eb.ttf  41.3 kB          [emitted]
 32941d6330044744c02493835b799e90.svg  62.9 kB          [emitted]
                            bundle.js  1.16 MB       0  [emitted]  main
 [206] ../webpack/buildin/amd-define.js 84 bytes {0} [built]
    + 219 hidden modules
```

Resolves #741