### PR TITLE
Added deepChildren support from ArcEglos' pull request

### DIFF
--- a/examples/common-chunk-grandchildren/README.md
+++ b/examples/common-chunk-grandchildren/README.md
@@ -1,0 +1,469 @@
+This example illustrates how common modules from deep ancestors of an entry point can be split into a seperate common chunk
+
+* `pageA` and `pageB` are dynamically required
+* `pageC` and `pageA` both require the `reusableComponent`
+* `pageB` dynamically requires `PageC`
+
+You can see that webpack outputs four files/chunks:
+
+* `output.js` is the entry chunk and contains
+  * the module system
+  * chunk loading logic
+  * the entry point `example.js`
+  * module `reusableComponent`
+* `0.output.js` is an additional chunk
+  * module `pageC`
+* `1.output.js` is an additional chunk
+  * module `pageB`
+* `2.output.js` is an additional chunk
+  * module `pageA`
+
+
+# example.js
+
+``` javascript
+var main = function() {
+	console.log("Main class");
+	require.ensure([], () => {
+		const page = require("./pageA");
+		page();
+	});
+	require.ensure([], () => {
+		const page = require("./pageB");
+		page();
+	});
+};
+
+main();
+```
+
+# pageA.js
+
+``` javascript
+var reusableComponent = require("./reusableComponent");
+
+module.exports = function() {
+	console.log("Page A");
+	reusableComponent();
+};
+```
+
+# pageB.js
+
+``` javascript
+module.exports = function() {
+	console.log("Page B");
+	require.ensure([], ()=>{
+		const page = require("./pageC");
+		page();
+	});
+};
+```
+
+# pageC.js
+
+``` javascript
+var reusableComponent = require("./reusableComponent");
+
+module.exports = function() {
+	console.log("Page C");
+	reusableComponent();
+};
+```
+
+# reusableComponent.js
+
+``` javascript
+module.exports = function() {
+	console.log("reusable Component");
+};
+```
+
+# webpack.config.js
+
+``` javascript
+var webpack = require("../../");
+
+module.exports = {
+	entry: {
+		main: ["./example.js"]
+	},
+	plugins: [
+		new webpack.optimize.CommonsChunkPlugin({
+			name: "main",
+			minChunks: 2,
+			children: true,
+			deepChildren: true,
+		})
+	]
+};
+```
+
+# js/output.js
+
+<details><summary><code>/******/ (function(modules) { /* webpackBootstrap */ })</code></summary>
+
+``` javascript
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// install a JSONP callback for chunk loading
+/******/ 	var parentJsonpFunction = window["webpackJsonp"];
+/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
+/******/ 		// add "moreModules" to the modules object,
+/******/ 		// then flag all "chunkIds" as loaded and fire callback
+/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
+/******/ 		for(;i < chunkIds.length; i++) {
+/******/ 			chunkId = chunkIds[i];
+/******/ 			if(installedChunks[chunkId]) {
+/******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
+/******/ 			installedChunks[chunkId] = 0;
+/******/ 		}
+/******/ 		for(moduleId in moreModules) {
+/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
+/******/ 				modules[moduleId] = moreModules[moduleId];
+/******/ 			}
+/******/ 		}
+/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
+/******/ 		while(resolves.length) {
+/******/ 			resolves.shift()();
+/******/ 		}
+/******/
+/******/ 	};
+/******/
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// objects to store loaded and loading chunks
+/******/ 	var installedChunks = {
+/******/ 		3: 0
+/******/ 	};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/ 	// This file contains only the entry chunk.
+/******/ 	// The chunk loading function for additional chunks
+/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
+/******/ 		var installedChunkData = installedChunks[chunkId];
+/******/ 		if(installedChunkData === 0) {
+/******/ 			return new Promise(function(resolve) { resolve(); });
+/******/ 		}
+/******/
+/******/ 		// a Promise means "currently loading".
+/******/ 		if(installedChunkData) {
+/******/ 			return installedChunkData[2];
+/******/ 		}
+/******/
+/******/ 		// setup Promise in chunk cache
+/******/ 		var promise = new Promise(function(resolve, reject) {
+/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
+/******/ 		});
+/******/ 		installedChunkData[2] = promise;
+/******/
+/******/ 		// start chunk loading
+/******/ 		var head = document.getElementsByTagName('head')[0];
+/******/ 		var script = document.createElement('script');
+/******/ 		script.type = 'text/javascript';
+/******/ 		script.charset = 'utf-8';
+/******/ 		script.async = true;
+/******/ 		script.timeout = 120000;
+/******/
+/******/ 		if (__webpack_require__.nc) {
+/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
+/******/ 		}
+/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
+/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
+/******/ 		script.onerror = script.onload = onScriptComplete;
+/******/ 		function onScriptComplete() {
+/******/ 			// avoid mem leaks in IE.
+/******/ 			script.onerror = script.onload = null;
+/******/ 			clearTimeout(timeout);
+/******/ 			var chunk = installedChunks[chunkId];
+/******/ 			if(chunk !== 0) {
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
+/******/ 				installedChunks[chunkId] = undefined;
+/******/ 			}
+/******/ 		};
+/******/ 		head.appendChild(script);
+/******/
+/******/ 		return promise;
+/******/ 	};
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "js/";
+/******/
+/******/ 	// on error function for async loading
+/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+```
+
+</details>
+
+``` javascript
+/******/ ([
+/* 0 */
+/*!********************!*\
+  !*** ./example.js ***!
+  \********************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+var main = function() {
+	console.log("Main class");
+	__webpack_require__.e/* require.ensure */(2).then((() => {
+		const page = __webpack_require__(/*! ./pageA */ 3);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+	__webpack_require__.e/* require.ensure */(1).then((() => {
+		const page = __webpack_require__(/*! ./pageB */ 4);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+};
+
+main();
+
+
+/***/ }),
+/* 1 */
+/*!***************************************!*\
+  !*** multi ./example.js ./example.js ***!
+  \***************************************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(/*! ./example.js */0);
+module.exports = __webpack_require__(/*! .\example.js */0);
+
+
+/***/ }),
+/* 2 */
+/*!******************************!*\
+  !*** ./reusableComponent.js ***!
+  \******************************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports) {
+
+module.exports = function() {
+	console.log("reusable Component");
+};
+
+
+/***/ })
+/******/ ]);
+```
+
+# js/0.output.js
+
+``` javascript
+webpackJsonp([0],{
+
+/***/ 5:
+/*!******************!*\
+  !*** ./pageC.js ***!
+  \******************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+var reusableComponent = __webpack_require__(/*! ./reusableComponent */ 2);
+
+module.exports = function() {
+	console.log("Page C");
+	reusableComponent();
+};
+
+
+/***/ })
+
+});
+```
+
+# js/1.output.js
+
+``` javascript
+webpackJsonp([1],{
+
+/***/ 4:
+/*!******************!*\
+  !*** ./pageB.js ***!
+  \******************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = function() {
+	console.log("Page B");
+	__webpack_require__.e/* require.ensure */(0).then((()=>{
+		const page = __webpack_require__(/*! ./pageC */ 5);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+};
+
+
+/***/ })
+
+});
+```
+
+# js/2.output.js
+
+``` javascript
+webpackJsonp([2],{
+
+/***/ 3:
+/*!******************!*\
+  !*** ./pageA.js ***!
+  \******************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+var reusableComponent = __webpack_require__(/*! ./reusableComponent */ 2);
+
+module.exports = function() {
+	console.log("Page A");
+	reusableComponent();
+};
+
+
+/***/ })
+
+});
+```
+
+# Info
+
+## Uncompressed
+
+```
+Hash: [1mfd4796594a8274a0759b[39m[22m
+Version: webpack [1m3.6.0[39m[22m
+Time: [1m91[39m[22mms
+      [1mAsset[39m[22m       [1mSize[39m[22m  [1mChunks[39m[22m  [1m[39m[22m           [1m[39m[22m[1mChunk Names[39m[22m
+[1m[32m0.output.js[39m[22m  388 bytes       [1m0[39m[22m  [1m[32m[emitted][39m[22m  
+[1m[32m1.output.js[39m[22m  481 bytes       [1m1[39m[22m  [1m[32m[emitted][39m[22m  
+[1m[32m2.output.js[39m[22m  388 bytes       [1m2[39m[22m  [1m[32m[emitted][39m[22m  
+  [1m[32moutput.js[39m[22m    7.08 kB       [1m3[39m[22m  [1m[32m[emitted][39m[22m  main
+Entrypoint [1mmain[39m[22m = [1m[32moutput.js[39m[22m
+chunk    {[1m[33m0[39m[22m} [1m[32m0.output.js[39m[22m 142 bytes {[1m[33m3[39m[22m}[1m[32m [rendered][39m[22m
+    > [4] [1m./pageB.js[39m[22m 3:1-6:3
+    [5] [1m./pageC.js[39m[22m 142 bytes {[1m[33m0[39m[22m}[1m[32m [built][39m[22m
+        cjs require [1m[36m./pageC[39m[22m [4] [1m[35m./pageB.js[39m[22m 4:15-33
+chunk    {[1m[33m1[39m[22m} [1m[32m1.output.js[39m[22m 140 bytes {[1m[33m3[39m[22m}[1m[32m [rendered][39m[22m
+    > [0] [1m./example.js[39m[22m 7:1-10:3
+    [4] [1m./pageB.js[39m[22m 140 bytes {[1m[33m1[39m[22m}[1m[32m [built][39m[22m
+        cjs require [1m[36m./pageB[39m[22m [0] [1m[35m./example.js[39m[22m 8:15-33
+chunk    {[1m[33m2[39m[22m} [1m[32m2.output.js[39m[22m 142 bytes {[1m[33m3[39m[22m}[1m[32m [rendered][39m[22m
+    > [0] [1m./example.js[39m[22m 3:1-6:3
+    [3] [1m./pageA.js[39m[22m 142 bytes {[1m[33m2[39m[22m}[1m[32m [built][39m[22m
+        cjs require [1m[36m./pageA[39m[22m [0] [1m[35m./example.js[39m[22m 4:15-33
+chunk    {[1m[33m3[39m[22m} [1m[32moutput.js[39m[22m (main) 345 bytes[1m[33m [entry][39m[22m[1m[32m [rendered][39m[22m
+    > main [1] [1mmulti ./example.js ./example.js[39m[22m 
+    [0] [1m./example.js[39m[22m 233 bytes {[1m[33m3[39m[22m}[1m[32m [built][39m[22m
+        single entry [1m[36m./example.js[39m[22m [1] [1m[35mmulti ./example.js ./example.js[39m[22m main:100000
+        single entry [1m[36m.\example.js[39m[22m [1] [1m[35mmulti ./example.js ./example.js[39m[22m main:100001
+    [1] [1mmulti ./example.js ./example.js[39m[22m 40 bytes {[1m[33m3[39m[22m}[1m[32m [built][39m[22m
+    [2] [1m./reusableComponent.js[39m[22m 72 bytes {[1m[33m3[39m[22m}[1m[32m [built][39m[22m
+        cjs require [1m[36m./reusableComponent[39m[22m [3] [1m[35m./pageA.js[39m[22m 1:24-54
+        cjs require [1m[36m./reusableComponent[39m[22m [5] [1m[35m./pageC.js[39m[22m 1:24-54
+```
+
+## Minimized (uglify-js, no zip)
+
+```
+Hash: [1mfd4796594a8274a0759b[39m[22m
+Version: webpack [1m3.6.0[39m[22m
+Time: [1m150[39m[22mms
+      [1mAsset[39m[22m       [1mSize[39m[22m  [1mChunks[39m[22m  [1m[39m[22m           [1m[39m[22m[1mChunk Names[39m[22m
+[1m[32m0.output.js[39m[22m   98 bytes       [1m0[39m[22m  [1m[32m[emitted][39m[22m  
+[1m[32m1.output.js[39m[22m  340 bytes       [1m1[39m[22m  [1m[32m[emitted][39m[22m  
+[1m[32m2.output.js[39m[22m   98 bytes       [1m2[39m[22m  [1m[32m[emitted][39m[22m  
+  [1m[32moutput.js[39m[22m    6.48 kB       [1m3[39m[22m  [1m[32m[emitted][39m[22m  main
+Entrypoint [1mmain[39m[22m = [1m[32moutput.js[39m[22m
+chunk    {[1m[33m0[39m[22m} [1m[32m0.output.js[39m[22m 142 bytes {[1m[33m3[39m[22m}[1m[32m [rendered][39m[22m
+    > [4] [1m./pageB.js[39m[22m 3:1-6:3
+    [5] [1m./pageC.js[39m[22m 142 bytes {[1m[33m0[39m[22m}[1m[32m [built][39m[22m
+        cjs require [1m[36m./pageC[39m[22m [4] [1m[35m./pageB.js[39m[22m 4:15-33
+chunk    {[1m[33m1[39m[22m} [1m[32m1.output.js[39m[22m 140 bytes {[1m[33m3[39m[22m}[1m[32m [rendered][39m[22m
+    > [0] [1m./example.js[39m[22m 7:1-10:3
+    [4] [1m./pageB.js[39m[22m 140 bytes {[1m[33m1[39m[22m}[1m[32m [built][39m[22m
+        cjs require [1m[36m./pageB[39m[22m [0] [1m[35m./example.js[39m[22m 8:15-33
+chunk    {[1m[33m2[39m[22m} [1m[32m2.output.js[39m[22m 142 bytes {[1m[33m3[39m[22m}[1m[32m [rendered][39m[22m
+    > [0] [1m./example.js[39m[22m 3:1-6:3
+    [3] [1m./pageA.js[39m[22m 142 bytes {[1m[33m2[39m[22m}[1m[32m [built][39m[22m
+        cjs require [1m[36m./pageA[39m[22m [0] [1m[35m./example.js[39m[22m 4:15-33
+chunk    {[1m[33m3[39m[22m} [1m[32moutput.js[39m[22m (main) 345 bytes[1m[33m [entry][39m[22m[1m[32m [rendered][39m[22m
+    > main [1] [1mmulti ./example.js ./example.js[39m[22m 
+    [0] [1m./example.js[39m[22m 233 bytes {[1m[33m3[39m[22m}[1m[32m [built][39m[22m
+        single entry [1m[36m./example.js[39m[22m [1] [1m[35mmulti ./example.js ./example.js[39m[22m main:100000
+        single entry [1m[36m.\example.js[39m[22m [1] [1m[35mmulti ./example.js ./example.js[39m[22m main:100001
+    [1] [1mmulti ./example.js ./example.js[39m[22m 40 bytes {[1m[33m3[39m[22m}[1m[32m [built][39m[22m
+    [2] [1m./reusableComponent.js[39m[22m 72 bytes {[1m[33m3[39m[22m}[1m[32m [built][39m[22m
+        cjs require [1m[36m./reusableComponent[39m[22m [3] [1m[35m./pageA.js[39m[22m 1:24-54
+        cjs require [1m[36m./reusableComponent[39m[22m [5] [1m[35m./pageC.js[39m[22m 1:24-54
+
+[1m[31mERROR in 1.output.js from UglifyJs
+Unexpected token: punc ()) [1.output.js:8,53][39m[22m
+
+[1m[31mERROR in output.js from UglifyJs
+Unexpected token: punc ()) [output.js:154,53][39m[22m
+```

