### PR TITLE
HarmonyImportSpecifierDependency: let import-var-suffix use dot notation instead of square bracket if possible

### DIFF
--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -107,10 +107,10 @@ HarmonyImportSpecifierDependency.Template = class HarmonyImportSpecifierDependen
 		if(dep.id) {
 			const used = importedModule ? importedModule.isUsed(dep.id) : dep.id;
 			const optionalComment = dep.id !== used ? " /* " + dep.id + " */" : "";
-			
-            if (typeof used === 'string' && used.match(/^[0-9a-zA-Z_$]+$/)) {
-                return `.${used}${optionalComment}`;
-            }
+
+			if(typeof used === "string" && used.match(/^[0-9a-zA-Z_$]+$/)) {
+				return `.${used}${optionalComment}`;
+			}
 
 			return `[${JSON.stringify(used)}${optionalComment}]`;
 		}

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -107,6 +107,11 @@ HarmonyImportSpecifierDependency.Template = class HarmonyImportSpecifierDependen
 		if(dep.id) {
 			const used = importedModule ? importedModule.isUsed(dep.id) : dep.id;
 			const optionalComment = dep.id !== used ? " /* " + dep.id + " */" : "";
+			
+            if (typeof used === 'string' && used.match(/^[0-9a-zA-Z_$]+$/)) {
+                return `.${used}${optionalComment}`;
+            }
+
 			return `[${JSON.stringify(used)}${optionalComment}]`;
 		}
 

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -108,7 +108,7 @@ HarmonyImportSpecifierDependency.Template = class HarmonyImportSpecifierDependen
 			const used = importedModule ? importedModule.isUsed(dep.id) : dep.id;
 			const optionalComment = dep.id !== used ? " /* " + dep.id + " */" : "";
 
-			if(typeof used === "string" && used.match(/^[0-9a-zA-Z_$]+$/)) {
+			if(typeof used === "string" && used.match(/^[a-zA-Z_$][0-9a-zA-Z_$]*$/)) {
 				return `.${used}${optionalComment}`;
 			}
 

--- a/test/statsCases/tree-shaking/expected.txt
+++ b/test/statsCases/tree-shaking/expected.txt
@@ -1,7 +1,7 @@
 Hash: 347e6d2384c1a580ac4d
 Time: Xms
     Asset     Size  Chunks             Chunk Names
-bundle.js  7.49 kB       0  [emitted]  main
+bundle.js  7.46 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 588 bytes [entry] [rendered]
    [0] (webpack)/test/statsCases/tree-shaking/a.js 13 bytes {0} [built]
        [exports: a]


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

No, but modified an existing stats test.

**If relevant, link to documentation update:**

N/A

**Summary**

This's to fix a problem when using typescript with es6 target and google's closure compiler.
https://github.com/google/closure-compiler/issues/2182

**Does this PR introduce a breaking change?**

No

**Other information**
