### PR TITLE
Prevent NormalModule contextify from contextifying query parameters

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -34,12 +34,13 @@ function asString(buf) {
 
 function contextify(context, request) {
 	return request.split("!").map(function(r) {
-		let rp = path.relative(context, r);
+		const splitPath = r.split("?");
+		splitPath[0] = path.relative(context, splitPath[0]);
 		if(path.sep === "\\")
-			rp = rp.replace(/\\/g, "/");
-		if(rp.indexOf("../") !== 0)
-			rp = "./" + rp;
-		return rp;
+			splitPath[0] = splitPath[0].replace(/\\/g, "/");
+		if(splitPath[0].indexOf("../") !== 0)
+			splitPath[0] = "./" + splitPath[0];
+		return splitPath.join("?");
 	}).join("!");
 }
 

--- a/test/NormalModule.test.js
+++ b/test/NormalModule.test.js
@@ -81,6 +81,22 @@ describe("NormalModule", function() {
 				}).should.eql("../userRequest!../other/userRequest!../thing/is/off/here");
 			});
 		});
+		describe("given a userRequest containing query parameters", function() {
+			it("ignores paths in query parameters", function() {
+				userRequest = "some/context/loader?query=foo\\bar&otherPath=testpath/other";
+				normalModule = new NormalModule(
+					request,
+					userRequest,
+					rawRequest,
+					loaders,
+					resource,
+					parser
+				);
+				normalModule.libIdent({
+					context: "some/context",
+				}).should.eql("./loader?query=foo\\bar&otherPath=testpath/other");
+			});
+		});
 	});
 
 	describe("#nameForCondition", function() {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

When passing a path as part of a loader query string the contextify function incorrectly modifies the query string paths, most notably converting windows separators. The change ensures only the main path is contextified.

**Did you add tests for your changes?**

Yes

**If relevant, link to documentation update:**

N/A

**Summary**

Fixes: #5411

**Does this PR introduce a breaking change?**

Possibly if anyone is relying on query string paths to be contextified
