### PR TITLE
Update minimum engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "worker-loader": "~0.7.0"
   },
   "engines": {
-    "node": ">=0.12"
+    "node": ">=4.2.3"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "worker-loader": "~0.7.0"
   },
   "engines": {
-    "node": ">=4.2.3"
+    "node": ">=4.7"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
With the introduction of ES6(-lite) code into `master`, webpack is no longer runnable by node 0.12.

Went with 4.2.3 minimum as it fixes a v8 JSON-related issue.

https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V4.md#2015-12-04-version-423-argon-lts-rvagg

4.1.0 would be the minimum otherwise as it fixes an important ES6 bug.

https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V4.md#4.1.0
