### PR TITLE
node v4 fails to reassignes const in for-of loops properly

### DIFF
--- a/lib/dependencies/CommonJsPlugin.js
+++ b/lib/dependencies/CommonJsPlugin.js
@@ -53,7 +53,7 @@ class CommonJsPlugin {
 					return;
 
 				const requireExpressions = ["require", "require.resolve", "require.resolveWeak"];
-				for(const expression of requireExpressions) {
+				for(let expression of requireExpressions) {
 					parser.plugin(`typeof ${expression}`, ParserHelpers.toConstantDependency("function"));
 					parser.plugin(`evaluate typeof ${expression}`, ParserHelpers.evaluateToString("function"));
 				}

--- a/lib/optimize/CommonsChunkPlugin.js
+++ b/lib/optimize/CommonsChunkPlugin.js
@@ -142,7 +142,7 @@ The available options are:
 						module.addChunk(commonChunk);
 					});
 					if(asyncOption) {
-						for(const chunk of reallyUsedChunks) {
+						for(let chunk of reallyUsedChunks) {
 							if(chunk.isInitial()) continue;
 							chunk.blocks.forEach((block) => {
 								block.chunks.unshift(commonChunk);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

N/A

**If relevant, link to documentation update:**

N/A

**Summary**

In node v4 a `for(const foo of bar)` loop is not correctly evaluated:

Actual:
```
> for(const x of [1,2,3]) {console.log(x)}
1
1
1
undefined
```
expected: 
```
> for(let x of [1,2,3]) {console.log(x)}
1
2
3
```
**Does this PR introduce a breaking change?**

No
