### PR TITLE
refactoring of used and provided exports

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -810,6 +810,10 @@ export interface OptimizationOptions {
 	 */
 	flagIncludedChunks?: boolean;
 	/**
+	 * Rename exports when possible to generate shorter code (depends on optimization.usedExports and optimization.providedExports)
+	 */
+	mangleExports?: boolean;
+	/**
 	 * Reduce size of WASM by changing imports to shorter strings.
 	 */
 	mangleWasmImports?: boolean;

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -44,7 +44,6 @@ const StatsFactory = require("./stats/StatsFactory");
 const StatsPrinter = require("./stats/StatsPrinter");
 const AsyncQueue = require("./util/AsyncQueue");
 const Queue = require("./util/Queue");
-const SortableSet = require("./util/SortableSet");
 const {
 	compareLocations,
 	concatComparators,
@@ -1497,7 +1496,7 @@ class Compilation {
 		this.chunkGraph.connectChunkAndRuntimeModule(chunk, module);
 
 		// Setup internals
-		this.moduleGraph.setUsedExports(module, new SortableSet());
+		this.moduleGraph.getExportsInfo(module).setUsedForSideEffectsOnly();
 		this.chunkGraph.addModuleRuntimeRequirements(module, [
 			RuntimeGlobals.require
 		]);

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1622,14 +1622,13 @@ class Compilation {
 	}
 
 	/**
-	 * @param {Module} module the module containing the dependency
 	 * @param {Dependency} dependency the dependency
 	 * @returns {DependencyReference} a reference for the dependency
 	 */
-	getDependencyReference(module, dependency) {
+	getDependencyReference(dependency) {
 		const ref = dependency.getReference(this.moduleGraph);
 		if (!ref) return null;
-		return this.hooks.dependencyReference.call(ref, dependency, module);
+		return this.hooks.dependencyReference.call(ref, dependency);
 	}
 
 	/**
@@ -1666,7 +1665,7 @@ class Compilation {
 		 */
 		const iteratorDependency = d => {
 			// We skip Dependencies without Reference
-			const ref = this.getDependencyReference(currentModule, d);
+			const ref = this.getDependencyReference(d);
 			if (!ref) {
 				return;
 			}
@@ -1692,8 +1691,6 @@ class Compilation {
 			blockQueue.push(b);
 		};
 
-		/** @type {Module} */
-		let currentModule;
 		/** @type {DependenciesBlock} */
 		let block;
 		/** @type {DependenciesBlock[]} */
@@ -1705,7 +1702,6 @@ class Compilation {
 
 		for (const module of this.modules) {
 			blockQueue = [module];
-			currentModule = module;
 			while (blockQueue.length > 0) {
 				block = blockQueue.pop();
 				blockInfoModules = new Set();

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -345,6 +345,9 @@ class Compilation {
 			/** @type {SyncHook<Iterable<Chunk>, any>} */
 			recordChunks: new SyncHook(["chunks", "records"]),
 
+			/** @type {SyncHook<Iterable<Module>>} */
+			optimizeCodeGeneration: new SyncHook(["modules"]),
+
 			/** @type {SyncHook} */
 			beforeModuleHash: new SyncHook([]),
 			/** @type {SyncHook} */
@@ -1287,6 +1290,8 @@ class Compilation {
 				this.hooks.recordModules.call(this.modules, this.records);
 				this.hooks.recordChunks.call(this.chunks, this.records);
 			}
+
+			this.hooks.optimizeCodeGeneration.call(this.modules);
 
 			this.hooks.beforeModuleHash.call();
 			this.createModuleHashes();

--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -13,17 +13,6 @@ const Queue = require("./util/Queue");
 /** @typedef {import("./Dependency")} Dependency */
 /** @typedef {import("./Module")} Module */
 
-const addToSet = (a, b) => {
-	let changed = false;
-	for (const item of b) {
-		if (!a.has(item)) {
-			a.add(item);
-			changed = true;
-		}
-	}
-	return changed;
-};
-
 const getCacheIdentifier = (compilation, module) => {
 	return `${
 		compilation.compilerPath
@@ -56,6 +45,7 @@ class FlagDependencyExportsPlugin {
 								) {
 									// Enqueue uncacheable module for determining the exports
 									queue.enqueue(module);
+									moduleGraph.getExportsInfo(module).setHasProvideInfo();
 									return callback();
 								}
 								compilation.cache.get(
@@ -65,10 +55,13 @@ class FlagDependencyExportsPlugin {
 										if (err) return callback(err);
 
 										if (result !== undefined) {
-											moduleGraph.setProvidedExports(module, result);
+											moduleGraph
+												.getExportsInfo(module)
+												.restoreProvided(result);
 										} else {
 											// Without cached info enqueue module for determining the exports
 											queue.enqueue(module);
+											moduleGraph.getExportsInfo(module).setHasProvideInfo();
 										}
 										callback();
 									}
@@ -85,56 +78,52 @@ class FlagDependencyExportsPlugin {
 
 								/** @type {Module} */
 								let module;
-								/** @type {Set<string> | true} */
-								let moduleProvidedExports;
-								let providedExportsAreCacheable = true;
+
+								let exportsInfo;
+
+								let cacheable = true;
+								let changed = false;
 
 								/**
 								 * @param {DependenciesBlock} depBlock the dependencies block
-								 * @returns {boolean} true if the traversal must be continued
+								 * @returns {void}
 								 */
 								const processDependenciesBlock = depBlock => {
 									for (const dep of depBlock.dependencies) {
-										if (processDependency(dep)) {
-											return true;
-										}
+										processDependency(dep);
 									}
 									for (const block of depBlock.blocks) {
-										if (processDependenciesBlock(block)) {
-											return true;
-										}
+										processDependenciesBlock(block);
 									}
-									return false;
 								};
 
 								/**
 								 * @param {Dependency} dep the dependency
-								 * @returns {boolean} true if the traversal must be continued
+								 * @returns {void}
 								 */
 								const processDependency = dep => {
 									const exportDesc = dep.getExports(moduleGraph);
 									if (!exportDesc) return;
 									const exports = exportDesc.exports;
-									// break early if it's only in the worst state
-									if (moduleProvidedExports === true) {
-										return true;
-									}
-									// break if it should move to the worst state
+									const exportDeps = exportDesc.dependencies;
 									if (exports === true) {
-										moduleProvidedExports = true;
-										notifyDependencies();
-										return true;
-									}
-									// merge in new exports
-									if (Array.isArray(exports)) {
-										if (addToSet(moduleProvidedExports, exports)) {
-											notifyDependencies();
+										// unknown exports
+										if (exportsInfo.setUnknownExportsProvided()) {
+											changed = true;
+										}
+									} else if (Array.isArray(exports)) {
+										// merge in new exports
+										for (const exportName of exports) {
+											const exportInfo = exportsInfo.getExportInfo(exportName);
+											if (exportInfo.provided === false) {
+												exportInfo.provided = true;
+												changed = true;
+											}
 										}
 									}
 									// store dependencies
-									const exportDeps = exportDesc.dependencies;
 									if (exportDeps) {
-										providedExportsAreCacheable = false;
+										cacheable = false;
 										for (const exportDependency of exportDeps) {
 											// add dependency for this module
 											const set = dependencies.get(exportDependency);
@@ -145,7 +134,6 @@ class FlagDependencyExportsPlugin {
 											}
 										}
 									}
-									return false;
 								};
 
 								const notifyDependencies = () => {
@@ -160,39 +148,38 @@ class FlagDependencyExportsPlugin {
 								while (queue.length > 0) {
 									module = queue.dequeue();
 
-									const providedExports = moduleGraph.getProvidedExports(
-										module
-									);
-									if (providedExports !== true) {
+									exportsInfo = moduleGraph.getExportsInfo(module);
+									if (exportsInfo.otherExportsInfo.provided !== null) {
 										if (!module.buildMeta || !module.buildMeta.exportsType) {
 											// It's a module without declared exports
-											moduleGraph.setProvidedExports(module, true);
+											exportsInfo.setUnknownExportsProvided();
 											modulesToStore.add(module);
 											notifyDependencies();
 										} else {
 											// It's a module with declared exports
-											moduleProvidedExports = /** @type {Set<string> | true} */ (Array.isArray(
-												providedExports
-											)
-												? new Set(providedExports)
-												: new Set());
-											providedExportsAreCacheable = true;
+
+											cacheable = true;
+											changed = false;
 
 											processDependenciesBlock(module);
 
-											if (providedExportsAreCacheable) {
+											if (cacheable) {
 												modulesToStore.add(module);
 											}
 
-											moduleGraph.setProvidedExports(
-												module,
-												moduleProvidedExports === true
-													? true
-													: Array.from(moduleProvidedExports)
-											);
+											if (changed) {
+												notifyDependencies();
+											}
 										}
 									}
 								}
+
+								/*for (const module of modules) {
+									console.log(
+										module.identifier(),
+										moduleGraph.getExportsInfo(module)
+									);
+								}*/
 
 								asyncLib.each(
 									modulesToStore,
@@ -207,7 +194,9 @@ class FlagDependencyExportsPlugin {
 										compilation.cache.store(
 											getCacheIdentifier(compilation, module),
 											module.buildInfo.hash,
-											moduleGraph.getProvidedExports(module),
+											moduleGraph
+												.getExportsInfo(module)
+												.getRestoreProvidedData(),
 											callback
 										);
 									},
@@ -218,24 +207,23 @@ class FlagDependencyExportsPlugin {
 					}
 				);
 
-				/** @type {WeakMap<Module, true | string[] | null>} */
+				/** @type {WeakMap<Module, any>} */
 				const providedExportsCache = new WeakMap();
 				compilation.hooks.rebuildModule.tap(
 					"FlagDependencyExportsPlugin",
 					module => {
 						providedExportsCache.set(
 							module,
-							moduleGraph.getProvidedExports(module)
+							moduleGraph.getExportsInfo(module).getRestoreProvidedData()
 						);
 					}
 				);
 				compilation.hooks.finishRebuildingModule.tap(
 					"FlagDependencyExportsPlugin",
 					module => {
-						moduleGraph.setProvidedExports(
-							module,
-							providedExportsCache.get(module)
-						);
+						moduleGraph
+							.getExportsInfo(module)
+							.restoreProvided(providedExportsCache.get(module));
 					}
 				);
 			}

--- a/lib/FlagDependencyUsagePlugin.js
+++ b/lib/FlagDependencyUsagePlugin.js
@@ -40,10 +40,19 @@ class FlagDependencyUsagePlugin {
 							changed = exportsInfo.setUsedInUnknownWay();
 						} else if (usedExports) {
 							for (const exportName of usedExports) {
-								const exportInfo = exportsInfo.getExportInfo(exportName);
-								if (exportInfo.used !== true) {
-									exportInfo.used = true;
-									changed = true;
+								if (
+									exportName === "default" &&
+									module.buildMeta.exportsType === "named"
+								) {
+									if (exportsInfo.setUsedAsNamedExportType()) {
+										changed = true;
+									}
+								} else {
+									const exportInfo = exportsInfo.getExportInfo(exportName);
+									if (exportInfo.used !== true) {
+										exportInfo.used = true;
+										changed = true;
+									}
 								}
 							}
 						} else {

--- a/lib/FlagDependencyUsagePlugin.js
+++ b/lib/FlagDependencyUsagePlugin.js
@@ -6,29 +6,12 @@
 "use strict";
 
 const { STAGE_DEFAULT } = require("./OptimizationStages");
-const SortableSet = require("./util/SortableSet");
+const Queue = require("./util/Queue");
 
 /** @typedef {import("./Compiler")} Compiler */
 /** @typedef {import("./DependenciesBlock")} DependenciesBlock */
 /** @typedef {import("./Dependency")} Dependency */
 /** @typedef {import("./Module")} Module */
-
-/** @typedef {false | true | SortableSet<string>} UsedExports */
-
-/**
- * @param {UsedExports} moduleUsedExports the current used exports of the module
- * @param {false | true | string[]} newUsedExports the new used exports
- * @returns {boolean} true, if the newUsedExports is part of the moduleUsedExports
- */
-const isContained = (moduleUsedExports, newUsedExports) => {
-	if (moduleUsedExports === null) return false;
-	if (moduleUsedExports === true) return true;
-	if (newUsedExports === true) return false;
-	if (newUsedExports === false) return true;
-	if (moduleUsedExports === false) return false;
-	if (newUsedExports.length > moduleUsedExports.size) return false;
-	return newUsedExports.every(item => moduleUsedExports.has(item));
-};
 
 class FlagDependencyUsagePlugin {
 	/**
@@ -51,79 +34,62 @@ class FlagDependencyUsagePlugin {
 					 * @returns {void}
 					 */
 					const processModule = (module, usedExports) => {
-						let ue = moduleGraph.getUsedExports(module);
-						if (ue === true) return;
+						const exportsInfo = moduleGraph.getExportsInfo(module);
+						let changed = false;
 						if (usedExports === true) {
-							moduleGraph.setUsedExports(module, (ue = true));
-						} else if (Array.isArray(usedExports)) {
-							if (!ue) {
-								moduleGraph.setUsedExports(
-									module,
-									(ue = new SortableSet(usedExports))
-								);
-							} else {
-								const old = ue ? ue.size : -1;
-								for (const exportName of usedExports) {
-									ue.add(exportName);
-								}
-								if (ue.size === old) {
-									return;
+							changed = exportsInfo.setUsedInUnknownWay();
+						} else if (usedExports) {
+							for (const exportName of usedExports) {
+								const exportInfo = exportsInfo.getExportInfo(exportName);
+								if (exportInfo.used !== true) {
+									exportInfo.used = true;
+									changed = true;
 								}
 							}
 						} else {
-							if (ue !== false) return;
-							moduleGraph.setUsedExports(module, (ue = new SortableSet()));
+							// for a module without side effects we stop tracking usage here when no export is used
+							// This module won't be evaluated in this case
+							if (module.factoryMeta.sideEffectFree) return;
+							changed = exportsInfo.setUsedForSideEffectsOnly();
 						}
 
-						// for a module without side effects we stop tracking usage here when no export is used
-						// This module won't be evaluated in this case
-						if (module.factoryMeta.sideEffectFree) {
-							if (ue !== true && ue.size === 0) return;
+						if (changed) {
+							queue.enqueue(module);
 						}
-
-						queue.push([module, module, ue]);
 					};
 
 					/**
-					 * @param {Module} module the module
 					 * @param {DependenciesBlock} depBlock the dependencies block
-					 * @param {UsedExports} usedExports the used exports
 					 * @returns {void}
 					 */
-					const processDependenciesBlock = (module, depBlock, usedExports) => {
+					const processDependenciesBlock = depBlock => {
 						for (const dep of depBlock.dependencies) {
-							processDependency(module, dep);
+							processDependency(dep);
 						}
 						for (const block of depBlock.blocks) {
-							queue.push([module, block, usedExports]);
+							queue.enqueue(block);
 						}
 					};
 
 					/**
-					 * @param {Module} module the module
 					 * @param {Dependency} dep the dependency
 					 * @returns {void}
 					 */
-					const processDependency = (module, dep) => {
+					const processDependency = dep => {
 						const reference = compilation.getDependencyReference(dep);
 						if (!reference) return;
 						const referenceModule = reference.module;
 						const importedNames = reference.importedNames;
-						const oldUsedExports = moduleGraph.getUsedExports(referenceModule);
-						if (
-							!oldUsedExports ||
-							!isContained(oldUsedExports, importedNames)
-						) {
-							processModule(referenceModule, importedNames);
-						}
+						processModule(referenceModule, importedNames);
 					};
 
 					for (const module of modules) {
-						moduleGraph.setUsedExports(module, false);
+						moduleGraph.getExportsInfo(module).setHasUseInfo();
 					}
 
-					/** @type {[Module, DependenciesBlock, UsedExports][]} */
-					const queue = [];
+					/** @type {Queue<DependenciesBlock>} */
+					const queue = new Queue();
+
 					for (const deps of compilation.entryDependencies.values()) {
 						for (const dep of deps) {
 							const module = moduleGraph.getModule(dep);
@@ -134,8 +100,8 @@ class FlagDependencyUsagePlugin {
 					}
 
 					while (queue.length) {
-						const queueItem = queue.pop();
-						processDependenciesBlock(queueItem[0], queueItem[1], queueItem[2]);
+						const depBlock = queue.dequeue();
+						processDependenciesBlock(depBlock);
 					}
 				}
 			);

--- a/lib/FlagDependencyUsagePlugin.js
+++ b/lib/FlagDependencyUsagePlugin.js
@@ -105,7 +105,7 @@ class FlagDependencyUsagePlugin {
 					 * @returns {void}
 					 */
 					const processDependency = (module, dep) => {
-						const reference = compilation.getDependencyReference(module, dep);
+						const reference = compilation.getDependencyReference(dep);
 						if (!reference) return;
 						const referenceModule = reference.module;
 						const importedNames = reference.importedNames;

--- a/lib/FlagInitialModulesAsUsedPlugin.js
+++ b/lib/FlagInitialModulesAsUsedPlugin.js
@@ -30,7 +30,7 @@ class FlagInitialModulesAsUsedPlugin {
 								return;
 							}
 							for (const module of chunkGraph.getChunkModulesIterable(chunk)) {
-								moduleGraph.setUsedExports(module, true);
+								moduleGraph.getExportsInfo(module).setUsedInUnknownWay();
 								moduleGraph.addExtraReason(module, this.explanation);
 							}
 						}

--- a/lib/FunctionModuleTemplatePlugin.js
+++ b/lib/FunctionModuleTemplatePlugin.js
@@ -84,14 +84,12 @@ class FunctionModuleTemplatePlugin {
 					source.add("  !*** " + reqStr + " ***!\n");
 					source.add("  \\****" + reqStrStar + "****/\n");
 					const exportsInfo = moduleGraph.getExportsInfo(module);
-					for (const exportInfo of exportsInfo.exports) {
+					for (const exportInfo of exportsInfo.orderedExports) {
 						source.add(
 							Template.toComment(
 								`export ${
-									exportInfo.usedName === exportInfo.name
-										? `${exportInfo.name} (renamed to ${exportInfo.usedName})`
-										: exportInfo.name
-								} [${exportInfo.getProvidedInfo()}] [${exportInfo.getUsedInfo()}] [${exportInfo.getCanMangleInfo()}]`
+									exportInfo.name
+								} [${exportInfo.getProvidedInfo()}] [${exportInfo.getUsedInfo()}] [${exportInfo.getRenameInfo()}]`
 							) + "\n"
 						);
 					}

--- a/lib/FunctionModuleTemplatePlugin.js
+++ b/lib/FunctionModuleTemplatePlugin.js
@@ -83,19 +83,28 @@ class FunctionModuleTemplatePlugin {
 					source.add("/*!****" + reqStrStar + "****!*\\\n");
 					source.add("  !*** " + reqStr + " ***!\n");
 					source.add("  \\****" + reqStrStar + "****/\n");
-					const providedExports = moduleGraph.getProvidedExports(module);
-					if (Array.isArray(providedExports)) {
-						if (providedExports.length === 0) {
-							source.add(Template.toComment("no exports provided") + "\n");
-						} else {
-							source.add(
-								Template.toComment(
-									"exports provided: " + providedExports.join(", ")
-								) + "\n"
-							);
-						}
-					} else if (providedExports) {
-						source.add(Template.toComment("no static exports found") + "\n");
+					const exportsInfo = moduleGraph.getExportsInfo(module);
+					for (const exportInfo of exportsInfo.exports) {
+						source.add(
+							Template.toComment(
+								`export ${
+									exportInfo.usedName === exportInfo.name
+										? `${exportInfo.name} (renamed to ${exportInfo.usedName})`
+										: exportInfo.name
+								} [${exportInfo.getProvidedInfo()}] [${exportInfo.getUsedInfo()}] [${exportInfo.getCanMangleInfo()}]`
+							) + "\n"
+						);
+					}
+					const otherExportsInfo = exportsInfo.otherExportsInfo;
+					if (
+						otherExportsInfo.provided !== false ||
+						otherExportsInfo.used !== false
+					) {
+						source.add(
+							Template.toComment(
+								`other exports [${otherExportsInfo.getProvidedInfo()}] [${otherExportsInfo.getUsedInfo()}]`
+							) + "\n"
+						);
 					}
 					source.add(
 						Template.toComment(
@@ -104,22 +113,6 @@ class FunctionModuleTemplatePlugin {
 							)}`
 						) + "\n"
 					);
-					const usedExports = moduleGraph.getUsedExports(module);
-					if (usedExports === true) {
-						source.add(Template.toComment("all exports used") + "\n");
-					} else if (usedExports === false) {
-						source.add(Template.toComment("module unused") + "\n");
-					} else if (usedExports) {
-						if (usedExports.size === 0) {
-							source.add(Template.toComment("no exports used") + "\n");
-						} else {
-							source.add(
-								Template.toComment(
-									"exports used: " + joinIterableWithComma(usedExports)
-								) + "\n"
-							);
-						}
-					}
 					const optimizationBailout = moduleGraph.getOptimizationBailout(
 						module
 					);

--- a/lib/LibManifestPlugin.js
+++ b/lib/LibManifestPlugin.js
@@ -71,9 +71,8 @@ class LibManifestPlugin {
 										associatedObjectForCache: compiler.root
 									});
 									if (ident) {
-										const providedExports = moduleGraph.getProvidedExports(
-											module
-										);
+										const exportsInfo = moduleGraph.getExportsInfo(module);
+										const providedExports = exportsInfo.getProvidedExports();
 										/** @type {ManifestModuleData} */
 										const data = {
 											id: chunkGraph.getModuleId(module),

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -432,7 +432,7 @@ class Module extends DependenciesBlock {
 		if (!usedExports.has(exportName)) return false;
 
 		// Mangle export name if possible
-		if (moduleGraph.isExportProvided(this, exportName)) {
+		if (moduleGraph.getExportInfo(this, exportName).canMangle) {
 			if (this.buildMeta.exportsType === "namespace") {
 				const idx = usedExports
 					.getFromUnorderedCache(getIndexMap)

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -218,13 +218,6 @@ class Module extends DependenciesBlock {
 		).getUsedExports(this);
 	}
 
-	set usedExports(value) {
-		ModuleGraph.getModuleGraphForModule(
-			this,
-			"Module.usedExports"
-		).setUsedExports(this, value);
-	}
-
 	get optimizationBailout() {
 		return ModuleGraph.getModuleGraphForModule(
 			this,
@@ -403,7 +396,7 @@ class Module extends DependenciesBlock {
 	 * @returns {boolean} true, if the module is used
 	 */
 	isModuleUsed(moduleGraph) {
-		return moduleGraph.getUsedExports(this) !== false;
+		return moduleGraph.getExportsInfo(this).isUsed() !== false;
 	}
 
 	/**
@@ -412,10 +405,8 @@ class Module extends DependenciesBlock {
 	 * @returns {boolean} true, if the export is used
 	 */
 	isExportUsed(moduleGraph, exportName) {
-		const usedExports = moduleGraph.getUsedExports(this);
-		if (usedExports === null || usedExports === true) return true;
-		if (usedExports === false) return false;
-		return usedExports.has(exportName);
+		const exportInfo = moduleGraph.getExportInfo(this, exportName);
+		return exportInfo.used !== false;
 	}
 
 	// TODO move to ModuleGraph

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -394,7 +394,7 @@ class Module extends DependenciesBlock {
 	 * @returns {boolean} true, if the export is used
 	 */
 	isExportUsed(moduleGraph, exportName) {
-		const exportInfo = moduleGraph.getExportInfo(this, exportName);
+		const exportInfo = moduleGraph.getReadOnlyExportInfo(this, exportName);
 		return exportInfo.used !== false;
 	}
 
@@ -406,7 +406,7 @@ class Module extends DependenciesBlock {
 	 *                           string, the mangled export name when used.
 	 */
 	getUsedName(moduleGraph, exportName) {
-		return moduleGraph.getReadOnlyExportInfo(this, exportName).getUsedName();
+		return moduleGraph.getExportInfo(this, exportName).getUsedName();
 	}
 
 	/**

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -8,7 +8,6 @@
 const ChunkGraph = require("./ChunkGraph");
 const DependenciesBlock = require("./DependenciesBlock");
 const ModuleGraph = require("./ModuleGraph");
-const Template = require("./Template");
 const { compareChunksById } = require("./util/comparators");
 const makeSerializable = require("./util/makeSerializable");
 
@@ -55,16 +54,6 @@ const makeSerializable = require("./util/makeSerializable");
 const EMPTY_RESOLVE_OPTIONS = {};
 
 let debugId = 1000;
-
-const getIndexMap = set => {
-	set.sort();
-	const map = new Map();
-	let idx = 0;
-	for (const item of set) {
-		map.set(item, idx++);
-	}
-	return map;
-};
 
 const getJoinedString = set => {
 	set.sort();
@@ -417,30 +406,7 @@ class Module extends DependenciesBlock {
 	 *                           string, the mangled export name when used.
 	 */
 	getUsedName(moduleGraph, exportName) {
-		const usedExports = moduleGraph.getUsedExports(this);
-		if (usedExports === null || usedExports === true) return exportName;
-		if (usedExports === false) return false;
-		if (!usedExports.has(exportName)) return false;
-
-		// Mangle export name if possible
-		if (moduleGraph.getExportInfo(this, exportName).canMangle) {
-			if (this.buildMeta.exportsType === "namespace") {
-				const idx = usedExports
-					.getFromUnorderedCache(getIndexMap)
-					.get(exportName);
-				return Template.numberToIdentifer(idx);
-			}
-			if (
-				this.buildMeta.exportsType === "named" &&
-				!usedExports.has("default")
-			) {
-				const idx = usedExports
-					.getFromUnorderedCache(getIndexMap)
-					.get(exportName);
-				return Template.numberToIdentifer(idx);
-			}
-		}
-		return exportName;
+		return moduleGraph.getReadOnlyExportInfo(this, exportName).getUsedName();
 	}
 
 	/**

--- a/lib/ModuleGraph.js
+++ b/lib/ModuleGraph.js
@@ -7,13 +7,13 @@
 
 const util = require("util");
 const ModuleGraphConnection = require("./ModuleGraphConnection");
+const SortableSet = require("./util/SortableSet");
 
 /** @typedef {import("./DependenciesBlock")} DependenciesBlock */
 /** @typedef {import("./Dependency")} Dependency */
 /** @typedef {import("./Module")} Module */
 /** @typedef {import("./ModuleProfile")} ModuleProfile */
 /** @typedef {import("./RequestShortener")} RequestShortener */
-/** @template T @typedef {import("./util/SortableSet")<T>} SortableSet<T> */
 
 /**
  * @callback OptimizationBailoutFunction
@@ -26,6 +26,7 @@ class ExportsInfo {
 		/** @type {Map<string, ExportInfo>} */
 		this._exports = new Map();
 		this._otherExportsInfo = new ExportInfo(null);
+		this._sideEffectsOnlyInfo = new ExportInfo("*side effects only*");
 		this._exportsIsOrdered = false;
 	}
 
@@ -60,6 +61,20 @@ class ExportsInfo {
 		}
 		if (this._otherExportsInfo.canMangle === undefined) {
 			this._otherExportsInfo.canMangle = true;
+		}
+	}
+
+	setHasUseInfo() {
+		for (const exportInfo of this._exports.values()) {
+			if (exportInfo.used === undefined) {
+				exportInfo.used = false;
+			}
+		}
+		if (this._otherExportsInfo.used === undefined) {
+			this._otherExportsInfo.used = false;
+		}
+		if (this._sideEffectsOnlyInfo.used === undefined) {
+			this._sideEffectsOnlyInfo.used = false;
 		}
 	}
 
@@ -105,6 +120,90 @@ class ExportsInfo {
 			changed = true;
 		}
 		return changed;
+	}
+
+	setUsedInUnknownWay() {
+		let changed = false;
+		if (this._isUsed === false) {
+			this._isUsed = true;
+			changed = true;
+		}
+		for (const exportInfo of this._exports.values()) {
+			if (exportInfo.used !== true && exportInfo.used !== null) {
+				exportInfo.used = null;
+				changed = true;
+			}
+			if (exportInfo.canMangle !== false) {
+				exportInfo.canMangle = false;
+				changed = true;
+			}
+		}
+		if (
+			this._otherExportsInfo.used !== true &&
+			this._otherExportsInfo.used !== null
+		) {
+			this._otherExportsInfo.used = null;
+			changed = true;
+		}
+		if (this._otherExportsInfo.canMangle !== false) {
+			this._otherExportsInfo.canMangle = false;
+			changed = true;
+		}
+		return changed;
+	}
+
+	setUsedForSideEffectsOnly() {
+		if (this._sideEffectsOnlyInfo.used === false) {
+			this._sideEffectsOnlyInfo.used = true;
+			return true;
+		}
+		return false;
+	}
+
+	isUsed() {
+		if (this._otherExportsInfo.used !== false) {
+			return true;
+		}
+		if (this._sideEffectsOnlyInfo.used !== false) {
+			return true;
+		}
+		for (const exportInfo of this._exports.values()) {
+			if (exportInfo.used !== false) {
+				return true;
+			}
+		}
+	}
+
+	getUsedExports() {
+		switch (this._otherExportsInfo.used) {
+			case undefined:
+				return null;
+			case null:
+				return true;
+			case true:
+				return true;
+		}
+		const array = [];
+		if (!this._exportsIsOrdered) this._sortExports();
+		for (const exportInfo of this._exports.values()) {
+			switch (exportInfo.used) {
+				case undefined:
+					return null;
+				case null:
+					return true;
+				case true:
+					array.push(exportInfo.name);
+			}
+		}
+		if (array.length === 0) {
+			switch (this._sideEffectsOnlyInfo.used) {
+				case undefined:
+					return null;
+				case false:
+					return false;
+			}
+		}
+		return new SortableSet(array);
 	}
 
 	getProvidedExports() {
@@ -184,6 +283,14 @@ class ExportInfo {
 		/** @type {string} */
 		this.name = name;
 		/**
+		 * true: it is used
+		 * false: it is not used
+		 * null: only the runtime knows if it is used
+		 * undefined: it was not determined if it is used
+		 * @type {boolean | null | undefined}
+		 */
+		this.used = initFrom ? initFrom.used : undefined;
+		/**
 		 * true: it is provided
 		 * false: it is not provided
 		 * null: only the runtime knows if it is provided
@@ -201,7 +308,16 @@ class ExportInfo {
 	}
 
 	getUsedInfo() {
-		return "no usage info";
+		switch (this.used) {
+			case undefined:
+				return "no usage info";
+			case null:
+				return "maybe used (runtime-defined)";
+			case true:
+				return "used";
+			case false:
+				return "unused";
+		}
 	}
 
 	getProvidedInfo() {
@@ -241,8 +357,6 @@ class ModuleGraphModule {
 		this.optimizationBailout = [];
 		/** @type {ExportsInfo} */
 		this.exports = new ExportsInfo();
-		/** @type {false | true | SortableSet<string> | null} */
-		this.usedExports = null;
 		/** @type {number} */
 		this.preOrderIndex = null;
 		/** @type {number} */
@@ -390,7 +504,6 @@ class ModuleGraph {
 		newMgm.postOrderIndex = oldMgm.postOrderIndex;
 		newMgm.preOrderIndex = oldMgm.preOrderIndex;
 		newMgm.depth = oldMgm.depth;
-		newMgm.usedExports = oldMgm.usedExports;
 		// TODO optimize this
 		newMgm.exports.restoreProvided(oldMgm.exports.getRestoreProvidedData());
 	}
@@ -621,17 +734,7 @@ class ModuleGraph {
 	 */
 	getUsedExports(module) {
 		const mgm = this._getModuleGraphModule(module);
-		return mgm.usedExports;
-	}
-
-	/**
-	 * @param {Module} module the module
-	 * @param {false | true | SortableSet<string>} usedExports the used exports
-	 * @returns {void}
-	 */
-	setUsedExports(module, usedExports) {
-		const mgm = this._getModuleGraphModule(module);
-		mgm.usedExports = usedExports;
+		return mgm.exports.getUsedExports();
 	}
 
 	/**

--- a/lib/ModuleGraph.js
+++ b/lib/ModuleGraph.js
@@ -27,10 +27,36 @@ class ExportsInfo {
 		this._exports = new Map();
 		this._otherExportsInfo = new ExportInfo(null);
 		this._sideEffectsOnlyInfo = new ExportInfo("*side effects only*");
-		this._exportsIsOrdered = false;
+		this._exportsAreOrdered = false;
+	}
+
+	setTo(exportsInfo) {
+		this._otherExportsInfo = new ExportInfo(
+			null,
+			exportsInfo._otherExportsInfo
+		);
+		this._sideEffectsOnlyInfo = new ExportInfo(
+			"*side effects only*",
+			exportsInfo._sideEffectsOnlyInfo
+		);
+		this._exportsAreOrdered = exportsInfo._exportsAreOrdered;
+		this._exports.clear();
+		for (const exportInfo of exportsInfo.exports) {
+			this._exports.set(
+				exportInfo.name,
+				new ExportInfo(exportInfo.name, exportInfo)
+			);
+		}
 	}
 
 	get exports() {
+		return this._exports.values();
+	}
+
+	get orderedExports() {
+		if (!this._exportsAreOrdered) {
+			this._sortExports();
+		}
 		return this._exports.values();
 	}
 
@@ -44,7 +70,7 @@ class ExportsInfo {
 			newMap.set(name, this._exports.get(name));
 		}
 		this._exports = newMap;
-		this._exportsIsOrdered = true;
+		this._exportsAreOrdered = true;
 	}
 
 	setHasProvideInfo() {
@@ -52,15 +78,15 @@ class ExportsInfo {
 			if (exportInfo.provided === undefined) {
 				exportInfo.provided = false;
 			}
-			if (exportInfo.canMangle === undefined) {
-				exportInfo.canMangle = true;
+			if (exportInfo.canMangleProvide === undefined) {
+				exportInfo.canMangleProvide = true;
 			}
 		}
 		if (this._otherExportsInfo.provided === undefined) {
 			this._otherExportsInfo.provided = false;
 		}
-		if (this._otherExportsInfo.canMangle === undefined) {
-			this._otherExportsInfo.canMangle = true;
+		if (this._otherExportsInfo.canMangleProvide === undefined) {
+			this._otherExportsInfo.canMangleProvide = true;
 		}
 	}
 
@@ -69,9 +95,15 @@ class ExportsInfo {
 			if (exportInfo.used === undefined) {
 				exportInfo.used = false;
 			}
+			if (exportInfo.canMangleUse === undefined) {
+				exportInfo.canMangleUse = true;
+			}
 		}
 		if (this._otherExportsInfo.used === undefined) {
 			this._otherExportsInfo.used = false;
+		}
+		if (this._otherExportsInfo.canMangleUse === undefined) {
+			this._otherExportsInfo.canMangleUse = true;
 		}
 		if (this._sideEffectsOnlyInfo.used === undefined) {
 			this._sideEffectsOnlyInfo.used = false;
@@ -83,7 +115,7 @@ class ExportsInfo {
 		if (info !== undefined) return info;
 		const newInfo = new ExportInfo(name, this._otherExportsInfo);
 		this._exports.set(name, newInfo);
-		this._exportsIsOrdered = false;
+		this._exportsAreOrdered = false;
 		return newInfo;
 	}
 
@@ -103,8 +135,8 @@ class ExportsInfo {
 				exportInfo.provided = null;
 				changed = true;
 			}
-			if (exportInfo.canMangle !== false) {
-				exportInfo.canMangle = false;
+			if (exportInfo.canMangleProvide !== false) {
+				exportInfo.canMangleProvide = false;
 				changed = true;
 			}
 		}
@@ -115,8 +147,8 @@ class ExportsInfo {
 			this._otherExportsInfo.provided = null;
 			changed = true;
 		}
-		if (this._otherExportsInfo.canMangle !== false) {
-			this._otherExportsInfo.canMangle = false;
+		if (this._otherExportsInfo.canMangleProvide !== false) {
+			this._otherExportsInfo.canMangleProvide = false;
 			changed = true;
 		}
 		return changed;
@@ -133,8 +165,8 @@ class ExportsInfo {
 				exportInfo.used = null;
 				changed = true;
 			}
-			if (exportInfo.canMangle !== false) {
-				exportInfo.canMangle = false;
+			if (exportInfo.canMangleUse !== false) {
+				exportInfo.canMangleUse = false;
 				changed = true;
 			}
 		}
@@ -145,8 +177,39 @@ class ExportsInfo {
 			this._otherExportsInfo.used = null;
 			changed = true;
 		}
-		if (this._otherExportsInfo.canMangle !== false) {
-			this._otherExportsInfo.canMangle = false;
+		if (this._otherExportsInfo.canMangleUse !== false) {
+			this._otherExportsInfo.canMangleUse = false;
+			changed = true;
+		}
+		return changed;
+	}
+
+	setUsedAsNamedExportType() {
+		let changed = false;
+		if (this._isUsed === false) {
+			this._isUsed = true;
+			changed = true;
+		}
+		this.getExportInfo("default").used = true;
+		for (const exportInfo of this._exports.values()) {
+			if (exportInfo.used !== true && exportInfo.used !== null) {
+				exportInfo.used = null;
+				changed = true;
+			}
+			if (exportInfo.name !== "default" && exportInfo.canMangleUse !== false) {
+				exportInfo.canMangleUse = false;
+				changed = true;
+			}
+		}
+		if (
+			this._otherExportsInfo.used !== true &&
+			this._otherExportsInfo.used !== null
+		) {
+			this._otherExportsInfo.used = null;
+			changed = true;
+		}
+		if (this._otherExportsInfo.canMangleUse !== false) {
+			this._otherExportsInfo.canMangleUse = false;
 			changed = true;
 		}
 		return changed;
@@ -184,7 +247,7 @@ class ExportsInfo {
 				return true;
 		}
 		const array = [];
-		if (!this._exportsIsOrdered) this._sortExports();
+		if (!this._exportsAreOrdered) this._sortExports();
 		for (const exportInfo of this._exports.values()) {
 			switch (exportInfo.used) {
 				case undefined:
@@ -216,7 +279,7 @@ class ExportsInfo {
 				return true;
 		}
 		const array = [];
-		if (!this._exportsIsOrdered) this._sortExports();
+		if (!this._exportsAreOrdered) this._sortExports();
 		for (const exportInfo of this._exports.values()) {
 			switch (exportInfo.provided) {
 				case undefined:
@@ -238,38 +301,38 @@ class ExportsInfo {
 
 	getRestoreProvidedData() {
 		const otherProvided = this._otherExportsInfo.provided;
-		const otherCanMangle = this._otherExportsInfo.canMangle;
+		const otherCanMangleProvide = this._otherExportsInfo.canMangleProvide;
 		const exports = [];
 		for (const exportInfo of this._exports.values()) {
 			if (
 				exportInfo.provided !== otherProvided ||
-				exportInfo.canMangle !== otherCanMangle
+				exportInfo.canMangleProvide !== otherCanMangleProvide
 			) {
 				exports.push({
 					name: exportInfo.name,
 					provided: exportInfo.provided,
-					canMangle: exportInfo.canMangle
+					canMangleProvide: exportInfo.canMangleProvide
 				});
 			}
 		}
 		return {
 			exports,
 			otherProvided,
-			otherCanMangle
+			otherCanMangleProvide
 		};
 	}
 
-	restoreProvided({ otherProvided, otherCanMangle, exports }) {
+	restoreProvided({ otherProvided, otherCanMangleProvide, exports }) {
 		for (const exportInfo of this._exports.values()) {
 			exportInfo.provided = otherProvided;
-			exportInfo.canMangle = otherCanMangle;
+			exportInfo.canMangleProvide = otherCanMangleProvide;
 		}
 		this._otherExportsInfo.provided = otherProvided;
-		this._otherExportsInfo.canMangle = otherCanMangle;
+		this._otherExportsInfo.canMangleProvide = otherCanMangleProvide;
 		for (const exp of exports) {
 			const exportInfo = this.getExportInfo(exp.name);
 			exportInfo.provided = exp.provided;
-			exportInfo.canMangle = exp.canMangle;
+			exportInfo.canMangleProvide = exp.canMangleProvide;
 		}
 	}
 }
@@ -282,6 +345,8 @@ class ExportInfo {
 	constructor(name, initFrom) {
 		/** @type {string} */
 		this.name = name;
+		/** @type {string | null} */
+		this.usedName = initFrom ? initFrom.usedName : null;
 		/**
 		 * true: it is used
 		 * false: it is not used
@@ -304,7 +369,42 @@ class ExportInfo {
 		 * undefined: it was not determined if it can be mangled
 		 * @type {boolean | undefined}
 		 */
-		this.canMangle = initFrom ? initFrom.canMangle : undefined;
+		this.canMangleProvide = initFrom ? initFrom.canMangleProvide : undefined;
+		/**
+		 * true: it can be mangled
+		 * false: is can not be mangled
+		 * undefined: it was not determined if it can be mangled
+		 * @type {boolean | undefined}
+		 */
+		this.canMangleUse = initFrom ? initFrom.canMangleUse : undefined;
+	}
+
+	get canMangle() {
+		switch (this.canMangleProvide) {
+			case undefined:
+				return this.canMangleUse === false ? false : undefined;
+			case false:
+				return false;
+			case true:
+				switch (this.canMangleUse) {
+					case undefined:
+						return undefined;
+					case false:
+						return false;
+					case true:
+						return true;
+				}
+		}
+		throw new Error(
+			`Unexpected flags for canMangle ${this.canMangleProvide} ${
+				this.canMangleUse
+			}`
+		);
+	}
+
+	getUsedName() {
+		if (this.used === false) return false;
+		return this.usedName || this.name;
 	}
 
 	getUsedInfo() {
@@ -333,15 +433,48 @@ class ExportInfo {
 		}
 	}
 
-	getCanMangleInfo() {
-		switch (this.canMangle) {
+	getRenameInfo() {
+		switch (this.canMangleProvide) {
 			case undefined:
-				return "can not be renamed (no info)";
+				switch (this.canMangleUse) {
+					case undefined:
+						return "missing provision and use info prevents renaming";
+					case false:
+						return "usage prevents renaming (no provision info)";
+					case true:
+						return "missing provision info prevents renaming";
+				}
+				break;
 			case true:
-				return "can be renamed";
+				switch (this.canMangleUse) {
+					case undefined:
+						return "missing usage info prevents renaming";
+					case false:
+						return "usage prevents renaming";
+					case true:
+						if (this.usedName && this.usedName !== this.name) {
+							return `renamed to ${this.usedName}`;
+						} else {
+							return "can be renamed";
+						}
+				}
+				break;
 			case false:
-				return "can not be renamed";
+				switch (this.canMangleUse) {
+					case undefined:
+						return "provision prevents renaming (no use info)";
+					case false:
+						return "usage and provision prevents renaming";
+					case true:
+						return "provision prevents renaming";
+				}
+				break;
 		}
+		throw new Error(
+			`Unexpected flags for getRenameInfo ${this.canMangleProvide} ${
+				this.canMangleUse
+			}`
+		);
 	}
 }
 
@@ -504,8 +637,7 @@ class ModuleGraph {
 		newMgm.postOrderIndex = oldMgm.postOrderIndex;
 		newMgm.preOrderIndex = oldMgm.preOrderIndex;
 		newMgm.depth = oldMgm.depth;
-		// TODO optimize this
-		newMgm.exports.restoreProvided(oldMgm.exports.getRestoreProvidedData());
+		newMgm.exports = oldMgm.exports;
 	}
 
 	/**
@@ -721,6 +853,16 @@ class ModuleGraph {
 	getExportInfo(module, exportName) {
 		const mgm = this._getModuleGraphModule(module);
 		return mgm.exports.getExportInfo(exportName);
+	}
+
+	/**
+	 * @param {Module} module the module
+	 * @param {string} exportName the export
+	 * @returns {ExportInfo} info about the export (do not modify)
+	 */
+	getReadOnlyExportInfo(module, exportName) {
+		const mgm = this._getModuleGraphModule(module);
+		return mgm.exports.getReadOnlyExportInfo(exportName);
 	}
 
 	/**

--- a/lib/ModuleGraph.js
+++ b/lib/ModuleGraph.js
@@ -113,6 +113,8 @@ class ExportsInfo {
 	getExportInfo(name) {
 		const info = this._exports.get(name);
 		if (info !== undefined) return info;
+		if (!name)
+			throw new Error("ModuleGraph.getExportInfo name must be a valid string");
 		const newInfo = new ExportInfo(name, this._otherExportsInfo);
 		this._exports.set(name, newInfo);
 		this._exportsAreOrdered = false;

--- a/lib/ModuleGraph.js
+++ b/lib/ModuleGraph.js
@@ -21,6 +21,214 @@ const ModuleGraphConnection = require("./ModuleGraphConnection");
  * @returns {string}
  */
 
+class ExportsInfo {
+	constructor() {
+		/** @type {Map<string, ExportInfo>} */
+		this._exports = new Map();
+		this._otherExportsInfo = new ExportInfo(null);
+		this._exportsIsOrdered = false;
+	}
+
+	get exports() {
+		return this._exports.values();
+	}
+
+	get otherExportsInfo() {
+		return this._otherExportsInfo;
+	}
+
+	_sortExports() {
+		const newMap = new Map();
+		for (const name of Array.from(this._exports.keys()).sort()) {
+			newMap.set(name, this._exports.get(name));
+		}
+		this._exports = newMap;
+		this._exportsIsOrdered = true;
+	}
+
+	setHasProvideInfo() {
+		for (const exportInfo of this._exports.values()) {
+			if (exportInfo.provided === undefined) {
+				exportInfo.provided = false;
+			}
+			if (exportInfo.canMangle === undefined) {
+				exportInfo.canMangle = true;
+			}
+		}
+		if (this._otherExportsInfo.provided === undefined) {
+			this._otherExportsInfo.provided = false;
+		}
+		if (this._otherExportsInfo.canMangle === undefined) {
+			this._otherExportsInfo.canMangle = true;
+		}
+	}
+
+	getExportInfo(name) {
+		const info = this._exports.get(name);
+		if (info !== undefined) return info;
+		const newInfo = new ExportInfo(name, this._otherExportsInfo);
+		this._exports.set(name, newInfo);
+		this._exportsIsOrdered = false;
+		return newInfo;
+	}
+
+	getReadOnlyExportInfo(name) {
+		const info = this._exports.get(name);
+		if (info !== undefined) return info;
+		return this._otherExportsInfo;
+	}
+
+	/**
+	 * @returns {boolean} true, if this call changed something
+	 */
+	setUnknownExportsProvided() {
+		let changed = false;
+		for (const exportInfo of this._exports.values()) {
+			if (exportInfo.provided !== true && exportInfo.provided !== null) {
+				exportInfo.provided = null;
+				changed = true;
+			}
+			if (exportInfo.canMangle !== false) {
+				exportInfo.canMangle = false;
+				changed = true;
+			}
+		}
+		if (
+			this._otherExportsInfo.provided !== true &&
+			this._otherExportsInfo.provided !== null
+		) {
+			this._otherExportsInfo.provided = null;
+			changed = true;
+		}
+		if (this._otherExportsInfo.canMangle !== false) {
+			this._otherExportsInfo.canMangle = false;
+			changed = true;
+		}
+		return changed;
+	}
+
+	getProvidedExports() {
+		switch (this._otherExportsInfo.provided) {
+			case undefined:
+				return null;
+			case null:
+				return true;
+			case true:
+				return true;
+		}
+		const array = [];
+		if (!this._exportsIsOrdered) this._sortExports();
+		for (const exportInfo of this._exports.values()) {
+			switch (exportInfo.provided) {
+				case undefined:
+					return null;
+				case null:
+					return true;
+				case true:
+					array.push(exportInfo.name);
+			}
+		}
+		return array;
+	}
+
+	isExportProvided(name) {
+		let info = this._exports.get(name);
+		if (info === undefined) info = this._otherExportsInfo;
+		return info.provided;
+	}
+
+	getRestoreProvidedData() {
+		const otherProvided = this._otherExportsInfo.provided;
+		const otherCanMangle = this._otherExportsInfo.canMangle;
+		const exports = [];
+		for (const exportInfo of this._exports.values()) {
+			if (
+				exportInfo.provided !== otherProvided ||
+				exportInfo.canMangle !== otherCanMangle
+			) {
+				exports.push({
+					name: exportInfo.name,
+					provided: exportInfo.provided,
+					canMangle: exportInfo.canMangle
+				});
+			}
+		}
+		return {
+			exports,
+			otherProvided,
+			otherCanMangle
+		};
+	}
+
+	restoreProvided({ otherProvided, otherCanMangle, exports }) {
+		for (const exportInfo of this._exports.values()) {
+			exportInfo.provided = otherProvided;
+			exportInfo.canMangle = otherCanMangle;
+		}
+		this._otherExportsInfo.provided = otherProvided;
+		this._otherExportsInfo.canMangle = otherCanMangle;
+		for (const exp of exports) {
+			const exportInfo = this.getExportInfo(exp.name);
+			exportInfo.provided = exp.provided;
+			exportInfo.canMangle = exp.canMangle;
+		}
+	}
+}
+
+class ExportInfo {
+	/**
+	 * @param {string} name the original name of the export
+	 * @param {ExportInfo=} initFrom init values from this ExportInfo
+	 */
+	constructor(name, initFrom) {
+		/** @type {string} */
+		this.name = name;
+		/**
+		 * true: it is provided
+		 * false: it is not provided
+		 * null: only the runtime knows if it is provided
+		 * undefined: it was not determined if it is provided
+		 * @type {boolean | null | undefined}
+		 */
+		this.provided = initFrom ? initFrom.provided : undefined;
+		/**
+		 * true: it can be mangled
+		 * false: is can not be mangled
+		 * undefined: it was not determined if it can be mangled
+		 * @type {boolean | undefined}
+		 */
+		this.canMangle = initFrom ? initFrom.canMangle : undefined;
+	}
+
+	getUsedInfo() {
+		return "no usage info";
+	}
+
+	getProvidedInfo() {
+		switch (this.provided) {
+			case undefined:
+				return "no provided info";
+			case null:
+				return "maybe provided (runtime-defined)";
+			case true:
+				return "provided";
+			case false:
+				return "not provided";
+		}
+	}
+
+	getCanMangleInfo() {
+		switch (this.canMangle) {
+			case undefined:
+				return "can not be renamed (no info)";
+			case true:
+				return "can be renamed";
+			case false:
+				return "can not be renamed";
+		}
+	}
+}
+
 class ModuleGraphModule {
 	constructor() {
 		/** @type {Set<ModuleGraphConnection>} */
@@ -31,10 +239,10 @@ class ModuleGraphModule {
 		this.issuer = undefined;
 		/** @type {(string | OptimizationBailoutFunction)[]} */
 		this.optimizationBailout = [];
+		/** @type {ExportsInfo} */
+		this.exports = new ExportsInfo();
 		/** @type {false | true | SortableSet<string> | null} */
 		this.usedExports = null;
-		/** @type {true | string[] | null} */
-		this.providedExports = null;
 		/** @type {number} */
 		this.preOrderIndex = null;
 		/** @type {number} */
@@ -183,7 +391,8 @@ class ModuleGraph {
 		newMgm.preOrderIndex = oldMgm.preOrderIndex;
 		newMgm.depth = oldMgm.depth;
 		newMgm.usedExports = oldMgm.usedExports;
-		newMgm.providedExports = oldMgm.providedExports;
+		// TODO optimize this
+		newMgm.exports.restoreProvided(oldMgm.exports.getRestoreProvidedData());
 	}
 
 	/**
@@ -366,33 +575,39 @@ class ModuleGraph {
 	 */
 	getProvidedExports(module) {
 		const mgm = this._getModuleGraphModule(module);
-		return mgm.providedExports;
-	}
-
-	/**
-	 * @param {Module} module the module
-	 * @param {true | string[] | null} providedExports the provided exports
-	 * @returns {void}
-	 */
-	setProvidedExports(module, providedExports) {
-		const mgm = this._getModuleGraphModule(module);
-		mgm.providedExports = providedExports;
+		return mgm.exports.getProvidedExports();
 	}
 
 	/**
 	 * @param {Module} module the module
 	 * @param {string} exportName a name of an export
-	 * @returns {boolean | null} true, if the export is provided why the module.
+	 * @returns {boolean | null} true, if the export is provided by the module.
 	 *                           null, if it's unknown.
 	 *                           false, if it's not provided.
 	 */
 	isExportProvided(module, exportName) {
 		const mgm = this._getModuleGraphModule(module);
-		if (Array.isArray(mgm.providedExports)) {
-			return mgm.providedExports.includes(exportName);
-		} else {
-			return null;
-		}
+		const result = mgm.exports.isExportProvided(exportName);
+		return result === undefined ? null : result;
+	}
+
+	/**
+	 * @param {Module} module the module
+	 * @returns {ExportsInfo} info about the exports
+	 */
+	getExportsInfo(module) {
+		const mgm = this._getModuleGraphModule(module);
+		return mgm.exports;
+	}
+
+	/**
+	 * @param {Module} module the module
+	 * @param {string} exportName the export
+	 * @returns {ExportInfo} info about the export
+	 */
+	getExportInfo(module, exportName) {
+		const mgm = this._getModuleGraphModule(module);
+		return mgm.exports.getExportInfo(exportName);
 	}
 
 	/**

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -63,6 +63,7 @@ const FlagDependencyUsagePlugin = require("./FlagDependencyUsagePlugin");
 const NoEmitOnErrorsPlugin = require("./NoEmitOnErrorsPlugin");
 const EnsureChunkConditionsPlugin = require("./optimize/EnsureChunkConditionsPlugin");
 const FlagIncludedChunksPlugin = require("./optimize/FlagIncludedChunksPlugin");
+const MangleExportsPlugin = require("./optimize/MangleExportsPlugin");
 const MergeDuplicateChunksPlugin = require("./optimize/MergeDuplicateChunksPlugin");
 const ModuleConcatenationPlugin = require("./optimize/ModuleConcatenationPlugin");
 const RemoveEmptyChunksPlugin = require("./optimize/RemoveEmptyChunksPlugin");
@@ -368,6 +369,9 @@ class WebpackOptionsApply extends OptionsApply {
 		}
 		if (options.optimization.usedExports) {
 			new FlagDependencyUsagePlugin().apply(compiler);
+		}
+		if (options.optimization.mangleExports) {
+			new MangleExportsPlugin().apply(compiler);
 		}
 		if (options.optimization.concatenateModules) {
 			new ModuleConcatenationPlugin().apply(compiler);

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -269,6 +269,9 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("optimization.usedExports", "make", options =>
 			isProductionLikeMode(options)
 		);
+		this.set("optimization.mangleExports", "make", options =>
+			isProductionLikeMode(options)
+		);
 		this.set("optimization.concatenateModules", "make", options =>
 			isProductionLikeMode(options)
 		);

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -9,6 +9,7 @@ const HarmonyLinkingError = require("../HarmonyLinkingError");
 const InitFragment = require("../InitFragment");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
+const { intersect } = require("../util/SetHelpers");
 const makeSerializable = require("../util/makeSerializable");
 const DependencyReference = require("./DependencyReference");
 const HarmonyImportDependency = require("./HarmonyImportDependency");
@@ -23,10 +24,13 @@ const HarmonyImportDependency = require("./HarmonyImportDependency");
 /** @typedef {import("../WebpackError")} WebpackError */
 /** @typedef {import("../util/createHash").Hash} Hash */
 
-/** @typedef {"missing"|"unused"|"empty-star"|"reexport-non-harmony-default"|"reexport-named-default"|"reexport-namespace-object"|"reexport-non-harmony-default-strict"|"reexport-fake-namespace-object"|"rexport-non-harmony-undefined"|"safe-reexport"|"checked-reexport"|"dynamic-reexport"} ExportModeType */
+/** @typedef {"missing"|"unused"|"empty-star"|"reexport-non-harmony-default"|"reexport-named-default"|"reexport-namespace-object"|"reexport-non-harmony-default-strict"|"reexport-fake-namespace-object"|"rexport-non-harmony-undefined"|"normal-reexport"|"dynamic-reexport"} ExportModeType */
 
 /** @type {Map<string, string>} */
 const EMPTY_MAP = new Map();
+
+/** @type {Set<string>} */
+const EMPTY_SET = new Set();
 
 class ExportMode {
 	/**
@@ -39,6 +43,10 @@ class ExportMode {
 		this.name = null;
 		/** @type {Map<string, string>} */
 		this.map = EMPTY_MAP;
+		/** @type {Set<string>|null} */
+		this.ignored = null;
+		/** @type {Set<string>|null} */
+		this.checked = null;
 		/** @type {null | function(): Module} */
 		this.getModule = null;
 		/** @type {string|null} */
@@ -46,9 +54,16 @@ class ExportMode {
 	}
 }
 
-const EMPTY_STAR_MODE = new ExportMode("empty-star");
-
 class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
+	/**
+	 * @param {string} request the request string
+	 * @param {number} sourceOrder the order in the original source file
+	 * @param {string | null} id the requested export name of the imported module
+	 * @param {string | null} name the export name of for this module
+	 * @param {Set<string>} activeExports other named exports in the module
+	 * @param {Iterable<Dependency>} otherStarExports other star exports in the module
+	 * @param {boolean} strictExportPresence when true, missing exports in the imported module lead to errors instead of warnings
+	 */
 	constructor(
 		request,
 		sourceOrder,
@@ -80,8 +95,6 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 		const name = this.name;
 		const id = this.id;
 		const parentModule = moduleGraph.getParentModule(this);
-		const used = parentModule.getUsedName(moduleGraph, name);
-		const usedExports = moduleGraph.getUsedExports(parentModule);
 		const importedModule = moduleGraph.getModule(this);
 
 		if (!importedModule) {
@@ -92,7 +105,12 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 			return mode;
 		}
 
-		if (!ignoreUnused && (name ? !used : usedExports === false)) {
+		if (
+			!ignoreUnused &&
+			(name
+				? parentModule.isExportUsed(moduleGraph, name) === false
+				: parentModule.isModuleUsed(moduleGraph) === false)
+		) {
 			const mode = new ExportMode("unused");
 
 			mode.name = name || "*";
@@ -102,6 +120,8 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 
 		const strictHarmonyModule = parentModule.buildMeta.strictHarmonyModule;
 
+		// Special handling for reexporting the default export
+		// from non-harmony modules
 		if (name && id === "default" && importedModule.buildMeta) {
 			if (!importedModule.buildMeta.exportsType) {
 				const mode = new ExportMode(
@@ -127,6 +147,7 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 		const isNotAHarmonyModule =
 			importedModule.buildMeta && !importedModule.buildMeta.exportsType;
 
+		// reexporting with a fixed name
 		if (name) {
 			let mode;
 
@@ -136,8 +157,9 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 					mode = new ExportMode("rexport-non-harmony-undefined");
 					mode.name = name;
 				} else {
-					mode = new ExportMode("safe-reexport");
+					mode = new ExportMode("normal-reexport");
 					mode.map = new Map([[name, id]]);
+					mode.checked = EMPTY_SET;
 				}
 			} else {
 				// export { * as name }
@@ -155,107 +177,93 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 			return mode;
 		}
 
-		const activeFromOtherStarExports = this._discoverActiveExportsFromOtherStartExports(
-			moduleGraph
-		);
+		// Star reexporting
 
-		const providedExports = moduleGraph.getProvidedExports(importedModule);
+		const exportsInfo = moduleGraph.getExportsInfo(parentModule);
+		const importedExportsInfo = moduleGraph.getExportsInfo(importedModule);
 
-		// export *
-		if (usedExports && usedExports !== true) {
-			// reexport * with known used exports
-			if (Array.isArray(providedExports)) {
-				const map = new Map(
-					Array.from(usedExports)
-						.filter(id => {
-							if (id === "default") return false;
-							if (this.activeExports.has(id)) return false;
-							if (activeFromOtherStarExports.has(id)) return false;
-							if (!providedExports.includes(id)) return false;
+		const noExtraExports =
+			importedExportsInfo.otherExportsInfo.provided === false;
+		const noExtraImports = exportsInfo.otherExportsInfo.used === false;
 
-							return true;
-						})
-						.map(item => {
-							/** @type {[string, string]} */
-							const tuple = [item, item];
+		const ignoredExports = new Set([
+			"default",
+			...this.activeExports,
+			...this._discoverActiveExportsFromOtherStarExports(moduleGraph)
+		]);
 
-							return tuple;
-						})
-				);
+		if (!noExtraExports && !noExtraImports) {
+			// We have to few info about the modules
+			// Delegate the logic to the runtime code
 
-				if (map.size === 0) {
-					return EMPTY_STAR_MODE;
+			const mode = new ExportMode("dynamic-reexport");
+			mode.ignored = ignoredExports;
+
+			mode.getModule = () => moduleGraph.getModule(this);
+
+			return mode;
+		}
+
+		/** @type {Set<string>|false} */
+		const exports = noExtraExports && new Set();
+		/** @type {Set<string>|false} */
+		const imports = noExtraImports && new Set();
+		/** @type {Set<string>} */
+		let checked;
+
+		if (noExtraImports) {
+			for (const exportInfo of exportsInfo.exports) {
+				if (ignoredExports.has(exportInfo.name)) continue;
+				if (exportInfo.used !== false) {
+					imports.add(exportInfo.name);
 				}
-
-				const mode = new ExportMode("safe-reexport");
-
-				mode.getModule = () => moduleGraph.getModule(this);
-				mode.map = map;
-
-				return mode;
 			}
+		}
 
-			const map = new Map(
-				Array.from(usedExports)
-					.filter(id => {
-						if (id === "default") return false;
-						if (this.activeExports.has(id)) return false;
-						if (activeFromOtherStarExports.has(id)) return false;
-
-						return true;
-					})
-					.map(item => {
-						/** @type {[string, string]} */
-						const tuple = [item, item];
-
-						return tuple;
-					})
-			);
-
-			if (map.size === 0) {
-				return EMPTY_STAR_MODE;
+		if (noExtraExports) {
+			checked = new Set();
+			for (const exportInfo of importedExportsInfo.exports) {
+				if (ignoredExports.has(exportInfo.name)) continue;
+				switch (exportInfo.provided) {
+					case true:
+						exports.add(exportInfo.name);
+						break;
+					case false:
+						break;
+					default: {
+						const name = exportInfo.name;
+						checked.add(name);
+						exports.add(name);
+						break;
+					}
+				}
 			}
+		} else {
+			checked = imports;
+		}
 
-			const mode = new ExportMode("checked-reexport");
+		const merged =
+			exports && imports ? intersect([exports, imports]) : exports || imports;
+
+		if (merged.size === 0) {
+			const mode = new ExportMode("empty-star");
 
 			mode.getModule = () => moduleGraph.getModule(this);
-			mode.map = map;
 
 			return mode;
 		}
 
-		if (Array.isArray(providedExports)) {
-			const map = new Map(
-				providedExports
-					.filter(id => {
-						if (id === "default") return false;
-						if (this.activeExports.has(id)) return false;
-						if (activeFromOtherStarExports.has(id)) return false;
-
-						return true;
-					})
-					.map(item => {
-						/** @type {[string, string]} */
-						const tuple = [item, item];
-						return tuple;
-					})
-			);
-
-			if (map.size === 0) {
-				return EMPTY_STAR_MODE;
-			}
-
-			const mode = new ExportMode("safe-reexport");
-
-			mode.getModule = () => moduleGraph.getModule(this);
-			mode.map = map;
-
-			return mode;
+		/** @type {Map<string, string>} */
+		const map = new Map();
+		for (const exportName of merged) {
+			map.set(exportName, exportName);
 		}
 
-		const mode = new ExportMode("dynamic-reexport");
+		const mode = new ExportMode("normal-reexport");
 
 		mode.getModule = () => moduleGraph.getModule(this);
+		mode.map = map;
+		mode.checked = checked;
 
 		return mode;
 	}
@@ -294,8 +302,7 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 					this.sourceOrder
 				);
 
-			case "safe-reexport":
-			case "checked-reexport":
+			case "normal-reexport":
 				return new DependencyReference(
 					mode.getModule,
 					Array.from(mode.map.values()),
@@ -320,7 +327,7 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 	 * @param {ModuleGraph} moduleGraph the module graph
 	 * @returns {Set<string>} exported names
 	 */
-	_discoverActiveExportsFromOtherStartExports(moduleGraph) {
+	_discoverActiveExportsFromOtherStarExports(moduleGraph) {
 		if (!this.otherStarExports) {
 			return new Set();
 		}
@@ -351,40 +358,41 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 	 * @returns {ExportsSpec | undefined} export names
 	 */
 	getExports(moduleGraph) {
-		if (this.name) {
-			return {
-				exports: [this.name],
-				dependencies: undefined
-			};
+		const mode = this.getMode(moduleGraph, true);
+
+		switch (mode.type) {
+			case "missing":
+				return undefined;
+			case "dynamic-reexport":
+				return {
+					exports: true,
+					// TODO: consider passing `ignored` from `dynamic-reexport`
+					dependencies: [mode.getModule()]
+				};
+			case "empty-star":
+				return {
+					exports: [],
+					dependencies: [mode.getModule()]
+				};
+			case "normal-reexport":
+				return {
+					exports: Array.from(mode.map.keys()),
+					dependencies: [mode.getModule()]
+				};
+			case "reexport-fake-namespace-object":
+			case "reexport-namespace-object":
+			case "reexport-non-harmony-default":
+			case "reexport-non-harmony-default-strict":
+			case "rexport-non-harmony-undefined":
+			case "reexport-named-default":
+				return {
+					exports: [mode.name],
+					dependencies: [mode.getModule()]
+				};
+
+			default:
+				throw new Error(`Unknown mode ${mode.type}`);
 		}
-
-		const importedModule = moduleGraph.getModule(this);
-
-		if (!importedModule) {
-			// no imported module available
-			return undefined;
-		}
-
-		const providedExports = moduleGraph.getProvidedExports(importedModule);
-
-		if (Array.isArray(providedExports)) {
-			return {
-				exports: providedExports.filter(id => id !== "default"),
-				dependencies: [importedModule]
-			};
-		}
-
-		if (providedExports) {
-			return {
-				exports: true,
-				dependencies: undefined
-			};
-		}
-
-		return {
-			exports: null,
-			dependencies: [importedModule]
-		};
 	}
 
 	/**
@@ -479,17 +487,20 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 	updateHash(hash, chunkGraph) {
 		super.updateHash(hash, chunkGraph);
 
-		const moduleGraph = chunkGraph.moduleGraph;
-		const importedModule = moduleGraph.getModule(this);
+		const mode = this.getMode(chunkGraph.moduleGraph);
 
-		if (importedModule) {
-			const usedExports = moduleGraph.getUsedExports(importedModule);
-			const providedExports = moduleGraph.getProvidedExports(importedModule);
-			const stringifiedUsedExports = JSON.stringify(usedExports);
-			const stringifiedProvidedExports = JSON.stringify(providedExports);
-
-			hash.update(stringifiedUsedExports + stringifiedProvidedExports);
+		hash.update(mode.type);
+		for (const [k, v] of mode.map) {
+			hash.update(k);
+			hash.update(v);
 		}
+		if (mode.ignored) {
+			hash.update("ignored");
+			for (const k of mode.ignored) {
+				hash.update(k);
+			}
+		}
+		hash.update(mode.name || "");
 	}
 
 	serialize(context) {
@@ -534,232 +545,214 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 	apply(dependency, source, templateContext) {
 		const dep = /** @type {HarmonyExportImportedSpecifierDependency} */ (dependency);
 
-		if (this.isUsed(dep, templateContext)) {
+		const mode = dep.getMode(templateContext.moduleGraph, false);
+
+		if (mode.type !== "unused" && mode.type !== "empty-star") {
 			super.apply(dependency, source, templateContext);
 
-			const exportFragment = this._getExportFragment(
+			this._addExportFragments(
+				templateContext.initFragments,
 				dep,
+				mode,
 				templateContext.module,
 				templateContext.moduleGraph,
 				templateContext.runtimeRequirements
 			);
-			templateContext.initFragments.push(exportFragment);
 		}
 	}
 
 	/**
-	 * @param {HarmonyExportImportedSpecifierDependency} dep the dependency
-	 * @param {DependencyTemplateContext} templateContext the template context
-	 * @returns {Boolean} true, if (any) export is used
-	 */
-	isUsed(dep, { moduleGraph, module }) {
-		if (dep.name) {
-			return module.isExportUsed(moduleGraph, dep.name);
-		} else {
-			const importedModule = moduleGraph.getModule(dep);
-			const activeFromOtherStarExports = dep._discoverActiveExportsFromOtherStartExports(
-				moduleGraph
-			);
-			const usedExports = moduleGraph.getUsedExports(module);
-
-			if (usedExports && usedExports !== true) {
-				// we know which exports are used
-				for (const id of usedExports) {
-					if (id === "default") continue;
-					if (dep.activeExports.has(id)) continue;
-					if (moduleGraph.isExportProvided(importedModule, id) === false)
-						continue;
-					if (activeFromOtherStarExports.has(id)) continue;
-
-					return true;
-				}
-
-				return false;
-			} else if (usedExports && importedModule) {
-				const providedExports = moduleGraph.getProvidedExports(importedModule);
-				if (Array.isArray(providedExports)) {
-					// not sure which exports are used, but we know which are provided
-					const unused = providedExports.every(id => {
-						if (id === "default") return true;
-						if (dep.activeExports.has(id)) return true;
-						if (activeFromOtherStarExports.has(id)) return true;
-
-						return false;
-					});
-
-					return !unused;
-				}
-			}
-
-			return true;
-		}
-	}
-
-	/**
+	 * @param {InitFragment[]} initFragments target array for init fragments
 	 * @param {HarmonyExportImportedSpecifierDependency} dep dependency
+	 * @param {ExportMode} mode the export mode
 	 * @param {Module} module the current module
 	 * @param {ModuleGraph} moduleGraph the module graph
 	 * @param {Set<string>} runtimeRequirements runtime requirements
-	 * @returns {InitFragment} the generated init fragment
+	 * @returns {void}
 	 */
-	_getExportFragment(dep, module, moduleGraph, runtimeRequirements) {
-		const mode = dep.getMode(moduleGraph, false);
+	_addExportFragments(
+		initFragments,
+		dep,
+		mode,
+		module,
+		moduleGraph,
+		runtimeRequirements
+	) {
 		const importedModule = moduleGraph.getModule(dep);
 		const importVar = dep.getImportVar(moduleGraph);
 
 		switch (mode.type) {
 			case "missing":
-				return new InitFragment(
-					"/* empty/unused harmony star reexport */\n",
-					InitFragment.STAGE_HARMONY_EXPORTS,
-					1
+				initFragments.push(
+					new InitFragment(
+						"/* empty/unused harmony star reexport */\n",
+						InitFragment.STAGE_HARMONY_EXPORTS,
+						1
+					)
 				);
+				break;
 
 			case "unused":
-				return new InitFragment(
-					`${Template.toNormalComment(
-						`unused harmony reexport ${mode.name}`
-					)}\n`,
-					InitFragment.STAGE_HARMONY_EXPORTS,
-					1
+				initFragments.push(
+					new InitFragment(
+						`${Template.toNormalComment(
+							`unused harmony reexport ${mode.name}`
+						)}\n`,
+						InitFragment.STAGE_HARMONY_EXPORTS,
+						1
+					)
 				);
-
-			case "reexport-non-harmony-default":
-				return new InitFragment(
-					"/* harmony reexport (default from non-harmony) */ " +
-						this.getReexportStatement(
-							module,
-							module.getUsedName(moduleGraph, mode.name),
-							importVar,
-							null,
-							runtimeRequirements
-						),
-					InitFragment.STAGE_HARMONY_EXPORTS,
-					1
-				);
-
-			case "reexport-named-default":
-				return new InitFragment(
-					"/* harmony reexport (default from named exports) */ " +
-						this.getReexportStatement(
-							module,
-							module.getUsedName(moduleGraph, mode.name),
-							importVar,
-							"",
-							runtimeRequirements
-						),
-					InitFragment.STAGE_HARMONY_EXPORTS,
-					1
-				);
-
-			case "reexport-fake-namespace-object":
-				return new InitFragment(
-					"/* harmony reexport (fake namespace object from non-harmony) */ " +
-						this.getReexportFakeNamespaceObjectStatement(
-							module,
-							module.getUsedName(moduleGraph, mode.name),
-							importVar,
-							runtimeRequirements
-						),
-					InitFragment.STAGE_HARMONY_EXPORTS,
-					1
-				);
-
-			case "rexport-non-harmony-undefined":
-				return new InitFragment(
-					"/* harmony reexport (non default export from non-harmony) */ " +
-						this.getReexportStatement(
-							module,
-							module.getUsedName(moduleGraph, mode.name),
-							"undefined",
-							"",
-							runtimeRequirements
-						),
-					InitFragment.STAGE_HARMONY_EXPORTS,
-					1
-				);
-
-			case "reexport-non-harmony-default-strict":
-				return new InitFragment(
-					"/* harmony reexport (default from non-harmony) */ " +
-						this.getReexportStatement(
-							module,
-							module.getUsedName(moduleGraph, mode.name),
-							importVar,
-							"",
-							runtimeRequirements
-						),
-					InitFragment.STAGE_HARMONY_EXPORTS,
-					1
-				);
-
-			case "reexport-namespace-object":
-				return new InitFragment(
-					"/* harmony reexport (module object) */ " +
-						this.getReexportStatement(
-							module,
-							module.getUsedName(moduleGraph, mode.name),
-							importVar,
-							"",
-							runtimeRequirements
-						),
-					InitFragment.STAGE_HARMONY_EXPORTS,
-					1
-				);
+				break;
 
 			case "empty-star":
-				return new InitFragment(
-					"/* empty/unused harmony star reexport */",
-					InitFragment.STAGE_HARMONY_EXPORTS,
-					1
+				initFragments.push(
+					new InitFragment(
+						"/* empty/unused harmony star reexport */\n",
+						InitFragment.STAGE_HARMONY_EXPORTS,
+						1
+					)
 				);
+				break;
 
-			case "safe-reexport":
-				return new InitFragment(
-					Array.from(mode.map.entries())
-						.map(item => {
-							return (
-								"/* harmony reexport (safe) */ " +
-								this.getReexportStatement(
-									module,
-									module.getUsedName(moduleGraph, item[0]),
-									importVar,
-									importedModule.getUsedName(moduleGraph, item[1]),
-									runtimeRequirements
-								)
-							);
-						})
-						.join(""),
-					InitFragment.STAGE_HARMONY_EXPORTS,
-					1
+			case "reexport-non-harmony-default":
+				initFragments.push(
+					new InitFragment(
+						"/* harmony reexport (default from non-harmony) */ " +
+							this.getReexportStatement(
+								module,
+								module.getUsedName(moduleGraph, mode.name),
+								importVar,
+								null,
+								runtimeRequirements
+							),
+						InitFragment.STAGE_HARMONY_EXPORTS,
+						1
+					)
 				);
+				break;
 
-			case "checked-reexport":
-				return new InitFragment(
-					Array.from(mode.map.entries())
-						.map(item => {
-							return (
+			case "reexport-named-default":
+				initFragments.push(
+					new InitFragment(
+						"/* harmony reexport (default from named exports) */ " +
+							this.getReexportStatement(
+								module,
+								module.getUsedName(moduleGraph, mode.name),
+								importVar,
+								"",
+								runtimeRequirements
+							),
+						InitFragment.STAGE_HARMONY_EXPORTS,
+						1
+					)
+				);
+				break;
+
+			case "reexport-fake-namespace-object":
+				initFragments.push(
+					new InitFragment(
+						"/* harmony reexport (fake namespace object from non-harmony) */ " +
+							this.getReexportFakeNamespaceObjectStatement(
+								module,
+								module.getUsedName(moduleGraph, mode.name),
+								importVar,
+								runtimeRequirements
+							),
+						InitFragment.STAGE_HARMONY_EXPORTS,
+						1
+					)
+				);
+				break;
+
+			case "rexport-non-harmony-undefined":
+				initFragments.push(
+					new InitFragment(
+						"/* harmony reexport (non default export from non-harmony) */ " +
+							this.getReexportStatement(
+								module,
+								module.getUsedName(moduleGraph, mode.name),
+								"undefined",
+								"",
+								runtimeRequirements
+							),
+						InitFragment.STAGE_HARMONY_EXPORTS,
+						1
+					)
+				);
+				break;
+
+			case "reexport-non-harmony-default-strict":
+				initFragments.push(
+					new InitFragment(
+						"/* harmony reexport (default from non-harmony) */ " +
+							this.getReexportStatement(
+								module,
+								module.getUsedName(moduleGraph, mode.name),
+								importVar,
+								"",
+								runtimeRequirements
+							),
+						InitFragment.STAGE_HARMONY_EXPORTS,
+						1
+					)
+				);
+				break;
+
+			case "reexport-namespace-object":
+				initFragments.push(
+					new InitFragment(
+						"/* harmony reexport (module object) */ " +
+							this.getReexportStatement(
+								module,
+								module.getUsedName(moduleGraph, mode.name),
+								importVar,
+								"",
+								runtimeRequirements
+							),
+						InitFragment.STAGE_HARMONY_EXPORTS,
+						1
+					)
+				);
+				break;
+
+			case "normal-reexport":
+				for (const [key, id] of mode.map) {
+					if (mode.checked.has(key)) {
+						initFragments.push(
+							new InitFragment(
 								"/* harmony reexport (checked) */ " +
-								this.getConditionalReexportStatement(
-									module,
-									item[0],
-									importVar,
-									item[1],
-									runtimeRequirements
-								) +
-								"\n"
-							);
-						})
-						.join(""),
-					InitFragment.STAGE_HARMONY_IMPORTS,
-					dep.sourceOrder
-				);
+									this.getConditionalReexportStatement(
+										module,
+										key,
+										importVar,
+										id,
+										runtimeRequirements
+									),
+								InitFragment.STAGE_HARMONY_IMPORTS,
+								dep.sourceOrder
+							)
+						);
+					} else {
+						initFragments.push(
+							new InitFragment(
+								"/* harmony reexport (safe) */ " +
+									this.getReexportStatement(
+										module,
+										module.getUsedName(moduleGraph, key),
+										importVar,
+										importedModule.getUsedName(moduleGraph, id),
+										runtimeRequirements
+									),
+								InitFragment.STAGE_HARMONY_EXPORTS,
+								1
+							)
+						);
+					}
+				}
+				break;
 
 			case "dynamic-reexport": {
-				const activeExports = new Set([
-					...dep.activeExports,
-					...dep._discoverActiveExportsFromOtherStartExports(moduleGraph)
-				]);
+				const ignored = mode.ignored;
 				let content =
 					"/* harmony reexport (unknown) */ for(var __WEBPACK_IMPORT_KEY__ in " +
 					importVar +
@@ -767,27 +760,32 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 
 				// Filter out exports which are defined by other exports
 				// and filter out default export because it cannot be reexported with *
-				if (activeExports.size > 0) {
+				if (ignored.size > 1) {
 					content +=
 						"if(" +
-						JSON.stringify(Array.from(activeExports).concat("default")) +
+						JSON.stringify(Array.from(ignored)) +
 						".indexOf(__WEBPACK_IMPORT_KEY__) < 0) ";
-				} else {
-					content += "if(__WEBPACK_IMPORT_KEY__ !== 'default') ";
+				} else if (ignored.size === 1) {
+					content += `if(__WEBPACK_IMPORT_KEY__ !== ${JSON.stringify(
+						ignored.values().next().value
+					)}) `;
 				}
 
 				runtimeRequirements.add(RuntimeGlobals.exports);
 				runtimeRequirements.add(RuntimeGlobals.definePropertyGetter);
 
 				const exportsName = module.exportsArgument;
-				return new InitFragment(
-					content +
-						`(function(key) { ${
-							RuntimeGlobals.definePropertyGetter
-						}(${exportsName}, key, function() { return ${importVar}[key]; }) }(__WEBPACK_IMPORT_KEY__));\n`,
-					InitFragment.STAGE_HARMONY_IMPORTS,
-					dep.sourceOrder
+				initFragments.push(
+					new InitFragment(
+						content +
+							`${
+								RuntimeGlobals.definePropertyGetter
+							}(${exportsName}, __WEBPACK_IMPORT_KEY__, function(key) { return ${importVar}[key]; }.bind(0, __WEBPACK_IMPORT_KEY__));\n`,
+						InitFragment.STAGE_HARMONY_IMPORTS,
+						dep.sourceOrder
+					)
 				);
+				break;
 			}
 
 			default:

--- a/lib/dependencies/RequireIncludeDependency.js
+++ b/lib/dependencies/RequireIncludeDependency.js
@@ -33,7 +33,7 @@ class RequireIncludeDependency extends ModuleDependency {
 		// This doesn't use any export
 		return new DependencyReference(
 			() => moduleGraph.getModule(this),
-			[],
+			false,
 			false
 		);
 	}

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -153,7 +153,8 @@ const getExternalImport = (
 	asCall,
 	strictHarmonyModule
 ) => {
-	const used = importedModule.getUsedName(moduleGraph, exportName);
+	const used =
+		exportName === true || importedModule.getUsedName(moduleGraph, exportName);
 	if (!used) return "/* unused reexport */undefined";
 	const comment =
 		used !== exportName ? ` ${Template.toNormalComment(exportName)}` : "";

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -557,7 +557,7 @@ class ConcatenatedModule extends Module {
 		const getConcatenatedImports = module => {
 			const references = module.dependencies
 				.filter(dep => dep instanceof HarmonyImportDependency)
-				.map(dep => compilation.getDependencyReference(module, dep))
+				.map(dep => compilation.getDependencyReference(dep))
 				.filter(ref => ref !== null);
 			DependencyReference.sort(references);
 			return references.map(ref => {

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -849,8 +849,7 @@ class ConcatenatedModule extends Module {
 		const result = new ConcatSource();
 
 		// add harmony compatibility flag (must be first because of possible circular dependencies)
-		const usedExports = moduleGraph.getUsedExports(this.rootModule);
-		if (usedExports === true) {
+		if (moduleGraph.getExportsInfo(this).otherExportsInfo.used !== false) {
 			result.add(
 				runtimeTemplate.defineEsModuleFlagStatement({
 					exportsArgument: this.exportsArgument,

--- a/lib/optimize/MangleExportsPlugin.js
+++ b/lib/optimize/MangleExportsPlugin.js
@@ -1,0 +1,77 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const { numberToIdentifer } = require("../Template");
+const {
+	concatComparators,
+	compareSelect,
+	compareStringsNumeric
+} = require("../util/comparators");
+
+/** @typedef {import("../Compiler")} Compiler */
+
+const canMangleSomething = exportsInfo => {
+	for (const exportInfo of exportsInfo.exports) {
+		if (exportInfo.canMangle === true) {
+			return true;
+		}
+	}
+	return false;
+};
+
+const comparator = concatComparators(
+	// Sort used before unused fields
+	compareSelect(e => e.used !== false, (a, b) => (a === b ? 0 : a ? -1 : 1)),
+	// Sort by name
+	compareSelect(e => e.name, compareStringsNumeric)
+);
+
+class MangleExportsPlugin {
+	/**
+	 * @param {Compiler} compiler webpack compiler
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap("MangleExportsPlugin", compilation => {
+			const moduleGraph = compilation.moduleGraph;
+			compilation.hooks.optimizeCodeGeneration.tap(
+				"MangleExportsPlugin",
+				modules => {
+					for (const module of modules) {
+						const exportsInfo = moduleGraph.getExportsInfo(module);
+						if (!canMangleSomething(exportsInfo)) continue;
+						const usedNames = new Set();
+						const mangleableExports = [];
+						// Don't rename single char exports or exports that can't be mangled
+						for (const exportInfo of exportsInfo.exports) {
+							const name = exportInfo.name;
+							if (exportInfo.canMangle === true && name.length > 1) {
+								mangleableExports.push(exportInfo);
+							} else {
+								exportInfo.usedName = name;
+								usedNames.add(name);
+							}
+						}
+						mangleableExports.sort(comparator);
+						let i = 0;
+						for (const exportInfo of mangleableExports) {
+							let newName = numberToIdentifer(i++);
+							while (usedNames.has(newName)) {
+								newName = numberToIdentifer(i++);
+							}
+							exportInfo.usedName = newName;
+							// we can skip adding newName to usedNames
+							// as numberToIdentifier never repeats results
+						}
+					}
+				}
+			);
+		});
+	}
+}
+
+module.exports = MangleExportsPlugin;

--- a/lib/optimize/MangleExportsPlugin.js
+++ b/lib/optimize/MangleExportsPlugin.js
@@ -49,7 +49,7 @@ class MangleExportsPlugin {
 						// Don't rename single char exports or exports that can't be mangled
 						for (const exportInfo of exportsInfo.exports) {
 							const name = exportInfo.name;
-							if (exportInfo.canMangle === true && name.length > 1) {
+							if (exportInfo.canMangle === true && /^a-zA-Z_\$$/.test(name)) {
 								mangleableExports.push(exportInfo);
 							} else {
 								exportInfo.usedName = name;

--- a/lib/optimize/ModuleConcatenationPlugin.js
+++ b/lib/optimize/ModuleConcatenationPlugin.js
@@ -382,7 +382,7 @@ class ModuleConcatenationPlugin {
 				.map(dep => {
 					if (!(dep instanceof HarmonyImportDependency)) return null;
 					if (!compilation) return dep.getReference(moduleGraph);
-					return compilation.getDependencyReference(module, dep);
+					return compilation.getDependencyReference(dep);
 				})
 
 				// Reference is valid and has a module

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -72,16 +72,18 @@ class SideEffectsFlagPlugin {
 							if (dep instanceof HarmonyExportImportedSpecifierDependency) {
 								if (module.factoryMeta.sideEffectFree) {
 									const mode = dep.getMode(moduleGraph, true);
-									if (mode.type === "safe-reexport") {
+									if (mode.type === "normal-reexport") {
 										let map = reexportMaps.get(module);
 										if (!map) {
 											reexportMaps.set(module, (map = new Map()));
 										}
-										for (const pair of mode.map) {
-											map.set(pair[0], {
-												module: mode.getModule(),
-												exportName: pair[1]
-											});
+										for (const [key, id] of mode.map) {
+											if (!mode.checked.has(key)) {
+												map.set(key, {
+													module: mode.getModule(),
+													exportName: id
+												});
+											}
 										}
 									}
 								}

--- a/lib/wasm/WasmFinalizeExportsPlugin.js
+++ b/lib/wasm/WasmFinalizeExportsPlugin.js
@@ -39,7 +39,6 @@ class WasmFinalizeExportsPlugin {
 									false
 								) {
 									const ref = compilation.getDependencyReference(
-										connection.originModule,
 										connection.dependency
 									);
 

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -469,6 +469,10 @@
           "description": "Also flag chunks as loaded which contain a subset of the modules",
           "type": "boolean"
         },
+        "mangleExports": {
+          "description": "Rename exports when possible to generate shorter code (depends on optimization.usedExports and optimization.providedExports)",
+          "type": "boolean"
+        },
         "mangleWasmImports": {
           "description": "Reduce size of WASM by changing imports to shorter strings.",
           "type": "boolean"

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -26,6 +26,7 @@ const DEFAULT_OPTIMIZATIONS = {
 	sideEffects: true,
 	providedExports: true,
 	usedExports: true,
+	mangleExports: true,
 	noEmitOnErrors: false,
 	concatenateModules: false,
 	moduleIds: "size",

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StatsTestCases should print correct stats for aggressive-splitting-entry 1`] = `
-"Hash: c99c0d5aad7172d3fc17c99c0d5aad7172d3fc17
+"Hash: 98b735993a3831bdf62998b735993a3831bdf629
 Child fitting:
-    Hash: c99c0d5aad7172d3fc17
+    Hash: 98b735993a3831bdf629
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
     PublicPath: (none)
@@ -11,8 +11,8 @@ Child fitting:
     4ec3a56d38eb3a2a2dae.js  1.92 KiB   {324}  [emitted]
     69ea1e0c4e453d2cc21c.js  1.07 KiB   {780}  [emitted]
     6e8afc9c2e15f398cc94.js  1.92 KiB   {972}  [emitted]
-    7b4bf185c2f47fcaaac6.js  12.1 KiB   {967}  [emitted]
-    Entrypoint main = 4ec3a56d38eb3a2a2dae.js 6e8afc9c2e15f398cc94.js 7b4bf185c2f47fcaaac6.js
+    9d13cf19fbc10147353c.js  12.1 KiB   {967}  [emitted]
+    Entrypoint main = 4ec3a56d38eb3a2a2dae.js 6e8afc9c2e15f398cc94.js 9d13cf19fbc10147353c.js
     chunk {324} 4ec3a56d38eb3a2a2dae.js 1.76 KiB [initial] [rendered] [recorded] aggressive splitted
         > ./index main
       [21] ./b.js 899 bytes {324} [built]
@@ -20,7 +20,7 @@ Child fitting:
     chunk {780} 69ea1e0c4e453d2cc21c.js 916 bytes [rendered]
         > ./g [967] ./index.js 7:0-13
      [780] ./g.js 916 bytes {780} [built]
-    chunk {967} 7b4bf185c2f47fcaaac6.js 1.87 KiB (javascript) 5.88 KiB (runtime) [entry] [rendered]
+    chunk {967} 9d13cf19fbc10147353c.js 1.87 KiB (javascript) 5.88 KiB (runtime) [entry] [rendered]
         > ./index main
      [153] ./f.js 900 bytes {967} [built]
      [601] ./e.js 899 bytes {967} [built]
@@ -31,7 +31,7 @@ Child fitting:
       [85] ./d.js 899 bytes {972} [built]
      [911] ./c.js 899 bytes {972} [built]
 Child content-change:
-    Hash: c99c0d5aad7172d3fc17
+    Hash: 98b735993a3831bdf629
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
     PublicPath: (none)
@@ -39,8 +39,8 @@ Child content-change:
     4ec3a56d38eb3a2a2dae.js  1.92 KiB   {324}  [emitted]
     69ea1e0c4e453d2cc21c.js  1.07 KiB   {780}  [emitted]
     6e8afc9c2e15f398cc94.js  1.92 KiB   {972}  [emitted]
-    7b4bf185c2f47fcaaac6.js  12.1 KiB   {967}  [emitted]
-    Entrypoint main = 4ec3a56d38eb3a2a2dae.js 6e8afc9c2e15f398cc94.js 7b4bf185c2f47fcaaac6.js
+    9d13cf19fbc10147353c.js  12.1 KiB   {967}  [emitted]
+    Entrypoint main = 4ec3a56d38eb3a2a2dae.js 6e8afc9c2e15f398cc94.js 9d13cf19fbc10147353c.js
     chunk {324} 4ec3a56d38eb3a2a2dae.js 1.76 KiB [initial] [rendered] [recorded] aggressive splitted
         > ./index main
       [21] ./b.js 899 bytes {324} [built]
@@ -48,7 +48,7 @@ Child content-change:
     chunk {780} 69ea1e0c4e453d2cc21c.js 916 bytes [rendered]
         > ./g [967] ./index.js 7:0-13
      [780] ./g.js 916 bytes {780} [built]
-    chunk {967} 7b4bf185c2f47fcaaac6.js 1.87 KiB (javascript) 5.88 KiB (runtime) [entry] [rendered]
+    chunk {967} 9d13cf19fbc10147353c.js 1.87 KiB (javascript) 5.88 KiB (runtime) [entry] [rendered]
         > ./index main
      [153] ./f.js 900 bytes {967} [built]
      [601] ./e.js 899 bytes {967} [built]
@@ -61,7 +61,7 @@ Child content-change:
 `;
 
 exports[`StatsTestCases should print correct stats for aggressive-splitting-on-demand 1`] = `
-"Hash: 975260ee5d294c0a2909
+"Hash: 9490c6f3b59a6253ac1a
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
 PublicPath: (none)
@@ -70,15 +70,15 @@ PublicPath: (none)
 498336c458ca3e2f210a.js  1020 bytes         {601}  [emitted]
 5712ee08c698584c013f.js  1020 bytes         {162}  [emitted]
 58c8dc21062619780583.js    1.92 KiB         {318}  [emitted]
-6570ba6ef4cff907e30e.js    8.85 KiB         {404}  [emitted]  main
 6e8afc9c2e15f398cc94.js    1.92 KiB         {972}  [emitted]
+7a2801cc285de7fba98d.js    8.85 KiB         {404}  [emitted]  main
 83eca01c31cb1c0587d9.js    1.92 KiB         {625}  [emitted]
 9d0ac517a27e3f3d19d0.js  1020 bytes         {355}  [emitted]
 c7cb1626aca4edc50d04.js    1.92 KiB         {909}  [emitted]
 e281eb2e68ed1d5784a5.js    1.92 KiB   {89}, {355}  [emitted]
 f3e49bab620d29da3576.js    1.92 KiB  {601}, {663}  [emitted]
 faec1dd207d2cf59dd83.js    1.91 KiB         {535}  [emitted]
-Entrypoint main = 6570ba6ef4cff907e30e.js
+Entrypoint main = 7a2801cc285de7fba98d.js
 chunk {89} e281eb2e68ed1d5784a5.js 1.76 KiB [rendered]
     > ./f ./g ./h ./i ./j ./k [967] ./index.js 4:0-51
  [355] ./k.js 899 bytes {89} {355} [built]
@@ -97,7 +97,7 @@ chunk {401} 481011ba787ca2245f6c.js 1.76 KiB [rendered] [recorded] aggressive sp
     > ./b ./d ./e ./f ./g ./h ./i ./j ./k [967] ./index.js 6:0-72
  [397] ./j.js 901 bytes {89} {401} [built]
  [917] ./i.js 899 bytes {318} {401} [built]
-chunk {404} 6570ba6ef4cff907e30e.js (main) 248 bytes (javascript) 3.96 KiB (runtime) [entry] [rendered]
+chunk {404} 7a2801cc285de7fba98d.js (main) 248 bytes (javascript) 3.96 KiB (runtime) [entry] [rendered]
     > ./index main
  [967] ./index.js 248 bytes {404} [built]
      + 4 hidden chunk modules
@@ -430,7 +430,7 @@ Child all:
 `;
 
 exports[`StatsTestCases should print correct stats for chunk-module-id-range 1`] = `
-"Hash: aef92999a177b4046170
+"Hash: 61bb5e85f9333ba31bb2
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
 PublicPath: (none)
@@ -458,7 +458,7 @@ chunk {1} main1.js (main1) 136 bytes (javascript) 279 bytes (runtime) [entry] [r
 `;
 
 exports[`StatsTestCases should print correct stats for chunks 1`] = `
-"Hash: 4204dacfe8ab0c98acce
+"Hash: 063cc5cd8592848eae41
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
 PublicPath: (none)
@@ -498,15 +498,15 @@ chunk {911} 911.bundle.js 54 bytes <{404}> >{130}< [rendered]
 `;
 
 exports[`StatsTestCases should print correct stats for chunks-development 1`] = `
-"Hash: dd98e862e1d888d75518
+"Hash: 574c5fae771e78363cc4
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
 PublicPath: (none)
               Asset       Size       Chunks             Chunk Names
-     b_js.bundle.js  385 bytes       {b_js}  [emitted]
-          bundle.js   7.97 KiB       {main}  [emitted]  main
-     c_js.bundle.js  594 bytes       {c_js}  [emitted]
-d_js-e_js.bundle.js  802 bytes  {d_js-e_js}  [emitted]
+     b_js.bundle.js  370 bytes       {b_js}  [emitted]
+          bundle.js   7.94 KiB       {main}  [emitted]  main
+     c_js.bundle.js  579 bytes       {c_js}  [emitted]
+d_js-e_js.bundle.js  772 bytes  {d_js-e_js}  [emitted]
 Entrypoint main = bundle.js
 chunk {b_js} b_js.bundle.js 22 bytes <{main}> [rendered]
     > ./b [./index.js] ./index.js 2:0-16
@@ -582,7 +582,7 @@ Entrypoint <CLR=BOLD>main</CLR> = <CLR=32>main.js</CLR>
 `;
 
 exports[`StatsTestCases should print correct stats for commons-chunk-min-size-0 1`] = `
-"Hash: b920d41e1e3b43bef164
+"Hash: e60dbab87c918344e104
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
      Asset       Size  Chunks             Chunk Names
@@ -600,7 +600,7 @@ Entrypoint entry-1 = 314.js entry-1.js
 `;
 
 exports[`StatsTestCases should print correct stats for commons-chunk-min-size-Infinity 1`] = `
-"Hash: f9d65c76c025d3f771ef
+"Hash: 72c8a6ff4b09531e216c
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
       Asset       Size  Chunks             Chunk Names
@@ -618,36 +618,37 @@ Entrypoint entry-1 = vendor-1.js entry-1.js
 `;
 
 exports[`StatsTestCases should print correct stats for commons-plugin-issue-4980 1`] = `
-"Hash: 6cfb2138c8ceb67deb0a80f6078e3c2dacf4b7d1
+"Hash: ed51af81631b861e5b8e0277476f1bbdb0c1c9f8
 Child
-    Hash: 6cfb2138c8ceb67deb0a
+    Hash: ed51af81631b861e5b8e
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
                              Asset       Size  Chunks             Chunk Names
-       app.58adf9207d7635a774f0.js   6.62 KiB   {131}  [emitted]  app
+       app.8e98a535c4631c44ee06.js   6.62 KiB   {131}  [emitted]  app
     vendor.db1343b8c15cbfb40349.js  616 bytes   {262}  [emitted]  vendor
-    Entrypoint app = vendor.db1343b8c15cbfb40349.js app.58adf9207d7635a774f0.js
+    Entrypoint app = vendor.db1343b8c15cbfb40349.js app.8e98a535c4631c44ee06.js
     [946] ./entry-1.js + 2 modules 190 bytes {131} [built]
     [950] ./constants.js 87 bytes {262} [built]
         + 4 hidden modules
 Child
-    Hash: 80f6078e3c2dacf4b7d1
+    Hash: 0277476f1bbdb0c1c9f8
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
                              Asset       Size  Chunks             Chunk Names
-       app.fe80305685dc4ae37f97.js   6.63 KiB   {131}  [emitted]  app
+       app.a06b0ba2f6779658cd9d.js   6.63 KiB   {131}  [emitted]  app
     vendor.db1343b8c15cbfb40349.js  616 bytes   {262}  [emitted]  vendor
-    Entrypoint app = vendor.db1343b8c15cbfb40349.js app.fe80305685dc4ae37f97.js
+    Entrypoint app = vendor.db1343b8c15cbfb40349.js app.a06b0ba2f6779658cd9d.js
     [914] ./entry-2.js + 2 modules 197 bytes {131} [built]
     [950] ./constants.js 87 bytes {262} [built]
         + 4 hidden modules"
 `;
 
 exports[`StatsTestCases should print correct stats for concat-and-sideeffects 1`] = `
-"[145] ./index.js + 2 modules 119 bytes {404} [built]
+"[695] ./node_modules/pmodule/a.js + 1 modules 73 bytes {404} [built]
       | ./node_modules/pmodule/aa.js 24 bytes [built]
       | ./node_modules/pmodule/a.js 49 bytes [built]
-      | ./index.js 46 bytes [built]
+[967] ./index.js 46 bytes {404} [built]
+      ModuleConcatenation bailout: Cannot concat with ./node_modules/pmodule/a.js (<- Module is referenced from different chunks by these modules: ./node_modules/pmodule/index.js)
 ./node_modules/pmodule/index.js 63 bytes [orphan] [built]
       ModuleConcatenation bailout: Module is not in any chunk
 ./node_modules/pmodule/b.js 49 bytes [orphan] [built]
@@ -714,7 +715,7 @@ Unexpected end of JSON input while parsing near ''
 `;
 
 exports[`StatsTestCases should print correct stats for exclude-with-loader 1`] = `
-"Hash: edd68ec5ce8683dfc8c0
+"Hash: 1c7f47bf57cd119a2d9b
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset      Size  Chunks             Chunk Names
@@ -738,9 +739,9 @@ Entrypoint main = main.js
 `;
 
 exports[`StatsTestCases should print correct stats for filter-warnings 1`] = `
-"Hash: 614c87c680ad23893c7c614c87c680ad23893c7c614c87c680ad23893c7c614c87c680ad23893c7c614c87c680ad23893c7c614c87c680ad23893c7c614c87c680ad23893c7c614c87c680ad23893c7c614c87c680ad23893c7c614c87c680ad23893c7c614c87c680ad23893c7c614c87c680ad23893c7c614c87c680ad23893c7c
+"Hash: 2f5b15eaf2a1fb80a33f2f5b15eaf2a1fb80a33f2f5b15eaf2a1fb80a33f2f5b15eaf2a1fb80a33f2f5b15eaf2a1fb80a33f2f5b15eaf2a1fb80a33f2f5b15eaf2a1fb80a33f2f5b15eaf2a1fb80a33f2f5b15eaf2a1fb80a33f2f5b15eaf2a1fb80a33f2f5b15eaf2a1fb80a33f2f5b15eaf2a1fb80a33f2f5b15eaf2a1fb80a33f
 Child undefined:
-    Hash: 614c87c680ad23893c7c
+    Hash: 2f5b15eaf2a1fb80a33f
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
@@ -770,49 +771,49 @@ Child undefined:
     WARNING in Terser Plugin: Dropping unused function someUnUsedFunction5 [./index.js:12,0]
 
 Child Terser:
-    Hash: 614c87c680ad23893c7c
+    Hash: 2f5b15eaf2a1fb80a33f
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
     bundle.js  1.32 KiB   {404}  [emitted]  main
     Entrypoint main = bundle.js
 Child /Terser/:
-    Hash: 614c87c680ad23893c7c
+    Hash: 2f5b15eaf2a1fb80a33f
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
     bundle.js  1.32 KiB   {404}  [emitted]  main
     Entrypoint main = bundle.js
 Child warnings => true:
-    Hash: 614c87c680ad23893c7c
+    Hash: 2f5b15eaf2a1fb80a33f
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
     bundle.js  1.32 KiB   {404}  [emitted]  main
     Entrypoint main = bundle.js
 Child [Terser]:
-    Hash: 614c87c680ad23893c7c
+    Hash: 2f5b15eaf2a1fb80a33f
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
     bundle.js  1.32 KiB   {404}  [emitted]  main
     Entrypoint main = bundle.js
 Child [/Terser/]:
-    Hash: 614c87c680ad23893c7c
+    Hash: 2f5b15eaf2a1fb80a33f
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
     bundle.js  1.32 KiB   {404}  [emitted]  main
     Entrypoint main = bundle.js
 Child [warnings => true]:
-    Hash: 614c87c680ad23893c7c
+    Hash: 2f5b15eaf2a1fb80a33f
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
     bundle.js  1.32 KiB   {404}  [emitted]  main
     Entrypoint main = bundle.js
 Child should not filter:
-    Hash: 614c87c680ad23893c7c
+    Hash: 2f5b15eaf2a1fb80a33f
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
@@ -842,7 +843,7 @@ Child should not filter:
     WARNING in Terser Plugin: Dropping unused function someUnUsedFunction5 [./index.js:12,0]
 
 Child /should not filter/:
-    Hash: 614c87c680ad23893c7c
+    Hash: 2f5b15eaf2a1fb80a33f
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
@@ -872,7 +873,7 @@ Child /should not filter/:
     WARNING in Terser Plugin: Dropping unused function someUnUsedFunction5 [./index.js:12,0]
 
 Child warnings => false:
-    Hash: 614c87c680ad23893c7c
+    Hash: 2f5b15eaf2a1fb80a33f
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
@@ -902,7 +903,7 @@ Child warnings => false:
     WARNING in Terser Plugin: Dropping unused function someUnUsedFunction5 [./index.js:12,0]
 
 Child [should not filter]:
-    Hash: 614c87c680ad23893c7c
+    Hash: 2f5b15eaf2a1fb80a33f
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
@@ -932,7 +933,7 @@ Child [should not filter]:
     WARNING in Terser Plugin: Dropping unused function someUnUsedFunction5 [./index.js:12,0]
 
 Child [/should not filter/]:
-    Hash: 614c87c680ad23893c7c
+    Hash: 2f5b15eaf2a1fb80a33f
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
@@ -962,7 +963,7 @@ Child [/should not filter/]:
     WARNING in Terser Plugin: Dropping unused function someUnUsedFunction5 [./index.js:12,0]
 
 Child [warnings => false]:
-    Hash: 614c87c680ad23893c7c
+    Hash: 2f5b15eaf2a1fb80a33f
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
@@ -1087,7 +1088,7 @@ chunk {trees} trees.js (trees) 70 bytes [rendered]
 `;
 
 exports[`StatsTestCases should print correct stats for import-context-filter 1`] = `
-"Hash: 144449879158d774f49b
+"Hash: e44c4398f9d7a53027f4
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
    Asset       Size  Chunks             Chunk Names
@@ -1105,7 +1106,7 @@ Entrypoint entry = entry.js
 `;
 
 exports[`StatsTestCases should print correct stats for import-weak 1`] = `
-"Hash: b9735fc7101f20f713f9
+"Hash: 9d25ae8d5dc05fa14984
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
    Asset       Size  Chunks             Chunk Names
@@ -1142,42 +1143,42 @@ Compilation error while processing magic comment(-s): /* webpackPrefetch: nope *
 `;
 
 exports[`StatsTestCases should print correct stats for issue-7577 1`] = `
-"Hash: 674de449ed250fedc74a974641d0bee2d29d3eff87858d9e7d8494baaa0d
+"Hash: 56a389f3f722ccfc241c6cd4f2521d3b26ef6f2fd7caa5f989d1768b1b83
 Child
-    Hash: 674de449ed250fedc74a
+    Hash: 56a389f3f722ccfc241c
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
                                      Asset       Size          Chunks             Chunk Names
         a-all-a_js-80d5d793105c1fbb58f1.js  149 bytes      {all-a_js}  [emitted]
             a-main-3ba9aa478578189dc722.js  115 bytes          {main}  [emitted]  main
-    a-runtime~main-51515c16a90b8ca4fd63.js   4.66 KiB  {runtime~main}  [emitted]  runtime~main
-    Entrypoint main = a-runtime~main-51515c16a90b8ca4fd63.js a-all-a_js-80d5d793105c1fbb58f1.js a-main-3ba9aa478578189dc722.js
+    a-runtime~main-e3134ada7cff4572b5d6.js   4.66 KiB  {runtime~main}  [emitted]  runtime~main
+    Entrypoint main = a-runtime~main-e3134ada7cff4572b5d6.js a-all-a_js-80d5d793105c1fbb58f1.js a-main-3ba9aa478578189dc722.js
     [./a.js] 18 bytes {all-a_js} [built]
         + 1 hidden module
 Child
-    Hash: 974641d0bee2d29d3eff
+    Hash: 6cd4f2521d3b26ef6f2f
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
                                                        Asset       Size                            Chunks             Chunk Names
                           b-all-b_js-f586ead775e42b6ef6f2.js  502 bytes                        {all-b_js}  [emitted]
                               b-main-13605e1c706573337764.js  148 bytes                            {main}  [emitted]  main
-                      b-runtime~main-e315648c3cfdbfdbbd34.js   6.08 KiB                    {runtime~main}  [emitted]  runtime~main
+                      b-runtime~main-f57bdc2529333fd92a20.js   6.08 KiB                    {runtime~main}  [emitted]  runtime~main
     b-vendors-node_modules_vendor_js-a7aa3079a16cbae3f591.js  194 bytes  {vendors-node_modules_vendor_js}  [emitted]
-    Entrypoint main = b-runtime~main-e315648c3cfdbfdbbd34.js b-vendors-node_modules_vendor_js-a7aa3079a16cbae3f591.js b-all-b_js-f586ead775e42b6ef6f2.js b-main-13605e1c706573337764.js
+    Entrypoint main = b-runtime~main-f57bdc2529333fd92a20.js b-vendors-node_modules_vendor_js-a7aa3079a16cbae3f591.js b-all-b_js-f586ead775e42b6ef6f2.js b-main-13605e1c706573337764.js
     [./b.js] 17 bytes {all-b_js} [built]
     [./node_modules/vendor.js] 23 bytes {vendors-node_modules_vendor_js} [built]
         + 4 hidden modules
 Child
-    Hash: 87858d9e7d8494baaa0d
+    Hash: d7caa5f989d1768b1b83
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
                                                        Asset       Size                            Chunks             Chunk Names
                           c-all-b_js-f586ead775e42b6ef6f2.js  502 bytes                        {all-b_js}  [emitted]
                           c-all-c_js-951cb2b9375c7bdea05d.js  369 bytes                        {all-c_js}  [emitted]
                               c-main-3b8ebb4d4d18bb8bef31.js  164 bytes                            {main}  [emitted]  main
-                      c-runtime~main-d37832fd5dfbab1ced95.js   9.54 KiB                    {runtime~main}  [emitted]  runtime~main
+                      c-runtime~main-7e3ce90aad438618ff00.js   9.54 KiB                    {runtime~main}  [emitted]  runtime~main
     c-vendors-node_modules_vendor_js-a7aa3079a16cbae3f591.js  194 bytes  {vendors-node_modules_vendor_js}  [emitted]
-    Entrypoint main = c-runtime~main-d37832fd5dfbab1ced95.js c-all-c_js-951cb2b9375c7bdea05d.js c-main-3b8ebb4d4d18bb8bef31.js (prefetch: c-vendors-node_modules_vendor_js-a7aa3079a16cbae3f591.js c-all-b_js-f586ead775e42b6ef6f2.js)
+    Entrypoint main = c-runtime~main-7e3ce90aad438618ff00.js c-all-c_js-951cb2b9375c7bdea05d.js c-main-3b8ebb4d4d18bb8bef31.js (prefetch: c-vendors-node_modules_vendor_js-a7aa3079a16cbae3f591.js c-all-b_js-f586ead775e42b6ef6f2.js)
     [./b.js] 17 bytes {all-b_js} [built]
     [./c.js] 61 bytes {all-c_js} [built]
     [./node_modules/vendor.js] 23 bytes {vendors-node_modules_vendor_js} [built]
@@ -1185,9 +1186,9 @@ Child
 `;
 
 exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 1`] = `
-"Hash: b1b5a334235024991861f7171095df531da2402146ebc6e59d1b60e9b8ba9ee395c9a44fadf020be
+"Hash: 84d1992ecaf2df38152405c36ea08061c49672c7bff3c899bd78957f7a9c4317fe43ebcc2eaa3ec3
 Child 1 chunks:
-    Hash: b1b5a334235024991861
+    Hash: 84d1992ecaf2df381524
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset      Size  Chunks             Chunk Names
@@ -1202,7 +1203,7 @@ Child 1 chunks:
      [967] ./index.js 101 bytes {404} [built]
          + 3 hidden chunk modules
 Child 2 chunks:
-    Hash: f7171095df531da24021
+    Hash: 05c36ea08061c49672c7
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
            Asset       Size  Chunks             Chunk Names
@@ -1219,7 +1220,7 @@ Child 2 chunks:
      [967] ./index.js 101 bytes {404} [built]
          + 7 hidden chunk modules
 Child 3 chunks:
-    Hash: 46ebc6e59d1b60e9b8ba
+    Hash: bff3c899bd78957f7a9c
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
             Asset       Size  Chunks             Chunk Names
@@ -1238,7 +1239,7 @@ Child 3 chunks:
      [967] ./index.js 101 bytes {404} [built]
          + 7 hidden chunk modules
 Child 4 chunks:
-    Hash: 9ee395c9a44fadf020be
+    Hash: 4317fe43ebcc2eaa3ec3
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
             Asset       Size  Chunks             Chunk Names
@@ -1316,7 +1317,7 @@ Entrypoint main = main.js
 `;
 
 exports[`StatsTestCases should print correct stats for module-assets 1`] = `
-"Hash: 2a2bff40bcaf79213d7a
+"Hash: d58658036bbe67257bce
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
 Entrypoint main = main.js
@@ -1453,7 +1454,7 @@ If you don't want to include a polyfill, you can use an empty module like this:
 `;
 
 exports[`StatsTestCases should print correct stats for module-reasons 1`] = `
-"Hash: d7522b75c43f47744105
+"Hash: 111485968d3961c5ca2e
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset      Size  Chunks             Chunk Names
@@ -1577,7 +1578,7 @@ Child
 `;
 
 exports[`StatsTestCases should print correct stats for named-chunks-plugin 1`] = `
-"Hash: ac118c65c3de13d240ee
+"Hash: 4c4b1d5b8b4f87917315
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset       Size    Chunks             Chunk Names
@@ -1592,7 +1593,7 @@ Entrypoint entry = vendor.js entry.js
 `;
 
 exports[`StatsTestCases should print correct stats for named-chunks-plugin-async 1`] = `
-"Hash: 3e5a8e10c5781110eb35
+"Hash: 0782deccbae8ad224562
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
           Asset       Size          Chunks             Chunk Names
@@ -1633,7 +1634,7 @@ Child child:
 `;
 
 exports[`StatsTestCases should print correct stats for optimize-chunks 1`] = `
-"Hash: 4f7e6948b648cba64ac3
+"Hash: dfbdea6e53c8df64ac55
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
             Asset       Size        Chunks             Chunk Names
@@ -1990,7 +1991,7 @@ chunk {855} normal.js (normal) 0 bytes [rendered]"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-detailed 1`] = `
-"Hash: 71702b22a6d262080c63
+"Hash: a608a60134c169755d1b
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
 PublicPath: (none)
@@ -2021,13 +2022,17 @@ chunk {911} 911.js 54 bytes <{404}> >{130}< [rendered]
 [967] ./index.js 51 bytes {404} [depth 0] [built]
       ModuleConcatenation bailout: Module is not an ECMAScript module
 webpack/runtime/ensure chunk 345 bytes {404} [runtime]
-      [no exports used]
+      [no exports]
+      [used exports unknown]
 webpack/runtime/get javascript chunk filename 183 bytes {404} [runtime]
-      [no exports used]
+      [no exports]
+      [used exports unknown]
 webpack/runtime/jsonp chunk loading 3.1 KiB {404} [runtime]
-      [no exports used]
+      [no exports]
+      [used exports unknown]
 webpack/runtime/publicPath 27 bytes {404} [runtime]
-      [no exports used]"
+      [no exports]
+      [used exports unknown]"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-errors-only 1`] = `""`;
@@ -2057,7 +2062,7 @@ exports[`StatsTestCases should print correct stats for preset-none-array 1`] = `
 exports[`StatsTestCases should print correct stats for preset-none-error 1`] = `""`;
 
 exports[`StatsTestCases should print correct stats for preset-normal 1`] = `
-"Hash: 71702b22a6d262080c63
+"Hash: a608a60134c169755d1b
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset       Size  Chunks             Chunk Names
@@ -2140,7 +2145,7 @@ Entrypoints:
 `;
 
 exports[`StatsTestCases should print correct stats for preset-verbose 1`] = `
-"Hash: 71702b22a6d262080c63
+"Hash: a608a60134c169755d1b
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
 PublicPath: (none)
@@ -2177,13 +2182,17 @@ chunk {404} main.js (main) 73 bytes (javascript) 3.64 KiB (runtime) >{21}< >{911
        entry ./index main
        Xms (resolving: Xms, restoring: Xms, integration: Xms, building: Xms, storing: Xms)
  webpack/runtime/ensure chunk 345 bytes {404} [runtime]
-       [no exports used]
+       [no exports]
+       [used exports unknown]
  webpack/runtime/get javascript chunk filename 183 bytes {404} [runtime]
-       [no exports used]
+       [no exports]
+       [used exports unknown]
  webpack/runtime/jsonp chunk loading 3.1 KiB {404} [runtime]
-       [no exports used]
+       [no exports]
+       [used exports unknown]
  webpack/runtime/publicPath 27 bytes {404} [runtime]
-       [no exports used]
+       [no exports]
+       [used exports unknown]
 chunk {911} 911.js 54 bytes <{404}> >{130}< [rendered]
     > ./c [967] ./index.js 3:0-16
  [911] ./c.js 54 bytes {911} [depth 1] [built]
@@ -2279,7 +2288,7 @@ Entrypoint e2 = runtime.js e2.js"
 `;
 
 exports[`StatsTestCases should print correct stats for scope-hoisting-bailouts 1`] = `
-"Hash: 0a87ab378771fc91a701
+"Hash: bc0f02f2c6ad3bdee4aa
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
 Entrypoint index = index.js
@@ -2308,9 +2317,9 @@ Entrypoint entry = entry.js
 `;
 
 exports[`StatsTestCases should print correct stats for scope-hoisting-multi 1`] = `
-"Hash: 688d8b568919cbd9a11213b4b115124c0312047a
+"Hash: 8f19a02eed394d9cad04a73d0b99e7b12c3667ad
 Child
-    Hash: 688d8b568919cbd9a112
+    Hash: 8f19a02eed394d9cad04
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
     Entrypoint first = vendor.js first.js
@@ -2328,7 +2337,7 @@ Child
     [885] ./common2.js 25 bytes {87} {603} [built]
         + 10 hidden modules
 Child
-    Hash: 13b4b115124c0312047a
+    Hash: a73d0b99e7b12c3667ad
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
     Entrypoint first = vendor.js first.js
@@ -2355,38 +2364,37 @@ Child
 `;
 
 exports[`StatsTestCases should print correct stats for side-effects-issue-7428 1`] = `
-"Hash: b4afab758fa19b485ba6
+"Hash: 8cc3b6a0e43cf6f6e017
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset       Size  Chunks             Chunk Names
-   1.js  489 bytes     {1}  [emitted]
-main.js   9.78 KiB     {0}  [emitted]  main
+   1.js  481 bytes     {1}  [emitted]
+main.js    9.5 KiB     {0}  [emitted]  main
 Entrypoint main = main.js
-[0] ./main.js + 1 modules 231 bytes {0} [built]
-    harmony side effect evaluation ./CompB ./components/src/CompAB/index.js 2:0-43
-    harmony export imported specifier ./CompB ./components/src/CompAB/index.js 2:0-43
+[0] ./main.js 144 bytes {0} [built]
     entry ./main.js main
-    | ./components/src/CompAB/CompB.js 77 bytes [built]
-    |     [only some exports used: default]
-    |     harmony import specifier ./components ./main.js 4:15-20 (skipped side-effect-free modules)
-    | ./main.js 144 bytes [built]
 [1] ./components/src/CompAB/CompA.js 89 bytes {0} [built]
     [only some exports used: default]
-    harmony import specifier ./components [0] ./main.js + 1 modules ./main.js 3:15-20 (skipped side-effect-free modules)
-    harmony import specifier ./components [3] ./foo.js 3:20-25 (skipped side-effect-free modules)
+    harmony import specifier ./components [0] ./main.js 3:15-20 (skipped side-effect-free modules)
+    harmony import specifier ./components [4] ./foo.js 3:20-25 (skipped side-effect-free modules)
     harmony side effect evaluation ./CompA ./components/src/CompAB/index.js 1:0-43
     harmony export imported specifier ./CompA ./components/src/CompAB/index.js 1:0-43
 [2] ./components/src/CompAB/utils.js 97 bytes {0} [built]
-    harmony side effect evaluation ./utils [0] ./main.js + 1 modules ./components/src/CompAB/CompB.js 1:0-30
-    harmony import specifier ./utils [0] ./main.js + 1 modules ./components/src/CompAB/CompB.js 5:2-5
     harmony side effect evaluation ./utils [1] ./components/src/CompAB/CompA.js 1:0-35
     harmony import specifier ./utils [1] ./components/src/CompAB/CompA.js 5:5-12
-[3] ./foo.js 101 bytes {1} [built]
-    import() ./foo [0] ./main.js + 1 modules ./main.js 6:0-15
+    harmony side effect evaluation ./utils [3] ./components/src/CompAB/CompB.js 1:0-30
+    harmony import specifier ./utils [3] ./components/src/CompAB/CompB.js 5:2-5
+[3] ./components/src/CompAB/CompB.js 77 bytes {0} [built]
+    [only some exports used: default]
+    harmony import specifier ./components [0] ./main.js 4:15-20 (skipped side-effect-free modules)
+    harmony side effect evaluation ./CompB ./components/src/CompAB/index.js 2:0-43
+    harmony export imported specifier ./CompB ./components/src/CompAB/index.js 2:0-43
+[4] ./foo.js 101 bytes {1} [built]
+    import() ./foo [0] ./main.js 6:0-15
 ./components/src/index.js 84 bytes [orphan] [built]
     [module unused]
-    harmony side effect evaluation ./components [0] ./main.js + 1 modules ./main.js 1:0-44
-    harmony side effect evaluation ./components [3] ./foo.js 1:0-37
+    harmony side effect evaluation ./components [0] ./main.js 1:0-44
+    harmony side effect evaluation ./components [4] ./foo.js 1:0-37
 ./components/src/CompAB/index.js 87 bytes [orphan] [built]
     [module unused]
     harmony side effect evaluation ./CompAB ./components/src/index.js 1:0-40
@@ -2400,39 +2408,39 @@ Entrypoint main = main.js
     [module unused]
     harmony side effect evaluation ./CompC ./components/src/CompC/index.js 1:0-34
     harmony export imported specifier ./CompC ./components/src/CompC/index.js 1:0-34
-    + 7 hidden modules"
+    + 6 hidden modules"
 `;
 
 exports[`StatsTestCases should print correct stats for side-effects-simple-unused 1`] = `
-"Hash: 7f20386a9daa52bf7114
+"Hash: cba08bd0b20a288185d8
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset      Size  Chunks             Chunk Names
-main.js  2.75 KiB   {404}  [emitted]  main
+main.js  3.52 KiB   {404}  [emitted]  main
 Entrypoint main = main.js
-[690] ./index.js + 2 modules 158 bytes {404} [built]
-      harmony side effect evaluation ./c ./node_modules/pmodule/b.js 5:0-24
-      harmony export imported specifier ./c ./node_modules/pmodule/b.js 5:0-24
+[200] ./index.js + 1 modules 135 bytes {404} [built]
       entry ./index main
       | ./node_modules/pmodule/index.js 75 bytes [built]
       |     [only some exports used: default]
       |     harmony side effect evaluation pmodule ./index.js 1:0-33
       |     harmony import specifier pmodule ./index.js 3:12-15
-      | ./node_modules/pmodule/c.js 28 bytes [built]
-      |     [only some exports used: z]
-      |     harmony import specifier pmodule ./index.js 3:17-18 (skipped side-effect-free modules)
       | ./index.js 55 bytes [built]
+[938] ./node_modules/pmodule/c.js 28 bytes {404} [built]
+      [only some exports used: z]
+      harmony import specifier pmodule [200] ./index.js + 1 modules ./index.js 3:17-18 (skipped side-effect-free modules)
+      harmony side effect evaluation ./c ./node_modules/pmodule/b.js 5:0-24
+      harmony export imported specifier ./c ./node_modules/pmodule/b.js 5:0-24
 ./node_modules/pmodule/a.js 60 bytes [orphan] [built]
       [module unused]
-      harmony side effect evaluation ./a [690] ./index.js + 2 modules ./node_modules/pmodule/index.js 1:0-20
-      harmony export imported specifier ./a [690] ./index.js + 2 modules ./node_modules/pmodule/index.js 1:0-20
+      harmony side effect evaluation ./a [200] ./index.js + 1 modules ./node_modules/pmodule/index.js 1:0-20
+      harmony export imported specifier ./a [200] ./index.js + 1 modules ./node_modules/pmodule/index.js 1:0-20
 ./node_modules/pmodule/b.js 69 bytes [orphan] [built]
       [module unused]
-      harmony side effect evaluation ./b [690] ./index.js + 2 modules ./node_modules/pmodule/index.js 2:0-30
-      harmony export imported specifier ./b [690] ./index.js + 2 modules ./node_modules/pmodule/index.js 2:0-30
-      harmony export imported specifier ./b [690] ./index.js + 2 modules ./node_modules/pmodule/index.js 2:0-30
-      harmony export imported specifier ./b [690] ./index.js + 2 modules ./node_modules/pmodule/index.js 2:0-30
-    + 2 hidden modules"
+      harmony side effect evaluation ./b [200] ./index.js + 1 modules ./node_modules/pmodule/index.js 2:0-30
+      harmony export imported specifier ./b [200] ./index.js + 1 modules ./node_modules/pmodule/index.js 2:0-30
+      harmony export imported specifier ./b [200] ./index.js + 1 modules ./node_modules/pmodule/index.js 2:0-30
+      harmony export imported specifier ./b [200] ./index.js + 1 modules ./node_modules/pmodule/index.js 2:0-30
+    + 3 hidden modules"
 `;
 
 exports[`StatsTestCases should print correct stats for simple 1`] = `
@@ -2440,7 +2448,7 @@ exports[`StatsTestCases should print correct stats for simple 1`] = `
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset      Size  Chunks             Chunk Names
-bundle.js  1.57 KiB  {main}  [emitted]  main
+bundle.js  1.56 KiB  {main}  [emitted]  main
 Entrypoint main = bundle.js
 [./index.js] 0 bytes {main} [built]"
 `;
@@ -3414,11 +3422,11 @@ chunk {784} default/784.js 110 bytes <{404}> ={329}= ={456}= [rendered] split ch
 `;
 
 exports[`StatsTestCases should print correct stats for tree-shaking 1`] = `
-"Hash: a3acb33e66e750f824f9
+"Hash: d233791da1aa6c47b203
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
-    Asset      Size  Chunks             Chunk Names
-bundle.js  7.61 KiB   {404}  [emitted]  main
+    Asset     Size  Chunks             Chunk Names
+bundle.js  7.6 KiB   {404}  [emitted]  main
 Entrypoint main = bundle.js
  [21] ./b.js 13 bytes {404} [built]
       [exports: b]
@@ -3452,7 +3460,7 @@ Entrypoint main = bundle.js
 `;
 
 exports[`StatsTestCases should print correct stats for warnings-terser 1`] = `
-"Hash: c96fbf67b17eab033a75
+"Hash: a1c39c4e43eb7943bde9
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset      Size  Chunks             Chunk Names
@@ -3475,7 +3483,7 @@ WARNING in Terser Plugin: Dropping unused function someUnRemoteUsedFunction5 [./
 `;
 
 exports[`StatsTestCases should print correct stats for wasm-explorer-examples-sync 1`] = `
-"Hash: 47b0ccb957697477ebb0
+"Hash: d8974465e44e9b3e2134
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
                            Asset       Size  Chunks             Chunk Names

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -503,10 +503,10 @@ Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
 PublicPath: (none)
               Asset       Size       Chunks             Chunk Names
-     b_js.bundle.js  329 bytes       {b_js}  [emitted]
-          bundle.js   7.86 KiB       {main}  [emitted]  main
-     c_js.bundle.js  538 bytes       {c_js}  [emitted]
-d_js-e_js.bundle.js  690 bytes  {d_js-e_js}  [emitted]
+     b_js.bundle.js  385 bytes       {b_js}  [emitted]
+          bundle.js   7.97 KiB       {main}  [emitted]  main
+     c_js.bundle.js  594 bytes       {c_js}  [emitted]
+d_js-e_js.bundle.js  802 bytes  {d_js-e_js}  [emitted]
 Entrypoint main = bundle.js
 chunk {b_js} b_js.bundle.js 22 bytes <{main}> [rendered]
     > ./b [./index.js] ./index.js 2:0-16
@@ -2440,7 +2440,7 @@ exports[`StatsTestCases should print correct stats for simple 1`] = `
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset      Size  Chunks             Chunk Names
-bundle.js  1.52 KiB  {main}  [emitted]  main
+bundle.js  1.57 KiB  {main}  [emitted]  main
 Entrypoint main = bundle.js
 [./index.js] 0 bytes {main} [built]"
 `;

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -618,26 +618,26 @@ Entrypoint entry-1 = vendor-1.js entry-1.js
 `;
 
 exports[`StatsTestCases should print correct stats for commons-plugin-issue-4980 1`] = `
-"Hash: ed51af81631b861e5b8e0277476f1bbdb0c1c9f8
+"Hash: 5ca2fed072b89be75c9bdd5a2c042002fbb32534
 Child
-    Hash: ed51af81631b861e5b8e
+    Hash: 5ca2fed072b89be75c9b
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
                              Asset       Size  Chunks             Chunk Names
-       app.8e98a535c4631c44ee06.js   6.62 KiB   {131}  [emitted]  app
-    vendor.db1343b8c15cbfb40349.js  616 bytes   {262}  [emitted]  vendor
-    Entrypoint app = vendor.db1343b8c15cbfb40349.js app.8e98a535c4631c44ee06.js
+       app.93b0bfb1b9b8da338cdb.js   6.61 KiB   {131}  [emitted]  app
+    vendor.db1343b8c15cbfb40349.js  622 bytes   {262}  [emitted]  vendor
+    Entrypoint app = vendor.db1343b8c15cbfb40349.js app.93b0bfb1b9b8da338cdb.js
     [946] ./entry-1.js + 2 modules 190 bytes {131} [built]
     [950] ./constants.js 87 bytes {262} [built]
         + 4 hidden modules
 Child
-    Hash: 0277476f1bbdb0c1c9f8
+    Hash: dd5a2c042002fbb32534
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
                              Asset       Size  Chunks             Chunk Names
-       app.a06b0ba2f6779658cd9d.js   6.63 KiB   {131}  [emitted]  app
-    vendor.db1343b8c15cbfb40349.js  616 bytes   {262}  [emitted]  vendor
-    Entrypoint app = vendor.db1343b8c15cbfb40349.js app.a06b0ba2f6779658cd9d.js
+       app.e9fca3d9db1a953c606a.js   6.62 KiB   {131}  [emitted]  app
+    vendor.db1343b8c15cbfb40349.js  622 bytes   {262}  [emitted]  vendor
+    Entrypoint app = vendor.db1343b8c15cbfb40349.js app.e9fca3d9db1a953c606a.js
     [914] ./entry-2.js + 2 modules 197 bytes {131} [built]
     [950] ./constants.js 87 bytes {262} [built]
         + 4 hidden modules"
@@ -2317,9 +2317,9 @@ Entrypoint entry = entry.js
 `;
 
 exports[`StatsTestCases should print correct stats for scope-hoisting-multi 1`] = `
-"Hash: 8f19a02eed394d9cad04a73d0b99e7b12c3667ad
+"Hash: 780703e0efe782df0a78cf578192451a754a1338
 Child
-    Hash: 8f19a02eed394d9cad04
+    Hash: 780703e0efe782df0a78
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
     Entrypoint first = vendor.js first.js
@@ -2337,7 +2337,7 @@ Child
     [885] ./common2.js 25 bytes {87} {603} [built]
         + 10 hidden modules
 Child
-    Hash: a73d0b99e7b12c3667ad
+    Hash: cf578192451a754a1338
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
     Entrypoint first = vendor.js first.js
@@ -2412,7 +2412,7 @@ Entrypoint main = main.js
 `;
 
 exports[`StatsTestCases should print correct stats for side-effects-simple-unused 1`] = `
-"Hash: cba08bd0b20a288185d8
+"Hash: faf7e0af8ada8b2bec86
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset      Size  Chunks             Chunk Names
@@ -3422,7 +3422,7 @@ chunk {784} default/784.js 110 bytes <{404}> ={329}= ={456}= [rendered] split ch
 `;
 
 exports[`StatsTestCases should print correct stats for tree-shaking 1`] = `
-"Hash: d233791da1aa6c47b203
+"Hash: 16949aa0a8a83760f86b
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset     Size  Chunks             Chunk Names
@@ -3483,24 +3483,24 @@ WARNING in Terser Plugin: Dropping unused function someUnRemoteUsedFunction5 [./
 `;
 
 exports[`StatsTestCases should print correct stats for wasm-explorer-examples-sync 1`] = `
-"Hash: d8974465e44e9b3e2134
+"Hash: f2759f1192495195a8d0
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
                            Asset       Size  Chunks             Chunk Names
-06bbff7f9ffc47aee5b2.module.wasm  132 bytes   {286}  [emitted]
+06bbff7f9ffc47aee5b2.module.wasm  142 bytes   {286}  [emitted]
                    147.bundle.js  844 bytes   {147}  [emitted]
                    286.bundle.js  431 bytes   {286}  [emitted]
-3136d1cffcb575eb6714.module.wasm  126 bytes   {827}  [emitted]
+3136d1cffcb575eb6714.module.wasm  149 bytes   {827}  [emitted]
                    363.bundle.js  431 bytes   {363}  [emitted]
-                   480.bundle.js  329 bytes   {480}  [emitted]
-                   827.bundle.js   3.93 KiB   {827}  [emitted]
-b55d07a57948324016ca.module.wasm  511 bytes   {363}  [emitted]
+                   480.bundle.js  336 bytes   {480}  [emitted]
+                   827.bundle.js   3.83 KiB   {827}  [emitted]
+b55d07a57948324016ca.module.wasm  527 bytes   {363}  [emitted]
                        bundle.js   13.2 KiB    {73}  [emitted]  main-1df31ce3
-f5547c837a1129d5a8d4.module.wasm  133 bytes   {147}  [emitted]
-f6c45b3a19cc49886819.module.wasm   95 bytes   {827}  [emitted]
-fd7f6dc0e275592cdc16.module.wasm  226 bytes   {147}  [emitted]
+f5547c837a1129d5a8d4.module.wasm  140 bytes   {147}  [emitted]
+f6c45b3a19cc49886819.module.wasm  106 bytes   {827}  [emitted]
+fd7f6dc0e275592cdc16.module.wasm  276 bytes   {147}  [emitted]
 Entrypoint main = bundle.js
-chunk {73} bundle.js (main-1df31ce3) 586 bytes (javascript) 6.53 KiB (runtime) [entry] [rendered]
+chunk {73} bundle.js (main-1df31ce3) 586 bytes (javascript) 6.54 KiB (runtime) [entry] [rendered]
  [967] ./index.js 586 bytes {73} [built]
      + 7 hidden chunk modules
 chunk {147} 147.bundle.js, f5547c837a1129d5a8d4.module.wasm, fd7f6dc0e275592cdc16.module.wasm 205 bytes (javascript) 444 bytes (webassembly) [rendered]

--- a/test/configCases/deep-scope-analysis/remove-export-scope-hoisting/webpack.config.js
+++ b/test/configCases/deep-scope-analysis/remove-export-scope-hoisting/webpack.config.js
@@ -18,9 +18,10 @@ module.exports = {
 							Array.isArray(ref.importedNames) &&
 							ref.importedNames.includes("unused")
 						) {
+							const newExports = ref.importedNames.filter(item => item !== "unused");
 							return new DependencyReference(
 								() => ref.module,
-								ref.importedNames.filter(item => item !== "unused"),
+								newExports.length > 0 ? newExports : false,
 								ref.weak,
 								ref.order
 							);

--- a/test/configCases/deep-scope-analysis/remove-export-scope-hoisting/webpack.config.js
+++ b/test/configCases/deep-scope-analysis/remove-export-scope-hoisting/webpack.config.js
@@ -10,7 +10,8 @@ module.exports = {
 			this.hooks.compilation.tap("Test", compilation => {
 				compilation.hooks.dependencyReference.tap(
 					"Test",
-					(ref, dep, module) => {
+					(ref, dep) => {
+						const module = compilation.moduleGraph.getParentModule(dep);
 						if (
 							module.identifier().endsWith("module.js") &&
 							ref.module &&

--- a/test/configCases/deep-scope-analysis/remove-export/webpack.config.js
+++ b/test/configCases/deep-scope-analysis/remove-export/webpack.config.js
@@ -18,9 +18,10 @@ module.exports = {
 							Array.isArray(ref.importedNames) &&
 							ref.importedNames.includes("unused")
 						) {
+							const newExports = ref.importedNames.filter(item => item !== "unused");
 							return new DependencyReference(
 								() => ref.module,
-								ref.importedNames.filter(item => item !== "unused"),
+								newExports.length > 0 ? newExports : false,
 								ref.weak,
 								ref.order
 							);

--- a/test/configCases/deep-scope-analysis/remove-export/webpack.config.js
+++ b/test/configCases/deep-scope-analysis/remove-export/webpack.config.js
@@ -10,7 +10,8 @@ module.exports = {
 			this.hooks.compilation.tap("Test", compilation => {
 				compilation.hooks.dependencyReference.tap(
 					"Test",
-					(ref, dep, module) => {
+					(ref, dep) => {
+						const module = compilation.moduleGraph.getParentModule(dep);
 						if (
 							module.identifier().endsWith("module.js") &&
 							ref.module &&


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

New `ExportsInfo` object in `ModuleGraph` tracks all info regarding exports.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
refactoring
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
existing tests
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes
`module` argument of `getDependencyReference` was removed
It's possible to get the module of a dependency with `ModuleGraph.getParentModule` so this is not needed.
Removing it reduces complexity of other code
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
new option `optimization.mangleExports` allows to enable/disable export mangling
By default it's only enabled in production mode.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
