### PR TITLE
Use `interop-require` for loading ES6 configs.

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -3,6 +3,7 @@ var fs = require("fs");
 fs.existsSync = fs.existsSync || path.existsSync;
 var resolve = require("enhanced-resolve");
 var interpret = require("interpret");
+var interopRequire = require("interop-require");
 
 module.exports = function(optimist, argv, convertOptions) {
 
@@ -77,7 +78,7 @@ module.exports = function(optimist, argv, convertOptions) {
 		}
 
 		registerCompiler(interpret.extensions[ext]);
-		options = require(configPath);
+		options = interopRequire(configPath);
 	}
 
 	if(typeof options !== "object" || options === null) {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "clone": "^1.0.2",
     "enhanced-resolve": "~0.9.0",
     "esprima": "^2.5.0",
+    "interop-require": "^1.0.0",
     "interpret": "^0.6.4",
     "loader-utils": "^0.2.11",
     "memory-fs": "~0.2.0",


### PR DESCRIPTION
With the release of `babel@6` the way generated modules work now does NOT set the `module.exports` property; instead it sets `exports.default`. Of course this basically breaks everything trying to `require()` it. This behavior is not changing: https://github.com/babel/babel/issues/2212.

So when using `interpret` and `babel@6` to have your configuration files in ES6 this shim is necessary. C'est la vie.