### PR TITLE
Fix issue #3612

### DIFF
--- a/lib/LoaderOptionsPlugin.js
+++ b/lib/LoaderOptionsPlugin.js
@@ -26,7 +26,13 @@ class LoaderOptionsPlugin {
 				if(ModuleFilenameHelpers.matchObject(options, i < 0 ? resource : resource.substr(0, i))) {
 					Object.keys(options)
 						.filter((key) => !filterSet.has(key))
-						.forEach((key) => Object.assign(context[key], options[key]));
+						.forEach((key) => {
+							if(context[key]) {
+								Object.assign(context[key], options[key]);
+							} else {
+								context[key] = options[key];
+							}
+						});
 				}
 			});
 		});

--- a/lib/LoaderOptionsPlugin.js
+++ b/lib/LoaderOptionsPlugin.js
@@ -16,17 +16,17 @@ class LoaderOptionsPlugin {
 	}
 
 	apply(compiler) {
-		let options = this.options;
+		const options = this.options;
+		const filterSet = new Set(["include", "exclude", "test"]);
 		compiler.plugin("compilation", (compilation) => {
 			compilation.plugin("normal-module-loader", (context, module) => {
-				let resource = module.resource;
+				const resource = module.resource;
 				if(!resource) return;
-				let i = resource.indexOf("?");
+				const i = resource.indexOf("?");
 				if(ModuleFilenameHelpers.matchObject(options, i < 0 ? resource : resource.substr(0, i))) {
-					let filterSet = new Set(["include", "exclude", "test"]);
 					Object.keys(options)
 						.filter((key) => !filterSet.has(key))
-						.forEach((key) => context[key] = options[key]);
+						.forEach((key) => Object.assign(context[key], options[key]));
 				}
 			});
 		});

--- a/test/configCases/plugins/issue-3612-LoaderOptionPlugin/index.js
+++ b/test/configCases/plugins/issue-3612-LoaderOptionPlugin/index.js
@@ -1,0 +1,5 @@
+it("should append style from LoaderOptionsPlugin and compile css", function() {
+	const css = require("./test.css").toString();
+
+	css.should.containEql("body { display: flex;}");
+});

--- a/test/configCases/plugins/issue-3612-LoaderOptionPlugin/node_modules/any-loader.js
+++ b/test/configCases/plugins/issue-3612-LoaderOptionPlugin/node_modules/any-loader.js
@@ -1,0 +1,3 @@
+module.exports = function(source) {
+	return source + "\n" + this.options.any;
+};

--- a/test/configCases/plugins/issue-3612-LoaderOptionPlugin/test.css
+++ b/test/configCases/plugins/issue-3612-LoaderOptionPlugin/test.css
@@ -1,0 +1,4 @@
+html, body {
+	height: 100%;
+	overflow: hidden;
+}

--- a/test/configCases/plugins/issue-3612-LoaderOptionPlugin/webpack.config.js
+++ b/test/configCases/plugins/issue-3612-LoaderOptionPlugin/webpack.config.js
@@ -1,0 +1,19 @@
+const webpack = require('webpack');
+
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				loaders: ["css-loader", "any-loader"]
+			}
+		]
+	},
+	plugins: [
+		new webpack.LoaderOptionsPlugin({
+			options: {
+				any: "body { display: flex;}"
+			}
+		})
+	],
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

Yes

**If relevant, link to documentation update:**

 N/A

**Summary**

There is a `options` property of `LoaderContext`. If user passes an object with `options` to `LoaderOptionsPlugin`, `options` will be override previously. Now ensure no more overriding.


**Does this PR introduce a breaking change?**

No
