### PR TITLE
Improve memory consumption of file serialization middleware

### DIFF
--- a/lib/serialization/FileMiddleware.js
+++ b/lib/serialization/FileMiddleware.js
@@ -255,6 +255,32 @@ const readSection = (filename, file, offset, size, callback) => {
 	});
 };
 
+const writeBuffers = (fileHandle, buffers, callback) => {
+	const stream = fs.createWriteStream(null, {
+		fd: fileHandle,
+		autoClose: false
+	});
+	let index = 0;
+
+	const doWrite = function() {
+		let canWriteMore = true;
+		while (canWriteMore && index < buffers.length) {
+			const chunk = buffers[index++];
+			canWriteMore = stream.write(chunk);
+		}
+
+		if (index < buffers.length) {
+			stream.once("drain", doWrite);
+		} else {
+			stream.end();
+		}
+	};
+
+	stream.on("error", err => callback(err));
+	stream.on("finish", () => callback(null));
+	doWrite();
+};
+
 class FileMiddleware extends SerializerMiddleware {
 	/**
 	 * @param {any[]} data data items
@@ -296,7 +322,7 @@ class FileMiddleware extends SerializerMiddleware {
 				mkdirp(path.dirname(filename), err => {
 					if (err) return reject(err);
 					fileManager.addJob(filename, true, (file, callback) => {
-						fs.writeFile(file, Buffer.concat(buffers), err => {
+						writeBuffers(file, buffers, err => {
 							if (err) return callback(err);
 							resolve(true);
 							callback();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

 On a large project with resolver cache enabled the total size of all serialized chunks in `FileMiddleware:: serialize` can reach hundreds of megabytes (~800 MB in our case). `Buffer.concat` call [here](https://github.com/webpack/webpack/blob/next/lib/serialization/FileMiddleware.js#L299) duplicates this data. [Node source for a reference](https://github.com/nodejs/node/blob/master/lib/buffer.js#L467).

 This PR changes `FileMiddleware` to use node.js streams for writing the data into the file without concatenation.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Performance improvement

**Did you add tests for your changes?**

Existing `TestCasesCachePack`/`TestCasesCacheInstant` should cover it

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing
