### PR TITLE
[Parser] support rename `this` in `.call(this)` inside arbitrary level `.call` for IIFE

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -266,6 +266,14 @@ class Parser extends Tapable {
 				return this.applyPluginsBailResult1("evaluate defined Identifier " + name, expr);
 			}
 		});
+		this.plugin("evaluate ThisExpression", function(expr) {
+			const name = this.scope.renames.$this;
+			if(name) {
+				const result = this.applyPluginsBailResult1("evaluate Identifier " + name, expr);
+				if(result) return result;
+				return new BasicEvaluatedExpression().setIdentifier(name).setRange(expr.range);
+			}
+		});
 		this.plugin("evaluate MemberExpression", function(expression) {
 			let expr = expression;
 			let exprName = [];

--- a/test/Parser.test.js
+++ b/test/Parser.test.js
@@ -180,6 +180,17 @@ describe("Parser", () => {
 				ijksub: ["test"]
 			}
 		],
+		"renaming this's properties with nested IIFE (called)": [
+			function() {
+				! function() {
+					! function() {
+						this.sub;
+					}.call(this);
+				}.call(ijk);
+			}, {
+				ijksub: ["test"]
+			}
+		],
 	};
 
 	Object.keys(testCases).forEach((name) => {

--- a/test/configCases/plugins/provide-plugin/index.js
+++ b/test/configCases/plugins/provide-plugin/index.js
@@ -24,6 +24,16 @@ it("should provide a module for a nested var within a IIFE's this", function() {
 	}.call(process));
 });
 
+it("should provide a module for a nested var within a nested IIFE's this", function() {
+	(function() {
+		(function() {
+			(this.env.NODE_ENV).should.be.eql("development");
+			var x = this.env.NODE_ENV;
+			x.should.be.eql("development");
+		}.call(this));
+	}.call(process));
+});
+
 it("should not provide a module for a part of a var", function() {
 	(typeof bbb).should.be.eql("undefined");
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
none
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
This change is a successor/supplementary/bugfix of #5076, which supports rename `this's property for IIFE for one level `.call`. This PR makes that available for arbitrary level.

For example, #5076 makes this available:
with config
```javascript
new webpack.ProvidePlugin({
  'window.jQuery': 'jquery',
})
```
code with one level `.call`
```javascript
(function () {
  window.export = this.jQuery;
}).call(window);
```
will replace the `jQuery` with resolved one.

but code with two level `.call`
```javascript
(function () {
  (function () {
    window.export = this.jQuery;
  }).call(this);
}).call(window);
```
`jQuery` would not be replaced.

This PR makes it available too.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
