### PR TITLE
Add originalSource method to NormalModule

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -456,9 +456,9 @@ class NormalModule extends Module {
 		return new CachedSource(source);
 	}
 
-    originalSource() {
-        return this._source;
-    }
+	originalSource() {
+		return this._source;
+	}
 
 	getHighestTimestamp(keys, timestampsByKey) {
 		let highestTimestamp = 0;

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -456,6 +456,10 @@ class NormalModule extends Module {
 		return new CachedSource(source);
 	}
 
+    originalSource() {
+        return this._source;
+    }
+
 	getHighestTimestamp(keys, timestampsByKey) {
 		let highestTimestamp = 0;
 		for(let i = 0; i < keys.length; i++) {

--- a/test/NormalModule.test.js
+++ b/test/NormalModule.test.js
@@ -141,6 +141,16 @@ describe("NormalModule", function() {
 		});
 	});
 
+	describe("#originalSource", function() {
+		let expectedSource = "some source";
+		beforeEach(function() {
+			normalModule._source = new RawSource(expectedSource);
+		});
+		it("returns an original Source", function() {
+			normalModule.originalSource().should.eql(normalModule._source);
+		});
+	});
+
 	describe("#updateHashWithSource", function() {
 		let hashSpy;
 		let hash;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

Yes

**If relevant, link to documentation update:**

N/A

**Summary**

I use `_source` property in my [Webpack Runtime Analyzer](https://github.com/smelukov/webpack-runtime-analyzer), but `_source` does not seem a `public` property

I expect to have `someModule.originalSource()` that uses `_source` property.

More details in https://github.com/webpack/webpack/issues/4526

**Does this PR introduce a breaking change?**

No