### PR TITLE
Use 2-digit format for day and month in "built at" output

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -730,7 +730,13 @@ class Stats {
 		if (typeof obj.builtAt === "number") {
 			const builtAtDate = new Date(obj.builtAt);
 			colors.normal("Built at: ");
-			colors.normal(builtAtDate.toLocaleDateString());
+			colors.normal(
+				builtAtDate.toLocaleDateString({
+					day: "2-digit",
+					month: "2-digit",
+					year: "numeric"
+				})
+			);
 			colors.normal(" ");
 			colors.bold(builtAtDate.toLocaleTimeString());
 			newline();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
refactor

**Did you add tests for your changes?**
nope. Made this change on Github, hoping no tests fail 🙂 

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

This format looks better, at least with Norwegian locale.

```js
new Date().toLocaleDateString("nb-NO");
// "5.3.2018"
new Date().toLocaleDateString("nb-NO", { day: "2-digit", month: "2-digit", year: "numeric" });
// "05.03.2018"
```

Without this change: 
![image](https://user-images.githubusercontent.com/1404810/36962878-8b03942c-2051-11e8-835e-cadd1402ba0a.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Shouldn't 🤞 

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
