### PR TITLE
Perf/use Date.now() instead of +new Date()/new Date().getTime()

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -201,7 +201,7 @@ class Compilation extends Tapable {
 
 	addModuleDependencies(module, dependencies, bail, cacheGroup, recursive, callback) {
 		let _this = this;
-		const start = _this.profile && +new Date();
+		const start = _this.profile && Date.now();
 
 		const factories = [];
 		for(let i = 0; i < dependencies.length; i++) {
@@ -270,7 +270,7 @@ class Compilation extends Tapable {
 					if(!dependentModule.profile) {
 						dependentModule.profile = {};
 					}
-					afterFactory = +new Date();
+					afterFactory = Date.now();
 					dependentModule.profile.factory = afterFactory - start;
 				}
 
@@ -290,7 +290,7 @@ class Compilation extends Tapable {
 						if(!module.profile) {
 							module.profile = {};
 						}
-						const time = +new Date() - start;
+						const time = Date.now() - start;
 						if(!module.profile.dependencies || time > module.profile.dependencies) {
 							module.profile.dependencies = time;
 						}
@@ -311,7 +311,7 @@ class Compilation extends Tapable {
 					iterationDependencies(dependencies);
 
 					if(_this.profile) {
-						const afterBuilding = +new Date();
+						const afterBuilding = Date.now();
 						module.profile.building = afterBuilding - afterFactory;
 					}
 
@@ -332,7 +332,7 @@ class Compilation extends Tapable {
 					}
 
 					if(_this.profile) {
-						const afterBuilding = +new Date();
+						const afterBuilding = Date.now();
 						dependentModule.profile.building = afterBuilding - afterFactory;
 					}
 
@@ -360,7 +360,7 @@ class Compilation extends Tapable {
 	}
 
 	_addModuleChain(context, dependency, onModule, callback) {
-		const start = this.profile && +new Date();
+		const start = this.profile && Date.now();
 
 		const errorAndCallback = this.bail ? function errorAndCallback(err) {
 			callback(err);
@@ -397,7 +397,7 @@ class Compilation extends Tapable {
 				if(!module.profile) {
 					module.profile = {};
 				}
-				afterFactory = +new Date();
+				afterFactory = Date.now();
 				module.profile.factory = afterFactory - start;
 			}
 
@@ -408,7 +408,7 @@ class Compilation extends Tapable {
 				onModule(module);
 
 				if(this.profile) {
-					const afterBuilding = +new Date();
+					const afterBuilding = Date.now();
 					module.profile.building = afterBuilding - afterFactory;
 				}
 
@@ -436,7 +436,7 @@ class Compilation extends Tapable {
 				}
 
 				if(this.profile) {
-					const afterBuilding = +new Date();
+					const afterBuilding = Date.now();
 					module.profile.building = afterBuilding - afterFactory;
 				}
 

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -36,7 +36,7 @@ function Watching(compiler, watchOptions, handler) {
 
 Watching.prototype._go = function() {
 	var self = this;
-	self.startTime = new Date().getTime();
+	self.startTime = Date.now();
 	self.running = true;
 	self.invalid = false;
 	self.compiler.applyPluginsAsync("watch-run", self, function(err) {
@@ -61,7 +61,7 @@ Watching.prototype._go = function() {
 
 						var stats = new Stats(compilation);
 						stats.startTime = self.startTime;
-						stats.endTime = new Date().getTime();
+						stats.endTime = Date.now();
 						self.compiler.applyPlugins("done", stats);
 
 						self.compiler.applyPluginsAsync("additional-pass", function(err) {
@@ -80,7 +80,7 @@ Watching.prototype._go = function() {
 Watching.prototype._getStats = function(compilation) {
 	var stats = new Stats(compilation);
 	stats.startTime = this.startTime;
-	stats.endTime = new Date().getTime();
+	stats.endTime = Date.now();
 	return stats;
 };
 
@@ -222,7 +222,7 @@ Compiler.prototype.watch = function(watchOptions, handler) {
 
 Compiler.prototype.run = function(callback) {
 	var self = this;
-	var startTime = new Date().getTime();
+	var startTime = Date.now();
 
 	self.applyPluginsAsync("before-run", self, function(err) {
 		if(err) return callback(err);
@@ -239,7 +239,7 @@ Compiler.prototype.run = function(callback) {
 					if(self.applyPluginsBailResult("should-emit", compilation) === false) {
 						var stats = new Stats(compilation);
 						stats.startTime = startTime;
-						stats.endTime = new Date().getTime();
+						stats.endTime = Date.now();
 						self.applyPlugins("done", stats);
 						return callback(null, stats);
 					}
@@ -252,7 +252,7 @@ Compiler.prototype.run = function(callback) {
 
 							var stats = new Stats(compilation);
 							stats.startTime = startTime;
-							stats.endTime = new Date().getTime();
+							stats.endTime = Date.now();
 							self.applyPlugins("done", stats);
 
 							self.applyPluginsAsync("additional-pass", function(err) {
@@ -267,7 +267,7 @@ Compiler.prototype.run = function(callback) {
 
 							var stats = new Stats(compilation);
 							stats.startTime = startTime;
-							stats.endTime = new Date().getTime();
+							stats.endTime = Date.now();
 							self.applyPlugins("done", stats);
 							return callback(null, stats);
 						});

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -99,7 +99,7 @@ class ContextModule extends Module {
 
 	build(options, compilation, resolver, fs, callback) {
 		this.built = true;
-		this.builtTime = new Date().getTime();
+		this.builtTime = Date.now();
 		this.resolveDependencies(fs, this.context, this.recursive, this.regExp, (err, dependencies) => {
 			if(err) return callback(err);
 

--- a/lib/DelegatedModule.js
+++ b/lib/DelegatedModule.js
@@ -37,7 +37,7 @@ class DelegatedModule extends Module {
 
 	build(options, compilation, resolver, fs, callback) {
 		this.built = true;
-		this.builtTime = new Date().getTime();
+		this.builtTime = Date.now();
 		this.usedExports = true;
 		this.providedExports = this.delegateData.exports || true;
 		this.dependencies.length = 0;

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -35,7 +35,7 @@ class ExternalModule extends Module {
 	}
 
 	build(options, compilation, resolver, fs, callback) {
-		this.builtTime = new Date().getTime();
+		this.builtTime = Date.now();
 		callback();
 	}
 

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -257,7 +257,7 @@ class NormalModule extends Module {
 	}
 
 	build(options, compilation, resolver, fs, callback) {
-		this.buildTimestamp = new Date().getTime();
+		this.buildTimestamp = Date.now();
 		this.built = true;
 		this._source = null;
 		this.error = null;

--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -157,9 +157,9 @@ class ProgressPlugin {
 				state = state.replace(/^\d+\/\d+\s+/, "");
 				if(percentage === 0) {
 					lastState = null;
-					lastStateTime = +new Date();
+					lastStateTime = Date.now();
 				} else if(state !== lastState || percentage === 1) {
-					const now = +new Date();
+					const now = Date.now();
 					if(lastState) {
 						const stateMsg = `${now - lastStateTime}ms ${lastState}`;
 						goToLineStart(stateMsg);

--- a/lib/RawModule.js
+++ b/lib/RawModule.js
@@ -36,7 +36,7 @@ module.exports = class RawModule extends Module {
 	}
 
 	build(options, compilations, resolver, fs, callback) {
-		this.builtTime = new Date().getTime();
+		this.builtTime = Date.now();
 		callback();
 	}
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Slightly improved performance.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Nope. But if you insist I could write some test on equivalence between `Date.now()`, `+new Date()` and `new Date().getTime()`.
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
No documentation update since it is internal minor change.
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Use `Date.now()` for slightly better performance since we don't do any manipulation on the created `Date` instance.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


**Does this PR introduce a breaking change?**
Nope.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->


**Other information**
Crystal clear.