### PR TITLE
Parser performance improvements

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -6,11 +6,11 @@
 
 // Syntax: https://developer.mozilla.org/en/SpiderMonkey/Parser_API
 
-const util = require("util");
 const acorn = require("acorn-dynamic-import").default;
 const Tapable = require("tapable");
 const json5 = require("json5");
 const BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
+const StackedSetMap = require("./util/StackedSetMap");
 
 function joinRanges(startRange, endRange) {
 	if(!endRange) return startRange;
@@ -37,77 +37,6 @@ const POSSIBLE_AST_OPTIONS = [{
 		dynamicImport: true
 	}
 }];
-
-class StackedSetMap {
-	constructor(defaultValue, parentStack) {
-		this.defaultValue = defaultValue;
-		this.stack = parentStack === undefined ? [] : parentStack.slice();
-		this.map = new Map();
-		this.stack.push(this.map);
-	}
-
-	add(item) {
-		this.map.set(item, true);
-	}
-
-	set(item, value) {
-		this.map.set(item, value);
-	}
-
-	delete(item) {
-		this.map.set(item, false);
-	}
-
-	has(item) {
-		return this.get(item, false);
-	}
-
-	get(item) {
-		const topValue = this.map.get(item);
-		if(typeof topValue !== "undefined")
-			return topValue;
-		for(var i = this.stack.length - 2; i >= 0; i--) {
-			const value = this.stack[i].get(item);
-			if(typeof value !== "undefined") {
-				this.map.set(item, value);
-				return value;
-			}
-		}
-		this.map.set(item, this.defaultValue);
-		return this.defaultValue;
-	}
-
-	_compress() {
-		this.map = new Map();
-		for(const data of this.stack) {
-			for(const pair of data) {
-				this.map.set(pair[0], pair[1]);
-			}
-		}
-		this.stack = [this.map];
-	}
-
-	asSet() {
-		this._compress();
-		return new Set(Array.from(this.map.entries()).filter(pair => pair[1]).map(pair => pair[0]));
-	}
-
-	createChild() {
-		return new StackedSetMap(this.defaultValue, this.stack);
-	}
-
-	get length() {
-		throw new Error("Parser.definitions is no longer an Array");
-	}
-
-	set length(value) {
-		throw new Error("Parser.definitions is no longer an Array");
-	}
-}
-
-StackedSetMap.prototype.push = util.deprecate(function(item) {
-	this.add(item);
-}, "Parser.definitions is no longer an Array: Use add instead.");
 
 class TrackingSet {
 	constructor(set) {

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -77,6 +77,21 @@ class StackedSetMap {
 		return this.defaultValue;
 	}
 
+	_compress() {
+		this.map = new Map();
+		for(const data of this.stack) {
+			for(const pair of data) {
+				this.map.set(pair[0], pair[1]);
+			}
+		}
+		this.stack = [this.map];
+	}
+
+	asSet() {
+		this._compress();
+		return new Set(Array.from(this.map.entries()).filter(pair => pair[1]).map(pair => pair[0]));
+	}
+
 	createChild() {
 		return new StackedSetMap(this.defaultValue, this.stack);
 	}
@@ -1493,7 +1508,7 @@ class Parser extends Tapable {
 		if(expr.type === "Identifier") {
 			free = !this.scope.definitions.has(expr.name);
 			exprName.push(this.scope.renames.get(expr.name) || expr.name);
-		} else if(expr.type === "ThisExpression" && this.scope.renames.$this) {
+		} else if(expr.type === "ThisExpression" && this.scope.renames.get("this")) {
 			free = true;
 			exprName.push(this.scope.renames.get("this"));
 		} else if(expr.type === "ThisExpression") {

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -6,6 +6,7 @@
 
 // Syntax: https://developer.mozilla.org/en/SpiderMonkey/Parser_API
 
+const util = require("util");
 const acorn = require("acorn-dynamic-import").default;
 const Tapable = require("tapable");
 const json5 = require("json5");
@@ -36,6 +37,92 @@ const POSSIBLE_AST_OPTIONS = [{
 		dynamicImport: true
 	}
 }];
+
+class StackedSetMap {
+	constructor(defaultValue, parentStack) {
+		this.defaultValue = defaultValue;
+		this.stack = parentStack === undefined ? [] : parentStack.slice();
+		this.map = new Map();
+		this.stack.push(this.map);
+	}
+
+	add(item) {
+		this.map.set(item, true);
+	}
+
+	set(item, value) {
+		this.map.set(item, value);
+	}
+
+	delete(item) {
+		this.map.set(item, false);
+	}
+
+	has(item) {
+		return this.get(item, false);
+	}
+
+	get(item) {
+		const topValue = this.map.get(item);
+		if(typeof topValue !== "undefined")
+			return topValue;
+		for(var i = this.stack.length - 2; i >= 0; i--) {
+			const value = this.stack[i].get(item);
+			if(typeof value !== "undefined") {
+				this.map.set(item, value);
+				return value;
+			}
+		}
+		this.map.set(item, this.defaultValue);
+		return this.defaultValue;
+	}
+
+	createChild() {
+		return new StackedSetMap(this.defaultValue, this.stack);
+	}
+
+	get length() {
+		throw new Error("Parser.definitions is no longer an Array");
+	}
+
+	set length(value) {
+		throw new Error("Parser.definitions is no longer an Array");
+	}
+}
+
+StackedSetMap.prototype.push = util.deprecate(function(item) {
+	this.add(item);
+}, "Parser.definitions is no longer an Array: Use add instead.");
+
+class TrackingSet {
+	constructor(set) {
+		this.set = set;
+		this.set2 = new Set();
+		this.stack = set.stack;
+	}
+
+	add(item) {
+		this.set2.add(item);
+		return this.set.add(item);
+	}
+
+	delete(item) {
+		this.set2.delete(item);
+		return this.set.delete(item);
+	}
+
+	has(item) {
+		return this.set.has(item);
+	}
+
+	createChild() {
+		return this.set.createChild();
+	}
+
+	getAddedItems() {
+		return this.set2;
+	}
+}
 
 class Parser extends Tapable {
 	constructor(options) {
@@ -207,8 +294,8 @@ class Parser extends Tapable {
 				let res;
 				let name;
 				if(expr.argument.type === "Identifier") {
-					name = this.scope.renames["$" + expr.argument.name] || expr.argument.name;
-					if(this.scope.definitions.indexOf(name) === -1) {
+					name = this.scope.renames.get(expr.argument.name) || expr.argument.name;
+					if(!this.scope.definitions.has(name)) {
 						res = this.applyPluginsBailResult1("evaluate typeof " + name, expr);
 						if(res !== undefined) return res;
 					}
@@ -248,8 +335,8 @@ class Parser extends Tapable {
 			return new BasicEvaluatedExpression().setString("undefined").setRange(expr.range);
 		});
 		this.plugin("evaluate Identifier", function(expr) {
-			const name = this.scope.renames["$" + expr.name] || expr.name;
-			if(this.scope.definitions.indexOf(expr.name) === -1) {
+			const name = this.scope.renames.get(expr.name) || expr.name;
+			if(!this.scope.definitions.has(expr.name)) {
 				const result = this.applyPluginsBailResult1("evaluate Identifier " + name, expr);
 				if(result) return result;
 				return new BasicEvaluatedExpression().setIdentifier(name).setRange(expr.range);
@@ -258,7 +345,7 @@ class Parser extends Tapable {
 			}
 		});
 		this.plugin("evaluate ThisExpression", function(expr) {
-			const name = this.scope.renames.$this;
+			const name = this.scope.renames.get("this");
 			if(name) {
 				const result = this.applyPluginsBailResult1("evaluate Identifier " + name, expr);
 				if(result) return result;
@@ -625,8 +712,8 @@ class Parser extends Tapable {
 	// Declarations
 	prewalkFunctionDeclaration(statement) {
 		if(statement.id) {
-			this.scope.renames["$" + statement.id.name] = undefined;
-			this.scope.definitions.push(statement.id.name);
+			this.scope.renames.set(statement.id.name, null);
+			this.scope.definitions.add(statement.id.name);
 		}
 	}
 
@@ -649,8 +736,8 @@ class Parser extends Tapable {
 		this.applyPluginsBailResult("import", statement, source);
 		statement.specifiers.forEach(function(specifier) {
 			const name = specifier.local.name;
-			this.scope.renames["$" + name] = undefined;
-			this.scope.definitions.push(name);
+			this.scope.renames.set(name, null);
+			this.scope.definitions.add(name);
 			switch(specifier.type) {
 				case "ImportDefaultSpecifier":
 					this.applyPluginsBailResult("import specifier", statement, source, "default", name);
@@ -678,9 +765,12 @@ class Parser extends Tapable {
 				throw new Error("Doesn't occur?");
 			} else {
 				if(!this.applyPluginsBailResult("export declaration", statement, statement.declaration)) {
-					const pos = this.scope.definitions.length;
+					const originalDefinitions = this.scope.definitions;
+					const tracker = new TrackingSet(this.scope.definitions);
+					this.scope.definitions = tracker;
 					this.prewalkStatement(statement.declaration);
-					const newDefs = this.scope.definitions.slice(pos);
+					const newDefs = Array.from(tracker.getAddedItems());
+					this.scope.definitions = originalDefinitions;
 					for(let index = newDefs.length - 1; index >= 0; index--) {
 						const def = newDefs[index];
 						this.applyPluginsBailResult("export specifier", statement, def, def, index);
@@ -714,9 +804,12 @@ class Parser extends Tapable {
 
 	prewalkExportDefaultDeclaration(statement) {
 		if(/Declaration$/.test(statement.declaration.type)) {
-			const pos = this.scope.definitions.length;
+			const originalDefinitions = this.scope.definitions;
+			const tracker = new TrackingSet(this.scope.definitions);
+			this.scope.definitions = tracker;
 			this.prewalkStatement(statement.declaration);
-			const newDefs = this.scope.definitions.slice(pos);
+			const newDefs = Array.from(tracker.getAddedItems());
+			this.scope.definitions = originalDefinitions;
 			for(let index = 0, len = newDefs.length; index < len; index++) {
 				const def = newDefs[index];
 				this.applyPluginsBailResult("export specifier", statement, def, "default");
@@ -756,8 +849,8 @@ class Parser extends Tapable {
 
 	prewalkClassDeclaration(statement) {
 		if(statement.id) {
-			this.scope.renames["$" + statement.id.name] = undefined;
-			this.scope.definitions.push(statement.id.name);
+			this.scope.renames.set(statement.id.name, null);
+			this.scope.definitions.add(statement.id.name);
 		}
 	}
 
@@ -798,9 +891,8 @@ class Parser extends Tapable {
 						this.enterPattern(declarator.id, (name, decl) => {
 							if(!this.applyPluginsBailResult1("var-" + declarator.kind + " " + name, decl)) {
 								if(!this.applyPluginsBailResult1("var " + name, decl)) {
-									this.scope.renames["$" + name] = undefined;
-									if(this.scope.definitions.indexOf(name) < 0)
-										this.scope.definitions.push(name);
+									this.scope.renames.set(name, null);
+									this.scope.definitions.add(name);
 								}
 							}
 						});
@@ -819,9 +911,8 @@ class Parser extends Tapable {
 						if(renameIdentifier && declarator.id.type === "Identifier" && this.applyPluginsBailResult1("can-rename " + renameIdentifier, declarator.init)) {
 							// renaming with "var a = b;"
 							if(!this.applyPluginsBailResult1("rename " + renameIdentifier, declarator.init)) {
-								this.scope.renames["$" + declarator.id.name] = this.scope.renames["$" + renameIdentifier] || renameIdentifier;
-								const idx = this.scope.definitions.indexOf(declarator.id.name);
-								if(idx >= 0) this.scope.definitions.splice(idx, 1);
+								this.scope.renames.set(declarator.id.name, this.scope.renames.get(renameIdentifier) || renameIdentifier);
+								this.scope.definitions.delete(declarator.id.name);
 							}
 						} else {
 							this.walkPattern(declarator.id);
@@ -979,15 +1070,14 @@ class Parser extends Tapable {
 		if(expression.left.type === "Identifier" && renameIdentifier && this.applyPluginsBailResult1("can-rename " + renameIdentifier, expression.right)) {
 			// renaming "a = b;"
 			if(!this.applyPluginsBailResult1("rename " + renameIdentifier, expression.right)) {
-				this.scope.renames["$" + expression.left.name] = renameIdentifier;
-				const idx = this.scope.definitions.indexOf(expression.left.name);
-				if(idx >= 0) this.scope.definitions.splice(idx, 1);
+				this.scope.renames.set(expression.left.name, renameIdentifier);
+				this.scope.definitions.delete(expression.left.name);
 			}
 		} else if(expression.left.type === "Identifier") {
 			if(!this.applyPluginsBailResult1("assigned " + expression.left.name, expression)) {
 				this.walkExpression(expression.right);
 			}
-			this.scope.renames["$" + expression.left.name] = undefined;
+			this.scope.renames.set(expression.left.name, null);
 			if(!this.applyPluginsBailResult1("assign " + expression.left.name, expression)) {
 				this.walkExpression(expression.left);
 			}
@@ -995,7 +1085,7 @@ class Parser extends Tapable {
 			this.walkExpression(expression.right);
 			this.walkPattern(expression.left);
 			this.enterPattern(expression.left, (name, decl) => {
-				this.scope.renames["$" + name] = undefined;
+				this.scope.renames.set(name, null);
 			});
 		}
 	}
@@ -1061,13 +1151,13 @@ class Parser extends Tapable {
 				return !args[idx];
 			}), () => {
 				if(renameThis) {
-					this.scope.renames.$this = renameThis;
+					this.scope.renames.set("this", renameThis);
 				}
 				for(let i = 0; i < args.length; i++) {
 					const param = args[i];
 					if(!param) continue;
 					if(!params[i] || params[i].type !== "Identifier") continue;
-					this.scope.renames["$" + params[i].name] = param;
+					this.scope.renames.set(params[i].name, param);
 				}
 				if(functionExpression.body.type === "BlockStatement") {
 					this.prewalkStatement(functionExpression.body);
@@ -1079,7 +1169,7 @@ class Parser extends Tapable {
 		if(expression.callee.type === "MemberExpression" &&
 			expression.callee.object.type === "FunctionExpression" &&
 			!expression.callee.computed &&
-			(["call", "bind"]).indexOf(expression.callee.property.name) >= 0 &&
+			(expression.callee.property.name === "call" || expression.callee.property.name === "bind") &&
 			expression.arguments &&
 			expression.arguments.length > 0
 		) {
@@ -1133,8 +1223,8 @@ class Parser extends Tapable {
 	}
 
 	walkIdentifier(expression) {
-		if(this.scope.definitions.indexOf(expression.name) === -1) {
-			const result = this.applyPluginsBailResult1("expression " + (this.scope.renames["$" + expression.name] || expression.name), expression);
+		if(!this.scope.definitions.has(expression.name)) {
+			const result = this.applyPluginsBailResult1("expression " + (this.scope.renames.get(expression.name) || expression.name), expression);
 			if(result === true)
 				return;
 		}
@@ -1145,23 +1235,23 @@ class Parser extends Tapable {
 		this.scope = {
 			inTry: false,
 			inShorthand: false,
-			definitions: oldScope.definitions.slice(),
-			renames: Object.create(oldScope.renames)
+			definitions: oldScope.definitions.createChild(),
+			renames: oldScope.renames.createChild()
 		};
 
-		this.scope.renames.$this = undefined;
+		this.scope.renames.set("this", null);
 
 		for(let paramIndex = 0, len = params.length; paramIndex < len; paramIndex++) {
 			const param = params[paramIndex];
 
 			if(typeof param !== "string") {
 				this.enterPattern(param, param => {
-					this.scope.renames["$" + param] = undefined;
-					this.scope.definitions.push(param);
+					this.scope.renames.set(param, null);
+					this.scope.definitions.add(param);
 				});
 			} else {
-				this.scope.renames["$" + param] = undefined;
-				this.scope.definitions.push(param);
+				this.scope.renames.set(param, null);
+				this.scope.definitions.add(param);
 			}
 		}
 
@@ -1343,8 +1433,8 @@ class Parser extends Tapable {
 		const oldComments = this.comments;
 		this.scope = {
 			inTry: false,
-			definitions: [],
-			renames: {}
+			definitions: new StackedSetMap(false),
+			renames: new StackedSetMap(null)
 		};
 		const state = this.state = initialState || {};
 		this.comments = comments;
@@ -1401,11 +1491,11 @@ class Parser extends Tapable {
 		}
 		let free;
 		if(expr.type === "Identifier") {
-			free = this.scope.definitions.indexOf(expr.name) === -1;
-			exprName.push(this.scope.renames["$" + expr.name] || expr.name);
+			free = !this.scope.definitions.has(expr.name);
+			exprName.push(this.scope.renames.get(expr.name) || expr.name);
 		} else if(expr.type === "ThisExpression" && this.scope.renames.$this) {
 			free = true;
-			exprName.push(this.scope.renames.$this);
+			exprName.push(this.scope.renames.get("this"));
 		} else if(expr.type === "ThisExpression") {
 			free = false;
 			exprName.push("this");
@@ -1429,3 +1519,4 @@ class Parser extends Tapable {
 Parser.ECMA_VERSION = ECMA_VERSION;
 
 module.exports = Parser;
+Parser.StackedSetMap = StackedSetMap;

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -1377,8 +1377,8 @@ class Parser extends Tapable {
 		const oldComments = this.comments;
 		this.scope = {
 			inTry: false,
-			definitions: new StackedSetMap(false),
-			renames: new StackedSetMap(null)
+			definitions: new StackedSetMap(),
+			renames: new StackedSetMap()
 		};
 		const state = this.state = initialState || {};
 		this.comments = comments;

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -370,7 +370,7 @@ class Parser extends Tapable {
 			const param = this.evaluateExpression(expr.callee.object);
 			if(!param) return;
 			const property = expr.callee.property.name || expr.callee.property.value;
-			return this.applyPluginsBailResult("evaluate CallExpression ." + property, expr, param);
+			return this.applyPluginsBailResult2("evaluate CallExpression ." + property, expr, param);
 		});
 		this.plugin("evaluate CallExpression .replace", function(expr, param) {
 			if(!param.isString()) return;
@@ -733,20 +733,20 @@ class Parser extends Tapable {
 
 	prewalkImportDeclaration(statement) {
 		const source = statement.source.value;
-		this.applyPluginsBailResult("import", statement, source);
+		this.applyPluginsBailResult2("import", statement, source);
 		statement.specifiers.forEach(function(specifier) {
 			const name = specifier.local.name;
 			this.scope.renames.set(name, null);
 			this.scope.definitions.add(name);
 			switch(specifier.type) {
 				case "ImportDefaultSpecifier":
-					this.applyPluginsBailResult("import specifier", statement, source, "default", name);
+					this.applyPluginsBailResult4("import specifier", statement, source, "default", name);
 					break;
 				case "ImportSpecifier":
-					this.applyPluginsBailResult("import specifier", statement, source, specifier.imported.name, name);
+					this.applyPluginsBailResult4("import specifier", statement, source, specifier.imported.name, name);
 					break;
 				case "ImportNamespaceSpecifier":
-					this.applyPluginsBailResult("import specifier", statement, source, null, name);
+					this.applyPluginsBailResult4("import specifier", statement, source, null, name);
 					break;
 			}
 		}, this);
@@ -756,7 +756,7 @@ class Parser extends Tapable {
 		let source;
 		if(statement.source) {
 			source = statement.source.value;
-			this.applyPluginsBailResult("export import", statement, source);
+			this.applyPluginsBailResult2("export import", statement, source);
 		} else {
 			this.applyPluginsBailResult1("export", statement);
 		}
@@ -764,7 +764,7 @@ class Parser extends Tapable {
 			if(/Expression$/.test(statement.declaration.type)) {
 				throw new Error("Doesn't occur?");
 			} else {
-				if(!this.applyPluginsBailResult("export declaration", statement, statement.declaration)) {
+				if(!this.applyPluginsBailResult2("export declaration", statement, statement.declaration)) {
 					const originalDefinitions = this.scope.definitions;
 					const tracker = new TrackingSet(this.scope.definitions);
 					this.scope.definitions = tracker;
@@ -773,7 +773,7 @@ class Parser extends Tapable {
 					this.scope.definitions = originalDefinitions;
 					for(let index = newDefs.length - 1; index >= 0; index--) {
 						const def = newDefs[index];
-						this.applyPluginsBailResult("export specifier", statement, def, def, index);
+						this.applyPluginsBailResult4("export specifier", statement, def, def, index);
 					}
 				}
 			}
@@ -786,9 +786,9 @@ class Parser extends Tapable {
 						{
 							const name = specifier.exported.name;
 							if(source)
-								this.applyPluginsBailResult("export import specifier", statement, source, specifier.local.name, name, specifierIndex);
+								this.applyPluginsBailResult5("export import specifier", statement, source, specifier.local.name, name, specifierIndex);
 							else
-								this.applyPluginsBailResult("export specifier", statement, specifier.local.name, name, specifierIndex);
+								this.applyPluginsBailResult4("export specifier", statement, specifier.local.name, name, specifierIndex);
 							break;
 						}
 				}
@@ -812,7 +812,7 @@ class Parser extends Tapable {
 			this.scope.definitions = originalDefinitions;
 			for(let index = 0, len = newDefs.length; index < len; index++) {
 				const def = newDefs[index];
-				this.applyPluginsBailResult("export specifier", statement, def, "default");
+				this.applyPluginsBailResult3("export specifier", statement, def, "default");
 			}
 		}
 	}
@@ -820,21 +820,21 @@ class Parser extends Tapable {
 	walkExportDefaultDeclaration(statement) {
 		this.applyPluginsBailResult1("export", statement);
 		if(/Declaration$/.test(statement.declaration.type)) {
-			if(!this.applyPluginsBailResult("export declaration", statement, statement.declaration)) {
+			if(!this.applyPluginsBailResult2("export declaration", statement, statement.declaration)) {
 				this.walkStatement(statement.declaration);
 			}
 		} else {
 			this.walkExpression(statement.declaration);
-			if(!this.applyPluginsBailResult("export expression", statement, statement.declaration)) {
-				this.applyPluginsBailResult("export specifier", statement, statement.declaration, "default");
+			if(!this.applyPluginsBailResult2("export expression", statement, statement.declaration)) {
+				this.applyPluginsBailResult3("export specifier", statement, statement.declaration, "default");
 			}
 		}
 	}
 
 	prewalkExportAllDeclaration(statement) {
 		const source = statement.source.value;
-		this.applyPluginsBailResult("export import", statement, source);
-		this.applyPluginsBailResult("export import specifier", statement, source, null, null, 0);
+		this.applyPluginsBailResult2("export import", statement, source);
+		this.applyPluginsBailResult5("export import specifier", statement, source, null, null, 0);
 	}
 
 	prewalkVariableDeclaration(statement) {
@@ -1438,7 +1438,7 @@ class Parser extends Tapable {
 		};
 		const state = this.state = initialState || {};
 		this.comments = comments;
-		if(this.applyPluginsBailResult("program", ast, comments) === undefined) {
+		if(this.applyPluginsBailResult2("program", ast, comments) === undefined) {
 			this.prewalkStatements(ast.body);
 			this.walkStatements(ast.body);
 		}

--- a/lib/dependencies/AMDDefineDependencyParserPlugin.js
+++ b/lib/dependencies/AMDDefineDependencyParserPlugin.js
@@ -105,7 +105,7 @@ class AMDDefineDependencyParserPlugin {
 					if(fnParamsOffset < 0) fnParamsOffset = 0;
 				}
 			}
-			let fnRenames = Object.create(parser.scope.renames);
+			let fnRenames = parser.scope.renames.createChild();
 			let identifiers;
 			if(array) {
 				identifiers = {};
@@ -114,7 +114,7 @@ class AMDDefineDependencyParserPlugin {
 				if(!result) return;
 				if(fnParams) fnParams = fnParams.slice(fnParamsOffset).filter((param, idx) => {
 					if(identifiers[idx]) {
-						fnRenames["$" + param.name] = identifiers[idx];
+						fnRenames.set(param.name, identifiers[idx]);
 						return false;
 					}
 					return true;
@@ -123,7 +123,7 @@ class AMDDefineDependencyParserPlugin {
 				identifiers = ["require", "exports", "module"];
 				if(fnParams) fnParams = fnParams.slice(fnParamsOffset).filter((param, idx) => {
 					if(identifiers[idx]) {
-						fnRenames["$" + param.name] = identifiers[idx];
+						fnRenames.set(param.name, identifiers[idx]);
 						return false;
 					}
 					return true;

--- a/lib/dependencies/CommonJsPlugin.js
+++ b/lib/dependencies/CommonJsPlugin.js
@@ -65,7 +65,7 @@ class CommonJsPlugin {
 					const dep = new ConstDependency("var require;", 0);
 					dep.loc = expr.loc;
 					parser.state.current.addDependency(dep);
-					parser.scope.definitions.push("require");
+					parser.scope.definitions.add("require");
 					return true;
 				});
 				parser.plugin("can-rename require", () => true);

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -37,7 +37,7 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 		});
 		parser.plugin("export declaration", statement => {});
 		parser.plugin("export specifier", (statement, id, name, idx) => {
-			const rename = parser.scope.renames[`$${id}`];
+			const rename = parser.scope.renames.get(id);
 			let dep;
 			if(rename === "imported var") {
 				const settings = parser.state.harmonySpecifier[`$${id}`];

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -25,8 +25,8 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			return true;
 		});
 		parser.plugin("import specifier", (statement, source, id, name) => {
-			parser.scope.definitions.length--;
-			parser.scope.renames[`$${name}`] = "imported var";
+			parser.scope.definitions.delete(name);
+			parser.scope.renames.set(name, "imported var");
 			if(!parser.state.harmonySpecifier) parser.state.harmonySpecifier = {};
 			parser.state.harmonySpecifier[`$${name}`] = [parser.state.lastHarmonyImport, HarmonyModulesHelpers.getModuleVar(parser.state, source), id];
 			return true;

--- a/lib/util/StackedSetMap.js
+++ b/lib/util/StackedSetMap.js
@@ -6,9 +6,11 @@
 
 const util = require("util");
 
+const TOMBSTONE = {};
+const UNDEFINED_MARKER = {};
+
 class StackedSetMap {
-	constructor(defaultValue, parentStack) {
-		this.defaultValue = defaultValue;
+	constructor(parentStack) {
 		this.stack = parentStack === undefined ? [] : parentStack.slice();
 		this.map = new Map();
 		this.stack.push(this.map);
@@ -19,37 +21,58 @@ class StackedSetMap {
 	}
 
 	set(item, value) {
-		this.map.set(item, value);
+		this.map.set(item, value === undefined ? UNDEFINED_MARKER : value);
 	}
 
 	delete(item) {
-		this.map.set(item, false);
+		if(this.stack.length > 1)
+			this.map.set(item, TOMBSTONE);
+		else
+			this.map.delete(item);
 	}
 
 	has(item) {
-		return this.get(item, false);
+		const topValue = this.map.get(item);
+		if(topValue !== undefined)
+			return topValue !== TOMBSTONE;
+		if(this.stack.length > 1) {
+			for(var i = this.stack.length - 2; i >= 0; i--) {
+				const value = this.stack[i].get(item);
+				if(value !== undefined) {
+					this.map.set(item, value);
+					return value !== TOMBSTONE;
+				}
+			}
+			this.map.set(item, TOMBSTONE);
+		}
+		return false;
 	}
 
 	get(item) {
 		const topValue = this.map.get(item);
-		if(typeof topValue !== "undefined")
-			return topValue;
-		for(var i = this.stack.length - 2; i >= 0; i--) {
-			const value = this.stack[i].get(item);
-			if(typeof value !== "undefined") {
-				this.map.set(item, value);
-				return value;
+		if(topValue !== undefined)
+			return topValue === TOMBSTONE || topValue === UNDEFINED_MARKER ? undefined : topValue;
+		if(this.stack.length > 1) {
+			for(var i = this.stack.length - 2; i >= 0; i--) {
+				const value = this.stack[i].get(item);
+				if(value !== undefined) {
+					this.map.set(item, value);
+					return value === TOMBSTONE || value === UNDEFINED_MARKER ? undefined : value;
+				}
 			}
+			this.map.set(item, TOMBSTONE);
 		}
-		this.map.set(item, this.defaultValue);
-		return this.defaultValue;
+		return undefined;
 	}
 
 	_compress() {
 		this.map = new Map();
 		for(const data of this.stack) {
 			for(const pair of data) {
-				this.map.set(pair[0], pair[1]);
+				if(pair[1] === TOMBSTONE)
+					this.map.delete(pair[0]);
+				else
+					this.map.set(pair[0], pair[1]);
 			}
 		}
 		this.stack = [this.map];
@@ -57,11 +80,16 @@ class StackedSetMap {
 
 	asSet() {
 		this._compress();
-		return new Set(Array.from(this.map.entries()).filter(pair => pair[1]).map(pair => pair[0]));
+		return new Set(Array.from(this.map.entries()).map(pair => pair[0]));
+	}
+
+	asMap() {
+		this._compress();
+		return new Map(this.map.entries());
 	}
 
 	createChild() {
-		return new StackedSetMap(this.defaultValue, this.stack);
+		return new StackedSetMap(this.stack);
 	}
 
 	get length() {

--- a/lib/util/StackedSetMap.js
+++ b/lib/util/StackedSetMap.js
@@ -1,0 +1,80 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+"use strict";
+
+const util = require("util");
+
+class StackedSetMap {
+	constructor(defaultValue, parentStack) {
+		this.defaultValue = defaultValue;
+		this.stack = parentStack === undefined ? [] : parentStack.slice();
+		this.map = new Map();
+		this.stack.push(this.map);
+	}
+
+	add(item) {
+		this.map.set(item, true);
+	}
+
+	set(item, value) {
+		this.map.set(item, value);
+	}
+
+	delete(item) {
+		this.map.set(item, false);
+	}
+
+	has(item) {
+		return this.get(item, false);
+	}
+
+	get(item) {
+		const topValue = this.map.get(item);
+		if(typeof topValue !== "undefined")
+			return topValue;
+		for(var i = this.stack.length - 2; i >= 0; i--) {
+			const value = this.stack[i].get(item);
+			if(typeof value !== "undefined") {
+				this.map.set(item, value);
+				return value;
+			}
+		}
+		this.map.set(item, this.defaultValue);
+		return this.defaultValue;
+	}
+
+	_compress() {
+		this.map = new Map();
+		for(const data of this.stack) {
+			for(const pair of data) {
+				this.map.set(pair[0], pair[1]);
+			}
+		}
+		this.stack = [this.map];
+	}
+
+	asSet() {
+		this._compress();
+		return new Set(Array.from(this.map.entries()).filter(pair => pair[1]).map(pair => pair[0]));
+	}
+
+	createChild() {
+		return new StackedSetMap(this.defaultValue, this.stack);
+	}
+
+	get length() {
+		throw new Error("This is no longer an Array");
+	}
+
+	set length(value) {
+		throw new Error("This is no longer an Array");
+	}
+}
+
+StackedSetMap.prototype.push = util.deprecate(function(item) {
+	this.add(item);
+}, "This is no longer an Array: Use add instead.");
+
+module.exports = StackedSetMap;

--- a/test/Parser.test.js
+++ b/test/Parser.test.js
@@ -219,7 +219,7 @@ describe("Parser", () => {
 			});
 			testParser.plugin("expression fgh", (expr) => {
 				if(!testParser.state.fgh) testParser.state.fgh = [];
-				testParser.state.fgh.push(testParser.scope.definitions.join(" "));
+				testParser.state.fgh.push(Array.from(testParser.scope.definitions.asSet()).join(" "));
 				return true;
 			});
 			testParser.plugin("expression fgh.sub", (expr) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,7 @@
 # yarn lockfile v1
 
 
-abbrev@1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
-
-abbrev@1.0.x:
+abbrev@1, abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
@@ -1072,17 +1068,13 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
 
-diff@3.2.0:
+diff@3.2.0, diff@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
 diff@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/diff/-/diff-2.2.3.tgz#60eafd0d28ee906e4e8ff0a52c1229521033bf99"
-
-diff@^3.1.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
 
 diffie-hellman@^5.0.0:
   version "5.0.2"
@@ -2192,7 +2184,6 @@ jade@^1.11.0:
     jstransformer "0.0.2"
     mkdirp "~0.5.0"
     transformers "2.1.0"
-    uglify-js "^2.4.19"
     void-elements "~2.0.1"
     with "~4.0.0"
 
@@ -2600,17 +2591,13 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@1.2.0, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
@@ -3402,11 +3389,7 @@ randombytes@^2.0.0, randombytes@^2.0.1:
   dependencies:
     safe-buffer "^5.1.0"
 
-range-parser@^1.0.3:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
-
-range-parser@~1.0.3:
+range-parser@^1.0.3, range-parser@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.0.3.tgz#6872823535c692e2c2a0103826afd82c2e0ff175"
 
@@ -3572,7 +3555,7 @@ request@2.42.0:
     stringstream "~0.0.4"
     tough-cookie ">=0.12.0"
 
-request@2.79.0:
+request@2.79.0, request@^2.34, request@^2.72.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -3597,7 +3580,7 @@ request@2.79.0:
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
-request@^2.34, request@^2.72.0, request@^2.81.0:
+request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -3958,11 +3941,7 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-statuses@1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
-
-statuses@~1.2.1:
+statuses@1, statuses@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.2.1.tgz#dded45cc18256d51ed40aec142489d5c61026d28"
 
@@ -4240,7 +4219,7 @@ ua-parser-js@^0.7.9:
   version "0.7.14"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.14.tgz#110d53fa4c3f326c121292bbeac904d2e03387ca"
 
-uglify-js@^2.4.19, uglify-js@^2.6, uglify-js@^2.8.29:
+uglify-js@^2.6, uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
performance
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
existing tests
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Parser.definitions and Parser.renames are using Maps now
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Yes
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
My first try was using `Set` for definitions, but this was slow because it's often copied for a nested scope. Because of this I implemented `StackedSetMap` which is a stacked versions of `Set` and `Map`. It keeps a stack of parent scope sets/maps to avoid copying. Asking the `StackedSetMap` for a value asks all maps in the stack for the value, starting with the top-most one. A found value is "cached" in the top-most map of the stack. Deleting is implemented as set to the default value in the top-most map. Set is implemented as Map with value is a boolean. This makes all operation very performant:
* creating child scope: O(1)
* reading a value the first time: O(n) with n is the number of parent scopes
* reading a value the second time: O(1)
* writing a value: O(1)