### PR TITLE
Convert .bind(this) to arrow functions

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -362,13 +362,13 @@ class Compilation extends Tapable {
 	_addModuleChain(context, dependency, onModule, callback) {
 		const start = this.profile && Date.now();
 
-		const errorAndCallback = this.bail ? function errorAndCallback(err) {
+		const errorAndCallback = this.bail ? (err) => {
 			callback(err);
-		} : function errorAndCallback(err) {
+		} : (err) => {
 			err.dependencies = [dependency];
 			this.errors.push(err);
 			callback();
-		}.bind(this);
+		}
 
 		if(typeof dependency !== "object" || dependency === null || !dependency.constructor) {
 			throw new Error("Parameter 'dependency' must be a Dependency");

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -368,7 +368,7 @@ class Compilation extends Tapable {
 			err.dependencies = [dependency];
 			this.errors.push(err);
 			callback();
-		}
+		};
 
 		if(typeof dependency !== "object" || dependency === null || !dependency.constructor) {
 			throw new Error("Parameter 'dependency' must be a Dependency");

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -201,7 +201,7 @@ class Compiler extends Tapable {
 					});
 				});
 			},
-			apply: function() {
+			apply: () => {
 				const args = arguments;
 				if(!deprecationReported) {
 					console.warn("webpack: Using compiler.parser is deprecated.\n" +
@@ -214,7 +214,7 @@ class Compiler extends Tapable {
 						parser.apply.apply(parser, args);
 					});
 				});
-			}.bind(this)
+			}
 		};
 
 		this.options = {};
