### PR TITLE
Fix #6243: Don't include initial chunks in chunkhash computation

### DIFF
--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -105,9 +105,9 @@ class TemplatedPathPlugin {
 				const outputOptions = this.outputOptions;
 				const chunkFilename = outputOptions.chunkFilename || outputOptions.filename;
 				if(REGEXP_CHUNKHASH_FOR_TEST.test(chunkFilename))
-					hash.update(JSON.stringify(chunk.getChunkMaps(true, true).hash));
+					hash.update(JSON.stringify(chunk.getChunkMaps(false, true).hash));
 				if(REGEXP_NAME_FOR_TEST.test(chunkFilename))
-					hash.update(JSON.stringify(chunk.getChunkMaps(true, true).name));
+					hash.update(JSON.stringify(chunk.getChunkMaps(false, true).name));
 			});
 		});
 	}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
In `TemplatedPathPlugin` set the `includeEntries` paramter to `false`

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No

**Summary**
Details in #6243.
