### PR TITLE
fix(NodeMainTemplate.runtime): use fs.readFileSync

### DIFF
--- a/lib/node/NodeMainTemplate.runtime.js
+++ b/lib/node/NodeMainTemplate.runtime.js
@@ -6,18 +6,26 @@
 module.exports = function() {
 	// eslint-disable-next-line no-unused-vars
 	function hotDownloadUpdateChunk(chunkId) {
-		var chunk = require("./" + $hotChunkFilename$);
+		var filename = require("path").join(__dirname, $hotChunkFilename$);
+		var content = require("fs").readFileSync(filename, "utf-8");
+		var chunk = {};
+		require("vm").runInThisContext("(function(exports) {" + content + "\n})", {
+			filename: filename
+		})(chunk);
+
 		hotAddUpdateChunk(chunk.id, chunk.modules);
 	}
 
 	// eslint-disable-next-line no-unused-vars
 	function hotDownloadManifest() {
 		try {
-			var update = require("./" + $hotMainFilename$);
+			var filename = require("path").join(__dirname, $hotMainFilename$);
+			var content = require("fs").readFileSync(filename, "utf-8");
+			var update = JSON.parse(content);
+			return Promise.resolve(update);
 		} catch (e) {
 			return Promise.resolve();
 		}
-		return Promise.resolve(update);
 	}
 
 	//eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
fixes: #9012

NodeMainTemplate can't run on Node11 so we use fs.readFileSync.
In addition, NodeMainTemplateAsync.runtime.js is already using fs module.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Nope.
But I guess we don't need to add tests because it ensures compatibility if passing the tests.
If necessary, we can add Node v11 to the CI.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

N/A

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
