### PR TITLE
Fix Windows filename backslash incompatibility

### DIFF
--- a/lib/RequestShortener.js
+++ b/lib/RequestShortener.js
@@ -5,6 +5,7 @@
 var path = require("path");
 
 function RequestShortener(directory) {
+	directory = directory.replace(/\\/g, "/");
 	var parentDirectory = path.dirname(directory);
 	if(/[\/\\]$/.test(directory)) directory = directory.substr(0, directory.length - 1);
 	if(directory) {
@@ -23,7 +24,7 @@ function RequestShortener(directory) {
 	}
 
 	if(__dirname.length >= 2) {
-		var buildins = path.join(__dirname, "..");
+		var buildins = path.join(__dirname, "..").replace(/\\/g, "/");
 		var buildinsAsModule = currentDirectoryRegExp && currentDirectoryRegExp.test(buildins);
 		var buildinsRegExp = buildins.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
 		buildinsRegExp = new RegExp("^" + buildinsRegExp + "|(!)" + buildinsRegExp, "g");
@@ -40,6 +41,7 @@ module.exports = RequestShortener;
 RequestShortener.prototype.shorten = function(request) {
 	if(!request)
 		return request;
+	request = request.replace(/\\/g, "/");
 	if(this.buildinsAsModule && this.buildinsRegExp)
 		request = request.replace(this.buildinsRegExp, "!(webpack)");
 	if(this.currentDirectoryRegExp)
@@ -48,7 +50,6 @@ RequestShortener.prototype.shorten = function(request) {
 		request = request.replace(this.parentDirectoryRegExp, "!..");
 	if(!this.buildinsAsModule && this.buildinsRegExp)
 		request = request.replace(this.buildinsRegExp, "!(webpack)");
-	request = request.replace(/\\/g, "/");
 	request = request.replace(this.nodeModulesRegExp, "/~/");
 	request = request.replace(this.indexJsRegExp, "$1");
 	return request.replace(/^!|!$/, "");


### PR DESCRIPTION
With some loaders (specifically with babel) under Windows the file names
in the source map already come converted to forward slashes. This is
incompatible with RequestShortener so that the source map paths are not
shortened to a relative path. This change makes RequestShortener tolerant
to such cases while preserving existing behaviour.

Fixes #1770