### PR TITLE
[WIP] Changing splitChunks.name default to false for production

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -270,7 +270,9 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("optimization.splitChunks.maxInitialRequests", "make", options => {
 			return isProductionLikeMode(options) ? 4 : Infinity;
 		});
-		this.set("optimization.splitChunks.name", true);
+		this.set("optimization.splitChunks.name", "make", options => {
+			return !isProductionLikeMode(options);
+		});
 		this.set("optimization.splitChunks.cacheGroups", {});
 		this.set("optimization.splitChunks.cacheGroups.default", {
 			automaticNamePrefix: "",

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -222,7 +222,7 @@ Child default:
      [2] ./d.js 20 bytes {2} {3} {4} {5} [built]
      [3] ./node_modules/x.js 20 bytes {2} {4} {5} {6} [built]
      [4] ./node_modules/y.js 20 bytes {2} {4} {7} [built]
-    chunk    {3} default/async-a~async-b~async-c.js (async-a~async-b~async-c) 20 bytes <{0}> ={1}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{9}< >{12}< [rendered] split chunk (cache group: default) (name: async-a~async-b~async-c)
+    chunk    {3} default/3.js 20 bytes <{0}> ={1}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{9}< >{12}< [rendered] split chunk (cache group: default)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
@@ -241,19 +241,19 @@ Child default:
      [6] ./f.js 20 bytes {4} {5} {9} [built]
      [7] ./c.js 72 bytes {5} {10} [built]
      [8] ./node_modules/z.js 20 bytes {5} {11} [built]
-    chunk    {6} default/vendors~async-a~async-b~async-c.js (vendors~async-a~async-b~async-c) 20 bytes <{0}> ={1}= ={3}= ={7}= ={8}= ={9}= ={10}= ={11}= >{9}< >{12}< [rendered] split chunk (cache group: defaultVendors) (name: vendors~async-a~async-b~async-c)
+    chunk    {6} default/6.js 20 bytes <{0}> ={1}= ={3}= ={7}= ={8}= ={9}= ={10}= ={11}= >{9}< >{12}< [rendered] split chunk (cache group: defaultVendors)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
      [3] ./node_modules/x.js 20 bytes {2} {4} {5} {6} [built]
-    chunk    {7} default/vendors~async-a~async-b.js (vendors~async-a~async-b) 20 bytes <{0}> ={1}= ={3}= ={6}= ={8}= ={9}= >{9}< >{12}< [rendered] split chunk (cache group: defaultVendors) (name: vendors~async-a~async-b)
+    chunk    {7} default/7.js 20 bytes <{0}> ={1}= ={3}= ={6}= ={8}= ={9}= >{9}< >{12}< [rendered] split chunk (cache group: defaultVendors)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
      [4] ./node_modules/y.js 20 bytes {2} {4} {7} [built]
     chunk    {8} default/async-b.js (async-b) 72 bytes <{0}> ={3}= ={6}= ={7}= ={9}= [rendered]
         > ./b [0] ./index.js 2:0-47
      [5] ./b.js 72 bytes {4} {8} [built]
-    chunk    {9} default/async-b~async-c~async-g.js (async-b~async-c~async-g) 20 bytes <{0}> <{1}> <{2}> <{3}> <{6}> <{7}> ={3}= ={6}= ={7}= ={8}= ={10}= ={11}= ={12}= [rendered] split chunk (cache group: default) (name: async-b~async-c~async-g)
+    chunk    {9} default/9.js 20 bytes <{0}> <{1}> <{2}> <{3}> <{6}> <{7}> ={3}= ={6}= ={7}= ={8}= ={10}= ={11}= ={12}= [rendered] split chunk (cache group: default)
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
         > ./g [] 6:0-47
@@ -261,7 +261,7 @@ Child default:
     chunk   {10} default/async-c.js (async-c) 72 bytes <{0}> ={3}= ={6}= ={9}= ={11}= [rendered]
         > ./c [0] ./index.js 3:0-47
      [7] ./c.js 72 bytes {5} {10} [built]
-    chunk   {11} default/vendors~async-c.js (vendors~async-c) 20 bytes <{0}> ={3}= ={6}= ={9}= ={10}= [rendered] split chunk (cache group: defaultVendors) (name: vendors~async-c)
+    chunk   {11} default/11.js 20 bytes <{0}> ={3}= ={6}= ={9}= ={10}= [rendered] split chunk (cache group: defaultVendors)
         > ./c [0] ./index.js 3:0-47
      [8] ./node_modules/z.js 20 bytes {5} {11} [built]
     chunk   {12} default/async-g.js (async-g) 34 bytes <{1}> <{2}> <{3}> <{6}> <{7}> ={9}= [rendered]
@@ -326,9 +326,9 @@ Child vendors:
      [9] ./g.js 34 bytes {8} [built]
 Child multiple-vendors:
     Entrypoint main = multiple-vendors/main.js
-    Entrypoint a = multiple-vendors/libs-x.js multiple-vendors/vendors~a~async-a~async-b~b.js multiple-vendors/a~async-a~async-b~async-c~b~c.js multiple-vendors/a.js
-    Entrypoint b = multiple-vendors/libs-x.js multiple-vendors/vendors~a~async-a~async-b~b.js multiple-vendors/a~async-a~async-b~async-c~b~c.js multiple-vendors/b.js
-    Entrypoint c = multiple-vendors/libs-x.js multiple-vendors/vendors~async-c~c.js multiple-vendors/a~async-a~async-b~async-c~b~c.js multiple-vendors/c.js
+    Entrypoint a = multiple-vendors/libs-x.js multiple-vendors/5.js multiple-vendors/3.js multiple-vendors/a.js
+    Entrypoint b = multiple-vendors/libs-x.js multiple-vendors/5.js multiple-vendors/3.js multiple-vendors/b.js
+    Entrypoint c = multiple-vendors/libs-x.js multiple-vendors/11.js multiple-vendors/3.js multiple-vendors/c.js
     chunk    {0} multiple-vendors/main.js (main) 147 bytes >{2}< >{3}< >{4}< >{5}< >{6}< >{8}< >{10}< >{11}< [entry] [rendered]
         > ./ main
      [0] ./index.js 147 bytes {0} [built]
@@ -342,7 +342,7 @@ Child multiple-vendors:
      [1] ./a.js + 1 modules 156 bytes {1} {2} [built]
          | ./e.js 20 bytes [built]
          | ./a.js 121 bytes [built]
-    chunk    {3} multiple-vendors/a~async-a~async-b~async-c~b~c.js (a~async-a~async-b~async-c~b~c) 20 bytes <{0}> ={1}= ={2}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: default) (name: a~async-a~async-b~async-c~b~c)
+    chunk    {3} multiple-vendors/3.js 20 bytes <{0}> ={1}= ={2}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: default)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
@@ -358,7 +358,7 @@ Child multiple-vendors:
         > ./b b
         > ./c c
      [3] ./node_modules/x.js 20 bytes {4} [built]
