### PR TITLE
Add error callback support to require.ensure

### DIFF
--- a/lib/HotModuleReplacement.runtime.js
+++ b/lib/HotModuleReplacement.runtime.js
@@ -43,34 +43,31 @@ module.exports = function() {
 			};
 		};
 		for(var name in $require$) {
-			if(Object.prototype.hasOwnProperty.call($require$, name)) {
+			if(Object.prototype.hasOwnProperty.call($require$, name) && name !== "e") {
 				Object.defineProperty(fn, name, ObjectFactory(name));
 			}
 		}
-		Object.defineProperty(fn, "e", {
-			enumerable: true,
-			value: function(chunkId) {
-				if(hotStatus === "ready")
-					hotSetStatus("prepare");
-				hotChunksLoading++;
-				return $require$.e(chunkId).then(finishChunkLoading, function(err) {
-					finishChunkLoading();
-					throw err;
-				});
+		fn.e = function(chunkId) {
+			if(hotStatus === "ready")
+				hotSetStatus("prepare");
+			hotChunksLoading++;
+			return $require$.e(chunkId).then(finishChunkLoading, function(err) {
+				finishChunkLoading();
+				throw err;
+			});
 
-				function finishChunkLoading() {
-					hotChunksLoading--;
-					if(hotStatus === "prepare") {
-						if(!hotWaitingFilesMap[chunkId]) {
-							hotEnsureUpdateChunk(chunkId);
-						}
-						if(hotChunksLoading === 0 && hotWaitingFiles === 0) {
-							hotUpdateDownloaded();
-						}
+			function finishChunkLoading() {
+				hotChunksLoading--;
+				if(hotStatus === "prepare") {
+					if(!hotWaitingFilesMap[chunkId]) {
+						hotEnsureUpdateChunk(chunkId);
+					}
+					if(hotChunksLoading === 0 && hotWaitingFiles === 0) {
+						hotUpdateDownloaded();
 					}
 				}
 			}
-		});
+		};
 		return fn;
 	}
 

--- a/lib/dependencies/RequireEnsureDependenciesBlock.js
+++ b/lib/dependencies/RequireEnsureDependenciesBlock.js
@@ -7,11 +7,19 @@ const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
 const RequireEnsureDependency = require("./RequireEnsureDependency");
 
 module.exports = class RequireEnsureDependenciesBlock extends AsyncDependenciesBlock {
-	constructor(expr, fnExpression, chunkName, chunkNameRange, module, loc) {
+	constructor(expr, successExpression, errorExpression, chunkName, chunkNameRange, module, loc) {
 		super(chunkName, module, loc);
 		this.expr = expr;
-		const bodyRange = fnExpression && fnExpression.body && fnExpression.body.range;
-		this.range = bodyRange && [bodyRange[0] + 1, bodyRange[1] - 1] || null;
+		const successBodyRange = successExpression && successExpression.body && successExpression.body.range;
+		const errorBodyRange = errorExpression && errorExpression.body && errorExpression.body.range;
+		this.range = null;
+		if(successBodyRange) {
+			if(errorBodyRange) {
+				this.range = [successBodyRange[0] + 1, errorBodyRange[1] - 1];
+			} else {
+				this.range = [successBodyRange[0] + 1, successBodyRange[1] - 1];
+			}
+		}
 		this.chunkNameRange = chunkNameRange;
 		let dep = new RequireEnsureDependency(this);
 		dep.loc = loc;

--- a/lib/dependencies/RequireEnsureDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/RequireEnsureDependenciesBlockParserPlugin.js
@@ -13,27 +13,48 @@ module.exports = class RequireEnsureDependenciesBlockParserPlugin {
 		parser.plugin("call require.ensure", expr => {
 			let chunkName = null;
 			let chunkNameRange = null;
+			let errorExpressionArg = null;
+			let errorExpression = null;
 			switch(expr.arguments.length) {
-				case 3:
+				case 4:
 					{
-						const chunkNameExpr = parser.evaluateExpression(expr.arguments[2]);
+						const chunkNameExpr = parser.evaluateExpression(expr.arguments[3]);
 						if(!chunkNameExpr.isString()) return;
 						chunkNameRange = chunkNameExpr.range;
 						chunkName = chunkNameExpr.string;
+					}
+					// falls through
+				case 3:
+					{
+						errorExpressionArg = expr.arguments[2];
+						errorExpression = getFunctionExpression(errorExpressionArg);
+
+						if(!errorExpression && !chunkName) {
+							const chunkNameExpr = parser.evaluateExpression(expr.arguments[2]);
+							if(!chunkNameExpr.isString()) return;
+							chunkNameRange = chunkNameExpr.range;
+							chunkName = chunkNameExpr.string;
+						}
 					}
 					// falls through
 				case 2:
 					{
 						const dependenciesExpr = parser.evaluateExpression(expr.arguments[0]);
 						const dependenciesItems = dependenciesExpr.isArray() ? dependenciesExpr.items : [dependenciesExpr];
-						const fnExpressionArg = expr.arguments[1];
-						const fnExpression = getFunctionExpression(fnExpressionArg);
+						const successExpressionArg = expr.arguments[1];
+						const successExpression = getFunctionExpression(successExpressionArg);
 
-						if(fnExpression) {
-							parser.walkExpressions(fnExpression.expressions);
+						if(successExpression) {
+							parser.walkExpressions(successExpression.expressions);
+						}
+						if(errorExpression) {
+							parser.walkExpressions(errorExpression.expressions);
 						}
 
-						const dep = new RequireEnsureDependenciesBlock(expr, fnExpression ? fnExpression.fn : fnExpressionArg, chunkName, chunkNameRange, parser.state.module, expr.loc);
+						const dep = new RequireEnsureDependenciesBlock(expr,
+							successExpression ? successExpression.fn : successExpressionArg,
+							errorExpression ? errorExpression.fn : errorExpressionArg,
+							chunkName, chunkNameRange, parser.state.module, expr.loc);
 						const old = parser.state.current;
 						parser.state.current = dep;
 						try {
@@ -52,18 +73,24 @@ module.exports = class RequireEnsureDependenciesBlockParserPlugin {
 							if(failed) {
 								return;
 							}
-							if(fnExpression) {
-								if(fnExpression.fn.body.type === "BlockStatement")
-									parser.walkStatement(fnExpression.fn.body);
+							if(successExpression) {
+								if(successExpression.fn.body.type === "BlockStatement")
+									parser.walkStatement(successExpression.fn.body);
 								else
-									parser.walkExpression(fnExpression.fn.body);
+									parser.walkExpression(successExpression.fn.body);
+							}
+							if(errorExpression) {
+								if(errorExpression.fn.body.type === "BlockStatement")
+									parser.walkStatement(errorExpression.fn.body);
+								else
+									parser.walkExpression(errorExpression.fn.body);
 							}
 							old.addBlock(dep);
 						} finally {
 							parser.state.current = old;
 						}
-						if(!fnExpression) {
-							parser.walkExpression(fnExpressionArg);
+						if(!successExpression) {
+							parser.walkExpression(successExpressionArg);
 						}
 						return true;
 					}

--- a/lib/dependencies/RequireEnsureDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/RequireEnsureDependenciesBlockParserPlugin.js
@@ -79,18 +79,20 @@ module.exports = class RequireEnsureDependenciesBlockParserPlugin {
 								else
 									parser.walkExpression(successExpression.fn.body);
 							}
-							if(errorExpression) {
-								if(errorExpression.fn.body.type === "BlockStatement")
-									parser.walkStatement(errorExpression.fn.body);
-								else
-									parser.walkExpression(errorExpression.fn.body);
-							}
 							old.addBlock(dep);
 						} finally {
 							parser.state.current = old;
 						}
 						if(!successExpression) {
 							parser.walkExpression(successExpressionArg);
+						}
+						if(errorExpression) {
+							if(errorExpression.fn.body.type === "BlockStatement")
+								parser.walkStatement(errorExpression.fn.body);
+							else
+								parser.walkExpression(errorExpression.fn.body);
+						} else if(errorExpressionArg) {
+							parser.walkExpression(errorExpressionArg);
 						}
 						return true;
 					}

--- a/lib/dependencies/RequireEnsureDependency.js
+++ b/lib/dependencies/RequireEnsureDependency.js
@@ -21,10 +21,17 @@ RequireEnsureDependency.Template = class RequireEnsureDependencyTemplate {
 	apply(dep, source, outputOptions, requestShortener) {
 		const depBlock = dep.block;
 		const wrapper = DepBlockHelpers.getLoadDepBlockWrapper(depBlock, outputOptions, requestShortener, "require.ensure");
+		const errorCallbackExists = depBlock.expr.arguments.length === 4 || (!depBlock.chunkName && depBlock.expr.arguments.length === 3);
 		const startBlock = wrapper[0] + "(";
-		const endBlock = `).bind(null, __webpack_require__)${wrapper[1]}__webpack_require__.oe${wrapper[2]}`;
+		const middleBlock = `).bind(null, __webpack_require__)${wrapper[1]}`;
+		const endBlock = `${middleBlock}__webpack_require__.oe${wrapper[2]}`;
 		source.replace(depBlock.expr.range[0], depBlock.expr.arguments[1].range[0] - 1, startBlock);
-		source.replace(depBlock.expr.arguments[1].range[1], depBlock.expr.range[1] - 1, endBlock);
+		if(errorCallbackExists) {
+			source.replace(depBlock.expr.arguments[1].range[1], depBlock.expr.arguments[2].range[0] - 1, middleBlock);
+			source.replace(depBlock.expr.arguments[2].range[1], depBlock.expr.range[1] - 1, wrapper[2]);
+		} else {
+			source.replace(depBlock.expr.arguments[1].range[1], depBlock.expr.range[1] - 1, endBlock);
+		}
 	}
 };
 

--- a/test/cases/chunks/named-chunks/index.js
+++ b/test/cases/chunks/named-chunks/index.js
@@ -35,37 +35,37 @@ it("should handle empty named chunks", function(done) {
 });
 
 it("should handle named chunks when there is an error callback", function(done) {
-  var sync = false;
-  require.ensure([], function(require) {
-    require("./empty?a");
-    require("./empty?b");
-    testLoad();
-    sync = true;
-    process.nextTick(function() {
-      sync = false;
-    });
-  }, function(error) {}, "named-chunk");
-  function testLoad() {
-    require.ensure([], function(require) {
-      require("./empty?c");
-      require("./empty?d");
-      sync.should.be.ok();
-      done();
-    }, function(error) {}, "named-chunk");
-  }
+	var sync = false;
+	require.ensure([], function(require) {
+		require("./empty?e");
+		require("./empty?f");
+		testLoad();
+		sync = true;
+		process.nextTick(function() {
+			sync = false;
+		});
+	}, function(error) {}, "named-chunk-for-error-callback");
+	function testLoad() {
+		require.ensure([], function(require) {
+			require("./empty?g");
+			require("./empty?h");
+			sync.should.be.ok();
+			done();
+		}, function(error) {}, "named-chunk-for-error-callback");
+	}
 });
 
 it("should handle empty named chunks when there is an error callback", function(done) {
-  var sync = false;
-  require.ensure([], function(require) {
-    sync.should.be.ok();
-  }, function(error) {}, "empty-named-chunk");
-  require.ensure([], function(require) {
-    sync.should.be.ok();
-    done();
-  }, function(error) {}, "empty-named-chunk");
-  sync = true;
-  setImmediate(function() {
-    sync = false;
-  });
+	var sync = false;
+	require.ensure([], function(require) {
+		sync.should.be.ok();
+	}, function(error) {}, "empty-named-chunk-for-error-callback");
+	require.ensure([], function(require) {
+		sync.should.be.ok();
+		done();
+	}, function(error) {}, "empty-named-chunk-for-error-callback");
+	sync = true;
+	setImmediate(function() {
+		sync = false;
+	});
 });

--- a/test/cases/chunks/named-chunks/index.js
+++ b/test/cases/chunks/named-chunks/index.js
@@ -33,3 +33,39 @@ it("should handle empty named chunks", function(done) {
 		sync = false;
 	});
 });
+
+it("should handle named chunks when there is an error callback", function(done) {
+  var sync = false;
+  require.ensure([], function(require) {
+    require("./empty?a");
+    require("./empty?b");
+    testLoad();
+    sync = true;
+    process.nextTick(function() {
+      sync = false;
+    });
+  }, function(error) {}, "named-chunk");
+  function testLoad() {
+    require.ensure([], function(require) {
+      require("./empty?c");
+      require("./empty?d");
+      sync.should.be.ok();
+      done();
+    }, function(error) {}, "named-chunk");
+  }
+});
+
+it("should handle empty named chunks when there is an error callback", function(done) {
+  var sync = false;
+  require.ensure([], function(require) {
+    sync.should.be.ok();
+  }, function(error) {}, "empty-named-chunk");
+  require.ensure([], function(require) {
+    sync.should.be.ok();
+    done();
+  }, function(error) {}, "empty-named-chunk");
+  sync = true;
+  setImmediate(function() {
+    sync = false;
+  });
+});

--- a/test/cases/parsing/issue-758/errors.js
+++ b/test/cases/parsing/issue-758/errors.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[/Module not found/, /Can't resolve '\.\/missingModule' /]
+];

--- a/test/cases/parsing/issue-758/file.js
+++ b/test/cases/parsing/issue-758/file.js
@@ -1,0 +1,3 @@
+define(function() {
+	return "file";
+});

--- a/test/cases/parsing/issue-758/index.js
+++ b/test/cases/parsing/issue-758/index.js
@@ -33,7 +33,7 @@ it("should call error callback on exception thrown in loading module", function(
 });
 
 it("should not call error callback on exception thrown in require callback", function(done) {
-	require.esnure(['./throwing'], function() {
+	require.ensure(['./throwing'], function() {
 		throw new Error('message');
 	}, function(error) {
 		error.should.be.instanceOf(Error);

--- a/test/cases/parsing/issue-758/index.js
+++ b/test/cases/parsing/issue-758/index.js
@@ -1,0 +1,43 @@
+it("should require existing module with supplied error callback", function(done) {
+	require.ensure(['./file'], function(){
+		var file = require('.file');
+		file.should.be.eql("file");
+		done();
+	}, function(error) {});
+});
+
+it("should call error callback on missing module", function(done) {
+	require.ensure(['./missingModule'], function(){}, function(error) {
+		error.should.be.instanceOf(Error);
+		error.message.should.be.eql('Cannot find module "./missingModule"');
+		done();
+	});
+});
+
+it("should call error callback on missing module in context", function(done) {
+	(function(module) {
+		require.ensure(['./' + module], function(){}, function(error) {
+			error.should.be.instanceOf(Error);
+			error.message.should.be.eql("Cannot find module './missingModule'.");
+			done();
+		});
+	})('missingModule');
+});
+
+it("should call error callback on exception thrown in loading module", function(done) {
+	require.ensure(['./throwing'], function(){}, function(error) {
+		error.should.be.instanceOf(Error);
+		error.message.should.be.eql('message');
+		done();
+	});
+});
+
+it("should not call error callback on exception thrown in require callback", function(done) {
+	require.esnure(['./throwing'], function() {
+		throw new Error('message');
+	}, function(error) {
+		error.should.be.instanceOf(Error);
+		error.message.should.be.eql('message');
+		done();
+	});
+});

--- a/test/cases/parsing/issue-758/index.js
+++ b/test/cases/parsing/issue-758/index.js
@@ -48,3 +48,15 @@ it("should not call error callback on exception thrown in require callback", fun
 		done();
 	});
 });
+
+it("should call error callback when there is an error loading the chunk", function(done) {
+	var temp = __webpack_require__.e;
+	__webpack_require__.e = function() { return Promise.reject('fake chunk load error'); };
+	require.ensure(['./file'], function(){
+		var file = require('./file');
+	}, function(error) {
+		error.should.be.eql('fake chunk load error');
+		done();
+	});
+	__webpack_require__.e = temp;
+});

--- a/test/cases/parsing/issue-758/index.js
+++ b/test/cases/parsing/issue-758/index.js
@@ -1,13 +1,15 @@
 it("should require existing module with supplied error callback", function(done) {
 	require.ensure(['./file'], function(){
-		var file = require('.file');
+		var file = require('./file');
 		file.should.be.eql("file");
 		done();
 	}, function(error) {});
 });
 
 it("should call error callback on missing module", function(done) {
-	require.ensure(['./missingModule'], function(){}, function(error) {
+	require.ensure(['./missingModule'], function(){
+		require('./missingModule');
+	}, function(error) {
 		error.should.be.instanceOf(Error);
 		error.message.should.be.eql('Cannot find module "./missingModule"');
 		done();
@@ -16,7 +18,9 @@ it("should call error callback on missing module", function(done) {
 
 it("should call error callback on missing module in context", function(done) {
 	(function(module) {
-		require.ensure(['./' + module], function(){}, function(error) {
+		require.ensure([], function(){
+			require('./' + module);
+		}, function(error) {
 			error.should.be.instanceOf(Error);
 			error.message.should.be.eql("Cannot find module './missingModule'.");
 			done();
@@ -25,7 +29,9 @@ it("should call error callback on missing module in context", function(done) {
 });
 
 it("should call error callback on exception thrown in loading module", function(done) {
-	require.ensure(['./throwing'], function(){}, function(error) {
+	require.ensure(['./throwing'], function(){
+		require('./throwing');
+	}, function(error) {
 		error.should.be.instanceOf(Error);
 		error.message.should.be.eql('message');
 		done();
@@ -34,6 +40,7 @@ it("should call error callback on exception thrown in loading module", function(
 
 it("should not call error callback on exception thrown in require callback", function(done) {
 	require.ensure(['./throwing'], function() {
+    require('./throwing');
 		throw new Error('message');
 	}, function(error) {
 		error.should.be.instanceOf(Error);

--- a/test/cases/parsing/issue-758/throwing.js
+++ b/test/cases/parsing/issue-758/throwing.js
@@ -1,0 +1,3 @@
+define(function() {
+	throw new Error('message');
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Fixes https://github.com/webpack/webpack/issues/758 by adding support for an error handling callback to require.ensure

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes, tests added in `test/cases/parsing/issue-758`

These were borrowed/adapted from https://github.com/webpack/webpack/pull/3247.

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

System.import already supports error callbacks, but require.ensure is still useful for a couple of reasons:

1) Supports chunk naming (https://github.com/webpack/webpack/issues/3132)
2) Supports recursive code splitting (https://github.com/webpack/webpack/issues/3364#issuecomment-273983958)

<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No. require.ensure still supports chunk naming with the old 3 argument style.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
