### PR TITLE
Update tests for new WebAssembly.Global API

### DIFF
--- a/test/cases/wasm/export-imported-global/index.js
+++ b/test/cases/wasm/export-imported-global/index.js
@@ -1,8 +1,18 @@
 it("should export imported global", function() {
 	return import("./module").then(function({ v, w, x, test }) {
-		expect(v).toBe(1);
-		expect(w).toBe(1);
-		expect(x).toBe(1.25);
+		if (WebAssembly.Global) {
+			expect(v.constructor).toBe(WebAssembly.Global);
+			expect(w.constructor).toBe(WebAssembly.Global);
+			expect(x.constructor).toBe(WebAssembly.Global);
+
+			expect(+v).toBe(1);
+			expect(+w).toBe(1);
+			expect(+x).toBe(1.25);
+		} else {
+			expect(v).toBe(1);
+			expect(w).toBe(1);
+			expect(x).toBe(1.25);
+		}
 		expect(test()).toBe(2);
 	});
 });

--- a/test/cases/wasm/imported-global-preserve-ordering/index.js
+++ b/test/cases/wasm/imported-global-preserve-ordering/index.js
@@ -1,6 +1,14 @@
 it("should preserve the ordering of globals", function() {
 	return import("./module.wat").then(function(e) {
-		expect(e.c).toBe(3);
-		expect(e.d).toBe(4);
+		if (WebAssembly.Global) {
+			expect(e.c.constructor).toBe(WebAssembly.Global);
+			expect(e.d.constructor).toBe(WebAssembly.Global);
+
+			expect(+e.c).toBe(3);
+			expect(+e.d).toBe(4);
+		} else {
+			expect(e.c).toBe(3);
+			expect(e.d).toBe(4);
+		}
 	});
 });


### PR DESCRIPTION
The current version of the WebAssembly JS API specification [1]
exports globals as WebAssembly.Global, rather than as Numbers. This
version of the API is shipped in Chrome 69 and Firefox 62, and is
also seen in Node 11 nightly builds.

This patch updates webpack's tests to permit either the new API or
the old one, for exports of WebAssembly Globals. One of the affected
tests passes on Node 11 (where it previously failed), and the other
fails for unrelated reasons (possibly related to [2]).

Fixes #8145

[1] https://webassembly.github.io/spec/js-api/index.html
[2] https://github.com/webpack/webpack/pull/7467/files#r223454525

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Permit either the old (Number) or the new (WebAssembly.Global) behavior for exported globals.

**Did you add tests for your changes?**

The change consists just of tests.

**Does this PR introduce a breaking change?**

No, but the WebAssembly API exported by browsers is changing observably.

**What needs to be documented once your changes are merged?**

We could document that exported globals from WebAssembly become WebAssembly.Global objects, but I think the right place to document that will be in the WebAssembly/ESM specification; webpack should point to that when it's ready.