### PR TITLE
Cache hasRunstime in chunk

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -454,6 +454,10 @@ class Chunk {
 	}
 
 	canBeIntegrated(otherChunk) {
+		if (this.preventIntegration || otherChunk.preventIntegration) {
+			return false;
+		}
+
 		const isAvailable = (a, b) => {
 			const queue = new Set(b.groupsIterable);
 			for (const chunkGroup of queue) {
@@ -466,14 +470,13 @@ class Chunk {
 			return true;
 		};
 
-		if (this.preventIntegration || otherChunk.preventIntegration) {
-			return false;
-		}
+		const selfHasRuntime = this.hasRuntime();
+		const otherChunkHasRuntime = otherChunk.hasRuntime();
 
-		if (this.hasRuntime() !== otherChunk.hasRuntime()) {
-			if (this.hasRuntime()) {
+		if (selfHasRuntime !== otherChunkHasRuntime) {
+			if (selfHasRuntime) {
 				return isAvailable(this, otherChunk);
-			} else if (otherChunk.hasRuntime()) {
+			} else if (otherChunkHasRuntime) {
 				return isAvailable(otherChunk, this);
 			} else {
 				return false;


### PR DESCRIPTION
Cache `this.hasRuntime()`, `otherChunk.hasRuntime()` in variable. Because in some cases these methods call twice.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Refactoring
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
No
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
