### PR TITLE
Log original and mapped filename+line+column on uglify error

### DIFF
--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -129,7 +129,7 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 							column: err.col
 						});
 						if(original && original.source) {
-							compilation.errors.push(new Error(file + " from UglifyJs\n" + err.message + " [" + requestShortener.shorten(original.source) + ":" + original.line + "," + original.column + "]"));
+							compilation.errors.push(new Error(file + " from UglifyJs\n" + err.message + " [" + requestShortener.shorten(original.source) + ":" + original.line + "," + original.column + "][" + file + ":" + err.line + "," + err.col + "]"));
 						} else {
 							compilation.errors.push(new Error(file + " from UglifyJs\n" + err.message + " [" + file + ":" + err.line + "," + err.col + "]"));
 						}


### PR DESCRIPTION
When an error occurs during minification of a source-mapped file, the error message indicates the name, line and column of the original file containing the error.

Sometimes the error is the result of an issue with transpilation. In order to ease debugging, the error message is extended with the name, line number and column at which the parsing error occurred in the transpiled file as well.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No