### PR TITLE
Adding support for output.libraryTarget "system"

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1122,7 +1122,8 @@ export interface OutputOptions {
 		| "amd-require"
 		| "umd"
 		| "umd2"
-		| "jsonp";
+		| "jsonp"
+		| "system";
 	/**
 	 * The output directory as **absolute path** (required).
 	 */

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -137,6 +137,7 @@ class ExternalModule extends Module {
 			case "amd-require":
 			case "umd":
 			case "umd2":
+			case "system":
 				return this.getSourceForAmdOrUmdExternal(
 					this.id,
 					this.optional,

--- a/lib/LibraryTemplatePlugin.js
+++ b/lib/LibraryTemplatePlugin.js
@@ -169,6 +169,13 @@ class LibraryTemplatePlugin {
 					new JsonpExportMainTemplatePlugin(this.name).apply(compilation);
 					break;
 				}
+				case "system": {
+					const SystemMainTemplatePlugin = require("./SystemMainTemplatePlugin");
+					new SystemMainTemplatePlugin({
+						name: this.name
+					}).apply(compilation);
+					break;
+				}
 				default:
 					throw new Error(`${this.target} is not a valid Library target`);
 			}

--- a/lib/SystemMainTemplatePlugin.js
+++ b/lib/SystemMainTemplatePlugin.js
@@ -34,7 +34,7 @@ class SystemMainTemplatePlugin {
 			const externals = chunk.getModules().filter(m => m.external);
 
 			// The name this bundle should be registered as with System
-			const name = this.name ? `"${this.name}", ` : ``;
+			const name = this.name ? `"${this.name}", ` : "";
 
 			// The array of dependencies that are external to webpack and will be provided by System
 			const systemDependencies = JSON.stringify(
@@ -44,7 +44,7 @@ class SystemMainTemplatePlugin {
 			);
 
 			// The name of the variable provided by System for exporting
-			const dynamicExport = `__WEBPACK_DYNAMIC_EXPORT__`;
+			const dynamicExport = "__WEBPACK_DYNAMIC_EXPORT__";
 
 			// An array of the internal variable names for the webpack externals
 			const externalWebpackNames = externals.map(
@@ -54,33 +54,48 @@ class SystemMainTemplatePlugin {
 			// Declaring variables for the internal variable names for the webpack externals
 			const externalVarDeclarations =
 				externalWebpackNames.length > 0
-					? `\n  var ${externalWebpackNames.join(", ")};`
-					: ``;
+					? `var ${externalWebpackNames.join(", ")};`
+					: "";
 
 			// The system.register format requires an array of setter functions for externals.
 			const setters =
 				externalWebpackNames.length === 0
 					? ""
-					: `\n    setters: [` +
-					  externalWebpackNames
-							.map(
-								external =>
-									`\n      function(module) {` +
-									`\n        ${external} = module;` +
-									`\n      }`
-							)
-							.join(",") +
-					  `\n    ],`;
+					: Template.asString([
+							"setters: [",
+							Template.indent(
+								externalWebpackNames.map((external, index) =>
+									Template.asString([
+										"function(module) {",
+										Template.indent(`${external} = module;`),
+										`}${index < externalWebpackNames.length - 1 ? "," : ""}`
+									])
+								)
+							),
+							"],"
+					  ]);
 
 			return new ConcatSource(
-				`System.register(${name}${systemDependencies}, function(${dynamicExport}) {` +
-					externalVarDeclarations +
-					`\n  return {` +
-					setters +
-					`\n    execute: function() {` +
-					`\n      ${dynamicExport}(`,
+				Template.asString([
+					`System.register(${name}${systemDependencies}, function(${dynamicExport}) {`,
+					Template.indent([
+						externalVarDeclarations,
+						"return {",
+						Template.indent([
+							setters,
+							"execute: function() {",
+							Template.indent(`${dynamicExport}(`)
+						])
+					])
+				]),
 				source,
-				`\n      )\n    }\n  };\n});`
+				Template.asString([
+					Template.indent([
+						Template.indent([Template.indent([");"]), "}"]),
+						"};"
+					]),
+					"})"
+				])
 			);
 		};
 

--- a/lib/SystemMainTemplatePlugin.js
+++ b/lib/SystemMainTemplatePlugin.js
@@ -34,7 +34,7 @@ class SystemMainTemplatePlugin {
 			const externals = chunk.getModules().filter(m => m.external);
 
 			// The name this bundle should be registered as with System
-			const name = this.name ? `"${this.name}", ` : "";
+			const name = this.name ? `${JSON.stringify(this.name)}, ` : "";
 
 			// The array of dependencies that are external to webpack and will be provided by System
 			const systemDependencies = JSON.stringify(
@@ -64,13 +64,15 @@ class SystemMainTemplatePlugin {
 					: Template.asString([
 							"setters: [",
 							Template.indent(
-								externalWebpackNames.map((external, index) =>
-									Template.asString([
-										"function(module) {",
-										Template.indent(`${external} = module;`),
-										`}${index < externalWebpackNames.length - 1 ? "," : ""}`
-									])
-								)
+								externalWebpackNames
+									.map(external =>
+										Template.asString([
+											"function(module) {",
+											Template.indent(`${external} = module;`),
+											"}"
+										])
+									)
+									.join(",\n")
 							),
 							"],"
 					  ]);
@@ -87,15 +89,16 @@ class SystemMainTemplatePlugin {
 							Template.indent(`${dynamicExport}(`)
 						])
 					])
-				]),
+				]) + "\n",
 				source,
-				Template.asString([
-					Template.indent([
-						Template.indent([Template.indent([");"]), "}"]),
-						"};"
-					]),
-					"})"
-				])
+				"\n" +
+					Template.asString([
+						Template.indent([
+							Template.indent([Template.indent([");"]), "}"]),
+							"};"
+						]),
+						"})"
+					])
 			);
 		};
 

