### PR TITLE
Introduce webpack/__boilerplate__/ prefix for ECMAScript module identifier

### DIFF
--- a/lib/dependencies/HarmonyDetectionParserPlugin.js
+++ b/lib/dependencies/HarmonyDetectionParserPlugin.js
@@ -10,7 +10,11 @@ module.exports = class HarmonyDetectionParserPlugin {
 	apply(parser) {
 		parser.plugin("program", (ast) => {
 			var isHarmony = ast.body.some(statement => {
-				return /^(Import|Export).*Declaration$/.test(statement.type);
+				return /^(Import|Export).*Declaration$/.test(statement.type) &&
+					!(statement.type === "ImportDeclaration" &&
+						statement.source &&
+						statement.source.type === "Literal" &&
+						statement.source.value.startsWith("webpack/__boilerplate__/"));
 			});
 			if(isHarmony) {
 				const module = parser.state.module;

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -10,6 +10,10 @@ const HarmonyAcceptImportDependency = require("./HarmonyAcceptImportDependency")
 const HarmonyAcceptDependency = require("./HarmonyAcceptDependency");
 const HarmonyModulesHelpers = require("./HarmonyModulesHelpers");
 
+function normalizeSource(source) {
+	return source.replace(/^webpack\/__boilerplate__\//, "");
+}
+
 module.exports = class HarmonyImportDependencyParserPlugin {
 	constructor(moduleOptions) {
 		this.strictExportPresence = moduleOptions.strictExportPresence;
@@ -18,17 +22,19 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 
 	apply(parser) {
 		parser.plugin("import", (statement, source) => {
-			const dep = new HarmonyImportDependency(source, HarmonyModulesHelpers.getNewModuleVar(parser.state, source), statement.range);
+			const normalizedSource = normalizeSource(source);
+			const dep = new HarmonyImportDependency(normalizedSource, HarmonyModulesHelpers.getNewModuleVar(parser.state, normalizedSource), statement.range);
 			dep.loc = statement.loc;
 			parser.state.current.addDependency(dep);
 			parser.state.lastHarmonyImport = dep;
 			return true;
 		});
 		parser.plugin("import specifier", (statement, source, id, name) => {
+			const normalizedSource = normalizeSource(source);
 			parser.scope.definitions.length--;
 			parser.scope.renames[`$${name}`] = "imported var";
 			if(!parser.state.harmonySpecifier) parser.state.harmonySpecifier = {};
-			parser.state.harmonySpecifier[`$${name}`] = [parser.state.lastHarmonyImport, HarmonyModulesHelpers.getModuleVar(parser.state, source), id];
+			parser.state.harmonySpecifier[`$${name}`] = [parser.state.lastHarmonyImport, HarmonyModulesHelpers.getModuleVar(parser.state, normalizedSource), id];
 			return true;
 		});
 		parser.plugin("expression imported var", (expr) => {

--- a/test/cases/parsing/harmony-boilerplate-commonjs-mix/boilerplate.js
+++ b/test/cases/parsing/harmony-boilerplate-commonjs-mix/boilerplate.js
@@ -1,0 +1,2 @@
+const c = 42;
+export default c;

--- a/test/cases/parsing/harmony-boilerplate-commonjs-mix/index.js
+++ b/test/cases/parsing/harmony-boilerplate-commonjs-mix/index.js
@@ -1,0 +1,11 @@
+import boilerplate from "webpack/__boilerplate__/./boilerplate";
+
+it("should provide CommonJS interfaces even if webpack/__boilerplate__ import exists", function() {
+	(function() {
+		module.exports = 1;
+	}).should.not.throw();
+});
+
+it("should strip webpack/__boilerplate__/ prefix when importing", function() {
+	boilerplate.should.be.eql(42);
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature.

**Did you add tests for your changes?**

Yes.

**If relevant, link to documentation update:**

https://github.com/webpack/webpack.js.org/pull/1681

**Summary**

When an ECMAScript module identifier is prefixed with `webpack/__boilerplate__/` for importing, it would import the module but NOT mark the importing module is ECMAScript module.
It is convenient when adding implicit import with loader or plugin. In such a case, this change allows the module to utilize CommonJS features unless it has explicit Harmony import or export declaration.

**Does this PR introduce a breaking change?**

No.

**Other information**

This change is motivated to use Babel's runtime transform. To utilize this change, you can write the following to `.babelrc`:
```JSON
{
  "plugins": [
    ["transform-runtime", {
      "moduleName": "webpack/__boilerplate__/babel-runtime"
    }]
  ]
}
```