### PR TITLE
Update License in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,7 @@
   "peerDependencies": {
     "node-libs-browser": ">= 0.4.0 <=0.5.0"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ],
+  "license": "MIT",
   "devDependencies": {
     "benchmark": "^1.0.0",
     "bundle-loader": "~0.5.0",


### PR DESCRIPTION
License as array is deprecated as of `npm@2.10.0`.
https://github.com/npm/npm/pull/8179