### PR TITLE
add "buildin" system.js and inject as dependency instead of evaluating to raw object

### DIFF
--- a/buildin/system.js
+++ b/buildin/system.js
@@ -1,0 +1,3 @@
+/* global System */
+// "fix" for users of "System" global
+module.exports = typeof System === "undefined" ? {} : System;

--- a/lib/dependencies/SystemPlugin.js
+++ b/lib/dependencies/SystemPlugin.js
@@ -3,6 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 "use strict";
+const path = require("path");
 
 const ParserHelpers = require("../ParserHelpers");
 
@@ -34,7 +35,17 @@ class SystemPlugin {
 				setNotSupported("System.set");
 				setNotSupported("System.get");
 				setNotSupported("System.register");
-				parser.plugin("expression System", ParserHelpers.toConstantDependency("{}"));
+				parser.plugin("expression System", function() {
+					function buildExpression(context, pathToModule) {
+						var moduleJsPath = path.relative(context, pathToModule);
+						if(!/^[A-Z]:/i.test(moduleJsPath)) {
+							moduleJsPath = "./" + moduleJsPath.replace(/\\/g, "/");
+						}
+						return "require(" + JSON.stringify(moduleJsPath) + ")";
+					}
+
+					return ParserHelpers.addParsedVariableToModule(this, "System", buildExpression(this.state.module.context, require.resolve("../../buildin/system.js")));
+				});
 			});
 		});
 	}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

Not yet, need to check if this is the way to go

**If relevant, link to documentation update:**

N/A

**Summary**

Instead of evaluating `System` to `{}` this injects a `System` "polyfill"

**Does this PR introduce a breaking change?**

No

**Other information**

PTAL @sokra @ljharb

i copy & pasted the `buildExpression` might need to want to extract that to parserHelpers if this approach is deemed to be "ok"

fixes #4329

- [ ] move `buildExpression` to ParserHelper?
- [ ] add test