### PR TITLE
Remove footer from source maps and eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,14 +217,14 @@ or are automatically applied via regex from your webpack configuration.
 |Name|Status|Description|
 |:--:|:----:|:----------|
 |<a href="https://github.com/vuejs/vue-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/vue-9.svg"></a>|![vue-npm]|Loads and compiles Vue Components|
-|<a href="https://github.com/JonDum/polymer-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/polymer.svg"></a>|![polymer-npm]|Process HTML & CSS with preprocessor of choice and `require()` Web Components like first-class modules|
+|<a href="https://github.com/webpack-contrib/polymer-webpack-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/polymer.svg"></a>|![polymer-npm]|Process HTML & CSS with preprocessor of choice and `require()` Web Components like first-class modules|
 |<a href="https://github.com/TheLarkInn/angular2-template-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/angular-icon-1.svg"></a>|![angular-npm]| Loads and compiles Angular 2 Components|
 |<a href="https://github.com/riot/tag-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/riot.svg"></a>|![riot-npm]| Riot official webpack loader|
 
 
 
 [vue-npm]: https://img.shields.io/npm/v/vue-loader.svg
-[polymer-npm]: https://img.shields.io/npm/v/polymer-loader.svg
+[polymer-npm]: https://img.shields.io/npm/v/polymer-webpack-loader.svg
 [angular-npm]: https://img.shields.io/npm/v/angular2-template-loader.svg
 [riot-npm]: https://img.shields.io/npm/v/riot-tag-loader.svg
 

--- a/lib/EvalDevToolModuleTemplatePlugin.js
+++ b/lib/EvalDevToolModuleTemplatePlugin.js
@@ -24,10 +24,7 @@ class EvalDevToolModuleTemplatePlugin {
 				moduleFilenameTemplate: this.moduleFilenameTemplate,
 				namespace: this.namespace
 			}, moduleTemplate.runtimeTemplate.requestShortener);
