### PR TITLE
Remove native module dep for profiling plugin.

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -1,6 +1,59 @@
 const fs = require("fs");
 const Trace = require("trace-event").Tracer;
-const profiler = require("v8-profiler");
+let inspector = null;
+
+try {
+	inspector = require("inspector");
+} catch(e) {
+	console.log("Unable to CPU profile in < node 8.0");
+}
+
+class Profiler {
+	startProfiling() {
+		if(inspector != null) {
+			this.session = new inspector.Session();
+			this.session.connect();
+
+			return Promise.all([
+				this.sendCommand("Profiler.setSamplingInterval", {
+					interval: 100
+				}),
+				this.sendCommand("Profiler.enable"),
+				this.sendCommand("Profiler.start"),
+			]);
+		} else {
+			return Promise.resolve();
+		}
+	}
+
+	sendCommand(method, params) {
+		if(this.session) {
+			return new Promise((res, rej) => {
+				return this.session.post(method, params, (err, params) => {
+					if(err != null) {
+						rej(null);
+					} else {
+						res(params);
+					}
+				});
+			});
+		} else {
+			return Promise.resolve();
+		}
+	}
+
+	destroy() {
+		if(this.session) {
+			this.session.disconnect();
+		}
+
+		return Promise.resolve();
+	}
+
+	stopProfiling() {
+		return this.sendCommand("Profiler.stop");
+	}
+}
 
 function sleep(num) {
 	return new Promise((res) => {
@@ -12,6 +65,9 @@ function createTrace() {
 	const trace = new Trace({
 		noStream: true
 	});
+
+	const profiler = new Profiler();
+
 	let counter = 0;
 
 	trace.pipe(fs.createWriteStream("events.log"));
@@ -47,7 +103,8 @@ function createTrace() {
 
 	return {
 		trace,
-		counter
+		counter,
+		profiler
 	};
 }
 
@@ -55,7 +112,8 @@ class ProfilingPlugin {
 
 	apply(compiler) {
 		const tracer = createTrace();
-		profiler.startProfiling("1", true);
+		tracer.profiler.startProfiling();
+
 		// Compiler Hooks
 		Object.keys(compiler.hooks).forEach(hookName => {
 			compiler.hooks[hookName].intercept(makeInterceptorFor("Compiler", tracer)(hookName));
@@ -80,11 +138,16 @@ class ProfilingPlugin {
 		compiler.plugin("done", () => {
 			// TODO(sean) Is there a better way to be the last thing to run?
 			sleep(2000).then(() => {
-				const profile = profiler.stopProfiling();
-				profile.export((err, profileResults) => {
-					const parsedResults = JSON.parse(profileResults);
-					const cpuStartTime = parsedResults.startTime;
-					const cpuEndTime = parsedResults.endTime;
+				tracer.profiler.stopProfiling().then((parsedResults) => {
+
+					if(parsedResults == null) {
+						tracer.profiler.destroy();
+						tracer.trace.flush();
+						return;
+					}
+
+					const cpuStartTime = parsedResults.profile.startTime;
+					const cpuEndTime = parsedResults.profile.endTime;
 
 					tracer.trace.completeEvent({
 						name: "TaskQueueManager::ProcessTaskFromWorkQueue",
@@ -120,11 +183,12 @@ class ProfilingPlugin {
 						ts: cpuEndTime,
 						args: {
 							data: {
-								cpuProfile: parsedResults
+								cpuProfile: parsedResults.profile
 							}
 						}
 					});
 
+					tracer.profiler.destroy();
 					tracer.trace.flush();
 				});
 			});
@@ -146,25 +210,25 @@ const interceptTemplateInstancesFrom = (compilation, tracer) => {
 	} = moduleTemplates;
 
 	[{
-		instance: mainTemplate,
-		name: "MainTemplate"
-	},
-	{
-		instance: chunkTemplate,
-		name: "ChunkTemplate"
-	},
-	{
-		instance: hotUpdateChunkTemplate,
-		name: "HotUpdateChunkTemplate"
-	},
-	{
-		instance: javascript,
-		name: "JavaScriptModuleTemplate"
-	},
-	{
-		instance: webassembly,
-		name: "WebAssemblyModuleTemplate"
-	}
+			instance: mainTemplate,
+			name: "MainTemplate"
+		},
+		{
+			instance: chunkTemplate,
+			name: "ChunkTemplate"
+		},
+		{
+			instance: hotUpdateChunkTemplate,
+			name: "HotUpdateChunkTemplate"
+		},
+		{
+			instance: javascript,
+			name: "JavaScriptModuleTemplate"
+		},
+		{
+			instance: webassembly,
+			name: "WebAssemblyModuleTemplate"
+		}
 	].forEach(templateObject => {
 		Object.keys(templateObject.instance.hooks).forEach(hookName => {
 			templateObject.instance.hooks[hookName].intercept(makeInterceptorFor(templateObject.name, tracer)(hookName));
@@ -214,7 +278,7 @@ const makeInterceptorFor = (instance, tracer) => (hookName) => ({
 
 /**
  * @param {string} hookName Name of the hook to profile.
- * @param {{counter: number, trace: *}} tracer Instance of tracer.
+ * @param {{counter: number, trace: *, profiler: *}} tracer Instance of tracer.
  * @param {{name: string, type: string, fn: Function}} opts Options for the profiled fn.
  * @returns {*} Chainable hooked function.
  */

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "tapable": "^1.0.0-beta.5",
     "trace-event": "samccone/node-trace-event",
     "uglifyjs-webpack-plugin": "^1.1.1",
-    "v8-profiler": "samccone/v8-profiler#sjs/highres-timestamps",
     "watchpack": "^1.4.0",
     "webpack-sources": "^1.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,6 +208,10 @@ asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
 
+assert-plus@0.1.x:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.1.5.tgz#ee74009413002d84cec7219c6ac811812e723160"
+
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
@@ -3771,7 +3775,7 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.3.0, nan@^2.5.1:
+nan@^2.3.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
@@ -3826,7 +3830,7 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
-node-pre-gyp@^0.6.34, node-pre-gyp@^0.6.39:
+node-pre-gyp@^0.6.39:
   version "0.6.39"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
   dependencies:
@@ -5815,13 +5819,6 @@ utils-merge@1.0.0:
 uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
-
-v8-profiler@samccone/v8-profiler#sjs/highres-timestamps:
-  version "5.7.0"
-  resolved "https://codeload.github.com/samccone/v8-profiler/tar.gz/55b9bd1578d6851d2becc969e3b3bf745b6ea45f"
-  dependencies:
-    nan "^2.5.1"
-    node-pre-gyp "^0.6.34"
 
 val-loader@^1.0.2:
   version "1.1.0"


### PR DESCRIPTION
This make the profiling plugin node 8.x+ only, but drops a native
dependency which is a win.