### PR TITLE
[WIP] Convert tests to Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "publish-patch": "npm run lint && npm run beautify-lint && mocha && npm version patch && git push && git push --tags && npm publish"
   },
   "jest": {
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "setupTestFrameworkScriptFile": "<rootDir>/test/setupTestFramework.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -118,6 +118,10 @@
   },
   "jest": {
     "testEnvironment": "node",
-    "setupTestFrameworkScriptFile": "<rootDir>/test/setupTestFramework.js"
+    "setupTestFrameworkScriptFile": "<rootDir>/test/setupTestFramework.js",
+    "testMatch": [
+      "<rootDir>/test/*.test.js",
+      "<rootDir>/test/*.unittest.js"
+    ]
   }
 }

--- a/test/BenchmarkTestCases.benchmark.js
+++ b/test/BenchmarkTestCases.benchmark.js
@@ -1,10 +1,8 @@
 "use strict";
 
-require("should");
 const path = require("path");
 const fs = require("fs");
 const asyncLib = require("async");
-var Test = require("mocha/lib/test");
 
 const Benchmark = require("benchmark");
 
@@ -24,8 +22,7 @@ describe("BenchmarkTestCases", function() {
 		fs.mkdirSync(baselinesPath);
 	} catch(e) {}
 
-	before(function(done) {
-		this.timeout(270000);
+	beforeAll(function(done) {
 		const git = require("simple-git");
 		const rootPath = path.join(__dirname, "..");
 		getBaselineRevs(rootPath, (err, baselineRevisions) => {
@@ -65,7 +62,7 @@ describe("BenchmarkTestCases", function() {
 				}
 			}, done);
 		});
-	});
+	}, 270000);
 
 	function getBaselineRevs(rootPath, callback) {
 		const git = require("simple-git")(rootPath);
@@ -169,17 +166,10 @@ describe("BenchmarkTestCases", function() {
 	tests.forEach(testName => {
 		const testDirectory = path.join(casesPath, testName);
 		let headStats = null;
-		const suite = describe(testName, function() {});
-		it(`${testName} create benchmarks`, function() {
+		describe(`${testName} create benchmarks`, function() {
 			baselines.forEach(baseline => {
 				let baselineStats = null;
-
-				function it(title, fn) {
-					const test = new Test(title, fn);
-					suite.addTest(test);
-				}
 				it(`should benchmark ${baseline.name} (${baseline.rev})`, function(done) {
-					this.timeout(180000);
 					const outputDirectory = path.join(__dirname, "js", "benchmark", `baseline-${baseline.name}`, testName);
 					const config = Object.create(require(path.join(testDirectory, "webpack.config.js")));
 					config.output = Object.create(config.output || {});
@@ -194,7 +184,7 @@ describe("BenchmarkTestCases", function() {
 							baselineStats = stats;
 						done();
 					});
-				});
+				}, 180000);
 
 				if(baseline.name !== "HEAD") {
 					it(`HEAD should not be slower than ${baseline.name} (${baseline.rev})`, function() {

--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -66,8 +66,6 @@ describe("ConfigTestCases", () => {
 							testConfig = Object.assign(testConfig, require(path.join(testDirectory, "test.config.js")));
 						} catch(e) {}
 
-						// this.timeout(testConfig.timeout);
-
 						webpack(options, (err, stats) => {
 							if(err) {
 								const fakeStats = {
@@ -89,7 +87,7 @@ describe("ConfigTestCases", () => {
 							let exportedTests = [];
 
 							function _it(title, fn) {
-								exportedTests.push(fit(title, fn));
+								exportedTests.push(fit(title, fn, testConfig.timeout));
 							}
 
 							const globalContext = {

--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -93,7 +93,8 @@ describe("ConfigTestCases", () => {
 							}
 
 							const globalContext = {
-								console: console
+								console: console,
+								expect: expect
 							};
 
 							function _require(currentDirectory, module) {

--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -1,13 +1,12 @@
 "use strict";
 
-/* globals describe it */
-require("should");
+/* globals describe expect it fit */
 const path = require("path");
 const fs = require("fs");
 const vm = require("vm");
 const mkdirp = require("mkdirp");
-const Test = require("mocha/lib/test");
 const checkArrayExpectation = require("./checkArrayExpectation");
+const async = require("async");
 
 const Stats = require("../lib/Stats");
 const webpack = require("../lib/webpack");
@@ -36,113 +35,114 @@ describe("ConfigTestCases", () => {
 	categories.forEach((category) => {
 		describe(category.name, () => {
 			category.tests.forEach((testName) => {
-				const suite = describe(testName, () => {});
-				it(testName + " should compile", function(done) {
-					const testDirectory = path.join(casesPath, category.name, testName);
-					const outputDirectory = path.join(__dirname, "js", "config", category.name, testName);
-					const options = prepareOptions(require(path.join(testDirectory, "webpack.config.js")));
-					const optionsArr = [].concat(options);
-					optionsArr.forEach((options, idx) => {
-						if(!options.context) options.context = testDirectory;
-						if(!options.mode) options.mode = "production";
-						if(!options.optimization) options.optimization = {};
-						if(options.optimization.minimize === undefined) options.optimization.minimize = false;
-						if(!options.entry) options.entry = "./index.js";
-						if(!options.target) options.target = "async-node";
-						if(!options.output) options.output = {};
-						if(!options.output.path) options.output.path = outputDirectory;
-						if(typeof options.output.pathinfo === "undefined") options.output.pathinfo = true;
-						if(!options.output.filename) options.output.filename = "bundle" + idx + ".js";
-					});
-					let testConfig = {
-						findBundle: function(i, options) {
-							if(fs.existsSync(path.join(options.output.path, "bundle" + i + ".js"))) {
-								return "./bundle" + i + ".js";
-							}
-						},
-						timeout: 30000
-					};
-					try {
-						// try to load a test file
-						testConfig = Object.assign(testConfig, require(path.join(testDirectory, "test.config.js")));
-					} catch(e) {}
-
-					this.timeout(testConfig.timeout);
-
-					webpack(options, (err, stats) => {
-						if(err) {
-							const fakeStats = {
-								errors: [err.stack]
-							};
-							if(checkArrayExpectation(testDirectory, fakeStats, "error", "Error", done)) return;
-							// Wait for uncatched errors to occur
-							return setTimeout(done, 200);
-						}
-						const statOptions = Stats.presetToOptions("verbose");
-						statOptions.colors = false;
-						mkdirp.sync(outputDirectory);
-						fs.writeFileSync(path.join(outputDirectory, "stats.txt"), stats.toString(statOptions), "utf-8");
-						const jsonStats = stats.toJson({
-							errorDetails: true
+				describe(testName, () => {
+					it(testName + " should compile", (done) => {
+						const testDirectory = path.join(casesPath, category.name, testName);
+						const outputDirectory = path.join(__dirname, "js", "config", category.name, testName);
+						const options = prepareOptions(require(path.join(testDirectory, "webpack.config.js")));
+						const optionsArr = [].concat(options);
+						optionsArr.forEach((options, idx) => {
+							if(!options.context) options.context = testDirectory;
+							if(!options.mode) options.mode = "production";
+							if(!options.optimization) options.optimization = {};
+							if(options.optimization.minimize === undefined) options.optimization.minimize = false;
+							if(!options.entry) options.entry = "./index.js";
+							if(!options.target) options.target = "async-node";
+							if(!options.output) options.output = {};
+							if(!options.output.path) options.output.path = outputDirectory;
+							if(typeof options.output.pathinfo === "undefined") options.output.pathinfo = true;
+							if(!options.output.filename) options.output.filename = "bundle" + idx + ".js";
 						});
-						if(checkArrayExpectation(testDirectory, jsonStats, "error", "Error", done)) return;
-						if(checkArrayExpectation(testDirectory, jsonStats, "warning", "Warning", done)) return;
-						let exportedTests = 0;
-
-						function _it(title, fn) {
-							const test = new Test(title, fn);
-							suite.addTest(test);
-							exportedTests++;
-							return test;
-						}
-
-						const globalContext = {
-							console: console
+						let testConfig = {
+							findBundle: function(i, options) {
+								if(fs.existsSync(path.join(options.output.path, "bundle" + i + ".js"))) {
+									return "./bundle" + i + ".js";
+								}
+							},
+							timeout: 30000
 						};
+						try {
+							// try to load a test file
+							testConfig = Object.assign(testConfig, require(path.join(testDirectory, "test.config.js")));
+						} catch(e) {}
 
-						function _require(currentDirectory, module) {
-							if(Array.isArray(module) || /^\.\.?\//.test(module)) {
-								let fn;
-								let content;
-								let p;
-								if(Array.isArray(module)) {
-									p = path.join(currentDirectory, module[0]);
-									content = module.map((arg) => {
-										p = path.join(currentDirectory, arg);
-										return fs.readFileSync(p, "utf-8");
-									}).join("\n");
-								} else {
-									p = path.join(currentDirectory, module);
-									content = fs.readFileSync(p, "utf-8");
-								}
-								if(options.target === "web" || options.target === "webworker") {
-									fn = vm.runInNewContext("(function(require, module, exports, __dirname, __filename, it, window) {" + content + "\n})", globalContext, p);
-								} else {
-									fn = vm.runInThisContext("(function(require, module, exports, __dirname, __filename, it) {" + content + "\n})", p);
-								}
-								const m = {
-									exports: {}
+						// this.timeout(testConfig.timeout);
+
+						webpack(options, (err, stats) => {
+							if(err) {
+								const fakeStats = {
+									errors: [err.stack]
 								};
-								fn.call(m.exports, _require.bind(null, path.dirname(p)), m, m.exports, path.dirname(p), p, _it, globalContext);
-								return m.exports;
-							} else if(testConfig.modules && module in testConfig.modules) {
-								return testConfig.modules[module];
-							} else return require(module);
-						}
-						let filesCount = 0;
-
-						if(testConfig.noTests) return process.nextTick(done);
-						for(let i = 0; i < optionsArr.length; i++) {
-							const bundlePath = testConfig.findBundle(i, optionsArr[i]);
-							if(bundlePath) {
-								filesCount++;
-								_require(outputDirectory, bundlePath);
+								if(checkArrayExpectation(testDirectory, fakeStats, "error", "Error", done)) return;
+								// Wait for uncatched errors to occur
+								return setTimeout(done, 200);
 							}
-						}
-						// give a free pass to compilation that generated an error
-						if(!jsonStats.errors.length && filesCount !== optionsArr.length) return done(new Error("Should have found at least one bundle file per webpack config"));
-						if(exportedTests < filesCount) return done(new Error("No tests exported by test case"));
-						process.nextTick(done);
+							const statOptions = Stats.presetToOptions("verbose");
+							statOptions.colors = false;
+							mkdirp.sync(outputDirectory);
+							fs.writeFileSync(path.join(outputDirectory, "stats.txt"), stats.toString(statOptions), "utf-8");
+							const jsonStats = stats.toJson({
+								errorDetails: true
+							});
+							if(checkArrayExpectation(testDirectory, jsonStats, "error", "Error", done)) return;
+							if(checkArrayExpectation(testDirectory, jsonStats, "warning", "Warning", done)) return;
+							let exportedTests = [];
+
+							function _it(title, fn) {
+								exportedTests.push(fit(title, fn));
+							}
+
+							const globalContext = {
+								console: console
+							};
+
+							function _require(currentDirectory, module) {
+								if(Array.isArray(module) || /^\.\.?\//.test(module)) {
+									let fn;
+									let content;
+									let p;
+									if(Array.isArray(module)) {
+										p = path.join(currentDirectory, module[0]);
+										content = module.map((arg) => {
+											p = path.join(currentDirectory, arg);
+											return fs.readFileSync(p, "utf-8");
+										}).join("\n");
+									} else {
+										p = path.join(currentDirectory, module);
+										content = fs.readFileSync(p, "utf-8");
+									}
+									if(options.target === "web" || options.target === "webworker") {
+										fn = vm.runInNewContext("(function(require, module, exports, __dirname, __filename, it, expect, window) {" + content + "\n})", globalContext, p);
+									} else {
+										fn = vm.runInThisContext("(function(require, module, exports, __dirname, __filename, it, expect) {" + content + "\n})", p);
+									}
+									const m = {
+										exports: {}
+									};
+									fn.call(m.exports, _require.bind(null, path.dirname(p)), m, m.exports, path.dirname(p), p, _it, expect, globalContext);
+									return m.exports;
+								} else if(testConfig.modules && module in testConfig.modules) {
+									return testConfig.modules[module];
+								} else return require(module);
+							}
+							let filesCount = 0;
+
+							if(testConfig.noTests) return process.nextTick(done);
+							for(let i = 0; i < optionsArr.length; i++) {
+								const bundlePath = testConfig.findBundle(i, optionsArr[i]);
+								if(bundlePath) {
+									filesCount++;
+									_require(outputDirectory, bundlePath);
+								}
+							}
+							// give a free pass to compilation that generated an error
+							if(!jsonStats.errors.length && filesCount !== optionsArr.length) return done(new Error("Should have found at least one bundle file per webpack config"));
+							if(exportedTests.length < filesCount) return done(new Error("No tests exported by test case"));
+							async.waterfall(
+								exportedTests.map(test => (callback) => test.execute(callback, true)),
+								done
+							);
+						});
 					});
 				});
 			});

--- a/test/ExternalModule.unittest.js
+++ b/test/ExternalModule.unittest.js
@@ -60,7 +60,7 @@ describe("ExternalModule", () => {
 			expect(externalModule.getSource.callCount).toBe(1);
 			expect(externalModule.getSourceString.callCount).toBe(1);
 			expect(externalModule.getSource.args[0][0]).toBe(expectedString);
-			expect(result).toBe(expectedSource);
+			expect(result).toEqual(expectedSource);
 		});
 	});
 
@@ -77,7 +77,7 @@ describe("ExternalModule", () => {
 				const result = externalModule.getSource(someSourceString);
 
 				// check
-				expect(result).toBeInstanceOf(OriginalSource);
+				expect(result).toEqualInstanceOf(OriginalSource);
 			});
 		});
 		describe("given it does not use source maps", () => {
@@ -92,7 +92,7 @@ describe("ExternalModule", () => {
 				const result = externalModule.getSource(someSourceString);
 
 				// check
-				expect(result).toBeInstanceOf(RawSource);
+				expect(result).toEqualInstanceOf(RawSource);
 			});
 		});
 	});
@@ -109,7 +109,7 @@ describe("ExternalModule", () => {
 				const result = externalModule.getSourceForGlobalVariableExternal(varName, type);
 
 				// check
-				expect(result).toBe(expected);
+				expect(result).toEqual(expected);
 			});
 		});
 		describe("given an single variable name", () => {
@@ -123,7 +123,7 @@ describe("ExternalModule", () => {
 				const result = externalModule.getSourceForGlobalVariableExternal(varName, type);
 
 				// check
-				expect(result).toBe(expected);
+				expect(result).toEqual(expected);
 			});
 		});
 	});
@@ -139,7 +139,7 @@ describe("ExternalModule", () => {
 				const result = externalModule.getSourceForCommonJsExternal(varName, type);
 
 				// check
-				expect(result).toBe(expected);
+				expect(result).toEqual(expected);
 			});
 		});
 		describe("given an single variable name", () => {
@@ -153,7 +153,7 @@ describe("ExternalModule", () => {
 				const result = externalModule.getSourceForCommonJsExternal(varName, type);
 
 				// check
-				expect(result).toBe(expected);
+				expect(result).toEqual(expected);
 			});
 		});
 	});
@@ -170,7 +170,7 @@ describe("ExternalModule", () => {
 			const result = externalModule.checkExternalVariable(variableToCheck, request);
 
 			// check
-			expect(result).toBe(expected);
+			expect(result).toEqual(expected);
 		});
 	});
 
@@ -185,7 +185,7 @@ describe("ExternalModule", () => {
 			const result = externalModule.getSourceForAmdOrUmdExternal(id, optional, request);
 
 			// check
-			expect(result).toBe(expected);
+			expect(result).toEqual(expected);
 		});
 		describe("given an optinal check is set", () => {
 			it("ads a check for the existance of the variable before looking it up", () => {
@@ -199,7 +199,7 @@ module.exports = __WEBPACK_EXTERNAL_MODULE_someId__;`;
 				const result = externalModule.getSourceForAmdOrUmdExternal(id, optional, request);
 
 				// check
-				expect(result).toBe(expected);
+				expect(result).toEqual(expected);
 			});
 		});
 	});
@@ -214,7 +214,7 @@ module.exports = __WEBPACK_EXTERNAL_MODULE_someId__;`;
 			const result = externalModule.getSourceForDefaultCase(optional, request);
 
 			// check
-			expect(result).toBe(expected);
+			expect(result).toEqual(expected);
 		});
 		describe("given an optinal check is requested", () => {
 			it("checks for the existance of the request setting it", () => {
@@ -227,7 +227,7 @@ module.exports = some/request;`;
 				const result = externalModule.getSourceForDefaultCase(optional, request);
 
 				// check
-				expect(result).toBe(expected);
+				expect(result).toEqual(expected);
 			});
 		});
 	});

--- a/test/ExternalModule.unittest.js
+++ b/test/ExternalModule.unittest.js
@@ -77,7 +77,7 @@ describe("ExternalModule", () => {
 				const result = externalModule.getSource(someSourceString);
 
 				// check
-				expect(result).toEqualInstanceOf(OriginalSource);
+				expect(result).toBeInstanceOf(OriginalSource);
 			});
 		});
 		describe("given it does not use source maps", () => {
@@ -92,7 +92,7 @@ describe("ExternalModule", () => {
 				const result = externalModule.getSource(someSourceString);
 
 				// check
-				expect(result).toEqualInstanceOf(RawSource);
+				expect(result).toBeInstanceOf(RawSource);
 			});
 		});
 	});

--- a/test/HotTestCases.test.js
+++ b/test/HotTestCases.test.js
@@ -1,35 +1,13 @@
 "use strict";
 
-require("should");
+/* globals expect fit */
 const path = require("path");
 const fs = require("fs");
 const vm = require("vm");
-const Test = require("mocha/lib/test");
 const checkArrayExpectation = require("./checkArrayExpectation");
+const async = require("async");
 
 const webpack = require("../lib/webpack");
-
-function createNestableIt(done) {
-	let counter = 0;
-	let aborted = false;
-	return (title, fn) => {
-		counter++;
-		fn((err) => {
-			if(aborted) {
-				return;
-			}
-			if(err) {
-				aborted = true;
-				done(err);
-			} else {
-				counter--;
-				if(counter === 0) {
-					done();
-				}
-			}
-		});
-	}
-}
 
 describe("HotTestCases", () => {
 	const casesPath = path.join(__dirname, "hotCases");
@@ -44,83 +22,87 @@ describe("HotTestCases", () => {
 	categories.forEach((category) => {
 		describe(category.name, () => {
 			category.tests.forEach((testName) => {
-				it(testName + " should compile", (done) => {
-					const testDirectory = path.join(casesPath, category.name, testName);
-					const outputDirectory = path.join(__dirname, "js", "hot-cases", category.name, testName);
-					const recordsPath = path.join(outputDirectory, "records.json");
-					if(fs.existsSync(recordsPath))
-						fs.unlinkSync(recordsPath);
-					const fakeUpdateLoaderOptions = {
-						updateIndex: 0
-					};
-					const configPath = path.join(testDirectory, "webpack.config.js");
-					let options = {};
-					if(fs.existsSync(configPath))
-						options = require(configPath);
-					if(!options.mode) options.mode = "development";
-					if(!options.context) options.context = testDirectory;
-					if(!options.entry) options.entry = "./index.js";
-					if(!options.output) options.output = {};
-					if(!options.output.path) options.output.path = outputDirectory;
-					if(!options.output.filename) options.output.filename = "bundle.js";
-					if(options.output.pathinfo === undefined) options.output.pathinfo = true;
-					if(!options.module) options.module = {};
-					if(!options.module.rules) options.module.rules = [];
-					options.module.rules.push({
-						test: /\.js$/,
-						loader: path.join(__dirname, "hotCases", "fake-update-loader.js"),
-						enforce: "pre"
-					});
-					if(!options.target) options.target = "async-node";
-					if(!options.plugins) options.plugins = [];
-					options.plugins.push(
-						new webpack.HotModuleReplacementPlugin(),
-						new webpack.NamedModulesPlugin(),
-						new webpack.LoaderOptionsPlugin(fakeUpdateLoaderOptions)
-					);
-					if(!options.recordsPath) options.recordsPath = recordsPath;
-					const compiler = webpack(options);
-					compiler.run((err, stats) => {
-						if(err) return done(err);
-						const jsonStats = stats.toJson({
-							errorDetails: true
+				describe(testName, () => {
+					it(testName + " should compile", (done) => {
+						const testDirectory = path.join(casesPath, category.name, testName);
+						const outputDirectory = path.join(__dirname, "js", "hot-cases", category.name, testName);
+						const recordsPath = path.join(outputDirectory, "records.json");
+						if(fs.existsSync(recordsPath))
+							fs.unlinkSync(recordsPath);
+						const fakeUpdateLoaderOptions = {
+							updateIndex: 0
+						};
+						const configPath = path.join(testDirectory, "webpack.config.js");
+						let options = {};
+						if(fs.existsSync(configPath))
+							options = require(configPath);
+						if(!options.mode) options.mode = "development";
+						if(!options.context) options.context = testDirectory;
+						if(!options.entry) options.entry = "./index.js";
+						if(!options.output) options.output = {};
+						if(!options.output.path) options.output.path = outputDirectory;
+						if(!options.output.filename) options.output.filename = "bundle.js";
+						if(options.output.pathinfo === undefined) options.output.pathinfo = true;
+						if(!options.module) options.module = {};
+						if(!options.module.rules) options.module.rules = [];
+						options.module.rules.push({
+							test: /\.js$/,
+							loader: path.join(__dirname, "hotCases", "fake-update-loader.js"),
+							enforce: "pre"
 						});
-						if(checkArrayExpectation(testDirectory, jsonStats, "error", "Error", done)) return;
-						if(checkArrayExpectation(testDirectory, jsonStats, "warning", "Warning", done)) return;
-						let exportedTests = 0;
-
-						const __it = createNestableIt(done);
-						function _it(title, fn) {
-							__it(title, fn);
-							exportedTests++;
-						}
-
-						function _next(callback) {
-							fakeUpdateLoaderOptions.updateIndex++;
-							compiler.run((err, stats) => {
-								if(err) return done(err);
-								const jsonStats = stats.toJson({
-									errorDetails: true
-								});
-								if(checkArrayExpectation(testDirectory, jsonStats, "error", "errors" + fakeUpdateLoaderOptions.updateIndex, "Error", done)) return;
-								if(checkArrayExpectation(testDirectory, jsonStats, "warning", "warnings" + fakeUpdateLoaderOptions.updateIndex, "Warning", done)) return;
-								if(callback) callback(jsonStats);
+						if(!options.target) options.target = "async-node";
+						if(!options.plugins) options.plugins = [];
+						options.plugins.push(
+							new webpack.HotModuleReplacementPlugin(),
+							new webpack.NamedModulesPlugin(),
+							new webpack.LoaderOptionsPlugin(fakeUpdateLoaderOptions)
+						);
+						if(!options.recordsPath) options.recordsPath = recordsPath;
+						const compiler = webpack(options);
+						compiler.run((err, stats) => {
+							if(err) return done(err);
+							const jsonStats = stats.toJson({
+								errorDetails: true
 							});
-						}
+							if(checkArrayExpectation(testDirectory, jsonStats, "error", "Error", done)) return;
+							if(checkArrayExpectation(testDirectory, jsonStats, "warning", "Warning", done)) return;
+							let exportedTests = [];
 
-						function _require(module) {
-							if(module.substr(0, 2) === "./") {
-								const p = path.join(outputDirectory, module);
-								const fn = vm.runInThisContext("(function(require, module, exports, __dirname, __filename, it, expect, NEXT, STATS) {" + fs.readFileSync(p, "utf-8") + "\n})", p);
-								const m = {
-									exports: {}
-								};
-								fn.call(m.exports, _require, m, m.exports, outputDirectory, p, _it, expect, _next, jsonStats);
-								return m.exports;
-							} else return require(module);
-						}
-						_require("./bundle.js");
-						if(exportedTests < 1) return done(new Error("No tests exported by test case"));
+							function _it(title, fn) {
+								exportedTests.push(fit(title, fn));
+							}
+
+							function _next(callback) {
+								fakeUpdateLoaderOptions.updateIndex++;
+								compiler.run((err, stats) => {
+									if(err) return done(err);
+									const jsonStats = stats.toJson({
+										errorDetails: true
+									});
+									if(checkArrayExpectation(testDirectory, jsonStats, "error", "errors" + fakeUpdateLoaderOptions.updateIndex, "Error", done)) return;
+									if(checkArrayExpectation(testDirectory, jsonStats, "warning", "warnings" + fakeUpdateLoaderOptions.updateIndex, "Warning", done)) return;
+									if(callback) callback(jsonStats);
+								});
+							}
+
+							function _require(module) {
+								if(module.substr(0, 2) === "./") {
+									const p = path.join(outputDirectory, module);
+									const fn = vm.runInThisContext("(function(require, module, exports, __dirname, __filename, it, expect, NEXT, STATS) {" + fs.readFileSync(p, "utf-8") + "\n})", p);
+									const m = {
+										exports: {}
+									};
+									fn.call(m.exports, _require, m, m.exports, outputDirectory, p, _it, expect, _next, jsonStats);
+									return m.exports;
+								} else return require(module);
+							}
+							_require("./bundle.js");
+							if(exportedTests.length < 1) return done(new Error("No tests exported by test case"));
+							async.waterfall(
+								exportedTests.map(test => (callback) => test.execute(callback, true)),
+								done
+							);
+						});
 					});
 				});
 			});

--- a/test/MultiStats.unittest.js
+++ b/test/MultiStats.unittest.js
@@ -263,7 +263,7 @@ describe("MultiStats", () => {
 		});
 
 		it("returns string representation", () => {
-			expect(result).toBe(
+			expect(result).toEqual(
 				"Hash: abc123xyz890\n" +
 				"Version: webpack 1.2.3\n" +
 				"Child abc123-compilation:\n" +

--- a/test/TestCases.test.js
+++ b/test/TestCases.test.js
@@ -1,13 +1,12 @@
-/* global describe, it*/
+/* global describe it fit expect */
 "use strict";
 
-require("should");
 const path = require("path");
 const fs = require("fs");
 const vm = require("vm");
 const mkdirp = require("mkdirp");
-const Test = require("mocha/lib/test");
 const checkArrayExpectation = require("./checkArrayExpectation");
+const async = require("async");
 
 const Stats = require("../lib/Stats");
 const webpack = require("../lib/webpack");
@@ -116,7 +115,6 @@ describe("TestCases", () => {
 		describe(config.name, () => {
 			categories.forEach((category) => {
 				describe(category.name, function() {
-					this.timeout(30000);
 					category.tests.filter((test) => {
 						const testDirectory = path.join(casesPath, category.name, test);
 						const filterPath = path.join(testDirectory, "test.filter.js");
@@ -126,95 +124,96 @@ describe("TestCases", () => {
 						}
 						return true;
 					}).forEach((testName) => {
-						const suite = describe(testName, () => {});
-						it(testName + " should compile", (done) => {
-							const testDirectory = path.join(casesPath, category.name, testName);
-							const outputDirectory = path.join(__dirname, "js", config.name, category.name, testName);
-							const options = {
-								context: casesPath,
-								entry: "./" + category.name + "/" + testName + "/index",
-								target: "async-node",
-								devtool: config.devtool,
-								mode: config.mode || "none",
-								optimization: config.mode ? NO_EMIT_ON_ERRORS_OPTIMIZATIONS : Object.assign({}, config.optimization, DEFAULT_OPTIMIZATIONS),
-								performance: {
-									hints: false
-								},
-								output: {
-									pathinfo: true,
-									path: outputDirectory,
-									filename: "bundle.js"
-								},
-								resolve: {
-									modules: ["web_modules", "node_modules"],
-									mainFields: ["webpack", "browser", "web", "browserify", ["jam", "main"], "main"],
-									aliasFields: ["browser"],
-									extensions: [".mjs", ".webpack.js", ".web.js", ".js", ".json"],
-									concord: true
-								},
-								resolveLoader: {
-									modules: ["web_loaders", "web_modules", "node_loaders", "node_modules"],
-									mainFields: ["webpackLoader", "webLoader", "loader", "main"],
-									extensions: [".webpack-loader.js", ".web-loader.js", ".loader.js", ".js"]
-								},
-								module: {
-									rules: [{
-										test: /\.coffee$/,
-										loader: "coffee-loader"
-									}, {
-										test: /\.jade$/,
-										loader: "jade-loader"
-									}]
-								},
-								plugins: (config.plugins || []).concat(function() {
-									this.hooks.compilation.tap("TestCasesTest", (compilation) => {
-										["optimize", "optimizeModulesBasic", "optimizeChunksBasic", "afterOptimizeTree", "afterOptimizeAssets"].forEach((hook) => {
-											compilation.hooks[hook].tap("TestCasesTest", () => compilation.checkConstraints());
+						describe(testName, () => {
+							it(testName + " should compile", (done) => {
+								const testDirectory = path.join(casesPath, category.name, testName);
+								const outputDirectory = path.join(__dirname, "js", config.name, category.name, testName);
+								const options = {
+									context: casesPath,
+									entry: "./" + category.name + "/" + testName + "/index",
+									target: "async-node",
+									devtool: config.devtool,
+									mode: config.mode || "none",
+									optimization: config.mode ? NO_EMIT_ON_ERRORS_OPTIMIZATIONS : Object.assign({}, config.optimization, DEFAULT_OPTIMIZATIONS),
+									performance: {
+										hints: false
+									},
+									output: {
+										pathinfo: true,
+										path: outputDirectory,
+										filename: "bundle.js"
+									},
+									resolve: {
+										modules: ["web_modules", "node_modules"],
+										mainFields: ["webpack", "browser", "web", "browserify", ["jam", "main"], "main"],
+										aliasFields: ["browser"],
+										extensions: [".mjs", ".webpack.js", ".web.js", ".js", ".json"],
+										concord: true
+									},
+									resolveLoader: {
+										modules: ["web_loaders", "web_modules", "node_loaders", "node_modules"],
+										mainFields: ["webpackLoader", "webLoader", "loader", "main"],
+										extensions: [".webpack-loader.js", ".web-loader.js", ".loader.js", ".js"]
+									},
+									module: {
+										rules: [{
+											test: /\.coffee$/,
+											loader: "coffee-loader"
+										}, {
+											test: /\.jade$/,
+											loader: "jade-loader"
+										}]
+									},
+									plugins: (config.plugins || []).concat(function() {
+										this.hooks.compilation.tap("TestCasesTest", (compilation) => {
+											["optimize", "optimizeModulesBasic", "optimizeChunksBasic", "afterOptimizeTree", "afterOptimizeAssets"].forEach((hook) => {
+												compilation.hooks[hook].tap("TestCasesTest", () => compilation.checkConstraints());
+											});
 										});
+									})
+								};
+								webpack(options, (err, stats) => {
+									if(err) return done(err);
+									const statOptions = Stats.presetToOptions("verbose");
+									statOptions.colors = false;
+									mkdirp.sync(outputDirectory);
+									fs.writeFileSync(path.join(outputDirectory, "stats.txt"), stats.toString(statOptions), "utf-8");
+									const jsonStats = stats.toJson({
+										errorDetails: true
 									});
-								})
-							};
-							webpack(options, (err, stats) => {
-								if(err) return done(err);
-								const statOptions = Stats.presetToOptions("verbose");
-								statOptions.colors = false;
-								mkdirp.sync(outputDirectory);
-								fs.writeFileSync(path.join(outputDirectory, "stats.txt"), stats.toString(statOptions), "utf-8");
-								const jsonStats = stats.toJson({
-									errorDetails: true
+									if(checkArrayExpectation(testDirectory, jsonStats, "error", "Error", done)) return;
+									if(checkArrayExpectation(testDirectory, jsonStats, "warning", "Warning", done)) return;
+									let exportedTests = [];
+
+									function _it(title, fn) {
+										exportedTests.push(fit(title, fn));
+										// TODO: is this necessary in 'jest'?
+										// WORKAROUND for a v8 bug
+										// Error objects retrain all scopes in the stacktrace
+										// test._trace = test._trace.message;
+									}
+
+									function _require(module) {
+										if(module.substr(0, 2) === "./") {
+											const p = path.join(outputDirectory, module);
+											const fn = vm.runInThisContext("(function(require, module, exports, __dirname, it, expect) {" + fs.readFileSync(p, "utf-8") + "\n})", p);
+											const m = {
+												exports: {},
+												webpackTestSuiteModule: true
+											};
+											fn.call(m.exports, _require, m, m.exports, outputDirectory, _it, expect);
+											return m.exports;
+										} else return require(module);
+									}
+									_require.webpackTestSuiteRequire = true;
+									_require("./bundle.js");
+									if(exportedTests.length === 0) return done(new Error("No tests exported by test case"));
+									async.waterfall(
+										exportedTests.map(test => (callback) => test.execute(callback, true)),
+										done
+									);
 								});
-								if(checkArrayExpectation(testDirectory, jsonStats, "error", "Error", done)) return;
-								if(checkArrayExpectation(testDirectory, jsonStats, "warning", "Warning", done)) return;
-								let exportedTest = 0;
-
-								function _it(title, fn) {
-									const test = new Test(title, fn);
-									suite.addTest(test);
-									exportedTest++;
-									// WORKAROUND for a v8 bug
-									// Error objects retrain all scopes in the stacktrace
-									test._trace = test._trace.message;
-
-									return test;
-								}
-
-								function _require(module) {
-									if(module.substr(0, 2) === "./") {
-										const p = path.join(outputDirectory, module);
-										const fn = vm.runInThisContext("(function(require, module, exports, __dirname, it) {" + fs.readFileSync(p, "utf-8") + "\n})", p);
-										const m = {
-											exports: {},
-											webpackTestSuiteModule: true
-										};
-										fn.call(m.exports, _require, m, m.exports, outputDirectory, _it);
-										return m.exports;
-									} else return require(module);
-								}
-								_require.webpackTestSuiteRequire = true;
-								_require("./bundle.js");
-								if(exportedTest === 0) return done(new Error("No tests exported by test case"));
-								done();
-							});
+							}, 30000);
 						});
 					});
 				});

--- a/test/TestCases.test.js
+++ b/test/TestCases.test.js
@@ -174,6 +174,7 @@ describe("TestCases", () => {
 								};
 								webpack(options, (err, stats) => {
 									if(err) return done(err);
+									console.log("compiled case:", category.name, "/", config.name, "/", testName);
 									const statOptions = Stats.presetToOptions("verbose");
 									statOptions.colors = false;
 									mkdirp.sync(outputDirectory);

--- a/test/browsertest/lib/index.web.js
+++ b/test/browsertest/lib/index.web.js
@@ -20,8 +20,8 @@ describe("main", function() {
 		expect(window.library2common.ok2).toEqual(expect.anything());
 		expect(window.library2common.ok2).toBe(true);
 		expect(window.library2).toEqual(expect.anything());
-		expect(window.library2.ok).toEqual(expect.anything());
-		expect(window.library2.ok).toBe(true);
+		expect(window.toBeTruthy()).toEqual(expect.anything());
+		expect(window.toBeTruthy()).toBe(true);
 	});
 
 	describe("web resolving", function() {
@@ -32,7 +32,7 @@ describe("main", function() {
 		it("should load correct replacements for files", function(done) {
 			require.ensure(["subcontent"], function(require) {
 				// Comments work!
-				exports.ok = true;
+				exports.toBeTruthy() = true;
 				test(require("subcontent") === "replaced", "node_modules should be replaced with web_modules");
 				test(require("subcontent2/file.js") === "orginal", "node_modules should still work when web_modules exists");
 				done();
@@ -40,8 +40,8 @@ describe("main", function() {
 		});
 
 		after(function() {
-			expect(exports.ok).toEqual(expect.anything());
-			expect(exports.ok).toBe(true);
+			expect(exports.toBeTruthy()).toEqual(expect.anything());
+			expect(exports.toBeTruthy()).toBe(true);
 		});
 	});
 

--- a/test/cases/amd/namedModules/index.js
+++ b/test/cases/amd/namedModules/index.js
@@ -16,14 +16,14 @@ define("named4", [], function() {
 
 define(["named1", "named2"], function(named1, named2) {
 	it("should load the named modules in defined dependencies", function() {
-		named1.should.be.eql("named1");
-		named2.should.be.eql("named2");
+		expect(named1).toBe("named1");
+		expect(named2).toBe("named2");
 	});
 
 	it("should load the named modules in require dependencies", function(done) {
 		require(["named3", "named4"], function (named3, named4) {
-			named3.should.be.eql("named3");
-			named4.should.be.eql("named4");
+			expect(named3).toBe("named3");
+			expect(named4).toBe("named4");
 			done();
 		});
 	});

--- a/test/cases/amd/namedModulesConstArrayDep/index.js
+++ b/test/cases/amd/namedModulesConstArrayDep/index.js
@@ -16,14 +16,14 @@ define("named4", [], function() {
 
 define("named1,named2".split(","), function(named1, named2) {
 	it("should load the named modules in const array defined dependencies", function() {
-		named1.should.be.eql("named1");
-		named2.should.be.eql("named2");
+		expect(named1).toBe("named1");
+		expect(named2).toBe("named2");
 	});
 
 	it("should load the named modules in const array require dependencies", function(done) {
 		require("named3,named4".split(","), function (named3, named4) {
-			named3.should.be.eql("named3");
-			named4.should.be.eql("named4");
+			expect(named3).toBe("named3");
+			expect(named4).toBe("named4");
 			done();
 		});
 	});

--- a/test/cases/chunks/circular-correctness/index.js
+++ b/test/cases/chunks/circular-correctness/index.js
@@ -2,7 +2,7 @@ it("should handle circular chunks correctly", function(done) {
 	import(/* webpackChunkName: "a" */"./module-a").then(function(result) {
 		return result.default();
 	}).then(function(result2) {
-		result2.default().should.be.eql("x");
+		expect(result2.default()).toBe("x");
 		done();
 	}).catch(function(e) {
 		done(e);

--- a/test/cases/chunks/context-weak/index.js
+++ b/test/cases/chunks/context-weak/index.js
@@ -1,8 +1,8 @@
 it("should not bundle context requires with asyncMode === 'weak'", function() {
 	var contextRequire = require.context(".", false, /two/, "weak");
-	(function() {
+	expect(function() {
 		contextRequire("./two")
-	}).should.throw(/not available/);
+	}).toThrowError(/not available/);
 });
 
 it("should find module with asyncMode === 'weak' when required elsewhere", function() {

--- a/test/cases/chunks/context-weak/index.js
+++ b/test/cases/chunks/context-weak/index.js
@@ -7,12 +7,12 @@ it("should not bundle context requires with asyncMode === 'weak'", function() {
 
 it("should find module with asyncMode === 'weak' when required elsewhere", function() {
 	var contextRequire = require.context(".", false, /.+/, "weak");
-	contextRequire("./three").should.be.eql(3);
+	expect(contextRequire("./three")).toBe(3);
 	require("./three"); // in a real app would be served as a separate chunk
 });
 
 it("should find module with asyncMode === 'weak' when required elsewhere (recursive)", function() {
 	var contextRequire = require.context(".", true, /.+/, "weak");
-	contextRequire("./dir/four").should.be.eql(4);
+	expect(contextRequire("./dir/four")).toBe(4);
 	require("./dir/four"); // in a real app would be served as a separate chunk
 });

--- a/test/cases/chunks/context/index.js
+++ b/test/cases/chunks/context/index.js
@@ -1,9 +1,9 @@
 it("should also work in a chunk", function(done) {
 	require.ensure([], function(require) {
 		var contextRequire = require.context(".", false, /two/);
-		contextRequire("./two").should.be.eql(2);
+		expect(contextRequire("./two")).toBe(2);
 		var tw = "tw";
-		require("." + "/" + tw + "o").should.be.eql(2);
+		expect(require("." + "/" + tw + "o")).toBe(2);
 		done();
 	});
 });

--- a/test/cases/chunks/import-context/index.js
+++ b/test/cases/chunks/import-context/index.js
@@ -2,11 +2,11 @@ function testCase(load, done) {
 	load("two", 2, function() {
 		var sync = true;
 		load("one", 1, function() {
-			sync.should.be.eql(false);
+			expect(sync).toBe(false);
 			load("three", 3, function() {
 				var sync = true;
 				load("two", 2, function() {
-					sync.should.be.eql(true);
+					expect(sync).toBe(true);
 					done();
 				});
 				Promise.resolve().then(function() {}).then(function() {}).then(function() {
@@ -23,7 +23,7 @@ function testCase(load, done) {
 it("should be able to use expressions in import", function(done) {
 	function load(name, expected, callback) {
 		import("./dir/" + name).then(function(result) {
-			result.should.be.eql({ default: expected });
+			expect(result).toEqual({ default: expected });
 			callback();
 		}).catch(function(err) {
 			done(err);

--- a/test/cases/chunks/import/index.js
+++ b/test/cases/chunks/import/index.js
@@ -1,6 +1,6 @@
 it("should be able to use import", function(done) {
 	import("./two").then(function(two) {
-		two.should.be.eql({ default: 2 });
+		expect(two).toEqual({ default: 2 });
 		done();
 	}).catch(function(err) {
 		done(err);

--- a/test/cases/chunks/inline-options/index.js
+++ b/test/cases/chunks/inline-options/index.js
@@ -91,15 +91,15 @@ it("should not find module when mode is weak and chunk not served elsewhere", fu
 	var name = "a";
 	return import(/* webpackMode: "weak" */ "./dir10/" + name)
 		.catch(function(e) {
-			e.should.match({ message: /not available/, code: /MODULE_NOT_FOUND/ });
-		})
+			expect(e).toMatchObject({ message: /not available/, code: /MODULE_NOT_FOUND/ });
+		});
 });
 
 it("should not find module when mode is weak and chunk not served elsewhere (without context)", function() {
 	return import(/* webpackMode: "weak" */ "./dir11/a")
 		.catch(function(e) {
-			e.should.match({ message: /not available/, code: /MODULE_NOT_FOUND/ });
-		})
+			expect(e).toMatchObject({ message: /not available/, code: /MODULE_NOT_FOUND/ });
+		});
 });
 
 function testChunkLoading(load, expectedSyncInitial, expectedSyncRequested) {

--- a/test/cases/chunks/inline-options/index.js
+++ b/test/cases/chunks/inline-options/index.js
@@ -106,16 +106,16 @@ function testChunkLoading(load, expectedSyncInitial, expectedSyncRequested) {
 	var sync = false;
 	var syncInitial = true;
 	var p = Promise.all([load("a"), load("b")]).then(function() {
-		syncInitial.should.be.eql(expectedSyncInitial);
+		expect(syncInitial).toBe(expectedSyncInitial);
 		sync = true;
 		var p = Promise.all([
 			load("a").then(function(a) {
-				a.should.be.eql({ default: "a" });
-				sync.should.be.eql(true);
+				expect(a).toEqual({ default: "a" });
+				expect(sync).toBe(true);
 			}),
 			load("c").then(function(c) {
-				c.should.be.eql({ default: "c" });
-				sync.should.be.eql(expectedSyncRequested);
+				expect(c).toEqual({ default: "c" });
+				expect(sync).toBe(expectedSyncRequested);
 			})
 		]);
 		Promise.resolve().then(function(){}).then(function(){}).then(function(){}).then(function(){

--- a/test/cases/chunks/issue-2443/index.js
+++ b/test/cases/chunks/issue-2443/index.js
@@ -1,7 +1,7 @@
 it("should be able to use expressions in import (directory)", function(done) {
 	function load(name, expected, callback) {
 		import("./dir/" + name + "/file.js").then(function(result) {
-			result.should.be.eql({ default: expected });
+			expect(result).toEqual({ default: expected });
 			callback();
 		}).catch(function(err) {
 			done(err);

--- a/test/cases/chunks/named-chunks/index.js
+++ b/test/cases/chunks/named-chunks/index.js
@@ -13,7 +13,7 @@ it("should handle named chunks", function(done) {
 		require.ensure([], function(require) {
 			require("./empty?c");
 			require("./empty?d");
-			sync.should.be.ok();
+			expect(sync).toBeTruthy();
 			done();
 		}, "named-chunk");
 	}
@@ -22,10 +22,10 @@ it("should handle named chunks", function(done) {
 it("should handle empty named chunks", function(done) {
 	var sync = false;
 	require.ensure([], function(require) {
-		sync.should.be.ok();
+		expect(sync).toBeTruthy();
 	}, "empty-named-chunk");
 	require.ensure([], function(require) {
-		sync.should.be.ok();
+		expect(sync).toBeTruthy();
 		done();
 	}, "empty-named-chunk");
 	sync = true;
@@ -49,7 +49,7 @@ it("should handle named chunks when there is an error callback", function(done) 
 		require.ensure([], function(require) {
 			require("./empty?g");
 			require("./empty?h");
-			sync.should.be.ok();
+			expect(sync).toBeTruthy();
 			done();
 		}, function(error) {}, "named-chunk-for-error-callback");
 	}
@@ -58,10 +58,10 @@ it("should handle named chunks when there is an error callback", function(done) 
 it("should handle empty named chunks when there is an error callback", function(done) {
 	var sync = false;
 	require.ensure([], function(require) {
-		sync.should.be.ok();
+		expect(sync).toBeTruthy();
 	}, function(error) {}, "empty-named-chunk-for-error-callback");
 	require.ensure([], function(require) {
-		sync.should.be.ok();
+		expect(sync).toBeTruthy();
 		done();
 	}, function(error) {}, "empty-named-chunk-for-error-callback");
 	sync = true;
@@ -75,13 +75,13 @@ it("should be able to use named chunks in import()", function(done) {
 	import("./empty?import1-in-chunk1" /* webpackChunkName: "import-named-chunk-1" */).then(function(result){
 		var i = 0;
 		import("./empty?import2-in-chunk1" /* webpackChunkName: "import-named-chunk-1" */).then(function(result){
-			sync.should.be.ok();
+			expect(sync).toBeTruthy();
 			if(i++ > 0) done();
 		}).catch(function(err){
 			done(err);
 		});
 		import("./empty?import3-in-chunk2" /* webpackChunkName: "import-named-chunk-2" */).then(function(result){
-			sync.should.not.be.ok();
+			expect(sync).toBeFalsy();
 			if(i++ > 0) done();
 		}).catch(function(err){
 			done(err);
@@ -99,13 +99,13 @@ it("should be able to use named chunk in context import()", function(done) {
 	import("./e" + mpty + "2" /* webpackChunkName: "context-named-chunk" */).then(function(result) {
 		var i = 0;
 		import("./e" + mpty + "3" /* webpackChunkName: "context-named-chunk" */).then(function(result){
-			sync.should.be.ok();
+			expect(sync).toBeTruthy();
 			if(i++ > 0) done();
 		}).catch(function(err){
 			done(err);
 		});
 		import("./e" + mpty + "4" /* webpackChunkName: "context-named-chunk-2" */).then(function(result){
-			sync.should.not.be.ok();
+			expect(sync).toBeFalsy();
 			if(i++ > 0) done();
 		}).catch(function(err){
 			done(err);

--- a/test/cases/chunks/parsing/index.js
+++ b/test/cases/chunks/parsing/index.js
@@ -2,11 +2,11 @@ var should = require("should");
 
 it("should handle bound function expressions", function(done) {
 	require.ensure([], function(require) {
-		this.should.be.eql({ test: true });
+		expect(this).toEqual({ test: true });
 		require("./empty?test");
 		process.nextTick.should.have.type("function"); // check if injection still works
 		require.ensure([], function(require) {
-			this.should.be.eql({ test: true });
+			expect(this).toEqual({ test: true });
 			done();
 		}.bind(this));
 	}.bind({test: true}));
@@ -21,7 +21,7 @@ it("should handle require.ensure without function expression", function(done) {
 
 it("should parse expression in require.ensure, which isn't a function expression", function(done) {
 	require.ensure([], (function() {
-		require("./empty?require.ensure:test").should.be.eql({});
+		expect(require("./empty?require.ensure:test")).toEqual({});
 		return function f() {
 			done();
 		};
@@ -36,7 +36,7 @@ it("should accept a require.include call", function(done) {
 	});
 	setImmediate(function() {
 		should.strictEqual(value, "require.include");
-		value.should.be.eql("require.include");
+		expect(value).toBe("require.include");
 		done();
 	});
 });

--- a/test/cases/chunks/parsing/index.js
+++ b/test/cases/chunks/parsing/index.js
@@ -1,10 +1,8 @@
-var should = require("should");
-
 it("should handle bound function expressions", function(done) {
 	require.ensure([], function(require) {
 		expect(this).toEqual({ test: true });
 		require("./empty?test");
-		process.nextTick.should.have.type("function"); // check if injection still works
+		expect(process.nextTick).toBeTypeOf("function"); // check if injection still works
 		require.ensure([], function(require) {
 			expect(this).toEqual({ test: true });
 			done();
@@ -35,7 +33,7 @@ it("should accept a require.include call", function(done) {
 		value = require("./require.include");
 	});
 	setImmediate(function() {
-		should.strictEqual(value, "require.include");
+		expect(value).toBe("require.include");
 		expect(value).toBe("require.include");
 		done();
 	});

--- a/test/cases/chunks/runtime/duplicate.js
+++ b/test/cases/chunks/runtime/duplicate.js
@@ -1,3 +1,3 @@
 require.ensure(["./a"], function(require) {
-	require("./a").should.be.eql("a");
+	expect(require("./a")).toBe("a");
 })

--- a/test/cases/chunks/runtime/duplicate2.js
+++ b/test/cases/chunks/runtime/duplicate2.js
@@ -1,3 +1,3 @@
 require.ensure(["./b"], function(require) {
-	require("./b").should.be.eql("a");
+	expect(require("./b")).toBe("a");
 })

--- a/test/cases/chunks/runtime/index.js
+++ b/test/cases/chunks/runtime/index.js
@@ -21,7 +21,7 @@ it("should not load a chunk which is included in a already loaded one", function
 	var asyncFlag = false;
 	require.ensure(["./empty?x", "./empty?y", "./empty?z"], function(require) {
 		try {
-			asyncFlag.should.be.eql(true);
+			expect(asyncFlag).toBe(true);
 			loadChunk();
 		} catch(e) {
 			done(e);
@@ -34,7 +34,7 @@ it("should not load a chunk which is included in a already loaded one", function
 		var sync = true;
 		require.ensure(["./empty?x", "./empty?y"], function(require) {
 			try {
-				sync.should.be.eql(true);
+				expect(sync).toBe(true);
 				done();
 			} catch(e) {
 				done(e);

--- a/test/cases/chunks/weak-dependencies-context/index.js
+++ b/test/cases/chunks/weak-dependencies-context/index.js
@@ -18,7 +18,7 @@ it("should not include a module with a weak dependency using context", function(
 	resolveWeakB.should.exist;
 	resolveWeakC.should.exist;
 
-	a.should.be.eql(false);
-	b.should.be.eql(false);
-	c.should.be.eql(true);
+	expect(a).toBe(false);
+	expect(b).toBe(false);
+	expect(c).toBe(true);
 });

--- a/test/cases/chunks/weak-dependencies-context/index.js
+++ b/test/cases/chunks/weak-dependencies-context/index.js
@@ -14,9 +14,9 @@ it("should not include a module with a weak dependency using context", function(
 	require(["./b"]);
 	require("./c");
 
-	resolveWeakA.should.exist;
-	resolveWeakB.should.exist;
-	resolveWeakC.should.exist;
+	expect(resolveWeakA).toBeDefined();
+	expect(resolveWeakB).toBeDefined();
+	expect(resolveWeakC).toBeDefined();
 
 	expect(a).toBe(false);
 	expect(b).toBe(false);

--- a/test/cases/chunks/weak-dependencies/index.js
+++ b/test/cases/chunks/weak-dependencies/index.js
@@ -5,9 +5,9 @@ it("should not include a module with a weak dependency", function() {
 	var d = !!__webpack_modules__[require.resolveWeak("./d")];
 	require(["./c"]);
 	require("./d");
-	
-	a.should.be.eql(false);
-	b.should.be.eql(true);
-	c.should.be.eql(false);
-	d.should.be.eql(true);
+
+	expect(a).toBe(false);
+	expect(b).toBe(true);
+	expect(c).toBe(false);
+	expect(d).toBe(true);
 });

--- a/test/cases/chunks/weird-reference-to-entry/index.js
+++ b/test/cases/chunks/weird-reference-to-entry/index.js
@@ -1,6 +1,6 @@
 it("should handle reference to entry chunk correctly", function(done) {
 	import(/* webpackChunkName: "main" */"./module-a").then(function(result) {
-		result.default.should.be.eql("ok");
+		expect(result.default).toBe("ok");
 		done();
 	}).catch(function(e) {
 		done(e);

--- a/test/cases/compile/deduplication-bundle-loader/index.js
+++ b/test/cases/compile/deduplication-bundle-loader/index.js
@@ -1,12 +1,12 @@
 it("should load a duplicate module with different dependencies correctly", function(done) {
 	var a = require("bundle-loader!./a/file");
 	var b = require("bundle-loader!./b/file");
-	(typeof a).should.be.eql("function");
-	(typeof b).should.be.eql("function");
+	expect((typeof a)).toBe("function");
+	expect((typeof b)).toBe("function");
 	a(function(ra) {
-		ra.should.be.eql("a");
+		expect(ra).toBe("a");
 		b(function(rb) {
-			rb.should.be.eql("b");
+			expect(rb).toBe("b");
 			done();
 		})
 	});

--- a/test/cases/compile/deduplication/index.js
+++ b/test/cases/compile/deduplication/index.js
@@ -1,6 +1,6 @@
 it("should load a duplicate module with different dependencies correctly", function() {
 	var dedupe1 = require("./dedupe1");
 	var dedupe2 = require("./dedupe2");
-	dedupe1.should.be.eql("dedupe1");
-	dedupe2.should.be.eql("dedupe2");
+	expect(dedupe1).toBe("dedupe1");
+	expect(dedupe2).toBe("dedupe2");
 });

--- a/test/cases/compile/error-hide-stack/index.js
+++ b/test/cases/compile/error-hide-stack/index.js
@@ -1,5 +1,5 @@
 it("should hide stack in details", function() {
-	(function f() {
+	expect(function f() {
 		require("./loader!");
-	}).should.throw();
+	}).toThrowError();
 });

--- a/test/cases/concord/inner-modules-and-extensions/index.js
+++ b/test/cases/concord/inner-modules-and-extensions/index.js
@@ -1,12 +1,12 @@
 it("should resolve the alias in package.json", function() {
-	require("app/file").default.should.be.eql("file");
+	expect(require("app/file").default).toBe("file");
 });
 
 it("should resolve the alias and extensions in package.json", function() {
-	require("app/file2").default.should.be.eql("correct file2");
+	expect(require("app/file2").default).toBe("correct file2");
 });
 
 it("should resolve the alias in package.json", function() {
-	require("thing").default.should.be.eql("the thing");
+	expect(require("thing").default).toBe("the thing");
 });
 

--- a/test/cases/context/ignore-hidden-files/index.js
+++ b/test/cases/context/ignore-hidden-files/index.js
@@ -1,6 +1,6 @@
 it("should ignore hidden files", function() {
-	(function() {
+	expect(function() {
 		var name = "./file.js";
 		require("./folder/" + name);
-	}).should.throw();
+	}).toThrowError();
 });

--- a/test/cases/context/issue-1769/index.js
+++ b/test/cases/context/issue-1769/index.js
@@ -3,7 +3,7 @@ it("should be able the catch a incorrect import", function(done) {
 	import("./folder/" + expr).then(function() {
 		done(new Error("should not be called"));
 	}).catch(function(err) {
-		err.should.be.instanceof(Error);
+		expect(err).toBeInstanceOf(Error);
 		done();
 	});
 });

--- a/test/cases/context/issue-3873/index.js
+++ b/test/cases/context/issue-3873/index.js
@@ -3,5 +3,5 @@ function get(name) {
 }
 
 it("should automatically infer the index.js file", function() {
-	get("module").should.be.eql("module");
+	expect(get("module")).toBe("module");
 });

--- a/test/cases/context/issue-524/index.js
+++ b/test/cases/context/issue-524/index.js
@@ -1,12 +1,12 @@
 it("should support an empty context", function() {
 	var c = require.context(".", true, /^nothing$/);
-	(typeof c.id).should.be.oneOf(["number", "string"]);
-	(function() {
+	expect(typeof c.id).to.be.oneOf(["number", "string"]);
+	expect(function() {
 		c.resolve("");
-	}).should.throw();
-	(function() {
+	}).toThrowError();
+	expect(function() {
 		c("");
-	}).should.throw();
+	}).toThrowError();
 	expect(c.keys()).toEqual([]);
 });
 

--- a/test/cases/context/issue-524/index.js
+++ b/test/cases/context/issue-524/index.js
@@ -1,6 +1,6 @@
 it("should support an empty context", function() {
 	var c = require.context(".", true, /^nothing$/);
-	expect(typeof c.id).to.be.oneOf(["number", "string"]);
+	expect(typeof c.id === "number" || typeof c.id === "string").toBeTruthy();
 	expect(function() {
 		c.resolve("");
 	}).toThrowError();

--- a/test/cases/context/issue-524/index.js
+++ b/test/cases/context/issue-524/index.js
@@ -7,7 +7,7 @@ it("should support an empty context", function() {
 	(function() {
 		c("");
 	}).should.throw();
-	c.keys().should.be.eql([]);
+	expect(c.keys()).toEqual([]);
 });
 
 // This would be a useful testcase, but it requires an (really) empty directory.
@@ -21,5 +21,5 @@ it("should support an empty context", function() {
 	(function() {
 		c("");
 	}).should.throw();
-	c.keys().should.be.eql([]);
+	expect(c.keys()).toEqual([]);
 });*/

--- a/test/cases/context/issue-5750/index.js
+++ b/test/cases/context/issue-5750/index.js
@@ -1,4 +1,4 @@
 it("should not use regexps with the g flag", function() {
-	require.context("./folder", true, /a/).keys().length.should.be.eql(1);
-	require.context("./folder", true, /a/g).keys().length.should.be.eql(0);
+	expect(require.context("./folder", true, /a/).keys().length).toBe(1);
+	expect(require.context("./folder", true, /a/g).keys().length).toBe(0);
 });

--- a/test/cases/context/issue-801/index.js
+++ b/test/cases/context/issue-801/index.js
@@ -1,7 +1,7 @@
 it("should emit valid code for dynamic require string with expr", function() {
 	var test = require("./folder/file");
-	test("file").should.be.eql({ a: false, b: false, c: true, d: true });
-	test("file.js").should.be.eql({ a: false, b: false, c: false, d: true });
-	test("./file").should.be.eql({ a: true, b: true, c: false, d: false });
-	test("./file.js").should.be.eql({ a: false, b: false, c: false, d: false });
+	expect(test("file")).toEqual({ a: false, b: false, c: true, d: true });
+	expect(test("file.js")).toEqual({ a: false, b: false, c: false, d: true });
+	expect(test("./file")).toEqual({ a: true, b: true, c: false, d: false });
+	expect(test("./file.js")).toEqual({ a: false, b: false, c: false, d: false });
 });

--- a/test/cases/errors/case-sensistive/index.js
+++ b/test/cases/errors/case-sensistive/index.js
@@ -3,6 +3,6 @@ it("should return different modules with different casing", function() {
 	var A = require("./A");
 	var b = require("./b/file.js");
 	var B = require("./B/file.js");
-	a.should.not.be.equal(A);
-	b.should.not.be.equal(B);
+	expect(a).not.toBe(A);
+	expect(b).not.toBe(B);
 });

--- a/test/cases/errors/harmony-import-missing/index.js
+++ b/test/cases/errors/harmony-import-missing/index.js
@@ -1,5 +1,5 @@
 it("should not crash on importing missing modules", function() {
-	(function() {
+	expect(function() {
 		require("./module");
-	}).should.throw();
+	}).toThrowError();
 });

--- a/test/cases/json/data/index.js
+++ b/test/cases/json/data/index.js
@@ -1,8 +1,8 @@
 it("should require json via require", function() {
-	({ data: require("./a.json") }).should.be.eql({ data: null });
-	({ data: require("./b.json") }).should.be.eql({ data: 123 });
-	({ data: require("./c.json") }).should.be.eql({ data: [1, 2, 3, 4] });
-	({ data: require("./e.json") }).should.be.eql({ data: {
+	({ data: require("./a.json") }expect()).toEqual({ data: null });
+	({ data: require("./b.json") }expect()).toEqual({ data: 123 });
+	({ data: require("./c.json") }expect()).toEqual({ data: [1, 2, 3, 4] });
+	({ data: require("./e.json") }expect()).toEqual({ data: {
 		"aa": 1,
 		"bb": 2,
 		"1": "x"

--- a/test/cases/json/import-by-name/index.js
+++ b/test/cases/json/import-by-name/index.js
@@ -10,12 +10,12 @@ it("should be possible to import json data", function() {
 	expect(aa).toBe(1);
 	expect(bb).toBe(2);
 	expect(named).toBe("named");
-	({ f }expect()).toEqual({
+	(expect({ f })).toEqual({
 		f: {
 			__esModule: true,
 			default: "default",
 			named: "named"
 		}
 	});
-	g.named.should.be.equal(gnamed);
+	expect(g.named).toBe(gnamed);
 });

--- a/test/cases/json/import-by-name/index.js
+++ b/test/cases/json/import-by-name/index.js
@@ -5,12 +5,12 @@ import f, { named } from "../data/f.json";
 import g, { named as gnamed } from "../data/g.json";
 
 it("should be possible to import json data", function() {
-	c[2].should.be.eql(3);
-	Object.keys(d).should.be.eql(["default"]);
-	aa.should.be.eql(1);
-	bb.should.be.eql(2);
-	named.should.be.eql("named");
-	({ f }).should.be.eql({
+	expect(c[2]).toBe(3);
+	expect(Object.keys(d)).toEqual(["default"]);
+	expect(aa).toBe(1);
+	expect(bb).toBe(2);
+	expect(named).toBe("named");
+	({ f }expect()).toEqual({
 		f: {
 			__esModule: true,
 			default: "default",

--- a/test/cases/json/import-with-default/index.js
+++ b/test/cases/json/import-with-default/index.js
@@ -6,16 +6,16 @@ import e from "../data/e.json";
 import f from "../data/f.json";
 
 it("should be possible to import json data", function() {
-	({a}).should.be.eql({a: null});
-	b.should.be.eql(123);
-	c.should.be.eql([1, 2, 3, 4]);
-	d.should.be.eql({});
-	e.should.be.eql({
+	({a}expect()).toEqual({a: null});
+	expect(b).toBe(123);
+	expect(c).toEqual([1, 2, 3, 4]);
+	expect(d).toEqual({});
+	expect(e).toEqual({
 		aa: 1,
 		bb: 2,
 		"1": "x"
 	});
-	f.should.be.eql({
+	expect(f).toEqual({
 		named: "named",
 		"default": "default",
 		__esModule: true

--- a/test/cases/loaders/async/index.js
+++ b/test/cases/loaders/async/index.js
@@ -1,14 +1,14 @@
 it("should allow combinations of async and sync loaders", function() {
-	require("./loaders/syncloader!./a").should.be.eql("a");
-	require("./loaders/asyncloader!./a").should.be.eql("a");
+	expect(require("./loaders/syncloader!./a")).toBe("a");
+	expect(require("./loaders/asyncloader!./a")).toBe("a");
 
-	require("./loaders/syncloader!./loaders/syncloader!./a").should.be.eql("a");
-	require("./loaders/syncloader!./loaders/asyncloader!./a").should.be.eql("a");
-	require("./loaders/asyncloader!./loaders/syncloader!./a").should.be.eql("a");
-	require("./loaders/asyncloader!./loaders/asyncloader!./a").should.be.eql("a");
+	expect(require("./loaders/syncloader!./loaders/syncloader!./a")).toBe("a");
+	expect(require("./loaders/syncloader!./loaders/asyncloader!./a")).toBe("a");
+	expect(require("./loaders/asyncloader!./loaders/syncloader!./a")).toBe("a");
+	expect(require("./loaders/asyncloader!./loaders/asyncloader!./a")).toBe("a");
 
-	require("./loaders/asyncloader!./loaders/asyncloader!./loaders/asyncloader!./a").should.be.eql("a");
-	require("./loaders/asyncloader!./loaders/syncloader!./loaders/asyncloader!./a").should.be.eql("a");
-	require("./loaders/syncloader!./loaders/asyncloader!./loaders/syncloader!./a").should.be.eql("a");
-	require("./loaders/syncloader!./loaders/syncloader!./loaders/syncloader!./a").should.be.eql("a");
+	expect(require("./loaders/asyncloader!./loaders/asyncloader!./loaders/asyncloader!./a")).toBe("a");
+	expect(require("./loaders/asyncloader!./loaders/syncloader!./loaders/asyncloader!./a")).toBe("a");
+	expect(require("./loaders/syncloader!./loaders/asyncloader!./loaders/syncloader!./a")).toBe("a");
+	expect(require("./loaders/syncloader!./loaders/syncloader!./loaders/syncloader!./a")).toBe("a");
 });

--- a/test/cases/loaders/coffee-loader/index.js
+++ b/test/cases/loaders/coffee-loader/index.js
@@ -1,10 +1,10 @@
 it("should handle the coffee loader correctly", function() {
-	require("!coffee-loader!../_resources/script.coffee").should.be.eql("coffee test");
-	require("../_resources/script.coffee").should.be.eql("coffee test");
+	expect(require("!coffee-loader!../_resources/script.coffee")).toBe("coffee test");
+	expect(require("../_resources/script.coffee")).toBe("coffee test");
 });
 
 it("should handle literate coffee script correctly", function() {
-	require("!coffee-loader?literate!./script.coffee.md").should.be.eql("literate coffee test");
+	expect(require("!coffee-loader?literate!./script.coffee.md")).toBe("literate coffee test");
 });
 
 it("should generate valid code with cheap-source-map", function() {

--- a/test/cases/loaders/context/index.js
+++ b/test/cases/loaders/context/index.js
@@ -1,5 +1,5 @@
 it("should be able to use a context with a loader", function() {
 	var abc = "abc", scr = "script.coffee";
-	require("../_resources/" + scr).should.be.eql("coffee test");
-	require("raw-loader!../_resources/" + abc + ".txt").should.be.eql("abc");
+	expect(require("../_resources/" + scr)).toBe("coffee test");
+	expect(require("raw-loader!../_resources/" + abc + ".txt")).toBe("abc");
 });

--- a/test/cases/loaders/css-loader/index.js
+++ b/test/cases/loaders/css-loader/index.js
@@ -1,5 +1,11 @@
 it("should handle the css loader correctly", function() {
-	(require("!css-loader!../_css/stylesheet.css") + "").indexOf(".rule-direct").should.not.be.eql(-1);
-	(require("!css-loader!../_css/stylesheet.css") + "").indexOf(".rule-import1").should.not.be.eql(-1);
-	(require("!css-loader!../_css/stylesheet.css") + "").indexOf(".rule-import2").should.not.be.eql(-1);
+	expect(
+        (require("!css-loader!../_css/stylesheet.css") + "").indexOf(".rule-direct")
+    ).not.toEqual(-1);
+	expect(
+        (require("!css-loader!../_css/stylesheet.css") + "").indexOf(".rule-import1")
+    ).not.toEqual(-1);
+	expect(
+        (require("!css-loader!../_css/stylesheet.css") + "").indexOf(".rule-import2")
+    ).not.toEqual(-1);
 });

--- a/test/cases/loaders/issue-2299/index.js
+++ b/test/cases/loaders/issue-2299/index.js
@@ -1,3 +1,3 @@
 it("should be able to use loadModule multiple times within a loader, on files in different directories", function() {
-	require('!./loader/index.js!./a.data').should.have.properties(['a', 'b', 'c']);
+	expect(require('!./loader/index.js!./a.data')).to.have.properties(['a', 'b', 'c']);
 });

--- a/test/cases/loaders/jade-loader/index.js
+++ b/test/cases/loaders/jade-loader/index.js
@@ -1,4 +1,4 @@
 it("should handle the jade loader correctly", function() {
-	require("!jade-loader?self!../_resources/template.jade")({abc: "abc"}).should.be.eql("<p>selfabc</p><h1>included</h1>");
-	require("../_resources/template.jade")({abc: "abc"}).should.be.eql("<p>abc</p><h1>included</h1>");
+	require("!jade-loader?self!../_resources/template.jade")({abc: "abc"}expect()).toBe("<p>selfabc</p><h1>included</h1>");
+	require("../_resources/template.jade")({abc: "abc"}expect()).toBe("<p>abc</p><h1>included</h1>");
 });

--- a/test/cases/loaders/json-loader/index.js
+++ b/test/cases/loaders/json-loader/index.js
@@ -1,13 +1,11 @@
-var should = require("should");
-
 it("should be able to load JSON files without loader", function() {
 	var someJson = require("./some.json");
-	someJson.should.have.property("it", "works");
-	someJson.should.have.property("number", 42);
+	expect(someJson).toHaveProperty("it", "works");
+	expect(someJson).toHaveProperty("number", 42);
 });
 
 it("should also work when the json extension is omitted", function() {
 	var someJson = require("./some");
-	someJson.should.have.property("it", "works");
-	someJson.should.have.property("number", 42);
+	expect(someJson).toHaveProperty("it", "works");
+	expect(someJson).toHaveProperty("number", 42);
 });

--- a/test/cases/loaders/less-loader/index.js
+++ b/test/cases/loaders/less-loader/index.js
@@ -1,5 +1,11 @@
 it("should handle the less loader (piped with raw loader) correctly", function() {
-	require("!raw-loader!less-loader!./less/stylesheet.less").indexOf(".less-rule-direct").should.not.be.eql(-1);
-	require("!raw-loader!less-loader!./less/stylesheet.less").indexOf(".less-rule-import1").should.not.be.eql(-1);
-	require("!raw-loader!less-loader!./less/stylesheet.less").indexOf(".less-rule-import2").should.not.be.eql(-1);
+	expect(
+        require("!raw-loader!less-loader!./less/stylesheet.less").indexOf(".less-rule-direct")
+    ).not.toEqual(-1);
+	expect(
+        require("!raw-loader!less-loader!./less/stylesheet.less").indexOf(".less-rule-import1")
+    ).not.toEqual(-1);
+	expect(
+        require("!raw-loader!less-loader!./less/stylesheet.less").indexOf(".less-rule-import2")
+    ).not.toEqual(-1);
 });

--- a/test/cases/loaders/module-description-file/index.js
+++ b/test/cases/loaders/module-description-file/index.js
@@ -1,12 +1,12 @@
 it("should run a loader from package.json", function() {
-	require("testloader!../_resources/abc.txt").should.be.eql("abcwebpack");
-	require("testloader/lib/loader2!../_resources/abc.txt").should.be.eql("abcweb");
-	require("testloader/lib/loader3!../_resources/abc.txt").should.be.eql("abcloader");
-	require("testloader/lib/loader-indirect!../_resources/abc.txt").should.be.eql("abcwebpack");
+	expect(require("testloader!../_resources/abc.txt")).toBe("abcwebpack");
+	expect(require("testloader/lib/loader2!../_resources/abc.txt")).toBe("abcweb");
+	expect(require("testloader/lib/loader3!../_resources/abc.txt")).toBe("abcloader");
+	expect(require("testloader/lib/loader-indirect!../_resources/abc.txt")).toBe("abcwebpack");
 });
 it("should run a loader from .webpack-loader.js extension", function() {
-	require("testloader/lib/loader!../_resources/abc.txt").should.be.eql("abcwebpack");
+	expect(require("testloader/lib/loader!../_resources/abc.txt")).toBe("abcwebpack");
 });
 it("should be able to pipe loaders", function() {
-	require("testloader!./reverseloader!../_resources/abc.txt").should.be.eql("cbawebpack");
+	expect(require("testloader!./reverseloader!../_resources/abc.txt")).toBe("cbawebpack");
 });

--- a/test/cases/loaders/query/index.js
+++ b/test/cases/loaders/query/index.js
@@ -1,6 +1,6 @@
 it("should pass query to loader", function() {
 	var result = require("./loaders/queryloader?query!./a?resourcequery");
-	result.should.be.eql({
+	expect(result).toEqual({
 		resourceQuery: "?resourcequery",
 		query: "?query",
 		prev: "module.exports = \"a\";"
@@ -9,7 +9,7 @@ it("should pass query to loader", function() {
 
 it("should pass query to loader without resource with resource query", function() {
 	var result = require("./loaders/queryloader?query!?resourcequery");
-	result.should.be.eql({
+	expect(result).toEqual({
 		resourceQuery: "?resourcequery",
 		query: "?query",
 		prev: null
@@ -18,7 +18,7 @@ it("should pass query to loader without resource with resource query", function(
 
 it("should pass query to loader without resource", function() {
 	var result = require("./loaders/queryloader?query!");
-	result.should.be.eql({
+	expect(result).toEqual({
 		query: "?query",
 		prev: null
 	});
@@ -39,7 +39,7 @@ it("should pass query to multiple loaders", function() {
 it("should pass query to loader over context", function() {
 	var test = "test";
 	var result = require("./loaders/queryloader?query!./context-query-test/" + test);
-	result.should.be.eql({
+	expect(result).toEqual({
 		resourceQuery: "",
 		query: "?query",
 		prev: "test content"

--- a/test/cases/loaders/query/index.js
+++ b/test/cases/loaders/query/index.js
@@ -27,9 +27,9 @@ it("should pass query to loader without resource", function() {
 it("should pass query to multiple loaders", function() {
 	var result = require("./loaders/queryloader?query1!./loaders/queryloader?query2!./a?resourcequery");
 	expect(result).toBeTypeOf("object");
-	expect(result).to.have.property("resourceQuery").toEqual("?resourcequery");
-	expect(result).to.have.property("query").toEqual("?query1");
-	expect(result).to.have.property("prev").toEqual("module.exports = " + JSON.stringify({
+	expect(result).toHaveProperty("resourceQuery", "?resourcequery");
+	expect(result).toHaveProperty("query", "?query1");
+	expect(result).toHaveProperty("prev", "module.exports = " + JSON.stringify({
 		resourceQuery: "?resourcequery",
 		query: "?query2",
 		prev: "module.exports = \"a\";"

--- a/test/cases/loaders/query/index.js
+++ b/test/cases/loaders/query/index.js
@@ -26,10 +26,10 @@ it("should pass query to loader without resource", function() {
 
 it("should pass query to multiple loaders", function() {
 	var result = require("./loaders/queryloader?query1!./loaders/queryloader?query2!./a?resourcequery");
-	result.should.have.type("object");
-	result.should.have.property("resourceQuery").be.eql("?resourcequery");
-	result.should.have.property("query").be.eql("?query1");
-	result.should.have.property("prev").be.eql("module.exports = " + JSON.stringify({
+	expect(result).toBeTypeOf("object");
+	expect(result).to.have.property("resourceQuery").toEqual("?resourcequery");
+	expect(result).to.have.property("query").toEqual("?query1");
+	expect(result).to.have.property("prev").toEqual("module.exports = " + JSON.stringify({
 		resourceQuery: "?resourcequery",
 		query: "?query2",
 		prev: "module.exports = \"a\";"

--- a/test/cases/loaders/raw-loader/index.js
+++ b/test/cases/loaders/raw-loader/index.js
@@ -1,3 +1,3 @@
 it("should handle the raw loader correctly", function() {
-	require("raw-loader!../_resources/abc.txt").should.be.eql("abc");
+	expect(require("raw-loader!../_resources/abc.txt")).toBe("abc");
 });

--- a/test/cases/loaders/val-loader/index.js
+++ b/test/cases/loaders/val-loader/index.js
@@ -1,5 +1,11 @@
 it("should handle the val loader (piped with css loader) correctly", function() {
-	(require("!css-loader!val-loader!../_css/generateCss") + "").indexOf("generated").should.not.be.eql(-1);
-	(require("!css-loader!val-loader!../_css/generateCss") + "").indexOf(".rule-import2").should.not.be.eql(-1);
-	(require("!raw-loader!val-loader!../_css/generateCss") + "").indexOf("generated").should.not.be.eql(-1);
+	expect(
+        (require("!css-loader!val-loader!../_css/generateCss") + "").indexOf("generated")
+    ).not.toEqual(-1);
+	expect(
+        (require("!css-loader!val-loader!../_css/generateCss") + "").indexOf(".rule-import2")
+    ).not.toEqual(-1);
+	expect(
+        (require("!raw-loader!val-loader!../_css/generateCss") + "").indexOf("generated")
+    ).not.toEqual(-1);
 });

--- a/test/cases/mjs/cjs-import-default/index.mjs
+++ b/test/cases/mjs/cjs-import-default/index.mjs
@@ -5,26 +5,26 @@ import { ns, default as def1, def as def2, data as data2 } from "./reexport.mjs"
 import * as reexport from "./reexport.mjs";
 
 it("should get correct values when importing named exports from a CommonJs module from mjs", function() {
-	(typeof data).should.be.eql("undefined");
-	({ data }).should.be.eql({ data: undefined });
-	def.should.be.eql({
+	expect((typeof data)).toBe("undefined");
+	({ data }expect()).toEqual({ data: undefined });
+	expect(def).toEqual({
 		data: "ok",
 		default: "default"
 	});
-	({ def }).should.be.eql({
+	({ def }expect()).toEqual({
 		def: {
 			data: "ok",
 			default: "default"
 		}
 	});
 	const valueOf = "valueOf";
-	star[valueOf]().should.be.eql({
+	expect(star[valueOf]()).toEqual({
 		default: {
 			data: "ok",
 			default: "default"
 		}
 	});
-	({ star }).should.be.eql({
+	({ star }expect()).toEqual({
 		star: {
 			default: {
 				data: "ok",
@@ -32,26 +32,26 @@ it("should get correct values when importing named exports from a CommonJs modul
 			}
 		}
 	});
-	star.default.should.be.eql({
+	expect(star.default).toEqual({
 		data: "ok",
 		default: "default"
 	});
-	ns.should.be.eql({
+	expect(ns).toEqual({
 		default: {
 			data: "ok",
 			default: "default"
 		}
 	});
-	def1.should.be.eql({
+	expect(def1).toEqual({
 		data: "ok",
 		default: "default"
 	});
-	def2.should.be.eql({
+	expect(def2).toEqual({
 		data: "ok",
 		default: "default"
 	});
-	(typeof data2).should.be.eql("undefined");
-	reexport[valueOf]().should.be.eql({
+	expect((typeof data2)).toBe("undefined");
+	expect(reexport[valueOf]()).toEqual({
 		ns: {
 			default: {
 				data: "ok",

--- a/test/cases/mjs/namespace-object-lazy/index.mjs
+++ b/test/cases/mjs/namespace-object-lazy/index.mjs
@@ -1,13 +1,13 @@
 it("should receive a namespace object when importing commonjs", function(done) {
 	import("./cjs.js").then(function(result) {
-		result.should.be.eql({ default: { named: "named", default: "default" } });
+		expect(result).toEqual({ default: { named: "named", default: "default" } });
 		done();
 	}).catch(done);
 });
 
 it("should receive a namespace object when importing commonjs with __esModule", function(done) {
 	import("./cjs-esmodule.js").then(function(result) {
-		result.should.be.eql({ default: { __esModule: true, named: "named", default: "default" } });
+		expect(result).toEqual({ default: { __esModule: true, named: "named", default: "default" } });
 		done();
 	}).catch(done);
 });
@@ -54,7 +54,7 @@ function contextMixed(name) {
 function promiseTest(promise, equalsTo) {
 	return promise.then(function(results) {
 		for(const result of results)
-			result.should.be.eql(equalsTo);
+			expect(result).toEqual(equalsTo);
 	});
 }
 

--- a/test/cases/mjs/non-mjs-namespace-object-lazy/index.js
+++ b/test/cases/mjs/non-mjs-namespace-object-lazy/index.js
@@ -1,13 +1,13 @@
 it("should receive a namespace object when importing commonjs", function(done) {
 	import("./cjs").then(function(result) {
-		result.should.be.eql({ default: { named: "named", default: "default" } });
+		expect(result).toEqual({ default: { named: "named", default: "default" } });
 		done();
 	}).catch(done);
 });
 
 it("should receive a namespace object when importing commonjs with __esModule", function(done) {
 	import("./cjs-esmodule").then(function(result) {
-		result.should.be.eql({ __esModule: true, named: "named", default: "default" });
+		expect(result).toEqual({ __esModule: true, named: "named", default: "default" });
 		done();
 	}).catch(done);
 });
@@ -54,7 +54,7 @@ function contextMixed(name) {
 function promiseTest(promise, equalsTo) {
 	return promise.then(function(results) {
 		for(const result of results)
-			result.should.be.eql(equalsTo);
+			expect(result).toEqual(equalsTo);
 	});
 }
 

--- a/test/cases/nonce/set-nonce/index.js
+++ b/test/cases/nonce/set-nonce/index.js
@@ -7,7 +7,7 @@ it("should load script with nonce 'nonce1234'", function(done) {
 	// if in browser context, test that nonce was added.
 	if (typeof document !== 'undefined') {
 		var script = document.querySelector('script[src="js/chunk-with-nonce.web.js"]');
-		script.getAttribute('nonce').should.be.eql('nonce1234');
+		expect(script.getAttribute('nonce')).toBe('nonce1234');
 	}
 	__webpack_nonce__ = undefined;
 	done();
@@ -21,7 +21,7 @@ it("should load script without nonce", function(done) {
 	// if in browser context, test that nonce was added.
 	if (typeof document !== 'undefined') {
 		var script = document.querySelector('script[src="js/chunk-without-nonce.web.js"]');
-		script.hasAttribute('nonce').should.be.eql(false);
+		expect(script.hasAttribute('nonce')).toBe(false);
 	}
 	__webpack_nonce__ = undefined;
 	done();

--- a/test/cases/optimize/side-effects-all-chain-unused/index.js
+++ b/test/cases/optimize/side-effects-all-chain-unused/index.js
@@ -2,6 +2,6 @@ import { log } from "pmodule/tracker";
 import { a } from "pmodule";
 
 it("should not evaluate a chain of modules", function() {
-	a.should.be.eql("a");
-	log.should.be.eql(["a.js"]);
+	expect(a).toBe("a");
+	expect(log).toEqual(["a.js"]);
 });

--- a/test/cases/optimize/side-effects-all-used/index.js
+++ b/test/cases/optimize/side-effects-all-used/index.js
@@ -3,9 +3,9 @@ import { a, x, z } from "pmodule";
 import def from "pmodule";
 
 it("should evaluate all modules", function() {
-	def.should.be.eql("def");
-	a.should.be.eql("a");
-	x.should.be.eql("x");
-	z.should.be.eql("z");
-	log.should.be.eql(["a.js", "b.js", "c.js", "index.js"]);
+	expect(def).toBe("def");
+	expect(a).toBe("a");
+	expect(x).toBe("x");
+	expect(z).toBe("z");
+	expect(log).toEqual(["a.js", "b.js", "c.js", "index.js"]);
 });

--- a/test/cases/optimize/side-effects-immediate-unused/index.js
+++ b/test/cases/optimize/side-effects-immediate-unused/index.js
@@ -2,7 +2,7 @@ import { log } from "pmodule/tracker";
 import { a, z } from "pmodule";
 
 it("should not evaluate an immediate module", function() {
-	a.should.be.eql("a");
-	z.should.be.eql("z");
-	log.should.be.eql(["a.js", "c.js"]);
+	expect(a).toBe("a");
+	expect(z).toBe("z");
+	expect(log).toEqual(["a.js", "c.js"]);
 });

--- a/test/cases/optimize/side-effects-reexport-start-unknown/index.js
+++ b/test/cases/optimize/side-effects-reexport-start-unknown/index.js
@@ -2,5 +2,5 @@ import * as m from "m";
 
 it("should handle unknown exports fine", function() {
 	var x = m;
-	x.should.be.eql({ foo: "foo" });
+	expect(x).toEqual({ foo: "foo" });
 });

--- a/test/cases/optimize/side-effects-root-unused/index.js
+++ b/test/cases/optimize/side-effects-root-unused/index.js
@@ -2,8 +2,8 @@ import { log } from "pmodule/tracker";
 import { a, x, z } from "pmodule";
 
 it("should evaluate all modules", function() {
-	a.should.be.eql("a");
-	x.should.be.eql("x");
-	z.should.be.eql("z");
-	log.should.be.eql(["a.js", "b.js", "c.js"]);
+	expect(a).toBe("a");
+	expect(x).toBe("x");
+	expect(z).toBe("z");
+	expect(log).toEqual(["a.js", "b.js", "c.js"]);
 });

--- a/test/cases/optimize/side-effects-simple-unused/index.js
+++ b/test/cases/optimize/side-effects-simple-unused/index.js
@@ -3,8 +3,8 @@ import { x, z } from "pmodule";
 import def from "pmodule";
 
 it("should not evaluate a simple unused module", function() {
-	def.should.be.eql("def");
-	x.should.be.eql("x");
-	z.should.be.eql("z");
-	log.should.be.eql(["b.js", "c.js", "index.js"]);
+	expect(def).toBe("def");
+	expect(x).toBe("x");
+	expect(z).toBe("z");
+	expect(log).toEqual(["b.js", "c.js", "index.js"]);
 });

--- a/test/cases/optimize/side-effects-transitive-unused/index.js
+++ b/test/cases/optimize/side-effects-transitive-unused/index.js
@@ -2,7 +2,7 @@ import { log } from "pmodule/tracker";
 import { a, y } from "pmodule";
 
 it("should not evaluate a reexporting transitive module", function() {
-	a.should.be.eql("a");
-	y.should.be.eql("y");
-	log.should.be.eql(["a.js", "b.js"]);
+	expect(a).toBe("a");
+	expect(y).toBe("y");
+	expect(log).toEqual(["a.js", "b.js"]);
 });

--- a/test/cases/optimize/tree-shaking-commonjs/index.js
+++ b/test/cases/optimize/tree-shaking-commonjs/index.js
@@ -1,5 +1,5 @@
 import { test } from "./a";
 
 it("should correctly tree shake star exports", function() {
-	test.should.be.eql(123);
+	expect(test).toBe(123);
 });

--- a/test/cases/optimize/tree-shaking-star/index.js
+++ b/test/cases/optimize/tree-shaking-star/index.js
@@ -2,7 +2,7 @@ import { test } from "./a";
 import { func1, func3 } from "./x";
 
 it("should correctly tree shake star exports", function() {
-	test.should.be.eql(123);
-	func1().should.be.eql("func1");
-	func3().should.be.eql("func3");
+	expect(test).toBe(123);
+	expect(func1()).toBe("func1");
+	expect(func3()).toBe("func3");
 });

--- a/test/cases/optimize/tree-shaking-star2/index.js
+++ b/test/cases/optimize/tree-shaking-star2/index.js
@@ -3,10 +3,10 @@ import { aa as aa2, d } from "./root3";
 var root6 = require("./root6");
 
 it("should correctly tree shake star exports", function() {
-	aa.should.be.eql("aa");
-	aa2.should.be.eql("aa");
-	d.should.be.eql("d");
-	root6.should.be.eql({
+	expect(aa).toBe("aa");
+	expect(aa2).toBe("aa");
+	expect(d).toBe("d");
+	expect(root6).toEqual({
 		aa: "aa",
 		c: "c"
 	});

--- a/test/cases/parsing/amd-rename/index.js
+++ b/test/cases/parsing/amd-rename/index.js
@@ -1,5 +1,5 @@
 it("should name require in define correctly", function() {
 	define(["require"], function(require) {
-		(typeof require).should.be.eql("function");
+		expect((typeof require)).toBe("function");
 	});
 });

--- a/test/cases/parsing/bom/index.js
+++ b/test/cases/parsing/bom/index.js
@@ -1,9 +1,9 @@
 it("should load a utf-8 file with BOM", function() {
 	var result = require("./bomfile");
-	result.should.be.eql("ok");
+	expect(result).toEqual("ok");
 });
 
 it("should load a css file with BOM", function() {
 	var css = require("!css-loader!./bomfile.css") + "";
-	css.should.be.eql("body{color:#abc}");
+	expect(css).toBe("body{color:#abc}");
 });

--- a/test/cases/parsing/browserify/index.js
+++ b/test/cases/parsing/browserify/index.js
@@ -10,5 +10,5 @@ it("should be able to parse browserified modules (UMD)", function() {
 	},{}]},{},[1])
 	(1)
 	});
-	module.exports.should.be.eql(1234);
+	expect(module.exports).toBe(1234);
 });

--- a/test/cases/parsing/chunks/index.js
+++ b/test/cases/parsing/chunks/index.js
@@ -30,7 +30,7 @@ it("should parse a string in require.ensure with arrow function expression", fun
 
 
 it("should parse a string in require.ensure with arrow function array expression", function(done) {
-	require.ensure("./file", require =>expect( (require("./file")).toBe("ok"), done()));
+	require.ensure("./file", require => (expect(require("./file")).toBe("ok"), done()));
 });
 
 

--- a/test/cases/parsing/chunks/index.js
+++ b/test/cases/parsing/chunks/index.js
@@ -1,7 +1,7 @@
 it("should parse a Coffeescript style function expression in require.ensure", function(done) {
 	require.ensure([], (function(_this) {
 		return function(require) {
-			require("./file").should.be.eql("ok");
+			expect(require("./file")).toBe("ok");
 			done();
 		};
 	}(this)));
@@ -9,28 +9,28 @@ it("should parse a Coffeescript style function expression in require.ensure", fu
 
 it("should parse a bound function expression in require.ensure", function(done) {
 	require.ensure([], function(require) {
-		require("./file").should.be.eql("ok");
+		expect(require("./file")).toBe("ok");
 		done();
 	}.bind(this));
 });
 
 it("should parse a string in require.ensure", function(done) {
 	require.ensure("./file", function(require) {
-		require("./file").should.be.eql("ok");
+		expect(require("./file")).toBe("ok");
 		done();
 	});
 });
 
 it("should parse a string in require.ensure with arrow function expression", function(done) {
 	require.ensure("./file", require => {
-		require("./file").should.be.eql("ok");
+		expect(require("./file")).toBe("ok");
 		done();
 	});
 });
 
 
 it("should parse a string in require.ensure with arrow function array expression", function(done) {
-	require.ensure("./file", require => (require("./file").should.be.eql("ok"), done()));
+	require.ensure("./file", require =>expect( (require("./file")).toBe("ok"), done()));
 });
 
 

--- a/test/cases/parsing/class/index.js
+++ b/test/cases/parsing/class/index.js
@@ -1,12 +1,12 @@
 import X, { A, B } from "./module";
 
 it("should parse classes", function() {
-	new X().a.should.be.eql("ok");
-	new A().a.should.be.eql("ok");
-	new B().a.should.be.eql("ok");
+	expect(new X().a).toBe("ok");
+	expect(new A().a).toBe("ok");
+	expect(new B().a).toBe("ok");
 });
 
 it("should parse methods", function() {
-	new X().b().should.be.eql("ok");
-	X.c().should.be.eql("ok");
+	expect(new X().b()).toBe("ok");
+	expect(X.c()).toBe("ok");
 });

--- a/test/cases/parsing/complex-require/amd.js
+++ b/test/cases/parsing/complex-require/amd.js
@@ -12,7 +12,7 @@ it("should parse template strings in amd requires", function(done) {
 	].length;
 
 	function test (result) {
-		result.default.should.eql("ok")
+		expect(result.default).toEqual("ok")
 		if (--pending <= 0) {
 			done()
 		}
@@ -31,7 +31,7 @@ it("should parse .concat strings in amd requires", function(done) {
 	].length;
 
 	function test (result) {
-		result.default.should.eql("ok")
+		expect(result.default).toEqual("ok")
 		if (--pending <= 0) {
 			done()
 		}

--- a/test/cases/parsing/complex-require/cjs.js
+++ b/test/cases/parsing/complex-require/cjs.js
@@ -12,7 +12,7 @@ it("should parse template strings in require.ensure requires", function(done) {
 		];
 
 		for (var i = 0; i < imports.length; i++) {
-			imports[i].default.should.eql("ok");
+			expect(imports[i].default).toEqual("ok");
 		}
 		done()
 	})
@@ -31,7 +31,7 @@ it("should parse template strings in sync requires", function() {
 	];
 
 	for (var i = 0; i < imports.length; i++) {
-		imports[i].default.should.eql("sync");
+		expect(imports[i].default).toEqual("sync");
 	}
 })
 
@@ -40,7 +40,7 @@ it("should parse template strings in require.resolve", function() {
 
 	// Arbitrary assertion; can't use .ok() as it could be 0,
 	// can't use typeof as that depends on webpack config.
-	require.resolve(`./sync/${name}Test`).should.not.be.undefined();
+	expect(require.resolve(`./sync/${name}Test`)).toBeDefined();
 })
 
 it("should parse .concat strings in require.ensure requires", function(done) {
@@ -55,7 +55,7 @@ it("should parse .concat strings in require.ensure requires", function(done) {
 		];
 
 		for (var i = 0; i < imports.length; i++) {
-			imports[i].default.should.eql("ok");
+			expect(imports[i].default).toEqual("ok");
 		}
 		done()
 	})
@@ -72,7 +72,7 @@ it("should parse .concat strings in sync requires", function() {
 	];
 
 	for (var i = 0; i < imports.length; i++) {
-		imports[i].default.should.eql("sync");
+		expect(imports[i].default).toEqual("sync");
 	}
 })
 
@@ -81,5 +81,5 @@ it("should parse .concat strings in require.resolve", function() {
 
 	// Arbitrary assertion; can't use .ok() as it could be 0,
 	// can't use typeof as that depends on webpack config.
-	require.resolve("./sync/".concat(name, "Test")).should.not.be.undefined();
+	expect(require.resolve("./sync/".concat(name, "Test"))).toBeDefined();
 })

--- a/test/cases/parsing/complex-require/index.js
+++ b/test/cases/parsing/complex-require/index.js
@@ -1,5 +1,3 @@
-var should = require('should')
-
 it("should parse template strings in import", function(done) {
 	var name = "abc".split("");
 	var suffix = "Test";
@@ -10,7 +8,7 @@ it("should parse template strings in import", function(done) {
 	])
 	.then(function (imports) {
 		for (var i = 0; i < imports.length; i++) {
-			imports[i].default.should.eql("ok");
+			expect(imports[i].default).toEqual("ok");
 		}
 	})
 	.then(function () { done(); }, done)
@@ -21,7 +19,7 @@ it("should parse .concat strings in import", function(done) {
 	var suffix = "Test";
 	import("./abc/".concat(name[0]).concat(name[1]).concat(name[2], "Test"))
 	.then(function (imported) {
-		imported.default.should.eql("ok");
+		expect(imported.default).toEqual("ok");
 	})
 	.then(function () { done(); }, done)
 });

--- a/test/cases/parsing/context/index.js
+++ b/test/cases/parsing/context/index.js
@@ -1,28 +1,28 @@
 it("should be able to load a file with the require.context method", function() {
-	require.context("./templates")("./tmpl").should.be.eql("test template");
-	(require.context("./././templates"))("./tmpl").should.be.eql("test template");
-	(require.context("././templates/.")("./tmpl")).should.be.eql("test template");
-	require.context("./loaders/queryloader?dog=bark!./templates?cat=meow")("./tmpl").should.be.eql({
+	expect(require.context("./templates")("./tmpl")).toBe("test template");
+	expect((require.context("./././templates"))("./tmpl")).toBe("test template");
+	expect((require.context("././templates/.")("./tmpl"))).toBe("test template");
+	expect(require.context("./loaders/queryloader?dog=bark!./templates?cat=meow")("./tmpl")).toEqual({
 		resourceQuery: "?cat=meow",
 		query: "?dog=bark",
 		prev: "module.exports = \"test template\";"
 	});
-	require . context ( "." + "/." + "/" + "templ" + "ates" ) ( "./subdir/tmpl.js" ).should.be.eql("subdir test template");
-	require.context("./templates", true, /./)("xyz").should.be.eql("xyz");
+	expect(require . context ( "." + "/." + "/" + "templ" + "ates" ) ( "./subdir/tmpl.js" )).toBe("subdir test template");
+	expect(require.context("./templates", true, /./)("xyz")).toBe("xyz");
 });
 
 it("should automatically create contexts", function() {
 	var template = "tmpl", templateFull = "./tmpl.js";
 	var mp = "mp", tmp = "tmp", mpl = "mpl";
-	require("./templates/" + template).should.be.eql("test template");
-	require("./templates/" + tmp + "l").should.be.eql("test template");
-	require("./templates/t" + mpl).should.be.eql("test template");
-	require("./templates/t" + mp + "l").should.be.eql("test template");
+	expect(require("./templates/" + template)).toBe("test template");
+	expect(require("./templates/" + tmp + "l")).toBe("test template");
+	expect(require("./templates/t" + mpl)).toBe("test template");
+	expect(require("./templates/t" + mp + "l")).toBe("test template");
 });
 
 it("should be able to require.resolve with automatical context", function() {
 	var template = "tmpl";
-	require.resolve("./templates/" + template).should.be.eql(require.resolve("./templates/tmpl"));
+	expect(require.resolve("./templates/" + template)).toBe(require.resolve("./templates/tmpl"));
 });
 
 it("should be able to use renaming combined with a context", function() {
@@ -30,7 +30,7 @@ it("should be able to use renaming combined with a context", function() {
 	require = function () {};
 	require("fail");
 	var template = "tmpl";
-	renamedRequire("./templates/" + template).should.be.eql("test template");
+	expect(renamedRequire("./templates/" + template)).toBe("test template");
 });
 
 it("should compile an empty context", function() {

--- a/test/cases/parsing/context/index.js
+++ b/test/cases/parsing/context/index.js
@@ -35,17 +35,17 @@ it("should be able to use renaming combined with a context", function() {
 
 it("should compile an empty context", function() {
 	var x = "xxx";
-	(function() {
+	expect(function() {
 		require("./templates/notExisting" + x);
-	}).should.throw(/xxx/);
+	}).toThrowError(/xxx/);
 });
 
 it("should execute an empty context", function() {
 	var context;
-	(function() {
+	expect(function() {
 		context = require.context("./templates/", true, /^\.\/notExisting/);
-	}).should.not.throw();
-	(function() {
+	}).not.toThrowError();
+	expect(function() {
 		context("");
-	}).should.throw();
+	}).toThrowError();
 });

--- a/test/cases/parsing/es6.nominimize/index.js
+++ b/test/cases/parsing/es6.nominimize/index.js
@@ -26,14 +26,14 @@ it("should parse classes", function() {
 
 it("should parse spread operator"/*, function() {
 	expect([0, ...require("./array")]).toEqual([0, 1, 2, 3]);
-	({z: 0, ...require("./object")}expect()).toEqual({z: 0, a: 1, b: 2, c: 3});
+	expect(({z: 0, ...require("./object")})).toEqual({z: 0, a: 1, b: 2, c: 3});
 }*/);
 
 it("should parse arrow function", function() {
-	(() =>expect( require("./a"))()).toBe("a");
-	(() => {
+	expect((() => require("./a"))()).toBe("a");
+	(expect(() => {
 		return require("./a");
-	}expect()()).toBe("a");
+	})()).toBe("a");
 	require.ensure([], () => {
 		require("./a");
 	});

--- a/test/cases/parsing/es6.nominimize/index.js
+++ b/test/cases/parsing/es6.nominimize/index.js
@@ -19,21 +19,21 @@ it("should parse classes", function() {
 
 	var x = new MyClass();
 
-	x.a.should.be.eql("a");
-	x.func().should.be.eql("b");
-	x.c().should.be.eql("c");
+	expect(x.a).toBe("a");
+	expect(x.func()).toBe("b");
+	expect(x.c()).toBe("c");
 });
 
 it("should parse spread operator"/*, function() {
-	[0, ...require("./array")].should.be.eql([0, 1, 2, 3]);
-	({z: 0, ...require("./object")}).should.be.eql({z: 0, a: 1, b: 2, c: 3});
+	expect([0, ...require("./array")]).toEqual([0, 1, 2, 3]);
+	({z: 0, ...require("./object")}expect()).toEqual({z: 0, a: 1, b: 2, c: 3});
 }*/);
 
 it("should parse arrow function", function() {
-	(() => require("./a"))().should.be.eql("a");
+	(() =>expect( require("./a"))()).toBe("a");
 	(() => {
 		return require("./a");
-	})().should.be.eql("a");
+	}expect()()).toBe("a");
 	require.ensure([], () => {
 		require("./a");
 	});
@@ -53,8 +53,8 @@ it("should parse template literals", function() {
 	}
 	var x = `a${require("./b")}c`;
 	var y = tag`a${require("./b")}c`;
-	x.should.be.eql("abc");
-	y.should.be.eql("b");
+	expect(x).toBe("abc");
+	expect(y).toBe("b");
 })
 
 it("should parse generators and yield", function() {
@@ -63,7 +63,7 @@ it("should parse generators and yield", function() {
 		yield require("./b");
 	}
 	var x = gen();
-	x.next().value.should.be.eql("a");
-	x.next().value.should.be.eql("b");
-	x.next().done.should.be.eql(true);
+	expect(x.next().value).toBe("a");
+	expect(x.next().value).toBe("b");
+	expect(x.next().done).toBe(true);
 })

--- a/test/cases/parsing/evaluate/index.js
+++ b/test/cases/parsing/evaluate/index.js
@@ -7,7 +7,7 @@ it("should evaluate null", function() {
 if("shouldn't evaluate expression", function() {
 	var value = "";
 	var x = (value + "") ? "fail" : "ok";
-	x.should.be.eql("ok");
+	expect(x).toBe("ok");
 });
 
 it("should short-circut evaluating", function() {
@@ -18,5 +18,5 @@ it("should short-circut evaluating", function() {
 
 it("should evaluate __dirname and __resourceQuery with replace and substr", function() {
 	var result = require("./resourceQuery/index?" + __dirname);
-	result.should.be.eql("?resourceQuery");
+	expect(result).toEqual("?resourceQuery");
 });

--- a/test/cases/parsing/extract-amd.nominimize/index.js
+++ b/test/cases/parsing/extract-amd.nominimize/index.js
@@ -20,36 +20,36 @@ it("should parse fancy function calls with arrow functions", function() {
 it("should parse fancy AMD calls with arrow functions", function() {
 	require("./constructor ./a".split(" "));
 	require("-> module module exports *constructor *a".replace("module", "require").substr(3).replace(/\*/g, "./").split(" "), (require, module, exports, constructor, a) => {
-		(typeof require).should.be.eql("function");
-		(typeof module).should.be.eql("object");
-		(typeof exports).should.be.eql("object");
-		(typeof require("./constructor")).should.be.eql("function");
-		(typeof constructor).should.be.eql("function");
-		a.should.be.eql("a");
+		expect((typeof require)).toBe("function");
+		expect((typeof module)).toBe("object");
+		expect((typeof exports)).toBe("object");
+		expect((typeof require("./constructor"))).toBe("function");
+		expect((typeof constructor)).toBe("function");
+		expect(a).toBe("a");
 	});
 	define("-> module module exports *constructor *a".replace("module", "require").substr(3).replace(/\*/g, "./").split(" "), (require, module, exports, constructor, a) => {
-		(typeof require).should.be.eql("function");
-		(typeof module).should.be.eql("object");
-		(typeof exports).should.be.eql("object");
-		(typeof require("./constructor")).should.be.eql("function");
-		(typeof constructor).should.be.eql("function");
-		a.should.be.eql("a");
+		expect((typeof require)).toBe("function");
+		expect((typeof module)).toBe("object");
+		expect((typeof exports)).toBe("object");
+		expect((typeof require("./constructor"))).toBe("function");
+		expect((typeof constructor)).toBe("function");
+		expect(a).toBe("a");
 	});
 });
 
 it("should be able to use AMD-style require with arrow functions", function(done) {
 	var template = "b";
 	require(["./circular", "./templates/" + template, true ? "./circular" : "fail"], (circular, testTemplate, circular2) => {
-		circular.should.be.eql(1);
-		circular2.should.be.eql(1);
-		testTemplate.should.be.eql("b");
+		expect(circular).toBe(1);
+		expect(circular2).toBe(1);
+		expect(testTemplate).toBe("b");
 		done();
 	});
 });
 
 it("should be able to use require.js-style define with arrow functions", function(done) {
 	define("name", ["./circular"], (circular) => {
-		circular.should.be.eql(1);
+		expect(circular).toBe(1);
 		done();
 	});
 });
@@ -63,14 +63,14 @@ it("should be able to use require.js-style define, optional dependancies, not ex
 
 it("should be able to use require.js-style define, special string, with arrow function", function(done) {
 	define(["require"], (require) => {
-		require("./circular").should.be.eql(1);
+		expect(require("./circular")).toBe(1);
 		done();
 	});
 });
 
 it("should be able to use require.js-style define, without name, with arrow function", function(done) {
 	true && define(["./circular"], (circular) => {
-		circular.should.be.eql(1);
+		expect(circular).toBe(1);
 		done();
 	});
 });
@@ -91,17 +91,17 @@ it("should offer AMD-style define for CommonJs with arrow function", function(do
 	var _test_exports = exports;
 	var _test_module = module;
 	define((require, exports, module) => {
-		(typeof require).should.be.eql("function");
+		expect((typeof require)).toBe("function");
 		exports.should.be.equal(_test_exports);
 		module.should.be.equal(_test_module);
-		require("./circular").should.be.eql(1);
+		expect(require("./circular")).toBe(1);
 		done();
 	});
 });
 
 it("should pull in all dependencies of an AMD module with arrow function", function(done) {
 	define((require) => {
-		require("./amdmodule").should.be.eql("a");
+		expect(require("./amdmodule")).toBe("a");
 		done();
 	});
 });
@@ -109,9 +109,9 @@ it("should pull in all dependencies of an AMD module with arrow function", funct
 it("should create a chunk for require.js require, with arrow function", function(done) {
 	var sameTick = true;
 	require(["./c"], (c) => {
-		sameTick.should.be.eql(false);
-		c.should.be.eql("c");
-		require("./d").should.be.eql("d");
+		expect(sameTick).toBe(false);
+		expect(c).toBe("c");
+		expect(require("./d")).toBe("d");
 		done();
 	});
 	sameTick = false;

--- a/test/cases/parsing/extract-amd.nominimize/index.js
+++ b/test/cases/parsing/extract-amd.nominimize/index.js
@@ -1,5 +1,3 @@
-var should = require("should");
-
 it("should parse fancy function calls with arrow functions", function() {
 	("function"==typeof define && define.amd ?
 		define :
@@ -7,14 +5,14 @@ it("should parse fancy function calls with arrow functions", function() {
 	)(["./constructor"], (c) => {
 		return new c(1324);
 	});
-	module.exports.should.have.property("value").be.eql(1324);
+	expect(module.exports).to.have.property("value").toEqual(1324);
 	(("function"==typeof define && define.amd ?
 		define :
 		(e,t) => {return t()}
 	)(["./constructor"], (c) => {
 		return new c(4231);
 	}));
-	module.exports.should.have.property("value").be.eql(4231);
+	expect(module.exports).to.have.property("value").toEqual(4231);
 });
 
 it("should parse fancy AMD calls with arrow functions", function() {
@@ -56,7 +54,7 @@ it("should be able to use require.js-style define with arrow functions", functio
 
 it("should be able to use require.js-style define, optional dependancies, not exist, with arrow function", function(done) {
 	define("name", ["./optional"], (optional) => {
-		should(optional.b).not.exist;
+		expect(optional.b).toBeFalsy();
 		done();
 	});
 });
@@ -92,8 +90,8 @@ it("should offer AMD-style define for CommonJs with arrow function", function(do
 	var _test_module = module;
 	define((require, exports, module) => {
 		expect((typeof require)).toBe("function");
-		exports.should.be.equal(_test_exports);
-		module.should.be.equal(_test_module);
+		expect(exports).toBe(_test_exports);
+		expect(module).toBe(_test_module);
 		expect(require("./circular")).toBe(1);
 		done();
 	});

--- a/test/cases/parsing/extract-amd.nominimize/index.js
+++ b/test/cases/parsing/extract-amd.nominimize/index.js
@@ -5,14 +5,14 @@ it("should parse fancy function calls with arrow functions", function() {
 	)(["./constructor"], (c) => {
 		return new c(1324);
 	});
-	expect(module.exports).to.have.property("value").toEqual(1324);
+	expect(module.exports).toHaveProperty("value", 1324);
 	(("function"==typeof define && define.amd ?
 		define :
 		(e,t) => {return t()}
 	)(["./constructor"], (c) => {
 		return new c(4231);
 	}));
-	expect(module.exports).to.have.property("value").toEqual(4231);
+	expect(module.exports).toHaveProperty("value", 4231);
 });
 
 it("should parse fancy AMD calls with arrow functions", function() {

--- a/test/cases/parsing/extract-amd/index.js
+++ b/test/cases/parsing/extract-amd/index.js
@@ -1,5 +1,3 @@
-var should = require("should");
-
 it("should parse fancy function calls", function() {
 	("function"==typeof define && define.amd ?
 		define :
@@ -7,14 +5,14 @@ it("should parse fancy function calls", function() {
 	)(["./constructor"], function(c) {
 		return new c(1324);
 	});
-	module.exports.should.have.property("value").be.eql(1324);
+	expect(module.exports).to.have.property("value").toEqual(1324);
 	(("function"==typeof define && define.amd ?
 		define :
 		function(e,t){return t()}
 	)(["./constructor"], function(c) {
 		return new c(4231);
 	}));
-	module.exports.should.have.property("value").be.eql(4231);
+	expect(module.exports).to.have.property("value").toEqual(4231);
 });
 
 it("should parse fancy AMD calls", function() {
@@ -56,7 +54,7 @@ it("should be able to use require.js-style define", function(done) {
 
 it("should be able to use require.js-style define, optional dependancies, not exist", function(done) {
 	define("name", ["./optional"], function(optional) {
-		should(optional.b).not.exist;
+		expect(optional.b).toBeFalsy();
 		done();
 	});
 });
@@ -107,12 +105,12 @@ it("should be able to use require.js-style define, with an object", function() {
 
 	true && define("blaaa", obj);
 
-	module.exports.should.be.equal(obj);
+	expect(module.exports).toBe(obj);
 	module.exports = null;
 
 	define("blaaa", obj);
 
-	module.exports.should.be.equal(obj);
+	expect(module.exports).toBe(obj);
 	module.exports = null;
 });
 
@@ -121,8 +119,8 @@ it("should offer AMD-style define for CommonJs", function(done) {
 	var _test_module = module;
 	define(function(require, exports, module) {
 		expect((typeof require)).toBe("function");
-		exports.should.be.equal(_test_exports);
-		module.should.be.equal(_test_module);
+		expect(exports).toBe(_test_exports);
+		expect(module).toBe(_test_module);
 		expect(require("./circular")).toBe(1);
 		done();
 	});

--- a/test/cases/parsing/extract-amd/index.js
+++ b/test/cases/parsing/extract-amd/index.js
@@ -20,36 +20,36 @@ it("should parse fancy function calls", function() {
 it("should parse fancy AMD calls", function() {
 	require("./constructor ./a".split(" "));
 	require("-> module module exports *constructor *a".replace("module", "require").substr(3).replace(/\*/g, "./").split(" "), function(require, module, exports, constructor, a) {
-		(typeof require).should.be.eql("function");
-		(typeof module).should.be.eql("object");
-		(typeof exports).should.be.eql("object");
-		(typeof require("./constructor")).should.be.eql("function");
-		(typeof constructor).should.be.eql("function");
-		a.should.be.eql("a");
+		expect((typeof require)).toBe("function");
+		expect((typeof module)).toBe("object");
+		expect((typeof exports)).toBe("object");
+		expect((typeof require("./constructor"))).toBe("function");
+		expect((typeof constructor)).toBe("function");
+		expect(a).toBe("a");
 	});
 	define("-> module module exports *constructor *a".replace("module", "require").substr(3).replace(/\*/g, "./").split(" "), function(require, module, exports, constructor, a) {
-		(typeof require).should.be.eql("function");
-		(typeof module).should.be.eql("object");
-		(typeof exports).should.be.eql("object");
-		(typeof require("./constructor")).should.be.eql("function");
-		(typeof constructor).should.be.eql("function");
-		a.should.be.eql("a");
+		expect((typeof require)).toBe("function");
+		expect((typeof module)).toBe("object");
+		expect((typeof exports)).toBe("object");
+		expect((typeof require("./constructor"))).toBe("function");
+		expect((typeof constructor)).toBe("function");
+		expect(a).toBe("a");
 	});
 });
 
 it("should be able to use AMD-style require", function(done) {
 	var template = "b";
 	require(["./circular", "./templates/" + template, true ? "./circular" : "fail"], function(circular, testTemplate, circular2) {
-		circular.should.be.eql(1);
-		circular2.should.be.eql(1);
-		testTemplate.should.be.eql("b");
+		expect(circular).toBe(1);
+		expect(circular2).toBe(1);
+		expect(testTemplate).toBe("b");
 		done();
 	});
 });
 
 it("should be able to use require.js-style define", function(done) {
 	define("name", ["./circular"], function(circular) {
-		circular.should.be.eql(1);
+		expect(circular).toBe(1);
 		done();
 	});
 });
@@ -63,14 +63,14 @@ it("should be able to use require.js-style define, optional dependancies, not ex
 
 it("should be able to use require.js-style define, special string", function(done) {
 	define(["require"], function(require) {
-		require("./circular").should.be.eql(1);
+		expect(require("./circular")).toBe(1);
 		done();
 	});
 });
 
 it("should be able to use require.js-style define, without name", function(done) {
 	true && define(["./circular"], function(circular) {
-		circular.should.be.eql(1);
+		expect(circular).toBe(1);
 		done();
 	});
 });
@@ -120,10 +120,10 @@ it("should offer AMD-style define for CommonJs", function(done) {
 	var _test_exports = exports;
 	var _test_module = module;
 	define(function(require, exports, module) {
-		(typeof require).should.be.eql("function");
+		expect((typeof require)).toBe("function");
 		exports.should.be.equal(_test_exports);
 		module.should.be.equal(_test_module);
-		require("./circular").should.be.eql(1);
+		expect(require("./circular")).toBe(1);
 		done();
 	});
 });
@@ -140,7 +140,7 @@ it("should be able to use AMD require without function expression (empty array)"
 it("should be able to use AMD require without function expression", function(done) {
 	require(["./circular"], fn);
 	function fn(c) {
-		c.should.be.eql(1);
+		expect(c).toBe(1);
 		done();
 	}
 });
@@ -148,9 +148,9 @@ it("should be able to use AMD require without function expression", function(don
 it("should create a chunk for require.js require", function(done) {
 	var sameTick = true;
 	require(["./c"], function(c) {
-		sameTick.should.be.eql(false);
-		c.should.be.eql("c");
-		require("./d").should.be.eql("d");
+		expect(sameTick).toBe(false);
+		expect(c).toBe("c");
+		expect(require("./d")).toBe("d");
 		done();
 	});
 	sameTick = false;
@@ -170,34 +170,34 @@ it("should not fail #138", function(done) {
 
 it("should parse a bound function expression 1", function(done) {
 	define(function(a, require, exports, module) {
-		a.should.be.eql(123);
-		(typeof require).should.be.eql("function");
-		require("./a").should.be.eql("a");
+		expect(a).toBe(123);
+		expect((typeof require)).toBe("function");
+		expect(require("./a")).toBe("a");
 		done();
 	}.bind(null, 123));
 });
 
 it("should parse a bound function expression 2", function(done) {
 	define("name", function(a, require, exports, module) {
-		a.should.be.eql(123);
-		(typeof require).should.be.eql("function");
-		require("./a").should.be.eql("a");
+		expect(a).toBe(123);
+		expect((typeof require)).toBe("function");
+		expect(require("./a")).toBe("a");
 		done();
 	}.bind(null, 123));
 });
 
 it("should parse a bound function expression 3", function(done) {
 	define(["./a"], function(number, a) {
-		number.should.be.eql(123);
-		a.should.be.eql("a");
+		expect(number).toBe(123);
+		expect(a).toBe("a");
 		done();
 	}.bind(null, 123));
 });
 
 it("should parse a bound function expression 4", function(done) {
 	define("name", ["./a"], function(number, a) {
-		number.should.be.eql(123);
-		a.should.be.eql("a");
+		expect(number).toBe(123);
+		expect(a).toBe("a");
 		done();
 	}.bind(null, 123));
 });
@@ -205,21 +205,21 @@ it("should parse a bound function expression 4", function(done) {
 it("should not fail issue #138 second", function() {
 	(function(define, global) { 'use strict';
 		define(function (require) {
-			(typeof require).should.be.eql("function");
-			require("./a").should.be.eql("a");
+			expect((typeof require)).toBe("function");
+			expect(require("./a")).toBe("a");
 			return "#138 2.";
 		});
 	})(typeof define === 'function' && define.amd ? define : function (factory) { module.exports = factory(require); }, this);
-	module.exports.should.be.eql("#138 2.");
+	expect(module.exports).toBe("#138 2.");
 });
 
 it("should parse an define with empty array and object", function() {
 	var obj = {ok: 95476};
 	define([], obj);
-	module.exports.should.be.eql(obj);
+	expect(module.exports).toBe(obj);
 });
 it("should parse an define with object", function() {
 	var obj = {ok: 76243};
 	define(obj);
-	module.exports.should.be.eql(obj);
+	expect(module.exports).toBe(obj);
 });

--- a/test/cases/parsing/extract-amd/index.js
+++ b/test/cases/parsing/extract-amd/index.js
@@ -5,14 +5,14 @@ it("should parse fancy function calls", function() {
 	)(["./constructor"], function(c) {
 		return new c(1324);
 	});
-	expect(module.exports).to.have.property("value").toEqual(1324);
+	expect(module.exports).toHaveProperty("value", 1324);
 	(("function"==typeof define && define.amd ?
 		define :
 		function(e,t){return t()}
 	)(["./constructor"], function(c) {
 		return new c(4231);
 	}));
-	expect(module.exports).to.have.property("value").toEqual(4231);
+	expect(module.exports).toHaveProperty("value", 4231);
 });
 
 it("should parse fancy AMD calls", function() {

--- a/test/cases/parsing/extract-require/index.js
+++ b/test/cases/parsing/extract-require/index.js
@@ -1,13 +1,13 @@
 var should = require("should");
 
 function testCase(number) {
-	require(number === 1 ? "./folder/file1" : number === 2 ? "./folder/file2" : number === 3 ? "./folder/file3" : "./missingModule").should.be.eql("file" + number);
+	expect(require(number === 1 ? "./folder/file1" : number === 2 ? "./folder/file2" : number === 3 ? "./folder/file3" : "./missingModule")).toBe("file" + number);
 	require(
 		number === 1 ? "./folder/file1" :
 		number === 2 ? "./folder/file2" :
 		number === 3 ? "./folder/file3" :
 		"./missingModule"
-	).should.be.eql("file" + number);
+	expect()).toBe("file" + number);
 }
 
 it("should parse complex require calls", function() {
@@ -16,24 +16,24 @@ it("should parse complex require calls", function() {
 });
 
 it("should let the user hide the require function", function() {
-	(function(require) { return require; }(1234)).should.be.eql(1234);
+	(function(require) { return require; }expect((1234))).toBe(1234);
 	function testFunc(abc, require) {
 		return require;
 	}
-	testFunc(333, 678).should.be.eql(678);
+	expect(testFunc(333, 678)).toBe(678);
 	(function() {
 		var require = 123;
-		require.should.be.eql(123);
+		expect(require).toBe(123);
 	}());
 	(function() {
 		function require() {
 			return 123;
 		};
-		require("error").should.be.eql(123);
+		expect(require("error")).toBe(123);
 	}());
 	(function() {
 		var module = 1233;
-		module.should.be.eql(1233);
+		expect(module).toBe(1233);
 	}());
 });
 

--- a/test/cases/parsing/extract-require/index.js
+++ b/test/cases/parsing/extract-require/index.js
@@ -1,22 +1,22 @@
-var should = require("should");
-
 function testCase(number) {
 	expect(require(number === 1 ? "./folder/file1" : number === 2 ? "./folder/file2" : number === 3 ? "./folder/file3" : "./missingModule")).toBe("file" + number);
-	require(
+	expect(require(
 		number === 1 ? "./folder/file1" :
 		number === 2 ? "./folder/file2" :
 		number === 3 ? "./folder/file3" :
 		"./missingModule"
-	expect()).toBe("file" + number);
+	)).toBe("file" + number);
 }
 
 it("should parse complex require calls", function() {
-	should.strictEqual(new(require("./constructor"))(1234).value, 1234, "Parse require in new(...) should work");
-	should.strictEqual(new ( require ( "./constructor" ) ) ( 1234 ) .value, 1234, "Parse require in new(...) should work, with spaces");
+	// "Parse require in new(...) should work"
+	expect(new(require("./constructor"))(1234).value).toBe(1234);
+	// "Parse require in new(...) should work, with spaces"
+	expect(new ( require ( "./constructor" ) ) ( 1234 ) .value).toBe(1234);
 });
 
 it("should let the user hide the require function", function() {
-	(function(require) { return require; }expect((1234))).toBe(1234);
+	expect((function(require) { return require; })(1234)).toBe(1234);
 	function testFunc(abc, require) {
 		return require;
 	}
@@ -42,3 +42,4 @@ it("should not create a context for the ?: operator", function() {
 	testCase(2);
 	testCase(3);
 });
+

--- a/test/cases/parsing/filename/index.js
+++ b/test/cases/parsing/filename/index.js
@@ -1,11 +1,11 @@
 it("should be a string (__filename)", function() {
-	__filename.should.be.type("string");
+	expect(__filename).toBeTypeOf("string");
 	var f = __filename;
-	f.should.be.type("string");
+	expect(f).toBeTypeOf("string");
 });
 
 it("should be a string (__dirname)", function() {
-	__dirname.should.be.type("string");
+	expect(__dirname).toBeTypeOf("string");
 	var d = __dirname;
-	d.should.be.type("string");
+	expect(d).toBeTypeOf("string");
 });

--- a/test/cases/parsing/harmony-commonjs-mix/index.js
+++ b/test/cases/parsing/harmony-commonjs-mix/index.js
@@ -1,4 +1,4 @@
 it("should result in a warning when using module.exports in harmony module", function() {
 	var x = require("./module1");
-	x.should.be.eql({default: 1234});
+	expect(x).toEqual({default: 1234});
 });

--- a/test/cases/parsing/harmony-commonjs-mix/module1.js
+++ b/test/cases/parsing/harmony-commonjs-mix/module1.js
@@ -1,15 +1,15 @@
 import "./module";
 
-(function() {
+expect(function() {
 	module.exports = 1;
-}).should.throw();
+}).toThrowError();
 
 expect((typeof module.exports)).toBe("undefined");
 
 expect((typeof define)).toBe("undefined");
-(function() {
+expect(function() {
 	define(function() {})
-}).should.throw(/define is not defined/);
+}).toThrowError(/define is not defined/);
 
 export default 1234;
 

--- a/test/cases/parsing/harmony-commonjs-mix/module1.js
+++ b/test/cases/parsing/harmony-commonjs-mix/module1.js
@@ -4,9 +4,9 @@ import "./module";
 	module.exports = 1;
 }).should.throw();
 
-(typeof module.exports).should.be.eql("undefined");
+expect((typeof module.exports)).toBe("undefined");
 
-(typeof define).should.be.eql("undefined");
+expect((typeof define)).toBe("undefined");
 (function() {
 	define(function() {})
 }).should.throw(/define is not defined/);
@@ -15,5 +15,5 @@ export default 1234;
 
 if(eval("typeof exports !== \"undefined\"")) {
 	// exports is node.js exports and not webpacks
-	Object.keys(exports).should.be.eql([]);
+	expect(Object.keys(exports)).toEqual([]);
 }

--- a/test/cases/parsing/harmony-commonjs/index.js
+++ b/test/cases/parsing/harmony-commonjs/index.js
@@ -2,7 +2,7 @@ import { x, y } from "./b";
 
 it("should pass when required by CommonJS module", function () {
 	var test1 = require('./a').default;
-	test1().should.be.eql("OK");
+	expect(test1()).toBe("OK");
 });
 
 it("should pass when use babeljs transpiler", function() {
@@ -13,18 +13,18 @@ it("should pass when use babeljs transpiler", function() {
 	var _test2 = _interopRequireDefault(_test);
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 	var test2 = (0, _test2.default)();
-	test2.should.be.eql("OK");
+	expect(test2).toBe("OK");
 });
 
 it("should double reexport from non-harmony modules correctly", function() {
-	y.should.be.eql("y");
-	x.should.be.eql("x");
+	expect(y).toBe("y");
+	expect(x).toBe("x");
 });
 
 
 import { a, b } from "./reexport"
 
 it("should be possible to reexport a module with unknown exports", function() {
-	a.should.be.eql("a");
-	b.should.be.eql("b");
+	expect(a).toBe("a");
+	expect(b).toBe("b");
 });

--- a/test/cases/parsing/harmony-duplicate-export/index.js
+++ b/test/cases/parsing/harmony-duplicate-export/index.js
@@ -15,21 +15,21 @@ var y6 = require("./6?b").x;
 var y7 = require("./7?b").x;
 
 it("should not overwrite when using star export (known exports)", function() {
-	x1.should.be.eql("1");
-	x2.should.be.eql("1");
-	x3.should.be.eql("a");
-	x4.should.be.eql("b");
-	x5.should.be.eql("c");
-	x6.should.be.eql("a");
-	x7.should.be.eql("d");
+	expect(x1).toBe("1");
+	expect(x2).toBe("1");
+	expect(x3).toBe("a");
+	expect(x4).toBe("b");
+	expect(x5).toBe("c");
+	expect(x6).toBe("a");
+	expect(x7).toBe("d");
 });
 
 it("should not overwrite when using star export (unknown exports)", function() {
-	y1.should.be.eql("1");
-	y2.should.be.eql("1");
-	y3.should.be.eql("a");
-	y4.should.be.eql("b");
-	y5.should.be.eql("c");
-	y6.should.be.eql("a");
-	y7.should.be.eql("d");
+	expect(y1).toBe("1");
+	expect(y2).toBe("1");
+	expect(y3).toBe("a");
+	expect(y4).toBe("b");
+	expect(y5).toBe("c");
+	expect(y6).toBe("a");
+	expect(y7).toBe("d");
 });

--- a/test/cases/parsing/harmony-edge-cases/index.js
+++ b/test/cases/parsing/harmony-edge-cases/index.js
@@ -3,9 +3,9 @@ import x, { b } from "./b";
 import { c, d } from "./fake-reexport";
 
 it("should be able to use exported function", function() {
-	a.should.be.eql("ok");
-	b.should.be.eql("ok");
-	x().should.be.eql("ok");
-	c.should.be.eql("ok");
-	d.should.be.eql("ok");
+	expect(a).toBe("ok");
+	expect(b).toBe("ok");
+	expect(x()).toBe("ok");
+	expect(c).toBe("ok");
+	expect(d).toBe("ok");
 });

--- a/test/cases/parsing/harmony-export-hoist/index.js
+++ b/test/cases/parsing/harmony-export-hoist/index.js
@@ -2,8 +2,8 @@
 
 it("should hoist exports", function() {
 	var result = require("./foo").default;
-	(typeof result.foo).should.have.eql("function");
-	(typeof result.foo2).should.have.eql("function");
+	expect(typeof result.foo).toEqual("function");
+	expect(typeof result.foo2).toEqual("function");
 	expect(result.foo()).toBe("ok");
 	expect(result.foo2()).toBe("ok");
 });

--- a/test/cases/parsing/harmony-export-hoist/index.js
+++ b/test/cases/parsing/harmony-export-hoist/index.js
@@ -4,6 +4,6 @@ it("should hoist exports", function() {
 	var result = require("./foo").default;
 	(typeof result.foo).should.have.eql("function");
 	(typeof result.foo2).should.have.eql("function");
-	result.foo().should.be.eql("ok");
-	result.foo2().should.be.eql("ok");
+	expect(result.foo()).toBe("ok");
+	expect(result.foo2()).toBe("ok");
 });

--- a/test/cases/parsing/harmony-export-precedence/index.js
+++ b/test/cases/parsing/harmony-export-precedence/index.js
@@ -3,19 +3,19 @@ import { a, b, c, d, e } from "./a";
 import defaultImport from "./a";
 
 it("should prefer local exports", function() {
-	a().should.be.eql("a1");
-	e.should.be.eql("e1");
+	expect(a()).toBe("a1");
+	expect(e).toBe("e1");
 });
 
 it("should prefer indirect exports over star exports", function() {
-	b.should.be.eql("b2");
-	d.should.be.eql("d2");
+	expect(b).toBe("b2");
+	expect(d).toBe("d2");
 });
 
 it("should use star exports", function() {
-	c.should.be.eql("c3");
+	expect(c).toBe("c3");
 });
 
 it("should not export default via star export", function() {
-	(typeof defaultImport).should.be.eql("undefined");
+	expect((typeof defaultImport)).toBe("undefined");
 });

--- a/test/cases/parsing/harmony-import-export-order/index.js
+++ b/test/cases/parsing/harmony-import-export-order/index.js
@@ -3,8 +3,8 @@ it("should process imports of star exports in the correct order", function() {
 	tracker.list.length = 0;
 	delete require.cache[require.resolve("./c")];
 	var c = require("./c");
-	tracker.list.should.be.eql(["a", "b", "c"]);
-	c.ax.should.be.eql("ax");
-	c.bx.should.be.eql("ax");
-	c.cx.should.be.eql("ax");
+	expect(tracker.list).toEqual(["a", "b", "c"]);
+	expect(c.ax).toBe("ax");
+	expect(c.bx).toBe("ax");
+	expect(c.cx).toBe("ax");
 });

--- a/test/cases/parsing/harmony-import-targets/index.js
+++ b/test/cases/parsing/harmony-import-targets/index.js
@@ -1,9 +1,9 @@
 import {x, f} from "./x";
 
 it("should import into object literal", function() {
-	({ x: x }).should.be.eql({x: 1});
+	({ x: x }expect()).toEqual({x: 1});
 	var obj = { x: x };
-	obj.should.be.eql({x: 1});
+	expect(obj).toEqual({x: 1});
 });
 
 function func(z) {
@@ -11,21 +11,21 @@ function func(z) {
 }
 
 it("should import into function argument", function() {
-	func(x).should.be.eql(1);
-	f(x).should.be.eql(1);
-	func({x:x}).should.be.eql({x:1});
-	f({x:x}).should.be.eql({x:1});
+	expect(func(x)).toBe(1);
+	expect(f(x)).toBe(1);
+	func({x:x}expect()).toEqual({x:1});
+	f({x:x}expect()).toEqual({x:1});
 	var y = f(x);
-	y.should.be.eql(1);
+	expect(y).toBe(1);
 	y = function() {
 		return x;
 	};
-	y().should.be.eql(1);
+	expect(y()).toBe(1);
 });
 
 it("should import into array literal", function() {
-	([x, f(2)]).should.be.eql([1, 2]);
+	expect(([x, f(2)])).toEqual([1, 2]);
 	([{
 		value: x
-	}]).should.be.eql([{ value: x }]);
+	}expect(])).toEqual([{ value: x }]);
 });

--- a/test/cases/parsing/harmony-injecting-order/index.js
+++ b/test/cases/parsing/harmony-injecting-order/index.js
@@ -1,3 +1,3 @@
 it("should inject variables before exporting", function() {
-	require("./file").f().should.be.eql({});
+	expect(require("./file").f()).toEqual({});
 });

--- a/test/cases/parsing/harmony-spec/index.js
+++ b/test/cases/parsing/harmony-spec/index.js
@@ -6,33 +6,33 @@ import cycleValue from "./export-cycle-a";
 import { data } from "./self-cycle";
 
 it("should establish live binding of values", function() {
-	value.should.be.eql(0);
+	expect(value).toBe(0);
 	add(2);
-	value.should.be.eql(2);
+	expect(value).toBe(2);
 });
 
 it("should establish live binding of values with transpiled es5 module", function() {
-	value2.should.be.eql(0);
+	expect(value2).toBe(0);
 	add2(5);
-	value2.should.be.eql(5);
+	expect(value2).toBe(5);
 });
 
 it("should allow to use eval with exports", function() {
-	valueEval.should.be.eql(0);
+	expect(valueEval).toBe(0);
 	evalInModule("value = 5");
-	valueEval.should.be.eql(5);
+	expect(valueEval).toBe(5);
 });
 
 it("should execute modules in the correct order", function() {
-	getLog().should.be.eql(["a", "b", "c"]);
+	expect(getLog()).toEqual(["a", "b", "c"]);
 });
 
 it("should bind exports before the module executes", function() {
-	cycleValue.should.be.eql(true);
+	expect(cycleValue).toBe(true);
 });
 
 it("should allow to import live variables from itself", function() {
-	data.should.be.eql([undefined, 1, 2]);
+	expect(data).toEqual([undefined, 1, 2]);
 });
 
 import { value as valueEval, evalInModule } from "./eval";

--- a/test/cases/parsing/harmony-tdz/index.js
+++ b/test/cases/parsing/harmony-tdz/index.js
@@ -2,7 +2,7 @@ import value, { exception } from "./module";
 
 it("should have a TDZ for exported const values", function() {
 	expect((typeof exception)).toBe("object");
-	exception.should.be.instanceof(Error);
-	exception.message.should.match(/ is not defined$/);
+	expect(exception).toBeInstanceOf(Error);
+	expect(exception.message).toMatch(/ is not defined$/);
 	expect(value).toBe("value");
 });

--- a/test/cases/parsing/harmony-tdz/index.js
+++ b/test/cases/parsing/harmony-tdz/index.js
@@ -1,8 +1,8 @@
 import value, { exception } from "./module";
 
 it("should have a TDZ for exported const values", function() {
-	(typeof exception).should.be.eql("object");
+	expect((typeof exception)).toBe("object");
 	exception.should.be.instanceof(Error);
 	exception.message.should.match(/ is not defined$/);
-	value.should.be.eql("value");
+	expect(value).toBe("value");
 });

--- a/test/cases/parsing/harmony-this/index.js
+++ b/test/cases/parsing/harmony-this/index.js
@@ -20,9 +20,9 @@ import * as New from "./new";
 
 it("should be possible to use new correctly", function() {
 	x
-	new C().should.match({ok: true});
+	expect(new C()).toMatch({ok: true});
 	x
-	new C2().should.match({ok: true});
+	expect(new C2()).toMatch({ok: true});
 	x
-	new New.C().should.match({ok: true});
+	expect(new New.C()).toMatch({ok: true});
 });

--- a/test/cases/parsing/harmony-this/index.js
+++ b/test/cases/parsing/harmony-this/index.js
@@ -7,11 +7,11 @@ import * as abc from "./abc";
 function x() { throw new Error("should not be executed"); }
 it("should have this = undefined on imported non-strict functions", function() {
 	x
-	d().should.be.eql("undefined");
+	expect(d()).toBe("undefined");
 	x
-	a().should.be.eql("undefined");
+	expect(a()).toBe("undefined");
 	x
-	B().should.be.eql("undefined");
+	expect(B()).toBe("undefined");
 });
 
 import C2, { C } from "./new";

--- a/test/cases/parsing/harmony-this/index.js
+++ b/test/cases/parsing/harmony-this/index.js
@@ -20,9 +20,9 @@ import * as New from "./new";
 
 it("should be possible to use new correctly", function() {
 	x
-	expect(new C()).toMatch({ok: true});
+	expect(new C()).toEqual({ok: true});
 	x
-	expect(new C2()).toMatch({ok: true});
+	expect(new C2()).toEqual({ok: true});
 	x
-	expect(new New.C()).toMatch({ok: true});
+	expect(new New.C()).toEqual({ok: true});
 });

--- a/test/cases/parsing/harmony/index.js
+++ b/test/cases/parsing/harmony/index.js
@@ -26,62 +26,62 @@ import "unused";
 
 
 it("should import a default export from a module", function() {
-	defaultExport.should.be.eql("def");
+	expect(defaultExport).toBe("def");
 });
 
 it("should import an identifier from a module", function() {
-	a.should.be.eql("a");
-	B.should.be.eql("b");
+	expect(a).toBe("a");
+	expect(B).toBe("b");
 });
 
 it("should import a whole module", function() {
-	abc.a.should.be.eql("a");
-	abc.b.should.be.eql("b");
-	abc.c.should.be.eql("c");
-	abc.d.c.should.be.eql("c");
-	abc.e.should.be.eql("c");
+	expect(abc.a).toBe("a");
+	expect(abc.b).toBe("b");
+	expect(abc.c).toBe("c");
+	expect(abc.d.c).toBe("c");
+	expect(abc.e).toBe("c");
 	var copy = (function(a) { return a; }(abc));
-	copy.a.should.be.eql("a");
-	copy.b.should.be.eql("b");
-	copy.c.should.be.eql("c");
-	copy.d.c.should.be.eql("c");
-	copy.e.should.be.eql("c");
-	(typeof abc).should.be.eql("object");
+	expect(copy.a).toBe("a");
+	expect(copy.b).toBe("b");
+	expect(copy.c).toBe("c");
+	expect(copy.d.c).toBe("c");
+	expect(copy.e).toBe("c");
+	expect((typeof abc)).toBe("object");
 });
 
 it("should export functions", function() {
 	fn.should.have.type("function");
-	fn().should.be.eql("fn");
-	(fn === fn).should.be.eql(true);
+	expect(fn()).toBe("fn");
+	expect((fn === fn)).toBe(true);
 });
 
 it("should multiple variables with one statement", function() {
-	one.should.be.eql("one");
-	two.should.be.eql("two");
+	expect(one).toBe("one");
+	expect(two).toBe("two");
 });
 
 it("should still be able to use exported stuff", function() {
-	test1.should.be.eql("fn");
-	test2.should.be.eql("two");
+	expect(test1).toBe("fn");
+	expect(test2).toBe("two");
 });
 
 it("should reexport a module", function() {
-	rea.should.be.eql("a");
-	reb.should.be.eql("b");
-	rec.should.be.eql("c");
-	reo.should.be.eql("one");
-	retwo.should.be.eql("two");
-	rea2.should.be.eql("a");
+	expect(rea).toBe("a");
+	expect(reb).toBe("b");
+	expect(rec).toBe("c");
+	expect(reo).toBe("one");
+	expect(retwo).toBe("two");
+	expect(rea2).toBe("a");
 });
 
 it("should support circular dependencies", function() {
-	threeIsOdd.should.be.eql(true);
-	even(4).should.be.eql(true);
+	expect(threeIsOdd).toBe(true);
+	expect(even(4)).toBe(true);
 });
 
 it("should support export specifier", function() {
-	specA.should.be.eql(1);
-	specB.should.be.eql(2);
+	expect(specA).toBe(1);
+	expect(specB).toBe(2);
 });
 
 it("should be able to import commonjs", function() {
@@ -90,25 +90,25 @@ it("should be able to import commonjs", function() {
 	x
 	Thing.should.have.type("function");
 	x
-	Thing().should.be.eql("thing");
+	expect(Thing()).toBe("thing");
 	x
-	Other.should.be.eql("other");
+	expect(Other).toBe("other");
 
 	Thing2.should.have.type("function");
-	new Thing2().value.should.be.eql("thing");
-	Other2.should.be.eql("other");
-	Thing3().should.be.eql("thing");
+	expect(new Thing2().value).toBe("thing");
+	expect(Other2).toBe("other");
+	expect(Thing3()).toBe("thing");
 });
 
 it("should be able to import commonjs with star import", function() {
 	var copyOfCommonjs = commonjs;
-	commonjs().should.be.eql("thing");
-	commonjs.Other.should.be.eql("other");
-	copyOfCommonjs().should.be.eql("thing");
-	copyOfCommonjs.Other.should.be.eql("other");
+	expect(commonjs()).toBe("thing");
+	expect(commonjs.Other).toBe("other");
+	expect(copyOfCommonjs()).toBe("thing");
+	expect(copyOfCommonjs.Other).toBe("other");
 	var copyOfCommonjsTrans = commonjsTrans;
-	new commonjsTrans.default().value.should.be.eql("thing");
-	commonjsTrans.Other.should.be.eql("other");
-	new copyOfCommonjsTrans.default().value.should.be.eql("thing");
-	copyOfCommonjsTrans.Other.should.be.eql("other");
+	expect(new commonjsTrans.default().value).toBe("thing");
+	expect(commonjsTrans.Other).toBe("other");
+	expect(new copyOfCommonjsTrans.default().value).toBe("thing");
+	expect(copyOfCommonjsTrans.Other).toBe("other");
 });

--- a/test/cases/parsing/harmony/index.js
+++ b/test/cases/parsing/harmony/index.js
@@ -50,7 +50,7 @@ it("should import a whole module", function() {
 });
 
 it("should export functions", function() {
-	fn.should.have.type("function");
+	expect(fn).toBeTypeOf("function");
 	expect(fn()).toBe("fn");
 	expect((fn === fn)).toBe(true);
 });
@@ -88,13 +88,13 @@ it("should be able to import commonjs", function() {
 	function x() { throw new Error("should not be executed"); }
 	// next line doesn't end with semicolon
 	x
-	Thing.should.have.type("function");
+	expect(Thing).toBeTypeOf("function");
 	x
 	expect(Thing()).toBe("thing");
 	x
 	expect(Other).toBe("other");
 
-	Thing2.should.have.type("function");
+	expect(Thing2).toBeTypeOf("function");
 	expect(new Thing2().value).toBe("thing");
 	expect(Other2).toBe("other");
 	expect(Thing3()).toBe("thing");

--- a/test/cases/parsing/hot-hash/index.js
+++ b/test/cases/parsing/hot-hash/index.js
@@ -1,7 +1,7 @@
 if(module.hot) {
 	it("should have __webpack_hash__", function() {
-		(typeof __webpack_hash__).should.be.type("string");
-		__webpack_hash__.should.match(/^[0-9a-f]{20}$/);
+		expect(typeof __webpack_hash__).toBeTypeOf("string");
+		expect(__webpack_hash__).toMatch(/^[0-9a-f]{20}$/);
 	});
 } else {
 	it("should have __webpack_hash__ (disabled)", function() {

--- a/test/cases/parsing/inject-free-vars/index.js
+++ b/test/cases/parsing/inject-free-vars/index.js
@@ -1,18 +1,18 @@
 it("should inject the module object into a chunk (AMD1)", function(done) {
 	require([], function() {
-		module.webpackPolyfill.should.be.eql(1);
+		expect(module.webpackPolyfill).toBe(1);
 		done();
 	});
 });
 
 it("should inject the module object into a chunk (AMD2)", function() {
 	require([module.webpackPolyfill ? "./x1" : "./fail"]);
-	module.webpackPolyfill.should.be.eql(1);
+	expect(module.webpackPolyfill).toBe(1);
 });
 
 it("should inject the module object into a chunk (ensure)", function(done) {
 	require.ensure([], function(require) {
-		module.webpackPolyfill.should.be.eql(1);
+		expect(module.webpackPolyfill).toBe(1);
 		done();
 	});
 });

--- a/test/cases/parsing/issue-1600/index.js
+++ b/test/cases/parsing/issue-1600/index.js
@@ -1,5 +1,5 @@
 import fn from './file';
 
 it("should compile correctly", function() {
-	fn().should.be.eql(1);
+	expect(fn()).toBe(1);
 });

--- a/test/cases/parsing/issue-2019/index.js
+++ b/test/cases/parsing/issue-2019/index.js
@@ -1,4 +1,4 @@
 it("should not fail on default export before export", function() {
-	require("./file").default.should.be.eql("default");
-	require("./file").CONSTANT.should.be.eql("const");
+	expect(require("./file").default).toBe("default");
+	expect(require("./file").CONSTANT).toBe("const");
 });

--- a/test/cases/parsing/issue-2050/index.js
+++ b/test/cases/parsing/issue-2050/index.js
@@ -1,5 +1,5 @@
 it("should support multiple reexports", function() {
-	require("./x").should.be.eql({
+	expect(require("./x")).toEqual({
 		xa: "a",
 		xb: "b",
 		xc: "c",

--- a/test/cases/parsing/issue-2084/index.js
+++ b/test/cases/parsing/issue-2084/index.js
@@ -7,8 +7,8 @@ it("should bind this context on require callback", function(done) {
 	runWithThis({ok: true}, function() {
 		require([], function() {
 			try {
-				require("./file").should.be.eql("file");
-				this.should.be.eql({ok: true});
+				expect(require("./file")).toBe("file");
+				expect(this).toEqual({ok: true});
 				done();
 			} catch(e) { done(e); }
 		}.bind(this));
@@ -19,9 +19,9 @@ it("should bind this context on require callback (loaded)", function(done) {
 	runWithThis({ok: true}, function() {
 		require(["./load.js"], function(load) {
 			try {
-				require("./file").should.be.eql("file");
-				load.should.be.eql("load");
-				this.should.be.eql({ok: true});
+				expect(require("./file")).toBe("file");
+				expect(load).toBe("load");
+				expect(this).toEqual({ok: true});
 				done();
 			} catch(e) { done(e); }
 		}.bind(this));
@@ -32,8 +32,8 @@ it("should bind this context on require callback (foo)", function(done) {
 	var foo = {ok: true};
 	require([], function(load) {
 		try {
-			require("./file").should.be.eql("file");
-			this.should.be.eql({ok: true});
+			expect(require("./file")).toBe("file");
+			expect(this).toEqual({ok: true});
 			done();
 		} catch(e) { done(e); }
 	}.bind(foo));
@@ -43,9 +43,9 @@ it("should bind this context on require callback (foo, loaded)", function(done) 
 	var foo = {ok: true};
 	require(["./load.js"], function(load) {
 		try {
-			require("./file").should.be.eql("file");
-			load.should.be.eql("load");
-			this.should.be.eql({ok: true});
+			expect(require("./file")).toBe("file");
+			expect(load).toBe("load");
+			expect(this).toEqual({ok: true});
 			done();
 		} catch(e) { done(e); }
 	}.bind(foo));
@@ -55,8 +55,8 @@ it("should bind this context on require callback (foo)", function(done) {
 	runWithThis({ok: true}, function() {
 		require([], function(load) {
 			try {
-				require("./file").should.be.eql("file");
-				this.should.be.eql({ok: {ok: true}});
+				expect(require("./file")).toBe("file");
+				expect(this).toEqual({ok: {ok: true}});
 				done();
 			} catch(e) { done(e); }
 		}.bind({ok: this}));
@@ -67,8 +67,8 @@ it("should bind this context on require.ensure callback", function(done) {
 	runWithThis({ok: true}, function() {
 		require.ensure([], function(require) {
 			try {
-				require("./file").should.be.eql("file");
-				this.should.be.eql({ok: true});
+				expect(require("./file")).toBe("file");
+				expect(this).toEqual({ok: true});
 				done();
 			} catch(e) { done(e); }
 		}.bind(this));
@@ -79,8 +79,8 @@ it("should bind this context on require.ensure callback (loaded)", function(done
 	runWithThis({ok: true}, function() {
 		require.ensure(["./load.js"], function(require) {
 			try {
-				require("./file").should.be.eql("file");
-				this.should.be.eql({ok: true});
+				expect(require("./file")).toBe("file");
+				expect(this).toEqual({ok: true});
 				done();
 			} catch(e) { done(e); }
 		}.bind(this));

--- a/test/cases/parsing/issue-2349/index.js
+++ b/test/cases/parsing/issue-2349/index.js
@@ -1,5 +1,5 @@
 import {x} from './a' // named imported cases an errors
 
 it("should be able to import a named export", function() {
-	x.should.be.eql(1);
+	expect(x).toBe(1);
 });

--- a/test/cases/parsing/issue-2522/index.js
+++ b/test/cases/parsing/issue-2522/index.js
@@ -9,7 +9,7 @@ it("should import into object shorthand", function() {
 		b,
 		c
 	};
-	o.should.be.eql({
+	expect(o).toEqual({
 		a: 123,
 		aa: 123,
 		b: 456,

--- a/test/cases/parsing/issue-2523/index.js
+++ b/test/cases/parsing/issue-2523/index.js
@@ -3,7 +3,7 @@ import { B } from "./module";
 import { c } from "./module";
 
 it("should allow to export a class", function() {
-	(typeof A).should.be.eql("function");
-	(typeof B).should.be.eql("function");
-	c.should.be.eql("c");
+	expect((typeof A)).toBe("function");
+	expect((typeof B)).toBe("function");
+	expect(c).toBe("c");
 })

--- a/test/cases/parsing/issue-2528/index.js
+++ b/test/cases/parsing/issue-2528/index.js
@@ -51,7 +51,7 @@ import { count } from "./module";
 it("should run async functions", function() {
 	var org = count;
 	notExportedAsync();
-	count.should.be.eql(org + 1);
+	expect(count).toBe(org + 1);
 	exportedAsync();
-	count.should.be.eql(org + 2);
+	expect(count).toBe(org + 2);
 });

--- a/test/cases/parsing/issue-2570/index.js
+++ b/test/cases/parsing/issue-2570/index.js
@@ -6,8 +6,8 @@ it("should generate valid code when calling a harmony import function with brack
 	var c = fn((3), (4));
 	var d = fn(5, (6));
 
-	a.should.be.eql([1]);
-	b.should.be.eql([2]);
-	c.should.be.eql([3, 4]);
-	d.should.be.eql([5, 6]);
+	expect(a).toEqual([1]);
+	expect(b).toEqual([2]);
+	expect(c).toEqual([3, 4]);
+	expect(d).toEqual([5, 6]);
 });

--- a/test/cases/parsing/issue-2618/index.js
+++ b/test/cases/parsing/issue-2618/index.js
@@ -1,9 +1,9 @@
 import defaultValue, { value, value2, value3, value4 } from "./module";
 
 it("should be possible to redefine Object in a module", function() {
-	value.should.be.eql(123);
-	value2.should.be.eql(123);
-	value3.should.be.eql(123);
-	value4.should.be.eql(123);
-	defaultValue.should.be.eql(123);
+	expect(value).toBe(123);
+	expect(value2).toBe(123);
+	expect(value3).toBe(123);
+	expect(value4).toBe(123);
+	expect(defaultValue).toBe(123);
 });

--- a/test/cases/parsing/issue-2622/index.js
+++ b/test/cases/parsing/issue-2622/index.js
@@ -9,8 +9,8 @@ var func2 = function(x = a, y = b) {
 }
 
 it("should import into default parameters", function() {
-	func().should.be.eql(["a", "b"]);
-	func2().should.be.eql(["a", "b"]);
-	func(1).should.be.eql([1, "b"]);
-	func2(2).should.be.eql([2, "b"]);
+	expect(func()).toEqual(["a", "b"]);
+	expect(func2()).toEqual(["a", "b"]);
+	expect(func(1)).toEqual([1, "b"]);
+	expect(func2(2)).toEqual([2, "b"]);
 });

--- a/test/cases/parsing/issue-2641/index.js
+++ b/test/cases/parsing/issue-2641/index.js
@@ -1,7 +1,7 @@
 it("should require existing module with supplied error callback", function(done) {
 	require(['./file'], function(file){
 		try {
-			file.should.be.eql("file");
+			expect(file).toBe("file");
 			done();
 		} catch(e) { done(e); }
 	}, function(error) { done(error); });
@@ -11,7 +11,7 @@ it("should call error callback on missing module", function(done) {
 	require(['./file', './missingModule'], function(file){}, function(error) {
 		try {
 			error.should.be.instanceOf(Error);
-			error.message.should.be.eql('Cannot find module "./missingModule"');
+			expect(error.message).toBe('Cannot find module "./missingModule"');
 			done();
 		} catch(e) {
 			done(e);
@@ -24,7 +24,7 @@ it("should call error callback on missing module in context", function(done) {
 		require(['./' + module], function(file){}, function(error) {
 			try {
 				error.should.be.instanceOf(Error);
-				error.message.should.be.eql("Cannot find module \"./missingModule\".");
+				expect(error.message).toBe("Cannot find module \"./missingModule\".");
 				done();
 			} catch(e) { done(e); }
 		});
@@ -35,7 +35,7 @@ it("should call error callback on exception thrown in loading module", function(
 	require(['./throwing'], function(){}, function(error) {
 		try {
 			error.should.be.instanceOf(Error);
-			error.message.should.be.eql('message');
+			expect(error.message).toBe('message');
 			done();
 		} catch(e) { done(e); }
 	});
@@ -47,7 +47,7 @@ it("should not call error callback on exception thrown in require callback", fun
 	}, function(error) {
 		try {
 			error.should.be.instanceOf(Error);
-			error.message.should.be.eql('message');
+			expect(error.message).toBe('message');
 			done();
 		} catch(e) { done(e); }
 	});

--- a/test/cases/parsing/issue-2641/index.js
+++ b/test/cases/parsing/issue-2641/index.js
@@ -10,7 +10,7 @@ it("should require existing module with supplied error callback", function(done)
 it("should call error callback on missing module", function(done) {
 	require(['./file', './missingModule'], function(file){}, function(error) {
 		try {
-			error.should.be.instanceOf(Error);
+			expect(error).toBeInstanceOf(Error);
 			expect(error.message).toBe('Cannot find module "./missingModule"');
 			done();
 		} catch(e) {
@@ -23,7 +23,7 @@ it("should call error callback on missing module in context", function(done) {
 	(function(module) {
 		require(['./' + module], function(file){}, function(error) {
 			try {
-				error.should.be.instanceOf(Error);
+				expect(error).toBeInstanceOf(Error);
 				expect(error.message).toBe("Cannot find module \"./missingModule\".");
 				done();
 			} catch(e) { done(e); }
@@ -34,7 +34,7 @@ it("should call error callback on missing module in context", function(done) {
 it("should call error callback on exception thrown in loading module", function(done) {
 	require(['./throwing'], function(){}, function(error) {
 		try {
-			error.should.be.instanceOf(Error);
+			expect(error).toBeInstanceOf(Error);
 			expect(error.message).toBe('message');
 			done();
 		} catch(e) { done(e); }
@@ -46,7 +46,7 @@ it("should not call error callback on exception thrown in require callback", fun
 		throw new Error('message');
 	}, function(error) {
 		try {
-			error.should.be.instanceOf(Error);
+			expect(error).toBeInstanceOf(Error);
 			expect(error.message).toBe('message');
 			done();
 		} catch(e) { done(e); }

--- a/test/cases/parsing/issue-2895/index.js
+++ b/test/cases/parsing/issue-2895/index.js
@@ -1,6 +1,6 @@
 import { a, b } from "./a";
 
 it("should export a const value without semicolon", function() {
-	a.should.be.eql({x: 1});
-	b.should.be.eql({x: 2});
+	expect(a).toEqual({x: 1});
+	expect(b).toEqual({x: 2});
 });

--- a/test/cases/parsing/issue-2942/index.js
+++ b/test/cases/parsing/issue-2942/index.js
@@ -2,11 +2,11 @@ it("should polyfill System", function() {
 	if (typeof System === "object" && typeof System.register === "function") {
 		require("fail");
 	}
-	(typeof System).should.be.eql("object");
-	(typeof System.register).should.be.eql("undefined");
-	(typeof System.get).should.be.eql("undefined");
-	(typeof System.set).should.be.eql("undefined");
-	(typeof System.anyNewItem).should.be.eql("undefined");
+	expect((typeof System)).toBe("object");
+	expect((typeof System.register)).toBe("undefined");
+	expect((typeof System.get)).toBe("undefined");
+	expect((typeof System.set)).toBe("undefined");
+	expect((typeof System.anyNewItem)).toBe("undefined");
 	var x = System.anyNewItem;
-	(typeof x).should.be.eql("undefined");
+	expect((typeof x)).toBe("undefined");
 })

--- a/test/cases/parsing/issue-3116/index.js
+++ b/test/cases/parsing/issue-3116/index.js
@@ -2,12 +2,12 @@ import * as file from "./file";
 import * as file2 from "./file2";
 
 it("should translate indexed access to harmony import correctly", function() {
-	file["default"].should.be.eql("default");
-	file["abc"].should.be.eql("abc");
+	expect(file["default"]).toBe("default");
+	expect(file["abc"]).toBe("abc");
 });
 
 it("should translate dynamic indexed access to harmony import correctly", function() {
 	var fault = "fault";
-	file2["de" + fault].should.be.eql("default");
-	file2["abc"].should.be.eql("abc");
+	expect(file2["de" + fault]).toBe("default");
+	expect(file2["abc"]).toBe("abc");
 });

--- a/test/cases/parsing/issue-3238/index.js
+++ b/test/cases/parsing/issue-3238/index.js
@@ -1,4 +1,4 @@
 it("supports empty element in destructuring", function() {
   const second = ([, x]) => x;
-  second([1, 2]).should.eql(2);
+  expect(second([1, 2])).toEqual(2);
 });

--- a/test/cases/parsing/issue-3252/index.js
+++ b/test/cases/parsing/issue-3252/index.js
@@ -6,5 +6,5 @@ function fooBar({some, bar = E.V6Engine}) {
 }
 
 it("supports default argument assignment in import", function () {
-	fooBar({some:"test"}).should.eql('V6');
+	expect(fooBar({some:"test"})).toEqual('V6');
 });

--- a/test/cases/parsing/issue-3273/index.js
+++ b/test/cases/parsing/issue-3273/index.js
@@ -2,37 +2,37 @@ import { test } from "./file";
 
 it("should hide import by local var", function() {
 	var test = "ok";
-	test.should.be.eql("ok");
+	expect(test).toBe("ok");
 });
 
 it("should hide import by object pattern", function() {
 	var { test } = { test: "ok" };
-	test.should.be.eql("ok");
+	expect(test).toBe("ok");
 });
 
 it("should hide import by array pattern", function() {
 	var [test] = ["ok"];
-	test.should.be.eql("ok");
+	expect(test).toBe("ok");
 });
 
 it("should hide import by array pattern (nested)", function() {
 	var [[test]] = [["ok"]];
-	test.should.be.eql("ok");
+	expect(test).toBe("ok");
 });
 
 it("should hide import by pattern in function", function() {
 	(function({test}) {
-		test.should.be.eql("ok");
+		expect(test).toBe("ok");
 	}({ test: "ok" }));
 });
 
 it("should allow import in default (incorrect)", function() {
 	var { other = test, test } = { test: "ok" };
-	test.should.be.eql("ok");
-	(typeof other).should.be.eql("undefined");
+	expect(test).toBe("ok");
+	expect((typeof other)).toBe("undefined");
 });
 
 it("should allow import in default", function() {
 	var { other = test } = { test: "ok" };
-	other.should.be.eql("test");
+	expect(other).toBe("test");
 });

--- a/test/cases/parsing/issue-345/index.js
+++ b/test/cases/parsing/issue-345/index.js
@@ -1,7 +1,7 @@
 it("should parse multiple expressions in a require", function(done) {
 	var name = "abc";
 	require(["./" + name + "/" + name + "Test"], function(x) {
-		x.should.be.eql("ok");
+		expect(x).toBe("ok");
 		done();
 	});
 });

--- a/test/cases/parsing/issue-3769/index.js
+++ b/test/cases/parsing/issue-3769/index.js
@@ -1,3 +1,3 @@
 it("should generate valid code", function() {
-	require("./module").myTest.should.be.eql("test");
+	expect(require("./module").myTest).toBe("test");
 });

--- a/test/cases/parsing/issue-387/index.js
+++ b/test/cases/parsing/issue-387/index.js
@@ -10,7 +10,7 @@ it("should parse cujojs UMD modules", function() {
 			? define
 			: function (factory) { module.exports = factory(require); }
 	));
-	module.exports.should.be.eql(123);
+	expect(module.exports).toBe(123);
 });
 
 it("should parse cujojs UMD modules with deps", function() {
@@ -30,7 +30,7 @@ it("should parse cujojs UMD modules with deps", function() {
 				module.exports = factory.apply(null, deps);
 			}
 	));
-	module.exports.should.be.eql(1234);
+	expect(module.exports).toBe(1234);
 });
 
 it("should parse cujojs UMD modules with inlinded deps", function() {
@@ -45,5 +45,5 @@ it("should parse cujojs UMD modules with inlinded deps", function() {
 			? define
 			: function (factory) { module.exports = factory(require); }
 	));
-	module.exports.should.be.eql(4321);
+	expect(module.exports).toBe(4321);
 });

--- a/test/cases/parsing/issue-3917/index.js
+++ b/test/cases/parsing/issue-3917/index.js
@@ -8,7 +8,7 @@ it("should not find a free exports", function() {
 	if(typeof exports !== "undefined")
 		(x.default).should.be.equal(exports);
 	else
-		(x.default).should.be.eql(false);
+		expect((x.default)).toBe(false);
 });
 
 export {}

--- a/test/cases/parsing/issue-3917/index.js
+++ b/test/cases/parsing/issue-3917/index.js
@@ -1,12 +1,12 @@
 it("should be able to compile a module with UMD", function() {
 	var x = require("./module");
-	x.default.should.be.equal(global);
+	expect(x.default).toBe(global);
 });
 
 it("should not find a free exports", function() {
 	var x = require("./module2");
 	if(typeof exports !== "undefined")
-		(x.default).should.be.equal(exports);
+		expect(x.default).toBe(exports);
 	else
 		expect((x.default)).toBe(false);
 });

--- a/test/cases/parsing/issue-3964/index.js
+++ b/test/cases/parsing/issue-3964/index.js
@@ -1,4 +1,4 @@
 it("should be possible to export default an imported name", function() {
 	var x = require("./module");
-	x.should.be.eql({ default: 1234 });
+	expect(x).toEqual({ default: 1234 });
 });

--- a/test/cases/parsing/issue-4179/index.js
+++ b/test/cases/parsing/issue-4179/index.js
@@ -2,7 +2,7 @@ import def from "./module?harmony";
 import * as mod from "./module?harmony-start"
 
 it("should export a sequence expression correctly", function() {
-	require("./module?cjs").should.be.eql({ default: 2 });
-	def.should.be.eql(2);
-	mod.default.should.be.eql(2);
+	expect(require("./module?cjs")).toEqual({ default: 2 });
+	expect(def).toBe(2);
+	expect(mod.default).toBe(2);
 });

--- a/test/cases/parsing/issue-4357/index.js
+++ b/test/cases/parsing/issue-4357/index.js
@@ -5,7 +5,7 @@ it("should parse dynamic property names", function() {
 		[require("./a")]: "a",
 		[b]: "b"
 	};
-	o.should.be.eql({
+	expect(o).toEqual({
 		a: "a",
 		b: "b"
 	});
@@ -21,7 +21,7 @@ it("should match dynamic property names", function() {
 			[b]: cc
 		}
 	}]] = [0, 1, {b: {b: "c"}}];
-	aa.should.be.eql("a");
-	bb.should.be.eql("b");
-	cc.should.be.eql("c");
+	expect(aa).toBe("a");
+	expect(bb).toBe("b");
+	expect(cc).toBe("c");
 });

--- a/test/cases/parsing/issue-4596/index.js
+++ b/test/cases/parsing/issue-4596/index.js
@@ -3,11 +3,11 @@ it("should evaluate require.resolve as truthy value", function() {
 	if(require.resolve)
 		id = require.resolve("./module.js");
 
-	(typeof id).should.be.oneOf("number", "string");
+	expect(typeof id).to.be.oneOf("number", "string");
 });
 
 it("should evaluate require.resolve in ?: expression", function() {
 	var id = require.resolve ? require.resolve("./module.js") : null;
 
-	(typeof id).should.be.oneOf("number", "string");
+	expect(typeof id).to.be.oneOf("number", "string");
 });

--- a/test/cases/parsing/issue-4596/index.js
+++ b/test/cases/parsing/issue-4596/index.js
@@ -3,11 +3,11 @@ it("should evaluate require.resolve as truthy value", function() {
 	if(require.resolve)
 		id = require.resolve("./module.js");
 
-	expect(typeof id).to.be.oneOf("number", "string");
+	expect(typeof id === "number" || typeof id === "string").toBeTruthy();
 });
 
 it("should evaluate require.resolve in ?: expression", function() {
 	var id = require.resolve ? require.resolve("./module.js") : null;
 
-	expect(typeof id).to.be.oneOf("number", "string");
+	expect(typeof id === "number" || typeof id === "string").toBeTruthy();
 });

--- a/test/cases/parsing/issue-4608-1/index.js
+++ b/test/cases/parsing/issue-4608-1/index.js
@@ -1,5 +1,5 @@
 it("should find var declaration later in code", function() {
-	(typeof require).should.be.eql("undefined");
+	expect((typeof require)).toBe("undefined");
 
 	var require;
 });
@@ -10,7 +10,7 @@ it("should find var declaration in same statement", function() {
 	}), require;
 
 	require = (function(x) {
-		x.should.be.eql("fail");
+		expect(x).toBe("fail");
 	});
 	fn();
 });
@@ -18,7 +18,7 @@ it("should find var declaration in same statement", function() {
 it("should find a catch block declaration", function() {
 	try {
 		var f = (function(x) {
-			x.should.be.eql("fail");
+			expect(x).toBe("fail");
 		});
 		throw f;
 	} catch(require) {
@@ -28,7 +28,7 @@ it("should find a catch block declaration", function() {
 
 it("should find var declaration in control statements", function() {
 	var f = (function(x) {
-		x.should.be.eql("fail");
+		expect(x).toBe("fail");
 	});
 
 	(function() {
@@ -83,7 +83,7 @@ it("should find var declaration in control statements", function() {
 
 it("should find var declaration in control statements after usage", function() {
 	var f = (function(x) {
-		x.should.be.eql("fail");
+		expect(x).toBe("fail");
 	});
 
 	(function() {

--- a/test/cases/parsing/issue-4608-2/index.js
+++ b/test/cases/parsing/issue-4608-2/index.js
@@ -2,7 +2,7 @@
 
 it("should find var declaration in control statements", function() {
 	var f = (function(x) {
-		x.should.be.eql("fail");
+		expect(x).toBe("fail");
 	});
 
 	(function() {
@@ -16,7 +16,7 @@ it("should find var declaration in control statements", function() {
 
 it("should find var declaration in control statements after usage", function() {
 	var f = (function(x) {
-		x.should.be.eql("fail");
+		expect(x).toBe("fail");
 	});
 
 	(function() {

--- a/test/cases/parsing/issue-4870/index.js
+++ b/test/cases/parsing/issue-4870/index.js
@@ -3,11 +3,11 @@ import { test } from "./file";
 it("should allow import in array destructing", function() {
 	var other;
 	[other = test] = [];
-	other.should.be.eql("test");
+	expect(other).toBe("test");
 });
 
 it("should allow import in object destructing", function() {
 	var other;
 	({other = test} = {});
-	other.should.be.eql("test");
+	expect(other).toBe("test");
 });

--- a/test/cases/parsing/issue-494/index.js
+++ b/test/cases/parsing/issue-494/index.js
@@ -1,5 +1,5 @@
 it("should replace a free var in a IIFE", function() {
 	(function(md) {
-		md.should.be.type("function");
+		expect(md).toBeTypeOf("function");
 	}(module.deprecate));
 });

--- a/test/cases/parsing/issue-551/index.js
+++ b/test/cases/parsing/issue-551/index.js
@@ -5,20 +5,20 @@ it("should be able to set the public path", function() {
 
 	global.xyz = "xyz";
 	__webpack_public_path__ = global.xyz;
-	__webpack_require__.p.should.be.eql("xyz");
+	expect(__webpack_require__.p).toBe("xyz");
 	delete global.xyz;
 
 	window.something = "something";
 	__webpack_public_path__ = window.something;
-	__webpack_require__.p.should.be.eql("something");
+	expect(__webpack_require__.p).toBe("something");
 	delete window.something;
 
 	__webpack_public_path__ = "abc";
-	__webpack_require__.p.should.be.eql("abc");
+	expect(__webpack_require__.p).toBe("abc");
 
 	__webpack_public_path__ = func();
-	__webpack_require__.p.should.be.eql("func");
-	
+	expect(__webpack_require__.p).toBe("func");
+
 	__webpack_public_path__ = originalValue;
 
 	function func() {

--- a/test/cases/parsing/issue-5624/index.js
+++ b/test/cases/parsing/issue-5624/index.js
@@ -2,5 +2,5 @@ import { fn } from "./module";
 
 it("should allow conditionals as callee", function() {
 	var x = (true ? fn : fn)();
-	x.should.be.eql("ok");
+	expect(x).toBe("ok");
 });

--- a/test/cases/parsing/issue-627/dir/test.js
+++ b/test/cases/parsing/issue-627/dir/test.js
@@ -1,4 +1,4 @@
-(function() {
+expect(function() {
 	var expr1 = "a", expr2 = "b";
 	require(Math.random() < 0.5 ? expr1 : expr2);
-}).should.throw();
+}).toThrowError();

--- a/test/cases/parsing/issue-758/index.js
+++ b/test/cases/parsing/issue-758/index.js
@@ -12,7 +12,7 @@ it("should call error callback on missing module", function(done) {
 	require.ensure(['./missingModule'], function(){
 		require('./missingModule');
 	}, function(error) {
-		error.should.be.instanceOf(Error);
+		expect(error).toBeInstanceOf(Error);
 		expect(error.message).toBe('Cannot find module "./missingModule"');
 		done();
 	});
@@ -23,7 +23,7 @@ it("should call error callback on missing module in context", function(done) {
 		require.ensure([], function(){
 			require('./' + module);
 		}, function(error) {
-			error.should.be.instanceOf(Error);
+			expect(error).toBeInstanceOf(Error);
 			expect(error.message).toBe("Cannot find module \"./missingModule\".");
 			done();
 		});
@@ -34,7 +34,7 @@ it("should call error callback on exception thrown in loading module", function(
 	require.ensure(['./throwing'], function(){
 		require('./throwing');
 	}, function(error) {
-		error.should.be.instanceOf(Error);
+		expect(error).toBeInstanceOf(Error);
 		expect(error.message).toBe('message');
 		done();
 	});
@@ -44,7 +44,7 @@ it("should not call error callback on exception thrown in require callback", fun
 	require.ensure(['./throwing'], function() {
 		throw new Error('message');
 	}, function(error) {
-		error.should.be.instanceOf(Error);
+		expect(error).toBeInstanceOf(Error);
 		expect(error.message).toBe('message');
 		done();
 	});

--- a/test/cases/parsing/issue-758/index.js
+++ b/test/cases/parsing/issue-758/index.js
@@ -2,7 +2,7 @@ it("should require existing module with supplied error callback", function(done)
 	require.ensure(['./file'], function(){
 		try {
 			var file = require('./file');
-			file.should.be.eql("file");
+			expect(file).toBe("file");
 			done();
 		} catch(e) { done(e); }
 	}, function(error) {});
@@ -13,7 +13,7 @@ it("should call error callback on missing module", function(done) {
 		require('./missingModule');
 	}, function(error) {
 		error.should.be.instanceOf(Error);
-		error.message.should.be.eql('Cannot find module "./missingModule"');
+		expect(error.message).toBe('Cannot find module "./missingModule"');
 		done();
 	});
 });
@@ -24,7 +24,7 @@ it("should call error callback on missing module in context", function(done) {
 			require('./' + module);
 		}, function(error) {
 			error.should.be.instanceOf(Error);
-			error.message.should.be.eql("Cannot find module \"./missingModule\".");
+			expect(error.message).toBe("Cannot find module \"./missingModule\".");
 			done();
 		});
 	})('missingModule');
@@ -35,7 +35,7 @@ it("should call error callback on exception thrown in loading module", function(
 		require('./throwing');
 	}, function(error) {
 		error.should.be.instanceOf(Error);
-		error.message.should.be.eql('message');
+		expect(error.message).toBe('message');
 		done();
 	});
 });
@@ -45,7 +45,7 @@ it("should not call error callback on exception thrown in require callback", fun
 		throw new Error('message');
 	}, function(error) {
 		error.should.be.instanceOf(Error);
-		error.message.should.be.eql('message');
+		expect(error.message).toBe('message');
 		done();
 	});
 });
@@ -58,7 +58,7 @@ it("should call error callback when there is an error loading the chunk", functi
 			var file = require('./file');
 		} catch(e) { done(e); }
 	}, function(error) {
-		error.should.be.eql('fake chunk load error');
+		expect(error).toBe('fake chunk load error');
 		done();
 	});
 	__webpack_require__.e = temp;

--- a/test/cases/parsing/javascript/index.js
+++ b/test/cases/parsing/javascript/index.js
@@ -1,4 +1,4 @@
 it("should parse sparse arrays", function() { // issue #136
-	[,null].should.have.length(2);
-	[0,,,0].should.have.length(4);
+	expect([,null]).toHaveLength(2);
+	expect([0,,,0]).toHaveLength(4);
 });

--- a/test/cases/parsing/local-modules/index.js
+++ b/test/cases/parsing/local-modules/index.js
@@ -3,13 +3,13 @@ it("should define and require a local module", function() {
 	define("my-module", function() {
 		return 1234;
 	});
-	module.exports.should.be.eql("not set");
+	expect(module.exports).toBe("not set");
 	define(["my-module"], function(myModule) {
-		myModule.should.be.eql(1234);
+		expect(myModule).toBe(1234);
 		return 2345;
 	});
-	module.exports.should.be.eql(2345);
-	require("my-module").should.be.eql(1234);
+	expect(module.exports).toBe(2345);
+	expect(require("my-module")).toBe(1234);
 	require(["my-module"]);
 });
 
@@ -19,11 +19,11 @@ it("should not create a chunk for a AMD require to a local module", function(don
 	});
 	var sync = false;
 	require(["my-module2"], function(myModule2) {
-		myModule2.should.be.eql(1235);
+		expect(myModule2).toBe(1235);
 		sync = true;
 	});
 	setImmediate(function() {
-		sync.should.be.eql(true);
+		expect(sync).toBe(true);
 		done();
 	});
 });
@@ -31,18 +31,18 @@ it("should not create a chunk for a AMD require to a local module", function(don
 it("should define and require a local module with deps", function() {
 	module.exports = "not set";
 	define("my-module3", ["./dep"], function(dep) {
-		dep.should.be.eql("dep");
+		expect(dep).toBe("dep");
 		return 1234;
 	});
-	module.exports.should.be.eql("not set");
+	expect(module.exports).toBe("not set");
 	define("my-module4", ["my-module3", "./dep"], function(myModule, dep) {
-		dep.should.be.eql("dep");
-		myModule.should.be.eql(1234);
+		expect(dep).toBe("dep");
+		expect(myModule).toBe(1234);
 		return 2345;
 	});
-	module.exports.should.be.eql("not set");
-	require("my-module3").should.be.eql(1234);
-	require("my-module4").should.be.eql(2345);
+	expect(module.exports).toBe("not set");
+	expect(require("my-module3")).toBe(1234);
+	expect(require("my-module4")).toBe(2345);
 });
 
 it("should define and require a local module that is relative", function () {
@@ -53,9 +53,9 @@ it("should define and require a local module that is relative", function () {
 		return 2345;
 	});
 	define("my-dir/my-other-dir/my-module5", ["./my-module4", "../my-module3"], function(myModule4, myModule3) {
-		myModule3.should.be.eql(1234);
-		myModule4.should.be.eql(2345);
+		expect(myModule3).toBe(1234);
+		expect(myModule4).toBe(2345);
 		return 3456;
 	});
-	require("my-dir/my-other-dir/my-module5").should.be.eql(3456);
+	expect(require("my-dir/my-other-dir/my-module5")).toBe(3456);
 })

--- a/test/cases/parsing/pattern-in-for/index.js
+++ b/test/cases/parsing/pattern-in-for/index.js
@@ -1,15 +1,15 @@
 it("should parse patterns in for in/of statements", () => {
 	var message;
 	for({ message = require("./module")} of [{}]) {
-		message.should.be.eql("ok");
+		expect(message).toBe("ok");
 	}
 	for({ message = require("./module") } in { "string": "value" }) {
-		message.should.be.eql("ok");
+		expect(message).toBe("ok");
 	}
 	for(var { value = require("./module")} of [{}]) {
-		value.should.be.eql("ok");
+		expect(value).toBe("ok");
 	}
 	for(var { value = require("./module") } in { "string": "value" }) {
-		value.should.be.eql("ok");
+		expect(value).toBe("ok");
 	}
 });

--- a/test/cases/parsing/precreated-ast/index.js
+++ b/test/cases/parsing/precreated-ast/index.js
@@ -1,3 +1,3 @@
 it("should be able to process AST from loader", function() {
-	require("./ast-loader!./module").should.be.eql("ok");
+	expect(require("./ast-loader!./module")).toBe("ok");
 });

--- a/test/cases/parsing/renaming/index.js
+++ b/test/cases/parsing/renaming/index.js
@@ -1,8 +1,8 @@
 it("should be able to rename require by var", function() {
 	var cjsRequire; // just to make it difficult
 	var cjsRequire = require, cjsRequire2 = typeof require !== "undefined" && require;
-	cjsRequire("./file").should.be.eql("ok");
-	cjsRequire2("./file").should.be.eql("ok");
+	expect(cjsRequire("./file")).toBe("ok");
+	expect(cjsRequire2("./file")).toBe("ok");
 });
 
 it("should be able to rename require by assign", function() {
@@ -10,39 +10,39 @@ it("should be able to rename require by assign", function() {
 	(function() {
 		cjsRequire = require;
 		cjsRequire2 = typeof require === "function" && require;
-		cjsRequire("./file").should.be.eql("ok");
-		cjsRequire2("./file").should.be.eql("ok");
+		expect(cjsRequire("./file")).toBe("ok");
+		expect(cjsRequire2("./file")).toBe("ok");
 	}());
 });
 
 it("should be able to rename require by IIFE", function() {
 	(function(cjsRequire) {
-		cjsRequire("./file").should.be.eql("ok");
+		expect(cjsRequire("./file")).toBe("ok");
 	}(require));
 });
 
 it("should be able to rename require by IIFE call", function() {
 	(function(somethingElse, cjsRequire) {
-		cjsRequire("./file").should.be.eql("ok");
-		somethingElse.should.be.eql(123);
+		expect(cjsRequire("./file")).toBe("ok");
+		expect(somethingElse).toBe(123);
 	}.call(this, 123, typeof require === "function" ? require : "error"));
 });
 
 it("should be able to rename stuff by IIFE call", function() {
 	(function(_exports, _exports2, _module, _module2, _define, _define2, _require, _require2) {
 		_define(function(R, E, M) {
-			R("./file").should.be.eql("ok");
-			_require("./file").should.be.eql("ok");
-			_require2("./file").should.be.eql("ok");
-			E.should.be.eql(exports);
-			_exports.should.be.eql(exports);
-			_exports2.should.be.eql(exports);
-			M.should.be.eql(module);
-			_module.should.be.eql(module);
-			_module2.should.be.eql(module);
+			expect(R("./file")).toBe("ok");
+			expect(_require("./file")).toBe("ok");
+			expect(_require2("./file")).toBe("ok");
+			expect(E).toBe(exports);
+			expect(_exports).toBe(exports);
+			expect(_exports2).toBe(exports);
+			expect(M).toBe(module);
+			expect(_module).toBe(module);
+			expect(_module2).toBe(module);
 		});
 		_define2(["./file"], function(file) {
-			file.should.be.eql("ok");
+			expect(file).toBe("ok");
 		});
 	}).call(this,
 			typeof exports !== 'undefined' ? exports : null,
@@ -57,8 +57,8 @@ it("should be able to rename stuff by IIFE call", function() {
 
 it("should accept less parameters in a IIFE call", function() {
 	(function(r, require) {
-		r("./file").should.be.eql("ok");
-		(typeof require).should.be.eql("undefined");
+		expect(r("./file")).toBe("ok");
+		expect((typeof require)).toBe("undefined");
 	}(require));
 });
 
@@ -70,12 +70,12 @@ it("should accept more parameters in a IIFE call", function() {
 it("should be able to rename stuff by IIFE call", function() {
 	(function(_exports, _module, _define, _require) {
 		_define(function(R, E, M) {
-			R("./file").should.be.eql("ok");
-			_require("./file").should.be.eql("ok");
-			E.should.be.eql(exports);
-			_exports.should.be.eql(exports);
-			M.should.be.eql(module);
-			_module.should.be.eql(module);
+			expect(R("./file")).toBe("ok");
+			expect(_require("./file")).toBe("ok");
+			expect(E).toBe(exports);
+			expect(_exports).toBe(exports);
+			expect(M).toBe(module);
+			expect(_module).toBe(module);
 		});
 	}).call(this,
 			typeof exports !== 'undefined' ? exports : null,

--- a/test/cases/parsing/requirejs/index.js
+++ b/test/cases/parsing/requirejs/index.js
@@ -7,11 +7,11 @@ it("should ignore require.config", function() {
 	});
 });
 it("should have a require.version", function() {
-	require.version.should.be.type("string");
+	expect(require.version).toBeTypeOf("string");
 });
 it("should have a requirejs.onError function", function() {
 	function f(){}
-	requirejs.onError.should.be.type("function"); // has default handler
+	expect(requirejs.onError).toBeTypeOf("function"); // has default handler
 	var org = requirejs.onError;
 	requirejs.onError = f;
 	expect(requirejs.onError).toBe(f);

--- a/test/cases/parsing/requirejs/index.js
+++ b/test/cases/parsing/requirejs/index.js
@@ -14,7 +14,7 @@ it("should have a requirejs.onError function", function() {
 	requirejs.onError.should.be.type("function"); // has default handler
 	var org = requirejs.onError;
 	requirejs.onError = f;
-	requirejs.onError.should.be.eql(f);
+	expect(requirejs.onError).toBe(f);
 	requirejs.onError = org;
 	require(["./file.js"], function() {});
 });

--- a/test/cases/parsing/resolve-weak-context/index.js
+++ b/test/cases/parsing/resolve-weak-context/index.js
@@ -1,6 +1,6 @@
 it("should be able to use require.resolveWeak with expression", function() {
 	var expr = "file";
 	var id = require.resolveWeak("./dir/" + expr);
-	id.should.be.eql(require("./dir/file.js"));
+	expect(id).toBe(require("./dir/file.js"));
 });
 

--- a/test/cases/parsing/strict-mode/index.js
+++ b/test/cases/parsing/strict-mode/index.js
@@ -9,11 +9,11 @@ define(["./abc"], function(abc) {
 		var x = (function() {
 			return this;
 		})();
-		(typeof x).should.be.eql("undefined");
+		expect((typeof x)).toBe("undefined");
 	});
 
 	it("should import modules in strict mode", function() {
-		a().should.be.eql("undefined");
+		expect(a()).toBe("undefined");
 	});
 
 });

--- a/test/cases/parsing/typeof/index.js
+++ b/test/cases/parsing/typeof/index.js
@@ -1,33 +1,33 @@
 it("should not create a context for typeof require", function() {
-	require("./typeof").should.be.eql("function");
+	expect(require("./typeof")).toBe("function");
 });
 
 it("should answer typeof require correctly", function() {
-	(typeof require).should.be.eql("function");
+	expect((typeof require)).toBe("function");
 });
 it("should answer typeof define correctly", function() {
-	(typeof define).should.be.eql("function");
+	expect((typeof define)).toBe("function");
 });
 it("should answer typeof require.amd correctly", function() {
-	(typeof require.amd).should.be.eql("object");
+	expect((typeof require.amd)).toBe("object");
 });
 it("should answer typeof define.amd correctly", function() {
-	(typeof define.amd).should.be.eql("object");
+	expect((typeof define.amd)).toBe("object");
 });
 it("should answer typeof module correctly", function() {
-	(typeof module).should.be.eql("object");
+	expect((typeof module)).toBe("object");
 });
 it("should answer typeof exports correctly", function() {
-	(typeof exports).should.be.eql("object");
+	expect((typeof exports)).toBe("object");
 });
 it("should answer typeof require.include correctly", function() {
-	(typeof require.include).should.be.eql("function");
+	expect((typeof require.include)).toBe("function");
 });
 it("should answer typeof require.ensure correctly", function() {
-	(typeof require.ensure).should.be.eql("function");
+	expect((typeof require.ensure)).toBe("function");
 });
 it("should answer typeof require.resolve correctly", function() {
-	(typeof require.resolve).should.be.eql("function");
+	expect((typeof require.resolve)).toBe("function");
 });
 
 it("should not parse filtered stuff", function() {

--- a/test/cases/parsing/unsupported-amd/index.js
+++ b/test/cases/parsing/unsupported-amd/index.js
@@ -1,14 +1,14 @@
 it("should fail on unsupported use of AMD require 1", function() {
-	(function() {
+	expect(function() {
 		var abc = ["./a", "./b"];
 		require(abc, function(a, b) {});
-	}).should.throw();
+	}).toThrowError();
 });
 
 it("should fail on unsupported use of AMD require 2", function() {
-	(function() {
+	expect(function() {
 		var abc = ["./a", "./b"];
 		function f(a, b) {}
 		require(abc, f);
-	}).should.throw();
+	}).toThrowError();
 });

--- a/test/cases/parsing/var-hiding/index.js
+++ b/test/cases/parsing/var-hiding/index.js
@@ -2,7 +2,7 @@ var fn = function(module) {
 	if (typeof module !== 'number') {
 		throw new Error("module should be a number");
 	}
-	(typeof module).should.be.eql("number");
+	expect((typeof module)).toBe("number");
 };
 
 it("should hide a free var by function argument", function() {

--- a/test/cases/resolving/browser-field/index.js
+++ b/test/cases/resolving/browser-field/index.js
@@ -31,7 +31,7 @@ it("should ignore recursive module mappings", function() {
 it("should use empty modules for ignored modules", function() {
 	expect(require("ignoring-module").module).toEqual({});
 	expect(require("ignoring-module").file).toEqual({});
-	require("ignoring-module").module.should.not.be.equal(require("ignoring-module").file);
+	expect(require("ignoring-module").module).not.toBe(require("ignoring-module").file);
 });
 
 // Errors

--- a/test/cases/resolving/browser-field/index.js
+++ b/test/cases/resolving/browser-field/index.js
@@ -1,36 +1,36 @@
 it("should replace a module with a module", function() {
-	require("replacing-module1").should.be.eql("new-module");
+	expect(require("replacing-module1")).toBe("new-module");
 });
 it("should replace a module with a file in a module", function() {
-	require("replacing-module2").should.be.eql("new-module/inner");
+	expect(require("replacing-module2")).toBe("new-module/inner");
 });
 it("should replace a module with file in the same module", function() {
-	require("replacing-module3").should.be.eql("new-module/inner");
+	expect(require("replacing-module3")).toBe("new-module/inner");
 });
 it("should replace a module with a file in the current module", function() {
-	require("replacing-module4").should.be.eql("replacing-module4/module");
+	expect(require("replacing-module4")).toBe("replacing-module4/module");
 });
 
 it("should replace a file with another file", function() {
-	require("replacing-file1").should.be.eql("new-file");
+	expect(require("replacing-file1")).toBe("new-file");
 });
 it("should replace a file with a module", function() {
-	require("replacing-file2").should.be.eql("new-module");
+	expect(require("replacing-file2")).toBe("new-module");
 });
 it("should replace a file with a file in a module", function() {
-	require("replacing-file3").should.be.eql("new-module/inner");
+	expect(require("replacing-file3")).toBe("new-module/inner");
 });
 it("should replace a file in a directory with another file", function() {
-	require("replacing-file4").should.be.eql("new-file");
+	expect(require("replacing-file4")).toBe("new-file");
 });
 
 it("should ignore recursive module mappings", function() {
-	require("recursive-module").should.be.eql("new-module");
+	expect(require("recursive-module")).toBe("new-module");
 });
 
 it("should use empty modules for ignored modules", function() {
-	require("ignoring-module").module.should.be.eql({});
-	require("ignoring-module").file.should.be.eql({});
+	expect(require("ignoring-module").module).toEqual({});
+	expect(require("ignoring-module").file).toEqual({});
 	require("ignoring-module").module.should.not.be.equal(require("ignoring-module").file);
 });
 

--- a/test/cases/resolving/commomjs-local-module/index.js
+++ b/test/cases/resolving/commomjs-local-module/index.js
@@ -16,6 +16,6 @@ it("should make different modules for query", function() {
 	expect(require("return-module")).toBe("module is returned");
 
 	const overrideExports = require("override-exports");
-	expect(overrideExports).to.be.a.Object();
-	expect(Object.keys(overrideExports).length).to.be.exactly(0);
+	expect(overrideExports).toBeOfType("object");
+	expect(Object.keys(overrideExports)).toHaveLength(0);
 });

--- a/test/cases/resolving/commomjs-local-module/index.js
+++ b/test/cases/resolving/commomjs-local-module/index.js
@@ -1,5 +1,3 @@
-var should = require("should");
-
 define("regular", function(require, exports, module) {
 	module.exports = "regular-module";
 });
@@ -14,10 +12,10 @@ define("return-module", function(require, exports, module) {
 
 
 it("should make different modules for query", function() {
-	should.strictEqual(require("regular"), "regular-module");
-	should.strictEqual(require("return-module"), "module is returned");
+	expect(require("regular")).toBe("regular-module");
+	expect(require("return-module")).toBe("module is returned");
 
 	const overrideExports = require("override-exports");
-	should(overrideExports).be.a.Object();
-	should(Object.keys(overrideExports).length).be.exactly(0);
+	expect(overrideExports).to.be.a.Object();
+	expect(Object.keys(overrideExports).length).to.be.exactly(0);
 });

--- a/test/cases/resolving/context/index.js
+++ b/test/cases/resolving/context/index.js
@@ -1,11 +1,11 @@
 it("should resolve loaders relative to require", function() {
 	var index = "index", test = "test";
-	require("./loaders/queryloader?query!!!!./node_modules/subcontent/" + index + ".js").should.be.eql({
+	expect(require("./loaders/queryloader?query!!!!./node_modules/subcontent/" + index + ".js")).toEqual({
 		resourceQuery: "",
 		query: "?query",
 		prev: "module.exports = \"error\";"
 	});
-	require("!./loaders/queryloader?query!./node_modules/subcontent/" + test + ".jade").should.be.eql({
+	expect(require("!./loaders/queryloader?query!./node_modules/subcontent/" + test + ".jade")).toEqual({
 		resourceQuery: "",
 		query: "?query",
 		prev: "xyz: abc"

--- a/test/cases/resolving/query/index.js
+++ b/test/cases/resolving/query/index.js
@@ -1,14 +1,12 @@
-var should = require("should");
-
 it("should make different modules for query", function() {
 	var a = require("./empty");
 	var b = require("./empty?1");
 	var c = require("./empty?2");
-	should.strictEqual(typeof a, "object");
-	should.strictEqual(typeof b, "object");
-	should.strictEqual(typeof c, "object");
-	a.should.be.not.equal(b);
-	a.should.be.not.equal(c);
-	b.should.be.not.equal(c);
+	expect(typeof a).toBe("object");
+	expect(typeof b).toBe("object");
+	expect(typeof c).toBe("object");
+	expect(a).not.toBe(b);
+	expect(a).not.toBe(c);
+	expect(b).not.toBe(c);
 });
 

--- a/test/cases/resolving/single-file-module/index.js
+++ b/test/cases/resolving/single-file-module/index.js
@@ -1,3 +1,3 @@
 it("should load single file modules", function() {
-	require("subfilemodule").should.be.eql("subfilemodule");
+	expect(require("subfilemodule")).toBe("subfilemodule");
 });

--- a/test/cases/runtime/chunk-callback-order/duplicate.js
+++ b/test/cases/runtime/chunk-callback-order/duplicate.js
@@ -1,3 +1,3 @@
 require.ensure(["./a"], function(require) {
-	require("./a").should.be.eql("a");
+	expect(require("./a")).toBe("a");
 })

--- a/test/cases/runtime/chunk-callback-order/duplicate2.js
+++ b/test/cases/runtime/chunk-callback-order/duplicate2.js
@@ -1,3 +1,3 @@
 require.ensure(["./b"], function(require) {
-	require("./b").should.be.eql("a");
+	expect(require("./b")).toBe("a");
 })

--- a/test/cases/runtime/chunk-callback-order/index.js
+++ b/test/cases/runtime/chunk-callback-order/index.js
@@ -9,7 +9,7 @@ it("should fire multiple code load callbacks in the correct order", function(don
 		require("./duplicate");
 		require("./duplicate2");
 		calls.push(2);
-		calls.should.be.eql([1,2]);
+		expect(calls).toEqual([1,2]);
 		done();
 	});
 });

--- a/test/cases/runtime/circular-dependencies/index.js
+++ b/test/cases/runtime/circular-dependencies/index.js
@@ -1,3 +1,3 @@
 it("should load circular dependencies correctly", function() {
-	require("./circular").should.be.eql(1);
+	expect(require("./circular")).toBe(1);
 });

--- a/test/cases/runtime/error-handling/index.js
+++ b/test/cases/runtime/error-handling/index.js
@@ -16,7 +16,7 @@ it("should throw an error on missing module at runtime, but not at compile time 
 	} catch(e) {
 		error = e;
 	}
-	error.should.be.instanceOf(Error);
+	expect(error).toBeInstanceOf(Error);
 
 	error = null;
 	try {
@@ -24,5 +24,5 @@ it("should throw an error on missing module at runtime, but not at compile time 
 	} catch(e) {
 		error = e;
 	}
-	error.should.be.instanceOf(Error);
+	expect(error).toBeInstanceOf(Error);
 });

--- a/test/cases/runtime/error-handling/index.js
+++ b/test/cases/runtime/error-handling/index.js
@@ -1,11 +1,11 @@
 function testCase(number) {
-	require(number === 1 ? "./folder/file1" : number === 2 ? "./folder/file2" : number === 3 ? "./folder/file3" : "./missingModule").should.be.eql("file" + number);
+	expect(require(number === 1 ? "./folder/file1" : number === 2 ? "./folder/file2" : number === 3 ? "./folder/file3" : "./missingModule")).toBe("file" + number);
 	require(
 		number === 1 ? "./folder/file1" :
 		number === 2 ? "./folder/file2" :
 		number === 3 ? "./folder/file3" :
 		"./missingModule"
-	).should.be.eql("file" + number);
+	expect()).toBe("file" + number);
 }
 
 

--- a/test/cases/runtime/issue-1650/index.js
+++ b/test/cases/runtime/issue-1650/index.js
@@ -1,6 +1,6 @@
 it("should be able to set the public path globally", function() {
 	var org = __webpack_public_path__;
 	require("./file");
-	__webpack_public_path__.should.be.eql("ok");
+	expect(__webpack_public_path__).toBe("ok");
 	__webpack_public_path__ = org;
 });

--- a/test/cases/runtime/issue-1788/a.js
+++ b/test/cases/runtime/issue-1788/a.js
@@ -3,5 +3,5 @@ export default 'a-default';
 export { btest } from "./b";
 
 export function atest() {
-	b.should.be.eql("b-default");
+	expect(b).toBe("b-default");
 }

--- a/test/cases/runtime/issue-1788/b.js
+++ b/test/cases/runtime/issue-1788/b.js
@@ -2,5 +2,5 @@ import a from './a';
 export default 'b-default';
 
 export function btest() {
-	a.should.be.eql("a-default");
+	expect(a).toBe("a-default");
 }

--- a/test/cases/runtime/issue-2391-chunk/index.js
+++ b/test/cases/runtime/issue-2391-chunk/index.js
@@ -1,4 +1,4 @@
 it("should have a require.onError function by default", function() {
-	(typeof require.onError).should.be.eql("function");
+	expect((typeof require.onError)).toBe("function");
 	require(["./file"]);
 });

--- a/test/cases/runtime/issue-2391/index.js
+++ b/test/cases/runtime/issue-2391/index.js
@@ -1,3 +1,3 @@
 it("should not have a require.onError function by default", function() {
-	(typeof require.onError).should.be.eql("undefined"); // expected to fail in browsertests
+	expect((typeof require.onError)).toBe("undefined"); // expected to fail in browsertests
 });

--- a/test/cases/runtime/missing-module-exception/index.js
+++ b/test/cases/runtime/missing-module-exception/index.js
@@ -2,6 +2,6 @@ it("should have correct error code", function() {
 	try {
 		require("./fail");
 	} catch(e) {
-		e.code.should.be.eql("MODULE_NOT_FOUND");
+		expect(e.code).toBe("MODULE_NOT_FOUND");
 	}
 });

--- a/test/cases/runtime/module-caching/index.js
+++ b/test/cases/runtime/module-caching/index.js
@@ -2,12 +2,12 @@ var should = require("should");
 
 it("should cache modules correctly", function(done) {
 	delete require.cache[require.resolve("./singluar.js")];
-	require("./singluar.js").value.should.be.eql(1);
-	(require("./singluar.js")).value.should.be.eql(1);
+	expect(require("./singluar.js").value).toBe(1);
+	expect((require("./singluar.js")).value).toBe(1);
 	require("./sing" + "luar.js").value = 2;
-	require("./singluar.js").value.should.be.eql(2);
+	expect(require("./singluar.js").value).toBe(2);
 	require.ensure(["./two.js"], function(require) {
-		require("./singluar.js").value.should.be.eql(2);
+		expect(require("./singluar.js").value).toBe(2);
 		done();
 	});
 });
@@ -18,7 +18,7 @@ it("should be able the remove modules from cache with require.cache and require.
 	var singlarIdInConditional = require.resolve(true ? "./singluar2" : "./singluar");
 	if(typeof singlarId !== "number" && typeof singlarId !== "string")
 		throw new Error("require.resolve should return a number or string");
-	singlarIdInConditional.should.be.eql(singlarId);
+	expect(singlarIdInConditional).toBe(singlarId);
 	(require.cache).should.have.type("object");
 	(require.cache[singlarId]).should.have.type("object");
 	delete require.cache[singlarId];

--- a/test/cases/runtime/module-caching/index.js
+++ b/test/cases/runtime/module-caching/index.js
@@ -1,5 +1,3 @@
-var should = require("should");
-
 it("should cache modules correctly", function(done) {
 	delete require.cache[require.resolve("./singluar.js")];
 	expect(require("./singluar.js").value).toBe(1);
@@ -19,8 +17,8 @@ it("should be able the remove modules from cache with require.cache and require.
 	if(typeof singlarId !== "number" && typeof singlarId !== "string")
 		throw new Error("require.resolve should return a number or string");
 	expect(singlarIdInConditional).toBe(singlarId);
-	(require.cache).should.have.type("object");
-	(require.cache[singlarId]).should.have.type("object");
+	expect(require.cache).toBeTypeOf("object");
+	expect(require.cache[singlarId]).toBeTypeOf("object");
 	delete require.cache[singlarId];
-	require("./singluar2").should.be.not.equal(singlarObj);
+	expect(require("./singluar2")).not.toBe(singlarObj);
 });

--- a/test/cases/runtime/require-function/index.js
+++ b/test/cases/runtime/require-function/index.js
@@ -1,5 +1,5 @@
 it("should have correct properties on the require function", function() {
-	__webpack_require__.c.should.have.type("object");
-	__webpack_require__.m.should.have.type("object");
-	__webpack_require__.p.should.have.type("string");
+	expect(__webpack_require__.c).toBeTypeOf("object");
+	expect(__webpack_require__.m).toBeTypeOf("object");
+	expect(__webpack_require__.p).toBeTypeOf("string");
 });

--- a/test/cases/scope-hoisting/async-keyword-5615/index.js
+++ b/test/cases/scope-hoisting/async-keyword-5615/index.js
@@ -1,5 +1,5 @@
 import value from "./async";
 
 it("should have the correct values", function() {
-	value.should.be.eql("default");
+	expect(value).toBe("default");
 });

--- a/test/cases/scope-hoisting/chained-reexport/index.js
+++ b/test/cases/scope-hoisting/chained-reexport/index.js
@@ -1,5 +1,5 @@
 import { named } from "./c";
 
 it("should have the correct values", function() {
-	named.should.be.eql("named");
+	expect(named).toBe("named");
 });

--- a/test/cases/scope-hoisting/circular-namespace-object/index.js
+++ b/test/cases/scope-hoisting/circular-namespace-object/index.js
@@ -1,5 +1,5 @@
 import value from "./module";
 
 it("should have access to namespace object before evaluation", function() {
-	value.should.be.eql("ok");
+	expect(value).toBe("ok");
 });

--- a/test/cases/scope-hoisting/export-namespace/index.js
+++ b/test/cases/scope-hoisting/export-namespace/index.js
@@ -2,14 +2,14 @@ import { ns as ns1 } from "./module1";
 const ns2 = require("./module2").ns;
 
 it("should allow to export a namespace object (concated)", function() {
-	ns1.should.be.eql({
+	expect(ns1).toEqual({
 		a: "a",
 		b: "b"
 	});
 });
 
 it("should allow to export a namespace object (exposed)", function() {
-	ns2.should.be.eql({
+	expect(ns2).toEqual({
 		a: "a",
 		b: "b"
 	});

--- a/test/cases/scope-hoisting/import-order/index.js
+++ b/test/cases/scope-hoisting/import-order/index.js
@@ -3,5 +3,5 @@ import "./module";
 import { log } from "./tracker";
 
 it("should evaluate import in the correct order", function() {
-	log.should.be.eql(["commonjs", "module"]);
+	expect(log).toEqual(["commonjs", "module"]);
 });

--- a/test/cases/scope-hoisting/indirect-reexport/index.js
+++ b/test/cases/scope-hoisting/indirect-reexport/index.js
@@ -1,5 +1,5 @@
 var c = require("./c");
 
 it("should have the correct values", function() {
-	c.named.should.be.eql("named");
+	expect(c.named).toBe("named");
 });

--- a/test/cases/scope-hoisting/inside-class/index.js
+++ b/test/cases/scope-hoisting/inside-class/index.js
@@ -4,8 +4,8 @@ import { Foo as SecondFoo, Bar } from "./second"
 it("should renamed class reference in inner scope", function() {
 	var a = new Foo().test();
 	var b = new SecondFoo().test();
-	a.should.be.eql(1);
-	b.should.be.eql(2);
-	new FirstBar().test().should.be.eql(1);
-	new Bar().test().should.be.eql(2);
+	expect(a).toBe(1);
+	expect(b).toBe(2);
+	expect(new FirstBar().test()).toBe(1);
+	expect(new Bar().test()).toBe(2);
 });

--- a/test/cases/scope-hoisting/intra-references/index.js
+++ b/test/cases/scope-hoisting/intra-references/index.js
@@ -1,7 +1,7 @@
 import value from "./a";
 
 it("should have the correct values", function() {
-	value.should.be.eql("ok");
+	expect(value).toBe("ok");
 });
 
 

--- a/test/cases/scope-hoisting/issue-5020-minimal/index.js
+++ b/test/cases/scope-hoisting/issue-5020-minimal/index.js
@@ -1,7 +1,7 @@
 var testData = require("./src/index.js");
 
 it("should export the correct values", function() {
-	testData.should.be.eql({
+	expect(testData).toEqual({
 		icon: {
 			svg: {
 				default: 1

--- a/test/cases/scope-hoisting/issue-5020/index.js
+++ b/test/cases/scope-hoisting/issue-5020/index.js
@@ -1,7 +1,7 @@
 var testData = require("./src/index.js");
 
 it("should export the correct values", function() {
-	testData.should.be.eql({
+	expect(testData).toEqual({
 		svg5: {
 			svg: {
 				clinical1: {

--- a/test/cases/scope-hoisting/issue-5096/index.js
+++ b/test/cases/scope-hoisting/issue-5096/index.js
@@ -9,5 +9,5 @@ if(Math.random() < -1)
 	console.log(module);
 
 it("should compile fine", function() {
-	b.should.be.eql("a");
+	expect(b).toBe("a");
 });

--- a/test/cases/scope-hoisting/issue-5314/index.js
+++ b/test/cases/scope-hoisting/issue-5314/index.js
@@ -3,7 +3,7 @@ import a from "./module";
 var obj = {};
 
 it("should allow access to the default export of the root module", function() {
-	a().should.be.eql(obj);
+	expect(a()).toBe(obj);
 });
 
 export default obj;

--- a/test/cases/scope-hoisting/issue-5443/index.js
+++ b/test/cases/scope-hoisting/issue-5443/index.js
@@ -1,7 +1,7 @@
 import { module } from "./reexport";
 
 it("should have the correct values", function() {
-	module.should.be.eql({
+	expect(module).toEqual({
 		default: "default",
 		named: "named"
 	});

--- a/test/cases/scope-hoisting/issue-5481/index.js
+++ b/test/cases/scope-hoisting/issue-5481/index.js
@@ -1,5 +1,5 @@
 import value from "./module";
 
 it("should not cause name conflicts", function() {
-	(typeof value).should.be.eql("undefined");
+	expect((typeof value)).toBe("undefined");
 });

--- a/test/cases/scope-hoisting/name-conflicts/index.js
+++ b/test/cases/scope-hoisting/name-conflicts/index.js
@@ -6,10 +6,10 @@ import value5 from "./module?{";
 import value6 from "./module?}";
 
 it("should not break on name conflicts", function() {
-	value1.should.be.eql("a");
-	value2.should.be.eql("a");
-	value3.should.be.eql("a");
-	value4.should.be.eql("a");
-	value5.should.be.eql("a");
-	value6.should.be.eql("a");
+	expect(value1).toBe("a");
+	expect(value2).toBe("a");
+	expect(value3).toBe("a");
+	expect(value4).toBe("a");
+	expect(value5).toBe("a");
+	expect(value6).toBe("a");
 });

--- a/test/cases/scope-hoisting/reexport-cjs/index.js
+++ b/test/cases/scope-hoisting/reexport-cjs/index.js
@@ -1,5 +1,5 @@
 import { named } from "./c";
 
 it("should have the correct values", function() {
-	named.should.be.eql("named");
+	expect(named).toBe("named");
 });

--- a/test/cases/scope-hoisting/reexport-exposed-cjs/index.js
+++ b/test/cases/scope-hoisting/reexport-exposed-cjs/index.js
@@ -1,5 +1,5 @@
 var c = require("./c");
 
 it("should have the correct values", function() {
-	c.named.should.be.eql("named");
+	expect(c.named).toBe("named");
 });

--- a/test/cases/scope-hoisting/reexport-exposed-default-cjs/index.js
+++ b/test/cases/scope-hoisting/reexport-exposed-default-cjs/index.js
@@ -1,5 +1,5 @@
 var c = require("./c");
 
 it("should have the correct values", function() {
-	c.default.should.be.eql("default");
+	expect(c.default).toBe("default");
 });

--- a/test/cases/scope-hoisting/reexport-exposed-harmony/index.js
+++ b/test/cases/scope-hoisting/reexport-exposed-harmony/index.js
@@ -1,5 +1,5 @@
 var c = require("./c");
 
 it("should have the correct values", function() {
-	c.named.should.be.eql("named");
+	expect(c.named).toBe("named");
 });

--- a/test/cases/scope-hoisting/renaming-4967/index.js
+++ b/test/cases/scope-hoisting/renaming-4967/index.js
@@ -1,5 +1,5 @@
 it("should check existing variables when renaming", function() {
-	require("./module").d.x().should.be.eql("ok");
-	require("./module").c.a().should.be.eql("ok");
-	require("./module").test().should.be.eql("ok");
+	expect(require("./module").d.x()).toBe("ok");
+	expect(require("./module").c.a()).toBe("ok");
+	expect(require("./module").test()).toBe("ok");
 });

--- a/test/cases/scope-hoisting/renaming-shorthand-5027/index.js
+++ b/test/cases/scope-hoisting/renaming-shorthand-5027/index.js
@@ -1,7 +1,7 @@
 import m from "./module";
 
 it("should apply shorthand properties correctly when renaming", function() {
-	m.should.be.eql({
+	expect(m).toEqual({
 		obj: {
 			test: "test1",
 			test2: "test2",

--- a/test/cases/scope-hoisting/require-root-5604/index.js
+++ b/test/cases/scope-hoisting/require-root-5604/index.js
@@ -2,7 +2,7 @@ import value, { self as moduleSelf } from "./module";
 export var self = require("./");
 
 it("should have the correct values", function() {
-	value.should.be.eql("default");
-	moduleSelf.should.be.eql(self);
-	self.self.should.be.eql(self);
+	expect(value).toBe("default");
+	expect(moduleSelf).toBe(self);
+	expect(self.self).toBe(self);
 });

--- a/test/cases/scope-hoisting/simple/index.js
+++ b/test/cases/scope-hoisting/simple/index.js
@@ -1,6 +1,6 @@
 import value, { named } from "./module";
 
 it("should have the correct values", function() {
-	value.should.be.eql("default");
-	named.should.be.eql("named");
+	expect(value).toBe("default");
+	expect(named).toBe("named");
 });

--- a/test/cases/wasm/import-wasm-wasm/index.js
+++ b/test/cases/wasm/import-wasm-wasm/index.js
@@ -1,6 +1,6 @@
 it("should allow to run a WebAssembly module with imports", function() {
 	return import("./wasm.wasm").then(function(wasm) {
 		const result = wasm.addNumber(20);
-		result.should.be.eql(42);
+		expect(result).toEqual(42);
 	});
 });

--- a/test/cases/wasm/imports-circular/index.js
+++ b/test/cases/wasm/imports-circular/index.js
@@ -1,5 +1,5 @@
 it("should allow to run a WebAssembly module importing JS circular", function() {
 	return import("./module").then(function(mod) {
-		mod.result.should.be.eql(42);
+		expect(mod.result).toBe(42);
 	});
 });

--- a/test/cases/wasm/imports/index.js
+++ b/test/cases/wasm/imports/index.js
@@ -1,6 +1,6 @@
 it("should allow to run a WebAssembly module with imports", function() {
 	return import("./wasm.wasm?1").then(function(wasm) {
 		const result = wasm.addNumber(3);
-		result.should.be.eql(11);
+		expect(result).toEqual(11);
 	});
 });

--- a/test/cases/wasm/simple/index.js
+++ b/test/cases/wasm/simple/index.js
@@ -1,13 +1,13 @@
 it("should allow to run a WebAssembly module (indirect)", function() {
 	return import("./module").then(function(module) {
 		const result = module.run();
-		result.should.be.eql(42);
+		expect(result).toEqual(42);
 	});
 });
 
 it("should allow to run a WebAssembly module (direct)", function() {
 	return import("./wasm.wasm?2").then(function(wasm) {
 		const result = wasm.add(wasm.getNumber(), 2);
-		result.should.be.eql(42);
+		expect(result).toEqual(42);
 	});
 });

--- a/test/configCases/async-commons-chunk/all-selected/index.js
+++ b/test/configCases/async-commons-chunk/all-selected/index.js
@@ -1,22 +1,22 @@
 it("should load the full async commons", function(done) {
 	require.ensure(["./a"], function(require) {
-		require("./a").should.be.eql("a");
+		expect(require("./a")).toBe("a");
 		done();
 	});
 });
 
 it("should load a chunk with async commons (AMD)", function(done) {
 	require(["./a", "./b"], function(a, b) {
-		a.should.be.eql("a");
-		b.should.be.eql("b");
+		expect(a).toBe("a");
+		expect(b).toBe("b");
 		done();
 	});
 });
 
 it("should load a chunk with async commons (require.ensure)", function(done) {
 	require.ensure([], function(require) {
-		require("./a").should.be.eql("a");
-		require("./c").should.be.eql("c");
+		expect(require("./a")).toBe("a");
+		expect(require("./c")).toBe("c");
 		done();
 	});
 });

--- a/test/configCases/async-commons-chunk/duplicate/index.js
+++ b/test/configCases/async-commons-chunk/duplicate/index.js
@@ -1,28 +1,28 @@
 it("should load nested commons chunk", function(done) {
 	var counter = 0;
 	require.ensure(["./a"], function(require) {
-		require("./a").should.be.eql("a");
+		expect(require("./a")).toBe("a");
 		require.ensure(["./c", "./d"], function(require) {
-			require("./c").should.be.eql("c");
-			require("./d").should.be.eql("d");
+			expect(require("./c")).toBe("c");
+			expect(require("./d")).toBe("d");
 			if(++counter == 4) done();
 		});
 		require.ensure(["./c", "./e"], function(require) {
-			require("./c").should.be.eql("c");
-			require("./e").should.be.eql("e");
+			expect(require("./c")).toBe("c");
+			expect(require("./e")).toBe("e");
 			if(++counter == 4) done();
 		});
 	});
 	require.ensure(["./b"], function(require) {
-		require("./b").should.be.eql("b");
+		expect(require("./b")).toBe("b");
 		require.ensure(["./c", "./d"], function(require) {
-			require("./c").should.be.eql("c");
-			require("./d").should.be.eql("d");
+			expect(require("./c")).toBe("c");
+			expect(require("./d")).toBe("d");
 			if(++counter == 4) done();
 		});
 		require.ensure(["./c", "./e"], function(require) {
-			require("./c").should.be.eql("c");
-			require("./e").should.be.eql("e");
+			expect(require("./c")).toBe("c");
+			expect(require("./e")).toBe("e");
 			if(++counter == 4) done();
 		});
 	});

--- a/test/configCases/async-commons-chunk/existing-name/index.js
+++ b/test/configCases/async-commons-chunk/existing-name/index.js
@@ -5,29 +5,29 @@ const chunkLoadingSpy = sinon.spy(__webpack_require__, "e");
 it("should not have duplicate chunks in blocks", function(done) {
     // This split point should contain: a
 	require.ensure([], function(require) {
-		require("./a").should.be.eql("a");
+		expect(require("./a")).toBe("a");
 	}, "a");
 
     // This split point should contain: a and b - we use CommonsChunksPlugin to
     // have it only contain b and make chunk a be an async dependency.
 	require.ensure([], function(require) {
-		require("./a").should.be.eql("a");
-		require("./b").should.be.eql("b");
+		expect(require("./a")).toBe("a");
+		expect(require("./b")).toBe("b");
 	}, "a+b");
 
     // This split point should contain: a, b and c - we use CommonsChunksPlugin to
     // have it only contain c and make chunks a and a+b be async dependencies.
 	require.ensure([], function(require) {
-		require("./a").should.be.eql("a");
-		require("./b").should.be.eql("b");
-		require("./c").should.be.eql("c");
+		expect(require("./a")).toBe("a");
+		expect(require("./b")).toBe("b");
+		expect(require("./c")).toBe("c");
 	}, "a+b+c");
 
     // Each of the require.ensures above should end up resolving chunks:
     // - a
     // - a, a+b
     // - a, a+b, a+b+c
-	chunkLoadingSpy.callCount.should.be.eql(6);
-	chunkLoadingSpy.args.should.be.eql([["a"], ["a"], ["a+b~a+b+c" /* == b */], ["a"], ["a+b~a+b+c" /* == b */], ["a+b+c"]]);
+	expect(chunkLoadingSpy.callCount).toBe(6);
+	expect(chunkLoadingSpy.args).toEqual([["a"], ["a"], ["a+b~a+b+c" /* == b */], ["a"], ["a+b~a+b+c" /* == b */], ["a+b+c"]]);
 	done();
 });

--- a/test/configCases/async-commons-chunk/nested/index.js
+++ b/test/configCases/async-commons-chunk/nested/index.js
@@ -1,19 +1,19 @@
 it("should load nested commons chunk", function(done) {
 	require.ensure(["./a"], function(require) {
-		require("./a").should.be.eql("a");
+		expect(require("./a")).toBe("a");
 		var counter = 0;
 		require.ensure(["./b", "./c"], function(require) {
-			require("./b").should.be.eql("b");
-			require("./c").should.be.eql("c");
+			expect(require("./b")).toBe("b");
+			expect(require("./c")).toBe("c");
 			if(++counter == 3) done();
 		});
 		require.ensure(["./b", "./d"], function(require) {
-			require("./b").should.be.eql("b");
-			require("./d").should.be.eql("d");
+			expect(require("./b")).toBe("b");
+			expect(require("./d")).toBe("d");
 			if(++counter == 3) done();
 		});
 		require.ensure(["./b"], function(require) {
-			require("./b").should.be.eql("b");
+			expect(require("./b")).toBe("b");
 			if(++counter == 3) done();
 		});
 	});

--- a/test/configCases/async-commons-chunk/simple/index.js
+++ b/test/configCases/async-commons-chunk/simple/index.js
@@ -1,22 +1,22 @@
 it("should load the full async commons", function(done) {
 	require.ensure(["./a"], function(require) {
-		require("./a").should.be.eql("a");
+		expect(require("./a")).toBe("a");
 		done();
 	});
 });
 
 it("should load a chunk with async commons (AMD)", function(done) {
 	require(["./a", "./b"], function(a, b) {
-		a.should.be.eql("a");
-		b.should.be.eql("b");
+		expect(a).toBe("a");
+		expect(b).toBe("b");
 		done();
 	});
 });
 
 it("should load a chunk with async commons (require.ensure)", function(done) {
 	require.ensure([], function(require) {
-		require("./a").should.be.eql("a");
-		require("./c").should.be.eql("c");
+		expect(require("./a")).toBe("a");
+		expect(require("./c")).toBe("c");
 		done();
 	});
 });

--- a/test/configCases/code-generation/require-context-id/index.js
+++ b/test/configCases/code-generation/require-context-id/index.js
@@ -1,5 +1,5 @@
 it("should escape require.context id correctly", function() {
 	var context = require.context("./folder");
 	expect(context("./a")).toBe("a");
-	context.id.should.be.type("string");
+	expect(context.id).toBeTypeOf("string");
 });

--- a/test/configCases/code-generation/require-context-id/index.js
+++ b/test/configCases/code-generation/require-context-id/index.js
@@ -1,5 +1,5 @@
 it("should escape require.context id correctly", function() {
 	var context = require.context("./folder");
-	context("./a").should.be.eql("a");
+	expect(context("./a")).toBe("a");
 	context.id.should.be.type("string");
 });

--- a/test/configCases/code-generation/use-strict/index.js
+++ b/test/configCases/code-generation/use-strict/index.js
@@ -15,7 +15,7 @@ it("should include only one use strict per module", function() {
 		match = regExp.exec(source);
 	}
 
-	matches.should.be.eql([
+	expect(matches).toEqual([
 		"__webpack_require__.r(__webpack_exports__);",
 		"/* unused harmony default export */ var _unused_webpack_default_export = (\"a\");",
 		"__webpack_require__.r(__webpack_exports__);",

--- a/test/configCases/commons-chunk-plugin/correct-order/index.js
+++ b/test/configCases/commons-chunk-plugin/correct-order/index.js
@@ -3,11 +3,11 @@ require("should");
 var a = require("./a");
 
 it("should run", function() {
-	a.should.be.eql("a");
+	expect(a).toBe("a");
 });
 
 var mainModule = require.main;
 
 it("should be main", function() {
-	mainModule.should.be.eql(module);
+	expect(mainModule).toBe(module);
 });

--- a/test/configCases/commons-chunk-plugin/hot-multi/first.js
+++ b/test/configCases/commons-chunk-plugin/hot-multi/first.js
@@ -4,5 +4,5 @@ require("./common");
 
 it("should have the correct main flag for multi first module", function() {
 	var multiModule = __webpack_require__.c[module.parents[0]];
-	multiModule.hot._main.should.be.eql(true);
+	expect(multiModule.hot._main).toBe(true);
 });

--- a/test/configCases/commons-chunk-plugin/hot-multi/second.js
+++ b/test/configCases/commons-chunk-plugin/hot-multi/second.js
@@ -4,5 +4,5 @@ require("./common");
 
 it("should have the correct main flag for multi second module", function() {
 	var multiModule = __webpack_require__.c[module.parents[0]];
-	multiModule.hot._main.should.be.eql(true);
+	expect(multiModule.hot._main).toBe(true);
 });

--- a/test/configCases/commons-chunk-plugin/hot-multi/vendor.js
+++ b/test/configCases/commons-chunk-plugin/hot-multi/vendor.js
@@ -4,5 +4,5 @@ module.exports = "vendor";
 
 it("should have the correct main flag for multi vendor module", function() {
 	var multiModule = __webpack_require__.c[module.parents[0]];
-	multiModule.hot._main.should.be.eql(true);
+	expect(multiModule.hot._main).toBe(true);
 });

--- a/test/configCases/commons-chunk-plugin/hot/index.js
+++ b/test/configCases/commons-chunk-plugin/hot/index.js
@@ -2,10 +2,10 @@ require("should");
 
 it("should have the correct main flag", function() {
 	var a = require("./vendor");
-	a._main.should.be.eql(false);
-	module.hot._main.should.be.eql(true);
+	expect(a._main).toBe(false);
+	expect(module.hot._main).toBe(true);
 });
 
 it("should be main", function() {
-	require.main.should.be.eql(module);
+	expect(require.main).toBe(module);
 });

--- a/test/configCases/commons-chunk-plugin/inverted-order/index.js
+++ b/test/configCases/commons-chunk-plugin/inverted-order/index.js
@@ -3,11 +3,11 @@ require("should");
 var a = require("./a");
 
 it("should run", function() {
-	a.should.be.eql("a");
+	expect(a).toBe("a");
 });
 
 var mainModule = require.main;
 
 it("should be main", function() {
-	mainModule.should.be.eql(module);
+	expect(mainModule).toBe(module);
 });

--- a/test/configCases/commons-chunk-plugin/library/index.js
+++ b/test/configCases/commons-chunk-plugin/library/index.js
@@ -1,4 +1,3 @@
-require("should");
 require.include("external1");
 require.ensure([], function() {
 	require.include("external2");
@@ -6,7 +5,7 @@ require.ensure([], function() {
 
 it("should have externals in main file", function() {
 	var a = require("./a");
-	a.vendor.should.containEql("require(\"external0\")");
-	a.main.should.containEql("require(\"external1\")");
-	a.main.should.containEql("require(\"external2\")");
+	expect(a.vendor).toMatch("require(\"external0\")");
+	expect(a.main).toMatch("require(\"external1\")");
+	expect(a.main).toMatch("require(\"external2\")");
 });

--- a/test/configCases/commons-chunk-plugin/move-entry/index.js
+++ b/test/configCases/commons-chunk-plugin/move-entry/index.js
@@ -1,5 +1,3 @@
-require("should");
-
 it("should not be moved", function() {
-	new Error().stack.should.not.match(/webpackBootstrap/);
+	expect(new Error().stack).not.toMatch(/webpackBootstrap/);
 });

--- a/test/configCases/commons-chunk-plugin/move-to-grandparent/index.js
+++ b/test/configCases/commons-chunk-plugin/move-to-grandparent/index.js
@@ -3,8 +3,8 @@ it("should correctly include indirect children in common chunk", function(done) 
 		import('./pageA'),
 		import('./pageB').then(m => m.default)
 	]).then((imports) => {
-		imports[0].default.should.be.eql("reuse");
-		imports[1].default.should.be.eql("reuse");
+		expect(imports[0].default).toBe("reuse");
+		expect(imports[1].default).toBe("reuse");
 		done();
 	}).catch(e => {
 		done(e);

--- a/test/configCases/commons-chunk-plugin/move-to-grandparent/second.js
+++ b/test/configCases/commons-chunk-plugin/move-to-grandparent/second.js
@@ -1,6 +1,6 @@
 it("should handle indirect children with multiple parents correctly", function(done) {
   import('./pageB').then(b => {
-expect(    b.default).toBe("reuse");
+    expect(b.default).toBe("reuse");
     done()
   }).catch(e => {
 		done();

--- a/test/configCases/commons-chunk-plugin/move-to-grandparent/second.js
+++ b/test/configCases/commons-chunk-plugin/move-to-grandparent/second.js
@@ -1,6 +1,6 @@
 it("should handle indirect children with multiple parents correctly", function(done) {
   import('./pageB').then(b => {
-    b.default.should.be.eql("reuse");
+expect(    b.default).toBe("reuse");
     done()
   }).catch(e => {
 		done();

--- a/test/configCases/commons-chunk-plugin/simple/index.js
+++ b/test/configCases/commons-chunk-plugin/simple/index.js
@@ -2,9 +2,9 @@ require("should");
 
 it("should run", function() {
 	var a = require("./a");
-	a.should.be.eql("a");
+	expect(a).toBe("a");
 });
 
 it("should be main", function() {
-	require.main.should.be.eql(module);
+	expect(require.main).toBe(module);
 });

--- a/test/configCases/context-exclusion/simple/index.js
+++ b/test/configCases/context-exclusion/simple/index.js
@@ -9,12 +9,9 @@ it("should not exclude paths not matching the exclusion pattern", function() {
 });
 
 it("should exclude paths/files matching the exclusion pattern", function() {
-		(() => requireInContext("dont")).
-			should.throw(/Cannot find module ".\/dont"/);
+		expect(() => requireInContext("dont")).toThrowError(/Cannot find module ".\/dont"/);
 
-		(() => requireInContext("dont-check-here/file")).
-			should.throw(/Cannot find module ".\/dont-check-here\/file"/);
+		expect(() => requireInContext("dont-check-here/file")).toThrowError(/Cannot find module ".\/dont-check-here\/file"/);
 
-		(() => requireInContext("check-here/dont-check-here/file")).
-			should.throw(/Cannot find module ".\/check-here\/dont-check-here\/file"/);
+		expect(() => requireInContext("check-here/dont-check-here/file")).toThrowError(/Cannot find module ".\/check-here\/dont-check-here\/file"/);
 });

--- a/test/configCases/context-exclusion/simple/index.js
+++ b/test/configCases/context-exclusion/simple/index.js
@@ -3,9 +3,9 @@ function requireInContext(someVariable) {
 }
 
 it("should not exclude paths not matching the exclusion pattern", function() {
-	requireInContext("file").should.be.eql("thats good");
-	requireInContext("check-here/file").should.be.eql("thats good");
-	requireInContext("check-here/check-here/file").should.be.eql("thats good");
+	expect(requireInContext("file")).toBe("thats good");
+	expect(requireInContext("check-here/file")).toBe("thats good");
+	expect(requireInContext("check-here/check-here/file")).toBe("thats good");
 });
 
 it("should exclude paths/files matching the exclusion pattern", function() {

--- a/test/configCases/context-replacement/System.import/index.js
+++ b/test/configCases/context-replacement/System.import/index.js
@@ -1,6 +1,6 @@
 it("should replace a async context with a manual map", function() {
 	var a = "a";
 	return import(a).then(function(a) {
-		a.should.be.eql({ default: "b" });
+		expect(a).toEqual({ default: "b" });
 	});
 });

--- a/test/configCases/context-replacement/a/index.js
+++ b/test/configCases/context-replacement/a/index.js
@@ -5,7 +5,7 @@ it("should replace a context with a new resource and reqExp", function(done) {
 		});
 	}
 	rqInContext("replaced", function(r) {
-		r.should.be.eql("ok");
+		expect(r).toBe("ok");
 		done();
 	});
 });

--- a/test/configCases/context-replacement/b/index.js
+++ b/test/configCases/context-replacement/b/index.js
@@ -2,5 +2,5 @@ it("should replace a context with a new regExp", function() {
 	function rqInContext(x) {
 		return require(x);
 	}
-	rqInContext("./only-this").should.be.eql("ok");
+	expect(rqInContext("./only-this")).toBe("ok");
 });

--- a/test/configCases/context-replacement/c/index.js
+++ b/test/configCases/context-replacement/c/index.js
@@ -7,7 +7,7 @@ it("should replace a context with a manual map", function() {
 	expect(rqInContext("./c")).toBe("b");
 	expect(rqInContext("d")).toBe("d");
 	expect(rqInContext("./d")).toBe("d");
-	(function() {
+	(expect(function() {
 		rqInContext("module-b")
-	}.should.throw());
+	}).toThrowError());
 });

--- a/test/configCases/context-replacement/c/index.js
+++ b/test/configCases/context-replacement/c/index.js
@@ -2,11 +2,11 @@ it("should replace a context with a manual map", function() {
 	function rqInContext(x) {
 		return require(x);
 	}
-	rqInContext("a").should.be.eql("a");
-	rqInContext("b").should.be.eql("b");
-	rqInContext("./c").should.be.eql("b");
-	rqInContext("d").should.be.eql("d");
-	rqInContext("./d").should.be.eql("d");
+	expect(rqInContext("a")).toBe("a");
+	expect(rqInContext("b")).toBe("b");
+	expect(rqInContext("./c")).toBe("b");
+	expect(rqInContext("d")).toBe("d");
+	expect(rqInContext("./d")).toBe("d");
 	(function() {
 		rqInContext("module-b")
 	}.should.throw());

--- a/test/configCases/context-replacement/d/index.js
+++ b/test/configCases/context-replacement/d/index.js
@@ -2,7 +2,7 @@ it("should replace a context with resource query and manual map", function() {
 	function rqInContext(x) {
 		return require(x);
 	}
-	rqInContext("a").should.be.eql({
+	expect(rqInContext("a")).toEqual({
 		resourceQuery: "?cats=meow",
 		query: "?lions=roar",
 		prev: "module.exports = \"a\";\n",

--- a/test/configCases/custom-hash-function/xxhash/index.js
+++ b/test/configCases/custom-hash-function/xxhash/index.js
@@ -2,7 +2,7 @@ it("should have unique ids", function () {
 	var ids = [];
 	for(var i = 1; i <= 15; i++) {
 		var id = require("./files/file" + i + ".js");
-		ids.indexOf(id).should.be.eql(-1);
+		expect(ids.indexOf(id)).toBe(-1);
 		ids.push(id);
 	}
 });

--- a/test/configCases/delegated-hash/simple/index.js
+++ b/test/configCases/delegated-hash/simple/index.js
@@ -1,7 +1,7 @@
 it("should delegate the modules", function() {
-	require("./a").should.be.eql("a");
-	require("./loader!./b").should.be.eql("b");
-	require("./dir/c").should.be.eql("c");
-	require("./d").should.be.eql("d");
-	require("./e").should.be.eql("e");
+	expect(require("./a")).toBe("a");
+	expect(require("./loader!./b")).toBe("b");
+	expect(require("./dir/c")).toBe("c");
+	expect(require("./d")).toBe("d");
+	expect(require("./e")).toBe("e");
 });

--- a/test/configCases/delegated/simple/index.js
+++ b/test/configCases/delegated/simple/index.js
@@ -1,5 +1,5 @@
 it("should delegate the modules", function() {
-	require("./a").should.be.eql("a");
-	require("./loader!./b").should.be.eql("b");
-	require("./dir/c").should.be.eql("c");
+	expect(require("./a")).toBe("a");
+	expect(require("./loader!./b")).toBe("b");
+	expect(require("./dir/c")).toBe("c");
 });

--- a/test/configCases/dll-plugin/1-use-dll/index.js
+++ b/test/configCases/dll-plugin/1-use-dll/index.js
@@ -4,37 +4,37 @@ import { x1, y2 } from "./e";
 import { x2, y1 } from "dll/e";
 
 it("should load a module from dll", function() {
-	require("dll/a").should.be.eql("a");
+	expect(require("dll/a")).toBe("a");
 });
 
 it("should load a module of non-default type without extension from dll", function() {
-	require("dll/f").should.be.eql("f");
+	expect(require("dll/f")).toBe("f");
 });
 
 it("should load an async module from dll", function(done) {
 	require("dll/b")().then(function(c) {
-		c.should.be.eql({ default: "c" });
+		expect(c).toEqual({ default: "c" });
 		done();
 	}).catch(done);
 });
 
 it("should load an harmony module from dll (default export)", function() {
-	d.should.be.eql("d");
+	expect(d).toBe("d");
 });
 
 it("should load an harmony module from dll (star export)", function() {
-	x1.should.be.eql(123);
-	x2.should.be.eql(123);
-	y1.should.be.eql(456);
-	y2.should.be.eql(456);
+	expect(x1).toBe(123);
+	expect(x2).toBe(123);
+	expect(y1).toBe(456);
+	expect(y2).toBe(456);
 });
 
 it("should load a module with loader applied", function() {
-	require("dll/g.abc.js").should.be.eql("number");
+	expect(require("dll/g.abc.js")).toBe("number");
 });
 
 it("should give modules the correct ids", function() {
-	Object.keys(__webpack_modules__).filter(m => !m.startsWith("../..")).should.be.eql([
+	Object.keys(__webpack_modules__).filter(m =>expect( !m.startsWith("../.."))).toEqual([
 		"./index.js",
 		"dll-reference ../0-create-dll/dll.js",
 		"dll/a.js",

--- a/test/configCases/dll-plugin/1-use-dll/index.js
+++ b/test/configCases/dll-plugin/1-use-dll/index.js
@@ -34,7 +34,7 @@ it("should load a module with loader applied", function() {
 });
 
 it("should give modules the correct ids", function() {
-	Object.keys(__webpack_modules__).filter(m =>expect( !m.startsWith("../.."))).toEqual([
+	expect(Object.keys(__webpack_modules__).filter(m => !m.startsWith("../.."))).toEqual([
 		"./index.js",
 		"dll-reference ../0-create-dll/dll.js",
 		"dll/a.js",

--- a/test/configCases/dll-plugin/2-use-dll-without-scope/index.js
+++ b/test/configCases/dll-plugin/2-use-dll-without-scope/index.js
@@ -4,37 +4,37 @@ import { x1, y2 } from "./e";
 import { x2, y1 } from "../0-create-dll/e";
 
 it("should load a module from dll", function() {
-	require("../0-create-dll/a").should.be.eql("a");
+	expect(require("../0-create-dll/a")).toBe("a");
 });
 
 it("should load a module of non-default type without extension from dll", function() {
-	require("../0-create-dll/f").should.be.eql("f");
+	expect(require("../0-create-dll/f")).toBe("f");
 });
 
 it("should load an async module from dll", function(done) {
 	require("../0-create-dll/b")().then(function(c) {
-		c.should.be.eql({ default: "c" });
+		expect(c).toEqual({ default: "c" });
 		done();
 	}).catch(done);
 });
 
 it("should load an harmony module from dll (default export)", function() {
-	d.should.be.eql("d");
+	expect(d).toBe("d");
 });
 
 it("should load an harmony module from dll (star export)", function() {
-	x1.should.be.eql(123);
-	x2.should.be.eql(123);
-	y1.should.be.eql(456);
-	y2.should.be.eql(456);
+	expect(x1).toBe(123);
+	expect(x2).toBe(123);
+	expect(y1).toBe(456);
+	expect(y2).toBe(456);
 });
 
 it("should load a module with loader applied", function() {
-	require("../0-create-dll/g.abc.js").should.be.eql("number");
+	expect(require("../0-create-dll/g.abc.js")).toBe("number");
 });
 
 it("should give modules the correct ids", function() {
-	Object.keys(__webpack_modules__).filter(m => !m.startsWith("../..")).should.be.eql([
+	Object.keys(__webpack_modules__).filter(m =>expect( !m.startsWith("../.."))).toEqual([
 		"../0-create-dll/a.js",
 		"../0-create-dll/b.js",
 		"../0-create-dll/d.js",

--- a/test/configCases/dll-plugin/2-use-dll-without-scope/index.js
+++ b/test/configCases/dll-plugin/2-use-dll-without-scope/index.js
@@ -34,7 +34,7 @@ it("should load a module with loader applied", function() {
 });
 
 it("should give modules the correct ids", function() {
-	Object.keys(__webpack_modules__).filter(m =>expect( !m.startsWith("../.."))).toEqual([
+	expect(Object.keys(__webpack_modules__).filter(m => !m.startsWith("../.."))).toEqual([
 		"../0-create-dll/a.js",
 		"../0-create-dll/b.js",
 		"../0-create-dll/d.js",

--- a/test/configCases/dll-plugin/3-use-dll-with-hashid/index.js
+++ b/test/configCases/dll-plugin/3-use-dll-with-hashid/index.js
@@ -4,29 +4,29 @@ import { x1, y2 } from "./e";
 import { x2, y1 } from "../0-create-dll/e";
 
 it("should load a module from dll", function() {
-	require("../0-create-dll/a").should.be.eql("a");
+	expect(require("../0-create-dll/a")).toBe("a");
 });
 
 it("should load an async module from dll", function(done) {
 	require("../0-create-dll/b")().then(function(c) {
-		c.should.be.eql({ default: "c" });
+		expect(c).toEqual({ default: "c" });
 		done();
 	}).catch(done);
 });
 
 it("should load an harmony module from dll (default export)", function() {
-	d.should.be.eql("d");
+	expect(d).toBe("d");
 });
 
 it("should load an harmony module from dll (star export)", function() {
-	x1.should.be.eql(123);
-	x2.should.be.eql(123);
-	y1.should.be.eql(456);
-	y2.should.be.eql(456);
+	expect(x1).toBe(123);
+	expect(x2).toBe(123);
+	expect(y1).toBe(456);
+	expect(y2).toBe(456);
 });
 
 it("should load a module with loader applied", function() {
-	require("../0-create-dll/g.abc.js").should.be.eql("number");
+	expect(require("../0-create-dll/g.abc.js")).toBe("number");
 });
 
 

--- a/test/configCases/entry/issue-1068/test.js
+++ b/test/configCases/entry/issue-1068/test.js
@@ -1,7 +1,7 @@
 var order = global.order;
 delete global.order;
 it("should run the modules in the correct order", function() {
-	order.should.be.eql([
+	expect(order).toEqual([
 		"a",
 		"b",
 		"c",

--- a/test/configCases/errors/multi-entry-missing-module/index.js
+++ b/test/configCases/errors/multi-entry-missing-module/index.js
@@ -2,9 +2,9 @@ it("Should use WebpackMissingModule when module is missing with multiple entry s
   var fs = require("fs");
   var path = require("path");
   var source = fs.readFileSync(path.join(__dirname, "b.js"), "utf-8");
-  source.should.containEql("!(function webpackMissingModule() { var e = new Error(\"Cannot find module \\\"./intentionally-missing-module.js\\\"\"); e.code = 'MODULE_NOT_FOUND'; throw e; }());");
+  expect(source).toMatch("!(function webpackMissingModule() { var e = new Error(\"Cannot find module \\\"./intentionally-missing-module.js\\\"\"); e.code = 'MODULE_NOT_FOUND'; throw e; }());");
 
-  (function() {
+  expect(function() {
     require("./intentionally-missing-module");
-  }).should.throw("Cannot find module \"./intentionally-missing-module\"");
+  }).toThrowError("Cannot find module \"./intentionally-missing-module\"");
 });

--- a/test/configCases/externals/externals-in-chunk/index.js
+++ b/test/configCases/externals/externals-in-chunk/index.js
@@ -1,9 +1,9 @@
 it("should move externals in chunks into entry chunk", function(done) {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename, "utf-8");
-	source.should.containEql("1+" + (1+1));
-	source.should.containEql("3+" + (2+2));
-	source.should.containEql("5+" + (3+3));
+	expect(source).toMatch("1+" + (1+1));
+	expect(source).toMatch("3+" + (2+2));
+	expect(source).toMatch("5+" + (3+3));
 
 	import("./chunk").then(function(chunk) {
 		expect(chunk.default.a).toBe(3);

--- a/test/configCases/externals/externals-in-chunk/index.js
+++ b/test/configCases/externals/externals-in-chunk/index.js
@@ -6,11 +6,11 @@ it("should move externals in chunks into entry chunk", function(done) {
 	source.should.containEql("5+" + (3+3));
 
 	import("./chunk").then(function(chunk) {
-		chunk.default.a.should.be.eql(3);
+		expect(chunk.default.a).toBe(3);
 		chunk.default.b.then(function(chunk2) {
-			chunk2.default.should.be.eql(7);
+			expect(chunk2.default).toBe(7);
 			import("external3").then(function(ex) {
-				ex.default.should.be.eql(11);
+				expect(ex.default).toBe(11);
 				done();
 			});
 		});

--- a/test/configCases/externals/externals-in-commons-chunk/index.js
+++ b/test/configCases/externals/externals-in-commons-chunk/index.js
@@ -1,18 +1,17 @@
 it("should not move externals into the commons chunk", function() {
-	require("should");
-	var fs = require("fs");
-	var source1 = fs.readFileSync(__dirname + "/main.js", "utf-8");
-	var source2 = fs.readFileSync(__dirname + "/other.js", "utf-8");
-	var source3 = fs.readFileSync(__dirname + "/common.js", "utf-8");
-	source1.should.containEql("1+" + (1+1));
-	source1.should.containEql("3+" + (2+2));
-	source2.should.containEql("1+" + (1+1));
-	source2.should.containEql("5+" + (3+3));
-	source3.should.not.containEql("1+" + (1+1));
-	source3.should.not.containEql("3+" + (2+2));
-	source3.should.not.containEql("5+" + (3+3));
+    var fs = require("fs");
+    var source1 = fs.readFileSync(__dirname + "/main.js", "utf-8");
+    var source2 = fs.readFileSync(__dirname + "/other.js", "utf-8");
+    var source3 = fs.readFileSync(__dirname + "/common.js", "utf-8");
+    expect(source1).toMatch("1+" + (1+1));
+    expect(source1).toMatch("3+" + (2+2));
+    expect(source2).toMatch("1+" + (1+1));
+    expect(source2).toMatch("5+" + (3+3));
+    expect(source3).not.toMatch("1+" + (1+1));
+    expect(source3).not.toMatch("3+" + (2+2));
+    expect(source3).not.toMatch("5+" + (3+3));
 
-	require("external");
-	require("external2");
-	require("./module");
+    require("external");
+    require("external2");
+    require("./module");
 });

--- a/test/configCases/externals/harmony/index.js
+++ b/test/configCases/externals/harmony/index.js
@@ -1,5 +1,5 @@
 import external from "external";
 
 it("should harmony import a dependency", function() {
-	external.should.be.eql("abc");
+	expect(external).toBe("abc");
 });

--- a/test/configCases/externals/non-umd-externals-umd/index.js
+++ b/test/configCases/externals/non-umd-externals-umd/index.js
@@ -4,7 +4,7 @@ var path = require("path");
 
 it("should correctly import a UMD external", function() {
 	var external = require("external0");
-	external.should.be.eql("module 0");
+	expect(external).toBe("module 0");
 });
 
 it("should contain `require()` statements for the UMD external", function() {
@@ -14,7 +14,7 @@ it("should contain `require()` statements for the UMD external", function() {
 
 it("should correctly import a non-UMD external", function() {
 	var external = require("external1");
-	external.should.be.eql("abc");
+	expect(external).toBe("abc");
 });
 
 it("should not contain `require()` statements for the non-UMD external", function() {

--- a/test/configCases/externals/non-umd-externals-umd/index.js
+++ b/test/configCases/externals/non-umd-externals-umd/index.js
@@ -1,4 +1,3 @@
-require("should");
 var fs = require("fs");
 var path = require("path");
 
@@ -9,7 +8,7 @@ it("should correctly import a UMD external", function() {
 
 it("should contain `require()` statements for the UMD external", function() {
 	var source = fs.readFileSync(path.join(__dirname, "bundle0.js"), "utf-8");
-	source.should.containEql("require(\"external0\")");
+	expect(source).toMatch("require(\"external0\")");
 });
 
 it("should correctly import a non-UMD external", function() {
@@ -19,5 +18,5 @@ it("should correctly import a non-UMD external", function() {
 
 it("should not contain `require()` statements for the non-UMD external", function() {
 	var source = fs.readFileSync(path.join(__dirname, "bundle0.js"), "utf-8");
-	source.should.not.containEql("require(\"'abc'\")");
+	expect(source).not.toMatch("require(\"'abc'\")");
 });

--- a/test/configCases/externals/non-umd-externals-umd2/index.js
+++ b/test/configCases/externals/non-umd-externals-umd2/index.js
@@ -4,7 +4,7 @@ var path = require("path");
 
 it("should correctly import a UMD2 external", function() {
 	var external = require("external0");
-	external.should.be.eql("module 0");
+	expect(external).toBe("module 0");
 });
 
 it("should contain `require()` statements for the UMD2 external", function() {
@@ -14,7 +14,7 @@ it("should contain `require()` statements for the UMD2 external", function() {
 
 it("should correctly import a non-UMD2 external", function() {
 	var external = require("external1");
-	external.should.be.eql("abc");
+	expect(external).toBe("abc");
 });
 
 it("should not contain `require()` statements for the non-UMD2 external", function() {

--- a/test/configCases/externals/non-umd-externals-umd2/index.js
+++ b/test/configCases/externals/non-umd-externals-umd2/index.js
@@ -1,4 +1,3 @@
-require("should");
 var fs = require("fs");
 var path = require("path");
 
@@ -9,7 +8,7 @@ it("should correctly import a UMD2 external", function() {
 
 it("should contain `require()` statements for the UMD2 external", function() {
 	var source = fs.readFileSync(path.join(__dirname, "bundle0.js"), "utf-8");
-	source.should.containEql("require(\"external0\")");
+	expect(source).toMatch("require(\"external0\")");
 });
 
 it("should correctly import a non-UMD2 external", function() {
@@ -19,5 +18,5 @@ it("should correctly import a non-UMD2 external", function() {
 
 it("should not contain `require()` statements for the non-UMD2 external", function() {
 	var source = fs.readFileSync(path.join(__dirname, "bundle0.js"), "utf-8");
-	source.should.not.containEql("require(\"'abc'\")");
+	expect(source).not.toMatch("require(\"'abc'\")");
 });

--- a/test/configCases/externals/optional-externals-cjs/index.js
+++ b/test/configCases/externals/optional-externals-cjs/index.js
@@ -2,7 +2,7 @@ it("should not fail on optional externals", function() {
 	try {
 		require("external");
 	} catch(e) {
-		e.should.be.instanceof(Error);
+		expect(e).toBeInstanceOf(Error);
 		expect(e.code).toBe("MODULE_NOT_FOUND");
 		return;
 	}

--- a/test/configCases/externals/optional-externals-cjs/index.js
+++ b/test/configCases/externals/optional-externals-cjs/index.js
@@ -3,7 +3,7 @@ it("should not fail on optional externals", function() {
 		require("external");
 	} catch(e) {
 		e.should.be.instanceof(Error);
-		e.code.should.be.eql("MODULE_NOT_FOUND");
+		expect(e.code).toBe("MODULE_NOT_FOUND");
 		return;
 	}
 	throw new Error("It doesn't fail");

--- a/test/configCases/externals/optional-externals-root/index.js
+++ b/test/configCases/externals/optional-externals-root/index.js
@@ -2,7 +2,7 @@ it("should not fail on optional externals", function() {
 	try {
 		require("external");
 	} catch(e) {
-		e.should.be.instanceof(Error);
+		expect(e).toBeInstanceOf(Error);
 		expect(e.code).toBe("MODULE_NOT_FOUND");
 		return;
 	}

--- a/test/configCases/externals/optional-externals-root/index.js
+++ b/test/configCases/externals/optional-externals-root/index.js
@@ -3,7 +3,7 @@ it("should not fail on optional externals", function() {
 		require("external");
 	} catch(e) {
 		e.should.be.instanceof(Error);
-		e.code.should.be.eql("MODULE_NOT_FOUND");
+		expect(e.code).toBe("MODULE_NOT_FOUND");
 		return;
 	}
 	throw new Error("It doesn't fail");

--- a/test/configCases/externals/optional-externals-umd/index.js
+++ b/test/configCases/externals/optional-externals-umd/index.js
@@ -2,7 +2,7 @@ it("should not fail on optional externals", function() {
 	try {
 		require("external");
 	} catch(e) {
-		e.should.be.instanceof(Error);
+		expect(e).toBeInstanceOf(Error);
 		expect(e.code).toBe("MODULE_NOT_FOUND");
 		return;
 	}

--- a/test/configCases/externals/optional-externals-umd/index.js
+++ b/test/configCases/externals/optional-externals-umd/index.js
@@ -3,7 +3,7 @@ it("should not fail on optional externals", function() {
 		require("external");
 	} catch(e) {
 		e.should.be.instanceof(Error);
-		e.code.should.be.eql("MODULE_NOT_FOUND");
+		expect(e.code).toBe("MODULE_NOT_FOUND");
 		return;
 	}
 	throw new Error("It doesn't fail");

--- a/test/configCases/externals/optional-externals-umd2-mixed/index.js
+++ b/test/configCases/externals/optional-externals-umd2-mixed/index.js
@@ -4,7 +4,7 @@ it("should not fail on optional externals", function() {
 		require("external");
 	} catch(e) {
 		e.should.be.instanceof(Error);
-		e.code.should.be.eql("MODULE_NOT_FOUND");
+		expect(e.code).toBe("MODULE_NOT_FOUND");
 		return;
 	}
 	throw new Error("It doesn't fail");

--- a/test/configCases/externals/optional-externals-umd2-mixed/index.js
+++ b/test/configCases/externals/optional-externals-umd2-mixed/index.js
@@ -3,7 +3,7 @@ it("should not fail on optional externals", function() {
 	try {
 		require("external");
 	} catch(e) {
-		e.should.be.instanceof(Error);
+		expect(e).toBeInstanceOf(Error);
 		expect(e.code).toBe("MODULE_NOT_FOUND");
 		return;
 	}

--- a/test/configCases/externals/optional-externals-umd2/index.js
+++ b/test/configCases/externals/optional-externals-umd2/index.js
@@ -2,7 +2,7 @@ it("should not fail on optional externals", function() {
 	try {
 		require("external");
 	} catch(e) {
-		e.should.be.instanceof(Error);
+		expect(e).toBeInstanceOf(Error);
 		expect(e.code).toBe("MODULE_NOT_FOUND");
 		return;
 	}

--- a/test/configCases/externals/optional-externals-umd2/index.js
+++ b/test/configCases/externals/optional-externals-umd2/index.js
@@ -3,7 +3,7 @@ it("should not fail on optional externals", function() {
 		require("external");
 	} catch(e) {
 		e.should.be.instanceof(Error);
-		e.code.should.be.eql("MODULE_NOT_FOUND");
+		expect(e.code).toBe("MODULE_NOT_FOUND");
 		return;
 	}
 	throw new Error("It doesn't fail");

--- a/test/configCases/filename-template/module-filename-template/index.js
+++ b/test/configCases/filename-template/module-filename-template/index.js
@@ -2,7 +2,7 @@ it("should include test.js in SourceMap", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	expect(map.sources).toMatch("dummy:///./test.js");
+	expect(map.sources).toContain("dummy:///./test.js");
 });
 
 require.include("./test.js");

--- a/test/configCases/filename-template/module-filename-template/index.js
+++ b/test/configCases/filename-template/module-filename-template/index.js
@@ -2,7 +2,7 @@ it("should include test.js in SourceMap", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	map.sources.should.containEql("dummy:///./test.js");
+	expect(map.sources).toMatch("dummy:///./test.js");
 });
 
 require.include("./test.js");

--- a/test/configCases/hash-length/hashed-module-ids/index.js
+++ b/test/configCases/hash-length/hashed-module-ids/index.js
@@ -2,7 +2,7 @@ it("should have unique ids", function () {
 	var ids = [];
 	for(var i = 1; i <= 15; i++) {
 		var id = require("./files/file" + i + ".js");
-		ids.indexOf(id).should.be.eql(-1);
+		expect(ids.indexOf(id)).toBe(-1);
 		ids.push(id);
 	}
 });

--- a/test/configCases/hash-length/output-filename/test.config.js
+++ b/test/configCases/hash-length/output-filename/test.config.js
@@ -1,5 +1,4 @@
 var fs = require("fs");
-require("should");
 
 var findFile = function(files, regex) {
 	return files.find(function(file) {
@@ -10,7 +9,7 @@ var findFile = function(files, regex) {
 };
 
 var verifyFilenameLength = function(filename, expectedNameLength) {
-	filename.should.match(new RegExp("^.{" + expectedNameLength + "}$"));
+	expect(filename).toMatch(new RegExp("^.{" + expectedNameLength + "}$"));
 };
 
 module.exports = {

--- a/test/configCases/ignore/only-resource-context/test.js
+++ b/test/configCases/ignore/only-resource-context/test.js
@@ -6,16 +6,16 @@ it("should ignore ignored resources", function() {
 		require("./src/" + mod);
 	};
 
-	(function() {
+	expect(function() {
 		folderBContext("ignored-module");
-	}).should.throw();
+	}).toThrowError();
 });
 it("should not ignore resources that do not match", function() {
 	const folderBContext = function(mod) {
 		require("./src/" + mod);
 	};
 
-	(function() {
+	expect(function() {
 		folderBContext("normal-module");
-	}).should.not.throw();
+	}).not.toThrowError();
 });

--- a/test/configCases/ignore/only-resource/test.js
+++ b/test/configCases/ignore/only-resource/test.js
@@ -2,12 +2,12 @@
 "use strict";
 
 it("should ignore ignored resources", function() {
-	(function() {
+	expect(function() {
 		require("./ignored-module");
-	}).should.throw();
+	}).toThrowError();
 });
 it("should not ignore resources that do not match", function() {
-	(function() {
+	expect(function() {
 		require("./normal-module");
-	}).should.not.throw();
+	}).not.toThrowError();
 });

--- a/test/configCases/ignore/resource-and-context-contextmodule/test.js
+++ b/test/configCases/ignore/resource-and-context-contextmodule/test.js
@@ -6,9 +6,9 @@ it("should ignore context modules that match resource regex and context", functi
 		require("./folder-b/" + mod);
 	};
 
-	(function() {
+	expect(function() {
 		folderBContext("normal-module");
-	}).should.throw();
+	}).toThrowError();
 });
 
 it("should not ignore context modules that dont match the resource", function() {
@@ -16,9 +16,9 @@ it("should not ignore context modules that dont match the resource", function() 
 		require("./folder-b/" + mod);
 	};
 
-	(function() {
+	expect(function() {
 		folderBContext("only-context-match");
-	}).should.not.throw();
+	}).not.toThrowError();
 });
 
 it("should not ignore context modules that dont match the context", function() {
@@ -26,10 +26,10 @@ it("should not ignore context modules that dont match the context", function() {
 		require("./folder-a/" + mod);
 	};
 
-	(function() {
+	expect(function() {
 		folderBContext("normal-module");
-	}).should.not.throw();
-	(function() {
+	}).not.toThrowError();
+	expect(function() {
 		folderBContext("ignored-module");
-	}).should.not.throw();
+	}).not.toThrowError();
 });

--- a/test/configCases/ignore/resource-and-context/test.js
+++ b/test/configCases/ignore/resource-and-context/test.js
@@ -2,19 +2,19 @@
 "use strict";
 
 it("should ignore resources that match resource regex and context", function() {
-	(function() {
+	expect(function() {
 		require("./folder-b/normal-module");
-	}).should.throw();
+	}).toThrowError();
 });
 
 it("should not ignore resources that match resource but not context", function() {
-	(function() {
+	expect(function() {
 		require("./folder-a/normal-module");
-	}).should.not.throw();
+	}).not.toThrowError();
 });
 
 it("should not ignore resources that do not match resource but do match context", function() {
-	(function() {
+	expect(function() {
 		require("./folder-b/only-context-match");
-	}).should.not.throw();
+	}).not.toThrowError();
 });

--- a/test/configCases/library/1-use-library/default-test.js
+++ b/test/configCases/library/1-use-library/default-test.js
@@ -2,6 +2,6 @@ import d from "library";
 var data = require("library");
 
 it("should get default export from library (" + NAME + ")", function() {
-	data.should.be.eql("default-value");
-	d.should.be.eql("default-value");
+	expect(data).toBe("default-value");
+	expect(d).toBe("default-value");
 });

--- a/test/configCases/library/1-use-library/global-test.js
+++ b/test/configCases/library/1-use-library/global-test.js
@@ -1,7 +1,7 @@
 var data = require("library");
 
 it("should be able get items from library (" + NAME + ")", function() {
-	data.should.have.property("default").be.eql("default-value");
-	data.should.have.property("a").be.eql("a");
-	data.should.have.property("b").be.eql("b");
+	expect(data).toHaveProperty("default", "default-value");
+	expect(data).toHaveProperty("a", "a");
+	expect(data).toHaveProperty("b", "b");
 });

--- a/test/configCases/library/1-use-library/index.js
+++ b/test/configCases/library/1-use-library/index.js
@@ -7,7 +7,7 @@ it("should be able to import hamorny exports from library (" + NAME + ")", funct
 	expect(b).toBe("b");
 	if(typeof TEST_EXTERNAL !== "undefined" && TEST_EXTERNAL) {
 		expect(external).toEqual(["external"]);
-		external.should.be.equal(require("external"));
+		expect(external).toBe(require("external"));
 	} else {
 		expect(external).toBe("non-external");
 	}

--- a/test/configCases/library/1-use-library/index.js
+++ b/test/configCases/library/1-use-library/index.js
@@ -2,13 +2,13 @@ import d from "library";
 import { a, b, external } from "library";
 
 it("should be able to import hamorny exports from library (" + NAME + ")", function() {
-	d.should.be.eql("default-value");
-	a.should.be.eql("a");
-	b.should.be.eql("b");
+	expect(d).toBe("default-value");
+	expect(a).toBe("a");
+	expect(b).toBe("b");
 	if(typeof TEST_EXTERNAL !== "undefined" && TEST_EXTERNAL) {
-		external.should.be.eql(["external"]);
+		expect(external).toEqual(["external"]);
 		external.should.be.equal(require("external"));
 	} else {
-		external.should.be.eql("non-external");
+		expect(external).toBe("non-external");
 	}
 });

--- a/test/configCases/library/b/index.js
+++ b/test/configCases/library/b/index.js
@@ -4,8 +4,8 @@ it("should run", function() {
 
 it("should have exported", function(done) {
 	setTimeout(function() {
-		exported.object.should.be.eql(module.exports.object);
-		exported.second.should.be.eql(module.exports.second);
+		expect(exported.object).toBe(module.exports.object);
+		expect(exported.second).toBe(module.exports.second);
 		done();
 	}, 1);
 });

--- a/test/configCases/loaders/generate-ident/index.js
+++ b/test/configCases/loaders/generate-ident/index.js
@@ -1,6 +1,6 @@
 it("should correctly pass complex query object with remaining request", function() {
-	require("./a").should.be.eql("ok");
-	require("./b").should.be.eql("maybe");
-	require("./c").should.be.eql("yes");
-	require("./d").should.be.eql("ok");
+	expect(require("./a")).toBe("ok");
+	expect(require("./b")).toBe("maybe");
+	expect(require("./c")).toBe("yes");
+	expect(require("./d")).toBe("ok");
 });

--- a/test/configCases/loaders/hot-in-context/index.js
+++ b/test/configCases/loaders/hot-in-context/index.js
@@ -1,3 +1,3 @@
 it("should have hmr flag in loader context", function() {
-	require("./loader!").should.be.eql(!!module.hot);
+	expect(require("./loader!")).toBe(!!module.hot);
 });

--- a/test/configCases/loaders/issue-3320/index.js
+++ b/test/configCases/loaders/issue-3320/index.js
@@ -1,23 +1,23 @@
 it("should resolve aliased loader module with query", function() {
 	var foo = require('./a');
 
-	foo.should.be.eql("someMessage");
+	expect(foo).toBe("someMessage");
 });
 
 it("should favor explicit loader query over aliased query (options in rule)", function() {
 	var foo = require('./b');
 
-	foo.should.be.eql("someOtherMessage");
+	expect(foo).toBe("someOtherMessage");
 });
 
 it("should favor explicit loader query over aliased query (inline query in rule)", function() {
 	var foo = require('./b2');
 
-	foo.should.be.eql("someOtherMessage");
+	expect(foo).toBe("someOtherMessage");
 });
 
 it("should favor explicit loader query over aliased query (inline query in rule.use)", function() {
 	var foo = require('./b3');
 
-	foo.should.be.eql("someOtherMessage");
+	expect(foo).toBe("someOtherMessage");
 });

--- a/test/configCases/loaders/pre-post-loader/index.js
+++ b/test/configCases/loaders/pre-post-loader/index.js
@@ -1,6 +1,6 @@
 it("should apply pre and post loaders correctly", function() {
-	require("./a").should.be.eql("resource loader2 loader1 loader3");
-	require("!./a").should.be.eql("resource loader2 loader3");
-	require("!!./a").should.be.eql("resource");
-	require("-!./a").should.be.eql("resource loader3");
+	expect(require("./a")).toBe("resource loader2 loader1 loader3");
+	expect(require("!./a")).toBe("resource loader2 loader3");
+	expect(require("!!./a")).toBe("resource");
+	expect(require("-!./a")).toBe("resource loader3");
 });

--- a/test/configCases/loaders/remaining-request/index.js
+++ b/test/configCases/loaders/remaining-request/index.js
@@ -1,3 +1,3 @@
 it("should correctly pass complex query object with remaining request", function() {
-	require("./a").should.be.eql("ok");
+	expect(require("./a")).toBe("ok");
 });

--- a/test/configCases/no-parse/module.exports/index.js
+++ b/test/configCases/no-parse/module.exports/index.js
@@ -1,4 +1,4 @@
 it("should correctly export stuff from not parsed modules", function() {
-	require("./not-parsed-a").should.be.eql("ok");
-	require("./not-parsed-b").should.be.eql("ok");
+	expect(require("./not-parsed-a")).toBe("ok");
+	expect(require("./not-parsed-b")).toBe("ok");
 });

--- a/test/configCases/no-parse/no-parse-function/index.js
+++ b/test/configCases/no-parse/no-parse-function/index.js
@@ -1,4 +1,4 @@
 it("should correctly export stuff from not parsed modules", function() {
-	require("./not-parsed-a").should.be.eql("ok");
-	require("./not-parsed-b").should.be.eql("ok");
+	expect(require("./not-parsed-a")).toBe("ok");
+	expect(require("./not-parsed-b")).toBe("ok");
 });

--- a/test/configCases/parsing/context/index.js
+++ b/test/configCases/parsing/context/index.js
@@ -1,5 +1,5 @@
 it("should automatically create contexts", function() {
 	var template = "tmpl", templateFull = "./tmpl.js";
-	require("../../../cases/parsing/context/templates/templateLoader")(templateFull).should.be.eql("test template");
-	require("../../../cases/parsing/context/templates/templateLoaderIndirect")(templateFull).should.be.eql("test template");
+	expect(require("../../../cases/parsing/context/templates/templateLoader")(templateFull)).toBe("test template");
+	expect(require("../../../cases/parsing/context/templates/templateLoaderIndirect")(templateFull)).toBe("test template");
 });

--- a/test/configCases/parsing/extended-api/index.js
+++ b/test/configCases/parsing/extended-api/index.js
@@ -4,5 +4,5 @@ it("should have __webpack_hash__", function() {
 });
 it("should have __webpack_chunkname__", function() {
 	(typeof __webpack_chunkname__).should.be.type("string");
-	__webpack_chunkname__.should.be.eql('other');
+	expect(__webpack_chunkname__).toBe('other');
 });

--- a/test/configCases/parsing/extended-api/index.js
+++ b/test/configCases/parsing/extended-api/index.js
@@ -1,8 +1,8 @@
 it("should have __webpack_hash__", function() {
-	(typeof __webpack_hash__).should.be.type("string");
-	__webpack_hash__.should.match(/^[0-9a-f]{20}$/);
+	expect(typeof __webpack_hash__).toBeTypeOf("string");
+	expect(__webpack_hash__).toMatch(/^[0-9a-f]{20}$/);
 });
 it("should have __webpack_chunkname__", function() {
-	(typeof __webpack_chunkname__).should.be.type("string");
+	expect(typeof __webpack_chunkname__).toBeTypeOf("string");
 	expect(__webpack_chunkname__).toBe('other');
 });

--- a/test/configCases/parsing/harmony-global/index.js
+++ b/test/configCases/parsing/harmony-global/index.js
@@ -1,5 +1,4 @@
-require("should");
 it("should be able to use global in a harmony module", function() {
 	var x = require("./module1");
-	(x.default === global).should.be.ok();
+	expect(x.default === global).toBeTruthy();
 });

--- a/test/configCases/parsing/harmony-this-concat/index.js
+++ b/test/configCases/parsing/harmony-this-concat/index.js
@@ -13,7 +13,7 @@ it("should have this = undefined on imported non-strict functions", function() {
 	x
 	expect(B()).toBe("undefined");
 	x
-	abc.a().should.be.type("object");
+	expect(abc.a()).toMatchObject({});
 	x
 	var thing = abc.a();
 	expect(Object.keys(thing)).toEqual(["a", "b", "default"]);
@@ -25,9 +25,9 @@ import * as New from "./new";
 
 it("should be possible to use new correctly", function() {
 	x
-	new C().should.match({ok: true});
+	expect(new C()).toMatch({ok: true});
 	x
-	new C2().should.match({ok: true});
+	expect(new C2()).toMatch({ok: true});
 	x
-	new New.C().should.match({ok: true});
+	expect(new New.C()).toMatch({ok: true});
 });

--- a/test/configCases/parsing/harmony-this-concat/index.js
+++ b/test/configCases/parsing/harmony-this-concat/index.js
@@ -25,9 +25,9 @@ import * as New from "./new";
 
 it("should be possible to use new correctly", function() {
 	x
-	expect(new C()).toMatch({ok: true});
+	expect(new C()).toEqual({ok: true});
 	x
-	expect(new C2()).toMatch({ok: true});
+	expect(new C2()).toEqual({ok: true});
 	x
-	expect(new New.C()).toMatch({ok: true});
+	expect(new New.C()).toEqual({ok: true});
 });

--- a/test/configCases/parsing/harmony-this-concat/index.js
+++ b/test/configCases/parsing/harmony-this-concat/index.js
@@ -7,16 +7,16 @@ import * as abc from "./abc";
 function x() { throw new Error("should not be executed"); }
 it("should have this = undefined on imported non-strict functions", function() {
 	x
-	d().should.be.eql("undefined");
+	expect(d()).toBe("undefined");
 	x
-	a().should.be.eql("undefined");
+	expect(a()).toBe("undefined");
 	x
-	B().should.be.eql("undefined");
+	expect(B()).toBe("undefined");
 	x
 	abc.a().should.be.type("object");
 	x
 	var thing = abc.a();
-	Object.keys(thing).should.be.eql(["a", "b", "default"]);
+	expect(Object.keys(thing)).toEqual(["a", "b", "default"]);
 });
 
 import C2, { C } from "./new";

--- a/test/configCases/parsing/harmony-this/index.js
+++ b/test/configCases/parsing/harmony-this/index.js
@@ -34,7 +34,7 @@ it("should have this = undefined on imported non-strict functions", function() {
 	expect(abc.a()).toMatchObject({});
 	x
 	var thing = abc.a();
-	expect(Object.keys(thing)).toBe(Object.keys(abc));
+	expect(Object.keys(thing)).toEqual(Object.keys(abc));
 });
 
 import C2, { C } from "./new";
@@ -43,9 +43,9 @@ import * as New from "./new";
 
 it("should be possible to use new correctly", function() {
 	x
-	expect(new C()).toMatch({ok: true});
+	expect(new C()).toEqual({ok: true});
 	x
-	expect(new C2()).toMatch({ok: true});
+	expect(new C2()).toEqual({ok: true});
 	x
-	expect(new New.C()).toMatch({ok: true});
+	expect(new New.C()).toEqual({ok: true});
 });

--- a/test/configCases/parsing/harmony-this/index.js
+++ b/test/configCases/parsing/harmony-this/index.js
@@ -9,12 +9,12 @@ it("should have this = undefined on harmony modules", function() {
 	expect((typeof abc.that)).toBe("undefined");
 	expect((typeof returnThisArrow())).toBe("undefined");
 	expect((typeof abc.returnThisArrow())).toBe("undefined");
-	(function() {
+	expect(function() {
 		returnThisMember();
-	}).should.throw();
-	(function() {
+	}).toThrowError();
+	expect(function() {
 		abc.returnThisMember();
-	}).should.throw();
+	}).toThrowError();
 });
 
 it("should not break classes and functions", function() {
@@ -31,7 +31,7 @@ it("should have this = undefined on imported non-strict functions", function() {
 	x
 	expect(B()).toBe("undefined");
 	x
-	abc.a().should.be.type("object");
+	expect(abc.a()).toMatchObject({});
 	x
 	var thing = abc.a();
 	expect(Object.keys(thing)).toBe(Object.keys(abc));
@@ -43,9 +43,9 @@ import * as New from "./new";
 
 it("should be possible to use new correctly", function() {
 	x
-	new C().should.match({ok: true});
+	expect(new C()).toMatch({ok: true});
 	x
-	new C2().should.match({ok: true});
+	expect(new C2()).toMatch({ok: true});
 	x
-	new New.C().should.match({ok: true});
+	expect(new New.C()).toMatch({ok: true});
 });

--- a/test/configCases/parsing/harmony-this/index.js
+++ b/test/configCases/parsing/harmony-this/index.js
@@ -5,10 +5,10 @@ import d, {a, b as B, C as _C, D as _D, returnThisArrow, returnThisMember, that}
 import * as abc from "./abc";
 
 it("should have this = undefined on harmony modules", function() {
-	(typeof that).should.be.eql("undefined");
-	(typeof abc.that).should.be.eql("undefined");
-	(typeof returnThisArrow()).should.be.eql("undefined");
-	(typeof abc.returnThisArrow()).should.be.eql("undefined");
+	expect((typeof that)).toBe("undefined");
+	expect((typeof abc.that)).toBe("undefined");
+	expect((typeof returnThisArrow())).toBe("undefined");
+	expect((typeof abc.returnThisArrow())).toBe("undefined");
 	(function() {
 		returnThisMember();
 	}).should.throw();
@@ -18,23 +18,23 @@ it("should have this = undefined on harmony modules", function() {
 });
 
 it("should not break classes and functions", function() {
-	(new _C).foo().should.be.eql("bar");
-	(new _D).prop().should.be.eql("ok");
+	expect((new _C).foo()).toBe("bar");
+	expect((new _D).prop()).toBe("ok");
 });
 
 function x() { throw new Error("should not be executed"); }
 it("should have this = undefined on imported non-strict functions", function() {
 	x
-	d().should.be.eql("undefined");
+	expect(d()).toBe("undefined");
 	x
-	a().should.be.eql("undefined");
+	expect(a()).toBe("undefined");
 	x
-	B().should.be.eql("undefined");
+	expect(B()).toBe("undefined");
 	x
 	abc.a().should.be.type("object");
 	x
 	var thing = abc.a();
-	Object.keys(thing).should.be.eql(Object.keys(abc));
+	expect(Object.keys(thing)).toBe(Object.keys(abc));
 });
 
 import C2, { C } from "./new";

--- a/test/configCases/parsing/issue-336/index.js
+++ b/test/configCases/parsing/issue-336/index.js
@@ -1,4 +1,4 @@
 it("should provide a module to a free var in a var decl", function() {
 	var x = aaa.test;
-	x.should.be.eql("test");
+	expect(x).toBe("test");
 });

--- a/test/configCases/parsing/issue-4857/index.js
+++ b/test/configCases/parsing/issue-4857/index.js
@@ -23,7 +23,7 @@ it("should transpile unreachable branches", () => {
 	true ? count++ : import("NOT_REACHABLE");
 	false ? import("NOT_REACHABLE") : count++;
 
-	count.should.be.eql(6);
+	expect(count).toBe(6);
 });
 
 it("should not remove hoisted variable declarations", () => {

--- a/test/configCases/parsing/issue-4857/index.js
+++ b/test/configCases/parsing/issue-4857/index.js
@@ -55,7 +55,7 @@ it("should not remove hoisted variable declarations", () => {
 			var withVar;
 		}
 	}
-	(() => {
+	expect(() => {
 		a;
 		b;
 		c;
@@ -71,19 +71,19 @@ it("should not remove hoisted variable declarations", () => {
 		m;
 		n;
 		o;
-	}).should.not.throw();
-	(() => {
+	}).not.toThrowError();
+	expect(() => {
 		withVar;
-	}).should.throw();
+	}).toThrowError();
 });
 
 it("should not remove hoisted function declarations in loose mode", () => {
 	if(false) {
 		function funcDecl() {}
 	}
-	(() => {
+	expect(() => {
 		funcDecl;
-	}).should.not.throw();
+	}).not.toThrowError();
 });
 
 it("should remove hoisted function declarations in strict mode", () => {
@@ -91,7 +91,7 @@ it("should remove hoisted function declarations in strict mode", () => {
 	if(false) {
 		function funcDecl() {}
 	}
-	(() => {
+	expect(() => {
 		funcDecl;
-	}).should.throw();
+	}).toThrowError();
 });

--- a/test/configCases/parsing/issue-5624/index.js
+++ b/test/configCases/parsing/issue-5624/index.js
@@ -2,10 +2,10 @@ import * as M from "./module";
 
 it("should allow conditionals as callee", function() {
 	var x = (true ? M.fn : M.fn)();
-	x.should.be.eql("ok");
+	expect(x).toBe("ok");
 });
 
 it("should allow conditionals as object", function() {
 	var x = (true ? M : M).fn();
-	x.should.be.eql("ok");
+	expect(x).toBe("ok");
 });

--- a/test/configCases/parsing/node-source-plugin-off/index.js
+++ b/test/configCases/parsing/node-source-plugin-off/index.js
@@ -1,5 +1,5 @@
 require("should");
 
 it("should not load node-libs-browser when node option is false", function() {
-	(typeof process).should.be.eql("undefined");
+	expect((typeof process)).toBe("undefined");
 });

--- a/test/configCases/parsing/node-source-plugin/index.js
+++ b/test/configCases/parsing/node-source-plugin/index.js
@@ -1,5 +1,5 @@
 require("should");
 
 it("should add node-libs-browser to target web by default", function() {
-	process.browser.should.be.eql(true);
+	expect(process.browser).toBe(true);
 });

--- a/test/configCases/parsing/relative-filedirname/index.js
+++ b/test/configCases/parsing/relative-filedirname/index.js
@@ -2,5 +2,5 @@ it("should define __dirname and __filename", function() {
 	expect(__dirname).toBe("");
 	expect(__filename).toBe("index.js");
 	expect(require("./dir/file").dirname).toBe("dir");
-	require("./dir/file").filename.should.match(/^dir[\\\/]file.js$/);
+	expect(require("./dir/file").filename).toMatch(/^dir[\\\/]file.js$/);
 });

--- a/test/configCases/parsing/relative-filedirname/index.js
+++ b/test/configCases/parsing/relative-filedirname/index.js
@@ -1,6 +1,6 @@
 it("should define __dirname and __filename", function() {
-	__dirname.should.be.eql("");
-	__filename.should.be.eql("index.js");
-	require("./dir/file").dirname.should.be.eql("dir");
+	expect(__dirname).toBe("");
+	expect(__filename).toBe("index.js");
+	expect(require("./dir/file").dirname).toBe("dir");
 	require("./dir/file").filename.should.match(/^dir[\\\/]file.js$/);
 });

--- a/test/configCases/parsing/require.main/index.js
+++ b/test/configCases/parsing/require.main/index.js
@@ -1,3 +1,3 @@
 it("should define require.main", function() {
-	require.main.should.be.eql(module);
+	expect(require.main).toBe(module);
 });

--- a/test/configCases/parsing/system.import/index.js
+++ b/test/configCases/parsing/system.import/index.js
@@ -8,9 +8,9 @@ it("should answer typeof System correctly", () => {
 
 it("should answer typeof System.import correctly", () => {
 	if(__SYSTEM__ === false) {
-		(() => {
+		expect(() => {
 			typeof System.import;
-		}).should.throw();
+		}).toThrowError();
 	} else {
 		expect((typeof System.import)).toBe("function");
 	}

--- a/test/configCases/parsing/system.import/index.js
+++ b/test/configCases/parsing/system.import/index.js
@@ -1,8 +1,8 @@
 it("should answer typeof System correctly", () => {
 	if(__SYSTEM__ === false) {
-		(typeof System).should.be.eql("undefined");
+		expect((typeof System)).toBe("undefined");
 	} else {
-		(typeof System).should.be.eql("object");
+		expect((typeof System)).toBe("object");
 	}
 });
 
@@ -12,7 +12,7 @@ it("should answer typeof System.import correctly", () => {
 			typeof System.import;
 		}).should.throw();
 	} else {
-		(typeof System.import).should.be.eql("function");
+		expect((typeof System.import)).toBe("function");
 	}
 });
 
@@ -22,7 +22,7 @@ it("should be able to use System.import()", done => {
 			if(__SYSTEM__ === false) {
 				done(new Error("System.import should not be parsed"));
 			} else {
-				mod.should.be.eql({ default: "ok" });
+				expect(mod).toEqual({ default: "ok" });
 				done();
 			}
 		});

--- a/test/configCases/performance/many-exports/index.js
+++ b/test/configCases/performance/many-exports/index.js
@@ -1,5 +1,5 @@
 import sum from "./reexport.loader.js!";
 
 it("should compile a module with many harmony exports in acceptable time", function() {
-	sum.should.be.eql(499500);
+	expect(sum).toBe(499500);
 });

--- a/test/configCases/plugins/banner-plugin-hashing/index.js
+++ b/test/configCases/plugins/banner-plugin-hashing/index.js
@@ -18,35 +18,35 @@ const banner = parseBanner(source)
 const REGEXP_HASH = /^[A-Za-z0-9]{20}$/
 
 it("should interpolate file hash in chunk banner", () => {
-	REGEXP_HASH.test(banner["hash"]).should.be.true;
+	expect(REGEXP_HASH.test(banner["hash"])).toBe(true);
 });
 
 it("should interpolate chunkHash in chunk banner", () => {
-	REGEXP_HASH.test(banner["chunkhash"]).should.be.true;
+	expect(REGEXP_HASH.test(banner["chunkhash"])).toBe(true);
 });
 
 it("should interpolate file into chunk banner", () => {
-	banner["file"].should.equal("dist/banner.js");
+	expect(banner["file"]).toBe("dist/banner.js");
 });
 
 it("should interpolate name in chunk banner", () => {
-	banner["name"].should.equal("dist/banner");
+	expect(banner["name"]).toBe("dist/banner");
 });
 
 it("should interpolate basename in chunk banner", () => {
-	banner["filebase"].should.equal("banner.js");
+	expect(banner["filebase"]).toBe("banner.js");
 });
 
 it("should interpolate query in chunk banner", () => {
-	banner["query"].should.equal("?value");
+	expect(banner["query"]).toBe("?value");
 });
 
 it("should parse entry into file in chunk banner", () => {
-	banner["file"].should.not.equal(banner["filebase"]);
+	expect(banner["file"]).not.toBe(banner["filebase"]);
 });
 
 it("should parse entry into name in chunk banner", () => {
-	banner["filebase"].should.not.equal(banner["name"]);
+	expect(banner["filebase"]).not.toBe(banner["name"]);
 });
 
 require.include("./test.js");

--- a/test/configCases/plugins/banner-plugin/index.js
+++ b/test/configCases/plugins/banner-plugin/index.js
@@ -1,14 +1,14 @@
 it("should contain banner in bundle0 chunk", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename, "utf-8");
-	source.should.containEql("A test value");
+	expect(source).toMatch("A test value");
 });
 
 it("should not contain banner in vendors chunk", function() {
 	var fs = require("fs"),
 		path = require("path");
 	var source = fs.readFileSync(path.join(__dirname, "vendors.js"), "utf-8");
-	source.should.not.containEql("A test value");
+	expect(source).not.toMatch("A test value");
 });
 
 require.include("./test.js");

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -1,77 +1,77 @@
 /* globals it, should */
 it("should define FALSE", function() {
-	FALSE.should.be.eql(false);
-	(typeof TRUE).should.be.eql("boolean");
+	expect(FALSE).toBe(false);
+	expect((typeof TRUE)).toBe("boolean");
 	var x = require(FALSE ? "fail" : "./a");
 	var y = FALSE ? require("fail") : require("./a");
 });
 
 it("should define CODE", function() {
-	CODE.should.be.eql(3);
-	(typeof CODE).should.be.eql("number");
+	expect(CODE).toBe(3);
+	expect((typeof CODE)).toBe("number");
 	if(CODE !== 3) require("fail");
 	if(typeof CODE !== "number") require("fail");
 });
 it("should define FUNCTION", function() {
-	(FUNCTION(5)).should.be.eql(6);
-	(typeof FUNCTION).should.be.eql("function");
+	expect((FUNCTION(5))).toBe(6);
+	expect((typeof FUNCTION)).toBe("function");
 	if(typeof FUNCTION !== "function") require("fail");
 });
 it("should define UNDEFINED", function() {
-	(typeof UNDEFINED).should.be.eql("undefined");
+	expect((typeof UNDEFINED)).toBe("undefined");
 	if(typeof UNDEFINED !== "undefined") require("fail");
 });
 it("should define REGEXP", function() {
-	REGEXP.toString().should.be.eql("/abc/i");
-	(typeof REGEXP).should.be.eql("object");
+	expect(REGEXP.toString()).toBe("/abc/i");
+	expect((typeof REGEXP)).toBe("object");
 	if(typeof REGEXP !== "object") require("fail");
 });
 it("should define OBJECT", function() {
 	var o = OBJECT;
-	o.SUB.FUNCTION(10).should.be.eql(11);
+	expect(o.SUB.FUNCTION(10)).toBe(11);
 });
 it("should define OBJECT.SUB.CODE", function() {
-	(typeof OBJECT.SUB.CODE).should.be.eql("number");
-	OBJECT.SUB.CODE.should.be.eql(3);
+	expect((typeof OBJECT.SUB.CODE)).toBe("number");
+	expect(OBJECT.SUB.CODE).toBe(3);
 	if(OBJECT.SUB.CODE !== 3) require("fail");
 	if(typeof OBJECT.SUB.CODE !== "number") require("fail");
 
 	(function(sub) {
 		// should not crash
-		sub.CODE.should.be.eql(3);
+		expect(sub.CODE).toBe(3);
 	}(OBJECT.SUB));
 });
 it("should define OBJECT.SUB.STRING", function() {
-	(typeof OBJECT.SUB.STRING).should.be.eql("string");
-	OBJECT.SUB.STRING.should.be.eql("string");
+	expect((typeof OBJECT.SUB.STRING)).toBe("string");
+	expect(OBJECT.SUB.STRING).toBe("string");
 	if(OBJECT.SUB.STRING !== "string") require("fail");
 	if(typeof OBJECT.SUB.STRING !== "string") require("fail");
 
 	(function(sub) {
 		// should not crash
-		sub.STRING.should.be.eql("string");
+		expect(sub.STRING).toBe("string");
 	}(OBJECT.SUB));
 });
 it("should define process.env.DEFINED_NESTED_KEY", function() {
-	(process.env.DEFINED_NESTED_KEY).should.be.eql(5);
-	(typeof process.env.DEFINED_NESTED_KEY).should.be.eql("number");
+	expect((process.env.DEFINED_NESTED_KEY)).toBe(5);
+	expect((typeof process.env.DEFINED_NESTED_KEY)).toBe("number");
 	if(process.env.DEFINED_NESTED_KEY !== 5) require("fail");
 	if(typeof process.env.DEFINED_NESTED_KEY !== "number") require("fail");
 
 	var x = process.env.DEFINED_NESTED_KEY;
-	x.should.be.eql(5);
+	expect(x).toBe(5);
 
 	var indirect = process.env;
-	(indirect.DEFINED_NESTED_KEY).should.be.eql(5);
+	expect((indirect.DEFINED_NESTED_KEY)).toBe(5);
 
 	(function(env) {
-		(env.DEFINED_NESTED_KEY).should.be.eql(5);
-		(typeof env.DEFINED_NESTED_KEY).should.be.eql("number");
+		expect((env.DEFINED_NESTED_KEY)).toBe(5);
+		expect((typeof env.DEFINED_NESTED_KEY)).toBe("number");
 		if(env.DEFINED_NESTED_KEY !== 5) require("fail");
 		if(typeof env.DEFINED_NESTED_KEY !== "number") require("fail");
 
 		var x = env.DEFINED_NESTED_KEY;
-		x.should.be.eql(5);
+		expect(x).toBe(5);
 	}(process.env));
 });
 it("should define process.env.DEFINED_NESTED_KEY_STRING", function() {
@@ -79,7 +79,7 @@ it("should define process.env.DEFINED_NESTED_KEY_STRING", function() {
 });
 it("should assign to process.env", function() {
 	process.env.TEST = "test";
-	process.env.TEST.should.be.eql("test");
+	expect(process.env.TEST).toBe("test");
 });
 it("should not have brakets on start", function() {
 	function f() {
@@ -111,6 +111,6 @@ it("should follow renamings in var (issue 5215)", function() {
 	var _process$env = process.env,
 		TEST = _process$env.TEST,
 		DEFINED_NESTED_KEY = _process$env.DEFINED_NESTED_KEY;
-	TEST.should.be.eql("test");
-	DEFINED_NESTED_KEY.should.be.eql(5);
+	expect(TEST).toBe("test");
+	expect(DEFINED_NESTED_KEY).toBe(5);
 });

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -90,13 +90,13 @@ it("should not have brakets on start", function() {
 });
 
 it("should not explode on recursive typeof calls", function() {
-	(typeof wurst).should.eql("undefined"); // <- is recursivly defined in config
+	expect(typeof wurst).toEqual("undefined"); // <- is recursivly defined in config
 });
 
 it("should not explode on recursive statements", function() {
-	(function() {
+	expect(function() {
 		wurst; // <- is recursivly defined in config
-	}).should.throw("suppe is not defined");
+	}).toThrowError("suppe is not defined");
 });
 
 it("should evaluate composed expressions (issue 5100)", function() {

--- a/test/configCases/plugins/lib-manifest-plugin/index.js
+++ b/test/configCases/plugins/lib-manifest-plugin/index.js
@@ -3,7 +3,7 @@ var path = require("path");
 
 it("should complete", function(done) {
 	require.ensure(["./a"], function(require) {
-		require("./a").should.be.eql("a");
+		expect(require("./a")).toBe("a");
 		done();
 	});
 });

--- a/test/configCases/plugins/lib-manifest-plugin/index.js
+++ b/test/configCases/plugins/lib-manifest-plugin/index.js
@@ -13,5 +13,5 @@ it("should write the correct manifest", function() {
 	expect(manifest).to.have.key("content", "name");
 	expect(manifest.content).not.toHaveProperty("./a.js");
 	expect(manifest.content).toHaveProperty("./index.js");
-	expect(manifest.content["./index.js"]).to.have.property("id").toEqual(module.id);
+	expect(manifest.content["./index.js"]).toHaveProperty("id", module.id);
 });

--- a/test/configCases/plugins/lib-manifest-plugin/index.js
+++ b/test/configCases/plugins/lib-manifest-plugin/index.js
@@ -10,8 +10,9 @@ it("should complete", function(done) {
 
 it("should write the correct manifest", function() {
 	var manifest = JSON.parse(fs.readFileSync(path.join(__dirname, 'bundle0-manifest.json'), "utf-8"));
-	expect(manifest).to.have.key("content", "name");
-	expect(manifest.content).not.toHaveProperty("./a.js");
-	expect(manifest.content).toHaveProperty("./index.js");
+	expect(manifest).toHaveProperty("content");
+	expect(manifest).toHaveProperty("name");
+	expect(manifest.content).not.toHaveProperty(["./a.js"]);
+	expect(manifest.content).toHaveProperty(["./index.js"]);
 	expect(manifest.content["./index.js"]).toHaveProperty("id", module.id);
 });

--- a/test/configCases/plugins/lib-manifest-plugin/index.js
+++ b/test/configCases/plugins/lib-manifest-plugin/index.js
@@ -10,8 +10,8 @@ it("should complete", function(done) {
 
 it("should write the correct manifest", function() {
 	var manifest = JSON.parse(fs.readFileSync(path.join(__dirname, 'bundle0-manifest.json'), "utf-8"));
-	manifest.should.have.key("content", "name");
-	manifest.content.should.not.have.property("./a.js");
-	manifest.content.should.have.property("./index.js");
-	manifest.content["./index.js"].should.have.property("id").eql(module.id);
+	expect(manifest).to.have.key("content", "name");
+	expect(manifest.content).not.toHaveProperty("./a.js");
+	expect(manifest.content).toHaveProperty("./index.js");
+	expect(manifest.content["./index.js"]).to.have.property("id").toEqual(module.id);
 });

--- a/test/configCases/plugins/loader-options-plugin/index.js
+++ b/test/configCases/plugins/loader-options-plugin/index.js
@@ -1,11 +1,11 @@
 it("should set correct options on js files", function() {
-	require("./loader!./index.js").should.be.eql({
+	expect(require("./loader!./index.js")).toEqual({
 		minimize: true,
 		jsfile: true
 	});
 });
 it("should set correct options on other files", function() {
-	require("./loader!./txt.txt").should.be.eql({
+	expect(require("./loader!./txt.txt")).toEqual({
 		minimize: true
 	});
 });

--- a/test/configCases/plugins/min-chunk-size/index.js
+++ b/test/configCases/plugins/min-chunk-size/index.js
@@ -1,18 +1,18 @@
 it("should combine two chunk if too small", done => {
 	// b should not yet available
 	var bf = __webpack_modules__[require.resolveWeak("./b")];
-	(typeof bf).should.be.eql("undefined");
+	expect((typeof bf)).toBe("undefined");
 
 	// load a
 	import("./a").then(a => {
-		a.default.should.be.eql("a");
+		expect(a.default).toBe("a");
 		// check if b is available too
 		var bf = __webpack_modules__[require.resolveWeak("./b")];
-		(typeof bf).should.be.eql("function");
+		expect((typeof bf)).toBe("function");
 
 		// load b (just to check if it's ok)
 		import("./b").then(b => {
-			b.default.should.be.eql("b");
+			expect(b.default).toBe("b");
 			done();
 		}).catch(done);
 	}).catch(done);

--- a/test/configCases/plugins/profiling-plugin/index.js
+++ b/test/configCases/plugins/profiling-plugin/index.js
@@ -2,7 +2,7 @@ it("should generate a events.json file", () => {
     var fs = require("fs"),
         path = require("path"),
         os = require("os");
-    fs.existsSync(path.join(os.tmpdir(), "events.json")).should.be.true();
+    expect(fs.existsSync(path.join(os.tmpdir(), "events.json"))).toBe(true);
 });
 
 it("should have proper setup record inside of the json stream", () => {
@@ -12,5 +12,5 @@ it("should have proper setup record inside of the json stream", () => {
 
     // convert json stream to valid
     var source = JSON.parse(fs.readFileSync(path.join(os.tmpdir(), "events.json"), "utf-8").toString() + "{}]");
-    source[0].id.should.eql(1);
+    expect(source[0].id).toEqual(1);
 });

--- a/test/configCases/plugins/progress-plugin/index.js
+++ b/test/configCases/plugins/progress-plugin/index.js
@@ -1,6 +1,6 @@
 it("should contain the custom progres messages", function() {
 	var data = require(__dirname + "/data");
-	expect(data).toMatch("optimizing");
-	expect(data).toMatch("optimizing|CustomPlugin");
-	expect(data).toMatch("optimizing|CustomPlugin|custom category|custom message");
+	expect(data).toContain("optimizing");
+	expect(data).toContain("optimizing|CustomPlugin");
+	expect(data).toContain("optimizing|CustomPlugin|custom category|custom message");
 });

--- a/test/configCases/plugins/progress-plugin/index.js
+++ b/test/configCases/plugins/progress-plugin/index.js
@@ -1,6 +1,6 @@
 it("should contain the custom progres messages", function() {
 	var data = require(__dirname + "/data");
-	data.should.containEql("optimizing");
-	data.should.containEql("optimizing|CustomPlugin");
-	data.should.containEql("optimizing|CustomPlugin|custom category|custom message");
+	expect(data).toMatch("optimizing");
+	expect(data).toMatch("optimizing|CustomPlugin");
+	expect(data).toMatch("optimizing|CustomPlugin|custom category|custom message");
 });

--- a/test/configCases/plugins/provide-plugin/index.js
+++ b/test/configCases/plugins/provide-plugin/index.js
@@ -1,54 +1,54 @@
 it("should provide a module for a simple free var", function() {
-	aaa.should.be.eql("aaa");
+	expect(aaa).toBe("aaa");
 });
 
 it("should provide a module for a nested var", function() {
-	(bbb.ccc).should.be.eql("bbbccc");
+	expect((bbb.ccc)).toBe("bbbccc");
 	var x = bbb.ccc;
-	x.should.be.eql("bbbccc");
+	expect(x).toBe("bbbccc");
 });
 
 it("should provide a module for a nested var within a IIFE's argument", function() {
 	(function(process) {
-		(process.env.NODE_ENV).should.be.eql("development");
+		expect((process.env.NODE_ENV)).toBe("development");
 		var x = process.env.NODE_ENV;
-		x.should.be.eql("development");
+		expect(x).toBe("development");
 	}(process));
 });
 
 it("should provide a module for a nested var within a IIFE's this", function() {
 	(function() {
-		(this.env.NODE_ENV).should.be.eql("development");
+		expect((this.env.NODE_ENV)).toBe("development");
 		var x = this.env.NODE_ENV;
-		x.should.be.eql("development");
+		expect(x).toBe("development");
 	}.call(process));
 });
 
 it("should provide a module for a nested var within a nested IIFE's this", function() {
 	(function() {
 		(function() {
-			(this.env.NODE_ENV).should.be.eql("development");
+			expect((this.env.NODE_ENV)).toBe("development");
 			var x = this.env.NODE_ENV;
-			x.should.be.eql("development");
+			expect(x).toBe("development");
 		}.call(this));
 	}.call(process));
 });
 
 it("should not provide a module for a part of a var", function() {
-	(typeof bbb).should.be.eql("undefined");
+	expect((typeof bbb)).toBe("undefined");
 });
 
 it("should provide a module for a property request", function() {
-	(dddeeefff).should.be.eql("fff");
+	expect((dddeeefff)).toBe("fff");
 	var x = dddeeefff;
-	x.should.be.eql("fff");
+	expect(x).toBe("fff");
 });
 
 it("should provide ES2015 modules", function() {
-	(es2015.default).should.be.eql("ECMAScript 2015");
-	(es2015.alias).should.be.eql("ECMAScript Harmony");
-	(es2015.year).should.be.eql(2015);
-	(es2015_name).should.be.eql("ECMAScript 2015");
-	(es2015_alias).should.be.eql("ECMAScript Harmony");
-	(es2015_year).should.be.eql(2015);
+	expect((es2015.default)).toBe("ECMAScript 2015");
+	expect((es2015.alias)).toBe("ECMAScript Harmony");
+	expect((es2015.year)).toBe(2015);
+	expect((es2015_name)).toBe("ECMAScript 2015");
+	expect((es2015_alias)).toBe("ECMAScript Harmony");
+	expect((es2015_year)).toBe(2015);
 });

--- a/test/configCases/plugins/source-map-dev-tool-plugin/index.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin/index.js
@@ -2,11 +2,11 @@ it("should contain publicPath prefix in [url] and resolve relatively to fileCont
 	var fs = require("fs"),
 			path = require("path");
 	var source = fs.readFileSync(path.join(__dirname, "public/test.js"), "utf-8");
-	source.should.containEql("//# sourceMappingURL=https://10.10.10.10/project/sourcemaps/test.js.map");
+	expect(source).toMatch("//# sourceMappingURL=https://10.10.10.10/project/sourcemaps/test.js.map");
 });
 
 it("should write sourcemap file relative fo fileContext", function() {
 	var fs = require("fs"),
 			path = require("path");
-	fs.existsSync(path.join(__dirname, "sourcemaps/test.js.map")).should.be.true();
+	expect(fs.existsSync(path.join(__dirname, "sourcemaps/test.js.map"))).toBe(true);
 });

--- a/test/configCases/plugins/uglifyjs-plugin/index.js
+++ b/test/configCases/plugins/uglifyjs-plugin/index.js
@@ -3,9 +3,9 @@ it("should contain no comments in out chunk", () => {
 
 	const source = fs.readFileSync(__filename, "utf-8");
 
-	source.should.not.match(/[^\"]comment should be stripped test\.1[^\"]/);
-	source.should.not.match(/[^\"]comment should be stripped test\.2[^\"]/);
-	source.should.not.match(/[^\"]comment should be stripped test\.3[^\"]/);
+	expect(source).not.toMatch(/[^\"]comment should be stripped test\.1[^\"]/);
+	expect(source).not.toMatch(/[^\"]comment should be stripped test\.2[^\"]/);
+	expect(source).not.toMatch(/[^\"]comment should be stripped test\.3[^\"]/);
 });
 
 it("should contain comments in vendors chunk", function() {
@@ -14,9 +14,9 @@ it("should contain comments in vendors chunk", function() {
 
 	const source = fs.readFileSync(path.join(__dirname, "vendors.js"), "utf-8");
 
-	source.should.containEql("comment should not be stripped vendors.1");
-	source.should.containEql("// comment should not be stripped vendors.2");
-	source.should.containEql(" * comment should not be stripped vendors.3");
+	expect(source).toMatch("comment should not be stripped vendors.1");
+	expect(source).toMatch("// comment should not be stripped vendors.2");
+	expect(source).toMatch(" * comment should not be stripped vendors.3");
 });
 
 it("should extract comments to separate file", function() {
@@ -25,10 +25,10 @@ it("should extract comments to separate file", function() {
 
 	const source = fs.readFileSync(path.join(__dirname, "extract.js.LICENSE"), "utf-8");
 
-	source.should.containEql("comment should be extracted extract-test.1");
-	source.should.not.containEql("comment should be stripped extract-test.2");
-	source.should.containEql("comment should be extracted extract-test.3");
-	source.should.not.containEql("comment should be stripped extract-test.4");
+	expect(source).toMatch("comment should be extracted extract-test.1");
+	expect(source).not.toMatch("comment should be stripped extract-test.2");
+	expect(source).toMatch("comment should be extracted extract-test.3");
+	expect(source).not.toMatch("comment should be stripped extract-test.4");
 });
 
 it("should remove extracted comments and insert a banner", function() {
@@ -37,11 +37,11 @@ it("should remove extracted comments and insert a banner", function() {
 
 	const source = fs.readFileSync(path.join(__dirname, "extract.js"), "utf-8");
 
-	source.should.not.containEql("comment should be extracted extract-test.1");
-	source.should.not.containEql("comment should be stripped extract-test.2");
-	source.should.not.containEql("comment should be extracted extract-test.3");
-	source.should.not.containEql("comment should be stripped extract-test.4");
-	source.should.containEql("/*! For license information please see extract.js.LICENSE */");
+	expect(source).not.toMatch("comment should be extracted extract-test.1");
+	expect(source).not.toMatch("comment should be stripped extract-test.2");
+	expect(source).not.toMatch("comment should be extracted extract-test.3");
+	expect(source).not.toMatch("comment should be stripped extract-test.4");
+	expect(source).toMatch("/*! For license information please see extract.js.LICENSE */");
 });
 
 it("should pass mangle options", function() {
@@ -50,7 +50,7 @@ it("should pass mangle options", function() {
 
 	const source = fs.readFileSync(path.join(__dirname, "ie8.js"), "utf-8");
 
-	source.should.containEql("t.exports=function(t){return function(n){try{t()}catch(t){n(t)}}}");
+	expect(source).toMatch("t.exports=function(t){return function(n){try{t()}catch(t){n(t)}}}");
 });
 
 it("should pass compress options", function() {
@@ -59,7 +59,7 @@ it("should pass compress options", function() {
 
 	const source = fs.readFileSync(path.join(__dirname, "compress.js"), "utf-8");
 
-	source.should.containEql("o.exports=function(){console.log(4),console.log(6),console.log(4),console.log(7)}");
+	expect(source).toMatch("o.exports=function(){console.log(4),console.log(6),console.log(4),console.log(7)}");
 });
 
 require.include("./test.js");

--- a/test/configCases/records/issue-295/test.js
+++ b/test/configCases/records/issue-295/test.js
@@ -5,5 +5,5 @@ it("should write relative paths to records", function() {
 	var fs = require("fs");
 	var path = require("path");
 	var content = fs.readFileSync(path.join(__dirname, "records.json"), "utf-8");
-	content.should.not.match(/webpack|issue/);
+	expect(content).not.toMatch(/webpack|issue/);
 });

--- a/test/configCases/records/issue-2991/test.js
+++ b/test/configCases/records/issue-2991/test.js
@@ -6,7 +6,7 @@ it("should write relative paths to records", function() {
 	var fs = require("fs");
 	var path = require("path");
 	var content = fs.readFileSync(path.join(__dirname, "records.json"), "utf-8");
-	content.should.eql(`{
+	expect(content).toEqual(`{
   "modules": {
     "byIdentifier": {
       "external \\"path\\"": 0,

--- a/test/configCases/rule-set/chaining/index.js
+++ b/test/configCases/rule-set/chaining/index.js
@@ -1,6 +1,6 @@
 it("should match rule with multiple loaders in 'loader'", function() {
 	var abc = require("./abc");
-	abc.should.be.eql([
+	expect(abc).toEqual([
 		"abc",
 		"?b",
 		"?a"
@@ -8,7 +8,7 @@ it("should match rule with multiple loaders in 'loader'", function() {
 });
 it("should match rule with multiple loaders in 'loaders'", function() {
 	var def = require("./def");
-	def.should.be.eql([
+	expect(def).toEqual([
 		"def",
 		"?d",
 		"?c"

--- a/test/configCases/rule-set/compiler/index.js
+++ b/test/configCases/rule-set/compiler/index.js
@@ -1,6 +1,6 @@
 it("should match rule with compiler name", function() {
 	var a = require("./a");
-	a.should.be.eql("loader matched");
+	expect(a).toBe("loader matched");
 	var b = require("./b");
-	b.should.be.eql("loader not matched");
+	expect(b).toBe("loader not matched");
 });

--- a/test/configCases/rule-set/custom/index.js
+++ b/test/configCases/rule-set/custom/index.js
@@ -1,6 +1,6 @@
 it("should match a custom loader", function() {
 	var a = require("./a");
-	a.should.be.eql([
+	expect(a).toEqual([
 		"a",
 		{
 			issuer: "index.js",
@@ -9,7 +9,7 @@ it("should match a custom loader", function() {
 		}
 	]);
 	var b = require("./b?hello");
-	b.should.be.eql([
+	expect(b).toEqual([
 		"b",
 		{
 			issuer: "index.js",
@@ -18,7 +18,7 @@ it("should match a custom loader", function() {
 		}
 	]);
 	var ca = require("./call-a?hello");
-	ca.should.be.eql([
+	expect(ca).toEqual([
 		"a",
 		{
 			issuer: "call-a.js",

--- a/test/configCases/rule-set/query/index.js
+++ b/test/configCases/rule-set/query/index.js
@@ -1,15 +1,15 @@
 it("should match rule with resource query", function() {
 	var a1 = require("./a");
-	a1.should.be.eql([
+	expect(a1).toEqual([
 		"a"
 	]);
 	var a2 = require("./a?loader");
-	a2.should.be.eql([
+	expect(a2).toEqual([
 		"a",
 		"?query"
 	]);
 	var a3 = require("./a?other");
-	a3.should.be.eql([
+	expect(a3).toEqual([
 		"a"
 	]);
 });

--- a/test/configCases/rule-set/resolve-options/index.js
+++ b/test/configCases/rule-set/resolve-options/index.js
@@ -1,6 +1,6 @@
 it("should allow to set custom resolving rules", function() {
 	var a = require("./a");
-	a.should.be.eql("ok");
+	expect(a).toBe("ok");
 	var b = require("./b");
-	b.should.be.eql("wrong");
+	expect(b).toBe("wrong");
 });

--- a/test/configCases/rule-set/simple-use-array-fn/index.js
+++ b/test/configCases/rule-set/simple-use-array-fn/index.js
@@ -1,6 +1,6 @@
 it("should match only one rule in a oneOf block", function() {
 	var ab = require("./ab");
-	ab.should.be.eql([
+	expect(ab).toEqual([
 		"ab",
 		"?first"
 	]);
@@ -8,11 +8,11 @@ it("should match only one rule in a oneOf block", function() {
 it("should match with issuer and any option value", function() {
 	var a = require("./a");
 	var b = require("./b");
-	a.should.be.eql([
+	expect(a).toEqual([
 		"a",
 		"?third",
 	]);
-	b.should.be.eql([[
+	expect(b).toEqual([[
 		"a",
 		"second-3",
 		"?second-2",

--- a/test/configCases/rule-set/simple-use-fn-array/index.js
+++ b/test/configCases/rule-set/simple-use-fn-array/index.js
@@ -1,6 +1,6 @@
 it("should match only one rule in a oneOf block", function() {
 	var ab = require("./ab");
-	ab.should.be.eql([
+	expect(ab).toEqual([
 		"ab",
 		"?first"
 	]);
@@ -8,11 +8,11 @@ it("should match only one rule in a oneOf block", function() {
 it("should match with issuer and any option value", function() {
 	var a = require("./a");
 	var b = require("./b");
-	a.should.be.eql([
+	expect(a).toEqual([
 		"a",
 		"?third",
 	]);
-	b.should.be.eql([[
+	expect(b).toEqual([[
 		"a",
 		"second-3",
 		"?second-2",

--- a/test/configCases/rule-set/simple/index.js
+++ b/test/configCases/rule-set/simple/index.js
@@ -1,6 +1,6 @@
 it("should match only one rule in a oneOf block", function() {
 	var ab = require("./ab");
-	ab.should.be.eql([
+	expect(ab).toEqual([
 		"ab",
 		"?first"
 	]);
@@ -8,11 +8,11 @@ it("should match only one rule in a oneOf block", function() {
 it("should match with issuer and any option value", function() {
 	var a = require("./a");
 	var b = require("./b");
-	a.should.be.eql([
+	expect(a).toEqual([
 		"a",
 		"?third",
 	]);
-	b.should.be.eql([[
+	expect(b).toEqual([[
 		"a",
 		"second-3",
 		"?second-2",

--- a/test/configCases/runtime/opt-in-finally/index.js
+++ b/test/configCases/runtime/opt-in-finally/index.js
@@ -1,8 +1,8 @@
 it("should throw exception on every try to load a module", function() {
-	(function() {
+	expect(function() {
 		require("./exception");
-	}).should.throw();
-	(function() {
+	}).toThrowError();
+	expect(function() {
 		require("./exception");
-	}).should.throw();
+	}).toThrowError();
 });

--- a/test/configCases/scope-hoisting/dll-plugin/index.js
+++ b/test/configCases/scope-hoisting/dll-plugin/index.js
@@ -1,5 +1,5 @@
 import value from "dll/module";
 
 it("should not scope hoist delegated modules", function() {
-	value.should.be.eql("ok");
+	expect(value).toBe("ok");
 });

--- a/test/configCases/scope-hoisting/named-modules/index.js
+++ b/test/configCases/scope-hoisting/named-modules/index.js
@@ -1,5 +1,5 @@
 import value from "./module";
 
 it("should generate valid code", function() {
-	value.should.be.eql("ok");
+	expect(value).toBe("ok");
 });

--- a/test/configCases/scope-hoisting/strictThisContextOnImports/index.js
+++ b/test/configCases/scope-hoisting/strictThisContextOnImports/index.js
@@ -2,10 +2,10 @@ import value, { identity } from "./module";
 import * as m from "./module";
 
 it("should parse and translate identifiers correctly", function() {
-	identity(value).should.be.eql(1234);
-	m.identity(value).should.be.eql(1234);
-	m.identity(identity).should.be.eql(identity);
-	m.identity(m.identity).should.be.eql(m.identity);
-	identity(m.identity).should.be.eql(m.identity);
-	identity(m.default).should.be.eql(1234);
+	expect(identity(value)).toBe(1234);
+	expect(m.identity(value)).toBe(1234);
+	expect(m.identity(identity)).toBe(identity);
+	expect(m.identity(m.identity)).toBe(m.identity);
+	expect(identity(m.identity)).toBe(m.identity);
+	expect(identity(m.default)).toBe(1234);
 });

--- a/test/configCases/side-effects/side-effects-override/index.js
+++ b/test/configCases/side-effects/side-effects-override/index.js
@@ -4,8 +4,8 @@ import p from "pmodule";
 import n from "nmodule";
 
 it("should be able to override side effects", function() {
-	p.should.be.eql("def");
-	n.should.be.eql("def");
-	plog.should.be.eql(["a.js", "b.js", "c.js", "index.js"]);
-	nlog.should.be.eql(["index.js"]);
+	expect(p).toBe("def");
+	expect(n).toBe("def");
+	expect(plog).toEqual(["a.js", "b.js", "c.js", "index.js"]);
+	expect(nlog).toEqual(["index.js"]);
 });

--- a/test/configCases/source-map/exclude-chunks-source-map/index.js
+++ b/test/configCases/source-map/exclude-chunks-source-map/index.js
@@ -2,14 +2,14 @@ it("should include test.js in SourceMap for bundle0 chunk", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	map.sources.should.containEql("webpack:///./test.js");
+	expect(map.sources).toMatch("webpack:///./test.js");
 });
 
 it("should not produce a SourceMap for vendors chunk", function() {
 	var fs = require("fs"),
 			path = require("path"),
 			assert = require("assert");
-	fs.existsSync(path.join(__dirname, "vendors.js.map")).should.be.false();
+	expect(fs.existsSync(path.join(__dirname, "vendors.js.map"))).toBe(false);
 });
 
 require.include("./test.js");

--- a/test/configCases/source-map/exclude-chunks-source-map/index.js
+++ b/test/configCases/source-map/exclude-chunks-source-map/index.js
@@ -2,7 +2,7 @@ it("should include test.js in SourceMap for bundle0 chunk", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	expect(map.sources).toMatch("webpack:///./test.js");
+	expect(map.sources).toContain("webpack:///./test.js");
 });
 
 it("should not produce a SourceMap for vendors chunk", function() {

--- a/test/configCases/source-map/line-to-line/index.js
+++ b/test/configCases/source-map/line-to-line/index.js
@@ -2,7 +2,7 @@ it("should include test.js in SourceMap", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	expect(map.sources).toMatch("webpack:///./test.js");
+	expect(map.sources).toContain("webpack:///./test.js");
 });
 
 require.include("./test.js");

--- a/test/configCases/source-map/line-to-line/index.js
+++ b/test/configCases/source-map/line-to-line/index.js
@@ -2,7 +2,7 @@ it("should include test.js in SourceMap", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	map.sources.should.containEql("webpack:///./test.js");
+	expect(map.sources).toMatch("webpack:///./test.js");
 });
 
 require.include("./test.js");

--- a/test/configCases/source-map/module-names/index.js
+++ b/test/configCases/source-map/module-names/index.js
@@ -7,14 +7,14 @@ function getSourceMap(filename) {
 
 it("should include test.js in SourceMap", function() {
 	var map = getSourceMap("bundle0.js");
-	map.sources.should.containEql("module");
-	map.sources.should.containEql("fallback");
-	map.sources.should.containEql("fallback**");
+	expect(map.sources).toMatch("module");
+	expect(map.sources).toMatch("fallback");
+	expect(map.sources).toMatch("fallback**");
 	map = getSourceMap("chunk-a.js");
-	map.sources.should.containEql("fallback*");
+	expect(map.sources).toMatch("fallback*");
 	map = getSourceMap("chunk-b.js");
-	map.sources.should.containEql("fallback*");
-	map.sources.should.containEql("fallback***");
+	expect(map.sources).toMatch("fallback*");
+	expect(map.sources).toMatch("fallback***");
 });
 
 require.ensure(["./test.js"], function(require) {}, "chunk-a");

--- a/test/configCases/source-map/module-names/index.js
+++ b/test/configCases/source-map/module-names/index.js
@@ -7,14 +7,14 @@ function getSourceMap(filename) {
 
 it("should include test.js in SourceMap", function() {
 	var map = getSourceMap("bundle0.js");
-	expect(map.sources).toMatch("module");
-	expect(map.sources).toMatch("fallback");
-	expect(map.sources).toMatch("fallback**");
+	expect(map.sources).toContain("module");
+	expect(map.sources).toContain("fallback");
+	expect(map.sources).toContain("fallback**");
 	map = getSourceMap("chunk-a.js");
-	expect(map.sources).toMatch("fallback*");
+	expect(map.sources).toContain("fallback*");
 	map = getSourceMap("chunk-b.js");
-	expect(map.sources).toMatch("fallback*");
-	expect(map.sources).toMatch("fallback***");
+	expect(map.sources).toContain("fallback*");
+	expect(map.sources).toContain("fallback***");
 });
 
 require.ensure(["./test.js"], function(require) {}, "chunk-a");

--- a/test/configCases/source-map/namespace-source-path.library/index.js
+++ b/test/configCases/source-map/namespace-source-path.library/index.js
@@ -2,7 +2,7 @@ it("should include webpack://mylibrary/./test.js in SourceMap", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	map.sources.should.containEql("webpack://mylibrary/./test.js");
+	expect(map.sources).toMatch("webpack://mylibrary/./test.js");
 });
 
 require.include("./test.js");

--- a/test/configCases/source-map/namespace-source-path.library/index.js
+++ b/test/configCases/source-map/namespace-source-path.library/index.js
@@ -2,7 +2,7 @@ it("should include webpack://mylibrary/./test.js in SourceMap", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	expect(map.sources).toMatch("webpack://mylibrary/./test.js");
+	expect(map.sources).toContain("webpack://mylibrary/./test.js");
 });
 
 require.include("./test.js");

--- a/test/configCases/source-map/namespace-source-path/index.js
+++ b/test/configCases/source-map/namespace-source-path/index.js
@@ -2,7 +2,7 @@ it("should include webpack://mynamespace/./test.js in SourceMap", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	map.sources.should.containEql("webpack://mynamespace/./test.js");
+	expect(map.sources).toMatch("webpack://mynamespace/./test.js");
 });
 
 require.include("./test.js");

--- a/test/configCases/source-map/namespace-source-path/index.js
+++ b/test/configCases/source-map/namespace-source-path/index.js
@@ -2,7 +2,7 @@ it("should include webpack://mynamespace/./test.js in SourceMap", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	expect(map.sources).toMatch("webpack://mynamespace/./test.js");
+	expect(map.sources).toContain("webpack://mynamespace/./test.js");
 });
 
 require.include("./test.js");

--- a/test/configCases/source-map/nosources/index.js
+++ b/test/configCases/source-map/nosources/index.js
@@ -2,7 +2,7 @@ it("should not include sourcesContent if noSources option is used", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	map.should.not.have.property('sourcesContent');
+	expect(map).not.toHaveProperty('sourcesContent');
 });
 
 require.include("./test.js");

--- a/test/configCases/source-map/relative-source-map-path/index.js
+++ b/test/configCases/source-map/relative-source-map-path/index.js
@@ -7,6 +7,7 @@ it("should have a relative url to the source-map", function() {
 
 it("should have a relative url to the source-map with prefix", function(done) {
 	require.ensure([], function(require) {
+		global.expect = expect;
 		require("./test.js");
 		done();
 	});

--- a/test/configCases/source-map/relative-source-map-path/index.js
+++ b/test/configCases/source-map/relative-source-map-path/index.js
@@ -2,7 +2,7 @@ it("should have a relative url to the source-map", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename, "utf-8");
 	var match = /sourceMappingURL\s*=\s*(.*)/.exec(source);
-	match[1].should.be.eql("bundle0.js.map");
+	expect(match[1]).toBe("bundle0.js.map");
 });
 
 it("should have a relative url to the source-map with prefix", function(done) {

--- a/test/configCases/source-map/relative-source-map-path/test.js
+++ b/test/configCases/source-map/relative-source-map-path/test.js
@@ -1,4 +1,4 @@
 var fs = require("fs");
 var source = fs.readFileSync(__filename, "utf-8");
 var match = /sourceMappingURL\s*=\s*(.*)/.exec(source);
-match[1].should.be.eql("c.js.map");
+expect(match[1]).toBe("c.js.map");

--- a/test/configCases/source-map/source-map-filename-contenthash/index.js
+++ b/test/configCases/source-map/source-map-filename-contenthash/index.js
@@ -2,5 +2,5 @@ it("should contain contenthash as query parameter and path", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename, "utf-8");
 	var match = /sourceMappingURL\s*=.*-([A-Fa-f0-9]{32})\.map\?([A-Fa-f0-9]{32})-([A-Fa-f0-9]{32})/.exec(source);
-	match.length.should.be.eql(4);
+	expect(match.length).toBe(4);
 });

--- a/test/configCases/source-map/sources-array-production/index.js
+++ b/test/configCases/source-map/sources-array-production/index.js
@@ -2,7 +2,7 @@ it("should include test.js in SourceMap", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	expect(map.sources).toMatch("webpack:///./test.js");
+	expect(map.sources).toContain("webpack:///./test.js");
 });
 
 require.include("./test.js");

--- a/test/configCases/source-map/sources-array-production/index.js
+++ b/test/configCases/source-map/sources-array-production/index.js
@@ -2,7 +2,7 @@ it("should include test.js in SourceMap", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	map.sources.should.containEql("webpack:///./test.js");
+	expect(map.sources).toMatch("webpack:///./test.js");
 });
 
 require.include("./test.js");

--- a/test/configCases/target/buffer-default/index.js
+++ b/test/configCases/target/buffer-default/index.js
@@ -1,7 +1,5 @@
-require("should");
-
 it("should provide a global Buffer shim", function () {
-	Buffer.should.be.a.Function();
+	expect(Buffer).toBeInstanceOf(Function);
 });
 
 it("should provide the buffer module", function () {

--- a/test/configCases/target/buffer-default/index.js
+++ b/test/configCases/target/buffer-default/index.js
@@ -6,5 +6,5 @@ it("should provide a global Buffer shim", function () {
 
 it("should provide the buffer module", function () {
 	var buffer = require("buffer");
-	(typeof buffer).should.be.eql("object");
+	expect((typeof buffer)).toBe("object");
 });

--- a/test/configCases/target/buffer/index.js
+++ b/test/configCases/target/buffer/index.js
@@ -1,7 +1,5 @@
-require("should");
-
 it("should provide a global Buffer shim", function () {
-	Buffer.should.be.a.Function();
+	expect(Buffer).toBeInstanceOf(Function);
 });
 
 it("should fail on the buffer module"/*, function () {

--- a/test/configCases/target/node-dynamic-import/index.js
+++ b/test/configCases/target/node-dynamic-import/index.js
@@ -2,11 +2,11 @@ function testCase(load, done) {
 	load("two", 2, function() {
 		var sync = true;
 		load("one", 1, function() {
-			sync.should.be.eql(false);
+			expect(sync).toBe(false);
 			load("three", 3, function() {
 				var sync = true;
 				load("two", 2, function() {
-					sync.should.be.eql(true);
+					expect(sync).toBe(true);
 					done();
 				});
 				Promise.resolve().then(function() {}).then(function() {}).then(function() {
@@ -23,7 +23,7 @@ function testCase(load, done) {
 it("should be able to use expressions in import", function(done) {
 	function load(name, expected, callback) {
 		import("./dir/" + name + '.js')
-			.then((result) => {result.should.be.eql({ default: expected }); callback()})
+			.then((result) => {expect(result).toEqual({ default: expected }); callback()})
 			.catch((err) => {done(err)});
 	}
 	testCase(load, done);
@@ -32,7 +32,7 @@ it("should be able to use expressions in import", function(done) {
 it("should be able to use expressions in lazy-once import", function(done) {
 	function load(name, expected, callback) {
 		import(/* webpackMode: "lazy-once" */ "./dir/" + name + '.js')
-			.then((result) => {result.should.be.eql({ default: expected }); callback()})
+			.then((result) => {expect(result).toEqual({ default: expected }); callback()})
 			.catch((err) => {done(err)});
 	}
 	testCase(load, done);
@@ -41,7 +41,7 @@ it("should be able to use expressions in lazy-once import", function(done) {
 it("should be able to use expressions in import", function(done) {
 	function load(name, expected, callback) {
 		import("./dir2/" + name).then((result) => {
-			result.should.be.eql({ default: expected });
+			expect(result).toEqual({ default: expected });
 			callback();
 		}).catch((err) => {
 			done(err);
@@ -51,12 +51,12 @@ it("should be able to use expressions in import", function(done) {
 });
 
 it("should convert to function in node", function() {
-	(typeof __webpack_require__.e).should.be.eql("function");
+	expect((typeof __webpack_require__.e)).toBe("function");
 })
 
 it("should be able to use import", function(done) {
 	import("./two").then((two) => {
-		two.should.be.eql({ default: 2 });
+		expect(two).toEqual({ default: 2 });
 		done();
 	}).catch(function(err) {
 		done(err);

--- a/test/configCases/target/strict-mode-global/index.js
+++ b/test/configCases/target/strict-mode-global/index.js
@@ -3,6 +3,6 @@
 require("should");
 
 it("should be able to use global in strict mode", function() {
-	(typeof global).should.be.eql("object");
-	(global === null).should.be.eql(false)
+	expect((typeof global)).toBe("object");
+	expect((global === null)).toBe(false)
 });

--- a/test/configCases/target/umd-auxiliary-comments-object/index.js
+++ b/test/configCases/target/umd-auxiliary-comments-object/index.js
@@ -6,8 +6,8 @@ it("should have auxiliary comments", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename, "utf-8");
 
-	source.should.containEql("//test " + "comment " + "commonjs");
-	source.should.containEql("//test " + "comment " + "commonjs2");
-	source.should.containEql("//test " + "comment " + "amd");
-	source.should.containEql("//test " + "comment " + "root");
+	expect(source).toMatch("//test " + "comment " + "commonjs");
+	expect(source).toMatch("//test " + "comment " + "commonjs2");
+	expect(source).toMatch("//test " + "comment " + "amd");
+	expect(source).toMatch("//test " + "comment " + "root");
 });

--- a/test/configCases/target/umd-auxiliary-comments-string/index.js
+++ b/test/configCases/target/umd-auxiliary-comments-string/index.js
@@ -5,6 +5,6 @@ it("should run", function() {
 it("should have auxiliary comment string", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename, "utf-8");
-	
-	source.should.containEql("//test " + "comment");
+
+	expect(source).toMatch("//test " + "comment");
 });

--- a/test/configCases/target/umd-named-define/index.js
+++ b/test/configCases/target/umd-named-define/index.js
@@ -6,5 +6,5 @@ it("should name define", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename, "utf-8");
 
-	source.should.containEql("define(\"NamedLibrary\",");
+	expect(source).toMatch("define(\"NamedLibrary\",");
 });

--- a/test/configCases/target/web/index.js
+++ b/test/configCases/target/web/index.js
@@ -1,11 +1,8 @@
-require("should");
-
-// shimming global XMLHttpRequest object so the http-module is happy.
 global.XMLHttpRequest = function() {};
 global.XMLHttpRequest.prototype.open = function() {};
 
 it("should provide a global Buffer constructor", function() {
-	Buffer.should.be.a.Function();
+	expect(Buffer).toBeInstanceOf(Function);
 });
 
 // Webpack is not providing a console shim by default
@@ -17,83 +14,83 @@ it("should provide a global Buffer constructor", function() {
 //});
 
 it("should provide a global process shim", function () {
-	process.should.be.an.Object();
+	expect(process).toBeInstanceOf(Object);
 });
 
 it("should provide a global setImmediate shim", function () {
-	setImmediate.should.be.a.Function();
+	expect(setImmediate).toBeInstanceOf(Function);
 });
 
 it("should provide a global clearImmediate shim", function () {
-	clearImmediate.should.be.a.Function();
+	expect(clearImmediate).toBeInstanceOf(Function);
 });
 
 it("should provide an assert shim", function () {
-	require("assert").should.be.a.Function();
+	expect(require("assert")).toBeInstanceOf(Function);
 });
 
 it("should provide a util shim", function () {
-	require("util").should.be.an.Object();
+	expect(require("util")).toBeInstanceOf(Object);
 });
 
 it("should provide a buffer shim", function () {
-	require("buffer").should.be.an.Object();
+	expect(require("buffer")).toBeInstanceOf(Object);
 });
 
 it("should provide a crypto shim", function () {
-	require("crypto").should.be.an.Object();
+	expect(require("crypto")).toBeInstanceOf(Object);
 });
 
 it("should provide a domain shim", function () {
-	require("domain").should.be.an.Object();
+	expect(require("domain")).toBeInstanceOf(Object);
 });
 
 it("should provide an events shim", function () {
-	require("events").should.be.a.Function();
+	expect(require("events")).toBeInstanceOf(Function);
 });
 
 it("should provide an http shim", function () {
-	require("http").should.be.an.Object();
+	expect(require("http")).toBeInstanceOf(Object);
 });
 
 it("should provide an https shim", function () {
-	require("https").should.be.an.Object();
+	expect(require("https")).toBeInstanceOf(Object);
 });
 
 it("should provide an os shim", function () {
-	require("os").should.be.an.Object();
+	expect(require("os")).toBeInstanceOf(Object);
 });
 
 it("should provide a path shim", function () {
-	require("path").should.be.an.Object();
+	expect(require("path")).toBeInstanceOf(Object);
 });
 
 it("should provide a punycode shim", function () {
-	require("punycode").should.be.an.Object();
+	expect(require("punycode")).toBeInstanceOf(Object);
 });
 
 it("should provide a stream shim", function () {
-	require("stream").should.be.a.Function();
+	expect(require("stream")).toBeInstanceOf(Function);
 });
 
 it("should provide a tty shim", function () {
-	require("tty").should.be.an.Object();
+	expect(require("tty")).toBeInstanceOf(Object);
 });
 
 it("should provide a url shim", function () {
-	require("url").should.be.an.Object();
+	expect(require("url")).toBeInstanceOf(Object);
 });
 
 it("should provide a util shim", function () {
-	require("util").should.be.an.Object();
+	expect(require("util")).toBeInstanceOf(Object);
 });
 
 it("should provide a vm shim", function () {
-	require("vm").should.be.an.Object();
+	expect(require("vm")).toBeInstanceOf(Object);
 });
 
 it("should provide a zlib shim", function () {
-	require("zlib").should.be.an.Object();
+	expect(require("zlib")).toBeInstanceOf(Object);
 });
 
 it("should provide a shim for a path in a build-in module", function () {

--- a/test/configCases/target/web/index.js
+++ b/test/configCases/target/web/index.js
@@ -97,5 +97,5 @@ it("should provide a zlib shim", function () {
 });
 
 it("should provide a shim for a path in a build-in module", function () {
-	require("process/in.js").should.be.eql("in process");
+	expect(require("process/in.js")).toBe("in process");
 });

--- a/test/configCases/target/webworker/index.js
+++ b/test/configCases/target/webworker/index.js
@@ -94,5 +94,5 @@ it("should provide a zlib shim", function () {
 });
 
 it("should provide a shim for a path in a build-in module", function () {
-	require("process/in.js").should.be.eql("in process");
+	expect(require("process/in.js")).toBe("in process");
 });

--- a/test/configCases/target/webworker/index.js
+++ b/test/configCases/target/webworker/index.js
@@ -1,96 +1,93 @@
-var should = require("should");
-// shimming global window object so the http-module is happy.
-// window is assigned without var on purpose.
 global.XMLHttpRequest = function() {};
 global.XMLHttpRequest.prototype.open = function() {};
 
 it("should provide a global Buffer constructor", function() {
-	Buffer.should.be.a.Function();
+	expect(Buffer).toBeInstanceOf(Function);
 });
 
 it("should provide a global console shim", function () {
-	console.should.be.an.Object();
-	console.time.should.be.a.Function();
+	expect(console).toBeInstanceOf(Object);
+	expect(console.time).toBeInstanceOf(Function);
 });
 
 it("should provide a global process shim", function () {
-	process.should.be.an.Object();
+	expect(process).toBeInstanceOf(Object);
 });
 
 it("should provide a global setImmediate shim", function () {
-	setImmediate.should.be.a.Function();
+	expect(setImmediate).toBeInstanceOf(Function);
 });
 
 it("should provide a global clearImmediate shim", function () {
-	clearImmediate.should.be.a.Function();
+	expect(clearImmediate).toBeInstanceOf(Function);
 });
 
 it("should provide an assert shim", function () {
-	require("assert").should.be.a.Function();
+	expect(require("assert")).toBeInstanceOf(Function);
 });
 
 it("should provide a util shim", function () {
-	require("util").should.be.an.Object();
+	expect(require("util")).toBeInstanceOf(Object);
 });
 
 it("should provide a buffer shim", function () {
-	require("buffer").should.be.an.Object();
+	expect(require("buffer")).toBeInstanceOf(Object);
 });
 
 it("should provide a crypto shim", function () {
-	require("crypto").should.be.an.Object();
+	expect(require("crypto")).toBeInstanceOf(Object);
 });
 
 it("should provide a domain shim", function () {
-	require("domain").should.be.an.Object();
+	expect(require("domain")).toBeInstanceOf(Object);
 });
 
 it("should provide an events shim", function () {
-	require("events").should.be.a.Function();
+	expect(require("events")).toBeInstanceOf(Function);
 });
 
 it("should provide an http shim", function () {
-	require("http").should.be.an.Object();
+	expect(require("http")).toBeInstanceOf(Object);
 });
 
 it("should provide an https shim", function () {
-	require("https").should.be.an.Object();
+	expect(require("https")).toBeInstanceOf(Object);
 });
 
 it("should provide an os shim", function () {
-	require("os").should.be.an.Object();
+	expect(require("os")).toBeInstanceOf(Object);
 });
 
 it("should provide a path shim", function () {
-	require("path").should.be.an.Object();
+	expect(require("path")).toBeInstanceOf(Object);
 });
 
 it("should provide a punycode shim", function () {
-	require("punycode").should.be.an.Object();
+	expect(require("punycode")).toBeInstanceOf(Object);
 });
 
 it("should provide a stream shim", function () {
-	require("stream").should.be.a.Function();
+	expect(require("stream")).toBeInstanceOf(Function);
 });
 
 it("should provide a tty shim", function () {
-	require("tty").should.be.an.Object();
+	expect(require("tty")).toBeInstanceOf(Object);
 });
 
 it("should provide a url shim", function () {
-	require("url").should.be.an.Object();
+	expect(require("url")).toBeInstanceOf(Object);
 });
 
 it("should provide a util shim", function () {
-	require("util").should.be.an.Object();
+	expect(require("util")).toBeInstanceOf(Object);
 });
 
 it("should provide a vm shim", function () {
-	require("vm").should.be.an.Object();
+	expect(require("vm")).toBeInstanceOf(Object);
 });
 
 it("should provide a zlib shim", function () {
-	require("zlib").should.be.an.Object();
+	expect(require("zlib")).toBeInstanceOf(Object);
 });
 
 it("should provide a shim for a path in a build-in module", function () {

--- a/test/configCases/target/webworker/index.js
+++ b/test/configCases/target/webworker/index.js
@@ -6,8 +6,8 @@ it("should provide a global Buffer constructor", function() {
 });
 
 it("should provide a global console shim", function () {
-	expect(console).toBeInstanceOf(Object);
-	expect(console.time).toBeInstanceOf(Function);
+	expect(console).toBeTypeOf("object");
+	expect(console.time).toBeTypeOf("function");
 });
 
 it("should provide a global process shim", function () {

--- a/test/hotCases/harmony/auto-import-default/out/bundle.js
+++ b/test/hotCases/harmony/auto-import-default/out/bundle.js
@@ -765,9 +765,9 @@ throw new Error("Module parse failed: Unexpected token (3:0)\nYou may need an ap
 
 
 it("should auto-import a ES6 imported value on accept", function(done) {
-	_file__WEBPACK_IMPORTED_MODULE_0__["value"].should.be.eql(1);
+	expect(_file__WEBPACK_IMPORTED_MODULE_0__["value"]).toEqual(1);
 	module.hot.accept(/*! ./file */ "./file.js", function(__WEBPACK_OUTDATED_DEPENDENCIES__) { /* harmony import */ _file__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./file */"./file.js"); /* harmony import */ _file__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_file__WEBPACK_IMPORTED_MODULE_0__); (function() {
-		_file__WEBPACK_IMPORTED_MODULE_0__["value"].should.be.eql(2);
+		expect(_file__WEBPACK_IMPORTED_MODULE_0__["value"]).toEqual(2);
 		outside();
 		done();
 	})(__WEBPACK_OUTDATED_DEPENDENCIES__); });
@@ -775,7 +775,7 @@ it("should auto-import a ES6 imported value on accept", function(done) {
 });
 
 function outside() {
-	_file__WEBPACK_IMPORTED_MODULE_0__["value"].should.be.eql(2);
+	expect(_file__WEBPACK_IMPORTED_MODULE_0__["value"]).toEqual(2);
 }
 
 

--- a/test/setupTestFramework.js
+++ b/test/setupTestFramework.js
@@ -1,0 +1,28 @@
+/* globals expect */
+expect.extend({
+	toBeTypeOf(received, expected) {
+		const objType = typeof received;
+		const pass = objType === expected;
+
+		const message = pass
+		? () =>
+			this.utils.matcherHint(".not.toBeTypeOf") +
+			"\n\n" +
+			"Expected value to not be (using typeof):\n" +
+			`  ${this.utils.printExpected(expected)}\n` +
+			"Received:\n" +
+			`  ${this.utils.printReceived(objType)}`
+		: () => {
+			return (
+				this.utils.matcherHint(".toBeTypeOf") +
+				"\n\n" +
+				"Expected value to be (using typeof):\n" +
+				`  ${this.utils.printExpected(expected)}\n` +
+				"Received:\n" +
+				`  ${this.utils.printReceived(objType)}`
+			);
+		};
+
+		return { message, pass };
+	}
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Refactoring tests (tooling change from `mocha` to `jest`).
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

😆
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Continuing the work of @ooflorent, this PR changes the way tests are run to one that is compatible with jest. Additionally, it migrates hundreds of tests to jest's `expect` form, from `should`.

The conversion is not complete yet, but the great majority of tests are now passing in `jest`.

**Does this PR introduce a breaking change?**

No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

Blocked on a bugfix to jest: https://github.com/facebook/jest/pull/5405