### PR TITLE
Drop io.js from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ node_js:
   - node
   - "5"
   - "4"
-  - iojs
-  - iojs-2
-  - iojs-1
   - "0.12"
 script: npm run travis
 env:


### PR DESCRIPTION
Io.js has been merged back into node, and some tests are failing on iojs-2