### PR TITLE
Fix double "use strict"

### DIFF
--- a/lib/FunctionModuleTemplatePlugin.js
+++ b/lib/FunctionModuleTemplatePlugin.js
@@ -16,7 +16,7 @@ FunctionModuleTemplatePlugin.prototype.apply = function(moduleTemplate) {
 			defaultArguments.push("__webpack_require__");
 		}
 		source.add("/***/ function(" + defaultArguments.concat(module.arguments || []).join(", ") + ") {\n\n");
-		if(module.strict) source.add("\"use strict\";");
+		if(module.strict) source.add("\"use strict\";\n");
 		source.add(moduleSource);
 		source.add("\n\n/***/ }");
 		return source;

--- a/lib/FunctionModuleTemplatePlugin.js
+++ b/lib/FunctionModuleTemplatePlugin.js
@@ -16,7 +16,7 @@ FunctionModuleTemplatePlugin.prototype.apply = function(moduleTemplate) {
 			defaultArguments.push("__webpack_require__");
 		}
 		source.add("/***/ function(" + defaultArguments.concat(module.arguments || []).join(", ") + ") {\n\n");
-		if(module.strict) source.add("\"use strict\";\n");
+		if(module.strict) source.add("\"use strict\";");
 		source.add(moduleSource);
 		source.add("\n\n/***/ }");
 		return source;

--- a/lib/UseStrictPlugin.js
+++ b/lib/UseStrictPlugin.js
@@ -3,7 +3,6 @@
 	Author Tobias Koppers @sokra
 */
 var ConstDependency = require("./dependencies/ConstDependency");
-var BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
 
 var NullFactory = require("./NullFactory");
 
