### PR TITLE
defaults: set source map option for UglifyJs to true if SourceMapDevToolPlugin exists

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -264,10 +264,14 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 				apply: compiler => {
 					// Lazy load the uglifyjs plugin
 					const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
+					const SourceMapDevToolPlugin = require("./SourceMapDevToolPlugin");
 					new UglifyJsPlugin({
 						cache: true,
 						parallel: true,
-						sourceMap: options.devtool && /source-?map/.test(options.devtool)
+						sourceMap:
+							(options.devtool && /source-?map/.test(options.devtool)) ||
+							(options.plugins &&
+								options.plugins.some(p => p instanceof SourceMapDevToolPlugin))
 					}).apply(compiler);
 				}
 			}


### PR DESCRIPTION
fixes #6614 

**What kind of change does this PR introduce?**

sets default to allow for source maps w/ mode: production

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

no

**Summary**

See #6614 

**Does this PR introduce a breaking change?**

no

**Other information**
