### PR TITLE
Fix for #8398 - call failed-hook on compilation errors

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -207,6 +207,10 @@ class Compiler extends Tapable {
 		const finalCallback = (err, stats) => {
 			this.running = false;
 
+			if (err) {
+				this.hooks.failed.call(err);
+			}
+
 			if (callback !== undefined) return callback(err, stats);
 		};
 

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -493,4 +493,25 @@ describe("Compiler", () => {
 			});
 		});
 	});
+	it("should call the failed-hook on error", done => {
+		const failedSpy = jest.fn();
+		const compiler = webpack({
+			bail: true,
+			context: __dirname,
+			mode: "production",
+			entry: "./missing",
+			output: {
+				path: "/",
+				filename: "bundle.js"
+			},
+		});
+		compiler.hooks.failed.tap('CompilerTest', failedSpy);
+		compiler.outputFileSystem = new MemoryFs();
+		compiler.run((err, stats) => {
+			expect(err).toBeTruthy();
+			expect(failedSpy).toHaveBeenCalledTimes(1);
+			expect(failedSpy).toHaveBeenCalledWith(err);
+			done();
+		});
+	});
 });


### PR DESCRIPTION
See: https://github.com/webpack/webpack/issues/8398

The problem: you currently can't use hooks to determine whether a compilation has failed. This makes it hard to wrap compilers with custom error handling. In master, the only time `hooks.failed` is called is when compilation fails during watch-mode. This PR calls the hook for normal compilations also.

**What kind of change does this PR introduce?**

This PR ensures the failed-hooked is called whenever compilation fails.

The `finalCallback` (from `compiler.run(finalCallback)` fame) is called as a bail-out whenever there's an error.  So adding the call to the failed-hook here makes sense because it minimizes the code changes.

**Did you add tests for your changes?**

Yes, added a test. To ensure this PR does the trick, either run the tests or the code below:

```
const webpack = require("webpack");

const compiler = webpack({
	bail: true,
	context: __dirname,
	mode: "production",
	entry: "./missing",
	output: {
		path: "/",
		filename: "bundle.js"
	}
});

compiler.hooks.failed.tap("CompilerTest", err => {
	console.log("I made it to Flavortown:\n", err);
});

compiler.run((err, stats) => {
	if (err || stats.hasError()) {
		console.log("Compilation failed.");
	}
});
```

**Does this PR introduce a breaking change?**

As far as I can tell, it should not break anything. That is, unless folks have existing code for the failed-hook that they never expect to be called, which seems unlikely.

**What needs to be documented once your changes are merged?**

[The docs](https://webpack.js.org/api/compiler-hooks/#failed) actually already state the failed-hook is called on failure, so nothing should need to be updated. This PR just makes the behavior match the docs.
