### PR TITLE
automatically add production entry hints to mainFields when nodeEnv === "production"

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -4,7 +4,7 @@
 */
 "use strict";
 
-const flatMap = require("lodash/flatMap");
+const flatMap = require("lodash.flatmap");
 const path = require("path");
 
 const OptionsDefaulter = require("./OptionsDefaulter");

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -63,10 +63,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 				test: /\.mjs$/i,
 				type: "javascript/esm",
 				resolve: {
-					mainFields:
-						isWebLikeTarget(options)
-							? ["browser", "main"]
-							: ["main"]
+					mainFields: isWebLikeTarget(options) ? ["browser", "main"] : ["main"]
 				}
 			},
 			{
@@ -297,8 +294,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("resolve.extensions", [".wasm", ".mjs", ".js", ".json"]);
 		this.set("resolve.mainFiles", ["index"]);
 		this.set("resolve.aliasFields", "make", options => {
-			if (isWebLikeTarget(options))
-				return ["browser"];
+			if (isWebLikeTarget(options)) return ["browser"];
 			else return [];
 		});
 		this.set("resolve.mainFields", "make", options => {

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -4,6 +4,7 @@
 */
 "use strict";
 
+const flatMap = require("lodash/flatMap");
 const path = require("path");
 
 const OptionsDefaulter = require("./OptionsDefaulter");
@@ -16,6 +17,10 @@ const isProductionLikeMode = options => {
 const isWebLikeTarget = options => {
 	return options.target === "web" || options.target === "webworker";
 };
+
+const injectProductionFieldVariant = field => [field + ":production", field];
+
+const baseFields = ["module", "main"];
 
 class WebpackOptionsDefaulter extends OptionsDefaulter {
 	constructor() {
@@ -297,9 +302,15 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 			else return [];
 		});
 		this.set("resolve.mainFields", "make", options => {
-			if (options.target === "web" || options.target === "webworker")
-				return ["browser", "module", "main"];
-			else return ["module", "main"];
+			let fields = baseFields;
+
+			if (isWebLikeTarget(options)) {
+				fields = ["browser"].concat(baseFields);
+			}
+
+			return isProductionLikeMode(options)
+				? flatMap(fields, injectProductionFieldVariant)
+				: fields;
 		});
 		this.set("resolve.cacheWithContext", "make", options => {
 			return (

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -59,7 +59,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 				type: "javascript/esm",
 				resolve: {
 					mainFields:
-						options.target === "web" || options.target === "webworker"
+						isWebLikeTarget(options)
 							? ["browser", "main"]
 							: ["main"]
 				}
@@ -292,7 +292,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("resolve.extensions", [".wasm", ".mjs", ".js", ".json"]);
 		this.set("resolve.mainFiles", ["index"]);
 		this.set("resolve.aliasFields", "make", options => {
-			if (options.target === "web" || options.target === "webworker")
+			if (isWebLikeTarget(options))
 				return ["browser"];
 			else return [];
 		});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "eslint-scope": "^3.7.1",
     "loader-runner": "^2.3.0",
     "loader-utils": "^1.1.0",
+    "lodash.flatmap": "^4.5.0",
     "memory-fs": "~0.4.1",
     "micromatch": "^3.1.8",
     "mkdirp": "~0.5.0",

--- a/test/WebpackOptionsDefaulter.unittest.js
+++ b/test/WebpackOptionsDefaulter.unittest.js
@@ -1,0 +1,60 @@
+"use strict";
+
+const should = require("should");
+const WebpackOptionsDefaulter = require("../lib/WebpackOptionsDefaulter");
+
+describe("WebpackOptionsDefaulter", () => {
+	let plugin;
+
+	beforeEach(() => (plugin = new WebpackOptionsDefaulter()));
+
+	describe("resolve.mainFields", () => {
+		it("sets the right fields for web target in dev mode", () => {
+			const options = plugin.process({
+				mode: "development",
+				target: "web"
+			});
+
+			should(options.resolve.mainFields).be.eql(["browser", "module", "main"]);
+		});
+
+		it("sets the right fields for web target in prod mode", () => {
+			const options = plugin.process({
+				mode: "production",
+				target: "web"
+			});
+
+			should(options.resolve.mainFields).be.eql([
+				"browser:production",
+				"browser",
+				"module:production",
+				"module",
+				"main:production",
+				"main"
+			]);
+		});
+
+		it("sets the right fields for non-web target in dev mode", () => {
+			const options = plugin.process({
+				mode: "development",
+				target: "node"
+			});
+
+			should(options.resolve.mainFields).be.eql(["module", "main"]);
+		});
+
+		it("sets the right fields for non-web target in prod mode", () => {
+			const options = plugin.process({
+				mode: "production",
+				target: "node"
+			});
+
+			should(options.resolve.mainFields).be.eql([
+				"module:production",
+				"module",
+				"main:production",
+				"main"
+			]);
+		});
+	});
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2520,6 +2520,10 @@ lodash.create@3.1.1:
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
+lodash.flatmap@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz#ef8cbf408f6e48268663345305c6acc0b778702e"
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
~~not yet, need guidance~~ yes, unit tests
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
n/a, will add after this is merged
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Closes #6828 

This feature is primarily targeted at module authors. It is a common practice to provide various flat bundles of a library in dev and production variants, but before this change the production version would have to be dynamically-required or manually set up via `resolve.alias`.

The dynamic require scenario is suboptimal for many reasons, the most important one in a webpack scenario being that it will cause a module concatenation deopt. If a library is able to provide an ESM build, this change makes enables the author to supply the right variant for development vs production scenarios and hopefully avoid a concatenation deopt.

For example, a library could then provide a package.json config like:

```json
{
  "name": "my-package",
  "main": "./flat-bundle.cjs.js",
  "main:production": "./flat-bundle.cjs.min.js",
  "module": "./flat-bundle.es.js",
  "module:production": "./flat-bundle.es.min.js",
  "browser": "./flat-bundle.umd.js",
  "browser:production": "./flat-bundle.umd.min.js"
}
```

This effectively replaces index patterns like this:

```js
if (process.env.NODE_ENV === "production") {
  module.exports = require("./flat-bundle.cjs.min.js");
} else {
  module.exports = require("./flat-bundle.cjs.js");
}
```

And the "module" equivalent actually wasn't possible before at all because you can't dynamically `require` an ES module, yet.

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->