### PR TITLE
change internal async variable name (CommonsChunkPlugin)

### DIFF
--- a/lib/optimize/CommonsChunkPlugin.js
+++ b/lib/optimize/CommonsChunkPlugin.js
@@ -32,7 +32,7 @@ function CommonsChunkPlugin(options) {
 	this.minChunks = options.minChunks;
 	this.selectedChunks = options.chunks;
 	if(options.children) this.selectedChunks = false;
-	this.asyncOption = options.async;
+	this.async = options.async;
 	this.minSize = options.minSize;
 	this.ident = __filename + (nextIdent++);
 }
@@ -43,7 +43,7 @@ CommonsChunkPlugin.prototype.apply = function(compiler) {
 	var filenameTemplate = this.filenameTemplate;
 	var minChunks = this.minChunks;
 	var selectedChunks = this.selectedChunks;
-	var asyncOption = this.asyncOption;
+	var asyncOption = this.async;
 	var minSize = this.minSize;
 	var ident = this.ident;
 	compiler.plugin("this-compilation", function(compilation) {

--- a/lib/optimize/CommonsChunkPlugin.js
+++ b/lib/optimize/CommonsChunkPlugin.js
@@ -32,7 +32,7 @@ function CommonsChunkPlugin(options) {
 	this.minChunks = options.minChunks;
 	this.selectedChunks = options.chunks;
 	if(options.children) this.selectedChunks = false;
-	this.async = options.async;
+	this.asyncOption = options.async;
 	this.minSize = options.minSize;
 	this.ident = __filename + (nextIdent++);
 }
@@ -43,7 +43,7 @@ CommonsChunkPlugin.prototype.apply = function(compiler) {
 	var filenameTemplate = this.filenameTemplate;
 	var minChunks = this.minChunks;
 	var selectedChunks = this.selectedChunks;
-	var async = this.async;
+	var asyncOption = this.asyncOption;
 	var minSize = this.minSize;
 	var ident = this.ident;
 	compiler.plugin("this-compilation", function(compilation) {
@@ -53,7 +53,7 @@ CommonsChunkPlugin.prototype.apply = function(compiler) {
 			compilation[ident] = true;
 
 			var commonChunks;
-			if(!chunkNames && (selectedChunks === false || async)) {
+			if(!chunkNames && (selectedChunks === false || asyncOption)) {
 				commonChunks = chunks;
 			} else if(Array.isArray(chunkNames) || typeof chunkNames === "string") {
 				commonChunks = [].concat(chunkNames).map(function(chunkName) {
@@ -75,10 +75,10 @@ CommonsChunkPlugin.prototype.apply = function(compiler) {
 						if(chunk === commonChunk) return false;
 						return selectedChunks.indexOf(chunk.name) >= 0;
 					});
-				} else if(selectedChunks === false || async) {
+				} else if(selectedChunks === false || asyncOption) {
 					usedChunks = (commonChunk.chunks || []).filter(function(chunk) {
 						// we can only move modules from this chunk if the "commonChunk" is the only parent
-						return async || chunk.parents.length === 1;
+						return asyncOption || chunk.parents.length === 1;
 					});
 				} else {
 					if(commonChunk.parents.length > 0) {
@@ -91,8 +91,8 @@ CommonsChunkPlugin.prototype.apply = function(compiler) {
 						return chunk.hasRuntime();
 					});
 				}
-				if(async) {
-					var asyncChunk = this.addChunk(typeof async === "string" ? async : undefined);
+				if(asyncOption) {
+					var asyncChunk = this.addChunk(typeof asyncOption === "string" ? asyncOption : undefined);
 					asyncChunk.chunkReason = "async commons chunk";
 					asyncChunk.extraAsync = true;
 					asyncChunk.addParent(commonChunk);
@@ -144,7 +144,7 @@ CommonsChunkPlugin.prototype.apply = function(compiler) {
 					commonChunk.addModule(module);
 					module.addChunk(commonChunk);
 				});
-				if(async) {
+				if(asyncOption) {
 					reallyUsedChunks.forEach(function(chunk) {
 						if(chunk.isInitial())
 							return;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

N/A

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

* `async` became a keyword ( ES2017 ).
* `var async = ...` broken syntax highlight (on editor, on github).
* Original code(async as a variable) work fine, but make little confuse.
* I try to change variable to `asyncFlag` but `async` option accept string. I choose name `asyncOption`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

