### PR TITLE
Improve error report of invalid esm export

### DIFF
--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -262,7 +262,14 @@ class HarmonyModuleDecoratorRuntimeModule extends RuntimeModule {
 				]),
 				"});",
 				"Object.defineProperty(module, 'exports', {",
-				Template.indent("enumerable: true"),
+				Template.indent([
+					"enumerable: true,",
+					"set: function () {",
+					Template.indent([
+						"throw new Error('ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: ' + module.id);"
+					]),
+					"}"
+				]),
 				"});",
 				"return module;"
 			]),

--- a/test/configCases/runtime/invalid-esm-export/esm-export.js
+++ b/test/configCases/runtime/invalid-esm-export/esm-export.js
@@ -1,0 +1,1 @@
+export const foo = "foo";

--- a/test/configCases/runtime/invalid-esm-export/esm-import-cjs-export.js
+++ b/test/configCases/runtime/invalid-esm-export/esm-import-cjs-export.js
@@ -1,0 +1,2 @@
+import { foo } from "./esm-export";
+module.exports = foo + "bar";

--- a/test/configCases/runtime/invalid-esm-export/index.js
+++ b/test/configCases/runtime/invalid-esm-export/index.js
@@ -1,0 +1,7 @@
+it("should throw exception when module.exports is assigned in es module", function() {
+	expect(function() {
+		require("./esm-import-cjs-export");
+	}).toThrowError(
+		'ES Modules may not assign module.exports or exports.*, Use ESM  export syntax, instead: ./esm-import-cjs-export.js'
+	);
+});

--- a/test/configCases/runtime/invalid-esm-export/index.js
+++ b/test/configCases/runtime/invalid-esm-export/index.js
@@ -2,6 +2,6 @@ it("should throw exception when module.exports is assigned in es module", functi
 	expect(function() {
 		require("./esm-import-cjs-export");
 	}).toThrowError(
-		'ES Modules may not assign module.exports or exports.*, Use ESM  export syntax, instead: ./esm-import-cjs-export.js'
+		'ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: ./esm-import-cjs-export.js'
 	);
 });

--- a/test/configCases/runtime/invalid-esm-export/webpack.config.js
+++ b/test/configCases/runtime/invalid-esm-export/webpack.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	mode: 'development',
+};


### PR DESCRIPTION
Consider the following invalid es module:

```js
import foo from 'foo';
module.exports = 'bar';
```

Obviously this is wrong... However, you will only learn of this breaking at runtime.

Since there is an import declaration - when type is `javascript/auto` webpack will determine ESM. Though, the cjs export is obviously incorrect and will definitely break at runtime.

The problem is this error is cryptic/a byproduct of the actual issue: `Cannot assign to read only property 'exports' of object '#<Object>`.

This pr aims to improve this error message.

**What kind of change does this PR introduce?**

small refactor, i guess?

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

N/A
