### PR TITLE
supports-color --colors support

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -29,7 +29,8 @@ yargs.options({
 		describe: "Prints the result as JSON."
 	},
 	"color": {
-		type: "boolean",
+		type: "boolean",,
+ +		alias: "colors",
 		group: DISPLAY_GROUP,
 		describe: "Enables/Disables colors on the console"
 	},

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -30,8 +30,8 @@ yargs.options({
 	},
 	"color": {
 		type: "boolean",
-  		alias: "colors",
-  		default: function supportsColor() { return require("supports-color"); },
+		alias: "colors",
+		default: function supportsColor() { return require("supports-color"); },
 		group: DISPLAY_GROUP,
 		describe: "Enables/Disables colors on the console"
 	},

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -31,6 +31,7 @@ yargs.options({
 	"color": {
 		type: "boolean",,
  +		alias: "colors",
+ +		default: function supportsColor() { return require("supports-color"); },
 		group: DISPLAY_GROUP,
 		describe: "Enables/Disables colors on the console"
 	},

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -29,9 +29,9 @@ yargs.options({
 		describe: "Prints the result as JSON."
 	},
 	"color": {
-		type: "boolean",,
- +		alias: "colors",
- +		default: function supportsColor() { return require("supports-color"); },
+		type: "boolean",
+  		alias: "colors",
+  		default: function supportsColor() { return require("supports-color"); },
 		group: DISPLAY_GROUP,
 		describe: "Enables/Disables colors on the console"
 	},

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -31,7 +31,9 @@ yargs.options({
 	"color": {
 		type: "boolean",
 		alias: "colors",
-		default: function supportsColor() { return require("supports-color"); },
+		default: function supportsColor() {
+			return require("supports-color");
+		},
 		group: DISPLAY_GROUP,
 		describe: "Enables/Disables colors on the console"
 	},


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] No automated tests were present for command line args
 - [x] I ran a few manual tests confirming the previous functionality and the new functionality
![color_upload](https://cloud.githubusercontent.com/assets/3954343/17003083/34f523e4-4e83-11e6-9c05-a20a84660050.jpg)

- [x] Docs have been added / updated (for bug fixes / features)
 - [x] yargs documents new alias and default function

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] enabled --colors, --no-colors arguments for supports-color

**What is the current behavior?** https://github.com/webpack/webpack/issues/2786
```
webpack --colors
Unknown argument: colors
```

**What is the new behavior?**
`webpack --colors` === `webpack --color`

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No
