### PR TITLE
Add native-image plugin to electron target

### DIFF
--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -137,7 +137,8 @@ WebpackOptionsApply.prototype.process = function(options, compiler) {
 						"clipboard",
 						"crash-reporter",
 						"screen",
-						"shell"
+						"shell",
+						"native-image"
 					]),
 					new LoaderTargetPlugin(options.target)
 				);


### PR DESCRIPTION
Currently, doing `require('browser-image')` in an Electron app fails. Fortunately, this was really easy to fix.

https://github.com/atom/electron/blob/master/docs/api/native-image.md