### PR TITLE
Use a class for dependency references

### DIFF
--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -3,7 +3,9 @@
 	Author Tobias Koppers @sokra
 */
 "use strict";
+
 const compareLocations = require("./compareLocations");
+const DependencyReference = require("./dependencies/DependencyReference");
 
 class Dependency {
 	constructor() {
@@ -20,11 +22,7 @@ class Dependency {
 	// Returns the referenced module and export
 	getReference() {
 		if (!this.module) return null;
-		return {
-			module: this.module,
-			weak: this.weak,
-			importedNames: true // true: full object, false: only sideeffects/no export, array of strings: the exports with this names
-		};
+		return new DependencyReference(this.module, true, this.weak);
 	}
 
 	// Returns the exported names

--- a/lib/dependencies/DelegatedExportsDependency.js
+++ b/lib/dependencies/DelegatedExportsDependency.js
@@ -3,6 +3,8 @@
 	Author Tobias Koppers @sokra
 */
 "use strict";
+
+const DependencyReference = require("./DependencyReference");
 const NullDependency = require("./NullDependency");
 
 class DelegatedExportsDependency extends NullDependency {
@@ -17,10 +19,7 @@ class DelegatedExportsDependency extends NullDependency {
 	}
 
 	getReference() {
-		return {
-			module: this.originModule,
-			importedNames: true
-		};
+		return new DependencyReference(this.originModule, true, false);
 	}
 
 	getExports() {

--- a/lib/dependencies/DependencyReference.js
+++ b/lib/dependencies/DependencyReference.js
@@ -1,0 +1,18 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Florent Cailhol @ooflorent
+*/
+"use strict";
+
+class DependencyReference {
+	constructor(module, importedNames, weak) {
+		this.module = module;
+		// true: full object
+		// false: only sideeffects/no export
+		// array of strings: the exports with this names
+		this.importedNames = importedNames;
+		this.weak = weak;
+	}
+}
+
+module.exports = DependencyReference;

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -3,6 +3,8 @@
 	Author Tobias Koppers @sokra
 */
 "use strict";
+
+const DependencyReference = require("./DependencyReference");
 const HarmonyImportDependency = require("./HarmonyImportDependency");
 const Template = require("../Template");
 
@@ -218,32 +220,24 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 
 			case "reexport-non-harmony-default":
 			case "reexport-named-default":
-				return {
-					module: mode.module,
-					importedNames: ["default"]
-				};
+				return new DependencyReference(mode.module, ["default"], false);
 
 			case "reexport-namespace-object":
 			case "reexport-non-harmony-default-strict":
 			case "reexport-fake-namespace-object":
 			case "rexport-non-harmony-undefined":
-				return {
-					module: mode.module,
-					importedNames: true
-				};
+				return new DependencyReference(mode.module, true, false);
 
 			case "safe-reexport":
 			case "checked-reexport":
-				return {
-					module: mode.module,
-					importedNames: Array.from(mode.map.values())
-				};
+				return new DependencyReference(
+					mode.module,
+					Array.from(mode.map.values()),
+					false
+				);
 
 			case "dynamic-reexport":
-				return {
-					module: mode.module,
-					importedNames: true
-				};
+				return new DependencyReference(mode.module, true, false);
 
 			default:
 				throw new Error(`Unknown mode ${mode.type}`);

--- a/lib/dependencies/HarmonyImportDependency.js
+++ b/lib/dependencies/HarmonyImportDependency.js
@@ -3,6 +3,8 @@
 	Author Tobias Koppers @sokra
 */
 "use strict";
+
+const DependencyReference = require("./DependencyReference");
 const ModuleDependency = require("./ModuleDependency");
 const Template = require("../Template");
 
@@ -16,12 +18,7 @@ class HarmonyImportDependency extends ModuleDependency {
 
 	getReference() {
 		if (!this.module) return null;
-
-		return {
-			module: this.module,
-			importedNames: false,
-			weak: this.weak
-		};
+		return new DependencyReference(this.module, false, this.weak);
 	}
 
 	getImportVar() {

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -3,6 +3,8 @@
 	Author Tobias Koppers @sokra
 */
 "use strict";
+
+const DependencyReference = require("./DependencyReference");
 const HarmonyImportDependency = require("./HarmonyImportDependency");
 
 class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
@@ -33,11 +35,11 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 
 	getReference() {
 		if (!this.module) return null;
-		return {
-			module: this.module,
-			importedNames:
-				this.id && !this.namespaceObjectAsContext ? [this.id] : true
-		};
+		return new DependencyReference(
+			this.module,
+			this.id && !this.namespaceObjectAsContext ? [this.id] : true,
+			false
+		);
 	}
 
 	getWarnings() {

--- a/lib/dependencies/RequireIncludeDependency.js
+++ b/lib/dependencies/RequireIncludeDependency.js
@@ -4,6 +4,7 @@
 */
 "use strict";
 
+const DependencyReference = require("./DependencyReference");
 const ModuleDependency = require("./ModuleDependency");
 const Template = require("../Template");
 
@@ -15,10 +16,8 @@ class RequireIncludeDependency extends ModuleDependency {
 
 	getReference() {
 		if (!this.module) return null;
-		return {
-			module: this.module,
-			importedNames: [] // This doesn't use any export
-		};
+		// This doesn't use any export
+		return new DependencyReference(this.module, [], false);
 	}
 
 	get type() {

--- a/lib/dependencies/WebAssemblyImportDependency.js
+++ b/lib/dependencies/WebAssemblyImportDependency.js
@@ -3,6 +3,8 @@
 	Author Tobias Koppers @sokra
 */
 "use strict";
+
+const DependencyReference = require("./DependencyReference");
 const ModuleDependency = require("./ModuleDependency");
 
 class WebAssemblyImportDependency extends ModuleDependency {
@@ -13,10 +15,7 @@ class WebAssemblyImportDependency extends ModuleDependency {
 
 	getReference() {
 		if (!this.module) return null;
-		return {
-			module: this.module,
-			importedNames: [this.name]
-		};
+		return new DependencyReference(this.module, [this.name], false);
 	}
 
 	get type() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

n/a

**Summary**

Use a class instead of an object to ensure that references share the same hidden class. This change should avoid potential deopts.

**Does this PR introduce a breaking change?**

no