### PR TITLE
make `electron-main` and `electron-renderer` targets works in 1.x

### DIFF
--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -112,6 +112,7 @@ WebpackOptionsApply.prototype.process = function(options, compiler) {
 				break;
 			case "atom":
 			case "electron":
+			case "electron-main":
 				var NodeTemplatePlugin = require("./node/NodeTemplatePlugin");
 				var NodeTargetPlugin = require("./node/NodeTargetPlugin");
 				var ExternalsPlugin = require("./ExternalsPlugin");
@@ -139,6 +140,37 @@ WebpackOptionsApply.prototype.process = function(options, compiler) {
 						"screen",
 						"shell",
 						"native-image"
+					]),
+					new LoaderTargetPlugin(options.target)
+				);
+				break;
+			case "electron-renderer":
+				var JsonpTemplatePlugin = require("./JsonpTemplatePlugin");
+				var NodeTargetPlugin = require("./node/NodeTargetPlugin");
+				var ExternalsPlugin = require("./ExternalsPlugin");
+				compiler.apply(
+					new JsonpTemplatePlugin(options.output),
+					new FunctionModulePlugin(options.output),
+					new NodeTargetPlugin(),
+					new ExternalsPlugin("commonjs", [
+						"app",
+						"auto-updater",
+						"browser-window",
+						"content-tracing",
+						"dialog",
+						"global-shortcut",
+						"ipc",
+						"menu",
+						"menu-item",
+						"power-monitor",
+						"protocol",
+						"tray",
+						"remote",
+						"web-view",
+						"clipboard",
+						"crash-reporter",
+						"screen",
+						"shell"
 					]),
 					new LoaderTargetPlugin(options.target)
 				);


### PR DESCRIPTION
This commit only be merged into master (2.x). I think it's worth in 1.x, too!