### PR TITLE
Use Buffer.from instead of new Buffer

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -288,7 +288,7 @@ class Compiler extends Tapable {
 					let content = source.source();
 
 					if(!Buffer.isBuffer(content)) {
-						content = new Buffer(content, "utf8"); // eslint-disable-line
+						content = Buffer.from(content, "utf8");
 					}
 
 					source.existsAt = targetPath;

--- a/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
+++ b/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
@@ -65,7 +65,7 @@ class EvalSourceMapDevToolModuleTemplatePlugin {
 			sourceMap.sourceRoot = options.sourceRoot || "";
 			sourceMap.file = `${module.id}.js`;
 
-			const footer = self.sourceMapComment.replace(/\[url\]/g, `data:application/json;charset=utf-8;base64,${new Buffer(JSON.stringify(sourceMap), "utf8").toString("base64")}`) + //eslint-disable-line
+			const footer = self.sourceMapComment.replace(/\[url\]/g, `data:application/json;charset=utf-8;base64,${Buffer.from(JSON.stringify(sourceMap), "utf8").toString("base64")}`) +
 				`\n//# sourceURL=webpack-internal:///${module.id}\n`; // workaround for chrome bug
 			source.__EvalSourceMapDevToolData = new RawSource(`eval(${JSON.stringify(content + footer)});`);
 			return source.__EvalSourceMapDevToolData;

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -33,7 +33,7 @@ const asString = (buf) => {
 
 const asBuffer = str => {
 	if(!Buffer.isBuffer(str)) {
-		return new Buffer(str, "utf-8"); // eslint-disable-line
+		return Buffer.from(str, "utf-8");
 	}
 	return str;
 };

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -224,7 +224,7 @@ class SourceMapDevToolPlugin {
 					} else {
 						asset.__SourceMapDevToolData[file] = compilation.assets[file] = new ConcatSource(new RawSource(source), currentSourceMappingURLComment
 							.replace(/\[map\]/g, () => sourceMapString)
-							.replace(/\[url\]/g, () => `data:application/json;charset=utf-8;base64,${new Buffer(sourceMapString, "utf-8").toString("base64")}`) // eslint-disable-line
+							.replace(/\[url\]/g, () => `data:application/json;charset=utf-8;base64,${Buffer.from(sourceMapString, "utf-8").toString("base64")}`)
 						);
 					}
 				});

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -629,7 +629,7 @@ class ConcatenatedModule extends Module {
 							exportName = true;
 						} else {
 							const exportData = match[2];
-							exportName = new Buffer(exportData, "hex").toString("utf-8"); // eslint-disable-line node/no-deprecated-api
+							exportName = Buffer.from(exportData, "hex").toString("utf-8");
 						}
 						const asCall = !!match[3];
 						const strictHarmonyModule = !!match[4];
@@ -768,7 +768,7 @@ class HarmonyImportSpecifierDependencyConcatenatedTemplate {
 		} else if(dep.namespaceObjectAsContext) {
 			content = `__WEBPACK_MODULE_REFERENCE__${info.index}_ns${strictFlag}__[${JSON.stringify(dep.id)}]`;
 		} else {
-			const exportData = new Buffer(dep.id, "utf-8").toString("hex"); // eslint-disable-line node/no-deprecated-api
+			const exportData = Buffer.from(dep.id, "utf-8").toString("hex");
 			content = `__WEBPACK_MODULE_REFERENCE__${info.index}_${exportData}${callFlag}${strictFlag}__`;
 		}
 		if(dep.shorthand) {
@@ -931,7 +931,7 @@ class HarmonyExportImportedSpecifierDependencyConcatenatedTemplate {
 					if(def.id === true) {
 						finalName = `__WEBPACK_MODULE_REFERENCE__${info.index}_ns${strictFlag}__`;
 					} else {
-						const exportData = new Buffer(def.id, "utf-8").toString("hex"); // eslint-disable-line node/no-deprecated-api
+						const exportData = Buffer.from(def.id, "utf-8").toString("hex");
 						finalName = `__WEBPACK_MODULE_REFERENCE__${info.index}_${exportData}${strictFlag}__`;
 					}
 					const exportsName = this.rootModule.exportsArgument;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

n/a

**Summary**

`new Buffer` is deprecated and can be replaced by `Buffer.from` since webpack does not support node v4.

**Does this PR introduce a breaking change?**

no