### PR TITLE
Fix bundle syntax errors with pathinfo: true and */ in request

### DIFF
--- a/lib/FunctionModuleTemplatePlugin.js
+++ b/lib/FunctionModuleTemplatePlugin.js
@@ -23,9 +23,9 @@ FunctionModuleTemplatePlugin.prototype.apply = function(moduleTemplate) {
 	moduleTemplate.plugin("package", function(moduleSource, module) {
 		if(this.outputOptions.pathinfo) {
 			var source = new ConcatSource();
-			var req = module.readableIdentifier(this.requestShortener);
+			var req = module.readableIdentifier(this.requestShortener).replace(/\*\//g, "*_/");
 			source.add("/*!****" + req.replace(/./g, "*") + "****!*\\\n");
-			source.add("  !*** " + req.replace(/\*\//g, "*_/") + " ***!\n");
+			source.add("  !*** " + req + " ***!\n");
 			source.add("  \\****" + req.replace(/./g, "*") + "****/\n");
 			source.add(moduleSource);
 			return source;

--- a/lib/MultiModule.js
+++ b/lib/MultiModule.js
@@ -43,7 +43,7 @@ MultiModule.prototype.source = function(dependencyTemplates, outputOptions) {
 				str.push("module.exports = ");
 			str.push("__webpack_require__(");
 			if(outputOptions.pathinfo)
-				str.push("/*! " + dep.request + " */");
+				str.push("/*! " + dep.request.replace(/\*\//g, "*_/") + " */");
 			str.push("" + JSON.stringify(dep.module.id));
 			str.push(")");
 		} else {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
#1759

**What is the new behavior?**
`*/` in a request is escaped to `*_/`, just like in https://github.com/webpack/webpack/blob/v1.13.2/lib/FunctionModuleTemplatePlugin.js#L28

**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No

**Other information**:

Closes #1759

Before:

``` javascript
module.exports = __webpack_require__(/*! ./main.js?*/ */1);
```

After:

``` javascript
module.exports = __webpack_require__(/*! ./main.js?*_/ */1);
```

Also fixes a completely superficial comment alignment problem

Before:

``` javascript
/*!********************!*\
  !*** ./main.js?*_/ ***!
  \********************/
```

After:

``` javascript
/*!*********************!*\
  !*** ./main.js?*_/ ***!
  \*********************/
```
