### PR TITLE
feat(watching): allow suspend/resume compilation

### DIFF
--- a/lib/MultiWatching.js
+++ b/lib/MultiWatching.js
@@ -18,6 +18,18 @@ class MultiWatching {
 		}
 	}
 
+	suspend() {
+		for (const watching of this.watchings) {
+			watching.suspend();
+		}
+	}
+
+	resume() {
+		for (const watching of this.watchings) {
+			watching.resume();
+		}
+	}
+
 	close(callback) {
 		asyncLib.forEach(
 			this.watchings,

--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -161,6 +161,7 @@ class Watching {
 			this.watcher.pause();
 			this.watcher = null;
 		}
+
 		if (this.running) {
 			this.invalid = true;
 			return false;
@@ -171,6 +172,7 @@ class Watching {
 
 	suspend() {
 		this.suspended = true;
+		this.invalid = false;
 	}
 
 	resume() {

--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -13,6 +13,7 @@ class Watching {
 		this.handler = handler;
 		this.callbacks = [];
 		this.closed = false;
+		this.suspended = false;
 		if (typeof watchOptions === "number") {
 			this.watchOptions = {
 				aggregateTimeout: watchOptions
@@ -133,7 +134,9 @@ class Watching {
 				this.compiler.fileTimestamps = fileTimestamps;
 				this.compiler.contextTimestamps = contextTimestamps;
 				this.compiler.removedFiles = removedFiles;
-				this._invalidate();
+				if (!this.suspended) {
+					this._invalidate();
+				}
 			},
 			(fileName, changeTime) => {
 				this.compiler.hooks.invalid.call(fileName, changeTime);
@@ -163,6 +166,17 @@ class Watching {
 			return false;
 		} else {
 			this._go();
+		}
+	}
+
+	suspend() {
+		this.suspended = true;
+	}
+
+	resume() {
+		if (this.suspended) {
+			this.suspended = false;
+			this._invalidate();
 		}
 	}
 

--- a/test/MultiWatching.unittest.js
+++ b/test/MultiWatching.unittest.js
@@ -7,6 +7,8 @@ const MultiWatching = require("../lib/MultiWatching");
 const createWatching = () => {
 	return {
 		invalidate: jest.fn(),
+		suspend: jest.fn(),
+		resume: jest.fn(),
 		close: jest.fn()
 	};
 };
@@ -40,6 +42,20 @@ describe("MultiWatching", () => {
 		it("invalidates each watching", () => {
 			expect(watchings[0].invalidate.mock.calls.length).toBe(1);
 			expect(watchings[1].invalidate.mock.calls.length).toBe(1);
+		});
+	});
+
+	describe("suspend", () => {
+		it("suspends each watching", () => {
+			myMultiWatching.suspend();
+			expect(watchings[0].suspend.mock.calls.length).toBe(1);
+			expect(watchings[1].suspend.mock.calls.length).toBe(1);
+		});
+
+		it("resume each watching", () => {
+			myMultiWatching.resume();
+			expect(watchings[0].resume.mock.calls.length).toBe(1);
+			expect(watchings[1].resume.mock.calls.length).toBe(1);
 		});
 	});
 

--- a/test/WatchSuspend.test.js
+++ b/test/WatchSuspend.test.js
@@ -1,0 +1,94 @@
+"use strict";
+
+/*globals describe it */
+const path = require("path");
+const fs = require("fs");
+
+const webpack = require("../");
+
+describe("WatchSuspend", () => {
+	if (process.env.NO_WATCH_TESTS) {
+		it.skip("long running tests excluded", () => {});
+		return;
+	}
+
+	jest.setTimeout(5000);
+
+	describe("suspend ans resume watcher", () => {
+		const fixturePath = path.join(
+			__dirname,
+			"fixtures",
+			"temp-watch-" + Date.now()
+		);
+		const filePath = path.join(fixturePath, "file.js");
+		let compiler = null;
+		let watching = null;
+
+		beforeAll(() => {
+			try {
+				fs.mkdirSync(fixturePath);
+			} catch (e) {
+				// skip
+			}
+			try {
+				fs.writeFileSync(filePath, "'foo'", "utf-8");
+			} catch (e) {
+				// skip
+			}
+		});
+
+		afterAll(done => {
+			watching.close();
+			compiler = null;
+			setTimeout(() => {
+				try {
+					fs.unlinkSync(filePath);
+				} catch (e) {
+					// skip
+				}
+				try {
+					fs.rmdirSync(fixturePath);
+				} catch (e) {
+					// skip
+				}
+				done();
+			}, 100); // cool down a bit
+		});
+
+		it("should compile successfully", done => {
+			compiler = webpack({
+				mode: "development",
+				entry: filePath,
+				output: {
+					path: fixturePath,
+					filename: "bundle.js"
+				}
+			});
+			watching = compiler.watch({ aggregateTimeout: 50 }, err => {
+				expect(err).toBe(null);
+				done();
+			});
+		});
+
+		it("should suspend compilation", done => {
+			const spy = jest.fn();
+			watching.suspend();
+			fs.writeFileSync(filePath, "'bar'", "utf-8");
+			compiler.hooks.compilation.tap("WatchSuspendTest", spy);
+			// compiler.hooks.done.tap("WatchSuspendTest", spy);
+			setTimeout(() => {
+				expect(spy.mock.calls.length).toBe(0);
+				done();
+			}, 100); // 2x aggregateTimeout
+		});
+
+		it("should resume compilation", done => {
+			compiler.hooks.done.tap("WatchSuspendTest", () => {
+				const outputPath = path.join(fixturePath, "bundle.js");
+				expect(fs.readFileSync(outputPath, "utf-8")).toContain("'bar'");
+				done();
+			});
+			watching.resume();
+		});
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Provide suspend and resume Node API for watch mode, to stop compilation when it's unnecessary.
related issues: https://github.com/webpack/webpack/issues/7341, https://github.com/webpack/webpack/issues/7653

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Two new apis of `watching`:
```js
watching.suspend()
watching.resume()
```
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
