### PR TITLE
[Shim] shim global object as directly called IIFE's this

### DIFF
--- a/lib/GlobalObjectPlugin.js
+++ b/lib/GlobalObjectPlugin.js
@@ -1,0 +1,23 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+"use strict";
+
+class GlobalObjectPlugin {
+	constructor(global) {
+		this.global = global;
+	}
+
+	apply(compiler) {
+		const global = this.global;
+		compiler.plugin("compilation", (compilation, params) => {
+			params.normalModuleFactory.plugin("parser", (parser, parserOptions) => {
+				parser.plugin("global", function() {
+					return global;
+				});
+			});
+		});
+	}
+}
+module.exports = GlobalObjectPlugin;

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -1074,6 +1074,8 @@ class Parser extends Tapable {
 			}), function() {
 				if(renameThis) {
 					this.scope.renames.$this = renameThis;
+				} else if(!currentThis && !this.scope.useStrict) {
+					this.scope.renames.$this = this.applyPluginsBailResult1("global");
 				}
 				for(let i = 0; i < args.length; i++) {
 					const param = args[i];

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -37,6 +37,15 @@ const POSSIBLE_AST_OPTIONS = [{
 	}
 }];
 
+function hasUseStrictBeforeAnyOtherStatements(blockStatementOrProgram) {
+	const firstStatement = blockStatementOrProgram.body[0];
+
+	return firstStatement &&
+		firstStatement.type === "ExpressionStatement" &&
+		firstStatement.expression.type === "Literal" &&
+		firstStatement.expression.value === "use strict";
+}
+
 class Parser extends Tapable {
 	constructor(options) {
 		super();
@@ -636,6 +645,9 @@ class Parser extends Tapable {
 		});
 		this.inScope(statement.params, function() {
 			if(statement.body.type === "BlockStatement") {
+				if(hasUseStrictBeforeAnyOtherStatements(statement.body)) {
+					this.scope.useStrict = true;
+				}
 				this.prewalkStatement(statement.body);
 				this.walkStatement(statement.body);
 			} else {
@@ -1070,6 +1082,9 @@ class Parser extends Tapable {
 					this.scope.renames["$" + params[i].name] = param;
 				}
 				if(functionExpression.body.type === "BlockStatement") {
+					if(hasUseStrictBeforeAnyOtherStatements(functionExpression.body)) {
+						this.scope.useStrict = true;
+					}
 					this.prewalkStatement(functionExpression.body);
 					this.walkStatement(functionExpression.body);
 				} else
@@ -1146,7 +1161,8 @@ class Parser extends Tapable {
 			inTry: false,
 			inShorthand: false,
 			definitions: oldScope.definitions.slice(),
-			renames: Object.create(oldScope.renames)
+			renames: Object.create(oldScope.renames),
+			useStrict: oldScope.useStrict,
 		};
 
 		this.scope.renames.$this = undefined;
@@ -1344,7 +1360,9 @@ class Parser extends Tapable {
 		this.scope = {
 			inTry: false,
 			definitions: [],
-			renames: {}
+			renames: {},
+			useStrict: ast.sourceType === "module" ||
+				(ast.sourceType === "script" && hasUseStrictBeforeAnyOtherStatements(ast)),
 		};
 		const state = this.state = initialState || {};
 		this.comments = comments;

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -78,6 +78,7 @@ exportPlugins(exports, {
 	"PrefetchPlugin": () => require("./PrefetchPlugin"),
 	"AutomaticPrefetchPlugin": () => require("./AutomaticPrefetchPlugin"),
 	"ProvidePlugin": () => require("./ProvidePlugin"),
+	"GlobalObjectPlugin": () => require("./GlobalObjectPlugin"),
 	"HotModuleReplacementPlugin": () => require("./HotModuleReplacementPlugin"),
 	"SourceMapDevToolPlugin": () => require("./SourceMapDevToolPlugin"),
 	"EvalSourceMapDevToolPlugin": () => require("./EvalSourceMapDevToolPlugin"),

--- a/test/Parser.test.js
+++ b/test/Parser.test.js
@@ -424,4 +424,63 @@ describe("Parser", () => {
 			});
 		});
 	});
+
+	describe("strict mode support", () => {
+		describe("should be strict mode", () => {
+			const cases = {
+				"inside source type module": "var foo = 'foo'",
+				// Webpack will first try to parse the code as "module", if failed then "script"
+				// "await" is reserved only in sourceType === "module", this makes Webpack recongnizes this part of code as "scirpt"
+				// See: http://www.ecma-international.org/ecma-262/6.0/#sec-future-reserved-words
+				"inside source type script which have 'use strict' at first": "'use strict'; var await = 'await';",
+				"inside function within source type script which have 'use strict' at first": "function bar() { 'use strict'; var await = 'await'; }",
+				"inside IIFE within source type script which have 'use strict' at first": "(function() { 'use strict'; var await = 'await'; })()",
+			};
+			const parser = new Parser();
+			parser.plugin("var foo", () => {
+				parser.state.useStrict = parser.scope.useStrict;
+			});
+			parser.plugin("var await", () => {
+				parser.state.useStrict = parser.scope.useStrict;
+			});
+
+			Object.keys(cases).forEach((name) => {
+				const expr = cases[name];
+				it(name, () => {
+					const actual = parser.parse(expr);
+					actual.should.be.eql({
+						useStrict: true,
+					});
+				});
+			});
+		});
+
+		describe("should not be strict mode", () => {
+			const cases = {
+				// Webpack will first try to parse the code as "module", if failed then "script"
+				// "await" is reserved only in sourceType === "module", this makes Webpack recongnizes this part of code as "scirpt"
+				// See: http://www.ecma-international.org/ecma-262/6.0/#sec-future-reserved-words
+				"inside source type script which don't have 'use strict'": "var await = 'await';",
+				"inside source type script which have 'use strict' but not at first": "var foo = 'foo'; 'use strict'; var await = 'await';",
+				"inside function within source type script which don't have 'use strict'": "function bar() { var await = 'await'; }",
+				"inside function within source type script which have 'use strict' but not at first": "function bar() { var foo = 'foo'; 'use strict'; var await = 'await'; }",
+				"inside IIFE within source type script which don't have 'use strict'": "(function() { var await = 'await'; })()",
+				"inside IIFE within source type script which have 'use strict' but not at first": "(function() { var foo = 'foo'; 'use strict'; var await = 'await'; })()",
+			};
+			const parser = new Parser();
+			parser.plugin("var await", () => {
+				parser.state.useStrict = parser.scope.useStrict;
+			});
+
+			Object.keys(cases).forEach((name) => {
+				const expr = cases[name];
+				it(name, () => {
+					const actual = parser.parse(expr);
+					actual.should.be.eql({
+						useStrict: false,
+					});
+				});
+			});
+		});
+	});
 });

--- a/test/configCases/plugins/global-object-plugin/foo.js
+++ b/test/configCases/plugins/global-object-plugin/foo.js
@@ -1,0 +1,1 @@
+module.exports = "bar";

--- a/test/configCases/plugins/global-object-plugin/index.js
+++ b/test/configCases/plugins/global-object-plugin/index.js
@@ -1,0 +1,7 @@
+it("should provide 'window' as 'this' of IIFE", function() {
+  var await = false;
+
+	(function() {
+		this.foo.should.be.eql("bar");
+	}());
+});

--- a/test/configCases/plugins/global-object-plugin/webpack.config.js
+++ b/test/configCases/plugins/global-object-plugin/webpack.config.js
@@ -1,0 +1,11 @@
+var GlobalObjectPlugin = require("../../../../lib/GlobalObjectPlugin");
+var ProvidePlugin = require("../../../../lib/ProvidePlugin");
+
+module.exports = {
+	plugins: [
+    new GlobalObjectPlugin("window"),
+    new ProvidePlugin({
+      "window.foo": "./foo"
+    })
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
[TODO if approved]
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
This is a successor of #5400 (including the changes the PR has not been merged) and demonstration of feasibility of shimming global object __only for IIFE same as parameters__ as described in #5381 .

This change makes shimming global object available for directly called IIFE's `this`. Before this cannot be done neither by `imports-loader` (see explanation in #5400) nor `ProvidePlugin`.

For code
```javascript
// this statement makes webpack parse this file as 'script' instead of 'module'
// this can be done by imports-loader in real use case
var await = false;
(function(){
    var jQueryInstance = this.jQuery;
}());
```
The webpack config with new `GlobalObjectPlugin` 
```javascript
  plugins: [
    new webpack.GlobalObjectPlugin('window'),
    new webpack.ProvidePlugin({
      'window.jQuery': 'jquery'
    }),
  ]
```
will shim `this.jQuery` inside the IIFE as
```javascript
// code requiring `jquery` as module 1

/* WEBPACK VAR INJECTION */(function(__webpack_provided_window_dot_jQuery) {var await = false;
(function(){
    var jQueryInstance = __webpack_provided_window_dot_jQuery;
}());

/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
```



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
<del>I think this can be done for non-IIFE functions too. If this is merged, I can start work on that.</del>