### PR TITLE
Use ellipsis instead of '...'

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -92,36 +92,36 @@ class Compiler extends Tapable {
 					this.resolverFactory.plugin("resolver normal", resolver => {
 						resolver.plugin(hook, fn);
 					});
-				}, "webpack: Using compiler.resolvers.normal is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver normal", resolver => {\n  resolver.plugin(/* ... */);\n}); instead.'),
+				}, "webpack: Using compiler.resolvers.normal is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver normal", resolver => {\n  resolver.plugin(/* … */);\n}); instead.'),
 				apply: util.deprecate((...args) => {
 					this.resolverFactory.plugin("resolver normal", resolver => {
 						resolver.apply(...args);
 					});
-				}, "webpack: Using compiler.resolvers.normal is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver normal", resolver => {\n  resolver.apply(/* ... */);\n}); instead.')
+				}, "webpack: Using compiler.resolvers.normal is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver normal", resolver => {\n  resolver.apply(/* … */);\n}); instead.')
 			},
 			loader: {
 				plugins: util.deprecate((hook, fn) => {
 					this.resolverFactory.plugin("resolver loader", resolver => {
 						resolver.plugin(hook, fn);
 					});
-				}, "webpack: Using compiler.resolvers.loader is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver loader", resolver => {\n  resolver.plugin(/* ... */);\n}); instead.'),
+				}, "webpack: Using compiler.resolvers.loader is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver loader", resolver => {\n  resolver.plugin(/* … */);\n}); instead.'),
 				apply: util.deprecate((...args) => {
 					this.resolverFactory.plugin("resolver loader", resolver => {
 						resolver.apply(...args);
 					});
-				}, "webpack: Using compiler.resolvers.loader is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver loader", resolver => {\n  resolver.apply(/* ... */);\n}); instead.')
+				}, "webpack: Using compiler.resolvers.loader is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver loader", resolver => {\n  resolver.apply(/* … */);\n}); instead.')
 			},
 			context: {
 				plugins: util.deprecate((hook, fn) => {
 					this.resolverFactory.plugin("resolver context", resolver => {
 						resolver.plugin(hook, fn);
 					});
-				}, "webpack: Using compiler.resolvers.context is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver context", resolver => {\n  resolver.plugin(/* ... */);\n}); instead.'),
+				}, "webpack: Using compiler.resolvers.context is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver context", resolver => {\n  resolver.plugin(/* … */);\n}); instead.'),
 				apply: util.deprecate((...args) => {
 					this.resolverFactory.plugin("resolver context", resolver => {
 						resolver.apply(...args);
 					});
-				}, "webpack: Using compiler.resolvers.context is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver context", resolver => {\n  resolver.apply(/* ... */);\n}); instead.')
+				}, "webpack: Using compiler.resolvers.context is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver context", resolver => {\n  resolver.apply(/* … */);\n}); instead.')
 			}
 		};
 

--- a/lib/JavascriptGenerator.js
+++ b/lib/JavascriptGenerator.js
@@ -84,9 +84,9 @@ class JavascriptGenerator {
 			 * we can not inject "foo" twice, therefore we just make two IIFEs like so:
 			 * (function(foo, bar, baz){
 			 *   (function(foo, some, more){
-			 *     ...
-			 *   }(...));
-			 * }(...));
+			 *     …
+			 *   }(…));
+			 * }(…));
 			 *
 			 * "splitVariablesInUniqueNamedChunks" splits the variables shown above up to this:
 			 * [[foo, bar, baz], [foo, some, more]]
