### PR TITLE
Change jade-loader url to pug-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Please see [Using Loaders](https://webpack.github.io/docs/using-loaders.html) fo
 
 **templating**
 * [`html`](https://github.com/webpack/html-loader): Exports HTML as string, require references to static resources.
-* [`jade`](https://github.com/webpack/jade-loader): Loads jade template and returns a function
+* [`pug`](https://github.com/pugjs/pug-loader): Loads pug template and returns a function
 * [`handlebars`](https://github.com/altano/handlebars-loader): Loads handlebars template and returns a function
 * [`ractive`](https://github.com/rstacruz/ractive-loader): Pre-compiles Ractive templates for interactive DOM manipulation
 * [`markdown`](https://github.com/peerigon/markdown-loader): Compiles Markdown to HTML


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Fixes a small inconsistency in the main readme for one of the templating loaders

**Did you add tests for your changes?**

N/A

**If relevant, did you update the documentation?**

N/A

**Summary**

The template engine Pug was previously called Jade, merely use the correct url (no redirect) and name where relevant.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

N/A

**Other information**

N/A

