### PR TITLE
fix(tests): fix line endings which broke master statsCases

### DIFF
--- a/test/statsCases/performance-error/expected.txt
+++ b/test/statsCases/performance-error/expected.txt
@@ -16,7 +16,7 @@ chunk    {<CLR=33,BOLD>3</CLR>} <CLR=32,BOLD>main.js</CLR> (main) 300 kB<CLR=33,
     [0] <CLR=BOLD>(webpack)/test/statsCases/performance-error/a.js</CLR> 300 kB {<CLR=33,BOLD>3</CLR>}<CLR=32,BOLD> [built]</CLR>
     [5] <CLR=BOLD>(webpack)/test/statsCases/performance-error/index.js</CLR> 52 bytes {<CLR=33,BOLD>3</CLR>}<CLR=32,BOLD> [built]</CLR>
 
-<CLR=31,BOLD>ERROR in asset size limit: The following asset(s) exceed the recommended size limit (250 kB). 
+<CLR=31,BOLD>ERROR in asset size limit: The following asset(s) exceed the recommended size limit (250 kB).
 This can impact web performance.
 Assets: 
   main.js (306 kB)</CLR>

--- a/test/statsCases/performance-no-async-chunks-shown/expected.txt
+++ b/test/statsCases/performance-no-async-chunks-shown/expected.txt
@@ -14,7 +14,7 @@ chunk    {<CLR=33,BOLD>1</CLR>} <CLR=32,BOLD>main.js</CLR> (main) 300 kB<CLR=33,
     [1] <CLR=BOLD>(webpack)/test/statsCases/performance-no-async-chunks-shown/a.js</CLR> 300 kB {<CLR=33,BOLD>1</CLR>}<CLR=32,BOLD> [built]</CLR>
     [4] <CLR=BOLD>(webpack)/test/statsCases/performance-no-async-chunks-shown/index.js</CLR> 32 bytes {<CLR=33,BOLD>1</CLR>}<CLR=32,BOLD> [built]</CLR>
 
-<CLR=33,BOLD>WARNING in asset size limit: The following asset(s) exceed the recommended size limit (250 kB). 
+<CLR=33,BOLD>WARNING in asset size limit: The following asset(s) exceed the recommended size limit (250 kB).
 This can impact web performance.
 Assets: 
   main.js (303 kB)</CLR>

--- a/test/statsCases/preset-normal-performance-ensure-filter-sourcemaps/expected.txt
+++ b/test/statsCases/preset-normal-performance-ensure-filter-sourcemaps/expected.txt
@@ -19,7 +19,7 @@ chunk    {<CLR=33,BOLD>3</CLR>} <CLR=32,BOLD>main.js, main.js.map</CLR> (main) 3
     [0] <CLR=BOLD>(webpack)/test/statsCases/preset-normal-performance-ensure-filter-sourcemaps/a.js</CLR> 300 kB {<CLR=33,BOLD>3</CLR>}<CLR=32,BOLD> [built]</CLR>
     [5] <CLR=BOLD>(webpack)/test/statsCases/preset-normal-performance-ensure-filter-sourcemaps/index.js</CLR> 52 bytes {<CLR=33,BOLD>3</CLR>}<CLR=32,BOLD> [built]</CLR>
 
-<CLR=33,BOLD>WARNING in asset size limit: The following asset(s) exceed the recommended size limit (250 kB). 
+<CLR=33,BOLD>WARNING in asset size limit: The following asset(s) exceed the recommended size limit (250 kB).
 This can impact web performance.
 Assets: 
   main.js (306 kB)</CLR>

--- a/test/statsCases/preset-normal-performance/expected.txt
+++ b/test/statsCases/preset-normal-performance/expected.txt
@@ -15,7 +15,7 @@ chunk    {<CLR=33,BOLD>3</CLR>} <CLR=32,BOLD>main.js</CLR> (main) 300 kB<CLR=33,
     [0] <CLR=BOLD>(webpack)/test/statsCases/preset-normal-performance/a.js</CLR> 300 kB {<CLR=33,BOLD>3</CLR>}<CLR=32,BOLD> [built]</CLR>
     [5] <CLR=BOLD>(webpack)/test/statsCases/preset-normal-performance/index.js</CLR> 52 bytes {<CLR=33,BOLD>3</CLR>}<CLR=32,BOLD> [built]</CLR>
 
-<CLR=33,BOLD>WARNING in asset size limit: The following asset(s) exceed the recommended size limit (250 kB). 
+<CLR=33,BOLD>WARNING in asset size limit: The following asset(s) exceed the recommended size limit (250 kB).
 This can impact web performance.
 Assets: 
   main.js (306 kB)</CLR>


### PR DESCRIPTION
A rogue extra line ending was breaking stats. This has been fixed now. 