### PR TITLE
support functions for templated string config properties

### DIFF
--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -60,6 +60,10 @@ const replacePathVariables = (path, data) => {
 	const chunkHash = chunk && (chunk.renderedHash || chunk.hash);
 	const chunkHashWithLength = chunk && chunk.hashWithLength;
 
+	if(typeof path === "function") {
+		path = path(data);
+	}
+
 	if(data.noChunkHash && REGEXP_CHUNKHASH_FOR_TEST.test(path)) {
 		throw new Error(`Cannot use [chunkhash] for chunk in '${path}' (use [hash] instead)`);
 	}

--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -296,7 +296,14 @@
         },
         "chunkFilename": {
           "description": "The filename of non-entry chunks as relative path inside the `output.path` directory.",
-          "type": "string",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "instanceof": "Function"
+            }
+          ],
           "absolutePath": false
         },
         "crossOriginLoading": {
@@ -348,7 +355,14 @@
         },
         "filename": {
           "description": "Specifies the name of each output file on disk. You must **not** specify an absolute path here! The `output.path` option determines the location on disk the files are written to, filename is used solely for naming the individual files.",
-          "type": "string",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "instanceof": "Function"
+            }
+          ],
           "absolutePath": false
         },
         "hashDigest": {
@@ -376,7 +390,14 @@
         },
         "hotUpdateChunkFilename": {
           "description": "The filename of the Hot Update Chunks. They are inside the output.path directory.",
-          "type": "string",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "instanceof": "Function"
+            }
+          ],
           "absolutePath": false
         },
         "hotUpdateFunction": {
@@ -385,7 +406,14 @@
         },
         "hotUpdateMainFilename": {
           "description": "The filename of the Hot Update Main File. It is inside the `output.path` directory.",
-          "type": "string",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "instanceof": "Function"
+            }
+          ],
           "absolutePath": false
         },
         "jsonpFunction": {
@@ -464,7 +492,14 @@
         },
         "publicPath": {
           "description": "The `publicPath` specifies the public URL address of the output files when referenced in a browser.",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "instanceof": "Function"
+            }
+          ]
         },
         "sourceMapFilename": {
           "description": "The filename of the SourceMaps for the JavaScript files. They are inside the `output.path` directory.",

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -128,8 +128,12 @@ describe("Validation", () => {
 			"      -> A non-empty string",
 			"    * configuration.entry should be an instance of function",
 			"      -> A Function returning an entry object, an entry string, an entry array or a promise to these things.",
-			" - configuration.output.filename should be a string.",
-			"   -> Specifies the name of each output file on disk. You must **not** specify an absolute path here! The `output.path` option determines the location on disk the files are written to, filename is used solely for naming the individual files."
+			" - configuration.output.filename should be one of these:",
+			"   string | function",
+			"   -> Specifies the name of each output file on disk. You must **not** specify an absolute path here! The `output.path` option determines the location on disk the files are written to, filename is used solely for naming the individual files.",
+			"   Details:",
+			"    * configuration.output.filename should be a string.",
+			"    * configuration.output.filename should be an instance of function"
 		]
 	}, {
 		name: "multiple configurations",
@@ -154,8 +158,12 @@ describe("Validation", () => {
 			"      -> A non-empty string",
 			"    * configuration[0].entry should be an instance of function",
 			"      -> A Function returning an entry object, an entry string, an entry array or a promise to these things.",
-			" - configuration[1].output.filename should be a string.",
-			"   -> Specifies the name of each output file on disk. You must **not** specify an absolute path here! The `output.path` option determines the location on disk the files are written to, filename is used solely for naming the individual files."
+			" - configuration[1].output.filename should be one of these:",
+			"   string | function",
+			"   -> Specifies the name of each output file on disk. You must **not** specify an absolute path here! The `output.path` option determines the location on disk the files are written to, filename is used solely for naming the individual files.",
+			"   Details:",
+			"    * configuration[1].output.filename should be a string.",
+			"    * configuration[1].output.filename should be an instance of function",
 		]
 	}, {
 		name: "deep error",

--- a/test/configCases/output/function/a.js
+++ b/test/configCases/output/function/a.js
@@ -1,0 +1,3 @@
+it("should output correctly with a function for output.filename", (done) => {
+	done();
+});

--- a/test/configCases/output/function/b.js
+++ b/test/configCases/output/function/b.js
@@ -1,0 +1,3 @@
+it("should output correctly with a function for output.filename", (done) => {
+	done();
+});

--- a/test/configCases/output/function/test.config.js
+++ b/test/configCases/output/function/test.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	findBundle: function() {
+		return [
+			"./a.js",
+			"./b.js"
+		];
+	}
+};

--- a/test/configCases/output/function/webpack.config.js
+++ b/test/configCases/output/function/webpack.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+	entry() {
+		return {
+			a: "./a",
+			b: "./b"
+		};
+	},
+	output: {
+		filename: (data) => {
+			return data.chunk.name === "a" ? `${data.chunk.name}.js` : "[name].js";
+		}
+	}
+};

--- a/test/configCases/output/string/a.js
+++ b/test/configCases/output/string/a.js
@@ -1,0 +1,3 @@
+it("should output correctly with a string for output.filename", (done) => {
+	done();
+});

--- a/test/configCases/output/string/test.config.js
+++ b/test/configCases/output/string/test.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	findBundle: function() {
+		return [
+			"./a.js"
+		];
+	}
+};

--- a/test/configCases/output/string/webpack.config.js
+++ b/test/configCases/output/string/webpack.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	entry() {
+		return {
+			a: "./a"
+		};
+	},
+	output: {
+		filename: "[name].js"
+	}
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

Yes, a config test for when `output.filename` is a string and when it's a function.

**If relevant, link to documentation update:**

https://github.com/webpack/webpack.js.org/pull/1751

**Summary**

Any config property that accepts a templated string (e.g. '[name].js')
can now accept a function that returns a templated string.

```
{
    output: {
        filename: () => '[name].js'
    }
}
```

Closes #6098 

**Does this PR introduce a breaking change?**

no