### PR TITLE
[WIP] Hooks for subresource integrity

### DIFF
--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -26,26 +26,13 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 		}
 		return source;
 	});
-	mainTemplate.plugin("require-ensure", function(_, chunk, hash) {
+	mainTemplate.plugin("jsonp-script", function(_, chunk, hash) {
 		var filename = this.outputOptions.filename;
 		var chunkFilename = this.outputOptions.chunkFilename;
 		var chunkMaps = chunk.getChunkMaps();
 		var crossOriginLoading = this.outputOptions.crossOriginLoading;
 		var chunkLoadTimeout = this.outputOptions.chunkLoadTimeout || 120000;
 		return this.asString([
-			"if(installedChunks[chunkId] === 0)",
-			this.indent([
-				"return Promise.resolve()"
-			]),
-			"",
-			"// an Promise means \"currently loading\".",
-			"if(installedChunks[chunkId]) {",
-			this.indent([
-				"return installedChunks[chunkId][2];"
-			]),
-			"}",
-			"// start chunk loading",
-			"var head = document.getElementsByTagName('head')[0];",
 			"var script = document.createElement('script');",
 			"script.type = 'text/javascript';",
 			"script.charset = 'utf-8';",
@@ -88,6 +75,25 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 				"}"
 			]),
 			"};",
+		]);
+	});
+	mainTemplate.plugin("require-ensure", function(_, chunk, hash) {
+		var chunkFilename = this.outputOptions.chunkFilename;
+		return this.asString([
+			"if(installedChunks[chunkId] === 0)",
+			this.indent([
+				"return Promise.resolve()"
+			]),
+			"",
+			"// an Promise means \"currently loading\".",
+			"if(installedChunks[chunkId]) {",
+			this.indent([
+				"return installedChunks[chunkId][2];"
+			]),
+			"}",
+			"// start chunk loading",
+			"var head = document.getElementsByTagName('head')[0];",
+			this.applyPluginsWaterfall("jsonp-script", "", chunk, hash),
 			"head.appendChild(script);",
 			"",
 			"var promise = new Promise(function(resolve, reject) {",


### PR DESCRIPTION
This adds a new plugin hook that allows adding additional attributes to dynamically created script tags.

@sokra for discussion:
- `webpack-subresource-integrity` would need the following contract for the `jsonp-script` hook: that there is a variable named `script` in scope, bound to the newly created script element, and a variable `chunkId` bound to the respective chunk ID. Can this be codified somehow, or can you think of an alternate approach that doesn't require the plugin code to rely on well-known variable names? 
- I haven't found tests for e.g. the `require-ensure` plugin hook. Do we need to add tests for the `jsonp-script` hook? If so, where would they go?
