### PR TITLE
Add async/await support to Parser

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -650,6 +650,12 @@ Parser.prototype.walkExpression = function walkExpression(expression) {
 		return this["walk" + expression.type](expression);
 };
 
+Parser.prototype.walkAwaitExpression = function walkAwaitExpression(expression) {
+	var argument = expression.argument
+	if(this["walk" + argument.type])
+		return this["walk" + argument.type](argument);
+}
+
 Parser.prototype.walkArrayExpression = function walkArrayExpression(expression) {
 	if(expression.elements)
 		this.walkExpressions(expression.elements);
@@ -1035,12 +1041,12 @@ Parser.prototype.parseCalculatedString = function parseCalculatedString(expressi
 var POSSIBLE_AST_OPTIONS = [{
 	ranges: true,
 	locations: true,
-	ecmaVersion: 6,
+	ecmaVersion: 2017,
 	sourceType: "module"
 }, {
 	ranges: true,
 	locations: true,
-	ecmaVersion: 6,
+	ecmaVersion: 2017,
 	sourceType: "script"
 }]
 
@@ -1062,7 +1068,7 @@ Parser.prototype.parse = function parse(source, initialState) {
 		ast = acorn.parse(source, {
 			ranges: true,
 			locations: true,
-			ecmaVersion: 6,
+			ecmaVersion: 2017,
 			sourceType: "module",
 			onComment: comments
 		});
@@ -1088,7 +1094,7 @@ Parser.prototype.evaluate = function evaluate(source) {
 	var ast = acorn.parse("(" + source + ")", {
 		ranges: true,
 		locations: true,
-		ecmaVersion: 6,
+		ecmaVersion: 2017,
 		sourceType: "module"
 	});
 	if(!ast || typeof ast !== "object" || ast.type !== "Program")


### PR DESCRIPTION
Now that webpack uses a version of acorn that can parse async/await, enable it (with the appropriate ecmaVersion) and use it to parse.

The main caveat I can think of is that there are new early errors added in ES2016 (e.g. `'use strict'` in the body of functions with complex parameter list).

Fixes #2872.

I am not sure how "sound" this is in case webpack wants to do something special when the call is wrapped in an await, but that is a much bigger refactoring than just accepting and detecting the expressions.
