### PR TITLE
perf: Enables uglify cache in prod mode

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -140,6 +140,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 				// Lazy load the uglifyjs plugin
 				const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 				new UglifyJsPlugin({
+					cache: true,
 					sourceMap: options.devtool && /source-?map/.test(options.devtool)
 				}).apply(compiler);
 			}

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -141,6 +141,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 				const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 				new UglifyJsPlugin({
 					cache: true,
+					parallel: true,
 					sourceMap: options.devtool && /source-?map/.test(options.devtool)
 				}).apply(compiler);
 			}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Performance
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
With the addition of `modes` Webpack now runs uglify by default which is currently initialized with the `sourcemap` option only. Given we are trying to simplify the onboarding, imo it makes sense to leverage the caching / threading in the uglify plugin to improve build performance ( see below )

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

##### `7900 modules`

##### Test Configuration
```
const path = require('path');
const webpack = require('webpack');

module.exports = {
  entry: './index.js',
  mode: 'production',
  output: {
    path: path.resolve(__dirname, './dist'),
    filename: 'bundle.js',
  },
  plugins: [
    new webpack.optimize.ModuleConcatenationPlugin(),
  ],
};
```

##### Initial build ( Left: No Cache | Right: With Cache )
![screen shot 2017-12-17 at 11 08 02 am](https://user-images.githubusercontent.com/8420490/34081921-142188f0-e31b-11e7-8ee0-e956b8ce27aa.png)


##### Subsequent build ( Left: No Cache | Right: With Cache )
![screen shot 2017-12-17 at 11 10 58 am](https://user-images.githubusercontent.com/8420490/34081922-1d26882e-e31b-11e7-917a-1744e1c0a38b.png)

##### Caching w/ Parallel execution ( Left: No Cache | Right: With Cache )
![screen shot 2017-12-17 at 9 41 18 pm](https://user-images.githubusercontent.com/8420490/34089049-24cf4694-e373-11e7-9030-b24fb9d7bed8.png)

