### PR TITLE
Remove context usage in ProgressPlugin

### DIFF
--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -10,6 +10,7 @@ const schema = require("../schemas/plugins/ProgressPlugin.json");
 
 /** @typedef {import("../declarations/plugins/ProgressPlugin").ProgressPluginArgument} ProgressPluginArgument */
 /** @typedef {import("../declarations/plugins/ProgressPlugin").ProgressPluginOptions} ProgressPluginOptions */
+/** @typedef {import("./Compiler")} Compiler */
 
 const createDefaultHandler = profile => {
 	let lineCaretPosition = 0;
@@ -76,7 +77,25 @@ const createDefaultHandler = profile => {
 	return defaultHandler;
 };
 
+/**
+ * @callback ReportProgress
+ * @param {number} p
+ * @param {...string[]} [args]
+ * @returns {void}
+ */
+
+/** @type {WeakMap<Compiler,ReportProgress>} */
+const progressReporters = new WeakMap();
+
 class ProgressPlugin {
+	/**
+	 * @param {Compiler} compiler the current compiler
+	 * @returns {ReportProgress} a progress reporter, if any
+	 */
+	static getReporter(compiler) {
+		return progressReporters.get(compiler);
+	}
+
 	/**
 	 * @param {ProgressPluginArgument} options options
 	 */
@@ -261,18 +280,15 @@ class ProgressPlugin {
 					const percentage = (idx / numberOfHooks) * 0.25 + 0.7;
 					compilation.hooks[name].intercept({
 						name: "ProgressPlugin",
-						context: true,
-						call: () => {
+						call() {
 							handler(percentage, title);
 						},
-						tap: (context, tap) => {
-							if (context) {
-								// p is percentage from 0 to 1
-								// args is any number of messages in a hierarchical matter
-								context.reportProgress = (p, ...args) => {
-									handler(percentage, title, tap.name, ...args);
-								};
-							}
+						tap(tap) {
+							// p is percentage from 0 to 1
+							// args is any number of messages in a hierarchical matter
+							progressReporters.set(compilation.compiler, (p, ...args) => {
+								handler(percentage, title, tap.name, ...args);
+							});
 							handler(percentage, title, tap.name);
 						}
 					});
@@ -280,31 +296,25 @@ class ProgressPlugin {
 			});
 			compiler.hooks.emit.intercept({
 				name: "ProgressPlugin",
-				context: true,
-				call: () => {
+				call() {
 					handler(0.95, "emitting");
 				},
-				tap: (context, tap) => {
-					if (context) {
-						context.reportProgress = (p, ...args) => {
-							handler(0.95, "emitting", tap.name, ...args);
-						};
-					}
+				tap(tap) {
+					progressReporters.set(compiler, (p, ...args) => {
+						handler(0.95, "emitting", tap.name, ...args);
+					});
 					handler(0.95, "emitting", tap.name);
 				}
 			});
 			compiler.hooks.afterEmit.intercept({
 				name: "ProgressPlugin",
-				context: true,
-				call: () => {
+				call() {
 					handler(0.98, "after emitting");
 				},
-				tap: (context, tap) => {
-					if (context) {
-						context.reportProgress = (p, ...args) => {
-							handler(0.98, "after emitting", tap.name, ...args);
-						};
-					}
+				tap(tap) {
+					progressReporters.set(compiler, (p, ...args) => {
+						handler(0.98, "after emitting", tap.name, ...args);
+					});
 					handler(0.98, "after emitting", tap.name);
 				}
 			});

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -9,6 +9,7 @@ const path = require("path");
 const validateOptions = require("schema-utils");
 const { ConcatSource, RawSource } = require("webpack-sources");
 const ModuleFilenameHelpers = require("./ModuleFilenameHelpers");
+const ProgressPlugin = require("./ProgressPlugin");
 const SourceMapDevToolModuleOptionsPlugin = require("./SourceMapDevToolModuleOptionsPlugin");
 const createHash = require("./util/createHash");
 
@@ -97,19 +98,12 @@ class SourceMapDevToolPlugin {
 			new SourceMapDevToolModuleOptionsPlugin(options).apply(compilation);
 
 			compilation.hooks.afterOptimizeChunkAssets.tap(
-				/** @type {TODO} */ ({
-					name: "SourceMapDevToolPlugin",
-					context: true
-				}),
-				/** @type {TODO} */
-				/** @param {any} context @param {Chunk[]} chunks @returns {void} */
-				((context, chunks) => {
+				"SourceMapDevToolPlugin",
+				chunks => {
 					const chunkGraph = compilation.chunkGraph;
 					const moduleToSourceNameMapping = new Map();
 					const reportProgress =
-						context && context.reportProgress
-							? context.reportProgress
-							: () => {};
+						ProgressPlugin.getReporter(compilation.compiler) || (() => {});
 
 					const files = [];
 					for (const chunk of chunks) {
@@ -301,7 +295,7 @@ class SourceMapDevToolPlugin {
 						}
 					});
 					reportProgress(1.0);
-				})
+				}
 			);
 		});
 	}

--- a/test/configCases/plugins/progress-plugin/webpack.config.js
+++ b/test/configCases/plugins/progress-plugin/webpack.config.js
@@ -12,12 +12,10 @@ module.exports = {
 			apply: compiler => {
 				compiler.hooks.compilation.tap("CustomPlugin", compilation => {
 					compilation.hooks.optimize.tap(
-						{
-							name: "CustomPlugin",
-							context: true
-						},
-						context => {
-							context.reportProgress(0, "custom category", "custom message");
+						"CustomPlugin",
+						() => {
+							const reportProgress = webpack.ProgressPlugin.getReporter(compiler);
+							reportProgress(0, "custom category", "custom message");
 						}
 					);
 				});


### PR DESCRIPTION
`ProgressPlugin` uses `Tap.context` to expose `reportProgress` which is unnecessary. This PR removes `Tap.context` usage in favor of a `WeakMap`.

While this API is not as convenient as the previous one, it ensures that webpack no longer rely on `Tap.context` and demonstrates that the previous API could be achieved in user-land.

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

already exists

**Does this PR introduce a breaking change?**

yes

**What needs to be documented once your changes are merged?**

`context.reportProgress` is no longer available. It has been replaced by `ProgressPlugin.getReporter(compilation)`