-    chunk    {5} multiple-vendors/vendors~a~async-a~async-b~b.js (vendors~a~async-a~async-b~b) 20 bytes <{0}> ={1}= ={2}= ={3}= ={4}= ={6}= ={7}= ={8}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors~a~async-a~async-b~b)
+    chunk    {5} multiple-vendors/5.js 20 bytes <{0}> ={1}= ={2}= ={3}= ={4}= ={6}= ={7}= ={8}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: vendors)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./a a
@@ -371,7 +371,7 @@ Child multiple-vendors:
         > ./b b
      [5] ./b.js 72 bytes {6} {7} [built]
      [6] ./f.js 20 bytes {7} {8} {9} [built]
-    chunk    {8} multiple-vendors/async-b~async-c~async-g.js (async-b~async-c~async-g) 20 bytes <{0}> <{1}> <{2}> <{3}> <{4}> <{5}> ={3}= ={4}= ={5}= ={6}= ={10}= ={11}= ={12}= [rendered] split chunk (cache group: default) (name: async-b~async-c~async-g)
+    chunk    {8} multiple-vendors/8.js 20 bytes <{0}> <{1}> <{2}> <{3}> <{4}> <{5}> ={3}= ={4}= ={5}= ={6}= ={10}= ={11}= ={12}= [rendered] split chunk (cache group: default)
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
         > ./g [] 6:0-47
@@ -383,7 +383,7 @@ Child multiple-vendors:
     chunk   {10} multiple-vendors/async-c.js (async-c) 72 bytes <{0}> ={3}= ={4}= ={8}= ={11}= [rendered]
         > ./c [0] ./index.js 3:0-47
      [7] ./c.js 72 bytes {9} {10} [built]
-    chunk   {11} multiple-vendors/vendors~async-c~c.js (vendors~async-c~c) 20 bytes <{0}> ={3}= ={4}= ={8}= ={9}= ={10}= [initial] [rendered] split chunk (cache group: vendors) (name: vendors~async-c~c)
+    chunk   {11} multiple-vendors/11.js 20 bytes <{0}> ={3}= ={4}= ={8}= ={9}= ={10}= [initial] [rendered] split chunk (cache group: vendors)
         > ./c [0] ./index.js 3:0-47
         > ./c c
      [8] ./node_modules/z.js 20 bytes {11} [built]
@@ -392,9 +392,9 @@ Child multiple-vendors:
      [9] ./g.js 34 bytes {12} [built]
 Child all:
     Entrypoint main = all/main.js
-    Entrypoint a = all/vendors~a~async-a~async-b~async-c~b~c.js all/vendors~a~async-a~async-b~b.js all/a~async-a~async-b~async-c~b~c.js all/a.js
-    Entrypoint b = all/vendors~a~async-a~async-b~async-c~b~c.js all/vendors~a~async-a~async-b~b.js all/a~async-a~async-b~async-c~b~c.js all/b.js
-    Entrypoint c = all/vendors~a~async-a~async-b~async-c~b~c.js all/vendors~async-c~c.js all/a~async-a~async-b~async-c~b~c.js all/c.js
+    Entrypoint a = all/4.js all/5.js all/3.js all/a.js
+    Entrypoint b = all/4.js all/5.js all/3.js all/b.js
+    Entrypoint c = all/4.js all/11.js all/3.js all/c.js
     chunk    {0} all/main.js (main) 147 bytes >{2}< >{3}< >{4}< >{5}< >{6}< >{8}< >{10}< >{11}< [entry] [rendered]
         > ./ main
      [0] ./index.js 147 bytes {0} [built]
@@ -408,7 +408,7 @@ Child all:
      [1] ./a.js + 1 modules 156 bytes {1} {2} [built]
          | ./e.js 20 bytes [built]
          | ./a.js 121 bytes [built]
-    chunk    {3} all/a~async-a~async-b~async-c~b~c.js (a~async-a~async-b~async-c~b~c) 20 bytes <{0}> ={1}= ={2}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: default) (name: a~async-a~async-b~async-c~b~c)
+    chunk    {3} all/3.js 20 bytes <{0}> ={1}= ={2}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: default)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
@@ -416,7 +416,7 @@ Child all:
         > ./b b
         > ./c c
      [2] ./d.js 20 bytes {3} [built]
-    chunk    {4} all/vendors~a~async-a~async-b~async-c~b~c.js (vendors~a~async-a~async-b~async-c~b~c) 20 bytes <{0}> ={1}= ={2}= ={3}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors~a~async-a~async-b~async-c~b~c)
+    chunk    {4} all/4.js 20 bytes <{0}> ={1}= ={2}= ={3}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: vendors)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
@@ -424,7 +424,7 @@ Child all:
         > ./b b
         > ./c c
      [3] ./node_modules/x.js 20 bytes {4} [built]
-    chunk    {5} all/vendors~a~async-a~async-b~b.js (vendors~a~async-a~async-b~b) 20 bytes <{0}> ={1}= ={2}= ={3}= ={4}= ={6}= ={7}= ={8}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors~a~async-a~async-b~b)
+    chunk    {5} all/5.js 20 bytes <{0}> ={1}= ={2}= ={3}= ={4}= ={6}= ={7}= ={8}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: vendors)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./a a
@@ -437,7 +437,7 @@ Child all:
         > ./b b
      [5] ./b.js 72 bytes {6} {7} [built]
      [6] ./f.js 20 bytes {7} {8} {9} [built]
-    chunk    {8} all/async-b~async-c~async-g.js (async-b~async-c~async-g) 20 bytes <{0}> <{1}> <{2}> <{3}> <{4}> <{5}> ={3}= ={4}= ={5}= ={6}= ={10}= ={11}= ={12}= [rendered] split chunk (cache group: default) (name: async-b~async-c~async-g)
+    chunk    {8} all/8.js 20 bytes <{0}> <{1}> <{2}> <{3}> <{4}> <{5}> ={3}= ={4}= ={5}= ={6}= ={10}= ={11}= ={12}= [rendered] split chunk (cache group: default)
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
         > ./g [] 6:0-47
@@ -449,7 +449,7 @@ Child all:
     chunk   {10} all/async-c.js (async-c) 72 bytes <{0}> ={3}= ={4}= ={8}= ={11}= [rendered]
         > ./c [0] ./index.js 3:0-47
      [7] ./c.js 72 bytes {9} {10} [built]
