### PR TITLE
Unhide own modules when loader path matches exclude filter

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -64,7 +64,7 @@ Stats.prototype.toJson = function toJson(options, forToString) {
 		}
 		if(excludeModules.length === 0)
 			return true;
-		var ident = module.identifier();
+		var ident = module.resource;
 		return !excludeModules.some(function(regExp) {
 			return regExp.test(ident);
 		});

--- a/test/statsCases/exclude-with-loader/a.txt
+++ b/test/statsCases/exclude-with-loader/a.txt
@@ -1,0 +1,1 @@
+module.exports = "a"

--- a/test/statsCases/exclude-with-loader/exclude/b.txt
+++ b/test/statsCases/exclude-with-loader/exclude/b.txt
@@ -1,0 +1,1 @@
+module.exports = "b"

--- a/test/statsCases/exclude-with-loader/expected.txt
+++ b/test/statsCases/exclude-with-loader/expected.txt
@@ -1,0 +1,7 @@
+Hash: affacd3db222d3fcb700
+Time: Xms
+    Asset     Size  Chunks             Chunk Names
+bundle.js  2.69 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 132 bytes [entry] [rendered]
+    [2] (webpack)/test/statsCases/exclude-with-loader/index.js 46 bytes {0} [built]
+     + 2 hidden modules

--- a/test/statsCases/exclude-with-loader/expected.txt
+++ b/test/statsCases/exclude-with-loader/expected.txt
@@ -3,5 +3,6 @@ Time: Xms
     Asset     Size  Chunks             Chunk Names
 bundle.js  2.69 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 132 bytes [entry] [rendered]
+    [0] (webpack)/test/statsCases/exclude-with-loader/a.txt 43 bytes {0} [built]
     [2] (webpack)/test/statsCases/exclude-with-loader/index.js 46 bytes {0} [built]
-     + 2 hidden modules
+     + 1 hidden modules

--- a/test/statsCases/exclude-with-loader/index.js
+++ b/test/statsCases/exclude-with-loader/index.js
@@ -1,0 +1,2 @@
+require("./a.txt")
+require("./exclude/b.txt")

--- a/test/statsCases/exclude-with-loader/webpack.config.js
+++ b/test/statsCases/exclude-with-loader/webpack.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+	entry: "./index",
+	output: {
+		filename: "bundle.js"
+	},
+	stats: {
+		exclude: [
+			"node_modules",
+			"exclude"
+		]
+	},
+	module: {
+		loaders: [{
+			test: /\.txt/,
+			loader: "raw-loader"
+		}]
+	}
+};


### PR DESCRIPTION
Currently, if loader implementation path matches filter, all modules loaded with it will be under "hidden modules" in stats output.

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
yes

**If relevant, did you update the documentation?**
not relevant

**Summary**

As the original issue author noted
> This makes it almost impossible to hide node_modules without hiding your application as well.

**Does this PR introduce a breaking change?**
no

**Other information**
Fix #1159