### PR TITLE
Fix progress indicator erasing too many characters. Fixes #3591

### DIFF
--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -131,7 +131,7 @@ ProgressPlugin.prototype.apply = function(compiler) {
 		});
 	}
 
-	var chars = 0,
+	var lineCaretPosition = 0,
 		lastState, lastStateTime;
 
 	function defaultHandler(percentage, msg) {
@@ -165,7 +165,7 @@ ProgressPlugin.prototype.apply = function(compiler) {
 					var stateMsg = (now - lastStateTime) + "ms " + lastState;
 					goToLineStart(stateMsg);
 					process.stderr.write(stateMsg + "\n");
-					chars = 0;
+					lineCaretPosition = 0;
 				}
 				lastState = state;
 				lastStateTime = now;
@@ -177,13 +177,13 @@ ProgressPlugin.prototype.apply = function(compiler) {
 
 	function goToLineStart(nextMessage) {
 		var str = "";
-		for(; chars > nextMessage.length; chars--) {
+		for(; lineCaretPosition > nextMessage.length; lineCaretPosition--) {
 			str += "\b \b";
 		}
-		chars = nextMessage.length;
-		for(var i = 0; i < chars; i++) {
+		for(var i = 0; i < lineCaretPosition; i++) {
 			str += "\b";
 		}
+		lineCaretPosition = nextMessage.length;
 		if(str) process.stderr.write(str);
 	}
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix.

**Did you add tests for your changes?**
No. Do I really need to?

**If relevant, link to documentation update:**
N/A

**Summary**
Fixes bug #3591.

**Does this PR introduce a breaking change?**
No.

**Other information**

The code was erasing (actually: moving the caret back for) too many characters
because the number of characters to move back was being overwritten
too early.

The bug manifests itself only in Windows Command Prompt via npm script
and only when webpack is run in conjunction with other npm scripts. Linux
terminal is also affected, but apparently is more graceful (doesn't allow the
backspace character to jump to the previous terminal line).