### PR TITLE
Set nodeEnv to default to "production"

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -213,7 +213,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 				}).apply(compiler);
 			}
 		}]);
-		this.set("optimization.nodeEnv", "make", options => options.mode || "production")
+		this.set("optimization.nodeEnv", "make", options => options.mode || "production");
 
 		this.set("resolve", "call", value => Object.assign({}, value));
 		this.set("resolve.unsafeCache", true);

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -213,7 +213,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 				}).apply(compiler);
 			}
 		}]);
-		this.set("optimization.nodeEnv", "make", options => options.mode);
+		this.set("optimization.nodeEnv", "make", options => options.mode || "production")
 
 		this.set("resolve", "call", value => Object.assign({}, value));
 		this.set("resolve.unsafeCache", true);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
n/a
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
By default we have decided to set mode: production, however we forgot to set nodeEnv to "production". This makes libraries like React and Vue OOB using no mode, look more bloated then they are.
**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
