### PR TITLE
feat: cleaner plugin

### DIFF
--- a/lib/CleanerPlugin.js
+++ b/lib/CleanerPlugin.js
@@ -1,0 +1,41 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+"use strict";
+const del = require("del");
+
+class CleanerPlugin {
+	constructor(options) {
+		this.options = options || {};
+
+		this.patterns = [];
+		this.cleanerOptions = {};
+
+		if (typeof this.options === "string") {
+			this.patterns = [this.options];
+		} else if (Array.isArray(this.options)) {
+			this.patterns = this.options;
+		} else {
+			this.patterns = this.options.patterns;
+			this.cleanerOptions = this.options.options;
+		}
+	}
+
+	apply(compiler) {
+		compiler.hooks.beforeRun.tapPromise(
+			"CleanerPlugin",
+			this.runCleaner.bind(this)
+		);
+		compiler.hooks.watchRun.tapPromise(
+			"CleanerPlugin",
+			this.runCleaner.bind(this)
+		);
+	}
+
+	runCleaner(compiler, callback) {
+		return del(this.patterns, this.cleanerOptions);
+	}
+}
+
+module.exports = CleanerPlugin;

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -41,6 +41,8 @@ const RequireIncludePlugin = require("./dependencies/RequireIncludePlugin");
 
 const WarnNoModeSetPlugin = require("./WarnNoModeSetPlugin");
 
+const CleanerPlugin = require("./CleanerPlugin");
+
 const EnsureChunkConditionsPlugin = require("./optimize/EnsureChunkConditionsPlugin");
 const RemoveParentModulesPlugin = require("./optimize/RemoveParentModulesPlugin");
 const RemoveEmptyChunksPlugin = require("./optimize/RemoveEmptyChunksPlugin");
@@ -193,6 +195,12 @@ class WebpackOptionsApply extends OptionsApply {
 			throw new Error("Unsupported target '" + options.target + "'.");
 		}
 
+		if (options.output.clean)
+			new CleanerPlugin(
+				options.output.clean === true
+					? [compiler.outputPath.replace(/\/$/, "") + "/**/*"]
+					: options.output.clean
+			).apply(compiler);
 		if (options.output.library || options.output.libraryTarget !== "var") {
 			let LibraryTemplatePlugin = require("./LibraryTemplatePlugin");
 			new LibraryTemplatePlugin(

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -88,6 +88,18 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 			}
 		});
 
