### PR TITLE
require() webpack-cli/webpack-command's bin module

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -47,6 +47,7 @@ const isInstalled = packageName => {
  * @typedef {Object} CliOption
  * @property {string} name display name
  * @property {string} package npm package name
+ * @property {string} binName name of the executable file
  * @property {string} alias shortcut for choice
  * @property {boolean} installed currently installed?
  * @property {string} url homepage
@@ -58,6 +59,7 @@ const CLIs = [
 	{
 		name: "webpack-cli",
 		package: "webpack-cli",
+		binName: "webpack-cli",
 		alias: "cli",
 		installed: isInstalled("webpack-cli"),
 		url: "https://github.com/webpack/webpack-cli",
@@ -66,6 +68,7 @@ const CLIs = [
 	{
 		name: "webpack-command",
 		package: "webpack-command",
+		binName: "webpack-command",
 		alias: "command",
 		installed: isInstalled("webpack-command"),
 		url: "https://github.com/webpack-contrib/webpack-command",
@@ -154,7 +157,10 @@ if (installedClis.length === 0) {
 			});
 	});
 } else if (installedClis.length === 1) {
-	require(installedClis[0].package); // eslint-disable-line
+	const path = require("path");
+	const pkgPath = require.resolve(`${installedClis[0].package}/package.json`);
+	const pkg = require(pkgPath); // eslint-disable-line
+	require(path.resolve(path.dirname(pkgPath), pkg.bin[installedClis[0].binName])); // eslint-disable-line
 } else {
 	console.warn(
 		`You have installed ${installedClis


### PR DESCRIPTION
Rather than require()-ing the "main" module in webpack-cli/
webpack-command, require() the "bin" module.

This avoids the issue described in
https://github.com/webpack-contrib/webpack-command/pull/30
where installing packages in this order results in no output from
./node_modules/.bin/webpack:

    $ npm install webpack-command
    $ npm install webpack
    $ ./node_modules/.bin/webpack
    # exit 0 with no output

~~Note: the [read-package-json](https://github.com/npm/read-package-json) package is by npm, and helps to normalize the shape of the `pkg.bin` object (since the [`"bin"` field in package.json](https://docs.npmjs.com/files/package.json#bin) can be either a string or an object).~~

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Bug fix

**Did you add tests for your changes?**

No. I could not find an existing test suite for the CLI. Welcome to suggestions here.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

Nothing.