### PR TITLE
CommonsChunkPlugin with async and multi entry points

### DIFF
--- a/lib/optimize/CommonsChunkPlugin.js
+++ b/lib/optimize/CommonsChunkPlugin.js
@@ -124,7 +124,7 @@ You can however specify the name of the async chunk by passing the desired strin
 						if(!asyncChunk) {
 							asyncChunk = this.createAsyncChunk(
 								compilation,
-								targetChunks.length <= 1 || typeof this.async !== "string" ? this.async :
+								targetChunks.length > 1 || typeof this.async !== "string" ? this.async :
 								targetChunk.name ? `${this.async}-${targetChunk.name}` :
 								true,
 								targetChunk

--- a/test/statsCases/commons-chunk-async-multi/a.js
+++ b/test/statsCases/commons-chunk-async-multi/a.js
@@ -1,0 +1,1 @@
+console.log("./a.js");

--- a/test/statsCases/commons-chunk-async-multi/b.js
+++ b/test/statsCases/commons-chunk-async-multi/b.js
@@ -1,0 +1,1 @@
+console.log("./b.js");

--- a/test/statsCases/commons-chunk-async-multi/commons.js
+++ b/test/statsCases/commons-chunk-async-multi/commons.js
@@ -1,0 +1,1 @@
+console.log("commons.js");

--- a/test/statsCases/commons-chunk-async-multi/entry-1.js
+++ b/test/statsCases/commons-chunk-async-multi/entry-1.js
@@ -1,0 +1,11 @@
+console.log("entry-1.js");
+
+require.ensure([], function() {
+	require("./a");
+	require("./vendor");
+}, 'entry-1-a-async');
+
+require.ensure([], function() {
+	require("./b");
+	require("./commons");
+}, 'entry-1-b-async');

--- a/test/statsCases/commons-chunk-async-multi/entry-2.js
+++ b/test/statsCases/commons-chunk-async-multi/entry-2.js
@@ -1,0 +1,11 @@
+console.log("entry-2.js");
+
+require.ensure([], function() {
+	require("./a");
+	require("./vendor");
+}, 'entry-2-a-async');
+
+require.ensure([], function() {
+	require("./b");
+	require("./commons");
+}, 'entry-2-b-async');

--- a/test/statsCases/commons-chunk-async-multi/expected.txt
+++ b/test/statsCases/commons-chunk-async-multi/expected.txt
@@ -1,0 +1,29 @@
+Hash: fe17b5d7f9afa85765de
+Time: Xms
+                   Asset       Size  Chunks             Chunk Names
+        chunk.commons.js  104 bytes       0  [emitted]  commons
+chunk.entry-2-a-async.js  239 bytes       1  [emitted]  entry-2-a-async
+chunk.entry-2-b-async.js  103 bytes       2  [emitted]  entry-2-b-async
+               main-2.js    6.44 kB       3  [emitted]  main-2
+               main-1.js    6.44 kB       4  [emitted]  main-1
+chunk    {0} chunk.commons.js (commons) 27 bytes {3} {4} [rendered]
+    [0] ./commons.js 27 bytes {0} [built]
+chunk    {1} chunk.entry-2-a-async.js (entry-2-a-async) 74 bytes {3} {4} [rendered]
+    [1] ./a.js 23 bytes {1} [built]
+    [2] ./vendor.js 51 bytes {1} [built]
+chunk    {2} chunk.entry-2-b-async.js (entry-2-b-async) 23 bytes {3} {4} [rendered]
+    [3] ./b.js 23 bytes {2} [built]
+chunk    {3} main-2.js (main-2) 246 bytes [entry] [rendered]
+    [6] multi ./entry-2 28 bytes {3} [built]
+    [7] ./entry-2.js 218 bytes {3} [built]
+chunk    {4} main-1.js (main-1) 246 bytes [entry] [rendered]
+    [4] multi ./entry-1 28 bytes {4} [built]
+    [5] ./entry-1.js 218 bytes {4} [built]
+   [0] ./commons.js 27 bytes {0} [built]
+   [1] ./a.js 23 bytes {1} [built]
+   [2] ./vendor.js 51 bytes {1} [built]
+   [3] ./b.js 23 bytes {2} [built]
+   [4] multi ./entry-1 28 bytes {4} [built]
+   [5] ./entry-1.js 218 bytes {4} [built]
+   [6] multi ./entry-2 28 bytes {3} [built]
+   [7] ./entry-2.js 218 bytes {3} [built]

--- a/test/statsCases/commons-chunk-async-multi/vendor.js
+++ b/test/statsCases/commons-chunk-async-multi/vendor.js
@@ -1,0 +1,3 @@
+console.log("./vendor.js");
+
+require("./commons");

--- a/test/statsCases/commons-chunk-async-multi/webpack.config.js
+++ b/test/statsCases/commons-chunk-async-multi/webpack.config.js
@@ -1,0 +1,21 @@
+var CommonsChunkPlugin = require("../../../lib/optimize/CommonsChunkPlugin");
+
+module.exports = {
+	entry: {
+		"main-1": ["./entry-1"],
+		"main-2": ["./entry-2"]
+	},
+	output: {
+		chunkFilename: "chunk.[name].js"
+	},
+	stats: {
+		chunks: true,
+		context: __dirname
+	},
+	plugins: [
+		new CommonsChunkPlugin({
+			async: "commons",
+			names: ["main-2", "main-1"],
+		})
+	]
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

Yes

**If relevant, link to documentation update:**

N/A

**Summary**

Currently when you enable CommonsChunkPlugin in async mode with multiple
entry points that share modules, it will break all entry point bundles after the first one.
This is because of the logic added in https://github.com/webpack/webpack/pull/5040 which
I feel was flawed. It used to say

```
* Find async chunk with the name this.async
* If it does not exist then:
** If there is more than 1 targetChunk and this.async is a string 
** Then name the asyncChunk `${this.async}-${targetChunk.name}`

This however breaks down because now the chunk is not named `this.async` and the
next targetChunk is going to hit the same logic and try to create its own scoped asyncChunk,
however, all of the shared modules have been moved out into the other async chunk that you don't have a reference to and that is named after the first targetChunk.

I believe the logic was intended to be

* If there is only ONE targetChunk suffix your async name with that targetChunk name since it is specific to just that one chunk.
```

The actual bug that occurs currently is that the entryPoints that follow the first entryPoint to do the CommonsChunkPlugin optimization will have code that tries to `__webpack_require__.e(ID)` where the ID is for a chunk that it does not actually have a reference to (when it is a named chunk) as the lookup Map in `__webpack_require__.e` does not contain the lookup from ID -> name.

I would love someone more familiar with the internals of this plugin to ensure 
I am not missing any major dragons lurking around the corners.

**Does this PR introduce a breaking change?**

No

**Other information**
