### PR TITLE
Drop unuseful `eval` call

### DIFF
--- a/buildin/global.js
+++ b/buildin/global.js
@@ -7,7 +7,7 @@ g = (function() {
 
 try {
 	// This works if eval is allowed (see CSP)
-	g = g || Function("return this")() || (1, eval)("this");
+	g = g || new Function("return this")();
 } catch (e) {
 	// This works if the window reference is available
 	if (typeof window === "object") g = window;


### PR DESCRIPTION
If use CSP (without `unsafe-eval`), both `new Function` and `eval` will be forbidden, so `eval` part is just dead code.

The only possibility `eval` part would run was `new Function('return this')()` return a falsy value, but it never possible as the spec (Is there any old engine violate this? Never heard about that.)

This pr also add `new` keyword to make the code a little bit explicit.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

clean unuseful code
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

no need
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

no need

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
