### PR TITLE
Fix template tag syntax

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -69,7 +69,7 @@ const getModulesIdent = set => {
 };
 
 /**
- * @template {T}
+ * @template T
  * @param {Set<T>} set the set to convert to array
  * @returns {Array<T>} the array returned from Array.from(set)
  */

--- a/lib/ChunkGroup.js
+++ b/lib/ChunkGroup.js
@@ -18,7 +18,7 @@ const compareLocations = require("./compareLocations");
 let debugId = 5000;
 
 /**
- * @template {T}
+ * @template T
  * @param {Set<T>} set set to convert to array.
  * @returns {T[]} the array format of existing set
  */


### PR DESCRIPTION
In Typescript 2.9 and earlier, Typescript allowed braces around the name introduced by the `@template` tag, even though this syntax is non-standard. In 3.0, Typescript introduces a more complex `@template` syntax that uses braces for specifying the constraint of a type parameter:

```js
/**
 * @template {Constraint} T -- By analogy with param syntax:
 * @param {T} name
 */
function f(name) { ... }
```

That means that the syntax `/** @template {T} */` will be illegal because it specifies the template's constraint but not the type parameter name. This PR fixes the uses of the `@template` tag ahead of Typescript 3.0 (as well as typescript@next as of June 5).