### PR TITLE
WebpackMissingModule: remove unused function

### DIFF
--- a/lib/dependencies/WebpackMissingModule.js
+++ b/lib/dependencies/WebpackMissingModule.js
@@ -7,17 +7,12 @@ const toErrorCode = err => `var e = new Error(${JSON.stringify(err)}); e.code = 
 
 exports.module = request => `!(function webpackMissingModule() { ${exports.moduleCode(request)} }())`;
 
-exports.promise = function(request) {
+exports.promise = (request) => {
 	const errorCode = toErrorCode(`Cannot find module "${request}"`);
 	return `Promise.reject(function webpackMissingModule() { ${errorCode}; return e; }())`;
 };
 
-exports.moduleCode = function(request) {
+exports.moduleCode = (request) => {
 	const errorCode = toErrorCode(`Cannot find module "${request}"`);
 	return `${errorCode}; throw e;`;
-};
-
-exports.moduleMetaInfo = function(request) {
-	const errorCode = toErrorCode(`Module cannot be imported because no meta info about exports is available "${request}"`);
-	return `!(function webpackMissingModuleMetaInfo() { ${errorCode}; throw e; }())`;
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Remove unused function in [WebpackMissingModule](https://github.com/webpack/webpack/blob/master/lib/dependencies/WebpackMissingModule.js)

**Did you add tests for your changes?**
No test needed

**Summary**
Deleted the `moduleMetaInfo` function in [WebpackMissingModule](https://github.com/webpack/webpack/blob/master/lib/dependencies/WebpackMissingModule.js), as part of the effort to increase test coverage (https://github.com/webpack/webpack/issues/3716). That function was only used in `LabeledModuleDependency`, a file that was deleted in https://github.com/webpack/webpack/commit/a14e563f67292cf2bdfe28b01abd8cb5fee1e20e

**Does this PR introduce a breaking change?**
No