### PR TITLE
prepend plugins instead of append when defined through CLI

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -283,6 +283,10 @@ module.exports = function(yargs, argv, convertOptions) {
 			}
 		}
 
+		function addPlugin(options, plugin) {
+			options.plugins.unshift(plugin);
+		}
+
 		ifArgPair("entry", function(name, entry) {
 			if(typeof options.entry[name] !== "undefined" && options.entry[name] !== null) {
 				options.entry[name] = [].concat(options.entry[name]).concat(entry);
@@ -330,7 +334,7 @@ module.exports = function(yargs, argv, convertOptions) {
 		}, function() {
 			ensureArray(options, "plugins");
 			var DefinePlugin = require("../lib/DefinePlugin");
-			options.plugins.push(new DefinePlugin(defineObject));
+			addPlugin(options, new DefinePlugin(defineObject));
 		});
 
 		ifArg("output-path", function(value) {
@@ -400,13 +404,13 @@ module.exports = function(yargs, argv, convertOptions) {
 		ifBooleanArg("hot", function() {
 			ensureArray(options, "plugins");
 			var HotModuleReplacementPlugin = require("../lib/HotModuleReplacementPlugin");
-			options.plugins.push(new HotModuleReplacementPlugin());
+			addPlugin(options, new HotModuleReplacementPlugin());
 		});
 
 		ifBooleanArg("debug", function() {
 			ensureArray(options, "plugins");
 			var LoaderOptionsPlugin = require("../lib/LoaderOptionsPlugin");
-			options.plugins.push(new LoaderOptionsPlugin({
+			addPlugin(options, new LoaderOptionsPlugin({
 				debug: true
 			}));
 		});
@@ -440,7 +444,7 @@ module.exports = function(yargs, argv, convertOptions) {
 		ifArg("optimize-max-chunks", function(value) {
 			ensureArray(options, "plugins");
 			var LimitChunkCountPlugin = require("../lib/optimize/LimitChunkCountPlugin");
-			options.plugins.push(new LimitChunkCountPlugin({
+			addPlugin(options, new LimitChunkCountPlugin({
 				maxChunks: parseInt(value, 10)
 			}));
 		});
@@ -448,7 +452,7 @@ module.exports = function(yargs, argv, convertOptions) {
 		ifArg("optimize-min-chunk-size", function(value) {
 			ensureArray(options, "plugins");
 			var MinChunkSizePlugin = require("../lib/optimize/MinChunkSizePlugin");
-			options.plugins.push(new MinChunkSizePlugin({
+			addPlugin(options, new MinChunkSizePlugin({
 				minChunkSize: parseInt(value, 10)
 			}));
 		});
@@ -457,10 +461,10 @@ module.exports = function(yargs, argv, convertOptions) {
 			ensureArray(options, "plugins");
 			var UglifyJsPlugin = require("../lib/optimize/UglifyJsPlugin");
 			var LoaderOptionsPlugin = require("../lib/LoaderOptionsPlugin");
-			options.plugins.push(new UglifyJsPlugin({
+			addPlugin(options, new UglifyJsPlugin({
 				sourceMap: options.devtool && (options.devtool.indexOf("sourcemap") >= 0 || options.devtool.indexOf("source-map") >= 0)
 			}));
-			options.plugins.push(new LoaderOptionsPlugin({
+			addPlugin(options, new LoaderOptionsPlugin({
 				minimize: true
 			}));
 		});
@@ -468,7 +472,7 @@ module.exports = function(yargs, argv, convertOptions) {
 		ifArg("prefetch", function(request) {
 			ensureArray(options, "plugins");
 			var PrefetchPlugin = require("../lib/PrefetchPlugin");
-			options.plugins.push(new PrefetchPlugin(request));
+			addPlugin(options, new PrefetchPlugin(request));
 		});
 
 		ifArg("provide", function(value) {
@@ -482,12 +486,12 @@ module.exports = function(yargs, argv, convertOptions) {
 				name = value;
 			}
 			var ProvidePlugin = require("../lib/ProvidePlugin");
-			options.plugins.push(new ProvidePlugin(name, value));
+			addPlugin(options, new ProvidePlugin(name, value));
 		});
 
 		ifArg("plugin", function(value) {
 			ensureArray(options, "plugins");
-			options.plugins.push(loadPlugin(value));
+			addPlugin(options, loadPlugin(value));
 		});
 
 		mapArgToBoolean("bail");

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -284,6 +284,7 @@ module.exports = function(yargs, argv, convertOptions) {
 		}
 
 		function addPlugin(options, plugin) {
+			ensureArray(options, "plugins");
 			options.plugins.unshift(plugin);
 		}
 
@@ -332,7 +333,6 @@ module.exports = function(yargs, argv, convertOptions) {
 		}, function() {
 			defineObject = {};
 		}, function() {
-			ensureArray(options, "plugins");
 			var DefinePlugin = require("../lib/DefinePlugin");
 			addPlugin(options, new DefinePlugin(defineObject));
 		});
@@ -402,13 +402,11 @@ module.exports = function(yargs, argv, convertOptions) {
 		mapArgToBoolean("cache");
 
 		ifBooleanArg("hot", function() {
-			ensureArray(options, "plugins");
 			var HotModuleReplacementPlugin = require("../lib/HotModuleReplacementPlugin");
 			addPlugin(options, new HotModuleReplacementPlugin());
 		});
 
 		ifBooleanArg("debug", function() {
-			ensureArray(options, "plugins");
 			var LoaderOptionsPlugin = require("../lib/LoaderOptionsPlugin");
 			addPlugin(options, new LoaderOptionsPlugin({
 				debug: true
@@ -442,7 +440,6 @@ module.exports = function(yargs, argv, convertOptions) {
 		});
 
 		ifArg("optimize-max-chunks", function(value) {
-			ensureArray(options, "plugins");
 			var LimitChunkCountPlugin = require("../lib/optimize/LimitChunkCountPlugin");
 			addPlugin(options, new LimitChunkCountPlugin({
 				maxChunks: parseInt(value, 10)
@@ -450,7 +447,6 @@ module.exports = function(yargs, argv, convertOptions) {
 		});
 
 		ifArg("optimize-min-chunk-size", function(value) {
-			ensureArray(options, "plugins");
 			var MinChunkSizePlugin = require("../lib/optimize/MinChunkSizePlugin");
 			addPlugin(options, new MinChunkSizePlugin({
 				minChunkSize: parseInt(value, 10)
@@ -458,7 +454,6 @@ module.exports = function(yargs, argv, convertOptions) {
 		});
 
 		ifBooleanArg("optimize-minimize", function() {
-			ensureArray(options, "plugins");
 			var UglifyJsPlugin = require("../lib/optimize/UglifyJsPlugin");
 			var LoaderOptionsPlugin = require("../lib/LoaderOptionsPlugin");
 			addPlugin(options, new UglifyJsPlugin({
@@ -470,13 +465,11 @@ module.exports = function(yargs, argv, convertOptions) {
 		});
 
 		ifArg("prefetch", function(request) {
-			ensureArray(options, "plugins");
 			var PrefetchPlugin = require("../lib/PrefetchPlugin");
 			addPlugin(options, new PrefetchPlugin(request));
 		});
 
 		ifArg("provide", function(value) {
-			ensureArray(options, "plugins");
 			var idx = value.indexOf("=");
 			var name;
 			if(idx >= 0) {
@@ -490,7 +483,6 @@ module.exports = function(yargs, argv, convertOptions) {
 		});
 
 		ifArg("plugin", function(value) {
-			ensureArray(options, "plugins");
 			addPlugin(options, loadPlugin(value));
 		});
 

--- a/test/binCases/configFile/plugins-presedence/index.js
+++ b/test/binCases/configFile/plugins-presedence/index.js
@@ -1,0 +1,4 @@
+// We test that the CLI define for TEST will override the one defined in
+// webpack.config.js. If the presedence is correct the entry will require ok.js,
+// if not it will try to require fail.js and fail.
+require("./" + TEST + ".js");

--- a/test/binCases/configFile/plugins-presedence/ok.js
+++ b/test/binCases/configFile/plugins-presedence/ok.js
@@ -1,0 +1,1 @@
+module.exports = "ok";

--- a/test/binCases/configFile/plugins-presedence/test.js
+++ b/test/binCases/configFile/plugins-presedence/test.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = function testAssertions(code, stdout, stderr) {
+	code.should.be.exactly(0);
+
+	stdout.should.be.ok();
+	stdout[6].should.containEql('ok.js')
+	stderr.should.be.empty();
+};

--- a/test/binCases/configFile/plugins-presedence/test.js
+++ b/test/binCases/configFile/plugins-presedence/test.js
@@ -4,6 +4,6 @@ module.exports = function testAssertions(code, stdout, stderr) {
 	code.should.be.exactly(0);
 
 	stdout.should.be.ok();
-	stdout[6].should.containEql('ok.js')
+	stdout[6].should.containEql("ok.js");
 	stderr.should.be.empty();
 };

--- a/test/binCases/configFile/plugins-presedence/test.opts
+++ b/test/binCases/configFile/plugins-presedence/test.opts
@@ -1,0 +1,6 @@
+--entry ./index.js
+--config ./webpack.config.js
+--output-filename [name].js
+--output-chunk-filename [id].chunk.js
+--target async-node
+--define TEST="ok"

--- a/test/binCases/configFile/plugins-presedence/webpack.config.js
+++ b/test/binCases/configFile/plugins-presedence/webpack.config.js
@@ -1,0 +1,11 @@
+var DefinePlugin = require("../../../../lib/DefinePlugin");
+var path = require("path");
+
+module.exports = {
+	entry: path.resolve(__dirname, "./index"),
+	plugins: [
+		new DefinePlugin({
+			TEST: JSON.stringify("fail")
+		})
+	]
+};


### PR DESCRIPTION
closes #4260

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Gives plugins presedence over webpack config file when defined through the CLI

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Unsure how to test this, but feel free til suggest. Will add if relevant

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
