### PR TITLE
[fix] error on HMR with es6 bundles

### DIFF
--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -195,8 +195,8 @@ class JsonpMainTemplatePlugin {
 function hotDisposeChunk(chunkId) {
 	delete installedChunks[chunkId];
 }
-var parentHotUpdateCallback = this[${JSON.stringify(hotUpdateFunction)}];
-this[${JSON.stringify(hotUpdateFunction)}] = ${runtimeSource}`;
+var parentHotUpdateCallback = window[${JSON.stringify(hotUpdateFunction)}];
+window[${JSON.stringify(hotUpdateFunction)}] = ${runtimeSource}`;
 		});
 		mainTemplate.plugin("hash", function(hash) {
 			hash.update("jsonp");

--- a/lib/webworker/WebWorkerMainTemplatePlugin.js
+++ b/lib/webworker/WebWorkerMainTemplatePlugin.js
@@ -82,8 +82,8 @@ class WebWorkerMainTemplatePlugin {
 			});
 
 			return source + "\n" +
-				`var parentHotUpdateCallback = window[${JSON.stringify(hotUpdateFunction)}];\n` +
-				`window[${JSON.stringify(hotUpdateFunction)}] = ` +
+				`var parentHotUpdateCallback = self[${JSON.stringify(hotUpdateFunction)}];\n` +
+				`self[${JSON.stringify(hotUpdateFunction)}] = ` +
 				Template.getFunctionContent(require("./WebWorkerMainTemplate.runtime.js"))
 				.replace(/\/\/\$semicolon/g, ";")
 				.replace(/\$require\$/g, this.requireFn)

--- a/lib/webworker/WebWorkerMainTemplatePlugin.js
+++ b/lib/webworker/WebWorkerMainTemplatePlugin.js
@@ -82,8 +82,8 @@ class WebWorkerMainTemplatePlugin {
 			});
 
 			return source + "\n" +
-				`var parentHotUpdateCallback = this[${JSON.stringify(hotUpdateFunction)}];\n` +
-				`this[${JSON.stringify(hotUpdateFunction)}] = ` +
+				`var parentHotUpdateCallback = window[${JSON.stringify(hotUpdateFunction)}];\n` +
+				`window[${JSON.stringify(hotUpdateFunction)}] = ` +
 				Template.getFunctionContent(require("./WebWorkerMainTemplate.runtime.js"))
 				.replace(/\/\/\$semicolon/g, ";")
 				.replace(/\$require\$/g, this.requireFn)

--- a/test/WebWorkerMainTemplatePlugin.unittest.js
+++ b/test/WebWorkerMainTemplatePlugin.unittest.js
@@ -188,8 +188,8 @@ installedChunks[chunkIds.pop()] = 1;
 				it("returns the original source with hot update callback", () => {
 					env.source.should.be.exactly(`
 moduleSource()
-var parentHotUpdateCallback = window["webpackHotUpdate"];
-window["webpackHotUpdate"] = function webpackHotUpdateCallback(chunkId, moreModules) { // eslint-disable-line no-unused-vars
+var parentHotUpdateCallback = self["webpackHotUpdate"];
+self["webpackHotUpdate"] = function webpackHotUpdateCallback(chunkId, moreModules) { // eslint-disable-line no-unused-vars
 	hotAddUpdateChunk(chunkId, moreModules);
 	if(parentHotUpdateCallback) parentHotUpdateCallback(chunkId, moreModules);
 } ;

--- a/test/WebWorkerMainTemplatePlugin.unittest.js
+++ b/test/WebWorkerMainTemplatePlugin.unittest.js
@@ -188,8 +188,8 @@ installedChunks[chunkIds.pop()] = 1;
 				it("returns the original source with hot update callback", () => {
 					env.source.should.be.exactly(`
 moduleSource()
-var parentHotUpdateCallback = this["webpackHotUpdate"];
-this["webpackHotUpdate"] = function webpackHotUpdateCallback(chunkId, moreModules) { // eslint-disable-line no-unused-vars
+var parentHotUpdateCallback = window["webpackHotUpdate"];
+window["webpackHotUpdate"] = function webpackHotUpdateCallback(chunkId, moreModules) { // eslint-disable-line no-unused-vars
 	hotAddUpdateChunk(chunkId, moreModules);
 	if(parentHotUpdateCallback) parentHotUpdateCallback(chunkId, moreModules);
 } ;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

It's a bug fix.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Update test.

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->
N/A

**Summary**

We notice a bug in webpack HMR during our spike on creating es6 bundles.

Bug:
- `bootstrap` dev bundle containes a `this` no longer bound to `window`, so it was undefined.

Fix:
- Use `window` instead of `this` in both scripts templates.

This bug was identifed in #5776

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Fix #5776
Made with @osirisxxl