### PR TITLE
Bump required node version to 0.12, the last supported LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "worker-loader": "~0.7.0"
   },
   "engines": {
-    "node": ">=0.6"
+    "node": ">=0.12"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Node.js >=0.6 is supported according to the `package.json`.

**What is the new behavior?**

Node.js >= 0.12 is supported. On Slack it was discussed that we should only support active LTS releases.

**Does this PR introduce a breaking change?**
- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the following... 

* Impact: If the user is running a Node.js version older then 0.12, webpack can break.
* Migration path for existing applications: Update Node.js to at least 0.12 
* Github Issue(s) this is regarding:


**Other information**:

//cc @NekR @danez 