### PR TITLE
Better ES6 support

### DIFF
--- a/examples/harmony/README.md
+++ b/examples/harmony/README.md
@@ -1,0 +1,142 @@
+
+# example.js
+
+``` javascript
+import { increment as inc } from './increment';
+var a = 1;
+inc(a); // 2
+```
+
+# increment.js
+
+``` javascript
+import { add } from './math';
+export function increment(val) {
+    return add(val, 1);
+};
+```
+
+# js/output.js
+
+``` javascript
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+/******/
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "js/";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/*!********************!*\
+  !*** ./example.js ***!
+  \********************/
+/***/ function(module, exports, __webpack_require__) {
+
+	/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__increment__ = __webpack_require__(/*! ./increment */ 1);
+	var a = 1;
+	/* harmony import */ __WEBPACK_IMPORTED_MODULE_0__increment__["increment"](a); // 2
+
+/***/ },
+/* 1 */
+/*!**********************!*\
+  !*** ./increment.js ***!
+  \**********************/
+/***/ function(module, exports, __webpack_require__) {
+
+	/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__math__ = __webpack_require__(/*! ./math */ 2);
+	/* harmony export declaration */function increment(val) {
+	    return /* harmony import */ __WEBPACK_IMPORTED_MODULE_0__math__["add"](val, 1);
+	}/* harmony export */ Object.defineProperty(exports, "increment", {configurable: false, enumerable: true, get: function() { return increment; }});;
+
+
+/***/ },
+/* 2 */
+/*!*****************!*\
+  !*** ./math.js ***!
+  \*****************/
+/***/ function(module, exports, __webpack_require__) {
+
+	/* harmony export declaration */function add() {
+		var sum = 0, i = 0, args = arguments, l = args.length;
+		while (i < l) {
+			sum += args[i++];
+		}
+		return sum;
+	}/* harmony export */ Object.defineProperty(exports, "add", {configurable: false, enumerable: true, get: function() { return add; }});
+
+
+/***/ }
+/******/ ])
+```
+
+# Info
+
+## Uncompressed
+
+```
+Hash: 2cddb2c302ef93d23ea9
+Version: webpack 1.4.15
+Time: 47ms
+    Asset  Size  Chunks             Chunk Names
+output.js  2792       0  [emitted]  main
+chunk    {0} output.js (main) 309 [rendered]
+    > main [0] ./example.js 
+    [0] ./example.js 73 {0} [built]
+    [1] ./increment.js 94 {0} [built]
+        harmony import ./increment [0] ./example.js 1:0-47
+    [2] ./math.js 142 {0} [built]
+        harmony import ./math [1] ./increment.js 1:0-29
+```
+
+## Minimized (uglify-js, no zip)
+
+```
+Hash: 810b804d71afd4672772
+Version: webpack 1.4.15
+Time: 141ms
+    Asset  Size  Chunks             Chunk Names
+output.js   585       0  [emitted]  main
+chunk    {0} output.js (main) 309 [rendered]
+    > main [0] ./example.js 
+    [0] ./example.js 73 {0} [built]
+    [1] ./increment.js 94 {0} [built]
+        harmony import ./increment [0] ./example.js 1:0-47
+    [2] ./math.js 142 {0} [built]
+        harmony import ./math [1] ./increment.js 1:0-29
+```

--- a/examples/harmony/build.js
+++ b/examples/harmony/build.js
@@ -1,0 +1,1 @@
+require("../build-common");

--- a/examples/harmony/example.js
+++ b/examples/harmony/example.js
@@ -1,0 +1,3 @@
+import { increment as inc } from './increment';
+var a = 1;
+inc(a); // 2

--- a/examples/harmony/increment.js
+++ b/examples/harmony/increment.js
@@ -1,0 +1,4 @@
+import { add } from './math';
+export function increment(val) {
+    return add(val, 1);
+};

--- a/examples/harmony/math.js
+++ b/examples/harmony/math.js
@@ -1,0 +1,7 @@
+export function add() {
+	var sum = 0, i = 0, args = arguments, l = args.length;
+	while (i < l) {
+		sum += args[i++];
+	}
+	return sum;
+}

