### PR TITLE
Add support for "noop" changes in watch tests

### DIFF
--- a/test/WatchTestCases.test.js
+++ b/test/WatchTestCases.test.js
@@ -176,16 +176,31 @@ describe("WatchTestCases", () => {
 							_require(outputDirectory, "./bundle.js");
 
 							if(exportedTests < 1) return done(new Error("No tests exported by test case"));
-							runIdx++;
-							if(runIdx < runs.length) {
-								run = runs[runIdx];
-								setTimeout(() => {
-									copyDiff(path.join(testDirectory, run.name), tempDirectory);
-								}, 1500);
-							} else {
-								watching.close();
-								process.nextTick(done);
-							}
+
+							const waitForWatchDelay = 1500;
+							const skipStepDelay = waitForWatchDelay * 2;
+							const nextStep = () => {
+								runIdx++;
+								if(runIdx < runs.length) {
+									run = runs[runIdx];
+									setTimeout(() => {
+										copyDiff(path.join(testDirectory, run.name), tempDirectory);
+										if(runIdx === runs.length) {
+											return;
+										}
+										const runReference = runIdx;
+										setTimeout(() => {
+											if(runReference === runIdx) {
+												nextStep();
+											}
+										}, skipStepDelay);
+									}, waitForWatchDelay);
+								} else {
+									watching.close();
+									process.nextTick(done);
+								}
+							};
+							nextStep();
 						});
 					});
 				});

--- a/test/watchCases/simple/noop-change/0/changing-file.js
+++ b/test/watchCases/simple/noop-change/0/changing-file.js
@@ -1,0 +1,1 @@
+module.exports = "0"

--- a/test/watchCases/simple/noop-change/0/index.js
+++ b/test/watchCases/simple/noop-change/0/index.js
@@ -1,0 +1,10 @@
+import "./noop-changing-file.js"
+import "./changing-file.js"
+
+it("should ignore change", function() {
+	switch(WATCH_STEP) {
+		case "1":
+			throw new Error("noop change should not trigger update")
+			break;
+	}
+});

--- a/test/watchCases/simple/noop-change/0/noop-changing-file.js
+++ b/test/watchCases/simple/noop-change/0/noop-changing-file.js
@@ -1,0 +1,1 @@
+module.exports = ""

--- a/test/watchCases/simple/noop-change/1/noop-changing-file.js
+++ b/test/watchCases/simple/noop-change/1/noop-changing-file.js
@@ -1,0 +1,1 @@
+module.exports = ""

--- a/test/watchCases/simple/noop-change/2/changing-file.js
+++ b/test/watchCases/simple/noop-change/2/changing-file.js
@@ -1,0 +1,1 @@
+module.exports = "flush"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Adds watch test for "noop" change and support for skipping steps in watch tests

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
It is only tests

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Allows to skip test steps that are not supposed to trigger compilation changes

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Extracted from #3806