### PR TITLE
Remove extraneous argument from setOptions call sites in OptionsDefaulter

### DIFF
--- a/lib/OptionsDefaulter.js
+++ b/lib/OptionsDefaulter.js
@@ -43,8 +43,7 @@ class OptionsDefaulter {
 					setProperty(
 						options,
 						name,
-						this.defaults[name].call(this, getProperty(options, name), options),
-						options
+						this.defaults[name].call(this, getProperty(options, name), options)
 					);
 					break;
 				case "make":
@@ -52,8 +51,7 @@ class OptionsDefaulter {
 						setProperty(
 							options,
 							name,
-							this.defaults[name].call(this, options),
-							options
+							this.defaults[name].call(this, options)
 						);
 					break;
 				case "append": {

--- a/lib/OptionsDefaulter.js
+++ b/lib/OptionsDefaulter.js
@@ -48,11 +48,7 @@ class OptionsDefaulter {
 					break;
 				case "make":
 					if (getProperty(options, name) === undefined)
-						setProperty(
-							options,
-							name,
-							this.defaults[name].call(this, options)
-						);
+						setProperty(options, name, this.defaults[name].call(this, options));
 					break;
 				case "append": {
 					let oldValue = getProperty(options, name);


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

code clean up

**Did you add tests for your changes?**

N/A

**If relevant, link to documentation update:**

N/A

**Summary**

As part of https://github.com/webpack/webpack/pull/6862 I'm fixing issues TypeScript has found 

**Does this PR introduce a breaking change?**
No

**Other information**