### PR TITLE
refactor(eslint): Added no-unsed-vars, env specific .eslintrc's for buildin & hot

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,7 @@
 		"es6": true
 	},
 	"rules": {
-		"quotes": [2, "double"],
+		"quotes": ["error", "double"],
 		"no-undef": "error",
 		"brace-style": "error",
 		"eol-last": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,7 @@
 		"es6": true
 	},
 	"rules": {
-		"quotes": ["error", "double"],
+		"quotes": [2, "double"],
 		"no-undef": "error",
 		"brace-style": "error",
 		"eol-last": "error",
@@ -21,7 +21,7 @@
 		"space-in-parens": "error",
 		"no-trailing-spaces": "error",
 		"no-use-before-define": "off",
-		"no-unused-vars": "off",
+		"no-unused-vars": ["error", {"args": "none"}],
 		"key-spacing": "error",
 		"space-infix-ops": "error",
 		"no-unsafe-negation": "error",

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -2,7 +2,6 @@ var path = require("path");
 var fs = require("fs");
 fs.existsSync = fs.existsSync || path.existsSync;
 var interpret = require("interpret");
-var WebpackOptionsDefaulter = require("../lib/WebpackOptionsDefaulter");
 
 module.exports = function(yargs, argv, convertOptions) {
 
@@ -223,12 +222,6 @@ module.exports = function(yargs, argv, convertOptions) {
 					options[optionName || name] = true;
 				else if(bool === false)
 					options[optionName || name] = false;
-			});
-		}
-
-		function mapArgToPath(name, optionName) {
-			ifArg(name, function(str) {
-				options[optionName || name] = path.resolve(str);
 			});
 		}
 

--- a/buildin/.eslintrc
+++ b/buildin/.eslintrc
@@ -1,0 +1,7 @@
+{
+	"env": {
+		"node": true,
+		"es6": false,
+		"browser": true
+	}
+}

--- a/buildin/amd-define.js
+++ b/buildin/amd-define.js
@@ -1,1 +1,3 @@
-module.exports = function() { throw new Error("define cannot be used indirect"); };
+module.exports = function() {
+	throw new Error("define cannot be used indirect");
+};

--- a/buildin/amd-options.js
+++ b/buildin/amd-options.js
@@ -1,1 +1,2 @@
+/* globals __webpack_amd_options__ */
 module.exports = __webpack_amd_options__;

--- a/buildin/global.js
+++ b/buildin/global.js
@@ -1,7 +1,9 @@
 var g;
 
 // This works in non-strict mode
