### PR TITLE
Add and expose WatchIgnorePlugin

### DIFF
--- a/lib/WatchIgnorePlugin.js
+++ b/lib/WatchIgnorePlugin.js
@@ -1,0 +1,42 @@
+function WatchIgnorePlugin(paths) {
+	this.paths = paths;
+}
+
+module.exports = WatchIgnorePlugin;
+
+WatchIgnorePlugin.prototype.apply = function (compiler) {
+	compiler.plugin("after-environment", function () {
+		compiler.watchFileSystem = new IgnoringWatchFileSystem(compiler.watchFileSystem, this.paths);
+	}.bind(this));
+};
+
+function IgnoringWatchFileSystem(wfs, paths) {
+	this.wfs = wfs;
+	this.paths = paths;
+}
+
+IgnoringWatchFileSystem.prototype.watch = function (files, dirs, missing, startTime, delay, callback, callbackUndelayed) {
+	var ignored = function (path) {
+		return this.paths.some(function (p) {
+			return ((p instanceof RegExp) ? p.test(path) : path.indexOf(p) === 0);
+		});
+	}.bind(this);
+
+	var notIgnored = function (path) { return !ignored(path); };
+	var ignoredFiles = files.filter(ignored);
+	var ignoredDirs = dirs.filter(ignored);
+
+	this.wfs.watch(files.filter(notIgnored), dirs.filter(notIgnored), missing, startTime, delay, function (err, filesModified, dirsModified, fileTimestamps, dirTimestamps) {
+		if(err) return callback(err);
+
+		ignoredFiles.forEach(function (path) {
+			fileTimestamps[path] = 1;
+		});
+
+		ignoredDirs.forEach(function (path) {
+			dirTimestamps[path] = 1;
+		});
+
+		callback(err, filesModified, dirsModified, fileTimestamps, dirTimestamps);
+	}, callbackUndelayed);
+};

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -62,6 +62,7 @@ exportPlugins(exports, ".", [
 	"NormalModuleReplacementPlugin",
 	"ContextReplacementPlugin",
 	"IgnorePlugin",
+	"WatchIgnorePlugin",
 	"BannerPlugin",
 	"PrefetchPlugin",
 	"AutomaticPrefetchPlugin",

--- a/test/configCases/plugins/watch-ignore-plugin/index.js
+++ b/test/configCases/plugins/watch-ignore-plugin/index.js
@@ -1,0 +1,1 @@
+it("should run", function() {});

--- a/test/configCases/plugins/watch-ignore-plugin/webpack.config.js
+++ b/test/configCases/plugins/watch-ignore-plugin/webpack.config.js
@@ -1,0 +1,7 @@
+var webpack = require("../../../../");
+
+module.exports = {
+	plugins: [
+		new webpack.WatchIgnorePlugin()
+	]
+};


### PR DESCRIPTION
See https://github.com/webpack/webpack-dev-server/issues/112. @sokra already wrote a plugin for this, but it was never added to the repository.

Usage like:

``` js
var path = require("path");
var WatchIgnorePlugin = require("webpack").WatchIgnorePlugin;

{
    plugins: [
        new WatchIgnorePlugin([
            path.resolve(__dirname, './ignore-more/'),
        ]),
    ],
}
```

If this is good to merge, I'll update the documentation after it's in master.