### PR TITLE
replace mkdirp in favour of fs with { recursive: true }

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -340,8 +340,9 @@ class Compiler extends Tapable {
 
 					if (targetFile.match(/\/|\\/)) {
 						const dir = path.dirname(targetFile);
-						this.outputFileSystem.mkdirp(
+						this.outputFileSystem.mkdir(
 							this.outputFileSystem.join(outputPath, dir),
+							{ recursive: true },
 							writeOut
 						);
 					} else {
@@ -363,7 +364,7 @@ class Compiler extends Tapable {
 		this.hooks.emit.callAsync(compilation, err => {
 			if (err) return callback(err);
 			outputPath = compilation.getPath(this.outputPath);
-			this.outputFileSystem.mkdirp(outputPath, emitFiles);
+			this.outputFileSystem.mkdir(outputPath, { recursive: true }, emitFiles);
 		});
 	}
 
@@ -389,10 +390,14 @@ class Compiler extends Tapable {
 		if (!recordsOutputPathDirectory) {
 			return writeFile();
 		}
-		this.outputFileSystem.mkdirp(recordsOutputPathDirectory, err => {
-			if (err) return callback(err);
-			writeFile();
-		});
+		this.outputFileSystem.mkdir(
+			recordsOutputPathDirectory,
+			{ recursive: true },
+			err => {
+				if (err) return callback(err);
+				writeFile();
+			}
+		);
 	}
 
 	readRecords(callback) {

--- a/lib/LibManifestPlugin.js
+++ b/lib/LibManifestPlugin.js
@@ -72,14 +72,18 @@ class LibManifestPlugin {
 							? JSON.stringify(manifest, null, 2)
 							: JSON.stringify(manifest);
 						const content = Buffer.from(manifestContent, "utf8");
-						compiler.outputFileSystem.mkdirp(path.dirname(targetPath), err => {
-							if (err) return callback(err);
-							compiler.outputFileSystem.writeFile(
-								targetPath,
-								content,
-								callback
-							);
-						});
+						compiler.outputFileSystem.mkdir(
+							path.dirname(targetPath),
+							{ recursive: true },
+							err => {
+								if (err) return callback(err);
+								compiler.outputFileSystem.writeFile(
+									targetPath,
+									content,
+									callback
+								);
+							}
+						);
 					},
 					callback
 				);

--- a/lib/node/NodeOutputFileSystem.js
+++ b/lib/node/NodeOutputFileSystem.js
@@ -6,11 +6,9 @@
 
 const fs = require("fs");
 const path = require("path");
-const mkdirp = require("mkdirp");
 
 class NodeOutputFileSystem {
 	constructor() {
-		this.mkdirp = mkdirp;
 		this.mkdir = fs.mkdir.bind(fs);
 		this.rmdir = fs.rmdir.bind(fs);
 		this.unlink = fs.unlink.bind(fs);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "loader-utils": "^1.1.0",
     "memory-fs": "~0.4.1",
     "micromatch": "^3.1.8",
-    "mkdirp": "~0.5.0",
     "neo-async": "^2.5.0",
     "node-libs-browser": "^2.0.0",
     "schema-utils": "^0.4.4",

--- a/test/Compiler-caching.test.js
+++ b/test/Compiler-caching.test.js
@@ -23,7 +23,7 @@ describe("Compiler (caching)", () => {
 		options.output.filename = "bundle.js";
 		options.output.pathinfo = true;
 		const logs = {
-			mkdirp: [],
+			mkdir: [],
 			writeFile: []
 		};
 
@@ -33,8 +33,8 @@ describe("Compiler (caching)", () => {
 			join() {
 				return [].join.call(arguments, "/").replace(/\/+/g, "/");
 			},
-			mkdirp(path, callback) {
-				logs.mkdirp.push(path);
+			mkdir(path, options, callback) {
+				logs.mkdir.push(path);
 				callback();
 			},
 			writeFile(name, content, callback) {

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -21,7 +21,7 @@ describe("Compiler", () => {
 			minimize: false
 		};
 		const logs = {
-			mkdirp: [],
+			mkdir: [],
 			writeFile: []
 		};
 
@@ -31,8 +31,8 @@ describe("Compiler", () => {
 			join() {
 				return [].join.call(arguments, "/").replace(/\/+/g, "/");
 			},
-			mkdirp(path, callback) {
-				logs.mkdirp.push(path);
+			mkdir(path, options, callback) {
+				logs.mkdir.push(path);
 				callback();
 			},
 			writeFile(name, content, callback) {
@@ -75,7 +75,7 @@ describe("Compiler", () => {
 				}
 			},
 			(stats, files) => {
-				expect(stats.logs.mkdirp).toEqual(["/what", "/what/the"]);
+				expect(stats.logs.mkdir).toEqual(["/what", "/what/the"]);
 				done();
 			}
 		);

--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -4,7 +4,6 @@
 const path = require("path");
 const fs = require("fs");
 const vm = require("vm");
-const mkdirp = require("mkdirp");
 const rimraf = require("rimraf");
 const checkArrayExpectation = require("./checkArrayExpectation");
 const createLazyTestEnv = require("./helpers/createLazyTestEnv");
@@ -61,7 +60,7 @@ describe("ConfigTestCases", () => {
 									resolve();
 								};
 								rimraf.sync(outputDirectory);
-								mkdirp.sync(outputDirectory);
+								fs.mkdirSync(outputDirectory);
 								const options = prepareOptions(
 									require(path.join(testDirectory, "webpack.config.js")),
 									{ testPath: outputDirectory }
@@ -127,7 +126,7 @@ describe("ConfigTestCases", () => {
 									}
 									const statOptions = Stats.presetToOptions("verbose");
 									statOptions.colors = false;
-									mkdirp.sync(outputDirectory);
+									fs.mkdirSync(outputDirectory);
 									fs.writeFileSync(
 										path.join(outputDirectory, "stats.txt"),
 										stats.toString(statOptions),

--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -60,7 +60,7 @@ describe("ConfigTestCases", () => {
 									resolve();
 								};
 								rimraf.sync(outputDirectory);
-								fs.mkdirSync(outputDirectory);
+								fs.mkdirSync(outputDirectory, { recursive: true });
 								const options = prepareOptions(
 									require(path.join(testDirectory, "webpack.config.js")),
 									{ testPath: outputDirectory }
@@ -126,7 +126,7 @@ describe("ConfigTestCases", () => {
 									}
 									const statOptions = Stats.presetToOptions("verbose");
 									statOptions.colors = false;
-									fs.mkdirSync(outputDirectory);
+									fs.mkdirSync(outputDirectory, { recursive: true });
 									fs.writeFileSync(
 										path.join(outputDirectory, "stats.txt"),
 										stats.toString(statOptions),

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -14,7 +14,7 @@ describe("Errors", () => {
 		const files = {};
 		c.outputFileSystem = {
 			join: path.join.bind(path),
-			mkdirp(path, callback) {
+			mkdir(path, options, callback) {
 				callback();
 			},
 			writeFile(name, content, callback) {

--- a/test/HotModuleReplacementPlugin.test.js
+++ b/test/HotModuleReplacementPlugin.test.js
@@ -2,7 +2,6 @@
 
 const path = require("path");
 const fs = require("fs");
-const mkdirp = require("mkdirp");
 
 const webpack = require("../");
 
@@ -34,7 +33,7 @@ describe("HotModuleReplacementPlugin", () => {
 			"records.json"
 		);
 		try {
-			mkdirp.sync(path.join(__dirname, "js", "HotModuleReplacementPlugin"));
+			fs.mkdirSync(path.join(__dirname, "js", "HotModuleReplacementPlugin"));
 		} catch (e) {
 			// empty
 		}
@@ -124,7 +123,7 @@ describe("HotModuleReplacementPlugin", () => {
 			"records.json"
 		);
 		try {
-			mkdirp.sync(path.join(__dirname, "js", "HotModuleReplacementPlugin"));
+			fs.mkdirSync(path.join(__dirname, "js", "HotModuleReplacementPlugin"));
 		} catch (e) {
 			// empty
 		}

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -4,7 +4,6 @@
 const path = require("path");
 const fs = require("fs");
 const vm = require("vm");
-const mkdirp = require("mkdirp");
 const TerserPlugin = require("terser-webpack-plugin");
 const checkArrayExpectation = require("./checkArrayExpectation");
 const createLazyTestEnv = require("./helpers/createLazyTestEnv");
@@ -176,7 +175,7 @@ const describeCases = config => {
 										if (err) done(err);
 										const statOptions = Stats.presetToOptions("verbose");
 										statOptions.colors = false;
-										mkdirp.sync(outputDirectory);
+										fs.mkdirSync(outputDirectory);
 										fs.writeFileSync(
 											path.join(outputDirectory, "stats.txt"),
 											stats.toString(statOptions),

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -175,7 +175,7 @@ const describeCases = config => {
 										if (err) done(err);
 										const statOptions = Stats.presetToOptions("verbose");
 										statOptions.colors = false;
-										fs.mkdirSync(outputDirectory);
+										fs.mkdirSync(outputDirectory, { recursive: true });
 										fs.writeFileSync(
 											path.join(outputDirectory, "stats.txt"),
 											stats.toString(statOptions),

--- a/test/WatchTestCases.test.js
+++ b/test/WatchTestCases.test.js
@@ -4,7 +4,6 @@
 const path = require("path");
 const fs = require("fs");
 const vm = require("vm");
-const mkdirp = require("mkdirp");
 const rimraf = require("rimraf");
 const checkArrayExpectation = require("./checkArrayExpectation");
 const createLazyTestEnv = require("./helpers/createLazyTestEnv");
@@ -185,7 +184,7 @@ describe("WatchTestCases", () => {
 										if (err) return compilationFinished(err);
 										const statOptions = Stats.presetToOptions("verbose");
 										statOptions.colors = false;
-										mkdirp.sync(outputDirectory);
+										fs.mkdirSync(outputDirectory);
 										fs.writeFileSync(
 											path.join(outputDirectory, "stats.txt"),
 											stats.toString(statOptions),

--- a/test/WatchTestCases.test.js
+++ b/test/WatchTestCases.test.js
@@ -184,7 +184,7 @@ describe("WatchTestCases", () => {
 										if (err) return compilationFinished(err);
 										const statOptions = Stats.presetToOptions("verbose");
 										statOptions.colors = false;
-										fs.mkdirSync(outputDirectory);
+										fs.mkdirSync(outputDirectory, { recursive: true });
 										fs.writeFileSync(
 											path.join(outputDirectory, "stats.txt"),
 											stats.toString(statOptions),

--- a/tooling/compile-to-definitions.js
+++ b/tooling/compile-to-definitions.js
@@ -1,6 +1,5 @@
 const fs = require("fs");
 const path = require("path");
-const mkdirp = require("mkdirp");
 const prettierrc = require("../.prettierrc.js"); // eslint-disable-line
 const { compileFromFile } = require("json-schema-to-typescript");
 
@@ -53,7 +52,7 @@ const makeDefinitionsForSchema = absSchemaPath => {
 			}
 			if (normalizedContent.trim() !== ts.trim()) {
 				if (doWrite) {
-					mkdirp.sync(path.dirname(filename));
+					fs.mkdirSync(path.dirname(filename));
 					fs.writeFileSync(filename, ts, "utf-8");
 					console.error(
 						`declarations/${basename.replace(/\\/g, "/")}.d.ts updated`

--- a/yarn.lock
+++ b/yarn.lock
@@ -5320,13 +5320,6 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  dependencies:
-    minimist "0.0.8"
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
This replaces all instances that depend on the mkdirp package with the node native fs.mkdir (available as of node v10.12.0) with the recursive option passed.

There appears to be numerous issues with mkdirp such as specifying an unavailable drive letter on windows causing it to enter an infinite loop and eat all available memory; but it appears the mkdirp package is no longer maintained.

**What kind of change does this PR introduce?**

Ultimately this removes an unnecessary (and unmaintained) dependency as well as fixing some bugs.

**Did you add tests for your changes?**

I have modified the tests to pass but the fs functionality isn't really tested so this should not matter.

**Does this PR introduce a breaking change?**

I don't know what version of node Webpack is expected to support as a minimum. But at least node v8 is in LTS until December 2019. So this could be considered a breaking change.

**What needs to be documented once your changes are merged?**

Nothing.