### PR TITLE
Fix user config options not being applied when they are imported from an es6 module with babel6

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -4,6 +4,7 @@ fs.existsSync = fs.existsSync || path.existsSync;
 var resolve = require("enhanced-resolve");
 var interpret = require("interpret");
 var WebpackOptionsDefaulter = require("../lib/WebpackOptionsDefaulter");
+var isES6DefaultExportedFunc = require("../lib/isES6DefaultExportedFunc");
 
 module.exports = function(optimist, argv, convertOptions) {
 
@@ -94,12 +95,8 @@ module.exports = function(optimist, argv, convertOptions) {
 		configFileLoaded = true;
 	}
 
-	var isES6DefaultExportedFunc = (
-		typeof options === "object" && options !== null && typeof options.default === "function"
-	);
-
-	if(typeof options === "function" || isES6DefaultExportedFunc) {
-		options = isES6DefaultExportedFunc ? options.default : options;
+	if(typeof options === "function" || isES6DefaultExportedFunc(options)) {
+		options = isES6DefaultExportedFunc(options) ? options.default : options;
 		options = options(argv.env, argv);
 	}
 

--- a/lib/isES6DefaultExportedFunc.js
+++ b/lib/isES6DefaultExportedFunc.js
@@ -1,0 +1,11 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+module.exports = function isES6DefaultExportedFunc(thing) {
+	return(
+		typeof thing === "object" &&
+		thing !== null &&
+		(typeof thing.default === "function" || thing.__esModule == true)
+	);
+};

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -7,9 +7,15 @@ var MultiCompiler = require("./MultiCompiler");
 var NodeEnvironmentPlugin = require("./node/NodeEnvironmentPlugin");
 var WebpackOptionsApply = require("./WebpackOptionsApply");
 var WebpackOptionsDefaulter = require("./WebpackOptionsDefaulter");
+var isES6DefaultExportedFunc = require("./isES6DefaultExportedFunc");
 
 function webpack(options, callback) {
 	var compiler;
+
+	if(isES6DefaultExportedFunc(options)) {
+		options = options.default;
+	}
+
 	if(Array.isArray(options)) {
 		compiler = new MultiCompiler(options.map(function(options) {
 			return webpack(options);


### PR DESCRIPTION
This bug exists in **webpack1 and webpack2**. This patch is against master, let me know if you want me to backport. As people upgrade to babel 6 more and more are going to hit it...

Bug could manifest in two ways:

* **webpack1**: `invalid argument pathToArray` error. This happens because the default for `output.path` is `""` in webpack1
* **webpack2**: compile not happening, `webpack()` returning super early but no errors thrown and no bundles created. This happens because the default for `output.path` is `cwd()`. Note: it **works** from the command line because the check was already there in the CLI parsing code, just not the node API.

This bug caused my working webpack config with babel5 to fail when upgrading to babel6. This was mainly due to my custom `output.path` being overwritten, so maybe other errors manifest differently than above. Also note the webpack1 error I got is hard to google...it usually is a symptom of people not putting in absolute paths to `output.path`...but in this case it is specified and webpack overwrites it as mentioned above.

This took me way too long to debug, mainly because there is a lot of indirection and the webpack `Options` have the concept of a "default" that isn't the same as an ES6 default of course! 🔎 