### PR TITLE
Fix exports argument in ConcatenatedModule

### DIFF
--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -287,7 +287,7 @@ class ConcatenatedModule extends Module {
 
 		const result = new ConcatSource();
 		if(moduleToInfoMap.get(this.rootModule).needCompatibilityFlag) {
-			result.add(`Object.defineProperty(${this.rootModule.moduleArgument || "exports"}, "__esModule", { value: true });\n`);
+			result.add(`Object.defineProperty(${this.rootModule.exportsArgument || "exports"}, "__esModule", { value: true });\n`);
 		}
 		modulesWithInfo.forEach(info => {
 			result.add(`\n// CONCATENAMED MODULE: ${info.module.readableIdentifier(requestShortener)}\n`);


### PR DESCRIPTION
This code was being generated, which uses a missing variable:
```
/***/ (function(module, __webpack_exports__, __webpack_require__) {

"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
```

The outputted error:
```
main.bundle.js:73 Uncaught ReferenceError: exports is not defined
    at Object../src/app/app.component.ts ./src/app/app.module.ts ./src/environments/environment.ts ./src/main.ts (main.bundle.js:73)
    at __webpack_require__ (bootstrap bd9f482…:56)
    at Object.0 (main.ts:11)
    at __webpack_require__ (bootstrap bd9f482…:56)
    at webpackJsonpCallback (bootstrap bd9f482…:25)
    at main.bundle.js:1
```

/cc @thelarkinn @sokra

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
