### PR TITLE
Use the interface of compilation.preparedChunks also for compilation.entries

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -418,7 +418,10 @@ Compilation.prototype.addEntry = function process(context, entry, name, callback
 	this._addModuleChain(context, entry, function(module) {
 
 		entry.module = module;
-		this.entries.push(module);
+		this.entries.push({
+			name: name,
+			module: module
+		});
 		module.issuer = null;
 		module.entry = true;
 


### PR DESCRIPTION
_Use the interface of compilation.preparedChunks also for compilation.entries to allow plugins and loaders to get the entry name before a chunk is added to preparedChunks_

Hi,
this pull request allows plugins and loaders to check if a `NormalModule` is an entry point of this compilation and get that entry points name **before** it is added to `preparedChunks`.

``` js
this.entries.push({
  name: name,
  module: module
});
```

This **IS** an **API change** - however all tests pass\* and I couldn't find any place which is using `compilation.entries`. Third party code might use this information however the migration path is a simple map function: `compilation.entries.map(function(entry){return entry.module}});`.

\* _the i18n module is broken but this was also the case before changing the code_

The interface is the same as `compilation.preparedChunks`:
https://github.com/webpack/webpack/blob/3201dc333d8863ff752d6ab9f62d9d6bb752106a/lib/Compilation.js#L431-L434

``` js
this.preparedChunks.push({
  name: name,
  module: module
});
```

Please let me know what you think
