### PR TITLE
Downgrade uglifyjs to 2.3.x to fix source-maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "optimist": "~0.6.0",
     "supports-color": "^1.2.0",
     "tapable": "~0.1.8",
-    "uglify-js": "~2.4.13",
+    "uglify-js": "~2.3.6",
     "watchpack": "^0.2.1",
     "webpack-core": "~0.6.0"
   },


### PR DESCRIPTION
I'm having some issues generating sourcemaps when using the UglifyJsPlugin. Looks like the 2.4.x version of uglify-js have some issues generating correct sourcemaps (https://github.com/mishoo/UglifyJS2/issues/700). 

I created a very simple webpack project to reproduce the issues with sourcemaps + uglify-js: (https://github.com/mllocs/webpack-test). Also, I think this uglify-js issue can be related with this open webpack issue https://github.com/webpack/webpack/issues/1104.