### PR TITLE
Use MD4 for hashing

### DIFF
--- a/lib/HashedModuleIdsPlugin.js
+++ b/lib/HashedModuleIdsPlugin.js
@@ -14,7 +14,7 @@ class HashedModuleIdsPlugin {
 
 		this.options = Object.assign({
 			context: null,
-			hashFunction: "md5",
+			hashFunction: "md4",
 			hashDigest: "base64",
 			hashDigestLength: 4
 		}, options);

--- a/lib/ModuleFilenameHelpers.js
+++ b/lib/ModuleFilenameHelpers.js
@@ -42,7 +42,7 @@ const getBefore = (str, token) => {
 };
 
 const getHash = str => {
-	const hash = createHash("md5");
+	const hash = createHash("md4");
 	hash.update(str);
 	return hash.digest("hex").substr(0, 4);
 };

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -211,7 +211,7 @@ class SourceMapDevToolPlugin {
 							basename: basename(filename)
 						});
 						if(sourceMapFile.includes("[contenthash]")) {
-							sourceMapFile = sourceMapFile.replace(/\[contenthash\]/g, createHash("md5").update(sourceMapString).digest("hex"));
+							sourceMapFile = sourceMapFile.replace(/\[contenthash\]/g, createHash("md4").update(sourceMapString).digest("hex"));
 						}
 						const sourceMapUrl = options.publicPath ? options.publicPath + sourceMapFile.replace(/\\/g, "/") : path.relative(path.dirname(file), sourceMapFile).replace(/\\/g, "/");
 						if(currentSourceMappingURLComment !== false) {

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -125,7 +125,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("output.crossOriginLoading", false);
 		this.set("output.jsonpScriptType", false);
 		this.set("output.chunkLoadTimeout", 120000);
-		this.set("output.hashFunction", "md5");
+		this.set("output.hashFunction", "md4");
 		this.set("output.hashDigest", "hex");
 		this.set("output.hashDigestLength", 20);
 		this.set("output.devtoolLineToLine", false);

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -361,7 +361,7 @@ class ConcatenatedModule extends Module {
 				orderedConcatenationListIdentifiers += " ";
 			}
 		}
-		const hash = createHash("md5");
+		const hash = createHash("md4");
 		hash.update(orderedConcatenationListIdentifiers);
 		return this.rootModule.identifier() + " " + hash.digest("hex");
 	}

