### PR TITLE
Display a note about the breaking change when forgot the -loader prefix

### DIFF
--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -213,6 +213,16 @@ NormalModuleFactory.prototype.resolveRequestArray = function resolveRequestArray
 	if(array.length === 0) return callback(null, []);
 	async.map(array, function(item, callback) {
 		resolver.resolve(contextInfo, context, item.loader, function(err, result) {
+			if(err && /^[^/]*$/.test(item.loader) && !/-loader$/.test(item.loader)) {
+				return resolver.resolve(contextInfo, context, item.loader + "-loader", function(err2) {
+					if(!err2) {
+						err.message = err.message + "\n" +
+							"BREAKING CHANGE: It's no longer allowed to omit the '-loader' prefix when using loaders.\n" +
+							"                 You need to specify '" + item.loader + "-loader' instead of '" + item.loader + "'.";
+					}
+					callback(err);
+				});
+			}
 			if(err) return callback(err);
 			return callback(null, objectAssign({}, item, {
 				loader: result

--- a/test/cases/resolving/issue-2986/errors.js
+++ b/test/cases/resolving/issue-2986/errors.js
@@ -1,0 +1,4 @@
+module.exports = [
+	[/Can't resolve 'any' in/, /BREAKING CHANGE/, /any-loader/],
+	[/Can't resolve 'other' in/]
+];

--- a/test/cases/resolving/issue-2986/index.js
+++ b/test/cases/resolving/issue-2986/index.js
@@ -1,0 +1,4 @@
+require.include("any!");
+require.include("other!");
+
+it("should have correct errors", function() {})

--- a/test/cases/resolving/issue-2986/node_modules/any-loader.js
+++ b/test/cases/resolving/issue-2986/node_modules/any-loader.js
@@ -1,0 +1,1 @@
+module.exports = function(source) { return source; }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [x] Feature

**What is the current behavior?** (You can also link to an open issue here)

``` js
require("any!./file");
```

``` text
(webpack)/test/cases/resolving/issue-2986/index.js
Module not found: Error: Can't resolve 'any' in '...'
```

**What is the new behavior?**

``` text
(webpack)/test/cases/resolving/issue-2986/index.js
Module not found: Error: Can't resolve 'any' in '...'
BREAKING CHANGE: It's no longer allowed to omit the '-loader' prefix when using loaders.
                 You need to specify 'any-loader' instead of 'any'.
```

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

Related to #2986