### PR TITLE
fixes 7778: query string in dynamic import()

### DIFF
--- a/lib/dependencies/ContextDependencyHelpers.js
+++ b/lib/dependencies/ContextDependencyHelpers.js
@@ -15,6 +15,32 @@ const quotemeta = str => {
 	return str.replace(/[-[\]\\/{}()*+?.^$|]/g, "\\$&");
 };
 
+const splitContextFromPrefix = prefix => {
+	const idx = prefix.lastIndexOf("/");
+	let context = ".";
+	if (idx >= 0) {
+		context = prefix.substr(0, idx);
+		prefix = `.${prefix.substr(idx)}`;
+	}
+	return {
+		context,
+		prefix
+	};
+};
+
+const splitQueryFromPostfix = postfix => {
+	const idx = postfix.indexOf("?");
+	let query = "";
+	if (idx >= 0) {
+		query = postfix.substr(idx);
+		postfix = postfix.substr(0, idx);
+	}
+	return {
+		postfix,
+		query
+	};
+};
+
 ContextDependencyHelpers.create = (
 	Dep,
 	range,
@@ -23,38 +49,30 @@ ContextDependencyHelpers.create = (
 	options,
 	contextOptions
 ) => {
-	let dep;
-	let prefix;
-	let postfix;
-	let prefixRange;
-	let valueRange;
-	let idx;
-	let context;
-	let regExp;
 	if (param.isTemplateString()) {
-		prefix = param.quasis[0].string;
-		postfix =
+		let prefixRaw = param.quasis[0].string;
+		let postfixRaw =
 			param.quasis.length > 1
 				? param.quasis[param.quasis.length - 1].string
 				: "";
-		prefixRange = [param.quasis[0].range[0], param.quasis[0].range[1]];
-		valueRange = param.range;
-		idx = prefix.lastIndexOf("/");
-		context = ".";
-		if (idx >= 0) {
-			context = prefix.substr(0, idx);
-			prefix = `.${prefix.substr(idx)}`;
-		}
+		const prefixRange = [param.quasis[0].range[0], param.quasis[0].range[1]];
+		const postfixRange =
+			param.quasis.length > 1
+				? param.quasis[param.quasis.length - 1].range
+				: "";
+		const valueRange = param.range;
+		const { context, prefix } = splitContextFromPrefix(prefixRaw);
+		const { postfix, query } = splitQueryFromPostfix(postfixRaw);
 		// If there are more than two quasis, maybe the generated RegExp can be more precise?
-		regExp = new RegExp(
+		const regExp = new RegExp(
 			`^${quotemeta(prefix)}${options.wrappedContextRegExp.source}${quotemeta(
 				postfix
 			)}$`
 		);
-		dep = new Dep(
+		const dep = new Dep(
 			Object.assign(
 				{
-					request: context,
+					request: context + query,
 					recursive: options.wrappedContextRecursive,
 					regExp,
 					mode: "sync"
@@ -65,12 +83,20 @@ ContextDependencyHelpers.create = (
 			valueRange
 		);
 		dep.loc = expr.loc;
-		dep.replaces = [
-			{
+		const replaces = [];
+		if (prefixRange && prefix !== prefixRaw) {
+			replaces.push({
 				range: prefixRange,
 				value: prefix
-			}
-		];
+			});
+		}
+		if (postfixRange && postfix !== postfixRaw) {
+			replaces.push({
+				range: postfixRange,
+				value: postfix
+			});
+		}
+		dep.replaces = replaces;
 		dep.critical =
 			options.wrappedContextCritical &&
 			"a part of the request of a dependency is an expression";
@@ -80,30 +106,26 @@ ContextDependencyHelpers.create = (
 		((param.prefix && param.prefix.isString()) ||
 			(param.postfix && param.postfix.isString()))
 	) {
-		prefix = param.prefix && param.prefix.isString() ? param.prefix.string : "";
-		postfix =
+		let prefixRaw =
+			param.prefix && param.prefix.isString() ? param.prefix.string : "";
+		let postfixRaw =
 			param.postfix && param.postfix.isString() ? param.postfix.string : "";
-		prefixRange =
+		const prefixRange =
 			param.prefix && param.prefix.isString() ? param.prefix.range : null;
-		valueRange = [
-			prefixRange ? prefixRange[1] : param.range[0],
-			param.range[1]
-		];
-		idx = prefix.lastIndexOf("/");
-		context = ".";
-		if (idx >= 0) {
-			context = prefix.substr(0, idx);
-			prefix = `.${prefix.substr(idx)}`;
-		}
-		regExp = new RegExp(
+		const postfixRange =
+			param.postfix && param.postfix.isString() ? param.postfix.range : null;
+		const valueRange = param.range;
+		const { context, prefix } = splitContextFromPrefix(prefixRaw);
+		const { postfix, query } = splitQueryFromPostfix(postfixRaw);
+		const regExp = new RegExp(
 			`^${quotemeta(prefix)}${options.wrappedContextRegExp.source}${quotemeta(
 				postfix
 			)}$`
 		);
-		dep = new Dep(
+		const dep = new Dep(
 			Object.assign(
 				{
-					request: context,
+					request: context + query,
 					recursive: options.wrappedContextRecursive,
 					regExp,
 					mode: "sync"
@@ -114,13 +136,26 @@ ContextDependencyHelpers.create = (
 			valueRange
 		);
 		dep.loc = expr.loc;
-		dep.prepend = param.prefix && param.prefix.isString() ? prefix : null;
+		const replaces = [];
+		if (prefixRange && prefix !== prefixRaw) {
+			replaces.push({
+				range: prefixRange,
+				value: JSON.stringify(prefix)
+			});
+		}
+		if (postfixRange && postfix !== postfixRaw) {
+			replaces.push({
+				range: postfixRange,
+				value: JSON.stringify(postfix)
+			});
+		}
+		dep.replaces = replaces;
 		dep.critical =
 			options.wrappedContextCritical &&
 			"a part of the request of a dependency is an expression";
 		return dep;
 	} else {
-		dep = new Dep(
+		const dep = new Dep(
 			Object.assign(
 				{
 					request: options.exprContextRequest,

--- a/lib/dependencies/ContextDependencyTemplateAsId.js
+++ b/lib/dependencies/ContextDependencyTemplateAsId.js
@@ -20,6 +20,7 @@ class ContextDependencyTemplateAsId {
 					}
 				}
 				source.replace(dep.valueRange[1], dep.range[1] - 1, ")");
+				// TODO webpack 5 remove `prepend` it's no longer used
 				source.replace(
 					dep.range[0],
 					dep.valueRange[0] - 1,

--- a/lib/dependencies/ContextDependencyTemplateAsRequireCall.js
+++ b/lib/dependencies/ContextDependencyTemplateAsRequireCall.js
@@ -20,6 +20,7 @@ class ContextDependencyTemplateAsRequireCall {
 					}
 				}
 				source.replace(dep.valueRange[1], dep.range[1] - 1, ")");
+				// TODO webpack 5 remove `prepend` it's no longer used
 				source.replace(
 					dep.range[0],
 					dep.valueRange[0] - 1,

--- a/test/cases/parsing/issue-7778/a.js
+++ b/test/cases/parsing/issue-7778/a.js
@@ -1,3 +1,3 @@
 export default function a() {
-    return 'a'
+    return 'a' + __resourceQuery
 }

--- a/test/cases/parsing/issue-7778/a.js
+++ b/test/cases/parsing/issue-7778/a.js
@@ -1,0 +1,3 @@
+export default function a() {
+    return 'a'
+}

--- a/test/cases/parsing/issue-7778/abc.js
+++ b/test/cases/parsing/issue-7778/abc.js
@@ -1,0 +1,3 @@
+export default function abc() {
+    return 'abc' + __resourceQuery
+}

--- a/test/cases/parsing/issue-7778/index.js
+++ b/test/cases/parsing/issue-7778/index.js
@@ -1,13 +1,57 @@
 it("should detect query strings in dynamic import as a static value 1 ", function() {
-    import("./a?queryString").then(({ default: a }) => {
-        expect(a()).toBe("a");
-    });
+	return Promise.all([
+		import("./a").then(({ default: a }) => {
+			expect(a()).toBe("a");
+		}),
+		import("./abc").then(({ default: a }) => {
+			expect(a()).toBe("abc");
+		}),
+		import("./a?queryString").then(({ default: a }) => {
+			expect(a()).toBe("a?queryString");
+		}),
+		import("./abc?query?String").then(({ default: a }) => {
+			expect(a()).toBe("abc?query?String");
+		}),
+	]);
 });
 
 it("should detect query strings in dynamic import as a static value 2", function() {
-    var testFileName = "a";
-    
-    import(`./${testFileName}?queryString`).then(({ default: a }) => {
-        expect(a()).toBe("a");
-    });
+	var testFileName = "a";
+
+	return Promise.all([
+		import(`./${testFileName}`).then(({ default: a }) => {
+			expect(a()).toBe("a");
+		}),
+		import(`./${testFileName}bc`).then(({ default: a }) => {
+			expect(a()).toBe("abc");
+		}),
+		import(`./${testFileName}?queryString`).then(({ default: a }) => {
+			expect(a()).toBe("a?queryString");
+		}),
+		import(`./${testFileName}bc?query?String`).then(({ default: a }) => {
+			expect(a()).toBe("abc?query?String");
+		})
+	]);
+});
+
+it("should detect query strings in dynamic import as a static value 2", function() {
+	var testFileName = "a";
+
+	return Promise.all([
+		import("./" + testFileName).then(({ default: a }) => {
+			expect(a()).toBe("a");
+		}),
+		import("./" + testFileName + "").then(({ default: a }) => {
+			expect(a()).toBe("a");
+		}),
+		import("./" + testFileName + "bc").then(({ default: a }) => {
+			expect(a()).toBe("abc");
+		}),
+		import("./" + testFileName + "?queryString").then(({ default: a }) => {
+			expect(a()).toBe("a?queryString");
+		}),
+		import("./" + testFileName + "bc?query?String").then(({ default: a }) => {
+			expect(a()).toBe("abc?query?String");
+		})
+	]);
 });

--- a/test/cases/parsing/issue-7778/index.js
+++ b/test/cases/parsing/issue-7778/index.js
@@ -7,7 +7,7 @@ it("should detect query strings in dynamic import as a static value 1 ", functio
 it("should detect query strings in dynamic import as a static value 2", function() {
     var testFileName = "a";
     
-    import(`./${testFileName}?queryStringSteven`).then(({ default: a }) => {
+    import(`./${testFileName}?queryString`).then(({ default: a }) => {
         expect(a()).toBe("a");
     });
 });

--- a/test/cases/parsing/issue-7778/index.js
+++ b/test/cases/parsing/issue-7778/index.js
@@ -1,0 +1,13 @@
+it("should detect query strings in dynamic import as a static value 1 ", function() {
+    import("./a?queryString").then(({ default: a }) => {
+        expect(a()).toBe("a");
+    });
+});
+
+it("should detect query strings in dynamic import as a static value 2", function() {
+    var testFileName = "a";
+    
+    import(`./${testFileName}?queryStringSteven`).then(({ default: a }) => {
+        expect(a()).toBe("a");
+    });
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Will hopefully end up fixing a bug where queryStrings are affecting the way imports are treated  

<!-- Try to link to an open issue for more information. -->
https://github.com/webpack/webpack/issues/7778

<!-- In addition to that please answer these questions: -->
**What kind of change does this PR introduce?**
(bugfix) Although currently just adds a failing test case, I think the problem lies somewhere inside ImportParserPlugin -> ContextDependencyHelpers but thats as far as I've gotten. Any help would be greatly appreciated

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes (hopefully they are fine)
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
It will hopefully correct existing documented functionality

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
