### PR TITLE
Fix multiPass mode on OSX

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -66,9 +66,11 @@ Watching.prototype._go = function() {
 						stats.endTime = new Date().getTime();
 						this.compiler.applyPlugins("done", stats);
 
-						this.compiler.applyPluginsAsync("additional-pass", function(err) {
-							if(err) return this._done(err);
-							this.compiler.compile(onCompiled.bind(this));
+						setTimeout(function () {
+							this.compiler.applyPluginsAsync("additional-pass", function(err) {
+								if(err) return this._done(err);
+								this.compiler.compile(onCompiled.bind(this));
+							}.bind(this));
 						}.bind(this));
 						return;
 					}


### PR DESCRIPTION
I'm submitting a PR to keep the conversation going. Without `setTimeout`, I'm [getting](https://github.com/webpack/webpack/issues/669#issuecomment-112077917) two `bundle is now INVALID.` in a row. With this change, I'm getting a correct `multiPass` rebuild.

Is there a proper fix? Probably! I just don't know what it is :-)