### PR TITLE
fix: add missing context in webpack.web for Compiler

### DIFF
--- a/lib/webpack.web.js
+++ b/lib/webpack.web.js
@@ -12,7 +12,7 @@ const WebpackOptionsDefaulter = require("./WebpackOptionsDefaulter");
 const webpack = (options, callback) => {
 	new WebpackOptionsDefaulter().process(options);
 
-	const compiler = new Compiler();
+	const compiler = new Compiler(options.context);
 	compiler.options = new WebpackOptionsApply().process(options, compiler);
 	new WebEnvironmentPlugin(
 		options.inputFileSystem,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

`RequestShortener's` constructor which is called in `Compiler's` constructor will use `context.replace`, add the missing parameter for avoiding error in webpack.web.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
