### PR TITLE
AMDDefineDependencyParserPlugin processItem simplification

### DIFF
--- a/lib/dependencies/AMDDefineDependencyParserPlugin.js
+++ b/lib/dependencies/AMDDefineDependencyParserPlugin.js
@@ -57,10 +57,7 @@ class AMDDefineDependencyParserPlugin {
 					["require", "module", "exports"].includes(param.string)
 				)
 					identifiers[idx] = param.string;
-				const result = this.processItem(parser, expr, param, namedModule);
-				if (result === undefined) {
-					this.processContext(parser, expr, param);
-				}
+				this.processItem(parser, expr, param, namedModule);
 			});
 			return true;
 		} else if (param.isConstArray()) {
@@ -100,12 +97,7 @@ class AMDDefineDependencyParserPlugin {
 	}
 	processItem(parser, expr, param, namedModule) {
 		if (param.isConditional()) {
-			param.options.forEach(param => {
-				const result = this.processItem(parser, expr, param);
-				if (result === undefined) {
-					this.processContext(parser, expr, param);
-				}
-			});
+			param.options.forEach(param => this.processItem(parser, expr, param));
 			return true;
 		} else if (param.isString()) {
 			let dep, localModule;
@@ -128,6 +120,8 @@ class AMDDefineDependencyParserPlugin {
 			dep.optional = !!parser.scope.inTry;
 			parser.state.current.addDependency(dep);
 			return true;
+		} else {
+			this.processContext(parser, expr, param);
 		}
 	}
 	processContext(parser, expr, param) {


### PR DESCRIPTION
This PR introduces small refactor to `processItem` function in `AMDDefineDependencyParserPlugin`. Currently with each invoke of  `processItem` the returned value has been checked and when result was missing `processContext` has been called. To simplify code and avoid additional checks `processContext` has been moved inside `processItem`.

I'm also not sure if boolean returns from `processItem` and `processContext` are still needed but I leave them for now. Also it seems that return of `processContext` was never used in current code. If you can confirm or deny this I can prepare suitable update to this PR.

**What kind of change does this PR introduce?**

Small refactor/code cleanup.

**Did you add tests for your changes?**

No.

**Does this PR introduce a breaking change?**

No.
