### PR TITLE
[tests] statsCases/module-deduplication

### DIFF
--- a/test/statsCases/module-deduplication-named/expected.txt
+++ b/test/statsCases/module-deduplication-named/expected.txt
@@ -1,4 +1,3 @@
-Time: Xms
 Asset       Size  Chunks             Chunk Names
  0.js  769 bytes       0  [emitted]  async3
  1.js  769 bytes       1  [emitted]  async2

--- a/test/statsCases/module-deduplication-named/webpack.config.js
+++ b/test/statsCases/module-deduplication-named/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
 	},
 	stats: {
 		hash: false,
-		timings: true,
+		timings: false,
 		chunks: true,
 		chunkModules: true,
 		modules: false

--- a/test/statsCases/module-deduplication/expected.txt
+++ b/test/statsCases/module-deduplication/expected.txt
@@ -1,4 +1,3 @@
-Time: Xms
 Asset       Size  Chunks             Chunk Names
  0.js  691 bytes    0, 3  [emitted]  
  1.js  691 bytes    1, 4  [emitted]  

--- a/test/statsCases/module-deduplication/webpack.config.js
+++ b/test/statsCases/module-deduplication/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
 	},
 	stats: {
 		hash: false,
-		timings: true,
+		timings: false,
 		chunks: true,
 		chunkModules: true,
 		modules: false


### PR DESCRIPTION
- Uses `timings: false` for module-deduplication tests and updates expected output.

**What kind of change does this PR introduce?**

Test update based on feedback in #5825 (https://github.com/webpack/webpack/pull/5825#discussion_r144687411) 

**Did you add tests for your changes?**

Updated existing.