### PR TITLE
Port #8890 to Webpack next branch

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -268,11 +268,13 @@ export type FilterItemTypes = RegExp | string | Function;
 
 export interface WebpackOptions {
 	/**
-	 * Set the value of `require.amd` and `define.amd`.
+	 * Set the value of `require.amd` and `define.amd`. Or disable AMD support.
 	 */
-	amd?: {
-		[k: string]: any;
-	};
+	amd?:
+		| false
+		| {
+				[k: string]: any;
+		  };
 	/**
 	 * Report the first error as a hard error instead of tolerating it.
 	 */

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -26,7 +26,6 @@ const APIPlugin = require("./APIPlugin");
 const CompatibilityPlugin = require("./CompatibilityPlugin");
 const ConstPlugin = require("./ConstPlugin");
 const NodeStuffPlugin = require("./NodeStuffPlugin");
-const RequireJsStuffPlugin = require("./RequireJsStuffPlugin");
 
 const TemplatedPathPlugin = require("./TemplatedPathPlugin");
 const UseStrictPlugin = require("./UseStrictPlugin");
@@ -34,7 +33,6 @@ const WarnCaseSensitiveModulesPlugin = require("./WarnCaseSensitiveModulesPlugin
 
 const ResolverCachePlugin = require("./cache/ResolverCachePlugin");
 
-const AMDPlugin = require("./dependencies/AMDPlugin");
 const CommonJsPlugin = require("./dependencies/CommonJsPlugin");
 const HarmonyModulesPlugin = require("./dependencies/HarmonyModulesPlugin");
 const ImportPlugin = require("./dependencies/ImportPlugin");
@@ -313,11 +311,15 @@ class WebpackOptionsApply extends OptionsApply {
 
 		new CompatibilityPlugin().apply(compiler);
 		new HarmonyModulesPlugin(options.module).apply(compiler);
-		new AMDPlugin(options.module, options.amd || {}).apply(compiler);
+		if (options.amd !== false) {
+			const AMDPlugin = require("./dependencies/AMDPlugin");
+			const RequireJsStuffPlugin = require("./RequireJsStuffPlugin");
+			new AMDPlugin(options.module, options.amd || {}).apply(compiler);
+			new RequireJsStuffPlugin().apply(compiler);
+		}
 		new CommonJsPlugin(options.module).apply(compiler);
 		new LoaderPlugin().apply(compiler);
 		new NodeStuffPlugin(options.node).apply(compiler);
-		new RequireJsStuffPlugin().apply(compiler);
 		new APIPlugin().apply(compiler);
 		new ConstPlugin().apply(compiler);
 		new UseStrictPlugin().apply(compiler);

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2074,7 +2074,17 @@
   "additionalProperties": false,
   "properties": {
     "amd": {
-      "description": "Set the value of `require.amd` and `define.amd`."
+      "description": "Set the value of `require.amd` and `define.amd`. Or disable AMD support.",
+      "anyOf": [
+        {
+          "description": "You can pass `false` to disable AMD support.",
+          "enum": [false]
+        },
+        {
+          "description": "You can pass an object to set the value of `require.amd` and `define.amd`.",
+          "type": "object"
+        }
+      ]
     },
     "bail": {
       "description": "Report the first error as a hard error instead of tolerating it.",

--- a/test/configCases/amd/disabled/index.js
+++ b/test/configCases/amd/disabled/index.js
@@ -1,0 +1,8 @@
+it("should compile", function(done) {
+	done();
+});
+
+it("should disable define", function(done) {
+	expect(typeof define).toBe('undefined')
+	done()
+})

--- a/test/configCases/amd/disabled/webpack.config.js
+++ b/test/configCases/amd/disabled/webpack.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	amd: false
+};


### PR DESCRIPTION
This ports the amd option for #8890 to the Webpack next branch, which is necessary to use this in ncc.