### PR TITLE
Fix chunk loading in Internet Explorer.

### DIFF
--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -97,14 +97,16 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 			"// start chunk loading",
 			"var head = document.getElementsByTagName('head')[0];",
 			this.applyPluginsWaterfall("jsonp-script", "", chunk, hash),
-			"head.appendChild(script);",
 			"",
 			"var promise = new Promise(function(resolve, reject) {",
 			this.indent([
 				"installedChunks[chunkId] = [resolve, reject];"
 			]),
 			"});",
-			"return installedChunks[chunkId][2] = promise;"
+			"installedChunks[chunkId][2] = promise;",
+			"",
+			"head.appendChild(script);",
+			"return promise;"
 		]);
 	});
 	mainTemplate.plugin("require-extensions", function(source, chunk) {

--- a/test/statsCases/aggressive-splitting-on-demand/expected.txt
+++ b/test/statsCases/aggressive-splitting-on-demand/expected.txt
@@ -6,7 +6,7 @@ cd45585186d59208602b.js    1.95 kB       1  [emitted]
 6b94c231e016c5aaccdb.js    1.94 kB       2  [emitted]  
 fd0985cee894c4f3f1a6.js    1.93 kB       3  [emitted]  
 d9fc46873c8ea924b895.js  977 bytes       4  [emitted]  
-90b55464dc36b9c472a9.js     7.2 kB       6  [emitted]  main
+90b55464dc36b9c472a9.js    7.22 kB       6  [emitted]  main
 b08c507d4e1e05cbab45.js  983 bytes       9  [emitted]  
 5d50e858fe6e559aa47c.js  975 bytes      11  [emitted]  
 Entrypoint main = 90b55464dc36b9c472a9.js

--- a/test/statsCases/chunks/expected.txt
+++ b/test/statsCases/chunks/expected.txt
@@ -4,7 +4,7 @@ Time: Xms
 0.bundle.js  227 bytes       0  [emitted]  
 1.bundle.js  106 bytes       1  [emitted]  
 2.bundle.js  200 bytes       2  [emitted]  
-  bundle.js    5.84 kB       3  [emitted]  main
+  bundle.js    5.86 kB       3  [emitted]  main
 chunk    {0} 0.bundle.js 54 bytes {3} [rendered]
     > [5] (webpack)/test/statsCases/chunks/index.js 3:0-16
     [2] (webpack)/test/statsCases/chunks/c.js 54 bytes {0} [built]

--- a/test/statsCases/optimize-chunks/expected.txt
+++ b/test/statsCases/optimize-chunks/expected.txt
@@ -8,7 +8,7 @@ Time: Xms
    4.js  136 bytes    4, 6  [emitted]  chunk
    5.js  293 bytes    5, 3  [emitted]  cir2 from cir1
    6.js   78 bytes       6  [emitted]  ac in ab
-main.js    6.45 kB       7  [emitted]  main
+main.js    6.47 kB       7  [emitted]  main
 chunk    {0} 0.js (cir1) 81 bytes {3} {5} {7} [rendered]
     > duplicate cir1 from cir2 [3] (webpack)/test/statsCases/optimize-chunks/circular2.js 1:0-79
     > duplicate cir1 [8] (webpack)/test/statsCases/optimize-chunks/index.js 13:0-54

--- a/test/statsCases/preset-verbose/expected.txt
+++ b/test/statsCases/preset-verbose/expected.txt
@@ -4,7 +4,7 @@ Time: Xms
    0.js  227 bytes       0  [emitted]  
    1.js  106 bytes       1  [emitted]  
    2.js  200 bytes       2  [emitted]  
-main.js    5.83 kB       3  [emitted]  main
+main.js    5.86 kB       3  [emitted]  main
 Entrypoint main = main.js
 chunk    {0} 0.js 54 bytes {3} [rendered]
     [2] (webpack)/test/statsCases/preset-verbose/c.js 54 bytes {0} [depth 1] [built]


### PR DESCRIPTION
Appending chunk loading script moved to the end of the function.

Because of unexpected behavior in some cases IE can execute `script` synchronously regardless `async` flag. We need to setup all needed callbacks before appending script to the DOM. It make `jsonp` callback ready to process even synchronous chunk code. 

Issue https://github.com/webpack/webpack/issues/2506