### PR TITLE
Use for-of loops instead of forEach

### DIFF
--- a/lib/BannerPlugin.js
+++ b/lib/BannerPlugin.js
@@ -35,44 +35,50 @@ class BannerPlugin {
 	apply(compiler) {
 		const options = this.options;
 		const banner = this.banner;
+		const matchObject = ModuleFilenameHelpers.matchObject.bind(undefined, options);
 
 		compiler.hooks.compilation.tap("BannerPlugin", (compilation) => {
 			compilation.hooks.optimizeChunkAssets.tap("BannerPlugin", (chunks) => {
-				chunks.forEach((chunk) => {
-					if(options.entryOnly && !chunk.canBeInitial()) return;
-					chunk.files
-						.filter(ModuleFilenameHelpers.matchObject.bind(undefined, options))
-						.forEach((file) => {
-							let basename;
-							let query = "";
-							let filename = file;
-							const hash = compilation.hash;
-							const querySplit = filename.indexOf("?");
+				for(const chunk of chunks) {
+					if(options.entryOnly && !chunk.canBeInitial()) {
+						continue;
+					}
 
-							if(querySplit >= 0) {
-								query = filename.substr(querySplit);
-								filename = filename.substr(0, querySplit);
-							}
+					for(const file of chunk.files) {
+						if(!matchObject(file)) {
+							continue;
+						}
 
-							const lastSlashIndex = filename.lastIndexOf("/");
+						let basename;
+						let query = "";
+						let filename = file;
+						const hash = compilation.hash;
+						const querySplit = filename.indexOf("?");
 
-							if(lastSlashIndex === -1) {
-								basename = filename;
-							} else {
-								basename = filename.substr(lastSlashIndex + 1);
-							}
+						if(querySplit >= 0) {
+							query = filename.substr(querySplit);
+							filename = filename.substr(0, querySplit);
+						}
 
-							const comment = compilation.getPath(banner, {
-								hash,
-								chunk,
-								filename,
-								basename,
-								query,
-							});
+						const lastSlashIndex = filename.lastIndexOf("/");
 
-							return compilation.assets[file] = new ConcatSource(comment, "\n", compilation.assets[file]);
+						if(lastSlashIndex === -1) {
+							basename = filename;
+						} else {
+							basename = filename.substr(lastSlashIndex + 1);
+						}
+
+						const comment = compilation.getPath(banner, {
+							hash,
+							chunk,
+							filename,
+							basename,
+							query,
 						});
-				});
+
+						compilation.assets[file] = new ConcatSource(comment, "\n", compilation.assets[file]);
+					}
+				}
 			});
 		});
 	}

--- a/lib/CachePlugin.js
+++ b/lib/CachePlugin.js
@@ -58,9 +58,9 @@ class CachePlugin {
 					});
 				}, err => {
 					if(err) return callback(err);
-					Object.keys(fileTs).forEach(key => {
+					for(const key of Object.keys(fileTs)) {
 						fileTs[key] += this.FS_ACCURENCY;
-					});
+					}
 					callback();
 				});
 			});

--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -26,9 +26,9 @@ const getFrozenArray = set => Object.freeze(Array.from(set));
 const getModulesIdent = set => {
 	set.sort();
 	let str = "";
-	set.forEach(m => {
+	for(const m of set) {
 		str += m.identifier() + "#";
-	});
+	}
 	return str;
 };
 
