### PR TITLE
Use devServer output if available

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -410,7 +410,7 @@ class Compilation extends Tapable {
 		this.profile = options && options.profile;
 		this.performance = options && options.performance;
 
-		this.mainTemplate = new MainTemplate(this.outputOptions);
+		this.mainTemplate = new MainTemplate(this.outputOptions, options.devServer);
 		this.chunkTemplate = new ChunkTemplate(this.outputOptions);
 		this.hotUpdateChunkTemplate = new HotUpdateChunkTemplate(
 			this.outputOptions

--- a/lib/MainTemplate.js
+++ b/lib/MainTemplate.js
@@ -497,7 +497,7 @@ module.exports = class MainTemplate extends Tapable {
 			publicPath += `:${this.devServerOptions.port}`;
 		}
 		if (this.devServerOptions.publicPath) {
-			publicPath += this.outputOptions.publicPath;
+			publicPath += this.devServerOptions.publicPath;
 		}
 		return this.hooks.assetPath.call(publicPath, options);
 	}

--- a/lib/MainTemplate.js
+++ b/lib/MainTemplate.js
@@ -57,11 +57,13 @@ module.exports = class MainTemplate extends Tapable {
 	/**
 	 *
 	 * @param {TODO=} outputOptions output options for the MainTemplate
+	 * @param {TODO=} devServerOptions  specific options for the dev server
 	 */
-	constructor(outputOptions) {
+	constructor(outputOptions, devServerOptions) {
 		super();
 		/** @type {TODO?} */
 		this.outputOptions = outputOptions || {};
+		this.devServerOptions = devServerOptions || {};
 		this.hooks = {
 			/** @type {SyncWaterfallHook<TODO[], RenderManifestOptions>} */
 			renderManifest: new SyncWaterfallHook(["result", "options"]),
@@ -485,10 +487,19 @@ module.exports = class MainTemplate extends Tapable {
 	 * @returns {string} hook call
 	 */
 	getPublicPath(options) {
-		return this.hooks.assetPath.call(
-			this.outputOptions.publicPath || "",
-			options
-		);
+		let publicPath = "";
+		if (this.devServerOptions.host) {
+			publicPath = `${this.outputOptions.https ? "https" : "http"}://${
+				this.devServerOptions.host
+			}`;
+		}
+		if (this.devServerOptions.port) {
+			publicPath += `:${this.devServerOptions.port}`;
+		}
+		if (this.devServerOptions.publicPath) {
+			publicPath += this.outputOptions.publicPath;
+		}
+		return this.hooks.assetPath.call(publicPath, options);
 	}
 
 	getAssetPath(path, options) {


### PR DESCRIPTION
I am running my own frontend on port 80 and running Webpack with the devServer hot option.
I am getting my page bundles without problems, but when there is a hot update, Webpack does not take into account the `devServer` options (`https`, `host`, `port`) to fetch the `[hash].hot-update.json` file.
This results in a 404 and no hot reload.

https://github.com/webpack/webpack-dev-server/issues/1385


**What kind of change does this PR introduce?**

Bugfix to include devServer options when fetching the `hot-update.json` from the dev server.

**Did you add tests for your changes?**

I didn't yet, it's my first contribution and I would like to have some feedback. I am not deeply familiar with all the internals, if the change needs to be replicated in other files, if that's the best place, ...

I would love some feedback on this change first before adding tests.

**Does this PR introduce a breaking change?**

I think it does. These parameters were ignored previously. If some apps relied on the previous behaviour and had some workarounds, that might break it.

**What needs to be documented once your changes are merged?**

No changes.
