### PR TITLE
Refactor WebpackError to initialize details as undefined

### DIFF
--- a/lib/WebpackError.js
+++ b/lib/WebpackError.js
@@ -8,7 +8,6 @@ module.exports = class WebpackError extends Error {
 	constructor(message) {
 		super(message);
 
-		this.message = message;
 		this.details = undefined;
 
 		Error.captureStackTrace(this, this.constructor);

--- a/lib/WebpackError.js
+++ b/lib/WebpackError.js
@@ -5,6 +5,16 @@
 "use strict";
 
 module.exports = class WebpackError extends Error {
+	constructor(message) {
+		super(message);
+		this.name = 'WebpackError';
+		this.message = message;
+		Error.captureStackTrace(this, this.constructor);
+
+		/** @type {string} */
+		this.details = undefined;
+	}
+
 	inspect() {
 		return this.stack + (this.details ? `\n${this.details}` : "");
 	}

--- a/lib/WebpackError.js
+++ b/lib/WebpackError.js
@@ -9,10 +9,10 @@ module.exports = class WebpackError extends Error {
 		super(message);
 
 		this.message = message;
+		this.details = undefined;
+
 		Error.captureStackTrace(this, this.constructor);
 	}
-
-	get details() {}
 
 	inspect() {
 		return this.stack + (this.details ? `\n${this.details}` : "");

--- a/lib/WebpackError.js
+++ b/lib/WebpackError.js
@@ -7,13 +7,12 @@
 module.exports = class WebpackError extends Error {
 	constructor(message) {
 		super(message);
-		this.name = 'WebpackError';
+
 		this.message = message;
 		Error.captureStackTrace(this, this.constructor);
-
-		/** @type {string} */
-		this.details = undefined;
 	}
+
+	get details() {}
 
 	inspect() {
 		return this.stack + (this.details ? `\n${this.details}` : "");

--- a/test/RemovedPlugins.unittest.js
+++ b/test/RemovedPlugins.unittest.js
@@ -4,14 +4,15 @@ require("should");
 
 describe("removed plugin errors", () => {
 	it("should error when accessing removed plugins", () => {
-		(() => webpack.optimize.UglifyJsPlugin).should.throw(
-			RemovedPluginError,
-			/webpack\.optimize\.UglifyJsPlugin has been removed, please use config\.optimization\.minimize instead\./
-		);
+		(() => webpack.optimize.UglifyJsPlugin).should.throw(RemovedPluginError, {
+			message: /webpack\.optimize\.UglifyJsPlugin has been removed, please use config\.optimization\.minimize instead\./
+		});
 
 		(() => webpack.optimize.CommonsChunkPlugin).should.throw(
 			RemovedPluginError,
-			/webpack\.optimize\.CommonsChunkPlugin has been removed, please use config\.optimization\.splitChunks instead\./
+			{
+				message: /webpack\.optimize\.CommonsChunkPlugin has been removed, please use config\.optimization\.splitChunks instead\./
+			}
 		);
 	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refactor
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
As part of https://github.com/webpack/webpack/pull/6862 I'm refactoring the base error class to initialize the `details` member so TypeScript is happy about this class 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
