### PR TITLE
update ajv + ajv-keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "acorn": "^5.0.0",
     "acorn-dynamic-import": "^2.0.0",
-    "ajv": "^5.1.5",
-    "ajv-keywords": "^2.0.0",
+    "ajv": "^6.1.0",
+    "ajv-keywords": "^3.1.0",
     "async": "^2.1.2",
     "enhanced-resolve": "^3.4.0",
     "escope": "^3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,9 +55,9 @@ ajv-keywords@^1.0.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
 
-ajv-keywords@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.0.tgz#a296e17f7bfae7c1ce4f7e0de53d29cb32162df0"
+ajv-keywords@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.1.0.tgz#ac2b27939c543e95d2c06e7f7f5c27be4aa543be"
 
 ajv@^4.7.0, ajv@^4.9.1:
   version "4.11.8"
@@ -66,7 +66,7 @@ ajv@^4.7.0, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.0.0, ajv@^5.1.5, ajv@^5.2.0:
+ajv@^5.0.0, ajv@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.2.tgz#47c68d69e86f5d953103b0074a9430dc63da5e39"
   dependencies:
@@ -74,6 +74,14 @@ ajv@^5.0.0, ajv@^5.1.5, ajv@^5.2.0:
     fast-deep-equal "^1.0.0"
     json-schema-traverse "^0.3.0"
     json-stable-stringify "^1.0.1"
+
+ajv@^6.1.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.1.1.tgz#978d597fbc2b7d0e5a5c3ddeb149a682f2abfa0e"
+  dependencies:
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -1359,6 +1367,10 @@ extsprintf@1.0.2:
 fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -3967,7 +3979,7 @@ ua-parser-js@^0.7.9:
   version "0.7.14"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.14.tgz#110d53fa4c3f326c121292bbeac904d2e03387ca"
 
-uglify-js@^2.6, uglify-js@^2.8.29:
+uglify-js@^2.4.19, uglify-js@^2.6, uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:


### PR DESCRIPTION
- updates to `ajv@6.1.0`
- updates to `ajv-keywords@3.1.0` (required for _better_ validation in webpack/webpack-cli#240)

**What kind of change does this PR introduce?**

dependency version bump (`ajv` and `ajv-keywords`)

**Did you add tests for your changes?**

No.

**If relevant, link to documentation update:**

N/A

**Summary**

webpack/webpack-cli#240 adds some basic configuration type validation using `webpack/validateSchema` (`ajv` powered). 

It seems the "cleanest" way to validate `Promise`-type configurations, would be to use `ajv-keyword`'s `"instanceof": "Promise"`, this was only added to the `3.x` release which has a dependency on `ajv@6`.

Current tests (validations) are still passing with this update – `ajv`'s changelog from `5.2-6` doesn't suggest any breaking changes based on `webpack`'s usage.

**Does this PR introduce a breaking change?**

No.

**Other information**

This does seem a little heavy-handed for resolving webpack/webpack-cli#240, but the version bump(s) seem generally safe.