--- a/lib/optimize/SplitChunksPlugin.js
+++ b/lib/optimize/SplitChunksPlugin.js
@@ -10,7 +10,7 @@ const GraphHelpers = require("../GraphHelpers");
 const isSubset = require("../util/SetHelpers").isSubset;
 
 const hashFilename = (name) => {
-	return crypto.createHash("md5").update(name).digest("hex").slice(0, 8);
+	return crypto.createHash("md4").update(name).digest("hex").slice(0, 8);
 };
 
 const sortByIdentifier = (a, b) => {

--- a/test/statsCases/aggressive-splitting-entry/expected.txt
+++ b/test/statsCases/aggressive-splitting-entry/expected.txt
@@ -1,53 +1,53 @@
-Hash: 1d3bfcee111df03fa6251d3bfcee111df03fa625
+Hash: a82dbd8d6c7a22df1cafa82dbd8d6c7a22df1caf
 Child fitting:
-    Hash: 1d3bfcee111df03fa625
+    Hash: a82dbd8d6c7a22df1caf
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
                       Asset      Size  Chunks             Chunk Names
-    706f97eb6a2b8fb1a17e.js  1.05 KiB       0  [emitted]  
-    a65f8652fd07c12d0049.js  9.92 KiB       1  [emitted]  
-    4c485a9e1dc58eedfbd1.js  1.94 KiB       2  [emitted]  
-    337c857e3e34cc5ef72d.js  1.94 KiB       3  [emitted]  
-    Entrypoint main = 4c485a9e1dc58eedfbd1.js 337c857e3e34cc5ef72d.js a65f8652fd07c12d0049.js
-    chunk    {0} 706f97eb6a2b8fb1a17e.js 916 bytes <{1}> <{2}> <{3}>
+    fb95acf7c457672e70d0.js  1.05 KiB       0  [emitted]  
+    a1e683753eca705a0882.js  9.92 KiB       1  [emitted]  
+    d43339a3d0f86c6b8d90.js  1.94 KiB       2  [emitted]  
+    6c7fb52c5514dbfbf094.js  1.94 KiB       3  [emitted]  
+    Entrypoint main = d43339a3d0f86c6b8d90.js 6c7fb52c5514dbfbf094.js a1e683753eca705a0882.js
+    chunk    {0} fb95acf7c457672e70d0.js 916 bytes <{1}> <{2}> <{3}>
         > ./g [4] ./index.js 7:0-13
         [7] ./g.js 916 bytes {0} [built]
-    chunk    {1} a65f8652fd07c12d0049.js 1.87 KiB ={2}= ={3}= >{0}< [entry] [rendered]
+    chunk    {1} a1e683753eca705a0882.js 1.87 KiB ={2}= ={3}= >{0}< [entry] [rendered]
         > ./index main
         [3] ./e.js 899 bytes {1} [built]
         [4] ./index.js 111 bytes {1} [built]
         [6] ./f.js 900 bytes {1} [built]
-    chunk    {2} 4c485a9e1dc58eedfbd1.js 1.76 KiB ={1}= ={3}= >{0}< [initial] [rendered] [recorded] aggressive splitted
+    chunk    {2} d43339a3d0f86c6b8d90.js 1.76 KiB ={1}= ={3}= >{0}< [initial] [rendered] [recorded] aggressive splitted
         > ./index main
         [0] ./b.js 899 bytes {2} [built]
         [5] ./a.js 899 bytes {2} [built]
-    chunk    {3} 337c857e3e34cc5ef72d.js 1.76 KiB ={1}= ={2}= >{0}< [initial] [rendered] [recorded] aggressive splitted
+    chunk    {3} 6c7fb52c5514dbfbf094.js 1.76 KiB ={1}= ={2}= >{0}< [initial] [rendered] [recorded] aggressive splitted
         > ./index main
         [1] ./c.js 899 bytes {3} [built]
         [2] ./d.js 899 bytes {3} [built]
 Child content-change:
-    Hash: 1d3bfcee111df03fa625
+    Hash: a82dbd8d6c7a22df1caf
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
                       Asset      Size  Chunks             Chunk Names
-    706f97eb6a2b8fb1a17e.js  1.05 KiB       0  [emitted]  
-    a65f8652fd07c12d0049.js  9.92 KiB       1  [emitted]  
-    4c485a9e1dc58eedfbd1.js  1.94 KiB       2  [emitted]  
-    337c857e3e34cc5ef72d.js  1.94 KiB       3  [emitted]  
-    Entrypoint main = 4c485a9e1dc58eedfbd1.js 337c857e3e34cc5ef72d.js a65f8652fd07c12d0049.js
-    chunk    {0} 706f97eb6a2b8fb1a17e.js 916 bytes <{1}> <{2}> <{3}>
+    fb95acf7c457672e70d0.js  1.05 KiB       0  [emitted]  
+    a1e683753eca705a0882.js  9.92 KiB       1  [emitted]  
+    d43339a3d0f86c6b8d90.js  1.94 KiB       2  [emitted]  
+    6c7fb52c5514dbfbf094.js  1.94 KiB       3  [emitted]  
+    Entrypoint main = d43339a3d0f86c6b8d90.js 6c7fb52c5514dbfbf094.js a1e683753eca705a0882.js
+    chunk    {0} fb95acf7c457672e70d0.js 916 bytes <{1}> <{2}> <{3}>
         > ./g [4] ./index.js 7:0-13
         [7] ./g.js 916 bytes {0} [built]
-    chunk    {1} a65f8652fd07c12d0049.js 1.87 KiB ={2}= ={3}= >{0}< [entry] [rendered]
+    chunk    {1} a1e683753eca705a0882.js 1.87 KiB ={2}= ={3}= >{0}< [entry] [rendered]
         > ./index main
         [3] ./e.js 899 bytes {1} [built]
         [4] ./index.js 111 bytes {1} [built]
         [6] ./f.js 900 bytes {1} [built]
-    chunk    {2} 4c485a9e1dc58eedfbd1.js 1.76 KiB ={1}= ={3}= >{0}< [initial] [rendered] [recorded] aggressive splitted
+    chunk    {2} d43339a3d0f86c6b8d90.js 1.76 KiB ={1}= ={3}= >{0}< [initial] [rendered] [recorded] aggressive splitted
         > ./index main
         [0] ./b.js 899 bytes {2} [built]
         [5] ./a.js 899 bytes {2} [built]
-    chunk    {3} 337c857e3e34cc5ef72d.js 1.76 KiB ={1}= ={2}= >{0}< [initial] [rendered] [recorded] aggressive splitted
+    chunk    {3} 6c7fb52c5514dbfbf094.js 1.76 KiB ={1}= ={2}= >{0}< [initial] [rendered] [recorded] aggressive splitted
         > ./index main
         [1] ./c.js 899 bytes {3} [built]
         [2] ./d.js 899 bytes {3} [built]

--- a/test/statsCases/aggressive-splitting-on-demand/expected.txt
+++ b/test/statsCases/aggressive-splitting-on-demand/expected.txt
@@ -1,61 +1,65 @@
-Hash: af168fd06ab994207f62
+Hash: ca712e9bc95207b9082e
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
                   Asset      Size  Chunks             Chunk Names
-031881c6ced2f576ff79.js  1.94 KiB       5  [emitted]  
-ba1a8dd27d611254d495.js  1.93 KiB       0  [emitted]  
-81950df8ced1664c8037.js  1.96 KiB       2  [emitted]  
-2a7cf3b38962fac54bb9.js  1.94 KiB       3  [emitted]  
-acfde31fdfbd1bdb41c4.js  1.01 KiB       4  [emitted]  
-f4818881f9e5138ad8ac.js     1 KiB       1  [emitted]  
-93666bd6f2b79d06cb66.js  1.94 KiB    6, 7  [emitted]  
-a28f1d7d7367daaaf00a.js     1 KiB       7  [emitted]  
-1c507089c2c8ceb9757d.js  1.94 KiB       8  [emitted]  
-9ac0014114101e5f7d2c.js  1.94 KiB    9, 1  [emitted]  
-f507739d37522e79688a.js  8.38 KiB      10  [emitted]  main
-Entrypoint main = f507739d37522e79688a.js
-chunk    {0} ba1a8dd27d611254d495.js 1.76 KiB <{10}> ={1}= ={2}= ={3}= ={7}= ={9}= [recorded] aggressive splitted
+620d3f8d9bdb989cde07.js  1.94 KiB    6, 7  [emitted]  
+4467a9f70ef8365bcb32.js  1.93 KiB       0  [emitted]  
+8debdc7e72b763a13e35.js  1.96 KiB       2  [emitted]  
+6a2c2702ac98f9f90db9.js  1.94 KiB    3, 1  [emitted]  
+258ba4b441feff644266.js  1.01 KiB       4  [emitted]  
+8ae4998ca98adb2a08ea.js  1.94 KiB       5  [emitted]  
+aafb9d82e452def4c3bb.js     1 KiB       1  [emitted]  
+344e13508b62e833aacf.js     1 KiB       7  [emitted]  
+2aaed192bbfbc2302c53.js  1.94 KiB       8  [emitted]  
+72e04d4eaed46d9aac4c.js  1.94 KiB       9  [emitted]  
+d20b83dfd7d0fd0c8793.js  8.41 KiB      10  [emitted]  main
+1165c0cca1ba14a506ff.js  1.94 KiB      11  [emitted]  
+Entrypoint main = d20b83dfd7d0fd0c8793.js
+chunk    {0} 4467a9f70ef8365bcb32.js 1.76 KiB <{10}> ={1}= ={2}= ={3}= ={7}= ={9}= [recorded] aggressive splitted
     > ./b ./d ./e ./f ./g [11] ./index.js 5:0-44
     > ./b ./d ./e ./f ./g ./h ./i ./j ./k [11] ./index.js 6:0-72
     [0] ./b.js 899 bytes {0} {5} [built]
     [1] ./d.js 899 bytes {0} {8} [built]
-chunk    {1} f4818881f9e5138ad8ac.js 899 bytes <{10}> ={0}= ={2}= ={8}=
+chunk    {1} aafb9d82e452def4c3bb.js 899 bytes <{10}> ={0}= ={2}= ={8}=
     > ./c ./d ./e [11] ./index.js 3:0-30
     > ./b ./d ./e ./f ./g [11] ./index.js 5:0-44
-    [2] ./e.js 899 bytes {1} {9} [built]
-chunk    {2} 81950df8ced1664c8037.js 1.76 KiB <{10}> ={0}= ={1}= ={3}= ={6}= ={7}= ={9}= [recorded] aggressive splitted
+    [2] ./e.js 899 bytes {1} {3} [built]
+chunk    {2} 8debdc7e72b763a13e35.js 1.76 KiB <{10}> ={0}= ={1}= ={11}= ={3}= ={6}= ={7}= ={9}= [recorded] aggressive splitted
     > ./f ./g ./h ./i ./j ./k [11] ./index.js 4:0-51
     > ./b ./d ./e ./f ./g [11] ./index.js 5:0-44
     > ./b ./d ./e ./f ./g ./h ./i ./j ./k [11] ./index.js 6:0-72
     [3] ./f.js 899 bytes {2} [built]
     [4] ./g.js 901 bytes {2} [built]
-chunk    {3} 2a7cf3b38962fac54bb9.js 1.76 KiB <{10}> ={0}= ={2}= ={6}= ={7}= ={9}= [recorded] aggressive splitted
-    > ./f ./g ./h ./i ./j ./k [11] ./index.js 4:0-51
+chunk    {3} 6a2c2702ac98f9f90db9.js 1.76 KiB <{10}> ={0}= ={2}= ={7}= ={9}= [rendered] [recorded] aggressive splitted
     > ./b ./d ./e ./f ./g ./h ./i ./j ./k [11] ./index.js 6:0-72
-    [6] ./h.js 899 bytes {3} [built]
-    [7] ./i.js 899 bytes {3} [built]
-chunk    {4} acfde31fdfbd1bdb41c4.js 899 bytes <{10}>
+    [2] ./e.js 899 bytes {1} {3} [built]
+    [6] ./h.js 899 bytes {3} {11} [built]
+chunk    {4} 258ba4b441feff644266.js 899 bytes <{10}>
     > ./a [11] ./index.js 1:0-16
    [10] ./a.js 899 bytes {4} [built]
-chunk    {5} 031881c6ced2f576ff79.js 1.76 KiB <{10}>
+chunk    {5} 8ae4998ca98adb2a08ea.js 1.76 KiB <{10}>
     > ./b ./c [11] ./index.js 2:0-23
     [0] ./b.js 899 bytes {0} {5} [built]
     [5] ./c.js 899 bytes {5} {8} [built]
-chunk    {6} 93666bd6f2b79d06cb66.js 1.76 KiB <{10}> ={2}= ={3}=
+chunk    {6} 620d3f8d9bdb989cde07.js 1.76 KiB <{10}> ={11}= ={2}=
     > ./f ./g ./h ./i ./j ./k [11] ./index.js 4:0-51
     [8] ./j.js 901 bytes {6} {9} [built]
     [9] ./k.js 899 bytes {6} {7} [built]
-chunk    {7} a28f1d7d7367daaaf00a.js 899 bytes <{10}> ={0}= ={2}= ={3}= ={9}=
+chunk    {7} 344e13508b62e833aacf.js 899 bytes <{10}> ={0}= ={2}= ={3}= ={9}=
     > ./b ./d ./e ./f ./g ./h ./i ./j ./k [11] ./index.js 6:0-72
     [9] ./k.js 899 bytes {6} {7} [built]
-chunk    {8} 1c507089c2c8ceb9757d.js 1.76 KiB <{10}> ={1}= [recorded] aggressive splitted
+chunk    {8} 2aaed192bbfbc2302c53.js 1.76 KiB <{10}> ={1}= [recorded] aggressive splitted
     > ./c ./d ./e [11] ./index.js 3:0-30
     [1] ./d.js 899 bytes {0} {8} [built]
     [5] ./c.js 899 bytes {5} {8} [built]
-chunk    {9} 9ac0014114101e5f7d2c.js 1.76 KiB <{10}> ={0}= ={2}= ={3}= ={7}= [recorded] aggressive splitted
+chunk    {9} 72e04d4eaed46d9aac4c.js 1.76 KiB <{10}> ={0}= ={2}= ={3}= ={7}= [rendered] [recorded] aggressive splitted
     > ./b ./d ./e ./f ./g ./h ./i ./j ./k [11] ./index.js 6:0-72
-    [2] ./e.js 899 bytes {1} {9} [built]
+    [7] ./i.js 899 bytes {9} {11} [built]
     [8] ./j.js 901 bytes {6} {9} [built]
-chunk   {10} f507739d37522e79688a.js (main) 248 bytes >{0}< >{1}< >{2}< >{3}< >{4}< >{5}< >{6}< >{7}< >{8}< >{9}< [entry]
+chunk   {10} d20b83dfd7d0fd0c8793.js (main) 248 bytes >{0}< >{1}< >{11}< >{2}< >{3}< >{4}< >{5}< >{6}< >{7}< >{8}< >{9}< [entry] [rendered]
     > ./index main
    [11] ./index.js 248 bytes {10} [built]
+chunk   {11} 1165c0cca1ba14a506ff.js 1.76 KiB <{10}> ={2}= ={6}= [rendered] [recorded] aggressive splitted
+    > ./f ./g ./h ./i ./j ./k [11] ./index.js 4:0-51
+    [6] ./h.js 899 bytes {3} {11} [built]
+    [7] ./i.js 899 bytes {9} {11} [built]

--- a/test/statsCases/chunks-development/expected.txt
+++ b/test/statsCases/chunks-development/expected.txt
@@ -1,4 +1,4 @@
-Hash: 5ce1f032cffdff8368b5
+Hash: e81afb52ad447e8765ab
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
       Asset       Size  Chunks             Chunk Names

--- a/test/statsCases/chunks/expected.txt
+++ b/test/statsCases/chunks/expected.txt
@@ -1,4 +1,4 @@
-Hash: 7870601bc1a1a4f9c4c1
+Hash: 4a1bda30edd6ae541ab2
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
       Asset       Size  Chunks             Chunk Names

--- a/test/statsCases/color-disabled/expected.txt
+++ b/test/statsCases/color-disabled/expected.txt
@@ -1,4 +1,4 @@
-Hash: 5ebdffcace96139575ac
+Hash: 0b32ee714cee3c8b25d4
 Time: Xms
 Built at: Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT
   Asset      Size  Chunks             Chunk Names

--- a/test/statsCases/color-enabled-custom/expected.txt
+++ b/test/statsCases/color-enabled-custom/expected.txt
@@ -1,4 +1,4 @@
-Hash: <CLR=BOLD>5ebdffcace96139575ac</CLR>
+Hash: <CLR=BOLD>0b32ee714cee3c8b25d4</CLR>
 Time: <CLR=BOLD>X</CLR>ms
 Built at: Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT
   <CLR=BOLD>Asset</CLR>      <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22><CLR=BOLD>Chunk Names</CLR>

--- a/test/statsCases/color-enabled/expected.txt
+++ b/test/statsCases/color-enabled/expected.txt
@@ -1,4 +1,4 @@
-Hash: <CLR=BOLD>5ebdffcace96139575ac</CLR>
+Hash: <CLR=BOLD>0b32ee714cee3c8b25d4</CLR>
 Time: <CLR=BOLD>X</CLR>ms
 Built at: Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT
   <CLR=BOLD>Asset</CLR>      <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22><CLR=BOLD>Chunk Names</CLR>

--- a/test/statsCases/commons-chunk-min-size-0/expected.txt
+++ b/test/statsCases/commons-chunk-min-size-0/expected.txt
@@ -1,4 +1,4 @@
-Hash: 2a374ac6d98475951384
+Hash: cad25b99a073374722a7
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
               Asset       Size  Chunks             Chunk Names

--- a/test/statsCases/commons-chunk-min-size-Infinity/expected.txt
+++ b/test/statsCases/commons-chunk-min-size-Infinity/expected.txt
@@ -1,4 +1,4 @@
-Hash: d86d9e4d7a615c762442
+Hash: c176225f44e51c7a39a4
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
       Asset       Size  Chunks             Chunk Names

--- a/test/statsCases/commons-plugin-issue-4980/expected.txt
+++ b/test/statsCases/commons-plugin-issue-4980/expected.txt
@@ -1,25 +1,25 @@
-Hash: cdd753ac70c5ff3b74bedd7e476c27a1777b4d27
+Hash: 1c62a4c91035f66150df2425703c4fe7d61799b3
 Child
-    Hash: cdd753ac70c5ff3b74be
+    Hash: 1c62a4c91035f66150df
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
                              Asset       Size  Chunks             Chunk Names
                             app.js   5.58 KiB       0  [emitted]  app
-    vendor.a86979cc789cd5f9d78f.js  619 bytes       1  [emitted]  vendor
-    Entrypoint app = vendor.a86979cc789cd5f9d78f.js app.js
+    vendor.c0e73bece4137a7015c2.js  619 bytes       1  [emitted]  vendor
+    Entrypoint app = vendor.c0e73bece4137a7015c2.js app.js
     [./constants.js] 87 bytes {1} [built]
     [./entry-1.js] ./entry-1.js + 2 modules 190 bytes {0} [built]
            | ./entry-1.js 67 bytes [built]
            | ./submodule-a.js 59 bytes [built]
            | ./submodule-b.js 59 bytes [built]
 Child
-    Hash: dd7e476c27a1777b4d27
+    Hash: 2425703c4fe7d61799b3
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
                              Asset       Size  Chunks             Chunk Names
                             app.js    5.6 KiB       0  [emitted]  app
-    vendor.a86979cc789cd5f9d78f.js  619 bytes       1  [emitted]  vendor
-    Entrypoint app = vendor.a86979cc789cd5f9d78f.js app.js
+    vendor.c0e73bece4137a7015c2.js  619 bytes       1  [emitted]  vendor
+    Entrypoint app = vendor.c0e73bece4137a7015c2.js app.js
     [./constants.js] 87 bytes {1} [built]
     [./entry-2.js] ./entry-2.js + 2 modules 197 bytes {0} [built]
            | ./entry-2.js 67 bytes [built]

--- a/test/statsCases/define-plugin/expected.txt
+++ b/test/statsCases/define-plugin/expected.txt
@@ -1,6 +1,6 @@
-Hash: 40b9288c7b06181fe56c92fc98986ee18223c384
+Hash: 189d0d15eb46be80d1f9eaead63561588b554cc6
 Child
-    Hash: 40b9288c7b06181fe56c
+    Hash: 189d0d15eb46be80d1f9
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
       Asset      Size  Chunks             Chunk Names
@@ -8,7 +8,7 @@ Child
     Entrypoint main = main.js
        [0] ./index.js 24 bytes {0} [built]
 Child
-    Hash: 92fc98986ee18223c384
+    Hash: eaead63561588b554cc6
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
       Asset      Size  Chunks             Chunk Names

--- a/test/statsCases/exclude-with-loader/expected.txt
+++ b/test/statsCases/exclude-with-loader/expected.txt
@@ -1,4 +1,4 @@
-Hash: 8ba560cc1610e1d6a812
+Hash: 8b3d74c47fe62d34ee43
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset      Size  Chunks             Chunk Names

--- a/test/statsCases/external/expected.txt
+++ b/test/statsCases/external/expected.txt
@@ -1,4 +1,4 @@
-Hash: bceb26d8b2be7c67df1d
+Hash: 3386bd94ba1fc3ae7f29
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset      Size  Chunks             Chunk Names

--- a/test/statsCases/filter-warnings/expected.txt
+++ b/test/statsCases/filter-warnings/expected.txt
@@ -1,6 +1,6 @@
-Hash: 29c7e69ca39c982193b929c7e69ca39c982193b929c7e69ca39c982193b929c7e69ca39c982193b929c7e69ca39c982193b929c7e69ca39c982193b929c7e69ca39c982193b929c7e69ca39c982193b929c7e69ca39c982193b929c7e69ca39c982193b929c7e69ca39c982193b929c7e69ca39c982193b929c7e69ca39c982193b9
+Hash: 544a1b5857637a949b33544a1b5857637a949b33544a1b5857637a949b33544a1b5857637a949b33544a1b5857637a949b33544a1b5857637a949b33544a1b5857637a949b33544a1b5857637a949b33544a1b5857637a949b33544a1b5857637a949b33544a1b5857637a949b33544a1b5857637a949b33544a1b5857637a949b33
 Child
-    Hash: 29c7e69ca39c982193b9
+    Hash: 544a1b5857637a949b33
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
@@ -20,69 +20,49 @@ Child
     Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
     Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]
 Child
