### PR TITLE
JS API: ProgressPlugin default handler

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -382,52 +382,7 @@ module.exports = function(optimist, argv, convertOptions) {
 		ifBooleanArg("progress", function() {
 			var ProgressPlugin = require("../lib/ProgressPlugin");
 			ensureArray(options, "plugins");
-			var chars = 0,
-				lastState, lastStateTime;
-			options.plugins.push(new ProgressPlugin(function(percentage, msg) {
-				var state = msg;
-				if(percentage < 1) {
-					percentage = Math.floor(percentage * 100);
-					msg = percentage + "% " + msg;
-					if(percentage < 100) {
-						msg = " " + msg;
-					}
-					if(percentage < 10) {
-						msg = " " + msg;
-					}
-				}
-				if(options.profile) {
-					state = state.replace(/^\d+\/\d+\s+/, "");
-					if(percentage === 0) {
-						lastState = null;
-						lastStateTime = +new Date();
-					} else if(state !== lastState || percentage === 1) {
-						var now = +new Date();
-						if(lastState) {
-							var stateMsg = (now - lastStateTime) + "ms " + lastState;
-							goToLineStart(stateMsg);
-							process.stderr.write(stateMsg + "\n");
-							chars = 0;
-						}
-						lastState = state;
-						lastStateTime = now;
-					}
-				}
-				goToLineStart(msg);
-				process.stderr.write(msg);
-			}));
-
-			function goToLineStart(nextMessage) {
-				var str = "";
-				for(; chars > nextMessage.length; chars--) {
-					str += "\b \b";
-				}
-				chars = nextMessage.length;
-				for(var i = 0; i < chars; i++) {
-					str += "\b";
-				}
-				if(str) process.stderr.write(str);
-			}
+			options.plugins.push(new ProgressPlugin());
 		});
 
 		ifArg("devtool", function(value) {

--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -8,7 +8,7 @@ function ProgressPlugin(handler) {
 module.exports = ProgressPlugin;
 
 ProgressPlugin.prototype.apply = function(compiler) {
-	var handler = this.handler;
+	var handler = this.handler || defaultHandler;
 	if(compiler.compilers) {
 		var states = new Array(compiler.compilers.length);
 		compiler.compilers.forEach(function(compiler, idx) {
@@ -76,5 +76,54 @@ ProgressPlugin.prototype.apply = function(compiler) {
 		compiler.plugin("done", function() {
 			handler(1, "");
 		});
+	}
+
+	var chars = 0,
+		lastState, lastStateTime;
+
+	function defaultHandler(percentage, msg) {
+		var state = msg;
+
+		function goToLineStart(nextMessage) {
+			var str = "";
+			for(; chars > nextMessage.length; chars--) {
+				str += "\b \b";
+			}
+			chars = nextMessage.length;
+			for(var i = 0; i < chars; i++) {
+				str += "\b";
+			}
+			if(str) process.stderr.write(str);
+		}
+
+		if(percentage < 1) {
+			percentage = Math.floor(percentage * 100);
+			msg = percentage + "% " + msg;
+			if(percentage < 100) {
+				msg = " " + msg;
+			}
+			if(percentage < 10) {
+				msg = " " + msg;
+			}
+		}
+		if(compiler.options.profile) {
+			state = state.replace(/^\d+\/\d+\s+/, "");
+			if(percentage === 0) {
+				lastState = null;
+				lastStateTime = +new Date();
+			} else if(state !== lastState || percentage === 1) {
+				var now = +new Date();
+				if(lastState) {
+					var stateMsg = (now - lastStateTime) + "ms " + lastState;
+					goToLineStart(stateMsg);
+					process.stderr.write(stateMsg + "\n");
+					chars = 0;
+				}
+				lastState = state;
+				lastStateTime = now;
+			}
+		}
+		goToLineStart(msg);
+		process.stderr.write(msg);
 	}
 };


### PR DESCRIPTION
Default handler moved from CLI args parser to plugin itself.
Now you can use ProgressPlugin in JS API without specifying handler.

Resolves webpack/webpack#1000