### PR TITLE
feat: allow webpack to input and output in mem

### DIFF
--- a/lib/node/NodeEnvironmentPlugin.js
+++ b/lib/node/NodeEnvironmentPlugin.js
@@ -7,6 +7,7 @@
 
 const CachedInputFileSystem = require("enhanced-resolve/lib/CachedInputFileSystem");
 const NodeJsInputFileSystem = require("enhanced-resolve/lib/NodeJsInputFileSystem");
+const NodeMemoryFileSystem = require("./NodeOutputMemoryFileSystem");
 const NodeOutputFileSystem = require("./NodeOutputFileSystem");
 const NodeWatchFileSystem = require("./NodeWatchFileSystem");
 
@@ -18,12 +19,31 @@ class NodeEnvironmentPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
+		const isMemoryFS = compiler.options.memory ? true : false;	
+		const {MemoryFileSystem} = isMemoryFS ? new NodeMemoryFileSystem() : null;
+		if (isMemoryFS) {
+			// @ts-ignore
+			try {
+				const fs = require('fs');
+				fs.statSync(compiler.options.entry);
+			} catch(err) {
+				if(err.code === 'ENOENT') {
+					MemoryFileSystem.mkdirpSync(process.cwd());
+					const noopEntry = process.cwd() + '/index.js';
+					MemoryFileSystem.writeFileSync(noopEntry, 'console.log("hi")', 'utf8');
+					compiler.options.entry = noopEntry;
+				}
+			}
+			compiler.memory = MemoryFileSystem;
+		}
+
 		compiler.inputFileSystem = new CachedInputFileSystem(
-			new NodeJsInputFileSystem(),
+			isMemoryFS ? MemoryFileSystem : new NodeJsInputFileSystem(),
 			60000
 		);
+
 		const inputFileSystem = compiler.inputFileSystem;
-		compiler.outputFileSystem = new NodeOutputFileSystem();
+		compiler.outputFileSystem =	isMemoryFS ? MemoryFileSystem : new NodeOutputFileSystem(),
 		compiler.watchFileSystem = new NodeWatchFileSystem(
 			compiler.inputFileSystem
 		);

--- a/lib/node/NodeOutputMemoryFileSystem.js
+++ b/lib/node/NodeOutputMemoryFileSystem.js
@@ -1,0 +1,26 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Even Stensberg @evenstensberg
+*/
+
+"use strict";
+
+const path = require("path");
+const memFs = require('memory-fs');
+
+class NodeOutputMemoryFileSystem {
+	constructor() {
+        this.MemoryFileSystem = new memFs();
+		this.mkdirp = this.MemoryFileSystem.mkdirp;
+		this.mkdir = this.MemoryFileSystem.mkdir;
+		this.rmdir = this.MemoryFileSystem.rmdir;
+		this.unlink = this.MemoryFileSystem.unlink;
+		this.writeFile = this.MemoryFileSystem.writeFile;
+        this.join = path.join.bind(path);
+        this.readFileSync = this.MemoryFileSystem.readFileSync;
+        this.writeFileSync = this.MemoryFileSystem.writeFileSync;
+        this.mkdirpSync = this.MemoryFileSystem.mkdirpSync;
+	}
+}
+
+module.exports = NodeOutputMemoryFileSystem;

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2120,6 +2120,10 @@
       "type": "string",
       "absolutePath": true
     },
+    "memory": {
+      "description": "Determines if webpack should output to memory instead of disk",
+      "type": "boolean"
+    },
     "dependencies": {
       "description": "References to other configurations to depend on.",
       "type": "array",


### PR DESCRIPTION
# Rationale 

There's been an interest in allowing webpack to be used with 0CJS, zero configuration and allowing webpack to run without having to supply any information (even though this is hard..). What this PR proposes, is a way to fallback to using a memory file (not emitting anything on disk) if there's no entries to be found by looking up common filenames or by common configuration names. When developing the new webpack CLI (next branch at webpack-cli), we're working on setting good defaults, and this is apart of that.
 
https://github.com/webpack/webpack-cli/issues/717

This functionality also turns out positive if the developer wants to run a webpack instance without the need of outputting to disk, such for webpack dev server or similar. Webpack Dev server has now the possibility of using the output webpack emits rather than wrapping their implementation in their own Memory FS wrapper. What I could envision, is that instead of adding the output to an object (quite big on large builds), we can serialize it for stats and then stats can pick up that information. 

This would be equivalent to emitting to disk, even though there are some advantages of doing memory compilations this way. The current abstraction of webpack is architectured in such a way that wrapping the files to a memory API is hard as the IO is abstracted (which is nice, but not in this use case) into two seperate API's and objects holding fs info. 

The implementation uses the `memory-fs` dependency already included, and used by enhanced resolve. Altough the abstraction is bad, this feature has the possibility to either do a duplex mem compilation, meaning that you can both supply input files in memory and output in memory. You can also have an input file (the main reason for this PR) as a memory file with a good initial default and output to disk.

I've thought about providing this abstraction elsewhere, such as in webpack-cli itself, but we are reliant on providing the object which holds the vfs data to webpack and getting it back with data in order to transpile. 

Adding duplex functionality (read/write) as for the `NodeInput` and `NodeOutput` filesystems aren't really well architectural-wise, as I think you would like to have this abstraction seperate (except in the instance of a virtual filesystem). Having the functionality implemented in [Enhanced-Resolve](https://github.com/webpack/enhanced-resolve/blob/master/lib/NodeJsInputFileSystem.js#L9) (https://github.com/webpack/webpack/blob/next/lib/node/NodeOutputFileSystem.js) at a granular level also breaks the abstraction, which is pretty good for webpack right now. 


**What kind of change does this PR introduce?**

The PR introduces a way for the CLI and webpack core to collaborate between outputting to disk and memory, either by having the entry point as a memory file, or both entry and output being in memory.

**Did you add tests for your changes?**

N/A

**Does this PR introduce a breaking change?**

N/A (needs to be elaborated on)


**What needs to be documented once your changes are merged?**

- webpack.js.org
- webpack-CLI 
- webpack-dev-server (maybe)

## Summary

Once this is implemented, we are able to run webpack without any files, but we can set defaults and help the user in the initial process of setting up webpack bottom-up. Also working on a few more 0CJS changes, but this is the most important one.

Let me know what is needed to get this through..

Even 
