### PR TITLE
add `minRemainingSize` option for splitChunks

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -976,6 +976,10 @@ export interface OptimizationSplitChunksOptions {
 	 */
 	minChunks?: number;
 	/**
+	 * Minimal size for the chunks the stay after moving the modules to a new chunk
+	 */
+	minRemainingSize?: OptimizationSplitChunksSizes;
+	/**
 	 * Minimal size for the created chunks
 	 */
 	minSize?: OptimizationSplitChunksSizes;
@@ -1035,6 +1039,10 @@ export interface OptimizationSplitChunksCacheGroup {
 	 * Minimum number of times a module has to be duplicated until it's considered for splitting
 	 */
 	minChunks?: number;
+	/**
+	 * Minimal size for the chunks the stay after moving the modules to a new chunk
+	 */
+	minRemainingSize?: OptimizationSplitChunksSizes;
 	/**
 	 * Minimal size for the created chunk
 	 */

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -911,7 +911,7 @@ webpackEmptyAsyncContext.id = ${JSON.stringify(id)};`;
 
 	/**
 	 * @param {string=} type the source type for which the size should be estimated
-	 * @returns {number} the estimated size of the module
+	 * @returns {number} the estimated size of the module (must be non-zero)
 	 */
 	size(type) {
 		// base penalty

--- a/lib/DelegatedModule.js
+++ b/lib/DelegatedModule.js
@@ -151,7 +151,7 @@ class DelegatedModule extends Module {
 
 	/**
 	 * @param {string=} type the source type for which the size should be estimated
-	 * @returns {number} the estimated size of the module
+	 * @returns {number} the estimated size of the module (must be non-zero)
 	 */
 	size(type) {
 		return 42;

--- a/lib/DllModule.js
+++ b/lib/DllModule.js
@@ -86,7 +86,7 @@ class DllModule extends Module {
 
 	/**
 	 * @param {string=} type the source type for which the size should be estimated
-	 * @returns {number} the estimated size of the module
+	 * @returns {number} the estimated size of the module (must be non-zero)
 	 */
 	size(type) {
 		return 12;

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -246,7 +246,7 @@ class ExternalModule extends Module {
 
 	/**
 	 * @param {string=} type the source type for which the size should be estimated
-	 * @returns {number} the estimated size of the module
+	 * @returns {number} the estimated size of the module (must be non-zero)
 	 */
 	size(type) {
 		return 42;

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -511,7 +511,7 @@ class Module extends DependenciesBlock {
 	/**
 	 * @abstract
 	 * @param {string=} type the source type for which the size should be estimated
-	 * @returns {number} the estimated size of the module
+	 * @returns {number} the estimated size of the module (must be non-zero)
 	 */
 	size(type) {
 		throw new Error("Module.size: Must be overriden");

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -757,10 +757,10 @@ class NormalModule extends Module {
 
 	/**
 	 * @param {string=} type the source type for which the size should be estimated
-	 * @returns {number} the estimated size of the module
+	 * @returns {number} the estimated size of the module (must be non-zero)
 	 */
 	size(type) {
-		return this.generator.getSize(this, type);
+		return Math.max(1, this.generator.getSize(this, type));
 	}
 
 	/**

--- a/lib/RawModule.js
+++ b/lib/RawModule.js
@@ -40,10 +40,10 @@ class RawModule extends Module {
 
 	/**
 	 * @param {string=} type the source type for which the size should be estimated
-	 * @returns {number} the estimated size of the module
+	 * @returns {number} the estimated size of the module (must be non-zero)
 	 */
 	size(type) {
-		return this.sourceStr.length;
+		return Math.max(1, this.sourceStr.length);
 	}
 
 	/**

--- a/lib/RuntimeModule.js
+++ b/lib/RuntimeModule.js
@@ -105,7 +105,7 @@ class RuntimeModule extends Module {
 
 	/**
 	 * @param {string=} type the source type for which the size should be estimated
-	 * @returns {number} the estimated size of the module
+	 * @returns {number} the estimated size of the module (must be non-zero)
 	 */
 	size(type) {
 		return this.getGeneratedCode().length;

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -283,6 +283,9 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("optimization.splitChunks.minSize", "make", options => {
 			return isProductionLikeMode(options) ? 30000 : 10000;
 		});
+		this.set("optimization.splitChunks.minRemainingSize", "make", options => {
+			return options.mode === "development" ? 0 : undefined;
+		});
 		this.set("optimization.splitChunks.maxAsyncRequests", "make", options => {
 			return isProductionLikeMode(options) ? 6 : Infinity;
 		});

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -525,7 +525,7 @@ class ConcatenatedModule extends Module {
 
 	/**
 	 * @param {string=} type the source type for which the size should be estimated
-	 * @returns {number} the estimated size of the module
+	 * @returns {number} the estimated size of the module (must be non-zero)
 	 */
 	size(type) {
 		// Guess size from embedded modules

--- a/lib/optimize/SplitChunksPlugin.js
+++ b/lib/optimize/SplitChunksPlugin.js
@@ -54,6 +54,7 @@ const MinMaxSizeWarning = require("./MinMaxSizeWarning");
  * @property {ChunkFilterFunction=} chunksFilter
  * @property {boolean=} enforce
  * @property {SplitChunksSizes} minSize
+ * @property {SplitChunksSizes} minRemainingSize
  * @property {SplitChunksSizes} maxAsyncSize
  * @property {SplitChunksSizes} maxInitialSize
  * @property {number=} minChunks
@@ -73,6 +74,7 @@ const MinMaxSizeWarning = require("./MinMaxSizeWarning");
  * @property {ChunkFilterFunction=} chunksFilter
  * @property {boolean=} enforce
  * @property {SplitChunksSizes} minSize
+ * @property {SplitChunksSizes} minRemainingSize
  * @property {SplitChunksSizes} minSizeForMaxSize
  * @property {SplitChunksSizes} maxAsyncSize
  * @property {SplitChunksSizes} maxInitialSize
@@ -118,6 +120,7 @@ const MinMaxSizeWarning = require("./MinMaxSizeWarning");
  * @typedef {Object} SplitChunksOptions
  * @property {ChunkFilterFunction} chunksFilter
  * @property {SplitChunksSizes} minSize
+ * @property {SplitChunksSizes} minRemainingSize
  * @property {SplitChunksSizes} maxInitialSize
  * @property {SplitChunksSizes} maxAsyncSize
  * @property {number} minChunks
@@ -251,6 +254,17 @@ const mergeSizes = (...sizes) => {
 };
 
 /**
+ * @param {SplitChunksSizes} sizes the sizes
+ * @returns {boolean} true, if there are sizes > 0
+ */
+const hasNonZeroSizes = sizes => {
+	for (const key of Object.keys(sizes)) {
+		if (sizes[key] > 0) return true;
+	}
+	return false;
+};
+
+/**
  * @param {SplitChunksSizes} a first sizes
  * @param {SplitChunksSizes} b second sizes
  * @param {CombineSizeFunction} combine a function to combine sizes
@@ -279,12 +293,12 @@ const combineSizes = (a, b, combine) => {
 /**
  * @param {SplitChunksSizes} sizes the sizes
  * @param {SplitChunksSizes} minSize the min sizes
- * @returns {boolean} true if sizes are below `minSize`
+ * @returns {boolean} true if there are sizes and all existing sizes are at least `minSize`
  */
 const checkMinSize = (sizes, minSize) => {
 	for (const key of Object.keys(minSize)) {
 		const size = sizes[key];
-		if (size === undefined) return false;
+		if (size === undefined || size === 0) continue;
 		if (size < minSize[key]) return false;
 	}
 	return true;
@@ -453,6 +467,7 @@ const createCacheGroupSource = options => {
 		chunksFilter: normalizeChunksFilter(options.chunks),
 		enforce: options.enforce,
 		minSize: normalizeSizes(options.minSize),
+		minRemainingSize: mergeSizes(options.minRemainingSize, options.minSize),
 		maxAsyncSize: mergeSizes(options.maxAsyncSize, options.maxSize),
 		maxInitialSize: mergeSizes(options.maxInitialSize, options.maxSize),
 		minChunks: options.minChunks,
@@ -476,8 +491,9 @@ module.exports = class SplitChunksPlugin {
 		this.options = {
 			chunksFilter: normalizeChunksFilter(options.chunks || "all"),
 			minSize: normalizeSizes(options.minSize),
-			maxAsyncSize: normalizeSizes(options.maxAsyncSize || options.maxSize),
-			maxInitialSize: normalizeSizes(options.maxInitialSize || options.maxSize),
+			minRemainingSize: mergeSizes(options.minRemainingSize, options.minSize),
+			maxAsyncSize: mergeSizes(options.maxAsyncSize, options.maxSize),
+			maxInitialSize: mergeSizes(options.maxInitialSize, options.maxSize),
 			minChunks: options.minChunks || 1,
 			maxAsyncRequests: options.maxAsyncRequests || 1,
 			maxInitialRequests: options.maxInitialRequests || 1,
@@ -700,7 +716,9 @@ module.exports = class SplitChunksPlugin {
 									),
 									cacheGroup,
 									name,
-									validateSize: Object.keys(cacheGroup.minSize).length > 0,
+									validateSize:
+										hasNonZeroSizes(cacheGroup.minSize) ||
+										hasNonZeroSizes(cacheGroup.minRemainingSize),
 									sizes: {},
 									chunks: new Set(),
 									reuseableChunks: new Set(),
@@ -755,6 +773,12 @@ module.exports = class SplitChunksPlugin {
 								minSize: mergeSizes(
 									cacheGroupSource.minSize,
 									cacheGroupSource.enforce ? undefined : this.options.minSize
+								),
+								minRemainingSize: mergeSizes(
+									cacheGroupSource.minRemainingSize,
+									cacheGroupSource.enforce
+										? undefined
+										: this.options.minRemainingSize
 								),
 								minSizeForMaxSize: mergeSizes(
 									cacheGroupSource.minSize,
@@ -954,12 +978,38 @@ module.exports = class SplitChunksPlugin {
 							});
 						}
 
-						validChunks = validChunks.filter(chunk => {
-							for (const module of item.modules) {
-								if (chunk.containsModule(module)) return true;
-							}
-							return false;
-						});
+						if (hasNonZeroSizes(item.cacheGroup.minRemainingSize)) {
+							validChunks = validChunks.filter(chunk => {
+								let chunkSizes = chunkGraph.getChunkModulesSizes(chunk);
+								let containsModule = false;
+
+								// early check for remaining size
+								if (!checkMinSize(chunkSizes, item.cacheGroup.minRemainingSize))
+									return false;
+
+								chunkSizes = Object.assign({}, chunkSizes);
+								for (const module of item.modules) {
+									if (chunkGraph.isModuleInChunk(module, chunk)) {
+										containsModule = true;
+										for (const type of module.getSourceTypes()) {
+											chunkSizes[type] -= module.size(type);
+										}
+									}
+								}
+
+								return (
+									containsModule &&
+									checkMinSize(chunkSizes, item.cacheGroup.minRemainingSize)
+								);
+							});
+						} else {
+							validChunks = validChunks.filter(chunk => {
+								for (const module of item.modules) {
+									if (chunkGraph.isModuleInChunk(module, chunk)) return true;
+								}
+								return false;
+							});
+						}
 
 						if (validChunks.length < usedChunks.length) {
 							if (isReused) validChunks.push(newChunk);

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -657,6 +657,14 @@
           "type": "number",
           "minimum": 1
         },
+        "minRemainingSize": {
+          "description": "Minimal size for the chunks the stay after moving the modules to a new chunk",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/OptimizationSplitChunksSizes"
+            }
+          ]
+        },
         "minSize": {
           "description": "Minimal size for the created chunk",
           "oneOf": [
@@ -864,6 +872,14 @@
           "description": "Minimum number of times a module has to be duplicated until it's considered for splitting",
           "type": "number",
           "minimum": 1
+        },
+        "minRemainingSize": {
+          "description": "Minimal size for the chunks the stay after moving the modules to a new chunk",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/OptimizationSplitChunksSizes"
+            }
+          ]
         },
         "minSize": {
           "description": "Minimal size for the created chunks",

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -297,9 +297,17 @@ Child vendors:
          + 3 hidden dependent modules
 Child multiple-vendors:
     Entrypoint main = multiple-vendors/main.js
-    Entrypoint a = multiple-vendors/282.js multiple-vendors/954.js multiple-vendors/767.js multiple-vendors/a.js
-    Entrypoint b = multiple-vendors/282.js multiple-vendors/954.js multiple-vendors/767.js multiple-vendors/b.js
-    Entrypoint c = multiple-vendors/282.js multiple-vendors/769.js multiple-vendors/767.js multiple-vendors/c.js
+    Entrypoint a = multiple-vendors/libs-x.js multiple-vendors/954.js multiple-vendors/767.js multiple-vendors/a.js
+    Entrypoint b = multiple-vendors/libs-x.js multiple-vendors/954.js multiple-vendors/767.js multiple-vendors/b.js
+    Entrypoint c = multiple-vendors/libs-x.js multiple-vendors/769.js multiple-vendors/767.js multiple-vendors/c.js
+    chunk {119} multiple-vendors/libs-x.js (libs-x) 20 bytes [initial] [rendered] split chunk (cache group: libs) (name: libs-x)
+        > ./a [10] ./index.js 1:0-47
+        > ./b [10] ./index.js 2:0-47
+        > ./c [10] ./index.js 3:0-47
+        > ./a a
+        > ./b b
+        > ./c c
+     [282] ./node_modules/x.js 20 bytes {119} [built]
     chunk {128} multiple-vendors/b.js (b) 92 bytes (javascript) 2.55 KiB (runtime) [entry] [rendered]
         > ./b b
      [996] ./b.js 72 bytes {128} {334} [built]
@@ -308,18 +316,10 @@ Child multiple-vendors:
     chunk {137} multiple-vendors/async-g.js (async-g) 34 bytes [rendered]
         > ./g ./a.js 6:0-47
      [785] ./g.js 34 bytes {137} [built]
-    chunk {179} multiple-vendors/main.js (main) 147 bytes (javascript) 4.6 KiB (runtime) [entry] [rendered]
+    chunk {179} multiple-vendors/main.js (main) 147 bytes (javascript) 4.61 KiB (runtime) [entry] [rendered]
         > ./ main
      [10] ./index.js 147 bytes {179} [built]
          + 7 hidden root modules
-    chunk {282} multiple-vendors/282.js 20 bytes [initial] [rendered] split chunk (cache group: vendors)
-        > ./a [10] ./index.js 1:0-47
-        > ./b [10] ./index.js 2:0-47
-        > ./c [10] ./index.js 3:0-47
-        > ./a a
-        > ./b b
-        > ./c c
-     [282] ./node_modules/x.js 20 bytes {282} [built]
     chunk {334} multiple-vendors/async-b.js (async-b) 72 bytes [rendered]
         > ./b [10] ./index.js 2:0-47
      [996] ./b.js 72 bytes {128} {334} [built]
@@ -1539,15 +1539,15 @@ exports[`StatsTestCases should print correct stats for named-chunk-groups 1`] = 
         > ./c [10] ./index.js 3:0-47
      [282] ./node_modules/x.js 20 bytes {216} [built]
      [954] ./node_modules/y.js 20 bytes {216} [built]
-    chunk {334} async-b.js (async-b) 40 bytes [rendered]
+    chunk {334} async-b.js (async-b) 175 bytes [rendered]
         > ./b [10] ./index.js 2:0-47
-     [996] ./b.js 40 bytes {334} [built]
+     [996] ./b.js 175 bytes {334} [built]
     chunk {383} async-c.js (async-c) 45 bytes [rendered]
         > ./c [10] ./index.js 3:0-47
      [460] ./c.js 45 bytes {383} [built]
-    chunk {794} async-a.js (async-a) 40 bytes [rendered]
+    chunk {794} async-a.js (async-a) 175 bytes [rendered]
         > ./a [10] ./index.js 1:0-47
-     [847] ./a.js 40 bytes {794} [built]
+     [847] ./a.js 175 bytes {794} [built]
 Child
     Entrypoint main = main.js
     Chunk Group async-a = 52.js async-a.js
@@ -1565,15 +1565,15 @@ Child
         > ./c [10] ./index.js 3:0-47
      [282] ./node_modules/x.js 20 bytes {216} [built]
      [954] ./node_modules/y.js 20 bytes {216} [built]
-    chunk {334} async-b.js (async-b) 40 bytes [rendered]
+    chunk {334} async-b.js (async-b) 175 bytes [rendered]
         > ./b [10] ./index.js 2:0-47
-     [996] ./b.js 40 bytes {334} [built]
+     [996] ./b.js 175 bytes {334} [built]
     chunk {383} async-c.js (async-c) 45 bytes [rendered]
         > ./c [10] ./index.js 3:0-47
      [460] ./c.js 45 bytes {383} [built]
-    chunk {794} async-a.js (async-a) 40 bytes [rendered]
+    chunk {794} async-a.js (async-a) 175 bytes [rendered]
         > ./a [10] ./index.js 1:0-47
-     [847] ./a.js 40 bytes {794} [built]"
+     [847] ./a.js 175 bytes {794} [built]"
 `;
 
 exports[`StatsTestCases should print correct stats for named-chunks-plugin 1`] = `
@@ -3000,6 +3000,28 @@ chunk {786} a.js (a) 12 bytes (javascript) 2.53 KiB (runtime) ={282}= [entry] [r
     > ./a a
  [847] ./a.js 12 bytes {786} [built]
      + 2 hidden root modules"
+`;
+
+exports[`StatsTestCases should print correct stats for split-chunks-keep-remaining-size 1`] = `
+"Entrypoint main = default/main.js
+chunk {52} default/52.js 102 bytes <{179}> ={383}= ={794}= [rendered] split chunk (cache group: default)
+    > ./a [10] ./index.js 1:0-47
+    > ./c [10] ./index.js 3:0-47
+ [52] ./shared.js 102 bytes {52} {334} [built]
+chunk {179} default/main.js (main) 147 bytes (javascript) 4.57 KiB (runtime) >{52}< >{334}< >{383}< >{794}< [entry] [rendered]
+    > ./ main
+ [10] ./index.js 147 bytes {179} [built]
+     + 7 hidden root modules
+chunk {334} default/async-b.js (async-b) 141 bytes <{179}> [rendered]
+    > ./b [10] ./index.js 2:0-47
+ [996] ./b.js 39 bytes {334} [built]
+     + 1 hidden dependent module
+chunk {383} default/async-c.js (async-c) 142 bytes <{179}> ={52}= [rendered]
+    > ./c [10] ./index.js 3:0-47
+ [460] ./c.js 142 bytes {383} [built]
+chunk {794} default/async-a.js (async-a) 142 bytes <{179}> ={52}= [rendered]
+    > ./a [10] ./index.js 1:0-47
+ [847] ./a.js 142 bytes {794} [built]"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-max-size 1`] = `

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -558,7 +558,7 @@ Built at: Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT
   Asset      Size  Chunks             Chunk Names
 main.js  1.32 KiB   {179}  [emitted]  main
 Entrypoint main = main.js
-[10] ./index.js 0 bytes {179} [built]"
+[10] ./index.js 1 bytes {179} [built]"
 `;
 
 exports[`StatsTestCases should print correct stats for color-enabled 1`] = `
@@ -568,7 +568,7 @@ Built at: Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT
   <CLR=BOLD>Asset</CLR>      <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>             <CLR=BOLD>Chunk Names</CLR>
 <CLR=32,BOLD>main.js</CLR>  1.32 KiB   {<CLR=33,BOLD>179</CLR>}  <CLR=32,BOLD>[emitted]</CLR>  main
 Entrypoint <CLR=BOLD>main</CLR> = <CLR=32,BOLD>main.js</CLR>
-[10] <CLR=BOLD>./index.js</CLR> 0 bytes {<CLR=33,BOLD>179</CLR>} <CLR=32,BOLD>[built]</CLR>"
+[10] <CLR=BOLD>./index.js</CLR> 1 bytes {<CLR=33,BOLD>179</CLR>} <CLR=32,BOLD>[built]</CLR>"
 `;
 
 exports[`StatsTestCases should print correct stats for color-enabled-custom 1`] = `
@@ -578,7 +578,7 @@ Built at: Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT
   <CLR=BOLD>Asset</CLR>      <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>             <CLR=BOLD>Chunk Names</CLR>
 <CLR=32>main.js</CLR>  1.32 KiB   {<CLR=33>179</CLR>}  <CLR=32>[emitted]</CLR>  main
 Entrypoint <CLR=BOLD>main</CLR> = <CLR=32>main.js</CLR>
-[10] <CLR=BOLD>./index.js</CLR> 0 bytes {<CLR=33>179</CLR>} <CLR=32>[built]</CLR>"
+[10] <CLR=BOLD>./index.js</CLR> 1 bytes {<CLR=33>179</CLR>} <CLR=32>[built]</CLR>"
 `;
 
 exports[`StatsTestCases should print correct stats for commons-chunk-min-size-0 1`] = `
@@ -1047,8 +1047,8 @@ chunk {786} a.js (a) 49 bytes <{257}> <{459}> >{128}< [rendered]
  [662] ./module-a.js 49 bytes {786} [built]
        import() ./module-a [65] ./module-c.js 1:0-47
        import() ./module-a [481] ./e1.js 2:0-47
-chunk {892} y.js (y) 0 bytes <{257}> <{621}> [rendered]
- [737] ./module-y.js 0 bytes {892} [built]
+chunk {892} y.js (y) 1 bytes <{257}> <{621}> [rendered]
+ [737] ./module-y.js 1 bytes {892} [built]
        import() ./module-y [456] ./module-x.js 1:0-47"
 `;
 
@@ -1065,21 +1065,21 @@ chunk {cycles} cycles.js (cycles) 156 bytes [rendered]
  [./cycles/1/index.js] 14 bytes {cycles} [built]
  [./cycles/2/index.js] 14 bytes {cycles} [built]
      + 6 hidden dependent modules
-chunk {id-equals-name_js} id-equals-name_js.js (id-equals-name_js) 0 bytes [rendered]
- [./id-equals-name.js?1] 0 bytes {id-equals-name_js} [built]
-chunk {id-equals-name_js-_70e2} id-equals-name_js-_70e2.js (id-equals-name_js-_70e2) 0 bytes [rendered]
- [./id-equals-name.js?2] 0 bytes {id-equals-name_js-_70e2} [built]
-chunk {id-equals-name_js0} id-equals-name_js0.js 0 bytes [rendered]
- [./id-equals-name.js] 0 bytes {id-equals-name_js0} [built]
-chunk {id-equals-name_js_3} id-equals-name_js_3.js 0 bytes [rendered]
- [./id-equals-name.js?3] 0 bytes {id-equals-name_js_3} [built]
+chunk {id-equals-name_js} id-equals-name_js.js (id-equals-name_js) 1 bytes [rendered]
+ [./id-equals-name.js?1] 1 bytes {id-equals-name_js} [built]
+chunk {id-equals-name_js-_70e2} id-equals-name_js-_70e2.js (id-equals-name_js-_70e2) 1 bytes [rendered]
+ [./id-equals-name.js?2] 1 bytes {id-equals-name_js-_70e2} [built]
+chunk {id-equals-name_js0} id-equals-name_js0.js 1 bytes [rendered]
+ [./id-equals-name.js] 1 bytes {id-equals-name_js0} [built]
+chunk {id-equals-name_js_3} id-equals-name_js_3.js 1 bytes [rendered]
+ [./id-equals-name.js?3] 1 bytes {id-equals-name_js_3} [built]
 chunk {main} main.js (main) 5.21 KiB (runtime) 639 bytes (javascript) [entry] [rendered]
  [./index.js] 639 bytes {main} [built]
      + 8 hidden root modules
-chunk {tree} tree.js (tree) 42 bytes [rendered]
+chunk {tree} tree.js (tree) 43 bytes [rendered]
  [./tree/index.js] 14 bytes {tree} [built]
      + 3 hidden dependent modules
-chunk {trees} trees.js (trees) 70 bytes [rendered]
+chunk {trees} trees.js (trees) 71 bytes [rendered]
  [./trees/1.js] 14 bytes {trees} [built]
  [./trees/2.js] 14 bytes {trees} [built]
  [./trees/3.js] 14 bytes {trees} [built]
@@ -1614,7 +1614,7 @@ Built at: Thu Jan 01 1970 00:00:00 GMT
 bundle.js  1.32 KiB   {179}  main
  child.js  1.32 KiB
 Entrypoint main = bundle.js
-[10] ./index.js 0 bytes {179} [built]
+[10] ./index.js 1 bytes {179} [built]
 
 WARNING in configuration
 The 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
@@ -1626,7 +1626,7 @@ Child child:
        Asset      Size  Chunks  Chunk Names
     child.js  1.32 KiB   {396}  child
     Entrypoint child = child.js
-    [10] ./index.js 0 bytes {396} [built]
+    [10] ./index.js 1 bytes {396} [built]
 
     ERROR in forced error
 "
@@ -1646,39 +1646,39 @@ cir2 from cir1.js  370 bytes  {288}, {289}  [emitted]  cir2 from cir1
           cir2.js  321 bytes         {289}  [emitted]  cir2
           main.js   8.17 KiB         {179}  [emitted]  main
 Entrypoint main = main.js
-chunk {90} ab.js (ab) 0 bytes <{179}> >{753}< [rendered]
+chunk {90} ab.js (ab) 2 bytes <{179}> >{753}< [rendered]
     > [10] ./index.js 1:0-6:8
- [836] ./modules/b.js 0 bytes {90} {374} [built]
- [839] ./modules/a.js 0 bytes {90} {374} [built]
-chunk {179} main.js (main) 523 bytes (javascript) 3.74 KiB (runtime) >{90}< >{289}< >{374}< >{592}< [entry] [rendered]
+ [836] ./modules/b.js 1 bytes {90} {374} [built]
+ [839] ./modules/a.js 1 bytes {90} {374} [built]
+chunk {179} main.js (main) 524 bytes (javascript) 3.74 KiB (runtime) >{90}< >{289}< >{374}< >{592}< [entry] [rendered]
     > ./index main
   [10] ./index.js 523 bytes {179} [built]
- [544] ./modules/f.js 0 bytes {179} [built]
+ [544] ./modules/f.js 1 bytes {179} [built]
      + 4 hidden chunk modules
-chunk {284} chunk.js (chunk) 0 bytes <{374}> <{753}> [rendered]
+chunk {284} chunk.js (chunk) 2 bytes <{374}> <{753}> [rendered]
     > [10] ./index.js 3:2-4:13
     > [10] ./index.js 9:1-10:12
- [115] ./modules/c.js 0 bytes {284} {753} [built]
- [928] ./modules/d.js 0 bytes {284} {374} [built]
-chunk {288} cir2 from cir1.js (cir2 from cir1) 81 bytes <{592}> [rendered]
+ [115] ./modules/c.js 1 bytes {284} {753} [built]
+ [928] ./modules/d.js 1 bytes {284} {374} [built]
+chunk {288} cir2 from cir1.js (cir2 from cir1) 82 bytes <{592}> [rendered]
     > [655] ./circular1.js 1:0-79
  [193] ./circular2.js 81 bytes {288} {289} [built]
- [798] ./modules/e.js 0 bytes {288} [built]
+ [798] ./modules/e.js 1 bytes {288} [built]
 chunk {289} cir2.js (cir2) 81 bytes <{179}> >{592}< [rendered]
     > [10] ./index.js 14:0-54
  [193] ./circular2.js 81 bytes {288} {289} [built]
-chunk {374} abd.js (abd) 0 bytes <{179}> >{284}< [rendered]
+chunk {374} abd.js (abd) 3 bytes <{179}> >{284}< [rendered]
     > [10] ./index.js 8:0-11:9
- [836] ./modules/b.js 0 bytes {90} {374} [built]
- [839] ./modules/a.js 0 bytes {90} {374} [built]
- [928] ./modules/d.js 0 bytes {284} {374} [built]
+ [836] ./modules/b.js 1 bytes {90} {374} [built]
+ [839] ./modules/a.js 1 bytes {90} {374} [built]
+ [928] ./modules/d.js 1 bytes {284} {374} [built]
 chunk {592} cir1.js (cir1) 81 bytes <{179}> <{289}> >{288}< [rendered]
     > [10] ./index.js 13:0-54
     > [193] ./circular2.js 1:0-79
  [655] ./circular1.js 81 bytes {592} [built]
-chunk {753} ac in ab.js (ac in ab) 0 bytes <{90}> >{284}< [rendered]
+chunk {753} ac in ab.js (ac in ab) 1 bytes <{90}> >{284}< [rendered]
     > [10] ./index.js 2:1-5:15
- [115] ./modules/c.js 0 bytes {284} {753} [built]"
+ [115] ./modules/c.js 1 bytes {284} {753} [built]"
 `;
 
 exports[`StatsTestCases should print correct stats for parse-error 1`] = `
@@ -1947,27 +1947,27 @@ exports[`StatsTestCases should print correct stats for prefetch 1`] = `
 prefetched2.js  119 bytes   {379}  [emitted]  prefetched2
 prefetched3.js  119 bytes   {220}  [emitted]  prefetched3
 Entrypoint main = main.js (prefetch: prefetched2.js prefetched.js prefetched3.js)
-chunk {30} normal.js (normal) 0 bytes <{179}> [rendered]
+chunk {30} normal.js (normal) 1 bytes <{179}> [rendered]
 chunk {179} main.js (main) 436 bytes (javascript) 5.87 KiB (runtime) >{30}< >{220}< >{379}< >{505}< (prefetch: {379} {505} {220}) [entry] [rendered]
-chunk {220} prefetched3.js (prefetched3) 0 bytes <{179}> [rendered]
-chunk {379} prefetched2.js (prefetched2) 0 bytes <{179}> [rendered]
+chunk {220} prefetched3.js (prefetched3) 1 bytes <{179}> [rendered]
+chunk {379} prefetched2.js (prefetched2) 1 bytes <{179}> [rendered]
 chunk {505} prefetched.js (prefetched) 228 bytes <{179}> >{641}< >{746}< (prefetch: {641} {746}) [rendered]
-chunk {641} inner2.js (inner2) 0 bytes <{505}> [rendered]
-chunk {746} inner.js (inner) 0 bytes <{505}> [rendered]"
+chunk {641} inner2.js (inner2) 2 bytes <{505}> [rendered]
+chunk {746} inner.js (inner) 1 bytes <{505}> [rendered]"
 `;
 
 exports[`StatsTestCases should print correct stats for prefetch-preload-mixed 1`] = `
-"chunk {3} c2.js (c2) 0 bytes <{459}> [rendered]
-chunk {74} a1.js (a1) 0 bytes <{786}> [rendered]
-chunk {76} c1.js (c1) 0 bytes <{459}> [rendered]
+"chunk {3} c2.js (c2) 1 bytes <{459}> [rendered]
+chunk {74} a1.js (a1) 1 bytes <{786}> [rendered]
+chunk {76} c1.js (c1) 1 bytes <{459}> [rendered]
 chunk {128} b.js (b) 203 bytes <{179}> >{132}< >{751}< >{978}< (prefetch: {751} {132}) (preload: {978}) [rendered]
-chunk {132} b3.js (b3) 0 bytes <{128}> [rendered]
-chunk {178} a2.js (a2) 0 bytes <{786}> [rendered]
+chunk {132} b3.js (b3) 1 bytes <{128}> [rendered]
+chunk {178} a2.js (a2) 1 bytes <{786}> [rendered]
 chunk {179} main.js (main) 195 bytes (javascript) 6.16 KiB (runtime) >{128}< >{459}< >{786}< (prefetch: {786} {128} {459}) [entry] [rendered]
 chunk {459} c.js (c) 134 bytes <{179}> >{3}< >{76}< (preload: {76} {3}) [rendered]
-chunk {751} b1.js (b1) 0 bytes <{128}> [rendered]
+chunk {751} b1.js (b1) 1 bytes <{128}> [rendered]
 chunk {786} a.js (a) 136 bytes <{179}> >{74}< >{178}< (prefetch: {74} {178}) [rendered]
-chunk {978} b2.js (b2) 0 bytes <{128}> [rendered]"
+chunk {978} b2.js (b2) 1 bytes <{128}> [rendered]"
 `;
 
 exports[`StatsTestCases should print correct stats for preload 1`] = `
@@ -1980,12 +1980,12 @@ exports[`StatsTestCases should print correct stats for preload 1`] = `
 preloaded2.js  118 bytes   {363}  [emitted]  preloaded2
 preloaded3.js  117 bytes   {355}  [emitted]  preloaded3
 Entrypoint main = main.js (preload: preloaded2.js preloaded.js preloaded3.js)
-chunk {30} normal.js (normal) 0 bytes [rendered]
+chunk {30} normal.js (normal) 1 bytes [rendered]
 chunk {179} main.js (main) 424 bytes (javascript) 5.9 KiB (runtime) (preload: {363} {851} {355}) [entry] [rendered]
-chunk {355} preloaded3.js (preloaded3) 0 bytes [rendered]
-chunk {363} preloaded2.js (preloaded2) 0 bytes [rendered]
-chunk {641} inner2.js (inner2) 0 bytes [rendered]
-chunk {746} inner.js (inner) 0 bytes [rendered]
+chunk {355} preloaded3.js (preloaded3) 1 bytes [rendered]
+chunk {363} preloaded2.js (preloaded2) 1 bytes [rendered]
+chunk {641} inner2.js (inner2) 2 bytes [rendered]
+chunk {746} inner.js (inner) 1 bytes [rendered]
 chunk {851} preloaded.js (preloaded) 226 bytes (preload: {641} {746}) [rendered]"
 `;
 
@@ -2211,9 +2211,9 @@ bundle.js  1.77 KiB   {179}  [emitted]  main
 Entrypoint main = bundle.js
  [10] ./index.js 48 bytes {179} [built]
 [258] ./node_modules/def/index.js 16 bytes {179} [built]
-[566] ./node_modules/def/node_modules/xyz/index.js 0 bytes {179} [built]
+[566] ./node_modules/def/node_modules/xyz/index.js 1 bytes {179} [built]
 [641] ./node_modules/abc/index.js 16 bytes {179} [built]
-[925] ./node_modules/xyz/index.js 0 bytes {179} [built]"
+[925] ./node_modules/xyz/index.js 1 bytes {179} [built]"
 `;
 
 exports[`StatsTestCases should print correct stats for reverse-sort-modules 1`] = `
@@ -2452,7 +2452,7 @@ Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset      Size  Chunks             Chunk Names
 bundle.js  1.56 KiB  {main}  [emitted]  main
 Entrypoint main = bundle.js
-[./index.js] 0 bytes {main} [built]"
+[./index.js] 1 bytes {main} [built]"
 `;
 
 exports[`StatsTestCases should print correct stats for simple-more-info 1`] = `
@@ -2463,7 +2463,7 @@ PublicPath: (none)
     Asset      Size  Chunks             Chunk Names
 bundle.js  1.32 KiB   {179}  [emitted]  main
 Entrypoint main = bundle.js
-[10] ./index.js 0 bytes {179} [built]
+[10] ./index.js 1 bytes {179} [built]
      entry ./index main
      Xms (resolving: Xms, restoring: Xms, integration: Xms, building: Xms, storing: Xms)"
 `;
@@ -3435,9 +3435,9 @@ Entrypoint main = bundle.js
 [405] ./require.include.js 36 bytes {179} [built]
       [exports: a, default]
       [no exports used]
-[416] ./unknown.js 0 bytes {179} [built]
+[416] ./unknown.js 1 bytes {179} [built]
       [only some exports used: c]
-[419] ./unknown2.js 0 bytes {179} [built]
+[419] ./unknown2.js 1 bytes {179} [built]
       [only some exports used: y]
 [641] ./reexport-unknown.js 83 bytes {179} [built]
       [exports: a, b, c, d]

--- a/test/statsCases/named-chunk-groups/a.js
+++ b/test/statsCases/named-chunk-groups/a.js
@@ -1,3 +1,6 @@
 import "./shared";
 
 export default "a";
+
+// content content content content content content content content
+// content content content content content content content content

--- a/test/statsCases/named-chunk-groups/b.js
+++ b/test/statsCases/named-chunk-groups/b.js
@@ -1,3 +1,6 @@
 import "./shared";
 
 export default "b";
+
+// content content content content content content content content
+// content content content content content content content content

--- a/test/statsCases/split-chunks-keep-remaining-size/a.js
+++ b/test/statsCases/split-chunks-keep-remaining-size/a.js
@@ -1,0 +1,5 @@
+import "./shared";
+export default "a";
+
+// content content content content content content
+// content content content content content content

--- a/test/statsCases/split-chunks-keep-remaining-size/b.js
+++ b/test/statsCases/split-chunks-keep-remaining-size/b.js
@@ -1,0 +1,2 @@
+import "./shared";
+export default "b";

--- a/test/statsCases/split-chunks-keep-remaining-size/c.js
+++ b/test/statsCases/split-chunks-keep-remaining-size/c.js
@@ -1,0 +1,5 @@
+import "./shared";
+export default "a";
+
+// content content content content content content
+// content content content content content content

--- a/test/statsCases/split-chunks-keep-remaining-size/index.js
+++ b/test/statsCases/split-chunks-keep-remaining-size/index.js
@@ -1,0 +1,3 @@
+import(/* webpackChunkName: "async-a" */ "./a");
+import(/* webpackChunkName: "async-b" */ "./b");
+import(/* webpackChunkName: "async-c" */ "./c");

--- a/test/statsCases/split-chunks-keep-remaining-size/shared.js
+++ b/test/statsCases/split-chunks-keep-remaining-size/shared.js
@@ -1,0 +1,2 @@
+// content content content content content content
+// content content content content content content

--- a/test/statsCases/split-chunks-keep-remaining-size/webpack.config.js
+++ b/test/statsCases/split-chunks-keep-remaining-size/webpack.config.js
@@ -15,12 +15,11 @@ module.exports = {
 		main: "./"
 	},
 	output: {
-		filename: "[name].js"
+		filename: "default/[name].js"
 	},
 	optimization: {
 		splitChunks: {
-			minSize: 100,
-			minRemainingSize: 0
+			minSize: 100
 		}
 	},
 	stats

--- a/test/statsCases/split-chunks-prefer-bigger-splits/webpack.config.js
+++ b/test/statsCases/split-chunks-prefer-bigger-splits/webpack.config.js
@@ -19,7 +19,8 @@ module.exports = {
 	},
 	optimization: {
 		splitChunks: {
-			minSize: 80
+			minSize: 80,
+			minRemainingSize: 0
 		}
 	},
 	stats


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

avoid zero sized modules as they lead to problems
add `minRemainingSize` option for splitChunks to ensure leftover chunks from splitting have a minimum size
defaults to `minSize` of cache group
defaults to global option when not specified
global option defaults to zero in development

fixes #8722

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix and new feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes, splitting behavior changes
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
New option `splitChunks.minRemainingSize` and `splitChunks.cacheGroups.xxx.minRemainingSize`.
`minRemainingSize` defaults to `minSize` so it doesn't need to be specified manually expect in rare cases where deep control is needed.
`minRemainingSize` ensures that the minimum size of the chunk which remains after splitting is above a limit.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
