### PR TITLE
Add tests for ModuleDependencyError

### DIFF
--- a/test/ModuleDependencyError.test.js
+++ b/test/ModuleDependencyError.test.js
@@ -1,0 +1,48 @@
+var path = require("path");
+var should = require("should");
+var sinon = require("sinon");
+var ModuleDependencyError = require("../lib/ModuleDependencyError");
+
+describe("ModuleDependencyError", function() {
+	var env;
+
+	beforeEach(function() {
+		env = {};
+	});
+
+	it("is a function", function() {
+		ModuleDependencyError.should.be.a.Function();
+	});
+
+	describe("when new error created", function() {
+		beforeEach(function() {
+			env.error = new Error("Error Message");
+			env.moduleDependencyError = new ModuleDependencyError("myModule", env.error, "Location");
+		});
+
+		it("is an error", function() {
+			env.moduleDependencyError.should.be.an.Error();
+		});
+
+		it("has a name property", function() {
+			env.moduleDependencyError.name.should.be.exactly("ModuleDependencyError");
+		});
+
+		it("has a message property", function() {
+			env.moduleDependencyError.message.should.be.exactly("Location Error Message");
+		});
+
+		it("has a details property", function() {
+			env.moduleDependencyError.details.should.containEql(path.join("test", "ModuleDependencyError.test.js:"));
+		});
+
+		it("has an origin property", function() {
+			env.moduleDependencyError.origin.should.be.exactly("myModule");
+		});
+
+		it("has an error property", function() {
+			env.moduleDependencyError.error.should.be.exactly(env.error);
+		});
+
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Add tests for ModuleDependencyError

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

This PR is only tests

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Based on the coveralls report, the `ModuleDependencyError` file has 20% test coverage. There is no `ModuleDependencyError` specific test file - this is added in this PR and aims to achieve 100% test coverage.
https://coveralls.io/builds/9689291/source?filename=lib%2FModuleDependencyError.js

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**

None