### PR TITLE
Replace deprecated Chunk.modules usage

### DIFF
--- a/lib/AmdMainTemplatePlugin.js
+++ b/lib/AmdMainTemplatePlugin.js
@@ -17,7 +17,7 @@ class AmdMainTemplatePlugin {
 		const mainTemplate = compilation.mainTemplate;
 
 		compilation.templatesPlugin("render-with-entry", (source, chunk, hash) => {
-			const externals = chunk.modules.filter((m) => m.external);
+			const externals = chunk.getModules().filter((m) => m.external);
 			const externalsDepsArray = JSON.stringify(externals.map((m) =>
 				typeof m.request === "object" ? m.request.amd : m.request
 			));

--- a/test/AmdMainTemplatePlugin.test.js
+++ b/test/AmdMainTemplatePlugin.test.js
@@ -67,7 +67,7 @@ describe("AmdMainTemplatePlugin", () => {
 				describe("with name", () => {
 					beforeEach(() => {
 						env.chunk = {
-							modules: env.modulesListWithExternals
+							getModules: () => env.modulesListWithExternals
 						};
 						env.eventBinding = setupPluginAndGetEventBinding("foo");
 					});
@@ -82,7 +82,7 @@ describe("AmdMainTemplatePlugin", () => {
 				describe("with external dependencies", () => {
 					beforeEach(() => {
 						env.chunk = {
-							modules: env.modulesListWithExternals
+							getModules: () => env.modulesListWithExternals
 						};
 						env.eventBinding = setupPluginAndGetEventBinding();
 					});
@@ -101,7 +101,7 @@ describe("AmdMainTemplatePlugin", () => {
 						};
 						const noExternals = env.modulesListWithExternals.map((module) => Object.assign(module, externalFlag));
 						env.chunk = {
-							modules: noExternals
+							getModules: () => env.modulesListWithExternals
 						};
 						env.eventBinding = setupPluginAndGetEventBinding();
 					});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Replaces deprecated usage of Chunk.modules.

**Did you add tests for your changes?**

No interface or functional changes.

**If relevant, link to documentation update:**

No documentation update.

**Summary**

Using output: libraryTarget: "amd" causes a deprecation warning. This appears to cause build failures in some circumstances. This change replaces the deprecated property use with an undeprecated method cal which contains the exact same functinality.

**Does this PR introduce a breaking change?**

No.

**Other information**