+		this.set("output.clean", "call", (value, options) => {
+			if (!value) return false;
+			if (typeof value === "boolean") {
+				return value;
+			} else if (typeof value === "string") {
+				return [value];
+			} else if (Array.isArray(value)) {
+				return value;
+			} else {
+				return Object.assign({}, value);
+			}
+		});
 		this.set("output.filename", "[name].js");
 		this.set("output.chunkFilename", "make", options => {
 			const filename = options.output.filename;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "ajv": "^6.1.0",
     "ajv-keywords": "^3.1.0",
     "chrome-trace-event": "^0.1.1",
+    "del": "^3.0.0",
     "enhanced-resolve": "^4.0.0",
     "eslint-scope": "^3.7.1",
     "loader-runner": "^2.3.0",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -327,6 +327,41 @@
           "type": "string",
           "absolutePath": false
         },
+        "clean": {
+          "description": "Enable auto deletion of files from `output.path` directory.",
+          "anyOf": [
+            {
+              "description": "`true` enables auto deletion of files from `output.path`.",
+              "type": "boolean"
+            },
+            {
+              "description": "Pattern by which files will be deleted (see `del` package).",
+              "type": "string"
+            },
+            {
+              "description": "Array pattern by which files will be deleted (see `del` package).",
+              "type": "array"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "patterns": {
+                  "description": "Array pattern by which files will be deleted (see `del` package).",
+                  "items": {
+                    "description": "Pattern by which files will be deleted (see `del` package).",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "options": {
+                  "description": "Cleaner options (see `del` package).",
+                  "type": "object"
+                }
+              }
+            }
+          ]
+        },
         "webassemblyModuleFilename": {
           "description": "The filename of WebAssembly modules as relative path inside the `output.path` directory.",
           "type": "string",

--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -101,6 +101,7 @@ describe("ConfigTestCases", () => {
 								} catch (e) {
 									// ignored
 								}
+								if (testConfig.beforeExecute) testConfig.beforeExecute(options);
 
 								webpack(options, (err, stats) => {
 									if (err) {
@@ -258,7 +259,7 @@ describe("ConfigTestCases", () => {
 										);
 									if (exportedTests.length < filesCount)
 										return done(new Error("No tests exported by test case"));
-									if (testConfig.afterExecute) testConfig.afterExecute();
+									if (testConfig.afterExecute) testConfig.afterExecute(options);
 									const asyncSuite = describe("exported tests", () => {
 										exportedBeforeEach.forEach(beforeEach);
 										exportedAfterEach.forEach(afterEach);

--- a/test/configCases/clean/boolean-false/index.js
+++ b/test/configCases/clean/boolean-false/index.js
@@ -1,0 +1,8 @@
+const path = require("path");
+
+it("should not find old file", function() {
+	var fs = require("fs");
+	expect(() =>
+		fs.readFileSync(path.join(__dirname, "file.js"), "utf-8")
+	).not.toThrow();
+});

--- a/test/configCases/clean/boolean-false/test.config.js
+++ b/test/configCases/clean/boolean-false/test.config.js
@@ -1,0 +1,12 @@
+const mkdirp = require("mkdirp");
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	beforeExecute(options) {
+		const outputPath = options.output.path;
+
+		mkdirp.sync(outputPath);
+		fs.writeFileSync(path.join(outputPath, "file.js"), "module.exports = 1;");
+	}
+};

--- a/test/configCases/clean/boolean-false/webpack.config.js
+++ b/test/configCases/clean/boolean-false/webpack.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	output: {
+		clean: false
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};

--- a/test/configCases/clean/boolean-true/index.js
+++ b/test/configCases/clean/boolean-true/index.js
@@ -1,0 +1,8 @@
+const path = require("path");
+
+it("should not find old file", function() {
+	var fs = require("fs");
+	expect(() =>
+		fs.readFileSync(path.join(__dirname, "file.js"), "utf-8")
+	).toThrow();
+});

--- a/test/configCases/clean/boolean-true/test.config.js
+++ b/test/configCases/clean/boolean-true/test.config.js
@@ -1,0 +1,12 @@
+const mkdirp = require("mkdirp");
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	beforeExecute(options) {
+		const outputPath = options.output.path;
+
+		mkdirp.sync(outputPath);
+		fs.writeFileSync(path.join(outputPath, "file.js"), "module.exports = 1;");
+	}
+};

--- a/test/configCases/clean/boolean-true/webpack.config.js
+++ b/test/configCases/clean/boolean-true/webpack.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	output: {
+		clean: true
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1410,6 +1410,17 @@ del@^2.0.2:
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
 
+del@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
+  dependencies:
+    globby "^6.1.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    p-map "^1.1.1"
+    pify "^3.0.0"
+    rimraf "^2.2.8"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -2236,6 +2247,16 @@ globby@^5.0.0:
   dependencies:
     array-union "^1.0.1"
     arrify "^1.0.0"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+
+globby@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  dependencies:
+    array-union "^1.0.1"
     glob "^7.0.3"
     object-assign "^4.0.1"
     pify "^2.0.0"
@@ -4155,6 +4176,10 @@ p-locate@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
+
+p-map@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
 p-try@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

yes, maybe need more

**If relevant, link to documentation update:**

not require right now

**Summary**

A small step to the zero configuration. Most of projects which uses `webpack` remove all files from build directory (i.e. `output.path`) before each build. Also we have a lot of plugin for `webpack` for this simple action. This PR solve this problem - not require any additional plugin. Also can be `true` in `webpack@5`. Feedback welcome!

**Does this PR introduce a breaking change?**

no

**Other information**

not require