### PR TITLE
Remove function redeclaration.

### DIFF
--- a/lib/EntryOptionPlugin.js
+++ b/lib/EntryOptionPlugin.js
@@ -8,20 +8,21 @@ const SingleEntryPlugin = require("./SingleEntryPlugin");
 const MultiEntryPlugin = require("./MultiEntryPlugin");
 const DynamicEntryPlugin = require("./DynamicEntryPlugin");
 
+function itemToPlugin(context, item, name) {
+	if(Array.isArray(item)) {
+		return new MultiEntryPlugin(context, item, name);
+	} else {
+		return new SingleEntryPlugin(context, item, name);
+	}
+}
+
 module.exports = class EntryOptionPlugin {
 	apply(compiler) {
 		compiler.plugin("entry-option", (context, entry) => {
-			function itemToPlugin(item, name) {
-				if(Array.isArray(item)) {
-					return new MultiEntryPlugin(context, item, name);
-				} else {
-					return new SingleEntryPlugin(context, item, name);
-				}
-			}
 			if(typeof entry === "string" || Array.isArray(entry)) {
-				compiler.apply(itemToPlugin(entry, "main"));
+				compiler.apply(itemToPlugin(context, entry, "main"));
 			} else if(typeof entry === "object") {
-				Object.keys(entry).forEach(name => compiler.apply(itemToPlugin(entry[name], name)));
+				Object.keys(entry).forEach(name => compiler.apply(itemToPlugin(context, entry[name], name)));
 			} else if(typeof entry === "function") {
 				compiler.apply(new DynamicEntryPlugin(context, entry));
 			}


### PR DESCRIPTION
What:
Move the function from within the function def to outside, to no longer depend
on function level scope values and instead pass the arguments
explicitly.

Impact:
This is a NOOP change, and only helps improve readability

Test plan:
`yarn test`