### PR TITLE
Add "single" option to RuntimeChunkPlugin

### DIFF
--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -291,7 +291,7 @@ class WebpackOptionsApply extends OptionsApply {
 		if(options.optimization.splitChunks)
 			new SplitChunksPlugin(options.optimization.splitChunks).apply(compiler);
 		if(options.optimization.runtimeChunk)
-			new RuntimeChunkPlugin().apply(compiler);
+			new RuntimeChunkPlugin(options.optimization.runtimeChunk).apply(compiler);
 		if(options.optimization.noEmitOnErrors)
 			new NoEmitOnErrorsPlugin().apply(compiler);
 		if(options.optimization.namedModules)

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -181,6 +181,19 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 			test: /[\\/]node_modules[\\/]/,
 			priority: -10
 		});
+		this.set("optimization.runtimeChunk", "call", value => {
+			if(value === "single") {
+				return {
+					name: "runtime"
+				};
+			}
+			if(value === true) {
+				return {
+					name: entrypoint => `runtime~${entrypoint.name}`
+				};
+			}
+			return value;
+		});
 		this.set("optimization.noEmitOnErrors", "make", options => isProductionLikeMode(options));
 		this.set("optimization.namedModules", "make", options => options.mode === "development");
 		this.set("optimization.namedChunks", "make", options => options.mode === "development");

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -187,7 +187,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 					name: "runtime"
 				};
 			}
