### PR TITLE
[fix] webpackOptionsSchema

### DIFF
--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -975,6 +975,7 @@
       "anyOf": [
         {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "context": {
               "type": "string",
@@ -996,6 +997,18 @@
             "assets": {
               "type": "boolean",
               "description": "add assets information"
+            },
+            "env": {
+              "type": "boolean",
+              "description": "add --env information"
+            },
+            "colors": {
+              "type": "boolean",
+              "description": "`webpack --colors` equivalent"
+            },
+            "maxModules": {
+              "type": "number",
+              "description": "Set the maximum number of modules to be shown"
             },
             "chunks": {
               "type": "boolean",

--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -1003,8 +1003,36 @@
               "description": "add --env information"
             },
             "colors": {
-              "type": "boolean",
-              "description": "`webpack --colors` equivalent"
+              "oneOf": [
+                {
+                  "type": "boolean",
+                  "description": "`webpack --colors` equivalent"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "bold": {
+                      "type": "string"
+                    },
+                    "red": {
+                      "type": "string"
+                    },
+                    "green": {
+                      "type": "string"
+                    },
+                    "cyan": {
+                      "type": "string"
+                    },
+                    "magenta": {
+                      "type": "string"
+                    },
+                    "yellow": {
+                      "type": "string"
+                    }
+                  }
+                }
+              ]
             },
             "maxModules": {
               "type": "number",
@@ -1030,6 +1058,10 @@
               "type": "boolean",
               "description": "add also information about cached (not built) modules"
             },
+            "cachedAssets": {
+              "type": "boolean",
+              "description": "Show cached assets (setting this to `false` only shows emitted files)"
+            },
             "reasons": {
               "type": "boolean",
               "description": "add information about the reasons why modules are included"
@@ -1054,6 +1086,10 @@
               "description": "Please use excludeModules instead.",
               "$ref": "#/definitions/filter-types"
             },
+            "entrypoints": {
+              "type": "boolean",
+              "description": "Display the entry points with the corresponding bundles"
+            },
             "errorDetails": {
               "type": "boolean",
               "description": "add details to errors (like resolving log)"
@@ -1077,6 +1113,10 @@
             "assetsSort": {
               "type": "string",
               "description": "sort the assets by that field"
+            },
+            "publicPath": {
+              "type": "boolean",
+              "description": "Add public path information"
             },
             "providedExports": {
               "type": "boolean",

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -199,6 +199,20 @@ describe("Validation", () => {
 		message: [
 			" - configuration.context: The provided value \"baz\" is not an absolute path!",
 		]
+	}, {
+		name: "missing stats option",
+		config: {
+			entry: "foo.js",
+			stats: {
+				foobar: true
+			}
+		},
+		test(e) {
+			e.message.should.startWith("Invalid configuration object.");
+			e.message.split("\n").slice(1)[0].should.be.eql(
+				" - configuration.stats should be one of these:"
+			);
+		}
 	}];
 	testCases.forEach((testCase) => {
 		it("should fail validation for " + testCase.name, () => {
@@ -207,6 +221,12 @@ describe("Validation", () => {
 			} catch(e) {
 				if(!(e instanceof WebpackOptionsValidationError))
 					throw e;
+
+				if(testCase.test) {
+					testCase.test(e);
+					return;
+				}
+
 				e.message.should.startWith("Invalid configuration object.");
 				e.message.split("\n").slice(1).should.be.eql(testCase.message);
 				return;

--- a/test/statsCases/module-deduplication-named/webpack.config.js
+++ b/test/statsCases/module-deduplication-named/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
 	},
 	stats: {
 		hash: false,
-		timing: false,
+		timings: true,
 		chunks: true,
 		chunkModules: true,
 		modules: false

--- a/test/statsCases/module-deduplication/webpack.config.js
+++ b/test/statsCases/module-deduplication/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
 	},
 	stats: {
 		hash: false,
-		timing: false,
+		timings: true,
 		chunks: true,
 		chunkModules: true,
 		modules: false


### PR DESCRIPTION
- Updates webpackOptionsSchema "stats" object to include "additionalProperties: false"
- Adds missing stats options
- Adds test for ensuring new stats options fail the schema check (if not included)



**What kind of change does this PR introduce?**

Fix/Test Update

**Did you add tests for your changes?**

Yes - I've added a Validation test for the `stats` object and it's use of `additionalProperties: false`

**If relevant, link to documentation update:**

N/A

**Summary**

Update based on @sokra's comment on #5811 ([here](https://github.com/webpack/webpack/pull/5811#issuecomment-336397137)). This adds a test that ensures validation will fail for the `stats` object if there are properties found in the configuration and _not_ in the schema ([additionalProperties](http://epoberezkin.github.io/ajv/keywords.html#additionalproperties)).


I've also added the ability to add a custom "test" for the validation object(s).

**Does this PR introduce a breaking change?**

No.

**Other information**

~There are a few properties that need to be added for the `Stats.test.js` cases, but wanted to make sure this was an acceptable approach before continuing.~ I went ahead and just resolved these. 


