### PR TITLE
feat: webpack API supports functions

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -13,14 +13,17 @@ const validateSchema = require("./validateSchema");
 const WebpackOptionsValidationError = require("./WebpackOptionsValidationError");
 const webpackOptionsSchema = require("../schemas/webpackOptionsSchema.json");
 
-function webpack(options, callback) {
+function webpack(options, callback, env, argv) {
+	if(typeof options === "function") {
+		options = options(env, argv);
+	}
 	const webpackOptionsValidationErrors = validateSchema(webpackOptionsSchema, options);
 	if(webpackOptionsValidationErrors.length) {
 		throw new WebpackOptionsValidationError(webpackOptionsValidationErrors);
 	}
 	let compiler;
 	if(Array.isArray(options)) {
-		compiler = new MultiCompiler(options.map(options => webpack(options)));
+		compiler = new MultiCompiler(options.map(options => webpack(options, null, env, argv)));
 	} else if(typeof options === "object") {
 		new WebpackOptionsDefaulter().process(options);
 

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -8,19 +8,25 @@ const webpack = require("../");
 const WebpackOptionsDefaulter = require("../lib/WebpackOptionsDefaulter");
 
 describe("Compiler", () => {
-	function compile(entry, options, callback) {
+	function setupOptions(entry, options) {
 		const noOutputPath = !options.output || !options.output.path;
 		new WebpackOptionsDefaulter().process(options);
 		options.entry = entry;
 		options.context = path.join(__dirname, "fixtures");
 		if(noOutputPath) options.output.path = "/";
 		options.output.pathinfo = true;
+		return options;
+	}
+
+	function compile(entry, options, callback, env, argv) {
+		setupOptions(entry, options);
+
 		const logs = {
 			mkdirp: [],
 			writeFile: [],
 		};
 
-		const c = webpack(options);
+		const c = webpack(options, null, env, argv);
 		const files = {};
 		c.outputFileSystem = {
 			join: function() {
@@ -56,6 +62,27 @@ describe("Compiler", () => {
 			callback(stats, files, compilation);
 		});
 	}
+
+	it("should accept options as a function", (done) => {
+		const env = {};
+		const argv = {};
+		compile("./c", (_env, _argv) => {
+			should.strictEqual(env, _env);
+			should.strictEqual(argv, _argv);
+			return setupOptions("./c", {
+				output: {
+					path: "/what",
+					filename: "the/hell.js",
+				}
+			});
+		}, (stats, files) => {
+			stats.logs.mkdirp.should.eql([
+				"/what",
+				"/what/the",
+			]);
+			done();
+		}, env, argv);
+	});
 
 	it("should compile a single file to deep output", (done) => {
 		compile("./c", {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
feature

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
yes

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->
We can update docs as needed if/when this is approved.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

The `webpack` function for programmatic access currently only supports options as plain object or array, unlike the CLI which also supports configuration files exporting functions and functions returning promises (and arrays thereof for the multi-compiler).

This adds to the `webpack` function to support options as functions (and arrays of functions). The signature is updated to allow optionally passing in the `env` and `argv` arguments that config functions can accept.

This feature makes it easier to use webpack programmatically, allowing users to directly pass in a required/imported config file that exports a function or array of functions, without having to manually execute or map over and execute them to return plain objects before calling `webpack`.

This is limited for now to not supporting functions returning promises, so as to retain existing behavior of returning the compiler instance synchronously. Perhaps in the future we could add support for this by returning a promise resolving with a compiler instance when a function config is detected to return a promise object rather than a plain object.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

Shouldn't, unless there's an error in the implementation.

**Other information**

I'm not sure if `env` and/or `argv` should be defaulted to empty objects here for parity with the CLI.

Also not sure if we should pass callback along in the mapped options for the multi-compiler, but I assume not for now since it wasn't being passed along before for whatever reason.

Related to https://github.com/webpack/webpack/pull/5196.
