### PR TITLE
Extract to parser helpers

### DIFF
--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -5,7 +5,7 @@
 "use strict";
 
 const ConstDependency = require("./dependencies/ConstDependency");
-const BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
+const ParserHelpers = require("./ParserHelpers");
 
 const NullFactory = require("./NullFactory");
 
@@ -43,9 +43,8 @@ class APIPlugin {
 						parser.state.current.addDependency(dep);
 						return true;
 					});
-					parser.plugin(`evaluate typeof ${key}`, expr => {
-						return new BasicEvaluatedExpression().setString(REPLACEMENT_TYPES[key]).setRange(expr.range);
-					});
+
+					parser.plugin(`evaluate typeof ${key}`, ParserHelpers.evaluateToString(REPLACEMENT_TYPES[key]));
 				});
 				IGNORES.forEach(key => {
 					parser.plugin(key, () => true);

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -6,6 +6,7 @@
 
 const ConstDependency = require("./dependencies/ConstDependency");
 const BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
+const ParserHelpers = require("./ParserHelpers");
 const NullFactory = require("./NullFactory");
 
 class DefinePlugin {
@@ -101,7 +102,7 @@ class DefinePlugin {
 					let code = stringifyObj(obj);
 					parser.plugin("can-rename " + key, () => true);
 					parser.plugin("evaluate Identifier " + key, (expr) => new BasicEvaluatedExpression().setRange(expr.range));
-					parser.plugin("evaluate typeof " + key, expr => new BasicEvaluatedExpression().setString("object").setRange(expr.range));
+					parser.plugin("evaluate typeof " + key, ParserHelpers.evaluateToString("object"));
 					parser.plugin("expression " + key, (expr) => {
 						let dep = new ConstDependency(code, expr.range);
 						dep.loc = expr.loc;

--- a/lib/ExtendedAPIPlugin.js
+++ b/lib/ExtendedAPIPlugin.js
@@ -2,8 +2,9 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+"use strict";
 var ConstDependency = require("./dependencies/ConstDependency");
-var BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
+const ParserHelpers = require("./ParserHelpers");
 
 var NullFactory = require("./NullFactory");
 
@@ -39,9 +40,7 @@ ExtendedAPIPlugin.prototype.apply = function(compiler) {
 					this.state.current.addDependency(dep);
 					return true;
 				});
-				parser.plugin("evaluate typeof " + key, function(expr) {
-					return new BasicEvaluatedExpression().setString(REPLACEMENT_TYPES[key]).setRange(expr.range);
-				});
+				parser.plugin("evaluate typeof " + key, ParserHelpers.evaluateToString(REPLACEMENT_TYPES[key]));
 			});
 		});
 	});

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -2,6 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+"use strict";
 var Template = require("./Template");
 var BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
 var ModuleHotAcceptDependency = require("./dependencies/ModuleHotAcceptDependency");
@@ -9,6 +10,7 @@ var ModuleHotDeclineDependency = require("./dependencies/ModuleHotDeclineDepende
 var RawSource = require("webpack-sources").RawSource;
 var ConstDependency = require("./dependencies/ConstDependency");
 var NullFactory = require("./NullFactory");
+const ParserHelpers = require("./ParserHelpers");
 
 function HotModuleReplacementPlugin(options) {
 	options = options || {};
@@ -201,9 +203,7 @@ HotModuleReplacementPlugin.prototype.apply = function(compiler) {
 				this.state.current.addDependency(dep);
 				return true;
 			});
-			parser.plugin("evaluate typeof __webpack_hash__", function(expr) {
-				return new BasicEvaluatedExpression().setString("string").setRange(expr.range);
-			});
+			parser.plugin("evaluate typeof __webpack_hash__", ParserHelpers.evaluateToString("string"));
 			parser.plugin("evaluate Identifier module.hot", function(expr) {
 				return new BasicEvaluatedExpression()
 					.setBoolean(!!this.state.compilation.hotUpdateChunkTemplate)

--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -3,7 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 var path = require("path");
-var ModuleParserHelpers = require("./ModuleParserHelpers");
+var ParserHelpers = require("./ParserHelpers");
 var ConstDependency = require("./dependencies/ConstDependency");
 var BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
 var UnsupportedFeatureWarning = require("./UnsupportedFeatureWarning");
@@ -115,7 +115,7 @@ NodeStuffPlugin.prototype.apply = function(compiler) {
 						moduleJsPath = "./" + moduleJsPath.replace(/\\/g, "/");
 					}
 				}
-				return ModuleParserHelpers.addParsedVariable(this, "module", "require(" + JSON.stringify(moduleJsPath) + ")(module)");
+				return ParserHelpers.addParsedVariableToModule(this, "module", "require(" + JSON.stringify(moduleJsPath) + ")(module)");
 			});
 		});
 	});

