### PR TITLE
Do not set nodeEnv when 'mode=none'

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -299,8 +299,11 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 			}
 		]);
 		this.set("optimization.nodeEnv", "make", options => {
-			// TODO: In webpack 5, it should return `false` when mode is `none`
-			return options.mode || "production";
+			if (options.mode === "none") {
+				return false;
+			} else {
+				return options.mode || "production";
+			}
 		});
 
 		this.set("resolve", "call", value => Object.assign({}, value));

--- a/test/configCases/issues/issue-7470/index.js
+++ b/test/configCases/issues/issue-7470/index.js
@@ -1,3 +1,7 @@
 it("should set NODE_ENV according to mode", () => {
-	expect(process.env.NODE_ENV).toBe(__MODE__);
+	if (__MODE__ === "none") {
+		expect(process.env.NODE_ENV).toBe("test");
+	} else {
+		expect(process.env.NODE_ENV).toBe(__MODE__);
+	}
 });


### PR DESCRIPTION
When `mode=none`, `nodeEnv` optimization is now disabled.

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

yes

**Does this PR introduce a breaking change?**

yes

**What needs to be documented once your changes are merged?**

`mode=none` now sets `optimization.nodeEnv=false`
