### PR TITLE
Add test coverage for profiling plugin.

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -3,7 +3,7 @@ const Trace = require("trace-event").Tracer;
 let inspector = null;
 
 try {
-	inspector = require("inspector");
+	inspector = require("inspector"); // eslint-disable-line node/no-missing-require
 } catch(e) {
 	console.log("Unable to CPU profile in < node 8.0");
 }
@@ -15,11 +15,11 @@ class Profiler {
 	}
 
 	hasSession() {
-		return this.session != null;
+		return this.session !== undefined;
 	}
 
 	startProfiling() {
-		if(this.inspector == null) {
+		if(this.inspector === undefined) {
 			return Promise.resolve();
 		}
 
@@ -44,7 +44,7 @@ class Profiler {
 		if(this.hasSession()) {
 			return new Promise((res, rej) => {
 				return this.session.post(method, params, (err, params) => {
-					if(err != null) {
+					if(err !== undefined) {
 						rej(null);
 					} else {
 						res(params);
@@ -77,6 +77,7 @@ function sleep(num) {
 
 /**
  * @param {string} outPath The location where to write the log.
+ * @returns {{trace: ?,	counter: number, profiler: Profiler}} The trace object
  */
 function createTrace(outPath) {
 	const trace = new Trace({
@@ -161,7 +162,7 @@ class ProfilingPlugin {
 			sleep(2000).then(() => {
 				tracer.profiler.stopProfiling().then((parsedResults) => {
 
-					if(parsedResults == null) {
+					if(parsedResults === undefined) {
 						tracer.profiler.destroy();
 						tracer.trace.flush();
 						return;

--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -75,7 +75,10 @@ function sleep(num) {
 	});
 }
 
-function createTrace() {
+/**
+ * @param {string} outPath The location where to write the log.
+ */
+function createTrace(outPath) {
 	const trace = new Trace({
 		noStream: true
 	});
@@ -84,7 +87,7 @@ function createTrace() {
 
 	let counter = 0;
 
-	trace.pipe(fs.createWriteStream("events.log"));
+	trace.pipe(fs.createWriteStream(outPath));
 	// These are critical events that need to be inserted so that tools like
 	// chrome dev tools can load the profile.
 	trace.instantEvent({
@@ -123,6 +126,10 @@ function createTrace() {
 }
 
 class ProfilingPlugin {
+	constructor(opts) {
+		opts = opts || {};
+		this.outPath = opts.outPath || "events.json";
+	}
 
 	apply(compiler) {
 		const tracer = createTrace();
@@ -371,3 +378,4 @@ const makeNewProfiledTapFn = (hookName, tracer, {
 };
 
 module.exports = ProfilingPlugin;
+module.exports.Profiler = Profiler;

--- a/test/ProfilingPlugin.test.js
+++ b/test/ProfilingPlugin.test.js
@@ -1,0 +1,62 @@
+"use strict";
+
+require("should");
+const ProfilingPlugin = require("../lib/debug/ProfilingPlugin");
+
+describe("Profiling Plugin", () => {
+	it("should persist the passed outpath", () => {
+		const plugin = new ProfilingPlugin({
+			outPath: "invest_in_doge_coin"
+		});
+		plugin.outPath.should.equal("invest_in_doge_coin");
+	});
+
+	it("should handle no options", () => {
+		const plugin = new ProfilingPlugin();
+		plugin.outPath.should.equal("events.json");
+	});
+
+	it("should handle when unable to require the inspector", (done) => {
+		const profiler = new ProfilingPlugin.Profiler();
+
+		profiler.startProfiling().then(() => {
+			done();
+		}).catch(e => {
+			done(e);
+		});
+	});
+
+	it("should handle when unable to start a profiling session", (done) => {
+		const profiler = new ProfilingPlugin.Profiler({
+			Session() {
+				throw new Error("Sean Larkin was here.");
+			}
+		});
+
+		profiler.startProfiling().then(() => {
+			done();
+		}).catch(e => {
+			done(e);
+		});
+	});
+
+	it("handles sending a profiling message when no session", (done) => {
+		const profiler = new ProfilingPlugin.Profiler();
+
+		profiler.sendCommand("randy", "is a puppers").then(() => {
+			done();
+		}).catch(e => {
+			done(e);
+		});
+	});
+
+	it("handles destroying when no session", (done) => {
+		const profiler = new ProfilingPlugin.Profiler();
+
+		profiler.destroy().then(() => {
+			done();
+		}).catch(e => {
+			done(e);
+		});
+	});
+});


### PR DESCRIPTION
* Add configurable option for where the log file is written to.
* Test basic booting of the plugin
* Test profiler adapter to make sure it falls back correctly when we have no inspect module or are unable to start an inspect session.