### PR TITLE
Allow MultiStats to be called with no options

### DIFF
--- a/lib/MultiStats.js
+++ b/lib/MultiStats.js
@@ -38,6 +38,9 @@ class MultiStats {
 	}
 
 	_createChildOptions(options, context) {
+		if (!options) {
+			options = {};
+		}
 		const { children: _, ...baseOptions } = options;
 		const children = this.stats.map((stat, idx) => {
 			const childOptions = Array.isArray(options.children)

--- a/test/MultiStats.test.js
+++ b/test/MultiStats.test.js
@@ -1,0 +1,31 @@
+/*globals describe it */
+"use strict";
+
+const webpack = require("..");
+const MemoryFs = require("memory-fs");
+
+describe("MultiStats", () => {
+	it("should create JSON of children stats", done => {
+		const compiler = webpack([{
+			context: __dirname,
+			entry: "./fixtures/a"
+		},{
+			context: __dirname,
+			entry: "./fixtures/b"
+		}]);
+		compiler.outputFileSystem = new MemoryFs();
+		compiler.run((err, stats) => {
+			if (err) return done(err);
+			try {
+				const statsObject = stats.toJson();
+				expect(
+					statsObject
+				).toEqual(expect.objectContaining({children: expect.any(Array)}));
+				expect(statsObject.children).toHaveLength(2);
+				done();
+			} catch (e) {
+				done(e);
+			}
+		});
+	});
+});


### PR DESCRIPTION
While attempting to upgrade a plugin to support v5 tests started failing, due to [a test that called toJson on stats returned from a multi-target build](https://github.com/jahredhope/html-render-webpack-plugin/blob/master/tests/test-cases/webpack-stats/src/render.js#L2).

This issue is only available in the alpha branch so I haven't raised an issue. See comment in v5 alpha branch feedback.
Issue: https://github.com/webpack/webpack/issues/8537#issuecomment-450118762

This change will allow consumers to call toJson and toString safely without any additional options. There is no change when options are passed in.

**What kind of change does this PR introduce?**

This is a bug fix to address an unreleased regression. Related change: https://github.com/webpack/webpack/commit/123b0a64e78d154e4c326c845239136e1129c7aa.

**Did you add tests for your changes?**

Yes.

**Does this PR introduce a breaking change?**

No. Not a breaking change.

**What needs to be documented once your changes are merged?**

No documentation changes.