### PR TITLE
[WIP] Feature: support universal target

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -397,7 +397,8 @@ export interface WebpackOptions {
 				| "async-node"
 				| "node-webkit"
 				| "electron-main"
-				| "electron-renderer")
+				| "electron-renderer"
+				| "universal")
 		| ((compiler: import("../lib/Compiler")) => void);
 	/**
 	 * Enter watch mode, which rebuilds on file change.

--- a/lib/RuntimeGlobals.js
+++ b/lib/RuntimeGlobals.js
@@ -174,3 +174,8 @@ exports.amdOptions = "__webpack_require__.amdO";
  * the System polyfill object
  */
 exports.system = "__webpack_require__.System";
+
+/**
+ * the runtime environment. used in universal ocassion
+ */
+exports.environment = "__webpack_require__.env";

--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -10,6 +10,7 @@ const CompatGetDefaultExportRuntimeModule = require("./runtime/CompatGetDefaultE
 const CreateFakeNamespaceObjectRuntimeModule = require("./runtime/CreateFakeNamespaceObjectRuntimeModule");
 const DefinePropertyGetterRuntimeModule = require("./runtime/DefinePropertyGetterRuntimeModule");
 const EnsureChunkRuntimeModule = require("./runtime/EnsureChunkRuntimeModule");
+const EnvironmentRuntimeModule = require("./runtime/EnvironmentRuntimeModule");
 const GetChunkFilenameRuntimeModule = require("./runtime/GetChunkFilenameRuntimeModule");
 const GetMainFilenameRuntimeModule = require("./runtime/GetMainFilenameRuntimeModule");
 const GlobalRuntimeModule = require("./runtime/GlobalRuntimeModule");
@@ -196,6 +197,19 @@ class RuntimePlugin {
 				.for(RuntimeGlobals.ensureChunkIncludeEntries)
 				.tap("RuntimePlugin", (chunk, set) => {
 					set.add(RuntimeGlobals.ensureChunkHandlers);
+				});
+			compilation.hooks.runtimeRequirementInTree
+				.for(RuntimeGlobals.environment)
+				.tap("RuntimePlugin", (chunk, set) => {
+					set.add(RuntimeGlobals.environment);
+					compilation.addRuntimeModule(
+						chunk,
+						new EnvironmentRuntimeModule(
+							compilation,
+							RuntimeGlobals.environment
+						)
+					);
+					return true;
 				});
 		});
 	}

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -144,6 +144,24 @@ class WebpackOptionsApply extends OptionsApply {
 					new StartupChunkDependenciesPlugin().apply(compiler);
 					break;
 				}
+				case "universal": {
+					const UniversalTemplatePlugin = require("./universal/UniversalTemplatePlugin");
+					const JsonpTemplatePlugin = require("./web/JsonpTemplatePlugin");
+					const WebWorkerTemplatePlugin = require("./webworker/WebWorkerTemplatePlugin");
+					const NodeTemplatePlugin = require("./node/NodeTemplatePlugin");
+					const NodeSourcePlugin = require("./node/NodeSourcePlugin");
+					const StartupChunkDependenciesPlugin = require("./runtime/StartupChunkDependenciesPlugin");
+					new UniversalTemplatePlugin().apply(compiler);
+					new JsonpTemplatePlugin().apply(compiler);
+					new WebWorkerTemplatePlugin().apply(compiler);
+					new NodeTemplatePlugin().apply(compiler);
+					// TODO Wasm ?
+					new FunctionModulePlugin().apply(compiler);
+					new NodeSourcePlugin(options.node).apply(compiler);
+					new LoaderTargetPlugin(options.target).apply(compiler);
+					new StartupChunkDependenciesPlugin().apply(compiler);
+					break;
+				}
 				case "node-webkit": {
 					const JsonpTemplatePlugin = require("./web/JsonpTemplatePlugin");
 					const NodeTargetPlugin = require("./node/NodeTargetPlugin");

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -171,6 +171,8 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 				case "async-node":
 				case "electron-main":
 					return "global";
+				case "universal":
+					return '(typeof self !== "undefined" ? self : typeof global !== "undefined" ? global : this)';
 				default:
 					return "self";
 			}

--- a/lib/node/NodeChunkTemplatePlugin.js
+++ b/lib/node/NodeChunkTemplatePlugin.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-const { ConcatSource } = require("webpack-sources");
+const { ConcatSource, PrefixSource, RawSource } = require("webpack-sources");
 const Template = require("../Template");
 
 /** @typedef {import("../ChunkTemplate")} ChunkTemplate */
