### PR TITLE
fixes for mini-css-extract-plugin

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -158,8 +158,6 @@ class Compilation extends Tapable {
 			beforeChunkAssets: new SyncHook([]),
 			additionalChunkAssets: new SyncHook(["chunks"]),
 
-			records: new SyncHook(["compilation", "records"]),
-
 			additionalAssets: new AsyncSeriesHook([]),
 			optimizeChunkAssets: new AsyncSeriesHook(["chunks"]),
 			afterOptimizeChunkAssets: new SyncHook(["chunks"]),
@@ -276,6 +274,9 @@ class Compilation extends Tapable {
 		const cacheName = (cacheGroup || "m") + identifier;
 		if (this.cache && this.cache[cacheName]) {
 			const cacheModule = this.cache[cacheName];
+
+			if (typeof cacheModule.updateCacheModule === "function")
+				cacheModule.updateCacheModule(module);
 
 			let rebuild = true;
 			if (this.fileTimestamps && this.contextTimestamps) {

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -45,6 +45,12 @@ class ContextModule extends Module {
 			throw new Error("options.mode is a required option");
 	}
 
+	updateCacheModule(module) {
+		this.resolveDependencies = module.resolveDependencies;
+		this.options = module.options;
+		this.resolveOptions = module.resolveOptions;
+	}
+
 	prettyRegExp(regexString) {
 		// remove the "/" at the front and the beginning
 		// "/foo/" -> "foo"

--- a/lib/HotUpdateChunkTemplate.js
+++ b/lib/HotUpdateChunkTemplate.js
@@ -47,7 +47,7 @@ module.exports = class HotUpdateChunkTemplate extends Tapable {
 		hotUpdateChunk.removedModules = removedModules;
 		const modulesSource = Template.renderChunkModules(
 			hotUpdateChunk,
-			() => true,
+			m => typeof m.source === "function",
 			moduleTemplate,
 			dependencyTemplates
 		);

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -336,5 +336,6 @@ Module.prototype.build = null;
 Module.prototype.source = null;
 Module.prototype.size = null;
 Module.prototype.nameForCondition = null;
+Module.prototype.updateCacheModule = null;
 
 module.exports = Module;

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -122,6 +122,15 @@ class NormalModule extends Module {
 		return this.resource;
 	}
 
+	updateCacheModule(module) {
+		this.userRequest = module.userRequest;
+		this.parser = module.parser;
+		this.generator = module.generator;
+		this.resource = module.resource;
+		this.loaders = module.loaders;
+		this.resolveOptions = module.resolveOptions;
+	}
+
 	createSourceForAsset(name, content, sourceMap) {
 		if (!sourceMap) {
 			return new RawSource(content);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
features and bugfixes
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no, existing tests
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
n/a
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
incremental build was broken for mini-css-extract-plugin, because modules cannot be updated.
adding `Module.updateCacheModule` allows this.
HMR chunk creation crashes because it misses the filter for `Module.source`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
