### PR TITLE
Add [file] placeholder for sourceMappingURL in SourceMapDevToolPlugin

### DIFF
--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -254,7 +254,7 @@ class SourceMapDevToolPlugin {
 								query = filename.substr(idx);
 								filename = filename.substr(0, idx);
 							}
-							let sourceMapFile = compilation.getPath(sourceMapFilename, {
+							const pathParams = {
 								chunk,
 								filename: options.fileContext
 									? path.relative(options.fileContext, filename)
@@ -264,7 +264,11 @@ class SourceMapDevToolPlugin {
 								contentHash: createHash("md4")
 									.update(sourceMapString)
 									.digest("hex")
-							});
+							};
+							let sourceMapFile = compilation.getPath(
+								sourceMapFilename,
+								pathParams
+							);
 							const sourceMapUrl = options.publicPath
 								? options.publicPath + sourceMapFile.replace(/\\/g, "/")
 								: path
@@ -273,9 +277,9 @@ class SourceMapDevToolPlugin {
 							if (currentSourceMappingURLComment !== false) {
 								assets[file] = compilation.assets[file] = new ConcatSource(
 									new RawSource(source),
-									currentSourceMappingURLComment.replace(
-										/\[url\]/g,
-										sourceMapUrl
+									compilation.getPath(
+										currentSourceMappingURLComment,
+										Object.assign({ url: sourceMapUrl }, pathParams)
 									)
 								);
 							}

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -13,7 +13,8 @@ const REGEXP_HASH = /\[hash(?::(\d+))?\]/gi,
 	REGEXP_MODULEID = /\[moduleid\]/gi,
 	REGEXP_FILE = /\[file\]/gi,
 	REGEXP_QUERY = /\[query\]/gi,
-	REGEXP_FILEBASE = /\[filebase\]/gi;
+	REGEXP_FILEBASE = /\[filebase\]/gi,
+	REGEXP_URL = /\[url\]/gi;
 
 // Using global RegExp for .test is dangerous
 // We use a normal RegExp instead of .test
@@ -111,6 +112,8 @@ const replacePathVariables = (path, data) => {
 			.replace(REGEXP_FILEBASE, getReplacer(data.basename))
 			// query is optional, it's OK if it's in a path but there's nothing to replace it with
 			.replace(REGEXP_QUERY, getReplacer(data.query, true))
+			// only available in sourceMappingURLComment
+			.replace(REGEXP_URL, getReplacer(data.url))
 	);
 };
 

--- a/test/configCases/plugins/source-map-dev-tool-plugin~append/index.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin~append/index.js
@@ -1,0 +1,6 @@
+it("should have [file] replaced with chunk filename in append", function() {
+	var fs = require("fs"),
+			path = require("path");
+	var source = fs.readFileSync(path.join(__dirname, "some-test.js"), "utf-8");
+	expect(source).toMatch("//# sourceMappingURL=http://localhost:50505/some-test.js.map");
+});

--- a/test/configCases/plugins/source-map-dev-tool-plugin~append/test.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin~append/test.js
@@ -1,0 +1,5 @@
+var testObject = {
+	a: 1
+};
+
+module.exports = testObject;

--- a/test/configCases/plugins/source-map-dev-tool-plugin~append/webpack.config.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin~append/webpack.config.js
@@ -1,0 +1,28 @@
+var webpack = require("../../../../");
+var TerserPlugin = require("terser-webpack-plugin");
+module.exports = {
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	entry: {
+		bundle0: ["./index.js"],
+		"some-test": ["./test.js"]
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		minimizer: [
+			new TerserPlugin({
+				sourceMap: true
+			})
+		]
+	},
+	plugins: [
+		new webpack.SourceMapDevToolPlugin({
+			filename: "sourcemaps/[file].map",
+			append: "\n//# sourceMappingURL=http://localhost:50505/[file].map"
+		})
+	]
+};


### PR DESCRIPTION
I want to fully customize the path of generated map file as well as the path in `sourceMappingURL`.
I found fileContext hard to use because it will generate url like `http://localhost:50505/aaa/../b/name.js.map`, which should have been `path.normalize`d and generate `http://localhost:50505/b/name.js.map`, though these two might be the same to browser at all.

So why not have a `[file]` placeholder and let the users concatenate the path on their own?


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
sourceMap feature

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
[SourceMapDevToolPlugin](https://webpack.js.org/plugins/source-map-dev-tool-plugin/)
options.append