### PR TITLE
[Proof of Concept] - Add an option to Uglify plugin to cache to disk

### DIFF
--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -7,6 +7,11 @@ var SourceMapSource = require("webpack-sources").SourceMapSource;
 var RawSource = require("webpack-sources").RawSource;
 var RequestShortener = require("../RequestShortener");
 var ModuleFilenameHelpers = require("../ModuleFilenameHelpers");
+
+var crypto = require('crypto');
+var fs = require('fs');
+var mkdirp = require('mkdirp');
+var path = require('path');
 var uglify = require("uglify-js");
 
 function UglifyJsPlugin(options) {
@@ -21,6 +26,11 @@ module.exports = UglifyJsPlugin;
 UglifyJsPlugin.prototype.apply = function(compiler) {
 	var options = this.options;
 	options.test = options.test || /\.js($|\?)/i;
+
+	var cacheDirectory = options.cacheDirectory ? path.normalize( options.cacheDirectory + path.sep) : false;
+	if (cacheDirectory) {
+		mkdirp.sync(cacheDirectory);
+	}
 
 	var requestShortener = new RequestShortener(compiler.context);
 	compiler.plugin("compilation", function(compilation) {
@@ -81,6 +91,26 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 						};
 					}
 					uglify.base54.reset();
+
+					if (options.sourceMap !== false) {
+						var map = uglify.SourceMap({ // eslint-disable-line new-cap
+							file: file,
+							root: ""
+						});
+					}
+					var inputMD5 = crypto.createHash("md5").update(input).digest("hex");
+					var cacheFile = path.normalize(cacheDirectory + path.sep + "uglify_" + inputMD5 + ".js");
+					try {
+						var cacheFileContent = fs.readFileSync(cacheFile);
+						asset.__UglifyJsPlugin = compilation.assets[file] = (map ?
+								new SourceMapSource(cacheFileContent, file, JSON.parse(map), input, inputSourceMap) :
+								new RawSource(cacheFileContent)
+						);
+						return;
+					} catch (e) {
+						// in case of error reading the cache, fallback on the regular flow
+					}
+
 					var ast = uglify.parse(input, {
 						filename: file
 					});
@@ -103,17 +133,18 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 					for(var k in options.output) {
 						output[k] = options.output[k];
 					}
-					if(options.sourceMap !== false) {
-						var map = uglify.SourceMap({ // eslint-disable-line new-cap
-							file: file,
-							root: ""
-						});
+
+					if (map) {
 						output.source_map = map; // eslint-disable-line camelcase
 					}
+
 					var stream = uglify.OutputStream(output); // eslint-disable-line new-cap
 					ast.print(stream);
 					if(map) map = map + "";
 					stream = stream + "";
+					if (cacheDirectory) {
+						fs.writeFileSync(cacheFile, stream);
+					}
 					asset.__UglifyJsPlugin = compilation.assets[file] = (map ?
 						new SourceMapSource(stream, file, JSON.parse(map), input, inputSourceMap) :
 						new RawSource(stream));


### PR DESCRIPTION
Uglify take a long time to run. Both the creation of the AST and the magnification are expensive operation.

It is frequent that you end up recreating the same bundle across build as the source has not changed. 

By giving the ability to cache the output somewhere and reuse it the next time an identical source is being processed, we can speed things up dramatically.

The pull request in its current form is a proof of concept as I am curious if it is something that can judge useful by other people.

Todo:
- [ ] update documentation
- [ ] add some tests
