### PR TITLE
Fix the "should name define" test in configCases/target/amd-unnamed

### DIFF
--- a/test/configCases/target/amd-unnamed/index.js
+++ b/test/configCases/target/amd-unnamed/index.js
@@ -6,5 +6,5 @@ it("should name define", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename, "utf-8");
 
-	expect(source).toMatch("define(function(");
+	expect(source).toMatch(/define\(\[[^\]]*\], function\(/);
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

While working on #8093, I noticed that the "should name define" test for unnamed AMD library target output was tautological, in that the test was matching a string against itself. Changing the test to use a regexp makes it actually test what it tries to test.

**Did you add tests for your changes?**

Yes?

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

Nothing.