### PR TITLE
Added `output.moduleExportsConfigurable` for mocking exports in tests

### DIFF
--- a/lib/MainTemplate.js
+++ b/lib/MainTemplate.js
@@ -237,7 +237,9 @@ module.exports = class MainTemplate extends Tapable {
 					Template.indent([
 						"Object.defineProperty(exports, name, {",
 						Template.indent([
-							"configurable: false,",
+							outputOptions.moduleExportsConfigurable
+								? "configurable: true,"
+								: "configurable: false,",
 							"enumerable: true,",
 							"get: getter"
 						]),

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -159,6 +159,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("output.hashDigest", "hex");
 		this.set("output.hashDigestLength", 20);
 		this.set("output.devtoolLineToLine", false);
+		this.set("output.moduleExportsConfigurable", false);
 		this.set("output.strictModuleExceptionHandling", false);
 
 		this.set("node", "call", value => {

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -536,6 +536,10 @@
             }
           ]
         },
+        "moduleExportsConfigurable": {
+          "description": "Defines getter properties on the export object as configurable so it can be mocked. Only works when `mode='development'`.",
+          "type": "boolean"
+        },
         "path": {
           "description": "The output directory as **absolute path** (required).",
           "type": "string",

--- a/test/configCases/output/moduleExportsConfigurable/cjs.js
+++ b/test/configCases/output/moduleExportsConfigurable/cjs.js
@@ -1,0 +1,3 @@
+exports.cjs = function() {
+	return "cjs";
+};

--- a/test/configCases/output/moduleExportsConfigurable/es6.js
+++ b/test/configCases/output/moduleExportsConfigurable/es6.js
@@ -1,0 +1,12 @@
+export default function() {
+	return "es6DefaultExport";
+}
+
+export function es6NamedExport() {
+	return "es6NamedExport";
+}
+
+function es6ExportSpecifier() {
+	return "es6ExportSpecifier";
+}
+export { es6ExportSpecifier };

--- a/test/configCases/output/moduleExportsConfigurable/esm.mjs
+++ b/test/configCases/output/moduleExportsConfigurable/esm.mjs
@@ -1,0 +1,3 @@
+export function esm() {
+	return "esm";
+}

--- a/test/configCases/output/moduleExportsConfigurable/index.js
+++ b/test/configCases/output/moduleExportsConfigurable/index.js
@@ -1,0 +1,47 @@
+import sinon from "sinon";
+import { smokeTest, es6DeepDive } from "./output.js";
+import * as cjs from "./cjs.js";
+import * as es6 from "./es6.js";
+import * as esm from "./esm.mjs";
+
+describe("unmocked", () => {
+	it("should ignore mocking", () => {
+		smokeTest().should.deepEqual(["cjs", "es6NamedExport", "esm"]);
+		es6DeepDive().should.deepEqual([
+			"es6DefaultExport",
+			"es6NamedExport",
+			"es6ExportSpecifier"
+		]);
+	});
+});
+
+describe("mocked", () => {
+	let sandbox;
+
+	beforeEach(() => {
+		sandbox = sinon.sandbox.create();
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+		sandbox = undefined;
+	});
+
+	it("should support mocking cjs exports", () => {
+		sandbox.stub(cjs, "cjs").get(() => () => "mocked");
+		smokeTest().should.deepEqual(["mocked", "es6NamedExport", "esm"]);
+	});
+
+	it("should support mocking es6 exports", () => {
+		sandbox.stub(es6, "default").get(() => () => "mocked");
+		sandbox.stub(es6, "es6NamedExport").get(() => () => "mocked");
+		sandbox.stub(es6, "es6ExportSpecifier").get(() => () => "mocked");
+		smokeTest().should.deepEqual(["cjs", "mocked", "esm"]);
+		es6DeepDive().should.deepEqual(["mocked", "mocked", "mocked"]);
+	});
+
+	it("should support mocking esm exports", () => {
+		sandbox.stub(esm, "esm").get(() => () => "mocked");
+		smokeTest().should.deepEqual(["cjs", "es6NamedExport", "mocked"]);
+	});
+});

--- a/test/configCases/output/moduleExportsConfigurable/output.js
+++ b/test/configCases/output/moduleExportsConfigurable/output.js
@@ -1,0 +1,11 @@
+import { cjs } from "./cjs.js";
+import defaultEs6, { es6NamedExport, es6ExportSpecifier } from "./es6.js";
+import { esm } from "./esm.mjs";
+
+export function smokeTest() {
+	return [cjs(), es6NamedExport(), esm()];
+}
+
+export function es6DeepDive() {
+	return [defaultEs6(), es6NamedExport(), es6ExportSpecifier()];
+}

--- a/test/configCases/output/moduleExportsConfigurable/webpack.config.js
+++ b/test/configCases/output/moduleExportsConfigurable/webpack.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	mode: "development",
+	output: {
+		moduleExportsConfigurable: true
+	}
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Added `output.moduleExportsConfigurable` that defines export properties as configurable so es6 exports can be mocked.
Mocking exports only works when `mode != 'production'`.

**Did you add tests for your changes?**

Yes

**If relevant, link to documentation update:**

If this PR is accepted, I'll happily create a PR in the docs repo.

**Summary**

[Continuing off this issue](https://github.com/webpack/webpack/issues/6979)...

Before Webpack 4 certain ES Module exports were assigned to the export object by mutating it.
Most stubbing libraries like SinonJS rely on the fact that objects are mutable to apply stubs, spies, etc...
I understand mutating exports can have undesirable consequences and Webpack 4 did a great job fixing this.
This PR keeps the default behavior intact and adds a configuration to enable simple mocks bypassing complex dependency injection libraries.

**Does this PR introduce a breaking change?**

No

**Other information**

I'm not married to the name of "moduleExportsConfigurable" and happy welcome feedback on only allowing this when mode === development.

Stubbing getter attributes with Sinon.JS: http://sinonjs.org/releases/v4.5.0/stubs/#stubgetgetterfn
