### PR TITLE
Add handling for devtool source-map with library specified as Object

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -134,6 +134,8 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("output.devtoolNamespace", "make", options => {
 			if (Array.isArray(options.output.library))
 				return options.output.library.join(".");
+			else if (typeof options.output.library === "object")
+				return options.output.library.root || "";
 			return options.output.library || "";
 		});
 		this.set("output.libraryTarget", "var");

--- a/test/configCases/source-map/object-as-output-library/index.js
+++ b/test/configCases/source-map/object-as-output-library/index.js
@@ -1,0 +1,1 @@
+it("should compile successfully when output.library is an object of type:name", function() {});

--- a/test/configCases/source-map/object-as-output-library/webpack.config.js
+++ b/test/configCases/source-map/object-as-output-library/webpack.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	devtool: "source-map",
+	output: {
+		library: {
+			root: "[name]",
+			amd: "[name]",
+			commonjs: "[name]"
+		},
+		libraryTarget: "umd"
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Fixes https://github.com/webpack/webpack/issues/6843

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Fixes bug when using an Object as config.output.library with devTool: 'source-map'

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
I am not 100% certain that my approach to setting devtoolNamespace to the output.library.root is correct, but I don't know enough about devtoolNamespace to have a better idea of what to use. Note that in the docs, it also specifies that the Object should be allowed to have Array values, which this PR does not support. That would have to be added later.