### PR TITLE
Fixes #3946 (stats options being ignored)

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -175,10 +175,11 @@ function processOptions(options) {
 	var statsPresetToOptions = require("../lib/Stats.js").presetToOptions;
 
 	var outputOptions = options.stats;
-	if(typeof outputOptions === "boolean" || typeof outputOptions === "string")
+	if(typeof outputOptions === "boolean" || typeof outputOptions === "string") {
 		outputOptions = statsPresetToOptions(outputOptions);
-	else
+	} else if(!outputOptions) {
 		outputOptions = {};
+	}
 	outputOptions = Object.create(outputOptions);
 	if(Array.isArray(options) && !outputOptions.children) {
 		outputOptions.children = options.map(o => o.stats);

--- a/test/binCases/stats/single-config/test.js
+++ b/test/binCases/stats/single-config/test.js
@@ -7,9 +7,10 @@ module.exports = function testAssertions(code, stdout, stderr) {
 	stdout[0].should.containEql("Hash: ");
 	stdout[1].should.containEql("Version: ");
 	stdout[2].should.containEql("Time: ");
-	stdout[4].should.containEql("null.js");
-	stdout[5].should.containEql("./index.js");
-	stdout[5].should.containEql("[built]");
+	stdout[4].should.containEql("\u001b[1m\u001b[32mnull.js\u001b[39m\u001b[22m");
+	stdout[5].should.not.containEql("./index.js");
+	stdout[5].should.not.containEql("[built]");
+	stdout[5].should.containEql("1 hidden module");
 
 	stderr.should.be.empty();
 };

--- a/test/binCases/stats/single-config/webpack.config.js
+++ b/test/binCases/stats/single-config/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	stats: {
 		assets: true,
 		colors: true,
-		chunks: true
+		chunks: true,
+		maxModules: 0
 	}
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix for #3946 - all `stats` options provided at Webpack config are being ignored.

**Did you add tests for your changes?**

It surprises me that such bug is passing existent tests.

**If relevant, link to documentation update:**

N/A

**Summary**

#3946 - stats options being ignored.

**Does this PR introduce a breaking change?**

No.

**Other information**

The whole issue is quite simple.

I have examined the commit which introduced the bug:

- https://github.com/webpack/webpack/pull/3524/files

Please pay attention at the changes for `lib/MultiStats.js`. There, the lines from 33 to 35 are preventing the bug. I just did the same to `lib/Stats.js`.
