### PR TITLE
delete duplicate of line 35

### DIFF
--- a/lib/ProvidePlugin.js
+++ b/lib/ProvidePlugin.js
@@ -38,7 +38,6 @@ ProvidePlugin.prototype.apply = function(compiler) {
 						return false;
 					}
 					if(scopedName) {
-						nameIdentifier = "__webpack_provided_" + name.replace(/\./g, "_dot_");
 						var dep = new ConstDependency(nameIdentifier, expr.range);
 						dep.loc = expr.loc;
 						this.state.current.addDependency(dep);


### PR DESCRIPTION
the named identifier for the scopedName is already set in line 35.
Probably because line 35 was at some point lifted to where it is now.

**What kind of change does this PR introduce?**

Merely a cleanup of a duplicate line of code.

**Summary**

Cleanup of duplicate line of code.

**Does this PR introduce a breaking change?**

No

