### PR TITLE
Copy watchOptions properly in Compiler.js

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -3,6 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 var path = require("path");
+var assign = require("object-assign");
 var Tapable = require("tapable");
 
 var Compilation = require("./Compilation");
@@ -23,7 +24,7 @@ function Watching(compiler, watchOptions, handler) {
 			aggregateTimeout: watchOptions
 		};
 	} else if(watchOptions && typeof watchOptions === "object") {
-		this.watchOptions = Object.create(watchOptions);
+		this.watchOptions = assign({}, watchOptions);
 	} else {
 		this.watchOptions = {};
 	}


### PR DESCRIPTION
Replace Object.create() with assign() from object-assign.

Fixes #1354 