### PR TITLE
Generate ident if non existant to make loader migrations easier

### DIFF
--- a/lib/RuleSet.js
+++ b/lib/RuleSet.js
@@ -436,12 +436,20 @@ RuleSet.prototype.findOptionsByIdent = function findOptionsByIdent(ident) {
 };
 
 RuleSet.generateIdent = function(item) {
-	const stringifiedItem = JSON.stringify(item, (_, val) => {
-		if(typeof val !== "function") {
-			return val;
+	const circularCheck = new Set();
+	const stringifiedItem = JSON.stringify(item, (key, val) => {
+		switch(typeof val) {
+			case "function":
+				// make sure we stringify functions to make it less likely they can collide
+				return val.toString();
+			case "object":
+				if(val === null) return null;
+				if(circularCheck.has(val)) return "(circular)";
+				circularCheck.add(val);
+				return val;
+			default:
+				return val;
 		}
-		// make sure we stringify functions to make it less likely they can collide
-		return val.toString();
 	});
 	return crypto.createHash("md5").update(stringifiedItem).digest("base64");
 };

--- a/lib/RuleSet.js
+++ b/lib/RuleSet.js
@@ -269,7 +269,7 @@ RuleSet.normalizeUseItem = function normalizeUseItem(item) {
 
 	// make sure to set an ident to make life easer for consumers
 	if(newItem.options && typeof newItem.options !== "string") {
-		newItem.options.ident = newItem.options.ident || generateIdent(item);
+		newItem.options.ident = newItem.options.ident || RuleSet.generateIdent(item);
 	}
 
 	var keys = Object.keys(item).filter(function(key) {
@@ -435,6 +435,13 @@ RuleSet.prototype.findOptionsByIdent = function findOptionsByIdent(ident) {
 	return options;
 };
 
-function generateIdent(item) {
-	return crypto.createHash("md5").update(JSON.stringify(item)).digest("base64");
-}
+RuleSet.generateIdent = function(item) {
+	const stringifiedItem = JSON.stringify(item, (_, val) => {
+		if(typeof val !== "function") {
+			return val;
+		}
+		// make sure we stringify functions to make it less likely they can collide
+		return val.toString();
+	});
+	return crypto.createHash("md5").update(stringifiedItem).digest("base64");
+};

--- a/lib/RuleSet.js
+++ b/lib/RuleSet.js
@@ -438,11 +438,13 @@ RuleSet.prototype.findOptionsByIdent = function findOptionsByIdent(ident) {
 RuleSet.generateIdent = function(item) {
 	const circularCheck = new Set();
 	const stringifiedItem = JSON.stringify(item, (key, val) => {
-		switch(typeof val) {
-			case "function":
+		switch(true) {
+			case typeof val === "function":
 				// make sure we stringify functions to make it less likely they can collide
 				return val.toString();
-			case "object":
+			case val instanceof RegExp:
+				return val.toString();
+			case typeof val === "object":
 				if(val === null) return null;
 				if(circularCheck.has(val)) return "(circular)";
 				circularCheck.add(val);

--- a/lib/RuleSet.js
+++ b/lib/RuleSet.js
@@ -69,6 +69,8 @@ normalized:
 }
 
 */
+"use strict";
+const crypto = require("crypto");
 
 function RuleSet(rules) {
 	this.references = {};
@@ -265,6 +267,11 @@ RuleSet.normalizeUseItem = function normalizeUseItem(item) {
 
 	newItem.options = item.options || item.query;
 
+	// make sure to set an ident to make life easer for consumers
+	if(newItem.options && typeof newItem.options !== "string") {
+		newItem.options.ident = newItem.options.ident || generateIdent(item);
+	}
+
 	var keys = Object.keys(item).filter(function(key) {
 		return ["options", "query"].indexOf(key) < 0;
 	});
@@ -427,3 +434,7 @@ RuleSet.prototype.findOptionsByIdent = function findOptionsByIdent(ident) {
 	if(!options) throw new Error("Can't find options with ident '" + ident + "'");
 	return options;
 };
+
+function generateIdent(item) {
+	return crypto.createHash("md5").update(JSON.stringify(item)).digest("base64");
+}

--- a/test/RuleSet.test.js
+++ b/test/RuleSet.test.js
@@ -190,7 +190,7 @@ describe("RuleSet", function() {
 				modules: 1
 			}
 		}]);
-		(match(loader, 'style.css')).should.eql(['css?{"modules":1}']);
+		(match(loader, 'style.css')).should.eql(['css?{"modules":1,"ident":"96REMT1/c781rQG9U9d6fQ=="}']);
 	});
 	it('should work with using array loaders with basic object notation', function() {
 		var loader = new RuleSet([{

--- a/test/RuleSet.test.js
+++ b/test/RuleSet.test.js
@@ -1,5 +1,7 @@
+/* globals describe, it, beforeEach */
+"use strict";
+
 var should = require("should");
-/* globals describe, it */
 var RuleSet = require("../lib/RuleSet");
 
 function match(ruleSet, resource) {
@@ -376,6 +378,43 @@ describe("RuleSet", function() {
 				}]);
 				(match(loader, "style.css")).should.eql(["css"]);
 			}, errorHasContext);
+		});
+	});
+	describe("RuleSet::generateIdent", function() {
+		let useA;
+		beforeEach(function() {
+			useA = {
+				loader: "./loader2",
+				options: {
+					f: function() {
+						return "ok";
+					}
+				}
+			};
+		});
+		it("generates an md5-hash based id for a given loader item", () => {
+			RuleSet.generateIdent(useA).should.be.type("string");
+			RuleSet.generateIdent(useA).should.eql("VaITzDUqemZHRi89ZhYxhA==");
+		});
+		describe("given different use items", () => {
+			let useB;
+			beforeEach(function() {
+				useB = {
+					loader: "./loader2",
+					options: {
+						f: function() {
+							return "not ok";
+						}
+					}
+				};
+			});
+			it("generates always the same ident for the same object given", () => {
+				RuleSet.generateIdent(useA).should.eql(RuleSet.generateIdent(useA));
+				RuleSet.generateIdent(useB).should.eql(RuleSet.generateIdent(useB));
+			});
+			it("generates different idents for different use items", () => {
+				RuleSet.generateIdent(useB).should.not.eql(RuleSet.generateIdent(useA));
+			});
 		});
 	});
 });

--- a/test/RuleSet.test.js
+++ b/test/RuleSet.test.js
@@ -1,5 +1,5 @@
 var should = require("should");
-
+/* globals describe, it */
 var RuleSet = require("../lib/RuleSet");
 
 function match(ruleSet, resource) {
@@ -17,146 +17,146 @@ function match(ruleSet, resource) {
 			return r.loader + "?" + r.options;
 		return r.loader + "?" + JSON.stringify(r.options);
 	});
-};
+}
 
 describe("RuleSet", function() {
-	it('should create RuleSet with a blank array', function() {
+	it("should create RuleSet with a blank array", function() {
 		var loader = new RuleSet([]);
 		(loader.rules).should.eql([]);
 	});
-	it('should create RuleSet and match with empty array', function() {
+	it("should create RuleSet and match with empty array", function() {
 		var loader = new RuleSet([]);
-		(match(loader, 'something')).should.eql([]);
+		(match(loader, "something")).should.eql([]);
 	});
-	it('should not match with loaders array', function() {
+	it("should not match with loaders array", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
-			loader: 'css'
+			loader: "css"
 		}]);
-		(match(loader, 'something')).should.eql([]);
+		(match(loader, "something")).should.eql([]);
 	});
-	it('should match with regex', function() {
+	it("should match with regex", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
-			loader: 'css'
+			loader: "css"
 		}]);
-		(match(loader, 'style.css')).should.eql(['css']);
+		(match(loader, "style.css")).should.eql(["css"]);
 	});
-	it('should match with string', function() {
+	it("should match with string", function() {
 		var loader = new RuleSet([{
-			test: 'style.css',
-			loader: 'css'
+			test: "style.css",
+			loader: "css"
 		}]);
-		(match(loader, 'style.css')).should.eql(['css']);
+		(match(loader, "style.css")).should.eql(["css"]);
 	});
-	it('should match with function', function() {
+	it("should match with function", function() {
 		var loader = new RuleSet([{
 			test: function(str) {
-				return str === 'style.css';
+				return str === "style.css";
 			},
-			loader: 'css'
+			loader: "css"
 		}]);
-		(match(loader, 'style.css')).should.eql(['css']);
+		(match(loader, "style.css")).should.eql(["css"]);
 	});
-	it('should throw if invalid test', function() {
+	it("should throw if invalid test", function() {
 		should.throws(function() {
 			var loader = new RuleSet([{
 				test: {
-					invalid: 'test'
+					invalid: "test"
 				},
-				loader: 'css'
+				loader: "css"
 			}]);
-			(match(loader, 'style.css')).should.eql(['css']);
+			(match(loader, "style.css")).should.eql(["css"]);
 		}, /Unexcepted property invalid in condition/);
 	});
-	it('should accept multiple test array that all match', function() {
+	it("should accept multiple test array that all match", function() {
 		var loader = new RuleSet([{
 			test: [
 				/style.css/,
 				/yle.css/
 			],
-			loader: 'css'
+			loader: "css"
 		}]);
-		(match(loader, 'style.css')).should.eql(['css']);
+		(match(loader, "style.css")).should.eql(["css"]);
 	});
-	it('should accept multiple test array that not all match', function() {
+	it("should accept multiple test array that not all match", function() {
 		var loader = new RuleSet([{
 			test: [
 				/style.css/,
 				/something.css/
 			],
-			loader: 'css'
+			loader: "css"
 		}]);
-		(match(loader, 'style.css')).should.eql(['css']);
+		(match(loader, "style.css")).should.eql(["css"]);
 	});
-	it('should not match if include does not match', function() {
+	it("should not match if include does not match", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
 			include: /output.css/,
-			loader: 'css'
+			loader: "css"
 		}]);
-		(match(loader, 'style.css')).should.eql([]);
+		(match(loader, "style.css")).should.eql([]);
 	});
-	it('should match if include matches', function() {
+	it("should match if include matches", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
 			include: /style.css/,
-			loader: 'css'
+			loader: "css"
 		}]);
-		(match(loader, 'style.css')).should.eql(['css']);
+		(match(loader, "style.css")).should.eql(["css"]);
 	});
-	it('should not match if exclude matches', function() {
+	it("should not match if exclude matches", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
 			exclude: /style.css/,
-			loader: 'css'
+			loader: "css"
 		}]);
-		(match(loader, 'style.css')).should.eql([]);
+		(match(loader, "style.css")).should.eql([]);
 	});
-	it('should match if exclude does not match', function() {
+	it("should match if exclude does not match", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
 			exclude: /output.css/,
-			loader: 'css'
+			loader: "css"
 		}]);
-		(match(loader, 'style.css')).should.eql(['css']);
+		(match(loader, "style.css")).should.eql(["css"]);
 	});
-	it('should work if a loader is applied to all files', function() {
+	it("should work if a loader is applied to all files", function() {
 		var loader = new RuleSet([{
-			loader: 'css'
+			loader: "css"
 		}]);
-		(match(loader, 'style.css')).should.eql(['css']);
-		(match(loader, 'scripts.js')).should.eql(['css']);
+		(match(loader, "style.css")).should.eql(["css"]);
+		(match(loader, "scripts.js")).should.eql(["css"]);
 	});
-	it('should work with using loader as string', function() {
-		var loader = new RuleSet([{
-			test: /\.css$/,
-			loader: 'css'
-		}]);
-		(match(loader, 'style.css')).should.eql(['css']);
-	});
-	it('should work with using loader as array', function() {
+	it("should work with using loader as string", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
-			loader: ['css']
+			loader: "css"
 		}]);
-		(match(loader, 'style.css')).should.eql(['css']);
+		(match(loader, "style.css")).should.eql(["css"]);
 	});
-	it('should work with using loaders as string', function() {
+	it("should work with using loader as array", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
-			loaders: 'css'
+			loader: ["css"]
 		}]);
-		(match(loader, 'style.css')).should.eql(['css']);
+		(match(loader, "style.css")).should.eql(["css"]);
 	});
-	it('should work with using loaders as array', function() {
+	it("should work with using loaders as string", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
-			loaders: ['css']
+			loaders: "css"
 		}]);
-		(match(loader, 'style.css')).should.eql(['css']);
+		(match(loader, "style.css")).should.eql(["css"]);
 	});
-	it('should throw if using loaders with non-string or array', function() {
+	it("should work with using loaders as array", function() {
+		var loader = new RuleSet([{
+			test: /\.css$/,
+			loaders: ["css"]
+		}]);
+		(match(loader, "style.css")).should.eql(["css"]);
+	});
+	it("should throw if using loaders with non-string or array", function() {
 		should.throws(function() {
 			var loader = new RuleSet([{
 				test: /\.css$/,
@@ -164,44 +164,44 @@ describe("RuleSet", function() {
 					someObj: true
 				}
 			}]);
-			(match(loader, 'style.css')).should.eql(['css']);
-		}, /No loader specified/)
+			(match(loader, "style.css")).should.eql(["css"]);
+		}, /No loader specified/);
 	});
-	it('should work with using loader with inline query', function() {
+	it("should work with using loader with inline query", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
-			loader: 'css?modules=1'
+			loader: "css?modules=1"
 		}]);
-		(match(loader, 'style.css')).should.eql(['css?modules=1']);
+		(match(loader, "style.css")).should.eql(["css?modules=1"]);
 	});
-	it('should work with using loader with string query', function() {
+	it("should work with using loader with string query", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
-			loader: 'css',
-			query: 'modules=1'
+			loader: "css",
+			query: "modules=1"
 		}]);
-		(match(loader, 'style.css')).should.eql(['css?modules=1']);
+		(match(loader, "style.css")).should.eql(["css?modules=1"]);
 	});
-	it('should work with using loader with object query', function() {
+	it("should work with using loader with object query", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
-			loader: 'css',
+			loader: "css",
 			query: {
 				modules: 1
 			}
 		}]);
-		(match(loader, 'style.css')).should.eql(['css?{"modules":1,"ident":"96REMT1/c781rQG9U9d6fQ=="}']);
+		(match(loader, "style.css")).should.eql(["css?{\"modules\":1,\"ident\":\"96REMT1/c781rQG9U9d6fQ==\"}"]);
 	});
