### PR TITLE
Use compilation instead of this in ChunkModuleIdRangePlugin

### DIFF
--- a/lib/optimize/ChunkModuleIdRangePlugin.js
+++ b/lib/optimize/ChunkModuleIdRangePlugin.js
@@ -11,7 +11,9 @@ class ChunkModuleIdRangePlugin {
 		const options = this.options;
 		compiler.hooks.compilation.tap("ChunkModuleIdRangePlugin", compilation => {
 			compilation.hooks.moduleIds.tap("ChunkModuleIdRangePlugin", modules => {
-				const chunk = this.chunks.find(chunk => chunk.name === options.name);
+				const chunk = compilation.chunks.find(
+					chunk => chunk.name === options.name
+				);
 				if (!chunk)
 					throw new Error(
 						"ChunkModuleIdRangePlugin: Chunk with name '" +

--- a/lib/optimize/ChunkModuleIdRangePlugin.js
+++ b/lib/optimize/ChunkModuleIdRangePlugin.js
@@ -3,10 +3,20 @@
 	Author Tobias Koppers @sokra
 */
 "use strict";
+
+const sortByIndex = (a, b) => {
+	return a.index - b.index;
+};
+
+const sortByIndex2 = (a, b) => {
+	return a.index2 - b.index2;
+};
+
 class ChunkModuleIdRangePlugin {
 	constructor(options) {
 		this.options = options;
 	}
+
 	apply(compiler) {
 		const options = this.options;
 		compiler.hooks.compilation.tap("ChunkModuleIdRangePlugin", compilation => {
@@ -14,26 +24,23 @@ class ChunkModuleIdRangePlugin {
 				const chunk = compilation.chunks.find(
 					chunk => chunk.name === options.name
 				);
-				if (!chunk)
+				if (!chunk) {
 					throw new Error(
-						"ChunkModuleIdRangePlugin: Chunk with name '" +
-							options.name +
-							"' was not found"
+						`ChunkModuleIdRangePlugin: Chunk with name '${
+							options.name
+						}"' was not found`
 					);
-				let currentId = options.start;
+				}
+
 				let chunkModules;
 				if (options.order) {
-					chunkModules = chunk.modules.slice();
+					chunkModules = Array.from(chunk.modulesIterable);
 					switch (options.order) {
 						case "index":
-							chunkModules.sort((a, b) => {
-								return a.index - b.index;
-							});
+							chunkModules.sort(sortByIndex);
 							break;
 						case "index2":
-							chunkModules.sort((a, b) => {
-								return a.index2 - b.index2;
-							});
+							chunkModules.sort(sortByIndex2);
 							break;
 						default:
 							throw new Error(
@@ -42,10 +49,11 @@ class ChunkModuleIdRangePlugin {
 					}
 				} else {
 					chunkModules = modules.filter(m => {
-						return m.chunks.includes(chunk);
+						return m.chunksIterable.has(chunk);
 					});
 				}
 
+				let currentId = options.start || 0;
 				for (let i = 0; i < chunkModules.length; i++) {
 					const m = chunkModules[i];
 					if (m.id === null) {

--- a/test/statsCases/chunk-module-id-range/a.js
+++ b/test/statsCases/chunk-module-id-range/a.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/test/statsCases/chunk-module-id-range/b.js
+++ b/test/statsCases/chunk-module-id-range/b.js
@@ -1,0 +1,1 @@
+export default "b";

--- a/test/statsCases/chunk-module-id-range/c.js
+++ b/test/statsCases/chunk-module-id-range/c.js
@@ -1,0 +1,1 @@
+export default "c";

--- a/test/statsCases/chunk-module-id-range/d.js
+++ b/test/statsCases/chunk-module-id-range/d.js
@@ -1,0 +1,1 @@
+export default "d";

--- a/test/statsCases/chunk-module-id-range/e.js
+++ b/test/statsCases/chunk-module-id-range/e.js
@@ -1,0 +1,1 @@
+export default "e";

--- a/test/statsCases/chunk-module-id-range/expected.txt
+++ b/test/statsCases/chunk-module-id-range/expected.txt
@@ -1,0 +1,22 @@
+Hash: 27b68d27e07b42624dae
+Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
+   Asset      Size  Chunks             Chunk Names
+main2.js  3.89 KiB       0  [emitted]  main2
+main1.js  3.89 KiB       1  [emitted]  main1
+Entrypoint main1 = main1.js
+Entrypoint main2 = main2.js
+chunk    {0} main2.js (main2) 136 bytes [entry] [rendered]
+    > ./main2 main2
+   [0] ./e.js 20 bytes {0} [built]
+   [1] ./f.js 20 bytes {0} [built]
+   [2] ./main2.js 56 bytes {0} [built]
+ [100] ./d.js 20 bytes {0} {1} [built]
+ [101] ./a.js 20 bytes {0} {1} [built]
+chunk    {1} main1.js (main1) 136 bytes [entry] [rendered]
+    > ./main1 main1
+   [3] ./b.js 20 bytes {1} [built]
+   [4] ./main1.js 56 bytes {1} [built]
+ [100] ./d.js 20 bytes {0} {1} [built]
+ [101] ./a.js 20 bytes {0} {1} [built]
+ [102] ./c.js 20 bytes {1} [built]

--- a/test/statsCases/chunk-module-id-range/f.js
+++ b/test/statsCases/chunk-module-id-range/f.js
@@ -1,0 +1,1 @@
+export default "f";

--- a/test/statsCases/chunk-module-id-range/main1.js
+++ b/test/statsCases/chunk-module-id-range/main1.js
@@ -1,0 +1,4 @@
+import "./a";
+import "./b";
+import "./c";
+import "./d";

--- a/test/statsCases/chunk-module-id-range/main2.js
+++ b/test/statsCases/chunk-module-id-range/main2.js
@@ -1,0 +1,4 @@
+import "./a";
+import "./d";
+import "./e";
+import "./f";

--- a/test/statsCases/chunk-module-id-range/webpack.config.js
+++ b/test/statsCases/chunk-module-id-range/webpack.config.js
@@ -1,0 +1,28 @@
+const webpack = require("../../../");
+
+module.exports = {
+	mode: "none",
+	entry: {
+		main1: "./main1",
+		main2: "./main2"
+	},
+	plugins: [
+		new webpack.optimize.ChunkModuleIdRangePlugin({
+			name: "main1",
+			start: 100,
+			end: 102
+		}),
+		new webpack.optimize.ChunkModuleIdRangePlugin({
+			name: "main2",
+			order: "index2"
+		})
+	],
+	stats: {
+		chunks: true,
+		chunkModules: true,
+		chunkOrigins: true,
+		entrypoints: true,
+		modules: false,
+		publicPath: true
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

yes

**If relevant, link to documentation update:**

N/A

**Summary**

Because of the arrow function `this` was no longer referencing the `compilation` which was a bug. Since there is no test or documentation about this plugin, I don't know to create a good test case for this. Is this plugin still relevant?

**Does this PR introduce a breaking change?**

no