### PR TITLE
Moved HMR logging to a module, added possibility to set log level.

### DIFF
--- a/hot/dev-server.js
+++ b/hot/dev-server.js
@@ -8,11 +8,12 @@ if(module.hot) {
 	var upToDate = function upToDate() {
 		return lastHash.indexOf(__webpack_hash__) >= 0;
 	};
+	var log = require("./log");
 	var check = function check() {
 		module.hot.check(true).then(function(updatedModules) {
 			if(!updatedModules) {
-				console.warn("[HMR] Cannot find update. Need to do a full reload!");
-				console.warn("[HMR] (Probably because of restarting the webpack-dev-server)");
+				log("warning", "[HMR] Cannot find update. Need to do a full reload!");
+				log("warning", "[HMR] (Probably because of restarting the webpack-dev-server)");
 				window.location.reload();
 				return;
 			}
@@ -24,17 +25,17 @@ if(module.hot) {
 			require("./log-apply-result")(updatedModules, updatedModules);
 
 			if(upToDate()) {
-				console.log("[HMR] App is up to date.");
+				log("info", "[HMR] App is up to date.");
 			}
 
 		}).catch(function(err) {
 			var status = module.hot.status();
 			if(["abort", "fail"].indexOf(status) >= 0) {
-				console.warn("[HMR] Cannot apply update. Need to do a full reload!");
-				console.warn("[HMR] " + err.stack || err.message);
+				log("warning", "[HMR] Cannot apply update. Need to do a full reload!");
+				log("warning", "[HMR] " + err.stack || err.message);
 				window.location.reload();
 			} else {
-				console.warn("[HMR] Update failed: " + err.stack || err.message);
+				log("warning", "[HMR] Update failed: " + err.stack || err.message);
 			}
 		});
 	};
@@ -42,11 +43,11 @@ if(module.hot) {
 	hotEmitter.on("webpackHotUpdate", function(currentHash) {
 		lastHash = currentHash;
 		if(!upToDate() && module.hot.status() === "idle") {
-			console.log("[HMR] Checking for updates on the server...");
+			log("info", "[HMR] Checking for updates on the server...");
 			check();
 		}
 	});
-	console.log("[HMR] Waiting for update signal from WDS...");
+	log("info", "[HMR] Waiting for update signal from WDS...");
 } else {
 	throw new Error("[HMR] Hot Module Replacement is disabled.");
 }

--- a/hot/log-apply-result.js
+++ b/hot/log-apply-result.js
@@ -6,25 +6,26 @@ module.exports = function(updatedModules, renewedModules) {
 	var unacceptedModules = updatedModules.filter(function(moduleId) {
 		return renewedModules && renewedModules.indexOf(moduleId) < 0;
 	});
+	var log = require("./log");
 
 	if(unacceptedModules.length > 0) {
-		console.warn("[HMR] The following modules couldn't be hot updated: (They would need a full reload!)");
+		log("warning", "[HMR] The following modules couldn't be hot updated: (They would need a full reload!)");
 		unacceptedModules.forEach(function(moduleId) {
-			console.warn("[HMR]  - " + moduleId);
+			log("warning", "[HMR]  - " + moduleId);
 		});
 	}
 
 	if(!renewedModules || renewedModules.length === 0) {
-		console.log("[HMR] Nothing hot updated.");
+		log("info", "[HMR] Nothing hot updated.");
 	} else {
-		console.log("[HMR] Updated modules:");
+		log("info", "[HMR] Updated modules:");
 		renewedModules.forEach(function(moduleId) {
-			console.log("[HMR]  - " + moduleId);
+			log("info", "[HMR]  - " + moduleId);
 		});
 		var numberIds = renewedModules.every(function(moduleId) {
 			return typeof moduleId === "number";
 		});
 		if(numberIds)
-			console.log("[HMR] Consider using the NamedModulesPlugin for module names.");
+			log("info", "[HMR] Consider using the NamedModulesPlugin for module names.");
 	}
 };

--- a/hot/log.js
+++ b/hot/log.js
@@ -1,0 +1,14 @@
+var logLevel = "info";
+
+module.exports = function(level, msg) {
+	if(logLevel === "info" && level === "info")
+		return console.log(msg);
+	if(["info", "warning"].indexOf(logLevel) >= 0 && level === "warning")
+		return console.warn(msg);
+	if(["info", "warning", "error"].indexOf(logLevel) >= 0 && level === "error")
+		return console.error(msg);
+};
+
+module.exports.setLogLevel = function(level) {
+	logLevel = level;
+};

--- a/hot/only-dev-server.js
+++ b/hot/only-dev-server.js
@@ -8,11 +8,12 @@ if(module.hot) {
 	var upToDate = function upToDate() {
 		return lastHash.indexOf(__webpack_hash__) >= 0;
 	};
+	var log = require("./log");
 	var check = function check() {
 		module.hot.check().then(function(updatedModules) {
 			if(!updatedModules) {
-				console.warn("[HMR] Cannot find update. Need to do a full reload!");
-				console.warn("[HMR] (Probably because of restarting the webpack-dev-server)");
+				log("warning", "[HMR] Cannot find update. Need to do a full reload!");
+				log("warning", "[HMR] (Probably because of restarting the webpack-dev-server)");
 				return;
 			}
 
@@ -21,14 +22,14 @@ if(module.hot) {
 				ignoreDeclined: true,
 				ignoreErrored: true,
 				onUnaccepted: function(data) {
-					console.warn("Ignored an update to unaccepted module " + data.chain.join(" -> "));
+					log("warning", "Ignored an update to unaccepted module " + data.chain.join(" -> "));
 				},
 				onDeclined: function(data) {
-					console.warn("Ignored an update to declined module " + data.chain.join(" -> "));
+					log("warning", "Ignored an update to declined module " + data.chain.join(" -> "));
 				},
 				onErrored: function(data) {
-					console.error(data.error);
-					console.warn("Ignored an error while updating module " + data.moduleId + " (" + data.type + ")");
+					log("error", data.error);
+					log("warning", "Ignored an error while updating module " + data.moduleId + " (" + data.type + ")");
 				}
 			}).then(function(renewedModules) {
 				if(!upToDate()) {
@@ -38,16 +39,16 @@ if(module.hot) {
 				require("./log-apply-result")(updatedModules, renewedModules);
 
 				if(upToDate()) {
-					console.log("[HMR] App is up to date.");
+					log("info", "[HMR] App is up to date.");
 				}
 			});
 		}).catch(function(err) {
 			var status = module.hot.status();
 			if(["abort", "fail"].indexOf(status) >= 0) {
-				console.warn("[HMR] Cannot check for update. Need to do a full reload!");
-				console.warn("[HMR] " + err.stack || err.message);
+				log("warning", "[HMR] Cannot check for update. Need to do a full reload!");
+				log("warning", "[HMR] " + err.stack || err.message);
 			} else {
-				console.warn("[HMR] Update check failed: " + err.stack || err.message);
+				log("warning", "[HMR] Update check failed: " + err.stack || err.message);
 			}
 		});
 	};
@@ -57,14 +58,14 @@ if(module.hot) {
 		if(!upToDate()) {
 			var status = module.hot.status();
 			if(status === "idle") {
-				console.log("[HMR] Checking for updates on the server...");
+				log("info", "[HMR] Checking for updates on the server...");
 				check();
 			} else if(["abort", "fail"].indexOf(status) >= 0) {
-				console.warn("[HMR] Cannot apply update as a previous update " + status + "ed. Need to do a full reload!");
+				log("warning", "[HMR] Cannot apply update as a previous update " + status + "ed. Need to do a full reload!");
 			}
 		}
 	});
-	console.log("[HMR] Waiting for update signal from WDS...");
+	log("info", "[HMR] Waiting for update signal from WDS...");
 } else {
 	throw new Error("[HMR] Hot Module Replacement is disabled.");
 }

--- a/hot/poll.js
+++ b/hot/poll.js
@@ -5,12 +5,13 @@
 /*globals __resourceQuery */
 if(module.hot) {
 	var hotPollInterval = +(__resourceQuery.substr(1)) || (10 * 60 * 1000);
+	var log = require("./log");
 
 	var checkForUpdate = function checkForUpdate(fromUpdate) {
 		if(module.hot.status() === "idle") {
 			module.hot.check(true).then(function(updatedModules) {
 				if(!updatedModules) {
-					if(fromUpdate) console.log("[HMR] Update applied.");
+					if(fromUpdate) log("info", "[HMR] Update applied.");
 					return;
 				}
 				require("./log-apply-result")(updatedModules, updatedModules);
@@ -18,11 +19,11 @@ if(module.hot) {
 			}).catch(function(err) {
 				var status = module.hot.status();
 				if(["abort", "fail"].indexOf(status) >= 0) {
-					console.warn("[HMR] Cannot apply update.");
-					console.warn("[HMR] " + err.stack || err.message);
-					console.warn("[HMR] You need to restart the application!");
+					log("warning", "[HMR] Cannot apply update.");
+					log("warning", "[HMR] " + err.stack || err.message);
+					log("warning", "[HMR] You need to restart the application!");
 				} else {
-					console.warn("[HMR] Update failed: " + err.stack || err.message);
+					log("warning", "[HMR] Update failed: " + err.stack || err.message);
 				}
 			});
 		}

--- a/hot/signal.js
+++ b/hot/signal.js
@@ -4,20 +4,21 @@
 */
 /*globals __resourceQuery */
 if(module.hot) {
+	var log = require("./log");
 	var checkForUpdate = function checkForUpdate(fromUpdate) {
 		module.hot.check().then(function(updatedModules) {
 			if(!updatedModules) {
 				if(fromUpdate)
-					console.log("[HMR] Update applied.");
+					log("info", "[HMR] Update applied.");
 				else
-					console.warn("[HMR] Cannot find update.");
+					log("warning", "[HMR] Cannot find update.");
 				return;
 			}
 
 			return module.hot.apply({
 				ignoreUnaccepted: true,
 				onUnaccepted: function(data) {
-					console.warn("Ignored an update to unaccepted module " + data.chain.join(" -> "));
+					log("warning", "Ignored an update to unaccepted module " + data.chain.join(" -> "));
 				},
 			}).then(function(renewedModules) {
 				require("./log-apply-result")(updatedModules, renewedModules);
@@ -27,19 +28,19 @@ if(module.hot) {
 		}).catch(function(err) {
 			var status = module.hot.status();
 			if(["abort", "fail"].indexOf(status) >= 0) {
-				console.warn("[HMR] Cannot apply update.");
-				console.warn("[HMR] " + err.stack || err.message);
-				console.warn("[HMR] You need to restart the application!");
+				log("warning", "[HMR] Cannot apply update.");
+				log("warning", "[HMR] " + err.stack || err.message);
+				log("warning", "[HMR] You need to restart the application!");
 			} else {
-				console.warn("[HMR] Update failed: " + err.stack || err.message);
+				log("warning", "[HMR] Update failed: " + err.stack || err.message);
 			}
 		});
 	};
 
 	process.on(__resourceQuery.substr(1) || "SIGUSR2", function() {
 		if(module.hot.status() !== "idle") {
-			console.warn("[HMR] Got signal but currently in " + module.hot.status() + " state.");
-			console.warn("[HMR] Need to be in idle state to start hot update.");
+			log("warning", "[HMR] Got signal but currently in " + module.hot.status() + " state.");
+			log("warning", "[HMR] Need to be in idle state to start hot update.");
 			return;
 		}
 


### PR DESCRIPTION
This is a proof of concept that offers a solution for the HMR logging issue described in https://github.com/webpack/webpack-dev-server/pull/925: 

> There is a long standing issue with the HMR logging in the browser console, which cannot be turned off.

It is based on that PR, but falls back gracefully on webpack-dev-server versions without that PR applied.

**What kind of change does this PR introduce?**
This is a bugfix.

**Did you add tests for your changes?**
No, as this is a proof of concept, I'll add tests if this passes reviews.

**If relevant, link to documentation update:**
N/A

**Summary**
The issue is `webpack-dev-server` related and is detailed in https://github.com/webpack/webpack-dev-server/pull/925.
As this is a proof of concept, it only changes `dev-server.js`, if this passes reviews we should also change `log-apply-results.js`, `only-dev-server.js`, `poll.js` and `signal.js`.

**Does this PR introduce a breaking change?**
There's no breaking change, as far as I can see. The bugfix uses `webpack-dev-server/client/log.js` if it exists (is there a more elegant way to check this?), and if not, it falls back to the current behavior, using `console.log()` & `console.warn()`.
