### PR TITLE
Small refactor for getting size

### DIFF
--- a/lib/optimize/CommonsChunkPlugin.js
+++ b/lib/optimize/CommonsChunkPlugin.js
@@ -114,9 +114,9 @@ CommonsChunkPlugin.prototype.apply = function(compiler) {
 					reallyUsedModules.push(module);
 				});
 				if(minSize) {
-					var size = reallyUsedModules.map(function(module) {
-						return module.size();
-					}).reduce(function(a, b) { return a + b; }, 0);
+					var size = reallyUsedModules.reduce(function(a, b) {
+						return a + b.size();
+					}, 0);
 					if(size < minSize)
 						return;
 				}


### PR DESCRIPTION
Currently, map is being called to extract sizes then reduce is called on that; so 2 iterations through the array. It is possible to solve this with only reduce: 1 iteration. reallyUsedModules probably won't ever be big enough for this to matter, so it comes down to readability.

I think doing a once-and-done reduce could be an improvement here. What do you guys think?