### PR TITLE
Fix UMD builds root reference

### DIFF
--- a/lib/UmdMainTemplatePlugin.js
+++ b/lib/UmdMainTemplatePlugin.js
@@ -83,7 +83,7 @@ class UmdMainTemplatePlugin {
 	 * @returns {void}
 	 */
 	apply(compilation) {
-		const { mainTemplate, chunkTemplate, runtimeTemplate } = compilation;
+		const { mainTemplate, chunkTemplate } = compilation;
 
 		const onRenderWithEntry = (source, chunk, hash) => {
 			let externals = chunk
@@ -269,9 +269,7 @@ class UmdMainTemplatePlugin {
 									: "		var a = factory();\n") +
 							  "		for(var i in a) (typeof exports === 'object' ? exports : root)[i] = a[i];\n" +
 							  "	}\n") +
-						`})(${
-							runtimeTemplate.outputOptions.globalObject
-						}, function(${externalsArguments(externals)}) {\nreturn `,
+						`})(this, function(${externalsArguments(externals)}) {\nreturn `,
 					"webpack/universalModuleDefinition"
 				),
 				source,

--- a/lib/UmdMainTemplatePlugin.js
+++ b/lib/UmdMainTemplatePlugin.js
@@ -269,7 +269,9 @@ class UmdMainTemplatePlugin {
 									: "		var a = factory();\n") +
 							  "		for(var i in a) (typeof exports === 'object' ? exports : root)[i] = a[i];\n" +
 							  "	}\n") +
-						`})(this, function(${externalsArguments(externals)}) {\nreturn `,
+						`})(this || self, function(${externalsArguments(
+							externals
+						)}) {\nreturn `,
 					"webpack/universalModuleDefinition"
 				),
 				source,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Fixes the UMD wrapper generated when setting `libraryTarget: 'umd'`.  It incorrectly references `window` as the global object which breaks in nodejs and other envs.  This is because the default `target` is 'web'.  However, in a UMD build the target is special/universal so we don't look up `globalObject`

Closes #6784

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no... I just want to get some feedback on the solution first.

I need some direction.  All the current umd tests should have been failing because webpacked umd doesn't work in node without this fix.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->