--- a/examples/harmony/template.md
+++ b/examples/harmony/template.md
@@ -1,0 +1,32 @@
+
+# example.js
+
+``` javascript
+{{example.js}}
+```
+
+# increment.js
+
+``` javascript
+{{increment.js}}
+```
+
+# js/output.js
+
+``` javascript
+{{js/output.js}}
+```
+
+# Info
+
+## Uncompressed
+
+```
+{{stdout}}
+```
+
+## Minimized (uglify-js, no zip)
+
+```
+{{min:stdout}}
+```

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -403,7 +403,8 @@ Parser.prototype.walkTryStatement = function walkTryStatement(statement) {
 		this.walkStatement(statement.block);
 		this.scope.inTry = false;
 	}
-	this.walkCatchClause(statement.handler);
+	if(statement.handler)
+		this.walkCatchClause(statement.handler);
 	if(statement.finalizer)
 		this.walkStatement(statement.finalizer);
 };

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -853,7 +853,7 @@ Parser.prototype.parseCalculatedString = function parseCalculatedString(expressi
 });
 
 Parser.prototype.parse = function parse(source, initialState) {
-	var ast = acorn.parse(source, {ranges: true, locations: true});
+	var ast = acorn.parse(source, {ranges: true, locations: true, ecmaVersion: 6});
 	if(!ast || typeof ast !== "object")
 		throw new Error("Source couldn't be parsed");
 	var oldScope = this.scope;
@@ -872,7 +872,7 @@ Parser.prototype.parse = function parse(source, initialState) {
 };
 
 Parser.prototype.evaluate = function evaluate(source) {
-	var ast = acorn.parse("("+source+")", {ranges: true, locations: true});
+	var ast = acorn.parse("("+source+")", {ranges: true, locations: true, ecmaVersion: 6});
 	if(!ast || typeof ast !== "object" || ast.type !== "Program")
 		throw new Error("evaluate: Source couldn't be parsed");
 	if(ast.body.length !== 1 || ast.body[0].type !== "ExpressionStatement")

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -2,7 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var esprima = require("esprima");
+var acorn = require("acorn");
 var Tapable = require("tapable");
 var BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
 
@@ -403,7 +403,7 @@ Parser.prototype.walkTryStatement = function walkTryStatement(statement) {
 		this.walkStatement(statement.block);
 		this.scope.inTry = false;
 	}
-	this.walkCatchClauses(statement.handlers);
+	this.walkCatchClause(statement.handler);
 	if(statement.finalizer)
 		this.walkStatement(statement.finalizer);
 };
@@ -462,14 +462,12 @@ Parser.prototype.walkSwitchCases = function walkSwitchCases(switchCases) {
 	}, this);
 };
 
