### PR TITLE
Parses require expressions to “true” in order to fix compilations errors with jsdom.

### DIFF
--- a/lib/dependencies/CommonJsPlugin.js
+++ b/lib/dependencies/CommonJsPlugin.js
@@ -56,6 +56,7 @@ class CommonJsPlugin {
 				for(let expression of requireExpressions) {
 					parser.plugin(`typeof ${expression}`, ParserHelpers.toConstantDependency("function"));
 					parser.plugin(`evaluate typeof ${expression}`, ParserHelpers.evaluateToString("function"));
+					parser.plugin(`expression ${expression}`, () => true);
 				}
 
 				parser.plugin("evaluate typeof module", ParserHelpers.evaluateToString("object"));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
This is a fix for compilation issues with jsdom in Webpack 2.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No. I could not successfully run the tests before or after my change. I would be open to adding tests if someone could provide a bit more context.

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
Test Project w/ Issue Present: https://github.com/coreyleelarson/webpack2-jsdom-test/tree/master
Test Project w/ Issue Fixed: https://github.com/coreyleelarson/webpack2-jsdom-test/tree/webpack-fixed 
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
My team has been waiting on a fix for this issue for a few months.
Per original issue: When you try to import jsdom, it compiles with warnings, and when you try to run the compiled output, it breaks with the exception ```Error: Cannot find module "."```.
Issue: https://github.com/webpack/webpack/issues/4596

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No.