### PR TITLE
Allow sourcemaps generated through SourceMapDevToolPlugin with optimize-minimize

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -437,8 +437,11 @@ module.exports = function(yargs, argv, convertOptions) {
 			ensureArray(options, "plugins");
 			var UglifyJsPlugin = require("../lib/optimize/UglifyJsPlugin");
 			var LoaderOptionsPlugin = require("../lib/LoaderOptionsPlugin");
+			var SourceMapDevToolPlugin = require("../lib/SourceMapDevToolPlugin");
 			options.plugins.push(new UglifyJsPlugin({
-				sourceMap: options.devtool && (options.devtool.indexOf("sourcemap") >= 0 || options.devtool.indexOf("source-map") >= 0)
+				sourceMap: (options.devtool && (options.devtool.indexOf("sourcemap") >= 0 || options.devtool.indexOf("source-map") >= 0) || options.plugins.find((plugin) => {
+					return plugin instanceof SourceMapDevToolPlugin
+				}))
 			}));
 			options.plugins.push(new LoaderOptionsPlugin({
 				minimize: true

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -440,7 +440,7 @@ module.exports = function(yargs, argv, convertOptions) {
 			var SourceMapDevToolPlugin = require("../lib/SourceMapDevToolPlugin");
 			options.plugins.push(new UglifyJsPlugin({
 				sourceMap: (options.devtool && (options.devtool.indexOf("sourcemap") >= 0 || options.devtool.indexOf("source-map") >= 0) || options.plugins.find((plugin) => {
-					return plugin instanceof SourceMapDevToolPlugin
+					return plugin instanceof SourceMapDevToolPlugin;
 				}))
 			}));
 			options.plugins.push(new LoaderOptionsPlugin({


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Currently, the command line option 'optimize-minimize' will allow generated sourcemaps if the user has the devtool option set, but doesn't respect the same settings when configured through the plugin directly.

**Did you add tests for your changes?**

Any feedback on testing for this change would be lovely; wasn't exactly sure how to get a cli test up and running using the SourceMapDevTool plugin

**Summary**

The CLI option -p, or 'optimize-minimize' is designed for production bundles. It will generate sourcemaps if the user configures sourcemaps through 'devtool', but doesn't respect that same settings when configured through the plugin directly.

**Does this PR introduce a breaking change?**

No

**Other information**
