### PR TITLE
Only use UMD or UMD2 externals for UMD libraryTarget. Resolve #5766

### DIFF
--- a/lib/UmdMainTemplatePlugin.js
+++ b/lib/UmdMainTemplatePlugin.js
@@ -42,7 +42,7 @@ class UmdMainTemplatePlugin {
 	apply(compilation) {
 		const mainTemplate = compilation.mainTemplate;
 		compilation.templatesPlugin("render-with-entry", (source, chunk, hash) => {
-			let externals = chunk.getModules().filter(m => m.external);
+			let externals = chunk.getModules().filter(m => m.external && (m.type === "umd" || m.type === "umd2"));
 			const optionalExternals = [];
 			let requiredExternals = [];
 			if(this.optionalAmdExternalAsGlobal) {

--- a/test/configCases/externals/non-umd-externals-umd/index.js
+++ b/test/configCases/externals/non-umd-externals-umd/index.js
@@ -1,0 +1,23 @@
+require("should");
+var fs = require("fs");
+var path = require("path");
+
+it("should correctly import a UMD external", function() {
+	var external = require("external0");
+	external.should.be.eql("module 0");
+});
+
+it("should contain `require()` statements for the UMD external", function() {
+	var source = fs.readFileSync(path.join(__dirname, "bundle0.js"), "utf-8");
+	source.should.containEql("require(\"external0\")");
+});
+
+it("should correctly import a non-UMD external", function() {
+	var external = require("external1");
+	external.should.be.eql("abc");
+});
+
+it("should not contain `require()` statements for the non-UMD external", function() {
+	var source = fs.readFileSync(path.join(__dirname, "bundle0.js"), "utf-8");
+	source.should.not.containEql("require(\"'abc'\")");
+});

--- a/test/configCases/externals/non-umd-externals-umd/test.config.js
+++ b/test/configCases/externals/non-umd-externals-umd/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	modules: {
+		external0: "module 0"
+	}
+};

--- a/test/configCases/externals/non-umd-externals-umd/webpack.config.js
+++ b/test/configCases/externals/non-umd-externals-umd/webpack.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+	output: {
+		libraryTarget: "umd"
+	},
+	externals: {
+		external0: "external0",
+		external1: "var 'abc'"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};

--- a/test/configCases/externals/non-umd-externals-umd2/index.js
+++ b/test/configCases/externals/non-umd-externals-umd2/index.js
@@ -1,0 +1,23 @@
+require("should");
+var fs = require("fs");
+var path = require("path");
+
+it("should correctly import a UMD2 external", function() {
+	var external = require("external0");
+	external.should.be.eql("module 0");
+});
+
+it("should contain `require()` statements for the UMD2 external", function() {
+	var source = fs.readFileSync(path.join(__dirname, "bundle0.js"), "utf-8");
+	source.should.containEql("require(\"external0\")");
+});
+
+it("should correctly import a non-UMD2 external", function() {
+	var external = require("external1");
+	external.should.be.eql("abc");
+});
+
+it("should not contain `require()` statements for the non-UMD2 external", function() {
+	var source = fs.readFileSync(path.join(__dirname, "bundle0.js"), "utf-8");
+	source.should.not.containEql("require(\"'abc'\")");
+});

--- a/test/configCases/externals/non-umd-externals-umd2/test.config.js
+++ b/test/configCases/externals/non-umd-externals-umd2/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	modules: {
+		external0: "module 0"
+	}
+};

--- a/test/configCases/externals/non-umd-externals-umd2/webpack.config.js
+++ b/test/configCases/externals/non-umd-externals-umd2/webpack.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+	output: {
+		libraryTarget: "umd2"
+	},
+	externals: {
+		external0: "external0",
+		external1: "var 'abc'"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Depending on if the issue I raised can be considered a bug, this is either a bugfix or a feature 😃

This change should remove `require`/`define` statements, whose output does not end up being used when using non-UMD externals (such as `var`) as seen in the diff here: https://github.com/NMinhNguyen/webpack-umd-with-var-externals-example/commit/f0126c58e1e7e0b5d096eed9ab613024d7ce9b8b

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

No, ~~as there weren't any existing tests for `UmdMainTemplatePlugin`~~, but I'm happy to add them if necessary - I realise this is quite an important part of the code. All existing tests pass though.

Update: I was looking for a `UmdMainTemplatePlugin.test.js` file but I now realise this code is actually tested via `ConfigTestCases` - I need to familiarise myself with the existing tests but I fully intend on converting my repro into a test case, at the very least.

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Resolves #5766 

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

I don't believe it does - if anything, this should potentially prevent breakages?

**Other information**

@sokra suggested checking for `m.type !== "umd" && m.type !== "umd2"`, but I went for `m.type === "umd" || m.type === "umd2"` (the logical opposite of the suggested change)