### PR TITLE
refactor HarmonyExportSpecifierDependency to es6

### DIFF
--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -2,53 +2,65 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var NullDependency = require("./NullDependency");
-var HarmonyModulesHelpers = require("./HarmonyModulesHelpers");
+"use strict";
+const NullDependency = require("./NullDependency");
+const HarmonyModulesHelpers = require("./HarmonyModulesHelpers");
 
-function HarmonyExportSpecifierDependency(originModule, id, name, position, immutable) {
-	NullDependency.call(this);
-	this.originModule = originModule;
-	this.id = id;
-	this.name = name;
-	this.position = position;
-	this.immutable = immutable;
+class HarmonyExportSpecifierDependency extends NullDependency {
+	constructor(originModule, id, name, position, immutable) {
+		super();
+		this.originModule = originModule;
+		this.id = id;
+		this.name = name;
+		this.position = position;
+		this.immutable = immutable;
+	}
+
+	get type() {
+		return "harmony export specifier";
+	}
+
+	getExports() {
+		return {
+			exports: [this.name]
+		};
+	}
+
+	describeHarmonyExport() {
+		return {
+			exportedName: this.name,
+			precedence: 1
+		};
+	}
 }
+
+HarmonyExportSpecifierDependency.Template = class HarmonyExportSpecifierDependencyTemplate {
+	apply(dep, source) {
+		const content = this.getPrefix(dep) + this.getContent(dep);
+		source.insert(dep.position, content);
+	}
+
+	getPrefix(dep) {
+		return dep.position > 0 ? "\n" : "";
+	}
+
+	getContent(dep) {
+		const used = dep.originModule.isUsed(dep.name);
+		const active = HarmonyModulesHelpers.isActive(dep.originModule, dep);
+		if(!used) {
+			return `/* unused harmony export ${(dep.name || "namespace")} */\n`;
+		}
+
+		if(!active) {
+			return `/* inactive harmony export ${(dep.name || "namespace")} */\n`;
+		}
+
+		if(dep.immutable) {
+			return `/* harmony export (immutable) */ exports[${JSON.stringify(used)}] = ${dep.id};\n`;
+		}
+
+		return `/* harmony export (binding) */ __webpack_require__.d(exports, ${JSON.stringify(used)}, function() { return ${dep.id}; });\n`;
+	}
+}
+
 module.exports = HarmonyExportSpecifierDependency;
-
-HarmonyExportSpecifierDependency.prototype = Object.create(NullDependency.prototype);
-HarmonyExportSpecifierDependency.prototype.constructor = HarmonyExportSpecifierDependency;
-HarmonyExportSpecifierDependency.prototype.type = "harmony export specifier";
-
-HarmonyExportSpecifierDependency.prototype.getExports = function() {
-	return {
-		exports: [this.name]
-	}
-};
-
-HarmonyExportSpecifierDependency.prototype.describeHarmonyExport = function() {
-	return {
-		exportedName: this.name,
-		precedence: 1
-	};
-};
-
-HarmonyExportSpecifierDependency.Template = function HarmonyExportSpecifierDependencyTemplate() {};
-
-HarmonyExportSpecifierDependency.Template.prototype.apply = function(dep, source) {
-	var used = dep.originModule.isUsed(dep.name);
-	var active = HarmonyModulesHelpers.isActive(dep.originModule, dep);
-	var content;
-	if(!used) {
-		content = "/* unused harmony export " + (dep.name || "namespace") + " */\n";
-	} else if(!active) {
-		content = "/* inactive harmony export " + (dep.name || "namespace") + " */\n";
-	} else if(dep.immutable) {
-		content = "/* harmony export (immutable) */ exports[" + JSON.stringify(used) + "] = " + dep.id + ";\n";
-	} else {
-		content = "/* harmony export (binding) */ __webpack_require__.d(exports, " + JSON.stringify(used) + ", function() { return " + dep.id + "; });\n";
-	}
-	if(dep.position > 0)
-		content = "\n" + content;
-	source.insert(dep.position, content);
-
-};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

current tests should pass

**If relevant, link to documentation update:**

N/A

**Summary**

upgrade HarmonyExportSpecifierDependency and HarmonyExportSpecifierDependencyTemplate to es6

**Does this PR introduce a breaking change?**

No
