### PR TITLE
refactor(HarmonyModulesHelpers): upgrade to ES6

### DIFF
--- a/lib/dependencies/HarmonyModulesHelpers.js
+++ b/lib/dependencies/HarmonyModulesHelpers.js
@@ -2,79 +2,84 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var HarmonyModulesHelpers = exports;
+"use strict";
 
-HarmonyModulesHelpers.getModuleVar = function(state, request) {
-	if(!state.harmonyModules) state.harmonyModules = [];
-	var idx = state.harmonyModules.indexOf(request);
-	if(idx < 0) {
-		idx = state.harmonyModules.length;
-		state.harmonyModules.push(request);
+class HarmonyModulesHelpers {
+
+	static getModuleVar(state, request) {
+		if(!state.harmonyModules) state.harmonyModules = [];
+		var idx = state.harmonyModules.indexOf(request);
+		if(idx < 0) {
+			idx = state.harmonyModules.length;
+			state.harmonyModules.push(request);
+		}
+		return "__WEBPACK_IMPORTED_MODULE_" + idx + "_" + request.replace(/[^A-Za-z0-9_]/g, "_").replace(/__+/g, "_") + "__";
 	}
-	return "__WEBPACK_IMPORTED_MODULE_" + idx + "_" + request.replace(/[^A-Za-z0-9_]/g, "_").replace(/__+/g, "_") + "__";
-};
 
-HarmonyModulesHelpers.getNewModuleVar = function(state, request) {
-	if(state.harmonyModules && state.harmonyModules.indexOf(request) >= 0)
-		return null;
-	return HarmonyModulesHelpers.getModuleVar(state, request);
-};
-
-HarmonyModulesHelpers.checkModuleVar = function(state, request) {
-	if(!state.harmonyModules || state.harmonyModules.indexOf(request) < 0)
-		return null;
-	return HarmonyModulesHelpers.getModuleVar(state, request);
-};
-
-// checks if an harmony dependency is active in a module according to
-// precedence rules.
-HarmonyModulesHelpers.isActive = function(module, depInQuestion) {
-	var desc = depInQuestion.describeHarmonyExport();
-	if(!desc.exportedName) return true;
-	var before = true;
-	for(var i = 0; i < module.dependencies.length; i++) {
-		var dep = module.dependencies[i];
-		if(dep === depInQuestion) {
-			before = false;
-			continue;
-		}
-		if(!dep.describeHarmonyExport) continue;
-		var d = dep.describeHarmonyExport();
-		if(!d || !d.exportedName) continue;
-		if(d.exportedName === desc.exportedName) {
-			if(d.precedence < desc.precedence) {
-				return false;
-			}
-			if(d.precedence === desc.precedence && !before) {
-				return false;
-			}
-		}
+	static getNewModuleVar(state, request) {
+		if(state.harmonyModules && state.harmonyModules.indexOf(request) >= 0)
+			return null;
+		return this.getModuleVar(state, request);
 	}
-	return true;
-};
 
-// get a list of named exports defined in a module
-// doesn't include * reexports.
-HarmonyModulesHelpers.getActiveExports = function(module, currentDependency) {
-	var desc = currentDependency && currentDependency.describeHarmonyExport();
-	var currentIndex = currentDependency ? module.dependencies.indexOf(currentDependency) : -1;
-	return module.dependencies.map(function(dep, idx) {
-		return {
-			dep: dep,
-			idx: idx
-		};
-	}).reduce(function(arr, data) {
-		var dep = data.dep;
-		if(!dep.describeHarmonyExport) return arr;
-		var d = dep.describeHarmonyExport();
-		if(!d) return arr;
-		if(!desc || (d.precedence < desc.precedence) || (d.precedence === desc.precedence && data.idx < currentIndex)) {
-			var names = [].concat(d.exportedName);
-			names.forEach(function(name) {
-				if(name && arr.indexOf(name) < 0)
-					arr.push(name);
-			});
+	static checkModuleVar(state, request) {
+		if(!state.harmonyModules || state.harmonyModules.indexOf(request) < 0)
+			return null;
+		return this.getModuleVar(state, request);
+	}
+
+	// checks if an harmony dependency is active in a module according to
+	// precedence rules.
+	static isActive(module, depInQuestion) {
+		var desc = depInQuestion.describeHarmonyExport();
+		if(!desc.exportedName) return true;
+		var before = true;
+		for(var i = 0; i < module.dependencies.length; i++) {
+			var dep = module.dependencies[i];
+			if(dep === depInQuestion) {
+				before = false;
+				continue;
+			}
+			if(!dep.describeHarmonyExport) continue;
+			var d = dep.describeHarmonyExport();
+			if(!d || !d.exportedName) continue;
+			if(d.exportedName === desc.exportedName) {
+				if(d.precedence < desc.precedence) {
+					return false;
+				}
+				if(d.precedence === desc.precedence && !before) {
+					return false;
+				}
+			}
 		}
-		return arr;
-	}, []);
-};
+		return true;
+	}
+
+	// get a list of named exports defined in a module
+	// doesn't include * reexports.
+	static getActiveExports(module, currentDependency) {
+		var desc = currentDependency && currentDependency.describeHarmonyExport();
+		var currentIndex = currentDependency ? module.dependencies.indexOf(currentDependency) : -1;
+		return module.dependencies.map((dep, idx) => {
+			return {
+				dep: dep,
+				idx: idx
+			};
+		}).reduce((arr, data) => {
+			var dep = data.dep;
+			if(!dep.describeHarmonyExport) return arr;
+			var d = dep.describeHarmonyExport();
+			if(!d) return arr;
+			if(!desc || (d.precedence < desc.precedence) || (d.precedence === desc.precedence && data.idx < currentIndex)) {
+				var names = [].concat(d.exportedName);
+				names.forEach(function(name) {
+					if(name && arr.indexOf(name) < 0)
+						arr.push(name);
+				});
+			}
+			return arr;
+		}, []);
+	}
+}
+
+module.exports = HarmonyModulesHelpers;

--- a/test/HarmonyModulesHelpers.test.js
+++ b/test/HarmonyModulesHelpers.test.js
@@ -1,0 +1,178 @@
+/* globals describe, it, beforeEach */
+"use strict";
+
+const should = require("should");
+const HarmonyModulesHelpers = require("../lib/dependencies/HarmonyModulesHelpers");
+
+describe("HarmonyModulesHelpers", () => {
+
+	describe("getModuleVar", () => {
+		it("returns a module var without special characters", () => {
+			should(HarmonyModulesHelpers.getModuleVar({}, 'w*thspeci@lcharact#rs')).be.eql("__WEBPACK_IMPORTED_MODULE_0_w_thspeci_lcharact_rs__");
+		});
+
+		it("returns a module var without double underscore", () => {
+			should(HarmonyModulesHelpers.getModuleVar({}, 'without__double__underscore')).be.eql("__WEBPACK_IMPORTED_MODULE_0_without_double_underscore__");
+		});
+
+		it("returns a module var without spaces", () => {
+			should(HarmonyModulesHelpers.getModuleVar({}, '    without spaces')).be.eql("__WEBPACK_IMPORTED_MODULE_0__without_spaces__");
+		});
+
+		describe("when has harmonyModules information", () => {
+			let request, state, harmonyModuleVarInformation;
+			before(() => {
+				request = 'requested module';
+				state = {
+					harmonyModules: ['sample test', request]
+				};
+				harmonyModuleVarInformation = HarmonyModulesHelpers.getModuleVar(state, request);
+			});
+
+			it("returns a module based on request position in state harmonyModules array", () => {
+				should(harmonyModuleVarInformation).be.containEql(1);
+			});
+
+			it("returns a module based on harmonyModules information", () => {
+				should(harmonyModuleVarInformation).be.eql("__WEBPACK_IMPORTED_MODULE_1_requested_module__");
+			});
+		});
+	});
+
+	describe("getNewModuleVar", () => {
+		it("returns module var based on `getModuleVar` method", () => {
+			const request = 'sample test';
+			const state = {
+				harmonyModules: []
+			};
+			should(HarmonyModulesHelpers.getNewModuleVar(state, request)).be.eql('__WEBPACK_IMPORTED_MODULE_0_sample_test__');
+		});
+
+		it("returns null if has request information inside state harmonyModules", () => {
+			const request = 'sample test';
+			const state = {
+				harmonyModules: [request]
+			};
+			should(HarmonyModulesHelpers.getNewModuleVar(state, request)).be.eql(null);
+		});
+	});
+
+	describe("checkModuleVar", () => {
+		it("returns null if has current dependency and module dependency are different", () => {
+			should(HarmonyModulesHelpers.checkModuleVar({
+				harmonyModules: ['sample test']
+			}, 'other sample test')).be.eql(null);
+		});
+
+		it("returns null if has NOT request information inside state harmonyModules", () => {
+			should(HarmonyModulesHelpers.checkModuleVar({
+				harmonyModules: []
+			}, 'sample test')).be.eql(null);
+		});
+
+		it("returns module var based on `getModuleVar` method", () => {
+			const request = 'sample test';
+			const state = {
+				harmonyModules: []
+			};
+			should(HarmonyModulesHelpers.getNewModuleVar(state, request)).be.eql('__WEBPACK_IMPORTED_MODULE_0_sample_test__');
+		});
+	});
+
+	describe("isActive", () => {
+		it("returns `true` if module has NOT dependencies", () => {
+			const currentDependency = {
+				describeHarmonyExport: () => {
+					return {
+						exportedName: '',
+						precedence: 1
+					};
+				}
+			};
+			const module = {
+				dependencies: []
+			};
+			should(HarmonyModulesHelpers.isActive(module, currentDependency)).be.eql(true);
+		});
+
+		it("returns `false` if module currentDependency has precedence greater than module dependency", () => {
+			const currentDependency = {
+				describeHarmonyExport: () => {
+					return {
+						exportedName: 'first dependency',
+						precedence: 2
+					};
+				}
+			};
+			const module = {
+				dependencies: [{
+					describeHarmonyExport: () => {
+						return {
+							exportedName: 'first dependency',
+							precedence: 1
+						};
+					}
+				}]
+			};
+			should(HarmonyModulesHelpers.isActive(module, currentDependency)).be.eql(false);
+		});
+
+		describe("getActiveExports", () => {
+			it("returns an empty array with modules has no dependency", () => {
+				const currentDependency = {
+					describeHarmonyExport: () => {}
+				};
+				const module = {
+					dependencies: []
+				};
+				should(HarmonyModulesHelpers.getActiveExports(module, currentDependency)).be.eql([]);
+			});
+
+			it("returns an empty array if the precedence of current dependency is less than module dependency", () => {
+				const currentDependency = {
+					describeHarmonyExport: () => {
+						return {
+							exportedName: 'first dependency',
+							precedence: 1
+						};
+					}
+				};
+				const module = {
+					dependencies: [{
+						describeHarmonyExport: () => {
+							return {
+								exportedName: 'first dependency',
+								precedence: 2
+							};
+						}
+					}]
+				};
+				should(HarmonyModulesHelpers.getActiveExports(module, currentDependency)).be.eql([]);
+			});
+
+			it("returns an array with modules if currentDependency has precedence greater than module dependency", () => {
+				const currentDependency = {
+					describeHarmonyExport: () => {
+						return {
+							exportedName: 'first dependency',
+							precedence: 2
+						};
+					}
+				};
+				const module = {
+					dependencies: [{
+						describeHarmonyExport: () => {
+							return {
+								exportedName: 'first dependency',
+								precedence: 1
+							};
+						}
+					}]
+				};
+				should(HarmonyModulesHelpers.getActiveExports(module, currentDependency)).be.eql(['first dependency']);
+			});
+		});
+
+	});
+
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

ES5 => ES6 refactor

**Did you add tests for your changes?**

Adding missed tests for `HarmonyModulesHelpers` library dependency

**If relevant, link to documentation update:**

N/A

**Summary**

Helping in part of the ES6 refactor

**Does this PR introduce a breaking change?**

Nope