### PR TITLE
Optimize getHashNumber

### DIFF
--- a/lib/ids/IdHelpers.js
+++ b/lib/ids/IdHelpers.js
@@ -45,7 +45,7 @@ const getHashNumber = (str, len) => {
 		}
 	}
 
-	return len > 0 ? (result * 10 + 1) * Math.pow(10, len - 1) : result;
+	return (result * 10 + 1) * Math.pow(10, len - 1);
 };
 
 /**

--- a/lib/ids/IdHelpers.js
+++ b/lib/ids/IdHelpers.js
@@ -33,16 +33,19 @@ const getHashNumber = (str, len) => {
 	const hash = createHash("md4");
 	hash.update(str);
 	const digest = hash.digest("hex");
-	let i = 0;
-	let result = "";
-	while (i < digest.length && result.length < len) {
-		if (digest.charCodeAt(i) < 58) {
-			result += digest[i];
+	let result = 0;
+	for (let i = 0; i < digest.length; i++) {
+		const charCode = digest.charCodeAt(i);
+		if (charCode < 58) {
+			result = result * 10 + (charCode - 48);
+			len--;
+			if (len < 1) {
+				return result;
+			}
 		}
-		i++;
 	}
 
-	return +(result + "10000000000".slice(0, len - result.length));
+	return len > 0 ? (result * 10 + 1) * Math.pow(10, len - 1) : result;
 };
 
 /**

--- a/lib/ids/IdHelpers.js
+++ b/lib/ids/IdHelpers.js
@@ -32,14 +32,17 @@ const getHash = (str, len) => {
 const getHashNumber = (str, len) => {
 	const hash = createHash("md4");
 	hash.update(str);
-	const digest = hash.digest("hex") + "10000000000";
-	if (len === 1) {
-		return +digest.match(/\d/)[0];
+	const digest = hash.digest("hex");
+	let i = 0;
+	let result = "";
+	while (i < digest.length && result.length < len) {
+		if (digest.charCodeAt(i) < 58) {
+			result += digest[i];
+		}
+		i++;
 	}
-	return +digest
-		.match(/\d/g)
-		.slice(0, len)
-		.join("");
+
+	return +(result + "10000000000".slice(0, len - result.length));
 };
 
 /**


### PR DESCRIPTION
I just optimized code which gets digits. `match` with `regexp + join` is not fast solution. I rewrote it without using RegExp and temporary arrays.
I tested speed of changed part of function https://jsperf.com/webpack-gethashnumber
<img width="441" alt="webpack-gethashnumber jsperf 2018-12-18 04-45-50" src="https://user-images.githubusercontent.com/4091305/50127233-6761a500-0281-11e9-9d79-6a0b9b44ef88.png">
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Refactoring
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
