### PR TITLE
Do not merge empty chunks

### DIFF
--- a/lib/optimize/FlagIncludedChunksPlugin.js
+++ b/lib/optimize/FlagIncludedChunksPlugin.js
@@ -19,6 +19,8 @@ class FlagIncludedChunksPlugin {
 						// as we loop twice the current A will be B and B then A
 						if(chunkA.modules.length < chunkB.modules.length) return;
 
+						if(chunkB.modules.length === 0) return;
+
 						// is chunkB in chunkA?
 						for(let i = 0; i < chunkB.modules.length; i++) {
 							if(chunkA.modules.indexOf(chunkB.modules[i]) < 0) return;

--- a/test/statsCases/commons-chunk-min-size-0/expected.txt
+++ b/test/statsCases/commons-chunk-min-size-0/expected.txt
@@ -1,8 +1,8 @@
-Hash: 9beb53e88067f8ed0026
+Hash: dc6038bec87a57d1a45e
 Time: Xms
       Asset      Size  Chunks             Chunk Names
  entry-1.js  25 bytes       0  [emitted]  entry-1
-vendor-1.js   6.72 kB    1, 0  [emitted]  vendor-1
+vendor-1.js    6.7 kB       1  [emitted]  vendor-1
 chunk    {0} entry-1.js (entry-1) 0 bytes {1} [initial] [rendered]
 chunk    {1} vendor-1.js (vendor-1) 329 bytes [entry] [rendered]
     [0] (webpack)/test/statsCases/commons-chunk-min-size-0/modules/a.js 22 bytes {1} [built]


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactoring/bugfix

**Did you add tests for your changes?**

Amended existing tests

**If relevant, link to documentation update:**

N/A

**Summary**

This prevents chunks without modules to be "integrated" into other chunks as its assumed they are a subset of those, even if they are completly unrelated.
A typical case would be the manifest-chunk that itself does not contain anything, and therefor is added to all other chunks as a dependency.
In the case described in #4438 that leads to unnecessary hash changes between builds.

I am however not aware of any implications of the change, or if the addition of empty-module-chunks is actually an expected behaviour?

**Does this PR introduce a breaking change?**

Not really

**Other information**

fixes #4438