### PR TITLE
feat(app): Git ignore *.log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /examples/*/js
 /coverage
 .DS_Store
+*.log


### PR DESCRIPTION
A small change that avoid commiting an `npm-debug.log` file when for example the command `npm run eslint` fails