### PR TITLE
[performance] Speed up Module.rewriteChunkInReasons.

### DIFF
--- a/lib/Module.js
+++ b/lib/Module.js
@@ -172,7 +172,7 @@ class Module extends DependenciesBlock {
 		// the work.
 		const newChunkMap = {};
 		newChunks.forEach(chunk => {
-			newChunkMap[chunk.id] = chunk;
+			newChunkMap[chunk.debugId] = chunk;
 		});
 
 		for(let reasonIndex = 0; reasonIndex < this.reasons.length; reasonIndex++) {
@@ -187,7 +187,7 @@ class Module extends DependenciesBlock {
 			for(let chunkIndex = 0; chunkIndex < r.chunks.length; chunkIndex++) {
 				const chunk = r.chunks[chunkIndex];
 				if(chunk !== oldChunk) {
-					chunksMap[chunk.id] = chunk;
+					chunksMap[chunk.debugId] = chunk;
 				}
 			}
 			// override any matching chunkIds

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -9,13 +9,6 @@ const DependenciesBlock = require("./DependenciesBlock");
 const ModuleReason = require("./ModuleReason");
 const Template = require("./Template");
 
-function addToSet(set, items) {
-	for(const item of items) {
-		if(set.indexOf(item) < 0)
-			set.push(item);
-	}
-}
-
 function byId(a, b) {
 	return a.id - b.id;
 }
@@ -171,18 +164,45 @@ class Module extends DependenciesBlock {
 		return false;
 	}
 
+	// Remove oldChunk from and add newChunks to the module's reasons.
+	// Use a hash map to avoid adding duplicate chunks. This approach is used
+	// rather than indexOf for performance reasons.
 	rewriteChunkInReasons(oldChunk, newChunks) {
-		this.reasons.forEach(r => {
+		// create the newChunksMap outside the reasons loop to avoid duplicating
+		// the work.
+		const newChunkMap = {};
+		newChunks.forEach(chunk => {
+			newChunkMap[chunk.id] = chunk;
+		});
+
+		for(let reasonIndex = 0; reasonIndex < this.reasons.length; reasonIndex++) {
+			const r = this.reasons[reasonIndex];
 			if(!r.chunks) {
 				if(!r.module._chunks.has(oldChunk))
-					return;
+					continue;
 				r.chunks = Array.from(r.module._chunks);
 			}
-			r.chunks = r.chunks.reduce((arr, c) => {
-				addToSet(arr, c !== oldChunk ? [c] : newChunks);
-				return arr;
-			}, []);
-		});
+
+			const chunksMap = {};
+			for(let chunkIndex = 0; chunkIndex < r.chunks.length; chunkIndex++) {
+				const chunk = r.chunks[chunkIndex];
+				if(chunk !== oldChunk) {
+					chunksMap[chunk.id] = chunk;
+				}
+			}
+			// override any matching chunkIds
+			Object.assign(chunksMap, newChunkMap);
+
+			// Convert each entry in the chunksMap into a value in an array.
+			// Creating a fixed length array seems to be the fastest method of doing this.
+			// https://jsperf.com/js-for-vs-map
+			const keys = Object.keys(chunksMap);
+			r.chunks = new Array(keys.length);
+			for(let keyIndex = 0; keyIndex < keys.length; keyIndex++) {
+				const chunk = chunksMap[keys[keyIndex]];
+				r.chunks[keyIndex] = chunk;
+			}
+		}
 	}
 
 	isUsed(exportName) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This is a performance change.

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

I didn't add any tests :( There aren't any tests yet for Module, guidance would be appreciated.

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->
N/A

**Summary**

This speeds up the implementation of rewriteChunkInReasons. Previously this was
calling indexOf via addToSet(), inside of a loop (looping over newChunks),
inside of another loop (this.reasons). Essentially a triply nested loop, which
was killing performance.

The new implementation moves the loop over newChunks outside of the
this.reasons loop, and avoids the indexOf call by using an object to ensure
unique chunks.

On a very large build, this saw improvements at > 40 seconds.

Sort of related issue - https://github.com/webpack/webpack/issues/4031

This function is being called 67k times for us, so using a `for` loop provided a lot of benefit.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

Nope.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

Small slice of a profile before this change:
![image](https://user-images.githubusercontent.com/4172067/26850606-010d7df6-4abd-11e7-9879-e7822a09e53f.png)

And after:
![image](https://user-images.githubusercontent.com/4172067/26850718-56014310-4abd-11e7-9324-e97bfb192627.png)



