### PR TITLE
Cache portable id to avoid expensive function call

### DIFF
--- a/lib/Module.js
+++ b/lib/Module.js
@@ -16,7 +16,7 @@ function Module() {
 	this.debugId = debugId++;
 	this.lastId = -1;
 	this.id = null;
-	this.portableIdentifier = null;
+	this.portableId = null;
 	this.index = null;
 	this.index2 = null;
 	this.used = null;

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -16,6 +16,7 @@ function Module() {
 	this.debugId = debugId++;
 	this.lastId = -1;
 	this.id = null;
+	this.portableIdentifier = null;
 	this.index = null;
 	this.index2 = null;
 	this.used = null;

--- a/lib/RecordIdsPlugin.js
+++ b/lib/RecordIdsPlugin.js
@@ -23,7 +23,8 @@ RecordIdsPlugin.prototype.apply = function(compiler) {
 			if(!records.modules.byIdentifier) records.modules.byIdentifier = {};
 			if(!records.modules.usedIds) records.modules.usedIds = {};
 			modules.forEach(function(module) {
-				var identifier = makeRelative(compiler, module.identifier());
+				if(!module.portableId) module.portableId = makeRelative(compiler, module.identifier());
+				var identifier = module.portableId;
 				records.modules.byIdentifier[identifier] = module.id;
 				records.modules.usedIds[module.id] = module.id;
 			});
@@ -34,7 +35,8 @@ RecordIdsPlugin.prototype.apply = function(compiler) {
 				var usedIds = {};
 				modules.forEach(function(module) {
 					if(module.id !== null) return;
-					var identifier = makeRelative(compiler, module.identifier());
+					if(!module.portableId) module.portableId = makeRelative(compiler, module.identifier());
+					var identifier = module.portableId;
 					var id = records.modules.byIdentifier[identifier];
 					if(id === undefined) return;
 					if(usedIds[id]) return;

--- a/test/RecordIdsPlugin.test.js
+++ b/test/RecordIdsPlugin.test.js
@@ -1,0 +1,55 @@
+var should = require("should");
+
+var path = require("path");
+var webpack = require("../lib/webpack");
+
+var RecordIdsPlugin = require("../lib/RecordIdsPlugin");
+
+function makeRelative(compiler, identifier) {
+	var context = compiler.context;
+	return identifier.split("|").map(function(str) {
+		return str.split("!").map(function(str) {
+			return path.relative(context, str);
+		}).join("!");
+	}).join("|");
+}
+
+describe("RecordIdsPlugin", function() {
+
+	var compiler;
+
+	before(function() {
+		compiler = webpack({
+			entry: "./nodetest/entry",
+			context: path.join(__dirname, "fixtures"),
+			output: {
+				path: path.join(__dirname, "nodetest", "js"),
+				filename: "result1.js"
+			}
+		});
+
+		compiler.plugin("compilation", function(compilation, callback) {
+			compilation.plugin("should-record", function() {
+				return true;
+			});
+		});
+	});
+
+	it("should cache identifiers", function(done) {
+		compiler.compile(function(err, compilation) {
+			if(err) done(err);
+			var pass = true;
+			for(var i = 0; i < compilation.modules.length; i++) {
+				try {
+					should.exist(compilation.modules[i].portableId);
+					compilation.modules[i].portableId.should.equal(makeRelative(compiler, compilation.modules[i].identifier()));
+				} catch(e) {
+					done(e);
+					pass = false;
+					break;
+				}
+			}
+			if(pass) done();
+		});
+	});
+});


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
All module identifiers are relativized on every incremental build (issue #3073).

**What is the new behavior?**
Relative identifiers get cached on module instances so only changed modules need to call the expensive `makeRelative` function on each build.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 
- Impact:
- Migration path for existing applications: 
- Github Issue(s) this is regarding:

**Other information**:
