### PR TITLE
Rename index/index2 to pre/postOrderIndices

### DIFF
--- a/lib/ChunkGroup.js
+++ b/lib/ChunkGroup.js
@@ -80,10 +80,10 @@ class ChunkGroup {
 		this.origins = [];
 		/** Indicies in top-down order */
 		/** @private @type {Map<Module, number>} */
-		this._moduleIndicies = new Map();
+		this._modulePreOrderIndices = new Map();
 		/** Indicies in bottom-up order */
 		/** @private @type {Map<Module, number>} */
-		this._moduleIndicies2 = new Map();
+		this._modulePostOrderIndices = new Map();
 	}
 
 	/**
@@ -463,7 +463,7 @@ class ChunkGroup {
 	 * @returns {void}
 	 */
 	setModulePreOrderIndex(module, index) {
-		this._moduleIndicies.set(module, index);
+		this._modulePreOrderIndices.set(module, index);
 	}
 
 	/**
@@ -472,10 +472,9 @@ class ChunkGroup {
 	 * @returns {number} index
 	 */
 	getModulePreOrderIndex(module) {
-		return this._moduleIndicies.get(module);
+		return this._modulePreOrderIndices.get(module);
 	}
 
-	// TODO rename to setModulePostOrderIndex
 	/**
 	 * Sets the bottom-up index of a module in this ChunkGroup
 	 * @param {Module} module module for which the index should be set
@@ -483,7 +482,7 @@ class ChunkGroup {
 	 * @returns {void}
 	 */
 	setModulePostOrderIndex(module, index) {
-		this._moduleIndicies2.set(module, index);
+		this._modulePostOrderIndices.set(module, index);
 	}
 
 	/**
@@ -492,7 +491,7 @@ class ChunkGroup {
 	 * @returns {number} index
 	 */
 	getModulePostOrderIndex(module) {
-		return this._moduleIndicies2.get(module);
+		return this._modulePostOrderIndices.get(module);
 	}
 
 	checkConstraints() {


### PR DESCRIPTION
Also remove useless `TODO` comment.

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

no (unless someone is using private fields)

**What needs to be documented once your changes are merged?**

nothing