### PR TITLE
Throw error when using `HotModuleReplacementPlugin` and `--hot`.

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -377,6 +377,12 @@ module.exports = function(optimist, argv, convertOptions) {
 		ifBooleanArg("hot", function() {
 			ensureArray(options, "plugins");
 			var HotModuleReplacementPlugin = require("../lib/HotModuleReplacementPlugin");
+			var alreadyHasPlugin = options.plugins.some(function(plugin) {
+				return plugin instanceof HotModuleReplacementPlugin;
+			});
+			if(alreadyHasPlugin) {
+				throw new Error("'HotModuleReplacementPlugin' should not be added to the config if using --hot");
+			}
 			options.plugins.push(new HotModuleReplacementPlugin());
 		});
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Increase of strictness

**What is the current behavior?** (You can also link to an open issue here)

Currently, it is possible to add the `--hot` flag and add the `HotModuleReplacementPlugin` in the webpack config. The [docs](https://webpack.github.io/docs/webpack-dev-server.html#webpack-dev-server-cli) say that this should never be done. However, a lot of people don't think of reading the docs because the error message it produces seems unrelated.

I have noticed this issue coming up a couple of times in webpack-dev-server, the only one I can find right now is https://github.com/webpack/webpack-dev-server/issues/488.

**What is the new behavior?**

When using the `--hot` flag, and the `HotModuleReplacementPlugin` is already added in the webpack config, the CLI will throw an error, clarifying that you can't combine the two.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:

This could possibly be seen as a breaking change, but using both ways almost always errors, so I didn't mark this as breaking.
