### PR TITLE
Do not pass ignoreUnaccepted: true to module.hot.apply

### DIFF
--- a/hot/only-dev-server.js
+++ b/hot/only-dev-server.js
@@ -16,9 +16,7 @@ if(module.hot) {
 				return;
 			}
 
-			module.hot.apply({
-				ignoreUnaccepted: true
-			}).then(function(renewedModules) {
+			module.hot.apply().then(function(renewedModules) {
 				if(!upToDate()) {
 					check();
 				}


### PR DESCRIPTION
This makes `only-dev-server` behave as documented -- it's a `dev-server` that just doesn't do `window.location.reload()`.

Passing `ignoreUnaccepted: true` would prevent `hotApply` from refusing updates that were declined / not accepted, not only hiding the diagnostics message but breaking the `installedModules` state.

The `ignoreUnaccepted` check might be dead code now, though.

See https://github.com/webpack/webpack/issues/2648#issuecomment-226348021