### PR TITLE
Prevent request names from breaking comments

### DIFF
--- a/lib/ModuleFilenameHelpers.js
+++ b/lib/ModuleFilenameHelpers.js
@@ -96,20 +96,18 @@ ModuleFilenameHelpers.createFooter = function createFooter(module, requestShorte
 	if(!module) module = "";
 	if(typeof module === "string") {
 		return [
-			"/** WEBPACK FOOTER **",
-			" ** " + requestShortener.shorten(module),
-			" **/"
+			"// WEBPACK FOOTER //",
+			"// " + requestShortener.shorten(module)
 		].join("\n");
 	} else {
 		return [
-			"/*****************",
-			" ** WEBPACK FOOTER",
-			" ** " + module.readableIdentifier(requestShortener),
-			" ** module id = " + module.id,
-			" ** module chunks = " + module.chunks.map(function(c) {
+			"//////////////////",
+			"// WEBPACK FOOTER",
+			"// " + module.readableIdentifier(requestShortener),
+			"// module id = " + module.id,
+			"// module chunks = " + module.chunks.map(function(c) {
 				return c.id;
-			}).join(" "),
-			" **/"
+			}).join(" ")
 		].join("\n");
 	}
 };


### PR DESCRIPTION
**This was previously merged into master as b2420d1. This is simply back-porting it to `webpack-1`.**

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/webpack/webpack/issues/1759#issuecomment-242489351


**What is the new behavior?**
Comments are not prematurely closed because single-line comments are used


**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No

**Other information**:

Using `/*` as comment delimiters allows request names to terminate a comment early, like in https://github.com/carteb/carte-blanche/pull/262.