### PR TITLE
refactor(removeAndDo): upgrading to ES6

### DIFF
--- a/lib/removeAndDo.js
+++ b/lib/removeAndDo.js
@@ -2,12 +2,14 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+"use strict";
+
 module.exports = function removeAndDo(collection, thing, action) {
-	var idx = this[collection].indexOf(thing);
-	if(idx >= 0) {
+	const idx = this[collection].indexOf(thing);
+	const hasThingInCollection = idx >= 0;
+	if(hasThingInCollection) {
 		this[collection].splice(idx, 1);
 		thing[action](this);
-		return true;
 	}
-	return false;
+	return hasThingInCollection;
 };

--- a/test/removeAndDo.test.js
+++ b/test/removeAndDo.test.js
@@ -1,0 +1,36 @@
+/* globals describe, it, beforeEach */
+"use strict";
+
+const should = require("should");
+const sinon = require("sinon");
+const removeAndDo = require("../lib/removeAndDo");
+
+describe("removeAndDo", () => {
+	let actionSpy;
+	let thingsMock;
+	let contextMock;
+	let anotherThingsMock;
+
+	beforeEach(() => {
+		actionSpy = sinon.spy();
+		thingsMock = {
+			action: actionSpy
+		};
+		anotherThingsMock = {
+			action: actionSpy
+		};
+		contextMock = {
+			context: [thingsMock]
+		};
+	});
+
+	it("should return true", () => {
+		should(removeAndDo.bind(contextMock)('context', thingsMock, 'action')).be.eql(true);
+		actionSpy.callCount.should.be.exactly(1);
+	});
+
+	it("should return false", () => {
+		should(removeAndDo.bind(contextMock)('context', anotherThingsMock, 'anotherAction')).be.eql(false);
+		actionSpy.callCount.should.be.exactly(0);
+	});
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**
ES5 => ES6 refactor and  increasing unit test code coverage

**If relevant, link to documentation update:**

N/A

**Summary**

Helping in part of the ES6 refactor and adding missed unit tests

**Does this PR introduce a breaking change?**

Nope