### PR TITLE
Fix CLI ignores watchOptions

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -170,6 +170,6 @@ function compilerCallback(err, stats) {
 if(options.watch) {
 	var primaryOptions = !Array.isArray(options) ? options : options[0];
 	var watchOptions = primaryOptions.watchOptions || primaryOptions.watch || {};
-	compiler.watch(options.watch, compilerCallback);
+	compiler.watch(watchOptions, compilerCallback);
 } else
 	compiler.run(compilerCallback);


### PR DESCRIPTION
This fixes a bug where the CLI would simply ignore the `options.watchOptions Object` of a `webpack.config.js` file.

I suppose this got lost in 89058a2c4a32a2ec31c88acb3789c4f9eda58db1.