### PR TITLE
feat(providePlugin): Add ability to exclude files for ProvidePlugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /test/js
 /test/browsertest/js
 /test/fixtures/temp-cache-fixture
+/test/fixtures/temp-watch-*
 /benchmark/js
 /benchmark/fixtures
 /examples/**/dist

--- a/lib/ProvidePlugin.js
+++ b/lib/ProvidePlugin.js
@@ -26,7 +26,24 @@ class ProvidePlugin {
 				);
 				const handler = (parser, parserOptions) => {
 					Object.keys(definitions).forEach(name => {
-						var request = [].concat(definitions[name]);
+						// Support ignore file
+						let provideFile = definitions[name];
+						let excludeFiles = [];
+						if (
+							!Array.isArray(provideFile) &&
+							provideFile !== null &&
+							typeof provideFile === "object"
+						) {
+							if (
+								typeof definitions[name].exclude === "string" ||
+								Array.isArray(definitions[name].exclude)
+							) {
+								excludeFiles = [].concat(definitions[name].exclude);
+							}
+							provideFile = provideFile.module;
+						}
+
+						var request = [].concat(provideFile);
 						var splittedName = name.split(".");
 						if (splittedName.length > 0) {
 							splittedName.slice(1).forEach((_, i) => {
@@ -37,6 +54,15 @@ class ProvidePlugin {
 							});
 						}
 						parser.hooks.expression.for(name).tap("ProvidePlugin", expr => {
+							// exclude files
+							const currentFile = parser.state.current.request;
+							for (let i in excludeFiles) {
+								console.log(currentFile, excludeFiles);
+								if (currentFile.match(excludeFiles[i])) {
+									return false;
+								}
+							}
+
 							let nameIdentifier = name;
 							const scopedName = name.includes(".");
 							let expression = `require(${JSON.stringify(request[0])})`;

--- a/test/configCases/plugins/provide-plugin/index.js
+++ b/test/configCases/plugins/provide-plugin/index.js
@@ -61,3 +61,17 @@ it("should not provide for mjs", function(){
 	var foo = require("./foo.mjs").default;
 	expect(foo()).toBe("undefined");
 });
+
+// Object structure
+
+it("should provide a module for a simple free var as object.module", function() {
+	expect(ooa).toBe("ooa");
+});
+
+it("should provide a module for a nested var as object.module", function() {
+	expect(oob).toBe("oob");
+});
+
+it("should exclude file from being provided", function() {
+	expect(typeof ooc).toEqual("undefined");
+});

--- a/test/configCases/plugins/provide-plugin/ooa.js
+++ b/test/configCases/plugins/provide-plugin/ooa.js
@@ -1,0 +1,1 @@
+module.exports = "ooa";

--- a/test/configCases/plugins/provide-plugin/oob.js
+++ b/test/configCases/plugins/provide-plugin/oob.js
@@ -1,0 +1,3 @@
+module.exports = {
+	bbb: "oob"
+};

--- a/test/configCases/plugins/provide-plugin/ooc.js
+++ b/test/configCases/plugins/provide-plugin/ooc.js
@@ -1,0 +1,1 @@
+module.exports = "ooc";

--- a/test/configCases/plugins/provide-plugin/webpack.config.js
+++ b/test/configCases/plugins/provide-plugin/webpack.config.js
@@ -11,6 +11,12 @@ module.exports = {
 			es2015_alias: ["./harmony", "alias"],
 			es2015_year: ["./harmony", "year"],
 			"this.aaa": "./aaa",
+			ooa: { module: "./ooa" },
+			oob: { module: ["./oob", "bbb"] },
+			ooc: {
+				module: "./ooc",
+				exclude: "configCases/plugins/provide-plugin/index.js"
+			},
 			esm: "fail"
 		})
 	]


### PR DESCRIPTION
This feature will allow one to exclude files from the ProvidePlugin. This is useful if you wish to override a native function such as XMLHttpRequest. See #6226 for more details.

**What kind of change does this PR introduce?**

This is a feature and adds a new form of input in `ProvidePlugin`:

```
new ProvidePlugin({ module: "aaa", exclude: "bbb.js" })
new ProvidePlugin({ module: "aaa" })
new ProvidePlugin({ module: ["aaa", "bbb"] })
```

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Need to update the documentation to show the new feature and optional data structure.
