### PR TITLE
Invalidate concatenated module on dep change

### DIFF
--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -576,9 +576,12 @@ class ConcatenatedModule extends Module {
 				moduleToInfoMap
 			)
 		);
+
+		// Must use full identifier in our cache here to ensure that the source
+		// is updated should our dependencies list change.
 		innerDependencyTemplates.set(
 			"hash",
-			innerDependencyTemplates.get("hash") + this.rootModule.identifier()
+			innerDependencyTemplates.get("hash") + this.identifier()
 		);
 
 		// Generate source code and analyse scopes

--- a/test/watchCases/scope-hoisting/caching-inner-source/0/index.js
+++ b/test/watchCases/scope-hoisting/caching-inner-source/0/index.js
@@ -1,0 +1,3 @@
+it("should not crash when scope-hoisted modules change", function() {
+	require("./module").default.should.be.eql(WATCH_STEP);
+})

--- a/test/watchCases/scope-hoisting/caching-inner-source/0/inner.js
+++ b/test/watchCases/scope-hoisting/caching-inner-source/0/inner.js
@@ -1,0 +1,1 @@
+export { x } from "./inner1";

--- a/test/watchCases/scope-hoisting/caching-inner-source/0/inner1.js
+++ b/test/watchCases/scope-hoisting/caching-inner-source/0/inner1.js
@@ -1,0 +1,1 @@
+export { x } from "./inner2";

--- a/test/watchCases/scope-hoisting/caching-inner-source/0/inner2.js
+++ b/test/watchCases/scope-hoisting/caching-inner-source/0/inner2.js
@@ -1,0 +1,1 @@
+export var x = "0";

--- a/test/watchCases/scope-hoisting/caching-inner-source/0/module.js
+++ b/test/watchCases/scope-hoisting/caching-inner-source/0/module.js
@@ -1,0 +1,3 @@
+import { x } from "./inner";
+
+export default x;

--- a/test/watchCases/scope-hoisting/caching-inner-source/1/inner1.js
+++ b/test/watchCases/scope-hoisting/caching-inner-source/1/inner1.js
@@ -1,0 +1,1 @@
+export var x = "1";

--- a/test/watchCases/scope-hoisting/caching-inner-source/webpack.config.js
+++ b/test/watchCases/scope-hoisting/caching-inner-source/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	optimization: {
+		concatenateModules: true
+	}
+};


### PR DESCRIPTION
Bugfix.

When the moduleSet for a given concatenated module changed, the source for the embedded modules would not necessarily, which lead to caching mismatch between the source and the modulesWithInfo structure.

Fixes #6168
