### PR TITLE
Use 'Reflect.defineProperty' instead of 'Object.defineProperty'

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -155,7 +155,7 @@ exportPlugins((exports.debug = {}), {
 });
 
 const defineMissingPluginError = (namespace, pluginName, errorMessage) => {
-	Reflect.defineProperty(namespace, pluginName, {
+	Object.defineProperty(namespace, pluginName, {
 		configurable: false,
 		enumerable: true,
 		get() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

n/a

**Summary**

~~`Reflect.defineProperty` is more meaningful than `Object.defineProperty`. Internally `Reflect.dP` performs less checks than `Object.dP`.~~

Use `Object.defineProperty`

**Does this PR introduce a breaking change?**

no