### PR TITLE
Added path field to compilation.assets

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -813,10 +813,12 @@ Compilation.prototype.createChunkAssets = function createChunkAssets() {
 	var namedChunkFilename = outputOptions.namedChunkFilename || null;
 	for(var i = 0; i < this.modules.length; i++) {
 		var module = this.modules[i];
+		var path = module.rawRequest;
 		if(module.assets) {
 			Object.keys(module.assets).forEach(function(name) {
 				var file = this.getPath(name);
 				this.assets[file] = module.assets[name];
+				this.assets[file].path = module.rawRequest;
 				this.applyPlugins("module-asset", module, file);
 			}, this);
 		}

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -139,6 +139,7 @@ Stats.prototype.toJson = function toJson(options, forToString) {
 				size: compilation.assets[asset].size(),
 				chunks: [],
 				chunkNames: [],
+				path: compilation.assets[asset].path || null,
 				emitted: compilation.assets[asset].emitted
 			};
 			assetsByFile[asset] = obj;


### PR DESCRIPTION
Adding path field that contains path to file (or null) to `compilation.assets` creates the possibility to use it in plugins for adding new assets and to know it real filepath (without hash).

This is done to solve the issue that i creates here - https://github.com/webpack/webpack/issues/1287