### PR TITLE
Adds empty into schema for node

### DIFF
--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -665,7 +665,8 @@
         "enum": [
           false,
           true,
-          "mock"
+          "mock",
+          "empty"
         ]
       },
       "properties": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Any `{ node: { fs: 'empty' } }` will not allow Webpack to run


**What is the new behavior?**
Any `{ node: { fs: 'empty' } }` will run as it did in beta.22


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: 
* Github Issue(s) this is regarding:


**Other information**:


Support for empty was broken through the schema, so I've added it back. This is exactly why Webpack should only be warning and not throwing errors as I now need to lock down to a version before the schema enforcement.