### PR TITLE
More eslint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
 	"root": true,
+	"extends": [
+		"eslint:recommended"
+	],
 	"env": {
 		"node": true
 	},
@@ -21,6 +24,8 @@
 		"consistent-return": 0,
 		"no-inner-declarations": 1,
 		"no-loop-func": 1,
-		"space-before-function-paren": [2, "never"] 
+		"space-before-function-paren": [2, "never"],
+		"no-console": 0,
+		"comma-dangle": 0
 	}
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,11 @@
 		"no-inner-declarations": 1,
 		"no-loop-func": 1,
 		"space-before-function-paren": [2, "never"],
+		"space-before-blocks": [2, "always"],
+		"space-before-keywords": [2, "always"],
 		"no-console": 0,
-		"comma-dangle": 0
+		"comma-dangle": 0,
+		"no-unexpected-multiline": 2,
+		"valid-jsdoc": 2
 	}
 }

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -280,7 +280,7 @@ function processOptions(options) {
 				console.error("\u001b[1m\u001b[31m" + e.message + "\u001b[39m\u001b[22m");
 			else
 				console.error(e.message);
-			process.exit(1);
+			process.exit(1); // eslint-disable-line no-process-exit
 		}
 		throw e;
 	}

--- a/lib/AsyncDependenciesBlock.js
+++ b/lib/AsyncDependenciesBlock.js
@@ -49,7 +49,7 @@ AsyncDependenciesBlock.prototype.sortItems = function() {
 	if(this.chunks) {
 		this.chunks.sort(function(a, b) {
 			var i = 0;
-			while(true) {
+			while(true) { // eslint-disable-line no-constant-condition
 				if(!a.modules[i] && !b.modules[i]) return 0;
 				if(!a.modules[i]) return -1;
 				if(!b.modules[i]) return 1;

--- a/lib/ContextReplacementPlugin.js
+++ b/lib/ContextReplacementPlugin.js
@@ -100,4 +100,4 @@ function createResolveDependenciesFromContextMap(createContextMap) {
 			callback(null, dependencies);
 		});
 	}
-};
+}

--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -71,7 +71,7 @@ FlagDependencyExportsPlugin.prototype.apply = function(compiler) {
 							module.providedExports = exports.slice();
 							changed = true;
 						}
-					};
+					}
 				}
 				if(changed) {
 					notifyDependencies();

--- a/lib/WebpackOptionsValidationError.js
+++ b/lib/WebpackOptionsValidationError.js
@@ -86,7 +86,7 @@ WebpackOptionsValidationError.formatValidationError = function formatValidationE
 				return dataPath + " should not be empty.";
 			else
 				return dataPath + " " + err.message;
-		default:
+		default: // eslint-disable-line no-fallthrough
 			return dataPath + " " + err.message + " (" + JSON.stringify(err, 0, 2) + ").\n" +
 				getSchemaPartText(err.parentSchema);
 	}

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -82,7 +82,7 @@ HarmonyExportImportedSpecifierDependency.prototype.getExports = function() {
 		return {
 			exports: [this.name]
 		}
-	};
+	}
 	if(this.importDependency.module && Array.isArray(this.importDependency.module.providedExports)) {
 		return {
 			exports: this.importDependency.module.providedExports.filter(function(id) {


### PR DESCRIPTION
This adds some extra rules to the eslint config.

All code already passes the rules, with only very few places that were an exception, so they either disabled the lint rule for the specific line or were fixed.

Other potential rules:

* `"quotes": [2, "double", "avoid-escape"]`: many places that don't follow it, but seems to be the convention
* `"semi": 2`: idem
* `"comma-dangle": [2, "only-multiline"]`: requires eslint upgrade