### PR TITLE
add `options.excludeModule` to specify external common used module

### DIFF
--- a/lib/optimize/CommonsChunkPlugin.js
+++ b/lib/optimize/CommonsChunkPlugin.js
@@ -33,6 +33,17 @@ function CommonsChunkPlugin(options) {
 	this.async = options.async;
 	this.minSize = options.minSize;
 	this.ident = __filename + (nextIdent++);
+	this.excludeModuleFn = function (module) {
+	    var excludeModule = options.excludeModule;
+	    if(excludeModule) {
+			if(excludeModule instanceof RegExp) {
+				return excludeModule.test(module.request);
+			} else if(typeof excludeModule === 'function') {
+				return excludeModule(module);
+			}
+	    }
+	    return false;
+	}
 }
 
 module.exports = CommonsChunkPlugin;
@@ -44,6 +55,7 @@ CommonsChunkPlugin.prototype.apply = function(compiler) {
 	var async = this.async;
 	var minSize = this.minSize;
 	var ident = this.ident;
+  	var excludeModuleFn = this.excludeModuleFn;
 	compiler.plugin("this-compilation", function(compilation) {
 		compilation.plugin(["optimize-chunks", "optimize-extracted-chunks"], function(chunks) {
 			// only optimize once
@@ -119,6 +131,8 @@ CommonsChunkPlugin.prototype.apply = function(compiler) {
 						if(!minChunks(module, count))
 							return;
 					} else if(count < (minChunks || Math.max(2, usedChunks.length))) {
+						return;
+					} else if(excludeModuleFn(module)) {
 						return;
 					}
 					reallyUsedModules.push(module);

--- a/lib/optimize/CommonsChunkPlugin.js
+++ b/lib/optimize/CommonsChunkPlugin.js
@@ -33,16 +33,16 @@ function CommonsChunkPlugin(options) {
 	this.async = options.async;
 	this.minSize = options.minSize;
 	this.ident = __filename + (nextIdent++);
-	this.excludeModuleFn = function (module) {
-	    var excludeModule = options.excludeModule;
-	    if(excludeModule) {
+	this.excludeModuleFn = function(module) {
+		var excludeModule = options.excludeModule;
+		if(excludeModule) {
 			if(excludeModule instanceof RegExp) {
 				return excludeModule.test(module.request);
 			} else if(typeof excludeModule === 'function') {
 				return excludeModule(module);
 			}
-	    }
-	    return false;
+		}
+		return false;
 	}
 }
 
@@ -55,7 +55,7 @@ CommonsChunkPlugin.prototype.apply = function(compiler) {
 	var async = this.async;
 	var minSize = this.minSize;
 	var ident = this.ident;
-  	var excludeModuleFn = this.excludeModuleFn;
+	var excludeModuleFn = this.excludeModuleFn;
 	compiler.plugin("this-compilation", function(compilation) {
 		compilation.plugin(["optimize-chunks", "optimize-extracted-chunks"], function(chunks) {
 			// only optimize once


### PR DESCRIPTION
add `options.excludeModule` to specify external common used module that should not be processed by CommonsChunkPlugin, to compatible with situations where both CommonsChunkPlugin and `webpack.externals` defined may cause error for external module.

Ref issue: #2066 

- options.excludeModule
    - type: `(RegExp | Function)`
    - default: `function () { return false; }`
    - Specify common used module filter regexp / function to exclude from  CommonsChunkPlugin process logic.