### PR TITLE
fix AggressiveSplittingPlugin logical bug

### DIFF
--- a/lib/optimize/AggressiveSplittingPlugin.js
+++ b/lib/optimize/AggressiveSplittingPlugin.js
@@ -76,7 +76,7 @@ class AggressiveSplittingPlugin {
 						chunk = chunks[i];
 						const chunkModuleNames = chunk.modules.map(makeRelative(compiler.context));
 
-						if(chunkModuleNames.length < splitData.modules)
+						if(chunkModuleNames.length < splitData.modules.length)
 							continue;
 						const moduleIndicies = splitData.modules.map(toIndexOf(chunkModuleNames));
 						const hasAllModules = moduleIndicies.every((idx) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
```js
if(chunkModuleNames.length < splitData.modules)
=> 
if(chunkModuleNames.length < splitData.modules.length)
```
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
The tests pass
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->
