### PR TITLE
Fix #1983 : Object properties can be mangle now.

### DIFF
--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -91,6 +91,9 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 						ast.figure_out_scope();
 						ast.compute_char_frequency(options.mangle || {});
 						ast.mangle_names(options.mangle || {});
+						if(options.mangle.props) {
+							uglify.mangle_properties(ast, options.mangle.props);
+						}
 					}
 					var output = {};
 					output.comments = Object.prototype.hasOwnProperty.call(options, "comments") ? options.comments : /^\**!|@preserve|@license/;


### PR DESCRIPTION
Use the following config:

```js
{
  plugins: [
    new webpack.optimize.UglifyJsPlugin({
      mangle: {
        props: {
          regex: /_$/
        },
      },
    }),
  ]
}
```

This PR fixes #1983 