### PR TITLE
refactoring AMDRequireDependenciesBlock to es6 syntax

### DIFF
--- a/lib/dependencies/AMDRequireDependenciesBlock.js
+++ b/lib/dependencies/AMDRequireDependenciesBlock.js
@@ -2,33 +2,32 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
-var AMDRequireDependency = require("./AMDRequireDependency");
+"use strict";
+const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
+const AMDRequireDependency = require("./AMDRequireDependency");
 
-function AMDRequireDependenciesBlock(expr, arrayRange, functionRange, errorCallbackRange, module, loc) {
-	AsyncDependenciesBlock.call(this, null, module, loc);
-	this.expr = expr;
-	this.outerRange = expr.range;
-	this.arrayRange = arrayRange;
-	this.functionRange = functionRange;
-	this.errorCallbackRange = errorCallbackRange;
-	this.bindThis = true;
-	if(arrayRange && functionRange && errorCallbackRange) {
-		this.range = [arrayRange[0], errorCallbackRange[1]];
-	} else if(arrayRange && functionRange) {
-		this.range = [arrayRange[0], functionRange[1]];
-	} else if(arrayRange) {
-		this.range = arrayRange;
-	} else if(functionRange) {
-		this.range = functionRange;
-	} else {
-		this.range = expr.range;
+module.exports = class AMDRequireDependenciesBlock extends AsyncDependenciesBlock {
+	constructor(expr, arrayRange, functionRange, errorCallbackRange, module, loc) {
+		super(null, module, loc);
+		this.expr = expr;
+		this.outerRange = expr.range;
+		this.arrayRange = arrayRange;
+		this.functionRange = functionRange;
+		this.errorCallbackRange = errorCallbackRange;
+		this.bindThis = true;
+		if(arrayRange && functionRange && errorCallbackRange) {
+			this.range = [arrayRange[0], errorCallbackRange[1]];
+		} else if(arrayRange && functionRange) {
+			this.range = [arrayRange[0], functionRange[1]];
+		} else if(arrayRange) {
+			this.range = arrayRange;
+		} else if(functionRange) {
+			this.range = functionRange;
+		} else {
+			this.range = expr.range;
+		}
+		let dep = new AMDRequireDependency(this);
+		dep.loc = loc;
+		this.addDependency(dep);
 	}
-	var dep = new AMDRequireDependency(this);
-	dep.loc = loc;
-	this.addDependency(dep);
 }
-module.exports = AMDRequireDependenciesBlock;
-
-AMDRequireDependenciesBlock.prototype = Object.create(AsyncDependenciesBlock.prototype);
-AMDRequireDependenciesBlock.prototype.constructor = AMDRequireDependenciesBlock;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
refactoring, ES5 => ES6

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No behavioural changes in functions, so all tests should pass
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Upgrade the MovedToPluginWarningPlugin to ES6
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
NO
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

