### PR TITLE
fix(nodemaintemplate): resolve async chunk path platform agnostic

### DIFF
--- a/lib/node/NodeMainTemplatePlugin.js
+++ b/lib/node/NodeMainTemplatePlugin.js
@@ -96,7 +96,7 @@ module.exports = class NodeMainTemplatePlugin {
 								"var promise = new Promise(function(resolve, reject) {",
 								Template.indent([
 									"installedChunkData = installedChunks[chunkId] = [resolve, reject];",
-									"var filename = __dirname + " +
+									"var filename = require('path').join(__dirname, " +
 										mainTemplate.getAssetPath(
 											JSON.stringify(`/${chunkFilename}`),
 											{
@@ -155,7 +155,7 @@ module.exports = class NodeMainTemplatePlugin {
 												contentHashType: "javascript"
 											}
 										) +
-										";",
+										");",
 									"require('fs').readFile(filename, 'utf-8',  function(err, content) {",
 									Template.indent(
 										[


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

closes #8032.

For `async-node` target, it creates template to resolve path to chunk bundles via string concat, ends up creating slash-mixed paths on windows platform, fail to some tools like vs code resolves correct sources. This PR updates template to use `path.resolve` instead to have platform agnostic path resolving behavior. `getAssetPath` still generates using fixed separator in slashes, but let it just correctly resovled via `path.resolve` directly instead of trying to make changes to those logics.

**Did you add tests for your changes?**

- manually verified behavior, bit unsure where would be best to add test cases for this.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
