### PR TITLE
Fix Error Formatting Issue

### DIFF
--- a/lib/CaseSensitiveModulesWarning.js
+++ b/lib/CaseSensitiveModulesWarning.js
@@ -7,7 +7,6 @@
 module.exports = class CaseSensitiveModulesWarning extends Error {
 	constructor(modules) {
 		super();
-		Error.captureStackTrace(this, CaseSensitiveModulesWarning);
 		this.name = "CaseSensitiveModulesWarning";
 
 		const sortedModules = this._sort(modules);
@@ -16,6 +15,7 @@ module.exports = class CaseSensitiveModulesWarning extends Error {
 			"This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.\n" +
 			`Use equal casing. Compare these module identifiers:\n${modulesList}`;
 		this.origin = this.module = sortedModules[0];
+		Error.captureStackTrace(this, CaseSensitiveModulesWarning);
 	}
 
 	_sort(modules) {

--- a/lib/ChunkRenderError.js
+++ b/lib/ChunkRenderError.js
@@ -8,17 +8,14 @@ class ChunkRenderError extends Error {
 
 	constructor(chunk, file, error) {
 		super();
-
-		if(Error.hasOwnProperty("captureStackTrace")) {
-			Error.captureStackTrace(this, this.constructor);
-		}
-
 		this.name = "ChunkRenderError";
 		this.error = error;
 		this.message = error.message;
 		this.details = error.stack;
 		this.file = file;
 		this.chunk = chunk;
+
+		Error.captureStackTrace(this, this.constructor);
 	}
 }
 

--- a/lib/EntryModuleNotFoundError.js
+++ b/lib/EntryModuleNotFoundError.js
@@ -4,11 +4,11 @@
 */
 function EntryModuleNotFoundError(err) {
 	Error.call(this);
-	Error.captureStackTrace(this, EntryModuleNotFoundError);
 	this.name = "EntryModuleNotFoundError";
 	this.message = "Entry module not found: " + err;
 	this.details = err.details;
 	this.error = err;
+	Error.captureStackTrace(this, EntryModuleNotFoundError);
 }
 module.exports = EntryModuleNotFoundError;
 

--- a/lib/ModuleBuildError.js
+++ b/lib/ModuleBuildError.js
@@ -10,9 +10,6 @@ class ModuleBuildError extends Error {
 
 	constructor(module, err) {
 		super();
-		if(Error.hasOwnProperty("captureStackTrace")) {
-			Error.captureStackTrace(this, this.constructor);
-		}
 		this.name = "ModuleBuildError";
 		this.message = "Module build failed: ";
 		if(err !== null && typeof err === "object") {
@@ -40,6 +37,7 @@ class ModuleBuildError extends Error {
 		}
 		this.module = module;
 		this.error = err;
+		Error.captureStackTrace(this, this.constructor);
 	}
 }
 

--- a/lib/ModuleDependencyError.js
+++ b/lib/ModuleDependencyError.js
@@ -10,14 +10,12 @@ module.exports = class ModuleDependencyError extends Error {
 	constructor(module, err, loc) {
 		super();
 
-		if(Error.hasOwnProperty("captureStackTrace")) {
-			Error.captureStackTrace(this, this.constructor);
-		}
 		this.name = "ModuleDependencyError";
-
 		this.message = `${formatLocation(loc)} ${err.message}`;
 		this.details = err.stack.split("\n").slice(1).join("\n");
 		this.origin = this.module = module;
 		this.error = err;
+
+		Error.captureStackTrace(this, this.constructor);
 	}
 };

--- a/lib/ModuleDependencyWarning.js
+++ b/lib/ModuleDependencyWarning.js
@@ -10,14 +10,12 @@ module.exports = class ModuleDependencyWarning extends Error {
 	constructor(module, err, loc) {
 		super();
 
-		if(Error.hasOwnProperty("captureStackTrace")) {
-			Error.captureStackTrace(this, this.constructor);
-		}
 		this.name = "ModuleDependencyWarning";
-
 		this.message = `${formatLocation(loc)} ${err.message}`;
 		this.details = err.stack.split("\n").slice(1).join("\n");
 		this.origin = this.module = module;
 		this.error = err;
+
+		Error.captureStackTrace(this, this.constructor);
 	}
 };

--- a/lib/ModuleError.js
+++ b/lib/ModuleError.js
@@ -8,13 +8,13 @@ class ModuleError extends Error {
 
 	constructor(module, err) {
 		super();
-		if(Error.hasOwnProperty("captureStackTrace")) {
-			Error.captureStackTrace(this, this.constructor);
-		}
+
 		this.name = "ModuleError";
 		this.module = module;
 		this.message = err;
 		this.error = err;
+
+		Error.captureStackTrace(this, this.constructor);
 	}
 }
 

--- a/lib/ModuleNotFoundError.js
+++ b/lib/ModuleNotFoundError.js
@@ -7,9 +7,7 @@
 class ModuleNotFoundError extends Error {
 	constructor(module, err, dependencies) {
 		super();
-		if(Error.hasOwnProperty("captureStackTrace")) {
-			Error.captureStackTrace(this, this.constructor);
-		}
+
 		this.name = "ModuleNotFoundError";
 		this.message = "Module not found: " + err;
 		this.details = err.details;
@@ -18,6 +16,8 @@ class ModuleNotFoundError extends Error {
 		this.origin = module;
 		this.dependencies = dependencies;
 		this.error = err;
+
+		Error.captureStackTrace(this, this.constructor);
 	}
 }
 

--- a/lib/ModuleParseError.js
+++ b/lib/ModuleParseError.js
@@ -4,7 +4,7 @@
 */
 function ModuleParseError(module, source, err) {
 	Error.call(this);
-	Error.captureStackTrace(this, ModuleParseError);
+
 	this.name = "ModuleParseError";
 	this.message = "Module parse failed: " + module.request + " " + err.message;
 	this.message += "\nYou may need an appropriate loader to handle this file type.";
@@ -21,6 +21,7 @@ function ModuleParseError(module, source, err) {
 	}
 	this.module = module;
 	this.error = err;
+	Error.captureStackTrace(this, ModuleParseError);
 }
 module.exports = ModuleParseError;
 

--- a/lib/ModuleWarning.js
+++ b/lib/ModuleWarning.js
@@ -8,13 +8,12 @@ class ModuleWarning extends Error {
 	constructor(module, warning) {
 		super();
 
-		if(Error.hasOwnProperty("captureStackTrace")) {
-			Error.captureStackTrace(this, this.constructor);
-		}
 		this.name = "ModuleWarning";
 		this.module = module;
 		this.message = warning;
 		this.warning = warning;
+
+		Error.captureStackTrace(this, this.constructor);
 	}
 }
 

--- a/lib/UnsupportedFeatureWarning.js
+++ b/lib/UnsupportedFeatureWarning.js
@@ -8,12 +8,12 @@ class UnsupportedFeatureWarning extends Error {
 
 	constructor(module, message) {
 		super();
-		if(Error.hasOwnProperty("captureStackTrace")) {
-			Error.captureStackTrace(this, this.constructor);
-		}
+
 		this.name = "UnsupportedFeatureWarning";
 		this.message = message;
 		this.origin = this.module = module;
+
+		Error.captureStackTrace(this, this.constructor);
 	}
 }
 

--- a/lib/WebpackOptionsValidationError.js
+++ b/lib/WebpackOptionsValidationError.js
@@ -51,15 +51,16 @@ class WebpackOptionsValidationError extends Error {
 	constructor(validationErrors) {
 		super();
 
-		if(Error.hasOwnProperty("captureStackTrace")) {
-			Error.captureStackTrace(this, this.constructor);
-		}
 		this.name = "WebpackOptionsValidationError";
 
 		this.message = "Invalid configuration object. " +
 			"Webpack has been initialised using a configuration object that does not match the API schema.\n" +
 			validationErrors.map(err => " - " + indent(WebpackOptionsValidationError.formatValidationError(err), "   ", false)).join("\n");
 		this.validationErrors = validationErrors;
+
+		if(Error.hasOwnProperty("captureStackTrace")) {
+			Error.captureStackTrace(this, this.constructor);
+		}
 	}
 
 	static formatSchema(schema, prevSchemas) {

--- a/lib/WebpackOptionsValidationError.js
+++ b/lib/WebpackOptionsValidationError.js
@@ -58,9 +58,7 @@ class WebpackOptionsValidationError extends Error {
 			validationErrors.map(err => " - " + indent(WebpackOptionsValidationError.formatValidationError(err), "   ", false)).join("\n");
 		this.validationErrors = validationErrors;
 
-		if(Error.hasOwnProperty("captureStackTrace")) {
-			Error.captureStackTrace(this, this.constructor);
-		}
+		Error.captureStackTrace(this, this.constructor);
 	}
 
 	static formatSchema(schema, prevSchemas) {

--- a/lib/dependencies/CriticalDependencyWarning.js
+++ b/lib/dependencies/CriticalDependencyWarning.js
@@ -8,11 +8,9 @@ class CriticalDependencyWarning extends Error {
 
 	constructor(message) {
 		super();
-		if(Error.hasOwnProperty("captureStackTrace")) {
-			Error.captureStackTrace(this, this.constructor);
-		}
 		this.name = "CriticalDependencyWarning";
 		this.message = "Critical dependency: " + message;
+		Error.captureStackTrace(this, this.constructor);
 	}
 }
 

--- a/lib/performance/AssetsOverSizeLimitWarning.js
+++ b/lib/performance/AssetsOverSizeLimitWarning.js
@@ -8,12 +8,13 @@ const SizeFormatHelpers = require("../SizeFormatHelpers");
 module.exports = class AssetsOverSizeLimitWarning extends Error {
 	constructor(assetsOverSizeLimit, assetLimit) {
 		super();
-		Error.captureStackTrace(this, this.constructor);
+
 		this.name = "AssetsOverSizeLimitWarning";
 		this.assets = assetsOverSizeLimit;
 		const assetLists = this.assets.map(asset => `\n  ${asset.name} (${SizeFormatHelpers.formatSize(asset.size)})`).join("");
 		this.message = `asset size limit: The following asset(s) exceed the recommended size limit (${SizeFormatHelpers.formatSize(assetLimit)}).
 This can impact web performance.
 Assets: ${assetLists}`;
+		Error.captureStackTrace(this, this.constructor);
 	}
 };

--- a/lib/performance/EntrypointsOverSizeLimitWarning.js
+++ b/lib/performance/EntrypointsOverSizeLimitWarning.js
@@ -8,7 +8,6 @@ const SizeFormatHelpers = require("../SizeFormatHelpers");
 module.exports = class EntrypointsOverSizeLimitWarning extends Error {
 	constructor(entrypoints, entrypointLimit) {
 		super();
-		Error.captureStackTrace(this, this.constructor);
 		this.name = "EntrypointsOverSizeLimitWarning";
 		this.entrypoints = entrypoints;
 		const entrypointList = this.entrypoints.map(entrypoint => `\n  ${
@@ -20,5 +19,6 @@ module.exports = class EntrypointsOverSizeLimitWarning extends Error {
 		}`).join();
 		this.message = `entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (${SizeFormatHelpers.formatSize(entrypointLimit)}). This can impact web performance.
 Entrypoints:${entrypointList}`;
+		Error.captureStackTrace(this, this.constructor);
 	}
 };

--- a/lib/performance/NoAsyncChunksWarning.js
+++ b/lib/performance/NoAsyncChunksWarning.js
@@ -7,10 +7,10 @@
 module.exports = class NoAsyncChunksWarning extends Error {
 	constructor() {
 		super();
-		Error.captureStackTrace(this, this.constructor);
 		this.name = "NoAsyncChunksWarning";
 		this.message = "webpack performance recommendations: \n" +
 			"You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.\n" +
 			"For more info visit https://webpack.js.org/guides/code-splitting/";
+		Error.captureStackTrace(this, this.constructor);
 	}
 };


### PR DESCRIPTION
So at the moment, when there is a validation error, it only outputs the stack trace, and not the actual error message. Simple reproduction:

```js
const webpack = require('webpack')
webpack({ foo: 'bar' })
```

If you run this, you'll see that the stack trace shows up, but not the actual error message, which is pretty unfortunate.

```
[...]/webpack/lib/webpack.js:19
		throw new WebpackOptionsValidationError(webpackOptionsValidationErrors);
		^

Error
    at webpack ([..]/webpack/lib/webpack.js:19:9)
    at Object.<anonymous> ([...]/test.js:3:1)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.runMain (module.js:605:10)
    at run (bootstrap_node.js:418:7)
    at startup (bootstrap_node.js:139:9)
```

I messed around with this for a while and was rather confused about why it happens, and finally stumbled across the answer. Basically, when you call `Error.captureStackTrace`, it not only captures and sets the `MyError.stack` property, it also messed with the error message a bit.

> "The first line of the trace, instead of being prefixed with ErrorType: message, will be the result of calling targetObject.toString()."
> -- [The Docs](https://nodejs.org/api/errors.html#errors_error_capturestacktrace_targetobject_constructoropt)

It does this immediately upon being called, so in this instance, it was calling `toString` on the instance **before** the error message was set, and therefore setting the error message to blank, leaving only the stack trace to show up when the error is thrown.

The fix here is simply moving it down to the bottom of the constructor, where it will run after the error message has been set. When I tested this, the error message was logged out correctly as expected 🙌 