### PR TITLE
check hasOwnProperty when looping over modules

### DIFF
--- a/lib/optimize/DedupePlugin.js
+++ b/lib/optimize/DedupePlugin.js
@@ -185,26 +185,30 @@ DedupePlugin.prototype.apply = function(compiler) {
 				"// Check all modules for deduplicated modules",
 				"for(var i in modules) {",
 				this.indent([
-					"switch(typeof modules[i]) {",
-					"case \"number\":",
+					"if(Object.prototype.hasOwnProperty.call(modules, i)) {",
 					this.indent([
-						"// Module is a copy of another module",
-						"modules[i] = modules[modules[i]];",
-						"break;"
-					]),
-					"case \"object\":",
-					this.indent([
-						"// Module can be created from a template",
-						"modules[i] = (function(_m) {",
+						"switch(typeof modules[i]) {",
+						"case \"number\":",
 						this.indent([
-							"var args = _m.slice(1), fn = modules[_m[0]];",
-							"return function (a,b,c) {",
-							this.indent([
-								"fn.apply(null, [a,b,c].concat(args));"
-							]),
-							"};"
+							"// Module is a copy of another module",
+							"modules[i] = modules[modules[i]];",
+							"break;"
 						]),
-						"}(modules[i]));"
+						"case \"object\":",
+						this.indent([
+							"// Module can be created from a template",
+							"modules[i] = (function(_m) {",
+							this.indent([
+								"var args = _m.slice(1), fn = modules[_m[0]];",
+								"return function (a,b,c) {",
+								this.indent([
+									"fn.apply(null, [a,b,c].concat(args));"
+								]),
+								"};"
+							]),
+							"}(modules[i]));"
+						]),
+						"}"
 					]),
 					"}"
 				]),


### PR DESCRIPTION
Using the DedupePlugin together with the core-js polyfill caused IE8 to fail with the message "Object doesn't support this property or method", because the `for...in` includes properties from the prototype chain of the polyfilled Array object. Using a regular `for` loop fixes this.