### PR TITLE
Dynamically evaluate global object for webpackJsonp

### DIFF
--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -124,9 +124,18 @@ class JsonpMainTemplatePlugin {
 				return this.asString([
 					source,
 					"",
+					"var __global = (function() {",
+					this.indent([
+						"if (typeof window !== 'undefined') { return window; }",
+						"if (typeof self !== 'undefined') { return self; }",
+						"if (typeof global !== 'undefined') { return global; }",
+						"throw new Error('unable to locate global object');"
+					]),
+					"})();",
+					"",
 					"// install a JSONP callback for chunk loading",
-					`var parentJsonpFunction = window[${JSON.stringify(jsonpFunction)}];`,
-					`window[${JSON.stringify(jsonpFunction)}] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {`,
+					`var parentJsonpFunction = __global[${JSON.stringify(jsonpFunction)}];`,
+					`__global[${JSON.stringify(jsonpFunction)}] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {`,
 					this.indent([
 						"// add \"moreModules\" to the modules object,",
 						"// then flag all \"chunkIds\" as loaded and fire callback",

--- a/test/statsCases/aggressive-splitting-on-demand/expected.txt
+++ b/test/statsCases/aggressive-splitting-on-demand/expected.txt
@@ -6,7 +6,7 @@ cd45585186d59208602b.js    1.96 kB       1  [emitted]
 6b94c231e016c5aaccdb.js    1.94 kB       2  [emitted]  
 fd0985cee894c4f3f1a6.js    1.94 kB       3  [emitted]  
 d9fc46873c8ea924b895.js  979 bytes       4  [emitted]  
-beecea47f9a8ded3c298.js    7.54 kB       6  [emitted]  main
+beecea47f9a8ded3c298.js    7.86 kB       6  [emitted]  main
 b08c507d4e1e05cbab45.js  985 bytes       9  [emitted]  
 5d50e858fe6e559aa47c.js  977 bytes      11  [emitted]  
 Entrypoint main = beecea47f9a8ded3c298.js

--- a/test/statsCases/chunks/expected.txt
+++ b/test/statsCases/chunks/expected.txt
@@ -4,7 +4,7 @@ Time: Xms
 0.bundle.js  238 bytes       0  [emitted]  
 1.bundle.js  108 bytes       1  [emitted]  
 2.bundle.js  204 bytes       2  [emitted]  
-  bundle.js    6.18 kB       3  [emitted]  main
+  bundle.js     6.5 kB       3  [emitted]  main
 chunk    {0} 0.bundle.js 54 bytes {3} [rendered]
     > [5] (webpack)/test/statsCases/chunks/index.js 3:0-16
     [2] (webpack)/test/statsCases/chunks/c.js 54 bytes {0} [built]

--- a/test/statsCases/commons-chunk-min-size-0/expected.txt
+++ b/test/statsCases/commons-chunk-min-size-0/expected.txt
@@ -2,7 +2,7 @@ Hash: dc6038bec87a57d1a45e
 Time: Xms
       Asset      Size  Chunks             Chunk Names
  entry-1.js  25 bytes       0  [emitted]  entry-1
-vendor-1.js   6.84 kB       1  [emitted]  vendor-1
+vendor-1.js   7.16 kB       1  [emitted]  vendor-1
 chunk    {0} entry-1.js (entry-1) 0 bytes {1} [initial] [rendered]
 chunk    {1} vendor-1.js (vendor-1) 329 bytes [entry] [rendered]
     [0] (webpack)/test/statsCases/commons-chunk-min-size-0/modules/a.js 22 bytes {1} [built]

--- a/test/statsCases/limit-chunk-count-plugin/expected.txt
+++ b/test/statsCases/limit-chunk-count-plugin/expected.txt
@@ -16,7 +16,7 @@ Child
     Time: Xms
           Asset       Size  Chunks             Chunk Names
     0.bundle.js  592 bytes       0  [emitted]  
-      bundle.js     6.2 kB       1  [emitted]  main
+      bundle.js    6.52 kB       1  [emitted]  main
     chunk    {0} 0.bundle.js 118 bytes {1} [rendered]
         [0] (webpack)/test/statsCases/limit-chunk-count-plugin/a.js 22 bytes {0} [built]
         [1] (webpack)/test/statsCases/limit-chunk-count-plugin/b.js 22 bytes {0} [built]
@@ -31,7 +31,7 @@ Child
           Asset       Size  Chunks             Chunk Names
     0.bundle.js  445 bytes       0  [emitted]  
     1.bundle.js  204 bytes       1  [emitted]  
-      bundle.js    6.19 kB       2  [emitted]  main
+      bundle.js    6.51 kB       2  [emitted]  main
     chunk    {0} 0.bundle.js 74 bytes {2} [rendered]
         [0] (webpack)/test/statsCases/limit-chunk-count-plugin/a.js 22 bytes {0} [built]
         [2] (webpack)/test/statsCases/limit-chunk-count-plugin/c.js 30 bytes {0} [built]
@@ -48,7 +48,7 @@ Child
     0.bundle.js  204 bytes       0  [emitted]  
     1.bundle.js  195 bytes       1  [emitted]  
     2.bundle.js  283 bytes       2  [emitted]  
-      bundle.js    6.18 kB       3  [emitted]  main
+      bundle.js     6.5 kB       3  [emitted]  main
     chunk    {0} 0.bundle.js 44 bytes {2} {3} [rendered]
         [1] (webpack)/test/statsCases/limit-chunk-count-plugin/b.js 22 bytes {0} [built]
         [4] (webpack)/test/statsCases/limit-chunk-count-plugin/e.js 22 bytes {0} [built]

--- a/test/statsCases/named-chunks-plugin-async/expected.txt
+++ b/test/statsCases/named-chunks-plugin-async/expected.txt
@@ -3,7 +3,7 @@ Time: Xms
                      Asset       Size                   Chunks             Chunk Names
 chunk-containing-__a_js.js  266 bytes  chunk-containing-__a_js  [emitted]  
 chunk-containing-__b_js.js  123 bytes  chunk-containing-__b_js  [emitted]  
-                  entry.js    6.07 kB                    entry  [emitted]  entry
+                  entry.js    6.39 kB                    entry  [emitted]  entry
 chunk {chunk-containing-__a_js} chunk-containing-__a_js.js 37 bytes {entry} [rendered]
     [2] (webpack)/test/statsCases/named-chunks-plugin-async/modules/a.js 37 bytes {chunk-containing-__a_js} [built]
 chunk {chunk-containing-__b_js} chunk-containing-__b_js.js 22 bytes {chunk-containing-__a_js} {entry} [rendered]

--- a/test/statsCases/named-chunks-plugin/expected.txt
+++ b/test/statsCases/named-chunks-plugin/expected.txt
@@ -2,7 +2,7 @@ Hash: ac63e5be974bcdfea3a3
 Time: Xms
       Asset       Size    Chunks             Chunk Names
    entry.js  345 bytes     entry  [emitted]  entry
-manifest.js    5.86 kB  manifest  [emitted]  manifest
+manifest.js    6.18 kB  manifest  [emitted]  manifest
   vendor.js  397 bytes    vendor  [emitted]  vendor
 chunk {entry} entry.js (entry) 94 bytes {vendor} [initial] [rendered]
  [./entry.js] (webpack)/test/statsCases/named-chunks-plugin/entry.js 72 bytes {entry} [built]

--- a/test/statsCases/optimize-chunks/expected.txt
+++ b/test/statsCases/optimize-chunks/expected.txt
@@ -8,7 +8,7 @@ Time: Xms
    4.js  140 bytes    4, 6  [emitted]  chunk
    5.js  306 bytes    5, 3  [emitted]  cir2 from cir1
    6.js   80 bytes       6  [emitted]  ac in ab
-main.js    6.85 kB       7  [emitted]  main
+main.js    7.17 kB       7  [emitted]  main
 chunk    {0} 0.js (cir1) 81 bytes {3} {5} {7} [rendered]
     > duplicate cir1 from cir2 [3] (webpack)/test/statsCases/optimize-chunks/circular2.js 1:0-79
     > duplicate cir1 [7] (webpack)/test/statsCases/optimize-chunks/index.js 13:0-54

--- a/test/statsCases/preset-normal-performance-ensure-filter-sourcemaps/expected.txt
+++ b/test/statsCases/preset-normal-performance-ensure-filter-sourcemaps/expected.txt
@@ -3,7 +3,7 @@ Time: <CLR=BOLD>X</CLR>ms
        <CLR=32,BOLD>0.js</CLR>  268 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
        <CLR=32,BOLD>1.js</CLR>  138 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
        <CLR=32,BOLD>2.js</CLR>  234 bytes       <CLR=BOLD>2</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
-    <CLR=33,BOLD>main.js</CLR>     <CLR=33,BOLD>306 kB</CLR>       <CLR=BOLD>3</CLR>  <CLR=32,BOLD>[emitted]</CLR>  <CLR=33,BOLD>[big]</CLR>  main
+    <CLR=33,BOLD>main.js</CLR>     <CLR=33,BOLD>307 kB</CLR>       <CLR=BOLD>3</CLR>  <CLR=32,BOLD>[emitted]</CLR>  <CLR=33,BOLD>[big]</CLR>  main
    <CLR=32,BOLD>0.js.map</CLR>  291 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
    <CLR=32,BOLD>1.js.map</CLR>  250 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
    <CLR=32,BOLD>2.js.map</CLR>  405 bytes       <CLR=BOLD>2</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
@@ -22,10 +22,10 @@ chunk    {<CLR=33,BOLD>3</CLR>} <CLR=32,BOLD>main.js, main.js.map</CLR> (main) 3
 <CLR=33,BOLD>WARNING in asset size limit: The following asset(s) exceed the recommended size limit (250 kB).
 This can impact web performance.
 Assets: 
-  main.js (306 kB)</CLR>
+  main.js (307 kB)</CLR>
 
 <CLR=33,BOLD>WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (250 kB). This can impact web performance.
 Entrypoints:
-  main (306 kB)
+  main (307 kB)
       main.js
 </CLR>

--- a/test/statsCases/preset-verbose/expected.txt
+++ b/test/statsCases/preset-verbose/expected.txt
@@ -4,7 +4,7 @@ Time: Xms
    0.js  238 bytes       0  [emitted]  
    1.js  108 bytes       1  [emitted]  
    2.js  204 bytes       2  [emitted]  
-main.js    6.18 kB       3  [emitted]  main
+main.js     6.5 kB       3  [emitted]  main
 Entrypoint main = main.js
 chunk    {0} 0.js 54 bytes {3} [rendered]
     [2] (webpack)/test/statsCases/preset-verbose/c.js 54 bytes {0} [depth 1] [built]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix (Issue: #4819)

**Did you add tests for your changes?**

There aren't any tests for `JsonpMainTemplatePlugin`...? I may just be totally missing them but I can't find them.

**If relevant, link to documentation update:**

N/A

**Summary**

Allows users to load Chunked modules in more than just the main browser thread (i.e. Worker threads)

**Does this PR introduce a breaking change?**

no

**Other information**

I followed the approach outlined in https://github.com/tc39/proposal-global
for evaluating the global scope dynamically (modified to prioritize the
window object if available)