### PR TITLE
Add Brief Description & Link To Webpack 1 "Old" Wiki In README => Support Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ We consider webpack to be a low-level tool used not only individually but also l
 
 If you're just getting started, take a look at [our new docs and concepts page](https://webpack.js.org/concepts/). This has a high level overview that is great for beginners!!
 
-Looking for webpack1 docs? Please check out the old [wiki](https://github.com/webpack/docs/wiki/contents), but note that this deprecated version is no longer supported.
+Looking for webpack 1 docs? Please check out the old [wiki](https://github.com/webpack/docs/wiki/contents), but note that this deprecated version is no longer supported.
 
 If you want to discuss something or just need help, [here is our Gitter room](https://gitter.im/webpack/webpack) where there are always individuals looking to help out!
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ We consider webpack to be a low-level tool used not only individually but also l
 
 If you're just getting started, take a look at [our new docs and concepts page](https://webpack.js.org/concepts/). This has a high level overview that is great for beginners!!
 
+Looking for webpack1 docs? Please check out the old [wiki](https://github.com/webpack/docs/wiki/contents), but note that this deprecated version is no longer supported.
+
 If you want to discuss something or just need help, [here is our Gitter room](https://gitter.im/webpack/webpack) where there are always individuals looking to help out!
 
 If you are still having difficulty, we would love for you to post


### PR DESCRIPTION
**What kind of change does this PR introduce?**
docs change

**Did you add tests for your changes?**
No

**If relevant, link to documentation update:**
No

**Summary**
This simple doc PR updates the _Support_ section of the `./README.md` to include a brief description about the reference of _webpack 1_ docs, a link to old [wiki](https://github.com/webpack/docs/wiki/contents) and _small disclaimer_  about the deprecated, unsupported _webpack 1_

This PR resolves #6390.

**Does this PR introduce a breaking change?**
No

**Other information**
This PR content is also based on the analysis of [webpack/webpack.js.org##1823](https://github.com/webpack/webpack.js.org/issues/1823). In the issue [webpack/webpack.js.org##1823](https://github.com/webpack/webpack.js.org/issues/1823), it mentioned about:
> Feel free to submit a PR to add a brief sentence to our [landing page](https://github.com/webpack/webpack.js.org/blob/master/src/content/index.md), as such:

> Looking for webpack 1 documentation? Please check out the old wiki, but note that this version is no longer supported.

Let me know if I'll need to submit another PR for the "_landing page_" in [webpack/webpack.js.org](https://github.com/webpack/webpack.js.org/blob/master/src/content/index.md) per the note ☝️. I'm more than happy to take care of the "_landing page_" update to keep the content of the reference of _webpack 1_ docs intact in appropriate, relevant documentation "_places_". (🙏for reviewing in advance)