--- a/lib/SystemMainTemplatePlugin.js
+++ b/lib/SystemMainTemplatePlugin.js
@@ -1,0 +1,113 @@
+/*
+ MIT License http://www.opensource.org/licenses/mit-license.php
+ Author Joel Denning @joeldenning
+ */
+
+"use strict";
+
+const { ConcatSource } = require("webpack-sources");
+const Template = require("./Template");
+
+/** @typedef {import("./Compilation")} Compilation */
+
+/**
+ * @typedef {Object} SystemMainTemplatePluginOptions
+ * @param {string=} name the library name
+ */
+
+class SystemMainTemplatePlugin {
+	/**
+	 * @param {SystemMainTemplatePluginOptions} options the plugin options
+	 */
+	constructor(options) {
+		this.name = options.name;
+	}
+
+	/**
+	 * @param {Compilation} compilation the compilation instance
+	 * @returns {void}
+	 */
+	apply(compilation) {
+		const { mainTemplate, chunkTemplate } = compilation;
+
+		const onRenderWithEntry = (source, chunk, hash) => {
+			const externals = chunk.getModules().filter(m => m.external);
+
+			// The name this bundle should be registered as with System
+			const name = this.name ? `"${this.name}", ` : ``;
+
+			// The array of dependencies that are external to webpack and will be provided by System
+			const systemDependencies = JSON.stringify(
+				externals.map(m =>
+					typeof m.request === "object" ? m.request.amd : m.request
+				)
+			);
+
+			// The name of the variable provided by System for exporting
+			const dynamicExport = `__WEBPACK_DYNAMIC_EXPORT__`;
+
+			// An array of the internal variable names for the webpack externals
+			const externalWebpackNames = externals.map(
+				m => `__WEBPACK_EXTERNAL_MODULE_${Template.toIdentifier(`${m.id}`)}__`
+			);
+
+			// Declaring variables for the internal variable names for the webpack externals
+			const externalVarDeclarations =
+				externalWebpackNames.length > 0
+					? `\n  var ${externalWebpackNames.join(", ")};`
+					: ``;
+
+			// The system.register format requires an array of setter functions for externals.
+			const setters =
+				externalWebpackNames.length === 0
+					? ""
+					: `\n    setters: [` +
+					  externalWebpackNames
+							.map(
+								external =>
+									`\n      function(module) {` +
+									`\n        ${external} = module;` +
+									`\n      }`
+							)
+							.join(",") +
+					  `\n    ],`;
+
+			return new ConcatSource(
+				`System.register(${name}${systemDependencies}, function(${dynamicExport}) {` +
+					externalVarDeclarations +
+					`\n  return {` +
+					setters +
+					`\n    execute: function() {` +
+					`\n      ${dynamicExport}(`,
+				source,
+				`\n      )\n    }\n  };\n});`
+			);
+		};
+
+		for (const template of [mainTemplate, chunkTemplate]) {
+			template.hooks.renderWithEntry.tap(
+				"SystemMainTemplatePlugin",
+				onRenderWithEntry
+			);
+		}
+
+		mainTemplate.hooks.globalHashPaths.tap(
+			"SystemMainTemplatePlugin",
+			paths => {
+				if (this.name) {
+					paths.push(this.name);
+				}
+				return paths;
+			}
+		);
+
+		mainTemplate.hooks.hash.tap("SystemMainTemplatePlugin", hash => {
+			hash.update("exports system");
+			if (this.name) {
+				hash.update(this.name);
+			}
+		});
+	}
+}
+
+module.exports = SystemMainTemplatePlugin;

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -986,7 +986,8 @@
             "amd-require",
             "umd",
             "umd2",
