### PR TITLE
Use Parser#hooks instead of Tapable#plugin

### DIFF
--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -41,8 +41,8 @@ class APIPlugin {
 
 			const handler = parser => {
 				Object.keys(REPLACEMENTS).forEach(key => {
-					parser.plugin(`expression ${key}`, NO_WEBPACK_REQUIRE[key] ? ParserHelpers.toConstantDependency(parser, REPLACEMENTS[key]) : ParserHelpers.toConstantDependencyWithWebpackRequire(parser, REPLACEMENTS[key]));
-					parser.plugin(`evaluate typeof ${key}`, ParserHelpers.evaluateToString(REPLACEMENT_TYPES[key]));
+					parser.hooks.expression.for(key).tap("APIPlugin", NO_WEBPACK_REQUIRE[key] ? ParserHelpers.toConstantDependency(parser, REPLACEMENTS[key]) : ParserHelpers.toConstantDependencyWithWebpackRequire(parser, REPLACEMENTS[key]));
+					parser.hooks.evaluateTypeof.for(key).tap("APIPlugin", ParserHelpers.evaluateToString(REPLACEMENT_TYPES[key]));
 				});
 			};
 

--- a/lib/CompatibilityPlugin.js
+++ b/lib/CompatibilityPlugin.js
@@ -22,7 +22,7 @@ class CompatibilityPlugin {
 				if(typeof parserOptions.browserify !== "undefined" && !parserOptions.browserify)
 					return;
 
-				parser.plugin("call require", (expr) => {
+				parser.hooks.call.for("require").tap("CompatibilityPlugin", (expr) => {
 					// support for browserify style require delegator: "require(o, !0)"
 					if(expr.arguments.length !== 2) return;
 					const second = parser.evaluateExpression(expr.arguments[1]);

--- a/lib/ConstPlugin.js
+++ b/lib/ConstPlugin.js
@@ -21,7 +21,7 @@ class ConstPlugin {
 			compilation.dependencyTemplates.set(ConstDependency, new ConstDependency.Template());
 
 			const handler = parser => {
-				parser.plugin("statement if", statement => {
+				parser.hooks.statementIf.tap("ConstPlugin", statement => {
 					const param = parser.evaluateExpression(statement.test);
 					const bool = param.asBool();
 					if(typeof bool === "boolean") {
@@ -33,7 +33,7 @@ class ConstPlugin {
 						return bool;
 					}
 				});
-				parser.plugin("expression ?:", expression => {
+				parser.hooks.expressionConditionalOperator.tap("ConstPlugin", expression => {
 					const param = parser.evaluateExpression(expression.test);
 					const bool = param.asBool();
 					if(typeof bool === "boolean") {
@@ -45,11 +45,11 @@ class ConstPlugin {
 						return bool;
 					}
 				});
-				parser.plugin("evaluate Identifier __resourceQuery", expr => {
+				parser.hooks.evaluateIdentifier.for("__resourceQuery").tap("ConstPlugin", expr => {
 					if(!parser.state.module) return;
 					return ParserHelpers.evaluateToString(getQuery(parser.state.module.resource))(expr);
 				});
-				parser.plugin("expression __resourceQuery", () => {
+				parser.hooks.expression.for("__resourceQuery").tap("ConstPlugin", () => {
 					if(!parser.state.module) return;
 					parser.state.current.addVariable("__resourceQuery", JSON.stringify(getQuery(parser.state.module.resource)));
 					return true;

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -56,7 +56,7 @@ class DefinePlugin {
 					const splittedKey = key.split(".");
 					splittedKey.slice(1).forEach((_, i) => {
 						const fullKey = prefix + splittedKey.slice(0, i + 1).join(".");
-						parser.plugin("can-rename " + fullKey, ParserHelpers.approve);
+						parser.hooks.canRename.for(fullKey).tap("DefinePlugin", ParserHelpers.approve);
 					});
 				};
 
@@ -67,8 +67,8 @@ class DefinePlugin {
 					let recurseTypeof = false;
 					code = toCode(code);
 					if(!isTypeof) {
-						parser.plugin("can-rename " + key, ParserHelpers.approve);
-						parser.plugin("evaluate Identifier " + key, (expr) => {
+						parser.hooks.canRename.for(key).tap("DefinePlugin", ParserHelpers.approve);
+						parser.hooks.evaluateIdentifier.for(key).tap("DefinePlugin", (expr) => {
 							/**
 							 * this is needed in case there is a recursion in the DefinePlugin
 							 * to prevent an endless recursion
@@ -84,10 +84,10 @@ class DefinePlugin {
 							res.setRange(expr.range);
 							return res;
 						});
-						parser.plugin("expression " + key, /__webpack_require__/.test(code) ? ParserHelpers.toConstantDependencyWithWebpackRequire(parser, code) : ParserHelpers.toConstantDependency(parser, code));
+						parser.hooks.expression.for(key).tap("DefinePlugin", /__webpack_require__/.test(code) ? ParserHelpers.toConstantDependencyWithWebpackRequire(parser, code) : ParserHelpers.toConstantDependency(parser, code));
 					}
 					const typeofCode = isTypeof ? code : "typeof (" + code + ")";
-					parser.plugin("evaluate typeof " + key, (expr) => {
+					parser.hooks.evaluateTypeof.for(key).tap("DefinePlugin", (expr) => {
 						/**
 						 * this is needed in case there is a recursion in the DefinePlugin
 						 * to prevent an endless recursion
@@ -103,7 +103,7 @@ class DefinePlugin {
 						res.setRange(expr.range);
 						return res;
 					});
-					parser.plugin("typeof " + key, (expr) => {
+					parser.hooks.typeof.for(key).tap("DefinePlugin", (expr) => {
 						const res = parser.evaluate(typeofCode);
 						if(!res.isString()) return;
 						return ParserHelpers.toConstantDependency(parser, JSON.stringify(res.string)).bind(parser)(expr);
@@ -112,11 +112,11 @@ class DefinePlugin {
 
 				const applyObjectDefine = (key, obj) => {
 					const code = stringifyObj(obj);
-					parser.plugin("can-rename " + key, ParserHelpers.approve);
-					parser.plugin("evaluate Identifier " + key, (expr) => new BasicEvaluatedExpression().setTruthy().setRange(expr.range));
-					parser.plugin("evaluate typeof " + key, ParserHelpers.evaluateToString("object"));
-					parser.plugin("expression " + key, /__webpack_require__/.test(code) ? ParserHelpers.toConstantDependencyWithWebpackRequire(parser, code) : ParserHelpers.toConstantDependency(parser, code));
-					parser.plugin("typeof " + key, ParserHelpers.toConstantDependency(parser, JSON.stringify("object")));
+					parser.hooks.canRename.for(key).tap("DefinePlugin", ParserHelpers.approve);
+					parser.hooks.evaluateIdentifier.for(key).tap("DefinePlugin", (expr) => new BasicEvaluatedExpression().setTruthy().setRange(expr.range));
+					parser.hooks.evaluateTypeof.for(key).tap("DefinePlugin", ParserHelpers.evaluateToString("object"));
+					parser.hooks.expression.for(key).tap("DefinePlugin", /__webpack_require__/.test(code) ? ParserHelpers.toConstantDependencyWithWebpackRequire(parser, code) : ParserHelpers.toConstantDependency(parser, code));
+					parser.hooks.typeof.for(key).tap("DefinePlugin", ParserHelpers.toConstantDependency(parser, JSON.stringify("object")));
 				};
 
 				walkDefinitions(definitions, "");

--- a/lib/ExtendedAPIPlugin.js
+++ b/lib/ExtendedAPIPlugin.js
@@ -41,8 +41,8 @@ class ExtendedAPIPlugin {
 
 			const handler = (parser, parserOptions) => {
 				Object.keys(REPLACEMENTS).forEach(key => {
-					parser.plugin(`expression ${key}`, ParserHelpers.toConstantDependencyWithWebpackRequire(parser, REPLACEMENTS[key]));
-					parser.plugin(`evaluate typeof ${key}`, ParserHelpers.evaluateToString(REPLACEMENT_TYPES[key]));
+					parser.hooks.expression.for(key).tap("ExtendedAPIPlugin", ParserHelpers.toConstantDependencyWithWebpackRequire(parser, REPLACEMENTS[key]));
+					parser.hooks.evaluateTypeof.for(key).tap("ExtendedAPIPlugin", ParserHelpers.evaluateToString(REPLACEMENT_TYPES[key]));
 				});
 			};
 

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -193,9 +193,9 @@ module.exports = class HotModuleReplacementPlugin {
 			});
 
 			const handler = (parser, parserOptions) => {
-				parser.plugin("expression __webpack_hash__", ParserHelpers.toConstantDependencyWithWebpackRequire(parser, "__webpack_require__.h()"));
-				parser.plugin("evaluate typeof __webpack_hash__", ParserHelpers.evaluateToString("string"));
-				parser.plugin("evaluate Identifier module.hot", expr => {
+				parser.hooks.expression.for("__webpack_hash__").tap("HotModuleReplacementPlugin", ParserHelpers.toConstantDependencyWithWebpackRequire(parser, "__webpack_require__.h()"));
+				parser.hooks.evaluateTypeof.for("__webpack_hash__").tap("HotModuleReplacementPlugin", ParserHelpers.evaluateToString("string"));
+				parser.hooks.evaluateIdentifier.for("module.hot").tap("HotModuleReplacementPlugin", expr => {
 					return ParserHelpers.evaluateToIdentifier("module.hot", !!parser.state.compilation.hotUpdateChunkTemplate)(expr);
 				});
 				// TODO webpack 5: refactor this, no custom hooks
@@ -203,7 +203,7 @@ module.exports = class HotModuleReplacementPlugin {
 					parser.hooks.hotAcceptCallback = new SyncBailHook(["expression", "requests"]);
 				if(!parser.hooks.hotAcceptWithoutCallback)
 					parser.hooks.hotAcceptWithoutCallback = new SyncBailHook(["expression", "requests"]);
-				parser.plugin("call module.hot.accept", expr => {
+				parser.hooks.call.for("module.hot.accept").tap("HotModuleReplacementPlugin", expr => {
 					if(!parser.state.compilation.hotUpdateChunkTemplate) return false;
 					if(expr.arguments.length >= 1) {
 						const arg = parser.evaluateExpression(expr.arguments[0]);
@@ -231,7 +231,7 @@ module.exports = class HotModuleReplacementPlugin {
 						}
 					}
 				});
-				parser.plugin("call module.hot.decline", expr => {
+				parser.hooks.call.for("module.hot.decline").tap("HotModuleReplacementPlugin", expr => {
 					if(!parser.state.compilation.hotUpdateChunkTemplate) return false;
 					if(expr.arguments.length === 1) {
 						const arg = parser.evaluateExpression(expr.arguments[0]);
@@ -250,7 +250,7 @@ module.exports = class HotModuleReplacementPlugin {
 						});
 					}
 				});
-				parser.plugin("expression module.hot", ParserHelpers.skipTraversal);
+				parser.hooks.expression.for("module.hot").tap("HotModuleReplacementPlugin", ParserHelpers.skipTraversal);
 			};
 
 			// TODO add HMR support for javascript/esm

--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -32,14 +32,14 @@ class NodeStuffPlugin {
 					localOptions = Object.assign({}, localOptions, parserOptions.node);
 
 				const setConstant = (expressionName, value) => {
-					parser.plugin(`expression ${expressionName}`, () => {
+					parser.hooks.expression.for(expressionName).tap("NodeStuffPlugin", () => {
 						parser.state.current.addVariable(expressionName, JSON.stringify(value));
 						return true;
 					});
 				};
 
 				const setModuleConstant = (expressionName, fn) => {
-					parser.plugin(`expression ${expressionName}`, () => {
+					parser.hooks.expression.for(expressionName).tap("NodeStuffPlugin", () => {
 						parser.state.current.addVariable(expressionName, JSON.stringify(fn(parser.state.module)));
 						return true;
 					});
@@ -50,7 +50,7 @@ class NodeStuffPlugin {
 				} else if(localOptions.__filename) {
 					setModuleConstant("__filename", module => path.relative(context, module.resource));
 				}
-				parser.plugin("evaluate Identifier __filename", expr => {
+				parser.hooks.evaluateIdentifier.for("__filename").tap("NodeStuffPlugin", expr => {
 					if(!parser.state.module) return;
 					const resource = parser.state.module.resource;
 					const i = resource.indexOf("?");
@@ -61,31 +61,28 @@ class NodeStuffPlugin {
 				} else if(localOptions.__dirname) {
 					setModuleConstant("__dirname", module => path.relative(context, module.context));
 				}
-				parser.plugin("evaluate Identifier __dirname", expr => {
+				parser.hooks.evaluateIdentifier.for("__dirname").tap("NodeStuffPlugin", expr => {
 					if(!parser.state.module) return;
 					return ParserHelpers.evaluateToString(parser.state.module.context)(expr);
 				});
-				parser.plugin("expression require.main", ParserHelpers.toConstantDependencyWithWebpackRequire(parser, "__webpack_require__.c[__webpack_require__.s]"));
-				parser.plugin(
-					"expression require.extensions",
-					ParserHelpers.expressionIsUnsupported(parser, "require.extensions is not supported by webpack. Use a loader instead.")
-				);
-				parser.plugin("expression module.loaded", expr => {
+				parser.hooks.expression.for("require.main").tap("NodeStuffPlugin", ParserHelpers.toConstantDependencyWithWebpackRequire(parser, "__webpack_require__.c[__webpack_require__.s]"));
+				parser.hooks.expression.for("require.extensions").tap("NodeStuffPlugin", ParserHelpers.expressionIsUnsupported(parser, "require.extensions is not supported by webpack. Use a loader instead."));
+				parser.hooks.expression.for("module.loaded").tap("NodeStuffPlugin", expr => {
 					parser.state.module.buildMeta.moduleConcatenationBailout = "module.loaded";
 					return ParserHelpers.toConstantDependency(parser, "module.l")(expr);
 				});
-				parser.plugin("expression module.id", expr => {
+				parser.hooks.expression.for("module.id").tap("NodeStuffPlugin", expr => {
 					parser.state.module.buildMeta.moduleConcatenationBailout = "module.id";
 					return ParserHelpers.toConstantDependency(parser, "module.i")(expr);
 				});
-				parser.plugin("expression module.exports", () => {
+				parser.hooks.expression.for("module.exports").tap("NodeStuffPlugin", () => {
 					const module = parser.state.module;
 					const isHarmony = module.buildMeta && module.buildMeta.harmonyModule;
 					if(!isHarmony)
 						return true;
 				});
-				parser.plugin("evaluate Identifier module.hot", ParserHelpers.evaluateToIdentifier("module.hot", false));
-				parser.plugin("expression module", () => {
+				parser.hooks.evaluateIdentifier.for("module.hot").tap("NodeStuffPlugin", ParserHelpers.evaluateToIdentifier("module.hot", false));
+				parser.hooks.expression.for("module").tap("NodeStuffPlugin", () => {
 					const module = parser.state.module;
 					const isHarmony = module.buildMeta && module.buildMeta.harmonyModule;
 					let moduleJsPath = path.join(__dirname, "..", "buildin", isHarmony ? "harmony-module.js" : "module.js");

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -70,13 +70,13 @@ class Parser extends Tapable {
 			assigned: new HookMap(() => new SyncBailHook(["expression"])),
 			assign: new HookMap(() => new SyncBailHook(["expression"])),
 			typeof: new HookMap(() => new SyncBailHook(["expression"])),
-			expressionConditionalOperator: new SyncBailHook(["expression"]),
 			importCall: new SyncBailHook(["expression"]),
 			call: new HookMap(() => new SyncBailHook(["expression"])),
 			callAnyMember: new HookMap(() => new SyncBailHook(["expression"])),
 			new: new HookMap(() => new SyncBailHook(["expression"])),
 			expression: new HookMap(() => new SyncBailHook(["expression"])),
 			expressionAnyMember: new HookMap(() => new SyncBailHook(["expression"])),
+			expressionConditionalOperator: new SyncBailHook(["expression"]),
 			program: new SyncBailHook(["ast", "comments"]),
 		};
 		const HOOK_MAP_COMPAT_CONFIG = {
@@ -95,10 +95,10 @@ class Parser extends Tapable {
 			typeof: /^typeof (.+)$/,
 			assigned: /^assigned (.+)$/,
 			assign: /^assign (.+)$/,
-			expressionConditionalOperator: /^expression \?:$/,
 			callAnyMember: /^call (.+)\.\*$/,
 			call: /^call (.+)$/,
 			new: /^new (.+)$/,
+			expressionConditionalOperator: /^expression \?:$/,
 			expressionAnyMember: /^expression (.+)\.\*$/,
 			expression: /^expression (.+)$/,
 		};
@@ -123,7 +123,7 @@ class Parser extends Tapable {
 	}
 
 	initializeEvaluating() {
-		this.plugin("evaluate Literal", expr => {
+		this.hooks.evaluate.for("Literal").tap("Parser", expr => {
 			switch(typeof expr.value) {
 				case "number":
 					return new BasicEvaluatedExpression().setNumber(expr.value).setRange(expr.range);
@@ -137,7 +137,7 @@ class Parser extends Tapable {
 			if(expr.value instanceof RegExp)
 				return new BasicEvaluatedExpression().setRegExp(expr.value).setRange(expr.range);
 		});
-		this.plugin("evaluate LogicalExpression", expr => {
+		this.hooks.evaluate.for("LogicalExpression").tap("Parser", expr => {
 			let left;
 			let leftAsBool;
 			let right;
@@ -157,7 +157,7 @@ class Parser extends Tapable {
 				return right.setRange(expr.range);
 			}
 		});
-		this.plugin("evaluate BinaryExpression", expr => {
+		this.hooks.evaluate.for("BinaryExpression").tap("Parser", expr => {
 			let left;
 			let right;
 			let res;
@@ -340,7 +340,7 @@ class Parser extends Tapable {
 				return res;
 			}
 		});
-		this.plugin("evaluate UnaryExpression", expr => {
+		this.hooks.evaluate.for("UnaryExpression").tap("Parser", expr => {
 			if(expr.operator === "typeof") {
 				let res;
 				let name;
@@ -396,10 +396,10 @@ class Parser extends Tapable {
 				return res;
 			}
 		});
-		this.plugin("evaluate typeof undefined", expr => {
+		this.hooks.evaluateTypeof.for("undefined").tap("Parser", expr => {
 			return new BasicEvaluatedExpression().setString("undefined").setRange(expr.range);
 		});
-		this.plugin("evaluate Identifier", expr => {
+		this.hooks.evaluate.for("Identifier").tap("Parser", expr => {
 			const name = this.scope.renames.get(expr.name) || expr.name;
 			if(!this.scope.definitions.has(expr.name)) {
 				const hook = this.hooks.evaluateIdentifier.get(name);
@@ -415,7 +415,7 @@ class Parser extends Tapable {
 				}
 			}
 		});
-		this.plugin("evaluate ThisExpression", expr => {
+		this.hooks.evaluate.for("ThisExpression").tap("Parser", expr => {
 			const name = this.scope.renames.get("this");
 			if(name) {
 				const hook = this.hooks.evaluateIdentifier.get(name);
@@ -426,7 +426,7 @@ class Parser extends Tapable {
 				return new BasicEvaluatedExpression().setIdentifier(name).setRange(expr.range);
 			}
 		});
-		this.plugin("evaluate MemberExpression", expression => {
+		this.hooks.evaluate.for("MemberExpression").tap("Parser", expression => {
 			let exprName = this.getNameForExpression(expression);
 			if(exprName) {
 				if(exprName.free) {
@@ -444,7 +444,7 @@ class Parser extends Tapable {
 				}
 			}
 		});
-		this.plugin("evaluate CallExpression", expr => {
+		this.hooks.evaluate.for("CallExpression").tap("Parser", expr => {
 			if(expr.callee.type !== "MemberExpression") return;
 			if(expr.callee.property.type !== (expr.callee.computed ? "Literal" : "Identifier")) return;
 			const param = this.evaluateExpression(expr.callee.object);
@@ -455,7 +455,7 @@ class Parser extends Tapable {
 				return hook.call(expr, param);
 			}
 		});
-		this.plugin("evaluate CallExpression .replace", (expr, param) => {
+		this.hooks.evaluateCallExpressionMember.for("replace").tap("Parser", (expr, param) => {
 			if(!param.isString()) return;
 			if(expr.arguments.length !== 2) return;
 			let arg1 = this.evaluateExpression(expr.arguments[0]);
@@ -467,7 +467,7 @@ class Parser extends Tapable {
 			return new BasicEvaluatedExpression().setString(param.string.replace(arg1, arg2)).setRange(expr.range);
 		});
 		["substr", "substring"].forEach(fn => {
-			this.plugin("evaluate CallExpression ." + fn, (expr, param) => {
+			this.hooks.evaluateCallExpressionMember.for(fn).tap("Parser", (expr, param) => {
 				if(!param.isString()) return;
 				let arg1;
 				let result, str = param.string;
@@ -519,20 +519,20 @@ class Parser extends Tapable {
 			return parts;
 		};
 
-		this.plugin("evaluate TemplateLiteral", node => {
+		this.hooks.evaluate.for("TemplateLiteral").tap("Parser", node => {
 			const parts = getSimplifiedTemplateResult.call(this, "cooked", node.quasis, node.expressions);
 			if(parts.length === 1) {
 				return parts[0].setRange(node.range);
 			}
 			return new BasicEvaluatedExpression().setTemplateString(parts).setRange(node.range);
 		});
-		this.plugin("evaluate TaggedTemplateExpression", node => {
+		this.hooks.evaluate.for("TaggedTemplateExpression").tap("Parser", node => {
 			if(this.evaluateExpression(node.tag).identifier !== "String.raw") return;
 			const parts = getSimplifiedTemplateResult.call(this, "raw", node.quasi.quasis, node.quasi.expressions);
 			return new BasicEvaluatedExpression().setTemplateString(parts).setRange(node.range);
 		});
 
-		this.plugin("evaluate CallExpression .concat", (expr, param) => {
+		this.hooks.evaluateCallExpressionMember.for("concat").tap("Parser", (expr, param) => {
 			if(!param.isString() && !param.isWrapped()) return;
 
 			let stringSuffix = null;
@@ -562,7 +562,7 @@ class Parser extends Tapable {
 				return new BasicEvaluatedExpression().setString(newString).setRange(expr.range);
 			}
 		});
-		this.plugin("evaluate CallExpression .split", (expr, param) => {
+		this.hooks.evaluateCallExpressionMember.for("split").tap("Parser", (expr, param) => {
 			if(!param.isString()) return;
 			if(expr.arguments.length !== 1) return;
 			let result;
@@ -574,7 +574,7 @@ class Parser extends Tapable {
 			} else return;
 			return new BasicEvaluatedExpression().setArray(result).setRange(expr.range);
 		});
-		this.plugin("evaluate ConditionalExpression", expr => {
+		this.hooks.evaluate.for("ConditionalExpression").tap("Parser", expr => {
 			const condition = this.evaluateExpression(expr.test);
 			const conditionValue = condition.asBool();
 			let res;
@@ -597,7 +597,7 @@ class Parser extends Tapable {
 			res.setRange(expr.range);
 			return res;
 		});
-		this.plugin("evaluate ArrayExpression", expr => {
+		this.hooks.evaluate.for("ArrayExpression").tap("Parser", expr => {
 			const items = expr.elements.map(element => {
 				return element !== null && this.evaluateExpression(element);
 			});

--- a/lib/RequireJsStuffPlugin.js
+++ b/lib/RequireJsStuffPlugin.js
@@ -20,11 +20,11 @@ module.exports = class RequireJsStuffPlugin {
 				if(typeof parserOptions.requireJs !== "undefined" && !parserOptions.requireJs)
 					return;
 
-				parser.plugin("call require.config", ParserHelpers.toConstantDependency(parser, "undefined"));
-				parser.plugin("call requirejs.config", ParserHelpers.toConstantDependency(parser, "undefined"));
+				parser.hooks.call.for("require.config").tap("RequireJsStuffPlugin", ParserHelpers.toConstantDependency(parser, "undefined"));
+				parser.hooks.call.for("requirejs.config").tap("RequireJsStuffPlugin", ParserHelpers.toConstantDependency(parser, "undefined"));
 
-				parser.plugin("expression require.version", ParserHelpers.toConstantDependency(parser, JSON.stringify("0.0.0")));
-				parser.plugin("expression requirejs.onError", ParserHelpers.toConstantDependencyWithWebpackRequire(parser, "__webpack_require__.oe"));
+				parser.hooks.expression.for("require.version").tap("RequireJsStuffPlugin", ParserHelpers.toConstantDependency(parser, JSON.stringify("0.0.0")));
+				parser.hooks.expression.for("requirejs.onError").tap("RequireJsStuffPlugin", ParserHelpers.toConstantDependencyWithWebpackRequire(parser, "__webpack_require__.oe"));
 			};
 			normalModuleFactory.hooks.parser.for("javascript/auto").tap("RequireJsStuffPlugin", handler);
 			normalModuleFactory.hooks.parser.for("javascript/dynamic").tap("RequireJsStuffPlugin", handler);

--- a/lib/dependencies/AMDDefineDependencyParserPlugin.js
+++ b/lib/dependencies/AMDDefineDependencyParserPlugin.js
@@ -123,7 +123,7 @@ class AMDDefineDependencyParserPlugin {
 			return true;
 		};
 
-		parser.plugin("call define", (expr) => {
+		parser.hooks.call.for("define").tap("AMDDefineDependencyParserPlugin", (expr) => {
 			let array, fn, obj, namedModule;
 			switch(expr.arguments.length) {
 				case 1:

--- a/lib/dependencies/AMDPlugin.js
+++ b/lib/dependencies/AMDPlugin.js
@@ -61,7 +61,7 @@ class AMDPlugin {
 					return;
 
 				const setExpressionToModule = (outerExpr, module) => {
-					parser.plugin("expression " + outerExpr, (expr) => {
+					parser.hooks.expression.for(outerExpr).tap("AMDPlugin", (expr) => {
 						const dep = new AMDRequireItemDependency(module, expr.range);
 						dep.userRequest = outerExpr;
 						dep.loc = expr.loc;
@@ -77,24 +77,24 @@ class AMDPlugin {
 				setExpressionToModule("define.amd", "!!webpack amd options");
 				setExpressionToModule("define", "!!webpack amd define");
 
-				parser.plugin("expression __webpack_amd_options__", () =>
+				parser.hooks.expression.for("__webpack_amd_options__").tap("AMDPlugin", () =>
 					parser.state.current.addVariable("__webpack_amd_options__", JSON.stringify(amdOptions)));
-				parser.plugin("evaluate typeof define.amd", ParserHelpers.evaluateToString(typeof amdOptions));
-				parser.plugin("evaluate typeof require.amd", ParserHelpers.evaluateToString(typeof amdOptions));
-				parser.plugin("evaluate Identifier define.amd", ParserHelpers.evaluateToIdentifier("define.amd", true));
-				parser.plugin("evaluate Identifier require.amd", ParserHelpers.evaluateToIdentifier("require.amd", true));
-				parser.plugin("typeof define", ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
-				parser.plugin("evaluate typeof define", ParserHelpers.evaluateToString("function"));
-				parser.plugin("can-rename define", ParserHelpers.approve);
-				parser.plugin("rename define", (expr) => {
+				parser.hooks.evaluateTypeof.for("define.amd").tap("AMDPlugin", ParserHelpers.evaluateToString(typeof amdOptions));
+				parser.hooks.evaluateTypeof.for("require.amd").tap("AMDPlugin", ParserHelpers.evaluateToString(typeof amdOptions));
+				parser.hooks.evaluateIdentifier.for("define.amd").tap("AMDPlugin", ParserHelpers.evaluateToIdentifier("define.amd", true));
+				parser.hooks.evaluateIdentifier.for("require.amd").tap("AMDPlugin", ParserHelpers.evaluateToIdentifier("require.amd", true));
+				parser.hooks.typeof.for("define").tap("AMDPlugin", ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
+				parser.hooks.evaluateTypeof.for("define").tap("AMDPlugin", ParserHelpers.evaluateToString("function"));
+				parser.hooks.canRename.for("define").tap("AMDPlugin", ParserHelpers.approve);
+				parser.hooks.rename.for("define").tap("AMDPlugin", (expr) => {
 					const dep = new AMDRequireItemDependency("!!webpack amd define", expr.range);
 					dep.userRequest = "define";
 					dep.loc = expr.loc;
 					parser.state.current.addDependency(dep);
 					return false;
 				});
-				parser.plugin("typeof require", ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
-				parser.plugin("evaluate typeof require", ParserHelpers.evaluateToString("function"));
+				parser.hooks.typeof.for("require").tap("AMDPlugin", ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
+				parser.hooks.evaluateTypeof.for("require").tap("AMDPlugin", ParserHelpers.evaluateToString("function"));
 			};
 
 			normalModuleFactory.hooks.parser.for("javascript/auto").tap("AMDPlugin", handler);

--- a/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
@@ -119,7 +119,7 @@ class AMDRequireDependenciesBlockParserPlugin {
 			return true;
 		};
 
-		parser.plugin("call require", (expr) => {
+		parser.hooks.call.for("require").tap("AMDRequireDependenciesBlockParserPlugin", (expr) => {
 			let param;
 			let dep;
 			let result;

--- a/lib/dependencies/CommonJsPlugin.js
+++ b/lib/dependencies/CommonJsPlugin.js
@@ -53,13 +53,13 @@ class CommonJsPlugin {
 
 				const requireExpressions = ["require", "require.resolve", "require.resolveWeak"];
 				for(let expression of requireExpressions) {
-					parser.plugin(`typeof ${expression}`, ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
-					parser.plugin(`evaluate typeof ${expression}`, ParserHelpers.evaluateToString("function"));
-					parser.plugin(`evaluate Identifier ${expression}`, ParserHelpers.evaluateToIdentifier(expression, true));
+					parser.hooks.typeof.for(expression).tap("CommonJsPlugin", ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
+					parser.hooks.evaluateTypeof.for(expression).tap("CommonJsPlugin", ParserHelpers.evaluateToString("function"));
+					parser.hooks.evaluateIdentifier.for(expression).tap("CommonJsPlugin", ParserHelpers.evaluateToIdentifier(expression, true));
 				}
 
-				parser.plugin("evaluate typeof module", ParserHelpers.evaluateToString("object"));
-				parser.plugin("assign require", (expr) => {
+				parser.hooks.evaluateTypeof.for("module").tap("CommonJsPlugin", ParserHelpers.evaluateToString("object"));
+				parser.hooks.assign.for("require").tap("CommonJsPlugin", (expr) => {
 					// to not leak to global "require", we need to define a local require here.
 					const dep = new ConstDependency("var require;", 0);
 					dep.loc = expr.loc;
@@ -67,16 +67,16 @@ class CommonJsPlugin {
 					parser.scope.definitions.add("require");
 					return true;
 				});
-				parser.plugin("can-rename require", () => true);
-				parser.plugin("rename require", (expr) => {
+				parser.hooks.canRename.for("require").tap("CommonJsPlugin", () => true);
+				parser.hooks.rename.for("require").tap("CommonJsPlugin", (expr) => {
 					// define the require variable. It's still undefined, but not "not defined".
 					const dep = new ConstDependency("var require;", 0);
 					dep.loc = expr.loc;
 					parser.state.current.addDependency(dep);
 					return false;
 				});
-				parser.plugin("typeof module", () => true);
-				parser.plugin("evaluate typeof exports", ParserHelpers.evaluateToString("object"));
+				parser.hooks.typeof.for("module").tap("CommonJsPlugin", () => true);
+				parser.hooks.evaluateTypeof.for("exports").tap("CommonJsPlugin", ParserHelpers.evaluateToString("object"));
 
 				new CommonJsRequireDependencyParserPlugin(options).apply(parser);
 				new RequireResolveDependencyParserPlugin(options).apply(parser);

--- a/lib/dependencies/CommonJsRequireDependencyParserPlugin.js
+++ b/lib/dependencies/CommonJsRequireDependencyParserPlugin.js
@@ -38,8 +38,8 @@ class CommonJsRequireDependencyParserPlugin {
 			return true;
 		};
 
-		parser.plugin("expression require.cache", ParserHelpers.toConstantDependencyWithWebpackRequire(parser, "__webpack_require__.c"));
-		parser.plugin("expression require", (expr) => {
+		parser.hooks.expression.for("require.cache").tap("CommonJsRequireDependencyParserPlugin", ParserHelpers.toConstantDependencyWithWebpackRequire(parser, "__webpack_require__.c"));
+		parser.hooks.expression.for("require").tap("CommonJsRequireDependencyParserPlugin", (expr) => {
 			const dep = new CommonJsRequireContextDependency({
 				request: options.unknownContextRequest,
 				recursive: options.unknownContextRecursive,
@@ -52,7 +52,7 @@ class CommonJsRequireDependencyParserPlugin {
 			parser.state.current.addDependency(dep);
 			return true;
 		});
-		parser.plugin("call require", (expr) => {
+		parser.hooks.call.for("require").tap("CommonJsRequireDependencyParserPlugin", (expr) => {
 			if(expr.arguments.length !== 1) return;
 			let localModule;
 			const param = parser.evaluateExpression(expr.arguments[0]);

--- a/lib/dependencies/HarmonyDetectionParserPlugin.js
+++ b/lib/dependencies/HarmonyDetectionParserPlugin.js
@@ -9,7 +9,7 @@ const HarmonyInitDependency = require("./HarmonyInitDependency");
 
 module.exports = class HarmonyDetectionParserPlugin {
 	apply(parser) {
-		parser.plugin("program", (ast) => {
+		parser.hooks.program.tap("HarmonyDetectionParserPlugin", (ast) => {
 			const isStrictHarmony = parser.state.module.type === "javascript/esm";
 			const isHarmony = isStrictHarmony || ast.body.some(statement => {
 				return /^(Import|Export).*Declaration$/.test(statement.type);
@@ -67,11 +67,11 @@ module.exports = class HarmonyDetectionParserPlugin {
 
 		const nonHarmonyIdentifiers = ["define", "exports"];
 		nonHarmonyIdentifiers.forEach(identifer => {
-			parser.plugin(`evaluate typeof ${identifer}`, nullInHarmony);
-			parser.plugin(`typeof ${identifer}`, skipInHarmony);
-			parser.plugin(`evaluate ${identifer}`, nullInHarmony);
-			parser.plugin(`expression ${identifer}`, skipInHarmony);
-			parser.plugin(`call ${identifer}`, skipInHarmony);
+			parser.hooks.evaluateTypeof.for(identifer).tap("HarmonyDetectionParserPlugin", nullInHarmony);
+			parser.hooks.typeof.for(identifer).tap("HarmonyDetectionParserPlugin", skipInHarmony);
+			parser.hooks.evaluate.for(identifer).tap("HarmonyDetectionParserPlugin", nullInHarmony);
+			parser.hooks.expression.for(identifer).tap("HarmonyDetectionParserPlugin", skipInHarmony);
+			parser.hooks.call.for(identifer).tap("HarmonyDetectionParserPlugin", skipInHarmony);
 		});
 	}
 };

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -17,14 +17,14 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 	}
 
 	apply(parser) {
-		parser.plugin("export", statement => {
+		parser.hooks.export.tap("HarmonyExportDependencyParserPlugin", statement => {
 			const dep = new HarmonyExportHeaderDependency(statement.declaration && statement.declaration.range, statement.range);
 			dep.loc = Object.create(statement.loc);
 			dep.loc.index = -1;
 			parser.state.current.addDependency(dep);
 			return true;
 		});
-		parser.plugin("export import", (statement, source) => {
+		parser.hooks.exportImport.tap("HarmonyExportDependencyParserPlugin", (statement, source) => {
 			parser.state.lastHarmonyImportOrder = (parser.state.lastHarmonyImportOrder || 0) + 1;
 			const clearDep = new ConstDependency("", statement.range);
 			clearDep.loc = Object.create(statement.loc);
@@ -36,15 +36,15 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 			parser.state.current.addDependency(sideEffectDep);
 			return true;
 		});
-		parser.plugin("export expression", (statement, expr) => {
+		parser.hooks.exportExpression.tap("HarmonyExportDependencyParserPlugin", (statement, expr) => {
 			const dep = new HarmonyExportExpressionDependency(parser.state.module, expr.range, statement.range);
 			dep.loc = Object.create(statement.loc);
 			dep.loc.index = -1;
 			parser.state.current.addDependency(dep);
 			return true;
 		});
-		parser.plugin("export declaration", statement => {});
-		parser.plugin("export specifier", (statement, id, name, idx) => {
+		parser.hooks.exportDeclaration.tap("HarmonyExportDependencyParserPlugin", statement => {});
+		parser.hooks.exportSpecifier.tap("HarmonyExportDependencyParserPlugin", (statement, id, name, idx) => {
 			const rename = parser.scope.renames.get(id);
 			let dep;
 			const harmonyNamedExports = parser.state.harmonyNamedExports = parser.state.harmonyNamedExports || new Set();
@@ -60,7 +60,7 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 			parser.state.current.addDependency(dep);
 			return true;
 		});
-		parser.plugin("export import specifier", (statement, source, id, name, idx) => {
+		parser.hooks.exportImportSpecifier.tap("HarmonyExportDependencyParserPlugin", (statement, source, id, name, idx) => {
 			const harmonyNamedExports = parser.state.harmonyNamedExports = parser.state.harmonyNamedExports || new Set();
 			let harmonyStarExports = null;
 			if(name) {

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -18,7 +18,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 	}
 
 	apply(parser) {
-		parser.plugin("import", (statement, source) => {
+		parser.hooks.import.tap("HarmonyImportDependencyParserPlugin", (statement, source) => {
 			parser.state.lastHarmonyImportOrder = (parser.state.lastHarmonyImportOrder || 0) + 1;
 			const clearDep = new ConstDependency("", statement.range);
 			clearDep.loc = statement.loc;
@@ -28,7 +28,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			parser.state.module.addDependency(sideEffectDep);
 			return true;
 		});
-		parser.plugin("import specifier", (statement, source, id, name) => {
+		parser.hooks.importSpecifier.tap("HarmonyImportDependencyParserPlugin", (statement, source, id, name) => {
 			parser.scope.definitions.delete(name);
 			parser.scope.renames.set(name, "imported var");
 			if(!parser.state.harmonySpecifier) parser.state.harmonySpecifier = new Map();
@@ -39,7 +39,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			});
 			return true;
 		});
-		parser.plugin("expression imported var", (expr) => {
+		parser.hooks.expression.for("imported var").tap("HarmonyImportDependencyParserPlugin", (expr) => {
 			const name = expr.name;
 			const settings = parser.state.harmonySpecifier.get(name);
 			const dep = new HarmonyImportSpecifierDependency(settings.source, parser.state.module, settings.sourceOrder, parser.state.harmonyParserScope, settings.id, name, expr.range, this.strictExportPresence);
@@ -49,7 +49,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			parser.state.module.addDependency(dep);
 			return true;
 		});
-		parser.plugin("expression imported var.*", (expr) => {
+		parser.hooks.expressionAnyMember.for("imported var").tap("HarmonyImportDependencyParserPlugin", (expr) => {
 			const name = expr.object.name;
 			const settings = parser.state.harmonySpecifier.get(name);
 			if(settings.id !== null)
@@ -63,7 +63,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 		});
 		if(this.strictThisContextOnImports) {
 			// only in case when we strictly follow the spec we need a special case here
-			parser.plugin("call imported var.*", (expr) => {
+			parser.hooks.callAnyMember.for("imported var").tap("HarmonyImportDependencyParserPlugin", (expr) => {
 				if(expr.callee.type !== "MemberExpression") return;
 				if(expr.callee.object.type !== "Identifier") return;
 				const name = expr.callee.object.name;
@@ -81,7 +81,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 				return true;
 			});
 		}
-		parser.plugin("call imported var", (expr) => {
+		parser.hooks.call.for("imported var").tap("HarmonyImportDependencyParserPlugin", (expr) => {
 			const args = expr.arguments;
 			const fullExpr = expr;
 			expr = expr.callee;
@@ -103,7 +103,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			parser.hooks.hotAcceptCallback = new SyncBailHook(["expression", "requests"]);
 		if(!parser.hooks.hotAcceptWithoutCallback)
 			parser.hooks.hotAcceptWithoutCallback = new SyncBailHook(["expression", "requests"]);
-		parser.plugin("hot accept callback", (expr, requests) => {
+		parser.hooks.hotAcceptCallback.tap("HarmonyImportDependencyParserPlugin", (expr, requests) => {
 			const dependencies = requests
 				.map(request => {
 					const dep = new HarmonyAcceptImportDependency(request, parser.state.module, parser.state.harmonyParserScope);
@@ -117,7 +117,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 				parser.state.module.addDependency(dep);
 			}
 		});
-		parser.plugin("hot accept without callback", (expr, requests) => {
+		parser.hooks.hotAcceptWithoutCallback.tap("HarmonyImportDependencyParserPlugin", (expr, requests) => {
 			const dependencies = requests
 				.map(request => {
 					const dep = new HarmonyAcceptImportDependency(request, parser.state.module, parser.state.harmonyParserScope);

--- a/lib/dependencies/ImportParserPlugin.js
+++ b/lib/dependencies/ImportParserPlugin.js
@@ -18,8 +18,7 @@ class ImportParserPlugin {
 
 	apply(parser) {
 		const options = this.options;
-
-		parser.plugin(["call System.import", "import-call"], (expr) => {
+		const handler = (expr) => {
 			if(expr.arguments.length !== 1)
 				throw new Error("Incorrect number of arguments provided to 'import(module: string) -> Promise'.");
 
@@ -98,7 +97,10 @@ class ImportParserPlugin {
 				parser.state.current.addDependency(dep);
 				return true;
 			}
-		});
+		};
+
+		parser.hooks.call.for("System.import").tap("ImportParserPlugin", handler);
+		parser.hooks.importCall.tap("ImportParserPlugin", handler);
 	}
 }
 module.exports = ImportParserPlugin;

--- a/lib/dependencies/RequireContextDependencyParserPlugin.js
+++ b/lib/dependencies/RequireContextDependencyParserPlugin.js
@@ -8,7 +8,7 @@ const RequireContextDependency = require("./RequireContextDependency");
 
 module.exports = class RequireContextDependencyParserPlugin {
 	apply(parser) {
-		parser.plugin("call require.context", expr => {
+		parser.hooks.call.for("require.context").tap("RequireContextDependencyParserPlugin", expr => {
 			let regExp = /^\.\/.*$/;
 			let recursive = true;
 			let mode = "sync";

--- a/lib/dependencies/RequireEnsureDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/RequireEnsureDependenciesBlockParserPlugin.js
@@ -10,7 +10,7 @@ const getFunctionExpression = require("./getFunctionExpression");
 
 module.exports = class RequireEnsureDependenciesBlockParserPlugin {
 	apply(parser) {
-		parser.plugin("call require.ensure", expr => {
+		parser.hooks.call.for("require.ensure").tap("RequireEnsureDependenciesBlockParserPlugin", expr => {
 			let chunkName = null;
 			let chunkNameRange = null;
 			let errorExpressionArg = null;

--- a/lib/dependencies/RequireEnsurePlugin.js
+++ b/lib/dependencies/RequireEnsurePlugin.js
@@ -30,8 +30,8 @@ class RequireEnsurePlugin {
 					return;
 
 				new RequireEnsureDependenciesBlockParserPlugin().apply(parser);
-				parser.plugin("evaluate typeof require.ensure", ParserHelpers.evaluateToString("function"));
-				parser.plugin("typeof require.ensure", ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
+				parser.hooks.evaluateTypeof.for("require.ensure").tap("RequireEnsurePlugin", ParserHelpers.evaluateToString("function"));
+				parser.hooks.typeof.for("require.ensure").tap("RequireEnsurePlugin", ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
 			};
 
 			normalModuleFactory.hooks.parser.for("javascript/auto").tap("RequireEnsurePlugin", handler);

--- a/lib/dependencies/RequireIncludeDependencyParserPlugin.js
+++ b/lib/dependencies/RequireIncludeDependencyParserPlugin.js
@@ -8,7 +8,7 @@ const RequireIncludeDependency = require("./RequireIncludeDependency");
 
 module.exports = class RequireIncludeDependencyParserPlugin {
 	apply(parser) {
-		parser.plugin("call require.include", expr => {
+		parser.hooks.call.for("require.include").tap("RequireIncludeDependencyParserPlugin", expr => {
 			if(expr.arguments.length !== 1) return;
 			const param = parser.evaluateExpression(expr.arguments[0]);
 			if(!param.isString()) return;

--- a/lib/dependencies/RequireIncludePlugin.js
+++ b/lib/dependencies/RequireIncludePlugin.js
@@ -22,8 +22,8 @@ class RequireIncludePlugin {
 					return;
 
 				new RequireIncludeDependencyParserPlugin().apply(parser);
-				parser.plugin("evaluate typeof require.include", ParserHelpers.evaluateToString("function"));
-				parser.plugin("typeof require.include", ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
+				parser.hooks.evaluateTypeof.for("require.include").tap("RequireIncludePlugin", ParserHelpers.evaluateToString("function"));
+				parser.hooks.typeof.for("require.include").tap("RequireIncludePlugin", ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
 			};
 
 			normalModuleFactory.hooks.parser.for("javascript/auto").tap("RequireIncludePlugin", handler);

--- a/lib/dependencies/RequireResolveDependencyParserPlugin.js
+++ b/lib/dependencies/RequireResolveDependencyParserPlugin.js
@@ -63,10 +63,10 @@ class RequireResolveDependencyParserPlugin {
 			return true;
 		};
 
-		parser.plugin("call require.resolve", (expr) => {
+		parser.hooks.call.for("require.resolve").tap("RequireResolveDependencyParserPlugin", (expr) => {
 			return process(expr, false);
 		});
-		parser.plugin("call require.resolveWeak", (expr) => {
+		parser.hooks.call.for("require.resolveWeak").tap("RequireResolveDependencyParserPlugin", (expr) => {
 			return process(expr, true);
 		});
 	}

--- a/lib/dependencies/SystemPlugin.js
+++ b/lib/dependencies/SystemPlugin.js
@@ -19,21 +19,22 @@ class SystemPlugin {
 					return;
 
 				const setNotSupported = name => {
-					parser.plugin("evaluate typeof " + name, ParserHelpers.evaluateToString("undefined"));
-					parser.plugin("expression " + name,
+					parser.hooks.evaluateTypeof.for(name).tap("SystemPlugin", ParserHelpers.evaluateToString("undefined"));
+					parser.hooks.expression.for(name).tap("SystemPlugin",
 						ParserHelpers.expressionIsUnsupported(parser, name + " is not supported by webpack.")
 					);
 				};
 
-				parser.plugin("typeof System.import", ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
-				parser.plugin("evaluate typeof System.import", ParserHelpers.evaluateToString("function"));
-				parser.plugin("typeof System", ParserHelpers.toConstantDependency(parser, JSON.stringify("object")));
-				parser.plugin("evaluate typeof System", ParserHelpers.evaluateToString("object"));
+				parser.hooks.typeof.for("System.import").tap("SystemPlugin", ParserHelpers.toConstantDependency(parser, JSON.stringify("function")));
+				parser.hooks.evaluateTypeof.for("System.import").tap("SystemPlugin", ParserHelpers.evaluateToString("function"));
+				parser.hooks.typeof.for("System").tap("SystemPlugin", ParserHelpers.toConstantDependency(parser, JSON.stringify("object")));
+				parser.hooks.evaluateTypeof.for("System").tap("SystemPlugin", ParserHelpers.evaluateToString("object"));
 
 				setNotSupported("System.set");
 				setNotSupported("System.get");
 				setNotSupported("System.register");
-				parser.plugin("expression System", () => {
+
+				parser.hooks.expression.for("System").tap("SystemPlugin", () => {
 					const systemPolyfillRequire = ParserHelpers.requireFileAsExpression(
 						parser.state.module.context, require.resolve("../../buildin/system.js"));
 					return ParserHelpers.addParsedVariableToModule(parser, "System", systemPolyfillRequire);

--- a/lib/node/NodeSourcePlugin.js
+++ b/lib/node/NodeSourcePlugin.js
@@ -29,7 +29,7 @@ module.exports = class NodeSourcePlugin {
 
 		const addExpression = (parser, name, module, type, suffix) => {
 			suffix = suffix || "";
-			parser.plugin(`expression ${name}`, () => {
+			parser.hooks.expression.for(name).tap("NodeSourcePlugin", () => {
 				if(parser.state.module && parser.state.module.resource === getPathToModule(module, type)) return;
 				const mockModule = ParserHelpers.requireFileAsExpression(parser.state.module.context, getPathToModule(module, type));
 				return ParserHelpers.addParsedVariableToModule(parser, name, mockModule + suffix);
@@ -48,7 +48,7 @@ module.exports = class NodeSourcePlugin {
 					localOptions = Object.assign({}, localOptions, parserOptions.node);
 
 				if(localOptions.global) {
-					parser.plugin("expression global", () => {
+					parser.hooks.expression.for("global").tap("NodeSourcePlugin", () => {
 						const retrieveGlobalModule = ParserHelpers.requireFileAsExpression(parser.state.module.context, require.resolve("../../buildin/global.js"));
 						return ParserHelpers.addParsedVariableToModule(parser, "global", retrieveGlobalModule);
 					});

--- a/lib/optimize/ModuleConcatenationPlugin.js
+++ b/lib/optimize/ModuleConcatenationPlugin.js
@@ -26,7 +26,7 @@ class ModuleConcatenationPlugin {
 			normalModuleFactory
 		}) => {
 			const handler = (parser, parserOptions) => {
-				parser.plugin("call eval", () => {
+				parser.hooks.call.for("eval").tap("ModuleConcatenationPlugin", () => {
 					// Because of variable renaming we can't use modules with eval.
 					parser.state.module.buildMeta.moduleConcatenationBailout = "eval()";
 				});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

n/a

**Summary**

Replace deprecated `Tapable#plugin` calls by `Hook#tap` calls.
After this PR, almost all `plugin` calls would be replaced! 🎉

**Does this PR introduce a breaking change?**

no