### PR TITLE
Fix link to side-effects example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -106,8 +106,8 @@
 ## Scope Hoisting
 [scope-hoisting](scope-hoisting)
 
-## Pure Module
-[pure-module](pure-module)
+## Side Effects
+[side-effects](side-effects)
 
 ## Source Map
 [source-map](source-map)


### PR DESCRIPTION
This started out as pure-module, but was moved without
this link being updated.