### PR TITLE
[WIP] fix(JavascriptModulesPlugin): don't emit empty chunks

### DIFF
--- a/lib/JavascriptModulesPlugin.js
+++ b/lib/JavascriptModulesPlugin.js
@@ -159,30 +159,44 @@ class JavascriptModulesPlugin {
 							filenameTemplate = outputOptions.chunkFilename;
 						}
 
-						result.push({
-							render: () =>
-								this.renderJavascript(
-									compilation,
-									compilation.chunkTemplate,
-									moduleTemplates.javascript,
-									{
-										chunk,
-										dependencyTemplates,
-										runtimeTemplate: compilation.runtimeTemplate,
-										moduleGraph,
-										chunkGraph: compilation.chunkGraph
-									}
-								),
-							filenameTemplate,
-							pathOptions: {
-								chunk,
-								contentHashType: "javascript"
-							},
-							identifier: `chunk${chunk.id}`,
-							hash: chunk.hash
-						});
+						const { chunkGraph } = compilation;
 
-						return result;
+						const hasModules = Array.from(
+							chunkGraph.getChunkModules(chunk)
+						).filter(module => {
+							if (hooks.shouldRender.call(module, chunk)) {
+								return true;
+							}
+
+							return false;
+						}).length;
+
+						if (hasModules > 0) {
+							result.push({
+								render: () =>
+									this.renderJavascript(
+										compilation,
+										compilation.chunkTemplate,
+										moduleTemplates.javascript,
+										{
+											chunk,
+											dependencyTemplates,
+											runtimeTemplate: compilation.runtimeTemplate,
+											moduleGraph,
+											chunkGraph: compilation.chunkGraph
+										}
+									),
+								filenameTemplate,
+								pathOptions: {
+									chunk,
+									contentHashType: "javascript"
+								},
+								identifier: `chunk${chunk.id}`,
+								hash: chunk.hash
+							});
+
+							return result;
+						}
 					}
 				);
 				compilation.hooks.contentHash.tap("JavascriptModulesPlugin", chunk => {

--- a/lib/JavascriptModulesPlugin.js
+++ b/lib/JavascriptModulesPlugin.js
@@ -184,17 +184,16 @@ class JavascriptModulesPlugin {
 
 						const { chunkGraph } = compilation;
 
-						const hasModules = Array.from(
-							chunkGraph.getChunkModules(chunk)
-						).filter(module => {
-							if (hooks.shouldRender.call(module, chunk)) {
-								return true;
-							}
+						const hasRenderedModules =
+							chunkGraph
+								.getChunkModules(chunk)
+								.filter(module => hooks.shouldRender.call(module, chunk))
+								.length > 0;
 
-							return false;
-						}).length;
+						const hasEntryModules =
+							chunkGraph.getNumberOfEntryModules(chunk) > 0;
 
-						if (hasModules > 0) {
+						if (hasEntryModules || hasRenderedModules) {
 							result.push({
 								render: () =>
 									this.renderJavascript(

--- a/lib/JavascriptModulesPlugin.js
+++ b/lib/JavascriptModulesPlugin.js
@@ -42,13 +42,17 @@ class JavascriptModulesPlugin {
 				"The 'compilation' argument must be an instance of Compilation"
 			);
 		}
+
 		let hooks = compilationHooksMap.get(compilation);
+
 		if (hooks === undefined) {
 			hooks = {
 				shouldRender: new SyncBailHook(["module", "chunk"])
 			};
+
 			compilationHooksMap.set(compilation, hooks);
 		}
+
 		return hooks;
 	}
 
@@ -57,67 +61,82 @@ class JavascriptModulesPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
-		compiler.hooks.compilation.tap(
+		const { compilation } = compiler.hooks;
+
+		compilation.tap(
 			"JavascriptModulesPlugin",
 			(compilation, { normalModuleFactory }) => {
-				const moduleGraph = compilation.moduleGraph;
 				const hooks = JavascriptModulesPlugin.getHooks(compilation);
+
 				hooks.shouldRender.tap("JavascriptModulesPlugin", module => {
 					if (module.type === "javascript/auto") return true;
 					if (module.type === "javascript/dynamic") return true;
 					if (module.type === "javascript/esm") return true;
 				});
-				normalModuleFactory.hooks.createParser
+
+				const { createParser, createGenerator } = normalModuleFactory.hooks;
+
+				createParser
 					.for("javascript/auto")
 					.tap("JavascriptModulesPlugin", options => {
 						return new JavascriptParser(options, "auto");
 					});
-				normalModuleFactory.hooks.createParser
+				createParser
 					.for("javascript/dynamic")
 					.tap("JavascriptModulesPlugin", options => {
 						return new JavascriptParser(options, "script");
 					});
-				normalModuleFactory.hooks.createParser
+				createParser
 					.for("javascript/esm")
 					.tap("JavascriptModulesPlugin", options => {
 						return new JavascriptParser(options, "module");
 					});
-				normalModuleFactory.hooks.createGenerator
+
+				createGenerator
 					.for("javascript/auto")
 					.tap("JavascriptModulesPlugin", () => {
 						return new JavascriptGenerator();
 					});
-				normalModuleFactory.hooks.createGenerator
+				createGenerator
 					.for("javascript/dynamic")
 					.tap("JavascriptModulesPlugin", () => {
 						return new JavascriptGenerator();
 					});
-				normalModuleFactory.hooks.createGenerator
+				createGenerator
 					.for("javascript/esm")
 					.tap("JavascriptModulesPlugin", () => {
 						return new JavascriptGenerator();
 					});
-				compilation.mainTemplate.hooks.renderManifest.tap(
+
+				const { moduleGraph } = compilation;
+				const { contentHash } = compilation.hooks;
+				const { mainTemplate, chunkTemplate } = compilation;
+
+				mainTemplate.hooks.renderManifest.tap(
 					"JavascriptModulesPlugin",
 					(result, options) => {
 						const chunk = options.chunk;
-						const hash = options.hash;
-						const outputOptions = options.outputOptions;
+						const { filename } = options.outputOptions;
+						const { hash } = options;
+						const { moduleGraph, chunkGraph } = options;
+
+						const mainTemplate = compilation.mainTemplate;
+
+						const filenameTemplate = chunk.filenameTemplate || filename;
+
+						const runtimeTemplate = options.runtimeTemplate;
 						const moduleTemplates = options.moduleTemplates;
 						const dependencyTemplates = options.dependencyTemplates;
 
-						const filenameTemplate =
-							chunk.filenameTemplate || outputOptions.filename;
-
 						result.push({
 							render: () =>
-								compilation.mainTemplate.render(moduleTemplates.javascript, {
+								mainTemplate.render(moduleTemplates.javascript, {
 									hash,
 									chunk,
-									dependencyTemplates,
-									runtimeTemplate: options.runtimeTemplate,
-									moduleGraph: options.moduleGraph,
-									chunkGraph: options.chunkGraph
+									chunkGraph,
+									moduleGraph,
+									runtimeTemplate,
+									dependencyTemplates
 								}),
 							filenameTemplate,
 							pathOptions: {
@@ -130,7 +149,8 @@ class JavascriptModulesPlugin {
 						return result;
 					}
 				);
-				compilation.mainTemplate.hooks.modules.tap(
+
+				mainTemplate.hooks.modules.tap(
 					"JavascriptModulesPlugin",
 					(source, moduleTemplate, renderContext) => {
 						const chunk = renderContext.chunk;
@@ -142,22 +162,25 @@ class JavascriptModulesPlugin {
 						);
 					}
 				);
-				compilation.chunkTemplate.hooks.renderManifest.tap(
+
+				chunkTemplate.hooks.renderManifest.tap(
 					"JavascriptModulesPlugin",
 					(result, options) => {
 						const chunk = options.chunk;
-						const outputOptions = options.outputOptions;
-						const moduleTemplates = options.moduleTemplates;
-						const dependencyTemplates = options.dependencyTemplates;
+						const { filename, chunkFilename } = options.outputOptions;
 
 						let filenameTemplate;
+
 						if (chunk.filenameTemplate) {
 							filenameTemplate = chunk.filenameTemplate;
 						} else if (chunk.isOnlyInitial()) {
-							filenameTemplate = outputOptions.filename;
+							filenameTemplate = filename;
 						} else {
-							filenameTemplate = outputOptions.chunkFilename;
+							filenameTemplate = chunkFilename;
 						}
+
+						const { chunkTemplate, runtimeTemplate } = compilation;
+						const { moduleTemplates, dependencyTemplates } = options;
 
 						const { chunkGraph } = compilation;
 
@@ -176,14 +199,14 @@ class JavascriptModulesPlugin {
 								render: () =>
 									this.renderJavascript(
 										compilation,
-										compilation.chunkTemplate,
+										chunkTemplate,
 										moduleTemplates.javascript,
 										{
 											chunk,
-											dependencyTemplates,
-											runtimeTemplate: compilation.runtimeTemplate,
+											chunkGraph,
 											moduleGraph,
-											chunkGraph: compilation.chunkGraph
+											runtimeTemplate,
+											dependencyTemplates
 										}
 									),
 								filenameTemplate,
@@ -199,10 +222,13 @@ class JavascriptModulesPlugin {
 						}
 					}
 				);
-				compilation.hooks.contentHash.tap("JavascriptModulesPlugin", chunk => {
+
+				contentHash.tap("JavascriptModulesPlugin", chunk => {
 					const {
 						chunkGraph,
 						moduleGraph,
+						mainTemplate,
+						chunkTemplate,
 						runtimeTemplate,
 						outputOptions: {
 							hashSalt,
@@ -211,18 +237,22 @@ class JavascriptModulesPlugin {
 							hashFunction
 						}
 					} = compilation;
+
 					const hash = createHash(hashFunction);
+
 					if (hashSalt) hash.update(hashSalt);
-					const template = chunk.hasRuntime()
-						? compilation.mainTemplate
-						: compilation.chunkTemplate;
+
+					const template = chunk.hasRuntime() ? mainTemplate : chunkTemplate;
+
 					hash.update(`${chunk.id} `);
 					hash.update(chunk.ids ? chunk.ids.join(",") : "");
+
 					template.updateHashForChunk(hash, chunk, {
 						chunkGraph,
 						moduleGraph,
 						runtimeTemplate
 					});
+
 					for (const m of chunkGraph.getOrderedChunkModulesIterable(
 						chunk,
 						compareModulesById(chunkGraph)
@@ -231,6 +261,7 @@ class JavascriptModulesPlugin {
 							hash.update(chunkGraph.getModuleHash(m));
 						}
 					}
+
 					chunk.contentHash.javascript = hash
 						.digest(hashDigest)
 						.substr(0, hashDigestLength);
@@ -250,25 +281,31 @@ class JavascriptModulesPlugin {
 		const hooks = JavascriptModulesPlugin.getHooks(compilation);
 
 		const chunk = renderContext.chunk;
+
 		const moduleSources = Template.renderChunkModules(
 			renderContext,
-			m => hooks.shouldRender.call(m, chunk),
+			module => hooks.shouldRender.call(module, chunk),
 			moduleTemplate
 		);
+
 		const core = chunkTemplate.hooks.modules.call(
 			moduleSources,
 			moduleTemplate,
 			renderContext
 		);
+
 		let source = chunkTemplate.hooks.render.call(
 			core,
 			moduleTemplate,
 			renderContext
 		);
+
 		if (renderContext.chunkGraph.getNumberOfEntryModules(chunk) > 0) {
 			source = chunkTemplate.hooks.renderWithEntry.call(source, chunk);
 		}
+
 		chunk.rendered = true;
+
 		return new ConcatSource(source, ";");
 	}
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix

**Did you add tests for your changes?**

- [x] Existing (with updated snapshots, may need additional testing)
 - #7386
 - #7601

**Does this PR introduce a breaking change?**

- [x] No

**What needs to be documented once your changes are merged?**

- [x] None

---

## TODO

### Fix

- [x] Check if the (empty) chunk contains an `EntryModule` (`ChunkGraph.getNumberOfEntryModules(chunk)`)
- [ ] Check if the (empty) chunk contains `prefetch`specifications (`chunk.getChildIdsByOrders(chunkGraph)`)

### Feature 

- [ ] Add a `shouldRenderChunk` hook (`JavascriptModulesPlugin`)

### Test

- [x] Drop snapshot updates (`statsTestCases`)
