### PR TITLE
Use limit for string split

### DIFF
--- a/lib/WebpackOptionsValidationError.js
+++ b/lib/WebpackOptionsValidationError.js
@@ -10,8 +10,7 @@ const WebpackError = require("./WebpackError");
 
 const getSchemaPart = (path, parents, additionalPath) => {
 	parents = parents || 0;
-	path = path.split("/");
-	path = path.slice(0, path.length - parents);
+	path = path.split("/", path.length - parents);
 	if (additionalPath) {
 		additionalPath = additionalPath.split("/");
 		path = path.concat(additionalPath);

--- a/lib/util/createHash.js
+++ b/lib/util/createHash.js
@@ -66,7 +66,7 @@ class DebugHash {
 		if (data.startsWith("debug-digest-")) {
 			data = Buffer.from(data.slice("debug-digest-".length), "hex").toString();
 		}
-		this.string += `[${data}](${new Error().stack.split("\n")[2]})\n`;
+		this.string += `[${data}](${new Error().stack.split("\n", 3)[2]})\n`;
 		return this;
 	}
 


### PR DESCRIPTION
I added second argument(limit) for string `split` to performance reason.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Refactoring
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
