### PR TITLE
adds stats.all option the the webpackOptionsSchema

### DIFF
--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -978,6 +978,7 @@
           "additionalProperties": false,
           "properties": {
             "all": {
+              "type": "boolean",
               "description": "fallback value for stats options when an option is not defined (has precedence over local webpack defaults)"
             },
             "context": {

--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -977,6 +977,9 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "all": {
+              "description": "fallback value for stats options when an option is not defined (has precedence over local webpack defaults)"
+            },
             "context": {
               "type": "string",
               "description": "context directory for request shortening",


### PR DESCRIPTION
Related to #5841 and #5840 

This one is undocumented, but technically a valid option. (https://github.com/webpack/webpack/blob/master/lib/Stats.js#L85)

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

No

**If relevant, link to documentation update:**

https://github.com/webpack/webpack.js.org/pull/1652
