### PR TITLE
Update UglifyJsPlugin to the version from webpack 2.x

### DIFF
--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -2,9 +2,9 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var SourceMapConsumer = require("webpack-core/lib/source-map").SourceMapConsumer;
-var SourceMapSource = require("webpack-core/lib/SourceMapSource");
-var RawSource = require("webpack-core/lib/RawSource");
+var SourceMapConsumer = require("source-map").SourceMapConsumer;
+var SourceMapSource = require("webpack-sources").SourceMapSource;
+var RawSource = require("webpack-sources").RawSource;
 var RequestShortener = require("../RequestShortener");
 var ModuleFilenameHelpers = require("../ModuleFilenameHelpers");
 var uglify = require("uglify-js");
@@ -24,7 +24,7 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 
 	var requestShortener = new RequestShortener(compiler.context);
 	compiler.plugin("compilation", function(compilation) {
-		if(options.sourceMap !== false) {
+		if(options.sourceMap) {
 			compilation.plugin("build-module", function(module) {
 				// to get detailed location info about errors
 				module.useSourceMap = true;
@@ -50,14 +50,16 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 						compilation.assets[file] = asset.__UglifyJsPlugin;
 						return;
 					}
-					if(options.sourceMap !== false) {
+					var input;
+					if(options.sourceMap) {
+						var inputSourceMap;
 						if(asset.sourceAndMap) {
 							var sourceAndMap = asset.sourceAndMap();
-							var inputSourceMap = sourceAndMap.map;
-							var input = sourceAndMap.source;
+							inputSourceMap = sourceAndMap.map;
+							input = sourceAndMap.source;
 						} else {
-							var inputSourceMap = asset.map();
-							var input = asset.source();
+							inputSourceMap = asset.map();
+							input = asset.source();
 						}
 						var sourceMap = new SourceMapConsumer(inputSourceMap);
 						uglify.AST_Node.warn_function = function(warning) { // eslint-disable-line camelcase
@@ -73,7 +75,7 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 								"[" + requestShortener.shorten(original.source) + ":" + original.line + "," + original.column + "]");
 						};
 					} else {
-						var input = asset.source();
+						input = asset.source();
 						uglify.AST_Node.warn_function = function(warning) { // eslint-disable-line camelcase
 							warnings.push(warning);
 						};
@@ -84,7 +86,9 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 					});
 					if(options.compress !== false) {
 						ast.figure_out_scope();
-						var compress = uglify.Compressor(options.compress); // eslint-disable-line new-cap
+						var compress = uglify.Compressor(options.compress || {
+							warnings: false
+						}); // eslint-disable-line new-cap
 						ast = ast.transform(compress);
 					}
 					if(options.mangle !== false) {
@@ -101,7 +105,7 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 					for(var k in options.output) {
 						output[k] = options.output[k];
 					}
-					if(options.sourceMap !== false) {
+					if(options.sourceMap) {
 						var map = uglify.SourceMap({ // eslint-disable-line new-cap
 							file: file,
 							root: ""
@@ -138,9 +142,6 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 				}
 			});
 			callback();
-		});
-		compilation.plugin("normal-module-loader", function(context) {
-			context.minimize = true;
 		});
 	});
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "tapable": "~0.1.8",
     "uglify-js": "~2.6.0",
     "watchpack": "^0.2.1",
-    "webpack-core": "~0.6.0"
+    "webpack-core": "~0.6.0",
+    "webpack-sources": "^0.1.2",
+    "source-map": "^0.5.6"
   },
   "license": "MIT",
   "devDependencies": {
@@ -50,13 +52,11 @@
     "raw-loader": "~0.5.0",
     "script-loader": "~0.6.0",
     "should": "^7.0.2",
-    "source-map": "^0.5.6",
     "style-loader": "~0.12.0",
     "url-loader": "~0.5.0",
     "val-loader": "~0.5.0",
     "vm-browserify": "~0.0.0",
     "webpack-dev-middleware": "^1.0.0",
-    "webpack-sources": "^0.1.2",
     "worker-loader": "~0.6.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "raw-loader": "~0.5.0",
     "script-loader": "~0.6.0",
     "should": "^7.0.2",
+    "source-map": "^0.5.6",
     "style-loader": "~0.12.0",
     "url-loader": "~0.5.0",
     "val-loader": "~0.5.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "val-loader": "~0.5.0",
     "vm-browserify": "~0.0.0",
     "webpack-dev-middleware": "^1.0.0",
+    "webpack-sources": "^0.1.2",
     "worker-loader": "~0.6.0"
   },
   "engines": {

--- a/test/configCases/source-map/sources-array-production-cheap-map/webpack.config.js
+++ b/test/configCases/source-map/sources-array-production-cheap-map/webpack.config.js
@@ -9,6 +9,8 @@ module.exports = {
 			filename: "[file].map",
 			cheap: true
 		}),
-		new webpack.optimize.UglifyJsPlugin()
+		new webpack.optimize.UglifyJsPlugin({
+      sourceMap: true
+    })
 	]
 };

--- a/test/configCases/source-map/sources-array-production/webpack.config.js
+++ b/test/configCases/source-map/sources-array-production/webpack.config.js
@@ -6,6 +6,8 @@ module.exports = {
 	},
 	devtool: "source-map",
 	plugins: [
-		new webpack.optimize.UglifyJsPlugin()
+		new webpack.optimize.UglifyJsPlugin({
+      sourceMap: true
+    })
 	]
 };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix

**What is the current behavior?**
Current UglifyJsPlugin (from 1.13.1) removes css prefixes while compressing dist files,
for example display: -webkit-flex.
Exaple issue: https://github.com/webpack/webpack/issues/2543

**What is the new behavior?**
Uglifying dist files not removing css prefixes.


**Does this PR introduce a breaking change?**
- [ ] No

