### PR TITLE
fix: catch && handle plugin `ValidationErrors` (`schema-utils`)

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -94,7 +94,9 @@ module.exports = function(yargs, argv, convertOptions) {
 		};
 
 		var requireConfig = function requireConfig(configPath) {
-			var options = require(configPath);
+			var options = (function WEBPACK_OPTIONS() {
+				return require(configPath);
+			})();
 			options = prepareOptions(options, argv);
 			return options;
 		};

--- a/lib/ErrorHelpers.js
+++ b/lib/ErrorHelpers.js
@@ -6,12 +6,27 @@
 
 const loaderFlag = "LOADER_EXECUTION";
 
-exports.cutOffLoaderExecution = (stack) => {
+const webpackOptionsFlag = "WEBPACK_OPTIONS";
+
+exports.cutOffByFlag = (stack, flag) => {
 	stack = stack.split("\n");
 	for(let i = 0; i < stack.length; i++)
-		if(stack[i].indexOf(loaderFlag) >= 0)
+		if(stack[i].indexOf(flag) >= 0)
 			stack.length = i;
 	return stack.join("\n");
+};
+
+exports.cutOffLoaderExecution = (stack) => exports.cutOffByFlag(stack, loaderFlag);
+
+exports.cutOffWebpackOptinos = (stack) => exports.cutOffByFlag(stack, webpackOptionsFlag);
+
+exports.cutOffMultilineMessage = (stack, message) => {
+	stack = stack.split("\n");
+	message = message.split("\n");
+
+	return stack
+		.reduce((acc, line, idx) => idx < message.length && line === message[idx] ? acc.concat(line) : acc, [])
+		.join("\n");
 };
 
 exports.cutOffMessage = (stack, message) => {
@@ -27,5 +42,11 @@ exports.cutOffMessage = (stack, message) => {
 exports.cleanUp = (stack, message) => {
 	stack = exports.cutOffLoaderExecution(stack);
 	stack = exports.cutOffMessage(stack, message);
+	return stack;
+};
+
+exports.cleanUpWebpackOptions = (stack, message) => {
+	stack = exports.cutOffWebpackOptinos(stack);
+	stack = exports.cutOffMultilineMessage(stack, message);
 	return stack;
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix 

**Did you add tests for your changes?**

- [ ] TODO (if backporting is approved => requires an update of one `devDependencies` plugin e.g ETWP) 

**If relevant, link to documentation update:**

- N/A

**Summary**

This is needed for contrib being able to use the lastest version of `schema-utils` for plugins without relying on the ugly `process.exit(1)` hack in `schema-utils =< v0.4.1` 

The changes are a backport of #5892  for `webpack >= v3.0.0` (`master`), so if this commit [`6d7df9d`](https://github.com/webpack/webpack/pull/5892/commits/6d7df9daaddac8976539884294b871e8e83f8bde) can be cherry-picked from the `next` branch instead this PR can be closed :)

**Does this PR introduce a breaking change?**

I hope not 🙃 