### PR TITLE
Stats.js formatError supports string errors

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -74,6 +74,8 @@ Stats.prototype.toJson = function toJson(options, forToString) {
 	}
 	function formatError(e) {
 		var text = "";
+		if(typeof e === "string")
+			e = {message: e};
 		if(e.module && e.module.readableIdentifier && typeof e.module.readableIdentifier === "function") {
 			text += e.module.readableIdentifier(requestShortener) + "\n";
 		} else if(e.file) {

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -7,6 +7,7 @@ var webpack = require("../lib/webpack");
 
 var base = path.join(__dirname, "statsCases");
 var tests = fs.readdirSync(base);
+var Stats = require("../lib/Stats");
 
 describe("Stats", function() {
 	tests.forEach(function(testName) {
@@ -59,4 +60,43 @@ describe("Stats", function() {
 			});
 		});
 	});
+	describe("Error Handling", function(){
+		describe("does have", function(){
+			it("hasErrors", function() {
+				mockStats = new Stats({errors:['firstError'],hash:'1234'});
+				mockStats.hasErrors().should.be.ok;
+			});
+			it("hasWarnings", function() {
+				mockStats = new Stats({warnings:['firstError'],hash:'1234'});
+				mockStats.hasWarnings().should.be.ok;
+			});
+		});
+		describe("does not have", function(){
+			it("hasErrors", function() {
+				mockStats = new Stats({errors:[],hash:'1234'});
+				mockStats.hasErrors().should.not.be.ok;
+			});
+			it("hasWarnings", function() {
+				mockStats = new Stats({warnings:[],hash:'1234'});
+				mockStats.hasWarnings().should.not.be.ok;
+			});
+		});
+		it("formatError handles string errors", function(){
+			mockStats = new Stats({
+				errors:['firstError'],
+				warnings:[],
+				assets:[],
+				chunks:[],
+				modules:[],
+				children:[],
+				hash:'1234',
+				mainTemplate:{
+					getPublicPath:function(){return 'path';}
+				}
+			});
+			obj = mockStats.toJson();
+			obj.errors[0].should.be.equal('firstError');
+		});
+	});
+
 });


### PR DESCRIPTION
We have plugins we use that were thowing errors that were strings. However the errors reporrted were 

`Error undefined` which was little to no help. Now we actually get the error reporting we need.

Stats now error reporting catches string errors. Some plugins appear to not obey the rules on error reporting. However this makes debuging a nightmare for users. Therefore the string should be allowed.