### PR TITLE
Manually exclude internal tap of plugin.

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -130,6 +130,8 @@ function createTrace(outPath) {
 	};
 }
 
+const pluginName = "ProfilingPlugin";
+
 class ProfilingPlugin {
 	// TODO: Add plugin schema validation here since there are options.
 	constructor(opts) {
@@ -150,7 +152,7 @@ class ProfilingPlugin {
 			compiler.resolverFactory.hooks[hookName].intercept(makeInterceptorFor("Resolver", tracer)(hookName));
 		});
 
-		compiler.hooks.compilation.tap("ProfilingPlugin", (compilation, {
+		compiler.hooks.compilation.tap(pluginName, (compilation, {
 			normalModuleFactory,
 			contextModuleFactory
 		}) => {
@@ -163,7 +165,7 @@ class ProfilingPlugin {
 
 		// We need to write out the CPU profile when we are all done.
 		compiler.hooks.done.tap({
-			name: "ProfilingPlugin",
+			name: pluginName,
 			stage: Infinity
 		}, () => {
 			tracer.profiler.stopProfiling().then((parsedResults) => {
@@ -356,6 +358,12 @@ const makeNewProfiledTapFn = (hookName, tracer, {
 		case "sync":
 			return(...args) => { // eslint-disable-line
 				const id = ++tracer.counter;
+				// Do not instrument outself due to the CPU
+				// profile needing to be the last event in the trace.
+				if(name === pluginName) {
+					return fn(...args);
+				}
+
 				tracer.trace.begin({
 					name,
 					id,


### PR DESCRIPTION
This was forcing the timestamp of the last trace to be the last event
in the JSON trace, and thus breaking the CPU profile.

Instead manually exclude this plugin from being traced to avoid this
issue.

--
reported here
https://twitter.com/probablyup/status/957436506263744513