### PR TITLE
fix: watch-run params should be compiler

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -44,7 +44,7 @@ class Watching {
 		this.startTime = Date.now();
 		this.running = true;
 		this.invalid = false;
-		this.compiler.applyPluginsAsync("watch-run", this, err => {
+		this.compiler.applyPluginsAsync("watch-run", this.compiler, err => {
 			if(err) return this._done(err);
 			const onCompiled = (err, compilation) => {
 				if(err) return this._done(err);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bugfix, watch-run event hook param should be `compiler`, but the param is `Watching` instance now

**Did you add tests for your changes?**

No, I think there is no need for tests.

**Summary**

watch-run params error.

**Does this PR introduce a breaking change?**

The watch-run event params: from watching to compiler
