### PR TITLE
refactor: collapse several array iterators into a single reduce

### DIFF
--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -17,6 +17,37 @@ const basename = (name) => {
 	return name.substr(name.lastIndexOf("/") + 1);
 };
 
+function getTaskForFile(file, chunk, options, compilation) {
+	const asset = compilation.assets[file];
+	if(asset.__SourceMapDevToolFile === file && asset.__SourceMapDevToolData) {
+		const data = asset.__SourceMapDevToolData;
+		for(const cachedFile in data) {
+			compilation.assets[cachedFile] = data[cachedFile];
+			if(cachedFile !== file)
+				chunk.files.push(cachedFile);
+		}
+		return;
+	}
+	let source, sourceMap;
+	if(asset.sourceAndMap) {
+		const sourceAndMap = asset.sourceAndMap(options);
+		sourceMap = sourceAndMap.map;
+		source = sourceAndMap.source;
+	} else {
+		sourceMap = asset.map(options);
+		source = asset.source();
+	}
+	if(sourceMap) {
+		return {
+			chunk,
+			file,
+			asset,
+			source,
+			sourceMap
+		};
+	}
+}
+
 class SourceMapDevToolPlugin {
 	constructor(options) {
 		if(arguments.length > 1)
@@ -43,57 +74,43 @@ class SourceMapDevToolPlugin {
 		const requestShortener = new RequestShortener(compiler.context);
 		const options = this.options;
 		options.test = options.test || /\.(js|css)($|\?)/i;
+
+		const matchObject = ModuleFilenameHelpers.matchObject.bind(undefined, options);
+
 		compiler.plugin("compilation", compilation => {
 			new SourceMapDevToolModuleOptionsPlugin(options).apply(compilation);
+
 			compilation.plugin("after-optimize-chunk-assets", function(chunks) {
 				const moduleToSourceNameMapping = new Map();
-				const tasks = [];
+				let tasks = [];
+
 				chunks.forEach(function(chunk) {
-					chunk.files.filter(ModuleFilenameHelpers.matchObject.bind(undefined, options)).map(function(file) {
-						const asset = compilation.assets[file];
-						if(asset.__SourceMapDevToolFile === file && asset.__SourceMapDevToolData) {
-							const data = asset.__SourceMapDevToolData;
-							for(const cachedFile in data) {
-								compilation.assets[cachedFile] = data[cachedFile];
-								if(cachedFile !== file)
-									chunk.files.push(cachedFile);
-							}
-							return;
-						}
-						let source, sourceMap;
-						if(asset.sourceAndMap) {
-							const sourceAndMap = asset.sourceAndMap(options);
-							sourceMap = sourceAndMap.map;
-							source = sourceAndMap.source;
-						} else {
-							sourceMap = asset.map(options);
-							source = asset.source();
-						}
-						if(sourceMap) {
-							return {
-								chunk,
-								file,
-								asset,
-								source,
-								sourceMap
-							};
-						}
-					}).filter(Boolean).map(task => {
-						const modules = task.sourceMap.sources.map(source => {
-							const module = compilation.findModule(source);
-							return module || source;
-						});
-						for(const module of modules) {
-							if(!moduleToSourceNameMapping.get(module)) {
-								moduleToSourceNameMapping.set(module, ModuleFilenameHelpers.createFilename(module, moduleFilenameTemplate, requestShortener));
+					tasks = chunk.files.reduce((queue, file) => {
+						if(matchObject(file)) {
+							const task = getTaskForFile(file, chunk, options, compilation);
+
+							if(task) {
+								const modules = task.sourceMap.sources.map(source => {
+									const module = compilation.findModule(source);
+									return module || source;
+								});
+
+								for(const module of modules) {
+									if(!moduleToSourceNameMapping.get(module)) {
+										moduleToSourceNameMapping.set(module, ModuleFilenameHelpers.createFilename(module, moduleFilenameTemplate, requestShortener));
+									}
+								}
+
+								task.modules = modules;
+
+								queue.push(task);
 							}
 						}
-						task.modules = modules;
-						return task;
-					}).forEach(task => {
-						tasks.push(task);
-					});
+
+						return queue;
+					}, tasks);
 				});
+
 				const usedNamesSet = new Set(moduleToSourceNameMapping.values());
 				const conflictDetectionSet = new Set();
 

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -43,7 +43,8 @@ function getTaskForFile(file, chunk, options, compilation) {
 			file,
 			asset,
 			source,
-			sourceMap
+			sourceMap,
+			modules: undefined
 		};
 	}
 }
@@ -82,10 +83,10 @@ class SourceMapDevToolPlugin {
 
 			compilation.plugin("after-optimize-chunk-assets", function(chunks) {
 				const moduleToSourceNameMapping = new Map();
-				let tasks = [];
+				const tasks = [];
 
 				chunks.forEach(function(chunk) {
-					tasks = chunk.files.reduce((queue, file) => {
+					chunk.files.forEach(file => {
 						if(matchObject(file)) {
 							const task = getTaskForFile(file, chunk, options, compilation);
 
@@ -103,12 +104,10 @@ class SourceMapDevToolPlugin {
 
 								task.modules = modules;
 
-								queue.push(task);
+								tasks.push(task);
 							}
 						}
-
-						return queue;
-					}, tasks);
+					});
 				});
 
 				const usedNamesSet = new Set(moduleToSourceNameMapping.values());

--- a/yarn.lock
+++ b/yarn.lock
@@ -4054,7 +4054,7 @@ ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
-uglify-js@^2.6, uglify-js@^2.8.29:
+uglify-js@^2.4.19, uglify-js@^2.6, uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
refactoring

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
using existing tests

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
n/a

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
This piece of code was very complicated and hard to read due to all the chaining. It seemed like a good use case for a `reduce` instead of all extra array iterations.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
n/a