### PR TITLE
added sortModules method to Chunk class

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -421,8 +421,12 @@ class Chunk {
 		};
 	}
 
+	sortModules(sortByFn = sortById) {
+		this._modules.sortWith(sortByFn);
+	}
+
 	sortItems() {
-		this._modules.sortWith(sortById);
+		this.sortModules();
 		this.origins.sort((a, b) => {
 			const aIdent = a.module.identifier();
 			const bIdent = b.module.identifier();

--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -421,8 +421,8 @@ class Chunk {
 		};
 	}
 
-	sortModules(sortByFn = sortById) {
-		this._modules.sortWith(sortByFn);
+	sortModules(sortByFn) {
+		this._modules.sortWith(sortByFn || sortById);
 	}
 
 	sortItems() {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
No.

**If relevant, link to documentation update:**

N/A

**Summary**

Added `sortModules` method to `Chunk` class.

`extract-text-webpack-plugin` is emitting extracted css in the incorrect order in which modules are imported due to `Chunk._modules` being converted from an `Array` to a `Set` in `webpack@3`

- https://github.com/webpack/webpack/issues/5204
- https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/548

**Does this PR introduce a breaking change?**
No.

