### PR TITLE
Add argument error handling for optimization plugins

### DIFF
--- a/lib/optimize/AggressiveMergingPlugin.js
+++ b/lib/optimize/AggressiveMergingPlugin.js
@@ -3,6 +3,9 @@
 	Author Tobias Koppers @sokra
 */
 function AggressiveMergingPlugin(options) {
+	if(options !== undefined && typeof options !== "object" || Array.isArray(options)) {
+		throw new Error("Argument should be an options object. To use defaults, pass in nothing.\nFor more info on options, see http://webpack.github.io/docs/list-of-plugins.html");
+	}
 	this.options = options || {};
 }
 module.exports = AggressiveMergingPlugin;

--- a/lib/optimize/LimitChunkCountPlugin.js
+++ b/lib/optimize/LimitChunkCountPlugin.js
@@ -3,6 +3,9 @@
 	Author Tobias Koppers @sokra
 */
 function LimitChunkCountPlugin(options) {
+	if(options !== undefined && typeof options !== "object" || Array.isArray(options)) {
+		throw new Error("Argument should be an options object.\nFor more info on options, see http://webpack.github.io/docs/list-of-plugins.html");
+	}
 	this.options = options || {};
 }
 module.exports = LimitChunkCountPlugin;

--- a/lib/optimize/MinChunkSizePlugin.js
+++ b/lib/optimize/MinChunkSizePlugin.js
@@ -3,6 +3,9 @@
 	Author Tobias Koppers @sokra
 */
 function MinChunkSizePlugin(options) {
+	if(options !== undefined && typeof options !== "object" || Array.isArray(options)) {
+		throw new Error("Argument should be an options object.\nFor more info on options, see http://webpack.github.io/docs/list-of-plugins.html");
+	}
 	this.options = options;
 }
 module.exports = MinChunkSizePlugin;

--- a/lib/optimize/MinChunkSizePlugin.js
+++ b/lib/optimize/MinChunkSizePlugin.js
@@ -3,7 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 function MinChunkSizePlugin(options) {
-	if(options !== undefined && typeof options !== "object" || Array.isArray(options)) {
+	if(typeof options !== "object" || Array.isArray(options)) {
 		throw new Error("Argument should be an options object.\nFor more info on options, see http://webpack.github.io/docs/list-of-plugins.html");
 	}
 	this.options = options;

--- a/lib/optimize/OccurrenceOrderPlugin.js
+++ b/lib/optimize/OccurrenceOrderPlugin.js
@@ -3,6 +3,9 @@
 	Author Tobias Koppers @sokra
 */
 function OccurrenceOrderPlugin(preferEntry) {
+	if(preferEntry !== undefined && typeof preferEntry !== "boolean") {
+		throw new Error("Argument should be a boolean.\nFor more info on this plugin, see http://webpack.github.io/docs/list-of-plugins.html");
+	}
 	this.preferEntry = preferEntry;
 }
 module.exports = OccurrenceOrderPlugin;

--- a/test/Integration.test.js
+++ b/test/Integration.test.js
@@ -52,7 +52,7 @@ describe("Integration", function() {
 				alias: { should: require.resolve("should") }
 			},
 			plugins: [
-				new webpack.optimize.LimitChunkCountPlugin(1),
+				new webpack.optimize.LimitChunkCountPlugin({maxChunks: 1}),
 				new webpack.DefinePlugin({
 					"typeof CONST_TYPEOF": JSON.stringify("typeof"),
 					CONST_TRUE: true,

--- a/test/NodeTemplatePlugin.test.js
+++ b/test/NodeTemplatePlugin.test.js
@@ -50,7 +50,7 @@ describe("NodeTemplatePlugin", function() {
 			},
 			entry: "./entry",
 			plugins: [
-				new webpack.optimize.LimitChunkCountPlugin(1),
+				new webpack.optimize.LimitChunkCountPlugin({maxChunks: 1}),
 				new webpack.optimize.UglifyJsPlugin()
 			]
 		}, function(err, stats) {

--- a/test/browsertest/library2config.coffee
+++ b/test/browsertest/library2config.coffee
@@ -14,7 +14,8 @@ module.exports =
 		alias:
 			should: require.resolve "should"
 	plugins: [
-		new webpack.optimize.LimitChunkCountPlugin 2
+		new webpack.optimize.LimitChunkCountPlugin
+			maxChunks: 2
 		new webpack.DefinePlugin
 			"typeof CONST_TYPEOF": JSON.stringify("typeof"),
 			CONST_UNDEFINED: undefined,


### PR DESCRIPTION
Throw errors if users don't pass in the correct type of argument to the plugin instead of leaving them in the dark. 

For OccurenceOrderPlugin, passing in no arguments should still work just in case there are people currently using it without arguments.