### PR TITLE
Allow afterEmit plugins to use `reportProgress`

### DIFF
--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -222,6 +222,21 @@ class ProgressPlugin {
 					handler(0.95, "emitting", tap.name);
 				}
 			});
+			compiler.hooks.afterEmit.intercept({
+				name: "ProgressPlugin",
+				context: true,
+				call: () => {
+					handler(0.98, "after emitting");
+				},
+				tap: (context, tap) => {
+					if (context) {
+						context.reportProgress = (p, ...args) => {
+							handler(0.98, "after emitting", tap.name, ...args);
+						};
+					}
+					handler(0.98, "after emitting", tap.name);
+				}
+			});
 			compiler.hooks.done.tap("ProgressPlugin", () => {
 				handler(1, "");
 			});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

With this change, plugins which tap into the `afterEmit` hook can use the context function `reportProgress` to show their progress. This is useful for plugins like cdn-upload-webpack-plugin, which will be able to report its progress, e.g.

```
 98% CdnUploadPlugin …: creating Azure blob container 'files'
 98% CdnUploadPlugin …ting blobs under 'files/my/test/folder'
 98% CdnUploadPlugin upload: found 2 blobs
 98% CdnUploadPlugin …ting 2 blobs under files/my/test/folder
 98% CdnUploadPlugin … (1/2) 'files/my/test/folder/bundle.js'
 98% CdnUploadPlugin …(2/2) 'files/my/test/folder/index.html'
 98% CdnUploadPlugin upload: uploaded 2 assets
 98% CdnUploadPlugin upload: pruned 0 extraneous assets
```

https://github.com/elliottsj/cdn-upload-webpack-plugin/blob/09ffeae20345d451895234e10d07df26dcb8a04d/src/storage/azure.ts#L529-L544

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Feature: an additional hook supporting the `reportProgress` function in ProgressPlugin.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No. With the [existing test suite for ProgressPlugin](https://github.com/webpack/webpack/blob/4f4a2bae33fa1f8b1954aa0bbfd5b9e3bef95cf8/test/ProgressPlugin.test.js), I'm not sure of the best way to test this change. Suggestions here are welcome!

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

Usage is as described by @ooflorent here: https://github.com/webpack/webpack/pull/6329#issuecomment-358244631

I couldn't find any documentation on https://webpack.js.org/ about usage of the existing `reportProgress` function.
