### PR TITLE
Source map cache busting

### DIFF
--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -3,6 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 var path = require("path");
+var crypto = require("crypto");
 var RequestShortener = require("./RequestShortener");
 var ConcatSource = require("webpack-sources").ConcatSource;
 var RawSource = require("webpack-sources").RawSource;
@@ -129,25 +130,26 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 					currentSourceMappingURLComment = currentSourceMappingURLComment.replace(/^\n\/\/(.*)$/, "\n/*$1*/");
 				}
 				if(sourceMapFilename) {
-					var filename = file,
-						query = "";
-					var idx = filename.indexOf("?");
-					if(idx >= 0) {
-						query = filename.substr(idx);
-						filename = filename.substr(0, idx);
+					var filename = splitQuery(file);
+					var contentHash;
+					if(sourceMapFilename.indexOf("[hash]")) {
+						var hash = crypto.createHash("md5");
+						hash.update(source);
+						contentHash = hash.digest("hex");
 					}
-					var sourceMapFile = this.getPath(sourceMapFilename, {
+					var sourceMapFile = splitQuery(this.getPath(sourceMapFilename, {
 						chunk: chunk,
-						filename: filename,
-						query: query,
-						basename: basename(filename)
-					});
-					var sourceMapUrl = path.relative(path.dirname(file), sourceMapFile).replace(/\\/g, "/");
+						filename: filename.name,
+						query: filename.query,
+						hash: contentHash,
+						basename: basename(filename.name)
+					}));
+					var sourceMapUrl = path.relative(path.dirname(file), sourceMapFile.name).replace(/\\/g, "/") + sourceMapFile.query;
 					if(currentSourceMappingURLComment !== false) {
 						asset.__SourceMapDevToolData[file] = this.assets[file] = new ConcatSource(new RawSource(source), currentSourceMappingURLComment.replace(/\[url\]/g, sourceMapUrl));
 					}
-					asset.__SourceMapDevToolData[sourceMapFile] = this.assets[sourceMapFile] = new RawSource(JSON.stringify(sourceMap));
-					chunk.files.push(sourceMapFile);
+					asset.__SourceMapDevToolData[sourceMapFile.name] = this.assets[sourceMapFile.name] = new RawSource(JSON.stringify(sourceMap));
+					chunk.files.push(sourceMapFile.name);
 				} else {
 					asset.__SourceMapDevToolData[file] = this.assets[file] = new ConcatSource(new RawSource(source), currentSourceMappingURLComment
 						.replace(/\[map\]/g, function() {
@@ -167,4 +169,19 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 function basename(name) {
 	if(name.indexOf("/") < 0) return name;
 	return name.substr(name.lastIndexOf("/") + 1);
+}
+
+function splitQuery(name) {
+	var idx = name.indexOf("?");
+	if(idx >= 0) {
+		return {
+			query: name.substr(idx),
+			name: name.substr(0, idx)
+		};
+	} else {
+		return {
+			query: "",
+			name: name
+		};
+	}
 }

--- a/test/configCases/source-map/source-map-filename-hash/index.js
+++ b/test/configCases/source-map/source-map-filename-hash/index.js
@@ -1,0 +1,6 @@
+it("should contain hash as query parameter", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+	var match = /sourceMappingURL\s*=\s*.*\?([A-Fa-f0-9]{32})/.exec(source);
+	match.length.should.be.eql(2);
+});

--- a/test/configCases/source-map/source-map-filename-hash/webpack.config.js
+++ b/test/configCases/source-map/source-map-filename-hash/webpack.config.js
@@ -1,0 +1,16 @@
+var webpack = require("../../../../");
+module.exports = {
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	devtool: "source-map",
+	output: {
+		sourceMapFilename: "[file].map?[hash]",
+	},
+	plugins: [
+		new webpack.optimize.UglifyJsPlugin({
+			sourceMap: true
+		})
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
I'd add this as a known issue/recipe to https://webpack.js.org/configuration/output/#output-sourcemapfilename if this PR is merged.
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
When chunk / source map size exceeds some threshold, [Chrome caches external source maps too hard](https://bugs.chromium.org/p/chromium/issues/detail?id=508270).

In some cases, with very large chunks, inline / eval source maps slow down every page reload significantly, while only needed when actually debugging JS.

"Disable cache" helps, but isn't nice as it slows down everything.

So this PR allows using `sourceMapFilename: "[file].map?[hash]"` as a watch-mode friendly cache busting mechanism.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
While we should all aim to have tiny chunks and lazy load all we can, when you retrofit webpack into a (very) large legacy application, it can take a while before that goal is achievable. Having fast watch mode development cycle is even more critical in large apps, and `cheap-module-source-map` with proper cache invalidation yields best results in my experience.