### PR TITLE
Disable manifest.json pretty print

### DIFF
--- a/lib/LibManifestPlugin.js
+++ b/lib/LibManifestPlugin.js
@@ -46,7 +46,7 @@ class LibManifestPlugin {
 						return obj;
 					}, {})
 				};
-				const content = new Buffer(JSON.stringify(manifest, null, 2), "utf8"); //eslint-disable-line
+				const content = new Buffer(JSON.stringify(manifest), "utf8"); //eslint-disable-line
 				compiler.outputFileSystem.mkdirp(path.dirname(targetPath), err => {
 					if(err) return callback(err);
 					compiler.outputFileSystem.writeFile(targetPath, content, callback);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
feature/refactoring

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No. As far as I have seen this doesn't affect how the generated `manifest.json` file is tested.

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
This disables the JSON pretty print of the - through `DLLPlugin` generated - `manifest.json` file for smaller file size as suggested here https://github.com/webpack/webpack/issues/4477.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No, unless somebody heavily relies on the pretty printed `manifest.json` file.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
In case this becomes a breaking change, we could add an option for this as it was suggested in the linked issue.

**Other information**
N/A