### PR TITLE
fix bug where sometimes the runtime would not be present on output

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -50,6 +50,7 @@ class Chunk {
 		this.ids = null;
 		this.debugId = debugId++;
 		this.name = name;
+		this.isRuntimeOnly = false;
 		this.entryModule = undefined;
 		this._modules = new SortableSet(undefined, sortByIdentifier);
 		this._groups = new SortableSet(undefined, sortById);
@@ -265,6 +266,9 @@ class Chunk {
 			}
 			return true;
 		};
+
+		if (otherChunk.isRuntimeOnly) return false;
+
 		if (this.hasRuntime() !== otherChunk.hasRuntime()) {
 			if (this.hasRuntime()) {
 				return isAvailable(this, otherChunk);

--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -50,7 +50,7 @@ class Chunk {
 		this.ids = null;
 		this.debugId = debugId++;
 		this.name = name;
-		this.isRuntimeOnly = false;
+		this.preventIntegration = false;
 		this.entryModule = undefined;
 		this._modules = new SortableSet(undefined, sortByIdentifier);
 		this._groups = new SortableSet(undefined, sortById);
@@ -267,7 +267,7 @@ class Chunk {
 			return true;
 		};
 
-		if (otherChunk.isRuntimeOnly) return false;
+		if (this.preventIntegration || otherChunk.preventIntegration) return false;
 
 		if (this.hasRuntime() !== otherChunk.hasRuntime()) {
 			if (this.hasRuntime()) {

--- a/lib/optimize/RuntimeChunkPlugin.js
+++ b/lib/optimize/RuntimeChunkPlugin.js
@@ -25,6 +25,7 @@ module.exports = class RuntimeChunkPlugin {
 							name = name(entrypoint);
 						}
 						const newChunk = compilation.addChunk(name);
+						newChunk.isRuntimeOnly = true;
 						entrypoint.unshiftChunk(newChunk);
 						newChunk.addGroup(entrypoint);
 						entrypoint.setRuntimeChunk(newChunk);

--- a/lib/optimize/RuntimeChunkPlugin.js
+++ b/lib/optimize/RuntimeChunkPlugin.js
@@ -25,7 +25,7 @@ module.exports = class RuntimeChunkPlugin {
 							name = name(entrypoint);
 						}
 						const newChunk = compilation.addChunk(name);
-						newChunk.isRuntimeOnly = true;
+						newChunk.preventIntegration = true;
 						entrypoint.unshiftChunk(newChunk);
 						newChunk.addGroup(entrypoint);
 						entrypoint.setRuntimeChunk(newChunk);

--- a/test/statsCases/runtime-chunk-integration/b.js
+++ b/test/statsCases/runtime-chunk-integration/b.js
@@ -1,0 +1,1 @@
+export default "b";

--- a/test/statsCases/runtime-chunk-integration/c.js
+++ b/test/statsCases/runtime-chunk-integration/c.js
@@ -1,0 +1,1 @@
+export default "c";

--- a/test/statsCases/runtime-chunk-integration/d.js
+++ b/test/statsCases/runtime-chunk-integration/d.js
@@ -1,0 +1,1 @@
+export default "d";

--- a/test/statsCases/runtime-chunk-integration/expected.txt
+++ b/test/statsCases/runtime-chunk-integration/expected.txt
@@ -1,0 +1,7 @@
+      Asset       Size  Chunks             Chunk Names
+       0.js  287 bytes       0  [emitted]  
+   main1.js  386 bytes       1  [emitted]  main1
+manifest.js   7.73 KiB       2  [emitted]  manifest
+Entrypoint main1 = manifest.js main1.js
+[0] ./b.js 20 bytes {0} [built]
+[1] ./main1.js 36 bytes {1} [built]

--- a/test/statsCases/runtime-chunk-integration/expected.txt
+++ b/test/statsCases/runtime-chunk-integration/expected.txt
@@ -1,7 +1,9 @@
       Asset       Size  Chunks             Chunk Names
-       0.js  287 bytes       0  [emitted]  
-   main1.js  386 bytes       1  [emitted]  main1
+       0.js  719 bytes       0  [emitted]  
+   main1.js  542 bytes       1  [emitted]  main1
 manifest.js   7.73 KiB       2  [emitted]  manifest
 Entrypoint main1 = manifest.js main1.js
 [0] ./b.js 20 bytes {0} [built]
-[1] ./main1.js 36 bytes {1} [built]
+[1] ./c.js 20 bytes {0} [built]
+[2] ./d.js 20 bytes {0} [built]
+[3] ./main1.js 66 bytes {1} [built]

--- a/test/statsCases/runtime-chunk-integration/expected.txt
+++ b/test/statsCases/runtime-chunk-integration/expected.txt
@@ -1,9 +1,22 @@
-      Asset       Size  Chunks             Chunk Names
-       0.js  719 bytes       0  [emitted]  
-   main1.js  542 bytes       1  [emitted]  main1
-manifest.js   7.73 KiB       2  [emitted]  manifest
-Entrypoint main1 = manifest.js main1.js
-[0] ./b.js 20 bytes {0} [built]
-[1] ./c.js 20 bytes {0} [built]
-[2] ./d.js 20 bytes {0} [built]
-[3] ./main1.js 66 bytes {1} [built]
+Child base:
+         Asset       Size  Chunks             Chunk Names
+          0.js  719 bytes       0  [emitted]  
+      main1.js  542 bytes       1  [emitted]  main1
+    runtime.js   7.73 KiB       2  [emitted]  runtime
+    Entrypoint main1 = runtime.js main1.js
+    [0] ./b.js 20 bytes {0} [built]
+    [1] ./c.js 20 bytes {0} [built]
+    [2] ./d.js 20 bytes {0} [built]
+    [3] ./main1.js 66 bytes {1} [built]
+Child manifest is named entry:
+          Asset       Size  Chunks             Chunk Names
+           0.js  719 bytes       0  [emitted]  
+    manifest.js   8.04 KiB       1  [emitted]  manifest
+       main1.js  542 bytes       2  [emitted]  main1
+    Entrypoint main1 = manifest.js main1.js
+    Entrypoint manifest = manifest.js
+    [0] ./b.js 20 bytes {0} [built]
+    [1] ./c.js 20 bytes {0} [built]
+    [2] ./d.js 20 bytes {0} [built]
+    [3] ./main1.js 66 bytes {2} [built]
+    [4] ./f.js 20 bytes {1} [built]

--- a/test/statsCases/runtime-chunk-integration/f.js
+++ b/test/statsCases/runtime-chunk-integration/f.js
@@ -1,0 +1,1 @@
+export default "f";

--- a/test/statsCases/runtime-chunk-integration/main1.js
+++ b/test/statsCases/runtime-chunk-integration/main1.js
@@ -1,3 +1,5 @@
 import("./b");
+import("./c");
+import("./d");
 
 export default "a";

--- a/test/statsCases/runtime-chunk-integration/main1.js
+++ b/test/statsCases/runtime-chunk-integration/main1.js
@@ -1,0 +1,3 @@
+import("./b");
+
+export default "a";

--- a/test/statsCases/runtime-chunk-integration/webpack.config.js
+++ b/test/statsCases/runtime-chunk-integration/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
 	},
 	plugins: [
 		new MinChunkSizePlugin({
-			minChunkSize: 30
+			minChunkSize: 1000
 		})
 	]
 };

--- a/test/statsCases/runtime-chunk-integration/webpack.config.js
+++ b/test/statsCases/runtime-chunk-integration/webpack.config.js
@@ -1,0 +1,28 @@
+const MinChunkSizePlugin = require("../../../lib/optimize/MinChunkSizePlugin");
+
+module.exports = {
+	mode: "production",
+	target: "web",
+	entry: {
+		main1: "./main1"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		runtimeChunk: {
+			name: "manifest"
+		}
+	},
+	stats: {
+		hash: false,
+		timings: false,
+		builtAt: false,
+		reasons: false
+	},
+	plugins: [
+		new MinChunkSizePlugin({
+			minChunkSize: 30
+		})
+	]
+};

--- a/test/statsCases/runtime-chunk-integration/webpack.config.js
+++ b/test/statsCases/runtime-chunk-integration/webpack.config.js
@@ -1,24 +1,15 @@
 const MinChunkSizePlugin = require("../../../lib/optimize/MinChunkSizePlugin");
 
-module.exports = {
+const baseConfig = {
 	mode: "production",
 	target: "web",
-	entry: {
-		main1: "./main1"
-	},
 	output: {
 		filename: "[name].js"
-	},
-	optimization: {
-		runtimeChunk: {
-			name: "manifest"
-		}
 	},
 	stats: {
 		hash: false,
 		timings: false,
-		builtAt: false,
-		reasons: false
+		builtAt: false
 	},
 	plugins: [
 		new MinChunkSizePlugin({
@@ -26,3 +17,28 @@ module.exports = {
 		})
 	]
 };
+
+const withoutNamedEntry = Object.assign({}, baseConfig, {
+	name: "base",
+	entry: {
+		main1: "./main1"
+	},
+	optimization: {
+		runtimeChunk: "single"
+	}
+});
+
+const withNamedEntry = Object.assign({}, baseConfig, {
+	name: "manifest is named entry",
+	entry: {
+		main1: "./main1",
+		manifest: "./f"
+	},
+	optimization: {
+		runtimeChunk: {
+			name: "manifest"
+		}
+	}
+});
+
+module.exports = [withoutNamedEntry, withNamedEntry];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

yes

**Summary**

fixed bug where sometimes the runtime would not be present on output

**Does this PR introduce a breaking change?**

i don't think so, more likely improves compatibility with webpack 3

**Other information**

Hello webpack team

I found a bug where sometimes the runtime would not be present on output

I encountered it by using:
- `optimization.runtimeChunk: true`
- `webpack.optimize.MinChunkSizePlugin`
- Dinamic imports

It seems the runtime chunk would get integrated into one of the asyncChunks, and after integration i would get removed from the chunk graph, causing it's `EntryPoint.runtimeChunk` to be a chunk thats not longer on the Graph.

Why is it getting integrated? Well is small since it has 0 modules, shares the same groups as the asyncChunk, and especilly shares the same EntryPoint

Example output from the new `runtime-chunk-integration` statsTestCase


### BaseLine
 - optimization.runtimeChunk: **false**
 - `webpack.optimize.MinChunkSizePlugin` **not used**

```
   Asset       Size  Chunks             Chunk Names
    0.js  287 bytes       0  [emitted]  
    1.js  296 bytes       1  [emitted]  
    2.js  290 bytes       2  [emitted]  
main1.js   7.32 KiB       3  [emitted]  main1
Entrypoint main1 = main1.js
[0] ./b.js 20 bytes {0} [built]
[1] ./c.js 20 bytes {1} [built]
[2] ./d.js 20 bytes {2} [built]
[3] ./main1.js 66 bytes {3} [built]
```


-------------------------------------------------------
### Before
 - optimization.runtimeChunk: **true**
 - `webpack.optimize.MinChunkSizePlugin` **used**
 - **Where are the 7KiB of the runtime?**
 - "./b.js", "./c.js", "./d.js"got integrated

```
   Asset       Size  Chunks             Chunk Names
    0.js  728 bytes       0  [emitted]  
main1.js  539 bytes       1  [emitted]  main1
Entrypoint main1 = 0.js main1.js
[0] ./main1.js 66 bytes {1} [built]
[1] ./b.js 20 bytes {0} [built]
[2] ./c.js 20 bytes {0} [built]
[3] ./d.js 20 bytes {0} [built]
```


-------------------------------------------------------
### After
 - optimization.runtimeChunk: **true**
 - `webpack.optimize.MinChunkSizePlugin` **used**
 - **Runtime now present**
 - "./b.js", "./c.js", "./d.js"got integrated

```
      Asset       Size  Chunks             Chunk Names
       0.js  719 bytes       0  [emitted]  
   main1.js  542 bytes       1  [emitted]  main1
manifest.js   7.73 KiB       2  [emitted]  manifest
Entrypoint main1 = manifest.js main1.js
[0] ./b.js 20 bytes {0} [built]
[1] ./c.js 20 bytes {0} [built]
[2] ./d.js 20 bytes {0} [built]
[3] ./main1.js 66 bytes {1} [built]
```

# Proposals for resolution:


### Option 1
Everytime a chunk that `chunk.hasRuntime() === true` gets integrated; make sure the its `Entrypoint.runtimeChunk` gets set to undefined `Entrypoint.setRuntimeChunk(undefined)`

**Pros**
 - none

**Cons**
 - The runtime chunk would likely get integrated to another chunk; users explicitly setting `optimization.runtimeChunk` most likely don't want this


### Option 2
 1. Set a new property on Chunk `Chunk.isRuntimeOnly`
 2. check against it on `Chunk.canBeIntegrated()`

**Pros**
 - Doesn't integrate the runtimeChunk, so users have a predictable output

**Cons**
 - Reduces the cohesion of the `Chunk` class


### Option 3
 1. Subclass `Chunk`, `RuntimeChunk`
 2. Create method `Chunk.isRuntimeOnly() --> false`
 3. Create method `RuntimeChunk.isRuntimeOnly() --> true`
 4. Check against it on `Chunk.canBeIntegrated()`

I personally like this one best, seems to be the approach you follow with `ChunkGroup` and `EntryPoint`

**Pros**
 - Doesn't integrate the runtimeChunk, so users have a predictable output

**Cons**
 - New bug: What if a namedChunk is called "manifest", and the `optimization.runtimeChunk.name: "manifest"`, current behavior would merge them together, witch is correct.
   - this solution would not merge them, not sure how to solve it.
   - in this case the namedChunk is not a `RuntimeChunk`, is just a `Chunk`
 - Reduces the cohesion of the `Chunk` class, arguably not as much
 - Too many classes?


# This Pull-request

This PR follows Option 2

So i think it's best not to allow a `Chunk.isRuntimeOnly` to be integrated onto another chunk

One question that i can't seem to answer is:

**Should a `Chunk.isRuntimeOnly` allow other chunk to be integrated onto it self?**
I think yes, but i am not sure, this PR assumes yes

Thoughts ?