--- a/examples/common-chunk-grandchildren/README.md
+++ b/examples/common-chunk-grandchildren/README.md
@@ -82,8 +82,9 @@ module.exports = function() {
 # webpack.config.js
 
 ``` javascript
+"use strict";
 const webpack = require("../../");
-const path = require('path');
+const path = require("path");
 
 module.exports = [
 	{
@@ -91,7 +92,7 @@ module.exports = [
 			main: ["./example.js"]
 		},
 		output: {
-			path: path.resolve(__dirname, 'js'),
+			path: path.resolve(__dirname, "js"),
 			filename: "output.js"
 		},
 		plugins: [
@@ -108,7 +109,7 @@ module.exports = [
 			main: ["./example.js"]
 		},
 		output: {
-			path: path.resolve(__dirname, 'js'),
+			path: path.resolve(__dirname, "js"),
 			filename: "asyncoutput.js"
 		},
 		plugins: [
@@ -273,7 +274,7 @@ module.exports = [
 /******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
 /******/ })
 /************************************************************************/
 ```
@@ -283,752 +284,18 @@ module.exports = [
 ``` javascript
 /******/ ([
 /* 0 */
-/*!********************!*\
-  !*** ./example.js ***!
-  \********************/
+/*!**************************!*\
+  !*** multi ./example.js ***!
+  \**************************/
 /*! no static exports found */
 /*! all exports used */
 /***/ (function(module, exports, __webpack_require__) {
 
-var main = function() {
-	console.log("Main class");
-	__webpack_require__.e/* require.ensure */(2).then((() => {
-		const page = __webpack_require__(/*! ./pageA */ 4);
-		page();
-	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
-	__webpack_require__.e/* require.ensure */(1).then((() => {
-		const page = __webpack_require__(/*! ./pageB */ 5);
-		page();
-	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
-};
-
-main();
+module.exports = __webpack_require__(/*! ./example.js */1);
 
 
 /***/ }),
 /* 1 */
-/*!******************************************************!*\
-  !*** multi ./example.js ./example.js ./js/output.js ***!
-  \******************************************************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(/*! ./example.js */0);
-__webpack_require__(/*! .\example.js */0);
-module.exports = __webpack_require__(/*! .\js\output.js */2);
-
-
-/***/ }),
-/* 2 */
-/*!**********************!*\
-  !*** ./js/output.js ***!
-  \**********************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports) {
-
-/******/ (function(modules) { // webpackBootstrap
-/******/ 	// install a JSONP callback for chunk loading
-/******/ 	var parentJsonpFunction = window["webpackJsonp"];
-/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
-/******/ 		// add "moreModules" to the modules object,
-/******/ 		// then flag all "chunkIds" as loaded and fire callback
-/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
-/******/ 		for(;i < chunkIds.length; i++) {
-/******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId]) {
-/******/ 				resolves.push(installedChunks[chunkId][0]);
-/******/ 			}
-/******/ 			installedChunks[chunkId] = 0;
-/******/ 		}
-/******/ 		for(moduleId in moreModules) {
-/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
-/******/ 				modules[moduleId] = moreModules[moduleId];
-/******/ 			}
-/******/ 		}
-/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length) {
-/******/ 			resolves.shift()();
-/******/ 		}
-/******/
-/******/ 	};
-/******/
-/******/ 	// The module cache
-/******/ 	var installedModules = {};
-/******/
-/******/ 	// objects to store loaded and loading chunks
-/******/ 	var installedChunks = {
-/******/ 		3: 0
-/******/ 	};
-/******/
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
-/******/
-/******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId]) {
-/******/ 			return installedModules[moduleId].exports;
-/******/ 		}
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = installedModules[moduleId] = {
-/******/ 			i: moduleId,
-/******/ 			l: false,
-/******/ 			exports: {}
-/******/ 		};
-/******/
-/******/ 		// Execute the module function
-/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
-/******/
-/******/ 		// Flag the module as loaded
-/******/ 		module.l = true;
-/******/
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
-/******/ 	}
-/******/
-/******/ 	// This file contains only the entry chunk.
-/******/ 	// The chunk loading function for additional chunks
-/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		var installedChunkData = installedChunks[chunkId];
-/******/ 		if(installedChunkData === 0) {
-/******/ 			return new Promise(function(resolve) { resolve(); });
-/******/ 		}
-/******/
-/******/ 		// a Promise means "currently loading".
-/******/ 		if(installedChunkData) {
-/******/ 			return installedChunkData[2];
-/******/ 		}
-/******/
-/******/ 		// setup Promise in chunk cache
-/******/ 		var promise = new Promise(function(resolve, reject) {
-/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
-/******/ 		});
-/******/ 		installedChunkData[2] = promise;
-/******/
-/******/ 		// start chunk loading
-/******/ 		var head = document.getElementsByTagName('head')[0];
-/******/ 		var script = document.createElement('script');
-/******/ 		script.type = 'text/javascript';
-/******/ 		script.charset = 'utf-8';
-/******/ 		script.async = true;
-/******/ 		script.timeout = 120000;
-/******/
-/******/ 		if (__webpack_require__.nc) {
-/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
-/******/ 		}
-/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
-/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
-/******/ 		script.onerror = script.onload = onScriptComplete;
-/******/ 		function onScriptComplete() {
-/******/ 			// avoid mem leaks in IE.
-/******/ 			script.onerror = script.onload = null;
-/******/ 			clearTimeout(timeout);
-/******/ 			var chunk = installedChunks[chunkId];
-/******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) {
-/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
-/******/ 				}
-/******/ 				installedChunks[chunkId] = undefined;
-/******/ 			}
-/******/ 		};
-/******/ 		head.appendChild(script);
-/******/
-/******/ 		return promise;
-/******/ 	};
-/******/
-/******/ 	// expose the modules object (__webpack_modules__)
-/******/ 	__webpack_require__.m = modules;
-/******/
-/******/ 	// expose the module cache
-/******/ 	__webpack_require__.c = installedModules;
-/******/
-/******/ 	// define getter function for harmony exports
-/******/ 	__webpack_require__.d = function(exports, name, getter) {
-/******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, {
-/******/ 				configurable: false,
-/******/ 				enumerable: true,
-/******/ 				get: getter
-/******/ 			});
-/******/ 		}
-/******/ 	};
-/******/
-/******/ 	// getDefaultExport function for compatibility with non-harmony modules
-/******/ 	__webpack_require__.n = function(module) {
-/******/ 		var getter = module && module.__esModule ?
-/******/ 			function getDefault() { return module['default']; } :
-/******/ 			function getModuleExports() { return module; };
-/******/ 		__webpack_require__.d(getter, 'a', getter);
-/******/ 		return getter;
-/******/ 	};
-/******/
-/******/ 	// Object.prototype.hasOwnProperty.call
-/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
-/******/
-/******/ 	// __webpack_public_path__
-/******/ 	__webpack_require__.p = "js/";
-/******/
-/******/ 	// on error function for async loading
-/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
-/******/
-/******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 1);
-/******/ })
-/************************************************************************/
-/******/ ([
-/* 0 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var main = function() {
-	console.log("Main class");
-	__webpack_require__.e/* require.ensure */(2).then((() => {
-		const page = __webpack_require__(4);
-		page();
-	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
-	__webpack_require__.e/* require.ensure */(1).then((() => {
-		const page = __webpack_require__(5);
-		page();
-	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
-};
-
-main();
-
-
-/***/ }),
-/* 1 */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(0);
-__webpack_require__(0);
-module.exports = __webpack_require__(2);
-
-
-/***/ }),
-/* 2 */
-/***/ (function(module, exports) {
-
-/******/ (function(modules) { // webpackBootstrap
-/******/ 	// install a JSONP callback for chunk loading
-/******/ 	var parentJsonpFunction = window["webpackJsonp"];
-/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
-/******/ 		// add "moreModules" to the modules object,
-/******/ 		// then flag all "chunkIds" as loaded and fire callback
-/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
-/******/ 		for(;i < chunkIds.length; i++) {
-/******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId]) {
-/******/ 				resolves.push(installedChunks[chunkId][0]);
-/******/ 			}
-/******/ 			installedChunks[chunkId] = 0;
-/******/ 		}
-/******/ 		for(moduleId in moreModules) {
-/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
-/******/ 				modules[moduleId] = moreModules[moduleId];
-/******/ 			}
-/******/ 		}
-/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length) {
-/******/ 			resolves.shift()();
-/******/ 		}
-/******/
-/******/ 	};
-/******/
-/******/ 	// The module cache
-/******/ 	var installedModules = {};
-/******/
-/******/ 	// objects to store loaded and loading chunks
-/******/ 	var installedChunks = {
-/******/ 		3: 0
-/******/ 	};
-/******/
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
-/******/
-/******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId]) {
-/******/ 			return installedModules[moduleId].exports;
-/******/ 		}
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = installedModules[moduleId] = {
-/******/ 			i: moduleId,
-/******/ 			l: false,
-/******/ 			exports: {}
-/******/ 		};
-/******/
-/******/ 		// Execute the module function
-/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
-/******/
-/******/ 		// Flag the module as loaded
-/******/ 		module.l = true;
-/******/
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
-/******/ 	}
-/******/
-/******/ 	// This file contains only the entry chunk.
-/******/ 	// The chunk loading function for additional chunks
-/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		var installedChunkData = installedChunks[chunkId];
-/******/ 		if(installedChunkData === 0) {
-/******/ 			return new Promise(function(resolve) { resolve(); });
-/******/ 		}
-/******/
-/******/ 		// a Promise means "currently loading".
-/******/ 		if(installedChunkData) {
-/******/ 			return installedChunkData[2];
-/******/ 		}
-/******/
-/******/ 		// setup Promise in chunk cache
-/******/ 		var promise = new Promise(function(resolve, reject) {
-/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
-/******/ 		});
-/******/ 		installedChunkData[2] = promise;
-/******/
-/******/ 		// start chunk loading
-/******/ 		var head = document.getElementsByTagName('head')[0];
-/******/ 		var script = document.createElement('script');
-/******/ 		script.type = 'text/javascript';
-/******/ 		script.charset = 'utf-8';
-/******/ 		script.async = true;
-/******/ 		script.timeout = 120000;
-/******/
-/******/ 		if (__webpack_require__.nc) {
-/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
-/******/ 		}
-/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
-/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
-/******/ 		script.onerror = script.onload = onScriptComplete;
-/******/ 		function onScriptComplete() {
-/******/ 			// avoid mem leaks in IE.
-/******/ 			script.onerror = script.onload = null;
-/******/ 			clearTimeout(timeout);
-/******/ 			var chunk = installedChunks[chunkId];
-/******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) {
-/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
-/******/ 				}
-/******/ 				installedChunks[chunkId] = undefined;
-/******/ 			}
-/******/ 		};
-/******/ 		head.appendChild(script);
-/******/
-/******/ 		return promise;
-/******/ 	};
-/******/
-/******/ 	// expose the modules object (__webpack_modules__)
-/******/ 	__webpack_require__.m = modules;
-/******/
-/******/ 	// expose the module cache
-/******/ 	__webpack_require__.c = installedModules;
-/******/
-/******/ 	// define getter function for harmony exports
-/******/ 	__webpack_require__.d = function(exports, name, getter) {
-/******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, {
-/******/ 				configurable: false,
-/******/ 				enumerable: true,
-/******/ 				get: getter
-/******/ 			});
-/******/ 		}
-/******/ 	};
-/******/
-/******/ 	// getDefaultExport function for compatibility with non-harmony modules
-/******/ 	__webpack_require__.n = function(module) {
-/******/ 		var getter = module && module.__esModule ?
-/******/ 			function getDefault() { return module['default']; } :
-/******/ 			function getModuleExports() { return module; };
-/******/ 		__webpack_require__.d(getter, 'a', getter);
-/******/ 		return getter;
-/******/ 	};
-/******/
-/******/ 	// Object.prototype.hasOwnProperty.call
-/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
-/******/
-/******/ 	// __webpack_public_path__
-/******/ 	__webpack_require__.p = "js/";
-/******/
-/******/ 	// on error function for async loading
-/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
-/******/
-/******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 1);
-/******/ })
-/************************************************************************/
-/******/ ([
-/* 0 */
-/*!********************!*\
-  !*** ./example.js ***!
-  \********************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports, __webpack_require__) {
-
-var main = function() {
-	console.log("Main class");
-	__webpack_require__.e/* require.ensure */(2).then((() => {
-		const page = __webpack_require__(/*! ./pageA */ 4);
-		page();
-	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
-	__webpack_require__.e/* require.ensure */(1).then((() => {
-		const page = __webpack_require__(/*! ./pageB */ 5);
-		page();
-	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
-};
-
-main();
-
-
-/***/ }),
-/* 1 */
-/*!******************************************************!*\
-  !*** multi ./example.js ./example.js ./js/output.js ***!
-  \******************************************************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(/*! ./example.js */0);
-__webpack_require__(/*! .\example.js */0);
-module.exports = __webpack_require__(/*! .\js\output.js */2);
-
-
-/***/ }),
-/* 2 */
-/*!**********************!*\
-  !*** ./js/output.js ***!
-  \**********************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports) {
-
-/******/ (function(modules) { // webpackBootstrap
-/******/ 	// install a JSONP callback for chunk loading
-/******/ 	var parentJsonpFunction = window["webpackJsonp"];
-/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
-/******/ 		// add "moreModules" to the modules object,
-/******/ 		// then flag all "chunkIds" as loaded and fire callback
-/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
-/******/ 		for(;i < chunkIds.length; i++) {
-/******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId]) {
-/******/ 				resolves.push(installedChunks[chunkId][0]);
-/******/ 			}
-/******/ 			installedChunks[chunkId] = 0;
-/******/ 		}
-/******/ 		for(moduleId in moreModules) {
-/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
-/******/ 				modules[moduleId] = moreModules[moduleId];
-/******/ 			}
-/******/ 		}
-/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length) {
-/******/ 			resolves.shift()();
-/******/ 		}
-/******/
-/******/ 	};
-/******/
-/******/ 	// The module cache
-/******/ 	var installedModules = {};
-/******/
-/******/ 	// objects to store loaded and loading chunks
-/******/ 	var installedChunks = {
-/******/ 		3: 0
-/******/ 	};
-/******/
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
-/******/
-/******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId]) {
-/******/ 			return installedModules[moduleId].exports;
-/******/ 		}
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = installedModules[moduleId] = {
-/******/ 			i: moduleId,
-/******/ 			l: false,
-/******/ 			exports: {}
-/******/ 		};
-/******/
-/******/ 		// Execute the module function
-/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
-/******/
-/******/ 		// Flag the module as loaded
-/******/ 		module.l = true;
-/******/
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
-/******/ 	}
-/******/
-/******/ 	// This file contains only the entry chunk.
-/******/ 	// The chunk loading function for additional chunks
-/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		var installedChunkData = installedChunks[chunkId];
-/******/ 		if(installedChunkData === 0) {
-/******/ 			return new Promise(function(resolve) { resolve(); });
-/******/ 		}
-/******/
-/******/ 		// a Promise means "currently loading".
-/******/ 		if(installedChunkData) {
-/******/ 			return installedChunkData[2];
-/******/ 		}
-/******/
-/******/ 		// setup Promise in chunk cache
-/******/ 		var promise = new Promise(function(resolve, reject) {
-/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
-/******/ 		});
-/******/ 		installedChunkData[2] = promise;
-/******/
-/******/ 		// start chunk loading
-/******/ 		var head = document.getElementsByTagName('head')[0];
-/******/ 		var script = document.createElement('script');
-/******/ 		script.type = 'text/javascript';
-/******/ 		script.charset = 'utf-8';
-/******/ 		script.async = true;
-/******/ 		script.timeout = 120000;
-/******/
-/******/ 		if (__webpack_require__.nc) {
-/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
-/******/ 		}
-/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
-/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
-/******/ 		script.onerror = script.onload = onScriptComplete;
-/******/ 		function onScriptComplete() {
-/******/ 			// avoid mem leaks in IE.
-/******/ 			script.onerror = script.onload = null;
-/******/ 			clearTimeout(timeout);
-/******/ 			var chunk = installedChunks[chunkId];
-/******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) {
-/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
-/******/ 				}
-/******/ 				installedChunks[chunkId] = undefined;
-/******/ 			}
-/******/ 		};
-/******/ 		head.appendChild(script);
-/******/
-/******/ 		return promise;
-/******/ 	};
-/******/
-/******/ 	// expose the modules object (__webpack_modules__)
-/******/ 	__webpack_require__.m = modules;
-/******/
-/******/ 	// expose the module cache
-/******/ 	__webpack_require__.c = installedModules;
-/******/
-/******/ 	// define getter function for harmony exports
-/******/ 	__webpack_require__.d = function(exports, name, getter) {
-/******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, {
-/******/ 				configurable: false,
-/******/ 				enumerable: true,
-/******/ 				get: getter
-/******/ 			});
-/******/ 		}
-/******/ 	};
-/******/
-/******/ 	// getDefaultExport function for compatibility with non-harmony modules
-/******/ 	__webpack_require__.n = function(module) {
-/******/ 		var getter = module && module.__esModule ?
-/******/ 			function getDefault() { return module['default']; } :
-/******/ 			function getModuleExports() { return module; };
-/******/ 		__webpack_require__.d(getter, 'a', getter);
-/******/ 		return getter;
-/******/ 	};
-/******/
-/******/ 	// Object.prototype.hasOwnProperty.call
-/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
-/******/
-/******/ 	// __webpack_public_path__
-/******/ 	__webpack_require__.p = "js/";
-/******/
-/******/ 	// on error function for async loading
-/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
-/******/
-/******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 1);
-/******/ })
-/************************************************************************/
-/******/ ([
-/* 0 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var main = function() {
-	console.log("Main class");
-	__webpack_require__.e/* require.ensure */(2).then((() => {
-		const page = __webpack_require__(4);
-		page();
-	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
-	__webpack_require__.e/* require.ensure */(1).then((() => {
-		const page = __webpack_require__(5);
-		page();
-	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
-};
-
-main();
-
-
-/***/ }),
-/* 1 */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(0);
-__webpack_require__(0);
-module.exports = __webpack_require__(2);
-
-
-/***/ }),
-/* 2 */
-/***/ (function(module, exports) {
-
-/******/ (function(modules) { // webpackBootstrap
-/******/ 	// install a JSONP callback for chunk loading
-/******/ 	var parentJsonpFunction = window["webpackJsonp"];
-/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
-/******/ 		// add "moreModules" to the modules object,
-/******/ 		// then flag all "chunkIds" as loaded and fire callback
-/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
-/******/ 		for(;i < chunkIds.length; i++) {
-/******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId]) {
-/******/ 				resolves.push(installedChunks[chunkId][0]);
-/******/ 			}
-/******/ 			installedChunks[chunkId] = 0;
-/******/ 		}
-/******/ 		for(moduleId in moreModules) {
-/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
-/******/ 				modules[moduleId] = moreModules[moduleId];
-/******/ 			}
-/******/ 		}
-/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length) {
-/******/ 			resolves.shift()();
-/******/ 		}
-/******/
-/******/ 	};
-/******/
-/******/ 	// The module cache
-/******/ 	var installedModules = {};
-/******/
-/******/ 	// objects to store loaded and loading chunks
-/******/ 	var installedChunks = {
-/******/ 		3: 0
-/******/ 	};
-/******/
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
-/******/
-/******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId]) {
-/******/ 			return installedModules[moduleId].exports;
-/******/ 		}
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = installedModules[moduleId] = {
-/******/ 			i: moduleId,
-/******/ 			l: false,
-/******/ 			exports: {}
-/******/ 		};
-/******/
-/******/ 		// Execute the module function
-/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
-/******/
-/******/ 		// Flag the module as loaded
-/******/ 		module.l = true;
-/******/
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
-/******/ 	}
-/******/
-/******/ 	// This file contains only the entry chunk.
-/******/ 	// The chunk loading function for additional chunks
-/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		var installedChunkData = installedChunks[chunkId];
-/******/ 		if(installedChunkData === 0) {
-/******/ 			return new Promise(function(resolve) { resolve(); });
-/******/ 		}
-/******/
-/******/ 		// a Promise means "currently loading".
-/******/ 		if(installedChunkData) {
-/******/ 			return installedChunkData[2];
-/******/ 		}
-/******/
-/******/ 		// setup Promise in chunk cache
-/******/ 		var promise = new Promise(function(resolve, reject) {
-/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
-/******/ 		});
-/******/ 		installedChunkData[2] = promise;
-/******/
-/******/ 		// start chunk loading
-/******/ 		var head = document.getElementsByTagName('head')[0];
-/******/ 		var script = document.createElement('script');
-/******/ 		script.type = 'text/javascript';
-/******/ 		script.charset = 'utf-8';
-/******/ 		script.async = true;
-/******/ 		script.timeout = 120000;
-/******/
-/******/ 		if (__webpack_require__.nc) {
-/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
-/******/ 		}
-/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
-/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
-/******/ 		script.onerror = script.onload = onScriptComplete;
-/******/ 		function onScriptComplete() {
-/******/ 			// avoid mem leaks in IE.
-/******/ 			script.onerror = script.onload = null;
-/******/ 			clearTimeout(timeout);
-/******/ 			var chunk = installedChunks[chunkId];
-/******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) {
-/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
-/******/ 				}
-/******/ 				installedChunks[chunkId] = undefined;
-/******/ 			}
-/******/ 		};
-/******/ 		head.appendChild(script);
-/******/
-/******/ 		return promise;
-/******/ 	};
-/******/
-/******/ 	// expose the modules object (__webpack_modules__)
-/******/ 	__webpack_require__.m = modules;
-/******/
-/******/ 	// expose the module cache
-/******/ 	__webpack_require__.c = installedModules;
-/******/
-/******/ 	// define getter function for harmony exports
-/******/ 	__webpack_require__.d = function(exports, name, getter) {
-/******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, {
-/******/ 				configurable: false,
-/******/ 				enumerable: true,
-/******/ 				get: getter
-/******/ 			});
-/******/ 		}
-/******/ 	};
-/******/
-/******/ 	// getDefaultExport function for compatibility with non-harmony modules
-/******/ 	__webpack_require__.n = function(module) {
-/******/ 		var getter = module && module.__esModule ?
-/******/ 			function getDefault() { return module['default']; } :
-/******/ 			function getModuleExports() { return module; };
-/******/ 		__webpack_require__.d(getter, 'a', getter);
-/******/ 		return getter;
-/******/ 	};
-/******/
-/******/ 	// Object.prototype.hasOwnProperty.call
-/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
-/******/
-/******/ 	// __webpack_public_path__
-/******/ 	__webpack_require__.p = "js/";
-/******/
-/******/ 	// on error function for async loading
-/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
-/******/
-/******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 1);
-/******/ })
-/************************************************************************/
-/******/ ([
-/* 0 */
 /*!********************!*\
   !*** ./example.js ***!
   \********************/
@@ -1052,78 +319,7 @@ main();
 
 
 /***/ }),
-/* 1 */
-/*!***************************************!*\
-  !*** multi ./example.js ./example.js ***!
-  \***************************************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(/*! ./example.js */0);
-module.exports = __webpack_require__(/*! .\example.js */0);
-
-
-/***/ }),
 /* 2 */
-/*!******************************!*\
-  !*** ./reusableComponent.js ***!
-  \******************************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports) {
-
-module.exports = function() {
-	console.log("reusable Component");
-};
-
-
-/***/ })
-/******/ ]);
-
-/***/ }),
-/* 3 */
-/***/ (function(module, exports) {
-
-module.exports = function() {
-	console.log("reusable Component");
-};
-
-
-/***/ })
-/******/ ]);
-
-/***/ }),
-/* 3 */
-/*!******************************!*\
-  !*** ./reusableComponent.js ***!
-  \******************************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports) {
-
-module.exports = function() {
-	console.log("reusable Component");
-};
-
-
-/***/ })
-/******/ ]);
-
-/***/ }),
-/* 3 */
-/***/ (function(module, exports) {
-
-module.exports = function() {
-	console.log("reusable Component");
-};
-
-
-/***/ })
-/******/ ]);
-
-/***/ }),
-/* 3 */
 /*!******************************!*\
   !*** ./reusableComponent.js ***!
   \******************************/
@@ -1145,7 +341,7 @@ module.exports = function() {
 ``` javascript
 webpackJsonp([0],{
 
-/***/ 6:
+/***/ 5:
 /*!******************!*\
   !*** ./pageC.js ***!
   \******************/
@@ -1153,7 +349,7 @@ webpackJsonp([0],{
 /*! all exports used */
 /***/ (function(module, exports, __webpack_require__) {
 
-var reusableComponent = __webpack_require__(/*! ./reusableComponent */ 3);
+var reusableComponent = __webpack_require__(/*! ./reusableComponent */ 2);
 
 module.exports = function() {
 	console.log("Page C");
@@ -1171,7 +367,7 @@ module.exports = function() {
 ``` javascript
 webpackJsonp([1],{
 
-/***/ 5:
+/***/ 4:
 /*!******************!*\
   !*** ./pageB.js ***!
   \******************/
@@ -1182,7 +378,7 @@ webpackJsonp([1],{
 module.exports = function() {
 	console.log("Page B");
 	__webpack_require__.e/* require.ensure */(0).then((()=>{
-		const page = __webpack_require__(/*! ./pageC */ 6);
+		const page = __webpack_require__(/*! ./pageC */ 5);
 		page();
 	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
 };
@@ -1198,7 +394,7 @@ module.exports = function() {
 ``` javascript
 webpackJsonp([2],{
 
-/***/ 4:
+/***/ 3:
 /*!******************!*\
   !*** ./pageA.js ***!
   \******************/
@@ -1206,7 +402,7 @@ webpackJsonp([2],{
 /*! all exports used */
 /***/ (function(module, exports, __webpack_require__) {
 
-var reusableComponent = __webpack_require__(/*! ./reusableComponent */ 3);
+var reusableComponent = __webpack_require__(/*! ./reusableComponent */ 2);
 
 module.exports = function() {
 	console.log("Page A");
@@ -1366,11 +562,23 @@ module.exports = function() {
 /******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
 /******/ })
 /************************************************************************/
 /******/ ([
 /* 0 */
+/*!**************************!*\
+  !*** multi ./example.js ***!
+  \**************************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(/*! ./example.js */1);
+
+
+/***/ }),
+/* 1 */
 /*!********************!*\
   !*** ./example.js ***!
   \********************/
@@ -1381,834 +589,17 @@ module.exports = function() {
 var main = function() {
 	console.log("Main class");
 	Promise.all/* require.ensure */([__webpack_require__.e(0), __webpack_require__.e(2)]).then((() => {
-		const page = __webpack_require__(/*! ./pageA */ 3);
+		const page = __webpack_require__(/*! ./pageA */ 2);
 		page();
 	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
 	__webpack_require__.e/* require.ensure */(1).then((() => {
-		const page = __webpack_require__(/*! ./pageB */ 4);
+		const page = __webpack_require__(/*! ./pageB */ 3);
 		page();
 	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
 };
 
 main();
 
-
-/***/ }),
-/* 1 */
-/*!******************************************************!*\
-  !*** multi ./example.js ./example.js ./js/output.js ***!
-  \******************************************************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(/*! ./example.js */0);
-__webpack_require__(/*! .\example.js */0);
-module.exports = __webpack_require__(/*! .\js\output.js */2);
-
-
-/***/ }),
-/* 2 */
-/*!**********************!*\
-  !*** ./js/output.js ***!
-  \**********************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports) {
-
-/******/ (function(modules) { // webpackBootstrap
-/******/ 	// install a JSONP callback for chunk loading
-/******/ 	var parentJsonpFunction = window["webpackJsonp"];
-/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
-/******/ 		// add "moreModules" to the modules object,
-/******/ 		// then flag all "chunkIds" as loaded and fire callback
-/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
-/******/ 		for(;i < chunkIds.length; i++) {
-/******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId]) {
-/******/ 				resolves.push(installedChunks[chunkId][0]);
-/******/ 			}
-/******/ 			installedChunks[chunkId] = 0;
-/******/ 		}
-/******/ 		for(moduleId in moreModules) {
-/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
-/******/ 				modules[moduleId] = moreModules[moduleId];
-/******/ 			}
-/******/ 		}
-/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length) {
-/******/ 			resolves.shift()();
-/******/ 		}
-/******/
-/******/ 	};
-/******/
-/******/ 	// The module cache
-/******/ 	var installedModules = {};
-/******/
-/******/ 	// objects to store loaded and loading chunks
-/******/ 	var installedChunks = {
-/******/ 		3: 0
-/******/ 	};
-/******/
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
-/******/
-/******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId]) {
-/******/ 			return installedModules[moduleId].exports;
-/******/ 		}
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = installedModules[moduleId] = {
-/******/ 			i: moduleId,
-/******/ 			l: false,
-/******/ 			exports: {}
-/******/ 		};
-/******/
-/******/ 		// Execute the module function
-/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
-/******/
-/******/ 		// Flag the module as loaded
-/******/ 		module.l = true;
-/******/
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
-/******/ 	}
-/******/
-/******/ 	// This file contains only the entry chunk.
-/******/ 	// The chunk loading function for additional chunks
-/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		var installedChunkData = installedChunks[chunkId];
-/******/ 		if(installedChunkData === 0) {
-/******/ 			return new Promise(function(resolve) { resolve(); });
-/******/ 		}
-/******/
-/******/ 		// a Promise means "currently loading".
-/******/ 		if(installedChunkData) {
-/******/ 			return installedChunkData[2];
-/******/ 		}
-/******/
-/******/ 		// setup Promise in chunk cache
-/******/ 		var promise = new Promise(function(resolve, reject) {
-/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
-/******/ 		});
-/******/ 		installedChunkData[2] = promise;
-/******/
-/******/ 		// start chunk loading
-/******/ 		var head = document.getElementsByTagName('head')[0];
-/******/ 		var script = document.createElement('script');
-/******/ 		script.type = 'text/javascript';
-/******/ 		script.charset = 'utf-8';
-/******/ 		script.async = true;
-/******/ 		script.timeout = 120000;
-/******/
-/******/ 		if (__webpack_require__.nc) {
-/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
-/******/ 		}
-/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
-/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
-/******/ 		script.onerror = script.onload = onScriptComplete;
-/******/ 		function onScriptComplete() {
-/******/ 			// avoid mem leaks in IE.
-/******/ 			script.onerror = script.onload = null;
-/******/ 			clearTimeout(timeout);
-/******/ 			var chunk = installedChunks[chunkId];
-/******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) {
-/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
-/******/ 				}
-/******/ 				installedChunks[chunkId] = undefined;
-/******/ 			}
-/******/ 		};
-/******/ 		head.appendChild(script);
-/******/
-/******/ 		return promise;
-/******/ 	};
-/******/
-/******/ 	// expose the modules object (__webpack_modules__)
-/******/ 	__webpack_require__.m = modules;
-/******/
-/******/ 	// expose the module cache
-/******/ 	__webpack_require__.c = installedModules;
-/******/
-/******/ 	// define getter function for harmony exports
-/******/ 	__webpack_require__.d = function(exports, name, getter) {
-/******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, {
-/******/ 				configurable: false,
-/******/ 				enumerable: true,
-/******/ 				get: getter
-/******/ 			});
-/******/ 		}
-/******/ 	};
-/******/
-/******/ 	// getDefaultExport function for compatibility with non-harmony modules
-/******/ 	__webpack_require__.n = function(module) {
-/******/ 		var getter = module && module.__esModule ?
-/******/ 			function getDefault() { return module['default']; } :
-/******/ 			function getModuleExports() { return module; };
-/******/ 		__webpack_require__.d(getter, 'a', getter);
-/******/ 		return getter;
-/******/ 	};
-/******/
-/******/ 	// Object.prototype.hasOwnProperty.call
-/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
-/******/
-/******/ 	// __webpack_public_path__
-/******/ 	__webpack_require__.p = "js/";
-/******/
-/******/ 	// on error function for async loading
-/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
-/******/
-/******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 1);
-/******/ })
-/************************************************************************/
-/******/ ([
-/* 0 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var main = function() {
-	console.log("Main class");
-	__webpack_require__.e/* require.ensure */(2).then((() => {
-		const page = __webpack_require__(4);
-		page();
-	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
-	__webpack_require__.e/* require.ensure */(1).then((() => {
-		const page = __webpack_require__(5);
-		page();
-	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
-};
-
-main();
-
-
-/***/ }),
-/* 1 */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(0);
-__webpack_require__(0);
-module.exports = __webpack_require__(2);
-
-
-/***/ }),
-/* 2 */
-/***/ (function(module, exports) {
-
-/******/ (function(modules) { // webpackBootstrap
-/******/ 	// install a JSONP callback for chunk loading
-/******/ 	var parentJsonpFunction = window["webpackJsonp"];
-/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
-/******/ 		// add "moreModules" to the modules object,
-/******/ 		// then flag all "chunkIds" as loaded and fire callback
-/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
-/******/ 		for(;i < chunkIds.length; i++) {
-/******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId]) {
-/******/ 				resolves.push(installedChunks[chunkId][0]);
-/******/ 			}
-/******/ 			installedChunks[chunkId] = 0;
-/******/ 		}
-/******/ 		for(moduleId in moreModules) {
-/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
-/******/ 				modules[moduleId] = moreModules[moduleId];
-/******/ 			}
-/******/ 		}
-/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length) {
-/******/ 			resolves.shift()();
-/******/ 		}
-/******/
-/******/ 	};
-/******/
-/******/ 	// The module cache
-/******/ 	var installedModules = {};
-/******/
-/******/ 	// objects to store loaded and loading chunks
-/******/ 	var installedChunks = {
-/******/ 		3: 0
-/******/ 	};
-/******/
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
-/******/
-/******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId]) {
-/******/ 			return installedModules[moduleId].exports;
-/******/ 		}
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = installedModules[moduleId] = {
-/******/ 			i: moduleId,
-/******/ 			l: false,
-/******/ 			exports: {}
-/******/ 		};
-/******/
-/******/ 		// Execute the module function
-/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
-/******/
-/******/ 		// Flag the module as loaded
-/******/ 		module.l = true;
-/******/
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
-/******/ 	}
-/******/
-/******/ 	// This file contains only the entry chunk.
-/******/ 	// The chunk loading function for additional chunks
-/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		var installedChunkData = installedChunks[chunkId];
-/******/ 		if(installedChunkData === 0) {
-/******/ 			return new Promise(function(resolve) { resolve(); });
-/******/ 		}
-/******/
-/******/ 		// a Promise means "currently loading".
-/******/ 		if(installedChunkData) {
-/******/ 			return installedChunkData[2];
-/******/ 		}
-/******/
-/******/ 		// setup Promise in chunk cache
-/******/ 		var promise = new Promise(function(resolve, reject) {
-/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
-/******/ 		});
-/******/ 		installedChunkData[2] = promise;
-/******/
-/******/ 		// start chunk loading
-/******/ 		var head = document.getElementsByTagName('head')[0];
-/******/ 		var script = document.createElement('script');
-/******/ 		script.type = 'text/javascript';
-/******/ 		script.charset = 'utf-8';
-/******/ 		script.async = true;
-/******/ 		script.timeout = 120000;
-/******/
-/******/ 		if (__webpack_require__.nc) {
-/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
-/******/ 		}
-/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
-/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
-/******/ 		script.onerror = script.onload = onScriptComplete;
-/******/ 		function onScriptComplete() {
-/******/ 			// avoid mem leaks in IE.
-/******/ 			script.onerror = script.onload = null;
-/******/ 			clearTimeout(timeout);
-/******/ 			var chunk = installedChunks[chunkId];
-/******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) {
-/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
-/******/ 				}
-/******/ 				installedChunks[chunkId] = undefined;
-/******/ 			}
-/******/ 		};
-/******/ 		head.appendChild(script);
-/******/
-/******/ 		return promise;
-/******/ 	};
-/******/
-/******/ 	// expose the modules object (__webpack_modules__)
-/******/ 	__webpack_require__.m = modules;
-/******/
-/******/ 	// expose the module cache
-/******/ 	__webpack_require__.c = installedModules;
-/******/
-/******/ 	// define getter function for harmony exports
-/******/ 	__webpack_require__.d = function(exports, name, getter) {
-/******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, {
-/******/ 				configurable: false,
-/******/ 				enumerable: true,
-/******/ 				get: getter
-/******/ 			});
-/******/ 		}
-/******/ 	};
-/******/
-/******/ 	// getDefaultExport function for compatibility with non-harmony modules
-/******/ 	__webpack_require__.n = function(module) {
-/******/ 		var getter = module && module.__esModule ?
-/******/ 			function getDefault() { return module['default']; } :
-/******/ 			function getModuleExports() { return module; };
-/******/ 		__webpack_require__.d(getter, 'a', getter);
-/******/ 		return getter;
-/******/ 	};
-/******/
-/******/ 	// Object.prototype.hasOwnProperty.call
-/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
-/******/
-/******/ 	// __webpack_public_path__
-/******/ 	__webpack_require__.p = "js/";
-/******/
-/******/ 	// on error function for async loading
-/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
-/******/
-/******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 1);
-/******/ })
-/************************************************************************/
-/******/ ([
-/* 0 */
-/*!********************!*\
-  !*** ./example.js ***!
-  \********************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports, __webpack_require__) {
-
-var main = function() {
-	console.log("Main class");
-	__webpack_require__.e/* require.ensure */(2).then((() => {
-		const page = __webpack_require__(/*! ./pageA */ 4);
-		page();
-	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
-	__webpack_require__.e/* require.ensure */(1).then((() => {
-		const page = __webpack_require__(/*! ./pageB */ 5);
-		page();
-	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
-};
-
-main();
-
-
-/***/ }),
-/* 1 */
-/*!******************************************************!*\
-  !*** multi ./example.js ./example.js ./js/output.js ***!
-  \******************************************************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(/*! ./example.js */0);
-__webpack_require__(/*! .\example.js */0);
-module.exports = __webpack_require__(/*! .\js\output.js */2);
-
-
-/***/ }),
-/* 2 */
-/*!**********************!*\
-  !*** ./js/output.js ***!
-  \**********************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports) {
-
-/******/ (function(modules) { // webpackBootstrap
-/******/ 	// install a JSONP callback for chunk loading
-/******/ 	var parentJsonpFunction = window["webpackJsonp"];
-/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
-/******/ 		// add "moreModules" to the modules object,
-/******/ 		// then flag all "chunkIds" as loaded and fire callback
-/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
-/******/ 		for(;i < chunkIds.length; i++) {
-/******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId]) {
-/******/ 				resolves.push(installedChunks[chunkId][0]);
-/******/ 			}
-/******/ 			installedChunks[chunkId] = 0;
-/******/ 		}
-/******/ 		for(moduleId in moreModules) {
-/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
-/******/ 				modules[moduleId] = moreModules[moduleId];
-/******/ 			}
-/******/ 		}
-/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length) {
-/******/ 			resolves.shift()();
-/******/ 		}
-/******/
-/******/ 	};
-/******/
-/******/ 	// The module cache
-/******/ 	var installedModules = {};
-/******/
-/******/ 	// objects to store loaded and loading chunks
-/******/ 	var installedChunks = {
-/******/ 		3: 0
-/******/ 	};
-/******/
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
-/******/
-/******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId]) {
-/******/ 			return installedModules[moduleId].exports;
-/******/ 		}
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = installedModules[moduleId] = {
-/******/ 			i: moduleId,
-/******/ 			l: false,
-/******/ 			exports: {}
-/******/ 		};
-/******/
-/******/ 		// Execute the module function
-/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
-/******/
-/******/ 		// Flag the module as loaded
-/******/ 		module.l = true;
-/******/
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
-/******/ 	}
-/******/
-/******/ 	// This file contains only the entry chunk.
-/******/ 	// The chunk loading function for additional chunks
-/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		var installedChunkData = installedChunks[chunkId];
-/******/ 		if(installedChunkData === 0) {
-/******/ 			return new Promise(function(resolve) { resolve(); });
-/******/ 		}
-/******/
-/******/ 		// a Promise means "currently loading".
-/******/ 		if(installedChunkData) {
-/******/ 			return installedChunkData[2];
-/******/ 		}
-/******/
-/******/ 		// setup Promise in chunk cache
-/******/ 		var promise = new Promise(function(resolve, reject) {
-/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
-/******/ 		});
-/******/ 		installedChunkData[2] = promise;
-/******/
-/******/ 		// start chunk loading
-/******/ 		var head = document.getElementsByTagName('head')[0];
-/******/ 		var script = document.createElement('script');
-/******/ 		script.type = 'text/javascript';
-/******/ 		script.charset = 'utf-8';
-/******/ 		script.async = true;
-/******/ 		script.timeout = 120000;
-/******/
-/******/ 		if (__webpack_require__.nc) {
-/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
-/******/ 		}
-/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
-/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
-/******/ 		script.onerror = script.onload = onScriptComplete;
-/******/ 		function onScriptComplete() {
-/******/ 			// avoid mem leaks in IE.
-/******/ 			script.onerror = script.onload = null;
-/******/ 			clearTimeout(timeout);
-/******/ 			var chunk = installedChunks[chunkId];
-/******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) {
-/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
-/******/ 				}
-/******/ 				installedChunks[chunkId] = undefined;
-/******/ 			}
-/******/ 		};
-/******/ 		head.appendChild(script);
-/******/
-/******/ 		return promise;
-/******/ 	};
-/******/
-/******/ 	// expose the modules object (__webpack_modules__)
-/******/ 	__webpack_require__.m = modules;
-/******/
-/******/ 	// expose the module cache
-/******/ 	__webpack_require__.c = installedModules;
-/******/
-/******/ 	// define getter function for harmony exports
-/******/ 	__webpack_require__.d = function(exports, name, getter) {
-/******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, {
-/******/ 				configurable: false,
-/******/ 				enumerable: true,
-/******/ 				get: getter
-/******/ 			});
-/******/ 		}
-/******/ 	};
-/******/
-/******/ 	// getDefaultExport function for compatibility with non-harmony modules
-/******/ 	__webpack_require__.n = function(module) {
-/******/ 		var getter = module && module.__esModule ?
-/******/ 			function getDefault() { return module['default']; } :
-/******/ 			function getModuleExports() { return module; };
-/******/ 		__webpack_require__.d(getter, 'a', getter);
-/******/ 		return getter;
-/******/ 	};
-/******/
-/******/ 	// Object.prototype.hasOwnProperty.call
-/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
-/******/
-/******/ 	// __webpack_public_path__
-/******/ 	__webpack_require__.p = "js/";
-/******/
-/******/ 	// on error function for async loading
-/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
-/******/
-/******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 1);
-/******/ })
-/************************************************************************/
-/******/ ([
-/* 0 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var main = function() {
-	console.log("Main class");
-	__webpack_require__.e/* require.ensure */(2).then((() => {
-		const page = __webpack_require__(4);
-		page();
-	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
-	__webpack_require__.e/* require.ensure */(1).then((() => {
-		const page = __webpack_require__(5);
-		page();
-	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
-};
-
-main();
-
-
-/***/ }),
-/* 1 */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(0);
-__webpack_require__(0);
-module.exports = __webpack_require__(2);
-
-
-/***/ }),
-/* 2 */
-/***/ (function(module, exports) {
-
-/******/ (function(modules) { // webpackBootstrap
-/******/ 	// install a JSONP callback for chunk loading
-/******/ 	var parentJsonpFunction = window["webpackJsonp"];
-/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
-/******/ 		// add "moreModules" to the modules object,
-/******/ 		// then flag all "chunkIds" as loaded and fire callback
-/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
-/******/ 		for(;i < chunkIds.length; i++) {
-/******/ 			chunkId = chunkIds[i];
-/******/ 			if(installedChunks[chunkId]) {
-/******/ 				resolves.push(installedChunks[chunkId][0]);
-/******/ 			}
-/******/ 			installedChunks[chunkId] = 0;
-/******/ 		}
-/******/ 		for(moduleId in moreModules) {
-/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
-/******/ 				modules[moduleId] = moreModules[moduleId];
-/******/ 			}
-/******/ 		}
-/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
-/******/ 		while(resolves.length) {
-/******/ 			resolves.shift()();
-/******/ 		}
-/******/
-/******/ 	};
-/******/
-/******/ 	// The module cache
-/******/ 	var installedModules = {};
-/******/
-/******/ 	// objects to store loaded and loading chunks
-/******/ 	var installedChunks = {
-/******/ 		3: 0
-/******/ 	};
-/******/
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
-/******/
-/******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId]) {
-/******/ 			return installedModules[moduleId].exports;
-/******/ 		}
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = installedModules[moduleId] = {
-/******/ 			i: moduleId,
-/******/ 			l: false,
-/******/ 			exports: {}
-/******/ 		};
-/******/
-/******/ 		// Execute the module function
-/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
-/******/
-/******/ 		// Flag the module as loaded
-/******/ 		module.l = true;
-/******/
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
-/******/ 	}
-/******/
-/******/ 	// This file contains only the entry chunk.
-/******/ 	// The chunk loading function for additional chunks
-/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
-/******/ 		var installedChunkData = installedChunks[chunkId];
-/******/ 		if(installedChunkData === 0) {
-/******/ 			return new Promise(function(resolve) { resolve(); });
-/******/ 		}
-/******/
-/******/ 		// a Promise means "currently loading".
-/******/ 		if(installedChunkData) {
-/******/ 			return installedChunkData[2];
-/******/ 		}
-/******/
-/******/ 		// setup Promise in chunk cache
-/******/ 		var promise = new Promise(function(resolve, reject) {
-/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
-/******/ 		});
-/******/ 		installedChunkData[2] = promise;
-/******/
-/******/ 		// start chunk loading
-/******/ 		var head = document.getElementsByTagName('head')[0];
-/******/ 		var script = document.createElement('script');
-/******/ 		script.type = 'text/javascript';
-/******/ 		script.charset = 'utf-8';
-/******/ 		script.async = true;
-/******/ 		script.timeout = 120000;
-/******/
-/******/ 		if (__webpack_require__.nc) {
-/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
-/******/ 		}
-/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
-/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
-/******/ 		script.onerror = script.onload = onScriptComplete;
-/******/ 		function onScriptComplete() {
-/******/ 			// avoid mem leaks in IE.
-/******/ 			script.onerror = script.onload = null;
-/******/ 			clearTimeout(timeout);
-/******/ 			var chunk = installedChunks[chunkId];
-/******/ 			if(chunk !== 0) {
-/******/ 				if(chunk) {
-/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
-/******/ 				}
-/******/ 				installedChunks[chunkId] = undefined;
-/******/ 			}
-/******/ 		};
-/******/ 		head.appendChild(script);
-/******/
-/******/ 		return promise;
-/******/ 	};
-/******/
-/******/ 	// expose the modules object (__webpack_modules__)
-/******/ 	__webpack_require__.m = modules;
-/******/
-/******/ 	// expose the module cache
-/******/ 	__webpack_require__.c = installedModules;
-/******/
-/******/ 	// define getter function for harmony exports
-/******/ 	__webpack_require__.d = function(exports, name, getter) {
-/******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, {
-/******/ 				configurable: false,
-/******/ 				enumerable: true,
-/******/ 				get: getter
-/******/ 			});
-/******/ 		}
-/******/ 	};
-/******/
-/******/ 	// getDefaultExport function for compatibility with non-harmony modules
-/******/ 	__webpack_require__.n = function(module) {
-/******/ 		var getter = module && module.__esModule ?
-/******/ 			function getDefault() { return module['default']; } :
-/******/ 			function getModuleExports() { return module; };
-/******/ 		__webpack_require__.d(getter, 'a', getter);
-/******/ 		return getter;
-/******/ 	};
-/******/
-/******/ 	// Object.prototype.hasOwnProperty.call
-/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
-/******/
-/******/ 	// __webpack_public_path__
-/******/ 	__webpack_require__.p = "js/";
-/******/
-/******/ 	// on error function for async loading
-/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
-/******/
-/******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 1);
-/******/ })
-/************************************************************************/
-/******/ ([
-/* 0 */
-/*!********************!*\
-  !*** ./example.js ***!
-  \********************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports, __webpack_require__) {
-
-var main = function() {
-	console.log("Main class");
-	__webpack_require__.e/* require.ensure */(2).then((() => {
-		const page = __webpack_require__(/*! ./pageA */ 3);
-		page();
-	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
-	__webpack_require__.e/* require.ensure */(1).then((() => {
-		const page = __webpack_require__(/*! ./pageB */ 4);
-		page();
-	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
-};
-
-main();
-
-
-/***/ }),
-/* 1 */
-/*!***************************************!*\
-  !*** multi ./example.js ./example.js ***!
-  \***************************************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(/*! ./example.js */0);
-module.exports = __webpack_require__(/*! .\example.js */0);
-
-
-/***/ }),
-/* 2 */
-/*!******************************!*\
-  !*** ./reusableComponent.js ***!
-  \******************************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports) {
-
-module.exports = function() {
-	console.log("reusable Component");
-};
-
-
-/***/ })
-/******/ ]);
-
-/***/ }),
-/* 3 */
-/***/ (function(module, exports) {
-
-module.exports = function() {
-	console.log("reusable Component");
-};
-
-
-/***/ })
-/******/ ]);
-
-/***/ }),
-/* 3 */
-/*!******************************!*\
-  !*** ./reusableComponent.js ***!
-  \******************************/
-/*! no static exports found */
-/*! all exports used */
-/***/ (function(module, exports) {
-
-module.exports = function() {
-	console.log("reusable Component");
-};
-
-
-/***/ })
-/******/ ]);
-
-/***/ }),
-/* 3 */
-/***/ (function(module, exports) {
-
-module.exports = function() {
-	console.log("reusable Component");
-};
-
-
-/***/ })
-/******/ ]);
 
 /***/ })
 /******/ ]);
