### PR TITLE
Remove v3 deprecated APIs

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -4,7 +4,6 @@
 */
 "use strict";
 
-const util = require("util");
 const SortableSet = require("./util/SortableSet");
 const GraphHelpers = require("./GraphHelpers");
 let debugId = 1000;
@@ -20,8 +19,6 @@ const sortByIdentifier = (a, b) => {
 	if(a.identifier() < b.identifier()) return -1;
 	return 0;
 };
-
-const getFrozenArray = set => Object.freeze(Array.from(set));
 
 const getModulesIdent = set => {
 	set.sort();
@@ -417,16 +414,7 @@ class Chunk {
 	}
 }
 
-Object.defineProperty(Chunk.prototype, "modules", {
-	configurable: false,
-	get: util.deprecate(function() {
-		return this._modules.getFromCache(getFrozenArray);
-	}, "Chunk.modules is deprecated. Use Chunk.getNumberOfModules/mapModules/forEachModule/containsModule instead."),
-	set: util.deprecate(function(value) {
-		this.setModules(value);
-	}, "Chunk.modules is deprecated. Use Chunk.addModule/removeModule instead.")
-});
-
+// TODO remove in webpack 5
 Object.defineProperty(Chunk.prototype, "chunks", {
 	configurable: false,
 	get() {
@@ -437,6 +425,7 @@ Object.defineProperty(Chunk.prototype, "chunks", {
 	}
 });
 
+// TODO remove in webpack 5
 Object.defineProperty(Chunk.prototype, "parents", {
 	configurable: false,
 	get() {
@@ -447,6 +436,7 @@ Object.defineProperty(Chunk.prototype, "parents", {
 	}
 });
 
+// TODO remove in webpack 5
 Object.defineProperty(Chunk.prototype, "blocks", {
 	configurable: false,
 	get() {
@@ -457,6 +447,7 @@ Object.defineProperty(Chunk.prototype, "blocks", {
 	}
 });
 
+// TODO remove in webpack 5
 Object.defineProperty(Chunk.prototype, "entrypoints", {
 	configurable: false,
 	get() {

--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -4,6 +4,7 @@
 */
 "use strict";
 
+const util = require("util");
 const SortableSet = require("./util/SortableSet");
 const GraphHelpers = require("./GraphHelpers");
 let debugId = 1000;

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1697,10 +1697,12 @@ class Compilation extends Tapable {
 	}
 }
 
+// TODO remove in webpack 5
 Compilation.prototype.applyPlugins = util.deprecate(function(name, ...args) {
 	this.hooks[name.replace(/[- ]([a-z])/g, match => match[1].toUpperCase())].call(...args);
 }, "Compilation.applyPlugins is deprecated. Use new API on `.hooks` instead");
 
+// TODO remove in webpack 5
 Object.defineProperty(Compilation.prototype, "moduleTemplate", {
 	configurable: false,
 	get: util.deprecate(function() {

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -82,6 +82,8 @@ class Compiler extends Tapable {
 		this.contextTimestamps = {};
 
 		this.resolverFactory = new ResolverFactory();
+
+		// TODO remove in webpack 5
 		this.resolvers = {
 			normal: {
 				plugins: util.deprecate(
@@ -143,30 +145,6 @@ class Compiler extends Tapable {
 					"Use compiler.resolverFactory.plugin(\"resolver context\", resolver => {\n  resolver.apply(/* ... */);\n}); instead."
 				)
 			}
-		};
-		this.parser = {
-			plugin: util.deprecate(
-				(hook, fn) => {
-					this.plugin("compilation", (compilation, data) => {
-						data.normalModuleFactory.plugin("parser", parser => {
-							parser.plugin(hook, fn);
-						});
-					});
-				},
-				"webpack: Using compiler.parser is deprecated.\n" +
-				"Use compiler.plugin(\"compilation\", function(compilation, data) {\n  data.normalModuleFactory.plugin(\"parser\", function(parser, options) { parser.plugin(/* ... */); });\n}); instead. "
-			),
-			apply: util.deprecate(
-				(...args) => {
-					this.plugin("compilation", (compilation, data) => {
-						data.normalModuleFactory.plugin("parser", parser => {
-							parser.apply(...args);
-						});
-					});
-				},
-				"webpack: Using compiler.parser is deprecated.\n" +
-				"Use compiler.plugin(\"compilation\", function(compilation, data) {\n  data.normalModuleFactory.plugin(\"parser\", function(parser, options) { parser.apply(/* ... */); });\n}); instead. "
-			)
 		};
 
 		this.options = {};

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -597,6 +597,7 @@ webpackEmptyAsyncContext.id = ${JSON.stringify(id)};`;
 	}
 }
 
+// TODO remove in webpack 5
 Object.defineProperty(ContextModule.prototype, "recursive", {
 	configurable: false,
 	get: util.deprecate(function() {
@@ -607,6 +608,7 @@ Object.defineProperty(ContextModule.prototype, "recursive", {
 	}, "ContextModule.recursive has been moved to ContextModule.options.recursive")
 });
 
+// TODO remove in webpack 5
 Object.defineProperty(ContextModule.prototype, "regExp", {
 	configurable: false,
 	get: util.deprecate(function() {
@@ -617,6 +619,7 @@ Object.defineProperty(ContextModule.prototype, "regExp", {
 	}, "ContextModule.regExp has been moved to ContextModule.options.regExp")
 });
 
+// TODO remove in webpack 5
 Object.defineProperty(ContextModule.prototype, "addon", {
 	configurable: false,
 	get: util.deprecate(function() {
@@ -627,6 +630,7 @@ Object.defineProperty(ContextModule.prototype, "addon", {
 	}, "ContextModule.addon has been moved to ContextModule.options.addon")
 });
 
+// TODO remove in webpack 5
 Object.defineProperty(ContextModule.prototype, "async", {
 	configurable: false,
 	get: util.deprecate(function() {
@@ -637,6 +641,7 @@ Object.defineProperty(ContextModule.prototype, "async", {
 	}, "ContextModule.async has been moved to ContextModule.options.mode")
 });
 
+// TODO remove in webpack 5
 Object.defineProperty(ContextModule.prototype, "chunkName", {
 	configurable: false,
 	get: util.deprecate(function() {

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -23,8 +23,6 @@ const sortByDebugId = (a, b) => {
 	return a.debugId - b.debugId;
 };
 
-const getFrozenArray = set => Object.freeze(Array.from(set));
-
 class Module extends DependenciesBlock {
 
 	constructor(type) {
@@ -302,6 +300,7 @@ class Module extends DependenciesBlock {
 	}
 }
 
+// TODO remove in webpack 5
 Object.defineProperty(Module.prototype, "entry", {
 	configurable: false,
 	get() {
@@ -312,16 +311,7 @@ Object.defineProperty(Module.prototype, "entry", {
 	}
 });
 
-Object.defineProperty(Module.prototype, "chunks", {
-	configurable: false,
-	get: util.deprecate(function() {
-		return this._chunks.getFromCache(getFrozenArray);
-	}, "Module.chunks: Use Module.forEachChunk/mapChunks/getNumberOfChunks/isInChunk/addChunk/removeChunk instead"),
-	set() {
-		throw new Error("Readonly. Use Module.addChunk/removeChunk to modify chunks.");
-	}
-});
-
+// TODO remove in webpack 5
 Object.defineProperty(Module.prototype, "meta", {
 	configurable: false,
 	get: util.deprecate(function() {

--- a/lib/ModuleReason.js
+++ b/lib/ModuleReason.js
@@ -4,8 +4,6 @@
 */
 "use strict";
 
-const util = require("util");
-
 class ModuleReason {
 	constructor(module, dependency, explanation) {
 		this.module = module;
@@ -41,15 +39,5 @@ class ModuleReason {
 		}
 	}
 }
-
-Object.defineProperty(ModuleReason.prototype, "chunks", {
-	configurable: false,
-	get: util.deprecate(function() {
-		return this._chunks ? Array.from(this._chunks) : null;
-	}, "ModuleReason.chunks: Use ModuleReason.hasChunk/rewriteChunks instead"),
-	set() {
-		throw new Error("Readonly. Use ModuleReason.rewriteChunks to modify chunks.");
-	}
-});
 
 module.exports = ModuleReason;

--- a/lib/util/StackedSetMap.js
+++ b/lib/util/StackedSetMap.js
@@ -115,6 +115,7 @@ class StackedSetMap {
 	}
 }
 
+// TODO remove in webpack 5
 StackedSetMap.prototype.push = util.deprecate(function(item) {
 	this.add(item);
 }, "This is no longer an Array: Use add instead.");


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

TODO

**Summary**

Remove APIs that were deprecated in v3:

 - `Chunk.modules`
 - `Module.chunks`
 - `ModuleReason.chunks`
 - `Compiler.parser`

I added a comment above the deprecated APIs in v4 to be easily identified when v5 development will start.

**Does this PR introduce a breaking change?**

yes