### PR TITLE
Allow to supress uglifyjs warnings

### DIFF
--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -21,6 +21,7 @@ class UglifyJsPlugin {
 	apply(compiler) {
 		let options = this.options;
 		options.test = options.test || /\.js($|\?)/i;
+		const warningsFilter = options.warningsFilter || (() => true);
 
 		let requestShortener = new RequestShortener(compiler.context);
 		compiler.plugin("compilation", (compilation) => {
@@ -66,6 +67,7 @@ class UglifyJsPlugin {
 									column: column
 								});
 								if(!original || !original.source || original.source === file) return;
+								if(!warningsFilter(original.source)) return;
 								warnings.push(warning.replace(/\[.+:([0-9]+),([0-9]+)\]/, "") +
 									"[" + requestShortener.shorten(original.source) + ":" + original.line + "," + original.column + "]");
 							};

--- a/test/statsCases/warnings-uglifyjs/a.js
+++ b/test/statsCases/warnings-uglifyjs/a.js
@@ -1,0 +1,7 @@
+module.export = function someUsedFunction() {};
+
+function someUnRemoteUsedFunction1() {}
+function someUnRemoteUsedFunction2() {}
+function someUnRemoteUsedFunction3() {}
+function someUnRemoteUsedFunction4() {}
+function someUnRemoteUsedFunction5() {}

--- a/test/statsCases/warnings-uglifyjs/expected.txt
+++ b/test/statsCases/warnings-uglifyjs/expected.txt
@@ -8,8 +8,8 @@ chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
    [2] (webpack)/test/statsCases/warnings-uglifyjs/index.js 299 bytes {0} [built]
 
 WARNING in bundle.js from UglifyJs
-Dropping unused function someUnUsedFunction1 [./index.js:8,0]
-Dropping unused function someUnUsedFunction2 [./index.js:9,0]
-Dropping unused function someUnUsedFunction3 [./index.js:10,0]
-Dropping unused function someUnUsedFunction4 [./index.js:11,0]
-Dropping unused function someUnUsedFunction5 [./index.js:12,0]
+Dropping unused function someUnRemoteUsedFunction1 [./a.js:3,0]
+Dropping unused function someUnRemoteUsedFunction2 [./a.js:4,0]
+Dropping unused function someUnRemoteUsedFunction3 [./a.js:5,0]
+Dropping unused function someUnRemoteUsedFunction4 [./a.js:6,0]
+Dropping unused function someUnRemoteUsedFunction5 [./a.js:7,0]

--- a/test/statsCases/warnings-uglifyjs/expected.txt
+++ b/test/statsCases/warnings-uglifyjs/expected.txt
@@ -1,0 +1,15 @@
+Hash: 4beee256fa6b8f69eae8
+Time: Xms
+    Asset    Size  Chunks             Chunk Names
+bundle.js  2.3 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
+   [0] (webpack)/buildin/module.js 495 bytes {0} [built]
+   [1] (webpack)/test/statsCases/warnings-uglifyjs/a.js 249 bytes {0} [built]
+   [2] (webpack)/test/statsCases/warnings-uglifyjs/index.js 299 bytes {0} [built]
+
+WARNING in bundle.js from UglifyJs
+Dropping unused function someUnUsedFunction1 [./index.js:8,0]
+Dropping unused function someUnUsedFunction2 [./index.js:9,0]
+Dropping unused function someUnUsedFunction3 [./index.js:10,0]
+Dropping unused function someUnUsedFunction4 [./index.js:11,0]
+Dropping unused function someUnUsedFunction5 [./index.js:12,0]

--- a/test/statsCases/warnings-uglifyjs/index.js
+++ b/test/statsCases/warnings-uglifyjs/index.js
@@ -1,0 +1,12 @@
+var someRequiredUsedFunction = require("./a");
+
+function someUsedFunction() {}
+
+someRequiredUsedFunction();
+someUsedFunction();
+
+function someUnUsedFunction1() {}
+function someUnUsedFunction2() {}
+function someUnUsedFunction3() {}
+function someUnUsedFunction4() {}
+function someUnUsedFunction5() {}

--- a/test/statsCases/warnings-uglifyjs/webpack.config.js
+++ b/test/statsCases/warnings-uglifyjs/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
 	},
 	plugins: [new webpack.optimize.UglifyJsPlugin({
 		warningsFilter: function(filename) {
-			return !/a\.js$/.test(filename);
+			return /a\.js$/.test(filename);
 		},
 		sourceMap: true,
 		compress: {

--- a/test/statsCases/warnings-uglifyjs/webpack.config.js
+++ b/test/statsCases/warnings-uglifyjs/webpack.config.js
@@ -1,0 +1,26 @@
+var webpack = require("webpack");
+
+module.exports = {
+	entry: "./index",
+	output: {
+		filename: "bundle.js"
+	},
+	plugins: [new webpack.optimize.UglifyJsPlugin({
+		warningsFilter: function(filename) {
+			return !/a\.js$/.test(filename);
+		},
+		sourceMap: true,
+		compress: {
+			warnings: true,
+		},
+		mangle: false,
+		beautify: true,
+		comments: false
+	})],
+	stats: {
+		chunkModules: false,
+		modules: true,
+		providedExports: true,
+		usedExports: true
+	}
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

yes

**If relevant, link to documentation update:**

N/A

**Summary**

fixes #1496 by adding a `warningsFilter` function to options for the UglifyJsPlugin that decides which warnings should be shown

**Does this PR introduce a breaking change?**

No

**Other information**

The test setup for uglifyJs is a bit messy so i just hacked in two tests. I didnt feel like making sense out of it.