### PR TITLE
added a[b] syntax for parser

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -234,8 +234,8 @@ Parser.prototype.initializeEvaluating = function() {
 	this.plugin("evaluate MemberExpression", function(expression) {
 		var expr = expression;
 		var exprName = [];
-		while(expr.type === "MemberExpression" && !expr.computed) {
-			exprName.unshift(expr.property.name);
+		while(expr.type === "MemberExpression") {
+			exprName.unshift(expr.property.name || expr.property.value);
 			expr = expr.object;
 		}
 		if(expr.type === "Identifier") {

--- a/test/Parser.test.js
+++ b/test/Parser.test.js
@@ -227,9 +227,9 @@ describe("Parser", function() {
 			"typeof 'str'": "string=string",
 			"typeof aString": "string=string",
 			"typeof b.Number": "string=number",
-			"typeof b[Number]": "",
+			"typeof b[Number]": "string=number",
 			"b.Number": "number=123",
-			"b[Number]": "",
+			"b[Number]": "number=123",
 			"'abc'.substr(1)": "string=bc",
 			"'abc'[substr](1)": "",
 		};


### PR DESCRIPTION
tried to fix this issue https://github.com/webpack/webpack/issues/1997. Supported `a['b']` matching in the parser.
