### PR TITLE
Fix invalid dependency for jspm

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "loader-utils": "^0.2.11",
     "memory-fs": "~0.3.0",
     "mkdirp": "~0.5.0",
-    "node-libs-browser": ">= 0.4.0 <=0.6.0",
+    "node-libs-browser": ">= 0.4.0 <=0.5.3",
     "optimist": "~0.6.0",
     "supports-color": "^3.1.0",
     "tapable": "~0.1.8",


### PR DESCRIPTION
This fixes installation with jspm:

```
$ jspm install npm:webpack@1.12.13

err  Installing npm:webpack@1.12.13, no version match for npm:node-libs-browser@0.6.0
```

It seems that `jspm` checks for the max version when installing dependencies and since `0.6.0` is not a [valid release](https://github.com/webpack/node-libs-browser/releases), it causes the installation to fail. I lowered the max dependency to the last real version. 