### PR TITLE
give hint what warnings were expected and which file

### DIFF
--- a/test/checkArrayExpectation.js
+++ b/test/checkArrayExpectation.js
@@ -12,11 +12,12 @@ module.exports = function checkArrayExpectation(testDirectory, object, kind, fil
 		return !/from UglifyJs/.test(item);
 	});
 	if(fs.existsSync(path.join(testDirectory, filename + ".js"))) {
-		var expected = require(path.join(testDirectory, filename + ".js"));
+		var expectedFilename = path.join(testDirectory, filename + ".js");
+		var expected = require(expectedFilename);
 		if(expected.length < array.length)
-			return done(new Error("More " + kind + "s while compiling than expected:\n\n" + array.join("\n\n"))), true;
+			return done(new Error("More " + kind + "s while compiling than expected:\n\n" + array.join("\n\n") + ". Check expected warnings: " + filename)), true;
 		else if(expected.length > array.length)
-			return done(new Error("Less " + kind + "s while compiling than expected:\n\n" + array.join("\n\n"))), true;
+			return done(new Error("Less " + kind + "s while compiling than expected:\n\n" + array.join("\n\n") + ". Check expected warnings: " + filename)), true;
 		for(var i = 0; i < array.length; i++) {
 			if(Array.isArray(expected[i])) {
 				for(var j = 0; j < expected[i].length; j++) {


### PR DESCRIPTION
currently if you "break" warnings you have no idea which ones where supposed to show
or which module actually failed.

**What kind of change does this PR introduce?**

better test hint

**Did you add tests for your changes?**

N/A

**Summary**

When breaking something on the expected warnings (as in they are not shown anymore) there is no way to figure out which files failed. This at least hints the file that was checked.

**Does this PR introduce a breaking change?**

NO

