### PR TITLE
Remove redundant `.type="text/javascript"` and `.async=true`

### DIFF
--- a/lib/JsonpMainTemplate.runtime.js
+++ b/lib/JsonpMainTemplate.runtime.js
@@ -12,7 +12,6 @@ module.exports = function() {
 	function hotDownloadUpdateChunk(chunkId) { // eslint-disable-line no-unused-vars
 		var head = document.getElementsByTagName("head")[0];
 		var script = document.createElement("script");
-		script.type = "text/javascript";
 		script.charset = "utf-8";
 		script.src = $require$.p + $hotChunkFilename$;
 		head.appendChild(script);

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -57,9 +57,7 @@ class JsonpMainTemplatePlugin {
 			});
 			return this.asString([
 				"var script = document.createElement('script');",
-				"script.type = 'text/javascript';",
 				"script.charset = 'utf-8';",
-				"script.async = true;",
 				`script.timeout = ${chunkLoadTimeout};`,
 				crossOriginLoading ? `script.crossOrigin = ${JSON.stringify(crossOriginLoading)};` : "",
 				`if (${this.requireFn}.nc) {`,

--- a/test/statsCases/aggressive-splitting-on-demand/expected.txt
+++ b/test/statsCases/aggressive-splitting-on-demand/expected.txt
@@ -8,7 +8,7 @@ a0bf69daa522fbf8540c.js  1.03 kB        0  [emitted]
 ffed75a7125f4bffaa65.js  1.99 kB        4  [emitted]  
 1eb486d42a31b58c16de.js  1.03 kB        5  [emitted]  
 c0be493fc1372241e789.js  1.03 kB        6  [emitted]  
-b377816b50b5f53bb16f.js  8.13 kB        7  [emitted]  main
+b377816b50b5f53bb16f.js  8.06 kB        7  [emitted]  main
 abfb187b6140d9d3505a.js  1.99 kB  8, 0, 5  [emitted]  
 Entrypoint main = b377816b50b5f53bb16f.js
 chunk    {0} c659704b2f31cae80013.js 1.8 kB {7} [rendered]

--- a/test/statsCases/chunks/expected.txt
+++ b/test/statsCases/chunks/expected.txt
@@ -4,7 +4,7 @@ Time: Xms
 0.bundle.js  288 bytes       0  [emitted]  
 1.bundle.js  152 bytes       1  [emitted]  
 2.bundle.js  232 bytes       2  [emitted]  
-  bundle.js    6.82 kB       3  [emitted]  main
+  bundle.js    6.74 kB       3  [emitted]  main
 chunk    {0} 0.bundle.js 54 bytes {3} [rendered]
     > [0] (webpack)/test/statsCases/chunks/index.js 3:0-16
     [3] (webpack)/test/statsCases/chunks/c.js 54 bytes {0} [built]

--- a/test/statsCases/commons-chunk-min-size-0/expected.txt
+++ b/test/statsCases/commons-chunk-min-size-0/expected.txt
@@ -2,7 +2,7 @@ Hash: e2982ecf41bd0a7eda73
 Time: Xms
       Asset      Size  Chunks             Chunk Names
  entry-1.js  81 bytes       0  [emitted]  entry-1
-vendor-1.js   7.89 kB       1  [emitted]  vendor-1
+vendor-1.js   7.81 kB       1  [emitted]  vendor-1
    [0] (webpack)/test/statsCases/commons-chunk-min-size-0/modules/a.js 22 bytes {1} [built]
    [1] (webpack)/test/statsCases/commons-chunk-min-size-0/modules/b.js 22 bytes {1} [built]
    [2] (webpack)/test/statsCases/commons-chunk-min-size-0/modules/c.js 22 bytes {1} [built]

--- a/test/statsCases/commons-plugin-issue-4980/expected.txt
+++ b/test/statsCases/commons-plugin-issue-4980/expected.txt
@@ -5,7 +5,7 @@ Child
                              Asset       Size  Chunks             Chunk Names
                             app.js    1.32 kB       0  [emitted]  app
     vendor.76e65ef421e93d510398.js  619 bytes       1  [emitted]  vendor
-                        runtime.js     6.9 kB       2  [emitted]  runtime
+                        runtime.js    6.82 kB       2  [emitted]  runtime
     [./constants.js] (webpack)/test/statsCases/commons-plugin-issue-4980/constants.js 87 bytes {1} [built]
     [./entry-1.js] (webpack)/test/statsCases/commons-plugin-issue-4980/entry-1.js 67 bytes {0} [built]
     [./submodule-a.js] (webpack)/test/statsCases/commons-plugin-issue-4980/submodule-a.js 59 bytes {0} [built]
@@ -16,7 +16,7 @@ Child
                              Asset       Size  Chunks             Chunk Names
                             app.js    1.37 kB       0  [emitted]  app
     vendor.76e65ef421e93d510398.js  619 bytes       1  [emitted]  vendor
-                        runtime.js     6.9 kB       2  [emitted]  runtime
+                        runtime.js    6.82 kB       2  [emitted]  runtime
     [./constants.js] (webpack)/test/statsCases/commons-plugin-issue-4980/constants.js 87 bytes {1} [built]
     [./entry-2.js] (webpack)/test/statsCases/commons-plugin-issue-4980/entry-2.js 67 bytes {0} [built]
     [./submodule-a.js] (webpack)/test/statsCases/commons-plugin-issue-4980/submodule-a.js 59 bytes {0} [built]

--- a/test/statsCases/import-weak/expected.txt
+++ b/test/statsCases/import-weak/expected.txt
@@ -2,7 +2,7 @@ Hash: 00bdc9e68dab6471776c
 Time: Xms
    Asset       Size  Chunks             Chunk Names
     0.js  149 bytes       0  [emitted]  
-entry.js    6.93 kB       1  [emitted]  entry
+entry.js    6.86 kB       1  [emitted]  entry
    [0] (webpack)/test/statsCases/import-weak/modules/b.js 22 bytes {0} [built]
    [1] (webpack)/test/statsCases/import-weak/entry.js 120 bytes {1} [built]
    [2] (webpack)/test/statsCases/import-weak/modules/a.js 37 bytes [built]

--- a/test/statsCases/limit-chunk-count-plugin/expected.txt
+++ b/test/statsCases/limit-chunk-count-plugin/expected.txt
@@ -16,7 +16,7 @@ Child
     Time: Xms
           Asset       Size  Chunks             Chunk Names
     0.bundle.js  651 bytes       0  [emitted]  
-      bundle.js    6.83 kB       1  [emitted]  main
+      bundle.js    6.76 kB       1  [emitted]  main
     chunk    {0} 0.bundle.js 118 bytes {1} [rendered]
         [1] (webpack)/test/statsCases/limit-chunk-count-plugin/a.js 22 bytes {0} [built]
         [2] (webpack)/test/statsCases/limit-chunk-count-plugin/b.js 22 bytes {0} [built]
@@ -31,7 +31,7 @@ Child
           Asset       Size  Chunks             Chunk Names
     0.bundle.js  504 bytes       0  [emitted]  
     1.bundle.js  232 bytes       1  [emitted]  
-      bundle.js    6.82 kB       2  [emitted]  main
+      bundle.js    6.75 kB       2  [emitted]  main
     chunk    {0} 0.bundle.js 74 bytes {2} [rendered]
         [1] (webpack)/test/statsCases/limit-chunk-count-plugin/a.js 22 bytes {0} [built]
         [3] (webpack)/test/statsCases/limit-chunk-count-plugin/c.js 30 bytes {0} [built]
@@ -48,7 +48,7 @@ Child
     0.bundle.js  232 bytes       0  [emitted]  
     1.bundle.js  254 bytes       1  [emitted]  
     2.bundle.js  333 bytes       2  [emitted]  
-      bundle.js    6.81 kB       3  [emitted]  main
+      bundle.js    6.73 kB       3  [emitted]  main
     chunk    {0} 0.bundle.js 44 bytes {2} {3} [rendered]
         [2] (webpack)/test/statsCases/limit-chunk-count-plugin/b.js 22 bytes {0} [built]
         [5] (webpack)/test/statsCases/limit-chunk-count-plugin/e.js 22 bytes {0} [built]

--- a/test/statsCases/named-chunks-plugin-async/expected.txt
+++ b/test/statsCases/named-chunks-plugin-async/expected.txt
@@ -3,7 +3,7 @@ Time: Xms
                      Asset       Size                   Chunks             Chunk Names
 chunk-containing-__a_js.js  316 bytes  chunk-containing-__a_js  [emitted]  
 chunk-containing-__b_js.js  173 bytes  chunk-containing-__b_js  [emitted]  
-                  entry.js     6.7 kB                    entry  [emitted]  entry
+                  entry.js    6.63 kB                    entry  [emitted]  entry
    [0] (webpack)/test/statsCases/named-chunks-plugin-async/modules/b.js 22 bytes {chunk-containing-__b_js} [built]
    [1] (webpack)/test/statsCases/named-chunks-plugin-async/entry.js 47 bytes {entry} [built]
    [2] (webpack)/test/statsCases/named-chunks-plugin-async/modules/a.js 37 bytes {chunk-containing-__a_js} [built]

--- a/test/statsCases/named-chunks-plugin/expected.txt
+++ b/test/statsCases/named-chunks-plugin/expected.txt
@@ -2,7 +2,7 @@ Hash: e2a3a4f76d4a30adbf3e
 Time: Xms
       Asset       Size    Chunks             Chunk Names
    entry.js  615 bytes     entry  [emitted]  entry
-manifest.js    6.91 kB  manifest  [emitted]  manifest
+manifest.js    6.83 kB  manifest  [emitted]  manifest
   vendor.js  469 bytes    vendor  [emitted]  vendor
    [0] multi ./modules/a ./modules/b 40 bytes {vendor} [built]
 [./entry.js] (webpack)/test/statsCases/named-chunks-plugin/entry.js 72 bytes {entry} [built]

--- a/test/statsCases/optimize-chunks/expected.txt
+++ b/test/statsCases/optimize-chunks/expected.txt
@@ -8,7 +8,7 @@ Time: Xms
    4.js  212 bytes    4, 6  [emitted]  chunk
    5.js  356 bytes    5, 3  [emitted]  cir2 from cir1
    6.js  130 bytes       6  [emitted]  ac in ab
-main.js    7.49 kB       7  [emitted]  main
+main.js    7.41 kB       7  [emitted]  main
 chunk    {0} 0.js (cir1) 81 bytes {3} {5} {7} [rendered]
     > duplicate cir1 from cir2 [6] (webpack)/test/statsCases/optimize-chunks/circular2.js 1:0-79
     > duplicate cir1 [7] (webpack)/test/statsCases/optimize-chunks/index.js 13:0-54

--- a/test/statsCases/preset-detailed/expected.txt
+++ b/test/statsCases/preset-detailed/expected.txt
@@ -4,7 +4,7 @@ Time: Xms
    0.js  288 bytes       0  [emitted]  
    1.js  152 bytes       1  [emitted]  
    2.js  232 bytes       2  [emitted]  
-main.js    6.81 kB       3  [emitted]  main
+main.js    6.73 kB       3  [emitted]  main
 Entrypoint main = main.js
 chunk    {0} 0.js 54 bytes {3} [rendered]
     > [0] (webpack)/test/statsCases/preset-detailed/index.js 3:0-16

--- a/test/statsCases/preset-normal/expected.txt
+++ b/test/statsCases/preset-normal/expected.txt
@@ -4,7 +4,7 @@ Time: Xms
    0.js  288 bytes       0  [emitted]  
    1.js  152 bytes       1  [emitted]  
    2.js  232 bytes       2  [emitted]  
-main.js    6.81 kB       3  [emitted]  main
+main.js    6.73 kB       3  [emitted]  main
    [0] (webpack)/test/statsCases/preset-normal/index.js 51 bytes {3} [built]
    [1] (webpack)/test/statsCases/preset-normal/a.js 22 bytes {3} [built]
    [2] (webpack)/test/statsCases/preset-normal/b.js 22 bytes {1} [built]

--- a/test/statsCases/preset-verbose/expected.txt
+++ b/test/statsCases/preset-verbose/expected.txt
@@ -4,7 +4,7 @@ Time: Xms
    0.js  288 bytes       0  [emitted]  
    1.js  152 bytes       1  [emitted]  
    2.js  232 bytes       2  [emitted]  
-main.js    6.81 kB       3  [emitted]  main
+main.js    6.73 kB       3  [emitted]  main
 Entrypoint main = main.js
 chunk    {0} 0.js 54 bytes {3} [rendered]
     > [0] (webpack)/test/statsCases/preset-verbose/index.js 3:0-16


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Cleanup/simplification

**Did you add tests for your changes?**

N/A

**Summary**

Remove `.type = 'text/javascript'` and `.async = true` on script-inserted elements as they are redundant. `'text/javascript'` is the default type for all `script` elements, and all script-inserted elements are `async` by default.
