### PR TITLE
Add hotupdatechunktemplateplugin tests

### DIFF
--- a/test/JsonpHotUpdateChunkTemplatePlugin.test.js
+++ b/test/JsonpHotUpdateChunkTemplatePlugin.test.js
@@ -1,0 +1,74 @@
+var should = require("should");
+var sinon = require("sinon");
+var ConcatSource = require("webpack-sources").ConcatSource;
+var JsonpHotUpdateChunkTemplatePlugin = require("../lib/JsonpHotUpdateChunkTemplatePlugin");
+var applyPluginWithOptions = require("./helpers/applyPluginWithOptions");
+
+describe("JsonpHotUpdateChunkTemplatePlugin", function() {
+	var handlerContext;
+
+	beforeEach(function() {
+		handlerContext = {
+			outputOptions: {
+				hotUpdateFunction: "Foo",
+				library: "Bar"
+			}
+		};
+	});
+
+	it("has apply function", function() {
+		(new JsonpHotUpdateChunkTemplatePlugin()).apply.should.be.a.Function();
+	});
+
+	describe("when applied", function() {
+		var eventBindings, eventBinding;
+
+		beforeEach(function() {
+			eventBindings = applyPluginWithOptions(JsonpHotUpdateChunkTemplatePlugin);
+		});
+
+		it("binds two event handlers", function() {
+			eventBindings.length.should.be.exactly(2);
+		});
+
+		describe("render handler", function() {
+			beforeEach(function() {
+				eventBinding = eventBindings[0];
+			});
+
+			it("binds to render event", function() {
+				eventBinding.name.should.be.exactly("render");
+			});
+
+			it("creates source wrapper with export", function() {
+				var source = eventBinding.handler.call(handlerContext, "moduleSource()", [], [], {}, 100);
+				source.should.be.instanceof(ConcatSource);
+				source.source().should.be.exactly("Foo(100,moduleSource())");
+			});
+		});
+
+		describe("hash handler", function() {
+			var hashMock;
+
+			beforeEach(function() {
+				eventBinding = eventBindings[1];
+				hashMock = {
+					update: sinon.spy()
+				};
+			});
+
+			it("binds to hash event", function() {
+				eventBinding.name.should.be.exactly("hash");
+			});
+
+			it("updates hash object", function() {
+				eventBinding.handler.call(handlerContext, hashMock);
+				hashMock.update.callCount.should.be.exactly(4);
+				sinon.assert.calledWith(hashMock.update, "JsonpHotUpdateChunkTemplatePlugin");
+				sinon.assert.calledWith(hashMock.update, "3");
+				sinon.assert.calledWith(hashMock.update, "Foo");
+				sinon.assert.calledWith(hashMock.update, "Bar");
+			});
+		});
+	});
+});

--- a/test/NodeHotUpdateChunkTemplatePlugin.test.js
+++ b/test/NodeHotUpdateChunkTemplatePlugin.test.js
@@ -1,0 +1,74 @@
+var should = require("should");
+var sinon = require("sinon");
+var ConcatSource = require("webpack-sources").ConcatSource;
+var NodeHotUpdateChunkTemplatePlugin = require("../lib/node/NodeHotUpdateChunkTemplatePlugin");
+var applyPluginWithOptions = require("./helpers/applyPluginWithOptions");
+
+describe("NodeHotUpdateChunkTemplatePlugin", function() {
+	var handlerContext;
+
+	beforeEach(function() {
+		handlerContext = {
+			outputOptions: {
+				hotUpdateFunction: "Foo",
+				library: "Bar"
+			}
+		};
+	});
+
+	it("has apply function", function() {
+		(new NodeHotUpdateChunkTemplatePlugin()).apply.should.be.a.Function();
+	});
+
+	describe("when applied", function() {
+		var eventBindings, eventBinding;
+
+		beforeEach(function() {
+			eventBindings = applyPluginWithOptions(NodeHotUpdateChunkTemplatePlugin);
+		});
+
+		it("binds two event handlers", function() {
+			eventBindings.length.should.be.exactly(2);
+		});
+
+		describe("render handler", function() {
+			beforeEach(function() {
+				eventBinding = eventBindings[0];
+			});
+
+			it("binds to render event", function() {
+				eventBinding.name.should.be.exactly("render");
+			});
+
+			it("creates source wrapper with export", function() {
+				var source = eventBinding.handler.call(handlerContext, "moduleSource()", [], [], {}, 100);
+				source.should.be.instanceof(ConcatSource);
+				source.source().should.be.exactly("exports.id = 100;\nexports.modules = moduleSource();");
+			});
+		});
+
+		describe("hash handler", function() {
+			var hashMock;
+
+			beforeEach(function() {
+				eventBinding = eventBindings[1];
+				hashMock = {
+					update: sinon.spy()
+				};
+			});
+
+			it("binds to hash event", function() {
+				eventBinding.name.should.be.exactly("hash");
+			});
+
+			it("updates hash object", function() {
+				eventBinding.handler.call(handlerContext, hashMock);
+				hashMock.update.callCount.should.be.exactly(4);
+				sinon.assert.calledWith(hashMock.update, "NodeHotUpdateChunkTemplatePlugin");
+				sinon.assert.calledWith(hashMock.update, "3");
+				sinon.assert.calledWith(hashMock.update, "Foo");
+				sinon.assert.calledWith(hashMock.update, "Bar");
+			});
+		});
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Add tests for two HotUpdateChunkTemplate plugins

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

This PR is only tests

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Based on the coveralls report, the `JsonpHotUpdateChunkTemplatePlugin` file has 75% test coverage. 
https://coveralls.io/builds/9498055/source?filename=lib%2FJsonpHotUpdateChunkTemplatePlugin.js

Based on the coveralls report, the `NodeHotUpdateChunkTemplatePlugin` file has 73% test coverage. 
https://coveralls.io/builds/9498425/source?filename=lib%2Fnode%2FNodeHotUpdateChunkTemplatePlugin.js

There are no `JsonpHotUpdateChunkTemplatePlugin` or `NodeHotUpdateChunkTemplatePlugin` specific test files - these are added in this PR and aim to achieve 100% test coverage.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**

These tests are similar in structure to the test added for `WebWorkerHotUpdateChunkTemplatePlugin` in PR #3685