### PR TITLE
fix capitalization of project name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ yarn add webpack --dev
 
 <h2 align="center">Introduction</h2>
 
-> This README reflects Webpack v2.x and v3.x. The Webpack v1.x documentation has been deprecated and deleted.
+> This README reflects webpack v2.x and v3.x. The webpack v1.x documentation has been deprecated and deleted.
 
 webpack is a bundler for modules. The main purpose is to bundle JavaScript
 files for usage in a browser, yet it is also capable of transforming, bundling,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

n/a

**If relevant, link to documentation update:**

It's README.md

**Summary**

I was confused because of this, but @TheLarkInn pointed me to the [branding guidelines](https://webpack.js.org/branding/).

**Does this PR introduce a breaking change?**

No

**Other information**

I like turtles