### PR TITLE
Sortable set

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -9,26 +9,26 @@ const compareLocations = require("./compareLocations");
 const SortableSet = require("./util/SortableSet");
 let debugId = 1000;
 
+const sortById = (a, b) => {
+	if(a.id < b.id) return -1;
+	if(b.id < a.id) return 1;
+	return 0;
+};
+
+const sortByIdentifier = (a, b) => {
+	if(a.identifier() > b.identifier()) return 1;
+	if(a.identifier() < b.identifier()) return -1;
+	return 0;
+};
+
 class Chunk {
-
-	static sortById(a, b) {
-		if(a.id < b.id) return -1;
-		if(b.id < a.id) return 1;
-		return 0;
-	}
-
-	static sortByIdentifier(a, b) {
-		if(a.identifier() > b.identifier()) return 1;
-		if(a.identifier() < b.identifier()) return -1;
-		return 0;
-	}
 
 	constructor(name, module, loc) {
 		this.id = null;
 		this.ids = null;
 		this.debugId = debugId++;
 		this.name = name;
-		this._modules = new SortableSet(undefined, Chunk.sortByIdentifier);
+		this._modules = new SortableSet(undefined, sortByIdentifier);
 		this.entrypoints = [];
 		this.chunks = [];
 		this.parents = [];
@@ -144,7 +144,7 @@ class Chunk {
 	}
 
 	setModules(modules) {
-		this._modules = new SortableSet(modules, Chunk.sortByIdentifier);
+		this._modules = new SortableSet(modules, sortByIdentifier);
 	}
 
 	getNumberOfModules() {
@@ -422,7 +422,7 @@ class Chunk {
 	}
 
 	sortItems() {
-		this._modules.sortWith(Chunk.sortById);
+		this._modules.sortWith(sortById);
 		this.origins.sort((a, b) => {
 			const aIdent = a.module.identifier();
 			const bIdent = b.module.identifier();
@@ -434,8 +434,8 @@ class Chunk {
 			if(origin.reasons)
 				origin.reasons.sort();
 		});
-		this.parents.sort(Chunk.sortById);
-		this.chunks.sort(Chunk.sortById);
+		this.parents.sort(sortById);
+		this.chunks.sort(sortById);
 	}
 
 	toString() {

--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -6,23 +6,29 @@
 
 const util = require("util");
 const compareLocations = require("./compareLocations");
+const SortableSet = require("./util/SortableSet");
 let debugId = 1000;
 
-const byId = (a, b) => {
-	if(a.id < b.id) return -1;
-	if(b.id < a.id) return 1;
-	return 0;
-};
-
 class Chunk {
+
+	static sortById(a, b) {
+		if(a.id < b.id) return -1;
+		if(b.id < a.id) return 1;
+		return 0;
+	}
+
+	static sortByIdentifier(a, b) {
+		if(a.identifier() > b.identifier()) return 1;
+		if(a.identifier() < b.identifier()) return -1;
+		return 0;
+	}
 
 	constructor(name, module, loc) {
 		this.id = null;
 		this.ids = null;
 		this.debugId = debugId++;
 		this.name = name;
-		this._modules = new Set();
-		this._modulesIsSorted = true;
+		this._modules = new SortableSet(undefined, Chunk.sortByIdentifier);
 		this.entrypoints = [];
 		this.chunks = [];
 		this.parents = [];
@@ -92,7 +98,6 @@ class Chunk {
 	addModule(module) {
 		if(!this._modules.has(module)) {
 			this._modules.add(module);
-			this._modulesIsSorted = false;
 			return true;
 		}
 		return false;
@@ -139,8 +144,7 @@ class Chunk {
 	}
 
 	setModules(modules) {
-		this._modules = new Set(modules);
-		this._modulesIsSorted = false;
+		this._modules = new SortableSet(modules, Chunk.sortByIdentifier);
 	}
 
 	getNumberOfModules() {
@@ -159,19 +163,9 @@ class Chunk {
 		return Array.from(this._modules, fn);
 	}
 
-	_ensureModulesSorted() {
-		if(this._modulesIsSorted) return;
-		this._modules = new Set(Array.from(this._modules).sort((a, b) => {
-			if(a.identifier() > b.identifier()) return 1;
-			if(a.identifier() < b.identifier()) return -1;
-			return 0;
-		}));
-		this._modulesIsSorted = true;
-	}
-
 	compareTo(otherChunk) {
-		this._ensureModulesSorted();
-		otherChunk._ensureModulesSorted();
+		this._modules.sort();
+		otherChunk._modules.sort();
 		if(this._modules.size > otherChunk._modules.size) return -1;
 		if(this._modules.size < otherChunk._modules.size) return 1;
 		const a = this._modules[Symbol.iterator]();
@@ -196,7 +190,7 @@ class Chunk {
 	}
 
 	getModulesIdent() {
-		this._ensureModulesSorted();
+		this._modules.sort();
 		let str = "";
 		this._modules.forEach(m => {
 			str += m.identifier() + "#";
@@ -428,7 +422,7 @@ class Chunk {
 	}
 
 	sortItems() {
-		this._modules = new Set(Array.from(this._modules).sort(byId));
+		this._modules.sortWith(Chunk.sortById);
 		this.origins.sort((a, b) => {
 			const aIdent = a.module.identifier();
 			const bIdent = b.module.identifier();
@@ -440,8 +434,8 @@ class Chunk {
 			if(origin.reasons)
 				origin.reasons.sort();
 		});
-		this.parents.sort(byId);
-		this.chunks.sort(byId);
+		this.parents.sort(Chunk.sortById);
+		this.chunks.sort(Chunk.sortById);
 	}
 
 	toString() {

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -74,6 +74,10 @@ class Module extends DependenciesBlock {
 		super.unseal();
 	}
 
+	setChunks(chunks) {
+		this._chunks = new SortableSet(chunks, sortById);
+	}
+
 	addChunk(chunk) {
 		this._chunks.add(chunk);
 		this._chunksDebugIdent = undefined;

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -5,21 +5,24 @@
 "use strict";
 
 const util = require("util");
+
 const DependenciesBlock = require("./DependenciesBlock");
 const ModuleReason = require("./ModuleReason");
+const SortableSet = require("./util/SortableSet");
 const Template = require("./Template");
-
-function byId(a, b) {
-	return a.id - b.id;
-}
-
-function byDebugId(a, b) {
-	return a.debugId - b.debugId;
-}
 
 let debugId = 1000;
 
 class Module extends DependenciesBlock {
+
+	static sortById(a, b) {
+		return a.id - b.id;
+	}
+
+	static sortByDebugId(a, b) {
+		return a.debugId - b.debugId;
+	}
+
 	constructor() {
 		super();
 		this.context = null;
@@ -34,9 +37,7 @@ class Module extends DependenciesBlock {
 		this.used = null;
 		this.usedExports = null;
 		this.providedExports = null;
-		this._chunks = new Set();
-		this._chunksIsSorted = true;
-		this._chunksIsSortedByDebugId = true;
+		this._chunks = new SortableSet(undefined, Module.sortById);
 		this._chunksDebugIdent = undefined;
 		this.warnings = [];
 		this.dependenciesWarnings = [];
@@ -59,7 +60,6 @@ class Module extends DependenciesBlock {
 		this.providedExports = null;
 		this._chunks.clear();
 		this._chunksDebugIdent = undefined;
-		this._chunksIsSorted = this._chunksIsSortedByDebugId = false;
 		super.disconnect();
 	}
 
@@ -71,14 +71,12 @@ class Module extends DependenciesBlock {
 		this.depth = null;
 		this._chunks.clear();
 		this._chunksDebugIdent = undefined;
-		this._chunksIsSorted = this._chunksIsSortedByDebugId = false;
 		super.unseal();
 	}
 
 	addChunk(chunk) {
 		this._chunks.add(chunk);
 		this._chunksDebugIdent = undefined;
-		this._chunksIsSorted = this._chunksIsSortedByDebugId = false;
 	}
 
 	removeChunk(chunk) {
@@ -96,7 +94,7 @@ class Module extends DependenciesBlock {
 
 	getChunkIdsIdent() {
 		if(this._chunksDebugIdent !== undefined) return this._chunksDebugIdent;
-		this._ensureChunksSortedByDebugId();
+		this._chunks.sortWith(Module.sortByDebugId);
 		const chunks = this._chunks;
 		const list = [];
 		for(const chunk of chunks) {
@@ -130,8 +128,8 @@ class Module extends DependenciesBlock {
 
 	hasEqualsChunks(otherModule) {
 		if(this._chunks.size !== otherModule._chunks.size) return false;
-		this._ensureChunksSortedByDebugId();
-		otherModule._ensureChunksSortedByDebugId();
+		this._chunks.sortWith(Module.sortByDebugId);
+		otherModule._chunks.sortWith(Module.sortByDebugId);
 		const a = this._chunks[Symbol.iterator]();
 		const b = otherModule._chunks[Symbol.iterator]();
 		while(true) { // eslint-disable-line
@@ -140,20 +138,6 @@ class Module extends DependenciesBlock {
 			if(aItem.done) return true;
 			if(aItem.value !== bItem.value) return false;
 		}
-	}
-
-	_ensureChunksSorted() {
-		if(this._chunksIsSorted) return;
-		this._chunks = new Set(Array.from(this._chunks).sort(byId));
-		this._chunksIsSortedByDebugId = false;
-		this._chunksIsSorted = true;
-	}
-
-	_ensureChunksSortedByDebugId() {
-		if(this._chunksIsSortedByDebugId) return;
-		this._chunks = new Set(Array.from(this._chunks).sort(byDebugId));
-		this._chunksIsSorted = false;
-		this._chunksIsSortedByDebugId = true;
 	}
 
 	addReason(module, dependency) {
@@ -221,8 +205,8 @@ class Module extends DependenciesBlock {
 	sortItems(sortChunks) {
 		super.sortItems();
 		if(sortChunks)
-			this._ensureChunksSorted();
-		this.reasons.sort((a, b) => byId(a.module, b.module));
+			this._chunks.sort();
+		this.reasons.sort((a, b) => Module.sortById(a.module, b.module));
 		if(Array.isArray(this.usedExports)) {
 			this.usedExports.sort();
 		}

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -13,15 +13,15 @@ const Template = require("./Template");
 
 let debugId = 1000;
 
+const sortById = (a, b) => {
+	return a.id - b.id;
+};
+
+const sortByDebugId = (a, b) => {
+	return a.debugId - b.debugId;
+};
+
 class Module extends DependenciesBlock {
-
-	static sortById(a, b) {
-		return a.id - b.id;
-	}
-
-	static sortByDebugId(a, b) {
-		return a.debugId - b.debugId;
-	}
 
 	constructor() {
 		super();
@@ -37,7 +37,7 @@ class Module extends DependenciesBlock {
 		this.used = null;
 		this.usedExports = null;
 		this.providedExports = null;
-		this._chunks = new SortableSet(undefined, Module.sortById);
+		this._chunks = new SortableSet(undefined, sortById);
 		this._chunksDebugIdent = undefined;
 		this.warnings = [];
 		this.dependenciesWarnings = [];
@@ -94,7 +94,7 @@ class Module extends DependenciesBlock {
 
 	getChunkIdsIdent() {
 		if(this._chunksDebugIdent !== undefined) return this._chunksDebugIdent;
-		this._chunks.sortWith(Module.sortByDebugId);
+		this._chunks.sortWith(sortByDebugId);
 		const chunks = this._chunks;
 		const list = [];
 		for(const chunk of chunks) {
@@ -128,8 +128,8 @@ class Module extends DependenciesBlock {
 
 	hasEqualsChunks(otherModule) {
 		if(this._chunks.size !== otherModule._chunks.size) return false;
-		this._chunks.sortWith(Module.sortByDebugId);
-		otherModule._chunks.sortWith(Module.sortByDebugId);
+		this._chunks.sortWith(sortByDebugId);
+		otherModule._chunks.sortWith(sortByDebugId);
 		const a = this._chunks[Symbol.iterator]();
 		const b = otherModule._chunks[Symbol.iterator]();
 		while(true) { // eslint-disable-line
@@ -206,7 +206,7 @@ class Module extends DependenciesBlock {
 		super.sortItems();
 		if(sortChunks)
 			this._chunks.sort();
-		this.reasons.sort((a, b) => Module.sortById(a.module, b.module));
+		this.reasons.sort((a, b) => sortById(a.module, b.module));
 		if(Array.isArray(this.usedExports)) {
 			this.usedExports.sort();
 		}

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -7,7 +7,6 @@
 const Module = require("../Module");
 const Template = require("../Template");
 const Parser = require("../Parser");
-const SortedSet = require("../util/SortableSet");
 const acorn = require("acorn");
 const escope = require("escope");
 const ReplaceSource = require("webpack-sources/lib/ReplaceSource");

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -130,13 +130,13 @@ function getPathInAst(ast, node) {
 class ConcatenatedModule extends Module {
 	constructor(rootModule, modules) {
 		super();
+		super.setChunks(rootModule._chunks);
 		this.rootModule = rootModule;
 		this.modules = modules;
 		this.usedExports = rootModule.usedExports;
 		this.providedExports = rootModule.providedExports;
 		this.optimizationBailout = rootModule.optimizationBailout;
 		this.used = rootModule.used;
-		this._chunks = new SortedSet(rootModule._chunks, Module.sortById);
 		this.index = rootModule.index;
 		this.index2 = rootModule.index2;
 		this.depth = rootModule.depth;

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -7,6 +7,7 @@
 const Module = require("../Module");
 const Template = require("../Template");
 const Parser = require("../Parser");
+const SortedSet = require("../util/SortableSet");
 const acorn = require("acorn");
 const escope = require("escope");
 const ReplaceSource = require("webpack-sources/lib/ReplaceSource");
@@ -135,7 +136,7 @@ class ConcatenatedModule extends Module {
 		this.providedExports = rootModule.providedExports;
 		this.optimizationBailout = rootModule.optimizationBailout;
 		this.used = rootModule.used;
-		this._chunks = new Set(rootModule._chunks);
+		this._chunks = new SortedSet(rootModule._chunks, Module.sortById);
 		this.index = rootModule.index;
 		this.index2 = rootModule.index2;
 		this.depth = rootModule.depth;

--- a/lib/util/SortableSet.js
+++ b/lib/util/SortableSet.js
@@ -5,6 +5,28 @@ module.exports = class SortableSet extends Set {
 	constructor(initialIterable, defaultSort) {
 		super(initialIterable);
 		this._sortFn = defaultSort;
+		this._lastActiveSortFn = null;
+		this._isSorted = false;
+	}
+
+	/**
+	 * @param {any} value - value to add to set
+	 * @returns {SortableSet} - returns itself
+	 */
+	add(value) {
+		this._lastActiveSortFn = null;
+		this._isSorted = false;
+		super.add(value);
+		return this;
+	}
+
+	/**
+	 * @returns {void}
+	 */
+	clear() {
+		this._lastActiveSortFn = null;
+		this._isSorted = false;
+		super.clear();
 	}
 
 	/**
@@ -12,11 +34,18 @@ module.exports = class SortableSet extends Set {
 	 * @returns {void}
 	 */
 	sortWith(sortFn) {
+		if(this._isSorted && sortFn === this._lastActiveSortFn) {
+			// already sorted - nothing to do
+			return;
+		}
+
 		const sortedArray = Array.from(this).sort(sortFn);
-		this.clear();
+		super.clear();
 		for(let i = 0; i < sortedArray.length; i += 1) {
 			this.add(sortedArray[i]);
 		}
+		this._lastActiveSortFn = sortFn;
+		this._isSorted = true;
 	}
 
 	/**

--- a/lib/util/SortableSet.js
+++ b/lib/util/SortableSet.js
@@ -1,0 +1,28 @@
+"use strict";
+
+module.exports = class SortableSet extends Set {
+
+	constructor(initialIterable, defaultSort) {
+		super(initialIterable);
+		this._sortFn = defaultSort;
+	}
+
+	/**
+	 * @param {Function} sortFn - function to sort the set
+	 * @returns {void}
+	 */
+	sortWith(sortFn) {
+		const sortedArray = Array.from(this).sort(sortFn);
+		this.clear();
+		for(let i = 0; i < sortedArray.length; i += 1) {
+			this.add(sortedArray[i]);
+		}
+	}
+
+	/**
+	 * @returns {void}
+	 */
+	sort() {
+		this.sortWith(this._sortFn);
+	}
+};

--- a/lib/util/SortableSet.js
+++ b/lib/util/SortableSet.js
@@ -6,7 +6,6 @@ module.exports = class SortableSet extends Set {
 		super(initialIterable);
 		this._sortFn = defaultSort;
 		this._lastActiveSortFn = null;
-		this._isSorted = false;
 	}
 
 	/**
@@ -15,18 +14,8 @@ module.exports = class SortableSet extends Set {
 	 */
 	add(value) {
 		this._lastActiveSortFn = null;
-		this._isSorted = false;
 		super.add(value);
 		return this;
-	}
-
-	/**
-	 * @returns {void}
-	 */
-	clear() {
-		this._lastActiveSortFn = null;
-		this._isSorted = false;
-		super.clear();
 	}
 
 	/**
@@ -34,7 +23,7 @@ module.exports = class SortableSet extends Set {
 	 * @returns {void}
 	 */
 	sortWith(sortFn) {
-		if(this._isSorted && sortFn === this._lastActiveSortFn) {
+		if(this.size === 0 || sortFn === this._lastActiveSortFn) {
 			// already sorted - nothing to do
 			return;
 		}
@@ -45,7 +34,6 @@ module.exports = class SortableSet extends Set {
 			this.add(sortedArray[i]);
 		}
 		this._lastActiveSortFn = sortFn;
-		this._isSorted = true;
 	}
 
 	/**

--- a/test/SortableSet.test.js
+++ b/test/SortableSet.test.js
@@ -5,19 +5,25 @@ const SortableSet = require("../lib/util/SortableSet");
 
 describe("util/SortableSet", () => {
 	it("Can be constructed like a normal Set", () => {
-		const sortableSet = new SortableSet([1,1,1,1,1,4,5,2], () =>{});
-		Array.from(sortableSet).should.eql([1,4,5,2]);
+		const sortableSet = new SortableSet([1, 1, 1, 1, 1, 4, 5, 2], () => {});
+		Array.from(sortableSet).should.eql([1, 4, 5, 2]);
 	});
 
 	it("Can sort its content", () => {
-		const sortableSet = new SortableSet([1,1,1,6,6,1,1,4,5,2,3,8,5,7,9,0,3,1], (a,b) => a - b);
+		const sortableSet = new SortableSet(
+			[1, 1, 1, 6, 6, 1, 1, 4, 5, 2, 3, 8, 5, 7, 9, 0, 3, 1],
+			(a, b) => a - b
+		);
 		sortableSet.sort();
-		Array.from(sortableSet).should.eql([0,1,2,3,4,5,6,7,8,9]);
+		Array.from(sortableSet).should.eql([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 	});
 
 	it("Can sort by a specified function", () => {
-		const sortableSet = new SortableSet([1,1,1,6,6,1,1,4,5,2,3,8,5,7,9,0,3,1], (a,b) => a - b);
-		sortableSet.sortWith((a,b)=> b - a);
-		Array.from(sortableSet).should.eql([9,8,7,6,5,4,3,2,1,0]);
+		const sortableSet = new SortableSet(
+			[1, 1, 1, 6, 6, 1, 1, 4, 5, 2, 3, 8, 5, 7, 9, 0, 3, 1],
+			(a, b) => a - b
+		);
+		sortableSet.sortWith((a, b) => b - a);
+		Array.from(sortableSet).should.eql([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
 	});
 });

--- a/test/SortableSet.test.js
+++ b/test/SortableSet.test.js
@@ -1,0 +1,23 @@
+/* globals describe, it */
+"use strict";
+
+const SortableSet = require("../lib/util/SortableSet");
+
+describe("util/SortableSet", () => {
+	it("Can be constructed like a normal Set", () => {
+		const sortableSet = new SortableSet([1,1,1,1,1,4,5,2], () =>{});
+		Array.from(sortableSet).should.eql([1,4,5,2]);
+	});
+
+	it("Can sort its content", () => {
+		const sortableSet = new SortableSet([1,1,1,6,6,1,1,4,5,2,3,8,5,7,9,0,3,1], (a,b) => a - b);
+		sortableSet.sort();
+		Array.from(sortableSet).should.eql([0,1,2,3,4,5,6,7,8,9]);
+	});
+
+	it("Can sort by a specified function", () => {
+		const sortableSet = new SortableSet([1,1,1,6,6,1,1,4,5,2,3,8,5,7,9,0,3,1], (a,b) => a - b);
+		sortableSet.sortWith((a,b)=> b - a);
+		Array.from(sortableSet).should.eql([9,8,7,6,5,4,3,2,1,0]);
+	});
+});

--- a/test/statsCases/scope-hoisting-multi/expected.txt
+++ b/test/statsCases/scope-hoisting-multi/expected.txt
@@ -19,7 +19,7 @@ Child
        [0] (webpack)/test/statsCases/scope-hoisting-multi/common_lazy_shared.js 25 bytes {0} {1} {2} [built]
        [1] (webpack)/test/statsCases/scope-hoisting-multi/vendor.js 25 bytes {5} [built]
            ModuleConcatenation (inner): module is an entrypoint
-       [2] (webpack)/test/statsCases/scope-hoisting-multi/common.js + 1 modules 62 bytes {4} {3} [built]
+       [2] (webpack)/test/statsCases/scope-hoisting-multi/common.js + 1 modules 62 bytes {3} {4} [built]
        [3] (webpack)/test/statsCases/scope-hoisting-multi/common_lazy.js 25 bytes {1} {2} [built]
        [4] (webpack)/test/statsCases/scope-hoisting-multi/first.js + 1 modules 238 bytes {4} [built]
            ModuleConcatenation (inner): module is an entrypoint


### PR DESCRIPTION
**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

tested through existing code

**If relevant, link to documentation update:**

N/A

**Summary**

Introduce a "SortableSet" Collection that abstracts the sorting out of the responsibility of Module/Chunk

**Does this PR introduce a breaking change?**

No

**Other information**

Per default `_chunks` are flagged as sorted in Module, however, this only holds true as they are initialized empty. 
Concatenated Module, however, has initial modules and therefore is not guaranteed to be ordered, the flags should, therefore, be false. Using SortedSet fixes this as a side effect.
