### PR TITLE
Initialize start and end time as undefined in Stats

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -19,6 +19,8 @@ class Stats {
 	constructor(compilation) {
 		this.compilation = compilation;
 		this.hash = compilation.hash;
+		this.startTime = undefined;
+		this.endTime = undefined;
 	}
 
 	static filterWarnings(warnings, warningsFilter) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
refactor
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
n/a
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
As part of https://github.com/webpack/webpack/pull/6862 this change adds initializers to Stats class 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
