### PR TITLE
Always set module info from loader, fix #1975

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -128,6 +128,9 @@ NormalModule.prototype.doBuild = function doBuild(options, compilation, resolver
 		context: loaderContext,
 		readResource: fs.readFile.bind(fs)
 	}, function(err, result) {
+		module.cacheable = result.cacheable;
+		module.fileDependencies = result.fileDependencies;
+		module.contextDependencies = result.contextDependencies;
 		if(err) {
 			module.error = err;
 			return callback(new ModuleBuildError(module, err));
@@ -136,9 +139,6 @@ NormalModule.prototype.doBuild = function doBuild(options, compilation, resolver
 		var resourceBuffer = result.resourceBuffer;
 		var source = result.result[0];
 		var sourceMap = result.result[1];
-		module.cacheable = result.cacheable;
-		module.fileDependencies = result.fileDependencies;
-		module.contextDependencies = result.contextDependencies;
 
 		if(!Buffer.isBuffer(source) && typeof source !== "string") {
 			module.error = new Error("Final loader didn't return a Buffer or String");
@@ -156,7 +156,7 @@ NormalModule.prototype.doBuild = function doBuild(options, compilation, resolver
 			module._source = new RawSource(source);
 		}
 		return callback();
-	})
+	});
 };
 
 NormalModule.prototype.disconnect = function disconnect() {


### PR DESCRIPTION
This can be merged after https://github.com/webpack/loader-runner/pull/1