### PR TITLE
fix numberToIdentifer so it cant output duplicates

### DIFF
--- a/lib/Template.js
+++ b/lib/Template.js
@@ -22,13 +22,13 @@ Template.toIdentifier = function(str) {
 
 var A_CODE = "a".charCodeAt(0);
 var Z_CODE = "z".charCodeAt(0);
-var AZ_COUNT = Z_CODE - A_CODE;
+var AZ_COUNT = Z_CODE - A_CODE + 1;
 var A2_CODE = "A".charCodeAt(0);
 var Z2_CODE = "Z".charCodeAt(0);
-var AZ2_COUNT = Z2_CODE - A2_CODE;
+var AZ2_COUNT = Z2_CODE - A2_CODE + 1;
 Template.numberToIdentifer = function numberToIdentifer(n) {
 	if(n < AZ_COUNT) return String.fromCharCode(A_CODE + n);
-	if(n < AZ_COUNT + AZ2_COUNT) return String.fromCharCode(A2_CODE + n + AZ_COUNT);
+	if(n < AZ_COUNT + AZ2_COUNT) return String.fromCharCode(A2_CODE + n - AZ_COUNT);
 	return "_" + (n - AZ_COUNT - AZ2_COUNT);
 };
 

--- a/test/Template.test.js
+++ b/test/Template.test.js
@@ -7,4 +7,18 @@ describe("Template", function() {
 	it("should generate valid identifiers", function() {
 		template.toIdentifier("0abc-def9").should.equal("_abc_def9");
 	});
+	it("should generate valid number identifiers", function() {
+		var items = [];
+		var item;
+		for(var i = 0; i < 80; i += 1) {
+			item = template.numberToIdentifer(i);
+			if(item === '') {
+				throw new Error('empty number identifier');
+			} else if(items.indexOf(item) > -1) {
+				throw new Error('duplicate number identifier');
+			} else {
+				items.push(item);
+			}
+		}
+	});
 });


### PR DESCRIPTION
Template numberToIdentifer produces duplicate identifiers for some values, causing issues when exporting such as 'Cannot redefine property: x';

18 = 25 = s
19 = 26 = t
20 = 27 = u
21 = 28 = v
22 = 29 = w
23 = 30 = x
24 = 31 = y

Fixed up logic and added a test to ensure no duplicates or non identifiers