### PR TITLE
Throw an error if no compiler found for non-JS config file

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -86,7 +86,9 @@ module.exports = function(yargs, argv, convertOptions) {
 							registerCompiler(moduleDescriptor[i]);
 							break;
 						} catch(e) {
-							// do nothing
+							if(i === moduleDescriptor.length - 1 && e.message.match(/Cannot find module/)) {
+								throw new Error("Cannot resolve config file. Install appropriate compiler and try again.");
+							}
 						}
 					}
 				}

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -86,10 +86,12 @@ module.exports = function(yargs, argv, convertOptions) {
 							registerCompiler(moduleDescriptor[i]);
 							break;
 						} catch(e) {
-							if(i === moduleDescriptor.length - 1 && e.message.match(/Cannot find module/)) {
-								throw new Error("Cannot resolve config file. Install appropriate compiler and try again.");
-							}
+							// do nothing
 						}
+					}
+					if(i === moduleDescriptor.length) {
+						var packages = moduleDescriptor.join(", ");
+						throw new Error("Cannot resolve config file. Install one of the following packages and try again: " + packages);
 					}
 				}
 			}

--- a/test/binCases/configFile/non-js/index.js
+++ b/test/binCases/configFile/non-js/index.js
@@ -1,0 +1,1 @@
+module.exports = "index";

--- a/test/binCases/configFile/non-js/test.js
+++ b/test/binCases/configFile/non-js/test.js
@@ -3,5 +3,5 @@
 module.exports = function testAssertions(code, stdout, stderr) {
 	code.should.not.eql(0);
 	stdout.should.be.empty();
-	stderr[4].should.containEql("Cannot resolve config file. Install appropriate compiler and try again.");
+	stderr[4].should.containEql("Cannot resolve config file. Install one of the following packages and try again:");
 };

--- a/test/binCases/configFile/non-js/test.js
+++ b/test/binCases/configFile/non-js/test.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = function testAssertions(code, stdout, stderr) {
+	code.should.not.eql(0);
+	stdout.should.be.empty();
+	stderr[4].should.containEql("Cannot resolve config file. Install appropriate compiler and try again.");
+};

--- a/test/binCases/configFile/non-js/test.opts
+++ b/test/binCases/configFile/non-js/test.opts
@@ -1,0 +1,3 @@
+--entry ./index.js
+--config ./webpack.config.ts
+--output-filename [name].js

--- a/test/binCases/configFile/non-js/webpack.config.ts
+++ b/test/binCases/configFile/non-js/webpack.config.ts
@@ -1,0 +1,1 @@
+export default {};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yep, added new test.
<!-- Note that we won't merge your changes if you don't add tests -->

<!-- **If relevant, link to documentation update:** -->

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
As described in #5053, currently if you try and run webpack with non-JS config file without the compiler, it will treat the file as a javascript and fail with some unhelpful error.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Doesn't seem so
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

<!-- **Other information** -->
