### PR TITLE
Test on multiple io.js's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ sudo: false
 language: node_js
 node_js:
   - "0.10"
-  - "0.12"
-  - "iojs"
+  - node
+  - iojs-1
+  - iojs-2
+  - iojs
 script: npm run travis
 env:
   - NO_WATCH_TESTS=1


### PR DESCRIPTION
The build is currently failing on `iojs@3.0.0` (see wadey/node-microtime#33), but I think it highlighted that we didn't test "older" versions of `iojs`.

This change also does not explicitly state `latest`, but will always test the newest (old behavior for `iojs`, new for `node`). This means adding an entry for it when a new version is released.