### PR TITLE
Update Parser helpers to be compatible with hooks

### DIFF
--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -41,7 +41,7 @@ class APIPlugin {
 
 			const handler = parser => {
 				Object.keys(REPLACEMENTS).forEach(key => {
-					parser.plugin(`expression ${key}`, NO_WEBPACK_REQUIRE[key] ? ParserHelpers.toConstantDependency(REPLACEMENTS[key]) : ParserHelpers.toConstantDependencyWithWebpackRequire(REPLACEMENTS[key]));
+					parser.plugin(`expression ${key}`, NO_WEBPACK_REQUIRE[key] ? ParserHelpers.toConstantDependency(parser, REPLACEMENTS[key]) : ParserHelpers.toConstantDependencyWithWebpackRequire(parser, REPLACEMENTS[key]));
 					parser.plugin(`evaluate typeof ${key}`, ParserHelpers.evaluateToString(REPLACEMENT_TYPES[key]));
 				});
 			};

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -84,7 +84,7 @@ class DefinePlugin {
 							res.setRange(expr.range);
 							return res;
 						});
-						parser.plugin("expression " + key, /__webpack_require__/.test(code) ? ParserHelpers.toConstantDependencyWithWebpackRequire(code) : ParserHelpers.toConstantDependency(code));
+						parser.plugin("expression " + key, /__webpack_require__/.test(code) ? ParserHelpers.toConstantDependencyWithWebpackRequire(parser, code) : ParserHelpers.toConstantDependency(parser, code));
 					}
 					const typeofCode = isTypeof ? code : "typeof (" + code + ")";
 					parser.plugin("evaluate typeof " + key, (expr) => {
@@ -106,7 +106,7 @@ class DefinePlugin {
 					parser.plugin("typeof " + key, (expr) => {
 						const res = parser.evaluate(typeofCode);
 						if(!res.isString()) return;
-						return ParserHelpers.toConstantDependency(JSON.stringify(res.string)).bind(parser)(expr);
+						return ParserHelpers.toConstantDependency(parser, JSON.stringify(res.string)).bind(parser)(expr);
 					});
 				};
 
@@ -115,8 +115,8 @@ class DefinePlugin {
 					parser.plugin("can-rename " + key, ParserHelpers.approve);
 					parser.plugin("evaluate Identifier " + key, (expr) => new BasicEvaluatedExpression().setTruthy().setRange(expr.range));
 					parser.plugin("evaluate typeof " + key, ParserHelpers.evaluateToString("object"));
-					parser.plugin("expression " + key, /__webpack_require__/.test(code) ? ParserHelpers.toConstantDependencyWithWebpackRequire(code) : ParserHelpers.toConstantDependency(code));
-					parser.plugin("typeof " + key, ParserHelpers.toConstantDependency(JSON.stringify("object")));
+					parser.plugin("expression " + key, /__webpack_require__/.test(code) ? ParserHelpers.toConstantDependencyWithWebpackRequire(parser, code) : ParserHelpers.toConstantDependency(parser, code));
+					parser.plugin("typeof " + key, ParserHelpers.toConstantDependency(parser, JSON.stringify("object")));
 				};
 
 				walkDefinitions(definitions, "");

--- a/lib/ExtendedAPIPlugin.js
+++ b/lib/ExtendedAPIPlugin.js
@@ -41,7 +41,7 @@ class ExtendedAPIPlugin {
 
 			const handler = (parser, parserOptions) => {
 				Object.keys(REPLACEMENTS).forEach(key => {
-					parser.plugin(`expression ${key}`, ParserHelpers.toConstantDependencyWithWebpackRequire(REPLACEMENTS[key]));
+					parser.plugin(`expression ${key}`, ParserHelpers.toConstantDependencyWithWebpackRequire(parser, REPLACEMENTS[key]));
 					parser.plugin(`evaluate typeof ${key}`, ParserHelpers.evaluateToString(REPLACEMENT_TYPES[key]));
 				});
 			};

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -193,7 +193,7 @@ module.exports = class HotModuleReplacementPlugin {
 			});
 
 			const handler = (parser, parserOptions) => {
-				parser.plugin("expression __webpack_hash__", ParserHelpers.toConstantDependencyWithWebpackRequire("__webpack_require__.h()"));
+				parser.plugin("expression __webpack_hash__", ParserHelpers.toConstantDependencyWithWebpackRequire(parser, "__webpack_require__.h()"));
 				parser.plugin("evaluate typeof __webpack_hash__", ParserHelpers.evaluateToString("string"));
 				parser.plugin("evaluate Identifier module.hot", expr => {
 					return ParserHelpers.evaluateToIdentifier("module.hot", !!parser.state.compilation.hotUpdateChunkTemplate)(expr);

--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -65,13 +65,13 @@ class NodeStuffPlugin {
 					if(!parser.state.module) return;
 					return ParserHelpers.evaluateToString(parser.state.module.context)(expr);
 				});
-				parser.plugin("expression require.main", ParserHelpers.toConstantDependencyWithWebpackRequire("__webpack_require__.c[__webpack_require__.s]"));
+				parser.plugin("expression require.main", ParserHelpers.toConstantDependencyWithWebpackRequire(parser, "__webpack_require__.c[__webpack_require__.s]"));
 				parser.plugin(
 					"expression require.extensions",
-					ParserHelpers.expressionIsUnsupported("require.extensions is not supported by webpack. Use a loader instead.")
+					ParserHelpers.expressionIsUnsupported(parser, "require.extensions is not supported by webpack. Use a loader instead.")
 				);
-				parser.plugin("expression module.loaded", ParserHelpers.toConstantDependency("module.l"));
-				parser.plugin("expression module.id", ParserHelpers.toConstantDependency("module.i"));
+				parser.plugin("expression module.loaded", ParserHelpers.toConstantDependency(parser, "module.l"));
+				parser.plugin("expression module.id", ParserHelpers.toConstantDependency(parser, "module.i"));
 				parser.plugin("expression module.exports", () => {
 					const module = parser.state.module;
 					const isHarmony = module.buildMeta && module.buildMeta.harmonyModule;

--- a/lib/ParserHelpers.js
+++ b/lib/ParserHelpers.js
@@ -35,20 +35,20 @@ ParserHelpers.requireFileAsExpression = (context, pathToModule) => {
 	return "require(" + JSON.stringify(moduleJsPath) + ")";
 };
 
-ParserHelpers.toConstantDependency = (value) => {
+ParserHelpers.toConstantDependency = (parser, value) => {
 	return function constDependency(expr) {
 		var dep = new ConstDependency(value, expr.range, false);
 		dep.loc = expr.loc;
-		this.state.current.addDependency(dep);
+		parser.state.current.addDependency(dep);
 		return true;
 	};
 };
 
-ParserHelpers.toConstantDependencyWithWebpackRequire = (value) => {
+ParserHelpers.toConstantDependencyWithWebpackRequire = (parser, value) => {
 	return function constDependencyWithWebpackRequire(expr) {
 		var dep = new ConstDependency(value, expr.range, true);
 		dep.loc = expr.loc;
-		this.state.current.addDependency(dep);
+		parser.state.current.addDependency(dep);
 		return true;
 	};
 };
@@ -74,13 +74,13 @@ ParserHelpers.evaluateToIdentifier = (identifier, truthy) => {
 	};
 };
 
-ParserHelpers.expressionIsUnsupported = (message) => {
+ParserHelpers.expressionIsUnsupported = (parser, message) => {
 	return function unsupportedExpression(expr) {
 		var dep = new ConstDependency("(void 0)", expr.range, false);
 		dep.loc = expr.loc;
-		this.state.current.addDependency(dep);
-		if(!this.state.module) return;
-		this.state.module.warnings.push(new UnsupportedFeatureWarning(this.state.module, message));
+		parser.state.current.addDependency(dep);
+		if(!parser.state.module) return;
+		parser.state.module.warnings.push(new UnsupportedFeatureWarning(parser.state.module, message));
 		return true;
 	};
 };

--- a/lib/ProvidePlugin.js
+++ b/lib/ProvidePlugin.js
@@ -45,7 +45,7 @@ class ProvidePlugin {
 							return false;
 						}
 						if(scopedName) {
-							ParserHelpers.toConstantDependency(nameIdentifier).call(parser, expr);
+							ParserHelpers.toConstantDependency(parser, nameIdentifier)(expr);
 						}
 						return true;
 					});

--- a/lib/RequireJsStuffPlugin.js
+++ b/lib/RequireJsStuffPlugin.js
@@ -20,11 +20,11 @@ module.exports = class RequireJsStuffPlugin {
 				if(typeof parserOptions.requireJs !== "undefined" && !parserOptions.requireJs)
 					return;
 
-				parser.plugin("call require.config", ParserHelpers.toConstantDependency("undefined"));
-				parser.plugin("call requirejs.config", ParserHelpers.toConstantDependency("undefined"));
+				parser.plugin("call require.config", ParserHelpers.toConstantDependency(parser, "undefined"));
+				parser.plugin("call requirejs.config", ParserHelpers.toConstantDependency(parser, "undefined"));
 
-				parser.plugin("expression require.version", ParserHelpers.toConstantDependency(JSON.stringify("0.0.0")));
-				parser.plugin("expression requirejs.onError", ParserHelpers.toConstantDependencyWithWebpackRequire("__webpack_require__.oe"));
+				parser.plugin("expression require.version", ParserHelpers.toConstantDependency(parser, JSON.stringify("0.0.0")));
+				parser.plugin("expression requirejs.onError", ParserHelpers.toConstantDependencyWithWebpackRequire(parser, "__webpack_require__.oe"));
 			};
 			normalModuleFactory.hooks.parser.for("javascript/auto").tap("RequireJsStuffPlugin", handler);
 			normalModuleFactory.hooks.parser.for("javascript/dynamic").tap("RequireJsStuffPlugin", handler);

--- a/lib/dependencies/AMDPlugin.js
+++ b/lib/dependencies/AMDPlugin.js
@@ -83,7 +83,7 @@ class AMDPlugin {
 				parser.plugin("evaluate typeof require.amd", ParserHelpers.evaluateToString(typeof amdOptions));
 				parser.plugin("evaluate Identifier define.amd", ParserHelpers.evaluateToIdentifier("define.amd", true));
 				parser.plugin("evaluate Identifier require.amd", ParserHelpers.evaluateToIdentifier("require.amd", true));
-				parser.plugin("typeof define", ParserHelpers.toConstantDependency(JSON.stringify("function")));
+				parser.plugin("typeof define", ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
 				parser.plugin("evaluate typeof define", ParserHelpers.evaluateToString("function"));
 				parser.plugin("can-rename define", ParserHelpers.approve);
 				parser.plugin("rename define", (expr) => {
@@ -93,7 +93,7 @@ class AMDPlugin {
 					parser.state.current.addDependency(dep);
 					return false;
 				});
-				parser.plugin("typeof require", ParserHelpers.toConstantDependency(JSON.stringify("function")));
+				parser.plugin("typeof require", ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
 				parser.plugin("evaluate typeof require", ParserHelpers.evaluateToString("function"));
 			};
 

--- a/lib/dependencies/CommonJsPlugin.js
+++ b/lib/dependencies/CommonJsPlugin.js
@@ -53,7 +53,7 @@ class CommonJsPlugin {
 
 				const requireExpressions = ["require", "require.resolve", "require.resolveWeak"];
 				for(let expression of requireExpressions) {
-					parser.plugin(`typeof ${expression}`, ParserHelpers.toConstantDependency(JSON.stringify("function")));
+					parser.plugin(`typeof ${expression}`, ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
 					parser.plugin(`evaluate typeof ${expression}`, ParserHelpers.evaluateToString("function"));
 					parser.plugin(`evaluate Identifier ${expression}`, ParserHelpers.evaluateToIdentifier(expression, true));
 				}

--- a/lib/dependencies/CommonJsRequireDependencyParserPlugin.js
+++ b/lib/dependencies/CommonJsRequireDependencyParserPlugin.js
@@ -38,7 +38,7 @@ class CommonJsRequireDependencyParserPlugin {
 			return true;
 		};
 
-		parser.plugin("expression require.cache", ParserHelpers.toConstantDependencyWithWebpackRequire("__webpack_require__.c"));
+		parser.plugin("expression require.cache", ParserHelpers.toConstantDependencyWithWebpackRequire(parser, "__webpack_require__.c"));
 		parser.plugin("expression require", (expr) => {
 			const dep = new CommonJsRequireContextDependency({
 				request: options.unknownContextRequest,

--- a/lib/dependencies/RequireEnsurePlugin.js
+++ b/lib/dependencies/RequireEnsurePlugin.js
@@ -31,7 +31,7 @@ class RequireEnsurePlugin {
 
 				parser.apply(new RequireEnsureDependenciesBlockParserPlugin());
 				parser.plugin("evaluate typeof require.ensure", ParserHelpers.evaluateToString("function"));
-				parser.plugin("typeof require.ensure", ParserHelpers.toConstantDependency(JSON.stringify("function")));
+				parser.plugin("typeof require.ensure", ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
 			};
 
 			normalModuleFactory.hooks.parser.for("javascript/auto").tap("RequireEnsurePlugin", handler);

--- a/lib/dependencies/RequireIncludePlugin.js
+++ b/lib/dependencies/RequireIncludePlugin.js
@@ -23,7 +23,7 @@ class RequireIncludePlugin {
 
 				parser.apply(new RequireIncludeDependencyParserPlugin());
 				parser.plugin("evaluate typeof require.include", ParserHelpers.evaluateToString("function"));
-				parser.plugin("typeof require.include", ParserHelpers.toConstantDependency(JSON.stringify("function")));
+				parser.plugin("typeof require.include", ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
 			};
 
 			normalModuleFactory.hooks.parser.for("javascript/auto").tap("RequireIncludePlugin", handler);

--- a/lib/dependencies/SystemPlugin.js
+++ b/lib/dependencies/SystemPlugin.js
@@ -21,13 +21,13 @@ class SystemPlugin {
 				const setNotSupported = name => {
 					parser.plugin("evaluate typeof " + name, ParserHelpers.evaluateToString("undefined"));
 					parser.plugin("expression " + name,
-						ParserHelpers.expressionIsUnsupported(name + " is not supported by webpack.")
+						ParserHelpers.expressionIsUnsupported(parser, name + " is not supported by webpack.")
 					);
 				};
 
-				parser.plugin("typeof System.import", ParserHelpers.toConstantDependency(JSON.stringify("function")));
+				parser.plugin("typeof System.import", ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
 				parser.plugin("evaluate typeof System.import", ParserHelpers.evaluateToString("function"));
-				parser.plugin("typeof System", ParserHelpers.toConstantDependency(JSON.stringify("object")));
+				parser.plugin("typeof System", ParserHelpers.toConstantDependency(parser, JSON.stringify("object")));
 				parser.plugin("evaluate typeof System", ParserHelpers.evaluateToString("object"));
 
 				setNotSupported("System.set");


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

n/a

**If relevant, link to documentation update:**

n/a

**Summary**

`Tapable`'s hooks are not bound to the parser instance. Without this change, the following would throw a `TypeError`:

```js
ParserHelpers.expressionIsUnsupported(parser, name + " is not supported.")
```

This PR modifies the `Parser` helpers to not rely on `this`.

**Does this PR introduce a breaking change?**

no

**Other information**

An alternative approach could have been used using `.bind(parser)`:

```js
ParserHelpers.expressionIsUnsupported(name + " is not supporte.").bind(parser)
```
