### PR TITLE
Fix ProgressPlugin for multi compiler caused by ES6 refactoring

### DIFF
--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -23,7 +23,7 @@ class ProgressPlugin {
 		if(compiler.compilers) {
 			const states = new Array(compiler.compilers.length);
 			compiler.compilers.forEach(function(compiler, idx) {
-				compiler.apply(new ProgressPlugin((p, msg) => {
+				compiler.apply(new ProgressPlugin(function(p, msg) {
 					states[idx] = Array.prototype.slice.apply(arguments);
 					handler.apply(null, [
 						states.map(state => state && state[0] || 0).reduce((a, b) => a + b) / states.length,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
refactoring bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Summary**

This PR fixes a ES6 refactoring error caused by 3e22f61bf1ebd04ad052cfb64fd62990a657ec6e

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

[arrow functions does not bind it's own arguments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
