### PR TITLE
Get rid of typeof for checking undefined

### DIFF
--- a/lib/ContextReplacementPlugin.js
+++ b/lib/ContextReplacementPlugin.js
@@ -60,13 +60,13 @@ class ContextReplacementPlugin {
 			cmf.hooks.beforeResolve.tap("ContextReplacementPlugin", result => {
 				if (!result) return;
 				if (resourceRegExp.test(result.request)) {
-					if (typeof newContentResource !== "undefined") {
+					if (newContentResource !== undefined) {
 						result.request = newContentResource;
 					}
-					if (typeof newContentRecursive !== "undefined") {
+					if (newContentRecursive !== undefined) {
 						result.recursive = newContentRecursive;
 					}
-					if (typeof newContentRegExp !== "undefined") {
+					if (newContentRegExp !== undefined) {
 						result.regExp = newContentRegExp;
 					}
 					if (typeof newContentCallback === "function") {
@@ -82,13 +82,13 @@ class ContextReplacementPlugin {
 			cmf.hooks.afterResolve.tap("ContextReplacementPlugin", result => {
 				if (!result) return;
 				if (resourceRegExp.test(result.resource)) {
-					if (typeof newContentResource !== "undefined") {
+					if (newContentResource !== undefined) {
 						result.resource = path.resolve(result.resource, newContentResource);
 					}
-					if (typeof newContentRecursive !== "undefined") {
+					if (newContentRecursive !== undefined) {
 						result.recursive = newContentRecursive;
 					}
-					if (typeof newContentRegExp !== "undefined") {
+					if (newContentRegExp !== undefined) {
 						result.regExp = newContentRegExp;
 					}
 					if (typeof newContentCreateContextMap === "function") {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Refactoring
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->


`typeof` for checking for undefined is not required here. We never catch exception because variables were defined in scope.