### PR TITLE
Convert finishModules hook to be an AsyncSeries

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -238,8 +238,8 @@ class Compilation extends Tapable {
 				"module"
 			]),
 
-			/** @type {SyncHook<Module[]>} */
-			finishModules: new SyncHook(["modules"]),
+			/** @type {AsyncSeriesHook<Module[]>} */
+			finishModules: new AsyncSeriesHook(["modules"]),
 			/** @type {SyncHook<Module>} */
 			finishRebuildingModule: new SyncHook(["module"]),
 			/** @type {SyncHook} */
@@ -1158,14 +1158,18 @@ class Compilation extends Tapable {
 		});
 	}
 
-	finish() {
+	finish(callback) {
 		const modules = this.modules;
-		this.hooks.finishModules.call(modules);
+		this.hooks.finishModules.callAsync(modules, err => {
+			if (err) return callback(err);
 
-		for (let index = 0; index < modules.length; index++) {
-			const module = modules[index];
-			this.reportDependencyErrorsAndWarnings(module, [module]);
-		}
+			for (let index = 0; index < modules.length; index++) {
+				const module = modules[index];
+				this.reportDependencyErrorsAndWarnings(module, [module]);
+			}
+
+			callback();
+		});
 	}
 
 	unseal() {

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -619,15 +619,17 @@ class Compiler extends Tapable {
 			this.hooks.make.callAsync(compilation, err => {
 				if (err) return callback(err);
 
-				compilation.finish();
-
-				compilation.seal(err => {
+				compilation.finish(err => {
 					if (err) return callback(err);
 
-					this.hooks.afterCompile.callAsync(compilation, err => {
+					compilation.seal(err => {
 						if (err) return callback(err);
 
-						return callback(null, compilation);
+						this.hooks.afterCompile.callAsync(compilation, err => {
+							if (err) return callback(err);
+
+							return callback(null, compilation);
+						});
 					});
 				});
 			});

--- a/test/configCases/finish-modules/simple/index.js
+++ b/test/configCases/finish-modules/simple/index.js
@@ -1,0 +1,3 @@
+it("should compile", function(done) {
+	done();
+});

--- a/test/configCases/finish-modules/simple/webpack.config.js
+++ b/test/configCases/finish-modules/simple/webpack.config.js
@@ -1,0 +1,14 @@
+var testPlugin = function() {
+	this.hooks.compilation.tap("TestPlugin", compilation => {
+		compilation.hooks.finishModules.tapAsync("TestPlugin", function(
+			_modules,
+			callback
+		) {
+			callback();
+		});
+	});
+};
+
+module.exports = {
+	plugins: [testPlugin]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

I am working on a new webpack plugin that requires access to the full module graph after the first pass. The plugin may trigger rebuilds, which could result in more modules being added to the graph — this work needs to occur before the `seal` phase begins.

Currently, `finishModules` fires at the correct time, but as `rebuild` is an async process, I can't tell webpack to wait for the rebuild before the sealing phase begins. The proposed solution is to make `finishModules` into an async hook, which **I've noticed is already the case in webpack v5**.

Ideally I'd like to release the plugin as soon as possible and have it be backwards compatible with webpack v4 for consumers.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

This is a new backwards compatible feature.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Added a new `configCase` test to ensure `finishModules` can be tapped asynchronously. 

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

As async hooks also support synchronous tapping then I don't it believe it does. 

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Proposed doc changes can be found [here](https://github.com/mattsjones/webpack.js.org/blob/feature/async-finish-modules/src/content/api/compilation-hooks.md#finishmodules), and can PR when requested. 

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
