### PR TITLE
pass chunk to updateHashForChunk

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1125,7 +1125,7 @@ class Compilation extends Tapable {
 			if(chunk.hasRuntime()) {
 				this.mainTemplate.updateHashForChunk(chunkHash, chunk);
 			} else {
-				this.chunkTemplate.updateHashForChunk(chunkHash);
+				this.chunkTemplate.updateHashForChunk(chunkHash, chunk);
 			}
 			this.applyPlugins2("chunk-hash", chunk, chunkHash);
 			chunk.hash = chunkHash.digest(hashDigest);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix: `hash-for-chunk` is called without a chunk

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

I didn't see any tests for things like `hash-for-chunk`. I'm happy to add one if someone points me in the right direction.

<!-- Note that we won't merge your changes if you don't add tests -->

**Summary**

The [`ChunkHash#updateHashForChunk`](https://github.com/webpack/webpack/blob/343cdc73101d7f91bd3d1bfb3d43fd98434e16b0/lib/ChunkTemplate.js#L32) method accepts a `chunk` parameter, but [`Compilation`](https://github.com/webpack/webpack/blob/343cdc73101d7f91bd3d1bfb3d43fd98434e16b0/lib/Compilation.js#L1128) doesn't pass it. This means that `hash-for-chunk` plugins are called without a chunk.

**Does this PR introduce a breaking change?**

No
