### PR TITLE
Add -c option shortcut for --config

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -26,6 +26,9 @@ module.exports = function(optimist, argv, convertOptions) {
 		argv["optimize-minimize"] = true;
 		argv["optimize-occurence-order"] = true;
 	}
+	if(argv.c) {
+		argv.config = argv.c;
+	}
 
 	var configPath, ext;
 	var extensions = Object.keys(interpret.extensions).sort(function(a, b) {


### PR DESCRIPTION
This option is specified in the help file (in `webpack/bin/config-optimist.js`) but it isn't actually parsed.  Now it is!