### PR TITLE
fix(schema): Remove `uniqueItems: true` from `noParse`

### DIFF
--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -144,8 +144,7 @@
                 "instanceof": "RegExp"
               },
               "minItems": 1,
-              "type": "array",
-              "uniqueItems": true
+              "type": "array"
             },
             {
               "instanceof": "RegExp"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Schema validation of `noParse` breaks with multiple RegExps as of beta26.


**What is the new behavior?**

`noParse` validation no longer breaks.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No


**Other information**:


Fixes #3284

Note: this should technically be possible to use, but
`uniqueItems` is broken in ajv; see
https://github.com/epoberezkin/ajv/issues/342

Regardless it is better to fix this bug, and there is technically
no reason why identical noParse RegExps are wrong, just superflous.