### PR TITLE
bot: Encapsulate output logs in details tag

### DIFF
--- a/open-bot.yaml
+++ b/open-bot.yaml
@@ -80,14 +80,28 @@ rules:
         - "^[\\s\\S]+?\\d+\\s+pending\n+"
         - "npm ERR!.*\n"
         - "\n*=============================================================================\n[\\s\\S]*"
+    string_cleanup:
+      id: firstError
+      value: "{{{logResult}}}"
+      remove:
+        - "^[\\s\\S]+?(?=\\s2\\)\\s)"
+    string_cleanup:
+      id: remainingErrors
+      value: "{{{logResult}}}"
+      remove:
+        - "\\s2\\)\\s[\\s\\S]*"
   actions:
     comment:
       identifier: "ci-result"
       message: |-
         @{{commit.author.login}} Please review the following output log for errors:
+        ```text
+        {{{firstError}}}
+        ```
         <details>
+          <summary>Show remaining errors</summary>
         ``` text
-        {{{logResult}}}
+        {{{remainingErrors}}}
         ```
         </details>
 

--- a/open-bot.yaml
+++ b/open-bot.yaml
@@ -85,10 +85,11 @@ rules:
       identifier: "ci-result"
       message: |-
         @{{commit.author.login}} Please review the following output log for errors:
-
+        <details>
         ``` text
         {{{logResult}}}
         ```
+        </details>
 
         See [complete report here]({{status.target_url}}).
     set:

--- a/open-bot.yaml
+++ b/open-bot.yaml
@@ -84,12 +84,12 @@ rules:
       id: firstError
       value: "{{{logResult}}}"
       remove:
-        - "^[\\s\\S]+?(?=\\s2\\)\\s)"
+        - "\\s2\\)\\s[\\s\\S]*"
     string_cleanup:
       id: remainingErrors
       value: "{{{logResult}}}"
       remove:
-        - "\\s2\\)\\s[\\s\\S]*"
+        - "^[\\s\\S]+?(?=\\s2\\)\\s)"
   actions:
     comment:
       identifier: "ci-result"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Readability change for @webpack-bot errors logs.

**Did you add tests for your changes?**

No

**Summary**

@webpack-bot is posting large tests errors logs in PRs creating large webpages with long scrolls, this make it harder to have meaningful conversations in PR.

This PR encapsulates those logs in a `<details>` tag (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) which is support by GitHub markdown.

With this change large logs will be collapsed by default unless you click on it.

Before
![image](https://user-images.githubusercontent.com/1002461/37216061-20c3f608-23ba-11e8-904d-d0d660dbcef1.png)

After

Collapsed by default
![image](https://user-images.githubusercontent.com/1002461/37216074-2842b9fa-23ba-11e8-8126-4d07dfe3c2b8.png)

After clicking on `Details`
![image](https://user-images.githubusercontent.com/1002461/37216084-325b4b78-23ba-11e8-9c87-3d67b8be3c4f.png)

