### PR TITLE
RFC: Ignore context in resolve caching when resolve or resolveLoader plugins are provided.

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -98,11 +98,17 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 			else
 				return ["module", "main"];
 		});
+		this.set("resolve.cacheWithContext", "make", (options) => {
+			return Array.isArray(options.resolve.plugins) && options.resolve.plugins.length > 0;
+		});
 		this.set("resolveLoader", {});
 		this.set("resolveLoader.unsafeCache", true);
 		this.set("resolveLoader.mainFields", ["loader", "main"]);
 		this.set("resolveLoader.extensions", [".js", ".json"]);
 		this.set("resolveLoader.mainFiles", ["index"]);
+		this.set("resolveLoader.cacheWithContext", "make", (options) => {
+			return Array.isArray(options.resolveLoader.plugins) && options.resolveLoader.plugins.length > 0;
+		});
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ajv": "^5.1.5",
     "ajv-keywords": "^2.0.0",
     "async": "^2.1.2",
-    "enhanced-resolve": "^3.0.0",
+    "enhanced-resolve": "mikesherov/enhanced-resolve#b03799b6f06f82423e0a5c57fcc196b8eaeb8c07",
     "escope": "^3.6.0",
     "interpret": "^1.0.0",
     "json-loader": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ajv": "^5.1.5",
     "ajv-keywords": "^2.0.0",
     "async": "^2.1.2",
-    "enhanced-resolve": "mikesherov/enhanced-resolve#b03799b6f06f82423e0a5c57fcc196b8eaeb8c07",
+    "enhanced-resolve": "^3.2.0",
     "escope": "^3.6.0",
     "interpret": "^1.0.0",
     "json-loader": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ajv": "^5.1.5",
     "ajv-keywords": "^2.0.0",
     "async": "^2.1.2",
-    "enhanced-resolve": "^3.2.0",
+    "enhanced-resolve": "^3.3.0",
     "escope": "^3.6.0",
     "interpret": "^1.0.0",
     "json-loader": "^0.5.4",

--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -483,6 +483,9 @@
         "cachePredicate": {
           "instanceof": "Function"
         },
+        "cacheWithContext": {
+          "type": "boolean"
+        },
         "descriptionFiles": {
           "$ref": "#/definitions/common.arrayOfStringValues"
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1102,9 +1102,9 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-enhanced-resolve@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz#9f4b626f577245edcf4b2ad83d86e17f4f421dec"
+enhanced-resolve@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz#950964ecc7f0332a42321b673b38dc8ff15535b3"
   dependencies:
     graceful-fs "^4.1.2"
     memory-fs "^0.4.0"


### PR DESCRIPTION
Fixes https://github.com/webpack/webpack/issues/4863

The CI builds will fail because they're pointing to my fork of enhanced-resolve, so this is just an RFC showing how we'd use https://github.com/webpack/enhanced-resolve/pull/92 to address the issue at hand.

In the future, we can even make resolve or resolveLoader plugins specify whether they need `context` and we can make the `cacheWithContext` check smarter.