### PR TITLE
add jsonp-script-alternative

### DIFF
--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -68,7 +68,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 		return this.asString([
 			"var xhr = new XMLHttpRequest;",
 			"var src = " + this.requireFn + ".p + " +
-			this.applyPluginsWaterfall("asset-path", JSON.stringify(chunkFilename), {
+			(this.applyPluginsWaterfall("asset-path", JSON.stringify(chunkFilename), {
 				hash: "\" + " + this.renderCurrentHashCode(hash) + " + \"",
 				hashWithLength: function(length) {
 					return "\" + " + this.renderCurrentHashCode(hash, length) + " + \"";
@@ -86,7 +86,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 					},
 					name: "\" + (" + JSON.stringify(chunkMaps.name) + "[chunkId]||chunkId) + \""
 				}
-			}) + ";",
+			})) + ";",
 			"xhr.open('GET', src, null);",
 			"xhr.withCredentials = true",
 			"xhr.onreadystatechange = function () {",

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -68,7 +68,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 		return this.asString([
 			"var xhr = new XMLHttpRequest;",
 			"var src = " + this.requireFn + ".p + " +
-			(this.applyPluginsWaterfall("asset-path", JSON.stringify(chunkFilename), {
+			this.applyPluginsWaterfall("asset-path", JSON.stringify(chunkFilename), {
 				hash: "\" + " + this.renderCurrentHashCode(hash) + " + \"",
 				hashWithLength: function(length) {
 					return "\" + " + this.renderCurrentHashCode(hash, length) + " + \"";
@@ -79,14 +79,14 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 					hashWithLength: function(length) {
 						var shortChunkHashMap = {};
 						Object.keys(chunkMaps.hash).forEach(function(chunkId) {
-							if (typeof chunkMaps.hash[chunkId] === "string")
+							if(typeof chunkMaps.hash[chunkId] === "string")
 								shortChunkHashMap[chunkId] = chunkMaps.hash[chunkId].substr(0, length);
 						});
 						return "\" + " + JSON.stringify(shortChunkHashMap) + "[chunkId] + \"";
 					},
 					name: "\" + (" + JSON.stringify(chunkMaps.name) + "[chunkId]||chunkId) + \""
 				}
-			})) + ";",
+			}) + ";",
 			"xhr.open('GET', src, null);",
 			"xhr.withCredentials = true",
 			"xhr.onreadystatechange = function () {",

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -70,15 +70,15 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 			"var src = " + this.requireFn + ".p + " +
 			this.applyPluginsWaterfall("asset-path", JSON.stringify(chunkFilename), {
 				hash: "\" + " + this.renderCurrentHashCode(hash) + " + \"",
-				hashWithLength: function (length) {
+				hashWithLength: function(length) {
 					return "\" + " + this.renderCurrentHashCode(hash, length) + " + \"";
 				}.bind(this),
 				chunk: {
 					id: "\" + chunkId + \"",
 					hash: "\" + " + JSON.stringify(chunkMaps.hash) + "[chunkId] + \"",
-					hashWithLength: function (length) {
+					hashWithLength: function(length) {
 						var shortChunkHashMap = {};
-						Object.keys(chunkMaps.hash).forEach(function (chunkId) {
+						Object.keys(chunkMaps.hash).forEach(function(chunkId) {
 							if (typeof chunkMaps.hash[chunkId] === "string")
 								shortChunkHashMap[chunkId] = chunkMaps.hash[chunkId].substr(0, length);
 						});

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -61,7 +61,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 			}) + ";"
 		]);
 	});
-	mainTemplate.plugin("jsonp-script-alternative", function (_, chunk, hash) {
+	mainTemplate.plugin("jsonp-script-alternative", function(_, chunk, hash) {
 		var filename = this.outputOptions.filename || "bundle.js";
 		var chunkFilename = this.outputOptions.chunkFilename || "[id]." + filename;
 		var chunkMaps = chunk.getChunkMaps();
@@ -105,7 +105,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 			"xhr.send();"
 		]);
 	});
-	mainTemplate.plugin("require-ensure", function (_, chunk, hash) {
+	mainTemplate.plugin("require-ensure", function(_, chunk, hash) {
 		var filename = this.outputOptions.filename || "bundle.js";
 		var chunkFilename = this.outputOptions.chunkFilename || "[id]." + filename;
 		return this.asString([

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -61,7 +61,51 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 			}) + ";"
 		]);
 	});
-	mainTemplate.plugin("require-ensure", function(_, chunk, hash) {
+	mainTemplate.plugin("jsonp-script-alternative", function (_, chunk, hash) {
+		var filename = this.outputOptions.filename || "bundle.js";
+		var chunkFilename = this.outputOptions.chunkFilename || "[id]." + filename;
+		var chunkMaps = chunk.getChunkMaps();
+		return this.asString([
+			"var xhr = new XMLHttpRequest;",
+			"var src = " + this.requireFn + ".p + " +
+			this.applyPluginsWaterfall("asset-path", JSON.stringify(chunkFilename), {
+				hash: "\" + " + this.renderCurrentHashCode(hash) + " + \"",
+				hashWithLength: function (length) {
+					return "\" + " + this.renderCurrentHashCode(hash, length) + " + \"";
+				}.bind(this),
+				chunk: {
+					id: "\" + chunkId + \"",
+					hash: "\" + " + JSON.stringify(chunkMaps.hash) + "[chunkId] + \"",
+					hashWithLength: function (length) {
+						var shortChunkHashMap = {};
+						Object.keys(chunkMaps.hash).forEach(function (chunkId) {
+							if (typeof chunkMaps.hash[chunkId] === "string")
+								shortChunkHashMap[chunkId] = chunkMaps.hash[chunkId].substr(0, length);
+						});
+						return "\" + " + JSON.stringify(shortChunkHashMap) + "[chunkId] + \"";
+					},
+					name: "\" + (" + JSON.stringify(chunkMaps.name) + "[chunkId]||chunkId) + \""
+				}
+			}) + ";",
+			"xhr.open('GET', src, null);",
+			"xhr.withCredentials = true",
+			"xhr.onreadystatechange = function () {",
+			this.indent([
+				"if (xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200) {",
+				this.indent([
+					"try {",
+					this.indent("eval(xhr.responseText);"),
+					"} catch (e) {",
+					this.indent("throw e"),
+					"}",
+				]),
+				"}"
+			]),
+			"};",
+			"xhr.send();"
+		]);
+	});
+	mainTemplate.plugin("require-ensure", function (_, chunk, hash) {
 		var filename = this.outputOptions.filename || "bundle.js";
 		var chunkFilename = this.outputOptions.chunkFilename || "[id]." + filename;
 		return this.asString([
@@ -76,9 +120,17 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 			this.indent([
 				"// start chunk loading",
 				"installedChunks[chunkId] = [callback];",
-				"var head = document.getElementsByTagName('head')[0];",
-				this.applyPluginsWaterfall("jsonp-script", "", chunk, hash),
-				"head.appendChild(script);"
+				"if(/android 2/i.test(window.navigator.userAgent)) {",
+				this.indent(
+					this.applyPluginsWaterfall("jsonp-script-alternative", "", chunk, hash)
+				),
+				"} else {",
+				this.indent([
+					"var head = document.getElementsByTagName('head')[0];",
+					this.applyPluginsWaterfall("jsonp-script", "", chunk, hash),
+					"head.appendChild(script);"
+				]),
+				"}"
 			]),
 			"}"
 		]);

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -96,7 +96,7 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 					"try {",
 					this.indent("eval(xhr.responseText);"),
 					"} catch (e) {",
-					this.indent("throw e"),
+					this.indent("throw e;"),
 					"}",
 				]),
 				"}"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x]  Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
dynamic load(require.ensure) is not working on Android 2.1 stock browser


**What is the new behavior?**
alternate jsonp on android 2.x stock browser


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: 
* Github Issue(s) this is regarding:


**Other information**:
jsonp is not supported on Android 2.1 stock browser
THX :)