### PR TITLE
Run linters (fast) before tests (slow)

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "appveyor": "node --max_old_space_size=4096 node_modules\\mocha\\bin\\mocha --harmony",
     "build:examples": "cd examples && node buildAll.js",
     "pretest": "npm run lint-files",
-    "postcover": "npm run lint-files && npm run nsp",
+    "precover": "npm run lint-files && npm run nsp",
     "lint-files": "npm run lint && npm run beautify-lint",
     "lint": "eslint lib bin hot",
     "beautify-lint": "beautify-lint lib/**/*.js hot/**/*.js bin/**/*.js benchmark/*.js test/*.js",


### PR DESCRIPTION
This runs linters before the test suite, as linters are much faster.

Failing a linter check would fail the CI build anyway.