### PR TITLE
Fix bug in Compiler where watchOptions.poll is not passed along.

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -23,7 +23,7 @@ function Watching(compiler, watchOptions, handler) {
 			aggregateTimeout: watchOptions
 		};
 	} else if(watchOptions && typeof watchOptions === "object") {
-		this.watchOptions = Object.create(watchOptions);
+		this.watchOptions = Object.assign({}, watchOptions);
 	} else {
 		this.watchOptions = {};
 	}


### PR DESCRIPTION
Fixes webpack/webpack#1354

> At https://github.com/webpack/webpack/blob/master/lib/Compiler.js#L26 it should use `Object.assign`, not `Object.create`.

> `Object.create` is for creating new objects with a prototype...

> Because of this `poll:true` cannot be set in `webpack.options` under `watchOptions`.