### PR TITLE
Ensure runtime code is written in ES5

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,16 +1,15 @@
 module.exports = {
-	"root": true,
-	"plugins": [
-		"prettier",
-		"node"
-	],
-	"extends": ["eslint:recommended", "plugin:node/recommended"],
-	"env": {
-		"node": true,
-		"es6": true,
+	root: true,
+	plugins: ["prettier", "node"],
+	extends: ["eslint:recommended", "plugin:node/recommended"],
+	env: {
+		node: true,
+		es6: true
 	},
-	"parserOptions": { "ecmaVersion": 2017 },
-	"rules": {
+	parserOptions: {
+		ecmaVersion: 2017
+	},
+	rules: {
 		"prettier/prettier": "error",
 		"no-undef": "error",
 		"no-extra-semi": "error",
@@ -25,7 +24,7 @@ module.exports = {
 		"no-extra-bind": "warn",
 		"no-process-exit": "warn",
 		"no-use-before-define": "off",
-		"no-unused-vars": ["error", { "args": "none" }],
+		"no-unused-vars": ["error", { args: "none" }],
 		"no-unsafe-negation": "error",
 		"no-loop-func": "warn",
 		"indent": "off",
@@ -34,16 +33,23 @@ module.exports = {
 		"node/no-unsupported-features": "error",
 		"node/no-deprecated-api": "error",
 		"node/no-missing-import": "error",
-		"node/no-missing-require": [
-			"error",
-			{
-				"allowModules": [
-					"webpack"
-				]
-			}
-		],
+		"node/no-missing-require": ["error", { allowModules: ["webpack"] }],
 		"node/no-unpublished-bin": "error",
 		"node/no-unpublished-require": "error",
 		"node/process-exit-as-throw": "error"
-	}
+	},
+	overrides: [
+		{
+			files: ["lib/**/*.runtime.js", "buildin/*.js", "hot/*.js"],
+			env: {
+				es6: false
+			},
+			globals: {
+				Promise: false,
+			},
+			parserOptions: {
+				ecmaVersion: 5
+			}
+		}
+	]
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

build change

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

n/a

**Summary**

Force runtime code to be written in ES5 to ensure browser compatibility.
Currently it does not check for ES2015+ prototype changes.

**Does this PR introduce a breaking change?**

no

**Other information**

Relates to #6764 