### PR TITLE
Fix JSDoc for makeNewProfiledTapFn to conform to TypeScript types

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -321,12 +321,23 @@ const makeInterceptorFor = (instance, tracer) => hookName => ({
 });
 
 /**
+ * @typedef NewProfiledTapOptions
+ * @property {string} name
+ * @property {string} type
+ * @property {Function} fn
+ * @description Options for the profiled fn.
+ */
+
+/**
  * @param {string} hookName Name of the hook to profile.
  * @param {{counter: number, trace: *, profiler: *}} tracer Instance of tracer.
- * @param {{name: string, type: string, fn: Function}} opts Options for the profiled fn.
  * @returns {*} Chainable hooked function.
  */
-const makeNewProfiledTapFn = (hookName, tracer, { name, type, fn }) => {
+const makeNewProfiledTapFn = (
+	hookName,
+	tracer,
+	/** @type {NewProfiledTapOptions} */ { name, type, fn }
+) => {
 	const defaultCategory = ["blink.user_timing"];
 
 	switch (type) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refactor 
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
This is part of #6862 
The way JSDoc works with TypeScript is a bit different and we want to make sure that TypeScript can understand our JSDoc. 
I'm asking the TypeScript team to make it easier to work with destructuring parameters. See https://github.com/Microsoft/TypeScript/issues/11597. Until that issue resolves, this is an intermediate solution. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No, just comment changes 
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
