### PR TITLE
devServer: setting clientLogLevel to none to actually mute all annoying browser console logs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
 	"env": {
 		"node": true,
 		"es6": true,
+		"browser": true,
 	},
 	"parserOptions": { "ecmaVersion": 2017 },
 	"rules": {

--- a/hot/log.js
+++ b/hot/log.js
@@ -1,8 +1,11 @@
 var logLevel = "info";
-
+var isNone = (window.localStorage.isNone === "true") || false; //webpack config devServer clientLogLevel is set to none??
 function dummy() {}
 
 function shouldLog(level) {
+	if(isNone) {
+		return false; //shouldn't log
+	}
 	var shouldLog = (logLevel === "info" && level === "info") ||
 		(["info", "warning"].indexOf(logLevel) >= 0 && level === "warning") ||
 		(["info", "warning", "error"].indexOf(logLevel) >= 0 && level === "error");
@@ -40,5 +43,11 @@ module.exports.groupCollapsed = logGroup(groupCollapsed);
 module.exports.groupEnd = logGroup(groupEnd);
 
 module.exports.setLogLevel = function(level) {
+	//after main module loads
 	logLevel = level;
+	if(level === "none") {
+		window.localStorage.isNone = true;
+	} else {
+		window.localStorage.isNone = false;
+	}
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Fixing this **annoying** bug

`clientLogLevel` to `none` keeps logging annoying messages to browser

https://github.com/gaearon/react-hot-loader/issues/79
https://github.com/webpack/webpack/issues/415
https://github.com/webpack/webpack/issues/1872
https://github.com/webpack/webpack/issues/422
https://github.com/webpack/webpack/issues/476
https://github.com/webpack/webpack/issues/4115
https://github.com/webpack/webpack/pull/4960
https://github.com/webpack/webpack-dev-server/pull/579
https://github.com/webpack/webpack-dev-server/pull/1096
https://github.com/webpack/webpack-dev-server/pull/926
https://github.com/webpack/webpack-dev-server/pull/925
https://github.com/webpack/webpack/pull/1323
https://github.com/webpack/webpack-dev-server/pull/925


**Did you add tests for your changes?**
Yes,
 9890 passing (7m)
 125 pending
 2 failing
I think I need better hardware to pass all tests

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->
N/A but we may add what "none" should do now exactly

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


We like our console to be clean
These messages are really annoying when frequently reloading app in the browser
![image](https://user-images.githubusercontent.com/7149686/34753592-93b13aa8-f5c1-11e7-9220-c5a1351b61b7.png)
Setting `clientLogLevel` to none... now creates no noise 😁

Now the problem should be fixed 🎉 


**Does this PR introduce a breaking change?**
No, it's done with the minimal code change

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
N/A

  