### PR TITLE
WIP Adds pilot support for top-level module await.

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -335,6 +335,18 @@ class Chunk {
 		return this.addMultiplierAndOverhead(integratedModulesSize, options);
 	}
 
+	hasTopLevelAwait() {
+		return this.modules.some(function(m) {
+			return m.topLevelAwait;
+		});
+	}
+
+	getTopLevelAwaitModules() {
+		return this.modules.filter(function(m) {
+			return m.topLevelAwait;
+		});
+	}
+
 	getChunkMaps(includeEntries, realHash) {
 		const chunksProcessed = [];
 		const chunkHashMap = {};

--- a/lib/JsonpChunkTemplatePlugin.js
+++ b/lib/JsonpChunkTemplatePlugin.js
@@ -17,6 +17,13 @@ class JsonpChunkTemplatePlugin {
 			if(entries.length > 0) {
 				source.add(`,${JSON.stringify(entries)}`);
 			}
+			const topLevelAwaits = chunk.getTopLevelAwaitModules().map(m => m.id);
+			if(topLevelAwaits.length > 0) {
+				if(entries.length === 0) {
+					source.add(",void 0");
+				}
+				source.add(`,${JSON.stringify(topLevelAwaits)}`);
+			}
 			source.add(")");
 			return source;
 		});

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -121,12 +121,28 @@ class JsonpMainTemplatePlugin {
 		mainTemplate.plugin("bootstrap", function(source, chunk, hash) {
 			if(chunk.chunks.length > 0) {
 				var jsonpFunction = this.outputOptions.jsonpFunction;
+				var topLevelAwaitHanding = this.topLevelAwaitInChildren(chunk);
+				var finalizeModulesCode = [
+					"while(resolves.length) {",
+					this.indent("resolves.shift()();"),
+					"}",
+					this.entryPointInChildren(chunk) ? [
+						"if(executeModules) {",
+						this.indent([
+							"for(i=0; i < executeModules.length; i++) {",
+							this.indent(`result = ${this.requireFn}(${this.requireFn}.s = executeModules[i]);`),
+							"}"
+						]),
+						"}",
+						"return result;",
+					] : "",
+				];
 				return this.asString([
 					source,
 					"",
 					"// install a JSONP callback for chunk loading",
 					`var parentJsonpFunction = window[${JSON.stringify(jsonpFunction)}];`,
-					`window[${JSON.stringify(jsonpFunction)}] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {`,
+					`window[${JSON.stringify(jsonpFunction)}] = function webpackJsonpCallback(chunkIds, moreModules, executeModules, topLevelAwaitModules) {`,
 					this.indent([
 						"// add \"moreModules\" to the modules object,",
 						"// then flag all \"chunkIds\" as loaded and fire callback",
@@ -148,19 +164,15 @@ class JsonpMainTemplatePlugin {
 						]),
 						"}",
 						"if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);",
-						"while(resolves.length) {",
-						this.indent("resolves.shift()();"),
-						"}",
-						this.entryPointInChildren(chunk) ? [
-							"if(executeModules) {",
-							this.indent([
-								"for(i=0; i < executeModules.length; i++) {",
-								this.indent(`result = ${this.requireFn}(${this.requireFn}.s = executeModules[i]);`),
-								"}"
-							]),
-							"}",
-							"return result;",
-						] : ""
+						topLevelAwaitHanding ? [
+							"var complete = function() {",
+							this.indent(finalizeModulesCode),
+							"};",
+							"if (!topLevelAwaitModules) { return complete(); }",
+							"Promise.all(topLevelAwaitModules.map(function(m) {",
+							this.indent(`return ${this.requireFn}(${this.requireFn}.s = m).__await;`),
+							"})).then(complete);"
+						] : finalizeModulesCode
 					]),
 					"};"
 				]);

--- a/lib/MainTemplate.js
+++ b/lib/MainTemplate.js
@@ -212,6 +212,17 @@ module.exports = class MainTemplate extends Template {
 		return checkChildren(chunk, []);
 	}
 
+	topLevelAwaitInChildren(chunk) {
+		const checkChildren = (chunk, alreadyCheckedChunks) => {
+			return chunk.chunks.some((child) => {
+				if(alreadyCheckedChunks.indexOf(child) >= 0) return;
+				alreadyCheckedChunks.push(child);
+				return child.hasTopLevelAwait() || checkChildren(child, alreadyCheckedChunks);
+			});
+		};
+		return checkChildren(chunk, []);
+	}
+
 	getPublicPath(options) {
 		return this.applyPluginsWaterfall("asset-path", this.outputOptions.publicPath || "", options);
 	}

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -74,6 +74,7 @@ class NormalModule extends Module {
 		this.assets = {};
 		this.built = false;
 		this._cachedSource = null;
+		this.topLevelAwait = false;
 	}
 
 	identifier() {
@@ -186,6 +187,7 @@ class NormalModule extends Module {
 				this.cacheable = result.cacheable;
 				this.fileDependencies = result.fileDependencies;
 				this.contextDependencies = result.contextDependencies;
+				this.topLevelAwait = result.topLevelAwait;
 			}
 
 			if(err) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

There is no functionality that allows to loader to introduce a wait into the module loading process. This allows inform the chunk initialization/bootstrap scripts to wait on exported by a module promise Promise.

**Did you add tests for your changes?**

There is a prototype for wasm-loader at 

https://github.com/yurydelendik/webpack-wasm-loader/

**If relevant, link to documentation update:**

N/A

**Summary**

The loader indicates by setting its topLevelAwait property/attribute
that after load the require.ensure will wait for __await promise/export.

**Does this PR introduce a breaking change?**

This is just a proposal since top-level module await is not a standard.

**Other information**

This is a WIP PR and require guidance and/or re-implementation.
