### PR TITLE
add module argument to DefinePlugin.runtimeValue functions

### DIFF
--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -29,7 +29,7 @@ class RuntimeValue {
 			}
 		}
 
-		return this.fn();
+		return this.fn(parser.state.module);
 	}
 }
 

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -29,7 +29,7 @@ class RuntimeValue {
 			}
 		}
 
-		return this.fn(parser.state.module);
+		return this.fn({ module: parser.state.module });
 	}
 }
 

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -114,3 +114,7 @@ it("should follow renamings in var (issue 5215)", function() {
 	expect(TEST).toBe("test");
 	expect(DEFINED_NESTED_KEY).toBe(5);
 });
+
+it("should check that runtimeValue callback argument is a module", function() {
+	expect(RUNTIMEVALUE_CALLBACK_ARGUMENT_IS_A_MODULE).toEqual(true);
+});

--- a/test/configCases/plugins/define-plugin/webpack.config.js
+++ b/test/configCases/plugins/define-plugin/webpack.config.js
@@ -26,7 +26,10 @@ module.exports = {
 			"typeof wurst": "typeof suppe",
 			"typeof suppe": "typeof wurst",
 			wurst: "suppe",
-			suppe: "wurst"
+			suppe: "wurst",
+			RUNTIMEVALUE_CALLBACK_ARGUMENT_IS_A_MODULE: DefinePlugin.runtimeValue(function(currentModule) {
+				return typeof currentModule === 'object';
+			})
 		})
 	]
 };

--- a/test/configCases/plugins/define-plugin/webpack.config.js
+++ b/test/configCases/plugins/define-plugin/webpack.config.js
@@ -1,4 +1,5 @@
 var DefinePlugin = require("../../../../lib/DefinePlugin");
+const Module = require("../../../../lib/Module");
 module.exports = {
 	plugins: [
 		new DefinePlugin({
@@ -28,8 +29,8 @@ module.exports = {
 			wurst: "suppe",
 			suppe: "wurst",
 			RUNTIMEVALUE_CALLBACK_ARGUMENT_IS_A_MODULE: DefinePlugin.runtimeValue(
-				function(currentModule) {
-					return typeof currentModule === "object";
+				function({ module }) {
+					return module instanceof Module;
 				}
 			)
 		})

--- a/test/configCases/plugins/define-plugin/webpack.config.js
+++ b/test/configCases/plugins/define-plugin/webpack.config.js
@@ -27,9 +27,11 @@ module.exports = {
 			"typeof suppe": "typeof wurst",
 			wurst: "suppe",
 			suppe: "wurst",
-			RUNTIMEVALUE_CALLBACK_ARGUMENT_IS_A_MODULE: DefinePlugin.runtimeValue(function(currentModule) {
-				return typeof currentModule === 'object';
-			})
+			RUNTIMEVALUE_CALLBACK_ARGUMENT_IS_A_MODULE: DefinePlugin.runtimeValue(
+				function(currentModule) {
+					return typeof currentModule === "object";
+				}
+			)
 		})
 	]
 };


### PR DESCRIPTION
PR #6793 added the ability for DefinePlugin to use function that return values.
This PR just add the ability to these functions to access the module being parsed (see #8301).
eg.
```
  webpack.DefinePlugin.runtimeValue(module => module.resource ....)
```

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
issue #8301

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
It adds a `module` an argument to fct in DefinePlugin.runtimeValue(fct)

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
About the additional `module` argument

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
