### PR TITLE
fix: Clear optimization bailouts on module.disconnect

### DIFF
--- a/lib/Module.js
+++ b/lib/Module.js
@@ -58,6 +58,7 @@ class Module extends DependenciesBlock {
 		this.providedExports = null;
 		this._chunks.clear();
 		this._chunksDebugIdent = undefined;
+		this.optimizationBailout.length = 0;
 		super.disconnect();
 	}
 


### PR DESCRIPTION
Ref: #5562

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

Fixes #5562.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No - will amend later with tests, first time w/Webpack tests and it's a bit overwhelming at the moment to get a hang of them.

<!-- Note that we won't merge your changes if you don't add tests -->

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

See #5562: ModuleConcatenationPlugin errors snowball over time in incremental builds because this array is not cleared. After a while, the process will crash with an out of memory error.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
