### PR TITLE
add --display-always to display stats even when build output hash does not change

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -118,6 +118,11 @@ yargs.options({
 		group: DISPLAY_GROUP,
 		describe: "Display details about errors"
 	},
+	"display-always": {
+		type: "boolean",
+		group: DISPLAY_GROUP,
+		describe: "Display stats in watch mode even when build output does not change (useful for linting)"
+	},
 	"verbose": {
 		type: "boolean",
 		group: DISPLAY_GROUP,
@@ -240,6 +245,11 @@ function processOptions(options) {
 				outputOptions.cachedAssets = true;
 		});
 
+		ifArg("display-always", function(bool) {
+			if(bool)
+				outputOptions.always = true;
+		});
+
 		if(!outputOptions.exclude && !argv["display-modules"])
 			outputOptions.exclude = ["node_modules", "bower_components", "jam", "components"];
 	} else {
@@ -310,7 +320,7 @@ function processOptions(options) {
 		}
 		if(outputOptions.json) {
 			process.stdout.write(JSON.stringify(stats.toJson(outputOptions), null, 2) + "\n");
-		} else if(stats.hash !== lastHash) {
+		} else if(outputOptions.always || stats.hash !== lastHash) {
 			lastHash = stats.hash;
 			process.stdout.write(stats.toString(outputOptions) + "\n");
 		}


### PR DESCRIPTION
fixes https://github.com/webpack/webpack/issues/2538

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
see https://github.com/webpack/webpack/issues/2538

**What is the new behavior?**
If `--display-always` is supplied, webpack shows output stats even when output hash does not change. This allows to see source code lint error messages etc.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:
