### PR TITLE
Multi `use strict` bug fixed

### DIFF
--- a/lib/FunctionModuleTemplatePlugin.js
+++ b/lib/FunctionModuleTemplatePlugin.js
@@ -16,7 +16,7 @@ FunctionModuleTemplatePlugin.prototype.apply = function(moduleTemplate) {
 			defaultArguments.push("__webpack_require__");
 		}
 		source.add("/***/ function(" + defaultArguments.concat(module.arguments || []).join(", ") + ") {\n\n");
-		if(module.strict) source.add(this.outputOptions.sourcePrefix + "\"use strict\";\n");
+		if(!module.strict) source.add(this.outputOptions.sourcePrefix + "\"use strict\";\n");
 		source.add(new PrefixSource(this.outputOptions.sourcePrefix, moduleSource));
 		source.add("\n\n/***/ }");
 		return source;


### PR DESCRIPTION
When source has `use strict`, no need add one.