### PR TITLE
Add support for variations of `sideEffects` values (#6074)

### DIFF
--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -8,17 +8,20 @@ const HarmonyExportImportedSpecifierDependency = require("../dependencies/Harmon
 const HarmonyImportSideEffectDependency = require("../dependencies/HarmonyImportSideEffectDependency");
 const HarmonyImportSpecifierDependency = require("../dependencies/HarmonyImportSpecifierDependency");
 
+const isSideEffectFree = resolveData => {
+	// TODO: Expand check to treat `sideEffects` as a glob and compare with
+	// file.
+	const sideEffects = resolveData.descriptionFileData.sideEffects;
+	return sideEffects === false || sideEffects === "false";
+};
+
 class SideEffectsFlagPlugin {
 	apply(compiler) {
 		compiler.hooks.normalModuleFactory.tap("SideEffectsFlagPlugin", (nmf) => {
 			nmf.hooks.module.tap("SideEffectsFlagPlugin", (module, data) => {
 				const resolveData = data.resourceResolveData;
 				if(resolveData && resolveData.descriptionFileData && resolveData.relativePath) {
-					const sideEffects = resolveData.descriptionFileData.sideEffects;
-					const isSideEffectFree = sideEffects === false; // TODO allow more complex expressions
-					if(isSideEffectFree) {
-						module.factoryMeta.sideEffectFree = true;
-					}
+					module.factoryMeta.sideEffectFree = isSideEffectFree(resolveData);
 				}
 
 				return module;

--- a/test/configCases/side-effects/side-effects-selector/index.js
+++ b/test/configCases/side-effects/side-effects-selector/index.js
@@ -1,0 +1,11 @@
+import { log as plog } from "pmodule/tracker";
+import { log as plog2 } from "pmodule2/tracker";
+import p from "pmodule";
+import p2 from "pmodule2";
+
+it("should understand variations of `false`", function() {
+	p.should.be.eql("def");
+	p2.should.be.eql("def");
+	plog.should.be.eql(["index.js"]);
+	plog2.should.be.eql(["index.js"]);
+});

--- a/test/configCases/side-effects/side-effects-selector/node_modules/pmodule/a.js
+++ b/test/configCases/side-effects/side-effects-selector/node_modules/pmodule/a.js
@@ -1,0 +1,8 @@
+var a = "a";
+var b = "b";
+var c = "c";
+
+export { a, b, c };
+
+import { track } from "./tracker";
+track("a.js");

--- a/test/configCases/side-effects/side-effects-selector/node_modules/pmodule/b.js
+++ b/test/configCases/side-effects/side-effects-selector/node_modules/pmodule/b.js
@@ -1,0 +1,8 @@
+var x = "x";
+var y = "y";
+
+export { x, y };
+export { z } from "./c";
+
+import { track } from "./tracker";
+track("b.js");

--- a/test/configCases/side-effects/side-effects-selector/node_modules/pmodule/c.js
+++ b/test/configCases/side-effects/side-effects-selector/node_modules/pmodule/c.js
@@ -1,0 +1,6 @@
+var z = "z";
+
+export { z };
+
+import { track } from "./tracker";
+track("c.js");

--- a/test/configCases/side-effects/side-effects-selector/node_modules/pmodule/index.js
+++ b/test/configCases/side-effects/side-effects-selector/node_modules/pmodule/index.js
@@ -1,0 +1,7 @@
+export * from "./a";
+export { x, y, z } from "./b";
+
+import { track } from "./tracker";
+track("index.js");
+
+export default "def";

--- a/test/configCases/side-effects/side-effects-selector/node_modules/pmodule/package.json
+++ b/test/configCases/side-effects/side-effects-selector/node_modules/pmodule/package.json
@@ -1,0 +1,3 @@
+{
+    "sideEffects": false
+}

--- a/test/configCases/side-effects/side-effects-selector/node_modules/pmodule/tracker.js
+++ b/test/configCases/side-effects/side-effects-selector/node_modules/pmodule/tracker.js
@@ -1,0 +1,10 @@
+export function track(file) {
+	log.push(file);
+	log.sort();
+}
+
+export var log = [];
+
+export function reset() {
+	log.length = 0;
+}

--- a/test/configCases/side-effects/side-effects-selector/node_modules/pmodule2/a.js
+++ b/test/configCases/side-effects/side-effects-selector/node_modules/pmodule2/a.js
@@ -1,0 +1,8 @@
+var a = "a";
+var b = "b";
+var c = "c";
+
+export { a, b, c };
+
+import { track } from "./tracker";
+track("a.js");

--- a/test/configCases/side-effects/side-effects-selector/node_modules/pmodule2/b.js
+++ b/test/configCases/side-effects/side-effects-selector/node_modules/pmodule2/b.js
@@ -1,0 +1,8 @@
+var x = "x";
+var y = "y";
+
+export { x, y };
+export { z } from "./c";
+
+import { track } from "./tracker";
+track("b.js");

--- a/test/configCases/side-effects/side-effects-selector/node_modules/pmodule2/c.js
+++ b/test/configCases/side-effects/side-effects-selector/node_modules/pmodule2/c.js
@@ -1,0 +1,6 @@
+var z = "z";
+
+export { z };
+
+import { track } from "./tracker";
+track("c.js");

--- a/test/configCases/side-effects/side-effects-selector/node_modules/pmodule2/index.js
+++ b/test/configCases/side-effects/side-effects-selector/node_modules/pmodule2/index.js
@@ -1,0 +1,7 @@
+export * from "./a";
+export { x, y, z } from "./b";
+
+import { track } from "./tracker";
+track("index.js");
+
+export default "def";

--- a/test/configCases/side-effects/side-effects-selector/node_modules/pmodule2/package.json
+++ b/test/configCases/side-effects/side-effects-selector/node_modules/pmodule2/package.json
@@ -1,0 +1,3 @@
+{
+    "sideEffects": "false"
+}

--- a/test/configCases/side-effects/side-effects-selector/node_modules/pmodule2/tracker.js
+++ b/test/configCases/side-effects/side-effects-selector/node_modules/pmodule2/tracker.js
@@ -1,0 +1,10 @@
+export function track(file) {
+	log.push(file);
+	log.sort();
+}
+
+export var log = [];
+
+export function reset() {
+	log.length = 0;
+}

--- a/test/configCases/side-effects/side-effects-selector/webpack.config.js
+++ b/test/configCases/side-effects/side-effects-selector/webpack.config.js
@@ -1,0 +1,14 @@
+const path = require("path");
+module.exports = {
+	mode: "production",
+	module: {
+		rules: [
+			{
+				test: path.resolve(__dirname, "node_modules/pmodule")
+			},
+			{
+				test: path.resolve(__dirname, "node_modules/pmodule2")
+			}
+		]
+	}
+};


### PR DESCRIPTION
This treats `"false"` and `false` equally and sets up a point to expand
the check to support globs.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This fixes the first part of #6074, treating `false` and `"false"` equally.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes.

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

N/A - This is a fallback to handle users mistakenly using the wrong value.  It should not be advertised.  Subsequent changes, handling globs, will require docs changes.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

#6074 

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

This is my first commit to this repo, so please feel free to beat me up.  ;)