-    Hash: 29c7e69ca39c982193b9
+    Hash: 544a1b5857637a949b33
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
     bundle.js  2.19 KiB       0  [emitted]  main
     Entrypoint main = bundle.js
 Child
-    Hash: 29c7e69ca39c982193b9
+    Hash: 544a1b5857637a949b33
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
     bundle.js  2.19 KiB       0  [emitted]  main
     Entrypoint main = bundle.js
 Child
-    Hash: 29c7e69ca39c982193b9
+    Hash: 544a1b5857637a949b33
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
     bundle.js  2.19 KiB       0  [emitted]  main
     Entrypoint main = bundle.js
 Child
-    Hash: 29c7e69ca39c982193b9
+    Hash: 544a1b5857637a949b33
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
     bundle.js  2.19 KiB       0  [emitted]  main
     Entrypoint main = bundle.js
 Child
-    Hash: 29c7e69ca39c982193b9
+    Hash: 544a1b5857637a949b33
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
     bundle.js  2.19 KiB       0  [emitted]  main
     Entrypoint main = bundle.js
 Child
-    Hash: 29c7e69ca39c982193b9
+    Hash: 544a1b5857637a949b33
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
     bundle.js  2.19 KiB       0  [emitted]  main
     Entrypoint main = bundle.js
 Child
