### PR TITLE
fix: Pitch loaders are now considered when exporting DLL lib manifests

### DIFF
--- a/lib/LibManifestPlugin.js
+++ b/lib/LibManifestPlugin.js
@@ -32,7 +32,7 @@ LibManifestPlugin.prototype.apply = function(compiler) {
 						var ident = module.libIdent({
 							context: this.options.context || compiler.options.context
 						});
-						if(ident) {
+						if(ident && !obj[ident]) {
 							obj[ident] = {
 								id: module.id,
 								meta: module.meta,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
N/A
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
The issue is a bit esoteric -- when we used pitch loaders to create a DLL bundle, the generated `manifest.json` ignored the results of those loaders and linked directly to the original libs. This effectively made the pitch loaders useless for our use case (and presumably will also cause some headache when users try to use something like the [expose-loader](https://github.com/webpack/expose-loader) in a DLL bundle).

After some stumbling around, I've managed to figure out that this is due to the fact that a pitch loader will internally generate a module with the same identifier (`module.libIdent` result) as the original library. Since that module will also be inserted at the start of the `modules` array, it will be overwritten by the original library when it is added to the manifest `obj`.

The fix I've figured out for this is to avoid adding entries to the manifest object when the key already exists. However, I fully admit I'm oblivious to some of the implications that this change might have -- you may be dependent on this behavior on some obscure cases; I'm not entirely sure this will work when chaining multiple pitch loaders; the `meta` and `exports` properties of the original library will be lost if they are not passed on the the pitch loader, which might break something as well.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No (...maybe?)
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
