### PR TITLE
Add a lookup index for modules to Chunks.

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -7,6 +7,7 @@ function Chunk(name, module, loc) {
 	this.ids = null;
 	this.name = name;
 	this.modules = [];
+	this.modulesIndex = {};
 	this.chunks = [];
 	this.parents = [];
 	this.blocks = [];
@@ -26,16 +27,28 @@ function Chunk(name, module, loc) {
 module.exports = Chunk;
 
 Chunk.prototype.addModule = function(module) {
-	if(this.modules.indexOf(module) >= 0) {
-		return false;
+	if(module.debugId) {
+		if(module.debugId in this.modulesIndex) {
+			return false;
+		}
+	} else {
+		if(this.modules.indexOf(module) >= 0) {
+			return false;
+		}
 	}
 	this.modules.push(module);
+	if(module.debugId) {
+		this.modulesIndex[module.debugId] = true;
+	}
 	return true;
 };
 
 Chunk.prototype._removeAndDo = require("./removeAndDo");
 
 Chunk.prototype.removeModule = function(module) {
+	if(module.debugId) {
+		delete this.modulesIndex[module.debugId];
+	}
 	this._removeAndDo("modules", module, "removeChunk");
 };
 

--- a/lib/optimize/RemoveParentModulesPlugin.js
+++ b/lib/optimize/RemoveParentModulesPlugin.js
@@ -3,7 +3,11 @@
 	Author Tobias Koppers @sokra
 */
 function hasModule(chunk, module, checkedChunks) {
-	if(chunk.modules.indexOf(module) >= 0) return [chunk];
+	if(module.debugId && chunk.modulesIndex) {
+		if(module.debugId in chunk.modulesIndex) return [chunk];
+	} else {
+		if(chunk.modules.indexOf(module) >= 0) return [chunk];
+	}
 	if(chunk.entry) return false;
 	return allHaveModule(chunk.parents.filter(function(c) {
 		return checkedChunks.indexOf(c) < 0;


### PR DESCRIPTION
Since Chunks often contain many many modules in large projects, being able to determine if a module is part of a chunk efficiently is important. This patch adds a lookup index off of the debugId which users of the chunk can use to determine if a module is in a chunk.

This patch also teaches the RemoveParentModulePlugin to use the index. In my profiling, that particular lookup is responsible for 99% of the time spent in the plugin, which is responsible for 95% of the rebuild time in large projects.

I did not apply this technique elsewhere, but it could be useful in many other places across the codebase. Adding a new `contains` method to collections that uses the index if available would make future changes easier to apply.
