### PR TITLE
fix eval-source-map failing when source ends with comment

### DIFF
--- a/lib/EvalDevToolModuleTemplatePlugin.js
+++ b/lib/EvalDevToolModuleTemplatePlugin.js
@@ -6,7 +6,7 @@ var RawSource = require("webpack-sources").RawSource;
 var ModuleFilenameHelpers = require("./ModuleFilenameHelpers");
 
 function EvalDevToolModuleTemplatePlugin(sourceUrlComment, moduleFilenameTemplate) {
-	this.sourceUrlComment = sourceUrlComment || "//# sourceURL=[url]";
+	this.sourceUrlComment = sourceUrlComment || "\n//# sourceURL=[url]";
 	this.moduleFilenameTemplate = moduleFilenameTemplate || "webpack:///[resourcePath]?[loaders]";
 }
 module.exports = EvalDevToolModuleTemplatePlugin;

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -217,9 +217,9 @@ WebpackOptionsApply.prototype.process = function(options, compiler) {
 	} else if(options.devtool && options.devtool.indexOf("eval") >= 0) {
 		var legacy = options.devtool.indexOf("@") >= 0;
 		var modern = options.devtool.indexOf("#") >= 0;
-		var comment = legacy && modern ? "//@ sourceURL=[url]\n//# sourceURL=[url]" :
-			legacy ? "//@ sourceURL=[url]" :
-			modern ? "//# sourceURL=[url]" :
+		var comment = legacy && modern ? "\n//@ sourceURL=[url]\n//# sourceURL=[url]" :
+			legacy ? "\n//@ sourceURL=[url]" :
+			modern ? "\n//# sourceURL=[url]" :
 			null;
 		compiler.apply(new EvalDevToolModulePlugin(comment, options.output.devtoolModuleFilenameTemplate));
 	}


### PR DESCRIPTION
When using `devtool: 'eval-source-map'`, if a source file's last non-empty line is a comment:

``` js
const a = 123
console.log(a)
// test
```

The parser treats it and the source map comment as one single comment and causing the source map to fail. For example, when the above file is loaded with `babel-loader` it ends up showing the log to be from a VM script which is the babel-generated code instead of the source:

<img width="372" alt="screen shot 2015-12-29 at 12 05 03 am" src="https://cloud.githubusercontent.com/assets/499550/12029729/04a5b2ee-adc0-11e5-8126-78dbc97fdf89.png">

Even if the source file contains newlines at end of file, it seems to get trimmed, so adding the newline in the `eval-source-map` plugin seems to be the way to fix it.