### PR TITLE
fix when minimizer is fn

### DIFF
--- a/test/configCases/optimization/minimizer/index.js
+++ b/test/configCases/optimization/minimizer/index.js
@@ -1,0 +1,1 @@
+it("should compile", () => {})

--- a/test/configCases/optimization/minimizer/webpack.config.js
+++ b/test/configCases/optimization/minimizer/webpack.config.js
@@ -1,0 +1,18 @@
+const Compiler = require('../../../../lib/Compiler');
+
+module.exports = {
+	optimization: {
+		minimize: true,
+		minimizer: [
+			{
+				apply(compiler) {
+					expect(compiler).toBeInstanceOf(Compiler);
+				},
+			},
+			function(compiler) {
+				expect(compiler).toBe(this);
+				expect(compiler).toBeInstanceOf(Compiler);
+			}
+		],
+	},
+};


### PR DESCRIPTION
As discussed offline with @sokra, this is a fix for when you provide a function entry for `optimization.minimizer` config.

**What kind of change does this PR introduce?**

bugfix (related: https://github.com/webpack/webpack/pull/8405)

**Did you add tests for your changes?**

No, should i?

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Done: https://github.com/webpack/webpack.js.org/pull/2743