### PR TITLE
Always append the inner message to the ModuleBuildError message

### DIFF
--- a/lib/ModuleBuildError.js
+++ b/lib/ModuleBuildError.js
@@ -15,16 +15,16 @@ class ModuleBuildError extends WebpackError {
 		this.message = "Module build failed: ";
 		if(err !== null && typeof err === "object") {
 			if(typeof err.stack === "string" && err.stack) {
+				if(typeof err.message === "string" && err.message) {
+					this.message += err.message;
+				} else {
+					this.message += err;
+				}
 				var stack = cutOffLoaderExecution(err.stack);
 				if(!err.hideStack) {
 					this.message += stack;
 				} else {
 					this.details = stack;
-					if(typeof err.message === "string" && err.message) {
-						this.message += err.message;
-					} else {
-						this.message += err;
-					}
 				}
 			} else if(typeof err.message === "string" && err.message) {
 				this.message += err.message;

--- a/test/ModuleBuildError.test.js
+++ b/test/ModuleBuildError.test.js
@@ -12,7 +12,7 @@ describe("ModuleBuildError", () => {
 
 	it("is a function", () => ModuleBuildError.should.be.a.Function());
 
-	describe("when new error created", () => {
+	describe("a newly created error", () => {
 		beforeEach(() => {
 			env.error = new Error("Custom Error Message");
 			env.moduleBuildError = new ModuleBuildError("myModule", env.error, "Location");
@@ -24,13 +24,13 @@ describe("ModuleBuildError", () => {
 
 		it("has a message property", () => env.moduleBuildError.message.should.startWith("Module build failed: Custom Error Message"));
 
-		it("contains a stack trace", () => env.moduleBuildError.message.should.match(/Context\.beforeEach/));
+		it("contains a stack trace", () => env.moduleBuildError.message.should.match(/ModuleBuildError\.test\.js/));
 
 		it("has an error property", () => env.moduleBuildError.error.should.be.exactly(env.error));
 
 	});
 
-	describe("when the error wants to hide the stack trace", () => {
+	describe("a newly created error with a hidden stack trace", () => {
 		beforeEach(() => {
 			env.error = new Error("Custom Error Message");
 			env.error.hideStack = true;
@@ -43,7 +43,7 @@ describe("ModuleBuildError", () => {
 
 		it("has a message property without a stack trace", () => env.moduleBuildError.message.should.be.exactly("Module build failed: Custom Error Message"));
 
-		it("has a stack trace in details", () => env.moduleBuildError.details.should.be.match(/Context\.beforeEach/));
+		it("has a stack trace in details", () => env.moduleBuildError.details.should.be.match(/ModuleBuildError\.test\.js/));
 
 		it("has an error property", () => env.moduleBuildError.error.should.be.exactly(env.error));
 

--- a/test/ModuleBuildError.test.js
+++ b/test/ModuleBuildError.test.js
@@ -1,0 +1,51 @@
+"use strict";
+
+const path = require("path");
+const should = require("should");
+const sinon = require("sinon");
+const ModuleBuildError = require("../lib/ModuleBuildError");
+
+describe("ModuleBuildError", () => {
+	let env;
+
+	beforeEach(() => env = {});
+
+	it("is a function", () => ModuleBuildError.should.be.a.Function());
+
+	describe("when new error created", () => {
+		beforeEach(() => {
+			env.error = new Error("Custom Error Message");
+			env.moduleBuildError = new ModuleBuildError("myModule", env.error, "Location");
+		});
+
+		it("is an error", () => env.moduleBuildError.should.be.an.Error());
+
+		it("has a name property", () => env.moduleBuildError.name.should.be.exactly("ModuleBuildError"));
+
+		it("has a message property", () => env.moduleBuildError.message.should.startWith("Module build failed: Custom Error Message"));
+
+		it("contains a stack trace", () => env.moduleBuildError.message.should.match(/Context\.beforeEach/));
+
+		it("has an error property", () => env.moduleBuildError.error.should.be.exactly(env.error));
+
+	});
+
+	describe("when the error wants to hide the stack trace", () => {
+		beforeEach(() => {
+			env.error = new Error("Custom Error Message");
+			env.error.hideStack = true;
+			env.moduleBuildError = new ModuleBuildError("myModule", env.error, "Location");
+		});
+
+		it("is an error", () => env.moduleBuildError.should.be.an.Error());
+
+		it("has a name property", () => env.moduleBuildError.name.should.be.exactly("ModuleBuildError"));
+
+		it("has a message property without a stack trace", () => env.moduleBuildError.message.should.be.exactly("Module build failed: Custom Error Message"));
+
+		it("has a stack trace in details", () => env.moduleBuildError.details.should.be.match(/Context\.beforeEach/));
+
+		it("has an error property", () => env.moduleBuildError.error.should.be.exactly(env.error));
+
+	});
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

improved error message

**Did you add tests for your changes?**

Yes

**If relevant, link to documentation update:**

N/A

**Summary**

When a loader throws an error with a stack trace, we weren't getting a helpful error message. It looks like it's because the error gets wrapped in a ModuleBuildError and the inner error's message isn't exposed.

I looked through the history of ModuleBuildError.cs and it seems like this behavior has been around since inception, so I'm not sure if the behavior is intentional or not.

Specifically, I'm using babel-loader with the plugin babel-plugin-undeclared-variables-check. This throws a [BabelLoaderError](https://github.com/babel/babel-loader/blob/f0bbb68ad484b5211926dafb57f25fd418d06dc4/src/index.js#L15-L23) back to webpack, where it's wrapped in a [ModuleBuildError](https://github.com/webpack/webpack/blob/4b2b1ad99b86458983714c589c6495772b1292ee/lib/NormalModule.js#L194).

**Does this PR introduce a breaking change?**

Not to my knowledge

**Other information**

The error I get before this change:

```
ERROR in ./entry.js
Module build failed: Error
    at transpile (/Users/stephen/t/node_modules/babel-loader/lib/index.js:64:13)
    at Object.module.exports (/Users/stephen/t/node_modules/babel-loader/lib/index.js:174:20)
```


And after the change:

```
ERROR in ./entry.js
Module build failed: /Users/stephen/t/entry.js: Reference to undeclared variable "foo"

> 1 | foo()
    | ^
  2 |
Error
    at transpile (/Users/stephen/t/node_modules/babel-loader/lib/index.js:64:13)
    at Object.module.exports (/Users/stephen/t/node_modules/babel-loader/lib/index.js:174:20)
```

And the webpack.config.js:

```js
var path = require('path')

module.exports = {
  entry: path.join(__dirname, 'entry.js'),

  output: {
    filename: 'output.js'
  },

  module: {
    rules: [
      {
        test: /\.js$/,
        use: {
          loader: 'babel-loader',
          options: {
            plugins: ['babel-plugin-undeclared-variables-check']
          }
        }
      }
    ]
  }
}
```