### PR TITLE
Add option to change source-map plugin test filter

### DIFF
--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -214,6 +214,7 @@ WebpackOptionsApply.prototype.process = function(options, compiler) {
 		var Plugin = evalWrapped ? EvalSourceMapDevToolPlugin : SourceMapDevToolPlugin;
 		compiler.apply(new Plugin({
 			filename: inline ? null : options.output.sourceMapFilename,
+			test: options.output.sourceMapTest,
 			moduleFilenameTemplate: options.output.devtoolModuleFilenameTemplate,
 			fallbackModuleFilenameTemplate: options.output.devtoolFallbackModuleFilenameTemplate,
 			append: hidden ? false : comment,

--- a/test/configCases/source-map/source-map-test/index.js
+++ b/test/configCases/source-map/source-map-test/index.js
@@ -1,0 +1,10 @@
+it("should include test.js in SourceMap", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename + ".map", "utf-8");
+	var map = JSON.parse(source);
+	map.sources.should.containEql("webpack:///./test.js");
+	map.sources.should.containEql("webpack:///./test-jsx.jsx");
+});
+
+require.include("./test.js");
+require.include("./test-jsx.jsx");

--- a/test/configCases/source-map/source-map-test/test-jsx.jsx
+++ b/test/configCases/source-map/source-map-test/test-jsx.jsx
@@ -1,0 +1,3 @@
+var foo = {};
+
+module.exports = foo;

--- a/test/configCases/source-map/source-map-test/test.js
+++ b/test/configCases/source-map/source-map-test/test.js
@@ -1,0 +1,3 @@
+var foo = {};
+
+module.exports = foo;

--- a/test/configCases/source-map/source-map-test/webpack.config.js
+++ b/test/configCases/source-map/source-map-test/webpack.config.js
@@ -1,0 +1,17 @@
+var webpack = require("../../../../");
+module.exports = {
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	output: {
+		sourceMapTest: /\.(js|jsx|css)($|\?)/i
+	},
+	plugins: [
+		new webpack.SourceMapDevToolPlugin({
+			filename: "[file].map",
+			cheap: true
+		}),
+		new webpack.optimize.UglifyJsPlugin()
+	]
+};


### PR DESCRIPTION
Without exposing this, one cannot generate source-maps for js-like
extensions such as es6 and jsx. This is particularly annoying for
react components and unittests of react components when using
webpack with babel.

Fixes #2078 
