### PR TITLE
Transform done hook into async

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -28,7 +28,7 @@ class Compiler extends Tapable {
 		super();
 		this.hooks = {
 			shouldEmit: new SyncBailHook(["compilation"]),
-			done: new SyncHook(["stats"]),
+			done: new AsyncSeriesHook(["stats"]),
 			additionalPass: new AsyncSeriesHook([]),
 			beforeRun: new AsyncSeriesHook(["compilation"]),
 			run: new AsyncSeriesHook(["compilation"]),
@@ -171,8 +171,11 @@ class Compiler extends Tapable {
 				const stats = new Stats(compilation);
 				stats.startTime = startTime;
 				stats.endTime = Date.now();
-				this.hooks.done.call(stats);
-				return callback(null, stats);
+				this.hooks.done.callAsync(stats, err => {
+					if(err) return callback(err);
+					return callback(null, stats);
+				});
+				return;
 			}
 
 			this.emitAssets(compilation, err => {
@@ -184,11 +187,13 @@ class Compiler extends Tapable {
 					const stats = new Stats(compilation);
 					stats.startTime = startTime;
 					stats.endTime = Date.now();
-					this.hooks.done.call(stats);
-
-					this.hooks.additionalPass.callAsync(err => {
+					this.hooks.done.callAsync(stats, err => {
 						if(err) return callback(err);
-						this.compile(onCompiled);
+
+						this.hooks.additionalPass.callAsync(err => {
+							if(err) return callback(err);
+							this.compile(onCompiled);
+						});
 					});
 					return;
 				}
@@ -199,8 +204,10 @@ class Compiler extends Tapable {
 					const stats = new Stats(compilation);
 					stats.startTime = startTime;
 					stats.endTime = Date.now();
-					this.hooks.done.call(stats);
-					return callback(null, stats);
+					this.hooks.done.callAsync(stats, err => {
+						if(err) return callback(err);
+						return callback(null, stats);
+					});
 				});
 			});
 		};

--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -59,11 +59,13 @@ class Watching {
 							const stats = new Stats(compilation);
 							stats.startTime = this.startTime;
 							stats.endTime = Date.now();
-							this.compiler.hooks.done.call(stats);
-
-							this.compiler.hooks.additionalPass.callAsync(err => {
+							this.compiler.hooks.done.callAsync(stats, err => {
 								if(err) return this._done(err);
-								this.compiler.compile(onCompiled);
+
+								this.compiler.hooks.additionalPass.callAsync(err => {
+									if(err) return this._done(err);
+									this.compiler.compile(onCompiled);
+								});
 							});
 							return;
 						}
@@ -93,13 +95,14 @@ class Watching {
 			return;
 		}
 
-		this.compiler.hooks.done.call(stats);
-		this.handler(null, stats);
-		if(!this.closed) {
-			this.watch(Array.from(compilation.fileDependencies), Array.from(compilation.contextDependencies), Array.from(compilation.missingDependencies));
-		}
-		for(const cb of this.callbacks) cb();
-		this.callbacks.length = 0;
+		this.compiler.hooks.done.callAsync(stats, () => {
+			this.handler(null, stats);
+			if(!this.closed) {
+				this.watch(Array.from(compilation.fileDependencies), Array.from(compilation.contextDependencies), Array.from(compilation.missingDependencies));
+			}
+			for(const cb of this.callbacks) cb();
+			this.callbacks.length = 0;
+		});
 	}
 
 	watch(files, dirs, missing) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

It makes the `done` compiler hook async.

**Did you add tests for your changes?**

Not yet, not sure what to add.

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

To be able to track our build time, I want my CI to send timings via HTTP to a server. Today this does not seem possible, as the only hook where I can get these timings is the `done` hook, but it is synchronous, and thus making async HTTP requests in it is not possible.

**Does this PR introduce a breaking change?**

Not sure yet.

**Other information**
