### PR TITLE
Preset option for errors & warnings only

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -369,7 +369,14 @@ export interface WebpackOptions {
 	stats?:
 		| StatsOptions
 		| boolean
-		| ("none" | "errors-only" | "minimal" | "normal" | "detailed" | "verbose" | "errors-warnings");
+		| (
+				| "none"
+				| "errors-only"
+				| "minimal"
+				| "normal"
+				| "detailed"
+				| "verbose"
+				| "errors-warnings");
 	/**
 	 * Environment to build for
 	 */

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -369,7 +369,7 @@ export interface WebpackOptions {
 	stats?:
 		| StatsOptions
 		| boolean
-		| ("none" | "errors-only" | "minimal" | "normal" | "detailed" | "verbose");
+		| ("none" | "errors-only" | "minimal" | "normal" | "detailed" | "verbose" | "errors-warnings");
 	/**
 	 * Environment to build for
 	 */

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -1408,6 +1408,12 @@ class Stats {
 					errors: true,
 					moduleTrace: true
 				};
+			case "errors-warnings":
+				return {
+					all: false,
+					errors: true,
+					warnings: true
+				};
 			default:
 				return {};
 		}

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2109,7 +2109,8 @@
             "minimal",
             "normal",
             "detailed",
-            "verbose"
+            "verbose",
+            "errors-warnings"
           ]
         }
       ]

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1915,6 +1915,8 @@ Module not found: Error: Can't resolve 'does-not-exist' in 'Xdir/preset-errors-o
  @ ./index.js 1:0-25"
 `;
 
+exports[`StatsTestCases should print correct stats for preset-errors-warnings 1`] = `""`;
+
 exports[`StatsTestCases should print correct stats for preset-minimal 1`] = `"   6 modules"`;
 
 exports[`StatsTestCases should print correct stats for preset-minimal-simple 1`] = `"   1 module"`;

--- a/test/statsCases/preset-errors-warnings/webpack.config.js
+++ b/test/statsCases/preset-errors-warnings/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	mode: "production",
+	entry: "./index",
+	stats: "errors-warnings"
+};


### PR DESCRIPTION
I've noticed that I often need just see warnings and errors since during rapid development I don't really need to see the modules stats. So I tend to write the same code every time and it would be nice to be able to just provide an "errors-warnings" preset to save space and improve readability.

**What kind of change does this PR introduce?**

Extension to the existing stats preset.

**Did you add tests for your changes?**

Tests added.

**Does this PR introduce a breaking change?**

No, this is a just an extension which will not break anything

**What needs to be documented once your changes are merged?**

The following page will need to be updated with additional stats preset option: https://webpack.js.org/configuration/stats/