### PR TITLE
Support UglifyJsPlugin with no arguments in CLI --plugin

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -227,7 +227,7 @@ module.exports = function(yargs, argv, convertOptions) {
 
 		function loadPlugin(name) {
 			var loadUtils = require("loader-utils");
-			var args = null;
+			var args;
 			try {
 				var p = name && name.indexOf("?");
 				if(p > -1) {

--- a/test/binCases/plugins/uglifyjsplugin-empty-args/index.js
+++ b/test/binCases/plugins/uglifyjsplugin-empty-args/index.js
@@ -1,0 +1,1 @@
+module.exports = "foo";

--- a/test/binCases/plugins/uglifyjsplugin-empty-args/test.js
+++ b/test/binCases/plugins/uglifyjsplugin-empty-args/test.js
@@ -4,12 +4,7 @@ module.exports = function testAssertions(code, stdout, stderr) {
 	code.should.be.exactly(0);
 
 	stdout.should.be.ok();
-	stdout[3].should.containEql("Hash: ");
-	stdout[4].should.containEql("Version: ");
-	stdout[5].should.containEql("Time: ");
-	stdout[7].should.containEql("null.js");
-	stdout[8].should.containEql("./index.js");
-	stdout[8].should.containEql("[built]");
+	stdout[4].should.containEql("bytes"); // without uglifyjs it's multiple kBs
 
 	stderr.should.be.empty();
 };

--- a/test/binCases/plugins/uglifyjsplugin-empty-args/test.js
+++ b/test/binCases/plugins/uglifyjsplugin-empty-args/test.js
@@ -1,15 +1,15 @@
 "use strict";
 
 module.exports = function testAssertions(code, stdout, stderr) {
-  code.should.be.exactly(0);
+	code.should.be.exactly(0);
 
-  stdout.should.be.ok();
-  stdout[3].should.containEql("Hash: ");
-  stdout[4].should.containEql("Version: ");
-  stdout[5].should.containEql("Time: ");
-  stdout[7].should.containEql("null.js");
-  stdout[8].should.containEql("./index.js");
-  stdout[8].should.containEql("[built]");
+	stdout.should.be.ok();
+	stdout[3].should.containEql("Hash: ");
+	stdout[4].should.containEql("Version: ");
+	stdout[5].should.containEql("Time: ");
+	stdout[7].should.containEql("null.js");
+	stdout[8].should.containEql("./index.js");
+	stdout[8].should.containEql("[built]");
 
-  stderr.should.be.empty();
-}
+	stderr.should.be.empty();
+};

--- a/test/binCases/plugins/uglifyjsplugin-empty-args/test.js
+++ b/test/binCases/plugins/uglifyjsplugin-empty-args/test.js
@@ -1,0 +1,15 @@
+"use strict";
+
+module.exports = function testAssertions(code, stdout, stderr) {
+  code.should.be.exactly(0);
+
+  stdout.should.be.ok();
+  stdout[3].should.containEql("Hash: ");
+  stdout[4].should.containEql("Version: ");
+  stdout[5].should.containEql("Time: ");
+  stdout[7].should.containEql("null.js");
+  stdout[8].should.containEql("./index.js");
+  stdout[8].should.containEql("[built]");
+
+  stderr.should.be.empty();
+}

--- a/test/binCases/plugins/uglifyjsplugin-empty-args/test.opts
+++ b/test/binCases/plugins/uglifyjsplugin-empty-args/test.opts
@@ -1,0 +1,1 @@
+--plugin webpack/lib/optimize/UglifyJsPlugin

--- a/test/binCases/plugins/uglifyjsplugin-empty-args/webpack.config.js
+++ b/test/binCases/plugins/uglifyjsplugin-empty-args/webpack.config.js
@@ -1,5 +1,5 @@
 var path = require("path");
 
 module.exports = {
-  entry: path.resolve(__dirname, "./index"),
-}
+	entry: path.resolve(__dirname, "./index"),
+};

--- a/test/binCases/plugins/uglifyjsplugin-empty-args/webpack.config.js
+++ b/test/binCases/plugins/uglifyjsplugin-empty-args/webpack.config.js
@@ -1,0 +1,5 @@
+var path = require("path");
+
+module.exports = {
+  entry: path.resolve(__dirname, "./index"),
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

I didn't see any existing CLI tests, so no.

**Summary**

UglifyJsPlugin checks `typeof options !== "object"`, which doesn't work as expected with `null` since its type is `"object"`. https://github.com/webpack/webpack/blob/a1dca894d9a04f55529e4b7c44dcabe2c1b439a1/lib/optimize/UglifyJsPlugin.js#L16

See https://github.com/webpack/webpack/commit/48e17ab308a996928c965c7f29a07735af1b9391#commitcomment-20424582

**Does this PR introduce a breaking change?**

No