### PR TITLE
assign correct records and cache to child compilations

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -80,6 +80,7 @@ class Compilation extends Tapable {
 		this.children = [];
 		this.dependencyFactories = new Map();
 		this.dependencyTemplates = new Map();
+		this.childrenCounters = {};
 	}
 
 	getStats() {
@@ -1218,8 +1219,10 @@ class Compilation extends Tapable {
 		return this.mainTemplate.applyPluginsWaterfall("asset-path", filename, data);
 	}
 
-	createChildCompiler(name, outputOptions) {
-		return this.compiler.createChildCompiler(this, name, outputOptions);
+	createChildCompiler(name, outputOptions, plugins) {
+		var idx = (this.childrenCounters[name] || 0);
+		this.childrenCounters[name] = idx + 1;
+		return this.compiler.createChildCompiler(this, name, idx, outputOptions, plugins);
 	}
 
 	checkConstraints() {

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -10,6 +10,8 @@ var Stats = require("./Stats");
 var NormalModuleFactory = require("./NormalModuleFactory");
 var ContextModuleFactory = require("./ContextModuleFactory");
 
+var makePathsRelative = require("./util/identifier").makePathsRelative;
+
 function Watching(compiler, watchOptions, handler) {
 	this.startTime = null;
 	this.invalid = false;
@@ -407,7 +409,7 @@ Compiler.prototype.readRecords = function readRecords(callback) {
 	});
 };
 
-Compiler.prototype.createChildCompiler = function(compilation, compilerName, outputOptions, plugins) {
+Compiler.prototype.createChildCompiler = function(compilation, compilerName, compilerIndex, outputOptions, plugins) {
 	var childCompiler = new Compiler();
 	if(Array.isArray(plugins)) {
 		plugins.forEach(plugin => childCompiler.apply(plugin));
@@ -423,8 +425,23 @@ Compiler.prototype.createChildCompiler = function(compilation, compilerName, out
 	childCompiler.resolvers = this.resolvers;
 	childCompiler.fileTimestamps = this.fileTimestamps;
 	childCompiler.contextTimestamps = this.contextTimestamps;
-	if(!this.records[compilerName]) this.records[compilerName] = [];
-	this.records[compilerName].push(childCompiler.records = {});
+
+	var relativeCompilerName = makePathsRelative(this.context, compilerName);
+	if(!this.records[relativeCompilerName]) this.records[relativeCompilerName] = [];
+	if(this.records[relativeCompilerName][compilerIndex])
+		childCompiler.records = this.records[relativeCompilerName][compilerIndex];
+	else
+		this.records[relativeCompilerName].push(childCompiler.records = {});
+
+	if(this.cache) {
+		if(!this.cache.children) this.cache.children = {};
+		if(!this.cache.children[compilerName]) this.cache.children[compilerName] = [];
+		if(this.cache.children[compilerName][compilerIndex])
+			childCompiler.cache = this.cache.children[compilerName][compilerIndex];
+		else
+			this.cache.children[compilerName].push(childCompiler.cache = {});
+	}
+
 	childCompiler.options = Object.create(this.options);
 	childCompiler.options.output = Object.create(childCompiler.options.output);
 	for(name in outputOptions) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
fixes #2777
creating a child compiler now assigns correct cache and records
compiler name is made relative
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
yes
This is a breaking change because plugins or loader could rely on this incorrect behavior
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
When using child compilations plugins and loaders should use a unique compiler name or use a consistent order