### PR TITLE
Refactor getInitFragments

### DIFF
--- a/lib/DependencyTemplate.js
+++ b/lib/DependencyTemplate.js
@@ -21,6 +21,7 @@
  * @property {ModuleGraph} moduleGraph the module graph
  * @property {ChunkGraph} chunkGraph the chunk graph
  * @property {Module} module current module
+ * @property {InitFragment[]} initFragments mutable array of init fragments for the current module
  */
 
 class DependencyTemplate {
@@ -33,15 +34,6 @@ class DependencyTemplate {
 	 */
 	apply(dependency, source, templateContext) {
 		throw new Error("DependencyTemplate.apply must be overriden");
-	}
-
-	/**
-	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {DependencyTemplateContext} templateContext the template context
-	 * @returns {InitFragment[]|null} the init fragments
-	 */
-	getInitFragments(dependency, templateContext) {
-		return null;
 	}
 }
 

--- a/lib/JavascriptGenerator.js
+++ b/lib/JavascriptGenerator.js
@@ -5,6 +5,7 @@
 
 "use strict";
 
+const util = require("util");
 const { ConcatSource, RawSource, ReplaceSource } = require("webpack-sources");
 const Generator = require("./Generator");
 
@@ -20,6 +21,12 @@ const Generator = require("./Generator");
 
 // TODO: clean up this file
 // replace with newer constructs
+
+const deprecatedGetInitFragment = util.deprecate(
+	(template, dependency, templateContext) =>
+		template.getInitFragments(dependency, templateContext),
+	"DependencyTemplate.getInitFragment is deprecated (use apply(dep, source, { initFragments }) instead)"
+);
 
 /**
  * @param {InitFragment} fragment the init fragment
@@ -136,16 +143,24 @@ class JavascriptGenerator extends Generator {
 			dependencyTemplates: generateContext.dependencyTemplates,
 			moduleGraph: generateContext.moduleGraph,
 			chunkGraph: generateContext.chunkGraph,
-			module
+			module,
+			initFragments
 		};
 
 		template.apply(dependency, source, templateContext);
 
-		const fragments = template.getInitFragments(dependency, templateContext);
+		// TODO remove in webpack 6
+		if ("getInitFragments" in template) {
+			const fragments = deprecatedGetInitFragment(
+				template,
+				dependency,
+				templateContext
+			);
 
-		if (fragments) {
-			for (const fragment of fragments) {
-				initFragments.push(fragment);
+			if (fragments) {
+				for (const fragment of fragments) {
+					initFragments.push(fragment);
+				}
 			}
 		}
 	}

--- a/lib/JavascriptGenerator.js
+++ b/lib/JavascriptGenerator.js
@@ -22,7 +22,7 @@ const Generator = require("./Generator");
 // TODO: clean up this file
 // replace with newer constructs
 
-const deprecatedGetInitFragment = util.deprecate(
+const deprecatedGetInitFragments = util.deprecate(
 	(template, dependency, templateContext) =>
 		template.getInitFragments(dependency, templateContext),
 	"DependencyTemplate.getInitFragment is deprecated (use apply(dep, source, { initFragments }) instead)"
@@ -151,7 +151,7 @@ class JavascriptGenerator extends Generator {
 
 		// TODO remove in webpack 6
 		if ("getInitFragments" in template) {
-			const fragments = deprecatedGetInitFragment(
+			const fragments = deprecatedGetInitFragments(
 				template,
 				dependency,
 				templateContext

--- a/lib/dependencies/CachedConstDependency.js
+++ b/lib/dependencies/CachedConstDependency.js
@@ -73,8 +73,21 @@ CachedConstDependency.Template = class CachedConstDependencyTemplate extends Dep
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
 	 */
-	apply(dependency, source, { runtimeTemplate, dependencyTemplates }) {
+	apply(
+		dependency,
+		source,
+		{ runtimeTemplate, dependencyTemplates, initFragments }
+	) {
 		const dep = /** @type {CachedConstDependency} */ (dependency);
+
+		initFragments.push(
+			new InitFragment(
+				`var ${dep.identifier} = ${dep.expression};\n`,
+				InitFragment.STAGE_CONSTANTS,
+				0,
+				`const ${dep.identifier}`
+			)
+		);
 
 		if (typeof dep.range === "number") {
 			source.insert(dep.range, dep.identifier);
@@ -83,24 +96,6 @@ CachedConstDependency.Template = class CachedConstDependencyTemplate extends Dep
 		}
 
 		source.replace(dep.range[0], dep.range[1] - 1, dep.identifier);
-	}
-
-	/**
-	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {DependencyTemplateContext} templateContext the template context
-	 * @returns {InitFragment[]|null} the init fragments
-	 */
-	getInitFragments(dependency, { runtimeTemplate, dependencyTemplates }) {
-		const dep = /** @type {CachedConstDependency} */ (dependency);
-
-		return [
-			new InitFragment(
-				`var ${dep.identifier} = ${dep.expression};\n`,
-				InitFragment.STAGE_CONSTANTS,
-				0,
-				`const ${dep.identifier}`
-			)
-		];
 	}
 };
 

--- a/lib/dependencies/HarmonyAcceptImportDependency.js
+++ b/lib/dependencies/HarmonyAcceptImportDependency.js
@@ -40,16 +40,6 @@ makeSerializable(
 	"webpack/lib/dependencies/HarmonyAcceptImportDependency"
 );
 
-HarmonyAcceptImportDependency.Template = class HarmonyAcceptImportDependencyTemplate extends HarmonyImportDependency.Template {
-	/**
-	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {ReplaceSource} source the current replace source which can be modified
-	 * @param {DependencyTemplateContext} templateContext the context object
-	 * @returns {void}
-	 */
-	apply(dependency, source, templateContext) {
-		// no-op
-	}
-};
+HarmonyAcceptImportDependency.Template = class HarmonyAcceptImportDependencyTemplate extends HarmonyImportDependency.Template {};
 
 module.exports = HarmonyAcceptImportDependency;

--- a/lib/dependencies/HarmonyCompatibilityDependency.js
+++ b/lib/dependencies/HarmonyCompatibilityDependency.js
@@ -32,31 +32,24 @@ HarmonyCompatibilityDependency.Template = class HarmonyExportDependencyTemplate 
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
 	 */
-	apply(dependency, source, templateContext) {
-		// no-op
-	}
-
-	/**
-	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {DependencyTemplateContext} templateContext the template context
-	 * @returns {InitFragment[]|null} the init fragments
-	 */
-	getInitFragments(dependency, { module, runtimeTemplate, moduleGraph }) {
+	apply(
+		dependency,
+		source,
+		{ module, runtimeTemplate, moduleGraph, initFragments }
+	) {
 		const usedExports = moduleGraph.getUsedExports(module);
 		if (usedExports === true || usedExports === null) {
 			const content = runtimeTemplate.defineEsModuleFlagStatement({
 				exportsArgument: module.exportsArgument
 			});
-			return [
+			initFragments.push(
 				new InitFragment(
 					content,
 					InitFragment.STAGE_HARMONY_EXPORTS,
 					0,
 					"harmony compatibility"
 				)
-			];
-		} else {
-			return null;
+			);
 		}
 	}
 };

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -522,24 +522,22 @@ module.exports = HarmonyExportImportedSpecifierDependency;
 HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedSpecifierDependencyTemplate extends HarmonyImportDependency.Template {
 	/**
 	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {DependencyTemplateContext} templateContext the template context
-	 * @returns {InitFragment[]|null} the init fragments
+	 * @param {ReplaceSource} source the current replace source which can be modified
+	 * @param {DependencyTemplateContext} templateContext the context object
+	 * @returns {void}
 	 */
-	getInitFragments(dependency, templateContext) {
+	apply(dependency, source, templateContext) {
 		const dep = /** @type {HarmonyExportImportedSpecifierDependency} */ (dependency);
 
 		if (this.isUsed(dep, templateContext)) {
-			const importFragments = super.getInitFragments(dep, templateContext);
+			super.apply(dependency, source, templateContext);
+
 			const exportFragment = this._getExportFragment(
 				dep,
 				templateContext.module,
 				templateContext.moduleGraph
 			);
-			return importFragments
-				? importFragments.concat(exportFragment)
-				: [exportFragment];
-		} else {
-			return null;
+			templateContext.initFragments.push(exportFragment);
 		}
 	}
 

--- a/lib/dependencies/HarmonyExportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportSpecifierDependency.js
@@ -66,23 +66,14 @@ HarmonyExportSpecifierDependency.Template = class HarmonyExportSpecifierDependen
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
 	 */
-	apply(dependency, source, templateContext) {
-		// no-op
-	}
-
-	/**
-	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {DependencyTemplateContext} templateContext the template context
-	 * @returns {InitFragment[]|null} the init fragments
-	 */
-	getInitFragments(dependency, { module, moduleGraph }) {
-		return [
+	apply(dependency, source, { module, moduleGraph, initFragments }) {
+		initFragments.push(
 			new InitFragment(
 				this.getContent(dependency, module, moduleGraph),
 				InitFragment.STAGE_HARMONY_EXPORTS,
 				1
 			)
-		];
+		);
 	}
 
 	getContent(dep, module, moduleGraph) {

--- a/lib/dependencies/HarmonyImportDependency.js
+++ b/lib/dependencies/HarmonyImportDependency.js
@@ -124,26 +124,6 @@ HarmonyImportDependency.Template = class HarmonyImportDependencyTemplate extends
 	 * @returns {void}
 	 */
 	apply(dependency, source, templateContext) {
-		// no-op
-	}
-
-	/**
-	 *
-	 * @param {Dependency} dep the dependency
-	 * @param {Module} module the module
-	 * @returns {boolean} true, when for this dependency and module a import init fragment was created
-	 */
-	static isImportEmitted(dep, module) {
-		const emittedModules = importEmittedMap.get(dep);
-		return emittedModules !== undefined && emittedModules.has(module);
-	}
-
-	/**
-	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {DependencyTemplateContext} templateContext the template context
-	 * @returns {InitFragment[]|null} the init fragments
-	 */
-	getInitFragments(dependency, templateContext) {
 		const dep = /** @type {HarmonyImportDependency} */ (dependency);
 		const { module, moduleGraph } = templateContext;
 
@@ -162,13 +142,24 @@ HarmonyImportDependency.Template = class HarmonyImportDependencyTemplate extends
 			emittedModules.add(module);
 		}
 
-		return [
+		templateContext.initFragments.push(
 			new InitFragment(
 				dep.getImportStatement(false, templateContext),
 				InitFragment.STAGE_HARMONY_IMPORTS,
 				dep.sourceOrder,
 				key
 			)
-		];
+		);
+	}
+
+	/**
+	 *
+	 * @param {Dependency} dep the dependency
+	 * @param {Module} module the module
+	 * @returns {boolean} true, when for this dependency and module a import init fragment was created
+	 */
+	static isImportEmitted(dep, module) {
+		const emittedModules = importEmittedMap.get(dep);
+		return emittedModules !== undefined && emittedModules.has(module);
 	}
 };

--- a/lib/dependencies/HarmonyImportSideEffectDependency.js
+++ b/lib/dependencies/HarmonyImportSideEffectDependency.js
@@ -8,6 +8,7 @@
 const makeSerializable = require("../util/makeSerializable");
 const HarmonyImportDependency = require("./HarmonyImportDependency");
 
+/** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
 /** @typedef {import("../Dependency")} Dependency */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../InitFragment")} InitFragment */

--- a/lib/dependencies/HarmonyImportSideEffectDependency.js
+++ b/lib/dependencies/HarmonyImportSideEffectDependency.js
@@ -46,6 +46,12 @@ makeSerializable(
 );
 
 HarmonyImportSideEffectDependency.Template = class HarmonyImportSideEffectDependencyTemplate extends HarmonyImportDependency.Template {
+	/**
+	 * @param {Dependency} dependency the dependency for which the template should be applied
+	 * @param {ReplaceSource} source the current replace source which can be modified
+	 * @param {DependencyTemplateContext} templateContext the context object
+	 * @returns {void}
+	 */
 	apply(dependency, source, templateContext) {
 		const dep = /** @type {HarmonyImportSideEffectDependency} */ (dependency);
 		const { moduleGraph } = templateContext;

--- a/lib/dependencies/HarmonyImportSideEffectDependency.js
+++ b/lib/dependencies/HarmonyImportSideEffectDependency.js
@@ -46,19 +46,12 @@ makeSerializable(
 );
 
 HarmonyImportSideEffectDependency.Template = class HarmonyImportSideEffectDependencyTemplate extends HarmonyImportDependency.Template {
-	/**
-	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {DependencyTemplateContext} templateContext the template context
-	 * @returns {InitFragment[]|null} the init fragments
-	 */
-	getInitFragments(dependency, templateContext) {
+	apply(dependency, source, templateContext) {
 		const dep = /** @type {HarmonyImportSideEffectDependency} */ (dependency);
 		const { moduleGraph } = templateContext;
 		const module = moduleGraph.getModule(dep);
-		if (module && module.factoryMeta.sideEffectFree) {
-			return null;
-		} else {
-			return super.getInitFragments(dep, templateContext);
+		if (!module || !module.factoryMeta.sideEffectFree) {
+			super.apply(dependency, source, templateContext);
 		}
 	}
 };

--- a/lib/dependencies/ModuleDecoratorDependency.js
+++ b/lib/dependencies/ModuleDecoratorDependency.js
@@ -43,17 +43,14 @@ ModuleDecoratorDependency.Template = class ModuleDecoratorDependencyTemplate ext
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
 	 */
-	apply(dependency, source, templateContext) {}
-
-	/**
-	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {DependencyTemplateContext} templateContext the template context
-	 * @returns {InitFragment[]|null} the init fragments
-	 */
-	getInitFragments(dependency, { runtimeTemplate, moduleGraph, chunkGraph }) {
+	apply(
+		dependency,
+		source,
+		{ runtimeTemplate, moduleGraph, chunkGraph, initFragments }
+	) {
 		const dep = /** @type {ModuleDecoratorDependency} */ (dependency);
 		const originModule = moduleGraph.getOrigin(dep);
-		return [
+		initFragments.push(
 			new InitFragment(
 				`/* module decorator */ ${
 					originModule.moduleArgument
@@ -66,7 +63,7 @@ ModuleDecoratorDependency.Template = class ModuleDecoratorDependencyTemplate ext
 				0,
 				`module decorator ${chunkGraph.getModuleId(originModule)}`
 			)
-		];
+		);
 	}
 };
 

--- a/lib/dependencies/ProvidedDependency.js
+++ b/lib/dependencies/ProvidedDependency.js
@@ -76,19 +76,13 @@ class ProvidedDependencyTemplate extends ModuleDependency.Template {
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
 	 */
-	apply(dependency, source, templateContext) {
+	apply(
+		dependency,
+		source,
+		{ runtimeTemplate, moduleGraph, chunkGraph, initFragments }
+	) {
 		const dep = /** @type {ProvidedDependency} */ (dependency);
-		source.replace(dep.range[0], dep.range[1] - 1, dep.identifier);
-	}
-
-	/**
-	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {DependencyTemplateContext} templateContext the template context
-	 * @returns {InitFragment[]|null} the init fragments
-	 */
-	getInitFragments(dependency, { runtimeTemplate, moduleGraph, chunkGraph }) {
-		const dep = /** @type {ProvidedDependency} */ (dependency);
-		return [
+		initFragments.push(
 			new InitFragment(
 				`/* provided dependency */ var ${
 					dep.identifier
@@ -101,7 +95,8 @@ class ProvidedDependencyTemplate extends ModuleDependency.Template {
 				1,
 				`provided ${dep.identifier}`
 			)
-		];
+		);
+		source.replace(dep.range[0], dep.range[1] - 1, dep.identifier);
 	}
 }
 

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -1277,23 +1277,6 @@ class HarmonyImportSpecifierDependencyConcatenatedTemplate extends DependencyTem
 
 	/**
 	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {DependencyTemplateContext} templateContext the template context
-	 * @returns {InitFragment[]|null} the init fragments
-	 */
-	getInitFragments(dependency, templateContext) {
-		const dep = /** @type {HarmonyImportSpecifierDependency} */ (dependency);
-		const { moduleGraph } = templateContext;
-		const module = moduleGraph.getModule(dep);
-		const info = this.modulesMap.get(module);
-		if (!info) {
-			return this.originalTemplate.getInitFragments(dep, templateContext);
-		} else {
-			return null;
-		}
-	}
-
-	/**
-	 * @param {Dependency} dependency the dependency for which the template should be applied
 	 * @param {ReplaceSource} source the current replace source which can be modified
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
@@ -1341,23 +1324,6 @@ class HarmonyImportSideEffectDependencyConcatenatedTemplate extends DependencyTe
 
 	/**
 	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {DependencyTemplateContext} templateContext the template context
-	 * @returns {InitFragment[]|null} the init fragments
-	 */
-	getInitFragments(dependency, templateContext) {
-		const dep = /** @type {HarmonyImportSideEffectDependency} */ (dependency);
-		const { moduleGraph } = templateContext;
-		const module = moduleGraph.getModule(dep);
-		const info = this.modulesMap.get(module);
-		if (!info) {
-			return this.originalTemplate.getInitFragments(dep, templateContext);
-		} else {
-			return null;
-		}
-	}
-
-	/**
-	 * @param {Dependency} dependency the dependency for which the template should be applied
 	 * @param {ReplaceSource} source the current replace source which can be modified
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
@@ -1383,20 +1349,6 @@ class HarmonyExportSpecifierDependencyConcatenatedTemplate extends DependencyTem
 
 	/**
 	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {DependencyTemplateContext} templateContext the template context
-	 * @returns {InitFragment[]|null} the init fragments
-	 */
-	getInitFragments(dependency, templateContext) {
-		const dep = /** @type {HarmonyExportSpecifierDependency} */ (dependency);
-		if (templateContext.module === this.rootModule) {
-			return this.originalTemplate.getInitFragments(dep, templateContext);
-		} else {
-			return null;
-		}
-	}
-
-	/**
-	 * @param {Dependency} dependency the dependency for which the template should be applied
 	 * @param {ReplaceSource} source the current replace source which can be modified
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
@@ -1417,15 +1369,17 @@ class HarmonyExportExpressionDependencyConcatenatedTemplate extends DependencyTe
 
 	/**
 	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {DependencyTemplateContext} templateContext the template context
-	 * @returns {InitFragment[]|null} the init fragments
+	 * @param {ReplaceSource} source the current replace source which can be modified
+	 * @param {DependencyTemplateContext} templateContext the context object
+	 * @returns {void}
 	 */
-	getInitFragments(dependency, templateContext) {
-		const { moduleGraph, module } = templateContext;
+	apply(dependency, source, { module, moduleGraph, initFragments }) {
+		const dep = /** @type {HarmonyExportExpressionDependency} */ (dependency);
+
 		if (module === this.rootModule) {
 			const used = module.getUsedName(moduleGraph, "default");
 			const exportsName = module.exportsArgument;
-			return [
+			initFragments.push(
 				new InitFragment(
 					`/* harmony export export */ ` +
 						`${
@@ -1435,18 +1389,9 @@ class HarmonyExportExpressionDependencyConcatenatedTemplate extends DependencyTe
 					InitFragment.STAGE_HARMONY_EXPORTS,
 					1
 				)
-			];
+			);
 		}
-	}
 
-	/**
-	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {ReplaceSource} source the current replace source which can be modified
-	 * @param {DependencyTemplateContext} templateContext the context object
-	 * @returns {void}
-	 */
-	apply(dependency, source, { module, moduleGraph }) {
-		const dep = /** @type {HarmonyExportExpressionDependency} */ (dependency);
 		const content =
 			"/* harmony default export */ var __WEBPACK_MODULE_DEFAULT_EXPORT__ = ";
 
@@ -1525,26 +1470,31 @@ class HarmonyExportImportedSpecifierDependencyConcatenatedTemplate extends Depen
 
 	/**
 	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {DependencyTemplateContext} templateContext the template context
-	 * @returns {InitFragment[]|null} the init fragments
+	 * @param {ReplaceSource} source the current replace source which can be modified
+	 * @param {DependencyTemplateContext} templateContext the context object
+	 * @returns {void}
 	 */
-	getInitFragments(dependency, templateContext) {
+	apply(dependency, source, templateContext) {
+		const { module, moduleGraph, initFragments } = templateContext;
 		const dep = /** @type {HarmonyExportImportedSpecifierDependency} */ (dependency);
-		const { moduleGraph, module } = templateContext;
 		const importedModule = moduleGraph.getModule(dep);
 		const info = this.modulesMap.get(importedModule);
 		if (!info) {
-			return this.originalTemplate.getInitFragments(dep, templateContext);
+			this.originalTemplate.apply(dependency, source, templateContext);
+			return;
 		} else if (module === this.rootModule) {
 			const exportDefs = this.getExports(dep, templateContext);
-			return exportDefs.map(def => {
+			for (const def of exportDefs) {
 				const used = module.getUsedName(moduleGraph, def.name);
 				if (!used) {
-					return new InitFragment(
-						`/* unused concated harmony import ${dep.name} */\n`,
-						InitFragment.STAGE_HARMONY_EXPORTS,
-						1
+					initFragments.push(
+						new InitFragment(
+							`/* unused concated harmony import ${dep.name} */\n`,
+							InitFragment.STAGE_HARMONY_EXPORTS,
+							1
+						)
 					);
+					continue;
 				}
 				let finalName;
 				const strictFlag = module.buildMeta.strictHarmonyModule
@@ -1567,25 +1517,10 @@ class HarmonyExportImportedSpecifierDependencyConcatenatedTemplate extends Depen
 					}(` +
 					`${exportsName}, ${JSON.stringify(used)}, ` +
 					`function() { return ${finalName}; });\n`;
-				return new InitFragment(content, InitFragment.STAGE_HARMONY_EXPORTS, 1);
-			});
-		}
-	}
-
-	/**
-	 * @param {Dependency} dependency the dependency for which the template should be applied
-	 * @param {ReplaceSource} source the current replace source which can be modified
-	 * @param {DependencyTemplateContext} templateContext the context object
-	 * @returns {void}
-	 */
-	apply(dependency, source, templateContext) {
-		const { moduleGraph } = templateContext;
-		const dep = /** @type {HarmonyExportImportedSpecifierDependency} */ (dependency);
-		const module = moduleGraph.getModule(dep);
-		const info = this.modulesMap.get(module);
-		if (!info) {
-			this.originalTemplate.apply(dependency, source, templateContext);
-			return;
+				initFragments.push(
+					new InitFragment(content, InitFragment.STAGE_HARMONY_EXPORTS, 1)
+				);
+			}
 		}
 	}
 }

--- a/test/HotModuleReplacementPlugin.test.js
+++ b/test/HotModuleReplacementPlugin.test.js
@@ -96,7 +96,7 @@ describe("HotModuleReplacementPlugin", () => {
 				});
 			});
 		});
-	});
+	}, 60000);
 
 	it("should correct working when entry is Object and key is a number", done => {
 		const entryFile = path.join(


### PR DESCRIPTION
Refactor getInitFragments to a property in templateContext and apply method

Having only a single method in DependencyTemplate makes it easier to override

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
refactor
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
existing test
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes, but with compat layer
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
DependencyTemplate.getInitFragments no longer exist and was replaced with a `initFragments` argument in the DependencyTemplate.apply method
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
