### PR TITLE
Fix bluebird warning in hot/signal

### DIFF
--- a/hot/signal.js
+++ b/hot/signal.js
@@ -24,6 +24,7 @@ if(module.hot) {
 				require("./log-apply-result")(updatedModules, renewedModules);
 
 				checkForUpdate(true);
+				return null;
 			});
 		}).catch(function(err) {
 			var status = module.hot.status();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
It fixes `bluebird` warning _"a promise was created in a handler but was not returned from it"_ 

**Did you add tests for your changes?**
No.

**If relevant, link to documentation update:**
N/A

**Summary**
This PR fixes #6206, which properly details the issue.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
N/A