-Parser.prototype.walkCatchClauses = function walkCatchClauses(catchClauses) {
-	catchClauses.forEach(function(catchClause) {
-		if(catchClause.guard)
-			this.walkExpression(catchClause.guard);
-		this.inScope([catchClause.param], function() {
-			this.walkStatement(catchClause.body);
-		}.bind(this));
-	}, this);
+Parser.prototype.walkCatchClause = function walkCatchClause(catchClause) {
+	if(catchClause.guard)
+		this.walkExpression(catchClause.guard);
+	this.inScope([catchClause.param], function() {
+		this.walkStatement(catchClause.body);
+	}.bind(this));
 };
 
 Parser.prototype.walkVariableDeclarators = function walkVariableDeclarators(declarators) {
@@ -777,7 +775,7 @@ Parser.prototype.parseCalculatedString = function parseCalculatedString(expressi
 });
 
 Parser.prototype.parse = function parse(source, initialState) {
-	var ast = esprima.parse(source, {range: true, loc: true, raw: true});
+	var ast = acorn.parse(source, {ranges: true, locations: true});
 	if(!ast || typeof ast !== "object")
 		throw new Error("Source couldn't be parsed");
 	var oldScope = this.scope;
@@ -796,7 +794,7 @@ Parser.prototype.parse = function parse(source, initialState) {
 };
 
 Parser.prototype.evaluate = function evaluate(source) {
-	var ast = esprima.parse("("+source+")", {range: true, loc: true, raw: true});
+	var ast = acorn.parse("("+source+")", {ranges: true, locations: true});
 	if(!ast || typeof ast !== "object" || ast.type !== "Program")
 		throw new Error("evaluate: Source couldn't be parsed");
 	if(ast.body.length !== 1 || ast.body[0].type !== "ExpressionStatement")

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -458,6 +458,75 @@ Parser.prototype.walkFunctionDeclaration = function walkFunctionDeclaration(stat
 	}.bind(this));
 };
 
+Parser.prototype.walkImportDeclaration = function walkImportDeclaration(statement) {
+	var source = statement.source.value;
+	this.applyPluginsBailResult("import", statement, source);
+	statement.specifiers.forEach(function(specifier) {
+		switch(specifier.type) {
+		case "ImportDefaultSpecifier":
+			var name = specifier.id.name;
+			this.scope.renames["$"+name] = undefined;
+			this.scope.definitions.push(name);
+			this.applyPluginsBailResult("import specifier", statement, source, "default", name);
+			break;
+		case "ImportSpecifier":
+			var name = (specifier.name || specifier.id).name;
+			this.scope.renames["$"+name] = undefined;
+			this.scope.definitions.push(name);
+			this.applyPluginsBailResult("import specifier", statement, source, specifier.id.name, name);
+			break;
+		case "ImportNamespaceSpecifier":
+			var name = specifier.id.name;
+			this.scope.renames["$"+name] = undefined;
+			this.scope.definitions.push(name);
+			this.applyPluginsBailResult("import specifier", statement, source, null, name);
+			break;
+		}
+	}, this);
+};
+
+Parser.prototype.walkExportDeclaration = function walkExportDeclaration(statement) {
+	if(statement.source) {
+		var source = statement.source.value;
+		this.applyPluginsBailResult("export import", statement, source);
+	} else {
+		this.applyPluginsBailResult("export", statement);
+	}
+	if(statement.declaration) {
+		if(/Expression$/.test(statement.declaration.type)) {
+			if(!this.applyPluginsBailResult("export expression", statement, statement.declaration)) {
+				this.walkExpression(statement.declaration);
+				this.applyPluginsBailResult("export specifier", statement, statement.declaration, "default");
+			}
+		} else {
+			if(!this.applyPluginsBailResult("export declaration", statement, statement.declaration)) {
+				var pos = this.scope.definitions.length;
+				this.walkStatement(statement.declaration);
+				var newDefs = this.scope.definitions.slice(pos);
+				newDefs.forEach(function(def) {
+					this.applyPluginsBailResult("export specifier", statement, def, statement["default"] ? "default" : def);
+				}, this);
+			}
+		}
+	}
+	if(statement.specifiers) {
+		statement.specifiers.forEach(function(specifier) {
+			switch(specifier.type) {
+			case "ExportSpecifier":
+				var name = (specifier.name || specifier.id).name;
+				if(source)
+					this.applyPluginsBailResult("export import specifier", statement, source, specifier.id.name, name);
+				else
+					this.applyPluginsBailResult("export specifier", statement, specifier.id.name, name);
+				break;
+			case "ExportBatchSpecifier":
+				this.applyPluginsBailResult("export import specifier", statement, source, null, null);
+				break;
+			}
+		}, this);
+	}
+};
+
 Parser.prototype.walkVariableDeclaration = function walkVariableDeclaration(statement) {
 	if(statement.declarations)
 		this.walkVariableDeclarators(statement.declarations);

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -437,6 +437,15 @@ Parser.prototype.walkForInStatement = function walkForInStatement(statement) {
 	this.walkStatement(statement.body);
 };
 
+Parser.prototype.walkForOfStatement = function walkForOfStatement(statement) {
+	if(statement.left.type === "VariableDeclaration")
+		this.walkStatement(statement.left);
+	else
+		this.walkExpression(statement.left);
+	this.walkExpression(statement.right);
+	this.walkStatement(statement.body);
+};
+
 // Declarations
 Parser.prototype.walkFunctionDeclaration = function walkFunctionDeclaration(statement) {
 	this.scope.renames["$"+statement.id.name] = undefined;

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -27,6 +27,7 @@ var WarnCaseSensitiveModulesPlugin = require("./WarnCaseSensitiveModulesPlugin")
 
 var LoaderPlugin = require("./dependencies/LoaderPlugin");
 var CommonJsPlugin = require("./dependencies/CommonJsPlugin");
+var HarmonyModulesPlugin = require("./dependencies/HarmonyModulesPlugin");
 var AMDPlugin = require("./dependencies/AMDPlugin");
 var LabeledModulesPlugin = require("./dependencies/LabeledModulesPlugin");
 var RequireContextPlugin = require("./dependencies/RequireContextPlugin");
@@ -250,7 +251,8 @@ WebpackOptionsApply.prototype.process = function(options, compiler) {
 		new RequireEnsurePlugin(),
 		new RequireContextPlugin(options.resolve.modulesDirectories, options.resolve.extensions),
 		new AMDPlugin(options.module, options.amd || {}),
-		new CommonJsPlugin(options.module)
+		new CommonJsPlugin(options.module),
+		new HarmonyModulesPlugin()
 	);
 
 	compiler.apply(

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -1,0 +1,45 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var AbstractPlugin = require("../AbstractPlugin");
+var HarmonyExportExpressionDependency = require("./HarmonyExportExpressionDependency");
+var HarmonyExportSpecifierDependency = require("./HarmonyExportSpecifierDependency");
+var HarmonyImportDependency = require("./HarmonyImportDependency");
+var HarmonyModulesHelpers = require("./HarmonyModulesHelpers");
+
+module.exports = AbstractPlugin.create({
+	"export": function(statement) {
+		var dep = new HarmonyExportExpressionDependency(null, statement.declaration && statement.declaration.range, statement.range);
+		dep.loc = statement.loc;
+		this.state.current.addDependency(dep);
+		return true;
+	},
+	"export import": function(statement, source) {
+		var dep = new HarmonyImportDependency(source, HarmonyModulesHelpers.getNewModuleVar(this.state, source), statement.range);
+		dep.loc = statement.loc;
+		this.state.current.addDependency(dep);
+		return true;
+	},
+	"export expression": function(statement, expr) {
+		var dep = new HarmonyExportExpressionDependency("default", expr.range, statement.range);
+		dep.loc = statement.loc;
+		this.state.current.addDependency(dep);
+		return true;
+	},
+	"export declaration": function(statement, name) {
+	},
+	"export specifier": function(statement, id, name) {
+		var dep = new HarmonyExportSpecifierDependency(null, id, name, statement.range[1] + 0.5);
+		dep.loc = statement.loc;
+		this.state.current.addDependency(dep);
+		return true;
+	},
+	"export import specifier": function(statement, source, id, name) {
+		var dep = new HarmonyExportSpecifierDependency(HarmonyModulesHelpers.getModuleVar(this.state, source), id, name, statement.range[1] + 0.5);
+		dep.loc = statement.loc;
+		this.state.current.addDependency(dep);
+		return true;
+	}
+});
+

--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -1,0 +1,28 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var NullDependency = require("./NullDependency");
+
+function HarmonyExportExpressionDependency(name, range, rangeStatement) {
+	NullDependency.call(this);
+	this.Class = HarmonyExportExpressionDependency;
+	this.name = name;
+	this.range = range;
+	this.rangeStatement = rangeStatement;
+}
+module.exports = HarmonyExportExpressionDependency;
+
+HarmonyExportExpressionDependency.prototype = Object.create(NullDependency.prototype);
+HarmonyExportExpressionDependency.prototype.type = "harmony export expression";
+
+HarmonyExportExpressionDependency.Template = function HarmonyExportDependencyTemplate() {};
+
+HarmonyExportExpressionDependency.Template.prototype.apply = function(dep, source) {
+	if(dep.name) {
+		var content = "exports[" + JSON.stringify(dep.name) + "] = ";
+	} else {
+		var content = "/* harmony export declaration */";
+	}
+	source.replace(dep.rangeStatement[0], dep.range ? dep.range[0]-1 : dep.rangeStatement[1]-1, content);
+}

--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -1,0 +1,31 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var NullDependency = require("./NullDependency");
+
+function HarmonyExportSpecifierDependency(request, id, name, position) {
+	NullDependency.call(this);
+	this.Class = HarmonyExportSpecifierDependency;
+	this.request = request;
+	this.id = id;
+	this.name = name;
+	this.position = position;
+}
+module.exports = HarmonyExportSpecifierDependency;
+
+HarmonyExportSpecifierDependency.prototype = Object.create(NullDependency.prototype);
+HarmonyExportSpecifierDependency.prototype.type = "harmony export specifier";
+
+HarmonyExportSpecifierDependency.Template = function HarmonyExportSpecifierDependencyTemplate() {};
+
+HarmonyExportSpecifierDependency.Template.prototype.apply = function(dep, source, outputOptions, requestShortener) {
+	var name = dep.request;
+	if(dep.name) {
+		var content = "/* harmony export */ Object.defineProperty(exports, " + JSON.stringify(dep.name) + ", {configurable: false, enumerable: true, get: function() { return " + (name ? name + "[" + JSON.stringify(dep.id) + "]" : dep.id) + "; }});"
+	} else {
+		var content = "/* harmony namespace export */ for(var __WEBPACK_IMPORT_KEY__ in " + name + ") (function(key) { Object.defineProperty(exports, key, {configurable: false, enumerable: true, get: function() { return " + name + "[key]; }}) }(__WEBPACK_IMPORT_KEY__));"
+	}
+	source.insert(dep.position, content);
+
+};

--- a/lib/dependencies/HarmonyImportDependency.js
+++ b/lib/dependencies/HarmonyImportDependency.js
@@ -1,0 +1,31 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var ModuleDependency = require("./ModuleDependency");
+
+function HarmonyImportDependency(request, importedVar, range) {
+	ModuleDependency.call(this, request);
+	this.Class = HarmonyImportDependency;
+	this.range = range;
+	this.importedVar = importedVar;
+}
+module.exports = HarmonyImportDependency;
+
+HarmonyImportDependency.prototype = Object.create(ModuleDependency.prototype);
+HarmonyImportDependency.prototype.type = "harmony import";
+
+HarmonyImportDependency.Template = function HarmonyImportDependencyTemplate() {};
+
+HarmonyImportDependency.Template.prototype.apply = function(dep, source, outputOptions, requestShortener) {
+	var comment = "";
+	if(outputOptions.pathinfo) comment = "/*! " + requestShortener.shorten(dep.request) + " */ ";
+	if(!dep.module) {
+		var content = "!(function webpackMissingModule() { throw new Error(" + JSON.stringify("Cannot find module \"" + dep.request + "\"") + "); }())";
+	} else if(dep.importedVar) {
+		var content = "/* harmony import */ var " + dep.importedVar + " = __webpack_require__(" + comment + dep.module.id + ");";
+	} else {
+		var content = "";
+	}
+	source.replace(dep.range[0], dep.range[1]-1, content);
+};

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -1,0 +1,33 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var AbstractPlugin = require("../AbstractPlugin");
+var HarmonyImportDependency = require("./HarmonyImportDependency");
+var HarmonyImportSpecifierDependency = require("./HarmonyImportSpecifierDependency");
+var HarmonyModulesHelpers = require("./HarmonyModulesHelpers");
+
+module.exports = AbstractPlugin.create({
+	"import": function(statement, source) {
+		var dep = new HarmonyImportDependency(source, HarmonyModulesHelpers.getNewModuleVar(this.state, source), statement.range);
+		dep.loc = statement.loc;
+		this.state.current.addDependency(dep);
+		return true;
+	},
+	"import specifier": function(statement, source, id, name) {
+		this.scope.definitions.length--;
+		this.scope.renames["$"+name] = "imported var";
+		if(!this.state.harmonySpecifier) this.state.harmonySpecifier = {};
+		this.state.harmonySpecifier["$"+name] = [HarmonyModulesHelpers.getModuleVar(this.state, source), id];
+		return true;
+	},
+	"expression imported var": function(expr) {
+		var name = expr.name;
+		var settings = this.state.harmonySpecifier["$"+name];
+		var dep = new HarmonyImportSpecifierDependency(settings[0], settings[1], name, expr.range);
+		dep.loc = expr.loc;
+		this.state.current.addDependency(dep);
+		return true;
+	}
+});
+

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -1,0 +1,29 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var NullDependency = require("./NullDependency");
+
+function HarmonyImportSpecifierDependency(importedVar, id, name, range) {
+	NullDependency.call(this);
+	this.Class = HarmonyImportSpecifierDependency;
+	this.importedVar = importedVar;
+	this.id = id;
+	this.name = name;
+	this.range = range;
+}
+module.exports = HarmonyImportSpecifierDependency;
+
+HarmonyImportSpecifierDependency.prototype = Object.create(NullDependency.prototype);
+HarmonyImportSpecifierDependency.prototype.type = "harmony import specifier";
+
+HarmonyImportSpecifierDependency.Template = function HarmonyImportSpecifierDependencyTemplate() {};
+
+HarmonyImportSpecifierDependency.Template.prototype.apply = function(dep, source, outputOptions, requestShortener) {
+	if(dep.id) {
+		var content = "/* harmony import */ " + dep.importedVar + "[" + JSON.stringify(dep.id) + "]";
+	} else {
+		var content = "/* harmony namespace import */ " + dep.importedVar;
+	}
+	source.replace(dep.range[0], dep.range[1]-1, content);
+};

--- a/lib/dependencies/HarmonyModulesHelpers.js
+++ b/lib/dependencies/HarmonyModulesHelpers.js
@@ -1,0 +1,21 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var HarmonyModulesHelpers = exports;
+
+HarmonyModulesHelpers.getModuleVar = function(state, request) {
+	if(!state.harmonyModules) state.harmonyModules = [];
+	var idx = state.harmonyModules.indexOf(request);
+	if(idx < 0) {
+		idx = state.harmonyModules.length;
+		state.harmonyModules.push(request);
+	}
+	return "__WEBPACK_IMPORTED_MODULE_" + idx + "_" + request.replace(/[^A-Za-z0-9_]/g, "_").replace(/__+/g, "_") + "__";
+};
+
+HarmonyModulesHelpers.getNewModuleVar = function(state, request) {
+	if(state.harmonyModules && state.harmonyModules.indexOf(request) >= 0)
+		return null;
+	return HarmonyModulesHelpers.getModuleVar(state, request);
+};

--- a/lib/dependencies/HarmonyModulesPlugin.js
+++ b/lib/dependencies/HarmonyModulesPlugin.js
@@ -1,0 +1,41 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var HarmonyImportDependency = require("./HarmonyImportDependency");
+var HarmonyImportSpecifierDependency = require("./HarmonyImportSpecifierDependency");
+var HarmonyExportExpressionDependency = require("./HarmonyExportExpressionDependency");
+var HarmonyExportSpecifierDependency = require("./HarmonyExportSpecifierDependency");
+
+var NullFactory = require("../NullFactory");
+
+var HarmonyImportDependencyParserPlugin = require("./HarmonyImportDependencyParserPlugin");
+var HarmonyExportDependencyParserPlugin = require("./HarmonyExportDependencyParserPlugin");
+
+var BasicEvaluatedExpression = require("../BasicEvaluatedExpression");
+
+function HarmonyModulesPlugin() {
+}
+module.exports = HarmonyModulesPlugin;
+
+HarmonyModulesPlugin.prototype.apply = function(compiler) {
+	compiler.plugin("compilation", function(compilation, params) {
+		var normalModuleFactory = params.normalModuleFactory;
+
+		compilation.dependencyFactories.set(HarmonyImportDependency, normalModuleFactory);
+		compilation.dependencyTemplates.set(HarmonyImportDependency, new HarmonyImportDependency.Template());
+
+		compilation.dependencyFactories.set(HarmonyImportSpecifierDependency, new NullFactory());
+		compilation.dependencyTemplates.set(HarmonyImportSpecifierDependency, new HarmonyImportSpecifierDependency.Template());
+
+		compilation.dependencyFactories.set(HarmonyExportExpressionDependency, new NullFactory());
+		compilation.dependencyTemplates.set(HarmonyExportExpressionDependency, new HarmonyExportExpressionDependency.Template());
+
+		compilation.dependencyFactories.set(HarmonyExportSpecifierDependency, new NullFactory());
+		compilation.dependencyTemplates.set(HarmonyExportSpecifierDependency, new HarmonyExportSpecifierDependency.Template());
+	});
+	compiler.parser.apply(
+		new HarmonyImportDependencyParserPlugin(),
+		new HarmonyExportDependencyParserPlugin()
+	);
+};

--- a/package.json
+++ b/package.json
@@ -4,19 +4,19 @@
 	"author": "Tobias Koppers @sokra",
 	"description": "Packs CommonJs/AMD modules for the browser. Allows to split your codebase into multiple bundles, which can be loaded on demand. Support loaders to preprocess files, i.e. json, jade, coffee, css, less, ... and your custom stuff.",
 	"dependencies": {
-		"esprima": "~1.2.0",
-		"mkdirp": "~0.5.0",
-		"optimist": "~0.6.0",
-		"uglify-js": "~2.4.13",
+		"acorn": "^0.12.0",
 		"async": "~0.9.0",
+		"clone": "~0.1.15",
 		"enhanced-resolve": "~0.8.2",
 		"memory-fs": "~0.2.0",
-		"clone": "~0.1.15",
-		"webpack-core": "~0.5.0",
+		"mkdirp": "~0.5.0",
 		"node-libs-browser": "~0.4.0",
-		"watchpack": "^0.2.1",
+		"optimist": "~0.6.0",
+		"supports-color": "^1.2.0",
 		"tapable": "~0.1.8",
-		"supports-color": "^1.2.0"
+		"uglify-js": "~2.4.13",
+		"watchpack": "^0.2.1",
+		"webpack-core": "~0.5.0"
 	},
 	"licenses": [
 		{
@@ -48,7 +48,7 @@
 		"component-webpack-plugin": "~0.2.0"
 	},
 	"engines": {
-		"node":  ">=0.6"
+		"node": ">=0.6"
 	},
 	"repository": {
 		"type": "git",

--- a/test/Examples.test.js
+++ b/test/Examples.test.js
@@ -36,9 +36,10 @@ describe("Examples", function() {
 			}
 			webpack(options, function(err, stats) {
 				if(err) return done(err);
-				stats = stats.toJson();
-				if(stats.errors.length > 0)
-					return done(stats.errors[0]);
+				stats = stats.toJson({ errorDetails: true });
+				if(stats.errors.length > 0) {
+					return done(new Error(stats.errors[0]));
+				}
 				done();
 			});
 		});

--- a/test/cases/parsing/harmony/index.js
+++ b/test/cases/parsing/harmony/index.js
@@ -1,0 +1,39 @@
+import {a, b as B} from "abc";
+
+import * as abc from "abc";
+
+import { fn } from "exportKinds";
+
+import { one, two } from "exportKinds";
+
+import { test1, test2 } from "exportKinds";
+
+import { a as rea, b as reb, c as rec, o as reo, two as retwo } from "reexport";
+
+it("should import an identifier from a module", function() {
+	a.should.be.eql("a");
+	B.should.be.eql("b");
+});
+
+it("should export functions", function() {
+	fn.should.have.type("function");
+	fn().should.be.eql("fn");
+});
+
+it("should multiple variables with one statement", function() {
+	one.should.be.eql("one");
+	two.should.be.eql("two");
+});
+
+it("should still be able to use exported stuff", function() {
+	test1.should.be.eql("fn");
+	test2.should.be.eql("two");
+});
+
+it("should reexport a module", function() {
+	rea.should.be.eql("a");
+	reb.should.be.eql("b");
+	rec.should.be.eql("c");
+	reo.should.be.eql("one");
+	retwo.should.be.eql("two");
+});

--- a/test/cases/parsing/harmony/node_modules/abc.js
+++ b/test/cases/parsing/harmony/node_modules/abc.js
@@ -1,0 +1,3 @@
+export var a = "a";
+export var b = "b";
+export var c = "c";

--- a/test/cases/parsing/harmony/node_modules/def.js
+++ b/test/cases/parsing/harmony/node_modules/def.js
@@ -1,0 +1,1 @@
+export default "def";

--- a/test/cases/parsing/harmony/node_modules/exportKinds.js
+++ b/test/cases/parsing/harmony/node_modules/exportKinds.js
@@ -1,0 +1,7 @@
+export function fn() {
+	return "fn";
+}
+export var one = "one", two = "two";
+
+export var test1 = fn();
+export var test2 = two;

--- a/test/cases/parsing/harmony/node_modules/reexport.js
+++ b/test/cases/parsing/harmony/node_modules/reexport.js
@@ -1,0 +1,2 @@
+export * from "abc";
+export { one as o, two } from "exportKinds";


### PR DESCRIPTION
I've switched to acorn, since it's more stable than esprima with regards to es6 support. The changes are tiny since both support the same interface. The only one is that acorn uses `.handler` in try-catch instead of `.handlers` (I think the latter is a mozilla extension?).

I've also added for-of loop parsing and merged in the harmony branch.

I'd love to base this on master, but if that isn't to your taste, I'll switch the branch to harmony, but I think that es6 support, even if only partial support is available, will be a great benefit to the community. This is what esprima is doing with it's 2.0.0 release as well.