### PR TITLE
Fix chunkAsset hook call in HotModuleReplacementPlugin - fixes #7828

### DIFF
--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -286,7 +286,6 @@ module.exports = class HotModuleReplacementPlugin {
 									hotUpdateMainContent.c[chunkId] = true;
 									currentChunk.files.push(filename);
 									compilation.hooks.chunkAsset.call(
-										"HotModuleReplacementPlugin",
 										currentChunk,
 										filename
 									);

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -285,10 +285,7 @@ module.exports = class HotModuleReplacementPlugin {
 									compilation.assets[filename] = source;
 									hotUpdateMainContent.c[chunkId] = true;
 									currentChunk.files.push(filename);
-									compilation.hooks.chunkAsset.call(
-										currentChunk,
-										filename
-									);
+									compilation.hooks.chunkAsset.call(currentChunk, filename);
 								}
 							} else {
 								hotUpdateMainContent.c[chunkId] = false;


### PR DESCRIPTION
The `compilation.hook.chunkAsset` hook expects 2 parameters, not three.

**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

No

**Does this PR introduce a breaking change?**

It depends from what perspective you look, it shows one of the problems with manual semantic versioning. The commit that introduced this behavior would not have been flagged as a breaking change, but it was a breaking change. Changing it back is a bug fix, but it also is a breaking change. At this point in time people might depend on the 'bad' behavior and changing it will break their code.

So, it's up to the maintainers to determine if this is classified as breaking change.

**What needs to be documented once your changes are merged?**

Not sure if there is a place in the documentation to mention these types of changes