-g = (function() { return this; })();
+g = (function() {
+	return this;
+})();
 
 try {
 	// This works if eval is allowed (see CSP)

--- a/buildin/module.js
+++ b/buildin/module.js
@@ -7,12 +7,16 @@ module.exports = function(module) {
 		Object.defineProperty(module, "loaded", {
 			enumerable: true,
 			configurable: false,
-			get: function() { return module.l; }
+			get: function() {
+				return module.l;
+			}
 		});
 		Object.defineProperty(module, "id", {
 			enumerable: true,
 			configurable: false,
-			get: function() { return module.i; }
+			get: function() {
+				return module.i;
+			}
 		});
 		module.webpackPolyfill = 1;
 	}

--- a/buildin/return-require.js
+++ b/buildin/return-require.js
@@ -1,1 +1,4 @@
-module.exports = function() { return __webpack_require__; };
+/* globals __webpack_require__ */
+module.exports = function() {
+	return __webpack_require__;
+};

--- a/hot/.eslintrc
+++ b/hot/.eslintrc
@@ -1,0 +1,7 @@
+{
+	"env": {
+		"node": true,
+		"es6": false,
+		"browser": true
+	}
+}

--- a/hot/only-dev-server.js
+++ b/hot/only-dev-server.js
@@ -2,7 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-/*globals window __webpack_hash__ */
+/*globals __webpack_hash__ */
 if(module.hot) {
 	var lastHash;
 	var upToDate = function upToDate() {

--- a/lib/CompatibilityPlugin.js
+++ b/lib/CompatibilityPlugin.js
@@ -2,7 +2,6 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var path = require("path");
 var ConstDependency = require("./dependencies/ConstDependency");
 
 var NullFactory = require("./NullFactory");

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -740,8 +740,6 @@ Compilation.prototype.assignIndex = function assignIndex(module) {
 };
 
 Compilation.prototype.assignDepth = function assignDepth(module) {
-	var _this = this;
-
 	function assignDepthToModule(module, depth) {
 		// enter module
 		if(typeof module.depth === "number" && module.depth <= depth) return;
@@ -760,8 +758,6 @@ Compilation.prototype.assignDepth = function assignDepth(module) {
 	}
 
 	function assignDepthToDependencyBlock(block, depth) {
-		var allDependencies = [];
-
 		function iteratorDependency(d) {
 			assignDepthToDependency(d, depth);
 		}

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -6,7 +6,6 @@ var path = require("path");
 var Tapable = require("tapable");
 
 var Compilation = require("./Compilation");
-var Resolver = require("enhanced-resolve/lib/Resolver");
 
 var NormalModuleFactory = require("./NormalModuleFactory");
 var ContextModuleFactory = require("./ContextModuleFactory");

--- a/lib/FlagInitialModulesAsUsedPlugin.js
+++ b/lib/FlagInitialModulesAsUsedPlugin.js
@@ -2,9 +2,6 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var path = require("path");
-var async = require("async");
-
 function FlagInitialModulesAsUsedPlugin() {}
 module.exports = FlagInitialModulesAsUsedPlugin;
 FlagInitialModulesAsUsedPlugin.prototype.apply = function(compiler) {

--- a/lib/FunctionModuleTemplatePlugin.js
+++ b/lib/FunctionModuleTemplatePlugin.js
@@ -3,7 +3,6 @@
 	Author Tobias Koppers @sokra
 */
 var ConcatSource = require("webpack-sources").ConcatSource;
-var PrefixSource = require("webpack-sources").PrefixSource;
 
 function FunctionModuleTemplatePlugin() {}
 module.exports = FunctionModuleTemplatePlugin;

--- a/lib/JsonpChunkTemplatePlugin.js
+++ b/lib/JsonpChunkTemplatePlugin.js
@@ -3,8 +3,6 @@
 	Author Tobias Koppers @sokra
 */
 var ConcatSource = require("webpack-sources").ConcatSource;
-var Template = require("./Template");
-
 function JsonpChunkTemplatePlugin() {}
 module.exports = JsonpChunkTemplatePlugin;
 

--- a/lib/JsonpChunkTemplatePlugin.js
+++ b/lib/JsonpChunkTemplatePlugin.js
@@ -3,6 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 var ConcatSource = require("webpack-sources").ConcatSource;
+
 function JsonpChunkTemplatePlugin() {}
 module.exports = JsonpChunkTemplatePlugin;
 

--- a/lib/JsonpHotUpdateChunkTemplatePlugin.js
+++ b/lib/JsonpHotUpdateChunkTemplatePlugin.js
@@ -3,7 +3,6 @@
 	Author Tobias Koppers @sokra
 */
 var ConcatSource = require("webpack-sources").ConcatSource;
-var Template = require("./Template");
 
 function JsonpHotUpdateChunkTemplatePlugin() {}
 module.exports = JsonpHotUpdateChunkTemplatePlugin;

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -27,7 +27,6 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 		return source;
 	});
 	mainTemplate.plugin("jsonp-script", function(_, chunk, hash) {
-		var filename = this.outputOptions.filename;
 		var chunkFilename = this.outputOptions.chunkFilename;
 		var chunkMaps = chunk.getChunkMaps();
 		var crossOriginLoading = this.outputOptions.crossOriginLoading;
@@ -81,7 +80,6 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 		]);
 	});
 	mainTemplate.plugin("require-ensure", function(_, chunk, hash) {
-		var chunkFilename = this.outputOptions.chunkFilename;
 		return this.asString([
 			"if(installedChunks[chunkId] === 0)",
 			this.indent([

--- a/lib/LibManifestPlugin.js
+++ b/lib/LibManifestPlugin.js
@@ -4,7 +4,6 @@
 */
 var path = require("path");
 var async = require("async");
-var HarmonyModulesHelpers = require("./dependencies/HarmonyModulesHelpers");
 
 function LibManifestPlugin(options) {
 	this.options = options;

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -5,7 +5,6 @@
 var DependenciesBlock = require("./DependenciesBlock");
 var ModuleReason = require("./ModuleReason");
 var Template = require("./Template");
-var HarmonyModulesHelpers = require("./dependencies/HarmonyModulesHelpers");
 
 var debugId = 1000;
 

--- a/lib/OptionsDefaulter.js
+++ b/lib/OptionsDefaulter.js
@@ -27,15 +27,6 @@ function setProperty(obj, name, value) {
 	obj[name.pop()] = value;
 }
 
-function hasProperty(obj, name, value) {
-	name = name.split(".");
-	for(var i = 0; i < name.length - 1; i++) {
-		obj = obj[name[i]];
-		if(typeof obj != "object" || !obj) return false;
-	}
-	return Object.prototype.hasOwnProperty.call(obj, name.pop());
-}
-
 OptionsDefaulter.prototype.process = function(options) {
 	var addItemTo = function addItemTo(list) {
 		return function(item) {

--- a/lib/UseStrictPlugin.js
+++ b/lib/UseStrictPlugin.js
@@ -5,7 +5,6 @@
 "use strict"
 
 const ConstDependency = require("./dependencies/ConstDependency");
-const NullFactory = require("./NullFactory");
 
 class UseStrictPlugin {
 	apply(compiler) {

--- a/lib/WebpackOptionsValidationError.js
+++ b/lib/WebpackOptionsValidationError.js
@@ -123,15 +123,6 @@ function getSchemaPart(path, parents, additionalPath) {
 	return schemaPart;
 }
 
-function getSchemaPartText2(path, parents, additionalPath) {
-	var schemaPart = getSchemaPart(path, parents, additionalPath);
-	while(schemaPart.$ref) schemaPart = getSchemaPart(schemaPart.$ref);
-	var schemaText = WebpackOptionsValidationError.formatSchema(schemaPart);
-	if(schemaPart.description)
-		schemaText += "\n" + schemaPart.description;
-	return schemaText;
-}
-
 function getSchemaPartText(schemaPart, additionalPath) {
 	if(additionalPath) {
 		for(var i = 0; i < additionalPath.length; i++) {

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -3,7 +3,6 @@
 	Author Tobias Koppers @sokra
 */
 var NullDependency = require("./NullDependency");
-var HarmonyModulesHelpers = require("./HarmonyModulesHelpers");
 
 function HarmonyImportSpecifierDependency(importDependency, importedVar, id, name, range) {
 	NullDependency.call(this);

--- a/lib/dependencies/ImportPlugin.js
+++ b/lib/dependencies/ImportPlugin.js
@@ -4,11 +4,6 @@
 */
 var ImportDependency = require("./ImportDependency");
 var ImportContextDependency = require("./ImportContextDependency");
-
-var UnsupportedFeatureWarning = require("../UnsupportedFeatureWarning");
-var ConstDependency = require("./ConstDependency");
-var BasicEvaluatedExpression = require("../BasicEvaluatedExpression");
-
 var ImportParserPlugin = require("./ImportParserPlugin");
 
 function ImportPlugin(options) {

--- a/lib/dependencies/SystemPlugin.js
+++ b/lib/dependencies/SystemPlugin.js
@@ -12,11 +12,7 @@ function SystemPlugin(options) {
 module.exports = SystemPlugin;
 
 SystemPlugin.prototype.apply = function(compiler) {
-	var options = this.options;
 	compiler.plugin("compilation", function(compilation, params) {
-		var normalModuleFactory = params.normalModuleFactory;
-		var contextModuleFactory = params.contextModuleFactory;
-
 		params.normalModuleFactory.plugin("parser", function(parser, parserOptions) {
 
 			if(typeof parserOptions.system !== "undefined" && !parserOptions.system)

--- a/lib/dependencies/UnsupportedDependency.js
+++ b/lib/dependencies/UnsupportedDependency.js
@@ -3,7 +3,6 @@
 	Author Tobias Koppers @sokra
 */
 var NullDependency = require("./NullDependency");
-var DepBlockHelpers = require("./DepBlockHelpers");
 
 function UnsupportedDependency(request, range) {
 	NullDependency.call(this);

--- a/lib/node/NodeMainTemplate.runtime.js
+++ b/lib/node/NodeMainTemplate.runtime.js
@@ -18,7 +18,7 @@ module.exports = function() {
 		return Promise.resolve(update);
 	}
 
-	function hotDisposeChunk(chunkId) {
+	function hotDisposeChunk(chunkId) { //eslint-disable-line no-unused-vars
 		delete installedChunks[chunkId];
 	}
 };

--- a/lib/node/NodeMainTemplateAsync.runtime.js
+++ b/lib/node/NodeMainTemplateAsync.runtime.js
@@ -34,7 +34,7 @@ module.exports = function() {
 		});
 	}
 
-	function hotDisposeChunk(chunkId) {
+	function hotDisposeChunk(chunkId) { //eslint-disable-line no-unused-vars
 		delete installedChunks[chunkId];
 	}
 };

--- a/lib/node/NodeMainTemplatePlugin.js
+++ b/lib/node/NodeMainTemplatePlugin.js
@@ -46,7 +46,6 @@ NodeMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 		return source;
 	});
 	mainTemplate.plugin("require-ensure", function(_, chunk, hash) {
-		var filename = this.outputOptions.filename;
 		var chunkFilename = this.outputOptions.chunkFilename;
 		var chunkMaps = chunk.getChunkMaps();
 		var insertMoreModules = [

--- a/lib/node/NodeSourcePlugin.js
+++ b/lib/node/NodeSourcePlugin.js
@@ -76,7 +76,6 @@ NodeSourcePlugin.prototype.apply = function(compiler) {
 		});
 	});
 	compiler.plugin("after-resolvers", function(compiler) {
-		var alias = {};
 		Object.keys(nodeLibsBrowser).forEach(function(lib) {
 			if(options[lib] !== false) {
 				compiler.resolvers.normal.apply(

--- a/lib/optimize/AggressiveSplittingPlugin.js
+++ b/lib/optimize/AggressiveSplittingPlugin.js
@@ -157,7 +157,6 @@ AggressiveSplittingPlugin.prototype.apply = function(compiler) {
 		compilation.plugin("record-hash", function(records) {
 			// 3. save to made splittings to records
 			var minSize = _this.options.minSize;
-			var maxSize = _this.options.maxSize;
 			if(!records.aggressiveSplits) records.aggressiveSplits = [];
 			compilation.chunks.forEach(function(chunk) {
 				if(chunk.hasEntryModule()) return;

--- a/lib/performance/SizeLimitsPlugin.js
+++ b/lib/performance/SizeLimitsPlugin.js
@@ -2,8 +2,6 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Sean Larkin @thelarkinn
 */
-var path = require("path");
-
 var EntrypointsOverSizeLimitWarning = require("./EntrypointsOverSizeLimitWarning");
 var AssetsOverSizeLimitWarning = require("./AssetsOverSizeLimitWarning");
 var NoAsyncChunksWarning = require("./NoAsyncChunksWarning");

--- a/lib/web/WebEnvironmentPlugin.js
+++ b/lib/web/WebEnvironmentPlugin.js
@@ -8,6 +8,5 @@ function WebEnvironmentPlugin(inputFileSystem, outputFileSystem) {
 }
 module.exports = WebEnvironmentPlugin;
 WebEnvironmentPlugin.prototype.apply = function(compiler) {
-	var inputFileSystem = compiler.inputFileSystem = this.inputFileSystem;
 	compiler.outputFileSystem = this.outputFileSystem;
 };

--- a/lib/webworker/WebWorkerMainTemplate.runtime.js
+++ b/lib/webworker/WebWorkerMainTemplate.runtime.js
@@ -51,7 +51,7 @@ module.exports = function() {
 		});
 	}
 
-	function hotDisposeChunk(chunkId) {
+	function hotDisposeChunk(chunkId) { //eslint-disable-line no-unused-vars
 		delete installedChunks[chunkId];
 	}
 };

--- a/lib/webworker/WebWorkerMainTemplatePlugin.js
+++ b/lib/webworker/WebWorkerMainTemplatePlugin.js
@@ -28,7 +28,6 @@ WebWorkerMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 		return source;
 	});
 	mainTemplate.plugin("require-ensure", function(_, chunk, hash) {
-		var filename = this.outputOptions.filename;
 		var chunkFilename = this.outputOptions.chunkFilename;
 		return this.asString([
 			"// \"1\" is the signal for \"already loaded\"",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "build:examples": "cd examples && node buildAll.js",
     "pretest": "npm run lint-files",
     "lint-files": "npm run lint && npm run beautify-lint",
-    "lint": "eslint lib bin hot",
+    "lint": "eslint lib bin hot buildin",
     "beautify-lint": "beautify-lint 'lib/**/*.js' 'hot/**/*.js' 'bin/**/*.js' 'benchmark/*.js' 'test/*.js'",
     "nsp": "nsp check --output summary",
     "cover": "node --harmony ./node_modules/.bin/istanbul cover -x '**/*.runtime.js' node_modules/mocha/bin/_mocha",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refactor
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Existing Tests Should Pass
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
* This change allows for buildin to now be part of the lint test by addition of an extra .eslintrc file which extends existing but sets es6 to false
* Turned on no-unused-vars for eslint, and then removed all warnings from turning that feature on
* Was getting notified of errors in "quote" property in eslintrc, so changed to correct value from error to 2.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Nope
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
