### PR TITLE
Initialize fileTimestamps and contextTimestamps in Compilation

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -253,6 +253,8 @@ class Compilation extends Tapable {
 		this.childrenCounters = {};
 		this.usedChunkIds = null;
 		this.usedModuleIds = null;
+		this.fileTimestamps = undefined;
+		this.contextTimestamps = undefined;
 
 		this._buildingModules = new Map();
 		this._rebuildingModules = new Map();

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -276,28 +276,6 @@ class Compilation extends Tapable {
 		const cacheName = (cacheGroup || "m") + identifier;
 		if (this.cache && this.cache[cacheName]) {
 			const cacheModule = this.cache[cacheName];
-
-			let rebuild = true;
-			if (this.fileTimestamps && this.contextTimestamps) {
-				rebuild = cacheModule.needRebuild(
-					this.fileTimestamps,
-					this.contextTimestamps
-				);
-			}
-
-			if (!rebuild) {
-				cacheModule.disconnect();
-				this._modules.set(identifier, cacheModule);
-				this.modules.push(cacheModule);
-				for (const err of cacheModule.errors) this.errors.push(err);
-				for (const err of cacheModule.warnings) this.warnings.push(err);
-				return {
-					module: cacheModule,
-					issuer: true,
-					build: false,
-					dependencies: true
-				};
-			}
 			cacheModule.unbuild();
 			module = cacheModule;
 		}

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -276,6 +276,28 @@ class Compilation extends Tapable {
 		const cacheName = (cacheGroup || "m") + identifier;
 		if (this.cache && this.cache[cacheName]) {
 			const cacheModule = this.cache[cacheName];
+
+			let rebuild = true;
+			if (this.fileTimestamps && this.contextTimestamps) {
+				rebuild = cacheModule.needRebuild(
+					this.fileTimestamps,
+					this.contextTimestamps
+				);
+			}
+
+			if (!rebuild) {
+				cacheModule.disconnect();
+				this._modules.set(identifier, cacheModule);
+				this.modules.push(cacheModule);
+				for (const err of cacheModule.errors) this.errors.push(err);
+				for (const err of cacheModule.warnings) this.warnings.push(err);
+				return {
+					module: cacheModule,
+					issuer: true,
+					build: false,
+					dependencies: true
+				};
+			}
 			cacheModule.unbuild();
 			module = cacheModule;
 		}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
refactor
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
`this.fileTimestamps && this.contextTimestamps` is always falsy in `Compilation`. I looked into Tapable too and those don't exist there either. I see `fileTimestamps` in `Compiler` class. Is that related?
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

Related to https://github.com/webpack/webpack/pull/6862
