### PR TITLE
reduce fn.bind(this) usage by aliasing `this` to `self`

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -518,116 +518,117 @@ Compilation.prototype.unseal = function unseal() {
 };
 
 Compilation.prototype.seal = function seal(callback) {
-	this.applyPlugins("seal");
-	this.nextFreeModuleIndex = 0;
-	this.nextFreeModuleIndex2 = 0;
-	this.preparedChunks.forEach(function(preparedChunk) {
+	var self = this;
+	self.applyPlugins("seal");
+	self.nextFreeModuleIndex = 0;
+	self.nextFreeModuleIndex2 = 0;
+	self.preparedChunks.forEach(function(preparedChunk) {
 		var module = preparedChunk.module;
-		var chunk = this.addChunk(preparedChunk.name, module);
-		var entrypoint = this.entrypoints[chunk.name] = new Entrypoint(chunk.name);
+		var chunk = self.addChunk(preparedChunk.name, module);
+		var entrypoint = self.entrypoints[chunk.name] = new Entrypoint(chunk.name);
 		entrypoint.unshiftChunk(chunk);
 
 		chunk.addModule(module);
 		module.addChunk(chunk);
 		chunk.entryModule = module;
 		if(typeof module.index !== "number") {
-			module.index = this.nextFreeModuleIndex++;
+			module.index = self.nextFreeModuleIndex++;
 		}
-		this.processDependenciesBlockForChunk(module, chunk);
+		self.processDependenciesBlockForChunk(module, chunk);
 		if(typeof module.index2 !== "number") {
-			module.index2 = this.nextFreeModuleIndex2++;
+			module.index2 = self.nextFreeModuleIndex2++;
 		}
-	}, this);
-	this.sortModules(this.modules);
-	this.applyPlugins("optimize");
+	}, self);
+	self.sortModules(self.modules);
+	self.applyPlugins("optimize");
 
-	while(this.applyPluginsBailResult("optimize-modules-basic", this.modules) ||
-		this.applyPluginsBailResult("optimize-modules", this.modules) ||
-		this.applyPluginsBailResult("optimize-modules-advanced", this.modules)); // eslint-disable-line no-extra-semi
-	this.applyPlugins("after-optimize-modules", this.modules);
+	while(self.applyPluginsBailResult("optimize-modules-basic", self.modules) ||
+		self.applyPluginsBailResult("optimize-modules", self.modules) ||
+		self.applyPluginsBailResult("optimize-modules-advanced", self.modules)); // eslint-disable-line no-extra-semi
+	self.applyPlugins("after-optimize-modules", self.modules);
 
-	while(this.applyPluginsBailResult("optimize-chunks-basic", this.chunks) ||
-		this.applyPluginsBailResult("optimize-chunks", this.chunks) ||
-		this.applyPluginsBailResult("optimize-chunks-advanced", this.chunks)); // eslint-disable-line no-extra-semi
-	this.applyPlugins("after-optimize-chunks", this.chunks);
+	while(self.applyPluginsBailResult("optimize-chunks-basic", self.chunks) ||
+		self.applyPluginsBailResult("optimize-chunks", self.chunks) ||
+		self.applyPluginsBailResult("optimize-chunks-advanced", self.chunks)); // eslint-disable-line no-extra-semi
+	self.applyPlugins("after-optimize-chunks", self.chunks);
 
-	this.applyPluginsAsync("optimize-tree", this.chunks, this.modules, function(err) {
+	self.applyPluginsAsync("optimize-tree", self.chunks, self.modules, function(err) {
 		if(err) {
 			return callback(err);
 		}
 
-		this.applyPlugins("after-optimize-tree", this.chunks, this.modules);
+		self.applyPlugins("after-optimize-tree", self.chunks, self.modules);
 
-		var shouldRecord = this.applyPluginsBailResult("should-record") !== false;
+		var shouldRecord = self.applyPluginsBailResult("should-record") !== false;
 
-		this.sortItemsBeforeIds();
+		self.sortItemsBeforeIds();
 
-		this.applyPlugins("revive-modules", this.modules, this.records);
-		this.applyPlugins("optimize-module-order", this.modules);
-		this.applyPlugins("advanced-optimize-module-order", this.modules);
-		this.applyPlugins("before-module-ids", this.modules);
-		this.applyPlugins("module-ids", this.modules);
-		this.applyModuleIds();
-		this.applyPlugins("optimize-module-ids", this.modules);
-		this.applyPlugins("after-optimize-module-ids", this.modules);
+		self.applyPlugins("revive-modules", self.modules, self.records);
+		self.applyPlugins("optimize-module-order", self.modules);
+		self.applyPlugins("advanced-optimize-module-order", self.modules);
+		self.applyPlugins("before-module-ids", self.modules);
+		self.applyPlugins("module-ids", self.modules);
+		self.applyModuleIds();
+		self.applyPlugins("optimize-module-ids", self.modules);
+		self.applyPlugins("after-optimize-module-ids", self.modules);
 
-		this.sortItemsWithModuleIds();
+		self.sortItemsWithModuleIds();
 
-		this.applyPlugins("revive-chunks", this.chunks, this.records);
-		this.applyPlugins("optimize-chunk-order", this.chunks);
-		this.applyPlugins("before-chunk-ids", this.chunks);
-		this.applyChunkIds();
-		this.applyPlugins("optimize-chunk-ids", this.chunks);
-		this.applyPlugins("after-optimize-chunk-ids", this.chunks);
+		self.applyPlugins("revive-chunks", self.chunks, self.records);
+		self.applyPlugins("optimize-chunk-order", self.chunks);
+		self.applyPlugins("before-chunk-ids", self.chunks);
+		self.applyChunkIds();
+		self.applyPlugins("optimize-chunk-ids", self.chunks);
+		self.applyPlugins("after-optimize-chunk-ids", self.chunks);
 
-		this.sortItemswithChunkIds();
-
-		if(shouldRecord)
-			this.applyPlugins("record-modules", this.modules, this.records);
-		if(shouldRecord)
-			this.applyPlugins("record-chunks", this.chunks, this.records);
-
-		this.applyPlugins("before-hash");
-		this.createHash();
-		this.applyPlugins("after-hash");
+		self.sortItemswithChunkIds();
 
 		if(shouldRecord)
-			this.applyPlugins("record-hash", this.records);
+			self.applyPlugins("record-modules", self.modules, self.records);
+		if(shouldRecord)
+			self.applyPlugins("record-chunks", self.chunks, self.records);
 
-		this.applyPlugins("before-module-assets");
-		this.createModuleAssets();
-		if(this.applyPluginsBailResult("should-generate-chunk-assets") !== false) {
-			this.applyPlugins("before-chunk-assets");
-			this.createChunkAssets();
+		self.applyPlugins("before-hash");
+		self.createHash();
+		self.applyPlugins("after-hash");
+
+		if(shouldRecord)
+			self.applyPlugins("record-hash", self.records);
+
+		self.applyPlugins("before-module-assets");
+		self.createModuleAssets();
+		if(self.applyPluginsBailResult("should-generate-chunk-assets") !== false) {
+			self.applyPlugins("before-chunk-assets");
+			self.createChunkAssets();
 		}
-		this.applyPlugins("additional-chunk-assets", this.chunks);
-		this.summarizeDependencies();
+		self.applyPlugins("additional-chunk-assets", self.chunks);
+		self.summarizeDependencies();
 		if(shouldRecord)
-			this.applyPlugins("record", this, this.records);
+			self.applyPlugins("record", self, self.records);
 
-		this.applyPluginsAsync("additional-assets", function(err) {
+		self.applyPluginsAsync("additional-assets", function(err) {
 			if(err) {
 				return callback(err);
 			}
-			this.applyPluginsAsync("optimize-chunk-assets", this.chunks, function(err) {
+			self.applyPluginsAsync("optimize-chunk-assets", self.chunks, function(err) {
 				if(err) {
 					return callback(err);
 				}
-				this.applyPlugins("after-optimize-chunk-assets", this.chunks);
-				this.applyPluginsAsync("optimize-assets", this.assets, function(err) {
+				self.applyPlugins("after-optimize-chunk-assets", self.chunks);
+				self.applyPluginsAsync("optimize-assets", self.assets, function(err) {
 					if(err) {
 						return callback(err);
 					}
-					this.applyPlugins("after-optimize-assets", this.assets);
-					if(this.applyPluginsBailResult("need-additional-seal")) {
-						this.unseal();
-						return this.seal(callback);
+					self.applyPlugins("after-optimize-assets", self.assets);
+					if(self.applyPluginsBailResult("need-additional-seal")) {
+						self.unseal();
+						return self.seal(callback);
 					}
-					return this.applyPluginsAsync("after-seal", callback);
-				}.bind(this));
-			}.bind(this));
-		}.bind(this));
-	}.bind(this));
+					return self.applyPluginsAsync("after-seal", callback);
+				});
+			});
+		});
+	});
 };
 
 Compilation.prototype.sortModules = function sortModules(modules) {

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -38,45 +38,46 @@ function Watching(compiler, watchOptions, handler) {
 }
 
 Watching.prototype._go = function() {
-	this.startTime = new Date().getTime();
-	this.running = true;
-	this.invalid = false;
-	this.compiler.applyPluginsAsync("watch-run", this, function(err) {
-		if(err) return this._done(err);
-		this.compiler.compile(function onCompiled(err, compilation) {
-			if(err) return this._done(err);
-			if(this.invalid) return this._done();
+	var self = this;
+	self.startTime = new Date().getTime();
+	self.running = true;
+	self.invalid = false;
+	self.compiler.applyPluginsAsync("watch-run", self, function(err) {
+		if(err) return self._done(err);
+		self.compiler.compile(function onCompiled(err, compilation) {
+			if(err) return self._done(err);
+			if(self.invalid) return self._done();
 
-			if(this.compiler.applyPluginsBailResult("should-emit", compilation) === false) {
-				return this._done(null, compilation);
+			if(self.compiler.applyPluginsBailResult("should-emit", compilation) === false) {
+				return self._done(null, compilation);
 			}
 
-			this.compiler.emitAssets(compilation, function(err) {
-				if(err) return this._done(err);
-				if(this.invalid) return this._done();
+			self.compiler.emitAssets(compilation, function(err) {
+				if(err) return self._done(err);
+				if(self.invalid) return self._done();
 
-				this.compiler.emitRecords(function(err) {
-					if(err) return this._done(err);
+				self.compiler.emitRecords(function(err) {
+					if(err) return self._done(err);
 
 					if(compilation.applyPluginsBailResult("need-additional-pass")) {
 						compilation.needAdditionalPass = true;
 
 						var stats = compilation.getStats();
-						stats.startTime = this.startTime;
+						stats.startTime = self.startTime;
 						stats.endTime = new Date().getTime();
-						this.compiler.applyPlugins("done", stats);
+						self.compiler.applyPlugins("done", stats);
 
-						this.compiler.applyPluginsAsync("additional-pass", function(err) {
-							if(err) return this._done(err);
-							this.compiler.compile(onCompiled.bind(this));
-						}.bind(this));
+						self.compiler.applyPluginsAsync("additional-pass", function(err) {
+							if(err) return self._done(err);
+							self.compiler.compile(onCompiled);
+						});
 						return;
 					}
-					return this._done(null, compilation);
-				}.bind(this));
-			}.bind(this));
-		}.bind(this));
-	}.bind(this));
+					return self._done(null, compilation);
+				});
+			});
+		});
+	});
 };
 
 Watching.prototype._done = function(err, compilation) {
@@ -206,28 +207,30 @@ Compiler.prototype.watch = function(watchOptions, handler) {
 };
 
 Compiler.prototype.run = function(callback) {
+	var self = this;
 	var startTime = new Date().getTime();
-	this.applyPluginsAsync("before-run", this, function(err) {
+
+	self.applyPluginsAsync("before-run", self, function(err) {
 		if(err) return callback(err);
 
-		this.applyPluginsAsync("run", this, function(err) {
+		self.applyPluginsAsync("run", self, function(err) {
 			if(err) return callback(err);
 
-			this.readRecords(function(err) {
+			self.readRecords(function(err) {
 				if(err) return callback(err);
 
-				this.compile(function onCompiled(err, compilation) {
+				self.compile(function onCompiled(err, compilation) {
 					if(err) return callback(err);
 
-					if(this.applyPluginsBailResult("should-emit", compilation) === false) {
+					if(self.applyPluginsBailResult("should-emit", compilation) === false) {
 						var stats = compilation.getStats();
 						stats.startTime = startTime;
 						stats.endTime = new Date().getTime();
-						this.applyPlugins("done", stats);
+						self.applyPlugins("done", stats);
 						return callback(null, stats);
 					}
 
-					this.emitAssets(compilation, function(err) {
+					self.emitAssets(compilation, function(err) {
 						if(err) return callback(err);
 
 						if(compilation.applyPluginsBailResult("need-additional-pass")) {
@@ -236,29 +239,29 @@ Compiler.prototype.run = function(callback) {
 							var stats = compilation.getStats();
 							stats.startTime = startTime;
 							stats.endTime = new Date().getTime();
-							this.applyPlugins("done", stats);
+							self.applyPlugins("done", stats);
 
-							this.applyPluginsAsync("additional-pass", function(err) {
+							self.applyPluginsAsync("additional-pass", function(err) {
 								if(err) return callback(err);
-								this.compile(onCompiled.bind(this));
-							}.bind(this));
+								self.compile(onCompiled);
+							});
 							return;
 						}
 
-						this.emitRecords(function(err) {
+						self.emitRecords(function(err) {
 							if(err) return callback(err);
 
 							var stats = compilation.getStats();
 							stats.startTime = startTime;
 							stats.endTime = new Date().getTime();
-							this.applyPlugins("done", stats);
+							self.applyPlugins("done", stats);
 							return callback(null, stats);
-						}.bind(this));
-					}.bind(this));
-				}.bind(this));
-			}.bind(this));
-		}.bind(this));
-	}.bind(this));
+						});
+					});
+				});
+			});
+		});
+	});
 };
 
 Compiler.prototype.runAsChild = function(callback) {
@@ -362,28 +365,29 @@ Compiler.prototype.emitRecords = function emitRecords(callback) {
 };
 
 Compiler.prototype.readRecords = function readRecords(callback) {
-	if(!this.recordsInputPath) {
-		this.records = {};
+	var self = this;
+	if(!self.recordsInputPath) {
+		self.records = {};
 		return callback();
 	}
-	this.inputFileSystem.stat(this.recordsInputPath, function(err) {
+	self.inputFileSystem.stat(self.recordsInputPath, function(err) {
 		// It doesn't exist
-		// We can ignore this.
+		// We can ignore self.
 		if(err) return callback();
 
-		this.inputFileSystem.readFile(this.recordsInputPath, function(err, content) {
+		self.inputFileSystem.readFile(self.recordsInputPath, function(err, content) {
 			if(err) return callback(err);
 
 			try {
-				this.records = JSON.parse(content);
+				self.records = JSON.parse(content);
 			} catch(e) {
 				e.message = "Cannot parse records: " + e.message;
 				return callback(e);
 			}
 
 			return callback();
-		}.bind(this));
-	}.bind(this));
+		});
+	});
 };
 
 Compiler.prototype.createChildCompiler = function(compilation, compilerName, outputOptions) {
@@ -452,15 +456,16 @@ Compiler.prototype.newCompilationParams = function() {
 };
 
 Compiler.prototype.compile = function(callback) {
-	var params = this.newCompilationParams();
-	this.applyPluginsAsync("before-compile", params, function(err) {
+	var self = this;
+	var params = self.newCompilationParams();
+	self.applyPluginsAsync("before-compile", params, function(err) {
 		if(err) return callback(err);
 
-		this.applyPlugins("compile", params);
+		self.applyPlugins("compile", params);
 
-		var compilation = this.newCompilation(params);
+		var compilation = self.newCompilation(params);
 
-		this.applyPluginsParallel("make", compilation, function(err) {
+		self.applyPluginsParallel("make", compilation, function(err) {
 			if(err) return callback(err);
 
 			compilation.finish();
@@ -468,12 +473,12 @@ Compiler.prototype.compile = function(callback) {
 			compilation.seal(function(err) {
 				if(err) return callback(err);
 
-				this.applyPluginsAsync("after-compile", compilation, function(err) {
+				self.applyPluginsAsync("after-compile", compilation, function(err) {
 					if(err) return callback(err);
 
 					return callback(null, compilation);
 				});
-			}.bind(this));
-		}.bind(this));
-	}.bind(this));
+			});
+		});
+	});
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the new behavior?**

No new behavior.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:

Some segments of code in `lib/Compiler.js` and `lib/Compilation.js` have significant levels of callback nesting, and each callback must bind to `this` to be able to access the Compiler API. This is hazardous and difficult to maintain; it is better to alias `this` to another variable.