### PR TITLE
Allow hot module replacement in "webworker" targets

### DIFF
--- a/hot/dev-server.js
+++ b/hot/dev-server.js
@@ -4,7 +4,7 @@
 */
 /*globals window __webpack_hash__ */
 if(module.hot) {
-	var lastData;
+	var lastHash;
 	var upToDate = function upToDate() {
 		return lastData.indexOf(__webpack_hash__) >= 0;
 	};
@@ -43,18 +43,12 @@ if(module.hot) {
 
 		});
 	};
-	var addEventListener = window.addEventListener ? function(eventName, listener) {
-		window.addEventListener(eventName, listener, false);
-	} : function(eventName, listener) {
-		window.attachEvent("on" + eventName, listener);
-	};
-	addEventListener("message", function(event) {
-		if(typeof event.data === "string" && event.data.indexOf("webpackHotUpdate") === 0) {
-			lastData = event.data;
-			if(!upToDate() && module.hot.status() === "idle") {
-				console.log("[HMR] Checking for updates on the server...");
-				check();
-			}
+	var hotEmitter = require("./emitter");
+	hotEmitter.on("webpackHotUpdate", function(currentHash) {
+		lastHash = currentHash;
+		if(!upToDate() && module.hot.status() === "idle") {
+			console.log("[HMR] Checking for updates on the server...");
+			check();
 		}
 	});
 	console.log("[HMR] Waiting for update signal from WDS...");

--- a/hot/emitter.js
+++ b/hot/emitter.js
@@ -1,0 +1,2 @@
+var EventEmitter = require("events");
+module.exports = new EventEmitter();

--- a/hot/only-dev-server.js
+++ b/hot/only-dev-server.js
@@ -4,7 +4,7 @@
 */
 /*globals window __webpack_hash__ */
 if(module.hot) {
-	var lastData;
+	var lastHash;
 	var upToDate = function upToDate() {
 		return lastData.indexOf(__webpack_hash__) >= 0;
 	};
@@ -57,18 +57,12 @@ if(module.hot) {
 			});
 		});
 	};
