### PR TITLE
Add errors when resolve.root/context are not absolute

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -2,6 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+var path = require('path');
 var Compiler = require("./Compiler");
 var MultiCompiler = require("./MultiCompiler");
 var NodeEnvironmentPlugin = require("./node/NodeEnvironmentPlugin");
@@ -18,8 +19,20 @@ function webpack(options, callback) {
 		if(!options.entry && !options.plugins) {
 			throw new Error("Passed 'options' object don't look like a valid webpack configuration");
 		}
-		new WebpackOptionsDefaulter().process(options);
-
+		if(options.context && !path.isAbsolute(options.context)) {
+			throw new Error("Passed option 'context' has to be an absolute path");
+		}
+		if(options.resolve && options.resolve.root && !Array.isArray(options.resolve.root)) {
+			if(!path.isAbsolute(options.resolve.root)) {
+				throw new Error("Passed option 'resolve.root' has to be an absolute path");
+			}
+		} else if(options.resolve && options.resolve.root) {
+			options.resolve.root.forEach(function(option, index) {
+				if(!path.isAbsolute(option)) {
+					throw new Error("Passed option '" + option + "' to 'resolve.root' has to be an absolute path");
+				}
+			});
+		}
 		compiler = new Compiler();
 		compiler.options = options;
 		compiler.options = new WebpackOptionsApply().process(options, compiler);


### PR DESCRIPTION
Ref #899, this should keep some confusion why things aren't working away

Not sure if there's a better place to put this – I can't find any other option validation at the moment. (Maybe we should generally start doing that for v2 if we don't? Might help quite a few people who have wrongly configured webpack instances…)
