### PR TITLE
Expose a method to reset NormalModuleFactory's dependencyCache

### DIFF
--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -56,7 +56,7 @@ const identToLoaderRequest = resultString => {
 	}
 };
 
-const dependencyCache = new WeakMap();
+let dependencyCache = new WeakMap();
 
 class NormalModuleFactory extends Tapable {
 	constructor(context, resolverFactory, options) {
@@ -520,6 +520,10 @@ class NormalModuleFactory extends Tapable {
 			type,
 			resolveOptions || EMPTY_RESOLVE_OPTIONS
 		);
+	}
+
+	purgeDependencyCache() {
+		dependencyCache = new WeakMap();
 	}
 }
 


### PR DESCRIPTION
Motivation: #8277

**What kind of change does this PR introduce?**
Exposes internal

**Did you add tests for your changes?**
Not yet.

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
Possibly indicate here:
- https://github.com/webpack/docs/wiki/plugins#the-normalmodulefactory
- https://webpack.js.org/api/compiler-hooks/#contextmodulefactory
but documentation around methods is sparse / non-existent.