### PR TITLE
Initialize compilationDependencies in Compilation as undefined

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1544,7 +1544,7 @@ class Compilation extends Tapable {
 				chunk.ids = [chunk.id];
 			}
 		}
-
+	}
 
 	sortItemsWithModuleIds() {
 		this.modules.sort(byIdOrIdentifier);

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -253,6 +253,7 @@ class Compilation extends Tapable {
 		this.childrenCounters = {};
 		this.usedChunkIds = null;
 		this.usedModuleIds = null;
+		this.compilationDependencies = undefined;
 
 		this._buildingModules = new Map();
 		this._rebuildingModules = new Map();
@@ -1593,7 +1594,7 @@ class Compilation extends Tapable {
 	}
 
 	summarizeDependencies() {
-		this.fileDependencies = new SortableSet();
+		this.fileDependencies = new SortableSet(this.compilationDependencies);
 		this.contextDependencies = new SortableSet();
 		this.missingDependencies = new SortableSet();
 

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1544,7 +1544,7 @@ class Compilation extends Tapable {
 				chunk.ids = [chunk.id];
 			}
 		}
-	}
+
 
 	sortItemsWithModuleIds() {
 		this.modules.sort(byIdOrIdentifier);
@@ -1593,7 +1593,7 @@ class Compilation extends Tapable {
 	}
 
 	summarizeDependencies() {
-		this.fileDependencies = new SortableSet(this.compilationDependencies);
+		this.fileDependencies = new SortableSet();
 		this.contextDependencies = new SortableSet();
 		this.missingDependencies = new SortableSet();
 


### PR DESCRIPTION
Related to https://github.com/webpack/webpack/pull/6862

@sokra you mentioned this is broken but I'm not sure removing the argument is the right change