### PR TITLE
Reset uglify's base54 counters for each file

### DIFF
--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -78,7 +78,7 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 							warnings.push(warning);
 						};
 					}
-          uglify.base54.reset();
+					uglify.base54.reset();
 					var ast = uglify.parse(input, {
 						filename: file
 					});

--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -78,6 +78,7 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 							warnings.push(warning);
 						};
 					}
+          uglify.base54.reset();
 					var ast = uglify.parse(input, {
 						filename: file
 					});


### PR DESCRIPTION
After some investigation of #1486, I came across some non-deterministic behavior from UglifyJS. That issue is well presented in https://github.com/mishoo/UglifyJS2/issues/219 and explained in https://github.com/mishoo/UglifyJS2/issues/229, and ultimately fixed via https://github.com/mishoo/UglifyJS2/commit/d0689c81bb859ac78a966c526073dcc50a8ccde9. Because UglifyJsPlugin duplicates minification logic, it hasn't picked up this change.

I'm unable to create this issue with a simple example, but within a larger project, I was able to verify this change fixes the issue, at least across ~10 builds. I think this is relatively safe to add regardless.