### PR TITLE
Try to type ContextExclusionPlugin

### DIFF
--- a/lib/ContextExclusionPlugin.js
+++ b/lib/ContextExclusionPlugin.js
@@ -1,13 +1,28 @@
 "use strict";
 
+/** @typedef {import("./Compiler")} Compiler */
+/** @typedef {import("./ContextModuleFactory")} ContextModuleFactory */
+
 class ContextExclusionPlugin {
+	/**
+	 * @param {RegExp} negativeMatcher Matcher regular expression
+	 */
 	constructor(negativeMatcher) {
 		this.negativeMatcher = negativeMatcher;
 	}
 
+	/**
+	 * Apply the plugin
+	 * @param {Compiler} compiler Webpack Compiler
+	 * @returns {void}
+	 */
 	apply(compiler) {
-		compiler.hooks.contextModuleFactory.tap("ContextExclusionPlugin", cmf => {
-			cmf.hooks.contextModuleFiles.tap("ContextExclusionPlugin", files => {
+		compiler.hooks.contextModuleFactory.tap("ContextExclusionPlugin", (
+			/** @type {ContextModuleFactory} */ cmf
+		) => {
+			cmf.hooks.contextModuleFiles.tap("ContextExclusionPlugin", (
+				/** @type {TODO} */ files
+			) => {
 				return files.filter(filePath => !this.negativeMatcher.test(filePath));
 			});
 		});


### PR DESCRIPTION
@sandersn @sokra 

We need to have a way of typing compiler hooks so we don't have to declare the types again when hooking into various compiler events. Do you have any suggestions? 