### PR TITLE
add new options moduleIds and chunkIds

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1292,6 +1292,9 @@ class Compilation extends Tapable {
 	 * @returns {void}
 	 */
 	sortModules(modules) {
+		// TODO webpack 5: this should only be enabled when `moduleIds: "natural"`
+		// TODO move it into a plugin (NaturalModuleIdsPlugin) and use this in WebpackOptionsApply
+		// TODO remove this method
 		modules.sort(byIndexOrIdentifier);
 	}
 

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -46,7 +46,9 @@ const RemoveParentModulesPlugin = require("./optimize/RemoveParentModulesPlugin"
 const RemoveEmptyChunksPlugin = require("./optimize/RemoveEmptyChunksPlugin");
 const MergeDuplicateChunksPlugin = require("./optimize/MergeDuplicateChunksPlugin");
 const FlagIncludedChunksPlugin = require("./optimize/FlagIncludedChunksPlugin");
-const OccurrenceOrderPlugin = require("./optimize/OccurrenceOrderPlugin");
+const OccurrenceChunkOrderPlugin = require("./optimize/OccurrenceChunkOrderPlugin");
+const OccurrenceModuleOrderPlugin = require("./optimize/OccurrenceModuleOrderPlugin");
+const NaturalChunkOrderPlugin = require("./optimize/NaturalChunkOrderPlugin");
 const SideEffectsFlagPlugin = require("./optimize/SideEffectsFlagPlugin");
 const FlagDependencyUsagePlugin = require("./FlagDependencyUsagePlugin");
 const FlagDependencyExportsPlugin = require("./FlagDependencyExportsPlugin");
@@ -325,9 +327,6 @@ class WebpackOptionsApply extends OptionsApply {
 		if (options.optimization.flagIncludedChunks) {
 			new FlagIncludedChunksPlugin().apply(compiler);
 		}
-		if (options.optimization.occurrenceOrder) {
-			new OccurrenceOrderPlugin(true).apply(compiler);
-		}
 		if (options.optimization.sideEffects) {
 			new SideEffectsFlagPlugin().apply(compiler);
 		}
@@ -352,14 +351,93 @@ class WebpackOptionsApply extends OptionsApply {
 		if (options.optimization.checkWasmTypes) {
 			new WasmFinalizeExportsPlugin().apply(compiler);
 		}
-		if (options.optimization.namedModules) {
-			new NamedModulesPlugin().apply(compiler);
+		let moduleIds = options.optimization.moduleIds;
+		if (moduleIds === undefined) {
+			// TODO webpack 5 remove all these options
+			if (options.optimization.occurrenceOrder) {
+				moduleIds = "size";
+			}
+			if (options.optimization.namedModules) {
+				moduleIds = "named";
+			}
+			if (options.optimization.hashedModuleIds) {
+				moduleIds = "hashed";
+			}
+			if (moduleIds === undefined) {
+				moduleIds = "natural";
+			}
 		}
-		if (options.optimization.hashedModuleIds) {
-			new HashedModuleIdsPlugin().apply(compiler);
+		if (moduleIds) {
+			switch (moduleIds) {
+				case "natural":
+					// TODO webpack 5: see hint in Compilation.sortModules
+					break;
+				case "named":
+					new NamedModulesPlugin().apply(compiler);
+					break;
+				case "hashed":
+					new HashedModuleIdsPlugin().apply(compiler);
+					break;
+				case "size":
+					new OccurrenceModuleOrderPlugin({
+						prioritiseInitial: true
+					}).apply(compiler);
+					break;
+				case "total-size":
+					new OccurrenceModuleOrderPlugin({
+						prioritiseInitial: false
+					}).apply(compiler);
+					break;
+				default:
+					throw new Error(
+						`webpack bug: moduleIds: ${moduleIds} is not implemented`
+					);
+			}
 		}
-		if (options.optimization.namedChunks) {
-			new NamedChunksPlugin().apply(compiler);
+		let chunkIds = options.optimization.chunkIds;
+		if (chunkIds === undefined) {
+			// TODO webpack 5 remove all these options
+			if (options.optimization.occurrenceOrder) {
+				// This looks weird but it's for backward-compat
+				// This bug already existed before adding this feature
+				chunkIds = "total-size";
+			}
+			if (options.optimization.namedChunks) {
+				chunkIds = "named";
+			}
+			if (chunkIds === undefined) {
+				chunkIds = "natural";
+			}
+		}
+		if (chunkIds) {
+			switch (chunkIds) {
+				case "natural":
+					new NaturalChunkOrderPlugin().apply(compiler);
+					break;
+				case "named":
+					// TODO webapck 5: for backward-compat this need to have OccurrenceChunkOrderPlugin too
+					// The NamedChunksPlugin doesn't give every chunk a name
+					// This should be fixed, and the OccurrenceChunkOrderPlugin should be removed here.
+					new OccurrenceChunkOrderPlugin({
+						prioritiseInitial: false
+					}).apply(compiler);
+					new NamedChunksPlugin().apply(compiler);
+					break;
+				case "size":
+					new OccurrenceChunkOrderPlugin({
+						prioritiseInitial: true
+					}).apply(compiler);
+					break;
+				case "total-size":
+					new OccurrenceChunkOrderPlugin({
+						prioritiseInitial: false
+					}).apply(compiler);
+					break;
+				default:
+					throw new Error(
+						`webpack bug: chunkIds: ${chunkIds} is not implemented`
+					);
+			}
 		}
 		if (options.optimization.nodeEnv) {
 			new DefinePlugin({

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -201,6 +201,9 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("optimization.flagIncludedChunks", "make", options =>
 			isProductionLikeMode(options)
 		);
+		// TODO webpack 5 add `moduleIds: "named"` default for development
+		// TODO webpack 5 add `moduleIds: "size"` default for production
+		// TODO webpack 5 remove optimization.occurrenceOrder
 		this.set("optimization.occurrenceOrder", "make", options =>
 			isProductionLikeMode(options)
 		);
@@ -261,12 +264,16 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 			isProductionLikeMode(options)
 		);
 		this.set("optimization.mangleWasmImports", false);
+		// TODO webpack 5 remove optimization.namedModules
 		this.set(
 			"optimization.namedModules",
 			"make",
 			options => options.mode === "development"
 		);
 		this.set("optimization.hashedModuleIds", false);
+		// TODO webpack 5 add `chunkIds: "named"` default for development
+		// TODO webpack 5 add `chunkIds: "size"` default for production
+		// TODO webpack 5 remove optimization.namedChunks
 		this.set(
 			"optimization.namedChunks",
 			"make",

--- a/lib/optimize/NaturalChunkOrderPlugin.js
+++ b/lib/optimize/NaturalChunkOrderPlugin.js
@@ -1,0 +1,41 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+"use strict";
+
+/** @typedef {import("../Compiler")} Compiler */
+
+class NaturalChunkOrderPlugin {
+	/**
+	 * @param {Compiler} compiler webpack compiler
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap("NaturalChunkOrderPlugin", compilation => {
+			compilation.hooks.optimizeChunkOrder.tap(
+				"NaturalChunkOrderPlugin",
+				chunks => {
+					chunks.sort((chunkA, chunkB) => {
+						const a = chunkA.modulesIterable[Symbol.iterator]();
+						const b = chunkB.modulesIterable[Symbol.iterator]();
+						// eslint-disable-next-line no-constant-condition
+						while (true) {
+							const aItem = a.next();
+							const bItem = b.next();
+							if (aItem.done && bItem.done) return 0;
+							if (aItem.done) return -1;
+							if (bItem.done) return 1;
+							const aModuleId = aItem.value.id;
+							const bModuleId = bItem.value.id;
+							if (aModuleId < bModuleId) return -1;
+							if (aModuleId > bModuleId) return 1;
+						}
+					});
+				}
+			);
+		});
+	}
+}
+
+module.exports = NaturalChunkOrderPlugin;

--- a/lib/optimize/OccurrenceChunkOrderPlugin.js
+++ b/lib/optimize/OccurrenceChunkOrderPlugin.js
@@ -1,0 +1,61 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+"use strict";
+
+const validateOptions = require("schema-utils");
+const schema = require("../../schemas/plugins/optimize/OccurrenceOrderChunkIdsPlugin.json");
+
+class OccurrenceOrderChunkIdsPlugin {
+	constructor(options = {}) {
+		validateOptions(schema, options, "Occurrence Order Chunk Ids Plugin");
+		this.options = options;
+	}
+
+	apply(compiler) {
+		const prioritiseInitial = this.options.prioritiseInitial;
+		compiler.hooks.compilation.tap(
+			"OccurrenceOrderChunkIdsPlugin",
+			compilation => {
+				compilation.hooks.optimizeChunkOrder.tap(
+					"OccurrenceOrderChunkIdsPlugin",
+					chunks => {
+						const occursInInitialChunksMap = new Map();
+						const originalOrder = new Map();
+
+						let i = 0;
+						for (const c of chunks) {
+							let occurs = 0;
+							for (const chunkGroup of c.groupsIterable) {
+								for (const parent of chunkGroup.parentsIterable) {
+									if (parent.isInitial()) occurs++;
+								}
+							}
+							occursInInitialChunksMap.set(c, occurs);
+							originalOrder.set(c, i++);
+						}
+
+						chunks.sort((a, b) => {
+							if (prioritiseInitial) {
+								const aEntryOccurs = occursInInitialChunksMap.get(a);
+								const bEntryOccurs = occursInInitialChunksMap.get(b);
+								if (aEntryOccurs > bEntryOccurs) return -1;
+								if (aEntryOccurs < bEntryOccurs) return 1;
+							}
+							const aOccurs = a.getNumberOfGroups();
+							const bOccurs = b.getNumberOfGroups();
+							if (aOccurs > bOccurs) return -1;
+							if (aOccurs < bOccurs) return 1;
+							const orgA = originalOrder.get(a);
+							const orgB = originalOrder.get(b);
+							return orgB - orgA;
+						});
+					}
+				);
+			}
+		);
+	}
+}
+
+module.exports = OccurrenceOrderChunkIdsPlugin;

--- a/lib/optimize/OccurrenceModuleOrderPlugin.js
+++ b/lib/optimize/OccurrenceModuleOrderPlugin.js
@@ -1,0 +1,103 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+"use strict";
+
+const validateOptions = require("schema-utils");
+const schema = require("../../schemas/plugins/optimize/OccurrenceOrderModuleIdsPlugin.json");
+
+class OccurrenceOrderModuleIdsPlugin {
+	constructor(options = {}) {
+		validateOptions(schema, options, "Occurrence Order Module Ids Plugin");
+		this.options = options;
+	}
+
+	apply(compiler) {
+		const prioritiseInitial = this.options.prioritiseInitial;
+		compiler.hooks.compilation.tap(
+			"OccurrenceOrderModuleIdsPlugin",
+			compilation => {
+				compilation.hooks.optimizeModuleOrder.tap(
+					"OccurrenceOrderModuleIdsPlugin",
+					modules => {
+						const occursInInitialChunksMap = new Map();
+						const occursInAllChunksMap = new Map();
+
+						const initialChunkChunkMap = new Map();
+						const entryCountMap = new Map();
+						for (const m of modules) {
+							let initial = 0;
+							let entry = 0;
+							for (const c of m.chunksIterable) {
+								if (c.canBeInitial()) initial++;
+								if (c.entryModule === m) entry++;
+							}
+							initialChunkChunkMap.set(m, initial);
+							entryCountMap.set(m, entry);
+						}
+
+						const countOccursInEntry = (sum, r) => {
+							if (!r.module) {
+								return sum;
+							}
+							return sum + initialChunkChunkMap.get(r.module);
+						};
+						const countOccurs = (sum, r) => {
+							if (!r.module) {
+								return sum;
+							}
+							let factor = 1;
+							if (typeof r.dependency.getNumberOfIdOccurrences === "function") {
+								factor = r.dependency.getNumberOfIdOccurrences();
+							}
+							if (factor === 0) {
+								return sum;
+							}
+							return sum + factor * r.module.getNumberOfChunks();
+						};
+
+						if (prioritiseInitial) {
+							for (const m of modules) {
+								const result =
+									m.reasons.reduce(countOccursInEntry, 0) +
+									initialChunkChunkMap.get(m) +
+									entryCountMap.get(m);
+								occursInInitialChunksMap.set(m, result);
+							}
+						}
+
+						const originalOrder = new Map();
+						let i = 0;
+						for (const m of modules) {
+							const result =
+								m.reasons.reduce(countOccurs, 0) +
+								m.getNumberOfChunks() +
+								entryCountMap.get(m);
+							occursInAllChunksMap.set(m, result);
+							originalOrder.set(m, i++);
+						}
+
+						modules.sort((a, b) => {
+							if (prioritiseInitial) {
+								const aEntryOccurs = occursInInitialChunksMap.get(a);
+								const bEntryOccurs = occursInInitialChunksMap.get(b);
+								if (aEntryOccurs > bEntryOccurs) return -1;
+								if (aEntryOccurs < bEntryOccurs) return 1;
+							}
+							const aOccurs = occursInAllChunksMap.get(a);
+							const bOccurs = occursInAllChunksMap.get(b);
+							if (aOccurs > bOccurs) return -1;
+							if (aOccurs < bOccurs) return 1;
+							const orgA = originalOrder.get(a);
+							const orgB = originalOrder.get(b);
+							return orgB - orgA;
+						});
+					}
+				);
+			}
+		);
+	}
+}
+
+module.exports = OccurrenceOrderModuleIdsPlugin;

--- a/lib/optimize/OccurrenceOrderPlugin.js
+++ b/lib/optimize/OccurrenceOrderPlugin.js
@@ -4,6 +4,8 @@
 */
 "use strict";
 
+// TODO webpack 5 remove this plugin
+// It has been splitted into separate plugins for modules and chunks
 class OccurrenceOrderPlugin {
 	constructor(preferEntry) {
 		if (preferEntry !== undefined && typeof preferEntry !== "boolean") {

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -137,6 +137,10 @@ exportPlugins((exports.optimize = {}), {
 	ModuleConcatenationPlugin: () =>
 		require("./optimize/ModuleConcatenationPlugin"),
 	OccurrenceOrderPlugin: () => require("./optimize/OccurrenceOrderPlugin"),
+	OccurrenceModuleOrderPlugin: () =>
+		require("./optimize/OccurrenceModuleOrderPlugin"),
+	OccurrenceChunkOrderPlugin: () =>
+		require("./optimize/OccurrenceChunkOrderPlugin"),
 	RuntimeChunkPlugin: () => require("./optimize/RuntimeChunkPlugin"),
 	SideEffectsFlagPlugin: () => require("./optimize/SideEffectsFlagPlugin"),
 	SplitChunksPlugin: () => require("./optimize/SplitChunksPlugin")

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1586,16 +1586,37 @@
           "description": "Reduce size of WASM by changing imports to shorter strings.",
           "type": "boolean"
         },
+        "moduleIds": {
+          "description": "Define the algorithm to choose module ids (natural: numeric ids in order for usage, named: readable ids for better debugging, hashed: short hashes as ids for better long term caching, size: numeric ids focused on minimal initial download size, total-size: numeric ids focused on minimal total download size, false: no algorithm used, as custom one can be provided via plugin)",
+          "enum": [
+            "natural",
+            "named",
+            "hashed",
+            "size",
+            "total-size",
+            false
+          ]
+        },
+        "chunkIds": {
+          "description": "Define the algorithm to choose chunk ids (named: readable ids for better debugging, size: numeric ids focused on minimal initial download size, total-size: numeric ids focused on minimal total download size, false: no algorithm used, as custom one can be provided via plugin)",
+          "enum": [
+            "natural",
+            "named",
+            "size",
+            "total-size",
+            false
+          ]
+        },
         "namedModules": {
-          "description": "Use readable module identifiers for better debugging",
+          "description": "Use readable module identifiers for better debugging (deprecated, used moduleIds: named instead)",
           "type": "boolean"
         },
         "hashedModuleIds": {
-          "description": "Use hashed module id instead module identifiers for better long term caching",
+          "description": "Use hashed module id instead module identifiers for better long term caching (deprecated, used moduleIds: hashed instead)",
           "type": "boolean"
         },
         "namedChunks": {
-          "description": "Use readable chunk identifiers for better debugging",
+          "description": "Use readable chunk identifiers for better debugging (deprecated, used chunkIds: named instead)",
           "type": "boolean"
         },
         "portableRecords": {

--- a/schemas/plugins/optimize/OccurrenceOrderChunkIdsPlugin.json
+++ b/schemas/plugins/optimize/OccurrenceOrderChunkIdsPlugin.json
@@ -1,0 +1,10 @@
+{
+  "additionalProperties": false,
+  "type": "object",
+  "properties": {
+    "prioritiseInitial": {
+      "description": "Prioritise initial size over total size",
+      "type": "boolean"
+    }
+  }
+}

--- a/schemas/plugins/optimize/OccurrenceOrderModuleIdsPlugin.json
+++ b/schemas/plugins/optimize/OccurrenceOrderModuleIdsPlugin.json
@@ -1,0 +1,10 @@
+{
+  "additionalProperties": false,
+  "type": "object",
+  "properties": {
+    "prioritiseInitial": {
+      "description": "Prioritise initial size over total size",
+      "type": "boolean"
+    }
+  }
+}

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -467,28 +467,28 @@ Child all:
 `;
 
 exports[`StatsTestCases should print correct stats for chunk-module-id-range 1`] = `
-"Hash: 7d8eb8b4418c6ae6a262
+"Hash: b385901db3d63ff731a3
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
    Asset      Size  Chunks             Chunk Names
-main2.js  4.85 KiB       0  [emitted]  main2
-main1.js  4.86 KiB       1  [emitted]  main1
+main1.js  4.86 KiB       0  [emitted]  main1
+main2.js  4.85 KiB       1  [emitted]  main2
 Entrypoint main1 = main1.js
 Entrypoint main2 = main2.js
-chunk    {0} main2.js (main2) 136 bytes [entry] [rendered]
-    > ./main2 main2
-   [0] ./e.js 20 bytes {0} [built]
-   [1] ./f.js 20 bytes {0} [built]
-   [2] ./main2.js 56 bytes {0} [built]
- [100] ./d.js 20 bytes {0} {1} [built]
- [101] ./a.js 20 bytes {0} {1} [built]
-chunk    {1} main1.js (main1) 136 bytes [entry] [rendered]
+chunk    {0} main1.js (main1) 136 bytes [entry] [rendered]
     > ./main1 main1
-   [3] ./b.js 20 bytes {1} [built]
-   [4] ./main1.js 56 bytes {1} [built]
+   [3] ./b.js 20 bytes {0} [built]
+   [4] ./main1.js 56 bytes {0} [built]
  [100] ./d.js 20 bytes {0} {1} [built]
  [101] ./a.js 20 bytes {0} {1} [built]
- [102] ./c.js 20 bytes {1} [built]"
+ [102] ./c.js 20 bytes {0} [built]
+chunk    {1} main2.js (main2) 136 bytes [entry] [rendered]
+    > ./main2 main2
+   [0] ./e.js 20 bytes {1} [built]
+   [1] ./f.js 20 bytes {1} [built]
+   [2] ./main2.js 56 bytes {1} [built]
+ [100] ./d.js 20 bytes {0} {1} [built]
+ [101] ./a.js 20 bytes {0} {1} [built]"
 `;
 
 exports[`StatsTestCases should print correct stats for chunks 1`] = `
@@ -530,14 +530,14 @@ chunk    {3} 3.bundle.js 44 bytes <{1}> [rendered]
 `;
 
 exports[`StatsTestCases should print correct stats for chunks-development 1`] = `
-"Hash: 491964abb8a9925c2f65
+"Hash: 83bf92a94bc3834801e8
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
       Asset       Size  Chunks             Chunk Names
-0.bundle.js  433 bytes       0  [emitted]  
-1.bundle.js  297 bytes       1  [emitted]  
-2.bundle.js  588 bytes       2  [emitted]  
+0.bundle.js  297 bytes       0  [emitted]  
+1.bundle.js  433 bytes       1  [emitted]  
   bundle.js   8.67 KiB    main  [emitted]  main
+2.bundle.js  588 bytes       2  [emitted]  
 Entrypoint main = bundle.js
 chunk {main} bundle.js (main) 73 bytes >{0}< >{1}< [entry] [rendered]
     > ./index main
@@ -548,17 +548,17 @@ chunk {main} bundle.js (main) 73 bytes >{0}< >{1}< [entry] [rendered]
  [./index.js] 51 bytes {main} [built]
      single entry ./index  main
      factory:Xms building:Xms = Xms
-chunk    {0} 0.bundle.js 54 bytes <{main}> >{2}< [rendered]
-    > ./c [./index.js] ./index.js 3:0-16
- [./c.js] 54 bytes {0} [built]
-     amd require ./c [./index.js] 3:0-16
-     [./index.js] Xms -> factory:Xms building:Xms = Xms
-chunk    {1} 1.bundle.js 22 bytes <{main}> [rendered]
+chunk    {0} 0.bundle.js 22 bytes <{main}> [rendered]
     > ./b [./index.js] ./index.js 2:0-16
- [./b.js] 22 bytes {1} [built]
+ [./b.js] 22 bytes {0} [built]
      amd require ./b [./index.js] 2:0-16
      [./index.js] Xms -> factory:Xms building:Xms = Xms
-chunk    {2} 2.bundle.js 60 bytes <{0}> [rendered]
+chunk    {1} 1.bundle.js 54 bytes <{main}> >{2}< [rendered]
+    > ./c [./index.js] ./index.js 3:0-16
+ [./c.js] 54 bytes {1} [built]
+     amd require ./c [./index.js] 3:0-16
+     [./index.js] Xms -> factory:Xms building:Xms = Xms
+chunk    {2} 2.bundle.js 60 bytes <{1}> [rendered]
     > [./c.js] ./c.js 1:0-52
  [./d.js] 22 bytes {2} [built]
      require.ensure item ./d [./c.js] 1:0-52


### PR DESCRIPTION
add new options moduleIds and chunkIds
deprecate namedModules, hashedModuleIds, namedChunks
add a lot of TODOs for webpack 5
split OccurenceOrderPlugin into separate plugins for modules and chunks
add NaturalChunkOrderPlugin and enable it in development

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature and bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
new options moduleIds and chunkIds (see schema for description)

#### optimization.moduleIds

Define the algorithm to choose module ids
natural: numeric ids in order for usage
named: readable ids for better debugging
hashed: short hashes as ids for better long term caching
size: numeric ids focused on minimal initial download size
total-size: numeric ids focused on minimal total download size
false: no algorithm used, as custom one can be provided via plugin)",

#### optimization.chunkIds

Define the algorithm to choose chunk ids
natural: numeric ids in order for usage
named: readable ids for better debugging
size: numeric ids focused on minimal initial download size
total-size: numeric ids focused on minimal total download size
false: no algorithm used, as custom one can be provided via plugin