### PR TITLE
Adjust to use of interpret module version 0.6

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -56,15 +56,27 @@ module.exports = function(optimist, argv, convertOptions) {
 	}
 
 	if(configPath) {
-		var moduleName = interpret.extensions[ext];
-		if (moduleName) {
-			var compiler = require(moduleName);
-			var register = interpret.register[moduleName];
-			var config = interpret.configurations[moduleName];
-			if (register) {
-				register(compiler, config);
+
+		function registerCompiler(moduleDescriptor) {
+			if (moduleDescriptor) {
+				if(typeof(moduleDescriptor) == "string") {
+					require(moduleDescriptor);
+				} else if(!Array.isArray(moduleDescriptor)) {
+					moduleDescriptor.register(require(moduleDescriptor.module));
+				} else {
+					for(var i = 0; i < moduleDescriptor.length; i++) {
+						try {
+							registerCompiler(moduleDescriptor[i]);
+							break;
+						} catch(e) {
+							// do nothing
+						}
+					}
+				}
 			}
 		}
+
+		registerCompiler(interpret.extensions[ext]);
 		options = require(configPath);
 	}
 


### PR DESCRIPTION
This commit bumped up interpret version to 0.6:

https://github.com/webpack/webpack/commit/bf3ea10f3cc988c78627498f81a188f796329e82#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R11

Because interpret changed the structure from 0.5 to 0.6 it made webpack stop working for me with webpack.config.coffee so I fixed the code that uses the interpret to behave in accordance to https://github.com/tkellen/js-interpret#how-to-use-it for version 0.6

Please accept the request quickly as the only thing I did to encounter the error was to install nodejs, webpack and coffee-script on clean machine and attempt to get something very basic working.

The bug also affects not only the people that like their webpack.config in different flavors of coffescript but also typescript, babel.js and jsx as you can infer from here: https://github.com/tkellen/js-interpret/blob/master/index.js