### PR TITLE
Add resolver result to module callback

### DIFF
--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -120,18 +120,19 @@ function NormalModuleFactory(context, resolvers, options) {
 							resource: resource
 						});
 
-					_this.resolvers.normal.resolve(resolveContextInfo, context, resource, function(err, resource, result) {
+					_this.resolvers.normal.resolve(resolveContextInfo, context, resource, function(err, resource, resourceResolveData) {
 						if(err) return callback(err);
-						callback(null, Object.assign({}, result, {
+						callback(null, {
+							resourceResolveData: resourceResolveData,
 							resource: resource,
-						}));
+						});
 					});
 				}
 			], function(err, results) {
 				if(err) return callback(err);
 				var loaders = results[0];
-				var resourceResolveData = results[1];
-				resource = resourceResolveData.resource;
+				var resourceResolveData = results[1].resourceResolveData;
+				resource = results[1].resource;
 
 				// translate option idents
 				try {

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -116,7 +116,8 @@ function NormalModuleFactory(context, resolvers, options) {
 				},
 				function(callback) {
 					if(resource === "" || resource[0] === "?")
-						return callback(null, resource);
+						return callback(null, { resource: resource });
+
 					_this.resolvers.normal.resolve(resolveContextInfo, context, resource, function(err, resource, result) {
 						if(err) return callback(err);
 						callback(null, Object.assign({}, result, {

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -117,15 +117,18 @@ function NormalModuleFactory(context, resolvers, options) {
 				function(callback) {
 					if(resource === "" || resource[0] === "?")
 						return callback(null, resource);
-					_this.resolvers.normal.resolve(resolveContextInfo, context, resource, function(err, result) {
+					_this.resolvers.normal.resolve(resolveContextInfo, context, resource, function(err, resource, result) {
 						if(err) return callback(err);
-						callback(null, result);
+						callback(null, Object.assign({}, result, {
+							resource: resource,
+						}));
 					});
 				}
 			], function(err, results) {
 				if(err) return callback(err);
 				var loaders = results[0];
-				resource = results[1];
+				var resolverResult = results[1];
+				resource = resolverResult.resource;
 
 				// translate option idents
 				try {
@@ -194,6 +197,7 @@ function NormalModuleFactory(context, resolvers, options) {
 						rawRequest: request,
 						loaders: loaders,
 						resource: resource,
+						resolverResult: resolverResult,
 						parser: _this.getParser(settings.parser)
 					});
 				}

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -116,7 +116,9 @@ function NormalModuleFactory(context, resolvers, options) {
 				},
 				function(callback) {
 					if(resource === "" || resource[0] === "?")
-						return callback(null, { resource: resource });
+						return callback(null, {
+							resource: resource
+						});
 
 					_this.resolvers.normal.resolve(resolveContextInfo, context, resource, function(err, resource, result) {
 						if(err) return callback(err);
@@ -128,8 +130,8 @@ function NormalModuleFactory(context, resolvers, options) {
 			], function(err, results) {
 				if(err) return callback(err);
 				var loaders = results[0];
-				var resolverResult = results[1];
-				resource = resolverResult.resource;
+				var resourceResolveData = results[1];
+				resource = resourceResolveData.resource;
 
 				// translate option idents
 				try {
@@ -198,7 +200,7 @@ function NormalModuleFactory(context, resolvers, options) {
 						rawRequest: request,
 						loaders: loaders,
 						resource: resource,
-						resolverResult: resolverResult,
+						resourceResolveData: resourceResolveData,
 						parser: _this.getParser(settings.parser)
 					});
 				}


### PR DESCRIPTION
A small change that passes the result of running `Resolver.resolve` up through the plugin chain a bit farther.

One reason for this is that it gives compilation plugins access to all the resolved module metadata, like descriptionFileData and allows greater coordination between resolvers and the overall compilation. I think this should enable some more interesting use-cases. such as pruning and optimizing the dependency graph based on package metadata (like semver) instead of just module source hashes. 

Overall doing optimization based on package data has never been a good fit for webpack core, but this should allow others to add stuff on top to suit more personal or specific use cases.