### PR TITLE
Add tests for LibraryTemplatePlugin

### DIFF
--- a/test/LibraryTemplatePlugin.test.js
+++ b/test/LibraryTemplatePlugin.test.js
@@ -1,0 +1,323 @@
+var should = require("should");
+var sinon = require("sinon");
+var LibraryTemplatePlugin = require("../lib/LibraryTemplatePlugin");
+var applyPluginWithOptions = require("./helpers/applyPluginWithOptions");
+
+describe("LibraryTemplatePlugin", function() {
+	var env;
+
+	beforeEach(function() {
+		env = {
+			compilation: sinon.spy()
+		};
+	});
+
+	it("has apply function", function() {
+		(new LibraryTemplatePlugin()).apply.should.be.a.Function();
+	});
+
+	describe("when applied", function() {
+		beforeEach(function() {
+			env.eventBindings = applyPluginWithOptions(LibraryTemplatePlugin);
+		});
+
+		it("binds two event handlers", function() {
+			env.eventBindings.length.should.be.exactly(1);
+		});
+
+		describe("this-compilation handler", function() {
+			beforeEach(function() {
+				env.eventBinding = env.eventBindings[0];
+			});
+
+			describe("event handler", function() {
+				it("binds to this-compilation event", function() {
+					env.eventBinding.name.should.be.exactly("this-compilation");
+				});
+			});
+
+			describe("when target is unknown", function() {
+				beforeEach(function() {
+					var unknownTarget = "unknownTarget";
+					env.eventBindings = applyPluginWithOptions(LibraryTemplatePlugin, "foo", unknownTarget, "bar", "baz");
+					env.eventBinding = env.eventBindings[0];
+				});
+
+				it("throws an error", function() {
+					should(function() {
+						env.eventBinding.handler(env.compilation);
+					}).throw("unknownTarget is not a valid Library target");
+				});
+			});
+
+			describe("name is a string", function() {
+				[{
+						type: "var",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly("var foo");
+							should(compilationContext.copyObject).be.undefined();
+						}
+					},
+					{
+						type: "assign",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly("foo");
+							should(compilationContext.copyObject).be.undefined();
+						}
+					},
+					{
+						type: "this",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly('this["foo"]');
+							should(compilationContext.copyObject).be.undefined();
+						}
+					},
+					{
+						type: "window",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly('window["foo"]');
+							should(compilationContext.copyObject).be.undefined();
+						}
+					},
+					{
+						type: "global",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly('global["foo"]');
+							should(compilationContext.copyObject).be.undefined();
+						}
+					},
+					{
+						type: "commonjs",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly('exports["foo"]');
+							should(compilationContext.copyObject).be.undefined();
+						}
+					},
+					{
+						type: "commonjs2",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly("module.exports");
+							should(compilationContext.copyObject).be.undefined();
+						}
+					},
+					{
+						type: "commonjs-module",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly("module.exports");
+							should(compilationContext.copyObject).be.undefined();
+						}
+					},
+					{
+						type: "amd",
+						assertion: function(compilationContext) {
+							compilationContext.name.should.be.exactly("foo");
+						}
+					},
+					{
+						type: "umd",
+						assertion: function(compilationContext) {
+							compilationContext.name.should.be.exactly("foo");
+							compilationContext.optionalAmdExternalAsGlobal.should.be.false();
+							compilationContext.namedDefine.should.be.exactly("bar");
+							compilationContext.auxiliaryComment.should.be.exactly("baz");
+						}
+					},
+					{
+						type: "umd2",
+						assertion: function(compilationContext) {
+							compilationContext.name.should.be.exactly("foo");
+							compilationContext.optionalAmdExternalAsGlobal.should.be.true();
+							compilationContext.namedDefine.should.be.exactly("bar");
+							compilationContext.auxiliaryComment.should.be.exactly("baz");
+						}
+					},
+					{
+						type: "jsonp",
+						assertion: function(compilationContext) {
+							compilationContext.name.should.be.exactly("foo");
+						}
+					}
+				].forEach(function(targetTypeAndAssertion) {
+					var type = targetTypeAndAssertion.type;
+
+					describe("when target is " + type, function() {
+						beforeEach(function() {
+							env.eventBindings = applyPluginWithOptions(LibraryTemplatePlugin, "foo", type, "bar", "baz");
+							env.eventBinding = env.eventBindings[0];
+							env.eventBinding.handler(env.compilation);
+						});
+
+						it("compilation callback is called", function() {
+							env.compilation.callCount.should.be.exactly(1);
+						});
+
+						it("compilation callback context is set up", function() {
+							var compilationContext = env.compilation.firstCall.thisValue;
+							targetTypeAndAssertion.assertion(compilationContext);
+						});
+					});
+				});
+			});
+
+			describe("name is an array of strings", function() {
+				[{
+						type: "var",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly('var foo = foo || {}; foo["bar"] = foo["bar"] || {}; foo["bar"]["baz"]');
+							should(compilationContext.copyObject).be.undefined();
+						}
+					},
+					{
+						type: "assign",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly('foo = typeof foo === "object" ? foo : {}; foo["bar"] = foo["bar"] || {}; foo["bar"]["baz"]');
+							should(compilationContext.copyObject).be.undefined();
+						}
+					},
+					{
+						type: "this",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly('this["foo"] = this["foo"] || {}; this["foo"]["bar"] = this["foo"]["bar"] || {}; this["foo"]["bar"]["baz"]');
+							should(compilationContext.copyObject).be.undefined();
+						}
+					},
+					{
+						type: "window",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly('window["foo"] = window["foo"] || {}; window["foo"]["bar"] = window["foo"]["bar"] || {}; window["foo"]["bar"]["baz"]');
+							should(compilationContext.copyObject).be.undefined();
+						}
+					},
+					{
+						type: "global",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly('global["foo"] = global["foo"] || {}; global["foo"]["bar"] = global["foo"]["bar"] || {}; global["foo"]["bar"]["baz"]');
+							should(compilationContext.copyObject).be.undefined();
+						}
+					},
+					{
+						type: "commonjs",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly('exports["foo"] = exports["foo"] || {}; exports["foo"]["bar"] = exports["foo"]["bar"] || {}; exports["foo"]["bar"]["baz"]');
+							should(compilationContext.copyObject).be.undefined();
+						}
+					},
+					{
+						type: "commonjs2",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly("module.exports");
+							should(compilationContext.copyObject).be.undefined();
+						}
+					},
+					{
+						type: "commonjs-module",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly("module.exports");
+							should(compilationContext.copyObject).be.undefined();
+						}
+					},
+					{
+						type: "amd",
+						assertion: function(compilationContext) {
+							compilationContext.name.should.deepEqual(["foo", "bar", "baz"]);
+						}
+					},
+					{
+						type: "umd",
+						assertion: function(compilationContext) {
+							compilationContext.name.should.deepEqual(["foo", "bar", "baz"]);
+							compilationContext.optionalAmdExternalAsGlobal.should.be.false();
+							compilationContext.namedDefine.should.be.exactly("bar");
+							compilationContext.auxiliaryComment.should.be.exactly("baz");
+						}
+					},
+					{
+						type: "umd2",
+						assertion: function(compilationContext) {
+							compilationContext.name.should.deepEqual(["foo", "bar", "baz"]);
+							compilationContext.optionalAmdExternalAsGlobal.should.be.true();
+							compilationContext.namedDefine.should.be.exactly("bar");
+							compilationContext.auxiliaryComment.should.be.exactly("baz");
+						}
+					},
+					{
+						type: "jsonp",
+						assertion: function(compilationContext) {
+							compilationContext.name.should.deepEqual(["foo", "bar", "baz"]);
+						}
+					}
+				].forEach(function(targetTypeAndAssertion) {
+					var type = targetTypeAndAssertion.type;
+
+					describe("when target is " + type, function() {
+						beforeEach(function() {
+							env.eventBindings = applyPluginWithOptions(LibraryTemplatePlugin, ["foo", "bar", "baz"], type, "bar", "baz");
+							env.eventBinding = env.eventBindings[0];
+							env.eventBinding.handler(env.compilation);
+						});
+
+						it("compilation callback is called", function() {
+							env.compilation.callCount.should.be.exactly(1);
+						});
+
+						it("compilation callback context is set up", function() {
+							var compilationContext = env.compilation.firstCall.thisValue;
+							targetTypeAndAssertion.assertion(compilationContext);
+						});
+					});
+				});
+			});
+
+			describe("name not provided", function() {
+				[{
+						type: "this",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly("this");
+							should(compilationContext.copyObject).be.true();
+						}
+					},
+					{
+						type: "window",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly("window");
+							should(compilationContext.copyObject).be.true();
+						}
+					},
+					{
+						type: "global",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly("global");
+							should(compilationContext.copyObject).be.true();
+						}
+					},
+					{
+						type: "commonjs",
+						assertion: function(compilationContext) {
+							compilationContext.varExpression.should.be.exactly("exports");
+							should(compilationContext.copyObject).be.true();
+						}
+					}
+				].forEach(function(targetTypeAndAssertion) {
+					var type = targetTypeAndAssertion.type;
+
+					describe("when target is " + type, function() {
+						beforeEach(function() {
+							env.eventBindings = applyPluginWithOptions(LibraryTemplatePlugin, undefined, type, "bar", "baz");
+							env.eventBinding = env.eventBindings[0];
+							env.eventBinding.handler(env.compilation);
+						});
+
+						it("compilation callback is called", function() {
+							env.compilation.callCount.should.be.exactly(1);
+						});
+
+						it("compilation callback context is set up", function() {
+							var compilationContext = env.compilation.firstCall.thisValue;
+							targetTypeAndAssertion.assertion(compilationContext);
+						});
+					});
+				});
+			});
+		});
+	});
+});

--- a/test/helpers/applyPluginWithOptions.js
+++ b/test/helpers/applyPluginWithOptions.js
@@ -1,7 +1,7 @@
 var PluginEnvironment = require('./PluginEnvironment');
 
-module.exports = function applyPluginWithOptions(Plugin, options) {
-	var plugin = new Plugin(options);
+module.exports = function applyPluginWithOptions(Plugin) {
+	var plugin = new (Function.prototype.bind.apply(Plugin, arguments));
 	var pluginEnvironment = new PluginEnvironment();
 	plugin.apply(pluginEnvironment.getEnvironmentStub());
 	return pluginEnvironment.getEventBindings();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Add tests for LibraryTemplatePlugin

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

This PR is only tests

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Based on the coveralls report, the `LibraryTemplatePlugin` file has 70% test coverage. There is no `LibraryTemplatePlugin` specific test file - this is added in this PR and aims to achieve 100% test coverage.
https://coveralls.io/builds/9566761/source?filename=lib%2FLibraryTemplatePlugin.js

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**

The `applyPluginWithOptions` helper function has been extended to allow multiple arguments which will all be passed into the plugin on instantiation. This is a backwards compatible change.