### PR TITLE
Resolve promise if script was cached and not executed.

### DIFF
--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -38,6 +38,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 			"script.charset = 'utf-8';",
 			"script.async = true;",
 			"script.timeout = " + chunkLoadTimeout + ";",
+			"var cached = script.readyState && script.readyState === 'loaded';",
 			crossOriginLoading ? "script.crossOrigin = '" + crossOriginLoading + "';" : "",
 			"script.src = " + this.requireFn + ".p + " +
 			this.applyPluginsWaterfall("asset-path", JSON.stringify(chunkFilename), {
@@ -69,8 +70,17 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 				"var chunk = installedChunks[chunkId];",
 				"if(chunk !== 0) {",
 				this.indent([
-					"if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));",
-					"installedChunks[chunkId] = undefined;"
+					"if (cached) {",
+					this.indent([
+						"chunk[0]();"
+					]),
+					"}",
+					"else {",
+					this.indent([
+						"if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));",
+						"installedChunks[chunkId] = undefined;"
+					]),
+					"}"
 				]),
 				"}"
 			]),


### PR DESCRIPTION
This should fix IE9's terrible script caching. Alternatively, we could check for a cached script that hasn't installed it's chunk and reload with a unique timestamp to bust the cache. This first pass seems to work for me though, so it may be all that's necessary.

Addresses #2506.
