### PR TITLE
Support loader/loaders with string/array notation

### DIFF
--- a/lib/LoadersList.js
+++ b/lib/LoadersList.js
@@ -20,40 +20,30 @@ function regExpAsMatcher(regExp) {
 function asMatcher(test) {
 	if(typeof test === "string") {
 		return regExpAsMatcher(new RegExp("^" + test.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")));
-	} else if(typeof test === "function") {
-		return test;
-	} else if(test instanceof RegExp) {
-		return regExpAsMatcher(test);
-	} else if(Array.isArray(test)) {
-		var matchers = test.map(function(item) {
-			if(Array.isArray(item)) {
-				var matchers = item.map(asMatcher);
-				return function(str) {
-					return matchers.every(function(matcher) {
-						return matcher(str);
-					});
-				};
-			} else {
-				return asMatcher(item);
-			}
-		});
-		return function(str) {
-			for(var i = 0; i < test.length; i++) {
-				if(matchers[i](str))
-					return true;
-			}
-			return false;
-		};
-	} else {
-		throw new Error(test + " is not a valid test");
 	}
+	if(typeof test === "function") {
+		return test;
+	}
+	if(test instanceof RegExp) {
+		return regExpAsMatcher(test);
+	}
+	if(Array.isArray(test)) {
+		// create an array of match functions
+		var matchers = test.map(asMatcher);
+		return function(str) {
+			return matchers.every(function(matcher) {
+				return matcher(str);
+			});
+		};
+	}
+	throw new TypeError(test + " is not a valid test");
 }
 
 function getLoaderWithQuery(loader, query) {
 	if(typeof query === "string") {
 		return loader + "?" + query;
 	}
-	return loaders + "?" + JSON.stringify(query);
+	return loader + "?" + JSON.stringify(query);
 }
 
 function getLoadersFromObject(element) {
@@ -91,7 +81,6 @@ function getLoadersFromObject(element) {
 }
 
 LoadersList.prototype.matchPart = function matchPart(str, test) {
-	if(!test) return true;
 	var matcher = asMatcher(test);
 	return matcher(str);
 };
@@ -104,7 +93,7 @@ LoadersList.prototype.match = function match(str) {
 		.filter(Boolean)
 		.reduce(function(loaders, r) {
 			return loaders.concat(r);
-		}, []) || [];
+		}, []);
 };
 
 LoadersList.prototype.matchObject = function matchObject(str, obj) {

--- a/lib/LoadersList.js
+++ b/lib/LoadersList.js
@@ -6,7 +6,7 @@ function LoadersList(list) {
 	this.list = list || [];
 	this.list.forEach(function(element) {
 		if(element === null || typeof element !== "object")
-			throw new Error("Each element of the loaders list must be an object or array");
+			throw new TypeError("Each element of the loaders list must be an object or array");
 	});
 }
 module.exports = LoadersList;
@@ -49,15 +49,45 @@ function asMatcher(test) {
 	}
 }
 
-function getLoadersFromObject(element) {
-	if(element.query) {
-		if(!element.loader || element.loader.indexOf("!") >= 0) throw new Error("Cannot define 'query' and multiple loaders in loaders list");
-		if(typeof element.query === "string") return [element.loader + "?" + element.query];
-		return [element.loader + "?" + JSON.stringify(element.query)];
+function getLoaderWithQuery(loader, query) {
+	if(typeof query === "string") {
+		return loader + "?" + query;
 	}
-	if(element.loader) return element.loader.split("!");
-	if(element.loaders) return element.loaders;
-	throw new Error("Element from loaders list should have one of the fields 'loader' or 'loaders'");
+	return loaders + "?" + JSON.stringify(query);
+}
+
+function getLoadersFromObject(element) {
+	var loaders = element.loaders || element.loader;
+	if(typeof loaders === "string") {
+		loaders = loaders.split("!");
+	} else if(!Array.isArray(loaders)) {
+		throw new TypeError("Element from loaders list should have one of the fields 'loader' or 'loaders'");
+	}
+	// legacy query usage
+	if(element.query) {
+		if(loaders.length > 1) {
+			throw new Error("Cannot define 'query' and multiple loaders in loaders list");
+		}
+		var loader = loaders[0];
+		return [getLoaderWithQuery(loader, element.query)];
+	}
+	return loaders.map(function(entry) {
+		if(typeof entry === "string") {
+			return entry;
+		}
+		if(typeof entry === "object") {
+			var loader = entry.loader;
+			if(!loader) {
+				throw new TypeError("Element from loaders list with objects should have a 'loader' specified");
+			}
+			var query = entry.query;
+			if(!query) {
+				return loader;
+			}
+			return getLoaderWithQuery(loader, query);
+		}
+		throw new TypeError("Element from loaders list should be a string or an object");
+	});
 }
 
 LoadersList.prototype.matchPart = function matchPart(str, test) {
@@ -67,30 +97,19 @@ LoadersList.prototype.matchPart = function matchPart(str, test) {
 };
 
 LoadersList.prototype.match = function match(str) {
-	return this.list.map(function(element) {
-		if(Array.isArray(element)) {
-			for(var i = 0; i < element.length; i++) {
-				if(this.matchObject(str, element[i]))
-					return getLoadersFromObject(element[i]);
-			}
-		} else {
-			if(this.matchObject(str, element))
-				return getLoadersFromObject(element);
-		}
-	}, this).filter(Boolean).reduce(function(array, r) {
-		r.forEach(function(r) {
-			array.push(r);
-		});
-		return array;
-	}, []) || [];
+	return this.list
+		.map(function(element) {
+			if(this.matchObject(str, element)) return getLoadersFromObject(element);
+		}, this)
+		.filter(Boolean)
+		.reduce(function(loaders, r) {
+			return loaders.concat(r);
+		}, []) || [];
 };
 
 LoadersList.prototype.matchObject = function matchObject(str, obj) {
-	if(obj.test)
-		if(!this.matchPart(str, obj.test)) return false;
-	if(obj.include)
-		if(!this.matchPart(str, obj.include)) return false;
-	if(obj.exclude)
-		if(this.matchPart(str, obj.exclude)) return false;
+	if(obj.test && !this.matchPart(str, obj.test)) return false;
+	if(obj.include && !this.matchPart(str, obj.include)) return false;
+	if(obj.exclude && this.matchPart(str, obj.exclude)) return false;
 	return true;
 };

--- a/test/LoaderList.test.js
+++ b/test/LoaderList.test.js
@@ -1,0 +1,269 @@
+var should = require("should");
+
+var LoadersList = require("../lib/LoadersList");
+
+describe("LoaderList", function() {
+	it('should create LoadersList without any input', function() {
+		var loader = new LoadersList();
+		(loader.list).should.eql([]);
+	});
+	it('should create LoadersList with a blank array', function() {
+		var loader = new LoadersList([]);
+		(loader.list).should.eql([]);
+	});
+	it('should throw when create LoadersList with an invalid array', function() {
+		should.throws(function() {
+			var loader = new LoadersList(['dummyString']);
+		}, /must be an object or array/);
+	});
+	it('should create LoadersList with an invalid array', function() {
+		should.throws(function() {
+			var loader = new LoadersList(['dummyString']);
+		}, /must be an object or array/);
+	});
+	it('should create LoadersList with an valid array', function() {
+		var loaders = [{
+			test: /\.css$/,
+			loader: 'css'
+		}];
+		var loader = new LoadersList(loaders);
+		(loader.list).should.eql(loaders);
+	});
+	it('should create LoadersList and match with empty array', function() {
+		var loader = new LoadersList([]);
+		(loader.match('something')).should.eql([]);
+	});
+	it('should not match with loaders array', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loader: 'css'
+		}]);
+		(loader.match('something')).should.eql([]);
+	});
+	it('should match with regex', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loader: 'css'
+		}]);
+		(loader.match('style.css')).should.eql(['css']);
+	});
+	it('should match with string', function() {
+		var loader = new LoadersList([{
+			test: 'style.css',
+			loader: 'css'
+		}]);
+		(loader.match('style.css')).should.eql(['css']);
+	});
+	it('should match with function', function() {
+		var loader = new LoadersList([{
+			test: function(str) {
+				return str === 'style.css';
+			},
+			loader: 'css'
+		}]);
+		(loader.match('style.css')).should.eql(['css']);
+	});
+	it('should throw if invalid test', function() {
+		var loader = new LoadersList([{
+			test: {
+				invalid: 'test'
+			},
+			loader: 'css'
+		}]);
+		should.throws(function() {
+			(loader.match('style.css')).should.eql(['css']);
+		}, /not a valid test/);
+	});
+	it('should accept multiple test array that all match', function() {
+		var loader = new LoadersList([{
+			test: [
+				/style.css/,
+				/yle.css/
+			],
+			loader: 'css'
+		}]);
+		(loader.match('style.css')).should.eql(['css']);
+	});
+	it('should accept multiple test array that not all match', function() {
+		var loader = new LoadersList([{
+			test: [
+				/style.css/,
+				/something.css/
+			],
+			loader: 'css'
+		}]);
+		(loader.match('style.css')).should.eql([]);
+	});
+	it('should not match if include does not match', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			include: /output.css/,
+			loader: 'css'
+		}]);
+		(loader.match('style.css')).should.eql([]);
+	});
+	it('should match if include matches', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			include: /style.css/,
+			loader: 'css'
+		}]);
+		(loader.match('style.css')).should.eql(['css']);
+	});
+	it('should not match if exclude matches', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			exclude: /style.css/,
+			loader: 'css'
+		}]);
+		(loader.match('style.css')).should.eql([]);
+	});
+	it('should match if exclude does not match', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			exclude: /output.css/,
+			loader: 'css'
+		}]);
+		(loader.match('style.css')).should.eql(['css']);
+	});
+	it('should work if a loader is applied to all files', function() {
+		var loader = new LoadersList([{
+			loader: 'css'
+		}]);
+		(loader.match('style.css')).should.eql(['css']);
+		(loader.match('scripts.js')).should.eql(['css']);
+	});
+	it('should work with using loader as string', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loader: 'css'
+		}]);
+		(loader.match('style.css')).should.eql(['css']);
+	});
+	it('should work with using loader as array', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loader: ['css']
+		}]);
+		(loader.match('style.css')).should.eql(['css']);
+	});
+	it('should work with using loaders as string', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loaders: 'css'
+		}]);
+		(loader.match('style.css')).should.eql(['css']);
+	});
+	it('should work with using loaders as array', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loaders: ['css']
+		}]);
+		(loader.match('style.css')).should.eql(['css']);
+	});
+	it('should throw if using loaders with non-string or array', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loaders: {
+				someObj: true
+			}
+		}]);
+		should.throws(function() {
+			(loader.match('style.css')).should.eql(['css']);
+		}, /should have one of the fields/)
+	});
+	it('should work with using loader with inline query', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loader: 'css?modules=1'
+		}]);
+		(loader.match('style.css')).should.eql(['css?modules=1']);
+	});
+	it('should work with using loader with string query', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loader: 'css',
+			query: 'modules=1'
+		}]);
+		(loader.match('style.css')).should.eql(['css?modules=1']);
+	});
+	it('should work with using loader with object query', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loader: 'css',
+			query: {
+				modules: 1
+			}
+		}]);
+		(loader.match('style.css')).should.eql(['css?{"modules":1}']);
+	});
+	it('should work with using array loaders with basic object notation', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loaders: [{
+				loader: 'css'
+			}]
+		}]);
+		(loader.match('style.css')).should.eql(['css']);
+	});
+	it('should throw if using array loaders with object notation without specifying a loader', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loaders: [{
+				stuff: 1
+			}]
+		}]);
+		should.throws(function() {
+			(loader.match('style.css')).should.eql(['css']);
+		}, /should have a 'loader' specified/)
+	});
+	it('should work with using array loaders with object notation', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loaders: [{
+				loader: 'css',
+				query: 'modules=1'
+			}]
+		}]);
+		(loader.match('style.css')).should.eql(['css?modules=1']);
+	});
+	it('should work with using multiple array loaders with object notation', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loaders: [{
+				loader: 'style',
+				query: 'filesize=1000'
+			}, {
+				loader: 'css',
+				query: 'modules=1'
+			}]
+		}]);
+		(loader.match('style.css')).should.eql(['style?filesize=1000', 'css?modules=1']);
+	});
+	it('should work with using string multiple loaders', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loaders: 'style?filesize=1000!css?modules=1'
+		}]);
+		(loader.match('style.css')).should.eql(['style?filesize=1000', 'css?modules=1']);
+	});
+	it('should throw if using array loaders with a single legacy', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loaders: ['style-loader', 'css-loader'],
+			query: 'modules=1'
+		}]);
+		should.throws(function() {
+			(loader.match('style.css')).should.eql(['css']);
+		}, /Cannot define 'query' and multiple loaders in loaders list/)
+	});
+	it('should throw if using array loaders with invalid type', function() {
+		var loader = new LoadersList([{
+			test: /\.css$/,
+			loaders: ['style-loader', 'css-loader', 5],
+		}]);
+		should.throws(function() {
+			(loader.match('style.css')).should.eql(['css']);
+		}, /Element from loaders list should be a string or an object/)
+	});
+});


### PR DESCRIPTION
Currently if user accidentally uses `'loaders'` instead of `'loader'` a very unhelpful `r.forEach is not a function` is thrown.

This commit will throw a helpful error if user uses `loaders` but does not specify an array as he should.