### PR TITLE
fix: hot update on a /sub/path

### DIFF
--- a/lib/JsonpMainTemplate.runtime.js
+++ b/lib/JsonpMainTemplate.runtime.js
@@ -14,7 +14,7 @@ module.exports = function() {
 		var script = document.createElement("script");
 		script.type = "text/javascript";
 		script.charset = "utf-8";
-		script.src = $require$.p + $hotChunkFilename$;
+		script.src = "/" + $require$.p + $hotChunkFilename$;
 		$crossOriginLoading$;
 		head.appendChild(script);
 	}
@@ -26,7 +26,7 @@ module.exports = function() {
 				return reject(new Error("No browser support"));
 			try {
 				var request = new XMLHttpRequest();
-				var requestPath = $require$.p + $hotMainFilename$;
+				var requestPath = "/" + $require$.p + $hotMainFilename$;
 				request.open("GET", requestPath, true);
 				request.timeout = requestTimeout;
 				request.send(null);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No.. not sure how. Or at least easily. There's seems to be a `tests/hotPlayground` but it doesn't deal with apps with router and /paths. It'd be too bit of a task to update it. The patch in comparison is relatively small...

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

When using hot module reloading in an app on a `/sub/path`, it tries to fetch the updates via url `/sub/xxx.hot-update.json` which it doesn't find and therefore end up doing a full reload.

This patch fixes it.

repro: https://github.com/laggingreflex/webpack-hmr-subpath-test

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
