### PR TITLE
Updated Invalid URL Reference: "Getting Started"

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ or packaging just about any resource or asset.
 
 ### Get Started
 
-Check out webpack's quick [**Get Started**](https://webpack.js.org/get-started/) guide and the [other guides](https://webpack.js.org/guides/).
+Check out webpack's quick [**Get Started**](https://webpack.js.org/guides/getting-started) guide and the [other guides](https://webpack.js.org/guides/).
 
 ### Browser Compatibility
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

README.md references a link returning a 404 response code.  

Referenced URL returns 404: [https://webpack.js.org/get-started/](https://webpack.js.org/get-started/)
Updated to: [https://webpack.js.org/guides/getting-started](https://webpack.js.org/guides/getting-started)