### PR TITLE
Use compile/compileStreaming when importObject is a Promise

### DIFF
--- a/lib/node/ReadFileCompileWasmTemplatePlugin.js
+++ b/lib/node/ReadFileCompileWasmTemplatePlugin.js
@@ -39,9 +39,11 @@ class ReadFileCompileWasmTemplatePlugin {
 						"})"
 					]);
 
-				new WasmMainTemplatePlugin(generateLoadBinaryCode).apply(
-					compilation.mainTemplate
+				const plugin = new WasmMainTemplatePlugin(
+					generateLoadBinaryCode,
+					false
 				);
+				plugin.apply(compilation.mainTemplate);
 			}
 		);
 	}

--- a/lib/wasm/WasmMainTemplatePlugin.js
+++ b/lib/wasm/WasmMainTemplatePlugin.js
@@ -127,8 +127,9 @@ function generateImportObject(module) {
 }
 
 class WasmMainTemplatePlugin {
-	constructor(generateLoadBinaryCode) {
+	constructor(generateLoadBinaryCode, supportsStreaming) {
 		this.generateLoadBinaryCode = generateLoadBinaryCode;
+		this.supportsStreaming = supportsStreaming;
 	}
 	apply(mainTemplate) {
 		mainTemplate.hooks.localVars.tap(
@@ -203,29 +204,55 @@ class WasmMainTemplatePlugin {
 						Template.indent(["promises.push(installedWasmModuleData);"]),
 						"else {",
 						Template.indent([
-							`var importObject = Promise.resolve(wasmImportObjects[wasmModuleId]());`,
+							`var importObject = wasmImportObjects[wasmModuleId]();`,
 							`var req = ${this.generateLoadBinaryCode(wasmModuleSrcPath)};`,
-							"promises.push(installedWasmModules[wasmModuleId] = importObject.then(function(importObject) {",
+							"var promise;",
+							this.supportsStreaming
+								? Template.asString([
+										"if(importObject instanceof Promise && typeof WebAssembly.compileStreaming === 'function') {",
+										Template.indent([
+											"promise = Promise.all([WebAssembly.compileStreaming(req), importObject]).then(function(items) {",
+											Template.indent([
+												"return WebAssembly.instantiate(items[0], items[1]);"
+											]),
+											"});"
+										]),
+										"} else if(typeof WebAssembly.instantiateStreaming === 'function') {",
+										Template.indent([
+											"promise = WebAssembly.instantiateStreaming(req, importObject);"
+										])
+								  ])
+								: Template.asString([
+										"if(importObject instanceof Promise) {",
+										Template.indent([
+											"var bytesPromise = req.then(function(x) { return x.arrayBuffer(); });",
+											"promise = Promise.all([",
+											Template.indent([
+												"bytesPromise.then(function(bytes) { return WebAssembly.compile(bytes); }),",
+												"importObject"
+											]),
+											"]).then(function(items) {",
+											Template.indent([
+												"return WebAssembly.instantiate(items[0], items[1]);"
+											]),
+											"});"
+										])
+								  ]),
+							"} else {",
 							Template.indent([
-								"if(typeof WebAssembly.instantiateStreaming === 'function') {",
+								"var bytesPromise = req.then(function(x) { return x.arrayBuffer(); });",
+								"promise = bytesPromise.then(function(bytes) {",
 								Template.indent([
-									"return WebAssembly.instantiateStreaming(req, importObject);"
+									"return WebAssembly.instantiate(bytes, importObject);"
 								]),
-								"} else {",
-								Template.indent([
-									"return req.then(x => x.arrayBuffer()).then(function(bytes) {",
-									Template.indent([
-										"return WebAssembly.instantiate(bytes, importObject);"
-									]),
-									"});"
-								]),
-								"}"
+								"});"
 							]),
-							"}).then(function(res) {",
+							"}",
+							"promises.push(installedWasmModules[wasmModuleId] = promise.then(function(res) {",
 							Template.indent([
 								`return ${
 									mainTemplate.requireFn
-								}.w[wasmModuleId] = res.instance;`
+								}.w[wasmModuleId] = res.instance || res;`
 							]),
 							"}));"
 						]),

--- a/lib/wasm/WebAssemblyJavascriptGenerator.js
+++ b/lib/wasm/WebAssemblyJavascriptGenerator.js
@@ -82,7 +82,7 @@ class WebAssemblyJavascriptGenerator extends Generator {
 			[
 				'"use strict";',
 				"// Instantiate WebAssembly module",
-				"var instance = __webpack_require__.w[module.i]",
+				"var instance = __webpack_require__.w[module.i];",
 
 				// this must be before import for circular dependencies
 				"// export exports from WebAssembly module",

--- a/lib/web/FetchCompileWasmTemplatePlugin.js
+++ b/lib/web/FetchCompileWasmTemplatePlugin.js
@@ -15,7 +15,8 @@ class FetchCompileWasmTemplatePlugin {
 				const generateLoadBinaryCode = path =>
 					`fetch(${mainTemplate.requireFn}.p + ${path})`;
 
-				new WasmMainTemplatePlugin(generateLoadBinaryCode).apply(mainTemplate);
+				const plugin = new WasmMainTemplatePlugin(generateLoadBinaryCode, true);
+				plugin.apply(mainTemplate);
 			}
 		);
 	}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
existing tests
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
better runtime performance when loading memory-sharing wasm modules.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
