### PR TITLE
fix: cli --watch-poll not accept number correctly

### DIFF
--- a/bin/config-yargs.js
+++ b/bin/config-yargs.js
@@ -172,7 +172,7 @@ module.exports = function(yargs) {
 				requiresArg: true
 			},
 			"watch-poll": {
-				type: "boolean",
+				type: "string",
 				describe: "The polling interval for watching (also enable polling)",
 				group: ADVANCED_GROUP
 			},

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -166,12 +166,12 @@ module.exports = function(yargs, argv, convertOptions) {
 			options.watchOptions.aggregateTimeout = +argv["watch-aggregate-timeout"];
 		}
 
-		if(argv["watch-poll"]) {
+		if(typeof argv["watch-poll"] !== undefined) {
 			options.watchOptions = options.watchOptions || {};
-			if(typeof argv["watch-poll"] !== "boolean")
-				options.watchOptions.poll = +argv["watch-poll"];
-			else
+			if(argv["watch-poll"] === "true" || argv["watch-poll"] === "")
 				options.watchOptions.poll = true;
+			else if(!isNaN(argv["watch-poll"]))
+				options.watchOptions.poll = +argv["watch-poll"];
 		}
 
 		if(argv["watch-stdin"]) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Summary**

The document say `--watch-poll` option can determine "The polling interval for watching (also enable polling)". But the previous implement only accept boolean value and no way to set the interval.

This patch try to fix this problem by allow number input like this: `--watch-poll=100`.

This patch also try to keep the original behavior not be changed as much as possible. So `--watch-poll` and `--watch-poll=true` are still acceptable (enable the polling ability).

But still has one incompatible change: original `--watch-poll=` mean disable polling but after this fix it mean enable polling. It's due to `yargs` can not differentiate the different between `--watch-poll` and
`--watch-poll=` when using string type option. So no way to workaround for this problem.

**Did you add tests for your changes?**

No, Not sure how to test this problem.