### PR TITLE
Add Experimental Preset Support

### DIFF
--- a/lib/PresetsApply.js
+++ b/lib/PresetsApply.js
@@ -1,0 +1,12 @@
+const merge = require("webpack-merge");
+
+class PresetsApply {
+	constructor() {
+		this.presets = new Set();
+	}
+	process(options) {
+		return merge({}, options, ...Array.from(this.presets));
+	}
+}
+
+module.exports = PresetsApply;

--- a/lib/WebpackPresetsApply.js
+++ b/lib/WebpackPresetsApply.js
@@ -1,0 +1,20 @@
+const path = require("path");
+const PresetsApply = require("./PresetsApply");
+
+const pkgPath = path.join(process.cwd(), "package.json");
+const pkg = require(pkgPath);
+const presets = Object.keys(pkg.devDependencies)
+	.filter(pkgName => pkgName.startsWith("webpack-preset-"))
+	.map(pkgName => path.resolve(process.cwd(), "node_modules", pkgName))
+	.map(require);
+
+class WebpackPresetsApply extends PresetsApply {
+	constructor() {
+		super(); // will set this.presets;
+		presets.forEach(preset => {
+			this.presets.add(preset);
+		});
+	}
+}
+
+module.exports = WebpackPresetsApply;

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -12,8 +12,10 @@ const WebpackOptionsDefaulter = require("./WebpackOptionsDefaulter");
 const validateSchema = require("./validateSchema");
 const WebpackOptionsValidationError = require("./WebpackOptionsValidationError");
 const webpackOptionsSchema = require("../schemas/WebpackOptions.json");
