### PR TITLE
`--module-bind` automatically appends `-loader`

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -296,6 +296,7 @@ module.exports = function(yargs, argv, convertOptions) {
 			ifArgPair(arg, function(name, binding) {
 				if(name === null) {
 					name = binding;
+					binding += "-loader";
 				}
 				options.module[collection].push({
 					test: new RegExp("\\." + name.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&") + "$"),

--- a/test/browsertest/build.js
+++ b/test/browsertest/build.js
@@ -34,10 +34,10 @@ var library1 = cp.spawn("node", join(["../../bin/webpack.js", "--output-pathinfo
 bindOutput(library1);
 library1.on("exit", function(code) {
 	if(code === 0) {
-		// node ../../bin/webpack --output-pathinfo --color --resolve-alias vm=vm-browserify --output-public-path js/ --output-chunk-filename [name].web.js --module-bind json --module-bind css=style!css --module-bind less=style!css!less --module-bind coffee --module-bind jade --prefetch ./lib/stylesheet.less ./lib/index "js/web.js?h=[hash]"
+		// node ../../bin/webpack --output-pathinfo --color --resolve-alias vm=vm-browserify --output-public-path js/ --output-chunk-filename [name].web.js --module-bind json --module-bind css=style!css --module-bind less=style-loader!css-loader!less-loader --module-bind coffee --module-bind jade --prefetch ./lib/stylesheet.less ./lib/index "js/web.js?h=[hash]"
 		var main = cp.spawn("node", join(["../../bin/webpack.js", "--output-pathinfo", "--color", "--resolve-alias", "vm=vm-browserify",
 											"--output-public-path", "js/", "--output-chunk-filename", "[name].web.js",
-											"--module-bind", "json", "--module-bind", "css=style!css", "--module-bind", "less=style/url!file?postfix=.css&string!less", "--module-bind", "coffee", "--module-bind", "jade", "--prefetch", "./lib/stylesheet.less", "./lib/index", "js/web.js?h=[hash]", "--progress"], extraArgs));
+											"--module-bind", "json", "--module-bind", "css=style-loader!css-loader", "--module-bind", "less=style-loader/url!file-loader?postfix=.css&string!less-loader", "--module-bind", "coffee", "--module-bind", "jade", "--prefetch", "./lib/stylesheet.less", "./lib/index", "js/web.js?h=[hash]", "--progress"], extraArgs));
 		bindOutput(main);
 	}
 });

--- a/test/browsertest/lib/index.web.js
+++ b/test/browsertest/lib/index.web.js
@@ -9,7 +9,7 @@ function test(cond, message) {
 }
 
 // load tests from library1, with script loader
-require("script!../js/library1.js");
+require("script-loader!../js/library1.js");
 
 // Buildin 'style' loader adds css to document
 require("./stylesheet.css");
@@ -32,7 +32,7 @@ describe("main", function() {
 		should.exist(window.library2.ok);
 		window.library2.ok.should.be.eql(true);
 	});
-	
+
 	describe("web resolving", function() {
 		it("should load index.web.js instead of index.js", function() {
 			true.should.be.eql(true);
@@ -87,8 +87,8 @@ describe("main", function() {
 
 	describe("web loaders", function() {
 		it("should handle the file loader correctly", function() {
-			require("!file!../img/image.png").should.match(/js\/.+\.png$/);
-			document.getElementById("image").src = require("file?prefix=img/!../img/image.png");
+			require("!file-loader!../img/image.png").should.match(/js\/.+\.png$/);
+			document.getElementById("image").src = require("file-loader?prefix=img/!../img/image.png");
 		});
 	});
 

--- a/test/browsertest/library2config.coffee
+++ b/test/browsertest/library2config.coffee
@@ -8,7 +8,7 @@ exports.default = new Promise (resolve, reject) ->
 				hashDigestLength: 5
 			module:
 				rules: [
-					{ test: /extra2?\.js/, loader: "raw!./node_modules/extra.loader.js!val?cacheable", enforce: "post" }
+					{ test: /extra2?\.js/, loader: "raw-loader!./node_modules/extra.loader.js!val-loader?cacheable", enforce: "post" }
 				]
 			amd:
 				fromOptions: true


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
`--module-bind abc` uses loader `abc` for `*.abc`


**What is the new behavior?**
`--module-bind abc` uses loader `abc-loader` for `*.abc`



**Does this PR introduce a breaking change?**
- [x] Yes

If this PR contains a breaking change, please describe the following... 

* Impact: `--module-bind` now works again
* Migration path for existing applications: none
