### PR TITLE
[WIP] feat(html): add HTML module support (`html`)

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -368,7 +368,8 @@ class Compilation {
 		/** @type {{javascript: ModuleTemplate, webassembly: ModuleTemplate}} */
 		this.moduleTemplates = {
 			javascript: new ModuleTemplate(this.runtimeTemplate, "javascript"),
-			webassembly: new ModuleTemplate(this.runtimeTemplate, "webassembly")
+			webassembly: new ModuleTemplate(this.runtimeTemplate, "webassembly"),
+			html: new ModuleTemplate(this.outputOptions)
 		};
 
 		this.moduleGraph = new ModuleGraph();
@@ -1900,6 +1901,7 @@ class Compilation {
 			if (!aEntry && bEntry) return -1;
 			return byId(a, b);
 		});
+
 		for (let i = 0; i < chunks.length; i++) {
 			const chunk = chunks[i];
 			const chunkHash = createHash(hashFunction);

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -7,9 +7,11 @@
 
 const OptionsApply = require("./OptionsApply");
 
+// Module Types
 const JavascriptModulesPlugin = require("./JavascriptModulesPlugin");
 const JsonModulesPlugin = require("./JsonModulesPlugin");
 const WebAssemblyModulesPlugin = require("./wasm/WebAssemblyModulesPlugin");
+const HTMLModulesPlugin = require("./html/HTMLModulesPlugin");
 
 const EvalDevToolModulePlugin = require("./EvalDevToolModulePlugin");
 const EvalSourceMapDevToolPlugin = require("./EvalSourceMapDevToolPlugin");
@@ -294,6 +296,7 @@ class WebpackOptionsApply extends OptionsApply {
 		new WebAssemblyModulesPlugin({
 			mangleImports: options.optimization.mangleWasmImports
 		}).apply(compiler);
+		new HTMLModulesPlugin().apply(compiler);
 
 		new EntryOptionPlugin().apply(compiler);
 		compiler.hooks.entryOption.call(options.context, options.entry);

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -84,6 +84,10 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 			{
 				test: /\.wasm$/i,
 				type: "webassembly/experimental"
+			},
+			{
+				test: /\.html$/i,
+				type: "html"
 			}
 		]);
 

--- a/lib/html/HTMLGenerator.js
+++ b/lib/html/HTMLGenerator.js
@@ -1,0 +1,46 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const { OriginalSource } = require("webpack-sources");
+
+class HTMLGenerator {
+	generate(module, { moduleGraph }) {
+		let source = module.originalSource().source();
+
+		for (const dependency of module.dependencies) {
+			const resolved = moduleGraph.getResolvedModule(dependency);
+
+			if (dependency.name.includes("HTML__URL")) {
+				source = source.replace(
+					"${" + dependency.name + "}",
+					"/" + Object.keys(resolved.buildInfo.assets)[0]
+				);
+			}
+
+			if (dependency.name.includes("HTML__IMPORT")) {
+				source = source.replace(
+					"${" + dependency.name + "}",
+					resolved.originalSource().source()
+				);
+			}
+
+			if (dependency.name.includes("HTML__ENTRY")) {
+				source = source.replace(dependency.name, resolved.userRequest);
+			}
+		}
+
+		const issuer = moduleGraph.getIssuer(module);
+
+		if (issuer && issuer.type.includes("javascript")) {
+			source = `module.exports = ${JSON.stringify(source)}`;
+		}
+
+		return new OriginalSource(source);
+	}
+}
+
+module.exports = HTMLGenerator;

