### PR TITLE
fix(JsonpMainTemplatePlugin): provide useful stacktrace on chunk loading failure

### DIFF
--- a/lib/web/JsonpMainTemplatePlugin.js
+++ b/lib/web/JsonpMainTemplatePlugin.js
@@ -169,6 +169,8 @@ class JsonpMainTemplatePlugin {
 								"}"
 						  ])
 						: "",
+					"// create error before stack unwound to get useful stacktrace later",
+					"var error = new Error();",
 					"onScriptComplete = function (event) {",
 					Template.indent([
 						"// avoid mem leaks in IE.",
@@ -181,7 +183,7 @@ class JsonpMainTemplatePlugin {
 							Template.indent([
 								"var errorType = event && (event.type === 'load' ? 'missing' : event.type);",
 								"var realSrc = event && event.target && event.target.src;",
-								"var error = new Error('Loading chunk ' + chunkId + ' failed.\\n(' + errorType + ': ' + realSrc + ')');",
+								"error.message = 'Loading chunk ' + chunkId + ' failed.\\n(' + errorType + ': ' + realSrc + ')';",
 								"error.type = errorType;",
 								"error.request = realSrc;",
 								"chunk[1](error);"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Error created from load/error event handler has no useful stack trace whatsoever as it's an async event and stack has unwound already at that point.

To have better (sync) stacktrace of what triggered loading of the chunk, create error before stack has unwound and use it and its stacktrace later, in case of an error.

The reason this is useful, is that it allows to trace the root code that triggered problematic load of the chunk. Especially when using systems like Sentry where we don't know exactly how or where given failure has been triggered. This allows to better see the code that triggered the chunk and potentially to figure out the actual problem.

This potentially has some processing overhead as browser needs to create a stacktrace. It's probably not that big though but I haven't done any real testing.

Fixes: #9109

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
no. I'm not too familiar with infrastracture. Would need to have more time to do it. Ideally someone with more knowledge would take over if this PR is accepted.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Not that I can think of.

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
none