### PR TITLE
add pack store mode for filesystem cache

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -428,9 +428,9 @@ export interface FileCacheOptions {
 	 */
 	hashAlgorithm?: string;
 	/**
-	 * Display log info. (debug: all access and errors with stack trace, info: all access, warning: only failed serialization)
+	 * Display log info. (debug: all access and errors with stack trace, verbose: all access, info: all write access, warning: only failed serialization)
 	 */
-	loglevel?: "debug" | "info" | "warning";
+	loglevel?: "debug" | "verbose" | "info" | "warning";
 	/**
 	 * Name for the cache. Different names will lead to different coexisting caches.
 	 */

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -436,9 +436,9 @@ export interface FileCacheOptions {
 	 */
 	name?: string;
 	/**
-	 * When to store data to the filesystem. (idle: Store data when compiler is idle; background: Store data in background while compiling, but doesn't block the compilation; instant: Store data when creating blocking compilation until data is stored; defaults to idle)
+	 * When to store data to the filesystem. (pack: Store data when compiler is idle in a single file, idle: Store data when compiler is idle in multiple files; background: Store data in background while compiling, but doesn't block the compilation; instant: Store data when creating blocking compilation until data is stored; defaults to idle)
 	 */
-	store?: "idle" | "background" | "instant";
+	store?: "pack" | "idle" | "background" | "instant";
 	/**
 	 * Filesystem caching
 	 */

--- a/lib/cache/FileCachePlugin.js
+++ b/lib/cache/FileCachePlugin.js
@@ -122,7 +122,7 @@ class FileCachePlugin {
 		const log = this.options.loglevel
 			? { debug: 4, verbose: 3, info: 2, warning: 1 }[this.options.loglevel]
 			: 0;
-		const store = this.options.store || "idle";
+		const store = this.options.store || "pack";
 
 		let pendingPromiseFactories = new Map();
 		const toHash = str => {

--- a/lib/cache/FileCachePlugin.js
+++ b/lib/cache/FileCachePlugin.js
@@ -173,7 +173,7 @@ class FileCachePlugin {
 			(identifier, etag, data) => {
 				const entry = {
 					identifier,
-					data: store === "pack" ? data : () => data,
+					data: etag ? () => data : data,
 					etag,
 					version
 				};

--- a/lib/cache/FileCachePlugin.js
+++ b/lib/cache/FileCachePlugin.js
@@ -305,7 +305,7 @@ class FileCachePlugin {
 											'Caching failed for pack, because content is flagged as not serializable. Use store: "idle" instead.'
 										);
 									}
-									return;
+									return resolve();
 								}
 								fs.unlink(`${cacheDirectory}.pack`, err => {
 									fs.rename(

--- a/lib/cache/FileCachePlugin.js
+++ b/lib/cache/FileCachePlugin.js
@@ -5,14 +5,86 @@
 
 "use strict";
 
+const fs = require("fs");
 const path = require("path");
 const createHash = require("../util/createHash");
+const makeSerializable = require("../util/makeSerializable");
 const serializer = require("../util/serializer");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../../declarations/WebpackOptions").FileCacheOptions} FileCacheOptions */
 /** @typedef {import("../Compiler")} Compiler */
 /** @typedef {import("../Module")} Module */
+
+class Pack {
+	constructor(version) {
+		this.version = version;
+		this.content = new Map();
+		this.lastAccess = new Map();
+		this.used = new Set();
+		this.invalid = false;
+	}
+
+	get(relativeFilename) {
+		this.used.add(relativeFilename);
+		return this.content.get(relativeFilename);
+	}
+
+	set(relativeFilename, data) {
+		this.used.add(relativeFilename);
+		this.invalid = true;
+		return this.content.set(relativeFilename, data);
+	}
+
+	collectGarbage(maxAge) {
+		this._updateLastAccess();
+		const now = Date.now();
+		for (const [relativeFilename, lastAccess] of this.lastAccess) {
+			if (now - lastAccess > maxAge) {
+				this.lastAccess.delete(relativeFilename);
+				this.content.delete(relativeFilename);
+			}
+		}
+	}
+
+	_updateLastAccess() {
+		const now = Date.now();
+		for (const relativeFilename of this.used) {
+			this.lastAccess.set(relativeFilename, now);
+		}
+		this.used.clear();
+	}
+
+	serialize({ write, snapshot, rollback }) {
+		this._updateLastAccess();
+		write(this.version);
+		for (const [relativeFilename, data] of this.content) {
+			const s = snapshot();
+			try {
+				write(relativeFilename);
+				write(data);
+			} catch (err) {
+				rollback(s);
+				continue;
+			}
+		}
+		write(null);
+		write(this.lastAccess);
+	}
+
+	deserialize({ read }) {
+		this.version = read();
+		this.content = new Map();
+		let relativeFilename = read();
+		while (relativeFilename !== null) {
+			this.content.set(relativeFilename, read());
+			relativeFilename = read();
+		}
+		this.lastAccess = read();
+	}
+}
+
+makeSerializable(Pack, "webpack/lib/cache/FileCachePlugin", "Pack");
 
 const memorize = fn => {
 	let result = undefined;
@@ -59,33 +131,82 @@ class FileCachePlugin {
 			const digest = hash.digest("hex");
 			return `${digest.slice(0, 2)}/${digest.slice(2)}`;
 		};
+		let packPromise;
+		if (store === "pack") {
+			packPromise = serializer
+				.deserializeFromFile(`${cacheDirectory}.pack`)
+				.then(cacheEntry => {
+					if (cacheEntry) {
+						if (!(cacheEntry instanceof Pack)) {
+							if (log >= 2) {
+								console.warn(
+									`Restored pack from ${cacheDirectory}.pack, but is not a Pack.`
+								);
+							}
+							return new Pack(version);
+						}
+						if (cacheEntry.version !== version) {
+							if (log >= 2) {
+								console.warn(
+									`Restored pack from ${cacheDirectory}.pack, but version doesn't match.`
+								);
+							}
+							return new Pack(version);
+						}
+						return cacheEntry;
+					}
+					return new Pack(version);
+				})
+				.catch(err => {
+					if (log >= 1 && err && err.code !== "ENOENT") {
+						console.warn(
+							`Restoring pack failed from ${cacheDirectory}.pack: ${
+								log >= 3 ? err.stack : err
+							}`
+						);
+					}
+					return new Pack(version);
+				});
+		}
 		compiler.cache.hooks.store.tapPromise(
 			"FileCachePlugin",
 			(identifier, etag, data) => {
-				const entry = { identifier, data: () => data, etag, version };
-				const filename = path.join(
-					cacheDirectory,
-					toHash(identifier) + ".data"
-				);
+				const entry = {
+					identifier,
+					data: store === "pack" ? data : () => data,
+					etag,
+					version
+				};
+				const relativeFilename = toHash(identifier) + ".data";
+				const filename = path.join(cacheDirectory, relativeFilename);
 				memoryCache.set(filename, entry);
-				const promiseFactory = () =>
-					serializer
-						.serializeToFile(entry, filename)
-						.then(() => {
-							if (log >= 2) {
-								console.warn(`Cached ${identifier} to ${filename}.`);
-							}
-						})
-						.catch(err => {
-							if (log >= 1) {
-								console.warn(
-									`Caching failed for ${identifier}: ${
-										log >= 3 ? err.stack : err
-									}`
-								);
-							}
-						});
-				if (store === "instant") {
+				const promiseFactory =
+					store === "pack"
+						? () =>
+								packPromise.then(pack => {
+									if (log >= 2) {
+										console.warn(`Cached ${identifier} to pack.`);
+									}
+									pack.set(relativeFilename, entry);
+								})
+						: () =>
+								serializer
+									.serializeToFile(entry, filename)
+									.then(() => {
+										if (log >= 2) {
+											console.warn(`Cached ${identifier} to ${filename}.`);
+										}
+									})
+									.catch(err => {
+										if (log >= 1) {
+											console.warn(
+												`Caching failed for ${identifier}: ${
+													log >= 3 ? err.stack : err
+												}`
+											);
+										}
+									});
+				if (store === "instant" || store === "pack") {
 					return promiseFactory();
 				} else if (store === "idle") {
 					pendingPromiseFactories.set(filename, promiseFactory);
@@ -100,32 +221,34 @@ class FileCachePlugin {
 		compiler.cache.hooks.get.tapPromise(
 			"FileCachePlugin",
 			(identifier, etag) => {
-				const filename = path.join(
-					cacheDirectory,
-					toHash(identifier) + ".data"
-				);
+				const relativeFilename = toHash(identifier) + ".data";
+				const filename = path.join(cacheDirectory, relativeFilename);
+				const logMessage = store === "pack" ? "pack" : filename;
 				const memory = memoryCache.get(filename);
 				if (memory !== undefined) {
 					return Promise.resolve(
-						memory.etag === etag && memory.version === version
-							? memory.data()
-							: undefined
+						memory.etag !== etag || memory.version !== version
+							? undefined
+							: typeof memory.data === "function"
+								? memory.data()
+								: memory.data
 					);
 				}
-				return serializer.deserializeFromFile(filename).then(
+				const cacheEntryPromise =
+					store === "pack"
+						? packPromise.then(pack => pack.get(relativeFilename))
+						: serializer.deserializeFromFile(filename);
+				return cacheEntryPromise.then(
 					cacheEntry => {
-						cacheEntry = {
-							identifier: cacheEntry.identifier,
-							etag: cacheEntry.etag,
-							version: cacheEntry.version,
-							data: memorize(cacheEntry.data)
-						};
+						if (cacheEntry === undefined) return;
+						if (typeof cacheEntry.data === "function")
+							cacheEntry.data = memorize(cacheEntry.data);
 						memoryCache.set(filename, cacheEntry);
 						if (cacheEntry === undefined) return;
 						if (cacheEntry.identifier !== identifier) {
 							if (log >= 2) {
 								console.warn(
-									`Restored ${identifier} from ${filename}, but identifier doesn't match.`
+									`Restored ${identifier} from ${logMessage}, but identifier doesn't match.`
 								);
 							}
 							return;
@@ -133,7 +256,7 @@ class FileCachePlugin {
 						if (cacheEntry.etag !== etag) {
 							if (log >= 2) {
 								console.warn(
-									`Restored ${etag} from ${filename}, but etag doesn't match.`
+									`Restored ${identifier} from ${logMessage}, but etag doesn't match.`
 								);
 							}
 							return;
@@ -141,20 +264,21 @@ class FileCachePlugin {
 						if (cacheEntry.version !== version) {
 							if (log >= 2) {
 								console.warn(
-									`Restored ${version} from ${filename}, but version doesn't match.`
+									`Restored ${identifier} from ${logMessage}, but version doesn't match.`
 								);
 							}
 							return;
 						}
 						if (log >= 2) {
-							console.warn(`Restored ${identifier} from ${filename}.`);
+							console.warn(`Restored ${identifier} from ${logMessage}.`);
 						}
-						return cacheEntry.data();
+						if (typeof cacheEntry.data === "function") return cacheEntry.data();
+						return cacheEntry.data;
 					},
 					err => {
 						if (log >= 1 && err && err.code !== "ENOENT") {
 							console.warn(
-								`Restoring failed for ${identifier} from ${filename}: ${
+								`Restoring failed for ${identifier} from ${logMessage}: ${
 									log >= 3 ? err.stack : err
 								}`
 							);
@@ -163,6 +287,55 @@ class FileCachePlugin {
 				);
 			}
 		);
+		const serializePack = () => {
+			packPromise = packPromise.then(pack => {
+				if (!pack.invalid) return pack;
+				if (log >= 3) {
+					console.warn(`Storing pack...`);
+				}
+				pack.collectGarbage(1000 * 60 * 60 * 24 * 2);
+				return serializer
+					.serializeToFile(pack, `${cacheDirectory}.pack~`)
+					.then(
+						result =>
+							new Promise((resolve, reject) => {
+								if (!result) {
+									if (log >= 1) {
+										console.warn(
+											'Caching failed for pack, because content is flagged as not serializable. Use store: "idle" instead.'
+										);
+									}
+									return;
+								}
+								fs.unlink(`${cacheDirectory}.pack`, err => {
+									fs.rename(
+										`${cacheDirectory}.pack~`,
+										`${cacheDirectory}.pack`,
+										err => {
+											if (err) return reject(err);
+											if (log >= 3) {
+												console.warn(`Stored pack`);
+											}
+											resolve();
+										}
+									);
+								});
+							})
+					)
+					.then(() => {
+						return serializer.deserializeFromFile(`${cacheDirectory}.pack`);
+					})
+					.catch(err => {
+						if (log >= 1) {
+							console.warn(
+								`Caching failed for pack: ${log >= 3 ? err.stack : err}`
+							);
+						}
+						return new Pack(version);
+					});
+			});
+			return packPromise;
+		};
 		compiler.cache.hooks.shutdown.tapPromise("FileCachePlugin", () => {
 			isIdle = false;
 			const promises = Array.from(pendingPromiseFactories.values()).map(fn =>
@@ -170,7 +343,11 @@ class FileCachePlugin {
 			);
 			pendingPromiseFactories.clear();
 			if (currentIdlePromise !== undefined) promises.push(currentIdlePromise);
-			return Promise.all(promises);
+			const promise = Promise.all(promises);
+			if (store === "pack") {
+				return promise.then(serializePack);
+			}
+			return promise;
 		});
 
 		let currentIdlePromise;
@@ -193,6 +370,10 @@ class FileCachePlugin {
 		};
 		compiler.cache.hooks.beginIdle.tap("FileCachePlugin", () => {
 			isIdle = true;
+			if (store === "pack") {
+				pendingPromiseFactories.delete("pack");
+				pendingPromiseFactories.set("pack", serializePack);
+			}
 			Promise.resolve().then(processIdleTasks);
 		});
 		compiler.cache.hooks.endIdle.tap("FileCachePlugin", () => {

--- a/lib/cache/FileCachePlugin.js
+++ b/lib/cache/FileCachePlugin.js
@@ -120,7 +120,7 @@ class FileCachePlugin {
 		const hashAlgorithm = this.options.hashAlgorithm || "md4";
 		const version = this.options.version || "";
 		const log = this.options.loglevel
-			? { debug: 3, info: 2, warning: 1 }[this.options.loglevel]
+			? { debug: 4, verbose: 3, info: 2, warning: 1 }[this.options.loglevel]
 			: 0;
 		const store = this.options.store || "idle";
 
@@ -138,7 +138,7 @@ class FileCachePlugin {
 				.then(cacheEntry => {
 					if (cacheEntry) {
 						if (!(cacheEntry instanceof Pack)) {
-							if (log >= 2) {
+							if (log >= 3) {
 								console.warn(
 									`Restored pack from ${cacheDirectory}.pack, but is not a Pack.`
 								);
@@ -146,7 +146,7 @@ class FileCachePlugin {
 							return new Pack(version);
 						}
 						if (cacheEntry.version !== version) {
-							if (log >= 2) {
+							if (log >= 3) {
 								console.warn(
 									`Restored pack from ${cacheDirectory}.pack, but version doesn't match.`
 								);
@@ -161,7 +161,7 @@ class FileCachePlugin {
 					if (log >= 1 && err && err.code !== "ENOENT") {
 						console.warn(
 							`Restoring pack failed from ${cacheDirectory}.pack: ${
-								log >= 3 ? err.stack : err
+								log >= 4 ? err.stack : err
 							}`
 						);
 					}
@@ -246,7 +246,7 @@ class FileCachePlugin {
 						memoryCache.set(filename, cacheEntry);
 						if (cacheEntry === undefined) return;
 						if (cacheEntry.identifier !== identifier) {
-							if (log >= 2) {
+							if (log >= 3) {
 								console.warn(
 									`Restored ${identifier} from ${logMessage}, but identifier doesn't match.`
 								);
@@ -254,7 +254,7 @@ class FileCachePlugin {
 							return;
 						}
 						if (cacheEntry.etag !== etag) {
-							if (log >= 2) {
+							if (log >= 3) {
 								console.warn(
 									`Restored ${identifier} from ${logMessage}, but etag doesn't match.`
 								);
@@ -262,14 +262,14 @@ class FileCachePlugin {
 							return;
 						}
 						if (cacheEntry.version !== version) {
-							if (log >= 2) {
+							if (log >= 3) {
 								console.warn(
 									`Restored ${identifier} from ${logMessage}, but version doesn't match.`
 								);
 							}
 							return;
 						}
-						if (log >= 2) {
+						if (log >= 3) {
 							console.warn(`Restored ${identifier} from ${logMessage}.`);
 						}
 						if (typeof cacheEntry.data === "function") return cacheEntry.data();
@@ -279,7 +279,7 @@ class FileCachePlugin {
 						if (log >= 1 && err && err.code !== "ENOENT") {
 							console.warn(
 								`Restoring failed for ${identifier} from ${logMessage}: ${
-									log >= 3 ? err.stack : err
+									log >= 4 ? err.stack : err
 								}`
 							);
 						}
@@ -328,7 +328,7 @@ class FileCachePlugin {
 					.catch(err => {
 						if (log >= 1) {
 							console.warn(
-								`Caching failed for pack: ${log >= 3 ? err.stack : err}`
+								`Caching failed for pack: ${log >= 4 ? err.stack : err}`
 							);
 						}
 						return new Pack(version);

--- a/lib/serialization/FileMiddleware.js
+++ b/lib/serialization/FileMiddleware.js
@@ -172,7 +172,7 @@ class FileMiddleware extends SerializerMiddleware {
 					if (err) return reject(err);
 					fs.writeFile(filename, Buffer.concat(buffers), err => {
 						if (err) return reject(err);
-						resolve();
+						resolve(true);
 					});
 				});
 			});

--- a/lib/serialization/MapObjectSerializer.js
+++ b/lib/serialization/MapObjectSerializer.js
@@ -7,16 +7,22 @@
 class MapObjectSerializer {
 	serialize(obj, { write }) {
 		write(obj.size);
-		for (const [key, value] of obj) {
+		for (const key of obj.keys()) {
 			write(key);
+		}
+		for (const value of obj.values()) {
 			write(value);
 		}
 	}
 	deserialize({ read }) {
 		let size = read();
 		const map = new Map();
+		const keys = [];
 		for (let i = 0; i < size; i++) {
-			map.set(read(), read());
+			keys.push(read());
+		}
+		for (let i = 0; i < size; i++) {
+			map.set(keys[i], read());
 		}
 		return map;
 	}

--- a/lib/serialization/ObjectMiddleware.js
+++ b/lib/serialization/ObjectMiddleware.js
@@ -51,6 +51,24 @@ Technically any value can be used.
  * @property {function(ObjectDeserializerContext): any} deserialize
  */
 
+const setSetSize = (set, size) => {
+	let i = 0;
+	for (const item of set) {
+		if (i++ >= size) {
+			set.delete(item);
+		}
+	}
+};
+
+const setMapSize = (map, size) => {
+	let i = 0;
+	for (const item of map.keys()) {
+		if (i++ >= size) {
+			map.delete(item);
+		}
+	}
+};
+
 const ESCAPE = null;
 const ESCAPE_ESCAPE_VALUE = null;
 const ESCAPE_END_OBJECT = true;
@@ -233,7 +251,11 @@ class ObjectMiddleware extends SerializerMiddleware {
 					throw new Error(
 						`Circular references can't be serialized (${Array.from(cycleStack)
 							.concat([item])
-							.map(obj => obj.constructor.name)
+							.map(obj => {
+								if (obj.constructor === Object)
+									return `Object { ${Object.keys(obj).join(", ")} }`;
+								return obj.constructor.name;
+							})
 							.join(" -> ")})`
 					);
 				}
@@ -257,6 +279,24 @@ class ObjectMiddleware extends SerializerMiddleware {
 				serializer.serialize(item, {
 					write(value) {
 						process(value);
+					},
+					snapshot() {
+						return {
+							length: result.length,
+							cycleStackSize: cycleStack.size,
+							referenceableSize: referenceable.size,
+							currentPos,
+							objectTypeLookupSize: objectTypeLookup.size,
+							currentPosTypeLookup
+						};
+					},
+					rollback(snapshot) {
+						result.length = snapshot.length;
+						setSetSize(cycleStack, snapshot.cycleStackSize);
+						setMapSize(referenceable, snapshot.referenceableSize);
+						currentPos = snapshot.currentPos;
+						setMapSize(objectTypeLookup, snapshot.objectTypeLookupSize);
+						currentPosTypeLookup = snapshot.currentPosTypeLookup;
 					}
 				});
 

--- a/lib/util/makeSerializable.js
+++ b/lib/util/makeSerializable.js
@@ -49,7 +49,11 @@ class ClassSerializer {
 		if (!this.hash) this._createHash();
 		const hash = context.read();
 		if (this.hash !== hash)
-			throw new Error(`Version missmatch for ${this.Constructor.name}`);
+			throw new Error(
+				`Version mismatch for ${this.Constructor.name}: ${hash} !== ${
+					this.hash
+				}`
+			);
 		if (typeof this.Constructor.deserialize === "function") {
 			return this.Constructor.deserialize(context);
 		}

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -177,8 +177,8 @@
           "type": "string"
         },
         "store": {
-          "description": "When to store data to the filesystem. (idle: Store data when compiler is idle; background: Store data in background while compiling, but doesn't block the compilation; instant: Store data when creating blocking compilation until data is stored; defaults to idle)",
-          "enum": ["idle", "background", "instant"]
+          "description": "When to store data to the filesystem. (pack: Store data when compiler is idle in a single file, idle: Store data when compiler is idle in multiple files; background: Store data in background while compiling, but doesn't block the compilation; instant: Store data when creating blocking compilation until data is stored; defaults to idle)",
+          "enum": ["pack", "idle", "background", "instant"]
         },
         "type": {
           "description": "Filesystem caching",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -169,8 +169,8 @@
           "type": "string"
         },
         "loglevel": {
-          "description": "Display log info. (debug: all access and errors with stack trace, info: all access, warning: only failed serialization)",
-          "enum": ["debug", "info", "warning"]
+          "description": "Display log info. (debug: all access and errors with stack trace, verbose: all access, info: all write access, warning: only failed serialization)",
+          "enum": ["debug", "verbose", "info", "warning"]
         },
         "name": {
           "description": "Name for the cache. Different names will lead to different coexisting caches.",

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -187,7 +187,11 @@ const describeCases = config => {
 								})
 							};
 							beforeAll(done => {
+								FileCachePlugin.purgeMemoryCache();
 								rimraf(cacheDirectory, done);
+							});
+							afterAll(() => {
+								FileCachePlugin.purgeMemoryCache();
 							});
 							if (config.cache) {
 								it(testName + " should pre-compile", done => {

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -104,12 +104,15 @@ const describeCases = config => {
 								performance: {
 									hints: false
 								},
-								cache: {
-									type: "filesystem",
-									cacheDirectory: cacheDirectory,
-									loglevel: "warning",
-									store: "instant"
-								},
+								cache:
+									config.cache &&
+									Object.assign(
+										{
+											loglevel: "warning",
+											cacheDirectory
+										},
+										config.cache
+									),
 								output: {
 									pathinfo: true,
 									path: outputDirectory,
@@ -186,18 +189,22 @@ const describeCases = config => {
 							beforeAll(done => {
 								rimraf(cacheDirectory, done);
 							});
-							it(testName + " should pre-compile", done => {
-								FileCachePlugin.purgeMemoryCache();
-								webpack(options, err => {
-									if (err) return done(err);
+							if (config.cache) {
+								it(testName + " should pre-compile", done => {
 									FileCachePlugin.purgeMemoryCache();
-									done();
+									const compiler = webpack(options, err => {
+										if (err) return done(err);
+										compiler.close(() => {
+											FileCachePlugin.purgeMemoryCache();
+											done();
+										});
+									});
 								});
-							});
+							}
 							it(
 								testName + " should compile",
 								done => {
-									webpack(options, (err, stats) => {
+									const compiler = webpack(options, (err, stats) => {
 										if (err) return done(err);
 										const statOptions = Stats.presetToOptions("verbose");
 										statOptions.colors = false;
@@ -263,7 +270,10 @@ const describeCases = config => {
 										if (getNumberOfTests() === 0)
 											return done(new Error("No tests exported by test case"));
 
-										done();
+										compiler.close(err => {
+											if (err) return done(err);
+											done();
+										});
 									});
 								},
 								60000

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -194,12 +194,20 @@ const describeCases = config => {
 								FileCachePlugin.purgeMemoryCache();
 							});
 							if (config.cache) {
-								it(testName + " should pre-compile", done => {
+								it(`${testName} should pre-compile to fill disk cache`, done => {
 									FileCachePlugin.purgeMemoryCache();
 									const compiler = webpack(options, err => {
 										if (err) return done(err);
 										compiler.close(() => {
-											FileCachePlugin.purgeMemoryCache();
+											done();
+										});
+									});
+								});
+								it(`${testName} should pre-compile to fill memory cache`, done => {
+									FileCachePlugin.purgeMemoryCache();
+									const compiler = webpack(options, err => {
+										if (err) return done(err);
+										compiler.close(() => {
 											done();
 										});
 									});

--- a/test/TestCasesCacheInstant.test.js
+++ b/test/TestCasesCacheInstant.test.js
@@ -1,0 +1,11 @@
+const { describeCases } = require("./TestCases.template");
+
+describe("TestCases", () => {
+	describeCases({
+		name: "cache instant",
+		cache: {
+			type: "filesystem",
+			store: "instant"
+		}
+	});
+});

--- a/test/TestCasesCachePack.test.js
+++ b/test/TestCasesCachePack.test.js
@@ -1,0 +1,11 @@
+const { describeCases } = require("./TestCases.template");
+
+describe("TestCases", () => {
+	describeCases({
+		name: "cache pack",
+		cache: {
+			type: "filesystem",
+			store: "pack"
+		}
+	});
+});

--- a/test/setupTestFramework.js
+++ b/test/setupTestFramework.js
@@ -50,3 +50,8 @@ if (process.env.ALTERNATIVE_SORT) {
 		return this;
 	};
 }
+
+// Workaround for a memory leak in wabt
+// It leaks an Error object on construction
+// so it leaks the whole stack trace
+require("wast-loader");


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
`cache.store: "pack"` was added. This mode stores all cache entries in a single file, including garbage collection for old entries.

* 😄 Less filesystem access
* 😄 Faster, as all cache entries are deserialized at once
* 😄 Smaller data, as deduplication happens between cache entries
* 😄 Handles small cache entries have less overhead compared to separate files
  * Especially relevant when the resolver cache is added
* 😄 Has Garbage Collection (entries are removed after 2 days unused)
  * Need to add option for that
* 😢 Unnecessary cache entries are deserialized and serialized until garbage collected
  * This is relevant when heavy changes made to the application and will reduce performance for 2 days
* 😢 Complete cache file has to be rewritten when single entry has changed
* 😢 Complete cache file has to be read when single entry is accessed
  * Normal usage access 99% of cache anyway, so less important

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
