### PR TITLE
👕⚒ lint fixes, 📦⬆ update webpack in examples

### DIFF
--- a/examples/aggressive-merging/README.md
+++ b/examples/aggressive-merging/README.md
@@ -56,21 +56,21 @@ module.exports = {
 ## Uncompressed
 
 ```
-Hash: 75bcce350a8b5f748873
-Version: webpack 2.3.2
+Hash: 1974cbce48c2f718486c
+Version: webpack 2.4.1
           Asset       Size  Chunks             Chunk Names
-     0.chunk.js    5.76 kB       0  [emitted]  
+     0.chunk.js    5.75 kB       0  [emitted]  
      1.chunk.js  401 bytes       1  [emitted]  
-pageB.bundle.js    6.41 kB       2  [emitted]  pageB
-pageA.bundle.js    6.38 kB       3  [emitted]  pageA
-pageC.bundle.js    6.17 kB       4  [emitted]  pageC
+pageB.bundle.js    6.49 kB       2  [emitted]  pageB
+pageA.bundle.js    6.46 kB       3  [emitted]  pageA
+pageC.bundle.js    6.26 kB       4  [emitted]  pageC
 Entrypoint pageA = pageA.bundle.js
 Entrypoint pageB = pageB.bundle.js
 Entrypoint pageC = pageC.bundle.js
-chunk    {0} 0.chunk.js 5.55 kB {2} {3} [rendered]
+chunk    {0} 0.chunk.js 5.54 kB {2} {3} [rendered]
     > aggressive-merge [3] ./pageA.js 1:0-3:2
     > aggressive-merge [4] ./pageB.js 1:0-3:2
-    [2] ./common.js 5.55 kB {0} [built]
+    [2] ./common.js 5.54 kB {0} [built]
         amd require ./common [3] ./pageA.js 1:0-3:2
         amd require ./common [4] ./pageB.js 1:0-3:2
 chunk    {1} 1.chunk.js 42 bytes {4} [rendered]
@@ -81,41 +81,41 @@ chunk    {1} 1.chunk.js 42 bytes {4} [rendered]
     [1] ./b.js 21 bytes {1} {2} [built]
         cjs require ./b [4] ./pageB.js 2:8-22
         cjs require ./b [5] ./pageC.js 2:17-31
-chunk    {2} pageB.bundle.js (pageB) 92 bytes [entry] [rendered]
+chunk    {2} pageB.bundle.js (pageB) 90 bytes [entry] [rendered]
     > pageB [4] ./pageB.js 
     [1] ./b.js 21 bytes {1} {2} [built]
         cjs require ./b [4] ./pageB.js 2:8-22
         cjs require ./b [5] ./pageC.js 2:17-31
-    [4] ./pageB.js 71 bytes {2} [built]
-chunk    {3} pageA.bundle.js (pageA) 92 bytes [entry] [rendered]
+    [4] ./pageB.js 69 bytes {2} [built]
+chunk    {3} pageA.bundle.js (pageA) 90 bytes [entry] [rendered]
     > pageA [3] ./pageA.js 
     [0] ./a.js 21 bytes {1} {3} [built]
         cjs require ./a [3] ./pageA.js 2:8-22
         amd require ./a [5] ./pageC.js 1:0-3:2
-    [3] ./pageA.js 71 bytes {3} [built]
-chunk    {4} pageC.bundle.js (pageC) 70 bytes [entry] [rendered]
+    [3] ./pageA.js 69 bytes {3} [built]
+chunk    {4} pageC.bundle.js (pageC) 68 bytes [entry] [rendered]
     > pageC [5] ./pageC.js 
-    [5] ./pageC.js 70 bytes {4} [built]
+    [5] ./pageC.js 68 bytes {4} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 75bcce350a8b5f748873
-Version: webpack 2.3.2
+Hash: 1974cbce48c2f718486c
+Version: webpack 2.4.1
           Asset      Size  Chunks             Chunk Names
      0.chunk.js  75 bytes       0  [emitted]  
      1.chunk.js  78 bytes       1  [emitted]  
-pageB.bundle.js   1.48 kB       2  [emitted]  pageB
-pageA.bundle.js   1.48 kB       3  [emitted]  pageA
-pageC.bundle.js   1.46 kB       4  [emitted]  pageC
+pageB.bundle.js   1.47 kB       2  [emitted]  pageB
+pageA.bundle.js   1.47 kB       3  [emitted]  pageA
+pageC.bundle.js   1.45 kB       4  [emitted]  pageC
 Entrypoint pageA = pageA.bundle.js
 Entrypoint pageB = pageB.bundle.js
 Entrypoint pageC = pageC.bundle.js
-chunk    {0} 0.chunk.js 5.55 kB {2} {3} [rendered]
+chunk    {0} 0.chunk.js 5.54 kB {2} {3} [rendered]
     > aggressive-merge [3] ./pageA.js 1:0-3:2
     > aggressive-merge [4] ./pageB.js 1:0-3:2
-    [2] ./common.js 5.55 kB {0} [built]
+    [2] ./common.js 5.54 kB {0} [built]
         amd require ./common [3] ./pageA.js 1:0-3:2
         amd require ./common [4] ./pageB.js 1:0-3:2
 chunk    {1} 1.chunk.js 42 bytes {4} [rendered]
@@ -126,19 +126,19 @@ chunk    {1} 1.chunk.js 42 bytes {4} [rendered]
     [1] ./b.js 21 bytes {1} {2} [built]
         cjs require ./b [4] ./pageB.js 2:8-22
         cjs require ./b [5] ./pageC.js 2:17-31
-chunk    {2} pageB.bundle.js (pageB) 92 bytes [entry] [rendered]
+chunk    {2} pageB.bundle.js (pageB) 90 bytes [entry] [rendered]
     > pageB [4] ./pageB.js 
     [1] ./b.js 21 bytes {1} {2} [built]
         cjs require ./b [4] ./pageB.js 2:8-22
         cjs require ./b [5] ./pageC.js 2:17-31
-    [4] ./pageB.js 71 bytes {2} [built]
-chunk    {3} pageA.bundle.js (pageA) 92 bytes [entry] [rendered]
+    [4] ./pageB.js 69 bytes {2} [built]
+chunk    {3} pageA.bundle.js (pageA) 90 bytes [entry] [rendered]
     > pageA [3] ./pageA.js 
     [0] ./a.js 21 bytes {1} {3} [built]
         cjs require ./a [3] ./pageA.js 2:8-22
         amd require ./a [5] ./pageC.js 1:0-3:2
-    [3] ./pageA.js 71 bytes {3} [built]
-chunk    {4} pageC.bundle.js (pageC) 70 bytes [entry] [rendered]
+    [3] ./pageA.js 69 bytes {3} [built]
+chunk    {4} pageC.bundle.js (pageC) 68 bytes [entry] [rendered]
     > pageC [5] ./pageC.js 
-    [5] ./pageC.js 70 bytes {4} [built]
+    [5] ./pageC.js 68 bytes {4} [built]
 ```

--- a/examples/build-common.js
+++ b/examples/build-common.js
@@ -11,10 +11,10 @@ var extraArgs = "";
 var targetArgs = global.NO_TARGET_ARGS ? "" : " ./example.js js/output.js";
 var displayReasons = global.NO_REASONS ? "" : " --display-reasons --display-used-exports --display-provided-exports";
 (function doIt(remainingTimes) {
-	cp.exec("node ../../bin/webpack.js" + displayReasons + " --display-chunks --display-modules --display-origins --display-entrypoints --output-public-path \"js/\" -p " + extraArgs + targetArgs, function (error, stdout, stderr) {
+	cp.exec("node ../../bin/webpack.js" + displayReasons + " --display-chunks --display-modules --display-origins --display-entrypoints --output-public-path \"js/\" -p " + extraArgs + targetArgs, function(error, stdout, stderr) {
 		if(stderr && remainingTimes === 1)
 			console.log(stderr);
-		if (error !== null && remainingTimes === 1)
+		if(error !== null && remainingTimes === 1)
 			console.log(error);
 		try {
 			var readme = tc.replaceResults(fs.readFileSync(require("path").join(process.cwd(), "template.md"), "utf-8"), process.cwd(), stdout.replace(/[\r\n]*$/, ""), "min");
@@ -22,12 +22,12 @@ var displayReasons = global.NO_REASONS ? "" : " --display-reasons --display-used
 			console.log(stderr);
 			throw e;
 		}
-		cp.exec("node ../../bin/webpack.js" + displayReasons + " --display-chunks --display-modules --display-origins --display-entrypoints --output-public-path \"js/\" --output-pathinfo " + extraArgs + targetArgs, function (error, stdout, stderr) {
+		cp.exec("node ../../bin/webpack.js" + displayReasons + " --display-chunks --display-modules --display-origins --display-entrypoints --output-public-path \"js/\" --output-pathinfo " + extraArgs + targetArgs, function(error, stdout, stderr) {
 			if(remainingTimes === 1)
 				console.log(stdout);
 			if(stderr && remainingTimes === 1)
 				console.log(stderr);
-			if (error !== null && remainingTimes === 1)
+			if(error !== null && remainingTimes === 1)
 				console.log(error);
 			readme = tc.replaceResults(readme, process.cwd(), stdout.replace(/[\r\n]*$/, ""));
 			readme = tc.replaceBase(readme);

--- a/examples/buildAll.js
+++ b/examples/buildAll.js
@@ -1,4 +1,4 @@
-var cp = require('child_process');
+var cp = require("child_process");
 var path = require("path");
 var fs = require("fs");
 
@@ -11,7 +11,7 @@ var cmds = fs.readdirSync(__dirname).filter(function(dirname) {
 var stack = function() {
 	console.log("done");
 };
-for(var i = cmds.length-1; i >= 0; i--) {
+for(var i = cmds.length - 1; i >= 0; i--) {
 	var cmd = cmds[i];
 	stack = (function(next, cmd) {
 		return function() {
@@ -21,7 +21,7 @@ for(var i = cmds.length-1; i >= 0; i--) {
 				else if(stderr) console.error(stderr), next();
 				else next();
 			});
-		}
+		};
 	}(stack, cmd));
 }
 stack();

--- a/examples/chunkhash/README.md
+++ b/examples/chunkhash/README.md
@@ -62,7 +62,7 @@ module.exports = {
 
 <!-- inlined minimized file "manifest.[chunkhash].js" -->
 <script>
-!function(e){function r(n){if(t[n])return t[n].exports;var o=t[n]={i:n,l:!1,exports:{}};return e[n].call(o.exports,o,o.exports,r),o.l=!0,o.exports}var n=window.webpackJsonp;window.webpackJsonp=function(t,c,u){for(var a,i,f,s=0,l=[];s<t.length;s++)i=t[s],o[i]&&l.push(o[i][0]),o[i]=0;for(a in c)Object.prototype.hasOwnProperty.call(c,a)&&(e[a]=c[a]);for(n&&n(t,c,u);l.length;)l.shift()();if(u)for(s=0;s<u.length;s++)f=r(r.s=u[s]);return f};var t={},o={4:0};r.e=function(e){function n(){u.onerror=u.onload=null,clearTimeout(a);var r=o[e];0!==r&&(r&&r[1](new Error("Loading chunk "+e+" failed.")),o[e]=void 0)}if(0===o[e])return Promise.resolve();if(o[e])return o[e][2];var t=new Promise(function(r,n){o[e]=[r,n]});o[e][2]=t;var c=document.getElementsByTagName("head")[0],u=document.createElement("script");u.type="text/javascript",u.charset="utf-8",u.async=!0,u.timeout=12e4,r.nc&&u.setAttribute("nonce",r.nc),u.src=r.p+""+{0:"d1359b519c10df30787b",1:"06459c375ec851b0e2ae",2:"4d752abc2fcf569f13fc",3:"8d8564a703e7631bff4b"}[e]+".js";var a=setTimeout(n,12e4);return u.onerror=u.onload=n,c.appendChild(u),t},r.m=e,r.c=t,r.i=function(e){return e},r.d=function(e,n,t){r.o(e,n)||Object.defineProperty(e,n,{configurable:!1,enumerable:!0,get:t})},r.n=function(e){var n=e&&e.__esModule?function(){return e.default}:function(){return e};return r.d(n,"a",n),n},r.o=function(e,r){return Object.prototype.hasOwnProperty.call(e,r)},r.p="js/",r.oe=function(e){throw console.error(e),e}}([]);
+!function(e){function r(n){if(t[n])return t[n].exports;var o=t[n]={i:n,l:!1,exports:{}};return e[n].call(o.exports,o,o.exports,r),o.l=!0,o.exports}var n=window.webpackJsonp;window.webpackJsonp=function(t,c,a){for(var u,i,f,s=0,l=[];s<t.length;s++)i=t[s],o[i]&&l.push(o[i][0]),o[i]=0;for(u in c)Object.prototype.hasOwnProperty.call(c,u)&&(e[u]=c[u]);for(n&&n(t,c,a);l.length;)l.shift()();if(a)for(s=0;s<a.length;s++)f=r(r.s=a[s]);return f};var t={},o={4:0};r.e=function(e){function n(){a.onerror=a.onload=null,clearTimeout(u);var r=o[e];0!==r&&(r&&r[1](new Error("Loading chunk "+e+" failed.")),o[e]=void 0)}if(0===o[e])return Promise.resolve();if(o[e])return o[e][2];var t=new Promise(function(r,n){o[e]=[r,n]});o[e][2]=t;var c=document.getElementsByTagName("head")[0],a=document.createElement("script");a.type="text/javascript",a.charset="utf-8",a.async=!0,a.timeout=12e4,r.nc&&a.setAttribute("nonce",r.nc),a.src=r.p+""+{0:"73c914f6cf22a5e4717f",1:"a459bae9ccae1d7cdd13",2:"8ea4052d1687a839d2f5",3:"e281070bd397e5cd1253"}[e]+".js";var u=setTimeout(n,12e4);return a.onerror=a.onload=n,c.appendChild(a),t},r.m=e,r.c=t,r.i=function(e){return e},r.d=function(e,n,t){r.o(e,n)||Object.defineProperty(e,n,{configurable:!1,enumerable:!0,get:t})},r.n=function(e){var n=e&&e.__esModule?function(){return e.default}:function(){return e};return r.d(n,"a",n),n},r.o=function(e,r){return Object.prototype.hasOwnProperty.call(e,r)},r.p="js/",r.oe=function(e){throw console.error(e),e}}([]);
 </script>
 
 <!-- optional when using the CommonChunkPlugin for vendor modules -->
@@ -143,67 +143,67 @@ __webpack_require__.e/* import() */(0).then(__webpack_require__.bind(null, /*! .
 ## Uncompressed
 
 ```
-Hash: ea635224271deb1b32d9
-Version: webpack 2.3.3
+Hash: a71b9cbde7c085c827d0
+Version: webpack 2.4.1
                   Asset       Size  Chunks             Chunk Names
-d1359b519c10df30787b.js  237 bytes       0  [emitted]  
-06459c375ec851b0e2ae.js  243 bytes       1  [emitted]  
-    common.[chunkhash].js  747 bytes       2  [emitted]  common
-      main.[chunkhash].js  654 bytes       3  [emitted]  main
-  manifest.[chunkhash].js    5.88 kB       4  [emitted]  manifest
+73c914f6cf22a5e4717f.js  236 bytes       0  [emitted]  
+a459bae9ccae1d7cdd13.js  242 bytes       1  [emitted]  
+    common.[chunkhash].js  745 bytes       2  [emitted]  common
+      main.[chunkhash].js  650 bytes       3  [emitted]  main
+  manifest.[chunkhash].js    5.96 kB       4  [emitted]  manifest
 Entrypoint main = manifest.[chunkhash].js common.[chunkhash].js main.[chunkhash].js
 Entrypoint common = manifest.[chunkhash].js common.[chunkhash].js
-chunk    {0} d1359b519c10df30787b.js 29 bytes {3} [rendered]
+chunk    {0} 73c914f6cf22a5e4717f.js 28 bytes {3} [rendered]
     > [3] ./example.js 4:0-18
-    [2] ./async2.js 29 bytes {0} [built]
+    [2] ./async2.js 28 bytes {0} [built]
         import() ./async2 [3] ./example.js 4:0-18
-chunk    {1} 06459c375ec851b0e2ae.js 29 bytes {3} [rendered]
+chunk    {1} a459bae9ccae1d7cdd13.js 28 bytes {3} [rendered]
     > [3] ./example.js 3:0-18
-    [1] ./async1.js 29 bytes {1} [built]
+    [1] ./async1.js 28 bytes {1} [built]
         import() ./async1 [3] ./example.js 3:0-18
-chunk    {2} common.[chunkhash].js (common) 97 bytes {4} [initial] [rendered]
+chunk    {2} common.[chunkhash].js (common) 95 bytes {4} [initial] [rendered]
     > common [4] multi ./vendor 
-    [0] ./vendor.js 69 bytes {2} [built]
+    [0] ./vendor.js 67 bytes {2} [built]
         [exports: default]
         harmony import ./vendor [3] ./example.js 1:0-30
         single entry ./vendor [4] multi ./vendor common:100000
     [4] multi ./vendor 28 bytes {2} [built]
-chunk    {3} main.[chunkhash].js (main) 90 bytes {2} [initial] [rendered]
+chunk    {3} main.[chunkhash].js (main) 86 bytes {2} [initial] [rendered]
     > main [3] ./example.js 
-    [3] ./example.js 90 bytes {3} [built]
+    [3] ./example.js 86 bytes {3} [built]
 chunk    {4} manifest.[chunkhash].js (manifest) 0 bytes [entry] [rendered]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: ea635224271deb1b32d9
-Version: webpack 2.3.3
+Hash: a71b9cbde7c085c827d0
+Version: webpack 2.4.1
                   Asset       Size  Chunks             Chunk Names
-d1359b519c10df30787b.js   38 bytes       0  [emitted]  
-06459c375ec851b0e2ae.js   37 bytes       1  [emitted]  
+73c914f6cf22a5e4717f.js   38 bytes       0  [emitted]  
+a459bae9ccae1d7cdd13.js   37 bytes       1  [emitted]  
     common.[chunkhash].js  152 bytes       2  [emitted]  common
       main.[chunkhash].js  166 bytes       3  [emitted]  main
   manifest.[chunkhash].js    1.48 kB       4  [emitted]  manifest
 Entrypoint main = manifest.[chunkhash].js common.[chunkhash].js main.[chunkhash].js
 Entrypoint common = manifest.[chunkhash].js common.[chunkhash].js
-chunk    {0} d1359b519c10df30787b.js 29 bytes {3} [rendered]
+chunk    {0} 73c914f6cf22a5e4717f.js 28 bytes {3} [rendered]
     > [3] ./example.js 4:0-18
-    [2] ./async2.js 29 bytes {0} [built]
+    [2] ./async2.js 28 bytes {0} [built]
         import() ./async2 [3] ./example.js 4:0-18
-chunk    {1} 06459c375ec851b0e2ae.js 29 bytes {3} [rendered]
+chunk    {1} a459bae9ccae1d7cdd13.js 28 bytes {3} [rendered]
     > [3] ./example.js 3:0-18
-    [1] ./async1.js 29 bytes {1} [built]
+    [1] ./async1.js 28 bytes {1} [built]
         import() ./async1 [3] ./example.js 3:0-18
-chunk    {2} common.[chunkhash].js (common) 97 bytes {4} [initial] [rendered]
+chunk    {2} common.[chunkhash].js (common) 95 bytes {4} [initial] [rendered]
     > common [4] multi ./vendor 
-    [0] ./vendor.js 69 bytes {2} [built]
+    [0] ./vendor.js 67 bytes {2} [built]
         [exports: default]
         harmony import ./vendor [3] ./example.js 1:0-30
         single entry ./vendor [4] multi ./vendor common:100000
     [4] multi ./vendor 28 bytes {2} [built]
-chunk    {3} main.[chunkhash].js (main) 90 bytes {2} [initial] [rendered]
+chunk    {3} main.[chunkhash].js (main) 86 bytes {2} [initial] [rendered]
     > main [3] ./example.js 
-    [3] ./example.js 90 bytes {3} [built]
+    [3] ./example.js 86 bytes {3} [built]
 chunk    {4} manifest.[chunkhash].js (manifest) 0 bytes [entry] [rendered]
 ```

--- a/examples/code-splitted-css-bundle/README.md
+++ b/examples/code-splitted-css-bundle/README.md
@@ -66,33 +66,33 @@ body {
 ## Uncompressed
 
 ```
-Hash: 921f06e52b5748b2b7f9
-Version: webpack 2.3.2
+Hash: 4335d3b22ec197d3addb
+Version: webpack 2.4.1
                                Asset       Size  Chunks             Chunk Names
 ce21cbdd9b894e6af794813eb3fdaf60.png  119 bytes          [emitted]  
                          0.output.js    2.24 kB       0  [emitted]  
-                           output.js    15.5 kB       1  [emitted]  main
-                           style.css   71 bytes       1  [emitted]  main
+                           output.js    15.3 kB       1  [emitted]  main
+                           style.css   68 bytes       1  [emitted]  main
 Entrypoint main = output.js style.css
-chunk    {0} 0.output.js 1.25 kB {1} [rendered]
+chunk    {0} 0.output.js 1.24 kB {1} [rendered]
     > [2] ./example.js 2:0-20
-    [1] ./chunk.js 26 bytes {0} [built]
+    [1] ./chunk.js 25 bytes {0} [built]
         amd require ./chunk [2] ./example.js 2:0-20
-    [5] (webpack)/~/css-loader!./style2.css 227 bytes {0} [built]
+    [5] (webpack)/~/css-loader!./style2.css 221 bytes {0} [built]
         cjs require !!../../node_modules/css-loader/index.js!./style2.css [6] ./style2.css 4:14-78
     [6] ./style2.css 914 bytes {0} [built]
         cjs require ./style2.css [1] ./chunk.js 1:0-23
     [7] ./image2.png 82 bytes {0} [built]
-        cjs require ./image2.png [5] (webpack)/~/css-loader!./style2.css 6:58-81
-chunk    {1} output.js, style.css (main) 8.75 kB [entry] [rendered]
+        cjs require ./image2.png [5] (webpack)/~/css-loader!./style2.css 6:56-79
+chunk    {1} output.js, style.css (main) 8.5 kB [entry] [rendered]
     > main [2] ./example.js 
     [0] ./style.css 41 bytes {1} [built]
         cjs require ./style.css [2] ./example.js 1:0-22
-    [2] ./example.js 48 bytes {1} [built]
+    [2] ./example.js 46 bytes {1} [built]
     [3] (webpack)/~/css-loader/lib/css-base.js 1.51 kB {1} [built]
         cjs require ../../node_modules/css-loader/lib/css-base.js [5] (webpack)/~/css-loader!./style2.css 1:27-83
         cjs require ../../node_modules/css-loader/lib/css-base.js [8] (webpack)/~/css-loader!./style.css 1:27-83
-    [4] (webpack)/~/style-loader/addStyles.js 7.15 kB {1} [built]
+    [4] (webpack)/~/style-loader/addStyles.js 6.91 kB {1} [built]
         cjs require !../../node_modules/style-loader/addStyles.js [6] ./style2.css 7:13-69
 Child extract-text-webpack-plugin:
     Entrypoint undefined = extract-text-webpack-plugin-output-filename
@@ -101,24 +101,24 @@ Child extract-text-webpack-plugin:
         [0] (webpack)/~/css-loader/lib/css-base.js 1.51 kB {0} [built]
             cjs require ../../node_modules/css-loader/lib/css-base.js [2] (webpack)/~/css-loader!./style.css 1:27-83
         [1] ./image.png 82 bytes {0} [built]
-            cjs require ./image.png [2] (webpack)/~/css-loader!./style.css 6:58-80
-        [2] (webpack)/~/css-loader!./style.css 226 bytes {0} [built]
+            cjs require ./image.png [2] (webpack)/~/css-loader!./style.css 6:56-78
+        [2] (webpack)/~/css-loader!./style.css 220 bytes {0} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: b832c58ce5b88806634b
-Version: webpack 2.3.2
+Hash: 45ba8a8ef1217fa4c736
+Version: webpack 2.4.1
                                Asset       Size  Chunks             Chunk Names
 ce21cbdd9b894e6af794813eb3fdaf60.png  119 bytes          [emitted]  
                          0.output.js  309 bytes       0  [emitted]  
-                           output.js    5.02 kB       1  [emitted]  main
+                           output.js    5.01 kB       1  [emitted]  main
                            style.css   61 bytes       1  [emitted]  main
 Entrypoint main = output.js style.css
 chunk    {0} 0.output.js 1.23 kB {1} [rendered]
     > [2] ./example.js 2:0-20
-    [1] ./chunk.js 26 bytes {0} [built]
+    [1] ./chunk.js 25 bytes {0} [built]
         amd require ./chunk [2] ./example.js 2:0-20
     [5] (webpack)/~/css-loader!./style2.css 210 bytes {0} [built]
         cjs require !!../../node_modules/css-loader/index.js!./style2.css [6] ./style2.css 4:14-78
@@ -126,15 +126,15 @@ chunk    {0} 0.output.js 1.23 kB {1} [rendered]
         cjs require ./style2.css [1] ./chunk.js 1:0-23
     [7] ./image2.png 82 bytes {0} [built]
         cjs require ./image2.png [5] (webpack)/~/css-loader!./style2.css 6:50-73
-chunk    {1} output.js, style.css (main) 8.75 kB [entry] [rendered]
+chunk    {1} output.js, style.css (main) 8.5 kB [entry] [rendered]
     > main [2] ./example.js 
     [0] ./style.css 41 bytes {1} [built]
         cjs require ./style.css [2] ./example.js 1:0-22
-    [2] ./example.js 48 bytes {1} [built]
+    [2] ./example.js 46 bytes {1} [built]
     [3] (webpack)/~/css-loader/lib/css-base.js 1.51 kB {1} [built]
         cjs require ../../node_modules/css-loader/lib/css-base.js [5] (webpack)/~/css-loader!./style2.css 1:27-83
         cjs require ../../node_modules/css-loader/lib/css-base.js [8] (webpack)/~/css-loader!./style.css 1:27-83
-    [4] (webpack)/~/style-loader/addStyles.js 7.15 kB {1} [built]
+    [4] (webpack)/~/style-loader/addStyles.js 6.91 kB {1} [built]
         cjs require !../../node_modules/style-loader/addStyles.js [6] ./style2.css 7:13-69
 Child extract-text-webpack-plugin:
     Entrypoint undefined = extract-text-webpack-plugin-output-filename

--- a/examples/code-splitted-require.context-amd/README.md
+++ b/examples/code-splitted-require.context-amd/README.md
@@ -28,8 +28,9 @@ getTemplate("b", function(b) {
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -38,8 +39,9 @@ getTemplate("b", function(b) {
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/
 /******/ 	};
 /******/
@@ -55,9 +57,9 @@ getTemplate("b", function(b) {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -78,8 +80,9 @@ getTemplate("b", function(b) {
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -112,7 +115,9 @@ getTemplate("b", function(b) {
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -278,53 +283,53 @@ module.exports = function() {
 ## Uncompressed
 
 ```
-Hash: 1c46bbe47e8b8a0ee8e2
-Version: webpack 2.3.2
+Hash: 6c476b947000c740015d
+Version: webpack 2.4.1
       Asset     Size  Chunks             Chunk Names
-0.output.js  1.85 kB       0  [emitted]  
-  output.js  6.36 kB       1  [emitted]  main
+0.output.js  1.84 kB       0  [emitted]  
+  output.js  6.43 kB       1  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} 0.output.js 463 bytes {1} [rendered]
+chunk    {0} 0.output.js 457 bytes {1} [rendered]
     > [0] ./example.js 2:1-4:3
     [1] ../require.context/templates ^\.\/.*$ 217 bytes {0} [built]
         amd require context ../require.context/templates [0] ./example.js 2:1-4:3
-    [2] ../require.context/templates/a.js 82 bytes {0} [optional] [built]
+    [2] ../require.context/templates/a.js 80 bytes {0} [optional] [built]
         context element ./a [1] ../require.context/templates ^\.\/.*$ ./a
         context element ./a.js [1] ../require.context/templates ^\.\/.*$ ./a.js
-    [3] ../require.context/templates/b.js 82 bytes {0} [optional] [built]
+    [3] ../require.context/templates/b.js 80 bytes {0} [optional] [built]
         context element ./b [1] ../require.context/templates ^\.\/.*$ ./b
         context element ./b.js [1] ../require.context/templates ^\.\/.*$ ./b.js
-    [4] ../require.context/templates/c.js 82 bytes {0} [optional] [built]
+    [4] ../require.context/templates/c.js 80 bytes {0} [optional] [built]
         context element ./c [1] ../require.context/templates ^\.\/.*$ ./c
         context element ./c.js [1] ../require.context/templates ^\.\/.*$ ./c.js
-chunk    {1} output.js (main) 261 bytes [entry] [rendered]
+chunk    {1} output.js (main) 251 bytes [entry] [rendered]
     > main [0] ./example.js 
-    [0] ./example.js 261 bytes {1} [built]
+    [0] ./example.js 251 bytes {1} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 1c46bbe47e8b8a0ee8e2
-Version: webpack 2.3.2
+Hash: 6c476b947000c740015d
+Version: webpack 2.4.1
       Asset       Size  Chunks             Chunk Names
 0.output.js  544 bytes       0  [emitted]  
-  output.js    1.54 kB       1  [emitted]  main
+  output.js    1.53 kB       1  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} 0.output.js 463 bytes {1} [rendered]
+chunk    {0} 0.output.js 457 bytes {1} [rendered]
     > [0] ./example.js 2:1-4:3
     [1] ../require.context/templates ^\.\/.*$ 217 bytes {0} [built]
         amd require context ../require.context/templates [0] ./example.js 2:1-4:3
-    [2] ../require.context/templates/a.js 82 bytes {0} [optional] [built]
+    [2] ../require.context/templates/a.js 80 bytes {0} [optional] [built]
         context element ./a [1] ../require.context/templates ^\.\/.*$ ./a
         context element ./a.js [1] ../require.context/templates ^\.\/.*$ ./a.js
-    [3] ../require.context/templates/b.js 82 bytes {0} [optional] [built]
+    [3] ../require.context/templates/b.js 80 bytes {0} [optional] [built]
         context element ./b [1] ../require.context/templates ^\.\/.*$ ./b
         context element ./b.js [1] ../require.context/templates ^\.\/.*$ ./b.js
-    [4] ../require.context/templates/c.js 82 bytes {0} [optional] [built]
+    [4] ../require.context/templates/c.js 80 bytes {0} [optional] [built]
         context element ./c [1] ../require.context/templates ^\.\/.*$ ./c
         context element ./c.js [1] ../require.context/templates ^\.\/.*$ ./c.js
-chunk    {1} output.js (main) 261 bytes [entry] [rendered]
+chunk    {1} output.js (main) 251 bytes [entry] [rendered]
     > main [0] ./example.js 
-    [0] ./example.js 261 bytes {1} [built]
+    [0] ./example.js 251 bytes {1} [built]
 ```

--- a/examples/code-splitted-require.context/README.md
+++ b/examples/code-splitted-require.context/README.md
@@ -28,8 +28,9 @@ getTemplate("b", function(b) {
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -38,8 +39,9 @@ getTemplate("b", function(b) {
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/
 /******/ 	};
 /******/
@@ -55,9 +57,9 @@ getTemplate("b", function(b) {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -78,8 +80,9 @@ getTemplate("b", function(b) {
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -112,7 +115,9 @@ getTemplate("b", function(b) {
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -278,53 +283,53 @@ module.exports = function() {
 ## Uncompressed
 
 ```
-Hash: f67ab883501eec17d2fb
-Version: webpack 2.3.2
+Hash: 7cfb8603084866aa929a
+Version: webpack 2.4.1
       Asset     Size  Chunks             Chunk Names
-0.output.js  1.85 kB       0  [emitted]  
-  output.js   6.3 kB       1  [emitted]  main
+0.output.js  1.84 kB       0  [emitted]  
+  output.js  6.37 kB       1  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} 0.output.js 463 bytes {1} [rendered]
+chunk    {0} 0.output.js 457 bytes {1} [rendered]
     > [0] ./example.js 2:1-4:3
     [1] ../require.context/templates ^\.\/.*$ 217 bytes {0} [built]
         cjs require context ../require.context/templates [0] ./example.js 3:11-64
-    [2] ../require.context/templates/a.js 82 bytes {0} [optional] [built]
+    [2] ../require.context/templates/a.js 80 bytes {0} [optional] [built]
         context element ./a [1] ../require.context/templates ^\.\/.*$ ./a
         context element ./a.js [1] ../require.context/templates ^\.\/.*$ ./a.js
-    [3] ../require.context/templates/b.js 82 bytes {0} [optional] [built]
+    [3] ../require.context/templates/b.js 80 bytes {0} [optional] [built]
         context element ./b [1] ../require.context/templates ^\.\/.*$ ./b
         context element ./b.js [1] ../require.context/templates ^\.\/.*$ ./b.js
-    [4] ../require.context/templates/c.js 82 bytes {0} [optional] [built]
+    [4] ../require.context/templates/c.js 80 bytes {0} [optional] [built]
         context element ./c [1] ../require.context/templates ^\.\/.*$ ./c
         context element ./c.js [1] ../require.context/templates ^\.\/.*$ ./c.js
-chunk    {1} output.js (main) 276 bytes [entry] [rendered]
+chunk    {1} output.js (main) 266 bytes [entry] [rendered]
     > main [0] ./example.js 
-    [0] ./example.js 276 bytes {1} [built]
+    [0] ./example.js 266 bytes {1} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: f67ab883501eec17d2fb
-Version: webpack 2.3.2
+Hash: 7cfb8603084866aa929a
+Version: webpack 2.4.1
       Asset       Size  Chunks             Chunk Names
 0.output.js  544 bytes       0  [emitted]  
   output.js    1.51 kB       1  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} 0.output.js 463 bytes {1} [rendered]
+chunk    {0} 0.output.js 457 bytes {1} [rendered]
     > [0] ./example.js 2:1-4:3
     [1] ../require.context/templates ^\.\/.*$ 217 bytes {0} [built]
         cjs require context ../require.context/templates [0] ./example.js 3:11-64
-    [2] ../require.context/templates/a.js 82 bytes {0} [optional] [built]
+    [2] ../require.context/templates/a.js 80 bytes {0} [optional] [built]
         context element ./a [1] ../require.context/templates ^\.\/.*$ ./a
         context element ./a.js [1] ../require.context/templates ^\.\/.*$ ./a.js
-    [3] ../require.context/templates/b.js 82 bytes {0} [optional] [built]
+    [3] ../require.context/templates/b.js 80 bytes {0} [optional] [built]
         context element ./b [1] ../require.context/templates ^\.\/.*$ ./b
         context element ./b.js [1] ../require.context/templates ^\.\/.*$ ./b.js
-    [4] ../require.context/templates/c.js 82 bytes {0} [optional] [built]
+    [4] ../require.context/templates/c.js 80 bytes {0} [optional] [built]
         context element ./c [1] ../require.context/templates ^\.\/.*$ ./c
         context element ./c.js [1] ../require.context/templates ^\.\/.*$ ./c.js
-chunk    {1} output.js (main) 276 bytes [entry] [rendered]
+chunk    {1} output.js (main) 266 bytes [entry] [rendered]
     > main [0] ./example.js 
-    [0] ./example.js 276 bytes {1} [built]
+    [0] ./example.js 266 bytes {1} [built]
 ```

--- a/examples/code-splitting-bundle-loader/README.md
+++ b/examples/code-splitting-bundle-loader/README.md
@@ -31,8 +31,9 @@ module.exports = "It works";
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -41,8 +42,9 @@ module.exports = "It works";
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/
 /******/ 	};
 /******/
@@ -58,9 +60,9 @@ module.exports = "It works";
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -81,8 +83,9 @@ module.exports = "It works";
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -115,7 +118,9 @@ module.exports = "It works";
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -238,28 +243,28 @@ module.exports = "It works";
 ## Uncompressed
 
 ```
-Hash: b569890a1f87dd375a1a
-Version: webpack 2.3.2
+Hash: dd6981a76eaabcafb273
+Version: webpack 2.4.1
       Asset       Size  Chunks             Chunk Names
 0.output.js  230 bytes       0  [emitted]  
-  output.js    6.69 kB       1  [emitted]  main
+  output.js    6.77 kB       1  [emitted]  main
 Entrypoint main = output.js
 chunk    {0} 0.output.js 28 bytes {1} [rendered]
     > [0] (webpack)/~/bundle-loader!./file.js 7:0-14:2
     [2] ./file.js 28 bytes {0} [built]
         cjs require !!./file.js [0] (webpack)/~/bundle-loader!./file.js 8:8-30
-chunk    {1} output.js (main) 378 bytes [entry] [rendered]
+chunk    {1} output.js (main) 375 bytes [entry] [rendered]
     > main [1] ./example.js 
     [0] (webpack)/~/bundle-loader!./file.js 281 bytes {1} [built]
         cjs require bundle-loader!./file.js [1] ./example.js 1:0-34
-    [1] ./example.js 97 bytes {1} [built]
+    [1] ./example.js 94 bytes {1} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: b569890a1f87dd375a1a
-Version: webpack 2.3.2
+Hash: dd6981a76eaabcafb273
+Version: webpack 2.4.1
       Asset      Size  Chunks             Chunk Names
 0.output.js  58 bytes       0  [emitted]  
   output.js   1.57 kB       1  [emitted]  main
@@ -268,9 +273,9 @@ chunk    {0} 0.output.js 28 bytes {1} [rendered]
     > [0] (webpack)/~/bundle-loader!./file.js 7:0-14:2
     [2] ./file.js 28 bytes {0} [built]
         cjs require !!./file.js [0] (webpack)/~/bundle-loader!./file.js 8:8-30
-chunk    {1} output.js (main) 378 bytes [entry] [rendered]
+chunk    {1} output.js (main) 375 bytes [entry] [rendered]
     > main [1] ./example.js 
     [0] (webpack)/~/bundle-loader!./file.js 281 bytes {1} [built]
         cjs require bundle-loader!./file.js [1] ./example.js 1:0-34
-    [1] ./example.js 97 bytes {1} [built]
+    [1] ./example.js 94 bytes {1} [built]
 ```

--- a/examples/code-splitting-harmony/README.md
+++ b/examples/code-splitting-harmony/README.md
@@ -39,8 +39,9 @@ Promise.all([loadC("1"), loadC("2")]).then(function(arr) {
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -49,8 +50,9 @@ Promise.all([loadC("1"), loadC("2")]).then(function(arr) {
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/
 /******/ 	};
 /******/
@@ -66,9 +68,9 @@ Promise.all([loadC("1"), loadC("2")]).then(function(arr) {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -89,8 +91,9 @@ Promise.all([loadC("1"), loadC("2")]).then(function(arr) {
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -123,7 +126,9 @@ Promise.all([loadC("1"), loadC("2")]).then(function(arr) {
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -270,13 +275,13 @@ Promise.all([loadC("1"), loadC("2")]).then(function(arr) {
 ## Uncompressed
 
 ```
-Hash: d615402477252ba51b19
-Version: webpack 2.3.2
+Hash: ba65a04e3475286b58c0
+Version: webpack 2.4.1
       Asset       Size  Chunks             Chunk Names
 0.output.js  218 bytes       0  [emitted]  
 1.output.js  218 bytes       1  [emitted]  
 2.output.js  210 bytes       2  [emitted]  
-  output.js    7.48 kB       3  [emitted]  main
+  output.js    7.55 kB       3  [emitted]  main
 Entrypoint main = output.js
 chunk    {0} 0.output.js 13 bytes {3} [rendered]
     [3] ./~/c/2.js 13 bytes {0} [optional] [built]
@@ -290,26 +295,26 @@ chunk    {2} 2.output.js 11 bytes {3} [rendered]
     > [4] ./example.js 3:0-11
     [5] ./~/b.js 11 bytes {2} [built]
         import() b [4] ./example.js 3:0-11
-chunk    {3} output.js (main) 427 bytes [entry] [rendered]
+chunk    {3} output.js (main) 414 bytes [entry] [rendered]
     > main [4] ./example.js 
     [0] ./~/a.js 11 bytes {3} [built]
         [no exports used]
         harmony import a [4] ./example.js 1:0-18
     [1] ./~/c async ^\.\/.*$ 160 bytes {3} [built]
         import() context c [4] ./example.js 8:8-27
-    [4] ./example.js 256 bytes {3} [built]
+    [4] ./example.js 243 bytes {3} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: d615402477252ba51b19
-Version: webpack 2.3.2
+Hash: ba65a04e3475286b58c0
+Version: webpack 2.4.1
       Asset      Size  Chunks             Chunk Names
 0.output.js  38 bytes       0  [emitted]  
 1.output.js  38 bytes       1  [emitted]  
 2.output.js  38 bytes       2  [emitted]  
-  output.js   1.92 kB       3  [emitted]  main
+  output.js   1.91 kB       3  [emitted]  main
 Entrypoint main = output.js
 chunk    {0} 0.output.js 13 bytes {3} [rendered]
     [3] ./~/c/2.js 13 bytes {0} [optional] [built]
@@ -323,12 +328,12 @@ chunk    {2} 2.output.js 11 bytes {3} [rendered]
     > [4] ./example.js 3:0-11
     [5] ./~/b.js 11 bytes {2} [built]
         import() b [4] ./example.js 3:0-11
-chunk    {3} output.js (main) 427 bytes [entry] [rendered]
+chunk    {3} output.js (main) 414 bytes [entry] [rendered]
     > main [4] ./example.js 
     [0] ./~/a.js 11 bytes {3} [built]
         [no exports used]
         harmony import a [4] ./example.js 1:0-18
     [1] ./~/c async ^\.\/.*$ 160 bytes {3} [built]
         import() context c [4] ./example.js 8:8-27
-    [4] ./example.js 256 bytes {3} [built]
+    [4] ./example.js 243 bytes {3} [built]
 ```

--- a/examples/code-splitting-native-import-context/README.md
+++ b/examples/code-splitting-native-import-context/README.md
@@ -46,8 +46,9 @@ export default foo;
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -56,8 +57,9 @@ export default foo;
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/
 /******/ 	};
 /******/
@@ -73,9 +75,9 @@ export default foo;
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -96,8 +98,9 @@ export default foo;
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -130,7 +133,9 @@ export default foo;
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -273,68 +278,68 @@ getTemplate("baz");
 ## Uncompressed
 
 ```
-Hash: 0d608a65d597e766b156
-Version: webpack 2.3.2
+Hash: 6ff942ea6efa4b698d2f
+Version: webpack 2.4.1
       Asset       Size  Chunks             Chunk Names
-0.output.js  442 bytes       0  [emitted]  
-1.output.js  442 bytes       1  [emitted]  
-2.output.js  448 bytes       2  [emitted]  
-  output.js    7.07 kB       3  [emitted]  main
+0.output.js  439 bytes       0  [emitted]  
+1.output.js  439 bytes       1  [emitted]  
+2.output.js  445 bytes       2  [emitted]  
+  output.js    7.14 kB       3  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} 0.output.js 41 bytes {3} [rendered]
-    [3] ./templates/foo.js 41 bytes {0} [optional] [built]
+chunk    {0} 0.output.js 38 bytes {3} [rendered]
+    [3] ./templates/foo.js 38 bytes {0} [optional] [built]
         [exports: default]
         context element ./foo [0] ./templates async ^\.\/.*$ ./foo
         context element ./foo.js [0] ./templates async ^\.\/.*$ ./foo.js
-chunk    {1} 1.output.js 41 bytes {3} [rendered]
-    [2] ./templates/baz.js 41 bytes {1} [optional] [built]
+chunk    {1} 1.output.js 38 bytes {3} [rendered]
+    [2] ./templates/baz.js 38 bytes {1} [optional] [built]
         [exports: default]
         context element ./baz [0] ./templates async ^\.\/.*$ ./baz
         context element ./baz.js [0] ./templates async ^\.\/.*$ ./baz.js
-chunk    {2} 2.output.js 41 bytes {3} [rendered]
-    [1] ./templates/bar.js 41 bytes {2} [optional] [built]
+chunk    {2} 2.output.js 38 bytes {3} [rendered]
+    [1] ./templates/bar.js 38 bytes {2} [optional] [built]
         [exports: default]
         context element ./bar [0] ./templates async ^\.\/.*$ ./bar
         context element ./bar.js [0] ./templates async ^\.\/.*$ ./bar.js
-chunk    {3} output.js (main) 456 bytes [entry] [rendered]
+chunk    {3} output.js (main) 441 bytes [entry] [rendered]
     > main [4] ./example.js 
     [0] ./templates async ^\.\/.*$ 160 bytes {3} [optional] [built]
         import() context ./templates [4] ./example.js 3:23-60
-    [4] ./example.js 296 bytes {3} [built]
+    [4] ./example.js 281 bytes {3} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 0d608a65d597e766b156
-Version: webpack 2.3.2
+Hash: 6ff942ea6efa4b698d2f
+Version: webpack 2.4.1
       Asset       Size  Chunks             Chunk Names
 0.output.js  117 bytes       0  [emitted]  
 1.output.js  117 bytes       1  [emitted]  
 2.output.js  116 bytes       2  [emitted]  
-  output.js    6.75 kB       3  [emitted]  main
+  output.js    6.82 kB       3  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} 0.output.js 41 bytes {3} [rendered]
-    [3] ./templates/foo.js 41 bytes {0} [optional] [built]
+chunk    {0} 0.output.js 38 bytes {3} [rendered]
+    [3] ./templates/foo.js 38 bytes {0} [optional] [built]
         [exports: default]
         context element ./foo [0] ./templates async ^\.\/.*$ ./foo
         context element ./foo.js [0] ./templates async ^\.\/.*$ ./foo.js
-chunk    {1} 1.output.js 41 bytes {3} [rendered]
-    [2] ./templates/baz.js 41 bytes {1} [optional] [built]
+chunk    {1} 1.output.js 38 bytes {3} [rendered]
+    [2] ./templates/baz.js 38 bytes {1} [optional] [built]
         [exports: default]
         context element ./baz [0] ./templates async ^\.\/.*$ ./baz
         context element ./baz.js [0] ./templates async ^\.\/.*$ ./baz.js
-chunk    {2} 2.output.js 41 bytes {3} [rendered]
-    [1] ./templates/bar.js 41 bytes {2} [optional] [built]
+chunk    {2} 2.output.js 38 bytes {3} [rendered]
+    [1] ./templates/bar.js 38 bytes {2} [optional] [built]
         [exports: default]
         context element ./bar [0] ./templates async ^\.\/.*$ ./bar
         context element ./bar.js [0] ./templates async ^\.\/.*$ ./bar.js
-chunk    {3} output.js (main) 456 bytes [entry] [rendered]
+chunk    {3} output.js (main) 441 bytes [entry] [rendered]
     > main [4] ./example.js 
     [0] ./templates async ^\.\/.*$ 160 bytes {3} [optional] [built]
         import() context ./templates [4] ./example.js 3:23-60
-    [4] ./example.js 296 bytes {3} [built]
+    [4] ./example.js 281 bytes {3} [built]
 
 ERROR in output.js from UglifyJs
-Unexpected token: keyword (function) [output.js:196,6]
+Unexpected token: keyword (function) [output.js:201,6]
 ```

--- a/examples/code-splitting-specify-chunk-name/README.md
+++ b/examples/code-splitting-specify-chunk-name/README.md
@@ -46,8 +46,9 @@ export default foo;
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -56,8 +57,9 @@ export default foo;
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/
 /******/ 	};
 /******/
@@ -73,9 +75,9 @@ export default foo;
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -96,8 +98,9 @@ export default foo;
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -130,7 +133,9 @@ export default foo;
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -265,65 +270,65 @@ __webpack_require__(/*! ./templates */ 1)("./ba" + createContextVar).then(functi
 ## Uncompressed
 
 ```
-Hash: 6c765b06647a6b15d61a
-Version: webpack 2.3.3
+Hash: 7528dd90edf2b8588036
+Version: webpack 2.4.1
       Asset       Size  Chunks             Chunk Names
-0.output.js  875 bytes       0  [emitted]  chunk-bar-baz
-1.output.js  439 bytes       1  [emitted]  chunk-foo
-  output.js    7.29 kB       2  [emitted]  main
+0.output.js  869 bytes       0  [emitted]  chunk-bar-baz
+1.output.js  436 bytes       1  [emitted]  chunk-foo
+  output.js    7.36 kB       2  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} 0.output.js (chunk-bar-baz) 82 bytes {2} [rendered]
-    [2] ./templates/bar.js 41 bytes {0} [optional] [built]
+chunk    {0} 0.output.js (chunk-bar-baz) 76 bytes {2} [rendered]
+    [2] ./templates/bar.js 38 bytes {0} [optional] [built]
         [exports: default]
         context element ./bar [1] ./templates async ^\.\/ba.*$ ./bar
         context element ./bar.js [1] ./templates async ^\.\/ba.*$ ./bar.js
-    [3] ./templates/baz.js 41 bytes {0} [optional] [built]
+    [3] ./templates/baz.js 38 bytes {0} [optional] [built]
         [exports: default]
         context element ./baz [1] ./templates async ^\.\/ba.*$ ./baz
         context element ./baz.js [1] ./templates async ^\.\/ba.*$ ./baz.js
-chunk    {1} 1.output.js (chunk-foo) 41 bytes {2} [rendered]
+chunk    {1} 1.output.js (chunk-foo) 38 bytes {2} [rendered]
     > duplicate chunk-foo [4] ./example.js 1:0-62
     > duplicate chunk-foo1 [4] ./example.js 5:0-8:16
-    [0] ./templates/foo.js 41 bytes {1} [built]
+    [0] ./templates/foo.js 38 bytes {1} [built]
         [exports: default]
         import() ./templates/foo [4] ./example.js 1:0-62
         cjs require ./templates/foo [4] ./example.js 6:11-37
-chunk    {2} output.js (main) 580 bytes [entry] [rendered]
+chunk    {2} output.js (main) 565 bytes [entry] [rendered]
     > main [4] ./example.js 
     [1] ./templates async ^\.\/ba.*$ 160 bytes {2} [built]
         import() context ./templates [4] ./example.js 11:0-84
-    [4] ./example.js 420 bytes {2} [built]
+    [4] ./example.js 405 bytes {2} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 6c765b06647a6b15d61a
-Version: webpack 2.3.3
+Hash: 7528dd90edf2b8588036
+Version: webpack 2.4.1
       Asset       Size  Chunks             Chunk Names
 0.output.js  212 bytes       0  [emitted]  chunk-bar-baz
 1.output.js  115 bytes       1  [emitted]  chunk-foo
-  output.js    1.85 kB       2  [emitted]  main
+  output.js    1.84 kB       2  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} 0.output.js (chunk-bar-baz) 82 bytes {2} [rendered]
-    [2] ./templates/bar.js 41 bytes {0} [optional] [built]
+chunk    {0} 0.output.js (chunk-bar-baz) 76 bytes {2} [rendered]
+    [2] ./templates/bar.js 38 bytes {0} [optional] [built]
         [exports: default]
         context element ./bar [1] ./templates async ^\.\/ba.*$ ./bar
         context element ./bar.js [1] ./templates async ^\.\/ba.*$ ./bar.js
-    [3] ./templates/baz.js 41 bytes {0} [optional] [built]
+    [3] ./templates/baz.js 38 bytes {0} [optional] [built]
         [exports: default]
         context element ./baz [1] ./templates async ^\.\/ba.*$ ./baz
         context element ./baz.js [1] ./templates async ^\.\/ba.*$ ./baz.js
-chunk    {1} 1.output.js (chunk-foo) 41 bytes {2} [rendered]
+chunk    {1} 1.output.js (chunk-foo) 38 bytes {2} [rendered]
     > duplicate chunk-foo [4] ./example.js 1:0-62
     > duplicate chunk-foo1 [4] ./example.js 5:0-8:16
-    [0] ./templates/foo.js 41 bytes {1} [built]
+    [0] ./templates/foo.js 38 bytes {1} [built]
         [exports: default]
         import() ./templates/foo [4] ./example.js 1:0-62
         cjs require ./templates/foo [4] ./example.js 6:11-37
-chunk    {2} output.js (main) 580 bytes [entry] [rendered]
+chunk    {2} output.js (main) 565 bytes [entry] [rendered]
     > main [4] ./example.js 
     [1] ./templates async ^\.\/ba.*$ 160 bytes {2} [built]
         import() context ./templates [4] ./example.js 11:0-84
-    [4] ./example.js 420 bytes {2} [built]
+    [4] ./example.js 405 bytes {2} [built]
 ```

--- a/examples/code-splitting/README.md
+++ b/examples/code-splitting/README.md
@@ -50,8 +50,9 @@ require.ensure(["c"], function(require) {
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -60,8 +61,9 @@ require.ensure(["c"], function(require) {
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/
 /******/ 	};
 /******/
@@ -77,9 +79,9 @@ require.ensure(["c"], function(require) {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -100,8 +102,9 @@ require.ensure(["c"], function(require) {
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -134,7 +137,9 @@ require.ensure(["c"], function(require) {
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -275,11 +280,11 @@ webpackJsonp([0],[,,,function(n,c){},function(n,c){}]);
 ## Uncompressed
 
 ```
-Hash: 2426d9b9f5a83189d95d
-Version: webpack 2.3.2
+Hash: 1df3128cc27b6bc63b7c
+Version: webpack 2.4.1
       Asset       Size  Chunks             Chunk Names
 0.output.js  420 bytes       0  [emitted]  
-  output.js    6.58 kB       1  [emitted]  main
+  output.js    6.66 kB       1  [emitted]  main
 Entrypoint main = output.js
 chunk    {0} 0.output.js 22 bytes {1} [rendered]
     > [2] ./example.js 3:0-6:2
@@ -287,24 +292,24 @@ chunk    {0} 0.output.js 22 bytes {1} [rendered]
         require.ensure item c [2] ./example.js 3:0-6:2
     [4] ./~/d.js 11 bytes {0} [built]
         cjs require d [2] ./example.js 5:12-24
-chunk    {1} output.js (main) 166 bytes [entry] [rendered]
+chunk    {1} output.js (main) 161 bytes [entry] [rendered]
     > main [2] ./example.js 
     [0] ./~/b.js 11 bytes {1} [built]
         cjs require b [2] ./example.js 2:8-20
         cjs require b [2] ./example.js 4:4-16
     [1] ./~/a.js 11 bytes {1} [built]
         cjs require a [2] ./example.js 1:8-20
-    [2] ./example.js 144 bytes {1} [built]
+    [2] ./example.js 139 bytes {1} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 2426d9b9f5a83189d95d
-Version: webpack 2.3.2
+Hash: 1df3128cc27b6bc63b7c
+Version: webpack 2.4.1
       Asset      Size  Chunks             Chunk Names
 0.output.js  55 bytes       0  [emitted]  
-  output.js   1.47 kB       1  [emitted]  main
+  output.js   1.46 kB       1  [emitted]  main
 Entrypoint main = output.js
 chunk    {0} 0.output.js 22 bytes {1} [rendered]
     > [2] ./example.js 3:0-6:2
@@ -312,12 +317,12 @@ chunk    {0} 0.output.js 22 bytes {1} [rendered]
         require.ensure item c [2] ./example.js 3:0-6:2
     [4] ./~/d.js 11 bytes {0} [built]
         cjs require d [2] ./example.js 5:12-24
-chunk    {1} output.js (main) 166 bytes [entry] [rendered]
+chunk    {1} output.js (main) 161 bytes [entry] [rendered]
     > main [2] ./example.js 
     [0] ./~/b.js 11 bytes {1} [built]
         cjs require b [2] ./example.js 2:8-20
         cjs require b [2] ./example.js 4:4-16
     [1] ./~/a.js 11 bytes {1} [built]
         cjs require a [2] ./example.js 1:8-20
-    [2] ./example.js 144 bytes {1} [built]
+    [2] ./example.js 139 bytes {1} [built]
 ```

--- a/examples/coffee-script/README.md
+++ b/examples/coffee-script/README.md
@@ -36,9 +36,9 @@ module.exports = 42
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -153,7 +153,7 @@ console.log(__webpack_require__(/*! ./cup1 */ 1));
 
 ```
 Hash: 0fb81f26f70778b1c84a
-Version: webpack 2.3.2
+Version: webpack 2.4.1
     Asset     Size  Chunks             Chunk Names
 output.js  3.45 kB       0  [emitted]  main
 Entrypoint main = output.js
@@ -171,9 +171,9 @@ chunk    {0} output.js (main) 206 bytes [entry] [rendered]
 
 ```
 Hash: 0fb81f26f70778b1c84a
-Version: webpack 2.3.2
+Version: webpack 2.4.1
     Asset       Size  Chunks             Chunk Names
-output.js  673 bytes       0  [emitted]  main
+output.js  666 bytes       0  [emitted]  main
 Entrypoint main = output.js
 chunk    {0} output.js (main) 206 bytes [entry] [rendered]
     > main [2] ./example.js 

--- a/examples/common-chunk-and-vendor-chunk/README.md
+++ b/examples/common-chunk-and-vendor-chunk/README.md
@@ -74,8 +74,9 @@ module.exports = {
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -84,8 +85,9 @@ module.exports = {
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/ 		if(executeModules) {
 /******/ 			for(i=0; i < executeModules.length; i++) {
 /******/ 				result = __webpack_require__(__webpack_require__.s = executeModules[i]);
@@ -106,9 +108,9 @@ module.exports = {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -129,8 +131,9 @@ module.exports = {
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -163,7 +166,9 @@ module.exports = {
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -377,14 +382,14 @@ module.exports = "pageC";
 ## Uncompressed
 
 ```
-Hash: 03a4f8b5f1f257f40a63
-Version: webpack 2.3.2
+Hash: 1cf65ca1e68fa1cc7b9d
+Version: webpack 2.4.1
     Asset       Size  Chunks             Chunk Names
 common.js  457 bytes       0  [emitted]  common
- pageA.js  593 bytes       1  [emitted]  pageA
- pageC.js  373 bytes       2  [emitted]  pageC
- pageB.js  373 bytes       3  [emitted]  pageB
-vendor.js    6.68 kB       4  [emitted]  vendor
+ pageA.js  590 bytes       1  [emitted]  pageA
+ pageC.js  370 bytes       2  [emitted]  pageC
+ pageB.js  370 bytes       3  [emitted]  pageB
+vendor.js    6.76 kB       4  [emitted]  vendor
 Entrypoint vendor = vendor.js
 Entrypoint pageA = vendor.js common.js pageA.js
 Entrypoint pageB = vendor.js common.js pageB.js
@@ -397,17 +402,17 @@ chunk    {0} common.js (common) 56 bytes {4} [initial] [rendered]
     [1] ./utility3.js 28 bytes {0} [built]
         cjs require ./utility3 [6] ./pageB.js 2:15-36
         cjs require ./utility3 [7] ./pageC.js 2:15-36
-chunk    {1} pageA.js (pageA) 133 bytes {0} [initial] [rendered]
+chunk    {1} pageA.js (pageA) 130 bytes {0} [initial] [rendered]
     > pageA [5] ./pageA.js 
     [2] ./utility1.js 28 bytes {1} [built]
         cjs require ./utility1 [5] ./pageA.js 1:15-36
-    [5] ./pageA.js 105 bytes {1} [built]
-chunk    {2} pageC.js (pageC) 105 bytes {0} [initial] [rendered]
+    [5] ./pageA.js 102 bytes {1} [built]
+chunk    {2} pageC.js (pageC) 102 bytes {0} [initial] [rendered]
     > pageC [7] ./pageC.js 
-    [7] ./pageC.js 105 bytes {2} [built]
-chunk    {3} pageB.js (pageB) 105 bytes {0} [initial] [rendered]
+    [7] ./pageC.js 102 bytes {2} [built]
+chunk    {3} pageB.js (pageB) 102 bytes {0} [initial] [rendered]
     > pageB [6] ./pageB.js 
-    [6] ./pageB.js 105 bytes {3} [built]
+    [6] ./pageB.js 102 bytes {3} [built]
 chunk    {4} vendor.js (vendor) 94 bytes [entry] [rendered]
     > vendor [8] multi ./vendor1 ./vendor2 
     [3] ./vendor1.js 27 bytes {4} [built]
@@ -420,14 +425,14 @@ chunk    {4} vendor.js (vendor) 94 bytes [entry] [rendered]
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 03a4f8b5f1f257f40a63
-Version: webpack 2.3.2
+Hash: 1cf65ca1e68fa1cc7b9d
+Version: webpack 2.4.1
     Asset       Size  Chunks             Chunk Names
 common.js   92 bytes       0  [emitted]  common
  pageA.js  109 bytes       1  [emitted]  pageA
  pageC.js   71 bytes       2  [emitted]  pageC
  pageB.js   71 bytes       3  [emitted]  pageB
-vendor.js     1.5 kB       4  [emitted]  vendor
+vendor.js    1.49 kB       4  [emitted]  vendor
 Entrypoint vendor = vendor.js
 Entrypoint pageA = vendor.js common.js pageA.js
 Entrypoint pageB = vendor.js common.js pageB.js
@@ -440,17 +445,17 @@ chunk    {0} common.js (common) 56 bytes {4} [initial] [rendered]
     [1] ./utility3.js 28 bytes {0} [built]
         cjs require ./utility3 [6] ./pageB.js 2:15-36
         cjs require ./utility3 [7] ./pageC.js 2:15-36
-chunk    {1} pageA.js (pageA) 133 bytes {0} [initial] [rendered]
+chunk    {1} pageA.js (pageA) 130 bytes {0} [initial] [rendered]
     > pageA [5] ./pageA.js 
     [2] ./utility1.js 28 bytes {1} [built]
         cjs require ./utility1 [5] ./pageA.js 1:15-36
-    [5] ./pageA.js 105 bytes {1} [built]
-chunk    {2} pageC.js (pageC) 105 bytes {0} [initial] [rendered]
+    [5] ./pageA.js 102 bytes {1} [built]
+chunk    {2} pageC.js (pageC) 102 bytes {0} [initial] [rendered]
     > pageC [7] ./pageC.js 
-    [7] ./pageC.js 105 bytes {2} [built]
-chunk    {3} pageB.js (pageB) 105 bytes {0} [initial] [rendered]
+    [7] ./pageC.js 102 bytes {2} [built]
+chunk    {3} pageB.js (pageB) 102 bytes {0} [initial] [rendered]
     > pageB [6] ./pageB.js 
-    [6] ./pageB.js 105 bytes {3} [built]
+    [6] ./pageB.js 102 bytes {3} [built]
 chunk    {4} vendor.js (vendor) 94 bytes [entry] [rendered]
     > vendor [8] multi ./vendor1 ./vendor2 
     [3] ./vendor1.js 27 bytes {4} [built]

--- a/examples/commonjs/README.md
+++ b/examples/commonjs/README.md
@@ -48,9 +48,9 @@ exports.add = function() {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -166,33 +166,33 @@ exports.add = function() {
 ## Uncompressed
 
 ```
-Hash: 1318ed7f2e042a045e6d
-Version: webpack 2.3.2
+Hash: 62ad92b89c95aab60efa
+Version: webpack 2.4.1
     Asset     Size  Chunks             Chunk Names
 output.js  3.54 kB       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 329 bytes [entry] [rendered]
+chunk    {0} output.js (main) 318 bytes [entry] [rendered]
     > main [1] ./example.js 
-    [0] ./increment.js 98 bytes {0} [built]
+    [0] ./increment.js 95 bytes {0} [built]
         cjs require ./increment [1] ./example.js 1:10-32
-    [1] ./example.js 69 bytes {0} [built]
-    [2] ./math.js 162 bytes {0} [built]
+    [1] ./example.js 67 bytes {0} [built]
+    [2] ./math.js 156 bytes {0} [built]
         cjs require ./math [0] ./increment.js 1:10-27
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 1318ed7f2e042a045e6d
-Version: webpack 2.3.2
+Hash: 62ad92b89c95aab60efa
+Version: webpack 2.4.1
     Asset       Size  Chunks             Chunk Names
-output.js  705 bytes       0  [emitted]  main
+output.js  698 bytes       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 329 bytes [entry] [rendered]
+chunk    {0} output.js (main) 318 bytes [entry] [rendered]
     > main [1] ./example.js 
-    [0] ./increment.js 98 bytes {0} [built]
+    [0] ./increment.js 95 bytes {0} [built]
         cjs require ./increment [1] ./example.js 1:10-32
-    [1] ./example.js 69 bytes {0} [built]
-    [2] ./math.js 162 bytes {0} [built]
+    [1] ./example.js 67 bytes {0} [built]
+    [2] ./math.js 156 bytes {0} [built]
         cjs require ./math [0] ./increment.js 1:10-27
 ```

--- a/examples/css-bundle/README.md
+++ b/examples/css-bundle/README.md
@@ -51,9 +51,9 @@ module.exports = {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -155,12 +155,12 @@ body {
 ## Uncompressed
 
 ```
-Hash: a7b9259b38bc83b8ca98
-Version: webpack 2.3.2
+Hash: f34a4d1736d3268a8b6c
+Version: webpack 2.4.1
                                Asset       Size  Chunks             Chunk Names
 ce21cbdd9b894e6af794813eb3fdaf60.png  119 bytes          [emitted]  
-                           output.js    3.05 kB       0  [emitted]  main
-                           style.css   69 bytes       0  [emitted]  main
+                           output.js    3.06 kB       0  [emitted]  main
+                           style.css   67 bytes       0  [emitted]  main
 Entrypoint main = output.js style.css
 chunk    {0} output.js, style.css (main) 64 bytes [entry] [rendered]
     > main [1] ./example.js 
@@ -176,18 +176,18 @@ Child extract-text-webpack-plugin:
         [0] (webpack)/~/css-loader/lib/css-base.js 1.51 kB {0} [built]
             cjs require ../../node_modules/css-loader/lib/css-base.js [2] (webpack)/~/css-loader!./style.css 1:27-83
         [1] ./image.png 82 bytes {0} [built]
-            cjs require ./image.png [2] (webpack)/~/css-loader!./style.css 6:58-80
-        [2] (webpack)/~/css-loader!./style.css 222 bytes {0} [built]
+            cjs require ./image.png [2] (webpack)/~/css-loader!./style.css 6:56-78
+        [2] (webpack)/~/css-loader!./style.css 218 bytes {0} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
 Hash: a59e06b8e4c98e831cac
-Version: webpack 2.3.2
+Version: webpack 2.4.1
                                Asset       Size  Chunks             Chunk Names
 ce21cbdd9b894e6af794813eb3fdaf60.png  119 bytes          [emitted]  
-                           output.js  537 bytes       0  [emitted]  main
+                           output.js  530 bytes       0  [emitted]  main
                            style.css   61 bytes       0  [emitted]  main
 Entrypoint main = output.js style.css
 chunk    {0} output.js, style.css (main) 64 bytes [entry] [rendered]

--- a/examples/dll-user/README.md
+++ b/examples/dll-user/README.md
@@ -44,9 +44,9 @@ console.log(require("module"));
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -138,7 +138,7 @@ module.exports = beta_282e8826843b2bb4eeb1;
   \**********************************************************************/
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = (__webpack_require__(0))(0);
+module.exports = (__webpack_require__(0))(0)
 
 /***/ }),
 /* 3 */
@@ -149,7 +149,7 @@ module.exports = (__webpack_require__(0))(0);
   \**************************************************************************/
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = (__webpack_require__(0))(1);
+module.exports = (__webpack_require__(0))(1)
 
 /***/ }),
 /* 4 */
@@ -160,7 +160,7 @@ module.exports = (__webpack_require__(0))(1);
   \*********************************************************************/
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = (__webpack_require__(1))(2);
+module.exports = (__webpack_require__(1))(2)
 
 /***/ }),
 /* 5 */
@@ -171,7 +171,7 @@ module.exports = (__webpack_require__(1))(2);
   \************************************************************************/
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = (__webpack_require__(1))(3);
+module.exports = (__webpack_require__(1))(3)
 
 /***/ }),
 /* 6 */
@@ -182,7 +182,7 @@ module.exports = (__webpack_require__(1))(3);
   \**********************************************************************/
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = (__webpack_require__(1))(4);
+module.exports = (__webpack_require__(1))(4)
 
 /***/ }),
 /* 7 */
@@ -193,7 +193,7 @@ module.exports = (__webpack_require__(1))(4);
   \*****************************************************************************************/
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = (__webpack_require__(0))(5);
+module.exports = (__webpack_require__(0))(5)
 
 /***/ }),
 /* 8 */
@@ -223,12 +223,12 @@ console.log(__webpack_require__(/*! module */ 7));
 ## Uncompressed
 
 ```
-Hash: 164f3c4abb86bb4c4462
-Version: webpack 2.3.2
+Hash: 31b432da9b9102c24f82
+Version: webpack 2.4.1
     Asset     Size  Chunks             Chunk Names
 output.js  6.16 kB       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 549 bytes [entry] [rendered]
+chunk    {0} output.js (main) 541 bytes [entry] [rendered]
     > main [8] ./example.js 
     [2] delegated ./a.js from dll-reference alpha_282e8826843b2bb4eeb1 42 bytes {0} [not cacheable] [built]
         cjs require ../dll/a [8] ./example.js 2:12-31
@@ -242,19 +242,19 @@ chunk    {0} output.js (main) 549 bytes [entry] [rendered]
         cjs require beta/c [8] ./example.js 6:12-29
     [7] delegated ../node_modules/module.js from dll-reference alpha_282e8826843b2bb4eeb1 42 bytes {0} [not cacheable] [built]
         cjs require module [8] ./example.js 8:12-29
-    [8] ./example.js 213 bytes {0} [built]
+    [8] ./example.js 205 bytes {0} [built]
      + 2 hidden modules
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 164f3c4abb86bb4c4462
-Version: webpack 2.3.2
+Hash: 31b432da9b9102c24f82
+Version: webpack 2.4.1
     Asset       Size  Chunks             Chunk Names
-output.js  937 bytes       0  [emitted]  main
+output.js  930 bytes       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 549 bytes [entry] [rendered]
+chunk    {0} output.js (main) 541 bytes [entry] [rendered]
     > main [8] ./example.js 
     [2] delegated ./a.js from dll-reference alpha_282e8826843b2bb4eeb1 42 bytes {0} [not cacheable] [built]
         cjs require ../dll/a [8] ./example.js 2:12-31
@@ -268,6 +268,6 @@ chunk    {0} output.js (main) 549 bytes [entry] [rendered]
         cjs require beta/c [8] ./example.js 6:12-29
     [7] delegated ../node_modules/module.js from dll-reference alpha_282e8826843b2bb4eeb1 42 bytes {0} [not cacheable] [built]
         cjs require module [8] ./example.js 8:12-29
-    [8] ./example.js 213 bytes {0} [built]
+    [8] ./example.js 205 bytes {0} [built]
      + 2 hidden modules
 ```

--- a/examples/dll/README.md
+++ b/examples/dll/README.md
@@ -41,9 +41,9 @@ var alpha_282e8826843b2bb4eeb1 =
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -185,9 +185,9 @@ module.exports = __webpack_require__;
 
 ```
 Hash: 282e8826843b2bb4eeb1
-Version: webpack 2.3.2
+Version: webpack 2.4.1
          Asset     Size  Chunks             Chunk Names
- MyDll.beta.js  3.46 kB       0  [emitted]  beta
+ MyDll.beta.js  3.47 kB       0  [emitted]  beta
 MyDll.alpha.js  3.49 kB       1  [emitted]  alpha
 Entrypoint alpha = MyDll.alpha.js
 Entrypoint beta = MyDll.beta.js
@@ -215,7 +215,7 @@ chunk    {1} MyDll.alpha.js (alpha) 84 bytes [entry] [rendered]
 
 ```
 Hash: 282e8826843b2bb4eeb1
-Version: webpack 2.3.2
+Version: webpack 2.4.1
          Asset       Size  Chunks             Chunk Names
  MyDll.beta.js  653 bytes       0  [emitted]  beta
 MyDll.alpha.js  657 bytes       1  [emitted]  alpha

--- a/examples/explicit-vendor-chunk/README.md
+++ b/examples/explicit-vendor-chunk/README.md
@@ -56,9 +56,9 @@ var vendor_32199746b38d6e93b44b =
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -169,9 +169,9 @@ module.exports = __webpack_require__;
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -248,7 +248,7 @@ module.exports = vendor_32199746b38d6e93b44b;
   \****************************************************************************/
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = (__webpack_require__(0))(0);
+module.exports = (__webpack_require__(0))(0)
 
 /***/ }),
 /* 2 */,
@@ -272,8 +272,8 @@ module.exports = "pageA";
 ## Uncompressed
 
 ```
-Hash: 32199746b38d6e93b44ba8c4dfdaf5a935b1ed38
-Version: webpack 2.3.2
+Hash: 32199746b38d6e93b44b195fbc5bb4c3e59806f2
+Version: webpack 2.4.1
 Child vendor:
     Hash: 32199746b38d6e93b44b
         Asset     Size  Chunks             Chunk Names
@@ -287,25 +287,25 @@ Child vendor:
             single entry ./vendor2 [2] dll main main:1
         [2] dll main 12 bytes {0} [built]
 Child app:
-    Hash: a8c4dfdaf5a935b1ed38
+    Hash: 195fbc5bb4c3e59806f2
        Asset     Size  Chunks             Chunk Names
     pageB.js  3.59 kB       0  [emitted]  pageB
-    pageA.js  3.57 kB       1  [emitted]  pageA
+    pageA.js  3.58 kB       1  [emitted]  pageA
     pageC.js  2.79 kB       2  [emitted]  pageC
     Entrypoint pageA = pageA.js
     Entrypoint pageB = pageB.js
     Entrypoint pageC = pageC.js
-    chunk    {0} pageB.js (pageB) 145 bytes [entry] [rendered]
+    chunk    {0} pageB.js (pageB) 144 bytes [entry] [rendered]
         > pageB [4] ./pageB.js 
         [2] delegated ./vendor2.js from dll-reference vendor_32199746b38d6e93b44b 42 bytes {0} [not cacheable] [built]
             cjs require ./vendor2 [4] ./pageB.js 1:12-32
-        [4] ./pageB.js 61 bytes {0} [built]
+        [4] ./pageB.js 60 bytes {0} [built]
          + 1 hidden modules
-    chunk    {1} pageA.js (pageA) 144 bytes [entry] [rendered]
+    chunk    {1} pageA.js (pageA) 143 bytes [entry] [rendered]
         > pageA [3] ./pageA.js 
         [1] delegated ./vendor.js from dll-reference vendor_32199746b38d6e93b44b 42 bytes {1} [not cacheable] [built]
             cjs require ./vendor [3] ./pageA.js 1:12-31
-        [3] ./pageA.js 60 bytes {1} [built]
+        [3] ./pageA.js 59 bytes {1} [built]
          + 1 hidden modules
     chunk    {2} pageC.js (pageC) 25 bytes [entry] [rendered]
         > pageC [5] ./pageC.js 
@@ -315,8 +315,8 @@ Child app:
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 32199746b38d6e93b44ba8c4dfdaf5a935b1ed38
-Version: webpack 2.3.2
+Hash: 32199746b38d6e93b44b195fbc5bb4c3e59806f2
+Version: webpack 2.4.1
 Child vendor:
     Hash: 32199746b38d6e93b44b
         Asset       Size  Chunks             Chunk Names
@@ -330,25 +330,25 @@ Child vendor:
             single entry ./vendor2 [2] dll main main:1
         [2] dll main 12 bytes {0} [built]
 Child app:
-    Hash: a8c4dfdaf5a935b1ed38
+    Hash: 195fbc5bb4c3e59806f2
        Asset       Size  Chunks             Chunk Names
-    pageB.js  642 bytes       0  [emitted]  pageB
-    pageA.js  641 bytes       1  [emitted]  pageA
-    pageC.js  534 bytes       2  [emitted]  pageC
+    pageB.js  635 bytes       0  [emitted]  pageB
+    pageA.js  634 bytes       1  [emitted]  pageA
+    pageC.js  527 bytes       2  [emitted]  pageC
     Entrypoint pageA = pageA.js
     Entrypoint pageB = pageB.js
     Entrypoint pageC = pageC.js
-    chunk    {0} pageB.js (pageB) 145 bytes [entry] [rendered]
+    chunk    {0} pageB.js (pageB) 144 bytes [entry] [rendered]
         > pageB [4] ./pageB.js 
         [2] delegated ./vendor2.js from dll-reference vendor_32199746b38d6e93b44b 42 bytes {0} [not cacheable] [built]
             cjs require ./vendor2 [4] ./pageB.js 1:12-32
-        [4] ./pageB.js 61 bytes {0} [built]
+        [4] ./pageB.js 60 bytes {0} [built]
          + 1 hidden modules
-    chunk    {1} pageA.js (pageA) 144 bytes [entry] [rendered]
+    chunk    {1} pageA.js (pageA) 143 bytes [entry] [rendered]
         > pageA [3] ./pageA.js 
         [1] delegated ./vendor.js from dll-reference vendor_32199746b38d6e93b44b 42 bytes {1} [not cacheable] [built]
             cjs require ./vendor [3] ./pageA.js 1:12-31
-        [3] ./pageA.js 60 bytes {1} [built]
+        [3] ./pageA.js 59 bytes {1} [built]
          + 1 hidden modules
     chunk    {2} pageC.js (pageC) 25 bytes [entry] [rendered]
         > pageC [5] ./pageC.js 

--- a/examples/externals/README.md
+++ b/examples/externals/README.md
@@ -70,9 +70,9 @@ return /******/ (function(modules) { // webpackBootstrap
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -181,27 +181,27 @@ exports.exampleValue = subtract(add(42, 2), 2);
 ## Uncompressed
 
 ```
-Hash: 0b46eba3c061e1157fa9
-Version: webpack 2.3.2
+Hash: b48b7e2830381b4297e4
+Version: webpack 2.4.1
     Asset     Size  Chunks             Chunk Names
-output.js  4.28 kB       0  [emitted]  main
+output.js  4.29 kB       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 197 bytes [entry] [rendered]
+chunk    {0} output.js (main) 194 bytes [entry] [rendered]
     > main [2] ./example.js 
-    [2] ./example.js 113 bytes {0} [built]
+    [2] ./example.js 110 bytes {0} [built]
      + 2 hidden modules
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 0b46eba3c061e1157fa9
-Version: webpack 2.3.2
+Hash: b48b7e2830381b4297e4
+Version: webpack 2.4.1
     Asset  Size  Chunks             Chunk Names
 output.js  1 kB       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 197 bytes [entry] [rendered]
+chunk    {0} output.js (main) 194 bytes [entry] [rendered]
     > main [2] ./example.js 
-    [2] ./example.js 113 bytes {0} [built]
+    [2] ./example.js 110 bytes {0} [built]
      + 2 hidden modules
 ```

--- a/examples/extra-async-chunk-advanced/README.md
+++ b/examples/extra-async-chunk-advanced/README.md
@@ -58,8 +58,9 @@ module.exports = {
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -68,8 +69,9 @@ module.exports = {
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/
 /******/ 	};
 /******/
@@ -85,9 +87,9 @@ module.exports = {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -108,8 +110,9 @@ module.exports = {
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -142,7 +145,9 @@ module.exports = {
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -236,8 +241,8 @@ Promise.all/* require.ensure */([__webpack_require__.e(1), __webpack_require__.e
 ## Uncompressed
 
 ```
-Hash: fcd85928f3d638b2b3af
-Version: webpack 2.3.2
+Hash: 91055824d9af71c9a22f
+Version: webpack 2.4.1
       Asset       Size  Chunks             Chunk Names
 0.output.js  220 bytes       0  [emitted]  async2
 1.output.js  211 bytes       1  [emitted]  async1
@@ -246,7 +251,7 @@ Version: webpack 2.3.2
 4.output.js  214 bytes       4  [emitted]  
 5.output.js  214 bytes       5  [emitted]  
 6.output.js  214 bytes       6  [emitted]  
-  output.js    7.22 kB       7  [emitted]  main
+  output.js    7.28 kB       7  [emitted]  main
 Entrypoint main = output.js
 chunk    {0} 0.output.js (async2) 21 bytes {2} {7} [rendered]
     > async commons duplicate [5] ./example.js 1:0-52
@@ -287,16 +292,16 @@ chunk    {6} 6.output.js 21 bytes {2} [rendered]
     > [5] ./example.js 10:1-12:3
     [6] ./f.js 21 bytes {6} [built]
         cjs require ./f [5] ./example.js 11:2-16
-chunk    {7} output.js (main) 362 bytes [entry] [rendered]
+chunk    {7} output.js (main) 346 bytes [entry] [rendered]
     > main [5] ./example.js 
-    [5] ./example.js 362 bytes {7} [built]
+    [5] ./example.js 346 bytes {7} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: fcd85928f3d638b2b3af
-Version: webpack 2.3.2
+Hash: 91055824d9af71c9a22f
+Version: webpack 2.4.1
       Asset      Size  Chunks             Chunk Names
 0.output.js  50 bytes       0  [emitted]  async2
 1.output.js  49 bytes       1  [emitted]  async1
@@ -305,7 +310,7 @@ Version: webpack 2.3.2
 4.output.js  51 bytes       4  [emitted]  
 5.output.js  51 bytes       5  [emitted]  
 6.output.js  51 bytes       6  [emitted]  
-  output.js   1.81 kB       7  [emitted]  main
+  output.js    1.8 kB       7  [emitted]  main
 Entrypoint main = output.js
 chunk    {0} 0.output.js (async2) 21 bytes {2} {7} [rendered]
     > async commons duplicate [5] ./example.js 1:0-52
@@ -346,7 +351,7 @@ chunk    {6} 6.output.js 21 bytes {2} [rendered]
     > [5] ./example.js 10:1-12:3
     [6] ./f.js 21 bytes {6} [built]
         cjs require ./f [5] ./example.js 11:2-16
-chunk    {7} output.js (main) 362 bytes [entry] [rendered]
+chunk    {7} output.js (main) 346 bytes [entry] [rendered]
     > main [5] ./example.js 
-    [5] ./example.js 362 bytes {7} [built]
+    [5] ./example.js 346 bytes {7} [built]
 ```

--- a/examples/extra-async-chunk/README.md
+++ b/examples/extra-async-chunk/README.md
@@ -78,8 +78,9 @@ module.exports = {
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -88,8 +89,9 @@ module.exports = {
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/
 /******/ 	};
 /******/
@@ -105,9 +107,9 @@ module.exports = {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -128,8 +130,9 @@ module.exports = {
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -162,7 +165,9 @@ module.exports = {
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -317,13 +322,13 @@ module.exports = "c";
 ## Uncompressed
 
 ```
-Hash: 87946ef95f806aa2da0f
-Version: webpack 2.3.2
+Hash: 17717faf3e890c146908
+Version: webpack 2.4.1
       Asset       Size  Chunks             Chunk Names
 0.output.js  401 bytes       0  [emitted]  
 1.output.js  214 bytes       1  [emitted]  
 2.output.js  214 bytes       2  [emitted]  
-  output.js    6.55 kB       3  [emitted]  main
+  output.js    6.63 kB       3  [emitted]  main
 Entrypoint main = output.js
 chunk    {0} 0.output.js 42 bytes {3} [rendered]
     > async commons [4] ./example.js 2:0-52
@@ -342,21 +347,21 @@ chunk    {2} 2.output.js 21 bytes {3} [rendered]
     > [4] ./example.js 2:0-52
     [2] ./c.js 21 bytes {2} [built]
         amd require ./c [4] ./example.js 2:0-52
-chunk    {3} output.js (main) 194 bytes [entry] [rendered]
+chunk    {3} output.js (main) 186 bytes [entry] [rendered]
     > main [4] ./example.js 
-    [4] ./example.js 194 bytes {3} [built]
+    [4] ./example.js 186 bytes {3} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 87946ef95f806aa2da0f
-Version: webpack 2.3.2
+Hash: 17717faf3e890c146908
+Version: webpack 2.4.1
       Asset      Size  Chunks             Chunk Names
 0.output.js  78 bytes       0  [emitted]  
 1.output.js  51 bytes       1  [emitted]  
 2.output.js  51 bytes       2  [emitted]  
-  output.js   1.56 kB       3  [emitted]  main
+  output.js   1.55 kB       3  [emitted]  main
 Entrypoint main = output.js
 chunk    {0} 0.output.js 42 bytes {3} [rendered]
     > async commons [4] ./example.js 2:0-52
@@ -375,7 +380,7 @@ chunk    {2} 2.output.js 21 bytes {3} [rendered]
     > [4] ./example.js 2:0-52
     [2] ./c.js 21 bytes {2} [built]
         amd require ./c [4] ./example.js 2:0-52
-chunk    {3} output.js (main) 194 bytes [entry] [rendered]
+chunk    {3} output.js (main) 186 bytes [entry] [rendered]
     > main [4] ./example.js 
-    [4] ./example.js 194 bytes {3} [built]
+    [4] ./example.js 186 bytes {3} [built]
 ```

--- a/examples/harmony-interop/README.md
+++ b/examples/harmony-interop/README.md
@@ -77,9 +77,9 @@ export var named = "named";
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -259,27 +259,27 @@ var named = "named";
 ## Uncompressed
 
 ```
-Hash: b21ca1313d330370bf98
-Version: webpack 2.3.2
+Hash: b04269a754124e85178b
+Version: webpack 2.4.1
     Asset     Size  Chunks             Chunk Names
-output.js  6.31 kB       0  [emitted]  main
+output.js  6.28 kB       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 1.2 kB [entry] [rendered]
+chunk    {0} output.js (main) 1.16 kB [entry] [rendered]
     > main [3] ./example.js 
-    [0] ./fs.js 265 bytes {0} [built]
+    [0] ./fs.js 258 bytes {0} [built]
         [only some exports used: default, readFile]
         harmony import ./fs [2] ./reexport-commonjs.js 2:0-21
         harmony import ./fs [3] ./example.js 4:0-22
         harmony import ./fs [3] ./example.js 5:0-32
         harmony import ./fs [3] ./example.js 6:0-28
-    [1] ./example2.js 159 bytes {0} [built]
+    [1] ./example2.js 152 bytes {0} [built]
         [no exports used]
         harmony import ./example2 [3] ./example.js 16:0-20
-    [2] ./reexport-commonjs.js 308 bytes {0} [built]
+    [2] ./reexport-commonjs.js 301 bytes {0} [built]
         [only some exports used: readFile]
         harmony import ./reexport-commonjs [3] ./example.js 12:0-60
-    [3] ./example.js 389 bytes {0} [built]
-    [4] ./harmony.js 78 bytes {0} [built]
+    [3] ./example.js 373 bytes {0} [built]
+    [4] ./harmony.js 75 bytes {0} [built]
         [exports: default, named]
         cjs require ./harmony [1] ./example2.js 4:13-33
 ```
@@ -287,27 +287,27 @@ chunk    {0} output.js (main) 1.2 kB [entry] [rendered]
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: b21ca1313d330370bf98
-Version: webpack 2.3.2
+Hash: b04269a754124e85178b
+Version: webpack 2.4.1
     Asset     Size  Chunks             Chunk Names
-output.js  1.06 kB       0  [emitted]  main
+output.js  1.05 kB       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 1.2 kB [entry] [rendered]
+chunk    {0} output.js (main) 1.16 kB [entry] [rendered]
     > main [3] ./example.js 
-    [0] ./fs.js 265 bytes {0} [built]
+    [0] ./fs.js 258 bytes {0} [built]
         [only some exports used: default, readFile]
         harmony import ./fs [2] ./reexport-commonjs.js 2:0-21
         harmony import ./fs [3] ./example.js 4:0-22
         harmony import ./fs [3] ./example.js 5:0-32
         harmony import ./fs [3] ./example.js 6:0-28
-    [1] ./example2.js 159 bytes {0} [built]
+    [1] ./example2.js 152 bytes {0} [built]
         [no exports used]
         harmony import ./example2 [3] ./example.js 16:0-20
-    [2] ./reexport-commonjs.js 308 bytes {0} [built]
+    [2] ./reexport-commonjs.js 301 bytes {0} [built]
         [only some exports used: readFile]
         harmony import ./reexport-commonjs [3] ./example.js 12:0-60
-    [3] ./example.js 389 bytes {0} [built]
-    [4] ./harmony.js 78 bytes {0} [built]
+    [3] ./example.js 373 bytes {0} [built]
+    [4] ./harmony.js 75 bytes {0} [built]
         [exports: default, named]
         cjs require ./harmony [1] ./example2.js 4:13-33
 ```

--- a/examples/harmony-library/README.md
+++ b/examples/harmony-library/README.md
@@ -38,9 +38,9 @@ return /******/ (function(modules) { // webpackBootstrap
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -133,27 +133,27 @@ function increment() {
 ## Uncompressed
 
 ```
-Hash: 313bc0b3685e952e6c32
-Version: webpack 2.3.2
+Hash: 7685c8928f57aaaabf28
+Version: webpack 2.4.1
            Asset    Size  Chunks             Chunk Names
 MyLibrary.umd.js  3.6 kB       0  [emitted]  main
 Entrypoint main = MyLibrary.umd.js
-chunk    {0} MyLibrary.umd.js (main) 97 bytes [entry] [rendered]
+chunk    {0} MyLibrary.umd.js (main) 92 bytes [entry] [rendered]
     > main [0] ./example.js 
-    [0] ./example.js 97 bytes {0} [built]
+    [0] ./example.js 92 bytes {0} [built]
         [exports: value, increment, default]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 313bc0b3685e952e6c32
-Version: webpack 2.3.2
+Hash: 7685c8928f57aaaabf28
+Version: webpack 2.4.1
            Asset       Size  Chunks             Chunk Names
 MyLibrary.umd.js  898 bytes       0  [emitted]  main
 Entrypoint main = MyLibrary.umd.js
-chunk    {0} MyLibrary.umd.js (main) 97 bytes [entry] [rendered]
+chunk    {0} MyLibrary.umd.js (main) 92 bytes [entry] [rendered]
     > main [0] ./example.js 
-    [0] ./example.js 97 bytes {0} [built]
+    [0] ./example.js 92 bytes {0} [built]
         [exports: value, increment, default]
 ```

--- a/examples/harmony-unused/README.md
+++ b/examples/harmony-unused/README.md
@@ -60,9 +60,9 @@ export { add as reexportedAdd, multiply as reexportedMultiply } from "./math";
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -223,7 +223,7 @@ __WEBPACK_IMPORTED_MODULE_1__library__["a" /* reexportedMultiply */](1, 2);
 # js/output.js
 
 ``` javascript
-!function(t){function n(e){if(r[e])return r[e].exports;var u=r[e]={i:e,l:!1,exports:{}};return t[e].call(u.exports,u,u.exports,n),u.l=!0,u.exports}var r={};return n.m=t,n.c=r,n.i=function(t){return t},n.d=function(t,r,e){n.o(t,r)||Object.defineProperty(t,r,{configurable:!1,enumerable:!0,get:e})},n.n=function(t){var r=t&&t.__esModule?function(){return t.default}:function(){return t};return n.d(r,"a",r),r},n.o=function(t,n){return Object.prototype.hasOwnProperty.call(t,n)},n.p="js/",n(n.s=3)}([function(t,n,r){"use strict";function e(){for(var t=0,n=0,r=arguments,e=r.length;n<e;)t+=r[n++];return t}function u(){for(var t=1,n=0,r=arguments,e=r.length;n<e;)t*=r[n++];return t}n.a=e,n.b=u},function(t,n,r){"use strict";var e=(r(2),r(0));r.d(n,"a",function(){return e.b})},function(t,n,r){"use strict"},function(t,n,r){"use strict";Object.defineProperty(n,"__esModule",{value:!0});var e=r(0),u=r(1);r.i(e.a)(1,2),u.a(1,2)}]);
+!function(t){function n(e){if(r[e])return r[e].exports;var u=r[e]={i:e,l:!1,exports:{}};return t[e].call(u.exports,u,u.exports,n),u.l=!0,u.exports}var r={};n.m=t,n.c=r,n.i=function(t){return t},n.d=function(t,r,e){n.o(t,r)||Object.defineProperty(t,r,{configurable:!1,enumerable:!0,get:e})},n.n=function(t){var r=t&&t.__esModule?function(){return t.default}:function(){return t};return n.d(r,"a",r),r},n.o=function(t,n){return Object.prototype.hasOwnProperty.call(t,n)},n.p="js/",n(n.s=3)}([function(t,n,r){"use strict";function e(){for(var t=0,n=0,r=arguments,e=r.length;n<e;)t+=r[n++];return t}function u(){for(var t=1,n=0,r=arguments,e=r.length;n<e;)t*=r[n++];return t}n.a=e,n.b=u},function(t,n,r){"use strict";var e=(r(2),r(0));r.d(n,"a",function(){return e.b})},function(t,n,r){"use strict"},function(t,n,r){"use strict";Object.defineProperty(n,"__esModule",{value:!0});var e=r(0),u=r(1);r.i(e.a)(1,2),u.a(1,2)}]);
 ```
 
 # Info
@@ -231,51 +231,51 @@ __WEBPACK_IMPORTED_MODULE_1__library__["a" /* reexportedMultiply */](1, 2);
 ## Uncompressed
 
 ```
-Hash: 3b24f63cc56b55f0e254
-Version: webpack 2.3.2
+Hash: a48d566ce3cfa53131c4
+Version: webpack 2.4.1
     Asset     Size  Chunks             Chunk Names
-output.js  5.19 kB       0  [emitted]  main
+output.js  5.17 kB       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 726 bytes [entry] [rendered]
+chunk    {0} output.js (main) 698 bytes [entry] [rendered]
     > main [3] ./example.js 
-    [0] ./math.js 366 bytes {0} [built]
+    [0] ./math.js 347 bytes {0} [built]
         [exports: add, multiply, list]
         [only some exports used: add, multiply]
         harmony import ./math [1] ./library.js 2:0-78
         harmony import ./math [3] ./example.js 1:0-29
-    [1] ./library.js 112 bytes {0} [built]
+    [1] ./library.js 111 bytes {0} [built]
         [exports: a, b, c, reexportedAdd, reexportedMultiply]
         [only some exports used: reexportedMultiply]
         harmony import ./library [3] ./example.js 2:0-37
-    [2] ./abc.js 129 bytes {0} [built]
+    [2] ./abc.js 126 bytes {0} [built]
         [exports: a, b, c]
         [no exports used]
         harmony import ./abc [1] ./library.js 1:0-32
-    [3] ./example.js 119 bytes {0} [built]
+    [3] ./example.js 114 bytes {0} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 3b24f63cc56b55f0e254
-Version: webpack 2.3.2
+Hash: a48d566ce3cfa53131c4
+Version: webpack 2.4.1
     Asset       Size  Chunks             Chunk Names
-output.js  925 bytes       0  [emitted]  main
+output.js  918 bytes       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 726 bytes [entry] [rendered]
+chunk    {0} output.js (main) 698 bytes [entry] [rendered]
     > main [3] ./example.js 
-    [0] ./math.js 366 bytes {0} [built]
+    [0] ./math.js 347 bytes {0} [built]
         [exports: add, multiply, list]
         [only some exports used: add, multiply]
         harmony import ./math [1] ./library.js 2:0-78
         harmony import ./math [3] ./example.js 1:0-29
-    [1] ./library.js 112 bytes {0} [built]
+    [1] ./library.js 111 bytes {0} [built]
         [exports: a, b, c, reexportedAdd, reexportedMultiply]
         [only some exports used: reexportedMultiply]
         harmony import ./library [3] ./example.js 2:0-37
-    [2] ./abc.js 129 bytes {0} [built]
+    [2] ./abc.js 126 bytes {0} [built]
         [exports: a, b, c]
         [no exports used]
         harmony import ./abc [1] ./library.js 1:0-32
-    [3] ./example.js 119 bytes {0} [built]
+    [3] ./example.js 114 bytes {0} [built]
 ```

--- a/examples/harmony/README.md
+++ b/examples/harmony/README.md
@@ -35,8 +35,9 @@ export function increment(val) {
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -45,8 +46,9 @@ export function increment(val) {
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/
 /******/ 	};
 /******/
@@ -62,9 +64,9 @@ export function increment(val) {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -85,8 +87,9 @@ export function increment(val) {
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -119,7 +122,9 @@ export function increment(val) {
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -245,25 +250,25 @@ function add() {
 ## Uncompressed
 
 ```
-Hash: 26e1ac7210bb6f6b7623
-Version: webpack 2.3.2
+Hash: c296fa177822d8b21a31
+Version: webpack 2.4.1
       Asset       Size  Chunks             Chunk Names
-0.output.js  488 bytes       0  [emitted]  
-  output.js    7.39 kB       1  [emitted]  main
+0.output.js  487 bytes       0  [emitted]  
+  output.js    7.45 kB       1  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} 0.output.js 25 bytes {1} [rendered]
+chunk    {0} 0.output.js 24 bytes {1} [rendered]
     > [2] ./example.js 6:0-24
-    [1] ./async-loaded.js 25 bytes {0} [built]
+    [1] ./async-loaded.js 24 bytes {0} [built]
         [exports: answer]
         import() ./async-loaded [2] ./example.js 6:0-24
-chunk    {1} output.js (main) 419 bytes [entry] [rendered]
+chunk    {1} output.js (main) 400 bytes [entry] [rendered]
     > main [2] ./example.js 
-    [0] ./increment.js 94 bytes {1} [built]
+    [0] ./increment.js 90 bytes {1} [built]
         [exports: increment]
         [only some exports used: increment]
         harmony import ./increment [2] ./example.js 1:0-47
-    [2] ./example.js 183 bytes {1} [built]
-    [3] ./math.js 142 bytes {1} [built]
+    [2] ./example.js 175 bytes {1} [built]
+    [3] ./math.js 135 bytes {1} [built]
         [exports: add]
         [only some exports used: add]
         harmony import ./math [0] ./increment.js 1:0-29
@@ -272,25 +277,25 @@ chunk    {1} output.js (main) 419 bytes [entry] [rendered]
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 26e1ac7210bb6f6b7623
-Version: webpack 2.3.2
+Hash: c296fa177822d8b21a31
+Version: webpack 2.4.1
       Asset       Size  Chunks             Chunk Names
 0.output.js  146 bytes       0  [emitted]  
-  output.js     1.7 kB       1  [emitted]  main
+  output.js    1.69 kB       1  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} 0.output.js 25 bytes {1} [rendered]
+chunk    {0} 0.output.js 24 bytes {1} [rendered]
     > [2] ./example.js 6:0-24
-    [1] ./async-loaded.js 25 bytes {0} [built]
+    [1] ./async-loaded.js 24 bytes {0} [built]
         [exports: answer]
         import() ./async-loaded [2] ./example.js 6:0-24
-chunk    {1} output.js (main) 419 bytes [entry] [rendered]
+chunk    {1} output.js (main) 400 bytes [entry] [rendered]
     > main [2] ./example.js 
-    [0] ./increment.js 94 bytes {1} [built]
+    [0] ./increment.js 90 bytes {1} [built]
         [exports: increment]
         [only some exports used: increment]
         harmony import ./increment [2] ./example.js 1:0-47
-    [2] ./example.js 183 bytes {1} [built]
-    [3] ./math.js 142 bytes {1} [built]
+    [2] ./example.js 175 bytes {1} [built]
+    [3] ./math.js 135 bytes {1} [built]
         [exports: add]
         [only some exports used: add]
         harmony import ./math [0] ./increment.js 1:0-29

--- a/examples/http2-aggressive-splitting/README.md
+++ b/examples/http2-aggressive-splitting/README.md
@@ -44,441 +44,447 @@ module.exports = {
 ## Uncompressed
 
 ```
-Hash: c9781c5521ffee4f5298
-Version: webpack 2.3.2
+Hash: 550b9653dc46c27e327c
+Version: webpack 2.4.1
                   Asset     Size  Chunks             Chunk Names
-0fc9e56af19a2e1125e3.js  52.7 kB       7  [emitted]  
-7923f88ea316bb0caf20.js  56.9 kB       0  [emitted]  
-cf8eaf7e2283857b2514.js  35.3 kB       2  [emitted]  
-1aebcb77e36ad0ed5500.js    56 kB       3  [emitted]  
-e7e0f7bc43020d03cea9.js  54.8 kB       4  [emitted]  
-cd30a0e5b23181f08280.js  53.6 kB       5  [emitted]  
-1126d5a81e2264177124.js  52.9 kB       6  [emitted]  
-4b56298728377da64928.js  56.6 kB       1  [emitted]  
-6969094ac64482ef5415.js  51.1 kB       8  [emitted]  
-b98a4783892edb35b41b.js  51.7 kB       9  [emitted]  
-97bba8f30c076dad7452.js  50.6 kB      10  [emitted]  
-7b9a99048247c52e6473.js    32 kB      11  [emitted]  
-3c590ca94c1cd4573c73.js  59.9 kB      12  [emitted]  
-bea9c6f9afcb80f33121.js  33.6 kB      13  [emitted]  
-85fc6439c97999cbcda0.js  24.2 kB      14  [emitted]  
-Entrypoint main = 3c590ca94c1cd4573c73.js 85fc6439c97999cbcda0.js bea9c6f9afcb80f33121.js
-chunk    {0} 7923f88ea316bb0caf20.js 49.7 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [17] (webpack)/~/react-dom/index.js 59 bytes {0} [built]
-   [31] (webpack)/~/fbjs/lib/ExecutionEnvironment.js 1.06 kB {0} [built]
-   [48] (webpack)/~/fbjs/lib/shallowEqual.js 1.74 kB {0} [built]
-   [50] (webpack)/~/react-dom/lib/DOMNamespaces.js 505 bytes {0} [built]
-   [65] (webpack)/~/fbjs/lib/EventListener.js 2.67 kB {0} [built]
-   [66] (webpack)/~/fbjs/lib/focusNode.js 704 bytes {0} [built]
-   [67] (webpack)/~/fbjs/lib/getActiveElement.js 895 bytes {0} [built]
-   [68] (webpack)/~/process/browser.js 5.3 kB {0} [built]
-   [69] (webpack)/~/react-dom/lib/CSSProperty.js 3.66 kB {0} [built]
-   [90] (webpack)/~/fbjs/lib/camelize.js 708 bytes {0} [built]
-   [91] (webpack)/~/fbjs/lib/camelizeStyleName.js 1 kB {0} [built]
-   [92] (webpack)/~/fbjs/lib/containsNode.js 1.05 kB {0} [built]
-   [93] (webpack)/~/fbjs/lib/createArrayFromMixed.js 4.11 kB {0} [built]
-   [94] (webpack)/~/fbjs/lib/createNodesFromMarkup.js 2.66 kB {0} [built]
-   [95] (webpack)/~/fbjs/lib/getMarkupWrap.js 3.04 kB {0} [built]
-   [96] (webpack)/~/fbjs/lib/getUnboundedScrollPosition.js 1.05 kB {0} [built]
-   [97] (webpack)/~/fbjs/lib/hyphenate.js 800 bytes {0} [built]
-   [98] (webpack)/~/fbjs/lib/hyphenateStyleName.js 974 bytes {0} [built]
-   [99] (webpack)/~/fbjs/lib/isNode.js 693 bytes {0} [built]
-  [100] (webpack)/~/fbjs/lib/isTextNode.js 605 bytes {0} [built]
-  [101] (webpack)/~/fbjs/lib/memoizeStringOnly.js 698 bytes {0} [built]
-  [102] (webpack)/~/react-dom/lib/ARIADOMPropertyConfig.js 1.82 kB {0} [built]
-  [103] (webpack)/~/react-dom/lib/AutoFocusUtils.js 599 bytes {0} [built]
-  [104] (webpack)/~/react-dom/lib/BeforeInputEventPlugin.js 13.3 kB {0} [built]
-chunk    {1} 4b56298728377da64928.js 49.8 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [34] (webpack)/~/react-dom/lib/SyntheticEvent.js 9.18 kB {1} [built]
-   [42] (webpack)/~/react-dom/lib/SyntheticUIEvent.js 1.57 kB {1} [built]
-   [44] (webpack)/~/react-dom/lib/SyntheticMouseEvent.js 2.14 kB {1} [built]
-   [45] (webpack)/~/react-dom/lib/Transaction.js 9.45 kB {1} [built]
-   [46] (webpack)/~/react-dom/lib/escapeTextContentForBrowser.js 3.43 kB {1} [built]
-   [58] (webpack)/~/react-dom/lib/createMicrosoftUnsafeLocalFunction.js 810 bytes {1} [built]
-   [59] (webpack)/~/react-dom/lib/getEventCharCode.js 1.5 kB {1} [built]
-   [81] (webpack)/~/react-dom/lib/accumulateInto.js 1.69 kB {1} [built]
-   [82] (webpack)/~/react-dom/lib/forEachAccumulated.js 855 bytes {1} [built]
-  [149] (webpack)/~/react-dom/lib/SyntheticFocusEvent.js 1.07 kB {1} [built]
-  [150] (webpack)/~/react-dom/lib/SyntheticInputEvent.js 1.09 kB {1} [built]
-  [151] (webpack)/~/react-dom/lib/SyntheticKeyboardEvent.js 2.71 kB {1} [built]
-  [152] (webpack)/~/react-dom/lib/SyntheticTouchEvent.js 1.28 kB {1} [built]
-  [153] (webpack)/~/react-dom/lib/SyntheticTransitionEvent.js 1.23 kB {1} [built]
-  [154] (webpack)/~/react-dom/lib/SyntheticWheelEvent.js 1.94 kB {1} [built]
-  [155] (webpack)/~/react-dom/lib/adler32.js 1.19 kB {1} [built]
-  [156] (webpack)/~/react-dom/lib/dangerousStyleValue.js 3.02 kB {1} [built]
-  [157] (webpack)/~/react-dom/lib/findDOMNode.js 2.46 kB {1} [built]
-  [158] (webpack)/~/react-dom/lib/flattenChildren.js 2.77 kB {1} [built]
-  [161] (webpack)/~/react-dom/lib/getNextDebugID.js 437 bytes {1} [built]
-chunk    {2} cf8eaf7e2283857b2514.js 29.5 kB {12} {13} {14} [rendered]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [29] (webpack)/~/react-dom/lib/reactProdInvariant.js 1.24 kB {2} [built]
-   [47] (webpack)/~/react-dom/lib/setInnerHTML.js 3.86 kB {2} [built]
-   [60] (webpack)/~/react-dom/lib/getEventModifierState.js 1.23 kB {2} [built]
-   [61] (webpack)/~/react-dom/lib/getEventTarget.js 1.01 kB {2} [built]
-   [62] (webpack)/~/react-dom/lib/isEventSupported.js 1.94 kB {2} [built]
-   [63] (webpack)/~/react-dom/lib/shouldUpdateReactComponent.js 1.4 kB {2} [built]
-   [83] (webpack)/~/react-dom/lib/getHostComponentFromComposite.js 740 bytes {2} [built]
-   [84] (webpack)/~/react-dom/lib/getTextContentAccessor.js 955 bytes {2} [built]
-   [85] (webpack)/~/react-dom/lib/instantiateReactComponent.js 5.05 kB {2} [built]
-   [86] (webpack)/~/react-dom/lib/isTextInputElement.js 1.04 kB {2} [built]
-   [87] (webpack)/~/react-dom/lib/setTextContent.js 1.45 kB {2} [built]
-  [159] (webpack)/~/react-dom/lib/getEventKey.js 2.87 kB {2} [built]
-  [160] (webpack)/~/react-dom/lib/getIteratorFn.js 1.12 kB {2} [built]
-  [162] (webpack)/~/react-dom/lib/getNodeForCharacterOffset.js 1.62 kB {2} [built]
-  [163] (webpack)/~/react-dom/lib/getVendorPrefixedEventName.js 2.87 kB {2} [built]
-  [164] (webpack)/~/react-dom/lib/quoteAttributeValueForBrowser.js 700 bytes {2} [built]
-  [165] (webpack)/~/react-dom/lib/renderSubtreeIntoContainer.js 422 bytes {2} [built]
-chunk    {3} 1aebcb77e36ad0ed5500.js 49.9 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [32] (webpack)/~/react-dom/lib/ReactInstrumentation.js 601 bytes {3} [built]
-   [41] (webpack)/~/react-dom/lib/ReactInstanceMap.js 1.22 kB {3} [built]
-   [56] (webpack)/~/react-dom/lib/ReactErrorUtils.js 2.25 kB {3} [built]
-   [75] (webpack)/~/react-dom/lib/ReactFeatureFlags.js 628 bytes {3} [built]
-   [76] (webpack)/~/react-dom/lib/ReactHostComponent.js 1.98 kB {3} [built]
-   [77] (webpack)/~/react-dom/lib/ReactInputSelection.js 4.27 kB {3} [built]
-   [79] (webpack)/~/react-dom/lib/ReactNodeTypes.js 1.02 kB {3} [built]
-  [123] (webpack)/~/react-dom/lib/ReactDOMSelection.js 6.78 kB {3} [built]
-  [124] (webpack)/~/react-dom/lib/ReactDOMTextComponent.js 5.82 kB {3} [built]
-  [125] (webpack)/~/react-dom/lib/ReactDOMTextarea.js 6.46 kB {3} [built]
-  [130] (webpack)/~/react-dom/lib/ReactEventEmitterMixin.js 959 bytes {3} [built]
-  [131] (webpack)/~/react-dom/lib/ReactEventListener.js 5.3 kB {3} [built]
-  [132] (webpack)/~/react-dom/lib/ReactInjection.js 1.2 kB {3} [built]
-  [133] (webpack)/~/react-dom/lib/ReactMarkupChecksum.js 1.47 kB {3} [built]
-  [135] (webpack)/~/react-dom/lib/ReactOwner.js 3.53 kB {3} [built]
-  [137] (webpack)/~/react-dom/lib/ReactReconcileTransaction.js 5.26 kB {3} [built]
-  [145] (webpack)/~/react-dom/lib/SyntheticAnimationEvent.js 1.21 kB {3} [built]
-chunk    {4} e7e0f7bc43020d03cea9.js 49.7 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [30] (webpack)/~/react-dom/lib/ReactDOMComponentTree.js 6.27 kB {4} [built]
-   [43] (webpack)/~/react-dom/lib/ReactBrowserEventEmitter.js 12.6 kB {4} [built]
-   [54] (webpack)/~/react-dom/lib/LinkedValueUtils.js 5.15 kB {4} [built]
-   [55] (webpack)/~/react-dom/lib/ReactComponentEnvironment.js 1.3 kB {4} [built]
-  [112] (webpack)/~/react-dom/lib/ReactChildReconciler.js 6.11 kB {4} [built]
-  [113] (webpack)/~/react-dom/lib/ReactComponentBrowserEnvironment.js 906 bytes {4} [built]
-  [115] (webpack)/~/react-dom/lib/ReactDOM.js 5.14 kB {4} [built]
-  [117] (webpack)/~/react-dom/lib/ReactDOMContainerInfo.js 967 bytes {4} [built]
-  [118] (webpack)/~/react-dom/lib/ReactDOMEmptyComponent.js 1.9 kB {4} [built]
-  [119] (webpack)/~/react-dom/lib/ReactDOMFeatureFlags.js 439 bytes {4} [built]
-  [120] (webpack)/~/react-dom/lib/ReactDOMIDOperations.js 956 bytes {4} [built]
-  [122] (webpack)/~/react-dom/lib/ReactDOMOption.js 3.69 kB {4} [built]
-  [126] (webpack)/~/react-dom/lib/ReactDOMTreeTraversal.js 3.72 kB {4} [built]
-  [129] (webpack)/~/react-dom/lib/ReactElementSymbol.js 622 bytes {4} [built]
-chunk    {5} cd30a0e5b23181f08280.js 49.9 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [33] (webpack)/~/react-dom/lib/ReactUpdates.js 9.53 kB {5} [built]
-   [57] (webpack)/~/react-dom/lib/ReactUpdateQueue.js 9.01 kB {5} [built]
-   [80] (webpack)/~/react-dom/lib/ViewportMetrics.js 606 bytes {5} [built]
-  [139] (webpack)/~/react-dom/lib/ReactServerRenderingTransaction.js 2.29 kB {5} [built]
-  [140] (webpack)/~/react-dom/lib/ReactServerUpdateQueue.js 4.83 kB {5} [built]
-  [142] (webpack)/~/react-dom/lib/SVGDOMPropertyConfig.js 7.32 kB {5} [built]
-  [143] (webpack)/~/react-dom/lib/SelectEventPlugin.js 6.06 kB {5} [built]
-  [144] (webpack)/~/react-dom/lib/SimpleEventPlugin.js 7.97 kB {5} [built]
-  [146] (webpack)/~/react-dom/lib/SyntheticClipboardEvent.js 1.17 kB {5} [built]
-  [148] (webpack)/~/react-dom/lib/SyntheticDragEvent.js 1.07 kB {5} [built]
-chunk    {6} 1126d5a81e2264177124.js 49.8 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [35] (webpack)/~/react-dom/lib/PooledClass.js 3.36 kB {6} [built]
-   [39] (webpack)/~/react-dom/lib/EventPluginHub.js 9.11 kB {6} [built]
-   [40] (webpack)/~/react-dom/lib/EventPropagators.js 5.09 kB {6} [built]
-   [51] (webpack)/~/react-dom/lib/EventPluginRegistry.js 9.75 kB {6} [built]
-   [52] (webpack)/~/react-dom/lib/EventPluginUtils.js 7.95 kB {6} [built]
-   [53] (webpack)/~/react-dom/lib/KeyEscapeUtils.js 1.29 kB {6} [built]
-  [107] (webpack)/~/react-dom/lib/Danger.js 2.24 kB {6} [built]
-  [109] (webpack)/~/react-dom/lib/EnterLeaveEventPlugin.js 3.16 kB {6} [built]
-  [110] (webpack)/~/react-dom/lib/FallbackCompositionState.js 2.43 kB {6} [built]
-  [111] (webpack)/~/react-dom/lib/HTMLDOMPropertyConfig.js 5.44 kB {6} [built]
-chunk    {7} 0fc9e56af19a2e1125e3.js 49.8 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [36] (webpack)/~/react-dom/lib/DOMLazyTree.js 3.71 kB {7} [built]
-   [37] (webpack)/~/react-dom/lib/DOMProperty.js 8.24 kB {7} [built]
-   [49] (webpack)/~/react-dom/lib/DOMChildrenOperations.js 7.67 kB {7} [built]
-   [70] (webpack)/~/react-dom/lib/CallbackQueue.js 3.16 kB {7} [built]
-   [71] (webpack)/~/react-dom/lib/DOMPropertyOperations.js 7.61 kB {7} [built]
-   [72] (webpack)/~/react-dom/lib/ReactDOMComponentFlags.js 429 bytes {7} [built]
-  [105] (webpack)/~/react-dom/lib/CSSPropertyOperations.js 6.87 kB {7} [built]
-  [106] (webpack)/~/react-dom/lib/ChangeEventPlugin.js 11.1 kB {7} [built]
-  [108] (webpack)/~/react-dom/lib/DefaultEventPluginOrder.js 1.08 kB {7} [built]
-chunk    {8} 6969094ac64482ef5415.js 49.9 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [38] (webpack)/~/react-dom/lib/ReactReconciler.js 6.21 kB {8} [built]
-   [78] (webpack)/~/react-dom/lib/ReactMount.js 25.5 kB {8} [built]
-  [134] (webpack)/~/react-dom/lib/ReactMultiChild.js 14.6 kB {8} [built]
-  [138] (webpack)/~/react-dom/lib/ReactRef.js 2.56 kB {8} [built]
-  [147] (webpack)/~/react-dom/lib/SyntheticCompositionEvent.js 1.1 kB {8} [built]
-chunk    {9} b98a4783892edb35b41b.js 50 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [73] (webpack)/~/react-dom/lib/ReactDOMSelect.js 6.81 kB {9} [built]
-   [74] (webpack)/~/react-dom/lib/ReactEmptyComponent.js 704 bytes {9} [built]
-  [116] (webpack)/~/react-dom/lib/ReactDOMComponent.js 38.5 kB {9} [built]
-  [128] (webpack)/~/react-dom/lib/ReactDefaultInjection.js 3.5 kB {9} [built]
-  [136] (webpack)/~/react-dom/lib/ReactPropTypesSecret.js 442 bytes {9} [built]
-chunk   {10} 97bba8f30c076dad7452.js 50 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-  [114] (webpack)/~/react-dom/lib/ReactCompositeComponent.js 35.2 kB {10} [built]
-  [121] (webpack)/~/react-dom/lib/ReactDOMInput.js 12.6 kB {10} [built]
-  [127] (webpack)/~/react-dom/lib/ReactDefaultBatchingStrategy.js 1.88 kB {10} [built]
-  [141] (webpack)/~/react-dom/lib/ReactVersion.js 350 bytes {10} [built]
-chunk   {11} 7b9a99048247c52e6473.js 31.1 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [64] (webpack)/~/react-dom/lib/validateDOMNesting.js 13.7 kB {11} [built]
-   [88] (webpack)/~/react-dom/lib/traverseAllChildren.js 7.04 kB {11} [built]
-   [89] (webpack)/~/react/lib/ReactComponentTreeHook.js 10.4 kB {11} [built]
-chunk   {12} 3c590ca94c1cd4573c73.js 50 kB [entry] [rendered] [recorded]
-    > aggressive-splitted main [16] ./example.js 
+7aefde1bb1e079d42670.js  52.8 kB       7  [emitted]  
+c8ff6eb321ccd33524ca.js  57.2 kB       0  [emitted]  
+4bb149689ae97f5d46e7.js    36 kB       2  [emitted]  
+8940e378350d3e1324c1.js  55.3 kB       3  [emitted]  
+cf267a3acb7f49cc1381.js  54.8 kB       4  [emitted]  
+ab338b99ed796fde08b9.js  53.7 kB       5  [emitted]  
+79966dbf56b74a83076f.js  53.4 kB       6  [emitted]  
+ddebc123ba75b638ee6d.js  56.3 kB       1  [emitted]  
+508c3a18fbaff81d37fc.js  51.9 kB       8  [emitted]  
+766d1060910b08c5b00b.js  34.5 kB       9  [emitted]  
+7731c65a1a824990e2dd.js  50.9 kB      10  [emitted]  
+32f25aae39ba65782773.js  50.6 kB      11  [emitted]  
+b546aa95198a765fcdbc.js  61.2 kB      12  [emitted]  
+bc7a8b74aab9bfc3ac10.js  34.2 kB      13  [emitted]  
+fe98766d3891955772be.js  30.3 kB      14  [emitted]  
+Entrypoint main = b546aa95198a765fcdbc.js fe98766d3891955772be.js bc7a8b74aab9bfc3ac10.js
+chunk    {0} c8ff6eb321ccd33524ca.js 49.9 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [19] (webpack)/~/react-dom/index.js 59 bytes {0} [built]
+   [34] (webpack)/~/fbjs/lib/ExecutionEnvironment.js 1.06 kB {0} [built]
+   [51] (webpack)/~/fbjs/lib/shallowEqual.js 1.74 kB {0} [built]
+   [68] (webpack)/~/fbjs/lib/EventListener.js 2.67 kB {0} [built]
+   [69] (webpack)/~/fbjs/lib/focusNode.js 704 bytes {0} [built]
+   [70] (webpack)/~/fbjs/lib/getActiveElement.js 1.04 kB {0} [built]
+   [71] (webpack)/~/process/browser.js 5.3 kB {0} [built]
+   [72] (webpack)/~/react-dom/lib/CSSProperty.js 3.66 kB {0} [built]
+   [75] (webpack)/~/react-dom/lib/ReactDOMComponentFlags.js 429 bytes {0} [built]
+   [93] (webpack)/~/fbjs/lib/camelize.js 708 bytes {0} [built]
+   [94] (webpack)/~/fbjs/lib/camelizeStyleName.js 1 kB {0} [built]
+   [95] (webpack)/~/fbjs/lib/containsNode.js 1.05 kB {0} [built]
+   [96] (webpack)/~/fbjs/lib/createArrayFromMixed.js 4.11 kB {0} [built]
+   [97] (webpack)/~/fbjs/lib/createNodesFromMarkup.js 2.66 kB {0} [built]
+   [98] (webpack)/~/fbjs/lib/getMarkupWrap.js 3.04 kB {0} [built]
+   [99] (webpack)/~/fbjs/lib/getUnboundedScrollPosition.js 1.12 kB {0} [built]
+  [100] (webpack)/~/fbjs/lib/hyphenate.js 800 bytes {0} [built]
+  [101] (webpack)/~/fbjs/lib/hyphenateStyleName.js 974 bytes {0} [built]
+  [102] (webpack)/~/fbjs/lib/isNode.js 828 bytes {0} [built]
+  [103] (webpack)/~/fbjs/lib/isTextNode.js 605 bytes {0} [built]
+  [104] (webpack)/~/fbjs/lib/memoizeStringOnly.js 698 bytes {0} [built]
+  [105] (webpack)/~/react-dom/lib/ARIADOMPropertyConfig.js 1.82 kB {0} [built]
+  [106] (webpack)/~/react-dom/lib/AutoFocusUtils.js 599 bytes {0} [built]
+  [107] (webpack)/~/react-dom/lib/BeforeInputEventPlugin.js 13.3 kB {0} [built]
+chunk    {1} ddebc123ba75b638ee6d.js 49.9 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [44] (webpack)/~/react-dom/lib/ReactInstanceMap.js 1.22 kB {1} [built]
+   [59] (webpack)/~/react-dom/lib/ReactErrorUtils.js 2.19 kB {1} [built]
+   [79] (webpack)/~/react-dom/lib/ReactHostComponent.js 1.98 kB {1} [built]
+   [80] (webpack)/~/react-dom/lib/ReactInputSelection.js 4.27 kB {1} [built]
+   [82] (webpack)/~/react-dom/lib/ReactNodeTypes.js 1.02 kB {1} [built]
+  [126] (webpack)/~/react-dom/lib/ReactDOMSelection.js 6.78 kB {1} [built]
+  [127] (webpack)/~/react-dom/lib/ReactDOMTextComponent.js 5.82 kB {1} [built]
+  [128] (webpack)/~/react-dom/lib/ReactDOMTextarea.js 6.46 kB {1} [built]
+  [131] (webpack)/~/react-dom/lib/ReactDefaultInjection.js 3.5 kB {1} [built]
+  [133] (webpack)/~/react-dom/lib/ReactEventEmitterMixin.js 959 bytes {1} [built]
+  [134] (webpack)/~/react-dom/lib/ReactEventListener.js 5.3 kB {1} [built]
+  [135] (webpack)/~/react-dom/lib/ReactInjection.js 1.2 kB {1} [built]
+  [136] (webpack)/~/react-dom/lib/ReactMarkupChecksum.js 1.47 kB {1} [built]
+  [138] (webpack)/~/react-dom/lib/ReactOwner.js 3.53 kB {1} [built]
+  [141] (webpack)/~/react-dom/lib/ReactRef.js 2.56 kB {1} [built]
+  [148] (webpack)/~/react-dom/lib/SyntheticAnimationEvent.js 1.21 kB {1} [built]
+  [167] (webpack)/~/react-dom/lib/renderSubtreeIntoContainer.js 422 bytes {1} [built]
+chunk    {2} 4bb149689ae97f5d46e7.js 30.5 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [32] (webpack)/~/react-dom/lib/reactProdInvariant.js 1.24 kB {2} [built]
+   [50] (webpack)/~/react-dom/lib/setInnerHTML.js 3.86 kB {2} [built]
+   [63] (webpack)/~/react-dom/lib/getEventModifierState.js 1.23 kB {2} [built]
+   [64] (webpack)/~/react-dom/lib/getEventTarget.js 1.01 kB {2} [built]
+   [65] (webpack)/~/react-dom/lib/isEventSupported.js 1.94 kB {2} [built]
+   [86] (webpack)/~/react-dom/lib/getHostComponentFromComposite.js 740 bytes {2} [built]
+   [87] (webpack)/~/react-dom/lib/getTextContentAccessor.js 955 bytes {2} [built]
+   [88] (webpack)/~/react-dom/lib/instantiateReactComponent.js 5.06 kB {2} [built]
+   [89] (webpack)/~/react-dom/lib/isTextInputElement.js 1.04 kB {2} [built]
+   [90] (webpack)/~/react-dom/lib/setTextContent.js 1.45 kB {2} [built]
+  [161] (webpack)/~/react-dom/lib/flattenChildren.js 2.77 kB {2} [built]
+  [162] (webpack)/~/react-dom/lib/getEventKey.js 2.87 kB {2} [built]
+  [163] (webpack)/~/react-dom/lib/getIteratorFn.js 1.12 kB {2} [built]
+  [164] (webpack)/~/react-dom/lib/getNodeForCharacterOffset.js 1.62 kB {2} [built]
+  [165] (webpack)/~/react-dom/lib/getVendorPrefixedEventName.js 2.87 kB {2} [built]
+  [166] (webpack)/~/react-dom/lib/quoteAttributeValueForBrowser.js 700 bytes {2} [built]
+chunk    {3} 8940e378350d3e1324c1.js 49.7 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [37] (webpack)/~/react-dom/lib/SyntheticEvent.js 9.18 kB {3} [built]
+   [45] (webpack)/~/react-dom/lib/SyntheticUIEvent.js 1.57 kB {3} [built]
+   [47] (webpack)/~/react-dom/lib/SyntheticMouseEvent.js 2.14 kB {3} [built]
+   [48] (webpack)/~/react-dom/lib/Transaction.js 9.45 kB {3} [built]
+   [49] (webpack)/~/react-dom/lib/escapeTextContentForBrowser.js 3.43 kB {3} [built]
+   [61] (webpack)/~/react-dom/lib/createMicrosoftUnsafeLocalFunction.js 810 bytes {3} [built]
+   [62] (webpack)/~/react-dom/lib/getEventCharCode.js 1.5 kB {3} [built]
+   [84] (webpack)/~/react-dom/lib/accumulateInto.js 1.69 kB {3} [built]
+   [85] (webpack)/~/react-dom/lib/forEachAccumulated.js 855 bytes {3} [built]
+  [147] (webpack)/~/react-dom/lib/SimpleEventPlugin.js 7.97 kB {3} [built]
+  [155] (webpack)/~/react-dom/lib/SyntheticTouchEvent.js 1.28 kB {3} [built]
+  [156] (webpack)/~/react-dom/lib/SyntheticTransitionEvent.js 1.23 kB {3} [built]
+  [157] (webpack)/~/react-dom/lib/SyntheticWheelEvent.js 1.94 kB {3} [built]
+  [158] (webpack)/~/react-dom/lib/adler32.js 1.19 kB {3} [built]
+  [159] (webpack)/~/react-dom/lib/dangerousStyleValue.js 3.02 kB {3} [built]
+  [160] (webpack)/~/react-dom/lib/findDOMNode.js 2.46 kB {3} [built]
+chunk    {4} cf267a3acb7f49cc1381.js 50 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [33] (webpack)/~/react-dom/lib/ReactDOMComponentTree.js 6.27 kB {4} [built]
+   [35] (webpack)/~/react-dom/lib/ReactInstrumentation.js 601 bytes {4} [built]
+   [38] (webpack)/~/react-dom/lib/PooledClass.js 3.36 kB {4} [built]
+   [46] (webpack)/~/react-dom/lib/ReactBrowserEventEmitter.js 12.6 kB {4} [built]
+   [57] (webpack)/~/react-dom/lib/LinkedValueUtils.js 5.25 kB {4} [built]
+   [58] (webpack)/~/react-dom/lib/ReactComponentEnvironment.js 1.3 kB {4} [built]
+  [115] (webpack)/~/react-dom/lib/ReactChildReconciler.js 6.11 kB {4} [built]
+  [118] (webpack)/~/react-dom/lib/ReactDOM.js 5.14 kB {4} [built]
+  [120] (webpack)/~/react-dom/lib/ReactDOMContainerInfo.js 967 bytes {4} [built]
+  [121] (webpack)/~/react-dom/lib/ReactDOMEmptyComponent.js 1.9 kB {4} [built]
+  [123] (webpack)/~/react-dom/lib/ReactDOMIDOperations.js 956 bytes {4} [built]
+  [125] (webpack)/~/react-dom/lib/ReactDOMOption.js 3.69 kB {4} [built]
+  [130] (webpack)/~/react-dom/lib/ReactDefaultBatchingStrategy.js 1.88 kB {4} [built]
+chunk    {5} ab338b99ed796fde08b9.js 49.9 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [42] (webpack)/~/react-dom/lib/EventPluginHub.js 9.11 kB {5} [built]
+   [43] (webpack)/~/react-dom/lib/EventPropagators.js 5.09 kB {5} [built]
+   [54] (webpack)/~/react-dom/lib/EventPluginRegistry.js 9.75 kB {5} [built]
+   [55] (webpack)/~/react-dom/lib/EventPluginUtils.js 7.95 kB {5} [built]
+   [56] (webpack)/~/react-dom/lib/KeyEscapeUtils.js 1.29 kB {5} [built]
+  [110] (webpack)/~/react-dom/lib/Danger.js 2.24 kB {5} [built]
+  [111] (webpack)/~/react-dom/lib/DefaultEventPluginOrder.js 1.08 kB {5} [built]
+  [112] (webpack)/~/react-dom/lib/EnterLeaveEventPlugin.js 3.16 kB {5} [built]
+  [113] (webpack)/~/react-dom/lib/FallbackCompositionState.js 2.43 kB {5} [built]
+  [114] (webpack)/~/react-dom/lib/HTMLDOMPropertyConfig.js 6.57 kB {5} [built]
+  [116] (webpack)/~/react-dom/lib/ReactComponentBrowserEnvironment.js 906 bytes {5} [built]
+  [144] (webpack)/~/react-dom/lib/ReactVersion.js 350 bytes {5} [built]
+chunk    {6} 79966dbf56b74a83076f.js 49.8 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [36] (webpack)/~/react-dom/lib/ReactUpdates.js 9.53 kB {6} [built]
+   [41] (webpack)/~/react-dom/lib/ReactReconciler.js 6.21 kB {6} [built]
+   [60] (webpack)/~/react-dom/lib/ReactUpdateQueue.js 9.36 kB {6} [built]
+   [83] (webpack)/~/react-dom/lib/ViewportMetrics.js 606 bytes {6} [built]
+  [143] (webpack)/~/react-dom/lib/ReactServerUpdateQueue.js 4.83 kB {6} [built]
+  [145] (webpack)/~/react-dom/lib/SVGDOMPropertyConfig.js 7.32 kB {6} [built]
+  [146] (webpack)/~/react-dom/lib/SelectEventPlugin.js 6.06 kB {6} [built]
+  [151] (webpack)/~/react-dom/lib/SyntheticDragEvent.js 1.07 kB {6} [built]
+  [152] (webpack)/~/react-dom/lib/SyntheticFocusEvent.js 1.07 kB {6} [built]
+  [153] (webpack)/~/react-dom/lib/SyntheticInputEvent.js 1.09 kB {6} [built]
+  [154] (webpack)/~/react-dom/lib/SyntheticKeyboardEvent.js 2.71 kB {6} [built]
+chunk    {7} 7aefde1bb1e079d42670.js 50 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [39] (webpack)/~/react-dom/lib/DOMLazyTree.js 3.71 kB {7} [built]
+   [40] (webpack)/~/react-dom/lib/DOMProperty.js 8.24 kB {7} [built]
+   [52] (webpack)/~/react-dom/lib/DOMChildrenOperations.js 7.67 kB {7} [built]
+   [53] (webpack)/~/react-dom/lib/DOMNamespaces.js 505 bytes {7} [built]
+   [73] (webpack)/~/react-dom/lib/CallbackQueue.js 3.16 kB {7} [built]
+   [74] (webpack)/~/react-dom/lib/DOMPropertyOperations.js 7.61 kB {7} [built]
+  [108] (webpack)/~/react-dom/lib/CSSPropertyOperations.js 6.87 kB {7} [built]
+  [109] (webpack)/~/react-dom/lib/ChangeEventPlugin.js 11.8 kB {7} [built]
+  [122] (webpack)/~/react-dom/lib/ReactDOMFeatureFlags.js 439 bytes {7} [built]
+chunk    {8} 508c3a18fbaff81d37fc.js 49.9 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [81] (webpack)/~/react-dom/lib/ReactMount.js 25.5 kB {8} [built]
+  [137] (webpack)/~/react-dom/lib/ReactMultiChild.js 14.6 kB {8} [built]
+  [140] (webpack)/~/react-dom/lib/ReactReconcileTransaction.js 5.26 kB {8} [built]
+  [142] (webpack)/~/react-dom/lib/ReactServerRenderingTransaction.js 2.29 kB {8} [built]
+  [149] (webpack)/~/react-dom/lib/SyntheticClipboardEvent.js 1.17 kB {8} [built]
+  [150] (webpack)/~/react-dom/lib/SyntheticCompositionEvent.js 1.1 kB {8} [built]
+chunk    {9} 766d1060910b08c5b00b.js 32.9 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [66] (webpack)/~/react-dom/lib/shouldUpdateReactComponent.js 1.4 kB {9} [built]
+   [67] (webpack)/~/react-dom/lib/validateDOMNesting.js 13.7 kB {9} [built]
+   [91] (webpack)/~/react-dom/lib/traverseAllChildren.js 7.04 kB {9} [built]
+   [92] (webpack)/~/react/lib/ReactComponentTreeHook.js 10.4 kB {9} [built]
+  [168] (webpack)/~/react/lib/getNextDebugID.js 437 bytes {9} [built]
+chunk   {10} 7731c65a1a824990e2dd.js 50 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [77] (webpack)/~/react-dom/lib/ReactEmptyComponent.js 704 bytes {10} [built]
+  [117] (webpack)/~/react-dom/lib/ReactCompositeComponent.js 35.2 kB {10} [built]
+  [124] (webpack)/~/react-dom/lib/ReactDOMInput.js 13 kB {10} [built]
+  [132] (webpack)/~/react-dom/lib/ReactElementSymbol.js 622 bytes {10} [built]
+  [139] (webpack)/~/react-dom/lib/ReactPropTypesSecret.js 442 bytes {10} [built]
+chunk   {11} 32f25aae39ba65782773.js 49.7 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [76] (webpack)/~/react-dom/lib/ReactDOMSelect.js 6.81 kB {11} [built]
+   [78] (webpack)/~/react-dom/lib/ReactFeatureFlags.js 628 bytes {11} [built]
+  [119] (webpack)/~/react-dom/lib/ReactDOMComponent.js 38.5 kB {11} [built]
+  [129] (webpack)/~/react-dom/lib/ReactDOMTreeTraversal.js 3.72 kB {11} [built]
+chunk   {12} b546aa95198a765fcdbc.js 49.9 kB [entry] [rendered] [recorded]
+    > aggressive-splitted main [15] ./example.js 
     [0] (webpack)/~/fbjs/lib/warning.js 2.1 kB {12} [built]
-    [2] (webpack)/~/fbjs/lib/invariant.js 1.63 kB {12} [built]
+    [1] (webpack)/~/fbjs/lib/invariant.js 1.63 kB {12} [built]
     [4] (webpack)/~/object-assign/index.js 2.11 kB {12} [built]
     [5] (webpack)/~/fbjs/lib/emptyFunction.js 1.08 kB {12} [built]
     [6] (webpack)/~/fbjs/lib/emptyObject.js 458 bytes {12} [built]
+    [7] (webpack)/~/react/lib/ReactComponent.js 4.61 kB {12} [built]
     [9] (webpack)/~/react/lib/ReactCurrentOwner.js 623 bytes {12} [built]
    [10] (webpack)/~/react/lib/ReactElementSymbol.js 622 bytes {12} [built]
-   [11] (webpack)/~/react/lib/ReactPropTypeLocationNames.js 572 bytes {12} [built]
-   [15] (webpack)/~/react/lib/React.js 2.69 kB {12} [built]
-   [18] (webpack)/~/react/lib/KeyEscapeUtils.js 1.29 kB {12} [built]
-   [19] (webpack)/~/react/lib/PooledClass.js 3.36 kB {12} [built]
-   [20] (webpack)/~/react/lib/ReactChildren.js 6.19 kB {12} [built]
-   [21] (webpack)/~/react/lib/ReactClass.js 26.5 kB {12} [built]
-   [24] (webpack)/~/react/lib/ReactPropTypesSecret.js 442 bytes {12} [built]
-   [26] (webpack)/~/react/lib/ReactVersion.js 350 bytes {12} [built]
-chunk   {13} bea9c6f9afcb80f33121.js 30.6 kB [initial] [rendered]
-    > aggressive-splitted main [16] ./example.js 
+   [12] (webpack)/~/react/react.js 56 bytes {12} [built]
+   [13] (webpack)/~/react/lib/React.js 3.32 kB {12} [built]
+   [14] (webpack)/~/prop-types/factory.js 890 bytes {12} [built]
+   [16] (webpack)/~/prop-types/checkPropTypes.js 2.94 kB {12} [built]
+   [17] (webpack)/~/prop-types/factoryWithTypeCheckers.js 17.6 kB {12} [built]
+   [18] (webpack)/~/prop-types/lib/ReactPropTypesSecret.js 436 bytes {12} [built]
+   [20] (webpack)/~/react/lib/KeyEscapeUtils.js 1.29 kB {12} [built]
+   [21] (webpack)/~/react/lib/PooledClass.js 3.36 kB {12} [built]
+   [22] (webpack)/~/react/lib/ReactChildren.js 6.19 kB {12} [built]
+   [25] (webpack)/~/react/lib/ReactPropTypeLocationNames.js 572 bytes {12} [built]
+chunk   {13} bc7a8b74aab9bfc3ac10.js 30.4 kB [initial] [rendered]
+    > aggressive-splitted main [15] ./example.js 
+    [2] (webpack)/~/react/lib/ReactElement.js 11.2 kB {13} [built]
     [3] (webpack)/~/react/lib/reactProdInvariant.js 1.24 kB {13} [built]
-    [8] (webpack)/~/react/lib/ReactNoopUpdateQueue.js 3.36 kB {13} [built]
-   [12] (webpack)/~/react/lib/canDefineProperty.js 661 bytes {13} [built]
-   [13] (webpack)/~/react/lib/getIteratorFn.js 1.12 kB {13} [built]
-   [16] ./example.js 44 bytes {13} [built]
-   [23] (webpack)/~/react/lib/ReactPropTypes.js 15.8 kB {13} [built]
-   [27] (webpack)/~/react/lib/onlyChild.js 1.34 kB {13} [built]
-   [28] (webpack)/~/react/lib/traverseAllChildren.js 7.03 kB {13} [built]
-chunk   {14} 85fc6439c97999cbcda0.js 22.7 kB [initial] [rendered]
-    > aggressive-splitted main [16] ./example.js 
-    [1] (webpack)/~/react/lib/ReactElement.js 11.2 kB {14} [built]
-    [7] (webpack)/~/react/lib/ReactComponent.js 4.61 kB {14} [built]
-   [14] (webpack)/~/react/react.js 56 bytes {14} [built]
-   [22] (webpack)/~/react/lib/ReactDOMFactories.js 5.53 kB {14} [built]
-   [25] (webpack)/~/react/lib/ReactPureComponent.js 1.32 kB {14} [built]
+   [11] (webpack)/~/react/lib/canDefineProperty.js 661 bytes {13} [built]
+   [15] ./example.js 42 bytes {13} [built]
+   [24] (webpack)/~/react/lib/ReactDOMFactories.js 5.53 kB {13} [built]
+   [26] (webpack)/~/react/lib/ReactPropTypes.js 500 bytes {13} [built]
+   [27] (webpack)/~/react/lib/ReactPureComponent.js 1.32 kB {13} [built]
+   [28] (webpack)/~/react/lib/ReactVersion.js 350 bytes {13} [built]
+   [29] (webpack)/~/react/lib/getIteratorFn.js 1.12 kB {13} [built]
+   [30] (webpack)/~/react/lib/onlyChild.js 1.34 kB {13} [built]
+   [31] (webpack)/~/react/lib/traverseAllChildren.js 7.03 kB {13} [built]
+chunk   {14} fe98766d3891955772be.js 30.3 kB [initial] [rendered] [recorded]
+    > aggressive-splitted main [15] ./example.js 
+    [8] (webpack)/~/react/lib/ReactNoopUpdateQueue.js 3.36 kB {14} [built]
+   [23] (webpack)/~/react/lib/ReactClass.js 26.9 kB {14} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: c9781c5521ffee4f5298
-Version: webpack 2.3.2
+Hash: 550b9653dc46c27e327c
+Version: webpack 2.4.1
                   Asset     Size  Chunks             Chunk Names
-0fc9e56af19a2e1125e3.js  10.2 kB       7  [emitted]  
-7923f88ea316bb0caf20.js  12.2 kB       0  [emitted]  
-cf8eaf7e2283857b2514.js  7.14 kB       2  [emitted]  
-1aebcb77e36ad0ed5500.js  10.5 kB       3  [emitted]  
-e7e0f7bc43020d03cea9.js  11.9 kB       4  [emitted]  
-cd30a0e5b23181f08280.js  15.3 kB       5  [emitted]  
-1126d5a81e2264177124.js  11.6 kB       6  [emitted]  
-4b56298728377da64928.js  7.86 kB       1  [emitted]  
-6969094ac64482ef5415.js  8.01 kB       8  [emitted]  
-b98a4783892edb35b41b.js  12.7 kB       9  [emitted]  
-97bba8f30c076dad7452.js  10.2 kB      10  [emitted]  
-7b9a99048247c52e6473.js   4.5 kB      11  [emitted]  
-3c590ca94c1cd4573c73.js  10.3 kB      12  [emitted]  
-bea9c6f9afcb80f33121.js  6.22 kB      13  [emitted]  
-85fc6439c97999cbcda0.js  4.61 kB      14  [emitted]  
-Entrypoint main = 3c590ca94c1cd4573c73.js 85fc6439c97999cbcda0.js bea9c6f9afcb80f33121.js
-chunk    {0} 7923f88ea316bb0caf20.js 49.7 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [17] (webpack)/~/react-dom/index.js 59 bytes {0} [built]
-   [31] (webpack)/~/fbjs/lib/ExecutionEnvironment.js 1.06 kB {0} [built]
-   [48] (webpack)/~/fbjs/lib/shallowEqual.js 1.74 kB {0} [built]
-   [50] (webpack)/~/react-dom/lib/DOMNamespaces.js 505 bytes {0} [built]
-   [65] (webpack)/~/fbjs/lib/EventListener.js 2.67 kB {0} [built]
-   [66] (webpack)/~/fbjs/lib/focusNode.js 704 bytes {0} [built]
-   [67] (webpack)/~/fbjs/lib/getActiveElement.js 895 bytes {0} [built]
-   [68] (webpack)/~/process/browser.js 5.3 kB {0} [built]
-   [69] (webpack)/~/react-dom/lib/CSSProperty.js 3.66 kB {0} [built]
-   [90] (webpack)/~/fbjs/lib/camelize.js 708 bytes {0} [built]
-   [91] (webpack)/~/fbjs/lib/camelizeStyleName.js 1 kB {0} [built]
-   [92] (webpack)/~/fbjs/lib/containsNode.js 1.05 kB {0} [built]
-   [93] (webpack)/~/fbjs/lib/createArrayFromMixed.js 4.11 kB {0} [built]
-   [94] (webpack)/~/fbjs/lib/createNodesFromMarkup.js 2.66 kB {0} [built]
-   [95] (webpack)/~/fbjs/lib/getMarkupWrap.js 3.04 kB {0} [built]
-   [96] (webpack)/~/fbjs/lib/getUnboundedScrollPosition.js 1.05 kB {0} [built]
-   [97] (webpack)/~/fbjs/lib/hyphenate.js 800 bytes {0} [built]
-   [98] (webpack)/~/fbjs/lib/hyphenateStyleName.js 974 bytes {0} [built]
-   [99] (webpack)/~/fbjs/lib/isNode.js 693 bytes {0} [built]
-  [100] (webpack)/~/fbjs/lib/isTextNode.js 605 bytes {0} [built]
-  [101] (webpack)/~/fbjs/lib/memoizeStringOnly.js 698 bytes {0} [built]
-  [102] (webpack)/~/react-dom/lib/ARIADOMPropertyConfig.js 1.82 kB {0} [built]
-  [103] (webpack)/~/react-dom/lib/AutoFocusUtils.js 599 bytes {0} [built]
-  [104] (webpack)/~/react-dom/lib/BeforeInputEventPlugin.js 13.3 kB {0} [built]
-chunk    {1} 4b56298728377da64928.js 49.8 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [34] (webpack)/~/react-dom/lib/SyntheticEvent.js 9.18 kB {1} [built]
-   [42] (webpack)/~/react-dom/lib/SyntheticUIEvent.js 1.57 kB {1} [built]
-   [44] (webpack)/~/react-dom/lib/SyntheticMouseEvent.js 2.14 kB {1} [built]
-   [45] (webpack)/~/react-dom/lib/Transaction.js 9.45 kB {1} [built]
-   [46] (webpack)/~/react-dom/lib/escapeTextContentForBrowser.js 3.43 kB {1} [built]
-   [58] (webpack)/~/react-dom/lib/createMicrosoftUnsafeLocalFunction.js 810 bytes {1} [built]
-   [59] (webpack)/~/react-dom/lib/getEventCharCode.js 1.5 kB {1} [built]
-   [81] (webpack)/~/react-dom/lib/accumulateInto.js 1.69 kB {1} [built]
-   [82] (webpack)/~/react-dom/lib/forEachAccumulated.js 855 bytes {1} [built]
-  [149] (webpack)/~/react-dom/lib/SyntheticFocusEvent.js 1.07 kB {1} [built]
-  [150] (webpack)/~/react-dom/lib/SyntheticInputEvent.js 1.09 kB {1} [built]
-  [151] (webpack)/~/react-dom/lib/SyntheticKeyboardEvent.js 2.71 kB {1} [built]
-  [152] (webpack)/~/react-dom/lib/SyntheticTouchEvent.js 1.28 kB {1} [built]
-  [153] (webpack)/~/react-dom/lib/SyntheticTransitionEvent.js 1.23 kB {1} [built]
-  [154] (webpack)/~/react-dom/lib/SyntheticWheelEvent.js 1.94 kB {1} [built]
-  [155] (webpack)/~/react-dom/lib/adler32.js 1.19 kB {1} [built]
-  [156] (webpack)/~/react-dom/lib/dangerousStyleValue.js 3.02 kB {1} [built]
-  [157] (webpack)/~/react-dom/lib/findDOMNode.js 2.46 kB {1} [built]
-  [158] (webpack)/~/react-dom/lib/flattenChildren.js 2.77 kB {1} [built]
-  [161] (webpack)/~/react-dom/lib/getNextDebugID.js 437 bytes {1} [built]
-chunk    {2} cf8eaf7e2283857b2514.js 29.5 kB {12} {13} {14} [rendered]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [29] (webpack)/~/react-dom/lib/reactProdInvariant.js 1.24 kB {2} [built]
-   [47] (webpack)/~/react-dom/lib/setInnerHTML.js 3.86 kB {2} [built]
-   [60] (webpack)/~/react-dom/lib/getEventModifierState.js 1.23 kB {2} [built]
-   [61] (webpack)/~/react-dom/lib/getEventTarget.js 1.01 kB {2} [built]
-   [62] (webpack)/~/react-dom/lib/isEventSupported.js 1.94 kB {2} [built]
-   [63] (webpack)/~/react-dom/lib/shouldUpdateReactComponent.js 1.4 kB {2} [built]
-   [83] (webpack)/~/react-dom/lib/getHostComponentFromComposite.js 740 bytes {2} [built]
-   [84] (webpack)/~/react-dom/lib/getTextContentAccessor.js 955 bytes {2} [built]
-   [85] (webpack)/~/react-dom/lib/instantiateReactComponent.js 5.05 kB {2} [built]
-   [86] (webpack)/~/react-dom/lib/isTextInputElement.js 1.04 kB {2} [built]
-   [87] (webpack)/~/react-dom/lib/setTextContent.js 1.45 kB {2} [built]
-  [159] (webpack)/~/react-dom/lib/getEventKey.js 2.87 kB {2} [built]
-  [160] (webpack)/~/react-dom/lib/getIteratorFn.js 1.12 kB {2} [built]
-  [162] (webpack)/~/react-dom/lib/getNodeForCharacterOffset.js 1.62 kB {2} [built]
-  [163] (webpack)/~/react-dom/lib/getVendorPrefixedEventName.js 2.87 kB {2} [built]
-  [164] (webpack)/~/react-dom/lib/quoteAttributeValueForBrowser.js 700 bytes {2} [built]
-  [165] (webpack)/~/react-dom/lib/renderSubtreeIntoContainer.js 422 bytes {2} [built]
-chunk    {3} 1aebcb77e36ad0ed5500.js 49.9 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [32] (webpack)/~/react-dom/lib/ReactInstrumentation.js 601 bytes {3} [built]
-   [41] (webpack)/~/react-dom/lib/ReactInstanceMap.js 1.22 kB {3} [built]
-   [56] (webpack)/~/react-dom/lib/ReactErrorUtils.js 2.25 kB {3} [built]
-   [75] (webpack)/~/react-dom/lib/ReactFeatureFlags.js 628 bytes {3} [built]
-   [76] (webpack)/~/react-dom/lib/ReactHostComponent.js 1.98 kB {3} [built]
-   [77] (webpack)/~/react-dom/lib/ReactInputSelection.js 4.27 kB {3} [built]
-   [79] (webpack)/~/react-dom/lib/ReactNodeTypes.js 1.02 kB {3} [built]
-  [123] (webpack)/~/react-dom/lib/ReactDOMSelection.js 6.78 kB {3} [built]
-  [124] (webpack)/~/react-dom/lib/ReactDOMTextComponent.js 5.82 kB {3} [built]
-  [125] (webpack)/~/react-dom/lib/ReactDOMTextarea.js 6.46 kB {3} [built]
-  [130] (webpack)/~/react-dom/lib/ReactEventEmitterMixin.js 959 bytes {3} [built]
-  [131] (webpack)/~/react-dom/lib/ReactEventListener.js 5.3 kB {3} [built]
-  [132] (webpack)/~/react-dom/lib/ReactInjection.js 1.2 kB {3} [built]
-  [133] (webpack)/~/react-dom/lib/ReactMarkupChecksum.js 1.47 kB {3} [built]
-  [135] (webpack)/~/react-dom/lib/ReactOwner.js 3.53 kB {3} [built]
-  [137] (webpack)/~/react-dom/lib/ReactReconcileTransaction.js 5.26 kB {3} [built]
-  [145] (webpack)/~/react-dom/lib/SyntheticAnimationEvent.js 1.21 kB {3} [built]
-chunk    {4} e7e0f7bc43020d03cea9.js 49.7 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [30] (webpack)/~/react-dom/lib/ReactDOMComponentTree.js 6.27 kB {4} [built]
-   [43] (webpack)/~/react-dom/lib/ReactBrowserEventEmitter.js 12.6 kB {4} [built]
-   [54] (webpack)/~/react-dom/lib/LinkedValueUtils.js 5.15 kB {4} [built]
-   [55] (webpack)/~/react-dom/lib/ReactComponentEnvironment.js 1.3 kB {4} [built]
-  [112] (webpack)/~/react-dom/lib/ReactChildReconciler.js 6.11 kB {4} [built]
-  [113] (webpack)/~/react-dom/lib/ReactComponentBrowserEnvironment.js 906 bytes {4} [built]
-  [115] (webpack)/~/react-dom/lib/ReactDOM.js 5.14 kB {4} [built]
-  [117] (webpack)/~/react-dom/lib/ReactDOMContainerInfo.js 967 bytes {4} [built]
-  [118] (webpack)/~/react-dom/lib/ReactDOMEmptyComponent.js 1.9 kB {4} [built]
-  [119] (webpack)/~/react-dom/lib/ReactDOMFeatureFlags.js 439 bytes {4} [built]
-  [120] (webpack)/~/react-dom/lib/ReactDOMIDOperations.js 956 bytes {4} [built]
-  [122] (webpack)/~/react-dom/lib/ReactDOMOption.js 3.69 kB {4} [built]
-  [126] (webpack)/~/react-dom/lib/ReactDOMTreeTraversal.js 3.72 kB {4} [built]
-  [129] (webpack)/~/react-dom/lib/ReactElementSymbol.js 622 bytes {4} [built]
-chunk    {5} cd30a0e5b23181f08280.js 49.9 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [33] (webpack)/~/react-dom/lib/ReactUpdates.js 9.53 kB {5} [built]
-   [57] (webpack)/~/react-dom/lib/ReactUpdateQueue.js 9.01 kB {5} [built]
-   [80] (webpack)/~/react-dom/lib/ViewportMetrics.js 606 bytes {5} [built]
-  [139] (webpack)/~/react-dom/lib/ReactServerRenderingTransaction.js 2.29 kB {5} [built]
-  [140] (webpack)/~/react-dom/lib/ReactServerUpdateQueue.js 4.83 kB {5} [built]
-  [142] (webpack)/~/react-dom/lib/SVGDOMPropertyConfig.js 7.32 kB {5} [built]
-  [143] (webpack)/~/react-dom/lib/SelectEventPlugin.js 6.06 kB {5} [built]
-  [144] (webpack)/~/react-dom/lib/SimpleEventPlugin.js 7.97 kB {5} [built]
-  [146] (webpack)/~/react-dom/lib/SyntheticClipboardEvent.js 1.17 kB {5} [built]
-  [148] (webpack)/~/react-dom/lib/SyntheticDragEvent.js 1.07 kB {5} [built]
-chunk    {6} 1126d5a81e2264177124.js 49.8 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [35] (webpack)/~/react-dom/lib/PooledClass.js 3.36 kB {6} [built]
-   [39] (webpack)/~/react-dom/lib/EventPluginHub.js 9.11 kB {6} [built]
-   [40] (webpack)/~/react-dom/lib/EventPropagators.js 5.09 kB {6} [built]
-   [51] (webpack)/~/react-dom/lib/EventPluginRegistry.js 9.75 kB {6} [built]
-   [52] (webpack)/~/react-dom/lib/EventPluginUtils.js 7.95 kB {6} [built]
-   [53] (webpack)/~/react-dom/lib/KeyEscapeUtils.js 1.29 kB {6} [built]
-  [107] (webpack)/~/react-dom/lib/Danger.js 2.24 kB {6} [built]
-  [109] (webpack)/~/react-dom/lib/EnterLeaveEventPlugin.js 3.16 kB {6} [built]
-  [110] (webpack)/~/react-dom/lib/FallbackCompositionState.js 2.43 kB {6} [built]
-  [111] (webpack)/~/react-dom/lib/HTMLDOMPropertyConfig.js 5.44 kB {6} [built]
-chunk    {7} 0fc9e56af19a2e1125e3.js 49.8 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [36] (webpack)/~/react-dom/lib/DOMLazyTree.js 3.71 kB {7} [built]
-   [37] (webpack)/~/react-dom/lib/DOMProperty.js 8.24 kB {7} [built]
-   [49] (webpack)/~/react-dom/lib/DOMChildrenOperations.js 7.67 kB {7} [built]
-   [70] (webpack)/~/react-dom/lib/CallbackQueue.js 3.16 kB {7} [built]
-   [71] (webpack)/~/react-dom/lib/DOMPropertyOperations.js 7.61 kB {7} [built]
-   [72] (webpack)/~/react-dom/lib/ReactDOMComponentFlags.js 429 bytes {7} [built]
-  [105] (webpack)/~/react-dom/lib/CSSPropertyOperations.js 6.87 kB {7} [built]
-  [106] (webpack)/~/react-dom/lib/ChangeEventPlugin.js 11.1 kB {7} [built]
-  [108] (webpack)/~/react-dom/lib/DefaultEventPluginOrder.js 1.08 kB {7} [built]
-chunk    {8} 6969094ac64482ef5415.js 49.9 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [38] (webpack)/~/react-dom/lib/ReactReconciler.js 6.21 kB {8} [built]
-   [78] (webpack)/~/react-dom/lib/ReactMount.js 25.5 kB {8} [built]
-  [134] (webpack)/~/react-dom/lib/ReactMultiChild.js 14.6 kB {8} [built]
-  [138] (webpack)/~/react-dom/lib/ReactRef.js 2.56 kB {8} [built]
-  [147] (webpack)/~/react-dom/lib/SyntheticCompositionEvent.js 1.1 kB {8} [built]
-chunk    {9} b98a4783892edb35b41b.js 50 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [73] (webpack)/~/react-dom/lib/ReactDOMSelect.js 6.81 kB {9} [built]
-   [74] (webpack)/~/react-dom/lib/ReactEmptyComponent.js 704 bytes {9} [built]
-  [116] (webpack)/~/react-dom/lib/ReactDOMComponent.js 38.5 kB {9} [built]
-  [128] (webpack)/~/react-dom/lib/ReactDefaultInjection.js 3.5 kB {9} [built]
-  [136] (webpack)/~/react-dom/lib/ReactPropTypesSecret.js 442 bytes {9} [built]
-chunk   {10} 97bba8f30c076dad7452.js 50 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-  [114] (webpack)/~/react-dom/lib/ReactCompositeComponent.js 35.2 kB {10} [built]
-  [121] (webpack)/~/react-dom/lib/ReactDOMInput.js 12.6 kB {10} [built]
-  [127] (webpack)/~/react-dom/lib/ReactDefaultBatchingStrategy.js 1.88 kB {10} [built]
-  [141] (webpack)/~/react-dom/lib/ReactVersion.js 350 bytes {10} [built]
-chunk   {11} 7b9a99048247c52e6473.js 31.1 kB {12} {13} {14} [rendered] [recorded]
-    > aggressive-splitted [16] ./example.js 2:0-22
-   [64] (webpack)/~/react-dom/lib/validateDOMNesting.js 13.7 kB {11} [built]
-   [88] (webpack)/~/react-dom/lib/traverseAllChildren.js 7.04 kB {11} [built]
-   [89] (webpack)/~/react/lib/ReactComponentTreeHook.js 10.4 kB {11} [built]
-chunk   {12} 3c590ca94c1cd4573c73.js 50 kB [entry] [rendered] [recorded]
-    > aggressive-splitted main [16] ./example.js 
+7aefde1bb1e079d42670.js  10.4 kB       7  [emitted]  
+c8ff6eb321ccd33524ca.js  12.2 kB       0  [emitted]  
+4bb149689ae97f5d46e7.js  7.08 kB       2  [emitted]  
+8940e378350d3e1324c1.js  9.58 kB       3  [emitted]  
+cf267a3acb7f49cc1381.js    12 kB       4  [emitted]  
+ab338b99ed796fde08b9.js  11.4 kB       5  [emitted]  
+79966dbf56b74a83076f.js  13.3 kB       6  [emitted]  
+ddebc123ba75b638ee6d.js  11.1 kB       1  [emitted]  
+508c3a18fbaff81d37fc.js  8.25 kB       8  [emitted]  
+766d1060910b08c5b00b.js  4.87 kB       9  [emitted]  
+7731c65a1a824990e2dd.js  10.2 kB      10  [emitted]  
+32f25aae39ba65782773.js  12.5 kB      11  [emitted]  
+b546aa95198a765fcdbc.js  11.8 kB      12  [emitted]  
+bc7a8b74aab9bfc3ac10.js  6.03 kB      13  [emitted]  
+fe98766d3891955772be.js  3.69 kB      14  [emitted]  
+Entrypoint main = b546aa95198a765fcdbc.js fe98766d3891955772be.js bc7a8b74aab9bfc3ac10.js
+chunk    {0} c8ff6eb321ccd33524ca.js 49.9 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [19] (webpack)/~/react-dom/index.js 59 bytes {0} [built]
+   [34] (webpack)/~/fbjs/lib/ExecutionEnvironment.js 1.06 kB {0} [built]
+   [51] (webpack)/~/fbjs/lib/shallowEqual.js 1.74 kB {0} [built]
+   [68] (webpack)/~/fbjs/lib/EventListener.js 2.67 kB {0} [built]
+   [69] (webpack)/~/fbjs/lib/focusNode.js 704 bytes {0} [built]
+   [70] (webpack)/~/fbjs/lib/getActiveElement.js 1.04 kB {0} [built]
+   [71] (webpack)/~/process/browser.js 5.3 kB {0} [built]
+   [72] (webpack)/~/react-dom/lib/CSSProperty.js 3.66 kB {0} [built]
+   [75] (webpack)/~/react-dom/lib/ReactDOMComponentFlags.js 429 bytes {0} [built]
+   [93] (webpack)/~/fbjs/lib/camelize.js 708 bytes {0} [built]
+   [94] (webpack)/~/fbjs/lib/camelizeStyleName.js 1 kB {0} [built]
+   [95] (webpack)/~/fbjs/lib/containsNode.js 1.05 kB {0} [built]
+   [96] (webpack)/~/fbjs/lib/createArrayFromMixed.js 4.11 kB {0} [built]
+   [97] (webpack)/~/fbjs/lib/createNodesFromMarkup.js 2.66 kB {0} [built]
+   [98] (webpack)/~/fbjs/lib/getMarkupWrap.js 3.04 kB {0} [built]
+   [99] (webpack)/~/fbjs/lib/getUnboundedScrollPosition.js 1.12 kB {0} [built]
+  [100] (webpack)/~/fbjs/lib/hyphenate.js 800 bytes {0} [built]
+  [101] (webpack)/~/fbjs/lib/hyphenateStyleName.js 974 bytes {0} [built]
+  [102] (webpack)/~/fbjs/lib/isNode.js 828 bytes {0} [built]
+  [103] (webpack)/~/fbjs/lib/isTextNode.js 605 bytes {0} [built]
+  [104] (webpack)/~/fbjs/lib/memoizeStringOnly.js 698 bytes {0} [built]
+  [105] (webpack)/~/react-dom/lib/ARIADOMPropertyConfig.js 1.82 kB {0} [built]
+  [106] (webpack)/~/react-dom/lib/AutoFocusUtils.js 599 bytes {0} [built]
+  [107] (webpack)/~/react-dom/lib/BeforeInputEventPlugin.js 13.3 kB {0} [built]
+chunk    {1} ddebc123ba75b638ee6d.js 49.9 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [44] (webpack)/~/react-dom/lib/ReactInstanceMap.js 1.22 kB {1} [built]
+   [59] (webpack)/~/react-dom/lib/ReactErrorUtils.js 2.19 kB {1} [built]
+   [79] (webpack)/~/react-dom/lib/ReactHostComponent.js 1.98 kB {1} [built]
+   [80] (webpack)/~/react-dom/lib/ReactInputSelection.js 4.27 kB {1} [built]
+   [82] (webpack)/~/react-dom/lib/ReactNodeTypes.js 1.02 kB {1} [built]
+  [126] (webpack)/~/react-dom/lib/ReactDOMSelection.js 6.78 kB {1} [built]
+  [127] (webpack)/~/react-dom/lib/ReactDOMTextComponent.js 5.82 kB {1} [built]
+  [128] (webpack)/~/react-dom/lib/ReactDOMTextarea.js 6.46 kB {1} [built]
+  [131] (webpack)/~/react-dom/lib/ReactDefaultInjection.js 3.5 kB {1} [built]
+  [133] (webpack)/~/react-dom/lib/ReactEventEmitterMixin.js 959 bytes {1} [built]
+  [134] (webpack)/~/react-dom/lib/ReactEventListener.js 5.3 kB {1} [built]
+  [135] (webpack)/~/react-dom/lib/ReactInjection.js 1.2 kB {1} [built]
+  [136] (webpack)/~/react-dom/lib/ReactMarkupChecksum.js 1.47 kB {1} [built]
+  [138] (webpack)/~/react-dom/lib/ReactOwner.js 3.53 kB {1} [built]
+  [141] (webpack)/~/react-dom/lib/ReactRef.js 2.56 kB {1} [built]
+  [148] (webpack)/~/react-dom/lib/SyntheticAnimationEvent.js 1.21 kB {1} [built]
+  [167] (webpack)/~/react-dom/lib/renderSubtreeIntoContainer.js 422 bytes {1} [built]
+chunk    {2} 4bb149689ae97f5d46e7.js 30.5 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [32] (webpack)/~/react-dom/lib/reactProdInvariant.js 1.24 kB {2} [built]
+   [50] (webpack)/~/react-dom/lib/setInnerHTML.js 3.86 kB {2} [built]
+   [63] (webpack)/~/react-dom/lib/getEventModifierState.js 1.23 kB {2} [built]
+   [64] (webpack)/~/react-dom/lib/getEventTarget.js 1.01 kB {2} [built]
+   [65] (webpack)/~/react-dom/lib/isEventSupported.js 1.94 kB {2} [built]
+   [86] (webpack)/~/react-dom/lib/getHostComponentFromComposite.js 740 bytes {2} [built]
+   [87] (webpack)/~/react-dom/lib/getTextContentAccessor.js 955 bytes {2} [built]
+   [88] (webpack)/~/react-dom/lib/instantiateReactComponent.js 5.06 kB {2} [built]
+   [89] (webpack)/~/react-dom/lib/isTextInputElement.js 1.04 kB {2} [built]
+   [90] (webpack)/~/react-dom/lib/setTextContent.js 1.45 kB {2} [built]
+  [161] (webpack)/~/react-dom/lib/flattenChildren.js 2.77 kB {2} [built]
+  [162] (webpack)/~/react-dom/lib/getEventKey.js 2.87 kB {2} [built]
+  [163] (webpack)/~/react-dom/lib/getIteratorFn.js 1.12 kB {2} [built]
+  [164] (webpack)/~/react-dom/lib/getNodeForCharacterOffset.js 1.62 kB {2} [built]
+  [165] (webpack)/~/react-dom/lib/getVendorPrefixedEventName.js 2.87 kB {2} [built]
+  [166] (webpack)/~/react-dom/lib/quoteAttributeValueForBrowser.js 700 bytes {2} [built]
+chunk    {3} 8940e378350d3e1324c1.js 49.7 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [37] (webpack)/~/react-dom/lib/SyntheticEvent.js 9.18 kB {3} [built]
+   [45] (webpack)/~/react-dom/lib/SyntheticUIEvent.js 1.57 kB {3} [built]
+   [47] (webpack)/~/react-dom/lib/SyntheticMouseEvent.js 2.14 kB {3} [built]
+   [48] (webpack)/~/react-dom/lib/Transaction.js 9.45 kB {3} [built]
+   [49] (webpack)/~/react-dom/lib/escapeTextContentForBrowser.js 3.43 kB {3} [built]
+   [61] (webpack)/~/react-dom/lib/createMicrosoftUnsafeLocalFunction.js 810 bytes {3} [built]
+   [62] (webpack)/~/react-dom/lib/getEventCharCode.js 1.5 kB {3} [built]
+   [84] (webpack)/~/react-dom/lib/accumulateInto.js 1.69 kB {3} [built]
+   [85] (webpack)/~/react-dom/lib/forEachAccumulated.js 855 bytes {3} [built]
+  [147] (webpack)/~/react-dom/lib/SimpleEventPlugin.js 7.97 kB {3} [built]
+  [155] (webpack)/~/react-dom/lib/SyntheticTouchEvent.js 1.28 kB {3} [built]
+  [156] (webpack)/~/react-dom/lib/SyntheticTransitionEvent.js 1.23 kB {3} [built]
+  [157] (webpack)/~/react-dom/lib/SyntheticWheelEvent.js 1.94 kB {3} [built]
+  [158] (webpack)/~/react-dom/lib/adler32.js 1.19 kB {3} [built]
+  [159] (webpack)/~/react-dom/lib/dangerousStyleValue.js 3.02 kB {3} [built]
+  [160] (webpack)/~/react-dom/lib/findDOMNode.js 2.46 kB {3} [built]
+chunk    {4} cf267a3acb7f49cc1381.js 50 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [33] (webpack)/~/react-dom/lib/ReactDOMComponentTree.js 6.27 kB {4} [built]
+   [35] (webpack)/~/react-dom/lib/ReactInstrumentation.js 601 bytes {4} [built]
+   [38] (webpack)/~/react-dom/lib/PooledClass.js 3.36 kB {4} [built]
+   [46] (webpack)/~/react-dom/lib/ReactBrowserEventEmitter.js 12.6 kB {4} [built]
+   [57] (webpack)/~/react-dom/lib/LinkedValueUtils.js 5.25 kB {4} [built]
+   [58] (webpack)/~/react-dom/lib/ReactComponentEnvironment.js 1.3 kB {4} [built]
+  [115] (webpack)/~/react-dom/lib/ReactChildReconciler.js 6.11 kB {4} [built]
+  [118] (webpack)/~/react-dom/lib/ReactDOM.js 5.14 kB {4} [built]
+  [120] (webpack)/~/react-dom/lib/ReactDOMContainerInfo.js 967 bytes {4} [built]
+  [121] (webpack)/~/react-dom/lib/ReactDOMEmptyComponent.js 1.9 kB {4} [built]
+  [123] (webpack)/~/react-dom/lib/ReactDOMIDOperations.js 956 bytes {4} [built]
+  [125] (webpack)/~/react-dom/lib/ReactDOMOption.js 3.69 kB {4} [built]
+  [130] (webpack)/~/react-dom/lib/ReactDefaultBatchingStrategy.js 1.88 kB {4} [built]
+chunk    {5} ab338b99ed796fde08b9.js 49.9 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [42] (webpack)/~/react-dom/lib/EventPluginHub.js 9.11 kB {5} [built]
+   [43] (webpack)/~/react-dom/lib/EventPropagators.js 5.09 kB {5} [built]
+   [54] (webpack)/~/react-dom/lib/EventPluginRegistry.js 9.75 kB {5} [built]
+   [55] (webpack)/~/react-dom/lib/EventPluginUtils.js 7.95 kB {5} [built]
+   [56] (webpack)/~/react-dom/lib/KeyEscapeUtils.js 1.29 kB {5} [built]
+  [110] (webpack)/~/react-dom/lib/Danger.js 2.24 kB {5} [built]
+  [111] (webpack)/~/react-dom/lib/DefaultEventPluginOrder.js 1.08 kB {5} [built]
+  [112] (webpack)/~/react-dom/lib/EnterLeaveEventPlugin.js 3.16 kB {5} [built]
+  [113] (webpack)/~/react-dom/lib/FallbackCompositionState.js 2.43 kB {5} [built]
+  [114] (webpack)/~/react-dom/lib/HTMLDOMPropertyConfig.js 6.57 kB {5} [built]
+  [116] (webpack)/~/react-dom/lib/ReactComponentBrowserEnvironment.js 906 bytes {5} [built]
+  [144] (webpack)/~/react-dom/lib/ReactVersion.js 350 bytes {5} [built]
+chunk    {6} 79966dbf56b74a83076f.js 49.8 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [36] (webpack)/~/react-dom/lib/ReactUpdates.js 9.53 kB {6} [built]
+   [41] (webpack)/~/react-dom/lib/ReactReconciler.js 6.21 kB {6} [built]
+   [60] (webpack)/~/react-dom/lib/ReactUpdateQueue.js 9.36 kB {6} [built]
+   [83] (webpack)/~/react-dom/lib/ViewportMetrics.js 606 bytes {6} [built]
+  [143] (webpack)/~/react-dom/lib/ReactServerUpdateQueue.js 4.83 kB {6} [built]
+  [145] (webpack)/~/react-dom/lib/SVGDOMPropertyConfig.js 7.32 kB {6} [built]
+  [146] (webpack)/~/react-dom/lib/SelectEventPlugin.js 6.06 kB {6} [built]
+  [151] (webpack)/~/react-dom/lib/SyntheticDragEvent.js 1.07 kB {6} [built]
+  [152] (webpack)/~/react-dom/lib/SyntheticFocusEvent.js 1.07 kB {6} [built]
+  [153] (webpack)/~/react-dom/lib/SyntheticInputEvent.js 1.09 kB {6} [built]
+  [154] (webpack)/~/react-dom/lib/SyntheticKeyboardEvent.js 2.71 kB {6} [built]
+chunk    {7} 7aefde1bb1e079d42670.js 50 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [39] (webpack)/~/react-dom/lib/DOMLazyTree.js 3.71 kB {7} [built]
+   [40] (webpack)/~/react-dom/lib/DOMProperty.js 8.24 kB {7} [built]
+   [52] (webpack)/~/react-dom/lib/DOMChildrenOperations.js 7.67 kB {7} [built]
+   [53] (webpack)/~/react-dom/lib/DOMNamespaces.js 505 bytes {7} [built]
+   [73] (webpack)/~/react-dom/lib/CallbackQueue.js 3.16 kB {7} [built]
+   [74] (webpack)/~/react-dom/lib/DOMPropertyOperations.js 7.61 kB {7} [built]
+  [108] (webpack)/~/react-dom/lib/CSSPropertyOperations.js 6.87 kB {7} [built]
+  [109] (webpack)/~/react-dom/lib/ChangeEventPlugin.js 11.8 kB {7} [built]
+  [122] (webpack)/~/react-dom/lib/ReactDOMFeatureFlags.js 439 bytes {7} [built]
+chunk    {8} 508c3a18fbaff81d37fc.js 49.9 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [81] (webpack)/~/react-dom/lib/ReactMount.js 25.5 kB {8} [built]
+  [137] (webpack)/~/react-dom/lib/ReactMultiChild.js 14.6 kB {8} [built]
+  [140] (webpack)/~/react-dom/lib/ReactReconcileTransaction.js 5.26 kB {8} [built]
+  [142] (webpack)/~/react-dom/lib/ReactServerRenderingTransaction.js 2.29 kB {8} [built]
+  [149] (webpack)/~/react-dom/lib/SyntheticClipboardEvent.js 1.17 kB {8} [built]
+  [150] (webpack)/~/react-dom/lib/SyntheticCompositionEvent.js 1.1 kB {8} [built]
+chunk    {9} 766d1060910b08c5b00b.js 32.9 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [66] (webpack)/~/react-dom/lib/shouldUpdateReactComponent.js 1.4 kB {9} [built]
+   [67] (webpack)/~/react-dom/lib/validateDOMNesting.js 13.7 kB {9} [built]
+   [91] (webpack)/~/react-dom/lib/traverseAllChildren.js 7.04 kB {9} [built]
+   [92] (webpack)/~/react/lib/ReactComponentTreeHook.js 10.4 kB {9} [built]
+  [168] (webpack)/~/react/lib/getNextDebugID.js 437 bytes {9} [built]
+chunk   {10} 7731c65a1a824990e2dd.js 50 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [77] (webpack)/~/react-dom/lib/ReactEmptyComponent.js 704 bytes {10} [built]
+  [117] (webpack)/~/react-dom/lib/ReactCompositeComponent.js 35.2 kB {10} [built]
+  [124] (webpack)/~/react-dom/lib/ReactDOMInput.js 13 kB {10} [built]
+  [132] (webpack)/~/react-dom/lib/ReactElementSymbol.js 622 bytes {10} [built]
+  [139] (webpack)/~/react-dom/lib/ReactPropTypesSecret.js 442 bytes {10} [built]
+chunk   {11} 32f25aae39ba65782773.js 49.7 kB {12} {13} {14} [rendered] [recorded]
+    > aggressive-splitted [15] ./example.js 2:0-22
+   [76] (webpack)/~/react-dom/lib/ReactDOMSelect.js 6.81 kB {11} [built]
+   [78] (webpack)/~/react-dom/lib/ReactFeatureFlags.js 628 bytes {11} [built]
+  [119] (webpack)/~/react-dom/lib/ReactDOMComponent.js 38.5 kB {11} [built]
+  [129] (webpack)/~/react-dom/lib/ReactDOMTreeTraversal.js 3.72 kB {11} [built]
+chunk   {12} b546aa95198a765fcdbc.js 49.9 kB [entry] [rendered] [recorded]
+    > aggressive-splitted main [15] ./example.js 
     [0] (webpack)/~/fbjs/lib/warning.js 2.1 kB {12} [built]
-    [2] (webpack)/~/fbjs/lib/invariant.js 1.63 kB {12} [built]
+    [1] (webpack)/~/fbjs/lib/invariant.js 1.63 kB {12} [built]
     [4] (webpack)/~/object-assign/index.js 2.11 kB {12} [built]
     [5] (webpack)/~/fbjs/lib/emptyFunction.js 1.08 kB {12} [built]
     [6] (webpack)/~/fbjs/lib/emptyObject.js 458 bytes {12} [built]
+    [7] (webpack)/~/react/lib/ReactComponent.js 4.61 kB {12} [built]
     [9] (webpack)/~/react/lib/ReactCurrentOwner.js 623 bytes {12} [built]
    [10] (webpack)/~/react/lib/ReactElementSymbol.js 622 bytes {12} [built]
-   [11] (webpack)/~/react/lib/ReactPropTypeLocationNames.js 572 bytes {12} [built]
-   [15] (webpack)/~/react/lib/React.js 2.69 kB {12} [built]
-   [18] (webpack)/~/react/lib/KeyEscapeUtils.js 1.29 kB {12} [built]
-   [19] (webpack)/~/react/lib/PooledClass.js 3.36 kB {12} [built]
-   [20] (webpack)/~/react/lib/ReactChildren.js 6.19 kB {12} [built]
-   [21] (webpack)/~/react/lib/ReactClass.js 26.5 kB {12} [built]
-   [24] (webpack)/~/react/lib/ReactPropTypesSecret.js 442 bytes {12} [built]
-   [26] (webpack)/~/react/lib/ReactVersion.js 350 bytes {12} [built]
-chunk   {13} bea9c6f9afcb80f33121.js 30.6 kB [initial] [rendered]
-    > aggressive-splitted main [16] ./example.js 
+   [12] (webpack)/~/react/react.js 56 bytes {12} [built]
+   [13] (webpack)/~/react/lib/React.js 3.32 kB {12} [built]
+   [14] (webpack)/~/prop-types/factory.js 890 bytes {12} [built]
+   [16] (webpack)/~/prop-types/checkPropTypes.js 2.94 kB {12} [built]
+   [17] (webpack)/~/prop-types/factoryWithTypeCheckers.js 17.6 kB {12} [built]
+   [18] (webpack)/~/prop-types/lib/ReactPropTypesSecret.js 436 bytes {12} [built]
+   [20] (webpack)/~/react/lib/KeyEscapeUtils.js 1.29 kB {12} [built]
+   [21] (webpack)/~/react/lib/PooledClass.js 3.36 kB {12} [built]
+   [22] (webpack)/~/react/lib/ReactChildren.js 6.19 kB {12} [built]
+   [25] (webpack)/~/react/lib/ReactPropTypeLocationNames.js 572 bytes {12} [built]
+chunk   {13} bc7a8b74aab9bfc3ac10.js 30.4 kB [initial] [rendered]
+    > aggressive-splitted main [15] ./example.js 
+    [2] (webpack)/~/react/lib/ReactElement.js 11.2 kB {13} [built]
     [3] (webpack)/~/react/lib/reactProdInvariant.js 1.24 kB {13} [built]
-    [8] (webpack)/~/react/lib/ReactNoopUpdateQueue.js 3.36 kB {13} [built]
-   [12] (webpack)/~/react/lib/canDefineProperty.js 661 bytes {13} [built]
-   [13] (webpack)/~/react/lib/getIteratorFn.js 1.12 kB {13} [built]
-   [16] ./example.js 44 bytes {13} [built]
-   [23] (webpack)/~/react/lib/ReactPropTypes.js 15.8 kB {13} [built]
-   [27] (webpack)/~/react/lib/onlyChild.js 1.34 kB {13} [built]
-   [28] (webpack)/~/react/lib/traverseAllChildren.js 7.03 kB {13} [built]
-chunk   {14} 85fc6439c97999cbcda0.js 22.7 kB [initial] [rendered]
-    > aggressive-splitted main [16] ./example.js 
-    [1] (webpack)/~/react/lib/ReactElement.js 11.2 kB {14} [built]
-    [7] (webpack)/~/react/lib/ReactComponent.js 4.61 kB {14} [built]
-   [14] (webpack)/~/react/react.js 56 bytes {14} [built]
-   [22] (webpack)/~/react/lib/ReactDOMFactories.js 5.53 kB {14} [built]
-   [25] (webpack)/~/react/lib/ReactPureComponent.js 1.32 kB {14} [built]
+   [11] (webpack)/~/react/lib/canDefineProperty.js 661 bytes {13} [built]
+   [15] ./example.js 42 bytes {13} [built]
+   [24] (webpack)/~/react/lib/ReactDOMFactories.js 5.53 kB {13} [built]
+   [26] (webpack)/~/react/lib/ReactPropTypes.js 500 bytes {13} [built]
+   [27] (webpack)/~/react/lib/ReactPureComponent.js 1.32 kB {13} [built]
+   [28] (webpack)/~/react/lib/ReactVersion.js 350 bytes {13} [built]
+   [29] (webpack)/~/react/lib/getIteratorFn.js 1.12 kB {13} [built]
+   [30] (webpack)/~/react/lib/onlyChild.js 1.34 kB {13} [built]
+   [31] (webpack)/~/react/lib/traverseAllChildren.js 7.03 kB {13} [built]
+chunk   {14} fe98766d3891955772be.js 30.3 kB [initial] [rendered] [recorded]
+    > aggressive-splitted main [15] ./example.js 
+    [8] (webpack)/~/react/lib/ReactNoopUpdateQueue.js 3.36 kB {14} [built]
+   [23] (webpack)/~/react/lib/ReactClass.js 26.9 kB {14} [built]
 ```
 
 ## Records
@@ -487,172 +493,175 @@ chunk   {14} 85fc6439c97999cbcda0.js 22.7 kB [initial] [rendered]
 {
   "modules": {
     "byIdentifier": {
-      "..\\..\\node_modules\\fbjs\\lib\\warning.js": 0,
-      "..\\..\\node_modules\\react\\lib\\ReactElement.js": 1,
-      "..\\..\\node_modules\\fbjs\\lib\\invariant.js": 2,
-      "..\\..\\node_modules\\react\\lib\\reactProdInvariant.js": 3,
-      "..\\..\\node_modules\\object-assign\\index.js": 4,
-      "..\\..\\node_modules\\fbjs\\lib\\emptyFunction.js": 5,
-      "..\\..\\node_modules\\fbjs\\lib\\emptyObject.js": 6,
-      "..\\..\\node_modules\\react\\lib\\ReactComponent.js": 7,
-      "..\\..\\node_modules\\react\\lib\\ReactNoopUpdateQueue.js": 8,
-      "..\\..\\node_modules\\react\\lib\\ReactCurrentOwner.js": 9,
-      "..\\..\\node_modules\\react\\lib\\ReactElementSymbol.js": 10,
-      "..\\..\\node_modules\\react\\lib\\ReactPropTypeLocationNames.js": 11,
-      "..\\..\\node_modules\\react\\lib\\canDefineProperty.js": 12,
-      "..\\..\\node_modules\\react\\lib\\getIteratorFn.js": 13,
-      "..\\..\\node_modules\\react\\react.js": 14,
-      "..\\..\\node_modules\\react\\lib\\React.js": 15,
-      "example.js": 16,
-      "..\\..\\node_modules\\react-dom\\index.js": 17,
-      "..\\..\\node_modules\\react\\lib\\KeyEscapeUtils.js": 18,
-      "..\\..\\node_modules\\react\\lib\\PooledClass.js": 19,
-      "..\\..\\node_modules\\react\\lib\\ReactChildren.js": 20,
-      "..\\..\\node_modules\\react\\lib\\ReactClass.js": 21,
-      "..\\..\\node_modules\\react\\lib\\ReactDOMFactories.js": 22,
-      "..\\..\\node_modules\\react\\lib\\ReactPropTypes.js": 23,
-      "..\\..\\node_modules\\react\\lib\\ReactPropTypesSecret.js": 24,
-      "..\\..\\node_modules\\react\\lib\\ReactPureComponent.js": 25,
-      "..\\..\\node_modules\\react\\lib\\ReactVersion.js": 26,
-      "..\\..\\node_modules\\react\\lib\\onlyChild.js": 27,
-      "..\\..\\node_modules\\react\\lib\\traverseAllChildren.js": 28,
-      "..\\..\\node_modules\\react-dom\\lib\\reactProdInvariant.js": 29,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDOMComponentTree.js": 30,
-      "..\\..\\node_modules\\fbjs\\lib\\ExecutionEnvironment.js": 31,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactInstrumentation.js": 32,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactUpdates.js": 33,
-      "..\\..\\node_modules\\react-dom\\lib\\SyntheticEvent.js": 34,
-      "..\\..\\node_modules\\react-dom\\lib\\PooledClass.js": 35,
-      "..\\..\\node_modules\\react-dom\\lib\\DOMLazyTree.js": 36,
-      "..\\..\\node_modules\\react-dom\\lib\\DOMProperty.js": 37,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactReconciler.js": 38,
-      "..\\..\\node_modules\\react-dom\\lib\\EventPluginHub.js": 39,
-      "..\\..\\node_modules\\react-dom\\lib\\EventPropagators.js": 40,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactInstanceMap.js": 41,
-      "..\\..\\node_modules\\react-dom\\lib\\SyntheticUIEvent.js": 42,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactBrowserEventEmitter.js": 43,
-      "..\\..\\node_modules\\react-dom\\lib\\SyntheticMouseEvent.js": 44,
-      "..\\..\\node_modules\\react-dom\\lib\\Transaction.js": 45,
-      "..\\..\\node_modules\\react-dom\\lib\\escapeTextContentForBrowser.js": 46,
-      "..\\..\\node_modules\\react-dom\\lib\\setInnerHTML.js": 47,
-      "..\\..\\node_modules\\fbjs\\lib\\shallowEqual.js": 48,
-      "..\\..\\node_modules\\react-dom\\lib\\DOMChildrenOperations.js": 49,
-      "..\\..\\node_modules\\react-dom\\lib\\DOMNamespaces.js": 50,
-      "..\\..\\node_modules\\react-dom\\lib\\EventPluginRegistry.js": 51,
-      "..\\..\\node_modules\\react-dom\\lib\\EventPluginUtils.js": 52,
-      "..\\..\\node_modules\\react-dom\\lib\\KeyEscapeUtils.js": 53,
-      "..\\..\\node_modules\\react-dom\\lib\\LinkedValueUtils.js": 54,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactComponentEnvironment.js": 55,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactErrorUtils.js": 56,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactUpdateQueue.js": 57,
-      "..\\..\\node_modules\\react-dom\\lib\\createMicrosoftUnsafeLocalFunction.js": 58,
-      "..\\..\\node_modules\\react-dom\\lib\\getEventCharCode.js": 59,
-      "..\\..\\node_modules\\react-dom\\lib\\getEventModifierState.js": 60,
-      "..\\..\\node_modules\\react-dom\\lib\\getEventTarget.js": 61,
-      "..\\..\\node_modules\\react-dom\\lib\\isEventSupported.js": 62,
-      "..\\..\\node_modules\\react-dom\\lib\\shouldUpdateReactComponent.js": 63,
-      "..\\..\\node_modules\\react-dom\\lib\\validateDOMNesting.js": 64,
-      "..\\..\\node_modules\\fbjs\\lib\\EventListener.js": 65,
-      "..\\..\\node_modules\\fbjs\\lib\\focusNode.js": 66,
-      "..\\..\\node_modules\\fbjs\\lib\\getActiveElement.js": 67,
-      "..\\..\\node_modules\\process\\browser.js": 68,
-      "..\\..\\node_modules\\react-dom\\lib\\CSSProperty.js": 69,
-      "..\\..\\node_modules\\react-dom\\lib\\CallbackQueue.js": 70,
-      "..\\..\\node_modules\\react-dom\\lib\\DOMPropertyOperations.js": 71,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDOMComponentFlags.js": 72,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDOMSelect.js": 73,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactEmptyComponent.js": 74,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactFeatureFlags.js": 75,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactHostComponent.js": 76,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactInputSelection.js": 77,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactMount.js": 78,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactNodeTypes.js": 79,
-      "..\\..\\node_modules\\react-dom\\lib\\ViewportMetrics.js": 80,
-      "..\\..\\node_modules\\react-dom\\lib\\accumulateInto.js": 81,
-      "..\\..\\node_modules\\react-dom\\lib\\forEachAccumulated.js": 82,
-      "..\\..\\node_modules\\react-dom\\lib\\getHostComponentFromComposite.js": 83,
-      "..\\..\\node_modules\\react-dom\\lib\\getTextContentAccessor.js": 84,
-      "..\\..\\node_modules\\react-dom\\lib\\instantiateReactComponent.js": 85,
-      "..\\..\\node_modules\\react-dom\\lib\\isTextInputElement.js": 86,
-      "..\\..\\node_modules\\react-dom\\lib\\setTextContent.js": 87,
-      "..\\..\\node_modules\\react-dom\\lib\\traverseAllChildren.js": 88,
-      "..\\..\\node_modules\\react\\lib\\ReactComponentTreeHook.js": 89,
-      "..\\..\\node_modules\\fbjs\\lib\\camelize.js": 90,
-      "..\\..\\node_modules\\fbjs\\lib\\camelizeStyleName.js": 91,
-      "..\\..\\node_modules\\fbjs\\lib\\containsNode.js": 92,
-      "..\\..\\node_modules\\fbjs\\lib\\createArrayFromMixed.js": 93,
-      "..\\..\\node_modules\\fbjs\\lib\\createNodesFromMarkup.js": 94,
-      "..\\..\\node_modules\\fbjs\\lib\\getMarkupWrap.js": 95,
-      "..\\..\\node_modules\\fbjs\\lib\\getUnboundedScrollPosition.js": 96,
-      "..\\..\\node_modules\\fbjs\\lib\\hyphenate.js": 97,
-      "..\\..\\node_modules\\fbjs\\lib\\hyphenateStyleName.js": 98,
-      "..\\..\\node_modules\\fbjs\\lib\\isNode.js": 99,
-      "..\\..\\node_modules\\fbjs\\lib\\isTextNode.js": 100,
-      "..\\..\\node_modules\\fbjs\\lib\\memoizeStringOnly.js": 101,
-      "..\\..\\node_modules\\react-dom\\lib\\ARIADOMPropertyConfig.js": 102,
-      "..\\..\\node_modules\\react-dom\\lib\\AutoFocusUtils.js": 103,
-      "..\\..\\node_modules\\react-dom\\lib\\BeforeInputEventPlugin.js": 104,
-      "..\\..\\node_modules\\react-dom\\lib\\CSSPropertyOperations.js": 105,
-      "..\\..\\node_modules\\react-dom\\lib\\ChangeEventPlugin.js": 106,
-      "..\\..\\node_modules\\react-dom\\lib\\Danger.js": 107,
-      "..\\..\\node_modules\\react-dom\\lib\\DefaultEventPluginOrder.js": 108,
-      "..\\..\\node_modules\\react-dom\\lib\\EnterLeaveEventPlugin.js": 109,
-      "..\\..\\node_modules\\react-dom\\lib\\FallbackCompositionState.js": 110,
-      "..\\..\\node_modules\\react-dom\\lib\\HTMLDOMPropertyConfig.js": 111,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactChildReconciler.js": 112,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactComponentBrowserEnvironment.js": 113,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactCompositeComponent.js": 114,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDOM.js": 115,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDOMComponent.js": 116,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDOMContainerInfo.js": 117,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDOMEmptyComponent.js": 118,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDOMFeatureFlags.js": 119,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDOMIDOperations.js": 120,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDOMInput.js": 121,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDOMOption.js": 122,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDOMSelection.js": 123,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDOMTextComponent.js": 124,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDOMTextarea.js": 125,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDOMTreeTraversal.js": 126,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDefaultBatchingStrategy.js": 127,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactDefaultInjection.js": 128,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactElementSymbol.js": 129,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactEventEmitterMixin.js": 130,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactEventListener.js": 131,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactInjection.js": 132,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactMarkupChecksum.js": 133,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactMultiChild.js": 134,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactOwner.js": 135,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactPropTypesSecret.js": 136,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactReconcileTransaction.js": 137,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactRef.js": 138,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactServerRenderingTransaction.js": 139,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactServerUpdateQueue.js": 140,
-      "..\\..\\node_modules\\react-dom\\lib\\ReactVersion.js": 141,
-      "..\\..\\node_modules\\react-dom\\lib\\SVGDOMPropertyConfig.js": 142,
-      "..\\..\\node_modules\\react-dom\\lib\\SelectEventPlugin.js": 143,
-      "..\\..\\node_modules\\react-dom\\lib\\SimpleEventPlugin.js": 144,
-      "..\\..\\node_modules\\react-dom\\lib\\SyntheticAnimationEvent.js": 145,
-      "..\\..\\node_modules\\react-dom\\lib\\SyntheticClipboardEvent.js": 146,
-      "..\\..\\node_modules\\react-dom\\lib\\SyntheticCompositionEvent.js": 147,
-      "..\\..\\node_modules\\react-dom\\lib\\SyntheticDragEvent.js": 148,
-      "..\\..\\node_modules\\react-dom\\lib\\SyntheticFocusEvent.js": 149,
-      "..\\..\\node_modules\\react-dom\\lib\\SyntheticInputEvent.js": 150,
-      "..\\..\\node_modules\\react-dom\\lib\\SyntheticKeyboardEvent.js": 151,
-      "..\\..\\node_modules\\react-dom\\lib\\SyntheticTouchEvent.js": 152,
-      "..\\..\\node_modules\\react-dom\\lib\\SyntheticTransitionEvent.js": 153,
-      "..\\..\\node_modules\\react-dom\\lib\\SyntheticWheelEvent.js": 154,
-      "..\\..\\node_modules\\react-dom\\lib\\adler32.js": 155,
-      "..\\..\\node_modules\\react-dom\\lib\\dangerousStyleValue.js": 156,
-      "..\\..\\node_modules\\react-dom\\lib\\findDOMNode.js": 157,
-      "..\\..\\node_modules\\react-dom\\lib\\flattenChildren.js": 158,
-      "..\\..\\node_modules\\react-dom\\lib\\getEventKey.js": 159,
-      "..\\..\\node_modules\\react-dom\\lib\\getIteratorFn.js": 160,
-      "..\\..\\node_modules\\react-dom\\lib\\getNextDebugID.js": 161,
-      "..\\..\\node_modules\\react-dom\\lib\\getNodeForCharacterOffset.js": 162,
-      "..\\..\\node_modules\\react-dom\\lib\\getVendorPrefixedEventName.js": 163,
-      "..\\..\\node_modules\\react-dom\\lib\\quoteAttributeValueForBrowser.js": 164,
-      "..\\..\\node_modules\\react-dom\\lib\\renderSubtreeIntoContainer.js": 165
+      "../../node_modules/fbjs/lib/warning.js": 0,
+      "../../node_modules/fbjs/lib/invariant.js": 1,
+      "../../node_modules/react/lib/ReactElement.js": 2,
+      "../../node_modules/react/lib/reactProdInvariant.js": 3,
+      "../../node_modules/object-assign/index.js": 4,
+      "../../node_modules/fbjs/lib/emptyFunction.js": 5,
+      "../../node_modules/fbjs/lib/emptyObject.js": 6,
+      "../../node_modules/react/lib/ReactComponent.js": 7,
+      "../../node_modules/react/lib/ReactNoopUpdateQueue.js": 8,
+      "../../node_modules/react/lib/ReactCurrentOwner.js": 9,
+      "../../node_modules/react/lib/ReactElementSymbol.js": 10,
+      "../../node_modules/react/lib/canDefineProperty.js": 11,
+      "../../node_modules/react/react.js": 12,
+      "../../node_modules/react/lib/React.js": 13,
+      "../../node_modules/prop-types/factory.js": 14,
+      "example.js": 15,
+      "../../node_modules/prop-types/checkPropTypes.js": 16,
+      "../../node_modules/prop-types/factoryWithTypeCheckers.js": 17,
+      "../../node_modules/prop-types/lib/ReactPropTypesSecret.js": 18,
+      "../../node_modules/react-dom/index.js": 19,
+      "../../node_modules/react/lib/KeyEscapeUtils.js": 20,
+      "../../node_modules/react/lib/PooledClass.js": 21,
+      "../../node_modules/react/lib/ReactChildren.js": 22,
+      "../../node_modules/react/lib/ReactClass.js": 23,
+      "../../node_modules/react/lib/ReactDOMFactories.js": 24,
+      "../../node_modules/react/lib/ReactPropTypeLocationNames.js": 25,
+      "../../node_modules/react/lib/ReactPropTypes.js": 26,
+      "../../node_modules/react/lib/ReactPureComponent.js": 27,
+      "../../node_modules/react/lib/ReactVersion.js": 28,
+      "../../node_modules/react/lib/getIteratorFn.js": 29,
+      "../../node_modules/react/lib/onlyChild.js": 30,
+      "../../node_modules/react/lib/traverseAllChildren.js": 31,
+      "../../node_modules/react-dom/lib/reactProdInvariant.js": 32,
+      "../../node_modules/react-dom/lib/ReactDOMComponentTree.js": 33,
+      "../../node_modules/fbjs/lib/ExecutionEnvironment.js": 34,
+      "../../node_modules/react-dom/lib/ReactInstrumentation.js": 35,
+      "../../node_modules/react-dom/lib/ReactUpdates.js": 36,
+      "../../node_modules/react-dom/lib/SyntheticEvent.js": 37,
+      "../../node_modules/react-dom/lib/PooledClass.js": 38,
+      "../../node_modules/react-dom/lib/DOMLazyTree.js": 39,
+      "../../node_modules/react-dom/lib/DOMProperty.js": 40,
+      "../../node_modules/react-dom/lib/ReactReconciler.js": 41,
+      "../../node_modules/react-dom/lib/EventPluginHub.js": 42,
+      "../../node_modules/react-dom/lib/EventPropagators.js": 43,
+      "../../node_modules/react-dom/lib/ReactInstanceMap.js": 44,
+      "../../node_modules/react-dom/lib/SyntheticUIEvent.js": 45,
+      "../../node_modules/react-dom/lib/ReactBrowserEventEmitter.js": 46,
+      "../../node_modules/react-dom/lib/SyntheticMouseEvent.js": 47,
+      "../../node_modules/react-dom/lib/Transaction.js": 48,
+      "../../node_modules/react-dom/lib/escapeTextContentForBrowser.js": 49,
+      "../../node_modules/react-dom/lib/setInnerHTML.js": 50,
+      "../../node_modules/fbjs/lib/shallowEqual.js": 51,
+      "../../node_modules/react-dom/lib/DOMChildrenOperations.js": 52,
+      "../../node_modules/react-dom/lib/DOMNamespaces.js": 53,
+      "../../node_modules/react-dom/lib/EventPluginRegistry.js": 54,
+      "../../node_modules/react-dom/lib/EventPluginUtils.js": 55,
+      "../../node_modules/react-dom/lib/KeyEscapeUtils.js": 56,
+      "../../node_modules/react-dom/lib/LinkedValueUtils.js": 57,
+      "../../node_modules/react-dom/lib/ReactComponentEnvironment.js": 58,
+      "../../node_modules/react-dom/lib/ReactErrorUtils.js": 59,
+      "../../node_modules/react-dom/lib/ReactUpdateQueue.js": 60,
+      "../../node_modules/react-dom/lib/createMicrosoftUnsafeLocalFunction.js": 61,
+      "../../node_modules/react-dom/lib/getEventCharCode.js": 62,
+      "../../node_modules/react-dom/lib/getEventModifierState.js": 63,
+      "../../node_modules/react-dom/lib/getEventTarget.js": 64,
+      "../../node_modules/react-dom/lib/isEventSupported.js": 65,
+      "../../node_modules/react-dom/lib/shouldUpdateReactComponent.js": 66,
+      "../../node_modules/react-dom/lib/validateDOMNesting.js": 67,
+      "../../node_modules/fbjs/lib/EventListener.js": 68,
+      "../../node_modules/fbjs/lib/focusNode.js": 69,
+      "../../node_modules/fbjs/lib/getActiveElement.js": 70,
+      "../../node_modules/process/browser.js": 71,
+      "../../node_modules/react-dom/lib/CSSProperty.js": 72,
+      "../../node_modules/react-dom/lib/CallbackQueue.js": 73,
+      "../../node_modules/react-dom/lib/DOMPropertyOperations.js": 74,
+      "../../node_modules/react-dom/lib/ReactDOMComponentFlags.js": 75,
+      "../../node_modules/react-dom/lib/ReactDOMSelect.js": 76,
+      "../../node_modules/react-dom/lib/ReactEmptyComponent.js": 77,
+      "../../node_modules/react-dom/lib/ReactFeatureFlags.js": 78,
+      "../../node_modules/react-dom/lib/ReactHostComponent.js": 79,
+      "../../node_modules/react-dom/lib/ReactInputSelection.js": 80,
+      "../../node_modules/react-dom/lib/ReactMount.js": 81,
+      "../../node_modules/react-dom/lib/ReactNodeTypes.js": 82,
+      "../../node_modules/react-dom/lib/ViewportMetrics.js": 83,
+      "../../node_modules/react-dom/lib/accumulateInto.js": 84,
+      "../../node_modules/react-dom/lib/forEachAccumulated.js": 85,
+      "../../node_modules/react-dom/lib/getHostComponentFromComposite.js": 86,
+      "../../node_modules/react-dom/lib/getTextContentAccessor.js": 87,
+      "../../node_modules/react-dom/lib/instantiateReactComponent.js": 88,
+      "../../node_modules/react-dom/lib/isTextInputElement.js": 89,
+      "../../node_modules/react-dom/lib/setTextContent.js": 90,
+      "../../node_modules/react-dom/lib/traverseAllChildren.js": 91,
+      "../../node_modules/react/lib/ReactComponentTreeHook.js": 92,
+      "../../node_modules/fbjs/lib/camelize.js": 93,
+      "../../node_modules/fbjs/lib/camelizeStyleName.js": 94,
+      "../../node_modules/fbjs/lib/containsNode.js": 95,
+      "../../node_modules/fbjs/lib/createArrayFromMixed.js": 96,
+      "../../node_modules/fbjs/lib/createNodesFromMarkup.js": 97,
+      "../../node_modules/fbjs/lib/getMarkupWrap.js": 98,
+      "../../node_modules/fbjs/lib/getUnboundedScrollPosition.js": 99,
+      "../../node_modules/fbjs/lib/hyphenate.js": 100,
+      "../../node_modules/fbjs/lib/hyphenateStyleName.js": 101,
+      "../../node_modules/fbjs/lib/isNode.js": 102,
+      "../../node_modules/fbjs/lib/isTextNode.js": 103,
+      "../../node_modules/fbjs/lib/memoizeStringOnly.js": 104,
+      "../../node_modules/react-dom/lib/ARIADOMPropertyConfig.js": 105,
+      "../../node_modules/react-dom/lib/AutoFocusUtils.js": 106,
+      "../../node_modules/react-dom/lib/BeforeInputEventPlugin.js": 107,
+      "../../node_modules/react-dom/lib/CSSPropertyOperations.js": 108,
+      "../../node_modules/react-dom/lib/ChangeEventPlugin.js": 109,
+      "../../node_modules/react-dom/lib/Danger.js": 110,
+      "../../node_modules/react-dom/lib/DefaultEventPluginOrder.js": 111,
+      "../../node_modules/react-dom/lib/EnterLeaveEventPlugin.js": 112,
+      "../../node_modules/react-dom/lib/FallbackCompositionState.js": 113,
+      "../../node_modules/react-dom/lib/HTMLDOMPropertyConfig.js": 114,
+      "../../node_modules/react-dom/lib/ReactChildReconciler.js": 115,
+      "../../node_modules/react-dom/lib/ReactComponentBrowserEnvironment.js": 116,
+      "../../node_modules/react-dom/lib/ReactCompositeComponent.js": 117,
+      "../../node_modules/react-dom/lib/ReactDOM.js": 118,
+      "../../node_modules/react-dom/lib/ReactDOMComponent.js": 119,
+      "../../node_modules/react-dom/lib/ReactDOMContainerInfo.js": 120,
+      "../../node_modules/react-dom/lib/ReactDOMEmptyComponent.js": 121,
+      "../../node_modules/react-dom/lib/ReactDOMFeatureFlags.js": 122,
+      "../../node_modules/react-dom/lib/ReactDOMIDOperations.js": 123,
+      "../../node_modules/react-dom/lib/ReactDOMInput.js": 124,
+      "../../node_modules/react-dom/lib/ReactDOMOption.js": 125,
+      "../../node_modules/react-dom/lib/ReactDOMSelection.js": 126,
+      "../../node_modules/react-dom/lib/ReactDOMTextComponent.js": 127,
+      "../../node_modules/react-dom/lib/ReactDOMTextarea.js": 128,
+      "../../node_modules/react-dom/lib/ReactDOMTreeTraversal.js": 129,
+      "../../node_modules/react-dom/lib/ReactDefaultBatchingStrategy.js": 130,
+      "../../node_modules/react-dom/lib/ReactDefaultInjection.js": 131,
+      "../../node_modules/react-dom/lib/ReactElementSymbol.js": 132,
+      "../../node_modules/react-dom/lib/ReactEventEmitterMixin.js": 133,
+      "../../node_modules/react-dom/lib/ReactEventListener.js": 134,
+      "../../node_modules/react-dom/lib/ReactInjection.js": 135,
+      "../../node_modules/react-dom/lib/ReactMarkupChecksum.js": 136,
+      "../../node_modules/react-dom/lib/ReactMultiChild.js": 137,
+      "../../node_modules/react-dom/lib/ReactOwner.js": 138,
+      "../../node_modules/react-dom/lib/ReactPropTypesSecret.js": 139,
+      "../../node_modules/react-dom/lib/ReactReconcileTransaction.js": 140,
+      "../../node_modules/react-dom/lib/ReactRef.js": 141,
+      "../../node_modules/react-dom/lib/ReactServerRenderingTransaction.js": 142,
+      "../../node_modules/react-dom/lib/ReactServerUpdateQueue.js": 143,
+      "../../node_modules/react-dom/lib/ReactVersion.js": 144,
+      "../../node_modules/react-dom/lib/SVGDOMPropertyConfig.js": 145,
+      "../../node_modules/react-dom/lib/SelectEventPlugin.js": 146,
+      "../../node_modules/react-dom/lib/SimpleEventPlugin.js": 147,
+      "../../node_modules/react-dom/lib/SyntheticAnimationEvent.js": 148,
+      "../../node_modules/react-dom/lib/SyntheticClipboardEvent.js": 149,
+      "../../node_modules/react-dom/lib/SyntheticCompositionEvent.js": 150,
+      "../../node_modules/react-dom/lib/SyntheticDragEvent.js": 151,
+      "../../node_modules/react-dom/lib/SyntheticFocusEvent.js": 152,
+      "../../node_modules/react-dom/lib/SyntheticInputEvent.js": 153,
+      "../../node_modules/react-dom/lib/SyntheticKeyboardEvent.js": 154,
+      "../../node_modules/react-dom/lib/SyntheticTouchEvent.js": 155,
+      "../../node_modules/react-dom/lib/SyntheticTransitionEvent.js": 156,
+      "../../node_modules/react-dom/lib/SyntheticWheelEvent.js": 157,
+      "../../node_modules/react-dom/lib/adler32.js": 158,
+      "../../node_modules/react-dom/lib/dangerousStyleValue.js": 159,
+      "../../node_modules/react-dom/lib/findDOMNode.js": 160,
+      "../../node_modules/react-dom/lib/flattenChildren.js": 161,
+      "../../node_modules/react-dom/lib/getEventKey.js": 162,
+      "../../node_modules/react-dom/lib/getIteratorFn.js": 163,
+      "../../node_modules/react-dom/lib/getNodeForCharacterOffset.js": 164,
+      "../../node_modules/react-dom/lib/getVendorPrefixedEventName.js": 165,
+      "../../node_modules/react-dom/lib/quoteAttributeValueForBrowser.js": 166,
+      "../../node_modules/react-dom/lib/renderSubtreeIntoContainer.js": 167,
+      "../../node_modules/react/lib/getNextDebugID.js": 168
     },
     "usedIds": {
       "0": 0,
@@ -820,24 +829,27 @@ chunk   {14} 85fc6439c97999cbcda0.js 22.7 kB [initial] [rendered]
       "162": 162,
       "163": 163,
       "164": 164,
-      "165": 165
+      "165": 165,
+      "166": 166,
+      "167": 167,
+      "168": 168
     }
   },
   "chunks": {
     "byName": {},
     "byBlocks": {
-      "example.js:0/0:2": 0,
-      "example.js:0/0:0": 1,
+      "example.js:0/0:3": 0,
+      "example.js:0/0:9": 1,
       "example.js:0/0:11": 2,
-      "example.js:0/0:9": 3,
+      "example.js:0/0:10": 3,
       "example.js:0/0:1": 4,
-      "example.js:0/0:10": 5,
-      "example.js:0/0:6": 6,
+      "example.js:0/0:6": 5,
+      "example.js:0/0:0": 6,
       "example.js:0/0:5": 7,
-      "example.js:0/0:3": 8,
-      "example.js:0/0:8": 9,
+      "example.js:0/0:4": 8,
+      "example.js:0/0:2": 9,
       "example.js:0/0:7": 10,
-      "example.js:0/0:4": 11
+      "example.js:0/0:8": 11
     },
     "usedIds": {
       "0": 0,
@@ -860,211 +872,245 @@ chunk   {14} 85fc6439c97999cbcda0.js 22.7 kB [initial] [rendered]
   "aggressiveSplits": [
     {
       "modules": [
-        "..\\..\\node_modules\\react-dom\\index.js",
-        "..\\..\\node_modules\\fbjs\\lib\\ExecutionEnvironment.js",
-        "..\\..\\node_modules\\fbjs\\lib\\shallowEqual.js",
-        "..\\..\\node_modules\\react-dom\\lib\\DOMNamespaces.js",
-        "..\\..\\node_modules\\fbjs\\lib\\EventListener.js",
-        "..\\..\\node_modules\\fbjs\\lib\\focusNode.js",
-        "..\\..\\node_modules\\fbjs\\lib\\getActiveElement.js",
-        "..\\..\\node_modules\\process\\browser.js",
-        "..\\..\\node_modules\\react-dom\\lib\\CSSProperty.js",
-        "..\\..\\node_modules\\fbjs\\lib\\camelize.js",
-        "..\\..\\node_modules\\fbjs\\lib\\camelizeStyleName.js",
-        "..\\..\\node_modules\\fbjs\\lib\\containsNode.js",
-        "..\\..\\node_modules\\fbjs\\lib\\createArrayFromMixed.js",
-        "..\\..\\node_modules\\fbjs\\lib\\createNodesFromMarkup.js",
-        "..\\..\\node_modules\\fbjs\\lib\\getMarkupWrap.js",
-        "..\\..\\node_modules\\fbjs\\lib\\getUnboundedScrollPosition.js",
-        "..\\..\\node_modules\\fbjs\\lib\\hyphenate.js",
-        "..\\..\\node_modules\\fbjs\\lib\\hyphenateStyleName.js",
-        "..\\..\\node_modules\\fbjs\\lib\\isNode.js",
-        "..\\..\\node_modules\\fbjs\\lib\\isTextNode.js",
-        "..\\..\\node_modules\\fbjs\\lib\\memoizeStringOnly.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ARIADOMPropertyConfig.js",
-        "..\\..\\node_modules\\react-dom\\lib\\AutoFocusUtils.js",
-        "..\\..\\node_modules\\react-dom\\lib\\BeforeInputEventPlugin.js"
+        "../../node_modules/react-dom/index.js",
+        "../../node_modules/fbjs/lib/ExecutionEnvironment.js",
+        "../../node_modules/fbjs/lib/shallowEqual.js",
+        "../../node_modules/fbjs/lib/EventListener.js",
+        "../../node_modules/fbjs/lib/focusNode.js",
+        "../../node_modules/fbjs/lib/getActiveElement.js",
+        "../../node_modules/process/browser.js",
+        "../../node_modules/react-dom/lib/CSSProperty.js",
+        "../../node_modules/react-dom/lib/ReactDOMComponentFlags.js",
+        "../../node_modules/fbjs/lib/camelize.js",
+        "../../node_modules/fbjs/lib/camelizeStyleName.js",
+        "../../node_modules/fbjs/lib/containsNode.js",
+        "../../node_modules/fbjs/lib/createArrayFromMixed.js",
+        "../../node_modules/fbjs/lib/createNodesFromMarkup.js",
+        "../../node_modules/fbjs/lib/getMarkupWrap.js",
+        "../../node_modules/fbjs/lib/getUnboundedScrollPosition.js",
+        "../../node_modules/fbjs/lib/hyphenate.js",
+        "../../node_modules/fbjs/lib/hyphenateStyleName.js",
+        "../../node_modules/fbjs/lib/isNode.js",
+        "../../node_modules/fbjs/lib/isTextNode.js",
+        "../../node_modules/fbjs/lib/memoizeStringOnly.js",
+        "../../node_modules/react-dom/lib/ARIADOMPropertyConfig.js",
+        "../../node_modules/react-dom/lib/AutoFocusUtils.js",
+        "../../node_modules/react-dom/lib/BeforeInputEventPlugin.js"
       ],
-      "hash": "7923f88ea316bb0caf20d0762dfcd0bb",
+      "hash": "c8ff6eb321ccd33524cad0a29682a86b",
       "id": 0
     },
     {
       "modules": [
-        "..\\..\\node_modules\\react-dom\\lib\\SyntheticEvent.js",
-        "..\\..\\node_modules\\react-dom\\lib\\SyntheticUIEvent.js",
-        "..\\..\\node_modules\\react-dom\\lib\\SyntheticMouseEvent.js",
-        "..\\..\\node_modules\\react-dom\\lib\\Transaction.js",
-        "..\\..\\node_modules\\react-dom\\lib\\escapeTextContentForBrowser.js",
-        "..\\..\\node_modules\\react-dom\\lib\\createMicrosoftUnsafeLocalFunction.js",
-        "..\\..\\node_modules\\react-dom\\lib\\getEventCharCode.js",
-        "..\\..\\node_modules\\react-dom\\lib\\accumulateInto.js",
-        "..\\..\\node_modules\\react-dom\\lib\\forEachAccumulated.js",
-        "..\\..\\node_modules\\react-dom\\lib\\SyntheticFocusEvent.js",
-        "..\\..\\node_modules\\react-dom\\lib\\SyntheticInputEvent.js",
-        "..\\..\\node_modules\\react-dom\\lib\\SyntheticKeyboardEvent.js",
-        "..\\..\\node_modules\\react-dom\\lib\\SyntheticTouchEvent.js",
-        "..\\..\\node_modules\\react-dom\\lib\\SyntheticTransitionEvent.js",
-        "..\\..\\node_modules\\react-dom\\lib\\SyntheticWheelEvent.js",
-        "..\\..\\node_modules\\react-dom\\lib\\adler32.js",
-        "..\\..\\node_modules\\react-dom\\lib\\dangerousStyleValue.js",
-        "..\\..\\node_modules\\react-dom\\lib\\findDOMNode.js",
-        "..\\..\\node_modules\\react-dom\\lib\\flattenChildren.js",
-        "..\\..\\node_modules\\react-dom\\lib\\getNextDebugID.js"
+        "../../node_modules/react-dom/lib/ReactInstanceMap.js",
+        "../../node_modules/react-dom/lib/ReactErrorUtils.js",
+        "../../node_modules/react-dom/lib/ReactHostComponent.js",
+        "../../node_modules/react-dom/lib/ReactInputSelection.js",
+        "../../node_modules/react-dom/lib/ReactNodeTypes.js",
+        "../../node_modules/react-dom/lib/ReactDOMSelection.js",
+        "../../node_modules/react-dom/lib/ReactDOMTextComponent.js",
+        "../../node_modules/react-dom/lib/ReactDOMTextarea.js",
+        "../../node_modules/react-dom/lib/ReactDefaultInjection.js",
+        "../../node_modules/react-dom/lib/ReactEventEmitterMixin.js",
+        "../../node_modules/react-dom/lib/ReactEventListener.js",
+        "../../node_modules/react-dom/lib/ReactInjection.js",
+        "../../node_modules/react-dom/lib/ReactMarkupChecksum.js",
+        "../../node_modules/react-dom/lib/ReactOwner.js",
+        "../../node_modules/react-dom/lib/ReactRef.js",
+        "../../node_modules/react-dom/lib/SyntheticAnimationEvent.js",
+        "../../node_modules/react-dom/lib/renderSubtreeIntoContainer.js"
       ],
-      "hash": "4b56298728377da64928376134ae6f85",
+      "hash": "ddebc123ba75b638ee6da7813d4204b8",
       "id": 1
     },
     {
       "modules": [
-        "..\\..\\node_modules\\react-dom\\lib\\ReactInstrumentation.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactInstanceMap.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactErrorUtils.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactFeatureFlags.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactHostComponent.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactInputSelection.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactNodeTypes.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDOMSelection.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDOMTextComponent.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDOMTextarea.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactEventEmitterMixin.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactEventListener.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactInjection.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactMarkupChecksum.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactOwner.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactReconcileTransaction.js",
-        "..\\..\\node_modules\\react-dom\\lib\\SyntheticAnimationEvent.js"
+        "../../node_modules/react-dom/lib/reactProdInvariant.js",
+        "../../node_modules/react-dom/lib/setInnerHTML.js",
+        "../../node_modules/react-dom/lib/getEventModifierState.js",
+        "../../node_modules/react-dom/lib/getEventTarget.js",
+        "../../node_modules/react-dom/lib/isEventSupported.js",
+        "../../node_modules/react-dom/lib/getHostComponentFromComposite.js",
+        "../../node_modules/react-dom/lib/getTextContentAccessor.js",
+        "../../node_modules/react-dom/lib/instantiateReactComponent.js",
+        "../../node_modules/react-dom/lib/isTextInputElement.js",
+        "../../node_modules/react-dom/lib/setTextContent.js",
+        "../../node_modules/react-dom/lib/flattenChildren.js",
+        "../../node_modules/react-dom/lib/getEventKey.js",
+        "../../node_modules/react-dom/lib/getIteratorFn.js",
+        "../../node_modules/react-dom/lib/getNodeForCharacterOffset.js",
+        "../../node_modules/react-dom/lib/getVendorPrefixedEventName.js",
+        "../../node_modules/react-dom/lib/quoteAttributeValueForBrowser.js"
       ],
-      "hash": "1aebcb77e36ad0ed5500e30100a262b2",
+      "hash": "4bb149689ae97f5d46e7b968ed2ba814",
+      "id": 2
+    },
+    {
+      "modules": [
+        "../../node_modules/react-dom/lib/SyntheticEvent.js",
+        "../../node_modules/react-dom/lib/SyntheticUIEvent.js",
+        "../../node_modules/react-dom/lib/SyntheticMouseEvent.js",
+        "../../node_modules/react-dom/lib/Transaction.js",
+        "../../node_modules/react-dom/lib/escapeTextContentForBrowser.js",
+        "../../node_modules/react-dom/lib/createMicrosoftUnsafeLocalFunction.js",
+        "../../node_modules/react-dom/lib/getEventCharCode.js",
+        "../../node_modules/react-dom/lib/accumulateInto.js",
+        "../../node_modules/react-dom/lib/forEachAccumulated.js",
+        "../../node_modules/react-dom/lib/SimpleEventPlugin.js",
+        "../../node_modules/react-dom/lib/SyntheticTouchEvent.js",
+        "../../node_modules/react-dom/lib/SyntheticTransitionEvent.js",
+        "../../node_modules/react-dom/lib/SyntheticWheelEvent.js",
+        "../../node_modules/react-dom/lib/adler32.js",
+        "../../node_modules/react-dom/lib/dangerousStyleValue.js",
+        "../../node_modules/react-dom/lib/findDOMNode.js"
+      ],
+      "hash": "8940e378350d3e1324c168d5b1a985e3",
       "id": 3
     },
     {
       "modules": [
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDOMComponentTree.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactBrowserEventEmitter.js",
-        "..\\..\\node_modules\\react-dom\\lib\\LinkedValueUtils.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactComponentEnvironment.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactChildReconciler.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactComponentBrowserEnvironment.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDOM.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDOMContainerInfo.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDOMEmptyComponent.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDOMFeatureFlags.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDOMIDOperations.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDOMOption.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDOMTreeTraversal.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactElementSymbol.js"
+        "../../node_modules/react-dom/lib/ReactDOMComponentTree.js",
+        "../../node_modules/react-dom/lib/ReactInstrumentation.js",
+        "../../node_modules/react-dom/lib/PooledClass.js",
+        "../../node_modules/react-dom/lib/ReactBrowserEventEmitter.js",
+        "../../node_modules/react-dom/lib/LinkedValueUtils.js",
+        "../../node_modules/react-dom/lib/ReactComponentEnvironment.js",
+        "../../node_modules/react-dom/lib/ReactChildReconciler.js",
+        "../../node_modules/react-dom/lib/ReactDOM.js",
+        "../../node_modules/react-dom/lib/ReactDOMContainerInfo.js",
+        "../../node_modules/react-dom/lib/ReactDOMEmptyComponent.js",
+        "../../node_modules/react-dom/lib/ReactDOMIDOperations.js",
+        "../../node_modules/react-dom/lib/ReactDOMOption.js",
+        "../../node_modules/react-dom/lib/ReactDefaultBatchingStrategy.js"
       ],
-      "hash": "e7e0f7bc43020d03cea98d16f6f5ae23",
+      "hash": "cf267a3acb7f49cc13810a8b47b37ebc",
       "id": 4
     },
     {
       "modules": [
-        "..\\..\\node_modules\\react-dom\\lib\\ReactUpdates.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactUpdateQueue.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ViewportMetrics.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactServerRenderingTransaction.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactServerUpdateQueue.js",
-        "..\\..\\node_modules\\react-dom\\lib\\SVGDOMPropertyConfig.js",
-        "..\\..\\node_modules\\react-dom\\lib\\SelectEventPlugin.js",
-        "..\\..\\node_modules\\react-dom\\lib\\SimpleEventPlugin.js",
-        "..\\..\\node_modules\\react-dom\\lib\\SyntheticClipboardEvent.js",
-        "..\\..\\node_modules\\react-dom\\lib\\SyntheticDragEvent.js"
+        "../../node_modules/react-dom/lib/EventPluginHub.js",
+        "../../node_modules/react-dom/lib/EventPropagators.js",
+        "../../node_modules/react-dom/lib/EventPluginRegistry.js",
+        "../../node_modules/react-dom/lib/EventPluginUtils.js",
+        "../../node_modules/react-dom/lib/KeyEscapeUtils.js",
+        "../../node_modules/react-dom/lib/Danger.js",
+        "../../node_modules/react-dom/lib/DefaultEventPluginOrder.js",
+        "../../node_modules/react-dom/lib/EnterLeaveEventPlugin.js",
+        "../../node_modules/react-dom/lib/FallbackCompositionState.js",
+        "../../node_modules/react-dom/lib/HTMLDOMPropertyConfig.js",
+        "../../node_modules/react-dom/lib/ReactComponentBrowserEnvironment.js",
+        "../../node_modules/react-dom/lib/ReactVersion.js"
       ],
-      "hash": "cd30a0e5b23181f08280ab3f19affcea",
+      "hash": "ab338b99ed796fde08b989edbaa7b3c7",
       "id": 5
     },
     {
       "modules": [
-        "..\\..\\node_modules\\react-dom\\lib\\PooledClass.js",
-        "..\\..\\node_modules\\react-dom\\lib\\EventPluginHub.js",
-        "..\\..\\node_modules\\react-dom\\lib\\EventPropagators.js",
-        "..\\..\\node_modules\\react-dom\\lib\\EventPluginRegistry.js",
-        "..\\..\\node_modules\\react-dom\\lib\\EventPluginUtils.js",
-        "..\\..\\node_modules\\react-dom\\lib\\KeyEscapeUtils.js",
-        "..\\..\\node_modules\\react-dom\\lib\\Danger.js",
-        "..\\..\\node_modules\\react-dom\\lib\\EnterLeaveEventPlugin.js",
-        "..\\..\\node_modules\\react-dom\\lib\\FallbackCompositionState.js",
-        "..\\..\\node_modules\\react-dom\\lib\\HTMLDOMPropertyConfig.js"
+        "../../node_modules/react-dom/lib/ReactUpdates.js",
+        "../../node_modules/react-dom/lib/ReactReconciler.js",
+        "../../node_modules/react-dom/lib/ReactUpdateQueue.js",
+        "../../node_modules/react-dom/lib/ViewportMetrics.js",
+        "../../node_modules/react-dom/lib/ReactServerUpdateQueue.js",
+        "../../node_modules/react-dom/lib/SVGDOMPropertyConfig.js",
+        "../../node_modules/react-dom/lib/SelectEventPlugin.js",
+        "../../node_modules/react-dom/lib/SyntheticDragEvent.js",
+        "../../node_modules/react-dom/lib/SyntheticFocusEvent.js",
+        "../../node_modules/react-dom/lib/SyntheticInputEvent.js",
+        "../../node_modules/react-dom/lib/SyntheticKeyboardEvent.js"
       ],
-      "hash": "1126d5a81e2264177124fd9fd67f21f8",
+      "hash": "79966dbf56b74a83076f5ba4ed889bfa",
       "id": 6
     },
     {
       "modules": [
-        "..\\..\\node_modules\\react-dom\\lib\\DOMLazyTree.js",
-        "..\\..\\node_modules\\react-dom\\lib\\DOMProperty.js",
-        "..\\..\\node_modules\\react-dom\\lib\\DOMChildrenOperations.js",
-        "..\\..\\node_modules\\react-dom\\lib\\CallbackQueue.js",
-        "..\\..\\node_modules\\react-dom\\lib\\DOMPropertyOperations.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDOMComponentFlags.js",
-        "..\\..\\node_modules\\react-dom\\lib\\CSSPropertyOperations.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ChangeEventPlugin.js",
-        "..\\..\\node_modules\\react-dom\\lib\\DefaultEventPluginOrder.js"
+        "../../node_modules/react-dom/lib/DOMLazyTree.js",
+        "../../node_modules/react-dom/lib/DOMProperty.js",
+        "../../node_modules/react-dom/lib/DOMChildrenOperations.js",
+        "../../node_modules/react-dom/lib/DOMNamespaces.js",
+        "../../node_modules/react-dom/lib/CallbackQueue.js",
+        "../../node_modules/react-dom/lib/DOMPropertyOperations.js",
+        "../../node_modules/react-dom/lib/CSSPropertyOperations.js",
+        "../../node_modules/react-dom/lib/ChangeEventPlugin.js",
+        "../../node_modules/react-dom/lib/ReactDOMFeatureFlags.js"
       ],
-      "hash": "0fc9e56af19a2e1125e351f6506ed162",
+      "hash": "7aefde1bb1e079d42670ca118b1554d6",
       "id": 7
     },
     {
       "modules": [
-        "..\\..\\node_modules\\react-dom\\lib\\ReactReconciler.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactMount.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactMultiChild.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactRef.js",
-        "..\\..\\node_modules\\react-dom\\lib\\SyntheticCompositionEvent.js"
+        "../../node_modules/react-dom/lib/ReactMount.js",
+        "../../node_modules/react-dom/lib/ReactMultiChild.js",
+        "../../node_modules/react-dom/lib/ReactReconcileTransaction.js",
+        "../../node_modules/react-dom/lib/ReactServerRenderingTransaction.js",
+        "../../node_modules/react-dom/lib/SyntheticClipboardEvent.js",
+        "../../node_modules/react-dom/lib/SyntheticCompositionEvent.js"
       ],
-      "hash": "6969094ac64482ef5415a16ccd2b5a43",
+      "hash": "508c3a18fbaff81d37fc8113a5d75bbf",
       "id": 8
     },
     {
       "modules": [
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDOMSelect.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactEmptyComponent.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDOMComponent.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDefaultInjection.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactPropTypesSecret.js"
+        "../../node_modules/react-dom/lib/shouldUpdateReactComponent.js",
+        "../../node_modules/react-dom/lib/validateDOMNesting.js",
+        "../../node_modules/react-dom/lib/traverseAllChildren.js",
+        "../../node_modules/react/lib/ReactComponentTreeHook.js",
+        "../../node_modules/react/lib/getNextDebugID.js"
       ],
-      "hash": "b98a4783892edb35b41b2e367c0acbad",
+      "hash": "766d1060910b08c5b00b13f7892a6776",
       "id": 9
     },
     {
       "modules": [
-        "..\\..\\node_modules\\react-dom\\lib\\ReactCompositeComponent.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDOMInput.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactDefaultBatchingStrategy.js",
-        "..\\..\\node_modules\\react-dom\\lib\\ReactVersion.js"
+        "../../node_modules/react-dom/lib/ReactEmptyComponent.js",
+        "../../node_modules/react-dom/lib/ReactCompositeComponent.js",
+        "../../node_modules/react-dom/lib/ReactDOMInput.js",
+        "../../node_modules/react-dom/lib/ReactElementSymbol.js",
+        "../../node_modules/react-dom/lib/ReactPropTypesSecret.js"
       ],
-      "hash": "97bba8f30c076dad74522fe4e914f4e2",
+      "hash": "7731c65a1a824990e2dd8cf0ba9d6ab6",
       "id": 10
     },
     {
       "modules": [
-        "..\\..\\node_modules\\react-dom\\lib\\validateDOMNesting.js",
-        "..\\..\\node_modules\\react-dom\\lib\\traverseAllChildren.js",
-        "..\\..\\node_modules\\react\\lib\\ReactComponentTreeHook.js"
+        "../../node_modules/react-dom/lib/ReactDOMSelect.js",
+        "../../node_modules/react-dom/lib/ReactFeatureFlags.js",
+        "../../node_modules/react-dom/lib/ReactDOMComponent.js",
+        "../../node_modules/react-dom/lib/ReactDOMTreeTraversal.js"
       ],
-      "hash": "7b9a99048247c52e6473e15c23d527b1",
+      "hash": "32f25aae39ba65782773d69b996549e8",
       "id": 11
     },
     {
       "modules": [
-        "..\\..\\node_modules\\fbjs\\lib\\warning.js",
-        "..\\..\\node_modules\\fbjs\\lib\\invariant.js",
-        "..\\..\\node_modules\\object-assign\\index.js",
-        "..\\..\\node_modules\\fbjs\\lib\\emptyFunction.js",
-        "..\\..\\node_modules\\fbjs\\lib\\emptyObject.js",
-        "..\\..\\node_modules\\react\\lib\\ReactCurrentOwner.js",
-        "..\\..\\node_modules\\react\\lib\\ReactElementSymbol.js",
-        "..\\..\\node_modules\\react\\lib\\ReactPropTypeLocationNames.js",
-        "..\\..\\node_modules\\react\\lib\\React.js",
-        "..\\..\\node_modules\\react\\lib\\KeyEscapeUtils.js",
-        "..\\..\\node_modules\\react\\lib\\PooledClass.js",
-        "..\\..\\node_modules\\react\\lib\\ReactChildren.js",
-        "..\\..\\node_modules\\react\\lib\\ReactClass.js",
-        "..\\..\\node_modules\\react\\lib\\ReactPropTypesSecret.js",
-        "..\\..\\node_modules\\react\\lib\\ReactVersion.js"
+        "../../node_modules/fbjs/lib/warning.js",
+        "../../node_modules/fbjs/lib/invariant.js",
+        "../../node_modules/object-assign/index.js",
+        "../../node_modules/fbjs/lib/emptyFunction.js",
+        "../../node_modules/fbjs/lib/emptyObject.js",
+        "../../node_modules/react/lib/ReactComponent.js",
+        "../../node_modules/react/lib/ReactCurrentOwner.js",
+        "../../node_modules/react/lib/ReactElementSymbol.js",
+        "../../node_modules/react/react.js",
+        "../../node_modules/react/lib/React.js",
+        "../../node_modules/prop-types/factory.js",
+        "../../node_modules/prop-types/checkPropTypes.js",
+        "../../node_modules/prop-types/factoryWithTypeCheckers.js",
+        "../../node_modules/prop-types/lib/ReactPropTypesSecret.js",
+        "../../node_modules/react/lib/KeyEscapeUtils.js",
+        "../../node_modules/react/lib/PooledClass.js",
+        "../../node_modules/react/lib/ReactChildren.js",
+        "../../node_modules/react/lib/ReactPropTypeLocationNames.js"
       ],
-      "hash": "3c590ca94c1cd4573c73c51c32492e00",
+      "hash": "b546aa95198a765fcdbc6d7d39dfda95",
       "id": 12
+    },
+    {
+      "modules": [
+        "../../node_modules/react/lib/ReactNoopUpdateQueue.js",
+        "../../node_modules/react/lib/ReactClass.js"
+      ],
+      "hash": "fe98766d3891955772be6d7f1522d28a",
+      "id": 14
     }
   ]
 }

--- a/examples/hybrid-routing/README.md
+++ b/examples/hybrid-routing/README.md
@@ -105,8 +105,9 @@ window.onLinkToPage = function onLinkToPage(name) { // name is "a" or "b"
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -115,8 +116,9 @@ window.onLinkToPage = function onLinkToPage(name) { // name is "a" or "b"
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/ 		if(executeModules) {
 /******/ 			for(i=0; i < executeModules.length; i++) {
 /******/ 				result = __webpack_require__(__webpack_require__.s = executeModules[i]);
@@ -137,9 +139,9 @@ window.onLinkToPage = function onLinkToPage(name) { // name is "a" or "b"
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -160,8 +162,9 @@ window.onLinkToPage = function onLinkToPage(name) { // name is "a" or "b"
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -194,7 +197,9 @@ window.onLinkToPage = function onLinkToPage(name) { // name is "a" or "b"
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -445,48 +450,48 @@ module.exports = function() {
 ## Uncompressed
 
 ```
-Hash: 4b84e80c971540cd022b
-Version: webpack 2.3.2
+Hash: 5edea6ee672ae8ead9ce
+Version: webpack 2.4.1
           Asset       Size  Chunks             Chunk Names
-     0.chunk.js  266 bytes       0  [emitted]  
-     1.chunk.js  272 bytes       1  [emitted]  
-pageB.bundle.js  606 bytes    2, 0  [emitted]  pageB
-pageA.bundle.js  628 bytes    3, 1  [emitted]  pageA
-     commons.js    9.48 kB       4  [emitted]  commons
+     0.chunk.js  264 bytes       0  [emitted]  
+     1.chunk.js  270 bytes       1  [emitted]  
+pageB.bundle.js  602 bytes    2, 0  [emitted]  pageB
+pageA.bundle.js  624 bytes    3, 1  [emitted]  pageA
+     commons.js    9.54 kB       4  [emitted]  commons
 Entrypoint pageA = commons.js pageA.bundle.js
 Entrypoint pageB = commons.js pageB.bundle.js
 Entrypoint commons = commons.js
-chunk    {0} 0.chunk.js 61 bytes {4} [rendered]
+chunk    {0} 0.chunk.js 59 bytes {4} [rendered]
     > [8] (webpack)/~/bundle-loader!./bPage.js 7:0-14:2
-    [2] ./bPage.js 61 bytes {0} {2} [built]
+    [2] ./bPage.js 59 bytes {0} {2} [built]
         cjs require ./bPage [5] ./bEntry.js 3:7-25
         cjs require !!./bPage.js [8] (webpack)/~/bundle-loader!./bPage.js 8:8-31
-chunk    {1} 1.chunk.js 61 bytes {4} [rendered]
+chunk    {1} 1.chunk.js 59 bytes {4} [rendered]
     > [7] (webpack)/~/bundle-loader!./aPage.js 7:0-14:2
-    [1] ./aPage.js 61 bytes {1} {3} [built]
+    [1] ./aPage.js 59 bytes {1} {3} [built]
         cjs require ./aPage [4] ./aEntry.js 3:7-25
         cjs require !!./aPage.js [7] (webpack)/~/bundle-loader!./aPage.js 8:8-31
-chunk    {2} pageB.bundle.js (pageB) 150 bytes {4} [initial] [rendered]
+chunk    {2} pageB.bundle.js (pageB) 146 bytes {4} [initial] [rendered]
     > pageB [5] ./bEntry.js 
-    [2] ./bPage.js 61 bytes {0} {2} [built]
+    [2] ./bPage.js 59 bytes {0} {2} [built]
         cjs require ./bPage [5] ./bEntry.js 3:7-25
         cjs require !!./bPage.js [8] (webpack)/~/bundle-loader!./bPage.js 8:8-31
-    [5] ./bEntry.js 89 bytes {2} [built]
-chunk    {3} pageA.bundle.js (pageA) 150 bytes {4} [initial] [rendered]
+    [5] ./bEntry.js 87 bytes {2} [built]
+chunk    {3} pageA.bundle.js (pageA) 146 bytes {4} [initial] [rendered]
     > pageA [4] ./aEntry.js 
-    [1] ./aPage.js 61 bytes {1} {3} [built]
+    [1] ./aPage.js 59 bytes {1} {3} [built]
         cjs require ./aPage [4] ./aEntry.js 3:7-25
         cjs require !!./aPage.js [7] (webpack)/~/bundle-loader!./aPage.js 8:8-31
-    [4] ./aEntry.js 89 bytes {3} [built]
-chunk    {4} commons.js (commons) 1.71 kB [entry] [rendered]
+    [4] ./aEntry.js 87 bytes {3} [built]
+chunk    {4} commons.js (commons) 1.69 kB [entry] [rendered]
     > commons [6] ./router.js 
-    [0] ./render.js 60 bytes {4} [built]
+    [0] ./render.js 58 bytes {4} [built]
         cjs require ./render [4] ./aEntry.js 2:13-32
         cjs require ./render [5] ./bEntry.js 2:13-32
         cjs require ./render [6] ./router.js 1:13-32
     [3] . (webpack)/~/bundle-loader! ^\.\/.*Page$ 184 bytes {4} [built]
         cjs require context bundle-loader!. [6] ./router.js 18:18-61
-    [6] ./router.js 903 bytes {4} [built]
+    [6] ./router.js 879 bytes {4} [built]
     [7] (webpack)/~/bundle-loader!./aPage.js 282 bytes {4} [optional] [built]
         context element ./aPage [3] . (webpack)/~/bundle-loader! ^\.\/.*Page$ ./aPage
     [8] (webpack)/~/bundle-loader!./bPage.js 282 bytes {4} [optional] [built]
@@ -496,8 +501,8 @@ chunk    {4} commons.js (commons) 1.71 kB [entry] [rendered]
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 4b84e80c971540cd022b
-Version: webpack 2.3.2
+Hash: 5edea6ee672ae8ead9ce
+Version: webpack 2.4.1
           Asset       Size  Chunks             Chunk Names
      0.chunk.js   83 bytes       0  [emitted]  
      1.chunk.js   82 bytes       1  [emitted]  
@@ -507,37 +512,37 @@ pageA.bundle.js  118 bytes    3, 1  [emitted]  pageA
 Entrypoint pageA = commons.js pageA.bundle.js
 Entrypoint pageB = commons.js pageB.bundle.js
 Entrypoint commons = commons.js
-chunk    {0} 0.chunk.js 61 bytes {4} [rendered]
+chunk    {0} 0.chunk.js 59 bytes {4} [rendered]
     > [8] (webpack)/~/bundle-loader!./bPage.js 7:0-14:2
-    [2] ./bPage.js 61 bytes {0} {2} [built]
+    [2] ./bPage.js 59 bytes {0} {2} [built]
         cjs require ./bPage [5] ./bEntry.js 3:7-25
         cjs require !!./bPage.js [8] (webpack)/~/bundle-loader!./bPage.js 8:8-31
-chunk    {1} 1.chunk.js 61 bytes {4} [rendered]
+chunk    {1} 1.chunk.js 59 bytes {4} [rendered]
     > [7] (webpack)/~/bundle-loader!./aPage.js 7:0-14:2
-    [1] ./aPage.js 61 bytes {1} {3} [built]
+    [1] ./aPage.js 59 bytes {1} {3} [built]
         cjs require ./aPage [4] ./aEntry.js 3:7-25
         cjs require !!./aPage.js [7] (webpack)/~/bundle-loader!./aPage.js 8:8-31
-chunk    {2} pageB.bundle.js (pageB) 150 bytes {4} [initial] [rendered]
+chunk    {2} pageB.bundle.js (pageB) 146 bytes {4} [initial] [rendered]
     > pageB [5] ./bEntry.js 
-    [2] ./bPage.js 61 bytes {0} {2} [built]
+    [2] ./bPage.js 59 bytes {0} {2} [built]
         cjs require ./bPage [5] ./bEntry.js 3:7-25
         cjs require !!./bPage.js [8] (webpack)/~/bundle-loader!./bPage.js 8:8-31
-    [5] ./bEntry.js 89 bytes {2} [built]
-chunk    {3} pageA.bundle.js (pageA) 150 bytes {4} [initial] [rendered]
+    [5] ./bEntry.js 87 bytes {2} [built]
+chunk    {3} pageA.bundle.js (pageA) 146 bytes {4} [initial] [rendered]
     > pageA [4] ./aEntry.js 
-    [1] ./aPage.js 61 bytes {1} {3} [built]
+    [1] ./aPage.js 59 bytes {1} {3} [built]
         cjs require ./aPage [4] ./aEntry.js 3:7-25
         cjs require !!./aPage.js [7] (webpack)/~/bundle-loader!./aPage.js 8:8-31
-    [4] ./aEntry.js 89 bytes {3} [built]
-chunk    {4} commons.js (commons) 1.71 kB [entry] [rendered]
+    [4] ./aEntry.js 87 bytes {3} [built]
+chunk    {4} commons.js (commons) 1.69 kB [entry] [rendered]
     > commons [6] ./router.js 
-    [0] ./render.js 60 bytes {4} [built]
+    [0] ./render.js 58 bytes {4} [built]
         cjs require ./render [4] ./aEntry.js 2:13-32
         cjs require ./render [5] ./bEntry.js 2:13-32
         cjs require ./render [6] ./router.js 1:13-32
     [3] . (webpack)/~/bundle-loader! ^\.\/.*Page$ 184 bytes {4} [built]
         cjs require context bundle-loader!. [6] ./router.js 18:18-61
-    [6] ./router.js 903 bytes {4} [built]
+    [6] ./router.js 879 bytes {4} [built]
     [7] (webpack)/~/bundle-loader!./aPage.js 282 bytes {4} [optional] [built]
         context element ./aPage [3] . (webpack)/~/bundle-loader! ^\.\/.*Page$ ./aPage
     [8] (webpack)/~/bundle-loader!./bPage.js 282 bytes {4} [optional] [built]

--- a/examples/i18n/README.md
+++ b/examples/i18n/README.md
@@ -59,9 +59,9 @@ module.exports = Object.keys(languages).map(function(language) {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -151,9 +151,9 @@ console.log("Missing Text");
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -232,24 +232,24 @@ console.log("Missing Text");
 ## Uncompressed
 
 ```
-Hash: b61d16621736c97f557e52b4d8e68140f1345ef8
-Version: webpack 2.3.2
+Hash: 4194dfc38a1d790c828d2b4d6ee6122bc1cc36c8
+Version: webpack 2.4.1
 Child en:
-    Hash: b61d16621736c97f557e
+    Hash: 4194dfc38a1d790c828d
            Asset     Size  Chunks             Chunk Names
-    en.output.js  2.84 kB       0  [emitted]  main
+    en.output.js  2.85 kB       0  [emitted]  main
     Entrypoint main = en.output.js
-    chunk    {0} en.output.js (main) 65 bytes [entry] [rendered]
+    chunk    {0} en.output.js (main) 64 bytes [entry] [rendered]
         > main [0] ./example.js 
-        [0] ./example.js 65 bytes {0} [built]
+        [0] ./example.js 64 bytes {0} [built]
 Child de:
-    Hash: 52b4d8e68140f1345ef8
+    Hash: 2b4d6ee6122bc1cc36c8
            Asset     Size  Chunks             Chunk Names
-    de.output.js  2.84 kB       0  [emitted]  main
+    de.output.js  2.85 kB       0  [emitted]  main
     Entrypoint main = de.output.js
-    chunk    {0} de.output.js (main) 65 bytes [entry] [rendered]
+    chunk    {0} de.output.js (main) 64 bytes [entry] [rendered]
         > main [0] ./example.js 
-        [0] ./example.js 65 bytes {0} [built] [1 warning]
+        [0] ./example.js 64 bytes {0} [built] [1 warning]
     
     WARNING in ./example.js
     Missing localization: Missing Text
@@ -258,24 +258,24 @@ Child de:
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: b61d16621736c97f557e52b4d8e68140f1345ef8
-Version: webpack 2.3.2
+Hash: 4194dfc38a1d790c828d2b4d6ee6122bc1cc36c8
+Version: webpack 2.4.1
 Child en:
-    Hash: b61d16621736c97f557e
+    Hash: 4194dfc38a1d790c828d
            Asset       Size  Chunks             Chunk Names
-    en.output.js  571 bytes       0  [emitted]  main
+    en.output.js  564 bytes       0  [emitted]  main
     Entrypoint main = en.output.js
-    chunk    {0} en.output.js (main) 65 bytes [entry] [rendered]
+    chunk    {0} en.output.js (main) 64 bytes [entry] [rendered]
         > main [0] ./example.js 
-        [0] ./example.js 65 bytes {0} [built]
+        [0] ./example.js 64 bytes {0} [built]
 Child de:
-    Hash: 52b4d8e68140f1345ef8
+    Hash: 2b4d6ee6122bc1cc36c8
            Asset       Size  Chunks             Chunk Names
-    de.output.js  570 bytes       0  [emitted]  main
+    de.output.js  563 bytes       0  [emitted]  main
     Entrypoint main = de.output.js
-    chunk    {0} de.output.js (main) 65 bytes [entry] [rendered]
+    chunk    {0} de.output.js (main) 64 bytes [entry] [rendered]
         > main [0] ./example.js 
-        [0] ./example.js 65 bytes {0} [built] [1 warning]
+        [0] ./example.js 64 bytes {0} [built] [1 warning]
     
     WARNING in ./example.js
     Missing localization: Missing Text

--- a/examples/loader/README.md
+++ b/examples/loader/README.md
@@ -44,9 +44,9 @@ module.exports = function(content) {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -123,7 +123,7 @@ exports = module.exports = __webpack_require__(/*! ../../~/css-loader/lib/css-ba
 
 
 // module
-exports.push([module.i, ".some-class {\r\n\tcolor: hotpink;\r\n}\r\n", ""]);
+exports.push([module.i, ".some-class {\n\tcolor: hotpink;\n}\n", ""]);
 
 // exports
 
@@ -237,19 +237,19 @@ Prints in node.js (`enhanced-require example.js`) and in browser:
 ## Uncompressed
 
 ```
-Hash: 122940bedb7c52974923
-Version: webpack 2.3.2
+Hash: 991d9d1ad579042df73a
+Version: webpack 2.4.1
     Asset     Size  Chunks             Chunk Names
 output.js  5.55 kB       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 1.96 kB [entry] [rendered]
+chunk    {0} output.js (main) 1.95 kB [entry] [rendered]
     > main [2] ./example.js 
-    [0] (webpack)/~/css-loader!./test.css 200 bytes {0} [built]
+    [0] (webpack)/~/css-loader!./test.css 194 bytes {0} [built]
         cjs require !css-loader!./test.css [2] ./example.js 6:12-45
         cjs require ./test.css [2] ./example.js 5:12-33
     [1] ./loader.js!./file.js 41 bytes {0} [built]
         cjs require ./loader!./file [2] ./example.js 2:12-38
-    [2] ./example.js 210 bytes {0} [built]
+    [2] ./example.js 204 bytes {0} [built]
     [3] (webpack)/~/css-loader/lib/css-base.js 1.51 kB {0} [built]
         cjs require ../../node_modules/css-loader/lib/css-base.js [0] (webpack)/~/css-loader!./test.css 1:27-83
 ```
@@ -257,19 +257,19 @@ chunk    {0} output.js (main) 1.96 kB [entry] [rendered]
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 9605bb0c7b03c2e56bef
-Version: webpack 2.3.2
+Hash: 1db4fa299743b412249c
+Version: webpack 2.4.1
     Asset     Size  Chunks             Chunk Names
 output.js  1.16 kB       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 1.94 kB [entry] [rendered]
+chunk    {0} output.js (main) 1.93 kB [entry] [rendered]
     > main [2] ./example.js 
     [0] (webpack)/~/css-loader!./test.css 183 bytes {0} [built]
         cjs require !css-loader!./test.css [2] ./example.js 6:12-45
         cjs require ./test.css [2] ./example.js 5:12-33
     [1] ./loader.js!./file.js 41 bytes {0} [built]
         cjs require ./loader!./file [2] ./example.js 2:12-38
-    [2] ./example.js 210 bytes {0} [built]
+    [2] ./example.js 204 bytes {0} [built]
     [3] (webpack)/~/css-loader/lib/css-base.js 1.51 kB {0} [built]
         cjs require ../../node_modules/css-loader/lib/css-base.js [0] (webpack)/~/css-loader!./test.css 1:27-83
 ```

--- a/examples/mixed/README.md
+++ b/examples/mixed/README.md
@@ -68,8 +68,9 @@ require(
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -78,8 +79,9 @@ require(
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/
 /******/ 	};
 /******/
@@ -95,9 +97,9 @@ require(
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -118,8 +120,9 @@ require(
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -152,7 +155,9 @@ require(
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -379,89 +384,89 @@ module.exports = function() {
 ## Uncompressed
 
 ```
-Hash: 9de04164c6e05168d4d0
-Version: webpack 2.3.2
+Hash: 9437942f663d7c8c9b79
+Version: webpack 2.4.1
       Asset     Size  Chunks             Chunk Names
 0.output.js  1.85 kB       0  [emitted]  
-  output.js  9.04 kB       1  [emitted]  main
+  output.js  9.09 kB       1  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} 0.output.js 439 bytes {1} [rendered]
+chunk    {0} 0.output.js 433 bytes {1} [rendered]
     > [3] ./example.js 7:0-14:1
     [4] ../require.context/templates ^\.\/.*\.js$ 193 bytes {0} [built]
         amd require context ../require.context/templates [3] ./example.js 7:0-14:1
-    [5] ../require.context/templates/a.js 82 bytes {0} [optional] [built]
+    [5] ../require.context/templates/a.js 80 bytes {0} [optional] [built]
         context element ./a.js [4] ../require.context/templates ^\.\/.*\.js$ ./a.js
-    [6] ../require.context/templates/b.js 82 bytes {0} [optional] [built]
+    [6] ../require.context/templates/b.js 80 bytes {0} [optional] [built]
         context element ./b.js [4] ../require.context/templates ^\.\/.*\.js$ ./b.js
-    [7] ../require.context/templates/c.js 82 bytes {0} [optional] [built]
+    [7] ../require.context/templates/c.js 80 bytes {0} [optional] [built]
         context element ./c.js [4] ../require.context/templates ^\.\/.*\.js$ ./c.js
-chunk    {1} output.js (main) 1.05 kB [entry] [rendered]
+chunk    {1} output.js (main) 1.01 kB [entry] [rendered]
     > main [3] ./example.js 
-    [0] ./amd.js 309 bytes {1} [built]
+    [0] ./amd.js 298 bytes {1} [built]
         amd require ./amd [1] ./commonjs.js 5:0-11:1
         cjs require ./amd [1] ./commonjs.js 8:13-29
         harmony import ./amd [2] ./harmony.js 3:0-24
         cjs require ./amd [3] ./example.js 3:11-27
         amd require ./amd [3] ./example.js 7:0-14:1
         amd require ./amd [3] ./example.js 7:0-14:1
-    [1] ./commonjs.js 233 bytes {1} [built]
+    [1] ./commonjs.js 223 bytes {1} [built]
         amd require ./commonjs [0] ./amd.js 2:0-12:1
         cjs require ./commonjs [0] ./amd.js 7:18-39
         harmony import ./commonjs [2] ./harmony.js 2:0-34
         cjs require ./commonjs [3] ./example.js 2:16-37
         amd require ./commonjs [3] ./example.js 7:0-14:1
         amd require ./commonjs [3] ./example.js 7:0-14:1
-    [2] ./harmony.js 101 bytes {1} [built]
+    [2] ./harmony.js 96 bytes {1} [built]
         [exports: default]
         amd require ./harmony [0] ./amd.js 2:0-12:1
         cjs require ./harmony [0] ./amd.js 8:17-37
         amd require ./harmony [1] ./commonjs.js 5:0-11:1
         cjs require ./harmony [1] ./commonjs.js 9:17-37
         cjs require ./harmony [3] ./example.js 4:15-35
-    [3] ./example.js 410 bytes {1} [built]
+    [3] ./example.js 396 bytes {1} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 9de04164c6e05168d4d0
-Version: webpack 2.3.2
+Hash: 9437942f663d7c8c9b79
+Version: webpack 2.4.1
       Asset       Size  Chunks             Chunk Names
 0.output.js  523 bytes       0  [emitted]  
-  output.js     1.9 kB       1  [emitted]  main
+  output.js    1.89 kB       1  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} 0.output.js 439 bytes {1} [rendered]
+chunk    {0} 0.output.js 433 bytes {1} [rendered]
     > [3] ./example.js 7:0-14:1
     [4] ../require.context/templates ^\.\/.*\.js$ 193 bytes {0} [built]
         amd require context ../require.context/templates [3] ./example.js 7:0-14:1
-    [5] ../require.context/templates/a.js 82 bytes {0} [optional] [built]
+    [5] ../require.context/templates/a.js 80 bytes {0} [optional] [built]
         context element ./a.js [4] ../require.context/templates ^\.\/.*\.js$ ./a.js
-    [6] ../require.context/templates/b.js 82 bytes {0} [optional] [built]
+    [6] ../require.context/templates/b.js 80 bytes {0} [optional] [built]
         context element ./b.js [4] ../require.context/templates ^\.\/.*\.js$ ./b.js
-    [7] ../require.context/templates/c.js 82 bytes {0} [optional] [built]
+    [7] ../require.context/templates/c.js 80 bytes {0} [optional] [built]
         context element ./c.js [4] ../require.context/templates ^\.\/.*\.js$ ./c.js
-chunk    {1} output.js (main) 1.05 kB [entry] [rendered]
+chunk    {1} output.js (main) 1.01 kB [entry] [rendered]
     > main [3] ./example.js 
-    [0] ./amd.js 309 bytes {1} [built]
+    [0] ./amd.js 298 bytes {1} [built]
         amd require ./amd [1] ./commonjs.js 5:0-11:1
         cjs require ./amd [1] ./commonjs.js 8:13-29
         harmony import ./amd [2] ./harmony.js 3:0-24
         cjs require ./amd [3] ./example.js 3:11-27
         amd require ./amd [3] ./example.js 7:0-14:1
         amd require ./amd [3] ./example.js 7:0-14:1
-    [1] ./commonjs.js 233 bytes {1} [built]
+    [1] ./commonjs.js 223 bytes {1} [built]
         amd require ./commonjs [0] ./amd.js 2:0-12:1
         cjs require ./commonjs [0] ./amd.js 7:18-39
         harmony import ./commonjs [2] ./harmony.js 2:0-34
         cjs require ./commonjs [3] ./example.js 2:16-37
         amd require ./commonjs [3] ./example.js 7:0-14:1
         amd require ./commonjs [3] ./example.js 7:0-14:1
-    [2] ./harmony.js 101 bytes {1} [built]
+    [2] ./harmony.js 96 bytes {1} [built]
         [exports: default]
         amd require ./harmony [0] ./amd.js 2:0-12:1
         cjs require ./harmony [0] ./amd.js 8:17-37
         amd require ./harmony [1] ./commonjs.js 5:0-11:1
         cjs require ./harmony [1] ./commonjs.js 9:17-37
         cjs require ./harmony [3] ./example.js 4:15-35
-    [3] ./example.js 410 bytes {1} [built]
+    [3] ./example.js 396 bytes {1} [built]
 ```

--- a/examples/move-to-parent/README.md
+++ b/examples/move-to-parent/README.md
@@ -105,16 +105,16 @@ module.exports = [{
 ## Uncompressed
 
 ```
-Hash: 92649f18837fbb021129ea807ff9294488030e7d297a4b5e23527060dcf866a6fc0a7d0ef06171d3
-Version: webpack 2.3.2
+Hash: ee2ff14cbcb134640818a08b99a288e09603fd38a026963c72c2ad9ef8aa50a04d749494b25fdf9e
+Version: webpack 2.4.1
 Child page:
-    Hash: 92649f18837fbb021129
+    Hash: ee2ff14cbcb134640818
              Asset       Size      Chunks             Chunk Names
         0.chunk.js  787 bytes  0, 1, 2, 3  [emitted]  
         1.chunk.js  595 bytes     1, 2, 3  [emitted]  
         2.chunk.js  403 bytes        2, 3  [emitted]  
         3.chunk.js  211 bytes           3  [emitted]  
-    page.bundle.js    6.61 kB           4  [emitted]  page
+    page.bundle.js    6.69 kB           4  [emitted]  page
     Entrypoint page = page.bundle.js
     chunk    {0} 0.chunk.js 84 bytes {4} [rendered]
         > [4] ./page.js 4:0-37
@@ -134,16 +134,16 @@ Child page:
     chunk    {3} 3.chunk.js 21 bytes {4} [rendered]
         > [4] ./page.js 1:0-16
         [0] ./a.js 21 bytes {0} {1} {2} {3} [built]
-    chunk    {4} page.bundle.js (page) 118 bytes [entry] [rendered]
+    chunk    {4} page.bundle.js (page) 114 bytes [entry] [rendered]
         > page [4] ./page.js 
-        [4] ./page.js 118 bytes {4} [built]
+        [4] ./page.js 114 bytes {4} [built]
 Child pageA:
-    Hash: ea807ff9294488030e7d
+    Hash: a08b99a288e09603fd38
               Asset       Size   Chunks             Chunk Names
          0.chunk.js  604 bytes  0, 1, 2  [emitted]  
          1.chunk.js  412 bytes     1, 2  [emitted]  
          2.chunk.js  220 bytes        2  [emitted]  
-    pageA.bundle.js     6.8 kB        3  [emitted]  pageA
+    pageA.bundle.js    6.88 kB        3  [emitted]  pageA
     Entrypoint pageA = pageA.bundle.js
     chunk    {0} 0.chunk.js 63 bytes {3} [rendered]
         > [4] ./page.js 4:0-37
@@ -157,16 +157,16 @@ Child pageA:
     chunk    {2} 2.chunk.js 21 bytes {3} [rendered]
         > [4] ./page.js 2:0-23
         [1] ./b.js 21 bytes {0} {1} {2} [built]
-    chunk    {3} pageA.bundle.js (pageA) 139 bytes [entry] [rendered]
+    chunk    {3} pageA.bundle.js (pageA) 135 bytes [entry] [rendered]
         > pageA [4] ./page.js 
         [0] ./a.js 21 bytes {3} [built]
-        [4] ./page.js 118 bytes {3} [built]
+        [4] ./page.js 114 bytes {3} [built]
 Child pageB:
-    Hash: 297a4b5e23527060dcf8
+    Hash: a026963c72c2ad9ef8aa
               Asset       Size  Chunks             Chunk Names
          0.chunk.js  421 bytes    0, 1  [emitted]  
          1.chunk.js  214 bytes       1  [emitted]  
-    pageB.bundle.js    6.96 kB       2  [emitted]  pageB
+    pageB.bundle.js    7.04 kB       2  [emitted]  pageB
     Entrypoint pageB = pageB.bundle.js
     chunk    {0} 0.chunk.js 42 bytes {2} [rendered]
         > [4] ./page.js 4:0-37
@@ -175,43 +175,43 @@ Child pageB:
     chunk    {1} 1.chunk.js 21 bytes {2} [rendered]
         > [4] ./page.js 3:0-30
         [2] ./c.js 21 bytes {0} {1} [built]
-    chunk    {2} pageB.bundle.js (pageB) 160 bytes [entry] [rendered]
+    chunk    {2} pageB.bundle.js (pageB) 156 bytes [entry] [rendered]
         > pageB [4] ./page.js 
         [0] ./a.js 21 bytes {2} [built]
         [1] ./b.js 21 bytes {2} [built]
-        [4] ./page.js 118 bytes {2} [built]
+        [4] ./page.js 114 bytes {2} [built]
 Child pageC:
-    Hash: 66a6fc0a7d0ef06171d3
+    Hash: 50a04d749494b25fdf9e
               Asset       Size  Chunks             Chunk Names
          0.chunk.js  220 bytes       0  [emitted]  
-    pageC.bundle.js    7.19 kB       1  [emitted]  pageC
+    pageC.bundle.js    7.27 kB       1  [emitted]  pageC
     Entrypoint pageC = pageC.bundle.js
     chunk    {0} 0.chunk.js 21 bytes {1} [rendered]
         > duplicate [4] ./page.js 2:0-23
         > duplicate [4] ./page.js 3:0-30
         > duplicate [4] ./page.js 4:0-37
         [1] ./b.js 21 bytes {0} [built]
-    chunk    {1} pageC.bundle.js (pageC) 181 bytes [entry] [rendered]
+    chunk    {1} pageC.bundle.js (pageC) 177 bytes [entry] [rendered]
         > pageC [4] ./page.js 
         [0] ./a.js 21 bytes {1} [built]
         [2] ./c.js 21 bytes {1} [built]
         [3] ./d.js 21 bytes {1} [built]
-        [4] ./page.js 118 bytes {1} [built]
+        [4] ./page.js 114 bytes {1} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 92649f18837fbb021129ea807ff9294488030e7d297a4b5e23527060dcf866a6fc0a7d0ef06171d3
-Version: webpack 2.3.2
+Hash: ee2ff14cbcb134640818a08b99a288e09603fd38a026963c72c2ad9ef8aa50a04d749494b25fdf9e
+Version: webpack 2.4.1
 Child page:
-    Hash: 92649f18837fbb021129
+    Hash: ee2ff14cbcb134640818
              Asset       Size      Chunks             Chunk Names
         0.chunk.js  142 bytes  0, 1, 2, 3  [emitted]  
         1.chunk.js  111 bytes     1, 2, 3  [emitted]  
         2.chunk.js   80 bytes        2, 3  [emitted]  
         3.chunk.js   49 bytes           3  [emitted]  
-    page.bundle.js    1.56 kB           4  [emitted]  page
+    page.bundle.js    1.55 kB           4  [emitted]  page
     Entrypoint page = page.bundle.js
     chunk    {0} 0.chunk.js 84 bytes {4} [rendered]
         > [4] ./page.js 4:0-37
@@ -231,16 +231,16 @@ Child page:
     chunk    {3} 3.chunk.js 21 bytes {4} [rendered]
         > [4] ./page.js 1:0-16
         [0] ./a.js 21 bytes {0} {1} {2} {3} [built]
-    chunk    {4} page.bundle.js (page) 118 bytes [entry] [rendered]
+    chunk    {4} page.bundle.js (page) 114 bytes [entry] [rendered]
         > page [4] ./page.js 
-        [4] ./page.js 118 bytes {4} [built]
+        [4] ./page.js 114 bytes {4} [built]
 Child pageA:
-    Hash: ea807ff9294488030e7d
+    Hash: a08b99a288e09603fd38
               Asset       Size   Chunks             Chunk Names
          0.chunk.js  112 bytes  0, 1, 2  [emitted]  
          1.chunk.js   81 bytes     1, 2  [emitted]  
          2.chunk.js   50 bytes        2  [emitted]  
-    pageA.bundle.js     1.6 kB        3  [emitted]  pageA
+    pageA.bundle.js    1.59 kB        3  [emitted]  pageA
     Entrypoint pageA = pageA.bundle.js
     chunk    {0} 0.chunk.js 63 bytes {3} [rendered]
         > [4] ./page.js 4:0-37
@@ -254,16 +254,16 @@ Child pageA:
     chunk    {2} 2.chunk.js 21 bytes {3} [rendered]
         > [4] ./page.js 2:0-23
         [1] ./b.js 21 bytes {0} {1} {2} [built]
-    chunk    {3} pageA.bundle.js (pageA) 139 bytes [entry] [rendered]
+    chunk    {3} pageA.bundle.js (pageA) 135 bytes [entry] [rendered]
         > pageA [4] ./page.js 
         [0] ./a.js 21 bytes {3} [built]
-        [4] ./page.js 118 bytes {3} [built]
+        [4] ./page.js 114 bytes {3} [built]
 Child pageB:
-    Hash: 297a4b5e23527060dcf8
+    Hash: a026963c72c2ad9ef8aa
               Asset      Size  Chunks             Chunk Names
          0.chunk.js  82 bytes    0, 1  [emitted]  
          1.chunk.js  51 bytes       1  [emitted]  
-    pageB.bundle.js   1.64 kB       2  [emitted]  pageB
+    pageB.bundle.js   1.63 kB       2  [emitted]  pageB
     Entrypoint pageB = pageB.bundle.js
     chunk    {0} 0.chunk.js 42 bytes {2} [rendered]
         > [4] ./page.js 4:0-37
@@ -272,26 +272,26 @@ Child pageB:
     chunk    {1} 1.chunk.js 21 bytes {2} [rendered]
         > [4] ./page.js 3:0-30
         [2] ./c.js 21 bytes {0} {1} [built]
-    chunk    {2} pageB.bundle.js (pageB) 160 bytes [entry] [rendered]
+    chunk    {2} pageB.bundle.js (pageB) 156 bytes [entry] [rendered]
         > pageB [4] ./page.js 
         [0] ./a.js 21 bytes {2} [built]
         [1] ./b.js 21 bytes {2} [built]
-        [4] ./page.js 118 bytes {2} [built]
+        [4] ./page.js 114 bytes {2} [built]
 Child pageC:
-    Hash: 66a6fc0a7d0ef06171d3
+    Hash: 50a04d749494b25fdf9e
               Asset      Size  Chunks             Chunk Names
          0.chunk.js  50 bytes       0  [emitted]  
-    pageC.bundle.js   1.66 kB       1  [emitted]  pageC
+    pageC.bundle.js   1.65 kB       1  [emitted]  pageC
     Entrypoint pageC = pageC.bundle.js
     chunk    {0} 0.chunk.js 21 bytes {1} [rendered]
         > duplicate [4] ./page.js 2:0-23
         > duplicate [4] ./page.js 3:0-30
         > duplicate [4] ./page.js 4:0-37
         [1] ./b.js 21 bytes {0} [built]
-    chunk    {1} pageC.bundle.js (pageC) 181 bytes [entry] [rendered]
+    chunk    {1} pageC.bundle.js (pageC) 177 bytes [entry] [rendered]
         > pageC [4] ./page.js 
         [0] ./a.js 21 bytes {1} [built]
         [2] ./c.js 21 bytes {1} [built]
         [3] ./d.js 21 bytes {1} [built]
-        [4] ./page.js 118 bytes {1} [built]
+        [4] ./page.js 114 bytes {1} [built]
 ```

--- a/examples/multi-compiler/README.md
+++ b/examples/multi-compiler/README.md
@@ -56,9 +56,9 @@ module.exports = [
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -150,9 +150,9 @@ console.log("Running " + "desktop" + " build");
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -244,49 +244,49 @@ console.log("Running " + "mobile" + " build");
 ## Uncompressed
 
 ```
-Hash: f70659afcc9f62694e35cceba4bc5163d755f291
-Version: webpack 2.3.2
+Hash: dced0418d24c0fc4eb2528f5d936e54472e7499c
+Version: webpack 2.4.1
 Child mobile:
-    Hash: f70659afcc9f62694e35
+    Hash: dced0418d24c0fc4eb25
         Asset     Size  Chunks             Chunk Names
     mobile.js  3.12 kB       0  [emitted]  main
     Entrypoint main = mobile.js
-    chunk    {0} mobile.js (main) 117 bytes [entry] [rendered]
+    chunk    {0} mobile.js (main) 114 bytes [entry] [rendered]
         > main [1] ./example.js 
         [0] ./mobile-stuff.js 20 bytes {0} [built]
             cjs require ./mobile-stuff [1] ./example.js 2:1-26
-        [1] ./example.js 97 bytes {0} [built]
+        [1] ./example.js 94 bytes {0} [built]
 Child desktop:
-    Hash: cceba4bc5163d755f291
+    Hash: 28f5d936e54472e7499c
          Asset     Size  Chunks             Chunk Names
     desktop.js  2.88 kB       0  [emitted]  main
     Entrypoint main = desktop.js
-    chunk    {0} desktop.js (main) 97 bytes [entry] [rendered]
+    chunk    {0} desktop.js (main) 94 bytes [entry] [rendered]
         > main [0] ./example.js 
-        [0] ./example.js 97 bytes {0} [built]
+        [0] ./example.js 94 bytes {0} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: f70659afcc9f62694e35cceba4bc5163d755f291
-Version: webpack 2.3.2
+Hash: dced0418d24c0fc4eb2528f5d936e54472e7499c
+Version: webpack 2.4.1
 Child mobile:
-    Hash: f70659afcc9f62694e35
+    Hash: dced0418d24c0fc4eb25
         Asset       Size  Chunks             Chunk Names
-    mobile.js  573 bytes       0  [emitted]  main
+    mobile.js  566 bytes       0  [emitted]  main
     Entrypoint main = mobile.js
-    chunk    {0} mobile.js (main) 117 bytes [entry] [rendered]
+    chunk    {0} mobile.js (main) 114 bytes [entry] [rendered]
         > main [1] ./example.js 
         [0] ./mobile-stuff.js 20 bytes {0} [built]
             cjs require ./mobile-stuff [1] ./example.js 2:1-26
-        [1] ./example.js 97 bytes {0} [built]
+        [1] ./example.js 94 bytes {0} [built]
 Child desktop:
-    Hash: cceba4bc5163d755f291
+    Hash: 28f5d936e54472e7499c
          Asset       Size  Chunks             Chunk Names
-    desktop.js  553 bytes       0  [emitted]  main
+    desktop.js  546 bytes       0  [emitted]  main
     Entrypoint main = desktop.js
-    chunk    {0} desktop.js (main) 97 bytes [entry] [rendered]
+    chunk    {0} desktop.js (main) 94 bytes [entry] [rendered]
         > main [0] ./example.js 
-        [0] ./example.js 97 bytes {0} [built]
+        [0] ./example.js 94 bytes {0} [built]
 ```

--- a/examples/multi-part-library/README.md
+++ b/examples/multi-part-library/README.md
@@ -55,9 +55,9 @@ return /******/ (function(modules) { // webpackBootstrap
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -157,9 +157,9 @@ return /******/ (function(modules) { // webpackBootstrap
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -240,9 +240,9 @@ module.exports = "beta";
 
 ```
 Hash: 082bbeea226fa367215b
-Version: webpack 2.3.2
+Version: webpack 2.4.1
              Asset     Size  Chunks             Chunk Names
- MyLibrary.beta.js  3.21 kB       0  [emitted]  beta
+ MyLibrary.beta.js  3.22 kB       0  [emitted]  beta
 MyLibrary.alpha.js  3.21 kB       1  [emitted]  alpha
 Entrypoint alpha = MyLibrary.alpha.js
 Entrypoint beta = MyLibrary.beta.js
@@ -258,7 +258,7 @@ chunk    {1} MyLibrary.alpha.js (alpha) 25 bytes [entry] [rendered]
 
 ```
 Hash: 082bbeea226fa367215b
-Version: webpack 2.3.2
+Version: webpack 2.4.1
              Asset       Size  Chunks             Chunk Names
  MyLibrary.beta.js  785 bytes       0  [emitted]  beta
 MyLibrary.alpha.js  787 bytes       1  [emitted]  alpha

--- a/examples/multiple-commons-chunks/README.md
+++ b/examples/multiple-commons-chunks/README.md
@@ -88,8 +88,9 @@ module.exports = {
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -98,8 +99,9 @@ module.exports = {
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/ 		if(executeModules) {
 /******/ 			for(i=0; i < executeModules.length; i++) {
 /******/ 				result = __webpack_require__(__webpack_require__.s = executeModules[i]);
@@ -121,9 +123,9 @@ module.exports = {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -144,8 +146,9 @@ module.exports = {
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -178,7 +181,9 @@ module.exports = {
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -340,25 +345,25 @@ __webpack_require__(/*! ./modules/admin */ 1);
 ## Uncompressed
 
 ```
-Hash: 8813e8cc41a26866a673
-Version: webpack 2.3.2
+Hash: 591b005286b61363c187
+Version: webpack 2.4.1
            Asset       Size  Chunks             Chunk Names
-        pageC.js  774 bytes       0  [emitted]  pageC
-        pageB.js  571 bytes       1  [emitted]  pageB
-        pageA.js  571 bytes       2  [emitted]  pageA
-   adminPageC.js  548 bytes    3, 4  [emitted]  adminPageC
+        pageC.js  771 bytes       0  [emitted]  pageC
+        pageB.js  568 bytes       1  [emitted]  pageB
+        pageA.js  568 bytes       2  [emitted]  pageA
+   adminPageC.js  547 bytes    3, 4  [emitted]  adminPageC
 admin-commons.js  235 bytes       4  [emitted]  admin-commons
-   adminPageB.js  339 bytes       5  [emitted]  adminPageB
-   adminPageA.js  339 bytes       6  [emitted]  adminPageA
-      commons.js    6.23 kB    7, 8  [emitted]  commons
-    c-commons.js    5.98 kB       8  [emitted]  c-commons
+   adminPageB.js  338 bytes       5  [emitted]  adminPageB
+   adminPageA.js  338 bytes       6  [emitted]  adminPageA
+      commons.js    6.31 kB    7, 8  [emitted]  commons
+    c-commons.js    6.07 kB       8  [emitted]  c-commons
 Entrypoint pageA = commons.js pageA.js
 Entrypoint pageB = commons.js pageB.js
 Entrypoint pageC = c-commons.js pageC.js
 Entrypoint adminPageA = commons.js admin-commons.js adminPageA.js
 Entrypoint adminPageB = commons.js admin-commons.js adminPageB.js
 Entrypoint adminPageC = c-commons.js adminPageC.js
-chunk    {0} pageC.js (pageC) 83 bytes {8} [initial] [rendered]
+chunk    {0} pageC.js (pageC) 80 bytes {8} [initial] [rendered]
     > pageC [10] ./pageC.js 
     [2] ./modules/a-c.js 0 bytes {0} {2} [built]
         cjs require ./modules/a-c [8] ./pageA.js 3:0-24
@@ -366,37 +371,37 @@ chunk    {0} pageC.js (pageC) 83 bytes {8} [initial] [rendered]
     [3] ./modules/b-c.js 0 bytes {0} {1} [built]
         cjs require ./modules/b-c [9] ./pageB.js 3:0-24
         cjs require ./modules/b-c [10] ./pageC.js 2:0-24
-   [10] ./pageC.js 83 bytes {0} [built]
-chunk    {1} pageB.js (pageB) 83 bytes {7} [initial] [rendered]
+   [10] ./pageC.js 80 bytes {0} [built]
+chunk    {1} pageB.js (pageB) 80 bytes {7} [initial] [rendered]
     > pageB [9] ./pageB.js 
     [3] ./modules/b-c.js 0 bytes {0} {1} [built]
         cjs require ./modules/b-c [9] ./pageB.js 3:0-24
         cjs require ./modules/b-c [10] ./pageC.js 2:0-24
-    [9] ./pageB.js 83 bytes {1} [built]
-chunk    {2} pageA.js (pageA) 83 bytes {7} [initial] [rendered]
+    [9] ./pageB.js 80 bytes {1} [built]
+chunk    {2} pageA.js (pageA) 80 bytes {7} [initial] [rendered]
     > pageA [8] ./pageA.js 
     [2] ./modules/a-c.js 0 bytes {0} {2} [built]
         cjs require ./modules/a-c [8] ./pageA.js 3:0-24
         cjs require ./modules/a-c [10] ./pageC.js 3:0-24
-    [8] ./pageA.js 83 bytes {2} [built]
-chunk    {3} adminPageC.js (adminPageC) 56 bytes {8} [initial] [rendered]
+    [8] ./pageA.js 80 bytes {2} [built]
+chunk    {3} adminPageC.js (adminPageC) 55 bytes {8} [initial] [rendered]
     > adminPageC [7] ./adminPageC.js 
     [1] ./modules/admin.js 0 bytes {3} {4} [built]
         cjs require ./modules/admin [5] ./adminPageA.js 2:0-26
         cjs require ./modules/admin [6] ./adminPageB.js 2:0-26
         cjs require ./modules/admin [7] ./adminPageC.js 2:0-26
-    [7] ./adminPageC.js 56 bytes {3} [built]
+    [7] ./adminPageC.js 55 bytes {3} [built]
 chunk    {4} admin-commons.js (admin-commons) 0 bytes {7} [initial] [rendered]
     [1] ./modules/admin.js 0 bytes {3} {4} [built]
         cjs require ./modules/admin [5] ./adminPageA.js 2:0-26
         cjs require ./modules/admin [6] ./adminPageB.js 2:0-26
         cjs require ./modules/admin [7] ./adminPageC.js 2:0-26
-chunk    {5} adminPageB.js (adminPageB) 56 bytes {4} [initial] [rendered]
+chunk    {5} adminPageB.js (adminPageB) 55 bytes {4} [initial] [rendered]
     > adminPageB [6] ./adminPageB.js 
-    [6] ./adminPageB.js 56 bytes {5} [built]
-chunk    {6} adminPageA.js (adminPageA) 56 bytes {4} [initial] [rendered]
+    [6] ./adminPageB.js 55 bytes {5} [built]
+chunk    {6} adminPageA.js (adminPageA) 55 bytes {4} [initial] [rendered]
     > adminPageA [5] ./adminPageA.js 
-    [5] ./adminPageA.js 56 bytes {6} [built]
+    [5] ./adminPageA.js 55 bytes {6} [built]
 chunk    {7} commons.js (commons) 0 bytes [entry] [rendered]
     [0] ./modules/a-b-c.js 0 bytes {7} {8} [built]
         cjs require ./modules/a-b-c [5] ./adminPageA.js 1:0-26
@@ -421,8 +426,8 @@ chunk    {8} c-commons.js (c-commons) 0 bytes [entry] [rendered]
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 8813e8cc41a26866a673
-Version: webpack 2.3.2
+Hash: 591b005286b61363c187
+Version: webpack 2.4.1
            Asset      Size  Chunks             Chunk Names
         pageC.js  96 bytes       0  [emitted]  pageC
         pageB.js  76 bytes       1  [emitted]  pageB
@@ -439,7 +444,7 @@ Entrypoint pageC = c-commons.js pageC.js
 Entrypoint adminPageA = commons.js admin-commons.js adminPageA.js
 Entrypoint adminPageB = commons.js admin-commons.js adminPageB.js
 Entrypoint adminPageC = c-commons.js adminPageC.js
-chunk    {0} pageC.js (pageC) 83 bytes {8} [initial] [rendered]
+chunk    {0} pageC.js (pageC) 80 bytes {8} [initial] [rendered]
     > pageC [10] ./pageC.js 
     [2] ./modules/a-c.js 0 bytes {0} {2} [built]
         cjs require ./modules/a-c [8] ./pageA.js 3:0-24
@@ -447,37 +452,37 @@ chunk    {0} pageC.js (pageC) 83 bytes {8} [initial] [rendered]
     [3] ./modules/b-c.js 0 bytes {0} {1} [built]
         cjs require ./modules/b-c [9] ./pageB.js 3:0-24
         cjs require ./modules/b-c [10] ./pageC.js 2:0-24
-   [10] ./pageC.js 83 bytes {0} [built]
-chunk    {1} pageB.js (pageB) 83 bytes {7} [initial] [rendered]
+   [10] ./pageC.js 80 bytes {0} [built]
+chunk    {1} pageB.js (pageB) 80 bytes {7} [initial] [rendered]
     > pageB [9] ./pageB.js 
     [3] ./modules/b-c.js 0 bytes {0} {1} [built]
         cjs require ./modules/b-c [9] ./pageB.js 3:0-24
         cjs require ./modules/b-c [10] ./pageC.js 2:0-24
-    [9] ./pageB.js 83 bytes {1} [built]
-chunk    {2} pageA.js (pageA) 83 bytes {7} [initial] [rendered]
+    [9] ./pageB.js 80 bytes {1} [built]
+chunk    {2} pageA.js (pageA) 80 bytes {7} [initial] [rendered]
     > pageA [8] ./pageA.js 
     [2] ./modules/a-c.js 0 bytes {0} {2} [built]
         cjs require ./modules/a-c [8] ./pageA.js 3:0-24
         cjs require ./modules/a-c [10] ./pageC.js 3:0-24
-    [8] ./pageA.js 83 bytes {2} [built]
-chunk    {3} adminPageC.js (adminPageC) 56 bytes {8} [initial] [rendered]
+    [8] ./pageA.js 80 bytes {2} [built]
+chunk    {3} adminPageC.js (adminPageC) 55 bytes {8} [initial] [rendered]
     > adminPageC [7] ./adminPageC.js 
     [1] ./modules/admin.js 0 bytes {3} {4} [built]
         cjs require ./modules/admin [5] ./adminPageA.js 2:0-26
         cjs require ./modules/admin [6] ./adminPageB.js 2:0-26
         cjs require ./modules/admin [7] ./adminPageC.js 2:0-26
-    [7] ./adminPageC.js 56 bytes {3} [built]
+    [7] ./adminPageC.js 55 bytes {3} [built]
 chunk    {4} admin-commons.js (admin-commons) 0 bytes {7} [initial] [rendered]
     [1] ./modules/admin.js 0 bytes {3} {4} [built]
         cjs require ./modules/admin [5] ./adminPageA.js 2:0-26
         cjs require ./modules/admin [6] ./adminPageB.js 2:0-26
         cjs require ./modules/admin [7] ./adminPageC.js 2:0-26
-chunk    {5} adminPageB.js (adminPageB) 56 bytes {4} [initial] [rendered]
+chunk    {5} adminPageB.js (adminPageB) 55 bytes {4} [initial] [rendered]
     > adminPageB [6] ./adminPageB.js 
-    [6] ./adminPageB.js 56 bytes {5} [built]
-chunk    {6} adminPageA.js (adminPageA) 56 bytes {4} [initial] [rendered]
+    [6] ./adminPageB.js 55 bytes {5} [built]
+chunk    {6} adminPageA.js (adminPageA) 55 bytes {4} [initial] [rendered]
     > adminPageA [5] ./adminPageA.js 
-    [5] ./adminPageA.js 56 bytes {6} [built]
+    [5] ./adminPageA.js 55 bytes {6} [built]
 chunk    {7} commons.js (commons) 0 bytes [entry] [rendered]
     [0] ./modules/a-b-c.js 0 bytes {7} {8} [built]
         cjs require ./modules/a-b-c [5] ./adminPageA.js 1:0-26

--- a/examples/multiple-entry-points-commons-chunk-css-bundle/README.md
+++ b/examples/multiple-entry-points-commons-chunk-css-bundle/README.md
@@ -179,39 +179,39 @@ body{background:url(js/ce21cbdd9b894e6af794813eb3fdaf60.png)}.c{background:url(j
 ## Uncompressed
 
 ```
-Hash: 82bd95dca40b04e5c383
-Version: webpack 2.3.2
+Hash: d8596ce424b009596b08
+Version: webpack 2.4.1
                                Asset       Size  Chunks             Chunk Names
-                                C.js    3.04 kB       2  [emitted]  C
+                                C.js    3.05 kB       2  [emitted]  C
 d090b6fba0f6d326d282a19146ff54a7.png  120 bytes          [emitted]  
 ce21cbdd9b894e6af794813eb3fdaf60.png  119 bytes          [emitted]  
 c2a2f62d69330b7d787782f5010f9d13.png  120 bytes          [emitted]  
-                                B.js  537 bytes       0  [emitted]  B
-                                A.js  559 bytes       1  [emitted]  A
+                                B.js  535 bytes       0  [emitted]  B
+                                A.js  557 bytes       1  [emitted]  A
 16155c689e517682064c99893cb832cc.png  120 bytes          [emitted]  
-                          commons.js       6 kB       3  [emitted]  commons
-                               A.css   69 bytes       1  [emitted]  A
-                               B.css   69 bytes       0  [emitted]  B
-                               C.css  140 bytes       2  [emitted]  C
-                         commons.css   71 bytes       3  [emitted]  commons
+                          commons.js    6.09 kB       3  [emitted]  commons
+                               A.css   66 bytes       1  [emitted]  A
+                               B.css   66 bytes       0  [emitted]  B
+                               C.css  134 bytes       2  [emitted]  C
+                         commons.css   68 bytes       3  [emitted]  commons
 Entrypoint A = commons.js commons.css A.js A.css
 Entrypoint B = commons.js commons.css B.js B.css
 Entrypoint C = C.js C.css
-chunk    {0} B.js, B.css (B) 92 bytes {3} [initial] [rendered]
+chunk    {0} B.js, B.css (B) 90 bytes {3} [initial] [rendered]
     > B [5] ./b.js 
     [2] ./styleB.css 41 bytes {0} [built]
         cjs require ./styleB.css [5] ./b.js 2:0-23
-    [5] ./b.js 51 bytes {0} [built]
-chunk    {1} A.js, A.css (A) 92 bytes {3} [initial] [rendered]
+    [5] ./b.js 49 bytes {0} [built]
+chunk    {1} A.js, A.css (A) 90 bytes {3} [initial] [rendered]
     > A [4] ./a.js 
     [1] ./styleA.css 41 bytes {1} [built]
         cjs require ./styleA.css [4] ./a.js 2:0-23
-    [4] ./a.js 51 bytes {1} [built]
-chunk    {2} C.js, C.css (C) 67 bytes [entry] [rendered]
+    [4] ./a.js 49 bytes {1} [built]
+chunk    {2} C.js, C.css (C) 66 bytes [entry] [rendered]
     > C [6] ./c.js 
     [3] ./styleC.css 41 bytes {2} [built]
         cjs require ./styleC.css [6] ./c.js 1:0-23
-    [6] ./c.js 26 bytes {2} [built]
+    [6] ./c.js 25 bytes {2} [built]
 chunk    {3} commons.js, commons.css (commons) 41 bytes [entry] [rendered]
     [0] ./style.css 41 bytes {3} [built]
         cjs require ./style.css [4] ./a.js 1:0-22
@@ -223,8 +223,8 @@ Child extract-text-webpack-plugin:
         [0] (webpack)/~/css-loader/lib/css-base.js 1.51 kB {0} [built]
             cjs require ../../node_modules/css-loader/lib/css-base.js [2] (webpack)/~/css-loader!./styleA.css 1:27-83
         [1] ./imageA.png 82 bytes {0} [built]
-            cjs require ./imageA.png [2] (webpack)/~/css-loader!./styleA.css 6:56-79
-        [2] (webpack)/~/css-loader!./styleA.css 225 bytes {0} [built]
+            cjs require ./imageA.png [2] (webpack)/~/css-loader!./styleA.css 6:54-77
+        [2] (webpack)/~/css-loader!./styleA.css 219 bytes {0} [built]
 Child extract-text-webpack-plugin:
     Entrypoint undefined = extract-text-webpack-plugin-output-filename
     chunk    {0} extract-text-webpack-plugin-output-filename 1.81 kB [entry] [rendered]
@@ -232,8 +232,8 @@ Child extract-text-webpack-plugin:
         [0] (webpack)/~/css-loader/lib/css-base.js 1.51 kB {0} [built]
             cjs require ../../node_modules/css-loader/lib/css-base.js [2] (webpack)/~/css-loader!./styleB.css 1:27-83
         [1] ./imageB.png 82 bytes {0} [built]
-            cjs require ./imageB.png [2] (webpack)/~/css-loader!./styleB.css 6:56-79
-        [2] (webpack)/~/css-loader!./styleB.css 225 bytes {0} [built]
+            cjs require ./imageB.png [2] (webpack)/~/css-loader!./styleB.css 6:54-77
+        [2] (webpack)/~/css-loader!./styleB.css 219 bytes {0} [built]
 Child extract-text-webpack-plugin:
     Entrypoint undefined = extract-text-webpack-plugin-output-filename
     chunk    {0} extract-text-webpack-plugin-output-filename 1.81 kB [entry] [rendered]
@@ -241,31 +241,31 @@ Child extract-text-webpack-plugin:
         [0] (webpack)/~/css-loader/lib/css-base.js 1.51 kB {0} [built]
             cjs require ../../node_modules/css-loader/lib/css-base.js [2] (webpack)/~/css-loader!./style.css 1:27-83
         [1] ./image.png 82 bytes {0} [built]
-            cjs require ./image.png [2] (webpack)/~/css-loader!./style.css 6:58-80
-        [2] (webpack)/~/css-loader!./style.css 226 bytes {0} [built]
+            cjs require ./image.png [2] (webpack)/~/css-loader!./style.css 6:56-78
+        [2] (webpack)/~/css-loader!./style.css 220 bytes {0} [built]
 Child extract-text-webpack-plugin:
     Entrypoint undefined = extract-text-webpack-plugin-output-filename
-    chunk    {0} extract-text-webpack-plugin-output-filename 2.2 kB [entry] [rendered]
+    chunk    {0} extract-text-webpack-plugin-output-filename 2.19 kB [entry] [rendered]
         > [3] (webpack)/~/css-loader!./styleC.css 
         [0] (webpack)/~/css-loader/lib/css-base.js 1.51 kB {0} [built]
             cjs require ../../node_modules/css-loader/lib/css-base.js [1] (webpack)/~/css-loader!./style.css 1:27-83
             cjs require ../../node_modules/css-loader/lib/css-base.js [3] (webpack)/~/css-loader!./styleC.css 1:27-83
-        [1] (webpack)/~/css-loader!./style.css 226 bytes {0} [built]
+        [1] (webpack)/~/css-loader!./style.css 220 bytes {0} [built]
             cjs require -!../../node_modules/css-loader/index.js!./style.css [3] (webpack)/~/css-loader!./styleC.css 3:10-73
         [2] ./imageC.png 82 bytes {0} [built]
-            cjs require ./imageC.png [3] (webpack)/~/css-loader!./styleC.css 6:56-79
-        [3] (webpack)/~/css-loader!./styleC.css 304 bytes {0} [built]
+            cjs require ./imageC.png [3] (webpack)/~/css-loader!./styleC.css 6:54-77
+        [3] (webpack)/~/css-loader!./styleC.css 298 bytes {0} [built]
         [4] ./image.png 82 bytes {0} [built]
-            cjs require ./image.png [1] (webpack)/~/css-loader!./style.css 6:58-80
+            cjs require ./image.png [1] (webpack)/~/css-loader!./style.css 6:56-78
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 58c46b8115ae51be12b7
-Version: webpack 2.3.2
+Hash: 0b769e13f5871263a184
+Version: webpack 2.4.1
                                Asset       Size  Chunks             Chunk Names
-                                C.js  541 bytes       2  [emitted]  C
+                                C.js  534 bytes       2  [emitted]  C
 d090b6fba0f6d326d282a19146ff54a7.png  120 bytes          [emitted]  
 ce21cbdd9b894e6af794813eb3fdaf60.png  119 bytes          [emitted]  
 c2a2f62d69330b7d787782f5010f9d13.png  120 bytes          [emitted]  
@@ -280,21 +280,21 @@ c2a2f62d69330b7d787782f5010f9d13.png  120 bytes          [emitted]
 Entrypoint A = commons.js commons.css A.js A.css
 Entrypoint B = commons.js commons.css B.js B.css
 Entrypoint C = C.js C.css
-chunk    {0} B.js, B.css (B) 92 bytes {3} [initial] [rendered]
+chunk    {0} B.js, B.css (B) 90 bytes {3} [initial] [rendered]
     > B [5] ./b.js 
     [2] ./styleB.css 41 bytes {0} [built]
         cjs require ./styleB.css [5] ./b.js 2:0-23
-    [5] ./b.js 51 bytes {0} [built]
-chunk    {1} A.js, A.css (A) 92 bytes {3} [initial] [rendered]
+    [5] ./b.js 49 bytes {0} [built]
+chunk    {1} A.js, A.css (A) 90 bytes {3} [initial] [rendered]
     > A [4] ./a.js 
     [1] ./styleA.css 41 bytes {1} [built]
         cjs require ./styleA.css [4] ./a.js 2:0-23
-    [4] ./a.js 51 bytes {1} [built]
-chunk    {2} C.js, C.css (C) 67 bytes [entry] [rendered]
+    [4] ./a.js 49 bytes {1} [built]
+chunk    {2} C.js, C.css (C) 66 bytes [entry] [rendered]
     > C [6] ./c.js 
     [3] ./styleC.css 41 bytes {2} [built]
         cjs require ./styleC.css [6] ./c.js 1:0-23
-    [6] ./c.js 26 bytes {2} [built]
+    [6] ./c.js 25 bytes {2} [built]
 chunk    {3} commons.js, commons.css (commons) 41 bytes [entry] [rendered]
     [0] ./style.css 41 bytes {3} [built]
         cjs require ./style.css [4] ./a.js 1:0-22

--- a/examples/multiple-entry-points/README.md
+++ b/examples/multiple-entry-points/README.md
@@ -95,8 +95,9 @@ module.exports = {
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -105,8 +106,9 @@ module.exports = {
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/ 		if(executeModules) {
 /******/ 			for(i=0; i < executeModules.length; i++) {
 /******/ 				result = __webpack_require__(__webpack_require__.s = executeModules[i]);
@@ -127,9 +129,9 @@ module.exports = {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -150,8 +152,9 @@ module.exports = {
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -184,7 +187,9 @@ module.exports = {
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -326,28 +331,28 @@ module.exports = function(msg) {
 ## Uncompressed
 
 ```
-Hash: 6f1a02fdead6a9246eeb
-Version: webpack 2.3.2
+Hash: 0d66fd2324ef88f9e257
+Version: webpack 2.4.1
           Asset       Size  Chunks             Chunk Names
-     0.chunk.js  336 bytes       0  [emitted]  
-pageB.bundle.js  520 bytes       1  [emitted]  pageB
-pageA.bundle.js  546 bytes       2  [emitted]  pageA
-     commons.js       6 kB       3  [emitted]  commons
+     0.chunk.js  333 bytes       0  [emitted]  
+pageB.bundle.js  516 bytes       1  [emitted]  pageB
+pageA.bundle.js  543 bytes       2  [emitted]  pageA
+     commons.js    6.09 kB       3  [emitted]  commons
 Entrypoint pageA = commons.js pageA.bundle.js
 Entrypoint pageB = commons.js pageB.bundle.js
-chunk    {0} 0.chunk.js 91 bytes {1} {2} [rendered]
+chunk    {0} 0.chunk.js 88 bytes {1} {2} [rendered]
     > duplicate [2] ./pageA.js 2:0-4:2
     > duplicate [3] ./pageB.js 2:0-5:2
-    [0] ./shared.js 91 bytes {0} [built]
+    [0] ./shared.js 88 bytes {0} [built]
         amd require ./shared [2] ./pageA.js 2:0-4:2
         require.ensure item ./shared [3] ./pageB.js 2:0-5:2
         cjs require ./shared [3] ./pageB.js 3:14-33
-chunk    {1} pageB.bundle.js (pageB) 152 bytes {3} [initial] [rendered]
+chunk    {1} pageB.bundle.js (pageB) 148 bytes {3} [initial] [rendered]
     > pageB [3] ./pageB.js 
-    [3] ./pageB.js 152 bytes {1} [built]
-chunk    {2} pageA.bundle.js (pageA) 108 bytes {3} [initial] [rendered]
+    [3] ./pageB.js 148 bytes {1} [built]
+chunk    {2} pageA.bundle.js (pageA) 105 bytes {3} [initial] [rendered]
     > pageA [2] ./pageA.js 
-    [2] ./pageA.js 108 bytes {2} [built]
+    [2] ./pageA.js 105 bytes {2} [built]
 chunk    {3} commons.js (commons) 26 bytes [entry] [rendered]
     [1] ./common.js 26 bytes {3} [built]
         cjs require ./common [0] ./shared.js 1:13-32
@@ -358,8 +363,8 @@ chunk    {3} commons.js (commons) 26 bytes [entry] [rendered]
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 6f1a02fdead6a9246eeb
-Version: webpack 2.3.2
+Hash: 0d66fd2324ef88f9e257
+Version: webpack 2.4.1
           Asset       Size  Chunks             Chunk Names
      0.chunk.js   80 bytes       0  [emitted]  
 pageB.bundle.js  122 bytes       1  [emitted]  pageB
@@ -367,19 +372,19 @@ pageA.bundle.js  147 bytes       2  [emitted]  pageA
      commons.js    1.41 kB       3  [emitted]  commons
 Entrypoint pageA = commons.js pageA.bundle.js
 Entrypoint pageB = commons.js pageB.bundle.js
-chunk    {0} 0.chunk.js 91 bytes {1} {2} [rendered]
+chunk    {0} 0.chunk.js 88 bytes {1} {2} [rendered]
     > duplicate [2] ./pageA.js 2:0-4:2
     > duplicate [3] ./pageB.js 2:0-5:2
-    [0] ./shared.js 91 bytes {0} [built]
+    [0] ./shared.js 88 bytes {0} [built]
         amd require ./shared [2] ./pageA.js 2:0-4:2
         require.ensure item ./shared [3] ./pageB.js 2:0-5:2
         cjs require ./shared [3] ./pageB.js 3:14-33
-chunk    {1} pageB.bundle.js (pageB) 152 bytes {3} [initial] [rendered]
+chunk    {1} pageB.bundle.js (pageB) 148 bytes {3} [initial] [rendered]
     > pageB [3] ./pageB.js 
-    [3] ./pageB.js 152 bytes {1} [built]
-chunk    {2} pageA.bundle.js (pageA) 108 bytes {3} [initial] [rendered]
+    [3] ./pageB.js 148 bytes {1} [built]
+chunk    {2} pageA.bundle.js (pageA) 105 bytes {3} [initial] [rendered]
     > pageA [2] ./pageA.js 
-    [2] ./pageA.js 108 bytes {2} [built]
+    [2] ./pageA.js 105 bytes {2} [built]
 chunk    {3} commons.js (commons) 26 bytes [entry] [rendered]
     [1] ./common.js 26 bytes {3} [built]
         cjs require ./common [0] ./shared.js 1:13-32

--- a/examples/named-chunks/README.md
+++ b/examples/named-chunks/README.md
@@ -38,8 +38,9 @@ require.ensure(["b"], function(require) {
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -48,8 +49,9 @@ require.ensure(["b"], function(require) {
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/
 /******/ 	};
 /******/
@@ -65,9 +67,9 @@ require.ensure(["b"], function(require) {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -88,8 +90,9 @@ require.ensure(["b"], function(require) {
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -122,7 +125,9 @@ require.ensure(["b"], function(require) {
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -302,12 +307,12 @@ webpackJsonp([1],[
 ## Uncompressed
 
 ```
-Hash: 32e44c81729dc14e3f5a
-Version: webpack 2.3.2
+Hash: 18dca45de121f9b513fb
+Version: webpack 2.4.1
       Asset       Size  Chunks             Chunk Names
 0.output.js  599 bytes    0, 1  [emitted]  my own chunk
 1.output.js  393 bytes       1  [emitted]  
-  output.js       7 kB       2  [emitted]  main
+  output.js    7.07 kB       2  [emitted]  main
 Entrypoint main = output.js
 chunk    {0} 0.output.js (my own chunk) 33 bytes {2} [rendered]
     > my own chunk [3] ./example.js 3:0-6:18
@@ -331,22 +336,22 @@ chunk    {1} 1.output.js 22 bytes {2} [rendered]
     [1] ./~/d.js 11 bytes {0} {1} [built]
         cjs require d [3] ./example.js 10:9-21
         cjs require d [3] ./example.js 19:9-21
-chunk    {2} output.js (main) 452 bytes [entry] [rendered]
+chunk    {2} output.js (main) 432 bytes [entry] [rendered]
     > main [3] ./example.js 
     [2] ./~/a.js 11 bytes {2} [built]
         cjs require a [3] ./example.js 1:8-20
-    [3] ./example.js 441 bytes {2} [built]
+    [3] ./example.js 421 bytes {2} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 32e44c81729dc14e3f5a
-Version: webpack 2.3.2
+Hash: 18dca45de121f9b513fb
+Version: webpack 2.4.1
       Asset      Size  Chunks             Chunk Names
 0.output.js  72 bytes    0, 1  [emitted]  my own chunk
 1.output.js  52 bytes       1  [emitted]  
-  output.js    1.6 kB       2  [emitted]  main
+  output.js   1.59 kB       2  [emitted]  main
 Entrypoint main = output.js
 chunk    {0} 0.output.js (my own chunk) 33 bytes {2} [rendered]
     > my own chunk [3] ./example.js 3:0-6:18
@@ -370,9 +375,9 @@ chunk    {1} 1.output.js 22 bytes {2} [rendered]
     [1] ./~/d.js 11 bytes {0} {1} [built]
         cjs require d [3] ./example.js 10:9-21
         cjs require d [3] ./example.js 19:9-21
-chunk    {2} output.js (main) 452 bytes [entry] [rendered]
+chunk    {2} output.js (main) 432 bytes [entry] [rendered]
     > main [3] ./example.js 
     [2] ./~/a.js 11 bytes {2} [built]
         cjs require a [3] ./example.js 1:8-20
-    [3] ./example.js 441 bytes {2} [built]
+    [3] ./example.js 421 bytes {2} [built]
 ```

--- a/examples/require.context/README.md
+++ b/examples/require.context/README.md
@@ -35,9 +35,9 @@ module.exports = function() {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -196,49 +196,49 @@ console.log(getTemplate("b"));
 ## Uncompressed
 
 ```
-Hash: 219dcd379f9f54c00e1f
-Version: webpack 2.3.2
+Hash: 1bb5b5a15a35d4d81609
+Version: webpack 2.4.1
     Asset     Size  Chunks             Chunk Names
 output.js  4.57 kB       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 613 bytes [entry] [rendered]
+chunk    {0} output.js (main) 603 bytes [entry] [rendered]
     > main [4] ./example.js 
-    [0] ./templates/a.js 82 bytes {0} [optional] [built]
+    [0] ./templates/a.js 80 bytes {0} [optional] [built]
         context element ./a [3] ./templates ^\.\/.*$ ./a
         context element ./a.js [3] ./templates ^\.\/.*$ ./a.js
-    [1] ./templates/b.js 82 bytes {0} [optional] [built]
+    [1] ./templates/b.js 80 bytes {0} [optional] [built]
         context element ./b [3] ./templates ^\.\/.*$ ./b
         context element ./b.js [3] ./templates ^\.\/.*$ ./b.js
-    [2] ./templates/c.js 82 bytes {0} [optional] [built]
+    [2] ./templates/c.js 80 bytes {0} [optional] [built]
         context element ./c [3] ./templates ^\.\/.*$ ./c
         context element ./c.js [3] ./templates ^\.\/.*$ ./c.js
     [3] ./templates ^\.\/.*$ 217 bytes {0} [built]
         cjs require context ./templates [4] ./example.js 2:8-44
-    [4] ./example.js 150 bytes {0} [built]
+    [4] ./example.js 146 bytes {0} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 219dcd379f9f54c00e1f
-Version: webpack 2.3.2
+Hash: 1bb5b5a15a35d4d81609
+Version: webpack 2.4.1
     Asset     Size  Chunks             Chunk Names
 output.js  1.11 kB       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 613 bytes [entry] [rendered]
+chunk    {0} output.js (main) 603 bytes [entry] [rendered]
     > main [4] ./example.js 
-    [0] ./templates/a.js 82 bytes {0} [optional] [built]
+    [0] ./templates/a.js 80 bytes {0} [optional] [built]
         context element ./a [3] ./templates ^\.\/.*$ ./a
         context element ./a.js [3] ./templates ^\.\/.*$ ./a.js
-    [1] ./templates/b.js 82 bytes {0} [optional] [built]
+    [1] ./templates/b.js 80 bytes {0} [optional] [built]
         context element ./b [3] ./templates ^\.\/.*$ ./b
         context element ./b.js [3] ./templates ^\.\/.*$ ./b.js
-    [2] ./templates/c.js 82 bytes {0} [optional] [built]
+    [2] ./templates/c.js 80 bytes {0} [optional] [built]
         context element ./c [3] ./templates ^\.\/.*$ ./c
         context element ./c.js [3] ./templates ^\.\/.*$ ./c.js
     [3] ./templates ^\.\/.*$ 217 bytes {0} [built]
         cjs require context ./templates [4] ./example.js 2:8-44
-    [4] ./example.js 150 bytes {0} [built]
+    [4] ./example.js 146 bytes {0} [built]
 ```
 
 # Code Splitting

--- a/examples/require.resolve/README.md
+++ b/examples/require.resolve/README.md
@@ -36,9 +36,9 @@ module.exports = Math.random();
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -144,33 +144,33 @@ if(a == a2) throw new Error("Cache clear failed :(");
 ## Uncompressed
 
 ```
-Hash: 4ed342adc60583d992ab
-Version: webpack 2.3.2
+Hash: 5d6a3015eff8d79dcd14
+Version: webpack 2.4.1
     Asset     Size  Chunks             Chunk Names
-output.js  3.34 kB       0  [emitted]  main
+output.js  3.33 kB       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 326 bytes [entry] [rendered]
+chunk    {0} output.js (main) 314 bytes [entry] [rendered]
     > main [1] ./example.js 
     [0] ./a.js 31 bytes {0} [built]
         cjs require ./a [1] ./example.js 1:8-22
         cjs require ./a [1] ./example.js 10:9-23
         require.resolve ./a.js [1] ./example.js 4:10-35
-    [1] ./example.js 295 bytes {0} [built]
+    [1] ./example.js 283 bytes {0} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 4ed342adc60583d992ab
-Version: webpack 2.3.2
+Hash: 5d6a3015eff8d79dcd14
+Version: webpack 2.4.1
     Asset       Size  Chunks             Chunk Names
-output.js  632 bytes       0  [emitted]  main
+output.js  625 bytes       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 326 bytes [entry] [rendered]
+chunk    {0} output.js (main) 314 bytes [entry] [rendered]
     > main [1] ./example.js 
     [0] ./a.js 31 bytes {0} [built]
         cjs require ./a [1] ./example.js 1:8-22
         cjs require ./a [1] ./example.js 10:9-23
         require.resolve ./a.js [1] ./example.js 4:10-35
-    [1] ./example.js 295 bytes {0} [built]
+    [1] ./example.js 283 bytes {0} [built]
 ```

--- a/examples/source-map/README.md
+++ b/examples/source-map/README.md
@@ -246,7 +246,7 @@ eval("var math, race,\n  slice = [].slice;\n\nmath = {\n  root: Math.sqrt,\n  sq
 
 ```
 Hash: e1eee77b6825ec38ac89465a726503b90d318f915f9e187528736f9dd586ad053259eb9ee4cf69b5354b67e68d715d903c312f2150aa82ec45caa3f79d388dea6bd43ac605cdd4e103e888cf20eaf6f75dc2d2924e3fdc22d6889086c1479edc2c87f028
-Version: webpack 2.3.3
+Version: webpack 2.4.1
 Child
     Hash: e1eee77b6825ec38ac89
                                   Asset     Size  Chunks             Chunk Names

--- a/examples/two-explicit-vendor-chunks/README.md
+++ b/examples/two-explicit-vendor-chunks/README.md
@@ -38,8 +38,9 @@ module.exports = {
 /******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
 /******/ 		for(;i < chunkIds.length; i++) {
 /******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId])
+/******/ 			if(installedChunks[chunkId]) {
 /******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
 /******/ 			installedChunks[chunkId] = 0;
 /******/ 		}
 /******/ 		for(moduleId in moreModules) {
@@ -48,8 +49,9 @@ module.exports = {
 /******/ 			}
 /******/ 		}
 /******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length)
+/******/ 		while(resolves.length) {
 /******/ 			resolves.shift()();
+/******/ 		}
 /******/ 		if(executeModules) {
 /******/ 			for(i=0; i < executeModules.length; i++) {
 /******/ 				result = __webpack_require__(__webpack_require__.s = executeModules[i]);
@@ -70,9 +72,9 @@ module.exports = {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -93,8 +95,9 @@ module.exports = {
 /******/ 	// This file contains only the entry chunk.
 /******/ 	// The chunk loading function for additional chunks
 /******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		if(installedChunks[chunkId] === 0)
+/******/ 		if(installedChunks[chunkId] === 0) {
 /******/ 			return Promise.resolve();
+/******/ 		}
 /******/
 /******/ 		// a Promise means "currently loading".
 /******/ 		if(installedChunks[chunkId]) {
@@ -127,7 +130,9 @@ module.exports = {
 /******/ 			clearTimeout(timeout);
 /******/ 			var chunk = installedChunks[chunkId];
 /******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
 /******/ 				installedChunks[chunkId] = undefined;
 /******/ 			}
 /******/ 		};
@@ -276,22 +281,22 @@ __webpack_require__(/*! ./vendor2 */ 1);
 ## Uncompressed
 
 ```
-Hash: 62391146f04ad7bbf99c
-Version: webpack 2.3.2
+Hash: 894a30061af5d69cca5a
+Version: webpack 2.4.1
      Asset       Size  Chunks             Chunk Names
-vendor2.js  583 bytes       0  [emitted]  vendor2
+vendor2.js  581 bytes       0  [emitted]  vendor2
   pageC.js  234 bytes       1  [emitted]  pageC
   pageB.js  234 bytes       2  [emitted]  pageB
-  pageA.js  341 bytes       3  [emitted]  pageA
-vendor1.js     6.4 kB       4  [emitted]  vendor1
+  pageA.js  338 bytes       3  [emitted]  pageA
+vendor1.js    6.48 kB       4  [emitted]  vendor1
 Entrypoint vendor1 = vendor1.js
 Entrypoint vendor2 = vendor1.js vendor2.js
 Entrypoint pageA = vendor1.js vendor2.js pageA.js
 Entrypoint pageB = vendor1.js vendor2.js pageB.js
 Entrypoint pageC = vendor1.js vendor2.js pageC.js
-chunk    {0} vendor2.js (vendor2) 80 bytes {4} [initial] [rendered]
+chunk    {0} vendor2.js (vendor2) 78 bytes {4} [initial] [rendered]
     > vendor2 [6] multi ./vendor2 
-    [1] ./vendor2.js 52 bytes {0} [built]
+    [1] ./vendor2.js 50 bytes {0} [built]
         cjs require ./vendor2 [2] ./pageA.js 3:0-20
         single entry ./vendor2 [6] multi ./vendor2 vendor2:100000
     [6] multi ./vendor2 28 bytes {0} [built]
@@ -301,9 +306,9 @@ chunk    {1} pageC.js (pageC) 25 bytes {0} [initial] [rendered]
 chunk    {2} pageB.js (pageB) 25 bytes {0} [initial] [rendered]
     > pageB [3] ./pageB.js 
     [3] ./pageB.js 25 bytes {2} [built]
-chunk    {3} pageA.js (pageA) 73 bytes {0} [initial] [rendered]
+chunk    {3} pageA.js (pageA) 70 bytes {0} [initial] [rendered]
     > pageA [2] ./pageA.js 
-    [2] ./pageA.js 73 bytes {3} [built]
+    [2] ./pageA.js 70 bytes {3} [built]
 chunk    {4} vendor1.js (vendor1) 55 bytes [entry] [rendered]
     > vendor1 [5] multi ./vendor1 
     [0] ./vendor1.js 27 bytes {4} [built]
@@ -316,22 +321,22 @@ chunk    {4} vendor1.js (vendor1) 55 bytes [entry] [rendered]
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 62391146f04ad7bbf99c
-Version: webpack 2.3.2
+Hash: 894a30061af5d69cca5a
+Version: webpack 2.4.1
      Asset       Size  Chunks             Chunk Names
 vendor2.js  102 bytes       0  [emitted]  vendor2
   pageC.js   59 bytes       1  [emitted]  pageC
   pageB.js   59 bytes       2  [emitted]  pageB
   pageA.js   71 bytes       3  [emitted]  pageA
-vendor1.js    1.46 kB       4  [emitted]  vendor1
+vendor1.js    1.45 kB       4  [emitted]  vendor1
 Entrypoint vendor1 = vendor1.js
 Entrypoint vendor2 = vendor1.js vendor2.js
 Entrypoint pageA = vendor1.js vendor2.js pageA.js
 Entrypoint pageB = vendor1.js vendor2.js pageB.js
 Entrypoint pageC = vendor1.js vendor2.js pageC.js
-chunk    {0} vendor2.js (vendor2) 80 bytes {4} [initial] [rendered]
+chunk    {0} vendor2.js (vendor2) 78 bytes {4} [initial] [rendered]
     > vendor2 [6] multi ./vendor2 
-    [1] ./vendor2.js 52 bytes {0} [built]
+    [1] ./vendor2.js 50 bytes {0} [built]
         cjs require ./vendor2 [2] ./pageA.js 3:0-20
         single entry ./vendor2 [6] multi ./vendor2 vendor2:100000
     [6] multi ./vendor2 28 bytes {0} [built]
@@ -341,9 +346,9 @@ chunk    {1} pageC.js (pageC) 25 bytes {0} [initial] [rendered]
 chunk    {2} pageB.js (pageB) 25 bytes {0} [initial] [rendered]
     > pageB [3] ./pageB.js 
     [3] ./pageB.js 25 bytes {2} [built]
-chunk    {3} pageA.js (pageA) 73 bytes {0} [initial] [rendered]
+chunk    {3} pageA.js (pageA) 70 bytes {0} [initial] [rendered]
     > pageA [2] ./pageA.js 
-    [2] ./pageA.js 73 bytes {3} [built]
+    [2] ./pageA.js 70 bytes {3} [built]
 chunk    {4} vendor1.js (vendor1) 55 bytes [entry] [rendered]
     > vendor1 [5] multi ./vendor1 
     [0] ./vendor1.js 27 bytes {4} [built]

--- a/examples/web-worker/README.md
+++ b/examples/web-worker/README.md
@@ -34,9 +34,9 @@ onmessage = function(event) {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -158,9 +158,9 @@ worker.onmessage = function(event) {
 /******/ 	function __webpack_require__(moduleId) {
 /******/
 /******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
+/******/ 		if(installedModules[moduleId]) {
 /******/ 			return installedModules[moduleId].exports;
-/******/
+/******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			i: moduleId,
@@ -334,75 +334,75 @@ module.exports = function() {
 ## Uncompressed
 
 ```
-Hash: 80e12ebf70d24b1c169d
-Version: webpack 2.3.2
+Hash: 4d1e840cc539240f5fa4
+Version: webpack 2.4.1
            Asset     Size  Chunks             Chunk Names
-0.hash.worker.js  1.85 kB          [emitted]  
+0.hash.worker.js  1.84 kB          [emitted]  
   hash.worker.js  4.02 kB          [emitted]  
        output.js   3.4 kB       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 311 bytes [entry] [rendered]
+chunk    {0} output.js (main) 305 bytes [entry] [rendered]
     > main [1] ./example.js 
     [0] (webpack)/~/worker-loader!./worker.js 96 bytes {0} [not cacheable] [built]
         cjs require worker-loader!./worker [1] ./example.js 1:13-46
-    [1] ./example.js 215 bytes {0} [built]
+    [1] ./example.js 209 bytes {0} [built]
 Child worker:
                Asset     Size  Chunks             Chunk Names
-    0.hash.worker.js  1.85 kB       0  [emitted]  
+    0.hash.worker.js  1.84 kB       0  [emitted]  
       hash.worker.js  4.02 kB       1  [emitted]  main
     Entrypoint main = hash.worker.js
-    chunk    {0} 0.hash.worker.js 463 bytes {1} [rendered]
+    chunk    {0} 0.hash.worker.js 457 bytes {1} [rendered]
         > [1] ./worker.js 3:1-5:3
         [0] ../require.context/templates ^\.\/.*$ 217 bytes {0} [built]
             amd require context ../require.context/templates [1] ./worker.js 3:1-5:3
-        [2] ../require.context/templates/a.js 82 bytes {0} [optional] [built]
+        [2] ../require.context/templates/a.js 80 bytes {0} [optional] [built]
             context element ./a [0] ../require.context/templates ^\.\/.*$ ./a
             context element ./a.js [0] ../require.context/templates ^\.\/.*$ ./a.js
-        [3] ../require.context/templates/b.js 82 bytes {0} [optional] [built]
+        [3] ../require.context/templates/b.js 80 bytes {0} [optional] [built]
             context element ./b [0] ../require.context/templates ^\.\/.*$ ./b
             context element ./b.js [0] ../require.context/templates ^\.\/.*$ ./b.js
-        [4] ../require.context/templates/c.js 82 bytes {0} [optional] [built]
+        [4] ../require.context/templates/c.js 80 bytes {0} [optional] [built]
             context element ./c [0] ../require.context/templates ^\.\/.*$ ./c
             context element ./c.js [0] ../require.context/templates ^\.\/.*$ ./c.js
-    chunk    {1} hash.worker.js (main) 168 bytes [entry] [rendered]
+    chunk    {1} hash.worker.js (main) 162 bytes [entry] [rendered]
         > main [1] ./worker.js 
-        [1] ./worker.js 168 bytes {1} [built]
+        [1] ./worker.js 162 bytes {1} [built]
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 80e12ebf70d24b1c169d
-Version: webpack 2.3.2
+Hash: 4d1e840cc539240f5fa4
+Version: webpack 2.4.1
            Asset       Size  Chunks             Chunk Names
 0.hash.worker.js  544 bytes          [emitted]  
-  hash.worker.js  833 bytes          [emitted]  
-       output.js  665 bytes       0  [emitted]  main
+  hash.worker.js  826 bytes          [emitted]  
+       output.js  658 bytes       0  [emitted]  main
 Entrypoint main = output.js
-chunk    {0} output.js (main) 311 bytes [entry] [rendered]
+chunk    {0} output.js (main) 305 bytes [entry] [rendered]
     > main [1] ./example.js 
     [0] (webpack)/~/worker-loader!./worker.js 96 bytes {0} [not cacheable] [built]
         cjs require worker-loader!./worker [1] ./example.js 1:13-46
-    [1] ./example.js 215 bytes {0} [built]
+    [1] ./example.js 209 bytes {0} [built]
 Child worker:
                Asset       Size  Chunks             Chunk Names
     0.hash.worker.js  544 bytes       0  [emitted]  
-      hash.worker.js  833 bytes       1  [emitted]  main
+      hash.worker.js  826 bytes       1  [emitted]  main
     Entrypoint main = hash.worker.js
-    chunk    {0} 0.hash.worker.js 463 bytes {1} [rendered]
+    chunk    {0} 0.hash.worker.js 457 bytes {1} [rendered]
         > [1] ./worker.js 3:1-5:3
         [0] ../require.context/templates ^\.\/.*$ 217 bytes {0} [built]
             amd require context ../require.context/templates [1] ./worker.js 3:1-5:3
-        [2] ../require.context/templates/a.js 82 bytes {0} [optional] [built]
+        [2] ../require.context/templates/a.js 80 bytes {0} [optional] [built]
             context element ./a [0] ../require.context/templates ^\.\/.*$ ./a
             context element ./a.js [0] ../require.context/templates ^\.\/.*$ ./a.js
-        [3] ../require.context/templates/b.js 82 bytes {0} [optional] [built]
+        [3] ../require.context/templates/b.js 80 bytes {0} [optional] [built]
             context element ./b [0] ../require.context/templates ^\.\/.*$ ./b
             context element ./b.js [0] ../require.context/templates ^\.\/.*$ ./b.js
-        [4] ../require.context/templates/c.js 82 bytes {0} [optional] [built]
+        [4] ../require.context/templates/c.js 80 bytes {0} [optional] [built]
             context element ./c [0] ../require.context/templates ^\.\/.*$ ./c
             context element ./c.js [0] ../require.context/templates ^\.\/.*$ ./c.js
-    chunk    {1} hash.worker.js (main) 168 bytes [entry] [rendered]
+    chunk    {1} hash.worker.js (main) 162 bytes [entry] [rendered]
         > main [1] ./worker.js 
-        [1] ./worker.js 168 bytes {1} [built]
+        [1] ./worker.js 162 bytes {1} [built]
 ```


### PR DESCRIPTION
👕⚒ auto lint fixes in examples/build-common & examples/build-all
📦⬆🕸🛅 using latest webpack version to build examples

with the linted build-common & build-all:

### result

#### updated version
<img width="171" alt="screen shot 2017-04-19 at 4 08 29 am" src="https://cloud.githubusercontent.com/assets/4022631/25177586/7ee85a60-24b7-11e7-98c0-8f8501ab8b38.png">

#### more readable paths
<img width="440" alt="screen shot 2017-04-19 at 4 06 58 am" src="https://cloud.githubusercontent.com/assets/4022631/25177589/8005980e-24b7-11e7-828d-27ee93af5402.png">

#### improved file sizes & build times
<img width="479" alt="screen shot 2017-04-19 at 4 06 44 am" src="https://cloud.githubusercontent.com/assets/4022631/25177590/8149f052-24b7-11e7-8391-38316dfc6854.png">