### PR TITLE
feat(chunk): Introduce asyncChunkMode and default to 'eager'

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -470,6 +470,10 @@ export interface EntryObject {
  */
 export interface ModuleOptions {
 	/**
+	 * The default webpackMode for async bundles
+	 */
+	asyncChunkMode?: "eager" | "lazy";
+	/**
 	 * An array of rules applied by default for modules.
 	 */
 	defaultRules?: RuleSetRules;

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -87,6 +87,10 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 				};
 			}
 		});
+		this.set("module.asyncChunkMode", "make", options => {
+			if (options.mode === "development") return "eager";
+			return "lazy";
+		});
 		this.set("module.rules", []);
 		this.set("module.defaultRules", "make", options => [
 			{

--- a/lib/dependencies/ImportParserPlugin.js
+++ b/lib/dependencies/ImportParserPlugin.js
@@ -14,7 +14,13 @@ const ImportDependency = require("./ImportDependency");
 const ImportEagerDependency = require("./ImportEagerDependency");
 const ImportWeakDependency = require("./ImportWeakDependency");
 
+/** @typedef {import("../../declarations/WebpackOptions").ModuleOptions} ModuleOptions */
+/** @typedef {"lazy"|"weak"|"eager"|"lazy-once"|"async-weak"} WebpackMode */
+
 class ImportParserPlugin {
+	/**
+	 * @param {ModuleOptions} options Normal Module Factory options
+	 */
 	constructor(options) {
 		this.options = options;
 	}
@@ -30,7 +36,8 @@ class ImportParserPlugin {
 			const param = parser.evaluateExpression(expr.arguments[0]);
 
 			let chunkName = null;
-			let mode = "lazy";
+			/** @type {WebpackMode} */
+			let mode = this.options.asyncChunkMode;
 			let include = null;
 			let exclude = null;
 			const groupOptions = {};

--- a/lib/dependencies/ImportPlugin.js
+++ b/lib/dependencies/ImportPlugin.js
@@ -11,11 +11,21 @@ const ImportEagerDependency = require("./ImportEagerDependency");
 const ImportParserPlugin = require("./ImportParserPlugin");
 const ImportWeakDependency = require("./ImportWeakDependency");
 
+/** @typedef {import("../../declarations/WebpackOptions").ModuleOptions} ModuleOptions */
+/** @typedef {import("../Compiler")} Compiler */
+
 class ImportPlugin {
+	/**
+	 * @param {ModuleOptions} options Normal Module Factory options
+	 */
 	constructor(options) {
 		this.options = options;
 	}
 
+	/**
+	 * @param {Compiler} compiler webpack compiler instance
+	 * @returns {void}
+	 */
 	apply(compiler) {
 		const options = this.options;
 		compiler.hooks.compilation.tap(

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -264,6 +264,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "asyncChunkMode": {
+          "description": "The default webpackMode for async bundles",
+          "enum": ["eager", "lazy"]
+        },
         "defaultRules": {
           "description": "An array of rules applied by default for modules.",
           "anyOf": [

--- a/test/configCases/split-chunks/chunk-filename-delimiter-default/webpack.config.js
+++ b/test/configCases/split-chunks/chunk-filename-delimiter-default/webpack.config.js
@@ -7,6 +7,9 @@ module.exports = {
 		__dirname: false,
 		__filename: false
 	},
+	module: {
+		asyncChunkMode: "lazy"
+	},
 	output: {
 		filename: "[name].js",
 		chunkFilename: "[name].bundle.js",

--- a/test/configCases/split-chunks/chunk-filename-delimiter/webpack.config.js
+++ b/test/configCases/split-chunks/chunk-filename-delimiter/webpack.config.js
@@ -7,6 +7,9 @@ module.exports = {
 		__dirname: false,
 		__filename: false
 	},
+	module: {
+		asyncChunkMode: "lazy"
+	},
 	output: {
 		filename: "[name].js",
 		chunkFilename: "[name].bundle.js",

--- a/test/statsCases/graph-roots/webpack.config.js
+++ b/test/statsCases/graph-roots/webpack.config.js
@@ -4,6 +4,9 @@ module.exports = {
 	optimization: {
 		splitChunks: false
 	},
+	module: {
+		asyncChunkMode: "lazy"
+	},
 	stats: {
 		all: false,
 		chunks: true,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Fixes #8644 

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Not yet, but we'll get there. 
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
Yes.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Technically this is a breaking change. By default webpack generates in `mode: development` a individual bundle for each use of `import()`. This PR would modify this behavior for the users dev environment to **not** create additional async bundles. 

However functionally this may only cause break's on extreme edge cases (strange SSR/mode usages?).

**What needs to be documented once your changes are merged?**
Addition of a new configuration property

```
module: {
  asnycChunkMode: "eager" // (or "lazy")
}
```

"eager" is the default for development environment, and "lazy" is the default for any other mode.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
