### PR TITLE
perf: refactor various timestamp caches into ES6 Maps

### DIFF
--- a/lib/CachePlugin.js
+++ b/lib/CachePlugin.js
@@ -59,9 +59,11 @@ class CachePlugin {
 					});
 				}, err => {
 					if(err) return callback(err);
-					Array.from(fileTs.keys()).forEach(key => {
-						fileTs.set(key, fileTs.get(key) + this.FS_ACCURENCY);
-					});
+
+					for(const [file, ts] of fileTs) {
+						fileTs.set(file, ts + this.FS_ACCURENCY);
+					}
+
 					callback();
 				});
 			});

--- a/lib/CachePlugin.js
+++ b/lib/CachePlugin.js
@@ -42,7 +42,7 @@ class CachePlugin {
 			compiler.hooks.run.tapAsync("CachePlugin", (compiler, callback) => {
 				if(!compiler._lastCompilationFileDependencies) return callback();
 				const fs = compiler.inputFileSystem;
-				const fileTs = compiler.fileTimestamps = {};
+				const fileTs = compiler.fileTimestamps = new Map();
 				asyncLib.forEach(compiler._lastCompilationFileDependencies, (file, callback) => {
 					fs.stat(file, (err, stat) => {
 						if(err) {
@@ -53,13 +53,14 @@ class CachePlugin {
 						if(stat.mtime)
 							this.applyMtime(+stat.mtime);
 
-						fileTs[file] = +stat.mtime || Infinity;
+						fileTs.set(file, +stat.mtime || Infinity);
+
 						callback();
 					});
 				}, err => {
 					if(err) return callback(err);
-					Object.keys(fileTs).forEach(key => {
-						fileTs[key] += this.FS_ACCURENCY;
+					Array.from(fileTs.keys()).forEach(key => {
+						fileTs.set(key, fileTs.get(key) + this.FS_ACCURENCY);
 					});
 					callback();
 				});

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -78,8 +78,8 @@ class Compiler extends Tapable {
 		this.recordsOutputPath = null;
 		this.records = {};
 
-		this.fileTimestamps = {};
-		this.contextTimestamps = {};
+		this.fileTimestamps = new Map();
+		this.contextTimestamps = new Map();
 
 		this.resolverFactory = new ResolverFactory();
 		this.resolvers = {
@@ -177,8 +177,8 @@ class Compiler extends Tapable {
 	}
 
 	watch(watchOptions, handler) {
-		this.fileTimestamps = {};
-		this.contextTimestamps = {};
+		this.fileTimestamps = new Map();
+		this.contextTimestamps = new Map();
 		return new Watching(this, watchOptions, handler);
 	}
 

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -129,7 +129,7 @@ class ContextModule extends Module {
 	}
 
 	needRebuild(fileTimestamps, contextTimestamps) {
-		const ts = contextTimestamps[this.context];
+		const ts = contextTimestamps.get(this.context);
 		if(!ts) {
 			return true;
 		}

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -543,12 +543,12 @@ class NormalModule extends Module {
 		// Missing timestamp -> need rebuild
 		// Timestamp bigger than buildTimestamp -> need rebuild
 		for(const file of this.buildInfo.fileDependencies) {
-			const timestamp = fileTimestamps[file];
+			const timestamp = fileTimestamps.get(file);
 			if(!timestamp) return true;
 			if(timestamp >= this.buildTimestamp) return true;
 		}
 		for(const file of this.buildInfo.contextDependencies) {
-			const timestamp = contextTimestamps[file];
+			const timestamp = contextTimestamps.get(file);
 			if(!timestamp) return true;
 			if(timestamp >= this.buildTimestamp) return true;
 		}

--- a/lib/WatchIgnorePlugin.js
+++ b/lib/WatchIgnorePlugin.js
@@ -40,11 +40,11 @@ class IgnoringWatchFileSystem {
 			if(err) return callback(err);
 
 			ignoredFiles.forEach(path => {
-				fileTimestamps[path] = 1;
+				fileTimestamps.set(path, 1);
 			});
 
 			ignoredDirs.forEach(path => {
-				dirTimestamps[path] = 1;
+				dirTimestamps.set(path, 1);
 			});
 
 			callback(err, filesModified, dirsModified, missingModified, fileTimestamps, dirTimestamps);
@@ -56,14 +56,14 @@ class IgnoringWatchFileSystem {
 			getContextTimestamps: () => {
 				const dirTimestamps = watcher.getContextTimestamps();
 				ignoredDirs.forEach(path => {
-					dirTimestamps[path] = 1;
+					dirTimestamps.set(path, 1);
 				});
 				return dirTimestamps;
 			},
 			getFileTimestamps: () => {
 				const fileTimestamps = watcher.getFileTimestamps();
 				ignoredFiles.forEach(path => {
-					fileTimestamps[path] = 1;
+					fileTimestamps.set(path, 1);
 				});
 				return fileTimestamps;
 			}

--- a/lib/node/NodeWatchFileSystem.js
+++ b/lib/node/NodeWatchFileSystem.js
@@ -5,6 +5,7 @@
 "use strict";
 
 const Watchpack = require("watchpack");
+const objectToMap = require("../util/objectToMap");
 
 class NodeWatchFileSystem {
 	constructor(inputFileSystem) {
@@ -41,7 +42,7 @@ class NodeWatchFileSystem {
 			if(this.inputFileSystem && this.inputFileSystem.purge) {
 				this.inputFileSystem.purge(changes);
 			}
-			const times = this.watcher.getTimes();
+			const times = objectToMap(this.watcher.getTimes());
 			callback(null,
 				changes.filter(file => files.includes(file)).sort(),
 				changes.filter(file => dirs.includes(file)).sort(),
@@ -67,15 +68,15 @@ class NodeWatchFileSystem {
 			},
 			getFileTimestamps: () => {
 				if(this.watcher)
-					return this.watcher.getTimes();
+					return objectToMap(this.watcher.getTimes());
 				else
-					return {};
+					return new Map();
 			},
 			getContextTimestamps: () => {
 				if(this.watcher)
-					return this.watcher.getTimes();
+					return objectToMap(this.watcher.getTimes());
 				else
-					return {};
+					return new Map();
 			}
 		};
 	}

--- a/lib/util/objectToMap.js
+++ b/lib/util/objectToMap.js
@@ -1,0 +1,10 @@
+/**
+ * convert an object into its 2D array equivalent to be turned
+ * into an ES6 map
+ *
+ * @param {object} obj - any object type that works with Object.keys()
+ * @returns {Map} an ES6 Map of KV pairs
+ */
+module.exports = function objectToMap(obj) {
+	return new Map(Object.keys(obj).map(key => [key, obj[key]]));
+};

--- a/test/NodeWatchFileSystem.unittest.js
+++ b/test/NodeWatchFileSystem.unittest.js
@@ -68,7 +68,7 @@ describe("NodeWatchFileSystem", function() {
 			if(err) throw err;
 			filesModified.should.be.eql([fileDirect]);
 			dirsModified.should.be.eql([]);
-			fileTimestamps.get(fileDirect).should.have.type("number");
+			(typeof fileTimestamps.get(fileDirect)).should.be.eql("number");
 			watcher.close();
 			done();
 		});
@@ -87,7 +87,7 @@ describe("NodeWatchFileSystem", function() {
 				if(err) throw err;
 				filesModified.should.be.eql([fileDirect]);
 				dirsModified.should.be.eql([]);
-				fileTimestamps.get(fileDirect).should.have.type("number");
+				(typeof fileTimestamps.get(fileDirect)).should.be.eql("number");
 				watcher.close();
 				done();
 			});
@@ -104,7 +104,7 @@ describe("NodeWatchFileSystem", function() {
 			if(err) throw err;
 			filesModified.should.be.eql([]);
 			dirsModified.should.be.eql([fixtures]);
-			dirTimestamps.get(fixtures).should.have.type("number");
+			(typeof dirTimestamps.get(fixtures)).should.be.eql("number");
 			watcher.close();
 			done();
 		});
@@ -123,7 +123,7 @@ describe("NodeWatchFileSystem", function() {
 				if(err) throw err;
 				filesModified.should.be.eql([]);
 				dirsModified.should.be.eql([fixtures]);
-				dirTimestamps.get(fixtures).should.have.type("number");
+				(typeof dirTimestamps.get(fixtures)).should.be.eql("number");
 				watcher.close();
 				done();
 			});
@@ -140,7 +140,7 @@ describe("NodeWatchFileSystem", function() {
 			if(err) throw err;
 			filesModified.should.be.eql([]);
 			dirsModified.should.be.eql([fixtures]);
-			dirTimestamps.get(fixtures).should.have.type("number");
+			(typeof dirTimestamps.get(fixtures)).should.be.eql("number");
 			watcher.close();
 			done();
 		});
@@ -159,7 +159,7 @@ describe("NodeWatchFileSystem", function() {
 				if(err) throw err;
 				filesModified.should.be.eql([]);
 				dirsModified.should.be.eql([fixtures]);
-				dirTimestamps.get(fixtures).should.have.type("number");
+				(typeof dirTimestamps.get(fixtures)).should.be.eql("number");
 				watcher.close();
 				done();
 			});
@@ -177,9 +177,9 @@ describe("NodeWatchFileSystem", function() {
 				if(err) throw err;
 				filesModified.should.be.eql([fileSubdir, fileDirect]);
 				dirsModified.should.be.eql([fixtures]);
-				fileTimestamps.get(fileDirect).should.have.type("number");
-				fileTimestamps.get(fileSubdir).should.have.type("number");
-				dirTimestamps.get(fixtures).should.have.type("number");
+				(typeof fileTimestamps.get(fileDirect)).should.be.eql("number");
+				(typeof fileTimestamps.get(fileSubdir)).should.be.eql("number");
+				(typeof dirTimestamps.get(fixtures)).should.be.eql("number");
 				watcher.close();
 				done();
 			});
@@ -197,9 +197,9 @@ describe("NodeWatchFileSystem", function() {
 			if(err) throw err;
 			filesModified.should.be.eql([fileSubdir, fileDirect]);
 			dirsModified.should.be.eql([fixtures]);
-			fileTimestamps.get(fileDirect).should.have.type("number");
-			fileTimestamps.get(fileSubdir).should.have.type("number");
-			dirTimestamps.get(fixtures).should.have.type("number");
+			(typeof fileTimestamps.get(fileDirect)).should.be.eql("number");
+			(typeof fileTimestamps.get(fileSubdir)).should.be.eql("number");
+			(typeof dirTimestamps.get(fixtures)).should.be.eql("number");
 			watcher.close();
 			done();
 		});

--- a/test/NodeWatchFileSystem.unittest.js
+++ b/test/NodeWatchFileSystem.unittest.js
@@ -68,7 +68,7 @@ describe("NodeWatchFileSystem", function() {
 			if(err) throw err;
 			filesModified.should.be.eql([fileDirect]);
 			dirsModified.should.be.eql([]);
-			Object.assign({}, fileTimestamps).should.have.property(fileDirect).have.type("number");
+			fileTimestamps.get(fileDirect).should.have.type("number");
 			watcher.close();
 			done();
 		});
@@ -87,7 +87,7 @@ describe("NodeWatchFileSystem", function() {
 				if(err) throw err;
 				filesModified.should.be.eql([fileDirect]);
 				dirsModified.should.be.eql([]);
-				Object.assign({}, fileTimestamps).should.have.property(fileDirect).have.type("number");
+				fileTimestamps.get(fileDirect).should.have.type("number");
 				watcher.close();
 				done();
 			});
@@ -104,7 +104,7 @@ describe("NodeWatchFileSystem", function() {
 			if(err) throw err;
 			filesModified.should.be.eql([]);
 			dirsModified.should.be.eql([fixtures]);
-			Object.assign({}, dirTimestamps).should.have.property(fixtures).have.type("number");
+			dirTimestamps.get(fixtures).should.have.type("number");
 			watcher.close();
 			done();
 		});
@@ -123,7 +123,7 @@ describe("NodeWatchFileSystem", function() {
 				if(err) throw err;
 				filesModified.should.be.eql([]);
 				dirsModified.should.be.eql([fixtures]);
-				Object.assign({}, dirTimestamps).should.have.property(fixtures).have.type("number");
+				dirTimestamps.get(fixtures).should.have.type("number");
 				watcher.close();
 				done();
 			});
@@ -140,7 +140,7 @@ describe("NodeWatchFileSystem", function() {
 			if(err) throw err;
 			filesModified.should.be.eql([]);
 			dirsModified.should.be.eql([fixtures]);
-			Object.assign({}, dirTimestamps).should.have.property(fixtures).have.type("number");
+			dirTimestamps.get(fixtures).should.have.type("number");
 			watcher.close();
 			done();
 		});
@@ -159,7 +159,7 @@ describe("NodeWatchFileSystem", function() {
 				if(err) throw err;
 				filesModified.should.be.eql([]);
 				dirsModified.should.be.eql([fixtures]);
-				Object.assign({}, dirTimestamps).should.have.property(fixtures).have.type("number");
+				dirTimestamps.get(fixtures).should.have.type("number");
 				watcher.close();
 				done();
 			});
@@ -177,9 +177,9 @@ describe("NodeWatchFileSystem", function() {
 				if(err) throw err;
 				filesModified.should.be.eql([fileSubdir, fileDirect]);
 				dirsModified.should.be.eql([fixtures]);
-				Object.assign({}, fileTimestamps).should.have.property(fileDirect).have.type("number");
-				Object.assign({}, fileTimestamps).should.have.property(fileSubdir).have.type("number");
-				Object.assign({}, dirTimestamps).should.have.property(fixtures).have.type("number");
+				fileTimestamps.get(fileDirect).should.have.type("number");
+				fileTimestamps.get(fileSubdir).should.have.type("number");
+				dirTimestamps.get(fixtures).should.have.type("number");
 				watcher.close();
 				done();
 			});
@@ -197,9 +197,9 @@ describe("NodeWatchFileSystem", function() {
 			if(err) throw err;
 			filesModified.should.be.eql([fileSubdir, fileDirect]);
 			dirsModified.should.be.eql([fixtures]);
-			Object.assign({}, fileTimestamps).should.have.property(fileDirect).have.type("number");
-			Object.assign({}, fileTimestamps).should.have.property(fileSubdir).have.type("number");
-			Object.assign({}, dirTimestamps).should.have.property(fixtures).have.type("number");
+			fileTimestamps.get(fileDirect).should.have.type("number");
+			fileTimestamps.get(fileSubdir).should.have.type("number");
+			dirTimestamps.get(fixtures).should.have.type("number");
 			watcher.close();
 			done();
 		});

--- a/test/NormalModule.unittest.js
+++ b/test/NormalModule.unittest.js
@@ -241,14 +241,14 @@ describe("NormalModule", function() {
 			fileB = "fileB";
 			fileDependencies = [fileA, fileB];
 			contextDependencies = [fileA, fileB];
-			fileTimestamps = {
-				[fileA]: 1,
-				[fileB]: 1,
-			};
-			contextTimestamps = {
-				[fileA]: 1,
-				[fileB]: 1,
-			};
+			fileTimestamps = new Map([
+				[fileA, 1],
+				[fileB, 1]
+			]);
+			contextTimestamps = new Map([
+				[fileA, 1],
+				[fileB, 1],
+			]);
 			normalModule.buildTimestamp = 2;
 			setDeps(fileDependencies, contextDependencies);
 		});
@@ -259,7 +259,7 @@ describe("NormalModule", function() {
 		});
 		describe("given a file timestamp is newer than the buildTimestamp", function() {
 			beforeEach(function() {
-				fileTimestamps[fileA] = 3;
+				fileTimestamps.set(fileA, 3);
 			});
 			it("returns true", function() {
 				normalModule.needRebuild(fileTimestamps, contextTimestamps).should.eql(true);
@@ -267,7 +267,7 @@ describe("NormalModule", function() {
 		});
 		describe("given a no file timestamp exists", function() {
 			beforeEach(function() {
-				fileTimestamps = {};
+				fileTimestamps = new Map();
 			});
 			it("returns true", function() {
 				normalModule.needRebuild(fileTimestamps, contextTimestamps).should.eql(true);
@@ -275,7 +275,7 @@ describe("NormalModule", function() {
 		});
 		describe("given a context timestamp is newer than the buildTimestamp", function() {
 			beforeEach(function() {
-				contextTimestamps[fileA] = 3;
+				contextTimestamps.set(fileA, 3);
 			});
 			it("returns true", function() {
 				normalModule.needRebuild(fileTimestamps, contextTimestamps).should.eql(true);
@@ -283,7 +283,7 @@ describe("NormalModule", function() {
 		});
 		describe("given a no context timestamp exists", function() {
 			beforeEach(function() {
-				contextTimestamps = {};
+				contextTimestamps = new Map();
 			});
 			it("returns true", function() {
 				normalModule.needRebuild(fileTimestamps, contextTimestamps).should.eql(true);

--- a/test/objectToMap.unittest.js
+++ b/test/objectToMap.unittest.js
@@ -1,0 +1,17 @@
+/* globals describe it */
+
+require("should");
+
+var objectToMap = require("../lib/util/objectToMap");
+
+describe("objectToMap", function() {
+	it("should convert a plain object into a Map successfully", function() {
+		const map = objectToMap({
+			foo: "bar",
+			bar: "baz"
+		});
+
+		map.get("foo").should.eql("bar");
+		map.get("bar").should.eql("baz");
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

modified existing unit tests

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

n/a
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

This change satisfies https://github.com/webpack/webpack/issues/6234 which desires to change the timestamp caches from plain objects to the ES6 Map type to avoid deopts, since v8 expects things to be added to Maps but objects are only fast if properties aren't added dynamically after initial assignment.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

I think yes if anything is downstream is using `compiler.fileTimestamps` or `compiler.contextTimestamps`.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
