### PR TITLE
fix 7841

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -10,6 +10,13 @@ const formatLocation = require("./formatLocation");
 const identifierUtils = require("./util/identifier");
 const compareLocations = require("./compareLocations");
 
+/** @typedef {string|RegExp|((warning: string) => boolean)} SingleWarningsFilter */
+/** @typedef {SingleWarningsFilter|SingleWarningsFilter[]} WarningsFilter */
+/**
+ * @typedef {Object} HasWarningsOptions
+ * @property {WarningsFilter=} warningsFilter
+ */
+
 const optionsOrFallback = (...args) => {
 	let optionValues = [];
 	optionValues.push(...args);
@@ -30,6 +37,11 @@ class Stats {
 		this.endTime = undefined;
 	}
 
+	/**
+	 * @param {string[]} warnings the current warnings
+	 * @param {WarningsFilter} warningsFilter the filter for your warnings
+	 * @returns {string[]} returns the filtered warnings
+	 */
 	static filterWarnings(warnings, warningsFilter) {
 		// we dont have anything to filter so all warnings can be shown
 		if (!warningsFilter) {
@@ -67,9 +79,16 @@ class Stats {
 			: `${filePath}`;
 	}
 
-	hasWarnings() {
+	/**
+	 * @param {HasWarningsOptions} options options for hasWarnings
+	 * @returns {boolean} returns true if warnings are present
+	 */
+	hasWarnings({ warningsFilter } = {}) {
+		const warnings = warningsFilter
+			? Stats.filterWarnings(this.compilation.warnings, warningsFilter)
+			: this.compilation.warnings;
 		return (
-			this.compilation.warnings.length > 0 ||
+			warnings.length > 0 ||
 			this.compilation.children.some(child => child.getStats().hasWarnings())
 		);
 	}

--- a/test/Stats.unittest.js
+++ b/test/Stats.unittest.js
@@ -74,6 +74,44 @@ describe(
 					expect(mockStats.hasWarnings()).toBe(false);
 				});
 			});
+			describe("does filter", () => {
+				it("hasWarnings all filtered", () => {
+					const mockStats = new Stats({
+						children: [],
+						warnings: ["firstError", "secondError"],
+						hash: "1234",
+						compiler: {
+							context: ""
+						}
+					});
+					const warningsFilter = /Error/;
+					expect(mockStats.hasWarnings({ warningsFilter })).toBe(false);
+				});
+				it("hasWarnings some filtered", () => {
+					const mockStats = new Stats({
+						children: [],
+						warnings: ["firstError", "secondError"],
+						hash: "1234",
+						compiler: {
+							context: ""
+						}
+					});
+					const warningsFilter = /secondError/;
+					expect(mockStats.hasWarnings({ warningsFilter })).toBe(true);
+				});
+				it("hasWarnings none filtered", () => {
+					const mockStats = new Stats({
+						children: [],
+						warnings: ["firstError", "secondError"],
+						hash: "1234",
+						compiler: {
+							context: ""
+						}
+					});
+					const warningsFilter = /thirdError/;
+					expect(mockStats.hasWarnings({ warningsFilter })).toBe(true);
+				});
+			});
 			describe("children have", () => {
 				it("hasErrors", () => {
 					const mockStats = new Stats({


### PR DESCRIPTION
Allow filtering of hasWarnings in stats.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

https://github.com/webpack/webpack/issues/7841

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feature

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

yes

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

I guess https://webpack.js.org/api/node/#stats-haswarnings-.

---

**Note**

This attempt was quite easy, but I don't think we're finished already. Before `filterWarnings` is called inside `toJson` the error will be formatted with `formatError`. See here: 

https://github.com/webpack/webpack/blob/9f16238054bad5c3ec62d24c41b12625defa72e5/lib/Stats.js#L341

For good results I guess I'd need to do the same so `hasWarnings` filters out the same warnings as `toJson`. Extracting `formatError` isn't that easy however, because it needs these options:

https://github.com/webpack/webpack/blob/9f16238054bad5c3ec62d24c41b12625defa72e5/lib/Stats.js#L141

https://github.com/webpack/webpack/blob/9f16238054bad5c3ec62d24c41b12625defa72e5/lib/Stats.js#L190

https://github.com/webpack/webpack/blob/9f16238054bad5c3ec62d24c41b12625defa72e5/lib/Stats.js#L192

These options however need some of the params passed to `toJson`.

I just would like to briefly discuss with you @sokra if I should extract `formatError` as a new method on `Stats` and if I should  enhance `hasWarnings` to get all options needed to properly call `formatError`?