### PR TITLE
Fix optimize-min-chunk-size option for CLI

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -394,8 +394,10 @@ module.exports = function(optimist, argv, convertOptions) {
 
 		ifArg("optimize-min-chunk-size", function(value) {
 			ensureArray(options, "plugins");
-			var LimitChunkSizePlugin = require("../lib/optimize/LimitChunkSizePlugin");
-			options.plugins.push(new LimitChunkSizePlugin(parseInt(value, 10)));
+			var MinChunkSizePlugin = require("../lib/optimize/MinChunkSizePlugin");
+			options.plugins.push(new MinChunkSizePlugin({
+				minChunkSize: parseInt(value, 10)
+			}));
 		});
 
 		ifBooleanArg("optimize-minimize", function() {


### PR DESCRIPTION
Currently, every user that uses the ```--optimize-min-chunk-size``` option gets an error because it requires ```LimitChunkSizePlugin```.

There doesn't seem to be a ```LimitChunkSizePlugin```. So this pull request fixes that by making the assumption that webpack actually wants to use ```MinChunkSizePlugin``` instead of the nowhere-to-be-found ```LimitChunkSizePlugin```.