### PR TITLE
Don't use deprecate APIs in unit tests

### DIFF
--- a/test/Chunk.unittest.js
+++ b/test/Chunk.unittest.js
@@ -154,7 +154,7 @@ describe("Chunk", () => {
 		});
 		describe("and the chunk does contain this module", function() {
 			beforeEach(function() {
-				ChunkInstance.parents = [chunk];
+				ChunkInstance.setParents([chunk]);
 			});
 			it("calls module.removeChunk with itself and returns true", function() {
 				ChunkInstance.removeParent(chunk).should.eql(true);

--- a/test/ModuleReason.unittest.js
+++ b/test/ModuleReason.unittest.js
@@ -56,22 +56,4 @@ describe("ModuleReason", () => {
 			should(myModuleReason.hasChunk(myChunk2)).be.false();
 		});
 	});
-
-	describe(".chunks", () => {
-		it("is null if no rewrites happen first", () => {
-			should(myModuleReason.chunks).be.Null();
-		});
-
-		it("is null if only invalid rewrites happen first", () => {
-			myModuleReason.rewriteChunks(myChunk, [myChunk2]);
-			should(myModuleReason.chunks).be.Null();
-		});
-
-		it("is an array of chunks if a valid rewrite happens", () => {
-			myModuleReason.module.addChunk(myChunk);
-			myModuleReason.rewriteChunks(myChunk, [myChunk2]);
-
-			should(myModuleReason.chunks).be.eql([myChunk2]);
-		});
-	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

n/a

**Summary**

- `Chunk.unittest.js` was using `Chunk#parents`. Use `Chunk#setParents()` instead.
- `ModuleReason.unittest.js` was testing a deprecated API

**Does this PR introduce a breaking change?**

no
