### PR TITLE
Pass mangle options to ast.figure_out_scope in uglify

### DIFF
--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -92,7 +92,7 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 						ast = ast.transform(compress);
 					}
 					if(options.mangle !== false) {
-						ast.figure_out_scope();
+						ast.figure_out_scope(options.mangle || {});
 						ast.compute_char_frequency(options.mangle || {});
 						ast.mangle_names(options.mangle || {});
 						if(options.mangle && options.mangle.props) {

--- a/test/configCases/plugins/uglifyjs-plugin/ie8.js
+++ b/test/configCases/plugins/uglifyjs-plugin/ie8.js
@@ -1,0 +1,11 @@
+function t(e) {
+    return function(error) {
+        try {
+            e()
+        } catch(e) {
+            error(e)
+        }
+    }
+}
+
+module.exports = t;

--- a/test/configCases/plugins/uglifyjs-plugin/index.js
+++ b/test/configCases/plugins/uglifyjs-plugin/index.js
@@ -15,5 +15,13 @@ it("should contain comments in vendors chunk", function() {
 	source.should.containEql(" * comment should not be stripped vendors.3");
 });
 
+// this test is based off https://github.com/mishoo/UglifyJS2/blob/master/test/compress/screw-ie8.js
+it("should pass mangle options", function() {
+	var fs = require("fs"),
+		path = require("path");
+	var source = fs.readFileSync(path.join(__dirname, "ie8.js"), "utf-8");
+	source.should.containEql("function r(n){return function(n){try{t()}catch(t){n(t)}}}");
+});
+
 
 require.include("./test.js");

--- a/test/configCases/plugins/uglifyjs-plugin/webpack.config.js
+++ b/test/configCases/plugins/uglifyjs-plugin/webpack.config.js
@@ -6,7 +6,8 @@ module.exports = {
 	},
 	entry: {
 		bundle0: ["./index.js"],
-		vendors: ["./vendors.js"]
+		vendors: ["./vendors.js"],
+		ie8: ["./ie8.js"]
 	},
 	output: {
 		filename: "[name].js"
@@ -14,7 +15,10 @@ module.exports = {
 	plugins: [
 		new webpack.optimize.UglifyJsPlugin({
 			comments: false,
-			exclude: ["vendors.js"]
+			exclude: ["vendors.js"],
+			mangle: {
+				screw_ie8: false
+			}
 		})
 	]
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Because `options.mangle` was not passed to `ast.figure_out_scope`, `screw_ie8` was not getting passed and ie8 was breaking. I ended up realizing this was the problem after https://github.com/mishoo/UglifyJS2/pull/1344 was merged to fix Uglify's tests. According to uglify's `node.js` file, they pass mangle options (as of https://github.com/mishoo/UglifyJS2/issues/219) so I added that to this plugin as well.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes, tests were added to verify that `screw_ie8` was passed along. The tests were derived from the uglify2 tests.

<!-- Note that we won't merge your changes if you don't add tests -->

**Summary**

Since the mangle options were not passed, uglify was mangling the function parameters and causing IE8 to break (see https://github.com/taylorhakes/promise-polyfill/issues/34#issuecomment-244017343). By passing the options along, we can ensure that uglify knows to not break ie8.

