### PR TITLE
Convert CaseSensitiveModulesWarning to es2015

### DIFF
--- a/lib/CaseSensitiveModulesWarning.js
+++ b/lib/CaseSensitiveModulesWarning.js
@@ -2,34 +2,42 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-function CaseSensitiveModulesWarning(modules) {
-	Error.call(this);
-	Error.captureStackTrace(this, CaseSensitiveModulesWarning);
-	this.name = "CaseSensitiveModulesWarning";
-	var modulesList = modules.slice().sort(function(a, b) {
-		a = a.identifier();
-		b = b.identifier();
-		if(a < b) return -1;
-		if(a > b) return 1;
-		return 0;
-	}).map(function(m) {
-		var message = "* " + m.identifier();
-		var validReasons = m.reasons.filter(function(r) {
-			return r.module;
-		});
-		if(validReasons.length > 0) {
-			message += "\n    Used by " + validReasons.length + " module(s), i. e.";
-			message += "\n    " + validReasons[0].module.identifier();
-		}
-		return message;
-	}).join("\n");
-	this.message = "There are multiple modules with names that only differ in casing.\n" +
-		"This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.\n" +
-		"Use equal casing. Compare these module identifiers:\n" +
-		modulesList;
-	this.origin = this.module = modules[0];
-}
-module.exports = CaseSensitiveModulesWarning;
+"use strict";
 
-CaseSensitiveModulesWarning.prototype = Object.create(Error.prototype);
-CaseSensitiveModulesWarning.prototype.constructor = CaseSensitiveModulesWarning;
+module.exports = class CaseSensitiveModulesWarning extends Error {
+	constructor(modules) {
+		super();
+		Error.captureStackTrace(this, CaseSensitiveModulesWarning);
+		this.name = "CaseSensitiveModulesWarning";
+
+		let sortedModules = this._sort(modules);
+		let modulesList = this._moduleMessages(sortedModules);
+		this.message = "There are multiple modules with names that only differ in casing.\n" +
+			"This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.\n" +
+			`Use equal casing. Compare these module identifiers:\n${modulesList}`;
+		this.origin = this.module = sortedModules[0];
+	}
+
+	_sort(modules) {
+		return modules.slice().sort((a, b) => {
+			a = a.identifier();
+			b = b.identifier();
+			if(a < b) return -1;
+			if(a > b) return 1;
+			return 0;
+		});
+	}
+
+	_moduleMessages(modules) {
+		return modules.map((m) => {
+			let message = `* ${m.identifier()}`;
+			let validReasons = m.reasons.filter((reason) => reason.module);
+
+			if(validReasons.length > 0) {
+				message += `\n    Used by ${validReasons.length} module(s), i. e.`;
+				message += `\n    ${validReasons[0].module.identifier()}`;
+			}
+			return message;
+		}).join("\n");
+	}
+}

--- a/test/CaseSensitiveModulesWarning.test.js
+++ b/test/CaseSensitiveModulesWarning.test.js
@@ -19,9 +19,9 @@ describe("CaseSensitiveModulesWarning", function() {
 
 	beforeEach(function() {
 		modules = [
+			createModule('FOOBAR'),
 			createModule('FooBar', 1),
-			createModule('foobar', 2),
-			createModule('FOOBAR')
+			createModule('foobar', 2)
 		];
 		myCaseSensitiveModulesWarning = new CaseSensitiveModulesWarning(modules);
 	});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
refactor to es2015

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Tests for the class already present

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

Refactor the function into an es2015 class
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
