### PR TITLE
Add CLI option for selecting a named config from a multi-config

### DIFF
--- a/bin/config-optimist.js
+++ b/bin/config-optimist.js
@@ -2,6 +2,7 @@ module.exports = function(optimist) {
 	optimist
 		.boolean("help").alias("help", "h").alias("help", "?").describe("help")
 		.string("config").describe("config", "Path to the config file")
+		.string("config-name").describe("config-name", "Name of the config to use")
 		.string("env").describe("env", "Environment passed to the config, when it is a function")
 		.string("context").describe("context", "The root directory for resolving entry point and stats")
 		.string("entry").describe("entry", "The entry point")

--- a/bin/config-yargs.js
+++ b/bin/config-yargs.js
@@ -20,6 +20,12 @@ module.exports = function(yargs) {
 				defaultDescription: "webpack.config.js or webpackfile.js",
 				requiresArg: true
 			},
+			"config-name": {
+				type: "string",
+				describe: "Name of the config to use",
+				group: CONFIG_GROUP,
+				requiresArg: true
+			},
 			"env": {
 				describe: "Environment passed to the config, when it is a function",
 				group: CONFIG_GROUP

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -130,6 +130,20 @@ module.exports = function(yargs, argv, convertOptions) {
 			return processConfiguredOptions(options.default);
 		}
 
+		// filter multi-config by name
+		if(Array.isArray(options) && argv["config-name"]) {
+			var namedOptions = options.filter(function(opt) {
+				return opt.name === argv["config-name"];
+			});
+			if(namedOptions.length === 0) {
+				console.error("Configuration with name '" + argv["config-name"] + "' was not found.");
+				process.exit(-1); // eslint-disable-line
+			} else if(namedOptions.length === 1) {
+				return processConfiguredOptions(namedOptions[0]);
+			}
+			options = namedOptions;
+		}
+
 		if(Array.isArray(options)) {
 			options.forEach(processOptions);
 		} else {

--- a/test/binCases/config-name/found-many/index.js
+++ b/test/binCases/config-name/found-many/index.js
@@ -1,0 +1,1 @@
+module.exports = "foo";

--- a/test/binCases/config-name/found-many/index2.js
+++ b/test/binCases/config-name/found-many/index2.js
@@ -1,0 +1,1 @@
+module.exports = "bar";

--- a/test/binCases/config-name/found-many/test.js
+++ b/test/binCases/config-name/found-many/test.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = function testAssertions(code, stdout, stderr) {
+	code.should.be.exactly(0);
+
+	stdout.should.be.ok();
+	stdout[7].should.containEql("./index2.js");
+	stdout[13].should.containEql("./index3.js");
+	stderr.should.be.empty();
+};
+

--- a/test/binCases/config-name/found-many/test.opts
+++ b/test/binCases/config-name/found-many/test.opts
@@ -1,0 +1,5 @@
+--config ./webpack.config.js
+--config-name bar
+--output-filename [name].js
+--output-chunk-filename [id].chunk.js
+--target async-node

--- a/test/binCases/config-name/found-many/webpack.config.js
+++ b/test/binCases/config-name/found-many/webpack.config.js
@@ -1,0 +1,16 @@
+var path = require("path");
+
+module.exports = [
+	{
+		name: "foo",
+		entry: path.resolve(__dirname, "./index")
+	},
+	{
+		name: "bar",
+		entry: path.resolve(__dirname, "./index2")
+	},
+	{
+		name: "bar",
+		entry: path.resolve(__dirname, "./index3.js")
+	}
+];

--- a/test/binCases/config-name/found-one/index.js
+++ b/test/binCases/config-name/found-one/index.js
@@ -1,0 +1,1 @@
+module.exports = "foo";

--- a/test/binCases/config-name/found-one/index2.js
+++ b/test/binCases/config-name/found-one/index2.js
@@ -1,0 +1,1 @@
+module.exports = "bar";

--- a/test/binCases/config-name/found-one/test.js
+++ b/test/binCases/config-name/found-one/test.js
@@ -1,0 +1,10 @@
+"use strict";
+
+module.exports = function testAssertions(code, stdout, stderr) {
+	code.should.be.exactly(0);
+
+	stdout.should.be.ok();
+	stdout[5].should.containEql("./index2.js");
+	stderr.should.be.empty();
+};
+

--- a/test/binCases/config-name/found-one/test.opts
+++ b/test/binCases/config-name/found-one/test.opts
@@ -1,0 +1,5 @@
+--config ./webpack.config.js
+--config-name bar
+--output-filename [name].js
+--output-chunk-filename [id].chunk.js
+--target async-node

--- a/test/binCases/config-name/found-one/webpack.config.js
+++ b/test/binCases/config-name/found-one/webpack.config.js
@@ -1,0 +1,12 @@
+var path = require("path");
+
+module.exports = [
+	{
+		name: "foo",
+		entry: path.resolve(__dirname, "./index")
+	},
+	{
+		name: "bar",
+		entry: path.resolve(__dirname, "./index2")
+	}
+];

--- a/test/binCases/config-name/not-found/test.js
+++ b/test/binCases/config-name/not-found/test.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = function testAssertions(code, stdout, stderr) {
+	code.should.be.exactly(255);
+
+	stdout.should.be.empty();
+	stderr[0].should.containEql("Configuration with name \'foo\' was not found.");
+};
+

--- a/test/binCases/config-name/not-found/test.js
+++ b/test/binCases/config-name/not-found/test.js
@@ -1,8 +1,7 @@
 "use strict";
 
 module.exports = function testAssertions(code, stdout, stderr) {
-	code.should.be.exactly(255);
-
+	code.should.not.eql(0);
 	stdout.should.be.empty();
 	stderr[0].should.containEql("Configuration with name \'foo\' was not found.");
 };

--- a/test/binCases/config-name/not-found/test.opts
+++ b/test/binCases/config-name/not-found/test.opts
@@ -1,0 +1,2 @@
+--config ./webpack.config.js
+--config-name foo

--- a/test/binCases/config-name/not-found/webpack.config.js
+++ b/test/binCases/config-name/not-found/webpack.config.js
@@ -1,0 +1,3 @@
+module.exports = [{
+	name: "bar"
+}];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Adds an option to specify a named configuration to use with multiple configs. 

Implements #2821
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
This option has no effect on single configurations. 
All configurations with a matching name in a multi-config will be compiled.