### PR TITLE
CommonsChunkPlugin: skip commonModules calculation if minChunks===Infinity

### DIFF
--- a/lib/optimize/CommonsChunkPlugin.js
+++ b/lib/optimize/CommonsChunkPlugin.js
@@ -68,8 +68,6 @@ CommonsChunkPlugin.prototype.apply = function(compiler) {
 				throw new Error("Invalid chunkNames argument");
 			}
 			commonChunks.forEach(function processCommonChunk(commonChunk, idx) {
-				var commonModulesCount = [];
-				var commonModules = [];
 				var usedChunks;
 				if(Array.isArray(selectedChunks)) {
 					usedChunks = chunks.filter(function(chunk) {
@@ -100,29 +98,33 @@ CommonsChunkPlugin.prototype.apply = function(compiler) {
 					commonChunk.addChunk(asyncChunk);
 					commonChunk = asyncChunk;
 				}
-				usedChunks.forEach(function(chunk) {
-					chunk.modules.forEach(function(module) {
-						var idx = commonModules.indexOf(module);
-						if(idx < 0) {
-							commonModules.push(module);
-							commonModulesCount.push(1);
-						} else {
-							commonModulesCount[idx]++;
-						}
-					});
-				});
-				var reallyUsedChunks = [];
 				var reallyUsedModules = [];
-				commonModulesCount.forEach(function(count, idx) {
-					var module = commonModules[idx];
-					if(typeof minChunks === "function") {
-						if(!minChunks(module, count))
+				if (minChunks !== Infinity) {
+					var commonModulesCount = [];
+					var commonModules = [];
+					usedChunks.forEach(function(chunk) {
+						chunk.modules.forEach(function(module) {
+							var idx = commonModules.indexOf(module);
+							if(idx < 0) {
+								commonModules.push(module);
+								commonModulesCount.push(1);
+							} else {
+								commonModulesCount[idx]++;
+							}
+						});
+					});
+					var _minChunks = (minChunks || Math.max(2, usedChunks.length))
+					commonModulesCount.forEach(function(count, idx) {
+						var module = commonModules[idx];
+						if(typeof minChunks === "function") {
+							if(!minChunks(module, count))
+								return;
+						} else if(count < _minChunks) {
 							return;
-					} else if(count < (minChunks || Math.max(2, usedChunks.length))) {
-						return;
-					}
-					reallyUsedModules.push(module);
-				});
+						}
+						reallyUsedModules.push(module);
+					});
+				}
 				if(minSize) {
 					var size = reallyUsedModules.reduce(function(a, b) {
 						return a + b.size();
@@ -130,6 +132,7 @@ CommonsChunkPlugin.prototype.apply = function(compiler) {
 					if(size < minSize)
 						return;
 				}
+				var reallyUsedChunks = [];
 				reallyUsedModules.forEach(function(module) {
 					usedChunks.forEach(function(chunk) {
 						if(module.removeChunk(chunk)) {


### PR DESCRIPTION
I introduced the `CommonsChunkPlugin` and experienced some slowdown in my build process. This isn't much, but in my build it was about `75ms` worth of time. Basically this just bypasses calculating `reallyUsedModules` if `minChunks === Infinity`.