### PR TITLE
Save identifier module after first getting

### DIFF
--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -44,6 +44,8 @@ class ContextModule extends Module {
 
 		if (typeof options.mode !== "string")
 			throw new Error("options.mode is a required option");
+
+		this._identifier = null;
 	}
 
 	prettyRegExp(regexString) {
@@ -65,6 +67,7 @@ class ContextModule extends Module {
 	}
 
 	identifier() {
+		if (this._identifier) return this._identifier;
 		let identifier = this.context;
 		if (this.options.resourceQuery)
 			identifier += ` ${this.options.resourceQuery}`;
@@ -77,6 +80,8 @@ class ContextModule extends Module {
 		if (this.options.namespaceObject === "strict")
 			identifier += " strict namespace object";
 		else if (this.options.namespaceObject) identifier += " namespace object";
+
+		this._identifier = identifier;
 
 		return identifier;
 	}

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -45,7 +45,7 @@ class ContextModule extends Module {
 		if (typeof options.mode !== "string")
 			throw new Error("options.mode is a required option");
 
-		this._identifier = null;
+		this._identifier = this._createIdentifier();
 	}
 
 	prettyRegExp(regexString) {
@@ -66,8 +66,7 @@ class ContextModule extends Module {
 			.join("!");
 	}
 
-	identifier() {
-		if (this._identifier) return this._identifier;
+	_createIdentifier() {
 		let identifier = this.context;
 		if (this.options.resourceQuery)
 			identifier += ` ${this.options.resourceQuery}`;
@@ -84,6 +83,10 @@ class ContextModule extends Module {
 		this._identifier = identifier;
 
 		return identifier;
+	}
+
+	identifier() {
+		return this._identifier;
 	}
 
 	readableIdentifier(requestShortener) {

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -80,8 +80,6 @@ class ContextModule extends Module {
 			identifier += " strict namespace object";
 		else if (this.options.namespaceObject) identifier += " namespace object";
 
-		this._identifier = identifier;
-
 		return identifier;
 	}
 

--- a/lib/MultiModule.js
+++ b/lib/MultiModule.js
@@ -15,10 +15,13 @@ class MultiModule extends Module {
 		// Info from Factory
 		this.dependencies = dependencies;
 		this.name = name;
+		this._identifier = `multi ${this.dependencies
+			.map(d => d.request)
+			.join(" ")}`;
 	}
 
 	identifier() {
-		return `multi ${this.dependencies.map(d => d.request).join(" ")}`;
+		return this._identifier;
 	}
 
 	readableIdentifier(requestShortener) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Performance. Cache module identifier after first call.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

In some plugins we have sort modules function like this:
```js
// From SplitChunksPlugin
const sortByIdentifier = (a, b) => {
	if (a.identifier() > b.identifier()) return 1;
	if (a.identifier() < b.identifier()) return -1;
	return 0;
};
```
Method `identifier()` can be run many times while sorting. Each call `identifier()` calculates identifier from options. We can cache it to avoid repeated calculate.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
