### PR TITLE
fix(bug) #5964 convert MS into S for scripts timeout attr

### DIFF
--- a/lib/web/JsonpMainTemplatePlugin.js
+++ b/lib/web/JsonpMainTemplatePlugin.js
@@ -98,7 +98,7 @@ class JsonpMainTemplatePlugin {
 						? `script.type = ${JSON.stringify(jsonpScriptType)};`
 						: "",
 					"script.charset = 'utf-8';",
-					`script.timeout = ${chunkLoadTimeout};`,
+					`script.timeout = ${chunkLoadTimeout / 1000};`,
 					crossOriginLoading
 						? `script.crossOrigin = ${JSON.stringify(crossOriginLoading)};`
 						: "",

--- a/test/statsCases/import-context-filter/expected.txt
+++ b/test/statsCases/import-context-filter/expected.txt
@@ -5,7 +5,7 @@ Built at: Thu Jan 01 1970 00:00:00 GMT
     0.js  305 bytes       0  [emitted]  
     1.js  314 bytes       1  [emitted]  
     2.js  308 bytes       2  [emitted]  
-entry.js   7.81 KiB       3  [emitted]  entry
+entry.js    7.8 KiB       3  [emitted]  entry
 Entrypoint entry = entry.js
    [0] ./templates/bar.js 38 bytes {0} [optional] [built]
    [1] ./templates/baz.js 38 bytes {1} [optional] [built]

--- a/test/statsCases/module-deduplication-named/expected.txt
+++ b/test/statsCases/module-deduplication-named/expected.txt
@@ -2,9 +2,9 @@
 async3.js  818 bytes       0  [emitted]  async3
 async1.js  818 bytes       1  [emitted]  async1
 async2.js  818 bytes       2  [emitted]  async2
-    e1.js   8.03 KiB       3  [emitted]  e1
-    e2.js   8.05 KiB       4  [emitted]  e2
-    e3.js   8.07 KiB       5  [emitted]  e3
+    e1.js   8.02 KiB       3  [emitted]  e1
+    e2.js   8.04 KiB       4  [emitted]  e2
+    e3.js   8.06 KiB       5  [emitted]  e3
 Entrypoint e1 = e1.js
 Entrypoint e2 = e2.js
 Entrypoint e3 = e3.js


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Converts miliseconds provided bia outputOptions configuration option into seconds for web script attribute `timeout`.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Fixes #5964
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
