### PR TITLE
Use `files` in package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-test/
-examples/
-coverage/
-.travis.yml
-appveyor.yml
-bm.js

--- a/package.json
+++ b/package.json
@@ -62,6 +62,13 @@
   "main": "lib/webpack.js",
   "web": "lib/webpack.web.js",
   "bin": "./bin/webpack.js",
+  "files": [
+    "lib/",
+    "bin/",
+    "buildin/",
+    "hot/",
+    "web_modules/"
+  ],
   "scripts": {
     "test": "eslint lib && mocha --reporter spec",
     "lint": "eslint lib",


### PR DESCRIPTION
I find it easier to maintain a whitelist than a blacklist.

Before: http://pastebin.com/Gm18trPn
After: http://pastebin.com/usfjMfHA

The difference is just `.gitattributes` and `.editorconfig` (as well as `.npmignore`)