### PR TITLE
Support passing sideEffects array in config file

### DIFF
--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -926,7 +926,14 @@
         },
         "sideEffects": {
           "description": "Flags a module as with or without side effects",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/common.arrayOfStringOrStringArrayValues"
+            }
+          ]
         },
         "query": {
           "description": "Shortcut for use.query",
@@ -1305,7 +1312,14 @@
         },
         "sideEffects": {
           "description": "Skip over modules which are flagged to contain no side effects when exports are not used",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/common.arrayOfStringOrStringArrayValues"
+            }
+          ]
         },
         "providedExports": {
           "description": "Figure out which exports are provided by modules to generate more efficient code",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

https://webpack.js.org/guides/tree-shaking/ says you can provide an array of
relative, absolute, and glob patterns to "sideEffects" (Merged in PR #6536)

It goes on to say:

> Finally, `"sideEffects"` can also be set from the `module.rules` configuration option.

Unfortunately, the JSON schema validation rules still only accept a boolean.  :-(

This PR updates that to include `#/definitions/common.arrayOfStringOrStringArrayValues`

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

*I'D* call it a bugfix...

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

I looked at adding tests, but figuring out how to prove that it was breaking *AND* prove that it was fixed looked a hundred times harder than the change itself...

If somebody would like to point me in the right direction, I'd be grateful!

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

Nothing; this actually makes the already-written documentation *MORE* correct...