### PR TITLE
UglifyJsPlugin: extract comments to separate file

### DIFF
--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -7,6 +7,7 @@
 const SourceMapConsumer = require("source-map").SourceMapConsumer;
 const SourceMapSource = require("webpack-sources").SourceMapSource;
 const RawSource = require("webpack-sources").RawSource;
+const ConcatSource = require("webpack-sources").ConcatSource;
 const RequestShortener = require("../RequestShortener");
 const ModuleFilenameHelpers = require("../ModuleFilenameHelpers");
 const uglify = require("uglify-js");
@@ -102,6 +103,54 @@ class UglifyJsPlugin {
 						for(let k in options.output) {
 							output[k] = options.output[k];
 						}
+						const extractedComments = [];
+						if(options.extractComments) {
+							const condition = {};
+							if(typeof options.extractComments === "string" || options.extractComments instanceof RegExp) {
+								// extractComments specifies the extract condition and output.comments specifies the preserve condition
+								condition.preserve = output.comments;
+								condition.extract = options.extractComments;
+							} else if(Object.prototype.hasOwnProperty.call(options.extractComments, "condition")) {
+								// Extract condition is given in extractComments.condition
+								condition.preserve = output.comments;
+								condition.extract = options.extractComments.condition;
+							} else {
+								// No extract condition is given. Extract comments that match output.comments instead of preserving them
+								condition.preserve = false;
+								condition.extract = output.comments;
+							}
+
+							// Ensure that both conditions are functions
+							["preserve", "extract"].forEach(key => {
+								switch(typeof condition[key]) {
+									case "boolean":
+										var b = condition[key];
+										condition[key] = () => b;
+									case "function": // eslint-disable-line no-fallthrough
+										break;
+									case "string":
+										if(condition[key] === "all") {
+											condition[key] = () => true;
+											break;
+										}
+										condition[key] = new RegExp(condition[key]);
+									default: // eslint-disable-line no-fallthrough
+										var regex = condition[key];
+										condition[key] = (astNode, comment) => regex.test(comment.value);
+								}
+							});
+
+							// Redefine the comments function to extract and preserve
+							// comments according to the two conditions
+							output.comments = (astNode, comment) => {
+								if(condition.extract(astNode, comment)) {
+									extractedComments.push(
+										comment.type === "comment2" ? "/*" + comment.value + "*/" : "//" + comment.value
+									);
+								}
+								return condition.preserve(astNode, comment);
+							};
+						}
 						let map;
 						if(options.sourceMap) {
 							map = uglify.SourceMap({ // eslint-disable-line new-cap
@@ -117,6 +166,41 @@ class UglifyJsPlugin {
 						asset.__UglifyJsPlugin = compilation.assets[file] = (map ?
 							new SourceMapSource(stringifiedStream, file, JSON.parse(map), input, inputSourceMap) :
 							new RawSource(stringifiedStream));
+						if(extractedComments.length > 0) {
+							let commentsFile = options.extractComments.file || file + ".LICENSE";
+							if(typeof commentsFile === "function") {
+								commentsFile = commentsFile(file);
+							}
+
+							// Write extracted comments to commentsFile
+							const commentsSource = new RawSource(extractedComments.join("\n\n") + "\n");
+							if(commentsFile in compilation.assets) {
+								// commentsFile already exists, append new comments...
+								if(compilation.assets[commentsFile] instanceof ConcatSource) {
+									compilation.assets[commentsFile].add("\n");
+									compilation.assets[commentsFile].add(commentsSource);
+								} else {
+									compilation.assets[commentsFile] = new ConcatSource(
+										compilation.assets[commentsFile], "\n", commentsSource
+									);
+								}
+							} else {
+								compilation.assets[commentsFile] = commentsSource;
+							}
+
+							// Add a banner to the original file
+							if(options.extractComments.banner !== false) {
+								let banner = options.extractComments.banner || "For license information please see " + commentsFile;
+								if(typeof banner === "function") {
+									banner = banner(commentsFile);
+								}
+								if(banner) {
+									asset.__UglifyJsPlugin = compilation.assets[file] = new ConcatSource(
+										"/*! " + banner + " */\n", compilation.assets[file]
+									);
+								}
+							}
+						}
 						if(warnings.length > 0) {
 							compilation.warnings.push(new Error(file + " from UglifyJs\n" + warnings.join("\n")));
 						}

--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -126,16 +126,19 @@ class UglifyJsPlugin {
 									case "boolean":
 										var b = condition[key];
 										condition[key] = () => b;
-									case "function": // eslint-disable-line no-fallthrough
+										break;
+									case "function":
 										break;
 									case "string":
 										if(condition[key] === "all") {
 											condition[key] = () => true;
 											break;
 										}
-										condition[key] = new RegExp(condition[key]);
-									default: // eslint-disable-line no-fallthrough
-										var regex = condition[key];
+										var regex = new RegExp(condition[key]);
+										condition[key] = (astNode, comment) => regex.test(comment.value);
+										break;
+									default:
+										regex = condition[key];
 										condition[key] = (astNode, comment) => regex.test(comment.value);
 								}
 							});
@@ -163,11 +166,11 @@ class UglifyJsPlugin {
 						ast.print(stream);
 						if(map) map = map + "";
 						const stringifiedStream = stream + "";
-						asset.__UglifyJsPlugin = compilation.assets[file] = (map ?
+						let outputSource = (map ?
 							new SourceMapSource(stringifiedStream, file, JSON.parse(map), input, inputSourceMap) :
 							new RawSource(stringifiedStream));
 						if(extractedComments.length > 0) {
-							let commentsFile = options.extractComments.file || file + ".LICENSE";
+							let commentsFile = options.extractComments.filename || file + ".LICENSE";
 							if(typeof commentsFile === "function") {
 								commentsFile = commentsFile(file);
 							}
@@ -195,12 +198,13 @@ class UglifyJsPlugin {
 									banner = banner(commentsFile);
 								}
 								if(banner) {
-									asset.__UglifyJsPlugin = compilation.assets[file] = new ConcatSource(
-										"/*! " + banner + " */\n", compilation.assets[file]
+									outputSource = new ConcatSource(
+										"/*! " + banner + " */\n", outputSource
 									);
 								}
 							}
 						}
+						asset.__UglifyJsPlugin = compilation.assets[file] = outputSource;
 						if(warnings.length > 0) {
 							compilation.warnings.push(new Error(file + " from UglifyJs\n" + warnings.join("\n")));
 						}

--- a/test/UglifyJsPlugin.test.js
+++ b/test/UglifyJsPlugin.test.js
@@ -227,7 +227,7 @@ describe("UglifyJsPlugin", function() {
 				comments: false,
 				extractComments: {
 					condition: 'should be extracted',
-					file: function(file) {
+					filename: function(file) {
 						return file.replace(/(\.\w+)$/, '.license$1');
 					},
 					banner: function(licenseFile) {
@@ -575,7 +575,7 @@ describe("UglifyJsPlugin", function() {
 				comments: "all",
 				extractComments: {
 					condition: /.*/,
-					file: "extracted-comments.js"
+					filename: "extracted-comments.js"
 				}
 			});
 			plugin.apply(compilerEnv);

--- a/test/configCases/plugins/uglifyjs-plugin/extract.js
+++ b/test/configCases/plugins/uglifyjs-plugin/extract.js
@@ -1,0 +1,15 @@
+/** @preserve comment should be extracted extract-test.1 */
+
+var foo = {};
+
+// comment should be stripped extract-test.2
+
+/*!
+ * comment should be extracted extract-test.3
+ */
+
+/**
+ * comment should be stripped extract-test.4
+ */
+
+module.exports = foo;

--- a/test/configCases/plugins/uglifyjs-plugin/index.js
+++ b/test/configCases/plugins/uglifyjs-plugin/index.js
@@ -23,5 +23,25 @@ it("should pass mangle options", function() {
 	source.should.containEql("function r(n){return function(n){try{t()}catch(t){n(t)}}}");
 });
 
+it("should extract comments to separate file", function() {
+	var fs = require("fs"),
+		path = require("path");
+	var source = fs.readFileSync(path.join(__dirname, "extract.js.LICENSE"), "utf-8");
+	source.should.containEql("comment should be extracted extract-test.1");
+	source.should.not.containEql("comment should be stripped extract-test.2");
+	source.should.containEql("comment should be extracted extract-test.3");
+	source.should.not.containEql("comment should be stripped extract-test.4");
+});
+
+it("should remove extracted comments and insert a banner", function() {
+	var fs = require("fs"),
+		path = require("path");
+	var source = fs.readFileSync(path.join(__dirname, "extract.js"), "utf-8");
+	source.should.not.containEql("comment should be extracted extract-test.1");
+	source.should.not.containEql("comment should be stripped extract-test.2");
+	source.should.not.containEql("comment should be extracted extract-test.3");
+	source.should.not.containEql("comment should be stripped extract-test.4");
+	source.should.containEql("/*! For license information please see extract.js.LICENSE */");
+});
 
 require.include("./test.js");

--- a/test/configCases/plugins/uglifyjs-plugin/webpack.config.js
+++ b/test/configCases/plugins/uglifyjs-plugin/webpack.config.js
@@ -7,7 +7,8 @@ module.exports = {
 	entry: {
 		bundle0: ["./index.js"],
 		vendors: ["./vendors.js"],
-		ie8: ["./ie8.js"]
+		ie8: ["./ie8.js"],
+		extract: ["./extract.js"]
 	},
 	output: {
 		filename: "[name].js"
@@ -15,10 +16,17 @@ module.exports = {
 	plugins: [
 		new webpack.optimize.UglifyJsPlugin({
 			comments: false,
-			exclude: ["vendors.js"],
+			exclude: ["vendors.js", "extract.js"],
 			mangle: {
 				screw_ie8: false
 			}
-		})
+		}),
+		new webpack.optimize.UglifyJsPlugin({
+			extractComments: true,
+			include: ["extract.js"],
+			mangle: {
+				screw_ie8: false
+			}
+		}),
 	]
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?**

feature in `UglifyJsPlugin`

**Did you add tests for your changes?**

yes

**If relevant, link to documentation update:**

Not yet, I will create a documentation PR if you agree with this feature

**Summary**

License comments use up a lot of space, especially when using many small libraries with large license blocks. With this addition, you can extract all license comments to a separate file and remove them from the bundle files. A small banner points to the file containing all license information such that the user can find it if needed.

**Does this PR introduce a breaking change?**

No

**Other information**

This PR adds a new option `extractComments` to the UglifyJsPlugin.
It can be omitted, then the behavior does not change, or it can be:
- `true`: All comments that normally would be preserved by the `comments` option will be moved to a separate file. If the original file is named `foo.js`, then the comments will be stored to `foo.js.LICENSE`
- regular expression (given as `RegExp` or `string`) or a `function (astNode, comment) -> boolean`:
  All comments that match the given expression (resp. are evaluated to `true` by the function) will be extracted to the separate file. The `comments` option specifies whether the comment will be preserved, i.e. it is possible to preserve some comments (e.g. annotations) while extracting others or even preserving comments that have been extracted.
- an `object` consisting of the following keys, all optional:
  - `condition`: regular expression or function (see previous point)
  - `filename`: The file where the extracted comments will be stored. Can be either a `string` or `function (string) -> string` which will be given the original filename. Default is to append the suffix `.LICENSE` to the original filename.
  - `banner`: The banner text that points to the extracted file and will be added on top of the original file. will be added to the original file. Can be `false` (no banner), a `string`, or a `function (string) -> string` that will be called with the filename where extracted comments have been stored. Will be wrapped into comment.
Default: `/*! For license information please see foo.js.LICENSE */`