### PR TITLE
define call should include empty dependencies list

### DIFF
--- a/lib/UmdMainTemplatePlugin.js
+++ b/lib/UmdMainTemplatePlugin.js
@@ -105,7 +105,7 @@ UmdMainTemplatePlugin.prototype.apply = function(compilation) {
 			"	else if(typeof define === 'function' && define.amd)\n" +
 			(requiredExternals.length > 0 ?
 				"		define(" + externalsDepsArray(requiredExternals) + ", " + amdFactory + ");\n" :
-				"		define(" + amdFactory + ");\n"
+				"		define([], " + amdFactory + ");\n"
 			) +
 			(this.name ?
 				"	else if(typeof exports === 'object')\n" +


### PR DESCRIPTION
see: https://github.com/umdjs/umd/pull/34

> Without this, the factory may be scanned for additional dependencies matching the literal string require("module-id"), which is not correct. See https://github.com/amdjs/amdjs-api/wiki/AMD#simplified-commonjs-wrapping-.