### PR TITLE
Disable System.import parser plugin by default

### DIFF
--- a/lib/dependencies/ImportParserPlugin.js
+++ b/lib/dependencies/ImportParserPlugin.js
@@ -17,8 +17,7 @@ class ImportParserPlugin {
 	}
 
 	apply(parser) {
-		const options = this.options;
-		const handler = (expr) => {
+		parser.hooks.importCall.tap("ImportParserPlugin", expr => {
 			if(expr.arguments.length !== 1)
 				throw new Error("Incorrect number of arguments provided to 'import(module: string) -> Promise'.");
 
@@ -84,7 +83,7 @@ class ImportParserPlugin {
 				if(mode === "weak") {
 					mode = "async-weak";
 				}
-				const dep = ContextDependencyHelpers.create(ImportContextDependency, expr.range, param, expr, options, {
+				const dep = ContextDependencyHelpers.create(ImportContextDependency, expr.range, param, expr, this.options, {
 					chunkName,
 					include,
 					exclude,
@@ -97,10 +96,7 @@ class ImportParserPlugin {
 				parser.state.current.addDependency(dep);
 				return true;
 			}
-		};
-
-		parser.hooks.call.for("System.import").tap("ImportParserPlugin", handler);
-		parser.hooks.importCall.tap("ImportParserPlugin", handler);
+		});
 	}
 }
 module.exports = ImportParserPlugin;

--- a/lib/dependencies/SystemPlugin.js
+++ b/lib/dependencies/SystemPlugin.js
@@ -3,7 +3,9 @@
 	Author Tobias Koppers @sokra
 */
 "use strict";
+
 const ParserHelpers = require("../ParserHelpers");
+const WebpackError = require("../WebpackError");
 
 class SystemPlugin {
 	constructor(options) {
@@ -17,6 +19,8 @@ class SystemPlugin {
 			const handler = (parser, parserOptions) => {
 				if(typeof parserOptions.system !== "undefined" && !parserOptions.system)
 					return;
+
+				const shouldWarn = typeof parserOptions.system === "undefined";
 
 				const setNotSupported = name => {
 					parser.hooks.evaluateTypeof.for(name).tap("SystemPlugin", ParserHelpers.evaluateToString("undefined"));
@@ -39,6 +43,14 @@ class SystemPlugin {
 						parser.state.module.context, require.resolve("../../buildin/system.js"));
 					return ParserHelpers.addParsedVariableToModule(parser, "System", systemPolyfillRequire);
 				});
+
+				parser.hooks.call.for("System.import").tap("SystemPlugin", expr => {
+					if(shouldWarn) {
+						parser.state.module.warnings.push(new SystemImportDeprecationWarning(parser.state.module, expr.loc));
+					}
+
+					return parser.hooks.importCall.call(expr);
+				});
 			};
 
 			normalModuleFactory.hooks.parser.for("javascript/auto").tap("SystemPlugin", handler);
@@ -46,4 +58,20 @@ class SystemPlugin {
 		});
 	}
 }
+
+class SystemImportDeprecationWarning extends WebpackError {
+	constructor(module, loc) {
+		super();
+
+		this.name = "SystemImportDeprecationWarning";
+		this.message = "System.import() is deprecated and will be removed soon. Use import() instead.\n" +
+			"For more info visit https://webpack.js.org/guides/code-splitting/";
+
+		this.origin = this.module = module;
+		this.originLoc = loc;
+
+		Error.captureStackTrace(this, this.constructor);
+	}
+}
+
 module.exports = SystemPlugin;

--- a/lib/node/NodeMainTemplatePlugin.js
+++ b/lib/node/NodeMainTemplatePlugin.js
@@ -36,7 +36,7 @@ module.exports = class NodeMainTemplatePlugin {
 					`${mainTemplate.requireFn}.oe = function(err) {`,
 					Template.indent([
 						"process.nextTick(function() {",
-						Template.indent("throw err; // catch this error by using System.import().catch()"),
+						Template.indent("throw err; // catch this error by using import().catch()"),
 						"});"
 					]),
 					"};"

--- a/test/Parser.unittest.js
+++ b/test/Parser.unittest.js
@@ -486,8 +486,8 @@ describe("Parser", () => {
 						param: "y"
 					}
 				],
-				"System.import": [
-					"async function x() { const y = await System.import('z'); }", {
+				"import": [
+					"async function x() { const y = await import('z'); }", {
 						param: "z"
 					}
 				]
@@ -498,7 +498,7 @@ describe("Parser", () => {
 				const param = parser.evaluateExpression(expr.arguments[0]);
 				parser.state.param = param.string;
 			});
-			parser.hooks.call.tap("System.import", "ParserTest", (expr) => {
+			parser.hooks.importCall.tap("ParserTest", (expr) => {
 				const param = parser.evaluateExpression(expr.arguments[0]);
 				parser.state.param = param.string;
 			});

--- a/test/browsertest/lib/index.web.js
+++ b/test/browsertest/lib/index.web.js
@@ -90,12 +90,12 @@ describe("main", function() {
 		it("should be able to handle chunk loading errors and try again", function(done) {
 			var old = __webpack_public_path__;
 			__webpack_public_path__ += "wrong/";
-			System.import("./three").then(function() {
+			import("./three").then(function() {
 				done(new Error("Chunk shouldn't be loaded"));
 			}).catch(function(err) {
 				err.should.be.instanceOf(Error);
 				__webpack_public_path__ = old;
-				System.import("./three").then(function(three) {
+				import("./three").then(function(three) {
 					three.should.be.eql(3);
 					done();
 				}).catch(function(err) {

--- a/test/cases/chunks/import-context/index.js
+++ b/test/cases/chunks/import-context/index.js
@@ -31,15 +31,3 @@ it("should be able to use expressions in import", function(done) {
 	}
 	testCase(load, done);
 });
-
-it("should be able to use expressions in System.import", function(done) {
-	function load(name, expected, callback) {
-		System.import("./dir2/" + name).then(function(result) {
-			result.should.be.eql({ default: expected });
-			callback();
-		}).catch(function(err) {
-			done(err);
-		});
-	}
-	testCase(load, done);
-});

--- a/test/cases/chunks/import/index.js
+++ b/test/cases/chunks/import/index.js
@@ -6,12 +6,3 @@ it("should be able to use import", function(done) {
 		done(err);
 	});
 });
-
-it("should be able to use System.import", function(done) {
-	System.import("./two").then(function(two) {
-		two.should.be.eql({ default: 2 });
-		done();
-	}).catch(function(err) {
-		done(err);
-	});
-});

--- a/test/cases/parsing/typeof/index.js
+++ b/test/cases/parsing/typeof/index.js
@@ -29,13 +29,6 @@ it("should answer typeof require.ensure correctly", function() {
 it("should answer typeof require.resolve correctly", function() {
 	(typeof require.resolve).should.be.eql("function");
 });
-it("should answer typeof System correctly", function() {
-	(typeof System).should.be.eql("object");
-});
-it("should answer typeof System.import correctly", function() {
-	(typeof System.import).should.be.eql("function");
-});
-
 
 it("should not parse filtered stuff", function() {
 	if(typeof require != "function") require("fail");
@@ -50,7 +43,6 @@ it("should not parse filtered stuff", function() {
 	if(typeof module != "object") module = require("fail");
 	if(typeof exports == "undefined") exports = require("fail");
 	if(typeof System !== "object") exports = require("fail");
-	if(typeof System.import !== "function") exports = require("fail");
 	if(typeof require.include !== "function") require.include("fail");
 	if(typeof require.ensure !== "function") require.ensure(["fail"], function(){});
 });

--- a/test/configCases/parsing/system.import/index.js
+++ b/test/configCases/parsing/system.import/index.js
@@ -1,0 +1,36 @@
+it("should answer typeof System correctly", () => {
+	if(__SYSTEM__ === false) {
+		(typeof System).should.be.eql("undefined");
+	} else {
+		(typeof System).should.be.eql("object");
+	}
+});
+
+it("should answer typeof System.import correctly", () => {
+	if(__SYSTEM__ === false) {
+		(() => {
+			typeof System.import;
+		}).should.throw();
+	} else {
+		(typeof System.import).should.be.eql("function");
+	}
+});
+
+it("should be able to use System.import()", done => {
+	try {
+		System.import("./module").then(mod => {
+			if(__SYSTEM__ === false) {
+				done(new Error("System.import should not be parsed"));
+			} else {
+				mod.should.be.eql({ default: "ok" });
+				done();
+			}
+		});
+	} catch(e) {
+		if(__SYSTEM__ === false) {
+			done();
+		} else {
+			done(e);
+		}
+	}
+});

--- a/test/configCases/parsing/system.import/module.js
+++ b/test/configCases/parsing/system.import/module.js
@@ -1,0 +1,1 @@
+export default "ok";

--- a/test/configCases/parsing/system.import/warnings.js
+++ b/test/configCases/parsing/system.import/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[/system_undef/, /System\.import\(\) is deprecated/]
+];

--- a/test/configCases/parsing/system.import/webpack.config.js
+++ b/test/configCases/parsing/system.import/webpack.config.js
@@ -1,0 +1,29 @@
+const webpack = require("../../../../");
+
+function createConfig(system) {
+	const systemString = "" + system;
+	return {
+		name: `system_${systemString}`,
+		module: {
+			rules: [
+				{
+					test: /\.js$/,
+					parser: {
+						system
+					}
+				}
+			]
+		},
+		plugins: [
+			new webpack.DefinePlugin({
+				__SYSTEM__: systemString
+			})
+		]
+	};
+}
+
+module.exports = [
+	createConfig(undefined),
+	createConfig(true),
+	createConfig(false)
+];

--- a/test/configCases/target/node-dynamic-import/index.js
+++ b/test/configCases/target/node-dynamic-import/index.js
@@ -38,9 +38,9 @@ it("should be able to use expressions in lazy-once import", function(done) {
 	testCase(load, done);
 });
 
-it("should be able to use expressions in System.import", function(done) {
+it("should be able to use expressions in import", function(done) {
 	function load(name, expected, callback) {
-		System.import("./dir2/" + name).then((result) => {
+		import("./dir2/" + name).then((result) => {
 			result.should.be.eql({ default: expected });
 			callback();
 		}).catch((err) => {
@@ -62,13 +62,3 @@ it("should be able to use import", function(done) {
 		done(err);
 	});
 });
-
-it("should be able to use System.import", function(done) {
-	System.import("./two").then((two) => {
-		two.should.be.eql({ default: 2 });
-		done();
-	}).catch(function(err) {
-		done(err);
-	});
-});
-

--- a/test/hotCases/chunks/accept-system-import/index.js
+++ b/test/hotCases/chunks/accept-system-import/index.js
@@ -1,13 +1,13 @@
 it("should import a changed chunk", function(done) {
-	System.import("./chunk").then(function(chunk) {
+	import("./chunk").then(function(chunk) {
 		chunk.value.should.be.eql(1);
-		System.import("./chunk2").then(function(chunk2) {
+		import("./chunk2").then(function(chunk2) {
 			chunk2.value.should.be.eql(1);
 			NEXT(require("../../update")(done));
 			module.hot.accept(["./chunk", "./chunk2"], function() {
-				System.import("./chunk").then(function(chunk) {
+				import("./chunk").then(function(chunk) {
 					chunk.value.should.be.eql(2);
-					System.import("./chunk2").then(function(chunk2) {
+					import("./chunk2").then(function(chunk2) {
 						chunk2.value.should.be.eql(2);
 						done();
 					}).catch(done);

--- a/test/hotCases/chunks/dynamic-system-import/index.js
+++ b/test/hotCases/chunks/dynamic-system-import/index.js
@@ -1,6 +1,6 @@
 it("should import a changed chunk (dynamic import)", function(done) {
 	function load(name) {
-		return System.import("./chunk" + name);
+		return import("./chunk" + name);
 	}
 	load(1).then(function(chunk) {
 		chunk.value.should.be.eql(1);

--- a/test/hotCases/chunks/system-import/index.js
+++ b/test/hotCases/chunks/system-import/index.js
@@ -1,5 +1,5 @@
 it("should import a changed chunk", function(done) {
-	System.import("./chunk").then(function(chunk) {
+	import("./chunk").then(function(chunk) {
 		chunk.value.should.be.eql(1);
 		chunk.value2.should.be.eql(3);
 		chunk.counter.should.be.eql(0);
@@ -7,7 +7,7 @@ it("should import a changed chunk", function(done) {
 			chunk.value.should.be.eql(2);
 			chunk.value2.should.be.eql(4);
 			chunk.counter.should.be.eql(1);
-			System.import("./chunk2").then(function(chunk2) {
+			import("./chunk2").then(function(chunk2) {
 				chunk2.value.should.be.eql(2);
 				chunk2.value2.should.be.eql(4);
 				chunk2.counter.should.be.eql(0);

--- a/test/hotCases/runtime/dispose-removed-chunk/module.js
+++ b/test/hotCases/runtime/dispose-removed-chunk/module.js
@@ -1,5 +1,5 @@
-export default System.import("./a");
+export default import("./a");
 ---
-export default System.import("./b");
+export default import("./b");
 ---
-export default System.import("./a");
+export default import("./a");


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

yes

**If relevant, link to documentation update:**

TODO since the parser options are updated.

**Summary**

`System.import` is deprecated since version [2.1.0-beta.28](https://github.com/webpack/webpack/releases/tag/v2.1.0-beta.28). ~~This PR disables `System.import` by default. Previously its support was opt-in. In order to enable it, the parser option `system` must be enabled:~~

This PR introduce a new warning if `System.import()` is used. The plugin can be toggled using a `parser` option:

```js
module: {
  rules: [
    {
      test: /\.js$/,
      parser: {
        system: true // no warning
      }
    }
  ],
}
```

Possible `system` values:

- `default`: Consider `System.import()` as `import()`. Emit a warning if `System.import()` is used.
- `true`: Consider `System.import()` as `import()`. No warning.
- `false`: `System.import()` is not intercepted. Using it most like triggers a `TypeError`

**Does this PR introduce a breaking change?**

yes (new warning)

**Other information**

cc @TheLarkInn @hansl @filipesilva