### PR TITLE
Set deterministic module ids in prod by default

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -228,7 +228,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 			isProductionLikeMode(options)
 		);
 		this.set("optimization.moduleIds", "make", options => {
-			if (isProductionLikeMode(options)) return "size";
+			if (isProductionLikeMode(options)) return "deterministic";
 			if (options.mode === "development") return "named";
 			return "natural";
 		});

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -86,7 +86,7 @@ describe("Compiler", () => {
 			expect(Object.keys(files)).toEqual(["/main.js"]);
 			const bundle = files["/main.js"];
 			expect(bundle).toMatch("function __webpack_require__(");
-			expect(bundle).toMatch(/__webpack_require__\(\/\*! \.\/a \*\/ \d\);/);
+			expect(bundle).toMatch(/__webpack_require__\(\/\*! \.\/a \*\/ \w+\);/);
 			expect(bundle).toMatch("./c.js");
 			expect(bundle).toMatch("./a.js");
 			expect(bundle).toMatch("This is a");
@@ -146,9 +146,9 @@ describe("Compiler", () => {
 	it("should compile a file with multiple chunks", done => {
 		compile("./chunks", {}, (stats, files) => {
 			expect(stats.chunks).toHaveLength(2);
-			expect(Object.keys(files)).toEqual(["/main.js", "/1.js"]);
+			expect(Object.keys(files)).toEqual(["/main.js", "/0.js"]);
 			const bundle = files["/main.js"];
-			const chunk = files["/1.js"];
+			const chunk = files["/0.js"];
 			expect(bundle).toMatch("function __webpack_require__(");
 			expect(bundle).toMatch("__webpack_require__(/*! ./b */");
 			expect(chunk).not.toMatch("__webpack_require__(/* ./b */");

--- a/test/__snapshots__/ConfigTestCases.test.js.snap
+++ b/test/__snapshots__/ConfigTestCases.test.js.snap
@@ -14,16 +14,16 @@ exports[`ConfigTestCases records issue-2991 exported tests should write relative
   },
   \\"modules\\": {
     \\"byIdentifier\\": {
-      \\"external \\\\\\"fs\\\\\\"\\": 2,
-      \\"external \\\\\\"path\\\\\\"\\": 3,
-      \\"ignored  pkgs/somepackage/foo\\": 1,
-      \\"test.js\\": 0
+      \\"external \\\\\\"fs\\\\\\"\\": 188,
+      \\"external \\\\\\"path\\\\\\"\\": 158,
+      \\"ignored  pkgs/somepackage/foo\\": 569,
+      \\"test.js\\": 316
     },
     \\"usedIds\\": [
-      0,
-      1,
-      2,
-      3
+      158,
+      188,
+      316,
+      569
     ]
   }
 }"
@@ -43,20 +43,20 @@ exports[`ConfigTestCases records issue-7339 exported tests should write relative
   },
   \\"modules\\": {
     \\"byIdentifier\\": {
-      \\"dependencies sync /^\\\\\\\\.\\\\\\\\/.*$/\\": 3,
-      \\"dependencies/bar.js\\": 0,
-      \\"dependencies/foo.js\\": 1,
-      \\"external \\\\\\"fs\\\\\\"\\": 4,
-      \\"external \\\\\\"path\\\\\\"\\": 5,
-      \\"test.js\\": 2
+      \\"dependencies sync /^\\\\\\\\.\\\\\\\\/.*$/\\": 913,
+      \\"dependencies/bar.js\\": 853,
+      \\"dependencies/foo.js\\": 494,
+      \\"external \\\\\\"fs\\\\\\"\\": 188,
+      \\"external \\\\\\"path\\\\\\"\\": 158,
+      \\"test.js\\": 316
     },
     \\"usedIds\\": [
-      0,
-      1,
-      2,
-      3,
-      4,
-      5
+      158,
+      188,
+      316,
+      494,
+      853,
+      913
     ]
   }
 }"

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1519,23 +1519,23 @@ Entrypoint entry = entry.js
 `;
 
 exports[`StatsTestCases should print correct stats for no-emit-on-errors-plugin-with-child-error 1`] = `
-"Hash: f4c3d60da082a270faa2
+"Hash: d34416d2e6d74425b231
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset      Size  Chunks  Chunk Names
-bundle.js  3.57 KiB       0  main
- child.js  3.57 KiB          
+bundle.js  3.58 KiB       0  main
+ child.js  3.58 KiB          
 Entrypoint main = bundle.js
-[0] ./index.js 0 bytes {0} [built]
+[967] ./index.js 0 bytes {0} [built]
 
 WARNING in configuration
 The 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
 You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/concepts/mode/
 Child child:
        Asset      Size  Chunks  Chunk Names
-    child.js  3.57 KiB       0  child
+    child.js  3.58 KiB       0  child
     Entrypoint child = child.js
-    [0] ./index.js 0 bytes {0} [built]
+    [967] ./index.js 0 bytes {0} [built]
     
     ERROR in forced error"
 `;


### PR DESCRIPTION
closes #8268
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

build related change

**Did you add tests for your changes?**

just updated snapshots

**Does this PR introduce a breaking change?**

no (?)

**What needs to be documented once your changes are merged?**

about `optimization.moduleIds`
