### PR TITLE
chore(yarn): exclude lock file from source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .DS_Store
 *.log
 .idea
+yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@
 .DS_Store
 *.log
 .idea
-yarn.lock

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,21 @@
+# Node generated files
+node_modules
+npm-debug.log
+# OS generated files
+Thumbs.db
+.DS_Store
+
+# Test and examples
+examples
+test
+
+# Other build related files and outputs
+benchmark
+coverage
+.*
+*.log
+yarn.lock
+
+!/LICENSE
+!/package.json
+!/README.md


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:
Source control exclusion

**What is the current behavior?** (You can also link to an open issue here)
yarn package manager generates a lock file locally, which shows up as a change in git repository.


**What is the new behavior?**
Generated yarn lock file is ignored by git.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: 
* Github Issue(s) this is regarding:


**Other information**:


