### PR TITLE
Fix hot module main flag for hot module replacement

### DIFF
--- a/lib/HotModuleReplacement.runtime.js
+++ b/lib/HotModuleReplacement.runtime.js
@@ -27,7 +27,7 @@ module.exports = function() {
 				console.warn("[HMR] unexpected require(" + request + ") from disposed module " + moduleId);
 				hotCurrentParents = [];
 			}
-			hotMainModule = false;
+			hotMainModule = !!installedModules[request];
 			return $require$(request);
 		};
 		var ObjectFactory = function ObjectFactory(name) {

--- a/lib/HotModuleReplacement.runtime.js
+++ b/lib/HotModuleReplacement.runtime.js
@@ -8,7 +8,7 @@ module.exports = function() {
 	var hotApplyOnUpdate = true;
 	var hotCurrentHash = $hash$; // eslint-disable-line no-unused-vars
 	var hotCurrentModuleData = {};
-	var hotMainModule = true; // eslint-disable-line no-unused-vars
+	var hotCurrentChildModule; // eslint-disable-line no-unused-vars
 	var hotCurrentParents = []; // eslint-disable-line no-unused-vars
 	var hotCurrentParentsTemp = []; // eslint-disable-line no-unused-vars
 
@@ -20,14 +20,16 @@ module.exports = function() {
 				if(installedModules[request]) {
 					if(installedModules[request].parents.indexOf(moduleId) < 0)
 						installedModules[request].parents.push(moduleId);
-				} else hotCurrentParents = [moduleId];
+				} else {
+					hotCurrentParents = [moduleId];
+					hotCurrentChildModule = request;
+				}
 				if(me.children.indexOf(request) < 0)
 					me.children.push(request);
 			} else {
 				console.warn("[HMR] unexpected require(" + request + ") from disposed module " + moduleId);
 				hotCurrentParents = [];
 			}
-			hotMainModule = !!installedModules[request];
 			return $require$(request);
 		};
 		var ObjectFactory = function ObjectFactory(name) {
@@ -82,7 +84,7 @@ module.exports = function() {
 			_selfAccepted: false,
 			_selfDeclined: false,
 			_disposeHandlers: [],
-			_main: hotMainModule,
+			_main: hotCurrentChildModule !== moduleId,
 
 			// Module API
 			active: true,
@@ -135,7 +137,7 @@ module.exports = function() {
 			//inherit from previous dispose call
 			data: hotCurrentModuleData[moduleId]
 		};
-		hotMainModule = true;
+		hotCurrentChildModule = undefined;
 		return hot;
 	}
 

--- a/test/configCases/commons-chunk-plugin/hot-multi/common.js
+++ b/test/configCases/commons-chunk-plugin/hot-multi/common.js
@@ -1,0 +1,1 @@
+module.exports = "common";

--- a/test/configCases/commons-chunk-plugin/hot-multi/first.js
+++ b/test/configCases/commons-chunk-plugin/hot-multi/first.js
@@ -1,0 +1,8 @@
+require("should");
+
+require("./common");
+
+it("should have the correct main flag for multi first module", function() {
+	var multiModule = __webpack_require__.c[module.parents[0]];
+	multiModule.hot._main.should.be.eql(true);
+});

--- a/test/configCases/commons-chunk-plugin/hot-multi/second.js
+++ b/test/configCases/commons-chunk-plugin/hot-multi/second.js
@@ -1,0 +1,8 @@
+require("should");
+
+require("./common");
+
+it("should have the correct main flag for multi second module", function() {
+	var multiModule = __webpack_require__.c[module.parents[0]];
+	multiModule.hot._main.should.be.eql(true);
+});

--- a/test/configCases/commons-chunk-plugin/hot-multi/shared.js
+++ b/test/configCases/commons-chunk-plugin/hot-multi/shared.js
@@ -1,0 +1,1 @@
+module.exports = "shared";

--- a/test/configCases/commons-chunk-plugin/hot-multi/test.config.js
+++ b/test/configCases/commons-chunk-plugin/hot-multi/test.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	findBundle: function(i, options) {
+		return [
+			"./vendor.js",
+			"./first.js",
+			"./second.js"
+		]
+	}
+};

--- a/test/configCases/commons-chunk-plugin/hot-multi/vendor.js
+++ b/test/configCases/commons-chunk-plugin/hot-multi/vendor.js
@@ -1,0 +1,3 @@
+require("./common");
+
+module.exports = "vendor";

--- a/test/configCases/commons-chunk-plugin/hot-multi/vendor.js
+++ b/test/configCases/commons-chunk-plugin/hot-multi/vendor.js
@@ -1,3 +1,8 @@
 require("./common");
 
 module.exports = "vendor";
+
+it("should have the correct main flag for multi vendor module", function() {
+	var multiModule = __webpack_require__.c[module.parents[0]];
+	multiModule.hot._main.should.be.eql(true);
+});

--- a/test/configCases/commons-chunk-plugin/hot-multi/webpack.config.js
+++ b/test/configCases/commons-chunk-plugin/hot-multi/webpack.config.js
@@ -1,0 +1,19 @@
+var CommonsChunkPlugin = require("../../../../lib/optimize/CommonsChunkPlugin");
+var HotModuleReplacementPlugin = require("../../../../lib/HotModuleReplacementPlugin");
+module.exports = {
+	entry: {
+		vendor: ["./vendor"],
+		first: ["./shared", "./first"],
+		second: ["./shared", "./second"]
+	},
+	target: "web",
+	output: {
+		filename: "[name].js"
+	},
+	plugins: [
+		new CommonsChunkPlugin({
+			name: "vendor"
+		}),
+		new HotModuleReplacementPlugin()
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bugfix for HMR
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
Yes, added a test case which reproduces the issue if the fix is not in place. The test case requires using `CommonsChunkPlugin` and multiple entries, but there could be a simpler test case.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

When a main module is loaded after a module which is already loaded, the main module should still be marked as a main module, but the current logic causes a main module to be marked a not a main module in this case, which causes issues with HMR. When an incorrectly marked main module is replaced, the current HMR logic will process the update and mark the module as accepted even though it was not.

To fix this issue, this change handles that case by making sure that `hotMainModule` is always `true` after a `require` from `hotCreateRequire`. `hotMainModule` should be set to `true` in `require` from `hotCreateRequire` in the case where `hotCreateModule` (which sets `hotCreateModule` to `true`) is not called. `hotCreateModule` is not called when the requested module is already loaded.

Reported corresponding issue: https://github.com/webpack/webpack/issues/4621

**Does this PR introduce a breaking change?**

No, unless there are some people who rely on unexpected behavior of HMR accepting modules with no accept handlers.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
