### PR TITLE
Removes duplicate aliases

### DIFF
--- a/bin/config-optimist.js
+++ b/bin/config-optimist.js
@@ -1,7 +1,7 @@
 module.exports = function(optimist) {
 	optimist
 		.boolean("help").alias("help", "h").alias("help", "?").describe("help")
-		.string("config").alias("config", "c").describe("config")
+		.string("config").describe("config")
 		.string("context").describe("context")
 		.string("entry").describe("entry")
 		.string("module-bind").describe("module-bind")
@@ -27,7 +27,7 @@ module.exports = function(optimist) {
 		.boolean("watch-stdin").alias("watch-stdin", "stdin").describe("watch which closes when stdin ends")
 		.describe("watch-aggregate-timeout")
 		.describe("watch-poll")
-		.boolean("hot").alias("hot", "h").describe("hot")
+		.boolean("hot").describe("hot")
 		.boolean("debug").describe("debug")
 		.string("devtool").describe("devtool")
 		.boolean("progress").describe("progress")


### PR DESCRIPTION
The `-c` and `-h` aliases were already used by `--colors` and `--help`, respectively. Adding `-c` to `config` doesn't do anything, since it was already defined later and adding `-h` to `hot` broke `help`.

I probably would've left -c for config, as that felt the most natural, but it existed for colors first...