### PR TITLE
Fix HMR browser warnings not appearing in Firefox

### DIFF
--- a/hot/dev-server.js
+++ b/hot/dev-server.js
@@ -40,10 +40,15 @@ if (module.hot) {
 						"warning",
 						"[HMR] Cannot apply update. Need to do a full reload!"
 					);
-					log("warning", "[HMR] " + err.stack || err.message);
+					if (status === "abort") {
+						log("warning", "[HMR] " + err.message);
+					} else {
+						log("warning", err);
+					}
 					window.location.reload();
 				} else {
-					log("warning", "[HMR] Update failed: " + err.stack || err.message);
+					log("warning", "[HMR] Update failed");
+					log("warning", err);
 				}
 			});
 	};

--- a/hot/only-dev-server.js
+++ b/hot/only-dev-server.js
@@ -72,12 +72,14 @@ if (module.hot) {
 						"warning",
 						"[HMR] Cannot check for update. Need to do a full reload!"
 					);
-					log("warning", "[HMR] " + err.stack || err.message);
+					if (status === "abort") {
+						log("warning", "[HMR] " + err.message);
+					} else {
+						log("warning", err);
+					}
 				} else {
-					log(
-						"warning",
-						"[HMR] Update check failed: " + err.stack || err.message
-					);
+					log("warning", "[HMR] Update check failed");
+					log("warning", err);
 				}
 			});
 	};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix, to improve HMR warning output and fix a particular issue with Firefox: https://github.com/webpack/webpack/issues/6589

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Unsure if it's needed, and since this is a cross browser issue it gets quirkier from there.

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

As detailed in https://github.com/webpack/webpack/issues/6589 due to the use of Error.prototype.stack which is a non-standard API, Firefox ends up missing detail relating to why an HMR reload might have happened.

This PR upgrades the HMR browser code to print simpler warnings and fix the issue for Firefox users by removing the stack trace for any errors with an abort status and printing just the message. Abort issues are generated internally, giving the stack trace limited value.

The change looks like this in all browsers for the typical, known errors (note the missing stack trace):

![screenshot_20180227_121045](https://user-images.githubusercontent.com/1351490/36746186-46989a56-1bb7-11e8-9d93-77c72ce8d9c3.png)

Additionally, for any other general errors such as a failed hot update in user code, the Error object is printed explicitly to be handled by the browser rather than use the stack property. Error.prototype.stack is currently non-standard and has different output across implementations --- V8 and Edge include the error message at the top while Firefox includes just the stack trace with no message.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No breaking changes.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
I chose the approach of printing out the Error explicitly for non-abort status errors, but this does end up looking a little odder in Edge/IE (though all the information is present). Error.stack would be better there, but then you hit the same Firefox issue of missing out on the message.