### PR TITLE
[ConstPlugin] fix bug introduced by evaluation of && and ||

### DIFF
--- a/lib/ConstPlugin.js
+++ b/lib/ConstPlugin.js
@@ -279,7 +279,15 @@ class ConstPlugin {
 										(expression.operator === "||" && !bool);
 
 									if (param.isBoolean() || keepRight) {
-										const dep = new ConstDependency(`${bool}`, param.range);
+										// for case like
+										//
+										//   return'development'===process.env.NODE_ENV&&'foo'
+										//
+										// we need a space before the bool to prevent result like
+										//
+										//   returnfalse&&'foo'
+										//
+										const dep = new ConstDependency(` ${bool}`, param.range);
 										dep.loc = expression.loc;
 										parser.state.current.addDependency(dep);
 									} else {

--- a/test/cases/parsing/evaluate/index.js
+++ b/test/cases/parsing/evaluate/index.js
@@ -11,12 +11,15 @@ it("should evaluate logical expression", function() {
 	var value4 = typeof require !== "function" && require("fail");
 	var value5 = "hello" && (() => "value5")();
 	var value6 = "" || (() => "value6")();
+	var value7 = (function () { return'value7'===typeof 'value7'&&'value7'})();
+
 	expect(value1).toBe("hello");
 	expect(value2).toBe(true);
 	expect(value3).toBe("");
 	expect(value4).toBe(false);
 	expect(value5).toBe("value5");
 	expect(value6).toBe("value6");
+	expect(value7).toBe(false);
 });
 
 if("shouldn't evaluate expression", function() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This PR closes #8269. When code is like 
```js
return'development'===process.env.NODE_ENV&&'foo'
```
It's valid but now it would be translated to 
```js
returnfalse&&'foo'
```

This fix changes it to
```js
return false&&'foo'
```
<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
no as it's bugfix
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
