### PR TITLE
refactor(TemplatedPathPlugin): split placeholder context (`chunk|module`)

### DIFF
--- a/declarations/plugins/BannerPlugin.d.ts
+++ b/declarations/plugins/BannerPlugin.d.ts
@@ -12,13 +12,7 @@ export type BannerPluginArgument =
  * The banner as function, it will be wrapped in a comment
  */
 export type BannerFunction = (
-	data: {
-		hash: string;
-		chunk: import("../../lib/Chunk");
-		filename: string;
-		basename: string;
-		query: string;
-	}
+	data: {hash: string; chunk: import("../../lib/Chunk"); filename: string}
 ) => string;
 export type Rules = Rule[] | Rule;
 export type Rule = RegExp | string;

--- a/lib/BannerPlugin.js
+++ b/lib/BannerPlugin.js
@@ -79,31 +79,13 @@ class BannerPlugin {
 							continue;
 						}
 
-						let basename;
-						let query = "";
-						let filename = file;
 						const hash = compilation.hash;
-						const querySplit = filename.indexOf("?");
-
-						if (querySplit >= 0) {
-							query = filename.substr(querySplit);
-							filename = filename.substr(0, querySplit);
-						}
-
-						const lastSlashIndex = filename.lastIndexOf("/");
-
-						if (lastSlashIndex === -1) {
-							basename = filename;
-						} else {
-							basename = filename.substr(lastSlashIndex + 1);
-						}
+						let filename = file;
 
 						const data = {
 							hash,
 							chunk,
-							filename,
-							basename,
-							query
+							filename
 						};
 
 						const comment = compilation.getPath(banner(data), data);

--- a/lib/BannerPlugin.js
+++ b/lib/BannerPlugin.js
@@ -79,16 +79,14 @@ class BannerPlugin {
 							continue;
 						}
 
-						const hash = compilation.hash;
 						let filename = file;
 
 						const data = {
-							hash,
 							chunk,
 							filename
 						};
 