-    chunk   {11} all/vendors~async-c~c.js (vendors~async-c~c) 20 bytes <{0}> ={3}= ={4}= ={8}= ={9}= ={10}= [initial] [rendered] split chunk (cache group: vendors) (name: vendors~async-c~c)
+    chunk   {11} all/11.js 20 bytes <{0}> ={3}= ={4}= ={8}= ={9}= ={10}= [initial] [rendered] split chunk (cache group: vendors)
         > ./c [0] ./index.js 3:0-47
         > ./c c
      [8] ./node_modules/z.js 20 bytes {11} [built]
@@ -603,13 +603,13 @@ Entrypoint <CLR=BOLD>main</CLR> = <CLR=32>main.js</CLR>
 `;
 
 exports[`StatsTestCases should print correct stats for commons-chunk-min-size-0 1`] = `
-"Hash: 909e4c9a262cbe4d7310
+"Hash: 5415bcc32308368f9976
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
-              Asset       Size  Chunks             Chunk Names
-         entry-1.js    6.6 KiB       0  [emitted]  entry-1
-vendor-1~entry-1.js  314 bytes       1  [emitted]  vendor-1~entry-1
-Entrypoint entry-1 = vendor-1~entry-1.js entry-1.js
+     Asset       Size  Chunks             Chunk Names
+      1.js  314 bytes       1  [emitted]  
+entry-1.js    6.6 KiB       0  [emitted]  entry-1
+Entrypoint entry-1 = 1.js entry-1.js
 [0] ./entry-1.js 145 bytes {0} [built]
 [1] ./modules/a.js 22 bytes {1} [built]
 [2] ./modules/b.js 22 bytes {1} [built]