@@ -19,9 +19,14 @@ class NodeChunkTemplatePlugin {
 	 * @returns {void}
 	 */
 	apply(chunkTemplate) {
+		const { target } = this.compilation.options;
 		chunkTemplate.hooks.render.tap(
 			"NodeChunkTemplatePlugin",
 			(modules, moduleTemplate, renderContext) => {
+				const previousSource = modules;
+				if (target === "universal") {
+					modules = new RawSource("__universal_modules__");
+				}
 				const { chunk, chunkGraph } = renderContext;
 				const source = new ConcatSource();
 				source.add(`exports.id = ${JSON.stringify(chunk.id)};\n`);
@@ -36,6 +41,15 @@ class NodeChunkTemplatePlugin {
 						Template.renderChunkRuntimeModules(runtimeModules, renderContext)
 					);
 					source.add(";\n");
+				}
+				if (target === "universal") {
+					return new ConcatSource(
+						previousSource,
+						"\n",
+						`if(__universal_env__ === "node") {\n`,
+						new PrefixSource("\t", source),
+						"\n}\n"
+					);
 				}
 				return source;
 			}

--- a/lib/node/RequireChunkLoadingRuntimeModule.js
+++ b/lib/node/RequireChunkLoadingRuntimeModule.js
@@ -13,13 +13,16 @@ class RequireChunkLoadingRuntimeModule extends RuntimeModule {
 		super("require chunk loading", 10);
 		this.chunk = chunk;
 		this.runtimeRequirements = runtimeRequirements;
+		this.shouldCheckEnvironment = runtimeRequirements.has(
+			RuntimeGlobals.environment
+		);
 	}
 
 	/**
 	 * @returns {string} runtime code
 	 */
 	generate() {
-		const { chunk } = this;
+		const { chunk, shouldCheckEnvironment } = this;
 		const fn = RuntimeGlobals.ensureChunkHandlers;
 		const withLoading = this.runtimeRequirements.has(
 			RuntimeGlobals.ensureChunkHandlers
@@ -30,7 +33,7 @@ class RequireChunkLoadingRuntimeModule extends RuntimeModule {
 		const withHmrManifest = this.runtimeRequirements.has(
 			RuntimeGlobals.hmrDownloadManifest
 		);
-		return Template.asString([
+		const runtimeCodeLines = [
 			"// object to store loaded chunks",
 			'// "1" means "loaded", otherwise not loaded yet',
 			"var installedChunks = {",
@@ -165,7 +168,15 @@ class RequireChunkLoadingRuntimeModule extends RuntimeModule {
 						"}"
 				  ])
 				: "// no HMR manifest"
-		]);
+		];
+
+		return shouldCheckEnvironment
+			? Template.asString([
+					`if(${RuntimeGlobals.environment} === "node") {`,
+					Template.indent(runtimeCodeLines),
+					"}"
+			  ])
+			: Template.asString(runtimeCodeLines);
 	}
 }
 

--- a/lib/runtime/EnvironmentRuntimeModule.js
+++ b/lib/runtime/EnvironmentRuntimeModule.js
@@ -1,0 +1,37 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+*/
+
+"use strict";
+
+const RuntimeModule = require("../RuntimeModule");
+const Template = require("../Template");
+
+class EnvironmentRuntimeModule extends RuntimeModule {
+	constructor(compilation, provideName) {
+		super("enviroment");
+		this.compilation = compilation;
+		this.provideName = provideName;
+	}
+
+	/**
+	 * @returns {string} runtime code
+	 */
+	generate() {
+		const { globalObject } = this.compilation.outputOptions;
+		const provideName = this.provideName;
+		return Template.asString([
+			`if (${globalObject}.document !== undefined) {`,
+			Template.indent([`${provideName} = "web";`]),
+			`} else if (typeof ${globalObject}.importScripts === "function") {`,
+			Template.indent([`${provideName} = "webworker";`]),
+			`} else if (${globalObject}.process !== undefined) {`,
+			Template.indent([`${provideName} = "node";`]),
+			"} else {",
+			Template.indent([`${provideName} = "web";`]),
+			"}"
+		]);
+	}
+}
+
+module.exports = EnvironmentRuntimeModule;

--- a/lib/universal/UniversalChunkTemplatePlugin.js
+++ b/lib/universal/UniversalChunkTemplatePlugin.js
@@ -1,0 +1,51 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+*/
+
+"use strict";
+
+const { ConcatSource, PrefixSource } = require("webpack-sources");
+const EnvironmentRuntimeModule = require("../runtime/EnvironmentRuntimeModule");
+
+/** @typedef {import("../Chunk")} Chunk */
+/** @typedef {import("../ChunkTemplate")} ChunkTemplate */
+/** @typedef {import("../Compilation")} Compilation */
+
+class UniversalChunkTemplatePlugin {
+	/**
+	 * @param {Compilation} compilation the compilation
+	 */
+	constructor(compilation) {
+		this.compilation = compilation;
+	}
+
+	/**
+	 * @param {ChunkTemplate} chunkTemplate the chunk template
+	 * @returns {void}
+	 */
+	apply(chunkTemplate) {
+		const runtimeEnvironment = new EnvironmentRuntimeModule(
+			this.compilation,
+			"__universal_env__"
+		).generate();
+		chunkTemplate.hooks.render.tap(
+			"UniversalChunkTemplatePlugin",
+			(modules, moduleTemplate, renderContext) => {
+				const source = new ConcatSource();
+				source.add("var __universal_env__;\n");
+				source.add(runtimeEnvironment);
+				source.add("\n");
+
+				// Hoisting modules to top level, this is for
+				// multiple chunk template renderer in universal occassion
+				source.add("/** Hoisted Modules **/\n");
+				source.add("var __universal_modules__ =");
+				source.add(new PrefixSource("\t", modules));
+				source.add(";\n");
+				return source;
+			}
+		);
+	}
+}
+
+module.exports = UniversalChunkTemplatePlugin;

--- a/lib/universal/UniversalTemplatePlugin.js
+++ b/lib/universal/UniversalTemplatePlugin.js
@@ -1,0 +1,29 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+*/
+
+"use strict";
+
+const RuntimeGlobals = require("../RuntimeGlobals");
+const UniversalChunkTemplatePlugin = require("./UniversalChunkTemplatePlugin");
+
+class UniversalTemplatePlugin {
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap(
+			"UniversalTemplatePlugin",
+			compilation => {
+				new UniversalChunkTemplatePlugin(compilation).apply(
+					compilation.chunkTemplate
+				);
+				compilation.hooks.additionalTreeRuntimeRequirements.tap(
+					"UniversalTemplatePlugin",
+					(chunk, runtimeRequirements) => {
+						runtimeRequirements.add(RuntimeGlobals.environment);
+					}
+				);
+			}
+		);
+	}
+}
+
+module.exports = UniversalTemplatePlugin;

--- a/lib/web/JsonpChunkLoadingRuntimeModule.js
+++ b/lib/web/JsonpChunkLoadingRuntimeModule.js
@@ -27,6 +27,9 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 		this.jsonpScript = jsonpScript;
 		this.linkPreload = linkPreload;
 		this.linkPrefetch = linkPrefetch;
+		this.shouldCheckEnvironment = runtimeRequirements.has(
+			RuntimeGlobals.environment
+		);
 	}
 
 	/**
@@ -39,7 +42,8 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 			linkPreload,
 			linkPrefetch,
 			chunkGraph,
-			outputOptions
+			outputOptions,
+			shouldCheckEnvironment
 		} = this;
 		const fn = RuntimeGlobals.ensureChunkHandlers;
 		const needPrefetchingCode = chunk => {
@@ -72,7 +76,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 		const jsonpObject = `${outputOptions.globalObject}[${JSON.stringify(
 			outputOptions.jsonpFunction
 		)}]`;
-		return Template.asString([
+		const runtimeCodeLines = [
 			withPreload
 				? `var chunkPreloadMap = ${JSON.stringify(
 						preloadChunkMap,
@@ -407,7 +411,15 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 						"var parentJsonpFunction = oldJsonpFunction;"
 				  ])
 				: "// no jsonp function"
-		]);
+		];
+
+		return shouldCheckEnvironment
+			? Template.asString([
+					`if(${RuntimeGlobals.environment} === "web") {`,
+					Template.indent(runtimeCodeLines),
+					"}"
+			  ])
+			: Template.asString(runtimeCodeLines);
 	}
 }
 

--- a/lib/web/JsonpChunkTemplatePlugin.js
+++ b/lib/web/JsonpChunkTemplatePlugin.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-const { ConcatSource } = require("webpack-sources");
+const { ConcatSource, PrefixSource, RawSource } = require("webpack-sources");
 const HotUpdateChunk = require("../HotUpdateChunk");
 const Template = require("../Template");
 const getEntryInfo = require("./JsonpHelpers").getEntryInfo;
@@ -27,9 +27,14 @@ class JsonpChunkTemplatePlugin {
 	 * @returns {void}
 	 */
 	apply(chunkTemplate) {
+		const { target } = this.compilation.options;
 		chunkTemplate.hooks.render.tap(
 			"JsonpChunkTemplatePlugin",
 			(modules, moduleTemplate, renderContext) => {
+				const previousSource = modules;
+				if (target === "universal") {
+					modules = new RawSource("__universal_modules__");
+				}
 				const { chunk, chunkGraph } = renderContext;
 				const hotUpdateChunk = chunk instanceof HotUpdateChunk ? chunk : null;
 				const globalObject = chunkTemplate.outputOptions.globalObject;
@@ -78,6 +83,15 @@ class JsonpChunkTemplatePlugin {
 						source.add(prefetchPart);
 					}
 					source.add("])");
+				}
+				if (target === "universal") {
+					return new ConcatSource(
+						previousSource,
+						"\n",
+						`if(__universal_env__ === "web") {\n`,
+						new PrefixSource("\t", source),
+						"\n}\n"
+					);
 				}
 				return source;
 			}

--- a/lib/webworker/ImportScriptsChunkLoadingRuntimeModule.js
+++ b/lib/webworker/ImportScriptsChunkLoadingRuntimeModule.js
@@ -14,13 +14,16 @@ class ImportScriptsChunkLoadingRuntimeModule extends RuntimeModule {
 		this.chunk = chunk;
 		this.outputOptions = outputOptions;
 		this.runtimeRequirements = runtimeRequirements;
+		this.shouldCheckEnvironment = runtimeRequirements.has(
+			RuntimeGlobals.environment
+		);
 	}
 
 	/**
 	 * @returns {string} runtime code
 	 */
 	generate() {
-		const { chunk, outputOptions } = this;
+		const { chunk, outputOptions, shouldCheckEnvironment } = this;
 		const { globalObject, chunkCallbackName } = outputOptions;
 		const fn = RuntimeGlobals.ensureChunkHandlers;
 		const withLoading = this.runtimeRequirements.has(
@@ -32,7 +35,7 @@ class ImportScriptsChunkLoadingRuntimeModule extends RuntimeModule {
 		const withHmrManifest = this.runtimeRequirements.has(
 			RuntimeGlobals.hmrDownloadManifest
 		);
-		return Template.asString([
+		const runtimeCodeLines = [
 			"// object to store loaded chunks",
 			'// "1" means "already loaded"',
 			"var installedChunks = {",
@@ -180,7 +183,15 @@ class ImportScriptsChunkLoadingRuntimeModule extends RuntimeModule {
 						"};"
 				  ])
 				: "// no HMR manifest"
-		]);
+		];
+
+		return shouldCheckEnvironment
+			? Template.asString([
+					`if(${RuntimeGlobals.environment} === "webworker") {`,
+					Template.indent(runtimeCodeLines),
+					"}"
+			  ])
+			: Template.asString(runtimeCodeLines);
 	}
 }
 

--- a/lib/webworker/WebWorkerChunkTemplatePlugin.js
+++ b/lib/webworker/WebWorkerChunkTemplatePlugin.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-const { ConcatSource } = require("webpack-sources");
+const { ConcatSource, PrefixSource, RawSource } = require("webpack-sources");
 const HotUpdateChunk = require("../HotUpdateChunk");
 const Template = require("../Template");
 
@@ -25,9 +25,14 @@ class WebWorkerChunkTemplatePlugin {
 	 * @returns {void}
 	 */
 	apply(chunkTemplate) {
+		const { target } = this.compilation.options;
 		chunkTemplate.hooks.render.tap(
 			"WebWorkerChunkTemplatePlugin",
 			(modules, moduleTemplate, renderContext) => {
+				const previousSource = modules;
+				if (target === "universal") {
+					modules = new RawSource("__universal_modules__");
+				}
 				const { chunk, chunkGraph } = renderContext;
 				const hotUpdateChunk = chunk instanceof HotUpdateChunk ? chunk : null;
 				const globalObject = chunkTemplate.outputOptions.globalObject;
@@ -56,6 +61,15 @@ class WebWorkerChunkTemplatePlugin {
 						source.add(runtimePart);
 					}
 					source.add(")");
+				}
+				if (target === "universal") {
+					return new ConcatSource(
+						previousSource,
+						"\n",
+						`if(__universal_env__ === "webworker") {\n`,
+						new PrefixSource("\t", source),
+						"\n}\n"
+					);
 				}
 				return source;
 			}

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2283,7 +2283,8 @@
             "async-node",
             "node-webkit",
             "electron-main",
-            "electron-renderer"
+            "electron-renderer",
+            "universal"
           ]
         },
         {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This PR try to resolve #6525.
Also resolve #6522.

WIP: Because of my knowledge of the whole internal code is inadequate, currently is working in progress, and some detail needs more advice and discussion.

## the things should be done (AFAIK):
After digging into the code, I think these two big things should be done to achieve this feature:
- MainTemplate: Add all runtime codes that may be used, but enable them conditionally at runtime.
- ChunkTemplate: Also like the main, first should pack all runtime loaders (JsonpArray, Jsonp, exports) wrapped with conditions into chunks, and hoist the chunk modules alone, then choose correct way to export them at runtime.

## Current implementation:
the steps of my implementation now:
- Add a new "universal" target.
- Apply all `web/webworker/node` templates, and a new `universal` template additionally at the new target:
  - UniversalTemplatePlugin (new)
  - JsonpTemplatePlugin
  - WebWorkerTemplatePlugin
  - NodeTemplatePlugin
  - TODO: any others ?
- Add a new runtime variable `__webpack_require__.env`(`RuntimeGlobals.environment`) to figure out the environment type of runtime.
- Add `RuntimeGlobals.environment` to `runtimeRequirements` while `UniversalTemplatePlugin` applied.
- Change `**RuntimeModule` that used for each kind of template, wrap a checker by `__webpack_require__.env` for their runtime code:
```javascript
return shouldCheckEnvironment
  ? Template.asString([
    `if(${RuntimeGlobals.environment} === "web") {`,
    Template.indent(runtimeCodeLines),
    "}"
  ])
  : Template.asString(runtimeCodeLines);
```
- Add `UniversalChunkTemplatePlugin`, make chunk modules render hoisted first and before other chunkTemplates render.
- Change other `**ChunkTemplatePlugin`, wrap a condition to original chunk source  when`options.target === "universal"`.
```javascript
if (target === "universal") {
  return new ConcatSource(
    previousSource,// chunk modules has been hoisted in here
    `if(__universal_env__ === "web") {`,
    new PrefixSource("\t", source),
    "}"
  );
}
return source;
```
- Finally, different runtime type runs different runtime code, both of `main` an `chunk`.

## Current problems (need help):

### Should `NodeSourcePlugin` be added? 
"universal" includes node support.

### How to put or reference `__webpack_require__.xxx` runtime globals to each chunk? Or any other ideas?
Because now both `main` and `chunk` need to check environment type at runtime. I have to re-create a useless `RuntimeModule` instance in `ChunkTemplatePlugin` to reuse the runtime check code, and also created some global variables like `__universal_env__`:
```javascript
const runtimeEnvironment = new EnvironmentRuntimeModule(
  this.compilation,
  "__universal_env__"
  ).generate();
//...
source.add("var __universal_env__;\n");
source.add(runtimeEnvironment);
```

### Avoid `output.globalObject` repetition:
Currently the `output.globalObject` only support a static value or inline statement, it should be dynamic at "universal" occassion, otherwise it will be excute repeatedly, and duplicated with runtime global:
```javascript
var __universal_env__;
if ((typeof self !== "undefined" ? self : typeof global !== "undefined" ? global : this).document !== undefined) {
	__universal_env__ = "web";
} else if (typeof (typeof self !== "undefined" ? self : typeof global !== "undefined" ? global : this).importScripts === "function") {
	__universal_env__ = "webworker";
} else if ((typeof self !== "undefined" ? self : typeof global !== "undefined" ? global : this).process !== undefined) {
	__universal_env__ = "node";
} else {
	__universal_env__ = "web";
}
```

### Redundant chunkTemplate conditions:
Each chunkTemplate's apply/render logic is separate. For support multiple types of runtime code exist together, I have to add at least two invasive conditions to each render . Any better idea?
```javascript
chunkTemplate.hooks.render.tap(
"JsonpChunkTemplatePlugin",
(modules, moduleTemplate, renderContext) => {
  const previousSource = modules;
  if (target === "universal") { // conditions 1
    modules = new RawSource("__universal_modules__");
  }

  // origin source generate...

  if (target === "universal") { // more conditions
    return new ConcatSource(
	previousSource,
	`if(__universal_env__ === "web") {`,
	new PrefixSource("\t", source),
	"}"
    );
  }
  return source;
});
```

### More: Any other problems?...

cc @sokra @ooflorent . Looking forward to some advice.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
TODO

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
New target option needs to be addressed.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
