### PR TITLE
Error.stackTrackLimit -> stackTraceLimit

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -152,7 +152,7 @@ ifArg("hide-modules", function(bool) {
 
 var webpack = require("../lib/webpack.js");
 
-Error.stackTrackLimit = 30;
+Error.stackTraceLimit = 30;
 var lastHash = null;
 var compiler = webpack(options);
 function compilerCallback(err, stats) {


### PR DESCRIPTION
Fixed typo in bin/webpack.js. Should be straightforward.