### PR TITLE
fix RawModule hashing

### DIFF
--- a/lib/RawModule.js
+++ b/lib/RawModule.js
@@ -47,4 +47,8 @@ module.exports = class RawModule extends Module {
 			return new RawSource(this.sourceStr);
 	}
 
+	updateHash(hash) {
+		hash.update(this.sourceStr);
+		super.updateHash(hash);
+	}
 };

--- a/test/RawModule.test.js
+++ b/test/RawModule.test.js
@@ -6,6 +6,7 @@ const RawSource = require("webpack-sources").RawSource;
 const RequestShortener = require("../lib/RequestShortener");
 const should = require("should");
 const path = require("path");
+const crypto = require("crypto");
 
 describe("RawModule", () => {
 	let myRawModule;
@@ -61,5 +62,19 @@ describe("RawModule", () => {
 				myRawModule.source().should.match(rawSource);
 			}
 		);
+	});
+
+	describe("updateHash", () => {
+		it("should include sourceStr in its hash", () => {
+			const hashModule = (module) => {
+				const hash = crypto.createHash("sha256");
+				module.updateHash(hash);
+				return hash.digest("hex");
+			};
+
+			const hashFoo = hashModule(new RawModule("\"foo\""));
+			const hashBar = hashModule(new RawModule("\"bar\""));
+			hashFoo.should.not.equal(hashBar);
+		});
 	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
yes

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary** 
`RawModule.updateHash` does not include its own `sourceStr`, leading to hash collisions between different modules. This appears to be a regression introduced in https://github.com/webpack/webpack/commit/5b094c0b5e4e47adccccccdcdc1703db18d85c74

This PR adds an `updateHash` method to RawModule, fixing https://github.com/webpack/webpack/issues/5070

**Does this PR introduce a breaking change?**
No