### PR TITLE
emit correct path when using loader in options

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -51,6 +51,13 @@ class Stats {
 		});
 	}
 
+	formatFilePath(filePath) {
+		const OPTIONS_REGEXP = /^(\s|\S)*!/;
+		return filePath.includes("!")
+			? `${filePath.replace(OPTIONS_REGEXP, "")} (${filePath})\n`
+			: `${filePath}\n`;
+	}
+
 	hasWarnings() {
 		return (
 			this.compilation.warnings.length > 0 ||
@@ -264,7 +271,9 @@ class Stats {
 				e.module.readableIdentifier &&
 				typeof e.module.readableIdentifier === "function"
 			) {
-				text += `${e.module.readableIdentifier(requestShortener)}\n`;
+				text += this.formatFilePath(
+					e.module.readableIdentifier(requestShortener)
+				);
 			}
 			text += e.message;
 			if (showErrorDetails && e.details) text += `\n${e.details}`;

--- a/test/Stats.unittest.js
+++ b/test/Stats.unittest.js
@@ -9,6 +9,24 @@ const packageJson = require("../package.json");
 describe(
 	"Stats",
 	() => {
+		describe("formatFilePath", () => {
+			it("emit the file path and request", () => {
+				const mockStats = new Stats({
+					children: [],
+					errors: ["firstError"],
+					hash: "1234",
+					compiler: {
+						context: ""
+					}
+				});
+				const inputPath =
+					"./node_modules/ts-loader!./node_modules/vue-loader/lib/selector.js?type=script&index=0!./src/app.vue";
+				const expectPath = `./src/app.vue (${inputPath})\n`;
+
+				mockStats.formatFilePath(inputPath).should.be.exactly(expectPath);
+			});
+		});
+
 		describe("Error Handling", () => {
 			describe("does have", () => {
 				it("hasErrors", () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
yes

**Summary**
fix the error message like below.
```
[now]
ERROR in ./node_modules/ts-loader!./node_modules/tslint-loader!./node_modules/vue-loader/lib/selector.js?type=script&index=0!./src/app.vue

[i want]
ERROR in ./src/app.vue
```
**Does this PR introduce a breaking change?**
no

**Other information**
webpack emits the error message when using loader in options like below.
```js
// webpack.config.js
module: {
  rules: [{
    test: /\.vue$/,
    use: [{
      loader: 'vue-loader',
      options: {
        loaders: {
          ts: 'ts-loader',
        },
      },
    }]
  }]
}
```