### PR TITLE
ignore `node_modules` dir at whatever level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/node_modules
+node_modules/
 /test/js
 /test/browsertest/js
 /benchmark/js


### PR DESCRIPTION
yes, `node_modules` dir should be ignored everywhere

In addition, always a new line at the end of file is good practice for git diff