### PR TITLE
Issue #4977 - Configuration Validation

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -3,6 +3,9 @@ var fs = require("fs");
 fs.existsSync = fs.existsSync || path.existsSync;
 var interpret = require("interpret");
 var prepareOptions = require("../lib/prepareOptions");
+var validateSchema = require("../lib/validateSchema");
+var WebpackOptionsValidationError = require("../lib/WebpackOptionsValidationError");
+var webpackConfigurationSchema = require("../schemas/webpackConfigurationSchema.json");
 
 module.exports = function(yargs, argv, convertOptions) {
 
@@ -115,8 +118,10 @@ module.exports = function(yargs, argv, convertOptions) {
 	}
 
 	function processConfiguredOptions(options) {
-		if(options === null || typeof options !== "object") {
-			console.error("Config did not export an object or a function returning an object.");
+		var webpackConfigurationValidationErrors = validateSchema(webpackConfigurationSchema, options);
+		if(webpackConfigurationValidationErrors.length) {
+			var error = new WebpackOptionsValidationError(webpackConfigurationValidationErrors);
+			console.error(error.message);
 			process.exit(-1); // eslint-disable-line
 		}
 

--- a/schemas/webpackConfigurationSchema.json
+++ b/schemas/webpackConfigurationSchema.json
@@ -1,0 +1,20 @@
+{
+  "oneOf": [
+    {
+      "type": "object",
+      "description": "A webpack configuration object."
+    },
+    {
+      "type": "array",
+      "description": "An array of webpack configuration objects.",
+      "items": {
+        "description": "A webpack configuration object.",
+        "type": "object"
+      }
+    },
+    {
+      "instanceof": "Function",
+      "description": "A function returning a configuration object, or an array of configuration objects."
+    }
+  ]
+}

--- a/test/binCases/config-type/array/entry-a.js
+++ b/test/binCases/config-type/array/entry-a.js
@@ -1,0 +1,1 @@
+module.exports = "entry-a.js";

--- a/test/binCases/config-type/array/entry-b.js
+++ b/test/binCases/config-type/array/entry-b.js
@@ -1,0 +1,1 @@
+module.exports = "entry-b.js";

--- a/test/binCases/config-type/array/test.js
+++ b/test/binCases/config-type/array/test.js
@@ -1,0 +1,15 @@
+"use strict";
+
+module.exports = function testAssertions(code, stdout, stderr) {
+	code.should.be.exactly(0);
+
+	stdout.should.be.ok();
+	stdout[0].should.containEql("Hash: ");
+	stdout[1].should.containEql("Version: ");
+	stdout[2].should.containEql("Child");
+	stdout[6].should.containEql("entry-a.bundle.js");
+	stdout[8].should.containEql("Child");
+	stdout[12].should.containEql("entry-b.bundle.js");
+
+	stderr.should.be.empty();
+};

--- a/test/binCases/config-type/array/test.opts
+++ b/test/binCases/config-type/array/test.opts
@@ -1,0 +1,2 @@
+--config ./webpack.config.js
+--target async-node

--- a/test/binCases/config-type/array/webpack.config.js
+++ b/test/binCases/config-type/array/webpack.config.js
@@ -1,0 +1,15 @@
+module.exports = [
+  {
+    entry: "./entry-a",
+    output: {
+      filename: "entry-a.bundle.js"
+    }
+  },
+  {
+    entry: "./entry-b",
+    output: {
+      filename: "entry-b.bundle.js"
+    }
+  }
+];
+

--- a/test/binCases/config-type/function/entry.js
+++ b/test/binCases/config-type/function/entry.js
@@ -1,0 +1,1 @@
+module.exports = "entry.js";

--- a/test/binCases/config-type/function/test.js
+++ b/test/binCases/config-type/function/test.js
@@ -1,0 +1,13 @@
+"use strict";
+
+module.exports = function testAssertions(code, stdout, stderr) {
+	code.should.be.exactly(0);
+
+	stdout.should.be.ok();
+	stdout[0].should.containEql("Hash: ");
+	stdout[1].should.containEql("Version: ");
+	stdout[2].should.containEql("Time: ");
+	stdout[4].should.containEql("entry.bundle.js");
+
+	stderr.should.be.empty();
+};

--- a/test/binCases/config-type/function/test.opts
+++ b/test/binCases/config-type/function/test.opts
@@ -1,0 +1,2 @@
+--config ./webpack.config.js
+--target async-node

--- a/test/binCases/config-type/function/webpack.config.js
+++ b/test/binCases/config-type/function/webpack.config.js
@@ -1,0 +1,8 @@
+module.exports = function(env) {
+	return {
+		entry: "./entry",
+		output: {
+			filename: "entry.bundle.js"
+		}
+	};
+};

--- a/test/binCases/config-type/invalid-array/entry-a.js
+++ b/test/binCases/config-type/invalid-array/entry-a.js
@@ -1,0 +1,1 @@
+module.exports = "entry-a.js";

--- a/test/binCases/config-type/invalid-array/entry-b.js
+++ b/test/binCases/config-type/invalid-array/entry-b.js
@@ -1,0 +1,1 @@
+module.exports = "entry-b.js";

--- a/test/binCases/config-type/invalid-array/test.js
+++ b/test/binCases/config-type/invalid-array/test.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = function testAssertions(code, stdout, stderr) {
-	code.should.be.exactly(255);
+	code.should.not.eql(0);
 
 	stderr.should.not.be.empty();
 	stderr[0].should.containEql("Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.");

--- a/test/binCases/config-type/invalid-array/test.js
+++ b/test/binCases/config-type/invalid-array/test.js
@@ -1,0 +1,8 @@
+"use strict";
+
+module.exports = function testAssertions(code, stdout, stderr) {
+	code.should.be.exactly(255);
+
+	stderr.should.not.be.empty();
+	stderr[0].should.containEql("Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.");
+};

--- a/test/binCases/config-type/invalid-array/test.opts
+++ b/test/binCases/config-type/invalid-array/test.opts
@@ -1,0 +1,2 @@
+--config ./webpack.config.js
+--target async-node

--- a/test/binCases/config-type/invalid-array/webpack.config.js
+++ b/test/binCases/config-type/invalid-array/webpack.config.js
@@ -1,0 +1,16 @@
+module.exports = [
+  {
+    entry: "./entry-a",
+    output: {
+      filename: "entry-a.bundle.js"
+    }
+  },
+  "this string makes this array of configurations invalid.",
+  {
+    entry: "./entry-b",
+    output: {
+      filename: "entry-b.bundle.js"
+    }
+  }
+];
+

--- a/test/binCases/config-type/invalid-type/entry.js
+++ b/test/binCases/config-type/invalid-type/entry.js
@@ -1,0 +1,1 @@
+module.exports = "entry.js";

--- a/test/binCases/config-type/invalid-type/test.js
+++ b/test/binCases/config-type/invalid-type/test.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = function testAssertions(code, stdout, stderr) {
-	code.should.be.exactly(255);
+	code.should.not.eql(0);
 
 	stderr.should.not.be.empty();
 	stderr[0].should.containEql("Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.");

--- a/test/binCases/config-type/invalid-type/test.js
+++ b/test/binCases/config-type/invalid-type/test.js
@@ -1,0 +1,8 @@
+"use strict";
+
+module.exports = function testAssertions(code, stdout, stderr) {
+	code.should.be.exactly(255);
+
+	stderr.should.not.be.empty();
+	stderr[0].should.containEql("Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.");
+};

--- a/test/binCases/config-type/invalid-type/test.opts
+++ b/test/binCases/config-type/invalid-type/test.opts
@@ -1,0 +1,2 @@
+--config ./webpack.config.js
+--target async-node

--- a/test/binCases/config-type/invalid-type/webpack.config.js
+++ b/test/binCases/config-type/invalid-type/webpack.config.js
@@ -1,0 +1,2 @@
+module.exports = 100;
+

--- a/test/binCases/config-type/object/entry.js
+++ b/test/binCases/config-type/object/entry.js
@@ -1,0 +1,1 @@
+module.exports = "entry.js";

--- a/test/binCases/config-type/object/test.js
+++ b/test/binCases/config-type/object/test.js
@@ -1,0 +1,13 @@
+"use strict";
+
+module.exports = function testAssertions(code, stdout, stderr) {
+	code.should.be.exactly(0);
+
+	stdout.should.be.ok();
+	stdout[0].should.containEql("Hash: ");
+	stdout[1].should.containEql("Version: ");
+	stdout[2].should.containEql("Time: ");
+	stdout[4].should.containEql("entry.bundle.js");
+
+	stderr.should.be.empty();
+};

--- a/test/binCases/config-type/object/test.opts
+++ b/test/binCases/config-type/object/test.opts
@@ -1,0 +1,2 @@
+--config ./webpack.config.js
+--target async-node

--- a/test/binCases/config-type/object/webpack.config.js
+++ b/test/binCases/config-type/object/webpack.config.js
@@ -1,0 +1,8 @@
+module.exports = function(env) {
+	return {
+		entry: "./entry",
+		output: {
+			filename: "entry.bundle.js"
+		}
+	};
+};


### PR DESCRIPTION
- uses JSON Schema via `ajv`/`validateSchema` for validating the parent configuration object.
- adds tests for both accepted configuration types and a few negative tests.


**What kind of change does this PR introduce?**

Feature

**Did you add tests for your changes?**

Yes – I'll probably add more based on _actual_ desired implementation.

**If relevant, link to documentation update:**

N/A – for now.

**Summary**

This should resolve #4977 or at least work toward solving it. There hasn't been an update on the issue in some time, I figured I'd open this to start up the conversation again.

**Does this PR introduce a breaking change?**

No, it's not expected to... However, it may cause previously invalid configuration objects to throw errors not seen before.

**Other information**

Some things I'm not sure of:

- Is using JSON schema validation too much for this?
  - It does seem like it might be better to combine this validation with the configuration options validation. This would be a much larger change and is worthy of a discussion.

- Should it be using the `WebpackOptionsValidationError` class? The updated output still leaves a bit to be desired. This could be accomplished using the same class or it's own.
  
```
joeb$ webpack --config ./webpack.config.js --target async-node
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration[1] should be one of these:
   object | [object] | function
   Details:
    * configuration[1] should be an object.
      -> A valid configuration object on it's own.
    * configuration[1] should be an array:
      [object]
      -> An array of valid configuration objects.
    * configuration[1] should be an instance of function
      -> A function returning an configuration object, or an array of configuration objects.
```
 
