### PR TITLE
Add dedupeInstance option to DedupePlugin.

### DIFF
--- a/lib/optimize/DedupePlugin.js
+++ b/lib/optimize/DedupePlugin.js
@@ -5,10 +5,15 @@
 var ConcatSource = require("webpack-core/lib/ConcatSource");
 var TemplateArgumentDependency = require("../dependencies/TemplateArgumentDependency");
 
-function DedupePlugin() {}
+function DedupePlugin(options) {
+	this.options = options;
+}
 module.exports = DedupePlugin;
 
 DedupePlugin.prototype.apply = function(compiler) {
+
+	var options = this.options;
+
 	compiler.plugin("compilation", function(compilation) {
 
 		compilation.dependencyTemplates.set(TemplateArgumentDependency, new TemplateArgumentDependency.Template());
@@ -168,7 +173,19 @@ DedupePlugin.prototype.apply = function(compiler) {
 					"break;"
 				]),
 				"default:",
-				this.indent([
+				this.indent(options && options.dedupeInstance ? [
+					"// Module is a copy of another module",
+					"modules[" + varModuleId + "] = (function(_a) {",
+					this.indent([
+						"return function(a, b, c) {",
+						this.indent([
+							"a.exports = c(_a);"
+						]),
+						"};"
+					]),
+					"}(_m));",
+					"break;"
+				] : [
 					"// Module is a copy of another module",
 					"modules[" + varModuleId + "] = modules[_m];",
 					"break;"
@@ -206,7 +223,19 @@ DedupePlugin.prototype.apply = function(compiler) {
 							"break;"
 						]),
 						"default:",
-						this.indent([
+						this.indent(options && options.dedupeInstance ? [
+							"// Module is a copy of another module",
+							"modules[i] = (function(_a) {",
+							this.indent([
+								"return function(a, b, c) {",
+								this.indent([
+									"a.exports = c(_a);"
+								]),
+								"};"
+							]),
+							"}(modules[i]));",
+							"break;"
+						] : [
 							"// Module is a copy of another module",
 							"modules[i] = modules[modules[i]];",
 							"break;"

--- a/test/configCases/dedupe/dedupe-instance/a/dedupe.js
+++ b/test/configCases/dedupe/dedupe-instance/a/dedupe.js
@@ -1,0 +1,4 @@
+var Foo = function() {
+};
+
+module.exports = Foo;

--- a/test/configCases/dedupe/dedupe-instance/b/dedupe.js
+++ b/test/configCases/dedupe/dedupe-instance/b/dedupe.js
@@ -1,0 +1,4 @@
+var Foo = function() {
+};
+
+module.exports = Foo;

--- a/test/configCases/dedupe/dedupe-instance/index.js
+++ b/test/configCases/dedupe/dedupe-instance/index.js
@@ -1,0 +1,6 @@
+it("should load only one instance with dedupeInstance option set", function (done) {
+	require(["./a/dedupe", "./b/dedupe"], function(a, b) {
+        a.should.be.eql(b);
+		done();
+	})
+});

--- a/test/configCases/dedupe/dedupe-instance/webpack.config.js
+++ b/test/configCases/dedupe/dedupe-instance/webpack.config.js
@@ -1,0 +1,6 @@
+var DedupePlugin = require("../../../../lib/optimize/DedupePlugin");
+module.exports = {
+	plugins: [
+		new DedupePlugin({ dedupeInstance: true }),
+	]
+};


### PR DESCRIPTION
When I use the DedupePlugin to optimize bundled output, I am expecting duplicated modules are completed removed as if there were only one copy in the bundle. However, I found it was not the case. 

In the following example:
```
exports.ids = [1];
exports.modules = [
/* 0 */,
/* 1 */
/***/ function(module, exports) {

	var Foo = function() {
	};

	module.exports = Foo;

/***/ },
/* 2 */
1
];;
```
Module 1 defines a simple class _Foo_, and module 2 was a duplicate of module 1. When I require module 2 in some other place, I thought I would get the same class definition _Foo_, but in fact, I got two instances of _Foo_ because module 1 and module 2 are initialized separately, and as a result ```require(1) !== require(2)```. When I want to update the class definition in another module with ```var Foo = require(1); Foo.prototype.bar = function() {}```, I am in trouble because some instances of _Foo_ get the new method and some instances not.

I thought this was a bug at first, and simply changed the implementation of DedupePlugin. However, I notice this seems to be by design (although I am not clear why) as there are test cases explicitly verifying ```require(1) !== require(2)```. I would like to at least add an option to the plugin. 