### PR TITLE
fix stats assetsByChunkName

### DIFF
--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -186,7 +186,9 @@ const SIMPLE_EXTRACTORS = {
 			object.assetsByChunkName = {};
 			for (const asset of object.assets) {
 				for (const name of asset.chunkNames) {
-					object.assetsByChunkName[name] = asset;
+					object.assetsByChunkName[name] = (
+						object.assetsByChunkName[name] || []
+					).concat(asset.name);
 				}
 			}
 		},

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -157,5 +157,70 @@ Object {
 }
 `);
 		});
+		it("should contain assets", async () => {
+			const stats = await compile({
+				context: __dirname,
+				entry: {
+					entryA: "./fixtures/a",
+					entryB: "./fixtures/chunk-b"
+				}
+			});
+			expect(
+				stats.toJson({
+					all: false,
+					assets: true
+				})
+			).toMatchInlineSnapshot(`
+Object {
+  "assets": Array [
+    Object {
+      "chunkNames": Array [
+        "chunkB",
+      ],
+      "chunks": Array [
+        787,
+      ],
+      "emitted": true,
+      "name": "chunkB.js",
+      "size": 119,
+    },
+    Object {
+      "chunkNames": Array [
+        "entryA",
+      ],
+      "chunks": Array [
+        827,
+      ],
+      "emitted": true,
+      "name": "entryA.js",
+      "size": 239,
+    },
+    Object {
+      "chunkNames": Array [
+        "entryB",
+      ],
+      "chunks": Array [
+        886,
+      ],
+      "emitted": true,
+      "name": "entryB.js",
+      "size": 2017,
+    },
+  ],
+  "assetsByChunkName": Object {
+    "chunkB": Array [
+      "chunkB.js",
+    ],
+    "entryA": Array [
+      "entryA.js",
+    ],
+    "entryB": Array [
+      "entryB.js",
+    ],
+  },
+  "filteredAssets": 0,
+}
+`);
+		});
 	});
 });


### PR DESCRIPTION
It's now always an array

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes, compared to the last alpha
it reverts a breaking change and is now mostly compatiblity to v4
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
`stats.assetsByChunkName[x]` is now always an array
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
