### PR TITLE
Ensure `require` is truthy

### DIFF
--- a/test/cases/parsing/issue-5889/index.js
+++ b/test/cases/parsing/issue-5889/index.js
@@ -1,0 +1,5 @@
+const result = require("./module");
+
+it("should correctly replace 'require' bindings", () => {
+	expect(result).toBe(true);
+});

--- a/test/cases/parsing/issue-5889/module.js
+++ b/test/cases/parsing/issue-5889/module.js
@@ -1,0 +1,6 @@
+let result = false;
+if (require) {
+  result = true;
+}
+
+module.exports = result;


### PR DESCRIPTION
Add a test case to validate `require` truthiness. This PR only adds a test to ensure that #5889 is no longer an issue.

Fixes #5889
Fixes #5209

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

yes

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

nothing