### PR TITLE
WIP: Fix: require-ensure should not include initial chunks

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -404,14 +404,14 @@ class Chunk {
 		return this.addMultiplierAndOverhead(integratedModulesSize, options);
 	}
 
-	getChunkMaps(includeEntries, realHash) {
+	getChunkMaps(includeInitial, realHash) {
 		const chunksProcessed = [];
 		const chunkHashMap = {};
 		const chunkNameMap = {};
 		(function addChunk(chunk) {
 			if(chunksProcessed.indexOf(chunk) >= 0) return;
 			chunksProcessed.push(chunk);
-			if(!chunk.hasRuntime() || includeEntries) {
+			if(!chunk.isInitial() || includeInitial) {
 				chunkHashMap[chunk.id] = realHash ? chunk.hash : chunk.renderedHash;
 				if(chunk.name)
 					chunkNameMap[chunk.id] = chunk.name;

--- a/lib/MainTemplate.js
+++ b/lib/MainTemplate.js
@@ -99,7 +99,9 @@ module.exports = class MainTemplate extends Template {
 		});
 		this.plugin("require-extensions", (source, chunk, hash) => {
 			const buf = [];
-			if(chunk.chunks.length > 0) {
+			const chunkMaps = chunk.getChunkMaps();
+			// Check if there are non initial chunks which need to be imported using require-ensure
+			if(Object.keys(chunkMaps.hash).length) {
 				buf.push("// This file contains only the entry chunk.");
 				buf.push("// The chunk loading function for additional chunks");
 				buf.push(`${this.requireFn}.e = function requireEnsure(chunkId) {`);

--- a/test/statsCases/commons-chunk-min-size-0/expected.txt
+++ b/test/statsCases/commons-chunk-min-size-0/expected.txt
@@ -2,7 +2,7 @@ Hash: dc6038bec87a57d1a45e
 Time: Xms
       Asset      Size  Chunks             Chunk Names
  entry-1.js  25 bytes       0  [emitted]  entry-1
-vendor-1.js   6.76 kB       1  [emitted]  vendor-1
+vendor-1.js   4.83 kB       1  [emitted]  vendor-1
    [0] (webpack)/test/statsCases/commons-chunk-min-size-0/modules/a.js 22 bytes {1} [built]
    [1] (webpack)/test/statsCases/commons-chunk-min-size-0/modules/b.js 22 bytes {1} [built]
    [2] (webpack)/test/statsCases/commons-chunk-min-size-0/modules/c.js 22 bytes {1} [built]

--- a/test/statsCases/commons-plugin-issue-4980/expected.txt
+++ b/test/statsCases/commons-plugin-issue-4980/expected.txt
@@ -5,7 +5,7 @@ Child
                              Asset       Size  Chunks             Chunk Names
                             app.js    1.27 kB       0  [emitted]  app
     vendor.bd2b4219dfda1a951495.js  443 bytes       1  [emitted]  vendor
-                        runtime.js    5.78 kB       2  [emitted]  runtime
+                        runtime.js    3.84 kB       2  [emitted]  runtime
     [./constants.js] (webpack)/test/statsCases/commons-plugin-issue-4980/constants.js 87 bytes {1} [built]
     [./entry-1.js] (webpack)/test/statsCases/commons-plugin-issue-4980/entry-1.js 67 bytes {0} [built]
     [./submodule-a.js] (webpack)/test/statsCases/commons-plugin-issue-4980/submodule-a.js 59 bytes {0} [built]
@@ -16,7 +16,7 @@ Child
                              Asset       Size  Chunks             Chunk Names
                             app.js    1.32 kB       0  [emitted]  app
     vendor.bd2b4219dfda1a951495.js  443 bytes       1  [emitted]  vendor
-                        runtime.js    5.78 kB       2  [emitted]  runtime
+                        runtime.js    3.84 kB       2  [emitted]  runtime
     [./constants.js] (webpack)/test/statsCases/commons-plugin-issue-4980/constants.js 87 bytes {1} [built]
     [./entry-2.js] (webpack)/test/statsCases/commons-plugin-issue-4980/entry-2.js 67 bytes {0} [built]
     [./submodule-a.js] (webpack)/test/statsCases/commons-plugin-issue-4980/submodule-a.js 59 bytes {0} [built]

--- a/test/statsCases/named-chunks-plugin/expected.txt
+++ b/test/statsCases/named-chunks-plugin/expected.txt
@@ -2,7 +2,7 @@ Hash: ac63e5be974bcdfea3a3
 Time: Xms
       Asset       Size    Chunks             Chunk Names
    entry.js  345 bytes     entry  [emitted]  entry
-manifest.js    5.78 kB  manifest  [emitted]  manifest
+manifest.js    3.85 kB  manifest  [emitted]  manifest
   vendor.js  397 bytes    vendor  [emitted]  vendor
    [0] multi ./modules/a ./modules/b 40 bytes {vendor} [built]
 [./entry.js] (webpack)/test/statsCases/named-chunks-plugin/entry.js 72 bytes {entry} [built]


### PR DESCRIPTION
PR for #6239 

**What kind of change does this PR introduce?**

- updated the `getChunkMaps` of `Chunk `to include only non-initial (previous was non-runtime) chunk.
- update `MainTemplate` to only generate `require-enusure` method if there are non initial chunks. This is checked using `getChunkMaps`

**Did you add tests for your changes?**

WIP

**Does this PR introduce a breaking change?**

If other plugins use the `getChunkMaps` method it could break things
