### PR TITLE
feat(performancebudgets): set warnings in console off by default

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -73,12 +73,7 @@ function WebpackOptionsDefaulter() {
 
 	this.set("performance.maxAssetSize", 250000);
 	this.set("performance.maxEntrypointSize", 250000);
-	this.set("performance.hints", "make", function(options) {
-		if(options.target === "web" || options.target === "webworker")
-			return "warning";
-		else
-			return false;
-	});
+	this.set("performance.hints", false);
 
 	this.set("resolve", {});
 	this.set("resolve.unsafeCache", true);

--- a/test/fixtures/temp-1000/file.js
+++ b/test/fixtures/temp-1000/file.js
@@ -1,0 +1,1 @@
+require('./file2'); again

--- a/test/fixtures/temp-1000/file2.js
+++ b/test/fixtures/temp-1000/file2.js
@@ -1,0 +1,1 @@
+original

--- a/test/statsCases/performance-no-async-chunks-shown/webpack.config.js
+++ b/test/statsCases/performance-no-async-chunks-shown/webpack.config.js
@@ -3,6 +3,9 @@ module.exports = {
 		main: "./index",
 		sec: "./index2"
 	},
+	performance: {
+		hints: "warning"
+	},
 	stats: {
 		colors: true,
 		hash: false,

--- a/test/statsCases/preset-normal-performance-ensure-filter-sourcemaps/webpack.config.js
+++ b/test/statsCases/preset-normal-performance-ensure-filter-sourcemaps/webpack.config.js
@@ -1,5 +1,8 @@
 module.exports = {
 	devtool: "sourcemap",
+	performance: {
+		hints: "warning"
+	},
 	entry: "./index",
 	stats: {
 		hash: false,

--- a/test/statsCases/preset-normal-performance/webpack.config.js
+++ b/test/statsCases/preset-normal-performance/webpack.config.js
@@ -1,5 +1,8 @@
 module.exports = {
 	entry: "./index",
+	performance: {
+		hints: "warning"
+	},
 	stats: {
 		hash: false,
 		colors: true


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Feature/Bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Updated existing tests to meet changes needs.
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
Will need to create issue. 
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Performance Hint warnings and errors will be now opt-in. However, the `[big]` entity will now show by default. Currently there is _no_ way in webpack to discern one env from another for developers, therefore its too difficult to control or _determine_ what env a user might be in and when to intelligently display perf hints. 

As much as an organization we want to do our part and encourage users to be aware of the sizes of their web application bundles that they are emitting, the feedback that we have gotten is that for this to be a opt-out, it needs to have more intelligent env understandings, as well as calculating gzip and minified sizes during dev env vs prod. 

It's better to instead have this opt-in for now, and for webpack v2.4-3+ to add more intelligent features that allow this to be turned back to an opt-out feature (which is end goal). 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Addresses concerns from #3485 and comments later in #3216.
**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Will need to update Documentation to state that perf.hints is now `false` by default. 