### PR TITLE
Add support for multiple library names [Incomplete]

### DIFF
--- a/lib/AmdMainTemplatePlugin.js
+++ b/lib/AmdMainTemplatePlugin.js
@@ -5,7 +5,7 @@
 var ConcatSource = require("webpack-sources").ConcatSource;
 
 function AmdMainTemplatePlugin(names) {
-	if (names && names.constructor !== Array) {
+	if (!Array.isArray(names)) {
 		names = [names];
 	}
 	this.names = names.length > 0 ? names : undefined;

--- a/lib/AmdMainTemplatePlugin.js
+++ b/lib/AmdMainTemplatePlugin.js
@@ -38,15 +38,11 @@ AmdMainTemplatePlugin.prototype.apply = function(compilation) {
 		}
 	}.bind(this));
 	mainTemplate.plugin("global-hash-paths", function(paths) {
-		if(this.name) paths.push(this.name);
+		if(this.names) paths.push.apply(paths, this.names);
 		return paths;
 	}.bind(this));
 	mainTemplate.plugin("hash", function(hash) {
 		hash.update("exports amd");
-		if (this.names) {
-			this.names.forEach(function(name) {
-				hash.update(name + "");
-			});
-		}
+		hash.update(JSON.stringify(this.names));
 	}.bind(this));
 };

--- a/lib/AmdMainTemplatePlugin.js
+++ b/lib/AmdMainTemplatePlugin.js
@@ -4,8 +4,11 @@
 */
 var ConcatSource = require("webpack-sources").ConcatSource;
 
