### PR TITLE
Fix #5794 by ignoring ENOENT errors in ContextModuleFactory.addDependencies

### DIFF
--- a/lib/ContextModuleFactory.js
+++ b/lib/ContextModuleFactory.js
@@ -113,7 +113,15 @@ module.exports = class ContextModuleFactory extends Tapable {
 					const subResource = path.join(directory, seqment);
 
 					fs.stat(subResource, (err, stat) => {
-						if(err) return callback(err);
+						if(err) {
+							if(err.code === "ENOENT") {
+								// ENOENT is ok here because the file may have been deleted between
+								// the readdir and stat calls.
+								return callback();
+							} else {
+								return callback(err);
+							}
+						}
 
 						if(stat.isDirectory()) {
 

--- a/test/ContextModuleFactory.test.js
+++ b/test/ContextModuleFactory.test.js
@@ -1,0 +1,46 @@
+/* globals describe, it, beforeEach */
+"use strict";
+require("should");
+const MemoryFs = require("memory-fs");
+const ContextModuleFactory = require("../lib/ContextModuleFactory");
+
+describe("ContextModuleFactory", function() {
+	describe("resolveDependencies", function() {
+		let factory, memfs;
+		beforeEach(function() {
+			factory = new ContextModuleFactory([]);
+			memfs = new MemoryFs();
+		});
+		it("should not report an error when ENOENT errors happen", function(done) {
+			memfs.readdir = (dir, callback) => {
+				setTimeout(() => callback(null, ["/file"]));
+			};
+			memfs.stat = (file, callback) => {
+				let err = new Error("fake ENOENT error");
+				err.code = "ENOENT";
+				setTimeout(() => callback(err, null));
+			};
+			factory.resolveDependencies(memfs, "/", true, /.*/, (err, res) => {
+				(!!err).should.be.false();
+				res.should.be.an.Array();
+				res.length.should.be.exactly(0);
+				done();
+			});
+		});
+		it("should report an error when non-ENOENT errors happen", function(done) {
+			memfs.readdir = (dir, callback) => {
+				setTimeout(() => callback(null, ["/file"]));
+			};
+			memfs.stat = (file, callback) => {
+				let err = new Error("fake EACCES error");
+				err.code = "EACCES";
+				setTimeout(() => callback(err, null));
+			};
+			factory.resolveDependencies(memfs, "/", true, /.*/, (err, res) => {
+				err.should.be.an.Error();
+				(!!res).should.be.false();
+				done();
+			});
+		});
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix for #5794

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yup

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
Nope

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
When --watch triggers a rebuild due to a delete/rename/move on Windows, it's possible for the `fs.readdir` call in `ContextModuleFactory.resolveDependencies` to return the file that was just removed. Then it tries to do `fs.stat` on the file, which fails. So it should ignore those errors.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Nope

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Nope
