### PR TITLE
[WIP] Fixes #9053: Wrong loaders order when using inline match resource

### DIFF
--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -335,7 +335,7 @@ class NormalModuleFactory extends Tapable {
 						],
 						(err, results) => {
 							if (err) return callback(err);
-							loaders = results[0].concat(loaders, results[1], results[2]);
+							loaders = results[0].concat(results[1], loaders, results[2]);
 							process.nextTick(() => {
 								const type = settings.type;
 								const resolveOptions = settings.resolve;

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -335,7 +335,11 @@ class NormalModuleFactory extends Tapable {
 						],
 						(err, results) => {
 							if (err) return callback(err);
-							loaders = results[0].concat(results[1], loaders, results[2]);
+							if (matchResource === undefined) {
+								loaders = results[0].concat(loaders, results[1], results[2]);
+							} else {
+								loaders = results[0].concat(results[1], loaders, results[2]);
+							}
 							process.nextTick(() => {
 								const type = settings.type;
 								const resolveOptions = settings.resolve;

--- a/test/configCases/loaders/issue-9053/a.js
+++ b/test/configCases/loaders/issue-9053/a.js
@@ -1,0 +1,1 @@
+module.exports = require("c.js!=!loader1!./b.js");

--- a/test/configCases/loaders/issue-9053/a.js
+++ b/test/configCases/loaders/issue-9053/a.js
@@ -1,1 +1,0 @@
-module.exports = require("c.js!=!loader1!./b.js");

--- a/test/configCases/loaders/issue-9053/b.js
+++ b/test/configCases/loaders/issue-9053/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/test/configCases/loaders/issue-9053/b.js
+++ b/test/configCases/loaders/issue-9053/b.js
@@ -1,1 +1,1 @@
-module.exports = "b";
+module.exports = ["b"];

--- a/test/configCases/loaders/issue-9053/c.js
+++ b/test/configCases/loaders/issue-9053/c.js
@@ -1,0 +1,1 @@
+module.exports = ["c"];

--- a/test/configCases/loaders/issue-9053/index.js
+++ b/test/configCases/loaders/issue-9053/index.js
@@ -1,5 +1,17 @@
 it("should apply inline loaders before matchResource", function() {
-	var foo = require("./a");
+	var foo = require("c.js!=!loader1!./b.js");
 
-	expect(foo).toBe("d");
+	expect(foo).toEqual(["b", "1", "2"]);
+});
+
+it("should apply config loaders before inline loaders", function() {
+	var foo = require("loader1!./c.js");
+
+	expect(foo).toEqual(["c", "2", "1"]);
+});
+
+it("should not apply config loaders when matchResource is used", function() {
+	var foo = require("d.js!=!loader1!./c.js");
+
+	expect(foo).toEqual(["c", "1", "3"]);
 });

--- a/test/configCases/loaders/issue-9053/index.js
+++ b/test/configCases/loaders/issue-9053/index.js
@@ -1,0 +1,5 @@
+it("should apply inline loaders before matchResource", function() {
+	var foo = require("./a");
+
+	expect(foo).toBe("d");
+});

--- a/test/configCases/loaders/issue-9053/node_modules/loader1.js
+++ b/test/configCases/loaders/issue-9053/node_modules/loader1.js
@@ -1,0 +1,3 @@
+module.exports = function(source) {
+    return "module.exports = \"c\";";
+};

--- a/test/configCases/loaders/issue-9053/node_modules/loader1.js
+++ b/test/configCases/loaders/issue-9053/node_modules/loader1.js
@@ -1,3 +1,3 @@
 module.exports = function(source) {
-    return "module.exports = \"c\";";
+	return source + '\nmodule.exports.push("1");';
 };

--- a/test/configCases/loaders/issue-9053/node_modules/loader2.js
+++ b/test/configCases/loaders/issue-9053/node_modules/loader2.js
@@ -1,0 +1,3 @@
+module.exports = function(source) {
+    return "module.exports = \"d\";";
+};

--- a/test/configCases/loaders/issue-9053/node_modules/loader2.js
+++ b/test/configCases/loaders/issue-9053/node_modules/loader2.js
@@ -1,3 +1,3 @@
 module.exports = function(source) {
-    return "module.exports = \"d\";";
+	return source + '\nmodule.exports.push("2");';
 };

--- a/test/configCases/loaders/issue-9053/node_modules/loader3.js
+++ b/test/configCases/loaders/issue-9053/node_modules/loader3.js
@@ -1,0 +1,3 @@
+module.exports = function(source) {
+	return source + '\nmodule.exports.push("3");';
+};

--- a/test/configCases/loaders/issue-9053/webpack.config.js
+++ b/test/configCases/loaders/issue-9053/webpack.config.js
@@ -4,6 +4,10 @@ module.exports = {
 			{
 				test: /c\.js$/,
 				use: ["loader2"]
+			},
+			{
+				test: /d\.js$/,
+				use: ["loader3"]
 			}
 		]
 	}

--- a/test/configCases/loaders/issue-9053/webpack.config.js
+++ b/test/configCases/loaders/issue-9053/webpack.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /c\.js$/,
+				use: ["loader2"]
+			}
+		]
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Loaders are applied in the wrong order when using inline match resource, as shown in #9053. The resulting behaviour does not match the expected behaviour as described by the documentation.

I'm attempting to write a loader which depends on `matchResource` working as documented, and the bug has been open for a while with no progress.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
A bugfix.

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
Yes.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Unsure. All tests were run and passing locally, but not sure if fix as written is appropriate, so opening a PR for review/guidance.

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
Hopefully none, as this makes `matchResource` behave as documented, however see above.
