### PR TITLE
fix(parser): add acorn-import-meta plugin

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -8,6 +8,7 @@
 
 const acorn = require("acorn");
 const acornDynamicImport = require("acorn-dynamic-import").default;
+const acornImportMeta = require("acorn-import-meta");
 const { Tapable, SyncBailHook, HookMap } = require("tapable");
 const util = require("util");
 const vm = require("vm");
@@ -15,7 +16,7 @@ const BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
 const StackedSetMap = require("./util/StackedSetMap");
 const TrackingSet = require("./util/TrackingSet");
 
-const acornParser = acorn.Parser.extend(acornDynamicImport);
+const acornParser = acorn.Parser.extend(acornDynamicImport, acornImportMeta);
 
 const joinRanges = (startRange, endRange) => {
 	if (!endRange) return startRange;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@webassemblyjs/wasm-parser": "1.8.5",
     "acorn": "^6.0.5",
     "acorn-dynamic-import": "^4.0.0",
+    "acorn-import-meta": "^1.0.0",
     "ajv": "^6.1.0",
     "ajv-keywords": "^3.1.0",
     "chrome-trace-event": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -622,6 +622,11 @@ acorn-globals@^4.1.0:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
+acorn-import-meta@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-import-meta/-/acorn-import-meta-1.0.0.tgz#6cff1f01db3b60148934823d3d2dd0c08354aead"
+  integrity sha512-yX652u86bKzuM+mzEHV84T0R+srQwTOmprUiFC3zlhlc02lBQzqxkB/H/7jexX9vlz/TRuQiZs9mKEDK3bbmhw==
+
 acorn-jsx@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Currently, any usage of `import.meta` makes the bundler to crash. This PR solves that. This PR does not implement any transformation in the webpack side, instead it just leaves import.meta untouched without crashing.

Relates with: https://github.com/webpack/webpack/issues/6719

**What kind of change does this PR introduce?**

It's a bug fix.

**Did you add tests for your changes?**

WIP, asking for feedback before further work!

**Does this PR introduce a breaking change?**

Nop
