### PR TITLE
fixing sub-property externals case for validation only

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ friendly** by using hashes.
 
 **We want contributing to webpack to be fun, enjoyable, and educational for anyone, and everyone.** We have a [vibrant ecosystem](https://medium.com/webpack/contributors-guide/home) that spans beyond this single repo. We welcome you to check out any of the repositories in [our organization](http://github.com/webpack) or [webpack-contrib organization](http://github.com/webpack-contrib) which houses all of our loaders and plugins.
 
+To get started, read [the contributing instructions](CONTRIBUTING.md).
+
 Contributions go far beyond pull requests and commits. Although we love giving you the opportunity to put your stamp on webpack, we also are thrilled to receive a variety of other contributions including:
 
 * [Documentation](https://github.com/webpack/webpack.js.org) updates, enhancements, designs, or bugfixes

--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -78,22 +78,26 @@
     "external": {
       "anyOf": [
         {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "array"
+        }
+      ],
+      "description": "Represents a replacement object for an external modules (configured by `externals`)"
+    },
+    "externals": {
+      "anyOf": [
+        {
           "description": "An exact matched dependency becomes external. The same string is used as external dependency.",
           "type": "string"
         },
         {
           "additionalProperties": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "object"
-              },
-              {
-                "type": "boolean"
-              }
-            ]
+            "$ref": "#/definitions/external"
           },
           "description": "If an dependency matches exactly a property of the object, the property value is used as dependency.",
           "type": "object"
@@ -108,7 +112,17 @@
         },
         {
           "items": {
-            "$ref": "#/definitions/external"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/external"
+              },
+              {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/external"
+                }
+              }
+            ]
           },
           "type": "array"
         }
@@ -823,8 +837,15 @@
       "$ref": "#/definitions/entry"
     },
     "externals": {
-      "type": "object",
-      "additionalProperties": {"$ref": "#/definitions/external"}
+      "anyOf": [
+        {
+          "$ref": "#/definitions/external"
+        },
+        {
+          "type": "object",
+          "additionalProperties": {"$ref": "#/definitions/external"}
+        }
+      ]
     },
     "loader": {
       "description": "Custom values available in the loader context.",

--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -75,7 +75,7 @@
         }
       ]
     },
-    "externals": {
+    "external": {
       "anyOf": [
         {
           "description": "An exact matched dependency becomes external. The same string is used as external dependency.",
@@ -108,7 +108,7 @@
         },
         {
           "items": {
-            "$ref": "#/definitions/externals"
+            "$ref": "#/definitions/external"
           },
           "type": "array"
         }
@@ -823,7 +823,8 @@
       "$ref": "#/definitions/entry"
     },
     "externals": {
-      "$ref": "#/definitions/externals"
+      "type": "object",
+      "additionalProperties": {"$ref": "#/definitions/external"}
     },
     "loader": {
       "description": "Custom values available in the loader context.",

--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -839,7 +839,7 @@
     "externals": {
       "anyOf": [
         {
-          "$ref": "#/definitions/external"
+          "$ref": "#/definitions/externals"
         },
         {
           "type": "object",

--- a/test/configCases/externals/externals-basic1/index.js
+++ b/test/configCases/externals/externals-basic1/index.js
@@ -1,0 +1,3 @@
+it("should not fail on external sub-properties", function() {
+	require("abc")
+});

--- a/test/configCases/externals/externals-basic1/webpack.config.js
+++ b/test/configCases/externals/externals-basic1/webpack.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	output: {
+		libraryTarget: "umd2"
+	},
+    externals: {
+        abc: {
+            root: "Abc",
+            commonjs: "abc"
+        }
+    }
+};

--- a/test/configCases/externals/externals-basic2/index.js
+++ b/test/configCases/externals/externals-basic2/index.js
@@ -1,0 +1,3 @@
+it("should not fail on external sub-properties", function() {
+	require("abc")
+});

--- a/test/configCases/externals/externals-basic2/webpack.config.js
+++ b/test/configCases/externals/externals-basic2/webpack.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	output: {
+		libraryTarget: "umd2"
+	},
+    externals: [
+        /abc/,
+        function() {
+
+        }
+    ]
+};

--- a/test/configCases/externals/externals-sub-property/index.js
+++ b/test/configCases/externals/externals-sub-property/index.js
@@ -1,0 +1,3 @@
+it("should not fail on external sub-properties", function() {
+	require("external/subProperty")
+});

--- a/test/configCases/externals/externals-sub-property/webpack.config.js
+++ b/test/configCases/externals/externals-sub-property/webpack.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	output: {
+		libraryTarget: "umd2"
+	},
+	externals: {
+		"external/subProperty": ["external","subProperty"]
+	}
+};


### PR DESCRIPTION
(eg {externals:{external:['a','b']}} ). Note that the actual handling of sub-properties still isn't working.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

Yes

**If relevant, link to documentation update:**

N/A

**Summary**

fixes #5631

**Does this PR introduce a breaking change?**

No

**Other information**

This shouldn't be merged in without properly implementing externals sub-properties.