### PR TITLE
Add a test case about nodeEnv

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -294,11 +294,10 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 				}
 			}
 		]);
-		this.set(
-			"optimization.nodeEnv",
-			"make",
-			options => options.mode || "production"
-		);
+		this.set("optimization.nodeEnv", "make", options => {
+			// TODO: In webpack 5, it should return `false` when mode is `none`
+			return options.mode || "production";
+		});
 
 		this.set("resolve", "call", value => Object.assign({}, value));
 		this.set("resolve.unsafeCache", true);

--- a/test/configCases/issues/issue-7470/index.js
+++ b/test/configCases/issues/issue-7470/index.js
@@ -1,0 +1,3 @@
+it("should set NODE_ENV according to mode", () => {
+	expect(process.env.NODE_ENV).toBe(__MODE__);
+});

--- a/test/configCases/issues/issue-7470/webpack.config.js
+++ b/test/configCases/issues/issue-7470/webpack.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const DefinePlugin = require("../../../../lib/DefinePlugin");
+
+module.exports = [
+	{
+		name: "development",
+		mode: "development",
+		plugins: [new DefinePlugin({ __MODE__: `"development"` })]
+	},
+	{
+		name: "production",
+		mode: "production",
+		plugins: [new DefinePlugin({ __MODE__: `"production"` })]
+	},
+	{
+		name: "none",
+		mode: "none",
+		plugins: [new DefinePlugin({ __MODE__: `"none"` })]
+	}
+];


### PR DESCRIPTION
When `mode` is set to `none`, `process.env.NODE_ENV` is also set to `none` which could be confusing (see #7470). Changing this behavior would be a breaking change.

This PR adds a `TODO` note and test cases to document the future change.

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

yes

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

nothing