### PR TITLE
update node linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,7 +51,7 @@ module.exports = {
 		}],
 		"no-console": "off",
 		"valid-jsdoc": "error",
-		"node/no-unsupported-features": ["error", { version: 7 }],
+		"node/no-unsupported-features": ["error", { version: 4 }],
 		"node/no-deprecated-api": "error",
 		"node/no-missing-import": "error",
 		"node/no-missing-require": [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,9 +4,9 @@ module.exports = {
 	"extends": ["eslint:recommended", "plugin:node/recommended"],
 	"env": {
 		"node": true,
-    "es6": true,
+		"es6": true,
 	},
-  "parserOptions": {"ecmaVersion": 2017},
+	"parserOptions": { "ecmaVersion": 2017 },
 	"rules": {
 		"quotes": ["error", "double"],
 		"no-undef": "error",
@@ -28,7 +28,7 @@ module.exports = {
 		"space-in-parens": "error",
 		"no-trailing-spaces": "error",
 		"no-use-before-define": "off",
-		"no-unused-vars": ["error", {"args": "none"}],
+		"no-unused-vars": ["error", { "args": "none" }],
 		"key-spacing": "error",
 		"space-infix-ops": "error",
 		"no-unsafe-negation": "error",
@@ -39,31 +39,31 @@ module.exports = {
 		"keyword-spacing": ["error", {
 			"after": false,
 			"overrides": {
-				"const": {"after": true},
-				"try": {"after": true},
-				"else": {"after": true},
-				"throw": {"after": true},
-				"case": {"after": true},
-				"return": {"after": true},
-				"finally": {"after": true},
-				"do": {"after": true}
+				"const": { "after": true },
+				"try": { "after": true },
+				"else": { "after": true },
+				"throw": { "after": true },
+				"case": { "after": true },
+				"return": { "after": true },
+				"finally": { "after": true },
+				"do": { "after": true }
 			}
 		}],
 		"no-console": "off",
 		"valid-jsdoc": "error",
-    "node/no-unsupported-features": ["error", {version: 7}],
-    "node/no-deprecated-api": "error",
-    "node/no-missing-import": "error",
-    "node/no-missing-require": [
-      "error",
-      {
-        "allowModules": [
-          "webpack"
-        ]
-      }
-    ],
-    "node/no-unpublished-bin": "error",
-    "node/no-unpublished-require": "error",
-    "node/process-exit-as-throw": "error"
+		"node/no-unsupported-features": ["error", { version: 7 }],
+		"node/no-deprecated-api": "error",
+		"node/no-missing-import": "error",
+		"node/no-missing-require": [
+			"error",
+			{
+				"allowModules": [
+					"webpack"
+				]
+			}
+		],
+		"node/no-unpublished-bin": "error",
+		"node/no-unpublished-require": "error",
+		"node/process-exit-as-throw": "error"
 	}
-}
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,12 @@
-{
+module.exports = {
 	"root": true,
 	"plugins": ["node"],
 	"extends": ["eslint:recommended", "plugin:node/recommended"],
 	"env": {
-		"node": true
+		"node": true,
+    "es6": true,
 	},
+  "parserOptions": {"ecmaVersion": 2017},
 	"rules": {
 		"quotes": ["error", "double"],
 		"no-undef": "error",
@@ -37,6 +39,7 @@
 		"keyword-spacing": ["error", {
 			"after": false,
 			"overrides": {
+				"const": {"after": true},
 				"try": {"after": true},
 				"else": {"after": true},
 				"throw": {"after": true},
@@ -47,7 +50,20 @@
 			}
 		}],
 		"no-console": "off",
-		"valid-jsdoc": "error"
+		"valid-jsdoc": "error",
+    "node/no-unsupported-features": ["error", {version: 7}],
+    "node/no-deprecated-api": "error",
+    "node/no-missing-import": "error",
+    "node/no-missing-require": [
+      "error",
+      {
+        "allowModules": [
+          "webpack"
+        ]
+      }
+    ],
+    "node/no-unpublished-bin": "error",
+    "node/no-unpublished-require": "error",
+    "node/process-exit-as-throw": "error"
 	}
 }
-


### PR DESCRIPTION
update linting for destructuring and latest node

uses .js rather than .eslintrc file

pulls in rules from
https://github.com/webpack/webpack-cli/pull/46/files#diff-df39304d828831c44a2b9f38cd45289cR40

adds spacing for this
<img width="495" alt="screen shot 2017-04-19 at 7 03 16 pm" src="https://cloud.githubusercontent.com/assets/4022631/25210014/eabff164-2532-11e7-89a3-837fde6c7101.png">
