### PR TITLE
fix html-webpack-plugin link address

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ within webpack itself use this plugin interface. This makes webpack very
 |[component-webpack-plugin][component]|![component-npm]|Use components with webpack|
 |[compression-webpack-plugin][compression]|![compression-npm]|Prepare compressed versions of assets to serve them with Content-Encoding|
 |[i18n-webpack-plugin][i18n]|![i18n-npm]|Adds i18n support to your bundles|
-|[html-webpack-plugin][html]|![html-npm]| Simplifies creation of HTML files (`index.html`) to serve your bundles|
+|[html-webpack-plugin][html-plugin]|![html-plugin-npm]| Simplifies creation of HTML files (`index.html`) to serve your bundles|
 
 
 [common]: https://github.com/webpack/webpack/blob/master/lib/optimize/CommonsChunkPlugin.js
@@ -84,8 +84,8 @@ within webpack itself use this plugin interface. This makes webpack very
 [compression-npm]: https://img.shields.io/npm/v/compression-webpack-plugin.svg
 [i18n]: https://github.com/webpack/i18n-webpack-plugin
 [i18n-npm]: https://img.shields.io/npm/v/i18n-webpack-plugin.svg
-[html]: https://github.com/ampedandwired/html-webpack-plugin
-[html-npm]: https://img.shields.io/npm/v/component-webpack-plugin.svg
+[html-plugin]: https://github.com/ampedandwired/html-webpack-plugin
+[html-plugin-npm]: https://img.shields.io/npm/v/component-webpack-plugin.svg
 
 ### [Loaders](https://webpack.js.org/loaders/)
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes. sure.
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
update readme.md, fix html-webpack-plugin link address conflict with html-loader
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

html-webpack-plugin address is conflict with html-loader. when click html-webpack-plugin anchor, it use html-loader address.
so rename html to html-plugin.