### PR TITLE
Fix ugilifyplugin twice in CLI

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -442,9 +442,11 @@ module.exports = function(yargs, argv, convertOptions) {
 			ensureArray(options, "plugins");
 			var UglifyJsPlugin = require("../lib/optimize/UglifyJsPlugin");
 			var LoaderOptionsPlugin = require("../lib/LoaderOptionsPlugin");
-			options.plugins.push(new UglifyJsPlugin({
-				sourceMap: options.devtool && (options.devtool.indexOf("sourcemap") >= 0 || options.devtool.indexOf("source-map") >= 0)
-			}));
+			if(!options.plugins.find(plugin => plugin instanceof UglifyJsPlugin)) {
+				options.plugins.push(new UglifyJsPlugin({
+					sourceMap: options.devtool && (options.devtool.indexOf("sourcemap") >= 0 || options.devtool.indexOf("source-map") >= 0)
+				}));
+			}
 			options.plugins.push(new LoaderOptionsPlugin({
 				minimize: true
 			}));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

No

**If relevant, link to documentation update:**

N/A

**Summary**

when using new UglifyJsPlugin，--opimize-minimize (or -p) ignores adding the UglifyJsPlugin twice. 

#1385 

**Does this PR introduce a breaking change?**

Nope