--- a/lib/html/HTMLModulesPlugin.js
+++ b/lib/html/HTMLModulesPlugin.js
@@ -1,0 +1,176 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const HTMLGenerator = require("./HTMLGenerator");
+const HTMLParser = require("./HTMLParser");
+const HTMLTemplate = require("./HTMLTemplate");
+
+const {
+	HTMLURLDependency,
+	HTMLEntryDependency,
+	HTMLImportDependency
+} = require("./dependencies");
+
+const { SyncBailHook } = require("tapable");
+const { ConcatSource } = require("webpack-sources");
+const Compilation = require("../Compilation");
+const JavascriptModulesPlugin = require("../JavascriptModulesPlugin");
+
+const hooksMap = new WeakMap();
+
+class HTMLModulesPlugin {
+	constructor() {
+		this.plugin = {
+			name: "HTMLModulesPlugin"
+		};
+	}
+
+	static getHooks(compilation) {
+		if (!(compilation instanceof Compilation)) {
+			throw new TypeError(
+				"The 'compilation' argument must be an instance of Compilation"
+			);
+		}
+
+		let hooks = hooksMap.get(compilation);
+
+		if (hooks === undefined) {
+			hooks = {
+				shouldRender: new SyncBailHook(["module", "chunk"])
+			};
+
+			hooksMap.set(compilation, hooks);
+		}
+
+		return hooks;
+	}
+
+	apply(compiler) {
+		const { plugin } = this;
+		const { compilation } = compiler.hooks;
+
+		compilation.tap(plugin, (compilation, { normalModuleFactory }) => {
+			const { createParser, createGenerator } = normalModuleFactory.hooks;
+
+			createParser.for("html").tap(plugin, options => {
+				return new HTMLParser(options);
+			});
+
+			createGenerator.for("html").tap(plugin, () => {
+				return new HTMLGenerator();
+			});
+
+			const { moduleGraph } = compilation;
+
+			const js = JavascriptModulesPlugin.getHooks(compilation);
+			const html = HTMLModulesPlugin.getHooks(compilation);
+			// HTML Components (JS Module (Issuer) => HTML Module)
+			//
+			// ```
+			// import html from './import.html'
+			//```
+			js.shouldRender.tap(plugin, module => {
+				if (module.type === "html") {
+					const issuer = moduleGraph.getIssuer(module);
+
+					return issuer && issuer.type.includes("javascript");
+				}
+			});
+			// HTML Components (HTML Module (Issuer) => HTML Module)
+			//
+			// ```
+			// <import src="./import.html"></import>
+			//```
+			html.shouldRender.tap(plugin, module => {
+				if (module.type === "html") {
+					const issuer = moduleGraph.getIssuer(module);
+
+					// TODO(michael-ciniawsky)
+					// HACK for HTML Entries
+					if (!issuer) {
+						return true;
+					}
+
+					return issuer && issuer.type === "html";
+				}
+			});
+
+			const { dependencyFactories, dependencyTemplates } = compilation;
+
+			dependencyFactories.set(HTMLURLDependency, normalModuleFactory);
+			dependencyFactories.set(HTMLEntryDependency, normalModuleFactory);
+			dependencyFactories.set(HTMLImportDependency, normalModuleFactory);
+
+			dependencyTemplates.set(
+				HTMLImportDependency,
+				new HTMLImportDependency.Template()
+			);
+
+			dependencyTemplates.set(
+				HTMLEntryDependency,
+				new HTMLEntryDependency.Template()
+			);
+
+			const { mainTemplate, runtimeTemplate } = compilation;
+
+			mainTemplate.hooks.renderManifest.tap(plugin, (result, options) => {
+				const chunk = options.chunk;
+				// const output = options.outputOptions;
+				const moduleTemplates = options.moduleTemplates;
+				const filenameTemplate = "[name].html";
+				const dependencyTemplates = options.dependencyTemplates;
+
+				const { chunkGraph } = compilation;
+
+				if (chunk.name !== "index") {
+					return;
+				}
+
+				result.push({
+					render: () =>
+						this.renderChunk(
+							compilation,
+							compilation.mainTemplate,
+							moduleTemplates.html,
+							{
+								chunk,
+								dependencyTemplates,
+								runtimeTemplate,
+								moduleGraph,
+								chunkGraph
+							}
+						),
+					filenameTemplate,
+					pathOptions: {
+						chunkGraph,
+						chunk
+					},
+					identifier: `HTML Chunk ${chunk.id}`,
+					hash: null
+				});
+
+				return result;
+			});
+		});
+	}
+
+	renderChunk(compilation, chunkTemplate, moduleTemplate, renderContext) {
+		const hooks = HTMLModulesPlugin.getHooks(compilation);
+
+		const { chunk } = renderContext;
+
+		const sources = HTMLTemplate.render(
+			renderContext,
+			module => hooks.shouldRender.call(module, chunk),
+			moduleTemplate
+		);
+
+		return new ConcatSource(sources);
+	}
+}
+
+module.exports = HTMLModulesPlugin;

