### PR TITLE
Adding format option for Dll Plugin to get a formatted manifest json. #7992

### DIFF
--- a/declarations/plugins/DllPlugin.d.ts
+++ b/declarations/plugins/DllPlugin.d.ts
@@ -14,7 +14,7 @@ export interface DllPluginOptions {
 	 */
 	entryOnly?: boolean;
 	/**
-	 * If true, manifest json file(output) will be formatted
+	 * If true, manifest json file (output) will be formatted
 	 */
 	format?: boolean;
 	/**

--- a/declarations/plugins/DllPlugin.d.ts
+++ b/declarations/plugins/DllPlugin.d.ts
@@ -14,6 +14,10 @@ export interface DllPluginOptions {
 	 */
 	entryOnly?: boolean;
 	/**
+	 * If true, manifest json file(output) will be formatted
+	 */
+	format?: boolean;
+	/**
 	 * Name of the exposed dll function (external name, use value of 'output.library')
 	 */
 	name?: string;

--- a/lib/DllPlugin.js
+++ b/lib/DllPlugin.js
@@ -20,10 +20,6 @@ class DllPlugin {
 	constructor(options) {
 		validateOptions(schema, options, "Dll Plugin");
 		this.options = options;
-
-		if (!options.format) {
-			this.options.format = false;
-		}
 	}
 
 	apply(compiler) {

--- a/lib/DllPlugin.js
+++ b/lib/DllPlugin.js
@@ -20,6 +20,10 @@ class DllPlugin {
 	constructor(options) {
 		validateOptions(schema, options, "Dll Plugin");
 		this.options = options;
+
+		if (!options.format) {
+			this.options.format = false;
+		}
 	}
 
 	apply(compiler) {

--- a/lib/LibManifestPlugin.js
+++ b/lib/LibManifestPlugin.js
@@ -67,7 +67,11 @@ class LibManifestPlugin {
 									return obj;
 								}, Object.create(null))
 						};
-						const content = Buffer.from(JSON.stringify(manifest), "utf8");
+						// Apply formatting to content if format flag is true;
+						const manifestContent = this.options.format
+							? JSON.stringify(manifest, null, 2)
+							: JSON.stringify(manifest);
+						const content = Buffer.from(manifestContent, "utf8");
 						compiler.outputFileSystem.mkdirp(path.dirname(targetPath), err => {
 							if (err) return callback(err);
 							compiler.outputFileSystem.writeFile(

--- a/schemas/plugins/DllPlugin.json
+++ b/schemas/plugins/DllPlugin.json
@@ -12,6 +12,10 @@
       "description": "If true, only entry points will be exposed",
       "type": "boolean"
     },
+    "format": {
+      "description": "If true, manifest json file (output) will be formatted",
+      "type": "boolean"
+    },
     "name": {
       "description": "Name of the exposed dll function (external name, use value of 'output.library')",
       "type": "string",

--- a/test/configCases/dll-plugin-format/0-create-dll/dep.js
+++ b/test/configCases/dll-plugin-format/0-create-dll/dep.js
@@ -1,0 +1,1 @@
+module.exports = "foo";

--- a/test/configCases/dll-plugin-format/0-create-dll/index.js
+++ b/test/configCases/dll-plugin-format/0-create-dll/index.js
@@ -1,0 +1,4 @@
+export { add } from "./utility";
+export default "Format";
+
+require("./dep");

--- a/test/configCases/dll-plugin-format/0-create-dll/test.config.js
+++ b/test/configCases/dll-plugin-format/0-create-dll/test.config.js
@@ -1,0 +1,1 @@
+exports.noTests = true;

--- a/test/configCases/dll-plugin-format/0-create-dll/utility.js
+++ b/test/configCases/dll-plugin-format/0-create-dll/utility.js
@@ -1,0 +1,7 @@
+export function add(a, b) {
+	return a + b;
+}
+
+export function diff(a, b) {
+	return a - b;
+}

--- a/test/configCases/dll-plugin-format/0-create-dll/webpack.config.js
+++ b/test/configCases/dll-plugin-format/0-create-dll/webpack.config.js
@@ -1,0 +1,23 @@
+var path = require("path");
+var webpack = require("../../../../");
+
+module.exports = {
+	entry: ["."],
+	resolve: {
+		extensions: [".js"]
+	},
+	output: {
+		filename: "dll.js",
+		chunkFilename: "[id].dll.js",
+		libraryTarget: "commonjs2"
+	},
+	plugins: [
+		new webpack.DllPlugin({
+			path: path.resolve(
+				__dirname,
+				"../../../js/config/dll-plugin-format/manifest0.json"
+			),
+			format: true
+		})
+	]
+};


### PR DESCRIPTION

**What kind of change does this PR introduce?**

Adding a feature (option) for DLL Plugin to format manifest json output file.

**Did you add tests for your changes?**

I assume no tests are required.

**Does this PR introduce a breaking change?**

This doesn't introduce a breaking change.

**What needs to be documented once your changes are merged?**
1. Change documentation for DLL Plugin and add a new option called "format" and it's use.

I will make a change to the documentation, to add format options in DLL Plugin documentation.

This Pr is for the issue #7992.
