### PR TITLE
Possibility to load chunks with crossorigin

### DIFF
--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -33,6 +33,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 		var filename = this.outputOptions.filename || "bundle.js";
 		var chunkFilename = this.outputOptions.chunkFilename || "[id]." + filename;
 		var chunkMaps = chunk.getChunkMaps();
+		var crossOriginLoading = this.outputOptions.crossOriginLoading;
 		return this.asString([
 			"// \"0\" is the signal for \"already loaded\"",
 			"if(installedChunks[chunkId] === 0)",
@@ -50,6 +51,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 				"script.type = 'text/javascript';",
 				"script.charset = 'utf-8';",
 				"script.async = true;",
+				crossOriginLoading ? "script.crossOrigin = '" + crossOriginLoading + "';" : "",
 				"script.src = " + this.requireFn + ".p + " +
 					this.applyPluginsWaterfall("asset-path", JSON.stringify(chunkFilename), {
 						hash: "\" + " + this.renderCurrentHashCode(hash) + " + \"",

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -34,6 +34,7 @@ function WebpackOptionsDefaulter() {
 	this.set("output.sourceMapFilename", "[file].map[query]");
 	this.set("output.hotUpdateChunkFilename", "[id].[hash].hot-update.js");
 	this.set("output.hotUpdateMainFilename", "[hash].hot-update.json");
+	this.set("output.crossOriginLoading", false);
 	this.set("output.hashFunction", "md5");
 	this.set("output.hashDigest", "hex");
 	this.set("output.hashDigestLength", 20);


### PR DESCRIPTION
We are facing the problem, that our tracking of javascript errors currently is not working, due to CORS restrictions. This is because we load our chunks from a cdn domain and not the pages current domain.

This can easily be fixed by adding the crossorigin attribute to the script tags, but we can't do that for the tags which are injected by webpack.

https://developer.mozilla.org/de/docs/Web/HTML/Element/script#attr-crossorigin

In this PR we added a new configuration option which can be set to one of the two valid options for the crossorigin attribute ('anonymous' or 'use-credentials')(by default false). If present the crossorigin attribute will be added to the injected script tag.

There are still some questions for this PR, which we are not sure about.

* the location of config option may be not placed correctly in the output options? Any better ideas where to put that option? Currently we have *output.crossOriginLoading*
* Should we validate the value of the configuration and throw if an invalid value is used? Where to do that?
* Can we test this feature? If so, can you point us to a place were this test would be best placed?

Sorry for all this questions, but we are not that fit with webpacks internals :)