### PR TITLE
Add tests for MultiCompiler

### DIFF
--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -4,23 +4,8 @@
 */
 var Tapable = require("tapable");
 var async = require("async");
-var Stats = require("./Stats");
-
-function MultiWatching(watchings) {
-	this.watchings = watchings;
-}
-
-MultiWatching.prototype.invalidate = function() {
-	this.watchings.forEach(function(watching) {
-		watching.invalidate();
-	});
-};
-
-MultiWatching.prototype.close = function(callback) {
-	async.forEach(this.watchings, function(watching, callback) {
-		watching.close(callback);
-	}, callback);
-};
+var MultiWatching = require("./MultiWatching");
+var MultiStats = require("./MultiStats");
 
 function MultiCompiler(compilers) {
 	Tapable.call(this);
@@ -190,55 +175,3 @@ MultiCompiler.prototype.purgeInputFileSystem = function() {
 			compiler.inputFileSystem.purge();
 	});
 };
-
-function MultiStats(stats) {
-	this.stats = stats;
-	this.hash = stats.map(function(stat) {
-		return stat.hash;
-	}).join("");
-}
-
-MultiStats.prototype.hasErrors = function() {
-	return this.stats.map(function(stat) {
-		return stat.hasErrors();
-	}).reduce(function(a, b) {
-		return a || b;
-	}, false);
-};
-
-MultiStats.prototype.hasWarnings = function() {
-	return this.stats.map(function(stat) {
-		return stat.hasWarnings();
-	}).reduce(function(a, b) {
-		return a || b;
-	}, false);
-};
-
-MultiStats.prototype.toJson = function(options, forToString) {
-	var jsons = this.stats.map(function(stat) {
-		var obj = stat.toJson(options, forToString);
-		obj.name = stat.compilation && stat.compilation.name;
-		return obj;
-	});
-	var obj = {
-		errors: jsons.reduce(function(arr, j) {
-			return arr.concat(j.errors.map(function(msg) {
-				return "(" + j.name + ") " + msg;
-			}));
-		}, []),
-		warnings: jsons.reduce(function(arr, j) {
-			return arr.concat(j.warnings.map(function(msg) {
-				return "(" + j.name + ") " + msg;
-			}));
-		}, [])
-	};
-	if(!options || options.version !== false)
-		obj.version = require("../package.json").version;
-	if(!options || options.hash !== false)
-		obj.hash = this.hash;
-	if(!options || options.children !== false)
-		obj.children = jsons;
-	return obj;
-};
-
-MultiStats.prototype.toString = Stats.prototype.toString;

--- a/lib/MultiStats.js
+++ b/lib/MultiStats.js
@@ -1,0 +1,59 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var Stats = require("./Stats");
+
+function MultiStats(stats) {
+	this.stats = stats;
+	this.hash = stats.map(function(stat) {
+		return stat.hash;
+	}).join("");
+}
+
+MultiStats.prototype.hasErrors = function() {
+	return this.stats.map(function(stat) {
+		return stat.hasErrors();
+	}).reduce(function(a, b) {
+		return a || b;
+	}, false);
+};
+
+MultiStats.prototype.hasWarnings = function() {
+	return this.stats.map(function(stat) {
+		return stat.hasWarnings();
+	}).reduce(function(a, b) {
+		return a || b;
+	}, false);
+};
+
+MultiStats.prototype.toJson = function(options, forToString) {
+	var jsons = this.stats.map(function(stat) {
+		var obj = stat.toJson(options, forToString);
+		obj.name = stat.compilation && stat.compilation.name;
+		return obj;
+	});
+	var obj = {
+		errors: jsons.reduce(function(arr, j) {
+			return arr.concat(j.errors.map(function(msg) {
+				return "(" + j.name + ") " + msg;
+			}));
+		}, []),
+		warnings: jsons.reduce(function(arr, j) {
+			return arr.concat(j.warnings.map(function(msg) {
+				return "(" + j.name + ") " + msg;
+			}));
+		}, [])
+	};
+	if(!options || options.version !== false)
+		obj.version = require("../package.json").version;
+	if(!options || options.hash !== false)
+		obj.hash = this.hash;
+	if(!options || options.children !== false)
+		obj.children = jsons;
+	return obj;
+};
+
+MultiStats.prototype.toString = Stats.prototype.toString;
+
+module.exports = MultiStats;

