### PR TITLE
fix typo

### DIFF
--- a/examples/harmony-unused/README.md
+++ b/examples/harmony-unused/README.md
@@ -2,7 +2,7 @@ This example demonstrates how webpack tracks the using of ES6 imports and export
 
 Excluding unused exports from bundles is known as "[tree-shaking](http://www.2ality.com/2015/12/webpack-tree-shaking.html)".
 
-In this example, only `add` and `multiply` in `./math.js` are used used by the app. `list` is unused and is not included in the minimized bundle (Look for `Array.from` in the minimized bundle).
+In this example, only `add` and `multiply` in `./math.js` are used by the app. `list` is unused and is not included in the minimized bundle (Look for `Array.from` in the minimized bundle).
 
 In addition to that, `library.js` simulates an entry point to a big library. `library.js` re-exports multiple identifiers from submodules. Often big parts of that is unused, like `abc.js`. Note how the usage information flows from `example.js` through `library.js` into `abc.js` and all declarations in `abc.js` are not included in the minimized bundle (Look for `console.log("a")` in the minimized bundle).
 


### PR DESCRIPTION
remove redundant, duplicate word from the readme