### PR TITLE
Make walk/prewalk calls static

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -908,30 +908,30 @@ class Parser extends Tapable {
 
 	prewalkForInStatement(statement) {
 		if(statement.left.type === "VariableDeclaration")
-			this.prewalkStatement(statement.left);
+			this.prewalkVariableDeclaration(statement.left);
 		this.prewalkStatement(statement.body);
 	}
 
 	walkForInStatement(statement) {
 		if(statement.left.type === "VariableDeclaration")
-			this.walkStatement(statement.left);
+			this.walkVariableDeclaration(statement.left);
 		else
-			this.walkExpression(statement.left);
+			this.walkPattern(statement.left);
 		this.walkExpression(statement.right);
 		this.walkStatement(statement.body);
 	}
 
 	prewalkForOfStatement(statement) {
 		if(statement.left.type === "VariableDeclaration")
-			this.prewalkStatement(statement.left);
+			this.prewalkVariableDeclaration(statement.left);
 		this.prewalkStatement(statement.body);
 	}
 
 	walkForOfStatement(statement) {
 		if(statement.left.type === "VariableDeclaration")
-			this.walkStatement(statement.left);
+			this.walkVariableDeclaration(statement.left);
 		else
-			this.walkExpression(statement.left);
+			this.walkPattern(statement.left);
 		this.walkExpression(statement.right);
 		this.walkStatement(statement.body);
 	}

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -648,16 +648,125 @@ class Parser extends Tapable {
 	}
 
 	prewalkStatement(statement) {
-		const handler = this["prewalk" + statement.type];
-		if(handler)
-			handler.call(this, statement);
+		switch(statement.type) {
+			case "BlockStatement":
+				this.prewalkBlockStatement(statement);
+				break;
+			case "ClassDeclaration":
+				this.prewalkClassDeclaration(statement);
+				break;
+			case "DoWhileStatement":
+				this.prewalkDoWhileStatement(statement);
+				break;
+			case "ExportAllDeclaration":
+				this.prewalkExportAllDeclaration(statement);
+				break;
+			case "ExportDefaultDeclaration":
+				this.prewalkExportDefaultDeclaration(statement);
+				break;
+			case "ExportNamedDeclaration":
+				this.prewalkExportNamedDeclaration(statement);
+				break;
+			case "ForInStatement":
+				this.prewalkForInStatement(statement);
+				break;
+			case "ForOfStatement":
+				this.prewalkForOfStatement(statement);
+				break;
+			case "ForStatement":
+				this.prewalkForStatement(statement);
+				break;
+			case "FunctionDeclaration":
+				this.prewalkFunctionDeclaration(statement);
+				break;
+			case "IfStatement":
+				this.prewalkIfStatement(statement);
+				break;
+			case "ImportDeclaration":
+				this.prewalkImportDeclaration(statement);
+				break;
+			case "LabeledStatement":
+				this.prewalkLabeledStatement(statement);
+				break;
+			case "SwitchStatement":
+				this.prewalkSwitchStatement(statement);
+				break;
+			case "TryStatement":
+				this.prewalkTryStatement(statement);
+				break;
+			case "VariableDeclaration":
+				this.prewalkVariableDeclaration(statement);
+				break;
+			case "WhileStatement":
+				this.prewalkWhileStatement(statement);
+				break;
+			case "WithStatement":
+				this.prewalkWithStatement(statement);
+				break;
+		}
 	}
 
 	walkStatement(statement) {
 		if(this.hooks.statement.call(statement) !== undefined) return;
-		const handler = this["walk" + statement.type];
-		if(handler)
-			handler.call(this, statement);
+		switch(statement.type) {
+			case "BlockStatement":
+				this.walkBlockStatement(statement);
+				break;
+			case "ClassDeclaration":
+				this.walkClassDeclaration(statement);
+				break;
+			case "DoWhileStatement":
+				this.walkDoWhileStatement(statement);
+				break;
+			case "ExportDefaultDeclaration":
+				this.walkExportDefaultDeclaration(statement);
+				break;
+			case "ExportNamedDeclaration":
+				this.walkExportNamedDeclaration(statement);
+				break;
+			case "ExpressionStatement":
+				this.walkExpressionStatement(statement);
+				break;
+			case "ForInStatement":
+				this.walkForInStatement(statement);
+				break;
+			case "ForOfStatement":
+				this.walkForOfStatement(statement);
+				break;
+			case "ForStatement":
+				this.walkForStatement(statement);
+				break;
+			case "FunctionDeclaration":
+				this.walkFunctionDeclaration(statement);
+				break;
+			case "IfStatement":
+				this.walkIfStatement(statement);
+				break;
+			case "LabeledStatement":
+				this.walkLabeledStatement(statement);
+				break;
+			case "ReturnStatement":
+				this.walkReturnStatement(statement);
+				break;
+			case "SwitchStatement":
+				this.walkSwitchStatement(statement);
+				break;
+			case "ThrowStatement":
+				this.walkThrowStatement(statement);
+				break;
+			case "TryStatement":
+				this.walkTryStatement(statement);
+				break;
+			case "VariableDeclaration":
+				this.walkVariableDeclaration(statement);
+				break;
+			case "WhileStatement":
+				this.walkWhileStatement(statement);
+				break;
+			case "WithStatement":
+				this.walkWithStatement(statement);
+				break;
+		}
 	}
 
 	// Real Statements
@@ -1053,10 +1162,23 @@ class Parser extends Tapable {
 	}
 
 	walkPattern(pattern) {
-		if(pattern.type === "Identifier")
-			return;
-		if(this["walk" + pattern.type])
-			this["walk" + pattern.type](pattern);
+		switch(pattern.type) {
+			case "ArrayPattern":
+				this.walkArrayPattern(pattern);
+				break;
+			case "AssignmentPattern":
+				this.walkAssignmentPattern(pattern);
+				break;
+			case "MemberExpression":
+				this.walkMemberExpression(pattern);
+				break;
+			case "ObjectPattern":
+				this.walkObjectPattern(pattern);
+				break;
+			case "RestElement":
+				this.walkRestElement(pattern);
+				break;
+		}
 	}
 
 	walkAssignmentPattern(pattern) {
@@ -1097,14 +1219,75 @@ class Parser extends Tapable {
 	}
 
 	walkExpression(expression) {
-		if(this["walk" + expression.type])
-			return this["walk" + expression.type](expression);
+		switch(expression.type) {
+			case "ArrayExpression":
+				this.walkArrayExpression(expression);
+				break;
+			case "ArrowFunctionExpression":
+				this.walkArrowFunctionExpression(expression);
+				break;
+			case "AssignmentExpression":
+				this.walkAssignmentExpression(expression);
+				break;
+			case "AwaitExpression":
+				this.walkAwaitExpression(expression);
+				break;
+			case "BinaryExpression":
+				this.walkBinaryExpression(expression);
+				break;
+			case "CallExpression":
+				this.walkCallExpression(expression);
+				break;
+			case "ClassExpression":
+				this.walkClassExpression(expression);
+				break;
+			case "ConditionalExpression":
+				this.walkConditionalExpression(expression);
+				break;
+			case "FunctionExpression":
+				this.walkFunctionExpression(expression);
+				break;
+			case "Identifier":
+				this.walkIdentifier(expression);
+				break;
+			case "LogicalExpression":
+				this.walkLogicalExpression(expression);
+				break;
+			case "MemberExpression":
+				this.walkMemberExpression(expression);
+				break;
+			case "NewExpression":
+				this.walkNewExpression(expression);
+				break;
+			case "ObjectExpression":
+				this.walkObjectExpression(expression);
+				break;
+			case "SequenceExpression":
+				this.walkSequenceExpression(expression);
+				break;
+			case "SpreadElement":
+				this.walkSpreadElement(expression);
+				break;
+			case "TaggedTemplateExpression":
+				this.walkTaggedTemplateExpression(expression);
+				break;
+			case "TemplateLiteral":
+				this.walkTemplateLiteral(expression);
+				break;
+			case "UnaryExpression":
+				this.walkUnaryExpression(expression);
+				break;
+			case "UpdateExpression":
+				this.walkUpdateExpression(expression);
+				break;
+			case "YieldExpression":
+				this.walkYieldExpression(expression);
+				break;
+		}
 	}
 
 	walkAwaitExpression(expression) {
-		const argument = expression.argument;
-		if(this["walk" + argument.type])
-			return this["walk" + argument.type](argument);
+		this.walkExpression(expression.argument);
 	}
 
 	walkArrayExpression(expression) {

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -1598,7 +1598,7 @@ class Parser extends Tapable {
 					this.scope.renames.set(param, null);
 					this.scope.definitions.add(param);
 				});
-			} else {
+			} else if(param) {
 				this.scope.renames.set(param, null);
 				this.scope.definitions.add(param);
 			}

--- a/test/Parser.unittest.js
+++ b/test/Parser.unittest.js
@@ -112,6 +112,22 @@ describe("Parser", () => {
 				fgh.sub;
 			}, {}
 		],
+		"class definition": [
+			function() {
+				class memberExpr {
+					cde() {
+						abc("cde");
+					}
+					static fgh() {
+						abc("fgh");
+						fgh();
+					}
+				}
+			}, {
+				abc: ["cde", "fgh"],
+				fgh: ["memberExpr"]
+			}
+		],
 		"in try": [
 			function() {
 				try {
@@ -201,6 +217,15 @@ describe("Parser", () => {
 				xyz: ["membertest"]
 			}
 		],
+		"spread calls/literals": [
+			function() {
+				var xyz = [...abc("xyz"), cde];
+				Math.max(...fgh);
+			}, {
+				abc: ["xyz"],
+				fgh: ["xyz"]
+			}
+		]
 	};
 	/* eslint-enable no-undef */
 	/* eslint-enable no-unused-vars */

--- a/test/cases/parsing/class/index.js
+++ b/test/cases/parsing/class/index.js
@@ -5,3 +5,8 @@ it("should parse classes", function() {
 	new A().a.should.be.eql("ok");
 	new B().a.should.be.eql("ok");
 });
+
+it("should parse methods", function() {
+	new X().b().should.be.eql("ok");
+	X.c().should.be.eql("ok");
+});

--- a/test/cases/parsing/class/module.js
+++ b/test/cases/parsing/class/module.js
@@ -14,6 +14,12 @@ export default class {
 	constructor() {
 		this.a = require("./a");
 	}
+	b() {
+		return require("./a");
+	}
+	static c() {
+		return require("./a");
+	}
 };
 
 export {

--- a/test/cases/parsing/pattern-in-for/index.js
+++ b/test/cases/parsing/pattern-in-for/index.js
@@ -1,0 +1,15 @@
+it("should parse patterns in for in/of statements", () => {
+	var message;
+	for({ message = require("./module")} of [{}]) {
+		message.should.be.eql("ok");
+	}
+	for({ message = require("./module") } in { "string": "value" }) {
+		message.should.be.eql("ok");
+	}
+	for(var { value = require("./module")} of [{}]) {
+		value.should.be.eql("ok");
+	}
+	for(var { value = require("./module") } in { "string": "value" }) {
+		value.should.be.eql("ok");
+	}
+});

--- a/test/cases/parsing/pattern-in-for/module.js
+++ b/test/cases/parsing/pattern-in-for/module.js
@@ -1,0 +1,1 @@
+module.exports = "ok";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring, perf

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

n/a

**Summary**

Replace dynamic calls to `walk*` and `prewalk*` by static calls. Here below is the time spent by webpack building itself, prior and after the change:

Before:
```
❯ time node build_webpack.js
node build_webpack.js  7.75s user 0.54s system 115% cpu 7.189 total
```

After:
```
❯ time node build_webpack.js
node build_webpack.js  7.04s user 0.54s system 115% cpu 6.587 total
```

I did 10 runs before and 10 after. I took the median time. The best time before this change was never faster than the worst.

**Does this PR introduce a breaking change?**

no