### PR TITLE
No errors plugin deprecate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /node_modules
 /test/js
 /test/browsertest/js
+/test/fixtures/temp-cache-fixture
 /benchmark/js
 /benchmark/fixtures
 /examples/*/js

--- a/lib/NoEmitOnErrorsPlugin.js
+++ b/lib/NoEmitOnErrorsPlugin.js
@@ -2,18 +2,11 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-function NoErrorsPlugin() {}
+function NoEmitOnErrorsPlugin() {}
 
-var deprecationReported = false;
-
-module.exports = NoErrorsPlugin;
-NoErrorsPlugin.prototype.apply = function(compiler) {
+module.exports = NoEmitOnErrorsPlugin;
+NoEmitOnErrorsPlugin.prototype.apply = function(compiler) {
 	compiler.plugin("should-emit", function(compilation) {
-		if(!deprecationReported) {
-			compilation.warnings.push("webpack: Using NoErrorsPlugin is deprecated.\n" +
-				"Use NoEmitOnErrorsPlugin instead.\n");
-			deprecationReported = true;
-		}
 		if(compilation.errors.length > 0)
 			return false;
 	});

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -98,6 +98,7 @@ exportPlugins(exports, ".", [
 	"SetVarMainTemplatePlugin",
 	"UmdMainTemplatePlugin",
 	"NoErrorsPlugin",
+	"NoEmitOnErrorsPlugin",
 	"NewWatchingPlugin",
 	"EnvironmentPlugin",
 	"DllPlugin",

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -114,6 +114,22 @@ describe("Errors", function() {
 			done();
 		});
 	});
+	it("should not warn if the NoEmitOnErrorsPlugin is used over the NoErrorsPlugin", function(done) {
+		getErrors({
+			entry: "./no-errors-deprecate",
+			plugins: [
+				new webpack.NoEmitOnErrorsPlugin()
+			]
+		}, function(errors, warnings) {
+			if(errors.length === 0) {
+				warnings.length.should.be.eql(0);
+			} else {
+				errors.length.should.be.eql(1);
+				warnings.length.should.be.eql(0);
+			}
+			done();
+		});
+	});
 	it("should throw an error when using incorrect CommonsChunkPlugin configuration", function(done) {
 		getErrors({
 			entry: {

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -109,14 +109,14 @@ describe("Errors", function() {
 			done();
 		});
 	});
-	it("should not warn if the NoEmitOnErrorsPlugin is used over the NoErrorsPlugin", function(done) {
+	it.only("should not warn if the NoEmitOnErrorsPlugin is used over the NoErrorsPlugin", function(done) {
 		getErrors({
 			entry: "./no-errors-deprecate",
 			plugins: [
 				new webpack.NoEmitOnErrorsPlugin()
 			]
 		}, function(errors, warnings) {
-			errors.length.should.be.eql(1);
+			errors.length.should.be.eql(0);
 			warnings.length.should.be.eql(0);
 			done();
 		});

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -109,7 +109,7 @@ describe("Errors", function() {
 			done();
 		});
 	});
-	it.only("should not warn if the NoEmitOnErrorsPlugin is used over the NoErrorsPlugin", function(done) {
+	it("should not warn if the NoEmitOnErrorsPlugin is used over the NoErrorsPlugin", function(done) {
 		getErrors({
 			entry: "./no-errors-deprecate",
 			plugins: [

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -99,18 +99,13 @@ describe("Errors", function() {
 				new webpack.NoErrorsPlugin()
 			]
 		}, function(errors, warnings) {
-			if(errors.length === 0) {
-				warnings.length.should.be.eql(1);
-				var lines = warnings[0].split("\n");
-				lines[0].should.match(/webpack/);
-				lines[0].should.match(/NoErrorsPlugin/);
-				lines[0].should.match(/deprecated/);
-				lines[1].should.match(/NoEmitOnErrorsPlugin/);
-				lines[1].should.match(/instead/);
-			} else {
-				errors.length.should.be.eql(1);
-				warnings.length.should.be.eql(0);
-			}
+			warnings.length.should.be.eql(1);
+			var lines = warnings[0].split("\n");
+			lines[0].should.match(/webpack/);
+			lines[0].should.match(/NoErrorsPlugin/);
+			lines[0].should.match(/deprecated/);
+			lines[1].should.match(/NoEmitOnErrorsPlugin/);
+			lines[1].should.match(/instead/);
 			done();
 		});
 	});
@@ -121,12 +116,31 @@ describe("Errors", function() {
 				new webpack.NoEmitOnErrorsPlugin()
 			]
 		}, function(errors, warnings) {
-			if(errors.length === 0) {
-				warnings.length.should.be.eql(0);
-			} else {
-				errors.length.should.be.eql(1);
-				warnings.length.should.be.eql(0);
-			}
+			errors.length.should.be.eql(1);
+			warnings.length.should.be.eql(0);
+			done();
+		});
+	});
+	it("should not not emit if NoEmitOnErrorsPlugin is used and there is an error", function(done) {
+		getErrors({
+			entry: "./missingFile",
+			plugins: [
+				new webpack.NoEmitOnErrorsPlugin()
+			]
+		}, function(errors, warnings) {
+			errors.length.should.be.eql(2);
+			warnings.length.should.be.eql(0);
+			errors.sort();
+			var lines = errors[0].split("\n");
+			lines[0].should.match(/missingFile.js/);
+			lines[1].should.match(/^Module not found/);
+			lines[1].should.match(/\.\/dir\/missing2/);
+			lines[2].should.match(/missingFile.js 12:9/);
+			lines = errors[1].split("\n");
+			lines[0].should.match(/missingFile.js/);
+			lines[1].should.match(/^Module not found/);
+			lines[1].should.match(/\.\/missing/);
+			lines[2].should.match(/missingFile.js 4:0/);
 			done();
 		});
 	});

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -92,6 +92,28 @@ describe("Errors", function() {
 			done();
 		});
 	});
+	it("should warn about NoErrorsPlugin being deprecated in favor of NoEmitOnErrorsPlugin", function(done) {
+		getErrors({
+			entry: "./no-errors-deprecate",
+			plugins: [
+				new webpack.NoErrorsPlugin()
+			]
+		}, function(errors, warnings) {
+			if(errors.length === 0) {
+				warnings.length.should.be.eql(1);
+				var lines = warnings[0].split("\n");
+				lines[0].should.match(/webpack/);
+				lines[0].should.match(/NoErrorsPlugin/);
+				lines[0].should.match(/deprecated/);
+				lines[1].should.match(/NoEmitOnErrorsPlugin/);
+				lines[1].should.match(/instead/);
+			} else {
+				errors.length.should.be.eql(1);
+				warnings.length.should.be.eql(0);
+			}
+			done();
+		});
+	});
 	it("should throw an error when using incorrect CommonsChunkPlugin configuration", function(done) {
 		getErrors({
 			entry: {

--- a/test/fixtures/errors/no-errors-deprecate.js
+++ b/test/fixtures/errors/no-errors-deprecate.js
@@ -1,0 +1,1 @@
+require('./file');

--- a/test/fixtures/temp-cache-fixture/a.js
+++ b/test/fixtures/temp-cache-fixture/a.js
@@ -1,0 +1,3 @@
+module.exports = function a() {
+	return "This is a";
+};

--- a/test/fixtures/temp-cache-fixture/a.js
+++ b/test/fixtures/temp-cache-fixture/a.js
@@ -1,3 +1,0 @@
-module.exports = function a() {
-	return "This is a";
-};

--- a/test/fixtures/temp-cache-fixture/c.js
+++ b/test/fixtures/temp-cache-fixture/c.js
@@ -1,4 +1,0 @@
-module.exports = function b() {
-	require("./a");
-	return "This is c";
-};

--- a/test/fixtures/temp-cache-fixture/c.js
+++ b/test/fixtures/temp-cache-fixture/c.js
@@ -1,0 +1,4 @@
+module.exports = function b() {
+	require("./a");
+	return "This is c";
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

It moves current NoErrorsPlugin functionality to a more accurately named NoEmitOnErrorsPlugin.

**Did you add tests for your changes?**

I did.

**Summary**

I saw an issue filed https://github.com/webpack/webpack/issues/3179.

I also think that the new plugin name will make things less confusing for users, ultimately resulting in less open issues. The deprecation warning also helps ease the transition.

**Does this PR introduce a breaking change?**

It does not. It does provide a warning however that in the future there might be a breaking change coming.

**Other information**

My first contribution - hopefully first of many. I want to acquire innate knowledge of _THE_ best build tool ever and what better way to do it then start off with some bugs / small enhancements? :)

Double commit because I amended commit message after reading contribution guidelines.
