### PR TITLE
Add preserveEntrypoint option to splitChunks cacheGroups (rebased)

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1156,6 +1156,10 @@ export interface OptimizationSplitChunksCacheGroup {
 	 */
 	name?: false | Function | string;
 	/**
+	 * Preserve existing entrypoint when chunk has equal name
+	 */
+	preserveEntrypoint?: boolean;
+	/**
 	 * Priority of this cache group
 	 */
 	priority?: number;

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -398,6 +398,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("optimization.splitChunks.cacheGroups.default", {
 			idHint: "",
 			reuseExistingChunk: true,
+			preserveEntrypoint: false,
 			minChunks: 2,
 			priority: -20
 		});

--- a/lib/optimize/SplitChunksPlugin.js
+++ b/lib/optimize/SplitChunksPlugin.js
@@ -66,6 +66,7 @@ const MinMaxSizeWarning = require("./MinMaxSizeWarning");
  * @property {string=} idHint
  * @property {string} automaticNameDelimiter
  * @property {boolean=} reuseExistingChunk
+ * @property {boolean=} preserveEntrypoint
  */
 
 /**
@@ -87,6 +88,7 @@ const MinMaxSizeWarning = require("./MinMaxSizeWarning");
  * @property {string=} idHint
  * @property {string} automaticNameDelimiter
  * @property {boolean=} reuseExistingChunk
+ * @property {boolean=} preserveEntrypoint
  */
 
 /**
@@ -479,7 +481,8 @@ const createCacheGroupSource = options => {
 		filename: options.filename,
 		idHint: options.idHint,
 		automaticNameDelimiter: options.automaticNameDelimiter,
-		reuseExistingChunk: options.reuseExistingChunk
+		reuseExistingChunk: options.reuseExistingChunk,
+		preserveEntrypoint: options.preserveEntrypoint
 	};
 };
 
@@ -837,7 +840,8 @@ module.exports = class SplitChunksPlugin {
 									cacheGroupSource.idHint !== undefined
 										? cacheGroupSource.idHint
 										: cacheGroupSource.key,
-								reuseExistingChunk: cacheGroupSource.reuseExistingChunk
+								reuseExistingChunk: cacheGroupSource.reuseExistingChunk,
+								preserveEntrypoint: cacheGroupSource.preserveEntrypoint
 							};
 							// For all combination of chunk selection
 							for (const chunkCombination of combs) {
@@ -1051,7 +1055,7 @@ module.exports = class SplitChunksPlugin {
 							newChunk.chunkReason += ` (name: ${chunkName})`;
 							// If the chosen name is already an entry point we remove the entry point
 							const entrypoint = compilation.entrypoints.get(chunkName);
-							if (entrypoint) {
+							if (!item.cacheGroup.preserveEntrypoint && entrypoint) {
 								compilation.entrypoints.delete(chunkName);
 								entrypoint.remove();
 								chunkGraph.disconnectEntries(newChunk);

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -813,6 +813,10 @@
             }
           ]
         },
+        "preserveEntrypoint": {
+          "description": "Preserve existing entrypoint when chunk has equal name",
+          "type": "boolean"
+        },
         "priority": {
           "description": "Priority of this cache group",
           "type": "number"

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -3685,6 +3685,15 @@ Child enforce-min-size:
      ./node_modules/small.js?2 67 bytes [built]"
 `;
 
+exports[`StatsTestCases should print correct stats for split-chunks-issue-7230 1`] = `
+"            Asset       Size  Chunks             Chunk Names
+   core.bundle.js  556 bytes       0  [emitted]  core
+   main.bundle.js  796 bytes       2  [emitted]  main
+runtime.bundle.js   6.04 KiB       1  [emitted]  runtime
+Entrypoint core = runtime.bundle.js core.bundle.js
+Entrypoint main = runtime.bundle.js core.bundle.js main.bundle.js"
+`;
+
 exports[`StatsTestCases should print correct stats for split-chunks-prefer-bigger-splits 1`] = `
 "Entrypoint main = default/main.js
 chunk default/118.js 110 bytes <{179}> ={334}= ={383}= [rendered] split chunk (cache group: default)

--- a/test/statsCases/split-chunks-issue-7230/a.js
+++ b/test/statsCases/split-chunks-issue-7230/a.js
@@ -1,0 +1,1 @@
+console.log("module a");

--- a/test/statsCases/split-chunks-issue-7230/b.js
+++ b/test/statsCases/split-chunks-issue-7230/b.js
@@ -1,0 +1,1 @@
+console.log("module b");

--- a/test/statsCases/split-chunks-issue-7230/core.js
+++ b/test/statsCases/split-chunks-issue-7230/core.js
@@ -1,0 +1,3 @@
+import "./a";
+
+console.log("core bundle");

--- a/test/statsCases/split-chunks-issue-7230/main.js
+++ b/test/statsCases/split-chunks-issue-7230/main.js
@@ -1,0 +1,4 @@
+import "./a";
+import "./b";
+
+console.log("main bundle");

--- a/test/statsCases/split-chunks-issue-7230/webpack.config.js
+++ b/test/statsCases/split-chunks-issue-7230/webpack.config.js
@@ -1,0 +1,40 @@
+const stats = {
+	hash: false,
+	timings: false,
+	builtAt: false,
+	assets: true,
+	chunks: false,
+	chunkOrigins: false,
+	entrypoints: true,
+	modules: false
+};
+module.exports = {
+	name: "default",
+	mode: "production",
+	entry: {
+		core: "./core",
+		main: "./main"
+	},
+	output: {
+		filename: "[name].bundle.js"
+	},
+	optimization: {
+		runtimeChunk: {
+			name: "runtime"
+		},
+		splitChunks: {
+			cacheGroups: {
+				default: false,
+				vendors: false,
+				core: {
+					chunks: "all",
+					name: "core",
+					minChunks: 2,
+					minSize: 0,
+					preserveEntrypoint: true
+				}
+			}
+		}
+	},
+	stats
+};


### PR DESCRIPTION
This is just a fork of #7242 rebased on master since the original pull request was not rebased.

Fixes #7230, closes #7242.