-            "jsonp"
+            "jsonp",
+            "system"
           ]
         },
         "path": {

--- a/test/configCases/externals/externals-system/index.js
+++ b/test/configCases/externals/externals-system/index.js
@@ -1,16 +1,11 @@
 /* This test verifies that webpack externals are properly indicated as dependencies to System.
  * Also that when System provides the external variables to webpack that the variables get plumbed
  * through correctly and are usable by the webpack bundle.
-*/
-afterEach(function(done) {
-	delete global.System;
-	done()
-})
-
+ */
 it("should get an external from System", function() {
 	const external1 = require("external1");
-	expect(external1).toBe('the external1 value');
+	expect(external1).toBe("the external1 value");
 
 	const external2 = require("external2");
-	expect(external2).toBe('the external2 value');
+	expect(external2).toBe("the external2 value");
 });

--- a/test/configCases/externals/externals-system/index.js
+++ b/test/configCases/externals/externals-system/index.js
@@ -3,14 +3,14 @@
  * through correctly and are usable by the webpack bundle.
 */
 afterEach(function(done) {
-  delete global.System;
-  done()
+	delete global.System;
+	done()
 })
 
 it("should get an external from System", function() {
 	const external1 = require("external1");
 	expect(external1).toBe('the external1 value');
 
-  const external2 = require("external2");
-  expect(external2).toBe('the external2 value');
+	const external2 = require("external2");
+	expect(external2).toBe('the external2 value');
 });

--- a/test/configCases/externals/externals-system/index.js
+++ b/test/configCases/externals/externals-system/index.js
@@ -1,0 +1,16 @@
+/* This test verifies that webpack externals are properly indicated as dependencies to System.
+ * Also that when System provides the external variables to webpack that the variables get plumbed
+ * through correctly and are usable by the webpack bundle.
+*/
+afterEach(function(done) {
+  delete global.System;
+  done()
+})
+
+it("should get an external from System", function() {
+	const external1 = require("external1");
+	expect(external1).toBe('the external1 value');
+
+  const external2 = require("external2");
+  expect(external2).toBe('the external2 value');
+});

--- a/test/configCases/externals/externals-system/test.config.js
+++ b/test/configCases/externals/externals-system/test.config.js
@@ -1,0 +1,16 @@
+const System = require("../../../helpers/fakeSystem");
+
+module.exports = {
+	beforeExecute: () => {
+		System.init({
+			external1: "the external1 value",
+			external2: "the external2 value"
+		});
+	},
+	moduleScope(scope) {
+		scope.System = System;
+	},
+	afterExecute: () => {
+		System.execute("(anonym)");
+	}
+};

--- a/test/configCases/externals/externals-system/webpack.config.js
+++ b/test/configCases/externals/externals-system/webpack.config.js
@@ -1,0 +1,31 @@
+const webpack = require("../../../../");
+module.exports = {
+	output: {
+		libraryTarget: "system"
+	},
+	externals: {
+		external1: "external1",
+		external2: "external2"
+	},
+	plugins: [
+		new webpack.BannerPlugin({
+			raw: true,
+			banner: `
+        System = {
+          register: function(deps, fn) {
+            function dynamicExport() {}
+            var mod = fn(dynamicExport);
+            deps.forEach((dep, i) => {
+              mod.setters[i](System.registry[dep]);
+            })
+            mod.execute();
+          },
+          registry: {
+            external1: 'the external1 value',
+            external2: 'the external2 value',
+          },
+        }
+      `
+		})
+	]
+};

--- a/test/configCases/externals/externals-system/webpack.config.js
+++ b/test/configCases/externals/externals-system/webpack.config.js
@@ -1,4 +1,3 @@
-const webpack = require("../../../../");
 module.exports = {
 	output: {
 		libraryTarget: "system"
@@ -6,26 +5,5 @@ module.exports = {
 	externals: {
 		external1: "external1",
 		external2: "external2"
-	},
-	plugins: [
-		new webpack.BannerPlugin({
-			raw: true,
-			banner: `
-				System = {
-					register: function(deps, fn) {
-						function dynamicExport() {}
-						var mod = fn(dynamicExport);
-						deps.forEach((dep, i) => {
-							mod.setters[i](System.registry[dep]);
-						})
-						mod.execute();
-					},
-					registry: {
-						external1: 'the external1 value',
-						external2: 'the external2 value',
-					},
-				}
-			`
-		})
-	]
+	}
 };

--- a/test/configCases/externals/externals-system/webpack.config.js
+++ b/test/configCases/externals/externals-system/webpack.config.js
@@ -11,21 +11,21 @@ module.exports = {
 		new webpack.BannerPlugin({
 			raw: true,
 			banner: `
-        System = {
-          register: function(deps, fn) {
-            function dynamicExport() {}
-            var mod = fn(dynamicExport);
-            deps.forEach((dep, i) => {
-              mod.setters[i](System.registry[dep]);
-            })
-            mod.execute();
-          },
-          registry: {
-            external1: 'the external1 value',
-            external2: 'the external2 value',
-          },
-        }
-      `
+				System = {
+					register: function(deps, fn) {
+						function dynamicExport() {}
+						var mod = fn(dynamicExport);
+						deps.forEach((dep, i) => {
+							mod.setters[i](System.registry[dep]);
+						})
+						mod.execute();
+					},
+					registry: {
+						external1: 'the external1 value',
+						external2: 'the external2 value',
+					},
+				}
+			`
 		})
 	]
 };

--- a/test/configCases/target/system-export/index.js
+++ b/test/configCases/target/system-export/index.js
@@ -1,22 +1,13 @@
 // This test verifies that values exported by a webpack bundle are consumable by systemjs.
 
 export const namedThing = {
-	hello: 'there'
-}
+	hello: "there"
+};
 
-export default 'the default export'
+export default "the default export";
 
-it("should successfully export values to System", function(done) {
-	var fs = require("fs");
-	var source = fs.readFileSync(__filename, "utf-8");
-
-	// set timeout allows the webpack bundle to finish exporting, which exports to System at the very
-	// end of its execution.
-	setTimeout(() => {
-		expect(global.SystemExports['default']).toBe('the default export')
-		expect(global.SystemExports.namedThing).toBe(namedThing)
-		delete global.System;
-		delete global.SystemExports
-		done()
-	})
+it("should successfully export values to System", function() {
+	const exports = eval("System").registry["(anonym)"].exports;
+	expect(exports["default"]).toBe("the default export");
+	expect(exports.namedThing).toBe(namedThing);
 });

--- a/test/configCases/target/system-export/index.js
+++ b/test/configCases/target/system-export/index.js
@@ -1,0 +1,22 @@
+// This test verifies that values exported by a webpack bundle are consumable by systemjs.
+
+export const namedThing = {
+	hello: 'there'
+}
+
+export default 'the default export'
+
+it("should successfully export values to System", function(done) {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+
+	// set timeout allows the webpack bundle to finish exporting, which exports to System at the very
+	// end of its execution.
+	setTimeout(() => {
+		expect(global.SystemExports['default']).toBe('the default export')
+		expect(global.SystemExports.namedThing).toBe(namedThing)
+		delete global.System;
+		delete global.SystemExports
+		done()
+	})
+});

--- a/test/configCases/target/system-export/test.config.js
+++ b/test/configCases/target/system-export/test.config.js
@@ -1,0 +1,13 @@
+const System = require("../../../helpers/fakeSystem");
+
+module.exports = {
+	beforeExecute: () => {
+		System.init();
+	},
+	moduleScope(scope) {
+		scope.System = System;
+	},
+	afterExecute: () => {
+		System.execute("(anonym)");
+	}
+};

--- a/test/configCases/target/system-export/webpack.config.js
+++ b/test/configCases/target/system-export/webpack.config.js
@@ -1,4 +1,3 @@
-const webpack = require("../../../../");
 module.exports = {
 	output: {
 		libraryTarget: "system"
@@ -6,23 +5,5 @@ module.exports = {
 	node: {
 		__dirname: false,
 		__filename: false
-	},
-	plugins: [
-		new webpack.BannerPlugin({
-			raw: true,
-			banner: `
-				global.SystemExports = {
-					'export': function(exports) {
-						Object.assign(global.SystemExports, exports);
-					}
-				};
-				global.System = {
-					register: function(deps, fn) {
-						var mod = fn(global.SystemExports['export']);
-						mod.execute();
-					}
-				};
-			`
-		})
-	]
+	}
 };

--- a/test/configCases/target/system-export/webpack.config.js
+++ b/test/configCases/target/system-export/webpack.config.js
@@ -1,0 +1,28 @@
+const webpack = require("../../../../");
+module.exports = {
+	output: {
+		libraryTarget: "system"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	plugins: [
+		new webpack.BannerPlugin({
+			raw: true,
+			banner: `
+				global.SystemExports = {
+					'export': function(exports) {
+						Object.assign(global.SystemExports, exports);
+					}
+				};
+				global.System = {
+					register: function(deps, fn) {
+						var mod = fn(global.SystemExports['export']);
+						mod.execute();
+					}
+				};
+			`
+		})
+	]
+};

--- a/test/configCases/target/system-named/index.js
+++ b/test/configCases/target/system-named/index.js
@@ -1,0 +1,15 @@
+/* This test verifies that when output.library is specified that the compiled bundle provides
+* the library name to System during the System.register
+*/
+
+afterEach(function(done) {
+	delete global.System;
+	done()
+})
+
+it("should call System.register without a name", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+
+	expect(source).toMatch(/.*System\.register\("named-system-module", \[[^\]]*\]/);
+});

--- a/test/configCases/target/system-named/index.js
+++ b/test/configCases/target/system-named/index.js
@@ -7,7 +7,7 @@ afterEach(function(done) {
 	done()
 })
 
-it("should call System.register without a name", function() {
+it("should call System.register with a name", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename, "utf-8");
 

--- a/test/configCases/target/system-named/index.js
+++ b/test/configCases/target/system-named/index.js
@@ -1,15 +1,5 @@
 /* This test verifies that when output.library is specified that the compiled bundle provides
-* the library name to System during the System.register
-*/
+ * the library name to System during the System.register
+ */
 
-afterEach(function(done) {
-	delete global.System;
-	done()
-})
-
-it("should call System.register with a name", function() {
-	var fs = require("fs");
-	var source = fs.readFileSync(__filename, "utf-8");
-
-	expect(source).toMatch(/.*System\.register\("named-system-module", \[[^\]]*\]/);
-});
+it("should call System.register with a name", function() {});

--- a/test/configCases/target/system-named/test.config.js
+++ b/test/configCases/target/system-named/test.config.js
@@ -1,0 +1,13 @@
+const System = require("../../../helpers/fakeSystem");
+
+module.exports = {
+	beforeExecute: () => {
+		System.init();
+	},
+	moduleScope(scope) {
+		scope.System = System;
+	},
+	afterExecute: () => {
+		System.execute("named-system-module");
+	}
+};

--- a/test/configCases/target/system-named/webpack.config.js
+++ b/test/configCases/target/system-named/webpack.config.js
@@ -1,0 +1,25 @@
+const webpack = require("../../../../");
+module.exports = {
+	output: {
+		library: "named-system-module",
+		libraryTarget: "system"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	plugins: [
+		new webpack.BannerPlugin({
+			raw: true,
+			banner: `
+				System = {
+					register: function(name, deps, fn) {
+						function dynamicExport() {}
+						var mod = fn(dynamicExport);
+						mod.execute();
+					}
+				}
+			`
+		})
+	]
+};

--- a/test/configCases/target/system-named/webpack.config.js
+++ b/test/configCases/target/system-named/webpack.config.js
@@ -1,4 +1,3 @@
-const webpack = require("../../../../");
 module.exports = {
 	output: {
 		library: "named-system-module",
@@ -7,19 +6,5 @@ module.exports = {
 	node: {
 		__dirname: false,
 		__filename: false
-	},
-	plugins: [
-		new webpack.BannerPlugin({
-			raw: true,
-			banner: `
-				System = {
-					register: function(name, deps, fn) {
-						function dynamicExport() {}
-						var mod = fn(dynamicExport);
-						mod.execute();
-					}
-				}
-			`
-		})
-	]
+	}
 };

--- a/test/configCases/target/system-unnamed/index.js
+++ b/test/configCases/target/system-unnamed/index.js
@@ -1,0 +1,15 @@
+/* This test verifies that when there is no output.library specified that the call to
+* System.register does not include a name argument.
+*/
+
+afterEach(function(done) {
+	delete global.System;
+	done()
+})
+
+it("should call System.register without a name", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+
+	expect(source).toMatch(/.*System\.register\(\[[^\]]*\], function\(__WEBPACK_DYNAMIC_EXPORT__\) {\s+(var .*;)?\s*return \{\s+setters: [^]+,[^]+execute: function\(\) {/);
+});

--- a/test/configCases/target/system-unnamed/index.js
+++ b/test/configCases/target/system-unnamed/index.js
@@ -1,15 +1,5 @@
 /* This test verifies that when there is no output.library specified that the call to
-* System.register does not include a name argument.
-*/
+ * System.register does not include a name argument.
+ */
 
-afterEach(function(done) {
-	delete global.System;
-	done()
-})
-
-it("should call System.register without a name", function() {
-	var fs = require("fs");
-	var source = fs.readFileSync(__filename, "utf-8");
-
-	expect(source).toMatch(/.*System\.register\(\[[^\]]*\], function\(__WEBPACK_DYNAMIC_EXPORT__\) {\s+(var .*;)?\s*return \{\s+setters: [^]+,[^]+execute: function\(\) {/);
-});
+it("should call System.register without a name", function() {});

--- a/test/configCases/target/system-unnamed/test.config.js
+++ b/test/configCases/target/system-unnamed/test.config.js
@@ -1,0 +1,13 @@
+const System = require("../../../helpers/fakeSystem");
+
+module.exports = {
+	beforeExecute: () => {
+		System.init();
+	},
+	moduleScope(scope) {
+		scope.System = System;
+	},
+	afterExecute: () => {
+		System.execute("(anonym)");
+	}
+};

--- a/test/configCases/target/system-unnamed/webpack.config.js
+++ b/test/configCases/target/system-unnamed/webpack.config.js
@@ -1,4 +1,3 @@
-const webpack = require("../../../../");
 module.exports = {
 	output: {
 		libraryTarget: "system"
@@ -6,20 +5,5 @@ module.exports = {
 	node: {
 		__dirname: false,
 		__filename: false
-	},
-	plugins: [
-		new webpack.BannerPlugin({
-			raw: true,
-			banner: `
-				System = {
-					register: function(deps, fn) {
-						function dynamicExport() {}
-
-						var mod = fn(dynamicExport)
-						mod.execute()
-					}
-				}
-			`
-		})
-	]
+	}
 };

--- a/test/configCases/target/system-unnamed/webpack.config.js
+++ b/test/configCases/target/system-unnamed/webpack.config.js
@@ -1,0 +1,25 @@
+const webpack = require("../../../../");
+module.exports = {
+	output: {
+		libraryTarget: "system"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	plugins: [
+		new webpack.BannerPlugin({
+			raw: true,
+			banner: `
+				System = {
+					register: function(deps, fn) {
+						function dynamicExport() {}
+
+						var mod = fn(dynamicExport)
+						mod.execute()
+					}
+				}
+			`
+		})
+	]
+};

--- a/test/helpers/fakeSystem.js
+++ b/test/helpers/fakeSystem.js
@@ -1,0 +1,80 @@
+const System = {
+	register: (name, deps, fn) => {
+		if (!System.registry) {
+			throw new Error("System is no initialized");
+		}
+		if (typeof name !== "string") {
+			fn = deps;
+			deps = name;
+			name = "(anonym)";
+		}
+		if (!Array.isArray(deps)) {
+			fn = deps;
+			deps = [];
+		}
+		const dynamicExport = result => {
+			if (System.registry[name] !== entry) {
+				throw new Error(`Module ${name} calls dynamicExport too late`);
+			}
+			entry.exports = result;
+		};
+		if (name in System.registry) {
+			throw new Error(`Module ${name} is already registered`);
+		}
+		const mod = fn(dynamicExport);
+		if (deps.length > 0) {
+			if (!Array.isArray(mod.setters)) {
+				throw new Error(
+					`Module ${name} must have setters, because it has dependencies`
+				);
+			}
+			if (mod.setters.length !== deps.length) {
+				throw new Error(
+					`Module ${name} has incorrect number of setters for the dependencies`
+				);
+			}
+		}
+		const entry = {
+			name,
+			deps,
+			fn,
+			mod,
+			executed: false,
+			exports: undefined
+		};
+		System.registry[name] = entry;
+	},
+	registry: undefined,
+	init: modules => {
+		System.registry = {};
+		if (modules) {
+			for (const name of Object.keys(modules)) {
+				System.registry[name] = {
+					executed: true,
+					exports: modules[name]
+				};
+			}
+		}
+	},
+	execute: name => {
+		const m = System.registry[name];
+		if (!m) throw new Error(`Module ${name} not registered`);
+		if (m.executed) throw new Error(`Module ${name} was already executed`);
+		return System.ensureExecuted(name);
+	},
+	ensureExecuted: name => {
+		const m = System.registry[name];
+		if (!m) throw new Error(`Module ${name} not registered`);
+		if (!m.executed) {
+			m.executed = true;
+			for (let i = 0; i < m.deps.length; i++) {
+				const dep = m.deps[i];
+				System.ensureExecuted(dep);
+				m.mod.setters[i](System.registry[dep].exports);
+			}
+			m.mod.execute();
+		}
+		return m.exports;
+	}
+};
+module.exports = System;


### PR DESCRIPTION
Resolves #8833. cc @sokra @guybedford

**What kind of change does this PR introduce?**
A new feature

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No -- completely new feature

**What needs to be documented once your changes are merged?**
We'll need to update the [output.libraryTarget docs](https://webpack.js.org/configuration/output/#outputlibrarytarget) to indicate that `"system"` is now a valid output option.