### PR TITLE
add moduleIds deterministic for simpler long term caching

### DIFF
--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -42,6 +42,7 @@ const SystemPlugin = require("./dependencies/SystemPlugin");
 
 const WarnNoModeSetPlugin = require("./WarnNoModeSetPlugin");
 
+const DeterministicModuleIdsPlugin = require("./ids/DeterministicModuleIdsPlugin");
 const HashedModuleIdsPlugin = require("./ids/HashedModuleIdsPlugin");
 const NamedChunkIdsPlugin = require("./ids/NamedChunkIdsPlugin");
 const NamedModuleIdsPlugin = require("./ids/NamedModuleIdsPlugin");
@@ -369,6 +370,11 @@ class WebpackOptionsApply extends OptionsApply {
 					break;
 				case "hashed":
 					new HashedModuleIdsPlugin().apply(compiler);
+					break;
+				case "deterministic":
+					new DeterministicModuleIdsPlugin({
+						maxLength: 3
+					}).apply(compiler);
 					break;
 				case "size":
 					new OccurrenceModuleIdsPlugin({

--- a/lib/ids/DeterministicModuleIdsPlugin.js
+++ b/lib/ids/DeterministicModuleIdsPlugin.js
@@ -1,0 +1,112 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Florent Cailhol @ooflorent
+*/
+
+"use strict";
+
+const {
+	compareModulesByPreOrderIndexOrIdentifier
+} = require("../util/comparators");
+const createHash = require("../util/createHash");
+
+/** @typedef {import("../Compiler")} Compiler */
+/** @typedef {import("../Module")} Module */
+
+/**
+ * @param {string} str string to hash
+ * @param {number} len max length of the number in decimal digests
+ * @returns {number} hash as number in the range from i. e. for len = 3: 0 - 999
+ */
+const getHashNumber = (str, len) => {
+	const hash = createHash("md4");
+	hash.update(str);
+	const digest = hash.digest("hex") + "10000000000";
+	if (len === 1) {
+		return +digest.match(/\d/)[0];
+	}
+	return +digest
+		.match(/\d/g)
+		.slice(0, len)
+		.join("");
+};
+
+class DeterministicModuleIdsPlugin {
+	constructor(options) {
+		this.options = options || {};
+	}
+
+	/**
+	 * @param {Compiler} compiler the compiler instance
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap(
+			"DeterministicModuleIdsPlugin",
+			compilation => {
+				compilation.hooks.moduleIds.tap(
+					"DeterministicModuleIdsPlugin",
+					modules => {
+						const chunkGraph = compilation.chunkGraph;
+						const context = this.options.context
+							? this.options.context
+							: compiler.context;
+
+						const modulesInNaturalOrder = Array.from(modules)
+							.filter(m => chunkGraph.getNumberOfModuleChunks(m) > 0)
+							.sort(
+								compareModulesByPreOrderIndexOrIdentifier(
+									compilation.moduleGraph
+								)
+							);
+
+						// 80% fill rate
+						const optimalLength = Math.ceil(
+							Math.log10(modulesInNaturalOrder.length * 1.25 + 1)
+						);
+
+						// use the provided length or default to the optimal length
+						const maxLength = Math.max(
+							Math.min(
+								typeof this.options.maxLength === "number"
+									? this.options.maxLength
+									: 0,
+								15 // higher values will give numerical problems
+							),
+							optimalLength
+						);
+
+						const usedIds = new Set();
+						if (compilation.usedModuleIds) {
+							for (const id of compilation.usedModuleIds) {
+								usedIds.add(id);
+							}
+						}
+
+						for (const module of modulesInNaturalOrder) {
+							const moduleId = chunkGraph.getModuleId(module);
+							if (moduleId !== null) {
+								usedIds.add(moduleId);
+							}
+						}
+
+						for (const module of modulesInNaturalOrder) {
+							if (chunkGraph.getModuleId(module) === null) {
+								const ident = module.libIdent({ context }) || "";
+								let id;
+								let i = 0;
+								do {
+									id = getHashNumber(ident + i++, maxLength);
+								} while (usedIds.has(id));
+								chunkGraph.setModuleId(module, id);
+								usedIds.add(id);
+							}
+						}
+					}
+				);
+			}
+		);
+	}
+}
+
+module.exports = DeterministicModuleIdsPlugin;

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -134,6 +134,8 @@ exportPlugins((exports.ids = {}), {
 	NaturalModuleIdsPlugin: () => require("./ids/NaturalModuleIdsPlugin"),
 	OccurrenceModuleIdsPlugin: () => require("./ids/OccurrenceModuleIdsPlugin"),
 	NamedModuleIdsPlugin: () => require("./ids/NamedModuleIdsPlugin"),
+	DeterministicModuleIdsPlugin: () =>
+		require("./ids/DeterministicModuleIdsPlugin"),
 	NamedChunkIdsPlugin: () => require("./ids/NamedChunkIdsPlugin"),
 	OccurrenceChunkIdsPlugin: () => require("./ids/OccurrenceChunkIdsPlugin"),
 	HashedModuleIdsPlugin: () => require("./ids/HashedModuleIdsPlugin")

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1542,8 +1542,16 @@
           "type": "boolean"
         },
         "moduleIds": {
-          "description": "Define the algorithm to choose module ids (natural: numeric ids in order of usage, named: readable ids for better debugging, hashed: short hashes as ids for better long term caching, size: numeric ids focused on minimal initial download size, total-size: numeric ids focused on minimal total download size, false: no algorithm used, as custom one can be provided via plugin)",
-          "enum": ["natural", "named", "hashed", "size", "total-size", false]
+          "description": "Define the algorithm to choose module ids (natural: numeric ids in order of usage, named: readable ids for better debugging, hashed: short hashes as ids for better long term caching, deterministic: numeric hash ids for better long term caching, size: numeric ids focused on minimal initial download size, total-size: numeric ids focused on minimal total download size, false: no algorithm used, as custom one can be provided via plugin)",
+          "enum": [
+            "natural",
+            "named",
+            "hashed",
+            "deterministic",
+            "size",
+            "total-size",
+            false
+          ]
         },
         "chunkIds": {
           "description": "Define the algorithm to choose chunk ids (named: readable ids for better debugging, size: numeric ids focused on minimal initial download size, total-size: numeric ids focused on minimal total download size, false: no algorithm used, as custom one can be provided via plugin)",

--- a/test/TestCasesDevtoolEvalDeterministicModuleIds.test.js
+++ b/test/TestCasesDevtoolEvalDeterministicModuleIds.test.js
@@ -1,0 +1,11 @@
+const { describeCases } = require("./TestCases.template");
+
+describe("TestCases", () => {
+	describeCases({
+		name: "devtool-eval",
+		devtool: "eval",
+		optimization: {
+			moduleIds: "deterministic"
+		}
+	});
+});

--- a/test/configCases/hash-length/deterministic-module-ids/files/file1.js
+++ b/test/configCases/hash-length/deterministic-module-ids/files/file1.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/hash-length/deterministic-module-ids/files/file10.js
+++ b/test/configCases/hash-length/deterministic-module-ids/files/file10.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/hash-length/deterministic-module-ids/files/file11.js
+++ b/test/configCases/hash-length/deterministic-module-ids/files/file11.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/hash-length/deterministic-module-ids/files/file12.js
+++ b/test/configCases/hash-length/deterministic-module-ids/files/file12.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/hash-length/deterministic-module-ids/files/file13.js
+++ b/test/configCases/hash-length/deterministic-module-ids/files/file13.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/hash-length/deterministic-module-ids/files/file14.js
+++ b/test/configCases/hash-length/deterministic-module-ids/files/file14.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/hash-length/deterministic-module-ids/files/file15.js
+++ b/test/configCases/hash-length/deterministic-module-ids/files/file15.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/hash-length/deterministic-module-ids/files/file2.js
+++ b/test/configCases/hash-length/deterministic-module-ids/files/file2.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/hash-length/deterministic-module-ids/files/file3.js
+++ b/test/configCases/hash-length/deterministic-module-ids/files/file3.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/hash-length/deterministic-module-ids/files/file4.js
+++ b/test/configCases/hash-length/deterministic-module-ids/files/file4.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/hash-length/deterministic-module-ids/files/file5.js
+++ b/test/configCases/hash-length/deterministic-module-ids/files/file5.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/hash-length/deterministic-module-ids/files/file6.js
+++ b/test/configCases/hash-length/deterministic-module-ids/files/file6.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/hash-length/deterministic-module-ids/files/file7.js
+++ b/test/configCases/hash-length/deterministic-module-ids/files/file7.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/hash-length/deterministic-module-ids/files/file8.js
+++ b/test/configCases/hash-length/deterministic-module-ids/files/file8.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/hash-length/deterministic-module-ids/files/file9.js
+++ b/test/configCases/hash-length/deterministic-module-ids/files/file9.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/hash-length/deterministic-module-ids/index.js
+++ b/test/configCases/hash-length/deterministic-module-ids/index.js
@@ -1,0 +1,8 @@
+it("should have unique ids", function () {
+	var ids = [];
+	for(var i = 1; i <= 15; i++) {
+		var id = require("./files/file" + i + ".js");
+		expect(ids.indexOf(id)).toBe(-1);
+		ids.push(id);
+	}
+});

--- a/test/configCases/hash-length/deterministic-module-ids/webpack.config.js
+++ b/test/configCases/hash-length/deterministic-module-ids/webpack.config.js
@@ -1,0 +1,28 @@
+var webpack = require("../../../../");
+module.exports = [
+	{
+		optimization: {
+			moduleIds: "deterministic"
+		}
+	},
+	{
+		optimization: {
+			moduleIds: false
+		},
+		plugins: [
+			new webpack.ids.DeterministicModuleIdsPlugin({
+				maxLength: 0
+			})
+		]
+	},
+	{
+		optimization: {
+			moduleIds: false
+		},
+		plugins: [
+			new webpack.ids.DeterministicModuleIdsPlugin({
+				maxLength: 100
+			})
+		]
+	}
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
`opimization.moduleIds: "deterministic"`

module names are hashed into small numeric values. This is useful for long term caching, but still results in small bundles compared to `"hashed"`. Length of the numeric value is chosen to fill a maximum of 80% of the id space. By default a minimum length of 3 digits is used. Use the `webpack.ids.DeterministicModuleIdsPlugin` (+ `optimization.moduleIds: false`) for more options.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
