### PR TITLE
Handle module.require, require.main.require, and module.parent.require

### DIFF
--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -109,6 +109,24 @@ class NodeStuffPlugin {
 							)
 						);
 					parser.hooks.expression
+						.for("require.main.require")
+						.tap(
+							"NodeStuffPlugin",
+							ParserHelpers.expressionIsUnsupported(
+								parser,
+								"require.main.require is not supported by webpack."
+							)
+						);
+					parser.hooks.expression
+						.for("module.parent.require")
+						.tap(
+							"NodeStuffPlugin",
+							ParserHelpers.expressionIsUnsupported(
+								parser,
+								"module.parent.require is not supported by webpack."
+							)
+						);
+					parser.hooks.expression
 						.for("module.loaded")
 						.tap("NodeStuffPlugin", expr => {
 							parser.state.module.buildMeta.moduleConcatenationBailout =

--- a/lib/dependencies/CommonJsRequireDependencyParserPlugin.js
+++ b/lib/dependencies/CommonJsRequireDependencyParserPlugin.js
@@ -125,6 +125,12 @@ class CommonJsRequireDependencyParserPlugin {
 		parser.hooks.new
 			.for("require")
 			.tap("CommonJsRequireDependencyParserPlugin", createHandler(true));
+		parser.hooks.call
+			.for("module.require")
+			.tap("CommonJsRequireDependencyParserPlugin", createHandler(false));
+		parser.hooks.new
+			.for("module.require")
+			.tap("CommonJsRequireDependencyParserPlugin", createHandler(true));
 	}
 }
 module.exports = CommonJsRequireDependencyParserPlugin;

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -94,6 +94,42 @@ describe("Errors", () => {
 			}
 		);
 	});
+	it("should report require.main.require as unsupported", done => {
+		getErrors(
+			{
+				mode: "development",
+				entry: "./require.main.require"
+			},
+			(errors, warnings) => {
+				expect(errors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				const lines = warnings[0].split("\n");
+				expect(lines[0]).toMatch(/require.main.require\.js/);
+				expect(lines[1]).toMatch(
+					/require.main.require is not supported by webpack/
+				);
+				done();
+			}
+		);
+	});
+	it("should report module.parent.require as unsupported", done => {
+		getErrors(
+			{
+				mode: "development",
+				entry: "./module.parent.require"
+			},
+			(errors, warnings) => {
+				expect(errors).toHaveLength(0);
+				expect(warnings).toHaveLength(1);
+				const lines = warnings[0].split("\n");
+				expect(lines[0]).toMatch(/module.parent.require\.js/);
+				expect(lines[1]).toMatch(
+					/module.parent.require is not supported by webpack/
+				);
+				done();
+			}
+		);
+	});
 	it("should warn about case-sensitive module names", done => {
 		getErrors(
 			{

--- a/test/cases/parsing/issue-7728/a.js
+++ b/test/cases/parsing/issue-7728/a.js
@@ -1,0 +1,3 @@
+export default function test() {
+  return "OK";
+}

--- a/test/cases/parsing/issue-7728/index.js
+++ b/test/cases/parsing/issue-7728/index.js
@@ -1,0 +1,4 @@
+it("should detect module.require dependency", function () {
+	var test1 = module.require('./a').default;
+	expect(test1()).toBe("OK");
+});

--- a/test/fixtures/errors/module.parent.require.js
+++ b/test/fixtures/errors/module.parent.require.js
@@ -1,0 +1,1 @@
+module.parent.require('./file');

--- a/test/fixtures/errors/require.main.require.js
+++ b/test/fixtures/errors/require.main.require.js
@@ -1,0 +1,1 @@
+require.main.require('./file');


### PR DESCRIPTION
- Resolve module.require dependencies

- Add require.main.require and module.parent.require as unsupported

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Issue #7728: Detect module.require dependency 

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Parser enhancement
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
1. Webpack can detect and resolve module.require
2. Webpack does not support require.main.require and module.parent.require

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