-	it('should work with using array loaders with basic object notation', function() {
+	it("should work with using array loaders with basic object notation", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
 			loaders: [{
-				loader: 'css'
+				loader: "css"
 			}]
 		}]);
-		(match(loader, 'style.css')).should.eql(['css']);
+		(match(loader, "style.css")).should.eql(["css"]);
 	});
-	it('should throw if using array loaders with object notation without specifying a loader', function() {
+	it("should throw if using array loaders with object notation without specifying a loader", function() {
 		should.throws(function() {
 			var loader = new RuleSet([{
 				test: /\.css$/,
@@ -209,114 +209,114 @@ describe("RuleSet", function() {
 					stuff: 1
 				}]
 			}]);
-			match(loader, 'style.css');
-		}, /No loader specified/)
+			match(loader, "style.css");
+		}, /No loader specified/);
 	});
-	it('should work with using array loaders with object notation', function() {
+	it("should work with using array loaders with object notation", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
 			loaders: [{
-				loader: 'css',
-				query: 'modules=1'
+				loader: "css",
+				query: "modules=1"
 			}]
 		}]);
-		(match(loader, 'style.css')).should.eql(['css?modules=1']);
+		(match(loader, "style.css")).should.eql(["css?modules=1"]);
 	});
-	it('should work with using multiple array loaders with object notation', function() {
+	it("should work with using multiple array loaders with object notation", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
 			loaders: [{
-				loader: 'style',
-				query: 'filesize=1000'
+				loader: "style",
+				query: "filesize=1000"
 			}, {
-				loader: 'css',
-				query: 'modules=1'
+				loader: "css",
+				query: "modules=1"
 			}]
 		}]);
