### PR TITLE
Make issue template easier to understand

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,4 +12,4 @@
 
 **If this is a feature request, what is motivation or use case for changing the behavior?**
 
-**Please mention other relevant information, such as the browser version, Node.js version or programming language.**
+**Please mention other relevant information such as the browser version, Node.js version, Operating System and programming language.**

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,39 +1,15 @@
-## **BEFORE YOU SUBMIT** please read the following:
-If you have a support request or question please 
-submit them to [StackOverflow](http://stackoverflow.com/questions/tagged/webpack) using the tag `[webpack]` or the [webpack Gitter](https://gitter.im/webpack/webpack). Future support requests will be closed.
-(remove this from issue)
+<!-- Before creating an issue please make sure you are using the latest version of webpack. -->
 
+**Do you want to request a *feature* or report a *bug*?**
+<!-- Please ask questions on StackOverflow or the webpack Gitter (https://gitter.im/webpack/webpack). Questions will be closed. -->
 
+**What is the current behavior?**
 
-**I'm submitting a bug report**
-**I'm submitting a feature request**
-**I'm submitting a support request** => Please do not submit support request here, see note at the top of this template.
-(remove inappropriate sentences)
+**If the current behavior is a bug, please provide the steps to reproduce.**
+<!-- A great way to do this is to provide your configuration via a GitHub gist. -->
 
+**What is the expected behavior?**
 
-**Webpack version:**
-1.10.x/2.x
+**If this is a feature request, what is motivation or use case for changing the behavior?**
 
-
-**Please tell us about your environment:**
-OSX 10.x / Linux / Windows 10
-
-
-**Current behavior:**
-
-
-**Expected/desired behavior:**
-
-
-* **If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem along with a gist/jsbin of your webpack configuration.** 
-
-
-* **What is the expected behavior?**
-
-
-* **What is the motivation / use case for changing the behavior?**
-
- 
-* **Browser:** [all | Chrome XX | Firefox XX | IE XX | Safari XX | Mobile Chrome XX | Android X.X Web Browser | iOS XX Safari | iOS XX UIWebView | iOS XX WKWebView ] 
- 
-* **Language:** [all | TypeScript X.X | ES6/7 | ES5 | Dart | ...] 
+**Please mention other relevant information, such as the browser version, Node.js version or programming language.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 - [ ] Docs have been added / updated (for bug fixes / features)
 
 
-**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+**What kind of change does this PR introduce?**
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
@@ -12,24 +12,15 @@
 - [ ] CI related changes
 - [ ] Other... Please describe:
 
-**What is the current behavior?** (You can also link to an open issue here)
-
-
+**What is the current behavior?**
+<!-- Please write a summary here and - preferably - link to an open issue for more information. -->
 
 **What is the new behavior?**
-
-
 
 **Does this PR introduce a breaking change?**
 - [ ] Yes
 - [ ] No
 
-If this PR contains a breaking change, please describe the following... 
-
-* Impact:
-* Migration path for existing applications: 
-* Github Issue(s) this is regarding:
-
+<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
 
 **Other information**:
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,26 +1,18 @@
-**Please check if the PR fulfills these requirements**
-- [ ] Tests for the changes have been added (for bug fixes / features)
-- [ ] Docs have been added / updated (for bug fixes / features)
-
+<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
 
 **What kind of change does this PR introduce?**
-- [ ] Bugfix
-- [ ] Feature
-- [ ] Code style update (formatting, local variables)
-- [ ] Refactoring (no functional changes, no api changes)
-- [ ] Build related changes
-- [ ] CI related changes
-- [ ] Other... Please describe:
+<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
 
-**What is the current behavior?**
-<!-- Please write a summary here and - preferably - link to an open issue for more information. -->
+**Did you add tests for your changes?**
 
-**What is the new behavior?**
+**If relevant, did you update the documentation?**
+
+**Summary**
+
+<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
+<!-- Try to link to an open issue for more information. -->
 
 **Does this PR introduce a breaking change?**
-- [ ] Yes
-- [ ] No
-
 <!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
 
-**Other information**:
+**Other information**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: issue template changes

**What is the current behavior?** (You can also link to an open issue here)

With the current issue template, people often won't know what to remove exactly.

Also, the first lines are basically shouting at you TO NOT CREATE AN ISSUE IF YOU HAVE A QUESTION. This is okay, but this scares / confuses people (myself included 😱 ). Unfortunately, many people are still asking questions here.

The current PR template has about the same problem; people don't know what to remove. The checkboxes are confusing in the overview, since it makes it seem like the PR is in progress.

**What is the new behavior?**

The new template asks real questions to the user, making it easier to fill out and know where to put the answers.

It still strongly makes clear that you should not ask questions here, but does so more subtly.

All hints are between HTML comments (`<!-- -->`), which means that even if the user forgets to remove that, it isn't visible in the issue anyway.

This was heavily inspired by Yarn's [issue template](https://raw.githubusercontent.com/yarnpkg/yarn/master/.github/ISSUE_TEMPLATE.md). Hope you don't mind, @cpojer!

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No