@@ -14,12 +13,20 @@ UseStrictPlugin.prototype.apply = function(compiler) {
 	compiler.plugin("compilation", function(compilation, params) {
 		params.normalModuleFactory.plugin("parser", function(parser) {
 			parser.plugin("program", function(ast) {
-				var body = ast.body[0]
-				if(body &&
-					body.type === "ExpressionStatement" &&
-					body.expression.type === "Literal" &&
-					body.expression.value === "use strict")
+				var firstNode = ast.body[0];
+				var dep;
+				if(firstNode &&
+					firstNode.type === "ExpressionStatement" &&
+					firstNode.expression.type === "Literal" &&
+					firstNode.expression.value === "use strict") {
+					// Remove "use strict" expression. It will be added later by the renderer again.
+					// This is necessary in order to not break the strict mode when webpack prepends code.
+					// @see https://github.com/webpack/webpack/issues/1970
+					dep = new ConstDependency("", firstNode.range);
+					dep.loc = firstNode.loc;
+					this.state.current.addDependency(dep);
 					this.state.module.strict = true;
+				}
 			});
 		})
 	})

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -3,14 +3,26 @@
 	Author Tobias Koppers @sokra
 */
 var AbstractPlugin = require("../AbstractPlugin");
+var HarmonyCompatiblilityDependency = require("./HarmonyCompatiblilityDependency");
 var HarmonyImportDependency = require("./HarmonyImportDependency");
 var HarmonyImportSpecifierDependency = require("./HarmonyImportSpecifierDependency");
 var HarmonyAcceptImportDependency = require("./HarmonyAcceptImportDependency");
 var HarmonyAcceptDependency = require("./HarmonyAcceptDependency");
 var HarmonyModulesHelpers = require("./HarmonyModulesHelpers");
 
+function makeHarmonyModule(module, loc) {
+	if(!module.meta.harmonyModule) {
+		var dep = new HarmonyCompatiblilityDependency(module);
+		dep.loc = loc;
+		module.addDependency(dep);
+		module.meta.harmonyModule = true;
+		module.strict = true;
+	}
+}
+
 module.exports = AbstractPlugin.create({
 	"import": function(statement, source) {
+		makeHarmonyModule(this.state.module, statement.loc);
 		var dep = new HarmonyImportDependency(source, HarmonyModulesHelpers.getNewModuleVar(this.state, source), statement.range);
 		dep.loc = statement.loc;
 		this.state.current.addDependency(dep);

--- a/test/configCases/code-generation/use-strict/harmony-with-strict.js
+++ b/test/configCases/code-generation/use-strict/harmony-with-strict.js
@@ -1,0 +1,2 @@
+"use strict";
+export default "a";

--- a/test/configCases/code-generation/use-strict/harmony-with-strict2.js
+++ b/test/configCases/code-generation/use-strict/harmony-with-strict2.js
@@ -1,0 +1,4 @@
+"use strict";
+import * as a from "./harmony-without-strict2";
+export default a;
+import "./harmony-with-strict3"

--- a/test/configCases/code-generation/use-strict/harmony-with-strict3.js
+++ b/test/configCases/code-generation/use-strict/harmony-with-strict3.js
@@ -1,0 +1,2 @@
+"use strict";
+export default "a";

--- a/test/configCases/code-generation/use-strict/harmony-without-strict.js
+++ b/test/configCases/code-generation/use-strict/harmony-without-strict.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/test/configCases/code-generation/use-strict/harmony-without-strict2.js
+++ b/test/configCases/code-generation/use-strict/harmony-without-strict2.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/test/configCases/code-generation/use-strict/index.js
+++ b/test/configCases/code-generation/use-strict/index.js
@@ -1,0 +1,26 @@
+"use strict";
+it("should include only one use strict per module", function() {
+	require("./harmony-with-strict");
+	require("./harmony-without-strict");
+	require("./harmony-with-strict2");
+
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+
+	var regExp = /\"use strict\";?\s*(.*)/g
+	var match = regExp.exec(source);
+	var matches = [];
+	while(match) {
+		matches.push(match[1]);
+		match = regExp.exec(source);
+	}
+
+	matches.should.be.eql([
+		"Object.defineProperty(exports, \"__esModule\", { value: true });",
+		"Object.defineProperty(exports, \"__esModule\", { value: true });",
+		"Object.defineProperty(exports, \"__esModule\", { value: true });",
+		"/* unused harmony default export */ var _unused_webpack_default_export = \"a\";",
+		"Object.defineProperty(exports, \"__esModule\", { value: true });",
+		"it(\"should include only one use strict per module\", function() {"
+	]);
+});

--- a/test/configCases/code-generation/use-strict/webpack.config.js
+++ b/test/configCases/code-generation/use-strict/webpack.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};

--- a/test/statsCases/tree-shaking/expected.txt
+++ b/test/statsCases/tree-shaking/expected.txt
@@ -1,7 +1,7 @@
-Hash: 84ac10223b6099395c33
+Hash: 37c14a3d270eb3a66a74
 Time: Xms
     Asset     Size  Chunks             Chunk Names
-bundle.js  7.07 kB       0  [emitted]  main
+bundle.js  7.14 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 588 bytes [entry] [rendered]
    [0] (webpack)/test/statsCases/tree-shaking/a.js 13 bytes {0} [built]
        [exports: a]

--- a/test/statsCases/tree-shaking/expected.txt
+++ b/test/statsCases/tree-shaking/expected.txt
@@ -1,7 +1,7 @@
 Hash: 84ac10223b6099395c33
 Time: Xms
     Asset     Size  Chunks             Chunk Names
-bundle.js  7.08 kB       0  [emitted]  main
+bundle.js  7.07 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 588 bytes [entry] [rendered]
    [0] (webpack)/test/statsCases/tree-shaking/a.js 13 bytes {0} [built]
        [exports: a]


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Sort of bug fix

**Did you add tests for your changes?**

No

**Summary**

This fixes a problem where webpack rendered modules with two "use strict" statements at the beginning

**Does this PR introduce a breaking change?**

No