### PR TITLE
Deprecate forEach* and map* methods

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -133,16 +133,6 @@ class Chunk {
 		return this._modules;
 	}
 
-	// TODO remove and replace calls with for of loop
-	forEachModule(fn) {
-		this._modules.forEach(fn);
-	}
-
-	// TODO remove and replace calls with Array.from
-	mapModules(fn) {
-		return Array.from(this._modules, fn);
-	}
-
 	addGroup(chunkGroup) {
 		if(this._groups.has(chunkGroup))
 			return false;
@@ -417,11 +407,27 @@ class Chunk {
 	}
 }
 
+// TODO remove in webpack 5
+Object.defineProperty(Chunk.prototype, "forEachModule", {
+	configurable: false,
+	value: util.deprecate(function(fn) {
+		this._modules.forEach(fn);
+	}, "Chunk.forEachModule: Use for(const module of chunk.modulesIterable) instead")
+});
+
+// TODO remove in webpack 5
+Object.defineProperty(Chunk.prototype, "mapModules", {
+	configurable: false,
+	value: util.deprecate(function(fn) {
+		return Array.from(this._modules, fn);
+	}, "Chunk.mapModules: Use Array.from(chunk.modulesIterable, fn) instead")
+});
+
 Object.defineProperty(Chunk.prototype, "modules", {
 	configurable: false,
 	get: util.deprecate(function() {
 		return this._modules.getFromCache(getFrozenArray);
-	}, "Chunk.modules is deprecated. Use Chunk.getNumberOfModules/mapModules/forEachModule/containsModule instead."),
+	}, "Chunk.modules is deprecated. Use Chunk.getNumberOfModules/containsModule/modulesIterable instead."),
 	set: util.deprecate(function(value) {
 		this.setModules(value);
 	}, "Chunk.modules is deprecated. Use Chunk.addModule/removeModule instead.")

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1280,7 +1280,9 @@ class Compilation extends Tapable {
 				return;
 			}
 			if(d.module.removeReason(module, d)) {
-				d.module.forEachChunk(chunk => this.patchChunksAfterReasonRemoval(d.module, chunk));
+				for(const chunk of d.module.chunksIterable) {
+					this.patchChunksAfterReasonRemoval(d.module, chunk);
+				}
 			}
 		};
 

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -63,7 +63,7 @@ module.exports = class HotModuleReplacementPlugin {
 				});
 				records.chunkModuleIds = {};
 				compilation.chunks.forEach(chunk => {
-					records.chunkModuleIds[chunk.id] = chunk.mapModules(m => m.id);
+					records.chunkModuleIds[chunk.id] = Array.from(chunk.modulesIterable, m => m.id);
 				});
 			});
 			let initialPass = false;

--- a/lib/LibManifestPlugin.js
+++ b/lib/LibManifestPlugin.js
@@ -30,7 +30,7 @@ class LibManifestPlugin {
 				const manifest = {
 					name,
 					type: this.options.type,
-					content: chunk.mapModules(module => {
+					content: Array.from(chunk.modulesIterable, module => {
 						if(module.libIdent) {
 							const ident = module.libIdent({
 								context: this.options.context || compiler.options.context

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -148,14 +148,6 @@ class Module extends DependenciesBlock {
 		return this.reasons.length > 0 && this.reasons.every(r => r.dependency && r.dependency.optional);
 	}
 
-	forEachChunk(fn) {
-		this._chunks.forEach(fn);
-	}
-
-	mapChunks(fn) {
-		return Array.from(this._chunks, fn);
-	}
-
 	getChunks() {
 		return Array.from(this._chunks);
 	}
@@ -302,6 +294,22 @@ class Module extends DependenciesBlock {
 	}
 }
 
+// TODO remove in webpack 5
+Object.defineProperty(Module.prototype, "forEachChunk", {
+	configurable: false,
+	value: util.deprecate(function(fn) {
+		this._chunks.forEach(fn);
+	}, "Module.forEachChunk: Use for(const chunk of module.chunksIterable) instead")
+});
+
+// TODO remove in webpack 5
+Object.defineProperty(Module.prototype, "mapChunks", {
+	configurable: false,
+	value: util.deprecate(function(fn) {
+		return Array.from(this._chunks, fn);
+	}, "Module.mapChunks: Use Array.from(module.chunksIterable, fn) instead")
+});
+
 Object.defineProperty(Module.prototype, "entry", {
 	configurable: false,
 	get() {
@@ -316,7 +324,7 @@ Object.defineProperty(Module.prototype, "chunks", {
 	configurable: false,
 	get: util.deprecate(function() {
 		return this._chunks.getFromCache(getFrozenArray);
-	}, "Module.chunks: Use Module.forEachChunk/mapChunks/getNumberOfChunks/isInChunk/addChunk/removeChunk instead"),
+	}, "Module.chunks: Use Module.chunksIterable/getNumberOfChunks/isInChunk/addChunk/removeChunk instead"),
 	set() {
 		throw new Error("Readonly. Use Module.addChunk/removeChunk to modify chunks.");
 	}

--- a/lib/ModuleFilenameHelpers.js
+++ b/lib/ModuleFilenameHelpers.js
@@ -125,7 +125,7 @@ ModuleFilenameHelpers.createFooter = (module, requestShortener) => {
 			"// WEBPACK FOOTER",
 			`// ${module.readableIdentifier(requestShortener)}`,
 			`// module id = ${module.id}`,
-			`// module chunks = ${module.mapChunks(c => c.id).join(" ")}`
+			`// module chunks = ${Array.from(module.chunksIterable, c => c.id).join(" ")}`
 		].join("\n");
 	}
 };

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -340,7 +340,7 @@ class Stats {
 				built: !!module.built,
 				optional: module.optional,
 				prefetched: module.prefetched,
-				chunks: module.mapChunks(chunk => chunk.id),
+				chunks: Array.from(module.chunksIterable, chunk => chunk.id),
 				assets: Object.keys(module.assets || {}),
 				issuer: module.issuer && module.issuer.identifier(),
 				issuerId: module.issuer && module.issuer.id,

--- a/lib/optimize/OccurrenceOrderPlugin.js
+++ b/lib/optimize/OccurrenceOrderPlugin.js
@@ -23,10 +23,10 @@ class OccurrenceOrderPlugin {
 				modules.forEach(m => {
 					let initial = 0;
 					let entry = 0;
-					m.forEachChunk(c => {
+					for(const c of m.chunksIterable) {
 						if(c.canBeInitial()) initial++;
 						if(c.entryModule === m) entry++;
-					});
+					}
 					initialChunkChunkMap.set(m, initial);
 					entryCountMap.set(m, entry);
 				});

--- a/test/statsCases/named-chunks-plugin-async/webpack.config.js
+++ b/test/statsCases/named-chunks-plugin-async/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
 			if(chunk.name) {
 				return chunk.name;
 			}
-			const chunkModulesToName = (chunk) => chunk.mapModules((mod) => {
+			const chunkModulesToName = (chunk) => Array.from(chunk.modulesIterable, (mod) => {
 				const rs = new RequestShortener(mod.context);
 				return rs.shorten(mod.request).replace(/[./\\]/g, "_");
 			}).join("-");


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

TODO

**Summary**

`forEach*` and `map*` methods are not needed and add complexity to webpack. Since these modules could be replaced by `Array.from()`, there are safe to deprecate.

**Does this PR introduce a breaking change?**

no