### PR TITLE
Initial spike for dumping a profile

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -1,4 +1,9 @@
+const fs = require('fs');
 const chalk = require("chalk");
+const Trace = require('trace-event').Tracer;
+let trace = new Trace();
+
+trace.pipe(fs.createWriteStream("events.log"));
 
 class ProfilingPlugin {
 	apply(compiler) {
@@ -63,35 +68,10 @@ const interceptAllParserHooks = (moduleFactory) => {
 	});
 };
 
-const instanceToFormat = (instanceString) => ({
-	"Compiler": ["#F12D2D", 0],
-	"Compilation": ["#FF9A3C", 1],
-	"Resolver": ["#5AC8D8", 1],
-	"Normal Module Factory": ["#FC5185", 1],
-	"Context Module Factory": ["#FFDE25", 1],
-	"MainTemplate": ["#EFE891", 2],
-	"ChunkTemplate": ["#50E3C2", 2],
-	"HotUpdateChunkTemplate": ["#D5FFFB", 2],
-	"JavaScriptModuleTemplate": ["#239D60", 2],
-	"WebAssemblyModuleTemplate": ["#D1F386", 2],
-	"Parser": ["#00BBF0", 2],
-	"default": ["#A3DE83", 0]
-}[instanceString]);
-
 const makeInterceptorFor = (instance) => (hookName) => ({
 	register: ({ name, type, fn }) => {
 		const newFn = makeNewProfiledTapFn(hookName, { name, type, fn });
-
 		return ({ name, type, fn: newFn });
-	},
-	call: (...args) => {
-		const hookNameFmt = chalk`{bold.underline ${hookName}}`;
-		const innerMessage = chalk`{bold Intercepting call from ${instance}: ${hookNameFmt} hook}`;
-		const coloredMessage = chalk.hex(instanceToFormat(instance)[0])(innerMessage);
-
-		console.log("".padStart(
-			instanceToFormat(instance)[1] * 4
-		) + coloredMessage);
 	}
 });
 
@@ -101,32 +81,31 @@ const makeNewProfiledTapFn = (hookName, { name, type, fn }) => {
 	switch(type) {
 		case "promise":
 			return (...args) => {
-				console.time(timingId);
+				trace.begin({name, id: timingId});
 				return fn(...args).then(r => {
-					console.timeEnd(timingId); return r;
+					trace.begin({name, id: timingId});
+					return r;
 				});
 			};
 		case "async":
 			return (...args) => {
-				console.time(chalk`{red timingId}`);
-				const callback = args.pop();
-
+				trace.begin({name, id: timingId});
 				fn(...args, (...r) => {
-					console.timeEnd(timingId);
+					trace.end({name, id: timingId});
 					callback(...r);
 				});
 			};
 		case "sync":
 			return (...args) => {
-				console.time(timingId);
+				trace.begin({name, id: timingId});
 				let r;
 				try {
 					r = fn(...args);
 				} catch(error) {
-					console.timeEnd(timingId);
+					trace.end({name, id: timingId});
 					throw error;
 				}
-				console.timeEnd(timingId);
+				trace.end({name, id: timingId});
 				return r;
 			};
 		default:

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "node-libs-browser": "^2.0.0",
     "schema-utils": "^0.4.2",
     "tapable": "^1.0.0-beta.5",
+    "trace-event": "samccone/node-trace-event",
     "uglifyjs-webpack-plugin": "^1.1.1",
     "watchpack": "^1.4.0",
     "webpack-sources": "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,6 +208,10 @@ asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
 
+assert-plus@0.1.x:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.1.5.tgz#ee74009413002d84cec7219c6ac811812e723160"
+
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
@@ -5624,6 +5628,12 @@ tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
     punycode "^1.4.1"
+
+trace-event@samccone/node-trace-event:
+  version "1.3.1"
+  resolved "https://codeload.github.com/samccone/node-trace-event/tar.gz/e352243a7b20c2a78c330e5b6747c9ba28cb5e7d"
+  dependencies:
+    assert-plus "0.1.x"
 
 transformers@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Add the ability to dump a profile from the profiling plugin.

For now this dumps to events.log but this is very much only a spike