### PR TITLE
Use a WeakMap instead of mutating objects in NMF

### DIFF
--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -46,6 +46,8 @@ const identToLoaderRequest = resultString => {
 	}
 };
 
+const dependencyCache = new WeakMap();
+
 class NormalModuleFactory extends Tapable {
 	constructor(context, resolverFactory, options) {
 		super();
@@ -329,7 +331,7 @@ class NormalModuleFactory extends Tapable {
 
 	create(data, callback) {
 		const dependencies = data.dependencies;
-		const cacheEntry = dependencies[0].__NormalModuleFactoryCache;
+		const cacheEntry = dependencyCache.get(dependencies[0]);
 		if (cacheEntry) return callback(null, cacheEntry);
 		const context = data.context || this.context;
 		const resolveOptions = data.resolveOptions || EMPTY_RESOLVE_OPTIONS;
@@ -359,7 +361,7 @@ class NormalModuleFactory extends Tapable {
 
 					if (module && this.cachePredicate(module)) {
 						for (const d of dependencies) {
-							d.__NormalModuleFactoryCache = module;
+							dependencyCache.set(d, module);
 						}
 					}
 


### PR DESCRIPTION
`NormalModuleFactory` was mutating dependency objects if the `unsafeCache` option was set. This PR uses a `WeakMap` to cache dependencies and avoid the mutation (and de-opt).

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

nothing