### PR TITLE
fix: remove unreasonable comparelocation logic and update test cases

### DIFF
--- a/lib/compareLocations.js
+++ b/lib/compareLocations.js
@@ -2,6 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+"use strict";
 module.exports = function compareLocations(a, b) {
 	if(typeof a === "string") {
 		if(typeof b === "string") {
@@ -17,14 +18,14 @@ module.exports = function compareLocations(a, b) {
 		if(typeof b === "string") {
 			return -1;
 		} else if(typeof b === "object") {
-			var aa = a.start ? a.start : a;
-			var bb = b.start ? b.start : b;
-			if(aa.line < bb.line) return -1;
-			if(aa.line > bb.line) return 1;
-			if(aa.column < bb.column) return -1;
-			if(aa.column > bb.column) return 1;
-			if(aa.index < bb.index) return -1;
-			if(aa.index > bb.index) return 1;
+			if(a.start && b.start) {
+				const ap = a.start;
+				const bp = b.start;
+				if(ap.line < bp.line) return -1;
+				if(ap.line > bp.line) return 1;
+				if(ap.column < bp.column) return -1;
+				if(ap.column > bp.column) return 1;
+			}
 			if(a.index < b.index) return -1;
 			if(a.index > b.index) return 1;
 			return 0;

--- a/test/compareLocations.test.js
+++ b/test/compareLocations.test.js
@@ -2,12 +2,19 @@
 
 const should = require("should");
 const compareLocations = require("../lib/compareLocations");
-const createLocation = function(overides) {
+const createPosition = function(overides) {
 	return Object.assign({
 		line: 10,
-		column: 5,
-		index: 3
+		column: 5
 	}, overides);
+};
+
+const createLocation = function(start, end, index) {
+	return {
+		start: createPosition(start),
+		end: createPosition(end),
+		index: index || 3
+	};
 };
 
 describe("compareLocations", () => {
@@ -35,8 +42,9 @@ describe("compareLocations", () => {
 				});
 			});
 
-			it("returns -1 when the first location line number comes before the second location line number", () =>
-				compareLocations(a, b).should.be.exactly(-1));
+			it("returns -1 when the first location line number comes before the second location line number", () => {
+				return compareLocations(a, b).should.be.exactly(-1)
+			});
 
 			it("returns 1 when the first location line number comes after the second location line number", () =>
 				compareLocations(b, a).should.be.exactly(1));
@@ -61,12 +69,8 @@ describe("compareLocations", () => {
 
 		describe("location index number", () => {
 			beforeEach(() => {
-				a = createLocation({
-					index: 10
-				});
-				b = createLocation({
-					index: 20
-				});
+				a = createLocation(null, null, 10);
+				b = createLocation(null, null, 20);
 			});
 
 			it("returns -1 when the first location index number comes before the second location index number", () =>
@@ -85,27 +89,6 @@ describe("compareLocations", () => {
 			it("returns 0", () => {
 				compareLocations(a, b).should.be.exactly(0);
 			});
-		});
-
-		describe("start location set", () => {
-			beforeEach(() => {
-				a = {
-					start: createLocation({
-						line: 10
-					})
-				};
-				b = {
-					start: createLocation({
-						line: 20
-					})
-				};
-			});
-
-			it("returns -1 when the first location line number comes before the second location line number", () =>
-				compareLocations(a, b).should.be.exactly(-1));
-
-			it("returns 1 when the first location line number comes after the second location line number", () =>
-				compareLocations(b, a).should.be.exactly(1));
 		});
 	});
 


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactor/fix

**Did you add tests for your changes?**

yes, adjusted

**If relevant, link to documentation update:**

N/A

**Summary**

What the `compareLocations` function compares are `SourceLocation` objects
or strings(based on current usage). There is no case to assume the input
are position objects. Therefore, remove the useless and unreasonable
code.

Relatively, update the tests to indicate the actual usage.

**Does this PR introduce a breaking change?**
Not in this repo/on Github. (Not sure if someone misuse it somewhere else)
