### PR TITLE
NormalModuleFactory: link to doc in error message

### DIFF
--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -254,7 +254,8 @@ NormalModuleFactory.prototype.resolveRequestArray = function resolveRequestArray
 					if(!err2) {
 						err.message = err.message + "\n" +
 							"BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.\n" +
-							"                 You need to specify '" + item.loader + "-loader' instead of '" + item.loader + "'.";
+							"                 You need to specify '" + item.loader + "-loader' instead of '" + item.loader + "',\n" +
+							"                 see https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed";
 					}
 					callback(err);
 				});


### PR DESCRIPTION
Add link to migrating guide when omitting the '-loader' suffix.