--- a/lib/html/HTMLParser.js
+++ b/lib/html/HTMLParser.js
@@ -1,0 +1,133 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const posthtml = require("posthtml");
+const { imports, urls } = require("@posthtml/esm");
+const entries = require("./plugins/entries");
+
+const {
+	HTMLURLDependency,
+	HTMLEntryDependency,
+	HTMLImportDependency,
+	HTMLExportDependency
+} = require("./dependencies");
+
+const SingleEntryPlugin = require("../SingleEntryPlugin");
+
+const { OriginalSource } = require("webpack-sources");
+
+const isDependency = msg => {
+	return (
+		msg.type.includes("import") ||
+		msg.type.includes("export") ||
+		msg.type.includes("entry")
+	);
+};
+
+class HTMLParser {
+	constructor(options = {}) {
+		this.options = options;
+	}
+
+	parse(source, state, cb) {
+		const plugins = [
+			entries(),
+			urls({
+				url: /ENTRY/
+			}),
+			imports({
+				imports: true
+			})
+		];
+
+		const options = {
+			to: state.module.resource,
+			from: state.module.resource
+		};
+
+		posthtml(plugins)
+			.process(source, options)
+			.then(({ tree, html, messages }) => {
+				state.module._ast = tree;
+				state.module._source = new OriginalSource(html);
+
+				const dependencies = messages.filter(isDependency);
+
+				return dependencies.reduce(
+					(done, dep) =>
+						new Promise((resolve, reject) => {
+							if (dep.name.includes("HTML__ENTRY")) {
+								state.module.addDependency(
+									new HTMLEntryDependency(dep.url, dep.name),
+									err => {
+										if (err) reject(err);
+
+										resolve();
+									}
+								);
+
+								const dependency = SingleEntryPlugin.createDependency(
+									dep.url,
+									dep.name
+								);
+
+								state.compilation.addEntry(
+									state.module.context,
+									dependency,
+									dep.name,
+									err => {
+										if (err) reject(err);
+
+										resolve();
+									}
+								);
+							}
+
+							if (dep.name.includes("HTML__URL")) {
+								const dependency = new HTMLURLDependency(dep.url, dep.name);
+
+								state.module.addDependency(dependency, err => {
+									if (err) reject(err);
+
+									resolve();
+								});
+							}
+
+							if (dep.name.includes("HTML__IMPORT")) {
+								const dependency = new HTMLImportDependency(dep.url, dep.name);
+
+								state.module.addDependency(dependency, err => {
+									if (err) reject(err);
+
+									resolve();
+								});
+							}
+
+							if (dep.name.includes("HTML__EXPORT")) {
+								const dependency = new HTMLExportDependency(
+									dep.export(),
+									dep.name
+								);
+
+								state.module.addDependency(dependency, err => {
+									if (err) reject(err);
+
+									resolve();
+								});
+							}
+
+							resolve();
+						}),
+					Promise.resolve()
+				);
+			})
+			.then(() => cb(null, state))
+			.catch(err => cb(err));
+	}
+}
+
+module.exports = HTMLParser;

--- a/lib/html/HTMLTemplate.js
+++ b/lib/html/HTMLTemplate.js
@@ -1,0 +1,52 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const { ConcatSource } = require("webpack-sources");
+
+class HTMLTemplate {
+	static render(renderContext, filterFn, moduleTemplate) {
+		const { chunk, chunkGraph } = renderContext;
+
+		const result = new ConcatSource();
+
+		const modules = chunkGraph.getChunkModules(chunk).filter(filterFn);
+		const removedModules = chunk.removedModules;
+
+		const sources = modules.map(module => {
+			return {
+				id: chunkGraph.getModuleId(module),
+				source: moduleTemplate.render(module, renderContext)
+			};
+		});
+
+		if (removedModules && removedModules.length > 0) {
+			for (const id of removedModules) {
+				sources.push({
+					id: id,
+					source: "<!-- HTML Module removed -->"
+				});
+			}
+		}
+
+		sources.sort().reduceRight((result, module, idx) => {
+			if (idx !== 0) {
+				result.add("\n");
+			}
+
+			result.add(`\n<!-- ${module.id} -->\n`);
+			result.add(module.source);
+
+			return result;
+		}, result);
+
+		result.add("\n");
+
+		return result;
+	}
+}
+
+module.exports = HTMLTemplate;

--- a/lib/html/dependencies/HTMLEntryDependency.js
+++ b/lib/html/dependencies/HTMLEntryDependency.js
@@ -1,0 +1,40 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const ModuleDependency = require("../../dependencies/ModuleDependency");
+const DependencyReference = require("../../dependencies/DependencyReference");
+
+class HTMLEntryDependency extends ModuleDependency {
+	constructor(request, name) {
+		super(request);
+
+		this.name = name;
+	}
+
+	get type() {
+		return "html entry";
+	}
+
+	getReference(moduleGraph) {
+		if (!moduleGraph.getModule(this)) {
+			return null;
+		}
+
+		return new DependencyReference(
+			() => moduleGraph.getModule(this),
+			false,
+			this.weak,
+			this.sourceOrder
+		);
+	}
+}
+
+HTMLEntryDependency.Template = class HTMLEntryDependencyTemplate {
+	apply(dependency, source, templateContext) {}
+};
+
+module.exports = HTMLEntryDependency;

