### PR TITLE
remove experimental from module type name

### DIFF
--- a/examples/wasm-complex/webpack.config.js
+++ b/examples/wasm-complex/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
 			{
 				test: /\.wat$/,
 				use: "wast-loader",
-				type: "webassembly/async-experimental"
+				type: "webassembly/async"
 			}
 		]
 	},

--- a/examples/wasm-simple/webpack.config.js
+++ b/examples/wasm-simple/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
 		rules: [
 			{
 				test: /\.wasm$/,
-				type: "webassembly/async-experimental"
+				type: "webassembly/async"
 			}
 		]
 	},

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -142,11 +142,11 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 				},
 				options.experiments.syncWebAssembly && {
 					test: /\.wasm$/i,
-					type: "webassembly/experimental"
+					type: "webassembly/sync"
 				},
 				options.experiments.asyncWebAssembly && {
 					test: /\.wasm$/i,
-					type: "webassembly/async-experimental"
+					type: "webassembly/async"
 				}
 			].filter(Boolean)
 		);

--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -321,8 +321,8 @@ const interceptAllParserHooks = (moduleFactory, tracer) => {
 		"javascript/dynamic",
 		"javascript/esm",
 		"json",
-		"webassembly/async-experimental",
-		"webassembly/experimental"
+		"webassembly/async",
+		"webassembly/sync"
 	];
 
 	moduleTypes.forEach(moduleType => {

--- a/lib/node/ReadFileCompileAsyncWasmPlugin.js
+++ b/lib/node/ReadFileCompileAsyncWasmPlugin.js
@@ -54,7 +54,7 @@ class ReadFileCompileAsyncWasmPlugin {
 						if (
 							!chunkGraph.hasModuleInGraph(
 								chunk,
-								m => m.type === "webassembly/async-experimental"
+								m => m.type === "webassembly/async"
 							)
 						) {
 							return;

--- a/lib/node/ReadFileCompileWasmPlugin.js
+++ b/lib/node/ReadFileCompileWasmPlugin.js
@@ -58,7 +58,7 @@ class ReadFileCompileWasmPlugin {
 						if (
 							!chunkGraph.hasModuleInGraph(
 								chunk,
-								m => m.type === "webassembly/experimental"
+								m => m.type === "webassembly/sync"
 							)
 						) {
 							return;

--- a/lib/wasm-async/AsyncWebAssemblyModulesPlugin.js
+++ b/lib/wasm-async/AsyncWebAssemblyModulesPlugin.js
@@ -35,12 +35,12 @@ class AsyncWebAssemblyModulesPlugin {
 				);
 
 				normalModuleFactory.hooks.createParser
-					.for("webassembly/async-experimental")
+					.for("webassembly/async")
 					.tap("AsyncWebAssemblyModulesPlugin", () => {
 						return new AsyncWebAssemblyParser();
 					});
 				normalModuleFactory.hooks.createGenerator
-					.for("webassembly/async-experimental")
+					.for("webassembly/async")
 					.tap("AsyncWebAssemblyModulesPlugin", () => {
 						return Generator.byType({
 							javascript: new AsyncWebAssemblyJavascriptGenerator(
@@ -67,7 +67,7 @@ class AsyncWebAssemblyModulesPlugin {
 						chunk,
 						compareModulesById(chunkGraph)
 					)) {
-						if (module.type === "webassembly/async-experimental") {
+						if (module.type === "webassembly/async") {
 							const filenameTemplate = outputOptions.webassemblyModuleFilename;
 
 							result.push({

--- a/lib/wasm/WebAssemblyModulesPlugin.js
+++ b/lib/wasm/WebAssemblyModulesPlugin.js
@@ -44,13 +44,13 @@ class WebAssemblyModulesPlugin {
 				);
 
 				normalModuleFactory.hooks.createParser
-					.for("webassembly/experimental")
+					.for("webassembly/sync")
 					.tap("WebAssemblyModulesPlugin", () => {
 						return new WebAssemblyParser();
 					});
 
 				normalModuleFactory.hooks.createGenerator
-					.for("webassembly/experimental")
+					.for("webassembly/sync")
 					.tap("WebAssemblyModulesPlugin", () => {
 						return Generator.byType({
 							javascript: new WebAssemblyJavascriptGenerator(),
@@ -71,7 +71,7 @@ class WebAssemblyModulesPlugin {
 							chunk,
 							compareModulesById(chunkGraph)
 						)) {
-							if (module.type === "webassembly/experimental") {
+							if (module.type === "webassembly/sync") {
 								const filenameTemplate =
 									outputOptions.webassemblyModuleFilename;
 
@@ -111,7 +111,7 @@ class WebAssemblyModulesPlugin {
 					for (const chunk of compilation.chunks) {
 						if (chunk.canBeInitial()) {
 							for (const module of chunkGraph.getChunkModulesIterable(chunk)) {
-								if (module.type === "webassembly/experimental") {
+								if (module.type === "webassembly/sync") {
 									initialWasmModules.add(module);
 								}
 							}

--- a/lib/web/FetchCompileAsyncWasmPlugin.js
+++ b/lib/web/FetchCompileAsyncWasmPlugin.js
@@ -29,7 +29,7 @@ class FetchCompileAsyncWasmPlugin {
 						if (
 							!chunkGraph.hasModuleInGraph(
 								chunk,
-								m => m.type === "webassembly/async-experimental"
+								m => m.type === "webassembly/async"
 							)
 						) {
 							return;

--- a/lib/web/FetchCompileWasmPlugin.js
+++ b/lib/web/FetchCompileWasmPlugin.js
@@ -33,7 +33,7 @@ class FetchCompileWasmPlugin {
 						if (
 							!chunkGraph.hasModuleInGraph(
 								chunk,
-								m => m.type === "webassembly/experimental"
+								m => m.type === "webassembly/sync"
 							)
 						) {
 							return;

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -159,7 +159,7 @@ const describeCases = config => {
 										{
 											test: /\.wat$/i,
 											loader: "wast-loader",
-											type: "webassembly/async-experimental"
+											type: "webassembly/async"
 										}
 									]
 								},

--- a/test/configCases/wasm/identical/webpack.config.js
+++ b/test/configCases/wasm/identical/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
 			{
 				test: /\.wat$/,
 				loader: "wast-loader",
-				type: "webassembly/async-experimental"
+				type: "webassembly/async"
 			}
 		]
 	},

--- a/test/configCases/wasm/wasm-in-initial-chunk-error/webpack.config.js
+++ b/test/configCases/wasm/wasm-in-initial-chunk-error/webpack.config.js
@@ -5,7 +5,7 @@ module.exports = {
 			{
 				test: /\.wat$/,
 				loader: "wast-loader",
-				type: "webassembly/experimental"
+				type: "webassembly/sync"
 			}
 		]
 	},


### PR DESCRIPTION
since there is the `experiments` config now

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
rename
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
existing tests
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
* `webassembly/experimental` -> `webassembly/sync`
* `webassembly/async-experimental` -> `webassembly/async`
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
