### PR TITLE
refactor amd-define dependency to es6

### DIFF
--- a/lib/dependencies/AMDDefineDependency.js
+++ b/lib/dependencies/AMDDefineDependency.js
@@ -2,113 +2,137 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var NullDependency = require("./NullDependency");
+"use strict";
+const NullDependency = require("./NullDependency");
 
-function AMDDefineDependency(range, arrayRange, functionRange, objectRange) {
-	NullDependency.call(this);
-	this.range = range;
-	this.arrayRange = arrayRange;
-	this.functionRange = functionRange;
-	this.objectRange = objectRange;
+class AMDDefineDependency extends NullDependency {
+	constructor(range, arrayRange, functionRange, objectRange) {
+		super();
+		this.range = range;
+		this.arrayRange = arrayRange;
+		this.functionRange = functionRange;
+		this.objectRange = objectRange;
+	}
+
+	get type() {
+		return "amd define";
+	}
 }
-module.exports = AMDDefineDependency;
 
-AMDDefineDependency.prototype = Object.create(NullDependency.prototype);
-AMDDefineDependency.prototype.constructor = AMDDefineDependency;
-AMDDefineDependency.prototype.type = "amd define";
+AMDDefineDependency.Template = class AMDDefineDependencyTemplate {
+	get definitions() {
+		return {
+			f: [
+				"var __WEBPACK_AMD_DEFINE_RESULT__;",
+				`!(__WEBPACK_AMD_DEFINE_RESULT__ = #.call(exports, __webpack_require__, exports, module),
+				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__))`
+			],
+			o: [
+				"",
+				"!(module.exports = #)"
+			],
+			of: [
+				"var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;",
+				`!(__WEBPACK_AMD_DEFINE_FACTORY__ = (#),
+				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
+				(__WEBPACK_AMD_DEFINE_FACTORY__.call(exports, __webpack_require__, exports, module)) :
+				__WEBPACK_AMD_DEFINE_FACTORY__),
+				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__))`
+			],
+			af: [
+				"var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;",
+				`!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, __WEBPACK_AMD_DEFINE_RESULT__ = #.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
+				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__))`
+			],
+			ao: [
+				"",
+				"!(#, module.exports = #)"
+			],
+			aof: [
+				"var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;",
+				`!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, __WEBPACK_AMD_DEFINE_FACTORY__ = (#),
+				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
+				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
+				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__))`
+			],
+			lf: [
+				"var XXX;",
+				"!(XXX = #.call(exports, __webpack_require__, exports, module))"
+			],
+			lo: [
+				"var XXX;",
+				"!(XXX = #)"
+			],
+			lof: [
+				"var __WEBPACK_AMD_DEFINE_FACTORY__, XXX;",
+				`!(__WEBPACK_AMD_DEFINE_FACTORY__ = (#), XXX = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
+				(__WEBPACK_AMD_DEFINE_FACTORY__.call(exports, __webpack_require__, exports, module)) : __WEBPACK_AMD_DEFINE_FACTORY__))`
+			],
+			laf: [
+				"var __WEBPACK_AMD_DEFINE_ARRAY__, XXX;",
+				"!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, XXX = (#.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)))"
+			],
+			lao: [
+				"var XXX;",
+				"!(#, XXX = #)"
+			],
+			laof: [
+				"var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_FACTORY__, XXX;",
+				`!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, __WEBPACK_AMD_DEFINE_FACTORY__ = (#),
+				XXX = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
+				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__))`
+			]
+		};
+	}
 
-AMDDefineDependency.Template = function AMDDefineDependencyTemplate() {};
+	apply(dependency, source) {
+		const branch = this.branch(dependency);
+		const defAndText = this.definitions[branch];
+		const definitions = defAndText[0];
+		const text = defAndText[1];
+		this.replace(dependency, source, definitions, text);
+	}
 
-AMDDefineDependency.Template.prototype.apply = function(dep, source) {
-	var localModuleVar = dep.localModule && dep.localModule.used && dep.localModule.variableName();
+	localModuleVar(dependency) {
+		return dependency.localModule && dependency.localModule.used && dependency.localModule.variableName();
+	}
 
-	function replace(def, text) {
-		if(localModuleVar) text = text.replace(/XXX/g, localModuleVar.replace(/\$/g, "$$$$"));
-		if(localModuleVar) def = def.replace(/XXX/g, localModuleVar.replace(/\$/g, "$$$$"));
-		var texts = text.split("#");
-		if(def)
-			source.insert(0, def);
-		var current = dep.range[0];
-		if(dep.arrayRange) {
-			source.replace(current, dep.arrayRange[0] - 1, texts.shift());
-			current = dep.arrayRange[1];
+	branch(dependency) {
+		const localModuleVar = this.localModuleVar(dependency) ? "l" : "";
+		const arrayRange = dependency.arrayRange ? "a" : "";
+		const objectRange = dependency.objectRange ? "o" : "";
+		const functionRange = dependency.functionRange ? "f" : "";
+		return localModuleVar + arrayRange + objectRange + functionRange;
+	}
+
+	replace(dependency, source, definition, text) {
+		const localModuleVar = this.localModuleVar(dependency);
+		if(localModuleVar) {
+			text = text.replace(/XXX/g, localModuleVar.replace(/\$/g, "$$$$"));
+			definition = definition.replace(/XXX/g, localModuleVar.replace(/\$/g, "$$$$"));
 		}
-		if(dep.objectRange) {
-			source.replace(current, dep.objectRange[0] - 1, texts.shift());
-			current = dep.objectRange[1];
-		} else if(dep.functionRange) {
-			source.replace(current, dep.functionRange[0] - 1, texts.shift());
-			current = dep.functionRange[1];
+
+		const texts = text.split("#");
+
+		if(definition) source.insert(0, definition);
+
+		let current = dependency.range[0];
+		if(dependency.arrayRange) {
+			source.replace(current, dependency.arrayRange[0] - 1, texts.shift());
+			current = dependency.arrayRange[1];
 		}
-		source.replace(current, dep.range[1] - 1, texts.shift());
+
+		if(dependency.objectRange) {
+			source.replace(current, dependency.objectRange[0] - 1, texts.shift());
+			current = dependency.objectRange[1];
+		} else if(dependency.functionRange) {
+			source.replace(current, dependency.functionRange[0] - 1, texts.shift());
+			current = dependency.functionRange[1];
+		}
+		source.replace(current, dependency.range[1] - 1, texts.shift());
 		if(texts.length > 0)
 			throw new Error("Implementation error");
 	}
-	var branch = (localModuleVar ? "l" : "") +
-		(dep.arrayRange ? "a" : "") +
-		(dep.objectRange ? "o" : "") +
-		(dep.functionRange ? "f" : "");
-	var defs = {
-		f: [
-			"var __WEBPACK_AMD_DEFINE_RESULT__;",
-			"!(__WEBPACK_AMD_DEFINE_RESULT__ = #.call(exports, __webpack_require__, exports, module), " +
-			"__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__))"
-		],
-		o: [
-			"",
-			"!(module.exports = #)"
-		],
-		of: [
-			"var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;",
-			"!(__WEBPACK_AMD_DEFINE_FACTORY__ = (#), " +
-			"__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? " +
-			"(__WEBPACK_AMD_DEFINE_FACTORY__.call(exports, __webpack_require__, exports, module)) : " +
-			"__WEBPACK_AMD_DEFINE_FACTORY__), " +
-			"__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__))"
-		],
-		af: [
-			"var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;",
-			"!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, __WEBPACK_AMD_DEFINE_RESULT__ = #.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), " +
-			"__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__))"
-		],
-		ao: [
-			"",
-			"!(#, module.exports = #)"
-		],
-		aof: [
-			"var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;",
-			"!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, __WEBPACK_AMD_DEFINE_FACTORY__ = (#), " +
-			"__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? " +
-			"(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__), " +
-			"__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__))"
-		],
-		lf: [
-			"var XXX;",
-			"!(XXX = #.call(exports, __webpack_require__, exports, module))"
-		],
-		lo: [
-			"var XXX;",
-			"!(XXX = #)"
-		],
-		lof: [
-			"var __WEBPACK_AMD_DEFINE_FACTORY__, XXX;",
-			"!(__WEBPACK_AMD_DEFINE_FACTORY__ = (#), XXX = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? " +
-			"(__WEBPACK_AMD_DEFINE_FACTORY__.call(exports, __webpack_require__, exports, module)) : __WEBPACK_AMD_DEFINE_FACTORY__))"
-		],
-		laf: [
-			"var __WEBPACK_AMD_DEFINE_ARRAY__, XXX;",
-			"!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, XXX = (#.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)))"
-		],
-		lao: [
-			"var XXX;",
-			"!(#, XXX = #)"
-		],
-		laof: [
-			"var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_FACTORY__, XXX;",
-			"!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, __WEBPACK_AMD_DEFINE_FACTORY__ = (#), " +
-			"XXX = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ? " +
-			"(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__))"
-		]
-	};
-	replace.apply(null, defs[branch]);
-};
+}
+
+module.exports = AMDDefineDependency;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

current tests should pass

**If relevant, link to documentation update:**

N/A

**Summary**

upgrade AMDDefineDependency and AMDDefineDependencyTemplate to es6

**Does this PR introduce a breaking change?**

No