### PR TITLE
Ensure module and exports are not defined in harmony modules

### DIFF
--- a/lib/DelegatedModule.js
+++ b/lib/DelegatedModule.js
@@ -58,7 +58,8 @@ DelegatedModule.prototype.source = function() {
 	if(!sourceModule) {
 		str = WebpackMissingModule.moduleCode(this.sourceRequest);
 	} else {
-		str = "module.exports = (__webpack_require__(" + sourceModule.id + "))";
+		str = (this.meta && this.meta.harmonyModule ? "__webpack_module__" : "module") +
+			".exports = (__webpack_require__(" + sourceModule.id + "))";
 		switch(this.type) {
 			case "require":
 				str += "(" + JSON.stringify(this.request) + ");";

--- a/lib/FunctionModuleTemplatePlugin.js
+++ b/lib/FunctionModuleTemplatePlugin.js
@@ -18,8 +18,9 @@ FunctionModuleTemplatePlugin.prototype.apply = function(moduleTemplate) {
 		source.add("/***/ function(" + defaultArguments.concat(module.arguments || []).join(", ") + ") {\n\n");
 		if(module.strict) source.add("\"use strict\";\n");
 		source.add(moduleSource);
-		if (module.meta && module.meta.harmonyModule) {
-			var withModule = !module.__harmony_shadowsModule, withExports = !module.__harmony_shadowsExports;
+		if(module.meta && module.meta.harmonyModule) {
+			var withModule = !module.__harmony_shadowsModule,
+				withExports = !module.__harmony_shadowsExports;
 			// Shadow any potential "module" or "exports" global(-looking) vars,
 			// but only if they're not already shadowed to avoid SyntaxError if the user
 			// is using let/const.
@@ -28,7 +29,7 @@ FunctionModuleTemplatePlugin.prototype.apply = function(moduleTemplate) {
 			// but making them "let", without it being optional, is ES5-incompatible.
 			//
 			// TODO: only add the definition if they're actually accessed
-			if (withModule || withExports) {
+			if(withModule || withExports) {
 				source.add("\nvar " + [withModule && "module", withExports && "exports"].filter(Boolean).join(", "));
 			}
 		}

--- a/lib/FunctionModuleTemplatePlugin.js
+++ b/lib/FunctionModuleTemplatePlugin.js
@@ -11,13 +11,27 @@ module.exports = FunctionModuleTemplatePlugin;
 FunctionModuleTemplatePlugin.prototype.apply = function(moduleTemplate) {
 	moduleTemplate.plugin("render", function(moduleSource, module) {
 		var source = new ConcatSource();
-		var defaultArguments = ["module", "exports"];
+		var defaultArguments = module.meta && module.meta.harmonyModule ? ["__webpack_module__", "__webpack_exports__"] : ["module", "exports"];
 		if((module.arguments && module.arguments.length !== 0) || module.hasDependencies()) {
 			defaultArguments.push("__webpack_require__");
 		}
 		source.add("/***/ function(" + defaultArguments.concat(module.arguments || []).join(", ") + ") {\n\n");
 		if(module.strict) source.add("\"use strict\";\n");
 		source.add(moduleSource);
+		if (module.meta && module.meta.harmonyModule) {
+			var withModule = !module.__harmony_shadowsModule, withExports = !module.__harmony_shadowsExports;
+			// Shadow any potential "module" or "exports" global(-looking) vars,
+			// but only if they're not already shadowed to avoid SyntaxError if the user
+			// is using let/const.
+			//
+			// TODO: these should be "let" to throw ReferenceError on access,
+			// but making them "let", without it being optional, is ES5-incompatible.
+			//
+			// TODO: only add the definition if they're actually accessed
+			if (withModule || withExports) {
+				source.add("\nvar " + [withModule && "module", withExports && "exports"].filter(Boolean).join(", "));
+			}
+		}
 		source.add("\n\n/***/ }");
 		return source;
 	});

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -260,7 +260,12 @@ HotModuleReplacementPlugin.prototype.apply = function(compiler) {
 					}.bind(this));
 				}
 			});
-			parser.plugin("expression module.hot", function() {
+			parser.plugin("expression module.hot", function(expr) {
+				if (this.state.module.meta.harmonyModule) {
+					var dep = new ConstDependency("__webpack_module__.hot", expr.range);
+					dep.loc = expr.loc;
+					this.state.current.addDependency(dep);
+				}
 				return true;
 			});
 		});

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -261,7 +261,7 @@ HotModuleReplacementPlugin.prototype.apply = function(compiler) {
 				}
 			});
 			parser.plugin("expression module.hot", function(expr) {
-				if (this.state.module.meta.harmonyModule) {
+				if(this.state.module.meta.harmonyModule) {
 					var dep = new ConstDependency("__webpack_module__.hot", expr.range);
 					dep.loc = expr.loc;
 					this.state.current.addDependency(dep);

--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -109,7 +109,7 @@ NodeStuffPlugin.prototype.apply = function(compiler) {
 				return new BasicEvaluatedExpression().setBoolean(false).setRange(expr.range);
 			});
 			parser.plugin("expression module", function() {
-				if (this.state.module.meta.harmonyModule) return;
+				if(this.state.module.meta.harmonyModule) return;
 
 				var moduleJsPath = path.join(__dirname, "..", "buildin", "module.js");
 				if(this.state.module.context) {

--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -93,13 +93,13 @@ NodeStuffPlugin.prototype.apply = function(compiler) {
 				return true;
 			});
 			parser.plugin("expression module.loaded", function(expr) {
-				var dep = new ConstDependency("module.l", expr.range);
+				var dep = new ConstDependency(this.state.module.meta.harmonyModule ? "__webpack_module__.l" : "module.l", expr.range);
 				dep.loc = expr.loc;
 				this.state.current.addDependency(dep);
 				return true;
 			});
 			parser.plugin("expression module.id", function(expr) {
-				var dep = new ConstDependency("module.i", expr.range);
+				var dep = new ConstDependency(this.state.module.meta.harmonyModule ? "__webpack_module__.i" : "module.i", expr.range);
 				dep.loc = expr.loc;
 				this.state.current.addDependency(dep);
 				return true;
@@ -109,6 +109,8 @@ NodeStuffPlugin.prototype.apply = function(compiler) {
 				return new BasicEvaluatedExpression().setBoolean(false).setRange(expr.range);
 			});
 			parser.plugin("expression module", function() {
+				if (this.state.module.meta.harmonyModule) return;
+
 				var moduleJsPath = path.join(__dirname, "..", "buildin", "module.js");
 				if(this.state.module.context) {
 					moduleJsPath = path.relative(this.state.module.context, moduleJsPath);

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -275,14 +275,14 @@ NormalModule.prototype.source = function(dependencyTemplates, outputOptions, req
 
 				varStartCode += "/* WEBPACK VAR INJECTION */(function(" + varNames.join(", ") + ") {";
 				// exports === this in the topLevelBlock, but exports do compress better...
-				varEndCode = (topLevelBlock === block ? "}.call(exports, " : "}.call(this, ") +
+				varEndCode = (topLevelBlock === block ? "}.call(" + (block.meta.harmonyModule ? "__webpack_exports__" : "exports") + ", " : "}.call(this, ") +
 					varExpressions.map(function(e) {
 						return e.source();
 					}).join(", ") + "))" + varEndCode;
 
 				varNames.length = 0;
 				varExpressions.length = 0;
-			}
+			};
 			vars.forEach(function(v) {
 				if(varNames.indexOf(v.name) >= 0) emitFunction();
 				varNames.push(v.name);

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -1138,8 +1138,10 @@ Parser.prototype.parse = function parse(source, initialState) {
 		renames: {}
 	};
 	var state = this.state = initialState || {};
-	if(this.applyPluginsBailResult("program", ast, comments) === undefined)
+	if(this.applyPluginsBailResult("program", ast, comments) === undefined) {
 		this.walkStatements(ast.body);
+		this.applyPlugins("program end", ast, comments)
+	}
 	this.scope = oldScope;
 	this.state = oldState;
 	return state;

--- a/lib/dependencies/HarmonyCompatiblilityDependency.js
+++ b/lib/dependencies/HarmonyCompatiblilityDependency.js
@@ -19,7 +19,7 @@ HarmonyCompatiblilityDependency.Template = function HarmonyExportDependencyTempl
 HarmonyCompatiblilityDependency.Template.prototype.apply = function(dep, source) {
 	var usedExports = dep.originModule.usedExports;
 	if(usedExports && !Array.isArray(usedExports)) {
-		var content = "Object.defineProperty(exports, \"__esModule\", { value: true });\n";
+		var content = "Object.defineProperty(__webpack_exports__, \"__esModule\", { value: true });\n";
 		source.insert(-1, content);
 	}
 };

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -67,7 +67,7 @@ module.exports = AbstractPlugin.create({
 		return true;
 	},
 	"program end": function() {
-		if (this.state.current.strict && this.state.current.meta.harmonyModule) {
+		if(this.state.current.strict && this.state.current.meta.harmonyModule) {
 			this.state.current.__harmony_shadowsExports = this.scope.definitions.indexOf('exports') >= 0;
 			this.state.current.__harmony_shadowsModule = this.scope.definitions.indexOf('module') >= 0;
 		}

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -65,7 +65,13 @@ module.exports = AbstractPlugin.create({
 		dep.loc = statement.loc;
 		this.state.current.addDependency(dep);
 		return true;
-	}
+	},
+	"program end": function() {
+		if (this.state.current.strict && this.state.current.meta.harmonyModule) {
+			this.state.current.__harmony_shadowsExports = this.scope.definitions.indexOf('exports') >= 0;
+			this.state.current.__harmony_shadowsModule = this.scope.definitions.indexOf('module') >= 0;
+		}
+	},
 });
 
 function isImmutableStatement(statement) {

--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -35,7 +35,7 @@ HarmonyExportExpressionDependency.Template.prototype.apply = function(dep, sourc
 	var used = dep.originModule.isUsed("default");
 	var content;
 	if(used)
-		content = "/* harmony default export */ exports[" + JSON.stringify(used) + "] = ";
+		content = "/* harmony default export */ __webpack_exports__[" + JSON.stringify(used) + "] = ";
 	else
 		content = "/* unused harmony default export */ var _unused_webpack_default_export = ";
 	if(dep.range) {

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -141,7 +141,7 @@ HarmonyExportImportedSpecifierDependency.Template.prototype.apply = function(dep
 
 	function getReexportStatement(key, valueKey) {
 		return(importIsHarmony || !valueKey ? "" : "if(__webpack_require__.o(" + name + ", " + valueKey + ")) ") +
-			"__webpack_require__.d(exports, " + key + ", " +
+			"__webpack_require__.d(__webpack_exports__, " + key + ", " +
 			"function() { return " + name + (valueKey === null ? "_default.a" : valueKey && "[" + valueKey + "]") + "; });\n"
 	}
 	if(!used) { // we want to rexport something, but the export isn't used
@@ -194,7 +194,7 @@ HarmonyExportImportedSpecifierDependency.Template.prototype.apply = function(dep
 			content += "if(" + JSON.stringify(activeExports.concat("default")) + ".indexOf(__WEBPACK_IMPORT_KEY__) < 0) ";
 		else
 			content += "if(__WEBPACK_IMPORT_KEY__ !== 'default') ";
-		content += "(function(key) { __webpack_require__.d(exports, key, function() { return " + name + "[key]; }) }(__WEBPACK_IMPORT_KEY__));\n";
+		content += "(function(key) { __webpack_require__.d(__webpack_exports__, key, function() { return " + name + "[key]; }) }(__WEBPACK_IMPORT_KEY__));\n";
 	} else {
 		content = "/* unused harmony reexport namespace */\n";
 	}

--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -43,9 +43,9 @@ HarmonyExportSpecifierDependency.Template.prototype.apply = function(dep, source
 	} else if(!active) {
 		content = "/* inactive harmony export " + (dep.name || "namespace") + " */\n";
 	} else if(dep.immutable) {
-		content = "/* harmony export (immutable) */ exports[" + JSON.stringify(used) + "] = " + dep.id + ";\n";
+		content = "/* harmony export (immutable) */ __webpack_exports__[" + JSON.stringify(used) + "] = " + dep.id + ";\n";
 	} else {
-		content = "/* harmony export (binding) */ __webpack_require__.d(exports, " + JSON.stringify(used) + ", function() { return " + dep.id + "; });\n";
+		content = "/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, " + JSON.stringify(used) + ", function() { return " + dep.id + "; });\n";
 	}
 	if(dep.position > 0)
 		content = "\n" + content;

--- a/test/cases/parsing/harmony-injecting-order/file.js
+++ b/test/cases/parsing/harmony-injecting-order/file.js
@@ -1,3 +1,3 @@
 export function f() {
-    return module;
+    return __dirname;
 };

--- a/test/cases/parsing/harmony-injecting-order/index.js
+++ b/test/cases/parsing/harmony-injecting-order/index.js
@@ -1,3 +1,3 @@
 it("should inject variables before exporting", function() {
-	require("./file").f().should.have.property("webpackPolyfill");
+	require("./file").f().should.equal("/");
 });

--- a/test/cases/parsing/harmony-module-exports/commonjs.js
+++ b/test/cases/parsing/harmony-module-exports/commonjs.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var harmony = require("./harmony");
+
+it("has an 'exports' free var", function() {
+	(typeof exports).should.equal("object");
+});
+
+it("has a 'module' free var", function() {
+	(typeof module).should.equal("object");
+});
+
+it("has access to the 'module' shim", function() {
+	var keyname = "loaded";
+	module[keyname].should.be.false;
+});
+
+it("sees an __esModule key in the harmony export", function() {
+	(typeof harmony.__esModule).should.not.be.undefined;
+	harmony.__esModule.should.be.true;
+})
+
+it("can access the harmony exports", function() {
+	(typeof harmony.default).should.equal("object");
+	(harmony.default === null).should.be.true;
+	(typeof harmony.foo).should.equal("function");
+})

--- a/test/cases/parsing/harmony-module-exports/harmony-shadow.js
+++ b/test/cases/parsing/harmony-module-exports/harmony-shadow.js
@@ -1,0 +1,4 @@
+export function bar () {}
+
+var exports = {};
+var module = { exports: exports };

--- a/test/cases/parsing/harmony-module-exports/harmony.js
+++ b/test/cases/parsing/harmony-module-exports/harmony.js
@@ -1,0 +1,26 @@
+it("has no 'exports' free var", function () {
+	(typeof exports).should.equal("undefined");
+});
+
+it("has no 'module' free var", function () {
+	(typeof module).should.equal("undefined");
+});
+
+it("should throw when accessing 'module.exports'", function () {
+	(function () { module.exports; }).should.throw();
+});
+
+// skipped as they require TDZ support to implement
+// TODO: have an option to enable TDZ (requires 'let' implementation in engine)
+it("throws on access to 'exports'", function () {
+	this.skip(); return;
+	(function () { return exports; }).should.throw(ReferenceError)
+});
+
+it("throws on access to 'module'", function () {
+	this.skip(); return;
+	(function () { module.exports; }).should.throw(ReferenceError)
+});
+
+export function foo () {};
+export default null;

--- a/test/cases/parsing/harmony-module-exports/index.js
+++ b/test/cases/parsing/harmony-module-exports/index.js
@@ -1,0 +1,22 @@
+import './harmony';
+import { bar } from './harmony-shadow.js';
+import './commonjs';
+import './loose';
+
+it("should correctly export even when module or exports are shadowed", function () {
+  (typeof bar).should.equal("function");
+})
+
+it("still has a '__filename' free var", function () {
+	(typeof __filename).should.equal("string");
+});
+
+it("still has a '__dirname' free var", function () {
+	(typeof __dirname).should.equal("string");
+});
+
+it("doesn't inject the 'module' shim even when providing __dirname", function () {
+  // do a dynamic-looking key lookup on module, which normally forces the shim to be added
+  var keyname = "loaded";
+  (function () { module[keyname]; }).should.throw();
+})

--- a/test/cases/parsing/harmony-module-exports/loose.js
+++ b/test/cases/parsing/harmony-module-exports/loose.js
@@ -1,0 +1,7 @@
+it("has an 'exports' free var", function() {
+	(typeof exports).should.equal("object");
+});
+
+it("has a 'module' free var", function() {
+	(typeof module).should.equal("object");
+});

--- a/test/cases/parsing/issue-2050/x.js
+++ b/test/cases/parsing/issue-2050/x.js
@@ -1,6 +1,6 @@
 import { xa, xb, xc, xd } from "./module";
 
-module.exports = {
+__webpack_module__.exports = {
 	xa: xa,
 	xb: xb,
 	xc: xc,

--- a/test/configCases/code-generation/use-strict/index.js
+++ b/test/configCases/code-generation/use-strict/index.js
@@ -16,11 +16,11 @@ it("should include only one use strict per module", function() {
 	}
 
 	matches.should.be.eql([
-		"Object.defineProperty(exports, \"__esModule\", { value: true });",
-		"Object.defineProperty(exports, \"__esModule\", { value: true });",
-		"Object.defineProperty(exports, \"__esModule\", { value: true });",
+		"Object.defineProperty(__webpack_exports__, \"__esModule\", { value: true });",
+		"Object.defineProperty(__webpack_exports__, \"__esModule\", { value: true });",
+		"Object.defineProperty(__webpack_exports__, \"__esModule\", { value: true });",
 		"/* unused harmony default export */ var _unused_webpack_default_export = \"a\";",
-		"Object.defineProperty(exports, \"__esModule\", { value: true });",
+		"Object.defineProperty(__webpack_exports__, \"__esModule\", { value: true });",
 		"it(\"should include only one use strict per module\", function() {"
 	]);
 });

--- a/test/statsCases/tree-shaking/expected.txt
+++ b/test/statsCases/tree-shaking/expected.txt
@@ -1,4 +1,4 @@
-Hash: 00d5541377fcfa0231b5
+Hash: e94a2c6bee98efb02ae8
 Time: Xms
     Asset    Size  Chunks             Chunk Names
 bundle.js  7.6 kB       0  [emitted]  main

--- a/test/statsCases/tree-shaking/expected.txt
+++ b/test/statsCases/tree-shaking/expected.txt
@@ -1,7 +1,7 @@
-Hash: e94a2c6bee98efb02ae8
+Hash: 00d5541377fcfa0231b5
 Time: Xms
-    Asset     Size  Chunks             Chunk Names
-bundle.js  7.14 kB       0  [emitted]  main
+    Asset    Size  Chunks             Chunk Names
+bundle.js  7.6 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 588 bytes [entry] [rendered]
    [0] (webpack)/test/statsCases/tree-shaking/a.js 13 bytes {0} [built]
        [exports: a]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Ensures that the commonjs `module` and `exports` pseudo-globals are not visible from within harmony modules.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

See #3491, #3571

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
Yes.

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
`module` and `exports` should not be defined inside ES modules, unless the user defines them. Accessing them should throw `ReferenceError`, however actually implementing that would require making use of ES6's `let`. I added a TODO comment about that, as it could be made configurable in the future.

This tries to implement that case by ensuring `module` and `exports` are `undefined`. The parameter received by the module function wrappers will be named `__webpack_module__` and `__webpack_exports__`, instead.

To ensure a potential `module` or `exports` global (from, say, running on Node) is not visible from the bundled module, a `var module, exports` is added to the end of each harmony module. These should just get stripped by the minifier.

As always declaring `var module, exports` at the end could cause `SyntaxError` should the user actually have a local `let` or `const` with either of those names, a new `"program end"` parser step is used to check if either of those vars is in the top level declaration scope.

To keep compatibility with existing hot reloading code, `module.hot`, `module.id` and `module.loaded` correspondingly map to the equivalent `__webpack_module__` expression. `module` is otherwise completely undefined.

In the future, when/if `import` meta-properties are defined, `module.hot` might be able to be moved to `import.hot`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Yes, but such code is already broken, only in a different way.

The migration path is to not mix harmony `import` or `export` and commonjs exports.

**Other information**
