### PR TITLE
[Seeking feedback] Reuse existing entry points if doing multiple passes

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -840,7 +840,9 @@ class Compilation extends Tapable {
 			const module = preparedEntrypoint.module;
 			const name = preparedEntrypoint.name;
 			const chunk = this.addChunk(name);
-			const entrypoint = new Entrypoint(name);
+			const entrypoint = this.namedChunkGroups.get("name")
+				? this.namedChunkGroups.get("name")
+				: new Entrypoint(name);
 			entrypoint.setRuntimeChunk(chunk);
 			entrypoint.addOrigin(null, name, preparedEntrypoint.request);
 			this.namedChunkGroups.set(name, entrypoint);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

Not yet. I wanted to get some feedback first.

**If relevant, link to documentation update:**

N/A

**Summary**

We have a slightly custom version of `webpack-dev-middleware` where we dynamically add entrypoints to the config as they're requested. I found that each top-level chunk was generating duplicate `Entrypoint` objects, which breaks `chunk.hasRuntime()` since `chunk.hasRuntime()` only looks at the first chunkGroup.

Looking for some feedback:
- Is this a bug?
- If so, is this best way to fix?
- How best to go about constructing a test case?

Thanks!

**Does this PR introduce a breaking change?**

Probably yes, but bug fix.

**Other information**

N/A