### PR TITLE
Feature: info-verbosity option validation using json schema

### DIFF
--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1821,6 +1821,14 @@
         }
       },
       "type": "object"
+    },
+    "info-verbosity": {
+      "description": "Controls the output of lifecycle messaging e.g. Started watching files... (verbose, info, none)",
+      "enum": [
+        "none",
+        "info",
+        "verbose"
+      ]
     }
   },
   "type": "object"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Validation for `info-verbosity` option which is being added in webpack/webpack-cli#200 pull request.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
There is a test in webpack-cli, @sokra do i need to add two additional tests under webpack repository (e.g. with invalid and valid info-verbosity)?

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
TBD after webpack/webpack-cli#200 is in
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
We want to be sure that `info-verbosity` is set within enum range.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
