### PR TITLE
Add ArrayBuffer fallback for #7918

### DIFF
--- a/lib/wasm/WasmMainTemplatePlugin.js
+++ b/lib/wasm/WasmMainTemplatePlugin.js
@@ -276,7 +276,7 @@ class WasmMainTemplatePlugin {
 											Template.indent([
 												`if (reason.name === "TypeError") {`,
 												Template.indent([
-													`console.log("Potential WASM MIME issue detected, falling back to arrayBuffer instantiation");`,
+													`console.warn("Potential WASM MIME issue detected, falling back to arrayBuffer instantiation");`,
 													"return req.then(function(x) { return x.arrayBuffer(); }).then(function(bytes) {",
 													Template.indent([
 														"return WebAssembly.instantiate(bytes, importObject);"

--- a/lib/wasm/WasmMainTemplatePlugin.js
+++ b/lib/wasm/WasmMainTemplatePlugin.js
@@ -272,7 +272,17 @@ class WasmMainTemplatePlugin {
 										Template.indent([
 											`promise = WebAssembly.instantiateStreaming(req, ${createImportObject(
 												"importObject"
-											)});`
+											)}).catch(function(reason) {`,
+											Template.indent([
+												"// We most often fail because of MIME types, fall back to",
+												"// ArrayBuffer instantiation as a workaround",
+												"return req.then(function(x) { return x.arrayBuffer(); }).then(function(bytes) {",
+												Template.indent([
+													"return WebAssembly.instantiate(bytes, importObject);"
+												]),
+												"});"
+											]),
+											"});"
 										])
 								  ])
 								: Template.asString([

--- a/lib/wasm/WasmMainTemplatePlugin.js
+++ b/lib/wasm/WasmMainTemplatePlugin.js
@@ -274,13 +274,17 @@ class WasmMainTemplatePlugin {
 												"importObject"
 											)}).catch(function(reason) {`,
 											Template.indent([
-												"// We most often fail because of MIME types, fall back to",
-												"// ArrayBuffer instantiation as a workaround",
-												"return req.then(function(x) { return x.arrayBuffer(); }).then(function(bytes) {",
+												`if (reason.name === "TypeError") {`,
 												Template.indent([
-													"return WebAssembly.instantiate(bytes, importObject);"
+													`console.log("Potential WASM MIME issue detected, falling back to arrayBuffer instantiation");`,
+													"return req.then(function(x) { return x.arrayBuffer(); }).then(function(bytes) {",
+													Template.indent([
+														"return WebAssembly.instantiate(bytes, importObject);"
+													]),
+													"});"
 												]),
-												"});"
+												"}",
+												"throw reason;"
 											]),
 											"});"
 										])


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Adds a failure case so Electron-style apps can easily use WebAssembly

**Did you add tests for your changes?**

Doesn't run a headless test, not sure how best to add test support (is tested using a local Electron app)

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Hopefully nothing? Think there may be a README example that needs updating, but this should be something that "just fixes" some background issues.
