### PR TITLE
chore(types): add types to GraphHelpers

### DIFF
--- a/lib/DependenciesBlock.js
+++ b/lib/DependenciesBlock.js
@@ -6,11 +6,15 @@
 
 const DependenciesBlockVariable = require("./DependenciesBlockVariable");
 
+/** @typedef {import("./ChunkGroup")} ChunkGroup */
+
 class DependenciesBlock {
 	constructor() {
 		this.dependencies = [];
 		this.blocks = [];
 		this.variables = [];
+		/** @type {ChunkGroup=} */
+		this.chunkGroup = undefined;
 	}
 
 	addBlock(block) {

--- a/lib/GraphHelpers.js
+++ b/lib/GraphHelpers.js
@@ -1,28 +1,64 @@
-exports.connectChunkGroupAndChunk = (chunkGroup, chunk) => {
+/** @typedef {import("./Chunk")} Chunk */
+/** @typedef {import("./ChunkGroup")} ChunkGroup */
+/** @typedef {import("./Module")} Module */
+/** @typedef {import("./DependenciesBlock")} DependenciesBlock */
+
+/**
+ * @param {ChunkGroup} chunkGroup the ChunkGroup to connect
+ * @param {Chunk} chunk chunk to tie to ChunkGroup
+ * @returns {void}
+ */
+const connectChunkGroupAndChunk = (chunkGroup, chunk) => {
 	if (chunkGroup.pushChunk(chunk)) {
 		chunk.addGroup(chunkGroup);
 	}
 };
 
-exports.connectChunkGroupParentAndChild = (parent, child) => {
+/**
+ * @param {ChunkGroup} parent parent ChunkGroup to connect
+ * @param {ChunkGroup} child child ChunkGroup to connect
+ * @returns {void}
+ */
+const connectChunkGroupParentAndChild = (parent, child) => {
 	if (parent.addChild(child)) {
 		child.addParent(parent);
 	}
 };
 
-exports.connectChunkAndModule = (chunk, module) => {
+/**
+ * @param {Chunk} chunk Chunk to connect to Module
+ * @param {Module} module Module to connect to Chunk
+ * @returns {void}
+ */
+const connectChunkAndModule = (chunk, module) => {
 	if (module.addChunk(chunk)) {
 		chunk.addModule(module);
 	}
 };
 
-exports.disconnectChunkAndModule = (chunk, module) => {
+/**
+ * @param {Chunk} chunk Chunk being disconnected
+ * @param {Module} module Module being disconnected
+ * @returns {void}
+ */
+const disconnectChunkAndModule = (chunk, module) => {
 	chunk.removeModule(module);
 	module.removeChunk(chunk);
 };
 
-exports.connectDependenciesBlockAndChunkGroup = (depBlock, chunkGroup) => {
+/**
+ * @param {DependenciesBlock} depBlock DepBlock being tied to ChunkGroup
+ * @param {ChunkGroup} chunkGroup ChunkGroup being tied to DepBlock
+ * @returns {void}
+ */
+const connectDependenciesBlockAndChunkGroup = (depBlock, chunkGroup) => {
 	if (chunkGroup.addBlock(depBlock)) {
 		depBlock.chunkGroup = chunkGroup;
 	}
 };
+
+exports.connectChunkGroupAndChunk = connectChunkGroupAndChunk;
+exports.connectChunkGroupParentAndChild = connectChunkGroupParentAndChild;
+exports.connectChunkAndModule = connectChunkAndModule;
+exports.disconnectChunkAndModule = disconnectChunkAndModule;
+exports.connectDependenciesBlockAndChunkGroup = connectDependenciesBlockAndChunkGroup;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Type Annotations
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
N/A
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**
N/A
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**
This PR adds Type Support for GraphHelpers via JSDoc Annotations

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
NO!
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

I thought it was strange that `DependenciesBlock` class now has the option to have a `ChunkGroup` tied to it? Should this actually fall to a subclass? 
