### PR TITLE
Update downloads badge to point to graph of downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![licenses][licenses]][licenses-url]
 
   <br>
-	<a href="https://npmjs.com/package/webpack">
+	<a href="https://npmcharts.com/compare/webpack?minimal=true">
 		<img src="https://img.shields.io/npm/dm/webpack.svg">
 	</a>
 	<a href="https://opencollective.com/webpack#backer">


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Update README's npm monthly download badge to point to graph of historical downloads

**Summary**

Hi! I noticed that your "npm" badge and "downloads" badge currently both point to the same page for the project on npmjs.org  

I was wondering if you might prefer having the download badge point to a [download chart](https://npmcharts.com/compare/webpack?minimal=true) instead?

If not, feel free to close and apologies for the drive-by PR 😄

**Does this PR introduce a breaking change?**

No
