### PR TITLE
Maintain ident when chaining pitching loaders

### DIFF
--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -133,7 +133,9 @@ class NormalModuleFactory extends Tapable {
 				try {
 					loaders.forEach(item => {
 						if(typeof item.options === "string" && /^\?/.test(item.options)) {
-							item.options = this.ruleSet.findOptionsByIdent(item.options.substr(1));
+							const ident = item.options.substr(1);
+							item.options = this.ruleSet.findOptionsByIdent(ident);
+							item.ident = ident;
 						}
 					});
 				} catch(e) {

--- a/test/configCases/loaders/generate-ident/index.js
+++ b/test/configCases/loaders/generate-ident/index.js
@@ -2,4 +2,5 @@ it("should correctly pass complex query object with remaining request", function
 	require("./a").should.be.eql("ok");
 	require("./b").should.be.eql("maybe");
 	require("./c").should.be.eql("yes");
+	require("./d").should.be.eql("ok");
 });

--- a/test/configCases/loaders/generate-ident/webpack.config.js
+++ b/test/configCases/loaders/generate-ident/webpack.config.js
@@ -42,6 +42,22 @@ module.exports = {
 						}
 					}
 				}
+			},
+			{
+				test: /d\.js$/,
+				use: [
+					"./loader1",
+					"./loader1",
+					"./loader1",
+					{
+						loader: "./loader2",
+						options: {
+							f: function() {
+								return "ok";
+							}
+						}
+					}
+				]
 			}
 		]
 	}


### PR DESCRIPTION
I came across a bug when chaining multiple (more than 2) pitching loaders. It appears that the loader `ident` property specified in the remaining request string was not being copied from one loader to the next, so any non-serializable loader options were lost along the way.

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

Yes

**If relevant, link to documentation update:**

N/A

**Summary**

This bug occurs when a remaining request containing non-serializable options is passed through multiple pitching loaders before arriving at the final loader. When the final loader runs, any non-serializable options have been lost.

Example:

webpack.config.js:

```javascript
module.exports = {
  entry: `./index.js`,
  module: {
    rules: [
      {
        include: require.resolve('./message'),
        use: [

          // Dummy pitching loader that just relays the output to the next loader
          { loader: require.resolve('./loaders/passthrough.js') },
          { loader: require.resolve('./loaders/passthrough.js') },

          // Normal loader that specifies non-serializable options
          {
            loader: require.resolve('./loaders/replace.js'),
            options: { pattern: /foo/, replacement: 'bar' },
          },
        ],
      },
    ],
  },
};
```

index.js:

```javascript
console.log(require('./message'));
```

message.js:

```javascript
module.exports = 'foo';
```

loaders/passthrough.js:

```javascript
const loaderUtils = require('loader-utils');

module.exports = function passthroughLoader() {};
module.exports.pitch = function pitch(request) {
  return `module.exports = require(${loaderUtils.stringifyRequest(this, `!!${request}`)});`;
};
```

loaders/replace.js:

```javascript
const loaderUtils = require('loader-utils');

module.exports = function replaceLoader(source) {
  const { pattern, replacement } = loaderUtils.getOptions(this);
  if (!(pattern instanceof RegExp)) { throw new Error('Pattern must be a regular expression'); }
  return source.replace(pattern, replacement);
};
```

Results:

- Before the fix, webpack fails with `Pattern must be a regular expression`
- After the fix, webpack compiles the bundle correctly

N.B. This only happens when multiple pitching loaders are chained: if one of the loaders is removed, the bundle compiles even with the current version of webpack.

**Does this PR introduce a breaking change?**

No

**Other information**

Let me know if there's any more information you need about this.