### PR TITLE
Fix module of electron target: web-view -> web-frame

### DIFF
--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -133,7 +133,7 @@ WebpackOptionsApply.prototype.process = function(options, compiler) {
 						"protocol",
 						"tray",
 						"remote",
-						"web-view",
+						"web-frame",
 						"clipboard",
 						"crash-reporter",
 						"screen",

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -133,6 +133,7 @@ WebpackOptionsApply.prototype.process = function(options, compiler) {
 						"protocol",
 						"tray",
 						"remote",
+						"web-view",
 						"web-frame",
 						"clipboard",
 						"crash-reporter",


### PR DESCRIPTION
See this [commit](https://github.com/atom/electron/commit/4ccb0cccf39e8831608483bf1d9dc50df2647ff6).

The `web-view` has been renamed to `web-frame`.