### PR TITLE
explicitly call `new Stats` with compilation

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -14,7 +14,6 @@ const ModuleDependencyError = require("./ModuleDependencyError");
 const Module = require("./Module");
 const Chunk = require("./Chunk");
 const Entrypoint = require("./Entrypoint");
-const Stats = require("./Stats");
 const MainTemplate = require("./MainTemplate");
 const ChunkTemplate = require("./ChunkTemplate");
 const HotUpdateChunkTemplate = require("./HotUpdateChunkTemplate");
@@ -1080,10 +1079,6 @@ class Compilation extends Tapable {
 		data = data || {};
 		data.hash = data.hash || this.hash;
 		return this.mainTemplate.applyPluginsWaterfall("asset-path", filename, data);
-	}
-
-	getStats() {
-		return new Stats(this);
 	}
 
 	createChildCompiler(name, outputOptions) {

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -6,7 +6,7 @@ var path = require("path");
 var Tapable = require("tapable");
 
 var Compilation = require("./Compilation");
-
+var Stats = require("./Stats");
 var NormalModuleFactory = require("./NormalModuleFactory");
 var ContextModuleFactory = require("./ContextModuleFactory");
 
@@ -14,7 +14,6 @@ function Watching(compiler, watchOptions, handler) {
 	this.startTime = null;
 	this.invalid = false;
 	this.error = null;
-	this.stats = null;
 	this.handler = handler;
 	if(typeof watchOptions === "number") {
 		this.watchOptions = {
@@ -60,7 +59,7 @@ Watching.prototype._go = function() {
 					if(compilation.applyPluginsBailResult("need-additional-pass")) {
 						compilation.needAdditionalPass = true;
 
-						var stats = compilation.getStats();
+						var stats = new Stats(compilation);
 						stats.startTime = self.startTime;
 						stats.endTime = new Date().getTime();
 						self.compiler.applyPlugins("done", stats);
@@ -82,7 +81,7 @@ Watching.prototype._done = function(err, compilation) {
 	this.running = false;
 	if(this.invalid) return this._go();
 	this.error = err || null;
-	this.stats = compilation ? compilation.getStats() : null;
+	this.stats = compilation ? new Stats(compilation) : null;
 	if(this.stats) {
 		this.stats.startTime = this.startTime;
 		this.stats.endTime = new Date().getTime();
@@ -221,7 +220,7 @@ Compiler.prototype.run = function(callback) {
 					if(err) return callback(err);
 
 					if(self.applyPluginsBailResult("should-emit", compilation) === false) {
-						var stats = compilation.getStats();
+						var stats = new Stats(compilation);
 						stats.startTime = startTime;
 						stats.endTime = new Date().getTime();
 						self.applyPlugins("done", stats);
@@ -234,7 +233,7 @@ Compiler.prototype.run = function(callback) {
 						if(compilation.applyPluginsBailResult("need-additional-pass")) {
 							compilation.needAdditionalPass = true;
 
-							var stats = compilation.getStats();
+							var stats = new Stats(compilation);
 							stats.startTime = startTime;
 							stats.endTime = new Date().getTime();
 							self.applyPlugins("done", stats);
@@ -249,7 +248,7 @@ Compiler.prototype.run = function(callback) {
 						self.emitRecords(function(err) {
 							if(err) return callback(err);
 
-							var stats = compilation.getStats();
+							var stats = new Stats(compilation);
 							stats.startTime = startTime;
 							stats.endTime = new Date().getTime();
 							self.applyPlugins("done", stats);


### PR DESCRIPTION
instead of having compilation.getStats returning a new instance of `Stats(this)`

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

N/A

**If relevant, link to documentation update:**

N/A

**Summary**

This is probably a question of style, but this way I see directly what `stats` is, while `compilation.getStats()` could also just mean its already a finished stats object or the like.
Ill just leave this here anyways :)

**Does this PR introduce a breaking change?**

Nope
