### PR TITLE
DefinePlugin: reevaluate runtime values on watch mode

### DIFF
--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -21,8 +21,12 @@ class RuntimeValue {
 	}
 
 	exec(parser) {
-		for (const fileDependency of this.fileDependencies) {
-			parser.state.module.buildInfo.fileDependencies.add(fileDependency);
+		if (this.fileDependencies === true) {
+			parser.state.module.buildInfo.cacheable = false;
+		} else {
+			for (const fileDependency of this.fileDependencies) {
+				parser.state.module.buildInfo.fileDependencies.add(fileDependency);
+			}
 		}
 
 		return this.fn();

--- a/test/watchCases/plugins/define-plugin/0/index.js
+++ b/test/watchCases/plugins/define-plugin/0/index.js
@@ -13,3 +13,11 @@ it("should not update a define when dependencies list is missing", function() {
 		type: "string"
 	}));
 });
+
+it("should update always when fileDependencies is true", function() {
+	const module3 = require("./module3");
+	expect(module3).toEqual(nsObj({
+		default: WATCH_STEP,
+		type: "string"
+	}));
+});

--- a/test/watchCases/plugins/define-plugin/0/module3.js
+++ b/test/watchCases/plugins/define-plugin/0/module3.js
@@ -1,0 +1,2 @@
+export default TEST_VALUE3;
+export const type = typeof TEST_VALUE3;

--- a/test/watchCases/plugins/define-plugin/webpack.config.js
+++ b/test/watchCases/plugins/define-plugin/webpack.config.js
@@ -16,7 +16,10 @@ module.exports = {
 			),
 			TEST_VALUE2: webpack.DefinePlugin.runtimeValue(() => {
 				return JSON.stringify(fs.readFileSync(valueFile, "utf-8").trim());
-			}, [])
+			}, []),
+			TEST_VALUE3: webpack.DefinePlugin.runtimeValue(() => {
+				return JSON.stringify(fs.readFileSync(valueFile, "utf-8").trim());
+			}, true)
 		})
 	]
 };


### PR DESCRIPTION
when `fileDependecies` arg on `runtimeValue` is `true`

closes #7717

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

build related change

**Did you add tests for your changes?**

yes

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

Some info about `runtimeValue`