### PR TITLE
Fix #5806, TypeError on ExternalModule hash.update

### DIFF
--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -120,7 +120,7 @@ class ExternalModule extends Module {
 	updateHash(hash) {
 		hash.update(this.type);
 		hash.update(JSON.stringify(this.request));
-		hash.update(JSON.stringify(this.optional));
+		hash.update(JSON.stringify(Boolean(this.optional)));
 		super.updateHash(hash);
 	}
 }

--- a/test/ExternalModule.test.js
+++ b/test/ExternalModule.test.js
@@ -340,4 +340,32 @@ module.exports = some/request;`;
 			hashedText.should.containEql("12345678");
 		});
 	});
+
+	describe("#updateHash without optional", function() {
+		let hashedText;
+		let hash;
+		beforeEach(function() {
+			hashedText = "";
+			hash = {
+				update: (text) => {
+					hashedText += text;
+				}
+			};
+			// Note no set of `externalModule.optional`, which crashed externals in 3.7.0
+			externalModule.id = 12345678;
+			externalModule.updateHash(hash);
+		});
+		it("updates hash with request", function() {
+			hashedText.should.containEql("some/request");
+		});
+		it("updates hash with type", function() {
+			hashedText.should.containEql("some-type");
+		});
+		it("updates hash with optional flag", function() {
+			hashedText.should.containEql("false");
+		});
+		it("updates hash with module id", function() {
+			hashedText.should.containEql("12345678");
+		});
+	});
 });


### PR DESCRIPTION
When `this.optional` is not set, undefined must be coerced to `false`.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes
<!-- Note that we won't merge your changes if you don't add tests -->
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

See #5806 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
