### PR TITLE
fix(require.ensure): add ArrowFunctionExpression support: Fixes #959

### DIFF
--- a/lib/dependencies/getFunctionExpression.js
+++ b/lib/dependencies/getFunctionExpression.js
@@ -4,13 +4,14 @@
 */
 module.exports = function(expr) {
 	// <FunctionExpression>
-	if(expr.type === "FunctionExpression") {
+	if(expr.type === "FunctionExpression" || expr.type === "ArrowFunctionExpression") {
 		return {
 			fn: expr,
 			expressions: [],
 			needThis: false
 		};
 	}
+
 	// <FunctionExpression>.bind(<Expression>)
 	if(expr.type === "CallExpression" &&
 		expr.callee.type === "MemberExpression" &&

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "source-map": "^0.5.3",
     "supports-color": "^3.1.0",
     "tapable": "~0.2.5",
-    "uglify-js": "~2.7.3",
+    "uglify-js": "^2.7.5",
     "watchpack": "^1.0.0",
     "webpack-sources": "^0.1.0",
     "yargs": "^6.0.0"

--- a/test/cases/parsing/chunks/index.js
+++ b/test/cases/parsing/chunks/index.js
@@ -27,3 +27,11 @@ it("should parse a string in require.ensure with arrow function expression", fun
 		done();
 	});
 });
+
+
+it("should parse a string in require.ensure with arrow function array expression", function(done) {
+	require.ensure("./file", require => (require("./file").should.be.eql("ok"), done()));
+});
+
+
+

--- a/test/cases/parsing/chunks/index.js
+++ b/test/cases/parsing/chunks/index.js
@@ -20,3 +20,10 @@ it("should parse a string in require.ensure", function(done) {
 		done();
 	});
 });
+
+it("should parse a string in require.ensure with arrow function expression", function(done) {
+	require.ensure("./file", require => {
+		require("./file").should.be.eql("ok");
+		done();
+	});
+});

--- a/test/cases/parsing/chunks/test.filter.js
+++ b/test/cases/parsing/chunks/test.filter.js
@@ -1,0 +1,5 @@
+var supportsES6 = require("../../../helpers/supportsES6");
+
+module.exports = function(config) {
+	return !config.minimize && supportsES6();
+};

--- a/test/configCases/target/node-dynamic-import/dir/one.js
+++ b/test/configCases/target/node-dynamic-import/dir/one.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/test/configCases/target/node-dynamic-import/dir/three.js
+++ b/test/configCases/target/node-dynamic-import/dir/three.js
@@ -1,0 +1,1 @@
+module.exports = 3;

--- a/test/configCases/target/node-dynamic-import/dir/two.js
+++ b/test/configCases/target/node-dynamic-import/dir/two.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/test/configCases/target/node-dynamic-import/dir2/one.js
+++ b/test/configCases/target/node-dynamic-import/dir2/one.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/test/configCases/target/node-dynamic-import/dir2/three.js
+++ b/test/configCases/target/node-dynamic-import/dir2/three.js
@@ -1,0 +1,1 @@
+module.exports = 3;

--- a/test/configCases/target/node-dynamic-import/dir2/two.js
+++ b/test/configCases/target/node-dynamic-import/dir2/two.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/test/configCases/target/node-dynamic-import/index.js
+++ b/test/configCases/target/node-dynamic-import/index.js
@@ -1,0 +1,65 @@
+function testCase(load, done) {
+	load("two", 2, function() {
+		var sync = true;
+		load("one", 1, function() {
+			sync.should.be.eql(false);
+			load("three", 3, function() {
+				var sync = true;
+				load("two", 2, function() {
+					sync.should.be.eql(true);
+					done();
+				});
+				Promise.resolve().then(function() {}).then(function() {}).then(function() {
+					sync = false;
+				});
+			});
+		});
+		Promise.resolve().then(function() {
+			sync = false;
+		});
+	});
+}
+
+it("should be able to use expressions in import", function(done) {
+	function load(name, expected, callback) {
+		import("./dir/" + name + '.js')
+			.then((result) => {result.should.be.eql(expected); callback()})
+			.catch((err) => {done(err)});
+	}
+	testCase(load, done);
+});
+
+it("should be able to use expressions in System.import", function(done) {
+	function load(name, expected, callback) {
+		System.import("./dir2/" + name).then((result) => {
+			result.should.be.eql(expected);
+			callback();
+		}).catch((err) => {
+			done(err);
+		});
+	}
+	testCase(load, done);
+});
+
+it("should convert to function in node", function() {
+	(typeof __webpack_require__.e).should.be.eql("function");
+})
+
+it("should be able to use import", function(done) {
+	import("./two").then((two) => {
+		two.should.be.eql(2);
+		done();
+	}).catch(function(err) {
+		done(err);
+	});
+});
+
+it("should be able to use System.import", function(done) {
+	System.import("./two").then((two) => {
+		two.should.be.eql(2);
+		done();
+	}).catch(function(err) {
+		done(err);
+	});
+});
+

--- a/test/configCases/target/node-dynamic-import/two.js
+++ b/test/configCases/target/node-dynamic-import/two.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/test/configCases/target/node-dynamic-import/webpack.config.js
+++ b/test/configCases/target/node-dynamic-import/webpack.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	target: "node",
+	performance: {
+		hints: false
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix. Fixes #959 

* `require.ensure` was erroring when passing arrow function as callback. 
* bumped uglify-js patch level deps
* add node target cases for `import()`

**Did you add tests for your changes?**
Yes 
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
