### PR TITLE
 process imports from mjs to non-esm correctly

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -39,7 +39,8 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 			test: /\.mjs$/i,
 			type: "javascript/esm",
 			resolve: {
-				enforceExtension: true
+				extensions: [],
+				enforceExtension: false
 			}
 		}, {
 			test: /\.json$/i,

--- a/lib/dependencies/HarmonyDetectionParserPlugin.js
+++ b/lib/dependencies/HarmonyDetectionParserPlugin.js
@@ -46,8 +46,10 @@ module.exports = class HarmonyDetectionParserPlugin {
 				module.meta.harmonyModule = true;
 				module.strict = true;
 				module.exportsArgument = "__webpack_exports__";
-				if(isStrictHarmony)
+				if(isStrictHarmony) {
+					module.meta.strictHarmonyModule = true;
 					module.moduleArgument = "__webpack_module__";
+				}
 			}
 		});
 

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -12,6 +12,10 @@ const HarmonyExportImportedSpecifierDependency = require("./HarmonyExportImporte
 const ConstDependency = require("./ConstDependency");
 
 module.exports = class HarmonyExportDependencyParserPlugin {
+	constructor(moduleOptions) {
+		this.strictExportPresence = moduleOptions.strictExportPresence;
+	}
+
 	apply(parser) {
 		parser.plugin("export", statement => {
 			const dep = new HarmonyExportHeaderDependency(statement.declaration && statement.declaration.range, statement.range);
@@ -47,7 +51,7 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 			harmonyNamedExports.add(name);
 			if(rename === "imported var") {
 				const settings = parser.state.harmonySpecifier.get(id);
-				dep = new HarmonyExportImportedSpecifierDependency(settings.source, parser.state.module, settings.sourceOrder, parser.state.harmonyParserScope, settings.id, name, harmonyNamedExports, null);
+				dep = new HarmonyExportImportedSpecifierDependency(settings.source, parser.state.module, settings.sourceOrder, parser.state.harmonyParserScope, settings.id, name, harmonyNamedExports, null, this.strictExportPresence);
 			} else {
 				dep = new HarmonyExportSpecifierDependency(parser.state.module, id, name);
 			}
@@ -64,7 +68,7 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 			} else {
 				harmonyStarExports = parser.state.harmonyStarExports = parser.state.harmonyStarExports || [];
 			}
-			const dep = new HarmonyExportImportedSpecifierDependency(source, parser.state.module, parser.state.lastHarmonyImportOrder, parser.state.harmonyParserScope, id, name, harmonyNamedExports, harmonyStarExports && harmonyStarExports.slice());
+			const dep = new HarmonyExportImportedSpecifierDependency(source, parser.state.module, parser.state.lastHarmonyImportOrder, parser.state.harmonyParserScope, id, name, harmonyNamedExports, harmonyStarExports && harmonyStarExports.slice(), this.strictExportPresence);
 			if(harmonyStarExports) {
 				harmonyStarExports.push(dep);
 			}

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -7,12 +7,13 @@ const HarmonyImportDependency = require("./HarmonyImportDependency");
 const Template = require("../Template");
 
 class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
-	constructor(request, originModule, sourceOrder, parserScope, id, name, activeExports, otherStarExports) {
+	constructor(request, originModule, sourceOrder, parserScope, id, name, activeExports, otherStarExports, strictExportPresence) {
 		super(request, originModule, sourceOrder, parserScope);
 		this.id = id;
 		this.name = name;
 		this.activeExports = activeExports;
 		this.otherStarExports = otherStarExports;
+		this.strictExportPresence = strictExportPresence;
 	}
 
 	get type() {
@@ -40,32 +41,57 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 		}
 
 		const isNotAHarmonyModule = importedModule.meta && !importedModule.meta.harmonyModule;
+		const strictHarmonyModule = this.originModule.meta.strictHarmonyModule;
 		if(name && id === "default" && isNotAHarmonyModule) {
-			return {
-				type: "reexport-non-harmony-default",
-				module: importedModule,
-				name
-			};
+			if(strictHarmonyModule) {
+				return {
+					type: "reexport-non-harmony-default-strict",
+					module: importedModule,
+					name
+				};
+			} else {
+				return {
+					type: "reexport-non-harmony-default",
+					module: importedModule,
+					name
+				};
+			}
 		}
 
 		if(name) {
 			// export { name as name }
 			if(id) {
-				return {
-					type: "safe-reexport",
-					module: importedModule,
-					map: new Map([
-						[name, id]
-					])
-				};
+				if(isNotAHarmonyModule && strictHarmonyModule) {
+					return {
+						type: "rexport-non-harmony-undefined",
+						module: importedModule,
+						name
+					};
+				} else {
+					return {
+						type: "safe-reexport",
+						module: importedModule,
+						map: new Map([
+							[name, id]
+						])
+					};
+				}
 			}
 
 			// export { * as name }
-			return {
-				type: "reexport-namespace-object",
-				module: importedModule,
-				name
-			};
+			if(isNotAHarmonyModule && strictHarmonyModule) {
+				return {
+					type: "reexport-fake-namespace-object",
+					module: importedModule,
+					name
+				};
+			} else {
+				return {
+					type: "reexport-namespace-object",
+					module: importedModule,
+					name
+				};
+			}
 		}
 
 		const hasUsedExports = Array.isArray(this.originModule.usedExports);
@@ -166,6 +192,9 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 				};
 
 			case "reexport-namespace-object":
+			case "reexport-non-harmony-default-strict":
+			case "reexport-fake-namespace-object":
+			case "rexport-non-harmony-undefined":
 				return {
 					module: mode.module,
 					importedNames: true
@@ -237,6 +266,55 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 			exports: null,
 			dependencies: [importedModule]
 		};
+	}
+
+	getWarnings() {
+		if(this.strictExportPresence || this.originModule.meta.strictHarmonyModule) {
+			return [];
+		}
+		return this._getErrors();
+	}
+
+	getErrors() {
+		if(this.strictExportPresence || this.originModule.meta.strictHarmonyModule) {
+			return this._getErrors();
+		}
+		return [];
+	}
+
+	_getErrors() {
+		const importedModule = this.module;
+		if(!importedModule) {
+			return;
+		}
+
+		if(!importedModule.meta || !importedModule.meta.harmonyModule) {
+			// It's not an harmony module
+			if(this.originModule.meta.strictHarmonyModule && this.id !== "default") {
+				// In strict harmony modules we only support the default export
+				const exportName = this.id ? `the named export '${this.id}'` : "the namespace object";
+				const err = new Error(`Can't reexport ${exportName} from non EcmaScript module (only default export is available)`);
+				err.hideStack = true;
+				return [err];
+			}
+			return;
+		}
+
+		if(!this.id) {
+			return;
+		}
+
+		if(importedModule.isProvided(this.id) !== false) {
+			// It's provided or we are not sure
+			return;
+		}
+
+		// We are sure that it's not provided
+		const idIsNotNameMessage = this.id !== this.name ? ` (reexported as '${this.name}')` : "";
+		const errorMessage = `"export '${this.id}'${idIsNotNameMessage} was not found in '${this.userRequest}'`;
+		const err = new Error(errorMessage);
+		err.hideStack = true;
+		return [err];
 	}
 
 	updateHash(hash) {
@@ -317,6 +395,15 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 			case "reexport-non-harmony-default":
 				return "/* harmony reexport (default from non-hamory) */ " + this.getReexportStatement(module, module.isUsed(mode.name), importVar, null);
 
+			case "reexport-fake-namespace-object":
+				return "/* harmony reexport (fake namespace object from non-hamory) */ " + this.getReexportFakeNamespaceObjectStatement(module, module.isUsed(mode.name), importVar);
+
+			case "rexport-non-harmony-undefined":
+				return "/* harmony reexport (non default export from non-hamory) */ " + this.getReexportStatement(module, module.isUsed(mode.name), "undefined", "");
+
+			case "reexport-non-harmony-default-strict":
+				return "/* harmony reexport (default from non-hamory) */ " + this.getReexportStatement(module, module.isUsed(mode.name), importVar, "");
+
 			case "reexport-namespace-object":
 				return "/* harmony reexport (module object) */ " + this.getReexportStatement(module, module.isUsed(mode.name), importVar, "");
 
@@ -357,6 +444,11 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 		const exportsName = module.exportsArgument;
 		const returnValue = this.getReturnValue(valueKey);
 		return `__webpack_require__.d(${exportsName}, ${JSON.stringify(key)}, function() { return ${name}${returnValue}; });\n`;
+	}
+
+	getReexportFakeNamespaceObjectStatement(module, key, name) {
+		const exportsName = module.exportsArgument;
+		return `__webpack_require__.d(${exportsName}, ${JSON.stringify(key)}, function() { return { "default": ${name} }; });\n`;
 	}
 
 	getConditionalReexportStatement(module, key, name, valueKey) {

--- a/lib/dependencies/HarmonyImportDependency.js
+++ b/lib/dependencies/HarmonyImportDependency.js
@@ -50,7 +50,7 @@ class HarmonyImportDependency extends ModuleDependency {
 		if(importVar) {
 			const isHarmonyModule = module.meta && module.meta.harmonyModule;
 			const content = `/* harmony import */ ${optDeclaration}${importVar} = __webpack_require__(${comment}${JSON.stringify(module.id)});${optNewline}`;
-			if(isHarmonyModule) {
+			if(isHarmonyModule || this.originModule.meta.strictHarmonyModule) {
 				return content;
 			}
 			return `${content}/* harmony import */ ${optDeclaration}${importVar}_default = /*#__PURE__*/__webpack_require__.n(${importVar});${optNewline}`;

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -31,14 +31,14 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 	}
 
 	getWarnings() {
-		if(this.strictExportPresence) {
+		if(this.strictExportPresence || this.originModule.meta.strictHarmonyModule) {
 			return [];
 		}
 		return this._getErrors();
 	}
 
 	getErrors() {
-		if(this.strictExportPresence) {
+		if(this.strictExportPresence || this.originModule.meta.strictHarmonyModule) {
 			return this._getErrors();
 		}
 		return [];
@@ -46,7 +46,19 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 
 	_getErrors() {
 		const importedModule = this.module;
-		if(!importedModule || !importedModule.meta || !importedModule.meta.harmonyModule) {
+		if(!importedModule) {
+			return;
+		}
+
+		if(!importedModule.meta || !importedModule.meta.harmonyModule) {
+			// It's not an harmony module
+			if(this.originModule.meta.strictHarmonyModule && this.id !== "default") {
+				// In strict harmony modules we only support the default export
+				const exportName = this.id ? `the named export '${this.id}'` : "the namespace object";
+				const err = new Error(`Can't import ${exportName} from non EcmaScript module (only default export is available)`);
+				err.hideStack = true;
+				return [err];
+			}
 			return;
 		}
 
@@ -55,9 +67,11 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		}
 
 		if(importedModule.isProvided(this.id) !== false) {
+			// It's provided or we are not sure
 			return;
 		}
 
+		// We are sure that it's not provided
 		const idIsNotNameMessage = this.id !== this.name ? ` (imported as '${this.name}')` : "";
 		const errorMessage = `"export '${this.id}'${idIsNotNameMessage} was not found in '${this.userRequest}'`;
 		const err = new Error(errorMessage);
@@ -90,26 +104,46 @@ HarmonyImportSpecifierDependency.Template = class HarmonyImportSpecifierDependen
 
 	getContent(dep, importedVar) {
 		const importedModule = dep.module;
-		const nonHarmonyDefaultImport = dep.directImport && dep.id === "default" && !(importedModule && (!importedModule.meta || importedModule.meta.harmonyModule));
+		const nonHarmonyImport = !(importedModule && (!importedModule.meta || importedModule.meta.harmonyModule));
+		const importedVarSuffix = this.getImportVarSuffix(dep.id, importedModule);
 		const shortHandPrefix = dep.shorthand ? `${dep.name}: ` : "";
-		const importedVarSuffix = this.getImportVarSuffix(dep.id, nonHarmonyDefaultImport, importedModule);
 
-		if(dep.call && nonHarmonyDefaultImport) {
-			return `${shortHandPrefix}${importedVar}_default()`;
+		// Note: dep.call and dep.shorthand are exclusive
+
+		if(nonHarmonyImport) {
+			const defaultExport = dep.id === "default";
+			if(dep.originModule.meta.strictHarmonyModule) {
+				if(defaultExport) {
+					return `${shortHandPrefix}${importedVar}`;
+				}
+
+				if(!dep.id) {
+					if(shortHandPrefix)
+						return `${shortHandPrefix}/* fake namespace object for non-esm import */ { default: ${importedVar} }`;
+					else
+						return `Object(/* fake namespace object for non-esm import */{ "default": ${importedVar} })`;
+				}
+
+				return `${shortHandPrefix}/* non-default import from non-esm module */undefined`;
+			} else {
+				if(dep.call && defaultExport) {
+					return `${shortHandPrefix}${importedVar}_default()`;
+				}
+
+				if(defaultExport) {
+					return `${shortHandPrefix}${importedVar}_default.a`;
+				}
+			}
 		}
 
-		if(dep.call && dep.id) {
-			return `${shortHandPrefix}Object(${importedVar}${importedVarSuffix})`;
+		if(dep.call && dep.id && dep.directImport) {
+			return `Object(${importedVar}${importedVarSuffix})`;
 		}
 
 		return `${shortHandPrefix}${importedVar}${importedVarSuffix}`;
 	}
 
-	getImportVarSuffix(id, nonHarmonyDefaultImport, importedModule) {
-		if(nonHarmonyDefaultImport) {
-			return "_default.a";
-		}
-
+	getImportVarSuffix(id, importedModule) {
 		if(id) {
 			const used = importedModule ? importedModule.isUsed(id) : id;
 			const optionalComment = id !== used ? " /* " + id + " */" : "";

--- a/lib/dependencies/HarmonyModulesPlugin.js
+++ b/lib/dependencies/HarmonyModulesPlugin.js
@@ -67,7 +67,7 @@ class HarmonyModulesPlugin {
 				parser.apply(
 					new HarmonyDetectionParserPlugin(),
 					new HarmonyImportDependencyParserPlugin(this.options),
-					new HarmonyExportDependencyParserPlugin()
+					new HarmonyExportDependencyParserPlugin(this.options)
 				);
 			});
 		});

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -20,23 +20,35 @@ const HarmonyExportExpressionDependency = require("../dependencies/HarmonyExport
 const HarmonyExportImportedSpecifierDependency = require("../dependencies/HarmonyExportImportedSpecifierDependency");
 const HarmonyCompatibilityDependency = require("../dependencies/HarmonyCompatibilityDependency");
 
-const ensureNsObjSource = (info, moduleToInfoMap, requestShortener) => {
+const ensureNsObjSource = (info, moduleToInfoMap, requestShortener, strictHarmonyModule) => {
 	if(!info.hasNamespaceObject) {
 		info.hasNamespaceObject = true;
 		const name = info.exportMap.get(true);
 		const nsObj = [`var ${name} = {};`];
 		for(const exportName of info.module.providedExports) {
-			const finalName = getFinalName(info, exportName, moduleToInfoMap, requestShortener, false);
+			const finalName = getFinalName(info, exportName, moduleToInfoMap, requestShortener, false, strictHarmonyModule);
 			nsObj.push(`__webpack_require__.d(${name}, ${JSON.stringify(exportName)}, function() { return ${finalName}; });`);
 		}
 		info.namespaceObjectSource = nsObj.join("\n") + "\n";
 	}
 };
 
-const getExternalImport = (importedModule, info, exportName, asCall) => {
-	if(exportName === true) return info.name;
+const getExternalImport = (importedModule, info, exportName, asCall, strictHarmonyModule) => {
+	if(exportName === true) {
+		if(info.interop && strictHarmonyModule) {
+			return `Object(/* fake namespace object for non-esm import */{ "default": ${info.name} })`;
+		}
+		return info.name;
+	}
 	const used = importedModule.isUsed(exportName);
 	if(!used) return "/* unused reexport */undefined";
+	if(info.interop && strictHarmonyModule) {
+		if(exportName === "default") {
+			return info.name;
+		} else {
+			return "/* non-default import from non-esm module */undefined";
+		}
+	}
 	if(info.interop && exportName === "default") {
 		return asCall ? `${info.interopName}()` : `${info.interopName}.a`;
 	}
@@ -47,14 +59,14 @@ const getExternalImport = (importedModule, info, exportName, asCall) => {
 	return reference;
 };
 
-const getFinalName = (info, exportName, moduleToInfoMap, requestShortener, asCall) => {
+const getFinalName = (info, exportName, moduleToInfoMap, requestShortener, asCall, strictHarmonyModule) => {
 	switch(info.type) {
 		case "concatenated":
 			{
 				const directExport = info.exportMap.get(exportName);
 				if(directExport) {
 					if(exportName === true)
-						ensureNsObjSource(info, moduleToInfoMap, requestShortener);
+						ensureNsObjSource(info, moduleToInfoMap, requestShortener, strictHarmonyModule);
 					const name = info.internalNames.get(directExport);
 					if(!name)
 						throw new Error(`The export "${directExport}" in "${info.module.readableIdentifier(requestShortener)}" has no internal name`);
@@ -65,7 +77,7 @@ const getFinalName = (info, exportName, moduleToInfoMap, requestShortener, asCal
 					const refInfo = moduleToInfoMap.get(reexport.module);
 					if(refInfo) {
 						// module is in the concatenation
-						return getFinalName(refInfo, reexport.exportName, moduleToInfoMap, requestShortener, asCall);
+						return getFinalName(refInfo, reexport.exportName, moduleToInfoMap, requestShortener, asCall, strictHarmonyModule);
 					}
 				}
 				const problem = `Cannot get final name for export "${exportName}" in "${info.module.readableIdentifier(requestShortener)}"` +
@@ -76,7 +88,7 @@ const getFinalName = (info, exportName, moduleToInfoMap, requestShortener, asCal
 		case "external":
 			{
 				const importedModule = info.module;
-				return getExternalImport(importedModule, info, exportName, asCall);
+				return getExternalImport(importedModule, info, exportName, asCall, strictHarmonyModule);
 			}
 	}
 };
@@ -516,7 +528,7 @@ class ConcatenatedModule extends Module {
 			if(info.globalScope) {
 				info.globalScope.through.forEach(reference => {
 					const name = reference.identifier.name;
-					if(/^__WEBPACK_MODULE_REFERENCE__\d+_([\da-f]+|ns)(_call)?__$/.test(name)) {
+					if(/^__WEBPACK_MODULE_REFERENCE__\d+_([\da-f]+|ns)(_call)?(_strict)?__$/.test(name)) {
 						for(const s of getSymbolsFromScope(reference.from, info.moduleScope)) {
 							allUsedNames.add(s);
 						}
@@ -583,7 +595,7 @@ class ConcatenatedModule extends Module {
 			if(info.type === "concatenated") {
 				info.globalScope.through.forEach(reference => {
 					const name = reference.identifier.name;
-					const match = /^__WEBPACK_MODULE_REFERENCE__(\d+)_([\da-f]+|ns)(_call)?__$/.exec(name);
+					const match = /^__WEBPACK_MODULE_REFERENCE__(\d+)_([\da-f]+|ns)(_call)?(_strict)?__$/.exec(name);
 					if(match) {
 						const referencedModule = modulesWithInfo[+match[1]];
 						let exportName;
@@ -594,7 +606,8 @@ class ConcatenatedModule extends Module {
 							exportName = new Buffer(exportData, "hex").toString("utf-8"); // eslint-disable-line node/no-deprecated-api
 						}
 						const asCall = !!match[3];
-						const finalName = getFinalName(referencedModule, exportName, moduleToInfoMap, requestShortener, asCall);
+						const strictHarmonyModule = !!match[4];
+						const finalName = getFinalName(referencedModule, exportName, moduleToInfoMap, requestShortener, asCall, strictHarmonyModule);
 						const r = reference.identifier.range;
 						const source = info.source;
 						source.replace(r[0], r[1] - 1, finalName);
@@ -713,13 +726,15 @@ class HarmonyImportSpecifierDependencyConcatenatedTemplate {
 			return;
 		}
 		let content;
+		const callFlag = dep.call ? "_call" : "";
+		const strictFlag = dep.originModule.meta.strictHarmonyModule ? "_strict" : "";
 		if(dep.id === null) {
-			content = `__WEBPACK_MODULE_REFERENCE__${info.index}_ns__`;
+			content = `__WEBPACK_MODULE_REFERENCE__${info.index}_ns${strictFlag}__`;
 		} else if(dep.namespaceObjectAsContext) {
-			content = `__WEBPACK_MODULE_REFERENCE__${info.index}_ns__[${JSON.stringify(dep.id)}]`;
+			content = `__WEBPACK_MODULE_REFERENCE__${info.index}_ns${strictFlag}__[${JSON.stringify(dep.id)}]`;
 		} else {
 			const exportData = new Buffer(dep.id, "utf-8").toString("hex"); // eslint-disable-line node/no-deprecated-api
-			content = `__WEBPACK_MODULE_REFERENCE__${info.index}_${exportData}${dep.call ? "_call" : ""}__`;
+			content = `__WEBPACK_MODULE_REFERENCE__${info.index}_${exportData}${callFlag}${strictFlag}__`;
 		}
 		if(dep.shorthand) {
 			content = dep.name + ": " + content;
@@ -877,11 +892,12 @@ class HarmonyExportImportedSpecifierDependencyConcatenatedTemplate {
 						source.insert(-1, `/* unused concated harmony import ${dep.name} */\n`);
 					}
 					let finalName;
+					const strictFlag = dep.originModule.meta.strictHarmonyModule ? "_strict" : "";
 					if(def.id === true) {
-						finalName = `__WEBPACK_MODULE_REFERENCE__${info.index}_ns__`;
+						finalName = `__WEBPACK_MODULE_REFERENCE__${info.index}_ns${strictFlag}__`;
 					} else {
 						const exportData = new Buffer(def.id, "utf-8").toString("hex"); // eslint-disable-line node/no-deprecated-api
-						finalName = `__WEBPACK_MODULE_REFERENCE__${info.index}_${exportData}__`;
+						finalName = `__WEBPACK_MODULE_REFERENCE__${info.index}_${exportData}${strictFlag}__`;
 					}
 					const exportsName = this.rootModule.exportsArgument;
 					const content = `/* concated harmony reexport */__webpack_require__.d(${exportsName}, ${JSON.stringify(used)}, function() { return ${finalName}; });\n`;

--- a/test/cases/mjs/cjs-import-default/cjs.js
+++ b/test/cases/mjs/cjs-import-default/cjs.js
@@ -1,0 +1,4 @@
+module.exports = {
+	data: "ok",
+	default: "default"
+};

--- a/test/cases/mjs/cjs-import-default/errors.js
+++ b/test/cases/mjs/cjs-import-default/errors.js
@@ -1,0 +1,20 @@
+module.exports = [
+	[
+		/Can't import the namespace object from non EcmaScript module \(only default export is available\)/
+	],
+	[
+		/Can't import the namespace object from non EcmaScript module \(only default export is available\)/
+	],
+	[
+		/Can't import the named export 'data' from non EcmaScript module \(only default export is available\)/
+	],
+	[
+		/Can't import the named export 'data' from non EcmaScript module \(only default export is available\)/
+	],
+	[
+		/Can't reexport the namespace object from non EcmaScript module \(only default export is available\)/
+	],
+	[
+		/Can't reexport the named export 'data' from non EcmaScript module \(only default export is available\)/
+	]
+];

--- a/test/cases/mjs/cjs-import-default/index.mjs
+++ b/test/cases/mjs/cjs-import-default/index.mjs
@@ -1,0 +1,71 @@
+import { data } from "./cjs.js";
+import * as star from "./cjs.js";
+import def from "./cjs.js";
+import { ns, default as def1, def as def2, data as data2 } from "./reexport.mjs";
+import * as reexport from "./reexport.mjs";
+
+it("should get correct values when importing named exports from a CommonJs module from mjs", function() {
+	(typeof data).should.be.eql("undefined");
+	({ data }).should.be.eql({ data: undefined });
+	def.should.be.eql({
+		data: "ok",
+		default: "default"
+	});
+	({ def }).should.be.eql({
+		def: {
+			data: "ok",
+			default: "default"
+		}
+	});
+	const valueOf = "valueOf";
+	star[valueOf]().should.be.eql({
+		default: {
+			data: "ok",
+			default: "default"
+		}
+	});
+	({ star }).should.be.eql({
+		star: {
+			default: {
+				data: "ok",
+				default: "default"
+			}
+		}
+	});
+	star.default.should.be.eql({
+		data: "ok",
+		default: "default"
+	});
+	ns.should.be.eql({
+		default: {
+			data: "ok",
+			default: "default"
+		}
+	});
+	def1.should.be.eql({
+		data: "ok",
+		default: "default"
+	});
+	def2.should.be.eql({
+		data: "ok",
+		default: "default"
+	});
+	(typeof data2).should.be.eql("undefined");
+	reexport[valueOf]().should.be.eql({
+		ns: {
+			default: {
+				data: "ok",
+				default: "default"
+			}
+		},
+		default: {
+			data: "ok",
+			default: "default"
+		},
+		def: {
+			data: "ok",
+			default: "default"
+		},
+		data: undefined
+	});
+});

--- a/test/cases/mjs/cjs-import-default/reexport.mjs
+++ b/test/cases/mjs/cjs-import-default/reexport.mjs
@@ -1,0 +1,5 @@
+import * as ns from "./cjs.js";
+export { ns };
+export { default } from "./cjs.js";
+export { default as def } from "./cjs.js";
+export { data as data } from "./cjs.js";

--- a/test/cases/mjs/need-extension/errors.js
+++ b/test/cases/mjs/need-extension/errors.js
@@ -1,0 +1,5 @@
+module.exports = [
+	[
+		/Can't resolve '.\/module'/
+	]
+];

--- a/test/cases/mjs/need-extension/index.js
+++ b/test/cases/mjs/need-extension/index.js
@@ -1,0 +1,5 @@
+it("should not be able to import a module without extension from .mjs files", function() {
+	(function() {
+		require("./test.mjs");
+	}).should.throw('Cannot find module "./module"');
+});

--- a/test/cases/mjs/need-extension/module.js
+++ b/test/cases/mjs/need-extension/module.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/test/cases/mjs/need-extension/module.mjs
+++ b/test/cases/mjs/need-extension/module.mjs
@@ -1,0 +1,1 @@
+export default 1;

--- a/test/cases/mjs/need-extension/test.mjs
+++ b/test/cases/mjs/need-extension/test.mjs
@@ -1,0 +1,1 @@
+import "./module";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
n/a
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
process imports from mjs to non-esm correctly 
give nice error messages when importing non-esm the wrong way
It also disallows using namespace object from non-esm modules

fixes #5686
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
yes
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