-    Hash: 29c7e69ca39c982193b9
-    Time: Xms
-    Built at: Thu Jan 01 1970 00:00:00 GMT
-        Asset      Size  Chunks             Chunk Names
-    bundle.js  2.19 KiB       0  [emitted]  main
-    Entrypoint main = bundle.js
-    
-    WARNING in bundle.js from UglifyJs
-    Dropping side-effect-free statement [./index.js:6,0]
-    Dropping unused function someUnUsedFunction1 [./index.js:8,0]
-    Dropping unused function someUnUsedFunction2 [./index.js:9,0]
-    Dropping unused function someUnUsedFunction3 [./index.js:10,0]
-    Dropping unused function someUnUsedFunction4 [./index.js:11,0]
-    Dropping unused function someUnUsedFunction5 [./index.js:12,0]
-    Dropping unused function someRemoteUnUsedFunction1 [./a.js:3,0]
-    Dropping unused function someRemoteUnUsedFunction2 [./a.js:4,0]
-    Dropping unused function someRemoteUnUsedFunction3 [./a.js:5,0]
-    Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
-    Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]
-Child
-    Hash: 29c7e69ca39c982193b9
+    Hash: 544a1b5857637a949b33
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
@@ -102,7 +82,7 @@ Child
     Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
     Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]
 Child
