### PR TITLE
Common and vendor chunk example

### DIFF
--- a/examples/common-chunk-and-vendor-chunk/README.md
+++ b/examples/common-chunk-and-vendor-chunk/README.md
@@ -1,0 +1,403 @@
+This example shows how to create an explicit vendor chunk as well as a common chunk for code shared among entry points. In this example, we have 3 entry points: `pageA`, `pageB`, and `pageC`. Those entry points share some of the same utility modules, but not others. This configuration will pull out any modules common to at least 2 bundles and place it it the `common` bundle instead, all while keeping the specified vendor libraries in their own bundle by themselves.
+
+To better understand, here are the entry points and which utility modules they depend on:
+
+- `pageA`
+ - `utility1`
+ - `utility2`
+- `pageB`
+ - `utility2`
+ - `utility3`
+- `pageC`
+ - `utility2`
+ - `utility3`
+
+Given this configuration, webpack will produce the following bundles:
+
+- `vendor`
+ - webpack runtime
+ - `vendor1`
+ - `vendor2`
+- `common`
+ - `utility2`
+ - `utility3`
+- `pageA`
+ - `pageA`
+ - `utility1`
+- `pageB`
+ - `pageB`
+- `pageC`
+ - `pageC`
+
+With this bundle configuration, you would load your third party libraries, then your common application code, then your page-specific application code.
+
+# webpack.config.js
+
+``` javascript
+var path = require("path");
+var CommonsChunkPlugin = require("../../lib/optimize/CommonsChunkPlugin");
+
+module.exports = {
+	entry: {
+		vendor: ["./vendor1", "./vendor2"],
+		pageA: "./pageA",
+		pageB: "./pageB",
+		pageC: "./pageC"
+		// older versions of webpack may require an empty entry point declaration here
+		// common: []
+	},
+	output: {
+		path: path.join(__dirname, "js"),
+		filename: "[name].js"
+	},
+	plugins: [
+		new CommonsChunkPlugin({
+			// The order of this array matters
+			names: ["common", "vendor"],
+			minChunks: 2
+		})
+	]
+};
+```
+
+# js/vendor.js
+
+``` javascript
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// install a JSONP callback for chunk loading
+/******/ 	var parentJsonpFunction = window["webpackJsonp"];
+/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModule) {
+/******/ 		// add "moreModules" to the modules object,
+/******/ 		// then flag all "chunkIds" as loaded and fire callback
+/******/ 		var moduleId, chunkId, i = 0, resolves = [];
+/******/ 		for(;i < chunkIds.length; i++) {
+/******/ 			chunkId = chunkIds[i];
+/******/ 			if(installedChunks[chunkId])
+/******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			installedChunks[chunkId] = 0;
+/******/ 		}
+/******/ 		for(moduleId in moreModules) {
+/******/ 			modules[moduleId] = moreModules[moduleId];
+/******/ 		}
+/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules);
+/******/ 		while(resolves.length)
+/******/ 			resolves.shift()();
+/******/ 		if(executeModule + 1) { // typeof executeModule === "number"
+/******/ 			return __webpack_require__(executeModule);
+/******/ 		}
+/******/ 	};
+
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// objects to store loaded and loading chunks
+/******/ 	var installedChunks = {
+/******/ 		0: 0
+/******/ 	};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+/******/ 	// This file contains only the entry chunk.
+/******/ 	// The chunk loading function for additional chunks
+/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
+/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 			return Promise.resolve()
+
+/******/ 		// an Promise means "currently loading".
+/******/ 		if(installedChunks[chunkId]) {
+/******/ 			return installedChunks[chunkId][2];
+/******/ 		}
+/******/ 		// start chunk loading
+/******/ 		var head = document.getElementsByTagName('head')[0];
+/******/ 		var script = document.createElement('script');
+/******/ 		script.type = 'text/javascript';
+/******/ 		script.charset = 'utf-8';
+/******/ 		script.async = true;
+/******/ 		script.timeout = 120000;
+
+/******/ 		script.src = __webpack_require__.p + "" + chunkId + "." + ({"1":"common","2":"pageA","3":"pageC","4":"pageB"}[chunkId]||chunkId) + ".js";
+/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
+/******/ 		script.onerror = script.onload = onScriptComplete;
+/******/ 		function onScriptComplete() {
+/******/ 			// avoid mem leaks in IE.
+/******/ 			script.onerror = script.onload = null;
+/******/ 			clearTimeout(timeout);
+/******/ 			var chunk = installedChunks[chunkId];
+/******/ 			if(chunk !== 0) {
+/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				installedChunks[chunkId] = undefined;
+/******/ 			}
+/******/ 		};
+/******/ 		head.appendChild(script);
+
+/******/ 		var promise = new Promise(function(resolve, reject) {
+/******/ 			installedChunks[chunkId] = [resolve, reject];
+/******/ 		});
+/******/ 		return installedChunks[chunkId][2] = promise;
+/******/ 	};
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// on error function for async loading
+/******/ 	__webpack_require__.oe = function(err) { throw err; };
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "js/";
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 8);
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ 3:
+/*!********************!*\
+  !*** ./vendor1.js ***!
+  \********************/
+/***/ function(module, exports) {
+
+	module.exports = "vendor1";
+
+/***/ },
+
+/***/ 4:
+/*!********************!*\
+  !*** ./vendor2.js ***!
+  \********************/
+/***/ function(module, exports) {
+
+	module.exports = "vendor2";
+
+/***/ },
+
+/***/ 8:
+/*!********************!*\
+  !*** multi vendor ***!
+  \********************/
+/***/ function(module, exports, __webpack_require__) {
+
+	__webpack_require__(/*! ./vendor1 */3);
+	module.exports = __webpack_require__(/*! ./vendor2 */4);
+
+
+/***/ }
+
+/******/ });
+```
+
+# js/common.js
+
+``` javascript
+webpackJsonp([1],[
+/* 0 */
+/*!*********************!*\
+  !*** ./utility2.js ***!
+  \*********************/
+/***/ function(module, exports) {
+
+	module.exports = "utility2";
+
+/***/ },
+/* 1 */
+/*!*********************!*\
+  !*** ./utility3.js ***!
+  \*********************/
+/***/ function(module, exports) {
+
+	module.exports = "utility3";
+
+/***/ }
+]);
+```
+
+# js/pageA.js
+
+``` javascript
+webpackJsonp([2],{
+
+/***/ 2:
+/*!*********************!*\
+  !*** ./utility1.js ***!
+  \*********************/
+/***/ function(module, exports) {
+
+	module.exports = "utility1";
+
+/***/ },
+
+/***/ 5:
+/*!******************!*\
+  !*** ./pageA.js ***!
+  \******************/
+/***/ function(module, exports, __webpack_require__) {
+
+	var utility1 = __webpack_require__(/*! ./utility1 */ 2);
+	var utility2 = __webpack_require__(/*! ./utility2 */ 0);
+
+	module.exports = "pageA";
+
+/***/ }
+
+},[5]);
+```
+
+# js/pageB.js
+
+``` javascript
+webpackJsonp([4],{
+
+/***/ 6:
+/*!******************!*\
+  !*** ./pageB.js ***!
+  \******************/
+/***/ function(module, exports, __webpack_require__) {
+
+	var utility2 = __webpack_require__(/*! ./utility2 */ 0);
+	var utility3 = __webpack_require__(/*! ./utility3 */ 1);
+
+	module.exports = "pageB";
+
+/***/ }
+
+},[6]);
+```
+
+# js/pageC.js
+
+``` javascript
+webpackJsonp([3],{
+
+/***/ 7:
+/*!******************!*\
+  !*** ./pageC.js ***!
+  \******************/
+/***/ function(module, exports, __webpack_require__) {
+
+	var utility2 = __webpack_require__(/*! ./utility2 */ 0);
+	var utility4 = __webpack_require__(/*! ./utility3 */ 1);
+
+	module.exports = "pageC";
+
+/***/ }
+
+},[7]);
+```
+
+# Info
+
+## Uncompressed
+
+```
+Hash: 9198c92456f7bd9db9cd
+Version: webpack 2.0.2-beta
+Time: 94ms
+    Asset       Size  Chunks             Chunk Names
+vendor.js    4.87 kB       0  [emitted]  vendor
+common.js  347 bytes       1  [emitted]  common
+ pageA.js  482 bytes       2  [emitted]  pageA
+ pageC.js  317 bytes       3  [emitted]  pageC
+ pageB.js  317 bytes       4  [emitted]  pageB
+chunk    {0} vendor.js (vendor) 94 bytes [rendered]
+    > vendor [8] multi vendor 
+    [3] ./vendor1.js 27 bytes {0} [built]
+        single entry ./vendor1 [8] multi vendor
+    [4] ./vendor2.js 27 bytes {0} [built]
+        single entry ./vendor2 [8] multi vendor
+    [8] multi vendor 40 bytes {0} [built]
+chunk    {1} common.js (common) 56 bytes {0} [rendered]
+    [0] ./utility2.js 28 bytes {1} [built]
+        cjs require ./utility2 [5] ./pageA.js 2:15-36
+        cjs require ./utility2 [6] ./pageB.js 1:15-36
+        cjs require ./utility2 [7] ./pageC.js 1:15-36
+    [1] ./utility3.js 28 bytes {1} [built]
+        cjs require ./utility3 [6] ./pageB.js 2:15-36
+        cjs require ./utility3 [7] ./pageC.js 2:15-36
+chunk    {2} pageA.js (pageA) 130 bytes {1} [rendered]
+    > pageA [5] ./pageA.js 
+    [2] ./utility1.js 28 bytes {2} [built]
+        cjs require ./utility1 [5] ./pageA.js 1:15-36
+    [5] ./pageA.js 102 bytes {2} [built]
+chunk    {3} pageC.js (pageC) 102 bytes {1} [rendered]
+    > pageC [7] ./pageC.js 
+    [7] ./pageC.js 102 bytes {3} [built]
+chunk    {4} pageB.js (pageB) 102 bytes {1} [rendered]
+    > pageB [6] ./pageB.js 
+    [6] ./pageB.js 102 bytes {4} [built]
+```
+
+## Minimized (uglify-js, no zip)
+
+```
+Hash: 9198c92456f7bd9db9cd
+Version: webpack 2.0.2-beta
+Time: 183ms
+    Asset       Size  Chunks             Chunk Names
+vendor.js    1.14 kB       0  [emitted]  vendor
+common.js   92 bytes       1  [emitted]  common
+ pageA.js  109 bytes       2  [emitted]  pageA
+ pageC.js   71 bytes       3  [emitted]  pageC
+ pageB.js   71 bytes       4  [emitted]  pageB
+chunk    {0} vendor.js (vendor) 94 bytes [rendered]
+    > vendor [8] multi vendor 
+    [3] ./vendor1.js 27 bytes {0} [built]
+        single entry ./vendor1 [8] multi vendor
+    [4] ./vendor2.js 27 bytes {0} [built]
+        single entry ./vendor2 [8] multi vendor
+    [8] multi vendor 40 bytes {0} [built]
+chunk    {1} common.js (common) 56 bytes {0} [rendered]
+    [0] ./utility2.js 28 bytes {1} [built]
+        cjs require ./utility2 [5] ./pageA.js 2:15-36
+        cjs require ./utility2 [6] ./pageB.js 1:15-36
+        cjs require ./utility2 [7] ./pageC.js 1:15-36
+    [1] ./utility3.js 28 bytes {1} [built]
+        cjs require ./utility3 [6] ./pageB.js 2:15-36
+        cjs require ./utility3 [7] ./pageC.js 2:15-36
+chunk    {2} pageA.js (pageA) 130 bytes {1} [rendered]
+    > pageA [5] ./pageA.js 
+    [2] ./utility1.js 28 bytes {2} [built]
+        cjs require ./utility1 [5] ./pageA.js 1:15-36
+    [5] ./pageA.js 102 bytes {2} [built]
+chunk    {3} pageC.js (pageC) 102 bytes {1} [rendered]
+    > pageC [7] ./pageC.js 
+    [7] ./pageC.js 102 bytes {3} [built]
+chunk    {4} pageB.js (pageB) 102 bytes {1} [rendered]
+    > pageB [6] ./pageB.js 
+    [6] ./pageB.js 102 bytes {4} [built]
+
+WARNING in pageA.js from UglifyJs
+Side effects in initialization of unused variable utility1 [./pageA.js:1,0]
+Side effects in initialization of unused variable utility2 [./pageA.js:2,0]
+
+WARNING in pageC.js from UglifyJs
+Side effects in initialization of unused variable utility2 [./pageC.js:1,0]
+Side effects in initialization of unused variable utility4 [./pageC.js:2,0]
+
+WARNING in pageB.js from UglifyJs
+Side effects in initialization of unused variable utility2 [./pageB.js:1,0]
+Side effects in initialization of unused variable utility3 [./pageB.js:2,0]
+```

