### PR TITLE
Add ident to the list of permissible properties for Rule.use

### DIFF
--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -931,6 +931,10 @@
                 }
               ]
             },
+            "ident": {
+              "description": "Unique loader identifier",
+              "type": "string"
+            },
             "query": {
               "description": "Loader query",
               "anyOf": [


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A bugfix to permit the valid use of the `ident` property described [here]() in `Rule.use`. This was identified as part of #6080.

**Did you add tests for your changes?**

I don't think this requires any tests but please let me know if it does.

**If relevant, link to documentation update:**

None required, this brings webpack in line with it's existing documentation.

**Summary**

See #6080.

**Does this PR introduce a breaking change?**

No

**Other information**

Thank you for reviewing, and let me know if this isn't the right solution or there are any changes required.
