### PR TITLE
Relaxed type check for hashDigest to allow other non NodeJS-native digest methods e.g. base62.

### DIFF
--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -410,11 +410,7 @@
         },
         "hashDigest": {
           "description": "Digest type used for the hash",
-          "enum": [
-            "latin1",
-            "hex",
-            "base64"
-          ]
+          "type": "string"
         },
         "hashDigestLength": {
           "description": "Number of chars which are used for the hash",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

yes

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

I figure we could change this part a little bit:

```
The encoding to use when generating the hash, defaults to 'hex'. All encodings from Node.JS' hash.digest are supported. Using 'base64' for filenames might be problematic since it has the character / in its alphabet. Likewise 'latin1' could contain any character.
```

=>

```
The encoding to use when generating the hash, defaults to 'hex'. All encodings from Node.JS' `hash.digest()` are supported by default. Using 'base64' or 'latin1' for filenames might be problematic since it has the character / in its alphabet. 

When you are using an alternative hash method e.g. via a plugin or via `output.hashFunction` then there might be additional digest types supported. Please refer to the docs of the plugin/class in this case.
```

Via: https://webpack.js.org/configuration/output/#output-hashdigest