### PR TITLE
RemoveParentModulesPlugin performance

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -257,7 +257,6 @@ class Chunk {
 		module.removeChunk(this);
 		module.addChunk(otherChunk);
 		otherChunk.addModule(module);
-		module.rewriteChunkInReasons(this, [otherChunk]);
 	}
 
 	replaceChunk(oldChunk, newChunk) {

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -141,12 +141,6 @@ class Module extends DependenciesBlock {
 		return false;
 	}
 
-	rewriteChunkInReasons(oldChunk, newChunks) {
-		for(let i = 0; i < this.reasons.length; i++) {
-			this.reasons[i].rewriteChunks(oldChunk, newChunks);
-		}
-	}
-
 	isUsed(exportName) {
 		if(this.used === null) return exportName;
 		if(!exportName) return !!this.used;

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -37,7 +37,6 @@ class Module extends DependenciesBlock {
 		this.usedExports = null;
 		this.providedExports = null;
 		this._chunks = new SortableSet(undefined, sortById);
-		this._chunksDebugIdent = undefined;
 		this.warnings = [];
 		this.dependenciesWarnings = [];
 		this.errors = [];
@@ -57,7 +56,6 @@ class Module extends DependenciesBlock {
 		this.usedExports = null;
 		this.providedExports = null;
 		this._chunks.clear();
-		this._chunksDebugIdent = undefined;
 		super.disconnect();
 	}
 
@@ -67,7 +65,6 @@ class Module extends DependenciesBlock {
 		this.index2 = null;
 		this.depth = null;
 		this._chunks.clear();
-		this._chunksDebugIdent = undefined;
 		super.unseal();
 	}
 
@@ -77,12 +74,10 @@ class Module extends DependenciesBlock {
 
 	addChunk(chunk) {
 		this._chunks.add(chunk);
-		this._chunksDebugIdent = undefined;
 	}
 
 	removeChunk(chunk) {
 		if(this._chunks.delete(chunk)) {
-			this._chunksDebugIdent = undefined;
 			chunk.removeModule(this);
 			return true;
 		}
@@ -91,24 +86,6 @@ class Module extends DependenciesBlock {
 
 	isInChunk(chunk) {
 		return this._chunks.has(chunk);
-	}
-
-	getChunkIdsIdent() {
-		if(this._chunksDebugIdent !== undefined) return this._chunksDebugIdent;
-		this._chunks.sortWith(sortByDebugId);
-		const chunks = this._chunks;
-		const list = [];
-		for(const chunk of chunks) {
-			const debugId = chunk.debugId;
-
-			if(typeof debugId !== "number") {
-				return this._chunksDebugIdent = null;
-			}
-
-			list.push(debugId);
-		}
-
-		return this._chunksDebugIdent = list.join(",");
 	}
 
 	forEachChunk(fn) {

--- a/lib/ModuleReason.js
+++ b/lib/ModuleReason.js
@@ -10,37 +10,17 @@ class ModuleReason {
 	constructor(module, dependency) {
 		this.module = module;
 		this.dependency = dependency;
-		this._chunks = null;
 	}
 
 	hasChunk(chunk) {
-		if(this._chunks) {
-			if(this._chunks.has(chunk))
-				return true;
-		} else if(this.module._chunks.has(chunk))
-			return true;
-		return false;
-	}
-
-	rewriteChunks(oldChunk, newChunks) {
-		if(!this._chunks) {
-			if(!this.module._chunks.has(oldChunk))
-				return;
-			this._chunks = new Set(this.module._chunks);
-		}
-		if(this._chunks.has(oldChunk)) {
-			this._chunks.delete(oldChunk);
-			for(let i = 0; i < newChunks.length; i++) {
-				this._chunks.add(newChunks[i]);
-			}
-		}
+		return this.dependency.module.isInChunk(chunk);
 	}
 }
 
 Object.defineProperty(ModuleReason.prototype, "chunks", {
 	configurable: false,
 	get: util.deprecate(function() {
-		return this._chunks ? Array.from(this._chunks) : null;
+		return this.dependency.module.getChunks();
 	}, "ModuleReason.chunks: Use ModuleReason.hasChunk/rewriteChunks instead"),
 	set() {
 		throw new Error("Readonly. Use ModuleReason.rewriteChunks to modify chunks.");

--- a/lib/optimize/EnsureChunkConditionsPlugin.js
+++ b/lib/optimize/EnsureChunkConditionsPlugin.js
@@ -25,7 +25,6 @@ class EnsureChunkConditionsPlugin {
 									newChunks.push(parent);
 								}
 							});
-							module.rewriteChunkInReasons(chunk, newChunks);
 							chunk.removeModule(module);
 							changed = true;
 						}

--- a/lib/optimize/RemoveParentModulesPlugin.js
+++ b/lib/optimize/RemoveParentModulesPlugin.js
@@ -43,7 +43,6 @@ class RemoveParentModulesPlugin {
 
 						var parentChunksWithModule = allHaveModule(chunk.parents, module);
 						if(parentChunksWithModule) {
-							module.rewriteChunkInReasons(chunk, Array.from(parentChunksWithModule));
 							chunk.removeModule(module);
 						}
 					}

--- a/lib/optimize/RemoveParentModulesPlugin.js
+++ b/lib/optimize/RemoveParentModulesPlugin.js
@@ -37,21 +37,11 @@ class RemoveParentModulesPlugin {
 					var chunk = chunks[index];
 					if(chunk.parents.length === 0) continue;
 
-					// TODO consider Map when performance has improved https://gist.github.com/sokra/b36098368da7b8f6792fd7c85fca6311
-					var cache = Object.create(null);
 					var modules = chunk.getModules();
 					for(var i = 0; i < modules.length; i++) {
 						var module = modules[i];
 
-						var dId = module.getChunkIdsIdent();
-						var parentChunksWithModule;
-						if(dId === null) {
-							parentChunksWithModule = allHaveModule(chunk.parents, module);
-						} else if(dId in cache) {
-							parentChunksWithModule = cache[dId];
-						} else {
-							parentChunksWithModule = cache[dId] = allHaveModule(chunk.parents, module);
-						}
+						var parentChunksWithModule = allHaveModule(chunk.parents, module);
 						if(parentChunksWithModule) {
 							module.rewriteChunkInReasons(chunk, Array.from(parentChunksWithModule));
 							chunk.removeModule(module);

--- a/test/ModuleReason.test.js
+++ b/test/ModuleReason.test.js
@@ -30,48 +30,4 @@ describe("ModuleReason", () => {
 			should(myModuleReason.hasChunk(myChunk)).be.true();
 		});
 	});
-
-	describe("rewriteChunks", () => {
-		it("if old chunk is present, it is replaced with new chunks", () => {
-			myModuleReason.module.addChunk(myChunk);
-			myModuleReason.rewriteChunks(myChunk, [myChunk2]);
-
-			should(myModuleReason.hasChunk(myChunk)).be.false();
-			should(myModuleReason.hasChunk(myChunk2)).be.true();
-		});
-
-		it("if old chunk is not present, new chunks are not added", () => {
-			myModuleReason.rewriteChunks(myChunk, [myChunk2]);
-
-			should(myModuleReason.hasChunk(myChunk)).be.false();
-			should(myModuleReason.hasChunk(myChunk2)).be.false();
-		});
-
-		it("if already rewritten chunk is present, it is replaced with new chunks", () => {
-			myModuleReason.module.addChunk(myChunk);
-			myModuleReason.rewriteChunks(myChunk, [myChunk2]);
-			myModuleReason.rewriteChunks(myChunk2, [myChunk]);
-
-			should(myModuleReason.hasChunk(myChunk)).be.true();
-			should(myModuleReason.hasChunk(myChunk2)).be.false();
-		});
-	});
-
-	describe(".chunks", () => {
-		it("is null if no rewrites happen first", () => {
-			should(myModuleReason.chunks).be.Null();
-		});
-
-		it("is null if only invalid rewrites happen first", () => {
-			myModuleReason.rewriteChunks(myChunk, [myChunk2]);
-			should(myModuleReason.chunks).be.Null();
-		});
-
-		it("is an array of chunks if a valid rewrite happens", () => {
-			myModuleReason.module.addChunk(myChunk);
-			myModuleReason.rewriteChunks(myChunk, [myChunk2]);
-
-			should(myModuleReason.chunks).be.eql([myChunk2]);
-		});
-	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Performance enhancing.

**Did you add tests for your changes?**
No, but I did update some tests related to my changes.

**If relevant, link to documentation update:**
N/A

**Summary**

There were two commits here, both related to performance. This change reduces our build time by roughly ~10%.

**[Module.getChunkIdsIdent] Remove getChunkIdsIdent from Module.**
This function appears to only have been used to generate a cache key inside
RemoveParentModulesPlugin. With the recent change to using sets, it is actually
faster to find parent chunks containing a module than it is to generate this
cache key.

To profile this, I added a wrapper function temporarily in my branch and timed
the duration of the RemoveParetModulesPlugin.

Before this change it took ~6113 ms when building our config.
After this change it takes ~3160 ms against the same config.

**[ModuleReasons] Remove ModuleReason chunk list.**
I didn't see a need for ModuleReason's to track their chunks separate from the
module's list of chunks. Having a single source of truth seems beneficial. This
has a double benefit of speeding up the RemoveParentModulesPlugin.

Before making this change, but including the previous commit: 3160ms
After making this change: 340ms

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Yes, but for undocumented features.  `Module.rewriteChunkInReasons`, `Module.getChunkIdsIdent` and `ModuleReasons.rewriteChunks` have all been removed. I couldn't find any documentation on any of these methods, and I believe that they're only used internally by webpack.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
