### PR TITLE
Add result for dynamic entry

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -236,6 +236,7 @@ class Compilation extends Tapable {
 
 		this.semaphore = new Semaphore(options.parallelism || 100);
 
+		this.entry = options.entry;
 		this.entries = [];
 		this._preparedEntrypoints = [];
 		this.entrypoints = new Map();
@@ -758,6 +759,10 @@ class Compilation extends Tapable {
 				return callback(null, module);
 			}
 		);
+	}
+
+	updateEntry(entry) {
+		this.entry = entry;
 	}
 
 	prefetch(context, dependency, callback) {

--- a/lib/DynamicEntryPlugin.js
+++ b/lib/DynamicEntryPlugin.js
@@ -47,6 +47,7 @@ class DynamicEntryPlugin {
 				};
 
 				Promise.resolve(this.entry()).then(entry => {
+					compilation.updateEntry(entry);
 					if (typeof entry === "string" || Array.isArray(entry)) {
 						addEntry(entry, "main").then(() => callback(), callback);
 					} else if (typeof entry === "object") {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

feature

**Summary**

Sometimes we need use the `entryObj` to do somethings but dynamic entry can't easily achieve.
Now you can get the `entryObj` through `compilation.entry`.

**Does this PR introduce a breaking change?**

No