### PR TITLE
Fix regression in Compilation.sortModules

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -32,6 +32,12 @@ function byId(a, b) {
 	return 0;
 }
 
+const byIndex = (a, b) => {
+	if(a.index < b.index) return -1;
+	if(a.index > b.index) return 1;
+	return 0;
+};
+
 function iterationBlockVariable(variables, fn) {
 	for(let indexVariable = 0; indexVariable < variables.length; indexVariable++) {
 		const varDep = variables[indexVariable].dependencies;
@@ -682,7 +688,7 @@ class Compilation extends Tapable {
 	}
 
 	sortModules(modules) {
-		modules.sort(byId);
+		modules.sort(byIndex);
 	}
 
 	reportDependencyErrorsAndWarnings(module, blocks) {

--- a/test/Compilation.test.js
+++ b/test/Compilation.test.js
@@ -1,0 +1,28 @@
+/* globals describe, it */
+"use strict";
+
+const should = require("should");
+const sinon = require("sinon");
+
+const Compilation = require("../lib/Compilation");
+
+describe("Compilation", () => {
+	describe('sortModules', () => {
+		it('should sort modules by index', () => {
+			let modules = [
+				{index: 5},
+				{index: 4},
+				{index: 8},
+				{index: 1},
+			];
+
+			Compilation.prototype.sortModules(modules);
+			modules.should.match([
+				{index: 1},
+				{index: 4},
+				{index: 5},
+				{index: 8},
+			]);
+		});
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bugfix (Regression introduced in #6203)

**Did you add tests for your changes?**

Yes

**If relevant, link to documentation update:**

N/A

**Summary**

This reverts the accidental change introduced in webpack/webpack#6203 which sorted modules by `id` instead of `index`.

@sokra in webpack/webpack#7194:
> The change you found really looks incorrect. Looks like this was changed accidentally. Could you send a PR including a test case and change this back to index order.
>
> the module.id is not available that this point, so that's wrong.

**Does this PR introduce a breaking change?**

No

**Other information**
