### PR TITLE
fixed [chunkhash] length regression

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -816,7 +816,8 @@ Compilation.prototype.createChunkAssets = function createChunkAssets() {
 			chunkFilename;
 		var usedHash = !chunk.entry || (this.mainTemplate.useChunkHash && this.mainTemplate.useChunkHash(chunk)) ? chunkHash : this.fullHash;
 		var argumentedChunk = Object.create(chunk);
-		argumentedChunk.renderedHash = usedHash;
+		var hashDigestLength = outputOptions.hashDigestLength;
+		argumentedChunk.renderedHash = usedHash.substr(0, hashDigestLength);
 		if(this.cache && this.cache["c" + chunk.id] && this.cache["c" + chunk.id].hash === usedHash) {
 			source = this.cache["c" + chunk.id].source;
 		} else {


### PR DESCRIPTION
It's a fix for regression.

Regression was introduced in commit 4e041dfd52ec78187e57785a53d2e115712ae93c (issue #1181).

Also it fixes a previously broken test:

```
  1) ConfigTestCases hash-length output-filename should load additional chunks:
     Uncaught ENOENT, open '/home/travis/build/webpack/webpack/test/js/config/hash-length/output-filename/1.bundle.25a1b5a14f3986614a73.js'
  Error: ENOENT, open 'test/js/config/hash-length/output-filename/1.bundle.25a1b5a14f3986614a73.js'
      at Error (native)
```

(output from https://travis-ci.org/webpack/webpack/jobs/68229001)