### PR TITLE
Refactor HMR hooks

### DIFF
--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -11,6 +11,7 @@ const ModuleHotAcceptDependency = require("./dependencies/ModuleHotAcceptDepende
 const ModuleHotDeclineDependency = require("./dependencies/ModuleHotDeclineDependency");
 const ConstDependency = require("./dependencies/ConstDependency");
 const NullFactory = require("./NullFactory");
+const JavascriptParser = require("./JavascriptParser");
 const {
 	evaluateToIdentifier,
 	evaluateToString,
@@ -26,6 +27,11 @@ const parserHooksMap = new WeakMap();
 
 module.exports = class HotModuleReplacementPlugin {
 	static getHooks(parser) {
+		if (!(parser instanceof JavascriptParser)) {
+			throw new TypeError(
+				"The 'parser' argument must be an instance of JavascriptParser"
+			);
+		}
 		let hooks = parserHooksMap.get(parser);
 		if (hooks === undefined) {
 			hooks = {

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -18,7 +18,25 @@ const {
 	toConstantDependencyWithWebpackRequire
 } = require("./JavascriptParserHelpers");
 
+const hotInitCode = Template.getFunctionContent(
+	require("./HotModuleReplacement.runtime.js")
+);
+
+const parserHooksMap = new WeakMap();
+
 module.exports = class HotModuleReplacementPlugin {
+	static getHooks(parser) {
+		let hooks = parserHooksMap.get(parser);
+		if (hooks === undefined) {
+			hooks = {
+				hotAcceptCallback: new SyncBailHook(["expression", "requests"]),
+				hotAcceptWithoutCallback: new SyncBailHook(["expression", "requests"])
+			};
+			parserHooksMap.set(parser, hooks);
+		}
+		return hooks;
+	}
+
 	constructor(options) {
 		this.options = options || {};
 		this.multiStep = this.options.multiStep;
@@ -42,6 +60,11 @@ module.exports = class HotModuleReplacementPlugin {
 		);
 
 		const addParserPlugins = (parser, parserOptions) => {
+			const {
+				hotAcceptCallback,
+				hotAcceptWithoutCallback
+			} = HotModuleReplacementPlugin.getHooks(parser);
+
 			parser.hooks.expression
 				.for("__webpack_hash__")
 				.tap(
@@ -66,19 +89,6 @@ module.exports = class HotModuleReplacementPlugin {
 					)(expr);
 				}
 			);
-			// TODO webpack 5: refactor this, no custom hooks
-			if (!parser.hooks.hotAcceptCallback) {
-				parser.hooks.hotAcceptCallback = new SyncBailHook([
-					"expression",
-					"requests"
-				]);
-			}
-			if (!parser.hooks.hotAcceptWithoutCallback) {
-				parser.hooks.hotAcceptWithoutCallback = new SyncBailHook([
-					"expression",
-					"requests"
-				]);
-			}
 			parser.hooks.call
 				.for("module.hot.accept")
 				.tap("HotModuleReplacementPlugin", expr => {
@@ -105,14 +115,11 @@ module.exports = class HotModuleReplacementPlugin {
 								requests.push(request);
 							});
 							if (expr.arguments.length > 1) {
-								parser.hooks.hotAcceptCallback.call(
-									expr.arguments[1],
-									requests
-								);
+								hotAcceptCallback.call(expr.arguments[1], requests);
 								parser.walkExpression(expr.arguments[1]); // other args are ignored
 								return true;
 							} else {
-								parser.hooks.hotAcceptWithoutCallback.call(expr, requests);
+								hotAcceptWithoutCallback.call(expr, requests);
 								return true;
 							}
 						}
@@ -407,7 +414,3 @@ module.exports = class HotModuleReplacementPlugin {
 		);
 	}
 };
-
-const hotInitCode = Template.getFunctionContent(
-	require("./HotModuleReplacement.runtime.js")
-);

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -4,7 +4,7 @@
 */
 "use strict";
 
-const { SyncBailHook } = require("tapable");
+const HotModuleReplacementPlugin = require("../HotModuleReplacementPlugin");
 const HarmonyImportSideEffectDependency = require("./HarmonyImportSideEffectDependency");
 const HarmonyImportSpecifierDependency = require("./HarmonyImportSpecifierDependency");
 const HarmonyAcceptImportDependency = require("./HarmonyAcceptImportDependency");
@@ -152,20 +152,11 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 				if (args) parser.walkExpressions(args);
 				return true;
 			});
-		// TODO webpack 5: refactor this, no custom hooks
-		if (!parser.hooks.hotAcceptCallback) {
-			parser.hooks.hotAcceptCallback = new SyncBailHook([
-				"expression",
-				"requests"
-			]);
-		}
-		if (!parser.hooks.hotAcceptWithoutCallback) {
-			parser.hooks.hotAcceptWithoutCallback = new SyncBailHook([
-				"expression",
-				"requests"
-			]);
-		}
-		parser.hooks.hotAcceptCallback.tap(
+		const {
+			hotAcceptCallback,
+			hotAcceptWithoutCallback
+		} = HotModuleReplacementPlugin.getHooks(parser);
+		hotAcceptCallback.tap(
 			"HarmonyImportDependencyParserPlugin",
 			(expr, requests) => {
 				const harmonyParserScope = parser.state.harmonyParserScope;
@@ -194,7 +185,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 				}
 			}
 		);
-		parser.hooks.hotAcceptWithoutCallback.tap(
+		hotAcceptWithoutCallback.tap(
 			"HarmonyImportDependencyParserPlugin",
 			(expr, requests) => {
 				const dependencies = requests.map(request => {


### PR DESCRIPTION
Refactor HMR plugin to change how hooks are installed.

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

already tested

**Does this PR introduce a breaking change?**

yes

**What needs to be documented once your changes are merged?**

Currently HMR hooks are not documented. If some day they are, then it must uses `HotModuleReplacementPlugin.hooks(parser)`.