### PR TITLE
Add "custom-progress" hook for ProgressPlugin

### DIFF
--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -130,6 +130,9 @@ class ProgressPlugin {
 			compiler.plugin("done", () => {
 				handler(1, "");
 			});
+			compiler.plugin("custom-progress", (percentage, msg) => {
+				handler(percentage, msg);
+			});
 		}
 
 		let lineCaretPosition = 0,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature

**Did you add tests for your changes?**

I couldn't find any tests for ProgressPlugin; if there's a good place to add tests, let me know!

**If relevant, link to documentation update:**

N/A

**Summary**

This allows plugins to pass a custom progress percentage and message to webpack's ProgressPlugin, e.g.
`compiler.applyPlugins("custom-progress", 0.98, "Uploading")`

This is useful for any plugins which perform long-running actions, such as uploading assets after webpack emits them.

**Does this PR introduce a breaking change?**

No

**Other information**

I'm not settled on the name `"custom-progress"`. Maybe `"progress"` is simpler?