### PR TITLE
Add sourcemap support for .mjs output files

### DIFF
--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -84,7 +84,7 @@ class SourceMapDevToolPlugin {
 		const fallbackModuleFilenameTemplate = this.fallbackModuleFilenameTemplate;
 		const requestShortener = compiler.requestShortener;
 		const options = this.options;
-		options.test = options.test || /\.(js|css)($|\?)/i;
+		options.test = options.test || /\.(m?js|css)($|\?)/i;
 
 		const matchObject = ModuleFilenameHelpers.matchObject.bind(
 			undefined,

--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -85,12 +85,13 @@ describe("ConfigTestCases", () => {
 								});
 								let testConfig = {
 									findBundle: function(i, options) {
+										const ext = path.extname(options.output.filename);
 										if (
 											fs.existsSync(
-												path.join(options.output.path, "bundle" + i + ".js")
+												path.join(options.output.path, "bundle" + i + ext)
 											)
 										) {
-											return "./bundle" + i + ".js";
+											return "./bundle" + i + ext;
 										}
 									},
 									timeout: 30000

--- a/test/configCases/source-map/default-filename-extensions-css/index.js
+++ b/test/configCases/source-map/default-filename-extensions-css/index.js
@@ -1,0 +1,6 @@
+it("creates source maps for .css output files by default", function() {
+  var fs = require("fs");
+  var source = fs.readFileSync(__filename, "utf-8");
+  var match = /sourceMappingURL\s*=\s*(.*)\*\//.exec(source);
+  expect(match[1]).toBe("bundle0.css.map");
+});

--- a/test/configCases/source-map/default-filename-extensions-css/test.js
+++ b/test/configCases/source-map/default-filename-extensions-css/test.js
@@ -1,0 +1,3 @@
+var foo = {};
+
+module.exports = foo;

--- a/test/configCases/source-map/default-filename-extensions-css/webpack.config.js
+++ b/test/configCases/source-map/default-filename-extensions-css/webpack.config.js
@@ -9,4 +9,3 @@ module.exports = {
 	},
 	devtool: "source-map"
 };
-

--- a/test/configCases/source-map/default-filename-extensions-css/webpack.config.js
+++ b/test/configCases/source-map/default-filename-extensions-css/webpack.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+	mode: "development",
+	output: {
+		filename: "bundle0.css"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	devtool: "source-map"
+};
+

--- a/test/configCases/source-map/default-filename-extensions-js/index.js
+++ b/test/configCases/source-map/default-filename-extensions-js/index.js
@@ -1,0 +1,6 @@
+it("creates source maps for .js output files by default", function() {
+  var fs = require("fs");
+  var source = fs.readFileSync(__filename, "utf-8");
+  var match = /sourceMappingURL\s*=\s*(.*)/.exec(source);
+  expect(match[1]).toBe("bundle0.js.map");
+});

--- a/test/configCases/source-map/default-filename-extensions-js/test.js
+++ b/test/configCases/source-map/default-filename-extensions-js/test.js
@@ -1,0 +1,3 @@
+var foo = {};
+
+module.exports = foo;

--- a/test/configCases/source-map/default-filename-extensions-js/webpack.config.js
+++ b/test/configCases/source-map/default-filename-extensions-js/webpack.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+	mode: "development",
+	output: {
+		filename: "bundle0.js"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	devtool: "source-map"
+};
+

--- a/test/configCases/source-map/default-filename-extensions-js/webpack.config.js
+++ b/test/configCases/source-map/default-filename-extensions-js/webpack.config.js
@@ -9,4 +9,3 @@ module.exports = {
 	},
 	devtool: "source-map"
 };
-

--- a/test/configCases/source-map/default-filename-extensions-mjs/index.js
+++ b/test/configCases/source-map/default-filename-extensions-mjs/index.js
@@ -1,0 +1,6 @@
+it("creates source maps for .mjs output files by default", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+	var match = /sourceMappingURL\s*=\s*(.*)/.exec(source);
+	expect(match[1]).toBe("bundle0.mjs.map");
+});

--- a/test/configCases/source-map/default-filename-extensions-mjs/test.js
+++ b/test/configCases/source-map/default-filename-extensions-mjs/test.js
@@ -1,0 +1,3 @@
+var foo = {};
+
+module.exports = foo;

--- a/test/configCases/source-map/default-filename-extensions-mjs/webpack.config.js
+++ b/test/configCases/source-map/default-filename-extensions-mjs/webpack.config.js
@@ -9,4 +9,3 @@ module.exports = {
 	},
 	devtool: "source-map"
 };
-

--- a/test/configCases/source-map/default-filename-extensions-mjs/webpack.config.js
+++ b/test/configCases/source-map/default-filename-extensions-mjs/webpack.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+	mode: "development",
+	output: {
+		filename: "bundle0.mjs"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	devtool: "source-map"
+};
+


### PR DESCRIPTION
Fixes: https://github.com/webpack/webpack/issues/7927.

**Did you add tests for your changes?**

I didn't see any tests for the existing behavior in [`test/SourceMapDevToolModuleOptionsPlugin.unittest.js`](https://github.com/webpack/webpack/blob/v4.17.1/test/SourceMapDevToolModuleOptionsPlugin.unittest.js), so I wasn't sure how best to add tests for this. Let me know if you think it needs tests.

**Does this PR introduce a breaking change?**

Nope.

/cc @mathiasbynens as FYI.
