### PR TITLE
Update MultiCompiler and lib/webpack to better support multiple watchOptions

### DIFF
--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -119,13 +119,10 @@ MultiCompiler.prototype.watch = function(watchOptions, handler) {
 	var compilerStatus = this.compilers.map(function() {
 		return false;
 	});
-	if(!Array.isArray(watchOptions)) {
-		watchOptions = [watchOptions];
-	}
 	runWithDependencies(this.compilers, function(compiler, callback) {
 		var compilerIdx = this.compilers.indexOf(compiler);
 		var firstRun = true;
-		var watching = compiler.watch(watchOptions[compilerIdx], function(err, stats) {
+		var watching = compiler.watch(Array.isArray(watchOptions) ? watchOptions[compilerIdx] : watchOptions, function(err, stats) {
 			if(err)
 				handler(err);
 			if(stats) {

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -119,11 +119,13 @@ MultiCompiler.prototype.watch = function(watchOptions, handler) {
 	var compilerStatus = this.compilers.map(function() {
 		return false;
 	});
-
+	if(!Array.isArray(watchOptions)) {
+		watchOptions = [watchOptions];
+	}
 	runWithDependencies(this.compilers, function(compiler, callback) {
 		var compilerIdx = this.compilers.indexOf(compiler);
 		var firstRun = true;
-		var watching = compiler.watch(watchOptions, function(err, stats) {
+		var watching = compiler.watch(watchOptions[compilerIdx], function(err, stats) {
 			if(err)
 				handler(err);
 			if(stats) {

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -40,7 +40,7 @@ function webpack(options, callback) {
 	if(callback) {
 		if(typeof callback !== "function") throw new Error("Invalid argument: callback");
 		if(options.watch === true || (Array.isArray(options) && options.some(o => o.watch))) {
-			const watchOptions = (!Array.isArray(options) ? options : options[0]).watchOptions || {};
+			const watchOptions = Array.isArray(options) ? options.map(o => o.watchOptions || {}) : (options.watchOptions || {});
 			return compiler.watch(watchOptions, callback);
 		}
 		compiler.run(callback);

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -300,12 +300,10 @@ describe("MultiCompiler", function() {
 				setupTwoCompilerEnvironment(env);
 				env.callback = sinon.spy();
 				env.options = [{
-						testWatchOptions: true
-					},
-					{
-						testWatchOptions2: true
-					}
-				];
+					testWatchOptions: true
+				}, {
+					testWatchOptions2: true
+				}];
 				env.result = env.myMultiCompiler.watch(env.options, env.callback);
 			});
 
@@ -404,12 +402,10 @@ describe("MultiCompiler", function() {
 				});
 				env.callback = sinon.spy();
 				env.options = [{
-						testWatchOptions: true
-					},
-					{
-						testWatchOptions2: true
-					}
-				];
+					testWatchOptions: true
+				}, {
+					testWatchOptions2: true
+				}];
 				env.result = env.myMultiCompiler.watch(env.options, env.callback);
 			});
 

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -299,9 +299,13 @@ describe("MultiCompiler", function() {
 			beforeEach(function() {
 				setupTwoCompilerEnvironment(env);
 				env.callback = sinon.spy();
-				env.options = {
-					testWatchOptions: true
-				};
+				env.options = [{
+						testWatchOptions: true
+					},
+					{
+						testWatchOptions2: true
+					}
+				];
 				env.result = env.myMultiCompiler.watch(env.options, env.callback);
 			});
 
@@ -312,9 +316,9 @@ describe("MultiCompiler", function() {
 
 			it("calls watch on each compiler with original options", function() {
 				env.compiler1WatchCallbacks.length.should.be.exactly(1);
-				env.compiler1WatchCallbacks[0].options.should.be.exactly(env.options);
+				env.compiler1WatchCallbacks[0].options.should.be.exactly(env.options[0]);
 				env.compiler2WatchCallbacks.length.should.be.exactly(1);
-				env.compiler2WatchCallbacks[0].options.should.be.exactly(env.options);
+				env.compiler2WatchCallbacks[0].options.should.be.exactly(env.options[1]);
 			});
 
 			it("calls the callback when all compilers watch", function() {
@@ -399,21 +403,25 @@ describe("MultiCompiler", function() {
 					name: "compiler2"
 				});
 				env.callback = sinon.spy();
-				env.options = {
-					testWatchOptions: true
-				};
+				env.options = [{
+						testWatchOptions: true
+					},
+					{
+						testWatchOptions2: true
+					}
+				];
 				env.result = env.myMultiCompiler.watch(env.options, env.callback);
 			});
 
 			it("calls run on each compiler in dependency order", function() {
 				env.compiler1WatchCallbacks.length.should.be.exactly(0);
 				env.compiler2WatchCallbacks.length.should.be.exactly(1);
-				env.compiler2WatchCallbacks[0].options.should.be.exactly(env.options);
+				env.compiler2WatchCallbacks[0].options.should.be.exactly(env.options[1]);
 				env.compiler2WatchCallbacks[0].callback(null, {
 					hash: 'bar'
 				});
 				env.compiler1WatchCallbacks.length.should.be.exactly(1);
-				env.compiler1WatchCallbacks[0].options.should.be.exactly(env.options);
+				env.compiler1WatchCallbacks[0].options.should.be.exactly(env.options[0]);
 			});
 
 			it("calls the callback when all compilers run in dependency order", function() {


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Fixes https://github.com/webpack/webpack/issues/4156

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Updated existing tests which checked for the previous (broken) behavior. Let me know if this is sufficient or you'd like more.
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

N/A that I'm aware of, but let me know if I'm missing something and happy to update.
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

Previously, MultiCompiler.watch would apply the watchOptions only from the first set of options to all compilers, regardless of how many options with watchOptions were passed. This changes MultiCompiler to correctly treat those options as an array and apply the relevant watchOptions to each compiler.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

Possibly... if someone was depending on being able to pass a single set of watchOptions to a multicompile and have them applied to all compilers, they will no longer be able to do that.

I believe that behavior was an implementation side effect and not something anyone would depend on, but if they were the migration path is to duplicate the options into an array with one entry for each compiler.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
