### PR TITLE
Add log when in watch mode

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -276,6 +276,7 @@ function processOptions(options) {
 			process.stdin.resume();
 		}
 		compiler.watch(watchOptions, compilerCallback);
+		console.log('\nWebpack is watching the files…\n');
 	} else
 		compiler.run(compilerCallback);
 


### PR DESCRIPTION
Ref #766

Looks like this when starting webpack with `--watch` (in this case the `i18n` example):

```Sh
➜  webpack git:(log-watching) ✗ ./bin/webpack.js examples/i18n/example.js examples/i18n/build.js --watch

Webpack is watching the files…

Hash: 98c6d507a15cefd64224
Version: webpack 2.1.0-beta.14
Time: 74ms
   Asset     Size  Chunks             Chunk Names
build.js  2.09 kB       0  [emitted]  main
   [0] (webpack)/examples/i18n/example.js 64 bytes {0} [built]
```