### PR TITLE
update uglifyjs-webpack-plugin to v0.4.6 to support webpack 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "source-map": "^0.5.3",
     "supports-color": "^3.1.0",
     "tapable": "~0.2.5",
-    "uglifyjs-webpack-plugin": "^0.4.4",
+    "uglifyjs-webpack-plugin": "^0.4.6",
     "watchpack": "^1.3.1",
     "webpack-sources": "^1.0.1",
     "yargs": "^6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4062,6 +4062,15 @@ uglify-js@^2.6:
   optionalDependencies:
     uglify-to-browserify "~1.0.0"
 
+uglify-js@^2.8.29:
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
+  dependencies:
+    source-map "~0.5.1"
+    yargs "~3.10.0"
+  optionalDependencies:
+    uglify-to-browserify "~1.0.0"
+
 uglify-js@~2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.2.5.tgz#a6e02a70d839792b9780488b7b8b184c095c99c7"
@@ -4073,11 +4082,12 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
-uglifyjs-webpack-plugin@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.4.tgz#7829c50ee5a5b755969d4458357ed5a2dd36fbbd"
+uglifyjs-webpack-plugin@^0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz#b951f4abb6bd617e66f63eb891498e391763e309"
   dependencies:
     source-map "^0.5.6"
+    uglify-js "^2.8.29"
     webpack-sources "^1.0.1"
 
 uid-number@^0.0.6:


### PR DESCRIPTION
[uglifyjs-webpack-plugin@v0.4.6](https://github.com/webpack-contrib/uglifyjs-webpack-plugin/releases/tag/v0.4.6
) update peerDependencies with webpack v3.0.0, but there is another PR #5010, remove uglifyjs-webpack-plugin from the webpack core. Is `uglifyjs-webpack-plugin` a breaking change in v3? Or it will be removed at v4?