### PR TITLE
:bug: Fix `watch` option recognition with multiple compilers

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -28,7 +28,10 @@ function webpack(options, callback) {
 	}
 	if(callback) {
 		if(typeof callback !== "function") throw new Error("Invalid argument: callback");
-		if(options.watch === true) {
+		if(options.watch === true || (Array.isArray(options) &&
+				options.some(function(o) {
+					return o.watch;
+				}))) {
 			var watchOptions = (!Array.isArray(options) ? options : options[0]).watchOptions || {};
 			return compiler.watch(watchOptions, callback);
 		}


### PR DESCRIPTION
Previously, webpack did not call `MultiCompiler#watch` when passing an array of compiler options. This happened because it was testing for `options.watch` which, when passing an array, is `undefined`. 

With this PR, it checks if any of the passed options has the `watch` flag set to `true`.