### PR TITLE
Fix for #5750 - Refuse to use regexes with g or y flags in contexts

### DIFF
--- a/lib/dependencies/AMDRequireContextDependency.js
+++ b/lib/dependencies/AMDRequireContextDependency.js
@@ -5,7 +5,6 @@
 "use strict";
 
 const ContextDependency = require("./ContextDependency");
-const CriticalDependencyWarning = require("./CriticalDependencyWarning");
 class AMDRequireContextDependency extends ContextDependency {
 	constructor(request, recursive, regExp, range, valueRange) {
 		super(request, recursive, regExp);
@@ -15,14 +14,6 @@ class AMDRequireContextDependency extends ContextDependency {
 
 	get type() {
 		return "amd require context";
-	}
-
-	getWarnings() {
-		if(this.critical) {
-			return [
-				new CriticalDependencyWarning(this.critical)
-			];
-		}
 	}
 }
 AMDRequireContextDependency.Template = require("./ContextDependencyTemplateAsRequireCall");

--- a/lib/dependencies/CommonJsRequireContextDependency.js
+++ b/lib/dependencies/CommonJsRequireContextDependency.js
@@ -4,7 +4,6 @@
 */
 "use strict";
 const ContextDependency = require("./ContextDependency");
-const CriticalDependencyWarning = require("./CriticalDependencyWarning");
 const ContextDependencyTemplateAsRequireCall = require("./ContextDependencyTemplateAsRequireCall");
 
 class CommonJsRequireContextDependency extends ContextDependency {
@@ -18,15 +17,6 @@ class CommonJsRequireContextDependency extends ContextDependency {
 		return "cjs require context";
 	}
 
-	getWarnings() {
-		if(!this.critical) {
-			return;
-		}
-
-		return [
-			new CriticalDependencyWarning(this.critical)
-		];
-	}
 }
 
 CommonJsRequireContextDependency.Template = ContextDependencyTemplateAsRequireCall;

--- a/lib/dependencies/ContextDependency.js
+++ b/lib/dependencies/ContextDependency.js
@@ -4,6 +4,7 @@
 */
 "use strict";
 const Dependency = require("../Dependency");
+const CriticalDependencyWarning = require("./CriticalDependencyWarning");
 
 class ContextDependency extends Dependency {
 	constructor(request, recursive, regExp) {
@@ -13,6 +14,13 @@ class ContextDependency extends Dependency {
 		this.recursive = recursive;
 		this.regExp = regExp;
 		this.async = false;
+
+		this.hadGlobalOrStickyRegExp = false;
+		if(this.regExp.global || this.regExp.sticky) {
+			this.regExp = null;
+			this.hadGlobalOrStickyRegExp = true;
+		}
+
 	}
 
 	isEqualResource(other) {
@@ -24,6 +32,18 @@ class ContextDependency extends Dependency {
 			this.regExp === other.regExp &&
 			this.async === other.async;
 	}
+
+	getWarnings() {
+		let warnings = super.getWarnings() || [];
+		if(this.critical) {
+			warnings.push(new CriticalDependencyWarning(this.critical));
+		}
+		if(this.hadGlobalOrStickyRegExp) {
+			warnings.push(new CriticalDependencyWarning("Contexts can't use RegExps with the 'g' or 'y' flags."));
+		}
+		return warnings;
+	}
+
 }
 
 module.exports = ContextDependency;

--- a/lib/dependencies/ImportContextDependency.js
+++ b/lib/dependencies/ImportContextDependency.js
@@ -4,7 +4,6 @@
 */
 "use strict";
 const ContextDependency = require("./ContextDependency");
-const CriticalDependencyWarning = require("./CriticalDependencyWarning");
 const ContextDependencyTemplateAsRequireCall = require("./ContextDependencyTemplateAsRequireCall");
 
 class ImportContextDependency extends ContextDependency {
@@ -19,15 +18,6 @@ class ImportContextDependency extends ContextDependency {
 		return "import() context";
 	}
 
-	getWarnings() {
-		if(!this.critical) {
-			return;
-		}
-
-		return [
-			new CriticalDependencyWarning(this.critical)
-		];
-	}
 }
 
 ImportContextDependency.Template = ContextDependencyTemplateAsRequireCall;

--- a/lib/dependencies/RequireResolveContextDependency.js
+++ b/lib/dependencies/RequireResolveContextDependency.js
@@ -4,7 +4,6 @@
 */
 "use strict";
 const ContextDependency = require("./ContextDependency");
-const CriticalDependencyWarning = require("./CriticalDependencyWarning");
 const ContextDependencyTemplateAsId = require("./ContextDependencyTemplateAsId");
 
 class RequireResolveContextDependency extends ContextDependency {
@@ -18,15 +17,6 @@ class RequireResolveContextDependency extends ContextDependency {
 		return "amd require context";
 	}
 
-	getWarnings() {
-		if(!this.critical) {
-			return;
-		}
-
-		return [
-			new CriticalDependencyWarning(this.critical)
-		];
-	}
 }
 
 RequireResolveContextDependency.Template = ContextDependencyTemplateAsId;

--- a/test/cases/context/issue-5750/index.js
+++ b/test/cases/context/issue-5750/index.js
@@ -1,0 +1,4 @@
+it("should not use regexps with the g flag", function() {
+	require.context("./folder", true, /a/).keys().length.should.be.eql(1);
+	require.context("./folder", true, /a/g).keys().length.should.be.eql(0);
+});

--- a/test/cases/context/issue-5750/warnings.js
+++ b/test/cases/context/issue-5750/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[/Critical dependency: Contexts can't use RegExps with the 'g' or 'y' flags/],
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Fix for #5750. Adds a warning if the g or y regex flag is passed to a context, and causes the context to become empty.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
~No.~ Yes.

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
No new documentation. The error message copy is "Contexts can't use RegExps with the 'g' or 'y' flags."

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Using the g or y flags causes files to be missing from a context. See #5750.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Previously, using the g flag could output garbage, now it always outputs a warning and an empty context.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Nope
