### PR TITLE
Keep the parsed comments along with the AST

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -1039,10 +1039,11 @@ var POSSIBLE_AST_OPTIONS = [{
 }]
 
 Parser.prototype.parse = function parse(source, initialState) {
-	var ast;
+	var ast, comments = [];
 	for(var i = 0; i < POSSIBLE_AST_OPTIONS.length; i++) {
 		if(!ast) {
 			try {
+				POSSIBLE_AST_OPTIONS[i].onComment = comments;
 				ast = acorn.parse(source, POSSIBLE_AST_OPTIONS[i]);
 			} catch(e) {
 				// ignore the error
@@ -1055,7 +1056,8 @@ Parser.prototype.parse = function parse(source, initialState) {
 			ranges: true,
 			locations: true,
 			ecmaVersion: 6,
-			sourceType: "module"
+			sourceType: "module",
+			onComment: comments
 		});
 	}
 	if(!ast || typeof ast !== "object")
@@ -1068,7 +1070,7 @@ Parser.prototype.parse = function parse(source, initialState) {
 		renames: {}
 	};
 	var state = this.state = initialState || {};
-	if(this.applyPluginsBailResult("program", ast) === undefined)
+	if(this.applyPluginsBailResult("program", ast, comments) === undefined)
 		this.walkStatements(ast.body);
 	this.scope = oldScope;
 	this.state = oldState;

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -1043,6 +1043,7 @@ Parser.prototype.parse = function parse(source, initialState) {
 	for(var i = 0; i < POSSIBLE_AST_OPTIONS.length; i++) {
 		if(!ast) {
 			try {
+				comments.length = 0;
 				POSSIBLE_AST_OPTIONS[i].onComment = comments;
 				ast = acorn.parse(source, POSSIBLE_AST_OPTIONS[i]);
 			} catch(e) {

--- a/test/Parser.test.js
+++ b/test/Parser.test.js
@@ -200,6 +200,36 @@ describe("Parser", function() {
 		});
 	});
 
+	it("should parse comments", function() {
+		var source = "//comment1\n/*comment2*/";
+		var state = [
+			{
+				type: 'Line',
+				value: 'comment1'
+			}, {
+				type: 'Block',
+				value: 'comment2'
+			}
+		];
+
+		var testParser = new Parser({});
+
+		testParser.plugin("program", function(ast, comments) {
+			if(!this.state.comments) this.state.comments = comments;
+			return true;
+		});
+
+		var actual = testParser.parse(source);
+		should.strictEqual(typeof actual, "object");
+		should.strictEqual(typeof actual.comments, "object");
+		state.forEach(function(element, index) {
+			should.strictEqual(typeof element.type, "string");
+			should.strictEqual(typeof element.value, "string");
+			element.type.should.be.eql(state[index].type);
+			element.value.should.be.eql(state[index].value);
+		});
+	});
+
 	describe("expression evaluation", function() {
 		function evaluateInParser(source) {
 			var parser = new Parser();

--- a/test/Parser.test.js
+++ b/test/Parser.test.js
@@ -222,7 +222,7 @@ describe("Parser", function() {
 		var actual = testParser.parse(source);
 		should.strictEqual(typeof actual, "object");
 		should.strictEqual(typeof actual.comments, "object");
-		state.forEach(function(element, index) {
+		actual.comments.forEach(function(element, index) {
 			should.strictEqual(typeof element.type, "string");
 			should.strictEqual(typeof element.value, "string");
 			element.type.should.be.eql(state[index].type);


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Feature

**What is the current behavior?**

The comments from parsing done by `acorn` are thrown away / ignored.

**What is the new behavior?**

We keep the comments and pass them along to the `'program'` plugin hook as a second, optional parameter, after the AST. This allows external plugins to make use of the comments contained within the files without re-parsing each file.

**Does this PR introduce a breaking change?**
- [x] No, it's a very minor change

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Question @TheLarkInn: where should the docs be updated / added?
