### PR TITLE
Use acorn v5

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -988,20 +988,16 @@ class Parser extends Tapable {
 			this.hooks.export.call(statement);
 		}
 		if(statement.declaration) {
-			if(/Expression$/.test(statement.declaration.type)) {
-				throw new Error("Doesn't occur?");
-			} else {
-				if(!this.hooks.exportDeclaration.call(statement, statement.declaration)) {
-					const originalDefinitions = this.scope.definitions;
-					const tracker = new TrackingSet(this.scope.definitions);
-					this.scope.definitions = tracker;
-					this.prewalkStatement(statement.declaration);
-					const newDefs = Array.from(tracker.getAddedItems());
-					this.scope.definitions = originalDefinitions;
-					for(let index = newDefs.length - 1; index >= 0; index--) {
-						const def = newDefs[index];
-						this.hooks.exportSpecifier.call(statement, def, def, index);
-					}
+			if(!this.hooks.exportDeclaration.call(statement, statement.declaration)) {
+				const originalDefinitions = this.scope.definitions;
+				const tracker = new TrackingSet(this.scope.definitions);
+				this.scope.definitions = tracker;
+				this.prewalkStatement(statement.declaration);
+				const newDefs = Array.from(tracker.getAddedItems());
+				this.scope.definitions = originalDefinitions;
+				for(let index = newDefs.length - 1; index >= 0; index--) {
+					const def = newDefs[index];
+					this.hooks.exportSpecifier.call(statement, def, def, index);
 				}
 			}
 		}
@@ -1030,7 +1026,7 @@ class Parser extends Tapable {
 	}
 
 	prewalkExportDefaultDeclaration(statement) {
-		if(/Declaration$/.test(statement.declaration.type)) {
+		if(statement.declaration.id) {
 			const originalDefinitions = this.scope.definitions;
 			const tracker = new TrackingSet(this.scope.definitions);
 			this.scope.definitions = tracker;
@@ -1046,12 +1042,21 @@ class Parser extends Tapable {
 
 	walkExportDefaultDeclaration(statement) {
 		this.hooks.export.call(statement);
-		if(/Declaration$/.test(statement.declaration.type)) {
+		if(statement.declaration.id) {
 			if(!this.hooks.exportDeclaration.call(statement, statement.declaration)) {
 				this.walkStatement(statement.declaration);
 			}
 		} else {
-			this.walkExpression(statement.declaration);
+			// Acorn parses `export default function() {}` as `FunctionDeclaration` and
+			// `export default class {}` as `ClassDeclaration`, both with `id = null`.
+			// These nodes must be treated as expressions.
+			if(statement.declaration.type === "FunctionDeclaration") {
+				this.walkFunctionDeclaration(statement.declaration);
+			} else if(statement.declaration.type === "ClassDeclaration") {
+				this.walkClassDeclaration(statement.declaration);
+			} else {
+				this.walkExpression(statement.declaration);
+			}
 			if(!this.hooks.exportExpression.call(statement, statement.declaration)) {
 				this.hooks.exportSpecifier.call(statement, statement.declaration, "default");
 			}

--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "4.0.0-alpha.4",
   "author": "Tobias Koppers @sokra",
   "description": "Packs CommonJs/AMD modules for the browser. Allows to split your codebase into multiple bundles, which can be loaded on demand. Support loaders to preprocess files, i.e. json, jsx, es7, css, less, ... and your custom stuff.",
+  "license": "MIT",
   "dependencies": {
     "acorn": "^5.0.0",
-    "acorn-dynamic-import": "^2.0.0",
+    "acorn-dynamic-import": "^3.0.0",
     "ajv": "^5.1.5",
     "ajv-keywords": "^2.0.0",
     "async": "^2.1.2",
@@ -22,7 +23,6 @@
     "watchpack": "^1.4.0",
     "webpack-sources": "^1.0.1"
   },
-  "license": "MIT",
   "devDependencies": {
     "beautify-lint": "^1.0.3",
     "benchmark": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,11 +17,11 @@ accepts@~1.2.12:
     mime-types "~2.1.6"
     negotiator "0.5.3"
 
-acorn-dynamic-import@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz#c752bd210bef679501b6c6cb7fc84f8f47158cc4"
+acorn-dynamic-import@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
   dependencies:
-    acorn "^4.0.3"
+    acorn "^5.0.0"
 
 acorn-globals@^1.0.3:
   version "1.0.9"
@@ -46,10 +46,6 @@ acorn@^2.1.0:
 acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
-
-acorn@^4.0.3:
-  version "4.0.13"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
 acorn@^5.0.0, acorn@^5.2.1:
   version "5.3.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

n/a

**Summary**

Before this PR, webpack was mainly using `acorn@4` because `acorn-dynamic-import` was pulling its own version. This PR forces the resolution of v5. However, after updating `acorn` some tests were failing. The `Parser` had to be updated.

**Does this PR introduce a breaking change?**

no
  