### PR TITLE
docs(examples): add yarn add webpack-cli step

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -120,8 +120,9 @@
 If you think an example is missing, please report it as issue. :)
 
 # Building an Example
-1. Run `npm install` in the root of the project.
-2. Run `npm link webpack` in the root of the project.
-3. Run `node build.js` in the specific example directory. (Ex: `cd examples/commonjs && node build.js`)
+1. Run `yarn` in the root of the project.
+2. Run `yarn link webpack` in the root of the project.
+3. Run `yarn add --dev webpack-cli` in the root of the project.
+4. Run `node build.js` in the specific example directory. (Ex: `cd examples/commonjs && node build.js`)
 
 Note: To build all examples run `npm run build:examples`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
docs change
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
No
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

Running `node cd examples/commonjs && node ./build.js` without `webpack-cli` installed will get hang.

The culprit is that webpack expects a stdin user input of whether to install webpack-cli or not. However, as examples/build-common uses `child_process.exec` to execute `webpack`, the user will not be prompted for any questions since the stdin is not piped and the stdout will be pass to parent process only after the child process exits. We can keep build-common simple by instructing devs to install webpack-cli before they build examples.

Also rewrite the install step using yarn since we use yarn in webpack.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
No

**Alternative Solution**
Add `webpack-cli` to `devDependencies`.