### PR TITLE
Uncaught exception from renderers

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -2254,24 +2254,28 @@ class Compilation extends Tapable {
 		for (let i = 0; i < chunks.length; i++) {
 			const chunk = chunks[i];
 			const chunkHash = createHash(hashFunction);
-			if (outputOptions.hashSalt) {
-				chunkHash.update(outputOptions.hashSalt);
+			try {
+				if (outputOptions.hashSalt) {
+					chunkHash.update(outputOptions.hashSalt);
+				}
+				chunk.updateHash(chunkHash);
+				const template = chunk.hasRuntime()
+					? this.mainTemplate
+					: this.chunkTemplate;
+				template.updateHashForChunk(
+					chunkHash,
+					chunk,
+					this.moduleTemplates.javascript,
+					this.dependencyTemplates
+				);
+				this.hooks.chunkHash.call(chunk, chunkHash);
+				chunk.hash = chunkHash.digest(hashDigest);
+				hash.update(chunk.hash);
+				chunk.renderedHash = chunk.hash.substr(0, hashDigestLength);
+				this.hooks.contentHash.call(chunk);
+			} catch (err) {
+				this.errors.push(new ChunkRenderError(chunk, "", err));
 			}
-			chunk.updateHash(chunkHash);
-			const template = chunk.hasRuntime()
-				? this.mainTemplate
-				: this.chunkTemplate;
-			template.updateHashForChunk(
-				chunkHash,
-				chunk,
-				this.moduleTemplates.javascript,
-				this.dependencyTemplates
-			);
-			this.hooks.chunkHash.call(chunk, chunkHash);
-			chunk.hash = chunkHash.digest(hashDigest);
-			hash.update(chunk.hash);
-			chunk.renderedHash = chunk.hash.substr(0, hashDigestLength);
-			this.hooks.contentHash.call(chunk);
 		}
 		this.fullHash = hash.digest(hashDigest);
 		this.hash = this.fullHash.substr(0, hashDigestLength);

--- a/test/configCases/errors/exception-in-chunk-renderer/errors.js
+++ b/test/configCases/errors/exception-in-chunk-renderer/errors.js
@@ -1,0 +1,4 @@
+module.exports = [
+	[/Test exception/],
+	[/Test exception/]
+];

--- a/test/configCases/errors/exception-in-chunk-renderer/index.js
+++ b/test/configCases/errors/exception-in-chunk-renderer/index.js
@@ -1,0 +1,3 @@
+it("should not crash when renderer throws exception", function(done) {
+	done();
+});

--- a/test/configCases/errors/exception-in-chunk-renderer/webpack.config.js
+++ b/test/configCases/errors/exception-in-chunk-renderer/webpack.config.js
@@ -1,0 +1,16 @@
+class ThrowsExceptionInRender {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("ThrowsException", compilation => {
+			compilation.mainTemplate.hooks.requireExtensions.tap(
+				"ThrowsException",
+				() => {
+					throw new Error("Test exception");
+				}
+			);
+		});
+	}
+}
+
+module.exports = {
+	plugins: [new ThrowsExceptionInRender()]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Prior to 4.19.0, exceptions thrown by plugins that hooked any of the bootstrap rendering events (e.g. `beforeStartup`, `requireEnsure`, etc.) were caught and the error message was added to `compilation.errors`.  This occurred because compilation.createChunkAssets() has a try/catch block that catches and processes exceptions thrown by the renderers.

Starting with 4.19.0, the bootstrap rendering code is now also called via compilation.createHash().  Any exceptions thrown by the rendering code from this call are not caught and the exceptions propagates up to node and the application is terminated.

This pr adds exception handling code to compilation.createHash() that is similar to what compilation.createChunkAssets() does so that  exceptions thrown by bootstrap rendering code will be handled in a similar way.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Improves exception handling

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix
**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
no documentation needed
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
