### PR TITLE
Automatically pull in webpack.config files written in compile-to-js langs

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -27,24 +27,29 @@ module.exports = function(optimist, argv, convertOptions) {
 		argv["optimize-occurence-order"] = true;
 	}
 
-	if(argv.config) {
-		var ext = path.extname(argv.config);
-		if (Object.keys(require.extensions).indexOf(ext) === -1) {
-			var moduleName = interpret.extensions[ext];
-			var compiler = require(moduleName);
-			var register = interpret.register[moduleName];
-			var config = interpret.configurations[moduleName];
-			if (register) {
-				register(compiler, config);
-			}
-		}
-		options = require(path.resolve(argv.config));
+	var configPath, extname;
+	if (argv.config) {
+		configPath = argv.config;
+		extname = path.extname(configPath);
 	} else {
-		var configPath = path.resolve("webpack.config.js");
-		if(fs.existsSync(configPath)) {
-			options = require(configPath);
+		Object.keys(interpret.extensions).some(function(ext) {
+			extname = ext;
+			configPath = path.resolve('webpack.config' + ext);
+			return fs.existsSync(configPath);
+		});
+	}
+
+	var moduleName = interpret.extensions[extname];
+	if (moduleName) {
+		var compiler = require(moduleName);
+		var register = interpret.register[moduleName];
+		var config = interpret.configurations[moduleName];
+		if (register) {
+			register(compiler, config);
 		}
 	}
+	options = require(configPath);
+
 	if(typeof options !== "object" || options === null) {
 		console.log("Config did not export a object.");
 		process.exit(-1);

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -27,19 +27,24 @@ module.exports = function(optimist, argv, convertOptions) {
 		argv["optimize-occurence-order"] = true;
 	}
 
-	var configPath, extname;
+	var configPath, ext;
 	if (argv.config) {
 		configPath = argv.config;
-		extname = path.extname(configPath);
+		ext = path.extname(configPath);
 	} else {
-		Object.keys(interpret.extensions).some(function(ext) {
-			extname = ext;
+		var found = Object.keys(interpret.extensions).some(function(extname) {
+			ext = extname;
 			configPath = path.resolve('webpack.config' + ext);
 			return fs.existsSync(configPath);
 		});
+
+		if (!found) {
+			configPath = 'webpack.config.js';
+			ext = '.js';
+		}
 	}
 
-	var moduleName = interpret.extensions[extname];
+	var moduleName = interpret.extensions[ext];
 	if (moduleName) {
 		var compiler = require(moduleName);
 		var register = interpret.register[moduleName];


### PR DESCRIPTION
Finally decided to bite the bullet and implement this, based off of node-liftoff's require code. Addresses #475 #949.

Any compile-to-js language in [node-interpret](https://github.com/tkellen/node-interpret) is pulled into your project automatically. This means `.coffee`, `.json`, `.babel.js`, etc. are all supported out of the box. 

I tested this on a local repo of mine and seems to work. @sokra would love some feedback.