### PR TITLE
fix: ReferenceError: onScriptComplete is not defined when using HMR o…

### DIFF
--- a/lib/web/JsonpMainTemplatePlugin.js
+++ b/lib/web/JsonpMainTemplatePlugin.js
@@ -173,7 +173,6 @@ class JsonpMainTemplatePlugin {
 						"onScriptComplete({ type: 'timeout', target: script });"
 					]),
 					`}, ${chunkLoadTimeout});`,
-					"script.onerror = script.onload = onScriptComplete;",
 					"function onScriptComplete(event) {",
 					Template.indent([
 						"// avoid mem leaks in IE.",
@@ -196,7 +195,8 @@ class JsonpMainTemplatePlugin {
 						]),
 						"}"
 					]),
-					"};"
+					"};",
+          "script.onerror = script.onload = onScriptComplete;"
 				]);
 			}
 		);

--- a/lib/web/JsonpMainTemplatePlugin.js
+++ b/lib/web/JsonpMainTemplatePlugin.js
@@ -196,7 +196,7 @@ class JsonpMainTemplatePlugin {
 						"}"
 					]),
 					"};",
-          "script.onerror = script.onload = onScriptComplete;"
+					"script.onerror = script.onload = onScriptComplete;"
 				]);
 			}
 		);


### PR DESCRIPTION
…n Firefox 45

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix for Firefox 45 and code improvement

**Did you add tests for your changes?**

no, it's an enhancement covered by existing tests

**If relevant, link to documentation update:**

N/A

**Summary**

I've been testing my app on out-dated Firefox (45) and realised the template relies on hoisting (`onScriptComplete` assigned before its declaration) which is not only a bad practice but it was crashing the bundling.

**Does this PR introduce a breaking change?**

no, this is just enhancement