### PR TITLE
Wrap eval devtool output into IIFE in order to circumvent Chrome debugger issue

### DIFF
--- a/lib/EvalDevToolModuleTemplatePlugin.js
+++ b/lib/EvalDevToolModuleTemplatePlugin.js
@@ -15,12 +15,21 @@ EvalDevToolModuleTemplatePlugin.prototype.apply = function(moduleTemplate) {
 	var self = this;
 	moduleTemplate.plugin("module", function(source, module) {
 		var content = source.source();
-		var str = ModuleFilenameHelpers.createFilename(module, self.moduleFilenameTemplate, this.requestShortener);
-		var footer = ["\n",
+		var filename = ModuleFilenameHelpers.createFilename(module, self.moduleFilenameTemplate, this.requestShortener);
+		var uri = encodeURI(filename)
+			.replace(/%2F/g, "/")
+			.replace(/%20/g, "_")
+			.replace(/%5E/g, "^")
+			.replace(/%5C/g, "\\")
+			.replace(/^\//, "");
+		var body = [
+			"(function() {",
+			content,
+			"})()",
 			ModuleFilenameHelpers.createFooter(module, this.requestShortener),
-			self.sourceUrlComment.replace(/\[url\]/g, encodeURI(str).replace(/%2F/g, "/").replace(/%20/g, "_").replace(/%5E/g, "^").replace(/%5C/g, "\\").replace(/^\//, ""))
+			self.sourceUrlComment.replace(/\[url\]/g, uri)
 		].join("\n");
-		return new RawSource("eval(" + JSON.stringify(content + footer) + ");");
+		return new RawSource("eval(" + JSON.stringify(body) + ");");
 	});
 	moduleTemplate.plugin("hash", function(hash) {
 		hash.update("EvalDevToolModuleTemplatePlugin");


### PR DESCRIPTION
Try outputing/watching `x` value in Chrome debugger:
`eval('"use strict"; var x = 100; debugger;');`
in current Chromium/Canary/Chrome/Opera you'll get `Uncaught ReferenceError: x is not defined`

any non-AMD module top-level vars (imports, constants etc) are inaccessible in debugger when using devtool: 'eval'

@jhnns created an issue https://bugs.chromium.org/p/chromium/issues/detail?id=590256

this can be temporarily circumvented by wrapping emitted module code in IIFE
