### PR TITLE
Add .mjs to default DelegatedModule options.extensions

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -7,7 +7,6 @@ declare namespace NodeJS {
 	}
 }
 
-
 declare module "neo-async" {
 	export interface Dictionary<T> {
 		[key: string]: T;

--- a/lib/DelegatedModuleFactoryPlugin.js
+++ b/lib/DelegatedModuleFactoryPlugin.js
@@ -15,7 +15,13 @@ class DelegatedModuleFactoryPlugin {
 	constructor(options) {
 		this.options = options;
 		options.type = options.type || "require";
-		options.extensions = options.extensions || ["", ".js"];
+		options.extensions = options.extensions || [
+			"",
+			".wasm",
+			".mjs",
+			".js",
+			".json"
+		];
 	}
 
 	apply(normalModuleFactory) {


### PR DESCRIPTION
I’d like to open the discussion on whether `.mjs` was omitted here for a reason or just as an oversight. 

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Add `.mjs` to default `DelegatedModule` `options.extensions`

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
