### PR TITLE
reuse logic as used in 2.2.1 to check what chunks should get their runtime extracted

### DIFF
--- a/lib/optimize/CommonsChunkPlugin.js
+++ b/lib/optimize/CommonsChunkPlugin.js
@@ -244,7 +244,7 @@ Take a look at the "name"/"names" or async/children option.`);
 		return allChunks.filter((chunk) => {
 			const found = targetChunks.indexOf(chunk);
 			if(found >= currentIndex) return false;
-			return chunk.parents.length === 0;
+			return chunk.hasRuntime();
 		});
 	}
 


### PR DESCRIPTION

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

N/A

**If relevant, link to documentation update:**

N/A

**Summary**

fixes the issue mentioned in #4598

**Does this PR introduce a breaking change?**

No

**Other information**

Not sure why the logic ever was changed or who would do this.

*insert cone of shame image here*