### PR TITLE
chunk.mapModules is not a function

### DIFF
--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -56,9 +56,7 @@ HotModuleReplacementPlugin.prototype.apply = function(compiler) {
 			});
 			records.chunkModuleIds = {};
 			this.chunks.forEach(function(chunk) {
-				records.chunkModuleIds[chunk.id] = chunk.mapModules(function(m) {
-					return m.id;
-				});
+				records.chunkModuleIds[chunk.id] = chunk.id
 			});
 		});
 		var initialPass = false;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
No

**If relevant, link to documentation update:**
n/a

**Summary**
We were getting this error on Windows 10: 

```
TypeError: chunk.mapModules is not a function
    at C:\Users\me\Code\chess\chess.com\node_modules\webpack\lib\HotModuleReplacementPlugin.js:59:46
```

And this error on macOS Sierra: 
```
TypeError: currentChunk.getModules is not a function
    at Compilation.<anonymous> (/Users/username/Documents/Development/chess.com/node_modules/webpack/lib/HotModuleReplacementPlugin.js:115:36)
```

This PR fixes both of those issues. We tried this in node 8.x, 7.9 and 6.4. It's broken in all of those versions, and this fixes it.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No, but it does _fix_ a breaking change.