### PR TITLE
Provide installedChunks to external world

### DIFF
--- a/lib/MainTemplate.js
+++ b/lib/MainTemplate.js
@@ -76,6 +76,10 @@ function MainTemplate(outputOptions) {
 			buf.push(this.requireFn + ".e = function requireEnsure(chunkId, callback) {");
 			buf.push(this.indent(this.applyPluginsWaterfall("require-ensure", "throw new Error('Not chunk loading available');", chunk, hash, "chunkId")));
 			buf.push("};");
+
+			buf.push("");
+			buf.push("// expose the chunks object");
+			buf.push(this.requireFn + ".s = installedChunks;");
 		}
 		buf.push("");
 		buf.push("// expose the modules object (__webpack_modules__)");

--- a/test/statsCases/chunks/expected.txt
+++ b/test/statsCases/chunks/expected.txt
@@ -1,7 +1,7 @@
 Hash: 27b51279f30c19c26769
 Time: Xms
       Asset       Size  Chunks             Chunk Names
-  bundle.js    3.83 kB       0  [emitted]  main
+  bundle.js    3.92 kB       0  [emitted]  main
 1.bundle.js  159 bytes       1  [emitted]  
 2.bundle.js  101 bytes       2  [emitted]  
 3.bundle.js  180 bytes       3  [emitted]  

--- a/test/statsCases/preset-verbose/expected.txt
+++ b/test/statsCases/preset-verbose/expected.txt
@@ -1,7 +1,7 @@
 Hash: 27b51279f30c19c26769
 Time: Xms
       Asset       Size  Chunks             Chunk Names
-  bundle.js    3.83 kB       0  [emitted]  main
+  bundle.js    3.92 kB       0  [emitted]  main
 1.bundle.js  159 bytes       1  [emitted]  
 2.bundle.js  101 bytes       2  [emitted]  
 3.bundle.js  180 bytes       3  [emitted]  


### PR DESCRIPTION
This will allow loader such this https://github.com/NekR/async-module-loader to more properly handle chunks dependencies loading. Right now, after loading fail callbacks are not cleared and possibly may make memory leaks.

I understand that webpack-2 is coming soon, but it's not clear how soon. Plus I still cannot understand if it will be possible to user second version without System.js or Promises. Anyway, I think people will stick with first version for quite some time yet, so this might be a good change.

If you are okay with this update, then I will write tests to cover this. Thanks.