### PR TITLE
Support CoffeeScript configuration files

### DIFF
--- a/bin/config-optimist.js
+++ b/bin/config-optimist.js
@@ -3,7 +3,13 @@ module.exports = function(optimist) {
 
 	.boolean("help").alias("help", "h").alias("help", "?").describe("help")
 
-	.string("config").describe("config")
+	.string("config")
+	.describe("config", "Read configuration from this module")
+	.default("config", "webpack.config")
+
+	.boolean("coffee")
+	.describe("coffee", "support CoffeeScript configuration files")
+	.default("coffee", false)
 
 	.string("context").describe("context")
 

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -26,13 +26,15 @@ module.exports = function(optimist, argv, convertOptions) {
 		argv["optimize-occurence-order"] = true;
 	}
 
-	if(argv.config) {
+	if(argv.coffee || (argv.config && /\.coffee$/.test(argv.config))) {
+		require('coffee-script/register');
+	}
+
+	try {
 		options = require(path.resolve(argv.config));
-	} else {
-		var configPath = path.resolve("webpack.config.js");
-		if(fs.existsSync(configPath)) {
-			options = require(configPath);
-		}
+	} catch (e) {
+		console.log("Could not load configuration:\n", e);
+		process.exit(-1);
 	}
 	if(typeof options !== "object" || options === null) {
 		console.log("Config did not export a object.");


### PR DESCRIPTION
Simply add --coffee to the webpack invocation and it will read coffeescript configuration files if available or when specified.

Doesn't add `coffee-script` dependency to webpack install, that's up to the user.

Fixes #475