### PR TITLE
Limit number of files processed asynchronously

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -232,7 +232,8 @@ Compiler.prototype.emitAssets = function(compilation, callback) {
 	function emitFiles(err) {
 		if(err) return callback(err);
 
-		require("async").forEach(Object.keys(compilation.assets), function(file, callback) {
+		var async = require("async");
+		async.forEachLimit(Object.keys(compilation.assets), process.env.WEBPACK_FILE_LIMIT || 1000, async.ensureAsync(function(file, callback) {
 
 			var targetFile = file;
 			var queryStringIdx = targetFile.indexOf("?");
@@ -261,7 +262,7 @@ Compiler.prototype.emitAssets = function(compilation, callback) {
 				this.outputFileSystem.writeFile(targetPath, content, callback);
 			}
 
-		}.bind(this), function(err) {
+		}).bind(this), function(err) {
 			if(err) return callback(err);
 
 			afterEmit.call(this);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
OS file limit is reached by processing too many files at the same time.

**What is the new behavior?**
Limits the number of files to 1000 or set by an environment variable. (Maybe it should be even lower ~500)

**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No

**Other information**:
Resolves https://github.com/webpack/webpack/issues/3164
