### PR TITLE
Fix typo that causes "TypeError: this.compiler.compiler is not a function

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -71,7 +71,7 @@ class Watching {
 
 							this.compiler.applyPluginsAsync("additional-pass", err => {
 								if(err) return this._done(err);
-								this.compiler.compiler(onCompiled);
+								this.compiler.compile(onCompiled);
 							});
 							return;
 						}


### PR DESCRIPTION
## BUG FIX

Fixed the typo that causes the following error:

*TypeError: this.compiler.compiler is not a function*

everytime after server side hot-reloading and emitting `additional-pass` event.