### PR TITLE
Use kibibytes instead of kilobytes

### DIFF
--- a/lib/SizeFormatHelpers.js
+++ b/lib/SizeFormatHelpers.js
@@ -11,8 +11,8 @@ SizeFormatHelpers.formatSize = size => {
 		return "0 bytes";
 	}
 
-	const abbreviations = ["bytes", "kB", "MB", "GB"];
-	const index = Math.floor(Math.log(size) / Math.log(1000));
+	const abbreviations = ["bytes", "KiB", "MiB", "GiB"];
+	const index = Math.floor(Math.log(size) / Math.log(1024));
 
-	return `${+(size / Math.pow(1000, index)).toPrecision(3)} ${abbreviations[index]}`;
+	return `${+(size / Math.pow(1024, index)).toPrecision(3)} ${abbreviations[index]}`;
 };


### PR DESCRIPTION
I noticed that the numbers that the performance
EntrypointsOverSizeLimitWarning message used were larger than what I was
seeing in my browser and what I thought I had configured it to be. I'd
like for these numbers to match up, and I think it makes sense to
express these using computer science units like kibibytes (which is what
the browser uses) instead of metric units like kilobytes.

More information: https://en.wikipedia.org/wiki/Kibibyte

We recently made a similar change that landed in source-map-explorer
v1.4.0, and it would also be nice if these tools used the same
measurements.

https://github.com/danvk/source-map-explorer/releases/tag/v1.4.0

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
No

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->
N/A? Maybe something here should be updated? https://webpack.js.org/configuration/performance/

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Please see commit message above.

<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No, I don't think so

**Other information**
