### PR TITLE
fix: restore backwards compatibility of ConcatenatedModule (fixes #5477)

### DIFF
--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -220,6 +220,10 @@ class ConcatenatedModule extends Module {
 		}
 	}
 
+	get modules() {
+		return this._orderedConcatenationList.map(m => m.module);
+	}
+
 	identifier() {
 		return this._orderedConcatenationList.map(info => {
 			switch(info.type) {

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -214,7 +214,9 @@ class ConcatenatedModule extends Module {
 	}
 
 	get modules() {
-		return this._orderedConcatenationList.map(m => m.module);
+		return this._orderedConcatenationList
+			.filter(info => info.type === "concatenated")
+			.map(info => info.module);
 	}
 
 	identifier() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
I just return an ability to have access to `ConcatenatedModule.modules`.

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Related issue #5477 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
