### PR TITLE
Split sourceMappingURL string

### DIFF
--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -206,9 +206,9 @@ class WebpackOptionsApply extends OptionsApply {
 			noSources = options.devtool.indexOf("nosources") >= 0;
 			legacy = options.devtool.indexOf("@") >= 0;
 			modern = options.devtool.indexOf("#") >= 0;
-			comment = legacy && modern ? "\n/*\n//@ sourceMappingURL=[url]\n//# sourceMappingURL=[url]\n*/" :
-				legacy ? "\n/*\n//@ sourceMappingURL=[url]\n*/" :
-				modern ? "\n//# sourceMappingURL=[url]" :
+			comment = legacy && modern ? "\n/*\n//@ source" + "MappingURL=[url]\n//# source" + "MappingURL=[url]\n*/" :
+				legacy ? "\n/*\n//@ source" + "MappingURL=[url]\n*/" :
+				modern ? "\n//# source" + "MappingURL=[url]" :
 				null;
 			let Plugin = evalWrapped ? EvalSourceMapDevToolPlugin : SourceMapDevToolPlugin;
 			compiler.apply(new Plugin({


### PR DESCRIPTION
This change is splitting `sourceMappingURL` to `source" + "MappingURL` in order to avoid syntax errors caused by babel when importing webpack in code that is transpiled by babel. This workaround was suggested in https://github.com/babel/babel/issues/4012 and this issue is an upstream to https://github.com/electron/electron-compilers/issues/67 and https://github.com/electron/electron-compile/issues/210 .

Apart from a small syntax change there are no changes to the functionality, no breaking changes and no other changes.