### PR TITLE
A new --concatenate-modules flag

### DIFF
--- a/bin/config-optimist.js
+++ b/bin/config-optimist.js
@@ -38,6 +38,7 @@ module.exports = function(optimist) {
 		.describe("optimize-max-chunks", "Try to keep the chunk count below a limit")
 		.describe("optimize-min-chunk-size", "Try to keep the chunk size above a limit")
 		.boolean("optimize-minimize").describe("optimize-minimize", "Minimize javascript and switches loaders to minimizing")
+		.boolean("concatenate-modules").describe("concatenate-modules", "Concatenate ES modules to remove module wrappers where possible")
 		.string("prefetch").describe("prefetch", "Prefetch this request")
 		.string("provide").describe("provide", "Provide these modules as free vars in all modules")
 		.string("plugin").describe("plugin", "Load this plugin")

--- a/bin/config-optimist.js
+++ b/bin/config-optimist.js
@@ -45,5 +45,5 @@ module.exports = function(optimist) {
 		.boolean("bail").describe("bail", "Abort the compilation on first error")
 		.boolean("profile").describe("profile", "Profile the compilation and include information in stats")
 		.boolean("d").describe("d", "shortcut for --debug --devtool eval-check-module-source-map --output-pathinfo")
-		.boolean("p").describe("p", "shortcut for --optimize-minimize --define process.env.NODE_ENV=\"production\"");
+		.boolean("p").describe("p", "shortcut for --optimize-minimize --define process.env.NODE_ENV=\"production\" --concatenate-modules");
 };

--- a/bin/config-yargs.js
+++ b/bin/config-yargs.js
@@ -225,6 +225,11 @@ module.exports = function(yargs) {
 				describe: "Minimize javascript and switches loaders to minimizing",
 				group: OPTIMIZE_GROUP
 			},
+			"concatenate-modules": {
+				type: "boolean",
+				describe: "Concatenate ES modules to remove module wrappers where possible",
+				group: OPTIMIZE_GROUP
+			},
 			"prefetch": {
 				type: "string",
 				describe: "Prefetch this request (Example: --prefetch ./file.js)",

--- a/bin/config-yargs.js
+++ b/bin/config-yargs.js
@@ -272,7 +272,7 @@ module.exports = function(yargs) {
 			},
 			"p": {
 				type: "boolean",
-				describe: "shortcut for --optimize-minimize --define process.env.NODE_ENV=\"production\"",
+				describe: "shortcut for --optimize-minimize --define process.env.NODE_ENV=\"production\" --concatenate-modules",
 				group: BASIC_GROUP
 			}
 		}).strict();

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -465,6 +465,12 @@ module.exports = function(yargs, argv, convertOptions) {
 			}));
 		});
 
+		ifBooleanArg("concatenate-modules", function() {
+			ensureArray(options, "plugins");
+			var ModuleConcatenationPlugin = require("../lib/optimize/ModuleConcatenationPlugin");
+			options.plugins.push(new ModuleConcatenationPlugin());
+		});
+
 		ifArg("prefetch", function(request) {
 			ensureArray(options, "plugins");
 			var PrefetchPlugin = require("../lib/PrefetchPlugin");

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -19,6 +19,7 @@ module.exports = function(yargs, argv, convertOptions) {
 	if(argv.p) {
 		argv["optimize-minimize"] = true;
 		argv["define"] = [].concat(argv["define"] || []).concat("process.env.NODE_ENV=\"production\"");
+		argv["concatenate-modules"] = true;
 	}
 
 	var configFileLoaded = false;

--- a/test/binCases/optimize/concatenate-modules/a.js
+++ b/test/binCases/optimize/concatenate-modules/a.js
@@ -1,0 +1,1 @@
+export const a = 5;

--- a/test/binCases/optimize/concatenate-modules/index.js
+++ b/test/binCases/optimize/concatenate-modules/index.js
@@ -1,0 +1,3 @@
+import {a} from './a.js';
+
+console.log(a);

--- a/test/binCases/optimize/concatenate-modules/test.js
+++ b/test/binCases/optimize/concatenate-modules/test.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = function testAssertions(code, stdout, stderr) {
+	code.should.be.exactly(0);
+
+	stdout.should.be.ok();
+	stdout[5].should.containEql("./index.js + 1 module");
+	stdout[6].should.not.containEql("./a.js");
+
+	stderr.should.be.empty();
+};

--- a/test/binCases/optimize/concatenate-modules/test.opts
+++ b/test/binCases/optimize/concatenate-modules/test.opts
@@ -1,0 +1,6 @@
+--entry ./index.js
+--config ./webpack.config.js
+--output-filename [name].js
+--output-chunk-filename [id].chunk.js
+--target async-node
+--concatenate-modules

--- a/test/binCases/optimize/concatenate-modules/webpack.config.js
+++ b/test/binCases/optimize/concatenate-modules/webpack.config.js
@@ -1,0 +1,5 @@
+var path = require("path");
+
+module.exports = {
+	entry: path.resolve(__dirname, "./index"),
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Feature (a new CLI flag).

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No – there’re no tests for CLI flags.

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

https://github.com/webpack/webpack.js.org/pull/1686

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

This PR adds a new `--concatenate-modules` CLI flag for the `ModuleConcatenationPlugin` + includes this flag under the `-p` flag umbrella.

The `ModuleConcatenationPlugin` noticeably decreases the bundle size and has no visible drawbacks except slowing down the build and breaking HMR (both of which are acceptable in production mode). Adding it under the `-p` flag improves the webpack UX (i.e. the easier it is to enable the production mode, the better).

The `--concatenate-modules` flag is required to include the plugin into the `-p` shortcut.

A follow-up from [the discussion with Sean](https://twitter.com/TheLarkInn/status/925797092303368193).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

Yes.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

N/A.
