### PR TITLE
fix config extension interpretation for .babel.js

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -28,11 +28,23 @@ module.exports = function(optimist, argv, convertOptions) {
 	}
 
 	var configPath, ext;
+	var extensions = Object.keys(interpret.extensions).sort(function(a, b){
+		return a.length - b.length;
+	});
+
 	if (argv.config) {
 		configPath = path.resolve(argv.config);
-		ext = path.extname(configPath);
+		for (var i = extensions.length - 1; i >= 0; i--) {
+			var tmpExt = extensions[i];
+			if (configPath.indexOf(tmpExt, configPath.length - tmpExt.length) > -1){
+				ext = tmpExt;
+				break;
+			}
+		};
+		if (!ext) {
+			ext = path.extname(configPath);
+		}
 	} else {
-		var extensions = Object.keys(interpret.extensions);
 		for(var i = 0; i < extensions.length; i++) {
 			var webpackConfig = path.resolve('webpack.config' + extensions[i]);
 			if(fs.existsSync(webpackConfig)) {


### PR DESCRIPTION
When using babel in your webpack.config, the config should be named ```webpack.config.babel.js```. Webpack can find it and works fine by default. However if one uses ```webpack --config webpack.config.babel.js``` it fails for invalid extension interpretation. This causes problem when using multiple webpack configs. I sort the extension array in order to exam ```.babel.js``` earlier than ```.js```