### PR TITLE
AMD Dependency producing invalid bundle

### DIFF
--- a/lib/dependencies/AMDRequireDependency.js
+++ b/lib/dependencies/AMDRequireDependency.js
@@ -49,7 +49,7 @@ AMDRequireDependency.Template.prototype.apply = function(dep, source, outputOpti
 			source.replace(depBlock.functionRange[1], depBlock.outerRange[1] - 1, "}" + (depBlock.bindThis ? ".bind(this)" : "") + wrapper[1]);
 		} else {
 			source.replace(depBlock.outerRange[0], depBlock.arrayRange[0] - 1,
-				"!/* require */(" + asComment(depBlock.chunkReason) + "function() { ");
+				";!/* require */(" + asComment(depBlock.chunkReason) + "function() { ");
 			source.insert(depBlock.arrayRange[0] + 0.9, "var __WEBPACK_AMD_REQUIRE_ARRAY__ = ");
 			source.replace(depBlock.arrayRange[1], depBlock.functionRange[0] - 1, "; (");
 			source.insert(depBlock.functionRange[1], ".apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__));");


### PR DESCRIPTION
Related to issue #2318.
This is reproducible in webpack 1.x and 2.x

```
module.exports = function(locale, callback)
{
    var prefix = "myfolder/",
        requestedBundles = [prefix + locale + "/folder2"];
    
    requestedBundles.push(prefix + locale + "/folder3");    
    
    require(requestedBundles,
      function(translations, localeElements) { }
    );
};
```

Produces in Webpack 1.x

```
__webpack_require__(1)!/* require */(/* empty */function() { var 
```

Produces in Webpack 2.x
```
!(function webpackMissingModule() { var e = new Error("Cannot find module \".\""); e.code = 'MODULE_NOT_FOUND'; throw e; }())Promise.resolve().catch( ...
```

Both **not parseable by the browser.**

In my case, I don't control the [code](https://github.com/oracle/oraclejet/blob/master/dist/js/libs/oj/debug/ojcore.js#L1809) that produces this, and the library shouldn't be outputting an invalid bundle.

I don't know if it's the perfect fix but it might help to understand the problem behind this use cases.

Thanks!
