### PR TITLE
EvalSourceMapDevToolPlugin: add ability to filter modules

### DIFF
--- a/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
+++ b/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
@@ -19,9 +19,14 @@ class EvalSourceMapDevToolModuleTemplatePlugin {
 	apply(moduleTemplate) {
 		const self = this;
 		const options = this.options;
+		const matchModule = ModuleFilenameHelpers.matchObject.bind(ModuleFilenameHelpers, options);
 		moduleTemplate.hooks.module.tap("EvalSourceMapDevToolModuleTemplatePlugin", (source, module) => {
 			if(source.__EvalSourceMapDevToolData)
 				return source.__EvalSourceMapDevToolData;
+			if(!matchModule(module.resource)) {
+				return source;
+			}
+
 			let sourceMap;
 			let content;
 			if(source.sourceAndMap) {

--- a/test/configCases/source-map/exclude-modules-source-map/index.js
+++ b/test/configCases/source-map/exclude-modules-source-map/index.js
@@ -1,0 +1,8 @@
+it("bundle1 should include eval sourcemapped test1.js and test2.js as is", function() {
+	var fs = require("fs");
+	var path = require("path");
+	var bundle1 = fs.readFileSync(path.join(__dirname, "bundle1.js"), "utf-8");
+	bundle1.should.containEql("eval(\"var test1marker");
+	bundle1.should.containEql("var test2marker");
+	bundle1.should.not.containEql("eval(\"var test2marker");
+});

--- a/test/configCases/source-map/exclude-modules-source-map/test1.js
+++ b/test/configCases/source-map/exclude-modules-source-map/test1.js
@@ -1,0 +1,3 @@
+var test1marker = {};
+
+module.exports = test1marker;

--- a/test/configCases/source-map/exclude-modules-source-map/test2.js
+++ b/test/configCases/source-map/exclude-modules-source-map/test2.js
@@ -1,0 +1,3 @@
+var test2marker = {};
+
+module.exports = test2marker;

--- a/test/configCases/source-map/exclude-modules-source-map/webpack.config.js
+++ b/test/configCases/source-map/exclude-modules-source-map/webpack.config.js
@@ -1,0 +1,22 @@
+var webpack = require("../../../../");
+module.exports = {
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	entry: {
+		bundle0: ["./index.js"],
+		bundle1: ["./test1.js", "./test2.js"]
+	},
+	output: {
+		filename: "[name].js"
+	},
+	plugins: [
+		new webpack.EvalSourceMapDevToolPlugin({
+			include: /\.js$/,
+			exclude: /test2\.js/,
+			module: true,
+			columns: false
+		})
+	]
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature. 

**Did you add tests for your changes?**
yes

**If relevant, link to documentation update:**
It's weird, the documentation contains this, see https://webpack.js.org/plugins/eval-source-map-dev-tool-plugin/, but when I run the new unit test I added, it fails... which indicates that maybe the docs were mistakenly added??? Unless I am missing something.

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Adding ability to filter which modules get sourcemapped when using EvalSourceMapDevToolPlugin.
See: https://github.com/webpack/webpack/issues/6450
This is useful to filter out stuff you don't care about or stuff that's very large and screws up with devtools.

**Does this PR introduce a breaking change?**
no

