### PR TITLE
enforce should not prevent using `minChunks` etc. on cacheGroup

### DIFF
--- a/lib/optimize/SplitChunksPlugin.js
+++ b/lib/optimize/SplitChunksPlugin.js
@@ -465,11 +465,7 @@ module.exports = class SplitChunksPlugin {
 						module
 					) => {
 						// Break if minimum number of chunks is not reached
-						if (
-							!cacheGroup.enforce &&
-							selectedChunks.length < cacheGroup.minChunks
-						)
-							return;
+						if (selectedChunks.length < cacheGroup.minChunks) return;
 						// Determine name for split chunk
 						const name = cacheGroup.getName(
 							module,
@@ -492,7 +488,7 @@ module.exports = class SplitChunksPlugin {
 									modules: new SortableSet(undefined, sortByIdentifier),
 									cacheGroup,
 									name,
-									validateSize: !cacheGroup.enforce && cacheGroup.minSize > 0,
+									validateSize: cacheGroup.minSize > 0,
 									size: 0,
 									chunks: new Set(),
 									reuseableChunks: new Set(),
@@ -534,27 +530,40 @@ module.exports = class SplitChunksPlugin {
 								priority: cacheGroupSource.priority || 0,
 								chunksFilter:
 									cacheGroupSource.chunksFilter || this.options.chunksFilter,
-								enforce: cacheGroupSource.enforce,
 								minSize:
+									cacheGroupSource.minSize !== undefined
+										? cacheGroupSource.minSize
+										: cacheGroupSource.enforce
+											? 0
+											: this.options.minSize,
+								minSizeForMaxSize:
 									cacheGroupSource.minSize !== undefined
 										? cacheGroupSource.minSize
 										: this.options.minSize,
 								maxSize:
 									cacheGroupSource.maxSize !== undefined
 										? cacheGroupSource.maxSize
-										: this.options.maxSize,
+										: cacheGroupSource.enforce
+											? 0
+											: this.options.maxSize,
 								minChunks:
 									cacheGroupSource.minChunks !== undefined
 										? cacheGroupSource.minChunks
-										: this.options.minChunks,
+										: cacheGroupSource.enforce
+											? 1
+											: this.options.minChunks,
 								maxAsyncRequests:
 									cacheGroupSource.maxAsyncRequests !== undefined
 										? cacheGroupSource.maxAsyncRequests
-										: this.options.maxAsyncRequests,
+										: cacheGroupSource.enforce
+											? Infinity
+											: this.options.maxAsyncRequests,
 								maxInitialRequests:
 									cacheGroupSource.maxInitialRequests !== undefined
 										? cacheGroupSource.maxInitialRequests
-										: this.options.maxInitialRequests,
+										: cacheGroupSource.enforce
+											? Infinity
+											: this.options.maxInitialRequests,
 								getName:
 									cacheGroupSource.getName !== undefined
 										? cacheGroupSource.getName
@@ -572,11 +581,7 @@ module.exports = class SplitChunksPlugin {
 							// For all combination of chunk selection
 							for (const chunkCombination of combs) {
 								// Break if minimum number of chunks is not reached
-								if (
-									!cacheGroup.enforce &&
-									chunkCombination.size < cacheGroup.minChunks
-								)
-									continue;
+								if (chunkCombination.size < cacheGroup.minChunks) continue;
 								// Select chunks by configuration
 								const {
 									chunks: selectedChunks,
@@ -586,14 +591,12 @@ module.exports = class SplitChunksPlugin {
 									cacheGroup.chunksFilter
 								);
 
-								if (selectedChunks.length > 0) {
-									addModuleToChunksInfoMap(
-										cacheGroup,
-										selectedChunks,
-										selectedChunksKey,
-										module
-									);
-								}
+								addModuleToChunksInfoMap(
+									cacheGroup,
+									selectedChunks,
+									selectedChunksKey,
+									module
+								);
 							}
 						}
 					}
@@ -672,9 +675,8 @@ module.exports = class SplitChunksPlugin {
 						if (usedChunks.length === 0) continue;
 
 						if (
-							!item.cacheGroup.enforce &&
-							(Number.isFinite(item.cacheGroup.maxInitialRequests) ||
-								Number.isFinite(item.cacheGroup.maxAsyncRequests))
+							Number.isFinite(item.cacheGroup.maxInitialRequests) ||
+							Number.isFinite(item.cacheGroup.maxAsyncRequests)
 						) {
 							const chunkInLimit = usedChunks.filter(chunk => {
 								// respect max requests when not enforced
@@ -692,8 +694,6 @@ module.exports = class SplitChunksPlugin {
 							});
 
 							if (chunkInLimit.length < usedChunks.length) {
-								// We do not need to check enforce here as it was
-								// already checked above.
 								if (chunkInLimit.length >= item.cacheGroup.minChunks) {
 									for (const module of item.modules) {
 										addModuleToChunksInfoMap(
@@ -775,7 +775,7 @@ module.exports = class SplitChunksPlugin {
 							maxSizeQueueMap.set(newChunk, {
 								minSize: Math.max(
 									oldMaxSizeSettings ? oldMaxSizeSettings.minSize : 0,
-									item.cacheGroup.minSize
+									item.cacheGroup.minSizeForMaxSize
 								),
 								maxSize: Math.min(
 									oldMaxSizeSettings ? oldMaxSizeSettings.maxSize : Infinity,

--- a/test/statsCases/split-chunks-automatic-name/webpack.config.js
+++ b/test/statsCases/split-chunks-automatic-name/webpack.config.js
@@ -17,17 +17,18 @@ module.exports = {
 	optimization: {
 		splitChunks: {
 			chunks: "all",
-			minSize: 1,
 			cacheGroups: {
 				default: {
 					automaticNamePrefix: "common",
 					reuseExistingChunk: true,
 					minChunks: 2,
-					priority: -20
+					priority: -20,
+					enforce: true // minChunks should have higher priority
 				},
 				vendors: {
 					automaticNamePrefix: "common",
 					test: /[\\/]node_modules[\\/]/,
+					minSize: 1,
 					priority: -10
 				}
 			}


### PR DESCRIPTION
Partial revert "enforce doesn't affect minSize for maxSize" #8451 

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
It reverts an accidental breaking introduces by #8451
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
The splitChunks.enforce documentation is incorrect.
It should be stated that `enforce` sets `minChunks: 1`, `minSize: 0` and `maxInitial/AsyncRequests: Infinity`, but it's supported that this can be overriden by the same property on the cacheGroup
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
