### PR TITLE
Prefer chunks with entry module when picking name (#7516)

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -389,6 +389,27 @@ class Chunk {
 			return false;
 		}
 
+		// Pick a new name for the integrated chunk
+		if (this.name && otherChunk.name) {
+			if (this.hasEntryModule() === otherChunk.hasEntryModule()) {
+				// When both chunks have entry modules or none have one, use
+				// shortest name
+				if (this.name.length !== otherChunk.name.length) {
+					this.name =
+						this.name.length < otherChunk.name.length
+							? this.name
+							: otherChunk.name;
+				} else {
+					this.name = this.name < otherChunk.name ? this.name : otherChunk.name;
+				}
+			} else if (otherChunk.hasEntryModule()) {
+				// Pick the name of the chunk with the entry module
+				this.name = otherChunk.name;
+			}
+		} else if (otherChunk.name) {
+			this.name = otherChunk.name;
+		}
+
 		// Array.from is used here to create a clone, because moveModule modifies otherChunk._modules
 		for (const module of Array.from(otherChunk._modules)) {
 			otherChunk.moveModule(module, this);
@@ -404,27 +425,6 @@ class Chunk {
 			this.addGroup(chunkGroup);
 		}
 		otherChunk._groups.clear();
-
-		// Pick a new name for the integrated chunk
-		if (this.name && otherChunk.name) {
-			if (!this.entryModule === !otherChunk.entryModule) {
-				// When both chunks have entry modules or none have one, use
-				// shortest name
-				if (this.name.length !== otherChunk.name.length) {
-					this.name =
-						this.name.length < otherChunk.name.length
-							? this.name
-							: otherChunk.name;
-				} else {
-					this.name = this.name < otherChunk.name ? this.name : otherChunk.name;
-				}
-			} else if (otherChunk.entryModule) {
-				// Pick the name of the chunk with the entry module
-				this.name = otherChunk.name;
-			}
-		} else if (otherChunk.name) {
-			this.name = otherChunk.name;
-		}
 
 		return true;
 	}

--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -405,18 +405,22 @@ class Chunk {
 		}
 		otherChunk._groups.clear();
 
-		// Pick a new name for the chunk; prefer chunks with an entry module
-		// Otherwise, choose chunk with shortest name
-		if (this.name && otherChunk.name && !this.entryModule) {
-			if (otherChunk.entryModule) {
+		// Pick a new name for the integrated chunk
+		if (this.name && otherChunk.name) {
+			if (!this.entryModule === !otherChunk.entryModule) {
+				// When both chunks have entry modules or none have one, use
+				// shortest name
+				if (this.name.length !== otherChunk.name.length) {
+					this.name =
+						this.name.length < otherChunk.name.length
+							? this.name
+							: otherChunk.name;
+				} else {
+					this.name = this.name < otherChunk.name ? this.name : otherChunk.name;
+				}
+			} else if (otherChunk.entryModule) {
+				// Pick the name of the chunk with the entry module
 				this.name = otherChunk.name;
-			} else if (this.name.length !== otherChunk.name.length) {
-				this.name =
-					this.name.length < otherChunk.name.length
-						? this.name
-						: otherChunk.name;
-			} else {
-				this.name = this.name < otherChunk.name ? this.name : otherChunk.name;
 			}
 		} else if (otherChunk.name) {
 			this.name = otherChunk.name;

--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -405,8 +405,12 @@ class Chunk {
 		}
 		otherChunk._groups.clear();
 
-		if (this.name && otherChunk.name) {
-			if (this.name.length !== otherChunk.name.length) {
+		// Pick a new name for the chunk; prefer chunks with an entry module
+		// Otherwise, choose chunk with shortest name
+		if (this.name && otherChunk.name && !this.entryModule) {
+			if (otherChunk.entryModule) {
+				this.name = otherChunk.name;
+			} else if (this.name.length !== otherChunk.name.length) {
 				this.name =
 					this.name.length < otherChunk.name.length
 						? this.name

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1164,75 +1164,75 @@ Child
 `;
 
 exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 1`] = `
-"Hash: eb610b429c869eba72876747d3a05d57aba4ed0100a352bc82c330d5a88b516679988e145181f3e2
+"Hash: 4c228d725cbf3eab49b00afd6501091c91b050e2c20f1c713e672e9a4d84f2c6304d1cd5ce667c54
 Child 1 chunks:
-    Hash: eb610b429c869eba7287
+    Hash: 4c228d725cbf3eab49b0
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
     bundle.js  6.67 KiB       0  [emitted]  main
     Entrypoint main = bundle.js
-    chunk    {0} bundle.js (main) 191 bytes <{0}> >{0}< [entry] [rendered]
-     [0] ./index.js 73 bytes {0} [built]
+    chunk    {0} bundle.js (main) 219 bytes <{0}> >{0}< [entry] [rendered]
+     [0] ./index.js 101 bytes {0} [built]
      [1] ./a.js 22 bytes {0} [built]
      [2] ./b.js 22 bytes {0} [built]
      [3] ./c.js 30 bytes {0} [built]
      [4] ./d.js 22 bytes {0} [built]
      [5] ./e.js 22 bytes {0} [built]
 Child 2 chunks:
-    Hash: 6747d3a05d57aba4ed01
+    Hash: 0afd6501091c91b050e2
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
           Asset       Size  Chunks             Chunk Names
-    0.bundle.js  641 bytes       0  [emitted]  
-      bundle.js   8.28 KiB       1  [emitted]  main
+    0.bundle.js  401 bytes       0  [emitted]  
+      bundle.js   8.52 KiB       1  [emitted]  main
     Entrypoint main = bundle.js
-    chunk    {0} 0.bundle.js 118 bytes <{0}> <{1}> >{0}< [rendered]
-     [1] ./a.js 22 bytes {0} [built]
-     [2] ./b.js 22 bytes {0} [built]
-     [3] ./c.js 30 bytes {0} [built]
+    chunk    {0} 0.bundle.js 88 bytes <{1}> [rendered]
+     [2] ./a.js 22 bytes {0} [built]
+     [3] ./b.js 22 bytes {0} [built]
      [4] ./d.js 22 bytes {0} [built]
      [5] ./e.js 22 bytes {0} [built]
-    chunk    {1} bundle.js (main) 73 bytes >{0}< [entry] [rendered]
-     [0] ./index.js 73 bytes {1} [built]
+    chunk    {1} bundle.js (main) 131 bytes <{1}> >{0}< >{1}< [entry] [rendered]
+     [0] ./index.js 101 bytes {1} [built]
+     [1] ./c.js 30 bytes {1} [built]
 Child 3 chunks:
-    Hash: 00a352bc82c330d5a88b
+    Hash: c20f1c713e672e9a4d84
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
           Asset       Size  Chunks             Chunk Names
-    0.bundle.js  485 bytes       0  [emitted]  
-    1.bundle.js  232 bytes       1  [emitted]  
-      bundle.js   8.28 KiB       2  [emitted]  main
+    1.bundle.js  245 bytes       1  [emitted]  
+    2.bundle.js  232 bytes       2  [emitted]  
+      bundle.js   8.52 KiB       0  [emitted]  main
     Entrypoint main = bundle.js
-    chunk    {0} 0.bundle.js 74 bytes <{2}> >{1}< [rendered]
-     [1] ./a.js 22 bytes {0} [built]
-     [2] ./b.js 22 bytes {0} [built]
-     [3] ./c.js 30 bytes {0} [built]
+    chunk    {0} bundle.js (main) 131 bytes <{0}> >{0}< >{1}< >{2}< [entry] [rendered]
+     [0] ./index.js 101 bytes {0} [built]
+     [1] ./c.js 30 bytes {0} [built]
     chunk    {1} 1.bundle.js 44 bytes <{0}> [rendered]
-     [4] ./d.js 22 bytes {1} [built]
-     [5] ./e.js 22 bytes {1} [built]
-    chunk    {2} bundle.js (main) 73 bytes >{0}< [entry] [rendered]
-     [0] ./index.js 73 bytes {2} [built]
+     [2] ./a.js 22 bytes {1} [built]
+     [3] ./b.js 22 bytes {1} [built]
+    chunk    {2} 2.bundle.js 44 bytes <{0}> [rendered]
+     [4] ./d.js 22 bytes {2} [built]
+     [5] ./e.js 22 bytes {2} [built]
 Child 4 chunks:
-    Hash: 516679988e145181f3e2
+    Hash: f2c6304d1cd5ce667c54
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
           Asset       Size  Chunks             Chunk Names
-    0.bundle.js  236 bytes       0  [emitted]  
-    1.bundle.js  232 bytes       1  [emitted]  
-    3.bundle.js  323 bytes       3  [emitted]  
-      bundle.js   8.28 KiB       2  [emitted]  main
+    1.bundle.js  245 bytes       1  [emitted]  
+    2.bundle.js  152 bytes       2  [emitted]  
+    3.bundle.js  152 bytes       3  [emitted]  
+      bundle.js   8.52 KiB       0  [emitted]  main
     Entrypoint main = bundle.js
-    chunk    {0} 0.bundle.js 44 bytes <{2}> [rendered]
-     [1] ./a.js 22 bytes {0} [built]
-     [2] ./b.js 22 bytes {0} [built]
-    chunk    {1} 1.bundle.js 44 bytes <{3}> [rendered]
-     [4] ./d.js 22 bytes {1} [built]
-     [5] ./e.js 22 bytes {1} [built]
-    chunk    {2} bundle.js (main) 73 bytes >{0}< >{3}< [entry] [rendered]
-     [0] ./index.js 73 bytes {2} [built]
-    chunk    {3} 3.bundle.js 30 bytes <{2}> >{1}< [rendered]
-     [3] ./c.js 30 bytes {3} [built]"
+    chunk    {0} bundle.js (main) 131 bytes <{0}> >{0}< >{1}< >{2}< >{3}< [entry] [rendered]
+     [0] ./index.js 101 bytes {0} [built]
+     [1] ./c.js 30 bytes {0} [built]
+    chunk    {1} 1.bundle.js 44 bytes <{0}> [rendered]
+     [2] ./a.js 22 bytes {1} [built]
+     [3] ./b.js 22 bytes {1} [built]
+    chunk    {2} 2.bundle.js 22 bytes <{0}> [rendered]
+     [4] ./d.js 22 bytes {2} [built]
+    chunk    {3} 3.bundle.js 22 bytes <{0}> [rendered]
+     [5] ./e.js 22 bytes {3} [built]"
 `;
 
 exports[`StatsTestCases should print correct stats for max-modules 1`] = `

--- a/test/statsCases/limit-chunk-count-plugin/index.js
+++ b/test/statsCases/limit-chunk-count-plugin/index.js
@@ -1,3 +1,3 @@
 require.ensure(["./a"], function() {});
 require(["./b"]);
-import("./c");
+import(/* webpackChunkName: "c" */ "./c");


### PR DESCRIPTION
This PR changes the behavior of `Chunk#integrate` to prefer chunks with an entry module when picking a name. If none have an entry module, the old algorithm is used instead, where the chunk with the shortest name is picked.

See #7516 for the bug report.

**What kind of change does this PR introduce?**
This change is a bugfix.

**Did you add tests for your changes?**
I could not find tests related to this change. Do you want me to add them?

**Does this PR introduce a breaking change?**
This PR introduces a breaking change by changing the behavior of `Chunk#integrate`. Projects, plugins and internal code relying on the fact that the shortest name is picked when integrating two chunks may break. However, I think more people are affected by the current behavior.

**What needs to be documented once your changes are merged?**
The behavior of `Chunk#integrate` with regards to naming might need to be documented to explain current behavior.

Fixes #7516