### PR TITLE
chore(pkg): update typescript nightly to Version 2.9.0-dev.20180421

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "simple-git": "^1.65.0",
     "sinon": "^2.3.2",
     "style-loader": "^0.19.1",
-    "typescript": "^2.9.0-dev.20180412",
+    "typescript": "^2.9.0-dev.20180420",
     "url-loader": "^0.6.2",
     "val-loader": "^1.0.2",
     "vm-browserify": "~0.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "simple-git": "^1.65.0",
     "sinon": "^2.3.2",
     "style-loader": "^0.19.1",
-    "typescript": "^2.9.0-dev.20180420",
+    "typescript": "^2.9.0-dev.20180421",
     "url-loader": "^0.6.2",
     "val-loader": "^1.0.2",
     "vm-browserify": "~0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4491,9 +4491,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.9.0-dev.20180412:
-  version "2.9.0-dev.20180412"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.0-dev.20180412.tgz#5380b2afb44b720b0d8164f844b90ebd81948a7e"
+typescript@^2.9.0-dev.20180420:
+  version "2.9.0-dev.20180420"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.0-dev.20180420.tgz#c828fdf776f95e858fa8f9276eed27ca4c320099"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4491,9 +4491,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.9.0-dev.20180420:
-  version "2.9.0-dev.20180420"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.0-dev.20180420.tgz#c828fdf776f95e858fa8f9276eed27ca4c320099"
+typescript@^2.9.0-dev.20180421:
+  version "2.9.0-dev.20180421"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.0-dev.20180421.tgz#b937b164ce73f833f2ed5c36571e238898b264ce"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Update dependencies
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
N/A
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
This PR updates the TypeScript nightly dependency for blocking `import("./module")` support for commonJS module and class types. 

The updated version would be `2.9.0-dev.20180421`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No, this is only for the build step, however this was failing locally. I will use this PR as a way to report this failure upstream (so lets wait on actually merging this). 
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
https://github.com/Microsoft/TypeScript/issues/23588 Upstream issue I've submitted for when this PR fails. 