### PR TITLE
Update node-libs-browser to ^1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "loader-utils": "^0.2.11",
     "memory-fs": "~0.3.0",
     "mkdirp": "~0.5.0",
-    "node-libs-browser": "^0.6.0",
+    "node-libs-browser": "^1.1.0",
     "optimist": "~0.6.0",
     "supports-color": "^3.1.0",
     "tapable": "~0.1.8",


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Dependency update

**Summary**
Since node-libs-browser 1.0.0 was released as a major version and only webpack 2 was updated, we had to maintain a `version-0` branch for webpack 1. We should update webpack 1 as well so we don't have to maintain two branches.

**Does this PR introduce a breaking change?**
[According to my research](https://github.com/webpack/node-libs-browser/issues/45), the risk of introducing a breaking change with this update is very low. node-libs-browser is designed to be in feature parity with node, but the exact node version is not pinned. So this is somewhat vague. If someone relied on a very ancient node feature or a bug that has been fixed, this would be a breaking change. But it is also likely that this update could fix some bugs for free. We actually had already some requests to update a node module in webpack-1 (https://github.com/webpack/node-libs-browser/issues/39, https://github.com/webpack/node-libs-browser/issues/40)