### PR TITLE
remove second param to `ChunkTemplate` constructor

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -34,7 +34,7 @@ function Compilation(compiler) {
 	this.performance = options && options.performance;
 
 	this.mainTemplate = new MainTemplate(this.outputOptions);
-	this.chunkTemplate = new ChunkTemplate(this.outputOptions, this.mainTemplate);
+	this.chunkTemplate = new ChunkTemplate(this.outputOptions);
 	this.hotUpdateChunkTemplate = new HotUpdateChunkTemplate(this.outputOptions);
 	this.moduleTemplate = new ModuleTemplate(this.outputOptions);
 


### PR DESCRIPTION
the ChunkTemplate contructor only expects one parameter, therefore it seams unnecessary that `this.mainTemplate` is passed

**What kind of change does this PR introduce?**

remove superfluous code

**Summary**

passing the main template as a second parameter to the ChunkTemplate is superfluous as the ChunkTempalte only expects one parameter.

**Does this PR introduce a breaking change?**

No