-		(match(loader, 'style.css')).should.eql(['style?filesize=1000', 'css?modules=1']);
+		(match(loader, "style.css")).should.eql(["style?filesize=1000", "css?modules=1"]);
 	});
-	it('should work with using string multiple loaders', function() {
+	it("should work with using string multiple loaders", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
-			loaders: 'style?filesize=1000!css?modules=1'
+			loaders: "style?filesize=1000!css?modules=1"
 		}]);
-		(match(loader, 'style.css')).should.eql(['style?filesize=1000', 'css?modules=1']);
+		(match(loader, "style.css")).should.eql(["style?filesize=1000", "css?modules=1"]);
 	});
-	it('should throw if using array loaders with a single legacy', function() {
+	it("should throw if using array loaders with a single legacy", function() {
 		should.throws(function() {
 			var loader = new RuleSet([{
 				test: /\.css$/,
-				loaders: ['style-loader', 'css-loader'],
-				query: 'modules=1'
+				loaders: ["style-loader", "css-loader"],
+				query: "modules=1"
 			}]);
-			(match(loader, 'style.css')).should.eql(['css']);
-		}, /options\/query cannot be used with loaders/)
+			(match(loader, "style.css")).should.eql(["css"]);
+		}, /options\/query cannot be used with loaders/);
 	});
