### PR TITLE
Truncate generated chunk name if too long

### DIFF
--- a/lib/optimize/SplitChunksPlugin.js
+++ b/lib/optimize/SplitChunksPlugin.js
@@ -4,8 +4,13 @@
 */
 "use strict";
 
+const crypto = require("crypto");
 const SortableSet = require("../util/SortableSet");
 const GraphHelpers = require("../GraphHelpers");
+
+const hashFilename = (name) => {
+	return crypto.createHash("md5").update(name).digest("hex").slice(0, 8);
+};
 
 const sortByIdentifier = (a, b) => {
 	if(a.identifier() > b.identifier()) return 1;
@@ -85,7 +90,15 @@ module.exports = class SplitChunksPlugin {
 				const names = chunks.map(c => c.name);
 				if(!names.every(Boolean)) return;
 				names.sort();
-				const name = (cacheGroup && cacheGroup !== "default" ? cacheGroup + "~" : "") + names.join("~");
+				let name = (cacheGroup && cacheGroup !== "default" ? cacheGroup + "~" : "") + names.join("~");
+				// Filenames and paths can't be too long otherwise an
+				// ENAMETOOLONG error is raised. If the generated name if too
+				// long, it is truncated and a hash is appended. The limit has
+				// been set to 100 to prevent `[name].[chunkhash].[ext]` from
+				// generating a 256+ character string.
+				if(name.length > 100) {
+					name = name.slice(0, 100) + "~" + hashFilename(name);
+				}
 				return name;
 			};
 			return fn;

--- a/test/statsCases/split-chunks/expected.txt
+++ b/test/statsCases/split-chunks/expected.txt
@@ -192,3 +192,72 @@ Child manual:
         [0] ./d.js 20 bytes {2} {3} {4} {6} {7} {8} [built]
         [1] ./f.js 20 bytes {1} {3} {4} {7} {8} [built]
         [5] ./c.js 72 bytes {4} {8} [built]
+Child name-too-long:
+    Entrypoint main = main.js
+    Entrypoint aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~716093be.js aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js
+    Entrypoint bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~716093be.js aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js
+    Entrypoint cccccccccccccccccccccccccccccc = vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~716093be.js vendors~async-c~cccccccccccccccccccccccccccccc.js cccccccccccccccccccccccccccccc.js
+    chunk    {0} vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~716093be.js (vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~716093be) 20 bytes <{9}> ={4}= ={12}= ={2}= ={11}= ={10}= ={1}= ={3}= ={8}= ={7}= ={6}= >{1}< >{5}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~716093be)
+        > ./c cccccccccccccccccccccccccccccc
+        > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+        > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        > ./c [8] ./index.js 3:0-47
+        > ./b [8] ./index.js 2:0-47
+        > ./a [8] ./index.js 1:0-47
+        [1] ./node_modules/x.js 20 bytes {0} {3} [built]
+    chunk    {1} async-b~async-c~async-g~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccccccccccccccccccc.js (async-b~async-c~async-g~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccccccccccccccccccc) 20 bytes <{0}> <{2}> <{10}> <{3}> <{6}> <{9}> ={5}= ={0}= ={4}= ={3}= ={8}= ={2}= ={7}= [rendered] split chunk (cache group: default) (name: async-b~async-c~async-g~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccccccccccccccccccc)
+        > ./g [] 6:0-47
+        > ./g [] 6:0-47
+        > ./c [8] ./index.js 3:0-47
+        > ./b [8] ./index.js 2:0-47
+        [2] ./f.js 20 bytes {1} {11} {12} [built]
+    chunk    {2} aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) 20 bytes <{9}> ={0}= ={11}= ={10}= ={1}= ={7}= ={3}= ={6}= >{1}< >{5}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+        > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+        > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        > ./b [8] ./index.js 2:0-47
+        > ./a [8] ./index.js 1:0-47
+        [3] ./node_modules/y.js 20 bytes {2} [built]
+    chunk    {3} aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccc~e7d53185.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccc~e7d53185) 40 bytes <{9}> ={0}= ={4}= ={1}= ={8}= ={2}= ={6}= >{1}< >{5}< [rendered] split chunk (cache group: default) (name: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccc~e7d53185)
+        > ./c [8] ./index.js 3:0-47
+        > ./a [8] ./index.js 1:0-47
+        [0] ./d.js 20 bytes {3} {7} {10} {11} {12} [built]
+        [1] ./node_modules/x.js 20 bytes {0} {3} [built]
+    chunk    {4} vendors~async-c~cccccccccccccccccccccccccccccc.js (vendors~async-c~cccccccccccccccccccccccccccccc) 20 bytes <{9}> ={0}= ={12}= ={1}= ={3}= ={8}= [initial] [rendered] split chunk (cache group: vendors) (name: vendors~async-c~cccccccccccccccccccccccccccccc)
+        > ./c cccccccccccccccccccccccccccccc
+        > ./c [8] ./index.js 3:0-47
+        [7] ./node_modules/z.js 20 bytes {4} [built]
+    chunk    {5} async-g.js (async-g) 34 bytes <{0}> <{2}> <{10}> <{3}> <{6}> ={1}= [rendered]
+        > ./g [] 6:0-47
+        > ./g [] 6:0-47
+        [9] ./g.js 34 bytes {5} [built]
+    chunk    {6} async-a.js (async-a) 156 bytes <{9}> ={0}= ={2}= ={3}= >{1}< >{5}< [rendered]
+        > ./a [8] ./index.js 1:0-47
+        [6] ./a.js + 1 modules 156 bytes {6} {10} [built]
+            | ./a.js 121 bytes [built]
+            | ./e.js 20 bytes [built]
+    chunk    {7} async-b.js (async-b) 92 bytes <{9}> ={0}= ={2}= ={1}= [rendered]
+        > ./b [8] ./index.js 2:0-47
+        [0] ./d.js 20 bytes {3} {7} {10} {11} {12} [built]
+        [4] ./b.js 72 bytes {7} {11} [built]
+    chunk    {8} async-c.js (async-c) 72 bytes <{9}> ={0}= ={4}= ={1}= ={3}= [rendered]
+        > ./c [8] ./index.js 3:0-47
+        [5] ./c.js 72 bytes {8} {12} [built]
+    chunk    {9} main.js (main) 147 bytes >{0}< >{2}< >{1}< >{7}< >{3}< >{6}< >{4}< >{8}< [entry] [rendered]
+        > ./ main
+        [8] ./index.js 147 bytes {9} [built]
+    chunk   {10} aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) 176 bytes ={0}= ={2}= >{1}< >{5}< [entry] [rendered]
+        > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        [0] ./d.js 20 bytes {3} {7} {10} {11} {12} [built]
+        [6] ./a.js + 1 modules 156 bytes {6} {10} [built]
+            | ./a.js 121 bytes [built]
+            | ./e.js 20 bytes [built]
+    chunk   {11} bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) 112 bytes ={0}= ={2}= [entry] [rendered]
+        > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+        [0] ./d.js 20 bytes {3} {7} {10} {11} {12} [built]
+        [2] ./f.js 20 bytes {1} {11} {12} [built]
+        [4] ./b.js 72 bytes {7} {11} [built]
+    chunk   {12} cccccccccccccccccccccccccccccc.js (cccccccccccccccccccccccccccccc) 112 bytes ={0}= ={4}= [entry] [rendered]
+        > ./c cccccccccccccccccccccccccccccc
+        [0] ./d.js 20 bytes {3} {7} {10} {11} {12} [built]
+        [2] ./f.js 20 bytes {1} {11} {12} [built]
+        [5] ./c.js 72 bytes {8} {12} [built]

--- a/test/statsCases/split-chunks/webpack.config.js
+++ b/test/statsCases/split-chunks/webpack.config.js
@@ -78,6 +78,26 @@ module.exports = [
 			}
 		},
 		stats
+	},
+	{
+		name: "name-too-long",
+		mode: "production",
+		entry: {
+			main: "./",
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: "./a",
+			bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: "./b",
+			cccccccccccccccccccccccccccccc: "./c"
+		},
+		output: {
+			filename: "[name].js"
+		},
+		optimization: {
+			splitChunks: {
+				minSize: 0,
+				chunks: "all"
+			}
+		},
+		stats
 	}
 
 ];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

yes

**If relevant, link to documentation update:**

n/a

**Summary**

If a filename is longer than 255 characters an `ENAMETOOLONG` error is raised. This PR truncates the chunk name generated by `SplitChunksPlugin` to 200 characters and happens a unique identifier after to avoid conflicts.

**Does this PR introduce a breaking change?**

no

**Other information**

This is more a patch than a proper fix. Ideally webpack should never generate a long filename. However, changing the way filenames are handled is a lot more complex.

Fixes #6426
