### PR TITLE
Update missing should type check calls

### DIFF
--- a/test/Compiler-caching.test.js
+++ b/test/Compiler-caching.test.js
@@ -56,7 +56,7 @@ describe("Compiler (caching)", function() {
 				});
 				should.strictEqual(typeof stats, "object");
 				stats.should.have.property("errors");
-				Array.isArray(stats.errors).should.be.ok;
+				Array.isArray(stats.errors).should.be.ok();
 				if(options.expectErrors) {
 					stats.errors.length.should.be.eql(options.expectErrors);
 				} else {

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -46,7 +46,7 @@ describe("Compiler", function() {
 			});
 			should.strictEqual(typeof stats, "object");
 			stats.should.have.property("errors");
-			Array.isArray(stats.errors).should.be.ok;
+			Array.isArray(stats.errors).should.be.ok();
 			if(stats.errors.length > 0) {
 				stats.errors[0].should.be.instanceOf(Error);
 				throw stats.errors[0];

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -35,8 +35,8 @@ describe("Errors", function() {
 			should.strictEqual(typeof stats, "object");
 			stats.should.have.property("errors");
 			stats.should.have.property("warnings");
-			Array.isArray(stats.errors).should.be.ok; // eslint-disable-line no-unused-expressions
-			Array.isArray(stats.warnings).should.be.ok; // eslint-disable-line no-unused-expressions
+			Array.isArray(stats.errors).should.be.ok(); // eslint-disable-line no-unused-expressions
+			Array.isArray(stats.warnings).should.be.ok(); // eslint-disable-line no-unused-expressions
 			callback(stats.errors, stats.warnings);
 		});
 	}

--- a/test/Integration.test.js
+++ b/test/Integration.test.js
@@ -18,8 +18,8 @@ describe("Integration", function() {
 			}
 		}, function(err, stats) {
 			if(err) throw err;
-			stats.hasErrors().should.be.not.ok;
-			stats.hasWarnings().should.be.not.ok;
+			stats.hasErrors().should.be.not.ok();
+			stats.hasWarnings().should.be.not.ok();
 			done();
 		});
 	});
@@ -86,8 +86,8 @@ describe("Integration", function() {
 			]
 		}, function(err, stats) {
 			if(err) throw err;
-			stats.hasErrors().should.be.not.ok;
-			stats.hasWarnings().should.be.not.ok;
+			stats.hasErrors().should.be.not.ok();
+			stats.hasWarnings().should.be.not.ok();
 			done();
 		});
 	});

