### PR TITLE
fix(hot): log messages

### DIFF
--- a/hot/dev-server.js
+++ b/hot/dev-server.js
@@ -40,10 +40,10 @@ if (module.hot) {
 						"warning",
 						"[HMR] Cannot apply update. Need to do a full reload!"
 					);
-					log("warning", "[HMR] " + err.stack || err.message);
+					log("warning", "[HMR] " + (err.stack || err.message));
 					window.location.reload();
 				} else {
-					log("warning", "[HMR] Update failed: " + err.stack || err.message);
+					log("warning", "[HMR] Update failed: " + (err.stack || err.message));
 				}
 			});
 	};

--- a/hot/only-dev-server.js
+++ b/hot/only-dev-server.js
@@ -72,11 +72,11 @@ if (module.hot) {
 						"warning",
 						"[HMR] Cannot check for update. Need to do a full reload!"
 					);
-					log("warning", "[HMR] " + err.stack || err.message);
+					log("warning", "[HMR] " + (err.stack || err.message));
 				} else {
 					log(
 						"warning",
-						"[HMR] Update check failed: " + err.stack || err.message
+						"[HMR] Update check failed: " + (err.stack || err.message)
 					);
 				}
 			});

--- a/hot/poll.js
+++ b/hot/poll.js
@@ -23,10 +23,13 @@ if (module.hot) {
 					var status = module.hot.status();
 					if (["abort", "fail"].indexOf(status) >= 0) {
 						log("warning", "[HMR] Cannot apply update.");
-						log("warning", "[HMR] " + err.stack || err.message);
+						log("warning", "[HMR] " + (err.stack || err.message));
 						log("warning", "[HMR] You need to restart the application!");
 					} else {
-						log("warning", "[HMR] Update failed: " + err.stack || err.message);
+						log(
+							"warning",
+							"[HMR] Update failed: " + (err.stack || err.message)
+						);
 					}
 				});
 		}

--- a/hot/signal.js
+++ b/hot/signal.js
@@ -37,10 +37,10 @@ if (module.hot) {
 				var status = module.hot.status();
 				if (["abort", "fail"].indexOf(status) >= 0) {
 					log("warning", "[HMR] Cannot apply update.");
-					log("warning", "[HMR] " + err.stack || err.message);
+					log("warning", "[HMR] " + (err.stack || err.message));
 					log("warning", "[HMR] You need to restart the application!");
 				} else {
-					log("warning", "[HMR] Update failed: " + err.stack || err.message);
+					log("warning", "[HMR] Update failed: " + (err.stack || err.message));
 				}
 			});
 	};


### PR DESCRIPTION
group arguments of operator or (||)
otherwise, nonempty string is always true

```js
const err = {message: 'some message'}
> 'HMR: ' + err.stack || err.message
<- HMR: undefined

> 'HMR: ' + (err.stack || err.message)
<- HMR: some message
```

**What kind of change does this PR introduce?**

tiny bugfix

**Did you add tests for your changes?**

nope

**Does this PR introduce a breaking change?**

nope

**What needs to be documented once your changes are merged?**

nothing
