### PR TITLE
feat(perf): Hoist RegExp literals in RequestShortener

### DIFF
--- a/lib/RequestShortener.js
+++ b/lib/RequestShortener.js
@@ -7,7 +7,7 @@
 const path = require("path");
 const NORMALIZE_SLASH_DIRECTION_REGEXP = /\\/g;
 const PATH_CHARS_REGEXP = /[-[\]{}()*+?.,\\^$|#\s]/g;
-const SEPERATOR_REGEXP = /[/\\]$/;
+const SEPARATOR_REGEXP = /[/\\]$/;
 const FRONT_OR_BACK_BANG_REGEXP = /^!|!$/g;
 const INDEX_JS_REGEXP = /\/index.js(!|\?|\(query\))/g;
 
@@ -23,14 +23,14 @@ const createRegExpForPath = (path) => {
 class RequestShortener {
 	constructor(directory) {
 		directory = normalizeBackSlashDirection(directory);
-		if(SEPERATOR_REGEXP.test(directory)) directory = directory.substr(0, directory.length - 1);
+		if(SEPARATOR_REGEXP.test(directory)) directory = directory.substr(0, directory.length - 1);
 
 		if(directory) {
 			this.currentDirectoryRegExp = createRegExpForPath(directory);
 		}
 
 		const dirname = path.dirname(directory);
-		const endsWithSeperator = SEPERATOR_REGEXP.test(dirname);
+		const endsWithSeperator = SEPARATOR_REGEXP.test(dirname);
 		const parentDirectory = endsWithSeperator ? dirname.substr(0, dirname.length - 1) : dirname;
 		if(parentDirectory && parentDirectory !== directory) {
 			this.parentDirectoryRegExp = createRegExpForPath(parentDirectory);

--- a/lib/RequestShortener.js
+++ b/lib/RequestShortener.js
@@ -8,7 +8,7 @@ const path = require("path");
 const NORMALIZE_SLASH_DIRECTION_REGEXP = /\\/g;
 const PATH_CHARS_REGEXP = /[-[\]{}()*+?.,\\^$|#\s]/g;
 const SEPERATOR_REGEXP = /[\/\\]$/;
-
+const FRONT_OR_BACK_BANG_REGEXP = /^!|!$/;
 
 const normalizeBackSlashDirection = (request) => {
 	return request.replace(NORMALIZE_SLASH_DIRECTION_REGEXP, "/");
@@ -22,7 +22,7 @@ const shortenPath = (path) => {
 class RequestShortener {
 	constructor(directory) {
 		directory = normalizeBackSlashDirection(directory);
-		if(/[\/\\]$/.test(directory)) directory = directory.substr(0, directory.length - 1);
+		if(SEPERATOR_REGEXP.test(directory)) directory = directory.substr(0, directory.length - 1);
 
 		if(directory) {
 			const currentDirectoryRegExpString = shortenPath(directory);
@@ -60,7 +60,7 @@ class RequestShortener {
 		if(!this.buildinsAsModule && this.buildinsRegExp)
 			request = request.replace(this.buildinsRegExp, "!(webpack)");
 		request = request.replace(this.indexJsRegExp, "$1");
-		return request.replace(/^!|!$/, "");
+		return request.replace(FRONT_OR_BACK_BANG_REGEXP, "");
 	}
 }
 

--- a/lib/RequestShortener.js
+++ b/lib/RequestShortener.js
@@ -7,7 +7,7 @@
 const path = require("path");
 const NORMALIZE_SLASH_DIRECTION_REGEXP = /\\/g;
 const PATH_CHARS_REGEXP = /[-[\]{}()*+?.,\\^$|#\s]/g;
-const SEPERATOR_REGEXP = /[\/\\]$/;
+const SEPERATOR_REGEXP = /[/\\]$/;
 const FRONT_OR_BACK_BANG_REGEXP = /^!|!$/g;
 const INDEX_JS_REGEXP = /\/index.js(!|\?|\(query\))/g;
 

--- a/lib/RequestShortener.js
+++ b/lib/RequestShortener.js
@@ -9,6 +9,7 @@ const NORMALIZE_SLASH_DIRECTION_REGEXP = /\\/g;
 const PATH_CHARS_REGEXP = /[-[\]{}()*+?.,\\^$|#\s]/g;
 const SEPERATOR_REGEXP = /[\/\\]$/;
 const FRONT_OR_BACK_BANG_REGEXP = /^!|!$/g;
+const INDEX_JS_REGEXP = /\/index.js(!|\?|\(query\))/g;
 
 const normalizeBackSlashDirection = (request) => {
 	return request.replace(NORMALIZE_SLASH_DIRECTION_REGEXP, "/");
@@ -41,8 +42,6 @@ class RequestShortener {
 			this.buildinsAsModule = buildinsAsModule;
 			this.buildinsRegExp = createRegExpForPath(buildins);
 		}
-
-		this.indexJsRegExp = /\/index.js(!|\?|\(query\))/g;
 	}
 
 	shorten(request) {
@@ -56,7 +55,7 @@ class RequestShortener {
 			request = request.replace(this.parentDirectoryRegExp, "!..");
 		if(!this.buildinsAsModule && this.buildinsRegExp)
 			request = request.replace(this.buildinsRegExp, "!(webpack)");
-		request = request.replace(this.indexJsRegExp, "$1");
+		request = request.replace(INDEX_JS_REGEXP, "$1");
 		return request.replace(FRONT_OR_BACK_BANG_REGEXP, "");
 	}
 }

--- a/lib/RequestShortener.js
+++ b/lib/RequestShortener.js
@@ -5,30 +5,43 @@
 "use strict";
 
 const path = require("path");
+const NORMALIZE_SLASH_DIRECTION_REGEXP = /\\/g;
+const PATH_CHARS_REGEXP = /[-[\]{}()*+?.,\\^$|#\s]/g;
+const SEPERATOR_REGEXP = /[\/\\]$/;
+
+
+const normalizeBackSlashDirection = (request) => {
+	return request.replace(NORMALIZE_SLASH_DIRECTION_REGEXP, "/");
+};
+
+const shortenPath = (path) => {
+	return path.replace(PATH_CHARS_REGEXP, "\\$&");
+};
+
 
 class RequestShortener {
 	constructor(directory) {
-		directory = directory.replace(/\\/g, "/");
+		directory = normalizeBackSlashDirection(directory);
 		if(/[\/\\]$/.test(directory)) directory = directory.substr(0, directory.length - 1);
 
 		if(directory) {
-			const currentDirectoryRegExpString = directory.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+			const currentDirectoryRegExpString = shortenPath(directory);
 			this.currentDirectoryRegExp = new RegExp("^" + currentDirectoryRegExpString + "|(!)" + currentDirectoryRegExpString, "g");
 		}
 
 		const dirname = path.dirname(directory);
-		const endsWithSeperator = /[\/\\]$/.test(dirname);
+		const endsWithSeperator = SEPERATOR_REGEXP.test(dirname);
 		const parentDirectory = endsWithSeperator ? dirname.substr(0, dirname.length - 1) : dirname;
 		if(parentDirectory && parentDirectory !== directory) {
-			const parentDirectoryRegExpString = parentDirectory.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+			const parentDirectoryRegExpString = shortenPath(parentDirectory);
 			this.parentDirectoryRegExp = new RegExp("^" + parentDirectoryRegExpString + "|(!)" + parentDirectoryRegExpString, "g");
 		}
 
 		if(__dirname.length >= 2) {
-			const buildins = path.join(__dirname, "..").replace(/\\/g, "/");
+			const buildins = normalizeBackSlashDirection(path.join(__dirname, ".."));
 			const buildinsAsModule = this.currentDirectoryRegExp && this.currentDirectoryRegExp.test(buildins);
 			this.buildinsAsModule = buildinsAsModule;
-			const buildinsRegExpString = buildins.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+			const buildinsRegExpString = shortenPath(buildins);
 			this.buildinsRegExp = new RegExp("^" + buildinsRegExpString + "|(!)" + buildinsRegExpString, "g");
 		}
 
@@ -37,7 +50,7 @@ class RequestShortener {
 
 	shorten(request) {
 		if(!request) return request;
-		request = request.replace(/\\/g, "/");
+		request = normalizeBackSlashDirection(request);
 		if(this.buildinsAsModule && this.buildinsRegExp)
 			request = request.replace(this.buildinsRegExp, "!(webpack)");
 		if(this.currentDirectoryRegExp)

--- a/lib/RequestShortener.js
+++ b/lib/RequestShortener.js
@@ -18,6 +18,9 @@ const shortenPath = (path) => {
 	return path.replace(PATH_CHARS_REGEXP, "\\$&");
 };
 
+const createRegExpForTypeWith = (regexpTypePartial) => {
+	return new RegExp(`^${regexpTypePartial}|(!)${regexpTypePartial}`, "g");
+};
 
 class RequestShortener {
 	constructor(directory) {
@@ -26,7 +29,7 @@ class RequestShortener {
 
 		if(directory) {
 			const currentDirectoryRegExpString = shortenPath(directory);
-			this.currentDirectoryRegExp = new RegExp("^" + currentDirectoryRegExpString + "|(!)" + currentDirectoryRegExpString, "g");
+			this.currentDirectoryRegExp = createRegExpForTypeWith(currentDirectoryRegExpString);
 		}
 
 		const dirname = path.dirname(directory);
@@ -34,7 +37,7 @@ class RequestShortener {
 		const parentDirectory = endsWithSeperator ? dirname.substr(0, dirname.length - 1) : dirname;
 		if(parentDirectory && parentDirectory !== directory) {
 			const parentDirectoryRegExpString = shortenPath(parentDirectory);
-			this.parentDirectoryRegExp = new RegExp("^" + parentDirectoryRegExpString + "|(!)" + parentDirectoryRegExpString, "g");
+			this.parentDirectoryRegExp = createRegExpForTypeWith(parentDirectoryRegExpString);
 		}
 
 		if(__dirname.length >= 2) {
@@ -42,7 +45,7 @@ class RequestShortener {
 			const buildinsAsModule = this.currentDirectoryRegExp && this.currentDirectoryRegExp.test(buildins);
 			this.buildinsAsModule = buildinsAsModule;
 			const buildinsRegExpString = shortenPath(buildins);
-			this.buildinsRegExp = new RegExp("^" + buildinsRegExpString + "|(!)" + buildinsRegExpString, "g");
+			this.buildinsRegExp = createRegExpForTypeWith(buildinsRegExpString);
 		}
 
 		this.indexJsRegExp = /\/index.js(!|\?|\(query\))/g;

--- a/lib/RequestShortener.js
+++ b/lib/RequestShortener.js
@@ -8,18 +8,15 @@ const path = require("path");
 const NORMALIZE_SLASH_DIRECTION_REGEXP = /\\/g;
 const PATH_CHARS_REGEXP = /[-[\]{}()*+?.,\\^$|#\s]/g;
 const SEPERATOR_REGEXP = /[\/\\]$/;
-const FRONT_OR_BACK_BANG_REGEXP = /^!|!$/;
+const FRONT_OR_BACK_BANG_REGEXP = /^!|!$/g;
 
 const normalizeBackSlashDirection = (request) => {
 	return request.replace(NORMALIZE_SLASH_DIRECTION_REGEXP, "/");
 };
 
-const shortenPath = (path) => {
-	return path.replace(PATH_CHARS_REGEXP, "\\$&");
-};
-
-const createRegExpForTypeWith = (regexpTypePartial) => {
-	return new RegExp(`^${regexpTypePartial}|(!)${regexpTypePartial}`, "g");
+const createRegExpForPath = (path) => {
+	const regexpTypePartial = path.replace(PATH_CHARS_REGEXP, "\\$&");
+	return new RegExp(`(^|!)${regexpTypePartial}`, "g");
 };
 
 class RequestShortener {
@@ -28,24 +25,21 @@ class RequestShortener {
 		if(SEPERATOR_REGEXP.test(directory)) directory = directory.substr(0, directory.length - 1);
 
 		if(directory) {
-			const currentDirectoryRegExpString = shortenPath(directory);
-			this.currentDirectoryRegExp = createRegExpForTypeWith(currentDirectoryRegExpString);
+			this.currentDirectoryRegExp = createRegExpForPath(directory);
 		}
 
 		const dirname = path.dirname(directory);
 		const endsWithSeperator = SEPERATOR_REGEXP.test(dirname);
 		const parentDirectory = endsWithSeperator ? dirname.substr(0, dirname.length - 1) : dirname;
 		if(parentDirectory && parentDirectory !== directory) {
-			const parentDirectoryRegExpString = shortenPath(parentDirectory);
-			this.parentDirectoryRegExp = createRegExpForTypeWith(parentDirectoryRegExpString);
+			this.parentDirectoryRegExp = createRegExpForPath(parentDirectory);
 		}
 
 		if(__dirname.length >= 2) {
 			const buildins = normalizeBackSlashDirection(path.join(__dirname, ".."));
 			const buildinsAsModule = this.currentDirectoryRegExp && this.currentDirectoryRegExp.test(buildins);
 			this.buildinsAsModule = buildinsAsModule;
-			const buildinsRegExpString = shortenPath(buildins);
-			this.buildinsRegExp = createRegExpForTypeWith(buildinsRegExpString);
+			this.buildinsRegExp = createRegExpForPath(buildins);
 		}
 
 		this.indexJsRegExp = /\/index.js(!|\?|\(query\))/g;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Minor Refactor  
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
N/A
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->
N/A
**Summary**
This hoists RegExp literals inside of request shortener. This should reduce the amount of references created as RequestShortener is instantiated heavily throughout webpack dependencyTemplates and moduleTemplates.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
