### PR TITLE
Fix one lint warning

### DIFF
--- a/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
+++ b/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
@@ -19,14 +19,15 @@ EvalSourceMapDevToolModuleTemplatePlugin.prototype.apply = function(moduleTempla
 	moduleTemplate.plugin("module", function(source, module) {
 		if(source.__EvalSourceMapDevToolData)
 			return source.__EvalSourceMapDevToolData;
-
+		var sourceMap;
+		var content;
 		if(source.sourceAndMap) {
 			var sourceAndMap = source.sourceAndMap(options);
-			var sourceMap = sourceAndMap.map;
-			var content = sourceAndMap.source;
+			sourceMap = sourceAndMap.map;
+			content = sourceAndMap.source;
 		} else {
-			var sourceMap = source.map(options);
-			var content = source.source();
+			sourceMap = source.map(options);
+			content = source.source();
 		}
 		if(!sourceMap) {
 			return source;


### PR DESCRIPTION
There's about 90+ lint warnings, a lot of which can be solved by moving the variable declaration outside of the `if` like this. Do you want me to go through and fix the rest?