### PR TITLE
Fix issue #3238

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -909,7 +909,7 @@ Parser.prototype.inScope = function inScope(params, fn) {
 };
 
 Parser.prototype.enterPattern = function enterPattern(pattern, onIdent) {
-	if(this["enter" + pattern.type])
+	if(pattern != null && this["enter" + pattern.type])
 		return this["enter" + pattern.type](pattern, onIdent);
 };
 

--- a/test/cases/parsing/issue-3238/index.js
+++ b/test/cases/parsing/issue-3238/index.js
@@ -1,4 +1,4 @@
-it("should pass", function() {
+it("supports empty element in destructuring", function() {
   const second = ([, x]) => x;
   second([1, 2]).should.eql(2);
 });

--- a/test/cases/parsing/issue-3238/index.js
+++ b/test/cases/parsing/issue-3238/index.js
@@ -1,0 +1,4 @@
+it("should pass", function() {
+  const second = ([, x]) => x;
+  second([1, 2]).should.eql(2);
+});

--- a/test/cases/parsing/issue-3238/test.filter.js
+++ b/test/cases/parsing/issue-3238/test.filter.js
@@ -1,0 +1,5 @@
+var supportsIteratorDestructuring = require("../../../helpers/supportsIteratorDestructuring");
+
+module.exports = function(config) {
+	return !config.minimize && supportsIteratorDestructuring();
+};

--- a/test/helpers/supportsIteratorDestructuring.js
+++ b/test/helpers/supportsIteratorDestructuring.js
@@ -1,0 +1,8 @@
+module.exports = function supportsIteratorDestructuring() {
+	try {
+		var f = eval("(function f([, x, ...y]) { return x; })");
+		return f([1, 2]) === 2;
+	} catch(e) {
+		return false;
+	}
+};


### PR DESCRIPTION
This fixes the Parser trying to access the tree of an empty pattern, which is `null`. This is valid syntax, and is useful for skipping iterator elements; `function second ([, x]) { return x }` will skip the first element of any iterator (including an array) and return the second.

I had some trouble with writing the tests; as you will be able to see from the CI results, the Uglify tests (and tests on node <= 4) will fail. `"$(npm bin)"/mocha --harmony --check-leaks -g 'normal.*issue-3238'`, however, passes on node >= 5.

Not sure how I could write a test for this that would only be evaluated on engines (or settings) where it would be supported... because Uglify is an ES5 parser, it's not possible to make this test pass on it other than by using es2015 transforms, which defeats the point of the test by avoiding the syntax that breaks Parser.