### PR TITLE
remove valid jsdoc rule in favour of eslint-plugin-jsdoc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,24 +33,6 @@ module.exports = {
 		"no-loop-func": "warn",
 		indent: "off",
 		"no-console": "off",
-		"valid-jsdoc": [
-			"error",
-			{
-				prefer: {
-					return: "returns",
-					prop: "property",
-					memberof: "DONTUSE",
-					class: "DONTUSE",
-					inheritdoc: "DONTUSE",
-					description: "DONTUSE",
-					readonly: "DONTUSE"
-				},
-				preferType: {
-					"*": "any"
-				},
-				requireReturnType: true
-			}
-		],
 		"node/no-unsupported-features": "error",
 		"node/no-deprecated-api": "error",
 		"node/no-missing-import": "error",
@@ -59,7 +41,15 @@ module.exports = {
 		"node/no-unpublished-require": "error",
 		"node/process-exit-as-throw": "error",
 		"jsdoc/require-hyphen-before-param-description": ["error", "never"],
-		"jsdoc/check-tag-names": "error"
+		"jsdoc/check-tag-names": "error",
+		"jsdoc/check-param-names": "error",
+		"jsdoc/require-param-description": "error",
+		"jsdoc/require-param-name": "error",
+		"jsdoc/require-param-type": "error",
+		"jsdoc/require-param": "error",
+		"jsdoc/require-returns-description": "error",
+		"jsdoc/require-returns-type": "error",
+		"jsdoc/require-returns": "error"
 	},
 	settings: {
 		jsdoc: {
@@ -72,8 +62,17 @@ module.exports = {
 					return acc;
 				}, {})),
 				extends: "extends",
-				constructor: "constructor"
-			}
+				return: "returns",
+				constructor: "constructor",
+				prop: "property",
+				arg: "param",
+				augments: "extends",
+				description: false,
+				desc: false,
+				inheritdoc: false,
+				class: false
+			},
+			overrideReplacesDocs: false
 		}
 	},
 	overrides: [

--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -78,8 +78,8 @@ class Profiler {
 }
 
 /**
+ * an object that wraps Tracer and Profiler with a counter
  * @typedef {Object} Trace
- * @description an object that wraps Tracer and Profiler with a counter
  * @property {Tracer} trace instance of Tracer
  * @property {number} counter Counter
  * @property {Profiler} profiler instance of Profiler


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
fixes https://github.com/webpack/webpack/issues/9416

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

refactoring
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
