### PR TITLE
Fix uncaught exception warning for HMR updates in Chrome #5175

### DIFF
--- a/lib/HotModuleReplacement.runtime.js
+++ b/lib/HotModuleReplacement.runtime.js
@@ -228,11 +228,19 @@ module.exports = function() {
 		hotDeferred = null;
 		if(!deferred) return;
 		if(hotApplyOnUpdate) {
-			hotApply(hotApplyOnUpdate).then(function(result) {
-				deferred.resolve(result);
-			}, function(err) {
-				deferred.reject(err);
-			});
+			// Wrap deferred object in Promise to mark it as a well-handled Promise to
+			// avoid triggering uncaught exception warning in Chrome.
+			// See https://bugs.chromium.org/p/chromium/issues/detail?id=465666
+			Promise.resolve().then(function() {
+				return hotApply(hotApplyOnUpdate);
+			}).then(
+				function(result) {
+					deferred.resolve(result);
+				},
+				function(err) {
+					deferred.reject(err);
+				}
+			);
 		} else {
 			var outdatedModules = [];
 			for(var id in hotUpdate) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Description**
This bugfix wrap deferred object in Promise to mark it as a well-handled Promise to avoid triggering uncaught exception warning in Chrome, and fixes #5175.

See discussion on the Chrome tracker, https://bugs.chromium.org/p/chromium/issues/detail?id=465666

Inline comment added with reference to the Chrome issue for future references. I don't know if this is an established webpack pattern. 

Credits goes to @sokra  + @B-Reif for the actual code change.

**Validation**
Validated the change in Chrome DevTools and VS Code with Chrome debugger.