### PR TITLE
Speed up Parser.getNameForExpression by avoiding an unneeded array.

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -1394,28 +1394,45 @@ class Parser extends Tapable {
 
 	getNameForExpression(expression) {
 		let expr = expression;
-		const exprName = [];
+		let basename = undefined;
+		let prefix = "";
 		while(expr.type === "MemberExpression" && expr.property.type === (expr.computed ? "Literal" : "Identifier")) {
-			exprName.push(expr.computed ? expr.property.value : expr.property.name);
+			const val = expr.computed ? expr.property.value : expr.property.name;
+			if(basename === undefined) {
+				basename = val;
+			} else {
+				prefix = val + "." + prefix;
+			}
 			expr = expr.object;
 		}
 		let free;
 		if(expr.type === "Identifier") {
 			free = this.scope.definitions.indexOf(expr.name) === -1;
-			exprName.push(this.scope.renames["$" + expr.name] || expr.name);
+			const val = this.scope.renames["$" + expr.name] || expr.name;
+			if(basename === undefined) {
+				basename = val;
+			} else {
+				prefix = val + "." + prefix;
+			}
 		} else if(expr.type === "ThisExpression" && this.scope.renames.$this) {
 			free = true;
-			exprName.push(this.scope.renames.$this);
+			if(basename === undefined) {
+				basename = this.scope.renames.$this;
+			} else {
+				prefix = this.scope.renames.$this + "." + prefix;
+			}
 		} else if(expr.type === "ThisExpression") {
+			if(basename === undefined) {
+				basename = "this";
+			} else {
+				prefix = "this." + prefix;
+			}
 			free = false;
-			exprName.push("this");
 		} else {
 			return null;
 		}
-		let prefix = "";
-		for(let i = exprName.length - 1; i >= 1; i--)
-			prefix += exprName[i] + ".";
-		const name = prefix + exprName[0];
+
+		const name = prefix + basename;
 		const nameGeneral = prefix + "*";
 		return {
 			name,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Performance improvement.

**Did you add tests for your changes?**
I didn't add unit tests, but I did run a very large build using the previous version and this version using `deep-equal` to ensure the results were the same.

**If relevant, link to documentation update:**
N/A

**Summary**
I was motivated to make this change as this function was reported as having a high self time when profiling my build in Chrome. There doesn't appear to be much low hanging fruit in terms of performance for functions that run in webpack, so the gains here are relatively small, 2 seconds off of a 3 minute build.

This change keeps the logic the same, but uses strings and variables directly rather than assigning values to an array and then referencing them again later.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Nope.