### PR TITLE
Run quick NodeWatchFileSystem tests as part of test run

### DIFF
--- a/test/NodeWatchFileSystem.test.js
+++ b/test/NodeWatchFileSystem.test.js
@@ -1,25 +1,9 @@
 /* globals describe it */
 
-if(process.env.NO_WATCH_TESTS) {
-	describe("NodeWatchFileSystem", function() {
-		it("tests excluded");
-	});
-	return;
-}
-
 var should = require("should");
-var path = require("path");
-var fs = require("fs");
-
 var NodeWatchFileSystem = require("../lib/node/NodeWatchFileSystem");
 
-var fixtures = path.join(__dirname, "fixtures");
-var fileDirect = path.join(fixtures, "watched-file.txt");
-var fileSubdir = path.join(fixtures, "subdir", "watched-file.txt");
-
 describe("NodeWatchFileSystem", function() {
-	this.timeout(10000);
-
 	it('should throw if \'files\' argument is not an array', function() {
 		should(function() {
 			new NodeWatchFileSystem().watch(undefined)
@@ -61,6 +45,19 @@ describe("NodeWatchFileSystem", function() {
 			new NodeWatchFileSystem().watch([], [], [], 42, {}, function() {}, 'undefined')
 		}).throw("Invalid arguments: 'callbackUndelayed'");
 	});
+
+	if(process.env.NO_WATCH_TESTS) {
+		it("long running tests excluded");
+		return;
+	}
+
+	var path = require("path");
+	var fs = require("fs");
+	var fixtures = path.join(__dirname, "fixtures");
+	var fileDirect = path.join(fixtures, "watched-file.txt");
+	var fileSubdir = path.join(fixtures, "subdir", "watched-file.txt");
+
+	this.timeout(10000);
 
 	it("should register a file change (change delayed)", function(done) {
 		var startTime = new Date().getTime();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Run quick NodeWatchFileSystem tests 

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

This PR is only changes tests

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

The `NodeWatchFileSystem` file has tests which are not run as part of the CI run as they are behind `NO_WATCH_TESTS` flag. However, error tests (added as part of #3837) are very fast and increase the reported test coverage. This PR moves these out of the `NO_WATCH_TESTS` flag to be included in the test coverage report.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**

None