### PR TITLE
Add stack to errors with the errorDetails option

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -309,16 +309,19 @@ class Stats {
 				}
 				text += "\n";
 			}
-			text += e.message;
+
+			if (showErrorDetails && e.stack && !e.details) {
+				text += e.stack;
+			} else {
+				text += e.message;
+			}
 			if (showErrorDetails && e.details) {
 				text += `\n${e.details}`;
 			}
 			if (showErrorDetails && e.missing) {
 				text += e.missing.map(item => `\n[${item}]`).join("");
 			}
-			if (showErrorDetails && e.stack) {
-				text += `\n${e.stack}`;
-			}
+
 			if (showModuleTrace && e.origin) {
 				text += `\n @ ${this.formatFilePath(
 					e.origin.readableIdentifier(requestShortener)

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -316,6 +316,9 @@ class Stats {
 			if (showErrorDetails && e.missing) {
 				text += e.missing.map(item => `\n[${item}]`).join("");
 			}
+			if (showErrorDetails && e.stack) {
+				text += `\n${e.stack}`;
+			}
 			if (showModuleTrace && e.origin) {
 				text += `\n @ ${this.formatFilePath(
 					e.origin.readableIdentifier(requestShortener)

--- a/test/Stats.unittest.js
+++ b/test/Stats.unittest.js
@@ -95,11 +95,11 @@ describe(
 					const mockStats = new Stats({
 						children: [
 							{
-								getStats: () =>
-									new Stats({
-										warnings: ["firstError"],
-										hash: "5678"
-									})
+							getStats: () =>
+								new Stats({
+									warnings: ["firstError"],
+									hash: "5678"
+								})
 							}
 						],
 						warnings: [],
@@ -134,8 +134,10 @@ describe(
 			});
 		});
 		describe("toJson", () => {
-			it("returns plain object representation", () => {
-				const mockStats = new Stats({
+			let fakeCompilation;
+			beforeEach(() => {
+				
+				fakeCompilation = {
 					errors: [],
 					warnings: [],
 					assets: [],
@@ -154,8 +156,12 @@ describe(
 					compiler: {
 						context: ""
 					}
-				});
+				};
+			});
+			it("returns plain object representation", () => {
+				const mockStats = new Stats(fakeCompilation);
 				const result = mockStats.toJson();
+
 				expect(result).toEqual({
 					assets: [],
 					assetsByChunkName: {},
@@ -173,6 +179,16 @@ describe(
 					version: packageJson.version,
 					warnings: []
 				});
+			});
+
+			it('Given showErrors it should return error with its stack', () => {
+				const fakeError = new Error('FAKE STACK');
+				fakeCompilation.errors = [fakeError];
+				const mockStats = new Stats(fakeCompilation);
+
+				const result = mockStats.toJson({ errorDetails: true });
+				
+				expect(result.errors[0]).toEqual(`${fakeError.message}\n${fakeError.stack}`);
 			});
 		});
 		describe("Presets", () => {

--- a/test/Stats.unittest.js
+++ b/test/Stats.unittest.js
@@ -95,11 +95,11 @@ describe(
 					const mockStats = new Stats({
 						children: [
 							{
-							getStats: () =>
-								new Stats({
-									warnings: ["firstError"],
-									hash: "5678"
-								})
+								getStats: () =>
+									new Stats({
+										warnings: ["firstError"],
+										hash: "5678"
+									})
 							}
 						],
 						warnings: [],
@@ -136,7 +136,6 @@ describe(
 		describe("toJson", () => {
 			let fakeCompilation;
 			beforeEach(() => {
-				
 				fakeCompilation = {
 					errors: [],
 					warnings: [],
@@ -181,14 +180,13 @@ describe(
 				});
 			});
 
-			it('Given showErrors it should return error with its stack', () => {
-				const fakeError = new Error('FAKE STACK');
+			it("returns an error with its stack when errorDetails is true", () => {
+				const fakeError = new Error("FAKE STACK");
 				fakeCompilation.errors = [fakeError];
 				const mockStats = new Stats(fakeCompilation);
-
 				const result = mockStats.toJson({ errorDetails: true });
 				
-				expect(result.errors[0]).toEqual(`${fakeError.message}\n${fakeError.stack}`);
+				expect(result.errors[0]).toEqual(fakeError.stack);
 			});
 		});
 		describe("Presets", () => {

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1111,15 +1111,81 @@ exports[`StatsTestCases should print correct stats for import-with-invalid-optio
 [5] ./chunk-d.js 27 bytes {3} [built]
 
 WARNING in ./chunk.js 4:11-77
-Compilation error while processing magic comment(-s): /* webpack Prefetch: 0, webpackChunkName: \\"notGoingToCompile-c\\" */: Unexpected identifier
+CommentCompilationWarning: Compilation error while processing magic comment(-s): /* webpack Prefetch: 0, webpackChunkName: \\"notGoingToCompile-c\\" */: Unexpected identifier
+    at parser.hooks.importCall.tap.expr (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\dependencies\\\\ImportParserPlugin.js:45:7)
+    at SyncBailHook.eval (eval at create (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\node_modules\\\\tapable\\\\lib\\\\HookCodeFactory.js:19:10), <anonymous>:7:16)
+    at Parser.walkCallExpression (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1819:39)
+    at Parser.walkExpression (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1500:10)
+    at Parser.walkExpressionStatement (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1000:8)
+    at Parser.walkStatement (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:946:10)
+    at Parser.walkStatements (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:864:9)
+    at Parser.walkBlockStatement (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:996:8)
+    at Parser.walkStatement (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:931:10)
+    at inScope (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1182:10)
+    at Parser.inScope (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1910:3)
+    at Parser.walkFunctionDeclaration (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1175:8)
+    at Parser.walkExportDefaultDeclaration (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1311:10)
+    at Parser.walkStatement (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:940:10)
+    at Parser.walkStatements (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:864:9)
+    at Parser.parse (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:2123:9)
+    at doBuild.err (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\NormalModule.js:460:32)
+    at runLoaders (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\NormalModule.js:342:12)
+    at C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\node_modules\\\\loader-runner\\\\lib\\\\LoaderRunner.js:370:3
+    at iterateNormalLoaders (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\node_modules\\\\loader-runner\\\\lib\\\\LoaderRunner.js:211:10)
+    at C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\node_modules\\\\loader-runner\\\\lib\\\\LoaderRunner.js:202:4
+    at Array.ifs.readFile.apply.args.concat (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\test\\\\StatsTestCases.test.js:73:9)
  @ ./index.js 1:0-49
 
 WARNING in ./chunk.js 5:11-38
-Compilation error while processing magic comment(-s): /* webpackPrefetch: nope */: nope is not defined
+CommentCompilationWarning: Compilation error while processing magic comment(-s): /* webpackPrefetch: nope */: nope is not defined
+    at parser.hooks.importCall.tap.expr (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\dependencies\\\\ImportParserPlugin.js:45:7)
+    at SyncBailHook.eval (eval at create (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\node_modules\\\\tapable\\\\lib\\\\HookCodeFactory.js:19:10), <anonymous>:7:16)
+    at Parser.walkCallExpression (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1819:39)
+    at Parser.walkExpression (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1500:10)
+    at Parser.walkExpressionStatement (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1000:8)
+    at Parser.walkStatement (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:946:10)
+    at Parser.walkStatements (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:864:9)
+    at Parser.walkBlockStatement (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:996:8)
+    at Parser.walkStatement (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:931:10)
+    at inScope (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1182:10)
+    at Parser.inScope (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1910:3)
+    at Parser.walkFunctionDeclaration (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1175:8)
+    at Parser.walkExportDefaultDeclaration (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1311:10)
+    at Parser.walkStatement (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:940:10)
+    at Parser.walkStatements (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:864:9)
+    at Parser.parse (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:2123:9)
+    at doBuild.err (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\NormalModule.js:460:32)
+    at runLoaders (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\NormalModule.js:342:12)
+    at C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\node_modules\\\\loader-runner\\\\lib\\\\LoaderRunner.js:370:3
+    at iterateNormalLoaders (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\node_modules\\\\loader-runner\\\\lib\\\\LoaderRunner.js:211:10)
+    at C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\node_modules\\\\loader-runner\\\\lib\\\\LoaderRunner.js:202:4
+    at Array.ifs.readFile.apply.args.concat (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\test\\\\StatsTestCases.test.js:73:9)
  @ ./index.js 1:0-49
 
 WARNING in ./chunk.js 2:11-84
-Compilation error while processing magic comment(-s): /* webpackPrefetch: true, webpackChunkName: notGoingToCompileChunkName */: notGoingToCompileChunkName is not defined
+CommentCompilationWarning: Compilation error while processing magic comment(-s): /* webpackPrefetch: true, webpackChunkName: notGoingToCompileChunkName */: notGoingToCompileChunkName is not defined
+    at parser.hooks.importCall.tap.expr (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\dependencies\\\\ImportParserPlugin.js:45:7)
+    at SyncBailHook.eval (eval at create (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\node_modules\\\\tapable\\\\lib\\\\HookCodeFactory.js:19:10), <anonymous>:7:16)
+    at Parser.walkCallExpression (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1819:39)
+    at Parser.walkExpression (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1500:10)
+    at Parser.walkExpressionStatement (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1000:8)
+    at Parser.walkStatement (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:946:10)
+    at Parser.walkStatements (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:864:9)
+    at Parser.walkBlockStatement (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:996:8)
+    at Parser.walkStatement (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:931:10)
+    at inScope (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1182:10)
+    at Parser.inScope (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1910:3)
+    at Parser.walkFunctionDeclaration (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1175:8)
+    at Parser.walkExportDefaultDeclaration (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:1311:10)
+    at Parser.walkStatement (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:940:10)
+    at Parser.walkStatements (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:864:9)
+    at Parser.parse (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\Parser.js:2123:9)
+    at doBuild.err (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\NormalModule.js:460:32)
+    at runLoaders (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\lib\\\\NormalModule.js:342:12)
+    at C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\node_modules\\\\loader-runner\\\\lib\\\\LoaderRunner.js:370:3
+    at iterateNormalLoaders (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\node_modules\\\\loader-runner\\\\lib\\\\LoaderRunner.js:211:10)
+    at C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\node_modules\\\\loader-runner\\\\lib\\\\LoaderRunner.js:202:4
+    at Array.ifs.readFile.apply.args.concat (C:\\\\dev\\\\workspace\\\\open-source\\\\webpack\\\\test\\\\StatsTestCases.test.js:73:9)
  @ ./index.js 1:0-49"
 `;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Try to link to an open issue for more information. -->
fixes #8425 

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Now, whenever you'll pass `errorDetails` to `toJson()` of Stats you'll also see the error's stack trace if it exists. 
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
