### PR TITLE
Option noSources that removes sourcesContent from sourcemaps

### DIFF
--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -112,7 +112,7 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 				var moduleFilenames = task.moduleFilenames;
 				var modules = task.modules;
 				sourceMap.sources = moduleFilenames;
-				if(sourceMap.sourcesContent) {
+				if(sourceMap.sourcesContent && !options.noSources) {
 					sourceMap.sourcesContent = sourceMap.sourcesContent.map(function(content, i) {
 						return content + "\n\n\n" + ModuleFilenameHelpers.createFooter(modules[i], requestShortener);
 					});

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -173,6 +173,7 @@ WebpackOptionsApply.prototype.process = function(options, compiler) {
 		var evalWrapped = options.devtool.indexOf("eval") >= 0;
 		var cheap = options.devtool.indexOf("cheap") >= 0;
 		var moduleMaps = options.devtool.indexOf("module") >= 0;
+		var noSources = options.devtool.indexOf("nosources") >= 0;
 		var legacy = options.devtool.indexOf("@") >= 0;
 		var modern = options.devtool.indexOf("#") >= 0;
 		var comment = legacy && modern ? "\n/*\n//@ sourceMappingURL=[url]\n//# sourceMappingURL=[url]\n*/" :
@@ -187,7 +188,8 @@ WebpackOptionsApply.prototype.process = function(options, compiler) {
 			append: hidden ? false : comment,
 			module: moduleMaps ? true : cheap ? false : true,
 			columns: cheap ? false : true,
-			lineToLine: options.output.devtoolLineToLine
+			lineToLine: options.output.devtoolLineToLine,
+			noSources: noSources,
 		}));
 	} else if(options.devtool && options.devtool.indexOf("eval") >= 0) {
 		var legacy = options.devtool.indexOf("@") >= 0;

--- a/test/configCases/source-map/nosources/index.js
+++ b/test/configCases/source-map/nosources/index.js
@@ -1,0 +1,8 @@
+it("should not include sourcesContent if noSources option is used", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename + ".map", "utf-8");
+	var map = JSON.parse(source);
+	map.should.not.have.property('sourcesContent');
+});
+
+require.include("./test.js");

--- a/test/configCases/source-map/nosources/test.js
+++ b/test/configCases/source-map/nosources/test.js
@@ -1,0 +1,3 @@
+var foo = {};
+
+module.exports = foo;

--- a/test/configCases/source-map/nosources/webpack.config.js
+++ b/test/configCases/source-map/nosources/webpack.config.js
@@ -1,0 +1,8 @@
+var webpack = require("../../../../");
+module.exports = {
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	devtool: "nosources-source-map",
+};


### PR DESCRIPTION
Also available as "nosources" in devtool option.
I'm not aware of any bad side-effects - sourcemaps still work as expected, both minified and normal.

Would solve this issue: https://github.com/webpack/webpack/issues/2034