### PR TITLE
Remove useless checks on ChunkGroup

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -532,18 +532,15 @@ class Chunk {
 		for (const group of this.groupsIterable) {
 			if (group.chunks[group.chunks.length - 1] === this) {
 				for (const childGroup of group.childrenIterable) {
-					// TODO webpack 5 remove this check for options
-					if (typeof childGroup.options === "object") {
-						for (const key of Object.keys(childGroup.options)) {
-							if (key.endsWith("Order")) {
-								const name = key.substr(0, key.length - "Order".length);
-								let list = lists.get(name);
-								if (list === undefined) lists.set(name, (list = []));
-								list.push({
-									order: childGroup.options[key],
-									group: childGroup
-								});
-							}
+					for (const key of Object.keys(childGroup.options)) {
+						if (key.endsWith("Order")) {
+							const name = key.substr(0, key.length - "Order".length);
+							let list = lists.get(name);
+							if (list === undefined) lists.set(name, (list = []));
+							list.push({
+								order: childGroup.options[key],
+								group: childGroup
+							});
 						}
 					}
 				}
@@ -554,11 +551,7 @@ class Chunk {
 			list.sort((a, b) => {
 				const cmp = b.order - a.order;
 				if (cmp !== 0) return cmp;
-				// TOOD webpack 5 remove this check of compareTo
-				if (a.group.compareTo) {
-					return a.group.compareTo(b.group);
-				}
-				return 0;
+				return a.group.compareTo(b.group);
 			});
 			result[name] = Array.from(
 				list.reduce((set, item) => {

--- a/lib/ChunkGroup.js
+++ b/lib/ChunkGroup.js
@@ -414,20 +414,17 @@ class ChunkGroup {
 	getChildrenByOrders() {
 		const lists = new Map();
 		for (const childGroup of this._children) {
-			// TODO webpack 5 remove this check for options
-			if (typeof childGroup.options === "object") {
-				for (const key of Object.keys(childGroup.options)) {
-					if (key.endsWith("Order")) {
-						const name = key.substr(0, key.length - "Order".length);
-						let list = lists.get(name);
-						if (list === undefined) {
-							lists.set(name, (list = []));
-						}
-						list.push({
-							order: childGroup.options[key],
-							group: childGroup
-						});
+			for (const key of Object.keys(childGroup.options)) {
+				if (key.endsWith("Order")) {
+					const name = key.substr(0, key.length - "Order".length);
+					let list = lists.get(name);
+					if (list === undefined) {
+						lists.set(name, (list = []));
 					}
+					list.push({
+						order: childGroup.options[key],
+						group: childGroup
+					});
 				}
 			}
 		}
@@ -436,11 +433,7 @@ class ChunkGroup {
 			list.sort((a, b) => {
 				const cmp = b.order - a.order;
 				if (cmp !== 0) return cmp;
-				// TOOD webpack 5 remove this check of compareTo
-				if (a.group.compareTo) {
-					return a.group.compareTo(b.group);
-				}
-				return 0;
+				return a.group.compareTo(b.group);
 			});
 			result[name] = list.map(i => i.group);
 		}

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1267,8 +1267,7 @@ class Compilation {
 					allCreatedChunkGroups.add(c);
 				}
 			} else {
-				// TODO webpack 5 remove addOptions check
-				if (c.addOptions) c.addOptions(b.groupOptions);
+				c.addOptions(b.groupOptions);
 				c.addOrigin(module, b.loc, b.request);
 			}
 


### PR DESCRIPTION
Remove some useless checks on `ChunkGroup` because:

- `#options` is always set in `constructor`
- `#addOptions(…)` and `#compareTo(…)` is set in the prototype

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

kinda

**What needs to be documented once your changes are merged?**

nothing