### PR TITLE
chore(pkg): add postinstall hook to locally link yarn and self

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "schemas/"
   ],
   "scripts": {
+    "postinstall": "yarn link || true && yarn link webpack",
     "test": "mocha test/*.test.js --harmony --check-leaks",
     "travis:test": "npm run cover:min",
     "travis:lint": "npm run lint-files && npm run nsp",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Build related change (for postinstall hook)
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Not Applicable
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
None needed hopefully
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
This adds a simple `postinstall` hook in package.json that will attempt to run `yarn link` and `yarn link webpack` (unless they already are linked). I'm not 100% sure if this is cross-platform compat so going to give it a shot, and update changes where needed.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
"Fixes"/Motivation: https://github.com/webpack/webpack/pull/4610#issuecomment-290974949
**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
