### PR TITLE
Make node-libs-browser optional

### DIFF
--- a/lib/node/NodeSourcePlugin.js
+++ b/lib/node/NodeSourcePlugin.js
@@ -5,17 +5,23 @@
 "use strict";
 const AliasPlugin = require("enhanced-resolve/lib/AliasPlugin");
 const ParserHelpers = require("../ParserHelpers");
-const nodeLibsBrowser = require("node-libs-browser");
-
+try {
+	const nodeLibsBrowser = require("node-libs-browser");
+} catch(err) {
+	nodeLibsBrowser = null;
+}
+	
 module.exports = class NodeSourcePlugin {
 	constructor(options) {
 		this.options = options;
+		
 	}
 	apply(compiler) {
 		const options = this.options;
 		if(options === false) // allow single kill switch to turn off this plugin
 			return;
-
+		if (nodeLibsBrowser === null)
+			return;
 		function getPathToModule(module, type) {
 			if(type === true || (type === undefined && nodeLibsBrowser[module])) {
 				if(!nodeLibsBrowser[module]) throw new Error(`No browser version for node.js core module ${module} available`);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "loader-utils": "^1.1.0",
     "memory-fs": "~0.4.1",
     "mkdirp": "~0.5.0",
-    "node-libs-browser": "^2.0.0",
     "source-map": "^0.5.3",
     "supports-color": "^4.2.1",
     "tapable": "^0.2.7",
@@ -28,6 +27,9 @@
     "yargs": "^8.0.2"
   },
   "license": "MIT",
+  "optionalDependencies": {
+    "node-libs-browser": "^2.0.0"
+  }
   "devDependencies": {
     "beautify-lint": "^1.0.3",
     "benchmark": "^2.1.1",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Feature improvement
**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->
N/A
**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Make node-libs-browser optional.
https://github.com/webpack/webpack/issues/3058

<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Yes, since node-libs-browser is now optional, anyone that was depending on the NodeSourcePlugin and also has optional dependencies turned off will no longer work, the user will have to install this optional dependency.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
