### PR TITLE
Add strictExportPresence option

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -27,6 +27,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("module.wrappedContextRegExp", /.*/);
 		this.set("module.wrappedContextRecursive", true);
 		this.set("module.wrappedContextCritical", false);
+		this.set("module.strictExportPresence", false);
 
 		this.set("module.unsafeCache", true);
 

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -11,6 +11,10 @@ const HarmonyAcceptDependency = require("./HarmonyAcceptDependency");
 const HarmonyModulesHelpers = require("./HarmonyModulesHelpers");
 
 module.exports = class HarmonyImportDependencyParserPlugin {
+	constructor(moduleOptions) {
+		this.strictExportPresence = moduleOptions.strictExportPresence;
+	}
+
 	apply(parser) {
 		parser.plugin("import", (statement, source) => {
 			const dep = new HarmonyImportDependency(source, HarmonyModulesHelpers.getNewModuleVar(parser.state, source), statement.range);
@@ -29,7 +33,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 		parser.plugin("expression imported var", (expr) => {
 			const name = expr.name;
 			const settings = parser.state.harmonySpecifier[`$${name}`];
-			const dep = new HarmonyImportSpecifierDependency(settings[0], settings[1], settings[2], name, expr.range);
+			const dep = new HarmonyImportSpecifierDependency(settings[0], settings[1], settings[2], name, expr.range, this.strictExportPresence);
 			dep.shorthand = parser.scope.inShorthand;
 			dep.directImport = true;
 			dep.loc = expr.loc;
@@ -41,7 +45,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			const settings = parser.state.harmonySpecifier[`$${name}`];
 			if(settings[2] !== null)
 				return false;
-			const dep = new HarmonyImportSpecifierDependency(settings[0], settings[1], expr.property.name || expr.property.value, name, expr.range);
+			const dep = new HarmonyImportSpecifierDependency(settings[0], settings[1], expr.property.name || expr.property.value, name, expr.range, this.strictExportPresence);
 			dep.shorthand = parser.scope.inShorthand;
 			dep.directImport = false;
 			dep.loc = expr.loc;
@@ -54,7 +58,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			expr = expr.callee;
 			const name = expr.name;
 			const settings = parser.state.harmonySpecifier[`$${name}`];
-			const dep = new HarmonyImportSpecifierDependency(settings[0], settings[1], settings[2], name, expr.range);
+			const dep = new HarmonyImportSpecifierDependency(settings[0], settings[1], settings[2], name, expr.range, this.strictExportPresence);
 			dep.directImport = true;
 			dep.callArgs = args;
 			dep.call = fullExpr;

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -6,13 +6,14 @@
 const NullDependency = require("./NullDependency");
 
 class HarmonyImportSpecifierDependency extends NullDependency {
-	constructor(importDependency, importedVar, id, name, range) {
+	constructor(importDependency, importedVar, id, name, range, strictExportPresence) {
 		super();
 		this.importDependency = importDependency;
 		this.importedVar = importedVar;
 		this.id = id;
 		this.name = name;
 		this.range = range;
+		this.strictExportPresence = strictExportPresence;
 	}
 
 	get type() {
@@ -28,6 +29,20 @@ class HarmonyImportSpecifierDependency extends NullDependency {
 	}
 
 	getWarnings() {
+		if(this.strictExportPresence) {
+			return [];
+		}
+		return this._getErrors();
+	}
+
+	getErrors() {
+		if(this.strictExportPresence) {
+			return this._getErrors();
+		}
+		return [];
+	}
+
+	_getErrors() {
 		const importedModule = this.importDependency.module;
 		if(!importedModule || !importedModule.meta || !importedModule.meta.harmonyModule) {
 			return;

--- a/lib/dependencies/HarmonyModulesPlugin.js
+++ b/lib/dependencies/HarmonyModulesPlugin.js
@@ -20,6 +20,9 @@ const HarmonyImportDependencyParserPlugin = require("./HarmonyImportDependencyPa
 const HarmonyExportDependencyParserPlugin = require("./HarmonyExportDependencyParserPlugin");
 
 class HarmonyModulesPlugin {
+	constructor(options) {
+		this.options = options;
+	}
 
 	apply(compiler) {
 		compiler.plugin("compilation", (compilation, params) => {
@@ -59,7 +62,7 @@ class HarmonyModulesPlugin {
 
 				parser.apply(
 					new HarmonyDetectionParserPlugin(),
-					new HarmonyImportDependencyParserPlugin(),
+					new HarmonyImportDependencyParserPlugin(this.options),
 					new HarmonyExportDependencyParserPlugin()
 				);
 			});

--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -218,6 +218,9 @@
         },
         "wrappedContextRegExp": {
           "instanceof": "RegExp"
+        },
+        "strictExportPresence": {
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/test/configCases/compiletime/error-not-found/errors.js
+++ b/test/configCases/compiletime/error-not-found/errors.js
@@ -1,0 +1,3 @@
+module.exports = [
+  /not found/
+];

--- a/test/configCases/compiletime/error-not-found/index.js
+++ b/test/configCases/compiletime/error-not-found/index.js
@@ -1,0 +1,7 @@
+import { NotHere } from './stub'
+
+it('should do nothing', function() {
+  if (typeof NotHere !== 'undefined') {
+    throw new Error('This shouldn\'t be here!');
+  }
+});

--- a/test/configCases/compiletime/error-not-found/stub.js
+++ b/test/configCases/compiletime/error-not-found/stub.js
@@ -1,0 +1,3 @@
+const foo = 'bar'
+
+export default foo

--- a/test/configCases/compiletime/error-not-found/webpack.config.js
+++ b/test/configCases/compiletime/error-not-found/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  module: {
+    strictExportPresence: true
+  }
+};

--- a/test/configCases/compiletime/warn-not-found/index.js
+++ b/test/configCases/compiletime/warn-not-found/index.js
@@ -1,0 +1,7 @@
+import { NotHere } from './stub'
+
+it('should do nothing', function() {
+  if (typeof NotHere !== 'undefined') {
+    throw new Error('This shouldn\'t be here!');
+  }
+});

--- a/test/configCases/compiletime/warn-not-found/stub.js
+++ b/test/configCases/compiletime/warn-not-found/stub.js
@@ -1,0 +1,3 @@
+const foo = 'bar'
+
+export default foo

--- a/test/configCases/compiletime/warn-not-found/warnings.js
+++ b/test/configCases/compiletime/warn-not-found/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+  /not found/
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
feature (bugfix)
Resolves https://github.com/webpack/webpack/issues/4347

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes 🎉 

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
Needs written.
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
This adds support for strict export presence so that a missing export becomes a compile error.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No. It probably should be switched to `true` by default in 3.0 though.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
