### PR TITLE
ProvidePlugin: add test case for ES2015 modules

### DIFF
--- a/test/configCases/plugins/provide-plugin/harmony.js
+++ b/test/configCases/plugins/provide-plugin/harmony.js
@@ -1,0 +1,3 @@
+export default "ECMAScript 2015";
+export const alias = "ECMAScript Harmony";
+export const year = 2015;

--- a/test/configCases/plugins/provide-plugin/index.js
+++ b/test/configCases/plugins/provide-plugin/index.js
@@ -25,3 +25,12 @@ it("should provide a module for a property request", function() {
 	var x = dddeeefff;
 	x.should.be.eql("fff");
 });
+
+it("should provide ES2015 modules", function() {
+	(es2015.default).should.be.eql("ECMAScript 2015");
+	(es2015.alias).should.be.eql("ECMAScript Harmony");
+	(es2015.year).should.be.eql(2015);
+	(es2015_name).should.be.eql("ECMAScript 2015");
+	(es2015_alias).should.be.eql("ECMAScript Harmony");
+	(es2015_year).should.be.eql(2015);
+});

--- a/test/configCases/plugins/provide-plugin/webpack.config.js
+++ b/test/configCases/plugins/provide-plugin/webpack.config.js
@@ -6,6 +6,10 @@ module.exports = {
 			"bbb.ccc": "./bbbccc",
 			"dddeeefff": ["./ddd", "eee", "3-f"],
 			"process.env.NODE_ENV": "./env",
+			es2015: "./harmony",
+			es2015_name: ["./harmony", "default"],
+			es2015_alias: ["./harmony", "alias"],
+			es2015_year: ["./harmony", "year"],
 		})
 	]
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?**

failing unit test for an unexpected behaviour

**Did you add tests for your changes?**

this is a unit test

**If relevant, link to documentation update:**

related: https://github.com/webpack/webpack.js.org/pull/1080

**Summary**

This PR introduces a failing unit test for the usage of ProvidePlugin together with an ES2015 module. For importing the default export of an ES2015 module, I can `import 'module'`. Counter-intuitively, this does not hold when using the `ProvidePlugin`: By default, it corresponds to the `import * from 'module'`.

The test `(es2015).should.be.eql("ECMAScript 2015");` in the PR fails with:
```
  2) ConfigTestCases plugins provide-plugin should provide ES2015 modules:
     AssertionError: expected Object {
  default: 'ECMAScript 2015',
  alias: 'ECMAScript Harmony',
  year: 2015
} to equal 'ECMAScript 2015'
      at Assertion.value (/home/simon/src/webpack/test/js/config/dll-plugin/2-use-dll-without-scope/bundle0.js:1920:19)
      at Context.<anonymous> (/home/simon/src/webpack/test/js/config/plugins/provide-plugin/bundle0.js:178:21)
      at callFn (/home/simon/src/webpack/node_modules/mocha/lib/runnable.js:345:21)
      at Test.Runnable.run (/home/simon/src/webpack/node_modules/mocha/lib/runnable.js:337:7)
      at Runner.runTest (/home/simon/src/webpack/node_modules/mocha/lib/runner.js:444:10)
      at /home/simon/src/webpack/node_modules/mocha/lib/runner.js:550:12
      at /home/simon/src/webpack/node_modules/mocha/lib/runner.js:371:7
      at Immediate.<anonymous> (/home/simon/src/webpack/node_modules/mocha/lib/runner.js:339:5)
      at tryOnImmediate (timers.js:639:5)
      at processImmediate [as _immediateCallback] (timers.js:611:5)
```

I find it counter-intuitive and might suddenly break the webpack build when a library switches to ES2015 modules.

**Does this PR introduce a breaking change?**

yes, if behaviour is changed

**Other information**
