### PR TITLE
🐌 Add combined CPU profile + user timing api to profiling plugin 🐙🌛

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const chalk = require("chalk");
 const Trace = require('trace-event').Tracer;
 const profiler = require('v8-profiler');
 

--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const Trace = require('trace-event').Tracer;
-const profiler = require('v8-profiler');
+const fs = require("fs");
+const Trace = require("trace-event").Tracer;
+const profiler = require("v8-profiler");
 
 function sleep(num) {
 	return new Promise((res) => {
@@ -9,11 +9,13 @@ function sleep(num) {
 }
 
 function createTrace() {
-	const trace = new Trace({ noStream: true });
+	const trace = new Trace({
+		noStream: true
+	});
 	let counter = 0;
 
 	trace.pipe(fs.createWriteStream("events.log"));
-	// These are critical events that need to be inserted so that tools like 
+	// These are critical events that need to be inserted so that tools like
 	// chrome dev tools can load the profile.
 	trace.instantEvent({
 		name: "TracingStartedInPage",
@@ -23,13 +25,11 @@ function createTrace() {
 			data: {
 				sessionId: "-1",
 				page: "0xfff",
-				frames: [
-					{
-						frame: "0xfff",
-						url: "webpack",
-						name: ""
-					}
-				]
+				frames: [{
+					frame: "0xfff",
+					url: "webpack",
+					name: ""
+				}]
 			}
 		}
 	});
@@ -46,7 +46,8 @@ function createTrace() {
 	});
 
 	return {
-		trace, counter
+		trace,
+		counter
 	};
 }
 
@@ -54,7 +55,7 @@ class ProfilingPlugin {
 
 	apply(compiler) {
 		const tracer = createTrace();
-		profiler.startProfiling('1', true);
+		profiler.startProfiling("1", true);
 		// Compiler Hooks
 		Object.keys(compiler.hooks).forEach(hookName => {
 			compiler.hooks[hookName].intercept(makeInterceptorFor("Compiler", tracer)(hookName));
@@ -64,7 +65,10 @@ class ProfilingPlugin {
 			compiler.resolverFactory.hooks[hookName].intercept(makeInterceptorFor("Resolver", tracer)(hookName));
 		});
 
-		compiler.hooks.compilation.tap("ProfilingPlugin", (compilation, { normalModuleFactory, contextModuleFactory }) => {
+		compiler.hooks.compilation.tap("ProfilingPlugin", (compilation, {
+			normalModuleFactory,
+			contextModuleFactory
+		}) => {
 			interceptAllHooksFor(compilation, tracer, "Compilation");
 			interceptAllHooksFor(normalModuleFactory, tracer, "Normal Module Factory");
 			interceptAllHooksFor(contextModuleFactory, tracer, "Context Module Factory");
@@ -72,77 +76,95 @@ class ProfilingPlugin {
 			interceptTemplateInstancesFrom(compilation, tracer);
 		});
 
-
 		// We need to write out the CPU profile when we are all done.
-		compiler.plugin('done', async () => {
+		compiler.plugin("done", () => {
 			// TODO(sean) Is there a better way to be the last thing to run?
-			await sleep(2000)
+			sleep(2000).then(() => {
+				const profile = profiler.stopProfiling();
+				profile.export((err, profileResults) => {
+					const parsedResults = JSON.parse(profileResults);
+					const cpuStartTime = parsedResults.startTime;
+					const cpuEndTime = parsedResults.endTime;
 
-			const profile = profiler.stopProfiling();
-			profile.export((err, profileResults) => {
-				const parsedResults = JSON.parse(profileResults);
-				const cpuStartTime = parsedResults.startTime;
-				const cpuEndTime = parsedResults.endTime;
-
-				tracer.trace.completeEvent({
-					name: "TaskQueueManager::ProcessTaskFromWorkQueue",
-					id: ++tracer.counter,
-					cat: ["toplevel"],
-					ts: cpuStartTime,
-					args: {
-						src_file: '../../ipc/ipc_moji_bootstrap.cc',
-						src_func: 'Accept'
-					}
-				});
-
-				tracer.trace.completeEvent({
-					name: "EvaluateScript",
-					id: ++tracer.counter,
-					cat: ["devtools.timeline"],
-					ts: cpuStartTime,
-					dur: cpuEndTime - cpuStartTime,
-					args: {
-						data: {
-							url: "webpack",
-							lineNumber: 1,
-							columnNumber: 1,
-							frame: "0xFFF"
+					tracer.trace.completeEvent({
+						name: "TaskQueueManager::ProcessTaskFromWorkQueue",
+						id: ++tracer.counter,
+						cat: ["toplevel"],
+						ts: cpuStartTime,
+						args: {
+							src_file: "../../ipc/ipc_moji_bootstrap.cc",
+							src_func: "Accept"
 						}
-					}
-				});
+					});
 
-				tracer.trace.instantEvent({
-					name: "CpuProfile",
-					id: ++tracer.counter,
-					cat: ["disabled-by-default-devtools.timeline"],
-					ts: cpuEndTime,
-					args: {
-						data: {
-							cpuProfile: parsedResults
+					tracer.trace.completeEvent({
+						name: "EvaluateScript",
+						id: ++tracer.counter,
+						cat: ["devtools.timeline"],
+						ts: cpuStartTime,
+						dur: cpuEndTime - cpuStartTime,
+						args: {
+							data: {
+								url: "webpack",
+								lineNumber: 1,
+								columnNumber: 1,
+								frame: "0xFFF"
+							}
 						}
-					}
-				});
+					});
 
-				tracer.trace.flush();
+					tracer.trace.instantEvent({
+						name: "CpuProfile",
+						id: ++tracer.counter,
+						cat: ["disabled-by-default-devtools.timeline"],
+						ts: cpuEndTime,
+						args: {
+							data: {
+								cpuProfile: parsedResults
+							}
+						}
+					});
+
+					tracer.trace.flush();
+				});
 			});
 		});
 	}
 }
 
 const interceptTemplateInstancesFrom = (compilation, tracer) => {
-	const { mainTemplate, chunkTemplate, hotUpdateChunkTemplate, moduleTemplates } = compilation;
+	const {
+		mainTemplate,
+		chunkTemplate,
+		hotUpdateChunkTemplate,
+		moduleTemplates
+	} = compilation;
 
 	const {
-    javascript,
+		javascript,
 		webassembly
-  } = moduleTemplates;
+	} = moduleTemplates;
 
-	[
-		{ instance: mainTemplate, name: "MainTemplate" },
-		{ instance: chunkTemplate, name: "ChunkTemplate" },
-		{ instance: hotUpdateChunkTemplate, name: "HotUpdateChunkTemplate" },
-		{ instance: javascript, name: "JavaScriptModuleTemplate" },
-		{ instance: webassembly, name: "WebAssemblyModuleTemplate" }
+	[{
+		instance: mainTemplate,
+		name: "MainTemplate"
+	},
+	{
+		instance: chunkTemplate,
+		name: "ChunkTemplate"
+	},
+	{
+		instance: hotUpdateChunkTemplate,
+		name: "HotUpdateChunkTemplate"
+	},
+	{
+		instance: javascript,
+		name: "JavaScriptModuleTemplate"
+	},
+	{
+		instance: webassembly,
+		name: "WebAssemblyModuleTemplate"
+	}
 	].forEach(templateObject => {
 		Object.keys(templateObject.instance.hooks).forEach(hookName => {
 			templateObject.instance.hooks[hookName].intercept(makeInterceptorFor(templateObject.name, tracer)(hookName));
@@ -172,52 +194,97 @@ const interceptAllParserHooks = (moduleFactory, tracer) => {
 };
 
 const makeInterceptorFor = (instance, tracer) => (hookName) => ({
-	register: ({ name, type, fn }) => {
-		const newFn = makeNewProfiledTapFn(hookName, tracer, { name, type, fn });
-		return ({ name, type, fn: newFn });
+	register: ({
+		name,
+		type,
+		fn
+	}) => {
+		const newFn = makeNewProfiledTapFn(hookName, tracer, {
+			name,
+			type,
+			fn
+		});
+		return ({
+			name,
+			type,
+			fn: newFn
+		});
 	}
 });
 
 /**
- * @param {string} hookName 
- * @param {{counter: number, trace: *}} tracer 
- * @param {{name: string, type: string, fn: Function}} opts
+ * @param {string} hookName Name of the hook to profile.
+ * @param {{counter: number, trace: *}} tracer Instance of tracer.
+ * @param {{name: string, type: string, fn: Function}} opts Options for the profiled fn.
+ * @returns {*} Chainable hooked function.
  */
-const makeNewProfiledTapFn = (hookName, tracer, { name, type, fn }) => {
+const makeNewProfiledTapFn = (hookName, tracer, {
+	name,
+	type,
+	fn
+}) => {
 	const defaultCategory = ["blink.user_timing"];
 
-	switch (type) {
+	switch(type) {
 		case "promise":
 			return (...args) => {
 				const id = ++tracer.counter;
-				tracer.trace.begin({ name, id, cat: defaultCategory });
+				tracer.trace.begin({
+					name,
+					id,
+					cat: defaultCategory
+				});
 				return fn(...args).then(r => {
-					tracer.trace.end({ name, id, cat: defaultCategory });
+					tracer.trace.end({
+						name,
+						id,
+						cat: defaultCategory
+					});
 					return r;
 				});
 			};
 		case "async":
 			return (...args) => {
 				const id = ++tracer.counter;
-				tracer.trace.begin({ name, id, cat: defaultCategory });
+				tracer.trace.begin({
+					name,
+					id,
+					cat: defaultCategory
+				});
 				fn(...args, (...r) => {
 					const callback = args.pop();
-					tracer.trace.end({ name, id, cat: defaultCategory });
+					tracer.trace.end({
+						name,
+						id,
+						cat: defaultCategory
+					});
 					callback(...r);
 				});
 			};
 		case "sync":
 			return (...args) => {
 				const id = ++tracer.counter;
-				tracer.trace.begin({ name, id, cat: defaultCategory });
+				tracer.trace.begin({
+					name,
+					id,
+					cat: defaultCategory
+				});
 				let r;
 				try {
 					r = fn(...args);
-				} catch (error) {
-					tracer.trace.end({ name, id, cat: defaultCategory });
+				} catch(error) {
+					tracer.trace.end({
+						name,
+						id,
+						cat: defaultCategory
+					});
 					throw error;
 				}
-				tracer.trace.end({ name, id, cat: defaultCategory });
+				tracer.trace.end({
+					name,
+					id,
+					cat: defaultCategory
+				});
 				return r;
 			};
 		default:

--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -201,6 +201,7 @@ const makeNewProfiledTapFn = (hookName, tracer, { name, type, fn }) => {
 				const id = ++tracer.counter;
 				tracer.trace.begin({ name, id, cat: defaultCategory });
 				fn(...args, (...r) => {
+					const callback = args.pop();
 					tracer.trace.end({ name, id, cat: defaultCategory });
 					callback(...r);
 				});

--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -1,32 +1,134 @@
 const fs = require('fs');
 const chalk = require("chalk");
 const Trace = require('trace-event').Tracer;
-let trace = new Trace();
+const profiler = require('v8-profiler');
 
-trace.pipe(fs.createWriteStream("events.log"));
+function sleep(num) {
+	return new Promise((res) => {
+		setTimeout(res, num);
+	});
+}
+
+function createTrace() {
+	const trace = new Trace();
+	let counter = 0;
+
+	trace.pipe(fs.createWriteStream("events.log"));
+	// These are critical events that need to be inserted so that tools like 
+	// chrome dev tools can load the profile.
+	trace.instantEvent({
+		name: "TracingStartedInPage",
+		id: ++counter,
+		cat: ["disabled-by-default-devtools.timeline"],
+		args: {
+			data: {
+				sessionId: "-1",
+				page: "0xfff",
+				frames: [
+					{
+						frame: "0xfff",
+						url: "webpack",
+						name: ""
+					}
+				]
+			}
+		}
+	});
+
+	trace.instantEvent({
+		name: "TracingStartedInBrowser",
+		id: ++counter,
+		cat: ["disabled-by-default-devtools.timeline"],
+		args: {
+			data: {
+				sessionId: "-1"
+			},
+		}
+	});
+
+	return {
+		trace, counter
+	};
+}
 
 class ProfilingPlugin {
+
 	apply(compiler) {
+		const tracer = createTrace();
+		profiler.startProfiling('1', true);
 		// Compiler Hooks
 		Object.keys(compiler.hooks).forEach(hookName => {
-			compiler.hooks[hookName].intercept(makeInterceptorFor("Compiler")(hookName));
+			compiler.hooks[hookName].intercept(makeInterceptorFor("Compiler", tracer)(hookName));
 		});
 
 		Object.keys(compiler.resolverFactory.hooks).forEach(hookName => {
-			compiler.resolverFactory.hooks[hookName].intercept(makeInterceptorFor("Resolver")(hookName));
+			compiler.resolverFactory.hooks[hookName].intercept(makeInterceptorFor("Resolver", tracer)(hookName));
 		});
 
 		compiler.hooks.compilation.tap("ProfilingPlugin", (compilation, { normalModuleFactory, contextModuleFactory }) => {
-			interceptAllHooksFor(compilation, "Compilation");
-			interceptAllHooksFor(normalModuleFactory, "Normal Module Factory");
-			interceptAllHooksFor(contextModuleFactory, "Context Module Factory");
-			interceptAllParserHooks(normalModuleFactory);
-			interceptTemplateInstancesFrom(compilation);
+			interceptAllHooksFor(compilation, tracer, "Compilation");
+			interceptAllHooksFor(normalModuleFactory, tracer, "Normal Module Factory");
+			interceptAllHooksFor(contextModuleFactory, tracer, "Context Module Factory");
+			interceptAllParserHooks(normalModuleFactory, tracer);
+			interceptTemplateInstancesFrom(compilation, tracer);
+		});
+
+
+		// We need to write out the CPU profile when we are all done.
+		compiler.plugin('done', async () => {
+			// TODO(sean) Is there a better way to be the last thing to run?
+			await sleep(2000)
+
+			const profile = profiler.stopProfiling();
+			profile.export((err, profileResults) => {
+				const parsedResults = JSON.parse(profileResults);
+				const cpuStartTime = parsedResults.startTime;
+				const cpuEndTime = parsedResults.endTime;
+
+				tracer.trace.completeEvent({
+					name: "TaskQueueManager::ProcessTaskFromWorkQueue",
+					id: ++tracer.counter,
+					cat: ["toplevel"],
+					ts: cpuStartTime,
+					args: {
+						src_file: '../../ipc/ipc_moji_bootstrap.cc',
+						src_func: 'Accept'
+					}
+				});
+
+				tracer.trace.completeEvent({
+					name: "EvaluateScript",
+					id: ++tracer.counter,
+					cat: ["devtools.timeline"],
+					ts: cpuStartTime,
+					dur: cpuEndTime - cpuStartTime,
+					args: {
+						data: {
+							url: "webpack",
+							lineNumber: 1,
+							columnNumber: 1,
+							frame: "0xFFF"
+						}
+					}
+				});
+
+				tracer.trace.instantEvent({
+					name: "CpuProfile",
+					id: ++tracer.counter,
+					cat: ["disabled-by-default-devtools.timeline"],
+					ts: cpuEndTime,
+					args: {
+						data: {
+							cpuProfile: parsedResults
+						}
+					}
+				});
+			});
 		});
 	}
 }
 
-const interceptTemplateInstancesFrom = (compilation) => {
+const interceptTemplateInstancesFrom = (compilation, tracer) => {
 	const { mainTemplate, chunkTemplate, hotUpdateChunkTemplate, moduleTemplates } = compilation;
 
 	const {
@@ -42,18 +144,18 @@ const interceptTemplateInstancesFrom = (compilation) => {
 		{ instance: webassembly, name: "WebAssemblyModuleTemplate" }
 	].forEach(templateObject => {
 		Object.keys(templateObject.instance.hooks).forEach(hookName => {
-			templateObject.instance.hooks[hookName].intercept(makeInterceptorFor(templateObject.name)(hookName));
+			templateObject.instance.hooks[hookName].intercept(makeInterceptorFor(templateObject.name, tracer)(hookName));
 		});
 	});
 };
 
-const interceptAllHooksFor = (instance, logLabel) => {
+const interceptAllHooksFor = (instance, tracer, logLabel) => {
 	Object.keys(instance.hooks).forEach(hookName => {
-		instance.hooks[hookName].intercept(makeInterceptorFor(logLabel)(hookName));
+		instance.hooks[hookName].intercept(makeInterceptorFor(logLabel, tracer)(hookName));
 	});
 };
 
-const interceptAllParserHooks = (moduleFactory) => {
+const interceptAllParserHooks = (moduleFactory, tracer) => {
 	const moduleTypes = [
 		"javascript/auto",
 		"javascript/esm",
@@ -63,49 +165,57 @@ const interceptAllParserHooks = (moduleFactory) => {
 
 	moduleTypes.forEach(moduleType => {
 		moduleFactory.hooks.parser.for(moduleType).tap("ProfilingPlugin", (parser, parserOpts) => {
-			interceptAllHooksFor(parser, "Parser");
+			interceptAllHooksFor(parser, tracer, "Parser");
 		});
 	});
 };
 
-const makeInterceptorFor = (instance) => (hookName) => ({
+const makeInterceptorFor = (instance, tracer) => (hookName) => ({
 	register: ({ name, type, fn }) => {
-		const newFn = makeNewProfiledTapFn(hookName, { name, type, fn });
+		const newFn = makeNewProfiledTapFn(hookName, tracer, { name, type, fn });
 		return ({ name, type, fn: newFn });
 	}
 });
 
-const makeNewProfiledTapFn = (hookName, { name, type, fn }) => {
-	const timingId = `${hookName}-${name}`;
+/**
+ * @param {string} hookName 
+ * @param {{counter: number, trace: *}} tracer 
+ * @param {{name: string, type: string, fn: Function}} opts
+ */
+const makeNewProfiledTapFn = (hookName, tracer, { name, type, fn }) => {
+	const defaultCategory = ["blink.user_timing"];
 
-	switch(type) {
+	switch (type) {
 		case "promise":
 			return (...args) => {
-				trace.begin({name, id: timingId});
+				const id = ++tracer.counter;
+				tracer.trace.begin({ name, id, cat: defaultCategory });
 				return fn(...args).then(r => {
-					trace.begin({name, id: timingId});
+					tracer.trace.end({ name, id, cat: defaultCategory });
 					return r;
 				});
 			};
 		case "async":
 			return (...args) => {
-				trace.begin({name, id: timingId});
+				const id = ++tracer.counter;
+				tracer.trace.begin({ name, id, cat: defaultCategory });
 				fn(...args, (...r) => {
-					trace.end({name, id: timingId});
+					tracer.trace.end({ name, id, cat: defaultCategory });
 					callback(...r);
 				});
 			};
 		case "sync":
 			return (...args) => {
-				trace.begin({name, id: timingId});
+				const id = ++tracer.counter;
+				tracer.trace.begin({ name, id, cat: defaultCategory });
 				let r;
 				try {
 					r = fn(...args);
-				} catch(error) {
-					trace.end({name, id: timingId});
+				} catch (error) {
+					tracer.trace.end({ name, id, cat: defaultCategory });
 					throw error;
 				}
-				trace.end({name, id: timingId});
+				tracer.trace.end({ name, id, cat: defaultCategory });
 				return r;
 			};
 		default:

--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -10,7 +10,7 @@ function sleep(num) {
 }
 
 function createTrace() {
-	const trace = new Trace();
+	const trace = new Trace({ noStream: true });
 	let counter = 0;
 
 	trace.pipe(fs.createWriteStream("events.log"));
@@ -123,6 +123,8 @@ class ProfilingPlugin {
 						}
 					}
 				});
+
+				tracer.trace.flush();
 			});
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "tapable": "^1.0.0-beta.5",
     "trace-event": "samccone/node-trace-event",
     "uglifyjs-webpack-plugin": "^1.1.1",
+    "v8-profiler": "samccone/v8-profiler#sjs/highres-timestamps",
     "watchpack": "^1.4.0",
     "webpack-sources": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "beautify-lint": "^1.0.3",
     "benchmark": "^2.1.1",
     "bundle-loader": "~0.5.0",
-    "chalk": "^2.3.0",
     "codacy-coverage": "^2.0.1",
     "coffee-loader": "~0.7.1",
     "coffee-script": "^1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3775,7 +3775,7 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.3.0:
+nan@^2.3.0, nan@^2.5.1:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
@@ -3830,7 +3830,7 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
-node-pre-gyp@^0.6.39:
+node-pre-gyp@^0.6.34, node-pre-gyp@^0.6.39:
   version "0.6.39"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
   dependencies:
@@ -5817,6 +5817,13 @@ utils-merge@1.0.0:
 uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
+v8-profiler@samccone/v8-profiler#sjs/highres-timestamps:
+  version "5.7.0"
+  resolved "https://codeload.github.com/samccone/v8-profiler/tar.gz/55b9bd1578d6851d2becc969e3b3bf745b6ea45f"
+  dependencies:
+    nan "^2.5.1"
+    node-pre-gyp "^0.6.34"
 
 val-loader@^1.0.2:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5631,9 +5631,7 @@ tough-cookie@~2.3.0, tough-cookie@~2.3.3:
 
 trace-event@samccone/node-trace-event:
   version "1.3.1"
-  resolved "https://codeload.github.com/samccone/node-trace-event/tar.gz/e352243a7b20c2a78c330e5b6747c9ba28cb5e7d"
-  dependencies:
-    assert-plus "0.1.x"
+  resolved "https://codeload.github.com/samccone/node-trace-event/tar.gz/004e5c14cba9cb3665fb2cb37c4a57cc4db9db67"
 
 transformers@2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,10 +208,6 @@ asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
 
-assert-plus@0.1.x:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.1.5.tgz#ee74009413002d84cec7219c6ac811812e723160"
-
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
@@ -5632,6 +5628,8 @@ tough-cookie@~2.3.0, tough-cookie@~2.3.3:
 trace-event@samccone/node-trace-event:
   version "1.3.1"
   resolved "https://codeload.github.com/samccone/node-trace-event/tar.gz/004e5c14cba9cb3665fb2cb37c4a57cc4db9db67"
+  dependencies:
+    assert-plus "0.1.x"
 
 transformers@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Using the v8 profiler + user timing api + a sprinkling of chrome dev tools specific trace events (thx @paulirish) we can understand the overhead of each plugin in context with the sampling CPU profiler.

This new profiling mode 🔓  unlocks the ability for both webpack core team + plugin authors to easily profile their code from within a normal webpack build flow 🐐 

---- details -----

This required a minor change to v8-profiler to use high res timestamps so that we could be aligned with the usertiming timestamps

https://github.com/samccone/v8-profiler/commit/55b9bd1578d6851d2becc969e3b3bf745b6ea45f#diff-89f966fa209341af28fef997db40999eL82

Another change was also made to the trace lib to enable us to buffer up multiple events and then manually flush the events at the end to ensure that we did not actually cause the profile to be impacted by many writes to the file (in practice this enabled the overall build time of a test project to go from 22seconds to 16seconds)

left after ⬅️ 
right before ➡️ 

![image](https://user-images.githubusercontent.com/883126/34655286-eb95f7fc-f3bb-11e7-863a-96522dbb73bb.png)


https://github.com/samccone/node-trace-event/commit/004e5c14cba9cb3665fb2cb37c4a57cc4db9db67

##### gif

![ezgif-2-a6c387f8c8](https://user-images.githubusercontent.com/883126/34655274-c500af9c-f3bb-11e7-984d-d671c832989a.gif)

### live trace that you can play with
  
https://chromedevtools.github.io/timeline-viewer/?loadTimelineFromURL=drive://163GY-H0wvF9rSrlwjJcrdTL-YLnppp55