### PR TITLE
IE8 for-in, skip prototype property.

### DIFF
--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -105,7 +105,11 @@ JsonpMainTemplatePlugin.prototype.apply = function(mainTemplate) {
 					]),
 					"}",
 					"for(moduleId in moreModules) {",
-					this.indent(this.renderAddModule(hash, chunk, "moduleId", "moreModules[moduleId]")),
+					this.indent([
+						"if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {",
+						this.indent(this.renderAddModule(hash, chunk, "moduleId", "moreModules[moduleId]")),
+						"}"
+					]),
 					"}",
 					"if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules);",
 					"while(callbacks.length)",


### PR DESCRIPTION
**What kind of change does this PR introduce?**
should not call method slice on [object object] #1912

**Did you add tests for your changes?**
All existing tests pass

**If relevant, link to documentation update:**
N/A

**Summary**
Fix the code used by webpack2
