### PR TITLE
Force LocalModuleDependency arity to 3

### DIFF
--- a/lib/dependencies/AMDDefineDependencyParserPlugin.js
+++ b/lib/dependencies/AMDDefineDependencyParserPlugin.js
@@ -81,7 +81,7 @@ class AMDDefineDependencyParserPlugin {
 					))
 				) {
 					// eslint-disable-line no-cond-assign
-					dep = new LocalModuleDependency(localModule);
+					dep = new LocalModuleDependency(localModule, undefined, false);
 					dep.loc = expr.loc;
 					parser.state.current.addDependency(dep);
 				} else {
@@ -122,7 +122,7 @@ class AMDDefineDependencyParserPlugin {
 				))
 			) {
 				// eslint-disable-line no-cond-assign
-				dep = new LocalModuleDependency(localModule, param.range);
+				dep = new LocalModuleDependency(localModule, param.range, false);
 			} else {
 				dep = this.newRequireItemDependency(param.string, param.range);
 			}

--- a/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
+++ b/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js
@@ -78,7 +78,7 @@ class AMDRequireDependenciesBlockParserPlugin {
 					))
 				) {
 					// eslint-disable-line no-cond-assign
-					dep = new LocalModuleDependency(localModule);
+					dep = new LocalModuleDependency(localModule, undefined, false);
 					dep.loc = expr.loc;
 					parser.state.current.addDependency(dep);
 				} else {
@@ -126,7 +126,7 @@ class AMDRequireDependenciesBlockParserPlugin {
 				))
 			) {
 				// eslint-disable-line no-cond-assign
-				dep = new LocalModuleDependency(localModule, param.range);
+				dep = new LocalModuleDependency(localModule, param.range, false);
 			} else {
 				dep = this.newRequireItemDependency(param.string, param.range);
 			}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

N/A

**Summary**

`LocalModuleDependency` constructor arity is 3.
With this PR, the 3 arguments are always passed.

**Does this PR introduce a breaking change?**

no