### PR TITLE
Remove export of ResolverPlugin which no longer exists

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -73,7 +73,6 @@ exportPlugins(exports, ".", [
 	"AutomaticPrefetchPlugin",
 	"ProvidePlugin",
 	"HotModuleReplacementPlugin",
-	"ResolverPlugin",
 	"SourceMapDevToolPlugin",
 	"EvalSourceMapDevToolPlugin",
 	"EvalDevToolModulePlugin",


### PR DESCRIPTION
The `ResolverPlugin` was removed in 461c49ab6636e5272362a28a6694d1c626227b05, so accessing it on the `webpack` object now throws an error `Cannot find module './ResolverPlugin'`.