### PR TITLE
Fix validation schema accepting invalid values when `instanceof` is used

### DIFF
--- a/lib/WebpackOptionsValidationError.js
+++ b/lib/WebpackOptionsValidationError.js
@@ -75,6 +75,8 @@ WebpackOptionsValidationError.formatValidationError = function formatValidationE
 			}
 			return dataPath + " should be " + err.params.type + ":\n" +
 				getSchemaPartText(err.parentSchema);
+		case "instanceof":
+			return dataPath + " should be an instance of " + getSchemaPartText(err.parentSchema) + ".";
 		case "required":
 			var missingProperty = err.params.missingProperty.replace(/^\./, "");
 			return dataPath + " misses the property '" + missingProperty + "'.\n" +

--- a/lib/validateWebpackOptions.js
+++ b/lib/validateWebpackOptions.js
@@ -9,6 +9,7 @@ var ajv = new Ajv({
 	allErrors: true,
 	verbose: true
 });
+require('ajv-keywords')(ajv);
 var validate = ajv.compile(webpackOptionsSchema);
 
 function validateWebpackOptions(options) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "acorn": "^4.0.3",
     "ajv": "^4.7.0",
+    "ajv-keywords": "^1.1.1",
     "async": "^2.1.2",
     "enhanced-resolve": "^2.2.0",
     "interpret": "^1.0.0",

--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -76,7 +76,14 @@
         },
         {
           "additionalProperties": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              }
+            ]
           },
           "description": "If an dependency matches exactly a property of the object, the property value is used as dependency.",
           "type": "object"
@@ -109,7 +116,14 @@
           "type": "boolean"
         },
         "exprContextRegExp": {
-          "instanceof": "RegExp"
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "instanceof": "RegExp"
+            }
+          ]
         },
         "exprContextRequest": {
           "type": "string"
@@ -153,7 +167,14 @@
           "type": "boolean"
         },
         "unknownContextRegExp": {
-          "instanceof": "RegExp"
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "instanceof": "RegExp"
+            }
+          ]
         },
         "unknownContextRequest": {
           "type": "string"

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -34,6 +34,17 @@ describe("Validation", function() {
 			"   The entry point(s) of the compilation."
 		]
 	}, {
+		name: "invalid instanceof",
+		config: {
+			entry: "a",
+			module: {
+				exprContextRegExp: 1337
+			}
+		},
+		message: [
+			" - configuration.module.exprContextRegExp should be an instance of RegExp.",
+		]
+	}, {
 		name: "multiple errors",
 		config: {
 			entry: [/a/],

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -38,11 +38,11 @@ describe("Validation", function() {
 		config: {
 			entry: "a",
 			module: {
-				exprContextRegExp: 1337
+				wrappedContextRegExp: 1337
 			}
 		},
 		message: [
-			" - configuration.module.exprContextRegExp should be an instance of RegExp.",
+			" - configuration.module.wrappedContextRegExp should be an instance of RegExp.",
 		]
 	}, {
 		name: "multiple errors",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

See #3231. tl;dr - when an option in the scheme uses `instanceof`, all values for that option were always accepted regardless of incorrect type.

**What is the new behavior?**

It will give a proper error when an option that uses `instanceof` contains an invalid value.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

Fixes #3231