### PR TITLE
fix(bin): remove webpack-command

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -46,52 +46,26 @@ const isInstalled = packageName => {
  * @property {string} name display name
  * @property {string} package npm package name
  * @property {string} binName name of the executable file
- * @property {string} alias shortcut for choice
  * @property {boolean} installed currently installed?
- * @property {boolean} recommended is recommended
  * @property {string} url homepage
- * @property {string} description description
  */
 
-/** @type {CliOption[]} */
-const CLIs = [
-	{
-		name: "webpack-cli",
-		package: "webpack-cli",
-		binName: "webpack-cli",
-		alias: "cli",
-		installed: isInstalled("webpack-cli"),
-		recommended: true,
-		url: "https://github.com/webpack/webpack-cli",
-		description: "The original webpack full-featured CLI."
-	},
-	{
-		name: "webpack-command",
-		package: "webpack-command",
-		binName: "webpack-command",
-		alias: "command",
-		installed: isInstalled("webpack-command"),
-		recommended: false,
-		url: "https://github.com/webpack-contrib/webpack-command",
-		description: "A lightweight, opinionated webpack CLI."
-	}
-];
+/** @type {CliOption} */
+const cli = {
+	name: "webpack-cli",
+	package: "webpack-cli",
+	binName: "webpack-cli",
+	installed: isInstalled("webpack-cli"),
+	url: "https://github.com/webpack/webpack-cli"
+};
 
-const installedClis = CLIs.filter(cli => cli.installed);
-
-if (installedClis.length === 0) {
+if (!cli.installed) {
 	const path = require("path");
 	const fs = require("fs");
 	const readLine = require("readline");
 
-	let notify =
-		"One CLI for webpack must be installed. These are recommended choices, delivered as separate packages:";
-
-	for (const item of CLIs) {
-		if (item.recommended) {
-			notify += `\n - ${item.name} (${item.url})\n   ${item.description}`;
-		}
-	}
+	const notify =
+		"CLI for webpack must be installed.\n" + `  ${cli.name} (${cli.url})\n`;
 
 	console.error(notify);
 
@@ -127,42 +101,28 @@ if (installedClis.length === 0) {
 			return;
 		}
 
-		const packageName = "webpack-cli";
-
 		console.log(
-			`Installing '${packageName}' (running '${packageManager} ${installOptions.join(
-				" "
-			)} ${packageName}')...`
+			`Installing '${
+				cli.package
+			}' (running '${packageManager} ${installOptions.join(" ")} ${
+				cli.package
+			}')...`
 		);
 
-		runCommand(packageManager, installOptions.concat(packageName))
+		runCommand(packageManager, installOptions.concat(cli.package))
 			.then(() => {
-				require(packageName); //eslint-disable-line
+				require(cli.package); //eslint-disable-line
 			})
 			.catch(error => {
 				console.error(error);
 				process.exitCode = 1;
 			});
 	});
-} else if (installedClis.length === 1) {
+} else {
 	const path = require("path");
-	const pkgPath = require.resolve(`${installedClis[0].package}/package.json`);
+	const pkgPath = require.resolve(`${cli.package}/package.json`);
 	// eslint-disable-next-line node/no-missing-require
 	const pkg = require(pkgPath);
 	// eslint-disable-next-line node/no-missing-require
-	require(path.resolve(
-		path.dirname(pkgPath),
-		pkg.bin[installedClis[0].binName]
-	));
-} else {
-	console.warn(
-		`You have installed ${installedClis
-			.map(item => item.name)
-			.join(
-				" and "
-			)} together. To work with the "webpack" command you need only one CLI package, please remove one of them or use them directly via their binary.`
-	);
-
-	// @ts-ignore
-	process.exitCode = 1;
+	require(path.resolve(path.dirname(pkgPath), pkg.bin[cli.binName]));
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

refactoring

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

no

**Does this PR introduce a breaking change?**

no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

N/A because webpack-command is already depricated.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

### Before

```sh
One CLI for webpack must be installed. These are recommended choices, delivered as separate packages:
 - webpack-cli (https://github.com/webpack/webpack-cli)
   The original webpack full-featured CLI.
We will use "yarn" to install the CLI via "yarn add -D".
Do you want to install 'webpack-cli' (yes/no): 
```

### After

```sh
CLI for webpack must be installed.
  webpack-cli (https://github.com/webpack/webpack-cli)

We will use "yarn" to install the CLI via "yarn add -D".
Do you want to install 'webpack-cli' (yes/no): 
```