### PR TITLE
Fix formatting of i18n README.md

### DIFF
--- a/examples/i18n/README.md
+++ b/examples/i18n/README.md
@@ -116,6 +116,8 @@ module.exports = Object.keys(languages).map(function(language) {
 /******/ 	return __webpack_require__(__webpack_require__.s = 0);
 /******/ })
 /************************************************************************/
+</details>
+``` javascript
 /******/ ([
 /* 0 */
 /* unknown exports provided */
@@ -134,6 +136,7 @@ console.log("Missing Text");
 
 # js/en.output.js
 
+<details><summary>`/******/ (function(modules) { /* webpackBootstrap */ })`</summary>
 ``` javascript
 /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Documentation formatting fix

**What is the current behavior?** (You can also link to an open issue here)
N.A.


**What is the new behavior?**
N.A.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications:  
* Github Issue(s) this is regarding:


**Other information**:


There was an error in the formatting of i18n README with the `details` closing tag, causing the English output code to be put in the German `details` tag. This should fix that.