### PR TITLE
Add the hook add-module-dependencies to track the dependencies when building

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -205,6 +205,7 @@ class Compilation extends Tapable {
 	}
 
 	addModuleDependencies(module, dependencies, bail, cacheGroup, recursive, callback) {
+        this.applyPlugins2("add-module-dependencies", module, dependencies); // This hook is used for tracking the total dependency map
 		let _this = this;
 		const start = _this.profile && Date.now();
 

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -205,7 +205,7 @@ class Compilation extends Tapable {
 	}
 
 	addModuleDependencies(module, dependencies, bail, cacheGroup, recursive, callback) {
-        this.applyPlugins2("add-module-dependencies", module, dependencies); // This hook is used for tracking the total dependency map
+		this.applyPlugins2("add-module-dependencies", module, dependencies); // This hook is used for tracking the total dependency map
 		let _this = this;
 		const start = _this.profile && Date.now();
 


### PR DESCRIPTION
# Summary

This PR only brings in a small hook into the Compilation, called "add-module-dependencies" when trying to build the module(and its dependencies)

# Purpose

I'm creating a small loader that will integrate the building process of sass into webpack.

What it means is that the dependency tracking for sass files can across the sass files and the js.

For example:

a.js references a.scss and b.js, b.js references b.scss, and b.scss references c.scss, the dependency map should be like this:

a.js -> a.scss
a.js -> b.js -> b.scss -> c.scss

So, when building scss for a.js, I should build the scss files using this order.

- c.scss
- b.scss
- a.scss

And give the output to the css loader of a.js

I can track the scss dependencies by using the comment syntax(since @import function is not functional for dependency management for now), and I'll use webpack to track down the dependencies through js using webpack.

The problem is, for now, that webpack is aimed to compile the scss as module, and once compiled, it won't get compile again, only get it out of the cache.

This means when there are multiple entries in the webpack configuration, I can't get all of them tracked, example like this:

a.js -> a.scss
a.js -> b.scss -> c.scss
b.js -> b.scss -> c.scss

When trying to compile, though c.scss is required by both of two js files, webpack will only compile it once. So, I can't apply it to the other js entry.

So, I need this hook to track down all modules and module dependencies when building, so that I can know exactly the dependency mapping when trying to build the scss for all entries.

# Other Purpose

I can use this function to track down the whole dependency map for each entry too, and generate the dependency tree easily using the output.

So, if there is another better way to do this, you can tell me, then this pull request is not needed, at least for now, I think this hook is very useful for me now, and the future functions.