### PR TITLE
Fail to load named modules when using ConstArray dependencies

### DIFF
--- a/lib/dependencies/AMDRequireArrayDependency.js
+++ b/lib/dependencies/AMDRequireArrayDependency.js
@@ -47,6 +47,8 @@ AMDRequireArrayDependency.Template = class AMDRequireArrayDependencyTemplate {
 		if(dep.module) {
 			const stringifiedId = JSON.stringify(dep.module.id);
 			return `__webpack_require__(${comment}${stringifiedId})`;
+		} else if(dep.localModule) {
+			return dep.localModule.variableName();
 		}
 
 		return webpackMissingModuleModule(dep.request);

--- a/test/cases/amd/namedModules/index.js
+++ b/test/cases/amd/namedModules/index.js
@@ -1,0 +1,30 @@
+define("named1", [], function() {
+	return "named1";
+});
+
+define("named2", [], function() {
+	return "named2";
+});
+
+define("named3", [], function() {
+	return "named3";
+});
+
+define("named4", [], function() {
+	return "named4";
+});
+
+define(["named1", "named2"], function(named1, named2) {
+	it("should load the named modules in defined dependencies", function() {
+		"named1".should.be.eql(named1);
+		"named2".should.be.eql(named2);
+	});
+
+	it("should load the named modules in require dependencies", function(done) {
+		require(["named3", "named4"], function (named3, named4) {
+			"named3".should.be.eql(named3);
+			"named4".should.be.eql(named4);
+			done();
+		});
+	});
+});

--- a/test/cases/amd/namedModules/index.js
+++ b/test/cases/amd/namedModules/index.js
@@ -16,14 +16,14 @@ define("named4", [], function() {
 
 define(["named1", "named2"], function(named1, named2) {
 	it("should load the named modules in defined dependencies", function() {
-		"named1".should.be.eql(named1);
-		"named2".should.be.eql(named2);
+		named1.should.be.eql("named1");
+		named2.should.be.eql("named2");
 	});
 
 	it("should load the named modules in require dependencies", function(done) {
 		require(["named3", "named4"], function (named3, named4) {
-			"named3".should.be.eql(named3);
-			"named4".should.be.eql(named4);
+			named3.should.be.eql("named3");
+			named4.should.be.eql("named4");
 			done();
 		});
 	});

--- a/test/cases/amd/namedModulesConstArrayDep/index.js
+++ b/test/cases/amd/namedModulesConstArrayDep/index.js
@@ -1,0 +1,30 @@
+define("named1", [], function() {
+	return "named1";
+});
+
+define("named2", [], function() {
+	return "named2";
+});
+
+define("named3", [], function() {
+	return "named3";
+});
+
+define("named4", [], function() {
+	return "named4";
+});
+
+define("named1,named2".split(","), function(named1, named2) {
+	it("should load the named modules in const array defined dependencies", function() {
+		"named1".should.be.eql(named1);
+		"named2".should.be.eql(named2);
+	});
+
+	it("should load the named modules in const array require dependencies", function(done) {
+		require("named3,named4".split(","), function (named3, named4) {
+			"named3".should.be.eql(named3);
+			"named4".should.be.eql(named4);
+			done();
+		});
+	});
+});

--- a/test/cases/amd/namedModulesConstArrayDep/index.js
+++ b/test/cases/amd/namedModulesConstArrayDep/index.js
@@ -16,14 +16,14 @@ define("named4", [], function() {
 
 define("named1,named2".split(","), function(named1, named2) {
 	it("should load the named modules in const array defined dependencies", function() {
-		"named1".should.be.eql(named1);
-		"named2".should.be.eql(named2);
+		named1.should.be.eql("named1");
+		named2.should.be.eql("named2");
 	});
 
 	it("should load the named modules in const array require dependencies", function(done) {
 		require("named3,named4".split(","), function (named3, named4) {
-			"named3".should.be.eql(named3);
-			"named4".should.be.eql(named4);
+			named3.should.be.eql("named3");
+			named4.should.be.eql("named4");
 			done();
 		});
 	});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?** Bug fix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?** Yes

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:** N/A

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary** Fix failure to load named modules (AMD) when using constArray dependencies.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?** No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information** Wasn't sure about the location of the unit tests.  Let me know if you want them moved.
