### PR TITLE
Added --output-filename to be consistent with naming conventions

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -260,6 +260,12 @@ module.exports = function(optimist, argv, convertOptions) {
 		});
 
 		ifArg("output-file", function(value) {
+			console.warn("output.file will be deprecated: Use 'output.filename' instead");
+			ensureObject(options, "output");
+			options.output.filename = value;
+		});
+
+		ifArg("output-filename", function(value) {
 			ensureObject(options, "output");
 			options.output.filename = value;
 		});


### PR DESCRIPTION
--output-pathinfo maps to output.pathinfo, however, output.filename is set
by --output-file instead of --output-filename.
Added the new argument while keeping the old one for compability.