### PR TITLE
EnvironmentPlugin: Support empty env variables

### DIFF
--- a/lib/EnvironmentPlugin.js
+++ b/lib/EnvironmentPlugin.js
@@ -23,7 +23,7 @@ class EnvironmentPlugin {
 
 	apply(compiler) {
 		const definitions = this.keys.reduce((defs, key) => {
-			const value = process.env[key] || this.defaultValues[key];
+			const value = process.env[key] !== undefined ? process.env[key] : this.defaultValues[key];
 
 			if(value === undefined) {
 				compiler.plugin("this-compilation", compilation => {

--- a/test/configCases/plugins/environment-plugin/errors.js
+++ b/test/configCases/plugins/environment-plugin/errors.js
@@ -1,4 +1,4 @@
-const variables = ['aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff', 'ggg', 'hhh'];
+const variables = ['aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff', 'ggg', 'hhh', 'iii'];
 const modules = [{
 	name: 'aaa',
 	variables: ['aaa']
@@ -14,6 +14,9 @@ const modules = [{
 }, {
 	name: 'ggghhh',
 	variables: ['ggg', 'hhh']
+}, {
+	name: 'iii',
+	variables: ['iii']
 }];
 
 // build an array of regular expressions of expected errors

--- a/test/configCases/plugins/environment-plugin/index.js
+++ b/test/configCases/plugins/environment-plugin/index.js
@@ -28,3 +28,8 @@ it("should import multiple process.env var with default values", () => {
 	if(process.env.HHH !== "hhh")
 		require.include("hhh");
 });
+
+it("should import process.env var with empty value", () => {
+	if(process.env.III !== "")
+		require.include("iii");
+});

--- a/test/configCases/plugins/environment-plugin/webpack.config.js
+++ b/test/configCases/plugins/environment-plugin/webpack.config.js
@@ -6,6 +6,7 @@ process.env.CCC = "ccc";
 process.env.EEE = "eee";
 process.env.FFF = "fff";
 process.env.GGG = "ggg";
+process.env.III = "";
 
 module.exports = [{
 	name: "aaa",
@@ -39,5 +40,11 @@ module.exports = [{
 			GGG: 'ggg-default',
 			HHH: 'hhh'
 		})
+	]
+}, {
+	name: "iii",
+	module: { unknownContextRegExp: /$^/, unknownContextCritical: false },
+	plugins: [
+		new EnvironmentPlugin("III")
 	]
 }];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bugfix in EnvironmentPlugin

**Did you add tests for your changes?**

Yes

**Summary**

When defining empty environment variables, node reports `process.env.EMPTY === ''`.

```bash
> EMPTY= node -e 'console.log(JSON.stringify(process.env.EMPTY))'
""
```

However, when trying to pass this environment variable into a bundle with EnvironmentPlugin,
it becomes `undefined` with the following warning:

```
EnvironmentPlugin - EMPTY environment variable is undefined.

You can pass an object with default values to suppress this warning.
See https://webpack.js.org/plugins/environment-plugin for example.
```

This PR removes the warning and passes the empty string into the bundle as expected.

**Does this PR introduce a breaking change?**

It only changes `undefined => ''` in situations that previously displayed a build-time warning.
