### PR TITLE
Add the option to disable the node module related plugins

### DIFF
--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -80,13 +80,15 @@ NodeStuffPlugin.prototype.apply = function(compiler) {
 		this.state.module.warnings.push(new UnsupportedFeatureWarning(this.state.module, "require.extensions is not supported by webpack. Use a loader instead."));
 		return true;
 	});
-	compiler.parser.plugin("expression module.exports", ignore);
-	compiler.parser.plugin("expression module.loaded", ignore);
-	compiler.parser.plugin("expression module.id", ignore);
-	compiler.parser.plugin("evaluate Identifier module.hot", function(expr) {
-		return new BasicEvaluatedExpression().setBoolean(false).setRange(expr.range);
-	});
-	compiler.parser.plugin("expression module", function() {
-		return ModuleParserHelpers.addParsedVariable(this, "module", "require(" + JSON.stringify(path.join(__dirname, "..", "buildin", "module.js")) + ")(module)");
-	});
+	if(this.options.module) {
+		compiler.parser.plugin("expression module.exports", ignore);
+		compiler.parser.plugin("expression module.loaded", ignore);
+		compiler.parser.plugin("expression module.id", ignore);
+		compiler.parser.plugin("evaluate Identifier module.hot", function(expr) {
+			return new BasicEvaluatedExpression().setBoolean(false).setRange(expr.range);
+		});
+		compiler.parser.plugin("expression module", function() {
+			return ModuleParserHelpers.addParsedVariable(this, "module", "require(" + JSON.stringify(path.join(__dirname, "..", "buildin", "module.js")) + ")(module)");
+		});
+	}
 };

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -46,6 +46,7 @@ function WebpackOptionsDefaulter() {
 	this.set("node.global", true);
 	// TODO: add this in next major version
 	// this.set("node.Buffer", true);
+	this.set("node.module", true);
 	this.set("node.setImmediate", true);
 	this.set("node.__filename", "mock");
 	this.set("node.__dirname", "mock");


### PR DESCRIPTION
As suggested by @sokra, we're supposed to have an option for node module related plugin, and we can use that option to disable shims about `node.module`
