### PR TITLE
Improve static analysis of Binary Expression

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -39,23 +39,26 @@ Parser.prototype.initializeEvaluating = function() {
 			return new BasicEvaluatedExpression().setRegExp(expr.value).setRange(expr.range);
 	});
 	this.plugin("evaluate LogicalExpression", function(expr) {
-		var left;
-		var leftAsBool;
-		var right;
+		var left = this.evaluateExpression(expr.left);
+		var leftAsBool = left && left.asBool();
+		var right = this.evaluateExpression(expr.right);
+		var rightAsBool = right && right.asBool();
 		if(expr.operator === "&&") {
-			left = this.evaluateExpression(expr.left);
-			leftAsBool = left && left.asBool();
+			/**
+			 * It is enough to know if one side is "false",
+			 * even if we are not able to statically analyze both sides
+			 */
 			if(leftAsBool === false) return left.setRange(expr.range);
-			if(leftAsBool !== true) return;
-			right = this.evaluateExpression(expr.right);
-			return right.setRange(expr.range);
+			if(rightAsBool === false) return right.setRange(expr.range);
+			if(leftAsBool === true && rightAsBool === true) return left.setRange(expr.range);
 		} else if(expr.operator === "||") {
-			left = this.evaluateExpression(expr.left);
-			leftAsBool = left && left.asBool();
+			/**
+			 * As with th "&&" we only need to be able to know if one side is "true",
+			 * even if we are not able to statically analyze both sides.
+			 */
 			if(leftAsBool === true) return left.setRange(expr.range);
-			if(leftAsBool !== false) return;
-			right = this.evaluateExpression(expr.right);
-			return right.setRange(expr.range);
+			if(rightAsBool === true) return right.setRange(expr.range);
+			if(leftAsBool === false && rightAsBool === false) return left.setRange(expr.range);
 		}
 	});
 	this.plugin("evaluate BinaryExpression", function(expr) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

Not yet

**If relevant, link to documentation update:**

N/A

**Summary**

The parser currently tries to statically evaluate expressions e.g. `&&` or `||` to check if it even needs to look into those.
It currently is very conservative as in it  wants to be able to statically analyze both sides of the check. However this is not necessary.
As for a "&&" it is enough for one side to be false and for "||" for one side to be true.
This change takes advantage of that.

**Does this PR introduce a breaking change?**

No
