### PR TITLE
Return original Arrays instead of converting them to Objects

### DIFF
--- a/lib/MainTemplate.js
+++ b/lib/MainTemplate.js
@@ -297,6 +297,7 @@ module.exports = class MainTemplate extends Tapable {
 					`if(mode & 1) value = ${this.requireFn}(value);`,
 					`if(mode & 8) return value;`,
 					"if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;",
+					"if((mode & 4) && Array.isArray(value) && value) return value;",
 					"var ns = Object.create(null);",
 					`${this.requireFn}.r(ns);`,
 					"Object.defineProperty(ns, 'default', { enumerable: true, value: value });",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Potentially fixes https://github.com/webpack/webpack/issues/7792 :)

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

I promise I will if it looks like a right direction :)

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

Yes,, `import()` may start returning Arrays instead of Objects.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

Seems like examples such as [code-splitting-harmony](https://github.com/webpack/webpack/blob/master/examples/code-splitting-harmony/README.md) are outdated and should be updated.