### PR TITLE
Add a test to check typeof transformation

### DIFF
--- a/test/cases/parsing/issue-7318/index.js
+++ b/test/cases/parsing/issue-7318/index.js
@@ -1,0 +1,5 @@
+const type = require("./typeof");
+
+it("should not output invalid code", () => {
+	expect(type).toBe("number");
+});

--- a/test/cases/parsing/issue-7318/typeof.js
+++ b/test/cases/parsing/issue-7318/typeof.js
@@ -1,0 +1,2 @@
+typeof 1
+module.exports = "number"


### PR DESCRIPTION
Add a test to ensure that `typeof` without semicolon does not output invalid code:

```js
typeof 1
module.exports = 2
```

I cannot reproduce the issue on webpack 3 or webpack 4.

Fix #7318 

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

tests

**Did you add tests for your changes?**

yes

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

n/a