### PR TITLE
feat(tapable): upgrade DllEntryPlugin - Tapable v1

### DIFF
--- a/lib/DllEntryPlugin.js
+++ b/lib/DllEntryPlugin.js
@@ -16,16 +16,16 @@ class DllEntryPlugin {
 	}
 
 	apply(compiler) {
-		compiler.plugin("compilation", (compilation, params) => {
+		compiler.hooks.compilation.tap("DllEntryPlugin", (compilation, { normalModuleFactory }) => {
 			const dllModuleFactory = new DllModuleFactory();
-			const normalModuleFactory = params.normalModuleFactory;
-
 			compilation.dependencyFactories.set(DllEntryDependency, dllModuleFactory);
-
 			compilation.dependencyFactories.set(SingleEntryDependency, normalModuleFactory);
 		});
-		compiler.plugin("make", (compilation, callback) => {
-			compilation.addEntry(this.context, new DllEntryDependency(this.entries.map((e, idx) => {
+
+		compiler.hooks.make.tapAsync("DllEntryPlugin", (compilation, callback) => {
+			const { context, entries } = this;
+
+			compilation.addEntry(context, new DllEntryDependency(entries.map((e, idx) => {
 				const dep = new SingleEntryDependency(e);
 				dep.loc = `${this.name}:${idx}`;
 				return dep;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Migration of simple plugin (DllEntryPlugin) to use new Tapable v1 API. 
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
N/A
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
This upgrades a single plugin to the new plugin hooks usage. I have wanted to get one Plugin upgraded as a POC so that we can then outline how new contributors can help out and upgrade the whole system. 
**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
