### PR TITLE
Add class member initializations for multiple classes

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -49,6 +49,7 @@ class Chunk {
 		this.ids = null;
 		this.debugId = debugId++;
 		this.name = name;
+		this.removedModules = undefined;
 		this.entryModule = undefined;
 		this._modules = new SortableSet(undefined, sortByIdentifier);
 		this._groups = new SortableSet(undefined, sortById);

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -208,6 +208,7 @@ class Compilation extends Tapable {
 					break;
 			}
 		});
+		this.name = undefined;
 		this.compiler = compiler;
 		this.resolverFactory = compiler.resolverFactory;
 		this.inputFileSystem = compiler.inputFileSystem;

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -74,6 +74,8 @@ class Compiler extends Tapable {
 			}
 		});
 
+		this.name = undefined;
+		this.parentCompilation = undefined;
 		this.outputPath = "";
 		this.outputFileSystem = null;
 		this.inputFileSystem = null;

--- a/lib/dependencies/AMDRequireDependenciesBlock.js
+++ b/lib/dependencies/AMDRequireDependenciesBlock.js
@@ -23,6 +23,8 @@ module.exports = class AMDRequireDependenciesBlock extends AsyncDependenciesBloc
 		this.functionRange = functionRange;
 		this.errorCallbackRange = errorCallbackRange;
 		this.bindThis = true;
+		this.functionBindThis = undefined;
+		this.errorCallbackBindThis = undefined;
 		if (arrayRange && functionRange && errorCallbackRange) {
 			this.range = [arrayRange[0], errorCallbackRange[1]];
 		} else if (arrayRange && functionRange) {

--- a/lib/dependencies/CommonJsRequireContextDependency.js
+++ b/lib/dependencies/CommonJsRequireContextDependency.js
@@ -11,6 +11,7 @@ class CommonJsRequireContextDependency extends ContextDependency {
 		super(options);
 		this.range = range;
 		this.valueRange = valueRange;
+		this.critical = undefined;
 	}
 
 	get type() {

--- a/lib/dependencies/ContextDependency.js
+++ b/lib/dependencies/ContextDependency.js
@@ -15,6 +15,7 @@ class ContextDependency extends Dependency {
 		this.options = options;
 		this.userRequest = this.options.request;
 		this.hadGlobalOrStickyRegExp = false;
+		this.critical = undefined;
 		if (this.options.regExp.global || this.options.regExp.sticky) {
 			this.options.regExp = null;
 			this.hadGlobalOrStickyRegExp = true;

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -28,6 +28,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		this.callArgs = undefined;
 		this.call = undefined;
 		this.directImport = undefined;
+		this.shorthand = undefined;
 	}
 
 	get type() {

--- a/lib/optimize/ChunkModuleIdRangePlugin.js
+++ b/lib/optimize/ChunkModuleIdRangePlugin.js
@@ -6,6 +6,7 @@
 class ChunkModuleIdRangePlugin {
 	constructor(options) {
 		this.options = options;
+		this.chunks = undefined;
 	}
 	apply(compiler) {
 		const options = this.options;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refactor
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
As part of #6862 I'm adding class members that are assigned during the class lifecycle to make TypeScript happy. This has extra benefit of letting V8 know about those members when initializing class instances 

This PR adds initializers to a bunch of classes. I'm happy to break it down to more PRs but these changes are mostly harmless. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Most likely not. 
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
