### PR TITLE
fix(parser): Rest element identifiers in object patterns not added to defined variables of scope

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -1954,6 +1954,9 @@ class Parser extends Tapable {
 			case "RestElement":
 				this.enterRestElement(pattern, onIdent);
 				break;
+			case "Property":
+				this.enterPattern(pattern.value, onIdent);
+				break;
 		}
 	}
 
@@ -1968,12 +1971,7 @@ class Parser extends Tapable {
 			propIndex++
 		) {
 			const prop = pattern.properties[propIndex];
-
-			if (prop.type === "Property") {
-				this.enterPattern(prop.value, onIdent);
-			} else {
-				this.enterPattern(prop, onIdent);
-			}
+			this.enterPattern(prop, onIdent);
 		}
 	}
 

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -1968,7 +1968,12 @@ class Parser extends Tapable {
 			propIndex++
 		) {
 			const prop = pattern.properties[propIndex];
-			this.enterPattern(prop.value, onIdent);
+
+			if (prop.type === "Property") {
+				this.enterPattern(prop.value, onIdent);
+			} else {
+				this.enterPattern(prop, onIdent);
+			}
 		}
 	}
 

--- a/test/Parser.unittest.js
+++ b/test/Parser.unittest.js
@@ -617,6 +617,22 @@ describe("Parser", () => {
 				});
 			});
 		});
+
+		it("should collect definitions from identifiers introduced in object patterns", () => {
+			let definitions;
+
+			const parser = new Parser();
+
+			parser.hooks.statement.tap("ParserTest", expr => {
+				definitions = parser.scope.definitions;
+				return true;
+			});
+
+			parser.parse("const { a, ...rest } = { a: 1, b: 2 };");
+
+			expect(definitions.has("a")).toBe(true);
+			expect(definitions.has("rest")).toBe(true);
+		});
 	});
 
 	describe("optional catch binding support", () => {


### PR DESCRIPTION
Fixes #9055, and possibly others, I investigated after having that issue

`enterObjectPattern` assumed all object property nodes had a value, which is not true for the `RestElement` node type, which has `argument` instead which contains the `Identifier`.

This meant that identifiers introduced by object pattern rest elements were not recognized as a variable declaration within the current scope, hence the identifier introduced by an import statement in the outer scope being used in #9055