-	it('should work when using array loaders', function() {
+	it("should work when using array loaders", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
-			loaders: ['style-loader', 'css-loader']
+			loaders: ["style-loader", "css-loader"]
 		}]);
-		(match(loader, 'style.css')).should.eql(['style-loader', 'css-loader']);
+		(match(loader, "style.css")).should.eql(["style-loader", "css-loader"]);
 	});
-	it('should work when using an array of functions returning a loader', function() {
+	it("should work when using an array of functions returning a loader", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
 			use: [
 				function(data) {
 					return {
-						loader: 'style-loader'
-					}
+						loader: "style-loader"
+					};
 				},
 				function(data) {
 					return {
-						loader: 'css-loader'
-					}
+						loader: "css-loader"
+					};
 				},
 			]
 		}]);
-		(match(loader, 'style.css')).should.eql(['style-loader', 'css-loader']);
+		(match(loader, "style.css")).should.eql(["style-loader", "css-loader"]);
 	});
-	it('should work when using an array of either functions or strings returning a loader', function() {
+	it("should work when using an array of either functions or strings returning a loader", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
 			use: [
 				"style-loader",
 				function(data) {
 					return {
-						loader: 'css-loader'
-					}
+						loader: "css-loader"
+					};
 				},
 			]
 		}]);
