### PR TITLE
Remove Dependency#getReference existance check

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1439,8 +1439,6 @@ class Compilation {
 	 * @returns {DependencyReference} a reference for the dependency
 	 */
 	getDependencyReference(module, dependency) {
-		// TODO remove dep.getReference existance check in webpack 5
-		if (typeof dependency.getReference !== "function") return null;
 		const ref = dependency.getReference();
 		if (!ref) return null;
 		return this.hooks.dependencyReference.call(ref, dependency, module);


### PR DESCRIPTION
Since `getReference` is defined into `Dependency`, this case shouldn't happen.

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

nothing