### PR TITLE
Fix multiconfig watch

### DIFF
--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -143,10 +143,14 @@ MultiCompiler.prototype.watch = function(watchOptions, handler) {
 				handler(err);
 			if(stats) {
 				allStats[compilerIdx] = stats;
-				compilerStatus[compilerIdx] = true;
+				compilerStatus[compilerIdx] = stats.hash;
 				if(compilerStatus.every(Boolean)) {
-					var multiStats = new MultiStats(allStats);
+					var freshStats = allStats.filter(function(s) {
+						return compilerStatus.indexOf(s.hash) > -1
+					});
+					var multiStats = new MultiStats(freshStats);
 					handler(null, multiStats)
+					compilerStatus.fill(true);
 				}
 			}
 			if(firstRun && !err) {

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -143,14 +143,14 @@ MultiCompiler.prototype.watch = function(watchOptions, handler) {
 				handler(err);
 			if(stats) {
 				allStats[compilerIdx] = stats;
-				compilerStatus[compilerIdx] = stats.hash;
+				compilerStatus[compilerIdx] = "new";
 				if(compilerStatus.every(Boolean)) {
-					var freshStats = allStats.filter(function(s) {
-						return compilerStatus.indexOf(s.hash) > -1
+					var freshStats = allStats.filter(function(s, idx) {
+						return compilerStatus[idx] === "new";
 					});
+					compilerStatus.fill(true);
 					var multiStats = new MultiStats(freshStats);
 					handler(null, multiStats)
-					compilerStatus.fill(true);
 				}
 			}
 			if(firstRun && !err) {

--- a/test/WatchTestCases.test.js
+++ b/test/WatchTestCases.test.js
@@ -89,14 +89,20 @@ describe("WatchTestCases", function() {
 						var configPath = path.join(testDirectory, "webpack.config.js");
 						if(fs.existsSync(configPath))
 							options = require(configPath);
-						if(!options.context) options.context = tempDirectory;
-						if(!options.entry) options.entry = "./index.js";
-						if(!options.target) options.target = "async-node";
-						if(!options.output) options.output = {};
-						if(!options.output.path) options.output.path = outputDirectory;
-						if(typeof options.output.pathinfo === "undefined") options.output.pathinfo = true;
-						if(!options.output.filename) options.output.filename = "bundle.js";
-
+						var applyConfig = function(options) {
+							if(!options.context) options.context = tempDirectory;
+							if(!options.entry) options.entry = "./index.js";
+							if(!options.target) options.target = "async-node";
+							if(!options.output) options.output = {};
+							if(!options.output.path) options.output.path = outputDirectory;
+							if(typeof options.output.pathinfo === "undefined") options.output.pathinfo = true;
+							if(!options.output.filename) options.output.filename = "bundle.js";
+						}
+						if(Array.isArray(options)) {
+							options.forEach(applyConfig)
+						} else {
+							applyConfig(options)
+						}
 						var runIdx = 0;
 						var run = runs[runIdx];
 						var lastHash = "";
@@ -142,11 +148,11 @@ describe("WatchTestCases", function() {
 										var p = path.join(currentDirectory, module);
 										content = fs.readFileSync(p, "utf-8");
 									}
-									fn = vm.runInThisContext("(function(require, module, exports, __dirname, __filename, it, WATCH_STEP) {" + content + "\n})", p);
+									fn = vm.runInThisContext("(function(require, module, exports, __dirname, __filename, it, WATCH_STEP, STATS_JSON) {" + content + "\n})", p);
 									var module = {
 										exports: {}
 									};
-									fn.call(module.exports, _require.bind(null, path.dirname(p)), module, module.exports, path.dirname(p), p, _it, run.name);
+									fn.call(module.exports, _require.bind(null, path.dirname(p)), module, module.exports, path.dirname(p), p, _it, run.name, jsonStats);
 									return module.exports;
 								} else if(testConfig.modules && module in testConfig.modules) {
 									return testConfig.modules[module];

--- a/test/WatchTestCases.test.js
+++ b/test/WatchTestCases.test.js
@@ -172,7 +172,9 @@ describe("WatchTestCases", function() {
 							runIdx++;
 							if(runIdx < runs.length) {
 								run = runs[runIdx];
-								copyDiff(path.join(testDirectory, run.name), tempDirectory);
+								setTimeout(function(){
+									copyDiff(path.join(testDirectory, run.name), tempDirectory);
+								}, 50);
 							} else {
 								process.nextTick(done);
 							}

--- a/test/WatchTestCases.test.js
+++ b/test/WatchTestCases.test.js
@@ -109,7 +109,7 @@ describe("WatchTestCases", function() {
 						copyDiff(path.join(testDirectory, run.name), tempDirectory);
 
 						var compiler = webpack(options);
-						compiler.watch({}, function(err, stats) {
+						var watching = compiler.watch({}, function(err, stats) {
 							if(stats.hash === lastHash)
 								return;
 							lastHash = stats.hash;
@@ -172,10 +172,11 @@ describe("WatchTestCases", function() {
 							runIdx++;
 							if(runIdx < runs.length) {
 								run = runs[runIdx];
-								setTimeout(function(){
+								setTimeout(function() {
 									copyDiff(path.join(testDirectory, run.name), tempDirectory);
 								}, 50);
 							} else {
+								watching.close();
 								process.nextTick(done);
 							}
 						});

--- a/test/watchCases/simple/multi-compiler/0/changing-file.js
+++ b/test/watchCases/simple/multi-compiler/0/changing-file.js
@@ -1,0 +1,1 @@
+module.exports = "0";

--- a/test/watchCases/simple/multi-compiler/0/index.js
+++ b/test/watchCases/simple/multi-compiler/0/index.js
@@ -1,0 +1,11 @@
+require("./changing-file")
+it("should watch for changes", function() {
+	switch(WATCH_STEP) {
+		case "0":
+			STATS_JSON.children.should.have.size(2);
+			break;
+		case "1":
+			STATS_JSON.children.should.have.size(1);
+			break;
+	}
+})

--- a/test/watchCases/simple/multi-compiler/0/static-file.js
+++ b/test/watchCases/simple/multi-compiler/0/static-file.js
@@ -1,0 +1,1 @@
+module.exports = "0";

--- a/test/watchCases/simple/multi-compiler/1/changing-file.js
+++ b/test/watchCases/simple/multi-compiler/1/changing-file.js
@@ -1,0 +1,1 @@
+module.exports = "1";

--- a/test/watchCases/simple/multi-compiler/webpack.config.js
+++ b/test/watchCases/simple/multi-compiler/webpack.config.js
@@ -1,13 +1,13 @@
 module.exports = [{
-    name: "changing",
-    entry: "./index.js",
-    output: {
-        filename: "./bundle.js"
-    }
+	name: "changing",
+	entry: "./index.js",
+	output: {
+		filename: "./bundle.js"
+	}
 }, {
-    name: "static",
-    entry: "./static-file.js",
-    output: {
-        filename: "./static.js"
-    }
+	name: "static",
+	entry: "./static-file.js",
+	output: {
+		filename: "./static.js"
+	}
 }];

--- a/test/watchCases/simple/multi-compiler/webpack.config.js
+++ b/test/watchCases/simple/multi-compiler/webpack.config.js
@@ -1,0 +1,13 @@
+module.exports = [{
+    name: "changing",
+    entry: "./index.js",
+    output: {
+        filename: "./bundle.js"
+    }
+}, {
+    name: "static",
+    entry: "./static-file.js",
+    output: {
+        filename: "./static.js"
+    }
+}];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Multi configuration watch is reporting stale stats for configurations that were not changed
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
There is some quirk about running watch tests on Windows/Linux. Change event doesn't fire. It is only observable when MultiCompilation is in use (probably because it uses parallel watchpacks). It is mitigated by adding small delay before changing the files, which is also part of this PR.