### PR TITLE
Name AMD module in UMD target if library is set

### DIFF
--- a/lib/LibraryTemplatePlugin.js
+++ b/lib/LibraryTemplatePlugin.js
@@ -22,9 +22,10 @@ function accessorAccess(base, accessor, joinWith) {
 	}).join(joinWith || "; ");
 }
 
-function LibraryTemplatePlugin(name, target) {
+function LibraryTemplatePlugin(name, target, umdNamedDefine) {
 	this.name = name;
 	this.target = target;
+	this.umdNamedDefine = umdNamedDefine;
 }
 module.exports = LibraryTemplatePlugin;
 LibraryTemplatePlugin.prototype.apply = function(compiler) {
@@ -60,7 +61,10 @@ LibraryTemplatePlugin.prototype.apply = function(compiler) {
 			case "umd":
 			case "umd2":
 				var UmdMainTemplatePlugin = require("./UmdMainTemplatePlugin");
-				compilation.apply(new UmdMainTemplatePlugin(this.name, this.target === "umd2"));
+				compilation.apply(new UmdMainTemplatePlugin(this.name, {
+					optionalAmdExternalAsGlobal: this.target === "umd2",
+					namedDefine: this.umdNamedDefine
+				}));
 				break;
 			case "jsonp":
 				var JsonpExportMainTemplatePlugin = require("./JsonpExportMainTemplatePlugin");

--- a/lib/UmdMainTemplatePlugin.js
+++ b/lib/UmdMainTemplatePlugin.js
@@ -20,9 +20,10 @@ function accessorAccess(base, accessor) {
 	}).join(", ");
 }
 
-function UmdMainTemplatePlugin(name, optionalAmdExternalAsGlobal) {
+function UmdMainTemplatePlugin(name, options) {
 	this.name = name;
-	this.optionalAmdExternalAsGlobal = optionalAmdExternalAsGlobal;
+	this.optionalAmdExternalAsGlobal = options.optionalAmdExternalAsGlobal;
+	this.namedDefine = options.namedDefine;
 }
 module.exports = UmdMainTemplatePlugin;
 UmdMainTemplatePlugin.prototype.apply = function(compilation) {
@@ -110,11 +111,11 @@ UmdMainTemplatePlugin.prototype.apply = function(compilation) {
 			"		module.exports = factory(" + externalsRequireArray("commonjs2") + ");\n" +
 			"	else if(typeof define === 'function' && define.amd)\n" +
 			(requiredExternals.length > 0 ?
-				(this.name ?
+				(this.name && this.namedDefine === true ?
 					"		define(" + libraryName(this.name) + ", " + externalsDepsArray(requiredExternals) + ", " + amdFactory + ");\n" :
 					"		define(" + externalsDepsArray(requiredExternals) + ", " + amdFactory + ");\n"
 				) :
-				(this.name ?
+				(this.name && this.namedDefine === true ?
 					"		define(" + libraryName(this.name) + ", [], " + amdFactory + ");\n" :
 					"		define([], " + amdFactory + ");\n"
 				)

--- a/lib/UmdMainTemplatePlugin.js
+++ b/lib/UmdMainTemplatePlugin.js
@@ -87,6 +87,11 @@ UmdMainTemplatePlugin.prototype.apply = function(compilation) {
 				return "__WEBPACK_EXTERNAL_MODULE_" + m.id + "__";
 			}).join(", ");
 		}
+
+		function libraryName(library) {
+			return JSON.stringify(replaceKeys([].concat(library).pop()));
+		}
+
 		if(optionalExternals.length > 0) {
 			var amdFactory = "function webpackLoadOptionalExternalModuleAmd(" + externalsArguments(requiredExternals) + ") {\n" +
 				"			return factory(" + (
@@ -98,18 +103,25 @@ UmdMainTemplatePlugin.prototype.apply = function(compilation) {
 		} else {
 			var amdFactory = "factory";
 		}
+
 		return new ConcatSource(new OriginalSource(
 			"(function webpackUniversalModuleDefinition(root, factory) {\n" +
 			"	if(typeof exports === 'object' && typeof module === 'object')\n" +
 			"		module.exports = factory(" + externalsRequireArray("commonjs2") + ");\n" +
 			"	else if(typeof define === 'function' && define.amd)\n" +
 			(requiredExternals.length > 0 ?
-				"		define(" + externalsDepsArray(requiredExternals) + ", " + amdFactory + ");\n" :
-				"		define([], " + amdFactory + ");\n"
+				(this.name ?
+					"		define(" + libraryName(this.name) + ", " + externalsDepsArray(requiredExternals) + ", " + amdFactory + ");\n" :
+					"		define(" + externalsDepsArray(requiredExternals) + ", " + amdFactory + ");\n"
+				) :
+				(this.name ?
+					"		define(" + libraryName(this.name) + ", [], " + amdFactory + ");\n" :
+					"		define([], " + amdFactory + ");\n"
+				)
 			) +
 			(this.name ?
 				"	else if(typeof exports === 'object')\n" +
-				"		exports[" + JSON.stringify(replaceKeys([].concat(this.name).pop())) + "] = factory(" + externalsRequireArray("commonjs") + ");\n" +
+				"		exports[" + libraryName(this.name) + "] = factory(" + externalsRequireArray("commonjs") + ");\n" +
 				"	else\n" +
 				"		" + replaceKeys(accessorAccess("root", this.name)) + " = factory(" + externalsRootArray(externals) + ");\n" :
 				"	else {\n" +

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -152,7 +152,7 @@ WebpackOptionsApply.prototype.process = function(options, compiler) {
 	}
 	if(options.output.library || options.output.libraryTarget !== "var") {
 		var LibraryTemplatePlugin = require("./LibraryTemplatePlugin");
-		compiler.apply(new LibraryTemplatePlugin(options.output.library, options.output.libraryTarget));
+		compiler.apply(new LibraryTemplatePlugin(options.output.library, options.output.libraryTarget, options.output.umdNamedDefine));
 	}
 	if(options.externals) {
 		var ExternalsPlugin = require("./ExternalsPlugin");

--- a/test/configCases/target/umd-named-define/index.js
+++ b/test/configCases/target/umd-named-define/index.js
@@ -1,0 +1,10 @@
+it("should run", function() {
+
+});
+
+it("should name define", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+
+	source.should.containEql("define(\"NamedLibrary\",");
+});

--- a/test/configCases/target/umd-named-define/webpack.config.js
+++ b/test/configCases/target/umd-named-define/webpack.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	output: {
+		library: "NamedLibrary",
+		libraryTarget: "umd",
+		umdNamedDefine: true
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};


### PR DESCRIPTION
In the AMD target the AMD module gets named, but in the UMD target its
is always anonymous, even if `library` is set in the config.

This patch names the AMD module if `library` is set.

See the discussion in the referenced issue to see the background for
this change.

If its a multi part library it uses the last key in the same was as it
does with the exports hash part of the UMD declaration. Is this the best
solution?

Resolves webpack/issues/989