### PR TITLE
Source maps: webpack serves null content from sourcesContent #5542

### DIFF
--- a/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
+++ b/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
@@ -55,7 +55,7 @@ class EvalSourceMapDevToolModuleTemplatePlugin {
 			sourceMap.sources = moduleFilenames;
 			if(sourceMap.sourcesContent) {
 				sourceMap.sourcesContent = sourceMap.sourcesContent.map(function(content, i) {
-					return `${content}\n\n\n${ModuleFilenameHelpers.createFooter(modules[i], this.requestShortener)}`;
+					return typeof content === "string" ? `${content}\n\n\n${ModuleFilenameHelpers.createFooter(modules[i], this.requestShortener)}` : null;
 				}, this);
 			}
 			sourceMap.sourceRoot = options.sourceRoot || "";

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -158,7 +158,7 @@ class SourceMapDevToolPlugin {
 					const moduleFilenames = modules.map(m => moduleToSourceNameMapping.get(m));
 					sourceMap.sources = moduleFilenames;
 					if(sourceMap.sourcesContent && !options.noSources) {
-						sourceMap.sourcesContent = sourceMap.sourcesContent.map((content, i) => `${content}\n\n\n${ModuleFilenameHelpers.createFooter(modules[i], requestShortener)}`);
+						sourceMap.sourcesContent = sourceMap.sourcesContent.map((content, i) => typeof content === "string" ? `${content}\n\n\n${ModuleFilenameHelpers.createFooter(modules[i], requestShortener)}` : null);
 					} else {
 						sourceMap.sourcesContent = undefined;
 					}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix for issue 5542

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No. Will write with some guidance on how/where to do it. I have read the writing tests readme, but still not sure.
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Rleated issue - https://github.com/webpack/webpack/issues/5542
sourcesContent is mapped incorrectly currently, i.e. even when content is null it gets mapped, and hence the bug. The change makes sure we only map the content when it is a string, and return null otherwise.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
See issue - https://github.com/webpack/webpack/issues/5542

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
