### PR TITLE
Change signature of externals function to an object

### DIFF
--- a/lib/ExternalModuleFactoryPlugin.js
+++ b/lib/ExternalModuleFactoryPlugin.js
@@ -21,29 +21,44 @@ class ExternalModuleFactoryPlugin {
 				const context = data.context;
 				const dependency = data.dependencies[0];
 
+				/**
+				 * @param {string|boolean} value the external config
+				 * @param {string|undefined} type type of external
+				 * @param {function(Error=, ExternalModule=): void} callback callback
+				 * @returns {void}
+				 */
 				const handleExternal = (value, type, callback) => {
-					if (typeof type === "function") {
-						callback = type;
-						type = undefined;
+					if (value === false) {
+						// Not externals, fallback to original factory
+						return factory(data, callback);
 					}
-					if (value === false) return factory(data, callback);
-					if (value === true) value = dependency.request;
-					if (type === undefined && /^[a-z0-9]+ /.test(value)) {
-						const idx = value.indexOf(" ");
-						type = value.substr(0, idx);
-						value = value.substr(idx + 1);
+					/** @type {string} */
+					let externalConfig;
+					if (value === true) {
+						externalConfig = dependency.request;
+					} else {
+						externalConfig = value;
+					}
+					// When no explicit type is specified, extract it from the externalConfig
+					if (type === undefined && /^[a-z0-9]+ /.test(externalConfig)) {
+						const idx = externalConfig.indexOf(" ");
+						type = externalConfig.substr(0, idx);
+						externalConfig = externalConfig.substr(idx + 1);
 					}
 					callback(
 						null,
-						new ExternalModule(value, type || globalType, dependency.request)
+						new ExternalModule(
+							externalConfig,
+							type || globalType,
+							dependency.request
+						)
 					);
-					return true;
 				};
 
 				const handleExternals = (externals, callback) => {
 					if (typeof externals === "string") {
 						if (externals === dependency.request) {
-							return handleExternal(dependency.request, callback);
+							return handleExternal(dependency.request, undefined, callback);
 						}
 					} else if (Array.isArray(externals)) {
 						let i = 0;
@@ -73,35 +88,47 @@ class ExternalModuleFactoryPlugin {
 						return;
 					} else if (externals instanceof RegExp) {
 						if (externals.test(dependency.request)) {
-							return handleExternal(dependency.request, callback);
+							return handleExternal(dependency.request, undefined, callback);
 						}
 					} else if (typeof externals === "function") {
-						externals.call(
-							null,
-							context,
-							dependency.request,
-							(err, value, type) => {
-								if (err) return callback(err);
-								if (value !== undefined) {
-									handleExternal(value, type, callback);
-								} else {
-									callback();
-								}
+						const cb = (err, value, type) => {
+							if (err) return callback(err);
+							if (value !== undefined) {
+								handleExternal(value, type, callback);
+							} else {
+								callback();
 							}
-						);
+						};
+						if (externals.length === 3) {
+							// TODO webpack 5 insert deprecation message here
+							// TODO webpack 6 remove this
+							externals.call(null, context, dependency.request, cb);
+						} else {
+							externals(
+								{
+									context,
+									request: dependency.request
+								},
+								cb
+							);
+						}
 						return;
 					} else if (
 						typeof externals === "object" &&
 						Object.prototype.hasOwnProperty.call(externals, dependency.request)
 					) {
-						return handleExternal(externals[dependency.request], callback);
+						return handleExternal(
+							externals[dependency.request],
+							undefined,
+							callback
+						);
 					}
 					callback();
 				};
 
 				handleExternals(this.externals, (err, module) => {
 					if (err) return callback(err);
-					if (!module) return handleExternal(false, callback);
+					if (!module) return handleExternal(false, undefined, callback);
 					return callback(null, module);
 				});
 			}


### PR DESCRIPTION
to be more extensible in future

#8527

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
refactor
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes, externals function signature changed
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
passing a function to `externals` has now this signature:
`({ context, request }, callback)`
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
