### PR TITLE
Update Jest Homepage URL

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -19,10 +19,10 @@ Watch mode:
 yarn jest --watch ConfigTestCases
 ```
 
-See also: [Jest CLI docs](https://facebook.github.io/jest/docs/cli.html)
+See also: [Jest CLI docs](https://jestjs.io/docs/cli)
 
 ## Test suite overview
-We use Jest for our tests. For more information on Jest you can visit their [homepage](https://facebook.github.io/jest/)!
+We use Jest for our tests. For more information on Jest you can visit their [homepage](https://jestjs.io/)!
 
 ### Class Tests
 All test files can be found in *.test.js. There are many tests that simply test API's of a specific class/file (such as `Compiler`, `Errors`, Integration, `Parser`, `RuleSet`, Validation).


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- Document Update

Their Homepage URL might be migrated.
Current writing URL was redirecting(with 301), therefore I was updated  to least URL.

![screen shot 2018-08-01 at 15 40 59](https://user-images.githubusercontent.com/5501268/43505601-5fb2e72a-95a2-11e8-953e-9a2874fb4b8b.png)

Thanks👏