### PR TITLE
Refactor dll entry dependency to es6

### DIFF
--- a/lib/DllEntryPlugin.js
+++ b/lib/DllEntryPlugin.js
@@ -9,11 +9,10 @@ const SingleEntryDependency = require("./dependencies/SingleEntryDependency");
 const DllModuleFactory = require("./DllModuleFactory");
 
 class DllEntryPlugin {
-	constructor(context, entries, name, type) {
+	constructor(context, entries, name) {
 		this.context = context;
 		this.entries = entries;
 		this.name = name;
-		this.type = type;
 	}
 
 	apply(compiler) {
@@ -30,7 +29,7 @@ class DllEntryPlugin {
 				let dep = new SingleEntryDependency(e);
 				dep.loc = `${this.name}:${idx}`;
 				return dep;
-			}), this.name, this.type), this.name, callback);
+			}), this.name), this.name, callback);
 		});
 	}
 }

--- a/lib/dependencies/DllEntryDependency.js
+++ b/lib/dependencies/DllEntryDependency.js
@@ -2,16 +2,20 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var Dependency = require("../Dependency");
+"use strict";
+const Dependency = require("../Dependency");
 
-function DllEntryDependency(dependencies, name, type) {
-	Dependency.call(this);
-	this.dependencies = dependencies;
-	this.name = name;
-	this.type = type;
+class DllEntryDependency extends Dependency {
+	constructor(dependencies, name, type) {
+		super();
+		this.dependencies = dependencies;
+		this.name = name;
+		this.type = type;
+	}
+
+	get type() {
+		return "dll entry";
+	}
 }
-module.exports = DllEntryDependency;
 
-DllEntryDependency.prototype = Object.create(Dependency.prototype);
-DllEntryDependency.prototype.constructor = DllEntryDependency;
-DllEntryDependency.prototype.type = "dll entry";
+module.exports = DllEntryDependency;

--- a/lib/dependencies/DllEntryDependency.js
+++ b/lib/dependencies/DllEntryDependency.js
@@ -6,11 +6,10 @@
 const Dependency = require("../Dependency");
 
 class DllEntryDependency extends Dependency {
-	constructor(dependencies, name, type) {
+	constructor(dependencies, name) {
 		super();
 		this.dependencies = dependencies;
 		this.name = name;
-		this.type = type;
 	}
 
 	get type() {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

current tests should pass

**If relevant, link to documentation update:**

N/A

**Summary**

upgrade DllEntryDependency to es6

**Does this PR introduce a breaking change?**

No

**Other Information**

is the removal of the "type" attribute/param ok?
