### PR TITLE
Log filtered test cases as skipped

### DIFF
--- a/test/TestCases.test.js
+++ b/test/TestCases.test.js
@@ -118,7 +118,9 @@ describe("TestCases", function() {
 						var testDirectory = path.join(casesPath, category.name, test);
 						var filterPath = path.join(testDirectory, "test.filter.js");
 						if(fs.existsSync(filterPath) && !require(filterPath)(config)) {
-							describe.skip(test, function() { it('filtered')});
+							describe.skip(test, function() {
+								it('filtered')
+							});
 							return false;
 						}
 						return true;

--- a/test/TestCases.test.js
+++ b/test/TestCases.test.js
@@ -117,8 +117,9 @@ describe("TestCases", function() {
 					category.tests.filter(function(test) {
 						var testDirectory = path.join(casesPath, category.name, test);
 						var filterPath = path.join(testDirectory, "test.filter.js");
-						if(fs.existsSync(filterPath)) {
-							return require(filterPath)(config);
+						if(fs.existsSync(filterPath) && !require(filterPath)(config)) {
+							describe.skip(test, function() { it('filtered')});
+							return false;
 						}
 						return true;
 					}).forEach(function(testName) {


### PR DESCRIPTION
When a TestCase case is skipped, add a mocha output entry indicating it is skipped.

Before (`mocha --harmony --check-leaks -g TestCases`):

```
  5855 passing (2m)
  32 pending
```

After:

```
  5855 passing (2m)
  57 pending
```