### PR TITLE
README: Fix duplicate GWT link

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ src="https://static.monei.net/monei-logo.svg" height="30" alt="MONEI"></a>
 * @medikoo for [modules-webmake](https://github.com/medikoo/modules-webmake), which is a similar project. webpack was born because I wanted Code Splitting for modules-webmake. Interestingly the [Code Splitting issue is still open](https://github.com/medikoo/modules-webmake/issues/7) (thanks also to @Phoscur for the discussion).
 * @substack for [browserify](http://browserify.org/), which is a similar project and source for many ideas.
 * @jrburke for [require.js](http://requirejs.org/), which is a similar project and source for many ideas.
-* @defunctzombie for the [browser-field spec](https://gist.github.com/defunctzombie/4339901), which makes modules available for node.js, browserify and webpack.http://www.gwtproject.org/
+* @defunctzombie for the [browser-field spec](https://gist.github.com/defunctzombie/4339901), which makes modules available for node.js, browserify and webpack.
 * Every early webpack user, which contributed to webpack by writing issues or PRs. You influenced the direction...
 * @shama, @jhnns and @sokra for maintaining this project
 * Everyone who has written a loader for webpack. You are the ecosystem...


### PR DESCRIPTION
**What kind of change does this PR introduce?**

README bugfix

**Summary**

https://github.com/webpack/webpack/pull/5558 introduced a duplicate link to the GWT project that this PR removes again