### PR TITLE
[Parser] Support rename this's property for IIFE

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -1059,16 +1059,18 @@ class Parser extends Tapable {
 	walkCallExpression(expression) {
 		let result;
 
-		function walkIIFE(functionExpression, options) {
-			const params = functionExpression.params;
-			const args = options.map(function(arg) {
-				const renameIdentifier = this.getRenameIdentifier(arg);
-				if(renameIdentifier && this.applyPluginsBailResult1("can-rename " + renameIdentifier, arg)) {
-					if(!this.applyPluginsBailResult1("rename " + renameIdentifier, arg))
+		function walkIIFE(functionExpression, options, currentThis) {
+			function renameArgOrThis(argOrThis) {
+				const renameIdentifier = this.getRenameIdentifier(argOrThis);
+				if(renameIdentifier && this.applyPluginsBailResult1("can-rename " + renameIdentifier, argOrThis)) {
+					if(!this.applyPluginsBailResult1("rename " + renameIdentifier, argOrThis))
 						return renameIdentifier;
 				}
-				this.walkExpression(arg);
-			}, this);
+				this.walkExpression(argOrThis);
+			}
+			const params = functionExpression.params;
+			const args = options.map(renameArgOrThis, this);
+			const renameThis = currentThis ? renameArgOrThis.call(this, currentThis) : null;
 			this.inScope(params.filter(function(identifier, idx) {
 				return !args[idx];
 			}), function() {
@@ -1077,6 +1079,9 @@ class Parser extends Tapable {
 					if(!param) continue;
 					if(!params[i] || params[i].type !== "Identifier") continue;
 					this.scope.renames["$" + params[i].name] = param;
+				}
+				if(renameThis) {
+					this.scope.renames.$this = renameThis;
 				}
 				if(functionExpression.body.type === "BlockStatement") {
 					this.prewalkStatement(functionExpression.body);
@@ -1090,11 +1095,10 @@ class Parser extends Tapable {
 			!expression.callee.computed &&
 			(["call", "bind"]).indexOf(expression.callee.property.name) >= 0 &&
 			expression.arguments &&
-			expression.arguments.length > 1
+			expression.arguments.length > 0
 		) {
 			// (function(...) { }.call/bind(?, ...))
-			walkIIFE.call(this, expression.callee.object, expression.arguments.slice(1));
-			this.walkExpression(expression.arguments[0]);
+			walkIIFE.call(this, expression.callee.object, expression.arguments.slice(1), expression.arguments[0]);
 		} else if(expression.callee.type === "FunctionExpression" && expression.arguments) {
 			// (function(...) { }(...))
 			walkIIFE.call(this, expression.callee, expression.arguments);
@@ -1134,8 +1138,13 @@ class Parser extends Tapable {
 			exprName.unshift(expr.property.name || expr.property.value);
 			expr = expr.object;
 		}
-		if(expr.type === "Identifier" && this.scope.definitions.indexOf(expr.name) === -1) {
-			exprName.unshift(this.scope.renames["$" + expr.name] || expr.name);
+		if((expr.type === "Identifier" && this.scope.definitions.indexOf(expr.name) === -1) ||
+			(expr.type === "ThisExpression" && this.scope.renames.$this)) {
+			if(expr.type === "Identifier") {
+				exprName.unshift(this.scope.renames["$" + expr.name] || expr.name);
+			} else {
+				exprName.unshift(this.scope.renames.$this);
+			}
 			let result = this.applyPluginsBailResult1("expression " + exprName.join("."), expression);
 			if(result === true)
 				return;

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -1069,19 +1069,19 @@ class Parser extends Tapable {
 				this.walkExpression(argOrThis);
 			}
 			const params = functionExpression.params;
-			const args = options.map(renameArgOrThis, this);
 			const renameThis = currentThis ? renameArgOrThis.call(this, currentThis) : null;
+			const args = options.map(renameArgOrThis, this);
 			this.inScope(params.filter(function(identifier, idx) {
 				return !args[idx];
 			}), function() {
+				if(renameThis) {
+					this.scope.renames.$this = renameThis;
+				}
 				for(let i = 0; i < args.length; i++) {
 					const param = args[i];
 					if(!param) continue;
 					if(!params[i] || params[i].type !== "Identifier") continue;
 					this.scope.renames["$" + params[i].name] = param;
-				}
-				if(renameThis) {
-					this.scope.renames.$this = renameThis;
 				}
 				if(functionExpression.body.type === "BlockStatement") {
 					this.prewalkStatement(functionExpression.body);
@@ -1140,10 +1140,10 @@ class Parser extends Tapable {
 		}
 		if((expr.type === "Identifier" && this.scope.definitions.indexOf(expr.name) === -1) ||
 			(expr.type === "ThisExpression" && this.scope.renames.$this)) {
-			if(expr.type === "Identifier") {
-				exprName.unshift(this.scope.renames["$" + expr.name] || expr.name);
-			} else {
+			if(expr.type === "ThisExpression") {
 				exprName.unshift(this.scope.renames.$this);
+			} else {
+				exprName.unshift(this.scope.renames["$" + expr.name] || expr.name);
 			}
 			let result = this.applyPluginsBailResult1("expression " + exprName.join("."), expression);
 			if(result === true)
@@ -1174,6 +1174,8 @@ class Parser extends Tapable {
 			definitions: oldScope.definitions.slice(),
 			renames: Object.create(oldScope.renames)
 		};
+
+		this.scope.renames.$this = undefined;
 
 		for(let paramIndex = 0, len = params.length; paramIndex < len; paramIndex++) {
 			const param = params[paramIndex];

--- a/test/Parser.test.js
+++ b/test/Parser.test.js
@@ -161,7 +161,7 @@ describe("Parser", () => {
 				abc: ["test"]
 			}
 		],
-		"renaming with IIFE (called)": [
+		"renaming arguments with IIFE (called)": [
 			function() {
 				! function(xyz) {
 					xyz("test");
@@ -169,6 +169,15 @@ describe("Parser", () => {
 			}, {
 				abc: ["test"],
 				fgh: [""]
+			}
+		],
+		"renaming this's properties with IIFE (called)": [
+			function() {
+				! function() {
+					this.sub;
+				}.call(ijk);
+			}, {
+				ijksub: ["test"]
 			}
 		],
 	};
@@ -181,6 +190,7 @@ describe("Parser", () => {
 
 			const testParser = new Parser({});
 			testParser.plugin("can-rename abc", (expr) => true);
+			testParser.plugin("can-rename ijk", (expr) => true);
 			testParser.plugin("call abc", (expr) => {
 				if(!testParser.state.abc) testParser.state.abc = [];
 				testParser.state.abc.push(testParser.parseString(expr.arguments[0]));
@@ -204,6 +214,11 @@ describe("Parser", () => {
 			testParser.plugin("expression fgh.sub", (expr) => {
 				if(!testParser.state.fghsub) testParser.state.fghsub = [];
 				testParser.state.fghsub.push(testParser.scope.inTry ? "try" : "notry");
+				return true;
+			});
+			testParser.plugin("expression ijk.sub", (expr) => {
+				if(!testParser.state.ijksub) testParser.state.ijksub = [];
+				testParser.state.ijksub.push("test");
 				return true;
 			});
 			testParser.plugin("expression memberExpr", (expr) => {

--- a/test/configCases/plugins/provide-plugin/index.js
+++ b/test/configCases/plugins/provide-plugin/index.js
@@ -8,12 +8,20 @@ it("should provide a module for a nested var", function() {
 	x.should.be.eql("bbbccc");
 });
 
-it("should provide a module for a nested var within a IIFE", function() {
+it("should provide a module for a nested var within a IIFE's argument", function() {
 	(function(process) {
 		(process.env.NODE_ENV).should.be.eql("development");
 		var x = process.env.NODE_ENV;
 		x.should.be.eql("development");
 	}(process));
+});
+
+it("should provide a module for a nested var within a IIFE's this", function() {
+	(function() {
+		(this.env.NODE_ENV).should.be.eql("development");
+		var x = this.env.NODE_ENV;
+		x.should.be.eql("development");
+	}.call(process));
 });
 
 it("should not provide a module for a part of a var", function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This is for fixing #5067.
ProvidePlugin supports replacing IIFE argument's property with resolved modules, but not `this`'s. This PR makes it available.

For example, for code
```
(function(){
  window.export = this.jQuery;

}).call(window);
```
config 
```
new webpack.ProvidePlugin({
  'window.jQuery': 'jquery',
})
```

will replace the `jQuery` with resolved one.

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
This PR only handles `iife.call()` or `iife.bind()` style call of IIFE, not 
1. The simple `iife()` style as it has more complicated `this` resolving rules (environment, strict mode or not).
2. `.apply`
3. arrow functions
3. object method
4. getter/setter
5. constructor (seems not needed)
6. callback