--- a/test/NodeTemplatePlugin.test.js
+++ b/test/NodeTemplatePlugin.test.js
@@ -22,8 +22,8 @@ describe("NodeTemplatePlugin", function() {
 			]
 		}, function(err, stats) {
 			if(err) return err;
-			stats.hasErrors().should.be.not.ok;
-			stats.hasWarnings().should.be.not.ok;
+			stats.hasErrors().should.be.not.ok();
+			stats.hasWarnings().should.be.not.ok();
 			var result = require("./js/result").abc;
 			result.nextTick.should.be.equal(process.nextTick);
 			result.fs.should.be.equal(require("fs"));
@@ -60,7 +60,7 @@ describe("NodeTemplatePlugin", function() {
 			]
 		}, function(err, stats) {
 			if(err) return err;
-			stats.hasErrors().should.be.not.ok;
+			stats.hasErrors().should.be.not.ok();
 			var result = require("./js/result2");
 			result.nextTick.should.be.equal(process.nextTick);
 			result.fs.should.be.equal(require("fs"));

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -104,14 +104,14 @@ describe("Stats", function() {
 					errors: ['firstError'],
 					hash: '1234'
 				});
-				mockStats.hasErrors().should.be.ok;
+				mockStats.hasErrors().should.be.ok();
 			});
 			it("hasWarnings", function() {
 				var mockStats = new Stats({
 					warnings: ['firstError'],
 					hash: '1234'
 				});
-				mockStats.hasWarnings().should.be.ok;
+				mockStats.hasWarnings().should.be.ok();
 			});
 		});
 		describe("does not have", function() {
@@ -120,14 +120,14 @@ describe("Stats", function() {
 					errors: [],
 					hash: '1234'
 				});
-				mockStats.hasErrors().should.not.be.ok;
+				mockStats.hasErrors().should.not.be.ok();
 			});
 			it("hasWarnings", function() {
 				var mockStats = new Stats({
 					warnings: [],
 					hash: '1234'
 				});
-				mockStats.hasWarnings().should.not.be.ok;
+				mockStats.hasWarnings().should.not.be.ok();
 			});
 		});
 		it("formatError handles string errors", function() {

--- a/test/cases/chunks/named-chunks/index.js
+++ b/test/cases/chunks/named-chunks/index.js
@@ -13,7 +13,7 @@ it("should handle named chunks", function(done) {
 		require.ensure([], function(require) {
 			require("./empty?c");
 			require("./empty?d");
-			sync.should.be.ok;
+			sync.should.be.ok();
 			done();
 		}, "named-chunk");
 	}
@@ -22,10 +22,10 @@ it("should handle named chunks", function(done) {
 it("should handle empty named chunks", function(done) {
 	var sync = false;
 	require.ensure([], function(require) {
-		sync.should.be.ok;
+		sync.should.be.ok();
 	}, "empty-named-chunk");
 	require.ensure([], function(require) {
-		sync.should.be.ok;
+		sync.should.be.ok();
 		done();
 	}, "empty-named-chunk");
 	sync = true;

--- a/test/cases/parsing/template-string/cjs.js
+++ b/test/cases/parsing/template-string/cjs.js
@@ -41,5 +41,5 @@ it("should parse template strings in require.resolve", function() {
 
 	// Arbitrary assertion; can't use .ok() as it could be 0,
 	// can't use typeof as that depends on webpack config.
-	require.resolve(`./sync/${name}Test`).should.not.be.undefined;
+	require.resolve(`./sync/${name}Test`).should.not.be.undefined();
 })

--- a/test/configCases/source-map/exclude-chunks-source-map/index.js
+++ b/test/configCases/source-map/exclude-chunks-source-map/index.js
@@ -9,7 +9,7 @@ it("should not produce a SourceMap for vendors chunk", function() {
 	var fs = require("fs"),
 			path = require("path"),
 			assert = require("assert");
-	fs.existsSync(path.join(__dirname, "vendors.js.map")).should.be.false;
+	fs.existsSync(path.join(__dirname, "vendors.js.map")).should.be.false();
 });
 
 require.include("./test.js");

--- a/test/configCases/target/buffer-default/index.js
+++ b/test/configCases/target/buffer-default/index.js
@@ -1,7 +1,7 @@
 require("should");
 
 it("should provide a global Buffer shim", function () {
-	Buffer.should.be.a.Function;
+	Buffer.should.be.a.Function();
 });
 
 it("should provide the buffer module", function () {

--- a/test/configCases/target/buffer/index.js
+++ b/test/configCases/target/buffer/index.js
@@ -1,7 +1,7 @@
 require("should");
 
 it("should provide a global Buffer shim", function () {
-	Buffer.should.be.a.Function;
+	Buffer.should.be.a.Function();
 });
 
 it("should fail on the buffer module"/*, function () {

--- a/test/configCases/target/web/index.js
+++ b/test/configCases/target/web/index.js
@@ -5,95 +5,95 @@ global.XMLHttpRequest = function() {};
 global.XMLHttpRequest.prototype.open = function() {};
 
 it("should provide a global Buffer constructor", function() {
-	Buffer.should.be.a.Function;
+	Buffer.should.be.a.Function();
 });
 
 // Webpack is not providing a console shim by default
 // @see lib/WebpackOptionsDefaulter.js
 // Uncomment this when defaults are changed
 //it("should provide a global console shim", function () {
-//	console.should.be.an.Object;
-//	console.time.should.be.a.Function;
+//	console.should.be.an.Object();
+//	console.time.should.be.a.Function();
 //});
 
 it("should provide a global process shim", function () {
-	process.should.be.an.Object;
+	process.should.be.an.Object();
 });
 
 it("should provide a global setImmediate shim", function () {
-	setImmediate.should.be.a.Function;
+	setImmediate.should.be.a.Function();
 });
 
 it("should provide a global clearImmediate shim", function () {
-	clearImmediate.should.be.a.Function;
+	clearImmediate.should.be.a.Function();
 });
 
 it("should provide an assert shim", function () {
-	require("assert").should.be.a.Function;
+	require("assert").should.be.a.Function();
 });
 
 it("should provide a util shim", function () {
-	require("util").should.be.an.Object;
+	require("util").should.be.an.Object();
 });
 
 it("should provide a buffer shim", function () {
-	require("buffer").should.be.an.Object;
+	require("buffer").should.be.an.Object();
 });
 
 it("should provide a crypto shim", function () {
-	require("crypto").should.be.an.Object;
+	require("crypto").should.be.an.Object();
 });
 
 it("should provide a domain shim", function () {
-	require("domain").should.be.an.Object;
+	require("domain").should.be.an.Object();
 });
 
 it("should provide an events shim", function () {
-	require("events").should.be.a.Function;
+	require("events").should.be.a.Function();
 });
 
 it("should provide an http shim", function () {
-	require("http").should.be.an.Object;
+	require("http").should.be.an.Object();
 });
 
 it("should provide an https shim", function () {
-	require("https").should.be.an.Object;
+	require("https").should.be.an.Object();
 });
 
 it("should provide an os shim", function () {
-	require("os").should.be.an.Object;
+	require("os").should.be.an.Object();
 });
 
 it("should provide a path shim", function () {
-	require("path").should.be.an.Object;
+	require("path").should.be.an.Object();
 });
 
 it("should provide a punycode shim", function () {
-	require("punycode").should.be.an.Object;
+	require("punycode").should.be.an.Object();
 });
 
 it("should provide a stream shim", function () {
-	require("stream").should.be.a.Function;
+	require("stream").should.be.a.Function();
 });
 
 it("should provide a tty shim", function () {
-	require("tty").should.be.an.Object;
+	require("tty").should.be.an.Object();
 });
 
 it("should provide a url shim", function () {
-	require("url").should.be.an.Object;
+	require("url").should.be.an.Object();
 });
 
 it("should provide a util shim", function () {
-	require("util").should.be.an.Object;
+	require("util").should.be.an.Object();
 });
 
 it("should provide a vm shim", function () {
-	require("vm").should.be.an.Object;
+	require("vm").should.be.an.Object();
 });
 
 it("should provide a zlib shim", function () {
-	require("zlib").should.be.an.Object;
+	require("zlib").should.be.an.Object();
 });
 
 it("should provide a shim for a path in a build-in module", function () {

--- a/test/configCases/target/webworker/index.js
+++ b/test/configCases/target/webworker/index.js
@@ -5,92 +5,92 @@ global.XMLHttpRequest = function() {};
 global.XMLHttpRequest.prototype.open = function() {};
 
 it("should provide a global Buffer constructor", function() {
-	Buffer.should.be.a.Function;
+	Buffer.should.be.a.Function();
 });
 
 it("should provide a global console shim", function () {
-	console.should.be.an.Object;
-	console.time.should.be.a.Function;
+	console.should.be.an.Object();
+	console.time.should.be.a.Function();
 });
 
 it("should provide a global process shim", function () {
-	process.should.be.an.Object;
+	process.should.be.an.Object();
 });
 
 it("should provide a global setImmediate shim", function () {
-	setImmediate.should.be.a.Function;
+	setImmediate.should.be.a.Function();
 });
 
 it("should provide a global clearImmediate shim", function () {
-	clearImmediate.should.be.a.Function;
+	clearImmediate.should.be.a.Function();
 });
 
 it("should provide an assert shim", function () {
-	require("assert").should.be.a.Function;
+	require("assert").should.be.a.Function();
 });
 
 it("should provide a util shim", function () {
-	require("util").should.be.an.Object;
+	require("util").should.be.an.Object();
 });
 
 it("should provide a buffer shim", function () {
-	require("buffer").should.be.an.Object;
+	require("buffer").should.be.an.Object();
 });
 
 it("should provide a crypto shim", function () {
-	require("crypto").should.be.an.Object;
+	require("crypto").should.be.an.Object();
 });
 
 it("should provide a domain shim", function () {
-	require("domain").should.be.an.Object;
+	require("domain").should.be.an.Object();
 });
 
 it("should provide an events shim", function () {
-	require("events").should.be.a.Function;
+	require("events").should.be.a.Function();
 });
 
 it("should provide an http shim", function () {
-	require("http").should.be.an.Object;
+	require("http").should.be.an.Object();
 });
 
 it("should provide an https shim", function () {
-	require("https").should.be.an.Object;
+	require("https").should.be.an.Object();
 });
 
 it("should provide an os shim", function () {
-	require("os").should.be.an.Object;
+	require("os").should.be.an.Object();
 });
 
 it("should provide a path shim", function () {
-	require("path").should.be.an.Object;
+	require("path").should.be.an.Object();
 });
 
 it("should provide a punycode shim", function () {
-	require("punycode").should.be.an.Object;
+	require("punycode").should.be.an.Object();
 });
 
 it("should provide a stream shim", function () {
-	require("stream").should.be.a.Function;
+	require("stream").should.be.a.Function();
 });
 
 it("should provide a tty shim", function () {
-	require("tty").should.be.an.Object;
+	require("tty").should.be.an.Object();
 });
 
 it("should provide a url shim", function () {
-	require("url").should.be.an.Object;
+	require("url").should.be.an.Object();
 });
 
 it("should provide a util shim", function () {
-	require("util").should.be.an.Object;
+	require("util").should.be.an.Object();
 });
 
 it("should provide a vm shim", function () {
-	require("vm").should.be.an.Object;
+	require("vm").should.be.an.Object();
 });
 
 it("should provide a zlib shim", function () {
-	require("zlib").should.be.an.Object;
+	require("zlib").should.be.an.Object();
 });
 
 it("should provide a shim for a path in a build-in module", function () {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Test bugfix

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

This PR is only tests

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

`should` type checks need to be called to error if the type check fails. Without calling, the test essentially has an empty body and will pass regardless.

Change made using find/replace in sublime
 - Find: `(\.be\.[^(;]+);`
 - Replace: `\1();`

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**

None
