### PR TITLE
fix(package.json): pin enhanced-resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ajv": "^4.7.0",
     "ajv-keywords": "^1.1.1",
     "async": "^2.1.2",
-    "enhanced-resolve": "^3.3.0",
+    "enhanced-resolve": "3.3.0",
     "interpret": "^1.0.0",
     "json-loader": "^0.5.4",
     "json5": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1086,7 +1086,7 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-enhanced-resolve@^3.3.0:
+enhanced-resolve@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz#950964ecc7f0332a42321b673b38dc8ff15535b3"
   dependencies:
@@ -2072,6 +2072,7 @@ jade@^1.11.0:
     jstransformer "0.0.2"
     mkdirp "~0.5.0"
     transformers "2.1.0"
+    uglify-js "^2.4.19"
     void-elements "~2.0.1"
     with "~4.0.0"
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Angular 2 apps don't compile in AoT.

See [angular-cli#7113](https://github.com/angular/angular-cli/issues/7113) and [webpack/enhanced-resolve#98](https://github.com/webpack/enhanced-resolve/issues/98) for context.

**Did you add tests for your changes?**

Not required

**Summary**

Angular 2 app doesn't build in AoT mode.

```
Module not found: Error: Can't resolve './$$_gendir/app/app.module.ngfactory'
 @ ./src/main.ts 5:0-74
 @ multi ./src/main.ts
```

**Does this PR introduce a breaking change?**

Previous versions of Webpack 2.x.x will fail compilation using AoT

**Other information**

See [angular-cli#7113](https://github.com/angular/angular-cli/issues/7113) and [webpack/enhanced-resolve#98](https://github.com/webpack/enhanced-resolve/issues/98) for context.