### PR TITLE
Allow use of booleans in the `externals` option

### DIFF
--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -82,6 +82,9 @@
               },
               {
                 "type": "object"
+              },
+              {
+                "type": "boolean"
               }
             ]
           },


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
Nope

**If relevant, did you update the documentation?**
Nope

**Summary**

With the schema validation, something like this was marked as invalid (#3299):

```js
externals: [
        {
            a: false,
            b: true
        },
]
```

But this [is supported](https://github.com/webpack/webpack/blob/master/lib/ExternalModuleFactoryPlugin.js#L25-L26).

**Does this PR introduce a breaking change?**
No

**Other information**

It fixes #3299.