### PR TITLE
Avoid needless sort in Chunk compare

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -313,17 +313,17 @@ class Chunk {
 	 * @returns {-1|0|1} this is a comparitor function like sort and returns -1, 0, or 1 based on sort order
 	 */
 	compareTo(otherChunk) {
-		this._modules.sort();
-		otherChunk._modules.sort();
 		if (this._modules.size > otherChunk._modules.size) return -1;
 		if (this._modules.size < otherChunk._modules.size) return 1;
+		this._modules.sort();
+		otherChunk._modules.sort();
 		const a = this._modules[Symbol.iterator]();
 		const b = otherChunk._modules[Symbol.iterator]();
 		// eslint-disable-next-line no-constant-condition
 		while (true) {
 			const aItem = a.next();
-			const bItem = b.next();
 			if (aItem.done) return 0;
+			const bItem = b.next();
 			const aModuleIdentifier = aItem.value.identifier();
 			const bModuleIdentifier = bItem.value.identifier();
 			if (aModuleIdentifier < bModuleIdentifier) return -1;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->



<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Refactoring
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Minor changes in `compareTo` method.
Moved `sort()` after size checking to avoid needless sorting if sizes are different.
Also similar changes inside while loop to avoid needless `b.next()`