### PR TITLE
pass fs itself, instead of fs.readFile.bind()

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -420,7 +420,7 @@ class NormalModule extends Module {
 				resource: this.resource,
 				loaders: this.loaders,
 				context: loaderContext,
-				readResource: fs.readFile.bind(fs)
+				inputFileSystem: fs
 			},
 			(err, result) => {
 				if (!result) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "events": "^3.0.0",
     "json-parse-better-errors": "^1.0.2",
     "json-stable-stringify": "^1.0.1",
-    "loader-runner": "3.0.0",
+    "loader-runner": "hulkish/loader-runner#prefer-fs-over-bind",
     "loader-utils": "^1.1.0",
     "memory-fs": "~0.4.1",
     "micromatch": "^3.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4327,10 +4327,9 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
-loader-runner@3.0.0:
+loader-runner@hulkish/loader-runner#prefer-fs-over-bind:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-3.0.0.tgz#c86f303af2dacbd27eabd2ea3aaa957291562e23"
-  integrity sha512-BlinBEAJYOUubaKH9hMxshD1FltYLTd3FA4DoxEh/82C0Rc4cmcqI61bEUj0/osbmW9FCTXTpMAO/jHZDZC5Fw==
+  resolved "https://codeload.github.com/hulkish/loader-runner/tar.gz/43610f1206c268d0af7e4b8146deca8530a1b28f"
 
 loader-utils@^1.0.0, loader-utils@^1.0.2, loader-utils@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This removes need for `fs.readFile.bind()`. Depends on https://github.com/webpack/loader-runner/pull/33. For ref: https://jsperf.com/function-calls-direct-vs-apply-vs-call-vs-bind/6

**What kind of change does this PR introduce?**

small refactor

**Did you add tests for your changes?**

N/A

**Does this PR introduce a breaking change?**

Not here. The breaking change lives in `loader-runner`, which has already received a major bump to separate from webpack 4. This change is intended for webpack 5+.

**What needs to be documented once your changes are merged?**

N/A
