### PR TITLE
show error when hotOnly HMR fails

### DIFF
--- a/hot/only-dev-server.js
+++ b/hot/only-dev-server.js
@@ -27,6 +27,7 @@ if(module.hot) {
 					console.warn("Ignored an update to declined module " + data.chain.join(" -> "));
 				},
 				onErrored: function(data) {
+					console.error(data.error);
 					console.warn("Ignored an error while updating module " + data.moduleId + " (" + data.type + ")");
 				}
 			}).then(function(renewedModules) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

More a feature. Just print an ignored error.

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

no...

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

![image](https://cloud.githubusercontent.com/assets/449224/26486123/67676ec0-422c-11e7-8a11-40122a63d648.png)

There's an error but I can't see the error due to the try/catch thing

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

no.

**Other information**
