### PR TITLE
Support resourceQuery in context dependencies.

### DIFF
--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -22,8 +22,20 @@ class ContextModule extends Module {
 
 		// Info from Factory
 		this.resolveDependencies = resolveDependencies;
-		this.options = options;
-		this.context = options.resource;
+		let resource, resourceQuery;
+		const queryIdx = options.resource.indexOf("?");
+		if(queryIdx >= 0) {
+			resource = options.resource.substr(0, queryIdx);
+			resourceQuery = options.resource.substr(queryIdx);
+		} else {
+			resource = options.resource;
+			resourceQuery = "";
+		}
+		this.options = Object.assign({}, options, {
+			resource: resource,
+			resourceQuery: resourceQuery
+		});
+		this.context = this.options.resource;
 
 		// Info from Build
 		this.builtTime = undefined;

--- a/lib/ContextModuleFactory.js
+++ b/lib/ContextModuleFactory.js
@@ -89,12 +89,14 @@ module.exports = class ContextModuleFactory extends Tapable {
 	resolveDependencies(fs, options, callback) {
 		const cmf = this;
 		let resource = options.resource;
+		let resourceQuery = options.resourceQuery;
 		let recursive = options.recursive;
 		let regExp = options.regExp;
 		let include = options.include;
 		let exclude = options.exclude;
 		if(!regExp || !resource)
 			return callback(null, []);
+
 		const addDirectory = (directory, callback) => {
 			fs.readdir(directory, (err, files) => {
 				if(err) return callback(err);
@@ -131,7 +133,7 @@ module.exports = class ContextModuleFactory extends Tapable {
 								this.applyPluginsAsyncWaterfall("alternatives", [obj], (err, alternatives) => {
 									if(err) return callback(err);
 									alternatives = alternatives.filter(obj => regExp.test(obj.request)).map(obj => {
-										const dep = new ContextElementDependency(obj.request);
+										const dep = new ContextElementDependency(obj.request + resourceQuery, obj.request);
 										dep.optional = true;
 										return dep;
 									});

--- a/lib/ContextReplacementPlugin.js
+++ b/lib/ContextReplacementPlugin.js
@@ -101,7 +101,7 @@ const createResolveDependenciesFromContextMap = (createContextMap) => {
 		createContextMap(fs, (err, map) => {
 			if(err) return callback(err);
 			const dependencies = Object.keys(map).map((key) => {
-				return new ContextElementDependency(map[key], key);
+				return new ContextElementDependency(map[key] + options.resourceQuery, key);
 			});
 			callback(null, dependencies);
 		});

--- a/test/cases/parsing/context/index.js
+++ b/test/cases/parsing/context/index.js
@@ -2,6 +2,11 @@ it("should be able to load a file with the require.context method", function() {
 	require.context("./templates")("./tmpl").should.be.eql("test template");
 	(require.context("./././templates"))("./tmpl").should.be.eql("test template");
 	(require.context("././templates/.")("./tmpl")).should.be.eql("test template");
+	require.context("./loaders/queryloader?dog=bark!./templates?cat=meow")("./tmpl").should.be.eql({
+		resourceQuery: "?cat=meow",
+		query: "?dog=bark",
+		prev: "module.exports = \"test template\";"
+	});
 	require . context ( "." + "/." + "/" + "templ" + "ates" ) ( "./subdir/tmpl.js" ).should.be.eql("subdir test template");
 	require.context("./templates", true, /./)("xyz").should.be.eql("xyz");
 });

--- a/test/cases/parsing/context/loaders/queryloader.js
+++ b/test/cases/parsing/context/loaders/queryloader.js
@@ -1,0 +1,7 @@
+module.exports = function(content) {
+	return "module.exports = " + JSON.stringify({
+		resourceQuery: this.resourceQuery,
+		query: this.query,
+		prev: content
+	});
+};

--- a/test/configCases/context-replacement/d/index.js
+++ b/test/configCases/context-replacement/d/index.js
@@ -1,0 +1,10 @@
+it("should replace a context with resource query and manual map", function() {
+	function rqInContext(x) {
+		return require(x);
+	}
+	rqInContext("a").should.be.eql({
+		resourceQuery: "?cats=meow",
+		query: "?lions=roar",
+		prev: "module.exports = \"a\";\n",
+	});
+});

--- a/test/configCases/context-replacement/d/modules/a.js
+++ b/test/configCases/context-replacement/d/modules/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/test/configCases/context-replacement/d/queryloader.js
+++ b/test/configCases/context-replacement/d/queryloader.js
@@ -1,0 +1,7 @@
+module.exports = function(content) {
+	return "module.exports = " + JSON.stringify({
+		resourceQuery: this.resourceQuery,
+		query: this.query,
+		prev: content
+	});
+};

--- a/test/configCases/context-replacement/d/webpack.config.js
+++ b/test/configCases/context-replacement/d/webpack.config.js
@@ -1,0 +1,20 @@
+var path = require("path");
+var webpack = require("../../../../");
+
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /a\.js$/,
+				use: [
+					"./queryloader?lions=roar"
+				]
+			}
+		]
+	},
+	plugins: [
+		new webpack.ContextReplacementPlugin(/context-replacement.d$/, path.resolve(__dirname, "modules?cats=meow"), {
+			"a": "./a",
+		})
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Adds support for resource queries in context dependencies.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Some loaders require resource query for proper usage, and cannot be used at all with context dependencies.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No, it only affects code that adds a resource query to a context, which currently does not work at all.

**Other information**

Fixes #5730 
