### PR TITLE
Use better error message for when given multiple args for CommonChunks Plugin

### DIFF
--- a/lib/optimize/CommonsChunkPlugin.js
+++ b/lib/optimize/CommonsChunkPlugin.js
@@ -5,8 +5,21 @@
 var nextIdent = 0;
 
 function CommonsChunkPlugin(options) {
-	if(arguments.length > 1)
-		throw new Error("CommonsChunkPlugin only takes one argument (pass an options object)");
+	if(arguments.length > 1) {
+		throw new Error("Deprecation notice: CommonsChunkPlugin now only takes a single argument. Either an options " +
+				"object *or* the name of the chunk.\n" +
+				"Example: if your old code looked like this:\n" +
+				"    new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.bundle.js')\n\n" +
+				"You would change it to:\n" +
+				"    new webpack.optimize.CommonsChunkPlugin({ name: 'vendor', filename: 'vendor.bundle.js' })\n\n" +
+				"The available options are:\n" +
+				"    name: string\n" +
+				"    names: string[]\n" +
+				"    filename: string\n" +
+				"    minChunks: number\n" +
+				"    async: boolean\n" +
+				"    minSize: number\n");
+	}
 	if(Array.isArray(options) || typeof options === "string") {
 		options = {
 			name: options


### PR DESCRIPTION
The error message previously was cryptic, this should help when people transition to webpack2