### PR TITLE
fix parameter missing  when plugin type is a funtion

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -225,6 +225,7 @@ export type ArrayOfStringOrStringArrayValues = (string | string[])[];
  * via the `definition` "WebpackPluginFunction".
  */
 export type WebpackPluginFunction = (
+	this: import("../lib/Compiler"),
 	compiler: import("../lib/Compiler")
 ) => void;
 /**

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -42,7 +42,7 @@ const webpack = (options, callback) => {
 		if (options.plugins && Array.isArray(options.plugins)) {
 			for (const plugin of options.plugins) {
 				if (typeof plugin === "function") {
-					plugin.apply(compiler);
+					plugin.call(compiler, compiler);
 				} else {
 					plugin.apply(compiler);
 				}

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1879,7 +1879,7 @@
     "WebpackPluginFunction": {
       "description": "Function acting as plugin",
       "instanceof": "Function",
-      "tsType": "(compiler: import('../lib/Compiler')) => void"
+      "tsType": "(this: import('../lib/Compiler'), compiler: import('../lib/Compiler')) => void"
     },
     "WebpackPluginInstance": {
       "description": "Plugin instance",


### PR DESCRIPTION
> Hello, here's a small change ...

/lib/webpack.js (now)
```
  if (typeof plugin === "function") {
    plugin.apply(compiler);  // missing parameter
  } else {
    plugin.apply(compiler);
  }
```
/lib/webpack.js (after)
```
  if (typeof plugin === "function") {
    plugin.apply(null, [compiler]); // yes
  } else {
    plugin.apply(compiler);
  }
```
/declarations/WebpackOptions.d.ts
```
type WebpackPluginFunction = (
	compiler: import("../lib/Compiler")
) => void;
```

**What kind of change does this PR introduce?**

a bugfix
