### PR TITLE
Moving parsing of the `progress` flag to webpack specific bin

### DIFF
--- a/bin/config-yargs.js
+++ b/bin/config-yargs.js
@@ -190,11 +190,6 @@ module.exports = function(yargs) {
 				group: BASIC_GROUP,
 				requiresArg: true
 			},
-			"progress": {
-				type: "boolean",
-				describe: "Print compilation progress in percentage",
-				group: BASIC_GROUP
-			},
 			"resolve-alias": {
 				type: "string",
 				describe: "Setup a module alias for resolving (Example: jquery-plugin=jquery.plugin)",

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -21,12 +21,18 @@ var yargs = require("yargs")
 require("./config-yargs")(yargs);
 
 var DISPLAY_GROUP = "Stats options:";
+var BASIC_GROUP = "Basic options:";
 
 yargs.options({
 	"json": {
 		type: "boolean",
 		alias: "j",
 		describe: "Prints the result as JSON."
+	},
+	"progress": {
+		type: "boolean",
+		describe: "Print compilation progress in percentage",
+		group: BASIC_GROUP
 	},
 	"color": {
 		type: "boolean",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

As discussed in #3015, `--progress` is shared between webpack and WDS.
This is inconsistent, because parsing of this flag happens in `bin/webpack.js` (not accesible by WDS).
Therefore, `--progress` should also be defined in `bin/webpack.js`.

**What is the new behavior?**

`--progress` is now only defined in the webpack-specific config.

**Does this PR introduce a breaking change?**
- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the following... 

* Impact: WDS needs to be updated.
* Migration path for existing applications: Not relevant, since it's an internal detail between webpack and WDS. 
* Github Issue(s) this is regarding: #3015


**Other information**:

Maybe the `--profile` flag should also be moved to `bin/webpack.js`, but I'm not sure about this.

@sokra ^