@@ -1115,41 +1115,41 @@ Compilation error while processing magic comment(-s): /* webpackPrefetch: nope *
 `;
 
 exports[`StatsTestCases should print correct stats for issue-7577 1`] = `
-"Hash: db9524722316531105303456484e3930807d47ca2f947370a312bb66478c
+"Hash: dbd4b7d63f22c4b4dcd83dec2521653092ed90dbe78704d0ba0c44389632
 Child
-    Hash: db952472231653110530
+    Hash: dbd4b7d63f22c4b4dcd8
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
                                      Asset       Size        Chunks             Chunk Names
-        a-all~main-0034bb84916bcade4cc7.js  154 bytes      all~main  [emitted]  all~main
-            a-main-9407860001b0bf9acb00.js  108 bytes          main  [emitted]  main
+               a-0-f8f9804acad5459b1e79.js  145 bytes             0  [emitted]  
+            a-main-8153e4f657436709e26b.js   99 bytes          main  [emitted]  main
     a-runtime~main-3965b14e62ab18a5b93e.js   6.05 KiB  runtime~main  [emitted]  runtime~main
-    Entrypoint main = a-runtime~main-3965b14e62ab18a5b93e.js a-all~main-0034bb84916bcade4cc7.js a-main-9407860001b0bf9acb00.js
-    [0] ./a.js 18 bytes {all~main} [built]
+    Entrypoint main = a-runtime~main-3965b14e62ab18a5b93e.js a-0-f8f9804acad5459b1e79.js a-main-8153e4f657436709e26b.js
+    [0] ./a.js 18 bytes {0} [built]
 Child
-    Hash: 3456484e3930807d47ca
+    Hash: 3dec2521653092ed90db
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
                                      Asset       Size        Chunks             Chunk Names
-        b-all~main-8fc824ada14cfa87179b.js  459 bytes      all~main  [emitted]  all~main
-            b-main-9b8bde6297868240e02c.js  123 bytes          main  [emitted]  main
+               b-0-8d3634c9c50f9b0177ed.js  450 bytes             0  [emitted]  
+               b-1-2a8654e1b96527742ef3.js  159 bytes             1  [emitted]  
+            b-main-61a2b92663307debcf7f.js  101 bytes          main  [emitted]  main
     b-runtime~main-3965b14e62ab18a5b93e.js   6.05 KiB  runtime~main  [emitted]  runtime~main
-    b-vendors~main-13c0fc262f08dee65613.js  172 bytes  vendors~main  [emitted]  vendors~main
-    Entrypoint main = b-runtime~main-3965b14e62ab18a5b93e.js b-vendors~main-13c0fc262f08dee65613.js b-all~main-8fc824ada14cfa87179b.js b-main-9b8bde6297868240e02c.js
-    [0] ./b.js 17 bytes {all~main} [built]
-    [1] ./node_modules/vendor.js 23 bytes {vendors~main} [built]
+    Entrypoint main = b-runtime~main-3965b14e62ab18a5b93e.js b-1-2a8654e1b96527742ef3.js b-0-8d3634c9c50f9b0177ed.js b-main-61a2b92663307debcf7f.js
+    [0] ./b.js 17 bytes {0} [built]
+    [1] ./node_modules/vendor.js 23 bytes {1} [built]
 Child
-    Hash: 2f947370a312bb66478c
+    Hash: e78704d0ba0c44389632
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
                                      Asset       Size        Chunks             Chunk Names
-        c-all~main-3f17001edc510ffa13b4.js  302 bytes      all~main  [emitted]  all~main
+               c-0-c1982a29e77c7a051af2.js  293 bytes             0  [emitted]  
               c-b0-08b1c51075eefabb49b0.js  462 bytes            b0  [emitted]  
               c-b1-b4adffe55c7947bb635f.js  156 bytes            b1  [emitted]  
-            c-main-d86aa80e7330f9a4e0c2.js  120 bytes          main  [emitted]  main
+            c-main-d176dadf5c763307f6af.js  111 bytes          main  [emitted]  main
     c-runtime~main-aee5be026dc40ed615b1.js   8.84 KiB  runtime~main  [emitted]  runtime~main
-    Entrypoint main = c-runtime~main-aee5be026dc40ed615b1.js c-all~main-3f17001edc510ffa13b4.js c-main-d86aa80e7330f9a4e0c2.js (prefetch: c-b1-b4adffe55c7947bb635f.js c-b0-08b1c51075eefabb49b0.js)
-    [0] ./c.js 61 bytes {all~main} [built]
+    Entrypoint main = c-runtime~main-aee5be026dc40ed615b1.js c-0-c1982a29e77c7a051af2.js c-main-d176dadf5c763307f6af.js (prefetch: c-b1-b4adffe55c7947bb635f.js c-b0-08b1c51075eefabb49b0.js)
+    [0] ./c.js 61 bytes {0} [built]
     [1] ./b.js 17 bytes {b0} [built]
     [2] ./node_modules/vendor.js 23 bytes {b1} [built]"
 `;
@@ -1440,8 +1440,8 @@ You may need an appropriate loader to handle this file type.
 exports[`StatsTestCases should print correct stats for named-chunk-groups 1`] = `
 "Child
     Chunk Group main = main.js
-    Chunk Group async-a = async-a~async-b.js async-a.js
-    Chunk Group async-b = async-a~async-b.js async-b.js
+    Chunk Group async-a = 2.js async-a.js
+    Chunk Group async-b = 2.js async-b.js
     Chunk Group async-c = vendors.js async-c.js
     chunk    {0} main.js (main) 146 bytes >{1}< >{2}< >{3}< >{4}< >{5}< [entry] [rendered]
         > ./ main
@@ -1449,7 +1449,7 @@ exports[`StatsTestCases should print correct stats for named-chunk-groups 1`] = 
     chunk    {1} async-a.js (async-a) 40 bytes <{0}> ={2}= [rendered]
         > ./a [0] ./index.js 1:0-47
      [1] ./a.js 40 bytes {1} [built]
-    chunk    {2} async-a~async-b.js (async-a~async-b) 133 bytes <{0}> ={1}= ={3}= [rendered] split chunk (cache group: default) (name: async-a~async-b)
+    chunk    {2} 2.js 133 bytes <{0}> ={1}= ={3}= [rendered] split chunk (cache group: default)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
      [2] ./shared.js 133 bytes {2} [built]
@@ -1465,8 +1465,8 @@ exports[`StatsTestCases should print correct stats for named-chunk-groups 1`] = 
      [6] ./node_modules/y.js 20 bytes {5} [built]
 Child
     Entrypoint main = main.js
-    Chunk Group async-a = async-a~async-b.js async-a.js
-    Chunk Group async-b = async-a~async-b.js async-b.js
+    Chunk Group async-a = 2.js async-a.js
+    Chunk Group async-b = 2.js async-b.js
     Chunk Group async-c = vendors.js async-c.js
     chunk    {0} main.js (main) 146 bytes >{1}< >{2}< >{3}< >{4}< >{5}< [entry] [rendered]
         > ./ main
@@ -1474,7 +1474,7 @@ Child
     chunk    {1} async-a.js (async-a) 40 bytes <{0}> ={2}= [rendered]
         > ./a [0] ./index.js 1:0-47
      [1] ./a.js 40 bytes {1} [built]
-    chunk    {2} async-a~async-b.js (async-a~async-b) 133 bytes <{0}> ={1}= ={3}= [rendered] split chunk (cache group: default) (name: async-a~async-b)
+    chunk    {2} 2.js 133 bytes <{0}> ={1}= ={3}= [rendered] split chunk (cache group: default)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
      [2] ./shared.js 133 bytes {2} [built]
@@ -2357,7 +2357,7 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
      [2] ./d.js 20 bytes {2} {3} {4} {5} [built]
      [3] ./node_modules/x.js 20 bytes {2} {4} {5} {6} [built]
      [4] ./node_modules/y.js 20 bytes {2} {4} {7} [built]
-    chunk    {3} default/async-a~async-b~async-c.js (async-a~async-b~async-c) 20 bytes <{0}> ={1}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{9}< >{12}< [rendered] split chunk (cache group: default) (name: async-a~async-b~async-c)
+    chunk    {3} default/3.js 20 bytes <{0}> ={1}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{9}< >{12}< [rendered] split chunk (cache group: default)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
@@ -2376,19 +2376,19 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
      [6] ./f.js 20 bytes {4} {5} {9} [built]
      [7] ./c.js 72 bytes {5} {10} [built]
      [8] ./node_modules/z.js 20 bytes {5} {11} [built]
-    chunk    {6} default/vendors~async-a~async-b~async-c.js (vendors~async-a~async-b~async-c) 20 bytes <{0}> ={1}= ={3}= ={7}= ={8}= ={9}= ={10}= ={11}= >{9}< >{12}< [rendered] split chunk (cache group: defaultVendors) (name: vendors~async-a~async-b~async-c)
+    chunk    {6} default/6.js 20 bytes <{0}> ={1}= ={3}= ={7}= ={8}= ={9}= ={10}= ={11}= >{9}< >{12}< [rendered] split chunk (cache group: defaultVendors)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
      [3] ./node_modules/x.js 20 bytes {2} {4} {5} {6} [built]
-    chunk    {7} default/vendors~async-a~async-b.js (vendors~async-a~async-b) 20 bytes <{0}> ={1}= ={3}= ={6}= ={8}= ={9}= >{9}< >{12}< [rendered] split chunk (cache group: defaultVendors) (name: vendors~async-a~async-b)
+    chunk    {7} default/7.js 20 bytes <{0}> ={1}= ={3}= ={6}= ={8}= ={9}= >{9}< >{12}< [rendered] split chunk (cache group: defaultVendors)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
      [4] ./node_modules/y.js 20 bytes {2} {4} {7} [built]
     chunk    {8} default/async-b.js (async-b) 72 bytes <{0}> ={3}= ={6}= ={7}= ={9}= [rendered]
         > ./b [0] ./index.js 2:0-47
      [5] ./b.js 72 bytes {4} {8} [built]
-    chunk    {9} default/async-b~async-c~async-g.js (async-b~async-c~async-g) 20 bytes <{0}> <{1}> <{2}> <{3}> <{6}> <{7}> ={3}= ={6}= ={7}= ={8}= ={10}= ={11}= ={12}= [rendered] split chunk (cache group: default) (name: async-b~async-c~async-g)
+    chunk    {9} default/9.js 20 bytes <{0}> <{1}> <{2}> <{3}> <{6}> <{7}> ={3}= ={6}= ={7}= ={8}= ={10}= ={11}= ={12}= [rendered] split chunk (cache group: default)
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
         > ./g [] 6:0-47
@@ -2396,7 +2396,7 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
     chunk   {10} default/async-c.js (async-c) 72 bytes <{0}> ={3}= ={6}= ={9}= ={11}= [rendered]
         > ./c [0] ./index.js 3:0-47
      [7] ./c.js 72 bytes {5} {10} [built]
-    chunk   {11} default/vendors~async-c.js (vendors~async-c) 20 bytes <{0}> ={3}= ={6}= ={9}= ={10}= [rendered] split chunk (cache group: defaultVendors) (name: vendors~async-c)
+    chunk   {11} default/11.js 20 bytes <{0}> ={3}= ={6}= ={9}= ={10}= [rendered] split chunk (cache group: defaultVendors)
         > ./c [0] ./index.js 3:0-47
      [8] ./node_modules/z.js 20 bytes {5} {11} [built]
     chunk   {12} default/async-g.js (async-g) 34 bytes <{1}> <{2}> <{3}> <{6}> <{7}> ={9}= [rendered]
@@ -2404,9 +2404,9 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
      [9] ./g.js 34 bytes {12} [built]
 Child all-chunks:
     Entrypoint main = default/main.js
-    Entrypoint a = default/vendors~a~async-a~async-b~async-c~b~c.js default/vendors~a~async-a~async-b~b.js default/a~async-a~async-b~async-c~b~c.js default/a.js
-    Entrypoint b = default/vendors~a~async-a~async-b~async-c~b~c.js default/vendors~a~async-a~async-b~b.js default/a~async-a~async-b~async-c~b~c.js default/b.js
-    Entrypoint c = default/vendors~a~async-a~async-b~async-c~b~c.js default/vendors~async-c~c.js default/a~async-a~async-b~async-c~b~c.js default/c.js
+    Entrypoint a = default/4.js default/5.js default/3.js default/a.js
+    Entrypoint b = default/4.js default/5.js default/3.js default/b.js
+    Entrypoint c = default/4.js default/11.js default/3.js default/c.js
     chunk    {0} default/main.js (main) 147 bytes >{2}< >{3}< >{4}< >{5}< >{6}< >{8}< >{10}< >{11}< [entry] [rendered]
         > ./ main
      [0] ./index.js 147 bytes {0} [built]
@@ -2420,7 +2420,7 @@ Child all-chunks:
      [1] ./a.js + 1 modules 156 bytes {1} {2} [built]
          | ./e.js 20 bytes [built]
          | ./a.js 121 bytes [built]
-    chunk    {3} default/a~async-a~async-b~async-c~b~c.js (a~async-a~async-b~async-c~b~c) 20 bytes <{0}> ={1}= ={2}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: default) (name: a~async-a~async-b~async-c~b~c)
+    chunk    {3} default/3.js 20 bytes <{0}> ={1}= ={2}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: default)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
@@ -2428,7 +2428,7 @@ Child all-chunks:
         > ./b b
         > ./c c
      [2] ./d.js 20 bytes {3} [built]
-    chunk    {4} default/vendors~a~async-a~async-b~async-c~b~c.js (vendors~a~async-a~async-b~async-c~b~c) 20 bytes <{0}> ={1}= ={2}= ={3}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: defaultVendors) (name: vendors~a~async-a~async-b~async-c~b~c)
+    chunk    {4} default/4.js 20 bytes <{0}> ={1}= ={2}= ={3}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: defaultVendors)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
@@ -2436,7 +2436,7 @@ Child all-chunks:
         > ./b b
         > ./c c
      [3] ./node_modules/x.js 20 bytes {4} [built]
-    chunk    {5} default/vendors~a~async-a~async-b~b.js (vendors~a~async-a~async-b~b) 20 bytes <{0}> ={1}= ={2}= ={3}= ={4}= ={6}= ={7}= ={8}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: defaultVendors) (name: vendors~a~async-a~async-b~b)
+    chunk    {5} default/5.js 20 bytes <{0}> ={1}= ={2}= ={3}= ={4}= ={6}= ={7}= ={8}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: defaultVendors)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./a a
@@ -2449,7 +2449,7 @@ Child all-chunks:
         > ./b b
      [5] ./b.js 72 bytes {6} {7} [built]
      [6] ./f.js 20 bytes {7} {8} {9} [built]
-    chunk    {8} default/async-b~async-c~async-g.js (async-b~async-c~async-g) 20 bytes <{0}> <{1}> <{2}> <{3}> <{4}> <{5}> ={3}= ={4}= ={5}= ={6}= ={10}= ={11}= ={12}= [rendered] split chunk (cache group: default) (name: async-b~async-c~async-g)
+    chunk    {8} default/8.js 20 bytes <{0}> <{1}> <{2}> <{3}> <{4}> <{5}> ={3}= ={4}= ={5}= ={6}= ={10}= ={11}= ={12}= [rendered] split chunk (cache group: default)
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
         > ./g [] 6:0-47
@@ -2461,7 +2461,7 @@ Child all-chunks:
     chunk   {10} default/async-c.js (async-c) 72 bytes <{0}> ={3}= ={4}= ={8}= ={11}= [rendered]
         > ./c [0] ./index.js 3:0-47
      [7] ./c.js 72 bytes {9} {10} [built]
-    chunk   {11} default/vendors~async-c~c.js (vendors~async-c~c) 20 bytes <{0}> ={3}= ={4}= ={8}= ={9}= ={10}= [initial] [rendered] split chunk (cache group: defaultVendors) (name: vendors~async-c~c)
+    chunk   {11} default/11.js 20 bytes <{0}> ={3}= ={4}= ={8}= ={9}= ={10}= [initial] [rendered] split chunk (cache group: defaultVendors)
         > ./c [0] ./index.js 3:0-47
         > ./c c
      [8] ./node_modules/z.js 20 bytes {11} [built]
@@ -2542,9 +2542,9 @@ Child manual:
      [9] ./g.js 34 bytes {8} [built]
 Child name-too-long:
     Entrypoint main = main.js
-    Entrypoint aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~50ebc41f.js vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccc~18066793.js async-a.js aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js
-    Entrypoint bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~50ebc41f.js vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccc~18066793.js async-b~async-c~async-g~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccccccccccccccccccc.js async-b.js bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js
-    Entrypoint cccccccccccccccccccccccccccccc = vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~50ebc41f.js vendors~async-c~cccccccccccccccccccccccccccccc.js aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccc~18066793.js async-b~async-c~async-g~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccccccccccccccccccc.js async-c.js cccccccccccccccccccccccccccccc.js
+    Entrypoint aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = 6.js 7.js 5.js async-a.js aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js
+    Entrypoint bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = 6.js 7.js 5.js 9.js async-b.js bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js
+    Entrypoint cccccccccccccccccccccccccccccc = 6.js 11.js 5.js 9.js async-c.js cccccccccccccccccccccccccccccc.js
     chunk    {0} aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) 0 bytes ={4}= ={5}= ={6}= ={7}= >{9}< >{12}< [entry] [rendered]
         > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     chunk    {1} bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) 0 bytes ={5}= ={6}= ={7}= ={8}= ={9}= [entry] [rendered]
@@ -2560,7 +2560,7 @@ Child name-too-long:
      [1] ./a.js + 1 modules 156 bytes {4} [built]
          | ./e.js 20 bytes [built]
          | ./a.js 121 bytes [built]
-    chunk    {5} aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccc~18066793.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccc~18066793) 20 bytes <{3}> ={0}= ={1}= ={2}= ={4}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{9}< >{12}< [initial] [rendered] split chunk (cache group: default) (name: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccc~18066793)
+    chunk    {5} 5.js 20 bytes <{3}> ={0}= ={1}= ={2}= ={4}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{9}< >{12}< [initial] [rendered] split chunk (cache group: default)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
@@ -2568,7 +2568,7 @@ Child name-too-long:
         > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
         > ./c cccccccccccccccccccccccccccccc
      [2] ./d.js 20 bytes {5} [built]
-    chunk    {6} vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~50ebc41f.js (vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~50ebc41f) 20 bytes <{3}> ={0}= ={1}= ={2}= ={4}= ={5}= ={7}= ={8}= ={9}= ={10}= ={11}= >{9}< >{12}< [initial] [rendered] split chunk (cache group: defaultVendors) (name: vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~async-c~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccc~50ebc41f)
+    chunk    {6} 6.js 20 bytes <{3}> ={0}= ={1}= ={2}= ={4}= ={5}= ={7}= ={8}= ={9}= ={10}= ={11}= >{9}< >{12}< [initial] [rendered] split chunk (cache group: defaultVendors)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
@@ -2576,7 +2576,7 @@ Child name-too-long:
         > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
         > ./c cccccccccccccccccccccccccccccc
      [3] ./node_modules/x.js 20 bytes {6} [built]
-    chunk    {7} vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js (vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) 20 bytes <{3}> ={0}= ={1}= ={4}= ={5}= ={6}= ={8}= ={9}= >{9}< >{12}< [initial] [rendered] split chunk (cache group: defaultVendors) (name: vendors~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa~async-a~async-b~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+    chunk    {7} 7.js 20 bytes <{3}> ={0}= ={1}= ={4}= ={5}= ={6}= ={8}= ={9}= >{9}< >{12}< [initial] [rendered] split chunk (cache group: defaultVendors)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -2586,7 +2586,7 @@ Child name-too-long:
         > ./b [0] ./index.js 2:0-47
         > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
      [5] ./b.js 72 bytes {8} [built]
-    chunk    {9} async-b~async-c~async-g~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccccccccccccccccccc.js (async-b~async-c~async-g~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccccccccccccccccccc) 20 bytes <{0}> <{3}> <{4}> <{5}> <{6}> <{7}> ={1}= ={2}= ={5}= ={6}= ={7}= ={8}= ={10}= ={11}= ={12}= [initial] [rendered] split chunk (cache group: default) (name: async-b~async-c~async-g~bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb~cccccccccccccccccccccccccccccc)
+    chunk    {9} 9.js 20 bytes <{0}> <{3}> <{4}> <{5}> <{6}> <{7}> ={1}= ={2}= ={5}= ={6}= ={7}= ={8}= ={10}= ={11}= ={12}= [initial] [rendered] split chunk (cache group: default)
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
         > ./g [] 6:0-47
@@ -2597,7 +2597,7 @@ Child name-too-long:
         > ./c [0] ./index.js 3:0-47
         > ./c cccccccccccccccccccccccccccccc
      [7] ./c.js 72 bytes {10} [built]
-    chunk   {11} vendors~async-c~cccccccccccccccccccccccccccccc.js (vendors~async-c~cccccccccccccccccccccccccccccc) 20 bytes <{3}> ={2}= ={5}= ={6}= ={9}= ={10}= [initial] [rendered] split chunk (cache group: defaultVendors) (name: vendors~async-c~cccccccccccccccccccccccccccccc)
+    chunk   {11} 11.js 20 bytes <{3}> ={2}= ={5}= ={6}= ={9}= ={10}= [initial] [rendered] split chunk (cache group: defaultVendors)
         > ./c [0] ./index.js 3:0-47
         > ./c cccccccccccccccccccccccccccccc
      [8] ./node_modules/z.js 20 bytes {11} [built]
@@ -2607,8 +2607,8 @@ Child name-too-long:
 Child custom-chunks-filter:
     Entrypoint main = default/main.js
     Entrypoint a = default/a.js
-    Entrypoint b = default/vendors~async-a~async-b~async-c~b~c.js default/vendors~async-a~async-b~b.js default/async-a~async-b~async-c~b~c.js default/b.js
-    Entrypoint c = default/vendors~async-a~async-b~async-c~b~c.js default/vendors~async-c~c.js default/async-a~async-b~async-c~b~c.js default/c.js
+    Entrypoint b = default/4.js default/5.js default/3.js default/b.js
+    Entrypoint c = default/4.js default/11.js default/3.js default/c.js
     chunk    {0} default/main.js (main) 147 bytes >{1}< >{3}< >{4}< >{5}< >{6}< >{8}< >{10}< >{11}< [entry] [rendered]
         > ./ main
      [0] ./index.js 147 bytes {0} [built]
@@ -2625,21 +2625,21 @@ Child custom-chunks-filter:
      [2] ./d.js 20 bytes {2} {3} [built]
      [3] ./node_modules/x.js 20 bytes {2} {4} [built]
      [4] ./node_modules/y.js 20 bytes {2} {5} [built]
-    chunk    {3} default/async-a~async-b~async-c~b~c.js (async-a~async-b~async-c~b~c) 20 bytes <{0}> ={1}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: default) (name: async-a~async-b~async-c~b~c)
+    chunk    {3} default/3.js 20 bytes <{0}> ={1}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: default)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
         > ./b b
         > ./c c
      [2] ./d.js 20 bytes {2} {3} [built]
-    chunk    {4} default/vendors~async-a~async-b~async-c~b~c.js (vendors~async-a~async-b~async-c~b~c) 20 bytes <{0}> ={1}= ={3}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: defaultVendors) (name: vendors~async-a~async-b~async-c~b~c)
+    chunk    {4} default/4.js 20 bytes <{0}> ={1}= ={3}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: defaultVendors)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
         > ./b b
         > ./c c
      [3] ./node_modules/x.js 20 bytes {2} {4} [built]
-    chunk    {5} default/vendors~async-a~async-b~b.js (vendors~async-a~async-b~b) 20 bytes <{0}> ={1}= ={3}= ={4}= ={6}= ={7}= ={8}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: defaultVendors) (name: vendors~async-a~async-b~b)
+    chunk    {5} default/5.js 20 bytes <{0}> ={1}= ={3}= ={4}= ={6}= ={7}= ={8}= >{8}< >{12}< [initial] [rendered] split chunk (cache group: defaultVendors)
         > ./a [0] ./index.js 1:0-47
         > ./b [0] ./index.js 2:0-47
         > ./b b
@@ -2651,7 +2651,7 @@ Child custom-chunks-filter:
         > ./b b
      [5] ./b.js 72 bytes {6} {7} [built]
      [6] ./f.js 20 bytes {7} {8} {9} [built]
-    chunk    {8} default/async-b~async-c~async-g.js (async-b~async-c~async-g) 20 bytes <{0}> <{1}> <{2}> <{3}> <{4}> <{5}> ={3}= ={4}= ={5}= ={6}= ={10}= ={11}= ={12}= [rendered] split chunk (cache group: default) (name: async-b~async-c~async-g)
+    chunk    {8} default/8.js 20 bytes <{0}> <{1}> <{2}> <{3}> <{4}> <{5}> ={3}= ={4}= ={5}= ={6}= ={10}= ={11}= ={12}= [rendered] split chunk (cache group: default)
         > ./b [0] ./index.js 2:0-47
         > ./c [0] ./index.js 3:0-47
         > ./g [] 6:0-47
@@ -2663,7 +2663,7 @@ Child custom-chunks-filter:
     chunk   {10} default/async-c.js (async-c) 72 bytes <{0}> ={3}= ={4}= ={8}= ={11}= [rendered]
         > ./c [0] ./index.js 3:0-47
      [7] ./c.js 72 bytes {9} {10} [built]
-    chunk   {11} default/vendors~async-c~c.js (vendors~async-c~c) 20 bytes <{0}> ={3}= ={4}= ={8}= ={9}= ={10}= [initial] [rendered] split chunk (cache group: defaultVendors) (name: vendors~async-c~c)
+    chunk   {11} default/11.js 20 bytes <{0}> ={3}= ={4}= ={8}= ={9}= ={10}= [initial] [rendered] split chunk (cache group: defaultVendors)
         > ./c [0] ./index.js 3:0-47
         > ./c c
      [8] ./node_modules/z.js 20 bytes {11} [built]
@@ -2745,37 +2745,41 @@ Child custom-chunks-filter-in-cache-groups:
 
 exports[`StatsTestCases should print correct stats for split-chunks-automatic-name 1`] = `
 "Entrypoint main = main.js
-chunk    {0} main.js (main) 147 bytes >{1}< >{2}< >{3}< >{4}< >{5}< >{6}< >{7}< [entry] [rendered]
+chunk    {0} main.js (main) 147 bytes >{1}< >{2}< >{3}< >{4}< >{5}< >{6}< >{7}< >{8}< [entry] [rendered]
     > ./ main
  [0] ./index.js 147 bytes {0} [built]
-chunk    {1} async-a.js (async-a) 107 bytes <{0}> ={2}= ={3}= [rendered]
+chunk    {1} async-a.js (async-a) 107 bytes <{0}> ={2}= ={3}= ={4}= [rendered]
     > ./a [0] ./index.js 1:0-47
  [1] ./a.js + 1 modules 107 bytes {1} [built]
      | ./e.js 20 bytes [built]
      | ./a.js 72 bytes [built]
-chunk    {2} common~async-a~async-b~async-c.js (common~async-a~async-b~async-c) 40 bytes <{0}> ={1}= ={3}= ={4}= ={5}= ={6}= ={7}= [rendered] split chunk (cache group: vendors) (name: common~async-a~async-b~async-c)
+chunk    {2} 2.js 20 bytes <{0}> ={1}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= [rendered] split chunk (cache group: default)
     > ./a [0] ./index.js 1:0-47
     > ./b [0] ./index.js 2:0-47
     > ./c [0] ./index.js 3:0-47
  [2] ./d.js 20 bytes {2} [built]
- [3] ./node_modules/x.js 20 bytes {2} [built]
-chunk    {3} common~async-a~async-b.js (common~async-a~async-b) 20 bytes <{0}> ={1}= ={2}= ={4}= ={5}= [rendered] split chunk (cache group: vendors) (name: common~async-a~async-b)
+chunk    {3} 3.js 20 bytes <{0}> ={1}= ={2}= ={4}= ={5}= ={6}= ={7}= ={8}= [rendered] split chunk (cache group: vendors)
     > ./a [0] ./index.js 1:0-47
     > ./b [0] ./index.js 2:0-47
- [4] ./node_modules/y.js 20 bytes {3} [built]
-chunk    {4} async-b.js (async-b) 72 bytes <{0}> ={2}= ={3}= ={5}= [rendered]
+    > ./c [0] ./index.js 3:0-47
+ [3] ./node_modules/x.js 20 bytes {3} [built]
+chunk    {4} 4.js 20 bytes <{0}> ={1}= ={2}= ={3}= ={5}= ={6}= [rendered] split chunk (cache group: vendors)
+    > ./a [0] ./index.js 1:0-47
     > ./b [0] ./index.js 2:0-47
- [5] ./b.js 72 bytes {4} [built]
-chunk    {5} common~async-b~async-c.js (common~async-b~async-c) 20 bytes <{0}> ={2}= ={3}= ={4}= ={6}= ={7}= [rendered] split chunk (cache group: vendors) (name: common~async-b~async-c)
+ [4] ./node_modules/y.js 20 bytes {4} [built]
+chunk    {5} async-b.js (async-b) 72 bytes <{0}> ={2}= ={3}= ={4}= ={6}= [rendered]
+    > ./b [0] ./index.js 2:0-47
+ [5] ./b.js 72 bytes {5} [built]
+chunk    {6} 6.js 20 bytes <{0}> ={2}= ={3}= ={4}= ={5}= ={7}= ={8}= [rendered] split chunk (cache group: default)
     > ./b [0] ./index.js 2:0-47
     > ./c [0] ./index.js 3:0-47
- [6] ./f.js 20 bytes {5} [built]
-chunk    {6} async-c.js (async-c) 72 bytes <{0}> ={2}= ={5}= ={7}= [rendered]
+ [6] ./f.js 20 bytes {6} [built]
+chunk    {7} async-c.js (async-c) 72 bytes <{0}> ={2}= ={3}= ={6}= ={8}= [rendered]
     > ./c [0] ./index.js 3:0-47
- [7] ./c.js 72 bytes {6} [built]
-chunk    {7} common~async-c.js (common~async-c) 20 bytes <{0}> ={2}= ={5}= ={6}= [rendered] split chunk (cache group: vendors) (name: common~async-c)
+ [7] ./c.js 72 bytes {7} [built]
+chunk    {8} 8.js 20 bytes <{0}> ={2}= ={3}= ={6}= ={7}= [rendered] split chunk (cache group: vendors)
     > ./c [0] ./index.js 3:0-47
- [8] ./node_modules/z.js 20 bytes {7} [built]"
+ [8] ./node_modules/z.js 20 bytes {8} [built]"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-combinations 1`] = `
@@ -2786,7 +2790,7 @@ chunk    {0} main.js (main) 343 bytes >{1}< >{2}< >{3}< >{4}< >{5}< >{6}< >{7}< 
 chunk    {1} async-a.js (async-a) 48 bytes <{0}> ={2}= [rendered]
     > ./a [0] ./index.js 1:0-47
  [1] ./a.js 48 bytes {1} [built]
-chunk    {2} async-a~async-b.js (async-a~async-b) 134 bytes <{0}> ={1}= ={8}= [rendered] split chunk (cache group: default) (name: async-a~async-b)
+chunk    {2} 2.js 134 bytes <{0}> ={1}= ={8}= [rendered] split chunk (cache group: default)
     > ./a [0] ./index.js 1:0-47
     > ./b [0] ./index.js 2:0-47
  [2] ./x.js 67 bytes {2} {3} {4} {5} {6} {7} [built]
@@ -2824,12 +2828,12 @@ chunk    {0} main.js (main) 147 bytes >{1}< >{2}< >{3}< >{4}< >{5}< [entry] [ren
 chunk    {1} async-a.js (async-a) 19 bytes <{0}> ={2}= ={3}= [rendered]
     > ./a [0] ./index.js 1:0-47
  [1] ./a.js 19 bytes {1} [built]
-chunk    {2} async-a~async-b~async-c.js (async-a~async-b~async-c) 11 bytes <{0}> ={1}= ={3}= ={4}= ={5}= [rendered] split chunk (cache group: default) (name: async-a~async-b~async-c)
+chunk    {2} 2.js 11 bytes <{0}> ={1}= ={3}= ={4}= ={5}= [rendered] split chunk (cache group: default)
     > ./a [0] ./index.js 1:0-47
     > ./b [0] ./index.js 2:0-47
     > ./c [0] ./index.js 3:0-47
  [2] ./common.js 11 bytes {2} [built]
-chunk    {3} vendors~async-a~async-b~async-c.js (vendors~async-a~async-b~async-c) 20 bytes <{0}> ={1}= ={2}= ={4}= ={5}= [rendered] split chunk (cache group: defaultVendors) (name: vendors~async-a~async-b~async-c)
+chunk    {3} 3.js 20 bytes <{0}> ={1}= ={2}= ={4}= ={5}= [rendered] split chunk (cache group: defaultVendors)
     > ./a [0] ./index.js 1:0-47
     > ./b [0] ./index.js 2:0-47
     > ./c [0] ./index.js 3:0-47
@@ -2861,13 +2865,13 @@ chunk    {3} async-b.js (async-b) 32 bytes <{0}> <{1}> [rendered]
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-7401 1`] = `
-"Entrypoint a = vendors~a~c.js a.js
+"Entrypoint a = 1.js a.js
 Entrypoint b = b.js
-Chunk Group c = vendors~a~c.js c.js
+Chunk Group c = 1.js c.js
 chunk    {0} a.js (a) 12 bytes ={1}= [entry] [rendered]
     > ./a a
  [0] ./a.js 12 bytes {0} [built]
-chunk    {1} vendors~a~c.js (vendors~a~c) 20 bytes <{2}> ={0}= ={3}= [initial] [rendered] split chunk (cache group: defaultVendors) (name: vendors~a~c)
+chunk    {1} 1.js 20 bytes <{2}> ={0}= ={3}= [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./c [2] ./b.js 1:0-41
     > ./a a
  [1] ./node_modules/x.js 20 bytes {1} [built]
@@ -2881,7 +2885,7 @@ chunk    {3} c.js (c) 12 bytes <{2}> ={1}= [rendered]
 
 exports[`StatsTestCases should print correct stats for split-chunks-max-size 1`] = `
 "Child production:
-    Entrypoint main = prod-vendors~main~7274e1de.js prod-vendors~main~0feae4ad.js prod-main~6e7ead72.js prod-main~6a2ae26b.js prod-main~17acad98.js prod-main~b2c7414a.js prod-main~75f09de8.js prod-main~052b3814.js prod-main~3ff27526.js prod-main~11485824.js prod-main~c6931360.js prod-main~cd7c5bfc.js prod-main~02369f19.js
+    Entrypoint main = prod-11.js prod-12.js prod-main~6e7ead72.js prod-main~6a2ae26b.js prod-main~17acad98.js prod-main~b2c7414a.js prod-main~75f09de8.js prod-main~052b3814.js prod-main~3ff27526.js prod-main~11485824.js prod-main~c6931360.js prod-main~cd7c5bfc.js prod-main~02369f19.js
     chunk    {0} prod-main~b2c7414a.js (main~b2c7414a) 1.19 KiB ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= ={12}= [initial] [rendered]
         > ./ main
      [0] ./index.js 1.19 KiB {0} [built]
@@ -2945,12 +2949,12 @@ exports[`StatsTestCases should print correct stats for split-chunks-max-size 1`]
     chunk   {10} prod-main~17acad98.js (main~17acad98) 1.57 KiB ={0}= ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={11}= ={12}= [initial] [rendered]
         > ./ main
      [40] ./in-some-directory/very-big.js?1 1.57 KiB {10} [built]
-    chunk   {11} prod-vendors~main~7274e1de.js (vendors~main~7274e1de) 402 bytes ={0}= ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={12}= [initial] [rendered] split chunk (cache group: defaultVendors) (name: vendors~main)
+    chunk   {11} prod-11.js 402 bytes ={0}= ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={12}= [initial] [rendered] split chunk (cache group: defaultVendors)
         > ./ main
      [41] ./node_modules/big.js?1 268 bytes {11} [built]
      [42] ./node_modules/small.js?1 67 bytes {11} [built]
      [43] ./node_modules/small.js?2 67 bytes {11} [built]
-    chunk   {12} prod-vendors~main~0feae4ad.js (vendors~main~0feae4ad) 1.57 KiB ={0}= ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= [initial] [rendered] split chunk (cache group: defaultVendors) (name: vendors~main)
+    chunk   {12} prod-12.js 1.57 KiB ={0}= ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= [initial] [rendered] split chunk (cache group: defaultVendors)
         > ./ main
      [44] ./node_modules/very-big.js?1 1.57 KiB {12} [built]
 Child development:
@@ -3038,7 +3042,7 @@ chunk    {1} default/async-a.js (async-a) 134 bytes <{0}> [rendered]
  [1] ./a.js 48 bytes {1} [built]
  [2] ./d.js 43 bytes {1} {2} [built]
  [3] ./e.js 43 bytes {1} {3} [built]
-chunk    {2} default/async-b~async-c.js (async-b~async-c) 110 bytes <{0}> ={3}= ={4}= [rendered] split chunk (cache group: default) (name: async-b~async-c)
+chunk    {2} default/2.js 110 bytes <{0}> ={3}= ={4}= [rendered] split chunk (cache group: default)
     > ./b [0] ./index.js 2:0-47
     > ./c [0] ./index.js 3:0-47
  [2] ./d.js 43 bytes {1} {2} [built]


### PR DESCRIPTION
Hi people!

Motivated by sokra's comment here: https://github.com/webpack/webpack/issues/8426#issuecomment-442375207. Closes #8426.

I also made a PR to the docs (https://github.com/webpack/webpack.js.org/pull/2672) for the current version - as the `false` option wasn't documented.

**What kind of change does this PR introduce?**

A new default value for production builds.

**Did you add tests for your changes?**

No directly - but there are tests that rely on this functionality (and those are updated). Happy to do more if needed.

**Does this PR introduce a breaking change?**

Yes, as the default value changes - the PR is made to `next`.

**What needs to be documented once your changes are merged?**

1) Slight update to https://webpack.js.org/plugins/split-chunks-plugin/#splitchunks-name
2) Update default config on https://webpack.js.org/concepts/mode/
