### PR TITLE
fix: `.wasm` extension should have lower priority when resolving modules

### DIFF
--- a/lib/DelegatedModuleFactoryPlugin.js
+++ b/lib/DelegatedModuleFactoryPlugin.js
@@ -17,10 +17,10 @@ class DelegatedModuleFactoryPlugin {
 		options.type = options.type || "require";
 		options.extensions = options.extensions || [
 			"",
-			".wasm",
 			".mjs",
 			".js",
-			".json"
+			".json",
+			".wasm"
 		];
 	}
 

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -324,7 +324,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("resolve", "call", value => Object.assign({}, value));
 		this.set("resolve.unsafeCache", true);
 		this.set("resolve.modules", ["node_modules"]);
-		this.set("resolve.extensions", [".wasm", ".mjs", ".js", ".json"]);
+		this.set("resolve.extensions", [".mjs", ".js", ".json", ".wasm"]);
 		this.set("resolve.mainFiles", ["index"]);
 		this.set("resolve.aliasFields", "make", options => {
 			if (


### PR DESCRIPTION
Fixes #8445

**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

No, not sure what kind of test should I add

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

https://github.com/webpack/webpack.js.org/blob/master/src/content/configuration/resolve.md#resolveextensions