### PR TITLE
fix missing `hashSalt` from options schema

### DIFF
--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -333,6 +333,10 @@
           "minLength": 1,
           "type": "string"
         },
+        "hashSalt": {
+          "minLength": 1,
+          "type": "string"
+        },
         "hotUpdateChunkFilename": {
           "description": "The filename of the Hot Update Chunks. They are inside the output.path directory.",
           "type": "string",


### PR DESCRIPTION
Bugfix: the [output.hashSalt option](https://webpack.js.org/configuration/output/#output-hashsalt) was not actually usable as it was not in the schema.

