### PR TITLE
Allow negative early bail for context

### DIFF
--- a/lib/ContextExclusionPlugin.js
+++ b/lib/ContextExclusionPlugin.js
@@ -1,0 +1,17 @@
+"use strict";
+
+class ContextExclusionPlugin {
+	constructor(negativeMatcher) {
+		this.negativeMatcher = negativeMatcher;
+	}
+
+	apply(compiler) {
+		compiler.plugin("context-module-factory", (cmf) => {
+			cmf.plugin("context-module-files", (files) => {
+				return files.filter(filePath => !this.negativeMatcher.test(filePath));
+			});
+		});
+	}
+}
+
+module.exports = ContextExclusionPlugin;

--- a/lib/ContextModuleFactory.js
+++ b/lib/ContextModuleFactory.js
@@ -99,11 +99,13 @@ module.exports = class ContextModuleFactory extends Tapable {
 	}
 
 	resolveDependencies(fs, resource, recursive, regExp, callback) {
+		const cmf = this;
 		if(!regExp || !resource)
 			return callback(null, []);
 		(function addDirectory(directory, callback) {
 			fs.readdir(directory, (err, files) => {
 				if(err) return callback(err);
+				files = cmf.applyPluginsWaterfall("context-module-files", files);
 				if(!files || files.length === 0) return callback(null, []);
 				asyncLib.map(files.filter(function(p) {
 					return p.indexOf(".") !== 0;

--- a/lib/ContextModuleFactory.js
+++ b/lib/ContextModuleFactory.js
@@ -18,7 +18,6 @@ module.exports = class ContextModuleFactory extends Tapable {
 	}
 
 	create(data, callback) {
-		const module = this;
 		const context = data.context;
 		const dependencies = data.dependencies;
 		const dependency = dependencies[0];
@@ -59,7 +58,7 @@ module.exports = class ContextModuleFactory extends Tapable {
 				resource = request;
 			}
 
-			const resolvers = module.resolvers;
+			const resolvers = this.resolvers;
 
 			asyncLib.parallel([
 				function(callback) {
@@ -79,14 +78,14 @@ module.exports = class ContextModuleFactory extends Tapable {
 			], (err, result) => {
 				if(err) return callback(err);
 
-				module.applyPluginsAsyncWaterfall("after-resolve", {
+				this.applyPluginsAsyncWaterfall("after-resolve", {
 					loaders: loadersPrefix + result[1].join("!") + (result[1].length > 0 ? "!" : ""),
 					resource: result[0],
 					recursive: recursive,
 					regExp: regExp,
 					async: asyncContext,
 					dependencies: dependencies,
-					resolveDependencies: module.resolveDependencies.bind(module)
+					resolveDependencies: this.resolveDependencies.bind(this)
 				}, function(err, result) {
 					if(err) return callback(err);
 

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -73,6 +73,7 @@ exportPlugins(exports, {
 	"DefinePlugin": () => require("./DefinePlugin"),
 	"NormalModuleReplacementPlugin": () => require("./NormalModuleReplacementPlugin"),
 	"ContextReplacementPlugin": () => require("./ContextReplacementPlugin"),
+	"ContextExclusionPlugin": () => require("./ContextExclusionPlugin"),
 	"IgnorePlugin": () => require("./IgnorePlugin"),
 	"WatchIgnorePlugin": () => require("./WatchIgnorePlugin"),
 	"BannerPlugin": () => require("./BannerPlugin"),

--- a/test/configCases/context-exclusion/simple/index.js
+++ b/test/configCases/context-exclusion/simple/index.js
@@ -1,0 +1,20 @@
+function requireInContext(someVariable) {
+	return require(`./some-dir/${someVariable}`);
+}
+
+it("should not exclude paths not matching the exclusion pattern", function() {
+	requireInContext("file").should.be.eql("thats good");
+	requireInContext("check-here/file").should.be.eql("thats good");
+	requireInContext("check-here/check-here/file").should.be.eql("thats good");
+});
+
+it("should exclude paths/files matching the exclusion pattern", function() {
+		(() => requireInContext("dont")).
+			should.throw(/Cannot find module '.\/dont'/);
+
+		(() => requireInContext("dont-check-here/file")).
+			should.throw(/Cannot find module '.\/dont-check-here\/file'/);
+
+		(() => requireInContext("check-here/dont-check-here/file")).
+			should.throw(/Cannot find module '.\/check-here\/dont-check-here\/file'/);
+});

--- a/test/configCases/context-exclusion/simple/some-dir/check-here/check-here/file.js
+++ b/test/configCases/context-exclusion/simple/some-dir/check-here/check-here/file.js
@@ -1,0 +1,1 @@
+module.exports = "thats good";

--- a/test/configCases/context-exclusion/simple/some-dir/check-here/dont-check-here/file.js
+++ b/test/configCases/context-exclusion/simple/some-dir/check-here/dont-check-here/file.js
@@ -1,0 +1,1 @@
+module.exports = "thats bad";

--- a/test/configCases/context-exclusion/simple/some-dir/check-here/file.js
+++ b/test/configCases/context-exclusion/simple/some-dir/check-here/file.js
@@ -1,0 +1,1 @@
+module.exports = "thats good";

--- a/test/configCases/context-exclusion/simple/some-dir/dont-check-here/file.js
+++ b/test/configCases/context-exclusion/simple/some-dir/dont-check-here/file.js
@@ -1,0 +1,1 @@
+module.exports = "thats bad";

--- a/test/configCases/context-exclusion/simple/some-dir/dont.js
+++ b/test/configCases/context-exclusion/simple/some-dir/dont.js
@@ -1,0 +1,1 @@
+module.exports = "thats bad";

--- a/test/configCases/context-exclusion/simple/some-dir/file.js
+++ b/test/configCases/context-exclusion/simple/some-dir/file.js
@@ -1,0 +1,1 @@
+module.exports = "thats good";

--- a/test/configCases/context-exclusion/simple/webpack.config.js
+++ b/test/configCases/context-exclusion/simple/webpack.config.js
@@ -1,0 +1,7 @@
+var webpack = require("../../../../");
+
+module.exports = {
+	plugins: [
+		new webpack.ContextExclusionPlugin(/dont/)
+	]
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

feature/fix

**Did you add tests for your changes?**

Yes

**If relevant, link to documentation update:**

N/A

**Summary**

There are a couple of reasons this could be helpfull:
1) If a context points to a folder with potentially many files the current process can be quite inefficient - also a "positive" matching as could be doable with `ContextReplacementPlugin` is not always possible. This helps speed up the build-time and allows for negative matching.
2) Webpack fails to detect symlinks in node_modules and having a context pointing to local linked package that contains node_modules can lead to endless loops, this can simply be prevented with this plugin by excluding `node_modules`.
3) The ContextReplacementPlugin covers too much to stuff this functionality into it as well. Also it kind of is out of scope of the ContextReplacementPlugin.

**Does this PR introduce a breaking change?**

No

