### PR TITLE
Optimize jsonpChunkTemplatePlugin

### DIFF
--- a/lib/web/JsonpChunkTemplatePlugin.js
+++ b/lib/web/JsonpChunkTemplatePlugin.js
@@ -9,13 +9,20 @@ const { ConcatSource } = require("webpack-sources");
 /** @typedef {import("../ChunkTemplate")} ChunkTemplate */
 
 const getEntryInfo = chunk => {
-	return [chunk.entryModule].filter(Boolean).map(m =>
-		[m.id].concat(
-			Array.from(chunk.groupsIterable)[0]
-				.chunks.filter(c => c !== chunk)
-				.map(c => c.id)
-		)
-	);
+	if (!chunk.entryModule) {
+		return [];
+	}
+
+	// We need only first group from iterable collection
+	const firstGroup = chunk.groupsIterable.values().next().value;
+	const result = [chunk.entryModule.id];
+	for (const c of firstGroup.chunks) {
+		if (c !== chunk) {
+			result.push(c.id);
+		}
+	}
+
+	return [result];
 };
 
 class JsonpChunkTemplatePlugin {
@@ -24,20 +31,17 @@ class JsonpChunkTemplatePlugin {
 	 * @returns {void}
 	 */
 	apply(chunkTemplate) {
+		const jsonpFunction = chunkTemplate.outputOptions.jsonpFunction;
+		const jsonpFunctionStringified = JSON.stringify(jsonpFunction);
+		const globalObject = chunkTemplate.outputOptions.globalObject;
+		const initArrayTemplate = `(${globalObject}[${jsonpFunctionStringified}] = ${globalObject}[${jsonpFunctionStringified}] || [])`;
+
 		chunkTemplate.hooks.render.tap(
 			"JsonpChunkTemplatePlugin",
 			(modules, chunk) => {
-				const jsonpFunction = chunkTemplate.outputOptions.jsonpFunction;
-				const globalObject = chunkTemplate.outputOptions.globalObject;
 				const source = new ConcatSource();
 				const prefetchChunks = chunk.getChildIdsByOrders().prefetch;
-				source.add(
-					`(${globalObject}[${JSON.stringify(
-						jsonpFunction
-					)}] = ${globalObject}[${JSON.stringify(
-						jsonpFunction
-					)}] || []).push([${JSON.stringify(chunk.ids)},`
-				);
+				source.add(`${initArrayTemplate}.push([${JSON.stringify(chunk.ids)},`);
 				source.add(modules);
 				const entries = getEntryInfo(chunk);
 				if (entries.length > 0) {
@@ -56,8 +60,8 @@ class JsonpChunkTemplatePlugin {
 		chunkTemplate.hooks.hash.tap("JsonpChunkTemplatePlugin", hash => {
 			hash.update("JsonpChunkTemplatePlugin");
 			hash.update("4");
-			hash.update(`${chunkTemplate.outputOptions.jsonpFunction}`);
-			hash.update(`${chunkTemplate.outputOptions.globalObject}`);
+			hash.update(`${jsonpFunction}`);
+			hash.update(`${globalObject}`);
 		});
 		chunkTemplate.hooks.hashForChunk.tap(
 			"JsonpChunkTemplatePlugin",


### PR DESCRIPTION
There are some complicated parts in original `getEntryInfo` function:
1) It always creates an array with only one element and checks it with filter and after runs map
```js
[chunk.entryModule].filter(Boolean).map(...
```
2) We need only the first element from Iterable collection. This code creates an array with all elements from iterator and after gets the first element.
```js
Array.from(chunk.groupsIterable)[0]
```
I refactored this function to avoid needless iterations.

And also i cached `JSON.stringify(chunkTemplate.outputOptions.jsonpFunction)`

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Refactoring
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
