### PR TITLE
patch ArrayMap to fix edge case

### DIFF
--- a/lib/ArrayMap.js
+++ b/lib/ArrayMap.js
@@ -10,7 +10,7 @@ module.exports = ArrayMap;
 
 ArrayMap.prototype.get = function(key) {
 	for(var i = 0; i < this.keys.length; i++) {
-		if(this.keys[i] === key) {
+		if(this.keys[i].toString() === key.toString()) {
 			return this.values[i];
 		}
 	}
@@ -19,7 +19,7 @@ ArrayMap.prototype.get = function(key) {
 
 ArrayMap.prototype.set = function(key, value) {
 	for(var i = 0; i < this.keys.length; i++) {
-		if(this.keys[i] === key) {
+		if(this.keys[i].toString() === key.toString()) {
 			this.values[i] = value;
 			return this;
 		}
@@ -31,7 +31,7 @@ ArrayMap.prototype.set = function(key, value) {
 
 ArrayMap.prototype.remove = function(key) {
 	for(var i = 0; i < this.keys.length; i++) {
-		if(this.keys[i] === key) {
+		if(this.keys[i].toString() === key.toString()) {
 			this.keys.splice(i, 1);
 			this.values.splice(i, 1);
 			return true;


### PR DESCRIPTION
When comparing functions, only the exact same instance would match, while in reality we just need to ensure it's the same function. Stringifying the keys before comparing solves this issue.

See #2515 for additional details! 🐫 