### PR TITLE
Fix a bug where ProgressPlugin is not working properly with MultiComp…

### DIFF
--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -83,7 +83,7 @@ class ProgressPlugin {
 			const states = new Array(compiler.compilers.length);
 			compiler.compilers.forEach((compiler, idx) => {
 				new ProgressPlugin((p, msg, ...args) => {
-					states[idx] = args;
+					states[idx] = [p, msg, ...args];
 					handler(
 						states
 							.map(state => (state && state[0]) || 0)

--- a/test/ProgressPlugin.test.js
+++ b/test/ProgressPlugin.test.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const path = require("path");
+const MemoryFs = require("memory-fs");
+const webpack = require("../");
+
+const createMultiCompiler = () => {
+	const compiler = webpack([
+		{
+			context: path.join(__dirname, "fixtures"),
+			entry: "./a.js"
+		},
+		{
+			context: path.join(__dirname, "fixtures"),
+			entry: "./b.js"
+		}
+	]);
+	compiler.outputFileSystem = new MemoryFs();
+	return compiler;
+};
+
+describe("ProgressPlugin", function() {
+	it("should not contain NaN as a percentage when it is applied to MultiCompiler", function(done) {
+		const compiler = createMultiCompiler();
+
+		let percentage = 0;
+		new webpack.ProgressPlugin((p, msg, ...args) => {
+			percentage += p;
+		}).apply(compiler);
+
+		compiler.run(err => {
+			if (err) {
+				throw err;
+			} else {
+				expect(percentage).not.toBe(NaN);
+				done();
+			}
+		});
+	});
+});


### PR DESCRIPTION
…iler

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
a bugfix

**Did you add tests for your changes?**
existing tests

**If relevant, link to documentation update:**
N/A

**Summary**
It resolves #7261.

When `ProgressPlugin` was refactored in the commit https://github.com/webpack/webpack/commit/f7c2f8e470d44686a2758c2debe59b86b3396c12, `states[idx]` was set to incorrect value.

**Does this PR introduce a breaking change?**
No

**Other information**