### PR TITLE
Add -c config alias to the CLI

### DIFF
--- a/bin/config-optimist.js
+++ b/bin/config-optimist.js
@@ -1,7 +1,7 @@
 module.exports = function(optimist) {
 	optimist
 		.boolean("help").alias("help", "h").alias("help", "?").describe("help")
-		.string("config").describe("config")
+		.string("config").alias("config", "c").describe("config")
 		.string("context").describe("context")
 		.string("entry").describe("entry")
 		.string("module-bind").describe("module-bind")


### PR DESCRIPTION
If you have multiple webpack configuration files then each of your scripts ends up requiring that you specify a config file, so having a shorthand for it is nice and convenient.