### PR TITLE
fix: replace for..of to prevent v8 deoptimization

### DIFF
--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -96,7 +96,8 @@ class SourceMapDevToolPlugin {
 									return module || source;
 								});
 
-								for(const module of modules) {
+								for(let idx = 0; idx < modules.length; idx++) {
+									const module = modules[idx];
 									if(!moduleToSourceNameMapping.get(module)) {
 										moduleToSourceNameMapping.set(module, ModuleFilenameHelpers.createFilename(module, moduleFilenameTemplate, requestShortener));
 									}
@@ -121,7 +122,8 @@ class SourceMapDevToolPlugin {
 				});
 
 				// find modules with conflicting source names
-				for(const module of allModules) {
+				for(let idx = 0; idx < allModules.length; idx++) {
+					const module = allModules[idx];
 					let sourceName = moduleToSourceNameMapping.get(module);
 					let hasName = conflictDetectionSet.has(sourceName);
 					if(!hasName) {

--- a/lib/dependencies/HarmonyModulesHelpers.js
+++ b/lib/dependencies/HarmonyModulesHelpers.js
@@ -34,8 +34,8 @@ class HarmonyModulesHelpers {
 		const desc = depInQuestion.describeHarmonyExport();
 		if(!desc.exportedName) return true;
 		let before = true;
-		for(const moduleDependency of module.dependencies) {
-			const dep = moduleDependency;
+		for(let idx = 0; idx < module.dependencies.length; idx++) {
+			const dep = module.dependencies[idx];
 			if(dep === depInQuestion) {
 				before = false;
 				continue;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Optimization via refactor of 3 `for...of` statements into `for` statements.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Existing test should break if the replacement is incorrect.
<!-- Note that we won't merge your changes if you don't add tests -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
According to https://github.com/GoogleChrome/devtools-docs/issues/53#issuecomment-319107156, use of `for...of` statements will cause a deopt in some versions of v8 such as the one used in `node@v6.11.1`, which is still LTS.

In a my particular case these two changes reduced 1.6 seconds in a big rebuild.

**Does this PR introduce a breaking change?**
No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

Here are two `.cpuprofile` files showing the effect of these changes:
- before: https://drive.google.com/file/d/0B06an8Bxmi7UZFJXOEU1cld5Q0k/view?usp=sharing
- after: https://drive.google.com/file/d/0B06an8Bxmi7URUFxMEpLNkNNOGs/view?usp=sharing

The rebuild in question is done via Angular CLI (`ng build --aot` on https://github.com/angular/angular/tree/master/aio) and has a lot of JS harmony modules (es5 code with ESM import/exports).

The change on `lib/dependencies/HarmonyModulesHelpers.js` affects the `isActive` entry, reducing it by 1.1s:

Before:
![image](https://user-images.githubusercontent.com/4172079/29822145-60eb7f60-8cc2-11e7-824d-c9dcf891dcd9.png)

After:
![image](https://user-images.githubusercontent.com/4172079/29822171-7415cff0-8cc2-11e7-968d-a3f8b2c73912.png)

The change on `lib/SourceMapDevToolPlugin.js` is a bit more subtle. 

Inside `innerArrayForEach->forEach`, which total 4178ms, there are two deoptimizations of the same kind (`for...of`):

Before:
![image](https://user-images.githubusercontent.com/4172079/29822284-d0ce4952-8cc2-11e7-9aac-747a5e790876.png)

The change causes `innerArrayForEach->forEach` total to go down to 2981ms, but the two operations now hit another deoptimization:

After:
![image](https://user-images.githubusercontent.com/4172079/29822409-3ee15d58-8cc3-11e7-9d62-ef4aed19538c.png)

The new deopt is not in `webpack` proper, but rather in `html-webpack-plugin/index.js:55` and is due to the use of Bluebird promises which do indeed use a try catch.

![image](https://user-images.githubusercontent.com/4172079/29822422-4ea7a42c-8cc3-11e7-97b3-4eb278ef95c4.png)

Edit: I tried to remove the deopt in `html-webpack-plugin` by replacing that specific promise with a native es6 promise and it shaved some 200ms extra ms (down to 2757ms for `innerArrayForEach->forEach`), but at point it might have been a bit of variance as well. Might be worth exploring., so I opened https://github.com/jantimon/html-webpack-plugin/issues/772.

/cc @TheLarkInn 
