### PR TITLE
Reduce the number of calls to hash.update

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -349,11 +349,14 @@ class Chunk {
 		return this._modules.size === 0;
 	}
 
-	updateHash(hash) {
-		hash.update(`${this.id} `);
-		hash.update(this.ids ? this.ids.join(",") : "");
-		hash.update(`${this.name || ""} `);
-		this._modules.forEach(m => m.updateHash(hash));
+	hashPart() {
+		let str = `${this.id} `;
+		str += this.ids ? this.ids.join(",") : "";
+		str += `${this.name || ""} `;
+		this._modules.forEach(m => {
+			str += m.hashPart();
+		});
+		return str;
 	}
 
 	canBeIntegrated(otherChunk) {

--- a/lib/ChunkTemplate.js
+++ b/lib/ChunkTemplate.js
@@ -24,8 +24,7 @@ module.exports = class ChunkTemplate extends Template {
 	}
 
 	updateHash(hash) {
-		hash.update("ChunkTemplate");
-		hash.update("2");
+		hash.update("ChunkTemplate2");
 		this.applyPlugins("hash", hash);
 	}
 

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1328,10 +1328,14 @@ class Compilation extends Tapable {
 		});
 		for(let i = 0; i < chunks.length; i++) {
 			const chunk = chunks[i];
-			const chunkHash = crypto.createHash(hashFunction);
+			let strToHash = "";
 			if(outputOptions.hashSalt)
-				chunkHash.update(outputOptions.hashSalt);
-			chunk.updateHash(chunkHash);
+				strToHash += outputOptions.hashSalt;
+			strToHash += chunk.hashPart();
+
+			const chunkHash = crypto.createHash(hashFunction);
+			chunkHash.update(strToHash); // TODO avoid more calls to hash.update
+
 			if(chunk.hasRuntime()) {
 				this.mainTemplate.updateHashForChunk(chunkHash, chunk);
 			} else {

--- a/lib/DependenciesBlock.js
+++ b/lib/DependenciesBlock.js
@@ -39,14 +39,18 @@ class DependenciesBlock {
 		this.dependencies.push(dependency);
 	}
 
-	updateHash(hash) {
-		function updateHash(i) {
-			i.updateHash(hash);
+	hashPart() {
+		let str = "";
+
+		function addHashPartToStr(i) {
+			str += i.hashPart();
 		}
 
-		this.dependencies.forEach(updateHash);
-		this.blocks.forEach(updateHash);
-		this.variables.forEach(updateHash);
+		this.dependencies.forEach(addHashPartToStr);
+		this.blocks.forEach(addHashPartToStr);
+		this.variables.forEach(addHashPartToStr);
+
+		return str;
 	}
 
 	disconnect() {

--- a/lib/DependenciesBlockVariable.js
+++ b/lib/DependenciesBlockVariable.js
@@ -14,12 +14,14 @@ class DependenciesBlockVariable {
 		this.dependencies = dependencies || [];
 	}
 
-	updateHash(hash) {
-		hash.update(this.name);
-		hash.update(this.expression);
+	hashPart() {
+		let dependenciesHashParts = "";
+
 		this.dependencies.forEach(d => {
-			d.updateHash(hash);
+			dependenciesHashParts += d.hashPart();
 		});
+
+		return this.name + this.expression + dependenciesHashParts;
 	}
 
 	expressionSource(dependencyTemplates, outputOptions, requestShortener) {

--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -36,8 +36,8 @@ class Dependency {
 		return null;
 	}
 
-	updateHash(hash) {
-		hash.update((this.module && this.module.id) + "");
+	hashPart() {
+		return (this.module && this.module.id) + "";
 	}
 
 	disconnect() {

--- a/lib/MainTemplate.js
+++ b/lib/MainTemplate.js
@@ -213,9 +213,7 @@ module.exports = class MainTemplate extends Template {
 	}
 
 	updateHash(hash) {
-		hash.update("maintemplate");
-		hash.update("3");
-		hash.update(this.outputOptions.publicPath + "");
+		hash.update("maintemplate3" + this.outputOptions.publicPath);
 		this.applyPlugins("hash", hash);
 	}
 

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -199,10 +199,8 @@ class Module extends DependenciesBlock {
 		return true;
 	}
 
-	updateHash(hash) {
-		hash.update(this.id + "" + this.used);
-		hash.update(JSON.stringify(this.usedExports));
-		super.updateHash(hash);
+	hashPart() {
+		return this.id + this.used + JSON.stringify(this.usedExports) + super.hashPart();
 	}
 
 	sortItems(sortChunks) {

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -311,8 +311,7 @@ class NormalModule extends Module {
 	getHashDigest(dependencyTemplates) {
 		let dtHash = dependencyTemplatesHashMap.get("hash");
 		const hash = crypto.createHash("md5");
-		this.updateHash(hash);
-		hash.update(`${dtHash}`);
+		hash.update(`${this.hashPart()}${dtHash}`);
 		return hash.digest("hex");
 	}
 
@@ -531,24 +530,18 @@ class NormalModule extends Module {
 		return this._source ? this._source.size() : -1;
 	}
 
-	updateHashWithSource(hash) {
-		if(!this._source) {
-			hash.update("null");
-			return;
-		}
-		hash.update("source");
-		this._source.updateHash(hash);
+	sourceHashPart() {
+		return this._source
+			? "null"
+			: "source" + this._source.source();
 	}
 
-	updateHashWithMeta(hash) {
-		hash.update("meta");
-		hash.update(JSON.stringify(this.meta));
+	metaHashPart() {
+		return "meta" + JSON.stringify(this.meta);
 	}
 
-	updateHash(hash) {
-		this.updateHashWithSource(hash);
-		this.updateHashWithMeta(hash);
-		super.updateHash(hash);
+	hashPart() {
+		return this.sourceHashPart() + this.metaHashPart() + super.hashPart();
 	}
 
 }

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -100,10 +100,13 @@ class TemplatedPathPlugin {
 			mainTemplate.plugin("hash-for-chunk", function(hash, chunk) {
 				const outputOptions = this.outputOptions;
 				const chunkFilename = outputOptions.chunkFilename || outputOptions.filename;
+				let strToHash = "";
 				if(REGEXP_CHUNKHASH_FOR_TEST.test(chunkFilename))
-					hash.update(JSON.stringify(chunk.getChunkMaps(true, true).hash));
+					strToHash += JSON.stringify(chunk.getChunkMaps(true, true).hash);
 				if(REGEXP_NAME_FOR_TEST.test(chunkFilename))
-					hash.update(JSON.stringify(chunk.getChunkMaps(true, true).name));
+					strToHash += JSON.stringify(chunk.getChunkMaps(true, true).name);
+				if(strToHash)
+					hash.update(strToHash);
 			});
 		});
 	}


### PR DESCRIPTION
I was profiling our webpack build on Node 8.9.0 and noticed that a fair
amount of time was spent calling hash.update. During the process of
building one of our bundles, ~115ms was spent inside of createHash. 95ms
of that time is spent in crypto's update itself. In the bottom up view
of the profiler, this is the 4th most expensive part of the profile, as
measured by self time.

It turns out that, concatenating up a string and calling crypto's update
once is much faster than calling update many times. In this commit, I
take a swing at replacing the pattern of passing around a hash object
that update is called on all the time, to concatenating up a string, and
reducing the number of calls to crypto's update.

After this change, my profiling shows that only 16.54ms is spent in
createHash. In the bottom up view, I verified that 8.5ms is now spent in
crypto's update, which moves it far from one of the most expensive
areas.

I think there are more opportunities like this, but I'm a little
hesitant to dig in much more at this point because of the staggering
amount of indirection which makes the code difficult to follow, the
profiling difficult to interpret, and the stack traces when I hit an
error not very helpful.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Optimization

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
Not yet. I wanted to get feedback on this before I fixed the tests.

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
See above. https://github.com/webpack/webpack/issues/5718

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
I don't think so

**Other information**

Before:
<img width="1156" alt="screen shot 2017-12-05 at 2 19 01 pm" src="https://user-images.githubusercontent.com/195534/33633920-501cabbc-d9c7-11e7-800e-45522002e299.png">

After:
<img width="1056" alt="screen shot 2017-12-05 at 2 19 13 pm" src="https://user-images.githubusercontent.com/195534/33633921-50336f96-d9c7-11e7-8cdf-c0c4b478be0b.png">
