### PR TITLE
enforce doesn't affect minSize for maxSize

### DIFF
--- a/lib/optimize/MinMaxSizeWarning.js
+++ b/lib/optimize/MinMaxSizeWarning.js
@@ -1,0 +1,29 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+"use strict";
+
+const WebpackError = require("../WebpackError");
+const SizeFormatHelpers = require("../SizeFormatHelpers");
+
+class MinMaxSizeWarning extends WebpackError {
+	constructor(keys, minSize, maxSize) {
+		let keysMessage = "Fallback cache group";
+		if (keys) {
+			keysMessage =
+				keys.length > 1
+					? `Cache groups ${keys.sort().join(", ")}`
+					: `Cache group ${keys[0]}`;
+		}
+		super(
+			`SplitChunksPlugin\n` +
+				`${keysMessage}\n` +
+				`Configured minSize (${SizeFormatHelpers.formatSize(minSize)}) is ` +
+				`bigger than maxSize (${SizeFormatHelpers.formatSize(maxSize)}).\n` +
+				"This seem to be a invalid optimiziation.splitChunks configuration."
+		);
+	}
+}
+
+module.exports = MinMaxSizeWarning;

--- a/lib/optimize/SplitChunksPlugin.js
+++ b/lib/optimize/SplitChunksPlugin.js
@@ -9,6 +9,7 @@ const SortableSet = require("../util/SortableSet");
 const GraphHelpers = require("../GraphHelpers");
 const { isSubset } = require("../util/SetHelpers");
 const deterministicGrouping = require("../util/deterministicGrouping");
+const MinMaxSizeWarning = require("./MinMaxSizeWarning");
 const contextify = require("../util/identifier").contextify;
 
 /** @typedef {import("../Compiler")} Compiler */
@@ -95,6 +96,8 @@ const compareEntries = (a, b) => {
 		if (aModuleIdentifier < bModuleIdentifier) return 1;
 	}
 };
+
+const compareNumbers = (a, b) => a - b;
 
 const INITIAL_CHUNK_FILTER = chunk => chunk.canBeInitial();
 const ASYNC_CHUNK_FILTER = chunk => !chunk.canBeInitial();
@@ -340,7 +343,7 @@ module.exports = class SplitChunksPlugin {
 					}
 					const getKey = chunks => {
 						return Array.from(chunks, c => indexMap.get(c))
-							.sort()
+							.sort(compareNumbers)
 							.join();
 					};
 					/** @type {Map<string, Set<Chunk>>} */