--- a/examples/common-chunk-and-vendor-chunk/build.js
+++ b/examples/common-chunk-and-vendor-chunk/build.js
@@ -1,0 +1,2 @@
+global.NO_TARGET_ARGS = true;
+require("../build-common");

--- a/examples/common-chunk-and-vendor-chunk/pageA.js
+++ b/examples/common-chunk-and-vendor-chunk/pageA.js
@@ -1,0 +1,4 @@
+var utility1 = require('./utility1');
+var utility2 = require('./utility2');
+
+module.exports = "pageA";

--- a/examples/common-chunk-and-vendor-chunk/pageB.js
+++ b/examples/common-chunk-and-vendor-chunk/pageB.js
@@ -1,0 +1,4 @@
+var utility2 = require('./utility2');
+var utility3 = require('./utility3');
+
+module.exports = "pageB";

--- a/examples/common-chunk-and-vendor-chunk/pageC.js
+++ b/examples/common-chunk-and-vendor-chunk/pageC.js
@@ -1,0 +1,4 @@
+var utility2 = require('./utility2');
+var utility3 = require('./utility3');
+
+module.exports = "pageC";

--- a/examples/common-chunk-and-vendor-chunk/template.md
+++ b/examples/common-chunk-and-vendor-chunk/template.md
@@ -1,0 +1,82 @@
+This example shows how to create an explicit vendor chunk as well as a common chunk for code shared among entry points. In this example, we have 3 entry points: `pageA`, `pageB`, and `pageC`. Those entry points share some of the same utility modules, but not others. This configuration will pull out any modules common to at least 2 bundles and place it it the `common` bundle instead, all while keeping the specified vendor libraries in their own bundle by themselves.
+
+To better understand, here are the entry points and which utility modules they depend on:
+
+- `pageA`
+ - `utility1`
+ - `utility2`
+- `pageB`
+ - `utility2`
+ - `utility3`
+- `pageC`
+ - `utility2`
+ - `utility3`
+
+Given this configuration, webpack will produce the following bundles:
+
+- `vendor`
+ - webpack runtime
+ - `vendor1`
+ - `vendor2`
+- `common`
+ - `utility2`
+ - `utility3`
+- `pageA`
+ - `pageA`
+ - `utility1`
+- `pageB`
+ - `pageB`
+- `pageC`
+ - `pageC`
+
+With this bundle configuration, you would load your third party libraries, then your common application code, then your page-specific application code.
+
+# webpack.config.js
+
+``` javascript
+{{webpack.config.js}}
+```
+
+# js/vendor.js
+
+``` javascript
+{{js/vendor.js}}
+```
+
+# js/common.js
+
+``` javascript
+{{js/common.js}}
+```
+
+# js/pageA.js
+
+``` javascript
+{{js/pageA.js}}
+```
+
+# js/pageB.js
+
+``` javascript
+{{js/pageB.js}}
+```
+
+# js/pageC.js
+
+``` javascript
+{{js/pageC.js}}
+```
+
+# Info
+
+## Uncompressed
+
+```
+{{stdout}}
+```
+
+## Minimized (uglify-js, no zip)
+
+```
+{{min:stdout}}
+```

