### PR TITLE
Fix webpack hanging under certain circumstance, use process.exitCode instead of process.exit in compilerCallback

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -364,7 +364,8 @@ yargs.parse(process.argv.slice(2), (err, argv, output) => {
 				lastHash = null;
 				console.error(err.stack || err);
 				if(err.details) console.error(err.details);
-				process.exit(1); // eslint-disable-line
+				process.exitCode = 1;
+				return;
 			}
 			if(outputOptions.json) {
 				process.stdout.write(JSON.stringify(stats.toJson(outputOptions), null, 2) + "\n");


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
No. It's hard to write test and maybe it is not necessary.

**Summary**
1. According to Node.js document, it is not correct to write something like
```
console.log('hello, world');
process.exit()
```

https://nodejs.org/dist/latest-v9.x/docs/api/process.html#process_process_exit_code
> Rather than calling process.exit() directly, the code should set the process.exitCode and allow the process to exit naturally by avoiding scheduling any additional work for the event loop:

2. There is an issue https://github.com/webpack-contrib/sass-loader/issues/523 fixed by this pull request.

The issue is that Node.js doesn't exit itself after the `process.exit(1)` in line 367 of `webpack.js`.
Some callbacks of `fs.stat` and `fs.readFile` were never called at this time.

I am not familiar with Node.js and libuv. The following is my guess.
`webpack` calls `fs` functions many times, and they will use the thread pool of libuv.
`node-sass` will use the same thread pool to do its work.
After the call to `process.exit()`, the `fs` functions will fail silently and won't release their threads, but `node-sass` is waiting for threads and `process.exit()` is waiting for `node-sass`.

**Does this PR introduce a breaking change?**
No.