### PR TITLE
prevent UnhandledPromiseRejectionWarning in node 6

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -137,9 +137,7 @@ const createTrace = outputPath => {
 				callback();
 			});
 			// Tear down the readable trace stream.
-			if (trace.destroy) {
-				trace.destroy();
-			}
+			trace.push(null);
 		}
 	};
 };

--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -137,7 +137,9 @@ const createTrace = outputPath => {
 				callback();
 			});
 			// Tear down the readable trace stream.
-			trace.destroy();
+			if (trace.destroy) {
+				trace.destroy();
+			}
 		}
 	};
 };


### PR DESCRIPTION
Fixes #7654

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This fixes the node 6 warning I was seeing (see issue #7654).  I'm not sure if there's a way to clean up the readable stream in node 6.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Prevents calling a method that doesn't exist in node 6

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No.  I tested manually by running this code against my codebase in node 6 (before and after making the change)

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
I hope not.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->



**What needs to be documented once your changes are merged?**
I don't think anything really needs to be documented.  This just prevents a warning from showing up in node 6.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
