### PR TITLE
feat(tapable): upgrade LibManifestPlugin to Tapable v1

### DIFF
--- a/lib/LibManifestPlugin.js
+++ b/lib/LibManifestPlugin.js
@@ -13,7 +13,7 @@ class LibManifestPlugin {
 	}
 
 	apply(compiler) {
-		compiler.plugin("emit", (compilation, callback) => {
+		compiler.hooks.emit.tapAsync("LibManifestPlugin", (compilation, callback) => {
 			asyncLib.forEach(compilation.chunks, (chunk, callback) => {
 				if(!chunk.isInitial()) {
 					callback();
@@ -51,7 +51,7 @@ class LibManifestPlugin {
 						return obj;
 					}, Object.create(null))
 				};
-				const content = new Buffer(JSON.stringify(manifest), "utf8"); //eslint-disable-line
+				const content = new Buffer.from(JSON.stringify(manifest), "utf8");
 				compiler.outputFileSystem.mkdirp(path.dirname(targetPath), err => {
 					if(err) return callback(err);
 					compiler.outputFileSystem.writeFile(targetPath, content, callback);

--- a/lib/LibManifestPlugin.js
+++ b/lib/LibManifestPlugin.js
@@ -51,7 +51,7 @@ class LibManifestPlugin {
 						return obj;
 					}, Object.create(null))
 				};
-				const content = new Buffer.from(JSON.stringify(manifest), "utf8");
+				const content = Buffer.from(JSON.stringify(manifest), "utf8");
 				compiler.outputFileSystem.mkdirp(path.dirname(targetPath), err => {
 					if(err) return callback(err);
 					compiler.outputFileSystem.writeFile(targetPath, content, callback);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refactor
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
N/A
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
This upgrades LibManifestPlugin to Tapable v1 and also changes new Buffer to Buffer.from() (which is deprecated in Node 6. 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Nope!
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
