### PR TITLE
Allow CSS source maps by default

### DIFF
--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -33,7 +33,7 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 	var fallbackModuleFilenameTemplate = this.fallbackModuleFilenameTemplate;
 	var requestShortener = new RequestShortener(compiler.context);
 	var options = this.options;
-	options.test = options.test || /\.js($|\?)/i;
+	options.test = options.test || /\.(js|css)($|\?)/i;
 	compiler.plugin("compilation", function(compilation) {
 		new SourceMapDevToolModuleOptionsPlugin(options).apply(compilation);
 		compilation.plugin("after-optimize-chunk-assets", function(chunks) {


### PR DESCRIPTION
This fixes [webpack/extract-text-webpack-plugin#61](https://github.com/webpack/extract-text-webpack-plugin/issues/61) with the method recommended by @sokra. Currently the workaround requires not using `devtool: 'sourcemap'` and doing this instead:

```javascript
plugins: [
    new webpack.SourceMapDevToolPlugin({
        test:      /\.(js|css)($|\?)/i,
        filename: '[file].map'
    })
]
```

The change doesn't affect JS source mapping.