### PR TITLE
refactor(es6): refactor IgnorePlugin to ES6 class

### DIFF
--- a/lib/IgnorePlugin.js
+++ b/lib/IgnorePlugin.js
@@ -2,31 +2,37 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-function IgnorePlugin(resourceRegExp, contextRegExp) {
-	this.resourceRegExp = resourceRegExp;
-	this.contextRegExp = contextRegExp;
+"use strict";
+
+class IgnorePlugin {
+	constructor(resourceRegExp, contextRegExp) {
+		this.resourceRegExp = resourceRegExp;
+		this.contextRegExp = contextRegExp;
+	}
+
+	apply(compiler) {
+		let resourceRegExp = this.resourceRegExp;
+		let contextRegExp = this.contextRegExp;
+		compiler.plugin("normal-module-factory", (nmf) => {
+			nmf.plugin("before-resolve", (result, callback) => {
+				if(!result) return callback();
+				if(resourceRegExp.test(result.request) &&
+					(!contextRegExp || contextRegExp.test(result.context))) {
+					return callback();
+				}
+				return callback(null, result);
+			});
+		});
+		compiler.plugin("context-module-factory", (cmf) => {
+			cmf.plugin("before-resolve", (result, callback) => {
+				if(!result) return callback();
+				if(resourceRegExp.test(result.request)) {
+					return callback();
+				}
+				return callback(null, result);
+			});
+		});
+	}
 }
+
 module.exports = IgnorePlugin;
-IgnorePlugin.prototype.apply = function(compiler) {
-	var resourceRegExp = this.resourceRegExp;
-	var contextRegExp = this.contextRegExp;
-	compiler.plugin("normal-module-factory", function(nmf) {
-		nmf.plugin("before-resolve", function(result, callback) {
-			if(!result) return callback();
-			if(resourceRegExp.test(result.request) &&
-				(!contextRegExp || contextRegExp.test(result.context))) {
-				return callback();
-			}
-			return callback(null, result);
-		});
-	});
-	compiler.plugin("context-module-factory", function(cmf) {
-		cmf.plugin("before-resolve", function(result, callback) {
-			if(!result) return callback();
-			if(resourceRegExp.test(result.request)) {
-				return callback();
-			}
-			return callback(null, result);
-		});
-	});
-};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refactor (ES5 => ES6)
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No functionality was changed, existing tests passed
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Refactors the IgnorePlugin to an ES6 class. Never contributed before, trying to get into the webpack codebase and understand it a bit more so this seemed like a good place to start. Let me know if I missed anything!
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Nope
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
