### PR TITLE
Remove extra argument passed to getEntrypointSize in SizeLimitsPlugin

### DIFF
--- a/lib/performance/SizeLimitsPlugin.js
+++ b/lib/performance/SizeLimitsPlugin.js
@@ -53,7 +53,7 @@ module.exports = class SizeLimitsPlugin {
 			for (const pair of compilation.entrypoints) {
 				const name = pair[0];
 				const entry = pair[1];
-				const size = getEntrypointSize(entry, compilation);
+				const size = getEntrypointSize(entry);
 
 				if (size > entrypointSizeLimit) {
 					entrypointsOverLimit.push({


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
refactori
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
n/a
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
As part of https://github.com/webpack/webpack/pull/6862 I'm fixing issues TypeScript has found 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
