### PR TITLE
Update uglify-js to v2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "optimist": "~0.6.0",
     "supports-color": "^3.1.0",
     "tapable": "~0.1.8",
-    "uglify-js": "~2.4.24",
+    "uglify-js": "~2.5.0",
     "watchpack": "^0.2.1",
     "webpack-core": "~0.6.0"
   },


### PR DESCRIPTION
Fix #1104

There were some issues with Uglify and sourcemaps. They bumped their version of their dependency of  the `source-map` package, and this fixed the issue.