@@ -178,8 +178,8 @@ class JavascriptGenerator {
 
 	/*
 	 * creates the start part of a IIFE around the module to inject a variable name
-	 * (function(...){   <- this part
-	 * }.call(...))
+	 * (function(…){   <- this part
+	 * }.call(…))
 	 */
 	variableInjectionFunctionWrapperStartCode(varNames) {
 		const args = varNames.join(", ");
@@ -195,8 +195,8 @@ class JavascriptGenerator {
 
 	/*
 	 * creates the end part of a IIFE around the module to inject a variable name
-	 * (function(...){
-	 * }.call(...))   <- this part
+	 * (function(…){
+	 * }.call(…))   <- this part
 	 */
 	variableInjectionFunctionWrapperEndCode(module, varExpressions, block) {
 		const firstParam = this.contextArgument(module, block);

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -1648,7 +1648,7 @@ class Parser extends Tapable {
 			expression.arguments &&
 			expression.arguments.length > 0
 		) {
-			// (function(...) { }.call/bind(?, ...))
+			// (function(…) { }.call/bind(?, …))
 			walkIIFE.call(
 				this,
 				expression.callee.object,
@@ -1659,7 +1659,7 @@ class Parser extends Tapable {
 			expression.callee.type === "FunctionExpression" &&
 			expression.arguments
 		) {
-			// (function(...) { }(...))
+			// (function(…) { }(…))
 			walkIIFE.call(this, expression.callee, expression.arguments);
 		} else if (expression.callee.type === "Import") {
 			result = this.hooks.importCall.call(expression);

--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -24,7 +24,7 @@ const createDefaultHandler = profile => {
 			for (let detail of details) {
 				if (!detail) continue;
 				if (detail.length > 40) {
-					detail = `...${detail.substr(detail.length - 37)}`;
+					detail = `…${detail.substr(detail.length - 39)}`;
 				}
 				msg += ` ${detail}`;
 			}

--- a/lib/Template.js
+++ b/lib/Template.js
@@ -118,7 +118,7 @@ module.exports = class Template {
 			if (minId > module.id) minId = module.id;
 		}
 		if (minId < 16 + ("" + minId).length) {
-			// add minId x ',' instead of 'Array(minId).concat(...)'
+			// add minId x ',' instead of 'Array(minId).concat(…)'
 			minId = 0;
 		}
 		var objectOverhead = modules

--- a/lib/WebpackOptionsValidationError.js
+++ b/lib/WebpackOptionsValidationError.js
@@ -116,7 +116,7 @@ class WebpackOptionsValidationError extends WebpackError {
 						if (!required.includes(property)) return property + "?";
 						return property;
 					})
-					.concat(schema.additionalProperties ? ["..."] : [])
+					.concat(schema.additionalProperties ? ["…"] : [])
 					.join(", ")} }`;
 			}
 			if (schema.additionalProperties) {
@@ -175,7 +175,7 @@ class WebpackOptionsValidationError extends WebpackError {
 					"    new webpack.LoaderOptionsPlugin({\n" +
 					"      // test: /\\.xxx$/, // may apply this only for some modules\n" +
 					"      options: {\n" +
-					`        ${err.params.additionalProperty}: ...\n` +
+					`        ${err.params.additionalProperty}: …\n` +
 					"      }\n" +
 					"    })\n" +
 					"  ]"

--- a/lib/dependencies/AMDDefineDependencyParserPlugin.js
+++ b/lib/dependencies/AMDDefineDependencyParserPlugin.js
@@ -152,10 +152,10 @@ class AMDDefineDependencyParserPlugin {
 		switch (expr.arguments.length) {
 			case 1:
 				if (isCallable(expr.arguments[0])) {
-					// define(f() {...})
+					// define(f() {…})
 					fn = expr.arguments[0];
 				} else if (expr.arguments[0].type === "ObjectExpression") {
-					// define({...})
+					// define({…})
 					obj = expr.arguments[0];
 				} else {
 					// define(expr)
@@ -166,45 +166,45 @@ class AMDDefineDependencyParserPlugin {
 			case 2:
 				if (expr.arguments[0].type === "Literal") {
 					namedModule = expr.arguments[0].value;
-					// define("...", ...)
+					// define("…", …)
 					if (isCallable(expr.arguments[1])) {
-						// define("...", f() {...})
+						// define("…", f() {…})
 						fn = expr.arguments[1];
 					} else if (expr.arguments[1].type === "ObjectExpression") {
-						// define("...", {...})
+						// define("…", {…})
 						obj = expr.arguments[1];
 					} else {
-						// define("...", expr)
+						// define("…", expr)
 						// unclear if function or object
 						obj = fn = expr.arguments[1];
 					}
 				} else {
 					array = expr.arguments[0];
 					if (isCallable(expr.arguments[1])) {
-						// define([...], f() {})
+						// define([…], f() {})
 						fn = expr.arguments[1];
 					} else if (expr.arguments[1].type === "ObjectExpression") {
-						// define([...], {...})
+						// define([…], {…})
 						obj = expr.arguments[1];
 					} else {
-						// define([...], expr)
+						// define([…], expr)
 						// unclear if function or object
 						obj = fn = expr.arguments[1];
 					}
 				}
 				break;
 			case 3:
-				// define("...", [...], f() {...})
+				// define("…", […], f() {…})
 				namedModule = expr.arguments[0].value;
 				array = expr.arguments[1];
 				if (isCallable(expr.arguments[2])) {
-					// define("...", [...], f() {})
+					// define("…", […], f() {})
 					fn = expr.arguments[2];
 				} else if (expr.arguments[2].type === "ObjectExpression") {
-					// define("...", [...], {...})
+					// define("…", […], {…})
 					obj = expr.arguments[2];
 				} else {
-					// define("...", [...], expr)
+					// define("…", […], expr)
 					// unclear if function or object
 					obj = fn = expr.arguments[2];
 				}

--- a/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
@@ -216,7 +216,7 @@ class AMDRequireDependenciesBlockParserPlugin {
 						parser.state.module.errors.push(
 							new UnsupportedFeatureWarning(
 								parser.state.module,
-								"Cannot statically analyse 'require(..., ...)' in line " +
+								"Cannot statically analyse 'require(…, …)' in line " +
 									expr.loc.start.line
 							)
 						);

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -210,7 +210,7 @@ describe("Validation", () => {
 				"       new webpack.LoaderOptionsPlugin({",
 				"         // test: /\\.xxx$/, // may apply this only for some modules",
 				"         options: {",
-				"           postcss: ...",
+				"           postcss: …",
 				"         }",
 				"       })",
 				"     ]"
@@ -297,7 +297,7 @@ describe("Validation", () => {
 			},
 			message: [
 				" - configuration.plugins[0] should be one of these:",
-				"   object { apply, ... } | function",
+				"   object { apply, … } | function",
 				"   -> Plugin of type object or instanceof Function",
 				"   Details:",
 				"    * configuration.plugins[0] should be an object.",
@@ -314,7 +314,7 @@ describe("Validation", () => {
 			},
 			message: [
 				" - configuration.plugins[0] should be one of these:",
-				"   object { apply, ... } | function",
+				"   object { apply, … } | function",
 				"   -> Plugin of type object or instanceof Function",
 				"   Details:",
 				"    * configuration.plugins[0] should be an object.",
@@ -331,7 +331,7 @@ describe("Validation", () => {
 			},
 			message: [
 				" - configuration.plugins[0] should be one of these:",
-				"   object { apply, ... } | function",
+				"   object { apply, … } | function",
 				"   -> Plugin of type object or instanceof Function",
 				"   Details:",
 				"    * configuration.plugins[0] should be an object.",
@@ -348,7 +348,7 @@ describe("Validation", () => {
 			},
 			message: [
 				" - configuration.plugins[0] should be one of these:",
-				"   object { apply, ... } | function",
+				"   object { apply, … } | function",
 				"   -> Plugin of type object or instanceof Function",
 				"   Details:",
 				"    * configuration.plugins[0] should be an object.",
@@ -365,7 +365,7 @@ describe("Validation", () => {
 			},
 			message: [
 				" - configuration.plugins[0] should be one of these:",
-				"   object { apply, ... } | function",
+				"   object { apply, … } | function",
 				"   -> Plugin of type object or instanceof Function",
 				"   Details:",
 				"    * configuration.plugins[0] misses the property 'apply'.",

--- a/test/browsertest/build.js
+++ b/test/browsertest/build.js
@@ -23,7 +23,7 @@ function join(a, b) {
 	return a;
 }
 
-console.log("compile scripts...");
+console.log("compile scripts…");
 
 var extraArgsNoWatch = extraArgs.slice(0);
 var watchIndex = extraArgsNoWatch.indexOf("--watch");

--- a/test/cases/parsing/extract-require/index.js
+++ b/test/cases/parsing/extract-require/index.js
@@ -11,8 +11,8 @@ function testCase(number) {
 }
 
 it("should parse complex require calls", function() {
-	should.strictEqual(new(require("./constructor"))(1234).value, 1234, "Parse require in new(...) should work");
-	should.strictEqual(new ( require ( "./constructor" ) ) ( 1234 ) .value, 1234, "Parse require in new(...) should work, with spaces");
+	should.strictEqual(new(require("./constructor"))(1234).value, 1234, "Parse require in new(…) should work");
+	should.strictEqual(new ( require ( "./constructor" ) ) ( 1234 ) .value, 1234, "Parse require in new(…) should work, with spaces");
 });
 
 it("should let the user hide the require function", function() {

--- a/test/cases/parsing/hot-api/index.js
+++ b/test/cases/parsing/hot-api/index.js
@@ -1,5 +1,5 @@
 if(module.hot) {
-	it("should run module.hot.accept(...)", function() {
+	it("should run module.hot.accept(…)", function() {
 		module.hot.accept("./a", function() {});
 	});
 	it("should run module.hot.accept()", function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

n/a

**Summary**

While searching through the codebase for `...` I hit a lot of comments and messages containing these characters. I think using an ellipsis instead is more readable.

Previously:

```
- configuration.plugins[0] should be one of these:
  object { apply, ... } | function
  -> Plugin of type object or instanceof Function
  Details:
```

Now:

```
- configuration.plugins[0] should be one of these:
  object { apply, … } | function
  -> Plugin of type object or instanceof Function
  Details:
```

**Does this PR introduce a breaking change?**

no, unless some code relies on error messages.
