### PR TITLE
Avoid deopt when cache is set in EvalSourceMapDevToolModuleTemplatePlugin

### DIFF
--- a/lib/EvalDevToolModuleTemplatePlugin.js
+++ b/lib/EvalDevToolModuleTemplatePlugin.js
@@ -6,6 +6,7 @@
 
 const { RawSource } = require("webpack-sources");
 const ModuleFilenameHelpers = require("./ModuleFilenameHelpers");
+
 const cache = new WeakMap();
 
 class EvalDevToolModuleTemplatePlugin {

--- a/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
+++ b/lib/EvalSourceMapDevToolModuleTemplatePlugin.js
@@ -7,6 +7,8 @@
 const { RawSource } = require("webpack-sources");
 const ModuleFilenameHelpers = require("./ModuleFilenameHelpers");
 
+const cache = new WeakMap();
+
 class EvalSourceMapDevToolModuleTemplatePlugin {
 	constructor(compilation, options) {
 		this.compilation = compilation;
@@ -29,8 +31,11 @@ class EvalSourceMapDevToolModuleTemplatePlugin {
 		moduleTemplate.hooks.module.tap(
 			"EvalSourceMapDevToolModuleTemplatePlugin",
 			(source, module) => {
-				if (source.__EvalSourceMapDevToolData)
-					return source.__EvalSourceMapDevToolData;
+				const cachedSource = cache.get(source);
+				if (cachedSource !== undefined) {
+					return cachedSource;
+				}
+
 				if (!matchModule(module.resource)) {
 					return source;
 				}
@@ -87,10 +92,14 @@ class EvalSourceMapDevToolModuleTemplatePlugin {
 							"utf8"
 						).toString("base64")}`
 					) + `\n//# sourceURL=webpack-internal:///${module.id}\n`; // workaround for chrome bug
-				source.__EvalSourceMapDevToolData = new RawSource(
+
+				const evalSource = new RawSource(
 					`eval(${JSON.stringify(content + footer)});`
 				);
-				return source.__EvalSourceMapDevToolData;
+
+				cache.set(source, evalSource);
+
+				return evalSource;
 			}
 		);
 		moduleTemplate.hooks.hash.tap(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**If relevant, link to documentation update:**

N/A

**Summary**

Avoid a potential deopt on `EvalSourceMapDevToolModuleTemplatePlugin` by replacing the cache key by a `WeakMap`.

**Does this PR introduce a breaking change?**

no