### PR TITLE
fix(test): Filter ES6 features from node v0.12. Fixes #3552

### DIFF
--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -22,13 +22,25 @@ describe("ConfigTestCases", function() {
 	});
 	categories.forEach(function(category) {
 		describe(category.name, function() {
-			category.tests.forEach(function(testName) {
+			category.tests.filter(function(testName) {
+				var testDirectory = path.join(casesPath, category.name, testName);
+				var filterPath = path.join(testDirectory, "test.filter.js");
+				var config = require(path.join(testDirectory, "webpack.config.js"));
+				if(fs.existsSync(filterPath) && !require(filterPath)(config)) {
+					describe.skip(testName, function() {
+						it('filtered');
+					});
+					return false;
+				}
+				return true;
+			}).forEach(function(testName) {
+				var testDirectory = path.join(casesPath, category.name, testName);
+				var filterPath = path.join(testDirectory, "test.filter.js");
+				var options = require(path.join(testDirectory, "webpack.config.js"));
 				var suite = describe(testName, function() {});
 				it(testName + " should compile", function(done) {
 					this.timeout(30000);
-					var testDirectory = path.join(casesPath, category.name, testName);
 					var outputDirectory = path.join(__dirname, "js", "config", category.name, testName);
-					var options = require(path.join(testDirectory, "webpack.config.js"));
 					var optionsArr = [].concat(options);
 					optionsArr.forEach(function(options, idx) {
 						if(!options.context) options.context = testDirectory;

--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -1,3 +1,4 @@
+/* globals describe it */
 var should = require("should");
 var path = require("path");
 var fs = require("fs");
@@ -7,10 +8,6 @@ var checkArrayExpectation = require("./checkArrayExpectation");
 
 var Stats = require("../lib/Stats");
 var webpack = require("../lib/webpack");
-
-function getConfig(testDirectory) {
-	return require(path.join(testDirectory, "webpack.config.js"));
-}
 
 describe("ConfigTestCases", function() {
 	var casesPath = path.join(__dirname, "configCases");
@@ -24,8 +21,7 @@ describe("ConfigTestCases", function() {
 			}).sort().filter(function(testName) {
 				var testDirectory = path.join(casesPath, cat, testName);
 				var filterPath = path.join(testDirectory, "test.filter.js");
-				var config = getConfig(testDirectory);
-				if(fs.existsSync(filterPath) && !require(filterPath)(config)) {
+				if(fs.existsSync(filterPath) && !require(filterPath)()) {
 					describe.skip(testName, function() {
 						it('filtered');
 					});

--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -8,6 +8,10 @@ var checkArrayExpectation = require("./checkArrayExpectation");
 var Stats = require("../lib/Stats");
 var webpack = require("../lib/webpack");
 
+function getConfig(testDirectory) {
+	return require(path.join(testDirectory, "webpack.config.js"));
+}
+
 describe("ConfigTestCases", function() {
 	var casesPath = path.join(__dirname, "configCases");
 	var categories = fs.readdirSync(casesPath);
@@ -25,7 +29,7 @@ describe("ConfigTestCases", function() {
 			category.tests.filter(function(testName) {
 				var testDirectory = path.join(casesPath, category.name, testName);
 				var filterPath = path.join(testDirectory, "test.filter.js");
-				var config = require(path.join(testDirectory, "webpack.config.js"));
+				var config = getConfig(testDirectory);
 				if(fs.existsSync(filterPath) && !require(filterPath)(config)) {
 					describe.skip(testName, function() {
 						it('filtered');
@@ -36,7 +40,7 @@ describe("ConfigTestCases", function() {
 			}).forEach(function(testName) {
 				var testDirectory = path.join(casesPath, category.name, testName);
 				var filterPath = path.join(testDirectory, "test.filter.js");
-				var options = require(path.join(testDirectory, "webpack.config.js"));
+				var options = getConfig(testDirectory);
 				var suite = describe(testName, function() {});
 				it(testName + " should compile", function(done) {
 					this.timeout(30000);

--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -21,13 +21,8 @@ describe("ConfigTestCases", function() {
 			name: cat,
 			tests: fs.readdirSync(path.join(casesPath, cat)).filter(function(folder) {
 				return folder.indexOf("_") < 0;
-			}).sort()
-		};
-	});
-	categories.forEach(function(category) {
-		describe(category.name, function() {
-			category.tests.filter(function(testName) {
-				var testDirectory = path.join(casesPath, category.name, testName);
+			}).sort().filter(function(testName) {
+				var testDirectory = path.join(casesPath, cat, testName);
 				var filterPath = path.join(testDirectory, "test.filter.js");
 				var config = getConfig(testDirectory);
 				if(fs.existsSync(filterPath) && !require(filterPath)(config)) {
@@ -37,14 +32,18 @@ describe("ConfigTestCases", function() {
 					return false;
 				}
 				return true;
-			}).forEach(function(testName) {
-				var testDirectory = path.join(casesPath, category.name, testName);
-				var filterPath = path.join(testDirectory, "test.filter.js");
-				var options = getConfig(testDirectory);
+			})
+		};
+	});
+	categories.forEach(function(category) {
+		describe(category.name, function() {
+			category.tests.forEach(function(testName) {
 				var suite = describe(testName, function() {});
 				it(testName + " should compile", function(done) {
 					this.timeout(30000);
+					var testDirectory = path.join(casesPath, category.name, testName);
 					var outputDirectory = path.join(__dirname, "js", "config", category.name, testName);
+					var options = require(path.join(testDirectory, "webpack.config.js"));
 					var optionsArr = [].concat(options);
 					optionsArr.forEach(function(options, idx) {
 						if(!options.context) options.context = testDirectory;

--- a/test/configCases/dll-plugin/1-use-dll/webpack.config.js
+++ b/test/configCases/dll-plugin/1-use-dll/webpack.config.js
@@ -4,8 +4,8 @@ var webpack = require("../../../../");
 module.exports = {
 	plugins: [
 		new webpack.DllReferencePlugin({
-			manifest: require(path.resolve(__dirname, "../../../js/config/dll-plugin/manifest0.json")),
-			name: path.resolve(__dirname, "../0-create-dll/dll.js"),
+			manifest: require("../../../js/config/dll-plugin/manifest0.json"),
+			name: "../0-create-dll/dll.js",
 			scope: "dll",
 			sourceType: "commonjs2",
 			extensions: ['.js', '.jsx']

--- a/test/configCases/dll-plugin/1-use-dll/webpack.config.js
+++ b/test/configCases/dll-plugin/1-use-dll/webpack.config.js
@@ -4,8 +4,8 @@ var webpack = require("../../../../");
 module.exports = {
 	plugins: [
 		new webpack.DllReferencePlugin({
-			manifest: require("../../../js/config/dll-plugin/manifest0.json"),
-			name: "../0-create-dll/dll.js",
+			manifest: require(path.resolve(__dirname, "../../../js/config/dll-plugin/manifest0.json")),
+			name: path.resolve(__dirname, "../0-create-dll/dll.js"),
 			scope: "dll",
 			sourceType: "commonjs2",
 			extensions: ['.js', '.jsx']

--- a/test/configCases/target/node-dynamic-import/test.filter.js
+++ b/test/configCases/target/node-dynamic-import/test.filter.js
@@ -1,0 +1,5 @@
+var supportsES6 = require("../../../helpers/supportsES6");
+
+module.exports = function(config) {
+	return !config.minimize && supportsES6();
+};

--- a/test/configCases/target/node-dynamic-import/test.filter.js
+++ b/test/configCases/target/node-dynamic-import/test.filter.js
@@ -1,5 +1,5 @@
-var supportsES6 = require("../../../helpers/supportsES6");
+var supportsArrowFn = require("../../../helpers/supportsArrowFunctionExpression");
 
 module.exports = function(config) {
-	return supportsES6();
+	return supportsArrowFn();
 };

--- a/test/configCases/target/node-dynamic-import/test.filter.js
+++ b/test/configCases/target/node-dynamic-import/test.filter.js
@@ -1,5 +1,5 @@
 var supportsES6 = require("../../../helpers/supportsES6");
 
 module.exports = function(config) {
-	return !config.minimize && supportsES6();
+	return supportsES6();
 };

--- a/test/helpers/supportsArrowFunctionExpression.js
+++ b/test/helpers/supportsArrowFunctionExpression.js
@@ -1,0 +1,8 @@
+module.exports = function supportArrowFunctionExpression() {
+	try {
+		eval("var foo = function(fn) {return fn.toString()}; foo(() => {return 'a'})");
+		return true;
+	} catch(e) {
+		return false;
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
N/A
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Filters ES6 features so arrow functions don't fail node 0.12 builds on travis. 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Fixes #3552