### PR TITLE
use Set for ModuleReason chunk rewriting

### DIFF
--- a/lib/Module.js
+++ b/lib/Module.js
@@ -9,13 +9,6 @@ const DependenciesBlock = require("./DependenciesBlock");
 const ModuleReason = require("./ModuleReason");
 const Template = require("./Template");
 
-function addToSet(set, items) {
-	for(const item of items) {
-		if(set.indexOf(item) < 0)
-			set.push(item);
-	}
-}
-
 function byId(a, b) {
 	return a.id - b.id;
 }
@@ -161,28 +154,17 @@ class Module extends DependenciesBlock {
 	}
 
 	hasReasonForChunk(chunk) {
-		for(const r of this.reasons) {
-			if(r.chunks) {
-				if(r.chunks.indexOf(chunk) >= 0)
-					return true;
-			} else if(r.module._chunks.has(chunk))
+		for(let i = 0; i < this.reasons.length; i++) {
+			if(this.reasons[i].hasChunk(chunk))
 				return true;
 		}
 		return false;
 	}
 
 	rewriteChunkInReasons(oldChunk, newChunks) {
-		this.reasons.forEach(r => {
-			if(!r.chunks) {
-				if(!r.module._chunks.has(oldChunk))
-					return;
-				r.chunks = Array.from(r.module._chunks);
-			}
-			r.chunks = r.chunks.reduce((arr, c) => {
-				addToSet(arr, c !== oldChunk ? [c] : newChunks);
-				return arr;
-			}, []);
-		});
+		for(let i = 0; i < this.reasons.length; i++) {
+			this.reasons[i].rewriteChunks(oldChunk, newChunks);
+		}
 	}
 
 	isUsed(exportName) {

--- a/lib/ModuleReason.js
+++ b/lib/ModuleReason.js
@@ -4,9 +4,47 @@
 */
 "use strict";
 
-module.exports = class ModuleReason {
+const util = require("util");
+
+class ModuleReason {
 	constructor(module, dependency) {
 		this.module = module;
 		this.dependency = dependency;
+		this._chunks = null;
 	}
-};
+
+	hasChunk(chunk) {
+		if(this._chunks) {
+			if(this._chunks.has(chunk))
+				return true;
+		} else if(this.module._chunks.has(chunk))
+			return true;
+		return false;
+	}
+
+	rewriteChunks(oldChunk, newChunks) {
+		if(!this._chunks) {
+			if(!this.module._chunks.has(oldChunk))
+				return;
+			this._chunks = new Set(this.module._chunks);
+		}
+		if(this._chunks.has(oldChunk)) {
+			this._chunks.delete(oldChunk);
+			for(let i = 0; i < newChunks.length; i++) {
+				this._chunks.add(newChunks[i]);
+			}
+		}
+	}
+}
+
+Object.defineProperty(ModuleReason.prototype, "chunks", {
+	configurable: false,
+	get: util.deprecate(function() {
+		return this._chunks ? Array.from(this._chunks) : null;
+	}, "ModuleReason.chunks: Use ModuleReason.hasChunk/rewriteChunks instead"),
+	set() {
+		throw new Error("Readonly. Use ModuleReason.rewriteChunks to modify chunks.");
+	}
+});
+
+module.exports = ModuleReason;

--- a/test/ModuleReason.test.js
+++ b/test/ModuleReason.test.js
@@ -1,0 +1,77 @@
+"use strict";
+
+const Module = require("../lib/Module");
+const Chunk = require("../lib/Chunk");
+const Dependency = require("../lib/Dependency");
+const ModuleReason = require("../lib/ModuleReason");
+const should = require("should");
+
+describe("ModuleReason", () => {
+	let myModule;
+	let myDependency;
+	let myModuleReason;
+	let myChunk;
+	let myChunk2;
+
+	beforeEach(() => {
+		myModule = new Module();
+		myDependency = new Dependency();
+		myChunk = new Chunk("chunk-test", "module-test", "loc-test");
+		myChunk2 = new Chunk("chunk-test", "module-test", "loc-test");
+
+		myModuleReason = new ModuleReason(myModule, myDependency);
+	});
+
+	describe("hasChunk", () => {
+		it("returns false when chunk is not present", () => should(myModuleReason.hasChunk(myChunk)).be.false());
+
+		it("returns true when chunk is present", () => {
+			myModuleReason.module.addChunk(myChunk);
+			should(myModuleReason.hasChunk(myChunk)).be.true();
+		});
+	});
+
+	describe("rewriteChunks", () => {
+		it("if old chunk is present, it is replaced with new chunks", () => {
+			myModuleReason.module.addChunk(myChunk);
+			myModuleReason.rewriteChunks(myChunk, [myChunk2]);
+
+			should(myModuleReason.hasChunk(myChunk)).be.false();
+			should(myModuleReason.hasChunk(myChunk2)).be.true();
+		});
+
+		it("if old chunk is not present, new chunks are not added", () => {
+			myModuleReason.rewriteChunks(myChunk, [myChunk2]);
+
+			should(myModuleReason.hasChunk(myChunk)).be.false();
+			should(myModuleReason.hasChunk(myChunk2)).be.false();
+		});
+
+		it("if already rewritten chunk is present, it is replaced with new chunks", () => {
+			myModuleReason.module.addChunk(myChunk);
+			myModuleReason.rewriteChunks(myChunk, [myChunk2]);
+			myModuleReason.rewriteChunks(myChunk2, [myChunk]);
+
+			should(myModuleReason.hasChunk(myChunk)).be.true();
+			should(myModuleReason.hasChunk(myChunk2)).be.false();
+		});
+	});
+
+	describe(".chunks", () => {
+		it("is null if no rewrites happen first", () => {
+			should(myModuleReason.chunks).be.Null();
+		});
+
+		it("is null if only invalid rewrites happen first", () => {
+			myModuleReason.rewriteChunks(myChunk, [myChunk2]);
+			should(myModuleReason.chunks).be.Null();
+		});
+
+		it("is an array of chunks if a valid rewrite happens", () => {
+			myModuleReason.module.addChunk(myChunk);
+			myModuleReason.rewriteChunks(myChunk, [myChunk2]);
+
+			should(myModuleReason.chunks).be.eql([myChunk2]);
+		});
+	});
+});


### PR DESCRIPTION
Following the previous conversions of modules and chunks to Sets, this converts reasons' chunks to `Sets`.

On a webpack run of a proviate codebase I maintain, this causes time for `rewriteChunkInReasons` to go from `904ms` to `91ms`, although I think this number fluctuates depending on whether I use the debugger or not.

It's overall effect on ApplpyPluginsBailResult1 is below:

## Before:
![image](https://user-images.githubusercontent.com/364532/27103139-afbec8a8-5055-11e7-8233-2c720e26e437.png)

## After:
![image](https://user-images.githubusercontent.com/364532/27103160-c0bf8ec6-5055-11e7-9a18-acedbda9bab5.png)


Adding more tests vs. #5019 showing that the `Set` approach with deprecated getter fallback is faster than the Map approach employed in #5019 

## #5019
 
![screen shot 2017-06-14 at 3 40 16 pm](https://user-images.githubusercontent.com/364532/27151316-30c94532-5118-11e7-9273-661ad8621845.png)
![screen shot 2017-06-14 at 3 40 38 pm](https://user-images.githubusercontent.com/364532/27151314-30c83d04-5118-11e7-82c5-4f2af9baee1e.png)

## This PR

![screen shot 2017-06-14 at 3 41 20 pm](https://user-images.githubusercontent.com/364532/27151313-30c65d90-5118-11e7-9e9f-ec34d070a892.png)
![screen shot 2017-06-14 at 3 41 33 pm](https://user-images.githubusercontent.com/364532/27151315-30c88ab6-5118-11e7-8cc2-f8c1820c4fd4.png)

