### PR TITLE
emit watch-close event when watcher closes

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -131,10 +131,12 @@ Watching.prototype.close = function(callback) {
 	}
 	if(this.running) {
 		this.invalid = true;
-		this._done = function() {
+		this._done = () => {
+			this.compiler.applyPlugins("watch-close");
 			callback();
 		};
 	} else {
+		this.compiler.applyPlugins("watch-close");
 		callback();
 	}
 };

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -148,7 +148,7 @@ MultiCompiler.prototype.watch = function(watchOptions, handler) {
 		// ignore
 	});
 
-	return new MultiWatching(watchings);
+	return new MultiWatching(watchings, this);
 };
 
 MultiCompiler.prototype.run = function(callback) {

--- a/lib/MultiWatching.js
+++ b/lib/MultiWatching.js
@@ -7,8 +7,9 @@
 const async = require("async");
 
 class MultiWatching {
-	constructor(watchings) {
+	constructor(watchings, compiler) {
 		this.watchings = watchings;
+		this.compiler = compiler;
 	}
 
 	invalidate() {
@@ -16,9 +17,15 @@ class MultiWatching {
 	}
 
 	close(callback) {
+		if(callback === undefined) callback = () => { /*do nothing*/ };
+
 		async.forEach(this.watchings, (watching, finishedCallback) => {
 			watching.close(finishedCallback);
-		}, callback);
+		}, err => {
+			this.compiler.applyPlugins("watch-close");
+			callback(err);
+		});
+
 	}
 }
 

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -278,7 +278,7 @@ describe("MultiCompiler", () => {
 
 			it("returns a multi-watching object", () => {
 				const result = JSON.stringify(env.result);
-				result.should.be.exactly('{"watchings":["compiler1","compiler2"]}');
+				result.should.be.exactly('{"watchings":["compiler1","compiler2"],"compiler":{"_plugins":{},"compilers":[{"name":"compiler1"},{"name":"compiler2"}]}}');
 			});
 
 			it("calls watch on each compiler with original options", () => {

--- a/test/MultiWatching.test.js
+++ b/test/MultiWatching.test.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const Tapable = require("tapable");
 const should = require("should");
 const sinon = require("sinon");
 const MultiWatching = require("../lib/MultiWatching");
@@ -11,12 +12,21 @@ const createWatching = function() {
 	};
 };
 
+const createCompiler = () => {
+	const compiler = {
+		_plugins: {}
+	};
+	Tapable.mixin(compiler);
+	return compiler;
+};
+
 describe("MultiWatching", () => {
-	let watchings, myMultiWatching;
+	let watchings, compiler, myMultiWatching;
 
 	beforeEach(() => {
 		watchings = [createWatching(), createWatching()];
-		myMultiWatching = new MultiWatching(watchings);
+		compiler = createCompiler();
+		myMultiWatching = new MultiWatching(watchings, compiler);
 	});
 
 	describe("invalidate", () => {

--- a/test/WatchTestCases.test.js
+++ b/test/WatchTestCases.test.js
@@ -80,7 +80,7 @@ describe("WatchTestCases", () => {
 					});
 					before(() => remove(tempDirectory));
 					it("should compile", function(done) {
-						this.timeout(30000);
+						this.timeout(45000);
 						const outputDirectory = path.join(__dirname, "js", "watch", category.name, testName);
 
 						let options = {};

--- a/test/WatcherEvents.test.js
+++ b/test/WatcherEvents.test.js
@@ -1,0 +1,69 @@
+"use strict";
+
+/*globals describe it before after  */
+const path = require("path");
+const should = require("should");
+const MemoryFs = require("memory-fs");
+const webpack = require("../");
+
+const createCompiler = config => {
+	const compiler = webpack(config);
+	compiler.outputFileSystem = new MemoryFs();
+	return compiler;
+};
+
+const createSingleCompiler = () => {
+	return createCompiler({
+		context: path.join(__dirname, "fixtures"),
+		entry: "./a.js"
+	});
+};
+
+const createMultiCompiler = () => {
+	return createCompiler([{
+		context: path.join(__dirname, "fixtures"),
+		entry: "./a.js"
+	}]);
+};
+
+describe("WatchEvents", () => {
+
+	it("should emit 'watch-close' when using single-compiler mode and the compiler is not running", function(done) {
+		let called = false;
+
+		const compiler = createSingleCompiler();
+		const watcher = compiler.watch({}, (err, stats) => {
+			called.should.be.exactly(true);
+			done(err);
+		});
+
+		compiler.plugin('watch-close', () => {
+			called = true
+		});
+
+		compiler.plugin('done', () => {
+			watcher.close();
+		});
+
+	});
+
+	it("should emit 'watch-close' when using multi-compiler mode and the compiler is not running", function(done) {
+		let called = false;
+
+		const compiler = createMultiCompiler();
+		const watcher = compiler.watch({}, (err, stats) => {
+			called.should.be.exactly(true);
+			done(err);
+		});
+
+		compiler.plugin('watch-close', () => {
+			called = true
+		});
+
+		compiler.plugin('done', () => {
+			watcher.close();
+		});
+
+	});
+
+});


### PR DESCRIPTION
This is a PR for https://github.com/webpack/webpack/issues/4405.

---

**Do you want to request a *feature* or report a *bug*?**

Feature

**What is the current behavior?**

The only way to know when the watcher stops watching is if you add a callback to `watcher.close()`. If I don't have access to the watcher (e.g. `hot-dev-middleware` created it and I no longer have access to the middleware), then I have no way of knowing that the watcher stopped.

**What is the expected behavior?**

There's already a `watch-run` event.

I would like `webpack.plugin('watch-close', () => console.log('watching closed'))` to be emitted when the watcher has closed and compilation is `done`. 

https://github.com/webpack/webpack/blob/479a0a4b7b22ed9c65c2f3c472a1be56db5ee0f0/lib/Compiler.js#L135

**If this is a feature request, what is motivation or use case for changing the behavior?**

To simplify waiting on a number of compilers to close.


---

I tried to add tests for when `watching.running === true` but had issues with `watching._done` never being called if the compilation wasn't yet complete (e.g. `done` has been emitted). 