### PR TITLE
fix(bug): chunkFilename as function doesn't work

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -94,6 +94,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 				// Elsewise prefix "[id]." in front of the basename to make it changing
 				return filename.replace(/(^|\/)([^/]*(?:\?|$))/, "$1[id].$2");
 			}
+			return "[id].js";
 		});
 		this.set("output.webassemblyModuleFilename", "[modulehash].module.wasm");
 		this.set("output.library", "");

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -85,14 +85,15 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("output.filename", "[name].js");
 		this.set("output.chunkFilename", "make", options => {
 			const filename = options.output.filename;
-			if (typeof filename === "function") return filename;
-			const hasName = filename.includes("[name]");
-			const hasId = filename.includes("[id]");
-			const hasChunkHash = filename.includes("[chunkhash]");
-			// Anything changing depending on chunk is fine
-			if (hasChunkHash || hasName || hasId) return filename;
-			// Elsewise prefix "[id]." in front of the basename to make it changing
-			return filename.replace(/(^|\/)([^/]*(?:\?|$))/, "$1[id].$2");
+			if (typeof filename !== "function") {
+				const hasName = filename.includes("[name]");
+				const hasId = filename.includes("[id]");
+				const hasChunkHash = filename.includes("[chunkhash]");
+				// Anything changing depending on chunk is fine
+				if (hasChunkHash || hasName || hasId) return filename;
+				// Elsewise prefix "[id]." in front of the basename to make it changing
+				return filename.replace(/(^|\/)([^/]*(?:\?|$))/, "$1[id].$2");
+			}
 		});
 		this.set("output.webassemblyModuleFilename", "[modulehash].module.wasm");
 		this.set("output.library", "");

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -324,14 +324,7 @@
         },
         "chunkFilename": {
           "description": "The filename of non-entry chunks as relative path inside the `output.path` directory.",
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "instanceof": "Function"
-            }
-          ],
+          "type": "string",
           "absolutePath": false
         },
         "webassemblyModuleFilename": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Fixes #6639 
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
For technically reasons chunkFilename can't be a function. This PR disabling it on the the schema level.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
