### PR TITLE
Support UglifyJsPlugin with no arguments in CLI --plugin

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -216,7 +216,7 @@ module.exports = function(optimist, argv, convertOptions) {
 
 		function loadPlugin(name) {
 			var loadUtils = require("loader-utils");
-			var args = null;
+			var args;
 			try {
 				var p = name && name.indexOf("?");
 				if(p > -1) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

I didn't see any existing CLI tests, so no.

**Summary**

UglifyJsPlugin checks `typeof options !== "object"`, which doesn't work as expected with `null` since its type is `"object"`. https://github.com/webpack/webpack/blob/a1dca894d9a04f55529e4b7c44dcabe2c1b439a1/lib/optimize/UglifyJsPlugin.js#L16

See https://github.com/webpack/webpack/commit/48e17ab308a996928c965c7f29a07735af1b9391#commitcomment-20424582

**Does this PR introduce a breaking change?**

No