### PR TITLE
Use node-interpret to import configuration in various formats.

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -2,6 +2,7 @@ var path = require("path");
 var fs = require("fs");
 fs.existsSync = fs.existsSync || path.existsSync;
 var resolve = require("enhanced-resolve");
+var interpret = require('interpret');
 
 module.exports = function(optimist, argv, convertOptions) {
 
@@ -27,6 +28,16 @@ module.exports = function(optimist, argv, convertOptions) {
 	}
 
 	if(argv.config) {
+		var ext = path.extname(argv.config);
+		if (Object.keys(require.extensions).indexOf(ext) === -1) {
+			var moduleName = interpret.extensions[ext];
+			var compiler = require(moduleName);
+			var register = interpret.register[moduleName];
+			var config = interpret.configurations[moduleName];
+			if (register) {
+				register(compiler, config);
+			}
+		}
 		options = require(path.resolve(argv.config));
 	} else {
 		var configPath = path.resolve("webpack.config.js");

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"description": "Packs CommonJs/AMD modules for the browser. Allows to split your codebase into multiple bundles, which can be loaded on demand. Support loaders to preprocess files, i.e. json, jade, coffee, css, less, ... and your custom stuff.",
 	"dependencies": {
 		"esprima": "~1.2.0",
+		"interpret": "^0.5.2",
 		"mkdirp": "~0.5.0",
 		"optimist": "~0.6.0",
 		"uglify-js": "~2.4.13",


### PR DESCRIPTION
This is a possible solution for #475.
Support for `*.coffee` configuration files is implemented using [node-interpret](https://github.com/tkellen/node-interpret).
Other formats work as well:
```
webpack --config webpack.config.coffee
webpack --config webpack.config.json
```

P.S. Are there any tests to cover CLI?