### PR TITLE
Add missing class member initializations found by TypeScript

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -208,6 +208,7 @@ class Compilation extends Tapable {
 					break;
 			}
 		});
+		this.name = undefined;
 		this.compiler = compiler;
 		this.resolverFactory = compiler.resolverFactory;
 		this.inputFileSystem = compiler.inputFileSystem;

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -74,6 +74,8 @@ class Compiler extends Tapable {
 			}
 		});
 
+		this.name = undefined;
+		this.parentCompilation = undefined;
 		this.outputPath = "";
 		this.outputFileSystem = null;
 		this.inputFileSystem = null;

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -28,6 +28,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		this.callArgs = undefined;
 		this.call = undefined;
 		this.directImport = undefined;
+		this.shorthand = undefined;
 	}
 
 	get type() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
refactor
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
n/a
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

As part of https://github.com/webpack/webpack/pull/6862 I'm adding class member initializers for properties that were added to class instances 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
