### PR TITLE
Use fullhash instead of hash in tests

### DIFF
--- a/test/HotTestCases.template.js
+++ b/test/HotTestCases.template.js
@@ -60,7 +60,7 @@ const describeCases = config => {
 								if (!options.output.filename)
 									options.output.filename = "bundle.js";
 								if (!options.output.chunkFilename)
-									options.output.chunkFilename = "[name].chunk.[hash].js";
+									options.output.chunkFilename = "[name].chunk.[fullhash].js";
 								if (options.output.pathinfo === undefined)
 									options.output.pathinfo = true;
 								if (!options.optimization) options.optimization = {};

--- a/test/NodeTemplatePlugin.test.js
+++ b/test/NodeTemplatePlugin.test.js
@@ -15,7 +15,7 @@ describe("NodeTemplatePlugin", () => {
 				output: {
 					path: path.join(__dirname, "js", "NodeTemplatePlugin"),
 					filename: "result.js",
-					chunkFilename: "[hash].result.[id].js",
+					chunkFilename: "[fullhash].result.[id].js",
 					library: "abc",
 					libraryTarget: "commonjs"
 				},
@@ -51,7 +51,7 @@ describe("NodeTemplatePlugin", () => {
 				output: {
 					path: path.join(__dirname, "js", "NodeTemplatePluginSingle"),
 					filename: "result2.js",
-					chunkFilename: "[hash].result2.[id].js",
+					chunkFilename: "[fullhash].result2.[id].js",
 					library: "def",
 					libraryTarget: "umd",
 					auxiliaryComment: "test"

--- a/test/configCases/hash-length/output-filename/webpack.config.js
+++ b/test/configCases/hash-length/output-filename/webpack.config.js
@@ -3,9 +3,9 @@ module.exports = [
 	{
 		name: "hash with length in publicPath",
 		output: {
-			publicPath: "/[hash:6]/",
-			filename: "bundle0.[hash:6].js",
-			chunkFilename: "[id].bundle0.[hash:6].js"
+			publicPath: "/[fullhash:6]/",
+			filename: "bundle0.[fullhash:6].js",
+			chunkFilename: "[id].bundle0.[fullhash:6].js"
 		},
 		amd: {
 			expectedFilenameLength: 17,
@@ -15,9 +15,9 @@ module.exports = [
 	{
 		name: "hash in publicPath",
 		output: {
-			publicPath: "/[hash]/",
-			filename: "bundle1.[hash].js",
-			chunkFilename: "[id].bundle1.[hash].js"
+			publicPath: "/[fullhash]/",
+			filename: "bundle1.[fullhash].js",
+			chunkFilename: "[id].bundle1.[fullhash].js"
 		},
 		amd: {
 			expectedFilenameLength: 31,
@@ -49,8 +49,8 @@ module.exports = [
 	{
 		name: "hash with and without length",
 		output: {
-			filename: "bundle4.[hash].js",
-			chunkFilename: "[id].bundle4.[hash:8].js"
+			filename: "bundle4.[fullhash].js",
+			chunkFilename: "[id].bundle4.[fullhash:8].js"
 		},
 		amd: {
 			expectedFilenameLength: 31,
@@ -60,8 +60,8 @@ module.exports = [
 	{
 		name: "hash with length",
 		output: {
-			filename: "bundle5.[hash:6].js",
-			chunkFilename: "[id].bundle5.[hash:8].js"
+			filename: "bundle5.[fullhash:6].js",
+			chunkFilename: "[id].bundle5.[fullhash:8].js"
 		},
 		amd: {
 			expectedFilenameLength: 17,
@@ -71,7 +71,7 @@ module.exports = [
 	{
 		name: "chunkhash in chunkFilename ",
 		output: {
-			filename: "bundle6.[hash].js",
+			filename: "bundle6.[fullhash].js",
 			chunkFilename: "[id].bundle6.[chunkhash:7].js"
 		},
 		amd: {
@@ -83,7 +83,7 @@ module.exports = [
 	{
 		name: "hash with length and chunkhash with length",
 		output: {
-			filename: "bundle7.[hash:7].js",
+			filename: "bundle7.[fullhash:7].js",
 			chunkFilename: "[id].bundle7.[chunkhash:7].js"
 		},
 		target: "node",
@@ -95,8 +95,8 @@ module.exports = [
 	{
 		name: "hash with length in chunkFilename",
 		output: {
-			filename: "bundle8.[hash].js",
-			chunkFilename: "[id].bundle8.[hash:7].js"
+			filename: "bundle8.[fullhash].js",
+			chunkFilename: "[id].bundle8.[fullhash:7].js"
 		},
 		target: "node",
 		amd: {
@@ -107,7 +107,7 @@ module.exports = [
 	{
 		name: "chunkhash with length in chunkFilename",
 		output: {
-			filename: "bundle9.[hash].js",
+			filename: "bundle9.[fullhash].js",
 			chunkFilename: "[id].bundle9.[chunkhash:7].js"
 		},
 		target: "node",

--- a/test/configCases/issues/issue-7563/webpack.config.js
+++ b/test/configCases/issues/issue-7563/webpack.config.js
@@ -1,9 +1,8 @@
 "use strict";
 
-// Have to test [hash] and [chunkhash] separately to avoid
-// "Cannot use [chunkhash] or [contenthash] for chunk in 'bundle1.[hash].[hash:16].[chunkhash].[chunkhash:16].[name].[id].[query].js' (use [hash] instead)"
-var testAllButHash = "[chunkhash].[chunkhash:16].[name].[id].[query]";
-var testHash = "[hash].[hash:16]";
+// [fullhash] and [chunkhash] must be used separately
+const testAllButHash = "[chunkhash].[chunkhash:16].[name].[id].[query]";
+const testHash = "[fullhash].[fullhash:16]";
 
 module.exports = [
 	{

--- a/test/configCases/plugins/banner-plugin-hashing/index.js
+++ b/test/configCases/plugins/banner-plugin-hashing/index.js
@@ -18,7 +18,7 @@ const banner = parseBanner(source)
 const REGEXP_HASH = /^[A-Za-z0-9]{20}$/
 
 it("should interpolate file hash in chunk banner", () => {
-	expect(REGEXP_HASH.test(banner["hash"])).toBe(true);
+	expect(REGEXP_HASH.test(banner["fullhash"])).toBe(true);
 });
 
 it("should interpolate chunkHash in chunk banner", () => {

--- a/test/configCases/plugins/banner-plugin-hashing/webpack.config.js
+++ b/test/configCases/plugins/banner-plugin-hashing/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
 	plugins: [
 		new webpack.BannerPlugin({
 			banner:
-				"hash:[hash], chunkhash:[chunkhash], name:[name], base:[base], query:[query], file:[file], path:[path], ext:[ext]"
+				"fullhash:[fullhash], chunkhash:[chunkhash], name:[name], base:[base], query:[query], file:[file], path:[path], ext:[ext]"
 		})
 	]
 };

--- a/test/configCases/plugins/lib-manifest-plugin/webpack.config.js
+++ b/test/configCases/plugins/lib-manifest-plugin/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
 				__dirname,
 				"../../../js/config/plugins/lib-manifest-plugin/[name]-manifest.json"
 			),
-			name: "[name]_[hash]"
+			name: "[name]_[fullhash]"
 		})
 	],
 	node: {

--- a/test/hotPlayground/webpack.config.js
+++ b/test/hotPlayground/webpack.config.js
@@ -3,7 +3,7 @@ module.exports = {
 	entry: ["../../hot/dev-server", "./index.js"],
 	output: {
 		filename: "bundle.js",
-		hotUpdateChunkFilename: "[id].[hash].bundle-update.js",
+		hotUpdateChunkFilename: "[id].[fullhash].bundle-update.js",
 		hashDigestLength: 4
 	},
 	plugins: [new webpack.HotModuleReplacementPlugin()],


### PR DESCRIPTION
Some tests were using `hash` instead of `fullhash`.

**What kind of change does this PR introduce?**

remove some deprecation notices from the tests

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

nothing