### PR TITLE
Convert errorAndCallback ternary to arrow function

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -362,13 +362,13 @@ class Compilation extends Tapable {
 	_addModuleChain(context, dependency, onModule, callback) {
 		const start = this.profile && Date.now();
 
-		const errorAndCallback = this.bail ? function errorAndCallback(err) {
+		const errorAndCallback = this.bail ? (err) => {
 			callback(err);
-		} : function errorAndCallback(err) {
+		} : (err) => {
 			err.dependencies = [dependency];
 			this.errors.push(err);
 			callback();
-		}.bind(this);
+		}
 
 		if(typeof dependency !== "object" || dependency === null || !dependency.constructor) {
 			throw new Error("Parameter 'dependency' must be a Dependency");

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -368,7 +368,7 @@ class Compilation extends Tapable {
 			err.dependencies = [dependency];
 			this.errors.push(err);
 			callback();
-		}
+		};
 
 		if(typeof dependency !== "object" || dependency === null || !dependency.constructor) {
 			throw new Error("Parameter 'dependency' must be a Dependency");


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refactoring


**Did you add tests for your changes?**
Minor refactor. Not applicable?

**Summary**
Convert function to arrow function, removing the need to bind.

**Does this PR introduce a breaking change?**
no
