### PR TITLE
Added support for WebAssembly modules when target is set to `electron-renderer`

### DIFF
--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -171,9 +171,13 @@ class WebpackOptionsApply extends OptionsApply {
 					break;
 				case "electron-renderer":
 					JsonpTemplatePlugin = require("./web/JsonpTemplatePlugin");
+					FetchCompileWasmTemplatePlugin = require("./web/FetchCompileWasmTemplatePlugin");
 					NodeTargetPlugin = require("./node/NodeTargetPlugin");
 					ExternalsPlugin = require("./ExternalsPlugin");
 					new JsonpTemplatePlugin().apply(compiler);
+					new FetchCompileWasmTemplatePlugin({
+						mangleImports: options.optimization.mangleWasmImports
+					}).apply(compiler);
 					new FunctionModulePlugin().apply(compiler);
 					new NodeTargetPlugin().apply(compiler);
 					new ExternalsPlugin("commonjs", [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Currently it is not possible to use WebAssembly modules when target is set to `electron-renderer`. This pull request adds support for it. See #7677.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

This PR adds a feature.

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

No.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**What needs to be documented once your changes are merged?**

I couldn't find much documentation on WebAssembly modules, so I don't think there is a place where this change can be documented before there is more documentation.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
