### PR TITLE
unify makeRelative method

### DIFF
--- a/lib/RecordIdsPlugin.js
+++ b/lib/RecordIdsPlugin.js
@@ -4,20 +4,9 @@
 */
 "use strict";
 
-const path = require("path");
+const identifierUtils = require("./util/identifier");
 
 class RecordIdsPlugin {
-
-	static looksLikeAbsolutePath(maybeAbsolutePath) {
-		return /^(?:[a-z]:\\|\/)/i.test(maybeAbsolutePath);
-	}
-
-	static makeRelative(context, identifier) {
-		return identifier
-			.split(/([|! ])/)
-			.map(str => RecordIdsPlugin.looksLikeAbsolutePath(str) ? path.relative(context, str) : str)
-			.join("");
-	}
 
 	apply(compiler) {
 		compiler.plugin("compilation", compilation => {
@@ -26,7 +15,7 @@ class RecordIdsPlugin {
 				if(!records.modules.byIdentifier) records.modules.byIdentifier = {};
 				if(!records.modules.usedIds) records.modules.usedIds = {};
 				modules.forEach(function(module) {
-					if(!module.portableId) module.portableId = RecordIdsPlugin.makeRelative(compiler.context, module.identifier());
+					if(!module.portableId) module.portableId = identifierUtils.makePathsRelative(compiler.context, module.identifier());
 					const identifier = module.portableId;
 					records.modules.byIdentifier[identifier] = module.id;
 					records.modules.usedIds[module.id] = module.id;
@@ -38,7 +27,7 @@ class RecordIdsPlugin {
 					const usedIds = {};
 					modules.forEach(function(module) {
 						if(module.id !== null) return;
-						if(!module.portableId) module.portableId = RecordIdsPlugin.makeRelative(compiler.context, module.identifier());
+						if(!module.portableId) module.portableId = identifierUtils.makePathsRelative(compiler.context, module.identifier());
 						const identifier = module.portableId;
 						const id = records.modules.byIdentifier[identifier];
 						if(id === undefined) return;
@@ -62,7 +51,7 @@ class RecordIdsPlugin {
 					block = block.parent;
 				}
 				if(!block.identifier) return null;
-				ident.unshift(RecordIdsPlugin.makeRelative(compiler.context, block.identifier()));
+				ident.unshift(identifierUtils.makePathsRelative(compiler.context, block.identifier()));
 				return ident.join(":");
 			}
 			compilation.plugin("record-chunks", (chunks, records) => {

--- a/lib/optimize/AggressiveSplittingPlugin.js
+++ b/lib/optimize/AggressiveSplittingPlugin.js
@@ -4,18 +4,7 @@
 */
 "use strict";
 
-let path = require("path");
-
-function makeRelative(context) {
-	return function(module) {
-		const identifier = module.identifier();
-		return identifier.split("|").map((str) => {
-			return str.split("!").map((str) => {
-				return path.relative(context, str);
-			}).join("!");
-		}).join("|");
-	};
-}
+const identifierUtils = require("../util/identifier");
 
 function toIndexOf(list) {
 	return function(item) {
@@ -73,7 +62,7 @@ class AggressiveSplittingPlugin {
 					const splitData = usedSplits[j];
 					for(let i = 0; i < chunks.length; i++) {
 						const chunk = chunks[i];
-						const chunkModuleNames = chunk.modules.map(makeRelative(compiler.context));
+						const chunkModuleNames = chunk.modules.map(m => identifierUtils.makePathsRelative(compiler.context, m.identifier()));
 
 						if(chunkModuleNames.length < splitData.modules.length)
 							continue;
@@ -148,7 +137,7 @@ class AggressiveSplittingPlugin {
 							newChunk.origins = chunk.origins.map(copyWithReason);
 							chunk.origins = chunk.origins.map(copyWithReason);
 							compilation._aggressiveSplittingSplits = (compilation._aggressiveSplittingSplits || []).concat({
-								modules: newChunk.modules.map(makeRelative(compiler.context))
+								modules: newChunk.modules.map(m => identifierUtils.makePathsRelative(compiler.context, m.identifier()))
 							});
 							return true;
 						} else {
@@ -165,7 +154,7 @@ class AggressiveSplittingPlugin {
 					if(chunk.hasEntryModule()) return;
 					const size = chunk.size(this.options);
 					const incorrectSize = size < minSize;
-					const modules = chunk.modules.map(makeRelative(compiler.context));
+					const modules = chunk.modules.map(m => identifierUtils.makePathsRelative(compiler.context, m.identifier()));
 					if(typeof chunk._fromAggressiveSplittingIndex === "undefined") {
 						if(incorrectSize) return;
 						chunk.recorded = true;

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -1,0 +1,13 @@
+"use strict";
+const path = require("path");
+
+const looksLikeAbsolutePath = exports.looksLikeAbsolutePath = (maybeAbsolutePath) => {
+	return /^(?:[a-z]:\\|\/)/i.test(maybeAbsolutePath);
+};
+
+exports.makePathsRelative = (context, identifier) => {
+	return identifier
+		.split(/([|! ])/)
+		.map(str => looksLikeAbsolutePath(str) ? path.relative(context, str) : str)
+		.join("");
+};

--- a/test/RecordIdsPlugin.test.js
+++ b/test/RecordIdsPlugin.test.js
@@ -2,11 +2,10 @@
 "use strict";
 
 const should = require("should");
-
 const path = require("path");
-const webpack = require("../lib/webpack");
 
-const RecordIdsPlugin = require("../lib/RecordIdsPlugin");
+const webpack = require("../lib/webpack");
+const identifierUtils = require("../lib/util/identifier");
 
 describe("RecordIdsPlugin", () => {
 
@@ -34,7 +33,7 @@ describe("RecordIdsPlugin", () => {
 			for(let i = 0; i < compilation.modules.length; i++) {
 				try {
 					should.exist(compilation.modules[i].portableId);
-					compilation.modules[i].portableId.should.equal(RecordIdsPlugin.makeRelative(compiler.context, compilation.modules[i].identifier()));
+					compilation.modules[i].portableId.should.equal(identifierUtils.makePathsRelative(compiler.context, compilation.modules[i].identifier()));
 				} catch(e) {
 					done(e);
 					pass = false;

--- a/test/util/identifier.test.js
+++ b/test/util/identifier.test.js
@@ -1,0 +1,24 @@
+/* globals describe, beforeEach, it */
+"use strict";
+
+const should = require("should");
+const path = require("path");
+
+const identifierUtil = require("../../lib/util/identifier");
+
+describe("pathUtil", () => {
+	describe("makeRelative", () => {
+		describe("given a context and a pathConstruct", () => {
+			let context, pathConstruct, expected;
+			beforeEach(() => {
+				context = "/some/dir/";
+				pathConstruct = "/some/dir/to/somwhere|some/other/dir!../more/dir";
+				expected = `${path.relative(context, "/some/dir/to/somwhere")}|${path.relative(context, "some/other/dir")}!${path.relative(context, "../more/dir")}`;
+			});
+
+			it("computes the correct relative results for the path construct", () => {
+				should(identifierUtil.makePathsRelative(context, pathConstruct)).be.exactly(expected);
+			});
+		});
+	});
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

Yes

**If relevant, link to documentation update:**

N/A

**Summary**

Replacement  for #4148 maybe this is good enough performance wise.
Speeds up unifies the `makeRelative` methods used in AggressiveSplittingPlugin and RecordIdsPlugin

**Does this PR introduce a breaking change?**

No

**Other information**

