### PR TITLE
Change internal representation of harmony export modes

### DIFF
--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -6,6 +6,20 @@
 const HarmonyImportDependency = require("./HarmonyImportDependency");
 const Template = require("../Template");
 
+const EMPTY_MAP = new Map();
+
+class ExportMode {
+	constructor(type) {
+		this.type = type;
+		this.name = null;
+		this.map = EMPTY_MAP;
+		this.module = null;
+		this.userRequest = null;
+	}
+}
+
+const EMPTY_STAR_MODE = new ExportMode("empty-star");
+
 class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 	constructor(
 		request,
@@ -37,81 +51,64 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 		const importedModule = this.module;
 
 		if (!importedModule) {
-			return {
-				type: "missing",
-				userRequest: this.userRequest
-			};
+			const mode = new ExportMode("missing");
+			mode.userRequest = this.userRequest;
+			return mode;
 		}
 
 		if (
 			!ignoreUnused &&
 			(name ? !used : this.originModule.usedExports === false)
 		) {
-			return {
-				type: "unused",
-				name: name || "*"
-			};
+			const mode = new ExportMode("unused");
+			mode.name = name || "*";
+			return mode;
 		}
 
 		const strictHarmonyModule = this.originModule.buildMeta.strictHarmonyModule;
 		if (name && id === "default" && importedModule.buildMeta) {
 			if (!importedModule.buildMeta.exportsType) {
-				if (strictHarmonyModule) {
-					return {
-						type: "reexport-non-harmony-default-strict",
-						module: importedModule,
-						name
-					};
-				} else {
-					return {
-						type: "reexport-non-harmony-default",
-						module: importedModule,
-						name
-					};
-				}
+				const mode = new ExportMode(
+					strictHarmonyModule
+						? "reexport-non-harmony-default-strict"
+						: "reexport-non-harmony-default"
+				);
+				mode.name = name;
+				mode.module = importedModule;
+				return mode;
 			} else if (importedModule.buildMeta.exportsType === "named") {
-				return {
-					type: "reexport-named-default",
-					module: importedModule,
-					name
-				};
+				const mode = new ExportMode("reexport-named-default");
+				mode.name = name;
+				mode.module = importedModule;
+				return mode;
 			}
 		}
 
 		const isNotAHarmonyModule =
 			importedModule.buildMeta && !importedModule.buildMeta.exportsType;
 		if (name) {
-			// export { name as name }
+			let mode;
 			if (id) {
+				// export { name as name }
 				if (isNotAHarmonyModule && strictHarmonyModule) {
-					return {
-						type: "rexport-non-harmony-undefined",
-						module: importedModule,
-						name
-					};
+					mode = new ExportMode("rexport-non-harmony-undefined");
+					mode.name = name;
 				} else {
-					return {
-						type: "safe-reexport",
-						module: importedModule,
-						map: new Map([[name, id]])
-					};
+					mode = new ExportMode("safe-reexport");
+					mode.map = new Map([[name, id]]);
+				}
+			} else {
+				// export { * as name }
+				if (isNotAHarmonyModule && strictHarmonyModule) {
+					mode = new ExportMode("reexport-fake-namespace-object");
+					mode.name = name;
+				} else {
+					mode = new ExportMode("reexport-namespace-object");
+					mode.name = name;
 				}
 			}
-
-			// export { * as name }
-			if (isNotAHarmonyModule && strictHarmonyModule) {
-				return {
-					type: "reexport-fake-namespace-object",
-					module: importedModule,
-					name
-				};
-			} else {
-				return {
-					type: "reexport-namespace-object",
-					module: importedModule,
-					name
-				};
-			}
+			mode.module = importedModule;
+			return mode;
 		}
 
 		const hasUsedExports = Array.isArray(this.originModule.usedExports);
@@ -138,16 +135,13 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 				);
 
 				if (map.size === 0) {
-					return {
-						type: "empty-star"
-					};
+					return EMPTY_STAR_MODE;
 				}
 
-				return {
-					type: "safe-reexport",
-					module: importedModule,
-					map
-				};
+				const mode = new ExportMode("safe-reexport");
+				mode.module = importedModule;
+				mode.map = map;
+				return mode;
 			}
 
 			const map = new Map(
@@ -163,16 +157,13 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 			);
 
 			if (map.size === 0) {
-				return {
-					type: "empty-star"
-				};
+				return EMPTY_STAR_MODE;
 			}
 
-			return {
-				type: "checked-reexport",
-				module: importedModule,
-				map
-			};
+			const mode = new ExportMode("checked-reexport");
+			mode.module = importedModule;
+			mode.map = map;
+			return mode;
 		}
 
 		if (hasProvidedExports) {
@@ -189,22 +180,18 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 			);
 
 			if (map.size === 0) {
-				return {
-					type: "empty-star"
-				};
+				return EMPTY_STAR_MODE;
 			}
 
-			return {
-				type: "safe-reexport",
-				module: importedModule,
-				map
-			};
+			const mode = new ExportMode("safe-reexport");
+			mode.module = importedModule;
+			mode.map = map;
+			return mode;
 		}
 
-		return {
-			type: "dynamic-reexport",
-			module: importedModule
-		};
+		const mode = new ExportMode("dynamic-reexport");
+		mode.module = importedModule;
+		return mode;
 	}
 
 	getReference() {
@@ -246,6 +233,7 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 				};
 
 			default:
+				console.log(mode);
 				throw new Error(`Unknown mode ${mode.type}`);
 		}
 	}

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -195,7 +195,7 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 	}
 
 	getReference() {
-		const mode = this.getMode();
+		const mode = this.getMode(false);
 
 		switch (mode.type) {
 			case "missing":
@@ -427,7 +427,7 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 	}
 
 	getContent(dep) {
-		const mode = dep.getMode();
+		const mode = dep.getMode(false);
 		const module = dep.originModule;
 		const importedModule = dep.module;
 		const importVar = dep.getImportVar();

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -233,7 +233,6 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 				};
 
 			default:
-				console.log(mode);
 				throw new Error(`Unknown mode ${mode.type}`);
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

N/A 

**Summary**

This change make `getReference` monomorphic since `getMode` will always return an `ExportMode`. By doing this, all modes share the same shape.

**Does this PR introduce a breaking change?**

no