### PR TITLE
remove originModule from Dependencies and add parent module to ModuleGraph

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -626,7 +626,10 @@ class Compilation {
 	processModuleDependencies(module, callback) {
 		const dependencies = new Map();
 
-		const addDependency = dep => {
+		let currentBlock = module;
+
+		const processDependency = dep => {
+			this.moduleGraph.setParents(dep, currentBlock, module);
 			const resourceIdent = dep.getResourceIdentifier();
 			if (resourceIdent) {
 				const factory = this.dependencyFactories.get(dep.constructor);
@@ -647,17 +650,18 @@ class Compilation {
 			}
 		};
 
-		const addDependenciesBlock = block => {
+		const processDependenciesBlock = block => {
 			if (block.dependencies) {
-				iterationOfArrayCallback(block.dependencies, addDependency);
+				currentBlock = block;
+				iterationOfArrayCallback(block.dependencies, processDependency);
 			}
 			if (block.blocks) {
-				iterationOfArrayCallback(block.blocks, addDependenciesBlock);
+				iterationOfArrayCallback(block.blocks, processDependenciesBlock);
 			}
 		};
 
 		try {
-			addDependenciesBlock(module);
+			processDependenciesBlock(module);
 		} catch (e) {
 			callback(e);
 		}

--- a/lib/DelegatedModule.js
+++ b/lib/DelegatedModule.js
@@ -90,7 +90,7 @@ class DelegatedModule extends Module {
 		);
 		this.addDependency(this.delegatedSourceDependency);
 		this.addDependency(
-			new DelegatedExportsDependency(this, this.delegateData.exports || true)
+			new DelegatedExportsDependency(this.delegateData.exports || true)
 		);
 		callback();
 	}

--- a/lib/ModuleGraph.js
+++ b/lib/ModuleGraph.js
@@ -7,6 +7,7 @@
 
 const ModuleGraphConnection = require("./ModuleGraphConnection");
 
+/** @typedef {import("./DependenciesBlock")} DependenciesBlock */
 /** @typedef {import("./Dependency")} Dependency */
 /** @typedef {import("./Module")} Module */
 
@@ -20,6 +21,8 @@ class ModuleGraph {
 		this._originMap = new Map();
 		/** @type {Map<any, Object>} */
 		this._metaMap = new Map();
+		/** @type {Map<Dependency, {module: Module, block: DependenciesBlock}>} */
+		this._parentsMap = new Map();
 	}
 
 	_getModuleSet(module) {
@@ -38,6 +41,34 @@ class ModuleGraph {
 			this._originMap.set(module, connections);
 		}
 		return connections;
+	}
+
+	/**
+	 * @param {Dependency} dependency the dependency
+	 * @param {DependenciesBlock} block parent block
+	 * @param {Module} module parent module
+	 * @returns {void}
+	 */
+	setParents(dependency, block, module) {
+		this._parentsMap.set(dependency, { module, block });
+	}
+
+	/**
+	 * @param {Dependency} dependency the dependency
+	 * @returns {Module} parent module
+	 */
+	getParentModule(dependency) {
+		const entry = this._parentsMap.get(dependency);
+		return entry !== undefined ? entry.module : null;
+	}
+
+	/**
+	 * @param {Dependency} dependency the dependency
+	 * @returns {DependenciesBlock} parent block
+	 */
+	getParentBlock(dependency) {
+		const entry = this._parentsMap.get(dependency);
+		return entry !== undefined ? entry.block : null;
 	}
 
 	/**
@@ -156,6 +187,15 @@ class ModuleGraph {
 	getOrigin(dependency) {
 		const connection = this._dependencyMap.get(dependency);
 		return connection !== undefined ? connection.originModule : null;
+	}
+
+	/**
+	 * @param {Dependency} dependency the dependency to look for a referencing module
+	 * @returns {Module} the original referencing module
+	 */
+	getResolvedOrigin(dependency) {
+		const connection = this._dependencyMap.get(dependency);
+		return connection !== undefined ? connection.resolvedOriginModule : null;
 	}
 
 	/**

--- a/lib/ModuleGraphConnection.js
+++ b/lib/ModuleGraphConnection.js
@@ -17,6 +17,7 @@ class ModuleGraphConnection {
 	 */
 	constructor(originModule, dependency, module, explanation) {
 		this.originModule = originModule;
+		this.resolvedOriginModule = originModule;
 		this.dependency = dependency;
 		this.resolvedModule = module;
 		this.module = module;

--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -170,8 +170,7 @@ class NodeStuffPlugin {
 							getModulePath(
 								parser.state.module.context,
 								isHarmony ? harmonyModuleBuildin : moduleBuildin
-							),
-							parser.state.module
+							)
 						);
 						dep.loc = expr.loc;
 						parser.state.module.addDependency(dep);

--- a/lib/dependencies/DelegatedExportsDependency.js
+++ b/lib/dependencies/DelegatedExportsDependency.js
@@ -12,9 +12,8 @@ const NullDependency = require("./NullDependency");
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 
 class DelegatedExportsDependency extends NullDependency {
-	constructor(originModule, exports) {
+	constructor(exports) {
 		super();
-		this.originModule = originModule;
 		this.exports = exports;
 	}
 
@@ -28,8 +27,11 @@ class DelegatedExportsDependency extends NullDependency {
 	 * @returns {DependencyReference} reference
 	 */
 	getReference(moduleGraph) {
-		if (!this.originModule) return null;
-		return new DependencyReference(() => this.originModule, true, false);
+		return new DependencyReference(
+			() => moduleGraph.getParentModule(this),
+			true,
+			false
+		);
 	}
 
 	/**

--- a/lib/dependencies/HarmonyAcceptImportDependency.js
+++ b/lib/dependencies/HarmonyAcceptImportDependency.js
@@ -12,8 +12,8 @@ const HarmonyImportDependency = require("./HarmonyImportDependency");
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 
 class HarmonyAcceptImportDependency extends HarmonyImportDependency {
-	constructor(request, originModule, parserScope) {
-		super(request, originModule, NaN, parserScope);
+	constructor(request, parserScope) {
+		super(request, NaN, parserScope);
 		this.weak = true;
 	}
 

--- a/lib/dependencies/HarmonyCompatibilityDependency.js
+++ b/lib/dependencies/HarmonyCompatibilityDependency.js
@@ -14,14 +14,6 @@ const NullDependency = require("./NullDependency");
 /** @typedef {import("../Module")} Module */
 
 class HarmonyCompatibilityDependency extends NullDependency {
-	/**
-	 * @param {Module} originModule the originating module
-	 */
-	constructor(originModule) {
-		super();
-		this.originModule = originModule;
-	}
-
 	get type() {
 		return "harmony export header";
 	}
@@ -43,12 +35,11 @@ HarmonyCompatibilityDependency.Template = class HarmonyExportDependencyTemplate 
 	 * @param {DependencyTemplateContext} templateContext the template context
 	 * @returns {InitFragment[]|null} the init fragments
 	 */
-	getInitFragments(dependency, { runtimeTemplate, moduleGraph }) {
-		const dep = /** @type {HarmonyCompatibilityDependency} */ (dependency);
-		const usedExports = dep.originModule.getUsedExports(moduleGraph);
+	getInitFragments(dependency, { module, runtimeTemplate, moduleGraph }) {
+		const usedExports = module.getUsedExports(moduleGraph);
 		if (usedExports === true || usedExports === null) {
 			const content = runtimeTemplate.defineEsModuleFlagStatement({
-				exportsArgument: dep.originModule.exportsArgument
+				exportsArgument: module.exportsArgument
 			});
 			return [
 				new InitFragment(

--- a/lib/dependencies/HarmonyDetectionParserPlugin.js
+++ b/lib/dependencies/HarmonyDetectionParserPlugin.js
@@ -18,7 +18,7 @@ module.exports = class HarmonyDetectionParserPlugin {
 				});
 			if (isHarmony) {
 				const module = parser.state.module;
-				const compatDep = new HarmonyCompatibilityDependency(module);
+				const compatDep = new HarmonyCompatibilityDependency();
 				compatDep.loc = {
 					start: {
 						line: -1,

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -42,7 +42,6 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 				parser.state.current.addDependency(clearDep);
 				const sideEffectDep = new HarmonyImportSideEffectDependency(
 					source,
-					parser.state.module,
 					parser.state.lastHarmonyImportOrder,
 					parser.state.harmonyParserScope
 				);
@@ -56,7 +55,6 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 			"HarmonyExportDependencyParserPlugin",
 			(statement, expr) => {
 				const dep = new HarmonyExportExpressionDependency(
-					parser.state.module,
 					expr.range,
 					statement.range
 				);
@@ -82,7 +80,6 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 					const settings = parser.state.harmonySpecifier.get(id);
 					dep = new HarmonyExportImportedSpecifierDependency(
 						settings.source,
-						parser.state.module,
 						settings.sourceOrder,
 						parser.state.harmonyParserScope,
 						settings.id,
@@ -92,11 +89,7 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 						this.strictExportPresence
 					);
 				} else {
-					dep = new HarmonyExportSpecifierDependency(
-						parser.state.module,
-						id,
-						name
-					);
+					dep = new HarmonyExportSpecifierDependency(id, name);
 				}
 				dep.loc = Object.create(statement.loc);
 				dep.loc.index = idx;
@@ -118,7 +111,6 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 				}
 				const dep = new HarmonyExportImportedSpecifierDependency(
 					source,
-					parser.state.module,
 					parser.state.lastHarmonyImportOrder,
 					parser.state.harmonyParserScope,
 					id,

--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -14,9 +14,8 @@ const NullDependency = require("./NullDependency");
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 
 class HarmonyExportExpressionDependency extends NullDependency {
-	constructor(originModule, range, rangeStatement) {
+	constructor(range, rangeStatement) {
 		super();
-		this.originModule = originModule;
 		this.range = range;
 		this.rangeStatement = rangeStatement;
 	}
@@ -45,10 +44,10 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
 	 */
-	apply(dependency, source, { moduleGraph }) {
+	apply(dependency, source, { module, moduleGraph }) {
 		const dep = /** @type {HarmonyExportExpressionDependency} */ (dependency);
-		const used = dep.originModule.getUsedName(moduleGraph, "default");
-		const content = this.getContent(dep.originModule, used);
+		const used = module.getUsedName(moduleGraph, "default");
+		const content = this.getContent(module, used);
 
 		if (dep.range) {
 			source.replace(dep.rangeStatement[0], dep.range[0] - 1, content + "(");

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -66,7 +66,6 @@ const EMPTY_STAR_MODE = new ExportMode("empty-star");
 class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 	constructor(
 		request,
-		originModule,
 		sourceOrder,
 		parserScope,
 		id,
@@ -75,7 +74,7 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 		otherStarExports,
 		strictExportPresence
 	) {
-		super(request, originModule, sourceOrder, parserScope);
+		super(request, sourceOrder, parserScope);
 		this.id = id;
 		this.name = name;
 		this.activeExports = activeExports;
@@ -95,8 +94,9 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 	getMode(moduleGraph, ignoreUnused) {
 		const name = this.name;
 		const id = this.id;
-		const used = this.originModule.getUsedName(moduleGraph, name);
-		const usedExports = this.originModule.getUsedExports(moduleGraph);
+		const parentModule = moduleGraph.getParentModule(this);
+		const used = parentModule.getUsedName(moduleGraph, name);
+		const usedExports = parentModule.getUsedExports(moduleGraph);
 		const importedModule = moduleGraph.getModule(this);
 
 		if (!importedModule) {
@@ -111,7 +111,7 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 			return mode;
 		}
 
-		const strictHarmonyModule = this.originModule.buildMeta.strictHarmonyModule;
+		const strictHarmonyModule = parentModule.buildMeta.strictHarmonyModule;
 		if (name && id === "default" && importedModule.buildMeta) {
 			if (!importedModule.buildMeta.exportsType) {
 				const mode = new ExportMode(
@@ -379,7 +379,7 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 	getWarnings(moduleGraph) {
 		if (
 			this.strictExportPresence ||
-			this.originModule.buildMeta.strictHarmonyModule
+			moduleGraph.getParentModule(this).buildMeta.strictHarmonyModule
 		) {
 			return [];
 		}
@@ -394,7 +394,7 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 	getErrors(moduleGraph) {
 		if (
 			this.strictExportPresence ||
-			this.originModule.buildMeta.strictHarmonyModule
+			moduleGraph.getParentModule(this).buildMeta.strictHarmonyModule
 		) {
 			return this._getErrors(moduleGraph);
 		}
@@ -410,7 +410,7 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 		if (!importedModule.buildMeta || !importedModule.buildMeta.exportsType) {
 			// It's not an harmony module
 			if (
-				this.originModule.buildMeta.strictHarmonyModule &&
+				moduleGraph.getParentModule(this).buildMeta.strictHarmonyModule &&
 				this.id !== "default"
 			) {
 				// In strict harmony modules we only support the default export
@@ -470,7 +470,11 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 		if (this.isUsed(dep, templateContext)) {
 			const importFragments = super.getInitFragments(dep, templateContext);
 			const exportFragment = new InitFragment(
-				this.getContent(dep, templateContext.moduleGraph),
+				this.getContent(
+					dep,
+					templateContext.module,
+					templateContext.moduleGraph
+				),
 				InitFragment.STAGE_HARMONY_IMPORTS,
 				dep.sourceOrder
 			);
@@ -487,16 +491,15 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 	 * @param {DependencyTemplateContext} templateContext the template context
 	 * @returns {Boolean} true, if (any) export is used
 	 */
-	isUsed(dep, templateContext) {
-		const moduleGraph = templateContext.moduleGraph;
+	isUsed(dep, { moduleGraph, module }) {
 		if (dep.name) {
-			return dep.originModule.isExportUsed(moduleGraph, dep.name);
+			return module.isExportUsed(moduleGraph, dep.name);
 		} else {
-			const importedModule = templateContext.moduleGraph.getModule(dep);
+			const importedModule = moduleGraph.getModule(dep);
 			const activeFromOtherStarExports = dep._discoverActiveExportsFromOtherStartExports(
-				templateContext.moduleGraph
+				moduleGraph
 			);
-			const usedExports = dep.originModule.getUsedExports(moduleGraph);
+			const usedExports = module.getUsedExports(moduleGraph);
 
 			if (usedExports && usedExports !== true) {
 				// we know which exports are used
@@ -528,12 +531,12 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 
 	/**
 	 * @param {HarmonyExportImportedSpecifierDependency} dep dependency
+	 * @param {Module} module the current module
 	 * @param {ModuleGraph} moduleGraph the module graph
 	 * @returns {string} the generated code
 	 */
-	getContent(dep, moduleGraph) {
+	getContent(dep, module, moduleGraph) {
 		const mode = dep.getMode(moduleGraph, false);
-		const module = dep.originModule;
 		const importedModule = moduleGraph.getModule(dep);
 		const importVar = dep.getImportVar(moduleGraph);
 
@@ -667,7 +670,7 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 				} else {
 					content += "if(__WEBPACK_IMPORT_KEY__ !== 'default') ";
 				}
-				const exportsName = dep.originModule.exportsArgument;
+				const exportsName = module.exportsArgument;
 				return (
 					content +
 					`(function(key) { __webpack_require__.d(${exportsName}, key, function() { return ${importVar}[key]; }) }(__WEBPACK_IMPORT_KEY__));\n`

--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -15,9 +15,8 @@ const NullDependency = require("./NullDependency");
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 
 class HarmonyExportSpecifierDependency extends NullDependency {
-	constructor(originModule, id, name) {
+	constructor(id, name) {
 		super();
-		this.originModule = originModule;
 		this.id = id;
 		this.name = name;
 	}
@@ -55,23 +54,23 @@ HarmonyExportSpecifierDependency.Template = class HarmonyExportSpecifierDependen
 	 * @param {DependencyTemplateContext} templateContext the template context
 	 * @returns {InitFragment[]|null} the init fragments
 	 */
-	getInitFragments(dependency, { moduleGraph }) {
+	getInitFragments(dependency, { module, moduleGraph }) {
 		return [
 			new InitFragment(
-				this.getContent(moduleGraph, dependency),
+				this.getContent(dependency, module, moduleGraph),
 				InitFragment.STAGE_HARMONY_EXPORTS,
 				1
 			)
 		];
 	}
 
-	getContent(moduleGraph, dep) {
-		const used = dep.originModule.getUsedName(moduleGraph, dep.name);
+	getContent(dep, module, moduleGraph) {
+		const used = module.getUsedName(moduleGraph, dep.name);
 		if (!used) {
 			return `/* unused harmony export ${dep.name || "namespace"} */\n`;
 		}
 
-		const exportsName = dep.originModule.exportsArgument;
+		const exportsName = module.exportsArgument;
 
 		return `/* harmony export (binding) */ __webpack_require__.d(${exportsName}, ${JSON.stringify(
 			used

--- a/lib/dependencies/HarmonyImportDependency.js
+++ b/lib/dependencies/HarmonyImportDependency.js
@@ -23,13 +23,11 @@ class HarmonyImportDependency extends ModuleDependency {
 	/**
 	 *
 	 * @param {string} request request string
-	 * @param {Module} originModule module which contains the dependency
 	 * @param {number} sourceOrder source order
 	 * @param {TODO} parserScope parser scope
 	 */
-	constructor(request, originModule, sourceOrder, parserScope) {
+	constructor(request, sourceOrder, parserScope) {
 		super(request);
-		this.originModule = originModule;
 		this.sourceOrder = sourceOrder;
 		this.parserScope = parserScope;
 	}
@@ -70,13 +68,13 @@ class HarmonyImportDependency extends ModuleDependency {
 	 * @param {DependencyTemplateContext} templateContext the template context
 	 * @returns {string} name of the variable for the import
 	 */
-	getImportStatement(update, { runtimeTemplate: runtime, moduleGraph }) {
-		return runtime.importStatement({
+	getImportStatement(update, { runtimeTemplate, module, moduleGraph }) {
+		return runtimeTemplate.importStatement({
 			update,
 			module: moduleGraph.getModule(this),
 			importVar: this.getImportVar(moduleGraph),
 			request: this.request,
-			originModule: this.originModule
+			originModule: module
 		});
 	}
 

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -29,7 +29,6 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 				parser.state.module.addDependency(clearDep);
 				const sideEffectDep = new HarmonyImportSideEffectDependency(
 					source,
-					parser.state.module,
 					parser.state.lastHarmonyImportOrder,
 					parser.state.harmonyParserScope
 				);
@@ -61,7 +60,6 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 				const settings = parser.state.harmonySpecifier.get(name);
 				const dep = new HarmonyImportSpecifierDependency(
 					settings.source,
-					parser.state.module,
 					settings.sourceOrder,
 					parser.state.harmonyParserScope,
 					settings.id,
@@ -83,7 +81,6 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 				if (settings.id !== null) return false;
 				const dep = new HarmonyImportSpecifierDependency(
 					settings.source,
-					parser.state.module,
 					settings.sourceOrder,
 					parser.state.harmonyParserScope,
 					expr.property.name || expr.property.value,
@@ -109,7 +106,6 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 					if (settings.id !== null) return false;
 					const dep = new HarmonyImportSpecifierDependency(
 						settings.source,
-						parser.state.module,
 						settings.sourceOrder,
 						parser.state.harmonyParserScope,
 						expr.callee.property.name || expr.callee.property.value,
@@ -137,7 +133,6 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 				const settings = parser.state.harmonySpecifier.get(name);
 				const dep = new HarmonyImportSpecifierDependency(
 					settings.source,
-					parser.state.module,
 					settings.sourceOrder,
 					parser.state.harmonyParserScope,
 					settings.id,
@@ -168,7 +163,6 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 				const dependencies = requests.map(request => {
 					const dep = new HarmonyAcceptImportDependency(
 						request,
-						parser.state.module,
 						harmonyParserScope
 					);
 					dep.loc = expr.loc;
@@ -197,7 +191,6 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 				const dependencies = requests.map(request => {
 					const dep = new HarmonyAcceptImportDependency(
 						request,
-						parser.state.module,
 						harmonyParserScope
 					);
 					dep.loc = expr.loc;

--- a/lib/dependencies/HarmonyImportSideEffectDependency.js
+++ b/lib/dependencies/HarmonyImportSideEffectDependency.js
@@ -15,8 +15,8 @@ const HarmonyImportDependency = require("./HarmonyImportDependency");
 /** @typedef {import("./DependencyReference")} DependencyReference */
 
 class HarmonyImportSideEffectDependency extends HarmonyImportDependency {
-	constructor(request, originModule, sourceOrder, parserScope) {
-		super(request, originModule, sourceOrder, parserScope);
+	constructor(request, sourceOrder, parserScope) {
+		super(request, sourceOrder, parserScope);
 	}
 
 	/**

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -20,7 +20,6 @@ const HarmonyImportDependency = require("./HarmonyImportDependency");
 class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 	constructor(
 		request,
-		originModule,
 		sourceOrder,
 		parserScope,
 		id,
@@ -28,7 +27,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		range,
 		strictExportPresence
 	) {
-		super(request, originModule, sourceOrder, parserScope);
+		super(request, sourceOrder, parserScope);
 		this.id = id === null ? null : `${id}`;
 		this.name = name;
 		this.range = range;
@@ -78,7 +77,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 	getWarnings(moduleGraph) {
 		if (
 			this.strictExportPresence ||
-			this.originModule.buildMeta.strictHarmonyModule
+			moduleGraph.getParentModule(this).buildMeta.strictHarmonyModule
 		) {
 			return [];
 		}
@@ -93,7 +92,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 	getErrors(moduleGraph) {
 		if (
 			this.strictExportPresence ||
-			this.originModule.buildMeta.strictHarmonyModule
+			moduleGraph.getParentModule(this).buildMeta.strictHarmonyModule
 		) {
 			return this._getErrors(moduleGraph);
 		}
@@ -109,7 +108,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		if (!importedModule.buildMeta || !importedModule.buildMeta.exportsType) {
 			// It's not an harmony module
 			if (
-				this.originModule.buildMeta.strictHarmonyModule &&
+				moduleGraph.getParentModule(this).buildMeta.strictHarmonyModule &&
 				this.getId(moduleGraph) !== "default"
 			) {
 				// In strict harmony modules we only support the default export
@@ -195,13 +194,13 @@ HarmonyImportSpecifierDependency.Template = class HarmonyImportSpecifierDependen
 		source.replace(dep.range[0], dep.range[1] - 1, content);
 	}
 
-	getContent(dep, { runtimeTemplate: runtime, moduleGraph }) {
-		const exportExpr = runtime.exportFromImport({
+	getContent(dep, { runtimeTemplate, module, moduleGraph }) {
+		const exportExpr = runtimeTemplate.exportFromImport({
 			moduleGraph,
 			module: moduleGraph.getModule(dep),
 			request: dep.request,
 			exportName: dep.getId(moduleGraph),
-			originModule: dep.originModule,
+			originModule: module,
 			asiSafe: dep.shorthand,
 			isCall: dep.call,
 			callContext: !dep.directImport,

--- a/lib/dependencies/ImportDependenciesBlock.js
+++ b/lib/dependencies/ImportDependenciesBlock.js
@@ -13,7 +13,7 @@ module.exports = class ImportDependenciesBlock extends AsyncDependenciesBlock {
 	constructor(request, range, groupOptions, module, loc, originModule) {
 		super(groupOptions, module, loc, request);
 		this.range = range;
-		const dep = new ImportDependency(request, originModule, this);
+		const dep = new ImportDependency(request, this);
 		dep.loc = loc;
 		this.addDependency(dep);
 	}

--- a/lib/dependencies/ImportDependency.js
+++ b/lib/dependencies/ImportDependency.js
@@ -12,9 +12,8 @@ const ModuleDependency = require("./ModuleDependency");
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 
 class ImportDependency extends ModuleDependency {
-	constructor(request, originModule, block) {
+	constructor(request, block) {
 		super(request);
-		this.originModule = originModule;
 		this.block = block;
 	}
 
@@ -30,13 +29,13 @@ ImportDependency.Template = class ImportDependencyTemplate extends ModuleDepende
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
 	 */
-	apply(dependency, source, { runtimeTemplate, moduleGraph }) {
+	apply(dependency, source, { runtimeTemplate, module, moduleGraph }) {
 		const dep = /** @type {ImportDependency} */ (dependency);
 		const content = runtimeTemplate.moduleNamespacePromise({
 			block: dep.block,
 			module: moduleGraph.getModule(dep),
 			request: dep.request,
-			strict: dep.originModule.buildMeta.strictHarmonyModule,
+			strict: module.buildMeta.strictHarmonyModule,
 			message: "import()"
 		});
 

--- a/lib/dependencies/ImportEagerDependency.js
+++ b/lib/dependencies/ImportEagerDependency.js
@@ -12,9 +12,8 @@ const ModuleDependency = require("./ModuleDependency");
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 
 class ImportEagerDependency extends ModuleDependency {
-	constructor(request, originModule, range) {
+	constructor(request, range) {
 		super(request);
-		this.originModule = originModule;
 		this.range = range;
 	}
 
@@ -30,12 +29,12 @@ ImportEagerDependency.Template = class ImportEagerDependencyTemplate extends Mod
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
 	 */
-	apply(dependency, source, { runtimeTemplate, moduleGraph }) {
+	apply(dependency, source, { runtimeTemplate, module, moduleGraph }) {
 		const dep = /** @type {ImportEagerDependency} */ (dependency);
 		const content = runtimeTemplate.moduleNamespacePromise({
 			module: moduleGraph.getModule(dep),
 			request: dep.request,
-			strict: dep.originModule.buildMeta.strictHarmonyModule,
+			strict: module.buildMeta.strictHarmonyModule,
 			message: "import() eager"
 		});
 		source.replace(dep.range[0], dep.range[1] - 1, content);

--- a/lib/dependencies/ImportParserPlugin.js
+++ b/lib/dependencies/ImportParserPlugin.js
@@ -187,18 +187,10 @@ class ImportParserPlugin {
 				}
 
 				if (mode === "eager") {
-					const dep = new ImportEagerDependency(
-						param.string,
-						parser.state.module,
-						expr.range
-					);
+					const dep = new ImportEagerDependency(param.string, expr.range);
 					parser.state.current.addDependency(dep);
 				} else if (mode === "weak") {
-					const dep = new ImportWeakDependency(
-						param.string,
-						parser.state.module,
-						expr.range
-					);
+					const dep = new ImportWeakDependency(param.string, expr.range);
 					parser.state.current.addDependency(dep);
 				} else {
 					const depBlock = new ImportDependenciesBlock(

--- a/lib/dependencies/ImportWeakDependency.js
+++ b/lib/dependencies/ImportWeakDependency.js
@@ -12,9 +12,8 @@ const ModuleDependency = require("./ModuleDependency");
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 
 class ImportWeakDependency extends ModuleDependency {
-	constructor(request, originModule, range) {
+	constructor(request, range) {
 		super(request);
-		this.originModule = originModule;
 		this.range = range;
 		this.weak = true;
 	}
@@ -31,12 +30,12 @@ ImportWeakDependency.Template = class ImportDependencyTemplate extends ModuleDep
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
 	 */
-	apply(dependency, source, { runtimeTemplate, moduleGraph }) {
+	apply(dependency, source, { runtimeTemplate, module, moduleGraph }) {
 		const dep = /** @type {ImportWeakDependency} */ (dependency);
 		const content = runtimeTemplate.moduleNamespacePromise({
 			module: moduleGraph.getModule(dep),
 			request: dep.request,
-			strict: dep.originModule.buildMeta.strictHarmonyModule,
+			strict: module.buildMeta.strictHarmonyModule,
 			message: "import() weak",
 			weak: true
 		});

--- a/lib/dependencies/ModuleDecoratorDependency.js
+++ b/lib/dependencies/ModuleDecoratorDependency.js
@@ -17,11 +17,6 @@ const ModuleDependency = require("./ModuleDependency");
 /** @typedef {import("../util/createHash").Hash} Hash */
 
 class ModuleDecoratorDependency extends ModuleDependency {
-	constructor(request, originModule) {
-		super(request);
-		this.originModule = originModule;
-	}
-
 	/**
 	 * Update the hash
 	 * @param {Hash} hash hash to be updated
@@ -50,17 +45,18 @@ ModuleDecoratorDependency.Template = class ModuleDecoratorDependencyTemplate ext
 	 */
 	getInitFragments(dependency, { runtimeTemplate, moduleGraph }) {
 		const dep = /** @type {ModuleDecoratorDependency} */ (dependency);
+		const originModule = moduleGraph.getOrigin(dep);
 		return [
 			new InitFragment(
 				`/* module decorator */ ${
-					dep.originModule.moduleArgument
+					originModule.moduleArgument
 				} = ${runtimeTemplate.moduleExports({
 					module: moduleGraph.getModule(dep),
 					request: dep.request
-				})}(${dep.originModule.moduleArgument});\n`,
+				})}(${originModule.moduleArgument});\n`,
 				InitFragment.STAGE_PROVIDES,
 				0,
-				`module decorator ${dep.originModule.id}`
+				`module decorator ${originModule.id}`
 			)
 		];
 	}

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -1282,7 +1282,7 @@ class HarmonyImportSpecifierDependencyConcatenatedTemplate extends DependencyTem
 	 * @returns {void}
 	 */
 	apply(dependency, source, templateContext) {
-		const { moduleGraph } = templateContext;
+		const { moduleGraph, module: parentModule } = templateContext;
 		const dep = /** @type {HarmonyImportSpecifierDependency} */ (dependency);
 		const module = moduleGraph.getModule(dep);
 		const info = this.modulesMap.get(module);
@@ -1292,7 +1292,7 @@ class HarmonyImportSpecifierDependencyConcatenatedTemplate extends DependencyTem
 		}
 		let content;
 		const callFlag = dep.call ? "_call" : "";
-		const strictFlag = dep.originModule.buildMeta.strictHarmonyModule
+		const strictFlag = parentModule.buildMeta.strictHarmonyModule
 			? "_strict"
 			: "";
 		const id = dep.getId(moduleGraph);
@@ -1371,7 +1371,7 @@ class HarmonyExportSpecifierDependencyConcatenatedTemplate extends DependencyTem
 	 */
 	getInitFragments(dependency, templateContext) {
 		const dep = /** @type {HarmonyExportSpecifierDependency} */ (dependency);
-		if (dep.originModule === this.rootModule) {
+		if (templateContext.module === this.rootModule) {
 			return this.originalTemplate.getInitFragments(dep, templateContext);
 		} else {
 			return null;
@@ -1385,8 +1385,7 @@ class HarmonyExportSpecifierDependencyConcatenatedTemplate extends DependencyTem
 	 * @returns {void}
 	 */
 	apply(dependency, source, templateContext) {
-		const dep = /** @type {HarmonyExportSpecifierDependency} */ (dependency);
-		if (dep.originModule === this.rootModule) {
+		if (templateContext.module === this.rootModule) {
 			this.originalTemplate.apply(dependency, source, templateContext);
 		}
 	}
@@ -1405,17 +1404,13 @@ class HarmonyExportExpressionDependencyConcatenatedTemplate extends DependencyTe
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
 	 */
-	apply(
-		dependency,
-		source,
-		{ runtimeTemplate, dependencyTemplates, moduleGraph }
-	) {
+	apply(dependency, source, { module, moduleGraph }) {
 		const dep = /** @type {HarmonyExportExpressionDependency} */ (dependency);
 		let content =
 			"/* harmony default export */ var __WEBPACK_MODULE_DEFAULT_EXPORT__ = ";
-		if (dep.originModule === this.rootModule) {
-			const used = dep.originModule.getUsedName(moduleGraph, "default");
-			const exportsName = dep.originModule.exportsArgument;
+		if (module === this.rootModule) {
+			const used = module.getUsedName(moduleGraph, "default");
+			const exportsName = module.exportsArgument;
 			if (used) {
 				content += `${exportsName}[${JSON.stringify(used)}] = `;
 			}
@@ -1497,14 +1492,14 @@ class HarmonyExportImportedSpecifierDependencyConcatenatedTemplate extends Depen
 	 * @returns {void}
 	 */
 	apply(dependency, source, templateContext) {
-		const { moduleGraph } = templateContext;
+		const { moduleGraph, module } = templateContext;
 		const dep = /** @type {HarmonyExportImportedSpecifierDependency} */ (dependency);
-		if (dep.originModule === this.rootModule) {
+		if (module === this.rootModule) {
 			if (this.modulesMap.get(moduleGraph.getModule(dep))) {
 				const exportDefs = this.getExports(dep, { moduleGraph });
 				for (const def of exportDefs) {
 					const info = this.modulesMap.get(def.module);
-					const used = dep.originModule.getUsedName(moduleGraph, def.name);
+					const used = module.getUsedName(moduleGraph, def.name);
 					if (!used) {
 						source.insert(
 							-1,
@@ -1512,7 +1507,7 @@ class HarmonyExportImportedSpecifierDependencyConcatenatedTemplate extends Depen
 						);
 					}
 					let finalName;
-					const strictFlag = dep.originModule.buildMeta.strictHarmonyModule
+					const strictFlag = module.buildMeta.strictHarmonyModule
 						? "_strict"
 						: "";
 					if (def.id === true) {


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
refactor
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
existing tests
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Some dependencies had `originModule` constructor argument and property. This is no longer the case. One can ask the ModuleGraph for the (origin) module via `getParentModule`.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
