### PR TITLE
Remove jscs-loader from README as it is abandoned

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,6 @@ or are automatically applied via regex from your webpack configuration.
 |<a href="https://github.com/webpack/mocha-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/mocha.svg"></a>|![mocha-npm]|Tests with mocha (Browser/NodeJS)|
 |<a href="https://github.com/MoOx/eslint-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/eslint.svg"></a>|![eslint-npm]|PreLoader for linting code using ESLint|
 |<a href="https://github.com/webpack/jslint-loader"><img width="48" height="48" src="http://jshint.com/res/jshint-dark.png"></a>|![jshint-npm]|PreLoader for linting code using JSHint|
-|<a href="https://github.com/unindented/jscs-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/jscs.svg"></a>|![jscs-npm]|PreLoader for code style checking using JSCS|
-
 
 [mocha-npm]: https://img.shields.io/npm/v/mocha-loader.svg
 [eslint-npm]: https://img.shields.io/npm/v/eslint-loader.svg


### PR DESCRIPTION
**What kind of change does this PR introduce?**

README removes jscs-loader as it is marked as abandoned 10 days ago: https://github.com/unindented/jscs-loader

**Did you add tests for your changes?**

No

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

I was looking for a linter and found an abandoned project linked via the README.

**Does this PR introduce a breaking change?**
No

**Other information**
