### PR TITLE
Include module file and context dependencies in ConcatenatedModule

### DIFF
--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -154,6 +154,8 @@ class ConcatenatedModule extends Module {
 		this.dependencies = [];
 		this.dependenciesWarnings = [];
 		this.dependenciesErrors = [];
+		this.fileDependencies = [];
+		this.contextDependencies = [];
 		this.warnings = [];
 		this.errors = [];
 		for(const m of modules) {
@@ -164,6 +166,10 @@ class ConcatenatedModule extends Module {
 			m.dependenciesWarnings.forEach(depWarning => this.dependenciesWarnings.push(depWarning));
 			// populate dep errors
 			m.dependenciesErrors.forEach(depError => this.dependenciesErrors.push(depError));
+			// populate file dependencies
+			if(m.fileDependencies) m.fileDependencies.forEach(file => this.fileDependencies.push(file));
+			// populate context dependencies
+			if(m.contextDependencies) m.contextDependencies.forEach(context => this.contextDependencies.push(context));
 			// populate warnings
 			m.warnings.forEach(warning => this.warnings.push(warning));
 			// populate errors

--- a/test/watchCases/plugins/module-concatenation-plugin/0/bar/a.js
+++ b/test/watchCases/plugins/module-concatenation-plugin/0/bar/a.js
@@ -1,0 +1,1 @@
+export default 'This ';

--- a/test/watchCases/plugins/module-concatenation-plugin/0/bar/abc.js
+++ b/test/watchCases/plugins/module-concatenation-plugin/0/bar/abc.js
@@ -1,0 +1,5 @@
+import a from './a';
+import b from './b';
+import c from './c';
+
+export default a + b + c;

--- a/test/watchCases/plugins/module-concatenation-plugin/0/bar/b.js
+++ b/test/watchCases/plugins/module-concatenation-plugin/0/bar/b.js
@@ -1,0 +1,1 @@
+export default 'is only';

--- a/test/watchCases/plugins/module-concatenation-plugin/0/bar/c.js
+++ b/test/watchCases/plugins/module-concatenation-plugin/0/bar/c.js
@@ -1,0 +1,1 @@
+export default ' a test';

--- a/test/watchCases/plugins/module-concatenation-plugin/0/foo/0.js
+++ b/test/watchCases/plugins/module-concatenation-plugin/0/foo/0.js
@@ -1,0 +1,1 @@
+module.exports = require('../bar/abc').default + '.0';

--- a/test/watchCases/plugins/module-concatenation-plugin/0/index.js
+++ b/test/watchCases/plugins/module-concatenation-plugin/0/index.js
@@ -1,0 +1,13 @@
+it("should watch for changes", function() {
+	if(WATCH_STEP === '0') {
+		require("./foo/" + WATCH_STEP).should.be.eql('This is only a test.' + WATCH_STEP);
+	}
+	else if(WATCH_STEP === '1') {
+		require("./foo/" + WATCH_STEP).should.be.eql('This should be a test.' + WATCH_STEP);
+	}
+	else if(WATCH_STEP === '2') {
+		require("./foo/" + WATCH_STEP).should.be.eql('This should be working.' + WATCH_STEP);
+	}
+
+	STATS_JSON.modules.length.should.equal(4 + Number(WATCH_STEP));
+});

--- a/test/watchCases/plugins/module-concatenation-plugin/1/bar/b.js
+++ b/test/watchCases/plugins/module-concatenation-plugin/1/bar/b.js
@@ -1,0 +1,1 @@
+export default 'should be';

--- a/test/watchCases/plugins/module-concatenation-plugin/1/foo/1.js
+++ b/test/watchCases/plugins/module-concatenation-plugin/1/foo/1.js
@@ -1,0 +1,1 @@
+module.exports = require('../bar/abc').default + '.1';

--- a/test/watchCases/plugins/module-concatenation-plugin/2/bar/c.js
+++ b/test/watchCases/plugins/module-concatenation-plugin/2/bar/c.js
@@ -1,0 +1,1 @@
+export default ' working';

--- a/test/watchCases/plugins/module-concatenation-plugin/2/foo/2.js
+++ b/test/watchCases/plugins/module-concatenation-plugin/2/foo/2.js
@@ -1,0 +1,1 @@
+module.exports = require('../bar/abc').default + '.2';

--- a/test/watchCases/plugins/module-concatenation-plugin/webpack.config.js
+++ b/test/watchCases/plugins/module-concatenation-plugin/webpack.config.js
@@ -1,0 +1,6 @@
+var webpack = require("../../../../");
+module.exports = {
+	plugins: [
+		new webpack.optimize.ModuleConcatenationPlugin()
+	]
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix #5132 

**Did you add tests for your changes?**

Yes

**If relevant, link to documentation update:**

N/A

**Summary**

#5132 

As ModuleConcatenationPlugin removes the concatenated modules from a
compilation, the file and context dependencies of those modules needs
to be stored in the ConcatenatedModule for webpack to be able to watch
those paths.

**Does this PR introduce a breaking change?**

No

**Other information**
