### PR TITLE
Align 'Cannot find module' message with native NodeJS

### DIFF
--- a/examples/code-splitted-require.context-amd/README.md
+++ b/examples/code-splitted-require.context-amd/README.md
@@ -259,7 +259,7 @@ function webpackContext(req) {
 function webpackContextResolve(req) {
 	var id = map[req];
 	if(!(id + 1)) { // check for number or string
-		var e = new Error('Cannot find module "' + req + '".');
+		var e = new Error("Cannot find module '" + req + "'");
 		e.code = 'MODULE_NOT_FOUND';
 		throw e;
 	}

--- a/examples/code-splitted-require.context/README.md
+++ b/examples/code-splitted-require.context/README.md
@@ -259,7 +259,7 @@ function webpackContext(req) {
 function webpackContextResolve(req) {
 	var id = map[req];
 	if(!(id + 1)) { // check for number or string
-		var e = new Error('Cannot find module "' + req + '".');
+		var e = new Error("Cannot find module '" + req + "'");
 		e.code = 'MODULE_NOT_FOUND';
 		throw e;
 	}

--- a/examples/code-splitting-harmony/README.md
+++ b/examples/code-splitting-harmony/README.md
@@ -248,7 +248,7 @@ function webpackAsyncContext(req) {
 	var ids = map[req];
 	if(!ids) {
 		return Promise.resolve().then(function() {
-			var e = new Error('Cannot find module "' + req + '".');
+			var e = new Error("Cannot find module '" + req + "'");
 			e.code = 'MODULE_NOT_FOUND';
 			throw e;
 		});

--- a/examples/code-splitting-native-import-context-filter/README.md
+++ b/examples/code-splitting-native-import-context-filter/README.md
@@ -275,7 +275,7 @@ function webpackAsyncContext(req) {
 	var ids = map[req];
 	if(!ids) {
 		return Promise.resolve().then(function() {
-			var e = new Error('Cannot find module "' + req + '".');
+			var e = new Error("Cannot find module '" + req + "'");
 			e.code = 'MODULE_NOT_FOUND';
 			throw e;
 		});

--- a/examples/code-splitting-native-import-context/README.md
+++ b/examples/code-splitting-native-import-context/README.md
@@ -264,7 +264,7 @@ function webpackAsyncContext(req) {
 	var ids = map[req];
 	if(!ids) {
 		return Promise.resolve().then(function() {
-			var e = new Error('Cannot find module "' + req + '".');
+			var e = new Error("Cannot find module '" + req + "'");
 			e.code = 'MODULE_NOT_FOUND';
 			throw e;
 		});

--- a/examples/code-splitting-specify-chunk-name/README.md
+++ b/examples/code-splitting-specify-chunk-name/README.md
@@ -256,7 +256,7 @@ function webpackAsyncContext(req) {
 	var ids = map[req];
 	if(!ids) {
 		return Promise.resolve().then(function() {
-			var e = new Error('Cannot find module "' + req + '".');
+			var e = new Error("Cannot find module '" + req + "'");
 			e.code = 'MODULE_NOT_FOUND';
 			throw e;
 		});

--- a/examples/hybrid-routing/README.md
+++ b/examples/hybrid-routing/README.md
@@ -153,7 +153,7 @@ function webpackAsyncContext(req) {
 	var ids = map[req];
 	if(!ids) {
 		return Promise.resolve().then(function() {
-			var e = new Error('Cannot find module "' + req + '".');
+			var e = new Error("Cannot find module '" + req + "'");
 			e.code = 'MODULE_NOT_FOUND';
 			throw e;
 		});

--- a/examples/mixed/README.md
+++ b/examples/mixed/README.md
@@ -357,7 +357,7 @@ function webpackContext(req) {
 function webpackContextResolve(req) {
 	var id = map[req];
 	if(!(id + 1)) { // check for number or string
-		var e = new Error('Cannot find module "' + req + '".');
+		var e = new Error("Cannot find module '" + req + "'");
 		e.code = 'MODULE_NOT_FOUND';
 		throw e;
 	}

--- a/examples/require.context/README.md
+++ b/examples/require.context/README.md
@@ -143,7 +143,7 @@ function webpackContext(req) {
 function webpackContextResolve(req) {
 	var id = map[req];
 	if(!(id + 1)) { // check for number or string
-		var e = new Error('Cannot find module "' + req + '".');
+		var e = new Error("Cannot find module '" + req + "'");
 		e.code = 'MODULE_NOT_FOUND';
 		throw e;
 	}

--- a/examples/web-worker/README.md
+++ b/examples/web-worker/README.md
@@ -284,7 +284,7 @@ function webpackContext(req) {
 function webpackContextResolve(req) {
 	var id = map[req];
 	if(!(id + 1)) { // check for number or string
-		var e = new Error('Cannot find module "' + req + '".');
+		var e = new Error("Cannot find module '" + req + "'");
 		e.code = 'MODULE_NOT_FOUND';
 		throw e;
 	}

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -330,7 +330,7 @@ function webpackContext(req) {
 function webpackContextResolve(req) {
 	var id = map[req];
 	if(!(id + 1)) { // check for number or string
-		var e = new Error('Cannot find module "' + req + '".');
+		var e = new Error("Cannot find module '" + req + "'");
 		e.code = 'MODULE_NOT_FOUND';
 		throw e;
 	}
@@ -365,7 +365,7 @@ function webpackContext(req) {
 function webpackContextResolve(req) {
 	var id = map[req];
 	if(!(id + 1)) { // check for number or string
-		var e = new Error('Cannot find module "' + req + '".');
+		var e = new Error("Cannot find module '" + req + "'");
 		e.code = 'MODULE_NOT_FOUND';
 		throw e;
 	}
@@ -404,7 +404,7 @@ function webpackAsyncContextResolve(req) {
 	return Promise.resolve().then(function() {
 		var id = map[req];
 		if(!(id + 1)) { // check for number or string
-			var e = new Error('Cannot find module "' + req + '".');
+			var e = new Error("Cannot find module '" + req + "'");
 			e.code = 'MODULE_NOT_FOUND';
 			throw e;
 		}
@@ -441,7 +441,7 @@ function webpackAsyncContextResolve(req) {
 	return Promise.resolve().then(function() {
 		var id = map[req];
 		if(!(id + 1)) { // check for number or string
-			var e = new Error('Cannot find module "' + req + '".');
+			var e = new Error("Cannot find module '" + req + "'");
 			e.code = 'MODULE_NOT_FOUND';
 			throw e;
 		}
@@ -481,7 +481,7 @@ function webpackAsyncContextResolve(req) {
 	return ${promise}.then(function() {
 		var id = map[req];
 		if(!(id + 1)) { // check for number or string
-			var e = new Error('Cannot find module "' + req + '".');
+			var e = new Error("Cannot find module '" + req + "'");
 			e.code = 'MODULE_NOT_FOUND';
 			throw e;
 		}
@@ -540,7 +540,7 @@ function webpackAsyncContext(req) {
 	var ids = map[req];
 	if(!ids) {
 		return Promise.resolve().then(function() {
-			var e = new Error('Cannot find module "' + req + '".');
+			var e = new Error("Cannot find module '" + req + "'");
 			e.code = 'MODULE_NOT_FOUND';
 			throw e;
 		});
@@ -559,7 +559,7 @@ module.exports = webpackAsyncContext;`;
 
 	getSourceForEmptyContext(id) {
 		return `function webpackEmptyContext(req) {
-	var e = new Error('Cannot find module "' + req + '".');
+	var e = new Error("Cannot find module '" + req + "'");
 	e.code = 'MODULE_NOT_FOUND';
 	throw e;
 }
@@ -574,7 +574,7 @@ webpackEmptyContext.id = ${JSON.stringify(id)};`;
 	// Here Promise.resolve().then() is used instead of new Promise() to prevent
 	// uncaught exception popping up in devtools
 	return Promise.resolve().then(function() {
-		var e = new Error('Cannot find module "' + req + '".');
+		var e = new Error("Cannot find module '" + req + "'");
 		e.code = 'MODULE_NOT_FOUND';
 		throw e;
 	});

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -44,7 +44,7 @@ module.exports = class RuntimeTemplate {
 	}
 
 	throwMissingModuleErrorFunction({ request }) {
-		const err = `Cannot find module "${request}"`;
+		const err = `Cannot find module '${request}'`;
 		return `function webpackMissingModule() { var e = new Error(${JSON.stringify(
 			err
 		)}); e.code = 'MODULE_NOT_FOUND'; throw e; }`;

--- a/lib/dependencies/WebpackMissingModule.js
+++ b/lib/dependencies/WebpackMissingModule.js
@@ -10,11 +10,11 @@ exports.module = request =>
 	`!(function webpackMissingModule() { ${exports.moduleCode(request)} }())`;
 
 exports.promise = request => {
-	const errorCode = toErrorCode(`Cannot find module "${request}"`);
+	const errorCode = toErrorCode(`Cannot find module '${request}'`);
 	return `Promise.reject(function webpackMissingModule() { ${errorCode} return e; }())`;
 };
 
 exports.moduleCode = request => {
-	const errorCode = toErrorCode(`Cannot find module "${request}"`);
+	const errorCode = toErrorCode(`Cannot find module '${request}'`);
 	return `${errorCode} throw e;`;
 };

--- a/test/ExternalModule.unittest.js
+++ b/test/ExternalModule.unittest.js
@@ -171,7 +171,7 @@ describe("ExternalModule", () => {
 			// set up
 			const variableToCheck = "foo";
 			const request = "bar";
-			const expected = `if(typeof foo === 'undefined') {var e = new Error("Cannot find module \\"bar\\""); e.code = 'MODULE_NOT_FOUND'; throw e;}
+			const expected = `if(typeof foo === 'undefined') {var e = new Error("Cannot find module 'bar'"); e.code = 'MODULE_NOT_FOUND'; throw e;}
 `;
 
 			// invoke
@@ -207,7 +207,7 @@ describe("ExternalModule", () => {
 				// set up
 				const id = "someId";
 				const optional = true;
-				const expected = `if(typeof __WEBPACK_EXTERNAL_MODULE_someId__ === 'undefined') {var e = new Error("Cannot find module \\"some/request\\""); e.code = 'MODULE_NOT_FOUND'; throw e;}
+				const expected = `if(typeof __WEBPACK_EXTERNAL_MODULE_someId__ === 'undefined') {var e = new Error("Cannot find module 'some/request'"); e.code = 'MODULE_NOT_FOUND'; throw e;}
 module.exports = __WEBPACK_EXTERNAL_MODULE_someId__;`;
 
 				// invoke
@@ -239,7 +239,7 @@ module.exports = __WEBPACK_EXTERNAL_MODULE_someId__;`;
 			it("checks for the existence of the request setting it", () => {
 				// set up
 				const optional = true;
-				const expected = `if(typeof some/request === 'undefined') {var e = new Error("Cannot find module \\"some/request\\""); e.code = 'MODULE_NOT_FOUND'; throw e;}
+				const expected = `if(typeof some/request === 'undefined') {var e = new Error("Cannot find module 'some/request'"); e.code = 'MODULE_NOT_FOUND'; throw e;}
 module.exports = some/request;`;
 
 				// invoke

--- a/test/WebpackMissingModule.unittest.js
+++ b/test/WebpackMissingModule.unittest.js
@@ -8,7 +8,7 @@ describe("WebpackMissingModule", () => {
 		it("returns an error message based on given error message", () => {
 			const errorMessage = WebpackMissingModule.moduleCode("mock message");
 			expect(errorMessage).toBe(
-				'var e = new Error("Cannot find module \\"mock message\\""); e.code = \'MODULE_NOT_FOUND\'; throw e;'
+				"var e = new Error(\"Cannot find module 'mock message'\"); e.code = 'MODULE_NOT_FOUND'; throw e;"
 			);
 		});
 	});
@@ -17,7 +17,7 @@ describe("WebpackMissingModule", () => {
 		it("returns an error message based on given error message", () => {
 			const errorMessage = WebpackMissingModule.promise("mock message");
 			expect(errorMessage).toBe(
-				'Promise.reject(function webpackMissingModule() { var e = new Error("Cannot find module \\"mock message\\""); e.code = \'MODULE_NOT_FOUND\'; return e; }())'
+				"Promise.reject(function webpackMissingModule() { var e = new Error(\"Cannot find module 'mock message'\"); e.code = 'MODULE_NOT_FOUND'; return e; }())"
 			);
 		});
 	});
@@ -26,7 +26,7 @@ describe("WebpackMissingModule", () => {
 		it("returns an error message based on given error message", () => {
 			const errorMessage = WebpackMissingModule.module("mock message");
 			expect(errorMessage).toBe(
-				'!(function webpackMissingModule() { var e = new Error("Cannot find module \\"mock message\\""); e.code = \'MODULE_NOT_FOUND\'; throw e; }())'
+				"!(function webpackMissingModule() { var e = new Error(\"Cannot find module 'mock message'\"); e.code = 'MODULE_NOT_FOUND'; throw e; }())"
 			);
 		});
 	});

--- a/test/cases/parsing/issue-2641/index.js
+++ b/test/cases/parsing/issue-2641/index.js
@@ -11,7 +11,7 @@ it("should call error callback on missing module", function(done) {
 	require(['./file', './missingModule'], function(file){}, function(error) {
 		try {
 			expect(error).toBeInstanceOf(Error);
-			expect(error.message).toBe('Cannot find module "./missingModule"');
+			expect(error.message).toBe("Cannot find module './missingModule'");
 			done();
 		} catch(e) {
 			done(e);
@@ -24,7 +24,7 @@ it("should call error callback on missing module in context", function(done) {
 		require(['./' + module], function(file){}, function(error) {
 			try {
 				expect(error).toBeInstanceOf(Error);
-				expect(error.message).toBe("Cannot find module \"./missingModule\".");
+				expect(error.message).toBe("Cannot find module './missingModule'");
 				done();
 			} catch(e) { done(e); }
 		});

--- a/test/cases/parsing/issue-758/index.js
+++ b/test/cases/parsing/issue-758/index.js
@@ -13,7 +13,7 @@ it("should call error callback on missing module", function(done) {
 		require('./missingModule');
 	}, function(error) {
 		expect(error).toBeInstanceOf(Error);
-		expect(error.message).toBe('Cannot find module "./missingModule"');
+		expect(error.message).toBe("Cannot find module './missingModule'");
 		done();
 	});
 });
@@ -24,7 +24,7 @@ it("should call error callback on missing module in context", function(done) {
 			require('./' + module);
 		}, function(error) {
 			expect(error).toBeInstanceOf(Error);
-			expect(error.message).toBe("Cannot find module \"./missingModule\".");
+			expect(error.message).toBe("Cannot find module './missingModule'");
 			done();
 		});
 	})('missingModule');

--- a/test/configCases/context-exclusion/simple/index.js
+++ b/test/configCases/context-exclusion/simple/index.js
@@ -9,9 +9,9 @@ it("should not exclude paths not matching the exclusion pattern", function() {
 });
 
 it("should exclude paths/files matching the exclusion pattern", function() {
-		expect(() => requireInContext("dont")).toThrowError(/Cannot find module ".\/dont"/);
+		expect(() => requireInContext("dont")).toThrowError(/Cannot find module '.\/dont'/);
 
-		expect(() => requireInContext("dont-check-here/file")).toThrowError(/Cannot find module ".\/dont-check-here\/file"/);
+		expect(() => requireInContext("dont-check-here/file")).toThrowError(/Cannot find module '.\/dont-check-here\/file'/);
 
-		expect(() => requireInContext("check-here/dont-check-here/file")).toThrowError(/Cannot find module ".\/check-here\/dont-check-here\/file"/);
+		expect(() => requireInContext("check-here/dont-check-here/file")).toThrowError(/Cannot find module '.\/check-here\/dont-check-here\/file'/);
 });

--- a/test/configCases/errors/multi-entry-missing-module/index.js
+++ b/test/configCases/errors/multi-entry-missing-module/index.js
@@ -2,9 +2,9 @@ it("Should use WebpackMissingModule when module is missing with multiple entry s
   var fs = require("fs");
   var path = require("path");
   var source = fs.readFileSync(path.join(__dirname, "b.js"), "utf-8");
-  expect(source).toMatch("!(function webpackMissingModule() { var e = new Error(\"Cannot find module \\\"./intentionally-missing-module.js\\\"\"); e.code = 'MODULE_NOT_FOUND'; throw e; }());");
+  expect(source).toMatch("!(function webpackMissingModule() { var e = new Error(\"Cannot find module './intentionally-missing-module.js'\"); e.code = 'MODULE_NOT_FOUND'; throw e; }());");
 
   expect(function() {
     require("./intentionally-missing-module");
-  }).toThrowError("Cannot find module \"./intentionally-missing-module\"");
+  }).toThrowError("Cannot find module './intentionally-missing-module'");
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix/refactor

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

I made relevant changes to the existing tests already testing this.
<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

N/a
<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

The `Cannot find module` error message coming from `require` is not consistent across this project, and it unnecessarily doesn't match NodeJS' message. I have tested NodeJS 4, 6, 8, and 9 and all gave the message `Cannot find module 'module-name'`, while webpack (in *some* locations) gives `Cannot find module "module-name".` (with double quotes and a period). This makes it hard to recognize the missing module from the error, especially for a dependency (that doesn't know if the code is getting webpacked).

Solves #7238 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

If someone is looking for webpack's message in the error, this check will fail.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
