### PR TITLE
Prevent webpack from running twice at a time

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -22,6 +22,7 @@ const ResolverFactory = require("./ResolverFactory");
 
 const RequestShortener = require("./RequestShortener");
 const makePathsRelative = require("./util/identifier").makePathsRelative;
+const ConcurrentCompilationError = require("./ConcurrentCompilationError");
 
 class Compiler extends Tapable {
 	constructor(context) {
@@ -134,12 +135,7 @@ class Compiler extends Tapable {
 	}
 
 	watch(watchOptions, handler) {
-		if (this.running)
-			return handler(
-				new Error(
-					"You ran Webpack twice. Each instance only supports a single concurrent compilation at a time."
-				)
-			);
+		if (this.running) return handler(new ConcurrentCompilationError());
 
 		this.running = true;
 		this.fileTimestamps = new Map();
@@ -148,12 +144,7 @@ class Compiler extends Tapable {
 	}
 
 	run(callback) {
-		if (this.running)
-			return callback(
-				new Error(
-					"You ran Webpack twice. Each instance only supports a single concurrent compilation at a time."
-				)
-			);
+		if (this.running) return callback(new ConcurrentCompilationError());
 
 		const finalCallback = (err, stats) => {
 			this.running = false;

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -129,16 +129,35 @@ class Compiler extends Tapable {
 		this.context = context;
 
 		this.requestShortener = new RequestShortener(context);
+
+		this.running = false;
 	}
 
 	watch(watchOptions, handler) {
+		if (this.running)
+			return handler(
+				new Error(
+					"You ran Webpack twice. Each instance only supports a single concurrent compilation at a time."
+				)
+			);
+
+		this.running = true;
 		this.fileTimestamps = new Map();
 		this.contextTimestamps = new Map();
 		return new Watching(this, watchOptions, handler);
 	}
 
 	run(callback) {
+		if (this.running)
+			return callback(
+				new Error(
+					"You ran Webpack twice. Each instance only supports a single concurrent compilation at a time."
+				)
+			);
+
 		const startTime = Date.now();
+
+		this.running = true;
 
 		const onCompiled = (err, compilation) => {
 			if (err) return callback(err);
@@ -148,6 +167,8 @@ class Compiler extends Tapable {
 				stats.startTime = startTime;
 				stats.endTime = Date.now();
 				this.hooks.done.callAsync(stats, err => {
+					this.running = false;
+
 					if (err) return callback(err);
 					return callback(null, stats);
 				});
@@ -181,6 +202,8 @@ class Compiler extends Tapable {
 					stats.startTime = startTime;
 					stats.endTime = Date.now();
 					this.hooks.done.callAsync(stats, err => {
+						this.running = false;
+
 						if (err) return callback(err);
 						return callback(null, stats);
 					});

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -155,28 +155,32 @@ class Compiler extends Tapable {
 				)
 			);
 
+		const finalCallback = (err, stats) => {
+			this.running = false;
+
+			if (callback !== undefined) return callback(err, stats);
+		};
+
 		const startTime = Date.now();
 
 		this.running = true;
 
 		const onCompiled = (err, compilation) => {
-			if (err) return callback(err);
+			if (err) return finalCallback(err);
 
 			if (this.hooks.shouldEmit.call(compilation) === false) {
 				const stats = new Stats(compilation);
 				stats.startTime = startTime;
 				stats.endTime = Date.now();
 				this.hooks.done.callAsync(stats, err => {
-					this.running = false;
-
-					if (err) return callback(err);
-					return callback(null, stats);
+					if (err) return finalCallback(err);
+					return finalCallback(null, stats);
 				});
 				return;
 			}
 
 			this.emitAssets(compilation, err => {
-				if (err) return callback(err);
+				if (err) return finalCallback(err);
 
 				if (compilation.hooks.needAdditionalPass.call()) {
 					compilation.needAdditionalPass = true;
@@ -185,10 +189,10 @@ class Compiler extends Tapable {
 					stats.startTime = startTime;
 					stats.endTime = Date.now();
 					this.hooks.done.callAsync(stats, err => {
-						if (err) return callback(err);
+						if (err) return finalCallback(err);
 
 						this.hooks.additionalPass.callAsync(err => {
-							if (err) return callback(err);
+							if (err) return finalCallback(err);
 							this.compile(onCompiled);
 						});
 					});
@@ -196,29 +200,27 @@ class Compiler extends Tapable {
 				}
 
 				this.emitRecords(err => {
-					if (err) return callback(err);
+					if (err) return finalCallback(err);
 
 					const stats = new Stats(compilation);
 					stats.startTime = startTime;
 					stats.endTime = Date.now();
 					this.hooks.done.callAsync(stats, err => {
-						this.running = false;
-
-						if (err) return callback(err);
-						return callback(null, stats);
+						if (err) return finalCallback(err);
+						return finalCallback(null, stats);
 					});
 				});
 			});
 		};
 
 		this.hooks.beforeRun.callAsync(this, err => {
-			if (err) return callback(err);
+			if (err) return finalCallback(err);
 
 			this.hooks.run.callAsync(this, err => {
-				if (err) return callback(err);
+				if (err) return finalCallback(err);
 
 				this.readRecords(err => {
-					if (err) return callback(err);
+					if (err) return finalCallback(err);
 
 					this.compile(onCompiled);
 				});

--- a/lib/ConcurrentCompilationError.js
+++ b/lib/ConcurrentCompilationError.js
@@ -1,0 +1,19 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Maksim Nazarjev @acupofspirt
+*/
+"use strict";
+
+const WebpackError = require("./WebpackError");
+
+module.exports = class ConcurrentCompilationError extends WebpackError {
+	constructor() {
+		super();
+
+		this.name = "ConcurrentCompilationError";
+		this.message =
+			"You ran Webpack twice. Each instance only supports a single concurrent compilation at a time.";
+
+		Error.captureStackTrace(this, this.constructor);
+	}
+};

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -189,16 +189,10 @@ module.exports = class MultiCompiler extends Tapable {
 	watch(watchOptions, handler) {
 		if (this.running) return handler(new ConcurrentCompilationError());
 
-		const finalHandler = (err, stats) => {
-			this.running = false;
-
-			if (handler !== undefined) handler(err, stats);
-		};
-
 		let watchings = [];
 		let allStats = this.compilers.map(() => null);
 		let compilerStatus = this.compilers.map(() => false);
-		if (this.validateDependencies(finalHandler)) {
+		if (this.validateDependencies(handler)) {
 			this.running = true;
 			this.runWithDependencies(
 				this.compilers,
@@ -210,7 +204,7 @@ module.exports = class MultiCompiler extends Tapable {
 							? watchOptions[compilerIdx]
 							: watchOptions,
 						(err, stats) => {
-							if (err) finalHandler(err);
+							if (err) handler(err);
 							if (stats) {
 								allStats[compilerIdx] = stats;
 								compilerStatus[compilerIdx] = "new";
@@ -220,7 +214,7 @@ module.exports = class MultiCompiler extends Tapable {
 									});
 									compilerStatus.fill(true);
 									const multiStats = new MultiStats(freshStats);
-									finalHandler(null, multiStats);
+									handler(null, multiStats);
 								}
 							}
 							if (firstRun && !err) {

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -10,6 +10,7 @@ const MultiHook = require("tapable").MultiHook;
 const asyncLib = require("neo-async");
 const MultiWatching = require("./MultiWatching");
 const MultiStats = require("./MultiStats");
+const ConcurrentCompilationError = require("./ConcurrentCompilationError");
 
 module.exports = class MultiCompiler extends Tapable {
 	constructor(compilers) {
@@ -186,12 +187,7 @@ module.exports = class MultiCompiler extends Tapable {
 	}
 
 	watch(watchOptions, handler) {
-		if (this.running)
-			return handler(
-				new Error(
-					"You ran Webpack twice. Each instance only supports a single concurrent compilation at a time."
-				)
-			);
+		if (this.running) return handler(new ConcurrentCompilationError());
 
 		const finalHandler = (err, stats) => {
 			this.running = false;
@@ -245,12 +241,7 @@ module.exports = class MultiCompiler extends Tapable {
 	}
 
 	run(callback) {
-		if (this.running)
-			return callback(
-				new Error(
-					"You ran Webpack twice. Each instance only supports a single concurrent compilation at a time."
-				)
-			);
+		if (this.running) return callback(new ConcurrentCompilationError());
 
 		const finalCallback = (err, stats) => {
 			this.running = false;

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -53,6 +53,7 @@ module.exports = class MultiCompiler extends Tapable {
 				}
 			});
 		}
+		this.running = false;
 	}
 
 	get outputPath() {
@@ -185,10 +186,24 @@ module.exports = class MultiCompiler extends Tapable {
 	}
 
 	watch(watchOptions, handler) {
+		if (this.running)
+			return handler(
+				new Error(
+					"You ran Webpack twice. Each instance only supports a single concurrent compilation at a time."
+				)
+			);
+
+		const finalHandler = (err, stats) => {
+			this.running = false;
+
+			if (handler !== undefined) handler(err, stats);
+		};
+
 		let watchings = [];
 		let allStats = this.compilers.map(() => null);
 		let compilerStatus = this.compilers.map(() => false);
-		if (this.validateDependencies(handler)) {
+		if (this.validateDependencies(finalHandler)) {
+			this.running = true;
 			this.runWithDependencies(
 				this.compilers,
 				(compiler, callback) => {
@@ -199,7 +214,7 @@ module.exports = class MultiCompiler extends Tapable {
 							? watchOptions[compilerIdx]
 							: watchOptions,
 						(err, stats) => {
-							if (err) handler(err);
+							if (err) finalHandler(err);
 							if (stats) {
 								allStats[compilerIdx] = stats;
 								compilerStatus[compilerIdx] = "new";
@@ -209,7 +224,7 @@ module.exports = class MultiCompiler extends Tapable {
 									});
 									compilerStatus.fill(true);
 									const multiStats = new MultiStats(freshStats);
-									handler(null, multiStats);
+									finalHandler(null, multiStats);
 								}
 							}
 							if (firstRun && !err) {
@@ -230,8 +245,22 @@ module.exports = class MultiCompiler extends Tapable {
 	}
 
 	run(callback) {
+		if (this.running)
+			return callback(
+				new Error(
+					"You ran Webpack twice. Each instance only supports a single concurrent compilation at a time."
+				)
+			);
+
+		const finalCallback = (err, stats) => {
+			this.running = false;
+
+			if (callback !== undefined) return callback(err, stats);
+		};
+
 		const allStats = this.compilers.map(() => null);
 		if (this.validateDependencies(callback)) {
+			this.running = true;
 			this.runWithDependencies(
 				this.compilers,
 				(compiler, callback) => {
@@ -243,8 +272,8 @@ module.exports = class MultiCompiler extends Tapable {
 					});
 				},
 				err => {
-					if (err) return callback(err);
-					callback(null, new MultiStats(allStats));
+					if (err) return finalCallback(err);
+					finalCallback(null, new MultiStats(allStats));
 				}
 			);
 		}

--- a/lib/MultiWatching.js
+++ b/lib/MultiWatching.js
@@ -27,6 +27,7 @@ class MultiWatching {
 			err => {
 				this.compiler.hooks.watchClose.call();
 				if (typeof callback === "function") {
+					this.compiler.running = false;
 					callback(err);
 				}
 			}

--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -166,9 +166,12 @@ class Watching {
 	}
 
 	close(callback) {
-		if (callback === undefined) callback = () => {};
+		const finalCallback = () => {
+			this.compiler.hooks.watchClose.call();
+			this.compiler.running = false;
+			if (callback !== undefined) callback();
+		};
 
-		this.compiler.running = false;
 		this.closed = true;
 		if (this.watcher) {
 			this.watcher.close();
@@ -180,13 +183,9 @@ class Watching {
 		}
 		if (this.running) {
 			this.invalid = true;
-			this._done = () => {
-				this.compiler.hooks.watchClose.call();
-				callback();
-			};
+			this._done = finalCallback;
 		} else {
-			this.compiler.hooks.watchClose.call();
-			callback();
+			finalCallback();
 		}
 	}
 }

--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -168,6 +168,7 @@ class Watching {
 	close(callback) {
 		if (callback === undefined) callback = () => {};
 
+		this.compiler.running = false;
 		this.closed = true;
 		if (this.watcher) {
 			this.watcher.close();

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -246,7 +246,7 @@ describe("Compiler", () => {
 			});
 		});
 	});
-	it("should not emit on errors", function(done) {
+  it("should not emit on errors", function(done) {
 		const compiler = webpack({
 			context: __dirname,
 			mode: "production",
@@ -282,5 +282,154 @@ describe("Compiler", () => {
 				return done(new Error("Bundle should not be created on error"));
 			done();
 		});
+  });
+  it("should not be run twice at a time (run)", function(done) {
+		const compiler = webpack({
+			context: __dirname,
+			mode: "production",
+			entry: "./c",
+			output: {
+				path: "/",
+				filename: "bundle.js"
+			}
+		});
+		compiler.outputFileSystem = new MemoryFs();
+		compiler.run((err, stats) => {
+			if (err) return done(err);
+		});
+		compiler.run((err, stats) => {
+			if (err) return done();
+		});
+	});
+  it("should not be run twice at a time (watch)", function(done) {
+		const compiler = webpack({
+			context: __dirname,
+			mode: "production",
+			entry: "./c",
+			output: {
+				path: "/",
+				filename: "bundle.js"
+			}
+		});
+		compiler.outputFileSystem = new MemoryFs();
+		compiler.watch({}, (err, stats) => {
+			if (err) return done(err);
+		});
+		compiler.watch({}, (err, stats) => {
+			if (err) return done();
+		});
+  });
+  it("should not be run twice at a time (run - watch)", function(done) {
+		const compiler = webpack({
+			context: __dirname,
+			mode: "production",
+			entry: "./c",
+			output: {
+				path: "/",
+				filename: "bundle.js"
+			}
+		});
+		compiler.outputFileSystem = new MemoryFs();
+		compiler.run((err, stats) => {
+			if (err) return done(err);
+		});
+    compiler.watch({}, (err, stats) => {
+			if (err) return done();
+		});
+	});
+  it("should not be run twice at a time (watch - run)", function(done) {
+		const compiler = webpack({
+			context: __dirname,
+			mode: "production",
+			entry: "./c",
+			output: {
+				path: "/",
+				filename: "bundle.js"
+			}
+		});
+		compiler.outputFileSystem = new MemoryFs();
+    compiler.watch({}, (err, stats) => {
+			if (err) return done(err);
+		});
+    compiler.run((err, stats) => {
+			if (err) return done();
+		});
+	});
+  it("should not be run twice at a time (instance cb)", function(done) {
+		const compiler = webpack({
+			context: __dirname,
+			mode: "production",
+			entry: "./c",
+			output: {
+				path: "/",
+				filename: "bundle.js"
+			}
+		}, () => {});
+		compiler.outputFileSystem = new MemoryFs();
+    compiler.run((err, stats) => {
+			if (err) return done();
+		});
+	});
+  it("should run again correctly after first compilation", function(done) {
+		const compiler = webpack({
+			context: __dirname,
+			mode: "production",
+			entry: "./c",
+			output: {
+				path: "/",
+				filename: "bundle.js"
+			}
+		});
+		compiler.outputFileSystem = new MemoryFs();
+    compiler.run((err, stats) => {
+      if (err) return done(err);
+
+      compiler.run((err, stats) => {
+        if (err) return done(err);
+        done()
+      });
+		});
+	});
+  it("should watch again correctly after first compilation", function(done) {
+		const compiler = webpack({
+			context: __dirname,
+			mode: "production",
+			entry: "./c",
+			output: {
+				path: "/",
+				filename: "bundle.js"
+			}
+		});
+		compiler.outputFileSystem = new MemoryFs();
+    compiler.run((err, stats) => {
+      if (err) return done(err);
+
+      compiler.watch({}, (err, stats) => {
+        if (err) return done(err);
+        done()
+      });
+		});
+	});
+  it("should run again correctly after first closed watch", function(done) {
+		const compiler = webpack({
+			context: __dirname,
+			mode: "production",
+			entry: "./c",
+			output: {
+				path: "/",
+				filename: "bundle.js"
+			}
+		});
+		compiler.outputFileSystem = new MemoryFs();
+    const watching = compiler.watch({}, (err, stats) => {
+      if (err) return done(err);
+      done()
+    });
+    watching.close(() => {
+      compiler.run((err, stats) => {
+        if (err) return done(err);
+        done()
+      });
+    })
 	});
 });

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -246,7 +246,7 @@ describe("Compiler", () => {
 			});
 		});
 	});
-  it("should not emit on errors", function(done) {
+	it("should not emit on errors", function(done) {
 		const compiler = webpack({
 			context: __dirname,
 			mode: "production",
@@ -282,8 +282,8 @@ describe("Compiler", () => {
 				return done(new Error("Bundle should not be created on error"));
 			done();
 		});
-  });
-  it("should not be run twice at a time (run)", function(done) {
+	});
+	it("should not be run twice at a time (run)", function(done) {
 		const compiler = webpack({
 			context: __dirname,
 			mode: "production",
@@ -301,7 +301,7 @@ describe("Compiler", () => {
 			if (err) return done();
 		});
 	});
-  it("should not be run twice at a time (watch)", function(done) {
+	it("should not be run twice at a time (watch)", function(done) {
 		const compiler = webpack({
 			context: __dirname,
 			mode: "production",
@@ -318,8 +318,8 @@ describe("Compiler", () => {
 		compiler.watch({}, (err, stats) => {
 			if (err) return done();
 		});
-  });
-  it("should not be run twice at a time (run - watch)", function(done) {
+	});
+	it("should not be run twice at a time (run - watch)", function(done) {
 		const compiler = webpack({
 			context: __dirname,
 			mode: "production",
@@ -333,11 +333,11 @@ describe("Compiler", () => {
 		compiler.run((err, stats) => {
 			if (err) return done(err);
 		});
-    compiler.watch({}, (err, stats) => {
+		compiler.watch({}, (err, stats) => {
 			if (err) return done();
 		});
 	});
-  it("should not be run twice at a time (watch - run)", function(done) {
+	it("should not be run twice at a time (watch - run)", function(done) {
 		const compiler = webpack({
 			context: __dirname,
 			mode: "production",
@@ -348,29 +348,32 @@ describe("Compiler", () => {
 			}
 		});
 		compiler.outputFileSystem = new MemoryFs();
-    compiler.watch({}, (err, stats) => {
+		compiler.watch({}, (err, stats) => {
 			if (err) return done(err);
 		});
-    compiler.run((err, stats) => {
+		compiler.run((err, stats) => {
 			if (err) return done();
 		});
 	});
-  it("should not be run twice at a time (instance cb)", function(done) {
-		const compiler = webpack({
-			context: __dirname,
-			mode: "production",
-			entry: "./c",
-			output: {
-				path: "/",
-				filename: "bundle.js"
-			}
-		}, () => {});
+	it("should not be run twice at a time (instance cb)", function(done) {
+		const compiler = webpack(
+			{
+				context: __dirname,
+				mode: "production",
+				entry: "./c",
+				output: {
+					path: "/",
+					filename: "bundle.js"
+				}
+			},
+			() => {}
+		);
 		compiler.outputFileSystem = new MemoryFs();
-    compiler.run((err, stats) => {
+		compiler.run((err, stats) => {
 			if (err) return done();
 		});
 	});
-  it("should run again correctly after first compilation", function(done) {
+	it("should run again correctly after first compilation", function(done) {
 		const compiler = webpack({
 			context: __dirname,
 			mode: "production",
@@ -381,16 +384,16 @@ describe("Compiler", () => {
 			}
 		});
 		compiler.outputFileSystem = new MemoryFs();
-    compiler.run((err, stats) => {
-      if (err) return done(err);
+		compiler.run((err, stats) => {
+			if (err) return done(err);
 
-      compiler.run((err, stats) => {
-        if (err) return done(err);
-        done()
-      });
+			compiler.run((err, stats) => {
+				if (err) return done(err);
+				done();
+			});
 		});
 	});
-  it("should watch again correctly after first compilation", function(done) {
+	it("should watch again correctly after first compilation", function(done) {
 		const compiler = webpack({
 			context: __dirname,
 			mode: "production",
@@ -401,16 +404,16 @@ describe("Compiler", () => {
 			}
 		});
 		compiler.outputFileSystem = new MemoryFs();
-    compiler.run((err, stats) => {
-      if (err) return done(err);
+		compiler.run((err, stats) => {
+			if (err) return done(err);
 
-      compiler.watch({}, (err, stats) => {
-        if (err) return done(err);
-        done()
-      });
+			compiler.watch({}, (err, stats) => {
+				if (err) return done(err);
+				done();
+			});
 		});
 	});
-  it("should run again correctly after first closed watch", function(done) {
+	it("should run again correctly after first closed watch", function(done) {
 		const compiler = webpack({
 			context: __dirname,
 			mode: "production",
@@ -421,15 +424,15 @@ describe("Compiler", () => {
 			}
 		});
 		compiler.outputFileSystem = new MemoryFs();
-    const watching = compiler.watch({}, (err, stats) => {
-      if (err) return done(err);
-      done()
-    });
-    watching.close(() => {
-      compiler.run((err, stats) => {
-        if (err) return done(err);
-        done()
-      });
-    })
+		const watching = compiler.watch({}, (err, stats) => {
+			if (err) return done(err);
+			done();
+		});
+		watching.close(() => {
+			compiler.run((err, stats) => {
+				if (err) return done(err);
+				done();
+			});
+		});
 	});
 });

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -426,10 +426,30 @@ describe("Compiler", () => {
 		compiler.outputFileSystem = new MemoryFs();
 		const watching = compiler.watch({}, (err, stats) => {
 			if (err) return done(err);
-			done();
 		});
 		watching.close(() => {
 			compiler.run((err, stats) => {
+				if (err) return done(err);
+				done();
+			});
+		});
+	});
+	it("should watch again correctly after first closed watch", function(done) {
+		const compiler = webpack({
+			context: __dirname,
+			mode: "production",
+			entry: "./c",
+			output: {
+				path: "/",
+				filename: "bundle.js"
+			}
+		});
+		compiler.outputFileSystem = new MemoryFs();
+		const watching = compiler.watch({}, (err, stats) => {
+			if (err) return done(err);
+		});
+		watching.close(() => {
+			compiler.watch({}, (err, stats) => {
 				if (err) return done(err);
 				done();
 			});

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -52,4 +52,105 @@ describe("MultiCompiler", function() {
 			}
 		});
 	});
+
+	it("should not be run twice at a time (run)", function(done) {
+		const compiler = createMultiCompiler();
+		compiler.run((err, stats) => {
+			if (err) return done(err);
+		});
+		compiler.run((err, stats) => {
+			if (err) return done();
+		});
+	});
+	it("should not be run twice at a time (watch)", function(done) {
+		const compiler = createMultiCompiler();
+		compiler.watch({}, (err, stats) => {
+			if (err) return done(err);
+		});
+		compiler.watch({}, (err, stats) => {
+			if (err) return done();
+		});
+	});
+	it("should not be run twice at a time (run - watch)", function(done) {
+		const compiler = createMultiCompiler();
+		compiler.run((err, stats) => {
+			if (err) return done(err);
+		});
+		compiler.watch({}, (err, stats) => {
+			if (err) return done();
+		});
+	});
+	it("should not be run twice at a time (watch - run)", function(done) {
+		const compiler = createMultiCompiler();
+		compiler.watch({}, (err, stats) => {
+			if (err) return done(err);
+		});
+		compiler.run((err, stats) => {
+			if (err) return done();
+		});
+	});
+	it("should not be run twice at a time (instance cb)", function(done) {
+		const compiler = webpack(
+			{
+				context: __dirname,
+				mode: "production",
+				entry: "./c",
+				output: {
+					path: "/",
+					filename: "bundle.js"
+				}
+			},
+			() => {}
+		);
+		compiler.outputFileSystem = new MemoryFs();
+		compiler.run((err, stats) => {
+			if (err) return done();
+		});
+	});
+	it("should run again correctly after first compilation", function(done) {
+		const compiler = createMultiCompiler();
+		compiler.run((err, stats) => {
+			if (err) return done(err);
+
+			compiler.run((err, stats) => {
+				if (err) return done(err);
+				done();
+			});
+		});
+	});
+	it("should watch again correctly after first compilation", function(done) {
+		const compiler = createMultiCompiler();
+		compiler.run((err, stats) => {
+			if (err) return done(err);
+
+			compiler.watch({}, (err, stats) => {
+				if (err) return done(err);
+				done();
+			});
+		});
+	});
+	it("should run again correctly after first closed watch", function(done) {
+		const compiler = createMultiCompiler();
+		const watching = compiler.watch({}, (err, stats) => {
+			if (err) return done(err);
+		});
+		watching.close(() => {
+			compiler.run((err, stats) => {
+				if (err) return done(err);
+				done();
+			});
+		});
+	});
+	it("should watch again correctly after first closed watch", function(done) {
+		const compiler = createMultiCompiler();
+		const watching = compiler.watch({}, (err, stats) => {
+			if (err) return done(err);
+		});
+		watching.close(() => {
+			compiler.watch({}, (err, stats) => {
+				if (err) return done(err);
+				done();
+			});
+		});
+	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
improve DX by explicit error messages
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
If webpack somehow starts in a synchronous manner like:
``` js
compiler.run();
compiler.run();
// or
compiler.run()
compiler.watch()
// or
const compiler = webpack({}, () => {})
compiler.run()
```
it will produce wierd and syntactically wrong code.
This PR add some flag to check if compiler in running state and prevent any starts until it done.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Related to #6667