### PR TITLE
Remove deprecated apply call

### DIFF
--- a/test/statsCases/no-emit-on-errors-plugin-with-child-error/TestChildCompilationFailurePlugin.js
+++ b/test/statsCases/no-emit-on-errors-plugin-with-child-error/TestChildCompilationFailurePlugin.js
@@ -18,7 +18,7 @@ module.exports = class TestChildCompilationFailurePlugin {
 			child.hooks.compilation.tap("TestChildCompilationFailurePlugin", childCompilation => {
 				childCompilation.errors.push(new Error("forced error"));
 			});
-			child.apply(new SingleEntryPlugin(compiler.options.context, compiler.options.entry, "child"));
+			new SingleEntryPlugin(compiler.options.context, compiler.options.entry, "child").apply(child);
 			child.runAsChild(cb);
 		});
 	}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

n/a

**Summary**

Don't use `Tapable#apply`.

**Does this PR introduce a breaking change?**

no
