### PR TITLE
add check for exclamation mark in absolute path

### DIFF
--- a/schemas/ajv.absolutePath.js
+++ b/schemas/ajv.absolutePath.js
@@ -34,7 +34,7 @@ module.exports = (ajv) => ajv.addKeyword("absolutePath", {
 			callback.errors = [getErrorFor(expected, data, schema)];
 			return false;
 		} : data => {
-			if (!path.isAbsolute(data)) {
+			if (path.isAbsolute(data)) {
 				callback.errors = [getErrorFor(expected, data, schema)];
 				return false;
 			}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix.

**Did you add tests for your changes?**

No.

**If relevant, link to documentation update:**

N/A

**Summary**

If users use `!` in their directory names, webpack will generate a bunch of unhelpful errors. This commit introduce a check in validation period, which makes webpack more user-friendly. See issue #6742 and #5320 for more information.

**Does this PR introduce a breaking change?**

No.

**Other information**

N/A