### PR TITLE
add getResolve method to loader context

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -184,6 +184,21 @@ class NormalModule extends Module {
 			resolve(context, request, callback) {
 				resolver.resolve({}, context, request, {}, callback);
 			},
+			getResolve(options) {
+				const child = options ? resolver.withOptions(options) : resolver;
+				return (context, request, callback) => {
+					if (callback) {
+						child.resolve({}, context, request, {}, callback);
+					} else {
+						return new Promise((resolve, reject) => {
+							child.resolve({}, context, request, {}, (err, result) => {
+								if (err) reject(err);
+								else resolve(result);
+							});
+						});
+					}
+				};
+			},
 			emitFile: (name, content, sourceMap) => {
 				if (!this.buildInfo.assets) {
 					this.buildInfo.assets = Object.create(null);

--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -7,6 +7,8 @@
 const { Tapable, HookMap, SyncHook, SyncWaterfallHook } = require("tapable");
 const Factory = require("enhanced-resolve").ResolverFactory;
 
+/** @typedef {import("enhanced-resolve").Resolver} Resolver */
+
 module.exports = class ResolverFactory extends Tapable {
 	constructor() {
 		super();
@@ -53,11 +55,22 @@ module.exports = class ResolverFactory extends Tapable {
 	}
 
 	_create(type, resolveOptions) {
+		const originalResolveOptions = Object.assign({}, resolveOptions);
 		resolveOptions = this.hooks.resolveOptions.for(type).call(resolveOptions);
 		const resolver = Factory.createResolver(resolveOptions);
 		if (!resolver) {
 			throw new Error("No resolver created");
 		}
+		/** @type {Map<Object, Resolver>} */
+		const childCache = new Map();
+		resolver.withOptions = options => {
+			const cacheEntry = childCache.get(options);
+			if (cacheEntry !== undefined) return cacheEntry;
+			const mergedOptions = Object.assign({}, originalResolveOptions, options);
+			const resolver = this.get(type, mergedOptions);
+			childCache.set(options, resolver);
+			return resolver;
+		};
 		this.hooks.resolver.for(type).call(resolver, resolveOptions);
 		return resolver;
 	}

--- a/test/cases/loaders/resolve/index.js
+++ b/test/cases/loaders/resolve/index.js
@@ -1,0 +1,7 @@
+it("should be possible to create resolver with different options", () => {
+	const result = require("./loader!");
+	expect(result).toEqual({
+		one: "index.js",
+		two: "index.xyz"
+	});
+})

--- a/test/cases/loaders/resolve/loader.js
+++ b/test/cases/loaders/resolve/loader.js
@@ -1,11 +1,16 @@
 const path = require("path");
-module.exports = async function() {
+module.exports = function() {
 	const resolve1 = this.getResolve();
 	const resolve2 = this.getResolve({
 		extensions: [".xyz", ".js"]
 	});
-	return `module.exports = ${JSON.stringify({
-		one: path.basename(await resolve1(__dirname, "./index")),
-		two: path.basename(await resolve2(__dirname, "./index")),
-	})}`;
+	return Promise.all([
+		resolve1(__dirname, "./index"),
+		resolve2(__dirname, "./index")
+	]).then(([one, two]) => {
+		return `module.exports = ${JSON.stringify({
+			one: path.basename(one),
+			two: path.basename(two),
+		})}`;
+	});
 };

--- a/test/cases/loaders/resolve/loader.js
+++ b/test/cases/loaders/resolve/loader.js
@@ -1,0 +1,11 @@
+const path = require("path");
+module.exports = async function() {
+	const resolve1 = this.getResolve();
+	const resolve2 = this.getResolve({
+		extensions: [".xyz", ".js"]
+	});
+	return `module.exports = ${JSON.stringify({
+		one: path.basename(await resolve1(__dirname, "./index")),
+		two: path.basename(await resolve2(__dirname, "./index")),
+	})}`;
+};


### PR DESCRIPTION
with allows to pass options

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
new `getResolve` method in loader context. An optional `options` object is merged with the original resolve options in the current module. For performance reasons try to pass the same object identity for every call.

``` js
getResolve(options?: Object) => ResolveFunction

ResolveFunction = (context: string, request: string, callback: ResolveCallback) => void
ResolveFunction = (context: string, request: string) => Promise<string>

ResolveCallback = (err?: Error, path?: string, data?: Object) => void
```


<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