--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -6,7 +6,6 @@ var path = require("path");
 var ParserHelpers = require("./ParserHelpers");
 var ConstDependency = require("./dependencies/ConstDependency");
 var BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
-var UnsupportedFeatureWarning = require("./UnsupportedFeatureWarning");
 
 var NullFactory = require("./NullFactory");
 
@@ -83,14 +82,10 @@ NodeStuffPlugin.prototype.apply = function(compiler) {
 				this.state.current.addDependency(dep);
 				return true;
 			});
-			parser.plugin("expression require.extensions", function(expr) {
-				var dep = new ConstDependency("(void 0)", expr.range);
-				dep.loc = expr.loc;
-				this.state.current.addDependency(dep);
-				if(!this.state.module) return;
-				this.state.module.warnings.push(new UnsupportedFeatureWarning(this.state.module, "require.extensions is not supported by webpack. Use a loader instead."));
-				return true;
-			});
+			parser.plugin(
+				"expression require.extensions",
+				ParserHelpers.expressionIsUnsupported("require.extensions is not supported by webpack. Use a loader instead.")
+			);
 			parser.plugin("expression module.loaded", function(expr) {
 				var dep = new ConstDependency("module.l", expr.range);
 				dep.loc = expr.loc;

--- a/lib/ParserHelpers.js
+++ b/lib/ParserHelpers.js
@@ -3,6 +3,9 @@
 	Author Tobias Koppers @sokra
 */
 "use strict";
+const BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
+const ConstDependency = require("./dependencies/ConstDependency");
+
 const ParserHelpers = exports;
 
 ParserHelpers.addParsedVariableToModule = function(parser, name, expression) {
@@ -19,4 +22,16 @@ ParserHelpers.addParsedVariableToModule = function(parser, name, expression) {
 	});
 	parser.state.current.addVariable(name, expression, deps);
 	return true;
+};
+
+ParserHelpers.setTypeof = function setTypeof(parser, expr, value) {
+	parser.plugin("evaluate typeof " + expr, function(expr) {
+		return new BasicEvaluatedExpression().setString(value).setRange(expr.range);
+	});
+	parser.plugin("typeof " + expr, function(expr) {
+		var dep = new ConstDependency(JSON.stringify(value), expr.range);
+		dep.loc = expr.loc;
+		this.state.current.addDependency(dep);
+		return true;
+	});
 };

--- a/lib/ParserHelpers.js
+++ b/lib/ParserHelpers.js
@@ -5,6 +5,7 @@
 "use strict";
 const BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
 const ConstDependency = require("./dependencies/ConstDependency");
+const UnsupportedFeatureWarning = require("./UnsupportedFeatureWarning");
 
 const ParserHelpers = exports;
 
@@ -34,4 +35,15 @@ ParserHelpers.setTypeof = function setTypeof(parser, expr, value) {
 		this.state.current.addDependency(dep);
 		return true;
 	});
