### PR TITLE
Prevent request names from breaking comments

### DIFF
--- a/lib/ModuleFilenameHelpers.js
+++ b/lib/ModuleFilenameHelpers.js
@@ -101,20 +101,18 @@ ModuleFilenameHelpers.createFooter = function createFooter(module, requestShorte
 	if(!module) module = "";
 	if(typeof module === "string") {
 		return [
-			"/** WEBPACK FOOTER **",
-			" ** " + requestShortener.shorten(module),
-			" **/"
+			"// WEBPACK FOOTER //",
+			"// " + requestShortener.shorten(module)
 		].join("\n");
 	} else {
 		return [
-			"/*****************",
-			" ** WEBPACK FOOTER",
-			" ** " + module.readableIdentifier(requestShortener),
-			" ** module id = " + module.id,
-			" ** module chunks = " + module.chunks.map(function(c) {
+			"//////////////////",
+			"// WEBPACK FOOTER",
+			"// " + module.readableIdentifier(requestShortener),
+			"// module id = " + module.id,
+			"// module chunks = " + module.chunks.map(function(c) {
 				return c.id;
-			}).join(" "),
-			" **/"
+			}).join(" ")
 		].join("\n");
 	}
 };


### PR DESCRIPTION
Using `/*` as comment delimiters allows request names to terminate a comment early, like in https://github.com/carteb/carte-blanche/pull/262.

