### PR TITLE
fix(content-object): stringify contents that is an object

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -330,11 +330,10 @@ class Compiler extends Tapable {
 						}
 						let content = source.source();
 
-						if (typeof content === "object") {
-							content = JSON.stringify(content);
-						}
-
 						if (!Buffer.isBuffer(content)) {
+							if (typeof content === "object") {
+								content = JSON.stringify(content);
+							}
 							content = Buffer.from(content, "utf8");
 						}
 

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -330,6 +330,10 @@ class Compiler extends Tapable {
 						}
 						let content = source.source();
 
+						if (typeof content === "object") {
+							content = JSON.stringify(content);
+						}
+
 						if (!Buffer.isBuffer(content)) {
 							content = Buffer.from(content, "utf8");
 						}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Adds a check to handles contents that is an object.
I got this error when using on a Windows, when I saved a file and webpack try to reload, it get an content that is an object and then crash. I can run the same project on Linux and Mac.
This simple change fix the bug.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
bugfix
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing, it will fix under the hood
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
