### PR TITLE
fixed error with importing JSON with ProfilingPlugin

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -266,7 +266,7 @@ const interceptTemplateInstancesFrom = (compilation, tracer) => {
 };
 
 const interceptAllHooksFor = (instance, tracer, logLabel) => {
-	if(Object.hasOwnProperty("hooks", instance)) {
+	if(Reflect.has(instance, "hooks")) {
 		Object.keys(instance.hooks).forEach(hookName => {
 			instance.hooks[hookName].intercept(makeInterceptorFor(logLabel, tracer)(hookName));
 		});

--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -266,9 +266,11 @@ const interceptTemplateInstancesFrom = (compilation, tracer) => {
 };
 
 const interceptAllHooksFor = (instance, tracer, logLabel) => {
-	Object.keys(instance.hooks).forEach(hookName => {
-		instance.hooks[hookName].intercept(makeInterceptorFor(logLabel, tracer)(hookName));
-	});
+	if(Object.hasOwnProperty("hooks", instance)) {
+		Object.keys(instance.hooks).forEach(hookName => {
+			instance.hooks[hookName].intercept(makeInterceptorFor(logLabel, tracer)(hookName));
+		});
+	}
 };
 
 const interceptAllParserHooks = (moduleFactory, tracer) => {

--- a/test/configCases/plugins/profiling-plugin/index.js
+++ b/test/configCases/plugins/profiling-plugin/index.js
@@ -1,3 +1,5 @@
+import "./test.json";
+
 it("should generate a events.json file", () => {
     var fs = require("fs"),
         path = require("path"),

--- a/test/configCases/plugins/profiling-plugin/test.json
+++ b/test/configCases/plugins/profiling-plugin/test.json
@@ -1,0 +1,3 @@
+{
+  "json": "should work"
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Bugfix

**Did you add tests for your changes?**
Yes

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Added check for the "hooks" property on instances passed into the `interceptAllHooksFor` function to avoid a TypeError thrown importing JSON files when using the ProfilePlugin. 

Rather than doing the check in the previous function on the stack, I have just wrapped the body of `interceptAllHooksFor` with an `if` statement as it is much simpler and a bit cleaner because it only requires one check on the passed in `instance` variable. However if the extra function call being pushed on to the stack is an issue, I can update this PR to remove that `if` statement and include the extra checks in the calling function. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
See https://github.com/webpack/webpack/issues/6414
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
