### PR TITLE
First stab at SourceMapDevToolPlugin exclude option

### DIFF
--- a/lib/ModuleFilenameHelpers.js
+++ b/lib/ModuleFilenameHelpers.js
@@ -41,6 +41,11 @@ function getHash(str) {
 	return hash.digest("hex").substr(0, 4);
 }
 
+function asRegExp(test) {
+	if(typeof test == "string") test = new RegExp("^"+test.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"));
+	return test;
+}
+
 ModuleFilenameHelpers.createFilename = function createFilename(module, moduleFilenameTemplate, requestShortener) {
 	if(typeof module === "string") {
 		var shortIdentifier = requestShortener.shorten(module);
@@ -113,4 +118,27 @@ ModuleFilenameHelpers.replaceDuplicates = function replaceDuplicates(array, fn, 
 			return fn(item, i, posMap[item]++);
 		} else return item;
 	});
+};
+
+
+ModuleFilenameHelpers.matchPart = function matchPart(str, test) {
+	if(!test) return true;
+	test = asRegExp(test);
+	if(Array.isArray(test)) {
+		return test.map(asRegExp).filter(function(regExp) {
+			return regExp.test(str);
+		}).length > 0;
+	} else {
+		return test.test(str);
+	}
+};
+
+ModuleFilenameHelpers.matchObject = function matchObject(obj, str) {
+	if(obj.test)
+		if(!ModuleFilenameHelpers.matchPart(str, obj.test)) return false;
+	if(obj.include)
+		if(!ModuleFilenameHelpers.matchPart(str, obj.include)) return false;
+	if(obj.exclude)
+		if(ModuleFilenameHelpers.matchPart(str, obj.exclude)) return false;
+	return true;
 };

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -34,8 +34,8 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 	var fallbackModuleFilenameTemplate = this.fallbackModuleFilenameTemplate;
 	var requestShortener = new RequestShortener(compiler.context);
 	var cheapMode = this.cheapMode;
-	var that = this;
 	var options = this.options;
