### PR TITLE
perf: use faster statement type check

### DIFF
--- a/lib/dependencies/HarmonyDetectionParserPlugin.js
+++ b/lib/dependencies/HarmonyDetectionParserPlugin.js
@@ -13,9 +13,11 @@ module.exports = class HarmonyDetectionParserPlugin {
 			const isStrictHarmony = parser.state.module.type === "javascript/esm";
 			const isHarmony =
 				isStrictHarmony ||
-				ast.body.some(statement => {
-					return /^(Import|Export).*Declaration$/.test(statement.type);
-				});
+				ast.body.some(statement => statement =>
+					statement.type === "ImportDeclaration" ||
+					statement.type === "ExportDefaultDeclaration" ||
+					statement.type === "ExportNamedDeclaration"
+				);
 			if (isHarmony) {
 				const module = parser.state.module;
 				const compatDep = new HarmonyCompatibilityDependency(module);

--- a/lib/dependencies/HarmonyDetectionParserPlugin.js
+++ b/lib/dependencies/HarmonyDetectionParserPlugin.js
@@ -13,10 +13,12 @@ module.exports = class HarmonyDetectionParserPlugin {
 			const isStrictHarmony = parser.state.module.type === "javascript/esm";
 			const isHarmony =
 				isStrictHarmony ||
-				ast.body.some(statement => statement =>
-					statement.type === "ImportDeclaration" ||
-					statement.type === "ExportDefaultDeclaration" ||
-					statement.type === "ExportNamedDeclaration"
+				ast.body.some(
+					statement =>
+						statement.type === "ImportDeclaration" ||
+						statement.type === "ExportDefaultDeclaration" ||
+						statement.type === "ExportNamedDeclaration" ||
+						statement.type === "ExportAllDeclaration"
 				);
 			if (isHarmony) {
 				const module = parser.state.module;


### PR DESCRIPTION
As discussed offline with @sokra, this change is meant to allow faster statement type lookup's. Based on https://jsperf.com/exact-pattern-vs-dot-star/1

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

N/A

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

N/A
