### PR TITLE
update node-libs-browser to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "loader-utils": "^0.2.11",
     "memory-fs": "~0.3.0",
     "mkdirp": "~0.5.0",
-    "node-libs-browser": ">= 0.4.0 <=0.6.0",
+    "node-libs-browser": "^1.0.0",
     "object-assign": "^4.0.1",
     "source-map": "^0.5.3",
     "supports-color": "^3.1.0",

--- a/test/configCases/target/web/webpack.config.js
+++ b/test/configCases/target/web/webpack.config.js
@@ -1,3 +1,8 @@
 module.exports = {
-	target: "web"
+	target: "web",
+	module: {
+		loaders: [
+			{ test: /\.json$/, loader: "json" }
+		]
+	}
 };


### PR DESCRIPTION
I've hit some issues using `webpack` with `node-libs-browser` previous to 1.0.0 due to it using a older version of the `Buffer` module (3.X), which is incompatible with the new 4.X. 

This PR solves that issue by upgrading the `node-libs-browser` inside `webpack`