### PR TITLE
Do not use deprecated features of enhanced-resolve

### DIFF
--- a/lib/ContextModuleFactory.js
+++ b/lib/ContextModuleFactory.js
@@ -77,14 +77,14 @@ module.exports = class ContextModuleFactory extends Tapable {
 
 			asyncLib.parallel([
 				callback => {
-					contextResolver.resolve({}, context, resource, (err, result) => {
+					contextResolver.resolve({}, context, resource, {}, (err, result) => {
 						if(err) return callback(err);
 						callback(null, result);
 					});
 				},
 				callback => {
 					asyncLib.map(loaders, (loader, callback) => {
-						loaderResolver.resolve({}, context, loader, (err, result) => {
+						loaderResolver.resolve({}, context, loader, {}, (err, result) => {
 							if(err) return callback(err);
 							callback(null, result);
 						});

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -160,7 +160,7 @@ class NormalModuleFactory extends Tapable {
 						});
 					}
 
-					normalResolver.resolve(contextInfo, context, resource, (err, resource, resourceResolveData) => {
+					normalResolver.resolve(contextInfo, context, resource, {}, (err, resource, resourceResolveData) => {
 						if(err) return callback(err);
 						callback(null, {
 							resourceResolveData,
@@ -302,9 +302,9 @@ class NormalModuleFactory extends Tapable {
 	resolveRequestArray(contextInfo, context, array, resolver, callback) {
 		if(array.length === 0) return callback(null, []);
 		asyncLib.map(array, (item, callback) => {
-			resolver.resolve(contextInfo, context, item.loader, (err, result) => {
+			resolver.resolve(contextInfo, context, item.loader, {}, (err, result) => {
 				if(err && /^[^/]*$/.test(item.loader) && !/-loader$/.test(item.loader)) {
-					return resolver.resolve(contextInfo, context, item.loader + "-loader", err2 => {
+					return resolver.resolve(contextInfo, context, item.loader + "-loader", {}, err2 => {
 						if(!err2) {
 							err.message = err.message + "\n" +
 								"BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.\n" +

--- a/test/statsCases/resolve-plugin-context/ResolvePackageFromRootPlugin.js
+++ b/test/statsCases/resolve-plugin-context/ResolvePackageFromRootPlugin.js
@@ -25,22 +25,22 @@ module.exports = class ResolvePackageFromRootPlugin {
 				return callback(null, originalResolved)
 			}
 
-			resolver.doResolve("resolve", {
+			resolver.doResolve(resolver.hooks.resolve, {
 				context: {},
 				path: originalResolved.context.issuer,
 				request: originalResolved.context.issuer
-			}, `resolve issuer of ${originalResolved.path}`, (err, issuer) => {
+			}, `resolve issuer of ${originalResolved.path}`, {}, (err, issuer) => {
 				if (err) {
 					return callback(null, originalResolved);
 				}
 
 				const moduleRequestPath = originalResolved.path.replace(replaceNodeModuleRegex, "");
 
-				resolver.doResolve("resolve", {
+				resolver.doResolve(resolver.hooks.resolve, {
 					context: {},
 					path: this.rootPath,
 					request: moduleRequestPath
-				}, `resolve ${moduleRequestPath} in ${this.rootPath}`, (err, resolvedInParentContext) => {
+				}, `resolve ${moduleRequestPath} in ${this.rootPath}`, {}, (err, resolvedInParentContext) => {
 					if (err) {
 						return callback(null, originalResolved);
 					}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

n/a

**Summary**

This PR addresses some deprecations of `enhanced-resolve`. Thus the tests are less verbose.

- First argument of `Resolver#doResolve` is now a Hook
- Fourth argument of `Resolver#resolve` is now `resolveContext`. `callback` is the fifth.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
