### PR TITLE
Include child compilation hash into parent hash computation

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -961,6 +961,9 @@ class Compilation extends Tapable {
 		this.mainTemplate.updateHash(hash);
 		this.chunkTemplate.updateHash(hash);
 		this.moduleTemplate.updateHash(hash);
+		this.children.forEach(function(child) {
+			hash.update(child.hash);
+		});
 		let chunk;
 		const chunks = this.chunks.slice();
 		chunks.sort((a, b) => {

--- a/test/WatchTestCases.test.js
+++ b/test/WatchTestCases.test.js
@@ -103,6 +103,8 @@ describe("WatchTestCases", function() {
 						} else {
 							applyConfig(options)
 						}
+
+						var state = {};
 						var runIdx = 0;
 						var run = runs[runIdx];
 						var lastHash = "";
@@ -148,11 +150,11 @@ describe("WatchTestCases", function() {
 										var p = path.join(currentDirectory, module);
 										content = fs.readFileSync(p, "utf-8");
 									}
-									fn = vm.runInThisContext("(function(require, module, exports, __dirname, __filename, it, WATCH_STEP, STATS_JSON) {" + content + "\n})", p);
+									fn = vm.runInThisContext("(function(require, module, exports, __dirname, __filename, it, WATCH_STEP, STATS_JSON, STATE) {" + content + "\n})", p);
 									var module = {
 										exports: {}
 									};
-									fn.call(module.exports, _require.bind(null, path.dirname(p)), module, module.exports, path.dirname(p), p, _it, run.name, jsonStats);
+									fn.call(module.exports, _require.bind(null, path.dirname(p)), module, module.exports, path.dirname(p), p, _it, run.name, jsonStats, state);
 									return module.exports;
 								} else if(testConfig.modules && module in testConfig.modules) {
 									return testConfig.modules[module];

--- a/test/statsCases/separate-css-bundle/expected.txt
+++ b/test/statsCases/separate-css-bundle/expected.txt
@@ -1,6 +1,6 @@
-Hash: 9ff2cfa8882f273c8c6d9ff2cfa8882f273c8c6d
+Hash: 961cb0ccbdd4410998cff853996e18b417486bde
 Child
-    Hash: 9ff2cfa8882f273c8c6d
+    Hash: 961cb0ccbdd4410998cf
     Time: Xms
                                    Asset      Size  Chunks             Chunk Names
                  f49aa1e6c5ada5da859b.js   2.65 kB       0  [emitted]  main
@@ -13,7 +13,7 @@ Child
             [0] (webpack)/~/css-loader/lib/css-base.js 1.46 kB {0} [built]
             [1] (webpack)/~/css-loader!(webpack)/test/statsCases/separate-css-bundle/a/file.css 192 bytes {0} [built]
 Child
-    Hash: 9ff2cfa8882f273c8c6d
+    Hash: f853996e18b417486bde
     Time: Xms
                                    Asset      Size  Chunks             Chunk Names
                  f49aa1e6c5ada5da859b.js   2.65 kB       0  [emitted]  main

--- a/test/watchCases/plugins/extract-text-plugin/0/index.js
+++ b/test/watchCases/plugins/extract-text-plugin/0/index.js
@@ -1,0 +1,12 @@
+import "./style.css"
+
+it("should handle css changes", function() {
+	switch(WATCH_STEP) {
+		case "0":
+			STATE.first = STATS_JSON.hash;
+			break;
+		case "1":
+			STATS_JSON.hash.should.not.be.eql(STATE.first, "stats hash should have changed, but didn't");
+			break;
+	}
+});

--- a/test/watchCases/plugins/extract-text-plugin/1/style.css
+++ b/test/watchCases/plugins/extract-text-plugin/1/style.css
@@ -1,0 +1,3 @@
+.x {
+	background: red;
+}

--- a/test/watchCases/plugins/extract-text-plugin/webpack.config.js
+++ b/test/watchCases/plugins/extract-text-plugin/webpack.config.js
@@ -1,0 +1,19 @@
+var ExtractTextPlugin = require("extract-text-webpack-plugin");
+
+module.exports = {
+	module: {
+		loaders: [
+			{
+				test: /\.css$/,
+				loader: ExtractTextPlugin.extract({
+					loader: "css-loader"
+				})
+			}
+		]
+	},
+	plugins: [
+		new ExtractTextPlugin({
+			filename: "[name].css"
+		})
+	]
+};


### PR DESCRIPTION
Without it, child compilations like those added by "extract-text-webpack-plugin" are not included in stats hash and aren't properly displayed on change.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Child compilations should affect parent hash.
This bug affects at least extract-text-webpack-plugin. Since child compilation does not affect parent hash, [this](https://github.com/webpack/webpack/blob/7327ee608a040ec784cc251663be85c2aedac44c/bin/webpack.js#L332) code hides the output.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Causes https://github.com/webpack/extract-text-webpack-plugin/issues/307