### PR TITLE
Auto-add names to factory functions in FunctionModuleTemplatePlugin

### DIFF
--- a/lib/FunctionModuleTemplatePlugin.js
+++ b/lib/FunctionModuleTemplatePlugin.js
@@ -14,7 +14,10 @@ class FunctionModuleTemplatePlugin {
 			if((module.arguments && module.arguments.length !== 0) || module.hasDependencies(d => d.requireWebpackRequire !== false)) {
 				defaultArguments.push("__webpack_require__");
 			}
-			source.add("/***/ (function(" + defaultArguments.concat(module.arguments || []).join(", ") + ") {\n\n");
+			const moduleName = this.outputOptions.pathinfo
+				? " " + module.readableIdentifier(this.requestShortener).replace(/[^a-z0-9\/]+/gi, "_").replace(/\//g, "$") :
+				: "";
+			source.add("/***/ (function" + moduleName + "(" + defaultArguments.concat(module.arguments || []).join(", ") + ") {\n\n");
 			if(module.strict) source.add("\"use strict\";\n");
 			source.add(moduleSource);
 			source.add("\n\n/***/ })");


### PR DESCRIPTION
I was trying to profile my app's startup in the Chrome devtools. I got this:

![image](https://cloud.githubusercontent.com/assets/6820/25933551/5d0f4d10-35cc-11e7-8726-08396a7a96b5.png)

Unfortunately, each of the "(anonymous)" blocks is a module factory created by webpack, and it's not easy to tell which is which.

This commit adds a slightly mangled version of the path name as that factory function's name, which gives us a profile that is actually useful:

![image](https://cloud.githubusercontent.com/assets/6820/25933580/9d2e8820-35cc-11e7-8c8f-c94da92d1286.png)

Much better.

~~

**What kind of change does this PR introduce?**

minor feature

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

no
