### PR TITLE
Preserve assets from concatenated module

### DIFF
--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -156,6 +156,7 @@ class ConcatenatedModule extends Module {
 		this.dependenciesErrors = [];
 		this.warnings = [];
 		this.errors = [];
+		this.assets = {};
 		for(const m of modules) {
 			// populate dependencies
 			m.dependencies.filter(dep => !modulesSet.has(dep.module))
@@ -168,6 +169,8 @@ class ConcatenatedModule extends Module {
 			m.warnings.forEach(warning => this.warnings.push(warning));
 			// populate errors
 			m.errors.forEach(error => this.errors.push(error));
+
+			Object.assign(this.assets, m.assets);
 		}
 	}
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Current ConcatenatedModule implementation doesn't preserve assets from modules. So those modules will be missing on final emit result. This pull request implements merging assets from modules and save it in generated ConcatenatedModule instance.

**Does this PR introduce a breaking change?**
no
