### PR TITLE
Convert from using null => undefined in plugin.

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const Trace = require("trace-event").Tracer;
-let inspector = null;
+let inspector = undefined;
 
 try {
 	inspector = require("inspector"); // eslint-disable-line node/no-missing-require
@@ -10,7 +10,7 @@ try {
 
 class Profiler {
 	constructor(inspector) {
-		this.session = null;
+		this.session = undefined;
 		this.inspector = inspector;
 	}
 
@@ -27,7 +27,7 @@ class Profiler {
 			this.session = new inspector.Session();
 			this.session.connect();
 		} catch(_) {
-			this.session = null;
+			this.session = undefined;
 			return Promise.resolve();
 		}
 
@@ -44,8 +44,8 @@ class Profiler {
 		if(this.hasSession()) {
 			return new Promise((res, rej) => {
 				return this.session.post(method, params, (err, params) => {
-					if(err !== undefined) {
-						rej(null);
+					if(err !== null) {
+						rej(err);
 					} else {
 						res(params);
 					}
@@ -133,7 +133,7 @@ class ProfilingPlugin {
 	}
 
 	apply(compiler) {
-		const tracer = createTrace();
+		const tracer = createTrace(this.outPath);
 		tracer.profiler.startProfiling();
 
 		// Compiler Hooks


### PR DESCRIPTION
Make sure to pass the custom dump path to the tracer when a user passes a custom outPath.