### PR TITLE
Fix typo in NoModeWarning.js

### DIFF
--- a/examples/dll-app-and-vendor/0-vendor/README.md
+++ b/examples/dll-app-and-vendor/0-vendor/README.md
@@ -2,7 +2,7 @@ This is the vendor build part.
 
 It's built separatly from the app part. The vendors dll is only built when vendors has changed and not while the normal development cycle.
 
-The DllPlugin in combination with the `output.library` option exposes the internal require function as global variable in the target enviroment.
+The DllPlugin in combination with the `output.library` option exposes the internal require function as global variable in the target environment.
 
 A manifest is creates which includes mappings from module names to internal ids.
 

--- a/examples/dll-app-and-vendor/0-vendor/template.md
+++ b/examples/dll-app-and-vendor/0-vendor/template.md
@@ -2,7 +2,7 @@ This is the vendor build part.
 
 It's built separatly from the app part. The vendors dll is only built when vendors has changed and not while the normal development cycle.
 
-The DllPlugin in combination with the `output.library` option exposes the internal require function as global variable in the target enviroment.
+The DllPlugin in combination with the `output.library` option exposes the internal require function as global variable in the target environment.
 
 A manifest is creates which includes mappings from module names to internal ids.
 

--- a/lib/NoModeWarning.js
+++ b/lib/NoModeWarning.js
@@ -13,7 +13,7 @@ module.exports = class NoModeWarning extends WebpackError {
 		this.name = "NoModeWarning";
 		this.message = "configuration\n" +
 			"The 'mode' option has not been set. " +
-			"Set 'mode' option to 'development' or 'production' to enable defaults for this enviroment. ";
+			"Set 'mode' option to 'development' or 'production' to enable defaults for this environment. ";
 
 		Error.captureStackTrace(this, this.constructor);
 	}

--- a/test/statsCases/no-emit-on-errors-plugin-with-child-error/expected.txt
+++ b/test/statsCases/no-emit-on-errors-plugin-with-child-error/expected.txt
@@ -1,4 +1,4 @@
-Hash: 2e82f0bf277419f24e02
+Hash: 20df5b67d3d2e479d4ec
 Time: Xms
     Asset     Size  Chunks  Chunk Names
  child.js  2.6 KiB          

--- a/test/statsCases/no-emit-on-errors-plugin-with-child-error/expected.txt
+++ b/test/statsCases/no-emit-on-errors-plugin-with-child-error/expected.txt
@@ -7,7 +7,7 @@ Entrypoint main = bundle.js
    [0] ./index.js 0 bytes {0} [built]
 
 WARNING in configuration
-The 'mode' option has not been set. Set 'mode' option to 'development' or 'production' to enable defaults for this enviroment. 
+The 'mode' option has not been set. Set 'mode' option to 'development' or 'production' to enable defaults for this environment. 
 Child child:
        Asset     Size  Chunks  Chunk Names
     child.js  2.6 KiB       0  child


### PR DESCRIPTION
So hours later I'm no closer to figuring out why ts-loader is hanging with webpack 4 alpha 4 post `after-compile`. :sob:

But I found a typo!  Small victories :smile:

**What kind of change does this PR introduce?**

Fixes typo.

**Did you add tests for your changes?**

No - but I don't think there's a test that covers the typo.

**Does this PR introduce a breaking change?**

Really kinda doubt it.

**Other information**

Wish `ts-loader` worked with webpack 4.  Huh.  Bygones