-    Hash: 29c7e69ca39c982193b9
+    Hash: 544a1b5857637a949b33
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
@@ -122,7 +102,7 @@ Child
     Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
     Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]
 Child
-    Hash: 29c7e69ca39c982193b9
+    Hash: 544a1b5857637a949b33
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
@@ -142,7 +122,7 @@ Child
     Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
     Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]
 Child
-    Hash: 29c7e69ca39c982193b9
+    Hash: 544a1b5857637a949b33
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
@@ -162,7 +142,27 @@ Child
     Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
     Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]
 Child
-    Hash: 29c7e69ca39c982193b9
+    Hash: 544a1b5857637a949b33
+    Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
+        Asset      Size  Chunks             Chunk Names
+    bundle.js  2.19 KiB       0  [emitted]  main
+    Entrypoint main = bundle.js
+    
+    WARNING in bundle.js from UglifyJs
+    Dropping side-effect-free statement [./index.js:6,0]
+    Dropping unused function someUnUsedFunction1 [./index.js:8,0]
+    Dropping unused function someUnUsedFunction2 [./index.js:9,0]
+    Dropping unused function someUnUsedFunction3 [./index.js:10,0]
+    Dropping unused function someUnUsedFunction4 [./index.js:11,0]
+    Dropping unused function someUnUsedFunction5 [./index.js:12,0]
+    Dropping unused function someRemoteUnUsedFunction1 [./a.js:3,0]
+    Dropping unused function someRemoteUnUsedFunction2 [./a.js:4,0]
+    Dropping unused function someRemoteUnUsedFunction3 [./a.js:5,0]
+    Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
+    Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]
+Child
+    Hash: 544a1b5857637a949b33
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names

