### PR TITLE
added option to disable case sensitivity warnings

### DIFF
--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -263,7 +263,11 @@ WebpackOptionsApply.prototype.process = function(options, compiler) {
 
 	compiler.apply(new RecordIdsPlugin());
 
-	compiler.apply(new WarnCaseSensitiveModulesPlugin());
+
+	if (options.caseSensitivity !== false) {
+		compiler.apply(new WarnCaseSensitiveModulesPlugin());	
+	}
+	
 
 	if(options.cache === undefined ? options.watch : options.cache) {
 		var CachePlugin = require("./CachePlugin");

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -10,7 +10,7 @@ function WebpackOptionsDefaulter() {
 	this.set("debug", false);
 	this.set("devtool", false);
 	this.set("cache", true);
-	this.set('caseSensitivity', true);
+	this.set("caseSensitivity", true);
 
 	this.set("context", process.cwd());
 	this.set("target", "web");

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -10,6 +10,7 @@ function WebpackOptionsDefaulter() {
 	this.set("debug", false);
 	this.set("devtool", false);
 	this.set("cache", true);
+	this.set('caseSensitivity', true);
 
 	this.set("context", process.cwd());
 	this.set("target", "web");


### PR DESCRIPTION
Added option that prevent case sensitive warnings. .
> 
WARNING in ./some/path/to/Components/MyComponent.js
There is another module with an equal name when case is ignored.
This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
Rename module if multiple modules are expected or use equal casing if one module is expected.

It is useful in work with React, where filenames often match with component classes