### PR TITLE
Fix unsafeCache default option

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -50,8 +50,8 @@ function WebpackOptionsDefaulter() {
 	this.set("node.__filename", "mock");
 	this.set("node.__dirname", "mock");
 
-	this.set("resolve.fastUnsafe", []);
-	this.set("resolveLoader.fastUnsafe", []);
+	this.set("resolve.unsafeCache", []);
+	this.set("resolveLoader.unsafeCache", []);
 
 	this.set("resolve.alias", {});
 	this.set("resolveLoader.alias", {});


### PR DESCRIPTION
The documentation states a default of `[]` for the `unsafeCache`, when in fact there is no default at all.
I'm guessing the `fastUnsafe` option actually should be `unsafeCache` as I can't find any other occurance of `fastUnsafe` in the whole project.