--- a/test/statsCases/import-context-filter/expected.txt
+++ b/test/statsCases/import-context-filter/expected.txt
@@ -1,4 +1,4 @@
-Hash: 3812be209526ddc2730f
+Hash: 20afe8e9eb9a69aecddb
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
    Asset       Size  Chunks             Chunk Names

--- a/test/statsCases/import-weak/expected.txt
+++ b/test/statsCases/import-weak/expected.txt
@@ -1,4 +1,4 @@
-Hash: a9db7f3b329c4330e089
+Hash: 1f9db3ad053a3687e3bb
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
    Asset       Size  Chunks             Chunk Names

--- a/test/statsCases/limit-chunk-count-plugin/expected.txt
+++ b/test/statsCases/limit-chunk-count-plugin/expected.txt
@@ -1,6 +1,6 @@
-Hash: 1c28a2310b8d6ad1d2eae9e095881f37f449e557b0dba9af2a29d62e7d950cfed055ea39eaf47f56
+Hash: 599eb45be3863921e183f90c7b21ae5c6e853a0df3a313c9918d7d712c3f113bf580db9e5c6196ce
 Child 1 chunks:
-    Hash: 1c28a2310b8d6ad1d2ea
+    Hash: 599eb45be3863921e183
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
@@ -14,7 +14,7 @@ Child 1 chunks:
         [4] ./d.js 22 bytes {0} [built]
         [5] ./e.js 22 bytes {0} [built]
 Child 2 chunks:
