### PR TITLE
added nonce capability

### DIFF
--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -16,13 +16,15 @@ var REPLACEMENTS = {
 	__webpack_modules__: "__webpack_require__.m", // eslint-disable-line camelcase
 	__webpack_chunk_load__: "__webpack_require__.e", // eslint-disable-line camelcase
 	__non_webpack_require__: "require", // eslint-disable-line camelcase
+	__webpack_nonce__: "__webpack_require__.nc", // eslint-disable-line camelcase
 	"require.onError": "__webpack_require__.oe" // eslint-disable-line camelcase
 };
 var REPLACEMENT_TYPES = {
 	__webpack_public_path__: "string", // eslint-disable-line camelcase
 	__webpack_require__: "function", // eslint-disable-line camelcase
 	__webpack_modules__: "object", // eslint-disable-line camelcase
-	__webpack_chunk_load__: "function" // eslint-disable-line camelcase
+	__webpack_chunk_load__: "function", // eslint-disable-line camelcase
+	__webpack_nonce__: "string" // eslint-disable-line camelcase
 };
 var IGNORES = [];
 APIPlugin.prototype.apply = function(compiler) {

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -39,6 +39,9 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 			"script.async = true;",
 			"script.timeout = " + chunkLoadTimeout + ";",
 			crossOriginLoading ? "script.crossOrigin = '" + crossOriginLoading + "';" : "",
+			"if (" + this.requireFn + ".nc) {",
+			this.indent("script.setAttribute(\"nonce\", " + this.requireFn + ".nc);"),
+			"}",
 			"script.src = " + this.requireFn + ".p + " +
 			this.applyPluginsWaterfall("asset-path", JSON.stringify(chunkFilename), {
 				hash: "\" + " + this.renderCurrentHashCode(hash) + " + \"",

--- a/lib/MainTemplate.js
+++ b/lib/MainTemplate.js
@@ -19,6 +19,7 @@ var Template = require("./Template");
 // __webpack_require__.n = compatibility get default export
 // __webpack_require__.h = the webpack hash
 // __webpack_require__.oe = the uncatched error handler for the webpack runtime
+// __webpack_require__.nc = the script nonce
 
 function MainTemplate(outputOptions) {
 	Template.call(this, outputOptions);

--- a/test/cases/nonce/set-nonce/index.js
+++ b/test/cases/nonce/set-nonce/index.js
@@ -1,0 +1,28 @@
+it("should load script with nonce 'nonce1234'", function(done) {
+	__webpack_nonce__ = 'nonce1234';
+	require.ensure([], function(require) {
+		require("./empty?a");
+	}, "chunk-with-nonce");
+	__webpack_nonce__ = undefined;
+	// if in browser context, test that nonce was added.
+	if (typeof document !== 'undefined') {
+		var script = document.querySelector('script[src="js/chunk-with-nonce.web.js"]');
+		script.getAttribute('nonce').should.be.eql('nonce1234');
+	}
+	__webpack_nonce__ = undefined;
+	done();
+});
+
+it("should load script without nonce", function(done) {
+	require.ensure([], function(require) {
+		require("./empty?b");
+	}, "chunk-without-nonce");
+
+	// if in browser context, test that nonce was added.
+	if (typeof document !== 'undefined') {
+		var script = document.querySelector('script[src="js/chunk-without-nonce.web.js"]');
+		script.hasAttribute('nonce').should.be.eql(false);
+	}
+	__webpack_nonce__ = undefined;
+	done();
+});

--- a/test/statsCases/aggressive-splitting-on-demand/expected.txt
+++ b/test/statsCases/aggressive-splitting-on-demand/expected.txt
@@ -6,7 +6,7 @@ Time: Xms
 5ae9e18455b866684bd0.js    1.94 kB       2  [emitted]  
 e91ec4902ca3057b42bb.js    1.93 kB       3  [emitted]  
 0947f0875d56ab0bfe02.js  977 bytes       4  [emitted]  
-6335d9dcc7fa048743b7.js    7.01 kB       6  [emitted]  main
+6335d9dcc7fa048743b7.js    7.13 kB       6  [emitted]  main
 cf500be0e585f01d2ccb.js  983 bytes       9  [emitted]  
 a7bfb642a544b4302cc4.js  975 bytes      11  [emitted]  
 Entrypoint main = 6335d9dcc7fa048743b7.js

--- a/test/statsCases/chunks/expected.txt
+++ b/test/statsCases/chunks/expected.txt
@@ -4,7 +4,7 @@ Time: Xms
 0.bundle.js  227 bytes       0  [emitted]  
 1.bundle.js  106 bytes       1  [emitted]  
 2.bundle.js  200 bytes       2  [emitted]  
-  bundle.js    5.65 kB       3  [emitted]  main
+  bundle.js    5.77 kB       3  [emitted]  main
 chunk    {0} 0.bundle.js 54 bytes {3} [rendered]
     > [5] (webpack)/test/statsCases/chunks/index.js 3:0-16
     [2] (webpack)/test/statsCases/chunks/c.js 54 bytes {0} [built]

--- a/test/statsCases/optimize-chunks/expected.txt
+++ b/test/statsCases/optimize-chunks/expected.txt
@@ -8,7 +8,7 @@ Time: Xms
    4.js  136 bytes    4, 6  [emitted]  chunk
    5.js  293 bytes    5, 3  [emitted]  cir2 from cir1
    6.js   78 bytes       6  [emitted]  ac in ab
-main.js    6.25 kB       7  [emitted]  main
+main.js    6.37 kB       7  [emitted]  main
 chunk    {0} 0.js (cir1) 81 bytes {7} {5} {3} [rendered]
     > duplicate cir1 from cir2 [3] (webpack)/test/statsCases/optimize-chunks/circular2.js 1:0-79
     > duplicate cir1 [8] (webpack)/test/statsCases/optimize-chunks/index.js 13:0-54

--- a/test/statsCases/preset-verbose/expected.txt
+++ b/test/statsCases/preset-verbose/expected.txt
@@ -4,7 +4,7 @@ Time: Xms
    0.js  227 bytes       0  [emitted]  
    1.js  106 bytes       1  [emitted]  
    2.js  200 bytes       2  [emitted]  
-main.js    5.64 kB       3  [emitted]  main
+main.js    5.76 kB       3  [emitted]  main
 Entrypoint main = main.js
 chunk    {0} 0.js 54 bytes {3} [rendered]
     [2] (webpack)/test/statsCases/preset-verbose/c.js 54 bytes {0} [built]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
#455

Currently, webpack does provide a way to add nonces to scripts. Given that the future of CSP could be a more nonce-based approach, having support for nonces is increasingly important. 
https://research.google.com/pubs/pub45542.html

**What is the new behavior?**
When user specifies webpack_nonce, a nonce is added to all loaded scripts. Because nonces are generally different on each page load, the nonce is specified in the entry file, not in the config file, similarly to a public path not known ahead of time.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 
- Impact:
- Migration path for existing applications: 
- Github Issue(s) this is regarding:

**Other information**:
