### PR TITLE
add support for new output option jsonpScriptType

### DIFF
--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -29,7 +29,7 @@ class JsonpMainTemplatePlugin {
 			const chunkMaps = chunk.getChunkMaps();
 			const crossOriginLoading = this.outputOptions.crossOriginLoading;
 			const chunkLoadTimeout = this.outputOptions.chunkLoadTimeout;
-			const jsonpScriptType = this.outputOptions.jsonpScriptType || "text/javascript";
+			const jsonpScriptType = this.outputOptions.jsonpScriptType;
 			const scriptSrcPath = this.applyPluginsWaterfall("asset-path", JSON.stringify(chunkFilename), {
 				hash: `" + ${this.renderCurrentHashCode(hash)} + "`,
 				hashWithLength: length => `" + ${this.renderCurrentHashCode(hash, length)} + "`,

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -49,7 +49,7 @@ class JsonpMainTemplatePlugin {
 			});
 			return this.asString([
 				"var script = document.createElement('script');",
-				`script.type = '${jsonpScriptType}';`,
+				`script.type = ${JSON.stringify(jsonpScriptType)};`,
 				"script.charset = 'utf-8';",
 				"script.async = true;",
 				`script.timeout = ${chunkLoadTimeout};`,

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -29,6 +29,7 @@ class JsonpMainTemplatePlugin {
 			const chunkMaps = chunk.getChunkMaps();
 			const crossOriginLoading = this.outputOptions.crossOriginLoading;
 			const chunkLoadTimeout = this.outputOptions.chunkLoadTimeout;
+			const jsonpScriptType = this.outputOptions.jsonpScriptType || 'text/javascript';
 			const scriptSrcPath = this.applyPluginsWaterfall("asset-path", JSON.stringify(chunkFilename), {
 				hash: `" + ${this.renderCurrentHashCode(hash)} + "`,
 				hashWithLength: length => `" + ${this.renderCurrentHashCode(hash, length)} + "`,
@@ -48,7 +49,7 @@ class JsonpMainTemplatePlugin {
 			});
 			return this.asString([
 				"var script = document.createElement('script');",
-				"script.type = 'text/javascript';",
+				`script.type = '${jsonpScriptType}';`,
 				"script.charset = 'utf-8';",
 				"script.async = true;",
 				`script.timeout = ${chunkLoadTimeout};`,

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -29,7 +29,7 @@ class JsonpMainTemplatePlugin {
 			const chunkMaps = chunk.getChunkMaps();
 			const crossOriginLoading = this.outputOptions.crossOriginLoading;
 			const chunkLoadTimeout = this.outputOptions.chunkLoadTimeout;
-			const jsonpScriptType = this.outputOptions.jsonpScriptType || 'text/javascript';
+			const jsonpScriptType = this.outputOptions.jsonpScriptType || "text/javascript";
 			const scriptSrcPath = this.applyPluginsWaterfall("asset-path", JSON.stringify(chunkFilename), {
 				hash: `" + ${this.renderCurrentHashCode(hash)} + "`,
 				hashWithLength: length => `" + ${this.renderCurrentHashCode(hash, length)} + "`,

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -61,6 +61,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("output.hotUpdateChunkFilename", "[id].[hash].hot-update.js");
 		this.set("output.hotUpdateMainFilename", "[hash].hot-update.json");
 		this.set("output.crossOriginLoading", false);
+		this.set("output.jsonpScriptType", "text/javascript");
 		this.set("output.chunkLoadTimeout", 120000);
 		this.set("output.hashFunction", "md5");
 		this.set("output.hashDigest", "hex");

--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -314,6 +314,13 @@
             "use-credentials"
           ]
         },
+        "jsonpScriptType": {
+          "description": "This option enables loading async chunks via a custom script type, such as script type=\"module\"",
+          "enum": [
+            "text/javascript",
+            "module"
+          ]
+        },
         "chunkLoadTimeout": {
           "description": "Number of milliseconds before chunk request expires",
           "type": "number"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This PR introduces a new output option `jsonpScriptType`, which allows us to customize the `type` attribute of the script tag the webpack runtime adds to the DOM. 

With this PR, we can add `outputOptions : { jsonpScriptType : 'module' }` to have the runtime load async chunks using `<script type="module" src="myAsyncChunk.js" />`. The default option is `text/javascript`, so this is fully backwards compatible.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

I couldn't find any tests for `JsonpMainTemplatePlugin.js`, any guidance on where/how to add integration tests for this particular feature would be helpful and I'll do the same.

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

Docs PR - https://github.com/webpack/webpack.js.org/pull/1770

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

This option is needed for bundling ES6 ready code and shipping it for modern browsers using `<script type="module">` as detailed [here](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/).

In situations where we have code split on routes, and we know what is the async chunk of the current page (so it can be preloaded / downloaded ahead of time), we can add a `<script type="module" src="myAsyncChunk.js"/>` to the head of the page, but when the webpack runtime loads, it downloads the async chunk using `<script type="text/javascript" src="myAsyncChunk.js" />`. This causes browsers to re-downloaded the resource as the two are treated differently.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

This change is fully backwards compatible

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