-		(match(loader, 'style.css')).should.eql(['style-loader', 'css-loader']);
+		(match(loader, "style.css")).should.eql(["style-loader", "css-loader"]);
 	});
-	it('should work when using an array of functions returning either a loader obejct or loader name string', function() {
+	it("should work when using an array of functions returning either a loader obejct or loader name string", function() {
 		var loader = new RuleSet([{
 			test: /\.css$/,
 			use: [
 				function(data) {
-					return 'style-loader'
+					return "style-loader";
 				},
 				function(data) {
 					return {
-						loader: 'css-loader'
-					}
+						loader: "css-loader"
+					};
 				},
 			]
 		}]);
-		(match(loader, 'style.css')).should.eql(['style-loader', 'css-loader']);
+		(match(loader, "style.css")).should.eql(["style-loader", "css-loader"]);
 	});
-	it('should throw if using array loaders with invalid type', function() {
+	it("should throw if using array loaders with invalid type", function() {
 		should.throws(function() {
 			var loader = new RuleSet([{
 				test: /\.css$/,
-				loaders: ['style-loader', 'css-loader', 5],
+				loaders: ["style-loader", "css-loader", 5],
 			}]);
-			(match(loader, 'style.css')).should.eql(['css']);
-		}, /No loader specified/)
+			(match(loader, "style.css")).should.eql(["css"]);
+		}, /No loader specified/);
 	});
-	describe('when exclude array holds an undefined item', function() {
+	describe("when exclude array holds an undefined item", function() {
 		function errorHasContext(err) {
 			if(/Expected condition but got falsy value/.test(err) &&
 				/test/.test(err) &&
@@ -327,55 +327,55 @@ describe("RuleSet", function() {
 				return true;
 			}
 		}
-		it('should throw with context', function() {
+		it("should throw with context", function() {
 			should.throws(function() {
 				var loader = new RuleSet([{
 					test: /\.css$/,
-					loader: 'css',
+					loader: "css",
 					include: [
-						'src',
+						"src",
 					],
 					exclude: [
-						'node_modules',
+						"node_modules",
 						undefined,
 					],
 				}]);
-				(match(loader, 'style.css')).should.eql(['css']);
-			}, errorHasContext)
+				(match(loader, "style.css")).should.eql(["css"]);
+			}, errorHasContext);
 		});
-		it('in resource should throw with context', function() {
+		it("in resource should throw with context", function() {
 			should.throws(function() {
 				var loader = new RuleSet([{
 					resource: {
 						test: /\.css$/,
 						include: [
-							'src',
+							"src",
 						],
 						exclude: [
-							'node_modules',
+							"node_modules",
 							undefined,
 						],
 					},
 				}]);
-				(match(loader, 'style.css')).should.eql(['css']);
-			}, errorHasContext)
+				(match(loader, "style.css")).should.eql(["css"]);
+			}, errorHasContext);
 		});
-		it('in issuer should throw with context', function() {
+		it("in issuer should throw with context", function() {
 			should.throws(function() {
 				var loader = new RuleSet([{
 					issuer: {
 						test: /\.css$/,
 						include: [
-							'src',
+							"src",
 						],
 						exclude: [
-							'node_modules',
+							"node_modules",
 							undefined,
 						],
 					},
 				}]);
-				(match(loader, 'style.css')).should.eql(['css']);
-			}, errorHasContext)
+				(match(loader, "style.css")).should.eql(["css"]);
+			}, errorHasContext);
 		});
 	});
 });

--- a/test/RuleSet.test.js
+++ b/test/RuleSet.test.js
@@ -416,5 +416,21 @@ describe("RuleSet", function() {
 				RuleSet.generateIdent(useB).should.not.eql(RuleSet.generateIdent(useA));
 			});
 		});
+		describe("given an item with circular reference", () => {
+			let useC;
+			beforeEach(function() {
+				let a = {};
+				let b = {};
+				a.b = b;
+				b.a = a;
+				useC = {
+					a: a,
+					b: b,
+				};
+			});
+			it("handle circular references gracefully", () => {
+				RuleSet.generateIdent(useC).should.be.type("string");
+			});
+		});
 	});
 });

