### PR TITLE
Make HarmonyAcceptImportDependencyTemplate extend HarmonyImportDependency.Template

### DIFF
--- a/lib/dependencies/HarmonyAcceptImportDependency.js
+++ b/lib/dependencies/HarmonyAcceptImportDependency.js
@@ -16,7 +16,7 @@ class HarmonyAcceptImportDependency extends HarmonyImportDependency {
 	}
 }
 
-HarmonyAcceptImportDependency.Template = class HarmonyAcceptImportDependencyTemplate {
+HarmonyAcceptImportDependency.Template = class HarmonyAcceptImportDependencyTemplate extends HarmonyImportDependency.Template {
 	apply(dep, source, runtime) {}
 };
 


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refactor 
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
This is something that TypeScript is complaining about in #6862 

When a static member a subclass does not conform to superclass static member TypeScript throws a type error. 

This is a code change that can potentially break things but on the other hand I thought it makes sense to have this class extend superclass static member class `Template`.

Please let me know if I'm wrong about this. 
 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Potentially 
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
This might be a TypeScript bug. FYI @DanielRosenwasser @mhegazy