### PR TITLE
Bump up test coverage on NodeWatchFileSystem test

### DIFF
--- a/test/NodeWatchFileSystem.test.js
+++ b/test/NodeWatchFileSystem.test.js
@@ -7,7 +7,7 @@ if(process.env.NO_WATCH_TESTS) {
 	return;
 }
 
-require("should");
+var should = require("should");
 var path = require("path");
 var fs = require("fs");
 
@@ -19,6 +19,35 @@ var fileSubdir = path.join(fixtures, "subdir", "watched-file.txt");
 
 describe("NodeWatchFileSystem", function() {
 	this.timeout(10000);
+
+	it('should throw if \'files\' argument is not an array', function() {
+		should(function() { new NodeWatchFileSystem().watch(undefined) }).throw(Error);
+	});
+
+	it('should throw if \'dirs\' argument is not an array', function() {
+		should(function() { new NodeWatchFileSystem().watch([], undefined) }).throw(Error);
+	});
+
+	it('should throw if \'missing\' argument is not an array', function() {
+		should(function() { new NodeWatchFileSystem().watch([], []. undefined) }).throw(Error);
+	});
+
+	it('should throw if \'starttime\' argument is missing', function() {
+		should(function() { new NodeWatchFileSystem().watch([], [], [], '42', {}, function() {}) }).throw(Error);
+	});
+
+	it('should throw if \'callback\' argument is missing', function() {
+		should(function() { new NodeWatchFileSystem().watch([], [], [], 42, {}, undefined) }).throw(Error);
+	});
+
+	it('should throw if \'options\' argument is invalid', function() {
+		should(function() { new NodeWatchFileSystem().watch([], [], [], 42, 'options', function() {} ) }).throw(Error);
+	});
+
+	it('should throw if \'callbackUndelayed\' argument is invalid', function() {
+		should(function() { new NodeWatchFileSystem().watch([], [], [], 42, {}, function() {}, 'undefined' ) }).throw(Error);
+	});
+
 	it("should register a file change (change delayed)", function(done) {
 		var startTime = new Date().getTime();
 		var wfs = new NodeWatchFileSystem();

--- a/test/NodeWatchFileSystem.test.js
+++ b/test/NodeWatchFileSystem.test.js
@@ -21,31 +21,45 @@ describe("NodeWatchFileSystem", function() {
 	this.timeout(10000);
 
 	it('should throw if \'files\' argument is not an array', function() {
-		should(function() { new NodeWatchFileSystem().watch(undefined) }).throw(Error);
+		should(function() {
+			new NodeWatchFileSystem().watch(undefined)
+		}).throw("Invalid arguments: 'files'");
 	});
 
 	it('should throw if \'dirs\' argument is not an array', function() {
-		should(function() { new NodeWatchFileSystem().watch([], undefined) }).throw(Error);
+		should(function() {
+			new NodeWatchFileSystem().watch([], undefined)
+		}).throw("Invalid arguments: 'dirs'");
 	});
 
 	it('should throw if \'missing\' argument is not an array', function() {
-		should(function() { new NodeWatchFileSystem().watch([], []. undefined) }).throw(Error);
+		should(function() {
+			new NodeWatchFileSystem().watch([], [], undefined)
+		}).throw("Invalid arguments: 'missing'");
 	});
 
 	it('should throw if \'starttime\' argument is missing', function() {
-		should(function() { new NodeWatchFileSystem().watch([], [], [], '42', {}, function() {}) }).throw(Error);
+		should(function() {
+			new NodeWatchFileSystem().watch([], [], [], '42', {}, function() {})
+		}).throw("Invalid arguments: 'startTime'");
 	});
 
 	it('should throw if \'callback\' argument is missing', function() {
-		should(function() { new NodeWatchFileSystem().watch([], [], [], 42, {}, undefined) }).throw(Error);
+		should(function() {
+			new NodeWatchFileSystem().watch([], [], [], 42, {}, undefined)
+		}).throw("Invalid arguments: 'callback'");
 	});
 
 	it('should throw if \'options\' argument is invalid', function() {
-		should(function() { new NodeWatchFileSystem().watch([], [], [], 42, 'options', function() {} ) }).throw(Error);
+		should(function() {
+			new NodeWatchFileSystem().watch([], [], [], 42, 'options', function() {})
+		}).throw("Invalid arguments: 'options'");
 	});
 
 	it('should throw if \'callbackUndelayed\' argument is invalid', function() {
-		should(function() { new NodeWatchFileSystem().watch([], [], [], 42, {}, function() {}, 'undefined' ) }).throw(Error);
+		should(function() {
+			new NodeWatchFileSystem().watch([], [], [], 42, {}, function() {}, 'undefined')
+		}).throw("Invalid arguments: 'callbackUndelayed'");
 	});
 
 	it("should register a file change (change delayed)", function(done) {


### PR DESCRIPTION
Like the title says, bump up the test cov.
A tiny contribution to => https://github.com/webpack/webpack/issues/3716

**What kind of change does this PR introduce?**

bumps up the test cov for `NodeWatchFileSystem`

**Did you add tests for your changes?**

They are **just** tests :smile: 

**Summary**

Adds a handful of more tests to `NodeWatchFileSystem` to bump up the test coverage.

**Does this PR introduce a breaking change?**

Nope

**Other information**
