### PR TITLE
Fix: Terser bug - Use named imports for terser.minify

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node-libs-browser": "^2.0.0",
     "schema-utils": "^0.4.4",
     "tapable": "^1.1.0",
-    "terser-webpack-plugin": "^1.1.0",
+    "terser-webpack-plugin": "^1.2.2",
     "watchpack": "^1.5.0",
     "webpack-sources": "^1.3.0"
   },


### PR DESCRIPTION
Need to update plugin version, which fixes this bug: https://github.com/webpack-contrib/terser-webpack-plugin/pull/69

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
