### PR TITLE
Fix output.globalObject value in node-webkit

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -123,12 +123,12 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 			switch (options.target) {
 				case "web":
 				case "electron-renderer":
+				case "node-webkit":
 					return "window";
 				case "webworker":
 					return "self";
 				case "node":
 				case "async-node":
-				case "node-webkit":
 				case "electron-main":
 					return "global";
 				default:


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fixes the default value of the `output.globalObject` config and restores old behavior for `node-webkit` targets.

**Summary**

The default value of `output.globalObject` is currently set to `global` instead of `window`. This can break NW.js applications when the application window reloads.
Fixes #7043

**Did you add tests for your changes?**

I couldn't find any existing tests for this specific config and didn't have time learning how to add new ones.

**If relevant, link to documentation update:**

This config option seems to be undocumented and was just briefly mentioned in the 4.0.0 changelog.

**Does this PR introduce a breaking change?**

No.
