### PR TITLE
Set "var result" only if needed

### DIFF
--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -131,7 +131,7 @@ class JsonpMainTemplatePlugin {
 					this.indent([
 						"// add \"moreModules\" to the modules object,",
 						"// then flag all \"chunkIds\" as loaded and fire callback",
-						"var moduleId, chunkId, i = 0, resolves = [], result;",
+						"var moduleId, chunkId, i = 0, resolves = [];",
 						"for(;i < chunkIds.length; i++) {",
 						this.indent([
 							"chunkId = chunkIds[i];",
@@ -153,6 +153,7 @@ class JsonpMainTemplatePlugin {
 						this.indent("resolves.shift()();"),
 						"}",
 						this.entryPointInChildren(chunk) ? [
+							"var result;",
 							"if(executeModules) {",
 							this.indent([
 								"for(i=0; i < executeModules.length; i++) {",

--- a/test/statsCases/aggressive-splitting-on-demand/expected.txt
+++ b/test/statsCases/aggressive-splitting-on-demand/expected.txt
@@ -6,7 +6,7 @@ cd45585186d59208602b.js    1.96 kB       1  [emitted]
 6b94c231e016c5aaccdb.js    1.94 kB       2  [emitted]  
 fd0985cee894c4f3f1a6.js    1.94 kB       3  [emitted]  
 d9fc46873c8ea924b895.js  979 bytes       4  [emitted]  
-a773fee259e5a284dea9.js    7.47 kB       6  [emitted]  main
+a773fee259e5a284dea9.js    7.46 kB       6  [emitted]  main
 b08c507d4e1e05cbab45.js  985 bytes       9  [emitted]  
 5d50e858fe6e559aa47c.js  977 bytes      11  [emitted]  
 Entrypoint main = a773fee259e5a284dea9.js

--- a/test/statsCases/commons-chunk-min-size-0/expected.txt
+++ b/test/statsCases/commons-chunk-min-size-0/expected.txt
@@ -2,7 +2,7 @@ Hash: dc6038bec87a57d1a45e
 Time: Xms
       Asset      Size  Chunks             Chunk Names
  entry-1.js  25 bytes       0  [emitted]  entry-1
-vendor-1.js   6.76 kB       1  [emitted]  vendor-1
+vendor-1.js   6.78 kB       1  [emitted]  vendor-1
    [0] (webpack)/test/statsCases/commons-chunk-min-size-0/modules/a.js 22 bytes {1} [built]
    [1] (webpack)/test/statsCases/commons-chunk-min-size-0/modules/b.js 22 bytes {1} [built]
    [2] (webpack)/test/statsCases/commons-chunk-min-size-0/modules/c.js 22 bytes {1} [built]

--- a/test/statsCases/commons-plugin-issue-4980/expected.txt
+++ b/test/statsCases/commons-plugin-issue-4980/expected.txt
@@ -5,7 +5,7 @@ Child
                              Asset       Size  Chunks             Chunk Names
                             app.js    1.27 kB       0  [emitted]  app
     vendor.bd2b4219dfda1a951495.js  443 bytes       1  [emitted]  vendor
-                        runtime.js    5.78 kB       2  [emitted]  runtime
+                        runtime.js    5.79 kB       2  [emitted]  runtime
     [./constants.js] (webpack)/test/statsCases/commons-plugin-issue-4980/constants.js 87 bytes {1} [built]
     [./entry-1.js] (webpack)/test/statsCases/commons-plugin-issue-4980/entry-1.js 67 bytes {0} [built]
     [./submodule-a.js] (webpack)/test/statsCases/commons-plugin-issue-4980/submodule-a.js 59 bytes {0} [built]
@@ -16,7 +16,7 @@ Child
                              Asset       Size  Chunks             Chunk Names
                             app.js    1.32 kB       0  [emitted]  app
     vendor.bd2b4219dfda1a951495.js  443 bytes       1  [emitted]  vendor
-                        runtime.js    5.78 kB       2  [emitted]  runtime
+                        runtime.js    5.79 kB       2  [emitted]  runtime
     [./constants.js] (webpack)/test/statsCases/commons-plugin-issue-4980/constants.js 87 bytes {1} [built]
     [./entry-2.js] (webpack)/test/statsCases/commons-plugin-issue-4980/entry-2.js 67 bytes {0} [built]
     [./submodule-a.js] (webpack)/test/statsCases/commons-plugin-issue-4980/submodule-a.js 59 bytes {0} [built]

--- a/test/statsCases/import-weak/expected.txt
+++ b/test/statsCases/import-weak/expected.txt
@@ -2,7 +2,7 @@ Hash: d34cc0bd2faeb65c3282
 Time: Xms
    Asset      Size  Chunks             Chunk Names
     0.js  99 bytes       0  [emitted]  
-entry.js   6.22 kB       1  [emitted]  entry
+entry.js   6.21 kB       1  [emitted]  entry
    [0] (webpack)/test/statsCases/import-weak/modules/b.js 22 bytes {0} [built]
    [1] (webpack)/test/statsCases/import-weak/entry.js 120 bytes {1} [built]
    [2] (webpack)/test/statsCases/import-weak/modules/a.js 37 bytes [built]

--- a/test/statsCases/limit-chunk-count-plugin/expected.txt
+++ b/test/statsCases/limit-chunk-count-plugin/expected.txt
@@ -16,7 +16,7 @@ Child
     Time: Xms
           Asset       Size  Chunks             Chunk Names
     0.bundle.js  601 bytes       0  [emitted]  
-      bundle.js    6.12 kB       1  [emitted]  main
+      bundle.js    6.11 kB       1  [emitted]  main
     chunk    {0} 0.bundle.js 118 bytes {1} [rendered]
         [1] (webpack)/test/statsCases/limit-chunk-count-plugin/a.js 22 bytes {0} [built]
         [2] (webpack)/test/statsCases/limit-chunk-count-plugin/b.js 22 bytes {0} [built]
@@ -31,7 +31,7 @@ Child
           Asset       Size  Chunks             Chunk Names
     0.bundle.js  454 bytes       0  [emitted]  
     1.bundle.js  182 bytes       1  [emitted]  
-      bundle.js    6.11 kB       2  [emitted]  main
+      bundle.js     6.1 kB       2  [emitted]  main
     chunk    {0} 0.bundle.js 74 bytes {2} [rendered]
         [1] (webpack)/test/statsCases/limit-chunk-count-plugin/a.js 22 bytes {0} [built]
         [3] (webpack)/test/statsCases/limit-chunk-count-plugin/c.js 30 bytes {0} [built]
@@ -48,7 +48,7 @@ Child
     0.bundle.js  182 bytes       0  [emitted]  
     1.bundle.js  204 bytes       1  [emitted]  
     2.bundle.js  283 bytes       2  [emitted]  
-      bundle.js     6.1 kB       3  [emitted]  main
+      bundle.js    6.09 kB       3  [emitted]  main
     chunk    {0} 0.bundle.js 44 bytes {2} {3} [rendered]
         [2] (webpack)/test/statsCases/limit-chunk-count-plugin/b.js 22 bytes {0} [built]
         [5] (webpack)/test/statsCases/limit-chunk-count-plugin/e.js 22 bytes {0} [built]

--- a/test/statsCases/named-chunks-plugin-async/expected.txt
+++ b/test/statsCases/named-chunks-plugin-async/expected.txt
@@ -3,7 +3,7 @@ Time: Xms
                      Asset       Size                   Chunks             Chunk Names
 chunk-containing-__a_js.js  266 bytes  chunk-containing-__a_js  [emitted]  
 chunk-containing-__b_js.js  123 bytes  chunk-containing-__b_js  [emitted]  
-                  entry.js    5.99 kB                    entry  [emitted]  entry
+                  entry.js    5.98 kB                    entry  [emitted]  entry
    [0] (webpack)/test/statsCases/named-chunks-plugin-async/modules/b.js 22 bytes {chunk-containing-__b_js} [built]
    [1] (webpack)/test/statsCases/named-chunks-plugin-async/entry.js 47 bytes {entry} [built]
    [2] (webpack)/test/statsCases/named-chunks-plugin-async/modules/a.js 37 bytes {chunk-containing-__a_js} [built]

--- a/test/statsCases/named-chunks-plugin/expected.txt
+++ b/test/statsCases/named-chunks-plugin/expected.txt
@@ -2,7 +2,7 @@ Hash: ac63e5be974bcdfea3a3
 Time: Xms
       Asset       Size    Chunks             Chunk Names
    entry.js  345 bytes     entry  [emitted]  entry
-manifest.js    5.78 kB  manifest  [emitted]  manifest
+manifest.js     5.8 kB  manifest  [emitted]  manifest
   vendor.js  397 bytes    vendor  [emitted]  vendor
    [0] multi ./modules/a ./modules/b 40 bytes {vendor} [built]
 [./entry.js] (webpack)/test/statsCases/named-chunks-plugin/entry.js 72 bytes {entry} [built]

--- a/test/statsCases/optimize-chunks/expected.txt
+++ b/test/statsCases/optimize-chunks/expected.txt
@@ -8,7 +8,7 @@ Time: Xms
    4.js  162 bytes    4, 6  [emitted]  chunk
    5.js  306 bytes    5, 3  [emitted]  cir2 from cir1
    6.js   80 bytes       6  [emitted]  ac in ab
-main.js    6.78 kB       7  [emitted]  main
+main.js    6.77 kB       7  [emitted]  main
 chunk    {0} 0.js (cir1) 81 bytes {3} {5} {7} [rendered]
     > duplicate cir1 from cir2 [6] (webpack)/test/statsCases/optimize-chunks/circular2.js 1:0-79
     > duplicate cir1 [7] (webpack)/test/statsCases/optimize-chunks/index.js 13:0-54

--- a/test/statsCases/preset-detailed/expected.txt
+++ b/test/statsCases/preset-detailed/expected.txt
@@ -4,7 +4,7 @@ Time: Xms
    0.js  238 bytes       0  [emitted]  
    1.js  102 bytes       1  [emitted]  
    2.js  182 bytes       2  [emitted]  
-main.js     6.1 kB       3  [emitted]  main
+main.js    6.09 kB       3  [emitted]  main
 Entrypoint main = main.js
 chunk    {0} 0.js 54 bytes {3} [rendered]
     > [0] (webpack)/test/statsCases/preset-detailed/index.js 3:0-16

--- a/test/statsCases/preset-normal/expected.txt
+++ b/test/statsCases/preset-normal/expected.txt
@@ -4,7 +4,7 @@ Time: Xms
    0.js  238 bytes       0  [emitted]  
    1.js  102 bytes       1  [emitted]  
    2.js  182 bytes       2  [emitted]  
-main.js     6.1 kB       3  [emitted]  main
+main.js    6.09 kB       3  [emitted]  main
    [0] (webpack)/test/statsCases/preset-normal/index.js 51 bytes {3} [built]
    [1] (webpack)/test/statsCases/preset-normal/a.js 22 bytes {3} [built]
    [2] (webpack)/test/statsCases/preset-normal/b.js 22 bytes {1} [built]

--- a/test/statsCases/preset-verbose/expected.txt
+++ b/test/statsCases/preset-verbose/expected.txt
@@ -4,7 +4,7 @@ Time: Xms
    0.js  238 bytes       0  [emitted]  
    1.js  102 bytes       1  [emitted]  
    2.js  182 bytes       2  [emitted]  
-main.js     6.1 kB       3  [emitted]  main
+main.js    6.09 kB       3  [emitted]  main
 Entrypoint main = main.js
 chunk    {0} 0.js 54 bytes {3} [rendered]
     > [0] (webpack)/test/statsCases/preset-verbose/index.js 3:0-16


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
Because it's a simple change.

**Summary**
The change is inspired by UglifyJS warning "Dropping unused variable result [webpack/bootstrap e49403bfdc612b79f1ba:6,0]"

**Does this PR introduce a breaking change?**
No.