### PR TITLE
[#2387] Uncaught TypeError: Cannot read property 'hot' of undefined

### DIFF
--- a/lib/HotModuleReplacement.runtime.js
+++ b/lib/HotModuleReplacement.runtime.js
@@ -510,8 +510,10 @@ module.exports = function() {
 				moduleOutdatedDependencies = outdatedDependencies[moduleId];
 				var callbacks = [];
 				for(i = 0; i < moduleOutdatedDependencies.length; i++) {
-					dependency = moduleOutdatedDependencies[i];
-					cb = module.hot._acceptedDependencies[dependency];
+					try {
+						dependency = moduleOutdatedDependencies[i];
+						cb = module.hot._acceptedDependencies[dependency];
+					} catch(e) {}
 					if(callbacks.indexOf(cb) >= 0) continue;
 					callbacks.push(cb);
 				}


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
No, as it is covered by already existing tests

**If relevant, link to documentation update:**
N/A

**Summary**
PR is solving a following reported issue "Uncaught TypeError: Cannot read property 'hot' of undefined" (https://github.com/webpack/webpack/issues/2387).
While one of installed modules inside a `moduleOutdatedDependencies` is `undefined`, it was crashing whole hot module replacement and was breaking an existing CSS for a given chunk. 
Wrapping possible error into a `try/catch` block - totally solved problem, and being tested by me on real project for a last week.

**Does this PR introduce a breaking change?**
No

**Other information**
N/A
