### PR TITLE
Add tests for RequireJsStuffPlugin

### DIFF
--- a/test/RequireJsStuffPlugin.test.js
+++ b/test/RequireJsStuffPlugin.test.js
@@ -1,0 +1,209 @@
+var should = require("should");
+var sinon = require("sinon");
+var RequireJsStuffPlugin = require("../lib/RequireJsStuffPlugin");
+var applyPluginWithOptions = require("./helpers/applyPluginWithOptions");
+var PluginEnvironment = require("./helpers/PluginEnvironment");
+
+describe("RequireJsStuffPlugin", function() {
+	it("has apply function", function() {
+		(new RequireJsStuffPlugin()).apply.should.be.a.Function();
+	});
+
+	describe("when applied", function() {
+		var eventBindings, eventBinding;
+
+		beforeEach(function() {
+			eventBindings = applyPluginWithOptions(RequireJsStuffPlugin);
+		});
+
+		it("binds one event handler", function() {
+			eventBindings.length.should.be.exactly(1);
+		});
+
+		describe("compilation handler", function() {
+			beforeEach(function() {
+				eventBinding = eventBindings[0];
+			});
+
+			it("binds to compilation event", function() {
+				eventBinding.name.should.be.exactly("compilation");
+			});
+
+			describe('when called', function() {
+				var pluginEnvironment, compilationEventBindings, compilation;
+
+				beforeEach(function() {
+					pluginEnvironment = new PluginEnvironment();
+					compilation = {
+						dependencyFactories: {
+							set: sinon.spy()
+						},
+						dependencyTemplates: {
+							set: sinon.spy()
+						}
+					};
+					var params = {
+						normalModuleFactory: pluginEnvironment.getEnvironmentStub()
+					};
+					eventBinding.handler(compilation, params);
+					compilationEventBindings = pluginEnvironment.getEventBindings();
+				});
+
+				it('sets the dependency factory', function() {
+					compilation.dependencyFactories.set.callCount.should.be.exactly(1);
+				});
+
+				it('sets the dependency template', function() {
+					compilation.dependencyTemplates.set.callCount.should.be.exactly(1);
+				});
+
+				it("binds one event handler", function() {
+					compilationEventBindings.length.should.be.exactly(1);
+				});
+
+				describe("parser handler", function() {
+					var parser, parserEventBindings;
+
+					beforeEach(function() {
+						compilationEventBinding = compilationEventBindings[0];
+						pluginEnvironment = new PluginEnvironment();
+						parser = pluginEnvironment.getEnvironmentStub();
+					});
+
+					it("binds to parser event", function() {
+						compilationEventBinding.name.should.be.exactly("parser");
+					});
+
+					describe('when called with parser options of requirejs as false', function() {
+						beforeEach(function() {
+							compilationEventBinding.handler(parser, {
+								requireJs: false
+							});
+							parserEventBindings = pluginEnvironment.getEventBindings();
+						});
+
+						it("binds no event handlers", function() {
+							parserEventBindings.length.should.be.exactly(0);
+						});
+					});
+
+					describe('when called with empty parser options', function() {
+						var parserEventBinding, parserEventContext, expressionMock;
+
+						beforeEach(function() {
+							parserEventContext = {
+								state: {
+									current: {
+										addDependency: sinon.spy()
+									}
+								}
+							};
+							expressionMock = {
+								range: 10,
+								loc: 5
+							};
+							compilationEventBinding.handler(parser, {});
+							parserEventBindings = pluginEnvironment.getEventBindings();
+						});
+
+						it("binds four event handlers", function() {
+							parserEventBindings.length.should.be.exactly(4);
+						});
+
+						describe("'call require.config' handler", function() {
+							beforeEach(function() {
+								parserEventBinding = parserEventBindings[0];
+							});
+
+							it("binds to 'call require.config' event", function() {
+								parserEventBinding.name.should.be.exactly("call require.config");
+							});
+
+							describe('when called', function() {
+								beforeEach(function() {
+									parserEventBinding.handler.call(parserEventContext, expressionMock);
+								});
+
+								it('adds dependency to current state', function() {
+									var addDependencySpy = parserEventContext.state.current.addDependency;
+									var addedDependency = JSON.stringify(addDependencySpy.getCall(0).args[0]);
+									addDependencySpy.callCount.should.be.exactly(1);
+									addedDependency.should.be.exactly('{"module":null,"expression":";","range":10,"loc":5}');
+								});
+							});
+						});
+
+						describe("'call requirejs.config' handler", function() {
+							beforeEach(function() {
+								parserEventBinding = parserEventBindings[1];
+							});
+
+							it("binds to 'call requirejs.config' event", function() {
+								parserEventBinding.name.should.be.exactly("call requirejs.config");
+							});
+
+							describe('when called', function() {
+								beforeEach(function() {
+									parserEventBinding.handler.call(parserEventContext, expressionMock);
+								});
+
+								it('adds dependency to current state', function() {
+									var addDependencySpy = parserEventContext.state.current.addDependency;
+									var addedDependency = JSON.stringify(addDependencySpy.getCall(0).args[0]);
+									addDependencySpy.callCount.should.be.exactly(1);
+									addedDependency.should.be.exactly('{"module":null,"expression":";","range":10,"loc":5}');
+								});
+							});
+						});
+
+						describe("'expression require.version' handler", function() {
+							beforeEach(function() {
+								parserEventBinding = parserEventBindings[2];
+							});
+
+							it("binds to 'expression require.version' event", function() {
+								parserEventBinding.name.should.be.exactly("expression require.version");
+							});
+
+							describe('when called', function() {
+								beforeEach(function() {
+									parserEventBinding.handler.call(parserEventContext, expressionMock);
+								});
+
+								it('adds dependency to current state', function() {
+									var addDependencySpy = parserEventContext.state.current.addDependency;
+									var addedDependency = JSON.stringify(addDependencySpy.getCall(0).args[0]);
+									addDependencySpy.callCount.should.be.exactly(1);
+									addedDependency.should.be.exactly('{"module":null,"expression":"\\"0.0.0\\"","range":10,"loc":5}');
+								});
+							});
+						});
+
+						describe("'expression requirejs.onError' handler", function() {
+							beforeEach(function() {
+								parserEventBinding = parserEventBindings[3];
+							});
+
+							it("binds to 'expression requirejs.onError' event", function() {
+								parserEventBinding.name.should.be.exactly("expression requirejs.onError");
+							});
+
+							describe('when called', function() {
+								beforeEach(function() {
+									parserEventBinding.handler.call(parserEventContext, expressionMock);
+								});
+
+								it('adds dependency to current state', function() {
+									var addDependencySpy = parserEventContext.state.current.addDependency;
+									var addedDependency = JSON.stringify(addDependencySpy.getCall(0).args[0]);
+									addDependencySpy.callCount.should.be.exactly(1);
+									addedDependency.should.be.exactly('{"module":null,"expression":"\\"__webpack_require__.oe\\"","range":10,"loc":5}');
+								});
+							});
+						});
+					});
+				});
+			});
+		});
+	});
+});

