### PR TITLE
Fix _done function not dealing with compilation being undefined

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -88,7 +88,7 @@ Watching.prototype._done = function(err, compilation) {
 	this.running = false;
 	if(this.invalid) return this._go();
 
-	var stats = this._getStats(compilation);
+	var stats = compilation ? this._getStats(compilation) : null;
 	if(err) {
 		this.compiler.applyPlugins("failed", err);
 		this.handler(err, stats);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

#3934 introduced a bug as the title says, this fixes that.

**Did you add tests for your changes?**

No, any pointer to where add this test too? It seems there are no tests for the watcher handler being called correctly with `err`.

**Summary**

This should land ASAP because currently webpack is broken for errors in some plugins.

**Does this PR introduce a breaking change?**

No.

**Other information**

None.
