### PR TITLE
Throw error if externals are missing instead of outputting undefined. webpa…

### DIFF
--- a/lib/UmdMainTemplatePlugin.js
+++ b/lib/UmdMainTemplatePlugin.js
@@ -72,6 +72,7 @@ class UmdMainTemplatePlugin {
 					let expr;
 					let request = m.request;
 					if(typeof request === "object") request = request[type];
+					if(typeof request === "undefined") throw new Error("Missing external configuration for type:" + type);
 					if(Array.isArray(request)) {
 						expr = `require(${JSON.stringify(request[0])})${accessorToObjectAccess(request.slice(1))}`;
 					} else


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This fixes #4771 so that libraries don't output non-working code and silently fail when configuration is missing in `externals`.

**Did you add tests for your changes?**

No, but I would love to do so, however I'm not clear on where it would be most appropriate to add the tests. Should I add them to the `externals` tests or is there a separate test for the `UmdMainTemplatePlugin`?

**If relevant, link to documentation update:**

N/A, however once this has been merged I will remove the note about a pitfall that I added in webpack/webpack.js.org#1158

**Summary**

#4771 Has most of the info but basically a misconfigured `externals` will lead to libraries outputting `require(undefined)` for certain contexts which will then fail when consumed instead of failing on build.

**Does this PR introduce a breaking change?**

Depends on how you look at it, this measure should have been there from the beginning and I couldn't think of any valid use cases to leave out the configurations which would cause this to happen, however I'm open to critique on this point!

**Other information**

Is the place where I've added the check the right way to go about this? I thought about validating config before run, as is done with absolute paths, but couldn't really think of any good way to do it. Also, if this is the right place, is simply throwing an error the best way to stop the build or is there some other mechanism that I have overlooked?