--- a/lib/html/dependencies/HTMLExportDependency.js
+++ b/lib/html/dependencies/HTMLExportDependency.js
@@ -1,0 +1,28 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const NullDependency = require("../../dependencies/NullDependency");
+
+class HTMLExportDependency extends NullDependency {
+	constructor(exports) {
+		super();
+
+		this.exports = exports;
+	}
+
+	get type() {
+		return "html exports";
+	}
+
+	getExports() {
+		return {
+			exports: this.exports
+		};
+	}
+}
+
+module.exports = HTMLExportDependency;

--- a/lib/html/dependencies/HTMLImportDependency.js
+++ b/lib/html/dependencies/HTMLImportDependency.js
@@ -1,0 +1,40 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const ModuleDependency = require("../../dependencies/ModuleDependency");
+const DependencyReference = require("../../dependencies/DependencyReference");
+
+class HTMLImportDependency extends ModuleDependency {
+	constructor(request, name) {
+		super(request);
+
+		this.name = name;
+	}
+
+	get type() {
+		return "html import";
+	}
+
+	getReference(moduleGraph) {
+		if (!moduleGraph.getModule(this)) {
+			return null;
+		}
+
+		return new DependencyReference(
+			() => moduleGraph.getModule(this),
+			false,
+			this.weak,
+			this.sourceOrder
+		);
+	}
+}
+
+HTMLImportDependency.Template = class HTMLImportDependencyTemplate {
+	apply(dependency, source, templateContext) {}
+};
+
+module.exports = HTMLImportDependency;

--- a/lib/html/dependencies/HTMLURLDependency.js
+++ b/lib/html/dependencies/HTMLURLDependency.js
@@ -1,0 +1,36 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const ModuleDependency = require("../../dependencies/ModuleDependency");
+const DependencyReference = require("../../dependencies/DependencyReference");
+
+class HTMLURLDependency extends ModuleDependency {
+	constructor(request, name) {
+		super(request);
+
+		this.name = name;
+	}
+
+	get type() {
+		return "html url";
+	}
+
+	getReference(moduleGraph) {
+		if (!moduleGraph.getModule(this)) {
+			return null;
+		}
+
+		return new DependencyReference(
+			() => moduleGraph.getModule(this),
+			false,
+			this.weak,
+			this.sourceOrder
+		);
+	}
+}
+
+module.exports = HTMLURLDependency;

--- a/lib/html/dependencies/index.js
+++ b/lib/html/dependencies/index.js
@@ -1,0 +1,18 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const HTMLURLDependency = require("./HTMLURLDependency");
+const HTMLEntryDependency = require("./HTMLEntryDependency");
+const HTMLImportDependency = require("./HTMLImportDependency");
+const HTMLExportDependency = require("./HTMLExportDependency");
+
+module.exports = {
+	HTMLURLDependency,
+	HTMLEntryDependency,
+	HTMLImportDependency,
+	HTMLExportDependency
+};

--- a/lib/html/plugins/entries.js
+++ b/lib/html/plugins/entries.js
@@ -1,0 +1,34 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const plugin = options => {
+	return function entries(tree) {
+		let idx = 0;
+
+		tree.match({ tag: "script" }, node => {
+			if (node.attrs) {
+				delete node.attrs.entry;
+
+				tree.messages.push({
+					type: "entry",
+					url: node.attrs.src,
+					name: `HTML__ENTRY__${idx}`
+				});
+
+				node.attrs.src = `HTML__ENTRY__${idx}`;
+			}
+
+			idx++;
+
+			return node;
+		});
+
+		return tree;
+	};
+};
+
+module.exports = plugin;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "tapable": "^1.1.0",
     "terser-webpack-plugin": "^1.1.0",
     "watchpack": "^1.5.0",
-    "webpack-sources": "^1.2.0"
+    "webpack-sources": "^1.2.0",
+    "@posthtml/esm": "^1.0.0",
+    "posthtml": "^0.11.3"
   },
   "devDependencies": {
     "@types/node": "^9.6.4",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1564,6 +1564,7 @@
             "javascript/dynamic",
             "javascript/esm",
             "json",
+            "html",
             "webassembly/experimental"
           ]
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,10 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@posthtml/esm@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@posthtml/esm/-/esm-1.0.0.tgz#09bcb28a02438dcee22ad1970ca1d85a000ae0cf"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -1603,9 +1607,24 @@ doctypes@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/doctypes/-/doctypes-1.1.0.tgz#ea80b106a87538774e8a3a4a5afe293de489e0a9"
 
