### PR TITLE
Yargs.alias does not take 3 argument, only 2

### DIFF
--- a/bin/config-yargs.js
+++ b/bin/config-yargs.js
@@ -9,7 +9,7 @@ var OPTIMIZE_GROUP = "Optimizing options:";
 module.exports = function(yargs) {
 	yargs
 		.help("help")
-		.alias("help", "h", "?")
+		.alias("help", "h")
 		.version()
 		.alias("version", "v")
 		.options({


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Yargs.alias only takes 2 arguments, not 3, this fixes `webpack/bin/config-yargs` using it wrongly.

This should fix the following problem: https://github.com/webpack/webpack-dev-server/issues/983

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

N/A

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

https://github.com/yargs/yargs/blob/master/docs/api.md#aliaskey-alias

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

Fixes https://github.com/webpack/webpack-dev-server/issues/983
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

Not as far as I know.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
