### PR TITLE
fix records revival of used chunk and module ids

### DIFF
--- a/lib/RecordIdsPlugin.js
+++ b/lib/RecordIdsPlugin.js
@@ -98,9 +98,7 @@ class RecordIdsPlugin {
 							usedIds.add(id);
 							module.id = id;
 						}
-					}
-					if (Array.isArray(records.modules.usedIds)) {
-						compilation.usedModuleIds = new Set(records.modules.usedIds);
+						compilation.usedModuleIds = usedIds;
 					}
 				}
 			);
@@ -219,9 +217,7 @@ class RecordIdsPlugin {
 							}
 						}
 					}
-					if (Array.isArray(records.chunks.usedIds)) {
-						compilation.usedChunkIds = new Set(records.chunks.usedIds);
-					}
+					compilation.usedChunkIds = usedIds;
 				}
 			);
 		});


### PR DESCRIPTION
When running webpack in watch mode or using portable records, revival of chunk and module ids happens correctly but after it `usedChunkIds` and `usedModuleIds` are assigned values from the records instead from what has actually been revived. It turns out to be that even if nothing is revived, `usedChunkIds` and `usedModuleIds` will be equal to values from previous compilation taken from records – this is clearly not intended.

Because of this, chunk ids will change on every compilation if running in watch mode or using portable records.

I believe it closes https://github.com/webpack/webpack/issues/8419

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

should be covered by existing tests

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

nothing
