### PR TITLE
Add brackets to fix parse errors on some runtimes

### DIFF
--- a/lib/JsonpMainTemplate.runtime.js
+++ b/lib/JsonpMainTemplate.runtime.js
@@ -7,7 +7,7 @@ module.exports = function() {
 	function webpackHotUpdateCallback(chunkId, moreModules) { // eslint-disable-line no-unused-vars
 		hotAddUpdateChunk(chunkId, moreModules);
 		if(parentHotUpdateCallback) parentHotUpdateCallback(chunkId, moreModules);
-	}
+	};
 
 	function hotDownloadUpdateChunk(chunkId) { // eslint-disable-line no-unused-vars
 		var head = document.getElementsByTagName("head")[0];


### PR DESCRIPTION
This might look like a pointless thing BUT not having this in the generated
bundle can cause parse errors on certain javascript runtimes.
Using [nashorn](http://openjdk.java.net/projects/nashorn/) for instance, we get
the following error:

jdk.nashorn.internal.runtime.ParserException:
<eval>#7:16<eval>:9:10 Expected ; but found function
/******/ 	function hotDownloadUpdateChunk(chunkId) { // eslint-disable-line ...
         	^

I'm afraid than writing a test case would be difficult since we have to use a JVM to reproduce.
However I can provide a repro if you guys are interested.

Since it is such a small change and I'm obviously not breaking anything, I hope you will trust me on this!