### PR TITLE
Use let const as blockscoped variables

### DIFF
--- a/lib/AmdMainTemplatePlugin.js
+++ b/lib/AmdMainTemplatePlugin.js
@@ -13,19 +13,19 @@ class AmdMainTemplatePlugin {
 	}
 
 	apply(compilation) {
-		let mainTemplate = compilation.mainTemplate;
+		const mainTemplate = compilation.mainTemplate;
 
 		compilation.templatesPlugin("render-with-entry", (source, chunk, hash) => {
-			let externals = chunk.modules.filter((m) => m.external);
-			let externalsDepsArray = JSON.stringify(externals.map((m) =>
+			const externals = chunk.modules.filter((m) => m.external);
+			const externalsDepsArray = JSON.stringify(externals.map((m) =>
 				typeof m.request === "object" ? m.request.amd : m.request
 			));
-			let externalsArguments = externals.map((m) =>
+			const externalsArguments = externals.map((m) =>
 				`__WEBPACK_EXTERNAL_MODULE_${m.id}__`
 			).join(", ");
 
 			if(this.name) {
-				let name = mainTemplate.applyPluginsWaterfall("asset-path", this.name, {
+				const name = mainTemplate.applyPluginsWaterfall("asset-path", this.name, {
 					hash,
 					chunk
 				});

--- a/lib/BannerPlugin.js
+++ b/lib/BannerPlugin.js
@@ -26,8 +26,8 @@ class BannerPlugin {
 	}
 
 	apply(compiler) {
-		let options = this.options;
-		let banner = this.banner;
+		const options = this.options;
+		const banner = this.banner;
 
 		compiler.plugin("compilation", (compilation) => {
 			compilation.plugin("optimize-chunk-assets", (chunks, callback) => {

--- a/lib/CaseSensitiveModulesWarning.js
+++ b/lib/CaseSensitiveModulesWarning.js
@@ -10,8 +10,8 @@ module.exports = class CaseSensitiveModulesWarning extends Error {
 		Error.captureStackTrace(this, CaseSensitiveModulesWarning);
 		this.name = "CaseSensitiveModulesWarning";
 
-		let sortedModules = this._sort(modules);
-		let modulesList = this._moduleMessages(sortedModules);
+		const sortedModules = this._sort(modules);
+		const modulesList = this._moduleMessages(sortedModules);
 		this.message = "There are multiple modules with names that only differ in casing.\n" +
 			"This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.\n" +
 			`Use equal casing. Compare these module identifiers:\n${modulesList}`;
@@ -34,7 +34,7 @@ module.exports = class CaseSensitiveModulesWarning extends Error {
 	_moduleMessages(modules) {
 		return modules.map((m) => {
 			let message = `* ${m.identifier()}`;
-			let validReasons = m.reasons.filter((reason) => reason.module);
+			const validReasons = m.reasons.filter((reason) => reason.module);
 
 			if(validReasons.length > 0) {
 				message += `\n    Used by ${validReasons.length} module(s), i. e.`;

--- a/lib/ChunkTemplate.js
+++ b/lib/ChunkTemplate.js
@@ -13,8 +13,8 @@ module.exports = class ChunkTemplate extends Template {
 	}
 
 	render(chunk, moduleTemplate, dependencyTemplates) {
-		let modules = this.renderChunkModules(chunk, moduleTemplate, dependencyTemplates);
-		let core = this.applyPluginsWaterfall("modules", modules, chunk, moduleTemplate, dependencyTemplates);
+		const modules = this.renderChunkModules(chunk, moduleTemplate, dependencyTemplates);
+		const core = this.applyPluginsWaterfall("modules", modules, chunk, moduleTemplate, dependencyTemplates);
 		let source = this.applyPluginsWaterfall("render", core, chunk, moduleTemplate, dependencyTemplates);
 		if(chunk.hasEntryModule()) {
 			source = this.applyPluginsWaterfall("render-with-entry", source, chunk);

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -199,7 +199,7 @@ class Compilation extends Tapable {
 		let _this = this;
 		const start = _this.profile && +new Date();
 
-		let factories = [];
+		const factories = [];
 		for(let i = 0; i < dependencies.length; i++) {
 			const factory = _this.dependencyFactories.get(dependencies[i][0].constructor);
 			if(!factory) {

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1144,16 +1144,14 @@ class Compilation extends Tapable {
 	}
 
 	createModuleAssets() {
-		function cacheAssetsAndApplyPlugins(name) {
-			const file = this.getPath(name);
-			this.assets[file] = module.assets[name];
-			this.applyPlugins2("module-asset", module, file);
-		}
-
 		for(let i = 0; i < this.modules.length; i++) {
 			const module = this.modules[i];
 			if(module.assets) {
-				Object.keys(module.assets).forEach(cacheAssetsAndApplyPlugins, this);
+				Object.keys(module.assets).forEach((assetName) => {
+					const fileName = this.getPath(assetName);
+					this.assets[fileName] = module.assets[assetName];
+					this.applyPlugins2("module-asset", module, fileName);
+				});
 			}
 		}
 	}

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -685,17 +685,16 @@ class Compilation extends Tapable {
 	}
 
 	addChunk(name, module, loc) {
-		let chunk;
 		if(name) {
 			if(Object.prototype.hasOwnProperty.call(this.namedChunks, name)) {
-				chunk = this.namedChunks[name];
+				const chunk = this.namedChunks[name];
 				if(module) {
 					chunk.addOrigin(module, loc);
 				}
 				return chunk;
 			}
 		}
-		chunk = new Chunk(name, module, loc);
+		const chunk = new Chunk(name, module, loc);
 		this.chunks.push(chunk);
 		if(name) {
 			this.namedChunks[name] = chunk;
@@ -1098,7 +1097,6 @@ class Compilation extends Tapable {
 		this.children.forEach(function(child) {
 			hash.update(child.hash);
 		});
-		let chunk;
 		// clone needed as sort below is inplace mutation
 		const chunks = this.chunks.slice();
 		/**
@@ -1114,7 +1112,7 @@ class Compilation extends Tapable {
 			return 0;
 		});
 		for(let i = 0; i < chunks.length; i++) {
-			chunk = chunks[i];
+			const chunk = chunks[i];
 			const chunkHash = crypto.createHash(hashFunction);
 			if(outputOptions.hashSalt)
 				chunkHash.update(outputOptions.hashSalt);
@@ -1146,8 +1144,6 @@ class Compilation extends Tapable {
 	}
 
 	createModuleAssets() {
-		let module;
-
 		function cacheAssetsAndApplyPlugins(name) {
 			const file = this.getPath(name);
 			this.assets[file] = module.assets[name];
@@ -1155,7 +1151,7 @@ class Compilation extends Tapable {
 		}
 
 		for(let i = 0; i < this.modules.length; i++) {
-			module = this.modules[i];
+			const module = this.modules[i];
 			if(module.assets) {
 				Object.keys(module.assets).forEach(cacheAssetsAndApplyPlugins, this);
 			}

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -68,6 +68,7 @@ class DefinePlugin {
 						parser.plugin("can-rename " + key, ParserHelpers.approve);
 						parser.plugin("evaluate Identifier " + key, (expr) => {
 							if(recurse) return;
+							recurse = true;
 							const res = parser.evaluate(code);
 							recurse = false;
 							res.setRange(expr.range);
@@ -78,6 +79,7 @@ class DefinePlugin {
 					const typeofCode = isTypeof ? code : "typeof (" + code + ")";
 					parser.plugin("evaluate typeof " + key, (expr) => {
 						if(recurseTypeof) return;
+						recurseTypeof = true;
 						const res = parser.evaluate(typeofCode);
 						recurseTypeof = false;
 						res.setRange(expr.range);

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -15,7 +15,7 @@ class DefinePlugin {
 	}
 
 	apply(compiler) {
-		let definitions = this.definitions;
+		const definitions = this.definitions;
 		compiler.plugin("compilation", (compilation, params) => {
 			compilation.dependencyFactories.set(ConstDependency, new NullFactory());
 			compilation.dependencyTemplates.set(ConstDependency, new ConstDependency.Template());
@@ -23,7 +23,7 @@ class DefinePlugin {
 			params.normalModuleFactory.plugin("parser", (parser) => {
 				(function walkDefinitions(definitions, prefix) {
 					Object.keys(definitions).forEach((key) => {
-						let code = definitions[key];
+						const code = definitions[key];
 						if(code && typeof code === "object" && !(code instanceof RegExp)) {
 							walkDefinitions(code, prefix + key + ".");
 							applyObjectDefine(prefix + key, code);
@@ -36,7 +36,7 @@ class DefinePlugin {
 
 				function stringifyObj(obj) {
 					return "__webpack_require__.i({" + Object.keys(obj).map((key) => {
-						let code = obj[key];
+						const code = obj[key];
 						return JSON.stringify(key) + ":" + toCode(code);
 					}).join(",") + "})";
 				}
@@ -59,7 +59,7 @@ class DefinePlugin {
 				}
 
 				function applyDefine(key, code) {
-					let isTypeof = /^typeof\s+/.test(key);
+					const isTypeof = /^typeof\s+/.test(key);
 					if(isTypeof) key = key.replace(/^typeof\s+/, "");
 					let recurse = false;
 					let recurseTypeof = false;
@@ -68,30 +68,30 @@ class DefinePlugin {
 						parser.plugin("can-rename " + key, ParserHelpers.approve);
 						parser.plugin("evaluate Identifier " + key, (expr) => {
 							if(recurse) return;
-							let res = parser.evaluate(code);
+							const res = parser.evaluate(code);
 							recurse = false;
 							res.setRange(expr.range);
 							return res;
 						});
 						parser.plugin("expression " + key, ParserHelpers.toConstantDependency(code));
 					}
-					let typeofCode = isTypeof ? code : "typeof (" + code + ")";
+					const typeofCode = isTypeof ? code : "typeof (" + code + ")";
 					parser.plugin("evaluate typeof " + key, (expr) => {
 						if(recurseTypeof) return;
-						let res = parser.evaluate(typeofCode);
+						const res = parser.evaluate(typeofCode);
 						recurseTypeof = false;
 						res.setRange(expr.range);
 						return res;
 					});
 					parser.plugin("typeof " + key, (expr) => {
-						let res = parser.evaluate(typeofCode);
+						const res = parser.evaluate(typeofCode);
 						if(!res.isString()) return;
 						return ParserHelpers.toConstantDependency(JSON.stringify(res.string)).bind(parser)(expr);
 					});
 				}
 
 				function applyObjectDefine(key, obj) {
-					let code = stringifyObj(obj);
+					const code = stringifyObj(obj);
 					parser.plugin("can-rename " + key, ParserHelpers.approve);
 					parser.plugin("evaluate Identifier " + key, (expr) => new BasicEvaluatedExpression().setRange(expr.range));
 					parser.plugin("evaluate typeof " + key, ParserHelpers.evaluateToString("object"));

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -67,6 +67,14 @@ class DefinePlugin {
 					if(!isTypeof) {
 						parser.plugin("can-rename " + key, ParserHelpers.approve);
 						parser.plugin("evaluate Identifier " + key, (expr) => {
+							/**
+							 * this is needed in case there is a recursion in the DefinePlugin
+							 * to prevent an endless recursion
+							 * e.g.: new DefinePlugin({
+							 * "a": "b",
+							 * "b": "a"
+							 * });
+							 */
 							if(recurse) return;
 							recurse = true;
 							const res = parser.evaluate(code);
@@ -78,6 +86,14 @@ class DefinePlugin {
 					}
 					const typeofCode = isTypeof ? code : "typeof (" + code + ")";
 					parser.plugin("evaluate typeof " + key, (expr) => {
+						/**
+						 * this is needed in case there is a recursion in the DefinePlugin
+						 * to prevent an endless recursion
+						 * e.g.: new DefinePlugin({
+						 * "typeof a": "tyepof b",
+						 * "typeof b": "typeof a"
+						 * });
+						 */
 						if(recurseTypeof) return;
 						recurseTypeof = true;
 						const res = parser.evaluate(typeofCode);

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -61,11 +61,15 @@ class DefinePlugin {
 				function applyDefine(key, code) {
 					const isTypeof = /^typeof\s+/.test(key);
 					if(isTypeof) key = key.replace(/^typeof\s+/, "");
+					let recurse = false;
+					let recurseTypeof = false;
 					code = toCode(code);
 					if(!isTypeof) {
 						parser.plugin("can-rename " + key, ParserHelpers.approve);
 						parser.plugin("evaluate Identifier " + key, (expr) => {
+							if(recurse) return;
 							const res = parser.evaluate(code);
+							recurse = false;
 							res.setRange(expr.range);
 							return res;
 						});
@@ -73,7 +77,9 @@ class DefinePlugin {
 					}
 					const typeofCode = isTypeof ? code : "typeof (" + code + ")";
 					parser.plugin("evaluate typeof " + key, (expr) => {
+						if(recurseTypeof) return;
 						const res = parser.evaluate(typeofCode);
+						recurseTypeof = false;
 						res.setRange(expr.range);
 						return res;
 					});

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -61,15 +61,11 @@ class DefinePlugin {
 				function applyDefine(key, code) {
 					const isTypeof = /^typeof\s+/.test(key);
 					if(isTypeof) key = key.replace(/^typeof\s+/, "");
-					let recurse = false;
-					let recurseTypeof = false;
 					code = toCode(code);
 					if(!isTypeof) {
 						parser.plugin("can-rename " + key, ParserHelpers.approve);
 						parser.plugin("evaluate Identifier " + key, (expr) => {
-							if(recurse) return;
 							const res = parser.evaluate(code);
-							recurse = false;
 							res.setRange(expr.range);
 							return res;
 						});
@@ -77,9 +73,7 @@ class DefinePlugin {
 					}
 					const typeofCode = isTypeof ? code : "typeof (" + code + ")";
 					parser.plugin("evaluate typeof " + key, (expr) => {
-						if(recurseTypeof) return;
 						const res = parser.evaluate(typeofCode);
-						recurseTypeof = false;
 						res.setRange(expr.range);
 						return res;
 					});

--- a/lib/DllEntryPlugin.js
+++ b/lib/DllEntryPlugin.js
@@ -17,8 +17,8 @@ class DllEntryPlugin {
 
 	apply(compiler) {
 		compiler.plugin("compilation", (compilation, params) => {
-			let dllModuleFactory = new DllModuleFactory();
-			let normalModuleFactory = params.normalModuleFactory;
+			const dllModuleFactory = new DllModuleFactory();
+			const normalModuleFactory = params.normalModuleFactory;
 
 			compilation.dependencyFactories.set(DllEntryDependency, dllModuleFactory);
 
@@ -26,7 +26,7 @@ class DllEntryPlugin {
 		});
 		compiler.plugin("make", (compilation, callback) => {
 			compilation.addEntry(this.context, new DllEntryDependency(this.entries.map((e, idx) => {
-				let dep = new SingleEntryDependency(e);
+				const dep = new SingleEntryDependency(e);
 				dep.loc = `${this.name}:${idx}`;
 				return dep;
 			}), this.name), this.name, callback);

--- a/lib/DllModuleFactory.js
+++ b/lib/DllModuleFactory.js
@@ -12,7 +12,7 @@ class DllModuleFactory extends Tapable {
 		super();
 	}
 	create(data, callback) {
-		let dependency = data.dependencies[0];
+		const dependency = data.dependencies[0];
 		callback(null, new DllModule(data.context, dependency.dependencies, dependency.name, dependency.type));
 	}
 }

--- a/lib/DllReferencePlugin.js
+++ b/lib/DllReferencePlugin.js
@@ -15,12 +15,12 @@ class DllReferencePlugin {
 
 	apply(compiler) {
 		compiler.plugin("compilation", (compilation, params) => {
-			let normalModuleFactory = params.normalModuleFactory;
+			const normalModuleFactory = params.normalModuleFactory;
 			compilation.dependencyFactories.set(DelegatedSourceDependency, normalModuleFactory);
 		});
 
 		compiler.plugin("before-compile", (params, callback) => {
-			let manifest = this.options.manifest;
+			const manifest = this.options.manifest;
 			if(typeof manifest === "string") {
 				params.compilationDependencies.push(manifest);
 				compiler.inputFileSystem.readFile(manifest, function(err, result) {
@@ -38,10 +38,10 @@ class DllReferencePlugin {
 			if(typeof manifest === "string") {
 				manifest = params["dll reference " + manifest];
 			}
-			let name = this.options.name || manifest.name;
-			let sourceType = this.options.sourceType || "var";
-			let externals = {};
-			let source = "dll-reference " + name;
+			const name = this.options.name || manifest.name;
+			const sourceType = this.options.sourceType || "var";
+			const externals = {};
+			const source = "dll-reference " + name;
 			externals[source] = name;
 			params.normalModuleFactory.apply(new ExternalModuleFactoryPlugin(sourceType, externals));
 			params.normalModuleFactory.apply(new DelegatedModuleFactoryPlugin({

--- a/lib/Entrypoint.js
+++ b/lib/Entrypoint.js
@@ -26,7 +26,7 @@ class Entrypoint {
 	}
 
 	getFiles() {
-		let files = [];
+		const files = [];
 
 		for(let chunkIdx = 0; chunkIdx < this.chunks.length; chunkIdx++) {
 			for(let fileIdx = 0; fileIdx < this.chunks[chunkIdx].files.length; fileIdx++) {

--- a/lib/EvalSourceMapDevToolPlugin.js
+++ b/lib/EvalSourceMapDevToolPlugin.js
@@ -21,7 +21,7 @@ class EvalSourceMapDevToolPlugin {
 	}
 
 	apply(compiler) {
-		let options = this.options;
+		const options = this.options;
 		compiler.plugin("compilation", (compilation) => {
 			new SourceMapDevToolModuleOptionsPlugin(options).apply(compilation);
 			compilation.moduleTemplate.apply(new EvalSourceMapDevToolModuleTemplatePlugin(compilation, options));

--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -45,9 +45,17 @@ class FlagDependencyExportsPlugin {
 					if(exportDeps) {
 						exportDeps.forEach((dep) => {
 							const depIdent = dep.identifier();
-							const array = dependencies[depIdent] = dependencies[depIdent] || [];
-							if(array.indexOf(module) < 0)
-								array.push(module);
+							// if this was not yet initialized
+							// initialize it as an array containing the module and stop
+							if(!dependencies[depIdent]) {
+								dependencies[depIdent] = [module];
+								return;
+							}
+
+							// check if this module is known
+							// if not, add it to the dependencies for this identifier
+							if(dependencies[depIdent].indexOf(module) < 0)
+								dependencies[depIdent].push(module);
 						});
 					}
 					let changed = false;

--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -45,8 +45,7 @@ class FlagDependencyExportsPlugin {
 					if(exportDeps) {
 						exportDeps.forEach((dep) => {
 							const depIdent = dep.identifier();
-							let array = dependencies[depIdent];
-							if(!array) array = dependencies[depIdent] = [];
+							const array = dependencies[depIdent] = dependencies[depIdent] || [];
 							if(array.indexOf(module) < 0)
 								array.push(module);
 						});

--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -47,15 +47,16 @@ class FlagDependencyExportsPlugin {
 							const depIdent = dep.identifier();
 							// if this was not yet initialized
 							// initialize it as an array containing the module and stop
-							if(!dependencies[depIdent]) {
+							const array = dependencies[depIdent];
+							if(!array) {
 								dependencies[depIdent] = [module];
 								return;
 							}
 
 							// check if this module is known
 							// if not, add it to the dependencies for this identifier
-							if(dependencies[depIdent].indexOf(module) < 0)
-								dependencies[depIdent].push(module);
+							if(array.indexOf(module) < 0)
+								array.push(module);
 						});
 					}
 					let changed = false;

--- a/lib/HashedModuleIdsPlugin.js
+++ b/lib/HashedModuleIdsPlugin.js
@@ -3,6 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 "use strict";
+const createHash = require("crypto").createHash;
 
 class HashedModuleIdsPlugin {
 	constructor(options) {
@@ -20,16 +21,16 @@ class HashedModuleIdsPlugin {
 			compilation.plugin("before-module-ids", (modules) => {
 				modules.forEach((module) => {
 					if(module.id === null && module.libIdent) {
-						let id = module.libIdent({
+						const id = module.libIdent({
 							context: this.options.context || compiler.options.context
 						});
-						const hash = require("crypto").createHash(options.hashFunction);
+						const hash = createHash(options.hashFunction);
 						hash.update(id);
-						id = hash.digest(options.hashDigest);
+						const hashId = hash.digest(options.hashDigest);
 						let len = options.hashDigestLength;
-						while(usedIds.has(id.substr(0, len)))
+						while(usedIds.has(hashId.substr(0, len)))
 							len++;
-						module.id = id.substr(0, len);
+						module.id = hashId.substr(0, len);
 						usedIds.add(module.id);
 					}
 				});

--- a/lib/HotUpdateChunkTemplate.js
+++ b/lib/HotUpdateChunkTemplate.js
@@ -12,13 +12,13 @@ module.exports = class HotUpdateChunkTemplate extends Template {
 	}
 
 	render(id, modules, removedModules, hash, moduleTemplate, dependencyTemplates) {
-		let modulesSource = this.renderChunkModules({
+		const modulesSource = this.renderChunkModules({
 			id: id,
 			modules: modules,
 			removedModules: removedModules
 		}, moduleTemplate, dependencyTemplates);
-		let core = this.applyPluginsWaterfall("modules", modulesSource, modules, removedModules, moduleTemplate, dependencyTemplates);
-		let source = this.applyPluginsWaterfall("render", core, modules, removedModules, hash, id, moduleTemplate, dependencyTemplates);
+		const core = this.applyPluginsWaterfall("modules", modulesSource, modules, removedModules, moduleTemplate, dependencyTemplates);
+		const source = this.applyPluginsWaterfall("render", core, modules, removedModules, hash, id, moduleTemplate, dependencyTemplates);
 		return source;
 	}
 

--- a/lib/IgnorePlugin.js
+++ b/lib/IgnorePlugin.js
@@ -11,8 +11,8 @@ class IgnorePlugin {
 	}
 
 	apply(compiler) {
-		let resourceRegExp = this.resourceRegExp;
-		let contextRegExp = this.contextRegExp;
+		const resourceRegExp = this.resourceRegExp;
+		const contextRegExp = this.contextRegExp;
 		compiler.plugin("normal-module-factory", (nmf) => {
 			nmf.plugin("before-resolve", (result, callback) => {
 				if(!result) return callback();

--- a/lib/LoaderOptionsPlugin.js
+++ b/lib/LoaderOptionsPlugin.js
@@ -16,14 +16,14 @@ class LoaderOptionsPlugin {
 	}
 
 	apply(compiler) {
-		let options = this.options;
+		const options = this.options;
 		compiler.plugin("compilation", (compilation) => {
 			compilation.plugin("normal-module-loader", (context, module) => {
-				let resource = module.resource;
+				const resource = module.resource;
 				if(!resource) return;
-				let i = resource.indexOf("?");
+				const i = resource.indexOf("?");
 				if(ModuleFilenameHelpers.matchObject(options, i < 0 ? resource : resource.substr(0, i))) {
-					let filterSet = new Set(["include", "exclude", "test"]);
+					const filterSet = new Set(["include", "exclude", "test"]);
 					Object.keys(options)
 						.filter((key) => !filterSet.has(key))
 						.forEach((key) => context[key] = options[key]);

--- a/lib/LoaderTargetPlugin.js
+++ b/lib/LoaderTargetPlugin.js
@@ -10,9 +10,8 @@ class LoaderTargetPlugin {
 	}
 
 	apply(compiler) {
-		let target = this.target;
 		compiler.plugin("compilation", (compilation) => {
-			compilation.plugin("normal-module-loader", (loaderContext) => loaderContext.target = target);
+			compilation.plugin("normal-module-loader", (loaderContext) => loaderContext.target = this.target);
 		});
 	}
 }

--- a/lib/MainTemplate.js
+++ b/lib/MainTemplate.js
@@ -27,7 +27,7 @@ module.exports = class MainTemplate extends Template {
 	constructor(outputOptions) {
 		super(outputOptions);
 		this.plugin("startup", (source, chunk, hash) => {
-			let buf = [];
+			const buf = [];
 			if(chunk.entryModule) {
 				buf.push("// Load entry module and return exports");
 				buf.push("return " + this.renderRequireFunctionForModule(hash, chunk, JSON.stringify(chunk.entryModule.id)) +
@@ -36,13 +36,13 @@ module.exports = class MainTemplate extends Template {
 			return this.asString(buf);
 		});
 		this.plugin("render", (bootstrapSource, chunk, hash, moduleTemplate, dependencyTemplates) => {
-			let source = new ConcatSource();
+			const source = new ConcatSource();
 			source.add("/******/ (function(modules) { // webpackBootstrap\n");
 			source.add(new PrefixSource("/******/", bootstrapSource));
 			source.add("/******/ })\n");
 			source.add("/************************************************************************/\n");
 			source.add("/******/ (");
-			let modules = this.renderChunkModules(chunk, moduleTemplate, dependencyTemplates, "/******/ ");
+			const modules = this.renderChunkModules(chunk, moduleTemplate, dependencyTemplates, "/******/ ");
 			source.add(this.applyPluginsWaterfall("modules", modules, chunk, hash, moduleTemplate, dependencyTemplates));
 			source.add(")");
 			return source;
@@ -99,7 +99,7 @@ module.exports = class MainTemplate extends Template {
 			]);
 		});
 		this.plugin("require-extensions", (source, chunk, hash) => {
-			let buf = [];
+			const buf = [];
 			if(chunk.chunks.length > 0) {
 				buf.push("// This file contains only the entry chunk.");
 				buf.push("// The chunk loading function for additional chunks");
@@ -155,7 +155,7 @@ module.exports = class MainTemplate extends Template {
 			buf.push("// Object.prototype.hasOwnProperty.call");
 			buf.push(this.requireFn + ".o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };");
 
-			let publicPath = this.getPublicPath({
+			const publicPath = this.getPublicPath({
 				hash: hash
 			});
 			buf.push("");
@@ -168,7 +168,7 @@ module.exports = class MainTemplate extends Template {
 	}
 
 	render(hash, chunk, moduleTemplate, dependencyTemplates) {
-		let buf = [];
+		const buf = [];
 		buf.push(this.applyPluginsWaterfall("bootstrap", "", chunk, hash, moduleTemplate, dependencyTemplates));
 		buf.push(this.applyPluginsWaterfall("local-vars", "", chunk, hash));
 		buf.push("");
@@ -203,7 +203,7 @@ module.exports = class MainTemplate extends Template {
 	}
 
 	entryPointInChildren(chunk) {
-		let checkChildren = (chunk, alreadyCheckedChunks) => {
+		const checkChildren = (chunk, alreadyCheckedChunks) => {
 			return chunk.chunks.some((child) => {
 				if(alreadyCheckedChunks.indexOf(child) >= 0) return;
 				alreadyCheckedChunks.push(child);
@@ -230,7 +230,7 @@ module.exports = class MainTemplate extends Template {
 	}
 
 	useChunkHash(chunk) {
-		let paths = this.applyPluginsWaterfall("global-hash-paths", []);
+		const paths = this.applyPluginsWaterfall("global-hash-paths", []);
 		return !this.applyPluginsBailResult("global-hash", chunk, paths);
 	}
 };

--- a/lib/ModuleTemplate.js
+++ b/lib/ModuleTemplate.js
@@ -11,10 +11,10 @@ module.exports = class ModuleTemplate extends Template {
 		super(outputOptions);
 	}
 	render(module, dependencyTemplates, chunk) {
-		let moduleSource = module.source(dependencyTemplates, this.outputOptions, this.requestShortener);
-		moduleSource = this.applyPluginsWaterfall("module", moduleSource, module, chunk, dependencyTemplates);
-		moduleSource = this.applyPluginsWaterfall("render", moduleSource, module, chunk, dependencyTemplates);
-		return this.applyPluginsWaterfall("package", moduleSource, module, chunk, dependencyTemplates);
+		const moduleSource = module.source(dependencyTemplates, this.outputOptions, this.requestShortener);
+		const moduleSourcePostModule = this.applyPluginsWaterfall("module", moduleSource, module, chunk, dependencyTemplates);
+		const moduleSourcePostRender = this.applyPluginsWaterfall("render", moduleSourcePostModule, module, chunk, dependencyTemplates);
+		return this.applyPluginsWaterfall("package", moduleSourcePostRender, module, chunk, dependencyTemplates);
 	}
 	updateHash(hash) {
 		hash.update("1");

--- a/lib/NormalModuleReplacementPlugin.js
+++ b/lib/NormalModuleReplacementPlugin.js
@@ -13,8 +13,8 @@ class NormalModuleReplacementPlugin {
 	}
 
 	apply(compiler) {
-		let resourceRegExp = this.resourceRegExp;
-		let newResource = this.newResource;
+		const resourceRegExp = this.resourceRegExp;
+		const newResource = this.newResource;
 		compiler.plugin("normal-module-factory", (nmf) => {
 			nmf.plugin("before-resolve", (result, callback) => {
 				if(!result) return callback();

--- a/lib/RequestShortener.js
+++ b/lib/RequestShortener.js
@@ -9,29 +9,27 @@ const path = require("path");
 class RequestShortener {
 	constructor(directory) {
 		directory = directory.replace(/\\/g, "/");
-		let parentDirectory = path.dirname(directory);
 		if(/[\/\\]$/.test(directory)) directory = directory.substr(0, directory.length - 1);
 
 		if(directory) {
-			let currentDirectoryRegExp = directory.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
-			currentDirectoryRegExp = new RegExp("^" + currentDirectoryRegExp + "|(!)" + currentDirectoryRegExp, "g");
-			this.currentDirectoryRegExp = currentDirectoryRegExp;
+			const currentDirectoryRegExpString = directory.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+			this.currentDirectoryRegExp = new RegExp("^" + currentDirectoryRegExpString + "|(!)" + currentDirectoryRegExpString, "g");
 		}
 
-		if(/[\/\\]$/.test(parentDirectory)) parentDirectory = parentDirectory.substr(0, parentDirectory.length - 1);
+		const dirname = path.dirname(directory);
+		const endsWithSeperator = /[\/\\]$/.test(dirname);
+		const parentDirectory = endsWithSeperator ? dirname.substr(0, dirname.length - 1) : dirname;
 		if(parentDirectory && parentDirectory !== directory) {
-			let parentDirectoryRegExp = parentDirectory.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
-			parentDirectoryRegExp = new RegExp("^" + parentDirectoryRegExp + "|(!)" + parentDirectoryRegExp, "g");
-			this.parentDirectoryRegExp = parentDirectoryRegExp;
+			const parentDirectoryRegExpString = parentDirectory.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+			this.parentDirectoryRegExp = new RegExp("^" + parentDirectoryRegExpString + "|(!)" + parentDirectoryRegExpString, "g");
 		}
 
 		if(__dirname.length >= 2) {
-			let buildins = path.join(__dirname, "..").replace(/\\/g, "/");
-			let buildinsAsModule = this.currentDirectoryRegExp && this.currentDirectoryRegExp.test(buildins);
-			let buildinsRegExp = buildins.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
-			buildinsRegExp = new RegExp("^" + buildinsRegExp + "|(!)" + buildinsRegExp, "g");
+			const buildins = path.join(__dirname, "..").replace(/\\/g, "/");
+			const buildinsAsModule = this.currentDirectoryRegExp && this.currentDirectoryRegExp.test(buildins);
 			this.buildinsAsModule = buildinsAsModule;
-			this.buildinsRegExp = buildinsRegExp;
+			const buildinsRegExpString = buildins.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+			this.buildinsRegExp = new RegExp("^" + buildinsRegExpString + "|(!)" + buildinsRegExpString, "g");
 		}
 
 		this.nodeModulesRegExp = /\/node_modules\//g;

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -81,30 +81,17 @@ class Stats {
 		};
 
 		const sortByField = (field) => {
-			let callback;
 			if(!field) {
-				callback = () => 0;
-				return callback;
+				return () => 0;
 			}
 
-			if(field[0] === "!") {
-				field = field.substr(1);
-				callback = (a, b) => {
-					if(a[field] === null && b[field] === null) return 0;
-					if(a[field] === null) return 1;
-					if(b[field] === null) return -1;
-					if(a[field] === b[field]) return 0;
-					return a[field] < b[field] ? 1 : -1;
-				};
-			}
-			callback = (a, b) => {
+			return (a, b) => {
 				if(a[field] === null && b[field] === null) return 0;
 				if(a[field] === null) return 1;
 				if(b[field] === null) return -1;
 				if(a[field] === b[field]) return 0;
 				return a[field] < b[field] ? -1 : 1;
 			};
-			return callback;
 		};
 
 		const formatError = (e) => {

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -80,18 +80,16 @@ class Stats {
 			};
 		};
 
-		const sortByField = (field) => {
+		const sortByField = (field) => (a, b) => {
 			if(!field) {
-				return () => 0;
+				return 0;
 			}
 
-			return (a, b) => {
-				if(a[field] === null && b[field] === null) return 0;
-				if(a[field] === null) return 1;
-				if(b[field] === null) return -1;
-				if(a[field] === b[field]) return 0;
-				return a[field] < b[field] ? -1 : 1;
-			};
+			if(a[field] === null && b[field] === null) return 0;
+			if(a[field] === null) return 1;
+			if(b[field] === null) return -1;
+			if(a[field] === b[field]) return 0;
+			return a[field] < b[field] ? -1 : 1;
 		};
 
 		const formatError = (e) => {

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -24,11 +24,20 @@ class Stats {
 		return this.compilation.errors.length > 0;
 	}
 
+	// remove a prefixed "!" that can be specified to reverse sort order
 	normalizeFieldKey(field) {
 		if(field[0] === "!") {
 			return field.substr(1);
 		}
 		return field;
+	}
+
+	// if a field is prefixed by a "!" reverse sort order
+	sortOrderRegular(field) {
+		if(field[0] === "!") {
+			return false;
+		}
+		return true;
 	}
 
 	toJson(options, forToString) {
@@ -87,6 +96,14 @@ class Stats {
 			};
 		};
 
+		const sortByFieldAndOrder = (fieldKey, a, b) => {
+			if(a[fieldKey] === null && b[fieldKey] === null) return 0;
+			if(a[fieldKey] === null) return 1;
+			if(b[fieldKey] === null) return -1;
+			if(a[fieldKey] === b[fieldKey]) return 0;
+			return a[fieldKey] < b[fieldKey] ? -1 : 1;
+		};
+
 		const sortByField = (field) => (a, b) => {
 			if(!field) {
 				return 0;
@@ -94,11 +111,10 @@ class Stats {
 
 			const fieldKey = this.normalizeFieldKey(field);
 
-			if(a[fieldKey] === null && b[fieldKey] === null) return 0;
-			if(a[fieldKey] === null) return 1;
-			if(b[fieldKey] === null) return -1;
-			if(a[fieldKey] === b[fieldKey]) return 0;
-			return a[fieldKey] < b[fieldKey] ? -1 : 1;
+			// if a field is prefixed with a "!" the sort is reversed!
+			const sortIsRegular = this.sortOrderRegular(field);
+
+			return sortByFieldAndOrder(fieldKey, sortIsRegular ? a : b, sortIsRegular ? b : a);
 		};
 
 		const formatError = (e) => {

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -767,7 +767,7 @@ class Stats {
 		}
 		if(obj.children) {
 			obj.children.forEach(child => {
-				let childString = Stats.jsonToString(child, useColors);
+				const childString = Stats.jsonToString(child, useColors);
 				if(childString) {
 					if(child.name) {
 						colors.normal("Child ");
@@ -851,10 +851,9 @@ class Stats {
 			innerOptions = Stats.presetToOptions(innerOptions);
 		if(!innerOptions)
 			return options;
-		let childOptions = Object.assign({}, options);
+		const childOptions = Object.assign({}, options);
 		delete childOptions.children; // do not inherit children
-		childOptions = Object.assign(childOptions, innerOptions);
-		return childOptions;
+		return Object.assign(childOptions, innerOptions);
 	}
 }
 

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -24,6 +24,13 @@ class Stats {
 		return this.compilation.errors.length > 0;
 	}
 
+	normalizeFieldKey(field) {
+		if(field[0] === "!") {
+			return field.substr(1);
+		}
+		return field;
+	}
+
 	toJson(options, forToString) {
 		if(typeof options === "boolean" || typeof options === "string") {
 			options = Stats.presetToOptions(options);
@@ -85,11 +92,13 @@ class Stats {
 				return 0;
 			}
 
-			if(a[field] === null && b[field] === null) return 0;
-			if(a[field] === null) return 1;
-			if(b[field] === null) return -1;
-			if(a[field] === b[field]) return 0;
-			return a[field] < b[field] ? -1 : 1;
+			const fieldKey = this.normalizeFieldKey(field);
+
+			if(a[fieldKey] === null && b[fieldKey] === null) return 0;
+			if(a[fieldKey] === null) return 1;
+			if(b[fieldKey] === null) return -1;
+			if(a[fieldKey] === b[fieldKey]) return 0;
+			return a[fieldKey] < b[fieldKey] ? -1 : 1;
 		};
 
 		const formatError = (e) => {

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -8,7 +8,7 @@ const RequestShortener = require("./RequestShortener");
 const SizeFormatHelpers = require("./SizeFormatHelpers");
 const formatLocation = require("./formatLocation");
 
-const d = (v, def) => v === undefined ? def : v;
+const optionOrFallback = (optionValue, fallbackValue) => optionValue !== undefined ? optionValue : fallbackValue;
 
 class Stats {
 	constructor(compilation) {
@@ -39,37 +39,37 @@ class Stats {
 		}
 
 		const compilation = this.compilation;
-		const requestShortener = new RequestShortener(d(options.context, process.cwd()));
-		const showPerformance = d(options.performance, true);
-		const showHash = d(options.hash, true);
-		const showVersion = d(options.version, true);
-		const showTimings = d(options.timings, true);
-		const showAssets = d(options.assets, true);
-		const showEntrypoints = d(options.entrypoints, !forToString);
-		const showChunks = d(options.chunks, true);
-		const showChunkModules = d(options.chunkModules, !!forToString);
-		const showChunkOrigins = d(options.chunkOrigins, !forToString);
-		const showModules = d(options.modules, !forToString);
-		const showDepth = d(options.depth, !forToString);
-		const showCachedModules = d(options.cached, true);
-		const showCachedAssets = d(options.cachedAssets, true);
-		const showReasons = d(options.reasons, !forToString);
-		const showUsedExports = d(options.usedExports, !forToString);
-		const showProvidedExports = d(options.providedExports, !forToString);
-		const showChildren = d(options.children, true);
-		const showSource = d(options.source, !forToString);
-		const showErrors = d(options.errors, true);
-		const showErrorDetails = d(options.errorDetails, !forToString);
-		const showWarnings = d(options.warnings, true);
-		const showPublicPath = d(options.publicPath, !forToString);
-		const excludeModules = [].concat(d(options.exclude, [])).map(str => {
+		const requestShortener = new RequestShortener(optionOrFallback(options.context, process.cwd()));
+		const showPerformance = optionOrFallback(options.performance, true);
+		const showHash = optionOrFallback(options.hash, true);
+		const showVersion = optionOrFallback(options.version, true);
+		const showTimings = optionOrFallback(options.timings, true);
+		const showAssets = optionOrFallback(options.assets, true);
+		const showEntrypoints = optionOrFallback(options.entrypoints, !forToString);
+		const showChunks = optionOrFallback(options.chunks, true);
+		const showChunkModules = optionOrFallback(options.chunkModules, !!forToString);
+		const showChunkOrigins = optionOrFallback(options.chunkOrigins, !forToString);
+		const showModules = optionOrFallback(options.modules, !forToString);
+		const showDepth = optionOrFallback(options.depth, !forToString);
+		const showCachedModules = optionOrFallback(options.cached, true);
+		const showCachedAssets = optionOrFallback(options.cachedAssets, true);
+		const showReasons = optionOrFallback(options.reasons, !forToString);
+		const showUsedExports = optionOrFallback(options.usedExports, !forToString);
+		const showProvidedExports = optionOrFallback(options.providedExports, !forToString);
+		const showChildren = optionOrFallback(options.children, true);
+		const showSource = optionOrFallback(options.source, !forToString);
+		const showErrors = optionOrFallback(options.errors, true);
+		const showErrorDetails = optionOrFallback(options.errorDetails, !forToString);
+		const showWarnings = optionOrFallback(options.warnings, true);
+		const showPublicPath = optionOrFallback(options.publicPath, !forToString);
+		const excludeModules = [].concat(optionOrFallback(options.exclude, [])).map(str => {
 			if(typeof str !== "string") return str;
 			return new RegExp(`[\\\\/]${str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")}([\\\\/]|$|!|\\?)`);
 		});
-		const maxModules = d(options.maxModules, forToString ? 15 : Infinity);
-		const sortModules = d(options.modulesSort, "id");
-		const sortChunks = d(options.chunksSort, "id");
-		const sortAssets = d(options.assetsSort, "");
+		const maxModules = optionOrFallback(options.maxModules, forToString ? 15 : Infinity);
+		const sortModules = optionOrFallback(options.modulesSort, "id");
+		const sortChunks = optionOrFallback(options.chunksSort, "id");
+		const sortAssets = optionOrFallback(options.assetsSort, "");
 
 		const createModuleFilter = () => {
 			let i = 0;
@@ -344,7 +344,7 @@ class Stats {
 			options = {};
 		}
 
-		const useColors = d(options.colors, false);
+		const useColors = optionOrFallback(options.colors, false);
 
 		const obj = this.toJson(options, true);
 

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -398,26 +398,23 @@ class Stats {
 		};
 
 		const table = (array, align, splitter) => {
-			let row;
 			const rows = array.length;
-			let col;
 			const cols = array[0].length;
 			const colSizes = new Array(cols);
-			let value;
-			for(col = 0; col < cols; col++)
+			for(let col = 0; col < cols; col++)
 				colSizes[col] = 0;
-			for(row = 0; row < rows; row++) {
-				for(col = 0; col < cols; col++) {
-					value = `${getText(array, row, col)}`;
+			for(let row = 0; row < rows; row++) {
+				for(let col = 0; col < cols; col++) {
+					const value = `${getText(array, row, col)}`;
 					if(value.length > colSizes[col]) {
 						colSizes[col] = value.length;
 					}
 				}
 			}
-			for(row = 0; row < rows; row++) {
-				for(col = 0; col < cols; col++) {
+			for(let row = 0; row < rows; row++) {
+				for(let col = 0; col < cols; col++) {
 					const format = array[row][col].color;
-					value = `${getText(array, row, col)}`;
+					const value = `${getText(array, row, col)}`;
 					let l = value.length;
 					if(align[col] === "l")
 						format(value);

--- a/lib/Template.js
+++ b/lib/Template.js
@@ -57,7 +57,7 @@ module.exports = class Template extends Tapable {
 		}
 		str = str.trim();
 		if(!str) return "";
-		let ind = (str[0] === "\n" ? "" : prefix);
+		const ind = (str[0] === "\n" ? "" : prefix);
 		return ind + str.replace(/\n([^\n])/g, "\n" + prefix + "$1");
 	}
 

--- a/lib/UseStrictPlugin.js
+++ b/lib/UseStrictPlugin.js
@@ -10,10 +10,9 @@ class UseStrictPlugin {
 	apply(compiler) {
 		compiler.plugin("compilation", (compilation, params) => {
 			params.normalModuleFactory.plugin("parser", (parser) => {
-				let parserInstance = parser;
+				const parserInstance = parser;
 				parser.plugin("program", (ast) => {
-					let firstNode = ast.body[0];
-					let dep;
+					const firstNode = ast.body[0];
 					if(firstNode &&
 						firstNode.type === "ExpressionStatement" &&
 						firstNode.expression.type === "Literal" &&
@@ -21,7 +20,7 @@ class UseStrictPlugin {
 						// Remove "use strict" expression. It will be added later by the renderer again.
 						// This is necessary in order to not break the strict mode when webpack prepends code.
 						// @see https://github.com/webpack/webpack/issues/1970
-						dep = new ConstDependency("", firstNode.range);
+						const dep = new ConstDependency("", firstNode.range);
 						dep.loc = firstNode.loc;
 						parserInstance.state.current.addDependency(dep);
 						parserInstance.state.module.strict = true;

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -43,7 +43,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		});
 		this.set("output.filename", "[name].js");
 		this.set("output.chunkFilename", "make", (options) => {
-			let filename = options.output.filename;
+			const filename = options.output.filename;
 			return filename.indexOf("[name]") >= 0 ? filename.replace("[name]", "[id]") : "[id]." + filename;
 		});
 		this.set("output.library", "");

--- a/lib/dependencies/AMDRequireDependenciesBlock.js
+++ b/lib/dependencies/AMDRequireDependenciesBlock.js
@@ -26,7 +26,7 @@ module.exports = class AMDRequireDependenciesBlock extends AsyncDependenciesBloc
 		} else {
 			this.range = expr.range;
 		}
-		let dep = new AMDRequireDependency(this);
+		const dep = new AMDRequireDependency(this);
 		dep.loc = loc;
 		this.addDependency(dep);
 	}

--- a/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
@@ -48,10 +48,9 @@ class AMDRequireDependenciesBlockParserPlugin {
 		parser.plugin("call require", (expr) => {
 			let param;
 			let dep;
-			let old;
 			let result;
 
-			old = parser.state.current;
+			const old = parser.state.current;
 
 			if(expr.arguments.length >= 1) {
 				param = parser.evaluateExpression(expr.arguments[0]);

--- a/lib/dependencies/CommonJsRequireDependencyParserPlugin.js
+++ b/lib/dependencies/CommonJsRequireDependencyParserPlugin.js
@@ -30,12 +30,12 @@ class CommonJsRequireDependencyParserPlugin {
 		});
 		parser.plugin("call require", (expr) => {
 			if(expr.arguments.length !== 1) return;
-			let localModule, dep;
+			let localModule;
 			const param = parser.evaluateExpression(expr.arguments[0]);
 			if(param.isConditional()) {
 				let isExpression = false;
 				const prevLength = parser.state.current.dependencies.length;
-				dep = new RequireHeaderDependency(expr.callee.range);
+				const dep = new RequireHeaderDependency(expr.callee.range);
 				dep.loc = expr.loc;
 				parser.state.current.addDependency(dep);
 				param.options.forEach(function(param) {
@@ -51,7 +51,7 @@ class CommonJsRequireDependencyParserPlugin {
 				}
 			}
 			if(param.isString() && (localModule = LocalModulesHelpers.getLocalModule(parser.state, param.string))) {
-				dep = new LocalModuleDependency(localModule, expr.range);
+				const dep = new LocalModuleDependency(localModule, expr.range);
 				dep.loc = expr.loc;
 				parser.state.current.addDependency(dep);
 				return true;
@@ -60,7 +60,7 @@ class CommonJsRequireDependencyParserPlugin {
 				if(result === undefined) {
 					parser.applyPluginsBailResult("call require:commonjs:context", expr, param);
 				} else {
-					dep = new RequireHeaderDependency(expr.callee.range);
+					const dep = new RequireHeaderDependency(expr.callee.range);
 					dep.loc = expr.loc;
 					parser.state.current.addDependency(dep);
 				}

--- a/lib/dependencies/ContextDependencyTemplateAsId.js
+++ b/lib/dependencies/ContextDependencyTemplateAsId.js
@@ -7,8 +7,9 @@
 class ContextDependencyTemplateAsId {
 
 	apply(dep, source, outputOptions, requestShortener) {
-		let comment = "";
-		if(outputOptions.pathinfo) comment = "/*! " + requestShortener.shorten(dep.request) + " */ ";
+		const comment = outputOptions.pathinfo ?
+			"/*! " + requestShortener.shorten(dep.request) + " */ " : "";
+
 		if(dep.module && dep.module.dependencies && dep.module.dependencies.length > 0) {
 			if(dep.valueRange) {
 				if(Array.isArray(dep.replaces)) {

--- a/lib/dependencies/ContextDependencyTemplateAsRequireCall.js
+++ b/lib/dependencies/ContextDependencyTemplateAsRequireCall.js
@@ -7,8 +7,9 @@
 class ContextDependencyTemplateAsRequireCall {
 
 	apply(dep, source, outputOptions, requestShortener) {
-		let comment = "";
-		if(outputOptions.pathinfo) comment = "/*! " + requestShortener.shorten(dep.request) + " */ ";
+		const comment = outputOptions.pathinfo ?
+			"/*! " + requestShortener.shorten(dep.request) + " */ " : "";
+
 		const containsDeps = dep.module && dep.module.dependencies && dep.module.dependencies.length > 0;
 		const isAsync = dep.module && dep.module.async;
 		if(dep.module && (isAsync || containsDeps)) {

--- a/lib/dependencies/HarmonyDetectionParserPlugin.js
+++ b/lib/dependencies/HarmonyDetectionParserPlugin.js
@@ -13,7 +13,7 @@ module.exports = class HarmonyDetectionParserPlugin {
 				return /^(Import|Export).*Declaration$/.test(statement.type);
 			});
 			if(isHarmony) {
-				let module = parser.state.module;
+				const module = parser.state.module;
 				const dep = new HarmonyCompatibilityDependency(module);
 				dep.loc = {
 					start: {
@@ -42,13 +42,13 @@ module.exports = class HarmonyDetectionParserPlugin {
 		});
 
 		function skipInHarmony() {
-			let module = this.state.module;
+			const module = this.state.module;
 			if(module && module.meta && module.meta.harmonyModule)
 				return true;
 		}
 
 		function nullInHarmony() {
-			let module = this.state.module;
+			const module = this.state.module;
 			if(module && module.meta && module.meta.harmonyModule)
 				return null;
 		}

--- a/lib/dependencies/ImportDependenciesBlock.js
+++ b/lib/dependencies/ImportDependenciesBlock.js
@@ -10,7 +10,7 @@ module.exports = class ImportDependenciesBlock extends AsyncDependenciesBlock {
 	constructor(request, range, module, loc) {
 		super(null, module, loc);
 		this.range = range;
-		let dep = new ImportDependency(request, this);
+		const dep = new ImportDependency(request, this);
 		dep.loc = loc;
 		this.addDependency(dep);
 	}

--- a/lib/dependencies/ImportParserPlugin.js
+++ b/lib/dependencies/ImportParserPlugin.js
@@ -18,14 +18,13 @@ class ImportParserPlugin {
 		parser.plugin(["call System.import", "import-call"], (expr) => {
 			if(expr.arguments.length !== 1)
 				throw new Error("Incorrect number of arguments provided to 'import(module: string) -> Promise'.");
-			let dep;
 			const param = parser.evaluateExpression(expr.arguments[0]);
 			if(param.isString()) {
 				const depBlock = new ImportDependenciesBlock(param.string, expr.range, parser.state.module, expr.loc);
 				parser.state.current.addBlock(depBlock);
 				return true;
 			} else {
-				dep = ContextDependencyHelpers.create(ImportContextDependency, expr.range, param, expr, options);
+				const dep = ContextDependencyHelpers.create(ImportContextDependency, expr.range, param, expr, options);
 				if(!dep) return;
 				dep.loc = expr.loc;
 				dep.optional = !!parser.scope.inTry;

--- a/lib/dependencies/ModuleDependencyTemplateAsId.js
+++ b/lib/dependencies/ModuleDependencyTemplateAsId.js
@@ -8,8 +8,8 @@ class ModuleDependencyTemplateAsId {
 
 	apply(dep, source, outputOptions, requestShortener) {
 		if(!dep.range) return;
-		let comment = "";
-		if(outputOptions.pathinfo) comment = `/*! ${requestShortener.shorten(dep.request)} */ `;
+		const comment = outputOptions.pathinfo ?
+			`/*! ${requestShortener.shorten(dep.request)} */ ` : "";
 		let content;
 		if(dep.module)
 			content = comment + JSON.stringify(dep.module.id);

--- a/lib/dependencies/ModuleDependencyTemplateAsRequireId.js
+++ b/lib/dependencies/ModuleDependencyTemplateAsRequireId.js
@@ -8,8 +8,8 @@ class ModuleDependencyTemplateAsRequireId {
 
 	apply(dep, source, outputOptions, requestShortener) {
 		if(!dep.range) return;
-		let comment = "";
-		if(outputOptions.pathinfo) comment = `/*! ${requestShortener.shorten(dep.request)} */ `;
+		const comment = outputOptions.pathinfo ?
+			`/*! ${requestShortener.shorten(dep.request)} */ ` : "";
 		let content;
 		if(dep.module)
 			content = `__webpack_require__(${comment}${JSON.stringify(dep.module.id)})`;

--- a/lib/dependencies/RequireEnsureDependenciesBlock.js
+++ b/lib/dependencies/RequireEnsureDependenciesBlock.js
@@ -13,7 +13,7 @@ module.exports = class RequireEnsureDependenciesBlock extends AsyncDependenciesB
 		const bodyRange = fnExpression && fnExpression.body && fnExpression.body.range;
 		this.range = bodyRange && [bodyRange[0] + 1, bodyRange[1] - 1] || null;
 		this.chunkNameRange = chunkNameRange;
-		let dep = new RequireEnsureDependency(this);
+		const dep = new RequireEnsureDependency(this);
 		dep.loc = loc;
 		this.addDependency(dep);
 	}

--- a/lib/dependencies/RequireResolveDependencyParserPlugin.js
+++ b/lib/dependencies/RequireResolveDependencyParserPlugin.js
@@ -25,7 +25,6 @@ class RequireResolveDependencyParserPlugin {
 		parser.plugin("call require.resolve(Weak)", (expr, weak) => {
 			if(expr.arguments.length !== 1) return;
 			const param = parser.evaluateExpression(expr.arguments[0]);
-			let dep;
 			if(param.isConditional()) {
 				param.options.forEach((option) => {
 					const result = parser.applyPluginsBailResult("call require.resolve(Weak):item", expr, option, weak);
@@ -33,7 +32,7 @@ class RequireResolveDependencyParserPlugin {
 						parser.applyPluginsBailResult("call require.resolve(Weak):context", expr, option, weak);
 					}
 				});
-				dep = new RequireResolveHeaderDependency(expr.callee.range);
+				const dep = new RequireResolveHeaderDependency(expr.callee.range);
 				dep.loc = expr.loc;
 				parser.state.current.addDependency(dep);
 				return true;
@@ -42,7 +41,7 @@ class RequireResolveDependencyParserPlugin {
 				if(result === undefined) {
 					parser.applyPluginsBailResult("call require.resolve(Weak):context", expr, param, weak);
 				}
-				dep = new RequireResolveHeaderDependency(expr.callee.range);
+				const dep = new RequireResolveHeaderDependency(expr.callee.range);
 				dep.loc = expr.loc;
 				parser.state.current.addDependency(dep);
 				return true;

--- a/lib/optimize/AggressiveMergingPlugin.js
+++ b/lib/optimize/AggressiveMergingPlugin.js
@@ -13,7 +13,7 @@ class AggressiveMergingPlugin {
 	}
 
 	apply(compiler) {
-		let options = this.options;
+		const options = this.options;
 		const minSizeReduce = options.minSizeReduce || 1.5;
 
 		function getParentsWeight(chunk) {

--- a/lib/optimize/AggressiveSplittingPlugin.js
+++ b/lib/optimize/AggressiveSplittingPlugin.js
@@ -8,7 +8,7 @@ let path = require("path");
 
 function makeRelative(context) {
 	return function(module) {
-		let identifier = module.identifier();
+		const identifier = module.identifier();
 		return identifier.split("|").map((str) => {
 			return str.split("!").map((str) => {
 				return path.relative(context, str);
@@ -42,7 +42,7 @@ function isNotAEntryModule(entryModule) {
 }
 
 function copyWithReason(obj) {
-	let newObj = {};
+	const newObj = {};
 	Object.keys(obj).forEach((key) => {
 		newObj[key] = obj[key];
 	});
@@ -62,18 +62,17 @@ class AggressiveSplittingPlugin {
 	apply(compiler) {
 		compiler.plugin("compilation", (compilation) => {
 			compilation.plugin("optimize-chunks-advanced", (chunks) => {
-				let i, chunk, newChunk;
 				const savedSplits = compilation.records && compilation.records.aggressiveSplits || [];
-				let usedSplits = savedSplits;
-				if(compilation._aggressiveSplittingSplits)
-					usedSplits = usedSplits.concat(compilation._aggressiveSplittingSplits);
+				const usedSplits = compilation._aggressiveSplittingSplits ?
+					usedSplits.concat(compilation._aggressiveSplittingSplits) : savedSplits;
+
 				const minSize = this.options.minSize;
 				const maxSize = this.options.maxSize;
 				// 1. try to restore to recorded splitting
 				for(let j = 0; j < usedSplits.length; j++) {
 					const splitData = usedSplits[j];
-					for(i = 0; i < chunks.length; i++) {
-						chunk = chunks[i];
+					for(let i = 0; i < chunks.length; i++) {
+						const chunk = chunks[i];
 						const chunkModuleNames = chunk.modules.map(makeRelative(compiler.context));
 
 						if(chunkModuleNames.length < splitData.modules)
@@ -85,7 +84,7 @@ class AggressiveSplittingPlugin {
 						if(hasAllModules) {
 							if(chunkModuleNames.length > splitData.modules.length) {
 								const selectedModules = moduleIndicies.map(toChunkModuleIndices(chunk.modules));
-								newChunk = compilation.addChunk();
+								const newChunk = compilation.addChunk();
 								selectedModules.forEach(moveModuleBetween(chunk, newChunk));
 								chunk.split(newChunk);
 								chunk.name = null;
@@ -106,11 +105,11 @@ class AggressiveSplittingPlugin {
 					}
 				}
 				// 2. for any other chunk which isn't splitted yet, split it
-				for(i = 0; i < chunks.length; i++) {
-					chunk = chunks[i];
+				for(let i = 0; i < chunks.length; i++) {
+					const chunk = chunks[i];
 					const size = chunk.size(this.options);
 					if(size > maxSize && chunk.modules.length > 1) {
-						newChunk = compilation.addChunk();
+						const newChunk = compilation.addChunk();
 						const modules = chunk.modules
 							.filter(isNotAEntryModule(chunk.entryModule))
 							.sort((a, b) => {
@@ -172,7 +171,7 @@ class AggressiveSplittingPlugin {
 							id: chunk.id
 						});
 					} else {
-						let splitData = records.aggressiveSplits[chunk._fromAggressiveSplittingIndex];
+						const splitData = records.aggressiveSplits[chunk._fromAggressiveSplittingIndex];
 						if(splitData.hash !== chunk.hash || incorrectSize) {
 							if(chunk._fromAggressiveSplitting) {
 								chunk._aggressiveSplittingInvalid = true;

--- a/lib/optimize/AggressiveSplittingPlugin.js
+++ b/lib/optimize/AggressiveSplittingPlugin.js
@@ -64,7 +64,7 @@ class AggressiveSplittingPlugin {
 			compilation.plugin("optimize-chunks-advanced", (chunks) => {
 				const savedSplits = compilation.records && compilation.records.aggressiveSplits || [];
 				const usedSplits = compilation._aggressiveSplittingSplits ?
-					usedSplits.concat(compilation._aggressiveSplittingSplits) : savedSplits;
+					savedSplits.concat(compilation._aggressiveSplittingSplits) : savedSplits;
 
 				const minSize = this.options.minSize;
 				const maxSize = this.options.maxSize;

--- a/lib/optimize/ChunkModuleIdRangePlugin.js
+++ b/lib/optimize/ChunkModuleIdRangePlugin.js
@@ -8,10 +8,10 @@ class ChunkModuleIdRangePlugin {
 		this.options = options;
 	}
 	apply(compiler) {
-		let options = this.options;
+		const options = this.options;
 		compiler.plugin("compilation", (compilation) => {
 			compilation.plugin("module-ids", (modules) => {
-				let chunk = this.chunks.filter((chunk) => {
+				const chunk = this.chunks.filter((chunk) => {
 					return chunk.name === options.name;
 				})[0];
 				if(!chunk) throw new Error("ChunkModuleIdRangePlugin: Chunk with name '" + options.name + "' was not found");
@@ -41,7 +41,7 @@ class ChunkModuleIdRangePlugin {
 				}
 				console.log(chunkModules);
 				for(let i = 0; i < chunkModules.length; i++) {
-					let m = chunkModules[i];
+					const m = chunkModules[i];
 					if(m.id === null) {
 						m.id = currentId++;
 					}

--- a/lib/optimize/ChunkModuleIdRangePlugin.js
+++ b/lib/optimize/ChunkModuleIdRangePlugin.js
@@ -39,7 +39,7 @@ class ChunkModuleIdRangePlugin {
 						return m.chunks.indexOf(chunk) >= 0;
 					});
 				}
-				console.log(chunkModules);
+
 				for(let i = 0; i < chunkModules.length; i++) {
 					const m = chunkModules[i];
 					if(m.id === null) {

--- a/lib/optimize/EnsureChunkConditionsPlugin.js
+++ b/lib/optimize/EnsureChunkConditionsPlugin.js
@@ -15,7 +15,7 @@ class EnsureChunkConditionsPlugin {
 						if(!module.chunkCondition) return;
 						if(!module.chunkCondition(chunk)) {
 							const usedChunks = module._EnsureChunkConditionsPlugin_usedChunks = (module._EnsureChunkConditionsPlugin_usedChunks || []).concat(chunk);
-							let newChunks = [];
+							const newChunks = [];
 							chunk.parents.forEach((parent) => {
 								if(usedChunks.indexOf(parent) < 0) {
 									parent.addModule(module);

--- a/lib/optimize/LimitChunkCountPlugin.js
+++ b/lib/optimize/LimitChunkCountPlugin.js
@@ -21,31 +21,31 @@ class LimitChunkCountPlugin {
 				if(chunks.length <= maxChunks) return;
 
 				if(chunks.length > maxChunks) {
-					let combinations = [];
-					chunks.forEach((a, idx) => {
+					const sortedExtendedPairCombinations = chunks.reduce((combinations, a, idx) => {
+						// create combination pairs
 						for(let i = 0; i < idx; i++) {
 							const b = chunks[i];
 							combinations.push([b, a]);
 						}
-					});
-
-					combinations.forEach((pair) => {
+						return combinations;
+					}, []).map((pair) => {
+						// extend combination pairs with size and integrated size
 						const a = pair[0].size(options);
 						const b = pair[1].size(options);
 						const ab = pair[0].integratedSize(pair[1], options);
-						pair.unshift(a + b - ab, ab);
-						pair.push(a, b);
-					});
-					combinations = combinations.filter((pair) => {
-						return pair[1] !== false;
-					});
-					combinations.sort((a, b) => {
+						return [a + b - ab, ab, pair[0], pair[1], a, b];
+					}).filter((extendedPair) => {
+						// filter pairs that do not have an integratedSize
+						// meaning they can NOT be integrated!
+						return extendedPair[1] !== false;
+					}).sort((a, b) => { // sadly javascript does an inplace sort here
+						// sort them by size
 						const diff = b[0] - a[0];
 						if(diff !== 0) return diff;
 						return a[1] - b[1];
 					});
 
-					const pair = combinations[0];
+					const pair = sortedExtendedPairCombinations[0];
 
 					if(pair && pair[2].integrate(pair[3], "limit")) {
 						chunks.splice(chunks.indexOf(pair[3]), 1);

--- a/lib/optimize/MinChunkSizePlugin.js
+++ b/lib/optimize/MinChunkSizePlugin.js
@@ -17,43 +17,44 @@ class MinChunkSizePlugin {
 		const minChunkSize = options.minChunkSize;
 		compiler.plugin("compilation", (compilation) => {
 			compilation.plugin("optimize-chunks-advanced", (chunks) => {
-
-				let combinations = [];
-				chunks.forEach((a, idx) => {
-					for(let i = 0; i < idx; i++) {
-						const b = chunks[i];
-						combinations.push([b, a]);
-					}
-				});
-
 				const equalOptions = {
 					chunkOverhead: 1,
 					entryChunkMultiplicator: 1
 				};
-				combinations = combinations.filter((pair) => {
-					return pair[0].size(equalOptions) < minChunkSize || pair[1].size(equalOptions) < minChunkSize;
-				});
 
-				combinations.forEach((pair) => {
+				const sortedSizeFilteredExtendedPairCombinations = chunks.reduce((combinations, a, idx) => {
+					// create combination pairs
+					for(let i = 0; i < idx; i++) {
+						const b = chunks[i];
+						combinations.push([b, a]);
+					}
+					return combinations;
+				}, []).filter((pair) => {
+					// check if one of the chunks sizes is smaller than the minChunkSize
+					const p0SmallerThanMinChunkSize = pair[0].size(equalOptions) < minChunkSize;
+					const p1mallerThanMinChunkSize = pair[1].size(equalOptions) < minChunkSize;
+					return p0SmallerThanMinChunkSize || p1mallerThanMinChunkSize;
+				}).map((pair) => {
+					// extend combination pairs with size and integrated size
 					const a = pair[0].size(options);
 					const b = pair[1].size(options);
 					const ab = pair[0].integratedSize(pair[1], options);
 					pair.unshift(a + b - ab, ab);
-				});
-
-				combinations = combinations.filter((pair) => {
+					return [a + b - ab, ab, pair[0], pair[1]];
+				}).filter((pair) => {
+					// filter pairs that do not have an integratedSize
+					// meaning they can NOT be integrated!
 					return pair[1] !== false;
-				});
-
-				if(combinations.length === 0) return;
-
-				combinations.sort((a, b) => {
+				}).sort((a, b) => { // sadly javascript does an inplace sort here
+					// sort by size
 					const diff = b[0] - a[0];
 					if(diff !== 0) return diff;
 					return a[1] - b[1];
 				});
 
-				const pair = combinations[0];
+				if(sortedSizeFilteredExtendedPairCombinations.length === 0) return;
+
+				const pair = sortedSizeFilteredExtendedPairCombinations[0];
 
 				pair[2].integrate(pair[3], "min-size");
 				chunks.splice(chunks.indexOf(pair[3]), 1);

--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -19,10 +19,10 @@ class UglifyJsPlugin {
 	}
 
 	apply(compiler) {
-		let options = this.options;
+		const options = this.options;
 		options.test = options.test || /\.js($|\?)/i;
 
-		let requestShortener = new RequestShortener(compiler.context);
+		const requestShortener = new RequestShortener(compiler.context);
 		compiler.plugin("compilation", (compilation) => {
 			if(options.sourceMap) {
 				compilation.plugin("build-module", (module) => {
@@ -31,16 +31,16 @@ class UglifyJsPlugin {
 				});
 			}
 			compilation.plugin("optimize-chunk-assets", (chunks, callback) => {
-				let files = [];
+				const files = [];
 				chunks.forEach((chunk) => files.push.apply(files, chunk.files));
 				files.push.apply(files, compilation.additionalChunkAssets);
 				const filterdFiles = files.filter(ModuleFilenameHelpers.matchObject.bind(undefined, options));
 				filterdFiles.forEach((file) => {
-					let oldWarnFunction = uglify.AST_Node.warn_function;
-					let warnings = [];
+					const oldWarnFunction = uglify.AST_Node.warn_function;
+					const warnings = [];
 					let sourceMap;
 					try {
-						let asset = compilation.assets[file];
+						const asset = compilation.assets[file];
 						if(asset.__UglifyJsPlugin) {
 							compilation.assets[file] = asset.__UglifyJsPlugin;
 							return;
@@ -49,7 +49,7 @@ class UglifyJsPlugin {
 						let inputSourceMap;
 						if(options.sourceMap) {
 							if(asset.sourceAndMap) {
-								let sourceAndMap = asset.sourceAndMap();
+								const sourceAndMap = asset.sourceAndMap();
 								inputSourceMap = sourceAndMap.map;
 								input = sourceAndMap.source;
 							} else {
@@ -58,10 +58,10 @@ class UglifyJsPlugin {
 							}
 							sourceMap = new SourceMapConsumer(inputSourceMap);
 							uglify.AST_Node.warn_function = (warning) => { // eslint-disable-line camelcase
-								let match = /\[.+:([0-9]+),([0-9]+)\]/.exec(warning);
-								let line = +match[1];
-								let column = +match[2];
-								let original = sourceMap.originalPositionFor({
+								const match = /\[.+:([0-9]+),([0-9]+)\]/.exec(warning);
+								const line = +match[1];
+								const column = +match[2];
+								const original = sourceMap.originalPositionFor({
 									line: line,
 									column: column
 								});
@@ -81,7 +81,7 @@ class UglifyJsPlugin {
 						});
 						if(options.compress !== false) {
 							ast.figure_out_scope();
-							let compress = uglify.Compressor(options.compress || {
+							const compress = uglify.Compressor(options.compress || {
 								warnings: false
 							}); // eslint-disable-line new-cap
 							ast = ast.transform(compress);
@@ -94,7 +94,7 @@ class UglifyJsPlugin {
 								uglify.mangle_properties(ast, options.mangle.props);
 							}
 						}
-						let output = {};
+						const output = {};
 						output.comments = Object.prototype.hasOwnProperty.call(options, "comments") ? options.comments : /^\**!|@preserve|@license/;
 						output.beautify = options.beautify;
 						for(let k in options.output) {
@@ -120,7 +120,7 @@ class UglifyJsPlugin {
 						}
 					} catch(err) {
 						if(err.line) {
-							let original = sourceMap && sourceMap.originalPositionFor({
+							const original = sourceMap && sourceMap.originalPositionFor({
 								line: err.line,
 								column: err.col
 							});

--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -108,13 +108,13 @@ class UglifyJsPlugin {
 							});
 							output.source_map = map; // eslint-disable-line camelcase
 						}
-						let stream = uglify.OutputStream(output); // eslint-disable-line new-cap
+						const stream = uglify.OutputStream(output); // eslint-disable-line new-cap
 						ast.print(stream);
 						if(map) map = map + "";
-						stream = stream + "";
+						const stringifiedStream = stream + "";
 						asset.__UglifyJsPlugin = compilation.assets[file] = (map ?
-							new SourceMapSource(stream, file, JSON.parse(map), input, inputSourceMap) :
-							new RawSource(stream));
+							new SourceMapSource(stringifiedStream, file, JSON.parse(map), input, inputSourceMap) :
+							new RawSource(stringifiedStream));
 						if(warnings.length > 0) {
 							compilation.warnings.push(new Error(file + " from UglifyJs\n" + warnings.join("\n")));
 						}

--- a/lib/optimize/UglifyJsPlugin.js
+++ b/lib/optimize/UglifyJsPlugin.js
@@ -34,8 +34,8 @@ class UglifyJsPlugin {
 				let files = [];
 				chunks.forEach((chunk) => files.push.apply(files, chunk.files));
 				files.push.apply(files, compilation.additionalChunkAssets);
-				files = files.filter(ModuleFilenameHelpers.matchObject.bind(undefined, options));
-				files.forEach((file) => {
+				const filterdFiles = files.filter(ModuleFilenameHelpers.matchObject.bind(undefined, options));
+				filterdFiles.forEach((file) => {
 					let oldWarnFunction = uglify.AST_Node.warn_function;
 					let warnings = [];
 					let sourceMap;

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -1,89 +1,104 @@
-it("should define FALSE", function() {
-	FALSE.should.be.eql(false);
-	(typeof TRUE).should.be.eql("boolean");
-	var x = require(FALSE ? "fail" : "./a");
-	var y = FALSE ? require("fail") : require("./a");
-});
+/* globals define, it, should */
+define("DefinePlugin", function() {
+	it("should define FALSE", function() {
+		FALSE.should.be.eql(false);
+		(typeof TRUE).should.be.eql("boolean");
+		var x = require(FALSE ? "fail" : "./a");
+		var y = FALSE ? require("fail") : require("./a");
+	});
 
-it("should define CODE", function() {
-	CODE.should.be.eql(3);
-	(typeof CODE).should.be.eql("number");
-	if(CODE !== 3) require("fail");
-	if(typeof CODE !== "number") require("fail");
-});
-it("should define FUNCTION", function() {
-	(FUNCTION(5)).should.be.eql(6);
-	(typeof FUNCTION).should.be.eql("function");
-	if(typeof FUNCTION !== "function") require("fail");
-});
-it("should define UNDEFINED", function() {
-	(typeof UNDEFINED).should.be.eql("undefined");
-	if(typeof UNDEFINED !== "undefined") require("fail");
-});
-it("should define REGEXP", function() {
-	REGEXP.toString().should.be.eql("/abc/i");
-	(typeof REGEXP).should.be.eql("object");
-	if(typeof REGEXP !== "object") require("fail");
-});
-it("should define OBJECT", function() {
-	var o = OBJECT;
-	o.SUB.FUNCTION(10).should.be.eql(11);
-});
-it("should define OBJECT.SUB.CODE", function() {
-	(typeof OBJECT.SUB.CODE).should.be.eql("number");
-	OBJECT.SUB.CODE.should.be.eql(3);
-	if(OBJECT.SUB.CODE !== 3) require("fail");
-	if(typeof OBJECT.SUB.CODE !== "number") require("fail");
+	it("should define CODE", function() {
+		CODE.should.be.eql(3);
+		(typeof CODE).should.be.eql("number");
+		if(CODE !== 3) require("fail");
+		if(typeof CODE !== "number") require("fail");
+	});
+	it("should define FUNCTION", function() {
+		(FUNCTION(5)).should.be.eql(6);
+		(typeof FUNCTION).should.be.eql("function");
+		if(typeof FUNCTION !== "function") require("fail");
+	});
+	it("should define UNDEFINED", function() {
+		(typeof UNDEFINED).should.be.eql("undefined");
+		if(typeof UNDEFINED !== "undefined") require("fail");
+	});
+	it("should define REGEXP", function() {
+		REGEXP.toString().should.be.eql("/abc/i");
+		(typeof REGEXP).should.be.eql("object");
+		if(typeof REGEXP !== "object") require("fail");
+	});
+	it("should define OBJECT", function() {
+		var o = OBJECT;
+		o.SUB.FUNCTION(10).should.be.eql(11);
+	});
+	it("should define OBJECT.SUB.CODE", function() {
+		(typeof OBJECT.SUB.CODE).should.be.eql("number");
+		OBJECT.SUB.CODE.should.be.eql(3);
+		if(OBJECT.SUB.CODE !== 3) require("fail");
+		if(typeof OBJECT.SUB.CODE !== "number") require("fail");
 
-	(function(sub) {
-		// should not crash
-		sub.CODE.should.be.eql(3);
-	}(OBJECT.SUB));
-});
-it("should define OBJECT.SUB.STRING", function() {
-	(typeof OBJECT.SUB.STRING).should.be.eql("string");
-	OBJECT.SUB.STRING.should.be.eql("string");
-	if(OBJECT.SUB.STRING !== "string") require("fail");
-	if(typeof OBJECT.SUB.STRING !== "string") require("fail");
+		(function(sub) {
+			// should not crash
+			sub.CODE.should.be.eql(3);
+		}(OBJECT.SUB));
+	});
+	it("should define OBJECT.SUB.STRING", function() {
+		(typeof OBJECT.SUB.STRING).should.be.eql("string");
+		OBJECT.SUB.STRING.should.be.eql("string");
+		if(OBJECT.SUB.STRING !== "string") require("fail");
+		if(typeof OBJECT.SUB.STRING !== "string") require("fail");
 
-	(function(sub) {
-		// should not crash
-		sub.STRING.should.be.eql("string");
-	}(OBJECT.SUB));
-});
-it("should define process.env.DEFINED_NESTED_KEY", function() {
-	(process.env.DEFINED_NESTED_KEY).should.be.eql(5);
-	(typeof process.env.DEFINED_NESTED_KEY).should.be.eql("number");
-	if(process.env.DEFINED_NESTED_KEY !== 5) require("fail");
-	if(typeof process.env.DEFINED_NESTED_KEY !== "number") require("fail");
+		(function(sub) {
+			// should not crash
+			sub.STRING.should.be.eql("string");
+		}(OBJECT.SUB));
+	});
+	it("should define process.env.DEFINED_NESTED_KEY", function() {
+		(process.env.DEFINED_NESTED_KEY).should.be.eql(5);
+		(typeof process.env.DEFINED_NESTED_KEY).should.be.eql("number");
+		if(process.env.DEFINED_NESTED_KEY !== 5) require("fail");
+		if(typeof process.env.DEFINED_NESTED_KEY !== "number") require("fail");
 
-	var x = process.env.DEFINED_NESTED_KEY;
-	x.should.be.eql(5);
-
-	var indirect = process.env;
-	(indirect.DEFINED_NESTED_KEY).should.be.eql(5);
-
-	(function(env) {
-		(env.DEFINED_NESTED_KEY).should.be.eql(5);
-		(typeof env.DEFINED_NESTED_KEY).should.be.eql("number");
-		if(env.DEFINED_NESTED_KEY !== 5) require("fail");
-		if(typeof env.DEFINED_NESTED_KEY !== "number") require("fail");
-
-		var x = env.DEFINED_NESTED_KEY;
+		var x = process.env.DEFINED_NESTED_KEY;
 		x.should.be.eql(5);
-	}(process.env));
-});
-it("should define process.env.DEFINED_NESTED_KEY_STRING", function() {
-	if(process.env.DEFINED_NESTED_KEY_STRING !== "string") require("fail");
-});
-it("should assign to process.env", function() {
-	process.env.TEST = "test";
-	process.env.TEST.should.be.eql("test");
-});
-it("should not have brakets on start", function() {
-	function f() {
-		throw new Error("should not be called");
-	}
-	f // <- no semicolon here
-	OBJECT;
+
+		var indirect = process.env;
+		(indirect.DEFINED_NESTED_KEY).should.be.eql(5);
+
+		(function(env) {
+			(env.DEFINED_NESTED_KEY).should.be.eql(5);
+			(typeof env.DEFINED_NESTED_KEY).should.be.eql("number");
+			if(env.DEFINED_NESTED_KEY !== 5) require("fail");
+			if(typeof env.DEFINED_NESTED_KEY !== "number") require("fail");
+
+			var x = env.DEFINED_NESTED_KEY;
+			x.should.be.eql(5);
+		}(process.env));
+	});
+	it("should define process.env.DEFINED_NESTED_KEY_STRING", function() {
+		if(process.env.DEFINED_NESTED_KEY_STRING !== "string") require("fail");
+	});
+	it("should assign to process.env", function() {
+		process.env.TEST = "test";
+		process.env.TEST.should.be.eql("test");
+	});
+	it("should not have brakets on start", function() {
+		function f() {
+			throw new Error("should not be called");
+		}
+		f // <- no semicolon here
+		OBJECT;
+	});
+
+	it("should not explode on recursive typeof calls", function() {
+		(typeof wurst).should.eql("undefined"); // <- is recursivly defined in config
+	});
+
+	it("should not explode on recursive statements", function() {
+		try {
+			wurst; // <- is recursivly defined in config
+		} catch(e) {
+			e.message.should.eql("suppe is not defined");
+		}
+	});
 });

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -1,104 +1,100 @@
-/* globals define, it, should */
-define("DefinePlugin", function() {
-	it("should define FALSE", function() {
-		FALSE.should.be.eql(false);
-		(typeof TRUE).should.be.eql("boolean");
-		var x = require(FALSE ? "fail" : "./a");
-		var y = FALSE ? require("fail") : require("./a");
-	});
+/* globals it, should */
+it("should define FALSE", function() {
+	FALSE.should.be.eql(false);
+	(typeof TRUE).should.be.eql("boolean");
+	var x = require(FALSE ? "fail" : "./a");
+	var y = FALSE ? require("fail") : require("./a");
+});
 
-	it("should define CODE", function() {
-		CODE.should.be.eql(3);
-		(typeof CODE).should.be.eql("number");
-		if(CODE !== 3) require("fail");
-		if(typeof CODE !== "number") require("fail");
-	});
-	it("should define FUNCTION", function() {
-		(FUNCTION(5)).should.be.eql(6);
-		(typeof FUNCTION).should.be.eql("function");
-		if(typeof FUNCTION !== "function") require("fail");
-	});
-	it("should define UNDEFINED", function() {
-		(typeof UNDEFINED).should.be.eql("undefined");
-		if(typeof UNDEFINED !== "undefined") require("fail");
-	});
-	it("should define REGEXP", function() {
-		REGEXP.toString().should.be.eql("/abc/i");
-		(typeof REGEXP).should.be.eql("object");
-		if(typeof REGEXP !== "object") require("fail");
-	});
-	it("should define OBJECT", function() {
-		var o = OBJECT;
-		o.SUB.FUNCTION(10).should.be.eql(11);
-	});
-	it("should define OBJECT.SUB.CODE", function() {
-		(typeof OBJECT.SUB.CODE).should.be.eql("number");
-		OBJECT.SUB.CODE.should.be.eql(3);
-		if(OBJECT.SUB.CODE !== 3) require("fail");
-		if(typeof OBJECT.SUB.CODE !== "number") require("fail");
+it("should define CODE", function() {
+	CODE.should.be.eql(3);
+	(typeof CODE).should.be.eql("number");
+	if(CODE !== 3) require("fail");
+	if(typeof CODE !== "number") require("fail");
+});
+it("should define FUNCTION", function() {
+	(FUNCTION(5)).should.be.eql(6);
+	(typeof FUNCTION).should.be.eql("function");
+	if(typeof FUNCTION !== "function") require("fail");
+});
+it("should define UNDEFINED", function() {
+	(typeof UNDEFINED).should.be.eql("undefined");
+	if(typeof UNDEFINED !== "undefined") require("fail");
+});
+it("should define REGEXP", function() {
+	REGEXP.toString().should.be.eql("/abc/i");
+	(typeof REGEXP).should.be.eql("object");
+	if(typeof REGEXP !== "object") require("fail");
+});
+it("should define OBJECT", function() {
+	var o = OBJECT;
+	o.SUB.FUNCTION(10).should.be.eql(11);
+});
+it("should define OBJECT.SUB.CODE", function() {
+	(typeof OBJECT.SUB.CODE).should.be.eql("number");
+	OBJECT.SUB.CODE.should.be.eql(3);
+	if(OBJECT.SUB.CODE !== 3) require("fail");
+	if(typeof OBJECT.SUB.CODE !== "number") require("fail");
 
-		(function(sub) {
-			// should not crash
-			sub.CODE.should.be.eql(3);
-		}(OBJECT.SUB));
-	});
-	it("should define OBJECT.SUB.STRING", function() {
-		(typeof OBJECT.SUB.STRING).should.be.eql("string");
-		OBJECT.SUB.STRING.should.be.eql("string");
-		if(OBJECT.SUB.STRING !== "string") require("fail");
-		if(typeof OBJECT.SUB.STRING !== "string") require("fail");
+	(function(sub) {
+		// should not crash
+		sub.CODE.should.be.eql(3);
+	}(OBJECT.SUB));
+});
+it("should define OBJECT.SUB.STRING", function() {
+	(typeof OBJECT.SUB.STRING).should.be.eql("string");
+	OBJECT.SUB.STRING.should.be.eql("string");
+	if(OBJECT.SUB.STRING !== "string") require("fail");
+	if(typeof OBJECT.SUB.STRING !== "string") require("fail");
 
-		(function(sub) {
-			// should not crash
-			sub.STRING.should.be.eql("string");
-		}(OBJECT.SUB));
-	});
-	it("should define process.env.DEFINED_NESTED_KEY", function() {
-		(process.env.DEFINED_NESTED_KEY).should.be.eql(5);
-		(typeof process.env.DEFINED_NESTED_KEY).should.be.eql("number");
-		if(process.env.DEFINED_NESTED_KEY !== 5) require("fail");
-		if(typeof process.env.DEFINED_NESTED_KEY !== "number") require("fail");
+	(function(sub) {
+		// should not crash
+		sub.STRING.should.be.eql("string");
+	}(OBJECT.SUB));
+});
+it("should define process.env.DEFINED_NESTED_KEY", function() {
+	(process.env.DEFINED_NESTED_KEY).should.be.eql(5);
+	(typeof process.env.DEFINED_NESTED_KEY).should.be.eql("number");
+	if(process.env.DEFINED_NESTED_KEY !== 5) require("fail");
+	if(typeof process.env.DEFINED_NESTED_KEY !== "number") require("fail");
 
-		var x = process.env.DEFINED_NESTED_KEY;
+	var x = process.env.DEFINED_NESTED_KEY;
+	x.should.be.eql(5);
+
+	var indirect = process.env;
+	(indirect.DEFINED_NESTED_KEY).should.be.eql(5);
+
+	(function(env) {
+		(env.DEFINED_NESTED_KEY).should.be.eql(5);
+		(typeof env.DEFINED_NESTED_KEY).should.be.eql("number");
+		if(env.DEFINED_NESTED_KEY !== 5) require("fail");
+		if(typeof env.DEFINED_NESTED_KEY !== "number") require("fail");
+
+		var x = env.DEFINED_NESTED_KEY;
 		x.should.be.eql(5);
+	}(process.env));
+});
+it("should define process.env.DEFINED_NESTED_KEY_STRING", function() {
+	if(process.env.DEFINED_NESTED_KEY_STRING !== "string") require("fail");
+});
+it("should assign to process.env", function() {
+	process.env.TEST = "test";
+	process.env.TEST.should.be.eql("test");
+});
+it("should not have brakets on start", function() {
+	function f() {
+		throw new Error("should not be called");
+	}
+	f // <- no semicolon here
+	OBJECT;
+});
 
-		var indirect = process.env;
-		(indirect.DEFINED_NESTED_KEY).should.be.eql(5);
+it("should not explode on recursive typeof calls", function() {
+	(typeof wurst).should.eql("undefined"); // <- is recursivly defined in config
+});
 
-		(function(env) {
-			(env.DEFINED_NESTED_KEY).should.be.eql(5);
-			(typeof env.DEFINED_NESTED_KEY).should.be.eql("number");
-			if(env.DEFINED_NESTED_KEY !== 5) require("fail");
-			if(typeof env.DEFINED_NESTED_KEY !== "number") require("fail");
-
-			var x = env.DEFINED_NESTED_KEY;
-			x.should.be.eql(5);
-		}(process.env));
-	});
-	it("should define process.env.DEFINED_NESTED_KEY_STRING", function() {
-		if(process.env.DEFINED_NESTED_KEY_STRING !== "string") require("fail");
-	});
-	it("should assign to process.env", function() {
-		process.env.TEST = "test";
-		process.env.TEST.should.be.eql("test");
-	});
-	it("should not have brakets on start", function() {
-		function f() {
-			throw new Error("should not be called");
-		}
-		f // <- no semicolon here
-		OBJECT;
-	});
-
-	it("should not explode on recursive typeof calls", function() {
-		(typeof wurst).should.eql("undefined"); // <- is recursivly defined in config
-	});
-
-	it("should not explode on recursive statements", function() {
-		try {
-			wurst; // <- is recursivly defined in config
-		} catch(e) {
-			e.message.should.eql("suppe is not defined");
-		}
-	});
+it("should not explode on recursive statements", function() {
+	(function() {
+		wurst; // <- is recursivly defined in config
+	}).should.throw("suppe is not defined");
 });

--- a/test/configCases/plugins/define-plugin/webpack.config.js
+++ b/test/configCases/plugins/define-plugin/webpack.config.js
@@ -22,7 +22,11 @@ module.exports = {
 				}
 			},
 			"process.env.DEFINED_NESTED_KEY": 5,
-			"process.env.DEFINED_NESTED_KEY_STRING": "\"string\""
+			"process.env.DEFINED_NESTED_KEY_STRING": "\"string\"",
+			"typeof wurst": "typeof suppe",
+			"typeof suppe": "typeof wurst",
+			"wurst": "suppe",
+			"suppe": "wurst",
 		})
 	]
 };

--- a/test/statsCases/reverse-sort-modules/a.js
+++ b/test/statsCases/reverse-sort-modules/a.js
@@ -1,0 +1,1 @@
+require("./c" + __resourceQuery)

--- a/test/statsCases/reverse-sort-modules/b.js
+++ b/test/statsCases/reverse-sort-modules/b.js
@@ -1,0 +1,1 @@
+require("./a" + __resourceQuery);

--- a/test/statsCases/reverse-sort-modules/c.js
+++ b/test/statsCases/reverse-sort-modules/c.js
@@ -1,0 +1,1 @@
+require("./b" + __resourceQuery)

--- a/test/statsCases/reverse-sort-modules/expected.txt
+++ b/test/statsCases/reverse-sort-modules/expected.txt
@@ -1,0 +1,26 @@
+Hash: 8f4b66734cb63e0581be
+Time: Xms
+  Asset     Size  Chunks             Chunk Names
+main.js  5.82 kB       0  [emitted]  main
+chunk    {0} main.js (main) 1.18 kB [entry] [rendered]
+   [30] (webpack)/test/statsCases/reverse-sort-modules/index.js 181 bytes {0} [built]
+   [28] (webpack)/test/statsCases/reverse-sort-modules/c.js?8 33 bytes {0} [built]
+   [27] (webpack)/test/statsCases/reverse-sort-modules/c.js?7 33 bytes {0} [built]
+   [26] (webpack)/test/statsCases/reverse-sort-modules/c.js?6 33 bytes {0} [built]
+   [25] (webpack)/test/statsCases/reverse-sort-modules/c.js?5 33 bytes {0} [built]
+   [24] (webpack)/test/statsCases/reverse-sort-modules/c.js?4 33 bytes {0} [built]
+   [23] (webpack)/test/statsCases/reverse-sort-modules/c.js?3 33 bytes {0} [built]
+   [22] (webpack)/test/statsCases/reverse-sort-modules/c.js?2 33 bytes {0} [built]
+   [21] (webpack)/test/statsCases/reverse-sort-modules/c.js?10 33 bytes {0} [built]
+   [20] (webpack)/test/statsCases/reverse-sort-modules/c.js?1 33 bytes {0} [built]
+    [9] (webpack)/test/statsCases/reverse-sort-modules/a.js?9 33 bytes {0} [built]
+    [8] (webpack)/test/statsCases/reverse-sort-modules/a.js?8 33 bytes {0} [built]
+    [7] (webpack)/test/statsCases/reverse-sort-modules/a.js?7 33 bytes {0} [built]
+    [6] (webpack)/test/statsCases/reverse-sort-modules/a.js?6 33 bytes {0} [built]
+    [5] (webpack)/test/statsCases/reverse-sort-modules/a.js?5 33 bytes {0} [built]
+    [4] (webpack)/test/statsCases/reverse-sort-modules/a.js?4 33 bytes {0} [built]
+    [3] (webpack)/test/statsCases/reverse-sort-modules/a.js?3 33 bytes {0} [built]
+    [2] (webpack)/test/statsCases/reverse-sort-modules/a.js?2 33 bytes {0} [built]
+    [1] (webpack)/test/statsCases/reverse-sort-modules/a.js?10 33 bytes {0} [built]
+    [0] (webpack)/test/statsCases/reverse-sort-modules/a.js?1 33 bytes {0} [built]
+     + 11 hidden modules

--- a/test/statsCases/reverse-sort-modules/index.js
+++ b/test/statsCases/reverse-sort-modules/index.js
@@ -1,0 +1,10 @@
+require("./a?1");
+require("./a?2");
+require("./a?3");
+require("./a?4");
+require("./a?5");
+require("./a?6");
+require("./a?7");
+require("./a?8");
+require("./a?9");
+require("./a?10");

--- a/test/statsCases/reverse-sort-modules/webpack.config.js
+++ b/test/statsCases/reverse-sort-modules/webpack.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	entry: "./index",
+	performance: false,
+	stats: {
+		maxModules: 20,
+		modulesSort: "!id",
+	}
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

N/A

**If relevant, link to documentation update:**

N/A

**Summary**

During the refactoring a lot of the `var` assignments where translated to `let`, `const` without taking into account that they are blockscoped.
On top of that `let` should only be used when a reference is reassigned in the code.
This allows for easier reading as something defined as a `const` can be considered "never reassigned" while something explicitly labeled as `let` will be reassigned later on.

**Does this PR introduce a breaking change?**

No

**Other information**

There are a couple of interesting finds that i stumpled upon while doing this change:
- in https://github.com/timse/webpack/commit/c3abf8f5cc6103480f04b101f6b80d081b232c0e some variables are assigned and checked and reassigne but are always false
- was this console.log intended? https://github.com/timse/webpack/commit/bd386ecf06c0886504fe2e957fc108b2c0b96b3a
- one assignment here will always be overridden, was that intended? https://github.com/timse/webpack/commit/424a0aead9fdf53f2eb5a0d1c72a42bcdbe2278b