### PR TITLE
Allow watch tests to be skip

### DIFF
--- a/test/WatchDetection.test.js
+++ b/test/WatchDetection.test.js
@@ -9,6 +9,11 @@ const MemoryFs = require("memory-fs");
 const webpack = require("../");
 
 describe("WatchDetection", () => {
+	if(process.env.NO_WATCH_TESTS) {
+		it("long running tests excluded");
+		return;
+	}
+
 	for(let changeTimeout = 0; changeTimeout < 100; changeTimeout += 10) {
 		createTestCase(changeTimeout);
 	}

--- a/test/WatchTestCases.test.js
+++ b/test/WatchTestCases.test.js
@@ -47,6 +47,11 @@ function remove(src) {
 }
 
 describe("WatchTestCases", () => {
+	if(process.env.NO_WATCH_TESTS) {
+		it("long running tests excluded");
+		return;
+	}
+
 	const casesPath = path.join(__dirname, "watchCases");
 	let categories = fs.readdirSync(casesPath);
 

--- a/test/WatcherEvents.test.js
+++ b/test/WatcherEvents.test.js
@@ -27,6 +27,11 @@ const createMultiCompiler = () => {
 };
 
 describe("WatcherEvents", function() {
+	if(process.env.NO_WATCH_TESTS) {
+		it("long running tests excluded");
+		return;
+	}
+
 	this.timeout(10000);
 
 	it("should emit 'watch-close' when using single-compiler mode and the compiler is not running", function(done) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

test changes

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

n/a

**Summary**

Allow _watcher_-related integration tests to be skipped.
This was already possible in unit tests:
https://github.com/webpack/webpack/blob/0c4d69b7c63f3dfa2b25faaed3ada84e9e9f8fbc/test/NodeWatchFileSystem.unittest.js#L49-L52

**Does this PR introduce a breaking change?**

no
