### PR TITLE
support arguments input for CLI --plugin

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -193,6 +193,19 @@ module.exports = function(optimist, argv, convertOptions) {
 		}
 
 		function loadPlugin(name) {
+			var loadUtils = require("loader-utils");
+			var args = null;
+			try {
+				var p = name && name.indexOf("?");
+				if (p > -1) {
+					args = loadUtils.parseQuery(name.substring(p));
+					name = name.substring(0, p);
+				}
+			} catch(e) {
+				console.log("Invalid plugin arguments" + e + ".");
+				process.exit(-1);
+			}
+
 			var path;
 			try {
 				path = resolve.sync(process.cwd(), name);
@@ -208,7 +221,7 @@ module.exports = function(optimist, argv, convertOptions) {
 				throw e;
 			}
 			try {
-				return new Plugin();
+				return new Plugin(args);
 			} catch(e) {
 				console.log("Cannot instantiate plugin " + name + ". (" + path + ")");
 				throw e;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "js-beautify": "^1.5.10",
     "json-loader": "~0.5.1",
     "less-loader": "^2.0.0",
+    "loader-utils": "^0.2.11",
     "microtime": "^1.2.0",
     "mocha": "~2.2.0",
     "mocha-lcov-reporter": "0.0.2",


### PR DESCRIPTION
for example, `webpack --plugin ThePlugin?arg1=123&arg2=456`

Now that support for option  "--plugin", why not support the plugins arguments input? So I am asking patch for it. And in my case, I wrote a custom plugin which for releasing my project. That means, I use webpack not only for module bundling but also project building like grunt.