### PR TITLE
fix: Convert webworker template runtime to be Promise-based API

### DIFF
--- a/lib/webworker/WebWorkerMainTemplate.runtime.js
+++ b/lib/webworker/WebWorkerMainTemplate.runtime.js
@@ -14,39 +14,41 @@ module.exports = function() {
 	}
 
 	function hotDownloadManifest(callback) { // eslint-disable-line no-unused-vars
-		if(typeof XMLHttpRequest === "undefined")
-			return callback(new Error("No browser support"));
-		try {
-			var request = new XMLHttpRequest();
-			var requestPath = $require$.p + $hotMainFilename$;
-			request.open("GET", requestPath, true);
-			request.timeout = 10000;
-			request.send(null);
-		} catch(err) {
-			return callback(err);
-		}
-		request.onreadystatechange = function() {
-			if(request.readyState !== 4) return;
-			if(request.status === 0) {
-				// timeout
-				callback(new Error("Manifest request to " + requestPath + " timed out."));
-			} else if(request.status === 404) {
-				// no update available
-				callback();
-			} else if(request.status !== 200 && request.status !== 304) {
-				// other failure
-				callback(new Error("Manifest request to " + requestPath + " failed."));
-			} else {
-				// success
-				try {
-					var update = JSON.parse(request.responseText);
-				} catch(e) {
-					callback(e);
-					return;
-				}
-				callback(null, update);
+		return new Promise(function(resolve, reject) {
+			if(typeof XMLHttpRequest === "undefined")
+				return reject(new Error("No browser support"));
+			try {
+				var request = new XMLHttpRequest();
+				var requestPath = $require$.p + $hotMainFilename$;
+				request.open("GET", requestPath, true);
+				request.timeout = 10000;
+				request.send(null);
+			} catch(err) {
+				return reject(err);
 			}
-		};
+			request.onreadystatechange = function() {
+				if(request.readyState !== 4) return;
+				if(request.status === 0) {
+					// timeout
+					reject(new Error("Manifest request to " + requestPath + " timed out."));
+				} else if(request.status === 404) {
+					// no update available
+					resolve();
+				} else if(request.status !== 200 && request.status !== 304) {
+					// other failure
+					reject(new Error("Manifest request to " + requestPath + " failed."));
+				} else {
+					// success
+					try {
+						var update = JSON.parse(request.responseText);
+					} catch(e) {
+						reject(e);
+						return;
+					}
+					resolve(update);
+				}
+			}
+		});
 	}
 
 	function hotDiposeChunk(chunkId) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`Cannot call method .then() on undefined` when using hot module replacement with a build that has a target of "webworker" because of this line in the `HotModuleReplacement.runtime` ...

https://github.com/webpack/webpack/blob/master/lib/HotModuleReplacement.runtime.js#L170

...which uses Promises, but the `WebWorkerMainTemplate.runtime` was never converted from the old callback-based API:

https://github.com/webpack/webpack/blob/master/lib/webworker/WebWorkerMainTemplate.runtime.js#L16


**What is the new behavior?**

Switches `WebWorkerMainTemplate.runtime` to a Promises API; no more runtime error; HMR now works with "webworker".


**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No


**Other information**:


Fixes 'cannot call method then on undefined' error when using HMR with a config
whose target is "webworker".

Probably should have happened with 2245c4acca9c028b2b55c5cd7f1a933da605187a