### PR TITLE
Freeze hooks to prevent deopts

### DIFF
--- a/lib/ChunkTemplate.js
+++ b/lib/ChunkTemplate.js
@@ -25,7 +25,7 @@ const { SyncWaterfallHook, SyncHook } = require("tapable");
 module.exports = class ChunkTemplate {
 	constructor(outputOptions) {
 		this.outputOptions = outputOptions || {};
-		this.hooks = {
+		this.hooks = Object.freeze({
 			/** @type {SyncWaterfallHook<TODO[], RenderManifestOptions>} */
 			renderManifest: new SyncWaterfallHook(["result", "options"]),
 			modules: new SyncWaterfallHook([
@@ -43,7 +43,7 @@ module.exports = class ChunkTemplate {
 			renderWithEntry: new SyncWaterfallHook(["source", "chunk"]),
 			hash: new SyncHook(["hash"]),
 			hashForChunk: new SyncHook(["hash", "chunk"])
-		};
+		});
 	}
 
 	/**

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -209,7 +209,7 @@ class Compilation {
 	 * @param {Compiler} compiler the compiler which created the compilation
 	 */
 	constructor(compiler) {
-		this.hooks = {
+		this.hooks = Object.freeze({
 			/** @type {SyncHook<Module>} */
 			buildModule: new SyncHook(["module"]),
 			/** @type {SyncHook<Module>} */
@@ -376,7 +376,7 @@ class Compilation {
 			// TODO move them for webpack 5
 			/** @type {SyncHook<object, Module>} */
 			normalModuleLoader: new SyncHook(["loaderContext", "module"])
-		};
+		});
 		/** @type {string=} */
 		this.name = undefined;
 		/** @type {Compiler} */

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -44,7 +44,7 @@ const ConcurrentCompilationError = require("./ConcurrentCompilationError");
 
 class Compiler {
 	constructor(context) {
-		this.hooks = {
+		this.hooks = Object.freeze({
 			/** @type {SyncBailHook<Compilation>} */
 			shouldEmit: new SyncBailHook(["compilation"]),
 			/** @type {AsyncSeriesHook<Stats>} */
@@ -99,7 +99,7 @@ class Compiler {
 			afterResolvers: new SyncHook(["compiler"]),
 			/** @type {SyncBailHook<string, EntryOptions>} */
 			entryOption: new SyncBailHook(["context", "entry"])
-		};
+		});
 
 		/** @type {string=} */
 		this.name = undefined;

--- a/lib/ContextModuleFactory.js
+++ b/lib/ContextModuleFactory.js
@@ -17,7 +17,7 @@ const EMPTY_RESOLVE_OPTIONS = {};
 
 module.exports = class ContextModuleFactory {
 	constructor(resolverFactory) {
-		this.hooks = {
+		this.hooks = Object.freeze({
 			/** @type {AsyncSeriesWaterfallHook<TODO>} */
 			beforeResolve: new AsyncSeriesWaterfallHook(["data"]),
 			/** @type {AsyncSeriesWaterfallHook<TODO>} */
@@ -26,7 +26,7 @@ module.exports = class ContextModuleFactory {
 			contextModuleFiles: new SyncWaterfallHook(["files"]),
 			/** @type {SyncWaterfallHook<TODO[]>} */
 			alternatives: new AsyncSeriesWaterfallHook(["modules"])
-		};
+		});
 		this.resolverFactory = resolverFactory;
 	}
 

--- a/lib/DllModuleFactory.js
+++ b/lib/DllModuleFactory.js
@@ -8,7 +8,7 @@ const DllModule = require("./DllModule");
 
 class DllModuleFactory {
 	constructor() {
-		this.hooks = {};
+		this.hooks = Object.freeze({});
 	}
 	create(data, callback) {
 		const dependency = data.dependencies[0];

--- a/lib/HotUpdateChunkTemplate.js
+++ b/lib/HotUpdateChunkTemplate.js
@@ -11,7 +11,7 @@ const { SyncWaterfallHook, SyncHook } = require("tapable");
 module.exports = class HotUpdateChunkTemplate {
 	constructor(outputOptions) {
 		this.outputOptions = outputOptions || {};
-		this.hooks = {
+		this.hooks = Object.freeze({
 			modules: new SyncWaterfallHook([
 				"source",
 				"modules",
@@ -29,7 +29,7 @@ module.exports = class HotUpdateChunkTemplate {
 				"dependencyTemplates"
 			]),
 			hash: new SyncHook(["hash"])
-		};
+		});
 	}
 
 	render(

--- a/lib/JavascriptParser.js
+++ b/lib/JavascriptParser.js
@@ -42,7 +42,7 @@ const EMPTY_COMMENT_OPTIONS = {
 
 class JavascriptParser {
 	constructor(options, sourceType = "auto") {
-		this.hooks = {
+		this.hooks = Object.freeze({
 			evaluateTypeof: new HookMap(() => new SyncBailHook(["expression"])),
 			evaluate: new HookMap(() => new SyncBailHook(["expression"])),
 			evaluateIdentifier: new HookMap(() => new SyncBailHook(["expression"])),
@@ -96,7 +96,7 @@ class JavascriptParser {
 			expressionAnyMember: new HookMap(() => new SyncBailHook(["expression"])),
 			expressionConditionalOperator: new SyncBailHook(["expression"]),
 			program: new SyncBailHook(["ast", "comments"])
-		};
+		});
 		this.options = options;
 		this.sourceType = sourceType;
 		this.scope = undefined;

--- a/lib/MainTemplate.js
+++ b/lib/MainTemplate.js
@@ -56,7 +56,7 @@ module.exports = class MainTemplate {
 	constructor(outputOptions) {
 		/** @type {TODO?} */
 		this.outputOptions = outputOptions || {};
-		this.hooks = {
+		this.hooks = Object.freeze({
 			/** @type {SyncWaterfallHook<TODO[], RenderManifestOptions>} */
 			renderManifest: new SyncWaterfallHook(["result", "options"]),
 			modules: new SyncWaterfallHook([
@@ -123,7 +123,7 @@ module.exports = class MainTemplate {
 			// TODO this should be moved somewhere else
 			// It's weird here
 			hotBootstrap: new SyncWaterfallHook(["source", "chunk", "hash"])
-		};
+		});
 		this.hooks.startup.tap("MainTemplate", (source, chunk, hash) => {
 			/** @type {string[]} */
 			const buf = [];

--- a/lib/ModuleTemplate.js
+++ b/lib/ModuleTemplate.js
@@ -13,7 +13,7 @@ module.exports = class ModuleTemplate {
 	constructor(runtimeTemplate, type) {
 		this.runtimeTemplate = runtimeTemplate;
 		this.type = type;
-		this.hooks = {
+		this.hooks = Object.freeze({
 			content: new SyncWaterfallHook([
 				"source",
 				"module",
@@ -39,7 +39,7 @@ module.exports = class ModuleTemplate {
 				"dependencyTemplates"
 			]),
 			hash: new SyncHook(["hash"])
-		};
+		});
 	}
 
 	/**

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -12,13 +12,13 @@ const ConcurrentCompilationError = require("./ConcurrentCompilationError");
 
 module.exports = class MultiCompiler {
 	constructor(compilers) {
-		this.hooks = {
+		this.hooks = Object.freeze({
 			done: new SyncHook(["stats"]),
 			invalid: new MultiHook(compilers.map(c => c.hooks.invalid)),
 			run: new MultiHook(compilers.map(c => c.hooks.run)),
 			watchClose: new SyncHook([]),
 			watchRun: new MultiHook(compilers.map(c => c.hooks.watchRun))
-		};
+		});
 		if (!Array.isArray(compilers)) {
 			compilers = Object.keys(compilers).map(name => {
 				compilers[name].name = name;

--- a/lib/MultiModuleFactory.js
+++ b/lib/MultiModuleFactory.js
@@ -8,7 +8,7 @@ const MultiModule = require("./MultiModule");
 
 module.exports = class MultiModuleFactory {
 	constructor() {
-		this.hooks = {};
+		this.hooks = Object.freeze({});
 	}
 
 	create(data, callback) {

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -59,7 +59,7 @@ const dependencyCache = new WeakMap();
 
 class NormalModuleFactory {
 	constructor(context, resolverFactory, options) {
-		this.hooks = {
+		this.hooks = Object.freeze({
 			resolver: new SyncWaterfallHook(["resolver"]),
 			factory: new SyncWaterfallHook(["factory"]),
 			beforeResolve: new AsyncSeriesWaterfallHook(["data"]),
@@ -74,7 +74,7 @@ class NormalModuleFactory {
 			generator: new HookMap(
 				() => new SyncHook(["generator", "generatorOptions"])
 			)
-		};
+		});
 		this.resolverFactory = resolverFactory;
 		this.ruleSet = new RuleSet(options.defaultRules.concat(options.rules));
 		this.cachePredicate =

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -9,12 +9,12 @@ const Factory = require("enhanced-resolve").ResolverFactory;
 
 module.exports = class ResolverFactory {
 	constructor() {
-		this.hooks = {
+		this.hooks = Object.freeze({
 			resolveOptions: new HookMap(
 				() => new SyncWaterfallHook(["resolveOptions"])
 			),
 			resolver: new HookMap(() => new SyncHook(["resolver", "resolveOptions"]))
-		};
+		});
 		this.cache1 = new WeakMap();
 		this.cache2 = new Map();
 	}

--- a/lib/wasm/WebAssemblyParser.js
+++ b/lib/wasm/WebAssemblyParser.js
@@ -60,7 +60,7 @@ const decoderOpts = {
 
 class WebAssemblyParser {
 	constructor(options) {
-		this.hooks = {};
+		this.hooks = Object.freeze({});
 		this.options = options;
 	}
 


### PR DESCRIPTION
**Note:** there is no speed penalty introduced by `Object.freeze`

This PR is a follow up of:

- #7672
- #7672

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

yes

**What needs to be documented once your changes are merged?**

hooks are no longer extensible. Use a `WeakMap` to add custom hooks.