### PR TITLE
When a user is already using --inspect and we are unable to create a session do not fail

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -9,25 +9,39 @@ try {
 }
 
 class Profiler {
-	startProfiling() {
-		if(inspector != null) {
-			this.session = new inspector.Session();
-			this.session.connect();
+	constructor(inspector) {
+		this.session = null;
+		this.inspector = inspector;
+	}
 
-			return Promise.all([
-				this.sendCommand("Profiler.setSamplingInterval", {
-					interval: 100
-				}),
-				this.sendCommand("Profiler.enable"),
-				this.sendCommand("Profiler.start"),
-			]);
-		} else {
+	hasSession() {
+		return this.session != null;
+	}
+
+	startProfiling() {
+		if(this.inspector == null) {
 			return Promise.resolve();
 		}
+
+		try {
+			this.session = new inspector.Session();
+			this.session.connect();
+		} catch(_) {
+			this.session = null;
+			return Promise.resolve();
+		}
+
+		return Promise.all([
+			this.sendCommand("Profiler.setSamplingInterval", {
+				interval: 100
+			}),
+			this.sendCommand("Profiler.enable"),
+			this.sendCommand("Profiler.start"),
+		]);
 	}
 
 	sendCommand(method, params) {
-		if(this.session) {
+		if(this.hasSession()) {
 			return new Promise((res, rej) => {
 				return this.session.post(method, params, (err, params) => {
 					if(err != null) {
@@ -43,7 +57,7 @@ class Profiler {
 	}
 
 	destroy() {
-		if(this.session) {
+		if(this.hasSession()) {
 			this.session.disconnect();
 		}
 
@@ -66,7 +80,7 @@ function createTrace() {
 		noStream: true
 	});
 
-	const profiler = new Profiler();
+	const profiler = new Profiler(inspector);
 
 	let counter = 0;
 


### PR DESCRIPTION
Instead do not record the CPU profile but still record the usertiming.
This provides a nice fallback to users instead of a runtime error :( 🕺 