-    Hash: e9e095881f37f449e557
+    Hash: f90c7b21ae5c6e853a0d
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
           Asset       Size  Chunks             Chunk Names
@@ -30,7 +30,7 @@ Child 2 chunks:
     chunk    {1} bundle.js (main) 73 bytes >{0}< [entry] [rendered]
         [5] ./index.js 73 bytes {1} [built]
 Child 3 chunks:
-    Hash: b0dba9af2a29d62e7d95
+    Hash: f3a313c9918d7d712c3f
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
           Asset       Size  Chunks             Chunk Names
@@ -48,7 +48,7 @@ Child 3 chunks:
     chunk    {2} bundle.js (main) 73 bytes >{0}< >{1}< [entry] [rendered]
         [5] ./index.js 73 bytes {2} [built]
 Child 4 chunks:
-    Hash: 0cfed055ea39eaf47f56
+    Hash: 113bf580db9e5c6196ce
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
           Asset       Size  Chunks             Chunk Names

--- a/test/statsCases/max-modules-default/expected.txt
+++ b/test/statsCases/max-modules-default/expected.txt
@@ -1,4 +1,4 @@
-Hash: 0fd8ab10acd7dd67da45
+Hash: c5cf5ab0cc0a404f1acf
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset      Size  Chunks             Chunk Names

--- a/test/statsCases/max-modules/expected.txt
+++ b/test/statsCases/max-modules/expected.txt
@@ -1,4 +1,4 @@
-Hash: 0fd8ab10acd7dd67da45
+Hash: c5cf5ab0cc0a404f1acf
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset      Size  Chunks             Chunk Names

--- a/test/statsCases/named-chunks-plugin-async/expected.txt
+++ b/test/statsCases/named-chunks-plugin-async/expected.txt
@@ -1,4 +1,4 @@
-Hash: 16c09fc31f1686ee930a
+Hash: c5b0089a4015e8744f8e
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
                      Asset       Size                   Chunks             Chunk Names

--- a/test/statsCases/named-chunks-plugin/expected.txt
+++ b/test/statsCases/named-chunks-plugin/expected.txt
@@ -1,4 +1,4 @@
-Hash: 8b9265d1f4b67c8201f5
+Hash: 5df55d54223f36cc303b
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset       Size  Chunks             Chunk Names

--- a/test/statsCases/no-emit-on-errors-plugin-with-child-error/expected.txt
+++ b/test/statsCases/no-emit-on-errors-plugin-with-child-error/expected.txt
@@ -1,4 +1,4 @@
-Hash: 6f576d572dc2e6e75ac3
+Hash: 885948e5541fff6e85ac
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset      Size  Chunks  Chunk Names

--- a/test/statsCases/optimize-chunks/expected.txt
+++ b/test/statsCases/optimize-chunks/expected.txt
@@ -1,4 +1,4 @@
-Hash: 6032753dfe117b1c3893
+Hash: c4c4476c6d07e1bf7404
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
             Asset       Size  Chunks             Chunk Names

--- a/test/statsCases/preset-detailed/expected.txt
+++ b/test/statsCases/preset-detailed/expected.txt
@@ -1,4 +1,4 @@
-Hash: d748792ec03ede1f69dc
+Hash: a181afd92c30187a0eba
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset       Size  Chunks             Chunk Names

--- a/test/statsCases/preset-normal/expected.txt
+++ b/test/statsCases/preset-normal/expected.txt
@@ -1,4 +1,4 @@
-Hash: d748792ec03ede1f69dc
+Hash: a181afd92c30187a0eba
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset       Size  Chunks             Chunk Names

--- a/test/statsCases/preset-verbose/expected.txt
+++ b/test/statsCases/preset-verbose/expected.txt
@@ -1,4 +1,4 @@
-Hash: d748792ec03ede1f69dc
+Hash: a181afd92c30187a0eba
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset       Size  Chunks             Chunk Names

--- a/test/statsCases/resolve-plugin-context/expected.txt
+++ b/test/statsCases/resolve-plugin-context/expected.txt
@@ -1,4 +1,4 @@
-Hash: 20d34a938ae78cffd3f2
+Hash: 47eae06ebcb26f6b883a
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset      Size  Chunks             Chunk Names

--- a/test/statsCases/reverse-sort-modules/expected.txt
+++ b/test/statsCases/reverse-sort-modules/expected.txt
@@ -1,4 +1,4 @@
-Hash: 0fd8ab10acd7dd67da45
+Hash: c5cf5ab0cc0a404f1acf
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset      Size  Chunks             Chunk Names

