### PR TITLE
Fixed documentation and config for chunkhash example in examples section

### DIFF
--- a/examples/chunkhash/README.md
+++ b/examples/chunkhash/README.md
@@ -1,5 +1,15 @@
 A common challenge with combining `[chunkhash]` and Code Splitting is that the entry chunk includes the webpack runtime and with it the chunkhash mappings. This means it's always updated and the `[chunkhash]` is pretty useless, because this chunk won't be cached.
 
+Chunk mappings in the entry chunk will look like this.
+
+``` javascript
+// script file - dist/main.[chunkhash].js
+// script path function - Chunkhash linked to module id's
+    function jsonpScriptSrc(chunkId) {
+        return __webpack_require__.p + "" + ({}[chunkId]||chunkId) + "." + {"1":[chunkhash],"2":[chunkhash]}[chunkId] + ".js"
+    }
+```
+
 A very simple solution to this problem is to create another chunk which contains only the webpack runtime (including chunkhash map). This can be achieved with the `optimization.runtimeChunk` options. To avoid the additional request for another chunk, this pretty small chunk can be inlined into the HTML page.
 
 The configuration required for this is:
@@ -297,8 +307,8 @@ Hash: 0a1b2c3d4e5f6a7b8c9d
 Version: webpack 4.8.0
                     Asset       Size  Chunks             Chunk Names
         main.[chunkhash].js  877 bytes       0  [emitted]  main
-           1.[chunkhash].js  270 bytes       1  [emitted]  
-           2.[chunkhash].js  264 bytes       2  [emitted]  
+           1.[chunkhash].js  270 bytes       1  [emitted]
+           2.[chunkhash].js  264 bytes       2  [emitted]
 runtime~main.[chunkhash].js   7.75 KiB       3  [emitted]  runtime~main
 Entrypoint main = runtime~main.[chunkhash].js main.[chunkhash].js
 chunk    {0} main.[chunkhash].js (main) 55 bytes ={3}= >{1}< >{2}< [initial] [rendered]
@@ -317,14 +327,25 @@ chunk    {3} runtime~main.[chunkhash].js (runtime~main) 0 bytes ={0}= >{1}< >{2}
     > ./example main
 ```
 
+After adding `optimization.runtimeChunk` option,
+chunk mappings will be moved into the runtime chunk.
+
+``` javascript
+// script file - dist/runtime~main.[chunkhash].js
+// script path function - Chunkhash linked to module id's
+    function jsonpScriptSrc(chunkId) {
+        return __webpack_require__.p + "" + ({}[chunkId]||chunkId) + "." + {"1":[chunkhash],"2":[chunkhash]}[chunkId] + ".js"
+    }
+```
+
 ## Production mode
 
 ```
 Hash: 0a1b2c3d4e5f6a7b8c9d
 Version: webpack 4.8.0
                     Asset       Size  Chunks             Chunk Names
-           0.[chunkhash].js   77 bytes       0  [emitted]  
-           1.[chunkhash].js   78 bytes       1  [emitted]  
+           0.[chunkhash].js   77 bytes       0  [emitted]
+           1.[chunkhash].js   78 bytes       1  [emitted]
 runtime~main.[chunkhash].js   1.79 KiB       2  [emitted]  runtime~main
         main.[chunkhash].js  349 bytes       3  [emitted]  main
 Entrypoint main = runtime~main.[chunkhash].js main.[chunkhash].js

--- a/examples/chunkhash/webpack.config.js
+++ b/examples/chunkhash/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
 	},
 	output: {
 		path: path.join(__dirname, "dist"),
-		filename: "[name].chunkhash.js",
-		chunkFilename: "[name].chunkhash.js"
+		filename: "[name].[chunkhash].js",
+		chunkFilename: "[name].[chunkhash].js"
 	}
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Config file for chunkhash example in examples section has an issue. Output chunks should use [chunkhash] instead of chunkhash.

Also modified documentation to provide more understanding on, how chunk mappings are linked after adding `optimization.runtimeChunk`.

<!-- Try to link to an open issue for more information. -->
No issue is opened

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

This PR introduces these changes.

1.  Change in webpack config file for chunkhash example.
2. Documentation change in the same example, to give more clarity on chunkhash mappings.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No, as this is a small change and doesn't affect the main source code.

**Does this PR introduce a breaking change?**

This PR doesn't have any breaking change.

**What needs to be documented once your changes are merged?**

Nothing needs to be documented.
