### PR TITLE
Add tests for WarnCaseSensitiveModulesPlugin

### DIFF
--- a/test/WarnCaseSensitiveModulesPlugin.test.js
+++ b/test/WarnCaseSensitiveModulesPlugin.test.js
@@ -1,0 +1,82 @@
+var should = require("should");
+var sinon = require("sinon");
+var PluginEnvironment = require("./helpers/PluginEnvironment");
+var applyPluginWithOptions = require("./helpers/applyPluginWithOptions");
+var WarnCaseSensitiveModulesPlugin = require("../lib/WarnCaseSensitiveModulesPlugin");
+
+describe("WarnCaseSensitiveModulesPlugin", function() {
+	var env;
+
+	beforeEach(function() {
+		env = {};
+	});
+
+	it("has apply function", function() {
+		(new WarnCaseSensitiveModulesPlugin()).apply.should.be.a.Function();
+	});
+
+	describe("when applied", function() {
+		beforeEach(function() {
+			env.eventBindings = applyPluginWithOptions(WarnCaseSensitiveModulesPlugin);
+		});
+
+		it("binds one event handler", function() {
+			env.eventBindings.length.should.be.exactly(1);
+		});
+
+		describe("compilation handler", function() {
+			beforeEach(function() {
+				env.pluginEnvironment = new PluginEnvironment();
+				env.eventBinding = env.eventBindings[0];
+				env.eventBinding.handler(env.pluginEnvironment.getEnvironmentStub());
+				env.compilationEventBindings = env.pluginEnvironment.getEventBindings();
+			});
+
+			it("binds to compilation event", function() {
+				env.eventBinding.name.should.be.exactly("compilation");
+			});
+
+			it("binds one compilation event handler", function() {
+				env.compilationEventBindings.length.should.be.exactly(1);
+			});
+
+			describe("seal handler", function() {
+				beforeEach(function() {
+					env.compilationEventContext = {
+						modules: [{
+								identifier: () => "Foo",
+								reasons: []
+							},
+							{
+								identifier: () => "Bar",
+								reasons: []
+							},
+							{
+								identifier: () => "fOO",
+								reasons: []
+							}
+						],
+						warnings: []
+					};
+					env.compilationEventBinding = env.compilationEventBindings[0];
+					env.compilationEventBinding.handler.call(env.compilationEventContext);
+				});
+
+				it("binds to seal event", function() {
+					env.compilationEventBinding.name.should.be.exactly("seal");
+				});
+
+				it("adds warning for each plugin with case insensitive name", function() {
+					env.compilationEventContext.warnings.length.should.be.exactly(1);
+					env.compilationEventContext.warnings[0].message.should.be.exactly(`
+There are multiple modules with names that only differ in casing.
+This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
+Use equal casing. Compare these module identifiers:
+* Foo
+* fOO
+`.trim());
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Add tests for WarnCaseSensitiveModulesPlugin

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

This PR is only tests

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Based on the coveralls report, the `WarnCaseSensitiveModulesPlugin` file has 86% test coverage. There is no `WarnCaseSensitiveModulesPlugin` specific test file - this is added in this PR and aims to achieve 100% test coverage.
https://coveralls.io/builds/9590222/source?filename=lib%2FWarnCaseSensitiveModulesPlugin.js

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**

The coverage of this file appears to depend on whether it is called in other tests (in other builds it has a coverage of 100%) - https://coveralls.io/builds/9584589/source?filename=lib%2FWarnCaseSensitiveModulesPlugin.js