### PR TITLE
fix: expand globs in npm scripts correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "express": "~4.13.1",
     "extract-text-webpack-plugin": "^1.0.0",
     "file-loader": "~0.8.0",
+    "glob-cli2": "^1.0.1",
     "i18n-webpack-plugin": "~0.2.0",
     "istanbul": "^0.4.1",
     "jade": "^1.11.0",
@@ -83,8 +84,8 @@
     "test": "mocha --harmony --full-trace --check-leaks",
     "travis": "npm run cover -- --report lcovonly",
     "lint": "eslint lib bin hot",
-    "beautify-lint": "beautify-lint lib/**.js hot/**.js bin/**.js benchmark/*.js test/*.js",
-    "beautify": "beautify-rewrite lib/**.js hot/**.js bin/**.js benchmark/*.js test/*.js",
+    "beautify-lint": "beautify-lint `glob 'lib/**/*.js' 'hot/**/*.js' 'bin/**/*.js'` benchmark/*.js test/*.js",
+    "beautify": "beautify-rewrite `glob 'lib/**/*.js' 'hot/**/*.js' 'bin/**/*.js'` benchmark/*.js test/*.js",
     "postcover": "npm run lint && npm run beautify-lint",
     "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
     "publish-patch": "npm run lint && npm run beautify-lint && mocha && npm version patch && git push && git push --tags && npm publish"


### PR DESCRIPTION
## Why?

Originally the npm scripts were using the glob `/**.js` which is no different than using `/*.js`, expanding to all the files inside that directory but not recursively through all subdirectories.

## Fix
A proper glob to expand recursively to all subdirectories would be `/**/*.js` if the globstar option is set (`shopt -s globstar`).

Even within environments with an up-to-date version of Bash (i.e. TravisCI) the proper configuration for expanding a glob such as `**/*.js` will not load when running non-interactive shells (i.e. npm scripts).

I'm not saying this solution is the best solution out there but adding a feature to `beautify-lint` that expands the globs correctly will not solve the underlying problem with globs and npm scripts.

Before the patch:
```
$ npm run beautify

> webpack@2.1.0-beta.13 beautify /Users/oviedoga/Documents/dev/webpack
> beautify-rewrite lib/**.js hot/**.js bin/**.js benchmark/*.js test/*.js

Done. (145 files checked)
```

After the patch:
```
 npm run beautify

> webpack@2.1.0-beta.13 beautify /Users/oviedoga/Documents/dev/webpack
> beautify-rewrite `glob 'lib/**/*.js' 'hot/**/*.js' 'bin/**/*.js'` benchmark/*.js test/*.js

- lib/dependencies/HarmonyExportImportedSpecifierDependency.js
- lib/dependencies/HarmonyModulesHelpers.js
- lib/optimize/CommonsChunkPlugin.js
- lib/optimize/RemoveParentModulesPlugin.js
- lib/optimize/UglifyJsPlugin.js
Done. (5 files updated, 252 files checked)
```