### PR TITLE
Rewrite top level `this` to `undefined` in Harmony modules

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -947,6 +947,7 @@ class Parser extends Tapable {
 		for(const param of statement.params)
 			this.walkPattern(param);
 		this.inScope(statement.params, () => {
+			this.scope.topLevelScope = false;
 			if(statement.body.type === "BlockStatement") {
 				this.prewalkStatement(statement.body);
 				this.walkStatement(statement.body);
@@ -1272,6 +1273,9 @@ class Parser extends Tapable {
 			case "TemplateLiteral":
 				this.walkTemplateLiteral(expression);
 				break;
+			case "ThisExpression":
+				this.walkThisExpression(expression);
+				break;
 			case "UnaryExpression":
 				this.walkUnaryExpression(expression);
 				break;
@@ -1315,6 +1319,7 @@ class Parser extends Tapable {
 		for(const param of expression.params)
 			this.walkPattern(param);
 		this.inScope(expression.params, () => {
+			this.scope.topLevelScope = false;
 			if(expression.body.type === "BlockStatement") {
 				this.prewalkStatement(expression.body);
 				this.walkStatement(expression.body);
@@ -1564,6 +1569,13 @@ class Parser extends Tapable {
 			this.walkExpression(expression.property);
 	}
 
+	walkThisExpression(expression) {
+		const expressionHook = this.hooks.expression.get("this");
+		if(expressionHook !== undefined) {
+			expressionHook.call(expression);
+		}
+	}
+
 	walkIdentifier(expression) {
 		if(!this.scope.definitions.has(expression.name)) {
 			const hook = this.hooks.expression.for(this.scope.renames.get(expression.name) || expression.name);
@@ -1578,6 +1590,7 @@ class Parser extends Tapable {
 	inScope(params, fn) {
 		const oldScope = this.scope;
 		this.scope = {
+			topLevelScope: oldScope.topLevelScope,
 			inTry: false,
 			inShorthand: false,
 			definitions: oldScope.definitions.createChild(),
@@ -1774,6 +1787,7 @@ class Parser extends Tapable {
 		const oldState = this.state;
 		const oldComments = this.comments;
 		this.scope = {
+			topLevelScope: true,
 			inTry: false,
 			definitions: new StackedSetMap(),
 			renames: new StackedSetMap()

--- a/lib/dependencies/HarmonyModulesPlugin.js
+++ b/lib/dependencies/HarmonyModulesPlugin.js
@@ -19,6 +19,7 @@ const NullFactory = require("../NullFactory");
 const HarmonyDetectionParserPlugin = require("./HarmonyDetectionParserPlugin");
 const HarmonyImportDependencyParserPlugin = require("./HarmonyImportDependencyParserPlugin");
 const HarmonyExportDependencyParserPlugin = require("./HarmonyExportDependencyParserPlugin");
+const HarmonyTopLevelThisParserPlugin = require("./HarmonyTopLevelThisParserPlugin");
 
 class HarmonyModulesPlugin {
 	constructor(options) {
@@ -66,6 +67,7 @@ class HarmonyModulesPlugin {
 				new HarmonyDetectionParserPlugin().apply(parser);
 				new HarmonyImportDependencyParserPlugin(this.options).apply(parser);
 				new HarmonyExportDependencyParserPlugin(this.options).apply(parser);
+				new HarmonyTopLevelThisParserPlugin().apply(parser);
 			};
 
 			normalModuleFactory.hooks.parser.for("javascript/auto").tap("HarmonyModulesPlugin", handler);

--- a/lib/dependencies/HarmonyTopLevelThisParserPlugin.js
+++ b/lib/dependencies/HarmonyTopLevelThisParserPlugin.js
@@ -1,0 +1,25 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Florent Cailhol @ooflorent
+*/
+"use strict";
+
+const ConstDependency = require("./ConstDependency");
+
+class HarmonyTopLevelThisParserPlugin {
+	apply(parser) {
+		parser.hooks.expression.for("this").tap("HarmonyTopLevelThisParserPlugin", node => {
+			if(!parser.scope.topLevelScope)
+				return;
+			const module = parser.state.module;
+			const isHarmony = !!(module.buildMeta && module.buildMeta.exportsType);
+			if(isHarmony) {
+				const dep = new ConstDependency("undefined", node.range, false);
+				dep.loc = node.loc;
+				parser.state.current.addDependency(dep);
+			}
+		});
+	}
+}
+
+module.exports = HarmonyTopLevelThisParserPlugin;

--- a/test/configCases/parsing/harmony-this/abc.js
+++ b/test/configCases/parsing/harmony-this/abc.js
@@ -11,4 +11,21 @@ export {
 	b
 }
 
+export const that = this;
+export const returnThisArrow = () => this;
+export const returnThisMember = () => this.a;
+
+export class C {
+	constructor() {
+		this.x = "bar";
+	}
+	foo() {
+		return this.x;
+	}
+}
+
+export function D() {
+	this.prop = () => "ok";
+}
+
 export default returnThis;

--- a/test/configCases/parsing/harmony-this/index.js
+++ b/test/configCases/parsing/harmony-this/index.js
@@ -1,8 +1,26 @@
 "use strict";
 
-import d, {a, b as B} from "./abc";
+import d, {a, b as B, C as _C, D as _D, returnThisArrow, returnThisMember, that} from "./abc";
 
 import * as abc from "./abc";
+
+it("should have this = undefined on harmony modules", function() {
+	(typeof that).should.be.eql("undefined");
+	(typeof abc.that).should.be.eql("undefined");
+	(typeof returnThisArrow()).should.be.eql("undefined");
+	(typeof abc.returnThisArrow()).should.be.eql("undefined");
+	(function() {
+		returnThisMember();
+	}).should.throw();
+	(function() {
+		abc.returnThisMember();
+	}).should.throw();
+});
+
+it("should not break classes and functions", function() {
+	(new _C).foo().should.be.eql("bar");
+	(new _D).prop().should.be.eql("ok");
+});
 
 function x() { throw new Error("should not be executed"); }
 it("should have this = undefined on imported non-strict functions", function() {
@@ -16,7 +34,7 @@ it("should have this = undefined on imported non-strict functions", function() {
 	abc.a().should.be.type("object");
 	x
 	var thing = abc.a();
-	Object.keys(thing).should.be.eql(["a", "b", "default"]);
+	Object.keys(thing).should.be.eql(Object.keys(abc));
 });
 
 import C2, { C } from "./new";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

yes

**If relevant, link to documentation update:**

n/a

**Summary**

Rewrite `this` to `undefined` in Harmony modules to be [spec-compliant](https://tc39.github.io/ecma262/#sec-module-environment-records-getthisbinding).

> **8.1.1.5.4 `GetThisBinding()`**
> 1. Return `undefined`.

```js
// in
console.log(this, this.exports);
export default this;

// out
console.log(undefined, undefined.exports);
export default undefined;
```

Fixes #5074 

**Does this PR introduce a breaking change?**

Yes if a module was relying on this broken behavior.
