### PR TITLE
fix: add missing public path in importScripts

### DIFF
--- a/lib/webworker/WebWorkerMainTemplatePlugin.js
+++ b/lib/webworker/WebWorkerMainTemplatePlugin.js
@@ -45,7 +45,7 @@ class WebWorkerMainTemplatePlugin {
 						"if(!installedChunks[chunkId]) {",
 						Template.indent([
 							"importScripts(" +
-								`__webpack_require__.p + ` +
+								"__webpack_require__.p + " +
 								mainTemplate.getAssetPath(JSON.stringify(chunkFilename), {
 									hash: `" + ${mainTemplate.renderCurrentHashCode(hash)} + "`,
 									hashWithLength: length =>

--- a/lib/webworker/WebWorkerMainTemplatePlugin.js
+++ b/lib/webworker/WebWorkerMainTemplatePlugin.js
@@ -45,9 +45,7 @@ class WebWorkerMainTemplatePlugin {
 						"if(!installedChunks[chunkId]) {",
 						Template.indent([
 							"importScripts(" +
-								`"` +
-								mainTemplate.getPublicPath({ hash }) +
-								`" + ` +
+								`__webpack_require__.p + ` +
 								mainTemplate.getAssetPath(JSON.stringify(chunkFilename), {
 									hash: `" + ${mainTemplate.renderCurrentHashCode(hash)} + "`,
 									hashWithLength: length =>

--- a/lib/webworker/WebWorkerMainTemplatePlugin.js
+++ b/lib/webworker/WebWorkerMainTemplatePlugin.js
@@ -45,6 +45,9 @@ class WebWorkerMainTemplatePlugin {
 						"if(!installedChunks[chunkId]) {",
 						Template.indent([
 							"importScripts(" +
+								`"` +
+								mainTemplate.getPublicPath({ hash }) +
+								`" + ` +
 								mainTemplate.getAssetPath(JSON.stringify(chunkFilename), {
 									hash: `" + ${mainTemplate.renderCurrentHashCode(hash)} + "`,
 									hashWithLength: length =>

--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -194,6 +194,7 @@ describe("ConfigTestCases", () => {
 											let runInNewContext = false;
 											const moduleScope = {
 												require: _require.bind(null, path.dirname(p)),
+												importScripts: _require.bind(null, path.dirname(p)),
 												module: m,
 												exports: m.exports,
 												__dirname: path.dirname(p),
@@ -216,6 +217,7 @@ describe("ConfigTestCases", () => {
 												options.target === "webworker"
 											) {
 												moduleScope.window = globalContext;
+												moduleScope.self = globalContext;
 												runInNewContext = true;
 											}
 											if (testConfig.moduleScope) {

--- a/test/configCases/target/webworker/index.js
+++ b/test/configCases/target/webworker/index.js
@@ -93,3 +93,10 @@ it("should provide a zlib shim", function () {
 it("should provide a shim for a path in a build-in module", function () {
 	expect(require("process/in.js")).toBe("in process");
 });
+
+it("should allow to load a chunk", () => {
+	__webpack_public_path__ = "./";
+	return import("./module").then(module => {
+		expect(module.default).toBe("ok");
+	});
+});

--- a/test/configCases/target/webworker/module.js
+++ b/test/configCases/target/webworker/module.js
@@ -1,0 +1,1 @@
+export default "ok";


### PR DESCRIPTION
fixes #7529, fixes #8562

In #8562, the changes made by @prateekbh seems don't work any more, as the webpack repository does not contain `lib/webworker/ImportScriptsChunkLoadingRuntimeModule.js`.

For more detail, here is the config:

```js
module.exports = {
    // ...
    output: {
        path: path.resolve(__dirname, '../public'),
        publicPath: '/',
        filename: 'static/scripts/[name].js',
    },
   // ...
}
```

After webpack bundling, it will output the following snippet:

```js
__webpack_require__.e = function requireEnsure(chunkId) {
    var promises = [];
    promises.push(Promise.resolve().then(function() {
        // "1" is the signal for "already loaded"
        if(!installedChunks[chunkId]) {
            importScripts("static/scripts/" + ({}[chunkId]||chunkId) + ".worker.js");
        }
    }));
    return Promise.all(promises);
};
```

Without public path, the browser will fetch a wrong path: `http://localhost:8000/static/scripts/static/scripts/5.worker.js`, which will cause 404 error.


**What kind of change does this PR introduce?**

a bugfix

**Did you add tests for your changes?**

Currently no tests.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

Nothing.