### PR TITLE
Pass mangle options to ast.figure_out_scope in uglify

### DIFF
--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -88,7 +88,7 @@ UglifyJsPlugin.prototype.apply = function(compiler) {
 						ast = ast.transform(compress);
 					}
 					if(options.mangle !== false) {
-						ast.figure_out_scope();
+						ast.figure_out_scope(options.mangle || {});
 						ast.compute_char_frequency(options.mangle || {});
 						ast.mangle_names(options.mangle || {});
 						if(options.mangle && options.mangle.props) {

--- a/test/configCases/plugins/uglifyjs-plugin/ie8.js
+++ b/test/configCases/plugins/uglifyjs-plugin/ie8.js
@@ -1,0 +1,9 @@
+function t(a,b) {
+    try {
+        throw a+a;
+    } catch(x) {
+        b(x);
+    }
+}
+
+module.exports = t;

--- a/test/configCases/plugins/uglifyjs-plugin/index.js
+++ b/test/configCases/plugins/uglifyjs-plugin/index.js
@@ -15,5 +15,13 @@ it("should contain comments in vendors chunk", function() {
 	source.should.containEql(" * comment should not be stripped vendors.3");
 });
 
+// this test is based off https://github.com/mishoo/UglifyJS2/blob/master/test/compress/screw-ie8.js
+it("should pass mangle options", function() {
+	var fs = require("fs"),
+		path = require("path");
+	var source = fs.readFileSync(path.join(__dirname, "ie8.js"), "utf-8");
+	source.should.containEql("function o(t,r){try{throw t+t}catch(o){r(o)}}");
+});
+
 
 require.include("./test.js");

--- a/test/configCases/plugins/uglifyjs-plugin/webpack.config.js
+++ b/test/configCases/plugins/uglifyjs-plugin/webpack.config.js
@@ -6,7 +6,8 @@ module.exports = {
 	},
 	entry: {
 		bundle0: ["./index.js"],
-		vendors: ["./vendors.js"]
+		vendors: ["./vendors.js"],
+		ie8: ["./ie8.js"]
 	},
 	output: {
 		filename: "[name].js"
@@ -14,7 +15,10 @@ module.exports = {
 	plugins: [
 		new webpack.optimize.UglifyJsPlugin({
 			comments: false,
-			exclude: ["vendors.js"]
+			exclude: ["vendors.js"],
+			mangle: {
+				screw_ie8: false
+			}
 		})
 	]
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?**
`options.mangle` was not passed to `ast.figure_out_scope`,` screw_ie8` was not getting passed and ie8 was breaking.
This PR is related with PR #3505 (Pass mangle options to ast.figure_out_scope in uglify).
The test case issue as mentioned on the PR #3505 is also solved.

You can check more detailed about this issue in https://github.com/webpack/webpack/pull/3505

**Did you add tests for your changes?**

Yes. The test case issue as mentioned on the PR #3505 is also solved. 

**Summary**

Since the mangle options were not passed, uglify was mangling the function parameters and causing IE8 to break (see taylorhakes/promise-polyfill#34 (comment)). By passing the options along, we can ensure that uglify knows to not break ie8.
(I quoted from PR #3505)
