### PR TITLE
Update NormalModuleReplacementPlugin to new api

### DIFF
--- a/lib/NormalModuleReplacementPlugin.js
+++ b/lib/NormalModuleReplacementPlugin.js
@@ -40,7 +40,6 @@ class NormalModuleReplacementPlugin {
 							result.request = newResource;
 						}
 					}
-					return result;
 				});
 				nmf.hooks.afterResolve.tap("NormalModuleReplacementPlugin", result => {
 					const createData = result.createData;
@@ -63,7 +62,6 @@ class NormalModuleReplacementPlugin {
 							}
 						}
 					}
-					return result;
 				});
 			}
 		);


### PR DESCRIPTION
Fix for
```
Error: NormalModuleFactory.afterResolve is no longer a waterfall hook, but a bailing hook instead. Do not return the passed object, but modify it instead. Returning false will ignore the request and results in no module created.
      at hooks.afterResolve.callAsync (webpack/lib/NormalModuleFactory.js:192:14)
```

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
