### PR TITLE
[tests] Uncomment inject-free-vars test.

### DIFF
--- a/test/cases/parsing/inject-free-vars/index.js
+++ b/test/cases/parsing/inject-free-vars/index.js
@@ -5,9 +5,10 @@ it("should inject the module object into a chunk (AMD1)", function(done) {
 	});
 });
 
-it("should inject the module object into a chunk (AMD2)"/*, function() {
+it("should inject the module object into a chunk (AMD2)", function() {
 	require([module.webpackPolyfill ? "./x1" : "./fail"]);
-}*/);
+	module.webpackPolyfill.should.be.eql(1);
+});
 
 it("should inject the module object into a chunk (ensure)", function(done) {
 	require.ensure([], function(require) {


### PR DESCRIPTION
This is just uncommenting a test that was disabled ~4 years ago. Running the test locally seems to work, so I imagine that this was fixed and never revisited.

I found this by looking at the oldest open issue - https://github.com/webpack/webpack/issues/171