### PR TITLE
remove buildin/return-require as it has no user (apparently)

### DIFF
--- a/buildin/return-require.js
+++ b/buildin/return-require.js
@@ -1,4 +1,0 @@
-/* globals __webpack_require__ */
-module.exports = function() {
-	return __webpack_require__;
-};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Delete dead file

**Did you add tests for your changes?**

N/A

**If relevant, link to documentation update:**

N/A

**Summary**

buildin/return-require.js has no user anymore and can probably be deleted?

**Does this PR introduce a breaking change?**

I would think no.
