### PR TITLE
[Parser] detect strict mode as the first step to support shimming global object

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -37,6 +37,15 @@ const POSSIBLE_AST_OPTIONS = [{
 	}
 }];
 
+function hasUseStrictBeforeAnyOtherStatements(blockStatementOrProgram) {
+	const firstStatement = blockStatementOrProgram.body[0];
+
+	return firstStatement &&
+		firstStatement.type === "ExpressionStatement" &&
+		firstStatement.expression.type === "Literal" &&
+		firstStatement.expression.value === "use strict";
+}
+
 class Parser extends Tapable {
 	constructor(options) {
 		super();
@@ -636,6 +645,9 @@ class Parser extends Tapable {
 		});
 		this.inScope(statement.params, function() {
 			if(statement.body.type === "BlockStatement") {
+				if(hasUseStrictBeforeAnyOtherStatements(statement.body)) {
+					this.scope.useStrict = true;
+				}
 				this.prewalkStatement(statement.body);
 				this.walkStatement(statement.body);
 			} else {
@@ -1070,6 +1082,9 @@ class Parser extends Tapable {
 					this.scope.renames["$" + params[i].name] = param;
 				}
 				if(functionExpression.body.type === "BlockStatement") {
+					if(hasUseStrictBeforeAnyOtherStatements(functionExpression.body)) {
+						this.scope.useStrict = true;
+					}
 					this.prewalkStatement(functionExpression.body);
 					this.walkStatement(functionExpression.body);
 				} else
@@ -1146,7 +1161,8 @@ class Parser extends Tapable {
 			inTry: false,
 			inShorthand: false,
 			definitions: oldScope.definitions.slice(),
-			renames: Object.create(oldScope.renames)
+			renames: Object.create(oldScope.renames),
+			useStrict: oldScope.useStrict,
 		};
 
 		this.scope.renames.$this = undefined;
@@ -1344,7 +1360,9 @@ class Parser extends Tapable {
 		this.scope = {
 			inTry: false,
 			definitions: [],
-			renames: {}
+			renames: {},
+			useStrict: ast.sourceType === "module" ||
+				(ast.sourceType === "script" && hasUseStrictBeforeAnyOtherStatements(ast)),
 		};
 		const state = this.state = initialState || {};
 		this.comments = comments;

--- a/test/Parser.test.js
+++ b/test/Parser.test.js
@@ -424,4 +424,63 @@ describe("Parser", () => {
 			});
 		});
 	});
+
+	describe("strict mode support", () => {
+		describe("should be strict mode", () => {
+			const cases = {
+				"inside source type module": "var foo = 'foo'",
+				// Webpack will first try to parse the code as "module", if failed then "script"
+				// "await" is reserved only in sourceType === "module", this makes Webpack recongnizes this part of code as "scirpt"
+				// See: http://www.ecma-international.org/ecma-262/6.0/#sec-future-reserved-words
+				"inside source type script which have 'use strict' at first": "'use strict'; var await = 'await';",
+				"inside function within source type script which have 'use strict' at first": "function bar() { 'use strict'; var await = 'await'; }",
+				"inside IIFE within source type script which have 'use strict' at first": "(function() { 'use strict'; var await = 'await'; })()",
+			};
+			const parser = new Parser();
+			parser.plugin("var foo", () => {
+				parser.state.useStrict = parser.scope.useStrict;
+			});
+			parser.plugin("var await", () => {
+				parser.state.useStrict = parser.scope.useStrict;
+			});
+
+			Object.keys(cases).forEach((name) => {
+				const expr = cases[name];
+				it(name, () => {
+					const actual = parser.parse(expr);
+					actual.should.be.eql({
+						useStrict: true,
+					});
+				});
+			});
+		});
+
+		describe("should not be strict mode", () => {
+			const cases = {
+				// Webpack will first try to parse the code as "module", if failed then "script"
+				// "await" is reserved only in sourceType === "module", this makes Webpack recongnizes this part of code as "scirpt"
+				// See: http://www.ecma-international.org/ecma-262/6.0/#sec-future-reserved-words
+				"inside source type script which don't have 'use strict'": "var await = 'await';",
+				"inside source type script which have 'use strict' but not at first": "var foo = 'foo'; 'use strict'; var await = 'await';",
+				"inside function within source type script which don't have 'use strict'": "function bar() { var await = 'await'; }",
+				"inside function within source type script which have 'use strict' but not at first": "function bar() { var foo = 'foo'; 'use strict'; var await = 'await'; }",
+				"inside IIFE within source type script which don't have 'use strict'": "(function() { var await = 'await'; })()",
+				"inside IIFE within source type script which have 'use strict' but not at first": "(function() { var foo = 'foo'; 'use strict'; var await = 'await'; })()",
+			};
+			const parser = new Parser();
+			parser.plugin("var await", () => {
+				parser.state.useStrict = parser.scope.useStrict;
+			});
+
+			Object.keys(cases).forEach((name) => {
+				const expr = cases[name];
+				it(name, () => {
+					const actual = parser.parse(expr);
+					actual.should.be.eql({
+						useStrict: false,
+					});
+				});
+			});
+		});
+	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
The change in this PR is internal, no need for doc update
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
This change is mainly for shimming global object as described in #5381 (this issue is wrongly closed).

For code
```javascript
(function(){
    var window = this || (0, eval)('this'),
        jQueryInstance = window["jQuery"];
   console.log(jQueryInstance);
}());
```
the inner `this` is the global object, which is `window` in browser and `global` in Node.js.

Using `imports-loaders?this=>window` would only handle `this` for the module, not the inner `this` inside the IIFE.
The generated code is like:
```javascript
/*** IMPORTS FROM imports-loader ***/
(function() {

(function(){
    var window = this || (0, eval)('this'),
        jQueryInstance = window["jQuery"];
    console.log(jQueryInstance);
}());

}.call(window));
```

If we run this part of code in Node.js with env set as
```javascript
global.jQuery = 'foo';
window = { jQuery: 'bar' };
```

the logged `jQuery` would be `'foo'`, but here we want `'bar'`.

For properly handle global object, strict mode needs to be handled properly first:
As described in the [spec](http://www.ecma-international.org/ecma-262/6.0/#sec-strict-mode-code) and [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this#Function_context), in strict mode, `this` for functions called with no explicit `this` is `undefined`; in non-strict code, `this` for functions called with no explicit `this` is the global object (which is `window` for browsers and `global` for Node.js).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
