### PR TITLE
show changed errors and warnings even when build hash didn't change

### DIFF
--- a/lib/MultiStats.js
+++ b/lib/MultiStats.js
@@ -66,6 +66,8 @@ MultiStats.prototype.toJson = function(options, forToString) {
 	return obj;
 };
 
+MultiStats.prototype.toStringAndJson = Stats.prototype.toStringAndJson;
+
 MultiStats.prototype.toString = Stats.prototype.toString;
 
 module.exports = MultiStats;

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -343,7 +343,7 @@ class Stats {
 		return obj;
 	}
 
-	toString(options) {
+	toStringAndJson(options) {
 		if(typeof options === "boolean" || typeof options === "string") {
 			options = Stats.presetToOptions(options);
 		} else if(!options) {
@@ -354,7 +354,14 @@ class Stats {
 
 		const obj = this.toJson(options, true);
 
-		return Stats.jsonToString(obj, useColors);
+		return {
+			string: Stats.jsonToString(obj, useColors),
+			json: obj
+		};
+	}
+
+	toString(options) {
+		return this.toStringAndJson(options).string;
 	}
 
 	static jsonToString(obj, useColors) {

--- a/lib/arrayEquals.js
+++ b/lib/arrayEquals.js
@@ -1,0 +1,5 @@
+module.exports = function arrayEquals(a, b) {
+	return a.length === b.length && a.every(function(e, i) {
+		return b[i] === e;
+	});
+};

--- a/test/ArrayEquals.test.js
+++ b/test/ArrayEquals.test.js
@@ -1,0 +1,14 @@
+var should = require("should");
+
+var arrayEquals = require("../lib/arrayEquals");
+
+describe("ArrayEquals", function() {
+	it("arrayEquals should compare arrays of primitives", function() {
+		var a = [null, 7, "5", 6];
+		var b = ["5", 6, null, 7];
+		var c = ["5", 6, null, 7];
+
+		arrayEquals(a, b).should.equal(false);
+		arrayEquals(b, c).should.equal(true);
+	});
+});


### PR DESCRIPTION
fixes #2538, fixes #3254

Old behaviour: if build hash didn't change but errors or warning did, the new errors and warnings were not displayed as build stats were not printed

New behaviour: print build stats if either errors and warnings have changed even when build hash didn't change

**Does this PR introduce a breaking change?**

no

**Other information**

This is an alternative approach w.r.t PR #3023 (--display-always).