--- a/lib/MultiWatching.js
+++ b/lib/MultiWatching.js
@@ -15,8 +15,8 @@ MultiWatching.prototype.invalidate = function() {
 };
 
 MultiWatching.prototype.close = function(callback) {
-	async.forEach(this.watchings, function(watching, callback) {
-		watching.close(callback);
+	async.forEach(this.watchings, function(watching, finishedCallback) {
+		watching.close(finishedCallback);
 	}, callback);
 };
 

--- a/lib/MultiWatching.js
+++ b/lib/MultiWatching.js
@@ -1,0 +1,23 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+var async = require("async");
+
+function MultiWatching(watchings) {
+	this.watchings = watchings;
+}
+
+MultiWatching.prototype.invalidate = function() {
+	this.watchings.forEach(function(watching) {
+		watching.invalidate();
+	});
+};
+
+MultiWatching.prototype.close = function(callback) {
+	async.forEach(this.watchings, function(watching, callback) {
+		watching.close(callback);
+	}, callback);
+};
+
+module.exports = MultiWatching;

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -1,0 +1,543 @@
+var should = require("should");
+var sinon = require("sinon");
+var MultiCompiler = require("../lib/MultiCompiler");
+
+function CompilerEnvironment() {
+	var pluginEvents = [];
+	var runCallbacks = [];
+	var watchCallbacks = [];
+
+	this.getCompilerStub = function() {
+		return {
+			plugin: function(name, handler) {
+				pluginEvents.push({
+					name,
+					handler
+				});
+			},
+			run: function(callback) {
+				runCallbacks.push({
+					callback
+				});
+			},
+			watch: function(options, callback) {
+				watchCallbacks.push({
+					options,
+					callback
+				});
+				return this.name;
+			}
+		};
+	};
+
+	this.getPluginEventBindings = function() {
+		return pluginEvents;
+	};
+
+	this.getRunCallbacks = function() {
+		return runCallbacks;
+	};
+
+	this.getWatchCallbacks = function() {
+		return watchCallbacks;
+	};
+};
+
+var createCompiler = function(overrides) {
+	var compilerEnvironment = new CompilerEnvironment();
+	return Object.assign({
+		outputPath: "/"
+	}, compilerEnvironment.getCompilerStub(), overrides);
+};
+
+var setupTwoCompilerEnvironment = function(env, compiler1Values, compiler2Values) {
+	var compilerEnvironment1 = new CompilerEnvironment();
+	var compilerEnvironment2 = new CompilerEnvironment();
+	var compilers = [
+		Object.assign({
+			name: "compiler1"
+		}, (compiler1Values || {}), compilerEnvironment1.getCompilerStub()),
+		Object.assign({
+			name: "compiler2"
+		}, (compiler2Values || {}), compilerEnvironment2.getCompilerStub())
+	];
+	env.myMultiCompiler = new MultiCompiler(compilers);
+	env.compiler1EventBindings = compilerEnvironment1.getPluginEventBindings();
+	env.compiler2EventBindings = compilerEnvironment2.getPluginEventBindings();
+	env.compiler1WatchCallbacks = compilerEnvironment1.getWatchCallbacks();
+	env.compiler2WatchCallbacks = compilerEnvironment2.getWatchCallbacks();
+	env.compiler1RunCallbacks = compilerEnvironment1.getRunCallbacks();
+	env.compiler2RunCallbacks = compilerEnvironment2.getRunCallbacks();
+};
+
+describe("MultiCompiler", function() {
+	var env;
+	beforeEach(function() {
+		env = {};
+	});
+
+	describe("constructor", function() {
+		describe("when provided an array of compilers", function() {
+			beforeEach(function() {
+				env.compilers = [createCompiler(), createCompiler()];
+				env.myMultiCompiler = new MultiCompiler(env.compilers);
+			});
+
+			it("sets the compilers property to the array", function() {
+				env.myMultiCompiler.compilers.should.be.exactly(env.compilers);
+			});
+		});
+
+		describe("when provided a compiler mapping", function() {
+			beforeEach(function() {
+				var compilers = {
+					compiler1: createCompiler(),
+					compiler2: createCompiler()
+				};
+				env.myMultiCompiler = new MultiCompiler(compilers);
+			});
+
+			it("sets the compilers property to an array of compilers", function() {
+				env.myMultiCompiler.compilers.should.deepEqual([
+					Object.assign({
+						name: "compiler1"
+					}, createCompiler()),
+					Object.assign({
+						name: "compiler2"
+					}, createCompiler())
+				]);
+			});
+		});
+
+		describe("defined properties", function() {
+			describe("outputFileSystem", function() {
+				beforeEach(function() {
+					env.compilers = [createCompiler(), createCompiler()];
+					env.myMultiCompiler = new MultiCompiler(env.compilers);
+				});
+
+				it("throws an error when reading the value", function() {
+					should(function() {
+						env.myMultiCompiler.outputFileSystem
+					}).throw("Cannot read outputFileSystem of a MultiCompiler");
+				});
+
+				it("updates all compilers when setting the value", function() {
+					env.myMultiCompiler.outputFileSystem = "foo";
+					env.compilers[0].outputFileSystem.should.be.exactly("foo");
+					env.compilers[1].outputFileSystem.should.be.exactly("foo");
+				});
+			});
+
+			describe("inputFileSystem", function() {
+				beforeEach(function() {
+					env.compilers = [createCompiler(), createCompiler()];
+					env.myMultiCompiler = new MultiCompiler(env.compilers);
+				});
+
+				it("throws an error when reading the value", function() {
+					should(function() {
+						env.myMultiCompiler.inputFileSystem
+					}).throw("Cannot read inputFileSystem of a MultiCompiler");
+				});
+
+				it("updates all compilers when setting the value", function() {
+					env.myMultiCompiler.inputFileSystem = "foo";
+					env.compilers[0].inputFileSystem.should.be.exactly("foo");
+					env.compilers[1].inputFileSystem.should.be.exactly("foo");
+				});
+			});
+
+			describe("outputPath", function() {
+				describe("when common path cannot be found and output path is absolute", function() {
+					beforeEach(function() {
+						env.compilers = [
+							createCompiler({
+								outputPath: "/foo/bar"
+							}),
+							createCompiler({
+								outputPath: "quux"
+							})
+						];
+						env.myMultiCompiler = new MultiCompiler(env.compilers);
+					});
+
+					it("returns the root path", function() {
+						env.myMultiCompiler.outputPath.should.be.exactly("/");
+					});
+				});
+
+				describe("when common path cannot be found and output path is relative", function() {
+					beforeEach(function() {
+						env.compilers = [
+							createCompiler({
+								outputPath: "foo/bar/baz"
+							}),
+							createCompiler({
+								outputPath: "quux"
+							})
+						];
+						env.myMultiCompiler = new MultiCompiler(env.compilers);
+					});
+
+					it("returns the first segment of relative path", function() {
+						env.myMultiCompiler.outputPath.should.be.exactly("foo");
+					});
+				});
+
+				describe("when common path can be found and output path is absolute", function() {
+					beforeEach(function() {
+						env.compilers = [
+							createCompiler({
+								outputPath: "/foo"
+							}),
+							createCompiler({
+								outputPath: "/foo/bar/baz"
+							})
+						];
+						env.myMultiCompiler = new MultiCompiler(env.compilers);
+					});
+
+					it("returns the shared path", function() {
+						env.myMultiCompiler.outputPath.should.be.exactly("/foo");
+					});
+				});
+
+				describe("when common path can be found and output path is relative", function() {
+					beforeEach(function() {
+						env.compilers = [
+							createCompiler({
+								outputPath: "foo"
+							}),
+							createCompiler({
+								outputPath: "foo/bar/baz"
+							})
+						];
+						env.myMultiCompiler = new MultiCompiler(env.compilers);
+					});
+
+					it("returns the shared path", function() {
+						env.myMultiCompiler.outputPath.should.be.exactly("foo");
+					});
+				});
+			});
+		});
+
+		describe("compiler events", function() {
+			beforeEach(function() {
+				setupTwoCompilerEnvironment(env);
+			});
+
+			it("binds two event handler", function() {
+				env.compiler1EventBindings.length.should.be.exactly(2);
+				env.compiler2EventBindings.length.should.be.exactly(2);
+			});
+
+			describe("done handler", function() {
+				beforeEach(function() {
+					env.doneEventBinding1 = env.compiler1EventBindings[0];
+					env.doneEventBinding2 = env.compiler2EventBindings[0];
+				});
+
+				it("binds to done event", function() {
+					env.doneEventBinding1.name.should.be.exactly("done");
+				});
+
+				describe('when called for first compiler', function() {
+					beforeEach(function() {
+						env.mockDonePlugin = sinon.spy();
+						env.myMultiCompiler.plugin('done', env.mockDonePlugin);
+						env.doneEventBinding1.handler({
+							hash: "foo"
+						});
+					});
+
+					it("does not call the done plugin when not all compilers are finished", function() {
+						env.mockDonePlugin.callCount.should.be.exactly(0);
+					});
+
+					describe('and called for second compiler', function() {
+						beforeEach(function() {
+							env.doneEventBinding2.handler({
+								hash: "bar"
+							});
+						});
+
+						it("calls the done plugin", function() {
+							env.mockDonePlugin.callCount.should.be.exactly(1);
+						});
+					});
+				});
+			});
+
+			describe("invalid handler", function() {
+				beforeEach(function() {
+					env.invalidEventBinding = env.compiler1EventBindings[1];
+				});
+
+				it("binds to invalid event", function() {
+					env.invalidEventBinding.name.should.be.exactly("invalid");
+				});
+
+				describe('when called', function() {
+					beforeEach(function() {
+						env.mockInvalidPlugin = sinon.spy();
+						env.myMultiCompiler.plugin('invalid', env.mockInvalidPlugin);
+						env.invalidEventBinding.handler();
+					});
+
+					it("calls the invalid plugin", function() {
+						env.mockInvalidPlugin.callCount.should.be.exactly(1);
+					});
+				});
+			});
+		});
+	});
+
+	describe("watch", function() {
+		describe("without compiler dependencies", function() {
+			beforeEach(function() {
+				setupTwoCompilerEnvironment(env);
+				env.callback = sinon.spy();
+				env.options = {
+					testWatchOptions: true
+				};
+				env.result = env.myMultiCompiler.watch(env.options, env.callback);
+			});
+
+			it("returns a multi-watching object", function() {
+				var result = JSON.stringify(env.result);
+				result.should.be.exactly('{"watchings":["compiler1","compiler2"]}');
+			});
+
+			it("calls watch on each compiler with original options", function() {
+				env.compiler1WatchCallbacks.length.should.be.exactly(1);
+				env.compiler1WatchCallbacks[0].options.should.be.exactly(env.options);
+				env.compiler2WatchCallbacks.length.should.be.exactly(1);
+				env.compiler2WatchCallbacks[0].options.should.be.exactly(env.options);
+			});
+
+			it("calls the callback when all compilers watch", function() {
+				env.compiler1WatchCallbacks[0].callback(null, {
+					hash: 'foo'
+				});
+				env.callback.callCount.should.be.exactly(0);
+				env.compiler2WatchCallbacks[0].callback(null, {
+					hash: 'bar'
+				});
+				env.callback.callCount.should.be.exactly(1);
+			});
+
+			describe("on first run", function() {
+				describe("callback called with no compiler errors", function() {
+					beforeEach(function() {
+						env.compiler1WatchCallbacks[0].callback(new Error('Test error'));
+					});
+
+					it('has failure parameters', function() {
+						env.callback.callCount.should.be.exactly(1);
+						env.callback.getCall(0).args[0].should.be.Error();
+						should(env.callback.getCall(0).args[1]).be.undefined();
+					});
+				});
+
+				describe("callback called with no compiler errors", function() {
+					beforeEach(function() {
+						env.compiler1WatchCallbacks[0].callback(null, {
+							hash: 'foo'
+						});
+					});
+
+					it('does not call the callback', function() {
+						env.callback.callCount.should.be.exactly(0);
+					});
+				});
+			});
+
+			describe("on subsequent runs", function() {
+				describe("callback called with compiler errors", function() {
+					beforeEach(function() {
+						env.compiler1WatchCallbacks[0].callback(null, {
+							hash: 'foo'
+						});
+						env.compiler2WatchCallbacks[0].callback(new Error('Test error'));
+					});
+
+					it('has failure parameters', function() {
+						env.callback.callCount.should.be.exactly(1);
+						env.callback.getCall(0).args[0].should.be.Error();
+						should(env.callback.getCall(0).args[1]).be.undefined();
+					});
+				});
+
+				describe("callback called with no compiler errors", function() {
+					beforeEach(function() {
+						env.compiler1WatchCallbacks[0].callback(null, {
+							hash: 'foo'
+						});
+						env.compiler2WatchCallbacks[0].callback(null, {
+							hash: 'bar'
+						});
+					});
+
+					it('has success parameters', function() {
+						env.callback.callCount.should.be.exactly(1);
+						should(env.callback.getCall(0).args[0]).be.Null();
+						var stats = JSON.stringify(env.callback.getCall(0).args[1]);
+						stats.should.be.exactly('{"stats":[{"hash":"foo"},{"hash":"bar"}],"hash":"foobar"}');
+					});
+				});
+			});
+		});
+
+		describe("with compiler dependencies", function() {
+			beforeEach(function() {
+				setupTwoCompilerEnvironment(env, {
+					name: "compiler1",
+					dependencies: ["compiler2"]
+				}, {
+					name: "compiler2"
+				});
+				env.callback = sinon.spy();
+				env.options = {
+					testWatchOptions: true
+				};
+				env.result = env.myMultiCompiler.watch(env.options, env.callback);
+			});
+
+			it("calls run on each compiler in dependency order", function() {
+				env.compiler1WatchCallbacks.length.should.be.exactly(0);
+				env.compiler2WatchCallbacks.length.should.be.exactly(1);
+				env.compiler2WatchCallbacks[0].options.should.be.exactly(env.options);
+				env.compiler2WatchCallbacks[0].callback(null, {
+					hash: 'bar'
+				});
+				env.compiler1WatchCallbacks.length.should.be.exactly(1);
+				env.compiler1WatchCallbacks[0].options.should.be.exactly(env.options);
+			});
+
+			it("calls the callback when all compilers run in dependency order", function() {
+				env.compiler2WatchCallbacks[0].callback(null, {
+					hash: 'bar'
+				});
+				env.callback.callCount.should.be.exactly(0);
+				env.compiler1WatchCallbacks[0].callback(null, {
+					hash: 'foo'
+				});
+				env.callback.callCount.should.be.exactly(1);
+			});
+		});
+	});
+
+	describe("run", function() {
+		describe("without compiler dependencies", function() {
+			beforeEach(function() {
+				setupTwoCompilerEnvironment(env);
+				env.callback = sinon.spy();
+				env.myMultiCompiler.run(env.callback);
+			});
+
+			it("calls run on each compiler", function() {
+				env.compiler1RunCallbacks.length.should.be.exactly(1);
+				env.compiler2RunCallbacks.length.should.be.exactly(1);
+			});
+
+			it("calls the callback when all compilers run", function() {
+				env.compiler1RunCallbacks[0].callback(null, {
+					hash: 'foo'
+				});
+				env.callback.callCount.should.be.exactly(0);
+				env.compiler2RunCallbacks[0].callback(null, {
+					hash: 'bar'
+				});
+				env.callback.callCount.should.be.exactly(1);
+			});
+
+			describe("callback called with no compiler errors", function() {
+				beforeEach(function() {
+					env.compiler1RunCallbacks[0].callback(null, {
+						hash: 'foo'
+					});
+					env.compiler2RunCallbacks[0].callback(null, {
+						hash: 'bar'
+					});
+				});
+
+				it('has success parameters', function() {
+					env.callback.callCount.should.be.exactly(1);
+					should(env.callback.getCall(0).args[0]).be.Null();
+					var stats = JSON.stringify(env.callback.getCall(0).args[1]);
+					stats.should.be.exactly('{"stats":[{"hash":"foo"},{"hash":"bar"}],"hash":"foobar"}');
+				});
+			});
+
+			describe("callback called with compiler errors", function() {
+				beforeEach(function() {
+					env.compiler1RunCallbacks[0].callback(null, {
+						hash: 'foo'
+					});
+					env.compiler2RunCallbacks[0].callback(new Error('Test error'));
+				});
+
+				it('has failure parameters', function() {
+					env.callback.callCount.should.be.exactly(1);
+					env.callback.getCall(0).args[0].should.be.Error();
+					should(env.callback.getCall(0).args[1]).be.undefined();
+				});
+			});
+		});
+
+		describe("with compiler dependencies", function() {
+			beforeEach(function() {
+				setupTwoCompilerEnvironment(env, {
+					name: "compiler1",
+					dependencies: ["compiler2"]
+				}, {
+					name: "compiler2"
+				});
+				env.callback = sinon.spy();
+				env.myMultiCompiler.run(env.callback);
+			});
+
+			it("calls run on each compiler in dependency order", function() {
+				env.compiler1RunCallbacks.length.should.be.exactly(0);
+				env.compiler2RunCallbacks.length.should.be.exactly(1);
+				env.compiler2RunCallbacks[0].callback(null, {
+					hash: 'bar'
+				});
+				env.compiler1RunCallbacks.length.should.be.exactly(1);
+			});
+
+			it("calls the callback when all compilers run in dependency order", function() {
+				env.compiler2RunCallbacks[0].callback(null, {
+					hash: 'bar'
+				});
+				env.callback.callCount.should.be.exactly(0);
+				env.compiler1RunCallbacks[0].callback(null, {
+					hash: 'foo'
+				});
+				env.callback.callCount.should.be.exactly(1);
+			});
+		});
+	});
+
+	describe("purgeInputFileSystem", function() {
+		beforeEach(function() {
+			env.compilers = [
+				Object.assign({
+					inputFileSystem: {
+						purge: sinon.spy()
+					}
+				}, createCompiler()),
+				createCompiler()
+			];
+			env.myMultiCompiler = new MultiCompiler(env.compilers);
+			env.myMultiCompiler.purgeInputFileSystem();
+		});
+
+		it("calls the compilers purge if available", function() {
+			var purgeSpy = env.compilers[0].inputFileSystem.purge;
+			purgeSpy.callCount.should.be.exactly(1);
+		});
+	});
+});

--- a/test/MultiStats.test.js
+++ b/test/MultiStats.test.js
@@ -1,0 +1,244 @@
+var should = require("should");
+var sinon = require("sinon");
+var package = require("../package.json");
+var MultiStats = require("../lib/MultiStats");
+
+var createStat = function(overides) {
+	return Object.assign({
+		hash: "foo",
+		compilation: {
+			name: "bar"
+		},
+		hasErrors: () => false,
+		hasWarnings: () => false,
+		toJson: () => ({
+			warnings: [],
+			errors: []
+		})
+	}, overides);
+};
+
+describe("MultiStats", function() {
+	var packageVersion, stats, myMultiStats, result;
+
+	beforeEach(function() {
+		packageVersion = package.version;
+		package.version = "1.2.3";
+	});
+
+	afterEach(function() {
+		package.version = packageVersion;
+	});
+
+	describe("created", function() {
+		beforeEach(function() {
+			stats = [
+				createStat({
+					hash: "abc123"
+				}),
+				createStat({
+					hash: "xyz890"
+				})
+			];
+			myMultiStats = new MultiStats(stats);
+		});
+
+		it("creates a hash string", function() {
+			myMultiStats.hash.should.be.exactly("abc123xyz890");
+		});
+	});
+
+	describe("hasErrors", function() {
+		describe("when both have errors", function() {
+			beforeEach(function() {
+				stats = [
+					createStat({
+						hasErrors: () => true
+					}),
+					createStat({
+						hasErrors: () => true
+					})
+				];
+				myMultiStats = new MultiStats(stats);
+			});
+
+			it("returns true", function() {
+				myMultiStats.hasErrors().should.be.exactly(true);
+			});
+		});
+
+		describe("when one has an error", function() {
+			beforeEach(function() {
+				stats = [
+					createStat({
+						hasErrors: () => true
+					}),
+					createStat()
+				];
+				myMultiStats = new MultiStats(stats);
+			});
+
+			it("returns true", function() {
+				myMultiStats.hasErrors().should.be.exactly(true);
+			});
+		});
+
+		describe("when none have errors", function() {
+			beforeEach(function() {
+				stats = [
+					createStat(),
+					createStat()
+				];
+				myMultiStats = new MultiStats(stats);
+			});
+
+			it("returns false", function() {
+				myMultiStats.hasErrors().should.be.exactly(false);
+			});
+		});
+	});
+
+	describe("hasWarnings", function() {
+		describe("when both have warnings", function() {
+			beforeEach(function() {
+				stats = [
+					createStat({
+						hasWarnings: () => true
+					}),
+					createStat({
+						hasWarnings: () => true
+					})
+				];
+				myMultiStats = new MultiStats(stats);
+			});
+
+			it("returns true", function() {
+				myMultiStats.hasWarnings().should.be.exactly(true);
+			});
+		});
+
+		describe("when one has a warning", function() {
+			beforeEach(function() {
+				stats = [
+					createStat({
+						hasWarnings: () => true
+					}),
+					createStat()
+				];
+				myMultiStats = new MultiStats(stats);
+			});
+
+			it("returns true", function() {
+				myMultiStats.hasWarnings().should.be.exactly(true);
+			});
+		});
+
+		describe("when none have warnings", function() {
+			beforeEach(function() {
+				stats = [
+					createStat(),
+					createStat()
+				];
+				myMultiStats = new MultiStats(stats);
+			});
+
+			it("returns false", function() {
+				myMultiStats.hasWarnings().should.be.exactly(false);
+			});
+		});
+	});
+
+	describe("toJson", function() {
+		beforeEach(function() {
+			stats = [
+				createStat({
+					hash: "abc123",
+					compilation: {
+						name: "abc123-compilation"
+					},
+					toJson: () => ({
+						warnings: ["abc123-warning"],
+						errors: ["abc123-error"]
+					})
+				}),
+				createStat({
+					hash: "xyz890",
+					compilation: {
+						name: "xyz890-compilation"
+					},
+					toJson: () => ({
+						warnings: ["xyz890-warning-1", "xyz890-warning-2"],
+						errors: []
+					})
+				})
+			];
+			myMultiStats = new MultiStats(stats);
+			result = myMultiStats.toJson();
+		});
+
+		it("returns plain object representation", function() {
+			result.should.deepEqual({
+				hash: "abc123xyz890",
+				version: "1.2.3",
+				errors: [
+					"(abc123-compilation) abc123-error"
+				],
+				warnings: [
+					"(abc123-compilation) abc123-warning",
+					"(xyz890-compilation) xyz890-warning-1",
+					"(xyz890-compilation) xyz890-warning-2"
+				],
+				children: [{
+						errors: [
+							"abc123-error"
+						],
+						name: "abc123-compilation",
+						warnings: [
+							"abc123-warning"
+						]
+					},
+					{
+						errors: [],
+						name: "xyz890-compilation",
+						warnings: [
+							"xyz890-warning-1",
+							"xyz890-warning-2"
+						]
+					}
+				]
+			});
+		});
+	});
+
+	describe("toString", function() {
+		beforeEach(function() {
+			stats = [
+				createStat({
+					hash: "abc123",
+					compilation: {
+						name: "abc123-compilation"
+					}
+				}),
+				createStat({
+					hash: "xyz890",
+					compilation: {
+						name: "xyz890-compilation"
+					}
+				})
+			];
+			myMultiStats = new MultiStats(stats);
+			result = myMultiStats.toString();
+		});
+
+		it("returns string representation", function() {
+			result.should.be.exactly(
+				"Hash: abc123xyz890\n" +
+				"Version: webpack 1.2.3\n" +
+				"Child abc123-compilation:\n" +
+				"    \n" +
+				"Child xyz890-compilation:\n" +
+				"    "
+			);
+		});
+	});
+});

--- a/test/MultiWatching.test.js
+++ b/test/MultiWatching.test.js
@@ -1,0 +1,53 @@
+var should = require("should");
+var sinon = require("sinon");
+var MultiWatching = require("../lib/MultiWatching");
+
+var createWatching = function() {
+	return {
+		invalidate: sinon.spy(),
+		close: sinon.spy()
+	};
+};
+
+describe("MultiWatching", function() {
+	var watchings, myMultiWatching;
+
+	beforeEach(function() {
+		watchings = [createWatching(), createWatching()];
+		myMultiWatching = new MultiWatching(watchings);
+	});
+
+	describe('invalidate', function() {
+		beforeEach(function() {
+			myMultiWatching.invalidate();
+		});
+
+		it('invalidates each watching', function() {
+			watchings[0].invalidate.callCount.should.be.exactly(1);
+			watchings[1].invalidate.callCount.should.be.exactly(1);
+		});
+	});
+
+	describe('close', function() {
+		var callback;
+		var callClosedFinishedCallback = function(watching) {
+			watching.close.getCall(0).args[0]();
+		};
+
+		beforeEach(function() {
+			callback = sinon.spy();
+			myMultiWatching.close(callback);
+		});
+
+		it('closes each watching', function() {
+			watchings[0].close.callCount.should.be.exactly(1);
+			watchings[1].close.callCount.should.be.exactly(1);
+		});
+
+		it('calls callback after each watching has closed', function() {
+			callClosedFinishedCallback(watchings[0]);
+			callClosedFinishedCallback(watchings[1]);
+			callback.callCount.should.be.exactly(1);
+		});
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Add tests for MultiCompiler

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

This PR is only tests, with some code split out

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Based on the coveralls report, the `MultiCompiler` file has 86% test coverage (previously 66% when picked up). There is no `MultiCompiler` specific test file - this is added in this PR as well as splitting out `MultiWatching` and `MultiStats` into separate files for testing, and aims to achieve 100% test coverage.
https://coveralls.io/builds/9547012/source?filename=lib%2FMultiCompiler.js

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**

None