### PR TITLE
refactor(es6) upgrade FlagInitialModulesAsUsedPlugin to ES6 class

### DIFF
--- a/lib/FlagInitialModulesAsUsedPlugin.js
+++ b/lib/FlagInitialModulesAsUsedPlugin.js
@@ -2,19 +2,23 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-function FlagInitialModulesAsUsedPlugin() {}
-module.exports = FlagInitialModulesAsUsedPlugin;
-FlagInitialModulesAsUsedPlugin.prototype.apply = function(compiler) {
-	compiler.plugin("compilation", function(compilation) {
-		compilation.plugin("after-optimize-chunks", function(chunks) {
-			chunks.forEach(function(chunk) {
-				if(!chunk.isInitial()) {
-					return;
-				}
-				chunk.modules.forEach(function(module) {
-					module.usedExports = true;
+"use strict";
+
+class FlagInitialModulesAsUsedPlugin {
+	apply(compiler) {
+		compiler.plugin("compilation", (compilation) => {
+			compilation.plugin("after-optimize-chunks", (chunks) => {
+				chunks.forEach((chunk) => {
+					if(!chunk.isInitial()) {
+						return;
+					}
+					chunk.modules.forEach((module) => {
+						module.usedExports = true;
+					});
 				});
 			});
 		});
-	});
-};
+	}
+}
+
+module.exports = FlagInitialModulesAsUsedPlugin;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Refactor (ES5 => ES6)

**Did you add tests for your changes?**

No functionality was changed, existing tests passed

**If relevant, link to documentation update:**

N/A

**Summary**

Refactor the FlagInitialModulesAsUsedPlugin to an ES6 class

**Does this PR introduce a breaking change?**

N/A

**Other information**
