### PR TITLE
Refactor: use const for non reassignable identifier

### DIFF
--- a/lib/RuleSet.js
+++ b/lib/RuleSet.js
@@ -104,7 +104,7 @@ module.exports = class RuleSet {
 		if(typeof rule !== "object")
 			throw new Error("Unexcepted " + typeof rule + " when object was expected as rule (" + rule + ")");
 
-		let newRule = {};
+		const newRule = {};
 		let useSource;
 		let resourceSource;
 		let condition;
@@ -265,7 +265,7 @@ module.exports = class RuleSet {
 			return RuleSet.normalizeUseItemString(item);
 		}
 
-		let newItem = {};
+		const newItem = {};
 
 		if(item.options && item.query)
 			throw new Error("Provided options and query in use");
@@ -312,7 +312,7 @@ module.exports = class RuleSet {
 		if(typeof condition !== "object")
 			throw Error("Unexcepted " + typeof condition + " when condition was expected (" + condition + ")");
 
-		let matchers = [];
+		const matchers = [];
 		Object.keys(condition).forEach(key => {
 			const value = condition[key];
 			switch(key) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
refactoring

**Did you add tests for your changes?**
not needed

**If relevant, link to documentation update:**
n/a

**Summary**
It's preferred to use const instead of let, if you don't reassign a variable.
It suggests to other developers that the binding between an identifier's name, and a value/reference will not change.

**Does this PR introduce a breaking change?**
n/a

**Other information**
