### PR TITLE
Add a status badge for the azure pipelines CI build

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![deps][deps]][deps-url]
 [![tests][tests]][tests-url]
 [![builds][builds]][builds-url]
+[![builds2][builds2]][builds2-url]
 [![coverage][cover]][cover-url]
 [![licenses][licenses]][licenses-url]
 
@@ -751,6 +752,9 @@ src="https://static.monei.net/monei-logo.svg" height="30" alt="MONEI"></a>
 
 [builds-url]: https://ci.appveyor.com/project/sokra/webpack/branch/master
 [builds]: https://ci.appveyor.com/api/projects/status/github/webpack/webpack?svg=true
+
+[builds2]: https://dev.azure.com/webpack/webpack/_apis/build/status/webpack.webpack
+[builds2-url]: https://dev.azure.com/webpack/webpack/_build/latest?definitionId=3
 
 [licenses-url]: https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack%2Fwebpack?ref=badge_shield
 [licenses]: https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack%2Fwebpack.svg?type=shield


### PR DESCRIPTION
This proposes a status badge in the README.md for the Azure Pipelines CI build.