### PR TITLE
Use find-cache-dir in order to calculate the webpack default cache directory

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -5,7 +5,9 @@
 
 "use strict";
 
+const findCacheDir = require("find-cache-dir");
 const path = require("path");
+const os = require("os");
 const OptionsDefaulter = require("./OptionsDefaulter");
 const Template = require("./Template");
 
@@ -60,7 +62,8 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 					value.version = "";
 				}
 				if (value.cacheDirectory === undefined) {
-					value.cacheDirectory = "node_modules/.cache/webpack/";
+					value.cacheDirectory =
+						findCacheDir({ name: "webpack" }) || os.tmpdir();
 				}
 				if (value.cacheLocation === undefined) {
 					value.cacheLocation = path.resolve(value.cacheDirectory, value.name);

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -6,8 +6,8 @@
 "use strict";
 
 const findCacheDir = require("find-cache-dir");
-const path = require("path");
 const os = require("os");
+const path = require("path");
 const OptionsDefaulter = require("./OptionsDefaulter");
 const Template = require("./Template");
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "enhanced-resolve": "^4.1.0",
     "eslint-scope": "^4.0.0",
     "events": "^3.0.0",
+    "find-cache-dir": "^2.1.0",
     "json-parse-better-errors": "^1.0.2",
     "loader-runner": "3.0.0",
     "loader-utils": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1934,6 +1934,15 @@ find-cache-dir@^2.0.0:
     make-dir "^1.0.0"
     pkg-dir "^3.0.0"
 
+find-cache-dir@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
+  integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^2.0.0"
+    pkg-dir "^3.0.0"
+
 find-parent-dir@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
@@ -3520,6 +3529,14 @@ make-dir@^1.0.0, make-dir@^1.3.0:
   dependencies:
     pify "^3.0.0"
 
+make-dir@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
+  dependencies:
+    pify "^4.0.1"
+    semver "^5.6.0"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -4177,6 +4194,11 @@ pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
+
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -4883,7 +4905,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==


### PR DESCRIPTION
This is a small PR in order to use the same behaviour to calculate the default cache dir on webpack that we are already using into the loaders. It was discussed here https://github.com/webpack-contrib/cache-loader/pull/64

/CC @evilebottnawi 