### PR TITLE
Use v4 of eslint-scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ajv-keywords": "^3.1.0",
     "chrome-trace-event": "^1.0.0",
     "enhanced-resolve": "^4.1.0",
-    "eslint-scope": "^3.7.1",
+    "eslint-scope": "^4.0.0",
     "json-parse-better-errors": "^1.0.2",
     "loader-runner": "^2.3.0",
     "loader-utils": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1871,6 +1871,13 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"


### PR DESCRIPTION
Bump `eslint-scope` to the latest version so webpack would benefit from future improvements and bugfixes.

**What kind of change does this PR introduce?**

build related change

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

nothinf