### PR TITLE
Improve JSON parse error

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -4,6 +4,7 @@
 */
 "use strict";
 
+const parseJson = require("json-parse-better-errors");
 const asyncLib = require("neo-async");
 const path = require("path");
 const util = require("util");
@@ -350,7 +351,7 @@ class Compiler extends Tapable {
 				if (err) return callback(err);
 
 				try {
-					this.records = JSON.parse(content.toString("utf-8"));
+					this.records = parseJson(content.toString("utf-8"));
 				} catch (e) {
 					e.message = "Cannot parse records: " + e.message;
 					return callback(e);

--- a/lib/DllReferencePlugin.js
+++ b/lib/DllReferencePlugin.js
@@ -4,6 +4,7 @@
 */
 "use strict";
 
+const parseJson = require("json-parse-better-errors");
 const DelegatedSourceDependency = require("./dependencies/DelegatedSourceDependency");
 const DelegatedModuleFactoryPlugin = require("./DelegatedModuleFactoryPlugin");
 const ExternalModuleFactoryPlugin = require("./ExternalModuleFactoryPlugin");
@@ -42,7 +43,7 @@ class DllReferencePlugin {
 					params.compilationDependencies.add(manifest);
 					compiler.inputFileSystem.readFile(manifest, (err, result) => {
 						if (err) return callback(err);
-						params["dll reference " + manifest] = JSON.parse(
+						params["dll reference " + manifest] = parseJson(
 							result.toString("utf-8")
 						);
 						return callback();

--- a/lib/JsonParser.js
+++ b/lib/JsonParser.js
@@ -4,6 +4,7 @@
 */
 "use strict";
 
+const parseJson = require("json-parse-better-errors");
 const JsonExportsDependency = require("./dependencies/JsonExportsDependency");
 
 class JsonParser {
@@ -12,7 +13,7 @@ class JsonParser {
 	}
 
 	parse(source, state) {
-		const data = JSON.parse(source);
+		const data = parseJson(source);
 		state.module.buildInfo.jsonData = data;
 		state.module.buildMeta.exportsType = "named";
 		if (typeof data === "object" && data)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "chrome-trace-event": "^0.1.1",
     "enhanced-resolve": "^4.0.0",
     "eslint-scope": "^3.7.1",
+    "json-parse-better-errors": "^1.0.2",
     "loader-runner": "^2.3.0",
     "loader-utils": "^1.1.0",
     "memory-fs": "~0.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3538,6 +3538,10 @@ json-loader@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
 
+json-parse-better-errors@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"


### PR DESCRIPTION
Use [`json-parse-better-errors`](https://github.com/zkat/json-parse-better-errors) to parse JSON files. This package enhances the `SyntaxError` to provide friendlier error messages.

Fix #7297

**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

nothing
