### PR TITLE
fix moduleFilter when using babel-loader

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -62,6 +62,8 @@ Stats.prototype.toJson = function toJson(options, forToString) {
 		if(excludeModules.length === 0)
 			return true;
 		var ident = module.identifier();
+		if (ident.indexOf("babel-loader") > -1)
+			return true;
 		return !excludeModules.some(function(regExp) {
 			return regExp.test(ident);
 		});


### PR DESCRIPTION
How could this be done properly?

The problem otherwise is that own modules are hidden because their identifier is

```
/x/node_modules/babel-loader/index.js?{\"presets\":[\"react\",\"es2015\"],\"plugins\":[\"transform-decorators\",\"lodash\"]}!/x/client/utils/fetch.js
```

and matches `/node_modules/`
