### PR TITLE
Hotfix/hotlinking examples index

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,58 +1,58 @@
 # examples
 
-## commonjs
+## [commonjs](commonjs)
 
 example demonstrating a very simple program
 
-## code-splitting
+## [code-splitting](code-splitting)
 
 example demonstrating a very simple case of Code Splitting.
 
-## require.resolve
+## [require.resolve](require.resolve)
 
 example demonstrating how to cache clearing of modules with `require.resolve` and `require.cache`.
 
-## require.context
+## [require.context](require.context)
 
 example demonstrating automatic creation of contexts when using variables in `require`.
 
-## code-splitted-require.context
+## [code-splitted-require.context](code-splitted-require.context)
 
 example demonstrating contexts in a code-split environment.
 
-## code-splitted-require.context-amd
+## [code-splitted-require.context-amd](code-splitted-require.context-amd)
 
 example demonstrating contexts in a code-split environment with AMD.
 
-## loader
+## [loader](loader)
 
 example demonstrating the usage of loaders.
 
-## coffee-script
+## [coffee-script](coffee-script)
 
 example demonstrating code written in coffee-script.
 
-## code-splitting-bundle-loader
+## [code-splitting-bundle-loader](code-splitting-bundle-loader)
 
 example demonstrating Code Splitting through the builder loader
 
-## names-chunks
+## [names-chunks](names-chunks)
 
 example demonstrating merging of chunks with named chunks
 
-## mixed
+## [mixed](mixed)
 
 example demonstrating mixing CommonJs and AMD
 
-## web-worker
+## [web-worker](web-worker)
 
 example demonstrating creating WebWorkers with webpack and the worker-loader.
 
-## i18n
+## [i18n](i18n)
 
 example demonstrating localization.
 
-## multiple-entry-points
+## [multiple-entry-points](multiple-entry-points)
 
 example demonstrating multiple entry points with Code Splitting.
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

Slight refactor to the examples index to hotlink the readme headers to the files for quick nav

No core changes for tests to run. Just repo readme file update here [examples](https://github.com/webpack/webpack/tree/master/examples)

After helping someone out on the webpack.js.org issues page [1018](https://github.com/webpack/webpack.js.org/issues/1018) I thought this would be a nice addition

No breaking changes
