### PR TITLE
Allow top-level return in script parsing. Fixes issue 8509 in master,…

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -2238,6 +2238,8 @@ class Parser extends Tapable {
 
 		if (type === "auto") {
 			parserOptions.sourceType = "module";
+		} else if (parserOptions.sourceType === "script") {
+			parserOptions.allowReturnOutsideFunction = true;
 		}
 
 		let ast;
@@ -2252,6 +2254,7 @@ class Parser extends Tapable {
 
 		if (threw && type === "auto") {
 			parserOptions.sourceType = "script";
+			parserOptions.allowReturnOutsideFunction = true;
 			if (Array.isArray(parserOptions.onComment)) {
 				parserOptions.onComment.length = 0;
 			}

--- a/test/fixtures/b.js
+++ b/test/fixtures/b.js
@@ -1,3 +1,6 @@
 module.exports = function b() {
 	return "This is b";
 };
+
+// Test CJS top-level return
+return;


### PR DESCRIPTION
… like PR 8510 fixed it for 'next'