### PR TITLE
replaced calls to Object.assign with objectAssign to support node 0.12.x

### DIFF
--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -2,6 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+var objectAssign = require('object-assign');
 var path = require("path");
 var ModuleParserHelpers = require("./ModuleParserHelpers");
 var ConstDependency = require("./dependencies/ConstDependency");
@@ -27,7 +28,7 @@ NodeStuffPlugin.prototype.apply = function(compiler) {
 
 			var localOptions = options;
 			if(parserOptions.node)
-				localOptions = Object.assign({}, localOptions, parserOptions.node);
+				localOptions = objectAssign({}, localOptions, parserOptions.node);
 
 			function ignore() {
 				return true;

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -3,7 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 var async = require("async");
-
+var objectAssign = require('object-assign');
 var Tapable = require("tapable");
 var NormalModule = require("./NormalModule");
 var RawModule = require("./RawModule");
@@ -214,7 +214,7 @@ NormalModuleFactory.prototype.resolveRequestArray = function resolveRequestArray
 	async.map(array, function(item, callback) {
 		resolver.resolve(contextInfo, context, item.loader, function(err, result) {
 			if(err) return callback(err);
-			return callback(null, Object.assign({}, item, {
+			return callback(null, objectAssign({}, item, {
 				loader: result
 			}));
 		});

--- a/lib/node/NodeSourcePlugin.js
+++ b/lib/node/NodeSourcePlugin.js
@@ -3,6 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 var AliasPlugin = require("enhanced-resolve/lib/AliasPlugin");
+var objectAssign = require('object-assign');
 var ModuleParserHelpers = require("../ModuleParserHelpers");
 var nodeLibsBrowser = require("node-libs-browser");
 
@@ -31,7 +32,7 @@ NodeSourcePlugin.prototype.apply = function(compiler) {
 
 			var localOptions = options;
 			if(parserOptions.node)
-				localOptions = Object.assign({}, localOptions, parserOptions.node);
+				localOptions = objectAssign({}, localOptions, parserOptions.node);
 
 			if(localOptions.process) {
 				var processType = localOptions.process;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ x] Bugfix

**What is the current behavior?**
Issue #3041. With node 0.12.x it fails with
```
/node_modules/webpack/lib/NormalModuleFactory.js:217
            return callback(null, Object.assign({}, item, {
                                         ^
TypeError: undefined is not a function
```

**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No
