### PR TITLE
:bug: Fix `watch` option recognition with multiple compilers

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -28,7 +28,10 @@ function webpack(options, callback) {
 	}
 	if(callback) {
 		if(typeof callback !== "function") throw new Error("Invalid argument: callback");
-		if(options.watch === true) {
+		if(options.watch === true || (Array.isArray(options) &&
+				options.some(function(o) {
+					return o.watch;
+				}))) {
 			var watchOptions = (!Array.isArray(options) ? options : options[0]).watchOptions || {};
 			// TODO remove this in next major version
 			var watchDelay = (!Array.isArray(options) ? options : options[0]).watchDelay;


### PR DESCRIPTION
This is just cherry picked from the 2.1 branch.  I'm not sure if 1.x is still getting bug fixes, but I was hoping to get this one in.

https://github.com/webpack/webpack/commit/ae762611513808937795fc8cb8d3bb6b2ccde20c