### PR TITLE
Update DedupePlugin.js to be more third-party-lib friendly

### DIFF
--- a/lib/optimize/DedupePlugin.js
+++ b/lib/optimize/DedupePlugin.js
@@ -181,7 +181,7 @@ DedupePlugin.prototype.apply = function(compiler) {
 			source.add("(function(modules) {\n");
 			source.add(this.indent([
 				"// Check all modules for deduplicated modules",
-				"for(var i in modules) {",
+				"for(var i=0; i<modules.length; i++) {",
 				this.indent([
 					"if(Object.prototype.hasOwnProperty.call(modules, i)) {",
 					this.indent([


### PR DESCRIPTION
Using for...in to iterate over an array without any guard is problematic when websites include third party libraries which (horribly) pollute global prototypes.  Popular examples of this include early versions of Mootools and Prototype.

This simple fix alleviates any problems having these libraries loaded would cause.