### PR TITLE
feat(app): devtool(Fallback)ModuleFilenameTemplate can now also be defined as function

### DIFF
--- a/lib/ModuleFilenameHelpers.js
+++ b/lib/ModuleFilenameHelpers.js
@@ -69,14 +69,14 @@ ModuleFilenameHelpers.createFilename = function createFilename(module, moduleFil
 	if(typeof moduleFilenameTemplate === "function") {
 		return moduleFilenameTemplate({
 			identifier: identifier,
-            shortIdentifier: shortIdentifier,
-            resource: resource,
-            resourcePath: resourcePath,
-            absoluteResourcePath: absoluteResourcePath,
-            allLoaders: allLoaders,
-            query: query,
-            moduleId: moduleId,
-            hash: hash
+			shortIdentifier: shortIdentifier,
+			resource: resource,
+			resourcePath: resourcePath,
+			absoluteResourcePath: absoluteResourcePath,
+			allLoaders: allLoaders,
+			query: query,
+			moduleId: moduleId,
+			hash: hash
 		});
 	}
 	return (moduleFilenameTemplate

--- a/lib/ModuleFilenameHelpers.js
+++ b/lib/ModuleFilenameHelpers.js
@@ -66,6 +66,19 @@ ModuleFilenameHelpers.createFilename = function createFilename(module, moduleFil
 	var allLoaders = getBefore(identifier, "!");
 	var query = getAfter(resource, "?");
 	var resourcePath = resource.substr(0, resource.length - query.length);
+	if(typeof moduleFilenameTemplate === "function") {
+		return moduleFilenameTemplate({
+			identifier: identifier,
+            shortIdentifier: shortIdentifier,
+            resource: resource,
+            resourcePath: resourcePath,
+            absoluteResourcePath: absoluteResourcePath,
+            allLoaders: allLoaders,
+            query: query,
+            moduleId: moduleId,
+            hash: hash
+		});
+	}
 	return (moduleFilenameTemplate
 		.replace(ModuleFilenameHelpers.REGEXP_ALL_LOADERS_RESOURCE, identifier)
 		.replace(ModuleFilenameHelpers.REGEXP_LOADERS_RESOURCE, shortIdentifier)

--- a/test/configCases/filename-template/module-filename-template/index.js
+++ b/test/configCases/filename-template/module-filename-template/index.js
@@ -1,0 +1,8 @@
+it("should include test.js in SourceMap", function() {
+    var fs = require("fs");
+    var source = fs.readFileSync(__filename + ".map", "utf-8");
+    var map = JSON.parse(source);
+    map.sources.should.containEql("dummy:///./test.js");
+});
+
+require.include("./test.js");

--- a/test/configCases/filename-template/module-filename-template/index.js
+++ b/test/configCases/filename-template/module-filename-template/index.js
@@ -1,8 +1,9 @@
 it("should include test.js in SourceMap", function() {
-    var fs = require("fs");
-    var source = fs.readFileSync(__filename + ".map", "utf-8");
-    var map = JSON.parse(source);
-    map.sources.should.containEql("dummy:///./test.js");
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename + ".map", "utf-8");
+	var map = JSON.parse(source);
+	map.sources.should.containEql("dummy:///./test.js");
 });
 
 require.include("./test.js");
+

--- a/test/configCases/filename-template/module-filename-template/webpack.config.js
+++ b/test/configCases/filename-template/module-filename-template/webpack.config.js
@@ -1,15 +1,14 @@
 module.exports = {
-    output: {
-        lineToLine: true,
-        devtoolModuleFilenameTemplate: function(info) {
-            return "dummy:///" + info.resourcePath;
-        }
-    },
-    node: {
-        __dirname: false,
-        __filename: false
-    },
-    devtool: "cheap-source-map"
+	output: {
+		lineToLine: true,
+		devtoolModuleFilenameTemplate: function(info) {
+			return "dummy:///" + info.resourcePath;
+		}
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	devtool: "cheap-source-map"
 
 };
-

--- a/test/configCases/filename-template/module-filename-template/webpack.config.js
+++ b/test/configCases/filename-template/module-filename-template/webpack.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+    output: {
+        lineToLine: true,
+        devtoolModuleFilenameTemplate: function(info) {
+            return "dummy:///" + info.resourcePath;
+        }
+    },
+    node: {
+        __dirname: false,
+        __filename: false
+    },
+    devtool: "cheap-source-map"
+
+};
+


### PR DESCRIPTION
Usage example
webpack.config.js
```js
module.exports = {
  entry: 'main.js',
  output: {
    filename : 'bundle.js',
    devtoolModuleFilenameTemplate: function(info) {
      // info is an objet which has the following properties:
      // - identifier
      // - shortIdentifier
      // - resource
      // - resourcePath
      // - absoluteResourcePath
      // - allLoaders
      // - query
      // - moduleId
      // - hash
      return info.resourcePath;
     }
  }
};
```