+	options.test = options.test || /\.js($|\?)/i;
 	compiler.plugin("compilation", function(compilation) {
 		if(cheapMode) {
 			compilation.moduleTemplate.plugin("module", function(source, module) {
@@ -52,7 +52,7 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 			var allModuleFilenames = [];
 			var tasks = [];
 			chunks.forEach(function(chunk) {
-				chunk.files.filter(that.matchObject.bind(that, options)).map(function(file) {
+				chunk.files.filter(ModuleFilenameHelpers.matchObject.bind(undefined, options)).map(function(file) {
 					var asset = this.assets[file];
 					if(asset.__SourceMapDevTool_Data) {
 						var data = asset.__SourceMapDevTool_Data;
@@ -162,28 +162,6 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 			}, this);
 		});
 	});
-};
-
-function asRegExp(test) {
-	if(typeof test == "string") test = new RegExp("^"+test.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"));
-	return test;
-}
-SourceMapDevToolPlugin.prototype.matchPart = function matchPart(str, test) {
-	if(!test) return true;
-	test = asRegExp(test);
-	if(Array.isArray(test)) {
-		return test.map(asRegExp).filter(function(regExp) {
-			return regExp.test(str);
-		}).length > 0;
-	} else {
-		return test.test(str);
-	}
-};
-
-SourceMapDevToolPlugin.prototype.matchObject = function matchObject(obj, str) {
-	if(obj.exclude)
-		if(this.matchPart(str, obj.exclude)) return false;
-	return true;
 };
 
 function basename(name) {

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -22,6 +22,7 @@ function SourceMapDevToolPlugin(options, sourceMappingURLComment, moduleFilename
 		this.moduleFilenameTemplate = options.moduleFilenameTemplate || "webpack:///[resourcePath]";
 		this.fallbackModuleFilenameTemplate = options.fallbackModuleFilenameTemplate || "webpack:///[resourcePath]?[hash]";
 		this.cheapMode = options.cheapMode;
+		this.excludeChunks = options.excludeChunks;
 	}
 }
 module.exports = SourceMapDevToolPlugin;
@@ -32,6 +33,7 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 	var fallbackModuleFilenameTemplate = this.fallbackModuleFilenameTemplate;
 	var requestShortener = new RequestShortener(compiler.context);
 	var cheapMode = this.cheapMode;
+	var excludeChunks = this.excludeChunks;
 	compiler.plugin("compilation", function(compilation) {
 		if(cheapMode) {
 			compilation.moduleTemplate.plugin("module", function(source, module) {
@@ -48,6 +50,9 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 			var allModuleFilenames = [];
 			var tasks = [];
 			chunks.forEach(function(chunk) {
+				if (excludeChunks && excludeChunks.indexOf(chunk.name) !== -1) {
+					return;
+				}
 				chunk.files.slice().map(function(file) {
 					var asset = this.assets[file];
 					if(asset.__SourceMapDevTool_Data) {

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -16,13 +16,14 @@ function SourceMapDevToolPlugin(options, sourceMappingURLComment, moduleFilename
 		this.sourceMappingURLComment = sourceMappingURLComment === false ? false : sourceMappingURLComment || "\n//# sourceMappingURL=[url]";
 		this.moduleFilenameTemplate = moduleFilenameTemplate || "webpack:///[resourcePath]";
 		this.fallbackModuleFilenameTemplate = fallbackModuleFilenameTemplate || "webpack:///[resourcePath]?[hash]";
+		this.options = {};
 	} else {
 		this.sourceMapFilename = options.filename;
 		this.sourceMappingURLComment = options.append === false ? false : options.append || "\n//# sourceMappingURL=[url]";
 		this.moduleFilenameTemplate = options.moduleFilenameTemplate || "webpack:///[resourcePath]";
 		this.fallbackModuleFilenameTemplate = options.fallbackModuleFilenameTemplate || "webpack:///[resourcePath]?[hash]";
 		this.cheapMode = options.cheapMode;
-		this.excludeChunks = options.excludeChunks;
+		this.options = options;
 	}
 }
 module.exports = SourceMapDevToolPlugin;
@@ -33,7 +34,8 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 	var fallbackModuleFilenameTemplate = this.fallbackModuleFilenameTemplate;
 	var requestShortener = new RequestShortener(compiler.context);
 	var cheapMode = this.cheapMode;
-	var excludeChunks = this.excludeChunks;
+	var that = this;
+	var options = this.options;
 	compiler.plugin("compilation", function(compilation) {
 		if(cheapMode) {
 			compilation.moduleTemplate.plugin("module", function(source, module) {
@@ -50,10 +52,7 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 			var allModuleFilenames = [];
 			var tasks = [];
 			chunks.forEach(function(chunk) {
-				if (excludeChunks && excludeChunks.indexOf(chunk.name) !== -1) {
-					return;
-				}
-				chunk.files.slice().map(function(file) {
+				chunk.files.filter(that.matchObject.bind(that, options)).map(function(file) {
 					var asset = this.assets[file];
 					if(asset.__SourceMapDevTool_Data) {
 						var data = asset.__SourceMapDevTool_Data;
@@ -163,6 +162,28 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 			}, this);
 		});
 	});
+};
+
+function asRegExp(test) {
+	if(typeof test == "string") test = new RegExp("^"+test.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"));
+	return test;
+}
+SourceMapDevToolPlugin.prototype.matchPart = function matchPart(str, test) {
+	if(!test) return true;
+	test = asRegExp(test);
+	if(Array.isArray(test)) {
+		return test.map(asRegExp).filter(function(regExp) {
+			return regExp.test(str);
+		}).length > 0;
+	} else {
+		return test.test(str);
+	}
+};
+
+SourceMapDevToolPlugin.prototype.matchObject = function matchObject(obj, str) {
+	if(obj.exclude)
+		if(this.matchPart(str, obj.exclude)) return false;
+	return true;
 };
 
 function basename(name) {

--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -6,6 +6,7 @@ var SourceMapConsumer = require("webpack-core/lib/source-map").SourceMapConsumer
 var SourceMapSource = require("webpack-core/lib/SourceMapSource");
 var RawSource = require("webpack-core/lib/RawSource");
 var RequestShortener = require("../RequestShortener");
+var ModuleFilenameHelpers = require("../ModuleFilenameHelpers");
 var uglify = require("uglify-js");
 
 function UglifyJsPlugin(options) {
@@ -19,7 +20,6 @@ module.exports = UglifyJsPlugin;
 
 UglifyJsPlugin.prototype.apply = function(compiler) {
 	var options = this.options;
-	var that = this;
 	options.test = options.test || /\.js($|\?)/i;
 
 	var requestShortener = new RequestShortener(compiler.context);
@@ -40,7 +40,7 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 			compilation.additionalChunkAssets.forEach(function(file) {
 				files.push(file);
 			});
-			files = files.filter(that.matchObject.bind(that, options));
+			files = files.filter(ModuleFilenameHelpers.matchObject.bind(undefined, options));
 			files.forEach(function(file) {
 				var oldWarnFunction = uglify.AST_Node.warn_function;
 				var warnings = [];
@@ -132,31 +132,4 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 			context.minimize = true;
 		});
 	});
-};
-
-function asRegExp(test) {
-	if(typeof test == "string") test = new RegExp("^"+test.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"));
-	return test;
-}
-
-UglifyJsPlugin.prototype.matchPart = function matchPart(str, test) {
-	if(!test) return true;
-	test = asRegExp(test);
-	if(Array.isArray(test)) {
-		return test.map(asRegExp).filter(function(regExp) {
-			return regExp.test(str);
-		}).length > 0;
-	} else {
-		return test.test(str);
-	}
-};
-
-UglifyJsPlugin.prototype.matchObject = function matchObject(obj, str) {
-	if(obj.test)
-		if(!this.matchPart(str, obj.test)) return false;
-	if(obj.include)
-		if(!this.matchPart(str, obj.include)) return false;
-	if(obj.exclude)
-		if(this.matchPart(str, obj.exclude)) return false;
-	return true;
 };

--- a/test/configCases/source-map/exclude-chunks-source-map/index.js
+++ b/test/configCases/source-map/exclude-chunks-source-map/index.js
@@ -1,0 +1,15 @@
+it("should include test.js in SourceMap for bundle0 chunk", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename + ".map", "utf-8");
+	var map = JSON.parse(source);
+	map.sources.should.containEql("webpack:///./test.js");
+});
+
+it("should not produce a SourceMap for vendors chunk", function() {
+	var fs = require("fs"),
+			path = require("path"),
+			assert = require("assert");
+	fs.existsSync(path.join(__dirname, "vendors.js.map")).should.be.false;
+});
+
+require.include("./test.js");

--- a/test/configCases/source-map/exclude-chunks-source-map/test.js
+++ b/test/configCases/source-map/exclude-chunks-source-map/test.js
@@ -1,0 +1,3 @@
+var foo = {};
+
+module.exports = foo;

--- a/test/configCases/source-map/exclude-chunks-source-map/vendors.js
+++ b/test/configCases/source-map/exclude-chunks-source-map/vendors.js
@@ -1,0 +1,3 @@
+var bar = {};
+
+module.exports = bar;

--- a/test/configCases/source-map/exclude-chunks-source-map/webpack.config.js
+++ b/test/configCases/source-map/exclude-chunks-source-map/webpack.config.js
@@ -1,0 +1,20 @@
+var webpack = require("../../../../");
+module.exports = {
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	entry: {
+		bundle0: ["./index.js"],
+		vendors: ["./vendors.js"]
+	},
+	output: {
+		filename: "[name].js"
+	},
+	plugins: [
+		new webpack.SourceMapDevToolPlugin({
+			filename: "[file].map",
+			excludeChunks: ["vendors"]
+		})
+	]
+};

--- a/test/configCases/source-map/exclude-chunks-source-map/webpack.config.js
+++ b/test/configCases/source-map/exclude-chunks-source-map/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
 	plugins: [
 		new webpack.SourceMapDevToolPlugin({
 			filename: "[file].map",
-			excludeChunks: ["vendors"]
+			exclude: ["vendors.js"]
 		})
 	]
 };


### PR DESCRIPTION
per @gaearon suggestion, see issue #650 raised by @davidtheclark: "The problem with this is that the vendor file can get pretty big, and its gigantic sourcemap then severely slows down dev tool initialization on page reload. I would much prefer to only have a sourcemap for my app chunk (and not to have a sourcemap for my vendor chunk)."

This is a first stab at the corresponding ```exclude``` options.
Note that it might get tedious to have to explicitly instantiate ```SourceMapDevToolPlugin```, maybe a more global option such ```as output.sourceMapExcludeChunks``` could be introduced as well.
```
	plugins: [
		new webpack.SourceMapDevToolPlugin({
			filename: "[file].map",
			excludeChunks: ["vendors"]
		})
```