### PR TITLE
refactor(ES6): upgrade NodeHotUpdateChunkTemplatePlugin to ES6

### DIFF
--- a/lib/node/NodeHotUpdateChunkTemplatePlugin.js
+++ b/lib/node/NodeHotUpdateChunkTemplatePlugin.js
@@ -2,23 +2,26 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var ConcatSource = require("webpack-sources").ConcatSource;
+"use strict";
 
-function NodeHotUpdateChunkTemplatePlugin() {}
+const ConcatSource = require("webpack-sources").ConcatSource;
+
+class NodeHotUpdateChunkTemplatePlugin {
+
+	apply(hotUpdateChunkTemplate) {
+		hotUpdateChunkTemplate.plugin("render", (modulesSource, modules, removedModules, hash, id) => {
+			const source = new ConcatSource();
+			source.add("exports.id = " + JSON.stringify(id) + ";\nexports.modules = ");
+			source.add(modulesSource);
+			source.add(";");
+			return source;
+		});
+		hotUpdateChunkTemplate.plugin("hash", function(hash) {
+			hash.update("NodeHotUpdateChunkTemplatePlugin");
+			hash.update("3");
+			hash.update(this.outputOptions.hotUpdateFunction + "");
+			hash.update(this.outputOptions.library + "");
+		});
+	}
+}
 module.exports = NodeHotUpdateChunkTemplatePlugin;
-
-NodeHotUpdateChunkTemplatePlugin.prototype.apply = function(hotUpdateChunkTemplate) {
-	hotUpdateChunkTemplate.plugin("render", function(modulesSource, modules, removedModules, hash, id) {
-		var source = new ConcatSource();
-		source.add("exports.id = " + JSON.stringify(id) + ";\nexports.modules = ");
-		source.add(modulesSource);
-		source.add(";");
-		return source;
-	});
-	hotUpdateChunkTemplate.plugin("hash", function(hash) {
-		hash.update("NodeHotUpdateChunkTemplatePlugin");
-		hash.update("3");
-		hash.update(this.outputOptions.hotUpdateFunction + "");
-		hash.update(this.outputOptions.library + "");
-	});
-};


### PR DESCRIPTION
What kind of change does this PR introduce?
refactor, ES5 => ES6

Did you add tests for your changes?
No, all existing tests pass

If relevant, link to documentation update:
N/A

Summary
upgraded NodeHotUpdateChunkTemplatePlugin to ES6

Does this PR introduce a breaking change?
No