### PR TITLE
feat: support config functions with multi-compiler

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -2,6 +2,7 @@ var path = require("path");
 var fs = require("fs");
 fs.existsSync = fs.existsSync || path.existsSync;
 var interpret = require("interpret");
+var prepareOptions = require("../lib/prepareOptions");
 
 module.exports = function(yargs, argv, convertOptions) {
 
@@ -94,13 +95,7 @@ module.exports = function(yargs, argv, convertOptions) {
 
 		var requireConfig = function requireConfig(configPath) {
 			var options = require(configPath);
-			var isES6DefaultExportedFunc = (
-				typeof options === "object" && options !== null && typeof options.default === "function"
-			);
-			if(typeof options === "function" || isES6DefaultExportedFunc) {
-				options = isES6DefaultExportedFunc ? options.default : options;
-				options = options(argv.env, argv);
-			}
+			options = prepareOptions(options, argv);
 			return options;
 		};
 

--- a/lib/prepareOptions.js
+++ b/lib/prepareOptions.js
@@ -1,0 +1,29 @@
+"use strict";
+
+module.exports = function prepareOptions(options, argv) {
+	argv = argv || {};
+
+	options = handleExport(options);
+
+	if(Array.isArray(options)) {
+		options = options.map(_options => handleFunction(_options, argv));
+	} else {
+		options = handleFunction(options, argv);
+	}
+	return options;
+};
+
+function handleExport(options) {
+	const isES6DefaultExported = (
+		typeof options === "object" && options !== null && typeof options.default !== "undefined"
+	);
+	options = isES6DefaultExported ? options.default : options;
+	return options;
+}
+
+function handleFunction(options, argv) {
+	if(typeof options === "function") {
+		options = options(argv.env, argv);
+	}
+	return options;
+}

--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -10,6 +10,7 @@ const checkArrayExpectation = require("./checkArrayExpectation");
 
 const Stats = require("../lib/Stats");
 const webpack = require("../lib/webpack");
+const prepareOptions = require("../lib/prepareOptions");
 
 describe("ConfigTestCases", () => {
 	const casesPath = path.join(__dirname, "configCases");
@@ -39,7 +40,7 @@ describe("ConfigTestCases", () => {
 					this.timeout(30000);
 					const testDirectory = path.join(casesPath, category.name, testName);
 					const outputDirectory = path.join(__dirname, "js", "config", category.name, testName);
-					const options = require(path.join(testDirectory, "webpack.config.js"));
+					const options = prepareOptions(require(path.join(testDirectory, "webpack.config.js")));
 					const optionsArr = [].concat(options);
 					optionsArr.forEach((options, idx) => {
 						if(!options.context) options.context = testDirectory;

--- a/test/configCases/simple/multi-compiler-functions-export/index.js
+++ b/test/configCases/simple/multi-compiler-functions-export/index.js
@@ -1,0 +1,3 @@
+it("should run a multi compiler with functions with export default", function() {
+
+});

--- a/test/configCases/simple/multi-compiler-functions-export/webpack.config.js
+++ b/test/configCases/simple/multi-compiler-functions-export/webpack.config.js
@@ -1,0 +1,5 @@
+exports.default = [
+	function() {
+		return {};
+	}
+];

--- a/test/configCases/simple/multi-compiler-functions/index.js
+++ b/test/configCases/simple/multi-compiler-functions/index.js
@@ -1,0 +1,3 @@
+it("should run a multi compiler with functions", function() {
+
+});

--- a/test/configCases/simple/multi-compiler-functions/webpack.config.js
+++ b/test/configCases/simple/multi-compiler-functions/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = [
+	function() {
+		return {};
+	}
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

feature

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

Yes, but let me know if inadequate.

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

No documentation updates yet, but can provide. Arguably, [the docs already imply that multiple functions are supported](https://webpack.js.org/configuration/configuration-types/#exporting-multiple-configurations).

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

We already support configurations arrays for the multi-compiler, and configurations as functions in the singular case, but they don't seem to work together - until now.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**Other information**

Feel free to ask.
