### PR TITLE
Add 'compile' hook to 'MultiCompiler'

### DIFF
--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -15,6 +15,7 @@ module.exports = class MultiCompiler extends Tapable {
 	constructor(compilers) {
 		super();
 		this.hooks = {
+			compile: new MultiHook(compilers.map(c => c.hooks.compile)),
 			done: new SyncHook(["stats"]),
 			invalid: new MultiHook(compilers.map(c => c.hooks.invalid)),
 			run: new MultiHook(compilers.map(c => c.hooks.run)),

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -22,16 +22,19 @@ const createMultiCompiler = () => {
 };
 
 describe("MultiCompiler", function() {
-	it("should trigger 'run' for each child compiler", done => {
+	it("should trigger 'run' and 'compile' for each child compiler", done => {
 		const compiler = createMultiCompiler();
-		let called = 0;
+		let runCalled = 0;
+		let compileCalled = 0;
 
-		compiler.hooks.run.tap("MultiCompiler test", () => called++);
+		compiler.hooks.run.tap("MultiCompiler test", () => runCalled++);
+		compiler.hooks.compile.tap("MultiCompiler test", () => compileCalled++);
 		compiler.run(err => {
 			if (err) {
 				throw err;
 			} else {
-				should(called).be.equal(2);
+				should(runCalled).be.equal(2);
+				should(compileCalled).be.equal(2);
 				done();
 			}
 		});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

yes

**If relevant, link to documentation update:**

n/a

**Summary**

`webpack-hot-middleware` uses `compiler.hooks.compiler` which was not available for `MultiCompiler` instances.

**Does this PR introduce a breaking change?**

no

**Other information**

Fixes #6633