### PR TITLE
Make node-libs-browser optional

### DIFF
--- a/lib/node/NodeSourcePlugin.js
+++ b/lib/node/NodeSourcePlugin.js
@@ -5,23 +5,14 @@
 "use strict";
 const AliasPlugin = require("enhanced-resolve/lib/AliasPlugin");
 const ParserHelpers = require("../ParserHelpers");
-var nodeLibsBrowser = null;
-try {
-	nodeLibsBrowser = require("node-libs-browser");
-} catch(err) {
-	nodeLibsBrowser = null;
-}
 
 module.exports = class NodeSourcePlugin {
 	constructor(options) {
 		this.options = options;
 	}
+
 	apply(compiler) {
-		const options = this.options;
-		if(options === false) // allow single kill switch to turn off this plugin
-			return;
-		if(nodeLibsBrowser === null)
-			return;
+		var nodeLibsBrowser = null;
 
 		function getPathToModule(module, type) {
 			if(type === true || (type === undefined && nodeLibsBrowser[module])) {
@@ -42,54 +33,60 @@ module.exports = class NodeSourcePlugin {
 				return ParserHelpers.addParsedVariableToModule(this, name, mockModule + suffix);
 			});
 		}
+		try {
+			nodeLibsBrowser = require("node-libs-browser");
+			const options = this.options;
+			if(options === false) // allow single kill switch to turn off this plugin
+				return;
 
-		compiler.plugin("compilation", function(compilation, params) {
-			params.normalModuleFactory.plugin("parser", function(parser, parserOptions) {
+			compiler.plugin("compilation", function(compilation, params) {
+				params.normalModuleFactory.plugin("parser", function(parser, parserOptions) {
 
-				if(parserOptions.node === false)
-					return;
+					if(parserOptions.node === false)
+						return;
 
-				let localOptions = options;
-				if(parserOptions.node)
-					localOptions = Object.assign({}, localOptions, parserOptions.node);
+					let localOptions = options;
+					if(parserOptions.node)
+						localOptions = Object.assign({}, localOptions, parserOptions.node);
 
-				if(localOptions.global) {
-					parser.plugin("expression global", function() {
-						const retrieveGlobalModule = ParserHelpers.requireFileAsExpression(this.state.module.context, require.resolve("../../buildin/global.js"));
-						return ParserHelpers.addParsedVariableToModule(this, "global", retrieveGlobalModule);
-					});
-				}
-				if(localOptions.process) {
-					const processType = localOptions.process;
-					addExpression(parser, "process", "process", processType);
-				}
-				if(localOptions.console) {
-					const consoleType = localOptions.console;
-					addExpression(parser, "console", "console", consoleType);
-				}
-				const bufferType = localOptions.Buffer;
-				if(bufferType) {
-					addExpression(parser, "Buffer", "buffer", bufferType, ".Buffer");
-				}
-				if(localOptions.setImmediate) {
-					const setImmediateType = localOptions.setImmediate;
-					addExpression(parser, "setImmediate", "timers", setImmediateType, ".setImmediate");
-					addExpression(parser, "clearImmediate", "timers", setImmediateType, ".clearImmediate");
-				}
+					if(localOptions.global) {
+						parser.plugin("expression global", function() {
+							const retrieveGlobalModule = ParserHelpers.requireFileAsExpression(this.state.module.context, require.resolve("../../buildin/global.js"));
+							return ParserHelpers.addParsedVariableToModule(this, "global", retrieveGlobalModule);
+						});
+					}
+					if(localOptions.process) {
+						const processType = localOptions.process;
+						addExpression(parser, "process", "process", processType);
+					}
+					if(localOptions.console) {
+						const consoleType = localOptions.console;
+						addExpression(parser, "console", "console", consoleType);
+					}
+					const bufferType = localOptions.Buffer;
+					if(bufferType) {
+						addExpression(parser, "Buffer", "buffer", bufferType, ".Buffer");
+					}
+					if(localOptions.setImmediate) {
+						const setImmediateType = localOptions.setImmediate;
+						addExpression(parser, "setImmediate", "timers", setImmediateType, ".setImmediate");
+						addExpression(parser, "clearImmediate", "timers", setImmediateType, ".clearImmediate");
+					}
+				});
 			});
-		});
-		compiler.plugin("after-resolvers", (compiler) => {
-			Object.keys(nodeLibsBrowser).forEach((lib) => {
-				if(options[lib] !== false) {
-					compiler.resolvers.normal.apply(
-						new AliasPlugin("described-resolve", {
-							name: lib,
-							onlyModule: true,
-							alias: getPathToModule(lib, options[lib])
-						}, "resolve")
-					);
-				}
+			compiler.plugin("after-resolvers", (compiler) => {
+				Object.keys(nodeLibsBrowser).forEach((lib) => {
+					if(options[lib] !== false) {
+						compiler.resolvers.normal.apply(
+							new AliasPlugin("described-resolve", {
+								name: lib,
+								onlyModule: true,
+								alias: getPathToModule(lib, options[lib])
+							}, "resolve")
+						);
+					}
+				});
 			});
-		});
+		} catch(err) {}
 	}
 };

--- a/lib/node/NodeSourcePlugin.js
+++ b/lib/node/NodeSourcePlugin.js
@@ -5,88 +5,96 @@
 "use strict";
 const AliasPlugin = require("enhanced-resolve/lib/AliasPlugin");
 const ParserHelpers = require("../ParserHelpers");
-
+function getNodeLibsBrowser() {
+	try {
+		return require("node-libs-browser");
+	}
+	catch (err) {
+		return null;
+	}
+}
 module.exports = class NodeSourcePlugin {
 	constructor(options) {
 		this.options = options;
 	}
 
 	apply(compiler) {
-		var nodeLibsBrowser = null;
-
+		const nodeLibsBrowser = getNodeLibsBrowser();
+		
 		function getPathToModule(module, type) {
-			if(type === true || (type === undefined && nodeLibsBrowser[module])) {
-				if(!nodeLibsBrowser[module]) throw new Error(`No browser version for node.js core module ${module} available`);
+			if (type === true || (type === undefined && nodeLibsBrowser[module])) {
+				if (!nodeLibsBrowser[module]) throw new Error(`No browser version for node.js core module ${module} available`);
 				return nodeLibsBrowser[module];
-			} else if(type === "mock") {
+			} else if (type === "mock") {
 				return require.resolve(`node-libs-browser/mock/${module}`);
-			} else if(type === "empty") {
+			} else if (type === "empty") {
 				return require.resolve("node-libs-browser/mock/empty");
 			} else return module;
 		}
 
 		function addExpression(parser, name, module, type, suffix) {
 			suffix = suffix || "";
-			parser.plugin(`expression ${name}`, function() {
-				if(this.state.module && this.state.module.resource === getPathToModule(module, type)) return;
+			parser.plugin(`expression ${name}`, function () {
+				if (this.state.module && this.state.module.resource === getPathToModule(module, type)) return;
 				const mockModule = ParserHelpers.requireFileAsExpression(this.state.module.context, getPathToModule(module, type));
 				return ParserHelpers.addParsedVariableToModule(this, name, mockModule + suffix);
 			});
 		}
-		try {
-			nodeLibsBrowser = require("node-libs-browser");
-			const options = this.options;
-			if(options === false) // allow single kill switch to turn off this plugin
-				return;
+		if (nodeLibsBrowser === null) {
+			return;
+		}
+		const options = this.options;
+		if (options === false) // allow single kill switch to turn off this plugin
+			return;
 
-			compiler.plugin("compilation", function(compilation, params) {
-				params.normalModuleFactory.plugin("parser", function(parser, parserOptions) {
+		compiler.plugin("compilation", function (compilation, params) {
+			params.normalModuleFactory.plugin("parser", function (parser, parserOptions) {
 
-					if(parserOptions.node === false)
-						return;
+				if (parserOptions.node === false)
+					return;
 
-					let localOptions = options;
-					if(parserOptions.node)
-						localOptions = Object.assign({}, localOptions, parserOptions.node);
+				let localOptions = options;
+				if (parserOptions.node)
+					localOptions = Object.assign({}, localOptions, parserOptions.node);
 
-					if(localOptions.global) {
-						parser.plugin("expression global", function() {
-							const retrieveGlobalModule = ParserHelpers.requireFileAsExpression(this.state.module.context, require.resolve("../../buildin/global.js"));
-							return ParserHelpers.addParsedVariableToModule(this, "global", retrieveGlobalModule);
-						});
-					}
-					if(localOptions.process) {
-						const processType = localOptions.process;
-						addExpression(parser, "process", "process", processType);
-					}
-					if(localOptions.console) {
-						const consoleType = localOptions.console;
-						addExpression(parser, "console", "console", consoleType);
-					}
-					const bufferType = localOptions.Buffer;
-					if(bufferType) {
-						addExpression(parser, "Buffer", "buffer", bufferType, ".Buffer");
-					}
-					if(localOptions.setImmediate) {
-						const setImmediateType = localOptions.setImmediate;
-						addExpression(parser, "setImmediate", "timers", setImmediateType, ".setImmediate");
-						addExpression(parser, "clearImmediate", "timers", setImmediateType, ".clearImmediate");
-					}
-				});
+				if (localOptions.global) {
+					parser.plugin("expression global", function () {
+						const retrieveGlobalModule = ParserHelpers.requireFileAsExpression(this.state.module.context, require.resolve("../../buildin/global.js"));
+						return ParserHelpers.addParsedVariableToModule(this, "global", retrieveGlobalModule);
+					});
+				}
+				if (localOptions.process) {
+					const processType = localOptions.process;
+					addExpression(parser, "process", "process", processType);
+				}
+				if (localOptions.console) {
+					const consoleType = localOptions.console;
+					addExpression(parser, "console", "console", consoleType);
+				}
+				const bufferType = localOptions.Buffer;
+				if (bufferType) {
+					addExpression(parser, "Buffer", "buffer", bufferType, ".Buffer");
+				}
+				if (localOptions.setImmediate) {
+					const setImmediateType = localOptions.setImmediate;
+					addExpression(parser, "setImmediate", "timers", setImmediateType, ".setImmediate");
+					addExpression(parser, "clearImmediate", "timers", setImmediateType, ".clearImmediate");
+				}
 			});
-			compiler.plugin("after-resolvers", (compiler) => {
-				Object.keys(nodeLibsBrowser).forEach((lib) => {
-					if(options[lib] !== false) {
-						compiler.resolvers.normal.apply(
-							new AliasPlugin("described-resolve", {
-								name: lib,
-								onlyModule: true,
-								alias: getPathToModule(lib, options[lib])
-							}, "resolve")
-						);
-					}
-				});
+		});
+		compiler.plugin("after-resolvers", (compiler) => {
+			Object.keys(nodeLibsBrowser).forEach((lib) => {
+				if (options[lib] !== false) {
+					compiler.resolvers.normal.apply(
+						new AliasPlugin("described-resolve", {
+							name: lib,
+							onlyModule: true,
+							alias: getPathToModule(lib, options[lib])
+						}, "resolve")
+					);
+				}
 			});
-		} catch(err) {}
+		});
+
 	}
 };

--- a/lib/node/NodeSourcePlugin.js
+++ b/lib/node/NodeSourcePlugin.js
@@ -5,17 +5,23 @@
 "use strict";
 const AliasPlugin = require("enhanced-resolve/lib/AliasPlugin");
 const ParserHelpers = require("../ParserHelpers");
-const nodeLibsBrowser = require("node-libs-browser");
-
+try {
+	const nodeLibsBrowser = require("node-libs-browser");
+} catch(err) {
+	nodeLibsBrowser = null;
+}
+	
 module.exports = class NodeSourcePlugin {
 	constructor(options) {
 		this.options = options;
+		
 	}
 	apply(compiler) {
 		const options = this.options;
 		if(options === false) // allow single kill switch to turn off this plugin
 			return;
-
+		if (nodeLibsBrowser === null)
+			return;
 		function getPathToModule(module, type) {
 			if(type === true || (type === undefined && nodeLibsBrowser[module])) {
 				if(!nodeLibsBrowser[module]) throw new Error(`No browser version for node.js core module ${module} available`);

--- a/lib/node/NodeSourcePlugin.js
+++ b/lib/node/NodeSourcePlugin.js
@@ -5,14 +5,15 @@
 "use strict";
 const AliasPlugin = require("enhanced-resolve/lib/AliasPlugin");
 const ParserHelpers = require("../ParserHelpers");
+
 function getNodeLibsBrowser() {
 	try {
 		return require("node-libs-browser");
-	}
-	catch (err) {
+	} catch(err) {
 		return null;
 	}
 }
+
 module.exports = class NodeSourcePlugin {
 	constructor(options) {
 		this.options = options;
@@ -20,62 +21,62 @@ module.exports = class NodeSourcePlugin {
 
 	apply(compiler) {
 		const nodeLibsBrowser = getNodeLibsBrowser();
-		
+
 		function getPathToModule(module, type) {
-			if (type === true || (type === undefined && nodeLibsBrowser[module])) {
-				if (!nodeLibsBrowser[module]) throw new Error(`No browser version for node.js core module ${module} available`);
+			if(type === true || (type === undefined && nodeLibsBrowser[module])) {
+				if(!nodeLibsBrowser[module]) throw new Error(`No browser version for node.js core module ${module} available`);
 				return nodeLibsBrowser[module];
-			} else if (type === "mock") {
+			} else if(type === "mock") {
 				return require.resolve(`node-libs-browser/mock/${module}`);
-			} else if (type === "empty") {
+			} else if(type === "empty") {
 				return require.resolve("node-libs-browser/mock/empty");
 			} else return module;
 		}
 
 		function addExpression(parser, name, module, type, suffix) {
 			suffix = suffix || "";
-			parser.plugin(`expression ${name}`, function () {
-				if (this.state.module && this.state.module.resource === getPathToModule(module, type)) return;
+			parser.plugin(`expression ${name}`, function() {
+				if(this.state.module && this.state.module.resource === getPathToModule(module, type)) return;
 				const mockModule = ParserHelpers.requireFileAsExpression(this.state.module.context, getPathToModule(module, type));
 				return ParserHelpers.addParsedVariableToModule(this, name, mockModule + suffix);
 			});
 		}
-		if (nodeLibsBrowser === null) {
+		if(nodeLibsBrowser === null) {
 			return;
 		}
 		const options = this.options;
-		if (options === false) // allow single kill switch to turn off this plugin
+		if(options === false) // allow single kill switch to turn off this plugin
 			return;
 
-		compiler.plugin("compilation", function (compilation, params) {
-			params.normalModuleFactory.plugin("parser", function (parser, parserOptions) {
+		compiler.plugin("compilation", function(compilation, params) {
+			params.normalModuleFactory.plugin("parser", function(parser, parserOptions) {
 
-				if (parserOptions.node === false)
+				if(parserOptions.node === false)
 					return;
 
 				let localOptions = options;
-				if (parserOptions.node)
+				if(parserOptions.node)
 					localOptions = Object.assign({}, localOptions, parserOptions.node);
 
-				if (localOptions.global) {
-					parser.plugin("expression global", function () {
+				if(localOptions.global) {
+					parser.plugin("expression global", function() {
 						const retrieveGlobalModule = ParserHelpers.requireFileAsExpression(this.state.module.context, require.resolve("../../buildin/global.js"));
 						return ParserHelpers.addParsedVariableToModule(this, "global", retrieveGlobalModule);
 					});
 				}
-				if (localOptions.process) {
+				if(localOptions.process) {
 					const processType = localOptions.process;
 					addExpression(parser, "process", "process", processType);
 				}
-				if (localOptions.console) {
+				if(localOptions.console) {
 					const consoleType = localOptions.console;
 					addExpression(parser, "console", "console", consoleType);
 				}
 				const bufferType = localOptions.Buffer;
-				if (bufferType) {
+				if(bufferType) {
 					addExpression(parser, "Buffer", "buffer", bufferType, ".Buffer");
 				}
-				if (localOptions.setImmediate) {
+				if(localOptions.setImmediate) {
 					const setImmediateType = localOptions.setImmediate;
 					addExpression(parser, "setImmediate", "timers", setImmediateType, ".setImmediate");
 					addExpression(parser, "clearImmediate", "timers", setImmediateType, ".clearImmediate");
@@ -84,7 +85,7 @@ module.exports = class NodeSourcePlugin {
 		});
 		compiler.plugin("after-resolvers", (compiler) => {
 			Object.keys(nodeLibsBrowser).forEach((lib) => {
-				if (options[lib] !== false) {
+				if(options[lib] !== false) {
 					compiler.resolvers.normal.apply(
 						new AliasPlugin("described-resolve", {
 							name: lib,

--- a/lib/node/NodeSourcePlugin.js
+++ b/lib/node/NodeSourcePlugin.js
@@ -5,23 +5,24 @@
 "use strict";
 const AliasPlugin = require("enhanced-resolve/lib/AliasPlugin");
 const ParserHelpers = require("../ParserHelpers");
+var nodeLibsBrowser = null;
 try {
-	const nodeLibsBrowser = require("node-libs-browser");
+	nodeLibsBrowser = require("node-libs-browser");
 } catch(err) {
 	nodeLibsBrowser = null;
 }
-	
+
 module.exports = class NodeSourcePlugin {
 	constructor(options) {
 		this.options = options;
-		
 	}
 	apply(compiler) {
 		const options = this.options;
 		if(options === false) // allow single kill switch to turn off this plugin
 			return;
-		if (nodeLibsBrowser === null)
+		if(nodeLibsBrowser === null)
 			return;
+
 		function getPathToModule(module, type) {
 			if(type === true || (type === undefined && nodeLibsBrowser[module])) {
 				if(!nodeLibsBrowser[module]) throw new Error(`No browser version for node.js core module ${module} available`);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "loader-utils": "^1.1.0",
     "memory-fs": "~0.4.1",
     "mkdirp": "~0.5.0",
-    "node-libs-browser": "^2.0.0",
     "source-map": "^0.5.3",
     "supports-color": "^4.2.1",
     "tapable": "^0.2.7",
@@ -28,6 +27,9 @@
     "yargs": "^8.0.2"
   },
   "license": "MIT",
+  "optionalDependencies": {
+    "node-libs-browser": "^2.0.0"
+  }
   "devDependencies": {
     "beautify-lint": "^1.0.3",
     "benchmark": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "optionalDependencies": {
     "node-libs-browser": "^2.0.0"
-  }
+  },
   "devDependencies": {
     "beautify-lint": "^1.0.3",
     "benchmark": "^2.1.1",

--- a/test/NodeSourcePlugin.test.js
+++ b/test/NodeSourcePlugin.test.js
@@ -1,0 +1,41 @@
+/* global describe, it */
+"use strict";
+
+const should = require("should");
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../lib/webpack");
+const nodeSourcePlugin = require("../lib/node/NodeSourcePlugin");
+const Compiler = require("../lib/Compiler");
+
+describe("NodeSourcePlugin", () => {
+
+	it("should apply if node-libs-browser is present", (done) => {
+		var plugin = new nodeSourcePlugin({});
+		var compiler = new Compiler();
+		plugin.apply(compiler);
+		compiler._plugins.should.have.property("compilation");
+		done();
+	});
+
+	it("should not apply if node-libs-browser is not present", (done) => {
+		var nodeLibsBrowser = require.resolve("node-libs-browser");
+		fs.rename(nodeLibsBrowser, nodeLibsBrowser + ".old", (err) => {
+			should.not.exist(err);
+			delete require.cache[nodeLibsBrowser];
+			var plugin = new nodeSourcePlugin({});
+
+			var compiler = new Compiler();
+			plugin.apply(compiler);
+			delete require.cache[nodeLibsBrowser];
+			fs.rename(nodeLibsBrowser + ".old", nodeLibsBrowser, (err) => {
+				should.not.exist(err);
+				compiler._plugins.should.not.have.property("compilation");
+				done();
+			});
+		});
+
+	});
+
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Feature

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
No new tests

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Make node-libs-browser optional.
#3058

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

Yes, since node-libs-browser is now optional, anyone that was depending on the NodeSourcePlugin and also has optional dependencies turned off will no longer work, the user will have to install this optional dependency.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
I've run the tests locally now and everything appears to run okay.