--- a/examples/common-chunk-and-vendor-chunk/utility1.js
+++ b/examples/common-chunk-and-vendor-chunk/utility1.js
@@ -1,0 +1,1 @@
+module.exports = "utility1";

--- a/examples/common-chunk-and-vendor-chunk/utility2.js
+++ b/examples/common-chunk-and-vendor-chunk/utility2.js
@@ -1,0 +1,1 @@
+module.exports = "utility2";

--- a/examples/common-chunk-and-vendor-chunk/utility3.js
+++ b/examples/common-chunk-and-vendor-chunk/utility3.js
@@ -1,0 +1,1 @@
+module.exports = "utility3";

--- a/examples/common-chunk-and-vendor-chunk/vendor1.js
+++ b/examples/common-chunk-and-vendor-chunk/vendor1.js
@@ -1,0 +1,1 @@
+module.exports = "vendor1";

--- a/examples/common-chunk-and-vendor-chunk/vendor2.js
+++ b/examples/common-chunk-and-vendor-chunk/vendor2.js
@@ -1,0 +1,1 @@
+module.exports = "vendor2";

--- a/examples/common-chunk-and-vendor-chunk/webpack.config.js
+++ b/examples/common-chunk-and-vendor-chunk/webpack.config.js
@@ -1,0 +1,24 @@
+var path = require("path");
+var CommonsChunkPlugin = require("../../lib/optimize/CommonsChunkPlugin");
+
+module.exports = {
+	entry: {
+		vendor: ["./vendor1", "./vendor2"],
+		pageA: "./pageA",
+		pageB: "./pageB",
+		pageC: "./pageC"
+		// older versions of webpack may require an empty entry point declaration here
+		// common: []
+	},
+	output: {
+		path: path.join(__dirname, "js"),
+		filename: "[name].js"
+	},
+	plugins: [
+		new CommonsChunkPlugin({
+			// The order of this array matters
+			names: ["common", "vendor"],
+			minChunks: 2
+		})
+	]
+};


### PR DESCRIPTION
I recently came across a scenario where I wanted webpack to create an explicit vendor bundle, a bundle with all code common to our entry points, and a bundle for each entry point. I knew it was possible but there were no examples close to what we needed. After a lot of trial and error I finally figured out a way to do it and I wanted to share. This example shows how I was able to do it using the `CommonsChunkPlugin `.

If this example isn't quite up to standards, please let me know and I'll be happy to fix any issues. Or, if a very similar example already exists, I can close this as well.

Thanks for the awesome tool. :+1: 