### PR TITLE
fix(warning): only use keyword instanceof, fixes #3562

### DIFF
--- a/lib/validateSchema.js
+++ b/lib/validateSchema.js
@@ -8,7 +8,7 @@ var ajv = new Ajv({
 	allErrors: true,
 	verbose: true
 });
-require("ajv-keywords")(ajv, ['instanceof']);
+require("ajv-keywords")(ajv, ["instanceof"]);
 
 function validateSchema(schema, options) {
 	if(Array.isArray(options)) {

--- a/lib/validateSchema.js
+++ b/lib/validateSchema.js
@@ -8,7 +8,7 @@ var ajv = new Ajv({
 	allErrors: true,
 	verbose: true
 });
-require("ajv-keywords")(ajv);
+require("ajv-keywords")(ajv, ['instanceof']);
 
 function validateSchema(schema, options) {
 	if(Array.isArray(options)) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Only adds the keyword "instanceof" to Ajv instance (it is the only one used in options schema), rather than all keywords defined in [ajv-keywords](https://github.com/epoberezkin/ajv-keywords) package.

**Did you add tests for your changes?**

It is already covered, actually less code from ajv-keywords is used.

**If relevant, link to documentation update:**

N/A

**Summary**

It removes the warning (#3562).

**Does this PR introduce a breaking change?**

No