### PR TITLE
Add descriptions for valid JSDoc

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -299,11 +299,10 @@ Parser.prototype.initializeEvaluating = function() {
 		});
 
 		/**
-		 * @param {Parser} this
-		 * @param {"cooked" | "raw"} kind
-		 * @param {any[]} quasis
-		 * @param {any[]} expressions
-		 * @return {BasicEvaluatedExpression[]}
+		 * @param {string} kind "cooked" | "raw"
+		 * @param {any[]} quasis quasis
+		 * @param {any[]} expressions expressions
+		 * @return {BasicEvaluatedExpression[]} Simplified template
 		 */
 		function getSimplifiedTemplateResult(kind, quasis, expressions) {
 			var i = 0, parts = [];

--- a/lib/dependencies/ContextDependencyHelpers.js
+++ b/lib/dependencies/ContextDependencyHelpers.js
@@ -6,8 +6,8 @@ var ContextDependencyHelpers = exports;
 
 /**
  * Escapes regular expression metacharacters
- * @param {string} str
- * @return string
+ * @param {string} str String to quote
+ * @return {string} Escaped string
  */
 function quotemeta(str) {
 	return str.replace(/[-[\]\\/{}()*+?.^$|]/g, "\\$&")


### PR DESCRIPTION
Fixes lint errors caused by a combination of different PRs

Alternatively, could disable the valid-jsdoc check. The JSDoc is mostly intended for VS Code autocompletion (the typescript server can use jsdoc as type annotations).