### PR TITLE
refactor: reduce array allocations, remove some excess iterations

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -392,9 +392,16 @@ class NormalModule extends Module {
 		 * These will contain the variable name and its expression.
 		 * The name will be added as a paramter in a IIFE the expression as its value.
 		 */
-		const vars = block.variables.map((variable) => this.sourceVariables(
-				variable, availableVars, dependencyTemplates, outputOptions, requestShortener))
-			.filter(Boolean);
+		const vars = block.variables.reduce((result, value) => {
+			const variable = this.sourceVariables(
+				value, availableVars, dependencyTemplates, outputOptions, requestShortener);
+
+			if(variable) {
+				result.push(variable);
+			}
+
+			return result;
+		}, []);
 
 		/**
 		 * if we actually have variables
@@ -420,15 +427,22 @@ class NormalModule extends Module {
 			const injectionVariableChunks = this.splitVariablesInUniqueNamedChunks(vars);
 
 			// create all the beginnings of IIFEs
-			const functionWrapperStarts = injectionVariableChunks.map((variableChunk) => variableChunk.map(variable => variable.name))
-				.map(names => this.variableInjectionFunctionWrapperStartCode(names));
+			const functionWrapperStarts = injectionVariableChunks.map((variableChunk) => {
+				return this.variableInjectionFunctionWrapperStartCode(
+					variableChunk.map(variable => variable.name)
+				);
+			});
 
 			// and all the ends
-			const functionWrapperEnds = injectionVariableChunks.map((variableChunk) => variableChunk.map(variable => variable.expression))
-				.map(expressions => this.variableInjectionFunctionWrapperEndCode(expressions, block));
+			const functionWrapperEnds = injectionVariableChunks.map((variableChunk) => {
+				return this.variableInjectionFunctionWrapperEndCode(
+					variableChunk.map(variable => variable.expression), block
+				);
+			});
 
 			// join them to one big string
 			const varStartCode = functionWrapperStarts.join("");
+
 			// reverse the ends first before joining them, as the last added must be the inner most
 			const varEndCode = functionWrapperEnds.reverse().join("");
 
@@ -440,8 +454,17 @@ class NormalModule extends Module {
 				source.insert(end + 0.5, "\n/* WEBPACK VAR INJECTION */" + varEndCode);
 			}
 		}
-		block.blocks.forEach((block) => this.sourceBlock(
-			block, availableVars.concat(vars), dependencyTemplates, source, outputOptions, requestShortener));
+
+		block.blocks.forEach((block) =>
+			this.sourceBlock(
+				block,
+				availableVars.concat(vars),
+				dependencyTemplates,
+				source,
+				outputOptions,
+				requestShortener
+			)
+		);
 	}
 
 	source(dependencyTemplates, outputOptions, requestShortener) {

--- a/lib/optimize/ChunkModuleIdRangePlugin.js
+++ b/lib/optimize/ChunkModuleIdRangePlugin.js
@@ -11,9 +11,7 @@ class ChunkModuleIdRangePlugin {
 		const options = this.options;
 		compiler.plugin("compilation", (compilation) => {
 			compilation.plugin("module-ids", (modules) => {
-				const chunk = this.chunks.filter((chunk) => {
-					return chunk.name === options.name;
-				})[0];
+				const chunk = this.chunks.find((chunk) => chunk.name === options.name);
 				if(!chunk) throw new Error("ChunkModuleIdRangePlugin: Chunk with name '" + options.name + "' was not found");
 				let currentId = options.start;
 				let chunkModules;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
light refactoring

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
existing tests

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
n/a

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
1. Moved usage of `[].concat` to `Array.prototype.concat` to remove the extra array allocation.
2. Collapsed some cases where array iterations could be successfully reduced

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
n/a