@@ -258,7 +258,9 @@ class Chunk {
 		hash.update(`${this.id} `);
 		hash.update(this.ids ? this.ids.join(",") : "");
 		hash.update(`${this.name || ""} `);
-		this._modules.forEach(m => hash.update(m.hash));
+		for(const m of this._modules) {
+			hash.update(m.hash);
+		}
 	}
 
 	canBeIntegrated(otherChunk) {

--- a/lib/ChunkGroup.js
+++ b/lib/ChunkGroup.js
@@ -231,7 +231,7 @@ class ChunkGroup {
 			parentChunkGroup._children.delete(this);
 
 			// cleanup "sub chunks"
-			this._children.forEach(chunkGroup => {
+			for(const chunkGroup of this._children) {
 				/**
 				 * remove this chunk as "intermediary" and connect
 				 * it "sub chunks" and parents directly
@@ -240,7 +240,7 @@ class ChunkGroup {
 				chunkGroup.addParent(parentChunkGroup);
 				// add "sub chunk" to parent
 				parentChunkGroup.addChild(chunkGroup);
-			});
+			}
 		}
 
 		/**

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -270,8 +270,8 @@ class Compilation extends Tapable {
 				cacheModule.disconnect();
 				this._modules.set(identifier, cacheModule);
 				this.modules.push(cacheModule);
-				cacheModule.errors.forEach(err => this.errors.push(err));
-				cacheModule.warnings.forEach(err => this.warnings.push(err));
+				for(const err of cacheModule.errors) this.errors.push(err);
+				for(const err of cacheModule.warnings) this.warnings.push(err);
 				return {
 					module: cacheModule,
 					issuer: true,
@@ -323,7 +323,7 @@ class Compilation extends Tapable {
 
 		const callback = err => {
 			this._buildingModules.delete(module);
-			callbackList.forEach(cb => cb(err));
+			for(const cb of callbackList) cb(err);
 		};
 
 		this.hooks.buildModule.call(module);
@@ -691,7 +691,7 @@ class Compilation extends Tapable {
 
 		const callback = err => {
 			this._rebuildingModules.delete(module);
-			callbackList.forEach(cb => cb(err));
+			for(const cb of callbackList) cb(err);
 		};
 
 		this.hooks.rebuildModule.call(module);
@@ -737,7 +737,9 @@ class Compilation extends Tapable {
 		this.namedChunkGroups.clear();
 		this.additionalChunkAssets.length = 0;
 		this.assets = {};
-		this.modules.forEach(module => module.unseal());
+		for(const module of this.modules) {
+			module.unseal();
+		}
 	}
 
 	seal(callback) {
@@ -750,7 +752,7 @@ class Compilation extends Tapable {
 
 		this.nextFreeModuleIndex = 0;
 		this.nextFreeModuleIndex2 = 0;
-		this._preparedEntrypoints.forEach(preparedEntrypoint => {
+		for(const preparedEntrypoint of this._preparedEntrypoints) {
 			const module = preparedEntrypoint.module;
 			const name = preparedEntrypoint.name;
 			const chunk = this.addChunk(name);
@@ -769,7 +771,7 @@ class Compilation extends Tapable {
 
 			this.assignIndex(module);
 			this.assignDepth(module);
-		});
+		}
 		this.processDependenciesBlocksForChunkGroups(this.chunkGroups);
 		this.sortModules(this.modules);
 		this.hooks.optimize.call();
@@ -1280,7 +1282,9 @@ class Compilation extends Tapable {
 				return;
 			}
 			if(d.module.removeReason(module, d)) {
-				d.module.forEachChunk(chunk => this.patchChunksAfterReasonRemoval(d.module, chunk));
+				for(const chunk of d.module.chunksIterable) {
+					this.patchChunksAfterReasonRemoval(d.module, chunk);
+				}
 			}
 		};
 
@@ -1511,11 +1515,11 @@ class Compilation extends Tapable {
 				addAllToSet(this.contextDependencies, module.buildInfo.contextDependencies);
 			}
 		}
-		this.errors.forEach(error => {
+		for(const error of this.errors) {
 			if(typeof error.missing === "object" && error.missing && error.missing[Symbol.iterator]) {
 				addAllToSet(this.missingDependencies, error.missing);
 			}
-		});
+		}
 		this.fileDependencies.sort();
 		this.contextDependencies.sort();
 		this.missingDependencies.sort();
@@ -1531,10 +1535,10 @@ class Compilation extends Tapable {
 			hash.update(outputOptions.hashSalt);
 		this.mainTemplate.updateHash(hash);
 		this.chunkTemplate.updateHash(hash);
-		Object.keys(this.moduleTemplates).sort().forEach(key => this.moduleTemplates[key].updateHash(hash));
-		this.children.forEach(child => hash.update(child.hash));
-		this.warnings.forEach(warning => hash.update(`${warning.message}`));
-		this.errors.forEach(error => hash.update(`${error.message}`));
+		for(const key of Object.keys(this.moduleTemplates).sort()) this.moduleTemplates[key].updateHash(hash);
+		for(const child of this.children) hash.update(child.hash);
+		for(const warning of this.warnings) hash.update(`${warning.message}`);
+		for(const error of this.errors) hash.update(`${error.message}`);
 		const modules = this.modules;
 		for(let i = 0; i < modules.length; i++) {
 			const module = modules[i];
@@ -1593,11 +1597,11 @@ class Compilation extends Tapable {
 		for(let i = 0; i < this.modules.length; i++) {
 			const module = this.modules[i];
 			if(module.buildInfo.assets) {
-				Object.keys(module.buildInfo.assets).forEach((assetName) => {
+				for(const assetName of Object.keys(module.buildInfo.assets)) {
 					const fileName = this.getPath(assetName);
 					this.assets[fileName] = module.buildInfo.assets[assetName];
 					this.hooks.moduleAsset.call(module, fileName);
-				});
+				}
 			}
 		}
 	}

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -4,6 +4,7 @@
 */
 "use strict";
 
+const asyncLib = require("async");
 const path = require("path");
 const util = require("util");
 const Tapable = require("tapable").Tapable;
@@ -246,9 +247,9 @@ class Compiler extends Tapable {
 			if(err) return callback(err);
 
 			this.parentCompilation.children.push(compilation);
-			Object.keys(compilation.assets).forEach(name => {
+			for(const name of Object.keys(compilation.assets)) {
 				this.parentCompilation.assets[name] = compilation.assets[name];
-			});
+			}
 
 			const entries = Array.from(compilation.entrypoints.values(), ep => ep.chunks).reduce((array, chunks) => {
 				return array.concat(chunks);
@@ -269,7 +270,7 @@ class Compiler extends Tapable {
 		const emitFiles = (err) => {
 			if(err) return callback(err);
 
-			require("async").forEach(Object.keys(compilation.assets), (file, callback) => {
+			asyncLib.forEach(Object.keys(compilation.assets), (file, callback) => {
 
 				let targetFile = file;
 				const queryStringIdx = targetFile.indexOf("?");
@@ -367,7 +368,7 @@ class Compiler extends Tapable {
 	createChildCompiler(compilation, compilerName, compilerIndex, outputOptions, plugins) {
 		const childCompiler = new Compiler(this.context);
 		if(Array.isArray(plugins)) {
-			plugins.forEach(plugin => plugin.apply(childCompiler));
+			for(const plugin of plugins) plugin.apply(childCompiler);
 		}
 		for(const name in this.hooks) {
 			if(!["make", "compile", "emit", "afterEmit", "invalid", "done", "thisCompilation"].includes(name)) {

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -155,10 +155,10 @@ class ContextModule extends Module {
 			}
 
 			// enhance dependencies with meta info
-			dependencies.forEach(dep => {
+			for(const dep of dependencies) {
 				dep.loc = dep.userRequest;
 				dep.request = this.options.addon + dep.request;
-			});
+			}
 
 			if(this.options.mode === "sync" || this.options.mode === "eager") {
 
@@ -172,33 +172,36 @@ class ContextModule extends Module {
 				// and add that block to this context
 				if(dependencies.length > 0) {
 					const block = new AsyncDependenciesBlock(this.options.chunkName, this);
-					dependencies.forEach(dep => {
+					for(const dep of dependencies) {
 						block.addDependency(dep);
-					});
+					}
 					this.addBlock(block);
 				}
 
 			} else if(this.options.mode === "weak" || this.options.mode === "async-weak") {
 
 				// we mark all dependencies as weak
-				dependencies.forEach(dep => dep.weak = true);
+				for(const dep of dependencies) {
+					dep.weak = true;
+				}
 				this.dependencies = dependencies;
 
 			} else if(this.options.mode === "lazy") {
 				// if we are lazy create a new async dependency block per dependency
 				// and add all blocks to this context
-				dependencies.forEach((dep, idx) => {
+				let index = 0;
+				for(const dep of dependencies) {
 					let chunkName = this.options.chunkName;
 					if(chunkName) {
 						if(!/\[(index|request)\]/.test(chunkName))
 							chunkName += "[index]";
-						chunkName = chunkName.replace(/\[index\]/g, idx);
+						chunkName = chunkName.replace(/\[index\]/g, index++);
 						chunkName = chunkName.replace(/\[request\]/g, Template.toPath(dep.userRequest));
 					}
 					const block = new AsyncDependenciesBlock(chunkName, dep.module, dep.loc, dep.userRequest);
 					block.addDependency(dep);
 					this.addBlock(block);
-				});
+				}
 			} else {
 				callback(new Error(`Unsupported mode "${this.options.mode}" in context`));
 				return;

--- a/lib/ContextReplacementPlugin.js
+++ b/lib/ContextReplacementPlugin.js
@@ -58,10 +58,10 @@ class ContextReplacementPlugin {
 					if(typeof newContentCallback === "function") {
 						newContentCallback(result);
 					} else {
-						result.dependencies.forEach((d) => {
+						for(const d of result.dependencies) {
 							if(d.critical)
 								d.critical = false;
-						});
+						}
 					}
 				}
 				return result;
@@ -84,10 +84,10 @@ class ContextReplacementPlugin {
 							result.resource = path.resolve(origResource, result.resource);
 						}
 					} else {
-						result.dependencies.forEach((d) => {
+						for(const d of result.dependencies) {
 							if(d.critical)
 								d.critical = false;
-						});
+						}
 					}
 				}
 				return result;

--- a/lib/DependenciesBlockVariable.js
+++ b/lib/DependenciesBlockVariable.js
@@ -17,25 +17,25 @@ class DependenciesBlockVariable {
 	updateHash(hash) {
 		hash.update(this.name);
 		hash.update(this.expression);
-		this.dependencies.forEach(d => {
+		for(const d of this.dependencies) {
 			d.updateHash(hash);
-		});
+		}
 	}
 
 	expressionSource(dependencyTemplates, runtimeTemplate) {
 		const source = new ReplaceSource(new RawSource(this.expression));
-		this.dependencies.forEach(dep => {
+		for(const dep of this.dependencies) {
 			const template = dependencyTemplates.get(dep.constructor);
 			if(!template) throw new Error(`No template for dependency: ${dep.constructor.name}`);
 			template.apply(dep, source, runtimeTemplate, dependencyTemplates);
-		});
+		}
 		return source;
 	}
 
 	disconnect() {
-		this.dependencies.forEach(d => {
+		for(const d of this.dependencies) {
 			d.disconnect();
-		});
+		}
 	}
 
 	hasDependencies(filter) {

--- a/lib/EntryOptionPlugin.js
+++ b/lib/EntryOptionPlugin.js
@@ -21,7 +21,9 @@ module.exports = class EntryOptionPlugin {
 			if(typeof entry === "string" || Array.isArray(entry)) {
 				itemToPlugin(context, entry, "main").apply(compiler);
 			} else if(typeof entry === "object") {
-				Object.keys(entry).forEach(name => itemToPlugin(context, entry[name], name).apply(compiler));
+				for(const name of Object.keys(entry)) {
+					itemToPlugin(context, entry[name], name).apply(compiler);
+				}
 			} else if(typeof entry === "function") {
 				new DynamicEntryPlugin(context, entry).apply(compiler);
 			}

--- a/lib/FlagDependencyUsagePlugin.js
+++ b/lib/FlagDependencyUsagePlugin.js
@@ -5,10 +5,10 @@
 "use strict";
 
 const addToSet = (a, b) => {
-	b.forEach(item => {
+	for(const item of b) {
 		if(!a.includes(item))
 			a.push(item);
-	});
+	}
 	return a;
 };
 
@@ -50,9 +50,17 @@ class FlagDependencyUsagePlugin {
 				};
 
 				const processDependenciesBlock = (depBlock, usedExports) => {
-					depBlock.dependencies.forEach(dep => processDependency(dep));
-					depBlock.variables.forEach(variable => variable.dependencies.forEach(dep => processDependency(dep)));
-					depBlock.blocks.forEach(block => queue.push([block, usedExports]));
+					for(const dep of depBlock.dependencies) {
+						processDependency(dep);
+					}
+					for(const variable of depBlock.variables) {
+						for(const dep of variable.dependencies) {
+							processDependency(dep);
+						}
+					}
+					for(const block of depBlock.blocks) {
+						queue.push([block, usedExports]);
+					}
 				};
 
 				const processDependency = dep => {
@@ -67,14 +75,16 @@ class FlagDependencyUsagePlugin {
 					}
 				};
 
-				modules.forEach(module => module.used = false);
+				for(const module of modules) {
+					module.used = false;
+				}
 
 				const queue = [];
-				compilation.chunks.forEach(chunk => {
+				for(const chunk of compilation.chunks) {
 					if(chunk.entryModule) {
 						processModule(chunk.entryModule, true);
 					}
-				});
+				}
 
 				while(queue.length) {
 					const queueItem = queue.pop();

--- a/lib/FlagInitialModulesAsUsedPlugin.js
+++ b/lib/FlagInitialModulesAsUsedPlugin.js
@@ -12,7 +12,7 @@ class FlagInitialModulesAsUsedPlugin {
 	apply(compiler) {
 		compiler.hooks.compilation.tap("FlagInitialModulesAsUsedPlugin", (compilation) => {
 			compilation.hooks.afterOptimizeChunks.tap("FlagInitialModulesAsUsedPlugin", (chunks) => {
-				chunks.forEach((chunk) => {
+				for(const chunk of chunks) {
 					if(!chunk.isOnlyInitial()) {
 						return;
 					}
@@ -21,7 +21,7 @@ class FlagInitialModulesAsUsedPlugin {
 						module.usedExports = true;
 						module.addReason(null, null, this.explanation);
 					}
-				});
+				}
 			});
 		});
 	}

--- a/lib/FunctionModuleTemplatePlugin.js
+++ b/lib/FunctionModuleTemplatePlugin.js
@@ -50,10 +50,15 @@ class FunctionModuleTemplatePlugin {
 				else if(module.usedExports)
 					source.add(Template.toComment("all exports used") + "\n");
 				if(module.optimizationBailout) {
-					module.optimizationBailout.forEach(text => {
-						if(typeof text === "function") text = text(moduleTemplate.runtimeTemplate.requestShortener);
-						source.add(Template.toComment(`${text}`) + "\n");
-					});
+					for(const text of module.optimizationBailout) {
+						let code;
+						if(typeof text === "function") {
+							code = text(moduleTemplate.runtimeTemplate.requestShortener);
+						} else {
+							code = text;
+						}
+						source.add(Template.toComment(`${code}`) + "\n");
+					}
 				}
 				source.add(moduleSource);
 				return source;

--- a/lib/HashedModuleIdsPlugin.js
+++ b/lib/HashedModuleIdsPlugin.js
@@ -13,6 +13,7 @@ class HashedModuleIdsPlugin {
 		validateOptions(schema, options || {}, "Hashed Module Ids Plugin");
 
 		this.options = Object.assign({
+			context: null,
 			hashFunction: "md5",
 			hashDigest: "base64",
 			hashDigestLength: 4
@@ -24,7 +25,7 @@ class HashedModuleIdsPlugin {
 		compiler.hooks.compilation.tap("HashedModuleIdsPlugin", (compilation) => {
 			const usedIds = new Set();
 			compilation.hooks.beforeModuleIds.tap("HashedModuleIdsPlugin", (modules) => {
-				modules.forEach((module) => {
+				for(const module of modules) {
 					if(module.id === null && module.libIdent) {
 						const id = module.libIdent({
 							context: this.options.context || compiler.options.context
@@ -38,7 +39,7 @@ class HashedModuleIdsPlugin {
 						module.id = hashId.substr(0, len);
 						usedIds.add(module.id);
 					}
-				});
+				}
 			});
 		});
 	}

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -51,20 +51,20 @@ module.exports = class HotModuleReplacementPlugin {
 				if(records.hash === compilation.hash) return;
 				records.hash = compilation.hash;
 				records.moduleHashs = {};
-				compilation.modules.forEach(module => {
+				for(const module of compilation.modules) {
 					const identifier = module.identifier();
 					const hash = createHash(compilation.outputOptions.hashFunction);
 					module.updateHash(hash);
 					records.moduleHashs[identifier] = hash.digest("hex");
-				});
+				}
 				records.chunkHashs = {};
-				compilation.chunks.forEach(chunk => {
+				for(const chunk of compilation.chunks) {
 					records.chunkHashs[chunk.id] = chunk.hash;
-				});
+				}
 				records.chunkModuleIds = {};
-				compilation.chunks.forEach(chunk => {
+				for(const chunk of compilation.chunks) {
 					records.chunkModuleIds[chunk.id] = chunk.mapModules(m => m.id);
-				});
+				}
 			});
 			let initialPass = false;
 			let recompilation = false;
@@ -99,18 +99,18 @@ module.exports = class HotModuleReplacementPlugin {
 				const records = compilation.records;
 				if(records.hash === compilation.hash) return;
 				if(!records.moduleHashs || !records.chunkHashs || !records.chunkModuleIds) return;
-				compilation.modules.forEach(module => {
+				for(const module of compilation.modules) {
 					const identifier = module.identifier();
 					let hash = createHash(compilation.outputOptions.hashFunction);
 					module.updateHash(hash);
 					hash = hash.digest("hex");
 					module.hotUpdate = records.moduleHashs[identifier] !== hash;
-				});
+				}
 				const hotUpdateMainContent = {
 					h: compilation.hash,
 					c: {},
 				};
-				Object.keys(records.chunkHashs).forEach(chunkId => {
+				for(let chunkId of Object.keys(records.chunkHashs)) {
 					chunkId = isNaN(+chunkId) ? chunkId : +chunkId;
 					const currentChunk = compilation.chunks.find(chunk => chunk.id === chunkId);
 					if(currentChunk) {
@@ -135,7 +135,7 @@ module.exports = class HotModuleReplacementPlugin {
 					} else {
 						hotUpdateMainContent.c[chunkId] = false;
 					}
-				}, compilation);
+				}
 				const source = new RawSource(JSON.stringify(hotUpdateMainContent));
 				const filename = compilation.getPath(hotUpdateMainFilename, {
 					hash: records.hash

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -63,7 +63,7 @@ module.exports = class HotModuleReplacementPlugin {
 				}
 				records.chunkModuleIds = {};
 				for(const chunk of compilation.chunks) {
-          records.chunkModuleIds[chunk.id] = Array.from(chunk.modulesIterable, m => m.id);
+					records.chunkModuleIds[chunk.id] = Array.from(chunk.modulesIterable, m => m.id);
 				}
 			});
 			let initialPass = false;

--- a/lib/LoaderOptionsPlugin.js
+++ b/lib/LoaderOptionsPlugin.js
@@ -28,10 +28,12 @@ class LoaderOptionsPlugin {
 				if(!resource) return;
 				const i = resource.indexOf("?");
 				if(ModuleFilenameHelpers.matchObject(options, i < 0 ? resource : resource.substr(0, i))) {
-					const filterSet = new Set(["include", "exclude", "test"]);
-					Object.keys(options)
-						.filter((key) => !filterSet.has(key))
-						.forEach((key) => context[key] = options[key]);
+					for(const key of Object.keys(options)) {
+						if(key === "include" || key === "exclude" || key === "test") {
+							continue;
+						}
+						context[key] = options[key];
+					}
 				}
 			});
 		});

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -148,6 +148,7 @@ class Module extends DependenciesBlock {
 		return this.reasons.length > 0 && this.reasons.every(r => r.dependency && r.dependency.optional);
 	}
 
+	// TODO remove and replace calls with for of loop
 	forEachChunk(fn) {
 		this._chunks.forEach(fn);
 	}

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -30,25 +30,27 @@ module.exports = class MultiCompiler extends Tapable {
 		this.compilers = compilers;
 		let doneCompilers = 0;
 		let compilerStats = [];
-		this.compilers.forEach((compiler, idx) => {
+		let index = 0;
+		for(const compiler of this.compilers) {
 			let compilerDone = false;
-			compiler.hooks.done.tap("MultiCompiler", stats => {
+			const compilerIndex = index++;
+			compiler.hooks.done.tap("MultiCompiler", stats => { // eslint-disable-line no-loop-func
 				if(!compilerDone) {
 					compilerDone = true;
 					doneCompilers++;
 				}
-				compilerStats[idx] = stats;
+				compilerStats[compilerIndex] = stats;
 				if(doneCompilers === this.compilers.length) {
 					this.hooks.done.call(new MultiStats(compilerStats));
 				}
 			});
-			compiler.hooks.invalid.tap("MultiCompiler", () => {
+			compiler.hooks.invalid.tap("MultiCompiler", () => { // eslint-disable-line no-loop-func
 				if(compilerDone) {
 					compilerDone = false;
 					doneCompilers--;
 				}
 			});
-		});
+		}
 	}
 
 	get outputPath() {
@@ -72,15 +74,15 @@ module.exports = class MultiCompiler extends Tapable {
 	}
 
 	set inputFileSystem(value) {
-		this.compilers.forEach(compiler => {
+		for(const compiler of this.compilers) {
 			compiler.inputFileSystem = value;
-		});
+		}
 	}
 
 	set outputFileSystem(value) {
-		this.compilers.forEach(compiler => {
+		for(const compiler of this.compilers) {
 			compiler.outputFileSystem = value;
-		});
+		}
 	}
 
 	validateDependencies(callback) {
@@ -225,9 +227,9 @@ module.exports = class MultiCompiler extends Tapable {
 	}
 
 	purgeInputFileSystem() {
-		this.compilers.forEach((compiler) => {
+		for(const compiler of this.compilers) {
 			if(compiler.inputFileSystem && compiler.inputFileSystem.purge)
 				compiler.inputFileSystem.purge();
-		});
+		}
 	}
 };

--- a/lib/MultiModule.js
+++ b/lib/MultiModule.js
@@ -50,7 +50,8 @@ class MultiModule extends Module {
 
 	source(dependencyTemplates, runtimeTemplate) {
 		const str = [];
-		this.dependencies.forEach((dep, idx) => {
+		let idx = 0;
+		for(const dep of this.dependencies) {
 			if(dep.module) {
 				if(idx === this.dependencies.length - 1)
 					str.push("module.exports = ");
@@ -64,7 +65,8 @@ class MultiModule extends Module {
 				str.push(content);
 			}
 			str.push(";\n");
-		});
+			idx++;
+		}
 		return new RawSource(str.join(""));
 	}
 }

--- a/lib/MultiStats.js
+++ b/lib/MultiStats.js
@@ -36,10 +36,11 @@ class MultiStats {
 		});
 		const showVersion = typeof options.version === "undefined" ? jsons.every(j => j.version) : options.version !== false;
 		const showHash = typeof options.hash === "undefined" ? jsons.every(j => j.hash) : options.hash !== false;
-		jsons.forEach(j => {
-			if(showVersion)
+		if(showVersion) {
+			for(const j of jsons) {
 				delete j.version;
-		});
+			}
+		}
 		const obj = {
 			errors: jsons.reduce((arr, j) => {
 				return arr.concat(j.errors.map(msg => {

--- a/lib/MultiWatching.js
+++ b/lib/MultiWatching.js
@@ -13,19 +13,20 @@ class MultiWatching {
 	}
 
 	invalidate() {
-		this.watchings.forEach((watching) => watching.invalidate());
+		for(const watching of this.watchings) {
+			watching.invalidate();
+		}
 	}
 
 	close(callback) {
-		if(callback === undefined) callback = () => { /*do nothing*/ };
-
 		asyncLib.forEach(this.watchings, (watching, finishedCallback) => {
 			watching.close(finishedCallback);
 		}, err => {
 			this.compiler.hooks.watchClose.call();
-			callback(err);
+			if(typeof callback === "function") {
+				callback(err);
+			}
 		});
-
 	}
 }
 

--- a/lib/NamedChunksPlugin.js
+++ b/lib/NamedChunksPlugin.js
@@ -17,11 +17,11 @@ class NamedChunksPlugin {
 	apply(compiler) {
 		compiler.hooks.compilation.tap("NamedChunksPlugin", (compilation) => {
 			compilation.hooks.beforeChunkIds.tap("NamedChunksPlugin", (chunks) => {
-				chunks.forEach((chunk) => {
+				for(const chunk of chunks) {
 					if(chunk.id === null) {
 						chunk.id = this.nameResolver(chunk);
 					}
-				});
+				}
 			});
 		});
 	}

--- a/lib/NamedModulesPlugin.js
+++ b/lib/NamedModulesPlugin.js
@@ -12,13 +12,13 @@ class NamedModulesPlugin {
 	apply(compiler) {
 		compiler.hooks.compilation.tap("NamedModulesPlugin", (compilation) => {
 			compilation.hooks.beforeModuleIds.tap("NamedModulesPlugin", (modules) => {
-				modules.forEach((module) => {
+				for(const module of modules) {
 					if(module.id === null && module.libIdent) {
 						module.id = module.libIdent({
 							context: this.options.context || compiler.options.context
 						});
 					}
-				});
+				}
 			});
 		});
 	}

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -422,8 +422,9 @@ class NormalModule extends Module {
 	}
 
 	sourceBlock(block, availableVars, dependencyTemplates, source, runtimeTemplate) {
-		block.dependencies.forEach((dependency) => this.sourceDependency(
-			dependency, dependencyTemplates, source, runtimeTemplate));
+		for(const dependency of block.dependencies) {
+			this.sourceDependency(dependency, dependencyTemplates, source, runtimeTemplate);
+		}
 
 		/**
 		 * Get the variables of all blocks that we need to inject.
@@ -493,15 +494,15 @@ class NormalModule extends Module {
 			}
 		}
 
-		block.blocks.forEach((block) =>
+		for(const childBlock of block.blocks) {
 			this.sourceBlock(
-				block,
+				childBlock,
 				availableVars.concat(vars),
 				dependencyTemplates,
 				source,
 				runtimeTemplate
-			)
-		);
+			);
+		}
 	}
 
 	source(dependencyTemplates, runtimeTemplate) {

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -176,13 +176,13 @@ class NormalModuleFactory extends Tapable {
 
 				// translate option idents
 				try {
-					loaders.forEach(item => {
+					for(const item of loaders) {
 						if(typeof item.options === "string" && item.options[0] === "?") {
 							const ident = item.options.substr(1);
 							item.options = this.ruleSet.findOptionsByIdent(ident);
 							item.ident = ident;
 						}
-					});
+					}
 				} catch(e) {
 					return callback(e);
 				}
@@ -218,7 +218,7 @@ class NormalModuleFactory extends Tapable {
 				const useLoadersPost = [];
 				const useLoaders = [];
 				const useLoadersPre = [];
-				result.forEach(r => {
+				for(const r of result) {
 					if(r.type === "use") {
 						if(r.enforce === "post" && !noPrePostAutoLoaders)
 							useLoadersPost.push(r.value);
@@ -231,7 +231,7 @@ class NormalModuleFactory extends Tapable {
 					} else {
 						settings[r.type] = r.value;
 					}
-				});
+				}
 				asyncLib.parallel([
 					this.resolveRequestArray.bind(this, contextInfo, this.context, useLoadersPost, loaderResolver),
 					this.resolveRequestArray.bind(this, contextInfo, this.context, useLoaders, loaderResolver),
@@ -291,7 +291,9 @@ class NormalModuleFactory extends Tapable {
 				if(err) return callback(err);
 
 				if(module && this.cachePredicate(module)) {
-					dependencies.forEach(d => d.__NormalModuleFactoryCache = module);
+					for(const d of dependencies) {
+						d.__NormalModuleFactoryCache = module;
+					}
 				}
 
 				callback(null, module);

--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -22,13 +22,13 @@ const createDefaultHandler = profile => {
 			if(percentage < 10) {
 				msg = ` ${msg}`;
 			}
-			details.forEach(detail => {
-				if(!detail) return;
+			for(let detail of details) {
+				if(!detail) continue;
 				if(detail.length > 40) {
 					detail = `...${detail.substr(detail.length - 37)}`;
 				}
 				msg += ` ${detail}`;
-			});
+			}
 		}
 		if(profile) {
 			state = state.replace(/^\d+\/\d+\s+/, "");

--- a/lib/RecordIdsPlugin.js
+++ b/lib/RecordIdsPlugin.js
@@ -18,25 +18,25 @@ class RecordIdsPlugin {
 				if(!records.modules) records.modules = {};
 				if(!records.modules.byIdentifier) records.modules.byIdentifier = {};
 				if(!records.modules.usedIds) records.modules.usedIds = {};
-				modules.forEach(module => {
+				for(const module of modules) {
 					const identifier = portableIds ? identifierUtils.makePathsRelative(compiler.context, module.identifier(), compilation.cache) : module.identifier();
 					records.modules.byIdentifier[identifier] = module.id;
 					records.modules.usedIds[module.id] = module.id;
-				});
+				}
 			});
 			compilation.hooks.reviveModules.tap("RecordIdsPlugin", (modules, records) => {
 				if(!records.modules) return;
 				if(records.modules.byIdentifier) {
 					const usedIds = new Set();
-					modules.forEach(module => {
-						if(module.id !== null) return;
+					for(const module of modules) {
+						if(module.id !== null) continue;
 						const identifier = portableIds ? identifierUtils.makePathsRelative(compiler.context, module.identifier(), compilation.cache) : module.identifier();
 						const id = records.modules.byIdentifier[identifier];
-						if(id === undefined) return;
-						if(usedIds.has(id)) return;
+						if(id === undefined) continue;
+						if(usedIds.has(id)) continue;
 						usedIds.add(id);
 						module.id = id;
-					});
+					}
 				}
 				if(Array.isArray(records.modules.usedIds))
 					compilation.usedModuleIds = new Set(records.modules.usedIds);
@@ -71,7 +71,7 @@ class RecordIdsPlugin {
 				if(!records.chunks.byName) records.chunks.byName = {};
 				if(!records.chunks.bySource) records.chunks.bySource = {};
 				const usedIds = new Set();
-				chunks.forEach(chunk => {
+				for(const chunk of chunks) {
 					const name = chunk.name;
 					if(name) records.chunks.byName[name] = chunk.id;
 					const sources = getChunkSources(chunk);
@@ -79,25 +79,25 @@ class RecordIdsPlugin {
 						records.chunks.bySource[source] = chunk.id;
 					}
 					usedIds.add(chunk.id);
-				});
+				}
 				records.chunks.usedIds = Array.from(usedIds);
 			});
 			compilation.hooks.reviveChunks.tap("RecordIdsPlugin", (chunks, records) => {
 				if(!records.chunks) return;
 				const usedIds = new Set();
 				if(records.chunks.byName) {
-					chunks.forEach(chunk => {
-						if(chunk.id !== null) return;
-						if(!chunk.name) return;
+					for(const chunk of chunks) {
+						if(chunk.id !== null) continue;
+						if(!chunk.name) continue;
 						const id = records.chunks.byName[chunk.name];
-						if(id === undefined) return;
-						if(usedIds.has(id)) return;
+						if(id === undefined) continue;
+						if(usedIds.has(id)) continue;
 						usedIds.add(id);
 						chunk.id = id;
-					});
+					}
 				}
 				if(records.chunks.bySource) {
-					chunks.forEach(chunk => {
+					for(const chunk of chunks) {
 						const sources = getChunkSources(chunk);
 						for(const source of sources) {
 							const id = records.chunks.bySource[source];
@@ -107,7 +107,7 @@ class RecordIdsPlugin {
 							chunk.id = id;
 							break;
 						}
-					});
+					}
 				}
 				if(Array.isArray(records.chunks.usedIds))
 					compilation.usedChunkIds = new Set(records.chunks.usedIds);

--- a/lib/RuleSet.js
+++ b/lib/RuleSet.js
@@ -231,16 +231,16 @@ module.exports = class RuleSet {
 		const keys = Object.keys(rule).filter((key) => {
 			return !["resource", "resourceQuery", "compiler", "test", "include", "exclude", "issuer", "loader", "options", "query", "loaders", "use", "rules", "oneOf"].includes(key);
 		});
-		keys.forEach((key) => {
+		for(const key of keys) {
 			newRule[key] = rule[key];
-		});
+		}
 
 		if(Array.isArray(newRule.use)) {
-			newRule.use.forEach((item) => {
+			for(const item of newRule.use) {
 				if(item.ident) {
 					refs[item.ident] = item.options;
 				}
-			});
+			}
 		}
 
 		return newRule;
@@ -304,9 +304,9 @@ module.exports = class RuleSet {
 			return !["options", "query"].includes(key);
 		});
 
-		keys.forEach(function(key) {
+		for(const key of keys) {
 			newItem[key] = item[key];
-		});
+		}
 
 		return newItem;
 	}
@@ -395,12 +395,12 @@ module.exports = class RuleSet {
 		const keys = Object.keys(rule).filter((key) => {
 			return !["resource", "resourceQuery", "compiler", "issuer", "rules", "oneOf", "use", "enforce"].includes(key);
 		});
-		keys.forEach((key) => {
+		for(const key of keys) {
 			result.push({
 				type: key,
 				value: rule[key]
 			});
-		});
+		}
 
 		if(rule.use) {
 			const process = use => {

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -90,16 +90,16 @@ class SourceMapDevToolPlugin {
 				const reportProgress = (context && context.reportProgress) ? context.reportProgress : () => {};
 
 				const files = [];
-				chunks.forEach(chunk => {
-					chunk.files.forEach(file => {
+				for(const chunk of chunks) {
+					for(const file of chunk.files) {
 						if(matchObject(file)) {
 							files.push({
 								file,
 								chunk
 							});
 						}
-					});
-				});
+					}
+				}
 
 				reportProgress(0.0);
 				const tasks = [];

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -212,13 +212,13 @@ class Stats {
 						text += ` ${locInfo}`;
 				}
 				if(e.dependencies) {
-					e.dependencies.forEach(dep => {
-						if(!dep.loc) return;
-						if(typeof dep.loc === "string") return;
+					for(const dep of e.dependencies) {
+						if(!dep.loc) continue;
+						if(typeof dep.loc === "string") continue;
 						const locInfo = formatLocation(dep.loc);
-						if(!locInfo) return;
+						if(!locInfo) continue;
 						text += ` ${locInfo}`;
-					});
+					}
 				}
 				let current = e.origin;
 				while(current.issuer) {
@@ -288,12 +288,12 @@ class Stats {
 			}).filter(createAssetFilter());
 			obj.filteredAssets = compilationAssets.length - obj.assets.length;
 
-			compilation.chunks.forEach(chunk => {
-				chunk.files.forEach(asset => {
+			for(const chunk of compilation.chunks) {
+				for(const asset of chunk.files) {
 					if(assetsByFile[asset]) {
-						chunk.ids.forEach(id => {
+						for(const id of chunk.ids) {
 							assetsByFile[asset].chunks.push(id);
-						});
+						}
 						if(chunk.name) {
 							assetsByFile[asset].chunkNames.push(chunk.name);
 							if(obj.assetsByChunkName[chunk.name])
@@ -302,8 +302,8 @@ class Stats {
 								obj.assetsByChunkName[chunk.name] = asset;
 						}
 					}
-				});
-			});
+				}
+			}
 			obj.assets.sort(sortByField(sortAssets));
 		}
 
@@ -649,7 +649,7 @@ class Stats {
 					color: colors.bold
 				}]
 			];
-			obj.assets.forEach(asset => {
+			for(const asset of obj.assets) {
 				t.push([{
 					value: asset.name,
 					color: getAssetColor(asset, colors.green)
@@ -669,7 +669,7 @@ class Stats {
 					value: asset.chunkNames.join(", "),
 					color: colors.normal
 				}]);
-			});
+			}
 			table(t, "rrrlll");
 		}
 		if(obj.filteredAssets > 0) {
@@ -683,7 +683,7 @@ class Stats {
 			newline();
 		}
 		if(obj.entrypoints) {
-			Object.keys(obj.entrypoints).forEach(name => {
+			for(const name of Object.keys(obj.entrypoints)) {
 				const ep = obj.entrypoints[name];
 				colors.normal("Entrypoint ");
 				colors.bold(name);
@@ -692,37 +692,37 @@ class Stats {
 					colors.yellow("[big]");
 				}
 				colors.normal(" =");
-				ep.assets.forEach(asset => {
+				for(const asset of ep.assets) {
 					colors.normal(" ");
 					colors.green(asset);
-				});
+				}
 				newline();
-			});
+			}
 		}
 		const modulesByIdentifier = {};
 		if(obj.modules) {
-			obj.modules.forEach(module => {
+			for(const module of obj.modules) {
 				modulesByIdentifier[`$${module.identifier}`] = module;
-			});
+			}
 		} else if(obj.chunks) {
-			obj.chunks.forEach(chunk => {
+			for(const chunk of obj.chunks) {
 				if(chunk.modules) {
-					chunk.modules.forEach(module => {
+					for(const module of chunk.modules) {
 						modulesByIdentifier[`$${module.identifier}`] = module;
-					});
+					}
 				}
-			});
+			}
 		}
 
 		const processModuleAttributes = (module) => {
 			colors.normal(" ");
 			colors.normal(SizeFormatHelpers.formatSize(module.size));
 			if(module.chunks) {
-				module.chunks.forEach(chunk => {
+				for(const chunk of module.chunks) {
 					colors.normal(" {");
 					colors.yellow(chunk);
 					colors.normal("}");
-				});
+				}
 			}
 			if(typeof module.depth === "number") {
 				colors.normal(` [depth ${module.depth}]`);
@@ -771,14 +771,14 @@ class Stats {
 				}
 			}
 			if(Array.isArray(module.optimizationBailout)) {
-				module.optimizationBailout.forEach(item => {
+				for(const item of module.optimizationBailout) {
 					colors.normal(prefix);
 					colors.yellow(item);
 					newline();
-				});
+				}
 			}
 			if(module.reasons) {
-				module.reasons.forEach(reason => {
+				for(const reason of module.reasons) {
 					colors.normal(prefix);
 					if(reason.type) {
 						colors.normal(reason.type);
@@ -802,32 +802,32 @@ class Stats {
 						colors.normal(reason.loc);
 					}
 					newline();
-				});
+				}
 			}
 			if(module.profile) {
 				colors.normal(prefix);
 				let sum = 0;
 				if(module.issuerPath) {
-					module.issuerPath.forEach(module => {
+					for(const m of module.issuerPath) {
 						colors.normal("[");
-						colors.normal(module.id);
+						colors.normal(m.id);
 						colors.normal("] ");
-						if(module.profile) {
-							const time = (module.profile.factory || 0) + (module.profile.building || 0);
+						if(m.profile) {
+							const time = (m.profile.factory || 0) + (m.profile.building || 0);
 							coloredTime(time);
 							sum += time;
 							colors.normal(" ");
 						}
 						colors.normal("-> ");
-					});
+					}
 				}
-				Object.keys(module.profile).forEach(key => {
+				for(const key of Object.keys(module.profile)) {
 					colors.normal(`${key}:`);
 					const time = module.profile[key];
 					coloredTime(time);
 					colors.normal(" ");
 					sum += time;
-				});
+				}
 				colors.normal("= ");
 				coloredTime(sum);
 				newline();
@@ -839,7 +839,7 @@ class Stats {
 
 		const processModulesList = (obj, prefix) => {
 			if(obj.modules) {
-				obj.modules.forEach(module => {
+				for(const module of obj.modules) {
 					colors.normal(prefix);
 					const name = module.name || module.identifier;
 					let contentPrefix = prefix + "   ";
@@ -860,7 +860,7 @@ class Stats {
 					processModuleAttributes(module);
 					newline();
 					processModuleContent(module, contentPrefix);
-				});
+				}
 				if(obj.filteredModules > 0) {
 					colors.normal(prefix);
 					colors.normal("   ");
@@ -876,7 +876,7 @@ class Stats {
 		};
 
 		if(obj.chunks) {
-			obj.chunks.forEach(chunk => {
+			for(const chunk of obj.chunks) {
 				colors.normal("chunk ");
 				if(chunk.id < 1000) colors.normal(" ");
 				if(chunk.id < 100) colors.normal(" ");
@@ -892,21 +892,21 @@ class Stats {
 				}
 				colors.normal(" ");
 				colors.normal(SizeFormatHelpers.formatSize(chunk.size));
-				chunk.parents.forEach(id => {
+				for(const id of chunk.parents) {
 					colors.normal(" <{");
 					colors.yellow(id);
 					colors.normal("}>");
-				});
-				chunk.siblings.forEach(id => {
+				}
+				for(const id of chunk.siblings) {
 					colors.normal(" ={");
 					colors.yellow(id);
 					colors.normal("}=");
-				});
-				chunk.children.forEach(id => {
+				}
+				for(const id of chunk.children) {
 					colors.normal(" >{");
 					colors.yellow(id);
 					colors.normal("}<");
-				});
+				}
 				if(chunk.entry) {
 					colors.yellow(" [entry]");
 				} else if(chunk.initial) {
@@ -923,7 +923,7 @@ class Stats {
 				}
 				newline();
 				if(chunk.origins) {
-					chunk.origins.forEach(origin => {
+					for(const origin of chunk.origins) {
 						colors.normal("    > ");
 						if(origin.reasons && origin.reasons.length) {
 							colors.yellow(origin.reasons.join(" "));
@@ -947,30 +947,30 @@ class Stats {
 							colors.normal(origin.loc);
 						}
 						newline();
-					});
+					}
 				}
 				processModulesList(chunk, " ");
-			});
+			}
 		}
 
 		processModulesList(obj, "");
 
 		if(obj._showWarnings && obj.warnings) {
-			obj.warnings.forEach(warning => {
+			for(const warning of obj.warnings) {
 				newline();
 				colors.yellow(`WARNING in ${warning}`);
 				newline();
-			});
+			}
 		}
 		if(obj._showErrors && obj.errors) {
-			obj.errors.forEach(error => {
+			for(const error of obj.errors) {
 				newline();
 				colors.red(`ERROR in ${error}`);
 				newline();
-			});
+			}
 		}
 		if(obj.children) {
-			obj.children.forEach(child => {
+			for(const child of obj.children) {
 				const childString = Stats.jsonToString(child, useColors);
 				if(childString) {
 					if(child.name) {
@@ -985,7 +985,7 @@ class Stats {
 					buf.push(childString.replace(/\n/g, "\n    "));
 					newline();
 				}
-			});
+			}
 		}
 		if(obj.needAdditionalPass) {
 			colors.yellow("Compilation needs an additional pass and will compile again.");

--- a/lib/Template.js
+++ b/lib/Template.js
@@ -101,10 +101,10 @@ module.exports = class Template {
 			return false;
 		var maxId = -Infinity;
 		var minId = Infinity;
-		modules.forEach(module => {
+		for(const module of modules) {
 			if(maxId < module.id) maxId = module.id;
 			if(minId > module.id) minId = module.id;
-		});
+		}
 		if(minId < 16 + ("" + minId).length) {
 			// add minId x ',' instead of 'Array(minId).concat(...)'
 			minId = 0;
@@ -137,12 +137,12 @@ module.exports = class Template {
 			};
 		});
 		if(removedModules && removedModules.length > 0) {
-			removedModules.forEach(id => {
+			for(const id of removedModules) {
 				allModules.push({
 					id: id,
 					source: "false"
 				});
-			});
+			}
 		}
 		var bounds = Template.getModulesArrayBounds(allModules);
 
@@ -153,9 +153,9 @@ module.exports = class Template {
 			if(minId !== 0) source.add("Array(" + minId + ").concat(");
 			source.add("[\n");
 			const modules = new Map();
-			allModules.forEach(module => {
+			for(const module of allModules) {
 				modules.set(module.id, module);
-			});
+			}
 			for(var idx = minId; idx <= maxId; idx++) {
 				var module = modules.get(idx);
 				if(idx !== minId) source.add(",\n");

--- a/lib/UmdMainTemplatePlugin.js
+++ b/lib/UmdMainTemplatePlugin.js
@@ -51,13 +51,13 @@ class UmdMainTemplatePlugin {
 			const optionalExternals = [];
 			let requiredExternals = [];
 			if(this.optionalAmdExternalAsGlobal) {
-				externals.forEach(m => {
+				for(const m of externals) {
 					if(m.optional) {
 						optionalExternals.push(m);
 					} else {
 						requiredExternals.push(m);
 					}
-				});
+				}
 				externals = requiredExternals.concat(optionalExternals);
 			} else {
 				requiredExternals = externals;

--- a/lib/WarnCaseSensitiveModulesPlugin.js
+++ b/lib/WarnCaseSensitiveModulesPlugin.js
@@ -11,7 +11,7 @@ class WarnCaseSensitiveModulesPlugin {
 		compiler.hooks.compilation.tap("WarnCaseSensitiveModulesPlugin", (compilation) => {
 			compilation.hooks.seal.tap("WarnCaseSensitiveModulesPlugin", () => {
 				const moduleWithoutCase = new Map();
-				compilation.modules.forEach(module => {
+				for(const module of compilation.modules) {
 					const identifier = module.identifier().toLowerCase();
 					const array = moduleWithoutCase.get(identifier);
 					if(array) {
@@ -19,7 +19,7 @@ class WarnCaseSensitiveModulesPlugin {
 					} else {
 						moduleWithoutCase.set(identifier, [module]);
 					}
-				});
+				}
 				for(const pair of moduleWithoutCase) {
 					const array = pair[1];
 					if(array.length > 1)

--- a/lib/WatchIgnorePlugin.js
+++ b/lib/WatchIgnorePlugin.js
@@ -39,13 +39,13 @@ class IgnoringWatchFileSystem {
 		const watcher = this.wfs.watch(files.filter(notIgnored), dirs.filter(notIgnored), missing, startTime, options, (err, filesModified, dirsModified, missingModified, fileTimestamps, dirTimestamps) => {
 			if(err) return callback(err);
 
-			ignoredFiles.forEach(path => {
+			for(const path of ignoredFiles) {
 				fileTimestamps[path] = 1;
-			});
+			}
 
-			ignoredDirs.forEach(path => {
+			for(const path of ignoredDirs) {
 				dirTimestamps[path] = 1;
-			});
+			}
 
 			callback(err, filesModified, dirsModified, missingModified, fileTimestamps, dirTimestamps);
 		}, callbackUndelayed);
@@ -55,16 +55,16 @@ class IgnoringWatchFileSystem {
 			pause: () => watcher.pause(),
 			getContextTimestamps: () => {
 				const dirTimestamps = watcher.getContextTimestamps();
-				ignoredDirs.forEach(path => {
+				for(const path of ignoredDirs) {
 					dirTimestamps[path] = 1;
-				});
+				}
 				return dirTimestamps;
 			},
 			getFileTimestamps: () => {
 				const fileTimestamps = watcher.getFileTimestamps();
-				ignoredFiles.forEach(path => {
+				for(const path of ignoredFiles) {
 					fileTimestamps[path] = 1;
-				});
+				}
 				return fileTimestamps;
 			}
 		};

--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -98,7 +98,7 @@ class Watching {
 		if(!this.closed) {
 			this.watch(Array.from(compilation.fileDependencies), Array.from(compilation.contextDependencies), Array.from(compilation.missingDependencies));
 		}
-		this.callbacks.forEach(cb => cb());
+		for(const cb of this.callbacks) cb();
 		this.callbacks.length = 0;
 	}
 

--- a/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
@@ -68,16 +68,16 @@ class AMDRequireDependenciesBlockParserPlugin {
 
 		const processArray = (expr, param) => {
 			if(param.isArray()) {
-				param.items.forEach((param) => {
-					const result = processItem(expr, param);
+				for(const p of param.items) {
+					const result = processItem(expr, p);
 					if(result === undefined) {
-						processContext(expr, param);
+						processContext(expr, p);
 					}
-				});
+				}
 				return true;
 			} else if(param.isConstArray()) {
 				const deps = [];
-				param.array.forEach((request) => {
+				for(const request of param.array) {
 					let dep, localModule;
 					if(request === "require") {
 						dep = "__webpack_require__";
@@ -94,7 +94,7 @@ class AMDRequireDependenciesBlockParserPlugin {
 						parser.state.current.addDependency(dep);
 					}
 					deps.push(dep);
-				});
+				}
 				const dep = new AMDRequireArrayDependency(deps, param.range);
 				dep.loc = expr.loc;
 				dep.optional = !!parser.scope.inTry;
@@ -104,12 +104,12 @@ class AMDRequireDependenciesBlockParserPlugin {
 		};
 		const processItem = (expr, param) => {
 			if(param.isConditional()) {
-				param.options.forEach((param) => {
-					const result = processItem(expr, param);
+				for(const p of param.options) {
+					const result = processItem(expr, p);
 					if(result === undefined) {
-						processContext(expr, param);
+						processContext(expr, p);
 					}
-				});
+				}
 				return true;
 			} else if(param.isString()) {
 				let dep, localModule;

--- a/lib/dependencies/CommonJsRequireDependencyParserPlugin.js
+++ b/lib/dependencies/CommonJsRequireDependencyParserPlugin.js
@@ -62,12 +62,12 @@ class CommonJsRequireDependencyParserPlugin {
 				const dep = new RequireHeaderDependency(expr.callee.range);
 				dep.loc = expr.loc;
 				parser.state.current.addDependency(dep);
-				param.options.forEach(param => {
-					const result = processItem(expr, param);
+				for(const p of param.options) {
+					const result = processItem(expr, p);
 					if(result === undefined) {
 						isExpression = true;
 					}
-				});
+				}
 				if(isExpression) {
 					parser.state.current.dependencies.length = prevLength;
 				} else {

--- a/lib/dependencies/HarmonyDetectionParserPlugin.js
+++ b/lib/dependencies/HarmonyDetectionParserPlugin.js
@@ -67,12 +67,12 @@ module.exports = class HarmonyDetectionParserPlugin {
 		};
 
 		const nonHarmonyIdentifiers = ["define", "exports"];
-		nonHarmonyIdentifiers.forEach(identifer => {
+		for(const identifer of nonHarmonyIdentifiers) {
 			parser.hooks.evaluateTypeof.for(identifer).tap("HarmonyDetectionParserPlugin", nullInHarmony);
 			parser.hooks.typeof.for(identifer).tap("HarmonyDetectionParserPlugin", skipInHarmony);
 			parser.hooks.evaluate.for(identifer).tap("HarmonyDetectionParserPlugin", nullInHarmony);
 			parser.hooks.expression.for(identifer).tap("HarmonyDetectionParserPlugin", skipInHarmony);
 			parser.hooks.call.for(identifer).tap("HarmonyDetectionParserPlugin", skipInHarmony);
-		});
+		}
 	}
 };

--- a/lib/dependencies/LoaderPlugin.js
+++ b/lib/dependencies/LoaderPlugin.js
@@ -44,10 +44,14 @@ class LoaderPlugin {
 							source = moduleSource.source();
 						}
 						if(dep.module.buildInfo.fileDependencies) {
-							dep.module.buildInfo.fileDependencies.forEach(dep => loaderContext.addDependency(dep));
+							for(const d of dep.module.buildInfo.fileDependencies) {
+								loaderContext.addDependency(d);
+							}
 						}
 						if(dep.module.buildInfo.contextDependencies) {
-							dep.module.buildInfo.contextDependencies.forEach(dep => loaderContext.addContextDependency(dep));
+							for(const d of dep.module.buildInfo.contextDependencies) {
+								loaderContext.addContextDependency(d);
+							}
 						}
 						return callback(null, source, map, dep.module);
 					});

--- a/lib/dependencies/RequireEnsureDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/RequireEnsureDependenciesBlockParserPlugin.js
@@ -60,7 +60,7 @@ module.exports = class RequireEnsureDependenciesBlockParserPlugin {
 						try {
 							let failed = false;
 							parser.inScope([], () => {
-								dependenciesItems.forEach(ee => {
+								for(const ee of dependenciesItems) {
 									if(ee.isString()) {
 										const edep = new RequireEnsureItemDependency(ee.string, ee.range);
 										edep.loc = dep.loc;
@@ -68,7 +68,7 @@ module.exports = class RequireEnsureDependenciesBlockParserPlugin {
 									} else {
 										failed = true;
 									}
-								});
+								}
 							});
 							if(failed) {
 								return;

--- a/lib/dependencies/RequireResolveDependencyParserPlugin.js
+++ b/lib/dependencies/RequireResolveDependencyParserPlugin.js
@@ -21,12 +21,12 @@ class RequireResolveDependencyParserPlugin {
 			if(expr.arguments.length !== 1) return;
 			const param = parser.evaluateExpression(expr.arguments[0]);
 			if(param.isConditional()) {
-				param.options.forEach((option) => {
+				for(const option of param.options) {
 					const result = processItem(expr, option, weak);
 					if(result === undefined) {
 						processContext(expr, option, weak);
 					}
-				});
+				}
 				const dep = new RequireResolveHeaderDependency(expr.callee.range);
 				dep.loc = expr.loc;
 				parser.state.current.addDependency(dep);

--- a/lib/node/NodeMainTemplatePlugin.js
+++ b/lib/node/NodeMainTemplatePlugin.js
@@ -87,10 +87,10 @@ module.exports = class NodeMainTemplatePlugin {
 										hash: `" + ${JSON.stringify(chunkMaps.hash)}[chunkId] + "`,
 										hashWithLength: (length) => {
 											const shortChunkHashMap = {};
-											Object.keys(chunkMaps.hash).forEach((chunkId) => {
+											for(const chunkId of Object.keys(chunkMaps.hash)) {
 												if(typeof chunkMaps.hash[chunkId] === "string")
 													shortChunkHashMap[chunkId] = chunkMaps.hash[chunkId].substr(0, length);
-											});
+											}
 											return `" + ${JSON.stringify(shortChunkHashMap)}[chunkId] + "`;
 										},
 										name: `" + (${JSON.stringify(chunkMaps.name)}[chunkId]||chunkId) + "`
@@ -134,10 +134,10 @@ module.exports = class NodeMainTemplatePlugin {
 						hash: `" + ${JSON.stringify(chunkMaps.hash)}[chunkId] + "`,
 						hashWithLength: (length) => {
 							const shortChunkHashMap = {};
-							Object.keys(chunkMaps.hash).forEach((chunkId) => {
+							for(const chunkId of Object.keys(chunkMaps.hash)) {
 								if(typeof chunkMaps.hash[chunkId] === "string")
 									shortChunkHashMap[chunkId] = chunkMaps.hash[chunkId].substr(0, length);
-							});
+							}
 							return `" + ${JSON.stringify(shortChunkHashMap)}[chunkId] + "`;
 						},
 						name: `" + (${JSON.stringify(chunkMaps.name)}[chunkId]||chunkId) + "`
@@ -172,10 +172,10 @@ module.exports = class NodeMainTemplatePlugin {
 					hash: `" + ${JSON.stringify(chunkMaps.hash)}[chunkId] + "`,
 					hashWithLength: (length) => {
 						const shortChunkHashMap = {};
-						Object.keys(chunkMaps.hash).forEach((chunkId) => {
+						for(const chunkId of Object.keys(chunkMaps.hash)) {
 							if(typeof chunkMaps.hash[chunkId] === "string")
 								shortChunkHashMap[chunkId] = chunkMaps.hash[chunkId].substr(0, length);
-						});
+						}
 						return `" + ${JSON.stringify(shortChunkHashMap)}[chunkId] + "`;
 					},
 					name: `" + (${JSON.stringify(chunkMaps.name)}[chunkId]||chunkId) + "`

--- a/lib/node/NodeSourcePlugin.js
+++ b/lib/node/NodeSourcePlugin.js
@@ -76,7 +76,7 @@ module.exports = class NodeSourcePlugin {
 			normalModuleFactory.hooks.parser.for("javascript/esm").tap("NodeSourcePlugin", handler);
 		});
 		compiler.hooks.afterResolvers.tap("NodeSourcePlugin", (compiler) => {
-			Object.keys(nodeLibsBrowser).forEach((lib) => {
+			for(const lib of Object.keys(nodeLibsBrowser)) {
 				if(options[lib] !== false) {
 					compiler.resolverFactory.hooks.resolver.for("normal").tap("NodeSourcePlugin", resolver => {
 						new AliasPlugin("described-resolve", {
@@ -86,7 +86,7 @@ module.exports = class NodeSourcePlugin {
 						}, "resolve").apply(resolver);
 					});
 				}
-			});
+			}
 		});
 	}
 };

--- a/lib/node/ReadFileCompileWasmMainTemplatePlugin.js
+++ b/lib/node/ReadFileCompileWasmMainTemplatePlugin.js
@@ -29,10 +29,10 @@ class ReadFileCompileWasmMainTemplatePlugin {
 					hash: `" + ${JSON.stringify(chunkModuleMaps.hash)}[wasmModuleId] + "`,
 					hashWithLength(length) {
 						const shortChunkHashMap = Object.create(null);
-						Object.keys(chunkModuleMaps.hash).forEach(wasmModuleId => {
+						for(const wasmModuleId of Object.keys(chunkModuleMaps.hash)) {
 							if(typeof chunkModuleMaps.hash[wasmModuleId] === "string")
 								shortChunkHashMap[wasmModuleId] = chunkModuleMaps.hash[wasmModuleId].substr(0, length);
-						});
+						}
 						return `" + ${JSON.stringify(shortChunkHashMap)}[wasmModuleId] + "`;
 					}
 				}

--- a/lib/optimize/AggressiveMergingPlugin.js
+++ b/lib/optimize/AggressiveMergingPlugin.js
@@ -32,7 +32,7 @@ class AggressiveMergingPlugin {
 					}
 				});
 
-				combinations.forEach((pair) => {
+				for(const pair of combinations) {
 					const a = pair.b.size({
 						chunkOverhead: 0
 					});
@@ -51,7 +51,7 @@ class AggressiveMergingPlugin {
 					}
 
 					pair.improvement = (a + b) / newSize;
-				});
+				}
 				combinations = combinations.filter((pair) => {
 					return pair.improvement !== false;
 				});

--- a/lib/optimize/AggressiveSplittingPlugin.js
+++ b/lib/optimize/AggressiveSplittingPlugin.js
@@ -47,11 +47,11 @@ class AggressiveSplittingPlugin {
 				// Precompute stuff
 				const nameToModuleMap = new Map();
 				const moduleToNameMap = new Map();
-				compilation.modules.forEach(m => {
+				for(const m of compilation.modules) {
 					const name = identifierUtils.makePathsRelative(compiler.context, m.identifier(), compilation.cache);
 					nameToModuleMap.set(name, m);
 					moduleToNameMap.set(m, name);
-				});
+				}
 
 				// Check used chunk ids
 				const usedIds = new Set();
@@ -186,7 +186,7 @@ class AggressiveSplittingPlugin {
 
 				// Check if some splittings are invalid
 				// We remove invalid splittings and try again
-				compilation.chunks.forEach((chunk) => {
+				for(const chunk of compilation.chunks) {
 					const splitData = chunkSplitDataMap.get(chunk);
 					if(splitData !== undefined) {
 						if(splitData.hash && chunk.hash !== splitData.hash) {
@@ -195,7 +195,7 @@ class AggressiveSplittingPlugin {
 							invalidSplits.add(splitData);
 						}
 					}
-				});
+				}
 
 				if(invalidSplits.size > 0) {
 
@@ -205,7 +205,7 @@ class AggressiveSplittingPlugin {
 				} else {
 
 					// set hash and id values on all (new) splittings
-					compilation.chunks.forEach((chunk) => {
+					for(const chunk of compilation.chunks) {
 						const splitData = chunkSplitDataMap.get(chunk);
 						if(splitData !== undefined) {
 							splitData.hash = chunk.hash;
@@ -214,7 +214,7 @@ class AggressiveSplittingPlugin {
 							// set flag for stats
 							chunk.recorded = true;
 						}
-					});
+					}
 
 					// Also add all unused historial splits (after the used ones)
 					// They can still be used in some future compilation

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -118,7 +118,9 @@ const getSymbolsFromScope = (s, untilScope) => {
 	let scope = s;
 	while(scope) {
 		if(untilScope === scope) break;
-		scope.variables.forEach(variable => allUsedNames.add(variable.name));
+		for(const variable of scope.variables) {
+			allUsedNames.add(variable.name);
+		}
 		scope = scope.upper;
 	}
 	return allUsedNames;
@@ -237,16 +239,25 @@ class ConcatenatedModule extends Module {
 				const m = info.module;
 
 				// populate dependencies
-				m.dependencies.filter(dep => !(dep instanceof HarmonyImportDependency) || !modulesSet.has(dep.module))
-					.forEach(d => this.dependencies.push(d));
+				for(const d of m.dependencies.filter(dep => !(dep instanceof HarmonyImportDependency) || !modulesSet.has(dep.module))) {
+					this.dependencies.push(d);
+				}
 				// populate file dependencies
-				if(m.buildInfo.fileDependencies) m.buildInfo.fileDependencies.forEach(file => this.buildInfo.fileDependencies.add(file));
+				if(m.buildInfo.fileDependencies) {
+					for(const file of m.buildInfo.fileDependencies) {
+						this.buildInfo.fileDependencies.add(file);
+					}
+				}
 				// populate context dependencies
-				if(m.buildInfo.contextDependencies) m.buildInfo.contextDependencies.forEach(context => this.buildInfo.contextDependencies.add(context));
+				if(m.buildInfo.contextDependencies) {
+					for(const context of m.buildInfo.contextDependencies) {
+						this.buildInfo.contextDependencies.add(context);
+					}
+				}
 				// populate warnings
-				m.warnings.forEach(warning => this.warnings.push(warning));
+				for(const warning of m.warnings) this.warnings.push(warning);
 				// populate errors
-				m.errors.forEach(error => this.errors.push(error));
+				for(const error of m.errors) this.errors.push(error);
 
 				if(m.buildInfo.assets) {
 					if(this.buildInfo.assets === undefined)
@@ -363,7 +374,7 @@ class ConcatenatedModule extends Module {
 					{
 						const exportMap = new Map();
 						const reexportMap = new Map();
-						info.module.dependencies.forEach(dep => {
+						for(const dep of info.module.dependencies) {
 							if(dep instanceof HarmonyExportSpecifierDependency) {
 								if(!exportMap.has(dep.name))
 									exportMap.set(dep.name, dep.id);
@@ -391,9 +402,9 @@ class ConcatenatedModule extends Module {
 										});
 									}
 								} else if(importedModule) {
-									importedModule.buildMeta.providedExports.forEach(name => {
+									for(const name of importedModule.buildMeta.providedExports) {
 										if(dep.activeExports.has(name) || name === "default")
-											return;
+											continue;
 										if(!reexportMap.has(name)) {
 											reexportMap.set(name, {
 												module: importedModule,
@@ -401,10 +412,10 @@ class ConcatenatedModule extends Module {
 												dependency: dep
 											});
 										}
-									});
+									}
 								}
 							}
-						});
+						}
 						return {
 							type: "concatenated",
 							module: info.module,
@@ -439,7 +450,9 @@ class ConcatenatedModule extends Module {
 
 		// Create mapping from module to info
 		const moduleToInfoMap = new Map();
-		modulesWithInfo.forEach(m => moduleToInfoMap.set(m.module, m));
+		for(const m of modulesWithInfo) {
+			moduleToInfoMap.set(m.module, m);
+		}
 
 		// Configure template decorators for dependencies
 		const innerDependencyTemplates = new Map(dependencyTemplates);
@@ -475,7 +488,7 @@ class ConcatenatedModule extends Module {
 
 		// Generate source code and analyse scopes
 		// Prepare a ReplaceSource for the final source
-		modulesWithInfo.forEach(info => {
+		for(const info of modulesWithInfo) {
 			if(info.type === "concatenated") {
 				const m = info.module;
 				const source = m.source(innerDependencyTemplates, runtimeTemplate);
@@ -509,7 +522,7 @@ class ConcatenatedModule extends Module {
 				info.globalScope = globalScope;
 				info.moduleScope = moduleScope;
 			}
-		});
+		}
 
 		// List of all used names to avoid conflicts
 		const allUsedNames = new Set([
@@ -546,9 +559,9 @@ class ConcatenatedModule extends Module {
 		]);
 
 		// get all global names
-		modulesWithInfo.forEach(info => {
+		for(const info of modulesWithInfo) {
 			if(info.globalScope) {
-				info.globalScope.through.forEach(reference => {
+				for(const reference of info.globalScope.through) {
 					const name = reference.identifier.name;
 					if(/^__WEBPACK_MODULE_REFERENCE__\d+_([\da-f]+|ns)(_call)?(_strict)?__$/.test(name)) {
 						for(const s of getSymbolsFromScope(reference.from, info.moduleScope)) {
@@ -557,12 +570,12 @@ class ConcatenatedModule extends Module {
 					} else {
 						allUsedNames.add(name);
 					}
-				});
+				}
 			}
-		});
+		}
 
 		// generate names for symbols
-		modulesWithInfo.forEach(info => {
+		for(const info of modulesWithInfo) {
 			switch(info.type) {
 				case "concatenated":
 					{
@@ -570,7 +583,7 @@ class ConcatenatedModule extends Module {
 						allUsedNames.add(namespaceObjectName);
 						info.internalNames.set(namespaceObjectName, namespaceObjectName);
 						info.exportMap.set(true, namespaceObjectName);
-						info.moduleScope.variables.forEach(variable => {
+						for(const variable of info.moduleScope.variables) {
 							const name = variable.name;
 							if(allUsedNames.has(name)) {
 								const references = getAllReferences(variable);
@@ -593,7 +606,7 @@ class ConcatenatedModule extends Module {
 								allUsedNames.add(name);
 								info.internalNames.set(name, name);
 							}
-						});
+						}
 						break;
 					}
 				case "external":
@@ -614,12 +627,12 @@ class ConcatenatedModule extends Module {
 						break;
 					}
 			}
-		});
+		}
 
 		// Find and replace referenced to modules
-		modulesWithInfo.forEach(info => {
+		for(const info of modulesWithInfo) {
 			if(info.type === "concatenated") {
-				info.globalScope.through.forEach(reference => {
+				for(const reference of info.globalScope.through) {
 					const name = reference.identifier.name;
 					const match = /^__WEBPACK_MODULE_REFERENCE__(\d+)_([\da-f]+|ns)(_call)?(_strict)?__$/.exec(name);
 					if(match) {
@@ -638,9 +651,9 @@ class ConcatenatedModule extends Module {
 						const source = info.source;
 						source.replace(r[0], r[1] - 1, finalName);
 					}
-				});
+				}
 			}
-		});
+		}
 
 		const result = new ConcatSource();
 
@@ -653,14 +666,14 @@ class ConcatenatedModule extends Module {
 		}
 
 		// define required namespace objects (must be before evaluation modules)
-		modulesWithInfo.forEach(info => {
+		for(const info of modulesWithInfo) {
 			if(info.namespaceObjectSource) {
 				result.add(info.namespaceObjectSource);
 			}
-		});
+		}
 
 		// evaluate modules in order
-		modulesWithInfo.forEach(info => {
+		for(const info of modulesWithInfo) {
 			switch(info.type) {
 				case "concatenated":
 					result.add(`\n// CONCATENATED MODULE: ${info.module.readableIdentifier(requestShortener)}\n`);
@@ -683,7 +696,7 @@ class ConcatenatedModule extends Module {
 				default:
 					throw new Error(`Unsupported concatenation entry type ${info.type}`);
 			}
-		});
+		}
 
 		return result;
 	}
@@ -920,7 +933,7 @@ class HarmonyExportImportedSpecifierDependencyConcatenatedTemplate {
 		if(dep.originModule === this.rootModule) {
 			if(this.modulesMap.get(dep.module)) {
 				const exportDefs = this.getExports(dep);
-				exportDefs.forEach(def => {
+				for(const def of exportDefs) {
 					const info = this.modulesMap.get(def.module);
 					const used = dep.originModule.isUsed(def.name);
 					if(!used) {
@@ -937,7 +950,7 @@ class HarmonyExportImportedSpecifierDependencyConcatenatedTemplate {
 					const exportsName = this.rootModule.exportsArgument;
 					const content = `/* concated harmony reexport */__webpack_require__.d(${exportsName}, ${JSON.stringify(used)}, function() { return ${finalName}; });\n`;
 					source.insert(-1, content);
-				});
+				}
 			} else {
 				this.originalTemplate.apply(dep, source, runtime, dependencyTemplates);
 			}

--- a/lib/optimize/FlagIncludedChunksPlugin.js
+++ b/lib/optimize/FlagIncludedChunksPlugin.js
@@ -9,25 +9,25 @@ class FlagIncludedChunksPlugin {
 	apply(compiler) {
 		compiler.hooks.compilation.tap("FlagIncludedChunksPlugin", (compilation) => {
 			compilation.hooks.optimizeChunkIds.tap("FlagIncludedChunksPlugin", (chunks) => {
-				chunks.forEach((chunkA) => {
-					chunks.forEach((chunkB) => {
+				for(const chunkA of chunks) {
+					loopB: for(const chunkB of chunks) {
 						// as we iterate the same iterables twice
 						// skip if we find ourselves
-						if(chunkA === chunkB) return;
+						if(chunkA === chunkB) continue loopB;
 
 						// instead of swapping A and B just bail
 						// as we loop twice the current A will be B and B then A
-						if(chunkA.getNumberOfModules() < chunkB.getNumberOfModules()) return;
+						if(chunkA.getNumberOfModules() < chunkB.getNumberOfModules()) continue loopB;
 
-						if(chunkB.getNumberOfModules() === 0) return;
+						if(chunkB.getNumberOfModules() === 0) continue loopB;
 
 						// is chunkB in chunkA?
 						for(const m of chunkB.modulesIterable) {
-							if(!chunkA.containsModule(m)) return;
+							if(!chunkA.containsModule(m)) continue loopB;
 						}
 						chunkA.ids.push(chunkB.id);
-					});
-				});
+					}
+				}
 			});
 		});
 	}

--- a/lib/optimize/ModuleConcatenationPlugin.js
+++ b/lib/optimize/ModuleConcatenationPlugin.js
@@ -184,24 +184,28 @@ class ModuleConcatenationPlugin {
 					const chunks = concatConfiguration.rootModule.getChunks();
 					for(const m of modules) {
 						usedModules.add(m);
-						chunks.forEach(chunk => chunk.removeModule(m));
+						for(const chunk of chunks) {
+							chunk.removeModule(m);
+						}
 					}
-					chunks.forEach(chunk => {
+					for(const chunk of chunks) {
 						chunk.addModule(newModule);
 						newModule.addChunk(chunk);
 						if(chunk.entryModule === concatConfiguration.rootModule)
 							chunk.entryModule = newModule;
-					});
+					}
 					compilation.modules.push(newModule);
-					newModule.reasons.forEach(reason => reason.dependency.module = newModule);
-					newModule.dependencies.forEach(dep => {
+					for(const reason of newModule.reasons) {
+						reason.dependency.module = newModule;
+					}
+					for(const dep of newModule.dependencies) {
 						if(dep.module) {
-							dep.module.reasons.forEach(reason => {
+							for(const reason of dep.module.reasons) {
 								if(reason.dependency === dep)
 									reason.module = newModule;
-							});
+							}
 						}
-					});
+					}
 				}
 				compilation.modules = compilation.modules.filter(m => !usedModules.has(m));
 			});

--- a/lib/optimize/OccurrenceOrderPlugin.js
+++ b/lib/optimize/OccurrenceOrderPlugin.js
@@ -20,16 +20,16 @@ class OccurrenceOrderPlugin {
 
 				const initialChunkChunkMap = new Map();
 				const entryCountMap = new Map();
-				modules.forEach(m => {
+				for(const m of modules) {
 					let initial = 0;
 					let entry = 0;
-					m.forEachChunk(c => {
+					for(const c of m.chunksIterable) {
 						if(c.canBeInitial()) initial++;
 						if(c.entryModule === m) entry++;
-					});
+					}
 					initialChunkChunkMap.set(m, initial);
 					entryCountMap.set(m, entry);
-				});
+				}
 
 				const countOccursInEntry = (sum, r) => {
 					if(!r.module) return sum;
@@ -45,19 +45,19 @@ class OccurrenceOrderPlugin {
 				};
 
 				if(preferEntry) {
-					modules.forEach(m => {
+					for(const m of modules) {
 						const result = m.reasons.reduce(countOccursInEntry, 0) + initialChunkChunkMap.get(m) + entryCountMap.get(m);
 						occursInInitialChunksMap.set(m, result);
-					});
+					}
 				}
 
 				const originalOrder = new Map();
 				let i = 0;
-				modules.forEach(m => {
+				for(const m of modules) {
 					const result = m.reasons.reduce(countOccurs, 0) + m.getNumberOfChunks() + entryCountMap.get(m);
 					occursInAllChunksMap.set(m, result);
 					originalOrder.set(m, i++);
-				});
+				}
 
 				modules.sort((a, b) => {
 					if(preferEntry) {
@@ -80,7 +80,7 @@ class OccurrenceOrderPlugin {
 				const originalOrder = new Map();
 
 				let i = 0;
-				chunks.forEach(c => {
+				for(const c of chunks) {
 					let occurs = 0;
 					for(const chunkGroup of c.groupsIterable) {
 						for(const parent of chunkGroup.parentsIterable) {
@@ -90,19 +90,15 @@ class OccurrenceOrderPlugin {
 					}
 					occursInInitialChunksMap.set(c, occurs);
 					originalOrder.set(c, i++);
-				});
-
-				const occurs = c => {
-					return c.getNumberOfGroups();
-				};
+				}
 
 				chunks.sort((a, b) => {
 					const aEntryOccurs = occursInInitialChunksMap.get(a);
 					const bEntryOccurs = occursInInitialChunksMap.get(b);
 					if(aEntryOccurs > bEntryOccurs) return -1;
 					if(aEntryOccurs < bEntryOccurs) return 1;
-					const aOccurs = occurs(a);
-					const bOccurs = occurs(b);
+					const aOccurs = a.getNumberOfGroups();
+					const bOccurs = b.getNumberOfGroups();
 					if(aOccurs > bOccurs) return -1;
 					if(aOccurs < bOccurs) return 1;
 					const orgA = originalOrder.get(a);

--- a/lib/performance/SizeLimitsPlugin.js
+++ b/lib/performance/SizeLimitsPlugin.js
@@ -34,20 +34,21 @@ module.exports = class SizeLimitsPlugin {
 				}, 0);
 
 			const assetsOverSizeLimit = [];
-			Object.keys(compilation.assets)
-				.filter(assetFilter)
-				.forEach(assetName => {
-					const asset = compilation.assets[assetName];
-					const size = asset.size();
+			for(const assetName of Object.keys(compilation.assets)) {
+				if(!assetFilter(assetName)) {
+					continue;
+				}
 
-					if(size > assetSizeLimit) {
-						assetsOverSizeLimit.push({
-							name: assetName,
-							size: size,
-						});
-						asset.isOverSizeLimit = true;
-					}
-				});
+				const asset = compilation.assets[assetName];
+				const size = asset.size();
+				if(size > assetSizeLimit) {
+					assetsOverSizeLimit.push({
+						name: assetName,
+						size: size,
+					});
+					asset.isOverSizeLimit = true;
+				}
+			}
 
 			const entrypointsOverLimit = [];
 			for(const pair of compilation.entrypoints) {

--- a/lib/validateSchema.js
+++ b/lib/validateSchema.js
@@ -41,7 +41,7 @@ const validateObject = (schema, options) => {
 
 const filterErrors = errors => {
 	let newErrors = [];
-	errors.forEach((err) => {
+	for(const err of errors) {
 		const dataPath = err.dataPath;
 		let children = [];
 		newErrors = newErrors.filter((oldError) => {
@@ -59,7 +59,7 @@ const filterErrors = errors => {
 			err.children = children;
 		}
 		newErrors.push(err);
-	});
+	}
 
 	return newErrors;
 };

--- a/lib/web/FetchCompileWasmMainTemplatePlugin.js
+++ b/lib/web/FetchCompileWasmMainTemplatePlugin.js
@@ -31,10 +31,10 @@ class FetchCompileWasmMainTemplatePlugin {
 					hash: `" + ${JSON.stringify(chunkModuleMaps.hash)}[wasmModuleId] + "`,
 					hashWithLength(length) {
 						const shortChunkHashMap = Object.create(null);
-						Object.keys(chunkModuleMaps.hash).forEach(wasmModuleId => {
+						for(const wasmModuleId of Object.keys(chunkModuleMaps.hash)) {
 							if(typeof chunkModuleMaps.hash[wasmModuleId] === "string")
 								shortChunkHashMap[wasmModuleId] = chunkModuleMaps.hash[wasmModuleId].substr(0, length);
-						});
+						}
 						return `" + ${JSON.stringify(shortChunkHashMap)}[wasmModuleId] + "`;
 					}
 				}

--- a/lib/web/JsonpMainTemplatePlugin.js
+++ b/lib/web/JsonpMainTemplatePlugin.js
@@ -65,10 +65,10 @@ class JsonpMainTemplatePlugin {
 					hash: `" + ${JSON.stringify(chunkMaps.hash)}[chunkId] + "`,
 					hashWithLength(length) {
 						const shortChunkHashMap = Object.create(null);
-						Object.keys(chunkMaps.hash).forEach(chunkId => {
+						for(const chunkId of Object.keys(chunkMaps.hash)) {
 							if(typeof chunkMaps.hash[chunkId] === "string")
 								shortChunkHashMap[chunkId] = chunkMaps.hash[chunkId].substr(0, length);
-						});
+						}
 						return `" + ${JSON.stringify(shortChunkHashMap)}[chunkId] + "`;
 					},
 					name: `" + (${JSON.stringify(chunkMaps.name)}[chunkId]||chunkId) + "`

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -28,7 +28,9 @@ const webpack = (options, callback) => {
 		compiler.options = options;
 		new NodeEnvironmentPlugin().apply(compiler);
 		if(options.plugins && Array.isArray(options.plugins)) {
-			options.plugins.forEach(plugin => plugin.apply(compiler));
+			for(const plugin of options.plugins) {
+				plugin.apply(compiler);
+			}
 		}
 		compiler.hooks.environment.call();
 		compiler.hooks.afterEnvironment.call();
@@ -59,13 +61,13 @@ webpack.validateSchema = validateSchema;
 webpack.WebpackOptionsValidationError = WebpackOptionsValidationError;
 
 const exportPlugins = (obj, mappings) => {
-	Object.keys(mappings).forEach(name => {
+	for(const name of Object.keys(mappings)) {
 		Object.defineProperty(obj, name, {
 			configurable: false,
 			enumerable: true,
 			get: mappings[name]
 		});
-	});
+	}
 };
 
 exportPlugins(exports, {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

n/a

**Summary**

Use `for-of` loops instead of `forEach` loops to reduce memory usage in intensive builds.
Here below are some data recorded before and after this PR.

```
node v8.9.3
  before:
    build times (ms): 872, 854, 841, 845, 845, 874, 858, 863, 857, 855
    mean (ms): 856
    median (ms): 856
    used memory (MB): 33.8, 41.3, 39.5, 38.9, 36.9, 30.1, 32.8, 39.6, 31.3, 32.4
    mean (MB): 35.7
    median (MB): 35.3
  after:
    build times (ms): 882, 882, 897, 884, 887, 865, 856, 858, 867, 878
    mean (ms): 876
    median (ms): 880
    used memory (MB): 33.6, 33.7, 34.0, 33.8, 33.7, 27.2, 33.9, 33.8, 33.6, 33.6
    mean (MB): 33.1
    median (MB): 33.7

node v9.4.0
  before:
    build times (ms): 811, 804, 827, 814, 895, 823, 849, 853, 853, 835
    mean (ms): 836
    median (ms): 831
    used memory (MB): 39.0, 38.2, 38.0, 38.9, 38.8, 38.2, 38.5, 38.4, 39.1, 38.7
    mean (MB): 38.6
    median (MB): 38.6
  after:
    build times (ms): 815, 816, 832, 832, 826, 809, 823, 806, 825, 829
    mean (ms): 821
    median (ms): 824
    used memory (MB): 28.2, 32.8, 32.9, 32.5, 33.0, 27.4, 32.6, 32.7, 28.9, 33.0
    mean (MB): 31.4
    median (MB): 32.6
```

**Does this PR introduce a breaking change?**

no