@@ -436,6 +439,7 @@ module.exports = class SplitChunksPlugin {
 					 * @property {SortableSet} modules
 					 * @property {TODO} cacheGroup
 					 * @property {string} name
+					 * @property {boolean} validateSize
 					 * @property {number} size
 					 * @property {Set<Chunk>} chunks
 					 * @property {Set<Chunk>} reuseableChunks
@@ -461,7 +465,11 @@ module.exports = class SplitChunksPlugin {
 						module
 					) => {
 						// Break if minimum number of chunks is not reached
-						if (selectedChunks.length < cacheGroup.minChunks) return;
+						if (
+							!cacheGroup.enforce &&
+							selectedChunks.length < cacheGroup.minChunks
+						)
+							return;
 						// Determine name for split chunk
 						const name = cacheGroup.getName(
 							module,
@@ -473,8 +481,8 @@ module.exports = class SplitChunksPlugin {
 						// Elsewise we create the key from chunks and cache group key
 						// This automatically merges equal names
 						const key =
-							(name && `name:${name}`) ||
-							`chunks:${selectedChunksKey} key:${cacheGroup.key}`;
+							cacheGroup.key +
+							(name ? ` name:${name}` : ` chunks:${selectedChunksKey}`);
 						// Add module to maps
 						let info = chunksInfoMap.get(key);
 						if (info === undefined) {
@@ -484,21 +492,18 @@ module.exports = class SplitChunksPlugin {
 									modules: new SortableSet(undefined, sortByIdentifier),
 									cacheGroup,
 									name,
+									validateSize: !cacheGroup.enforce && cacheGroup.minSize > 0,
 									size: 0,
 									chunks: new Set(),
 									reuseableChunks: new Set(),
 									chunksKeys: new Set()
 								})
 							);
-						} else {
-							if (info.cacheGroup !== cacheGroup) {
-								if (info.cacheGroup.priority < cacheGroup.priority) {
-									info.cacheGroup = cacheGroup;
-								}
-							}
 						}
 						info.modules.add(module);
-						info.size += module.size();
+						if (info.validateSize) {
+							info.size += module.size();
+						}
 						if (!info.chunksKeys.has(selectedChunksKey)) {
 							info.chunksKeys.add(selectedChunksKey);
 							for (const chunk of selectedChunks) {
@@ -529,36 +534,27 @@ module.exports = class SplitChunksPlugin {
 								priority: cacheGroupSource.priority || 0,
 								chunksFilter:
 									cacheGroupSource.chunksFilter || this.options.chunksFilter,
+								enforce: cacheGroupSource.enforce,
 								minSize:
 									cacheGroupSource.minSize !== undefined
 										? cacheGroupSource.minSize
-										: cacheGroupSource.enforce
-											? 0
-											: this.options.minSize,
+										: this.options.minSize,
 								maxSize:
 									cacheGroupSource.maxSize !== undefined
 										? cacheGroupSource.maxSize
-										: cacheGroupSource.enforce
-											? 0
-											: this.options.maxSize,
+										: this.options.maxSize,
 								minChunks:
 									cacheGroupSource.minChunks !== undefined
 										? cacheGroupSource.minChunks
-										: cacheGroupSource.enforce
-											? 1
-											: this.options.minChunks,
+										: this.options.minChunks,
 								maxAsyncRequests:
 									cacheGroupSource.maxAsyncRequests !== undefined
 										? cacheGroupSource.maxAsyncRequests
-										: cacheGroupSource.enforce
-											? Infinity
-											: this.options.maxAsyncRequests,
+										: this.options.maxAsyncRequests,
 								maxInitialRequests:
 									cacheGroupSource.maxInitialRequests !== undefined
 										? cacheGroupSource.maxInitialRequests
-										: cacheGroupSource.enforce
-											? Infinity
-											: this.options.maxInitialRequests,
+										: this.options.maxInitialRequests,
 								getName:
 									cacheGroupSource.getName !== undefined
 										? cacheGroupSource.getName
@@ -576,7 +572,11 @@ module.exports = class SplitChunksPlugin {
 							// For all combination of chunk selection
 							for (const chunkCombination of combs) {
 								// Break if minimum number of chunks is not reached
-								if (chunkCombination.size < cacheGroup.minChunks) continue;
+								if (
+									!cacheGroup.enforce &&
+									chunkCombination.size < cacheGroup.minChunks
+								)
+									continue;
 								// Select chunks by configuration
 								const {
 									chunks: selectedChunks,
@@ -586,17 +586,27 @@ module.exports = class SplitChunksPlugin {
 									cacheGroup.chunksFilter
 								);
 
-								addModuleToChunksInfoMap(
-									cacheGroup,
-									selectedChunks,
-									selectedChunksKey,
-									module
-								);
+								if (selectedChunks.length > 0) {
+									addModuleToChunksInfoMap(
+										cacheGroup,
+										selectedChunks,
+										selectedChunksKey,
+										module
+									);
+								}
 							}
 						}
 					}
 
-					/** @type {Map<Chunk, {minSize: number, maxSize: number, automaticNameDelimiter: string}>} */
+					// Filter items were size < minSize
+					for (const pair of chunksInfoMap) {
+						const info = pair[1];
+						if (info.validateSize && info.size < info.cacheGroup.minSize) {
+							chunksInfoMap.delete(pair[0]);
+						}
+					}
+
+					/** @type {Map<Chunk, {minSize: number, maxSize: number, automaticNameDelimiter: string, keys: string[]}>} */
 					const maxSizeQueueMap = new Map();
 
 					while (chunksInfoMap.size > 0) {
@@ -606,19 +616,14 @@ module.exports = class SplitChunksPlugin {
 						for (const pair of chunksInfoMap) {
 							const key = pair[0];
 							const info = pair[1];
-							if (info.size >= info.cacheGroup.minSize) {
-								if (bestEntry === undefined) {
-									bestEntry = info;
-									bestEntryKey = key;
-								} else if (compareEntries(bestEntry, info) < 0) {
-									bestEntry = info;
-									bestEntryKey = key;
-								}
+							if (bestEntry === undefined) {
+								bestEntry = info;
+								bestEntryKey = key;
+							} else if (compareEntries(bestEntry, info) < 0) {
+								bestEntry = info;
+								bestEntryKey = key;
 							}
 						}
-
-						// No suitable item left
-						if (bestEntry === undefined) break;
 
 						const item = bestEntry;
 						chunksInfoMap.delete(bestEntryKey);
@@ -666,29 +671,41 @@ module.exports = class SplitChunksPlugin {
 						// Skip when no chunk selected
 						if (usedChunks.length === 0) continue;
 
-						const chunkInLimit = usedChunks.filter(chunk => {
-							// respect max requests when not enforced
-							const maxRequests = chunk.isOnlyInitial()
-								? item.cacheGroup.maxInitialRequests
-								: chunk.canBeInitial()
-									? Math.min(
-											item.cacheGroup.maxInitialRequests,
-											item.cacheGroup.maxAsyncRequests
-									  )
-									: item.cacheGroup.maxAsyncRequests;
-							return !isFinite(maxRequests) || getRequests(chunk) < maxRequests;
-						});
-
-						if (chunkInLimit.length < usedChunks.length) {
-							for (const module of item.modules) {
-								addModuleToChunksInfoMap(
-									item.cacheGroup,
-									chunkInLimit,
-									getKey(chunkInLimit),
-									module
+						if (
+							!item.cacheGroup.enforce &&
+							(Number.isFinite(item.cacheGroup.maxInitialRequests) ||
+								Number.isFinite(item.cacheGroup.maxAsyncRequests))
+						) {
+							const chunkInLimit = usedChunks.filter(chunk => {
+								// respect max requests when not enforced
+								const maxRequests = chunk.isOnlyInitial()
+									? item.cacheGroup.maxInitialRequests
+									: chunk.canBeInitial()
+										? Math.min(
+												item.cacheGroup.maxInitialRequests,
+												item.cacheGroup.maxAsyncRequests
+										  )
+										: item.cacheGroup.maxAsyncRequests;
+								return (
+									!isFinite(maxRequests) || getRequests(chunk) < maxRequests
 								);
+							});
+
+							if (chunkInLimit.length < usedChunks.length) {
+								// We do not need to check enforce here as it was
+								// already checked above.
+								if (chunkInLimit.length >= item.cacheGroup.minChunks) {
+									for (const module of item.modules) {
+										addModuleToChunksInfoMap(
+											item.cacheGroup,
+											chunkInLimit,
+											getKey(chunkInLimit),
+											module
+										);
+									}
+								}
+								continue;
 							}
-							continue;
 						}
 
 						// Create the new chunk if not reusing one
@@ -764,24 +781,39 @@ module.exports = class SplitChunksPlugin {
 									oldMaxSizeSettings ? oldMaxSizeSettings.maxSize : Infinity,
 									item.cacheGroup.maxSize
 								),
-								automaticNameDelimiter: item.cacheGroup.automaticNameDelimiter
+								automaticNameDelimiter: item.cacheGroup.automaticNameDelimiter,
+								keys: oldMaxSizeSettings
+									? oldMaxSizeSettings.keys.concat(item.cacheGroup.key)
+									: [item.cacheGroup.key]
 							});
 						}
 
 						// remove all modules from other entries and update size
 						for (const [key, info] of chunksInfoMap) {
 							if (isOverlap(info.chunks, item.chunks)) {
-								const oldSize = info.modules.size;
-								for (const module of item.modules) {
-									info.modules.delete(module);
-								}
-								if (info.modules.size === 0) {
-									chunksInfoMap.delete(key);
-									continue;
-								}
-								if (info.modules.size !== oldSize) {
-									info.size = getModulesSize(info.modules);
-									if (info.size < info.cacheGroup.minSize) {
+								if (info.validateSize) {
+									// update modules and total size
+									// may remove it from the map when < minSize
+									const oldSize = info.modules.size;
+									for (const module of item.modules) {
+										info.modules.delete(module);
+									}
+									if (info.modules.size === 0) {
+										chunksInfoMap.delete(key);
+										continue;
+									}
+									if (info.modules.size !== oldSize) {
+										info.size = getModulesSize(info.modules);
+										if (info.size < info.cacheGroup.minSize) {
+											chunksInfoMap.delete(key);
+										}
+									}
+								} else {
+									// only update the modules
+									for (const module of item.modules) {
+										info.modules.delete(module);
+									}
+									if (info.modules.size === 0) {
 										chunksInfoMap.delete(key);
 									}
 								}
@@ -789,11 +821,22 @@ module.exports = class SplitChunksPlugin {
 						}
 					}
 
+					const incorrectMinMaxSizeSet = new Set();
+
 					// Make sure that maxSize is fulfilled
 					for (const chunk of compilation.chunks.slice()) {
-						const { minSize, maxSize, automaticNameDelimiter } =
+						const { minSize, maxSize, automaticNameDelimiter, keys } =
 							maxSizeQueueMap.get(chunk) || this.options.fallbackCacheGroup;
 						if (!maxSize) continue;
+						if (minSize > maxSize) {
+							const warningKey = `${keys && keys.join()} ${minSize} ${maxSize}`;
+							if (!incorrectMinMaxSizeSet.has(warningKey)) {
+								incorrectMinMaxSizeSet.add(warningKey);
+								compilation.warnings.push(
+									new MinMaxSizeWarning(keys, minSize, maxSize)
+								);
+							}
+						}
 						const results = deterministicGroupingForModules({
 							maxSize: Math.max(minSize, maxSize),
 							minSize,

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -2696,7 +2696,7 @@ Child custom-chunks-filter-in-cache-groups:
 
 exports[`StatsTestCases should print correct stats for split-chunks-automatic-name 1`] = `
 "Entrypoint main = main.js
-chunk    {0} common~async-a~async-b~async-c.js (common~async-a~async-b~async-c) 40 bytes <{7}> ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= [rendered] split chunk (cache group: vendors) (name: common~async-a~async-b~async-c)
+chunk    {0} common~async-a~async-b~async-c.js (common~async-a~async-b~async-c) 40 bytes <{7}> ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= [rendered] split chunk (cache group: default) (name: common~async-a~async-b~async-c)
     > ./a [0] ./index.js 1:0-47
     > ./b [0] ./index.js 2:0-47
     > ./c [0] ./index.js 3:0-47
@@ -2706,7 +2706,7 @@ chunk    {1} common~async-a~async-b.js (common~async-a~async-b) 20 bytes <{7}> =
     > ./a [0] ./index.js 1:0-47
     > ./b [0] ./index.js 2:0-47
  [6] ./node_modules/y.js 20 bytes {1} [built]
-chunk    {2} common~async-b~async-c.js (common~async-b~async-c) 20 bytes <{7}> ={0}= ={1}= ={4}= ={5}= ={6}= [rendered] split chunk (cache group: vendors) (name: common~async-b~async-c)
+chunk    {2} common~async-b~async-c.js (common~async-b~async-c) 20 bytes <{7}> ={0}= ={1}= ={4}= ={5}= ={6}= [rendered] split chunk (cache group: default) (name: common~async-b~async-c)
     > ./b [0] ./index.js 2:0-47
     > ./c [0] ./index.js 3:0-47
  [7] ./f.js 20 bytes {2} [built]
@@ -3040,6 +3040,16 @@ Child switched:
      [41] ./node_modules/small.js?1 67 bytes {8} [built]
      [42] ./node_modules/small.js?2 67 bytes {8} [built]
      [43] ./node_modules/very-big.js?1 1.57 KiB {8} [built]
+    
+    WARNING in SplitChunksPlugin
+    Cache group vendors
+    Configured minSize (1000 bytes) is bigger than maxSize (100 bytes).
+    This seem to be a invalid optimiziation.splitChunks configuration.
+    
+    WARNING in SplitChunksPlugin
+    Fallback cache group
+    Configured minSize (1000 bytes) is bigger than maxSize (100 bytes).
+    This seem to be a invalid optimiziation.splitChunks configuration.
 Child zero-min:
     Entrypoint main = zero-min-vendors~main~7274e1de.js zero-min-vendors~main~0feae4ad.js zero-min-main~6e7ead72.js zero-min-main~6a2ae26b.js zero-min-main~17acad98.js zero-min-main~b2c7414a.js zero-min-main~75f09de8.js zero-min-main~052b3814.js zero-min-main~3ff27526.js zero-min-main~11485824.js zero-min-main~c6931360.js zero-min-main~cd7c5bfc.js zero-min-main~02369f19.js
     chunk    {0} zero-min-main~02369f19.js (main~02369f19) 1.57 KiB ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= ={12}= [entry] [rendered]
@@ -3112,7 +3122,82 @@ Child zero-min:
         > ./ main
      [40] ./node_modules/big.js?1 268 bytes {12} [built]
      [41] ./node_modules/small.js?1 67 bytes {12} [built]
-     [42] ./node_modules/small.js?2 67 bytes {12} [built]"
+     [42] ./node_modules/small.js?2 67 bytes {12} [built]
+Child enforce-min-size:
+    Entrypoint main = enforce-min-size-all~main~6e7ead72.js enforce-min-size-all~main~6a2ae26b.js enforce-min-size-all~main~17acad98.js enforce-min-size-all~main~b2c7414a.js enforce-min-size-all~main~75f09de8.js enforce-min-size-all~main~7274e1de.js enforce-min-size-all~main~0feae4ad.js enforce-min-size-all~main~052b3814.js enforce-min-size-all~main~3ff27526.js enforce-min-size-all~main~11485824.js enforce-min-size-all~main~c6931360.js enforce-min-size-all~main~cd7c5bfc.js enforce-min-size-all~main~02369f19.js enforce-min-size-main.js
+    chunk    {0} enforce-min-size-all~main~02369f19.js (all~main~02369f19) 1.57 KiB ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= ={12}= ={13}= [initial] [rendered] split chunk (cache group: all) (name: all~main)
+        > ./ main
+     [11] ./very-big.js?1 1.57 KiB {0} [built]
+    chunk    {1} enforce-min-size-all~main~052b3814.js (all~main~052b3814) 603 bytes ={0}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= ={12}= ={13}= [initial] [rendered] split chunk (cache group: all) (name: all~main)
+        > ./ main
+      [2] ./small.js?1 67 bytes {1} [built]
+      [3] ./small.js?2 67 bytes {1} [built]
+      [4] ./small.js?3 67 bytes {1} [built]
+      [5] ./small.js?4 67 bytes {1} [built]
+      [6] ./small.js?5 67 bytes {1} [built]
+      [7] ./small.js?6 67 bytes {1} [built]
+      [8] ./small.js?7 67 bytes {1} [built]
+      [9] ./small.js?8 67 bytes {1} [built]
+     [10] ./small.js?9 67 bytes {1} [built]
+    chunk    {2} enforce-min-size-all~main~0feae4ad.js (all~main~0feae4ad) 1.57 KiB ={0}= ={1}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= ={12}= ={13}= [initial] [rendered] split chunk (cache group: all) (name: all~main)
+        > ./ main
+     [43] ./node_modules/very-big.js?1 1.57 KiB {2} [built]
+    chunk    {3} enforce-min-size-all~main~11485824.js (all~main~11485824) 603 bytes ={0}= ={1}= ={2}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= ={12}= ={13}= [initial] [rendered] split chunk (cache group: all) (name: all~main)
+        > ./ main
+     [16] ./subfolder/small.js?1 67 bytes {3} [built]
+     [17] ./subfolder/small.js?2 67 bytes {3} [built]
+     [18] ./subfolder/small.js?3 67 bytes {3} [built]
+     [19] ./subfolder/small.js?4 67 bytes {3} [built]
+     [20] ./subfolder/small.js?5 67 bytes {3} [built]
+     [21] ./subfolder/small.js?6 67 bytes {3} [built]
+     [22] ./subfolder/small.js?7 67 bytes {3} [built]
+     [23] ./subfolder/small.js?8 67 bytes {3} [built]
+     [24] ./subfolder/small.js?9 67 bytes {3} [built]
+    chunk    {4} enforce-min-size-all~main~17acad98.js (all~main~17acad98) 1.57 KiB ={0}= ={1}= ={2}= ={3}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= ={12}= ={13}= [initial] [rendered] split chunk (cache group: all) (name: all~main)
+        > ./ main
+     [39] ./in-some-directory/very-big.js?1 1.57 KiB {4} [built]
+    chunk    {5} enforce-min-size-all~main~3ff27526.js (all~main~3ff27526) 536 bytes ={0}= ={1}= ={2}= ={3}= ={4}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= ={12}= ={13}= [initial] [rendered] split chunk (cache group: all) (name: all~main)
+        > ./ main
+     [14] ./subfolder/big.js?1 268 bytes {5} [built]
+     [15] ./subfolder/big.js?2 268 bytes {5} [built]
+    chunk    {6} enforce-min-size-all~main~6a2ae26b.js (all~main~6a2ae26b) 536 bytes ={0}= ={1}= ={2}= ={3}= ={4}= ={5}= ={7}= ={8}= ={9}= ={10}= ={11}= ={12}= ={13}= [initial] [rendered] split chunk (cache group: all) (name: all~main)
+        > ./ main
+     [34] ./in-some-directory/big.js?1 268 bytes {6} [built]
+     [35] ./in-some-directory/small.js?1 67 bytes {6} [built]
+     [36] ./in-some-directory/small.js?2 67 bytes {6} [built]
+     [37] ./in-some-directory/small.js?3 67 bytes {6} [built]
+     [38] ./in-some-directory/small.js?4 67 bytes {6} [built]
+    chunk    {7} enforce-min-size-all~main~6e7ead72.js (all~main~6e7ead72) 536 bytes ={0}= ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= ={8}= ={9}= ={10}= ={11}= ={12}= ={13}= [initial] [rendered] split chunk (cache group: all) (name: all~main)
+        > ./ main
+     [0] ./big.js?1 268 bytes {7} [built]
+     [1] ./big.js?2 268 bytes {7} [built]
+    chunk    {8} enforce-min-size-all~main~7274e1de.js (all~main~7274e1de) 402 bytes ={0}= ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={9}= ={10}= ={11}= ={12}= ={13}= [initial] [rendered] split chunk (cache group: all) (name: all~main)
+        > ./ main
+     [40] ./node_modules/big.js?1 268 bytes {8} [built]
+     [41] ./node_modules/small.js?1 67 bytes {8} [built]
+     [42] ./node_modules/small.js?2 67 bytes {8} [built]
+    chunk    {9} enforce-min-size-all~main~75f09de8.js (all~main~75f09de8) 603 bytes ={0}= ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={10}= ={11}= ={12}= ={13}= [initial] [rendered] split chunk (cache group: all) (name: all~main)
+        > ./ main
+     [25] ./inner-module/small.js?1 67 bytes {9} [built]
+     [26] ./inner-module/small.js?2 67 bytes {9} [built]
+     [27] ./inner-module/small.js?3 67 bytes {9} [built]
+     [28] ./inner-module/small.js?4 67 bytes {9} [built]
+     [29] ./inner-module/small.js?5 67 bytes {9} [built]
+     [30] ./inner-module/small.js?6 67 bytes {9} [built]
+     [31] ./inner-module/small.js?7 67 bytes {9} [built]
+     [32] ./inner-module/small.js?8 67 bytes {9} [built]
+     [33] ./inner-module/small.js?9 67 bytes {9} [built]
+    chunk   {10} enforce-min-size-all~main~b2c7414a.js (all~main~b2c7414a) 1.19 KiB ={0}= ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={11}= ={12}= ={13}= [initial] [rendered] split chunk (cache group: all) (name: all~main)
+        > ./ main
+     [44] ./index.js 1.19 KiB {10} [built]
+    chunk   {11} enforce-min-size-all~main~c6931360.js (all~main~c6931360) 1.57 KiB ={0}= ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={12}= ={13}= [initial] [rendered] split chunk (cache group: all) (name: all~main)
+        > ./ main
+     [12] ./very-big.js?2 1.57 KiB {11} [built]
+    chunk   {12} enforce-min-size-all~main~cd7c5bfc.js (all~main~cd7c5bfc) 1.57 KiB ={0}= ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= ={13}= [initial] [rendered] split chunk (cache group: all) (name: all~main)
+        > ./ main
+     [13] ./very-big.js?3 1.57 KiB {12} [built]
+    chunk   {13} enforce-min-size-main.js (main) 0 bytes ={0}= ={1}= ={2}= ={3}= ={4}= ={5}= ={6}= ={7}= ={8}= ={9}= ={10}= ={11}= ={12}= [entry] [rendered]
+        > ./ main"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-prefer-bigger-splits 1`] = `

--- a/test/statsCases/split-chunks-max-size/webpack.config.js
+++ b/test/statsCases/split-chunks-max-size/webpack.config.js
@@ -81,4 +81,27 @@ module.exports = [
 		},
 		stats
 	},
+	{
+		name: "enforce-min-size",
+		mode: "production",
+		entry: {
+			main: "./"
+		},
+		output: {
+			filename: "enforce-min-size-[name].js"
+		},
+		optimization: {
+			splitChunks: {
+				minSize: 100,
+				cacheGroups: {
+					all: {
+						maxSize: 1000,
+						chunks: "all",
+						enforce: true
+					}
+				}
+			}
+		},
+		stats
+	},
 ];


### PR DESCRIPTION
enforce now works as documented
emit warning for minSize > maxSize configuration
performance improvements
bugfix when multiple cacheGroups have the same name

fixes #8407

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes, but a bugfix
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
`enforce` now works as documented.

> Tells webpack to ignore splitChunks.minSize, splitChunks.maxSize, splitChunks.minChunks, splitChunks.maxAsyncRequests and splitChunks.maxInitialRequests options and always create chunks for this cache group.

But there is a little error in the documentation as `splitChunks.maxSize` is not ignored.

Tells webpack to ignore splitChunks.minSize, splitChunks.minChunks, splitChunks.maxAsyncRequests and splitChunks.maxInitialRequests options and always create chunks for this cache group.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
