### PR TITLE
Add tests for CaseSensitiveModulesWarning

### DIFF
--- a/test/CaseSensitiveModulesWarning.test.js
+++ b/test/CaseSensitiveModulesWarning.test.js
@@ -1,0 +1,55 @@
+var should = require("should");
+var CaseSensitiveModulesWarning = require("../lib/CaseSensitiveModulesWarning");
+
+var createModule = function(identifier, numberOfReasons) {
+	var reasons = new Array(numberOfReasons || 0).fill(null).map(function(value, index) {
+		return {
+			module: createModule(`${identifier}-reason-${index}`)
+		};
+	});
+
+	return {
+		identifier: () => identifier,
+		reasons
+	};
+};
+
+describe("CaseSensitiveModulesWarning", function() {
+	var myCaseSensitiveModulesWarning, modules;
+
+	beforeEach(function() {
+		modules = [
+			createModule('FooBar', 1),
+			createModule('foobar', 2),
+			createModule('FOOBAR')
+		];
+		myCaseSensitiveModulesWarning = new CaseSensitiveModulesWarning(modules);
+	});
+
+	it('has the a name', function() {
+		myCaseSensitiveModulesWarning.name.should.be.exactly('CaseSensitiveModulesWarning');
+	});
+
+	it('has the a message', function() {
+		myCaseSensitiveModulesWarning.message.should.be.exactly(`
+There are multiple modules with names that only differ in casing.
+This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
+Use equal casing. Compare these module identifiers:
+* FOOBAR
+* FooBar
+    Used by 1 module(s), i. e.
+    FooBar-reason-0
+* foobar
+    Used by 2 module(s), i. e.
+    foobar-reason-0
+`.trim());
+	});
+
+	it('has the an origin', function() {
+		myCaseSensitiveModulesWarning.origin.should.be.exactly(modules[0]);
+	});
+
+	it('has the a module', function() {
+		myCaseSensitiveModulesWarning.module.should.be.exactly(modules[0]);
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Add tests for CaseSensitiveModulesWarning

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

This PR is only tests

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Based on the coveralls report, the `CaseSensitiveModulesWarning` file has 18% test coverage. There is no `CaseSensitiveModulesWarning` specific test file - this is added in this PR and aims to achieve 100% test coverage.
https://coveralls.io/builds/9506896/source?filename=lib%2FCaseSensitiveModulesWarning.js

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**

The coverage of this file appears to depend on whether it is called in other tests (in other builds it has a coverage of 95%) - https://coveralls.io/builds/9506579/source?filename=lib%2FCaseSensitiveModulesWarning.js