### PR TITLE
Fix GFM rendering issues in Multi Compiler Readme

### DIFF
--- a/examples/multi-compiler/README.md
+++ b/examples/multi-compiler/README.md
@@ -45,7 +45,8 @@ module.exports = [
 
 # js/desktop.js
 
-<details><summary>`/******/ (function(modules) { /* webpackBootstrap */ })`</summary>
+<details><summary><code>/******/ (function(modules) { /* webpackBootstrap */ })</code></summary>
+
 ``` javascript
 /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
@@ -116,7 +117,9 @@ module.exports = [
 /******/ })
 /************************************************************************/
 ```
+
 </details>
+
 ``` javascript
 /******/ ([
 /* 0 */


### PR DESCRIPTION
- The inline code snippet inside of `summary` didn't read as markdown, used `code` tag instead
- Code block before and after the closing `details` tag were breaking, added line breaks to fix

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Fixed bad GFM rendering

**Did you add tests for your changes?**

N/A

**If relevant, link to documentation update:**

N/A

**Summary**

Layout of the Readme in Github was breaking, this fixes it for everybody.

**Does this PR introduce a breaking change?**

No

