### PR TITLE
Fix hot loader compatibility with Java8 Nashorn

### DIFF
--- a/lib/JsonpMainTemplate.runtime.js
+++ b/lib/JsonpMainTemplate.runtime.js
@@ -7,7 +7,7 @@ module.exports = function() {
 	function webpackHotUpdateCallback(chunkId, moreModules) { // eslint-disable-line no-unused-vars
 		hotAddUpdateChunk(chunkId, moreModules);
 		if(parentHotUpdateCallback) parentHotUpdateCallback(chunkId, moreModules);
-	}
+	} //$semicolon
 
 	function hotDownloadUpdateChunk(chunkId) { // eslint-disable-line no-unused-vars
 		var head = document.getElementsByTagName("head")[0];

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -160,6 +160,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 		return source + "\n" +
 			"var parentHotUpdateCallback = this[" + JSON.stringify(hotUpdateFunction) + "];\n" +
 			"this[" + JSON.stringify(hotUpdateFunction) + "] = " + Template.getFunctionContent(require("./JsonpMainTemplate.runtime.js"))
+			.replace(/\/\/\$semicolon/g, ";")
 			.replace(/\$require\$/g, this.requireFn)
 			.replace(/\$hotMainFilename\$/g, currentHotUpdateMainFilename)
 			.replace(/\$hotChunkFilename\$/g, currentHotUpdateChunkFilename)

--- a/lib/webworker/WebWorkerMainTemplate.runtime.js
+++ b/lib/webworker/WebWorkerMainTemplate.runtime.js
@@ -7,7 +7,7 @@ module.exports = function() {
 	function webpackHotUpdateCallback(chunkId, moreModules) { // eslint-disable-line no-unused-vars
 		hotAddUpdateChunk(chunkId, moreModules);
 		if(parentHotUpdateCallback) parentHotUpdateCallback(chunkId, moreModules);
-	}
+	} //$semicolon
 
 	function hotDownloadUpdateChunk(chunkId) { // eslint-disable-line no-unused-vars
 		importScripts($require$.p + $hotChunkFilename$);

--- a/lib/webworker/WebWorkerMainTemplatePlugin.js
+++ b/lib/webworker/WebWorkerMainTemplatePlugin.js
@@ -90,6 +90,7 @@ WebWorkerMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 		return source + "\n" +
 			"var parentHotUpdateCallback = this[" + JSON.stringify(hotUpdateFunction) + "];\n" +
 			"this[" + JSON.stringify(hotUpdateFunction) + "] = " + Template.getFunctionContent(require("./WebWorkerMainTemplate.runtime.js"))
+			.replace(/\/\/\$semicolon/g, ";")
 			.replace(/\$require\$/g, this.requireFn)
 			.replace(/\$hotMainFilename\$/g, currentHotUpdateMainFilename)
 			.replace(/\$hotChunkFilename\$/g, currentHotUpdateChunkFilename)


### PR DESCRIPTION
The way that the hot loader is included in a bundle breaks in Java 8's
Nashorn engine, because of a missing semicolon. This change introduces
a placeholder value that can be correctly substituted when building
a bundle, but is otherwise inert.

Note that I don't particularly like this change, so if there's a better
fix, I'd like to hear about it.