### PR TITLE
Support turn off  NodeSourcePlugin with false option

### DIFF
--- a/lib/node/NodeSourcePlugin.js
+++ b/lib/node/NodeSourcePlugin.js
@@ -13,6 +13,8 @@ module.exports = class NodeSourcePlugin {
 	}
 	apply(compiler) {
 		const options = this.options;
+		if(options === false) // allow single kill switch to turn off this plugin
+			return;
 
 		function getPathToModule(module, type) {
 			if(type === true || (type === undefined && nodeLibsBrowser[module])) {

--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -808,55 +808,64 @@
     },
     "node": {
       "description": "Include polyfills or mocks for various node stuff.",
-      "additionalProperties": {
-        "enum": [
-          false,
-          true,
-          "mock",
-          "empty"
-        ]
-      },
-      "properties": {
-        "Buffer": {
+      "anyOf": [
+        {
           "enum": [
-            false,
-            true,
-            "mock"
+            false
           ]
         },
-        "__dirname": {
-          "enum": [
-            false,
-            true,
-            "mock"
-          ]
-        },
-        "__filename": {
-          "enum": [
-            false,
-            true,
-            "mock"
-          ]
-        },
-        "console": {
-          "enum": [
-            false,
-            true,
-            "mock"
-          ]
-        },
-        "global": {
-          "type": "boolean"
-        },
-        "process": {
-          "enum": [
-            false,
-            true,
-            "mock"
-          ]
+        {
+          "additionalProperties": {
+            "enum": [
+              false,
+              true,
+              "mock",
+              "empty"
+            ]
+          },
+          "properties": {
+            "Buffer": {
+              "enum": [
+                false,
+                true,
+                "mock"
+              ]
+            },
+            "__dirname": {
+              "enum": [
+                false,
+                true,
+                "mock"
+              ]
+            },
+            "__filename": {
+              "enum": [
+                false,
+                true,
+                "mock"
+              ]
+            },
+            "console": {
+              "enum": [
+                false,
+                true,
+                "mock"
+              ]
+            },
+            "global": {
+              "type": "boolean"
+            },
+            "process": {
+              "enum": [
+                false,
+                true,
+                "mock"
+              ]
+            }
+          },
+          "type": "object"
         }
-      },
-      "type": "object"
+      ]
     },
     "output": {
       "$ref": "#/definitions/output"

--- a/test/configCases/parsing/node-source-plugin-off/index.js
+++ b/test/configCases/parsing/node-source-plugin-off/index.js
@@ -1,0 +1,5 @@
+require("should");
+
+it("should not load node-libs-browser when node option is false", function() {
+	(typeof process).should.be.eql("undefined");
+});

--- a/test/configCases/parsing/node-source-plugin-off/webpack.config.js
+++ b/test/configCases/parsing/node-source-plugin-off/webpack.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	target: "web",
+	node: false
+};

--- a/test/configCases/parsing/node-source-plugin/index.js
+++ b/test/configCases/parsing/node-source-plugin/index.js
@@ -1,0 +1,5 @@
+require("should");
+
+it("should add node-libs-browser to target web by default", function() {
+	process.browser.should.be.eql(true);
+});

--- a/test/configCases/parsing/node-source-plugin/webpack.config.js
+++ b/test/configCases/parsing/node-source-plugin/webpack.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	target: "web",
+	node: {
+		process: true
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Allow a new value `false` for the `node` option to turn off the `NodeSourcePlugin` completely.  

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

As requested here https://github.com/webpack/webpack/issues/4976, it is desired to have a simple way to turn off `NodeSourcePlugin` completely to avoid any unintentional code to pull in node compatible code for the browser.  Since the plugin supports the `node` option but doesn't have an easy and simple way for turning it off, this PR updates to support that.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
