### PR TITLE
Variables defined by "let" keyword causes reference error in safari when eval-sourcemap is enabled.

### DIFF
--- a/lib/EvalDevToolModuleTemplatePlugin.js
+++ b/lib/EvalDevToolModuleTemplatePlugin.js
@@ -15,7 +15,7 @@ class EvalDevToolModuleTemplatePlugin {
 
 	apply(moduleTemplate) {
 		moduleTemplate.plugin("module", (source, module) => {
-			const content = "{" + source.source() + "}";
+			const content = "{" + source.source() + "\n}";
 			const str = ModuleFilenameHelpers.createFilename(module, this.moduleFilenameTemplate, moduleTemplate.requestShortener);
 			const footer = ["\n",
 				ModuleFilenameHelpers.createFooter(module, moduleTemplate.requestShortener),

--- a/lib/EvalDevToolModuleTemplatePlugin.js
+++ b/lib/EvalDevToolModuleTemplatePlugin.js
@@ -15,7 +15,7 @@ class EvalDevToolModuleTemplatePlugin {
 
 	apply(moduleTemplate) {
 		moduleTemplate.plugin("module", (source, module) => {
-			const content = source.source();
+			const content = "{" + source.source() + "}";
 			const str = ModuleFilenameHelpers.createFilename(module, this.moduleFilenameTemplate, moduleTemplate.requestShortener);
 			const footer = ["\n",
 				ModuleFilenameHelpers.createFooter(module, moduleTemplate.requestShortener),

--- a/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
+++ b/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
@@ -55,7 +55,7 @@ class EvalSourceMapDevToolModuleTemplatePlugin {
 			sourceMap.sources = moduleFilenames;
 			if(sourceMap.sourcesContent) {
 				sourceMap.sourcesContent = sourceMap.sourcesContent.map(function(content, i) {
-					return `{${content}}\n\n\n${ModuleFilenameHelpers.createFooter(modules[i], this.requestShortener)}`;
+					return `{${content}\n}\n\n\n${ModuleFilenameHelpers.createFooter(modules[i], this.requestShortener)}`;
 				}, this);
 			}
 			sourceMap.sourceRoot = options.sourceRoot || "";

--- a/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
+++ b/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
@@ -55,7 +55,7 @@ class EvalSourceMapDevToolModuleTemplatePlugin {
 			sourceMap.sources = moduleFilenames;
 			if(sourceMap.sourcesContent) {
 				sourceMap.sourcesContent = sourceMap.sourcesContent.map(function(content, i) {
-					return `${content}\n\n\n${ModuleFilenameHelpers.createFooter(modules[i], this.requestShortener)}`;
+					return `{${content}}\n\n\n${ModuleFilenameHelpers.createFooter(modules[i], this.requestShortener)}`;
 				}, this);
 			}
 			sourceMap.sourceRoot = options.sourceRoot || "";


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

No. It's browser dependant.

**If relevant, link to documentation update:**

N/A

**Summary**

Variables defined with "let" keyword are ignored and causes reference error in safari (OS X).

I reproduced the error.
https://github.com/h-ikeda/test-webpack-eval-source-map

It seems safari to try to access global variable and show the reference error.

In this PR, I wrapped eval content by { }, then variables with "let" is in block scope :-)

**Does this PR introduce a breaking change?**

No.

**Other information**