### PR TITLE
Update WebAssembly declaration

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -255,7 +255,7 @@ declare const hotAddUpdateChunk;
 declare const parentHotUpdateCallback;
 declare const $hotChunkFilename$;
 declare const $hotMainFilename$;
-declare const WebAssembly;
+declare namespace WebAssembly {}
 declare const importScripts;
 declare const $crossOriginLoading$;
 declare const chunkId;


### PR DESCRIPTION
TS 3.5 and above have WebAssembly types, so the ambient declaration in declarations.d.ts needs to be compatible with that declaration. The previous declaration, `declare const`, was not. This PR changes it to `declare namespace`.

Fixes #9021

**What kind of change does this PR introduce?**
Fixes type declarations.

**Did you add tests for your changes?**
The build is the test. If the PR builds, the change is backward compatible.

**Does this PR introduce a breaking change?**
No.

**What needs to be documented once your changes are merged?**

Nothing, unless you think of d.ts as documentation for humans.