### PR TITLE
fix: Compiler parser.apply.apply misssing bug

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -204,7 +204,7 @@ class Compiler extends Tapable {
 					const args = arguments;
 					this.plugin("compilation", (compilation, data) => {
 						data.normalModuleFactory.plugin("parser", parser => {
-							parser.apply(parser, args);
+							parser.apply.apply(parser, args);
 						});
 					});
 				},


### PR DESCRIPTION
fix parser.apply.apply instead of parser.apply in lib/Compiler.js

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

related to https://github.com/webpack/webpack/pull/5985

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
