### PR TITLE
Add options argument to ProvidePlugin

### DIFF
--- a/lib/ProvidePlugin.js
+++ b/lib/ProvidePlugin.js
@@ -3,15 +3,18 @@
 	Author Tobias Koppers @sokra
 */
 var ModuleParserHelpers = require("./ModuleParserHelpers");
+var ModuleFilenameHelpers = require("./ModuleFilenameHelpers");
 var ConstDependency = require("./dependencies/ConstDependency");
 
 var NullFactory = require("./NullFactory");
 
-function ProvidePlugin(definitions) {
+function ProvidePlugin(definitions, options) {
 	this.definitions = definitions;
+	this.options = options;
 }
 module.exports = ProvidePlugin;
 ProvidePlugin.prototype.apply = function(compiler) {
+	var options = this.options;
 	compiler.plugin("compilation", function(compilation) {
 		compilation.dependencyFactories.set(ConstDependency, new NullFactory());
 		compilation.dependencyTemplates.set(ConstDependency, new ConstDependency.Template());
@@ -26,6 +29,9 @@ ProvidePlugin.prototype.apply = function(compiler) {
 			});
 		}
 		compiler.parser.plugin("expression " + name, function(expr) {
+			if(options && !ModuleFilenameHelpers.matchObject(options, this.state.current.resource)) {
+				return true;
+			}
 			var nameIdentifier = name;
 			var scopedName = name.indexOf(".") >= 0;
 			if(scopedName) {


### PR DESCRIPTION
Brings finer control over exactly what resources will be affected by ProvidePlugin.

For instance, I might only want to provide `window.jQuery` to a single module, and have it evaluate to undefined everywhere else.
