### PR TITLE
Allow options.amd to disable AMDPlugin/RequireJsStuffPlugin

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -249,7 +249,7 @@ export interface WebpackOptions {
 	 * Set the value of `require.amd` and `define.amd`. Or disable AMD support.
 	 */
 	amd?:
-		| boolean
+		| false
 		| {
 				[k: string]: any;
 		  };

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -250,7 +250,7 @@ export interface WebpackOptions {
 	 */
 	amd?: {
 		[k: string]: any;
-	};
+	} | false;
 	/**
 	 * Report the first error as a hard error instead of tolerating it.
 	 */

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -246,11 +246,13 @@ export type FilterItemTypes = RegExp | string | Function;
 
 export interface WebpackOptions {
 	/**
-	 * Set the value of `require.amd` and `define.amd`.
+	 * Set the value of `require.amd` and `define.amd`. Or disable AMD support.
 	 */
-	amd?: {
-		[k: string]: any;
-	} | false;
+	amd?:
+		| boolean
+		| {
+				[k: string]: any;
+		  };
 	/**
 	 * Report the first error as a hard error instead of tolerating it.
 	 */

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -21,7 +21,6 @@ const RecordIdsPlugin = require("./RecordIdsPlugin");
 
 const APIPlugin = require("./APIPlugin");
 const ConstPlugin = require("./ConstPlugin");
-const RequireJsStuffPlugin = require("./RequireJsStuffPlugin");
 const NodeStuffPlugin = require("./NodeStuffPlugin");
 const CompatibilityPlugin = require("./CompatibilityPlugin");
 
@@ -34,7 +33,6 @@ const CommonJsPlugin = require("./dependencies/CommonJsPlugin");
 const HarmonyModulesPlugin = require("./dependencies/HarmonyModulesPlugin");
 const SystemPlugin = require("./dependencies/SystemPlugin");
 const ImportPlugin = require("./dependencies/ImportPlugin");
-const AMDPlugin = require("./dependencies/AMDPlugin");
 const RequireContextPlugin = require("./dependencies/RequireContextPlugin");
 const RequireEnsurePlugin = require("./dependencies/RequireEnsurePlugin");
 const RequireIncludePlugin = require("./dependencies/RequireIncludePlugin");
@@ -308,11 +306,15 @@ class WebpackOptionsApply extends OptionsApply {
 
 		new CompatibilityPlugin().apply(compiler);
 		new HarmonyModulesPlugin(options.module).apply(compiler);
-		new AMDPlugin(options.module, options.amd || {}).apply(compiler);
+		if(options.amd !== false) {
+			const AMDPlugin = require("./dependencies/AMDPlugin");
+			const RequireJsStuffPlugin = require("./RequireJsStuffPlugin");
+			new AMDPlugin(options.module, options.amd || {}).apply(compiler);
+			new RequireJsStuffPlugin().apply(compiler);
+		}
 		new CommonJsPlugin(options.module).apply(compiler);
 		new LoaderPlugin().apply(compiler);
 		new NodeStuffPlugin(options.node).apply(compiler);
-		new RequireJsStuffPlugin().apply(compiler);
 		new APIPlugin().apply(compiler);
 		new ConstPlugin().apply(compiler);
 		new UseStrictPlugin().apply(compiler);

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -306,7 +306,7 @@ class WebpackOptionsApply extends OptionsApply {
 
 		new CompatibilityPlugin().apply(compiler);
 		new HarmonyModulesPlugin(options.module).apply(compiler);
-		if(options.amd !== false) {
+		if (options.amd !== false) {
 			const AMDPlugin = require("./dependencies/AMDPlugin");
 			const RequireJsStuffPlugin = require("./RequireJsStuffPlugin");
 			new AMDPlugin(options.module, options.amd || {}).apply(compiler);

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1907,7 +1907,7 @@
       "anyOf": [
         {
           "description": "You can pass `false` to disable AMD support.",
-          "type": "boolean"
+          "enum": [false]
         },
         {
           "description": "You can pass an object to set the value of `require.amd` and `define.amd`.",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1903,7 +1903,17 @@
   "additionalProperties": false,
   "properties": {
     "amd": {
-      "description": "Set the value of `require.amd` and `define.amd`."
+      "description": "Set the value of `require.amd` and `define.amd`. Or disable AMD support.",
+      "anyOf": [
+        {
+          "description": "You can pass `false` to disable AMD support.",
+          "type": "boolean"
+        },
+        {
+          "description": "You can pass an object to set the value of `require.amd` and `define.amd`.",
+          "type": "object"
+        }
+      ]
     },
     "bail": {
       "description": "Report the first error as a hard error instead of tolerating it.",

--- a/test/configCases/amd/disabled/index.js
+++ b/test/configCases/amd/disabled/index.js
@@ -1,0 +1,3 @@
+it("should compile", function(done) {
+	done();
+});

--- a/test/configCases/amd/disabled/index.js
+++ b/test/configCases/amd/disabled/index.js
@@ -4,4 +4,5 @@ it("should compile", function(done) {
 
 it("should disable define", function(done) {
 	expect(typeof define).toBe('undefined')
+	done()
 })

--- a/test/configCases/amd/disabled/index.js
+++ b/test/configCases/amd/disabled/index.js
@@ -1,3 +1,7 @@
 it("should compile", function(done) {
 	done();
 });
+
+it("should disable define", function(done) {
+	expect(typeof define).toBe('undefined')
+})

--- a/test/configCases/amd/disabled/webpack.config.js
+++ b/test/configCases/amd/disabled/webpack.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  amd: false
+	amd: false
 };

--- a/test/configCases/amd/disabled/webpack.config.js
+++ b/test/configCases/amd/disabled/webpack.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  amd: false
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
As discussed with @sokra:

Introduces a new value `false` for `options.amd` that disables AMD support completely.

This would mainly be useful in for example ncc, Next.js etc where it’s either fully commonjs/esmodules (ncc) or fully esmodules (Next.js)


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Feature

**Did you add tests for your changes?**

Still have to add one 👍
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

https://webpack.js.org/configuration/other-options/#amd

- The `amd` value can be set to `false` which will disable webpack's AMD support.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
