### PR TITLE
improve performance of ModuleConcatenationPlugin for loop

### DIFF
--- a/lib/optimize/ModuleConcatenationPlugin.js
+++ b/lib/optimize/ModuleConcatenationPlugin.js
@@ -281,9 +281,12 @@ class ModuleConcatenationPlugin {
 							for (const reason of newModule.reasons) {
 								reason.dependency.module = newModule;
 							}
-							for (const dep of newModule.dependencies) {
+							for (let i = 0; i < newModule.dependencies.length; i++) {
+								let dep = newModule.dependencies[i];
 								if (dep.module) {
-									for (const reason of dep.module.reasons) {
+									let reasons = dep.module.reasons;
+									for (let j = 0; j < reasons.length; j++) {
+										let reason = reasons[j];
 										if (reason.dependency === dep) reason.module = newModule;
 									}
 								}

--- a/lib/optimize/ModuleConcatenationPlugin.js
+++ b/lib/optimize/ModuleConcatenationPlugin.js
@@ -281,6 +281,10 @@ class ModuleConcatenationPlugin {
 							for (const reason of newModule.reasons) {
 								reason.dependency.module = newModule;
 							}
+							// TODO: remove when LTS node version contains fixed v8 version
+							// @see https://github.com/webpack/webpack/pull/6613
+							// Turbofan does not correctly inline for-of loops with polymorphic input arrays.
+							// Work around issue by using a standard for loop and assigning dep.module.reasons
 							for (let i = 0; i < newModule.dependencies.length; i++) {
 								let dep = newModule.dependencies[i];
 								if (dep.module) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix / performance improvement

**Did you add tests for your changes?**

No

**If relevant, link to documentation update:**

N/A

**Summary**

In our large Angular 5 project (~3400 modules) ModuleConcatenationPlugin is now taking 60% of the build time in webpack 4.

Webpack is spending 869499ms in 'chunk modules optimization' within ModuleConcatenationPlugin.

Most of this time is consumed in 2 nested for-of loops in the ModuleConcatenationPlugin. By changing the for-of loops to standard for loops we have reduced the time we spend in ModuleConcatenationPlugin from 14 minutes 29 seconds to 2 minutes 35 seconds.

**Does this PR introduce a breaking change?**

No

**Other information**

Node: 8.9.3
Webpack: 4.0.1 and 4.0.0
Windows 10

During our prod build the inner for-of loop is visited a total of 7,309,580,444 (7.3 billion) times.

When debugging most of the time was spent in the following 2 for loops in ModuleConcatenationPlugin.js. Original time taken: 14m 29s (869499ms)

https://github.com/webpack/webpack/blob/6a5d081f294a225d9f02b56c55fdcd61b7b4db20/lib/optimize/ModuleConcatenationPlugin.js#L284-L290

Changing the above for of loop to a standard for loop reduces the time taken to  6m 8s (368453ms)
```
for (let i = 0; i < newModule.dependencies.length; i++) {
    let dep = newModule.dependencies[i];
    if (dep.module) {
        for (let j = 0; j < dep.module.reasons.length; j++) {
            let reason = dep.module.reasons[j];
            if (reason.dependency === dep) reason.module = newModule;
        }
    }
}
```
Making a further change to `let reasons = dep.module.reasons;` reduces the time taken to 2m 35s (141326ms)

```
for (let i = 0; i < newModule.dependencies.length; i++) {
    let dep = newModule.dependencies[i];
    if (dep.module) {
        let reasons = dep.module.reasons;
        for (let j = 0; j < reasons.length; j++) {
            let reason = reasons[j];
            if (reason.dependency === dep) reason.module = newModule;
        }
    }
}
```