### PR TITLE
Also add script.crossOrigin for hot-reloaded chunks

### DIFF
--- a/lib/JsonpMainTemplate.runtime.js
+++ b/lib/JsonpMainTemplate.runtime.js
@@ -2,7 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-/*globals hotAddUpdateChunk parentHotUpdateCallback document XMLHttpRequest $require$ $hotChunkFilename$ $hotMainFilename$ */
+/*globals hotAddUpdateChunk parentHotUpdateCallback document XMLHttpRequest $require$ $hotChunkFilename$ $hotMainFilename$ $crossOriginLoading$ */
 module.exports = function() {
 	function webpackHotUpdateCallback(chunkId, moreModules) { // eslint-disable-line no-unused-vars
 		hotAddUpdateChunk(chunkId, moreModules);
@@ -15,6 +15,7 @@ module.exports = function() {
 		script.type = "text/javascript";
 		script.charset = "utf-8";
 		script.src = $require$.p + $hotChunkFilename$;
+		$crossOriginLoading$;
 		head.appendChild(script);
 	}
 

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -171,6 +171,7 @@ class JsonpMainTemplatePlugin {
 		mainTemplate.plugin("hot-bootstrap", function(source, chunk, hash) {
 			const hotUpdateChunkFilename = this.outputOptions.hotUpdateChunkFilename;
 			const hotUpdateMainFilename = this.outputOptions.hotUpdateMainFilename;
+			const crossOriginLoading = this.outputOptions.crossOriginLoading;
 			const hotUpdateFunction = this.outputOptions.hotUpdateFunction;
 			const currentHotUpdateChunkFilename = this.applyPluginsWaterfall("asset-path", JSON.stringify(hotUpdateChunkFilename), {
 				hash: `" + ${this.renderCurrentHashCode(hash)} + "`,
@@ -186,6 +187,7 @@ class JsonpMainTemplatePlugin {
 			const runtimeSource = Template.getFunctionContent(require("./JsonpMainTemplate.runtime.js"))
 				.replace(/\/\/\$semicolon/g, ";")
 				.replace(/\$require\$/g, this.requireFn)
+				.replace(/\$crossOriginLoading\$/g, crossOriginLoading ? `script.crossOrigin = ${JSON.stringify(crossOriginLoading)}` : "")
 				.replace(/\$hotMainFilename\$/g, currentHotUpdateMainFilename)
 				.replace(/\$hotChunkFilename\$/g, currentHotUpdateChunkFilename)
 				.replace(/\$hash\$/g, JSON.stringify(hash));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bugfix - or a feature, depending on your point of view.

**Did you add tests for your changes?**

I didn't see any tests asserting this behavior; however, I ran the change on my own applications and found that it fixed the React 16 errors we were seeing (https://facebook.github.io/react/docs/cross-origin-errors.html)

<!-- Note that we won't merge your changes if you don't add tests -->

**Summary**

Also adds the `crossOrigin` attribute to hot-reloaded chunks if `output.crossOriginLoading` is set.

Related: #988

Useful especially for hot-reloaded React 16 apps so that the global
onerror handler can render error boundaries properly.

**Does this PR introduce a breaking change?**

No breaking change - dev only.
