### PR TITLE
chore(security): Enables nsp checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "less-loader": "^2.0.0",
     "mocha": "^2.3.4",
     "mocha-lcov-reporter": "^1.0.0",
+    "nsp": "^2.6.1",
     "raw-loader": "~0.5.0",
     "react": "^15.2.1",
     "react-dom": "^15.2.1",
@@ -85,9 +86,10 @@
     "travis": "npm run cover -- --report lcovonly",
     "appveyor": "mocha --harmony --full-trace",
     "lint": "eslint lib bin hot",
+    "nsp": "nsp check --output summary",
     "beautify-lint": "beautify-lint lib/**/*.js hot/**/*.js bin/**/*.js benchmark/*.js test/*.js",
     "beautify": "beautify-rewrite lib/**/*.js hot/**/*.js bin/**/*.js benchmark/*.js test/*.js",
-    "postcover": "npm run lint && npm run beautify-lint",
+    "postcover": "npm run lint && npm run beautify-lint && npm run nsp",
     "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
     "publish-patch": "npm run lint && npm run beautify-lint && mocha && npm version patch && git push && git push --tags && npm publish"
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
No nsp checks currently executed


**What is the new behavior?**
- nsp checks are executed in the `postcover` script after linting, a failure returns an exit(1) and fails the build.

**Travis output**
![screen shot 2016-07-23 at 1 14 07 am](https://cloud.githubusercontent.com/assets/8420490/17076224/d1d50580-5072-11e6-897d-a69d9888ee99.png)

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact: Failing security check fails the Travis run in postcover.
* Migration path for existing applications: N/A
* Github Issue(s) this is regarding: #2795

**Other information**:
  - Adds nsp devDependency
  - Execute nsp check in `postcover` script

**Question**
IMO a failure for nsp would be a failure that you would want feedback on prior to executing the test suite to save CI time. With the current travis configuration, `postcover` is the logical place to execute the task which obviously doesn't "fail fast"

Curious if we want to explore the "fail fast" concept by reordering the Travis task execution.