-function AmdMainTemplatePlugin(name) {
-	this.name = name;
+function AmdMainTemplatePlugin(names) {
+	if (names && names.constructor !== Array) {
+		names = [names];
+	}
+	this.names = names.length > 0 ? names : undefined;
 }
 module.exports = AmdMainTemplatePlugin;
 AmdMainTemplatePlugin.prototype.apply = function(compilation) {
@@ -20,12 +23,14 @@ AmdMainTemplatePlugin.prototype.apply = function(compilation) {
 		var externalsArguments = externals.map(function(m) {
 			return "__WEBPACK_EXTERNAL_MODULE_" + m.id + "__";
 		}).join(", ");
-		if(this.name) {
-			var name = mainTemplate.applyPluginsWaterfall("asset-path", this.name, {
-				hash: hash,
-				chunk: chunk
-			});
-			return new ConcatSource("define(" + JSON.stringify(name) + ", " + externalsDepsArray + ", function(" + externalsArguments + ") { return ", source, "});");
+		if(this.names) {
+			return this.names.map(function(nameSrc) {
+				var name = mainTemplate.applyPluginsWaterfall("asset-path", nameSrc, {
+					hash: hash,
+					chunk: chunk
+				}).join("");
+				return new ConcatSource("define(" + JSON.stringify(name) + ", " + externalsDepsArray + ", function(" + externalsArguments + ") { return ", source, "});");
+			})
 		} else if(externalsArguments) {
 			return new ConcatSource("define(" + externalsDepsArray + ", function(" + externalsArguments + ") { return ", source, "});");
 		} else {
@@ -38,6 +43,10 @@ AmdMainTemplatePlugin.prototype.apply = function(compilation) {
 	}.bind(this));
 	mainTemplate.plugin("hash", function(hash) {
 		hash.update("exports amd");
-		hash.update(this.name + "");
+		if (this.names) {
+			this.names.forEach(function(name) {
+				hash.update(name + "");
+			});
+		}
 	}.bind(this));
 };

--- a/lib/JsonpExportMainTemplatePlugin.js
+++ b/lib/JsonpExportMainTemplatePlugin.js
@@ -14,13 +14,13 @@ module.exports = JsonpExportMainTemplatePlugin;
 JsonpExportMainTemplatePlugin.prototype.apply = function(compilation) {
 	var mainTemplate = compilation.mainTemplate;
 	compilation.templatesPlugin("render-with-entry", function(source, chunk, hash) {
-		return this.names.map(function(nameSrc) {
+		return new ConcatSource(this.names.map(function(nameSrc) {
 			var name = mainTemplate.applyPluginsWaterfall("asset-path", nameSrc || "", {
 				hash: hash,
 				chunk: chunk
 			});
-			return new ConcatSource(name + " && " + name + "(", source, ");");
-		}).join("");
+			return name + " && " + name + "(", source, ");";
+		}).join(""));
 	}.bind(this));
 	mainTemplate.plugin("global-hash-paths", function(paths) {
 		if(this.names) paths = paths.concat(this.names);

--- a/lib/JsonpExportMainTemplatePlugin.js
+++ b/lib/JsonpExportMainTemplatePlugin.js
@@ -23,15 +23,11 @@ JsonpExportMainTemplatePlugin.prototype.apply = function(compilation) {
 		}).join(""));
 	}.bind(this));
 	mainTemplate.plugin("global-hash-paths", function(paths) {
-		if(this.names) paths = paths.concat(this.names);
+		if(this.names) paths.push.apply(paths, this.names);
 		return paths;
 	}.bind(this));
 	mainTemplate.plugin("hash", function(hash) {
 		hash.update("jsonp export");
-		if (this.names) {
-			this.names.forEach(function(name) {
-				hash.update(name + "");
-			});
-		}
+		hash.update(JSON.stringify(this.names));
 	}.bind(this));
 };

--- a/lib/JsonpExportMainTemplatePlugin.js
+++ b/lib/JsonpExportMainTemplatePlugin.js
@@ -5,7 +5,7 @@
 var ConcatSource = require("webpack-sources").ConcatSource;
 
 function JsonpExportMainTemplatePlugin(names) {
-	if (names && names.constructor !== Array) {
+	if (!Array.isArray(names)) {
 		names = [names];
 	}
 	this.names = names.length > 0 ? names : undefined;

--- a/lib/JsonpExportMainTemplatePlugin.js
+++ b/lib/JsonpExportMainTemplatePlugin.js
@@ -4,25 +4,34 @@
 */
 var ConcatSource = require("webpack-sources").ConcatSource;
 
-function JsonpExportMainTemplatePlugin(name) {
-	this.name = name;
+function JsonpExportMainTemplatePlugin(names) {
+	if (names && names.constructor !== Array) {
+		names = [names];
+	}
+	this.names = names.length > 0 ? names : undefined;
 }
 module.exports = JsonpExportMainTemplatePlugin;
 JsonpExportMainTemplatePlugin.prototype.apply = function(compilation) {
 	var mainTemplate = compilation.mainTemplate;
 	compilation.templatesPlugin("render-with-entry", function(source, chunk, hash) {
-		var name = mainTemplate.applyPluginsWaterfall("asset-path", this.name || "", {
-			hash: hash,
-			chunk: chunk
-		});
-		return new ConcatSource(name + "(", source, ");");
+		return this.names.map(function(nameSrc) {
+			var name = mainTemplate.applyPluginsWaterfall("asset-path", nameSrc || "", {
+				hash: hash,
+				chunk: chunk
+			});
+			return new ConcatSource(name + " && " + name + "(", source, ");");
+		}).join("");
 	}.bind(this));
 	mainTemplate.plugin("global-hash-paths", function(paths) {
-		if(this.name) paths.push(this.name);
+		if(this.names) paths = paths.concat(this.names);
 		return paths;
 	}.bind(this));
 	mainTemplate.plugin("hash", function(hash) {
 		hash.update("jsonp export");
-		hash.update(this.name + "");
+		if (this.names) {
+			this.names.forEach(function(name) {
+				hash.update(name + "");
+			});
+		}
 	}.bind(this));
 };

--- a/lib/LibraryTemplatePlugin.js
+++ b/lib/LibraryTemplatePlugin.js
@@ -59,7 +59,7 @@ LibraryTemplatePlugin.prototype.apply = function(compiler) {
 				if(this.names) {
 					var varExpressions = this.names.map(function(name) {
 						return accessorAccess(this.target, name);
-					});
+					}.bind(this));
 					compilation.apply(new SetVarMainTemplatePlugin(varExpressions));
 				}
 				else

--- a/lib/LibraryTemplatePlugin.js
+++ b/lib/LibraryTemplatePlugin.js
@@ -43,9 +43,9 @@ LibraryTemplatePlugin.prototype.apply = function(compiler) {
 		switch(this.target) {
 			case "var":
 				var varExpressions = this.names.map(function(name) {
-					return "var " + accessorAccess(false, name);
+					return accessorAccess(false, name);
 				});
-				compilation.apply(new SetVarMainTemplatePlugin(varExpressions));
+				compilation.apply(new SetVarMainTemplatePlugin(varExpressions, false, true));
 				break;
 			case "assign":
 				var varExpressions = this.names.map(function(name) {

--- a/lib/LibraryTemplatePlugin.js
+++ b/lib/LibraryTemplatePlugin.js
@@ -58,7 +58,7 @@ LibraryTemplatePlugin.prototype.apply = function(compiler) {
 			case "global":
 				if(this.names) {
 					var varExpressions = this.names.map(function(name) {
-						return accessorAccess(this.target, this.name);
+						return accessorAccess(this.target, name);
 					});
 					compilation.apply(new SetVarMainTemplatePlugin(varExpressions));
 				}

--- a/lib/LibraryTemplatePlugin.js
+++ b/lib/LibraryTemplatePlugin.js
@@ -23,8 +23,16 @@ function accessorAccess(base, accessor, joinWith) {
 	}).join(joinWith || "; ");
 }
 
-function LibraryTemplatePlugin(name, target, umdNamedDefine, auxiliaryComment) {
-	this.name = name;
+function LibraryTemplatePlugin(names, target, umdNamedDefine, auxiliaryComment) {
+	if (names) {
+		if (names.constructor !== Array) {
+			names = [names];
+		}
+		if (names.length > 0 && names[0].constructor !== Array) {
+			names = [names];
+		}
+	}
+	this.names = names.length > 0 ? names : undefined;
 	this.target = target;
 	this.umdNamedDefine = umdNamedDefine;
 	this.auxiliaryComment = auxiliaryComment;
@@ -34,39 +42,53 @@ LibraryTemplatePlugin.prototype.apply = function(compiler) {
 	compiler.plugin("this-compilation", function(compilation) {
 		switch(this.target) {
 			case "var":
-				compilation.apply(new SetVarMainTemplatePlugin("var " + accessorAccess(false, this.name)));
+				var varExpressions = this.names.map(function(name) {
+					return "var " + accessorAccess(false, name);
+				});
+				compilation.apply(new SetVarMainTemplatePlugin(varExpressions));
 				break;
 			case "assign":
-				compilation.apply(new SetVarMainTemplatePlugin(accessorAccess(undefined, this.name)));
+				var varExpressions = this.names.map(function(name) {
+					return accessorAccess(undefined, name);
+				});
+				compilation.apply(new SetVarMainTemplatePlugin(varExpressions));
 				break;
 			case "this":
 			case "window":
 			case "global":
-				if(this.name)
-					compilation.apply(new SetVarMainTemplatePlugin(accessorAccess(this.target, this.name)));
+				if(this.names) {
+					var varExpressions = this.names.map(function(name) {
+						return accessorAccess(this.target, this.name);
+					});
+					compilation.apply(new SetVarMainTemplatePlugin(varExpressions));
+				}
 				else
-					compilation.apply(new SetVarMainTemplatePlugin(this.target, true));
+					compilation.apply(new SetVarMainTemplatePlugin([this.target], true));
 				break;
 			case "commonjs":
-				if(this.name)
-					compilation.apply(new SetVarMainTemplatePlugin(accessorAccess("exports", this.name)));
+				if(this.names) {
+					var varExpressions = this.names.map(function(name) {
+						return accessorAccess("exports", name);
+					});
+					compilation.apply(new SetVarMainTemplatePlugin(varExpressions));
+				}
 				else
-					compilation.apply(new SetVarMainTemplatePlugin("exports", true));
+					compilation.apply(new SetVarMainTemplatePlugin(["exports"], true));
 				break;
 			case "commonjs2":
-				compilation.apply(new SetVarMainTemplatePlugin("module.exports"));
+				compilation.apply(new SetVarMainTemplatePlugin(["module.exports"]));
 				break;
 			case "commonjs-module":
 				compilation.apply(new CommonJsHarmonyMainTemplatePlugin());
 				break;
 			case "amd":
 				var AmdMainTemplatePlugin = require("./AmdMainTemplatePlugin");
-				compilation.apply(new AmdMainTemplatePlugin(this.name));
+				compilation.apply(new AmdMainTemplatePlugin(this.names));
 				break;
 			case "umd":
 			case "umd2":
 				var UmdMainTemplatePlugin = require("./UmdMainTemplatePlugin");
-				compilation.apply(new UmdMainTemplatePlugin(this.name, {
+				compilation.apply(new UmdMainTemplatePlugin(this.names, {
 					optionalAmdExternalAsGlobal: this.target === "umd2",
 					namedDefine: this.umdNamedDefine,
 					auxiliaryComment: this.auxiliaryComment
@@ -74,7 +96,7 @@ LibraryTemplatePlugin.prototype.apply = function(compiler) {
 				break;
 			case "jsonp":
 				var JsonpExportMainTemplatePlugin = require("./JsonpExportMainTemplatePlugin");
-				compilation.apply(new JsonpExportMainTemplatePlugin(this.name));
+				compilation.apply(new JsonpExportMainTemplatePlugin(this.names));
 				break;
 			default:
 				throw new Error(this.target + " is not a valid Library target");

--- a/lib/LibraryTemplatePlugin.js
+++ b/lib/LibraryTemplatePlugin.js
@@ -25,10 +25,10 @@ function accessorAccess(base, accessor, joinWith) {
 
 function LibraryTemplatePlugin(names, target, umdNamedDefine, auxiliaryComment) {
 	if (names) {
-		if (names.constructor !== Array) {
+		if (!Array.isArray(names)) {
 			names = [names];
 		}
-		if (names.length > 0 && names[0].constructor !== Array) {
+		if (names.length > 0 && !Array.isArray(names[0])) {
 			names = [names];
 		}
 	}

--- a/lib/SetVarMainTemplatePlugin.js
+++ b/lib/SetVarMainTemplatePlugin.js
@@ -30,12 +30,16 @@ SetVarMainTemplatePlugin.prototype.apply = function(compilation) {
 		}).join("");
 	}.bind(this));
 	mainTemplate.plugin("global-hash-paths", function(paths) {
-		if(this.varExpression) paths.push(this.varExpression);
+		if(this.varExpressions) paths = paths.concat(this.varExpressions);
 		return paths;
 	});
 	mainTemplate.plugin("hash", function(hash) {
 		hash.update("set var");
-		hash.update(this.varExpression + "");
+		if (this.varExpressions) {
+			this.varExpressions.forEach(function(varExpression) {
+				hash.update(varExpression + "");
+			});
+		}
 		hash.update(this.copyObject + "");
 	}.bind(this));
 };

--- a/lib/SetVarMainTemplatePlugin.js
+++ b/lib/SetVarMainTemplatePlugin.js
@@ -4,12 +4,16 @@
 */
 var ConcatSource = require("webpack-sources").ConcatSource;
 
-function SetVarMainTemplatePlugin(varExpressions, copyObject) {
+function SetVarMainTemplatePlugin(varExpressions, copyObject, defineVars) {
 	if (varExpressions && varExpressions.constructor !== Array) {
 		varExpressions = [varExpressions];
 	}
 	this.varExpressions = varExpressions.length > 0 ? varExpressions : undefined;
+	if (copyObject && defineVars) {
+		throw new Error("defineVars invalid with copyObject option.");
+	}
 	this.copyObject = copyObject;
+	this.defineVars = !!defineVars;
 }
 module.exports = SetVarMainTemplatePlugin;
 SetVarMainTemplatePlugin.prototype.apply = function(compilation) {
@@ -27,9 +31,18 @@ SetVarMainTemplatePlugin.prototype.apply = function(compilation) {
 				"}(" +
 				JSON.stringify(varExpressionsSrc) + ",\n", source, "\n))");
 		} else {
-			var prefix = varExpressionsSrc.map(function(varExpression) {
-				return varExpression + " ="
-			}).join(" ")+"\n";
+			var prefix = "";
+			if (varExpressionsSrc.length === 1) {
+				prefix = "var " + varExpressionsSrc[0] + " =\n";
+			}
+			else {
+				if (this.defineVars) {
+					prefix += "var " + varExpressionsSrc.join(", ")+";\n";
+				}
+				prefix += varExpressionsSrc.map(function(varExpression) {
+					return varExpression + " ="
+				}).join(" ")+"\n";
+			}
 			return new ConcatSource(prefix, source);
 		}
 	}.bind(this));

--- a/lib/SetVarMainTemplatePlugin.js
+++ b/lib/SetVarMainTemplatePlugin.js
@@ -5,7 +5,7 @@
 var ConcatSource = require("webpack-sources").ConcatSource;
 
 function SetVarMainTemplatePlugin(varExpressions, copyObject, defineVars) {
-	if (varExpressions && varExpressions.constructor !== Array) {
+	if (!Array.isArray(varExpressions)) {
 		varExpressions = [varExpressions];
 	}
 	this.varExpressions = varExpressions.length > 0 ? varExpressions : undefined;

--- a/lib/SetVarMainTemplatePlugin.js
+++ b/lib/SetVarMainTemplatePlugin.js
@@ -26,8 +26,12 @@ SetVarMainTemplatePlugin.prototype.apply = function(compilation) {
 			});
 		});
 		if(this.copyObject) {
+			if (varExpressionsSrc.length === 1) {
+				return new ConcatSource("(function(e, a) { for(var i in a) e[i] = a[i]; }(" +
+					varExpressionsSrc[0] + ",\n", source, "\n))");
+			}
 			return new ConcatSource("(function(e, a) { for(var i in a) " +
-					"for(var j=0; j<e.length; j++) e[j][i] = a[i];" +
+					"for(var j = 0; j < e.length; j++) e[j][i] = a[i];" +
 				"}(" +
 				JSON.stringify(varExpressionsSrc) + ",\n", source, "\n))");
 		} else {

--- a/lib/SetVarMainTemplatePlugin.js
+++ b/lib/SetVarMainTemplatePlugin.js
@@ -25,7 +25,7 @@ SetVarMainTemplatePlugin.prototype.apply = function(compilation) {
 			return new ConcatSource("(function(e, a) { for(var i in a) " +
 					"for(var j=0; j<e.length; j++) e[j][i] = a[i];" +
 				"}(" +
-				JSON.stringify(varExpressionsSrc) + ", \n", source, "\n))");
+				JSON.stringify(varExpressionsSrc) + ",\n", source, "\n))");
 		} else {
 			var prefix = varExpressionsSrc.map(function(varExpression) {
 				return varExpression + " ="

--- a/lib/SetVarMainTemplatePlugin.js
+++ b/lib/SetVarMainTemplatePlugin.js
@@ -8,26 +8,30 @@ function SetVarMainTemplatePlugin(varExpressions, copyObject) {
 	if (varExpressions && varExpressions.constructor !== Array) {
 		varExpressions = [varExpressions];
 	}
-	this.varExpressions = varExpressions;
+	this.varExpressions = varExpressions.length > 0 ? varExpressions : undefined;
 	this.copyObject = copyObject;
 }
 module.exports = SetVarMainTemplatePlugin;
 SetVarMainTemplatePlugin.prototype.apply = function(compilation) {
 	var mainTemplate = compilation.mainTemplate;
 	compilation.templatesPlugin("render-with-entry", function(source, chunk, hash) {
-		return this.varExpressions.map(function(varExpressionSrc) {
-			var varExpression = mainTemplate.applyPluginsWaterfall("asset-path", varExpressionSrc, {
+		var varExpressionsSrc = this.varExpressions.map(function(varExpressionSrc) {
+			return mainTemplate.applyPluginsWaterfall("asset-path", varExpressionSrc, {
 				hash: hash,
 				chunk: chunk
 			});
-			if(this.copyObject) {
-				return new ConcatSource("(function(e, a) { for(var i in a) e[i] = a[i]; }(" +
-					varExpression + ", ", source, "))");
-			} else {
-				var prefix = varExpression + " =\n";
-				return new ConcatSource(prefix, source);
-			}
-		}).join("");
+		});
+		if(this.copyObject) {
+			return new ConcatSource("(function(e, a) { for(var i in a) " +
+					"for(var j=0; j<e.length; j++) e[j][i] = a[i];" +
+				"}(" +
+				JSON.stringify(varExpressionsSrc) + ", \n", source, "\n))");
+		} else {
+			var prefix = varExpressionsSrc.map(function(varExpression) {
+				return varExpression + " ="
+			}).join(" ")+"\n";
+			return new ConcatSource(prefix, source);
+		}
 	}.bind(this));
 	mainTemplate.plugin("global-hash-paths", function(paths) {
 		if(this.varExpressions) paths = paths.concat(this.varExpressions);

--- a/lib/SetVarMainTemplatePlugin.js
+++ b/lib/SetVarMainTemplatePlugin.js
@@ -4,25 +4,30 @@
 */
 var ConcatSource = require("webpack-sources").ConcatSource;
 
-function SetVarMainTemplatePlugin(varExpression, copyObject) {
-	this.varExpression = varExpression;
+function SetVarMainTemplatePlugin(varExpressions, copyObject) {
+	if (varExpressions && varExpressions.constructor !== Array) {
+		varExpressions = [varExpressions];
+	}
+	this.varExpressions = varExpressions;
 	this.copyObject = copyObject;
 }
 module.exports = SetVarMainTemplatePlugin;
 SetVarMainTemplatePlugin.prototype.apply = function(compilation) {
 	var mainTemplate = compilation.mainTemplate;
 	compilation.templatesPlugin("render-with-entry", function(source, chunk, hash) {
-		var varExpression = mainTemplate.applyPluginsWaterfall("asset-path", this.varExpression, {
-			hash: hash,
-			chunk: chunk
-		});
-		if(this.copyObject) {
-			return new ConcatSource("(function(e, a) { for(var i in a) e[i] = a[i]; }(" +
-				varExpression + ", ", source, "))");
-		} else {
-			var prefix = varExpression + " =\n";
-			return new ConcatSource(prefix, source);
-		}
+		return this.varExpressions.map(function(varExpressionSrc) {
+			var varExpression = mainTemplate.applyPluginsWaterfall("asset-path", varExpressionSrc, {
+				hash: hash,
+				chunk: chunk
+			});
+			if(this.copyObject) {
+				return new ConcatSource("(function(e, a) { for(var i in a) e[i] = a[i]; }(" +
+					varExpression + ", ", source, "))");
+			} else {
+				var prefix = varExpression + " =\n";
+				return new ConcatSource(prefix, source);
+			}
+		}).join("");
 	}.bind(this));
 	mainTemplate.plugin("global-hash-paths", function(paths) {
 		if(this.varExpression) paths.push(this.varExpression);

--- a/lib/UmdMainTemplatePlugin.js
+++ b/lib/UmdMainTemplatePlugin.js
@@ -20,8 +20,11 @@ function accessorAccess(base, accessor) {
 	}).join(", ");
 }
 
-function UmdMainTemplatePlugin(name, options) {
-	this.name = name;
+function UmdMainTemplatePlugin(names, options) {
+	if (names && names.constructor !== Array) {
+		names = [names];
+	}
+	this.names = names.length > 0 ? names : undefined;
 	this.optionalAmdExternalAsGlobal = options.optionalAmdExternalAsGlobal;
 	this.namedDefine = options.namedDefine;
 	this.auxiliaryComment = options.auxiliaryComment;
@@ -128,16 +131,22 @@ UmdMainTemplatePlugin.prototype.apply = function(compilation) {
 			) +
 			"	else if(typeof define === 'function' && define.amd)\n" +
 			(requiredExternals.length > 0 ?
-				(this.name && this.namedDefine === true ?
-					"		define(" + libraryName(this.name) + ", " + externalsDepsArray(requiredExternals) + ", " + amdFactory + ");\n" :
-					"		define(" + externalsDepsArray(requiredExternals) + ", " + amdFactory + ");\n"
+				(this.names && this.namedDefine === true ?
+					"       var factory = " + amdFactory + ";\n" +
+					this.names.map(function(name) {
+						return "		define(" + libraryName(name) + ", " + externalsDepsArray(requiredExternals) + ", factory);\n"
+					}).join("") :
+					"		define(" + externalsDepsArray(requiredExternals) + ", " + amdFactory + ");\n";
 				) :
-				(this.name && this.namedDefine === true ?
-					"		define(" + libraryName(this.name) + ", [], " + amdFactory + ");\n" :
+				(this.names && this.namedDefine === true ?
+					"       var factory = " + amdFactory + ";\n" +
+					this.names.map(function(name) {
+						return "		define(" + libraryName(name) + ", [], factory);\n";
+					}).join("") :
 					"		define([], " + amdFactory + ");\n"
 				)
 			) +
-			(this.name ?
+			(this.names ?
 				(this.auxiliaryComment &&
 					typeof this.auxiliaryComment === 'string' ?
 					"   //" + this.auxiliaryComment + "\n" :
@@ -146,7 +155,10 @@ UmdMainTemplatePlugin.prototype.apply = function(compilation) {
 					""
 				) +
 				"	else if(typeof exports === 'object')\n" +
-				"		exports[" + libraryName(this.name) + "] = factory(" + externalsRequireArray("commonjs") + ");\n" +
+				"       " +
+				this.names.map(function(name) {
+					return "exports[" + libraryName(name) + "] = ";
+				}).join("") + "factory(" + externalsRequireArray("commonjs") + ");\n" +
 				(this.auxiliaryComment &&
 					typeof this.auxiliaryComment === 'string' ?
 					"   //" + this.auxiliaryComment + "\n" :
@@ -155,7 +167,10 @@ UmdMainTemplatePlugin.prototype.apply = function(compilation) {
 					""
 				) +
 				"	else\n" +
-				"		" + replaceKeys(accessorAccess("root", this.name)) + " = factory(" + externalsRootArray(externals) + ");\n" :
+				"       " +
+				this.names.map(function(name) {
+					return replaceKeys(accessorAccess("root", name)) + " = ";
+				}).join("") + "factory(" + externalsRootArray(externals) + ");\n" :
 				"	else {\n" +
 				(externals.length > 0 ?
 					"		var a = typeof exports === 'object' ? factory(" + externalsRequireArray("commonjs") + ") : factory(" + externalsRootArray(externals) + ");\n" :
@@ -167,11 +182,15 @@ UmdMainTemplatePlugin.prototype.apply = function(compilation) {
 			"})(this, function(" + externalsArguments(externals) + ") {\nreturn ", "webpack/universalModuleDefinition"), source, "\n});\n");
 	}.bind(this));
 	mainTemplate.plugin("global-hash-paths", function(paths) {
-		if(this.name) paths = paths.concat(this.name);
+		if(this.names) paths = paths.concat(this.names);
 		return paths;
 	}.bind(this));
 	mainTemplate.plugin("hash", function(hash) {
 		hash.update("umd");
-		hash.update(this.name + "");
+		if (this.names) {
+			this.names.forEach(function(name) {
+				hash.update(name + "");
+			});
+		}
 	}.bind(this));
 };

--- a/lib/UmdMainTemplatePlugin.js
+++ b/lib/UmdMainTemplatePlugin.js
@@ -132,16 +132,16 @@ UmdMainTemplatePlugin.prototype.apply = function(compilation) {
 			"	else if(typeof define === 'function' && define.amd)\n" +
 			(requiredExternals.length > 0 ?
 				(this.names && this.namedDefine === true ?
-					"       var factory = " + amdFactory + ";\n" +
+					"		var amdFactory = " + amdFactory + ";\n" +
 					this.names.map(function(name) {
-						return "		define(" + libraryName(name) + ", " + externalsDepsArray(requiredExternals) + ", factory);\n"
+						return "		define(" + libraryName(name) + ", " + externalsDepsArray(requiredExternals) + ", amdFactory);\n"
 					}).join("") :
-					"		define(" + externalsDepsArray(requiredExternals) + ", " + amdFactory + ");\n";
+					"		define(" + externalsDepsArray(requiredExternals) + ", " + amdFactory + ");\n"
 				) :
 				(this.names && this.namedDefine === true ?
-					"       var factory = " + amdFactory + ";\n" +
+					"		var amdFactory = " + amdFactory + ";\n" +
 					this.names.map(function(name) {
-						return "		define(" + libraryName(name) + ", [], factory);\n";
+						return "		define(" + libraryName(name) + ", [], amdFactory);\n";
 					}).join("") :
 					"		define([], " + amdFactory + ");\n"
 				)
@@ -155,7 +155,7 @@ UmdMainTemplatePlugin.prototype.apply = function(compilation) {
 					""
 				) +
 				"	else if(typeof exports === 'object')\n" +
-				"       " +
+				"		" +
 				this.names.map(function(name) {
 					return "exports[" + libraryName(name) + "] = ";
 				}).join("") + "factory(" + externalsRequireArray("commonjs") + ");\n" +
@@ -167,7 +167,7 @@ UmdMainTemplatePlugin.prototype.apply = function(compilation) {
 					""
 				) +
 				"	else\n" +
-				"       " +
+				"		" +
 				this.names.map(function(name) {
 					return replaceKeys(accessorAccess("root", name)) + " = ";
 				}).join("") + "factory(" + externalsRootArray(externals) + ");\n" :

--- a/lib/UmdMainTemplatePlugin.js
+++ b/lib/UmdMainTemplatePlugin.js
@@ -21,7 +21,7 @@ function accessorAccess(base, accessor) {
 }
 
 function UmdMainTemplatePlugin(names, options) {
-	if (names && names.constructor !== Array) {
+	if (!Array.isArray(names)) {
 		names = [names];
 	}
 	this.names = names.length > 0 ? names : undefined;

--- a/lib/UmdMainTemplatePlugin.js
+++ b/lib/UmdMainTemplatePlugin.js
@@ -182,15 +182,11 @@ UmdMainTemplatePlugin.prototype.apply = function(compilation) {
 			"})(this, function(" + externalsArguments(externals) + ") {\nreturn ", "webpack/universalModuleDefinition"), source, "\n});\n");
 	}.bind(this));
 	mainTemplate.plugin("global-hash-paths", function(paths) {
-		if(this.names) paths = paths.concat(this.names);
+		if(this.names) paths.push.apply(paths, this.names);
 		return paths;
 	}.bind(this));
 	mainTemplate.plugin("hash", function(hash) {
 		hash.update("umd");
-		if (this.names) {
-			this.names.forEach(function(name) {
-				hash.update(name + "");
-			});
-		}
+		hash.update(JSON.stringify(this.names));
 	}.bind(this));
 };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
No support for exporting as multiple names.

**What is the new behavior?**
Adds support for exporting as a library with multiple names. (#2981, https://github.com/clappr/clappr/issues/1145)

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:
I still need to add/update tests and the docs but would like someone to check I'm along the right lines first.

I get an error building something with the `libraryTarget` set to "amd" or "jsonp", but I also get the same error when I build without the changes made in this PR so was wondering if this is a known bug at the moment?

```
ERROR in chunk main [entry]
[output file name here]
path.replace is not a function
```

Also I am aware this doesn't work with `libraryType` `var` at the moment as it results in `var a = var b = X`.
