### PR TITLE
Allow serve property in webpack configuration

### DIFF
--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1679,6 +1679,10 @@
         }
       ]
     },
+    "serve": {
+      "description": "Options for webpack-serve",
+      "type": "object"
+    },
     "stats": {
       "description": "Used by the webpack CLI program to pass stats options.",
       "anyOf": [

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -199,7 +199,7 @@ describe("Validation", () => {
 				" - configuration has an unknown property 'postcss'. These properties are valid:",
 				"   object { mode?, amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, externals?, " +
 					"loader?, module?, name?, node?, output?, optimization?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, " +
-					"recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, stats?, target?, watch?, watchOptions? }",
+					"recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, serve?, stats?, target?, watch?, watchOptions? }",
 				"   For typos: please correct them.",
 				"   For loader options: webpack >= v2.0.0 no longer allows custom properties in configuration.",
 				"     Loaders should be updated to allow passing options via loader options in module.rules.",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Allow to specify `serve` property in webpack configurations. This is used to configure [webpack-serve](https://github.com/webpack-contrib/webpack-serve).

Fixes #7306 


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

No, adapted tests.

**Does this PR introduce a breaking change?**

No, but a new config options is available

**What needs to be documented once your changes are merged?**

The `serve` property should be listed under https://webpack.js.org/configuration/ and documented there.
