### PR TITLE
Make LibManifestPlugin output to compilation assets

### DIFF
--- a/lib/LibManifestPlugin.js
+++ b/lib/LibManifestPlugin.js
@@ -4,6 +4,7 @@
 */
 var path = require("path");
 var async = require("async");
+var RawSource = require("webpack-sources").RawSource;
 
 function LibManifestPlugin(options) {
 	this.options = options;
@@ -39,11 +40,10 @@ LibManifestPlugin.prototype.apply = function(compiler) {
 					return obj;
 				}.bind(this), {})
 			};
-			var content = new Buffer(JSON.stringify(manifest, null, 2), "utf-8");
-			compiler.outputFileSystem.mkdirp(path.dirname(targetPath), function(err) {
-				if(err) return callback(err);
-				compiler.outputFileSystem.writeFile(targetPath, content, callback);
-			});
+			var targetPathRelative = path.relative(compiler.outputPath, targetPath);
+			var content = JSON.stringify(manifest, null, 2);
+			compilation.assets[targetPathRelative] = new RawSource(content);
+			callback();
 		}.bind(this), callback);
 	}.bind(this));
 };


### PR DESCRIPTION
I noticed while messing around with [DllPlugin](https://webpack.github.io/docs/list-of-plugins.html#dllplugin) and [webpack-stream](https://github.com/shama/webpack-stream) that the manifest files of the DLL plugin don't seem to get output at all by webpack-stream.

While comparing the code of the manifest plugin to [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin) (which works just fine with webpack-stream), I noticed that the manifest plugin writes its file [using `compiler.outputFileSystem`](https://github.com/webpack/webpack/blob/master/lib/LibManifestPlugin.js#L42-L46) whereas html-webpack-plugin [uses `compilation.assets`](https://github.com/ampedandwired/html-webpack-plugin/blob/c229fcbab27126c427dfd2678d10b410c3de275b/index.js#L167-L174) instead, which seems to be what webpack-stream [reads from](https://github.com/shama/webpack-stream/blob/e4e65856e32037813e7931a934afab380f3a46e4/index.js#L172) as well.

Changing the manifest plugin to also use `compilation.assets` seems to fix the issue, while still working fine with the existing tests.