### PR TITLE
Fixed Dedupe plugin for Maple engine

### DIFF
--- a/lib/optimize/DedupePlugin.js
+++ b/lib/optimize/DedupePlugin.js
@@ -167,12 +167,7 @@ DedupePlugin.prototype.apply = function(compiler) {
 					"modules[" + varModuleId + "] = _m;",
 					"break;"
 				]),
-				"case \"undefined\":",
-				this.indent([
-					"// Module is skipped in this bundle",
-					"break;"
-				]),
-				"default:",
+				"case \"number\":",
 				this.indent([
 					"// Module is a copy of another module",
 					"modules[" + varModuleId + "] = modules[_m];",
@@ -194,7 +189,6 @@ DedupePlugin.prototype.apply = function(compiler) {
 					"if(Object.prototype.hasOwnProperty.call(modules, i)) {",
 					this.indent([
 						"switch(typeof modules[i]) {",
-						"case \"function\": break;",
 						"case \"object\":",
 						this.indent([
 							"// Module can be created from a template",
@@ -210,12 +204,7 @@ DedupePlugin.prototype.apply = function(compiler) {
 							"}(modules[i]));",
 							"break;"
 						]),
-						"case \"undefined\":",
-						this.indent([
-							"// Module is skipped in this bundle",
-							"break;"
-						]),
-						"default:",
+						"case \"number\":",
 						this.indent([
 							"// Module is a copy of another module",
 							"modules[i] = modules[modules[i]];",

--- a/lib/optimize/DedupePlugin.js
+++ b/lib/optimize/DedupePlugin.js
@@ -167,6 +167,11 @@ DedupePlugin.prototype.apply = function(compiler) {
 					"modules[" + varModuleId + "] = _m;",
 					"break;"
 				]),
+				"case \"undefined\":",
+				this.indent([
+					"// Module is skipped in this bundle",
+					"break;"
+				]),
 				"default:",
 				this.indent([
 					"// Module is a copy of another module",
@@ -203,6 +208,11 @@ DedupePlugin.prototype.apply = function(compiler) {
 								"};"
 							]),
 							"}(modules[i]));",
+							"break;"
+						]),
+						"case \"undefined\":",
+						this.indent([
+							"// Module is skipped in this bundle",
 							"break;"
 						]),
 						"default:",


### PR DESCRIPTION
Maple engine is used by some TVs to render HbbTv (HTML/JS based) applications. It has it's own peculiarities and because of it DedupePlugin works not as expected.

For example:
`for (var i in [1, , 3]) console.log(i);` would usually produce `0, 2`, but with Maple it would also include skipped index (`0, 1, 2`). Because of it, modules get overwritten with undefined and bundle becomes invalid.

I understand that supporting such uncommon case might not be the first concern for webpack, yet fix for this issue is pretty straight forward, so it could be as well included to the future release.
