### PR TITLE
Support Windows network shares as absolute paths

### DIFF
--- a/schemas/ajv.absolutePath.js
+++ b/schemas/ajv.absolutePath.js
@@ -26,7 +26,7 @@ module.exports = ajv =>
 				let passes = true;
 				const isExclamationMarkPresent = data.includes("!");
 				const isCorrectAbsoluteOrRelativePath =
-					expected === /^(?:[A-Za-z]:\\|\/)/.test(data);
+					expected === /^(?:[A-Za-z]:\\|\\\\|\/)/.test(data);
 
 				if (isExclamationMarkPresent) {
 					callback.errors = [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Windows shares start with `\\`. It would be nice if webpack could output a bundle directly to a folder on a Windows share.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Allows `config.output.path` to start with `\\` which, on Windows systems, is a valid absolute path to a network share.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No - it is not clear to me how to "test" this.
Do I add a test that checks if a path that starts with `\\` is now allowed?
Or a test that depends on a network share being available and actually writing to that output?

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

https://webpack.js.org/concepts/output/ should probably include an example of using a Windows share.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
