### PR TITLE
Refactor webpack main

### DIFF
--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -11,7 +11,16 @@ const ConcurrentCompilationError = require("./ConcurrentCompilationError");
 const MultiStats = require("./MultiStats");
 const MultiWatching = require("./MultiWatching");
 
+/** @typedef {import("./Compiler")} Compiler */
+
+const STATUS_PENDING = 0;
+const STATUS_DONE = 1;
+const STATUS_NEW = 2;
+
 module.exports = class MultiCompiler {
+	/**
+	 * @param {Compiler[]} compilers child compilers
+	 */
 	constructor(compilers) {
 		this.hooks = Object.freeze({
 			done: new SyncHook(["stats"]),
@@ -27,6 +36,8 @@ module.exports = class MultiCompiler {
 			});
 		}
 		this.compilers = compilers;
+		/** @type {WeakMap<Compiler, string[]>} */
+		this.dependencies = new WeakMap();
 		let doneCompilers = 0;
 		let compilerStats = [];
 		let index = 0;
@@ -90,6 +101,15 @@ module.exports = class MultiCompiler {
 		}
 	}
 
+	/**
+	 * @param {Compiler} compiler the child compiler
+	 * @param {string[]} dependencies its dependencies
+	 * @returns {void}
+	 */
+	setDependencies(compiler, dependencies) {
+		this.dependencies.set(compiler, dependencies);
+	}
+
 	validateDependencies(callback) {
 		const edges = new Set();
 		const missing = [];
@@ -108,8 +128,9 @@ module.exports = class MultiCompiler {
 			);
 		};
 		for (const source of this.compilers) {
-			if (source.dependencies) {
-				for (const dep of source.dependencies) {
+			const dependencies = this.dependencies.get(source);
+			if (dependencies) {
+				for (const dep of dependencies) {
 					const target = this.compilers.find(c => c.name === dep);
 					if (!target) {
 						missing.push(dep);
@@ -160,8 +181,9 @@ module.exports = class MultiCompiler {
 			let list = remainingCompilers;
 			remainingCompilers = [];
 			for (const c of list) {
+				const dependencies = this.dependencies.get(c);
 				const ready =
-					!c.dependencies || c.dependencies.every(isDependencyFulfilled);
+					!dependencies || dependencies.every(isDependencyFulfilled);
 				if (ready) {
 					readyCompilers.push(c);
 				} else {
@@ -188,11 +210,14 @@ module.exports = class MultiCompiler {
 	}
 
 	watch(watchOptions, handler) {
-		if (this.running) return handler(new ConcurrentCompilationError());
+		if (this.running) {
+			return handler(new ConcurrentCompilationError());
+		}
 
-		let watchings = [];
-		let allStats = this.compilers.map(() => null);
-		let compilerStatus = this.compilers.map(() => false);
+		const watchings = [];
+		const allStats = this.compilers.map(() => null);
+		const compilerStatus = this.compilers.map(() => STATUS_PENDING);
+
 		if (this.validateDependencies(handler)) {
 			this.running = true;
 			this.runWithDependencies(
@@ -208,12 +233,12 @@ module.exports = class MultiCompiler {
 							if (err) handler(err);
 							if (stats) {
 								allStats[compilerIdx] = stats;
-								compilerStatus[compilerIdx] = "new";
-								if (compilerStatus.every(Boolean)) {
+								compilerStatus[compilerIdx] = STATUS_NEW;
+								if (compilerStatus.every(status => status !== STATUS_PENDING)) {
 									const freshStats = allStats.filter((s, idx) => {
-										return compilerStatus[idx] === "new";
+										return compilerStatus[idx] === STATUS_NEW;
 									});
-									compilerStatus.fill(true);
+									compilerStatus.fill(STATUS_DONE);
 									const multiStats = new MultiStats(freshStats);
 									handler(null, multiStats);
 								}

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -13,6 +13,8 @@ const MultiWatching = require("./MultiWatching");
 
 /** @typedef {import("./Compiler")} Compiler */
 
+/** @typedef {number} CompilerStatus */
+
 const STATUS_PENDING = 0;
 const STATUS_DONE = 1;
 const STATUS_NEW = 2;
@@ -216,6 +218,8 @@ module.exports = class MultiCompiler {
 
 		const watchings = [];
 		const allStats = this.compilers.map(() => null);
+
+		/** @type {CompilerStatus[]} */
 		const compilerStatus = this.compilers.map(() => STATUS_PENDING);
 
 		if (this.validateDependencies(handler)) {

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -93,9 +93,6 @@ class WebpackOptionsApply extends OptionsApply {
 		compiler.recordsOutputPath =
 			options.recordsOutputPath || options.recordsPath;
 		compiler.name = options.name;
-		// TODO webpack 5 refactor this to MultiCompiler.setDependencies() with a WeakMap
-		// @ts-ignore TODO
-		compiler.dependencies = options.dependencies;
 		if (typeof options.target === "string") {
 			let JsonpTemplatePlugin;
 			let FetchCompileWasmPlugin;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,137 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const util = require("util");
+const { version } = require("../package.json");
+const webpackOptionsSchema = require("../schemas/WebpackOptions.json");
+const Compiler = require("./Compiler");
+const MultiCompiler = require("./MultiCompiler");
+const WebpackOptionsApply = require("./WebpackOptionsApply");
+const WebpackOptionsDefaulter = require("./WebpackOptionsDefaulter");
+const WebpackOptionsValidationError = require("./WebpackOptionsValidationError");
+const NodeEnvironmentPlugin = require("./node/NodeEnvironmentPlugin");
+const validateSchema = require("./validateSchema");
+const webpack = require("./webpack");
+
+exports = module.exports = webpack;
+exports.WebpackOptionsApply = WebpackOptionsApply;
+exports.WebpackOptionsDefaulter = WebpackOptionsDefaulter;
+exports.WebpackOptionsValidationError = WebpackOptionsValidationError;
+exports.Compiler = Compiler;
+exports.MultiCompiler = MultiCompiler;
+exports.NodeEnvironmentPlugin = NodeEnvironmentPlugin;
+exports.validate = validateSchema.bind(null, webpackOptionsSchema);
+exports.validateSchema = validateSchema;
+exports.version = version;
+
+const exportPlugins = (obj, mappings) => {
+	for (const name of Object.keys(mappings)) {
+		Object.defineProperty(obj, name, {
+			configurable: false,
+			enumerable: true,
+			get: mappings[name]
+		});
+	}
+};
+
+exportPlugins(exports, {
+	AutomaticPrefetchPlugin: () => require("./AutomaticPrefetchPlugin"),
+	BannerPlugin: () => require("./BannerPlugin"),
+	ContextExclusionPlugin: () => require("./ContextExclusionPlugin"),
+	ContextReplacementPlugin: () => require("./ContextReplacementPlugin"),
+	DefinePlugin: () => require("./DefinePlugin"),
+	Dependency: () => require("./Dependency"),
+	DllPlugin: () => require("./DllPlugin"),
+	DllReferencePlugin: () => require("./DllReferencePlugin"),
+	EntryPlugin: () => require("./EntryPlugin"),
+	EnvironmentPlugin: () => require("./EnvironmentPlugin"),
+	EvalDevToolModulePlugin: () => require("./EvalDevToolModulePlugin"),
+	EvalSourceMapDevToolPlugin: () => require("./EvalSourceMapDevToolPlugin"),
+	ExternalsPlugin: () => require("./ExternalsPlugin"),
+	HotModuleReplacementPlugin: () => require("./HotModuleReplacementPlugin"),
+	IgnorePlugin: () => require("./IgnorePlugin"),
+	LibraryTemplatePlugin: () => require("./LibraryTemplatePlugin"),
+	LoaderOptionsPlugin: () => require("./LoaderOptionsPlugin"),
+	LoaderTargetPlugin: () => require("./LoaderTargetPlugin"),
+	MemoryOutputFileSystem: () => require("./MemoryOutputFileSystem"),
+	Module: () => require("./Module"),
+	ModuleFilenameHelpers: () => require("./ModuleFilenameHelpers"),
+	NoEmitOnErrorsPlugin: () => require("./NoEmitOnErrorsPlugin"),
+	NormalModuleReplacementPlugin: () =>
+		require("./NormalModuleReplacementPlugin"),
+	PrefetchPlugin: () => require("./PrefetchPlugin"),
+	ProgressPlugin: () => require("./ProgressPlugin"),
+	ProvidePlugin: () => require("./ProvidePlugin"),
+	SingleEntryPlugin: util.deprecate(
+		() => require("./EntryPlugin"),
+		"SingleEntryPlugin was renamed to EntryPlugin"
+	),
+	SetVarMainTemplatePlugin: () => require("./SetVarMainTemplatePlugin"),
+	SourceMapDevToolPlugin: () => require("./SourceMapDevToolPlugin"),
+	Stats: () => require("./Stats"),
+	Template: () => require("./Template"),
+	UmdMainTemplatePlugin: () => require("./UmdMainTemplatePlugin"),
+	WatchIgnorePlugin: () => require("./WatchIgnorePlugin")
+});
+
+exportPlugins((exports.cache = {}), {
+	MemoryCachePlugin: () => require("./cache/MemoryCachePlugin")
+});
+
+exportPlugins((exports.dependencies = {}), {
+	DependencyReference: () => require("./dependencies/DependencyReference")
+});
+
+exportPlugins((exports.ids = {}), {
+	ChunkModuleIdRangePlugin: () => require("./ids/ChunkModuleIdRangePlugin"),
+	NaturalModuleIdsPlugin: () => require("./ids/NaturalModuleIdsPlugin"),
+	OccurrenceModuleIdsPlugin: () => require("./ids/OccurrenceModuleIdsPlugin"),
+	NamedModuleIdsPlugin: () => require("./ids/NamedModuleIdsPlugin"),
+	DeterministicModuleIdsPlugin: () =>
+		require("./ids/DeterministicModuleIdsPlugin"),
+	NamedChunkIdsPlugin: () => require("./ids/NamedChunkIdsPlugin"),
+	OccurrenceChunkIdsPlugin: () => require("./ids/OccurrenceChunkIdsPlugin"),
+	HashedModuleIdsPlugin: () => require("./ids/HashedModuleIdsPlugin")
+});
+
+exportPlugins((exports.optimize = {}), {
+	AggressiveMergingPlugin: () => require("./optimize/AggressiveMergingPlugin"),
+	AggressiveSplittingPlugin: util.deprecate(
+		() => require("./optimize/AggressiveSplittingPlugin"),
+		"AggressiveSplittingPlugin is deprecated in favor of SplitChunksPlugin"
+	),
+	LimitChunkCountPlugin: () => require("./optimize/LimitChunkCountPlugin"),
+	MinChunkSizePlugin: () => require("./optimize/MinChunkSizePlugin"),
+	ModuleConcatenationPlugin: () =>
+		require("./optimize/ModuleConcatenationPlugin"),
+	RuntimeChunkPlugin: () => require("./optimize/RuntimeChunkPlugin"),
+	SideEffectsFlagPlugin: () => require("./optimize/SideEffectsFlagPlugin"),
+	SplitChunksPlugin: () => require("./optimize/SplitChunksPlugin")
+});
+
+exportPlugins((exports.web = {}), {
+	FetchCompileWasmPlugin: () => require("./web/FetchCompileWasmPlugin"),
+	JsonpTemplatePlugin: () => require("./web/JsonpTemplatePlugin")
+});
+
+exportPlugins((exports.webworker = {}), {
+	WebWorkerTemplatePlugin: () => require("./webworker/WebWorkerTemplatePlugin")
+});
+
+exportPlugins((exports.node = {}), {
+	NodeTemplatePlugin: () => require("./node/NodeTemplatePlugin"),
+	ReadFileCompileWasmPlugin: () => require("./node/ReadFileCompileWasmPlugin")
+});
+
+exportPlugins((exports.debug = {}), {
+	ProfilingPlugin: () => require("./debug/ProfilingPlugin")
+});
+
+exportPlugins((exports.util = {}), {
+	createHash: () => require("./util/createHash"),
+	comparators: () => require("./util/comparators")
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,6 @@ const MultiCompiler = require("./MultiCompiler");
 const WebpackOptionsApply = require("./WebpackOptionsApply");
 const WebpackOptionsDefaulter = require("./WebpackOptionsDefaulter");
 const WebpackOptionsValidationError = require("./WebpackOptionsValidationError");
-const NodeEnvironmentPlugin = require("./node/NodeEnvironmentPlugin");
 const validateSchema = require("./validateSchema");
 const webpack = require("./webpack");
 
@@ -23,7 +22,6 @@ exports.WebpackOptionsDefaulter = WebpackOptionsDefaulter;
 exports.WebpackOptionsValidationError = WebpackOptionsValidationError;
 exports.Compiler = Compiler;
 exports.MultiCompiler = MultiCompiler;
-exports.NodeEnvironmentPlugin = NodeEnvironmentPlugin;
 exports.validate = validateSchema.bind(null, webpackOptionsSchema);
 exports.validateSchema = validateSchema;
 exports.version = version;
@@ -123,6 +121,7 @@ exportPlugins((exports.webworker = {}), {
 });
 
 exportPlugins((exports.node = {}), {
+	NodeEnvironmentPlugin: () => require("./node/NodeEnvironmentPlugin"),
 	NodeTemplatePlugin: () => require("./node/NodeTemplatePlugin"),
 	ReadFileCompileWasmPlugin: () => require("./node/ReadFileCompileWasmPlugin")
 });

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -5,8 +5,6 @@
 
 "use strict";
 
-const util = require("util");
-const version = require("../package.json").version;
 const webpackOptionsSchema = require("../schemas/WebpackOptions.json");
 const Compiler = require("./Compiler");
 const MultiCompiler = require("./MultiCompiler");
@@ -20,172 +18,88 @@ const validateSchema = require("./validateSchema");
 /** @typedef {import("./Stats")} Stats */
 
 /**
- * @param {WebpackOptions} options options object
- * @param {function(Error=, Stats=): void=} callback callback
- * @returns {Compiler | MultiCompiler} the compiler object
+ * @callback WebpackCallback
+ * @param {Error=} err
+ * @param {Stats=} stats
+ * @returns {void}
  */
-const webpack = (options, callback) => {
-	const webpackOptionsValidationErrors = validateSchema(
-		webpackOptionsSchema,
-		options
-	);
-	if (webpackOptionsValidationErrors.length) {
-		throw new WebpackOptionsValidationError(webpackOptionsValidationErrors);
-	}
-	let compiler;
-	if (Array.isArray(options)) {
-		compiler = new MultiCompiler(options.map(options => webpack(options)));
-	} else if (typeof options === "object") {
-		options = new WebpackOptionsDefaulter().process(options);
 
-		compiler = new Compiler(options.context);
-		compiler.options = options;
-		new NodeEnvironmentPlugin().apply(compiler);
-		if (options.plugins && Array.isArray(options.plugins)) {
-			for (const plugin of options.plugins) {
-				if (typeof plugin === "function") {
-					plugin.call(compiler, compiler);
-				} else {
-					plugin.apply(compiler);
-				}
-			}
+/**
+ * @param {WebpackOptions[]} childOptions options array
+ * @returns {MultiCompiler} a multi-compiler
+ */
+const createMultiCompiler = childOptions => {
+	const compilers = childOptions.map(options => createCompiler(options));
+	const compiler = new MultiCompiler(compilers);
+	for (const childCompiler of compilers) {
+		if (childCompiler.options.dependencies) {
+			compiler.setDependencies(
+				childCompiler,
+				childCompiler.options.dependencies
+			);
 		}
-		compiler.hooks.environment.call();
-		compiler.hooks.afterEnvironment.call();
-		compiler.options = new WebpackOptionsApply().process(options, compiler);
-	} else {
-		throw new Error("Invalid argument: options");
-	}
-	if (callback) {
-		if (typeof callback !== "function") {
-			throw new Error("Invalid argument: callback");
-		}
-		if (
-			options.watch === true ||
-			(Array.isArray(options) && options.some(o => o.watch))
-		) {
-			const watchOptions = Array.isArray(options)
-				? options.map(o => o.watchOptions || {})
-				: options.watchOptions || {};
-			return compiler.watch(watchOptions, callback);
-		}
-		compiler.run((err, stats) => {
-			compiler.close(err2 => {
-				callback(err || err2, stats);
-			});
-		});
 	}
 	return compiler;
 };
 
-exports = module.exports = webpack;
-exports.version = version;
-
-webpack.WebpackOptionsDefaulter = WebpackOptionsDefaulter;
-webpack.WebpackOptionsApply = WebpackOptionsApply;
-webpack.Compiler = Compiler;
-webpack.MultiCompiler = MultiCompiler;
-webpack.NodeEnvironmentPlugin = NodeEnvironmentPlugin;
-// @ts-ignore Global @this directive is not supported
-webpack.validate = validateSchema.bind(this, webpackOptionsSchema);
-webpack.validateSchema = validateSchema;
-webpack.WebpackOptionsValidationError = WebpackOptionsValidationError;
-
-const exportPlugins = (obj, mappings) => {
-	for (const name of Object.keys(mappings)) {
-		Object.defineProperty(obj, name, {
-			configurable: false,
-			enumerable: true,
-			get: mappings[name]
-		});
+/**
+ * @param {WebpackOptions} options options object
+ * @returns {Compiler} a compiler
+ */
+const createCompiler = options => {
+	options = new WebpackOptionsDefaulter().process(options);
+	const compiler = new Compiler(options.context);
+	compiler.options = options;
+	new NodeEnvironmentPlugin().apply(compiler);
+	if (Array.isArray(options.plugins)) {
+		for (const plugin of options.plugins) {
+			if (typeof plugin === "function") {
+				plugin.call(compiler, compiler);
+			} else {
+				plugin.apply(compiler);
+			}
+		}
 	}
+	compiler.hooks.environment.call();
+	compiler.hooks.afterEnvironment.call();
+	compiler.options = new WebpackOptionsApply().process(options, compiler);
+	return compiler;
 };
 
-exportPlugins(exports, {
-	AutomaticPrefetchPlugin: () => require("./AutomaticPrefetchPlugin"),
-	BannerPlugin: () => require("./BannerPlugin"),
-	ContextExclusionPlugin: () => require("./ContextExclusionPlugin"),
-	ContextReplacementPlugin: () => require("./ContextReplacementPlugin"),
-	DefinePlugin: () => require("./DefinePlugin"),
-	Dependency: () => require("./Dependency"),
-	DllPlugin: () => require("./DllPlugin"),
-	DllReferencePlugin: () => require("./DllReferencePlugin"),
-	EntryPlugin: () => require("./EntryPlugin"),
-	EnvironmentPlugin: () => require("./EnvironmentPlugin"),
-	EvalDevToolModulePlugin: () => require("./EvalDevToolModulePlugin"),
-	EvalSourceMapDevToolPlugin: () => require("./EvalSourceMapDevToolPlugin"),
-	ExternalsPlugin: () => require("./ExternalsPlugin"),
-	HotModuleReplacementPlugin: () => require("./HotModuleReplacementPlugin"),
-	IgnorePlugin: () => require("./IgnorePlugin"),
-	LibraryTemplatePlugin: () => require("./LibraryTemplatePlugin"),
-	LoaderOptionsPlugin: () => require("./LoaderOptionsPlugin"),
-	LoaderTargetPlugin: () => require("./LoaderTargetPlugin"),
-	MemoryOutputFileSystem: () => require("./MemoryOutputFileSystem"),
-	Module: () => require("./Module"),
-	ModuleFilenameHelpers: () => require("./ModuleFilenameHelpers"),
-	NoEmitOnErrorsPlugin: () => require("./NoEmitOnErrorsPlugin"),
-	NormalModuleReplacementPlugin: () =>
-		require("./NormalModuleReplacementPlugin"),
-	PrefetchPlugin: () => require("./PrefetchPlugin"),
-	ProgressPlugin: () => require("./ProgressPlugin"),
-	ProvidePlugin: () => require("./ProvidePlugin"),
-	SingleEntryPlugin: util.deprecate(
-		() => require("./EntryPlugin"),
-		"SingleEntryPlugin was renamed to EntryPlugin"
-	),
-	SetVarMainTemplatePlugin: () => require("./SetVarMainTemplatePlugin"),
-	SourceMapDevToolPlugin: () => require("./SourceMapDevToolPlugin"),
-	Stats: () => require("./Stats"),
-	Template: () => require("./Template"),
-	UmdMainTemplatePlugin: () => require("./UmdMainTemplatePlugin"),
-	WatchIgnorePlugin: () => require("./WatchIgnorePlugin")
-});
-exportPlugins((exports.cache = {}), {
-	MemoryCachePlugin: () => require("./cache/MemoryCachePlugin")
-});
-exportPlugins((exports.dependencies = {}), {
-	DependencyReference: () => require("./dependencies/DependencyReference")
-});
-exportPlugins((exports.ids = {}), {
-	ChunkModuleIdRangePlugin: () => require("./ids/ChunkModuleIdRangePlugin"),
-	NaturalModuleIdsPlugin: () => require("./ids/NaturalModuleIdsPlugin"),
-	OccurrenceModuleIdsPlugin: () => require("./ids/OccurrenceModuleIdsPlugin"),
-	NamedModuleIdsPlugin: () => require("./ids/NamedModuleIdsPlugin"),
-	DeterministicModuleIdsPlugin: () =>
-		require("./ids/DeterministicModuleIdsPlugin"),
-	NamedChunkIdsPlugin: () => require("./ids/NamedChunkIdsPlugin"),
-	OccurrenceChunkIdsPlugin: () => require("./ids/OccurrenceChunkIdsPlugin"),
-	HashedModuleIdsPlugin: () => require("./ids/HashedModuleIdsPlugin")
-});
-exportPlugins((exports.optimize = {}), {
-	AggressiveMergingPlugin: () => require("./optimize/AggressiveMergingPlugin"),
-	AggressiveSplittingPlugin: util.deprecate(
-		() => require("./optimize/AggressiveSplittingPlugin"),
-		"AggressiveSplittingPlugin is deprecated in favor of SplitChunksPlugin"
-	),
-	LimitChunkCountPlugin: () => require("./optimize/LimitChunkCountPlugin"),
-	MinChunkSizePlugin: () => require("./optimize/MinChunkSizePlugin"),
-	ModuleConcatenationPlugin: () =>
-		require("./optimize/ModuleConcatenationPlugin"),
-	RuntimeChunkPlugin: () => require("./optimize/RuntimeChunkPlugin"),
-	SideEffectsFlagPlugin: () => require("./optimize/SideEffectsFlagPlugin"),
-	SplitChunksPlugin: () => require("./optimize/SplitChunksPlugin")
-});
-exportPlugins((exports.web = {}), {
-	FetchCompileWasmPlugin: () => require("./web/FetchCompileWasmPlugin"),
-	JsonpTemplatePlugin: () => require("./web/JsonpTemplatePlugin")
-});
-exportPlugins((exports.webworker = {}), {
-	WebWorkerTemplatePlugin: () => require("./webworker/WebWorkerTemplatePlugin")
-});
-exportPlugins((exports.node = {}), {
-	NodeTemplatePlugin: () => require("./node/NodeTemplatePlugin"),
-	ReadFileCompileWasmPlugin: () => require("./node/ReadFileCompileWasmPlugin")
-});
-exportPlugins((exports.debug = {}), {
-	ProfilingPlugin: () => require("./debug/ProfilingPlugin")
-});
-exportPlugins((exports.util = {}), {
-	createHash: () => require("./util/createHash"),
-	comparators: () => require("./util/comparators")
-});
+/**
+ * @param {WebpackOptions | WebpackOptions[]} options options object
+ * @param {WebpackCallback=} callback callback
+ * @returns {Compiler | MultiCompiler} the compiler object
+ */
+const webpack = (options, callback) => {
+	const validationErrors = validateSchema(webpackOptionsSchema, options);
+	if (validationErrors.length) {
+		throw new WebpackOptionsValidationError(validationErrors);
+	}
+	let compiler;
+	let watch = false;
+	let watchOptions;
+	if (Array.isArray(options)) {
+		compiler = createMultiCompiler(options);
+		watch = options.some(options => options.watch);
+		watchOptions = options.map(options => options.watchOptions || {});
+	} else {
+		compiler = createCompiler(options);
+		watch = options.watch;
+		watchOptions = options.watchOptions || {};
+	}
+	if (callback) {
+		if (watch) {
+			compiler.watch(watchOptions, callback);
+		} else {
+			compiler.run((err, stats) => {
+				compiler.close(err2 => {
+					callback(err || err2, stats);
+				});
+			});
+		}
+	}
+	return compiler;
+};
+
+module.exports = webpack;

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "url": "https://github.com/webpack/webpack.git"
   },
   "homepage": "https://github.com/webpack/webpack",
-  "main": "lib/webpack.js",
+  "main": "lib/index.js",
   "bin": "./bin/webpack.js",
   "files": [
     "lib/",

--- a/test/BenchmarkTestCases.benchmark.js
+++ b/test/BenchmarkTestCases.benchmark.js
@@ -77,7 +77,7 @@ describe("BenchmarkTestCases", function() {
 
 					function doLoadWebpack() {
 						const baselineWebpack = require.requireActual(
-							path.resolve(baselinePath, "lib/webpack.js")
+							path.resolve(baselinePath, "lib/index.js")
 						);
 						baselines.push({
 							name: baselineInfo.name,

--- a/test/Compiler-caching.test.js
+++ b/test/Compiler-caching.test.js
@@ -5,7 +5,7 @@ const path = require("path");
 const fs = require("fs");
 const rimraf = require("rimraf");
 
-const webpack = require("../");
+const webpack = require("..");
 const WebpackOptionsDefaulter = require("../lib/WebpackOptionsDefaulter");
 let fixtureCount = 0;
 

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -3,7 +3,7 @@
 
 const path = require("path");
 
-const webpack = require("../");
+const webpack = require("..");
 const Stats = require("../lib/Stats");
 const WebpackOptionsDefaulter = require("../lib/WebpackOptionsDefaulter");
 const MemoryFs = require("memory-fs");

--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -11,7 +11,7 @@ const createLazyTestEnv = require("./helpers/createLazyTestEnv");
 const FakeDocument = require("./helpers/FakeDocument");
 
 const Stats = require("../lib/Stats");
-const webpack = require("../lib/webpack");
+const webpack = require("..");
 const prepareOptions = require("./helpers/prepareOptions");
 
 describe("ConfigTestCases", () => {

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -3,7 +3,7 @@
 /*globals describe it */
 const path = require("path");
 
-const webpack = require("../lib/webpack");
+const webpack = require("..");
 
 const base = path.join(__dirname, "fixtures", "errors");
 

--- a/test/Examples.test.js
+++ b/test/Examples.test.js
@@ -3,7 +3,7 @@
 /* globals describe it */
 const path = require("path");
 const fs = require("fs");
-const webpack = require("../");
+const webpack = require("..");
 
 describe("Examples", () => {
 	const basePath = path.join(__dirname, "..", "examples");

--- a/test/HotModuleReplacementPlugin.test.js
+++ b/test/HotModuleReplacementPlugin.test.js
@@ -4,7 +4,7 @@ const path = require("path");
 const fs = require("fs");
 const mkdirp = require("mkdirp");
 
-const webpack = require("../");
+const webpack = require("..");
 
 describe("HotModuleReplacementPlugin", () => {
 	jest.setTimeout(20000);

--- a/test/HotTestCases.template.js
+++ b/test/HotTestCases.template.js
@@ -7,7 +7,7 @@ const vm = require("vm");
 const checkArrayExpectation = require("./checkArrayExpectation");
 const createLazyTestEnv = require("./helpers/createLazyTestEnv");
 
-const webpack = require("../lib/webpack");
+const webpack = require("..");
 
 const casesPath = path.join(__dirname, "hotCases");
 let categories = fs

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -3,7 +3,7 @@
 /* globals describe it */
 const path = require("path");
 const MemoryFs = require("memory-fs");
-const webpack = require("../");
+const webpack = require("..");
 
 const createMultiCompiler = () => {
 	const compiler = webpack([

--- a/test/NodeTemplatePlugin.test.js
+++ b/test/NodeTemplatePlugin.test.js
@@ -2,7 +2,7 @@
 "use strict";
 
 const path = require("path");
-const webpack = require("../lib/webpack");
+const webpack = require("..");
 
 describe("NodeTemplatePlugin", () => {
 	jest.setTimeout(20000);

--- a/test/ProgressPlugin.test.js
+++ b/test/ProgressPlugin.test.js
@@ -2,7 +2,7 @@
 
 const path = require("path");
 const MemoryFs = require("memory-fs");
-const webpack = require("../");
+const webpack = require("..");
 
 const createMultiCompiler = () => {
 	const compiler = webpack([

--- a/test/RemoveFiles.test.js
+++ b/test/RemoveFiles.test.js
@@ -3,7 +3,7 @@
 /* globals describe it */
 const path = require("path");
 const MemoryFs = require("memory-fs");
-const webpack = require("../");
+const webpack = require("..");
 const fs = require("fs");
 const rimraf = require("rimraf");
 

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -1,7 +1,7 @@
 /*globals describe it */
 "use strict";
 
-const webpack = require("../lib/webpack");
+const webpack = require("..");
 const MemoryFs = require("memory-fs");
 
 describe("Stats", () => {

--- a/test/StatsTestCases.test.js
+++ b/test/StatsTestCases.test.js
@@ -4,7 +4,7 @@
 const path = require("path");
 const fs = require("fs");
 
-const webpack = require("../lib/webpack");
+const webpack = require("..");
 const Stats = require("../lib/Stats");
 
 const base = path.join(__dirname, "statsCases");

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -12,7 +12,7 @@ const createLazyTestEnv = require("./helpers/createLazyTestEnv");
 
 const Stats = require("../lib/Stats");
 const FileCachePlugin = require("../lib/cache/FileCachePlugin");
-const webpack = require("../lib/webpack");
+const webpack = require("..");
 
 const terserForTesting = new TerserPlugin({
 	cache: false,

--- a/test/TestCasesAllCombined.test.js
+++ b/test/TestCasesAllCombined.test.js
@@ -1,5 +1,5 @@
 const { describeCases } = require("./TestCases.template");
-const webpack = require("../lib/webpack");
+const webpack = require("..");
 
 describe("TestCases", () => {
 	describeCases({

--- a/test/TestCasesHot.test.js
+++ b/test/TestCasesHot.test.js
@@ -1,5 +1,5 @@
 const { describeCases } = require("./TestCases.template");
-const webpack = require("../lib/webpack");
+const webpack = require("..");
 
 describe("TestCases", () => {
 	describeCases({

--- a/test/TestCasesHotMultiStep.test.js
+++ b/test/TestCasesHotMultiStep.test.js
@@ -1,5 +1,5 @@
 const { describeCases } = require("./TestCases.template");
-const webpack = require("../lib/webpack");
+const webpack = require("..");
 
 describe("TestCases", () => {
 	describeCases({

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -1,7 +1,7 @@
 /* globals describe, it */
 "use strict";
 
-const webpack = require("../lib/webpack");
+const webpack = require("..");
 
 describe("Validation", () => {
 	const testCases = [

--- a/test/WatchDetection.test.js
+++ b/test/WatchDetection.test.js
@@ -5,7 +5,7 @@ const path = require("path");
 const fs = require("fs");
 const MemoryFs = require("memory-fs");
 
-const webpack = require("../");
+const webpack = require("..");
 
 describe("WatchDetection", () => {
 	if (process.env.NO_WATCH_TESTS) {

--- a/test/WatchTestCases.test.js
+++ b/test/WatchTestCases.test.js
@@ -11,7 +11,7 @@ const createLazyTestEnv = require("./helpers/createLazyTestEnv");
 const { remove } = require("./helpers/remove");
 
 const Stats = require("../lib/Stats");
-const webpack = require("../lib/webpack");
+const webpack = require("..");
 
 function copyDiff(src, dest, initial) {
 	if (!fs.existsSync(dest)) fs.mkdirSync(dest);

--- a/test/WatcherEvents.test.js
+++ b/test/WatcherEvents.test.js
@@ -3,7 +3,7 @@
 /* globals describe it */
 const path = require("path");
 const MemoryFs = require("memory-fs");
-const webpack = require("../");
+const webpack = require("..");
 
 const createCompiler = config => {
 	const compiler = webpack(config);


### PR DESCRIPTION
- Removes `Compiler#dependencies` in favor of `MultiCompiler#setDependencies`
- Renames `lib/webpack.js` into `lib/index.js`
- Moves `webpack` function into `lib/webpack.js`
- Refactors `webpack` to better handle multi-options

**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

yes

**What needs to be documented once your changes are merged?**

`Compiler#dependencies` has been removed.