### PR TITLE
Add --resolve-extensions support to CLI

### DIFF
--- a/bin/config-optimist.js
+++ b/bin/config-optimist.js
@@ -32,6 +32,7 @@ module.exports = function(optimist) {
 		.string("devtool").describe("devtool", "Enable devtool for better debugging experience")
 		.boolean("progress").describe("progress", "Print compilation progress in percentage")
 		.string("resolve-alias").describe("resolve-alias", "Setup a module alias for resolving")
+		.string("resolve-extensions").describe("resolve-extensions", "Setup extensions that should be used to resolve modules")
 		.string("resolve-loader-alias").describe("resolve-loader-alias", "Setup a loader alias for resolving")
 		.describe("optimize-max-chunks", "Try to keep the chunk count below a limit")
 		.describe("optimize-min-chunk-size", "Try to keep the chunk size above a limit")

--- a/bin/config-yargs.js
+++ b/bin/config-yargs.js
@@ -195,6 +195,12 @@ module.exports = function(yargs) {
 				group: RESOLVE_GROUP,
 				requiresArg: true
 			},
+			"resolve-extensions": {
+				"type": "string",
+				describe: "Setup extensions that should be used to resolve modules (Example: --resolve-extensions '.es6,.js')",
+				group: RESOLVE_GROUP,
+				requiresArg: true
+			},
 			"resolve-loader-alias": {
 				type: "string",
 				describe: "Setup a loader alias for resolving",

--- a/bin/config-yargs.js
+++ b/bin/config-yargs.js
@@ -196,8 +196,8 @@ module.exports = function(yargs) {
 				requiresArg: true
 			},
 			"resolve-extensions": {
-				"type": "string",
-				describe: "Setup extensions that should be used to resolve modules (Example: --resolve-extensions '.es6,.js')",
+				"type": "array",
+				describe: "Setup extensions that should be used to resolve modules (Example: --resolve-extensions .es6 .js)",
 				group: RESOLVE_GROUP,
 				requiresArg: true
 			},

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -406,7 +406,11 @@ module.exports = function(optimist, argv, convertOptions) {
 
 		ifArg("resolve-extensions", function(value) {
 			ensureObject(options, "resolve");
-			options.resolve.extensions = value.split(/,\s*/);
+			if (Array.isArray(value)) {
+				options.resolve.extensions = value;
+			} else {
+				options.resolve.extensions = value.split(/,\s*/);
+			}
 		});
 
 		ifArg("optimize-max-chunks", function(value) {

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -406,7 +406,7 @@ module.exports = function(optimist, argv, convertOptions) {
 
 		ifArg("resolve-extensions", function(value) {
 			ensureObject(options, "resolve");
-			if (Array.isArray(value)) {
+			if(Array.isArray(value)) {
 				options.resolve.extensions = value;
 			} else {
 				options.resolve.extensions = value.split(/,\s*/);

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -404,6 +404,11 @@ module.exports = function(optimist, argv, convertOptions) {
 		processResolveAlias("resolve-alias", "resolve");
 		processResolveAlias("resolve-loader-alias", "resolveLoader");
 
+		ifArg("resolve-extensions", function(value) {
+			ensureObject(options, "resolve");
+			options.resolve.extensions = value.split(/,\s*/);
+		});
+
 		ifArg("optimize-max-chunks", function(value) {
 			ensureArray(options, "plugins");
 			var LimitChunkCountPlugin = require("../lib/optimize/LimitChunkCountPlugin");


### PR DESCRIPTION
Wasn't supported so far, so I went ahead and added support for it.

I'm not sure if the API is the way you want it though, I wasn't sure how to let people enter an array from the CLI. I made it so we split at "," so usage of this option would look like this:

```Sh
$ webpack --resolve-extensions '.js,.es6'
```

Which will set `resolve.extensions` to `[".js", ".es6"]`. (I also account for whitespace, so `".js, .es6"` also works)

Closes #1447