### PR TITLE
Change stats wording when all exports are used

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -922,19 +922,30 @@ class Stats {
 			if (module.usedExports !== undefined) {
 				if (module.usedExports !== true) {
 					colors.normal(prefix);
-					if (module.usedExports === null)
+					if (module.usedExports === null) {
 						colors.cyan("[used exports unknown]");
-					else if (module.usedExports === false)
+					} else if (module.usedExports === false) {
 						colors.cyan("[no exports used]");
-					else if (
+					} else if (
 						Array.isArray(module.usedExports) &&
 						module.usedExports.length === 0
-					)
+					) {
 						colors.cyan("[no exports used]");
-					else if (Array.isArray(module.usedExports))
-						colors.cyan(
-							`[only some exports used: ${module.usedExports.join(", ")}]`
-						);
+					} else if (Array.isArray(module.usedExports)) {
+						const providedExportsCount = Array.isArray(module.providedExports)
+							? module.providedExports.length
+							: null;
+						if (
+							providedExportsCount !== null &&
+							providedExportsCount === module.usedExports.length
+						) {
+							colors.cyan("[all exports used]");
+						} else {
+							colors.cyan(
+								`[only some exports used: ${module.usedExports.join(", ")}]`
+							);
+						}
+					}
 					newline();
 				}
 			}

--- a/test/statsCases/tree-shaking/expected.txt
+++ b/test/statsCases/tree-shaking/expected.txt
@@ -6,7 +6,7 @@ bundle.js  7.27 KiB       0  [emitted]  main
 Entrypoint main = bundle.js
  [0] ./a.js 13 bytes {0} [built]
      [exports: a]
-     [only some exports used: a]
+     [all exports used]
  [1] ./b.js 13 bytes {0} [built]
      [exports: b]
      [no exports used]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

yes

**If relevant, link to documentation update:**

n/a

**Summary**

Change stats wording when all exports are used:

```diff
Entrypoint main = bundle.js
 [0] ./a.js 13 bytes {0} [built]
     [exports: a]
-    [only some exports used: a]
+    [all exports used]
```

**Does this PR introduce a breaking change?**

no

**Other information**

Fixes #6995 