### PR TITLE
Fixed error in Profiling Plugin, if given folder path doesn't exist.

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 const { Tracer } = require("chrome-trace-event");
 const validateOptions = require("schema-utils");
 const schema = require("../../schemas/plugins/debug/ProfilingPlugin.json");
@@ -86,13 +87,18 @@ class Profiler {
 
 /**
  * @param {string} outputPath The location where to write the log.
+ * @param {Object} compiler Current compiler Instance
  * @returns {Trace} The trace object
  */
-const createTrace = outputPath => {
+const createTrace = (outputPath, compiler) => {
 	const trace = new Tracer({
 		noStream: true
 	});
 	const profiler = new Profiler(inspector);
+	if (outputPath.match(/\/|\\/)) {
+		const dir = path.dirname(outputPath);
+		compiler.outputFileSystem.mkdirp(dir);
+	}
 	const fsStream = fs.createWriteStream(outputPath);
 
 	let counter = 0;
@@ -158,7 +164,7 @@ class ProfilingPlugin {
 	}
 
 	apply(compiler) {
-		const tracer = createTrace(this.outputPath);
+		const tracer = createTrace(this.outputPath, compiler);
 		tracer.profiler.startProfiling();
 
 		// Compiler Hooks

--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const mkdirp = require("mkdirp");
 const { Tracer } = require("chrome-trace-event");
 const validateOptions = require("schema-utils");
 const schema = require("../../schemas/plugins/debug/ProfilingPlugin.json");
@@ -87,17 +88,16 @@ class Profiler {
 
 /**
  * @param {string} outputPath The location where to write the log.
- * @param {Object} compiler Current compiler Instance
  * @returns {Trace} The trace object
  */
-const createTrace = (outputPath, compiler) => {
+const createTrace = outputPath => {
 	const trace = new Tracer({
 		noStream: true
 	});
 	const profiler = new Profiler(inspector);
-	if (outputPath.match(/\/|\\/)) {
-		const dir = path.dirname(outputPath);
-		compiler.outputFileSystem.mkdirp(dir);
+	if (/\/|\\/.test(outputPath)) {
+		const dirPath = path.dirname(outputPath);
+		mkdirp.sync(dirPath);
 	}
 	const fsStream = fs.createWriteStream(outputPath);
 
@@ -164,7 +164,7 @@ class ProfilingPlugin {
 	}
 
 	apply(compiler) {
-		const tracer = createTrace(this.outputPath, compiler);
+		const tracer = createTrace(this.outputPath);
 		tracer.profiler.startProfiling();
 
 		// Compiler Hooks

--- a/test/ProfilingPlugin.test.js
+++ b/test/ProfilingPlugin.test.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const path = require("path");
+const fs = require("fs");
+const webpack = require("../");
+const rimraf = require("rimraf");
+
+describe("Profiling Plugin", function() {
+	it("should handle output path with folder creation", done => {
+		const finalPath = "test/js/profilingPath/events.json";
+		const outputPath = path.join(__dirname, "/js/profilingPath");
+		rimraf(outputPath, () => {
+			const compiler = webpack({
+				context: "/",
+				entry: "./fixtures/a.js",
+				plugins: [
+					new webpack.debug.ProfilingPlugin({
+						outputPath: finalPath
+					})
+				]
+			});
+			compiler.run(err => {
+				if (err) return done(err);
+				if (!fs.existsSync(outputPath))
+					return done(new Error("Folder should be created."));
+				done();
+			});
+		});
+	});
+});

--- a/test/ProfilingPlugin.unittest.js
+++ b/test/ProfilingPlugin.unittest.js
@@ -1,9 +1,6 @@
 "use strict";
 
 const ProfilingPlugin = require("../lib/debug/ProfilingPlugin");
-const path = require("path");
-const fs = require("fs");
-const webpack = require("../");
 
 describe("Profiling Plugin", () => {
 	it("should persist the passed outpath", () => {
@@ -16,26 +13,6 @@ describe("Profiling Plugin", () => {
 	it("should handle no options", () => {
 		const plugin = new ProfilingPlugin();
 		expect(plugin.outputPath).toBe("events.json");
-	});
-
-	it("should handle outpath with folder", done => {
-		const finalPath = "test/fixtures/profilingPath/events.json";
-		const compiler = webpack({
-			context: "/",
-			entry: "./fixtures/a.js",
-			plugins: [
-				new webpack.debug.ProfilingPlugin({
-					outputPath: finalPath
-				})
-			]
-		});
-		const outputPath = path.join(__dirname, "/fixtures/profilingPath");
-		compiler.run(err => {
-			if (err) return done(err);
-			if (!fs.existsSync(outputPath))
-				return done(new Error("Folder should be created."));
-			done();
-		});
 	});
 
 	it("should handle when unable to require the inspector", () => {

--- a/test/ProfilingPlugin.unittest.js
+++ b/test/ProfilingPlugin.unittest.js
@@ -1,6 +1,9 @@
 "use strict";
 
 const ProfilingPlugin = require("../lib/debug/ProfilingPlugin");
+const path = require("path");
+const fs = require("fs");
+const webpack = require("../");
 
 describe("Profiling Plugin", () => {
 	it("should persist the passed outpath", () => {
@@ -13,6 +16,26 @@ describe("Profiling Plugin", () => {
 	it("should handle no options", () => {
 		const plugin = new ProfilingPlugin();
 		expect(plugin.outputPath).toBe("events.json");
+	});
+
+	it("should handle outpath with folder", done => {
+		const finalPath = "test/fixtures/profilingPath/events.json";
+		const compiler = webpack({
+			context: "/",
+			entry: "./fixtures/a.js",
+			plugins: [
+				new webpack.debug.ProfilingPlugin({
+					outputPath: finalPath
+				})
+			]
+		});
+		const outputPath = path.join(__dirname, "/fixtures/profilingPath");
+		compiler.run(err => {
+			if (err) return done(err);
+			if (!fs.existsSync(outputPath))
+				return done(new Error("Folder should be created."));
+			done();
+		});
 	});
 
 	it("should handle when unable to require the inspector", () => {


### PR DESCRIPTION

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This is a fix for the below issue. Profiling plugin will create a folder based on the output path, if it doesn't exists.

https://github.com/webpack/webpack/issues/8503


**What kind of change does this PR introduce?**

 bugfix

**Did you add tests for your changes?**

Yes, i have added a test for checking if folder is getting created in the provided path.

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

No documentation needed.
