### PR TITLE
Refactor harmony import and harmony accept import dependency to es6

### DIFF
--- a/lib/dependencies/HarmonyAcceptDependency.js
+++ b/lib/dependencies/HarmonyAcceptDependency.js
@@ -4,7 +4,7 @@
 */
 "use strict";
 const NullDependency = require("./NullDependency");
-const HarmonyImportDependency = require("./HarmonyImportDependency");
+const makeHarmonyImportStatement = require("./HarmonyImportDependency").makeImportStatement;
 
 class HarmonyAcceptDependency extends NullDependency {
 	constructor(range, dependencies, hasCallback) {
@@ -21,9 +21,8 @@ class HarmonyAcceptDependency extends NullDependency {
 
 HarmonyAcceptDependency.Template = class HarmonyAcceptDependencyTemplate {
 	apply(dep, source, outputOptions, requestShortener) {
-		const harmonyImportDependencyTemplate = new HarmonyImportDependency.Template();
 		const content = dep.dependencies
-			.map(dependency => harmonyImportDependencyTemplate.getContent(
+			.map(dependency => makeHarmonyImportStatement(
 				false,
 				dependency,
 				outputOptions,

--- a/lib/dependencies/HarmonyAcceptDependency.js
+++ b/lib/dependencies/HarmonyAcceptDependency.js
@@ -21,8 +21,9 @@ class HarmonyAcceptDependency extends NullDependency {
 
 HarmonyAcceptDependency.Template = class HarmonyAcceptDependencyTemplate {
 	apply(dep, source, outputOptions, requestShortener) {
+		const harmonyImportDependencyTemplate = new HarmonyImportDependency.Template();
 		const content = dep.dependencies
-			.map(dependency => new HarmonyImportDependency().makeStatement(
+			.map(dependency => harmonyImportDependencyTemplate.getContent(
 				false,
 				dependency,
 				outputOptions,

--- a/lib/dependencies/HarmonyAcceptDependency.js
+++ b/lib/dependencies/HarmonyAcceptDependency.js
@@ -22,7 +22,7 @@ class HarmonyAcceptDependency extends NullDependency {
 HarmonyAcceptDependency.Template = class HarmonyAcceptDependencyTemplate {
 	apply(dep, source, outputOptions, requestShortener) {
 		const content = dep.dependencies
-			.map(dependency => HarmonyImportDependency.makeStatement(
+			.map(dependency => new HarmonyImportDependency().makeStatement(
 				false,
 				dependency,
 				outputOptions,

--- a/lib/dependencies/HarmonyAcceptImportDependency.js
+++ b/lib/dependencies/HarmonyAcceptImportDependency.js
@@ -2,17 +2,21 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var HarmonyImportDependency = require("./HarmonyImportDependency");
+"use strict";
+const HarmonyImportDependency = require("./HarmonyImportDependency");
 
-function HarmonyAcceptImportDependency(request, importedVar, range) {
-	HarmonyImportDependency.call(this, request, importedVar, range);
+class HarmonyAcceptImportDependency extends HarmonyImportDependency {
+	constructor(request, importedVar, range) {
+		super(request, importedVar, range);
+	}
+
+	get type() {
+		return "harmony accept";
+	}
 }
+
+HarmonyAcceptImportDependency.Template = class HarmonyAcceptImportDependencyTemplate {
+	apply(dep, source, outputOptions, requestShortener) {}
+}
+
 module.exports = HarmonyAcceptImportDependency;
-
-HarmonyAcceptImportDependency.prototype = Object.create(HarmonyImportDependency.prototype);
-HarmonyAcceptImportDependency.prototype.constructor = HarmonyAcceptImportDependency;
-HarmonyAcceptImportDependency.prototype.type = "harmony accept";
-
-HarmonyAcceptImportDependency.Template = function HarmonyAcceptImportDependencyTemplate() {};
-
-HarmonyAcceptImportDependency.Template.prototype.apply = function(dep, source, outputOptions, requestShortener) {};

--- a/lib/dependencies/HarmonyImportDependency.js
+++ b/lib/dependencies/HarmonyImportDependency.js
@@ -2,55 +2,62 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+"use strict"
 var ModuleDependency = require("./ModuleDependency");
 
-function HarmonyImportDependency(request, importedVar, range) {
-	ModuleDependency.call(this, request);
-	this.range = range;
-	this.importedVar = importedVar;
-}
-module.exports = HarmonyImportDependency;
-
-HarmonyImportDependency.prototype = Object.create(ModuleDependency.prototype);
-HarmonyImportDependency.prototype.constructor = HarmonyImportDependency;
-HarmonyImportDependency.prototype.type = "harmony import";
-
-HarmonyImportDependency.prototype.getReference = function() {
-	if(!this.module) return null;
-	return {
-		module: this.module,
-		importedNames: false
-	};
-};
-
-HarmonyImportDependency.prototype.updateHash = function updateHash(hash) {
-	ModuleDependency.prototype.updateHash.call(this, hash);
-	hash.update((this.module && (!this.module.meta || this.module.meta.harmonyModule)) + "");
-};
-
-HarmonyImportDependency.makeStatement = function(declare, dep, outputOptions, requestShortener) {
-	var comment = "";
-	if(outputOptions.pathinfo) comment = "/*! " + requestShortener.shorten(dep.request) + " */ ";
-	var declaration = declare ? "var " : "";
-	var newline = declare ? "\n" : " ";
-	var content;
-	if(!dep.module) {
-		content = "throw new Error(" + JSON.stringify("Cannot find module \"" + dep.request + "\"") + ");" + newline;
-	} else if(dep.importedVar) {
-		content = "/* harmony import */ " + declaration + dep.importedVar + " = __webpack_require__(" + comment + JSON.stringify(dep.module.id) + ");" + newline;
-		if(!(dep.module.meta && dep.module.meta.harmonyModule)) {
-			content += "/* harmony import */ " + declaration + dep.importedVar + "_default = __webpack_require__.n(" + dep.importedVar + ");" + newline;
-		}
-	} else {
-		content = "";
+class HarmonyImportDependency extends ModuleDependency {
+	constructor(request, importedVar, range) {
+		super(request);
+		this.range = range;
+		this.importedVar = importedVar;
 	}
-	return content;
-};
 
-HarmonyImportDependency.Template = function HarmonyImportDependencyTemplate() {};
+	get type() {
+		return "harmony import";
+	}
 
-HarmonyImportDependency.Template.prototype.apply = function(dep, source, outputOptions, requestShortener) {
-	var content = HarmonyImportDependency.makeStatement(true, dep, outputOptions, requestShortener);
-	source.replace(dep.range[0], dep.range[1] - 1, "");
-	source.insert(-1, content);
-};
+	getReference() {
+		if(!this.module) return null;
+
+		return {
+			module: this.module,
+			importedNames: false
+		};
+	}
+
+	updateHash(hash) {
+		super.updateHash(hash);
+		hash.update((this.module && (!this.module.meta || this.module.meta.harmonyModule)) + "");
+	}
+
+	makeStatement(declare, dep, outputOptions, requestShortener) {
+		let comment = "";
+		if(outputOptions.pathinfo) comment = "/*! " + requestShortener.shorten(dep.request) + " */ ";
+		const declaration = declare ? "var " : "";
+		const newline = declare ? "\n" : " ";
+		let content;
+		if(!dep.module) {
+			content = "throw new Error(" + JSON.stringify("Cannot find module \"" + dep.request + "\"") + ");" + newline;
+		} else if(dep.importedVar) {
+			content = "/* harmony import */ " + declaration + dep.importedVar + " = __webpack_require__(" + comment + JSON.stringify(dep.module.id) + ");" + newline;
+			if(!(dep.module.meta && dep.module.meta.harmonyModule)) {
+				content += "/* harmony import */ " + declaration + dep.importedVar + "_default = __webpack_require__.n(" + dep.importedVar + ");" + newline;
+			}
+		} else {
+			content = "";
+		}
+
+		return content;
+	}
+}
+
+HarmonyImportDependency.Template = class HarmonyImportDependencyTemplate {
+	apply(dep, source, outputOptions, requestShortener) {
+		const harmonyImportDependency = new HarmonyImportDependency();
+		const content = harmonyImportDependency.makeStatement(true, dep, outputOptions, requestShortener);
+		source.replace(dep.range[0], dep.range[1] - 1, "");
+		source.insert(-1, content);
+	}
+}
+
+module.exports = HarmonyImportDependency;

--- a/lib/dependencies/HarmonyImportDependency.js
+++ b/lib/dependencies/HarmonyImportDependency.js
@@ -29,34 +29,42 @@ class HarmonyImportDependency extends ModuleDependency {
 		super.updateHash(hash);
 		hash.update((this.module && (!this.module.meta || this.module.meta.harmonyModule)) + "");
 	}
-
-	makeStatement(declare, dep, outputOptions, requestShortener) {
-		let comment = "";
-		if(outputOptions.pathinfo) comment = "/*! " + requestShortener.shorten(dep.request) + " */ ";
-		const declaration = declare ? "var " : "";
-		const newline = declare ? "\n" : " ";
-		let content;
-		if(!dep.module) {
-			content = "throw new Error(" + JSON.stringify("Cannot find module \"" + dep.request + "\"") + ");" + newline;
-		} else if(dep.importedVar) {
-			content = "/* harmony import */ " + declaration + dep.importedVar + " = __webpack_require__(" + comment + JSON.stringify(dep.module.id) + ");" + newline;
-			if(!(dep.module.meta && dep.module.meta.harmonyModule)) {
-				content += "/* harmony import */ " + declaration + dep.importedVar + "_default = __webpack_require__.n(" + dep.importedVar + ");" + newline;
-			}
-		} else {
-			content = "";
-		}
-
-		return content;
-	}
 }
 
 HarmonyImportDependency.Template = class HarmonyImportDependencyTemplate {
 	apply(dep, source, outputOptions, requestShortener) {
-		const harmonyImportDependency = new HarmonyImportDependency();
-		const content = harmonyImportDependency.makeStatement(true, dep, outputOptions, requestShortener);
+		const content = this.getContent(true, dep, outputOptions, requestShortener);
 		source.replace(dep.range[0], dep.range[1] - 1, "");
 		source.insert(-1, content);
+	}
+
+	getContent(declare, dep, outputOptions, requestShortener) {
+		const comment = this.getOptionalComment(outputOptions.pathinfo, requestShortener.shorten(dep.request));
+		const declaration = declare ? "var " : "";
+		const newline = declare ? "\n" : " ";
+
+		if(!dep.module) {
+			const stringifiedError = JSON.stringify(`Cannot find module "${dep.request}"`);
+			return `throw new Error(${stringifiedError});${newline}`;
+		}
+
+		if(dep.importedVar) {
+			const isHarmonyModule = dep.module.meta && dep.module.meta.harmonyModule;
+			const content = `/* harmony import */ ${declaration}${dep.importedVar} = __webpack_require__(${comment}${JSON.stringify(dep.module.id)});${newline}`;
+			if(isHarmonyModule) {
+				return content;
+			}
+			return `${content}/* harmony import */ ${declaration}${dep.importedVar}_default = __webpack_require__.n(${dep.importedVar});${newline}`;
+		}
+
+		return "";
+	}
+
+	getOptionalComment(pathinfo, shortenedRequest) {
+		if(!pathinfo) {
+			return "";
+		}
+		return `/*! ${shortenedRequest} */ `;
 	}
 }
 

--- a/lib/dependencies/HarmonyImportDependency.js
+++ b/lib/dependencies/HarmonyImportDependency.js
@@ -33,39 +33,40 @@ class HarmonyImportDependency extends ModuleDependency {
 
 HarmonyImportDependency.Template = class HarmonyImportDependencyTemplate {
 	apply(dep, source, outputOptions, requestShortener) {
-		const content = this.getContent(true, dep, outputOptions, requestShortener);
+		const content = makeImportStatement(true, dep, outputOptions, requestShortener);
 		source.replace(dep.range[0], dep.range[1] - 1, "");
 		source.insert(-1, content);
 	}
+}
 
-	getContent(declare, dep, outputOptions, requestShortener) {
-		const comment = this.getOptionalComment(outputOptions.pathinfo, requestShortener.shorten(dep.request));
-		const declaration = declare ? "var " : "";
-		const newline = declare ? "\n" : " ";
-
-		if(!dep.module) {
-			const stringifiedError = JSON.stringify(`Cannot find module "${dep.request}"`);
-			return `throw new Error(${stringifiedError});${newline}`;
-		}
-
-		if(dep.importedVar) {
-			const isHarmonyModule = dep.module.meta && dep.module.meta.harmonyModule;
-			const content = `/* harmony import */ ${declaration}${dep.importedVar} = __webpack_require__(${comment}${JSON.stringify(dep.module.id)});${newline}`;
-			if(isHarmonyModule) {
-				return content;
-			}
-			return `${content}/* harmony import */ ${declaration}${dep.importedVar}_default = __webpack_require__.n(${dep.importedVar});${newline}`;
-		}
-
+function getOptionalComment(pathinfo, shortenedRequest) {
+	if(!pathinfo) {
 		return "";
 	}
-
-	getOptionalComment(pathinfo, shortenedRequest) {
-		if(!pathinfo) {
-			return "";
-		}
-		return `/*! ${shortenedRequest} */ `;
-	}
+	return `/*! ${shortenedRequest} */ `;
 }
+
+function makeImportStatement(declare, dep, outputOptions, requestShortener) {
+	const comment = getOptionalComment(outputOptions.pathinfo, requestShortener.shorten(dep.request));
+	const declaration = declare ? "var " : "";
+	const newline = declare ? "\n" : " ";
+
+	if(!dep.module) {
+		const stringifiedError = JSON.stringify(`Cannot find module "${dep.request}"`);
+		return `throw new Error(${stringifiedError});${newline}`;
+	}
+
+	if(dep.importedVar) {
+		const isHarmonyModule = dep.module.meta && dep.module.meta.harmonyModule;
+		const content = `/* harmony import */ ${declaration}${dep.importedVar} = __webpack_require__(${comment}${JSON.stringify(dep.module.id)});${newline}`;
+		if(isHarmonyModule) {
+			return content;
+		}
+		return `${content}/* harmony import */ ${declaration}${dep.importedVar}_default = __webpack_require__.n(${dep.importedVar});${newline}`;
+	}
+
+	return "";
+}
+HarmonyImportDependency.makeImportStatement = makeImportStatement;
 
 module.exports = HarmonyImportDependency;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

current tests should pass

**If relevant, link to documentation update:**

N/A

**Summary**

upgrade HarmonyImportDependency and HarmonyAcceptImportDependency to es6

**Does this PR introduce a breaking change?**

No

**Other Information**

amend usage of HarmonyAcceptImportDependency in HarmonyAcceptDependency
