### PR TITLE
Salt chunk hash instead of main hash in loop

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -979,7 +979,7 @@ class Compilation extends Tapable {
 			chunk = chunks[i];
 			const chunkHash = crypto.createHash(hashFunction);
 			if(outputOptions.hashSalt)
-				hash.update(outputOptions.hashSalt);
+				chunkHash.update(outputOptions.hashSalt);
 			chunk.updateHash(chunkHash);
 			if(chunk.hasRuntime()) {
 				this.mainTemplate.updateHashForChunk(chunkHash, chunk);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fix (maybe?)

**Did you add tests for your changes?**

N/A

**If relevant, link to documentation update:**

N/A

**Summary**

updating `chunkHash.update(outputOptions.hashSalt);` with the salt instead of repeatedly the `hash` might fix so far unknown "bugs".

**Does this PR introduce a breaking change?**

Should not.