### PR TITLE
Webpack error

### DIFF
--- a/lib/CaseSensitiveModulesWarning.js
+++ b/lib/CaseSensitiveModulesWarning.js
@@ -4,18 +4,21 @@
 */
 "use strict";
 
-module.exports = class CaseSensitiveModulesWarning extends Error {
+const WebpackError = require("./WebpackError");
+
+module.exports = class CaseSensitiveModulesWarning extends WebpackError {
 	constructor(modules) {
 		super();
-		this.name = "CaseSensitiveModulesWarning";
 
+		this.name = "CaseSensitiveModulesWarning";
 		const sortedModules = this._sort(modules);
 		const modulesList = this._moduleMessages(sortedModules);
 		this.message = "There are multiple modules with names that only differ in casing.\n" +
 			"This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.\n" +
 			`Use equal casing. Compare these module identifiers:\n${modulesList}`;
 		this.origin = this.module = sortedModules[0];
-		Error.captureStackTrace(this, CaseSensitiveModulesWarning);
+
+		Error.captureStackTrace(this, this.constructor);
 	}
 
 	_sort(modules) {

--- a/lib/ChunkRenderError.js
+++ b/lib/ChunkRenderError.js
@@ -4,10 +4,12 @@
 */
 "use strict";
 
-class ChunkRenderError extends Error {
+const WebpackError = require("./WebpackError");
 
+class ChunkRenderError extends WebpackError {
 	constructor(chunk, file, error) {
 		super();
+
 		this.name = "ChunkRenderError";
 		this.error = error;
 		this.message = error.message;

--- a/lib/EntryModuleNotFoundError.js
+++ b/lib/EntryModuleNotFoundError.js
@@ -4,14 +4,18 @@
 */
 "use strict";
 
-class EntryModuleNotFoundError extends Error {
+const WebpackError = require("./WebpackError");
+
+class EntryModuleNotFoundError extends WebpackError {
 	constructor(err) {
 		super();
+
 		this.name = "EntryModuleNotFoundError";
 		this.message = "Entry module not found: " + err;
 		this.details = err.details;
 		this.error = err;
-		Error.captureStackTrace(this, EntryModuleNotFoundError);
+
+		Error.captureStackTrace(this, this.constructor);
 	}
 }
 

--- a/lib/ModuleBuildError.js
+++ b/lib/ModuleBuildError.js
@@ -4,12 +4,13 @@
 */
 "use strict";
 
+const WebpackError = require("./WebpackError");
 const cutOffLoaderExecution = require("./ErrorHelpers").cutOffLoaderExecution;
 
-class ModuleBuildError extends Error {
-
+class ModuleBuildError extends WebpackError {
 	constructor(module, err) {
 		super();
+
 		this.name = "ModuleBuildError";
 		this.message = "Module build failed: ";
 		if(err !== null && typeof err === "object") {
@@ -33,6 +34,7 @@ class ModuleBuildError extends Error {
 		}
 		this.module = module;
 		this.error = err;
+
 		Error.captureStackTrace(this, this.constructor);
 	}
 }

--- a/lib/ModuleDependencyError.js
+++ b/lib/ModuleDependencyError.js
@@ -4,9 +4,10 @@
 */
 "use strict";
 
+const WebpackError = require("./WebpackError");
 const formatLocation = require("./formatLocation");
 
-module.exports = class ModuleDependencyError extends Error {
+module.exports = class ModuleDependencyError extends WebpackError {
 	constructor(module, err, loc) {
 		super();
 

--- a/lib/ModuleDependencyWarning.js
+++ b/lib/ModuleDependencyWarning.js
@@ -4,9 +4,10 @@
 */
 "use strict";
 
+const WebpackError = require("./WebpackError");
 const formatLocation = require("./formatLocation");
 
-module.exports = class ModuleDependencyWarning extends Error {
+module.exports = class ModuleDependencyWarning extends WebpackError {
 	constructor(module, err, loc) {
 		super();
 

--- a/lib/ModuleError.js
+++ b/lib/ModuleError.js
@@ -4,10 +4,10 @@
 */
 "use strict";
 
+const WebpackError = require("./WebpackError");
 const cleanUp = require("./ErrorHelpers").cleanUp;
 
-class ModuleError extends Error {
-
+class ModuleError extends WebpackError {
 	constructor(module, err) {
 		super();
 

--- a/lib/ModuleNotFoundError.js
+++ b/lib/ModuleNotFoundError.js
@@ -4,7 +4,9 @@
 */
 "use strict";
 
-class ModuleNotFoundError extends Error {
+const WebpackError = require("./WebpackError");
+
+class ModuleNotFoundError extends WebpackError {
 	constructor(module, err, dependencies) {
 		super();
 

--- a/lib/ModuleParseError.js
+++ b/lib/ModuleParseError.js
@@ -4,9 +4,12 @@
 */
 "use strict";
 
-class ModuleParseError extends Error {
+const WebpackError = require("./WebpackError");
+
+class ModuleParseError extends WebpackError {
 	constructor(module, source, err) {
 		super();
+
 		this.name = "ModuleParseError";
 		this.message = "Module parse failed: " + module.request + " " + err.message;
 		this.message += "\nYou may need an appropriate loader to handle this file type.";
@@ -23,9 +26,8 @@ class ModuleParseError extends Error {
 		}
 		this.module = module;
 		this.error = err;
-		if(Error.hasOwnProperty("captureStackTrace")) {
-			Error.captureStackTrace(this, this.constructor);
-		}
+
+		Error.captureStackTrace(this, this.constructor);
 	}
 }
 

--- a/lib/ModuleWarning.js
+++ b/lib/ModuleWarning.js
@@ -4,10 +4,10 @@
 */
 "use strict";
 
+const WebpackError = require("./WebpackError");
 const cleanUp = require("./ErrorHelpers").cleanUp;
 
-class ModuleWarning extends Error {
-
+class ModuleWarning extends WebpackError {
 	constructor(module, warning) {
 		super();
 

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -15,6 +15,7 @@ const ReplaceSource = require("webpack-sources").ReplaceSource;
 const CachedSource = require("webpack-sources").CachedSource;
 const LineToLineMappedSource = require("webpack-sources").LineToLineMappedSource;
 
+const WebpackError = require("./WebpackError");
 const Module = require("./Module");
 const ModuleParseError = require("./ModuleParseError");
 const ModuleBuildError = require("./ModuleBuildError");
@@ -42,8 +43,7 @@ function contextify(context, request) {
 	}).join("!");
 }
 
-class NonErrorEmittedError extends Error {
-
+class NonErrorEmittedError extends WebpackError {
 	constructor(error) {
 		super();
 

--- a/lib/UnsupportedFeatureWarning.js
+++ b/lib/UnsupportedFeatureWarning.js
@@ -4,8 +4,9 @@
 */
 "use strict";
 
-class UnsupportedFeatureWarning extends Error {
+const WebpackError = require("./WebpackError");
 
+class UnsupportedFeatureWarning extends WebpackError {
 	constructor(module, message) {
 		super();
 

--- a/lib/WebpackError.js
+++ b/lib/WebpackError.js
@@ -1,0 +1,11 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Jarid Margolin @jaridmargolin
+*/
+"use strict";
+
+module.exports = class WebpackError extends Error {
+	inspect() {
+		return this.stack + (this.details ? `\n${this.details}` : "");
+	}
+};

--- a/lib/WebpackOptionsValidationError.js
+++ b/lib/WebpackOptionsValidationError.js
@@ -4,6 +4,7 @@
 */
 "use strict";
 
+const WebpackError = require("./WebpackError");
 const webpackOptionsSchema = require("../schemas/webpackOptionsSchema.json");
 
 const getSchemaPart = (path, parents, additionalPath) => {
@@ -46,13 +47,11 @@ const indent = (str, prefix, firstLine) => {
 	}
 };
 
-class WebpackOptionsValidationError extends Error {
-
+class WebpackOptionsValidationError extends WebpackError {
 	constructor(validationErrors) {
 		super();
 
 		this.name = "WebpackOptionsValidationError";
-
 		this.message = "Invalid configuration object. " +
 			"Webpack has been initialised using a configuration object that does not match the API schema.\n" +
 			validationErrors.map(err => " - " + indent(WebpackOptionsValidationError.formatValidationError(err), "   ", false)).join("\n");

--- a/lib/dependencies/CriticalDependencyWarning.js
+++ b/lib/dependencies/CriticalDependencyWarning.js
@@ -4,12 +4,15 @@
 */
 "use strict";
 
-class CriticalDependencyWarning extends Error {
+const WebpackError = require("../WebpackError");
 
+class CriticalDependencyWarning extends WebpackError {
 	constructor(message) {
 		super();
+
 		this.name = "CriticalDependencyWarning";
 		this.message = "Critical dependency: " + message;
+
 		Error.captureStackTrace(this, this.constructor);
 	}
 }

--- a/lib/performance/AssetsOverSizeLimitWarning.js
+++ b/lib/performance/AssetsOverSizeLimitWarning.js
@@ -3,9 +3,11 @@
 	Author Sean Larkin @thelarkinn
 */
 "use strict";
+
+const WebpackError = require("../WebpackError");
 const SizeFormatHelpers = require("../SizeFormatHelpers");
 
-module.exports = class AssetsOverSizeLimitWarning extends Error {
+module.exports = class AssetsOverSizeLimitWarning extends WebpackError {
 	constructor(assetsOverSizeLimit, assetLimit) {
 		super();
 
@@ -15,6 +17,7 @@ module.exports = class AssetsOverSizeLimitWarning extends Error {
 		this.message = `asset size limit: The following asset(s) exceed the recommended size limit (${SizeFormatHelpers.formatSize(assetLimit)}).
 This can impact web performance.
 Assets: ${assetLists}`;
+
 		Error.captureStackTrace(this, this.constructor);
 	}
 };

--- a/lib/performance/EntrypointsOverSizeLimitWarning.js
+++ b/lib/performance/EntrypointsOverSizeLimitWarning.js
@@ -3,11 +3,14 @@
 	Author Sean Larkin @thelarkinn
 */
 "use strict";
+
+const WebpackError = require("../WebpackError");
 const SizeFormatHelpers = require("../SizeFormatHelpers");
 
-module.exports = class EntrypointsOverSizeLimitWarning extends Error {
+module.exports = class EntrypointsOverSizeLimitWarning extends WebpackError {
 	constructor(entrypoints, entrypointLimit) {
 		super();
+
 		this.name = "EntrypointsOverSizeLimitWarning";
 		this.entrypoints = entrypoints;
 		const entrypointList = this.entrypoints.map(entrypoint => `\n  ${
@@ -19,6 +22,7 @@ module.exports = class EntrypointsOverSizeLimitWarning extends Error {
 		}`).join("");
 		this.message = `entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (${SizeFormatHelpers.formatSize(entrypointLimit)}). This can impact web performance.
 Entrypoints:${entrypointList}\n`;
+
 		Error.captureStackTrace(this, this.constructor);
 	}
 };

--- a/lib/performance/NoAsyncChunksWarning.js
+++ b/lib/performance/NoAsyncChunksWarning.js
@@ -4,13 +4,17 @@
 */
 "use strict";
 
-module.exports = class NoAsyncChunksWarning extends Error {
+const WebpackError = require("../WebpackError");
+
+module.exports = class NoAsyncChunksWarning extends WebpackError {
 	constructor() {
 		super();
+
 		this.name = "NoAsyncChunksWarning";
 		this.message = "webpack performance recommendations: \n" +
 			"You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.\n" +
 			"For more info visit https://webpack.js.org/guides/code-splitting/";
+
 		Error.captureStackTrace(this, this.constructor);
 	}
 };

--- a/test/WebpackError.test.js
+++ b/test/WebpackError.test.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const util = require("util");
+
+const should = require("should");
+const WebpackError = require("../lib/WebpackError");
+
+describe("WebpackError", () => {
+	class CustomError extends WebpackError {
+		constructor(message) {
+			super();
+
+			this.name = "CustomError";
+			this.message = "CustomMessage";
+			this.details = "CustomDetails";
+
+			Error.captureStackTrace(this, this.constructor);
+		}
+	}
+
+	it("Should provide inspect method for use by for util.inspect", function() {
+		const errorStr = util.inspect(new CustomError("Message"));
+		const errorArr = errorStr.split("\n");
+
+		errorArr[0].should.equal("CustomError: CustomMessage");
+		errorArr[1].should.containEql("WebpackError.test.js");
+		errorArr[errorArr.length - 1].should.equal("CustomDetails");
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Refactor which introduces new feature.

**Did you add tests for your changes?**

Yes. Three additional tests have been added.

**If relevant, link to documentation update:**

Currently no PR for documentation exists. Upon review, node api documentation regarding error handling could be altered to show simplified logging approach:

```
if (err) {
  return console.error(err);
}
```

**Summary**

Currently the process to log errors is unnecessarily tedious:

```
  if (err) {
    console.error(err.stack || err);
    if (err.details) {
      console.error(err.details);
    }
    return;
  }
```

Behind the scenes `console.error` utilizes `util.inspect` to determine how to transform the passed arguments into a string. If the passed argument contains an `inspect` method, `util.inspect` will respect it. By having all Error classes inherit from a base `WebpackError` class we can add this method in a central location (with ability to override) and reduce error logging complexity:

```
  if (err) {
    return console.log(err);
  }
```

**Does this PR introduce a breaking change?**

No

**Other information**

N/A