### PR TITLE
Add missing double-quotes

### DIFF
--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -109,7 +109,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 			this._id !== this.name ? ` (imported as '${this.name}')` : "";
 		const errorMessage = `"export '${
 			this._id
-		}'${idIsNotNameMessage} was not found in '${this.userRequest}'`;
+		}'"${idIsNotNameMessage} was not found in '${this.userRequest}'`;
 		return [new HarmonyLinkingError(errorMessage)];
 	}
 

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -107,9 +107,9 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		// We are sure that it's not provided
 		const idIsNotNameMessage =
 			this._id !== this.name ? ` (imported as '${this.name}')` : "";
-		const errorMessage = `"export '${
+		const errorMessage = `Export '${
 			this._id
-		}'"${idIsNotNameMessage} was not found in '${this.userRequest}'`;
+		}'${idIsNotNameMessage} was not found in '${this.userRequest}'`;
 		return [new HarmonyLinkingError(errorMessage)];
 	}
 


### PR DESCRIPTION
There was a double-quote missing in one of the error messages. Now it's there. Yay.