### PR TITLE
Fix emit for prefetching chunks from runtime chunk

### DIFF
--- a/lib/web/JsonpChunkLoadingRuntimeModule.js
+++ b/lib/web/JsonpChunkLoadingRuntimeModule.js
@@ -176,7 +176,9 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 						]),
 						"}",
 						prefetchChunks && prefetchChunks.length > 0
-							? prefetchChunks.map(c => `prefetchChunk("${c}");`).join("\n")
+							? prefetchChunks
+									.map(c => `prefetchChunk(${JSON.stringify(c)});`)
+									.join("\n")
 							: ""
 				  ])
 				: "// no prefetching",

--- a/lib/web/JsonpChunkLoadingRuntimeModule.js
+++ b/lib/web/JsonpChunkLoadingRuntimeModule.js
@@ -176,9 +176,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 						]),
 						"}",
 						prefetchChunks && prefetchChunks.length > 0
-							? prefetchChunks
-									.map(c => `prefetchChunk("${c}"); /* test */`)
-									.join("\n")
+							? prefetchChunks.map(c => `prefetchChunk("${c}");`).join("\n")
 							: ""
 				  ])
 				: "// no prefetching",

--- a/lib/web/JsonpChunkLoadingRuntimeModule.js
+++ b/lib/web/JsonpChunkLoadingRuntimeModule.js
@@ -176,7 +176,9 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 						]),
 						"}",
 						prefetchChunks && prefetchChunks.length > 0
-							? prefetchChunks.map(c => `\nprefetchChunk(${c});`)
+							? prefetchChunks
+									.map(c => `prefetchChunk("${c}"); /* test */`)
+									.join("\n")
 							: ""
 				  ])
 				: "// no prefetching",

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1933,7 +1933,7 @@ prefetched2.js  119 bytes   {569}  [emitted]  prefetched2
 prefetched3.js  119 bytes   {402}  [emitted]  prefetched3
 Entrypoint main = main.js (prefetch: prefetched2.js prefetched.js prefetched3.js)
 chunk {402} prefetched3.js (prefetched3) 0 bytes <{404}> [rendered]
-chunk {404} main.js (main) 436 bytes (javascript) 5.92 KiB (runtime) >{402}< >{569}< >{586}< >{855}< (prefetch: {569} {586} {402}) [entry] [rendered]
+chunk {404} main.js (main) 436 bytes (javascript) 5.89 KiB (runtime) >{402}< >{569}< >{586}< >{855}< (prefetch: {569} {586} {402}) [entry] [rendered]
 chunk {503} inner.js (inner) 0 bytes <{586}> [rendered]
 chunk {557} inner2.js (inner2) 0 bytes <{586}> [rendered]
 chunk {569} prefetched2.js (prefetched2) 0 bytes <{404}> [rendered]
@@ -1948,7 +1948,7 @@ chunk {193} a.js (a) 136 bytes <{404}> >{103}< >{720}< (prefetch: {720} {103}) [
 chunk {253} b2.js (b2) 0 bytes <{912}> [rendered]
 chunk {284} b1.js (b1) 0 bytes <{912}> [rendered]
 chunk {322} b3.js (b3) 0 bytes <{912}> [rendered]
-chunk {404} main.js (main) 195 bytes (javascript) 6.22 KiB (runtime) >{43}< >{193}< >{912}< (prefetch: {193} {912} {43}) [entry] [rendered]
+chunk {404} main.js (main) 195 bytes (javascript) 6.19 KiB (runtime) >{43}< >{193}< >{912}< (prefetch: {193} {912} {43}) [entry] [rendered]
 chunk {515} c2.js (c2) 0 bytes <{43}> [rendered]
 chunk {720} a1.js (a1) 0 bytes <{193}> [rendered]
 chunk {852} c1.js (c1) 0 bytes <{43}> [rendered]

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1948,7 +1948,7 @@ chunk {193} a.js (a) 136 bytes <{404}> >{103}< >{720}< (prefetch: {720} {103}) [
 chunk {253} b2.js (b2) 0 bytes <{912}> [rendered]
 chunk {284} b1.js (b1) 0 bytes <{912}> [rendered]
 chunk {322} b3.js (b3) 0 bytes <{912}> [rendered]
-chunk {404} main.js (main) 195 bytes (javascript) 6.19 KiB (runtime) >{43}< >{193}< >{912}< (prefetch: {193} {912} {43}) [entry] [rendered]
+chunk {404} main.js (main) 195 bytes (javascript) 6.18 KiB (runtime) >{43}< >{193}< >{912}< (prefetch: {193} {912} {43}) [entry] [rendered]
 chunk {515} c2.js (c2) 0 bytes <{43}> [rendered]
 chunk {720} a1.js (a1) 0 bytes <{193}> [rendered]
 chunk {852} c1.js (c1) 0 bytes <{43}> [rendered]

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1933,7 +1933,7 @@ prefetched2.js  119 bytes   {569}  [emitted]  prefetched2
 prefetched3.js  119 bytes   {402}  [emitted]  prefetched3
 Entrypoint main = main.js (prefetch: prefetched2.js prefetched.js prefetched3.js)
 chunk {402} prefetched3.js (prefetched3) 0 bytes <{404}> [rendered]
-chunk {404} main.js (main) 436 bytes (javascript) 5.89 KiB (runtime) >{402}< >{569}< >{586}< >{855}< (prefetch: {569} {586} {402}) [entry] [rendered]
+chunk {404} main.js (main) 436 bytes (javascript) 5.92 KiB (runtime) >{402}< >{569}< >{586}< >{855}< (prefetch: {569} {586} {402}) [entry] [rendered]
 chunk {503} inner.js (inner) 0 bytes <{586}> [rendered]
 chunk {557} inner2.js (inner2) 0 bytes <{586}> [rendered]
 chunk {569} prefetched2.js (prefetched2) 0 bytes <{404}> [rendered]
@@ -1948,7 +1948,7 @@ chunk {193} a.js (a) 136 bytes <{404}> >{103}< >{720}< (prefetch: {720} {103}) [
 chunk {253} b2.js (b2) 0 bytes <{912}> [rendered]
 chunk {284} b1.js (b1) 0 bytes <{912}> [rendered]
 chunk {322} b3.js (b3) 0 bytes <{912}> [rendered]
-chunk {404} main.js (main) 195 bytes (javascript) 6.18 KiB (runtime) >{43}< >{193}< >{912}< (prefetch: {193} {912} {43}) [entry] [rendered]
+chunk {404} main.js (main) 195 bytes (javascript) 6.22 KiB (runtime) >{43}< >{193}< >{912}< (prefetch: {193} {912} {43}) [entry] [rendered]
 chunk {515} c2.js (c2) 0 bytes <{43}> [rendered]
 chunk {720} a1.js (a1) 0 bytes <{193}> [rendered]
 chunk {852} c1.js (c1) 0 bytes <{43}> [rendered]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This fixes a bug in the v5 branch of webpack. Before this change, the code emitted when prefetching chunks from the runtime chunk had two errors:
1. It didn't join the mapped array into a string, so extraneous `,` characters were added that did not parse.
2. It didn't wrap the chunk names in quotes; as such, they were treated as undefined identifiers.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Bug fix (see https://github.com/webpack/webpack/issues/8537#issuecomment-450979354)

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Not yet. I'm unsure how to add tests that simply verify that emitted Javascript parses, which would have caught this issue.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Nothing; this is a bugfix;

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
