### PR TITLE
Error and Reporting Alignment : Phase 1

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -33,6 +33,7 @@ const createHash = require("./util/createHash");
 const Queue = require("./util/Queue");
 const SortableSet = require("./util/SortableSet");
 const GraphHelpers = require("./GraphHelpers");
+const WebpackErrorArray = require("./WebpackErrorArray");
 
 const byId = (a, b) => {
 	if (a.id < b.id) return -1;
@@ -241,8 +242,8 @@ class Compilation extends Tapable {
 		this.nextFreeModuleIndex2 = undefined;
 		this.additionalChunkAssets = [];
 		this.assets = {};
-		this.errors = [];
-		this.warnings = [];
+		this.errors = new WebpackErrorArray();
+		this.warnings = new WebpackErrorArray();
 		this.children = [];
 		this.dependencyFactories = new Map();
 		this.dependencyTemplates = new Map();

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -10,6 +10,7 @@ const DependenciesBlock = require("./DependenciesBlock");
 const ModuleReason = require("./ModuleReason");
 const SortableSet = require("./util/SortableSet");
 const Template = require("./Template");
+const WebpackErrorArray = require("./WebpackErrorArray");
 
 const EMPTY_RESOLVE_OPTIONS = {};
 
@@ -41,8 +42,8 @@ class Module extends DependenciesBlock {
 		this.factoryMeta = {};
 
 		// Info from Build
-		this.warnings = [];
-		this.errors = [];
+		this.errors = new WebpackErrorArray();
+		this.warnings = new WebpackErrorArray();
 		this.buildMeta = undefined;
 		this.buildInfo = undefined;
 

--- a/lib/WebpackError.js
+++ b/lib/WebpackError.js
@@ -12,13 +12,13 @@ const meta = Symbol("meta");
 module.exports = class WebpackError extends Error {
 	constructor(
 		message,
-		options = Object.create({
+		options = {
 			category: "error",
 			// NOTE: went with a more semantic structure here, even though it
 			// deviates from other similar structures in webpack
 			column: { end: 0, start: 0 },
 			line: { end: 0, start: 0 }
-		})
+		}
 	) {
 		// TODO: enable message assertion during construction in a commit to follow
 		// if (!message) {
@@ -50,9 +50,6 @@ module.exports = class WebpackError extends Error {
 			.split("\n")
 			.slice(3, 4)
 			.join("\n");
-		// use process.stdout to assert the message will be displayed in
-		// environments where console has been proxied. this mimics node's
-		// util.deprecate method.
 		process.emitWarning(`DeprecationWarning: ${message}\n${stack}\n`);
 	}
 

--- a/lib/WebpackError.js
+++ b/lib/WebpackError.js
@@ -4,8 +4,81 @@
 */
 "use strict";
 
+const createHash = require("./util/createHash");
+
+const hash = Symbol();
+const meta = Symbol();
+
 module.exports = class WebpackError extends Error {
+	constructor(
+		message,
+		line = 0,
+		column = 0,
+		columnEnd = 0,
+		category = "error"
+	) {
+		// TODO: enable message assertion during construction in a commit to follow
+		// if (!message) {
+		// 	WebpackError.deprecate("message must be a non-null, non-empty value.");
+		// }
+		// TODO: enable message length limit at a commit to follow
+		// else if (message.length > 160) {
+		// 	WebpackError.deprecate("message cannot be longer than 80 characters.");
+		// }
+
+		super(message);
+
+		this[hash] = createHash("md4");
+		this[meta] = {};
+		this.category = category;
+		this.column = column;
+		this.columnEnd = columnEnd;
+		this.line = line;
+
+		// TODO: enable abstract protection at a commit to follow
+		// if (this.constructor === WebpackError) {
+		// 	const message = `A WebpackError cannot be directly constructed.`;
+		// 	WebpackError.deprecate(message);
+		// }
+	}
+
+	static deprecate(message) {
+		const err = new Error();
+		const stack = err.stack
+			.split("\n")
+			.slice(3, 4)
+			.join("\n");
+		// use process.stdout to assert the message will be displayed in
+		// environments where console has been proxied. this mimics node's
+		// util.deprecate method.
+		process.stdout.write(`DeprecationWarning: ${message}\n${stack}\n`);
+	}
+
+	get id() {
+		return this[hash];
+	}
+
 	inspect() {
 		return this.stack + (this.details ? `\n${this.details}` : "");
 	}
+
+	get meta() {
+		return this[meta];
+	}
+
+	// TODO: enable this standard output in a later PR. at present, webpack tests
+	// rely heavily on arbitrary toString() output of different errors.
+	// toString(formatFn) {
+	// 	if (formatFn) {
+	// 		return formatFn(this);
+	// 	}
+	//
+	// 	let preface = `${this.line}:${this.column} `;
+	//
+	// 	if (this.category) {
+	// 		preface += `${this.category}: `;
+	// 	}
+	//
+	// 	return `${preface}${this.message}`;
+	// }
 };

--- a/lib/WebpackError.js
+++ b/lib/WebpackError.js
@@ -6,16 +6,19 @@
 
 const createHash = require("./util/createHash");
 
-const hash = Symbol();
-const meta = Symbol();
+const hash = Symbol("hash");
+const meta = Symbol("meta");
 
 module.exports = class WebpackError extends Error {
 	constructor(
 		message,
-		line = 0,
-		column = 0,
-		columnEnd = 0,
-		category = "error"
+		options = Object.create({
+			category: "error",
+			// NOTE: went with a more semantic structure here, even though it
+			// deviates from other similar structures in webpack
+			column: { end: 0, start: 0 },
+			line: { end: 0, start: 0 }
+		})
 	) {
 		// TODO: enable message assertion during construction in a commit to follow
 		// if (!message) {
@@ -29,11 +32,10 @@ module.exports = class WebpackError extends Error {
 		super(message);
 
 		this[hash] = createHash("md4");
-		this[meta] = {};
-		this.category = category;
-		this.column = column;
-		this.columnEnd = columnEnd;
-		this.line = line;
+		this[meta] = Object.create(null);
+		this.category = options.category;
+		this.column = options.column;
+		this.line = options.line;
 
 		// TODO: enable abstract protection at a commit to follow
 		// if (this.constructor === WebpackError) {
@@ -51,7 +53,7 @@ module.exports = class WebpackError extends Error {
 		// use process.stdout to assert the message will be displayed in
 		// environments where console has been proxied. this mimics node's
 		// util.deprecate method.
-		process.stdout.write(`DeprecationWarning: ${message}\n${stack}\n`);
+		process.emitWarning(`DeprecationWarning: ${message}\n${stack}\n`);
 	}
 
 	get id() {

--- a/lib/WebpackErrorArray.js
+++ b/lib/WebpackErrorArray.js
@@ -1,0 +1,33 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Andrew Powell <andrew@shellscape.org>
+*/
+"use strict";
+
+const WebpackError = require("./WebpackError");
+
+module.exports = class WebpackErrorArray extends Array {
+	constructor(...args) {
+		// TODO: validation will be enabled in a later PR
+		// if (args.length > 0 && typeof args[0] !== "number") {
+		// 	WebpackErrorArray.validate(...args);
+		// }
+		super(...args);
+	}
+
+	push(...args) {
+		// TODO: validation will be enabled in a later PR
+		// WebpackErrorArray.validate(...args);
+		super.push(...args);
+	}
+
+	static validate(...args) {
+		for (const arg of args) {
+			if (!(arg instanceof WebpackError)) {
+				const message = `A WebpackErrorArray can only contain WebpackError objects.
+  Offending Argument: ${arg}`;
+				WebpackError.deprecate(message);
+			}
+		}
+	}
+};

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -18,6 +18,7 @@ const HarmonyExportExpressionDependency = require("../dependencies/HarmonyExport
 const HarmonyExportImportedSpecifierDependency = require("../dependencies/HarmonyExportImportedSpecifierDependency");
 const HarmonyCompatibilityDependency = require("../dependencies/HarmonyCompatibilityDependency");
 const createHash = require("../util/createHash");
+const WebpackErrorArray = require("../WebpackErrorArray");
 
 const ensureNsObjSource = (
 	info,
@@ -288,8 +289,8 @@ class ConcatenatedModule extends Module {
 
 		this.dependencies = [];
 
-		this.warnings = [];
-		this.errors = [];
+		this.errors = new WebpackErrorArray();
+		this.warnings = new WebpackErrorArray();
 		this._orderedConcatenationList = this._createOrderedConcatenationList(
 			rootModule,
 			modulesSet

--- a/test/RemovedPlugins.unittest.js
+++ b/test/RemovedPlugins.unittest.js
@@ -4,14 +4,15 @@ require("should");
 
 describe("removed plugin errors", () => {
 	it("should error when accessing removed plugins", () => {
-		(() => webpack.optimize.UglifyJsPlugin).should.throw(
-			RemovedPluginError,
-			/webpack\.optimize\.UglifyJsPlugin has been removed, please use config\.optimization\.minimize instead\./
-		);
+		(() => webpack.optimize.UglifyJsPlugin).should.throw(RemovedPluginError, {
+			message: /webpack\.optimize\.UglifyJsPlugin has been removed, please use config\.optimization\.minimize instead\./
+		});
 
 		(() => webpack.optimize.CommonsChunkPlugin).should.throw(
 			RemovedPluginError,
-			/webpack\.optimize\.CommonsChunkPlugin has been removed, please use config\.optimization\.splitChunks instead\./
+			{
+				message: /webpack\.optimize\.CommonsChunkPlugin has been removed, please use config\.optimization\.splitChunks instead\./
+			}
 		);
 	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Refactor, RFC Implementation

**Did you add tests for your changes?**

Not yet needed, but tests were updated to satisfy changes in this PR.

**If relevant, link to documentation update:**

Not yet needed, but will occur when the validation and deprecation messages are enabled.

**Summary**

This PR is Phase 1 for changes proposed in RFC #6534. It introduces `WebpackErrorArray` and implemented a refactor to `WebpackError`. This is setup required for future work. The use of Errors across the webpack codebase is inconsistent and spread out. Many tests rely on arbitrary tests that differ greatly. It's for those reasons that a phased approach to fulfill the RFC is required.

To be implemented in later phases to follow shortly:
- Create proper Error types which extend `WebpackError` for code using `new Error`
- Enforcement in `WebpackError` construction
- Enforcement of types pushed to `WebpackErrorArray`
- Standardization of `toString` for `WebpackError`

**Does this PR introduce a breaking change?**

Nope

**Other information**
