### PR TITLE
Makes WatchIgnorePlugin work with VirtualModules

### DIFF
--- a/lib/WatchIgnorePlugin.js
+++ b/lib/WatchIgnorePlugin.js
@@ -13,6 +13,7 @@ class IgnoringWatchFileSystem {
 	constructor(wfs, paths) {
 		this.wfs = wfs;
 		this.paths = paths;
+		this.watcher = wfs.watcher;
 	}
 
 	watch(files, dirs, missing, startTime, options, callback, callbackUndelayed) {


### PR DESCRIPTION
Line 50 of webpack-virtual-modules/index.js breaks when applying WatchIgnorePlugin as the attribute "watcher" is not present on the IngoringWatchFileSystem

if (self._watcher && self._watcher.watchFileSystem.watcher.fileWatchers.length) {

Bugfix

No tests necessary

No breaking change

No docs needed
