### PR TITLE
Adds sourceURLTemplate as optional param to options for EvalSourceMapDevToolModuleTemplatePlugin

### DIFF
--- a/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
+++ b/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
@@ -12,6 +12,7 @@ class EvalSourceMapDevToolModuleTemplatePlugin {
 		this.compilation = compilation;
 		this.sourceMapComment = options.append || "//# sourceURL=[module]\n//# sourceMappingURL=[url]";
 		this.moduleFilenameTemplate = options.moduleFilenameTemplate || "webpack:///[resource-path]?[hash]";
+		this.sourceURLTemplate = options.sourceURLTemplate;
 		this.options = options;
 	}
 
@@ -61,8 +62,12 @@ class EvalSourceMapDevToolModuleTemplatePlugin {
 			sourceMap.sourceRoot = options.sourceRoot || "";
 			sourceMap.file = `${module.id}.js`;
 
+			const sourceURL = options.sourceURLTemplate ?
+				ModuleFilenameHelpers.createFilename(module, self.sourceURLTemplate, this.requestShortener) :
+				`webpack-internal:///${module.id}`;
+
 			const footer = self.sourceMapComment.replace(/\[url\]/g, `data:application/json;charset=utf-8;base64,${new Buffer(JSON.stringify(sourceMap), "utf8").toString("base64")}`) + //eslint-disable-line
-				`\n//# sourceURL=webpack-internal:///${module.id}\n`; // workaround for chrome bug
+				`\n//# sourceURL=${sourceURL}\n`; // workaround for chrome bug
 			source.__EvalSourceMapDevToolData = new RawSource(`eval(${JSON.stringify(content + footer)});`);
 			return source.__EvalSourceMapDevToolData;
 		});


### PR DESCRIPTION
Adds ability to specify sourceURLTemplate so as to override the default web pack-internal:/// which has been seen as cross-origin error in React 16, error handling code.
Example usage: 
``` js
new webpack.EvalSourceMapDevToolPlugin({
  sourceURLTemplate: module => `/${module.identifier}`
})
```
OR
``` js
new webpack.EvalSourceMapDevToolPlugin({
  sourceURLTemplate: '[all-loaders][resource]'
})
```