### PR TITLE
Update `-loader`error message

### DIFF
--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -217,7 +217,7 @@ NormalModuleFactory.prototype.resolveRequestArray = function resolveRequestArray
 				return resolver.resolve(contextInfo, context, item.loader + "-loader", function(err2) {
 					if(!err2) {
 						err.message = err.message + "\n" +
-							"BREAKING CHANGE: It's no longer allowed to omit the '-loader' prefix when using loaders.\n" +
+							"BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.\n" +
 							"                 You need to specify '" + item.loader + "-loader' instead of '" + item.loader + "'.";
 					}
 					callback(err);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Print `BREAKING CHANGE: It's no longer allowed to omit the '-loader' prefix when using loaders."`



**What is the new behavior?**
Print `BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders."`


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: 
* Github Issue(s) this is regarding:


**Other information**:
`-loader` is a suffix, not a prefix. A prefix goes at the beginning of a word, and a suffix goes at the end.