-			const footer = ["\n",
-				ModuleFilenameHelpers.createFooter(module, moduleTemplate.runtimeTemplate.requestShortener),
-				this.sourceUrlComment.replace(/\[url\]/g, encodeURI(str).replace(/%2F/g, "/").replace(/%20/g, "_").replace(/%5E/g, "^").replace(/%5C/g, "\\").replace(/^\//, ""))
-			].join("\n");
+			const footer = this.sourceUrlComment.replace(/\[url\]/g, encodeURI(str).replace(/%2F/g, "/").replace(/%20/g, "_").replace(/%5E/g, "^").replace(/%5C/g, "\\").replace(/^\//, ""));
 			const result = new RawSource(`eval(${JSON.stringify(content + footer)});`);
 			cache.set(source, result);
 			return result;

--- a/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
+++ b/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
@@ -58,9 +58,7 @@ class EvalSourceMapDevToolModuleTemplatePlugin {
 			});
 			sourceMap.sources = moduleFilenames;
 			if(sourceMap.sourcesContent) {
-				sourceMap.sourcesContent = sourceMap.sourcesContent.map((content, i) => {
-					return typeof content === "string" ? `${content}\n\n\n${ModuleFilenameHelpers.createFooter(modules[i], moduleTemplate.runtimeTemplate.requestShortener)}` : null;
-				});
+				sourceMap.sourcesContent = sourceMap.sourcesContent.map(content => typeof content === "string" ? content : null);
 			}
 			sourceMap.sourceRoot = options.sourceRoot || "";
 			sourceMap.file = `${module.id}.js`;

--- a/lib/ModuleFilenameHelpers.js
+++ b/lib/ModuleFilenameHelpers.js
@@ -112,24 +112,6 @@ ModuleFilenameHelpers.createFilename = (module, options, requestShortener) => {
 		.replace(ModuleFilenameHelpers.REGEXP_NAMESPACE, opts.namespace);
 };
 
-ModuleFilenameHelpers.createFooter = (module, requestShortener) => {
-	if(!module) module = "";
-	if(typeof module === "string") {
-		return [
-			"// WEBPACK FOOTER //",
-			`// ${requestShortener.shorten(module)}`
-		].join("\n");
-	} else {
-		return [
-			"//////////////////",
-			"// WEBPACK FOOTER",
-			`// ${module.readableIdentifier(requestShortener)}`,
-			`// module id = ${module.id}`,
-			`// module chunks = ${Array.from(module.chunksIterable, c => c.id).join(" ")}`
-		].join("\n");
-	}
-};
-
 ModuleFilenameHelpers.replaceDuplicates = (array, fn, comparator) => {
 	const countMap = Object.create(null);
 	const posMap = Object.create(null);

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -185,7 +185,7 @@ class SourceMapDevToolPlugin {
 					const moduleFilenames = modules.map(m => moduleToSourceNameMapping.get(m));
 					sourceMap.sources = moduleFilenames;
 					if(sourceMap.sourcesContent && !options.noSources) {
-						sourceMap.sourcesContent = sourceMap.sourcesContent.map((content, i) => typeof content === "string" ? `${content}\n\n\n${ModuleFilenameHelpers.createFooter(modules[i], requestShortener)}` : null);
+						sourceMap.sourcesContent = sourceMap.sourcesContent.map((content) => typeof content === "string" ? content : null);
 					} else {
 						sourceMap.sourcesContent = undefined;
 					}

--- a/test/statsCases/chunks-development/expected.txt
+++ b/test/statsCases/chunks-development/expected.txt
@@ -1,10 +1,10 @@
 Hash: 5ce1f032cffdff8368b5
 Time: Xms
       Asset       Size  Chunks             Chunk Names
-0.bundle.js  530 bytes       0  [emitted]  
-1.bundle.js  394 bytes       1  [emitted]  
-2.bundle.js  782 bytes       2  [emitted]  
-  bundle.js   7.58 KiB    main  [emitted]  main
+0.bundle.js  431 bytes       0  [emitted]  
+1.bundle.js  295 bytes       1  [emitted]  
+2.bundle.js  584 bytes       2  [emitted]  
+  bundle.js   7.38 KiB    main  [emitted]  main
 Entrypoint main = bundle.js
 chunk {main} bundle.js (main) 73 bytes >{0}< >{1}< [entry] [rendered]
     > ./index main

--- a/test/statsCases/preset-normal-performance-ensure-filter-sourcemaps/expected.txt
+++ b/test/statsCases/preset-normal-performance-ensure-filter-sourcemaps/expected.txt
@@ -4,10 +4,10 @@ Time: <CLR=BOLD>X</CLR>ms
        <CLR=32,BOLD>1.js</CLR>  319 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
     <CLR=33,BOLD>main.js</CLR>    <CLR=33,BOLD>300 KiB</CLR>       <CLR=BOLD>2</CLR>  <CLR=32,BOLD>[emitted]</CLR>  <CLR=33,BOLD>[big]</CLR>  main
        <CLR=32,BOLD>3.js</CLR>  257 bytes       <CLR=BOLD>3</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
-   <CLR=32,BOLD>0.js.map</CLR>  250 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
-   <CLR=32,BOLD>1.js.map</CLR>  291 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
+   <CLR=32,BOLD>0.js.map</CLR>  156 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
+   <CLR=32,BOLD>1.js.map</CLR>  197 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
 <CLR=32,BOLD>main.js.map</CLR>   1.72 MiB       <CLR=BOLD>2</CLR>  <CLR=32,BOLD>[emitted]</CLR>         main
-   <CLR=32,BOLD>3.js.map</CLR>  402 bytes       <CLR=BOLD>3</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
+   <CLR=32,BOLD>3.js.map</CLR>  214 bytes       <CLR=BOLD>3</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> = <CLR=32,BOLD>main.js</CLR> <CLR=32,BOLD>main.js.map</CLR>
    [0] <CLR=BOLD>./d.js</CLR> 22 bytes {<CLR=33,BOLD>3</CLR>}<CLR=32,BOLD> [built]</CLR>
    [1] <CLR=BOLD>./e.js</CLR> 22 bytes {<CLR=33,BOLD>3</CLR>}<CLR=32,BOLD> [built]</CLR>

--- a/test/statsCases/simple/expected.txt
+++ b/test/statsCases/simple/expected.txt
@@ -1,6 +1,6 @@
 Hash: f0bbd0723c33cf044c2f
 Time: Xms
     Asset      Size  Chunks             Chunk Names
-bundle.js  2.89 KiB    main  [emitted]  main
+bundle.js  2.78 KiB    main  [emitted]  main
 Entrypoint main = bundle.js
 [./index.js] 0 bytes {main} [built]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
refactoring

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No.

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Some development tool (eg Chrome DevTools) needs to get unmodified source codes.

Thus, SourceMapDevTool and EvalSourceMapDevTool plugins accept a new option called "noFooter". If it's true then no footer is generated for source maps.

This is a basic solution to #6400

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
