### PR TITLE
Fix using --version and -v

### DIFF
--- a/bin/config-yargs.js
+++ b/bin/config-yargs.js
@@ -10,6 +10,8 @@ module.exports = function(yargs) {
 	yargs
 		.help("help")
 		.alias("help", "h", "?")
+		.version()
+		.alias("version", "v")
 		.options({
 			"config": {
 				type: "string",
@@ -21,12 +23,6 @@ module.exports = function(yargs) {
 			"env": {
 				describe: "Enviroment passed to the config, when it is a function",
 				group: CONFIG_GROUP
-			},
-			"version": {
-				type: "string",
-				describe: "Webpack version",
-				alias: "v",
-				group: BASIC_GROUP,
 			},
 			"context": {
 				type: "string",

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -6,21 +6,9 @@ var interpret = require("interpret");
 var WebpackOptionsDefaulter = require("../lib/WebpackOptionsDefaulter");
 var validateWebpackOptions = require("../lib/validateWebpackOptions");
 
-module.exports = function(optimist, argv, convertOptions) {
+module.exports = function(yargs, argv, convertOptions) {
 
 	var options = [];
-
-	// Help
-	if(argv.help) {
-		optimist.showHelp();
-		process.exit(0); // eslint-disable-line
-	}
-
-	// Version
-	if(argv.v || argv.version) {
-		console.log(require("../package.json").version);
-		process.exit(0); // eslint-disable-line
-	}
 
 	// Shortcuts
 	if(argv.d) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

If you execute `webpack -v` or `webpack --version`, the help menu is shown. 

**What is the new behavior?**

If you execute `webpack -v` or `webpack --version`, only the webpack version will show.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:

This worked before the optimist -> yargs migration, but was not migrated properly.
I also removed some legacy code from before the yargs migration that would show the help menu, but this code was never used.

After this is merged, I will also fix this in webpack-dev-server.
