### PR TITLE
New resolveLoader.extensions defaults

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -368,7 +368,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("resolveLoader", "call", value => Object.assign({}, value));
 		this.set("resolveLoader.cache", "make", options => !!options.cache);
 		this.set("resolveLoader.mainFields", ["loader", "main"]);
-		this.set("resolveLoader.extensions", [".js", ".json"]);
+		this.set("resolveLoader.extensions", [".js"]);
 		this.set("resolveLoader.mainFiles", ["index"]);
 	}
 }


### PR DESCRIPTION
It's not possible for a `.json` file to be a [valid loader](https://github.com/webpack/loader-runner/blob/master/lib/loadLoader.js#L29). This change aims to make the default config reflect this fact.

**What kind of change does this PR introduce?**

config defaults improvement

**Did you add tests for your changes?**

N/A

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

is this needed?
