### PR TITLE
Fix version in configuration error messages

### DIFF
--- a/lib/WebpackOptionsValidationError.js
+++ b/lib/WebpackOptionsValidationError.js
@@ -155,7 +155,7 @@ class WebpackOptionsValidationError extends WebpackError {
 					case "debug":
 						return (
 							`${baseMessage}\n` +
-							"The 'debug' property was removed in webpack 2.\n" +
+							"The 'debug' property was removed in webpack 2.0.0.\n" +
 							"Loaders should be updated to allow passing this option via loader options in module.rules.\n" +
 							"Until loaders are updated one can use the LoaderOptionsPlugin to switch loaders into debug mode:\n" +
 							"plugins: [\n" +
@@ -166,8 +166,7 @@ class WebpackOptionsValidationError extends WebpackError {
 						);
 				}
 				return (
-					baseMessage +
-					"\n" +
+					`${baseMessage}\n` +
 					"For typos: please correct them.\n" +
 					"For loader options: webpack >= v2.0.0 no longer allows custom properties in configuration.\n" +
 					"  Loaders should be updated to allow passing options via loader options in module.rules.\n" +


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
I've edited existing test.

**If relevant, link to documentation update:**
N/A

**Summary**
Version in message was hardcoded, I replaced it with the one present in `package.json`.

Fixes #6605 

**Does this PR introduce a breaking change?**
No

**Other information**
Disable prettier on those lines because introduce like break around variable. See:
https://github.com/prettier/prettier/issues/1893
https://github.com/prettier/prettier/issues/3368