### PR TITLE
[Module.getChunkIdsIdent] Remove getChunkIdsIdent from Module.

### DIFF
--- a/lib/Module.js
+++ b/lib/Module.js
@@ -37,7 +37,6 @@ class Module extends DependenciesBlock {
 		this.usedExports = null;
 		this.providedExports = null;
 		this._chunks = new SortableSet(undefined, sortById);
-		this._chunksDebugIdent = undefined;
 		this.warnings = [];
 		this.dependenciesWarnings = [];
 		this.errors = [];
@@ -57,7 +56,6 @@ class Module extends DependenciesBlock {
 		this.usedExports = null;
 		this.providedExports = null;
 		this._chunks.clear();
-		this._chunksDebugIdent = undefined;
 		this.optimizationBailout.length = 0;
 		super.disconnect();
 	}
@@ -68,7 +66,6 @@ class Module extends DependenciesBlock {
 		this.index2 = null;
 		this.depth = null;
 		this._chunks.clear();
-		this._chunksDebugIdent = undefined;
 		super.unseal();
 	}
 
@@ -79,12 +76,10 @@ class Module extends DependenciesBlock {
 
 	addChunk(chunk) {
 		this._chunks.add(chunk);
-		this._chunksDebugIdent = undefined;
 	}
 
 	removeChunk(chunk) {
 		if(this._chunks.delete(chunk)) {
-			this._chunksDebugIdent = undefined;
 			chunk.removeModule(this);
 			return true;
 		}
@@ -93,24 +88,6 @@ class Module extends DependenciesBlock {
 
 	isInChunk(chunk) {
 		return this._chunks.has(chunk);
-	}
-
-	getChunkIdsIdent() {
-		if(this._chunksDebugIdent !== undefined) return this._chunksDebugIdent;
-		this._chunks.sortWith(sortByDebugId);
-		const chunks = this._chunks;
-		const list = [];
-		for(const chunk of chunks) {
-			const debugId = chunk.debugId;
-
-			if(typeof debugId !== "number") {
-				return this._chunksDebugIdent = null;
-			}
-
-			list.push(debugId);
-		}
-
-		return this._chunksDebugIdent = list.join(",");
 	}
 
 	forEachChunk(fn) {

--- a/lib/optimize/RemoveParentModulesPlugin.js
+++ b/lib/optimize/RemoveParentModulesPlugin.js
@@ -37,21 +37,11 @@ class RemoveParentModulesPlugin {
 					var chunk = chunks[index];
 					if(chunk.parents.length === 0) continue;
 
-					// TODO consider Map when performance has improved https://gist.github.com/sokra/b36098368da7b8f6792fd7c85fca6311
-					var cache = Object.create(null);
 					var modules = chunk.getModules();
 					for(var i = 0; i < modules.length; i++) {
 						var module = modules[i];
 
-						var dId = module.getChunkIdsIdent();
-						var parentChunksWithModule;
-						if(dId === null) {
-							parentChunksWithModule = allHaveModule(chunk.parents, module);
-						} else if(dId in cache) {
-							parentChunksWithModule = cache[dId];
-						} else {
-							parentChunksWithModule = cache[dId] = allHaveModule(chunk.parents, module);
-						}
+						var parentChunksWithModule = allHaveModule(chunk.parents, module);
 						if(parentChunksWithModule) {
 							module.rewriteChunkInReasons(chunk, Array.from(parentChunksWithModule));
 							chunk.removeModule(module);


### PR DESCRIPTION
What kind of change does this PR introduce?
Performance enhancing.

Did you add tests for your changes?
No, but I did update some tests related to my changes.

If relevant, link to documentation update:
N/A

Summary
This change reduces our build time by roughly ~5%.

[Module.getChunkIdsIdent] Remove getChunkIdsIdent from Module.
This function appears to only have been used to generate a cache key inside
RemoveParentModulesPlugin. With the recent change to using sets, it is actually
faster to find parent chunks containing a module than it is to generate this
cache key.

To profile this, I added a wrapper function temporarily in my branch and timed
the duration of the RemoveParentModulesPlugin.

Before this change it took ~6113 ms when building our config.
After this change it takes ~3160 ms against the same config.