### PR TITLE
Pass file name as part of options hash to vm.runInThisContext

### DIFF
--- a/lib/node/NodeMainTemplateAsync.runtime.js
+++ b/lib/node/NodeMainTemplateAsync.runtime.js
@@ -15,7 +15,7 @@ module.exports = function() {
 			var chunk = {};
 			require("vm").runInThisContext(
 				"(function(exports) {" + content + "\n})",
-				filename
+				{ filename }
 			)(chunk);
 			hotAddUpdateChunk(chunk.id, chunk.modules);
 		});

--- a/lib/node/NodeMainTemplateAsync.runtime.js
+++ b/lib/node/NodeMainTemplateAsync.runtime.js
@@ -15,7 +15,7 @@ module.exports = function() {
 			var chunk = {};
 			require("vm").runInThisContext(
 				"(function(exports) {" + content + "\n})",
-				{ filename }
+				{ filename: filename }
 			)(chunk);
 			hotAddUpdateChunk(chunk.id, chunk.modules);
 		});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refactor
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
Existing code is technically correct. The API has changed in Node 8 and higher to accept an option hash but kept backward compatibility. Using the new API will make TypeScript happy at #6862 and make it easier to add more options in the future. 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
At the same time I'm trying to update DT to understand old API usages as well:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24798