+dom-serializer@0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+  dependencies:
+    domelementtype "~1.1.1"
+    entities "~1.1.1"
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
+
+domelementtype@1, domelementtype@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+
+domelementtype@~1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
 
 domexception@^1.0.0:
   version "1.0.1"
@@ -1613,7 +1632,29 @@ domexception@^1.0.0:
   dependencies:
     webidl-conversions "^4.0.2"
 
-duplexify@^3.4.2, duplexify@^3.6.0:
+domhandler@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
+  dependencies:
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
+duplexify@^3.4.2:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.1.tgz#4e1516be68838bc90a49994f0b39a6e5960befcd"
+  dependencies:
+    end-of-stream "^1.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+    stream-shift "^1.0.0"
+
+duplexify@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.6.0.tgz#592903f5d80b38d037220541264d69a198fb3410"
   dependencies:
@@ -1672,7 +1713,17 @@ enhanced-resolve@^4.1.0:
     memory-fs "^0.4.0"
     tapable "^1.0.0"
 
-errno@^0.1.1, errno@^0.1.3, errno@~0.1.7:
+entities@^1.1.1, entities@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+errno@^0.1.1, errno@^0.1.3:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.6.tgz#c386ce8a6283f14fc09563b71560908c9bf53026"
+  dependencies:
+    prr "~1.0.1"
+
+errno@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
   dependencies:
@@ -2532,6 +2583,17 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+htmlparser2@^3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -2987,7 +3049,7 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
-isobject@^2.0.0:
+isobject@^2.0.0, isobject@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
@@ -4844,6 +4906,26 @@ postcss@^6.0.1:
     chalk "^2.4.1"
     source-map "^0.6.1"
     supports-color "^5.4.0"
+
+posthtml-parser@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.3.3.tgz#3fe986fca9f00c0f109d731ba590b192f26e776d"
+  dependencies:
+    htmlparser2 "^3.9.2"
+    isobject "^2.1.0"
+    object-assign "^4.1.1"
+
+posthtml-render@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-1.1.0.tgz#854fcaaf3d4b9c8c1dc736fd5d80e52b709d98b7"
+
+posthtml@^0.11.3:
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/posthtml/-/posthtml-0.11.3.tgz#17ea2921b0555b7455f33c977bd16d8b8cb74f27"
+  dependencies:
+    object-assign "^4.1.1"
+    posthtml-parser "^0.3.3"
+    posthtml-render "^1.1.0"
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This PR attempts to add support for a new module type (`module.type === 'html'`)  to support HTML 'natively', replacing the need for loaders/plugins like the `html-loader/html-webpack-plugin` and  **adding support for using HTML as an Entrypoint** and to declare Entrypoints  (JS, CSS, HTML) from within the HTML Template

**`entry.html`**
```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8">
    <title>HTML Modules</title>
    <!-- Entrypoint Support (CSS) -->
    <link href="./entry.css" rel="stylesheet" entry>
  </head>
  <body>
    <div>
      <!-- HTML Module Support -->
      <import src="./import.html"></import>

      <!-- Asset Module Support -->
      <img src="./assets/file.png">

      <!-- Entrypoint Support (HTML) -->
      <a href="./entry.html" entry></a>

      <!-- Entrypoint Support (JS) -->
      <script src="./entry.js" entry></script>
    </div>
  </body>
</html>
```

**`webpack.config.js`**
```js
const config = {
  entry: {
    index: 'path/to/entry.html'
  },
  module: {
    rules: [
       {
           test: /\.html$/,
           type: 'html'
       },
       ...
    ]
  }
}
```

> :information_source: This PR includes defaults for common `module.rules`, so normally it won't be necessary to specify `module.rules` for common cases (`.html`) like in the example above, it's sole purpose is to illustrate the concept, adding custom rules for e.g other templating languages (`.pug` etc) is of course supported aswell

---
### TODO

### Fix

- [ ] Render HTML correctly 
   - `HTMLTemplate`
   - `HTMLGenerator` (Dependencies)
- [ ] Replace entrypoint placeholders with `output` URLs (Assets URLs)
   - needs to rerender on every change, alonside the changes files

### Feature

- [ ] Figure out how to treat/handle a HTML `ChunkGroup/Chunk` (Entrypoint)
- [ ] `output` (`webpack.config.js`) Support (e.g `[name].[ext]`)
   - no `[hash]` placeholder support (doesn't make sense)
   - the 'main'  entry should ideally (always) be named `index` (`index.html`)
- [ ] `preload`  Support
- [ ] `prefetch` Support
  - `<a rel="next" href="./entry.html" entry>` (maybe)

### Chore

- [ ] Add Type Definitions

### Test

- [ ] Add tests
---