### PR TITLE
Catch errors while parsing DLL manifest

### DIFF
--- a/lib/DllReferencePlugin.js
+++ b/lib/DllReferencePlugin.js
@@ -10,6 +10,7 @@ const DelegatedModuleFactoryPlugin = require("./DelegatedModuleFactoryPlugin");
 const ExternalModuleFactoryPlugin = require("./ExternalModuleFactoryPlugin");
 const DelegatedExportsDependency = require("./dependencies/DelegatedExportsDependency");
 const NullFactory = require("./NullFactory");
+const makePathsRelative = require("./util/identifier").makePathsRelative;
 
 const validateOptions = require("schema-utils");
 const schema = require("../schemas/plugins/DllReferencePlugin.json");
@@ -43,9 +44,21 @@ class DllReferencePlugin {
 					params.compilationDependencies.add(manifest);
 					compiler.inputFileSystem.readFile(manifest, (err, result) => {
 						if (err) return callback(err);
-						params["dll reference " + manifest] = parseJson(
-							result.toString("utf-8")
-						);
+						// Catch errors parsing the manifest so that blank
+						// or malformed manifest files don't kill the process.
+						try {
+							params["dll reference " + manifest] = parseJson(
+								result.toString("utf-8")
+							);
+						} catch (e) {
+							// Store the error in the params so that it can
+							// be added as a compilation error later on.
+							const manifestPath = this.options.context
+								? makePathsRelative(this.options.context, manifest)
+								: manifest;
+							e.message = `Dll manifest ${manifestPath}\n${e.message}`;
+							params["dll reference parse error " + manifest] = e;
+						}
 						return callback();
 					});
 				} else {
@@ -57,6 +70,12 @@ class DllReferencePlugin {
 		compiler.hooks.compile.tap("DllReferencePlugin", params => {
 			let manifest = this.options.manifest;
 			if (typeof manifest === "string") {
+				// If there was an error parsing the manifest
+				// file, exit now because the error will be added
+				// as a compilation error in the "compilation" hook.
+				if (params["dll reference parse error " + manifest]) {
+					return;
+				}
 				manifest = params["dll reference " + manifest];
 			}
 			const name = this.options.name || manifest.name;
@@ -78,6 +97,21 @@ class DllReferencePlugin {
 				extensions: this.options.extensions
 			}).apply(normalModuleFactory);
 		});
+
+		compiler.hooks.compilation.tap(
+			"DllReferencePlugin",
+			(compilation, params) => {
+				let manifest = this.options.manifest;
+				if (typeof manifest === "string") {
+					// If there was an error parsing the manifest file, add the
+					// error as a compilation error to make the compilation fail.
+					let e = params["dll reference parse error " + manifest];
+					if (e) {
+						compilation.errors.push(e);
+					}
+				}
+			}
+		);
 	}
 }
 

--- a/lib/DllReferencePlugin.js
+++ b/lib/DllReferencePlugin.js
@@ -54,9 +54,10 @@ class DllReferencePlugin {
 						} catch (e) {
 							// Store the error in the params so that it can
 							// be added as a compilation error later on.
-							const manifestPath = this.options.context
-								? makePathsRelative(this.options.context, manifest)
-								: manifest;
+							const manifestPath = makePathsRelative(
+								compiler.options.context,
+								manifest
+							);
 							params[
 								"dll reference parse error " + manifest
 							] = new DllManifestError(manifestPath, e.message);

--- a/lib/DllReferencePlugin.js
+++ b/lib/DllReferencePlugin.js
@@ -11,6 +11,7 @@ const ExternalModuleFactoryPlugin = require("./ExternalModuleFactoryPlugin");
 const DelegatedExportsDependency = require("./dependencies/DelegatedExportsDependency");
 const NullFactory = require("./NullFactory");
 const makePathsRelative = require("./util/identifier").makePathsRelative;
+const WebpackError = require("./WebpackError");
 
 const validateOptions = require("schema-utils");
 const schema = require("../schemas/plugins/DllReferencePlugin.json");
@@ -56,8 +57,9 @@ class DllReferencePlugin {
 							const manifestPath = this.options.context
 								? makePathsRelative(this.options.context, manifest)
 								: manifest;
-							e.message = `Dll manifest ${manifestPath}\n${e.message}`;
-							params["dll reference parse error " + manifest] = e;
+							params[
+								"dll reference parse error " + manifest
+							] = new DllManifestError(manifestPath, e.message);
 						}
 						return callback();
 					});
@@ -112,6 +114,17 @@ class DllReferencePlugin {
 				}
 			}
 		);
