### PR TITLE
Fix race condition in profiling plugin.

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -130,7 +130,14 @@ function createTrace(outputPath) {
 		trace,
 		counter,
 		profiler,
-		end: callback => fsStream.end(callback)
+		end: callback => {
+			// Wait until the write stream finishes.
+			fsStream.on("finish", () => {
+				callback();
+			});
+			// Tear down the readable trace stream.
+			trace.destroy();
+		}
 	};
 }
 


### PR DESCRIPTION
Based on some digging in this git history for the profiling plugin it looks like this commit exacerbated the issue:
883088e

Note, we are calling end() and then writeStream right after we call flush on the trace object
https://github.com/samccone/chrome-trace-event/blob/64b514e9bd364ca5b6df3c0fb121ba0d3b239cc2/lib/trace-event.ts#L123

The trace object is only calling _push to the writable stream but in no way ensuring that all data that has been pushed has actually been written to the output stream sooo we find ourselves encounter 🐎 [race] conditions.

Fixes #7450

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

no
**What needs to be documented once your changes are merged?**

nothing