### PR TITLE
Add tests for SourceMapDevToolModuleOptionsPlugin

### DIFF
--- a/test/SourceMapDevToolModuleOptionsPlugin.test.js
+++ b/test/SourceMapDevToolModuleOptionsPlugin.test.js
@@ -1,0 +1,137 @@
+var should = require("should");
+var SourceMapDevToolModuleOptionsPlugin = require("../lib/SourceMapDevToolModuleOptionsPlugin");
+var applyPluginWithOptions = require('./helpers/applyPluginWithOptions');
+
+describe("SourceMapDevToolModuleOptionsPlugin", function() {
+	it("has apply function", function() {
+		(new SourceMapDevToolModuleOptionsPlugin()).apply.should.be.a.Function();
+	});
+
+	describe("when applied", function() {
+		var eventBindings;
+
+		beforeEach(function() {
+			eventBindings = undefined;
+		});
+
+		describe("with module false and line-to-line false", function() {
+			beforeEach(function() {
+				eventBindings = applyPluginWithOptions(SourceMapDevToolModuleOptionsPlugin, {
+					module: false,
+					lineToLine: false
+				});
+			});
+
+			it("does not bind any event handlers", function() {
+				eventBindings.length.should.be.exactly(0);
+			});
+		});
+
+		describe("with module true", function() {
+			beforeEach(function() {
+				eventBindings = applyPluginWithOptions(SourceMapDevToolModuleOptionsPlugin, {
+					module: true,
+					lineToLine: false
+				});
+			});
+
+			it("binds one event handler", function() {
+				eventBindings.length.should.be.exactly(1);
+			});
+
+			describe("event handler", function() {
+				it("binds to build-module event", function() {
+					eventBindings[0].name.should.be.exactly("build-module");
+				});
+
+				it("sets source map flag", function() {
+					var module = {};
+					eventBindings[0].handler(module);
+					module.should.deepEqual({
+						useSourceMap: true
+					});
+				});
+			});
+		});
+
+		describe("with line-to-line true", function() {
+			beforeEach(function() {
+				eventBindings = applyPluginWithOptions(SourceMapDevToolModuleOptionsPlugin, {
+					module: false,
+					lineToLine: true
+				});
+			});
+
+			it("binds one event handler", function() {
+				eventBindings.length.should.be.exactly(1);
+			});
+
+			describe("event handler", function() {
+				it("binds to build-module event", function() {
+					eventBindings[0].name.should.be.exactly("build-module");
+				});
+
+				it("sets line-to-line flag", function() {
+					var module = {};
+					eventBindings[0].handler(module);
+					module.should.deepEqual({
+						lineToLine: true
+					});
+				});
+			});
+		});
+
+		describe("with line-to-line object", function() {
+			beforeEach(function() {
+				eventBindings = applyPluginWithOptions(SourceMapDevToolModuleOptionsPlugin, {
+					module: false,
+					lineToLine: {}
+				});
+			});
+
+			it("binds one event handler", function() {
+				eventBindings.length.should.be.exactly(1);
+			});
+
+			describe("event handler", function() {
+				it("binds to build-module event", function() {
+					eventBindings[0].name.should.be.exactly("build-module");
+				});
+
+				describe("when module has no resource", function() {
+					it("makes no changes", function() {
+						var module = {};
+						eventBindings[0].handler(module);
+						module.should.deepEqual({});
+					});
+				});
+
+				describe("when module has a resource", function() {
+					it("sets line-to-line flag", function() {
+						var module = {
+							resource: "foo"
+						};
+						eventBindings[0].handler(module);
+						module.should.deepEqual({
+							lineToLine: true,
+							resource: "foo"
+						});
+					});
+				});
+
+				describe("when module has a resource with query", function() {
+					it("sets line-to-line flag", function() {
+						var module = {
+							resource: "foo?bar"
+						};
+						eventBindings[0].handler(module);
+						module.should.deepEqual({
+							lineToLine: true,
+							resource: "foo?bar"
+						});
+					});
+				});
+			});
+		});
+	});
+});

--- a/test/helpers/applyPluginWithOptions.js
+++ b/test/helpers/applyPluginWithOptions.js
@@ -1,0 +1,25 @@
+function PluginEnvironment() {
+	var events = [];
+
+	this.getCompilerStub = function() {
+		return {
+			plugin: function(name, handler) {
+				events.push({
+					name,
+					handler
+				});
+			}
+		};
+	};
+
+	this.getEventBindings = function() {
+		return events;
+	};
+}
+
+module.exports = function applyPluginWithOptions(Plugin, options) {
+	var plugin = new Plugin(options);
+	var pluginEnvironment = new PluginEnvironment();
+	plugin.apply(pluginEnvironment.getCompilerStub());
+	return pluginEnvironment.getEventBindings();
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Add tests for SourceMapDevToolModuleOptionsPlugin

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

This PR is only tests

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Based on the coveralls report, the `SourceMapDevToolModuleOptionsPlugin` file has 68% test coverage. There is no `SourceMapDevToolModuleOptionsPlugin` specific test file - this is added in this PR and aims to achieve 100% test coverage.
https://coveralls.io/builds/9491731/source?filename=lib%2FSourceMapDevToolModuleOptionsPlugin.js

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**

This PR introduces a helper function for testing plugins. The new function, `applyPluginWithOptions`, allows the plugin logic to be called with different options, and then exposes the event bindings the plugin uses, allowing the corresponding handlers to then be tested.
See #3685 for an follow-up PR which also makes use of this helper.