### PR TITLE
Docs - update deprecated cssnext link

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Please see [Using Loaders](https://webpack.github.io/docs/using-loaders.html) fo
 **styling**
 * [`style`](https://github.com/webpack/style-loader): Add exports of a module as style to DOM
 * [`css`](https://github.com/webpack/css-loader): Loads css file with resolved imports and returns css code
-* [`cssnext`](https://github.com/MoOx/cssnext-loader): Loads and compiles a css file using [cssnext](http://cssnext.io/)
+* [`cssnext`](https://github.com/MoOx/postcss-cssnext): Loads and compiles a css file using [cssnext](http://cssnext.io/)
 * [`less`](https://github.com/webpack/less-loader): Loads and compiles a less file
 * [`sass`](https://github.com/jtangelder/sass-loader): Loads and compiles a scss file
 * [`stylus`](https://github.com/shama/stylus-loader): Loads and compiles a stylus file

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Please see [Using Loaders](https://webpack.github.io/docs/using-loaders.html) fo
 **styling**
 * [`style`](https://github.com/webpack/style-loader): Add exports of a module as style to DOM
 * [`css`](https://github.com/webpack/css-loader): Loads css file with resolved imports and returns css code
-* [`cssnext`](https://github.com/MoOx/postcss-cssnext): Loads and compiles a css file using [cssnext](http://cssnext.io/)
+* [`postcss`](https://github.com/postcss/postcss-loader): Loads and compiles css using various [plugins](https://github.com/postcss/postcss#plugins)
 * [`less`](https://github.com/webpack/less-loader): Loads and compiles a less file
 * [`sass`](https://github.com/jtangelder/sass-loader): Loads and compiles a scss file
 * [`stylus`](https://github.com/shama/stylus-loader): Loads and compiles a stylus file


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] N/A - Tests for the changes have been added (for bug fixes / features)
- [ ] N/A - Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:
Docs

**What is the current behavior?** (You can also link to an open issue here)
Deprecated readme link (https://github.com/MoOx/cssnext-loader)

**What is the new behavior?**
 Updated to new link (https://github.com/MoOx/postcss-cssnext)


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: 
* Github Issue(s) this is regarding:


**Other information**:
