### PR TITLE
Expose output path in Stats object

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -133,6 +133,7 @@ class Stats {
 		const sortModules = optionsOrFallback(options.modulesSort, "id");
 		const sortChunks = optionsOrFallback(options.chunksSort, "id");
 		const sortAssets = optionsOrFallback(options.assetsSort, "");
+		const showOutputPath = optionOrLocalFallback(options.outputPath, true);
 
 		if(!showCachedModules) {
 			excludeModules.push((ident, module) => !module.built);
@@ -265,6 +266,9 @@ class Stats {
 			obj.publicPath = this.compilation.mainTemplate.getPublicPath({
 				hash: this.compilation.hash
 			});
+		}
+		if(showOutputPath) {
+			obj.outputPath = this.compilation.mainTemplate.outputOptions.path;
 		}
 		if(showAssets) {
 			const assetsByFile = {};

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -133,7 +133,7 @@ class Stats {
 		const sortModules = optionsOrFallback(options.modulesSort, "id");
 		const sortChunks = optionsOrFallback(options.chunksSort, "id");
 		const sortAssets = optionsOrFallback(options.assetsSort, "");
-		const showOutputPath = optionOrLocalFallback(options.outputPath, true);
+		const showOutputPath = optionOrLocalFallback(options.outputPath, !forToString);
 
 		if(!showCachedModules) {
 			excludeModules.push((ident, module) => !module.built);

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1822,6 +1822,10 @@
               "type": "boolean",
               "description": "Add public path information"
             },
+            "outputPath": {
+              "type": "boolean",
+              "description": "Add output path information"
+            },
             "providedExports": {
               "type": "boolean",
               "description": "show exports provided by modules"

--- a/test/Stats.unittest.js
+++ b/test/Stats.unittest.js
@@ -3,7 +3,7 @@
 
 require("should");
 const Stats = require("../lib/Stats");
-const packageJson = require("../package.json")
+const packageJson = require("../package.json");
 
 describe("Stats", () => {
 	describe("Error Handling", () => {
@@ -113,7 +113,7 @@ describe("Stats", () => {
 				errors: [],
 				warnings: [],
 				assets: [],
-				entrypoints: {},
+				entrypoints: new Map(),
 				chunks: [],
 				modules: [],
 				children: [],
@@ -123,6 +123,9 @@ describe("Stats", () => {
 						path: "/"
 					},
 					getPublicPath: () => "path"
+				},
+				compiler: {
+					context: ""
 				}
 			});
 			const result = mockStats.toJson();
@@ -132,9 +135,9 @@ describe("Stats", () => {
 				children: [],
 				chunks: [],
 				entrypoints: {},
-				errors: [],
 				filteredAssets: 0,
 				filteredModules: 0,
+				errors: [],
 				hash: "1234",
 				modules: [],
 				outputPath: "/",

--- a/test/Stats.unittest.js
+++ b/test/Stats.unittest.js
@@ -2,8 +2,8 @@
 "use strict";
 
 require("should");
-
 const Stats = require("../lib/Stats");
+const packageJson = require("../package.json")
 
 describe("Stats", () => {
 	describe("Error Handling", () => {
@@ -94,6 +94,9 @@ describe("Stats", () => {
 				children: [],
 				hash: "1234",
 				mainTemplate: {
+					outputOptions: {
+						path: ""
+					},
 					getPublicPath: () => "path"
 				},
 				compiler: {
@@ -102,6 +105,43 @@ describe("Stats", () => {
 			});
 			const obj = mockStats.toJson();
 			obj.errors[0].should.be.equal("firstError");
+		});
+	});
+	describe("toJson", () => {
+		it("returns plain object representation", () => {
+			const mockStats = new Stats({
+				errors: [],
+				warnings: [],
+				assets: [],
+				entrypoints: {},
+				chunks: [],
+				modules: [],
+				children: [],
+				hash: "1234",
+				mainTemplate: {
+					outputOptions: {
+						path: "/"
+					},
+					getPublicPath: () => "path"
+				}
+			});
+			const result = mockStats.toJson();
+			result.should.deepEqual({
+				assets: [],
+				assetsByChunkName: {},
+				children: [],
+				chunks: [],
+				entrypoints: {},
+				errors: [],
+				filteredAssets: 0,
+				filteredModules: 0,
+				hash: "1234",
+				modules: [],
+				outputPath: "/",
+				publicPath: "path",
+				version: packageJson.version,
+				warnings: []
+			});
 		});
 	});
 	describe("Presets", () => {

--- a/test/Stats.unittest.js
+++ b/test/Stats.unittest.js
@@ -2,6 +2,7 @@
 "use strict";
 
 require("should");
+
 const Stats = require("../lib/Stats");
 const packageJson = require("../package.json");
 

--- a/test/statsCases/simple-more-info/webpack.config.js
+++ b/test/statsCases/simple-more-info/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
 		cachedAssets: true,
 		source: true,
 		errorDetails: true,
-		publicPath: true
+		publicPath: true,
+		outputPath: true,
 	}
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR adds a feature to include the output path in the Stats object.

**Did you add tests for your changes?**
Added a test on the `toJson` function of `Stats` to confirm the output is expected and includes the newly added `outputPath` field.

**If relevant, link to documentation update:**
https://github.com/webpack/webpack.js.org/pull/1807

**Summary**
Open issue: https://github.com/webpack/webpack/issues/6373

Having the output path in the Stats object is particularly useful when the stats file is emitted and you'd like to do analysis of the emitted files given the stats file.

For example, when using a tool like [webpack-bundle-analyzer](https://www.npmjs.com/package/webpack-bundle-analyzer), it currently requires a second option to pass the Webpack output path.

Ideally the stats file already contained this path and was able to be parsed by such tools so a sane default could be obtained from the stats file. 

**Does this PR introduce a breaking change?**
This should not be a breaking change