+};
+
+ParserHelpers.expressionIsUnsupported = function expressionIsUnsupported(message) {
+	return function unsupportedExpression(expr) {
+		var dep = new ConstDependency("(void 0)", expr.range);
+		dep.loc = expr.loc;
+		this.state.current.addDependency(dep);
+		if(!this.state.module) return;
+		this.state.module.warnings.push(new UnsupportedFeatureWarning(this.state.module, message));
+		return true;
+	};
 };

--- a/lib/ParserHelpers.js
+++ b/lib/ParserHelpers.js
@@ -26,7 +26,7 @@ ParserHelpers.addParsedVariableToModule = function(parser, name, expression) {
 };
 
 ParserHelpers.toConstantDependency = function toConstantDependency(value) {
-	return function(expr) {
+	return function constantDependency(expr) {
 		var dep = new ConstDependency(JSON.stringify(value), expr.range);
 		dep.loc = expr.loc;
 		this.state.current.addDependency(dep);
@@ -34,8 +34,8 @@ ParserHelpers.toConstantDependency = function toConstantDependency(value) {
 	};
 };
 
-ParserHelpers.evaluateToString = function setTypeof(value) {
-	return function(expr) {
+ParserHelpers.evaluateToString = function evaluateToString(value) {
+	return function stringExpression(expr) {
 		return new BasicEvaluatedExpression().setString(value).setRange(expr.range);
 	};
 };

--- a/lib/ParserHelpers.js
+++ b/lib/ParserHelpers.js
@@ -25,16 +25,19 @@ ParserHelpers.addParsedVariableToModule = function(parser, name, expression) {
 	return true;
 };
 
-ParserHelpers.setTypeof = function setTypeof(parser, expr, value) {
-	parser.plugin("evaluate typeof " + expr, function(expr) {
-		return new BasicEvaluatedExpression().setString(value).setRange(expr.range);
-	});
-	parser.plugin("typeof " + expr, function(expr) {
+ParserHelpers.toConstantDependency = function toConstantDependency(value) {
+	return function(expr) {
 		var dep = new ConstDependency(JSON.stringify(value), expr.range);
 		dep.loc = expr.loc;
 		this.state.current.addDependency(dep);
 		return true;
-	});
+	};
+};
+
+ParserHelpers.evaluateToString = function setTypeof(value) {
+	return function(expr) {
+		return new BasicEvaluatedExpression().setString(value).setRange(expr.range);
+	};
 };
 
 ParserHelpers.expressionIsUnsupported = function expressionIsUnsupported(message) {

--- a/lib/ParserHelpers.js
+++ b/lib/ParserHelpers.js
@@ -2,9 +2,10 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var ModuleParserHelpers = exports;
+"use strict";
+const ParserHelpers = exports;
 
-ModuleParserHelpers.addParsedVariable = function(parser, name, expression) {
+ParserHelpers.addParsedVariableToModule = function(parser, name, expression) {
 	if(!parser.state.current.addVariable) return false;
 	var deps = [];
 	parser.parse(expression, {

--- a/lib/ProvidePlugin.js
+++ b/lib/ProvidePlugin.js
@@ -2,7 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var ModuleParserHelpers = require("./ModuleParserHelpers");
+var ParserHelpers = require("./ParserHelpers");
 var ConstDependency = require("./dependencies/ConstDependency");
 
 var NullFactory = require("./NullFactory");
@@ -40,7 +40,7 @@ ProvidePlugin.prototype.apply = function(compiler) {
 							return "[" + JSON.stringify(r) + "]";
 						}).join("");
 					}
-					if(!ModuleParserHelpers.addParsedVariable(this, nameIdentifier, expression)) {
+					if(!ParserHelpers.addParsedVariableToModule(this, nameIdentifier, expression)) {
 						return false;
 					}
 					if(scopedName) {

--- a/lib/dependencies/AMDPlugin.js
+++ b/lib/dependencies/AMDPlugin.js
@@ -80,12 +80,8 @@ AMDPlugin.prototype.apply = function(compiler) {
 			parser.plugin("expression __webpack_amd_options__", function() {
 				return this.state.current.addVariable("__webpack_amd_options__", JSON.stringify(amdOptions));
 			});
-			parser.plugin("evaluate typeof define.amd", function(expr) {
-				return new BasicEvaluatedExpression().setString(typeof amdOptions).setRange(expr.range);
-			});
-			parser.plugin("evaluate typeof require.amd", function(expr) {
-				return new BasicEvaluatedExpression().setString(typeof amdOptions).setRange(expr.range);
-			});
+			parser.plugin("evaluate typeof define.amd", ParserHelpers.evaluateToString(typeof amdOptions));
+			parser.plugin("evaluate typeof require.amd", ParserHelpers.evaluateToString(typeof amdOptions));
 			parser.plugin("evaluate Identifier define.amd", function(expr) {
 				return new BasicEvaluatedExpression().setBoolean(true).setRange(expr.range);
 			});

--- a/lib/dependencies/AMDPlugin.js
+++ b/lib/dependencies/AMDPlugin.js
@@ -10,7 +10,6 @@ var AMDRequireContextDependency = require("./AMDRequireContextDependency");
 var AMDDefineDependency = require("./AMDDefineDependency");
 var UnsupportedDependency = require("./UnsupportedDependency");
 var LocalModuleDependency = require("./LocalModuleDependency");
-var ConstDependency = require("./ConstDependency");
 
 var NullFactory = require("../NullFactory");
 
@@ -20,6 +19,7 @@ var AMDDefineDependencyParserPlugin = require("./AMDDefineDependencyParserPlugin
 var AliasPlugin = require("enhanced-resolve/lib/AliasPlugin");
 
 var BasicEvaluatedExpression = require("../BasicEvaluatedExpression");
+var ParserHelpers = require("../ParserHelpers");
 
 function AMDPlugin(options, amdOptions) {
 	this.amdOptions = amdOptions;
@@ -60,18 +60,6 @@ AMDPlugin.prototype.apply = function(compiler) {
 			if(typeof parserOptions.amd !== "undefined" && !parserOptions.amd)
 				return;
 
-			function setTypeof(expr, value) {
-				parser.plugin("evaluate typeof " + expr, function(expr) {
-					return new BasicEvaluatedExpression().setString(value).setRange(expr.range);
-				});
-				parser.plugin("typeof " + expr, function(expr) {
-					var dep = new ConstDependency(JSON.stringify(value), expr.range);
-					dep.loc = expr.loc;
-					this.state.current.addDependency(dep);
-					return true;
-				});
-			}
-
 			function setExpressionToModule(expr, module) {
 				parser.plugin("expression " + expr, function(expr) {
 					var dep = new AMDRequireItemDependency(module, expr.range);
@@ -104,7 +92,7 @@ AMDPlugin.prototype.apply = function(compiler) {
 			parser.plugin("evaluate Identifier require.amd", function(expr) {
 				return new BasicEvaluatedExpression().setBoolean(true).setRange(expr.range);
 			});
-			setTypeof("define", "function");
+			ParserHelpers.setTypeof(parser, "define", "function");
 			parser.plugin("can-rename define", function() {
 				return true;
 			});
@@ -115,7 +103,7 @@ AMDPlugin.prototype.apply = function(compiler) {
 				this.state.current.addDependency(dep);
 				return false;
 			});
-			setTypeof("require", "function");
+			ParserHelpers.setTypeof(parser, "require", "function");
 		});
 	});
 	compiler.plugin("after-resolvers", function() {

--- a/lib/dependencies/AMDPlugin.js
+++ b/lib/dependencies/AMDPlugin.js
@@ -92,7 +92,8 @@ AMDPlugin.prototype.apply = function(compiler) {
 			parser.plugin("evaluate Identifier require.amd", function(expr) {
 				return new BasicEvaluatedExpression().setBoolean(true).setRange(expr.range);
 			});
-			ParserHelpers.setTypeof(parser, "define", "function");
+			parser.plugin("typeof define", ParserHelpers.toConstantDependency("function"));
+			parser.plugin("evaluate typeof define", ParserHelpers.evaluateToString("function"));
 			parser.plugin("can-rename define", function() {
 				return true;
 			});
@@ -103,7 +104,8 @@ AMDPlugin.prototype.apply = function(compiler) {
 				this.state.current.addDependency(dep);
 				return false;
 			});
-			ParserHelpers.setTypeof(parser, "require", "function");
+			parser.plugin("typeof require", ParserHelpers.toConstantDependency("function"));
+			parser.plugin("evaluate typeof require", ParserHelpers.evaluateToString("function"));
 		});
 	});
 	compiler.plugin("after-resolvers", function() {

--- a/lib/dependencies/CommonJsPlugin.js
+++ b/lib/dependencies/CommonJsPlugin.js
@@ -16,7 +16,6 @@ var NullFactory = require("../NullFactory");
 var RequireResolveDependencyParserPlugin = require("./RequireResolveDependencyParserPlugin");
 var CommonJsRequireDependencyParserPlugin = require("./CommonJsRequireDependencyParserPlugin");
 
-var BasicEvaluatedExpression = require("../BasicEvaluatedExpression");
 var ParserHelpers = require("../ParserHelpers");
 
 function CommonJsPlugin(options) {
@@ -59,9 +58,7 @@ CommonJsPlugin.prototype.apply = function(compiler) {
 				parser.plugin(`evaluate typeof ${expression}`, ParserHelpers.evaluateToString("function"));
 			}
 
-			parser.plugin("evaluate typeof module", function(expr) {
-				return new BasicEvaluatedExpression().setString("object").setRange(expr.range);
-			});
+			parser.plugin("evaluate typeof module", ParserHelpers.evaluateToString("object"));
 			parser.plugin("assign require", function(expr) {
 				// to not leak to global "require", we need to define a local require here.
 				var dep = new ConstDependency("var require;", 0);
@@ -83,9 +80,7 @@ CommonJsPlugin.prototype.apply = function(compiler) {
 			parser.plugin("typeof module", function() {
 				return true;
 			});
-			parser.plugin("evaluate typeof exports", function(expr) {
-				return new BasicEvaluatedExpression().setString("object").setRange(expr.range);
-			});
+			parser.plugin("evaluate typeof exports", ParserHelpers.evaluateToString("object"));
 			parser.apply(
 				new CommonJsRequireDependencyParserPlugin(options),
 				new RequireResolveDependencyParserPlugin(options)

--- a/lib/dependencies/CommonJsPlugin.js
+++ b/lib/dependencies/CommonJsPlugin.js
@@ -16,6 +16,7 @@ var RequireResolveDependencyParserPlugin = require("./RequireResolveDependencyPa
 var CommonJsRequireDependencyParserPlugin = require("./CommonJsRequireDependencyParserPlugin");
 
 var BasicEvaluatedExpression = require("../BasicEvaluatedExpression");
+var ParserHelpers = require("../ParserHelpers");
 
 function CommonJsPlugin(options) {
 	this.options = options;
@@ -51,21 +52,9 @@ CommonJsPlugin.prototype.apply = function(compiler) {
 			if(typeof parserOptions.commonjs !== "undefined" && !parserOptions.commonjs)
 				return;
 
-			function setTypeof(expr, value) {
-				parser.plugin("evaluate typeof " + expr, function(expr) {
-					return new BasicEvaluatedExpression().setString(value).setRange(expr.range);
-				});
-				parser.plugin("typeof " + expr, function(expr) {
-					var dep = new ConstDependency(JSON.stringify(value), expr.range);
-					dep.loc = expr.loc;
-					this.state.current.addDependency(dep);
-					return true;
-				});
-			}
-
-			setTypeof("require", "function");
-			setTypeof("require.resolve", "function");
-			setTypeof("require.resolveWeak", "function");
+			ParserHelpers.setTypeof(parser, "require", "function");
+			ParserHelpers.setTypeof(parser, "require.resolve", "function");
+			ParserHelpers.setTypeof(parser, "require.resolveWeak", "function");
 			parser.plugin("evaluate typeof module", function(expr) {
 				return new BasicEvaluatedExpression().setString("object").setRange(expr.range);
 			});

--- a/lib/dependencies/CommonJsPlugin.js
+++ b/lib/dependencies/CommonJsPlugin.js
@@ -2,6 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+"use strict";
 var ConstDependency = require("./ConstDependency");
 var CommonJsRequireDependency = require("./CommonJsRequireDependency");
 var CommonJsRequireContextDependency = require("./CommonJsRequireContextDependency");
@@ -52,9 +53,12 @@ CommonJsPlugin.prototype.apply = function(compiler) {
 			if(typeof parserOptions.commonjs !== "undefined" && !parserOptions.commonjs)
 				return;
 
-			ParserHelpers.setTypeof(parser, "require", "function");
-			ParserHelpers.setTypeof(parser, "require.resolve", "function");
-			ParserHelpers.setTypeof(parser, "require.resolveWeak", "function");
+			const requireExpressions = ["require", "require.resolve", "require.resolveWeak"];
+			for(const expression of requireExpressions) {
+				parser.plugin(`typeof ${expression}`, ParserHelpers.toConstantDependency("function"));
+				parser.plugin(`evaluate typeof ${expression}`, ParserHelpers.evaluateToString("function"));
+			}
+
 			parser.plugin("evaluate typeof module", function(expr) {
 				return new BasicEvaluatedExpression().setString("object").setRange(expr.range);
 			});

--- a/lib/dependencies/RequireEnsurePlugin.js
+++ b/lib/dependencies/RequireEnsurePlugin.js
@@ -2,6 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+"use strict";
 var RequireEnsureItemDependency = require("./RequireEnsureItemDependency");
 var RequireEnsureDependency = require("./RequireEnsureDependency");
 var ConstDependency = require("./ConstDependency");
@@ -10,7 +11,7 @@ var NullFactory = require("../NullFactory");
 
 var RequireEnsureDependenciesBlockParserPlugin = require("./RequireEnsureDependenciesBlockParserPlugin");
 
-var BasicEvaluatedExpression = require("../BasicEvaluatedExpression");
+const ParserHelpers = require("../ParserHelpers");
 
 function RequireEnsurePlugin() {}
 module.exports = RequireEnsurePlugin;
@@ -31,9 +32,7 @@ RequireEnsurePlugin.prototype.apply = function(compiler) {
 				return;
 
 			parser.apply(new RequireEnsureDependenciesBlockParserPlugin());
-			parser.plugin("evaluate typeof require.ensure", function(expr) {
-				return new BasicEvaluatedExpression().setString("function").setRange(expr.range);
-			});
+			parser.plugin("evaluate typeof require.ensure", ParserHelpers.evaluateToString("function"));
 			parser.plugin("typeof require.ensure", function(expr) {
 				var dep = new ConstDependency("'function'", expr.range);
 				dep.loc = expr.loc;

--- a/lib/dependencies/RequireIncludePlugin.js
+++ b/lib/dependencies/RequireIncludePlugin.js
@@ -2,11 +2,12 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+"use strict";
 var RequireIncludeDependency = require("./RequireIncludeDependency");
 var RequireIncludeDependencyParserPlugin = require("./RequireIncludeDependencyParserPlugin");
 var ConstDependency = require("./ConstDependency");
 
-var BasicEvaluatedExpression = require("../BasicEvaluatedExpression");
+const ParserHelpers = require("../ParserHelpers");
 
 function RequireIncludePlugin() {}
 module.exports = RequireIncludePlugin;
@@ -24,9 +25,7 @@ RequireIncludePlugin.prototype.apply = function(compiler) {
 				return;
 
 			parser.apply(new RequireIncludeDependencyParserPlugin());
-			parser.plugin("evaluate typeof require.include", function(expr) {
-				return new BasicEvaluatedExpression().setString("function").setRange(expr.range);
-			});
+			parser.plugin("evaluate typeof require.include", ParserHelpers.evaluateToString("function"));
 			parser.plugin("typeof require.include", function(expr) {
 				var dep = new ConstDependency("'function'", expr.range);
 				dep.loc = expr.loc;

--- a/lib/dependencies/SystemPlugin.js
+++ b/lib/dependencies/SystemPlugin.js
@@ -5,6 +5,7 @@
 var UnsupportedFeatureWarning = require("../UnsupportedFeatureWarning");
 var ConstDependency = require("./ConstDependency");
 var BasicEvaluatedExpression = require("../BasicEvaluatedExpression");
+var ParserHelpers = require("../ParserHelpers");
 
 function SystemPlugin(options) {
 	this.options = options;
@@ -17,18 +18,6 @@ SystemPlugin.prototype.apply = function(compiler) {
 
 			if(typeof parserOptions.system !== "undefined" && !parserOptions.system)
 				return;
-
-			function setTypeof(expr, value) {
-				parser.plugin("evaluate typeof " + expr, function(expr) {
-					return new BasicEvaluatedExpression().setString(value).setRange(expr.range);
-				});
-				parser.plugin("typeof " + expr, function(expr) {
-					var dep = new ConstDependency(JSON.stringify(value), expr.range);
-					dep.loc = expr.loc;
-					this.state.current.addDependency(dep);
-					return true;
-				});
-			}
 
 			function setNotSupported(name) {
 				parser.plugin("evaluate typeof " + name, function(expr) {
@@ -44,8 +33,8 @@ SystemPlugin.prototype.apply = function(compiler) {
 				});
 			}
 
-			setTypeof("System", "object");
-			setTypeof("System.import", "function");
+			ParserHelpers.setTypeof(parser, "System", "object");
+			ParserHelpers.setTypeof(parser, "System.import", "function");
 			setNotSupported("System.set");
 			setNotSupported("System.get");
 			setNotSupported("System.register");

--- a/lib/dependencies/SystemPlugin.js
+++ b/lib/dependencies/SystemPlugin.js
@@ -27,8 +27,12 @@ SystemPlugin.prototype.apply = function(compiler) {
 				);
 			}
 
-			ParserHelpers.setTypeof(parser, "System", "object");
-			ParserHelpers.setTypeof(parser, "System.import", "function");
+			parser.plugin("typeof System", ParserHelpers.toConstantDependency("object"));
+			parser.plugin("evaluate typeof System", ParserHelpers.evaluateToString("object"));
+
+			parser.plugin("typeof System.import", ParserHelpers.toConstantDependency("function"));
+			parser.plugin("evaluate typeof System.import", ParserHelpers.evaluateToString("function"));
+
 			setNotSupported("System.set");
 			setNotSupported("System.get");
 			setNotSupported("System.register");

--- a/lib/dependencies/SystemPlugin.js
+++ b/lib/dependencies/SystemPlugin.js
@@ -2,7 +2,6 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var UnsupportedFeatureWarning = require("../UnsupportedFeatureWarning");
 var ConstDependency = require("./ConstDependency");
 var BasicEvaluatedExpression = require("../BasicEvaluatedExpression");
 var ParserHelpers = require("../ParserHelpers");
@@ -23,14 +22,9 @@ SystemPlugin.prototype.apply = function(compiler) {
 				parser.plugin("evaluate typeof " + name, function(expr) {
 					return new BasicEvaluatedExpression().setString("undefined").setRange(expr.range);
 				});
-				parser.plugin("expression " + name, function(expr) {
-					var dep = new ConstDependency("(void 0)", expr.range);
-					dep.loc = expr.loc;
-					this.state.current.addDependency(dep);
-					if(!this.state.module) return;
-					this.state.module.warnings.push(new UnsupportedFeatureWarning(this.state.module, name + " is not supported by webpack."));
-					return true;
-				});
+				parser.plugin("expression " + name,
+					ParserHelpers.expressionIsUnsupported(name + " is not supported by webpack.")
+				);
 			}
 
 			ParserHelpers.setTypeof(parser, "System", "object");

--- a/lib/dependencies/SystemPlugin.js
+++ b/lib/dependencies/SystemPlugin.js
@@ -3,7 +3,6 @@
 	Author Tobias Koppers @sokra
 */
 var ConstDependency = require("./ConstDependency");
-var BasicEvaluatedExpression = require("../BasicEvaluatedExpression");
 var ParserHelpers = require("../ParserHelpers");
 
 function SystemPlugin(options) {
@@ -19,9 +18,7 @@ SystemPlugin.prototype.apply = function(compiler) {
 				return;
 
 			function setNotSupported(name) {
-				parser.plugin("evaluate typeof " + name, function(expr) {
-					return new BasicEvaluatedExpression().setString("undefined").setRange(expr.range);
-				});
+				parser.plugin("evaluate typeof " + name, ParserHelpers.evaluateToString("undefined"));
 				parser.plugin("expression " + name,
 					ParserHelpers.expressionIsUnsupported(name + " is not supported by webpack.")
 				);

--- a/lib/node/NodeSourcePlugin.js
+++ b/lib/node/NodeSourcePlugin.js
@@ -4,7 +4,7 @@
 */
 var path = require("path");
 var AliasPlugin = require("enhanced-resolve/lib/AliasPlugin");
-var ModuleParserHelpers = require("../ModuleParserHelpers");
+var ParserHelpers = require("../ParserHelpers");
 var nodeLibsBrowser = require("node-libs-browser");
 
 function NodeSourcePlugin(options) {
@@ -37,7 +37,7 @@ NodeSourcePlugin.prototype.apply = function(compiler) {
 		suffix = suffix || "";
 		parser.plugin("expression " + name, function() {
 			if(this.state.module && this.state.module.resource === getPathToModule(module, type)) return;
-			return ModuleParserHelpers.addParsedVariable(this, name, buildExpression(this.state.module.context, getPathToModule(module, type)) + suffix);
+			return ParserHelpers.addParsedVariableToModule(this, name, buildExpression(this.state.module.context, getPathToModule(module, type)) + suffix);
 		});
 	}
 
@@ -53,7 +53,7 @@ NodeSourcePlugin.prototype.apply = function(compiler) {
 
 			if(localOptions.global) {
 				parser.plugin("expression global", function() {
-					return ModuleParserHelpers.addParsedVariable(this, "global", buildExpression(this.state.module.context, require.resolve("../../buildin/global.js")));
+					return ParserHelpers.addParsedVariableToModule(this, "global", buildExpression(this.state.module.context, require.resolve("../../buildin/global.js")));
 				});
 			}
 			if(localOptions.process) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

Is covered by existing tests

**If relevant, link to documentation update:**

N/A

**Summary**

While doing my refactorings to es6 i noticed that certain calls to the parser repeat themselves over several modules. 
First I tried to pull them as a whole into a helper function but then realized that for now a more atomic approach should probably be more reasonable, as it removes the sideeffects and makes it reusable throughout the code.

For me the these helper functions abstract a lot of the clutter away and make the code more readable as I can see with one glimpse what is happening.

**Does this PR introduce a breaking change?**

No

**Other information**

If this approach is "ok" I would love to continue on this bit by bit.
If the PR gets to big it will introduce too many conflicts with existing PRs I guess.
Therefore if I may continue, I would try this with a bunch of smaller PRs to keep the impact on files and therefore other PRs as small as possible.