### PR TITLE
Don't provide __webpack_require__ argument to external modules

### DIFF
--- a/lib/FunctionModuleTemplatePlugin.js
+++ b/lib/FunctionModuleTemplatePlugin.js
@@ -12,7 +12,11 @@ module.exports = FunctionModuleTemplatePlugin;
 FunctionModuleTemplatePlugin.prototype.apply = function(moduleTemplate) {
 	moduleTemplate.plugin("render", function(moduleSource, module) {
 		var source = new ConcatSource();
-		source.add("/***/ function(" + ["module", "exports", "__webpack_require__"].concat(module.arguments || []).join(", ") + ") {\n\n");
+		var defaultArguments = ["module", "exports"];
+		if (!module.external) {
+			defaultArguments.push("__webpack_require__");
+		}
+		source.add("/***/ function(" + defaultArguments.concat(module.arguments || []).join(", ") + ") {\n\n");
 		source.add(new PrefixSource(this.outputOptions.sourcePrefix, moduleSource));
 		source.add("\n\n/***/ }");
 		return source;


### PR DESCRIPTION
In order to avoid conflicts with the `__webpack_require__` variable when dealing with externals (#1054), I thought we could just not provide the `__webpack_require__` argument to external modules since, from my understanding, they would never call it anyways.

That way, external modules would end up looking like:
```js
/* 3 */
/***/ function(module, exports) {

    module.exports = require("react");

/***/ },
```
and when they are rewritten in the outer bundle, they would end up like:
```js
/* 3 */
/***/ function(module, exports) {

    module.exports = __webpack_require__(11);

/***/ },
```

Where `__webpack_require__` would correctly reference the `__webpack_require__` from the outer bundle and not the inner bundle like it does now.

This is just my initial attempt at a fix for #1054. What are your thoughts @sokra? I'm totally open to better ideas.