-			if(value === true) {
+			if(value === true || value === "multiple") {
 				return {
 					name: entrypoint => `runtime~${entrypoint.name}`
 				};

--- a/lib/optimize/RuntimeChunkPlugin.js
+++ b/lib/optimize/RuntimeChunkPlugin.js
@@ -5,15 +5,19 @@
 "use strict";
 
 module.exports = class RuntimeChunkPlugin {
-	constructor(options) {}
+	constructor(options) {
+		this.single = options === "single";
+	}
 
 	apply(compiler) {
 		compiler.hooks.thisCompilation.tap("RuntimeChunkPlugin", compilation => {
 			compilation.hooks.optimizeChunksAdvanced.tap("RuntimeChunkPlugin", () => {
+				const singleRuntimeChunk = this.single ? compilation.addChunk("runtime") : undefined;
+
 				for(const entrypoint of compilation.entrypoints.values()) {
 					const chunk = entrypoint.getRuntimeChunk();
 					if(chunk.getNumberOfModules() > 0) {
-						const newChunk = compilation.addChunk(entrypoint.name + "-runtime");
+						const newChunk = this.single ? singleRuntimeChunk : compilation.addChunk(entrypoint.name + "-runtime");
 						entrypoint.unshiftChunk(newChunk);
 						newChunk.addGroup(entrypoint);
 						entrypoint.setRuntimeChunk(newChunk);

--- a/lib/optimize/RuntimeChunkPlugin.js
+++ b/lib/optimize/RuntimeChunkPlugin.js
@@ -6,18 +6,22 @@
 
 module.exports = class RuntimeChunkPlugin {
 	constructor(options) {
-		this.single = options === "single";
+		this.options = Object.assign({
+			name: entrypoint => `runtime~${entrypoint.name}`
+		}, options);
 	}
 
 	apply(compiler) {
 		compiler.hooks.thisCompilation.tap("RuntimeChunkPlugin", compilation => {
 			compilation.hooks.optimizeChunksAdvanced.tap("RuntimeChunkPlugin", () => {
-				const singleRuntimeChunk = this.single ? compilation.addChunk("runtime") : undefined;
-
 				for(const entrypoint of compilation.entrypoints.values()) {
 					const chunk = entrypoint.getRuntimeChunk();
 					if(chunk.getNumberOfModules() > 0) {
-						const newChunk = this.single ? singleRuntimeChunk : compilation.addChunk(entrypoint.name + "-runtime");
+						let name = this.options.name;
+						if(typeof name === "function") {
+							name = name(entrypoint);
+						}
+						const newChunk = compilation.addChunk(name);
 						entrypoint.unshiftChunk(newChunk);
 						newChunk.addGroup(entrypoint);
 						entrypoint.setRuntimeChunk(newChunk);

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1490,7 +1490,8 @@
             },
             {
               "enum": [
-                "single"
+                "single",
+                "multiple"
               ]
             },
             {

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1484,7 +1484,16 @@
         },
         "runtimeChunk": {
           "description": "Create an additional chunk which contains only the webpack runtime and chunk hash maps",
-          "type": "boolean"
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "enum": [
+                "single"
+              ]
+            }
+          ]
         },
         "noEmitOnErrors": {
           "description": "Avoid emitting assets when errors occur",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1492,6 +1492,23 @@
               "enum": [
                 "single"
               ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "description": "The name or name factory for the runtime chunks",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "instanceof": "Function"
+                    }
+                  ]
+                }
+              }
             }
           ]
         },

--- a/test/statsCases/runtime-chunk-single/e1.js
+++ b/test/statsCases/runtime-chunk-single/e1.js
@@ -1,0 +1,1 @@
+module.exports = "entry1";

--- a/test/statsCases/runtime-chunk-single/e2.js
+++ b/test/statsCases/runtime-chunk-single/e2.js
@@ -1,0 +1,1 @@
+module.exports = "entry2";

--- a/test/statsCases/runtime-chunk-single/expected.txt
+++ b/test/statsCases/runtime-chunk-single/expected.txt
@@ -1,0 +1,2 @@
+Entrypoint e1 = runtime.js e1.js
+Entrypoint e2 = runtime.js e2.js

--- a/test/statsCases/runtime-chunk-single/webpack.config.js
+++ b/test/statsCases/runtime-chunk-single/webpack.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+	mode: "development",
+	entry: {
+		e1: "./e1",
+		e2: "./e2"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	stats: {
+		hash: false,
+		timings: false,
+		assets: false,
+		modules: false,
+		reasons: true
+	},
+	optimization: {
+		runtimeChunk: "single"
+	}
+};

--- a/test/statsCases/runtime-chunk-single/webpack.config.js
+++ b/test/statsCases/runtime-chunk-single/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
 	stats: {
 		hash: false,
 		timings: false,
+		builtAt: false,
 		assets: false,
 		modules: false,
 		reasons: true

--- a/test/statsCases/runtime-chunk/e1.js
+++ b/test/statsCases/runtime-chunk/e1.js
@@ -1,0 +1,1 @@
+module.exports = "entry1";

--- a/test/statsCases/runtime-chunk/e2.js
+++ b/test/statsCases/runtime-chunk/e2.js
@@ -1,0 +1,1 @@
+module.exports = "entry2";

--- a/test/statsCases/runtime-chunk/expected.txt
+++ b/test/statsCases/runtime-chunk/expected.txt
@@ -1,0 +1,2 @@
+Entrypoint e1 = e1-runtime.js e1.js
+Entrypoint e2 = e2-runtime.js e2.js

--- a/test/statsCases/runtime-chunk/expected.txt
+++ b/test/statsCases/runtime-chunk/expected.txt
@@ -1,2 +1,2 @@
-Entrypoint e1 = e1-runtime.js e1.js
-Entrypoint e2 = e2-runtime.js e2.js
+Entrypoint e1 = runtime~e1.js e1.js
+Entrypoint e2 = runtime~e2.js e2.js

--- a/test/statsCases/runtime-chunk/webpack.config.js
+++ b/test/statsCases/runtime-chunk/webpack.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+	mode: "development",
+	entry: {
+		e1: "./e1",
+		e2: "./e2"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	stats: {
+		hash: false,
+		timings: false,
+		assets: false,
+		modules: false,
+		reasons: false
+	},
+	optimization: {
+		runtimeChunk: true
+	}
+};

--- a/test/statsCases/runtime-chunk/webpack.config.js
+++ b/test/statsCases/runtime-chunk/webpack.config.js
@@ -15,6 +15,6 @@ module.exports = {
 		reasons: false
 	},
 	optimization: {
-		runtimeChunk: true
+		runtimeChunk: "multiple"
 	}
 };

--- a/test/statsCases/runtime-chunk/webpack.config.js
+++ b/test/statsCases/runtime-chunk/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
 	stats: {
 		hash: false,
 		timings: false,
+		builtAt: false,
 		assets: false,
 		modules: false,
 		reasons: false


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Add config option `optimization.runtimeChunk: 'single'` to generate a single runtime chunk for all entrypoints instead of each entrypoint getting their own runtime.

**Did you add tests for your changes?**

Basic tests for the existence of runtime files, nothing that tests that the contents of the runtime file are generated correctly.

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
My company's webpack setup involves including multiple entrypoint files on a page, so adding a separate runtime chunk for each entrypoint results in too many parallel loading chunks.

See @sokra's comment in the alpha.5 issue: https://github.com/webpack/webpack/issues/6357#issuecomment-360435877

**Does this PR introduce a breaking change?**

No, just a new option in the config and the RuntimeChunkPlugin.

**Other information**

Let me know if you approve of the way I am handling passing in the option. Once I get a 👍 I'll update docs and add tests. I mostly wanted to make sure you won't want to allow a custom name for the runtime chunk.