### PR TITLE
Improve performance of SourceMapSource serialization

### DIFF
--- a/lib/util/registerExternalSerializer.js
+++ b/lib/util/registerExternalSerializer.js
@@ -279,9 +279,14 @@ register(
 		 * @returns {void}
 		 */
 		serialize(source, { write }) {
-			const data = source.sourceAndMap({});
-			write(data.source);
-			write(JSON.stringify(data.map));
+			if (source._innerSourceMap) {
+				const data = source.sourceAndMap({});
+				write(data.source);
+				write(JSON.stringify(data.map));
+			} else {
+				write(source.source());
+				write(JSON.stringify(source._sourceMap));
+			}
 		}
 
 		/**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

[Background](https://github.com/webpack/webpack/issues/8537#issuecomment-451492722).

After initial tests, I've decided to investigate why initial build became much slower on webpack 5. I've noticed that a lot of time is spent on something after the emit and naturally thought about serialization. Here is the [CPU Profile](https://github.com/webpack/webpack/files/2727382/CPU-20190104T154902.cpuprofile.zip). Majority of the time is spent in `SourceMapSource::node`(we are using `cheap-module-sourcemap` in development). For me, it looks like expensive `node` call can be skipped if the source has no input source map. After this patch I've got the results (roughly 2 min faster than before):

<details>
<summary>webpack 5 + patch, clean build</summary>
<pre>
        User time (seconds): 1092.08
        System time (seconds): 185.20
        Percent of CPU this job got: 310%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 6:51.06
        Maximum resident set size (kbytes): 4264796
</pre>
</details>


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Performance optimization.

**Did you add tests for your changes?**

I haven't found tests for serialization. Would gladly add them if you could suggest the right way of testing it.

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing aside from changelog entry, I think
