### PR TITLE
Add sourceURLTemplate to EvalSourceMapDevToolModuleTemplatePlugin to configure footer

### DIFF
--- a/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
+++ b/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
@@ -61,9 +61,9 @@ class EvalSourceMapDevToolModuleTemplatePlugin {
 			}
 			sourceMap.sourceRoot = options.sourceRoot || "";
 			sourceMap.file = `${module.id}.js`;
-			const sourceURL = self.sourceURLTemplate
-				? ModuleFilenameHelpers.createFilename(module, self.sourceURLTemplate, this.requestShortener)
-				: `webpack-internal:///${module.id}`;
+			const sourceURL = self.sourceURLTemplate ?
+				ModuleFilenameHelpers.createFilename(module, self.sourceURLTemplate, this.requestShortener) :
+				`webpack-internal:///${module.id}`;
 			const footer = self.sourceMapComment.replace(/\[url\]/g, `data:application/json;charset=utf-8;base64,${new Buffer(JSON.stringify(sourceMap), "utf8").toString("base64")}`) + //eslint-disable-line
 				`\n//# sourceURL=${sourceURL}\n`; // workaround for chrome bug
 			source.__EvalSourceMapDevToolData = new RawSource(`eval(${JSON.stringify(content + footer)});`);

--- a/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
+++ b/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
@@ -12,6 +12,7 @@ class EvalSourceMapDevToolModuleTemplatePlugin {
 		this.compilation = compilation;
 		this.sourceMapComment = options.append || "//# sourceURL=[module]\n//# sourceMappingURL=[url]";
 		this.moduleFilenameTemplate = options.moduleFilenameTemplate || "webpack:///[resource-path]?[hash]";
+		this.sourceURLTemplate = options.sourceURLTemplate;
 		this.options = options;
 	}
 
@@ -60,9 +61,11 @@ class EvalSourceMapDevToolModuleTemplatePlugin {
 			}
 			sourceMap.sourceRoot = options.sourceRoot || "";
 			sourceMap.file = `${module.id}.js`;
-
+			const sourceURL = self.sourceURLTemplate
+				? ModuleFilenameHelpers.createFilename(module, self.sourceURLTemplate, this.requestShortener)
+				: `webpack-internal:///${module.id}`;
 			const footer = self.sourceMapComment.replace(/\[url\]/g, `data:application/json;charset=utf-8;base64,${new Buffer(JSON.stringify(sourceMap), "utf8").toString("base64")}`) + //eslint-disable-line
-				`\n//# sourceURL=webpack-internal:///${module.id}\n`; // workaround for chrome bug
+				`\n//# sourceURL=${sourceURL}\n`; // workaround for chrome bug
 			source.__EvalSourceMapDevToolData = new RawSource(`eval(${JSON.stringify(content + footer)});`);
 			return source.__EvalSourceMapDevToolData;
 		});


### PR DESCRIPTION
Example usage: ``` js
new webpack.EvalSourceMapDevToolPlugin({
  sourceURLTemplate: module => `/${module.identifier}`
})
```
OR
``` js
new webpack.EvalSourceMapDevToolPlugin({
  sourceURLTemplate: '[all-loaders][resource]'
})
```