### PR TITLE
Protect when outdatedDep is not in installedModules

### DIFF
--- a/lib/HotModuleReplacement.runtime.js
+++ b/lib/HotModuleReplacement.runtime.js
@@ -499,6 +499,7 @@ module.exports = function() {
 		for(moduleId in outdatedDependencies) {
 			if(Object.prototype.hasOwnProperty.call(outdatedDependencies, moduleId)) {
 				module = installedModules[moduleId];
+				if(!module) continue;
 				moduleOutdatedDependencies = outdatedDependencies[moduleId];
 				var callbacks = [];
 				for(i = 0; i < moduleOutdatedDependencies.length; i++) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

Not really sure how to add a test for this.  This module is one giant function with many global variable references. If I could get some guidance on how to mock globals within the mocha testing framework I'd be happy to setup some tests.

**If relevant, link to documentation update:**

N/A

**Summary**

In almost every internal function a check is made to see if a given moduleId exists within the installedModules object before acting on the module. If it doesn't exist, the functions skip that module and continue their process. However in the "call accept handlers" section we don't make this check. This PR makes that check.

**Does this PR introduce a breaking change?**

No

**Other information**
