### PR TITLE
Convert Template and subclasses to ES2015

### DIFF
--- a/lib/ChunkTemplate.js
+++ b/lib/ChunkTemplate.js
@@ -2,36 +2,35 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var ConcatSource = require("webpack-sources").ConcatSource;
-var Template = require("./Template");
+"use strict";
 
-function ChunkTemplate(outputOptions) {
-	Template.call(this, outputOptions);
-}
+const ConcatSource = require("webpack-sources").ConcatSource;
+const Template = require("./Template");
 
-module.exports = ChunkTemplate;
-
-ChunkTemplate.prototype = Object.create(Template.prototype);
-ChunkTemplate.prototype.constructor = ChunkTemplate;
-
-ChunkTemplate.prototype.render = function(chunk, moduleTemplate, dependencyTemplates) {
-	var modules = this.renderChunkModules(chunk, moduleTemplate, dependencyTemplates);
-	var core = this.applyPluginsWaterfall("modules", modules, chunk, moduleTemplate, dependencyTemplates);
-	var source = this.applyPluginsWaterfall("render", core, chunk, moduleTemplate, dependencyTemplates);
-	if(chunk.hasEntryModule()) {
-		source = this.applyPluginsWaterfall("render-with-entry", source, chunk);
+module.exports = class ChunkTemplate extends Template {
+	constructor(outputOptions) {
+		super(outputOptions);
 	}
-	chunk.rendered = true;
-	return new ConcatSource(source, ";");
-};
 
-ChunkTemplate.prototype.updateHash = function(hash) {
-	hash.update("ChunkTemplate");
-	hash.update("2");
-	this.applyPlugins("hash", hash);
-};
+	render(chunk, moduleTemplate, dependencyTemplates) {
+		let modules = this.renderChunkModules(chunk, moduleTemplate, dependencyTemplates);
+		let core = this.applyPluginsWaterfall("modules", modules, chunk, moduleTemplate, dependencyTemplates);
+		let source = this.applyPluginsWaterfall("render", core, chunk, moduleTemplate, dependencyTemplates);
+		if(chunk.hasEntryModule()) {
+			source = this.applyPluginsWaterfall("render-with-entry", source, chunk);
+		}
+		chunk.rendered = true;
+		return new ConcatSource(source, ";");
+	}
 
-ChunkTemplate.prototype.updateHashForChunk = function(hash, chunk) {
-	this.updateHash(hash);
-	this.applyPlugins("hash-for-chunk", hash, chunk);
+	updateHash(hash) {
+		hash.update("ChunkTemplate");
+		hash.update("2");
+		this.applyPlugins("hash", hash);
+	}
+
+	updateHashForChunk(hash, chunk) {
+		this.updateHash(hash);
+		this.applyPlugins("hash-for-chunk", hash, chunk);
+	}
 };

--- a/lib/HotUpdateChunkTemplate.js
+++ b/lib/HotUpdateChunkTemplate.js
@@ -2,30 +2,29 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var Template = require("./Template");
+"use strict";
 
-function HotUpdateChunkTemplate(outputOptions) {
-	Template.call(this, outputOptions);
-}
+const Template = require("./Template");
 
-module.exports = HotUpdateChunkTemplate;
+module.exports = class HotUpdateChunkTemplate extends Template {
+	constructor(outputOptions) {
+		super(outputOptions);
+	}
 
-HotUpdateChunkTemplate.prototype = Object.create(Template.prototype);
-HotUpdateChunkTemplate.prototype.constructor = HotUpdateChunkTemplate;
+	render(id, modules, removedModules, hash, moduleTemplate, dependencyTemplates) {
+		let modulesSource = this.renderChunkModules({
+			id: id,
+			modules: modules,
+			removedModules: removedModules
+		}, moduleTemplate, dependencyTemplates);
+		let core = this.applyPluginsWaterfall("modules", modulesSource, modules, removedModules, moduleTemplate, dependencyTemplates);
+		let source = this.applyPluginsWaterfall("render", core, modules, removedModules, hash, id, moduleTemplate, dependencyTemplates);
+		return source;
+	}
 
-HotUpdateChunkTemplate.prototype.render = function(id, modules, removedModules, hash, moduleTemplate, dependencyTemplates) {
-	var modulesSource = this.renderChunkModules({
-		id: id,
-		modules: modules,
-		removedModules: removedModules
-	}, moduleTemplate, dependencyTemplates);
-	var core = this.applyPluginsWaterfall("modules", modulesSource, modules, removedModules, moduleTemplate, dependencyTemplates);
-	var source = this.applyPluginsWaterfall("render", core, modules, removedModules, hash, id, moduleTemplate, dependencyTemplates);
-	return source;
-};
-
-HotUpdateChunkTemplate.prototype.updateHash = function(hash) {
-	hash.update("HotUpdateChunkTemplate");
-	hash.update("1");
-	this.applyPlugins("hash", hash);
+	updateHash(hash) {
+		hash.update("HotUpdateChunkTemplate");
+		hash.update("1");
+		this.applyPlugins("hash", hash);
+	}
 };

--- a/lib/MainTemplate.js
+++ b/lib/MainTemplate.js
@@ -2,10 +2,12 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var ConcatSource = require("webpack-sources").ConcatSource;
-var OriginalSource = require("webpack-sources").OriginalSource;
-var PrefixSource = require("webpack-sources").PrefixSource;
-var Template = require("./Template");
+"use strict";
+
+const ConcatSource = require("webpack-sources").ConcatSource;
+const OriginalSource = require("webpack-sources").OriginalSource;
+const PrefixSource = require("webpack-sources").PrefixSource;
+const Template = require("./Template");
 
 // require function shortcuts:
 // __webpack_require__.s = the module id of the entry point
@@ -21,214 +23,214 @@ var Template = require("./Template");
 // __webpack_require__.oe = the uncatched error handler for the webpack runtime
 // __webpack_require__.nc = the script nonce
 
-function MainTemplate(outputOptions) {
-	Template.call(this, outputOptions);
-	this.plugin("startup", function(source, chunk, hash) {
-		var buf = [];
-		if(chunk.entryModule) {
-			buf.push("// Load entry module and return exports");
-			buf.push("return " + this.renderRequireFunctionForModule(hash, chunk, JSON.stringify(chunk.entryModule.id)) +
-				"(" + this.requireFn + ".s = " + JSON.stringify(chunk.entryModule.id) + ");");
-		}
-		return this.asString(buf);
-	});
-	this.plugin("render", function(bootstrapSource, chunk, hash, moduleTemplate, dependencyTemplates) {
-		var source = new ConcatSource();
-		source.add("/******/ (function(modules) { // webpackBootstrap\n");
-		source.add(new PrefixSource("/******/", bootstrapSource));
-		source.add("/******/ })\n");
-		source.add("/************************************************************************/\n");
-		source.add("/******/ (");
-		var modules = this.renderChunkModules(chunk, moduleTemplate, dependencyTemplates, "/******/ ");
-		source.add(this.applyPluginsWaterfall("modules", modules, chunk, hash, moduleTemplate, dependencyTemplates));
-		source.add(")");
-		return source;
-	});
-	this.plugin("local-vars", function(source, chunk, hash) {
-		return this.asString([
-			source,
-			"// The module cache",
-			"var installedModules = {};"
-		]);
-	});
-	this.plugin("require", function(source, chunk, hash) {
-		return this.asString([
-			source,
-			"// Check if module is in cache",
-			"if(installedModules[moduleId])",
-			this.indent("return installedModules[moduleId].exports;"),
-			"",
-			"// Create a new module (and put it into the cache)",
-			"var module = installedModules[moduleId] = {",
-			this.indent(this.applyPluginsWaterfall("module-obj", "", chunk, hash, "moduleId")),
-			"};",
-			"",
-			this.asString(outputOptions.strictModuleExceptionHandling ? [
-				"// Execute the module function",
-				"var threw = true;",
-				"try {",
-				this.indent([
+module.exports = class MainTemplate extends Template {
+	constructor(outputOptions) {
+		super(outputOptions);
+		this.plugin("startup", (source, chunk, hash) => {
+			let buf = [];
+			if(chunk.entryModule) {
+				buf.push("// Load entry module and return exports");
+				buf.push("return " + this.renderRequireFunctionForModule(hash, chunk, JSON.stringify(chunk.entryModule.id)) +
+					"(" + this.requireFn + ".s = " + JSON.stringify(chunk.entryModule.id) + ");");
+			}
+			return this.asString(buf);
+		});
+		this.plugin("render", (bootstrapSource, chunk, hash, moduleTemplate, dependencyTemplates) => {
+			let source = new ConcatSource();
+			source.add("/******/ (function(modules) { // webpackBootstrap\n");
+			source.add(new PrefixSource("/******/", bootstrapSource));
+			source.add("/******/ })\n");
+			source.add("/************************************************************************/\n");
+			source.add("/******/ (");
+			let modules = this.renderChunkModules(chunk, moduleTemplate, dependencyTemplates, "/******/ ");
+			source.add(this.applyPluginsWaterfall("modules", modules, chunk, hash, moduleTemplate, dependencyTemplates));
+			source.add(")");
+			return source;
+		});
+		this.plugin("local-vars", (source, chunk, hash) => {
+			return this.asString([
+				source,
+				"// The module cache",
+				"var installedModules = {};"
+			]);
+		});
+		this.plugin("require", (source, chunk, hash) => {
+			return this.asString([
+				source,
+				"// Check if module is in cache",
+				"if(installedModules[moduleId])",
+				this.indent("return installedModules[moduleId].exports;"),
+				"",
+				"// Create a new module (and put it into the cache)",
+				"var module = installedModules[moduleId] = {",
+				this.indent(this.applyPluginsWaterfall("module-obj", "", chunk, hash, "moduleId")),
+				"};",
+				"",
+				this.asString(outputOptions.strictModuleExceptionHandling ? [
+					"// Execute the module function",
+					"var threw = true;",
+					"try {",
+					this.indent([
+						"modules[moduleId].call(module.exports, module, module.exports, " + this.renderRequireFunctionForModule(hash, chunk, "moduleId") + ");",
+						"threw = false;"
+					]),
+					"} finally {",
+					this.indent([
+						"if(threw) delete installedModules[moduleId];"
+					]),
+					"}"
+				] : [
+					"// Execute the module function",
 					"modules[moduleId].call(module.exports, module, module.exports, " + this.renderRequireFunctionForModule(hash, chunk, "moduleId") + ");",
-					"threw = false;"
 				]),
-				"} finally {",
+				"",
+				"// Flag the module as loaded",
+				"module.l = true;",
+				"",
+				"// Return the exports of the module",
+				"return module.exports;"
+			]);
+		});
+		this.plugin("module-obj", (source, chunk, hash, varModuleId) => {
+			return this.asString([
+				"i: moduleId,",
+				"l: false,",
+				"exports: {}"
+			]);
+		});
+		this.plugin("require-extensions", (source, chunk, hash) => {
+			let buf = [];
+			if(chunk.chunks.length > 0) {
+				buf.push("// This file contains only the entry chunk.");
+				buf.push("// The chunk loading function for additional chunks");
+				buf.push(this.requireFn + ".e = function requireEnsure(chunkId) {");
+				buf.push(this.indent(this.applyPluginsWaterfall("require-ensure", "throw new Error('Not chunk loading available');", chunk, hash, "chunkId")));
+				buf.push("};");
+			}
+			buf.push("");
+			buf.push("// expose the modules object (__webpack_modules__)");
+			buf.push(this.requireFn + ".m = modules;");
+
+			buf.push("");
+			buf.push("// expose the module cache");
+			buf.push(this.requireFn + ".c = installedModules;");
+
+			buf.push("");
+			buf.push("// identity function for calling harmony imports with the correct context");
+			buf.push(this.requireFn + ".i = function(value) { return value; };");
+
+			buf.push("");
+			buf.push("// define getter function for harmony exports");
+			buf.push(this.requireFn + ".d = function(exports, name, getter) {");
+			buf.push(this.indent([
+				"if(!" + this.requireFn + ".o(exports, name)) {",
 				this.indent([
-					"if(threw) delete installedModules[moduleId];"
+					"Object.defineProperty(exports, name, {",
+					this.indent([
+						"configurable: false,",
+						"enumerable: true,",
+						"get: getter"
+					]),
+					"});"
 				]),
 				"}"
-			] : [
-				"// Execute the module function",
-				"modules[moduleId].call(module.exports, module, module.exports, " + this.renderRequireFunctionForModule(hash, chunk, "moduleId") + ");",
-			]),
-			"",
-			"// Flag the module as loaded",
-			"module.l = true;",
-			"",
-			"// Return the exports of the module",
-			"return module.exports;"
-		]);
-	});
-	this.plugin("module-obj", function(source, chunk, hash, varModuleId) {
-		return this.asString([
-			"i: moduleId,",
-			"l: false,",
-			"exports: {}"
-		]);
-	});
-	this.plugin("require-extensions", function(source, chunk, hash) {
-		var buf = [];
-		if(chunk.chunks.length > 0) {
-			buf.push("// This file contains only the entry chunk.");
-			buf.push("// The chunk loading function for additional chunks");
-			buf.push(this.requireFn + ".e = function requireEnsure(chunkId) {");
-			buf.push(this.indent(this.applyPluginsWaterfall("require-ensure", "throw new Error('Not chunk loading available');", chunk, hash, "chunkId")));
+			]));
 			buf.push("};");
-		}
-		buf.push("");
-		buf.push("// expose the modules object (__webpack_modules__)");
-		buf.push(this.requireFn + ".m = modules;");
 
-		buf.push("");
-		buf.push("// expose the module cache");
-		buf.push(this.requireFn + ".c = installedModules;");
-
-		buf.push("");
-		buf.push("// identity function for calling harmony imports with the correct context");
-		buf.push(this.requireFn + ".i = function(value) { return value; };");
-
-		buf.push("");
-		buf.push("// define getter function for harmony exports");
-		buf.push(this.requireFn + ".d = function(exports, name, getter) {");
-		buf.push(this.indent([
-			"if(!" + this.requireFn + ".o(exports, name)) {",
-			this.indent([
-				"Object.defineProperty(exports, name, {",
+			buf.push("");
+			buf.push("// getDefaultExport function for compatibility with non-harmony modules");
+			buf.push(this.requireFn + ".n = function(module) {");
+			buf.push(this.indent([
+				"var getter = module && module.__esModule ?",
 				this.indent([
-					"configurable: false,",
-					"enumerable: true,",
-					"get: getter"
+					"function getDefault() { return module['default']; } :",
+					"function getModuleExports() { return module; };"
 				]),
-				"});"
-			]),
-			"}"
-		]));
-		buf.push("};");
+				this.requireFn + ".d(getter, 'a', getter);",
+				"return getter;"
+			]));
+			buf.push("};");
 
-		buf.push("");
-		buf.push("// getDefaultExport function for compatibility with non-harmony modules");
-		buf.push(this.requireFn + ".n = function(module) {");
-		buf.push(this.indent([
-			"var getter = module && module.__esModule ?",
-			this.indent([
-				"function getDefault() { return module['default']; } :",
-				"function getModuleExports() { return module; };"
-			]),
-			this.requireFn + ".d(getter, 'a', getter);",
-			"return getter;"
-		]));
-		buf.push("};");
+			buf.push("");
+			buf.push("// Object.prototype.hasOwnProperty.call");
+			buf.push(this.requireFn + ".o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };");
 
-		buf.push("");
-		buf.push("// Object.prototype.hasOwnProperty.call");
-		buf.push(this.requireFn + ".o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };");
-
-		var publicPath = this.getPublicPath({
-			hash: hash
+			let publicPath = this.getPublicPath({
+				hash: hash
+			});
+			buf.push("");
+			buf.push("// __webpack_public_path__");
+			buf.push(this.requireFn + ".p = " + JSON.stringify(publicPath) + ";");
+			return this.asString(buf);
 		});
+
+		this.requireFn = "__webpack_require__";
+	}
+
+	render(hash, chunk, moduleTemplate, dependencyTemplates) {
+		let buf = [];
+		buf.push(this.applyPluginsWaterfall("bootstrap", "", chunk, hash, moduleTemplate, dependencyTemplates));
+		buf.push(this.applyPluginsWaterfall("local-vars", "", chunk, hash));
 		buf.push("");
-		buf.push("// __webpack_public_path__");
-		buf.push(this.requireFn + ".p = " + JSON.stringify(publicPath) + ";");
-		return this.asString(buf);
-	});
-}
-module.exports = MainTemplate;
-
-MainTemplate.prototype = Object.create(Template.prototype);
-MainTemplate.prototype.constructor = MainTemplate;
-MainTemplate.prototype.requireFn = "__webpack_require__";
-MainTemplate.prototype.render = function(hash, chunk, moduleTemplate, dependencyTemplates) {
-	var buf = [];
-	buf.push(this.applyPluginsWaterfall("bootstrap", "", chunk, hash, moduleTemplate, dependencyTemplates));
-	buf.push(this.applyPluginsWaterfall("local-vars", "", chunk, hash));
-	buf.push("");
-	buf.push("// The require function");
-	buf.push("function " + this.requireFn + "(moduleId) {");
-	buf.push(this.indent(this.applyPluginsWaterfall("require", "", chunk, hash)));
-	buf.push("}");
-	buf.push("");
-	buf.push(this.asString(this.applyPluginsWaterfall("require-extensions", "", chunk, hash)));
-	buf.push("");
-	buf.push(this.asString(this.applyPluginsWaterfall("startup", "", chunk, hash)));
-	var source = this.applyPluginsWaterfall("render", new OriginalSource(this.prefix(buf, " \t") + "\n", "webpack/bootstrap " + hash), chunk, hash, moduleTemplate, dependencyTemplates);
-	if(chunk.hasEntryModule()) {
-		source = this.applyPluginsWaterfall("render-with-entry", source, chunk, hash);
+		buf.push("// The require function");
+		buf.push("function " + this.requireFn + "(moduleId) {");
+		buf.push(this.indent(this.applyPluginsWaterfall("require", "", chunk, hash)));
+		buf.push("}");
+		buf.push("");
+		buf.push(this.asString(this.applyPluginsWaterfall("require-extensions", "", chunk, hash)));
+		buf.push("");
+		buf.push(this.asString(this.applyPluginsWaterfall("startup", "", chunk, hash)));
+		let source = this.applyPluginsWaterfall("render", new OriginalSource(this.prefix(buf, " \t") + "\n", "webpack/bootstrap " + hash), chunk, hash, moduleTemplate, dependencyTemplates);
+		if(chunk.hasEntryModule()) {
+			source = this.applyPluginsWaterfall("render-with-entry", source, chunk, hash);
+		}
+		if(!source) throw new Error("Compiler error: MainTemplate plugin 'render' should return something");
+		chunk.rendered = true;
+		return new ConcatSource(source, ";");
 	}
-	if(!source) throw new Error("Compiler error: MainTemplate plugin 'render' should return something");
-	chunk.rendered = true;
-	return new ConcatSource(source, ";");
-};
 
-MainTemplate.prototype.renderRequireFunctionForModule = function(hash, chunk, varModuleId) {
-	return this.applyPluginsWaterfall("module-require", this.requireFn, chunk, hash, varModuleId);
-};
-
-MainTemplate.prototype.renderAddModule = function(hash, chunk, varModuleId, varModule) {
-	return this.applyPluginsWaterfall("add-module", "modules[" + varModuleId + "] = " + varModule + ";", chunk, hash, varModuleId, varModule);
-};
-
-MainTemplate.prototype.renderCurrentHashCode = function(hash, length) {
-	length = length || Infinity;
-	return this.applyPluginsWaterfall("current-hash", JSON.stringify(hash.substr(0, length)), length);
-};
-
-MainTemplate.prototype.entryPointInChildren = function(chunk) {
-	function checkChildren(chunk, alreadyCheckedChunks) {
-		return chunk.chunks.some(function(child) {
-			if(alreadyCheckedChunks.indexOf(child) >= 0) return;
-			alreadyCheckedChunks.push(child);
-			return child.hasEntryModule() || checkChildren(child, alreadyCheckedChunks);
-		});
+	renderRequireFunctionForModule(hash, chunk, varModuleId) {
+		return this.applyPluginsWaterfall("module-require", this.requireFn, chunk, hash, varModuleId);
 	}
-	return checkChildren(chunk, []);
-};
 
-MainTemplate.prototype.getPublicPath = function(options) {
-	return this.applyPluginsWaterfall("asset-path", this.outputOptions.publicPath || "", options);
-};
+	renderAddModule(hash, chunk, varModuleId, varModule) {
+		return this.applyPluginsWaterfall("add-module", "modules[" + varModuleId + "] = " + varModule + ";", chunk, hash, varModuleId, varModule);
+	}
 
-MainTemplate.prototype.updateHash = function(hash) {
-	hash.update("maintemplate");
-	hash.update("3");
-	hash.update(this.outputOptions.publicPath + "");
-	this.applyPlugins("hash", hash);
-};
+	renderCurrentHashCode(hash, length) {
+		length = length || Infinity;
+		return this.applyPluginsWaterfall("current-hash", JSON.stringify(hash.substr(0, length)), length);
+	}
 
-MainTemplate.prototype.updateHashForChunk = function(hash, chunk) {
-	this.updateHash(hash);
-	this.applyPlugins("hash-for-chunk", hash, chunk);
-};
+	entryPointInChildren(chunk) {
+		let checkChildren = (chunk, alreadyCheckedChunks) => {
+			return chunk.chunks.some((child) => {
+				if(alreadyCheckedChunks.indexOf(child) >= 0) return;
+				alreadyCheckedChunks.push(child);
+				return child.hasEntryModule() || checkChildren(child, alreadyCheckedChunks);
+			});
+		};
+		return checkChildren(chunk, []);
+	}
 
-MainTemplate.prototype.useChunkHash = function(chunk) {
-	var paths = this.applyPluginsWaterfall("global-hash-paths", []);
-	return !this.applyPluginsBailResult("global-hash", chunk, paths);
+	getPublicPath(options) {
+		return this.applyPluginsWaterfall("asset-path", this.outputOptions.publicPath || "", options);
+	}
+
+	updateHash(hash) {
+		hash.update("maintemplate");
+		hash.update("3");
+		hash.update(this.outputOptions.publicPath + "");
+		this.applyPlugins("hash", hash);
+	}
+
+	updateHashForChunk(hash, chunk) {
+		this.updateHash(hash);
+		this.applyPlugins("hash-for-chunk", hash, chunk);
+	}
+
+	useChunkHash(chunk) {
+		let paths = this.applyPluginsWaterfall("global-hash-paths", []);
+		return !this.applyPluginsBailResult("global-hash", chunk, paths);
+	}
 };

--- a/lib/Template.js
+++ b/lib/Template.js
@@ -2,159 +2,160 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var Tapable = require("tapable");
-var ConcatSource = require("webpack-sources").ConcatSource;
+"use strict";
 
-function Template(outputOptions) {
-	Tapable.call(this);
-	this.outputOptions = outputOptions || {};
-}
-module.exports = Template;
+const Tapable = require("tapable");
+const ConcatSource = require("webpack-sources").ConcatSource;
 
-Template.getFunctionContent = function(fn) {
-	return fn.toString().replace(/^function\s?\(\)\s?\{\n?|\n?\}$/g, "").replace(/^\t/mg, "");
-};
+const START_LOWERCASE_ALPHABET_CODE = "a".charCodeAt(0);
+const START_UPPERCASE_ALPHABET_CODE = "A".charCodeAt(0);
+const DELTA_A_TO_Z = "z".charCodeAt(0) - START_LOWERCASE_ALPHABET_CODE + 1;
 
-Template.toIdentifier = function(str) {
-	if(typeof str !== "string") return "";
-	return str.replace(/^[^a-zA-Z$_]/, "_").replace(/[^a-zA-Z0-9$_]/g, "_");
-};
+module.exports = class Template extends Tapable {
+	constructor(outputOptions) {
+		super();
+		this.outputOptions = outputOptions || {};
+	}
 
-var START_LOWERCASE_ALPHABET_CODE = "a".charCodeAt(0);
-var START_UPPERCASE_ALPHABET_CODE = "A".charCodeAt(0);
-var DELTA_A_TO_Z = "z".charCodeAt(0) - START_LOWERCASE_ALPHABET_CODE + 1;
-// map number to a single character a-z, A-Z or <_ + number> if number is too big
-Template.numberToIdentifer = function numberToIdentifer(n) {
-	// lower case
-	if(n < DELTA_A_TO_Z) return String.fromCharCode(START_LOWERCASE_ALPHABET_CODE + n);
+	static getFunctionContent(fn) {
+		return fn.toString().replace(/^function\s?\(\)\s?\{\n?|\n?\}$/g, "").replace(/^\t/mg, "");
+	}
 
-	// upper case
-	n -= DELTA_A_TO_Z;
-	if(n < DELTA_A_TO_Z) return String.fromCharCode(START_UPPERCASE_ALPHABET_CODE + n);
+	static toIdentifier(str) {
+		if(typeof str !== "string") return "";
+		return str.replace(/^[^a-zA-Z$_]/, "_").replace(/[^a-zA-Z0-9$_]/g, "_");
+	}
 
-	// fall back to _ + number
-	n -= DELTA_A_TO_Z;
-	return "_" + n;
-};
+	// map number to a single character a-z, A-Z or <_ + number> if number is too big
+	static numberToIdentifer(n) {
+		// lower case
+		if(n < DELTA_A_TO_Z) return String.fromCharCode(START_LOWERCASE_ALPHABET_CODE + n);
 
-Template.prototype = Object.create(Tapable.prototype);
-Template.prototype.constructor = Template;
+		// upper case
+		n -= DELTA_A_TO_Z;
+		if(n < DELTA_A_TO_Z) return String.fromCharCode(START_UPPERCASE_ALPHABET_CODE + n);
 
-Template.prototype.indent = function indent(str) {
-	if(Array.isArray(str)) {
-		return str.map(indent).join("\n");
-	} else {
-		str = str.trimRight();
+		// fall back to _ + number
+		n -= DELTA_A_TO_Z;
+		return "_" + n;
+	}
+
+	indent(str) {
+		if(Array.isArray(str)) {
+			return str.map(this.indent.bind(this)).join("\n");
+		} else {
+			str = str.trimRight();
+			if(!str) return "";
+			var ind = (str[0] === "\n" ? "" : "\t");
+			return ind + str.replace(/\n([^\n])/g, "\n\t$1");
+		}
+	}
+
+	prefix(str, prefix) {
+		if(Array.isArray(str)) {
+			str = str.join("\n");
+		}
+		str = str.trim();
 		if(!str) return "";
-		var ind = (str[0] === "\n" ? "" : "\t");
-		return ind + str.replace(/\n([^\n])/g, "\n\t$1");
+		let ind = (str[0] === "\n" ? "" : prefix);
+		return ind + str.replace(/\n([^\n])/g, "\n" + prefix + "$1");
 	}
-};
 
-Template.prototype.prefix = function(str, prefix) {
-	if(Array.isArray(str)) {
-		str = str.join("\n");
+	asString(str) {
+		if(Array.isArray(str)) {
+			return str.join("\n");
+		}
+		return str;
 	}
-	str = str.trim();
-	if(!str) return "";
-	var ind = (str[0] === "\n" ? "" : prefix);
-	return ind + str.replace(/\n([^\n])/g, "\n" + prefix + "$1");
-};
 
-Template.prototype.asString = function(str) {
-	if(Array.isArray(str)) {
-		return str.join("\n");
+	getModulesArrayBounds(modules) {
+		if(!modules.every(moduleIdIsNumber))
+			return false;
+		var maxId = -Infinity;
+		var minId = Infinity;
+		modules.forEach(function(module) {
+			if(maxId < module.id) maxId = module.id;
+			if(minId > module.id) minId = module.id;
+		});
+		if(minId < 16 + ("" + minId).length) {
+			// add minId x ',' instead of 'Array(minId).concat(...)'
+			minId = 0;
+		}
+		var objectOverhead = modules.map(function(module) {
+			var idLength = (module.id + "").length;
+			return idLength + 2;
+		}).reduce(function(a, b) {
+			return a + b;
+		}, -1);
+		var arrayOverhead = minId === 0 ? maxId : 16 + ("" + minId).length + maxId;
+		return arrayOverhead < objectOverhead ? [minId, maxId] : false;
 	}
-	return str;
+
+	renderChunkModules(chunk, moduleTemplate, dependencyTemplates, prefix) {
+		if(!prefix) prefix = "";
+		var source = new ConcatSource();
+		if(chunk.modules.length === 0) {
+			source.add("[]");
+			return source;
+		}
+		var removedModules = chunk.removedModules;
+		var allModules = chunk.modules.map(function(module) {
+			return {
+				id: module.id,
+				source: moduleTemplate.render(module, dependencyTemplates, chunk)
+			};
+		});
+		if(removedModules && removedModules.length > 0) {
+			removedModules.forEach(function(id) {
+				allModules.push({
+					id: id,
+					source: "false"
+				});
+			});
+		}
+		var bounds = this.getModulesArrayBounds(chunk.modules);
+
+		if(bounds) {
+			// Render a spare array
+			var minId = bounds[0];
+			var maxId = bounds[1];
+			if(minId !== 0) source.add("Array(" + minId + ").concat(");
+			source.add("[\n");
+			var modules = {};
+			allModules.forEach(function(module) {
+				modules[module.id] = module;
+			});
+			for(var idx = minId; idx <= maxId; idx++) {
+				var module = modules[idx];
+				if(idx !== minId) source.add(",\n");
+				source.add("/* " + idx + " */");
+				if(module) {
+					source.add("\n");
+					source.add(module.source);
+				}
+			}
+			source.add("\n" + prefix + "]");
+			if(minId !== 0) source.add(")");
+		} else {
+			// Render an object
+			source.add("{\n");
+			allModules.sort(function(a, b) {
+				var aId = a.id + "";
+				var bId = b.id + "";
+				if(aId < bId) return -1;
+				if(aId > bId) return 1;
+				return 0;
+			}).forEach(function(module, idx) {
+				if(idx !== 0) source.add(",\n");
+				source.add("\n/***/ " + JSON.stringify(module.id) + ":\n");
+				source.add(module.source);
+			});
+			source.add("\n\n" + prefix + "}");
+		}
+		return source;
+	}
 };
 
 function moduleIdIsNumber(module) {
 	return typeof module.id === "number";
 }
-
-Template.prototype.getModulesArrayBounds = function(modules) {
-	if(!modules.every(moduleIdIsNumber))
-		return false;
-	var maxId = -Infinity;
-	var minId = Infinity;
-	modules.forEach(function(module) {
-		if(maxId < module.id) maxId = module.id;
-		if(minId > module.id) minId = module.id;
-	});
-	if(minId < 16 + ("" + minId).length) {
-		// add minId x ',' instead of 'Array(minId).concat(...)'
-		minId = 0;
-	}
-	var objectOverhead = modules.map(function(module) {
-		var idLength = (module.id + "").length;
-		return idLength + 2;
-	}).reduce(function(a, b) {
-		return a + b;
-	}, -1);
-	var arrayOverhead = minId === 0 ? maxId : 16 + ("" + minId).length + maxId;
-	return arrayOverhead < objectOverhead ? [minId, maxId] : false;
-};
-
-Template.prototype.renderChunkModules = function(chunk, moduleTemplate, dependencyTemplates, prefix) {
-	if(!prefix) prefix = "";
-	var source = new ConcatSource();
-	if(chunk.modules.length === 0) {
-		source.add("[]");
-		return source;
-	}
-	var removedModules = chunk.removedModules;
-	var allModules = chunk.modules.map(function(module) {
-		return {
-			id: module.id,
-			source: moduleTemplate.render(module, dependencyTemplates, chunk)
-		};
-	});
-	if(removedModules && removedModules.length > 0) {
-		removedModules.forEach(function(id) {
-			allModules.push({
-				id: id,
-				source: "false"
-			});
-		});
-	}
-	var bounds = this.getModulesArrayBounds(chunk.modules);
-
-	if(bounds) {
-		// Render a spare array
-		var minId = bounds[0];
-		var maxId = bounds[1];
-		if(minId !== 0) source.add("Array(" + minId + ").concat(");
-		source.add("[\n");
-		var modules = {};
-		allModules.forEach(function(module) {
-			modules[module.id] = module;
-		});
-		for(var idx = minId; idx <= maxId; idx++) {
-			var module = modules[idx];
-			if(idx !== minId) source.add(",\n");
-			source.add("/* " + idx + " */");
-			if(module) {
-				source.add("\n");
-				source.add(module.source);
-			}
-		}
-		source.add("\n" + prefix + "]");
-		if(minId !== 0) source.add(")");
-	} else {
-		// Render an object
-		source.add("{\n");
-		allModules.sort(function(a, b) {
-			var aId = a.id + "";
-			var bId = b.id + "";
-			if(aId < bId) return -1;
-			if(aId > bId) return 1;
-			return 0;
-		}).forEach(function(module, idx) {
-			if(idx !== 0) source.add(",\n");
-			source.add("\n/***/ " + JSON.stringify(module.id) + ":\n");
-			source.add(module.source);
-		});
-		source.add("\n\n" + prefix + "}");
-	}
-	return source;
-};


### PR DESCRIPTION
Subclasses include `MainTemplate`, `ChunkTemplate` and
`HotUpdateChunkTemplate`.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refactor to ES2015.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Tests already present.
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Move few files to ES2015.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
