### PR TITLE
Fix issue with async dynamic System.import dependencies not being re-emitted

### DIFF
--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -5,7 +5,7 @@
 var Module = require("./Module");
 var OriginalSource = require("webpack-sources").OriginalSource;
 var RawSource = require("webpack-sources").RawSource;
-var DependenciesBlock = require("./DependenciesBlock");
+var AsyncDependenciesBlock = require("./AsyncDependenciesBlock");
 
 function ContextModule(resolveDependencies, context, recursive, regExp, addon, async) {
 	Module.call(this);
@@ -80,12 +80,13 @@ ContextModule.prototype.build = function(options, compilation, resolver, fs, cal
 			});
 		}
 		if(this.async) {
-			this.blocks = dependencies && dependencies.map(function(dep) {
-				var block = new DependenciesBlock();
-				block.parent = this;
-				block.dependencies = [dep];
-				return block;
-			}, this);
+			if(dependencies) {
+				dependencies.forEach(function(dep) {
+					var block = new AsyncDependenciesBlock(null, dep.module, dep.loc);
+					block.addDependency(dep);
+					this.addBlock(block);
+				}, this);
+			}
 		} else {
 			this.dependencies = dependencies;
 		}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Per #2490, chunks of dynamic System.import dependencies are not re-emitted on hot reload.
Per webpack/extract-text-webpack-plugin#188, the plugin fails because it cannot find the non re-emitted chunk.


**What is the new behavior?**
The chunks are now emitted when a reload occurs, fixing #2490 and webpack/extract-text-webpack-plugin#188.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No
