### PR TITLE
disable progress notifications when terminal is not interactive

### DIFF
--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -15,6 +15,7 @@ function ProgressPlugin(options) {
 module.exports = ProgressPlugin;
 
 ProgressPlugin.prototype.apply = function(compiler) {
+	var defaultHandler = process.stdout.isTTY ? standardHandler : nullHandler;
 	var handler = this.handler || defaultHandler;
 	var profile = this.profile;
 	if(compiler.compilers) {
@@ -134,7 +135,11 @@ ProgressPlugin.prototype.apply = function(compiler) {
 	var chars = 0,
 		lastState, lastStateTime;
 
-	function defaultHandler(percentage, msg) {
+	function nullHandler(percentage, msg) {
+		process.stdout.write("Progress notifications disabled (non-tty)\n");
+	}
+
+	function standardHandler(percentage, msg) {
 		var state = msg;
 		var details = Array.prototype.slice.call(arguments, 2);
 		if(percentage < 1) {

--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -136,7 +136,7 @@ ProgressPlugin.prototype.apply = function(compiler) {
 		lastState, lastStateTime;
 
 	function nullHandler(percentage, msg) {
-		process.stdout.write("Progress notifications disabled (non-tty)\n");
+		
 	}
 
 	function standardHandler(percentage, msg) {


### PR DESCRIPTION
Currently, builds with `--progress` go a little nuts on non-interactive terminals. For instance, when building on Heroku, you get lines that are tens of thousands of characters long with "1.0%1.1%1.2%" etc.

This PR institutes a check for TTYs before outputting progress messages.
