### PR TITLE
Upgrade to Acorn 5.0.0

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -536,8 +536,10 @@ Parser.prototype.walkForOfStatement = function walkForOfStatement(statement) {
 
 // Declarations
 Parser.prototype.walkFunctionDeclaration = function walkFunctionDeclaration(statement) {
-	this.scope.renames["$" + statement.id.name] = undefined;
-	this.scope.definitions.push(statement.id.name);
+	if(statement.id) {
+		this.scope.renames["$" + statement.id.name] = undefined;
+		this.scope.definitions.push(statement.id.name);
+	}
 	this.inScope(statement.params, function() {
 		if(statement.body.type === "BlockStatement")
 			this.walkStatement(statement.body);
@@ -637,8 +639,10 @@ Parser.prototype.walkVariableDeclaration = function walkVariableDeclaration(stat
 };
 
 Parser.prototype.walkClassDeclaration = function walkClassDeclaration(statement) {
-	this.scope.renames["$" + statement.id.name] = undefined;
-	this.scope.definitions.push(statement.id.name);
+	if(statement.id) {
+		this.scope.renames["$" + statement.id.name] = undefined;
+		this.scope.definitions.push(statement.id.name);
+	}
 	this.walkClass(statement);
 };
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Packs CommonJs/AMD modules for the browser. Allows to split your codebase into multiple bundles, which can be loaded on demand. Support loaders to preprocess files, i.e. json, jsx, es7, css, less, ... and your custom stuff.",
   "dependencies": {
-    "acorn": "^4.0.4",
+    "acorn": "^5.0.0",
     "acorn-dynamic-import": "^2.0.0",
     "ajv": "^4.7.0",
     "ajv-keywords": "^1.1.1",


### PR DESCRIPTION
Acorn 5.0.0 introduces a breaking change to conform to what other ESTree-compatible parsers are doing for `export default` declarations (see https://github.com/ternjs/acorn/issues/512). This means that `FunctionDeclaration` and `ClassDeclaration` nodes are no longer guaranteed to have an `id` property. This patch updates the version of the acorn dependency and fixes the code where it assumed such a property is never null.

I was not able to run the tests on my machine (clone, npm install, npm test produced a `Cannot find module 'webpack/lib/Chunk'` error), so I'm hoping the CI will run them for me.