### PR TITLE
Use a single object shape for dependency exports

### DIFF
--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -43,7 +43,8 @@ const identToLoaderRequest = resultString => {
 		};
 	} else {
 		return {
-			loader: resultString
+			loader: resultString,
+			options
 		};
 	}
 };

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -31,20 +31,17 @@ const loaderToIdent = data => {
 
 const identToLoaderRequest = resultString => {
 	const idx = resultString.indexOf("?");
-	let options;
-
 	if (idx >= 0) {
-		options = resultString.substr(idx + 1);
-		resultString = resultString.substr(0, idx);
-
+		const loader = resultString.substr(0, idx);
+		const options = resultString.substr(idx + 1);
 		return {
-			loader: resultString,
+			loader,
 			options
 		};
 	} else {
 		return {
 			loader: resultString,
-			options
+			options: undefined
 		};
 	}
 };

--- a/lib/dependencies/AMDDefineDependencyParserPlugin.js
+++ b/lib/dependencies/AMDDefineDependencyParserPlugin.js
@@ -223,9 +223,8 @@ class AMDDefineDependencyParserPlugin {
 			}
 		}
 		let fnRenames = parser.scope.renames.createChild();
-		let identifiers;
 		if (array) {
-			identifiers = {};
+			const identifiers = {};
 			const param = parser.evaluateExpression(array);
 			const result = this.processArray(
 				parser,
@@ -244,7 +243,7 @@ class AMDDefineDependencyParserPlugin {
 					return true;
 				});
 		} else {
-			identifiers = ["require", "exports", "module"];
+			const identifiers = ["require", "exports", "module"];
 			if (fnParams)
 				fnParams = fnParams.slice(fnParamsOffset).filter((param, idx) => {
 					if (identifiers[idx]) {

--- a/lib/dependencies/DelegatedExportsDependency.js
+++ b/lib/dependencies/DelegatedExportsDependency.js
@@ -24,7 +24,8 @@ class DelegatedExportsDependency extends NullDependency {
 
 	getExports() {
 		return {
-			exports: this.exports
+			exports: this.exports,
+			dependencies: undefined
 		};
 	}
 }

--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -19,7 +19,8 @@ class HarmonyExportExpressionDependency extends NullDependency {
 
 	getExports() {
 		return {
-			exports: ["default"]
+			exports: ["default"],
+			dependencies: undefined
 		};
 	}
 }

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -252,7 +252,8 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 	getExports() {
 		if (this.name) {
 			return {
-				exports: [this.name]
+				exports: [this.name],
+				dependencies: undefined
 			};
 		}
 
@@ -261,7 +262,8 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 		if (!importedModule) {
 			// no imported module available
 			return {
-				exports: null
+				exports: null,
+				dependencies: undefined
 			};
 		}
 
@@ -276,7 +278,8 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 
 		if (importedModule.buildMeta.providedExports) {
 			return {
-				exports: true
+				exports: true,
+				dependencies: undefined
 			};
 		}
 

--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -19,7 +19,8 @@ class HarmonyExportSpecifierDependency extends NullDependency {
 
 	getExports() {
 		return {
-			exports: [this.name]
+			exports: [this.name],
+			dependencies: undefined
 		};
 	}
 }

--- a/lib/dependencies/JsonExportsDependency.js
+++ b/lib/dependencies/JsonExportsDependency.js
@@ -17,7 +17,8 @@ class JsonExportsDependency extends NullDependency {
 
 	getExports() {
 		return {
-			exports: this.exports
+			exports: this.exports,
+			dependencies: undefined
 		};
 	}
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

n/a

**Summary**

`getExports` was returning 2 types of shape which could force its caller to deopt.
This also was the case for `identToLoaderRequest`

**Does this PR introduce a breaking change?**

no
