### PR TITLE
feat(moduletemplate): Wrap function module template wrappers with parens

### DIFF
--- a/lib/FunctionModuleTemplatePlugin.js
+++ b/lib/FunctionModuleTemplatePlugin.js
@@ -14,10 +14,10 @@ FunctionModuleTemplatePlugin.prototype.apply = function(moduleTemplate) {
 		if((module.arguments && module.arguments.length !== 0) || module.hasDependencies()) {
 			defaultArguments.push("__webpack_require__");
 		}
-		source.add("/***/ function(" + defaultArguments.concat(module.arguments || []).join(", ") + ") {\n\n");
+		source.add("/***/ (function(" + defaultArguments.concat(module.arguments || []).join(", ") + ") {\n\n");
 		if(module.strict) source.add("\"use strict\";\n");
 		source.add(moduleSource);
-		source.add("\n\n/***/ }");
+		source.add("\n\n/***/ })");
 		return source;
 	});
 	moduleTemplate.plugin("package", function(moduleSource, module) {

--- a/test/statsCases/aggressive-splitting-entry/expected.txt
+++ b/test/statsCases/aggressive-splitting-entry/expected.txt
@@ -1,10 +1,10 @@
 Hash: 94ea214f5f8dfcaa01e7
 Time: Xms
                   Asset       Size  Chunks             Chunk Names
-48c8b1dae03a37363ec8.js    4.24 kB       1  [emitted]  
-7ae90280671106fd3e86.js    2.22 kB       2  [emitted]  
-9356e9a0fb00a97b2e73.js    1.93 kB       3  [emitted]  
-88d78642a86768757078.js  977 bytes       4  [emitted]  
+48c8b1dae03a37363ec8.js    4.25 kB       1  [emitted]  
+7ae90280671106fd3e86.js    2.23 kB       2  [emitted]  
+9356e9a0fb00a97b2e73.js    1.94 kB       3  [emitted]  
+88d78642a86768757078.js  979 bytes       4  [emitted]  
 Entrypoint main = 48c8b1dae03a37363ec8.js 9356e9a0fb00a97b2e73.js 88d78642a86768757078.js 7ae90280671106fd3e86.js
 chunk    {1} 48c8b1dae03a37363ec8.js 1.8 kB [entry] [rendered]
     > aggressive-splitted main [4] (webpack)/test/statsCases/aggressive-splitting-entry/index.js 

--- a/test/statsCases/aggressive-splitting-on-demand/expected.txt
+++ b/test/statsCases/aggressive-splitting-on-demand/expected.txt
@@ -1,14 +1,14 @@
 Hash: a724b9eabbc88a7196a7
 Time: Xms
                   Asset       Size  Chunks             Chunk Names
-fc930a2adf8206ea2dc5.js    1.93 kB       0  [emitted]  
-cd45585186d59208602b.js    1.95 kB       1  [emitted]  
+fc930a2adf8206ea2dc5.js    1.94 kB       0  [emitted]  
+cd45585186d59208602b.js    1.96 kB       1  [emitted]  
 6b94c231e016c5aaccdb.js    1.94 kB       2  [emitted]  
-fd0985cee894c4f3f1a6.js    1.93 kB       3  [emitted]  
-d9fc46873c8ea924b895.js  977 bytes       4  [emitted]  
+fd0985cee894c4f3f1a6.js    1.94 kB       3  [emitted]  
+d9fc46873c8ea924b895.js  979 bytes       4  [emitted]  
 90b55464dc36b9c472a9.js    7.22 kB       6  [emitted]  main
-b08c507d4e1e05cbab45.js  983 bytes       9  [emitted]  
-5d50e858fe6e559aa47c.js  975 bytes      11  [emitted]  
+b08c507d4e1e05cbab45.js  985 bytes       9  [emitted]  
+5d50e858fe6e559aa47c.js  977 bytes      11  [emitted]  
 Entrypoint main = 90b55464dc36b9c472a9.js
 chunk    {0} fc930a2adf8206ea2dc5.js 1.8 kB {6}
     > aggressive-splitted duplicate [9] (webpack)/test/statsCases/aggressive-splitting-on-demand/index.js 4:0-51

--- a/test/statsCases/chunks/expected.txt
+++ b/test/statsCases/chunks/expected.txt
@@ -1,10 +1,10 @@
 Hash: 160bbe49f674da1a2284
 Time: Xms
       Asset       Size  Chunks             Chunk Names
-0.bundle.js  236 bytes       0  [emitted]  
-1.bundle.js  106 bytes       1  [emitted]  
-2.bundle.js  200 bytes       2  [emitted]  
-  bundle.js    5.86 kB       3  [emitted]  main
+0.bundle.js  238 bytes       0  [emitted]  
+1.bundle.js  108 bytes       1  [emitted]  
+2.bundle.js  204 bytes       2  [emitted]  
+  bundle.js    5.87 kB       3  [emitted]  main
 chunk    {0} 0.bundle.js 54 bytes {3} [rendered]
     > [5] (webpack)/test/statsCases/chunks/index.js 3:0-16
     [2] (webpack)/test/statsCases/chunks/c.js 54 bytes {0} [built]

--- a/test/statsCases/max-modules-default/expected.txt
+++ b/test/statsCases/max-modules-default/expected.txt
@@ -1,7 +1,7 @@
 Hash: e36ab7d25d7661d1d913
 Time: Xms
   Asset     Size  Chunks             Chunk Names
-main.js  5.76 kB       0  [emitted]  main
+main.js  5.82 kB       0  [emitted]  main
 chunk    {0} main.js (main) 1.18 kB [entry] [rendered]
     [0] (webpack)/test/statsCases/max-modules-default/a.js?1 33 bytes {0} [built]
     [1] (webpack)/test/statsCases/max-modules-default/a.js?10 33 bytes {0} [built]

--- a/test/statsCases/max-modules/expected.txt
+++ b/test/statsCases/max-modules/expected.txt
@@ -1,7 +1,7 @@
 Hash: e36ab7d25d7661d1d913
 Time: Xms
   Asset     Size  Chunks             Chunk Names
-main.js  5.76 kB       0  [emitted]  main
+main.js  5.82 kB       0  [emitted]  main
 chunk    {0} main.js (main) 1.18 kB [entry] [rendered]
     [0] (webpack)/test/statsCases/max-modules/a.js?1 33 bytes {0} [built]
     [1] (webpack)/test/statsCases/max-modules/a.js?10 33 bytes {0} [built]

--- a/test/statsCases/optimize-chunks/expected.txt
+++ b/test/statsCases/optimize-chunks/expected.txt
@@ -1,13 +1,13 @@
 Hash: 98677d85dd05d16cbe7f
 Time: Xms
   Asset       Size  Chunks             Chunk Names
-   0.js  229 bytes       0  [emitted]  cir1
-   1.js  212 bytes    1, 2  [emitted]  abd
-   2.js  129 bytes       2  [emitted]  ab
-   3.js  244 bytes       3  [emitted]  cir2
-   4.js  136 bytes    4, 6  [emitted]  chunk
-   5.js  302 bytes    5, 3  [emitted]  cir2 from cir1
-   6.js   78 bytes       6  [emitted]  ac in ab
+   0.js  231 bytes       0  [emitted]  cir1
+   1.js  218 bytes    1, 2  [emitted]  abd
+   2.js  133 bytes       2  [emitted]  ab
+   3.js  246 bytes       3  [emitted]  cir2
+   4.js  140 bytes    4, 6  [emitted]  chunk
+   5.js  306 bytes    5, 3  [emitted]  cir2 from cir1
+   6.js   80 bytes       6  [emitted]  ac in ab
 main.js    6.53 kB       7  [emitted]  main
 chunk    {0} 0.js (cir1) 81 bytes {3} {5} {7} [rendered]
     > duplicate cir1 from cir2 [3] (webpack)/test/statsCases/optimize-chunks/circular2.js 1:0-79

--- a/test/statsCases/performance-disabled/expected.txt
+++ b/test/statsCases/performance-disabled/expected.txt
@@ -1,8 +1,8 @@
 Time: <CLR=BOLD>X</CLR>ms
   <CLR=BOLD>Asset</CLR>       <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22><CLR=BOLD>Chunk Names</CLR>
-   <CLR=32,BOLD>0.js</CLR>  236 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>  
-   <CLR=32,BOLD>1.js</CLR>  106 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>  
-   <CLR=32,BOLD>2.js</CLR>  200 bytes       <CLR=BOLD>2</CLR>  <CLR=32,BOLD>[emitted]</CLR>  
+   <CLR=32,BOLD>0.js</CLR>  238 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>  
+   <CLR=32,BOLD>1.js</CLR>  108 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>  
+   <CLR=32,BOLD>2.js</CLR>  204 bytes       <CLR=BOLD>2</CLR>  <CLR=32,BOLD>[emitted]</CLR>  
 <CLR=32,BOLD>main.js</CLR>     306 kB       <CLR=BOLD>3</CLR>  <CLR=32,BOLD>[emitted]</CLR>  main
 Entrypoint <CLR=BOLD>main</CLR> = <CLR=32,BOLD>main.js</CLR>
 chunk    {<CLR=33,BOLD>0</CLR>} <CLR=32,BOLD>0.js</CLR> 54 bytes {<CLR=33,BOLD>3</CLR>}<CLR=32,BOLD> [rendered]</CLR>

--- a/test/statsCases/performance-error/expected.txt
+++ b/test/statsCases/performance-error/expected.txt
@@ -1,8 +1,8 @@
 Time: <CLR=BOLD>X</CLR>ms
   <CLR=BOLD>Asset</CLR>       <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22>       <CLR=BOLD>Chunk Names</CLR>
-   <CLR=32,BOLD>0.js</CLR>  236 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
-   <CLR=32,BOLD>1.js</CLR>  106 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
-   <CLR=32,BOLD>2.js</CLR>  200 bytes       <CLR=BOLD>2</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
+   <CLR=32,BOLD>0.js</CLR>  238 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
+   <CLR=32,BOLD>1.js</CLR>  108 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
+   <CLR=32,BOLD>2.js</CLR>  204 bytes       <CLR=BOLD>2</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
 <CLR=33,BOLD>main.js</CLR>     <CLR=33,BOLD>306 kB</CLR>       <CLR=BOLD>3</CLR>  <CLR=32,BOLD>[emitted]</CLR>  <CLR=33,BOLD>[big]</CLR>  main
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> = <CLR=32,BOLD>main.js</CLR>
 chunk    {<CLR=33,BOLD>0</CLR>} <CLR=32,BOLD>0.js</CLR> 54 bytes {<CLR=33,BOLD>3</CLR>}<CLR=32,BOLD> [rendered]</CLR>

--- a/test/statsCases/performance-no-hints/expected.txt
+++ b/test/statsCases/performance-no-hints/expected.txt
@@ -1,8 +1,8 @@
 Time: <CLR=BOLD>X</CLR>ms
   <CLR=BOLD>Asset</CLR>       <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22>       <CLR=BOLD>Chunk Names</CLR>
-   <CLR=32,BOLD>0.js</CLR>  236 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
-   <CLR=32,BOLD>1.js</CLR>  106 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
-   <CLR=32,BOLD>2.js</CLR>  200 bytes       <CLR=BOLD>2</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
+   <CLR=32,BOLD>0.js</CLR>  238 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
+   <CLR=32,BOLD>1.js</CLR>  108 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
+   <CLR=32,BOLD>2.js</CLR>  204 bytes       <CLR=BOLD>2</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
 <CLR=33,BOLD>main.js</CLR>     <CLR=33,BOLD>306 kB</CLR>       <CLR=BOLD>3</CLR>  <CLR=32,BOLD>[emitted]</CLR>  <CLR=33,BOLD>[big]</CLR>  main
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> = <CLR=32,BOLD>main.js</CLR>
 chunk    {<CLR=33,BOLD>0</CLR>} <CLR=32,BOLD>0.js</CLR> 54 bytes {<CLR=33,BOLD>3</CLR>}<CLR=32,BOLD> [rendered]</CLR>

--- a/test/statsCases/preset-normal-performance-ensure-filter-sourcemaps/expected.txt
+++ b/test/statsCases/preset-normal-performance-ensure-filter-sourcemaps/expected.txt
@@ -1,8 +1,8 @@
 Time: <CLR=BOLD>X</CLR>ms
       <CLR=BOLD>Asset</CLR>       <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22>       <CLR=BOLD>Chunk Names</CLR>
-       <CLR=32,BOLD>0.js</CLR>  266 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
-       <CLR=32,BOLD>1.js</CLR>  136 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
-       <CLR=32,BOLD>2.js</CLR>  230 bytes       <CLR=BOLD>2</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
+       <CLR=32,BOLD>0.js</CLR>  268 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
+       <CLR=32,BOLD>1.js</CLR>  138 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
+       <CLR=32,BOLD>2.js</CLR>  234 bytes       <CLR=BOLD>2</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
     <CLR=33,BOLD>main.js</CLR>     <CLR=33,BOLD>306 kB</CLR>       <CLR=BOLD>3</CLR>  <CLR=32,BOLD>[emitted]</CLR>  <CLR=33,BOLD>[big]</CLR>  main
    <CLR=32,BOLD>0.js.map</CLR>  291 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
    <CLR=32,BOLD>1.js.map</CLR>  250 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         

--- a/test/statsCases/preset-normal-performance/expected.txt
+++ b/test/statsCases/preset-normal-performance/expected.txt
@@ -1,8 +1,8 @@
 Time: <CLR=BOLD>X</CLR>ms
   <CLR=BOLD>Asset</CLR>       <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22>       <CLR=BOLD>Chunk Names</CLR>
-   <CLR=32,BOLD>0.js</CLR>  236 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
-   <CLR=32,BOLD>1.js</CLR>  106 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
-   <CLR=32,BOLD>2.js</CLR>  200 bytes       <CLR=BOLD>2</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
+   <CLR=32,BOLD>0.js</CLR>  238 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
+   <CLR=32,BOLD>1.js</CLR>  108 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
+   <CLR=32,BOLD>2.js</CLR>  204 bytes       <CLR=BOLD>2</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
 <CLR=33,BOLD>main.js</CLR>     <CLR=33,BOLD>306 kB</CLR>       <CLR=BOLD>3</CLR>  <CLR=32,BOLD>[emitted]</CLR>  <CLR=33,BOLD>[big]</CLR>  main
 chunk    {<CLR=33,BOLD>0</CLR>} <CLR=32,BOLD>0.js</CLR> 54 bytes {<CLR=33,BOLD>3</CLR>}<CLR=32,BOLD> [rendered]</CLR>
     [2] <CLR=BOLD>(webpack)/test/statsCases/preset-normal-performance/c.js</CLR> 54 bytes {<CLR=33,BOLD>0</CLR>}<CLR=32,BOLD> [built]</CLR>

--- a/test/statsCases/preset-verbose/expected.txt
+++ b/test/statsCases/preset-verbose/expected.txt
@@ -1,9 +1,9 @@
 Hash: 85e57db9faf6765d1cf0
 Time: Xms
   Asset       Size  Chunks             Chunk Names
-   0.js  236 bytes       0  [emitted]  
-   1.js  106 bytes       1  [emitted]  
-   2.js  200 bytes       2  [emitted]  
+   0.js  238 bytes       0  [emitted]  
+   1.js  108 bytes       1  [emitted]  
+   2.js  204 bytes       2  [emitted]  
 main.js    5.86 kB       3  [emitted]  main
 Entrypoint main = main.js
 chunk    {0} 0.js 54 bytes {3} [rendered]

--- a/test/statsCases/tree-shaking/expected.txt
+++ b/test/statsCases/tree-shaking/expected.txt
@@ -1,7 +1,7 @@
 Hash: e94a2c6bee98efb02ae8
 Time: Xms
     Asset     Size  Chunks             Chunk Names
-bundle.js  7.14 kB       0  [emitted]  main
+bundle.js  7.16 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 588 bytes [entry] [rendered]
    [0] (webpack)/test/statsCases/tree-shaking/a.js 13 bytes {0} [built]
        [exports: a]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
N/A
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
All browser engines currently can be signaled to lazy parse code by wrapping iife's with parents. After speaking with @fhinkel and a few other members of the V8 team, we were recommended that we use this heuristic technique. The change is very minimal in that in converts the output template to go from: 

```
/***/ function(module, exports, __webpack_require__) {
		var add = __webpack_require__(/*! ./math */ 1).add;
		exports.increment = function(val) {
			return add(val, 1);
		};
/***/ },
```

to 

```
/***/ (function(module, exports, __webpack_require__) {
		var add = __webpack_require__(/*! ./math */ 1).add;
		exports.increment = function(val) {
			return add(val, 1);
		};
/***/ }),
```

Overall findings by @nolanlawson state that load and performance gains of over 10%-50% depending on browser engine. https://github.com/nolanlawson/optimize-js#benchmark-overview

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
