### PR TITLE
[WIP] Fix code generation for scoped packages specified as externals

### DIFF
--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -11,6 +11,19 @@ const Template = require("./Template");
 
 /** @typedef {import("./util/createHash").Hash} Hash */
 
+const illegalCharacters = /[^$_a-zA-Z0-9]/g;
+const startsWithDigit = str => /\d/.test(str[0]);
+const makeLegalIdentifier = identifier => {
+	identifier = identifier
+		.replace(/-(\w)/g, (_, letter) => letter.toUpperCase())
+		.replace(illegalCharacters, "_");
+
+	if (startsWithDigit(identifier)) {
+		identifier = `_${identifier}`;
+	}
+	return identifier;
+};
+
 class ExternalModule extends Module {
 	constructor(request, type, userRequest) {
 		super("javascript/dynamic", null);
@@ -109,7 +122,9 @@ class ExternalModule extends Module {
 			.slice(1)
 			.map(r => `[${JSON.stringify(r)}]`)
 			.join("");
-		return `${missingModuleError}module.exports = ${variableName}${objectLookup};`;
+		return `${missingModuleError}module.exports = ${makeLegalIdentifier(
+			variableName
+		)}${objectLookup};`;
 	}
 
 	getSourceString(runtime) {

--- a/test/configCases/externals/externals-scoped/index.js
+++ b/test/configCases/externals/externals-scoped/index.js
@@ -1,0 +1,5 @@
+it("should not fail compilation code with scoped external", function(done) {
+	// eslint-disable-next-line node/no-missing-require
+	require("@scoped/package");
+	done();
+});

--- a/test/configCases/externals/externals-scoped/webpack.config.js
+++ b/test/configCases/externals/externals-scoped/webpack.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	externals: ["@scoped/package"]
+};


### PR DESCRIPTION
**Motivation**

I've skipped creating an issue about this, as the issue is straightforward. I'd like to work on a fix, this PR is very WIP at the moment - I'd love to get some pointers on how to improve it (maybe handle more cases?) as webpack's codebase is huge and I'm first time contributor to it, so naturally I don't know the internal architecture very well and my quick attempt to fix it is probably wrong placed.

Webpack currently outputs such code when specifying scoped package as external:
```js
/* 0 */
/***/ (function(module, exports) {

module.exports = @babel/runtime/helpers/esm/extends;

/***/ }),
/* 1 */
/***/ (function(module, exports) {

module.exports = @babel/runtime/helpers/esm/assertThisInitialized;

/***/ }),
```

Which is not a valid JS, so the parsing fails. I'd like to make it parseable. I'm not sure though how externals work in this case anyway - are they supposed to be reachable globals? I suspect the answer is yes - not sure what's the correct fix then, should we reference those as properties on global object?

**What kind of change does this PR introduce?**

bug fix

**Did you add tests for your changes?**

yes

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

nothing