@@ -2219,7 +610,7 @@ module.exports = function() {
 ``` javascript
 webpackJsonp([0],{
 
-/***/ 5:
+/***/ 4:
 /*!******************************!*\
   !*** ./reusableComponent.js ***!
   \******************************/
@@ -2242,7 +633,7 @@ module.exports = function() {
 ``` javascript
 webpackJsonp([1],{
 
-/***/ 4:
+/***/ 3:
 /*!******************!*\
   !*** ./pageB.js ***!
   \******************/
@@ -2253,7 +644,7 @@ webpackJsonp([1],{
 module.exports = function() {
 	console.log("Page B");
 	Promise.all/* require.ensure */([__webpack_require__.e(0), __webpack_require__.e(3)]).then((()=>{
-		const page = __webpack_require__(/*! ./pageC */ 6);
+		const page = __webpack_require__(/*! ./pageC */ 5);
 		page();
 	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
 };
@@ -2269,7 +660,7 @@ module.exports = function() {
 ``` javascript
 webpackJsonp([2],{
 
-/***/ 3:
+/***/ 2:
 /*!******************!*\
   !*** ./pageA.js ***!
   \******************/
@@ -2277,7 +668,7 @@ webpackJsonp([2],{
 /*! all exports used */
 /***/ (function(module, exports, __webpack_require__) {
 
-var reusableComponent = __webpack_require__(/*! ./reusableComponent */ 5);
+var reusableComponent = __webpack_require__(/*! ./reusableComponent */ 4);
 
 module.exports = function() {
 	console.log("Page A");
@@ -2295,7 +686,7 @@ module.exports = function() {
 ``` javascript
 webpackJsonp([3],{
 
-/***/ 6:
+/***/ 5:
 /*!******************!*\
   !*** ./pageC.js ***!
   \******************/
@@ -2303,7 +694,7 @@ webpackJsonp([3],{
 /*! all exports used */
 /***/ (function(module, exports, __webpack_require__) {
 
-var reusableComponent = __webpack_require__(/*! ./reusableComponent */ 5);
+var reusableComponent = __webpack_require__(/*! ./reusableComponent */ 4);
 
 module.exports = function() {
 	console.log("Page C");
@@ -2321,157 +712,145 @@ module.exports = function() {
 ## Uncompressed
 
 ```
-Hash: 5566a60d53497fc227db049be214a9c917f17307
+Hash: 777f989f517d7831d56f1d268f47bc8703ad9f73
 Version: webpack 3.6.0
 Child
-    Hash: 5566a60d53497fc227db
+    Hash: 777f989f517d7831d56f
           Asset       Size  Chunks             Chunk Names
     0.output.js  388 bytes       0  [emitted]  
     1.output.js  481 bytes       1  [emitted]  
     2.output.js  388 bytes       2  [emitted]  
-      output.js      35 kB       3  [emitted]  main
+      output.js    6.95 kB       3  [emitted]  main
     Entrypoint main = output.js
     chunk    {0} 0.output.js 142 bytes {3} [rendered]
-        > [5] ./pageB.js 3:1-6:3
-        [6] ./pageC.js 142 bytes {0} [built]
-            cjs require ./pageC [5] ./pageB.js 4:15-33
+        > [4] ./pageB.js 3:1-6:3
+        [5] ./pageC.js 142 bytes {0} [built]
+            cjs require ./pageC [4] ./pageB.js 4:15-33
     chunk    {1} 1.output.js 140 bytes {3} [rendered]
-        > [0] ./example.js 7:1-10:3
-        [5] ./pageB.js 140 bytes {1} [built]
-            cjs require ./pageB [0] ./example.js 8:15-33
+        > [1] ./example.js 7:1-10:3
+        [4] ./pageB.js 140 bytes {1} [built]
+            cjs require ./pageB [1] ./example.js 8:15-33
     chunk    {2} 2.output.js 142 bytes {3} [rendered]
-        > [0] ./example.js 3:1-6:3
-        [4] ./pageA.js 142 bytes {2} [built]
-            cjs require ./pageA [0] ./example.js 4:15-33
-    chunk    {3} output.js (main) 28 kB [entry] [rendered]
-        > main [1] multi ./example.js ./example.js ./js/output.js 
-        [0] ./example.js 233 bytes {3} [built]
-            single entry ./example.js [1] multi ./example.js ./example.js ./js/output.js main:100000
-            single entry .\example.js [1] multi ./example.js ./example.js ./js/output.js main:100001
-        [1] multi ./example.js ./example.js ./js/output.js 52 bytes {3} [built]
-        [2] ./js/output.js 27.6 kB {3} [built]
-            single entry .\js\output.js [1] multi ./example.js ./example.js ./js/output.js main:100002
-        [3] ./reusableComponent.js 72 bytes {3} [built]
-            cjs require ./reusableComponent [4] ./pageA.js 1:24-54
-            cjs require ./reusableComponent [6] ./pageC.js 1:24-54
+        > [1] ./example.js 3:1-6:3
+        [3] ./pageA.js 142 bytes {2} [built]
+            cjs require ./pageA [1] ./example.js 4:15-33
+    chunk    {3} output.js (main) 333 bytes [entry] [rendered]
+        > main [0] multi ./example.js 
+        [0] multi ./example.js 28 bytes {3} [built]
+        [1] ./example.js 233 bytes {3} [built]
+            single entry ./example.js [0] multi ./example.js main:100000
+        [2] ./reusableComponent.js 72 bytes {3} [built]
+            cjs require ./reusableComponent [3] ./pageA.js 1:24-54
+            cjs require ./reusableComponent [5] ./pageC.js 1:24-54
 Child
-    Hash: 049be214a9c917f17307
+    Hash: 1d268f47bc8703ad9f73
                Asset       Size  Chunks             Chunk Names
     0.asyncoutput.js  314 bytes       0  [emitted]  
     1.asyncoutput.js  522 bytes       1  [emitted]  
     2.asyncoutput.js  388 bytes       2  [emitted]  
     3.asyncoutput.js  388 bytes       3  [emitted]  
-      asyncoutput.js    34.8 kB       4  [emitted]  main
+      asyncoutput.js     6.7 kB       4  [emitted]  main
     Entrypoint main = asyncoutput.js
     chunk    {0} 0.asyncoutput.js 72 bytes {4} [rendered]
-        > async commons [0] ./example.js 3:1-6:3
-        > async commons [4] ./pageB.js 3:1-6:3
-        [5] ./reusableComponent.js 72 bytes {0} [built]
-            cjs require ./reusableComponent [3] ./pageA.js 1:24-54
-            cjs require ./reusableComponent [6] ./pageC.js 1:24-54
+        > async commons [1] ./example.js 3:1-6:3
+        > async commons [3] ./pageB.js 3:1-6:3
+        [4] ./reusableComponent.js 72 bytes {0} [built]
+            cjs require ./reusableComponent [2] ./pageA.js 1:24-54
+            cjs require ./reusableComponent [5] ./pageC.js 1:24-54
     chunk    {1} 1.asyncoutput.js 140 bytes {4} [rendered]
-        > [0] ./example.js 7:1-10:3
-        [4] ./pageB.js 140 bytes {1} [built]
-            cjs require ./pageB [0] ./example.js 8:15-33
+        > [1] ./example.js 7:1-10:3
+        [3] ./pageB.js 140 bytes {1} [built]
+            cjs require ./pageB [1] ./example.js 8:15-33
     chunk    {2} 2.asyncoutput.js 142 bytes {4} [rendered]
-        > [0] ./example.js 3:1-6:3
-        [3] ./pageA.js 142 bytes {2} [built]
-            cjs require ./pageA [0] ./example.js 4:15-33
+        > [1] ./example.js 3:1-6:3
+        [2] ./pageA.js 142 bytes {2} [built]
+            cjs require ./pageA [1] ./example.js 4:15-33
     chunk    {3} 3.asyncoutput.js 142 bytes {1} [rendered]
-        > [4] ./pageB.js 3:1-6:3
-        [6] ./pageC.js 142 bytes {3} [built]
-            cjs require ./pageC [4] ./pageB.js 4:15-33
-    chunk    {4} asyncoutput.js (main) 27.9 kB [entry] [rendered]
-        > main [1] multi ./example.js ./example.js ./js/output.js 
-        [0] ./example.js 233 bytes {4} [built]
-            single entry ./example.js [1] multi ./example.js ./example.js ./js/output.js main:100000
-            single entry .\example.js [1] multi ./example.js ./example.js ./js/output.js main:100001
-        [1] multi ./example.js ./example.js ./js/output.js 52 bytes {4} [built]
-        [2] ./js/output.js 27.6 kB {4} [built]
-            single entry .\js\output.js [1] multi ./example.js ./example.js ./js/output.js main:100002
+        > [3] ./pageB.js 3:1-6:3
+        [5] ./pageC.js 142 bytes {3} [built]
+            cjs require ./pageC [3] ./pageB.js 4:15-33
+    chunk    {4} asyncoutput.js (main) 261 bytes [entry] [rendered]
+        > main [0] multi ./example.js 
+        [0] multi ./example.js 28 bytes {4} [built]
+        [1] ./example.js 233 bytes {4} [built]
+            single entry ./example.js [0] multi ./example.js main:100000
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: 6da2284b85eb94fe413c441b1a1e2d3dbb9961d8
+Hash: 777f989f517d7831d56f1d268f47bc8703ad9f73
 Version: webpack 3.6.0
 Child
-    Hash: 6da2284b85eb94fe413c
+    Hash: 777f989f517d7831d56f
           Asset       Size  Chunks             Chunk Names
     0.output.js   98 bytes       0  [emitted]  
     1.output.js  340 bytes       1  [emitted]  
     2.output.js   98 bytes       2  [emitted]  
-      output.js    27.6 kB       3  [emitted]  main
+      output.js    6.46 kB       3  [emitted]  main
     Entrypoint main = output.js
     chunk    {0} 0.output.js 142 bytes {3} [rendered]
-        > [5] ./pageB.js 3:1-6:3
-        [6] ./pageC.js 142 bytes {0} [built]
-            cjs require ./pageC [5] ./pageB.js 4:15-33
+        > [4] ./pageB.js 3:1-6:3
+        [5] ./pageC.js 142 bytes {0} [built]
+            cjs require ./pageC [4] ./pageB.js 4:15-33
     chunk    {1} 1.output.js 140 bytes {3} [rendered]
-        > [0] ./example.js 7:1-10:3
-        [5] ./pageB.js 140 bytes {1} [built]
-            cjs require ./pageB [0] ./example.js 8:15-33
+        > [1] ./example.js 7:1-10:3
+        [4] ./pageB.js 140 bytes {1} [built]
+            cjs require ./pageB [1] ./example.js 8:15-33
     chunk    {2} 2.output.js 142 bytes {3} [rendered]
-        > [0] ./example.js 3:1-6:3
-        [4] ./pageA.js 142 bytes {2} [built]
-            cjs require ./pageA [0] ./example.js 4:15-33
-    chunk    {3} output.js (main) 21.4 kB [entry] [rendered]
-        > main [1] multi ./example.js ./example.js ./js/output.js 
-        [0] ./example.js 233 bytes {3} [built]
-            single entry ./example.js [1] multi ./example.js ./example.js ./js/output.js main:100000
-            single entry .\example.js [1] multi ./example.js ./example.js ./js/output.js main:100001
-        [1] multi ./example.js ./example.js ./js/output.js 52 bytes {3} [built]
-        [2] ./js/output.js 21.1 kB {3} [built]
-            single entry .\js\output.js [1] multi ./example.js ./example.js ./js/output.js main:100002
-        [3] ./reusableComponent.js 72 bytes {3} [built]
-            cjs require ./reusableComponent [4] ./pageA.js 1:24-54
-            cjs require ./reusableComponent [6] ./pageC.js 1:24-54
+        > [1] ./example.js 3:1-6:3
+        [3] ./pageA.js 142 bytes {2} [built]
+            cjs require ./pageA [1] ./example.js 4:15-33
+    chunk    {3} output.js (main) 333 bytes [entry] [rendered]
+        > main [0] multi ./example.js 
+        [0] multi ./example.js 28 bytes {3} [built]
+        [1] ./example.js 233 bytes {3} [built]
+            single entry ./example.js [0] multi ./example.js main:100000
+        [2] ./reusableComponent.js 72 bytes {3} [built]
+            cjs require ./reusableComponent [3] ./pageA.js 1:24-54
+            cjs require ./reusableComponent [5] ./pageC.js 1:24-54
     
     ERROR in 1.output.js from UglifyJs
     Unexpected token: punc ()) [1.output.js:8,53]
     
     ERROR in output.js from UglifyJs
-    Unexpected token: punc ()) [output.js:154,53]
+    Unexpected token: punc ()) [output.js:161,53]
 Child
-    Hash: 441b1a1e2d3dbb9961d8
+    Hash: 1d268f47bc8703ad9f73
                Asset       Size  Chunks             Chunk Names
     0.asyncoutput.js   93 bytes       0  [emitted]  
     1.asyncoutput.js  381 bytes       1  [emitted]  
     2.asyncoutput.js   98 bytes       2  [emitted]  
     3.asyncoutput.js   98 bytes       3  [emitted]  
-      asyncoutput.js    27.5 kB       4  [emitted]  main
+      asyncoutput.js    6.37 kB       4  [emitted]  main
     Entrypoint main = asyncoutput.js
     chunk    {0} 0.asyncoutput.js 72 bytes {4} [rendered]
-        > async commons [0] ./example.js 3:1-6:3
-        > async commons [4] ./pageB.js 3:1-6:3
-        [5] ./reusableComponent.js 72 bytes {0} [built]
-            cjs require ./reusableComponent [3] ./pageA.js 1:24-54
-            cjs require ./reusableComponent [6] ./pageC.js 1:24-54
+        > async commons [1] ./example.js 3:1-6:3
+        > async commons [3] ./pageB.js 3:1-6:3
+        [4] ./reusableComponent.js 72 bytes {0} [built]
+            cjs require ./reusableComponent [2] ./pageA.js 1:24-54
+            cjs require ./reusableComponent [5] ./pageC.js 1:24-54
     chunk    {1} 1.asyncoutput.js 140 bytes {4} [rendered]
-        > [0] ./example.js 7:1-10:3
-        [4] ./pageB.js 140 bytes {1} [built]
-            cjs require ./pageB [0] ./example.js 8:15-33
+        > [1] ./example.js 7:1-10:3
+        [3] ./pageB.js 140 bytes {1} [built]
+            cjs require ./pageB [1] ./example.js 8:15-33
     chunk    {2} 2.asyncoutput.js 142 bytes {4} [rendered]
-        > [0] ./example.js 3:1-6:3
-        [3] ./pageA.js 142 bytes {2} [built]
-            cjs require ./pageA [0] ./example.js 4:15-33
+        > [1] ./example.js 3:1-6:3
+        [2] ./pageA.js 142 bytes {2} [built]
+            cjs require ./pageA [1] ./example.js 4:15-33
     chunk    {3} 3.asyncoutput.js 142 bytes {1} [rendered]
-        > [4] ./pageB.js 3:1-6:3
-        [6] ./pageC.js 142 bytes {3} [built]
-            cjs require ./pageC [4] ./pageB.js 4:15-33
-    chunk    {4} asyncoutput.js (main) 21.3 kB [entry] [rendered]
-        > main [1] multi ./example.js ./example.js ./js/output.js 
-        [0] ./example.js 233 bytes {4} [built]
-            single entry ./example.js [1] multi ./example.js ./example.js ./js/output.js main:100000
-            single entry .\example.js [1] multi ./example.js ./example.js ./js/output.js main:100001
-        [1] multi ./example.js ./example.js ./js/output.js 52 bytes {4} [built]
-        [2] ./js/output.js 21.1 kB {4} [built]
-            single entry .\js\output.js [1] multi ./example.js ./example.js ./js/output.js main:100002
+        > [3] ./pageB.js 3:1-6:3
+        [5] ./pageC.js 142 bytes {3} [built]
+            cjs require ./pageC [3] ./pageB.js 4:15-33
+    chunk    {4} asyncoutput.js (main) 261 bytes [entry] [rendered]
+        > main [0] multi ./example.js 
+        [0] multi ./example.js 28 bytes {4} [built]
+        [1] ./example.js 233 bytes {4} [built]
+            single entry ./example.js [0] multi ./example.js main:100000
     
     ERROR in 1.asyncoutput.js from UglifyJs
     Unexpected token: punc ()) [1.asyncoutput.js:8,94]
     
     ERROR in asyncoutput.js from UglifyJs
-    Unexpected token: punc ()) [asyncoutput.js:154,94]
+    Unexpected token: punc ()) [asyncoutput.js:161,94]
 ```

--- a/examples/common-chunk-grandchildren/README.md
+++ b/examples/common-chunk-grandchildren/README.md
@@ -82,21 +82,46 @@ module.exports = function() {
 # webpack.config.js
 
 ``` javascript
-var webpack = require("../../");
+const webpack = require("../../");
+const path = require('path');
 
-module.exports = {
-	entry: {
-		main: ["./example.js"]
+module.exports = [
+	{
+		entry: {
+			main: ["./example.js"]
+		},
+		output: {
+			path: path.resolve(__dirname, 'js'),
+			filename: "output.js"
+		},
+		plugins: [
+			new webpack.optimize.CommonsChunkPlugin({
+				name: "main",
+				minChunks: 2,
+				children: true,
+				deepChildren: true,
+			})
+		]
 	},
-	plugins: [
-		new webpack.optimize.CommonsChunkPlugin({
-			name: "main",
-			minChunks: 2,
-			children: true,
-			deepChildren: true,
-		})
-	]
-};
+	{
+		entry: {
+			main: ["./example.js"]
+		},
+		output: {
+			path: path.resolve(__dirname, 'js'),
+			filename: "asyncoutput.js"
+		},
+		plugins: [
+			new webpack.optimize.CommonsChunkPlugin({
+				name: "main",
+				minChunks: 2,
+				async: true,
+				children: true,
+				deepChildren: true,
+			})
+		]
+	}
+];
 ```
 
 # js/output.js
@@ -268,6 +293,752 @@ module.exports = {
 var main = function() {
 	console.log("Main class");
 	__webpack_require__.e/* require.ensure */(2).then((() => {
+		const page = __webpack_require__(/*! ./pageA */ 4);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+	__webpack_require__.e/* require.ensure */(1).then((() => {
+		const page = __webpack_require__(/*! ./pageB */ 5);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+};
+
+main();
+
+
+/***/ }),
+/* 1 */
+/*!******************************************************!*\
+  !*** multi ./example.js ./example.js ./js/output.js ***!
+  \******************************************************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(/*! ./example.js */0);
+__webpack_require__(/*! .\example.js */0);
+module.exports = __webpack_require__(/*! .\js\output.js */2);
+
+
+/***/ }),
+/* 2 */
+/*!**********************!*\
+  !*** ./js/output.js ***!
+  \**********************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports) {
+
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// install a JSONP callback for chunk loading
+/******/ 	var parentJsonpFunction = window["webpackJsonp"];
+/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
+/******/ 		// add "moreModules" to the modules object,
+/******/ 		// then flag all "chunkIds" as loaded and fire callback
+/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
+/******/ 		for(;i < chunkIds.length; i++) {
+/******/ 			chunkId = chunkIds[i];
+/******/ 			if(installedChunks[chunkId]) {
+/******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
+/******/ 			installedChunks[chunkId] = 0;
+/******/ 		}
+/******/ 		for(moduleId in moreModules) {
+/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
+/******/ 				modules[moduleId] = moreModules[moduleId];
+/******/ 			}
+/******/ 		}
+/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
+/******/ 		while(resolves.length) {
+/******/ 			resolves.shift()();
+/******/ 		}
+/******/
+/******/ 	};
+/******/
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// objects to store loaded and loading chunks
+/******/ 	var installedChunks = {
+/******/ 		3: 0
+/******/ 	};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/ 	// This file contains only the entry chunk.
+/******/ 	// The chunk loading function for additional chunks
+/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
+/******/ 		var installedChunkData = installedChunks[chunkId];
+/******/ 		if(installedChunkData === 0) {
+/******/ 			return new Promise(function(resolve) { resolve(); });
+/******/ 		}
+/******/
+/******/ 		// a Promise means "currently loading".
+/******/ 		if(installedChunkData) {
+/******/ 			return installedChunkData[2];
+/******/ 		}
+/******/
+/******/ 		// setup Promise in chunk cache
+/******/ 		var promise = new Promise(function(resolve, reject) {
+/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
+/******/ 		});
+/******/ 		installedChunkData[2] = promise;
+/******/
+/******/ 		// start chunk loading
+/******/ 		var head = document.getElementsByTagName('head')[0];
+/******/ 		var script = document.createElement('script');
+/******/ 		script.type = 'text/javascript';
+/******/ 		script.charset = 'utf-8';
+/******/ 		script.async = true;
+/******/ 		script.timeout = 120000;
+/******/
+/******/ 		if (__webpack_require__.nc) {
+/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
+/******/ 		}
+/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
+/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
+/******/ 		script.onerror = script.onload = onScriptComplete;
+/******/ 		function onScriptComplete() {
+/******/ 			// avoid mem leaks in IE.
+/******/ 			script.onerror = script.onload = null;
+/******/ 			clearTimeout(timeout);
+/******/ 			var chunk = installedChunks[chunkId];
+/******/ 			if(chunk !== 0) {
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
+/******/ 				installedChunks[chunkId] = undefined;
+/******/ 			}
+/******/ 		};
+/******/ 		head.appendChild(script);
+/******/
+/******/ 		return promise;
+/******/ 	};
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "js/";
+/******/
+/******/ 	// on error function for async loading
+/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var main = function() {
+	console.log("Main class");
+	__webpack_require__.e/* require.ensure */(2).then((() => {
+		const page = __webpack_require__(4);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+	__webpack_require__.e/* require.ensure */(1).then((() => {
+		const page = __webpack_require__(5);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+};
+
+main();
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(0);
+__webpack_require__(0);
+module.exports = __webpack_require__(2);
+
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports) {
+
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// install a JSONP callback for chunk loading
+/******/ 	var parentJsonpFunction = window["webpackJsonp"];
+/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
+/******/ 		// add "moreModules" to the modules object,
+/******/ 		// then flag all "chunkIds" as loaded and fire callback
+/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
+/******/ 		for(;i < chunkIds.length; i++) {
+/******/ 			chunkId = chunkIds[i];
+/******/ 			if(installedChunks[chunkId]) {
+/******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
+/******/ 			installedChunks[chunkId] = 0;
+/******/ 		}
+/******/ 		for(moduleId in moreModules) {
+/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
+/******/ 				modules[moduleId] = moreModules[moduleId];
+/******/ 			}
+/******/ 		}
+/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
+/******/ 		while(resolves.length) {
+/******/ 			resolves.shift()();
+/******/ 		}
+/******/
+/******/ 	};
+/******/
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// objects to store loaded and loading chunks
+/******/ 	var installedChunks = {
+/******/ 		3: 0
+/******/ 	};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/ 	// This file contains only the entry chunk.
+/******/ 	// The chunk loading function for additional chunks
+/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
+/******/ 		var installedChunkData = installedChunks[chunkId];
+/******/ 		if(installedChunkData === 0) {
+/******/ 			return new Promise(function(resolve) { resolve(); });
+/******/ 		}
+/******/
+/******/ 		// a Promise means "currently loading".
+/******/ 		if(installedChunkData) {
+/******/ 			return installedChunkData[2];
+/******/ 		}
+/******/
+/******/ 		// setup Promise in chunk cache
+/******/ 		var promise = new Promise(function(resolve, reject) {
+/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
+/******/ 		});
+/******/ 		installedChunkData[2] = promise;
+/******/
+/******/ 		// start chunk loading
+/******/ 		var head = document.getElementsByTagName('head')[0];
+/******/ 		var script = document.createElement('script');
+/******/ 		script.type = 'text/javascript';
+/******/ 		script.charset = 'utf-8';
+/******/ 		script.async = true;
+/******/ 		script.timeout = 120000;
+/******/
+/******/ 		if (__webpack_require__.nc) {
+/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
+/******/ 		}
+/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
+/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
+/******/ 		script.onerror = script.onload = onScriptComplete;
+/******/ 		function onScriptComplete() {
+/******/ 			// avoid mem leaks in IE.
+/******/ 			script.onerror = script.onload = null;
+/******/ 			clearTimeout(timeout);
+/******/ 			var chunk = installedChunks[chunkId];
+/******/ 			if(chunk !== 0) {
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
+/******/ 				installedChunks[chunkId] = undefined;
+/******/ 			}
+/******/ 		};
+/******/ 		head.appendChild(script);
+/******/
+/******/ 		return promise;
+/******/ 	};
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "js/";
+/******/
+/******/ 	// on error function for async loading
+/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/*!********************!*\
+  !*** ./example.js ***!
+  \********************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+var main = function() {
+	console.log("Main class");
+	__webpack_require__.e/* require.ensure */(2).then((() => {
+		const page = __webpack_require__(/*! ./pageA */ 4);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+	__webpack_require__.e/* require.ensure */(1).then((() => {
+		const page = __webpack_require__(/*! ./pageB */ 5);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+};
+
+main();
+
+
+/***/ }),
+/* 1 */
+/*!******************************************************!*\
+  !*** multi ./example.js ./example.js ./js/output.js ***!
+  \******************************************************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(/*! ./example.js */0);
+__webpack_require__(/*! .\example.js */0);
+module.exports = __webpack_require__(/*! .\js\output.js */2);
+
+
+/***/ }),
+/* 2 */
+/*!**********************!*\
+  !*** ./js/output.js ***!
+  \**********************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports) {
+
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// install a JSONP callback for chunk loading
+/******/ 	var parentJsonpFunction = window["webpackJsonp"];
+/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
+/******/ 		// add "moreModules" to the modules object,
+/******/ 		// then flag all "chunkIds" as loaded and fire callback
+/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
+/******/ 		for(;i < chunkIds.length; i++) {
+/******/ 			chunkId = chunkIds[i];
+/******/ 			if(installedChunks[chunkId]) {
+/******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
+/******/ 			installedChunks[chunkId] = 0;
+/******/ 		}
+/******/ 		for(moduleId in moreModules) {
+/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
+/******/ 				modules[moduleId] = moreModules[moduleId];
+/******/ 			}
+/******/ 		}
+/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
+/******/ 		while(resolves.length) {
+/******/ 			resolves.shift()();
+/******/ 		}
+/******/
+/******/ 	};
+/******/
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// objects to store loaded and loading chunks
+/******/ 	var installedChunks = {
+/******/ 		3: 0
+/******/ 	};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/ 	// This file contains only the entry chunk.
+/******/ 	// The chunk loading function for additional chunks
+/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
+/******/ 		var installedChunkData = installedChunks[chunkId];
+/******/ 		if(installedChunkData === 0) {
+/******/ 			return new Promise(function(resolve) { resolve(); });
+/******/ 		}
+/******/
+/******/ 		// a Promise means "currently loading".
+/******/ 		if(installedChunkData) {
+/******/ 			return installedChunkData[2];
+/******/ 		}
+/******/
+/******/ 		// setup Promise in chunk cache
+/******/ 		var promise = new Promise(function(resolve, reject) {
+/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
+/******/ 		});
+/******/ 		installedChunkData[2] = promise;
+/******/
+/******/ 		// start chunk loading
+/******/ 		var head = document.getElementsByTagName('head')[0];
+/******/ 		var script = document.createElement('script');
+/******/ 		script.type = 'text/javascript';
+/******/ 		script.charset = 'utf-8';
+/******/ 		script.async = true;
+/******/ 		script.timeout = 120000;
+/******/
+/******/ 		if (__webpack_require__.nc) {
+/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
+/******/ 		}
+/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
+/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
+/******/ 		script.onerror = script.onload = onScriptComplete;
+/******/ 		function onScriptComplete() {
+/******/ 			// avoid mem leaks in IE.
+/******/ 			script.onerror = script.onload = null;
+/******/ 			clearTimeout(timeout);
+/******/ 			var chunk = installedChunks[chunkId];
+/******/ 			if(chunk !== 0) {
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
+/******/ 				installedChunks[chunkId] = undefined;
+/******/ 			}
+/******/ 		};
+/******/ 		head.appendChild(script);
+/******/
+/******/ 		return promise;
+/******/ 	};
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "js/";
+/******/
+/******/ 	// on error function for async loading
+/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var main = function() {
+	console.log("Main class");
+	__webpack_require__.e/* require.ensure */(2).then((() => {
+		const page = __webpack_require__(4);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+	__webpack_require__.e/* require.ensure */(1).then((() => {
+		const page = __webpack_require__(5);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+};
+
+main();
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(0);
+__webpack_require__(0);
+module.exports = __webpack_require__(2);
+
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports) {
+
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// install a JSONP callback for chunk loading
+/******/ 	var parentJsonpFunction = window["webpackJsonp"];
+/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
+/******/ 		// add "moreModules" to the modules object,
+/******/ 		// then flag all "chunkIds" as loaded and fire callback
+/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
+/******/ 		for(;i < chunkIds.length; i++) {
+/******/ 			chunkId = chunkIds[i];
+/******/ 			if(installedChunks[chunkId]) {
+/******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
+/******/ 			installedChunks[chunkId] = 0;
+/******/ 		}
+/******/ 		for(moduleId in moreModules) {
+/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
+/******/ 				modules[moduleId] = moreModules[moduleId];
+/******/ 			}
+/******/ 		}
+/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
+/******/ 		while(resolves.length) {
+/******/ 			resolves.shift()();
+/******/ 		}
+/******/
+/******/ 	};
+/******/
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// objects to store loaded and loading chunks
+/******/ 	var installedChunks = {
+/******/ 		3: 0
+/******/ 	};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/ 	// This file contains only the entry chunk.
+/******/ 	// The chunk loading function for additional chunks
+/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
+/******/ 		var installedChunkData = installedChunks[chunkId];
+/******/ 		if(installedChunkData === 0) {
+/******/ 			return new Promise(function(resolve) { resolve(); });
+/******/ 		}
+/******/
+/******/ 		// a Promise means "currently loading".
+/******/ 		if(installedChunkData) {
+/******/ 			return installedChunkData[2];
+/******/ 		}
+/******/
+/******/ 		// setup Promise in chunk cache
+/******/ 		var promise = new Promise(function(resolve, reject) {
+/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
+/******/ 		});
+/******/ 		installedChunkData[2] = promise;
+/******/
+/******/ 		// start chunk loading
+/******/ 		var head = document.getElementsByTagName('head')[0];
+/******/ 		var script = document.createElement('script');
+/******/ 		script.type = 'text/javascript';
+/******/ 		script.charset = 'utf-8';
+/******/ 		script.async = true;
+/******/ 		script.timeout = 120000;
+/******/
+/******/ 		if (__webpack_require__.nc) {
+/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
+/******/ 		}
+/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
+/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
+/******/ 		script.onerror = script.onload = onScriptComplete;
+/******/ 		function onScriptComplete() {
+/******/ 			// avoid mem leaks in IE.
+/******/ 			script.onerror = script.onload = null;
+/******/ 			clearTimeout(timeout);
+/******/ 			var chunk = installedChunks[chunkId];
+/******/ 			if(chunk !== 0) {
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
+/******/ 				installedChunks[chunkId] = undefined;
+/******/ 			}
+/******/ 		};
+/******/ 		head.appendChild(script);
+/******/
+/******/ 		return promise;
+/******/ 	};
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "js/";
+/******/
+/******/ 	// on error function for async loading
+/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/*!********************!*\
+  !*** ./example.js ***!
+  \********************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+var main = function() {
+	console.log("Main class");
+	__webpack_require__.e/* require.ensure */(2).then((() => {
 		const page = __webpack_require__(/*! ./pageA */ 3);
 		page();
 	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
@@ -309,6 +1080,64 @@ module.exports = function() {
 
 /***/ })
 /******/ ]);
+
+/***/ }),
+/* 3 */
+/***/ (function(module, exports) {
+
+module.exports = function() {
+	console.log("reusable Component");
+};
+
+
+/***/ })
+/******/ ]);
+
+/***/ }),
+/* 3 */
+/*!******************************!*\
+  !*** ./reusableComponent.js ***!
+  \******************************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports) {
+
+module.exports = function() {
+	console.log("reusable Component");
+};
+
+
+/***/ })
+/******/ ]);
+
+/***/ }),
+/* 3 */
+/***/ (function(module, exports) {
+
+module.exports = function() {
+	console.log("reusable Component");
+};
+
+
+/***/ })
+/******/ ]);
+
+/***/ }),
+/* 3 */
+/*!******************************!*\
+  !*** ./reusableComponent.js ***!
+  \******************************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports) {
+
+module.exports = function() {
+	console.log("reusable Component");
+};
+
+
+/***/ })
+/******/ ]);
 ```
 
 # js/0.output.js
@@ -316,7 +1145,7 @@ module.exports = function() {
 ``` javascript
 webpackJsonp([0],{
 
-/***/ 5:
+/***/ 6:
 /*!******************!*\
   !*** ./pageC.js ***!
   \******************/
@@ -324,7 +1153,7 @@ webpackJsonp([0],{
 /*! all exports used */
 /***/ (function(module, exports, __webpack_require__) {
 
-var reusableComponent = __webpack_require__(/*! ./reusableComponent */ 2);
+var reusableComponent = __webpack_require__(/*! ./reusableComponent */ 3);
 
 module.exports = function() {
 	console.log("Page C");
@@ -342,7 +1171,7 @@ module.exports = function() {
 ``` javascript
 webpackJsonp([1],{
 
-/***/ 4:
+/***/ 5:
 /*!******************!*\
   !*** ./pageB.js ***!
   \******************/
@@ -353,7 +1182,7 @@ webpackJsonp([1],{
 module.exports = function() {
 	console.log("Page B");
 	__webpack_require__.e/* require.ensure */(0).then((()=>{
-		const page = __webpack_require__(/*! ./pageC */ 5);
+		const page = __webpack_require__(/*! ./pageC */ 6);
 		page();
 	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
 };
@@ -369,6 +1198,1077 @@ module.exports = function() {
 ``` javascript
 webpackJsonp([2],{
 
+/***/ 4:
+/*!******************!*\
+  !*** ./pageA.js ***!
+  \******************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+var reusableComponent = __webpack_require__(/*! ./reusableComponent */ 3);
+
+module.exports = function() {
+	console.log("Page A");
+	reusableComponent();
+};
+
+
+/***/ })
+
+});
+```
+
+# js/asyncoutput.js
+
+``` javascript
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// install a JSONP callback for chunk loading
+/******/ 	var parentJsonpFunction = window["webpackJsonp"];
+/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
+/******/ 		// add "moreModules" to the modules object,
+/******/ 		// then flag all "chunkIds" as loaded and fire callback
+/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
+/******/ 		for(;i < chunkIds.length; i++) {
+/******/ 			chunkId = chunkIds[i];
+/******/ 			if(installedChunks[chunkId]) {
+/******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
+/******/ 			installedChunks[chunkId] = 0;
+/******/ 		}
+/******/ 		for(moduleId in moreModules) {
+/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
+/******/ 				modules[moduleId] = moreModules[moduleId];
+/******/ 			}
+/******/ 		}
+/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
+/******/ 		while(resolves.length) {
+/******/ 			resolves.shift()();
+/******/ 		}
+/******/
+/******/ 	};
+/******/
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// objects to store loaded and loading chunks
+/******/ 	var installedChunks = {
+/******/ 		4: 0
+/******/ 	};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/ 	// This file contains only the entry chunk.
+/******/ 	// The chunk loading function for additional chunks
+/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
+/******/ 		var installedChunkData = installedChunks[chunkId];
+/******/ 		if(installedChunkData === 0) {
+/******/ 			return new Promise(function(resolve) { resolve(); });
+/******/ 		}
+/******/
+/******/ 		// a Promise means "currently loading".
+/******/ 		if(installedChunkData) {
+/******/ 			return installedChunkData[2];
+/******/ 		}
+/******/
+/******/ 		// setup Promise in chunk cache
+/******/ 		var promise = new Promise(function(resolve, reject) {
+/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
+/******/ 		});
+/******/ 		installedChunkData[2] = promise;
+/******/
+/******/ 		// start chunk loading
+/******/ 		var head = document.getElementsByTagName('head')[0];
+/******/ 		var script = document.createElement('script');
+/******/ 		script.type = 'text/javascript';
+/******/ 		script.charset = 'utf-8';
+/******/ 		script.async = true;
+/******/ 		script.timeout = 120000;
+/******/
+/******/ 		if (__webpack_require__.nc) {
+/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
+/******/ 		}
+/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".asyncoutput.js";
+/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
+/******/ 		script.onerror = script.onload = onScriptComplete;
+/******/ 		function onScriptComplete() {
+/******/ 			// avoid mem leaks in IE.
+/******/ 			script.onerror = script.onload = null;
+/******/ 			clearTimeout(timeout);
+/******/ 			var chunk = installedChunks[chunkId];
+/******/ 			if(chunk !== 0) {
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
+/******/ 				installedChunks[chunkId] = undefined;
+/******/ 			}
+/******/ 		};
+/******/ 		head.appendChild(script);
+/******/
+/******/ 		return promise;
+/******/ 	};
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "js/";
+/******/
+/******/ 	// on error function for async loading
+/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/*!********************!*\
+  !*** ./example.js ***!
+  \********************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+var main = function() {
+	console.log("Main class");
+	Promise.all/* require.ensure */([__webpack_require__.e(0), __webpack_require__.e(2)]).then((() => {
+		const page = __webpack_require__(/*! ./pageA */ 3);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+	__webpack_require__.e/* require.ensure */(1).then((() => {
+		const page = __webpack_require__(/*! ./pageB */ 4);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+};
+
+main();
+
+
+/***/ }),
+/* 1 */
+/*!******************************************************!*\
+  !*** multi ./example.js ./example.js ./js/output.js ***!
+  \******************************************************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(/*! ./example.js */0);
+__webpack_require__(/*! .\example.js */0);
+module.exports = __webpack_require__(/*! .\js\output.js */2);
+
+
+/***/ }),
+/* 2 */
+/*!**********************!*\
+  !*** ./js/output.js ***!
+  \**********************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports) {
+
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// install a JSONP callback for chunk loading
+/******/ 	var parentJsonpFunction = window["webpackJsonp"];
+/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
+/******/ 		// add "moreModules" to the modules object,
+/******/ 		// then flag all "chunkIds" as loaded and fire callback
+/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
+/******/ 		for(;i < chunkIds.length; i++) {
+/******/ 			chunkId = chunkIds[i];
+/******/ 			if(installedChunks[chunkId]) {
+/******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
+/******/ 			installedChunks[chunkId] = 0;
+/******/ 		}
+/******/ 		for(moduleId in moreModules) {
+/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
+/******/ 				modules[moduleId] = moreModules[moduleId];
+/******/ 			}
+/******/ 		}
+/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
+/******/ 		while(resolves.length) {
+/******/ 			resolves.shift()();
+/******/ 		}
+/******/
+/******/ 	};
+/******/
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// objects to store loaded and loading chunks
+/******/ 	var installedChunks = {
+/******/ 		3: 0
+/******/ 	};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/ 	// This file contains only the entry chunk.
+/******/ 	// The chunk loading function for additional chunks
+/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
+/******/ 		var installedChunkData = installedChunks[chunkId];
+/******/ 		if(installedChunkData === 0) {
+/******/ 			return new Promise(function(resolve) { resolve(); });
+/******/ 		}
+/******/
+/******/ 		// a Promise means "currently loading".
+/******/ 		if(installedChunkData) {
+/******/ 			return installedChunkData[2];
+/******/ 		}
+/******/
+/******/ 		// setup Promise in chunk cache
+/******/ 		var promise = new Promise(function(resolve, reject) {
+/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
+/******/ 		});
+/******/ 		installedChunkData[2] = promise;
+/******/
+/******/ 		// start chunk loading
+/******/ 		var head = document.getElementsByTagName('head')[0];
+/******/ 		var script = document.createElement('script');
+/******/ 		script.type = 'text/javascript';
+/******/ 		script.charset = 'utf-8';
+/******/ 		script.async = true;
+/******/ 		script.timeout = 120000;
+/******/
+/******/ 		if (__webpack_require__.nc) {
+/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
+/******/ 		}
+/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
+/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
+/******/ 		script.onerror = script.onload = onScriptComplete;
+/******/ 		function onScriptComplete() {
+/******/ 			// avoid mem leaks in IE.
+/******/ 			script.onerror = script.onload = null;
+/******/ 			clearTimeout(timeout);
+/******/ 			var chunk = installedChunks[chunkId];
+/******/ 			if(chunk !== 0) {
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
+/******/ 				installedChunks[chunkId] = undefined;
+/******/ 			}
+/******/ 		};
+/******/ 		head.appendChild(script);
+/******/
+/******/ 		return promise;
+/******/ 	};
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "js/";
+/******/
+/******/ 	// on error function for async loading
+/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var main = function() {
+	console.log("Main class");
+	__webpack_require__.e/* require.ensure */(2).then((() => {
+		const page = __webpack_require__(4);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+	__webpack_require__.e/* require.ensure */(1).then((() => {
+		const page = __webpack_require__(5);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+};
+
+main();
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(0);
+__webpack_require__(0);
+module.exports = __webpack_require__(2);
+
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports) {
+
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// install a JSONP callback for chunk loading
+/******/ 	var parentJsonpFunction = window["webpackJsonp"];
+/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
+/******/ 		// add "moreModules" to the modules object,
+/******/ 		// then flag all "chunkIds" as loaded and fire callback
+/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
+/******/ 		for(;i < chunkIds.length; i++) {
+/******/ 			chunkId = chunkIds[i];
+/******/ 			if(installedChunks[chunkId]) {
+/******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
+/******/ 			installedChunks[chunkId] = 0;
+/******/ 		}
+/******/ 		for(moduleId in moreModules) {
+/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
+/******/ 				modules[moduleId] = moreModules[moduleId];
+/******/ 			}
+/******/ 		}
+/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
+/******/ 		while(resolves.length) {
+/******/ 			resolves.shift()();
+/******/ 		}
+/******/
+/******/ 	};
+/******/
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// objects to store loaded and loading chunks
+/******/ 	var installedChunks = {
+/******/ 		3: 0
+/******/ 	};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/ 	// This file contains only the entry chunk.
+/******/ 	// The chunk loading function for additional chunks
+/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
+/******/ 		var installedChunkData = installedChunks[chunkId];
+/******/ 		if(installedChunkData === 0) {
+/******/ 			return new Promise(function(resolve) { resolve(); });
+/******/ 		}
+/******/
+/******/ 		// a Promise means "currently loading".
+/******/ 		if(installedChunkData) {
+/******/ 			return installedChunkData[2];
+/******/ 		}
+/******/
+/******/ 		// setup Promise in chunk cache
+/******/ 		var promise = new Promise(function(resolve, reject) {
+/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
+/******/ 		});
+/******/ 		installedChunkData[2] = promise;
+/******/
+/******/ 		// start chunk loading
+/******/ 		var head = document.getElementsByTagName('head')[0];
+/******/ 		var script = document.createElement('script');
+/******/ 		script.type = 'text/javascript';
+/******/ 		script.charset = 'utf-8';
+/******/ 		script.async = true;
+/******/ 		script.timeout = 120000;
+/******/
+/******/ 		if (__webpack_require__.nc) {
+/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
+/******/ 		}
+/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
+/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
+/******/ 		script.onerror = script.onload = onScriptComplete;
+/******/ 		function onScriptComplete() {
+/******/ 			// avoid mem leaks in IE.
+/******/ 			script.onerror = script.onload = null;
+/******/ 			clearTimeout(timeout);
+/******/ 			var chunk = installedChunks[chunkId];
+/******/ 			if(chunk !== 0) {
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
+/******/ 				installedChunks[chunkId] = undefined;
+/******/ 			}
+/******/ 		};
+/******/ 		head.appendChild(script);
+/******/
+/******/ 		return promise;
+/******/ 	};
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "js/";
+/******/
+/******/ 	// on error function for async loading
+/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/*!********************!*\
+  !*** ./example.js ***!
+  \********************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+var main = function() {
+	console.log("Main class");
+	__webpack_require__.e/* require.ensure */(2).then((() => {
+		const page = __webpack_require__(/*! ./pageA */ 4);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+	__webpack_require__.e/* require.ensure */(1).then((() => {
+		const page = __webpack_require__(/*! ./pageB */ 5);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+};
+
+main();
+
+
+/***/ }),
+/* 1 */
+/*!******************************************************!*\
+  !*** multi ./example.js ./example.js ./js/output.js ***!
+  \******************************************************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(/*! ./example.js */0);
+__webpack_require__(/*! .\example.js */0);
+module.exports = __webpack_require__(/*! .\js\output.js */2);
+
+
+/***/ }),
+/* 2 */
+/*!**********************!*\
+  !*** ./js/output.js ***!
+  \**********************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports) {
+
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// install a JSONP callback for chunk loading
+/******/ 	var parentJsonpFunction = window["webpackJsonp"];
+/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
+/******/ 		// add "moreModules" to the modules object,
+/******/ 		// then flag all "chunkIds" as loaded and fire callback
+/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
+/******/ 		for(;i < chunkIds.length; i++) {
+/******/ 			chunkId = chunkIds[i];
+/******/ 			if(installedChunks[chunkId]) {
+/******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
+/******/ 			installedChunks[chunkId] = 0;
+/******/ 		}
+/******/ 		for(moduleId in moreModules) {
+/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
+/******/ 				modules[moduleId] = moreModules[moduleId];
+/******/ 			}
+/******/ 		}
+/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
+/******/ 		while(resolves.length) {
+/******/ 			resolves.shift()();
+/******/ 		}
+/******/
+/******/ 	};
+/******/
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// objects to store loaded and loading chunks
+/******/ 	var installedChunks = {
+/******/ 		3: 0
+/******/ 	};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/ 	// This file contains only the entry chunk.
+/******/ 	// The chunk loading function for additional chunks
+/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
+/******/ 		var installedChunkData = installedChunks[chunkId];
+/******/ 		if(installedChunkData === 0) {
+/******/ 			return new Promise(function(resolve) { resolve(); });
+/******/ 		}
+/******/
+/******/ 		// a Promise means "currently loading".
+/******/ 		if(installedChunkData) {
+/******/ 			return installedChunkData[2];
+/******/ 		}
+/******/
+/******/ 		// setup Promise in chunk cache
+/******/ 		var promise = new Promise(function(resolve, reject) {
+/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
+/******/ 		});
+/******/ 		installedChunkData[2] = promise;
+/******/
+/******/ 		// start chunk loading
+/******/ 		var head = document.getElementsByTagName('head')[0];
+/******/ 		var script = document.createElement('script');
+/******/ 		script.type = 'text/javascript';
+/******/ 		script.charset = 'utf-8';
+/******/ 		script.async = true;
+/******/ 		script.timeout = 120000;
+/******/
+/******/ 		if (__webpack_require__.nc) {
+/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
+/******/ 		}
+/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
+/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
+/******/ 		script.onerror = script.onload = onScriptComplete;
+/******/ 		function onScriptComplete() {
+/******/ 			// avoid mem leaks in IE.
+/******/ 			script.onerror = script.onload = null;
+/******/ 			clearTimeout(timeout);
+/******/ 			var chunk = installedChunks[chunkId];
+/******/ 			if(chunk !== 0) {
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
+/******/ 				installedChunks[chunkId] = undefined;
+/******/ 			}
+/******/ 		};
+/******/ 		head.appendChild(script);
+/******/
+/******/ 		return promise;
+/******/ 	};
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "js/";
+/******/
+/******/ 	// on error function for async loading
+/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var main = function() {
+	console.log("Main class");
+	__webpack_require__.e/* require.ensure */(2).then((() => {
+		const page = __webpack_require__(4);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+	__webpack_require__.e/* require.ensure */(1).then((() => {
+		const page = __webpack_require__(5);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+};
+
+main();
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(0);
+__webpack_require__(0);
+module.exports = __webpack_require__(2);
+
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports) {
+
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// install a JSONP callback for chunk loading
+/******/ 	var parentJsonpFunction = window["webpackJsonp"];
+/******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules, executeModules) {
+/******/ 		// add "moreModules" to the modules object,
+/******/ 		// then flag all "chunkIds" as loaded and fire callback
+/******/ 		var moduleId, chunkId, i = 0, resolves = [], result;
+/******/ 		for(;i < chunkIds.length; i++) {
+/******/ 			chunkId = chunkIds[i];
+/******/ 			if(installedChunks[chunkId]) {
+/******/ 				resolves.push(installedChunks[chunkId][0]);
+/******/ 			}
+/******/ 			installedChunks[chunkId] = 0;
+/******/ 		}
+/******/ 		for(moduleId in moreModules) {
+/******/ 			if(Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
+/******/ 				modules[moduleId] = moreModules[moduleId];
+/******/ 			}
+/******/ 		}
+/******/ 		if(parentJsonpFunction) parentJsonpFunction(chunkIds, moreModules, executeModules);
+/******/ 		while(resolves.length) {
+/******/ 			resolves.shift()();
+/******/ 		}
+/******/
+/******/ 	};
+/******/
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// objects to store loaded and loading chunks
+/******/ 	var installedChunks = {
+/******/ 		3: 0
+/******/ 	};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/ 	// This file contains only the entry chunk.
+/******/ 	// The chunk loading function for additional chunks
+/******/ 	__webpack_require__.e = function requireEnsure(chunkId) {
+/******/ 		var installedChunkData = installedChunks[chunkId];
+/******/ 		if(installedChunkData === 0) {
+/******/ 			return new Promise(function(resolve) { resolve(); });
+/******/ 		}
+/******/
+/******/ 		// a Promise means "currently loading".
+/******/ 		if(installedChunkData) {
+/******/ 			return installedChunkData[2];
+/******/ 		}
+/******/
+/******/ 		// setup Promise in chunk cache
+/******/ 		var promise = new Promise(function(resolve, reject) {
+/******/ 			installedChunkData = installedChunks[chunkId] = [resolve, reject];
+/******/ 		});
+/******/ 		installedChunkData[2] = promise;
+/******/
+/******/ 		// start chunk loading
+/******/ 		var head = document.getElementsByTagName('head')[0];
+/******/ 		var script = document.createElement('script');
+/******/ 		script.type = 'text/javascript';
+/******/ 		script.charset = 'utf-8';
+/******/ 		script.async = true;
+/******/ 		script.timeout = 120000;
+/******/
+/******/ 		if (__webpack_require__.nc) {
+/******/ 			script.setAttribute("nonce", __webpack_require__.nc);
+/******/ 		}
+/******/ 		script.src = __webpack_require__.p + "" + chunkId + ".output.js";
+/******/ 		var timeout = setTimeout(onScriptComplete, 120000);
+/******/ 		script.onerror = script.onload = onScriptComplete;
+/******/ 		function onScriptComplete() {
+/******/ 			// avoid mem leaks in IE.
+/******/ 			script.onerror = script.onload = null;
+/******/ 			clearTimeout(timeout);
+/******/ 			var chunk = installedChunks[chunkId];
+/******/ 			if(chunk !== 0) {
+/******/ 				if(chunk) {
+/******/ 					chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
+/******/ 				}
+/******/ 				installedChunks[chunkId] = undefined;
+/******/ 			}
+/******/ 		};
+/******/ 		head.appendChild(script);
+/******/
+/******/ 		return promise;
+/******/ 	};
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "js/";
+/******/
+/******/ 	// on error function for async loading
+/******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/*!********************!*\
+  !*** ./example.js ***!
+  \********************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+var main = function() {
+	console.log("Main class");
+	__webpack_require__.e/* require.ensure */(2).then((() => {
+		const page = __webpack_require__(/*! ./pageA */ 3);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+	__webpack_require__.e/* require.ensure */(1).then((() => {
+		const page = __webpack_require__(/*! ./pageB */ 4);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+};
+
+main();
+
+
+/***/ }),
+/* 1 */
+/*!***************************************!*\
+  !*** multi ./example.js ./example.js ***!
+  \***************************************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(/*! ./example.js */0);
+module.exports = __webpack_require__(/*! .\example.js */0);
+
+
+/***/ }),
+/* 2 */
+/*!******************************!*\
+  !*** ./reusableComponent.js ***!
+  \******************************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports) {
+
+module.exports = function() {
+	console.log("reusable Component");
+};
+
+
+/***/ })
+/******/ ]);
+
+/***/ }),
+/* 3 */
+/***/ (function(module, exports) {
+
+module.exports = function() {
+	console.log("reusable Component");
+};
+
+
+/***/ })
+/******/ ]);
+
+/***/ }),
+/* 3 */
+/*!******************************!*\
+  !*** ./reusableComponent.js ***!
+  \******************************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports) {
+
+module.exports = function() {
+	console.log("reusable Component");
+};
+
+
+/***/ })
+/******/ ]);
+
+/***/ }),
+/* 3 */
+/***/ (function(module, exports) {
+
+module.exports = function() {
+	console.log("reusable Component");
+};
+
+
+/***/ })
+/******/ ]);
+
+/***/ })
+/******/ ]);
+```
+
+# js/0.asyncoutput.js
+
+``` javascript
+webpackJsonp([0],{
+
+/***/ 5:
+/*!******************************!*\
+  !*** ./reusableComponent.js ***!
+  \******************************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports) {
+
+module.exports = function() {
+	console.log("reusable Component");
+};
+
+
+/***/ })
+
+});
+```
+
+# js/1.asyncoutput.js
+
+``` javascript
+webpackJsonp([1],{
+
+/***/ 4:
+/*!******************!*\
+  !*** ./pageB.js ***!
+  \******************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = function() {
+	console.log("Page B");
+	Promise.all/* require.ensure */([__webpack_require__.e(0), __webpack_require__.e(3)]).then((()=>{
+		const page = __webpack_require__(/*! ./pageC */ 6);
+		page();
+	}).bind(null, __webpack_require__)).catch(__webpack_require__.oe);
+};
+
+
+/***/ })
+
+});
+```
+
+# js/2.asyncoutput.js
+
+``` javascript
+webpackJsonp([2],{
+
 /***/ 3:
 /*!******************!*\
   !*** ./pageA.js ***!
@@ -377,10 +2277,36 @@ webpackJsonp([2],{
 /*! all exports used */
 /***/ (function(module, exports, __webpack_require__) {
 
-var reusableComponent = __webpack_require__(/*! ./reusableComponent */ 2);
+var reusableComponent = __webpack_require__(/*! ./reusableComponent */ 5);
 
 module.exports = function() {
 	console.log("Page A");
+	reusableComponent();
+};
+
+
+/***/ })
+
+});
+```
+
+# js/3.asyncoutput.js
+
+``` javascript
+webpackJsonp([3],{
+
+/***/ 6:
+/*!******************!*\
+  !*** ./pageC.js ***!
+  \******************/
+/*! no static exports found */
+/*! all exports used */
+/***/ (function(module, exports, __webpack_require__) {
+
+var reusableComponent = __webpack_require__(/*! ./reusableComponent */ 5);
+
+module.exports = function() {
+	console.log("Page C");
 	reusableComponent();
 };
 
@@ -395,75 +2321,157 @@ module.exports = function() {
 ## Uncompressed
 
 ```
-Hash: [1mfd4796594a8274a0759b[39m[22m
-Version: webpack [1m3.6.0[39m[22m
-Time: [1m91[39m[22mms
-      [1mAsset[39m[22m       [1mSize[39m[22m  [1mChunks[39m[22m  [1m[39m[22m           [1m[39m[22m[1mChunk Names[39m[22m
-[1m[32m0.output.js[39m[22m  388 bytes       [1m0[39m[22m  [1m[32m[emitted][39m[22m  
-[1m[32m1.output.js[39m[22m  481 bytes       [1m1[39m[22m  [1m[32m[emitted][39m[22m  
-[1m[32m2.output.js[39m[22m  388 bytes       [1m2[39m[22m  [1m[32m[emitted][39m[22m  
-  [1m[32moutput.js[39m[22m    7.08 kB       [1m3[39m[22m  [1m[32m[emitted][39m[22m  main
-Entrypoint [1mmain[39m[22m = [1m[32moutput.js[39m[22m
-chunk    {[1m[33m0[39m[22m} [1m[32m0.output.js[39m[22m 142 bytes {[1m[33m3[39m[22m}[1m[32m [rendered][39m[22m
-    > [4] [1m./pageB.js[39m[22m 3:1-6:3
-    [5] [1m./pageC.js[39m[22m 142 bytes {[1m[33m0[39m[22m}[1m[32m [built][39m[22m
-        cjs require [1m[36m./pageC[39m[22m [4] [1m[35m./pageB.js[39m[22m 4:15-33
-chunk    {[1m[33m1[39m[22m} [1m[32m1.output.js[39m[22m 140 bytes {[1m[33m3[39m[22m}[1m[32m [rendered][39m[22m
-    > [0] [1m./example.js[39m[22m 7:1-10:3
-    [4] [1m./pageB.js[39m[22m 140 bytes {[1m[33m1[39m[22m}[1m[32m [built][39m[22m
-        cjs require [1m[36m./pageB[39m[22m [0] [1m[35m./example.js[39m[22m 8:15-33
-chunk    {[1m[33m2[39m[22m} [1m[32m2.output.js[39m[22m 142 bytes {[1m[33m3[39m[22m}[1m[32m [rendered][39m[22m
-    > [0] [1m./example.js[39m[22m 3:1-6:3
-    [3] [1m./pageA.js[39m[22m 142 bytes {[1m[33m2[39m[22m}[1m[32m [built][39m[22m
-        cjs require [1m[36m./pageA[39m[22m [0] [1m[35m./example.js[39m[22m 4:15-33
-chunk    {[1m[33m3[39m[22m} [1m[32moutput.js[39m[22m (main) 345 bytes[1m[33m [entry][39m[22m[1m[32m [rendered][39m[22m
-    > main [1] [1mmulti ./example.js ./example.js[39m[22m 
-    [0] [1m./example.js[39m[22m 233 bytes {[1m[33m3[39m[22m}[1m[32m [built][39m[22m
-        single entry [1m[36m./example.js[39m[22m [1] [1m[35mmulti ./example.js ./example.js[39m[22m main:100000
-        single entry [1m[36m.\example.js[39m[22m [1] [1m[35mmulti ./example.js ./example.js[39m[22m main:100001
-    [1] [1mmulti ./example.js ./example.js[39m[22m 40 bytes {[1m[33m3[39m[22m}[1m[32m [built][39m[22m
-    [2] [1m./reusableComponent.js[39m[22m 72 bytes {[1m[33m3[39m[22m}[1m[32m [built][39m[22m
-        cjs require [1m[36m./reusableComponent[39m[22m [3] [1m[35m./pageA.js[39m[22m 1:24-54
-        cjs require [1m[36m./reusableComponent[39m[22m [5] [1m[35m./pageC.js[39m[22m 1:24-54
+Hash: 5566a60d53497fc227db049be214a9c917f17307
+Version: webpack 3.6.0
+Child
+    Hash: 5566a60d53497fc227db
+          Asset       Size  Chunks             Chunk Names
+    0.output.js  388 bytes       0  [emitted]  
+    1.output.js  481 bytes       1  [emitted]  
+    2.output.js  388 bytes       2  [emitted]  
+      output.js      35 kB       3  [emitted]  main
+    Entrypoint main = output.js
+    chunk    {0} 0.output.js 142 bytes {3} [rendered]
+        > [5] ./pageB.js 3:1-6:3
+        [6] ./pageC.js 142 bytes {0} [built]
+            cjs require ./pageC [5] ./pageB.js 4:15-33
+    chunk    {1} 1.output.js 140 bytes {3} [rendered]
+        > [0] ./example.js 7:1-10:3
+        [5] ./pageB.js 140 bytes {1} [built]
+            cjs require ./pageB [0] ./example.js 8:15-33
+    chunk    {2} 2.output.js 142 bytes {3} [rendered]
+        > [0] ./example.js 3:1-6:3
+        [4] ./pageA.js 142 bytes {2} [built]
+            cjs require ./pageA [0] ./example.js 4:15-33
+    chunk    {3} output.js (main) 28 kB [entry] [rendered]
+        > main [1] multi ./example.js ./example.js ./js/output.js 
+        [0] ./example.js 233 bytes {3} [built]
+            single entry ./example.js [1] multi ./example.js ./example.js ./js/output.js main:100000
+            single entry .\example.js [1] multi ./example.js ./example.js ./js/output.js main:100001
+        [1] multi ./example.js ./example.js ./js/output.js 52 bytes {3} [built]
+        [2] ./js/output.js 27.6 kB {3} [built]
+            single entry .\js\output.js [1] multi ./example.js ./example.js ./js/output.js main:100002
+        [3] ./reusableComponent.js 72 bytes {3} [built]
+            cjs require ./reusableComponent [4] ./pageA.js 1:24-54
+            cjs require ./reusableComponent [6] ./pageC.js 1:24-54
+Child
+    Hash: 049be214a9c917f17307
+               Asset       Size  Chunks             Chunk Names
+    0.asyncoutput.js  314 bytes       0  [emitted]  
+    1.asyncoutput.js  522 bytes       1  [emitted]  
+    2.asyncoutput.js  388 bytes       2  [emitted]  
+    3.asyncoutput.js  388 bytes       3  [emitted]  
+      asyncoutput.js    34.8 kB       4  [emitted]  main
+    Entrypoint main = asyncoutput.js
+    chunk    {0} 0.asyncoutput.js 72 bytes {4} [rendered]
+        > async commons [0] ./example.js 3:1-6:3
+        > async commons [4] ./pageB.js 3:1-6:3
+        [5] ./reusableComponent.js 72 bytes {0} [built]
+            cjs require ./reusableComponent [3] ./pageA.js 1:24-54
+            cjs require ./reusableComponent [6] ./pageC.js 1:24-54
+    chunk    {1} 1.asyncoutput.js 140 bytes {4} [rendered]
+        > [0] ./example.js 7:1-10:3
+        [4] ./pageB.js 140 bytes {1} [built]
+            cjs require ./pageB [0] ./example.js 8:15-33
+    chunk    {2} 2.asyncoutput.js 142 bytes {4} [rendered]
+        > [0] ./example.js 3:1-6:3
+        [3] ./pageA.js 142 bytes {2} [built]
+            cjs require ./pageA [0] ./example.js 4:15-33
+    chunk    {3} 3.asyncoutput.js 142 bytes {1} [rendered]
+        > [4] ./pageB.js 3:1-6:3
+        [6] ./pageC.js 142 bytes {3} [built]
+            cjs require ./pageC [4] ./pageB.js 4:15-33
+    chunk    {4} asyncoutput.js (main) 27.9 kB [entry] [rendered]
+        > main [1] multi ./example.js ./example.js ./js/output.js 
+        [0] ./example.js 233 bytes {4} [built]
+            single entry ./example.js [1] multi ./example.js ./example.js ./js/output.js main:100000
+            single entry .\example.js [1] multi ./example.js ./example.js ./js/output.js main:100001
+        [1] multi ./example.js ./example.js ./js/output.js 52 bytes {4} [built]
+        [2] ./js/output.js 27.6 kB {4} [built]
+            single entry .\js\output.js [1] multi ./example.js ./example.js ./js/output.js main:100002
 ```
 
 ## Minimized (uglify-js, no zip)
 
 ```
-Hash: [1mfd4796594a8274a0759b[39m[22m
-Version: webpack [1m3.6.0[39m[22m
-Time: [1m150[39m[22mms
-      [1mAsset[39m[22m       [1mSize[39m[22m  [1mChunks[39m[22m  [1m[39m[22m           [1m[39m[22m[1mChunk Names[39m[22m
-[1m[32m0.output.js[39m[22m   98 bytes       [1m0[39m[22m  [1m[32m[emitted][39m[22m  
-[1m[32m1.output.js[39m[22m  340 bytes       [1m1[39m[22m  [1m[32m[emitted][39m[22m  
-[1m[32m2.output.js[39m[22m   98 bytes       [1m2[39m[22m  [1m[32m[emitted][39m[22m  
-  [1m[32moutput.js[39m[22m    6.48 kB       [1m3[39m[22m  [1m[32m[emitted][39m[22m  main
-Entrypoint [1mmain[39m[22m = [1m[32moutput.js[39m[22m
-chunk    {[1m[33m0[39m[22m} [1m[32m0.output.js[39m[22m 142 bytes {[1m[33m3[39m[22m}[1m[32m [rendered][39m[22m
-    > [4] [1m./pageB.js[39m[22m 3:1-6:3
-    [5] [1m./pageC.js[39m[22m 142 bytes {[1m[33m0[39m[22m}[1m[32m [built][39m[22m
-        cjs require [1m[36m./pageC[39m[22m [4] [1m[35m./pageB.js[39m[22m 4:15-33
-chunk    {[1m[33m1[39m[22m} [1m[32m1.output.js[39m[22m 140 bytes {[1m[33m3[39m[22m}[1m[32m [rendered][39m[22m
-    > [0] [1m./example.js[39m[22m 7:1-10:3
-    [4] [1m./pageB.js[39m[22m 140 bytes {[1m[33m1[39m[22m}[1m[32m [built][39m[22m
-        cjs require [1m[36m./pageB[39m[22m [0] [1m[35m./example.js[39m[22m 8:15-33
-chunk    {[1m[33m2[39m[22m} [1m[32m2.output.js[39m[22m 142 bytes {[1m[33m3[39m[22m}[1m[32m [rendered][39m[22m
-    > [0] [1m./example.js[39m[22m 3:1-6:3
-    [3] [1m./pageA.js[39m[22m 142 bytes {[1m[33m2[39m[22m}[1m[32m [built][39m[22m
-        cjs require [1m[36m./pageA[39m[22m [0] [1m[35m./example.js[39m[22m 4:15-33
-chunk    {[1m[33m3[39m[22m} [1m[32moutput.js[39m[22m (main) 345 bytes[1m[33m [entry][39m[22m[1m[32m [rendered][39m[22m
-    > main [1] [1mmulti ./example.js ./example.js[39m[22m 
-    [0] [1m./example.js[39m[22m 233 bytes {[1m[33m3[39m[22m}[1m[32m [built][39m[22m
-        single entry [1m[36m./example.js[39m[22m [1] [1m[35mmulti ./example.js ./example.js[39m[22m main:100000
-        single entry [1m[36m.\example.js[39m[22m [1] [1m[35mmulti ./example.js ./example.js[39m[22m main:100001
-    [1] [1mmulti ./example.js ./example.js[39m[22m 40 bytes {[1m[33m3[39m[22m}[1m[32m [built][39m[22m
-    [2] [1m./reusableComponent.js[39m[22m 72 bytes {[1m[33m3[39m[22m}[1m[32m [built][39m[22m
-        cjs require [1m[36m./reusableComponent[39m[22m [3] [1m[35m./pageA.js[39m[22m 1:24-54
-        cjs require [1m[36m./reusableComponent[39m[22m [5] [1m[35m./pageC.js[39m[22m 1:24-54
-
-[1m[31mERROR in 1.output.js from UglifyJs
-Unexpected token: punc ()) [1.output.js:8,53][39m[22m
-
-[1m[31mERROR in output.js from UglifyJs
-Unexpected token: punc ()) [output.js:154,53][39m[22m
+Hash: 6da2284b85eb94fe413c441b1a1e2d3dbb9961d8
+Version: webpack 3.6.0
+Child
+    Hash: 6da2284b85eb94fe413c
+          Asset       Size  Chunks             Chunk Names
+    0.output.js   98 bytes       0  [emitted]  
+    1.output.js  340 bytes       1  [emitted]  
+    2.output.js   98 bytes       2  [emitted]  
+      output.js    27.6 kB       3  [emitted]  main
+    Entrypoint main = output.js
+    chunk    {0} 0.output.js 142 bytes {3} [rendered]
+        > [5] ./pageB.js 3:1-6:3
+        [6] ./pageC.js 142 bytes {0} [built]
+            cjs require ./pageC [5] ./pageB.js 4:15-33
+    chunk    {1} 1.output.js 140 bytes {3} [rendered]
+        > [0] ./example.js 7:1-10:3
+        [5] ./pageB.js 140 bytes {1} [built]
+            cjs require ./pageB [0] ./example.js 8:15-33
+    chunk    {2} 2.output.js 142 bytes {3} [rendered]
+        > [0] ./example.js 3:1-6:3
+        [4] ./pageA.js 142 bytes {2} [built]
+            cjs require ./pageA [0] ./example.js 4:15-33
+    chunk    {3} output.js (main) 21.4 kB [entry] [rendered]
+        > main [1] multi ./example.js ./example.js ./js/output.js 
+        [0] ./example.js 233 bytes {3} [built]
+            single entry ./example.js [1] multi ./example.js ./example.js ./js/output.js main:100000
+            single entry .\example.js [1] multi ./example.js ./example.js ./js/output.js main:100001
+        [1] multi ./example.js ./example.js ./js/output.js 52 bytes {3} [built]
+        [2] ./js/output.js 21.1 kB {3} [built]
+            single entry .\js\output.js [1] multi ./example.js ./example.js ./js/output.js main:100002
+        [3] ./reusableComponent.js 72 bytes {3} [built]
+            cjs require ./reusableComponent [4] ./pageA.js 1:24-54
+            cjs require ./reusableComponent [6] ./pageC.js 1:24-54
+    
+    ERROR in 1.output.js from UglifyJs
+    Unexpected token: punc ()) [1.output.js:8,53]
+    
+    ERROR in output.js from UglifyJs
+    Unexpected token: punc ()) [output.js:154,53]
+Child
+    Hash: 441b1a1e2d3dbb9961d8
+               Asset       Size  Chunks             Chunk Names
+    0.asyncoutput.js   93 bytes       0  [emitted]  
+    1.asyncoutput.js  381 bytes       1  [emitted]  
+    2.asyncoutput.js   98 bytes       2  [emitted]  
+    3.asyncoutput.js   98 bytes       3  [emitted]  
+      asyncoutput.js    27.5 kB       4  [emitted]  main
+    Entrypoint main = asyncoutput.js
+    chunk    {0} 0.asyncoutput.js 72 bytes {4} [rendered]
+        > async commons [0] ./example.js 3:1-6:3
+        > async commons [4] ./pageB.js 3:1-6:3
+        [5] ./reusableComponent.js 72 bytes {0} [built]
+            cjs require ./reusableComponent [3] ./pageA.js 1:24-54
+            cjs require ./reusableComponent [6] ./pageC.js 1:24-54
+    chunk    {1} 1.asyncoutput.js 140 bytes {4} [rendered]
+        > [0] ./example.js 7:1-10:3
+        [4] ./pageB.js 140 bytes {1} [built]
+            cjs require ./pageB [0] ./example.js 8:15-33
+    chunk    {2} 2.asyncoutput.js 142 bytes {4} [rendered]
+        > [0] ./example.js 3:1-6:3
+        [3] ./pageA.js 142 bytes {2} [built]
+            cjs require ./pageA [0] ./example.js 4:15-33
+    chunk    {3} 3.asyncoutput.js 142 bytes {1} [rendered]
+        > [4] ./pageB.js 3:1-6:3
+        [6] ./pageC.js 142 bytes {3} [built]
+            cjs require ./pageC [4] ./pageB.js 4:15-33
+    chunk    {4} asyncoutput.js (main) 21.3 kB [entry] [rendered]
+        > main [1] multi ./example.js ./example.js ./js/output.js 
+        [0] ./example.js 233 bytes {4} [built]
+            single entry ./example.js [1] multi ./example.js ./example.js ./js/output.js main:100000
+            single entry .\example.js [1] multi ./example.js ./example.js ./js/output.js main:100001
+        [1] multi ./example.js ./example.js ./js/output.js 52 bytes {4} [built]
+        [2] ./js/output.js 21.1 kB {4} [built]
+            single entry .\js\output.js [1] multi ./example.js ./example.js ./js/output.js main:100002
+    
+    ERROR in 1.asyncoutput.js from UglifyJs
+    Unexpected token: punc ()) [1.asyncoutput.js:8,94]
+    
+    ERROR in asyncoutput.js from UglifyJs
+    Unexpected token: punc ()) [asyncoutput.js:154,94]
 ```

--- a/examples/common-chunk-grandchildren/build.js
+++ b/examples/common-chunk-grandchildren/build.js
@@ -1,0 +1,1 @@
+require("../build-common");

--- a/examples/common-chunk-grandchildren/build.js
+++ b/examples/common-chunk-grandchildren/build.js
@@ -1,1 +1,2 @@
+global.NO_TARGET_ARGS = true;
 require("../build-common");

--- a/examples/common-chunk-grandchildren/example.js
+++ b/examples/common-chunk-grandchildren/example.js
@@ -1,0 +1,13 @@
+var main = function() {
+	console.log("Main class");
+	require.ensure([], () => {
+		const page = require("./pageA");
+		page();
+	});
+	require.ensure([], () => {
+		const page = require("./pageB");
+		page();
+	});
+};
+
+main();

--- a/examples/common-chunk-grandchildren/pageA.js
+++ b/examples/common-chunk-grandchildren/pageA.js
@@ -1,0 +1,6 @@
+var reusableComponent = require("./reusableComponent");
+
+module.exports = function() {
+	console.log("Page A");
+	reusableComponent();
+};

--- a/examples/common-chunk-grandchildren/pageB.js
+++ b/examples/common-chunk-grandchildren/pageB.js
@@ -1,0 +1,7 @@
+module.exports = function() {
+	console.log("Page B");
+	require.ensure([], ()=>{
+		const page = require("./pageC");
+		page();
+	});
+};

--- a/examples/common-chunk-grandchildren/pageC.js
+++ b/examples/common-chunk-grandchildren/pageC.js
@@ -1,0 +1,6 @@
+var reusableComponent = require("./reusableComponent");
+
+module.exports = function() {
+	console.log("Page C");
+	reusableComponent();
+};

--- a/examples/common-chunk-grandchildren/reusableComponent.js
+++ b/examples/common-chunk-grandchildren/reusableComponent.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+	console.log("reusable Component");
+};

--- a/examples/common-chunk-grandchildren/template.md
+++ b/examples/common-chunk-grandchildren/template.md
@@ -79,6 +79,36 @@ You can see that webpack outputs four files/chunks:
 {{js/2.output.js}}
 ```
 
+# js/asyncoutput.js
+
+``` javascript
+{{js/asyncoutput.js}}
+```
+
+# js/0.asyncoutput.js
+
+``` javascript
+{{js/0.asyncoutput.js}}
+```
+
+# js/1.asyncoutput.js
+
+``` javascript
+{{js/1.asyncoutput.js}}
+```
+
+# js/2.asyncoutput.js
+
+``` javascript
+{{js/2.asyncoutput.js}}
+```
+
+# js/3.asyncoutput.js
+
+``` javascript
+{{js/3.asyncoutput.js}}
+```
+
 # Info
 
 ## Uncompressed

--- a/examples/common-chunk-grandchildren/template.md
+++ b/examples/common-chunk-grandchildren/template.md
@@ -1,0 +1,94 @@
+This example illustrates how common modules from deep ancestors of an entry point can be split into a seperate common chunk
+
+* `pageA` and `pageB` are dynamically required
+* `pageC` and `pageA` both require the `reusableComponent`
+* `pageB` dynamically requires `PageC`
+
+You can see that webpack outputs four files/chunks:
+
+* `output.js` is the entry chunk and contains
+  * the module system
+  * chunk loading logic
+  * the entry point `example.js`
+  * module `reusableComponent`
+* `0.output.js` is an additional chunk
+  * module `pageC`
+* `1.output.js` is an additional chunk
+  * module `pageB`
+* `2.output.js` is an additional chunk
+  * module `pageA`
+
+
+# example.js
+
+``` javascript
+{{example.js}}
+```
+
+# pageA.js
+
+``` javascript
+{{pageA.js}}
+```
+
+# pageB.js
+
+``` javascript
+{{pageB.js}}
+```
+
+# pageC.js
+
+``` javascript
+{{pageC.js}}
+```
+
+# reusableComponent.js
+
+``` javascript
+{{reusableComponent.js}}
+```
+
+# webpack.config.js
+
+``` javascript
+{{webpack.config.js}}
+```
+
+# js/output.js
+
+``` javascript
+{{js/output.js}}
+```
+
+# js/0.output.js
+
+``` javascript
+{{js/0.output.js}}
+```
+
+# js/1.output.js
+
+``` javascript
+{{js/1.output.js}}
+```
+
+# js/2.output.js
+
+``` javascript
+{{js/2.output.js}}
+```
+
+# Info
+
+## Uncompressed
+
+```
+{{stdout}}
+```
+
+## Minimized (uglify-js, no zip)
+
+```
+{{min:stdout}}
+```

--- a/examples/common-chunk-grandchildren/webpack.config.js
+++ b/examples/common-chunk-grandchildren/webpack.config.js
@@ -1,0 +1,15 @@
+var webpack = require("../../");
+
+module.exports = {
+	entry: {
+		main: ["./example.js"]
+	},
+	plugins: [
+		new webpack.optimize.CommonsChunkPlugin({
+			name: "main",
+			minChunks: 2,
+			children: true,
+			deepChildren: true,
+		})
+	]
+};

--- a/examples/common-chunk-grandchildren/webpack.config.js
+++ b/examples/common-chunk-grandchildren/webpack.config.js
@@ -1,15 +1,41 @@
-var webpack = require("../../");
+"use strict";
+const webpack = require("../../");
+const path = require("path");
 
-module.exports = {
-	entry: {
-		main: ["./example.js"]
+module.exports = [
+	{
+		entry: {
+			main: ["./example.js"]
+		},
+		output: {
+			path: path.resolve(__dirname, "js"),
+			filename: "output.js"
+		},
+		plugins: [
+			new webpack.optimize.CommonsChunkPlugin({
+				name: "main",
+				minChunks: 2,
+				children: true,
+				deepChildren: true,
+			})
+		]
 	},
-	plugins: [
-		new webpack.optimize.CommonsChunkPlugin({
-			name: "main",
-			minChunks: 2,
-			children: true,
-			deepChildren: true,
-		})
-	]
-};
+	{
+		entry: {
+			main: ["./example.js"]
+		},
+		output: {
+			path: path.resolve(__dirname, "js"),
+			filename: "asyncoutput.js"
+		},
+		plugins: [
+			new webpack.optimize.CommonsChunkPlugin({
+				name: "main",
+				minChunks: 2,
+				async: true,
+				children: true,
+				deepChildren: true,
+			})
+		]
+	}
+];

--- a/examples/template-common.js
+++ b/examples/template-common.js
@@ -2,6 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+"use strict";
 const fs = require("fs");
 const path = require("path");
 

--- a/lib/optimize/CommonsChunkPlugin.js
+++ b/lib/optimize/CommonsChunkPlugin.js
@@ -225,13 +225,13 @@ Take a look at the "name"/"names" or async/children option.`);
 			// b) themselves affected chunks
 			// we can assume that this chunk is an affected chunk too, as there is no way a chunk that
 			// isn't only depending on the target chunk is a parent of the chunk tested
-			if(asyncOption || chunk.parents.every((parentChunk) => parentChunk === targetChunk || affectedChunks.indexOf(parentChunk) >= 0)) {
+			if(asyncOption || chunk.parents.every((parentChunk) => parentChunk === targetChunk || affectedChunks.has(parentChunk))) {
 				// This check not only dedupes the affectedChunks but also guarantees we avoid endless loops
-				if(affectedChunks.findIndex(usedChunk => usedChunk === chunk) < 1) {
+				if(!affectedChunks.has(chunk) || affectedChunks.values().next().value === chunk) {
 					// We mutate the affected chunks before going deeper, so the deeper levels and other branches
-					// Have the information of this chunk being affected for their assertion if a chunk shouldnt
-					// be affected
-					affectedChunks.push(chunk);
+					// Have the information of this chunk being affected for their assertion if a chunk should
+					// not be affected
+					affectedChunks.add(chunk);
 
 					// We recurse down to all the children of the chunk, applying the same assumption.
 					// This guarantees that if a chunk should be an affected chunk,
@@ -257,9 +257,9 @@ Take a look at the "name"/"names" or async/children option.`);
 		}
 
 		if(asyncOrNoSelectedChunk) {
-			let affectedChunks = [];
+			let affectedChunks = new Set();
 			this.getAffectedUnnamedChunks(affectedChunks, targetChunk, asyncOption);
-			return affectedChunks;
+			return Array.from(affectedChunks);
 		}
 
 		/**

--- a/lib/optimize/CommonsChunkPlugin.js
+++ b/lib/optimize/CommonsChunkPlugin.js
@@ -4,6 +4,7 @@
 */
 "use strict";
 let nextIdent = 0;
+
 class CommonsChunkPlugin {
 	constructor(options) {
 		if(arguments.length > 1) {
@@ -31,6 +32,7 @@ The available options are:
 		this.minChunks = normalizedOptions.minChunks;
 		this.selectedChunks = normalizedOptions.selectedChunks;
 		this.children = normalizedOptions.children;
+		this.deepChildren = normalizedOptions.deepChildren;
 		this.async = normalizedOptions.async;
 		this.minSize = normalizedOptions.minSize;
 		this.ident = __filename + (nextIdent++);
@@ -76,6 +78,7 @@ You can however specify the name of the async chunk by passing the desired strin
 			minChunks: options.minChunks,
 			selectedChunks: options.chunks,
 			children: options.children,
+			deepChildren: options.deepChildren,
 			async: options.async,
 			minSize: options.minSize
 		};
@@ -211,6 +214,37 @@ You can however specify the name of the async chunk by passing the desired strin
 Take a look at the "name"/"names" or async/children option.`);
 	}
 
+	getAffectedUnnamedChunks(affectedChunks, targetChunk, asyncOption) {
+		let chunks = targetChunk.chunks;
+		chunks && chunks.forEach((chunk) => {
+			if(chunk.isInitial()) {
+				return;
+			}
+			// If all the parents of a chunk are either
+			// a) the target chunk we started with
+			// b) themselves affected chunks
+			// we can assume that this chunk is an affected chunk too, as there is no way a chunk that
+			// isn't only depending on the target chunk is a parent of the chunk tested
+			if(asyncOption || chunk.parents.every((parentChunk) => parentChunk === targetChunk || affectedChunks.indexOf(parentChunk) >= 0)) {
+				// This check not only dedupes the affectedChunks but also guarantees we avoid endless loops
+				if(affectedChunks.findIndex(usedChunk => usedChunk === chunk) < 1) {
+					// We mutate the affected chunks before going deeper, so the deeper levels and other branches
+					// Have the information of this chunk being affected for their assertion if a chunk shouldnt
+					// be affected
+					affectedChunks.push(chunk);
+
+					// We recurse down to all the children of the chunk, applying the same assumption.
+					// This guarantees that if a chunk should be an affected chunk,
+					// at the latest the last connection to the same chunk meets the
+					// condition to add it to the affected chunks.
+					if(this.deepChildren === true) {
+						this.getAffectedUnnamedChunks(affectedChunks, chunk, asyncOption);
+					}
+				}
+			}
+		});
+	}
+
 	getAffectedChunks(compilation, allChunks, targetChunk, targetChunks, currentIndex, selectedChunks, asyncOption, children) {
 		const asyncOrNoSelectedChunk = children || asyncOption;
 
@@ -223,22 +257,9 @@ Take a look at the "name"/"names" or async/children option.`);
 		}
 
 		if(asyncOrNoSelectedChunk) {
-			// nothing to do here
-			if(!targetChunk.chunks) {
-				return [];
-			}
-
-			return targetChunk.chunks.filter((chunk) => {
-				// we only are interested in on-demand chunks
-				if(chunk.isInitial())
-					return false;
-
-				// we can only move modules from this chunk if the "commonChunk" is the only parent
-				if(!asyncOption)
-					return chunk.parents.length === 1;
-
-				return true;
-			});
+			let affectedChunks = [];
+			this.getAffectedUnnamedChunks(affectedChunks, targetChunk, asyncOption);
+			return affectedChunks;
 		}
 
 		/**

--- a/test/configCases/commons-chunk-plugin/move-to-grandparent/index.js
+++ b/test/configCases/commons-chunk-plugin/move-to-grandparent/index.js
@@ -7,6 +7,6 @@ it("should correctly include indirect children in common chunk", function(done) 
 		imports[1].default.should.be.eql("reuse");
 		done();
 	}).catch(e => {
-		done();
+		done(e);
 	})
 });

--- a/test/configCases/commons-chunk-plugin/move-to-grandparent/index.js
+++ b/test/configCases/commons-chunk-plugin/move-to-grandparent/index.js
@@ -2,9 +2,9 @@ it("should correctly include indirect children in common chunk", function(done) 
 	Promise.all([
 		import('./pageA'),
 		import('./pageB')
-	]).then(([a, b]) => {
-		a.default.should.be.eql("reuse");
-		b.default.should.be.eql("reuse");
+	]).then((imports) => {
+		imports[0].default.should.be.eql("reuse");
+		imports[1].default.should.be.eql("reuse");
 		done();
 	}).catch(e => {
 		done();

--- a/test/configCases/commons-chunk-plugin/move-to-grandparent/index.js
+++ b/test/configCases/commons-chunk-plugin/move-to-grandparent/index.js
@@ -1,0 +1,12 @@
+it("should correctly include indirect children in common chunk", function(done) {
+	Promise.all([
+		import('./pageA'),
+		import('./pageB')
+	]).then(([a, b]) => {
+		a.default.should.be.eql("reuse");
+		b.default.should.be.eql("reuse");
+		done();
+	}).catch(e => {
+		done();
+	})
+});

--- a/test/configCases/commons-chunk-plugin/move-to-grandparent/pageA.js
+++ b/test/configCases/commons-chunk-plugin/move-to-grandparent/pageA.js
@@ -1,0 +1,3 @@
+var reusableComponent = require("./reusableComponent");
+
+export default reusableComponent.default;

--- a/test/configCases/commons-chunk-plugin/move-to-grandparent/pageB.js
+++ b/test/configCases/commons-chunk-plugin/move-to-grandparent/pageB.js
@@ -1,0 +1,1 @@
+module.exports = import('./pageC')

--- a/test/configCases/commons-chunk-plugin/move-to-grandparent/pageC.js
+++ b/test/configCases/commons-chunk-plugin/move-to-grandparent/pageC.js
@@ -1,0 +1,3 @@
+var reusableComponent = require("./reusableComponent");
+
+export default reusableComponent.default;

--- a/test/configCases/commons-chunk-plugin/move-to-grandparent/reusableComponent.js
+++ b/test/configCases/commons-chunk-plugin/move-to-grandparent/reusableComponent.js
@@ -1,0 +1,3 @@
+const reuse = "reuse";
+
+export default reuse;

--- a/test/configCases/commons-chunk-plugin/move-to-grandparent/second.js
+++ b/test/configCases/commons-chunk-plugin/move-to-grandparent/second.js
@@ -1,0 +1,8 @@
+it("should handle indirect children with multiple parents correctly", function(done) {
+  import('./pageB').then(b => {
+    b.default.should.be.eql("reuse");
+    done()
+  }).catch(e => {
+		done();
+	})
+})

--- a/test/configCases/commons-chunk-plugin/move-to-grandparent/test.config.js
+++ b/test/configCases/commons-chunk-plugin/move-to-grandparent/test.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	findBundle: function(i, options) {
+		return [
+			"./main.js",
+			"./misc.js",
+		];
+	}
+};

--- a/test/configCases/commons-chunk-plugin/move-to-grandparent/webpack.config.js
+++ b/test/configCases/commons-chunk-plugin/move-to-grandparent/webpack.config.js
@@ -1,0 +1,19 @@
+var CommonsChunkPlugin = require("../../../../lib/optimize/CommonsChunkPlugin");
+
+module.exports = {
+	entry: {
+		main: "./index",
+		misc: "./second",
+	},
+	output: {
+		filename: "[name].js"
+	},
+	plugins: [
+		new CommonsChunkPlugin({
+			name: "main",
+			minChunks: 2,
+			children: true,
+			deepChildren: true,
+		})
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

https://github.com/webpack/webpack.js.org/pull/1625
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

If you use the CommonsChunkPlugin with the children flag enabled it currently only cares about direct children. This change makes it so it cares about all children that are not required from somewhere else than the common chunk.
https://github.com/webpack/webpack/issues/3981

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

If the config deepChildren isn't set the behavior stays the same as before, it only changes if the flag gets set.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

Thanks to Florian Scholz (ArcEglos) for doing all the work.
https://github.com/webpack/webpack/pull/4255