### PR TITLE
Implement all path variables for webworker dynamic imports

### DIFF
--- a/lib/webworker/WebWorkerMainTemplatePlugin.js
+++ b/lib/webworker/WebWorkerMainTemplatePlugin.js
@@ -54,6 +54,20 @@ class WebWorkerMainTemplatePlugin {
 										)} + "`,
 									chunk: {
 										id: '" + chunkId + "',
+										hash: `" + ${JSON.stringify(chunkMaps.hash)}[chunkId] + "`,
+										hashWithLength(length) {
+											const shortChunkHashMap = Object.create(null);
+											for (const chunkId of Object.keys(chunkMaps.hash)) {
+												if (typeof chunkMaps.hash[chunkId] === "string") {
+													shortChunkHashMap[chunkId] = chunkMaps.hash[
+														chunkId
+													].substr(0, length);
+												}
+											}
+											return `" + ${JSON.stringify(
+												shortChunkHashMap
+											)}[chunkId] + "`;
+										},
 										contentHash: {
 											javascript: `" + ${JSON.stringify(
 												chunkMaps.contentHash.javascript
@@ -74,7 +88,10 @@ class WebWorkerMainTemplatePlugin {
 													shortContentHashMap
 												)}[chunkId] + "`;
 											}
-										}
+										},
+										name: `" + (${JSON.stringify(
+											chunkMaps.name
+										)}[chunkId]||chunkId) + "`
 									},
 									contentHashType: "javascript"
 								}) +

--- a/test/configCases/issues/issue-7563/index.js
+++ b/test/configCases/issues/issue-7563/index.js
@@ -1,0 +1,3 @@
+it("should compile without error", function() {
+	return import(/* webpackChunkName: "one" */ "./one");
+});

--- a/test/configCases/issues/issue-7563/one.js
+++ b/test/configCases/issues/issue-7563/one.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/test/configCases/issues/issue-7563/test.config.js
+++ b/test/configCases/issues/issue-7563/test.config.js
@@ -1,0 +1,22 @@
+var fs = require('fs');
+
+module.exports = {
+	noTests: true,
+	findBundle: function(i, options) {
+		var regex = new RegExp("^bundle\." + options.name, "i");
+		var files = fs.readdirSync(options.output.path);
+		var bundle = files.find(function (file) {
+			return regex.test(file);
+		});
+
+		if (!bundle) {
+			throw new Error(
+				`No file found with correct name (regex: ${
+					regex.source
+				}, files: ${files.join(", ")})`
+			);
+		}
+
+		return "./" + bundle;
+	}
+};

--- a/test/configCases/issues/issue-7563/webpack.config.js
+++ b/test/configCases/issues/issue-7563/webpack.config.js
@@ -1,0 +1,65 @@
+"use strict";
+
+// Have to test [hash] and [chunkhash] separately to avoid
+// "Cannot use [chunkhash] or [contenthash] for chunk in 'bundle1.[hash].[hash:16].[chunkhash].[chunkhash:16].[name].[id].[query].js' (use [hash] instead)"
+var testAllButHash = "[chunkhash].[chunkhash:16].[name].[id].[query]";
+var testHash = "[hash].[hash:16]";
+
+module.exports = [
+	{
+		name: "webworker-all",
+		target: "webworker",
+		output: {
+			filename: "bundle.webworker-all." + testAllButHash + ".js"
+		}
+	},
+	{
+		name: "webworker-hash",
+		target: "webworker",
+		output: {
+			filename: "bundle.webworker-hash." + testHash + ".js"
+		}
+	},
+	{
+		name: "node-all",
+		target: "node",
+		output: {
+			filename: "bundle.node-all." + testAllButHash + ".js"
+		}
+	},
+	{
+		name: "node",
+		target: "node",
+		output: {
+			filename: "bundle.node-hash." + testHash + ".js"
+		}
+	},
+	{
+		name: "async-node-all",
+		target: "async-node",
+		output: {
+			filename: "bundle.async-node-all." + testAllButHash + ".js"
+		}
+	},
+	{
+		name: "async-node-hash",
+		target: "async-node",
+		output: {
+			filename: "bundle.async-node-hash." + testHash + ".js"
+		}
+	},
+	{
+		name: "web-all",
+		target: "web",
+		output: {
+			filename: "bundle.web-all." + testAllButHash + ".js"
+		}
+	},
+	{
+		name: "web-hash",
+		target: "web",
+		output: {
+			filename: "bundle.web-hash." + testHash + ".js"
+		}
+	}
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Previously, not all path variables were implemented when doing dynamic imports and targeting webworker. See #7563.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

A bugfix. WebWorkerMainTemplatePlugin.js was missing some required chunk attributes.

**Did you add tests for your changes?**
 
<!-- Note that we won't merge your changes if you don't add tests -->

Yes. Though I do have questions about the test framework. I'll post those as a separate comment.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. Prior to this commit, unsupported path variables would either throw at compile time or produce unexpected import paths at runtime.

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

No new documentation needed.