### PR TITLE
ProvidePlugin: support properties from modules. Closes #2864

### DIFF
--- a/lib/ProvidePlugin.js
+++ b/lib/ProvidePlugin.js
@@ -18,7 +18,7 @@ ProvidePlugin.prototype.apply = function(compiler) {
 		compilation.dependencyTemplates.set(ConstDependency, new ConstDependency.Template());
 		params.normalModuleFactory.plugin("parser", function(parser, parserOptions) {
 			Object.keys(definitions).forEach(function(name) {
-				var request = definitions[name];
+				var request = [].concat(definitions[name]);
 				var splittedName = name.split(".");
 				if(splittedName.length > 0) {
 					splittedName.slice(1).forEach(function(_, i) {
@@ -31,10 +31,16 @@ ProvidePlugin.prototype.apply = function(compiler) {
 				parser.plugin("expression " + name, function(expr) {
 					var nameIdentifier = name;
 					var scopedName = name.indexOf(".") >= 0;
+					var expression = "require(" + JSON.stringify(request[0]) + ")";
 					if(scopedName) {
 						nameIdentifier = "__webpack_provided_" + name.replace(/\./g, "_dot_");
 					}
-					if(!ModuleParserHelpers.addParsedVariable(this, nameIdentifier, "require(" + JSON.stringify(request) + ")")) {
+					if(request.length > 1) {
+						expression += request.slice(1).map(function(r) {
+							return "[" + JSON.stringify(r) + "]";
+						}).join("");
+					}
+					if(!ModuleParserHelpers.addParsedVariable(this, nameIdentifier, expression)) {
 						return false;
 					}
 					if(scopedName) {

--- a/test/configCases/plugins/provide-plugin/ddd.js
+++ b/test/configCases/plugins/provide-plugin/ddd.js
@@ -1,0 +1,7 @@
+var ddd = {
+	eee: {
+		"3-f": "fff"
+	}
+};
+
+module.exports = ddd;

--- a/test/configCases/plugins/provide-plugin/index.js
+++ b/test/configCases/plugins/provide-plugin/index.js
@@ -19,3 +19,9 @@ it("should provide a module for a nested var within a IIFE", function() {
 it("should not provide a module for a part of a var", function() {
 	(typeof bbb).should.be.eql("undefined");
 });
+
+it("should provide a module for a property request", function() {
+	(dddeeefff).should.be.eql("fff");
+	var x = dddeeefff;
+	x.should.be.eql("fff");
+});

--- a/test/configCases/plugins/provide-plugin/webpack.config.js
+++ b/test/configCases/plugins/provide-plugin/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
 		new ProvidePlugin({
 			aaa: "./aaa",
 			"bbb.ccc": "./bbbccc",
+			"dddeeefff": ["./ddd", "eee", "3-f"],
 			"process.env.NODE_ENV": "./env",
 		})
 	]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Feature

**Did you add tests for your changes?**

Yes

**If relevant, link to documentation update:**

N/A

**Summary**

Implements the feature request in #2864
The ProvidePlugin could previously only provide top-level (default) exports.  This adds support for providing named exports as well.  The existing API stays the same for default exports.  To provide named exports, the API can also accept an array as `["./module", "property"]`

```js
new ProvidePlugin({
  foobar: ["./foo", "bar"]
})
```
foo.js:
```js
module.exports = {
  bar: "baz"
}
```
```js
console.log(foobar) // "baz"
```

**Does this PR introduce a breaking change?**

No
