### PR TITLE
Report constructor correctly when inheriting from Tapable

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -59,6 +59,8 @@ function Compilation(compiler) {
 module.exports = Compilation;
 
 Compilation.prototype = Object.create(Tapable.prototype);
+Compilation.prototype.constructor = Compilation;
+
 Compilation.prototype.templatesPlugin = function(name, fn) {
 	this.mainTemplate.plugin(name, fn);
 	this.chunkTemplate.plugin(name, fn);

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -152,6 +152,7 @@ function Compiler() {
 module.exports = Compiler;
 
 Compiler.prototype = Object.create(Tapable.prototype);
+Compiler.prototype.constructor = Compiler;
 
 Compiler.Watching = Watching;
 Compiler.prototype.watch = function(watchOptions, handler) {

--- a/lib/ContextModuleFactory.js
+++ b/lib/ContextModuleFactory.js
@@ -16,6 +16,8 @@ function ContextModuleFactory(resolvers) {
 module.exports = ContextModuleFactory;
 
 ContextModuleFactory.prototype = Object.create(Tapable.prototype);
+ContextModuleFactory.prototype.constructor = ContextModuleFactory;
+
 ContextModuleFactory.prototype.create = function(context, dependency, callback) {
 	this.applyPluginsAsyncWaterfall("before-resolve", {
 		context: context,

--- a/lib/DllModuleFactory.js
+++ b/lib/DllModuleFactory.js
@@ -11,6 +11,8 @@ function DllModuleFactory() {
 module.exports = DllModuleFactory;
 
 DllModuleFactory.prototype = Object.create(Tapable.prototype);
+DllModuleFactory.prototype.constructor = DllModuleFactory;
+
 DllModuleFactory.prototype.create = function(context, dependency, callback) {
 	callback(null, new DllModule(context, dependency.dependencies, dependency.name, dependency.type));
 };

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -88,6 +88,7 @@ function MultiCompiler(compilers) {
 module.exports = MultiCompiler;
 
 MultiCompiler.prototype = Object.create(Tapable.prototype);
+MultiCompiler.prototype.constructor = MultiCompiler;
 
 MultiCompiler.prototype.watch = function(watchDelay, handler) {
 	var watchings = this.compilers.map(function(compiler) {

--- a/lib/MultiModuleFactory.js
+++ b/lib/MultiModuleFactory.js
@@ -11,6 +11,8 @@ function MultiModuleFactory() {
 module.exports = MultiModuleFactory;
 
 MultiModuleFactory.prototype = Object.create(Tapable.prototype);
+MultiModuleFactory.prototype.constructor = MultiModuleFactory;
+
 MultiModuleFactory.prototype.create = function(context, dependency, callback) {
 	callback(null, new MultiModule(context, dependency.dependencies, dependency.name));
 };

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -133,6 +133,8 @@ function NormalModuleFactory(context, resolvers, parser, options) {
 module.exports = NormalModuleFactory;
 
 NormalModuleFactory.prototype = Object.create(Tapable.prototype);
+NormalModuleFactory.prototype.constructor = NormalModuleFactory;
+
 NormalModuleFactory.prototype.create = function(context, dependency, callback) {
 	context = context || this.context;
 	var request = dependency.request;

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -16,6 +16,8 @@ module.exports = Parser;
 // Syntax: https://developer.mozilla.org/en/SpiderMonkey/Parser_API
 
 Parser.prototype = Object.create(Tapable.prototype);
+Parser.prototype.constructor = Parser;
+
 Parser.prototype.initializeEvaluating = function() {
 	function joinRanges(startRange, endRange) {
 		if(!endRange) return startRange;

--- a/lib/Template.js
+++ b/lib/Template.js
@@ -21,6 +21,7 @@ Template.toIdentifier = function(str) {
 };
 
 Template.prototype = Object.create(Tapable.prototype);
+Template.prototype.constructor = Template;
 
 Template.prototype.indent = function indent(str) {
 	if(Array.isArray(str)) {


### PR DESCRIPTION
At the moment any subclass that inherits from Tapable is reported as Tapable rather than the subclass itself and this makes it hard to debug the code. Here is an example setup that demonstrates the problem:

```javascript
function Tapable() {}

function Compiler() {
  Tapable.call(this);
}
Compiler.prototype = Object.create(Tapable.prototype);
```

Now, if we ask an instance of Compiler what its constructor is, then we will get `Tapable` rather than `Compiler`:
```javascript
new Compiler().constructor; // function Tapable() { ... }
```

The problem stems from overwriting Compiler's prototype object and the way to fix is to set the constructor manually:
```javascript
Compiler.prototype.constructor = Compiler;

new Compiler().constructor; // function Compiler() { ... }
```

By having the correct information available it will be easier to tell which Tapable subclass is being handled at any point during execution.
