### PR TITLE
Fix bundle syntax errors with pathinfo: true and */ in request

### DIFF
--- a/lib/FunctionModuleTemplatePlugin.js
+++ b/lib/FunctionModuleTemplatePlugin.js
@@ -24,9 +24,9 @@ class FunctionModuleTemplatePlugin {
 		moduleTemplate.plugin("package", function(moduleSource, module) {
 			if(this.outputOptions.pathinfo) {
 				const source = new ConcatSource();
-				const req = module.readableIdentifier(this.requestShortener);
+				const req = module.readableIdentifier(this.requestShortener).replace(/\*\//g, "*_/");
 				source.add("/*!****" + req.replace(/./g, "*") + "****!*\\\n");
-				source.add("  !*** " + req.replace(/\*\//g, "*_/") + " ***!\n");
+				source.add("  !*** " + req + " ***!\n");
 				source.add("  \\****" + req.replace(/./g, "*") + "****/\n");
 				if(Array.isArray(module.providedExports))
 					source.add("/*! exports provided: " + module.providedExports.join(", ") + " */\n");

--- a/lib/MultiModule.js
+++ b/lib/MultiModule.js
@@ -58,7 +58,7 @@ class MultiModule extends Module {
 					str.push("module.exports = ");
 				str.push("__webpack_require__(");
 				if(outputOptions.pathinfo)
-					str.push(`/*! ${dep.request} */`);
+					str.push(`/*! ${dep.request.replace(/\*\//g, "*_/")} */`);
 				str.push(`${JSON.stringify(dep.module.id)}`);
 				str.push(")");
 			} else {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

Not yet

**Summary**

Fixes #1759

**Does this PR introduce a breaking change?**

No

**Other information**

Before:
```javascript
module.exports = __webpack_require__(/*! ./src/index.js?*/ */1);
```

After:
```javascript
module.exports = __webpack_require__(/*! ./src/index.js?*_/ */1);
```

Also fixes a completely superficial comment alignment problem

Before:

``` javascript
/*!********************!*\
  !*** ./main.js?*_/ ***!
  \********************/
```

After:

``` javascript
/*!*********************!*\
  !*** ./main.js?*_/ ***!
  \*********************/
```