### PR TITLE
Allow jsonp promise global to be configured in output.promiseGlobal

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -91,6 +91,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("output.jsonpFunction", "make", options => {
 			return Template.toIdentifier("webpackJsonp" + Template.toIdentifier(options.output.library));
 		});
+		this.set("output.promiseGlobal", "Promise");
 		this.set("output.chunkCallbackName", "make", options => {
 			return Template.toIdentifier("webpackChunk" + Template.toIdentifier(options.output.library));
 		});

--- a/lib/web/JsonpMainTemplatePlugin.js
+++ b/lib/web/JsonpMainTemplatePlugin.js
@@ -116,6 +116,7 @@ class JsonpMainTemplatePlugin {
 			]);
 		});
 		mainTemplate.hooks.requireEnsure.tap("JsonpMainTemplatePlugin", (source, chunk, hash) => {
+			const promiseGlobal = mainTemplate.outputOptions.promiseGlobal;
 			return Template.asString([
 				source,
 				"",
@@ -133,7 +134,7 @@ class JsonpMainTemplatePlugin {
 					"} else {",
 					Template.indent([
 						"// setup Promise in chunk cache",
-						"var promise = new Promise(function(resolve, reject) {",
+						"var promise = new " + promiseGlobal + "(function(resolve, reject) {",
 						Template.indent([
 							"installedChunkData = installedChunks[chunkId] = [resolve, reject];"
 						]),

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -477,6 +477,10 @@
           "description": "The JSONP function used by webpack for async loading of chunks.",
           "type": "string"
         },
+        "promiseGlobal": {
+          "description": "The Promise global used for async loading of chunks.",
+          "type": "string"
+        },
         "chunkCallbackName": {
           "description": "The callback function name used by webpack for loading of chunks in WebWorkers.",
           "type": "string"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Config change to allow support for jsonp in older browsers, without window.Promise polyfill

**Did you add tests for your changes?**

(Will do, but first want to get some feedback on the change to see if it's viable)

**If relevant, link to documentation update:**

(Will do, but first want to get some feedback on the change to see if it's viable)

**Summary**

This fixes the fact that presently, `new Promise` is hard-coded in JsonpMainTemplatePlugin. This prevents using jsonp or chunking without first polyfilling window.Promise. Polyfilling is not advisable when building scripts to run on third party domains, such as SDKs or libraries which need to be run across many different sites where the browser environment is not under the direct control of the script author.

For example:

```javascript
output: {
    promiseGlobal: '__my_custom_promise__'
}
```

Now `window.__my_custom_promise__` can be safely set without modifying or polyfilling `window.Promise`, and `window.__my_custom_promise__` will be used for any jsonp fetching.

This provides a path forward for the issue at https://github.com/webpack/webpack/issues/3531

**Does this PR introduce a breaking change?**

No

**Other information**

n/a
