### PR TITLE
Allow app entry points w/ dll builds

### DIFF
--- a/lib/DllPlugin.js
+++ b/lib/DllPlugin.js
@@ -17,7 +17,7 @@ DllPlugin.prototype.apply = function(compiler) {
 			if(Array.isArray(item))
 				return new DllEntryPlugin(context, item, name);
 			else
-        return new SingleEntryPlugin(context, item, name);
+				return new SingleEntryPlugin(context, item, name);
 		}
 		if(typeof entry === "object" && !Array.isArray(entry)) {
 			Object.keys(entry).forEach(function(name) {

--- a/lib/DllPlugin.js
+++ b/lib/DllPlugin.js
@@ -3,6 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 var DllEntryPlugin = require("./DllEntryPlugin");
+var SingleEntryPlugin = require('./SingleEntryPlugin');
 var LibManifestPlugin = require("./LibManifestPlugin");
 var FlagInitialModulesAsUsedPlugin = require("./FlagInitialModulesAsUsedPlugin");
 
@@ -16,7 +17,7 @@ DllPlugin.prototype.apply = function(compiler) {
 			if(Array.isArray(item))
 				return new DllEntryPlugin(context, item, name);
 			else
-				throw new Error("DllPlugin: supply an Array as entry");
+        return new SingleEntryPlugin(context, item, name);
 		}
 		if(typeof entry === "object" && !Array.isArray(entry)) {
 			Object.keys(entry).forEach(function(name) {


### PR DESCRIPTION
This allows you to build both dll/library packages as well as an application file in the same `webpack.config.js`.

For example (extending `examples/dll/webpack.config.js`):

```javascript
module.exports = {
	resolve: {
		extensions: ['.js', '.jsx']
	},
	entry: {
		app: "./app",  // built as single entry
		alpha: ["./alpha", "./a", "module"],
		beta: ["./beta", "./b", "./c"]
	},
	output: {
		path: path.join(__dirname, "js"),
		filename: "[name].js",
		library: "[name]_[hash]"
	},
	plugins: [
		new webpack.DllPlugin({
			path: path.join(__dirname, "js", "[name]-manifest.json"),
			name: "[name]_[hash]"
		})
	]
};

```

I'm using this in our own application ([Sentry](/getsentry/sentry)), which has a single application entry point as well as two libraries that are exported as dll's for consumption in an external closed-source project. (See: getsentry/sentry#4412, affected webpack config [here](https://github.com/getsentry/sentry/pull/4412/files#diff-11e9f7f953edc64ba14b0cc350ae7b9dL7))

Right now I'm accomplishing this by creating my own custom `SentryDLLPlugin` that implements the behavior in this PR, but I think it makes sense to make this core behavior – I don't see the point of throwing a hard error (the current behavior) if someone attempts to do this.

I'd be glad to add tests, etc, if you could provide some guidance on how best to cover this behavior.