--- a/test/RuleSet.test.js
+++ b/test/RuleSet.test.js
@@ -384,6 +384,7 @@ describe("RuleSet", function() {
 		let useA;
 		beforeEach(function() {
 			useA = {
+				test: /some-regex/,
 				loader: "./loader2",
 				options: {
 					f: function() {
@@ -394,26 +395,44 @@ describe("RuleSet", function() {
 		});
 		it("generates an md5-hash based id for a given loader item", () => {
 			RuleSet.generateIdent(useA).should.be.type("string");
-			RuleSet.generateIdent(useA).should.eql("VaITzDUqemZHRi89ZhYxhA==");
+			RuleSet.generateIdent(useA).should.eql("7GgMweKMhCG7otxcesj12g==");
 		});
 		describe("given different use items", () => {
-			let useB;
+			let items;
 			beforeEach(function() {
-				useB = {
-					loader: "./loader2",
-					options: {
-						f: function() {
-							return "not ok";
-						}
-					}
+				const regexA = /some-regex-a/;
+				const regexB = /some-regex-b/;
+				const fnA = () => "a";
+				const fnB = () => "b";
+				const useA = {
+					regexA: regexA,
+					fnA: fnA,
 				};
+				const useB = {
+					regexA: regexB,
+					fnA: fnA,
+				};
+				const useC = {
+					regexA: regexA,
+					fnA: fnB,
+				};
+				const useD = {
+					regexA: regexB,
+					fnA: fnB,
+				};
+				items = [useA, useB, useC, useD];
 			});
 			it("generates always the same ident for the same object given", () => {
-				RuleSet.generateIdent(useA).should.eql(RuleSet.generateIdent(useA));
-				RuleSet.generateIdent(useB).should.eql(RuleSet.generateIdent(useB));
+				items.forEach(item => RuleSet.generateIdent(item).should.eql(RuleSet.generateIdent(item)));
 			});
 			it("generates different idents for different use items", () => {
-				RuleSet.generateIdent(useB).should.not.eql(RuleSet.generateIdent(useA));
+				items.forEach(itemA => {
+					items.forEach(itemB => {
+						if(itemA !== itemB) {
+							RuleSet.generateIdent(itemA).should.not.eql(RuleSet.generateIdent(itemB));
+						}
+					});
+				});
 			});
 		});
 		describe("given an item with circular reference", () => {

--- a/test/configCases/loaders/generate-ident/index.js
+++ b/test/configCases/loaders/generate-ident/index.js
@@ -1,0 +1,3 @@
+it("should correctly pass complex query object with remaining request", function() {
+	require("./a").should.be.eql("ok");
+});

--- a/test/configCases/loaders/generate-ident/loader1.js
+++ b/test/configCases/loaders/generate-ident/loader1.js
@@ -1,0 +1,3 @@
+module.exports.pitch = function(remainingRequest) {
+	return "module.exports = require(" + JSON.stringify("!!" + remainingRequest) + ");";
+};

--- a/test/configCases/loaders/generate-ident/loader2.js
+++ b/test/configCases/loaders/generate-ident/loader2.js
@@ -1,0 +1,3 @@
+module.exports = function(source) {
+	return "module.exports = " + JSON.stringify(this.query.f());
+};

--- a/test/configCases/loaders/generate-ident/webpack.config.js
+++ b/test/configCases/loaders/generate-ident/webpack.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /a\.js$/,
+				use: [
+					"./loader1",
+					{
+						loader: "./loader2",
+						options: {
+							f: function() {
+								return "ok";
+							}
+						}
+					}
+				]
+			}
+		]
+	}
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

Yes

**If relevant, link to documentation update:**

N/A

**Summary**

As loader/plugin options as part of the webpack config are only
allowed as part of the options a lot of people forget to add an "ident"
when they migrate their loaders. This ident is requried as the options
get stringified along the way and therefore a "behind the back" lookup is
made with the ident to retrieve non stringifiable data.
This should be done automagically though and not left for the user unless
they want to specify an "ident" (imho).

this pr should fix issues that are currently arrising in css-loaders et all.

**Does this PR introduce a breaking change?**

No

**Other Information**

some related issues
https://github.com/webpack/extract-text-webpack-plugin/issues/296
https://github.com/webpack/css-loader/issues/389
