### PR TITLE
devtool and output.library.root as array throws an error

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -17,6 +17,16 @@ const isWebLikeTarget = options => {
 	return options.target === "web" || options.target === "webworker";
 };
 
+const getDevtoolNamespace = library => {
+	// if options.output.library is a string
+	if (Array.isArray(library)) {
+		return library.join(".");
+	} else if (typeof library === "object") {
+		return getDevtoolNamespace(library.root);
+	}
+	return library || "";
+}
+
 class WebpackOptionsDefaulter extends OptionsDefaulter {
 	constructor() {
 		super();
@@ -60,8 +70,8 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 				resolve: {
 					mainFields:
 						options.target === "web" ||
-						options.target === "webworker" ||
-						options.target === "electron-renderer"
+							options.target === "webworker" ||
+							options.target === "electron-renderer"
 							? ["browser", "main"]
 							: ["main"]
 				}
@@ -136,12 +146,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 			}
 		});
 		this.set("output.devtoolNamespace", "make", options => {
-			if (Array.isArray(options.output.library)) {
-				return options.output.library.join(".");
-			} else if (typeof options.output.library === "object") {
-				return options.output.library.root || "";
-			}
-			return options.output.library || "";
+			return getDevtoolNamespace(options.output.library);
 		});
 		this.set("output.libraryTarget", "var");
 		this.set("output.path", path.join(process.cwd(), "dist"));

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -25,7 +25,7 @@ const getDevtoolNamespace = library => {
 		return getDevtoolNamespace(library.root);
 	}
 	return library || "";
-}
+};
 
 class WebpackOptionsDefaulter extends OptionsDefaulter {
 	constructor() {
@@ -70,8 +70,8 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 				resolve: {
 					mainFields:
 						options.target === "web" ||
-							options.target === "webworker" ||
-							options.target === "electron-renderer"
+						options.target === "webworker" ||
+						options.target === "electron-renderer"
 							? ["browser", "main"]
 							: ["main"]
 				}

--- a/test/configCases/source-map/array-as-output-library-in-object-output/index.js
+++ b/test/configCases/source-map/array-as-output-library-in-object-output/index.js
@@ -1,0 +1,1 @@
+it("should compile successfully when output.library.root is an array of strings", function () { });

--- a/test/configCases/source-map/array-as-output-library-in-object-output/webpack.config.js
+++ b/test/configCases/source-map/array-as-output-library-in-object-output/webpack.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	devtool: "source-map",
+	output: {
+		library: {
+			root: ["Foo", "[name]"],
+			amd: "[name]",
+			commonjs: "[name]"
+		},
+		libraryTarget: "umd"
+	}
+};


### PR DESCRIPTION
When using the following configuration:

```javascript
module.exports = {
	devtool: "source-map",
	output: {
		library: {
			root: ["Foo", "[name]"],
			amd: "[name]",
			commonjs: "[name]"
		},
		libraryTarget: "umd"
	}
};
``` 
Devtool throws the following error:

```
ValidationError: SourceMap DevTool Plugin Invalid Options

options.namespace should be string
```

This PR fixes this issue.

**What kind of change does this PR introduce?**

Fixes the bug by recursively checking if the value iss an array or a string.

**Did you add tests for your changes?**

Tests were added

**Does this PR introduce a breaking change?**

No breaking change

**What needs to be documented once your changes are merged?**

Bug fix, no need to change documentation.