### PR TITLE
Refactor harmony export import specifier dependency to es6

### DIFF
--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -139,13 +139,15 @@ module.exports = HarmonyExportImportedSpecifierDependency;
 
 HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedSpecifierDependencyTemplate {
 	apply(dep, source, outputOptions, requestShortener) {
+		const content = this.getContent(dep);
+		source.insert(-1, content);
+	}
+
+	getContent(dep) {
 		const name = dep.importedVar;
 		const used = dep.originModule.isUsed(dep.name);
 		const importedModule = dep.importDependency.module;
 		const active = HarmonyModulesHelpers.isActive(dep.originModule, dep);
-		let content;
-		let activeExports;
-		let items;
 		const importsExportsUnknown = !importedModule || !Array.isArray(importedModule.providedExports);
 
 		function getReexportStatement(key, valueKey) {
@@ -154,20 +156,31 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 				"__webpack_require__.d(exports, " + key + ", " +
 				"function() { return " + name + (valueKey === null ? "_default.a" : valueKey && "[" + valueKey + "]") + "; });\n"
 		}
+
 		if(!used) { // we want to rexport something, but the export isn't used
-			content = "/* unused harmony reexport " + dep.name + " */\n";
-		} else if(!active) { // we want to reexport something but another exports overrides this one
-			content = "/* inactive harmony reexport " + (dep.name || "namespace") + " */\n";
-		} else if(dep.name && dep.id === "default" && !(importedModule && (!importedModule.meta || importedModule.meta.harmonyModule))) { // we want to reexport the default export from a non-hamory module
-			content = "/* harmony reexport (default from non-hamory) */ " + getReexportStatement(JSON.stringify(used), null);
-		} else if(dep.name && dep.id) { // we want to reexport a key as new key
+			return "/* unused harmony reexport " + dep.name + " */\n";
+		}
+
+		if(!active) { // we want to reexport something but another exports overrides this one
+			return "/* inactive harmony reexport " + (dep.name || "namespace") + " */\n";
+		}
+
+		if(dep.name && dep.id === "default" && !(importedModule && (!importedModule.meta || importedModule.meta.harmonyModule))) { // we want to reexport the default export from a non-hamory module
+			return "/* harmony reexport (default from non-hamory) */ " + getReexportStatement(JSON.stringify(used), null);
+		}
+
+		if(dep.name && dep.id) { // we want to reexport a key as new key
 			var idUsed = importedModule && importedModule.isUsed(dep.id);
-			content = "/* harmony reexport (binding) */ " + getReexportStatement(JSON.stringify(used), JSON.stringify(idUsed));
-		} else if(dep.name) { // we want to reexport the module object as named export
-			content = "/* harmony reexport (module object) */ " + getReexportStatement(JSON.stringify(used), "");
-		} else if(Array.isArray(dep.originModule.usedExports)) { // we know which exports are used
-			activeExports = HarmonyModulesHelpers.getActiveExports(dep.originModule, dep);
-			items = dep.originModule.usedExports.map(function(id) {
+			return "/* harmony reexport (binding) */ " + getReexportStatement(JSON.stringify(used), JSON.stringify(idUsed));
+		}
+
+		if(dep.name) { // we want to reexport the module object as named export
+			return "/* harmony reexport (module object) */ " + getReexportStatement(JSON.stringify(used), "");
+		}
+
+		if(Array.isArray(dep.originModule.usedExports)) { // we know which exports are used
+			const activeExports = HarmonyModulesHelpers.getActiveExports(dep.originModule, dep);
+			const items = dep.originModule.usedExports.map(function(id) {
 				if(id === "default") return;
 				if(activeExports.indexOf(id) >= 0) return;
 				if(importedModule.isProvided(id) === false) return;
@@ -176,13 +189,17 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 				return [exportUsed, idUsed];
 			}).filter(Boolean);
 			if(items.length > 0) {
-				content = items.map(function(item) {
+				return items.map(function(item) {
 					return "/* harmony namespace reexport (by used) */ " + getReexportStatement(JSON.stringify(item[0]), JSON.stringify(item[1]));
 				}).join("");
-			} else content = "/* unused harmony namespace reexport */\n";
-		} else if(dep.originModule.usedExports && importedModule && Array.isArray(importedModule.providedExports)) { // not sure which exports are used, but we know which are provided
-			activeExports = HarmonyModulesHelpers.getActiveExports(dep.originModule, dep);
-			items = importedModule.providedExports.map(function(id) {
+			}
+
+			return "/* unused harmony namespace reexport */\n";
+		}
+
+		if(dep.originModule.usedExports && importedModule && Array.isArray(importedModule.providedExports)) { // not sure which exports are used, but we know which are provided
+			const activeExports = HarmonyModulesHelpers.getActiveExports(dep.originModule, dep);
+			const items = importedModule.providedExports.map(function(id) {
 				if(id === "default") return;
 				if(activeExports.indexOf(id) >= 0) return;
 				var exportUsed = dep.originModule.isUsed(id);
@@ -190,13 +207,17 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 				return [exportUsed, idUsed];
 			}).filter(Boolean);
 			if(items.length > 0) {
-				content = items.map(function(item) {
+				return items.map(function(item) {
 					return "/* harmony namespace reexport (by provided) */ " + getReexportStatement(JSON.stringify(item[0]), JSON.stringify(item[1]));
 				}).join("");
-			} else content = "/* empty harmony namespace reexport */\n";
-		} else if(dep.originModule.usedExports) { // not sure which exports are used and provided
-			activeExports = HarmonyModulesHelpers.getActiveExports(dep.originModule, dep);
-			content = "/* harmony namespace reexport (unknown) */ for(var __WEBPACK_IMPORT_KEY__ in " + name + ") ";
+			}
+
+			return "/* empty harmony namespace reexport */\n";
+		}
+
+		if(dep.originModule.usedExports) { // not sure which exports are used and provided
+			const activeExports = HarmonyModulesHelpers.getActiveExports(dep.originModule, dep);
+			let content = "/* harmony namespace reexport (unknown) */ for(var __WEBPACK_IMPORT_KEY__ in " + name + ") ";
 
 			// Filter out exports which are defined by other exports
 			// and filter out default export because it cannot be reexported with *
@@ -204,10 +225,9 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 				content += "if(" + JSON.stringify(activeExports.concat("default")) + ".indexOf(__WEBPACK_IMPORT_KEY__) < 0) ";
 			else
 				content += "if(__WEBPACK_IMPORT_KEY__ !== 'default') ";
-			content += "(function(key) { __webpack_require__.d(exports, key, function() { return " + name + "[key]; }) }(__WEBPACK_IMPORT_KEY__));\n";
-		} else {
-			content = "/* unused harmony reexport namespace */\n";
+			return content + "(function(key) { __webpack_require__.d(exports, key, function() { return " + name + "[key]; }) }(__WEBPACK_IMPORT_KEY__));\n";
 		}
-		source.insert(-1, content);
+
+		return "/* unused harmony reexport namespace */\n";
 	}
 }

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -137,77 +137,77 @@ class HarmonyExportImportedSpecifierDependency extends NullDependency {
 
 module.exports = HarmonyExportImportedSpecifierDependency;
 
-HarmonyExportImportedSpecifierDependency.Template = function HarmonyExportImportedSpecifierDependencyTemplate() {};
+HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedSpecifierDependencyTemplate {
+	apply(dep, source, outputOptions, requestShortener) {
+		const name = dep.importedVar;
+		const used = dep.originModule.isUsed(dep.name);
+		const importedModule = dep.importDependency.module;
+		const active = HarmonyModulesHelpers.isActive(dep.originModule, dep);
+		let content;
+		let activeExports;
+		let items;
+		const importsExportsUnknown = !importedModule || !Array.isArray(importedModule.providedExports);
 
-HarmonyExportImportedSpecifierDependency.Template.prototype.apply = function(dep, source, outputOptions, requestShortener) {
-	var name = dep.importedVar;
-	var used = dep.originModule.isUsed(dep.name);
-	var importedModule = dep.importDependency.module;
-	var active = HarmonyModulesHelpers.isActive(dep.originModule, dep);
-	var content;
-	var activeExports;
-	var items;
-	var importsExportsUnknown = !importedModule || !Array.isArray(importedModule.providedExports);
+		function getReexportStatement(key, valueKey) {
+			var conditional = !importsExportsUnknown || !valueKey ? "" : "if(__webpack_require__.o(" + name + ", " + valueKey + ")) ";
+			return conditional +
+				"__webpack_require__.d(exports, " + key + ", " +
+				"function() { return " + name + (valueKey === null ? "_default.a" : valueKey && "[" + valueKey + "]") + "; });\n"
+		}
+		if(!used) { // we want to rexport something, but the export isn't used
+			content = "/* unused harmony reexport " + dep.name + " */\n";
+		} else if(!active) { // we want to reexport something but another exports overrides this one
+			content = "/* inactive harmony reexport " + (dep.name || "namespace") + " */\n";
+		} else if(dep.name && dep.id === "default" && !(importedModule && (!importedModule.meta || importedModule.meta.harmonyModule))) { // we want to reexport the default export from a non-hamory module
+			content = "/* harmony reexport (default from non-hamory) */ " + getReexportStatement(JSON.stringify(used), null);
+		} else if(dep.name && dep.id) { // we want to reexport a key as new key
+			var idUsed = importedModule && importedModule.isUsed(dep.id);
+			content = "/* harmony reexport (binding) */ " + getReexportStatement(JSON.stringify(used), JSON.stringify(idUsed));
+		} else if(dep.name) { // we want to reexport the module object as named export
+			content = "/* harmony reexport (module object) */ " + getReexportStatement(JSON.stringify(used), "");
+		} else if(Array.isArray(dep.originModule.usedExports)) { // we know which exports are used
+			activeExports = HarmonyModulesHelpers.getActiveExports(dep.originModule, dep);
+			items = dep.originModule.usedExports.map(function(id) {
+				if(id === "default") return;
+				if(activeExports.indexOf(id) >= 0) return;
+				if(importedModule.isProvided(id) === false) return;
+				var exportUsed = dep.originModule.isUsed(id);
+				var idUsed = importedModule && importedModule.isUsed(id);
+				return [exportUsed, idUsed];
+			}).filter(Boolean);
+			if(items.length > 0) {
+				content = items.map(function(item) {
+					return "/* harmony namespace reexport (by used) */ " + getReexportStatement(JSON.stringify(item[0]), JSON.stringify(item[1]));
+				}).join("");
+			} else content = "/* unused harmony namespace reexport */\n";
+		} else if(dep.originModule.usedExports && importedModule && Array.isArray(importedModule.providedExports)) { // not sure which exports are used, but we know which are provided
+			activeExports = HarmonyModulesHelpers.getActiveExports(dep.originModule, dep);
+			items = importedModule.providedExports.map(function(id) {
+				if(id === "default") return;
+				if(activeExports.indexOf(id) >= 0) return;
+				var exportUsed = dep.originModule.isUsed(id);
+				var idUsed = importedModule && importedModule.isUsed(id);
+				return [exportUsed, idUsed];
+			}).filter(Boolean);
+			if(items.length > 0) {
+				content = items.map(function(item) {
+					return "/* harmony namespace reexport (by provided) */ " + getReexportStatement(JSON.stringify(item[0]), JSON.stringify(item[1]));
+				}).join("");
+			} else content = "/* empty harmony namespace reexport */\n";
+		} else if(dep.originModule.usedExports) { // not sure which exports are used and provided
+			activeExports = HarmonyModulesHelpers.getActiveExports(dep.originModule, dep);
+			content = "/* harmony namespace reexport (unknown) */ for(var __WEBPACK_IMPORT_KEY__ in " + name + ") ";
 
-	function getReexportStatement(key, valueKey) {
-		var conditional = !importsExportsUnknown || !valueKey ? "" : "if(__webpack_require__.o(" + name + ", " + valueKey + ")) ";
-		return conditional +
-			"__webpack_require__.d(exports, " + key + ", " +
-			"function() { return " + name + (valueKey === null ? "_default.a" : valueKey && "[" + valueKey + "]") + "; });\n"
+			// Filter out exports which are defined by other exports
+			// and filter out default export because it cannot be reexported with *
+			if(activeExports.length > 0)
+				content += "if(" + JSON.stringify(activeExports.concat("default")) + ".indexOf(__WEBPACK_IMPORT_KEY__) < 0) ";
+			else
+				content += "if(__WEBPACK_IMPORT_KEY__ !== 'default') ";
+			content += "(function(key) { __webpack_require__.d(exports, key, function() { return " + name + "[key]; }) }(__WEBPACK_IMPORT_KEY__));\n";
+		} else {
+			content = "/* unused harmony reexport namespace */\n";
+		}
+		source.insert(-1, content);
 	}
-	if(!used) { // we want to rexport something, but the export isn't used
-		content = "/* unused harmony reexport " + dep.name + " */\n";
-	} else if(!active) { // we want to reexport something but another exports overrides this one
-		content = "/* inactive harmony reexport " + (dep.name || "namespace") + " */\n";
-	} else if(dep.name && dep.id === "default" && !(importedModule && (!importedModule.meta || importedModule.meta.harmonyModule))) { // we want to reexport the default export from a non-hamory module
-		content = "/* harmony reexport (default from non-hamory) */ " + getReexportStatement(JSON.stringify(used), null);
-	} else if(dep.name && dep.id) { // we want to reexport a key as new key
-		var idUsed = importedModule && importedModule.isUsed(dep.id);
-		content = "/* harmony reexport (binding) */ " + getReexportStatement(JSON.stringify(used), JSON.stringify(idUsed));
-	} else if(dep.name) { // we want to reexport the module object as named export
-		content = "/* harmony reexport (module object) */ " + getReexportStatement(JSON.stringify(used), "");
-	} else if(Array.isArray(dep.originModule.usedExports)) { // we know which exports are used
-		activeExports = HarmonyModulesHelpers.getActiveExports(dep.originModule, dep);
-		items = dep.originModule.usedExports.map(function(id) {
-			if(id === "default") return;
-			if(activeExports.indexOf(id) >= 0) return;
-			if(importedModule.isProvided(id) === false) return;
-			var exportUsed = dep.originModule.isUsed(id);
-			var idUsed = importedModule && importedModule.isUsed(id);
-			return [exportUsed, idUsed];
-		}).filter(Boolean);
-		if(items.length > 0) {
-			content = items.map(function(item) {
-				return "/* harmony namespace reexport (by used) */ " + getReexportStatement(JSON.stringify(item[0]), JSON.stringify(item[1]));
-			}).join("");
-		} else content = "/* unused harmony namespace reexport */\n";
-	} else if(dep.originModule.usedExports && importedModule && Array.isArray(importedModule.providedExports)) { // not sure which exports are used, but we know which are provided
-		activeExports = HarmonyModulesHelpers.getActiveExports(dep.originModule, dep);
-		items = importedModule.providedExports.map(function(id) {
-			if(id === "default") return;
-			if(activeExports.indexOf(id) >= 0) return;
-			var exportUsed = dep.originModule.isUsed(id);
-			var idUsed = importedModule && importedModule.isUsed(id);
-			return [exportUsed, idUsed];
-		}).filter(Boolean);
-		if(items.length > 0) {
-			content = items.map(function(item) {
-				return "/* harmony namespace reexport (by provided) */ " + getReexportStatement(JSON.stringify(item[0]), JSON.stringify(item[1]));
-			}).join("");
-		} else content = "/* empty harmony namespace reexport */\n";
-	} else if(dep.originModule.usedExports) { // not sure which exports are used and provided
-		activeExports = HarmonyModulesHelpers.getActiveExports(dep.originModule, dep);
-		content = "/* harmony namespace reexport (unknown) */ for(var __WEBPACK_IMPORT_KEY__ in " + name + ") ";
-
-		// Filter out exports which are defined by other exports
-		// and filter out default export because it cannot be reexported with *
-		if(activeExports.length > 0)
-			content += "if(" + JSON.stringify(activeExports.concat("default")) + ".indexOf(__WEBPACK_IMPORT_KEY__) < 0) ";
-		else
-			content += "if(__WEBPACK_IMPORT_KEY__ !== 'default') ";
-		content += "(function(key) { __webpack_require__.d(exports, key, function() { return " + name + "[key]; }) }(__WEBPACK_IMPORT_KEY__));\n";
-	} else {
-		content = "/* unused harmony reexport namespace */\n";
-	}
-	source.insert(-1, content);
-};
+}

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -85,31 +85,31 @@ class HarmonyExportImportedSpecifierDependency extends NullDependency {
 		}
 
 		const importedModule = this.importDependency.module;
-		if(importedModule && Array.isArray(importedModule.providedExports)) {
+
+		if(!importedModule) {
+			// no imported module available
 			return {
-				exports: importedModule.providedExports.filter(function(id) {
-					return id !== "default"
-				}),
+				exports: null
+			};
+		}
+
+		if(Array.isArray(importedModule.providedExports)) {
+			return {
+				exports: importedModule.providedExports.filter(id => id !== "default"),
 				dependencies: [importedModule]
 			};
 		}
 
-		if(importedModule && importedModule.providedExports) {
+		if(importedModule.providedExports) {
 			return {
 				exports: true
 			};
 		}
 
-		if(importedModule) {
-			return {
-				exports: null,
-				dependencies: [importedModule]
-			};
-		}
-
 		return {
-			exports: null
-		}
+			exports: null,
+			dependencies: [importedModule]
+		};
 	}
 
 	describeHarmonyExport() {

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -21,59 +21,69 @@ class HarmonyExportImportedSpecifierDependency extends NullDependency {
 	}
 
 	getReference() {
-		const used = this.originModule.isUsed(this.name);
+		const name = this.name;
+		const used = this.originModule.isUsed(name);
 		const active = HarmonyModulesHelpers.isActive(this.originModule, this);
-		if(!this.importDependency.module || !used || !active) return null;
-		if(!this.originModule.usedExports) return null;
 		const importedModule = this.importDependency.module;
-		if(!this.name) {
-			// export *
-			if(Array.isArray(this.originModule.usedExports)) {
-				// reexport * with known used exports
-				var activeExports = HarmonyModulesHelpers.getActiveExports(this.originModule, this);
-				if(Array.isArray(importedModule.providedExports)) {
-					return {
-						module: importedModule,
-						importedNames: this.originModule.usedExports.filter(function(id) {
-							return activeExports.indexOf(id) < 0 && importedModule.providedExports.indexOf(id) >= 0 && id !== "default";
-						}, this)
-					}
-				} else {
-					return {
-						module: importedModule,
-						importedNames: this.originModule.usedExports.filter(function(id) {
-							return activeExports.indexOf(id) < 0 && id !== "default";
-						}, this)
-					}
-				}
-			} else if(Array.isArray(importedModule.providedExports)) {
-				return {
-					module: importedModule,
-					importedNames: importedModule.providedExports.filter(function(id) {
-						return id !== "default"
-					})
-				}
-			} else {
-				return {
-					module: importedModule,
-					importedNames: true
-				}
-			}
-		} else {
-			if(Array.isArray(this.originModule.usedExports) && this.originModule.usedExports.indexOf(this.name) < 0) return null;
+
+		if(!importedModule || !used || !active) return null;
+		if(!this.originModule.usedExports) return null;
+
+		if(name) {
+			const nameIsNotInUsedExports = Array.isArray(this.originModule.usedExports) && this.originModule.usedExports.indexOf(name) < 0;
+			if(nameIsNotInUsedExports) return null;
+
+			// export { name as name }
 			if(this.id) {
-				// export { name as name }
 				return {
 					module: importedModule,
 					importedNames: [this.id]
 				};
-			} else {
-				// export { * as name }
+			}
+
+			// export { * as name }
+			return {
+				module: importedModule,
+				importedNames: true
+			};
+		}
+
+		// export *
+		if(Array.isArray(this.originModule.usedExports)) {
+			// reexport * with known used exports
+			var activeExports = HarmonyModulesHelpers.getActiveExports(this.originModule, this);
+			if(Array.isArray(importedModule.providedExports)) {
 				return {
 					module: importedModule,
-					importedNames: true
-				};
+					importedNames: this.originModule.usedExports.filter((id) => {
+						const notInActiveExports = activeExports.indexOf(id) < 0;
+						const notDefault = id !== "default";
+						const inProvidedExports = importedModule.providedExports.indexOf(id) >= 0;
+						return notInActiveExports && notDefault && inProvidedExports;
+					}),
+				}
 			}
+
+			return {
+				module: importedModule,
+				importedNames: this.originModule.usedExports.filter(id => {
+					const notInActiveExports = activeExports.indexOf(id) < 0;
+					const notDefault = id !== "default";
+					return notInActiveExports && notDefault;
+				}),
+			}
+		}
+
+		if(Array.isArray(importedModule.providedExports)) {
+			return {
+				module: importedModule,
+				importedNames: importedModule.providedExports.filter(id => id !== "default"),
+			}
+		}
+
+		return {
+			module: importedModule,
+			importedNames: true,
 		}
 	}
 

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -152,28 +152,35 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 
 		const getReexportStatement = this.reexportStatementCreator(importsExportsUnknown, name);
 
-		if(!used) { // we want to rexport something, but the export isn't used
+		// we want to rexport something, but the export isn't used
+		if(!used) {
 			return "/* unused harmony reexport " + dep.name + " */\n";
 		}
 
-		if(!active) { // we want to reexport something but another exports overrides this one
+		// we want to reexport something but another exports overrides this one
+		if(!active) {
 			return "/* inactive harmony reexport " + (dep.name || "namespace") + " */\n";
 		}
 
-		if(dep.name && dep.id === "default" && !(importedModule && (!importedModule.meta || importedModule.meta.harmonyModule))) { // we want to reexport the default export from a non-hamory module
+		// we want to reexport the default export from a non-hamory module
+		const isNotAHarmonyModule = !(importedModule && (!importedModule.meta || importedModule.meta.harmonyModule));
+		if(dep.name && dep.id === "default" && isNotAHarmonyModule) {
 			return "/* harmony reexport (default from non-hamory) */ " + getReexportStatement(JSON.stringify(used), null);
 		}
 
-		if(dep.name && dep.id) { // we want to reexport a key as new key
+		// we want to reexport a key as new key
+		if(dep.name && dep.id) {
 			var idUsed = importedModule && importedModule.isUsed(dep.id);
 			return "/* harmony reexport (binding) */ " + getReexportStatement(JSON.stringify(used), JSON.stringify(idUsed));
 		}
 
-		if(dep.name) { // we want to reexport the module object as named export
+		// we want to reexport the module object as named export
+		if(dep.name) {
 			return "/* harmony reexport (module object) */ " + getReexportStatement(JSON.stringify(used), "");
 		}
 
-		if(Array.isArray(dep.originModule.usedExports)) { // we know which exports are used
+		// we know which exports are used
+		if(Array.isArray(dep.originModule.usedExports)) {
 			const activeExports = HarmonyModulesHelpers.getActiveExports(dep.originModule, dep);
 			const items = dep.originModule.usedExports.map(function(id) {
 				if(id === "default") return;
@@ -183,16 +190,18 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 				var idUsed = importedModule && importedModule.isUsed(id);
 				return [exportUsed, idUsed];
 			}).filter(Boolean);
-			if(items.length > 0) {
-				return items.map(function(item) {
-					return "/* harmony namespace reexport (by used) */ " + getReexportStatement(JSON.stringify(item[0]), JSON.stringify(item[1]));
-				}).join("");
+
+			if(items.length === 0) {
+				return "/* unused harmony namespace reexport */\n";
 			}
 
-			return "/* unused harmony namespace reexport */\n";
+			return items.map(function(item) {
+				return "/* harmony namespace reexport (by used) */ " + getReexportStatement(JSON.stringify(item[0]), JSON.stringify(item[1]));
+			}).join("");
 		}
 
-		if(dep.originModule.usedExports && importedModule && Array.isArray(importedModule.providedExports)) { // not sure which exports are used, but we know which are provided
+		// not sure which exports are used, but we know which are provided
+		if(dep.originModule.usedExports && importedModule && Array.isArray(importedModule.providedExports)) {
 			const activeExports = HarmonyModulesHelpers.getActiveExports(dep.originModule, dep);
 			const items = importedModule.providedExports.map(function(id) {
 				if(id === "default") return;
@@ -201,16 +210,18 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 				var idUsed = importedModule && importedModule.isUsed(id);
 				return [exportUsed, idUsed];
 			}).filter(Boolean);
-			if(items.length > 0) {
-				return items.map(function(item) {
-					return "/* harmony namespace reexport (by provided) */ " + getReexportStatement(JSON.stringify(item[0]), JSON.stringify(item[1]));
-				}).join("");
+
+			if(items.length === 0) {
+				return "/* empty harmony namespace reexport */\n";
 			}
 
-			return "/* empty harmony namespace reexport */\n";
+			return items.map(function(item) {
+				return "/* harmony namespace reexport (by provided) */ " + getReexportStatement(JSON.stringify(item[0]), JSON.stringify(item[1]));
+			}).join("");
 		}
 
-		if(dep.originModule.usedExports) { // not sure which exports are used and provided
+		// not sure which exports are used and provided
+		if(dep.originModule.usedExports) {
 			const activeExports = HarmonyModulesHelpers.getActiveExports(dep.originModule, dep);
 			let content = "/* harmony namespace reexport (unknown) */ for(var __WEBPACK_IMPORT_KEY__ in " + name + ") ";
 

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -2,130 +2,140 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var NullDependency = require("./NullDependency");
-var HarmonyModulesHelpers = require("./HarmonyModulesHelpers");
+"use strict";
+const NullDependency = require("./NullDependency");
+const HarmonyModulesHelpers = require("./HarmonyModulesHelpers");
 
-function HarmonyExportImportedSpecifierDependency(originModule, importDependency, importedVar, id, name) {
-	NullDependency.call(this);
-	this.originModule = originModule;
-	this.importDependency = importDependency;
-	this.importedVar = importedVar;
-	this.id = id;
-	this.name = name;
-}
-module.exports = HarmonyExportImportedSpecifierDependency;
+class HarmonyExportImportedSpecifierDependency extends NullDependency {
+	constructor(originModule, importDependency, importedVar, id, name) {
+		super();
+		this.originModule = originModule;
+		this.importDependency = importDependency;
+		this.importedVar = importedVar;
+		this.id = id;
+		this.name = name;
+	}
 
-HarmonyExportImportedSpecifierDependency.prototype = Object.create(NullDependency.prototype);
-HarmonyExportImportedSpecifierDependency.prototype.constructor = HarmonyExportImportedSpecifierDependency;
-HarmonyExportImportedSpecifierDependency.prototype.type = "harmony export imported specifier";
+	get type() {
+		return "harmony export imported specifier";
+	}
 
-HarmonyExportImportedSpecifierDependency.prototype.getReference = function() {
-	var used = this.originModule.isUsed(this.name);
-	var active = HarmonyModulesHelpers.isActive(this.originModule, this);
-	if(!this.importDependency.module || !used || !active) return null;
-	if(!this.originModule.usedExports) return null;
-	var m = this.importDependency.module;
-	if(!this.name) {
-		// export *
-		if(Array.isArray(this.originModule.usedExports)) {
-			// reexport * with known used exports
-			var activeExports = HarmonyModulesHelpers.getActiveExports(this.originModule, this);
-			if(Array.isArray(m.providedExports)) {
+	getReference() {
+		const used = this.originModule.isUsed(this.name);
+		const active = HarmonyModulesHelpers.isActive(this.originModule, this);
+		if(!this.importDependency.module || !used || !active) return null;
+		if(!this.originModule.usedExports) return null;
+		const importedModule = this.importDependency.module;
+		if(!this.name) {
+			// export *
+			if(Array.isArray(this.originModule.usedExports)) {
+				// reexport * with known used exports
+				var activeExports = HarmonyModulesHelpers.getActiveExports(this.originModule, this);
+				if(Array.isArray(importedModule.providedExports)) {
+					return {
+						module: importedModule,
+						importedNames: this.originModule.usedExports.filter(function(id) {
+							return activeExports.indexOf(id) < 0 && importedModule.providedExports.indexOf(id) >= 0 && id !== "default";
+						}, this)
+					}
+				} else {
+					return {
+						module: importedModule,
+						importedNames: this.originModule.usedExports.filter(function(id) {
+							return activeExports.indexOf(id) < 0 && id !== "default";
+						}, this)
+					}
+				}
+			} else if(Array.isArray(importedModule.providedExports)) {
 				return {
-					module: m,
-					importedNames: this.originModule.usedExports.filter(function(id) {
-						return activeExports.indexOf(id) < 0 && m.providedExports.indexOf(id) >= 0 && id !== "default";
-					}, this)
+					module: importedModule,
+					importedNames: importedModule.providedExports.filter(function(id) {
+						return id !== "default"
+					})
 				}
 			} else {
 				return {
-					module: m,
-					importedNames: this.originModule.usedExports.filter(function(id) {
-						return activeExports.indexOf(id) < 0 && id !== "default";
-					}, this)
+					module: importedModule,
+					importedNames: true
 				}
 			}
-		} else if(Array.isArray(m.providedExports)) {
+		} else {
+			if(Array.isArray(this.originModule.usedExports) && this.originModule.usedExports.indexOf(this.name) < 0) return null;
+			if(this.id) {
+				// export { name as name }
+				return {
+					module: importedModule,
+					importedNames: [this.id]
+				};
+			} else {
+				// export { * as name }
+				return {
+					module: importedModule,
+					importedNames: true
+				};
+			}
+		}
+	}
+
+	getExports() {
+		if(this.name) {
 			return {
-				module: m,
-				importedNames: m.providedExports.filter(function(id) {
+				exports: [this.name]
+			}
+		}
+
+		const importedModule = this.importDependency.module;
+		if(importedModule && Array.isArray(importedModule.providedExports)) {
+			return {
+				exports: importedModule.providedExports.filter(function(id) {
 					return id !== "default"
-				})
-			}
-		} else {
-			return {
-				module: m,
-				importedNames: true
-			}
-		}
-	} else {
-		if(Array.isArray(this.originModule.usedExports) && this.originModule.usedExports.indexOf(this.name) < 0) return null;
-		if(this.id) {
-			// export { name as name }
-			return {
-				module: m,
-				importedNames: [this.id]
-			};
-		} else {
-			// export { * as name }
-			return {
-				module: m,
-				importedNames: true
+				}),
+				dependencies: [importedModule]
 			};
 		}
-	}
-};
 
-HarmonyExportImportedSpecifierDependency.prototype.getExports = function() {
-	if(this.name) {
+		if(importedModule && importedModule.providedExports) {
+			return {
+				exports: true
+			};
+		}
+
+		if(importedModule) {
+			return {
+				exports: null,
+				dependencies: [importedModule]
+			};
+		}
+
 		return {
-			exports: [this.name]
+			exports: null
 		}
 	}
-	if(this.importDependency.module && Array.isArray(this.importDependency.module.providedExports)) {
-		return {
-			exports: this.importDependency.module.providedExports.filter(function(id) {
-				return id !== "default"
-			}),
-			dependencies: [this.importDependency.module]
-		};
-	}
-	if(this.importDependency.module && this.importDependency.module.providedExports) {
-		return {
-			exports: true
-		};
-	}
-	if(this.importDependency.module) {
-		return {
-			exports: null,
-			dependencies: [this.importDependency.module]
-		};
-	}
-	return {
-		exports: null
-	}
-};
 
-HarmonyExportImportedSpecifierDependency.prototype.describeHarmonyExport = function() {
-	var importedModule = this.importDependency.module;
-	if(!this.name && importedModule && Array.isArray(importedModule.providedExports)) {
-		// for a star export and when we know which exports are provided, we can tell so
-		return {
-			exportedName: importedModule.providedExports,
-			precedence: 3
+	describeHarmonyExport() {
+		const importedModule = this.importDependency.module;
+		if(!this.name && importedModule && Array.isArray(importedModule.providedExports)) {
+			// for a star export and when we know which exports are provided, we can tell so
+			return {
+				exportedName: importedModule.providedExports,
+				precedence: 3
+			}
 		}
-	}
-	return {
-		exportedName: this.name,
-		precedence: this.name ? 2 : 3
-	};
-};
 
-HarmonyExportImportedSpecifierDependency.prototype.updateHash = function(hash) {
-	NullDependency.prototype.updateHash.call(this, hash);
-	var importedModule = this.importDependency.module;
-	hash.update((importedModule && (importedModule.used + JSON.stringify(importedModule.usedExports) + JSON.stringify(importedModule.providedExports))) + "");
-};
+		return {
+			exportedName: this.name,
+			precedence: this.name ? 2 : 3
+		};
+	}
+
+	updateHash(hash) {
+		super.updateHash(hash);
+		const importedModule = this.importDependency.module;
+		hash.update((importedModule && (importedModule.used + JSON.stringify(importedModule.usedExports) + JSON.stringify(importedModule.providedExports))) + "");
+	}
+}
+
+module.exports = HarmonyExportImportedSpecifierDependency;
 
 HarmonyExportImportedSpecifierDependency.Template = function HarmonyExportImportedSpecifierDependencyTemplate() {};
 

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -130,8 +130,18 @@ class HarmonyExportImportedSpecifierDependency extends NullDependency {
 
 	updateHash(hash) {
 		super.updateHash(hash);
-		const importedModule = this.importDependency.module;
-		hash.update((importedModule && (importedModule.used + JSON.stringify(importedModule.usedExports) + JSON.stringify(importedModule.providedExports))) + "");
+		const hashValue = this.getHashValue(this.importDependency.module);
+		hash.update(hashValue);
+	}
+
+	getHashValue(importedModule) {
+		if(!importedModule) {
+			return importedModule;
+		}
+
+		const stringifiedUsedExport = JSON.stringify(importedModule.usedExports);
+		const stringifiedProvidedExport = JSON.stringify(importedModule.providedExports);
+		return importedModule.used + stringifiedUsedExport + stringifiedProvidedExport;
 	}
 }
 

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -150,12 +150,7 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 		const active = HarmonyModulesHelpers.isActive(dep.originModule, dep);
 		const importsExportsUnknown = !importedModule || !Array.isArray(importedModule.providedExports);
 
-		function getReexportStatement(key, valueKey) {
-			var conditional = !importsExportsUnknown || !valueKey ? "" : "if(__webpack_require__.o(" + name + ", " + valueKey + ")) ";
-			return conditional +
-				"__webpack_require__.d(exports, " + key + ", " +
-				"function() { return " + name + (valueKey === null ? "_default.a" : valueKey && "[" + valueKey + "]") + "; });\n"
-		}
+		const getReexportStatement = this.reexportStatementCreator(importsExportsUnknown, name);
 
 		if(!used) { // we want to rexport something, but the export isn't used
 			return "/* unused harmony reexport " + dep.name + " */\n";
@@ -229,5 +224,30 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 		}
 
 		return "/* unused harmony reexport namespace */\n";
+	}
+
+	reexportStatementCreator(importsExportsUnknown, name) {
+		const getReexportStatement = (key, valueKey) => {
+			const conditional = this.getConditional(importsExportsUnknown, valueKey, name);
+			const returnValue = this.getReturnValue(valueKey)
+			return `${conditional}__webpack_require__.d(exports, ${key}, function() { return ${name}${returnValue}; });\n`;
+		};
+		return getReexportStatement;
+	}
+
+	getConditional(importsExportsUnknown, valueKey, name) {
+		if(!importsExportsUnknown || !valueKey) {
+			return "";
+		}
+
+		return `if(__webpack_require__.o(${name}, ${valueKey})) `;
+	}
+
+	getReturnValue(valueKey) {
+		if(valueKey === null) {
+			return "_default.a";
+		}
+
+		return valueKey && "[" + valueKey + "]";
 	}
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

current tests should pass

**If relevant, link to documentation update:**

N/A

**Summary**

upgrade HarmonyExportImportedSpecifierDependency and HarmonyExportImportedSpecifierDependencyTemplate to es6

**Does this PR introduce a breaking change?**

No
