### PR TITLE
Fix windows cross driver path not found issue

### DIFF
--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -89,7 +89,10 @@ NodeStuffPlugin.prototype.apply = function(compiler) {
 	compiler.parser.plugin("expression module", function() {
 		var moduleJsPath = path.join(__dirname, "..", "buildin", "module.js");
 		if(this.state.module.context) {
-			moduleJsPath = "./" + path.relative(this.state.module.context, moduleJsPath).replace(/\\/g, "/");
+			moduleJsPath = path.relative(this.state.module.context, moduleJsPath);
+            if(!/^[A-Z]:/i.test(moduleJsPath)) {
+                moduleJsPath = "./" + moduleJsPath.replace(/\\/g, "/");
+            }
 		}
 		return ModuleParserHelpers.addParsedVariable(this, "module", "require(" + JSON.stringify(moduleJsPath) + ")(module)");
 	});

--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -90,9 +90,9 @@ NodeStuffPlugin.prototype.apply = function(compiler) {
 		var moduleJsPath = path.join(__dirname, "..", "buildin", "module.js");
 		if(this.state.module.context) {
 			moduleJsPath = path.relative(this.state.module.context, moduleJsPath);
-            if(!/^[A-Z]:/i.test(moduleJsPath)) {
-                moduleJsPath = "./" + moduleJsPath.replace(/\\/g, "/");
-            }
+			if(!/^[A-Z]:/i.test(moduleJsPath)) {
+				moduleJsPath = "./" + moduleJsPath.replace(/\\/g, "/");
+			}
 		}
 		return ModuleParserHelpers.addParsedVariable(this, "module", "require(" + JSON.stringify(moduleJsPath) + ")(module)");
 	});


### PR DESCRIPTION
If `context` and `moduleJsPath` were not in the same driver, an error like `Cannot resolve "file" or "directory" ./C:/xxx` will be throw.

So, when moduleJsPath is an absolute windows path, just keep it absolute.