### PR TITLE
Fix #5684 DelegatedModule does not updateHash with its parameters

### DIFF
--- a/lib/DelegatedModule.js
+++ b/lib/DelegatedModule.js
@@ -89,7 +89,8 @@ class DelegatedModule extends Module {
 	}
 
 	updateHash(hash) {
-		hash.update(this.identifier());
+		hash.update(this.type);
+		hash.update(JSON.stringify(this.request));
 		super.updateHash(hash);
 	}
 }

--- a/lib/DelegatedModule.js
+++ b/lib/DelegatedModule.js
@@ -87,6 +87,11 @@ class DelegatedModule extends Module {
 	size() {
 		return 42;
 	}
+
+	updateHash(hash) {
+		hash.update(this.identifier());
+		super.updateHash(hash);
+	}
 }
 
 module.exports = DelegatedModule;

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -116,6 +116,12 @@ class ExternalModule extends Module {
 	size() {
 		return 42;
 	}
+
+	updateHash(hash) {
+		hash.update(this.type);
+		hash.update(JSON.stringify(this.request));
+		super.updateHash(hash);
+	}
 }
 
 module.exports = ExternalModule;

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -120,6 +120,7 @@ class ExternalModule extends Module {
 	updateHash(hash) {
 		hash.update(this.type);
 		hash.update(JSON.stringify(this.request));
+		hash.update(JSON.stringify(this.optional));
 		super.updateHash(hash);
 	}
 }

--- a/test/DelegatedModule.test.js
+++ b/test/DelegatedModule.test.js
@@ -1,0 +1,30 @@
+/* globals describe, it, beforeEach */
+"use strict";
+require("should");
+const DelegatedModule = require("../lib/DelegatedModule");
+
+describe("DelegatedModule", function() {
+	describe("#updateHash", function() {
+		const sourceRequest = "dll-reference dll_e54c0fb67f8152792ad2";
+		const data = {
+			id: "/xg9"
+		};
+		const type = "require";
+		const userRequest = "./library.js";
+		let hashedText;
+		let hash;
+		beforeEach(function() {
+			hashedText = "";
+			hash = {
+				update: (text) => {
+					hashedText += text;
+				}
+			};
+			const delegatedModule = new DelegatedModule(sourceRequest, data, type, userRequest);
+			delegatedModule.updateHash(hash);
+		});
+		it("calls hash function with delegated module ID", function() {
+			hashedText.should.containEql("/xg9");
+		});
+	});
+});

--- a/test/DelegatedModule.test.js
+++ b/test/DelegatedModule.test.js
@@ -23,8 +23,11 @@ describe("DelegatedModule", function() {
 			const delegatedModule = new DelegatedModule(sourceRequest, data, type, userRequest);
 			delegatedModule.updateHash(hash);
 		});
-		it("calls hash function with delegated module ID", function() {
+		it("updates hash with delegated module ID", function() {
 			hashedText.should.containEql("/xg9");
+		});
+		it("updates hash with delegation type", function() {
+			hashedText.should.containEql("require");
 		});
 	});
 });

--- a/test/ExternalModule.test.js
+++ b/test/ExternalModule.test.js
@@ -323,6 +323,7 @@ module.exports = some/request;`;
 					hashedText += text;
 				}
 			};
+			externalModule.optional = true;
 			externalModule.updateHash(hash);
 		});
 		it("updates hash with request", function() {
@@ -330,6 +331,9 @@ module.exports = some/request;`;
 		});
 		it("updates hash with type", function() {
 			hashedText.should.containEql("some-type");
+		});
+		it("updates hash with optional flag", function() {
+			hashedText.should.containEql("true");
 		});
 	});
 });

--- a/test/ExternalModule.test.js
+++ b/test/ExternalModule.test.js
@@ -312,4 +312,24 @@ module.exports = some/request;`;
 			});
 		});
 	});
+
+	describe("#updateHash", function() {
+		let hashedText;
+		let hash;
+		beforeEach(function() {
+			hashedText = "";
+			hash = {
+				update: (text) => {
+					hashedText += text;
+				}
+			};
+			externalModule.updateHash(hash);
+		});
+		it("updates hash with request", function() {
+			hashedText.should.containEql("some/request");
+		});
+		it("updates hash with type", function() {
+			hashedText.should.containEql("some-type");
+		});
+	});
 });

--- a/test/ExternalModule.test.js
+++ b/test/ExternalModule.test.js
@@ -324,6 +324,7 @@ module.exports = some/request;`;
 				}
 			};
 			externalModule.optional = true;
+			externalModule.id = 12345678;
 			externalModule.updateHash(hash);
 		});
 		it("updates hash with request", function() {
@@ -334,6 +335,9 @@ module.exports = some/request;`;
 		});
 		it("updates hash with optional flag", function() {
 			hashedText.should.containEql("true");
+		});
+		it("updates hash with module id", function() {
+			hashedText.should.containEql("12345678");
 		});
 	});
 });

--- a/test/statsCases/external/expected.txt
+++ b/test/statsCases/external/expected.txt
@@ -1,4 +1,4 @@
-Hash: 86950abf8dcf924d9cc1
+Hash: 7861295d7291830ba01f
 Time: Xms
   Asset     Size  Chunks             Chunk Names
 main.js  2.61 kB       0  [emitted]  main

--- a/test/statsCases/external/expected.txt
+++ b/test/statsCases/external/expected.txt
@@ -1,4 +1,4 @@
-Hash: 7861295d7291830ba01f
+Hash: e500321cbaac14df7284
 Time: Xms
   Asset     Size  Chunks             Chunk Names
 main.js  2.61 kB       0  [emitted]  main


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes. Also confirm that the added test will fail without this change.
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Fixes #5684 (please see that issue for detailed information and a reproducable case)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Hash of DelegatedModule changed, so users of DllReferencePlugin should expect the compilation/chunk hash to change.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
N/A