--- a/test/statsCases/scope-hoisting-bailouts/expected.txt
+++ b/test/statsCases/scope-hoisting-bailouts/expected.txt
@@ -1,4 +1,4 @@
-Hash: 8ea520d39e2a8caaf145
+Hash: 2f9dacd48c09c3072b04
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
 Entrypoint index = index.js

--- a/test/statsCases/scope-hoisting-multi/expected.txt
+++ b/test/statsCases/scope-hoisting-multi/expected.txt
@@ -1,6 +1,6 @@
-Hash: f987d10439866c1320274e05ad6ebdcc88f97d91
+Hash: 1e05cb63c83229a31d7fe3bbe6aa8fb8e8ec3bd9
 Child
-    Hash: f987d10439866c132027
+    Hash: 1e05cb63c83229a31d7f
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
     Entrypoint first = vendor.js first.js
@@ -17,7 +17,7 @@ Child
        [9] ./module_first.js 31 bytes {4} [built]
       [10] ./second.js 177 bytes {5} [built]
 Child
-    Hash: 4e05ad6ebdcc88f97d91
+    Hash: e3bbe6aa8fb8e8ec3bd9
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
     Entrypoint first = vendor.js first.js

--- a/test/statsCases/simple-more-info/expected.txt
+++ b/test/statsCases/simple-more-info/expected.txt
@@ -1,4 +1,4 @@
-Hash: 1911bed74c47698d017f
+Hash: ee367da3e170c28a39bf
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset      Size  Chunks             Chunk Names

--- a/test/statsCases/simple/expected.txt
+++ b/test/statsCases/simple/expected.txt
@@ -1,4 +1,4 @@
-Hash: f0bbd0723c33cf044c2f
+Hash: 18342b523b0aca4784a6
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset      Size  Chunks             Chunk Names

--- a/test/statsCases/split-chunks/expected.txt
+++ b/test/statsCases/split-chunks/expected.txt
@@ -192,10 +192,10 @@ Child manual:
         [5] ./c.js 72 bytes {4} {8} [built]
 Child name-too-long:
     Entrypoint main = main.js
-    Entrypoint aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~716093be.js vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js
-    Entrypoint bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~716093be.js vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js
-    Entrypoint cccccccccccccccccccccccccccccc = vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~716093be.js vendors~async-c~cccccccccccccccccccccccccccccc.js cccccccccccccccccccccccccccccc.js
-    chunk    {0} vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~716093be.js (vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~716093be) 20 bytes <{9}> ={1}= ={10}= ={11}= ={12}= ={2}= ={3}= ={4}= ={6}= ={7}= ={8}= >{2}< >{5}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~716093be)
+    Entrypoint aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~50ebc41f.js vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js
+    Entrypoint bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~50ebc41f.js vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js
+    Entrypoint cccccccccccccccccccccccccccccc = vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~50ebc41f.js vendors~async-c~cccccccccccccccccccccccccccccc.js cccccccccccccccccccccccccccccc.js
+    chunk    {0} vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~50ebc41f.js (vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~50ebc41f) 20 bytes <{9}> ={1}= ={10}= ={11}= ={12}= ={2}= ={3}= ={4}= ={6}= ={7}= ={8}= >{2}< >{5}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~50ebc41f)
         > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
         > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
         > ./c cccccccccccccccccccccccccccccc
@@ -203,7 +203,7 @@ Child name-too-long:
         > ./b [8] ./index.js 2:0-47
         > ./c [8] ./index.js 3:0-47
         [2] ./node_modules/x.js 20 bytes {0} [built]
-    chunk    {1} aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccc~e7d53185.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccc~e7d53185) 20 bytes <{9}> ={0}= ={2}= ={3}= ={4}= ={6}= ={7}= ={8}= >{2}< >{5}< [rendered] split chunk (cache group: default) (name: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccc~e7d53185)
+    chunk    {1} aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccc~18066793.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccc~18066793) 20 bytes <{9}> ={0}= ={2}= ={3}= ={4}= ={6}= ={7}= ={8}= >{2}< >{5}< [rendered] split chunk (cache group: default) (name: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccc~18066793)
         > ./a [8] ./index.js 1:0-47
         > ./b [8] ./index.js 2:0-47
         > ./c [8] ./index.js 3:0-47

--- a/test/statsCases/tree-shaking/expected.txt
+++ b/test/statsCases/tree-shaking/expected.txt
@@ -1,4 +1,4 @@
-Hash: 612f7baf263b811351ca
+Hash: 6877ac726b04eb5d7985
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset      Size  Chunks             Chunk Names

--- a/test/statsCases/warnings-uglifyjs/expected.txt
+++ b/test/statsCases/warnings-uglifyjs/expected.txt
@@ -1,4 +1,4 @@
-Hash: 646a540e1a95f55e1b8c
+Hash: 2d94d00e348948925d75
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset      Size  Chunks             Chunk Names


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

build related change

**Did you add tests for your changes?**

yes

**If relevant, link to documentation update:**

n/a

**Summary**

`md4` is faster than `md5`. Since webpack doesn't need secure hashes, `md4` could be used to improve the build performance.

**Does this PR introduce a breaking change?**

no
