### PR TITLE
[WIP] Fixes #5392. EnvironmentPlugin now extends process.env

### DIFF
--- a/lib/EnvironmentPlugin.js
+++ b/lib/EnvironmentPlugin.js
@@ -8,7 +8,7 @@
 /** @typedef {import("./Compiler")} Compiler */
 
 const WebpackError = require("./WebpackError");
-const DefinePlugin = require("./DefinePlugin");
+const ParserHelpers = require("./ParserHelpers");
 
 const needsEnvVarFix =
 	["8", "9"].indexOf(process.versions.node.split(".")[0]) >= 0 &&
@@ -33,7 +33,7 @@ class EnvironmentPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
-		const definitions = this.keys.reduce((defs, key) => {
+		const definitions = this.keys.map(key => {
 			// TODO remove once the fix has made its way into Node 8.
 			// Work around https://github.com/nodejs/node/pull/18463,
 			// affecting Node 8 & 9 by performing an OS-level
@@ -58,14 +58,38 @@ class EnvironmentPlugin {
 					compilation.warnings.push(error);
 				});
 			}
-
-			defs[`process.env.${key}`] =
-				value === undefined ? "undefined" : JSON.stringify(value);
-
-			return defs;
+			const code = value === undefined ? "undefined" : JSON.stringify(value);
+			return `process.env.${key}=${code}`;
 		}, {});
 
-		new DefinePlugin(definitions).apply(compiler);
+		const envOverrideCode =
+			definitions.reduce((defs, def) => defs + ";\n" + def) + ";\n";
+
+		compiler.hooks.normalModuleFactory.tap("EnvironmentPlugin", factory => {
+			var overridden = false;
+			const handler = (parser, options) => {
+				parser.hooks.expression
+					.for("process")
+					.tap("EnvironmentPlugin", expr => {
+						if (overridden) return;
+						overridden = true;
+						expr.range = [0, 0];
+						return ParserHelpers.toConstantDependency(parser, envOverrideCode)(
+							expr
+						);
+					});
+			};
+
+			factory.hooks.parser
+				.for("javascript/auto")
+				.tap("EnvironmentPlugin", handler);
+			factory.hooks.parser
+				.for("javascript/dynamic")
+				.tap("EnvironmentPlugin", handler);
+			factory.hooks.parser
+				.for("javascript/esm")
+				.tap("EnvironmentPlugin", handler);
+		});
 	}
 }
 


### PR DESCRIPTION
Currently, the `EnvironmentPlugin` is just a shortcut to use the `DefinePlugin` on `process.env` keys ([link](https://webpack.js.org/plugins/environment-plugin/)).

As pointed out in [#5392](https://github.com/webpack/webpack/issues/5392) this doesn't work for object destructuring:

```js
/* webpack.config.js */
const path = require("path");
const { EnvironmentPlugin } = require("webpack");

module.exports = {
    entry: "./main.js",
    output: {
        path: path.resolve(__dirname),
        filename: "bundle.js"
    },
    plugins: [
        new EnvironmentPlugin({
            "MY_VAR": "I'm your var!"
        })
    ]
};

/* main.js */
const { MY_VAR } = process.env; // undefined
```
The problem is that the `DefinePlugin` can't detect some edge case like:
```js
const key = 'MY_VAR'
const MY_VAR = process.env[key] // undefined
```

To solve this I add some code at the beginning of the output, that initializes the environment variables. For example, the result would be
```js
/* main.js */
const { MY_VAR } = process.env;

/* bundle.js */
process.env.MY_VAR="I'm your var";
const { MY_VAR } = process.env;
```

I've tried different solutions but removing the `DefinePlugin` seems the cleanest way of solving this.
This is my first contribution, every feedback is welcome 😇 

**What kind of change does this PR introduce?**

This is a bugfix 🐛

**Did you add tests for your changes?**

If this seems the correct approach to solve the issue I'm going to add some tests

**Does this PR introduce a breaking change?**

I don't think so, now it actually adds some keys to the `process.env` as you would expect.

**What needs to be documented once your changes are merged?**

I need to update the EnvironmentPlugin documentation
