### PR TITLE
fix NodeSourcePlugin include absolute path cause different chunkhash

### DIFF
--- a/lib/DependenciesBlockVariable.js
+++ b/lib/DependenciesBlockVariable.js
@@ -18,7 +18,7 @@ DependenciesBlockVariable.prototype.updateHash = function(hash) {
 	var mathces = REGEXP_FOR_REQUIRE_PATH.exec(this.expression);
 	hash.update(this.name);
 	if(mathces !== null && mathces.length === 2) {
-		hash.update(this.expression.replace(mathces[1],path.relative(process.cwd(), mathces[1])));
+		hash.update(this.expression.replace(mathces[1], path.relative(process.cwd(), mathces[1])));
 	} else {
 		hash.update(this.expression);
 	}

--- a/lib/DependenciesBlockVariable.js
+++ b/lib/DependenciesBlockVariable.js
@@ -4,6 +4,8 @@
 */
 var ReplaceSource = require("webpack-sources").ReplaceSource;
 var RawSource = require("webpack-sources").RawSource;
+var path = require("path");
+var REGEXP_FOR_REQUIRE_PATH = /^require\("(.*?)"\)$/;
 
 function DependenciesBlockVariable(name, expression, dependencies) {
 	this.name = name;
@@ -13,8 +15,13 @@ function DependenciesBlockVariable(name, expression, dependencies) {
 module.exports = DependenciesBlockVariable;
 
 DependenciesBlockVariable.prototype.updateHash = function(hash) {
+	var mathces = REGEXP_FOR_REQUIRE_PATH.exec(this.expression);
 	hash.update(this.name);
-	hash.update(this.expression);
+	if(mathces.length === 2){
+		hash.update(this.expression.replace(mathces[1],path.relative(process.cwd(), mathces[1])));
+	}else{
+		hash.update(this.expression);
+	}
 	this.dependencies.forEach(function(d) {
 		d.updateHash(hash);
 	});

--- a/lib/DependenciesBlockVariable.js
+++ b/lib/DependenciesBlockVariable.js
@@ -17,9 +17,9 @@ module.exports = DependenciesBlockVariable;
 DependenciesBlockVariable.prototype.updateHash = function(hash) {
 	var mathces = REGEXP_FOR_REQUIRE_PATH.exec(this.expression);
 	hash.update(this.name);
-	if(mathces.length === 2){
+	if(mathces !== null && mathces.length === 2) {
 		hash.update(this.expression.replace(mathces[1],path.relative(process.cwd(), mathces[1])));
-	}else{
+	} else {
 		hash.update(this.expression);
 	}
 	this.dependencies.forEach(function(d) {


### PR DESCRIPTION
Becauseof NodeSourcePlugin  use a absolute file path to a expression , DependenciesBlockVariable.js will update the chunkhash by using this expression.
In My solution:
I use  path.relative to get a relative path base my project.
And Done. 