### PR TITLE
fix: better no mode warning message

### DIFF
--- a/lib/NoModeWarning.js
+++ b/lib/NoModeWarning.js
@@ -14,9 +14,9 @@ module.exports = class NoModeWarning extends WebpackError {
 		this.message =
 			"configuration\n" +
 			"The 'mode' option has not been set, webpack will fallback to 'production' for this value. " +
-      "Set 'mode' option to 'development' or 'production' to enable defaults for each environment.\n" +
-      "You can also set it to 'none' to disable any default behavior. " +
-      "Learn more: https://webpack.js.org/concepts/mode/";
+			"Set 'mode' option to 'development' or 'production' to enable defaults for each environment.\n" +
+			"You can also set it to 'none' to disable any default behavior. " +
+			"Learn more: https://webpack.js.org/concepts/mode/";
 
 		Error.captureStackTrace(this, this.constructor);
 	}

--- a/lib/NoModeWarning.js
+++ b/lib/NoModeWarning.js
@@ -13,8 +13,10 @@ module.exports = class NoModeWarning extends WebpackError {
 		this.name = "NoModeWarning";
 		this.message =
 			"configuration\n" +
-			"The 'mode' option has not been set. " +
-			"Set 'mode' option to 'development' or 'production' to enable defaults for this environment. ";
+			"The 'mode' option has not been set, webpack will fallback to 'production' for this value. " +
+      "Set 'mode' option to 'development' or 'production' to enable defaults for each environment.\n" +
+      "You can also set it to 'none' to disable any default behavior. " +
+      "Learn more: https://webpack.js.org/concepts/mode/";
 
 		Error.captureStackTrace(this, this.constructor);
 	}

--- a/test/statsCases/no-emit-on-errors-plugin-with-child-error/expected.txt
+++ b/test/statsCases/no-emit-on-errors-plugin-with-child-error/expected.txt
@@ -1,4 +1,4 @@
-Hash: 885948e5541fff6e85ac
+Hash: 550499db0a071b393308
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset      Size  Chunks  Chunk Names
@@ -8,7 +8,8 @@ Entrypoint main = bundle.js
    [0] ./index.js 0 bytes {0} [built]
 
 WARNING in configuration
-The 'mode' option has not been set. Set 'mode' option to 'development' or 'production' to enable defaults for this environment. 
+The 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
+You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/concepts/mode/
 Child child:
        Asset      Size  Chunks  Chunk Names
     child.js  2.61 KiB       0  child


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Improvement to the warning shown in terminal when no mode option was set.

**Did you add tests for your changes?**

No.

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

The message that we are showing to users when the `mode` option is not set is a little confusing. First of all, we are not communicating that we are defaulting to `production`, something which actually caused confusion while writing docs when contributors wanted to come up with what was the default using this message as source of truth: https://github.com/webpack/webpack.js.org/pull/1940

**Does this PR introduce a breaking change?**

No

**Other information**

I didn't add any test because I don't see the specific value of it for this specific case, but if you think that's a blocker I can come up with some way to test a warning with some message related to the option setting is thrown.

The new output would look like:

> WARNING in configuration
The 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/concepts/mode/