### PR TITLE
Use JsonpMainTemplatePlugin.hooks instead of MainTemplate#hooks

### DIFF
--- a/lib/web/JsonpMainTemplatePlugin.js
+++ b/lib/web/JsonpMainTemplatePlugin.js
@@ -5,12 +5,18 @@
 "use strict";
 
 const { SyncWaterfallHook } = require("tapable");
+const MainTemplate = require("../MainTemplate");
 const Template = require("../Template");
 
 const mainTemplateHooksMap = new WeakMap();
 
 class JsonpMainTemplatePlugin {
-	static hooks(mainTemplate) {
+	static getHooks(mainTemplate) {
+		if (!(mainTemplate instanceof MainTemplate)) {
+			throw new TypeError(
+				"The 'mainTemplate' argument must be an instance of MainTemplate"
+			);
+		}
 		let hooks = mainTemplateHooksMap.get(mainTemplate);
 		if (hooks === undefined) {
 			hooks = {
@@ -142,7 +148,7 @@ class JsonpMainTemplatePlugin {
 			}
 		);
 
-		const mainTemplateHooks = JsonpMainTemplatePlugin.hooks(mainTemplate);
+		const mainTemplateHooks = JsonpMainTemplatePlugin.getHooks(mainTemplate);
 
 		mainTemplateHooks.jsonpScript.tap(
 			"JsonpMainTemplatePlugin",

--- a/lib/web/JsonpMainTemplatePlugin.js
+++ b/lib/web/JsonpMainTemplatePlugin.js
@@ -7,7 +7,22 @@
 const { SyncWaterfallHook } = require("tapable");
 const Template = require("../Template");
 
+const mainTemplateHooksMap = new WeakMap();
+
 class JsonpMainTemplatePlugin {
+	static hooks(mainTemplate) {
+		let hooks = mainTemplateHooksMap.get(mainTemplate);
+		if (hooks === undefined) {
+			hooks = {
+				jsonpScript: new SyncWaterfallHook(["source", "chunk", "hash"]),
+				linkPreload: new SyncWaterfallHook(["source", "chunk", "hash"]),
+				linkPrefetch: new SyncWaterfallHook(["source", "chunk", "hash"])
+			};
+			mainTemplateHooksMap.set(mainTemplate, hooks);
+		}
+		return hooks;
+	}
+
 	apply(mainTemplate) {
 		const needChunkOnDemandLoadingCode = chunk => {
 			for (const chunkGroup of chunk.groupsIterable) {
@@ -32,17 +47,6 @@ class JsonpMainTemplatePlugin {
 			const allPrefetchChunks = chunk.getChildIdsByOrdersMap(true).prefetch;
 			return allPrefetchChunks && Object.keys(allPrefetchChunks).length;
 		};
-
-		// TODO webpack 5, no adding to .hooks, use WeakMap and static methods
-		["jsonpScript", "linkPreload", "linkPrefetch"].forEach(hook => {
-			if (!mainTemplate.hooks[hook]) {
-				mainTemplate.hooks[hook] = new SyncWaterfallHook([
-					"source",
-					"chunk",
-					"hash"
-				]);
-			}
-		});
 
 		const getScriptSrcPath = (hash, chunk, chunkIdExpression) => {
 			const chunkFilename = mainTemplate.outputOptions.chunkFilename;
@@ -138,7 +142,9 @@ class JsonpMainTemplatePlugin {
 			}
 		);
 
-		mainTemplate.hooks.jsonpScript.tap(
+		const mainTemplateHooks = JsonpMainTemplatePlugin.hooks(mainTemplate);
+
+		mainTemplateHooks.jsonpScript.tap(
 			"JsonpMainTemplatePlugin",
 			(_, chunk, hash) => {
 				const crossOriginLoading =
@@ -201,7 +207,7 @@ class JsonpMainTemplatePlugin {
 				]);
 			}
 		);
-		mainTemplate.hooks.linkPreload.tap(
+		mainTemplateHooks.linkPreload.tap(
 			"JsonpMainTemplatePlugin",
 			(_, chunk, hash) => {
 				const crossOriginLoading =
@@ -234,7 +240,7 @@ class JsonpMainTemplatePlugin {
 				]);
 			}
 		);
-		mainTemplate.hooks.linkPrefetch.tap(
+		mainTemplateHooks.linkPrefetch.tap(
 			"JsonpMainTemplatePlugin",
 			(_, chunk, hash) => {
 				const crossOriginLoading =
@@ -283,7 +289,7 @@ class JsonpMainTemplatePlugin {
 							"",
 							"// start chunk loading",
 							"var head = document.getElementsByTagName('head')[0];",
-							mainTemplate.hooks.jsonpScript.call("", chunk, hash),
+							mainTemplateHooks.jsonpScript.call("", chunk, hash),
 							"head.appendChild(script);"
 						]),
 						"}"
@@ -316,7 +322,7 @@ class JsonpMainTemplatePlugin {
 							"if(installedChunks[chunkId] === undefined) {",
 							Template.indent([
 								"installedChunks[chunkId] = null;",
-								mainTemplate.hooks.linkPreload.call("", chunk, hash),
+								mainTemplateHooks.linkPreload.call("", chunk, hash),
 								"head.appendChild(link);"
 							]),
 							"}"
@@ -394,7 +400,7 @@ class JsonpMainTemplatePlugin {
 											"if(installedChunks[chunkId] === undefined) {",
 											Template.indent([
 												"installedChunks[chunkId] = null;",
-												mainTemplate.hooks.linkPrefetch.call("", chunk, hash),
+												mainTemplateHooks.linkPrefetch.call("", chunk, hash),
 												"head.appendChild(link);"
 											]),
 											"}"


### PR DESCRIPTION
Refactor `JsonpMainTemplatePlugin` plugin to change how hooks are installed into `MainTemplate`.
cc @jantimon

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

yes

**What needs to be documented once your changes are merged?**

Maybe `JsonpMainTemplatePlugin.hooks`.