### PR TITLE
Handle amd define with arrow function

### DIFF
--- a/lib/dependencies/AMDDefineDependency.js
+++ b/lib/dependencies/AMDDefineDependency.js
@@ -25,7 +25,7 @@ AMDDefineDependency.Template = class AMDDefineDependencyTemplate {
 		return {
 			f: [
 				"var __WEBPACK_AMD_DEFINE_RESULT__;",
-				`!(__WEBPACK_AMD_DEFINE_RESULT__ = #.call(exports, __webpack_require__, exports, module),
+				`!(__WEBPACK_AMD_DEFINE_RESULT__ = (#).call(exports, __webpack_require__, exports, module),
 				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__))`
 			],
 			o: [
@@ -42,7 +42,7 @@ AMDDefineDependency.Template = class AMDDefineDependencyTemplate {
 			],
 			af: [
 				"var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;",
-				`!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, __WEBPACK_AMD_DEFINE_RESULT__ = #.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
+				`!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, __WEBPACK_AMD_DEFINE_RESULT__ = (#).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
 				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__))`
 			],
 			ao: [
@@ -70,7 +70,7 @@ AMDDefineDependency.Template = class AMDDefineDependencyTemplate {
 			],
 			laf: [
 				"var __WEBPACK_AMD_DEFINE_ARRAY__, XXX;",
-				"!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, XXX = (#.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)))"
+				"!(__WEBPACK_AMD_DEFINE_ARRAY__ = #, XXX = ((#).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)))"
 			],
 			lao: [
 				"var XXX;",

--- a/lib/dependencies/AMDDefineDependencyParserPlugin.js
+++ b/lib/dependencies/AMDDefineDependencyParserPlugin.js
@@ -23,6 +23,18 @@ function isBoundFunctionExpression(expr) {
 	return true;
 }
 
+function isUnboundFunctionExpression(expr) {
+	if(expr.type === "FunctionExpression") return true;
+	if(expr.type === "ArrowFunctionExpression") return true;
+	return false;
+}
+
+function isCallable(expr) {
+	if(isUnboundFunctionExpression(expr)) return true;
+	if(isBoundFunctionExpression(expr)) return true;
+	return false;
+}
+
 class AMDDefineDependencyParserPlugin {
 	constructor(options) {
 		this.options = options;
@@ -38,7 +50,7 @@ class AMDDefineDependencyParserPlugin {
 			let array, fn, obj, namedModule;
 			switch(expr.arguments.length) {
 				case 1:
-					if(expr.arguments[0].type === "FunctionExpression" || isBoundFunctionExpression(expr.arguments[0])) {
+					if(isCallable(expr.arguments[0])) {
 						// define(f() {...})
 						fn = expr.arguments[0];
 					} else if(expr.arguments[0].type === "ObjectExpression") {
@@ -54,7 +66,7 @@ class AMDDefineDependencyParserPlugin {
 					if(expr.arguments[0].type === "Literal") {
 						namedModule = expr.arguments[0].value;
 						// define("...", ...)
-						if(expr.arguments[1].type === "FunctionExpression" || isBoundFunctionExpression(expr.arguments[1])) {
+						if(isCallable(expr.arguments[1])) {
 							// define("...", f() {...})
 							fn = expr.arguments[1];
 						} else if(expr.arguments[1].type === "ObjectExpression") {
@@ -67,7 +79,7 @@ class AMDDefineDependencyParserPlugin {
 						}
 					} else {
 						array = expr.arguments[0];
-						if(expr.arguments[1].type === "FunctionExpression" || isBoundFunctionExpression(expr.arguments[1])) {
+						if(isCallable(expr.arguments[1])) {
 							// define([...], f() {})
 							fn = expr.arguments[1];
 						} else if(expr.arguments[1].type === "ObjectExpression") {
@@ -84,7 +96,7 @@ class AMDDefineDependencyParserPlugin {
 					// define("...", [...], f() {...})
 					namedModule = expr.arguments[0].value;
 					array = expr.arguments[1];
-					if(expr.arguments[2].type === "FunctionExpression" || isBoundFunctionExpression(expr.arguments[2])) {
+					if(isCallable(expr.arguments[2])) {
 						// define("...", [...], f() {})
 						fn = expr.arguments[2];
 					} else if(expr.arguments[2].type === "ObjectExpression") {
@@ -102,7 +114,7 @@ class AMDDefineDependencyParserPlugin {
 			let fnParams = null;
 			let fnParamsOffset = 0;
 			if(fn) {
-				if(fn.type === "FunctionExpression") fnParams = fn.params;
+				if(isUnboundFunctionExpression(fn)) fnParams = fn.params;
 				else if(isBoundFunctionExpression(fn)) {
 					fnParams = fn.callee.object.params;
 					fnParamsOffset = fn.arguments.length - 1;
@@ -134,7 +146,7 @@ class AMDDefineDependencyParserPlugin {
 				});
 			}
 			let inTry;
-			if(fn && fn.type === "FunctionExpression") {
+			if(fn && isUnboundFunctionExpression(fn)) {
 				inTry = parser.scope.inTry;
 				parser.inScope(fnParams, () => {
 					parser.scope.renames = fnRenames;

--- a/lib/dependencies/AMDRequireDependency.js
+++ b/lib/dependencies/AMDRequireDependency.js
@@ -44,8 +44,8 @@ AMDRequireDependency.Template = class AMDRequireDependencyTemplate {
 
 			source.replace(depBlock.outerRange[0], depBlock.arrayRange[0] - 1, startBlock);
 			source.insert(depBlock.arrayRange[0] + 0.9, "var __WEBPACK_AMD_REQUIRE_ARRAY__ = ");
-			source.replace(depBlock.arrayRange[1], depBlock.functionRange[0] - 1, "; (");
-			source.insert(depBlock.functionRange[1], ".apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__));");
+			source.replace(depBlock.arrayRange[1], depBlock.functionRange[0] - 1, "; ((");
+			source.insert(depBlock.functionRange[1], ").apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__));");
 			source.replace(depBlock.functionRange[1], depBlock.errorCallbackRange[0] - 1, errorRangeBlock);
 			source.replace(depBlock.errorCallbackRange[1], depBlock.outerRange[1] - 1, endBlock);
 			return;
@@ -57,8 +57,8 @@ AMDRequireDependency.Template = class AMDRequireDependencyTemplate {
 			const endBlock = `}${depBlock.functionBindThis ? ".bind(this)" : ""}${wrapper[1]}__webpack_require__.oe${wrapper[2]}`;
 			source.replace(depBlock.outerRange[0], depBlock.arrayRange[0] - 1, startBlock);
 			source.insert(depBlock.arrayRange[0] + 0.9, "var __WEBPACK_AMD_REQUIRE_ARRAY__ = ");
-			source.replace(depBlock.arrayRange[1], depBlock.functionRange[0] - 1, "; (");
-			source.insert(depBlock.functionRange[1], ".apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__));");
+			source.replace(depBlock.arrayRange[1], depBlock.functionRange[0] - 1, "; ((");
+			source.insert(depBlock.functionRange[1], ").apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__));");
 			source.replace(depBlock.functionRange[1], depBlock.outerRange[1] - 1, endBlock);
 		}
 	}

--- a/test/cases/parsing/extract-amd.nominimize/a.js
+++ b/test/cases/parsing/extract-amd.nominimize/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/test/cases/parsing/extract-amd.nominimize/amdmodule.js
+++ b/test/cases/parsing/extract-amd.nominimize/amdmodule.js
@@ -1,0 +1,3 @@
+define((require) => {
+	return require("./a");
+});

--- a/test/cases/parsing/extract-amd.nominimize/c.js
+++ b/test/cases/parsing/extract-amd.nominimize/c.js
@@ -1,0 +1,1 @@
+module.exports = "c";

--- a/test/cases/parsing/extract-amd.nominimize/circular.js
+++ b/test/cases/parsing/extract-amd.nominimize/circular.js
@@ -1,0 +1,2 @@
+module.exports = 1;
+module.exports = require("./circular");

--- a/test/cases/parsing/extract-amd.nominimize/constructor.js
+++ b/test/cases/parsing/extract-amd.nominimize/constructor.js
@@ -1,0 +1,3 @@
+module.exports = function(value) {
+	this.value = value;
+}

--- a/test/cases/parsing/extract-amd.nominimize/d.js
+++ b/test/cases/parsing/extract-amd.nominimize/d.js
@@ -1,0 +1,1 @@
+module.exports = "d";

--- a/test/cases/parsing/extract-amd.nominimize/index.js
+++ b/test/cases/parsing/extract-amd.nominimize/index.js
@@ -1,0 +1,118 @@
+var should = require("should");
+
+it("should parse fancy function calls with arrow functions", function() {
+	("function"==typeof define && define.amd ?
+		define :
+		(e,t) => {return t()}
+	)(["./constructor"], (c) => {
+		return new c(1324);
+	});
+	module.exports.should.have.property("value").be.eql(1324);
+	(("function"==typeof define && define.amd ?
+		define :
+		(e,t) => {return t()}
+	)(["./constructor"], (c) => {
+		return new c(4231);
+	}));
+	module.exports.should.have.property("value").be.eql(4231);
+});
+
+it("should parse fancy AMD calls with arrow functions", function() {
+	require("./constructor ./a".split(" "));
+	require("-> module module exports *constructor *a".replace("module", "require").substr(3).replace(/\*/g, "./").split(" "), (require, module, exports, constructor, a) => {
+		(typeof require).should.be.eql("function");
+		(typeof module).should.be.eql("object");
+		(typeof exports).should.be.eql("object");
+		(typeof require("./constructor")).should.be.eql("function");
+		(typeof constructor).should.be.eql("function");
+		a.should.be.eql("a");
+	});
+	define("-> module module exports *constructor *a".replace("module", "require").substr(3).replace(/\*/g, "./").split(" "), (require, module, exports, constructor, a) => {
+		(typeof require).should.be.eql("function");
+		(typeof module).should.be.eql("object");
+		(typeof exports).should.be.eql("object");
+		(typeof require("./constructor")).should.be.eql("function");
+		(typeof constructor).should.be.eql("function");
+		a.should.be.eql("a");
+	});
+});
+
+it("should be able to use AMD-style require with arrow functions", function(done) {
+	var template = "b";
+	require(["./circular", "./templates/" + template, true ? "./circular" : "fail"], (circular, testTemplate, circular2) => {
+		circular.should.be.eql(1);
+		circular2.should.be.eql(1);
+		testTemplate.should.be.eql("b");
+		done();
+	});
+});
+
+it("should be able to use require.js-style define with arrow functions", function(done) {
+	define("name", ["./circular"], (circular) => {
+		circular.should.be.eql(1);
+		done();
+	});
+});
+
+it("should be able to use require.js-style define, optional dependancies, not exist, with arrow function", function(done) {
+	define("name", ["./optional"], (optional) => {
+		should(optional.b).not.exist;
+		done();
+	});
+});
+
+it("should be able to use require.js-style define, special string, with arrow function", function(done) {
+	define(["require"], (require) => {
+		require("./circular").should.be.eql(1);
+		done();
+	});
+});
+
+it("should be able to use require.js-style define, without name, with arrow function", function(done) {
+	true && define(["./circular"], (circular) => {
+		circular.should.be.eql(1);
+		done();
+	});
+});
+
+it("should be able to use require.js-style define, with empty dependencies, with arrow function", function(done) {
+	define("name", [], () => {
+		done();
+	});
+});
+
+it("should be able to use require.js-style define, without dependencies, with arrow function", function(done) {
+	true && define("name", () => {
+		done();
+	});
+});
+
+it("should offer AMD-style define for CommonJs with arrow function", function(done) {
+	var _test_exports = exports;
+	var _test_module = module;
+	define((require, exports, module) => {
+		(typeof require).should.be.eql("function");
+		exports.should.be.equal(_test_exports);
+		module.should.be.equal(_test_module);
+		require("./circular").should.be.eql(1);
+		done();
+	});
+});
+
+it("should pull in all dependencies of an AMD module with arrow function", function(done) {
+	define((require) => {
+		require("./amdmodule").should.be.eql("a");
+		done();
+	});
+});
+
+it("should create a chunk for require.js require, with arrow function", function(done) {
+	var sameTick = true;
+	require(["./c"], (c) => {
+		sameTick.should.be.eql(false);
+		c.should.be.eql("c");
+		require("./d").should.be.eql("d");
+		done();
+	});
+	sameTick = false;
+});

--- a/test/cases/parsing/extract-amd.nominimize/optional.js
+++ b/test/cases/parsing/extract-amd.nominimize/optional.js
@@ -1,0 +1,3 @@
+module.exports = 2;
+try { module.exports.a = require("./a"); } catch (e) {};
+try { module.exports.b = require("./b"); } catch (e) {};

--- a/test/cases/parsing/extract-amd.nominimize/templates/a.js
+++ b/test/cases/parsing/extract-amd.nominimize/templates/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/test/cases/parsing/extract-amd.nominimize/templates/b.js
+++ b/test/cases/parsing/extract-amd.nominimize/templates/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/test/cases/parsing/extract-amd.nominimize/templates/c.js
+++ b/test/cases/parsing/extract-amd.nominimize/templates/c.js
@@ -1,0 +1,1 @@
+module.exports = "c";

--- a/test/cases/parsing/extract-amd.nominimize/test.filter.js
+++ b/test/cases/parsing/extract-amd.nominimize/test.filter.js
@@ -1,0 +1,5 @@
+var supportsES6 = require("../../../helpers/supportsES6");
+
+module.exports = function(config) {
+	return !config.minimize && supportsES6();
+};

--- a/test/cases/parsing/extract-amd.nominimize/warnings.js
+++ b/test/cases/parsing/extract-amd.nominimize/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[/Module not found/, /Can't resolve '\.\/b' /, /b\.js/]
+];

--- a/test/cases/parsing/extract-amd/index.js
+++ b/test/cases/parsing/extract-amd/index.js
@@ -168,20 +168,6 @@ it("should not fail #138", function(done) {
 	}(function () { done() }));
 });
 
-it("should parse a simplified commonjs wrapping", function(done) {
-	define(function(require) {
-		require("./a").should.be.eql("a");
-		done();
-	});
-});
-
-it("should parse a simplified commonjs wrapping arrow function", function(done) {
-	define((require) => {
-		require("./a").should.be.eql("a");
-		done();
-	});
-});
-
 it("should parse a bound function expression 1", function(done) {
 	define(function(a, require, exports, module) {
 		a.should.be.eql(123);

--- a/test/cases/parsing/extract-amd/index.js
+++ b/test/cases/parsing/extract-amd/index.js
@@ -168,6 +168,20 @@ it("should not fail #138", function(done) {
 	}(function () { done() }));
 });
 
+it("should parse a simplified commonjs wrapping", function(done) {
+	define(function(require) {
+		require("./a").should.be.eql("a");
+		done();
+	});
+});
+
+it("should parse a simplified commonjs wrapping arrow function", function(done) {
+	define((require) => {
+		require("./a").should.be.eql("a");
+		done();
+	});
+});
+
 it("should parse a bound function expression 1", function(done) {
 	define(function(a, require, exports, module) {
 		a.should.be.eql(123);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
Yes tests have been added.

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->
N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This is a bugfix for https://github.com/webpack/webpack/issues/5916
AMD define with arrow function was not including dependencies.

```js
define((require) => { ... });
```

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
