### PR TITLE
Simplify identifier creation in ConcatenatedModules

### DIFF
--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -295,12 +295,15 @@ class ConcatenatedModule extends Module {
 	}
 
 	_createIdentifier() {
-		const hash = crypto.createHash("md5");
-		this._orderedConcatenationList.forEach(info => {
-			if(info.type === "concatenated") {
-				hash.update(info.module.identifier() + " ");
+		let orderedConcatenationListIdentifiers = "";
+		for(let i = 0; i < this._orderedConcatenationList.length; i++) {
+			if(this._orderedConcatenationList[i].type === "concatenated") {
+				orderedConcatenationListIdentifiers += this._orderedConcatenationList[i].module.identifier();
+				orderedConcatenationListIdentifiers += " ";
 			}
-		});
+		}
+		const hash = crypto.createHash("md5");
+		hash.update(orderedConcatenationListIdentifiers);
 		return this.rootModule.identifier() + " " + hash.digest("hex");
 	}
 

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -295,14 +295,12 @@ class ConcatenatedModule extends Module {
 	}
 
 	_createIdentifier() {
-		const orderedConcatenationListIdentifiers = this._orderedConcatenationList.map(info => {
-			switch(info.type) {
-				case "concatenated":
-					return info.module.identifier();
-			}
-		}).filter(Boolean).join(" ");
 		const hash = crypto.createHash("md5");
-		hash.update(orderedConcatenationListIdentifiers);
+		this._orderedConcatenationList.forEach(info => {
+			if(info.type === "concatenated") {
+				hash.update(info.module.identifier() + " ");
+			}
+		});
 		return this.rootModule.identifier() + " " + hash.digest("hex");
 	}
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Optimization

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
No

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This was implemented in #5997 to fix some memory issues, but I think we
can make this a little more efficient. By using a single forEach instead
of a map, filter, and join, we avoid unnecessary array creations and
iterations.


**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
