### PR TITLE
Avoid relying on Node’s internals

### DIFF
--- a/lib/EnvironmentPlugin.js
+++ b/lib/EnvironmentPlugin.js
@@ -7,6 +7,9 @@
 
 const DefinePlugin = require("./DefinePlugin");
 
+const needsEnvVarFix = ["8", "9"].indexOf(process.versions.node.split(".")[0]) >= 0 &&
+	process.platform === "win32";
+
 class EnvironmentPlugin {
 	constructor(keys) {
 		if(Array.isArray(keys)) {
@@ -23,6 +26,13 @@ class EnvironmentPlugin {
 
 	apply(compiler) {
 		const definitions = this.keys.reduce((defs, key) => {
+			// TODO remove once the fix has made its way into Node 8.
+			// Work around https://github.com/nodejs/node/pull/18463,
+			// affecting Node 8 & 9 by performing an OS-level
+			// operation that always succeeds before reading
+			// environment variables:
+			if(needsEnvVarFix) require("os").cpus();
+
 			const value = process.env[key] !== undefined ? process.env[key] : this.defaultValues[key];
 
 			if(value === undefined) {

--- a/lib/node/NodeTargetPlugin.js
+++ b/lib/node/NodeTargetPlugin.js
@@ -6,9 +6,11 @@
 
 const ExternalsPlugin = require("../ExternalsPlugin");
 
+const builtins = require("module").builtinModules || Object.keys(process.binding("natives"));
+
 class NodeTargetPlugin {
 	apply(compiler) {
-		new ExternalsPlugin("commonjs", Object.keys(process.binding("natives"))).apply(compiler);
+		new ExternalsPlugin("commonjs", builtins).apply(compiler);
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Future-proofing / being a good OSS citizen.

**Did you add tests for your changes?**

No, but Webpack doesn’t seem to test current verions of Node in CI right now anyway.
Once Node 9 or above is in there, this is going to be tested automatically.

**If relevant, link to documentation update:**

N/A

**Summary**

`process.binding()` is not a public API, and should
not be used.

Luckily, Node recently introduced an API that does
exactly what Webpack needs:
https://nodejs.org/api/modules.html#modules_module_builtinmodules

So use that instead and keep the old path as a fallback.

**Does this PR introduce a breaking change?**

No.

**Other information**

Nope. :)