### PR TITLE
Allow use to specify ident

### DIFF
--- a/lib/RuleSet.js
+++ b/lib/RuleSet.js
@@ -373,7 +373,8 @@ module.exports = class RuleSet {
 		newItem.options = item.options || item.query;
 
 		if (typeof newItem.options === "object" && newItem.options) {
-			if (newItem.options.ident) newItem.ident = newItem.options.ident;
+			if (item.ident) newItem.ident = item.ident;
+			else if (newItem.options.ident) newItem.ident = newItem.options.ident;
 			else newItem.ident = ident;
 		}
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

In `vue-loader` 15's new architecture we are cloning user rules and applying them to the language blocks inside a Vue single file component. One side effect of this is by default any cloned Uses with options will get a different ident. This results in a subtle edge case where if a user imports the same CSS file from within a Vue SFC and a JS file, the request strings generated by `css-loader` will be different due to the different idents in the loader chain. So the same CSS file gets duplicated in the final bundle.

We are currently working around this by explicitly setting the same ident for clone Uses via `options.ident`. However, some loaders (e.g. `style-loader`, `babel-loader`, `ts-loader`) perform options validation that does not allow additional properties - which means `options.ident` will causes these loaders to error out. This essentially means there's no reliable way to explicitly set `ident` for arbitrary uses, it has to depend on whether the loader allows it, which is not ideal.

For `vue-loader`, the ideal case is that all cloned rules **should** use the same ident with the original so that they are using the exact same options object. But due to the problems described we can currently only clone the ident on a whitelist of loaders.

This PR proposes that we allow `ident` to be placed on the Use itself directly, which solves the problem and also seem to be the more reasonable place to put it rather than tucking it inside loader options.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Feature

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Not yet, but can add if feature is accepted.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

Probably not since `ident` isn't a documented feature.

EDIT @sokra: This need to be added to the configuration page.