### PR TITLE
Remove Tapable compatibility

### DIFF
--- a/lib/ChunkTemplate.js
+++ b/lib/ChunkTemplate.js
@@ -4,7 +4,7 @@
 */
 "use strict";
 
-const { Tapable, SyncWaterfallHook, SyncHook } = require("tapable");
+const { SyncWaterfallHook, SyncHook } = require("tapable");
 
 /** @typedef {import("./ModuleTemplate")} ModuleTemplate */
 /** @typedef {import("./Chunk")} Chunk */
@@ -21,9 +21,8 @@ const { Tapable, SyncWaterfallHook, SyncHook } = require("tapable");
  * @property {Map<TODO, TODO>} dependencyTemplates
  */
 
-module.exports = class ChunkTemplate extends Tapable {
+module.exports = class ChunkTemplate {
 	constructor(outputOptions) {
-		super();
 		this.outputOptions = outputOptions || {};
 		this.hooks = {
 			renderManifest: new SyncWaterfallHook(["result", "options"]),

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -8,7 +8,6 @@ const asyncLib = require("neo-async");
 const util = require("util");
 const { CachedSource } = require("webpack-sources");
 const {
-	Tapable,
 	SyncHook,
 	SyncBailHook,
 	SyncWaterfallHook,
@@ -95,9 +94,8 @@ function addAllToSet(set, otherSet) {
 	}
 }
 
-class Compilation extends Tapable {
+class Compilation {
 	constructor(compiler) {
-		super();
 		this.hooks = {
 			buildModule: new SyncHook(["module"]),
 			rebuildModule: new SyncHook(["module"]),
@@ -197,17 +195,7 @@ class Compilation extends Tapable {
 			optimizeExtractedChunksAdvanced: new SyncBailHook(["chunks"]),
 			afterOptimizeExtractedChunks: new SyncHook(["chunks"])
 		};
-		this._pluginCompat.tap("Compilation", options => {
-			switch (options.name) {
-				case "optimize-tree":
-				case "additional-assets":
-				case "optimize-chunk-assets":
-				case "optimize-assets":
-				case "after-seal":
-					options.async = true;
-					break;
-			}
-		});
+
 		this.name = undefined;
 		this.compiler = compiler;
 		this.resolverFactory = compiler.resolverFactory;

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -9,7 +9,6 @@ const asyncLib = require("neo-async");
 const path = require("path");
 const util = require("util");
 const {
-	Tapable,
 	SyncHook,
 	SyncBailHook,
 	AsyncParallelHook,
@@ -27,9 +26,8 @@ const RequestShortener = require("./RequestShortener");
 const { makePathsRelative } = require("./util/identifier");
 const ConcurrentCompilationError = require("./ConcurrentCompilationError");
 
-class Compiler extends Tapable {
+class Compiler {
 	constructor(context) {
-		super();
 		this.hooks = {
 			shouldEmit: new SyncBailHook(["compilation"]),
 			done: new AsyncSeriesHook(["stats"]),
@@ -59,21 +57,6 @@ class Compiler extends Tapable {
 			afterResolvers: new SyncHook(["compiler"]),
 			entryOption: new SyncBailHook(["context", "entry"])
 		};
-		this._pluginCompat.tap("Compiler", options => {
-			switch (options.name) {
-				case "additional-pass":
-				case "before-run":
-				case "run":
-				case "emit":
-				case "after-emit":
-				case "before-compile":
-				case "make":
-				case "after-compile":
-				case "watch-run":
-					options.async = true;
-					break;
-			}
-		});
 
 		this.name = undefined;
 		this.parentCompilation = undefined;
@@ -89,46 +72,6 @@ class Compiler extends Tapable {
 		this.contextTimestamps = new Map();
 
 		this.resolverFactory = new ResolverFactory();
-
-		// TODO remove in webpack 5
-		this.resolvers = {
-			normal: {
-				plugins: util.deprecate((hook, fn) => {
-					this.resolverFactory.plugin("resolver normal", resolver => {
-						resolver.plugin(hook, fn);
-					});
-				}, "webpack: Using compiler.resolvers.normal is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver normal", resolver => {\n  resolver.plugin(/* … */);\n}); instead.'),
-				apply: util.deprecate((...args) => {
-					this.resolverFactory.plugin("resolver normal", resolver => {
-						resolver.apply(...args);
-					});
-				}, "webpack: Using compiler.resolvers.normal is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver normal", resolver => {\n  resolver.apply(/* … */);\n}); instead.')
-			},
-			loader: {
-				plugins: util.deprecate((hook, fn) => {
-					this.resolverFactory.plugin("resolver loader", resolver => {
-						resolver.plugin(hook, fn);
-					});
-				}, "webpack: Using compiler.resolvers.loader is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver loader", resolver => {\n  resolver.plugin(/* … */);\n}); instead.'),
-				apply: util.deprecate((...args) => {
-					this.resolverFactory.plugin("resolver loader", resolver => {
-						resolver.apply(...args);
-					});
-				}, "webpack: Using compiler.resolvers.loader is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver loader", resolver => {\n  resolver.apply(/* … */);\n}); instead.')
-			},
-			context: {
-				plugins: util.deprecate((hook, fn) => {
-					this.resolverFactory.plugin("resolver context", resolver => {
-						resolver.plugin(hook, fn);
-					});
-				}, "webpack: Using compiler.resolvers.context is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver context", resolver => {\n  resolver.plugin(/* … */);\n}); instead.'),
-				apply: util.deprecate((...args) => {
-					this.resolverFactory.plugin("resolver context", resolver => {
-						resolver.apply(...args);
-					});
-				}, "webpack: Using compiler.resolvers.context is deprecated.\n" + 'Use compiler.resolverFactory.plugin("resolver context", resolver => {\n  resolver.apply(/* … */);\n}); instead.')
-			}
-		};
 
 		this.options = {};
 

--- a/lib/ContextModuleFactory.js
+++ b/lib/ContextModuleFactory.js
@@ -7,34 +7,20 @@
 const asyncLib = require("neo-async");
 const path = require("path");
 
-const {
-	Tapable,
-	AsyncSeriesWaterfallHook,
-	SyncWaterfallHook
-} = require("tapable");
+const { AsyncSeriesWaterfallHook, SyncWaterfallHook } = require("tapable");
 const ContextModule = require("./ContextModule");
 const ContextElementDependency = require("./dependencies/ContextElementDependency");
 
 const EMPTY_RESOLVE_OPTIONS = {};
 
-module.exports = class ContextModuleFactory extends Tapable {
+module.exports = class ContextModuleFactory {
 	constructor(resolverFactory) {
-		super();
 		this.hooks = {
 			beforeResolve: new AsyncSeriesWaterfallHook(["data"]),
 			afterResolve: new AsyncSeriesWaterfallHook(["data"]),
 			contextModuleFiles: new SyncWaterfallHook(["files"]),
 			alternatives: new AsyncSeriesWaterfallHook(["modules"])
 		};
-		this._pluginCompat.tap("ContextModuleFactory", options => {
-			switch (options.name) {
-				case "before-resolve":
-				case "after-resolve":
-				case "alternatives":
-					options.async = true;
-					break;
-			}
-		});
 		this.resolverFactory = resolverFactory;
 	}
 

--- a/lib/DllModuleFactory.js
+++ b/lib/DllModuleFactory.js
@@ -4,12 +4,10 @@
 */
 "use strict";
 
-const { Tapable } = require("tapable");
 const DllModule = require("./DllModule");
 
-class DllModuleFactory extends Tapable {
+class DllModuleFactory {
 	constructor() {
-		super();
 		this.hooks = {};
 	}
 	create(data, callback) {

--- a/lib/HotUpdateChunkTemplate.js
+++ b/lib/HotUpdateChunkTemplate.js
@@ -6,11 +6,10 @@
 
 const Template = require("./Template");
 const HotUpdateChunk = require("./HotUpdateChunk");
-const { Tapable, SyncWaterfallHook, SyncHook } = require("tapable");
+const { SyncWaterfallHook, SyncHook } = require("tapable");
 
-module.exports = class HotUpdateChunkTemplate extends Tapable {
+module.exports = class HotUpdateChunkTemplate {
 	constructor(outputOptions) {
-		super();
 		this.outputOptions = outputOptions || {};
 		this.hooks = {
 			modules: new SyncWaterfallHook([

--- a/lib/MainTemplate.js
+++ b/lib/MainTemplate.js
@@ -10,12 +10,7 @@ const {
 	PrefixSource,
 	RawSource
 } = require("webpack-sources");
-const {
-	Tapable,
-	SyncWaterfallHook,
-	SyncHook,
-	SyncBailHook
-} = require("tapable");
+const { SyncWaterfallHook, SyncHook, SyncBailHook } = require("tapable");
 const Template = require("./Template");
 
 /** @typedef {import("webpack-sources").ConcatSource} ConcatSource */
@@ -51,13 +46,12 @@ const Template = require("./Template");
 // __webpack_require__.oe = the uncaught error handler for the webpack runtime
 // __webpack_require__.nc = the script nonce
 
-module.exports = class MainTemplate extends Tapable {
+module.exports = class MainTemplate {
 	/**
 	 *
 	 * @param {TODO=} outputOptions output options for the MainTemplate
 	 */
 	constructor(outputOptions) {
-		super();
 		/** @type {TODO?} */
 		this.outputOptions = outputOptions || {};
 		this.hooks = {

--- a/lib/ModuleTemplate.js
+++ b/lib/ModuleTemplate.js
@@ -4,14 +4,13 @@
 */
 "use strict";
 
-const { Tapable, SyncWaterfallHook, SyncHook } = require("tapable");
+const { SyncWaterfallHook, SyncHook } = require("tapable");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("./Module")} Module */
 
-module.exports = class ModuleTemplate extends Tapable {
+module.exports = class ModuleTemplate {
 	constructor(runtimeTemplate, type) {
-		super();
 		this.runtimeTemplate = runtimeTemplate;
 		this.type = type;
 		this.hooks = {

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -4,15 +4,14 @@
 */
 "use strict";
 
-const { Tapable, SyncHook, MultiHook } = require("tapable");
+const { SyncHook, MultiHook } = require("tapable");
 const asyncLib = require("neo-async");
 const MultiWatching = require("./MultiWatching");
 const MultiStats = require("./MultiStats");
 const ConcurrentCompilationError = require("./ConcurrentCompilationError");
 
-module.exports = class MultiCompiler extends Tapable {
+module.exports = class MultiCompiler {
 	constructor(compilers) {
-		super();
 		this.hooks = {
 			done: new SyncHook(["stats"]),
 			invalid: new MultiHook(compilers.map(c => c.hooks.invalid)),

--- a/lib/MultiModuleFactory.js
+++ b/lib/MultiModuleFactory.js
@@ -4,12 +4,10 @@
 */
 "use strict";
 
-const { Tapable } = require("tapable");
 const MultiModule = require("./MultiModule");
 
-module.exports = class MultiModuleFactory extends Tapable {
+module.exports = class MultiModuleFactory {
 	constructor() {
-		super();
 		this.hooks = {};
 	}
 

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -7,7 +7,6 @@
 const path = require("path");
 const asyncLib = require("neo-async");
 const {
-	Tapable,
 	AsyncSeriesWaterfallHook,
 	SyncWaterfallHook,
 	SyncBailHook,
@@ -58,9 +57,8 @@ const identToLoaderRequest = resultString => {
 
 const dependencyCache = new WeakMap();
 
-class NormalModuleFactory extends Tapable {
+class NormalModuleFactory {
 	constructor(context, resolverFactory, options) {
-		super();
 		this.hooks = {
 			resolver: new SyncWaterfallHook(["resolver"]),
 			factory: new SyncWaterfallHook(["factory"]),
@@ -77,40 +75,6 @@ class NormalModuleFactory extends Tapable {
 				() => new SyncHook(["generator", "generatorOptions"])
 			)
 		};
-		this._pluginCompat.tap("NormalModuleFactory", options => {
-			switch (options.name) {
-				case "before-resolve":
-				case "after-resolve":
-					options.async = true;
-					break;
-				case "parser":
-					this.hooks.parser
-						.for("javascript/auto")
-						.tap(options.fn.name || "unnamed compat plugin", options.fn);
-					return true;
-			}
-			let match;
-			match = /^parser (.+)$/.exec(options.name);
-			if (match) {
-				this.hooks.parser
-					.for(match[1])
-					.tap(
-						options.fn.name || "unnamed compat plugin",
-						options.fn.bind(this)
-					);
-				return true;
-			}
-			match = /^create-parser (.+)$/.exec(options.name);
-			if (match) {
-				this.hooks.createParser
-					.for(match[1])
-					.tap(
-						options.fn.name || "unnamed compat plugin",
-						options.fn.bind(this)
-					);
-				return true;
-			}
-		});
 		this.resolverFactory = resolverFactory;
 		this.ruleSet = new RuleSet(options.defaultRules.concat(options.rules));
 		this.cachePredicate =

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -7,7 +7,7 @@
 // Syntax: https://developer.mozilla.org/en/SpiderMonkey/Parser_API
 
 const acorn = require("acorn-dynamic-import").default;
-const { Tapable, SyncBailHook, HookMap } = require("tapable");
+const { SyncBailHook, HookMap } = require("tapable");
 const util = require("util");
 const vm = require("vm");
 const BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
@@ -41,9 +41,8 @@ const EMPTY_COMMENT_OPTIONS = {
 	errors: null
 };
 
-class Parser extends Tapable {
+class Parser {
 	constructor(options, sourceType = "auto") {
-		super();
 		this.hooks = {
 			evaluateTypeof: new HookMap(() => new SyncBailHook(["expression"])),
 			evaluate: new HookMap(() => new SyncBailHook(["expression"])),
@@ -99,50 +98,6 @@ class Parser extends Tapable {
 			expressionConditionalOperator: new SyncBailHook(["expression"]),
 			program: new SyncBailHook(["ast", "comments"])
 		};
-		const HOOK_MAP_COMPAT_CONFIG = {
-			evaluateTypeof: /^evaluate typeof (.+)$/,
-			evaluateIdentifier: /^evaluate Identifier (.+)$/,
-			evaluateDefinedIdentifier: /^evaluate defined Identifier (.+)$/,
-			evaluateCallExpressionMember: /^evaluate CallExpression .(.+)$/,
-			evaluate: /^evaluate (.+)$/,
-			label: /^label (.+)$/,
-			varDeclarationLet: /^var-let (.+)$/,
-			varDeclarationConst: /^var-const (.+)$/,
-			varDeclarationVar: /^var-var (.+)$/,
-			varDeclaration: /^var (.+)$/,
-			canRename: /^can-rename (.+)$/,
-			rename: /^rename (.+)$/,
-			typeof: /^typeof (.+)$/,
-			assigned: /^assigned (.+)$/,
-			assign: /^assign (.+)$/,
-			callAnyMember: /^call (.+)\.\*$/,
-			call: /^call (.+)$/,
-			new: /^new (.+)$/,
-			expressionConditionalOperator: /^expression \?:$/,
-			expressionAnyMember: /^expression (.+)\.\*$/,
-			expression: /^expression (.+)$/
-		};
-		this._pluginCompat.tap("Parser", options => {
-			for (const name of Object.keys(HOOK_MAP_COMPAT_CONFIG)) {
-				const regexp = HOOK_MAP_COMPAT_CONFIG[name];
-				const match = regexp.exec(options.name);
-				if (match) {
-					if (match[1]) {
-						this.hooks[name].tap(
-							match[1],
-							options.fn.name || "unnamed compat plugin",
-							options.fn.bind(this)
-						);
-					} else {
-						this.hooks[name].tap(
-							options.fn.name || "unnamed compat plugin",
-							options.fn.bind(this)
-						);
-					}
-					return true;
-				}
-			}
-		});
 		this.options = options;
 		this.sourceType = sourceType;
 		this.scope = undefined;

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -4,39 +4,17 @@
  */
 "use strict";
 
-const { Tapable, HookMap, SyncHook, SyncWaterfallHook } = require("tapable");
+const { HookMap, SyncHook, SyncWaterfallHook } = require("tapable");
 const Factory = require("enhanced-resolve").ResolverFactory;
 
-module.exports = class ResolverFactory extends Tapable {
+module.exports = class ResolverFactory {
 	constructor() {
-		super();
 		this.hooks = {
 			resolveOptions: new HookMap(
 				() => new SyncWaterfallHook(["resolveOptions"])
 			),
 			resolver: new HookMap(() => new SyncHook(["resolver", "resolveOptions"]))
 		};
-		this._pluginCompat.tap("ResolverFactory", options => {
-			let match;
-			match = /^resolve-options (.+)$/.exec(options.name);
-			if (match) {
-				this.hooks.resolveOptions.tap(
-					match[1],
-					options.fn.name || "unnamed compat plugin",
-					options.fn
-				);
-				return true;
-			}
-			match = /^resolver (.+)$/.exec(options.name);
-			if (match) {
-				this.hooks.resolver.tap(
-					match[1],
-					options.fn.name || "unnamed compat plugin",
-					options.fn
-				);
-				return true;
-			}
-		});
 		this.cache1 = new WeakMap();
 		this.cache2 = new Map();
 	}

--- a/lib/wasm/WebAssemblyParser.js
+++ b/lib/wasm/WebAssemblyParser.js
@@ -10,7 +10,6 @@ const {
 	moduleContextFromModuleAST
 } = require("@webassemblyjs/helper-module-context");
 
-const { Tapable } = require("tapable");
 const WebAssemblyImportDependency = require("../dependencies/WebAssemblyImportDependency");
 const WebAssemblyExportImportedDependency = require("../dependencies/WebAssemblyExportImportedDependency");
 
@@ -59,9 +58,8 @@ const decoderOpts = {
 	ignoreCustomNameSection: true
 };
 
-class WebAssemblyParser extends Tapable {
+class WebAssemblyParser {
 	constructor(options) {
-		super();
 		this.hooks = {};
 		this.options = options;
 	}


### PR DESCRIPTION
Remove deprecated Tapable API.

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

yes

**What needs to be documented once your changes are merged?**

Methods `.apply` and `.plugin` no longer exist in webpack.
Hooks must be used instead.
