### PR TITLE
Only Require Plugins When Needed

### DIFF
--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -39,13 +39,6 @@ const RequireContextPlugin = require("./dependencies/RequireContextPlugin");
 const RequireEnsurePlugin = require("./dependencies/RequireEnsurePlugin");
 const RequireIncludePlugin = require("./dependencies/RequireIncludePlugin");
 
-const WarnNoModeSetPlugin = require("./WarnNoModeSetPlugin");
-
-const EnsureChunkConditionsPlugin = require("./optimize/EnsureChunkConditionsPlugin");
-const RemoveParentModulesPlugin = require("./optimize/RemoveParentModulesPlugin");
-const RemoveEmptyChunksPlugin = require("./optimize/RemoveEmptyChunksPlugin");
-const MergeDuplicateChunksPlugin = require("./optimize/MergeDuplicateChunksPlugin");
-
 /** @typedef {import("../declarations/WebpackOptions").WebpackOptions} WebpackOptions */
 /** @typedef {import("./Compiler")} Compiler */
 
@@ -310,14 +303,18 @@ class WebpackOptionsApply extends OptionsApply {
 		new SystemPlugin(options.module).apply(compiler);
 
 		if (typeof options.mode !== "string") {
+			const WarnNoModeSetPlugin = require("./WarnNoModeSetPlugin");
 			new WarnNoModeSetPlugin().apply(compiler);
 		}
 
+		const EnsureChunkConditionsPlugin = require("./optimize/EnsureChunkConditionsPlugin");
 		new EnsureChunkConditionsPlugin().apply(compiler);
 		if (options.optimization.removeAvailableModules) {
+			const RemoveParentModulesPlugin = require("./optimize/RemoveParentModulesPlugin");
 			new RemoveParentModulesPlugin().apply(compiler);
 		}
 		if (options.optimization.removeEmptyChunks) {
+			const RemoveEmptyChunksPlugin = require("./optimize/RemoveEmptyChunksPlugin");
 			new RemoveEmptyChunksPlugin().apply(compiler);
 		}
 		if (options.optimization.mergeDuplicateChunks) {

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -45,23 +45,6 @@ const EnsureChunkConditionsPlugin = require("./optimize/EnsureChunkConditionsPlu
 const RemoveParentModulesPlugin = require("./optimize/RemoveParentModulesPlugin");
 const RemoveEmptyChunksPlugin = require("./optimize/RemoveEmptyChunksPlugin");
 const MergeDuplicateChunksPlugin = require("./optimize/MergeDuplicateChunksPlugin");
-const FlagIncludedChunksPlugin = require("./optimize/FlagIncludedChunksPlugin");
-const OccurrenceChunkOrderPlugin = require("./optimize/OccurrenceChunkOrderPlugin");
-const OccurrenceModuleOrderPlugin = require("./optimize/OccurrenceModuleOrderPlugin");
-const NaturalChunkOrderPlugin = require("./optimize/NaturalChunkOrderPlugin");
-const SideEffectsFlagPlugin = require("./optimize/SideEffectsFlagPlugin");
-const FlagDependencyUsagePlugin = require("./FlagDependencyUsagePlugin");
-const FlagDependencyExportsPlugin = require("./FlagDependencyExportsPlugin");
-const ModuleConcatenationPlugin = require("./optimize/ModuleConcatenationPlugin");
-const SplitChunksPlugin = require("./optimize/SplitChunksPlugin");
-const RuntimeChunkPlugin = require("./optimize/RuntimeChunkPlugin");
-const NoEmitOnErrorsPlugin = require("./NoEmitOnErrorsPlugin");
-const NamedModulesPlugin = require("./NamedModulesPlugin");
-const NamedChunksPlugin = require("./NamedChunksPlugin");
-const HashedModuleIdsPlugin = require("./HashedModuleIdsPlugin");
-const DefinePlugin = require("./DefinePlugin");
-const SizeLimitsPlugin = require("./performance/SizeLimitsPlugin");
-const WasmFinalizeExportsPlugin = require("./wasm/WasmFinalizeExportsPlugin");
 
 /** @typedef {import("../declarations/WebpackOptions").WebpackOptions} WebpackOptions */
 /** @typedef {import("./Compiler")} Compiler */
@@ -338,33 +321,43 @@ class WebpackOptionsApply extends OptionsApply {
 			new RemoveEmptyChunksPlugin().apply(compiler);
 		}
 		if (options.optimization.mergeDuplicateChunks) {
+			const MergeDuplicateChunksPlugin = require("./optimize/MergeDuplicateChunksPlugin");
 			new MergeDuplicateChunksPlugin().apply(compiler);
 		}
 		if (options.optimization.flagIncludedChunks) {
+			const FlagIncludedChunksPlugin = require("./optimize/FlagIncludedChunksPlugin");
 			new FlagIncludedChunksPlugin().apply(compiler);
 		}
 		if (options.optimization.sideEffects) {
+			const SideEffectsFlagPlugin = require("./optimize/SideEffectsFlagPlugin");
 			new SideEffectsFlagPlugin().apply(compiler);
 		}
 		if (options.optimization.providedExports) {
+			const FlagDependencyExportsPlugin = require("./FlagDependencyExportsPlugin");
 			new FlagDependencyExportsPlugin().apply(compiler);
 		}
 		if (options.optimization.usedExports) {
+			const FlagDependencyUsagePlugin = require("./FlagDependencyUsagePlugin");
 			new FlagDependencyUsagePlugin().apply(compiler);
 		}
 		if (options.optimization.concatenateModules) {
+			const ModuleConcatenationPlugin = require("./optimize/ModuleConcatenationPlugin");
 			new ModuleConcatenationPlugin().apply(compiler);
 		}
 		if (options.optimization.splitChunks) {
+			const SplitChunksPlugin = require("./optimize/SplitChunksPlugin");
 			new SplitChunksPlugin(options.optimization.splitChunks).apply(compiler);
 		}
 		if (options.optimization.runtimeChunk) {
+			const RuntimeChunkPlugin = require("./optimize/RuntimeChunkPlugin");
 			new RuntimeChunkPlugin(options.optimization.runtimeChunk).apply(compiler);
 		}
 		if (options.optimization.noEmitOnErrors) {
+			const NoEmitOnErrorsPlugin = require("./NoEmitOnErrorsPlugin");
 			new NoEmitOnErrorsPlugin().apply(compiler);
 		}
 		if (options.optimization.checkWasmTypes) {
+			const WasmFinalizeExportsPlugin = require("./wasm/WasmFinalizeExportsPlugin");
 			new WasmFinalizeExportsPlugin().apply(compiler);
 		}
 		let moduleIds = options.optimization.moduleIds;
@@ -384,6 +377,9 @@ class WebpackOptionsApply extends OptionsApply {
 			}
 		}
 		if (moduleIds) {
+			const NamedModulesPlugin = require("./NamedModulesPlugin");
+			const HashedModuleIdsPlugin = require("./HashedModuleIdsPlugin");
+			const OccurrenceModuleOrderPlugin = require("./optimize/OccurrenceModuleOrderPlugin");
 			switch (moduleIds) {
 				case "natural":
 					// TODO webpack 5: see hint in Compilation.sortModules
@@ -426,6 +422,9 @@ class WebpackOptionsApply extends OptionsApply {
 			}
 		}
 		if (chunkIds) {
+			const NaturalChunkOrderPlugin = require("./optimize/NaturalChunkOrderPlugin");
+			const NamedChunksPlugin = require("./NamedChunksPlugin");
+			const OccurrenceChunkOrderPlugin = require("./optimize/OccurrenceChunkOrderPlugin");
 			switch (chunkIds) {
 				case "natural":
 					new NaturalChunkOrderPlugin().apply(compiler);
@@ -456,6 +455,7 @@ class WebpackOptionsApply extends OptionsApply {
 			}
 		}
 		if (options.optimization.nodeEnv) {
+			const DefinePlugin = require("./DefinePlugin");
 			new DefinePlugin({
 				"process.env.NODE_ENV": JSON.stringify(options.optimization.nodeEnv)
 			}).apply(compiler);
@@ -471,6 +471,7 @@ class WebpackOptionsApply extends OptionsApply {
 		}
 
 		if (options.performance) {
+			const SizeLimitsPlugin = require("./performance/SizeLimitsPlugin");
 			new SizeLimitsPlugin(options.performance).apply(compiler);
 		}
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Instead of requiring plugins at the top of the file, they are required right before their instantiation. This can help shrink bootup cost as not all plugins will need to be required.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Refactoring/Performance tweak

**Did you add tests for your changes?**

N/A

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

N/A