### PR TITLE
Allow banner to be specified as a function

### DIFF
--- a/lib/BannerPlugin.js
+++ b/lib/BannerPlugin.js
@@ -39,12 +39,12 @@ class BannerPlugin {
 		this.options = options || {};
 
 		if (typeof options.banner === "function") {
-			let getBanner = this.options.banner;
+			const getBanner = this.options.banner;
 			this.banner = this.options.raw
 				? getBanner
 				: data => wrapComment(getBanner(data));
 		} else {
-			let banner = this.options.raw
+			const banner = this.options.raw
 				? this.options.banner
 				: wrapComment(this.options.banner);
 			this.banner = () => banner;

--- a/lib/BannerPlugin.js
+++ b/lib/BannerPlugin.js
@@ -22,21 +22,33 @@ const wrapComment = str => {
 
 class BannerPlugin {
 	constructor(options) {
-		if (arguments.length > 1)
+		if (arguments.length > 1) {
 			throw new Error(
 				"BannerPlugin only takes one argument (pass an options object)"
 			);
+		}
 
 		validateOptions(schema, options, "Banner Plugin");
 
-		if (typeof options === "string")
+		if (typeof options === "string" || typeof options === "function") {
 			options = {
 				banner: options
 			};
+		}
+
 		this.options = options || {};
-		this.banner = this.options.raw
-			? options.banner
-			: wrapComment(options.banner);
+
+		if (typeof options.banner === "function") {
+			let getBanner = this.options.banner;
+			this.banner = this.options.raw
+				? getBanner
+				: data => wrapComment(getBanner(data));
+		} else {
+			let banner = this.options.raw
+				? this.options.banner
+				: wrapComment(this.options.banner);
+			this.banner = () => banner;
+		}
 	}
 
 	apply(compiler) {
@@ -78,13 +90,15 @@ class BannerPlugin {
 							basename = filename.substr(lastSlashIndex + 1);
 						}
 
-						const comment = compilation.getPath(banner, {
+						const data = {
 							hash,
 							chunk,
 							filename,
 							basename,
 							query
-						});
+						};
+
+						const comment = compilation.getPath(banner(data), data);
 
 						compilation.assets[file] = new ConcatSource(
 							comment,

--- a/schemas/plugins/BannerPlugin.json
+++ b/schemas/plugins/BannerPlugin.json
@@ -39,8 +39,15 @@
       ],
       "properties": {
         "banner": {
-          "description": "The banner as string, it will be wrapped in a comment",
-          "type": "string"
+          "description": "Specifies the banner",
+          "anyOf": [
+            {
+              "instanceof": "Function"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "raw": {
           "description": "If true, banner will not be wrapped in a comment",
@@ -75,6 +82,10 @@
           ]
         }
       }
+    },
+    {
+      "description": "The banner as function, it will be wrapped in a comment",
+      "instanceof": "Function"
     },
     {
       "description": "The banner as string, it will be wrapped in a comment",

--- a/test/configCases/plugins/banner-plugin/index.js
+++ b/test/configCases/plugins/banner-plugin/index.js
@@ -1,13 +1,16 @@
-it("should contain banner in bundle0 chunk", function() {
-	var fs = require("fs");
-	var source = fs.readFileSync(__filename, "utf-8");
+const fs = require("fs");
+const path = require("path");
+
+it("should contain banner in bundle0 chunk", () => {
+	const source = fs.readFileSync(__filename, "utf-8");
 	expect(source).toMatch("A test value");
+	expect(source).toMatch("banner is a string");
+	expect(source).toMatch("banner is a function");
+	expect(source).toMatch("/*!\n * multiline\n * banner\n * 1\n */");
 });
 
-it("should not contain banner in vendors chunk", function() {
-	var fs = require("fs"),
-		path = require("path");
-	var source = fs.readFileSync(path.join(__dirname, "vendors.js"), "utf-8");
+it("should not contain banner in vendors chunk", () => {
+	const source = fs.readFileSync(path.join(__dirname, "vendors.js"), "utf-8");
 	expect(source).not.toMatch("A test value");
 });
 

--- a/test/configCases/plugins/banner-plugin/webpack.config.js
+++ b/test/configCases/plugins/banner-plugin/webpack.config.js
@@ -12,9 +12,14 @@ module.exports = {
 		filename: "[name].js"
 	},
 	plugins: [
+		new webpack.BannerPlugin("banner is a string"),
+		new webpack.BannerPlugin(() => "banner is a function"),
 		new webpack.BannerPlugin({
 			banner: "A test value",
 			exclude: ["vendors.js"]
+		}),
+		new webpack.BannerPlugin({
+			banner: ({ chunk }) => `multiline\nbanner\n${chunk.id}`
 		})
 	]
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

yes

**If relevant, link to documentation update:**

TODO if the feature is merged.

**Summary**

Allow banner to be specified as a function.
Exposed variables are:

- compilation's hash
- chunk object
- filename
- basename
- query

Fixes #7269

**Does this PR introduce a breaking change?**

no