### PR TITLE
Multiple-build Support

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -3,6 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 var async = require("async");
+var shortid = require("shortid");
 
 var Tapable = require("tapable");
 var EntryModuleNotFoundError = require("./EntryModuleNotFoundError");
@@ -26,6 +27,7 @@ function Compilation(compiler) {
 
 	var options = this.options = compiler.options;
 	this.outputOptions = options && options.output;
+	this.outputOptions.localNamespace = this.outputOptions && this.outputOptions.localNamespace || shortid.generate();
 	this.bail = options && options.bail;
 	this.profile = options && options.profile;
 

--- a/lib/JsonpChunkTemplatePlugin.js
+++ b/lib/JsonpChunkTemplatePlugin.js
@@ -13,7 +13,7 @@ JsonpChunkTemplatePlugin.prototype.apply = function(chunkTemplate) {
 	chunkTemplate.plugin("render", function(modules, chunk) {
 		var jsonpFunction = this.outputOptions.jsonpFunction || Template.toIdentifier("webpackJsonp" + (this.outputOptions.library || ""));
 		var source = new ConcatSource();
-		source.add(jsonpFunction + "(" + JSON.stringify(chunk.ids) + ",");
+		source.add(jsonpFunction + "(" + JSON.stringify(this.outputOptions.localNamespace) + "," + JSON.stringify(chunk.ids) + ",");
 		source.add(modules);
 		source.add(")");
 		return source;

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -12,10 +12,12 @@ JsonpMainTemplatePlugin.prototype.constructor = JsonpMainTemplatePlugin;
 JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 	mainTemplate.plugin("local-vars", function(source, chunk) {
 		if(chunk.chunks.length > 0) {
+			var externals = this.outputOptions.externals || {};
 			return this.asString([
 				source,
 				"",
 				"var localNamespace = \"" + this.outputOptions.localNamespace + "\";",
+				"var externals = " + JSON.stringify(externals) + ";",
 				"",
 				"// object to store loaded and loading chunks",
 				"// \"0\" means \"already loaded\"",
@@ -91,14 +93,16 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 				this.indent([
 					"// add \"moreModules\" to the modules object,",
 					"// then flag all \"chunkIds\" as loaded and fire callback",
-					"var moduleId, chunkId, i = 0, callbacks = [];",
+					"var moduleId, chunkId, i = 0, external, callbacks = [];",
 					"for(;i < chunkIds.length; i++) {",
 					this.indent([
 						"chunkId = chunkIds[i];",
 						"// use chunkIds verbatim only if namespace matches local",
+						"// if no match, check externals for chunk from non-local build",
 						"if(namespace !== localNamespace) {",
 						this.indent([
-							"chunkId = null;"
+							"external = externals[namespace];",
+							"chunkId = external.chunks[chunkId];"
 						]),
 						"}",
 						"if(installedChunks[chunkId])",
@@ -107,7 +111,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 					]),
 					"}",
 					"for(moduleId in moreModules) {",
-					this.indent(this.renderAddModule(hash, chunk, "moduleId", "moreModules[moduleId]")),
+					this.indent(this.renderAddModule(hash, chunk, "moduleId", "moreModules[external ? external.modules[moduleId] : moduleId]")),
 					"}",
 					"if(parentJsonpFunction) parentJsonpFunction(namespace, chunkIds, moreModules);",
 					"while(callbacks.length)",

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -15,6 +15,8 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 			return this.asString([
 				source,
 				"",
+				"var localNamespace = \"" + this.outputOptions.localNamespace + "\";",
+				"",
 				"// object to store loaded and loading chunks",
 				"// \"0\" means \"already loaded\"",
 				"// Array means \"loading\", array contains callbacks",
@@ -85,7 +87,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 				"",
 				"// install a JSONP callback for chunk loading",
 				"var parentJsonpFunction = window[" + JSON.stringify(jsonpFunction) + "];",
-				"window[" + JSON.stringify(jsonpFunction) + "] = function webpackJsonpCallback(chunkIds, moreModules) {",
+				"window[" + JSON.stringify(jsonpFunction) + "] = function webpackJsonpCallback(namespace, chunkIds, moreModules) {",
 				this.indent([
 					"// add \"moreModules\" to the modules object,",
 					"// then flag all \"chunkIds\" as loaded and fire callback",
@@ -93,6 +95,12 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 					"for(;i < chunkIds.length; i++) {",
 					this.indent([
 						"chunkId = chunkIds[i];",
+						"// use chunkIds verbatim only if namespace matches local",
+						"if(namespace !== localNamespace) {",
+						this.indent([
+							"chunkId = null;"
+						]),
+						"}",
 						"if(installedChunks[chunkId])",
 						this.indent("callbacks.push.apply(callbacks, installedChunks[chunkId]);"),
 						"installedChunks[chunkId] = 0;"
@@ -101,7 +109,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 					"for(moduleId in moreModules) {",
 					this.indent(this.renderAddModule(hash, chunk, "moduleId", "moreModules[moduleId]")),
 					"}",
-					"if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules);",
+					"if(parentJsonpFunction) parentJsonpFunction(namespace, chunkIds, moreModules);",
 					"while(callbacks.length)",
 					this.indent("callbacks.shift().call(null, " + this.requireFn + ");"),
 					(this.entryPointInChildren(chunk) ? [

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "mkdirp": "~0.5.0",
     "node-libs-browser": "~0.4.0",
     "optimist": "~0.6.0",
+    "shortid": "^2.2.2",
     "supports-color": "^1.2.0",
     "tapable": "~0.1.8",
     "uglify-js": "~2.4.13",

--- a/test/statsCases/chunks/expected.txt
+++ b/test/statsCases/chunks/expected.txt
@@ -1,10 +1,10 @@
 Hash: 80887ec4f74063cf6be8
 Time: Xms
       Asset       Size  Chunks             Chunk Names
-  bundle.js    3.85 kB       0  [emitted]  main
-1.bundle.js  159 bytes       1  [emitted]  
-2.bundle.js  122 bytes       2  [emitted]  
-3.bundle.js  222 bytes       3  [emitted]  
+  bundle.js    4.29 kB       0  [emitted]  main
+1.bundle.js  170 bytes       1  [emitted]  
+2.bundle.js  133 bytes       2  [emitted]  
+3.bundle.js  233 bytes       3  [emitted]  
 chunk    {0} bundle.js (main) 73 bytes [rendered]
     [0] (webpack)/test/statsCases/chunks/index.js 51 bytes {0} [built]
        factory:Xms building:Xms = Xms


### PR DESCRIPTION
Two changes introduced here, with the second depending on the first.

- A per-build, unique namespace is defined and included on chunk load to avoid module/chunk ID collisions with JS from other builds.
- Provide mechanism for plugins to override chunks at run-time with other chunks from separate webpack builds.

Very open to feedback, and hoping that this or something like it will be acceptable.

Fuller descriptions from the commit messages:
```
Allow bundles from separate builds to co-exist on page.

Before this change, two webpack bundles from separate builds could not
be loaded on the same page if they both loaded chunks asynchronously.
If module 2 from build A were in the first async chunk loaded, both
`webpackJsonp` callbacks would be fired.  Since module IDs are inferred
from the module's position in the chunk's module array, build B would
load build A's module 2 as its own. This limited the use of Webpack
to single-build SPAs.

This change adds a canonical universally-unique build namespace,
to disambiguate async chunk/module loading.
```
```
Support loading of aliased chunks/modules from external build.

At present, it is only possible for the Webpack runtime loader to
load chunks that were generated as part of the same build as the
entry point.

However, for distributed teams like the Walmart.com team, it is
advantageous to share chunks of code between different entry points;
both those loaded in the same browser context and otherwise.  The
primary benefit is client-side caching of code.  If 30 of our
sub-projects bundle Underscore.js, the chunk containing that
library would ideally be cached and re-used by each of those
sub-projects.

I first attempted to support this use case as a plugin.  However,
plugins for generating the entry bootstrap are applied in waterfall.
https://github.com/divmain/webpack/blob/dc81f2ed975b0bf49fbf4ca600222e1c071c0680/lib/MainTemplate.js#L101-L101

This fundamentally interfered and necessitated overriding templating
at a much higher level.  This is undesirable, as the plug-in could
quickly fall behind changes made to Webpack.

This commit provides the most basic functionality to define a
mapping of external to local chunks and modules.  The `externals`
object would map the external build namespace to local aliases for
the chunks and modules.

Example:

  {
    "other-build-namespace": {
      "chunks": {
        4: 7 // where 4 is the chunk ID from other-build and 7 is from this build
      },
      "modules": {
        5: 9 // where 5 is the module ID from other-build and 9 is from this build
      }
    }
  }

The onus would be on plugin authors to generate this externals object.

My plan is to build a plugin that aliases chunks from other Webpack
builds to their local counterparts at build-time.  These chunks will
be identical in every way except for the chunk and module IDs.  These
IDs will be mapped and made available as `externals` by exporting
asset manifests from consumable projects, and importing and processing
those manifests from consuming projects.
```