### PR TITLE
remove leftovers of jam already removed in 4c7c9290966599dfb81651f87f030fda591ea7a9

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -266,7 +266,7 @@ function processOptions(options) {
 		});
 
 		if(!outputOptions.exclude)
-			outputOptions.exclude = ["node_modules", "bower_components", "jam", "components"];
+			outputOptions.exclude = ["node_modules", "bower_components", "components"];
 
 		if(argv["display-modules"]) {
 			outputOptions.maxModules = Infinity;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

 N/A

**If relevant, link to documentation update:**

 N/A

**Summary**

fixes #3054 
finishes up of jam removal that was done in `4c7c9290966599dfb81651f87f030fda591ea7a9`

**Does this PR introduce a breaking change?**

No (i guess)

**Other information**
