### PR TITLE
fix: make excludeModules accept booleans

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -1175,7 +1175,7 @@ class Stats {
 					optimizationBailout: true,
 					errorDetails: true,
 					publicPath: true,
-					exclude: () => false,
+					exclude: false,
 					maxModules: Infinity
 				};
 			case "detailed":
@@ -1190,7 +1190,7 @@ class Stats {
 					optimizationBailout: true,
 					errorDetails: true,
 					publicPath: true,
-					exclude: () => false,
+					exclude: false,
 					maxModules: Infinity
 				};
 			case "minimal":

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -106,6 +106,7 @@ class Stats {
 			if (item && typeof item === "object" && typeof item.test === "function")
 				return ident => item.test(ident);
 			if (typeof item === "function") return item;
+			if (typeof item === "boolean") return () => item;
 		};
 
 		const compilation = this.compilation;

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1821,10 +1821,13 @@
               ]
             },
             "excludeModules": {
-              "description": "Suppress modules that match the specified filters. Filters can be Strings, RegExps or Functions",
+              "description": "Suppress modules that match the specified filters. Filters can be Strings, RegExps, Booleans or Functions",
               "anyOf": [
                 {
                   "$ref": "#/definitions/filter-types"
+                },
+                {
+                  "type": "boolean"
                 }
               ]
             },
@@ -1833,6 +1836,9 @@
               "anyOf": [
                 {
                   "$ref": "#/definitions/filter-types"
+                },
+                {
+                  "type": "boolean"
                 }
               ]
             },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

feature request

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**
n/a

**Summary**

Addresses #6726. Now `exclude` and `excludeModules` can accept boolean values. Eg. use `excludeModules: false` to disable filtering.

**Does this PR introduce a breaking change?**

no
