### PR TITLE
Fix issue #2221 by adding a newline character to generated code

### DIFF
--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -39,7 +39,7 @@ HarmonyExportSpecifierDependency.Template.prototype.apply = function(dep, source
 	} else if(dep.immutable) {
 		content = "/* harmony export */ exports[" + JSON.stringify(used) + "] = " + dep.id + ";";
 	} else {
-		content = "/* harmony export */ Object.defineProperty(exports, " + JSON.stringify(used) + ", {configurable: false, enumerable: true, get: function() { return " + dep.id + "; }});";
+		content = "\n/* harmony export */ Object.defineProperty(exports, " + JSON.stringify(used) + ", {configurable: false, enumerable: true, get: function() { return " + dep.id + "; }});";
 	}
 	source.insert(dep.position, content);
 

--- a/test/cases/compile/issue2221/exportvar.js
+++ b/test/cases/compile/issue2221/exportvar.js
@@ -1,0 +1,1 @@
+export var foo = "bar"

--- a/test/cases/compile/issue2221/index.js
+++ b/test/cases/compile/issue2221/index.js
@@ -1,0 +1,3 @@
+it("should compile non-immutable exports with missing semicolons", function(){
+    require("./exportvar");
+});


### PR DESCRIPTION
Add a newline prefix to the code generated for non-immutable harmony exports. This
resolves a case where export statements without a trailing semicolon would cause
webpack to generate a bundle with invalid syntax.