### PR TITLE
Fixing memory leak causing node go out of memory

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -319,6 +319,12 @@ Compilation.prototype.addModuleDependencies = function(module, dependencies, bai
 
 		});
 	}, function(err) {
+		// In V8, the Error objects keep a reference to the functions on the stack. These warnings &
+		// errors are created inside closures that keep a reference to the Compilation, so errors are
+		// leaking the Compilation object. Setting _this to null workarounds the following issue in V8.
+		// https://bugs.chromium.org/p/chromium/issues/detail?id=612191
+		_this = null;
+
 		if(err) {
 			return callback(err);
 		}


### PR DESCRIPTION
Setting _this to null to workaround a bug in V8 that keeps Compilation object alive and makes node run out of memory: https://bugs.chromium.org/p/chromium/issues/detail?id=612191

This usually happens when there's at least one module that shows an error or warning.