### PR TITLE
Factory method for require dependency in AMDRequireDependenciesBlock

### DIFF
--- a/lib/dependencies/AMDRequireDependenciesBlock.js
+++ b/lib/dependencies/AMDRequireDependenciesBlock.js
@@ -36,8 +36,12 @@ module.exports = class AMDRequireDependenciesBlock extends AsyncDependenciesBloc
 		} else {
 			this.range = expr.range;
 		}
-		const dep = new AMDRequireDependency(this);
+		const dep = this.newRequireDependency();
 		dep.loc = loc;
 		this.addDependency(dep);
+	}
+
+	newRequireDependency() {
+		return new AMDRequireDependency(this);
 	}
 };

--- a/lib/dependencies/AMDRequireDependency.js
+++ b/lib/dependencies/AMDRequireDependency.js
@@ -13,17 +13,6 @@ class AMDRequireDependency extends NullDependency {
 }
 
 AMDRequireDependency.Template = class AMDRequireDependencyTemplate {
-	get definitions() {
-		return {
-			a: "var __WEBPACK_AMD_REQUIRE_ARRAY__ = ",
-			af: "; (",
-			f: ").apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__);",
-			ea: "var __WEBPACK_AMD_REQUIRE_ARRAY__ = ",
-			eaf: "; (",
-			ef: ").apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__);"
-		};
-	}
-
 	apply(dep, source, runtime) {
 		const depBlock = dep.block;
 		const promise = runtime.blockPromise({
@@ -84,13 +73,19 @@ AMDRequireDependency.Template = class AMDRequireDependencyTemplate {
 				depBlock.arrayRange[0] - 1,
 				startBlock
 			);
-			source.insert(depBlock.arrayRange[0] + 0.9, this.definitions.ea);
+			source.insert(
+				depBlock.arrayRange[0] + 0.9,
+				"var __WEBPACK_AMD_REQUIRE_ARRAY__ = "
+			);
 			source.replace(
 				depBlock.arrayRange[1],
 				depBlock.functionRange[0] - 1,
-				this.definitions.eaf
+				"; ("
 			);
-			source.insert(depBlock.functionRange[1], this.definitions.ef);
+			source.insert(
+				depBlock.functionRange[1],
+				").apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__);"
+			);
 			source.replace(
 				depBlock.functionRange[1],
 				depBlock.errorCallbackRange[0] - 1,
@@ -115,13 +110,19 @@ AMDRequireDependency.Template = class AMDRequireDependencyTemplate {
 				depBlock.arrayRange[0] - 1,
 				startBlock
 			);
-			source.insert(depBlock.arrayRange[0] + 0.9, this.definitions.a);
+			source.insert(
+				depBlock.arrayRange[0] + 0.9,
+				"var __WEBPACK_AMD_REQUIRE_ARRAY__ = "
+			);
 			source.replace(
 				depBlock.arrayRange[1],
 				depBlock.functionRange[0] - 1,
-				this.definitions.af
+				"; ("
 			);
-			source.insert(depBlock.functionRange[1], this.definitions.f);
+			source.insert(
+				depBlock.functionRange[1],
+				").apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__);"
+			);
 			source.replace(
 				depBlock.functionRange[1],
 				depBlock.outerRange[1] - 1,

--- a/lib/dependencies/AMDRequireDependency.js
+++ b/lib/dependencies/AMDRequireDependency.js
@@ -13,6 +13,17 @@ class AMDRequireDependency extends NullDependency {
 }
 
 AMDRequireDependency.Template = class AMDRequireDependencyTemplate {
+	get definitions() {
+		return {
+			a: "var __WEBPACK_AMD_REQUIRE_ARRAY__ = ",
+			af: "; (",
+			f: ").apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__);",
+			ea: "var __WEBPACK_AMD_REQUIRE_ARRAY__ = ",
+			eaf: "; (",
+			ef: ").apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__);"
+		};
+	}
+
 	apply(dep, source, runtime) {
 		const depBlock = dep.block;
 		const promise = runtime.blockPromise({
@@ -73,19 +84,13 @@ AMDRequireDependency.Template = class AMDRequireDependencyTemplate {
 				depBlock.arrayRange[0] - 1,
 				startBlock
 			);
-			source.insert(
-				depBlock.arrayRange[0] + 0.9,
-				"var __WEBPACK_AMD_REQUIRE_ARRAY__ = "
-			);
+			source.insert(depBlock.arrayRange[0] + 0.9, this.definitions.ea);
 			source.replace(
 				depBlock.arrayRange[1],
 				depBlock.functionRange[0] - 1,
-				"; ("
+				this.definitions.eaf
 			);
-			source.insert(
-				depBlock.functionRange[1],
-				").apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__);"
-			);
+			source.insert(depBlock.functionRange[1], this.definitions.ef);
 			source.replace(
 				depBlock.functionRange[1],
 				depBlock.errorCallbackRange[0] - 1,
@@ -110,19 +115,13 @@ AMDRequireDependency.Template = class AMDRequireDependencyTemplate {
 				depBlock.arrayRange[0] - 1,
 				startBlock
 			);
-			source.insert(
-				depBlock.arrayRange[0] + 0.9,
-				"var __WEBPACK_AMD_REQUIRE_ARRAY__ = "
-			);
+			source.insert(depBlock.arrayRange[0] + 0.9, this.definitions.a);
 			source.replace(
 				depBlock.arrayRange[1],
 				depBlock.functionRange[0] - 1,
-				"; ("
+				this.definitions.af
 			);
-			source.insert(
-				depBlock.functionRange[1],
-				").apply(null, __WEBPACK_AMD_REQUIRE_ARRAY__);"
-			);
+			source.insert(depBlock.functionRange[1], this.definitions.f);
 			source.replace(
 				depBlock.functionRange[1],
 				depBlock.outerRange[1] - 1,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This is a modified re-submission of #8501 which was rejected because of concerns about the code being too tightly coupled with webpack internals.  This submission contains only the change to add the factory method to AMDRequireDependenciesBlock.js.  This change is consistent with existing patterns, including:

*  https://github.com/webpack/webpack/blob/master/lib/dependencies/AMDDefineDependencyParserPlugin.js#L329
*  https://github.com/webpack/webpack/blob/master/lib/dependencies/AMDDefineDependencyParserPlugin.js#L332
*  https://github.com/webpack/webpack/blob/master/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js#L267
*  https://github.com/webpack/webpack/blob/master/lib/dependencies/AMDRequireDependenciesBlockParserPlugin.js#L270

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Refactoring in support of code reuse and extensibility
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No, not needed.  No functional changes.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
N/A
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
N/A