### PR TITLE
allow emitting to the same filename when hash matches

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -39,6 +39,7 @@ const GraphHelpers = require("./GraphHelpers");
 /** @typedef {import("./Module")} Module */
 /** @typedef {import("./DependenciesBlock")} DependenciesBlock */
 /** @typedef {import("./AsyncDependenciesBlock")} AsyncDependenciesBlock */
+/** @typedef {import("webpack-sources").Source} Source */
 
 const byId = (a, b) => {
 	if (a.id < b.id) return -1;
@@ -1869,6 +1870,8 @@ class Compilation extends Tapable {
 	createChunkAssets() {
 		const outputOptions = this.outputOptions;
 		const cachedSourceMap = new Map();
+		/** @type {Map<string, {hash: string, source: Source, chunk: Chunk}>} */
+		const alreadyWrittenFiles = new Map();
 		for (let i = 0; i < this.chunks.length; i++) {
 			const chunk = this.chunks[i];
 			chunk.files = [];
@@ -1891,6 +1894,28 @@ class Compilation extends Tapable {
 					const cacheName = fileManifest.identifier;
 					const usedHash = fileManifest.hash;
 					filenameTemplate = fileManifest.filenameTemplate;
+					file = this.getPath(filenameTemplate, fileManifest.pathOptions);
+
+					// check if the same filename was already written by another chunk
+					const alreadyWritten = alreadyWrittenFiles.get(file);
+					if (alreadyWritten !== undefined) {
+						if (alreadyWritten.hash === usedHash) {
+							if (this.cache) {
+								this.cache[cacheName] = {
+									hash: usedHash,
+									source: alreadyWritten.source
+								};
+							}
+							chunk.files.push(file);
+							this.hooks.chunkAsset.call(chunk, file);
+							continue;
+						} else {
+							throw new Error(
+								`Conflict: Multiple chunks emit assets to the same filename ${file}` +
+									` (chunks ${alreadyWritten.chunk.id} and ${chunk.id})`
+							);
+						}
+					}
 					if (
 						this.cache &&
 						this.cache[cacheName] &&
@@ -1917,7 +1942,6 @@ class Compilation extends Tapable {
 							};
 						}
 					}
-					file = this.getPath(filenameTemplate, fileManifest.pathOptions);
 					if (this.assets[file] && this.assets[file] !== source) {
 						throw new Error(
 							`Conflict: Multiple assets emit to the same filename ${file}`
@@ -1926,6 +1950,11 @@ class Compilation extends Tapable {
 					this.assets[file] = source;
 					chunk.files.push(file);
 					this.hooks.chunkAsset.call(chunk, file);
+					alreadyWrittenFiles.set(file, {
+						hash: usedHash,
+						source,
+						chunk
+					});
 				}
 			} catch (err) {
 				this.errors.push(

--- a/test/configCases/wasm/identical/index.js
+++ b/test/configCases/wasm/identical/index.js
@@ -1,0 +1,13 @@
+it("should allow reference the same wasm multiple times", function() {
+	return import("./module").then(function(module) {
+		const result = module.run();
+		expect(result).toEqual(84);
+	});
+});
+
+it("should allow reference the same wasm multiple times (other chunk)", function() {
+	return import("./module?2").then(function(module) {
+		const result = module.run();
+		expect(result).toEqual(84);
+	});
+});

--- a/test/configCases/wasm/identical/module.js
+++ b/test/configCases/wasm/identical/module.js
@@ -1,0 +1,6 @@
+import { getNumber } from "./wasm.wat?1";
+import { getNumber as getNumber2 } from "./wasm.wat?2";
+
+export function run() {
+	return getNumber() + getNumber2();
+};

--- a/test/configCases/wasm/identical/test.filter.js
+++ b/test/configCases/wasm/identical/test.filter.js
@@ -1,0 +1,5 @@
+var supportsWebAssembly = require("../../../helpers/supportsWebAssembly");
+
+module.exports = function(config) {
+	return supportsWebAssembly();
+};

--- a/test/configCases/wasm/identical/wasm.wat
+++ b/test/configCases/wasm/identical/wasm.wat
@@ -1,0 +1,10 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (result i32)))
+  (func $add (export "add") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    (i32.add
+      (get_local $p0)
+      (get_local $p1)))
+  (func $getNumber (export "getNumber") (type $t1) (result i32)
+    (i32.const 42)))
+

--- a/test/configCases/wasm/identical/webpack.config.js
+++ b/test/configCases/wasm/identical/webpack.config.js
@@ -1,0 +1,35 @@
+const { CachedSource } = require("webpack-sources");
+
+/** @typedef {import("../../../lib/Compilation")} Compilation */
+
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /\.wat$/,
+				loader: "wast-loader",
+				type: "webassembly/experimental"
+			}
+		]
+	},
+	plugins: [
+		function() {
+			this.hooks.compilation.tap(
+				"Test",
+				/**
+				 * @param {Compilation} compilation Compilation
+				 * @returns {void}
+				 */
+				compilation => {
+					compilation.moduleTemplates.webassembly.hooks.package.tap(
+						"Test",
+						source => {
+							// this is important to make each returned value a new instance
+							return new CachedSource(source);
+						}
+					);
+				}
+			);
+		}
+	]
+};


### PR DESCRIPTION
fixes webpack-contrib/mini-css-extract-plugin#190
fixes webpack-contrib/mini-css-extract-plugin#194

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
