### PR TITLE
Remove extra argument passed to JavascriptGenerator constructor

### DIFF
--- a/lib/JavascriptModulesPlugin.js
+++ b/lib/JavascriptModulesPlugin.js
@@ -32,18 +32,18 @@ class JavascriptModulesPlugin {
 					});
 				normalModuleFactory.hooks.createGenerator
 					.for("javascript/auto")
-					.tap("JavascriptModulesPlugin", options => {
-						return new JavascriptGenerator(options);
+					.tap("JavascriptModulesPlugin", () => {
+						return new JavascriptGenerator();
 					});
 				normalModuleFactory.hooks.createGenerator
 					.for("javascript/dynamic")
-					.tap("JavascriptModulesPlugin", options => {
-						return new JavascriptGenerator(options);
+					.tap("JavascriptModulesPlugin", () => {
+						return new JavascriptGenerator();
 					});
 				normalModuleFactory.hooks.createGenerator
 					.for("javascript/esm")
-					.tap("JavascriptModulesPlugin", options => {
-						return new JavascriptGenerator(options);
+					.tap("JavascriptModulesPlugin", () => {
+						return new JavascriptGenerator();
 					});
 				compilation.mainTemplate.hooks.renderManifest.tap(
 					"JavascriptModulesPlugin",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
refactor
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
no
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
As part of https://github.com/webpack/webpack/pull/6862 I'm proposing fixes that TypeScript have found 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
