### PR TITLE
Make define dependency object creation overridable.

### DIFF
--- a/lib/dependencies/AMDDefineDependencyParserPlugin.js
+++ b/lib/dependencies/AMDDefineDependencyParserPlugin.js
@@ -28,6 +28,10 @@ class AMDDefineDependencyParserPlugin {
 		this.options = options;
 	}
 
+	newDefineDependency(range, arrayRange, functionRange, objectRange, namedModule) {
+		return new AMDDefineDependency(range, arrayRange, functionRange, objectRange, namedModule);
+	}
+
 	apply(parser) {
 		const options = this.options;
 		parser.plugin("call define", (expr) => {
@@ -156,7 +160,7 @@ class AMDDefineDependencyParserPlugin {
 				parser.walkExpression(fn || obj);
 			}
 
-			const dep = new AMDDefineDependency(
+			const dep = this.newDefineDependency(
 				expr.range,
 				array ? array.range : null,
 				fn ? fn.range : null,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?** Enhance code reusability

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?** This change does not affect test coverage

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:** N/A

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary** Enables reuse of "call define" processing by subclasses that need to override define dependency object creation.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?** No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
