### PR TITLE
Reduce SortableSet memory consumption

### DIFF
--- a/lib/util/SortableSet.js
+++ b/lib/util/SortableSet.js
@@ -1,13 +1,13 @@
 "use strict";
 
-module.exports = class SortableSet extends Set {
+class SortableSet extends Set {
 
 	constructor(initialIterable, defaultSort) {
 		super(initialIterable);
 		this._sortFn = defaultSort;
 		this._lastActiveSortFn = null;
-		this._cache = null;
-		this._cacheOrderIndependent = null;
+		this._cache = undefined;
+		this._cacheOrderIndependent = undefined;
 	}
 
 	/**
@@ -16,21 +16,21 @@ module.exports = class SortableSet extends Set {
 	 */
 	add(value) {
 		this._lastActiveSortFn = null;
-		this._cache = null;
-		this._cacheOrderIndependent = null;
+		this._invalidateCache();
+		this._invalidateOrderedCache();
 		super.add(value);
 		return this;
 	}
 
 	delete(value) {
-		this._cache = null;
-		this._cacheOrderIndependent = null;
+		this._invalidateCache();
+		this._invalidateOrderedCache();
 		return super.delete(value);
 	}
 
 	clear() {
-		this._cache = null;
-		this._cacheOrderIndependent = null;
+		this._invalidateCache();
+		this._invalidateOrderedCache();
 		return super.clear();
 	}
 
@@ -50,7 +50,7 @@ module.exports = class SortableSet extends Set {
 			super.add(sortedArray[i]);
 		}
 		this._lastActiveSortFn = sortFn;
-		this._cache = null;
+		this._invalidateCache();
 	}
 
 	/**
@@ -65,7 +65,7 @@ module.exports = class SortableSet extends Set {
 	 * @returns {any} - returns result of fn(this), cached until set changes
 	 */
 	getFromCache(fn) {
-		if(this._cache === null) {
+		if(this._cache === undefined) {
 			this._cache = new Map();
 		} else {
 			const data = this._cache.get(fn);
@@ -77,12 +77,13 @@ module.exports = class SortableSet extends Set {
 		this._cache.set(fn, newData);
 		return newData;
 	}
+
 	/**
 	 * @param {Function} fn - function to calculate value
 	 * @returns {any} - returns result of fn(this), cached until set changes
 	 */
 	getFromUnorderedCache(fn) {
-		if(this._cacheOrderIndependent === null) {
+		if(this._cacheOrderIndependent === undefined) {
 			this._cacheOrderIndependent = new Map();
 		} else {
 			const data = this._cacheOrderIndependent.get(fn);
@@ -94,4 +95,16 @@ module.exports = class SortableSet extends Set {
 		this._cacheOrderIndependent.set(fn, newData);
 		return newData;
 	}
-};
+
+	_invalidateCache() {
+		if(this._cache !== undefined)
+			this._cache.clear();
+	}
+
+	_invalidateOrderedCache() {
+		if(this._cacheOrderIndependent !== undefined)
+			this._cacheOrderIndependent.clear();
+	}
+}
+
+module.exports = SortableSet;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

n/a

**Summary**

`SortableSet` can reuse its `Map` instances to reduce its memory consumption.

**Does this PR introduce a breaking change?**

no
