### PR TITLE
[Perf] Memoize relative paths to speed up builds

### DIFF
--- a/lib/optimize/AggressiveSplittingPlugin.js
+++ b/lib/optimize/AggressiveSplittingPlugin.js
@@ -56,7 +56,7 @@ class AggressiveSplittingPlugin {
 
 						const nameToModuleMap = new Map();
 						chunk.forEachModule(m => {
-							const name = identifierUtils.makePathsRelative(compiler.context, m.identifier());
+							const name = identifierUtils.makePathsRelative(compiler.context, m.identifier(), compilation.cache);
 							nameToModuleMap.set(name, m);
 						});
 
@@ -127,7 +127,7 @@ class AggressiveSplittingPlugin {
 							newChunk.origins = chunk.origins.map(copyWithReason);
 							chunk.origins = chunk.origins.map(copyWithReason);
 							compilation._aggressiveSplittingSplits = (compilation._aggressiveSplittingSplits || []).concat({
-								modules: newChunk.mapModules(m => identifierUtils.makePathsRelative(compiler.context, m.identifier()))
+								modules: newChunk.mapModules(m => identifierUtils.makePathsRelative(compiler.context, m.identifier(), compilation.cache))
 							});
 							return true;
 						} else {
@@ -144,7 +144,7 @@ class AggressiveSplittingPlugin {
 					if(chunk.hasEntryModule()) return;
 					const size = chunk.size(this.options);
 					const incorrectSize = size < minSize;
-					const modules = chunk.mapModules(m => identifierUtils.makePathsRelative(compiler.context, m.identifier()));
+					const modules = chunk.mapModules(m => identifierUtils.makePathsRelative(compiler.context, m.identifier(), compilation.cache));
 					if(typeof chunk._fromAggressiveSplittingIndex === "undefined") {
 						if(incorrectSize) return;
 						chunk.recorded = true;

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -19,18 +19,20 @@ exports.makePathsRelative = (context, identifier, cache) => {
 	if(!cache) return _makePathsRelative(context, identifier);
 
 	const relativePaths = cache.relativePaths || (cache.relativePaths = new Map());
-	if(!relativePaths.has(context)) {
-		relativePaths.set(context, new Map());
+
+	let cachedResult;
+	let contextCache = relativePaths.get(context)
+	if(typeof contextCache === "undefined") {
+		relativePaths.set(context, contextCache = new Map());
+	} else {
+		cachedResult = contextCache.get(identifier)
 	}
 
-	const contextCache = relativePaths.get(context);
-
-	if(contextCache.has(identifier)) {
-		return contextCache.get(identifier);
+	if(typeof cachedResult !== "undefined") {
+		return cachedResult;
 	} else {
-		let relativePath = _makePathsRelative(context, identifier);
+		const relativePath = _makePathsRelative(context, identifier);
 		contextCache.set(identifier, relativePath);
 		return relativePath;
 	}
-
 };

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -21,11 +21,11 @@ exports.makePathsRelative = (context, identifier, cache) => {
 	const relativePaths = cache.relativePaths || (cache.relativePaths = new Map());
 
 	let cachedResult;
-	let contextCache = relativePaths.get(context)
+	let contextCache = relativePaths.get(context);
 	if(typeof contextCache === "undefined") {
 		relativePaths.set(context, contextCache = new Map());
 	} else {
-		cachedResult = contextCache.get(identifier)
+		cachedResult = contextCache.get(identifier);
 	}
 
 	if(typeof cachedResult !== "undefined") {

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -7,10 +7,26 @@ const looksLikeAbsolutePath = (maybeAbsolutePath) => {
 
 const normalizePathSeparator = (p) => p.replace(/\\/g, "/");
 
+/* A map from context dir strings to maps from identifier names to relative paths */
+const relativePaths = new Map();
+
 exports.makePathsRelative = (context, identifier) => {
-	return identifier
-		.split(/([|! ])/)
-		.map(str => looksLikeAbsolutePath(str) ?
-			normalizePathSeparator(path.relative(context, str)) : str)
-		.join("");
+	if(!relativePaths.has(context)) {
+		relativePaths.set(context, new Map());
+	}
+
+	const contextCache = relativePaths.get(context);
+
+	if(contextCache.has(identifier)) {
+		return contextCache.get(identifier);
+	} else {
+		var relativePath = identifier
+			.split(/([|! ])/)
+			.map(str => looksLikeAbsolutePath(str) ?
+				normalizePathSeparator(path.relative(context, str)) : str)
+			.join("");
+		contextCache.set(identifier, relativePath);
+		return relativePath;
+	}
+
 };

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -13,7 +13,7 @@ const _makePathsRelative = (context, identifier) => {
 		.map(str => looksLikeAbsolutePath(str) ?
 			normalizePathSeparator(path.relative(context, str)) : str)
 		.join("");
-}
+};
 
 exports.makePathsRelative = (context, identifier, cache) => {
 	if(!cache) return _makePathsRelative(context, identifier);

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -7,10 +7,18 @@ const looksLikeAbsolutePath = (maybeAbsolutePath) => {
 
 const normalizePathSeparator = (p) => p.replace(/\\/g, "/");
 
-/* A map from context dir strings to maps from identifier names to relative paths */
-const relativePaths = new Map();
+const _makePathsRelative = (context, identifier) => {
+	return identifier
+		.split(/([|! ])/)
+		.map(str => looksLikeAbsolutePath(str) ?
+			normalizePathSeparator(path.relative(context, str)) : str)
+		.join("");
+}
 
-exports.makePathsRelative = (context, identifier) => {
+exports.makePathsRelative = (context, identifier, cache) => {
+	if(!cache) return _makePathsRelative(context, identifier);
+
+	const relativePaths = cache.relativePaths || (cache.relativePaths = new Map());
 	if(!relativePaths.has(context)) {
 		relativePaths.set(context, new Map());
 	}
@@ -20,11 +28,7 @@ exports.makePathsRelative = (context, identifier) => {
 	if(contextCache.has(identifier)) {
 		return contextCache.get(identifier);
 	} else {
-		var relativePath = identifier
-			.split(/([|! ])/)
-			.map(str => looksLikeAbsolutePath(str) ?
-				normalizePathSeparator(path.relative(context, str)) : str)
-			.join("");
+		let relativePath = _makePathsRelative(context, identifier);
 		contextCache.set(identifier, relativePath);
 		return relativePath;
 	}


### PR DESCRIPTION
AggressiveSplittingPlugin asks for relative paths for each (module,chunk) pair for every time it is run (which is a lot if it does multiple splits). On the example in the [webpack stress test](https://github.com/asolove/webpack-stress-test), just looking up relative paths was most of the time in the profile.

This PR adds a manual memoization to the relative path lookup. On the webpack stress test, this reduces the run time from ~60s to ~12s on my machine.

In Slack, there was discussion of two other solutions to this, which are not in this PR:

1. We could actually fix the logic in AggressiveSplittingPlugin. Right now, the plugin re-runs all of its logic every time it makes a split, so if it ends up making N splits, the time required actually grows O(n^2). This should still be done, but it was beyond my current understanding. This PR makes the coefficient on the O(n^2) drastically smaller and so is already a substantial improvement. 

2. It was suggested to switch from a manual memoization to the lodash implementation. I have currently not done this because lodash is currently a dev dependency and adding it to this logic would force it to become a hard dependency. Also, the manual version performs a good deal better (12s v 30s on the stress test). I think this is because lodash needs to inspect `arguments` and run a function to transform them into a cache key, whereas my manual memoization takes advantage of knowing we have exactly two strings to avoid that. (I'm happy to switch to lodash if someone is ok with adding it as a dependency and accepting the slowdown.)