### PR TITLE
Escape webpackContext.id value

### DIFF
--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -121,7 +121,7 @@ ContextModule.prototype.source = function() {
 			"};\n",
 			"webpackContext.resolve = webpackContextResolve;\n",
 			"module.exports = webpackContext;\n",
-			"webpackContext.id = " + this.id + ";\n"
+			"webpackContext.id = " + JSON.stringify(this.id) + ";\n"
 		];
 	} else if(this.blocks && this.blocks.length > 0) {
 		var items = this.blocks.map(function(block) {
@@ -165,7 +165,7 @@ ContextModule.prototype.source = function() {
 			"\treturn Object.keys(map);\n",
 			"};\n",
 			"module.exports = webpackAsyncContext;\n",
-			"webpackAsyncContext.id = " + this.id + ";\n"
+			"webpackAsyncContext.id = " + JSON.stringify(this.id) + ";\n"
 		];
 	} else {
 		str = [
@@ -175,7 +175,7 @@ ContextModule.prototype.source = function() {
 			"webpackEmptyContext.keys = function() { return []; };\n",
 			"webpackEmptyContext.resolve = webpackEmptyContext;\n",
 			"module.exports = webpackEmptyContext;\n",
-			"webpackEmptyContext.id = " + this.id + ";\n"
+			"webpackEmptyContext.id = " + JSON.stringify(this.id) + ";\n"
 		];
 	}
 	if(this.useSourceMap) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** Bugfix

**Summary** When using `HashedModuleIdsPlugin` along with a `require.context()` statement, value of `this.id` would be a string. It was previously passed unescaped which would compile improperly.

**Does this PR introduce a breaking change?** No

**Other information**

I couldn't find a test case for this module and I'm not sure where I would create it. I'm happy to try though if someone tells me where to create the test case within the `tests/` folder hierarchy.