### PR TITLE
refactor(DependenciesBlockVariable): upgrade to ES6

### DIFF
--- a/lib/DependenciesBlockVariable.js
+++ b/lib/DependenciesBlockVariable.js
@@ -2,40 +2,45 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var ReplaceSource = require("webpack-sources").ReplaceSource;
-var RawSource = require("webpack-sources").RawSource;
+"use strict";
 
-function DependenciesBlockVariable(name, expression, dependencies) {
-	this.name = name;
-	this.expression = expression;
-	this.dependencies = dependencies || [];
+const ReplaceSource = require("webpack-sources").ReplaceSource;
+const RawSource = require("webpack-sources").RawSource;
+
+class DependenciesBlockVariable {
+	constructor(name, expression, dependencies) {
+		this.name = name;
+		this.expression = expression;
+		this.dependencies = dependencies || [];
+	}
+
+	updateHash(hash) {
+		hash.update(this.name);
+		hash.update(this.expression);
+		this.dependencies.forEach(d => {
+			d.updateHash(hash);
+		});
+	}
+
+	expressionSource(dependencyTemplates, outputOptions, requestShortener) {
+		const source = new ReplaceSource(new RawSource(this.expression));
+		this.dependencies.forEach(dep => {
+			const template = dependencyTemplates.get(dep.constructor);
+			if(!template) throw new Error(`No template for dependency: ${dep.constructor.name}`);
+			template.apply(dep, source, outputOptions, requestShortener, dependencyTemplates);
+		});
+		return source;
+	}
+
+	disconnect() {
+		this.dependencies.forEach(d => {
+			d.disconnect();
+		});
+	}
+
+	hasDependencies() {
+		return this.dependencies.length > 0;
+	}
 }
+
 module.exports = DependenciesBlockVariable;
-
-DependenciesBlockVariable.prototype.updateHash = function(hash) {
-	hash.update(this.name);
-	hash.update(this.expression);
-	this.dependencies.forEach(function(d) {
-		d.updateHash(hash);
-	});
-};
-
-DependenciesBlockVariable.prototype.expressionSource = function(dependencyTemplates, outputOptions, requestShortener) {
-	var source = new ReplaceSource(new RawSource(this.expression));
-	this.dependencies.forEach(function(dep) {
-		var template = dependencyTemplates.get(dep.constructor);
-		if(!template) throw new Error("No template for dependency: " + dep.constructor.name);
-		template.apply(dep, source, outputOptions, requestShortener, dependencyTemplates);
-	});
-	return source;
-};
-
-DependenciesBlockVariable.prototype.disconnect = function() {
-	this.dependencies.forEach(function(d) {
-		d.disconnect();
-	});
-};
-
-DependenciesBlockVariable.prototype.hasDependencies = function() {
-	return this.dependencies.length > 0;
-};

--- a/test/DependenciesBlockVariable.test.js
+++ b/test/DependenciesBlockVariable.test.js
@@ -1,0 +1,98 @@
+var should = require("should");
+var sinon = require("sinon");
+var DependenciesBlockVariable = require("../lib/DependenciesBlockVariable");
+
+describe("DependenciesBlockVariable", function() {
+	var DependenciesBlockVariableInstance,
+		dependencyMock,
+		sandbox;
+
+	before(function() {
+		sandbox = sinon.sandbox.create();
+		dependencyMock = {
+			constructor: {
+				name: "DependencyMock"
+			},
+			disconnect: sandbox.spy(),
+			updateHash: sandbox.spy()
+		};
+		DependenciesBlockVariableInstance = new DependenciesBlockVariable(
+			"dependencies-name",
+			"expression", [dependencyMock]);
+	});
+
+	afterEach(function() {
+		sandbox.restore();
+	});
+
+	describe("hasDependencies", function() {
+		it("returns `true` if has dependencies", function() {
+			should(DependenciesBlockVariableInstance.hasDependencies()).be.true();
+		});
+	});
+
+	describe("disconnect", function() {
+		it("trigger dependencies disconnection", function() {
+			DependenciesBlockVariableInstance.disconnect();
+			should(dependencyMock.disconnect.calledOnce).be.true();
+		});
+	});
+
+	describe("updateHash", function() {
+		var hash;
+		before(function() {
+			hash = {
+				update: sandbox.spy()
+			};
+			DependenciesBlockVariableInstance.updateHash(hash);
+		});
+
+		it("should update hash dependencies with name", function() {
+			should(hash.update.calledWith("dependencies-name")).be.true();
+		});
+
+		it("should update hash dependencies with expression", function() {
+			should(hash.update.calledWith("expression")).be.true();
+		});
+
+		it("should update hash inside dependencies", function() {
+			should(dependencyMock.updateHash.calledOnce).be.true();
+		});
+	});
+
+	describe("expressionSource", function() {
+		var dependencyTemplates,
+			applyMock;
+
+		before(function() {
+			applyMock = sandbox.spy();
+		});
+
+		it("aplies information inside dependency templates", function() {
+			dependencyTemplates = {
+				get: function() {
+					return {
+						apply: applyMock
+					};
+				}
+			};
+			DependenciesBlockVariableInstance.expressionSource(
+				dependencyTemplates, {}, {}
+			);
+			should(applyMock.calledOnce).be.true();
+		});
+
+		it("aplies information inside dependency templates", function() {
+			dependencyTemplates = {
+				get: function() {
+					return false;
+				}
+			};
+			should(function() {
+				DependenciesBlockVariableInstance.expressionSource(
+					dependencyTemplates, {}, {}
+				)
+			}).throw("No template for dependency: DependencyMock");
+		})
+	});
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

ES5 => ES6 refactor

**Did you add tests for your changes?**

refactor, all existing tests pass. By the way, I'm adding some missed tests for `DependenciesBlockVariable`

**If relevant, link to documentation update:**

N/A

**Summary**

Helping in part of the ES6 refactor

**Does this PR introduce a breaking change?**

Nope