### PR TITLE
Timestamp & Save flag

### DIFF
--- a/bin/config-yargs.js
+++ b/bin/config-yargs.js
@@ -154,6 +154,12 @@ module.exports = function(yargs) {
 				describe: "Watch the filesystem for changes",
 				group: BASIC_GROUP
 			},
+			"save": {
+				type: "boolean",
+				alias: "s",
+				describe: "Rebuilds on save regardless of changes in watch mode",
+				group: BASIC_GROUP
+			},
 			"watch-stdin": {
 				type: "boolean",
 				alias: "stdin",

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -332,7 +332,9 @@ function processOptions(options) {
 			process.stdout.write(JSON.stringify(stats.toJson(outputOptions), null, 2) + "\n");
 		} else if(stats.hash !== lastHash) {
 			lastHash = stats.hash;
+			process.stdout.write("\n" + new Date() + "\n" + "\n");
 			process.stdout.write(stats.toString(outputOptions) + "\n");
+			if(argv.s) lastHash = null;
 		}
 		if(!options.watch && stats.hasErrors()) {
 			process.on("exit", function() {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

PR introduces timestamps on builds and a save option in watch mode to allow a new build to refresh regardless of change. #1499 & #1992 

**Did you add tests for your changes?**

No

**Does this PR introduce a breaking change?**

Probably not

