### PR TITLE
Refactor usage of $crossOriginLoading$

### DIFF
--- a/lib/web/JsonpMainTemplate.runtime.js
+++ b/lib/web/JsonpMainTemplate.runtime.js
@@ -16,7 +16,6 @@ module.exports = function() {
 		var script = document.createElement("script");
 		script.charset = "utf-8";
 		script.src = $require$.p + $hotChunkFilename$;
-		$crossOriginLoading$;
 		head.appendChild(script);
 	}
 

--- a/lib/web/JsonpMainTemplate.runtime.js
+++ b/lib/web/JsonpMainTemplate.runtime.js
@@ -16,7 +16,7 @@ module.exports = function() {
 		var script = document.createElement("script");
 		script.charset = "utf-8";
 		script.src = $require$.p + $hotChunkFilename$;
-		script.crossOrigin = $crossOriginLoading$;
+		if ($crossOriginLoading$) script.crossOrigin = $crossOriginLoading$;
 		head.appendChild(script);
 	}
 

--- a/lib/web/JsonpMainTemplate.runtime.js
+++ b/lib/web/JsonpMainTemplate.runtime.js
@@ -16,6 +16,7 @@ module.exports = function() {
 		var script = document.createElement("script");
 		script.charset = "utf-8";
 		script.src = $require$.p + $hotChunkFilename$;
+		script.crossOrigin = $crossOriginLoading$;
 		head.appendChild(script);
 	}
 

--- a/lib/web/JsonpMainTemplatePlugin.js
+++ b/lib/web/JsonpMainTemplatePlugin.js
@@ -562,9 +562,7 @@ class JsonpMainTemplatePlugin {
 					.replace(/\$require\$/g, mainTemplate.requireFn)
 					.replace(
 						/\$crossOriginLoading\$/g,
-						crossOriginLoading
-							? JSON.stringify(crossOriginLoading)
-							: "null"
+						crossOriginLoading ? JSON.stringify(crossOriginLoading) : "null"
 					)
 					.replace(/\$hotMainFilename\$/g, currentHotUpdateMainFilename)
 					.replace(/\$hotChunkFilename\$/g, currentHotUpdateChunkFilename)

--- a/lib/web/JsonpMainTemplatePlugin.js
+++ b/lib/web/JsonpMainTemplatePlugin.js
@@ -563,8 +563,8 @@ class JsonpMainTemplatePlugin {
 					.replace(
 						/\$crossOriginLoading\$/g,
 						crossOriginLoading
-							? `script.crossOrigin = ${JSON.stringify(crossOriginLoading)}`
-							: ""
+							? JSON.stringify(crossOriginLoading)
+							: "null"
 					)
 					.replace(/\$hotMainFilename\$/g, currentHotUpdateMainFilename)
 					.replace(/\$hotChunkFilename\$/g, currentHotUpdateChunkFilename)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
The variable `$crossOriginLoading$` looks like it's not used and static analysis will suggest removing it.

It was introduced in commit 6aa31547531d51b317c4b318ec214de9bf183099 from PR #988. 

A comment from @Aladdin-ADD makes me believe I'm not the only one who thought this variable was unused.

**What kind of change does this PR introduce?**

Code cleanup. I refactored the code a bit to avoid this confusion (I hope) for future users reading the code. The default value of `script.crossOrigin` is null so this will assign crossOrigin to the value specified or null if nothing was specified.

**Did you add tests for your changes?**

No, the behavior is unaffected.

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing, no change to API.
