### PR TITLE
Add default value for entry option.

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -161,8 +161,8 @@ module.exports = function(optimist, argv, convertOptions) {
 	}
 
 	function processOptions(options) {
-		var noOutputFilenameDefined = !options.output || !options.output.filename;
 		new WebpackOptionsDefaulter().process(options);
+		var noOutputFilenameDefined = !options.output || !options.output.filename;
 
 		function ifArg(name, fn, init, finalize) {
 			if(Array.isArray(argv[name])) {

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -26,6 +26,15 @@ function WebpackOptionsDefaulter() {
 	this.set("module.wrappedContextRecursive", true);
 	this.set("module.wrappedContextCritical", false);
 
+	this.set("entry", "call", function(value, options) {
+		if(typeof value === "object") {
+			return value;
+		}
+		return {
+			main: value || "./src/index.js"
+		};
+	});
+
 	this.set("output", "call", function(value, options) {
 		if(typeof value === "string") {
 			return {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
A missing configuration for the `entry` option leads to an error being shown.
See #2954

**What is the new behavior?**
If no `entry` point has been specified, a default of `{main: "./src/index.js"}` is assumed.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 
- Impact:
- Migration path for existing applications: 
- Github Issue(s) this is regarding:

**Other information**:
Did not implement a new default for the `output` configuration as that already has a default value (both for path and filename) and changing it would be a breaking change.

Closes #2954
