### PR TITLE
ci(travis): Drop NodeJS 0.12 support officially & remove from CI Matrix

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,8 @@
 		"eslint:recommended"
 	],
 	"env": {
-		"node": true
+		"node": true,
+		"es6": true
 	},
 	"rules": {
 		"strict": 0,

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ matrix:
     - os: linux
       node_js: "4"
       env: NO_WATCH_TESTS=1 JOB_PART=test
-    - os: linux
-      node_js: "v0.12.17"
-      env: NO_WATCH_TESTS=1 JOB_PART=test
     - os: osx
       node_js: "7"
       env: NO_WATCH_TESTS=1 JOB_PART=test
@@ -33,7 +30,6 @@ matrix:
       node_js: "4"
       env: NO_WATCH_TESTS=1 JOB_PART=test
   allow_failures:
-    - node_js: "v0.12.17"
     - os: osx
   fast_finish: true
 

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 set -ev
 
-if [ "$TRAVIS_NODE_VERSION" == "v0.12.17" ]; then 
-    npm install --force && npm link && npm link webpack;
-else 
-    npm install yarn -g && yarn install && yarn link || true && yarn link webpack;
-fi
+npm install yarn -g && yarn install && yarn link || true && yarn link webpack;
+


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Refactoring, feature, build change.

**Did you add tests for your changes?**
None needed yet until we define style guide for es6/eslint. 
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Node LTE for 0.12 is done at end of year. Since we will not publish another release till after EOY, then it's safe to drop 0.12 support now. This way, contributors can start submitting PR's for using Spread, Class, let, const, etc. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Only for Node 0.12 users. Migration path would be to use a supported version of NodeJS 4+. 
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