+const WebpackPresetsApply = require("./WebpackPresetsApply");
 
 const webpack = (options, callback) => {
+	console.log("WERBPERK");
 	const webpackOptionsValidationErrors = validateSchema(webpackOptionsSchema, options);
 	if(webpackOptionsValidationErrors.length) {
 		throw new WebpackOptionsValidationError(webpackOptionsValidationErrors);
@@ -22,8 +24,8 @@ const webpack = (options, callback) => {
 	if(Array.isArray(options)) {
 		compiler = new MultiCompiler(options.map(options => webpack(options)));
 	} else if(typeof options === "object") {
+		options = new WebpackPresetsApply().process(options);
 		options = new WebpackOptionsDefaulter().process(options);
-
 		compiler = new Compiler(options.context);
 		compiler.options = options;
 		new NodeEnvironmentPlugin().apply(compiler);
@@ -41,7 +43,7 @@ const webpack = (options, callback) => {
 	if(callback) {
 		if(typeof callback !== "function") throw new Error("Invalid argument: callback");
 		if(options.watch === true || (Array.isArray(options) && options.some(o => o.watch))) {
-			const watchOptions = Array.isArray(options) ? options.map(o => o.watchOptions || {}) : (options.watchOptions || {});
+			const watchOptions = Array.isArray(options) ? options.map(o => o.watchOptions || {}) : options.watchOptions || {};
 			return compiler.watch(watchOptions, callback);
 		}
 		compiler.run(callback);
@@ -71,64 +73,64 @@ const exportPlugins = (obj, mappings) => {
 };
 
 exportPlugins(exports, {
-	"AutomaticPrefetchPlugin": () => require("./AutomaticPrefetchPlugin"),
-	"BannerPlugin": () => require("./BannerPlugin"),
-	"CachePlugin": () => require("./CachePlugin"),
-	"ContextExclusionPlugin": () => require("./ContextExclusionPlugin"),
-	"ContextReplacementPlugin": () => require("./ContextReplacementPlugin"),
-	"DefinePlugin": () => require("./DefinePlugin"),
-	"DllPlugin": () => require("./DllPlugin"),
-	"DllReferencePlugin": () => require("./DllReferencePlugin"),
-	"EnvironmentPlugin": () => require("./EnvironmentPlugin"),
-	"EvalDevToolModulePlugin": () => require("./EvalDevToolModulePlugin"),
-	"EvalSourceMapDevToolPlugin": () => require("./EvalSourceMapDevToolPlugin"),
-	"ExtendedAPIPlugin": () => require("./ExtendedAPIPlugin"),
-	"ExternalsPlugin": () => require("./ExternalsPlugin"),
-	"HashedModuleIdsPlugin": () => require("./HashedModuleIdsPlugin"),
-	"HotModuleReplacementPlugin": () => require("./HotModuleReplacementPlugin"),
-	"IgnorePlugin": () => require("./IgnorePlugin"),
-	"LibraryTemplatePlugin": () => require("./LibraryTemplatePlugin"),
-	"LoaderOptionsPlugin": () => require("./LoaderOptionsPlugin"),
-	"LoaderTargetPlugin": () => require("./LoaderTargetPlugin"),
-	"MemoryOutputFileSystem": () => require("./MemoryOutputFileSystem"),
-	"ModuleFilenameHelpers": () => require("./ModuleFilenameHelpers"),
-	"NamedChunksPlugin": () => require("./NamedChunksPlugin"),
-	"NamedModulesPlugin": () => require("./NamedModulesPlugin"),
-	"NoEmitOnErrorsPlugin": () => require("./NoEmitOnErrorsPlugin"),
-	"NormalModuleReplacementPlugin": () => require("./NormalModuleReplacementPlugin"),
-	"PrefetchPlugin": () => require("./PrefetchPlugin"),
-	"ProgressPlugin": () => require("./ProgressPlugin"),
-	"ProvidePlugin": () => require("./ProvidePlugin"),
-	"SetVarMainTemplatePlugin": () => require("./SetVarMainTemplatePlugin"),
-	"SingleEntryPlugin": () => require("./SingleEntryPlugin"),
-	"SourceMapDevToolPlugin": () => require("./SourceMapDevToolPlugin"),
-	"Stats": () => require("./Stats"),
-	"UmdMainTemplatePlugin": () => require("./UmdMainTemplatePlugin"),
-	"WatchIgnorePlugin": () => require("./WatchIgnorePlugin"),
+	AutomaticPrefetchPlugin: () => require("./AutomaticPrefetchPlugin"),
+	BannerPlugin: () => require("./BannerPlugin"),
+	CachePlugin: () => require("./CachePlugin"),
+	ContextExclusionPlugin: () => require("./ContextExclusionPlugin"),
+	ContextReplacementPlugin: () => require("./ContextReplacementPlugin"),
+	DefinePlugin: () => require("./DefinePlugin"),
+	DllPlugin: () => require("./DllPlugin"),
+	DllReferencePlugin: () => require("./DllReferencePlugin"),
+	EnvironmentPlugin: () => require("./EnvironmentPlugin"),
+	EvalDevToolModulePlugin: () => require("./EvalDevToolModulePlugin"),
+	EvalSourceMapDevToolPlugin: () => require("./EvalSourceMapDevToolPlugin"),
+	ExtendedAPIPlugin: () => require("./ExtendedAPIPlugin"),
+	ExternalsPlugin: () => require("./ExternalsPlugin"),
+	HashedModuleIdsPlugin: () => require("./HashedModuleIdsPlugin"),
+	HotModuleReplacementPlugin: () => require("./HotModuleReplacementPlugin"),
+	IgnorePlugin: () => require("./IgnorePlugin"),
+	LibraryTemplatePlugin: () => require("./LibraryTemplatePlugin"),
+	LoaderOptionsPlugin: () => require("./LoaderOptionsPlugin"),
+	LoaderTargetPlugin: () => require("./LoaderTargetPlugin"),
+	MemoryOutputFileSystem: () => require("./MemoryOutputFileSystem"),
+	ModuleFilenameHelpers: () => require("./ModuleFilenameHelpers"),
+	NamedChunksPlugin: () => require("./NamedChunksPlugin"),
+	NamedModulesPlugin: () => require("./NamedModulesPlugin"),
+	NoEmitOnErrorsPlugin: () => require("./NoEmitOnErrorsPlugin"),
+	NormalModuleReplacementPlugin: () => require("./NormalModuleReplacementPlugin"),
+	PrefetchPlugin: () => require("./PrefetchPlugin"),
+	ProgressPlugin: () => require("./ProgressPlugin"),
+	ProvidePlugin: () => require("./ProvidePlugin"),
+	SetVarMainTemplatePlugin: () => require("./SetVarMainTemplatePlugin"),
+	SingleEntryPlugin: () => require("./SingleEntryPlugin"),
+	SourceMapDevToolPlugin: () => require("./SourceMapDevToolPlugin"),
+	Stats: () => require("./Stats"),
+	UmdMainTemplatePlugin: () => require("./UmdMainTemplatePlugin"),
+	WatchIgnorePlugin: () => require("./WatchIgnorePlugin")
 });
-exportPlugins(exports.optimize = {}, {
-	"AggressiveMergingPlugin": () => require("./optimize/AggressiveMergingPlugin"),
-	"AggressiveSplittingPlugin": () => require("./optimize/AggressiveSplittingPlugin"),
-	"ChunkModuleIdRangePlugin": () => require("./optimize/ChunkModuleIdRangePlugin"),
-	"LimitChunkCountPlugin": () => require("./optimize/LimitChunkCountPlugin"),
-	"MinChunkSizePlugin": () => require("./optimize/MinChunkSizePlugin"),
-	"ModuleConcatenationPlugin": () => require("./optimize/ModuleConcatenationPlugin"),
-	"OccurrenceOrderPlugin": () => require("./optimize/OccurrenceOrderPlugin"),
-	"RuntimeChunkPlugin": () => require("./optimize/RuntimeChunkPlugin"),
-	"SideEffectsFlagPlugin": () => require("./optimize/SideEffectsFlagPlugin"),
-	"SplitChunksPlugin": () => require("./optimize/SplitChunksPlugin"),
+exportPlugins((exports.optimize = {}), {
+	AggressiveMergingPlugin: () => require("./optimize/AggressiveMergingPlugin"),
+	AggressiveSplittingPlugin: () => require("./optimize/AggressiveSplittingPlugin"),
+	ChunkModuleIdRangePlugin: () => require("./optimize/ChunkModuleIdRangePlugin"),
+	LimitChunkCountPlugin: () => require("./optimize/LimitChunkCountPlugin"),
+	MinChunkSizePlugin: () => require("./optimize/MinChunkSizePlugin"),
+	ModuleConcatenationPlugin: () => require("./optimize/ModuleConcatenationPlugin"),
+	OccurrenceOrderPlugin: () => require("./optimize/OccurrenceOrderPlugin"),
+	RuntimeChunkPlugin: () => require("./optimize/RuntimeChunkPlugin"),
+	SideEffectsFlagPlugin: () => require("./optimize/SideEffectsFlagPlugin"),
+	SplitChunksPlugin: () => require("./optimize/SplitChunksPlugin")
 });
-exportPlugins(exports.web = {}, {
-	"FetchCompileWasmTemplatePlugin": () => require("./web/FetchCompileWasmTemplatePlugin"),
-	"JsonpTemplatePlugin": () => require("./web/JsonpTemplatePlugin"),
+exportPlugins((exports.web = {}), {
+	FetchCompileWasmTemplatePlugin: () => require("./web/FetchCompileWasmTemplatePlugin"),
+	JsonpTemplatePlugin: () => require("./web/JsonpTemplatePlugin")
 });
-exportPlugins(exports.webworker = {}, {
-	"WebWorkerTemplatePlugin": () => require("./webworker/WebWorkerTemplatePlugin"),
+exportPlugins((exports.webworker = {}), {
+	WebWorkerTemplatePlugin: () => require("./webworker/WebWorkerTemplatePlugin")
 });
-exportPlugins(exports.node = {}, {
-	"NodeTemplatePlugin": () => require("./node/NodeTemplatePlugin"),
-	"ReadFileCompileWasmTemplatePlugin": () => require("./node/ReadFileCompileWasmTemplatePlugin"),
+exportPlugins((exports.node = {}), {
+	NodeTemplatePlugin: () => require("./node/NodeTemplatePlugin"),
+	ReadFileCompileWasmTemplatePlugin: () => require("./node/ReadFileCompileWasmTemplatePlugin")
 });
-exportPlugins(exports.debug = {}, {
-	"ProfilingPlugin": () => require("./debug/ProfilingPlugin"),
+exportPlugins((exports.debug = {}), {
+	ProfilingPlugin: () => require("./debug/ProfilingPlugin")
 });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "tapable": "^1.0.0-beta.5",
     "uglifyjs-webpack-plugin": "^1.1.1",
     "watchpack": "^1.4.0",
+    "webpack-merge": "^4.1.1",
     "webpack-sources": "^1.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4261,6 +4261,12 @@ webpack-dev-middleware@^1.9.0:
     range-parser "^1.0.3"
     time-stamp "^2.0.0"
 
+webpack-merge@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.1.1.tgz#f1197a0a973e69c6fbeeb6d658219aa8c0c13555"
+  dependencies:
+    lodash "^4.17.4"
+
 webpack-sources@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Feature (WIP)
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No this is experimental right now. Kind of WIP to also discuss implementation details. 
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
The following PR adds a Work in Progress, Proof of Concepts of a highly primitive preset system. 

A webpack preset is detected by searching a users "package.json" devDependencies for all package names starting with `webpack-preset-`. From there we will require those dependencies and they will yield their configuration objects which are `webpack-merge`'d together. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Whether or not we think #0CJS is a big deal, extending it is what it really means to empathize with a large subset of our users we have yet to tap into. Also, I would like this PR to be a place to help start the design discussion that is testable. 

A preset is just a module that exports a configuration. <==== **likely where we want to design more**

**Does this PR introduce a breaking change?**
Nope.

**Other information**

