### PR TITLE
Use //# as the default sourceMappingURL format for eval-source-map

### DIFF
--- a/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
+++ b/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
@@ -7,7 +7,7 @@ var ModuleFilenameHelpers = require("./ModuleFilenameHelpers");
 
 function EvalSourceMapDevToolModuleTemplatePlugin(compilation, options, sourceMapComment, moduleFilenameTemplate) {
 	this.compilation = compilation;
-	this.sourceMapComment = sourceMapComment || "//@ sourceMappingURL=[url]";
+	this.sourceMapComment = sourceMapComment || "//# sourceMappingURL=[url]";
 	this.moduleFilenameTemplate = moduleFilenameTemplate || "webpack:///[resource-path]?[hash]";
 	this.options = options;
 }


### PR DESCRIPTION
`source-map` defaults to `//#` here https://github.com/webpack/webpack/blob/master/lib/SourceMapDevToolPlugin.js#L22 but it looks like `eval-source-map` got missed.