### PR TITLE
Add null check

### DIFF
--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -199,7 +199,7 @@ module.exports = class RuntimeTemplate {
 		callContext,
 		importVar
 	}) {
-		const exportsType = module.buildMeta && module.buildMeta.exportsType;
+		const exportsType = module && module.buildMeta && module.buildMeta.exportsType;
 
 		if(!exportsType) {
 			if(exportName === "default") {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
N/A

**If relevant, link to documentation update:**
N/A

**Summary**
webpack will crash unexpectedly if you save the code to load the module from a path that does not exist during watching.


**Does this PR introduce a breaking change?**
No

**Other information**

```
/webpack/lib/RuntimeTemplate.js:202
                const exportsType = module.buildMeta && module.buildMeta.exportsType;
                             ^
TypeError: Cannot read property 'buildMeta' of null
    at RuntimeTemplate.exportFromImport (/webpack/lib/RuntimeTemplate.js:202:30)
    at HarmonyImportSpecifierDependencyTemplate.getContent (/webpack/lib/dependencies/HarmonyImportSpecifierDependency.js:105:30)
    at HarmonyImportSpecifierDependencyTemplate.apply (/webpack/lib/dependencies/HarmonyImportSpecifierDependency.js:100:24)
    at JavascriptGenerator.sourceDependency (/webpack/lib/JavascriptGenerator.js:119:12)
    at JavascriptGenerator.sourceBlock (/webpack/lib/JavascriptGenerator.js:32:9)
    at JavascriptGenerator.generate (/webpack/lib/JavascriptGenerator.js:25:8)
    at NormalModule.source (/webpack/lib/NormalModule.js:373:33)
    at ModuleTemplate.render (/webpack/lib/ModuleTemplate.js:25:31)
    at modules.map.module (/webpack/lib/Template.js:134:28)
    at Array.map (<anonymous>)
```