### PR TITLE
bot: Fix Markdown format for output logs

### DIFF
--- a/open-bot.yaml
+++ b/open-bot.yaml
@@ -100,7 +100,8 @@ rules:
         ```
         <details>
           <summary>Show remaining errors</summary>
-        ``` text
+
+        ```text
         {{{remainingErrors}}}
         ```
         </details>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fix for bug introduce in https://github.com/webpack/webpack/pull/6713

**Did you add tests for your changes?**

No, but tested that this formatting actually works in https://github.com/montogeek/webpack-dev-middleware-bug/pull/1#issuecomment-373100450

**Summary**

It looks like Markdown code formatting inside `<details>` tag needs an empty line above it to correctly format code.

Before this change
![image](https://user-images.githubusercontent.com/1002461/37419066-f4cf34ba-27b3-11e8-9fd5-51db12b02c96.png)

After this change
![image](https://user-images.githubusercontent.com/1002461/37419118-0df09b82-27b4-11e8-8745-4d2ba764f6ac.png)

![image](https://user-images.githubusercontent.com/1002461/37419111-0be7e084-27b4-11e8-86c8-8c98318ffb43.png)


**Does this PR introduce a breaking change?**
No
