### PR TITLE
Fix AMD require call with three arguments

### DIFF
--- a/lib/dependencies/AMDRequireDependenciesBlock.js
+++ b/lib/dependencies/AMDRequireDependenciesBlock.js
@@ -5,13 +5,25 @@
 var AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
 var AMDRequireDependency = require("./AMDRequireDependency");
 
-function AMDRequireDependenciesBlock(expr, arrayRange, functionRange, module, loc) {
+function AMDRequireDependenciesBlock(expr, arrayRange, functionRange, errorCallbackRange, module, loc) {
 	AsyncDependenciesBlock.call(this, null, module, loc);
 	this.expr = expr;
 	this.outerRange = expr.range;
 	this.arrayRange = arrayRange;
 	this.functionRange = functionRange;
+	this.errorCallbackRange = errorCallbackRange;
 	this.bindThis = true;
+	if(arrayRange && functionRange && errorCallbackRange) {
+		this.range = [arrayRange[0], errorCallbackRange[1]];
+	} else if(arrayRange && functionRange) {
+		this.range = [arrayRange[0], functionRange[1]];
+	} else if(arrayRange) {
+		this.range = arrayRange;
+	} else if(functionRange) {
+		this.range = functionRange;
+	} else {
+		this.range = expr.range;
+	}
 	this.range = arrayRange && functionRange ? [arrayRange[0], functionRange[1]] :
 		arrayRange ? arrayRange :
 		functionRange ? functionRange :

--- a/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
@@ -20,6 +20,28 @@ function AMDRequireDependenciesBlockParserPlugin(options) {
 
 module.exports = AMDRequireDependenciesBlockParserPlugin;
 
+function needsThis(parser, expression) {
+	var bindThis = true;
+	var fnData = getFunctionExpression(expression);
+	if(fnData) {
+		parser.inScope(fnData.fn.params.filter(function(i) {
+			return ["require", "module", "exports"].indexOf(i.name) < 0;
+		}), function() {
+			if(fnData.fn.body.type === "BlockStatement")
+				parser.walkStatement(fnData.fn.body);
+			else
+				parser.walkExpression(fnData.fn.body);
+		}.bind(parser));
+		parser.walkExpressions(fnData.expressions);
+		if(fnData.needThis === false) {
+			bindThis = false;
+		}
+	} else {
+		parser.walkExpression(expression);
+	}
+	return bindThis;
+}
+
 AMDRequireDependenciesBlockParserPlugin.prototype.apply = function(parser) {
 	var options = this.options;
 	parser.plugin("call require", function(expr) {
@@ -27,61 +49,55 @@ AMDRequireDependenciesBlockParserPlugin.prototype.apply = function(parser) {
 		var dep;
 		var old;
 		var result;
-		switch(expr.arguments.length) {
-			case 1:
-				param = this.evaluateExpression(expr.arguments[0]);
-				dep = new AMDRequireDependenciesBlock(expr, param.range, null, this.state.module, expr.loc);
-				old = this.state.current;
-				this.state.current = dep;
+
+		old = this.state.current;
+
+		if(expr.arguments.length) {
+			param = this.evaluateExpression(expr.arguments[0]);
+			dep = new AMDRequireDependenciesBlock(
+				expr,
+				param.range,
+				(expr.arguments.length > 1) ? expr.arguments[1].range : null,
+				(expr.arguments.length > 2) ? expr.arguments[2].range : null,
+				this.state.module,
+				expr.loc
+			);
+			this.state.current = dep;
+		}
+
+		if(expr.arguments.length === 1) {
+			this.inScope([], function() {
+				result = this.applyPluginsBailResult("call require:amd:array", expr, param);
+			}.bind(this));
+			this.state.current = old;
+			if(!result) return;
+			this.state.current.addBlock(dep);
+			return true;
+		}
+
+		if(expr.arguments.length === 2 || expr.arguments.length === 3) {
+			try {
 				this.inScope([], function() {
 					result = this.applyPluginsBailResult("call require:amd:array", expr, param);
 				}.bind(this));
-				this.state.current = old;
-				if(!result) return;
-				this.state.current.addBlock(dep);
-				return true;
-			case 2:
-				param = this.evaluateExpression(expr.arguments[0]);
-				dep = new AMDRequireDependenciesBlock(expr, param.range, expr.arguments[1].range, this.state.module, expr.loc);
-				dep.loc = expr.loc;
-				old = this.state.current;
-				this.state.current = dep;
-				try {
-					this.inScope([], function() {
-						result = this.applyPluginsBailResult("call require:amd:array", expr, param);
-					}.bind(this));
-					if(!result) {
-						dep = new UnsupportedDependency("unsupported", expr.range);
-						old.addDependency(dep);
-						if(this.state.module)
-							this.state.module.errors.push(new UnsupportedFeatureWarning(this.state.module, "Cannot statically analyse 'require(..., ...)' in line " + expr.loc.start.line));
-						dep = null;
-						return true;
-					}
-					var fnData = getFunctionExpression(expr.arguments[1]);
-					if(fnData) {
-						this.inScope(fnData.fn.params.filter(function(i) {
-							return ["require", "module", "exports"].indexOf(i.name) < 0;
-						}), function() {
-							if(fnData.fn.body.type === "BlockStatement")
-								this.walkStatement(fnData.fn.body);
-							else
-								this.walkExpression(fnData.fn.body);
-						}.bind(this));
-						this.walkExpressions(fnData.expressions);
-						if(fnData.needThis === false) {
-							// smaller bundles for simple function expression
-							dep.bindThis = false;
-						}
-					} else {
-						this.walkExpression(expr.arguments[1]);
-					}
-				} finally {
-					this.state.current = old;
-					if(dep)
-						this.state.current.addBlock(dep);
+				if(!result) {
+					dep = new UnsupportedDependency("unsupported", expr.range);
+					old.addDependency(dep);
+					if(this.state.module)
+						this.state.module.errors.push(new UnsupportedFeatureWarning(this.state.module, "Cannot statically analyse 'require(..., ...)' in line " + expr.loc.start.line));
+					dep = null;
+					return true;
 				}
-				return true;
+				dep.bindThis = needsThis(this, expr.arguments[1]);
+				if(expr.arguments.length === 3) {
+					dep.errorCallbackBindThis = needsThis(this, expr.arguments[2]);
+				}
+			} finally {
+				this.state.current = old;
+				if(dep)
+					this.state.current.addBlock(dep);
+			}
+			return true;
 		}
 	});
 	parser.plugin("call require:amd:array", function(expr, param) {

--- a/lib/dependencies/AMDRequireDependency.js
+++ b/lib/dependencies/AMDRequireDependency.js
@@ -22,17 +22,25 @@ AMDRequireDependency.Template.prototype.apply = function(dep, source, outputOpti
 	if(depBlock.arrayRange && !depBlock.functionRange) {
 		source.replace(depBlock.outerRange[0], depBlock.arrayRange[0] - 1,
 			wrapper[0] + "function() {");
-		source.replace(depBlock.arrayRange[1], depBlock.outerRange[1] - 1, ";}" + wrapper[1]);
+		source.replace(depBlock.arrayRange[1], depBlock.outerRange[1] - 1, ";}" + wrapper[1] + wrapper[2] + wrapper[3]);
 	} else if(!depBlock.arrayRange && depBlock.functionRange) {
 		source.replace(depBlock.outerRange[0], depBlock.functionRange[0] - 1,
 			wrapper[0] + "function() {(");
-		source.replace(depBlock.functionRange[1], depBlock.outerRange[1] - 1, ".call(exports, __webpack_require__, exports, module));}" + wrapper[1]);
+		source.replace(depBlock.functionRange[1], depBlock.outerRange[1] - 1, ".call(exports, __webpack_require__, exports, module));}" + wrapper[1] + wrapper[2] + wrapper[3]);
+	} else if(depBlock.arrayRange && depBlock.functionRange && depBlock.errorCallbackRange) {
+		source.replace(depBlock.outerRange[0], depBlock.arrayRange[0] - 1,
+			wrapper[0] + "function() { ");
+		source.insert(depBlock.arrayRange[0] + 0.9, "var __WEBPACK_AMD_REQUIRE_ARRAY__ = ");
+		source.replace(depBlock.arrayRange[1], depBlock.functionRange[0] - 1, "; (");
+		source.insert(depBlock.functionRange[1], ".apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__));");
+		source.replace(depBlock.functionRange[1], depBlock.errorCallbackRange[0] - 1, "}" + (depBlock.bindThis ? ".bind(this)" : "") + wrapper[1]);
+		source.replace(depBlock.errorCallbackRange[1], depBlock.outerRange[1] - 1, (depBlock.errorCallbackBindThis ? ".bind(this)" : "") + wrapper[3]);
 	} else if(depBlock.arrayRange && depBlock.functionRange) {
 		source.replace(depBlock.outerRange[0], depBlock.arrayRange[0] - 1,
 			wrapper[0] + "function() { ");
 		source.insert(depBlock.arrayRange[0] + 0.9, "var __WEBPACK_AMD_REQUIRE_ARRAY__ = ");
 		source.replace(depBlock.arrayRange[1], depBlock.functionRange[0] - 1, "; (");
 		source.insert(depBlock.functionRange[1], ".apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__));");
-		source.replace(depBlock.functionRange[1], depBlock.outerRange[1] - 1, "}" + (depBlock.bindThis ? ".bind(this)" : "") + wrapper[1]);
+		source.replace(depBlock.functionRange[1], depBlock.outerRange[1] - 1, "}" + (depBlock.bindThis ? ".bind(this)" : "") + wrapper[1] + wrapper[2] + wrapper[3]);
 	}
 };

--- a/lib/dependencies/DepBlockHelpers.js
+++ b/lib/dependencies/DepBlockHelpers.js
@@ -7,7 +7,9 @@ var DepBlockHelpers = exports;
 DepBlockHelpers.getLoadDepBlockWrapper = function(depBlock, outputOptions, requestShortener, name) {
 	var promiseCode = DepBlockHelpers.getDepBlockPromise(depBlock, outputOptions, requestShortener, name);
 	return [
-		promiseCode + ".catch(function(err) { __webpack_require__.oe(err); }).then(",
+		promiseCode + ".then(",
+		").catch(",
+		"function(err) { __webpack_require__.oe(err); }",
 		")"
 	];
 };

--- a/lib/dependencies/RequireEnsureDependency.js
+++ b/lib/dependencies/RequireEnsureDependency.js
@@ -21,5 +21,5 @@ RequireEnsureDependency.Template.prototype.apply = function(dep, source, outputO
 	var depBlock = dep.block;
 	var wrapper = DepBlockHelpers.getLoadDepBlockWrapper(depBlock, outputOptions, requestShortener, /*require.e*/ "nsure");
 	source.replace(depBlock.expr.range[0], depBlock.expr.arguments[1].range[0] - 1, wrapper[0] + "(");
-	source.replace(depBlock.expr.arguments[1].range[1], depBlock.expr.range[1] - 1, ").bind(null, __webpack_require__)" + wrapper[1]);
+	source.replace(depBlock.expr.arguments[1].range[1], depBlock.expr.range[1] - 1, ").bind(null, __webpack_require__)" + wrapper[1] + wrapper[2] + wrapper[3]);
 };

--- a/test/cases/parsing/issue-2641/errors.js
+++ b/test/cases/parsing/issue-2641/errors.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[/Module not found/, /Can't resolve '\.\/missingModule' /]
+];

--- a/test/cases/parsing/issue-2641/file.js
+++ b/test/cases/parsing/issue-2641/file.js
@@ -1,0 +1,3 @@
+define(function() {
+	return "file";
+});

--- a/test/cases/parsing/issue-2641/index.js
+++ b/test/cases/parsing/issue-2641/index.js
@@ -1,0 +1,42 @@
+it("should require existing module with supplied error callback", function(done) {
+	require(['./file'], function(file){
+		file.should.be.eql("file");
+		done();
+	}, function(error) {});
+});
+
+it("should call error callback on missing module", function(done) {
+	require(['./file', './missingModule'], function(file){}, function(error) {
+		error.should.be.instanceOf(Error);
+		error.message.should.be.eql('Cannot find module "./missingModule"');
+		done();
+	});
+});
+
+it("should call error callback on missing module in context", function(done) {
+	(function(module) {
+		require(['./' + module], function(file){}, function(error) {
+			error.should.be.instanceOf(Error);
+			error.message.should.be.eql("Cannot find module './missingModule'.");
+			done();
+		});
+	})('missingModule');
+});
+
+it("should call error callback on exception thrown in loading module", function(done) {
+	require(['./throwing'], function(){}, function(error) {
+		error.should.be.instanceOf(Error);
+		error.message.should.be.eql('message');
+		done();
+	});
+});
+
+it("should not call error callback on exception thrown in require callback", function(done) {
+	require(['./throwing'], function() {
+		throw new Error('message');
+	}, function(error) {
+		error.should.be.instanceOf(Error);
+		error.message.should.be.eql('message');
+		done();
+	});
+});

--- a/test/cases/parsing/issue-2641/throwing.js
+++ b/test/cases/parsing/issue-2641/throwing.js
@@ -1,0 +1,3 @@
+define(function() {
+	throw new Error('message');
+});


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
AMD require call with three arguments is not identified by webpack
https://github.com/webpack/webpack/issues/2641

**What is the new behavior?**
Third argument of AMD require call is used as `.catch` promise callback.   

**Does this PR introduce a breaking change?**
- [x] Yes
- [ ] No
- Impact: Originally RequireJS handles exception happened during module loading and exception thrown in loaded module, for example this exceptions will be handled by errorCallback:

``` js
require(['notExistingModule'], function() {}, function errorCallback(error) {
    console.error('Error happened during module loading');
    console.error(error);
});

// or

define('throwingModule', function() {
    throw new Error('Ooops, something really bad happened!');
});

require(['throwingModule'], function() {}, function errorCallback(error) {
    console.error('Error happened during module execution');
    console.error(error);
});
```

But any exception thrown in require callback will be unhandled,  i.e.

``` js
require(['someModule'], function(someModule) {
    throw new Error('Ooops, something really bad happened!'); // would cause unhandled exception in global scope
}, function errorCallback(error) {
    // would not be called
});
```

As i think there is no need to copy this behavior and it's better to handle these exceptions the same as others.
- Migration path for existing applications: Expect that any exception thrown in require callback will be handled by default error callback or supplied errorCallback (3rd argument of require call)
- Github Issue(s) this is regarding: #2641
