### PR TITLE
CommonsChunkPlugin can cause duplicate chunk blocks

### DIFF
--- a/lib/optimize/CommonsChunkPlugin.js
+++ b/lib/optimize/CommonsChunkPlugin.js
@@ -340,7 +340,9 @@ Take a look at the "name"/"names" or async/children option.`);
 	moveExtractedChunkBlocksToTargetChunk(chunks, targetChunk) {
 		for(let chunk of chunks) {
 			for(let block of chunk.blocks) {
-				block.chunks.unshift(targetChunk);
+				if(block.chunks.indexOf(targetChunk) === -1) {
+					block.chunks.unshift(targetChunk);
+				}
 				targetChunk.addBlock(block);
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "script-loader": "~0.7.0",
     "should": "^11.1.1",
     "simple-git": "^1.65.0",
-    "sinon": "^1.17.7",
+    "sinon": "^2.3.2",
     "style-loader": "~0.13.0",
     "url-loader": "~0.5.0",
     "val-loader": "~0.5.0",

--- a/test/configCases/async-commons-chunk/existing-name/a.js
+++ b/test/configCases/async-commons-chunk/existing-name/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/test/configCases/async-commons-chunk/existing-name/b.js
+++ b/test/configCases/async-commons-chunk/existing-name/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/test/configCases/async-commons-chunk/existing-name/c.js
+++ b/test/configCases/async-commons-chunk/existing-name/c.js
@@ -1,0 +1,1 @@
+module.exports = "c";

--- a/test/configCases/async-commons-chunk/existing-name/index.js
+++ b/test/configCases/async-commons-chunk/existing-name/index.js
@@ -1,0 +1,33 @@
+require("should");
+const sinon = require("sinon");
+const chunkLoadingSpy = sinon.spy(__webpack_require__, 'e');
+
+it("should not have duplicate chunks in blocks", function(done) {
+    // This split point should contain: a
+	require.ensure([], function(require) {
+		require("./a").should.be.eql("a");
+	}, 'a');
+
+    // This split point should contain: a and b - we use CommonsChunksPlugin to
+    // have it only contain b and make chunk a be an async dependency.
+	require.ensure([], function(require) {
+		require("./a").should.be.eql("a");
+		require("./b").should.be.eql("b");
+	}, 'a+b');
+
+    // This split point should contain: a, b and c - we use CommonsChunksPlugin to
+    // have it only contain c and make chunks a and a+b be async dependencies.
+	require.ensure([], function(require) {
+		require("./a").should.be.eql("a");
+		require("./b").should.be.eql("b");
+		require("./c").should.be.eql("c");
+	}, 'a+b+c');
+
+    // Each of the require.ensures above should end up resolving chunks:
+    // - a
+    // - a, a+b
+    // - a, a+b, a+b+c
+	chunkLoadingSpy.callCount.should.be.eql(6);
+	chunkLoadingSpy.args.should.be.eql([[0], [0], [1], [0], [1], [2]]);
+	done();
+});

--- a/test/configCases/async-commons-chunk/existing-name/webpack.config.js
+++ b/test/configCases/async-commons-chunk/existing-name/webpack.config.js
@@ -1,0 +1,14 @@
+var webpack = require("../../../../");
+
+module.exports = {
+	plugins: [
+		new webpack.optimize.CommonsChunkPlugin({
+			chunks: ["a+b", "a+b+c"],
+			async: "a+b",
+		}),
+		new webpack.optimize.CommonsChunkPlugin({
+			chunks: ["a", "a+b"],
+			async: "a",
+		}),
+	]
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,7 +1029,7 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
 
-diff@3.2.0:
+diff@3.2.0, diff@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
@@ -1500,11 +1500,11 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-formatio@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+formatio@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
   dependencies:
-    samsam "~1.1"
+    samsam "1.x"
 
 forwarded@~0.1.0:
   version "0.1.0"
@@ -2371,9 +2371,9 @@ log-driver@1.2.5, log-driver@^1.x:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
 
-lolex@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -2540,6 +2540,10 @@ mute-stream@0.0.5:
 nan@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -2822,6 +2826,12 @@ path-parse@^1.0.5:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -3551,9 +3561,9 @@ safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
-samsam@1.1.2, samsam@~1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
 
 sax@~1.2.1:
   version "1.2.2"
@@ -3693,14 +3703,18 @@ simple-git@^1.65.0:
   dependencies:
     debug "^2.6.7"
 
-sinon@^1.17.7:
-  version "1.17.7"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+sinon@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.3.2.tgz#c43a9c570f32baac1159505cfeed19108855df89"
   dependencies:
-    formatio "1.1.1"
-    lolex "1.3.2"
-    samsam "1.1.2"
-    util ">=0.10.3 <1"
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^1.6.0"
+    native-promise-only "^0.8.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -3969,6 +3983,10 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -4034,6 +4052,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
 type-is@~1.6.6:
   version "1.6.15"
@@ -4122,7 +4144,7 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-util@0.10.3, "util@>=0.10.3 <1", util@^0.10.3:
+util@0.10.3, util@^0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   dependencies:


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

Added a ConfigCase to that fails without the fix to prevent future regressions.

**Summary**

When using CommonsChunkPlugin to create async chunks, its currently possible to introduce duplicate chunk blocks.

I found this when I noticed this in the output of my build:

```
Promise.all/* require.ensure */([__webpack_require__.e("main"), __webpack_require__.e("main"), __webpack_require__.e("main")])..
```

The setup I had that reproduced this issue involves the following normal chunks
1. main
2. main + some extra code
3. main + some extra code + all my code

Using the CommonsChunks I basically wanted the chunks to be:
1. main
2. some extra code (with main being an async chunk)
3. rest of my code (with 2 and 1 being async chunks)

The motivation for this setup was that depending on the user type (normal, developer, admin), I wanted to be able to load 1, 1 + 2 and 1 + 2 + 3 without having 1 and 2 duplicated multiple times.

**Does this PR introduce a breaking change?**

No. The current behavior without the fix is not "broken", since multiple blocks to the same chunk works fine, it's just extra bytes and potentially has issues for long term caching.