-	var addEventListener = window.addEventListener ? function(eventName, listener) {
-		window.addEventListener(eventName, listener, false);
-	} : function(eventName, listener) {
-		window.attachEvent("on" + eventName, listener);
-	};
-	addEventListener("message", function(event) {
-		if(typeof event.data === "string" && event.data.indexOf("webpackHotUpdate") === 0) {
-			lastData = event.data;
-			if(!upToDate() && module.hot.status() === "idle") {
-				console.log("[HMR] Checking for updates on the server...");
-				check();
-			}
+	var hotEmitter = require("./emitter");
+	hotEmitter.on("webpackHotUpdate", function(currentHash) {
+		lastHash = currentHash;
+		if(!upToDate() && module.hot.status() === "idle") {
+			console.log("[HMR] Checking for updates on the server...");
+			check();
 		}
 	});
 	console.log("[HMR] Waiting for update signal from WDS...");

--- a/lib/webworker/WebWorkerHotUpdateChunkTemplatePlugin.js
+++ b/lib/webworker/WebWorkerHotUpdateChunkTemplatePlugin.js
@@ -1,0 +1,26 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var ConcatSource = require("webpack-core/lib/ConcatSource");
+var Template = require("../Template");
+
+function WebWorkerHotUpdateChunkTemplatePlugin() {}
+module.exports = WebWorkerHotUpdateChunkTemplatePlugin;
+
+WebWorkerHotUpdateChunkTemplatePlugin.prototype.apply = function(hotUpdateChunkTemplate) {
+	hotUpdateChunkTemplate.plugin("render", function(modulesSource, modules, hash, id) {
+		var chunkCallbackName = this.outputOptions.hotUpdateFunction || Template.toIdentifier("webpackHotUpdate" + (this.outputOptions.library || ""));
+		var source = new ConcatSource();
+		source.add(chunkCallbackName + "(" + JSON.stringify(id) + ",");
+		source.add(modulesSource);
+		source.add(")");
+		return source;
+	});
+	hotUpdateChunkTemplate.plugin("hash", function(hash) {
+		hash.update("WebWorkerHotUpdateChunkTemplatePlugin");
+		hash.update("3");
+		hash.update(this.outputOptions.hotUpdateFunction + "");
+		hash.update(this.outputOptions.library + "");
+	});
+};

--- a/lib/webworker/WebWorkerMainTemplate.runtime.js
+++ b/lib/webworker/WebWorkerMainTemplate.runtime.js
@@ -1,0 +1,51 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+/*globals hotAddUpdateChunk parentHotUpdateCallback importScripts XMLHttpRequest $require$ $hotChunkFilename$ $hotMainFilename$ */
+module.exports = function() {
+	function webpackHotUpdateCallback(chunkId, moreModules) { // eslint-disable-line no-unused-vars
+		hotAddUpdateChunk(chunkId, moreModules);
+		if(parentHotUpdateCallback) parentHotUpdateCallback(chunkId, moreModules);
+	}
+
+	function hotDownloadUpdateChunk(chunkId) { // eslint-disable-line no-unused-vars
+		importScripts($require$.p + $hotChunkFilename$);
+	}
+
+	function hotDownloadManifest(callback) { // eslint-disable-line no-unused-vars
+		if(typeof XMLHttpRequest === "undefined")
+			return callback(new Error("No browser support"));
+		try {
+			var request = new XMLHttpRequest();
+			var requestPath = $require$.p + $hotMainFilename$;
+			request.open("GET", requestPath, true);
+			request.timeout = 10000;
+			request.send(null);
+		} catch(err) {
+			return callback(err);
+		}
+		request.onreadystatechange = function() {
+			if(request.readyState !== 4) return;
+			if(request.status === 0) {
+				// timeout
+				callback(new Error("Manifest request to " + requestPath + " timed out."));
+			} else if(request.status === 404) {
+				// no update available
+				callback();
+			} else if(request.status !== 200 && request.status !== 304) {
+				// other failure
+				callback(new Error("Manifest request to " + requestPath + " failed."));
+			} else {
+				// success
+				try {
+					var update = JSON.parse(request.responseText);
+				} catch(e) {
+					callback(e);
+					return;
+				}
+				callback(null, update);
+			}
+		};
+	}
+};

--- a/lib/webworker/WebWorkerMainTemplatePlugin.js
+++ b/lib/webworker/WebWorkerMainTemplatePlugin.js
@@ -7,6 +7,7 @@ var Template = require("../Template");
 function WebWorkerMainTemplatePlugin() {}
 module.exports = WebWorkerMainTemplatePlugin;
 
+WebWorkerMainTemplatePlugin.prototype.constructor = WebWorkerMainTemplatePlugin;
 WebWorkerMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 	mainTemplate.plugin("local-vars", function(source, chunk) {
 		if(chunk.chunks.length > 0) {
@@ -65,6 +66,34 @@ WebWorkerMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 			]);
 		}
 		return source;
+	});
+	mainTemplate.plugin("hot-bootstrap", function(source, chunk, hash) {
+		var hotUpdateChunkFilename = this.outputOptions.hotUpdateChunkFilename;
+		var hotUpdateMainFilename = this.outputOptions.hotUpdateMainFilename;
+		var hotUpdateFunction = this.outputOptions.hotUpdateFunction || Template.toIdentifier("webpackHotUpdate" + (this.outputOptions.library || ""));
+		var currentHotUpdateChunkFilename = this.applyPluginsWaterfall("asset-path", JSON.stringify(hotUpdateChunkFilename), {
+			hash: "\" + " + this.renderCurrentHashCode(hash) + " + \"",
+			hashWithLength: function(length) {
+				return "\" + " + this.renderCurrentHashCode(hash, length) + " + \"";
+			}.bind(this),
+			chunk: {
+				id: "\" + chunkId + \""
+			}
+		});
+		var currentHotUpdateMainFilename = this.applyPluginsWaterfall("asset-path", JSON.stringify(hotUpdateMainFilename), {
+			hash: "\" + " + this.renderCurrentHashCode(hash) + " + \"",
+			hashWithLength: function(length) {
+				return "\" + " + this.renderCurrentHashCode(hash, length) + " + \"";
+			}.bind(this)
+		});
+
+		return source + "\n" +
+			"var parentHotUpdateCallback = this[" + JSON.stringify(hotUpdateFunction) + "];\n" +
+			"this[" + JSON.stringify(hotUpdateFunction) + "] = " + Template.getFunctionContent(require("./WebWorkerMainTemplate.runtime.js"))
+			.replace(/\$require\$/g, this.requireFn)
+			.replace(/\$hotMainFilename\$/g, currentHotUpdateMainFilename)
+			.replace(/\$hotChunkFilename\$/g, currentHotUpdateChunkFilename)
+			.replace(/\$hash\$/g, JSON.stringify(hash));
 	});
 	mainTemplate.plugin("hash", function(hash) {
 		hash.update("webworker");

--- a/lib/webworker/WebWorkerTemplatePlugin.js
+++ b/lib/webworker/WebWorkerTemplatePlugin.js
@@ -4,6 +4,7 @@
 */
 var WebWorkerMainTemplatePlugin = require("./WebWorkerMainTemplatePlugin");
 var WebWorkerChunkTemplatePlugin = require("./WebWorkerChunkTemplatePlugin");
+var WebWorkerHotUpdateChunkTemplatePlugin = require("./WebWorkerHotUpdateChunkTemplatePlugin");
 
 function WebWorkerTemplatePlugin() {}
 module.exports = WebWorkerTemplatePlugin;
@@ -11,5 +12,6 @@ WebWorkerTemplatePlugin.prototype.apply = function(compiler) {
 	compiler.plugin("this-compilation", function(compilation) {
 		compilation.mainTemplate.apply(new WebWorkerMainTemplatePlugin());
 		compilation.chunkTemplate.apply(new WebWorkerChunkTemplatePlugin());
+		compilation.hotUpdateChunkTemplate.apply(new WebWorkerHotUpdateChunkTemplatePlugin());
 	});
 };


### PR DESCRIPTION
The changes here allow webpack to hot-replace modules when ["target"](http://webpack.github.io/docs/configuration.html#target) is set to `"webworker"` and the resulting bundle is run inside a web worker.

Summary of changes:
* Add `WebWorkerHotUpdateChunkTemplatePlugin.js`, `WebWorkerMainTemplate.runtime.js`, and amend `WebWorkerMainTemplatePlugin.js` to include the new runtime template. I used the `Jsonp*` modules as the basis for these changes, except the new runtime template now uses [`importScripts`](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts) instead of appending a `<script>` to the document (which is of course unsupported inside a web worker).
* Add an [EventEmitter](https://nodejs.org/api/events.html#events_class_events_eventemitter) `hot/emitter.js` to replace the existing `window.addEventListener` which listened for `"webpackHotUpdate"` events from [`webpack-dev-server/client`](https://github.com/webpack/webpack-dev-server/blob/976512d08af2f109816df437f92d61180155bc7b/client/index.js#L79). This requires webpack-dev-server to use the new EventEmitter to emit `"webpackHotUpdate"` events: https://github.com/webpack/webpack-dev-server/pull/298

Check this out for an example: https://github.com/elliottsj/webpack-worker-hmr-example