-						const comment = compilation.getPath(banner(data), data);
+						const comment = compilation.getPath(banner, data);
 
 						compilation.assets[file] = new ConcatSource(
 							comment,

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -2214,7 +2214,14 @@ class Compilation {
 	 * @returns {string} interpolated path
 	 */
 	getPath(filename, data) {
-		data.hash = data.hash || this.hash;
+		if (!data.hash) {
+			data = Object.assign(
+				{
+					hash: this.hash
+				},
+				data
+			);
+		}
 		return this.mainTemplate.getAssetPath(filename, data);
 	}
 

--- a/lib/JavascriptModulesPlugin.js
+++ b/lib/JavascriptModulesPlugin.js
@@ -122,7 +122,6 @@ class JavascriptModulesPlugin {
 							filenameTemplate,
 							pathOptions: {
 								chunk,
-								filename: { ext: ".js" },
 								contentHashType: "javascript"
 							},
 							identifier: `chunk${chunk.id}`,
@@ -177,7 +176,6 @@ class JavascriptModulesPlugin {
 							filenameTemplate,
 							pathOptions: {
 								chunk,
-								filename: { ext: ".js" },
 								contentHashType: "javascript"
 							},
 							identifier: `chunk${chunk.id}`,

--- a/lib/JavascriptModulesPlugin.js
+++ b/lib/JavascriptModulesPlugin.js
@@ -121,8 +121,9 @@ class JavascriptModulesPlugin {
 								}),
 							filenameTemplate,
 							pathOptions: {
-								contentHashType: "javascript",
-								chunk
+								chunk,
+								filename: { ext: ".js" },
+								contentHashType: "javascript"
 							},
 							identifier: `chunk${chunk.id}`,
 							hash: chunk.hash
@@ -176,6 +177,7 @@ class JavascriptModulesPlugin {
 							filenameTemplate,
 							pathOptions: {
 								chunk,
+								filename: { ext: ".js" },
 								contentHashType: "javascript"
 							},
 							identifier: `chunk${chunk.id}`,

--- a/lib/LibManifestPlugin.js
+++ b/lib/LibManifestPlugin.js
@@ -35,13 +35,11 @@ class LibManifestPlugin {
 						}
 						const chunkGraph = compilation.chunkGraph;
 						const targetPath = compilation.getPath(this.options.path, {
-							hash: compilation.hash,
 							chunk
 						});
 						const name =
 							this.options.name &&
 							compilation.getPath(this.options.name, {
-								hash: compilation.hash,
 								chunk
 							});
 						const manifest = {

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -252,19 +252,11 @@ class SourceMapDevToolPlugin {
 						const sourceMapString = JSON.stringify(sourceMap);
 						if (sourceMapFilename) {
 							let filename = file;
-							let query = "";
-							const idx = filename.indexOf("?");
-							if (idx >= 0) {
-								query = filename.substr(idx);
-								filename = filename.substr(0, idx);
-							}
 							let sourceMapFile = compilation.getPath(sourceMapFilename, {
 								chunk,
 								filename: options.fileContext
 									? path.relative(options.fileContext, filename)
 									: filename,
-								query,
-								basename: path.basename(filename),
 								contentHash: createHash("md4")
 									.update(sourceMapString)
 									.digest("hex")

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -5,59 +5,74 @@
 
 "use strict";
 
+const { basename, extname } = require("path");
+
 const Module = require("./Module");
 
 /** @typedef {import("./Compilation").PathData} PathData */
 
-const REGEXP_HASH = /\[hash(?::(\d+))?\]/gi,
-	REGEXP_CHUNKHASH = /\[chunkhash(?::(\d+))?\]/gi,
-	REGEXP_MODULEHASH = /\[modulehash(?::(\d+))?\]/gi,
-	REGEXP_CONTENTHASH = /\[contenthash(?::(\d+))?\]/gi,
-	REGEXP_NAME = /\[name\]/gi,
-	REGEXP_ID = /\[id\]/gi,
-	REGEXP_MODULEID = /\[moduleid\]/gi,
-	REGEXP_FILE = /\[file\]/gi,
-	REGEXP_QUERY = /\[query\]/gi,
-	REGEXP_FILEBASE = /\[filebase\]/gi;
+const REGEXP_ID = /\[id\]/gi;
+const REGEXP_EXT = /\[ext\]/gi;
+const REGEXP_NAME = /\[name\]/gi;
+const REGEXP_HASH = /\[hash(?::(\d+))?\]/gi;
+const REGEXP_QUERY = /\[query\]/gi;
+const REGEXP_FILE = /\[file\]/gi;
+const REGEXP_FILEBASE = /\[filebase\]/gi;
+// Chunks
+const REGEXP_CHUNKHASH = /\[chunkhash(?::(\d+))?\]/gi;
+const REGEXP_CONTENTHASH = /\[contenthash(?::(\d+))?\]/gi;
+// Modules
+const REGEXP_MODULEID = /\[moduleid\]/gi;
+const REGEXP_MODULEHASH = /\[modulehash(?::(\d+))?\]/gi;
 
 const prepareId = id => {
 	if (typeof id !== "string") return id;
+
 	if (/^"\s\+*.*\+\s*"$/.test(id)) {
 		const match = /^"\s\+*\s*(.*)\s*\+\s*"$/.exec(id);
+
 		return `" + (${
 			match[1]
 		} + "").replace(/(^[.-]|[^a-zA-Z0-9_-])+/g, "_") + "`;
 	}
+
 	return id.replace(/(^[.-]|[^a-zA-Z0-9_-])+/g, "_");
 };
 
-const withHashLength = (replacer, handlerFn) => {
+const hashLength = (replacer, handler) => {
 	const fn = (match, hashLength, ...args) => {
 		const length = hashLength && parseInt(hashLength, 10);
-		if (length && handlerFn) {
-			return handlerFn(length);
+
+		if (length && handler) {
+			return handler(length);
 		}
+
 		const hash = replacer(match, hashLength, ...args);
+
 		return length ? hash.slice(0, length) : hash;
 	};
+
 	return fn;
 };
 
-const getReplacer = (value, allowEmpty) => {
+const replacer = (value, allowEmpty) => {
 	const fn = (match, ...args) => {
 		// last argument in replacer is the entire input string
 		const input = args[args.length - 1];
+
 		if (value === null || value === undefined) {
 			if (!allowEmpty) {
 				throw new Error(
 					`Path variable ${match} not implemented in this context: ${input}`
 				);
 			}
+
 			return "";
 		} else {
 			return `${value}`;
 		}
 	};
+
 	return fn;
 };
 
@@ -68,77 +83,150 @@ const getReplacer = (value, allowEmpty) => {
  */
 const replacePathVariables = (path, data) => {
 	const chunkGraph = data.chunkGraph;
-	const chunk = data.chunk;
-	const chunkId = chunk && chunk.id;
-	const chunkName = chunk && (chunk.name || chunk.id);
-	const chunkHash = chunk && (chunk.renderedHash || chunk.hash);
-	const chunkHashWithLength =
-		chunk && "hashWithLength" in chunk && chunk.hashWithLength;
-	const contentHashType = data.contentHashType;
-	const contentHash =
-		data.contentHash ||
-		(chunk &&
-			contentHashType &&
-			chunk.contentHash &&
-			chunk.contentHash[contentHashType]);
-	const contentHashWithLength =
-		data.contentHashWithLength ||
-		(chunk && "contentHashWithLength" in chunk
-			? chunk.contentHashWithLength[contentHashType]
-			: undefined);
-	const module = data.module;
-	const moduleId =
-		module &&
-		(module instanceof Module ? chunkGraph.getModuleId(module) : module.id);
-	const moduleHash =
-		module &&
-		(module instanceof Module
-			? chunkGraph.getRenderedModuleHash(module)
-			: module.renderedHash || module.hash);
-	const moduleHashWithLength =
-		module && "hashWithLength" in module && module.hashWithLength;
 
-	if (typeof path === "function") {
-		path = path(data);
+	let file = {};
+
+	if (data.filename) {
+		if (typeof data.filename === "string") {
+			const idx = data.filename.indexOf("?");
+
+			if (idx >= 0) {
+				file.path = data.filename.substr(0, idx);
+				file.query = data.filename.substr(idx);
+			} else {
+				file.path = data.filename;
+				file.query = "";
+			}
+
+			file.ext = extname(file.path);
+			file.base = basename(file.path);
+			file.name = file.base.replace(file.ext, "");
+		}
+
+		if (typeof data.filename === "object") {
+			file = data.filename;
+		}
 	}
 
-	return (
-		path
-			.replace(
-				REGEXP_HASH,
-				withHashLength(getReplacer(data.hash), data.hashWithLength)
-			)
-			.replace(
-				REGEXP_CHUNKHASH,
-				withHashLength(getReplacer(chunkHash), chunkHashWithLength)
-			)
-			.replace(
-				REGEXP_CONTENTHASH,
-				withHashLength(getReplacer(contentHash), contentHashWithLength)
-			)
-			.replace(
-				REGEXP_MODULEHASH,
-				withHashLength(getReplacer(moduleHash), moduleHashWithLength)
-			)
-			.replace(REGEXP_ID, getReplacer(chunkId))
-			.replace(REGEXP_MODULEID, getReplacer(prepareId(moduleId)))
-			.replace(REGEXP_NAME, getReplacer(chunkName))
-			.replace(REGEXP_FILE, getReplacer(data.filename))
-			.replace(REGEXP_FILEBASE, getReplacer(data.basename))
-			// query is optional, it's OK if it's in a path but there's nothing to replace it with
-			.replace(REGEXP_QUERY, getReplacer(data.query, true))
-	);
+	// Chunk Context
+	//
+	// Placeholders
+	//
+	// [id] - chunk.id (0.js)
+	// [ext] - file.ext (app.{js, css, ...})
+	// [name] - chunk.name (app.js)
+	// [hash] - data.hash (53276435.js)
+	// [chunkhash] - chunk.hash (7823t4t4.js)
+	// [contenthash] - chunk.contentHash[type] (3256urzg.js)
+	// [query] - data.query (app.js?v=1.0.0)
+	// [file] - file.path (/context/file.map.js)
+	// [filebase] - file.base (file.map.js)
+	if (data.chunk) {
+		const chunk = data.chunk;
+
+		const id = chunk.id;
+		const name = chunk.name || chunk.id;
+
+		const chunkHash = chunk.renderedHash || chunk.hash;
+		// @ts-ignore
+		const chunkHashWithLength = chunk.hashWithLength || undefined;
+
+		const contentHashType = data.contentHashType;
+		const contentHash =
+			data.contentHash ||
+			(contentHashType &&
+				chunk.contentHash &&
+				chunk.contentHash[contentHashType]);
+		const contentHashWithLength =
+			data.contentHashWithLength ||
+			// @ts-ignore
+			(chunk.contentHashWithLength &&
+				// @ts-ignore
+				chunk.contentHashWithLength[contentHashType]) ||
+			undefined;
+
+		if (typeof path === "function") {
+			path = path(data);
+		}
+
+		return (
+			path
+				.replace(REGEXP_ID, replacer(id))
+				.replace(REGEXP_EXT, replacer(file.ext))
+				.replace(REGEXP_NAME, replacer(name))
+				.replace(
+					REGEXP_HASH,
+					hashLength(replacer(data.hash), data.hashWithLength)
+				)
+				.replace(
+					REGEXP_CHUNKHASH,
+					hashLength(replacer(chunkHash), chunkHashWithLength)
+				)
+				.replace(
+					REGEXP_CONTENTHASH,
+					hashLength(replacer(contentHash), contentHashWithLength)
+				)
+				// query is optional, it's OK if it's in a path
+				// but there's nothing to replace it with
+				.replace(REGEXP_QUERY, replacer(file.query, true))
+				.replace(REGEXP_FILE, replacer(file.path))
+				.replace(REGEXP_FILEBASE, replacer(file.base))
+		);
+	}
+
+	// Module Context
+	//
+	// Placeholders
+	//
+	// [id] - module.id (2.png)
+	// [ext] - file.ext (file.{png, svg, ...})
+	// [hash] - module.hash (6237543873.png)
+	// [name] - file.name (file)
+	// [file] - file.base (file.png)
+	//
+	// Legacy Placeholders
+	//
+	// [moduleid] - module.id (2.png)
+	// [modulehash] - module.hash (6237543873.png)
+	if (data.module) {
+		const module = data.module;
+
+		const id =
+			module instanceof Module ? chunkGraph.getModuleId(module) : module.id;
+
+		const hash =
+			module instanceof Module
+				? chunkGraph.getRenderedModuleHash(module)
+				: module.renderedHash || module.hash;
+		// @ts-ignore
+		const hashWithLength = module.hashWithLength || undefined;
+
+		if (typeof path === "function") {
+			path = path(data);
+		}
+
+		return (
+			path
+				.replace(REGEXP_ID, replacer(prepareId(id)))
+				.replace(REGEXP_EXT, replacer(file.ext))
+				.replace(REGEXP_NAME, replacer(file.name))
+				.replace(REGEXP_FILE, replacer(file.base))
+				.replace(REGEXP_HASH, hashLength(replacer(hash), hashWithLength))
+				// Legacy
+				.replace(REGEXP_MODULEID, replacer(prepareId(id)))
+				.replace(REGEXP_MODULEHASH, hashLength(replacer(hash), hashWithLength))
+		);
+	}
 };
+
+const plugin = "TemplatedPathPlugin";
 
 class TemplatedPathPlugin {
 	apply(compiler) {
-		compiler.hooks.compilation.tap("TemplatedPathPlugin", compilation => {
+		compiler.hooks.compilation.tap(plugin, compilation => {
 			const mainTemplate = compilation.mainTemplate;
 
-			mainTemplate.hooks.assetPath.tap(
-				"TemplatedPathPlugin",
-				replacePathVariables
-			);
+			mainTemplate.hooks.assetPath.tap(plugin, replacePathVariables);
 		});
 	}
 }

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -11,26 +11,7 @@ const Module = require("./Module");
 
 /** @typedef {import("./Compilation").PathData} PathData */
 
-// Compilation
-const REGEXP_FULLHASH = /\[fullhash(?::(\d+))?\]/gi;
-const REGEXP_HASH = /\[hash(?::(\d+))?\]/gi;
-// Chunks and Modules
-const REGEXP_ID = /\[id\]/gi;
-// Chunks and Filenames
-const REGEXP_NAME = /\[name\]/gi;
-// Filename
-const REGEXP_FILE = /\[file\]/gi;
-const REGEXP_QUERY = /\[query\]/gi;
-const REGEXP_PATH = /\[path\]/gi;
-const REGEXP_BASE = /\[base\]/gi;
-const REGEXP_FILEBASE = /\[filebase\]/gi;
-const REGEXP_EXT = /\[ext\]/gi;
-// Chunks
-const REGEXP_CHUNKHASH = /\[chunkhash(?::(\d+))?\]/gi;
-const REGEXP_CONTENTHASH = /\[contenthash(?::(\d+))?\]/gi;
-// Modules
-const REGEXP_MODULEID = /\[moduleid\]/gi;
-const REGEXP_MODULEHASH = /\[modulehash(?::(\d+))?\]/gi;
+const REGEXP = /\[([a-z]+)(?::(\d+))?\]/gi;
 
 const prepareId = id => {
 	if (typeof id !== "string") return id;
@@ -103,6 +84,7 @@ const deprecated = (fn, message) => {
 const replacePathVariables = (path, data) => {
 	const chunkGraph = data.chunkGraph;
 
+	/** @type {Map<string, Function>} */
 	const replacements = new Map();
 
 	// Filename context
@@ -135,15 +117,15 @@ const replacePathVariables = (path, data) => {
 			const name = base.slice(0, base.length - ext.length);
 			const path = file.slice(0, file.length - base.length);
 
-			replacements.set(REGEXP_FILE, replacer(file));
-			replacements.set(REGEXP_QUERY, replacer(query, true));
-			replacements.set(REGEXP_PATH, replacer(path));
-			replacements.set(REGEXP_BASE, replacer(base));
-			replacements.set(REGEXP_NAME, replacer(name));
-			replacements.set(REGEXP_EXT, replacer(ext, true));
+			replacements.set("file", replacer(file));
+			replacements.set("query", replacer(query, true));
+			replacements.set("path", replacer(path));
+			replacements.set("base", replacer(base));
+			replacements.set("name", replacer(name));
+			replacements.set("ext", replacer(ext, true));
 			// Legacy
 			replacements.set(
-				REGEXP_FILEBASE,
+				"filebase",
 				deprecated(replacer(base), "[filebase] is now [base]")
 			);
 		}
@@ -157,11 +139,11 @@ const replacePathVariables = (path, data) => {
 	if (data.hash) {
 		const hashReplacer = hashLength(replacer(data.hash), data.hashWithLength);
 
-		replacements.set(REGEXP_FULLHASH, hashReplacer);
+		replacements.set("fullhash", hashReplacer);
 
 		// Legacy
 		replacements.set(
-			REGEXP_HASH,
+			"hash",
 			deprecated(
 				hashReplacer,
 				"[hash] is now [fullhash] (also consider using [chunkhash] or [contenthash], see documentation for details)"
@@ -202,10 +184,10 @@ const replacePathVariables = (path, data) => {
 					: undefined)
 		);
 
-		replacements.set(REGEXP_ID, idReplacer);
-		replacements.set(REGEXP_NAME, nameReplacer);
-		replacements.set(REGEXP_CHUNKHASH, chunkhashReplacer);
-		replacements.set(REGEXP_CONTENTHASH, contenthashReplacer);
+		replacements.set("id", idReplacer);
+		replacements.set("name", nameReplacer);
+		replacements.set("chunkhash", chunkhashReplacer);
+		replacements.set("contenthash", contenthashReplacer);
 	}
 
 	// Module Context
@@ -236,15 +218,15 @@ const replacePathVariables = (path, data) => {
 			"hashWithLength" in module ? module.hashWithLength : undefined
 		);
 
-		replacements.set(REGEXP_ID, idReplacer);
-		replacements.set(REGEXP_HASH, hashReplacer);
+		replacements.set("id", idReplacer);
+		replacements.set("hash", hashReplacer);
 		// Legacy
 		replacements.set(
-			REGEXP_MODULEID,
+			"moduleid",
 			deprecated(idReplacer, "[moduleid] is now [id]")
 		);
 		replacements.set(
-			REGEXP_MODULEHASH,
+			"modulehash",
 			deprecated(hashReplacer, "[modulehash] is now [hash]")
 		);
 	}
@@ -253,9 +235,13 @@ const replacePathVariables = (path, data) => {
 		path = path(data);
 	}
 
-	for (const [regExp, replacer] of replacements) {
-		path = path.replace(regExp, replacer);
-	}
+	path = path.replace(REGEXP, (match, kind, ...args) => {
+		const replacer = replacements.get(kind);
+		if (replacer !== undefined) {
+			return replacer(match, ...args);
+		}
+		return match;
+	});
 
 	return path;
 };

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -86,6 +86,8 @@ const replacePathVariables = (path, data) => {
 
 	let file = {};
 
+	const replacements = new Map();
+
 	if (data.filename) {
 		if (typeof data.filename === "string") {
 			const idx = data.filename.indexOf("?");
@@ -141,33 +143,26 @@ const replacePathVariables = (path, data) => {
 				chunk.contentHashWithLength[contentHashType]) ||
 			undefined;
 
-		if (typeof path === "function") {
-			path = path(data);
-		}
-
-		return (
-			path
-				.replace(REGEXP_ID, replacer(id))
-				.replace(REGEXP_EXT, replacer(file.ext))
-				.replace(REGEXP_NAME, replacer(name))
-				.replace(
-					REGEXP_HASH,
-					hashLength(replacer(data.hash), data.hashWithLength)
-				)
-				.replace(
-					REGEXP_CHUNKHASH,
-					hashLength(replacer(chunkHash), chunkHashWithLength)
-				)
-				.replace(
-					REGEXP_CONTENTHASH,
-					hashLength(replacer(contentHash), contentHashWithLength)
-				)
-				// query is optional, it's OK if it's in a path
-				// but there's nothing to replace it with
-				.replace(REGEXP_QUERY, replacer(file.query, true))
-				.replace(REGEXP_FILE, replacer(file.path))
-				.replace(REGEXP_FILEBASE, replacer(file.base))
+		replacements.set(REGEXP_ID, replacer(id));
+		replacements.set(REGEXP_EXT, replacer(file.ext));
+		replacements.set(REGEXP_NAME, replacer(name));
+		replacements.set(
+			REGEXP_HASH,
+			hashLength(replacer(data.hash), data.hashWithLength)
 		);
+		replacements.set(
+			REGEXP_CHUNKHASH,
+			hashLength(replacer(chunkHash), chunkHashWithLength)
+		);
+		replacements.set(
+			REGEXP_CONTENTHASH,
+			hashLength(replacer(contentHash), contentHashWithLength)
+		);
+		// query is optional, it's OK if it's in a path
+		// but there's nothing to replace it with
+		replacements.set(REGEXP_QUERY, replacer(file.query, true));
+		replacements.set(REGEXP_FILE, replacer(file.path));
+		replacements.set(REGEXP_FILEBASE, replacer(file.base));
 	}
 
 	// Module Context
@@ -197,22 +192,28 @@ const replacePathVariables = (path, data) => {
 		// @ts-ignore
 		const hashWithLength = module.hashWithLength || undefined;
 
-		if (typeof path === "function") {
-			path = path(data);
-		}
-
-		return (
-			path
-				.replace(REGEXP_ID, replacer(prepareId(id)))
-				.replace(REGEXP_EXT, replacer(file.ext))
-				.replace(REGEXP_NAME, replacer(file.name))
-				.replace(REGEXP_FILE, replacer(file.base))
-				.replace(REGEXP_HASH, hashLength(replacer(hash), hashWithLength))
-				// Legacy
-				.replace(REGEXP_MODULEID, replacer(prepareId(id)))
-				.replace(REGEXP_MODULEHASH, hashLength(replacer(hash), hashWithLength))
+		replacements.set(REGEXP_ID, replacer(prepareId(id)));
+		replacements.set(REGEXP_EXT, replacer(file.ext));
+		replacements.set(REGEXP_NAME, replacer(file.name));
+		replacements.set(REGEXP_FILE, replacer(file.base));
+		replacements.set(REGEXP_HASH, hashLength(replacer(hash), hashWithLength));
+		// Legacy
+		replacements.set(REGEXP_MODULEID, replacer(prepareId(id)));
+		replacements.set(
+			REGEXP_MODULEHASH,
+			hashLength(replacer(hash), hashWithLength)
 		);
 	}
+
+	if (typeof path === "function") {
+		path = path(data);
+	}
+
+	for (const [regExp, replacer] of replacements) {
+		path = path.replace(regExp, replacer);
+	}
+
+	return path;
 };
 
 const plugin = "TemplatedPathPlugin";

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -102,10 +102,6 @@ const replacePathVariables = (path, data) => {
 			file.base = basename(file.path);
 			file.name = file.base.replace(file.ext, "");
 		}
-
-		if (typeof data.filename === "object") {
-			file = data.filename;
-		}
 	}
 
 	// Chunk Context

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -6,18 +6,25 @@
 "use strict";
 
 const { basename, extname } = require("path");
-
+const util = require("util");
 const Module = require("./Module");
 
 /** @typedef {import("./Compilation").PathData} PathData */
 
-const REGEXP_ID = /\[id\]/gi;
-const REGEXP_EXT = /\[ext\]/gi;
-const REGEXP_NAME = /\[name\]/gi;
+// Compilation
+const REGEXP_FULLHASH = /\[fullhash(?::(\d+))?\]/gi;
 const REGEXP_HASH = /\[hash(?::(\d+))?\]/gi;
-const REGEXP_QUERY = /\[query\]/gi;
+// Chunks and Modules
+const REGEXP_ID = /\[id\]/gi;
+// Chunks and Filenames
+const REGEXP_NAME = /\[name\]/gi;
+// Filename
 const REGEXP_FILE = /\[file\]/gi;
+const REGEXP_QUERY = /\[query\]/gi;
+const REGEXP_PATH = /\[path\]/gi;
+const REGEXP_BASE = /\[base\]/gi;
 const REGEXP_FILEBASE = /\[filebase\]/gi;
+const REGEXP_EXT = /\[ext\]/gi;
 // Chunks
 const REGEXP_CHUNKHASH = /\[chunkhash(?::(\d+))?\]/gi;
 const REGEXP_CONTENTHASH = /\[contenthash(?::(\d+))?\]/gi;
@@ -57,11 +64,10 @@ const hashLength = (replacer, handler) => {
 
 const replacer = (value, allowEmpty) => {
 	const fn = (match, ...args) => {
-		// last argument in replacer is the entire input string
-		const input = args[args.length - 1];
-
 		if (value === null || value === undefined) {
 			if (!allowEmpty) {
+				// last argument in replacer is the entire input string
+				const input = args[args.length - 1];
 				throw new Error(
 					`Path variable ${match} not implemented in this context: ${input}`
 				);
@@ -76,6 +82,19 @@ const replacer = (value, allowEmpty) => {
 	return fn;
 };
 
+const deprecationCache = new Map();
+const deprecated = (fn, message) => {
+	let d = deprecationCache.get(message);
+	if (d === undefined) {
+		d = util.deprecate(() => {}, message);
+		deprecationCache.set(message, d);
+	}
+	return (...args) => {
+		d();
+		return fn(...args);
+	};
+};
+
 /**
  * @param {string | function(PathData): string} path the raw path
  * @param {PathData} data context data
@@ -84,26 +103,70 @@ const replacer = (value, allowEmpty) => {
 const replacePathVariables = (path, data) => {
 	const chunkGraph = data.chunkGraph;
 
-	let file = {};
-
 	const replacements = new Map();
 
+	// Filename context
+	//
+	// Placeholders
+	//
+	// for /some/path/file.js?query:
+	// [file] - /some/path/file.js
+	// [query] - ?query
+	// [base] - file.js
+	// [path] - /some/path/
+	// [name] - file
+	// [ext] - .js
 	if (data.filename) {
 		if (typeof data.filename === "string") {
 			const idx = data.filename.indexOf("?");
 
+			let file, query;
+
 			if (idx >= 0) {
-				file.path = data.filename.substr(0, idx);
-				file.query = data.filename.substr(idx);
+				file = data.filename.substr(0, idx);
+				query = data.filename.substr(idx);
 			} else {
-				file.path = data.filename;
-				file.query = "";
+				file = data.filename;
+				query = "";
 			}
 
-			file.ext = extname(file.path);
-			file.base = basename(file.path);
-			file.name = file.base.replace(file.ext, "");
+			const ext = extname(file);
+			const base = basename(file);
+			const name = base.slice(0, base.length - ext.length);
+			const path = file.slice(0, file.length - base.length);
+
+			replacements.set(REGEXP_FILE, replacer(file));
+			replacements.set(REGEXP_QUERY, replacer(query, true));
+			replacements.set(REGEXP_PATH, replacer(path));
+			replacements.set(REGEXP_BASE, replacer(base));
+			replacements.set(REGEXP_NAME, replacer(name));
+			replacements.set(REGEXP_EXT, replacer(ext, true));
+			// Legacy
+			replacements.set(
+				REGEXP_FILEBASE,
+				deprecated(replacer(base), "[filebase] is now [base]")
+			);
 		}
+	}
+
+	// Compilation context
+	//
+	// Placeholders
+	//
+	// [hash] - data.hash (3a4b5c6e7f)
+	if (data.hash) {
+		const hashReplacer = hashLength(replacer(data.hash), data.hashWithLength);
+
+		replacements.set(REGEXP_FULLHASH, hashReplacer);
+
+		// Legacy
+		replacements.set(
+			REGEXP_HASH,
+			deprecated(
+				hashReplacer,
+				"[hash] is now [fullhash] (also consider using [chunkhash] or [contenthash], see documentation for details)"
+			)
+		);
 	}
 
 	// Chunk Context
@@ -111,58 +174,38 @@ const replacePathVariables = (path, data) => {
 	// Placeholders
 	//
 	// [id] - chunk.id (0.js)
-	// [ext] - file.ext (app.{js, css, ...})
 	// [name] - chunk.name (app.js)
 	// [hash] - data.hash (53276435.js)
 	// [chunkhash] - chunk.hash (7823t4t4.js)
 	// [contenthash] - chunk.contentHash[type] (3256urzg.js)
-	// [query] - data.query (app.js?v=1.0.0)
-	// [file] - file.path (/context/file.map.js)
-	// [filebase] - file.base (file.map.js)
 	if (data.chunk) {
 		const chunk = data.chunk;
 
-		const id = chunk.id;
-		const name = chunk.name || chunk.id;
-
-		const chunkHash = chunk.renderedHash || chunk.hash;
-		// @ts-ignore
-		const chunkHashWithLength = chunk.hashWithLength || undefined;
-
 		const contentHashType = data.contentHashType;
-		const contentHash =
-			data.contentHash ||
-			(contentHashType &&
-				chunk.contentHash &&
-				chunk.contentHash[contentHashType]);
-		const contentHashWithLength =
-			data.contentHashWithLength ||
-			// @ts-ignore
-			(chunk.contentHashWithLength &&
-				// @ts-ignore
-				chunk.contentHashWithLength[contentHashType]) ||
-			undefined;
 
-		replacements.set(REGEXP_ID, replacer(id));
-		replacements.set(REGEXP_EXT, replacer(file.ext));
-		replacements.set(REGEXP_NAME, replacer(name));
-		replacements.set(
-			REGEXP_HASH,
-			hashLength(replacer(data.hash), data.hashWithLength)
+		const idReplacer = replacer(chunk.id);
+		const nameReplacer = replacer(chunk.name || chunk.id);
+		const chunkhashReplacer = hashLength(
+			replacer(chunk.renderedHash || chunk.hash),
+			"hashWithLength" in chunk ? chunk.hashWithLength : undefined
 		);
-		replacements.set(
-			REGEXP_CHUNKHASH,
-			hashLength(replacer(chunkHash), chunkHashWithLength)
+		const contenthashReplacer = hashLength(
+			replacer(
+				data.contentHash ||
+					(contentHashType &&
+						chunk.contentHash &&
+						chunk.contentHash[contentHashType])
+			),
+			data.contentHashWithLength ||
+				("contentHashWithLength" in chunk && chunk.contentHashWithLength
+					? chunk.contentHashWithLength[contentHashType]
+					: undefined)
 		);
-		replacements.set(
-			REGEXP_CONTENTHASH,
-			hashLength(replacer(contentHash), contentHashWithLength)
-		);
-		// query is optional, it's OK if it's in a path
-		// but there's nothing to replace it with
-		replacements.set(REGEXP_QUERY, replacer(file.query, true));
-		replacements.set(REGEXP_FILE, replacer(file.path));
-		replacements.set(REGEXP_FILEBASE, replacer(file.base));
+
+		replacements.set(REGEXP_ID, idReplacer);
+		replacements.set(REGEXP_NAME, nameReplacer);
+		replacements.set(REGEXP_CHUNKHASH, chunkhashReplacer);
+		replacements.set(REGEXP_CONTENTHASH, contenthashReplacer);
 	}
 
 	// Module Context
@@ -170,10 +213,7 @@ const replacePathVariables = (path, data) => {
 	// Placeholders
 	//
 	// [id] - module.id (2.png)
-	// [ext] - file.ext (file.{png, svg, ...})
 	// [hash] - module.hash (6237543873.png)
-	// [name] - file.name (file)
-	// [file] - file.base (file.png)
 	//
 	// Legacy Placeholders
 	//
@@ -182,26 +222,30 @@ const replacePathVariables = (path, data) => {
 	if (data.module) {
 		const module = data.module;
 
-		const id =
-			module instanceof Module ? chunkGraph.getModuleId(module) : module.id;
+		const idReplacer = replacer(
+			prepareId(
+				module instanceof Module ? chunkGraph.getModuleId(module) : module.id
+			)
+		);
+		const hashReplacer = hashLength(
+			replacer(
+				module instanceof Module
+					? chunkGraph.getRenderedModuleHash(module)
+					: module.renderedHash || module.hash
+			),
+			"hashWithLength" in module ? module.hashWithLength : undefined
+		);
 
-		const hash =
-			module instanceof Module
-				? chunkGraph.getRenderedModuleHash(module)
-				: module.renderedHash || module.hash;
-		// @ts-ignore
-		const hashWithLength = module.hashWithLength || undefined;
-
-		replacements.set(REGEXP_ID, replacer(prepareId(id)));
-		replacements.set(REGEXP_EXT, replacer(file.ext));
-		replacements.set(REGEXP_NAME, replacer(file.name));
-		replacements.set(REGEXP_FILE, replacer(file.base));
-		replacements.set(REGEXP_HASH, hashLength(replacer(hash), hashWithLength));
+		replacements.set(REGEXP_ID, idReplacer);
+		replacements.set(REGEXP_HASH, hashReplacer);
 		// Legacy
-		replacements.set(REGEXP_MODULEID, replacer(prepareId(id)));
+		replacements.set(
+			REGEXP_MODULEID,
+			deprecated(idReplacer, "[moduleid] is now [id]")
+		);
 		replacements.set(
 			REGEXP_MODULEHASH,
-			hashLength(replacer(hash), hashWithLength)
+			deprecated(hashReplacer, "[modulehash] is now [hash]")
 		);
 	}
 

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -141,7 +141,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 			}
 			return "[id].js";
 		});
-		this.set("output.webassemblyModuleFilename", "[modulehash].module.wasm");
+		this.set("output.webassemblyModuleFilename", "[hash].module.wasm");
 		this.set("output.library", "");
 		this.set("output.hotUpdateFunction", "make", options => {
 			return Template.toIdentifier(

--- a/lib/wasm/WebAssemblyModulesPlugin.js
+++ b/lib/wasm/WebAssemblyModulesPlugin.js
@@ -79,8 +79,6 @@ class WebAssemblyModulesPlugin {
 							compareModulesById(chunkGraph)
 						)) {
 							if (module.type && module.type.startsWith("webassembly")) {
-								// @ts-ignore
-								const filename = module.resource;
 								const filenameTemplate =
 									outputOptions.webassemblyModuleFilename;
 
@@ -100,7 +98,6 @@ class WebAssemblyModulesPlugin {
 									filenameTemplate,
 									pathOptions: {
 										module,
-										filename,
 										chunkGraph
 									},
 									identifier: `webassemblyModule${chunkGraph.getModuleId(

--- a/lib/wasm/WebAssemblyModulesPlugin.js
+++ b/lib/wasm/WebAssemblyModulesPlugin.js
@@ -79,6 +79,8 @@ class WebAssemblyModulesPlugin {
 							compareModulesById(chunkGraph)
 						)) {
 							if (module.type && module.type.startsWith("webassembly")) {
+								// @ts-ignore
+								const filename = module.resource;
 								const filenameTemplate =
 									outputOptions.webassemblyModuleFilename;
 
@@ -97,8 +99,9 @@ class WebAssemblyModulesPlugin {
 										),
 									filenameTemplate,
 									pathOptions: {
-										chunkGraph,
-										module
+										module,
+										filename,
+										chunkGraph
 									},
 									identifier: `webassemblyModule${chunkGraph.getModuleId(
 										module

--- a/schemas/plugins/BannerPlugin.json
+++ b/schemas/plugins/BannerPlugin.json
@@ -3,7 +3,7 @@
     "BannerFunction": {
       "description": "The banner as function, it will be wrapped in a comment",
       "instanceof": "Function",
-      "tsType": "(data: { hash: string, chunk: import('../../lib/Chunk'), filename: string, basename: string, query: string}) => string"
+      "tsType": "(data: { hash: string, chunk: import('../../lib/Chunk'), filename: string }) => string"
     },
     "Rule": {
       "oneOf": [


### PR DESCRIPTION
Needed for #6446

**What kind of change does this PR introduce?**

- [x] Refactor

**Did you add tests for your changes?**

Existing tests (Could need additional tests for `module` context, better done in #6446)

**Does this PR introduce a breaking change?**

- [x] Yes (`lib/BannerPlugin.js`) (TBD)

**What needs to be documented once your changes are merged?**

**`webpack.config.js`**
```js
const config = {
  output: {
     filename: '[name].[contenthash].js' // e.g bundle.68545679.js
     webassemblyFilename: '[name].[hash].[ext]' // e.g module.43875468.wasm
  }
}
```

### `File`

```js
const file = Object {
   path: data.filename || "",
   ext: extname(data.filename),
   base: basename(data.filename),
   name: file.base.replace(file.ext, ""),
   query: ""
}
```

### `Chunk` (`filename|chunkFilename`)

#### `Placeholders`

|Name|Replacer|
|:----:|:--------:|
|`[id]`|`chunk.id`|
|**`[ext]`**|**`file.ext`**|
|`[name]`|`chunk.id\|chunk.name`|
|`[hash]`|`data.hash`|
|`[chunkhash]`|`chunk.hash`|
|`[contenthash]`|`chunk.contentHash`|
|`[query]`|`file.query`|
|`[file]`|`file.name`|
|`[filebase]`|`file.base`|


### `Module` (`*ModuleFilename`)

#### `Placeholders`

|Name|Replacer|
|:----:|:--------:|
|`[id]`|`module.id`|
|`[ext]`|`file.ext`|
|`[file]`|`file.base`|
|`[name]`|`file.name`|
|`[hash]`|`module.hash`|