### PR TITLE
Allow exports of multiple modules for libraries #2809

### DIFF
--- a/examples/exportAllModules/README.md
+++ b/examples/exportAllModules/README.md
@@ -1,0 +1,146 @@
+Demonstrates the usage of the `output.exportAllModules` configuration. 
+
+Two files; `a.js` and `b.js` are bundled in one entry to `bundle.js`.
+
+The configuration option makes sure that all externals from all modules are exported from the bundle.
+
+# a.js
+
+``` javascript
+exports.A = "a"
+```
+
+# b.js
+
+``` javascript
+exports.B = "b"
+```
+# webpack.config.js
+
+``` javascript
+var path = require("path");
+module.exports = {
+	entry: {
+		bundle: ["./a", "./b"]
+	},
+	output: {
+		path: path.join(__dirname, "js"),
+		filename: "[name].js",
+		exportAllModules: true
+	}
+}
+```
+
+# js/bundle.js
+
+``` javascript
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// identity function for calling harmory imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+
+/******/ 	// define getter function for harmory exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		Object.defineProperty(exports, name, {
+/******/ 			configurable: false,
+/******/ 			enumerable: true,
+/******/ 			get: getter
+/******/ 		});
+/******/ 	};
+
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 2);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+exports.A = "a"
+
+/***/ },
+/* 1 */
+/***/ function(module, exports) {
+
+exports.B = "b"
+
+/***/ },
+/* 2 */
+/***/ function(module, exports, __webpack_require__) {
+
+var export0 = __webpack_require__(0)
+for(var i in Object.keys(export0)) {
+	module.exports[Object.keys(export0)[i]] = export0[Object.keys(export0)[i]]
+};
+var export1 = __webpack_require__(1)
+for(var i in Object.keys(export1)) {
+	module.exports[Object.keys(export1)[i]] = export1[Object.keys(export1)[i]]
+};
+
+
+/***/ }
+/******/ ]);
+```
+
+# Info
+
+## Uncompressed
+
+```
+Hash: e56f95c1a381be3b34ad
+Version: webpack 2.1.0-beta.20
+Time: 53ms
+    Asset    Size  Chunks             Chunk Names
+bundle.js  2.9 kB       0  [emitted]  bundle
+   [0] ./a.js 15 bytes {0} [built]
+   [1] ./b.js 15 bytes {0} [built]
+   [2] multi bundle 40 bytes {0} [built]
+```

--- a/examples/exportAllModules/a.js
+++ b/examples/exportAllModules/a.js
@@ -1,0 +1,1 @@
+exports.A = "a"

--- a/examples/exportAllModules/b.js
+++ b/examples/exportAllModules/b.js
@@ -1,0 +1,1 @@
+exports.B = "b"

--- a/examples/exportAllModules/webpack.config.js
+++ b/examples/exportAllModules/webpack.config.js
@@ -1,0 +1,11 @@
+var path = require("path");
+module.exports = {
+	entry: {
+		bundle: ["./a", "./b"]
+	},
+	output: {
+		path: path.join(__dirname, "js"),
+		filename: "[name].js",
+		exportAllModules: true
+	}
+}

--- a/lib/MultiModule.js
+++ b/lib/MultiModule.js
@@ -40,13 +40,22 @@ MultiModule.prototype.source = function(dependencyTemplates, outputOptions) {
 	var str = [];
 	this.dependencies.forEach(function(dep, idx) {
 		if(dep.module) {
-			if(idx === this.dependencies.length - 1)
-				str.push("module.exports = ");
-			str.push("__webpack_require__(");
-			if(outputOptions.pathinfo)
-				str.push("/*! " + dep.request + " */");
-			str.push("" + JSON.stringify(dep.module.id));
-			str.push(")");
+			if (outputOptions.exportAllModules === true) {
+				str.push("var export" + dep.module.id + " = __webpack_require__(");
+				if (outputOptions.pathinfo)
+					str.push("/*! " + dep.request + " */");
+				str.push("" + JSON.stringify(dep.module.id));
+				str.push(")");
+				str.push("\nfor(var i in Object.keys(export" + dep.module.id + ")) {\n\tmodule.exports[Object.keys(export" + dep.module.id + ")[i]] = export" + dep.module.id + "[Object.keys(export" + dep.module.id + ")[i]]\n}");
+			} else {
+				if (idx === this.dependencies.length - 1)
+					str.push("module.exports = ");
+				str.push("__webpack_require__(");
+				if (outputOptions.pathinfo)
+					str.push("/*! " + dep.request + " */");
+				str.push("" + JSON.stringify(dep.module.id));
+				str.push(")");
+			}
 		} else {
 			str.push("(function webpackMissingModule() { throw new Error(");
 			str.push(JSON.stringify("Cannot find module \"" + dep.request + "\""));


### PR DESCRIPTION
The configuration setting output.exportAllModuels:boolean allows multiple exports, instead of just the last one. For more information see: #2809