### PR TITLE
Add jsx, ts, and tsx for sourcemap generation

### DIFF
--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -32,7 +32,7 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 	var fallbackModuleFilenameTemplate = this.fallbackModuleFilenameTemplate;
 	var requestShortener = new RequestShortener(compiler.context);
 	var options = this.options;
-	options.test = options.test || /\.(js|css)($|\?)/i;
+	options.test = options.test || /\.(js|css|jsx|ts|tsx)($|\?)/i;
 	compiler.plugin("compilation", function(compilation) {
 		new SourceMapDevToolModuleOptionsPlugin(options).apply(compilation);
 		compilation.plugin("after-optimize-chunk-assets", function(chunks) {


### PR DESCRIPTION
Fixes https://github.com/webpack/webpack.js.org/issues/151

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
Nope T_T

**If relevant, link to documentation update:**

https://github.com/webpack/webpack.js.org/issues/151

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

I don't think so

**Other information**
This PR solves when entries for jsx / ts / tsx would not generate sourcemaps