### PR TITLE
Remove dead links from /examples README.md.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -15,12 +15,6 @@
 
 [code-splitting-specify-chunk-name](code-splitting-specify-chunk-name)
 
-[move-to-parent](move-to-parent)
-
-[multiple-commons-chunks](multiple-commons-chunks)
-
-[multiple-entry-points-commons-chunk-css-bundle](multiple-entry-points-commons-chunk-css-bundle)
-
 [named-chunks](named-chunks) example demonstrating merging of chunks with named chunks
 
 [two-explicit-vendor-chunks](two-explicit-vendor-chunks)
@@ -48,11 +42,6 @@
 
 ## CommonJS
 [commonjs](commonjs) example demonstrating a very simple program
-
-## Css Bundle
-[css-bundle](css-bundle)
-
-[multiple-entry-points-commons-chunk-css-bundle](multiple-entry-points-commons-chunk-css-bundle)
 
 ## DLL
 [dll](dll)


### PR DESCRIPTION
**Motivation:**
* Examples documentation is outdated.
* There was an attempt(#7398) to resolve this issue(#7222) by @UiCandy but things seem to have gotten stale due to his inactivity.
* Additionally it seems that @UiCandy overlooked [few other dead links](https://github.com/webpack/webpack/tree/master/examples#css-bundle) (Css Bundle Section links).

**What kind of change does this PR introduce?**
Docs change only.

**Did you add tests for your changes?**
No tests since these are purely docs changes.

**Does this PR introduce a breaking change?**
No.

**What needs to be documented once your changes are merged?**
Nothing.