### PR TITLE
Pass changed file into `invalid` plugin hook

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -105,8 +105,8 @@ Watching.prototype.watch = function(files, dirs, missing) {
 		this.compiler.fileTimestamps = fileTimestamps;
 		this.compiler.contextTimestamps = contextTimestamps;
 		this.invalidate();
-	}.bind(this), function() {
-		this.compiler.applyPlugins("invalid");
+	}.bind(this), function(fileName, changeTime) {
+		this.compiler.applyPlugins("invalid", fileName, changeTime);
 	}.bind(this));
 };
 


### PR DESCRIPTION
Fixes #2021 

Just a small non-breaking change so it's possible to write simple plugin like this:

	compiler.plugin('invalid', function(fileName, changeTime) {
		console.log('changed file:', fileName, 'at', changeTime);
	});
