### PR TITLE
SourceMapDevToolPlugin: Enable path stripping from source map filenam…

### DIFF
--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -188,10 +188,7 @@ class SourceMapDevToolPlugin {
 						if(sourceMapFile.indexOf("[contenthash]") !== -1) {
 							sourceMapFile = sourceMapFile.replace(/\[contenthash\]/g, crypto.createHash("md5").update(sourceMapString).digest("hex"));
 						}
-						let sourceMapUrl = (options.fileContext ? sourceMapFile : path.relative(path.dirname(file), sourceMapFile)).replace(/\\/g, "/");
-						if(options.publicPath) {
-							sourceMapUrl = options.publicPath + sourceMapUrl;
-						}
+						const sourceMapUrl = options.publicPath ? options.publicPath + sourceMapFile.replace(/\\/g, "/") : path.relative(path.dirname(file), sourceMapFile).replace(/\\/g, "/");
 						if(currentSourceMappingURLComment !== false) {
 							asset.__SourceMapDevToolData[file] = compilation.assets[file] = new ConcatSource(new RawSource(source), currentSourceMappingURLComment.replace(/\[url\]/g, sourceMapUrl));
 						}

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -181,14 +181,17 @@ class SourceMapDevToolPlugin {
 						}
 						let sourceMapFile = compilation.getPath(sourceMapFilename, {
 							chunk,
-							filename,
+							filename: options.fileContext ? path.relative(options.fileContext, filename) : filename,
 							query,
 							basename: basename(filename)
 						});
 						if(sourceMapFile.indexOf("[contenthash]") !== -1) {
 							sourceMapFile = sourceMapFile.replace(/\[contenthash\]/g, crypto.createHash("md5").update(sourceMapString).digest("hex"));
 						}
-						const sourceMapUrl = path.relative(path.dirname(file), sourceMapFile).replace(/\\/g, "/");
+						let sourceMapUrl = (options.fileContext ? sourceMapFile : path.relative(path.dirname(file), sourceMapFile)).replace(/\\/g, "/");
+						if(options.publicPath) {
+							sourceMapUrl = options.publicPath + sourceMapUrl;
+						}
 						if(currentSourceMappingURLComment !== false) {
 							asset.__SourceMapDevToolData[file] = compilation.assets[file] = new ConcatSource(new RawSource(source), currentSourceMappingURLComment.replace(/\[url\]/g, sourceMapUrl));
 						}

--- a/test/configCases/plugins/source-map-dev-tool-plugin/index.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin/index.js
@@ -1,0 +1,6 @@
+it("should contain publicPath prefix in [url] and resolve relatively to fileContext", function() {
+	var fs = require("fs"),
+			path = require("path");
+	var source = fs.readFileSync(path.join(__dirname, "dist/public/test.js"), "utf-8");
+	source.should.containEql("//# sourceMappingURL=https://10.10.10.10/project/sourcemaps/test.js.map");
+});

--- a/test/configCases/plugins/source-map-dev-tool-plugin/index.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin/index.js
@@ -4,3 +4,9 @@ it("should contain publicPath prefix in [url] and resolve relatively to fileCont
 	var source = fs.readFileSync(path.join(__dirname, "dist/public/test.js"), "utf-8");
 	source.should.containEql("//# sourceMappingURL=https://10.10.10.10/project/sourcemaps/test.js.map");
 });
+
+it("should write sourcemap file relative fo fileContext", function() {
+	var fs = require("fs"),
+			path = require("path");
+	fs.existsSync(path.join(__dirname, "sourcemaps/test.js.map")).should.be.true();
+});

--- a/test/configCases/plugins/source-map-dev-tool-plugin/index.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin/index.js
@@ -1,7 +1,7 @@
 it("should contain publicPath prefix in [url] and resolve relatively to fileContext", function() {
 	var fs = require("fs"),
 			path = require("path");
-	var source = fs.readFileSync(path.join(__dirname, "dist/public/test.js"), "utf-8");
+	var source = fs.readFileSync(path.join(__dirname, "public/test.js"), "utf-8");
 	source.should.containEql("//# sourceMappingURL=https://10.10.10.10/project/sourcemaps/test.js.map");
 });
 

--- a/test/configCases/plugins/source-map-dev-tool-plugin/test.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin/test.js
@@ -1,0 +1,5 @@
+var testObject = {
+	a: 1
+};
+
+module.exports = testObject;

--- a/test/configCases/plugins/source-map-dev-tool-plugin/webpack.config.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin/webpack.config.js
@@ -1,0 +1,21 @@
+var webpack = require("../../../../");
+module.exports = {
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	entry: {
+		"bundle0": ["./index.js"],
+		"dist/public/test": ["./test.js"],
+	},
+	output: {
+		filename: "[name].js"
+	},
+	plugins: [
+		new webpack.SourceMapDevToolPlugin({
+			filename: "sourcemaps/[file].map",
+			publicPath: "https://10.10.10.10/project/",
+			fileContext: "dist/public"
+		})
+	]
+};

--- a/test/configCases/plugins/source-map-dev-tool-plugin/webpack.config.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
 	},
 	entry: {
 		"bundle0": ["./index.js"],
-		"dist/public/test": ["./test.js"],
+		"public/test": ["./test.js"],
 	},
 	output: {
 		filename: "[name].js"
@@ -15,7 +15,7 @@ module.exports = {
 		new webpack.SourceMapDevToolPlugin({
 			filename: "sourcemaps/[file].map",
 			publicPath: "https://10.10.10.10/project/",
-			fileContext: "dist/public"
+			fileContext: "public"
 		})
 	]
 };


### PR DESCRIPTION
…e path when using custom append. Fix a bug where outside directory path was appended to URL (../)

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Improvement and a bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No, did not find SourceMapDevToolPlugin tests, not sure its worth to start implementing those from this PR.
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
https://github.com/webpack/webpack.js.org/pull/1707
```diff
+ The documentation PR is updated again in regard of this PR
```
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Enable path stripping from source map filename path when using custom append. Fix a bug where outside directory path was appended to source map URL (../). Fixes #5554
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
None