### PR TITLE
add missing wasm preprocessing

### DIFF
--- a/lib/wasm/WebAssemblyGenerator.js
+++ b/lib/wasm/WebAssemblyGenerator.js
@@ -7,9 +7,25 @@
 const Generator = require("../Generator");
 const { RawSource } = require("webpack-sources");
 
+const { shrinkPaddedLEB128 } = require("@webassemblyjs/wasm-opt");
 const { editWithAST, addWithAST } = require("@webassemblyjs/wasm-edit");
 const { decode } = require("@webassemblyjs/wasm-parser");
 const t = require("@webassemblyjs/ast");
+
+/**
+ * @typedef {(ArrayBuffer) => ArrayBuffer} ArrayBufferTransform
+ */
+
+/**
+ * Run some preprocessing on the binary before wasm-edit
+ *
+ * @param {ArrayBuffer} ab - original binary
+ * @returns {ArrayBufferTransform} transform
+ */
+function preprocess(ab) {
+	const optBin = shrinkPaddedLEB128(new Uint8Array(ab));
+	return optBin.buffer;
+}
 
 function compose(...fns) {
 	return fns.reverse().reduce((prevFn, nextFn) => {
@@ -34,9 +50,6 @@ const isFuncImport = n => n.descr.type === "FuncImportDescr";
 const initFuncId = t.identifier("__webpack_init__");
 
 // TODO replace with @callback
-/**
- * @typedef {(ArrayBuffer) => ArrayBuffer} ArrayBufferTransform
- */
 
 /**
  * Removes the start instruction
@@ -244,7 +257,8 @@ const addInitFunction = ({
 
 class WebAssemblyGenerator extends Generator {
 	generate(module) {
-		const bin = module.originalSource().source();
+		let bin = module.originalSource().source();
+		bin = preprocess(bin);
 
 		const ast = decode(bin, {
 			ignoreDataSection: true,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@webassemblyjs/ast": "1.4.3",
     "@webassemblyjs/wasm-edit": "1.4.3",
+    "@webassemblyjs/wasm-opt": "1.4.3",
     "@webassemblyjs/wasm-parser": "1.4.3",
     "acorn": "^5.0.0",
     "acorn-dynamic-import": "^3.0.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

I forgot to add this. It removes the padded LEB128 to normal one and that make the transformation (wasm-edit) more stable.