### PR TITLE
Make RequireResolveContextDependency deduplicable

### DIFF
--- a/lib/dependencies/ContextDependencyTemplateAsId.js
+++ b/lib/dependencies/ContextDependencyTemplateAsId.js
@@ -20,3 +20,12 @@ ContextDependencyTemplateAsId.prototype.apply = function(dep, source, outputOpti
 		source.replace(dep.range[0], dep.range[1] - 1, content);
 	}
 };
+
+ContextDependencyTemplateAsId.prototype.applyAsTemplateArgument = function(name, dep, source, outputOptions, requestShortener) {
+	if(dep.valueRange) {
+		source.replace(dep.valueRange[1], dep.range[1] - 1, ")");
+		source.replace(dep.range[0], dep.valueRange[0] - 1, "__webpack_require__(" + name + ").resolve(" + (typeof dep.prepend === "string" ? JSON.stringify(dep.prepend) : "") + "");
+	} else {
+		source.replace(dep.range[0], dep.range[1] - 1, "__webpack_require__(" + name + ").resolve");
+	}
+};


### PR DESCRIPTION
Hey,

I have little time to debug this, so I'm not even 100% sure it works as expected, but it prevents an error in my project when using Dedupe plugin:

> Template cannot be applied as TemplateArgument: RequireResolveContextDependency

I based this commit on:

https://github.com/webpack/webpack/commit/7b971015fb6a09ae83901097325787384807a837

Could you help with failing test case?
