### PR TITLE
fix(nmf): Fix exports for var injection to include free glob export or args

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -270,10 +270,9 @@ NormalModule.prototype.source = function(dependencyTemplates, outputOptions, req
 
 			var emitFunction = function emitFunction() {
 				if(varNames.length === 0) return;
-
 				varStartCode += "/* WEBPACK VAR INJECTION */(function(" + varNames.join(", ") + ") {";
 				// exports === this in the topLevelBlock, but exports do compress better...
-				varEndCode = (topLevelBlock === block ? "}.call(exports, " : "}.call(this, ") +
+				varEndCode = (topLevelBlock === block ? "}.call(module.exportsArgument || 'exports', " : "}.call(this, ") +
 					varExpressions.map(function(e) {
 						return e.source();
 					}).join(", ") + "))" + varEndCode;

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -272,7 +272,7 @@ NormalModule.prototype.source = function(dependencyTemplates, outputOptions, req
 				if(varNames.length === 0) return;
 				varStartCode += "/* WEBPACK VAR INJECTION */(function(" + varNames.join(", ") + ") {";
 				// exports === this in the topLevelBlock, but exports do compress better...
-				varEndCode = (topLevelBlock === block ? "}.call(module.exportsArgument || 'exports', " : "}.call(this, ") +
+				varEndCode = (topLevelBlock === block ? "}.call(" + (topLevelBlock.exportsArgument || "exports") + ", " : "}.call(this, ") +
 					varExpressions.map(function(e) {
 						return e.source();
 					}).join(", ") + "))" + varEndCode;

--- a/test/configCases/parsing/harmony-global/index.js
+++ b/test/configCases/parsing/harmony-global/index.js
@@ -1,0 +1,5 @@
+require("should");
+it("should be able to use global in a harmony module", function() {
+	var x = require("./module1");
+	(x.default === global).should.be.ok();
+});

--- a/test/configCases/parsing/harmony-global/module.js
+++ b/test/configCases/parsing/harmony-global/module.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/test/configCases/parsing/harmony-global/module1.js
+++ b/test/configCases/parsing/harmony-global/module1.js
@@ -1,0 +1,3 @@
+var freeGlobal = typeof global === "object" && global && global.Object === Object && global;
+
+export default freeGlobal;

--- a/test/configCases/parsing/harmony-global/webpack.config.js
+++ b/test/configCases/parsing/harmony-global/webpack.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	target: "web",
+	performance: {
+		hints: false
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
N/A
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Patches issue discovered in RC5. exportArguments should be tried first before "exports".
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Fixes #3917