### PR TITLE
Exit top level scope when traversing Class nodes

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -609,9 +609,13 @@ class Parser extends Tapable {
 		if(classy.superClass)
 			this.walkExpression(classy.superClass);
 		if(classy.body && classy.body.type === "ClassBody") {
-			for(const methodDefinition of classy.body.body)
+			const wasTopLevel = this.scope.topLevelScope;
+			this.scope.topLevelScope = false;
+			for(const methodDefinition of classy.body.body) {
 				if(methodDefinition.type === "MethodDefinition")
 					this.walkMethodDefinition(methodDefinition);
+			}
+			this.scope.topLevelScope = wasTopLevel;
 		}
 	}
 

--- a/test/configCases/parsing/harmony-this/abc.js
+++ b/test/configCases/parsing/harmony-this/abc.js
@@ -22,6 +22,13 @@ export class C {
 	foo() {
 		return this.x;
 	}
+	bar(x = this.x) {
+		return x;
+	}
+}
+
+export const extendThisClass = () => {
+	return class extends this.Buffer {};
 }
 
 export function D() {

--- a/test/configCases/parsing/harmony-this/index.js
+++ b/test/configCases/parsing/harmony-this/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import d, {a, b as B, C as _C, D as _D, returnThisArrow, returnThisMember, that} from "./abc";
+import d, {a, b as B, C as _C, D as _D, extendThisClass, returnThisArrow, returnThisMember, that} from "./abc";
 
 import * as abc from "./abc";
 
@@ -15,10 +15,14 @@ it("should have this = undefined on harmony modules", function() {
 	(function() {
 		abc.returnThisMember();
 	}).should.throw();
+	(function() {
+		extendThisClass();
+	}).should.throw();
 });
 
 it("should not break classes and functions", function() {
 	(new _C).foo().should.be.eql("bar");
+	(new _C).bar().should.be.eql("bar");
 	(new _D).prop().should.be.eql("ok");
 });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

yes

**If relevant, link to documentation update:**

n/a

**Summary**

Due to a scope issue, some `this` statement were wrongly erased.

**Does this PR introduce a breaking change?**

no

**Other information**

This change also paves the road to class properties.
Fixes #6379