### PR TITLE
fix(ConcatenatedModule): don't throw on arrays with empty values

### DIFF
--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -143,6 +143,7 @@ function getPathInAst(ast, node) {
 	}
 
 	function enterNode(n) {
+		if(!n) return undefined;
 		const r = n.range;
 		if(r) {
 			if(r[0] <= nr[0] && r[1] >= nr[1]) {

--- a/test/cases/scope-hoisting/issue-6407/import-one.js
+++ b/test/cases/scope-hoisting/issue-6407/import-one.js
@@ -1,0 +1,4 @@
+function foo(n) {
+  return 'bar';
+}
+export default [, foo];

--- a/test/cases/scope-hoisting/issue-6407/import-two.js
+++ b/test/cases/scope-hoisting/issue-6407/import-two.js
@@ -1,0 +1,4 @@
+function foo(n) {
+  return 'bar';
+}
+export default [, foo];

--- a/test/cases/scope-hoisting/issue-6407/index.js
+++ b/test/cases/scope-hoisting/issue-6407/index.js
@@ -1,0 +1,11 @@
+import importOne from './import-one';
+import importTwo from './import-two';
+
+it("should concatenate modules default exports and empty array values", function() {
+	importOne.length.should.be.eql(2);
+	(typeof importOne[0]).should.be.eql('undefined');
+	(typeof importOne[1]).should.be.eql('function');
+	importTwo.length.should.be.eql(2);
+	(typeof importTwo[0]).should.be.eql('undefined');
+	(typeof importTwo[1]).should.be.eql('function');
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
yes

**If relevant, link to documentation update:**
N/A

**Summary**
When importing multiple files with default exports, arrays with empty values and functions with the same name, the ConcatenatedModule will throw an error.
See issue #6407 for details.
Fixes #6407, #5415
Ref https://github.com/angular/angular/issues/21809

**Does this PR introduce a breaking change?**
No