--- a/test/helpers/PluginEnvironment.js
+++ b/test/helpers/PluginEnvironment.js
@@ -1,0 +1,18 @@
+module.exports = function PluginEnvironment() {
+	var events = [];
+
+	this.getEnvironmentStub = function() {
+		return {
+			plugin: function(name, handler) {
+				events.push({
+					name,
+					handler
+				});
+			}
+		};
+	};
+
+	this.getEventBindings = function() {
+		return events;
+	};
+};

--- a/test/helpers/applyPluginWithOptions.js
+++ b/test/helpers/applyPluginWithOptions.js
@@ -1,25 +1,8 @@
-function PluginEnvironment() {
-	var events = [];
-
-	this.getCompilerStub = function() {
-		return {
-			plugin: function(name, handler) {
-				events.push({
-					name,
-					handler
-				});
-			}
-		};
-	};
-
-	this.getEventBindings = function() {
-		return events;
-	};
-}
+var PluginEnvironment = require('./PluginEnvironment');
 
 module.exports = function applyPluginWithOptions(Plugin, options) {
 	var plugin = new Plugin(options);
 	var pluginEnvironment = new PluginEnvironment();
-	plugin.apply(pluginEnvironment.getCompilerStub());
+	plugin.apply(pluginEnvironment.getEnvironmentStub());
 	return pluginEnvironment.getEventBindings();
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Add tests for RequireJsStuffPlugin

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

This PR is only tests

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Based on the coveralls report, the `RequireJsStuffPlugin` file has 82% test coverage. There is no `RequireJsStuffPlugin` specific test file - this is added in this PR and aims to achieve 100% test coverage.
https://coveralls.io/builds/9498425/source?filename=lib%2FRequireJsStuffPlugin.js

This plugin, although a higher percentage test coverage than other files, was taken on as an example of how to test nested event bindings. This PR extracts the `PluginEnvironment` helper into a separate file, and makes use of it in order to capture internal event handlers for testing.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**

None