### PR TITLE
feature(esModule): set __esModule to true when required by CommonJS (#3168)

### DIFF
--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -37,6 +37,7 @@ HarmonyExportSpecifierDependency.Template = function HarmonyExportSpecifierDepen
 HarmonyExportSpecifierDependency.Template.prototype.apply = function(dep, source) {
 	var used = dep.originModule.isUsed(dep.name);
 	var active = HarmonyModulesHelpers.isActive(dep.originModule, dep);
+	var requiredByCommonJs = HarmonyModulesHelpers.isRequiredByCommonJs(dep.originModule);
 	var content;
 	if(!used) {
 		content = "/* unused harmony export " + (dep.name || "namespace") + " */\n";
@@ -46,6 +47,9 @@ HarmonyExportSpecifierDependency.Template.prototype.apply = function(dep, source
 		content = "/* harmony export (immutable) */ exports[" + JSON.stringify(used) + "] = " + dep.id + ";\n";
 	} else {
 		content = "/* harmony export (binding) */ __webpack_require__.d(exports, " + JSON.stringify(used) + ", function() { return " + dep.id + "; });\n";
+	}
+	if(requiredByCommonJs) {
+		content = content + "\n" + 'Object.defineProperty(exports, "__esModule", {value: true});\n';
 	}
 	if(dep.position > 0)
 		content = "\n" + content;

--- a/lib/dependencies/HarmonyModulesHelpers.js
+++ b/lib/dependencies/HarmonyModulesHelpers.js
@@ -26,7 +26,7 @@ HarmonyModulesHelpers.checkModuleVar = function(state, request) {
 	return HarmonyModulesHelpers.getModuleVar(state, request);
 };
 
-// checks if an harmory dependency is active in a module according to
+// checks if an harmony dependency is active in a module according to
 // precedence rules.
 HarmonyModulesHelpers.isActive = function(module, depInQuestion) {
 	var desc = depInQuestion.describeHarmonyExport();
@@ -68,3 +68,15 @@ HarmonyModulesHelpers.getActiveExports = function(module) {
 		return arr;
 	}, [])
 };
+
+//check if an harmony module has been required by CommonJS module
+HarmonyModulesHelpers.isRequiredByCommonJs = function(module) {
+	var reasons = module.reasons;
+	for(var i = 0; i < reasons.length; i++) {
+		var reason = reasons[i];
+		if(reason.dependency && reason.dependency.constructor.name === 'CommonJsRequireDependency') {
+			return true
+		}
+	}
+	return false;
+}

--- a/test/cases/parsing/harmony-commonjs/a.js
+++ b/test/cases/parsing/harmony-commonjs/a.js
@@ -1,0 +1,3 @@
+export default function test() {
+	return "OK";
+}

--- a/test/cases/parsing/harmony-commonjs/index.js
+++ b/test/cases/parsing/harmony-commonjs/index.js
@@ -1,0 +1,15 @@
+it("should pass when required by CommonJS module", function () {
+	var test1 = require('./a').default;
+	test1().should.be.eql("OK");
+});
+
+it("should pass when use babeljs transpiler", function() {
+	//the following are generated code by use babeljs.
+	// use it this way will save trouble to setup babel-loader
+	// the babeljs transpiled code depends on the __esMoudule to be set
+	var _test = require('./a');
+	var _test2 = _interopRequireDefault(_test);
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+	var test2 = (0, _test2.default)();
+	test2.should.be.eql("OK");
+})


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Webpack doesn't set `__esModule` value for ES6 modules. (#3168)


**What is the new behavior?**
Webpack sets `__esModule` to `true` when it's being used by another CommonJS module.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: 
* Github Issue(s) this is regarding:


**Other information**:

