### PR TITLE
Add 'events' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "chrome-trace-event": "^1.0.0",
     "enhanced-resolve": "^4.1.0",
     "eslint-scope": "^4.0.0",
+    "events": "^3.0.0",
     "json-parse-better-errors": "^1.0.2",
     "json-stable-stringify": "^1.0.1",
     "loader-runner": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2122,6 +2122,11 @@ event-emitter@^0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
+events@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
+  integrity sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==
+
 exec-sh@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"


### PR DESCRIPTION
`webpack/hot/emitter.js` requires `events`.
This package used to be polyfilled automatically.
Now it requires the dependency to be manually installed.

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

nothing