### PR TITLE
Add original error to stats-output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /coverage
 .DS_Store
 *.log
+.idea/

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -78,6 +78,20 @@ Stats.prototype.toJson = function toJson(options, forToString) {
 		};
 	}
 
+	function getErrorMessage(err) {
+		var errors = [];
+
+		if(err.error) {
+			errors.push(getErrorMessage(err.error));
+			// Flatten array
+			errors = [].concat.apply([], errors);
+		}
+
+		errors.push(err.message.split("\n").join("\n\t"));
+
+		return errors;
+	}
+
 	function formatError(e) {
 		var text = "";
 		if(typeof e === "string")
@@ -109,6 +123,9 @@ Stats.prototype.toJson = function toJson(options, forToString) {
 				text += " " + dep.loc.start.line + ":" + dep.loc.start.column + "-" +
 					(dep.loc.start.line !== dep.loc.end.line ? dep.loc.end.line + ":" : "") + dep.loc.end.column;
 			});
+		}
+		if(showErrorDetails && e.error) {
+			text += "\n\nOriginal error is: " + getErrorMessage(e.error).reverse().join("\n");
 		}
 		return text;
 	}


### PR DESCRIPTION
I'm using the `stylus-loader`, and in one of my `mixin`s I raise an error. If the error is raised during compilation, the compilation fails (which is good), but the original error is lost (which is bad).

I wrote some on Gitter about it, link for reference: https://gitter.im/webpack/webpack?at=55a8bbd3ad99869443daa560

Without this patch, error output is
![image](https://cloud.githubusercontent.com/assets/1404810/8744539/33d0082c-2c78-11e5-85a8-6c58370c820a.png)

while this change makes the output
![image](https://cloud.githubusercontent.com/assets/1404810/8744563/6072fe16-2c78-11e5-8f4c-ab18802928bb.png)

I was unable to write a test for it. Do I have to force a `ModuleBuildError`?

It's a pretty naive implementation as well, but it gets the job done in my case at least.
