### PR TITLE
Fix: Enforced chunks cause mismatch on chunks at runtime

### DIFF
--- a/lib/optimize/SplitChunksPlugin.js
+++ b/lib/optimize/SplitChunksPlugin.js
@@ -616,14 +616,19 @@ module.exports = class SplitChunksPlugin {
 						for (const pair of chunksInfoMap) {
 							const key = pair[0];
 							const info = pair[1];
-							if (bestEntry === undefined) {
-								bestEntry = info;
-								bestEntryKey = key;
-							} else if (compareEntries(bestEntry, info) < 0) {
-								bestEntry = info;
-								bestEntryKey = key;
+							if (info.validateSize && info.size >= info.cacheGroup.minSize) {
+								if (bestEntry === undefined) {
+									bestEntry = info;
+									bestEntryKey = key;
+								} else if (compareEntries(bestEntry, info) < 0) {
+									bestEntry = info;
+									bestEntryKey = key;
+								}
 							}
 						}
+
+						// No suitable item left
+						if (bestEntry === undefined) break;
 
 						const item = bestEntry;
 						chunksInfoMap.delete(bestEntryKey);


### PR DESCRIPTION
**Change**
- Add check around finding best matching entry for only running when
chunks with size validation required. Enforced chunks would not match up
causing a runtime error when executing chunk

**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
No, as I'm not 100% sure how to test this scenario, happy to add tests if this is validated as correct solution. 

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
N/A

## Further info 

A bug was introduced in 4.27.0 within this commit: https://github.com/webpack/webpack/commit/3b46b48fa73bf659c064fc11c48b2f54acf653d2?diff=unified#diff-64e8e63f33596df33d814452fa5d5b83L609

Enforced chunks in a configuration like below, breaks at runtime with error:

```
optimization: {
    runtimeChunk: {
      name: 'manifest',
    },
    splitChunks: {
      cacheGroups: {
        vendor: {
          chunks: 'initial',
          test: PATH.nodeModules,
          name: 'vendor',
          enforce: true,
        },
        commons: {
          chunks: 'initial',
          minChunks: 3,
          name: 'commons',
          enforce: true,
        },
      },
    },
  },
```

```
VM746 manifest.23aa7c50082f3762ce69.js:1 Uncaught TypeError: Cannot read property 'call' of undefined
    at s (VM746 manifest.23aa7c50082f3762ce69.js:1)
    at t (VM746 manifest.23aa7c50082f3762ce69.js:1)
    at Array.a [as push] (VM746 manifest.23aa7c50082f3762ce69.js:1)
    at VM748 main.fcdae5ecbf3a250d4386.js:1
```

As far as I can tell a check was removed were still necessary, i'm not familiar with the code so not 100% sure this is the ideal solution or whether this check can be done elsewhere. 
