### PR TITLE
Fix for #2176. Replaced documentation link for CommonJS to Wiki Page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ or packaging just about any resource or asset.
 
 **TL; DR**
 
-* Bundles both [CommonJs](http://www.commonjs.org/specs/modules/1.0/) and [AMD](https://github.com/amdjs/amdjs-api/wiki/AMD) modules (even combined).
+* Bundles both [CommonJs](http://wiki.commonjs.org/) and [AMD](https://github.com/amdjs/amdjs-api/wiki/AMD) modules (even combined).
 * Can create a single bundle or multiple chunks that are asynchronously loaded at runtime (to reduce initial loading time).
 * Dependencies are resolved during compilation reducing the runtime size.
 * Loaders can preprocess files while compiling, e.g. coffeescript to JavaScript, handlebars strings to compiled functions, images to Base64, etc.


### PR DESCRIPTION
Updated readme so that CommonJS modules link (which is currently 404'd), points to the CommonJS.org's wiki page. 