### PR TITLE
fixes a bug in which complex options are not passed through chain

### DIFF
--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -118,6 +118,17 @@ function NormalModuleFactory(context, resolvers, options) {
 				var loaders = results[0];
 				resource = results[1];
 
+				// translate option idents
+				try {
+					loaders.forEach(function(item) {
+						if(typeof item.options === "string" && /^\?/.test(item.options)) {
+							item.options = _this.ruleSet.findOptionsByIdent(item.options.substr(1));
+						}
+					})
+				} catch(e) {
+					return callback(e);
+				}
+
 				if(resource === false)
 					return callback(null,
 						new RawModule("/* (ignored) */",

--- a/lib/RuleSet.js
+++ b/lib/RuleSet.js
@@ -74,24 +74,25 @@ normalized:
 */
 
 function RuleSet(rules) {
-	this.rules = RuleSet.normalizeRules(rules);
+	this.references = {};
+	this.rules = RuleSet.normalizeRules(rules, this.references);
 }
 
 module.exports = RuleSet;
 
-RuleSet.normalizeRules = function(rules) {
+RuleSet.normalizeRules = function(rules, refs) {
 	if(Array.isArray(rules)) {
 		return rules.map(function(rule) {
-			return RuleSet.normalizeRule(rule);
+			return RuleSet.normalizeRule(rule, refs);
 		});
 	} else if(rules) {
-		return [RuleSet.normalizeRule(rules)]
+		return [RuleSet.normalizeRule(rules, refs)]
 	} else {
 		return [];
 	}
 };
 
-RuleSet.normalizeRule = function(rule) {
+RuleSet.normalizeRule = function(rule, refs) {
 	if(typeof rule === "string")
 		return {
 			use: [{
@@ -166,10 +167,10 @@ RuleSet.normalizeRule = function(rule) {
 	}
 
 	if(rule.rules)
-		newRule.rules = RuleSet.normalizeRules(rule.rules);
+		newRule.rules = RuleSet.normalizeRules(rule.rules, refs);
 
 	if(rule.oneOf)
-		newRule.oneOf = RuleSet.normalizeRules(rule.oneOf);
+		newRule.oneOf = RuleSet.normalizeRules(rule.oneOf, refs);
 
 	var keys = Object.keys(rule).filter(function(key) {
 		return ["resource", "test", "include", "exclude", "issuer", "loader", "options", "query", "loaders", "use", "rules", "oneOf"].indexOf(key) < 0;
@@ -188,6 +189,14 @@ RuleSet.normalizeRule = function(rule) {
 		if(resourceSource && resourceSource !== newSource)
 			throw new Error("Rule can only have one resource source (provided " + newSource + " and " + resourceSource + ")");
 		resourceSource = newSource;
+	}
+
+	if(Array.isArray(newRule.use)) {
+		newRule.use.forEach(function(item) {
+			if(typeof item.options === "object" && item.options && item.options.ident) {
+				refs["$" + item.options.ident] = item.options;
+			}
+		});
 	}
 
 	return newRule;
@@ -388,4 +397,10 @@ RuleSet.prototype._run = function _run(data, rule, result) {
 	}
 
 	return true;
+};
+
+RuleSet.prototype.findOptionsByIdent = function findOptionsByIdent(ident) {
+	var options = this.references["$" + ident];
+	if(!options) throw new Error("Can't find options with ident '" + ident + "'");
+	return options;
 };

--- a/test/configCases/loaders/remaining-request/index.js
+++ b/test/configCases/loaders/remaining-request/index.js
@@ -1,0 +1,3 @@
+it("should correctly pass complex query object with remaining request", function() {
+	require("./a").should.be.eql("ok");
+});

--- a/test/configCases/loaders/remaining-request/loader1.js
+++ b/test/configCases/loaders/remaining-request/loader1.js
@@ -1,0 +1,3 @@
+module.exports.pitch = function(remainingRequest) {
+	return "module.exports = require(" + JSON.stringify("!!" + remainingRequest) + ");";
+};

--- a/test/configCases/loaders/remaining-request/loader2.js
+++ b/test/configCases/loaders/remaining-request/loader2.js
@@ -1,0 +1,3 @@
+module.exports = function(source) {
+	return "module.exports = " + JSON.stringify(this.query.f());
+};

--- a/test/configCases/loaders/remaining-request/webpack.config.js
+++ b/test/configCases/loaders/remaining-request/webpack.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /a\.js$/,
+				use: [
+					"./loader1",
+					{
+						loader: "./loader2",
+						options: {
+							ident: "loader2",
+							f: function() {
+								return "ok";
+							}
+						}
+					}
+				]
+			}
+		]
+	}
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
yes

**If relevant, did you update the documentation?**
N/A

**Summary**
pitching loaders get the `remainingRequest` passed. As this is a string complex options doesn't get passed. Instead the `ident` is passed. This PR fixes the conversion from ident back to complex options.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no, it's a bugfix
