### PR TITLE
Add output.jsonpBeforeCallback to intercept chunk loading

### DIFF
--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -333,8 +333,8 @@ function webpackAsyncContext(req) {
 	var ids = map[req];
 	if(!ids)
 		return Promise.reject(new Error("Cannot find module '" + req + "'."));
-	return ${requestPrefix}.then(function() {
-		return __webpack_require__(ids[0]);
+	return ${requestPrefix}.then(function(reason) {
+		return reason || __webpack_require__(ids[0]);
 	});
 };
 webpackAsyncContext.keys = function webpackAsyncContextKeys() {

--- a/lib/JsonpMainTemplatePlugin.js
+++ b/lib/JsonpMainTemplatePlugin.js
@@ -30,6 +30,7 @@ class JsonpMainTemplatePlugin {
 			const crossOriginLoading = this.outputOptions.crossOriginLoading;
 			const chunkLoadTimeout = this.outputOptions.chunkLoadTimeout;
 			const jsonpScriptType = this.outputOptions.jsonpScriptType;
+			const jsonpBeforeCallback = this.outputOptions.jsonpBeforeCallback;
 			const scriptSrcPath = this.applyPluginsWaterfall("asset-path", JSON.stringify(chunkFilename), {
 				hash: `" + ${this.renderCurrentHashCode(hash)} + "`,
 				hashWithLength: length => `" + ${this.renderCurrentHashCode(hash, length)} + "`,
@@ -47,6 +48,7 @@ class JsonpMainTemplatePlugin {
 					name: `" + (${JSON.stringify(chunkMaps.name)}[chunkId]||chunkId) + "`
 				}
 			});
+			const haveJsonpBefore = !!jsonpBeforeCallback;
 			return this.asString([
 				"var script = document.createElement('script');",
 				`script.type = ${JSON.stringify(jsonpScriptType)};`,
@@ -58,6 +60,10 @@ class JsonpMainTemplatePlugin {
 				this.indent(`script.setAttribute("nonce", ${this.requireFn}.nc);`),
 				"}",
 				`script.src = ${this.requireFn}.p + ${scriptSrcPath};`,
+				`var reason; if (${haveJsonpBefore} && (reason=(${jsonpBeforeCallback})(script))) {`,
+				this.indent("installedChunks[chunkId][0](reason); // resolve with reason"),
+				this.indent("return installedChunks[chunkId][2];"),
+				"}",
 				`var timeout = setTimeout(onScriptComplete, ${chunkLoadTimeout});`,
 				"script.onerror = script.onload = onScriptComplete;",
 				"function onScriptComplete() {",

--- a/schemas/webpackOptionsSchema.json
+++ b/schemas/webpackOptionsSchema.json
@@ -524,6 +524,17 @@
         "umdNamedDefine": {
           "description": "If `output.libraryTarget` is set to umd and `output.library` is set, setting this to true will name the AMD module.",
           "type": "boolean"
+        },
+        "jsonpBeforeCallback": {
+          "description": "Function (or name of global function) to be called before a chunk is loaded. Function gets the script node as argument.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "instanceof": "Function"
+            }
+          ]
         }
       },
       "type": "object"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
feature

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Not yet - wanted to get some feedback first.

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
TBD
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Solves a problem similar to what `output.publicPath` does, except for cases where one or *more* of the following is true: 
1. I don't know the path at compile time
1. I have both chunked and non-chunked bundles (say, a bootstrap file)
1. The main bundle may be loaded remotely.

So the component is a library that may be loaded in any number of environments.  Here's the scenario:  My component is a service that lives in b-&lt;env&gt;.com where &lt;env&gt; is, say, dev, stage, etc.   
 It has multiple chunks (say, locales). Then some app on a-&lt;env&gt;.com uses my component:
```
// a-dev.com/html: 
  <script src=b-dev.com/bootstrap>
  // webpack adds chunk scripts:
  <script src=chunk-N>      <--  wrong domain, should be b-dev.com
```
`publicPath` wouldn't help here since we have different environments.  Also `jsonpFunction` is no help as it's called after the script is loaded. 

What this PR allows is for my component to intercept the chunk loading and modify the `script.src`.
```
module.exports = {
  ...
  output: {
    jsonpBeforeCallback: function(script) {
       script.src = script.src.replace(/a-(dev|stage|prod)/, 'b-$1');
    }
  }
}
```
It can also return any truthy (e.g., a reason) which cancels the load altogether.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

Possibly related discussion: #150 