### PR TITLE
fix(Compiler): Promisifed webpack returns errors as a return value

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -203,7 +203,6 @@ class Compiler extends Tapable {
 
 	run(callback) {
 		if (this.running) return callback(new ConcurrentCompilationError());
-
 		const finalCallback = (err, stats) => {
 			this.running = false;
 
@@ -213,10 +212,14 @@ class Compiler extends Tapable {
 		const startTime = Date.now();
 
 		this.running = true;
-
 		const onCompiled = (err, compilation) => {
+			const onCompilationErrors = compilation => {
+				if (compilation.errors.length && compilation.bail && !this.watchMode) {
+					finalCallback(compilation.errors[0]);
+				}
+			};
 			if (err) return finalCallback(err);
-
+			onCompilationErrors(compilation);
 			if (this.hooks.shouldEmit.call(compilation) === false) {
 				const stats = new Stats(compilation);
 				stats.startTime = startTime;
@@ -230,7 +233,6 @@ class Compiler extends Tapable {
 
 			this.emitAssets(compilation, err => {
 				if (err) return finalCallback(err);
-
 				if (compilation.hooks.needAdditionalPass.call()) {
 					compilation.needAdditionalPass = true;
 
@@ -250,7 +252,6 @@ class Compiler extends Tapable {
 
 				this.emitRecords(err => {
 					if (err) return finalCallback(err);
-
 					const stats = new Stats(compilation);
 					stats.startTime = startTime;
 					stats.endTime = Date.now();
@@ -264,7 +265,6 @@ class Compiler extends Tapable {
 
 		this.hooks.beforeRun.callAsync(this, err => {
 			if (err) return finalCallback(err);
-
 			this.hooks.run.callAsync(this, err => {
 				if (err) return finalCallback(err);
 
@@ -280,7 +280,6 @@ class Compiler extends Tapable {
 	runAsChild(callback) {
 		this.compile((err, compilation) => {
 			if (err) return callback(err);
-
 			this.parentCompilation.children.push(compilation);
 			for (const name of Object.keys(compilation.assets)) {
 				this.parentCompilation.assets[name] = compilation.assets[name];
@@ -537,7 +536,6 @@ class Compiler extends Tapable {
 			this.hooks.compile.call(params);
 
 			const compilation = this.newCompilation(params);
-
 			this.hooks.make.callAsync(compilation, err => {
 				if (err) return callback(err);
 
@@ -548,7 +546,6 @@ class Compiler extends Tapable {
 
 					this.hooks.afterCompile.callAsync(compilation, err => {
 						if (err) return callback(err);
-
 						return callback(null, compilation);
 					});
 				});

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -4,6 +4,7 @@
 const path = require("path");
 
 const webpack = require("../");
+const Stats = require("../lib/Stats");
 const WebpackOptionsDefaulter = require("../lib/WebpackOptionsDefaulter");
 const MemoryFs = require("memory-fs");
 
@@ -258,6 +259,76 @@ describe("Compiler", () => {
 			done();
 		});
 	});
+	/* eslint-disable node/no-unsupported-features */
+	/* eslint-disable node/no-unsupported-features/es-syntax */
+	it("should bubble up errors when wrapped in a promise and bail is true", async done => {
+		try {
+			const createCompiler = options => {
+				return new Promise((resolve, reject) => {
+					const c = webpack(options);
+					c.run((err, stats) => {
+						if (err) {
+							reject(err);
+						}
+						if (stats !== undefined && "errors" in stats) {
+							reject(err);
+						} else {
+							resolve(stats);
+						}
+					});
+				});
+			};
+			const compiler = await createCompiler({
+				context: __dirname,
+				mode: "production",
+				entry: "./missing-file",
+				output: {
+					path: "/",
+					filename: "bundle.js"
+				},
+				bail: true
+			});
+			done();
+			return compiler;
+		} catch (err) {
+			expect(err.toString()).toMatch(
+				"EntryModuleNotFoundError: Entry module not found: Error: Can't resolve './missing-file'"
+			);
+			done();
+		}
+	});
+	/* eslint-disable node/no-unsupported-features */
+	/* eslint-disable node/no-unsupported-features/es-syntax */
+	it("should not emit compilation errors in async (watch)", async done => {
+		try {
+			const createCompiler = options => {
+				return new Promise((resolve, reject) => {
+					const c = webpack(options);
+					c.outputFileSystem = new MemoryFs();
+					const watching = c.watch({}, (err, stats) => {
+						watching.close();
+						if (err) return reject(err);
+						resolve(stats);
+					});
+				});
+			};
+			const compiler = await createCompiler({
+				context: __dirname,
+				mode: "production",
+				entry: "./missing-file",
+				output: {
+					path: "/",
+					filename: "bundle.js"
+				},
+				watch: true
+			});
+			expect(compiler).toBeInstanceOf(Stats);
+			done();
+		} catch (err) {
+			done(err);
+		}
+	});
+
 	it("should not emit on errors (watch)", done => {
 		const compiler = webpack({
 			context: __dirname,

--- a/test/RemoveFiles.test.js
+++ b/test/RemoveFiles.test.js
@@ -29,7 +29,7 @@ const createSingleCompiler = () => {
 };
 
 describe("RemovedFiles", () => {
-	jest.setTimeout(20000);
+	jest.setTimeout(50000);
 
 	function cleanup() {
 		rimraf.sync(tempFolderPath);

--- a/test/fixtures/missing-file.js
+++ b/test/fixtures/missing-file.js
@@ -1,0 +1,5 @@
+module.exports = function b() {
+	/* eslint-disable node/no-missing-require */
+	require("./nonexistentfile");
+	return "This is a missing file";
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

  When Webpack is promisified any compilation error is swallowed and returned in the stats response and thus won't bubble up to the catch block. This adds an additional check for compilation errors and if the configuration object has `bail: true`. If they're both present then any compilation error is thrown and thus bubbles up and allows catch to capture it. 

- [x] Fix

**Did you add tests for your changes?**

- [x] Yes

**Does this PR introduce a breaking change?**

- [x] No

**What needs to be documented once your changes are merged?**

- Fixes #8298

