### PR TITLE
fix #7829

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1025,6 +1025,7 @@ class Compilation extends Tapable {
 	addEntry(context, entry, name, callback) {
 		const slot = {
 			name: name,
+			// TODO webpack 5 remove `request`
 			request: null,
 			module: null
 		};
@@ -1033,7 +1034,14 @@ class Compilation extends Tapable {
 			slot.request = entry.request;
 		}
 
-		this._preparedEntrypoints.push(slot);
+		// TODO webpack 5: merge modules instead when multiple entry modules are supported
+		const idx = this._preparedEntrypoints.findIndex(slot => slot.name === name);
+		if (idx >= 0) {
+			// Overwrite existing entrypoint
+			this._preparedEntrypoints[idx] = slot;
+		} else {
+			this._preparedEntrypoints.push(slot);
+		}
 		this._addModuleChain(
 			context,
 			entry,
@@ -1049,7 +1057,9 @@ class Compilation extends Tapable {
 					slot.module = module;
 				} else {
 					const idx = this._preparedEntrypoints.indexOf(slot);
-					this._preparedEntrypoints.splice(idx, 1);
+					if (idx >= 0) {
+						this._preparedEntrypoints.splice(idx, 1);
+					}
 				}
 				return callback(null, module);
 			}

--- a/test/configCases/entry/override-entry-point/fail.js
+++ b/test/configCases/entry/override-entry-point/fail.js
@@ -1,0 +1,3 @@
+it("should load correct entry", function() {
+	throw new Error("This entrypoint should not be used");
+});

--- a/test/configCases/entry/override-entry-point/ok.js
+++ b/test/configCases/entry/override-entry-point/ok.js
@@ -1,0 +1,3 @@
+it("should load correct entry", function() {
+	// ok
+});

--- a/test/configCases/entry/override-entry-point/test.config.js
+++ b/test/configCases/entry/override-entry-point/test.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	findBundle: function() {
+		return [
+			"./runtime~main.js",
+			"./main.chunk.js"
+		]
+	}
+};

--- a/test/configCases/entry/override-entry-point/webpack.config.js
+++ b/test/configCases/entry/override-entry-point/webpack.config.js
@@ -1,0 +1,16 @@
+const SingleEntryPlugin = require("../../../../lib/SingleEntryPlugin");
+module.exports = {
+	entry: () => ({}),
+	optimization: {
+		runtimeChunk: true
+	},
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[name].chunk.js"
+	},
+	target: "web",
+	plugins: [
+		new SingleEntryPlugin(__dirname, "./fail", "main"),
+		new SingleEntryPlugin(__dirname, "./ok", "main")
+	]
+};


### PR DESCRIPTION
webpack-hot-client seem to call `addEntry` multiple
which causes two Entrypoints with the same name
This lead the bad side effects
i. e. optimization.runtimeChunk no longer works correctly

Now adding an entry with the same name replaces the existing entry

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
