### PR TITLE
Send `exit(0)` when stdin closed.

### DIFF
--- a/bin/config-optimist.js
+++ b/bin/config-optimist.js
@@ -24,6 +24,7 @@ module.exports = function(optimist) {
 		.string("target").describe("target")
 		.boolean("cache").describe("cache").default("cache", true)
 		.boolean("watch").alias("watch", "w").describe("watch")
+		.boolean("watch-stdin").alias("watch-stdin", "stdin").describe("watch which closes when stdin ends")
 		.describe("watch-aggregate-timeout")
 		.describe("watch-poll")
 		.boolean("hot").alias("hot", "h").describe("hot")

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -132,6 +132,12 @@ module.exports = function(optimist, argv, convertOptions) {
 			options.watchOptions.poll = true;
 	}
 
+	if(argv["watch-stdin"]) {
+		options.watchOptions = options.watchOptions || {};
+		options.watchOptions.stdin = true;
+		options.watch = true;
+	}
+
 	function processOptions(options) {
 		function ifArg(name, fn, init, finalize) {
 			if(Array.isArray(argv[name])) {

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -167,6 +167,12 @@ function compilerCallback(err, stats) {
 if(options.watch) {
 	var primaryOptions = !Array.isArray(options) ? options : options[0];
 	var watchOptions = primaryOptions.watchOptions || primaryOptions.watch || {};
+	if(watchOptions.stdin) {
+		process.stdin.on('end', function() {
+			process.exit(0)
+		});
+		process.stdin.resume();
+	}
 	compiler.watch(watchOptions, compilerCallback);
 } else
 	compiler.run(compilerCallback);


### PR DESCRIPTION
This will send the proper exit signal when stdin closed for #1308 

I would like to automatically run `webpack --watch` as part of my application but, when it shuts down, the webpack process persists and continues running. I have observed that my application does close STDIN, however, `webpack --watch` is not currently checking if STDIN was closed or not.