### PR TITLE
Add webworkerhotupdatechunktemplateplugin tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "memory-fs": "~0.4.1",
     "mkdirp": "~0.5.0",
     "node-libs-browser": "^2.0.0",
+    "sinon": "^1.17.7",
     "source-map": "^0.5.3",
     "supports-color": "^3.1.0",
     "tapable": "~0.2.5",

--- a/test/WebWorkerHotUpdateChunkTemplatePlugin.test.js
+++ b/test/WebWorkerHotUpdateChunkTemplatePlugin.test.js
@@ -1,0 +1,85 @@
+var should = require("should");
+var sinon = require("sinon");
+var ConcatSource = require("webpack-sources").ConcatSource;
+var WebWorkerHotUpdateChunkTemplatePlugin = require("../lib/webworker/WebWorkerHotUpdateChunkTemplatePlugin");
+var applyPluginWithOptions = require("./helpers/applyPluginWithOptions");
+
+describe("WebWorkerHotUpdateChunkTemplatePlugin", function() {
+	var handlerContext;
+
+	beforeEach(function() {
+		handlerContext = {
+			outputOptions: {
+				hotUpdateFunction: "Foo",
+				library: "Bar"
+			}
+		};
+	});
+
+	it("has apply function", function() {
+		(new WebWorkerHotUpdateChunkTemplatePlugin()).apply.should.be.a.Function();
+	});
+
+	describe("when applied", function() {
+		var eventBindings, eventBinding;
+
+		beforeEach(function() {
+			eventBindings = applyPluginWithOptions(WebWorkerHotUpdateChunkTemplatePlugin);
+		});
+
+		it("binds two event handlers", function() {
+			eventBindings.length.should.be.exactly(2);
+		});
+
+		describe("render handler", function() {
+			beforeEach(function() {
+				eventBinding = eventBindings[0];
+			});
+
+			it("binds to render event", function() {
+				eventBinding.name.should.be.exactly("render");
+			});
+
+			describe("with hot update function name set", function() {
+				it("creates source wrapper with function name", function() {
+					var source = eventBinding.handler.call(handlerContext, "moduleSource()", [], [], {}, 100);
+					source.should.be.instanceof(ConcatSource);
+					source.source().should.be.exactly("Foo(100,moduleSource())");
+				});
+			});
+
+			describe("without hot update function name set", function() {
+				it("creates source wrapper with library name", function() {
+					delete handlerContext.outputOptions.hotUpdateFunction;
+					var source = eventBinding.handler.call(handlerContext, "moduleSource()", [], [], {}, 100);
+					source.should.be.instanceof(ConcatSource);
+					source.source().should.be.exactly("webpackHotUpdateBar(100,moduleSource())");
+				});
+			});
+		});
+
+		describe("hash handler", function() {
+			var hashMock;
+
+			beforeEach(function() {
+				eventBinding = eventBindings[1];
+				hashMock = {
+					update: sinon.spy()
+				};
+			});
+
+			it("binds to hash event", function() {
+				eventBinding.name.should.be.exactly("hash");
+			});
+
+			it("updates hash object", function() {
+				eventBinding.handler.call(handlerContext, hashMock);
+				hashMock.update.callCount.should.be.exactly(4);
+				sinon.assert.calledWith(hashMock.update, "WebWorkerHotUpdateChunkTemplatePlugin");
+				sinon.assert.calledWith(hashMock.update, "3");
+				sinon.assert.calledWith(hashMock.update, "Foo");
+				sinon.assert.calledWith(hashMock.update, "Bar");
+			});
+		});
+	});
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1140,6 +1140,16 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-plugin-node@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-3.0.5.tgz#03c8e23c6011eabd240e7ebf3556ec6e50fc734e"
+  dependencies:
+    ignore "^3.0.11"
+    minimatch "^3.0.2"
+    object-assign "^4.0.1"
+    resolve "^1.1.7"
+    semver "5.3.0"
+
 eslint@3.12.2:
   version "3.12.2"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.12.2.tgz#6be5a9aa29658252abd7f91e9132bab1f26f3c34"
@@ -1427,6 +1437,12 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+formatio@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+  dependencies:
+    samsam "~1.1"
+
 forwarded@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.0.tgz#19ef9874c4ae1c297bcf078fde63a09b66a84363"
@@ -1702,7 +1718,7 @@ ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
-ignore@^3.2.0:
+ignore@^3.0.11, ignore@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.0.tgz#8d88f03c3002a0ac52114db25d2c673b0bf1e435"
 
@@ -2231,6 +2247,10 @@ lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.3, lodash@^4.3.0:
 log-driver@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
+
+lolex@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -3300,7 +3320,7 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@1.1.x, resolve@^1.1.6:
+resolve@1.1.x, resolve@^1.1.6, resolve@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
@@ -3343,6 +3363,10 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+samsam@1.1.2, samsam@~1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+
 sax@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
@@ -3353,7 +3377,7 @@ script-loader@~0.7.0:
   dependencies:
     raw-loader "~0.5.1"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@~5.3.0:
+"semver@2 || 3 || 4 || 5", semver@5.3.0, semver@^5.0.3, semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
@@ -3474,6 +3498,15 @@ sigmund@^1.0.1:
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon@^1.17.7:
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+  dependencies:
+    formatio "1.1.1"
+    lolex "1.3.2"
+    samsam "1.1.2"
+    util ">=0.10.3 <1"
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -3873,7 +3906,7 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-util@0.10.3, util@^0.10.3:
+util@0.10.3, "util@>=0.10.3 <1", util@^0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   dependencies:
@@ -3924,7 +3957,7 @@ void-elements@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
 
-watchpack@^1.0.0:
+watchpack@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.2.0.tgz#15d4620f1e7471f13fcb551d5c030d2c3eb42dbb"
   dependencies:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Add tests for webworkerhotupdatechunktemplateplugin

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

This PR is only tests

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Based on the coveralls report, the `webworkerhotupdatechunktemplateplugin` file has 41% test coverage. There is no `webworkerhotupdatechunktemplateplugin` specific test file - this is added in this PR and aims to achieve 100% test coverage.
https://coveralls.io/builds/9491731/source?filename=lib%2Fwebworker%2FWebWorkerHotUpdateChunkTemplatePlugin.js

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**

This PR is branched off PR #3684, which introduces the `applyPluginWithOptions` helper function. This helper has been used for testing this plugin too.
This PR also introduces [`sinon`](https://www.npmjs.com/package/sinon) (as [recommended by mocha](https://github.com/mochajs/mocha/wiki/Spies)) to help with checking if callbacks are called, and if they are called with the correct parameters.