### PR TITLE
solving outputing unnecessary spaces

### DIFF
--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -24,7 +24,7 @@ const createDefaultHandler = profile => {
 			for (let detail of details) {
 				if (!detail) continue;
 				if (detail.length > 40) {
-					detail = `…${detail.substr(detail.length - 39)}`;
+					detail = `...${detail.substr(detail.length - 39)}`;
 				}
 				msg += ` ${detail}`;
 			}


### PR DESCRIPTION
`…` is causing terminals like git bash on windows to output unnecessary spaces

- Fixes #7274 
- Fixes #7979 

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

a bugfix

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

nothing
