### PR TITLE
No longer accept strings in compareLocations

### DIFF
--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -77,7 +77,10 @@ class Dependency {
 	disconnect() {
 		this.module = null;
 	}
+
+	static compare(a, b) {
+		return compareLocations(a.loc, b.loc);
+	}
 }
-Dependency.compare = (a, b) => compareLocations(a.loc, b.loc);
 
 module.exports = Dependency;

--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -4,7 +4,6 @@
 */
 "use strict";
 
-const compareLocations = require("./compareLocations");
 const DependencyReference = require("./dependencies/DependencyReference");
 
 /** @typedef {import("./Module")} Module */
@@ -76,10 +75,6 @@ class Dependency {
 
 	disconnect() {
 		this.module = null;
-	}
-
-	static compare(a, b) {
-		return compareLocations(a.loc, b.loc);
 	}
 }
 

--- a/lib/compareLocations.js
+++ b/lib/compareLocations.js
@@ -6,47 +6,34 @@
 
 /** @typedef {import("./Dependency").DependencyLocation} DependencyLocation */
 
-// TODO webpack 5 remove string type from a and b
 /**
  * Compare two locations
- * @param {string|DependencyLocation} a A location node
- * @param {string|DependencyLocation} b A location node
+ * @param {DependencyLocation} a A location node
+ * @param {DependencyLocation} b A location node
  * @returns {-1|0|1} sorting comparator value
  */
 module.exports = (a, b) => {
-	if (typeof a === "string") {
-		if (typeof b === "string") {
-			if (a < b) return -1;
-			if (a > b) return 1;
-			return 0;
-		} else if (typeof b === "object") {
-			return 1;
-		} else {
-			return 0;
-		}
-	} else if (typeof a === "object") {
-		if (typeof b === "string") {
-			return -1;
-		} else if (typeof b === "object") {
-			if ("start" in a && "start" in b) {
-				const ap = a.start;
-				const bp = b.start;
-				if (ap.line < bp.line) return -1;
-				if (ap.line > bp.line) return 1;
-				if (ap.column < bp.column) return -1;
-				if (ap.column > bp.column) return 1;
-			}
-			if ("name" in a && "name" in b) {
-				if (a.name < b.name) return -1;
-				if (a.name > b.name) return 1;
-			}
-			if ("index" in a && "index" in b) {
-				if (a.index < b.index) return -1;
-				if (a.index > b.index) return 1;
-			}
-			return 0;
-		} else {
-			return 0;
-		}
+	if (typeof a !== "object" || a === null) {
+		return undefined;
 	}
+	if (typeof b !== "object" || b === null) {
+		return 0;
+	}
+	if ("start" in a && "start" in b) {
+		const ap = a.start;
+		const bp = b.start;
+		if (ap.line < bp.line) return -1;
+		if (ap.line > bp.line) return 1;
+		if (ap.column < bp.column) return -1;
+		if (ap.column > bp.column) return 1;
+	}
+	if ("name" in a && "name" in b) {
+		if (a.name < b.name) return -1;
+		if (a.name > b.name) return 1;
+	}
+	if ("index" in a && "index" in b) {
+		if (a.index < b.index) return -1;
+		if (a.index > b.index) return 1;
+	}
+	return 0;
 };

--- a/lib/compareLocations.js
+++ b/lib/compareLocations.js
@@ -13,10 +13,11 @@
  * @returns {-1|0|1} sorting comparator value
  */
 module.exports = (a, b) => {
-	if (typeof a !== "object" || a === null) {
-		return undefined;
-	}
-	if (typeof b !== "object" || b === null) {
+	let isObjectA = typeof a === "object" && a !== null;
+	let isObjectB = typeof b === "object" && b !== null;
+	if (!isObjectA || !isObjectB) {
+		if (isObjectA) return 1;
+		if (isObjectB) return -1;
 		return 0;
 	}
 	if ("start" in a && "start" in b) {

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StatsTestCases should print correct stats for aggressive-splitting-entry 1`] = `
-"Hash: 117441fc09d4a86a78de117441fc09d4a86a78de
+"Hash: 331363f0645f09dfa3fa331363f0645f09dfa3fa
 Child fitting:
-    Hash: 117441fc09d4a86a78de
+    Hash: 331363f0645f09dfa3fa
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
                       Asset      Size  Chunks             Chunk Names
     d4b551c6319035df2898.js  1.05 KiB       0  [emitted]  
-    330c6c101c7e6fb1007a.js  11.1 KiB       1  [emitted]  
+    f706563c87d3bff90636.js  11.1 KiB       1  [emitted]  
     33966214360bbbb31383.js  1.94 KiB       2  [emitted]  
     445d4c6a1d7381d6cb2c.js  1.94 KiB       3  [emitted]  
-    Entrypoint main = 33966214360bbbb31383.js 445d4c6a1d7381d6cb2c.js 330c6c101c7e6fb1007a.js
+    Entrypoint main = 33966214360bbbb31383.js 445d4c6a1d7381d6cb2c.js f706563c87d3bff90636.js
     chunk    {0} d4b551c6319035df2898.js 916 bytes <{1}> <{2}> <{3}>
         > ./g [4] ./index.js 7:0-13
      [7] ./g.js 916 bytes {0} [built]
-    chunk    {1} 330c6c101c7e6fb1007a.js 1.87 KiB ={2}= ={3}= >{0}< [entry] [rendered]
+    chunk    {1} f706563c87d3bff90636.js 1.87 KiB ={2}= ={3}= >{0}< [entry] [rendered]
         > ./index main
      [3] ./e.js 899 bytes {1} [built]
      [4] ./index.js 111 bytes {1} [built]
@@ -29,19 +29,19 @@ Child fitting:
      [1] ./c.js 899 bytes {3} [built]
      [2] ./d.js 899 bytes {3} [built]
 Child content-change:
-    Hash: 117441fc09d4a86a78de
+    Hash: 331363f0645f09dfa3fa
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
                       Asset      Size  Chunks             Chunk Names
     d4b551c6319035df2898.js  1.05 KiB       0  [emitted]  
-    330c6c101c7e6fb1007a.js  11.1 KiB       1  [emitted]  
+    f706563c87d3bff90636.js  11.1 KiB       1  [emitted]  
     33966214360bbbb31383.js  1.94 KiB       2  [emitted]  
     445d4c6a1d7381d6cb2c.js  1.94 KiB       3  [emitted]  
-    Entrypoint main = 33966214360bbbb31383.js 445d4c6a1d7381d6cb2c.js 330c6c101c7e6fb1007a.js
+    Entrypoint main = 33966214360bbbb31383.js 445d4c6a1d7381d6cb2c.js f706563c87d3bff90636.js
     chunk    {0} d4b551c6319035df2898.js 916 bytes <{1}> <{2}> <{3}>
         > ./g [4] ./index.js 7:0-13
      [7] ./g.js 916 bytes {0} [built]
-    chunk    {1} 330c6c101c7e6fb1007a.js 1.87 KiB ={2}= ={3}= >{0}< [entry] [rendered]
+    chunk    {1} f706563c87d3bff90636.js 1.87 KiB ={2}= ={3}= >{0}< [entry] [rendered]
         > ./index main
      [3] ./e.js 899 bytes {1} [built]
      [4] ./index.js 111 bytes {1} [built]
@@ -611,35 +611,35 @@ Entrypoint <CLR=BOLD>main</CLR> = <CLR=32>main.js</CLR>
 `;
 
 exports[`StatsTestCases should print correct stats for commons-chunk-min-size-0 1`] = `
-"Hash: 54d4e5458e5d48cb25ea
+"Hash: 52acce682a8cc367048a
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
               Asset       Size  Chunks             Chunk Names
          entry-1.js    6.6 KiB       0  [emitted]  entry-1
-vendor-1~entry-1.js  314 bytes       1  [emitted]  vendor-1~entry-1
+vendor-1~entry-1.js  323 bytes       1  [emitted]  vendor-1~entry-1
 Entrypoint entry-1 = vendor-1~entry-1.js entry-1.js
 [0] ./entry-1.js 145 bytes {0} [built]
-[1] ./modules/a.js 22 bytes {1} [built]
-[2] ./modules/b.js 22 bytes {1} [built]
-[3] ./modules/c.js 22 bytes {1} [built]
-[4] ./modules/d.js 22 bytes {0} [built]
+[1] ./modules/d.js 22 bytes {0} [built]
+[2] ./modules/a.js 22 bytes {1} [built]
+[3] ./modules/b.js 22 bytes {1} [built]
+[4] ./modules/c.js 22 bytes {1} [built]
 [5] ./modules/e.js 22 bytes {0} [built]
 [6] ./modules/f.js 22 bytes {0} [built]"
 `;
 
 exports[`StatsTestCases should print correct stats for commons-chunk-min-size-Infinity 1`] = `
-"Hash: 275af2436329c6c382a9
+"Hash: d7d5394052029cff9f3b
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
       Asset       Size  Chunks             Chunk Names
  entry-1.js    6.6 KiB       0  [emitted]  entry-1
-vendor-1.js  314 bytes       1  [emitted]  vendor-1
+vendor-1.js  323 bytes       1  [emitted]  vendor-1
 Entrypoint entry-1 = vendor-1.js entry-1.js
 [0] ./entry-1.js 145 bytes {0} [built]
-[1] ./modules/a.js 22 bytes {1} [built]
-[2] ./modules/b.js 22 bytes {1} [built]
-[3] ./modules/c.js 22 bytes {1} [built]
-[4] ./modules/d.js 22 bytes {0} [built]
+[1] ./modules/d.js 22 bytes {0} [built]
+[2] ./modules/a.js 22 bytes {1} [built]
+[3] ./modules/b.js 22 bytes {1} [built]
+[4] ./modules/c.js 22 bytes {1} [built]
 [5] ./modules/e.js 22 bytes {0} [built]
 [6] ./modules/f.js 22 bytes {0} [built]"
 `;
@@ -1219,22 +1219,22 @@ Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset      Size  Chunks             Chunk Names
 main.js  6.81 KiB       0  [emitted]  main
 Entrypoint main = main.js
- [0] ./a.js?1 33 bytes {0} [built]
- [1] ./a.js?2 33 bytes {0} [built]
- [2] ./a.js?3 33 bytes {0} [built]
- [3] ./a.js?4 33 bytes {0} [built]
- [4] ./a.js?5 33 bytes {0} [built]
- [5] ./a.js?6 33 bytes {0} [built]
+ [0] ./a.js?6 33 bytes {0} [built]
+ [1] ./a.js?1 33 bytes {0} [built]
+ [2] ./a.js?2 33 bytes {0} [built]
+ [3] ./a.js?3 33 bytes {0} [built]
+ [4] ./a.js?4 33 bytes {0} [built]
+ [5] ./a.js?5 33 bytes {0} [built]
  [6] ./a.js?7 33 bytes {0} [built]
  [7] ./a.js?8 33 bytes {0} [built]
  [8] ./a.js?9 33 bytes {0} [built]
  [9] ./a.js?10 33 bytes {0} [built]
 [10] ./index.js 181 bytes {0} [built]
-[11] ./c.js?1 33 bytes {0} [built]
-[13] ./c.js?2 33 bytes {0} [built]
-[15] ./c.js?3 33 bytes {0} [built]
-[17] ./c.js?4 33 bytes {0} [built]
-[19] ./c.js?5 33 bytes {0} [built]
+[11] ./c.js?6 33 bytes {0} [built]
+[13] ./c.js?1 33 bytes {0} [built]
+[15] ./c.js?2 33 bytes {0} [built]
+[17] ./c.js?3 33 bytes {0} [built]
+[19] ./c.js?4 33 bytes {0} [built]
 [23] ./c.js?7 33 bytes {0} [built]
 [25] ./c.js?8 33 bytes {0} [built]
 [27] ./c.js?9 33 bytes {0} [built]
@@ -1249,19 +1249,19 @@ Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset      Size  Chunks             Chunk Names
 main.js  6.81 KiB       0  [emitted]  main
 Entrypoint main = main.js
- [0] ./a.js?1 33 bytes {0} [built]
- [1] ./a.js?2 33 bytes {0} [built]
- [2] ./a.js?3 33 bytes {0} [built]
- [3] ./a.js?4 33 bytes {0} [built]
- [4] ./a.js?5 33 bytes {0} [built]
- [5] ./a.js?6 33 bytes {0} [built]
+ [0] ./a.js?6 33 bytes {0} [built]
+ [1] ./a.js?1 33 bytes {0} [built]
+ [2] ./a.js?2 33 bytes {0} [built]
+ [3] ./a.js?3 33 bytes {0} [built]
+ [4] ./a.js?4 33 bytes {0} [built]
+ [5] ./a.js?5 33 bytes {0} [built]
  [6] ./a.js?7 33 bytes {0} [built]
  [7] ./a.js?8 33 bytes {0} [built]
  [8] ./a.js?9 33 bytes {0} [built]
  [9] ./a.js?10 33 bytes {0} [built]
 [10] ./index.js 181 bytes {0} [built]
-[11] ./c.js?1 33 bytes {0} [built]
-[13] ./c.js?2 33 bytes {0} [built]
+[11] ./c.js?6 33 bytes {0} [built]
+[13] ./c.js?1 33 bytes {0} [built]
 [27] ./c.js?9 33 bytes {0} [built]
 [29] ./c.js?10 33 bytes {0} [built]
     + 16 hidden modules"
@@ -2057,22 +2057,22 @@ Entrypoint main = main.js
 [27] ./c.js?9 33 bytes {0} [built]
 [25] ./c.js?8 33 bytes {0} [built]
 [23] ./c.js?7 33 bytes {0} [built]
-[19] ./c.js?5 33 bytes {0} [built]
-[17] ./c.js?4 33 bytes {0} [built]
-[15] ./c.js?3 33 bytes {0} [built]
-[13] ./c.js?2 33 bytes {0} [built]
-[11] ./c.js?1 33 bytes {0} [built]
+[19] ./c.js?4 33 bytes {0} [built]
+[17] ./c.js?3 33 bytes {0} [built]
+[15] ./c.js?2 33 bytes {0} [built]
+[13] ./c.js?1 33 bytes {0} [built]
+[11] ./c.js?6 33 bytes {0} [built]
 [10] ./index.js 181 bytes {0} [built]
  [9] ./a.js?10 33 bytes {0} [built]
  [8] ./a.js?9 33 bytes {0} [built]
  [7] ./a.js?8 33 bytes {0} [built]
  [6] ./a.js?7 33 bytes {0} [built]
- [5] ./a.js?6 33 bytes {0} [built]
- [4] ./a.js?5 33 bytes {0} [built]
- [3] ./a.js?4 33 bytes {0} [built]
- [2] ./a.js?3 33 bytes {0} [built]
- [1] ./a.js?2 33 bytes {0} [built]
- [0] ./a.js?1 33 bytes {0} [built]
+ [5] ./a.js?5 33 bytes {0} [built]
+ [4] ./a.js?4 33 bytes {0} [built]
+ [3] ./a.js?3 33 bytes {0} [built]
+ [2] ./a.js?2 33 bytes {0} [built]
+ [1] ./a.js?1 33 bytes {0} [built]
+ [0] ./a.js?6 33 bytes {0} [built]
     + 11 hidden modules"
 `;
 
@@ -2117,7 +2117,7 @@ Entrypoint e2 = runtime.js e2.js"
 `;
 
 exports[`StatsTestCases should print correct stats for scope-hoisting-bailouts 1`] = `
-"Hash: 900e01719757ad40b4ee
+"Hash: cb836ce85fd653d2b7b0
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
 Entrypoint index = index.js
@@ -2245,7 +2245,7 @@ Entrypoint main = main.js
 `;
 
 exports[`StatsTestCases should print correct stats for side-effects-simple-unused 1`] = `
-"Hash: 98f9f698f299e2fa69de
+"Hash: 903fd6b83a6fe8c110da
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset     Size  Chunks             Chunk Names
@@ -2777,14 +2777,14 @@ exports[`StatsTestCases should print correct stats for split-chunks-max-size 1`]
     Entrypoint main = prod-vendors~main~7274e1de.js prod-vendors~main~0feae4ad.js prod-main~6e7ead72.js prod-main~6a2ae26b.js prod-main~17acad98.js prod-main~b2c7414a.js prod-main~75f09de8.js prod-main~052b3814.js prod-main~3ff27526.js prod-main~11485824.js prod-main~c6931360.js prod-main~cd7c5bfc.js prod-main~02369f19.js
     chunk    {0} prod-main~02369f19.js (main~02369f19) 1.57 KiB ={1}= ={10}= ={11}= ={12}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= [entry] [rendered]
         > ./ main
-     [11] ./very-big.js?1 1.57 KiB {0} [built]
+     [12] ./very-big.js?1 1.57 KiB {0} [built]
     chunk    {1} prod-vendors~main~0feae4ad.js (vendors~main~0feae4ad) 1.57 KiB ={0}= ={10}= ={11}= ={12}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= [initial] [rendered] split chunk (cache group: defaultVendors) (name: vendors~main)
         > ./ main
      [43] ./node_modules/very-big.js?1 1.57 KiB {1} [built]
     chunk    {2} prod-main~6e7ead72.js (main~6e7ead72) 536 bytes ={0}= ={1}= ={10}= ={11}= ={12}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= [initial] [rendered]
         > ./ main
-     [0] ./big.js?1 268 bytes {2} [built]
-     [1] ./big.js?2 268 bytes {2} [built]
+     [1] ./big.js?1 268 bytes {2} [built]
+     [2] ./big.js?2 268 bytes {2} [built]
     chunk    {3} prod-main~6a2ae26b.js (main~6a2ae26b) 536 bytes ={0}= ={1}= ={10}= ={11}= ={12}= ={2}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= [initial] [rendered]
         > ./ main
      [34] ./in-some-directory/big.js?1 268 bytes {3} [built]
@@ -2811,36 +2811,36 @@ exports[`StatsTestCases should print correct stats for split-chunks-max-size 1`]
      [33] ./inner-module/small.js?9 67 bytes {6} [built]
     chunk    {7} prod-main~052b3814.js (main~052b3814) 603 bytes ={0}= ={1}= ={10}= ={11}= ={12}= ={2}= ={3}= ={4}= ={5}= ={6}= ={8}= ={9}= [initial] [rendered]
         > ./ main
-      [2] ./small.js?1 67 bytes {7} [built]
-      [3] ./small.js?2 67 bytes {7} [built]
-      [4] ./small.js?3 67 bytes {7} [built]
-      [5] ./small.js?4 67 bytes {7} [built]
-      [6] ./small.js?5 67 bytes {7} [built]
-      [7] ./small.js?6 67 bytes {7} [built]
-      [8] ./small.js?7 67 bytes {7} [built]
-      [9] ./small.js?8 67 bytes {7} [built]
-     [10] ./small.js?9 67 bytes {7} [built]
+      [3] ./small.js?1 67 bytes {7} [built]
+      [4] ./small.js?2 67 bytes {7} [built]
+      [5] ./small.js?3 67 bytes {7} [built]
+      [6] ./small.js?4 67 bytes {7} [built]
+      [7] ./small.js?5 67 bytes {7} [built]
+      [8] ./small.js?6 67 bytes {7} [built]
+      [9] ./small.js?7 67 bytes {7} [built]
+     [10] ./small.js?8 67 bytes {7} [built]
+     [11] ./small.js?9 67 bytes {7} [built]
     chunk    {8} prod-main~3ff27526.js (main~3ff27526) 536 bytes ={0}= ={1}= ={10}= ={11}= ={12}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={9}= [initial] [rendered]
         > ./ main
-     [14] ./subfolder/big.js?1 268 bytes {8} [built]
-     [15] ./subfolder/big.js?2 268 bytes {8} [built]
+     [15] ./subfolder/big.js?1 268 bytes {8} [built]
+     [16] ./subfolder/big.js?2 268 bytes {8} [built]
     chunk    {9} prod-main~11485824.js (main~11485824) 603 bytes ={0}= ={1}= ={10}= ={11}= ={12}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= [initial] [rendered]
         > ./ main
-     [16] ./subfolder/small.js?1 67 bytes {9} [built]
-     [17] ./subfolder/small.js?2 67 bytes {9} [built]
-     [18] ./subfolder/small.js?3 67 bytes {9} [built]
-     [19] ./subfolder/small.js?4 67 bytes {9} [built]
-     [20] ./subfolder/small.js?5 67 bytes {9} [built]
-     [21] ./subfolder/small.js?6 67 bytes {9} [built]
+      [0] ./subfolder/small.js?6 67 bytes {9} [built]
+     [17] ./subfolder/small.js?1 67 bytes {9} [built]
+     [18] ./subfolder/small.js?2 67 bytes {9} [built]
+     [19] ./subfolder/small.js?3 67 bytes {9} [built]
+     [20] ./subfolder/small.js?4 67 bytes {9} [built]
+     [21] ./subfolder/small.js?5 67 bytes {9} [built]
      [22] ./subfolder/small.js?7 67 bytes {9} [built]
      [23] ./subfolder/small.js?8 67 bytes {9} [built]
      [24] ./subfolder/small.js?9 67 bytes {9} [built]
     chunk   {10} prod-main~c6931360.js (main~c6931360) 1.57 KiB ={0}= ={1}= ={11}= ={12}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= [initial] [rendered]
         > ./ main
-     [12] ./very-big.js?2 1.57 KiB {10} [built]
+     [13] ./very-big.js?2 1.57 KiB {10} [built]
     chunk   {11} prod-main~cd7c5bfc.js (main~cd7c5bfc) 1.57 KiB ={0}= ={1}= ={10}= ={12}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= [initial] [rendered]
         > ./ main
-     [13] ./very-big.js?3 1.57 KiB {11} [built]
+     [14] ./very-big.js?3 1.57 KiB {11} [built]
     chunk   {12} prod-vendors~main~7274e1de.js (vendors~main~7274e1de) 402 bytes ={0}= ={1}= ={10}= ={11}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= [initial] [rendered]
         > ./ main
      [40] ./node_modules/big.js?1 268 bytes {12} [built]
@@ -2946,7 +2946,7 @@ chunk    {4} default/main.js (main) 147 bytes >{0}< >{1}< >{2}< >{3}< [entry] [r
 `;
 
 exports[`StatsTestCases should print correct stats for tree-shaking 1`] = `
-"Hash: 7664ceef8f3f695c9688
+"Hash: 4a5dae93bbed582e4039
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset      Size  Chunks             Chunk Names

--- a/test/compareLocations.unittest.js
+++ b/test/compareLocations.unittest.js
@@ -20,20 +20,6 @@ const createLocation = (start, end, index) => {
 };
 
 describe("compareLocations", () => {
-	describe("string location comparison", () => {
-		it("returns -1 when the first string comes before the second string", () => {
-			expect(compareLocations("alpha", "beta")).toBe(-1);
-		});
-
-		it("returns 1 when the first string comes after the second string", () => {
-			expect(compareLocations("beta", "alpha")).toBe(1);
-		});
-
-		it("returns 0 when the first string is the same as the second string", () => {
-			expect(compareLocations("charlie", "charlie")).toBe(0);
-		});
-	});
-
 	describe("object location comparison", () => {
 		let a, b;
 
@@ -102,27 +88,18 @@ describe("compareLocations", () => {
 		});
 	});
 
-	describe("string and object location comparison", () => {
-		it("returns 1 when the first parameter is a string and the second parameter is an object", () => {
-			expect(compareLocations("alpha", createLocation())).toBe(1);
-		});
-
-		it("returns -1 when the first parameter is an object and the second parameter is a string", () => {
-			expect(compareLocations(createLocation(), "alpha")).toBe(-1);
-		});
-	});
-
 	describe("unknown location type comparison", () => {
-		it("returns 0 when the first parameter is an object and the second parameter is a number", () => {
+		it("returns 0 when the first parameter is an object and the second parameter is not", () => {
 			expect(compareLocations(createLocation(), 123)).toBe(0);
+			expect(compareLocations(createLocation(), "alpha")).toBe(0);
 		});
 
 		it("returns undefined when the first parameter is a number and the second parameter is an object", () => {
 			expect(compareLocations(123, createLocation())).toBe(undefined);
 		});
 
-		it("returns 0 when the first parameter is a string and the second parameter is a number", () => {
-			expect(compareLocations("alpha", 123)).toBe(0);
+		it("returns undefined when the first parameter is a string and the second parameter is a number", () => {
+			expect(compareLocations("alpha", 123)).toBe(undefined);
 		});
 
 		it("returns undefined when the first parameter is a number and the second parameter is a string", () => {

--- a/test/compareLocations.unittest.js
+++ b/test/compareLocations.unittest.js
@@ -89,25 +89,18 @@ describe("compareLocations", () => {
 	});
 
 	describe("unknown location type comparison", () => {
-		it("returns 0 when the first parameter is an object and the second parameter is not", () => {
-			expect(compareLocations(createLocation(), 123)).toBe(0);
-			expect(compareLocations(createLocation(), "alpha")).toBe(0);
+		it("returns 1 when the first parameter is an object and the second parameter is not", () => {
+			expect(compareLocations(createLocation(), 123)).toBe(1);
+			expect(compareLocations(createLocation(), "alpha")).toBe(1);
 		});
 
-		it("returns undefined when the first parameter is a number and the second parameter is an object", () => {
-			expect(compareLocations(123, createLocation())).toBe(undefined);
+		it("returns -1 when the first parameter is not an object and the second parameter is", () => {
+			expect(compareLocations(123, createLocation())).toBe(-1);
+			expect(compareLocations("alpha", createLocation())).toBe(-1);
 		});
 
-		it("returns undefined when the first parameter is a string and the second parameter is a number", () => {
-			expect(compareLocations("alpha", 123)).toBe(undefined);
-		});
-
-		it("returns undefined when the first parameter is a number and the second parameter is a string", () => {
-			expect(compareLocations(123, "alpha")).toBe(undefined);
-		});
-
-		it("returns undefined when both the first parameter and the second parameter is a number", () => {
-			expect(compareLocations(123, 456)).toBe(undefined);
+		it("returns 0 when both the first parameter and the second parameter is an object", () => {
+			expect(compareLocations(123, 456)).toBe(0);
 		});
 	});
 });


### PR DESCRIPTION
Some notes about this change:

- `Dependency.compare` is not used inside webpack
- `compareLocations` neither is

Is it worth keeping this helper?

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

yes

**Does this PR introduce a breaking change?**

yes

**What needs to be documented once your changes are merged?**

Nothing. This is an internal helper I think.