### PR TITLE
Fix lost context when invoking require()

### DIFF
--- a/lib/dependencies/DepBlockHelpers.js
+++ b/lib/dependencies/DepBlockHelpers.js
@@ -25,11 +25,11 @@ DepBlockHelpers.getLoadDepBlockWrapper = function(depBlock, outputOptions, reque
 				"if(--__WEBPACK_REMAINING_CHUNKS__ < 1) (",
 
 				"(__webpack_require__));" +
-				"};" +
+				"}.bind(this);" +
 				chunks.map(function(chunk) {
 					return "__webpack_require__.e(" + chunk.id + ", __WEBPACK_CALLBACK__);";
 				}).join("") +
-				"}())"
+				"}).call(this)"
 			];
 		}
 	}

--- a/test/cases/compile/require-context/index.js
+++ b/test/cases/compile/require-context/index.js
@@ -1,6 +1,8 @@
 it("should maintain require context", function() {
 	var context = {foo: "bar"};
-	require(["./a", "./b"], function(a, b) {
-		this.foo.should.eql("bar");
-	}.bind(context));
+	(function(){
+		require(["./a", "./b"], function(a, b) {
+			this.foo.should.eql("bar");
+		}.bind(this));
+	}).call(context);
 });

--- a/test/cases/compile/require-context/index.js
+++ b/test/cases/compile/require-context/index.js
@@ -1,8 +1,0 @@
-it("should maintain require context", function() {
-	var context = {foo: "bar"};
-	(function(){
-		require(["./a", "./b"], function(a, b) {
-			this.foo.should.eql("bar");
-		}.bind(this));
-	}).call(context);
-});

--- a/test/cases/compile/require-context/index.js
+++ b/test/cases/compile/require-context/index.js
@@ -1,0 +1,6 @@
+it("should maintain require context", function() {
+	var context = {foo: "bar"};
+	require(["./a", "./b"], function(a, b) {
+		this.foo.should.eql("bar");
+	}.bind(context));
+});

--- a/test/configCases/async-commons-chunk/require-context/a.js
+++ b/test/configCases/async-commons-chunk/require-context/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/test/configCases/async-commons-chunk/require-context/b.js
+++ b/test/configCases/async-commons-chunk/require-context/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/test/configCases/async-commons-chunk/require-context/index.js
+++ b/test/configCases/async-commons-chunk/require-context/index.js
@@ -1,0 +1,11 @@
+it("should maintain require context", function(done) {
+	var context = {foo: "bar"};
+	(function(){
+		require(["./a", "./b"], function(a, b) {
+			this.foo.should.eql("bar");
+			done();
+		}.bind(this));
+	}).call(context);
+	// Call require again so that CommonsChunkPlugin will create separate chunks for a and b
+	require(["./a"], function(a) {});
+});

--- a/test/configCases/async-commons-chunk/require-context/webpack.config.js
+++ b/test/configCases/async-commons-chunk/require-context/webpack.config.js
@@ -1,0 +1,9 @@
+var webpack = require("../../../../");
+
+module.exports = {
+	plugins: [
+		new webpack.optimize.CommonsChunkPlugin({
+			async: true
+		})
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Fix lost context when invoking AMD require.  For example:
```
require(['foo', 'bar'], function(foo, bar) {
    this.something();   // Error, this points to global scope!!!
}.bind(this));
```

**Did you add tests for your changes?**
No

**If relevant, did you update the documentation?**
N/A

**Summary**
Allow code that attempts to pass context to require callback to work with Webpack.

**Does this PR introduce a breaking change?**
No

**Other information**
I assumed the the webpack-1 branch was for ongoing 1.x development.  Please let me know if I need to submit this PR to a different branch.
