### PR TITLE
Improve `PluginEnvironment` helper to support tapable's hooks

### DIFF
--- a/test/helpers/PluginEnvironment.js
+++ b/test/helpers/PluginEnvironment.js
@@ -1,14 +1,48 @@
 module.exports = function PluginEnvironment() {
-	var events = [];
+	const events = [];
+
+	function addEvent(name, handler) {
+		events.push({
+			name,
+			handler
+		});
+	}
+
+	function getEventName(hookName) {
+		// Convert a hook name to an event name.
+		// e.g. `buildModule` -> `build-module`
+		return hookName.replace(/[A-Z]/g, c => "-" + c.toLowerCase());
+	}
 
 	this.getEnvironmentStub = function() {
+		const hooks = new Map();
 		return {
-			plugin: function(name, handler) {
-				events.push({
-					name,
-					handler
-				});
-			}
+			plugin: addEvent,
+			// TODO: Figure out a better way of doing this
+			// In the meanwhile, `hooks` is a `Proxy` which creates fake hooks
+			// on demand. Instead of creating a dummy object with a few `Hook`
+			// method, a custom `Hook` class could be used.
+			hooks: new Proxy({}, {
+				get(target, hookName) {
+					let hook = hooks.get(hookName);
+					if (hook === undefined) {
+						const eventName = getEventName(hookName);
+						hook = {
+							tap(_, handler) {
+								addEvent(eventName, handler);
+							},
+							tapAsync(_, handler) {
+								addEvent(eventName, handler);
+							},
+							tapPromise(_, handler) {
+								addEvent(eventName, handler);
+							}
+						};
+						hooks.set(hookName, hook);
+					}
+					return hook;
+				}
+			})
 		};
 	};
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Feature / bugfix

**Did you add tests for your changes?**

No

**Summary**

While converting some plugins to `Tapable` I noticed that the tests started to fail since `PluginEnvironment` does not correctly mock what is passed to `Plugin#apply()`. Some test cases use `PluginEnvironment` to monitor plugins' actions. Before this change, it only mocked `.plugin()` which is not enough to test plugins written using `Tapable#hooks`.

This implementation uses a `Proxy` to trap hook calls and log them as events.

```js
class SomePlugin {
	apply(compiler) {
		compiler.hooks.afterCompile.tap("SomePlugin", handler)
		//       ^^^^^ ^^^^^^^^^^^^ ^^^
		//         |         |       logs { name: "after-compile", handler }
		//    this is now    |
		//      a Proxy     fake
		//                  hook
	}
}
```

**Does this PR introduce a breaking change?**

No

**Other information**

This is more a patch than a feature. Ideally the tests should be refactored to depend on hook calls rather than the event names. This change eases the migration towards `Tapable#hooks` since it does not force the rewrite of test files.