### PR TITLE
#5947 - ryant/master/hmr-outdated-dependency-tree to master

### DIFF
--- a/lib/HotModuleReplacement.runtime.js
+++ b/lib/HotModuleReplacement.runtime.js
@@ -358,83 +358,89 @@ module.exports = function() {
 		};
 
 		for(var id in hotUpdate) {
-			if(Object.prototype.hasOwnProperty.call(hotUpdate, id)) {
-				moduleId = toModuleId(id);
-				var result;
-				if(hotUpdate[id]) {
-					result = getAffectedStuff(moduleId);
-				} else {
-					result = {
-						type: "disposed",
-						moduleId: id
-					};
-				}
-				var abortError = false;
-				var doApply = false;
-				var doDispose = false;
-				var chainInfo = "";
-				if(result.chain) {
-					chainInfo = "\nUpdate propagation: " + result.chain.join(" -> ");
-				}
-				switch(result.type) {
-					case "self-declined":
-						if(options.onDeclined)
-							options.onDeclined(result);
-						if(!options.ignoreDeclined)
-							abortError = new Error("Aborted because of self decline: " + result.moduleId + chainInfo);
-						break;
-					case "declined":
-						if(options.onDeclined)
-							options.onDeclined(result);
-						if(!options.ignoreDeclined)
-							abortError = new Error("Aborted because of declined dependency: " + result.moduleId + " in " + result.parentId + chainInfo);
-						break;
-					case "unaccepted":
-						if(options.onUnaccepted)
-							options.onUnaccepted(result);
-						if(!options.ignoreUnaccepted)
-							abortError = new Error("Aborted because " + moduleId + " is not accepted" + chainInfo);
-						break;
-					case "accepted":
-						if(options.onAccepted)
-							options.onAccepted(result);
-						doApply = true;
-						break;
-					case "disposed":
-						if(options.onDisposed)
-							options.onDisposed(result);
-						doDispose = true;
-						break;
-					default:
-						throw new Error("Unexception type " + result.type);
-				}
-				if(abortError) {
-					hotSetStatus("abort");
-					return Promise.reject(abortError);
-				}
-				if(doApply) {
-					appliedUpdate[moduleId] = hotUpdate[moduleId];
-					addAllToSet(outdatedModules, result.outdatedModules);
-					for(moduleId in result.outdatedDependencies) {
-						if(Object.prototype.hasOwnProperty.call(result.outdatedDependencies, moduleId)) {
-							if(!outdatedDependencies[moduleId])
-								outdatedDependencies[moduleId] = [];
-							addAllToSet(outdatedDependencies[moduleId], result.outdatedDependencies[moduleId]);
-						}
+			if(!Object.prototype.hasOwnProperty.call(hotUpdate, id)) {
+				continue;
+			}
+
+			moduleId = toModuleId(id);
+			var result;
+			if(hotUpdate[id]) {
+				result = getAffectedStuff(moduleId);
+			} else {
+				result = {
+					type: "disposed",
+					moduleId: id
+				};
+			}
+			var abortError = false;
+			var doApply = false;
+			var doDispose = false;
+			var chainInfo = "";
+			if(result.chain) {
+				chainInfo = "\nUpdate propagation: " + result.chain.join(" -> ");
+			}
+			switch(result.type) {
+				case "self-declined":
+					if(options.onDeclined)
+						options.onDeclined(result);
+					if(!options.ignoreDeclined)
+						abortError = new Error("Aborted because of self decline: " + result.moduleId + chainInfo);
+					break;
+				case "declined":
+					if(options.onDeclined)
+						options.onDeclined(result);
+					if(!options.ignoreDeclined)
+						abortError = new Error("Aborted because of declined dependency: " + result.moduleId + " in " + result.parentId + chainInfo);
+					break;
+				case "unaccepted":
+					if(options.onUnaccepted)
+						options.onUnaccepted(result);
+					if(!options.ignoreUnaccepted)
+						abortError = new Error("Aborted because " + moduleId + " is not accepted" + chainInfo);
+					break;
+				case "accepted":
+					if(options.onAccepted)
+						options.onAccepted(result);
+					doApply = true;
+					break;
+				case "disposed":
+					if(options.onDisposed)
+						options.onDisposed(result);
+					doDispose = true;
+					break;
+				default:
+					throw new Error("Unexception type " + result.type);
+			}
+			if(abortError) {
+				hotSetStatus("abort");
+				return Promise.reject(abortError);
+			}
+			if(doApply) {
+				appliedUpdate[moduleId] = hotUpdate[moduleId];
+				addAllToSet(outdatedModules, result.outdatedModules);
+				for(moduleId in result.outdatedDependencies) {
+					if(!Object.prototype.hasOwnProperty.call(result.outdatedDependencies, moduleId)) {
+						continue;
 					}
 
-					for(moduleId in result.outdatedDependencyChains) {
-						if(Object.prototype.hasOwnProperty.call(result.outdatedDependencyChains, moduleId)) {
-							if(!outdatedDependencyChains[moduleId])
-								outdatedDependencyChains[moduleId] = [];
-							addAllToSet(outdatedDependencyChains[moduleId], result.outdatedDependencyChains[moduleId]);
-						}
+					if(!outdatedDependencies[moduleId])
+						outdatedDependencies[moduleId] = [];
+					addAllToSet(outdatedDependencies[moduleId], result.outdatedDependencies[moduleId]);
+				}
+
+				for(moduleId in result.outdatedDependencyChains) {
+					if(!Object.prototype.hasOwnProperty.call(result.outdatedDependencyChains, moduleId)) {
+						continue;
 					}
+
+					if(!outdatedDependencyChains[moduleId])
+						outdatedDependencyChains[moduleId] = [];
+					addAllToSet(outdatedDependencyChains[moduleId], result.outdatedDependencyChains[moduleId]);
 				}
-				if(doDispose) {
-					addAllToSet(outdatedModules, [result.moduleId]);
-					appliedUpdate[moduleId] = warnUnexpectedRequire;
-				}
+			}
+			if(doDispose) {
+				addAllToSet(outdatedModules, [result.moduleId]);
+				appliedUpdate[moduleId] = warnUnexpectedRequire;
 			}
 		}
 
@@ -498,16 +504,20 @@ module.exports = function() {
 		var dependency;
 		var moduleOutdatedDependencies;
 		for(moduleId in outdatedDependencies) {
-			if(Object.prototype.hasOwnProperty.call(outdatedDependencies, moduleId)) {
-				module = installedModules[moduleId];
-				if(module) {
-					moduleOutdatedDependencies = outdatedDependencies[moduleId];
-					for(j = 0; j < moduleOutdatedDependencies.length; j++) {
-						dependency = moduleOutdatedDependencies[j];
-						idx = module.children.indexOf(dependency);
-						if(idx >= 0) module.children.splice(idx, 1);
-					}
-				}
+			if(!Object.prototype.hasOwnProperty.call(outdatedDependencies, moduleId)) {
+				continue;
+			}
+
+			module = installedModules[moduleId];
+			if(!module) {
+				continue;
+			}
+
+			moduleOutdatedDependencies = outdatedDependencies[moduleId];
+			for(j = 0; j < moduleOutdatedDependencies.length; j++) {
+				dependency = moduleOutdatedDependencies[j];
+				idx = module.children.indexOf(dependency);
+				if(idx >= 0) module.children.splice(idx, 1);
 			}
 		}
 
@@ -556,39 +566,43 @@ module.exports = function() {
 		var moduleOutdatedDependencyTree;
 
 		for(moduleId in outdatedDependencies) {
-			if(Object.prototype.hasOwnProperty.call(outdatedDependencies, moduleId)) {
-				module = installedModules[moduleId];
-				if(module) {
-					moduleOutdatedDependencies = outdatedDependencies[moduleId];
-					moduleOutdatedDependencyTree = buildOutdatedDependencyTree(moduleId);
+			if(!Object.prototype.hasOwnProperty.call(outdatedDependencies, moduleId)) {
+				continue;
+			}
 
-					var callbacks = [];
-					for(i = 0; i < moduleOutdatedDependencies.length; i++) {
-						dependency = moduleOutdatedDependencies[i];
-						cb = module.hot._acceptedDependencies[dependency];
-						if(cb) {
-							if(callbacks.indexOf(cb) >= 0) continue;
-							callbacks.push(cb);
-						}
+			module = installedModules[moduleId];
+			if(!module) {
+				continue;
+			}
+
+			moduleOutdatedDependencies = outdatedDependencies[moduleId];
+			moduleOutdatedDependencyTree = buildOutdatedDependencyTree(moduleId);
+
+			var callbacks = [];
+			for(i = 0; i < moduleOutdatedDependencies.length; i++) {
+				dependency = moduleOutdatedDependencies[i];
+				cb = module.hot._acceptedDependencies[dependency];
+				if(cb && callbacks.indexOf(cb) < 0) {
+					callbacks.push(cb);
+				}
+			}
+
+			for(i = 0; i < callbacks.length; i++) {
+				cb = callbacks[i];
+				try {
+					cb(moduleOutdatedDependencies, moduleOutdatedDependencyTree);
+				} catch(err) {
+					if(options.onErrored) {
+						options.onErrored({
+							type: "accept-errored",
+							moduleId: moduleId,
+							dependencyId: moduleOutdatedDependencies[i],
+							error: err
+						});
 					}
-					for(i = 0; i < callbacks.length; i++) {
-						cb = callbacks[i];
-						try {
-							cb(moduleOutdatedDependencies, moduleOutdatedDependencyTree);
-						} catch(err) {
-							if(options.onErrored) {
-								options.onErrored({
-									type: "accept-errored",
-									moduleId: moduleId,
-									dependencyId: moduleOutdatedDependencies[i],
-									error: err
-								});
-							}
-							if(!options.ignoreErrored) {
-								if(!error)
-									error = err;
-							}
-						}
+					if(!options.ignoreErrored) {
+						if(!error)
+							error = err;
 					}
 				}
 			}

--- a/lib/HotModuleReplacement.runtime.js
+++ b/lib/HotModuleReplacement.runtime.js
@@ -265,6 +265,7 @@ module.exports = function() {
 		function getAffectedStuff(updateModuleId) {
 			var outdatedModules = [updateModuleId];
 			var outdatedDependencies = {};
+			var outdatedDependencyChains = {};
 
 			var queue = outdatedModules.slice().map(function(id) {
 				return {
@@ -305,6 +306,13 @@ module.exports = function() {
 							parentId: parentId
 						};
 					}
+
+					if(!outdatedDependencyChains[parentId])
+						outdatedDependencyChains[parentId] = [];
+
+					if(outdatedDependencyChains[parentId].indexOf(moduleId) < 0)
+						outdatedDependencyChains[parentId].push(moduleId);
+
 					if(outdatedModules.indexOf(parentId) >= 0) continue;
 					if(parent.hot._acceptedDependencies[moduleId]) {
 						if(!outdatedDependencies[parentId])
@@ -325,7 +333,8 @@ module.exports = function() {
 				type: "accepted",
 				moduleId: updateModuleId,
 				outdatedModules: outdatedModules,
-				outdatedDependencies: outdatedDependencies
+				outdatedDependencies: outdatedDependencies,
+				outdatedDependencyChains: outdatedDependencyChains
 			};
 		}
 
@@ -340,6 +349,7 @@ module.exports = function() {
 		// at begin all updates modules are outdated
 		// the "outdated" status can propagate to parents if they don't accept the children
 		var outdatedDependencies = {};
+		var outdatedDependencyChains = {};
 		var outdatedModules = [];
 		var appliedUpdate = {};
 
@@ -410,6 +420,14 @@ module.exports = function() {
 							if(!outdatedDependencies[moduleId])
 								outdatedDependencies[moduleId] = [];
 							addAllToSet(outdatedDependencies[moduleId], result.outdatedDependencies[moduleId]);
+						}
+					}
+
+					for(moduleId in result.outdatedDependencyChains) {
+						if(Object.prototype.hasOwnProperty.call(result.outdatedDependencyChains, moduleId)) {
+							if(!outdatedDependencyChains[moduleId])
+								outdatedDependencyChains[moduleId] = [];
+							addAllToSet(outdatedDependencyChains[moduleId], result.outdatedDependencyChains[moduleId]);
 						}
 					}
 				}
@@ -505,13 +523,45 @@ module.exports = function() {
 			}
 		}
 
+		// used to recursively walk the outdated dependency children (depth first)
+		// to build the outdated dependency tree
+		function buildOutdatedDependencyTree(outdatedDependencyId, outdatedDependencyTree) {
+			if(!outdatedDependencyTree) {
+				outdatedDependencyTree = {};
+			}
+
+			if(outdatedDependencyTree[outdatedDependencyId]) {
+				// outdated id already in tree === circular reference, ignore this child
+				return outdatedDependencyTree;
+			}
+
+			var outdatedChildren = outdatedDependencyChains[outdatedDependencyId];
+			if(!outdatedChildren) {
+				// leaf node, add to tree and head back up
+				outdatedDependencyTree[outdatedDependencyId] = [];
+				return outdatedDependencyTree;
+			}
+
+			outdatedDependencyTree[outdatedDependencyId] = outdatedChildren;
+
+			for(var outdatedChildIndex = 0, outdatedChildCount = outdatedChildren.length; outdatedChildIndex < outdatedChildCount; ++outdatedChildIndex) {
+				outdatedDependencyTree = buildOutdatedDependencyTree(outdatedChildren[outdatedChildIndex], outdatedDependencyTree);
+			}
+
+			return outdatedDependencyTree;
+		}
+
 		// call accept handlers
 		var error = null;
+		var moduleOutdatedDependencyTree;
+
 		for(moduleId in outdatedDependencies) {
 			if(Object.prototype.hasOwnProperty.call(outdatedDependencies, moduleId)) {
 				module = installedModules[moduleId];
 				if(module) {
 					moduleOutdatedDependencies = outdatedDependencies[moduleId];
+					moduleOutdatedDependencyTree = buildOutdatedDependencyTree(moduleId);
+
 					var callbacks = [];
 					for(i = 0; i < moduleOutdatedDependencies.length; i++) {
 						dependency = moduleOutdatedDependencies[i];
@@ -524,7 +574,7 @@ module.exports = function() {
 					for(i = 0; i < callbacks.length; i++) {
 						cb = callbacks[i];
 						try {
-							cb(moduleOutdatedDependencies);
+							cb(moduleOutdatedDependencies, moduleOutdatedDependencyTree);
 						} catch(err) {
 							if(options.onErrored) {
 								options.onErrored({

--- a/test/hotCases/errors/events/index.js
+++ b/test/hotCases/errors/events/index.js
@@ -4,6 +4,8 @@ import d from "./d";
 import f from "./f";
 import h from "./h";
 import j from "./j";
+import k from "./k";
+import l from "./l";
 
 it("should fire the correct events", function(done) {
 	var events = [];
@@ -36,6 +38,7 @@ it("should fire the correct events", function(done) {
 				type: "accepted",
 				moduleId: "./c.js",
 				outdatedDependencies: { "./b.js": [ "./c.js" ] },
+				outdatedDependencyChains: { "./b.js": [ "./c.js"] },
 				outdatedModules: [ "./c.js" ],
 			},
 			{
@@ -53,13 +56,79 @@ it("should fire the correct events", function(done) {
 				type: "accepted",
 				moduleId: "./i.js",
 				outdatedDependencies: { "./h.js": [ "./i.js" ] },
+				outdatedDependencyChains: { "./h.js": [ "./i.js"] },
 				outdatedModules: [ "./i.js" ],
 			},
 			{
 				type: "accepted",
 				moduleId: "./j.js",
 				outdatedDependencies: {},
+				outdatedDependencyChains: {},
 				outdatedModules: [ "./j.js" ],
+			},
+			{
+				type: "accepted",
+				moduleId: "./k_valueA.js",
+				outdatedDependencies: { "./k.js": [ "./k_exports.js"] },
+				outdatedDependencyChains: {
+					"./k.js": ["./k_exports.js"],
+					"./k_exports.js": [ "./k_valueA.js" ]
+				},
+				outdatedModules: [ "./k_valueA.js", "./k_exports.js" ]
+			},
+			{
+				type: "accepted",
+				moduleId: "./k_valueB.js",
+				outdatedDependencies: { "./k.js": [ "./k_exports.js"] },
+				outdatedDependencyChains: {
+					"./k.js": ["./k_exports.js"],
+					"./k_exports.js": [ "./k_valueB.js" ]
+				},
+				outdatedModules: [ "./k_valueB.js", "./k_exports.js" ]
+			},
+			{
+				type: "accepted",
+				moduleId: "./k_valueC.js",
+				outdatedDependencies: { "./k.js": [ "./k_exports.js"] },
+				outdatedDependencyChains: {
+					"./k.js": ["./k_exports.js"],
+					"./k_exports.js": [ "./k_valueC.js" ]
+				},
+				outdatedModules: [ "./k_valueC.js", "./k_exports.js" ]
+			},
+			{
+				type: "accepted",
+				moduleId: "./k_valueD.js",
+				outdatedDependencies: { "./k.js": [ "./k_exports.js"] },
+				outdatedDependencyChains: {
+					"./k.js": ["./k_exports.js"],
+					"./k_exports.js": [ "./k_valueD.js" ]
+				},
+				outdatedModules: [ "./k_valueD.js", "./k_exports.js" ]
+			},
+			{
+				type: "accepted",
+				moduleId: "./l_valueA.js",
+				outdatedDependencies: { "./l.js": [ "./l_exports.js"] },
+				outdatedDependencyChains: {
+					"./l.js": ["./l_exports.js"],
+					"./l_exports.js": [ "./l_valueA.js", "./l_valueD.js", "./l_valueC.js" ],
+					"./l_valueC.js": [ "./l_exports.js" ],
+					"./l_valueD.js": [ "./l_exports.js" ]
+				},
+				outdatedModules: [ "./l_valueA.js", "./l_exports.js", "./l_valueC.js", "./l_valueD.js" ]
+			},
+			{
+				type: "accepted",
+				moduleId: "./l_valueC.js",
+				outdatedDependencies: { "./l.js": [ "./l_exports.js"] },
+				outdatedDependencyChains: {
+					"./l.js": ["./l_exports.js"],
+					"./l_exports.js": [ "./l_valueC.js", "./l_valueD.js" ],
+					"./l_valueC.js": [ "./l_exports.js" ],
+					"./l_valueD.js": [ "./l_exports.js" ]
+				},
+				outdatedModules: [ "./l_valueC.js", "./l_exports.js", "./l_valueD.js" ]
 			},
 			{
 				type: "accept-errored",

--- a/test/hotCases/errors/events/k.js
+++ b/test/hotCases/errors/events/k.js
@@ -1,0 +1,5 @@
+import values from "./k_exports";
+
+if(module.hot) {
+	module.hot.accept("./k_exports");
+}

--- a/test/hotCases/errors/events/k_exports.js
+++ b/test/hotCases/errors/events/k_exports.js
@@ -1,0 +1,4 @@
+export { valueA } from './k_valueA';
+export { valueB } from './k_valueB';
+export { valueC } from './k_valueC';
+export { valueD } from './k_valueD';

--- a/test/hotCases/errors/events/k_valueA.js
+++ b/test/hotCases/errors/events/k_valueA.js
@@ -1,0 +1,3 @@
+export const valueA = 1;
+---
+export const valueA = 2;

--- a/test/hotCases/errors/events/k_valueB.js
+++ b/test/hotCases/errors/events/k_valueB.js
@@ -1,0 +1,3 @@
+export const valueB = 1;
+---
+export const valueB = 2;

--- a/test/hotCases/errors/events/k_valueC.js
+++ b/test/hotCases/errors/events/k_valueC.js
@@ -1,0 +1,3 @@
+export const valueC = 1;
+---
+export const valueC = 2;

--- a/test/hotCases/errors/events/k_valueD.js
+++ b/test/hotCases/errors/events/k_valueD.js
@@ -1,0 +1,3 @@
+export const valueD = 1;
+---
+export const valueD = 2;

--- a/test/hotCases/errors/events/l.js
+++ b/test/hotCases/errors/events/l.js
@@ -1,0 +1,5 @@
+import values from "./l_exports";
+
+if(module.hot) {
+	module.hot.accept("./l_exports");
+}

--- a/test/hotCases/errors/events/l_exports.js
+++ b/test/hotCases/errors/events/l_exports.js
@@ -1,0 +1,4 @@
+export { valueA } from './l_valueA';
+export { valueB } from './l_valueB';
+export { valueC } from './l_valueC';
+export { valueD } from './l_valueD';

--- a/test/hotCases/errors/events/l_valueA.js
+++ b/test/hotCases/errors/events/l_valueA.js
@@ -1,0 +1,3 @@
+export const valueA = 1;
+---
+export const valueA = 2;

--- a/test/hotCases/errors/events/l_valueB.js
+++ b/test/hotCases/errors/events/l_valueB.js
@@ -1,0 +1,1 @@
+export const valueB = 1;

--- a/test/hotCases/errors/events/l_valueC.js
+++ b/test/hotCases/errors/events/l_valueC.js
@@ -1,0 +1,5 @@
+import { valueA } from './l_exports';
+export const valueC = valueA + 5;
+---
+import { valueA } from './l_exports';
+export const valueC = valueA + 10;

--- a/test/hotCases/errors/events/l_valueD.js
+++ b/test/hotCases/errors/events/l_valueD.js
@@ -1,0 +1,2 @@
+import { valueC } from './l_exports';
+export const valueD = valueC * 2;

--- a/test/hotCases/runtime/accept-callback-first-parameter-complex-tree/index.js
+++ b/test/hotCases/runtime/accept-callback-first-parameter-complex-tree/index.js
@@ -1,0 +1,47 @@
+var values = require('./root');
+
+it("should accept dependencies and receive the outdated module ids as the first parameter of the callback", function(done) {
+	values.valueA.should.be.eql(1);
+	values.valueB.should.be.eql(1);
+	values.valueC.should.be.eql(6);
+	values.valueD.should.be.eql(12);
+
+	var rootModuleId = require.resolve('./root');
+	var expectedOutdatedModuleIds = [rootModuleId];
+
+	module.hot.accept("./root", function(outdatedModuleIds) {
+		values = require("./root");
+
+		values.valueA.should.be.eql(2);
+		values.valueB.should.be.eql(1);
+		values.valueC.should.be.eql(7);
+		values.valueD.should.be.eql(14);
+
+		outsideA();
+		outsideB();
+		outsideC();
+		outsideD();
+
+		outdatedModuleIds.should.be.eql(expectedOutdatedModuleIds);
+
+		done();
+	});
+
+	NEXT(require("../../update")(done));
+});
+
+function outsideA() {
+	values.valueA.should.be.eql(2);
+}
+
+function outsideB() {
+	values.valueB.should.be.eql(1);
+}
+
+function outsideC() {
+	values.valueC.should.be.eql(7);
+}
+
+function outsideD() {
+	values.valueD.should.be.eql(14);
+}

--- a/test/hotCases/runtime/accept-callback-first-parameter-complex-tree/root.js
+++ b/test/hotCases/runtime/accept-callback-first-parameter-complex-tree/root.js
@@ -1,0 +1,4 @@
+export { valueA } from './valueA';
+export { valueB } from './valueB';
+export { valueC } from './valueC';
+export { valueD } from './valueD';

--- a/test/hotCases/runtime/accept-callback-first-parameter-complex-tree/valueA.js
+++ b/test/hotCases/runtime/accept-callback-first-parameter-complex-tree/valueA.js
@@ -1,0 +1,3 @@
+export const valueA = 1;
+---
+export const valueA = 2;

--- a/test/hotCases/runtime/accept-callback-first-parameter-complex-tree/valueB.js
+++ b/test/hotCases/runtime/accept-callback-first-parameter-complex-tree/valueB.js
@@ -1,0 +1,1 @@
+export const valueB = 1;

--- a/test/hotCases/runtime/accept-callback-first-parameter-complex-tree/valueC.js
+++ b/test/hotCases/runtime/accept-callback-first-parameter-complex-tree/valueC.js
@@ -1,0 +1,2 @@
+import { valueA } from './root';
+export const valueC = valueA + 5;

--- a/test/hotCases/runtime/accept-callback-first-parameter-complex-tree/valueD.js
+++ b/test/hotCases/runtime/accept-callback-first-parameter-complex-tree/valueD.js
@@ -1,0 +1,2 @@
+import { valueC } from './root';
+export const valueD = valueC * 2;

--- a/test/hotCases/runtime/accept-callback-first-parameter/fileA.js
+++ b/test/hotCases/runtime/accept-callback-first-parameter/fileA.js
@@ -1,0 +1,3 @@
+module.exports = 1;
+---
+module.exports = 2;

--- a/test/hotCases/runtime/accept-callback-first-parameter/index.js
+++ b/test/hotCases/runtime/accept-callback-first-parameter/index.js
@@ -1,0 +1,24 @@
+var value = require("./fileA");
+
+it("should accept a dependency and receive the outdated module id as the first parameter of the callback", function(done) {
+	value.should.be.eql(1);
+
+	var fileA_ModuleId = require.resolve('./fileA');
+	var expectedOutdatedModuleIds = [fileA_ModuleId];
+
+	module.hot.accept("./fileA", function(outdatedModuleIds) {
+		value = require("./fileA");
+		value.should.be.eql(2);
+		outside();
+
+		outdatedModuleIds.should.be.eql(expectedOutdatedModuleIds);
+
+		done();
+	});
+
+	NEXT(require("../../update")(done));
+});
+
+function outside() {
+	value.should.be.eql(2);
+}

--- a/test/hotCases/runtime/accept-callback-second-parameter-complex-tree/index.js
+++ b/test/hotCases/runtime/accept-callback-second-parameter-complex-tree/index.js
@@ -1,0 +1,59 @@
+var values = require('./root');
+
+it("should accept dependencies and receive the outdated module dependency tree as the second parameter of the callback", function(done) {
+	values.valueA.should.be.eql(1);
+	values.valueB.should.be.eql(1);
+	values.valueC.should.be.eql(6);
+	values.valueD.should.be.eql(3);
+
+	var rootModuleId = require.resolve('./root');
+	var valueA_ModuleId = require.resolve('./valueA');
+	var valueC_ModuleId = require.resolve('./valueC');
+	var valueD_ModuleId = require.resolve('./valueD');
+
+	var expectedOutdatedDependencyTree = {};
+	expectedOutdatedDependencyTree[module.id] = [rootModuleId];
+
+	// because c and d require from their parent (root), their order will be inverted
+	expectedOutdatedDependencyTree[rootModuleId] = [valueA_ModuleId, valueD_ModuleId, valueC_ModuleId];
+
+	expectedOutdatedDependencyTree[valueA_ModuleId] = []; // empty array for leaves
+	expectedOutdatedDependencyTree[valueC_ModuleId] = [rootModuleId]; // will only have [root] as a child because root will already be in the tree and continuing would create a loop
+	expectedOutdatedDependencyTree[valueD_ModuleId] = [rootModuleId]; // will only have [root] as a child because root will already be in the tree and continuing would create a loop
+
+	module.hot.accept("./root", function(outdatedModuleIds, outdatedDependencyTree) {
+		values = require('./root');
+
+		values.valueA.should.be.eql(2);
+		values.valueB.should.be.eql(1);
+		values.valueC.should.be.eql(7);
+		values.valueD.should.be.eql(6);
+
+		outsideA();
+		outsideB();
+		outsideC();
+		outsideD();
+
+		outdatedDependencyTree.should.be.eql(expectedOutdatedDependencyTree);
+
+		done();
+	});
+
+	NEXT(require("../../update")(done));
+});
+
+function outsideA() {
+	values.valueA.should.be.eql(2);
+}
+
+function outsideB() {
+	values.valueB.should.be.eql(1);
+}
+
+function outsideC() {
+	values.valueC.should.be.eql(7);
+}
+
+function outsideD() {
+	values.valueD.should.be.eql(6);
+}

--- a/test/hotCases/runtime/accept-callback-second-parameter-complex-tree/root.js
+++ b/test/hotCases/runtime/accept-callback-second-parameter-complex-tree/root.js
@@ -1,0 +1,4 @@
+export { valueA } from './valueA';
+export { valueB } from './valueB';
+export { valueC } from './valueC';
+export { valueD } from './valueD';

--- a/test/hotCases/runtime/accept-callback-second-parameter-complex-tree/valueA.js
+++ b/test/hotCases/runtime/accept-callback-second-parameter-complex-tree/valueA.js
@@ -1,0 +1,3 @@
+export const valueA = 1;
+---
+export const valueA = 2;

--- a/test/hotCases/runtime/accept-callback-second-parameter-complex-tree/valueB.js
+++ b/test/hotCases/runtime/accept-callback-second-parameter-complex-tree/valueB.js
@@ -1,0 +1,1 @@
+export const valueB = 1;

--- a/test/hotCases/runtime/accept-callback-second-parameter-complex-tree/valueC.js
+++ b/test/hotCases/runtime/accept-callback-second-parameter-complex-tree/valueC.js
@@ -1,0 +1,2 @@
+import { valueA } from './root';
+export const valueC = valueA + 5;

--- a/test/hotCases/runtime/accept-callback-second-parameter-complex-tree/valueD.js
+++ b/test/hotCases/runtime/accept-callback-second-parameter-complex-tree/valueD.js
@@ -1,0 +1,2 @@
+import { valueA } from './root';
+export const valueD = valueA * 3;

--- a/test/hotCases/runtime/accept-callback-second-parameter/fileA.js
+++ b/test/hotCases/runtime/accept-callback-second-parameter/fileA.js
@@ -1,0 +1,3 @@
+module.exports = 1;
+---
+module.exports = 2;

--- a/test/hotCases/runtime/accept-callback-second-parameter/index.js
+++ b/test/hotCases/runtime/accept-callback-second-parameter/index.js
@@ -1,0 +1,26 @@
+var value = require("./fileA");
+
+it("should accept a dependency and receive the outdated dependency tree as the second parameter of the callback", function(done) {
+	value.should.be.eql(1);
+
+	var fileA_ModuleId = require.resolve('./fileA');
+	var expectedOutdatedDependencyTree = {};
+	expectedOutdatedDependencyTree[module.id] = [fileA_ModuleId];
+	expectedOutdatedDependencyTree[fileA_ModuleId] = []; // empty array for leaf
+
+	module.hot.accept("./fileA", function(__ignored__, outdatedDependencyTree) {
+		value = require("./fileA");
+		value.should.be.eql(2);
+		outside();
+
+		outdatedDependencyTree.should.be.eql(expectedOutdatedDependencyTree);
+
+		done();
+	});
+
+	NEXT(require("../../update")(done));
+});
+
+function outside() {
+	value.should.be.eql(2);
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature, addresses issue #5947 

**Did you add tests for your changes?**
Yes
1. Added unit tests for the existing first parameter (outdated dependencies) passed to the `module.hot.accept` callback.
2. Added unit tests for the *new* second parameter (outdated dependency graph) passed to the `module.hot.accept` callback.
3. Updated the `test/hotCases/errors/events/index.js` expected results to include the additional `outdatedDependencyChains` member. 
4. Added additional events test cases `k` and `l` to to cover re-export and circular references, respectively.

**Summary**
Provides a 2nd parameter to `module.hot.accept` callbacks containing information about all of the outdated dependencies in the update including outdated grandchildren.

See the issue description.

**Does this PR introduce a breaking change?**
No. The additional outdated dependency graph is provided as a new parameter, the first parameter to the callback has been left unchanged.