### PR TITLE
Allow top-level return in script parsing, PR for #8509

### DIFF
--- a/lib/JavascriptParser.js
+++ b/lib/JavascriptParser.js
@@ -2198,6 +2198,8 @@ class JavascriptParser {
 
 		if (type === "auto") {
 			parserOptions.sourceType = "module";
+		} else if (parserOptions.sourceType === "script") {
+			parserOptions.allowReturnOutsideFunction = true;
 		}
 
 		let ast;
@@ -2212,6 +2214,7 @@ class JavascriptParser {
 
 		if (threw && type === "auto") {
 			parserOptions.sourceType = "script";
+			parserOptions.allowReturnOutsideFunction = true;
 			if (Array.isArray(parserOptions.onComment)) {
 				parserOptions.onComment.length = 0;
 			}

--- a/test/fixtures/b.js
+++ b/test/fixtures/b.js
@@ -1,3 +1,6 @@
 module.exports = function b() {
 	return "This is b";
 };
+
+// Test CJS top-level return
+return;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Adds the `allowReturnOutsideFunction` acorn flag when parsing scripts, as this is supported in ComonJS semantics.

Fixes https://github.com/webpack/webpack/issues/8509.
<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

A test case is included, but I'm open to suggestions to changing it to be more directly tested instead of placing it in an existing fixture.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Nothing, it is a bug fix to align with CJS semantics.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
