### PR TITLE
fix(ProfilingPlugin): complete after the writeStream had finished flushing the data to the filesystem

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -121,7 +121,7 @@ function createTrace(outputPath) {
 		trace,
 		counter,
 		profiler,
-		end: (callback) => fsStream.end(callback)
+		end: callback => fsStream.end(callback)
 	};
 }
 

--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -73,7 +73,7 @@ class Profiler {
 
 /**
  * @param {string} outputPath The location where to write the log.
- * @returns {{trace: ?,	counter: number, profiler: Profiler, fsStream: WriteStream}} The trace object
+ * @returns {{trace: ?,	counter: number, profiler: Profiler, end: Function}} The trace object
  */
 function createTrace(outputPath) {
 	const trace = new Trace({
@@ -121,7 +121,7 @@ function createTrace(outputPath) {
 		trace,
 		counter,
 		profiler,
-		fsStream
+		end: (callback) => fsStream.end(callback)
 	};
 }
 
@@ -181,7 +181,7 @@ class ProfilingPlugin {
 					if (parsedResults === undefined) {
 						tracer.profiler.destroy();
 						tracer.trace.flush();
-						tracer.fsStream.end(callback);
+						tracer.end(callback);
 						return;
 					}
 
@@ -229,7 +229,7 @@ class ProfilingPlugin {
 
 					tracer.profiler.destroy();
 					tracer.trace.flush();
-					tracer.fsStream.end(callback);
+					tracer.end(callback);
 				});
 			}
 		);

--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -73,17 +73,18 @@ class Profiler {
 
 /**
  * @param {string} outputPath The location where to write the log.
- * @returns {{trace: ?,	counter: number, profiler: Profiler}} The trace object
+ * @returns {{trace: ?,	counter: number, profiler: Profiler, fsStream: WriteStream}} The trace object
  */
 function createTrace(outputPath) {
 	const trace = new Trace({
 		noStream: true
 	});
 	const profiler = new Profiler(inspector);
+	const fsStream = fs.createWriteStream(outputPath);
 
 	let counter = 0;
 
-	trace.pipe(fs.createWriteStream(outputPath));
+	trace.pipe(fsStream);
 	// These are critical events that need to be inserted so that tools like
 	// chrome dev tools can load the profile.
 	trace.instantEvent({
@@ -119,7 +120,8 @@ function createTrace(outputPath) {
 	return {
 		trace,
 		counter,
-		profiler
+		profiler,
+		fsStream
 	};
 }
 
@@ -169,16 +171,17 @@ class ProfilingPlugin {
 		);
 
 		// We need to write out the CPU profile when we are all done.
-		compiler.hooks.done.tap(
+		compiler.hooks.done.tapAsync(
 			{
 				name: pluginName,
 				stage: Infinity
 			},
-			() => {
+			(stats, callback) => {
 				tracer.profiler.stopProfiling().then(parsedResults => {
 					if (parsedResults === undefined) {
 						tracer.profiler.destroy();
 						tracer.trace.flush();
+						tracer.fsStream.end(callback);
 						return;
 					}
 
@@ -226,6 +229,7 @@ class ProfilingPlugin {
 
 					tracer.profiler.destroy();
 					tracer.trace.flush();
+					tracer.fsStream.end(callback);
 				});
 			}
 		);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

No reliable way to test this, since this depends on the order the OS flushes data to the FS. I've tested in place where this race condition was being triggered and it works. Actually, this was causing flakiness of the profiling-plugin ConfigCases test, so that should be fixed.

**If relevant, link to documentation update:**

N/A

**Summary**

Fixes a race-condition where `events.json` might not yet be available immediately after compilation.

**Does this PR introduce a breaking change?**

No.
