### PR TITLE
Add "amd-require" libraryTarget, resulting in a require() wrapper

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1112,6 +1112,7 @@ export interface OutputOptions {
 		| "commonjs2"
 		| "commonjs-module"
 		| "amd"
+		| "amd-require"
 		| "umd"
 		| "umd2"
 		| "jsonp";

--- a/declarations/plugins/DllReferencePlugin.d.ts
+++ b/declarations/plugins/DllReferencePlugin.d.ts
@@ -78,6 +78,7 @@ export type DllReferencePluginOptionsSourceType =
 	| "commonjs2"
 	| "commonjs-module"
 	| "amd"
+	| "amd-require"
 	| "umd"
 	| "umd2"
 	| "jsonp";

--- a/lib/AmdMainTemplatePlugin.js
+++ b/lib/AmdMainTemplatePlugin.js
@@ -10,13 +10,20 @@ const Template = require("./Template");
 
 /** @typedef {import("./Compilation")} Compilation */
 
+/**
+ * @typedef {Object} AmdMainTemplatePluginOptions
+ * @property {boolean=} requireAsWrapper
+ */
+
 class AmdMainTemplatePlugin {
 	/**
 	 * @param {string=} name the library name
+	 * @param {AmdMainTemplatePluginOptions} options the plugin options
 	 */
-	constructor(name) {
+	constructor(name, options) {
 		/** @type {string=} */
 		this.name = name;
+		this.requireAsWrapper = options.requireAsWrapper;
 	}
 
 	/**
@@ -39,7 +46,13 @@ class AmdMainTemplatePlugin {
 				)
 				.join(", ");
 
-			if (this.name) {
+			if (this.requireAsWrapper) {
+				return new ConcatSource(
+					`require(${externalsDepsArray}, function(${externalsArguments}) { return `,
+					source,
+					"});"
+				);
+			} else if (this.name) {
 				const name = mainTemplate.getAssetPath(this.name, {
 					hash,
 					chunk

--- a/lib/AmdMainTemplatePlugin.js
+++ b/lib/AmdMainTemplatePlugin.js
@@ -12,18 +12,22 @@ const Template = require("./Template");
 
 /**
  * @typedef {Object} AmdMainTemplatePluginOptions
+ * @param {string=} name the library name
  * @property {boolean=} requireAsWrapper
  */
 
 class AmdMainTemplatePlugin {
 	/**
-	 * @param {string=} name the library name
 	 * @param {AmdMainTemplatePluginOptions} options the plugin options
 	 */
-	constructor(name, options) {
-		/** @type {string=} */
-		this.name = name;
-		this.requireAsWrapper = options.requireAsWrapper;
+	constructor(options) {
+		if (!options || typeof options === "string") {
+			this.name = options;
+			this.requireAsWrapper = false;
+		} else {
+			this.name = options.name;
+			this.requireAsWrapper = options.requireAsWrapper;
+		}
 	}
 
 	/**

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -134,6 +134,7 @@ class ExternalModule extends Module {
 			case "commonjs2":
 				return this.getSourceForCommonJsExternal(request);
 			case "amd":
+			case "amd-require":
 			case "umd":
 			case "umd2":
 				return this.getSourceForAmdOrUmdExternal(

--- a/lib/LibraryTemplatePlugin.js
+++ b/lib/LibraryTemplatePlugin.js
@@ -141,16 +141,13 @@ class LibraryTemplatePlugin {
 				case "amd":
 				case "amd-require": {
 					const AmdMainTemplatePlugin = require("./AmdMainTemplatePlugin");
-					const options = {
-						requireAsWrapper: this.target === "amd-require"
-					};
-					if (this.name) {
-						if (typeof this.name !== "string")
-							throw new Error("library name must be a string for amd target");
-						new AmdMainTemplatePlugin(this.name, options).apply(compilation);
-					} else {
-						new AmdMainTemplatePlugin(null, options).apply(compilation);
+					if (this.name && typeof this.name !== "string") {
+						throw new Error("library name must be a string for amd target");
 					}
+					new AmdMainTemplatePlugin({
+						name: this.name,
+						requireAsWrapper: this.target === "amd-require"
+					}).apply(compilation);
 					break;
 				}
 				case "umd":

--- a/lib/LibraryTemplatePlugin.js
+++ b/lib/LibraryTemplatePlugin.js
@@ -138,14 +138,18 @@ class LibraryTemplatePlugin {
 						compilation
 					);
 					break;
-				case "amd": {
+				case "amd":
+				case "amd-require": {
 					const AmdMainTemplatePlugin = require("./AmdMainTemplatePlugin");
+					const options = {
+						requireAsWrapper: this.target === "amd-require"
+					};
 					if (this.name) {
 						if (typeof this.name !== "string")
 							throw new Error("library name must be a string for amd target");
-						new AmdMainTemplatePlugin(this.name).apply(compilation);
+						new AmdMainTemplatePlugin(this.name, options).apply(compilation);
 					} else {
-						new AmdMainTemplatePlugin().apply(compilation);
+						new AmdMainTemplatePlugin(null, options).apply(compilation);
 					}
 					break;
 				}

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -979,6 +979,7 @@
             "commonjs2",
             "commonjs-module",
             "amd",
+            "amd-require",
             "umd",
             "umd2",
             "jsonp"

--- a/schemas/plugins/DllReferencePlugin.json
+++ b/schemas/plugins/DllReferencePlugin.json
@@ -88,6 +88,7 @@
         "commonjs2",
         "commonjs-module",
         "amd",
+        "amd-require",
         "umd",
         "umd2",
         "jsonp"

--- a/test/configCases/target/amd-require/index.js
+++ b/test/configCases/target/amd-require/index.js
@@ -1,0 +1,10 @@
+it("should run", function() {
+
+});
+
+it("should name require", function() {
+	var fs = nodeRequire("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+
+	expect(source).toMatch(/require\(\[[^\]]*\], function\(/);
+});

--- a/test/configCases/target/amd-require/webpack.config.js
+++ b/test/configCases/target/amd-require/webpack.config.js
@@ -1,0 +1,17 @@
+const webpack = require("../../../../");
+module.exports = {
+	output: {
+		libraryTarget: "amd-require"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	plugins: [
+		new webpack.BannerPlugin({
+			raw: true,
+			banner:
+				"var nodeRequire = require;\nvar require = function(deps, fn) { fn(); }\n"
+		})
+	]
+};


### PR DESCRIPTION
This is a partial fix for #8079.

**What kind of change does this PR introduce?**

This PR adds `"amd-require"` as a new library target. The target is otherwise the same as `"amd"`, except that it uses `require()` as a wrapper instead of `define()`. The specification for this API is [here](https://github.com/amdjs/amdjs-api/blob/master/require.md).

Specifically, we're using the global `require(dependencies, factory)` form, which will resolve the dependencies, and then immediately call the factory function with them as parameters. The library name is ignored in this case.

The rationale for including this target is that it enables compiling an immediately executed module that has AMD dependencies, which has not been previously possible with Webpack. As is, AMD dependencies are only resolved with the `"amd"` library target, which results in a `define()` wrapper. To execute the JavaScript of such output, a subsequent `require()` call is needed. If the intent is not to produce a library, this becomes clumsy and potentially difficult (see jantimon/html-webpack-plugin#1052).

**Did you add tests for your changes?**

Yes.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

The new target should be documented under the [Module Definition Systems](https://webpack.js.org/configuration/output/#module-definition-systems) section of the Output configuration page.