@@ -313,13 +313,7 @@ class Compiler extends Tapable {
 	emitAssets(compilation, callback) {
 		let outputPath;
 
-		this.applyPluginsAsync("emit", compilation, err => {
-			if(err) return callback(err);
-			outputPath = compilation.getPath(this.outputPath);
-			this.outputFileSystem.mkdirp(outputPath, emitFiles.bind(this));
-		});
-
-		function emitFiles(err) {
+		const emitFiles = (err) => {
 			if(err) return callback(err);
 
 			require("async").forEach(Object.keys(compilation.assets), (file, callback) => {
@@ -330,12 +324,7 @@ class Compiler extends Tapable {
 					targetFile = targetFile.substr(0, queryStringIdx);
 				}
 
-				if(targetFile.match(/\/|\\/)) {
-					const dir = path.dirname(targetFile);
-					this.outputFileSystem.mkdirp(this.outputFileSystem.join(outputPath, dir), writeOut.bind(this));
-				} else writeOut.call(this);
-
-				function writeOut(err) {
+				const writeOut = (err) => {
 					if(err) return callback(err);
 					const targetPath = this.outputFileSystem.join(outputPath, targetFile);
 					const source = compilation.assets[file];
@@ -352,14 +341,25 @@ class Compiler extends Tapable {
 					source.existsAt = targetPath;
 					source.emitted = true;
 					this.outputFileSystem.writeFile(targetPath, content, callback);
-				}
+				};
+
+				if(targetFile.match(/\/|\\/)) {
+					const dir = path.dirname(targetFile);
+					this.outputFileSystem.mkdirp(this.outputFileSystem.join(outputPath, dir), writeOut);
+				} else writeOut();
 
 			}, err => {
 				if(err) return callback(err);
 
 				afterEmit.call(this);
 			});
-		}
+		};
+
+		this.applyPluginsAsync("emit", compilation, err => {
+			if(err) return callback(err);
+			outputPath = compilation.getPath(this.outputPath);
+			this.outputFileSystem.mkdirp(outputPath, emitFiles);
+		});
 
 		function afterEmit() {
 			this.applyPluginsAsyncSeries1("after-emit", compilation, err => {

--- a/lib/ContextModuleFactory.js
+++ b/lib/ContextModuleFactory.js
@@ -103,16 +103,16 @@ module.exports = class ContextModuleFactory extends Tapable {
 		if(!regExp || !resource)
 			return callback(null, []);
 		(function addDirectory(directory, callback) {
-			fs.readdir(directory, function(err, files) {
+			fs.readdir(directory, (err, files) => {
 				if(err) return callback(err);
 				if(!files || files.length === 0) return callback(null, []);
 				asyncLib.map(files.filter(function(p) {
 					return p.indexOf(".") !== 0;
-				}), function(seqment, callback) {
+				}), (seqment, callback) => {
 
 					const subResource = path.join(directory, seqment);
 
-					fs.stat(subResource, function(err, stat) {
+					fs.stat(subResource, (err, stat) => {
 						if(err) return callback(err);
 
 						if(stat.isDirectory()) {
@@ -141,9 +141,9 @@ module.exports = class ContextModuleFactory extends Tapable {
 
 						} else callback();
 
-					}.bind(this));
+					});
 
-				}.bind(this), (err, result) => {
+				}, (err, result) => {
 					if(err) return callback(err);
 
 					if(!result) return callback(null, []);
@@ -154,7 +154,7 @@ module.exports = class ContextModuleFactory extends Tapable {
 						return a.concat(i);
 					}, []));
 				});
-			}.bind(this));
+			});
 		}.call(this, resource, callback));
 	}
 };

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -634,14 +634,14 @@ class Parser extends Tapable {
 		statement.params.forEach(param => {
 			this.walkPattern(param);
 		});
-		this.inScope(statement.params, function() {
+		this.inScope(statement.params, () => {
 			if(statement.body.type === "BlockStatement") {
 				this.prewalkStatement(statement.body);
 				this.walkStatement(statement.body);
 			} else {
 				this.walkExpression(statement.body);
 			}
-		}.bind(this));
+		});
 	}
 
 	prewalkImportDeclaration(statement) {
@@ -784,10 +784,10 @@ class Parser extends Tapable {
 	}
 
 	walkCatchClause(catchClause) {
-		this.inScope([catchClause.param], function() {
+		this.inScope([catchClause.param], () => {
 			this.prewalkStatement(catchClause.body);
 			this.walkStatement(catchClause.body);
-		}.bind(this));
+		});
 	}
 
 	prewalkVariableDeclarators(declarators) {
@@ -916,28 +916,28 @@ class Parser extends Tapable {
 		expression.params.forEach(param => {
 			this.walkPattern(param);
 		});
-		this.inScope(expression.params, function() {
+		this.inScope(expression.params, () => {
 			if(expression.body.type === "BlockStatement") {
 				this.prewalkStatement(expression.body);
 				this.walkStatement(expression.body);
 			} else {
 				this.walkExpression(expression.body);
 			}
-		}.bind(this));
+		});
 	}
 
 	walkArrowFunctionExpression(expression) {
 		expression.params.forEach(param => {
 			this.walkPattern(param);
 		});
-		this.inScope(expression.params, function() {
+		this.inScope(expression.params, () => {
 			if(expression.body.type === "BlockStatement") {
 				this.prewalkStatement(expression.body);
 				this.walkStatement(expression.body);
 			} else {
 				this.walkExpression(expression.body);
 			}
-		}.bind(this));
+		});
 	}
 
 	walkSequenceExpression(expression) {
@@ -1059,7 +1059,7 @@ class Parser extends Tapable {
 			const args = options.map(renameArgOrThis, this);
 			this.inScope(params.filter(function(identifier, idx) {
 				return !args[idx];
-			}), function() {
+			}), () => {
 				if(renameThis) {
 					this.scope.renames.$this = renameThis;
 				}
@@ -1074,7 +1074,7 @@ class Parser extends Tapable {
 					this.walkStatement(functionExpression.body);
 				} else
 					this.walkExpression(functionExpression.body);
-			}.bind(this));
+			});
 		}
 		if(expression.callee.type === "MemberExpression" &&
 			expression.callee.object.type === "FunctionExpression" &&

--- a/lib/UmdMainTemplatePlugin.js
+++ b/lib/UmdMainTemplatePlugin.js
@@ -41,7 +41,7 @@ class UmdMainTemplatePlugin {
 
 	apply(compilation) {
 		const mainTemplate = compilation.mainTemplate;
-		compilation.templatesPlugin("render-with-entry", function(source, chunk, hash) {
+		compilation.templatesPlugin("render-with-entry", (source, chunk, hash) => {
 			let externals = chunk.getModules().filter(m => m.external);
 			const optionalExternals = [];
 			let requiredExternals = [];
@@ -172,19 +172,19 @@ class UmdMainTemplatePlugin {
 					"	}\n"
 				) +
 				"})(this, function(" + externalsArguments(externals) + ") {\nreturn ", "webpack/universalModuleDefinition"), source, ";\n})");
-		}.bind(this));
-		mainTemplate.plugin("global-hash-paths", function(paths) {
+		});
+		mainTemplate.plugin("global-hash-paths", (paths) => {
 			if(this.names.root) paths = paths.concat(this.names.root);
 			if(this.names.amd) paths = paths.concat(this.names.amd);
 			if(this.names.commonjs) paths = paths.concat(this.names.commonjs);
 			return paths;
-		}.bind(this));
-		mainTemplate.plugin("hash", function(hash) {
+		});
+		mainTemplate.plugin("hash", (hash) => {
 			hash.update("umd");
 			hash.update(`${this.names.root}`);
 			hash.update(`${this.names.amd}`);
 			hash.update(`${this.names.commonjs}`);
-		}.bind(this));
+		});
 	}
 }
 


### PR DESCRIPTION
#**What kind of change does this PR introduce?**
Refactoring

**Did you add tests for your changes?**
Not applicable.  


**Summary**
Related to https://github.com/webpack/webpack/pull/5495
Convert `bind(this)` instances to arrow functions where applicable.  Some binds are in classes and class properties & fields are not supported yet.  

**Does this PR introduce a breaking change?**
No