### PR TITLE
Remove moduleIds=total-size and deprecate moduleIds=hashed

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -780,16 +780,9 @@ export interface OptimizationOptions {
 	 */
 	minimizer?: (WebpackPluginInstance | WebpackPluginFunction)[];
 	/**
-	 * Define the algorithm to choose module ids (natural: numeric ids in order of usage, named: readable ids for better debugging, hashed: short hashes as ids for better long term caching, deterministic: numeric hash ids for better long term caching, size: numeric ids focused on minimal initial download size, total-size: numeric ids focused on minimal total download size, false: no algorithm used, as custom one can be provided via plugin)
+	 * Define the algorithm to choose module ids (natural: numeric ids in order of usage, named: readable ids for better debugging, hashed: (deprecated) short hashes as ids for better long term caching, deterministic: numeric hash ids for better long term caching, size: numeric ids focused on minimal initial download size, false: no algorithm used, as custom one can be provided via plugin)
 	 */
-	moduleIds?:
-		| "natural"
-		| "named"
-		| "hashed"
-		| "deterministic"
-		| "size"
-		| "total-size"
-		| false;
+	moduleIds?: "natural" | "named" | "hashed" | "deterministic" | "size" | false;
 	/**
 	 * Avoid emitting assets when errors occur
 	 */

--- a/lib/WarnDeprecatedOptionPlugin.js
+++ b/lib/WarnDeprecatedOptionPlugin.js
@@ -1,0 +1,43 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Florent Cailhol @ooflorent
+*/
+
+"use strict";
+
+const WebpackError = require("./WebpackError");
+
+class WarnDeprecatedOptionPlugin {
+	constructor(option, value, suggestion) {
+		this.option = option;
+		this.value = value;
+		this.suggestion = suggestion;
+	}
+
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap(
+			"WarnDeprecatedOptionPlugin",
+			compilation => {
+				compilation.warnings.push(
+					new DeprecatedOptionWarning(this.option, this.value, this.suggestion)
+				);
+			}
+		);
+	}
+}
+
+class DeprecatedOptionWarning extends WebpackError {
+	constructor(option, value, suggestion) {
+		super();
+
+		this.name = "DeprecatedOptionWarning";
+		this.message =
+			"configuration\n" +
+			`The value '${value}' for option '${option}' is deprecated. ` +
+			`Use '${suggestion}' instead.`;
+
+		Error.captureStackTrace(this, this.constructor);
+	}
+}
+
+module.exports = WarnDeprecatedOptionPlugin;

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -40,6 +40,7 @@ const RequireEnsurePlugin = require("./dependencies/RequireEnsurePlugin");
 const RequireIncludePlugin = require("./dependencies/RequireIncludePlugin");
 const SystemPlugin = require("./dependencies/SystemPlugin");
 
+const WarnDeprecatedOptionPlugin = require("./WarnDeprecatedOptionPlugin");
 const WarnNoModeSetPlugin = require("./WarnNoModeSetPlugin");
 
 const DeterministicModuleIdsPlugin = require("./ids/DeterministicModuleIdsPlugin");
@@ -381,6 +382,11 @@ class WebpackOptionsApply extends OptionsApply {
 					new NamedModuleIdsPlugin().apply(compiler);
 					break;
 				case "hashed":
+					new WarnDeprecatedOptionPlugin(
+						"optimization.moduleIds",
+						"hashed",
+						"deterministic"
+					).apply(compiler);
 					new HashedModuleIdsPlugin().apply(compiler);
 					break;
 				case "deterministic":
@@ -391,11 +397,6 @@ class WebpackOptionsApply extends OptionsApply {
 				case "size":
 					new OccurrenceModuleIdsPlugin({
 						prioritiseInitial: true
-					}).apply(compiler);
-					break;
-				case "total-size":
-					new OccurrenceModuleIdsPlugin({
-						prioritiseInitial: false
 					}).apply(compiler);
 					break;
 				default:

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -443,16 +443,8 @@
           }
         },
         "moduleIds": {
-          "description": "Define the algorithm to choose module ids (natural: numeric ids in order of usage, named: readable ids for better debugging, hashed: short hashes as ids for better long term caching, deterministic: numeric hash ids for better long term caching, size: numeric ids focused on minimal initial download size, total-size: numeric ids focused on minimal total download size, false: no algorithm used, as custom one can be provided via plugin)",
-          "enum": [
-            "natural",
-            "named",
-            "hashed",
-            "deterministic",
-            "size",
-            "total-size",
-            false
-          ]
+          "description": "Define the algorithm to choose module ids (natural: numeric ids in order of usage, named: readable ids for better debugging, hashed: (deprecated) short hashes as ids for better long term caching, deterministic: numeric hash ids for better long term caching, size: numeric ids focused on minimal initial download size, false: no algorithm used, as custom one can be provided via plugin)",
+          "enum": ["natural", "named", "hashed", "deterministic", "size", false]
         },
         "noEmitOnErrors": {
           "description": "Avoid emitting assets when errors occur",

--- a/test/configCases/code-generation/require-context-id/warnings.js
+++ b/test/configCases/code-generation/require-context-id/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[/hashed/, /deprecated/]
+];

--- a/test/configCases/delegated-hash/simple/warnings.js
+++ b/test/configCases/delegated-hash/simple/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[/hashed/, /deprecated/]
+];

--- a/test/configCases/dll-plugin/3-use-dll-with-hashid/warnings.js
+++ b/test/configCases/dll-plugin/3-use-dll-with-hashid/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[/hashed/, /deprecated/]
+];

--- a/test/configCases/optimization/hashed-module-ids/warnings.js
+++ b/test/configCases/optimization/hashed-module-ids/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[/hashed/, /deprecated/]
+];


### PR DESCRIPTION
Deprecate `moduleIds=hashed` in favor of `moduleIds=deterministic`.
Also remove `moduleIds=total-size`.

**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

yes

**Does this PR introduce a breaking change?**

yes

**What needs to be documented once your changes are merged?**

- `optimization.moduleIds=total-size` has been removed
- `optimization.moduleIds=hashed` is deprecated. Use `deterministic` instead.