### PR TITLE
Adds stats presets support to the CLI

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -135,6 +135,11 @@ function processOptions(options) {
 
 	var firstOptions = Array.isArray(options) ? options[0] : options;
 
+	if(typeof options.stats === "boolean" || typeof options.stats === "string") {
+		var statsPresetToOptions = require("../lib/Stats.js").presetToOptions;
+		options.stats = statsPresetToOptions(options.stats);
+	}
+
 	var outputOptions = Object.create(options.stats || firstOptions.stats || {});
 	if(typeof outputOptions.context === "undefined")
 		outputOptions.context = firstOptions.context;


### PR DESCRIPTION
the CLI wasn't processing stats presets (added in #1323) and was throwing

```sh
webpack/bin/webpack.js:63
	var outputOptions = Object.create(options.stats || firstOptions.stats || {});
	                           ^

TypeError: Object prototype may only be an Object or null
```

First PR here and couldn't find a contributor guide, so let me know if you need me to fix/add something =)