### PR TITLE
Use WeakMaps instead of mutating assets in SourceMapDevToolPlugin

### DIFF
--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -18,12 +18,14 @@ const basename = name => {
 	return name.substr(name.lastIndexOf("/") + 1);
 };
 
+const assetsCache = new WeakMap();
+
 const getTaskForFile = (file, chunk, options, compilation) => {
 	const asset = compilation.assets[file];
-	if (asset.__SourceMapDevToolFile === file && asset.__SourceMapDevToolData) {
-		const data = asset.__SourceMapDevToolData;
-		for (const cachedFile in data) {
-			compilation.assets[cachedFile] = data[cachedFile];
+	const cache = assetsCache.get(asset);
+	if (cache && cache.file === file) {
+		for (const cachedFile in cache.assets) {
+			compilation.assets[cachedFile] = cache.assets[cachedFile];
 			if (cachedFile !== file) chunk.files.push(cachedFile);
 		}
 		return;
@@ -207,6 +209,7 @@ class SourceMapDevToolPlugin {
 							task.file,
 							"attach SourceMap"
 						);
+						const assets = Object.create(null);
 						const chunk = task.chunk;
 						const file = task.file;
 						const asset = task.asset;
@@ -222,8 +225,7 @@ class SourceMapDevToolPlugin {
 						}
 						sourceMap.sourceRoot = options.sourceRoot || "";
 						sourceMap.file = file;
-						asset.__SourceMapDevToolFile = file;
-						asset.__SourceMapDevToolData = {};
+						assetsCache.set(asset, { file, assets });
 						let currentSourceMappingURLComment = sourceMappingURLComment;
 						if (
 							currentSourceMappingURLComment !== false &&
@@ -260,9 +262,7 @@ class SourceMapDevToolPlugin {
 										.relative(path.dirname(file), sourceMapFile)
 										.replace(/\\/g, "/");
 							if (currentSourceMappingURLComment !== false) {
-								asset.__SourceMapDevToolData[file] = compilation.assets[
-									file
-								] = new ConcatSource(
+								assets[file] = compilation.assets[file] = new ConcatSource(
 									new RawSource(source),
 									currentSourceMappingURLComment.replace(
 										/\[url\]/g,
@@ -270,14 +270,12 @@ class SourceMapDevToolPlugin {
 									)
 								);
 							}
-							asset.__SourceMapDevToolData[sourceMapFile] = compilation.assets[
+							assets[sourceMapFile] = compilation.assets[
 								sourceMapFile
 							] = new RawSource(sourceMapString);
 							chunk.files.push(sourceMapFile);
 						} else {
-							asset.__SourceMapDevToolData[file] = compilation.assets[
-								file
-							] = new ConcatSource(
+							assets[file] = compilation.assets[file] = new ConcatSource(
 								new RawSource(source),
 								currentSourceMappingURLComment
 									.replace(/\[map\]/g, () => sourceMapString)


### PR DESCRIPTION
`SourceMapDevToolPlugin` was mutating asset objects. This PR uses `WeakMap` to cache source map data and avoid the mutations (and de-opt).

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

nothing