+	}
+}
+
+class DllManifestError extends WebpackError {
+	constructor(filename, message) {
+		super();
+
+		this.name = "DllManifestError";
+		this.message = `Dll manifest ${filename}\n${message}`;
+
+		Error.captureStackTrace(this, this.constructor);
 	}
 }
 

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -731,7 +731,7 @@ Entrypoint main = bundle.js
 `;
 
 exports[`StatsTestCases should print correct stats for dll-reference-plugin-issue-7624-error 1`] = `
-"Hash: db465df0da5d95ebf88f
+"Hash: 701dcf62b26d0347b899
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset     Size  Chunks  Chunk Names
@@ -739,7 +739,7 @@ bundle.js  3.6 KiB       0  main
 Entrypoint main = bundle.js
 [0] ./entry.js 29 bytes {0} [built]
 
-ERROR in Dll manifest Xdir/dll-reference-plugin-issue-7624-error/blank-manifest.json
+ERROR in Dll manifest blank-manifest.json
 Unexpected end of JSON input while parsing near ''"
 `;
 

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -720,6 +720,29 @@ Child
     [0] ./index.js 24 bytes {0} [built]"
 `;
 
+exports[`StatsTestCases should print correct stats for dll-reference-plugin-issue-7624 1`] = `
+"Hash: 29b62432962bce4c54c0
+Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
+    Asset     Size  Chunks             Chunk Names
+bundle.js  3.6 KiB       0  [emitted]  main
+Entrypoint main = bundle.js
+[0] ./entry.js 29 bytes {0} [built]"
+`;
+
+exports[`StatsTestCases should print correct stats for dll-reference-plugin-issue-7624-error 1`] = `
+"Hash: db465df0da5d95ebf88f
+Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
+    Asset     Size  Chunks  Chunk Names
+bundle.js  3.6 KiB       0  main
+Entrypoint main = bundle.js
+[0] ./entry.js 29 bytes {0} [built]
+
+ERROR in Dll manifest Xdir/dll-reference-plugin-issue-7624-error/blank-manifest.json
+Unexpected end of JSON input while parsing near ''"
+`;
+
 exports[`StatsTestCases should print correct stats for exclude-with-loader 1`] = `
 "Hash: 52eadc5de721f000106b
 Time: Xms

--- a/test/statsCases/dll-reference-plugin-issue-7624-error/entry.js
+++ b/test/statsCases/dll-reference-plugin-issue-7624-error/entry.js
@@ -1,0 +1,1 @@
+// Intentionally left blank.

--- a/test/statsCases/dll-reference-plugin-issue-7624-error/webpack.config.js
+++ b/test/statsCases/dll-reference-plugin-issue-7624-error/webpack.config.js
@@ -1,0 +1,15 @@
+var webpack = require("../../../");
+
+module.exports = {
+	mode: "production",
+	entry: "./entry.js",
+	output: {
+		filename: "bundle.js"
+	},
+	plugins: [
+		new webpack.DllReferencePlugin({
+			manifest: __dirname + "/blank-manifest.json",
+			name: "blank-manifest"
+		})
+	]
+};

--- a/test/statsCases/dll-reference-plugin-issue-7624/entry.js
+++ b/test/statsCases/dll-reference-plugin-issue-7624/entry.js
@@ -1,0 +1,1 @@
+// Intentionally left blank.

--- a/test/statsCases/dll-reference-plugin-issue-7624/non-blank-manifest.json
+++ b/test/statsCases/dll-reference-plugin-issue-7624/non-blank-manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "foo",
+  "content": {
+    "./foo.js": {
+      "id": 0,
+      "buildMeta": {
+        "providedExports": true
+      }
+    }
+  }
+}

--- a/test/statsCases/dll-reference-plugin-issue-7624/webpack.config.js
+++ b/test/statsCases/dll-reference-plugin-issue-7624/webpack.config.js
@@ -1,0 +1,15 @@
+var webpack = require("../../../");
+
+module.exports = {
+	mode: "production",
+	entry: "./entry.js",
+	output: {
+		filename: "bundle.js"
+	},
+	plugins: [
+		new webpack.DllReferencePlugin({
+			manifest: __dirname + "/non-blank-manifest.json",
+			name: "non-blank-manifest"
+		})
+	]
+};


### PR DESCRIPTION
Fixes #7624.

If the DLL manifest file is blank (as experienced in #7624), or malformed in some way, parsing it will throw an error and, if left uncaught, will kill the process if webpack is in watch mode.

To prevent this, I've added a try/catch block around the JSON parsing. If an error occurs, it's fed into the compilation's errors so that the compilation fails, but the process (and the webpack compiler) continues to run.

**What kind of change does this PR introduce?**

Bugfix.

**Did you add tests for your changes?**

Yes.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

None.