### PR TITLE
Update watchpack dependency also for webpack 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "supports-color": "^3.1.0",
     "tapable": "~0.1.8",
     "uglify-js": "~2.7.3",
-    "watchpack": "^0.2.1",
+    "watchpack": "^1.2.0",
     "webpack-core": "~0.6.9"
   },
   "license": "MIT",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Dependency update

**Did you add tests for your changes?**

N/A

**If relevant, link to documentation update:**

N/A

**Summary**

Watchpack version bump to `1.2.0` is already landed in webpack 2 via #3649. 

This PR is a cherry pick of e91c799 to apply this version version bump also for webpack 1 as the current version constraint `^0.2.1` does not satisfy `1.2.0`.

Fixes:
- watch mode fires an immediate rebuild  (webpack/watchpack#40)
- allow usage of watchOptions.ignored (webpack/watchpack#23)

**Does this PR introduce a breaking change?**

No

**Other information**
