### PR TITLE
Use a Map for dependencyTemplatesHashMap instead of a WeakMap

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -61,7 +61,8 @@ class NonErrorEmittedError extends WebpackError {
 	}
 }
 
-const dependencyTemplatesHashMap = new WeakMap();
+/** @type {Map<string, string>} */
+const dependencyTemplatesHashMap = new Map();
 
 class NormalModule extends Module {
 	constructor({


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refactor (potential bug fix)
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
`WeakMap` can not have string keys. In `getHashDigest` following statement indicates keys of this map is string:

```ts
dependencyTemplatesHashMap.get("hash");
```

Setting a string as key of a WeakMap throws an error:

```ts
> const wm = new WeakMap()
undefined
> wm.set('foo', global)
TypeError: Invalid value used as weak map key
    at WeakMap.set (native)
>
```
Using primitives as key for WeakMap doesn't have any benefits because GC doesn't work with primitives 
**Does this PR introduce a breaking change?**
Probably not... Hopefully not! 
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information*
