### PR TITLE
Initialize loc member in Dependency

### DIFF
--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -10,6 +10,7 @@ class Dependency {
 		this.module = null;
 		this.weak = false;
 		this.optional = false;
+		this.loc = undefined;
 	}
 
 	getResourceIdentifier() {


### PR DESCRIPTION
Related to https://github.com/webpack/webpack/pull/6862


This change is being proposed based on [this comment](https://github.com/webpack/webpack/pull/6869#discussion_r177343671) that says Webpack prefers initializing possible members in classes 