### PR TITLE
Drop node 4 support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,7 +51,7 @@ module.exports = {
 		}],
 		"no-console": "off",
 		"valid-jsdoc": "error",
-		"node/no-unsupported-features": ["error", { version: 4 }],
+		"node/no-unsupported-features": ["error", { version: 6 }],
 		"node/no-deprecated-api": "error",
 		"node/no-missing-import": "error",
 		"node/no-missing-require": [

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "worker-loader": "~0.7.0"
   },
   "engines": {
-    "node": ">=4.3.0 <5.0.0 || >=5.10"
+    "node": ">=6.10"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

requirements

**Did you add tests for your changes?**

N/A

**If relevant, link to documentation update:**

N/A

**Summary**

As LTS for v4 was dropped its time to update minimum requirement of node to v6

**Does this PR introduce a breaking change?**

yes as in older node versions may no longer work if this gets merged and features of v6 of node get merged too.

**Other information**

The latest LTS is 6.10+ which also is supported by AWS lambda, therefore it may be reasonable to only support v6+ for the next release