### PR TITLE
Make AMD parser modules extensible again

### DIFF
--- a/lib/dependencies/AMDDefineDependencyParserPlugin.js
+++ b/lib/dependencies/AMDDefineDependencyParserPlugin.js
@@ -260,9 +260,11 @@ class AMDDefineDependencyParserPlugin {
 			parser.inScope(fnParams, () => {
 				parser.scope.renames = fnRenames;
 				parser.scope.inTry = inTry;
-				if (fn.body.type === "BlockStatement")
+				if (fn.body.type === "BlockStatement") {
 					parser.walkStatement(fn.body);
-				else parser.walkExpression(fn.body);
+				} else {
+					parser.walkExpression(fn.body);
+				}
 			});
 		} else if (fn && isBoundFunctionExpression(fn)) {
 			inTry = parser.scope.inTry;

--- a/lib/dependencies/AMDDefineDependencyParserPlugin.js
+++ b/lib/dependencies/AMDDefineDependencyParserPlugin.js
@@ -41,18 +41,15 @@ class AMDDefineDependencyParserPlugin {
 	}
 
 	apply(parser) {
-		parser.hooks.call.for("define").tap(
-			"AMDDefineDependencyParserPlugin",
-			this.processCallDefine.bind(
-				Object.create(this, {
-					parser: { value: parser }
-				})
-			)
-		);
+		parser.hooks.call
+			.for("define")
+			.tap(
+				"AMDDefineDependencyParserPlugin",
+				this.processCallDefine.bind(this, parser)
+			);
 	}
 
-	processArray(expr, param, identifiers, namedModule) {
-		const parser = this.parser;
+	processArray(parser, expr, param, identifiers, namedModule) {
 		if (param.isArray()) {
 			param.items.forEach((param, idx) => {
 				if (
@@ -60,9 +57,9 @@ class AMDDefineDependencyParserPlugin {
 					["require", "module", "exports"].includes(param.string)
 				)
 					identifiers[idx] = param.string;
-				const result = this.processItem(expr, param, namedModule);
+				const result = this.processItem(parser, expr, param, namedModule);
 				if (result === undefined) {
-					this.processContext(expr, param);
+					this.processContext(parser, expr, param);
 				}
 			});
 			return true;
@@ -102,13 +99,12 @@ class AMDDefineDependencyParserPlugin {
 			return true;
 		}
 	}
-	processItem(expr, param, namedModule) {
-		const parser = this.parser;
+	processItem(parser, expr, param, namedModule) {
 		if (param.isConditional()) {
 			param.options.forEach(param => {
-				const result = this.processItem(expr, param);
+				const result = this.processItem(parser, expr, param);
 				if (result === undefined) {
-					this.processContext(expr, param);
+					this.processContext(parser, expr, param);
 				}
 			});
 			return true;
@@ -136,7 +132,7 @@ class AMDDefineDependencyParserPlugin {
 			return true;
 		}
 	}
-	processContext(expr, param) {
+	processContext(parser, expr, param) {
 		const dep = ContextDependencyHelpers.create(
 			AMDRequireContextDependency,
 			param.range,
@@ -146,13 +142,12 @@ class AMDDefineDependencyParserPlugin {
 		);
 		if (!dep) return;
 		dep.loc = expr.loc;
-		dep.optional = !!this.parser.scope.inTry;
-		this.parser.state.current.addDependency(dep);
+		dep.optional = !!parser.scope.inTry;
+		parser.state.current.addDependency(dep);
 		return true;
 	}
 
-	processCallDefine(expr) {
-		const parser = this.parser;
+	processCallDefine(parser, expr) {
 		let array, fn, obj, namedModule;
 		switch (expr.arguments.length) {
 			case 1:
@@ -232,7 +227,13 @@ class AMDDefineDependencyParserPlugin {
 		if (array) {
 			identifiers = {};
 			const param = parser.evaluateExpression(array);
-			const result = this.processArray(expr, param, identifiers, namedModule);
+			const result = this.processArray(
+				parser,
+				expr,
+				param,
+				identifiers,
+				namedModule
+			);
 			if (!result) return;
 			if (fnParams)
 				fnParams = fnParams.slice(fnParamsOffset).filter((param, idx) => {
@@ -302,14 +303,26 @@ class AMDDefineDependencyParserPlugin {
 		return true;
 	}
 
-	newDefineDependency(...args) {
-		return new AMDDefineDependency(...args);
+	newDefineDependency(
+		range,
+		arrayRange,
+		functionRange,
+		objectRange,
+		namedModule
+	) {
+		return new AMDDefineDependency(
+			range,
+			arrayRange,
+			functionRange,
+			objectRange,
+			namedModule
+		);
 	}
-	newRequireArrayDependency(...args) {
-		return new AMDRequireArrayDependency(...args);
+	newRequireArrayDependency(depsArray, range) {
+		return new AMDRequireArrayDependency(depsArray, range);
 	}
-	newRequireItemDependency(...args) {
-		return new AMDRequireItemDependency(...args);
+	newRequireItemDependency(request, range) {
+		return new AMDRequireItemDependency(request, range);
 	}
 }
 module.exports = AMDDefineDependencyParserPlugin;

--- a/lib/dependencies/AMDDefineDependencyParserPlugin.js
+++ b/lib/dependencies/AMDDefineDependencyParserPlugin.js
@@ -41,7 +41,6 @@ class AMDDefineDependencyParserPlugin {
 	}
 
 	apply(parser) {
-		this.parser = parser;
 		parser.hooks.call.for("define").tap(
 			"AMDDefineDependencyParserPlugin",
 			this.processCallDefine.bind(

--- a/lib/dependencies/AMDDefineDependencyParserPlugin.js
+++ b/lib/dependencies/AMDDefineDependencyParserPlugin.js
@@ -40,272 +40,275 @@ class AMDDefineDependencyParserPlugin {
 		this.options = options;
 	}
 
-	newDefineDependency(
-		range,
-		arrayRange,
-		functionRange,
-		objectRange,
-		namedModule
-	) {
-		return new AMDDefineDependency(
-			range,
-			arrayRange,
-			functionRange,
-			objectRange,
-			namedModule
+	apply(parser) {
+		this.parser = parser;
+		parser.hooks.call.for("define").tap(
+			"AMDDefineDependencyParserPlugin",
+			this.processCallDefine.bind(
+				Object.create(this, {
+					parser: { value: parser }
+				})
+			)
 		);
 	}
 
-	apply(parser) {
-		const options = this.options;
-
-		const processArray = (expr, param, identifiers, namedModule) => {
-			if (param.isArray()) {
-				param.items.forEach((param, idx) => {
-					if (
-						param.isString() &&
-						["require", "module", "exports"].includes(param.string)
-					)
-						identifiers[idx] = param.string;
-					const result = processItem(expr, param, namedModule);
-					if (result === undefined) {
-						processContext(expr, param);
-					}
-				});
-				return true;
-			} else if (param.isConstArray()) {
-				const deps = [];
-				param.array.forEach((request, idx) => {
-					let dep;
-					let localModule;
-					if (request === "require") {
-						identifiers[idx] = request;
-						dep = "__webpack_require__";
-					} else if (["exports", "module"].includes(request)) {
-						identifiers[idx] = request;
-						dep = request;
-					} else if (
-						(localModule = LocalModulesHelpers.getLocalModule(
-							parser.state,
-							request
-						))
-					) {
-						// eslint-disable-line no-cond-assign
-						dep = new LocalModuleDependency(localModule);
-						dep.loc = expr.loc;
-						parser.state.current.addDependency(dep);
-					} else {
-						dep = new AMDRequireItemDependency(request);
-						dep.loc = expr.loc;
-						dep.optional = !!parser.scope.inTry;
-						parser.state.current.addDependency(dep);
-					}
-					deps.push(dep);
-				});
-				const dep = new AMDRequireArrayDependency(deps, param.range);
-				dep.loc = expr.loc;
-				dep.optional = !!parser.scope.inTry;
-				parser.state.current.addDependency(dep);
-				return true;
-			}
-		};
-		const processItem = (expr, param, namedModule) => {
-			if (param.isConditional()) {
-				param.options.forEach(param => {
-					const result = processItem(expr, param);
-					if (result === undefined) {
-						processContext(expr, param);
-					}
-				});
-				return true;
-			} else if (param.isString()) {
-				let dep, localModule;
-				if (param.string === "require") {
-					dep = new ConstDependency("__webpack_require__", param.range);
-				} else if (["require", "exports", "module"].includes(param.string)) {
-					dep = new ConstDependency(param.string, param.range);
+	processArray(expr, param, identifiers, namedModule) {
+		const parser = this.parser;
+		if (param.isArray()) {
+			param.items.forEach((param, idx) => {
+				if (
+					param.isString() &&
+					["require", "module", "exports"].includes(param.string)
+				)
+					identifiers[idx] = param.string;
+				const result = this.processItem(expr, param, namedModule);
+				if (result === undefined) {
+					this.processContext(expr, param);
+				}
+			});
+			return true;
+		} else if (param.isConstArray()) {
+			const deps = [];
+			param.array.forEach((request, idx) => {
+				let dep;
+				let localModule;
+				if (request === "require") {
+					identifiers[idx] = request;
+					dep = "__webpack_require__";
+				} else if (["exports", "module"].includes(request)) {
+					identifiers[idx] = request;
+					dep = request;
 				} else if (
 					(localModule = LocalModulesHelpers.getLocalModule(
 						parser.state,
-						param.string,
-						namedModule
+						request
 					))
 				) {
 					// eslint-disable-line no-cond-assign
-					dep = new LocalModuleDependency(localModule, param.range);
+					dep = new LocalModuleDependency(localModule);
+					dep.loc = expr.loc;
+					parser.state.current.addDependency(dep);
 				} else {
-					dep = new AMDRequireItemDependency(param.string, param.range);
+					dep = this.newRequireItemDependency(request);
+					dep.loc = expr.loc;
+					dep.optional = !!parser.scope.inTry;
+					parser.state.current.addDependency(dep);
 				}
-				dep.loc = expr.loc;
-				dep.optional = !!parser.scope.inTry;
-				parser.state.current.addDependency(dep);
-				return true;
-			}
-		};
-		const processContext = (expr, param) => {
-			const dep = ContextDependencyHelpers.create(
-				AMDRequireContextDependency,
-				param.range,
-				param,
-				expr,
-				options
-			);
-			if (!dep) return;
+				deps.push(dep);
+			});
+			const dep = this.newRequireArrayDependency(deps, param.range);
 			dep.loc = expr.loc;
 			dep.optional = !!parser.scope.inTry;
 			parser.state.current.addDependency(dep);
 			return true;
-		};
-
-		parser.hooks.call
-			.for("define")
-			.tap("AMDDefineDependencyParserPlugin", expr => {
-				let array, fn, obj, namedModule;
-				switch (expr.arguments.length) {
-					case 1:
-						if (isCallable(expr.arguments[0])) {
-							// define(f() {...})
-							fn = expr.arguments[0];
-						} else if (expr.arguments[0].type === "ObjectExpression") {
-							// define({...})
-							obj = expr.arguments[0];
-						} else {
-							// define(expr)
-							// unclear if function or object
-							obj = fn = expr.arguments[0];
-						}
-						break;
-					case 2:
-						if (expr.arguments[0].type === "Literal") {
-							namedModule = expr.arguments[0].value;
-							// define("...", ...)
-							if (isCallable(expr.arguments[1])) {
-								// define("...", f() {...})
-								fn = expr.arguments[1];
-							} else if (expr.arguments[1].type === "ObjectExpression") {
-								// define("...", {...})
-								obj = expr.arguments[1];
-							} else {
-								// define("...", expr)
-								// unclear if function or object
-								obj = fn = expr.arguments[1];
-							}
-						} else {
-							array = expr.arguments[0];
-							if (isCallable(expr.arguments[1])) {
-								// define([...], f() {})
-								fn = expr.arguments[1];
-							} else if (expr.arguments[1].type === "ObjectExpression") {
-								// define([...], {...})
-								obj = expr.arguments[1];
-							} else {
-								// define([...], expr)
-								// unclear if function or object
-								obj = fn = expr.arguments[1];
-							}
-						}
-						break;
-					case 3:
-						// define("...", [...], f() {...})
-						namedModule = expr.arguments[0].value;
-						array = expr.arguments[1];
-						if (isCallable(expr.arguments[2])) {
-							// define("...", [...], f() {})
-							fn = expr.arguments[2];
-						} else if (expr.arguments[2].type === "ObjectExpression") {
-							// define("...", [...], {...})
-							obj = expr.arguments[2];
-						} else {
-							// define("...", [...], expr)
-							// unclear if function or object
-							obj = fn = expr.arguments[2];
-						}
-						break;
-					default:
-						return;
+		}
+	}
+	processItem(expr, param, namedModule) {
+		const parser = this.parser;
+		if (param.isConditional()) {
+			param.options.forEach(param => {
+				const result = this.processItem(expr, param);
+				if (result === undefined) {
+					this.processContext(expr, param);
 				}
-				let fnParams = null;
-				let fnParamsOffset = 0;
-				if (fn) {
-					if (isUnboundFunctionExpression(fn)) fnParams = fn.params;
-					else if (isBoundFunctionExpression(fn)) {
-						fnParams = fn.callee.object.params;
-						fnParamsOffset = fn.arguments.length - 1;
-						if (fnParamsOffset < 0) fnParamsOffset = 0;
+			});
+			return true;
+		} else if (param.isString()) {
+			let dep, localModule;
+			if (param.string === "require") {
+				dep = new ConstDependency("__webpack_require__", param.range);
+			} else if (["require", "exports", "module"].includes(param.string)) {
+				dep = new ConstDependency(param.string, param.range);
+			} else if (
+				(localModule = LocalModulesHelpers.getLocalModule(
+					parser.state,
+					param.string,
+					namedModule
+				))
+			) {
+				// eslint-disable-line no-cond-assign
+				dep = new LocalModuleDependency(localModule, param.range);
+			} else {
+				dep = this.newRequireItemDependency(param.string, param.range);
+			}
+			dep.loc = expr.loc;
+			dep.optional = !!parser.scope.inTry;
+			parser.state.current.addDependency(dep);
+			return true;
+		}
+	}
+	processContext(expr, param) {
+		const dep = ContextDependencyHelpers.create(
+			AMDRequireContextDependency,
+			param.range,
+			param,
+			expr,
+			this.options
+		);
+		if (!dep) return;
+		dep.loc = expr.loc;
+		dep.optional = !!this.parser.scope.inTry;
+		this.parser.state.current.addDependency(dep);
+		return true;
+	}
+
+	processCallDefine(expr) {
+		const parser = this.parser;
+		let array, fn, obj, namedModule;
+		switch (expr.arguments.length) {
+			case 1:
+				if (isCallable(expr.arguments[0])) {
+					// define(f() {...})
+					fn = expr.arguments[0];
+				} else if (expr.arguments[0].type === "ObjectExpression") {
+					// define({...})
+					obj = expr.arguments[0];
+				} else {
+					// define(expr)
+					// unclear if function or object
+					obj = fn = expr.arguments[0];
+				}
+				break;
+			case 2:
+				if (expr.arguments[0].type === "Literal") {
+					namedModule = expr.arguments[0].value;
+					// define("...", ...)
+					if (isCallable(expr.arguments[1])) {
+						// define("...", f() {...})
+						fn = expr.arguments[1];
+					} else if (expr.arguments[1].type === "ObjectExpression") {
+						// define("...", {...})
+						obj = expr.arguments[1];
+					} else {
+						// define("...", expr)
+						// unclear if function or object
+						obj = fn = expr.arguments[1];
+					}
+				} else {
+					array = expr.arguments[0];
+					if (isCallable(expr.arguments[1])) {
+						// define([...], f() {})
+						fn = expr.arguments[1];
+					} else if (expr.arguments[1].type === "ObjectExpression") {
+						// define([...], {...})
+						obj = expr.arguments[1];
+					} else {
+						// define([...], expr)
+						// unclear if function or object
+						obj = fn = expr.arguments[1];
 					}
 				}
-				let fnRenames = parser.scope.renames.createChild();
-				let identifiers;
-				if (array) {
-					identifiers = {};
-					const param = parser.evaluateExpression(array);
-					const result = processArray(expr, param, identifiers, namedModule);
-					if (!result) return;
-					if (fnParams)
-						fnParams = fnParams.slice(fnParamsOffset).filter((param, idx) => {
-							if (identifiers[idx]) {
-								fnRenames.set(param.name, identifiers[idx]);
-								return false;
-							}
-							return true;
-						});
+				break;
+			case 3:
+				// define("...", [...], f() {...})
+				namedModule = expr.arguments[0].value;
+				array = expr.arguments[1];
+				if (isCallable(expr.arguments[2])) {
+					// define("...", [...], f() {})
+					fn = expr.arguments[2];
+				} else if (expr.arguments[2].type === "ObjectExpression") {
+					// define("...", [...], {...})
+					obj = expr.arguments[2];
 				} else {
-					identifiers = ["require", "exports", "module"];
-					if (fnParams)
-						fnParams = fnParams.slice(fnParamsOffset).filter((param, idx) => {
-							if (identifiers[idx]) {
-								fnRenames.set(param.name, identifiers[idx]);
-								return false;
-							}
-							return true;
-						});
+					// define("...", [...], expr)
+					// unclear if function or object
+					obj = fn = expr.arguments[2];
 				}
-				let inTry;
-				if (fn && isUnboundFunctionExpression(fn)) {
-					inTry = parser.scope.inTry;
-					parser.inScope(fnParams, () => {
-						parser.scope.renames = fnRenames;
-						parser.scope.inTry = inTry;
-						if (fn.body.type === "BlockStatement")
-							parser.walkStatement(fn.body);
-						else parser.walkExpression(fn.body);
-					});
-				} else if (fn && isBoundFunctionExpression(fn)) {
-					inTry = parser.scope.inTry;
-					parser.inScope(
-						fn.callee.object.params.filter(
-							i => !["require", "module", "exports"].includes(i.name)
-						),
-						() => {
-							parser.scope.renames = fnRenames;
-							parser.scope.inTry = inTry;
-							if (fn.callee.object.body.type === "BlockStatement")
-								parser.walkStatement(fn.callee.object.body);
-							else parser.walkExpression(fn.callee.object.body);
-						}
-					);
-					if (fn.arguments) parser.walkExpressions(fn.arguments);
-				} else if (fn || obj) {
-					parser.walkExpression(fn || obj);
-				}
-
-				const dep = this.newDefineDependency(
-					expr.range,
-					array ? array.range : null,
-					fn ? fn.range : null,
-					obj ? obj.range : null,
-					namedModule ? namedModule : null
-				);
-				dep.loc = expr.loc;
-				if (namedModule) {
-					dep.localModule = LocalModulesHelpers.addLocalModule(
-						parser.state,
-						namedModule
-					);
-				}
-				parser.state.current.addDependency(dep);
-				return true;
+				break;
+			default:
+				return;
+		}
+		let fnParams = null;
+		let fnParamsOffset = 0;
+		if (fn) {
+			if (isUnboundFunctionExpression(fn)) fnParams = fn.params;
+			else if (isBoundFunctionExpression(fn)) {
+				fnParams = fn.callee.object.params;
+				fnParamsOffset = fn.arguments.length - 1;
+				if (fnParamsOffset < 0) fnParamsOffset = 0;
+			}
+		}
+		let fnRenames = parser.scope.renames.createChild();
+		let identifiers;
+		if (array) {
+			identifiers = {};
+			const param = parser.evaluateExpression(array);
+			const result = this.processArray(expr, param, identifiers, namedModule);
+			if (!result) return;
+			if (fnParams)
+				fnParams = fnParams.slice(fnParamsOffset).filter((param, idx) => {
+					if (identifiers[idx]) {
+						fnRenames.set(param.name, identifiers[idx]);
+						return false;
+					}
+					return true;
+				});
+		} else {
+			identifiers = ["require", "exports", "module"];
+			if (fnParams)
+				fnParams = fnParams.slice(fnParamsOffset).filter((param, idx) => {
+					if (identifiers[idx]) {
+						fnRenames.set(param.name, identifiers[idx]);
+						return false;
+					}
+					return true;
+				});
+		}
+		let inTry;
+		if (fn && isUnboundFunctionExpression(fn)) {
+			inTry = parser.scope.inTry;
+			parser.inScope(fnParams, () => {
+				parser.scope.renames = fnRenames;
+				parser.scope.inTry = inTry;
+				if (fn.body.type === "BlockStatement")
+					parser.walkStatement(fn.body);
+				else parser.walkExpression(fn.body);
 			});
+		} else if (fn && isBoundFunctionExpression(fn)) {
+			inTry = parser.scope.inTry;
+			parser.inScope(
+				fn.callee.object.params.filter(
+					i => !["require", "module", "exports"].includes(i.name)
+				),
+				() => {
+					parser.scope.renames = fnRenames;
+					parser.scope.inTry = inTry;
+					if (fn.callee.object.body.type === "BlockStatement")
+						parser.walkStatement(fn.callee.object.body);
+					else parser.walkExpression(fn.callee.object.body);
+				}
+			);
+			if (fn.arguments) parser.walkExpressions(fn.arguments);
+		} else if (fn || obj) {
+			parser.walkExpression(fn || obj);
+		}
+
+		const dep = this.newDefineDependency(
+			expr.range,
+			array ? array.range : null,
+			fn ? fn.range : null,
+			obj ? obj.range : null,
+			namedModule ? namedModule : null
+		);
+		dep.loc = expr.loc;
+		if (namedModule) {
+			dep.localModule = LocalModulesHelpers.addLocalModule(
+				parser.state,
+				namedModule
+			);
+		}
+		parser.state.current.addDependency(dep);
+		return true;
+	}
+
+	newDefineDependency(...args) {
+		return new AMDDefineDependency(...args);
+	}
+	newRequireArrayDependency(...args) {
+		return new AMDRequireArrayDependency(...args);
+	}
+	newRequireItemDependency(...args) {
+		return new AMDRequireItemDependency(...args);
 	}
 }
 module.exports = AMDDefineDependencyParserPlugin;

--- a/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
@@ -46,8 +46,117 @@ class AMDRequireDependenciesBlockParserPlugin {
 	}
 
 	apply(parser) {
-		const options = this.options;
+		this.parser = parser;
+		parser.hooks.call.for("require").tap(
+			"AMDRequireDependenciesBlockParserPlugin",
+			this.processCallRequire.bind(
+				Object.create(this, {
+					parser: { value: parser }
+				})
+			)
+		);
+	}
 
+	processArray(expr, param) {
+		const parser = this.parser;
+		if (param.isArray()) {
+			for (const p of param.items) {
+				const result = this.processItem(expr, p);
+				if (result === undefined) {
+					this.processContext(expr, p);
+				}
+			}
+			return true;
+		} else if (param.isConstArray()) {
+			const deps = [];
+			for (const request of param.array) {
+				let dep, localModule;
+				if (request === "require") {
+					dep = "__webpack_require__";
+				} else if (["exports", "module"].includes(request)) {
+					dep = request;
+				} else if (
+					(localModule = LocalModulesHelpers.getLocalModule(
+						parser.state,
+						request
+					))
+				) {
+					// eslint-disable-line no-cond-assign
+					dep = new LocalModuleDependency(localModule);
+					dep.loc = expr.loc;
+					parser.state.current.addDependency(dep);
+				} else {
+					dep = this.newRequireItemDependency(request);
+					dep.loc = expr.loc;
+					dep.optional = !!parser.scope.inTry;
+					parser.state.current.addDependency(dep);
+				}
+				deps.push(dep);
+			}
+			const dep = this.newRequireArrayDependency(deps, param.range);
+			dep.loc = expr.loc;
+			dep.optional = !!parser.scope.inTry;
+			parser.state.current.addDependency(dep);
+			return true;
+		}
+	}
+	processItem(expr, param) {
+		const parser = this.parser;
+		if (param.isConditional()) {
+			for (const p of param.options) {
+				const result = this.processItem(expr, p);
+				if (result === undefined) {
+					this.processContext(expr, p);
+				}
+			}
+			return true;
+		} else if (param.isString()) {
+			let dep, localModule;
+			if (param.string === "require") {
+				dep = new ConstDependency("__webpack_require__", param.string);
+			} else if (param.string === "module") {
+				dep = new ConstDependency(
+					parser.state.module.buildInfo.moduleArgument,
+					param.range
+				);
+			} else if (param.string === "exports") {
+				dep = new ConstDependency(
+					parser.state.module.buildInfo.exportsArgument,
+					param.range
+				);
+			} else if (
+				(localModule = LocalModulesHelpers.getLocalModule(
+					parser.state,
+					param.string
+				))
+			) {
+				// eslint-disable-line no-cond-assign
+				dep = new LocalModuleDependency(localModule, param.range);
+			} else {
+				dep = this.newRequireItemDependency(param.string, param.range);
+			}
+			dep.loc = expr.loc;
+			dep.optional = !!parser.scope.inTry;
+			parser.state.current.addDependency(dep);
+			return true;
+		}
+	}
+	processContext(expr, param) {
+		const dep = ContextDependencyHelpers.create(
+			AMDRequireContextDependency,
+			param.range,
+			param,
+			expr,
+			this.options
+		);
+		if (!dep) return;
+		dep.loc = expr.loc;
+		dep.optional = !!this.parser.scope.inTry;
+		this.parser.state.current.addDependency(dep);
+		return true;
+	}
+
+	processCallRequire(expr) {
 		const processArrayForRequestString = param => {
 			if (param.isArray()) {
 				const result = param.items.map(item =>
@@ -70,172 +179,82 @@ class AMDRequireDependenciesBlockParserPlugin {
 			}
 		};
 
-		const processArray = (expr, param) => {
-			if (param.isArray()) {
-				for (const p of param.items) {
-					const result = processItem(expr, p);
-					if (result === undefined) {
-						processContext(expr, p);
-					}
-				}
-				return true;
-			} else if (param.isConstArray()) {
-				const deps = [];
-				for (const request of param.array) {
-					let dep, localModule;
-					if (request === "require") {
-						dep = "__webpack_require__";
-					} else if (["exports", "module"].includes(request)) {
-						dep = request;
-					} else if (
-						(localModule = LocalModulesHelpers.getLocalModule(
-							parser.state,
-							request
-						))
-					) {
-						// eslint-disable-line no-cond-assign
-						dep = new LocalModuleDependency(localModule);
-						dep.loc = expr.loc;
-						parser.state.current.addDependency(dep);
-					} else {
-						dep = new AMDRequireItemDependency(request);
-						dep.loc = expr.loc;
-						dep.optional = !!parser.scope.inTry;
-						parser.state.current.addDependency(dep);
-					}
-					deps.push(dep);
-				}
-				const dep = new AMDRequireArrayDependency(deps, param.range);
-				dep.loc = expr.loc;
-				dep.optional = !!parser.scope.inTry;
-				parser.state.current.addDependency(dep);
-				return true;
-			}
-		};
-		const processItem = (expr, param) => {
-			if (param.isConditional()) {
-				for (const p of param.options) {
-					const result = processItem(expr, p);
-					if (result === undefined) {
-						processContext(expr, p);
-					}
-				}
-				return true;
-			} else if (param.isString()) {
-				let dep, localModule;
-				if (param.string === "require") {
-					dep = new ConstDependency("__webpack_require__", param.string);
-				} else if (param.string === "module") {
-					dep = new ConstDependency(
-						parser.state.module.buildInfo.moduleArgument,
-						param.range
-					);
-				} else if (param.string === "exports") {
-					dep = new ConstDependency(
-						parser.state.module.buildInfo.exportsArgument,
-						param.range
-					);
-				} else if (
-					(localModule = LocalModulesHelpers.getLocalModule(
-						parser.state,
-						param.string
-					))
-				) {
-					// eslint-disable-line no-cond-assign
-					dep = new LocalModuleDependency(localModule, param.range);
-				} else {
-					dep = new AMDRequireItemDependency(param.string, param.range);
-				}
-				dep.loc = expr.loc;
-				dep.optional = !!parser.scope.inTry;
-				parser.state.current.addDependency(dep);
-				return true;
-			}
-		};
-		const processContext = (expr, param) => {
-			const dep = ContextDependencyHelpers.create(
-				AMDRequireContextDependency,
-				param.range,
-				param,
+		let param;
+		let dep;
+		let result;
+
+		const parser = this.parser;
+		const old = parser.state.current;
+
+		if (expr.arguments.length >= 1) {
+			param = parser.evaluateExpression(expr.arguments[0]);
+			dep = this.newRequireDependenciesBlock(
 				expr,
-				options
+				param.range,
+				expr.arguments.length > 1 ? expr.arguments[1].range : null,
+				expr.arguments.length > 2 ? expr.arguments[2].range : null,
+				parser.state.module,
+				expr.loc,
+				processArrayForRequestString(param)
 			);
-			if (!dep) return;
-			dep.loc = expr.loc;
-			dep.optional = !!parser.scope.inTry;
-			parser.state.current.addDependency(dep);
-			return true;
-		};
+			parser.state.current = dep;
+		}
 
-		parser.hooks.call
-			.for("require")
-			.tap("AMDRequireDependenciesBlockParserPlugin", expr => {
-				let param;
-				let dep;
-				let result;
-
-				const old = parser.state.current;
-
-				if (expr.arguments.length >= 1) {
-					param = parser.evaluateExpression(expr.arguments[0]);
-					dep = new AMDRequireDependenciesBlock(
-						expr,
-						param.range,
-						expr.arguments.length > 1 ? expr.arguments[1].range : null,
-						expr.arguments.length > 2 ? expr.arguments[2].range : null,
-						parser.state.module,
-						expr.loc,
-						processArrayForRequestString(param)
-					);
-					parser.state.current = dep;
-				}
-
-				if (expr.arguments.length === 1) {
-					parser.inScope([], () => {
-						result = processArray(expr, param);
-					});
-					parser.state.current = old;
-					if (!result) return;
-					parser.state.current.addBlock(dep);
-					return true;
-				}
-
-				if (expr.arguments.length === 2 || expr.arguments.length === 3) {
-					try {
-						parser.inScope([], () => {
-							result = processArray(expr, param);
-						});
-						if (!result) {
-							dep = new UnsupportedDependency("unsupported", expr.range);
-							old.addDependency(dep);
-							if (parser.state.module)
-								parser.state.module.errors.push(
-									new UnsupportedFeatureWarning(
-										parser.state.module,
-										"Cannot statically analyse 'require(..., ...)' in line " +
-											expr.loc.start.line
-									)
-								);
-							dep = null;
-							return true;
-						}
-						dep.functionBindThis = this.processFunctionArgument(
-							parser,
-							expr.arguments[1]
-						);
-						if (expr.arguments.length === 3) {
-							dep.errorCallbackBindThis = this.processFunctionArgument(
-								parser,
-								expr.arguments[2]
-							);
-						}
-					} finally {
-						parser.state.current = old;
-						if (dep) parser.state.current.addBlock(dep);
-					}
-					return true;
-				}
+		if (expr.arguments.length === 1) {
+			parser.inScope([], () => {
+				result = this.processArray(expr, param);
 			});
+			parser.state.current = old;
+			if (!result) return;
+			parser.state.current.addBlock(dep);
+			return true;
+		}
+
+		if (expr.arguments.length === 2 || expr.arguments.length === 3) {
+			try {
+				parser.inScope([], () => {
+					result = this.processArray(expr, param);
+				});
+				if (!result) {
+					dep = new UnsupportedDependency("unsupported", expr.range);
+					old.addDependency(dep);
+					if (parser.state.module)
+						parser.state.module.errors.push(
+							new UnsupportedFeatureWarning(
+								parser.state.module,
+								"Cannot statically analyse 'require(..., ...)' in line " +
+									expr.loc.start.line
+							)
+						);
+					dep = null;
+					return true;
+				}
+				dep.functionBindThis = this.processFunctionArgument(
+					parser,
+					expr.arguments[1]
+				);
+				if (expr.arguments.length === 3) {
+					dep.errorCallbackBindThis = this.processFunctionArgument(
+						parser,
+						expr.arguments[2]
+					);
+				}
+			} finally {
+				parser.state.current = old;
+				if (dep) parser.state.current.addBlock(dep);
+			}
+			return true;
+		}
+	}
+
+	newRequireDependenciesBlock(...args) {
+		return new AMDRequireDependenciesBlock(...args);
+	}
+	newRequireItemDependency(...args) {
+		return new AMDRequireItemDependency(...args);
+	}
+	newRequireArrayDependency(...args) {
+		return new AMDRequireArrayDependency(...args);
 	}
 }
 module.exports = AMDRequireDependenciesBlockParserPlugin;

--- a/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
@@ -46,7 +46,6 @@ class AMDRequireDependenciesBlockParserPlugin {
 	}
 
 	apply(parser) {
-		this.parser = parser;
 		parser.hooks.call.for("require").tap(
 			"AMDRequireDependenciesBlockParserPlugin",
 			this.processCallRequire.bind(

--- a/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
@@ -46,23 +46,20 @@ class AMDRequireDependenciesBlockParserPlugin {
 	}
 
 	apply(parser) {
-		parser.hooks.call.for("require").tap(
-			"AMDRequireDependenciesBlockParserPlugin",
-			this.processCallRequire.bind(
-				Object.create(this, {
-					parser: { value: parser }
-				})
-			)
-		);
+		parser.hooks.call
+			.for("require")
+			.tap(
+				"AMDRequireDependenciesBlockParserPlugin",
+				this.processCallRequire.bind(this, parser)
+			);
 	}
 
-	processArray(expr, param) {
-		const parser = this.parser;
+	processArray(parser, expr, param) {
 		if (param.isArray()) {
 			for (const p of param.items) {
-				const result = this.processItem(expr, p);
+				const result = this.processItem(parser, expr, p);
 				if (result === undefined) {
-					this.processContext(expr, p);
+					this.processContext(parser, expr, p);
 				}
 			}
 			return true;
@@ -99,13 +96,12 @@ class AMDRequireDependenciesBlockParserPlugin {
 			return true;
 		}
 	}
-	processItem(expr, param) {
-		const parser = this.parser;
+	processItem(parser, expr, param) {
 		if (param.isConditional()) {
 			for (const p of param.options) {
-				const result = this.processItem(expr, p);
+				const result = this.processItem(parser, expr, p);
 				if (result === undefined) {
-					this.processContext(expr, p);
+					this.processContext(parser, expr, p);
 				}
 			}
 			return true;
@@ -140,7 +136,7 @@ class AMDRequireDependenciesBlockParserPlugin {
 			return true;
 		}
 	}
-	processContext(expr, param) {
+	processContext(parser, expr, param) {
 		const dep = ContextDependencyHelpers.create(
 			AMDRequireContextDependency,
 			param.range,
@@ -150,39 +146,38 @@ class AMDRequireDependenciesBlockParserPlugin {
 		);
 		if (!dep) return;
 		dep.loc = expr.loc;
-		dep.optional = !!this.parser.scope.inTry;
-		this.parser.state.current.addDependency(dep);
+		dep.optional = !!parser.scope.inTry;
+		parser.state.current.addDependency(dep);
 		return true;
 	}
 
-	processCallRequire(expr) {
-		const processArrayForRequestString = param => {
-			if (param.isArray()) {
-				const result = param.items.map(item =>
-					processItemForRequestString(item)
-				);
-				if (result.every(Boolean)) return result.join(" ");
-			} else if (param.isConstArray()) {
-				return param.array.join(" ");
-			}
-		};
+	processArrayForRequestString(param) {
+		if (param.isArray()) {
+			const result = param.items.map(item =>
+				this.processItemForRequestString(item)
+			);
+			if (result.every(Boolean)) return result.join(" ");
+		} else if (param.isConstArray()) {
+			return param.array.join(" ");
+		}
+	}
 
-		const processItemForRequestString = param => {
-			if (param.isConditional()) {
-				const result = param.options.map(item =>
-					processItemForRequestString(item)
-				);
-				if (result.every(Boolean)) return result.join("|");
-			} else if (param.isString()) {
-				return param.string;
-			}
-		};
+	processItemForRequestString(param) {
+		if (param.isConditional()) {
+			const result = param.options.map(item =>
+				this.processItemForRequestString(item)
+			);
+			if (result.every(Boolean)) return result.join("|");
+		} else if (param.isString()) {
+			return param.string;
+		}
+	}
 
+	processCallRequire(parser, expr) {
 		let param;
 		let dep;
 		let result;
 
-		const parser = this.parser;
 		const old = parser.state.current;
 
 		if (expr.arguments.length >= 1) {
@@ -194,14 +189,14 @@ class AMDRequireDependenciesBlockParserPlugin {
 				expr.arguments.length > 2 ? expr.arguments[2].range : null,
 				parser.state.module,
 				expr.loc,
-				processArrayForRequestString(param)
+				this.processArrayForRequestString(param)
 			);
 			parser.state.current = dep;
 		}
 
 		if (expr.arguments.length === 1) {
 			parser.inScope([], () => {
-				result = this.processArray(expr, param);
+				result = this.processArray(parser, expr, param);
 			});
 			parser.state.current = old;
 			if (!result) return;
@@ -212,7 +207,7 @@ class AMDRequireDependenciesBlockParserPlugin {
 		if (expr.arguments.length === 2 || expr.arguments.length === 3) {
 			try {
 				parser.inScope([], () => {
-					result = this.processArray(expr, param);
+					result = this.processArray(parser, expr, param);
 				});
 				if (!result) {
 					dep = new UnsupportedDependency("unsupported", expr.range);
@@ -246,14 +241,30 @@ class AMDRequireDependenciesBlockParserPlugin {
 		}
 	}
 
-	newRequireDependenciesBlock(...args) {
-		return new AMDRequireDependenciesBlock(...args);
+	newRequireDependenciesBlock(
+		expr,
+		arrayRange,
+		functionRange,
+		errorCallbackRange,
+		module,
+		loc,
+		request
+	) {
+		return new AMDRequireDependenciesBlock(
+			expr,
+			arrayRange,
+			functionRange,
+			errorCallbackRange,
+			module,
+			loc,
+			request
+		);
 	}
-	newRequireItemDependency(...args) {
-		return new AMDRequireItemDependency(...args);
+	newRequireItemDependency(request, range) {
+		return new AMDRequireItemDependency(request, range);
 	}
-	newRequireArrayDependency(...args) {
-		return new AMDRequireArrayDependency(...args);
+	newRequireArrayDependency(depsArray, range) {
+		return new AMDRequireArrayDependency(depsArray, range);
 	}
 }
 module.exports = AMDRequireDependenciesBlockParserPlugin;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?** 

Structural (non-functional) changes to the AMD parser modules that restore extensibility which was lost in the v4 upgrade

**Did you add tests for your changes?**

No.  Not needed.  No functional changes.

**If relevant, link to documentation update:**

N/A

**Summary**

Prior to V4, code reuse in the AMD parser modules could be achieved through the use of the `call require:amd:array`, `call require:amd:item`, `call define:amd:array` and `call define:amd:item` plugin events.  These events were removed in V4, with no alternative to facilitate reuse of parser code by plugins.  This PR restores extensibility through the use of class inheritance (a cleaner approach for the use case).  The extensibility is needed by [dojo-webpack-plugin](https://github.com/OpenNTF/dojo-webpack-plugin) which needs to subclass and provide custom implementations of thie `processArray`  and `processItem` methods while leveraging the core parser functionality of the base classes.

<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

This PR is best reviewed by ignoring whitespace changes.