### PR TITLE
Prefer the IDL 'nonce' property over .getAttribute('nonce')

### DIFF
--- a/test/cases/nonce/set-nonce/index.js
+++ b/test/cases/nonce/set-nonce/index.js
@@ -7,7 +7,8 @@ it("should load script with nonce 'nonce1234'", function(done) {
 	// if in browser context, test that nonce was added.
 	if (typeof document !== 'undefined') {
 		var script = document.querySelector('script[src="js/chunk-with-nonce.web.js"]');
-		expect(script.getAttribute('nonce')).toBe('nonce1234');
+		var nonce = script.nonce || script.getAttribute('nonce');
+		expect(nonce).toBe('nonce1234');
 	}
 	__webpack_nonce__ = undefined;
 	done();


### PR DESCRIPTION
Prefer the IDL 'nonce' property over .getAttribute('nonce'), which does not work due to https://bugs.chromium.org/p/chromium/issues/detail?id=680419 and https://codereview.chromium.org/2628733005/.
