### PR TITLE
Refactor size method for Chunks

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -180,10 +180,8 @@ Chunk.prototype.size = function(options) {
 	var CHUNK_OVERHEAD = options.chunkOverhead || 10000;
 	var ENTRY_CHUNK_MULTIPLICATOR = options.entryChunkMultiplicator || 10;
 
-	var modulesSize = this.modules.map(function(m) {
-		return m.size();
-	}).reduce(function(a, b) {
-		return a + b;
+	var modulesSize = this.modules.reduce(function(a, b) {
+		return a + b.size();
 	}, 0);
 	return modulesSize * (this.initial ? ENTRY_CHUNK_MULTIPLICATOR : 1) + CHUNK_OVERHEAD;
 };


### PR DESCRIPTION
Same small refactor as a [previous pull](https://github.com/webpack/webpack/commit/7edffc381d5aa97c3969d6b38761bd92c94b9f95). Does one ```reduce``` iteration instead of a ```map``` -> ```reduce```