### PR TITLE
refactor(es6): Upgrade HashedModuleIdsPlugin to es6

### DIFF
--- a/lib/HashedModuleIdsPlugin.js
+++ b/lib/HashedModuleIdsPlugin.js
@@ -2,33 +2,40 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-function HashedModuleIdsPlugin(options) {
-	this.options = options || {};
-	this.options.hashFunction = this.options.hashFunction || "md5";
-	this.options.hashDigest = this.options.hashDigest || "base64";
-	this.options.hashDigestLength = this.options.hashDigestLength || 4;
+"use strict";
+
+class HashedModuleIdsPlugin {
+	constructor(options) {
+		this.options = Object.assign({
+			hashFunction: "md5",
+			hashDigest: "base64",
+			hashDigestLength: 4
+		}, options);
+	}
+
+	apply(compiler) {
+		const options = this.options;
+		compiler.plugin("compilation", (compilation) => {
+			const usedIds = {};
+			compilation.plugin("before-module-ids", (modules) => {
+				modules.forEach((module) => {
+					if(module.id === null && module.libIdent) {
+						let id = module.libIdent({
+							context: this.options.context || compiler.options.context
+						});
+						const hash = require("crypto").createHash(options.hashFunction);
+						hash.update(id);
+						id = hash.digest(options.hashDigest);
+						let len = options.hashDigestLength;
+						while(usedIds[id.substr(0, len)])
+							len++;
+						module.id = id.substr(0, len);
+						usedIds[module.id] = true;
+					}
+				});
+			});
+		});
+	}
 }
+
 module.exports = HashedModuleIdsPlugin;
-HashedModuleIdsPlugin.prototype.apply = function(compiler) {
-	var options = this.options;
-	compiler.plugin("compilation", function(compilation) {
-		var usedIds = {};
-		compilation.plugin("before-module-ids", function(modules) {
-			modules.forEach(function(module) {
-				if(module.id === null && module.libIdent) {
-					var id = module.libIdent({
-						context: this.options.context || compiler.options.context
-					});
-					var hash = require("crypto").createHash(options.hashFunction);
-					hash.update(id);
-					id = hash.digest(options.hashDigest);
-					var len = options.hashDigestLength;
-					while(usedIds[id.substr(0, len)])
-						len++;
-					module.id = id.substr(0, len);
-					usedIds[module.id] = true;
-				}
-			}, this);
-		}.bind(this));
-	}.bind(this));
-};

--- a/lib/HashedModuleIdsPlugin.js
+++ b/lib/HashedModuleIdsPlugin.js
@@ -16,7 +16,7 @@ class HashedModuleIdsPlugin {
 	apply(compiler) {
 		const options = this.options;
 		compiler.plugin("compilation", (compilation) => {
-			const usedIds = {};
+			const usedIds = new Set();
 			compilation.plugin("before-module-ids", (modules) => {
 				modules.forEach((module) => {
 					if(module.id === null && module.libIdent) {
@@ -27,10 +27,10 @@ class HashedModuleIdsPlugin {
 						hash.update(id);
 						id = hash.digest(options.hashDigest);
 						let len = options.hashDigestLength;
-						while(usedIds[id.substr(0, len)])
+						while(usedIds.has(id.substr(0, len)))
 							len++;
 						module.id = id.substr(0, len);
-						usedIds[module.id] = true;
+						usedIds.add(module.id);
 					}
 				});
 			});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Refactoring

**Did you add tests for your changes?**

No functionality was changed, tested in my project (webpack@2.2.0-rc.3)

**If relevant, link to documentation update:**

N/A

**Summary**

Upgrade HashedModuleIdsPlugin to es6.

**Does this PR introduce a breaking change?**

Nope
