### PR TITLE
Set a more explicit default entry

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -21,7 +21,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 	constructor() {
 		super();
 
-		this.set("entry", "./src");
+		this.set("entry", "./src/index.js");
 
 		this.set(
 			"devtool",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no, already tested

**If relevant, link to documentation update:**

todo

**Summary**

When running webpack without config, some user may encounter the following error:

```
ERROR in Entry module not found: Error: Can't resolve './src' in '…'
```

This could be confusing if the directory `src` exists and contains some files (see #6858).
With this change applied, the error message is more explicit:

```
ERROR in Entry module not found: Error: Can't resolve './src/index.js' in '…'
```

**Does this PR introduce a breaking change?**

no

**Other information**

https://github.com/webpack/webpack.js.org/pull/1903
