### PR TITLE
Pass 'context' as constructor argument

### DIFF
--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -17,11 +17,8 @@ class ContextModule extends Module {
 	// resolveDependencies: (fs: FS, options: ContextOptions, (err: Error?, dependencies: Dependency[]) => void) => void
 	// options: ContextOptions
 	constructor(resolveDependencies, options) {
-		super("javascript/dynamic");
-
-		// Info from Factory
-		this.resolveDependencies = resolveDependencies;
-		let resource, resourceQuery;
+		let resource;
+		let resourceQuery;
 		const queryIdx = options.resource.indexOf("?");
 		if(queryIdx >= 0) {
 			resource = options.resource.substr(0, queryIdx);
@@ -30,11 +27,15 @@ class ContextModule extends Module {
 			resource = options.resource;
 			resourceQuery = "";
 		}
+
+		super("javascript/dynamic", resource);
+
+		// Info from Factory
+		this.resolveDependencies = resolveDependencies;
 		this.options = Object.assign({}, options, {
 			resource: resource,
 			resourceQuery: resourceQuery
 		});
-		this.context = this.options.resource;
 		if(options.resolveOptions !== undefined)
 			this.resolveOptions = options.resolveOptions;
 

--- a/lib/DelegatedModule.js
+++ b/lib/DelegatedModule.js
@@ -13,7 +13,7 @@ const DelegatedExportsDependency = require("./dependencies/DelegatedExportsDepen
 
 class DelegatedModule extends Module {
 	constructor(sourceRequest, data, type, userRequest, originalRequest) {
-		super("javascript/dynamic");
+		super("javascript/dynamic", null);
 
 		// Info from Factory
 		this.sourceRequest = sourceRequest;

--- a/lib/DllModule.js
+++ b/lib/DllModule.js
@@ -9,10 +9,9 @@ const RawSource = require("webpack-sources").RawSource;
 
 class DllModule extends Module {
 	constructor(context, dependencies, name, type) {
-		super("javascript/dynamic");
+		super("javascript/dynamic", context);
 
 		// Info from Factory
-		this.context = context;
 		this.dependencies = dependencies;
 		this.name = name;
 		this.type = type;

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -11,7 +11,7 @@ const Template = require("./Template");
 
 class ExternalModule extends Module {
 	constructor(request, type, userRequest) {
-		super("javascript/dynamic");
+		super("javascript/dynamic", null);
 
 		// Info from Factory
 		this.request = request;

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -25,9 +25,10 @@ const sortByDebugId = (a, b) => {
 
 class Module extends DependenciesBlock {
 
-	constructor(type) {
+	constructor(type, context = null) {
 		super();
 		this.type = type;
+		this.context = context;
 
 		// Unique Id
 		this.debugId = debugId++;
@@ -37,8 +38,6 @@ class Module extends DependenciesBlock {
 		this.renderedHash = undefined;
 
 		// Info from Factory
-		// TODO refactor: pass as constructor argument
-		this.context = null;
 		this.resolveOptions = EMPTY_RESOLVE_OPTIONS;
 		this.factoryMeta = {};
 

--- a/lib/MultiModule.js
+++ b/lib/MultiModule.js
@@ -11,10 +11,9 @@ const RawSource = require("webpack-sources").RawSource;
 class MultiModule extends Module {
 
 	constructor(context, dependencies, name) {
-		super("javascript/dynamic");
+		super("javascript/dynamic", context);
 
 		// Info from Factory
-		this.context = context;
 		this.dependencies = dependencies;
 		this.name = name;
 	}

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -75,7 +75,7 @@ class NormalModule extends Module {
 		generator,
 		resolveOptions
 	}) {
-		super(type);
+		super(type, getContext(resource));
 
 		// Info from Factory
 		this.request = request;
@@ -85,7 +85,6 @@ class NormalModule extends Module {
 		this.parser = parser;
 		this.generator = generator;
 		this.resource = resource;
-		this.context = getContext(resource);
 		this.loaders = loaders;
 		if(resolveOptions !== undefined)
 			this.resolveOptions = resolveOptions;

--- a/lib/RawModule.js
+++ b/lib/RawModule.js
@@ -11,7 +11,7 @@ const RawSource = require("webpack-sources").RawSource;
 module.exports = class RawModule extends Module {
 
 	constructor(source, identifier, readableIdentifier) {
-		super("javascript/dynamic");
+		super("javascript/dynamic", null);
 		this.sourceStr = source;
 		this.identifierStr = identifier || this.sourceStr;
 		this.readableIdentifierStr = readableIdentifier || this.identifierStr;

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -194,7 +194,7 @@ const getPathInAst = (ast, node) => {
 
 class ConcatenatedModule extends Module {
 	constructor(rootModule, modules) {
-		super("javascript/esm");
+		super("javascript/esm", null);
 		super.setChunks(rootModule._chunks);
 
 		// Info from Factory


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

n/a

**Summary**

When extending `Module`, `context` is now defined as a constructor argument.

**Does this PR introduce a breaking change?**

no
