### PR TITLE
Remove `webpack/bootstrap` hash in source map

### DIFF
--- a/lib/MainTemplate.js
+++ b/lib/MainTemplate.js
@@ -249,7 +249,7 @@ module.exports = class MainTemplate extends Template {
 		buf.push(this.asString(this.hooks.requireExtensions.call("", chunk, hash)));
 		buf.push("");
 		buf.push(this.asString(this.hooks.startup.call("", chunk, hash)));
-		let source = this.hooks.render.call(new OriginalSource(this.prefix(buf, " \t") + "\n", `webpack/bootstrap ${hash}`), chunk, hash, moduleTemplate, dependencyTemplates);
+		let source = this.hooks.render.call(new OriginalSource(this.prefix(buf, " \t") + "\n", "webpack/bootstrap"), chunk, hash, moduleTemplate, dependencyTemplates);
 		if(chunk.hasEntryModule()) {
 			source = this.hooks.renderWithEntry.call(source, chunk, hash);
 		}


### PR DESCRIPTION


Fix #6082

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Refactoring

**Did you add tests for your changes?**

No, only manual testing. 
Unit/integration tests were not testing the hash.

**If relevant, link to documentation update:**

#6082 

**Summary**

Before this change, a hash was appended to `webpack:///webpack/bootstrap`
and appeared in source maps' `sources`.

```js
// before
{"version":3,"sources":["webpack:///webpack/bootstrap a0df2f8d793658baad72",…

// now
{"version":3,"sources":["webpack:///webpack/bootstrap",…
```

**Does this PR introduce a breaking change?**

Yes

**Other information**

Fixes #6082 

> @sokra 
> Send a PR to remove this hash in the next branch. It's not needed anyway...