### PR TITLE
[WIP] - chore(test): Increase timeout for WatchTestCases

### DIFF
--- a/test/WatchTestCases.test.js
+++ b/test/WatchTestCases.test.js
@@ -82,7 +82,7 @@ describe("WatchTestCases", function() {
 						remove(tempDirectory);
 					});
 					it("should compile", function(done) {
-						this.timeout(30000);
+						this.timeout(50000);
 						var outputDirectory = path.join(__dirname, "js", "watch", category.name, testName);
 
 						var options = {};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Fix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
N/A
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
This increases the timeout for WatchTestCases. It appears that CircleCI flakes out and is making PR's look failed from a timeout. Increasing this timeout to fix that. 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Nope
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Nope