### PR TITLE
add logging API

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1350,7 +1350,7 @@ export interface StatsOptions {
 	/**
 	 * add logging output
 	 */
-	logging?: boolean;
+	logging?: boolean | ("error" | "warn" | "info" | "log" | "verbose");
 	/**
 	 * add stack traces to logging output
 	 */

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -304,7 +304,7 @@ export interface WebpackOptions {
 		/**
 		 * Log level
 		 */
-		level?: "error" | "warn" | "info" | "log" | "verbose";
+		level?: "none" | "error" | "warn" | "info" | "log" | "verbose";
 	};
 	/**
 	 * Custom values available in the loader context.
@@ -1359,7 +1359,7 @@ export interface StatsOptions {
 	/**
 	 * add logging output
 	 */
-	logging?: boolean | ("error" | "warn" | "info" | "log" | "verbose");
+	logging?: boolean | ("none" | "error" | "warn" | "info" | "log" | "verbose");
 	/**
 	 * Include debug logging of specified loggers (i. e. for plugins or loaders). Filters can be Strings, RegExps or Functions
 	 */

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -76,6 +76,16 @@ export type ExternalItem =
  */
 export type ArrayOfStringValues = string[];
 /**
+ * This interface was referenced by `WebpackOptions`'s JSON-Schema
+ * via the `definition` "FilterTypes".
+ */
+export type FilterTypes = FilterItemTypes | FilterItemTypes[];
+/**
+ * This interface was referenced by `WebpackOptions`'s JSON-Schema
+ * via the `definition` "FilterItemTypes".
+ */
+export type FilterItemTypes = RegExp | string | ((value: string) => boolean);
+/**
  * One or multiple rule conditions
  *
  * This interface was referenced by `WebpackOptions`'s JSON-Schema
@@ -235,16 +245,6 @@ export type WebpackPluginFunction = (
  * via the `definition` "RuleSetRules".
  */
 export type RuleSetRules = RuleSetRule[];
-/**
- * This interface was referenced by `WebpackOptions`'s JSON-Schema
- * via the `definition` "FilterTypes".
- */
-export type FilterTypes = FilterItemTypes | FilterItemTypes[];
-/**
- * This interface was referenced by `WebpackOptions`'s JSON-Schema
- * via the `definition` "FilterItemTypes".
- */
-export type FilterItemTypes = RegExp | string | Function;
 
 export interface WebpackOptions {
 	/**
@@ -293,6 +293,19 @@ export interface WebpackOptions {
 	 * Specify dependencies that shouldn't be resolved by webpack, but should become dependencies of the resulting bundle. The kind of the dependency depends on `output.libraryTarget`.
 	 */
 	externals?: Externals;
+	/**
+	 * Options for infrastructure level logging
+	 */
+	infrastructureLogging?: {
+		/**
+		 * Enable debug logging for specific loggers
+		 */
+		debug?: FilterTypes | boolean;
+		/**
+		 * Log level
+		 */
+		level?: "error" | "warn" | "info" | "log" | "verbose";
+	};
 	/**
 	 * Custom values available in the loader context.
 	 */
@@ -1344,13 +1357,13 @@ export interface StatsOptions {
 	 */
 	hash?: boolean;
 	/**
-	 * Include debug logging of specified modules (plugins/loaders). Filters can be Strings, RegExps or Functions
-	 */
-	includeDebugLogging?: FilterTypes;
-	/**
 	 * add logging output
 	 */
 	logging?: boolean | ("error" | "warn" | "info" | "log" | "verbose");
+	/**
+	 * Include debug logging of specified loggers (i. e. for plugins or loaders). Filters can be Strings, RegExps or Functions
+	 */
+	loggingDebug?: FilterTypes | boolean;
 	/**
 	 * add stack traces to logging output
 	 */

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1344,6 +1344,18 @@ export interface StatsOptions {
 	 */
 	hash?: boolean;
 	/**
+	 * Include debug logging of specified modules (plugins/loaders). Filters can be Strings, RegExps or Functions
+	 */
+	includeDebugLogging?: FilterTypes;
+	/**
+	 * add logging output
+	 */
+	logging?: boolean;
+	/**
+	 * add stack traces to logging output
+	 */
+	loggingTrace?: boolean;
+	/**
 	 * Set the maximum number of modules to be shown
 	 */
 	maxModules?: number;

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -36,6 +36,8 @@ const SortableSet = require("./util/SortableSet");
 const GraphHelpers = require("./GraphHelpers");
 const ModuleDependency = require("./dependencies/ModuleDependency");
 const compareLocations = require("./compareLocations");
+const { Logger, LogType } = require("./logging/Logger");
+const ErrorHelpers = require("./ErrorHelpers");
 
 /** @typedef {import("./Module")} Module */
 /** @typedef {import("./Compiler")} Compiler */
@@ -93,6 +95,13 @@ const compareLocations = require("./compareLocations");
  * @property {Dependency[]} dependencies
  * @property {AsyncDependenciesBlock[]} blocks
  * @property {DependenciesBlockVariable[]} variables
+ */
+
+/**
+ * @typedef {Object} LogEntry
+ * @property {string} type
+ * @property {any[]} args
+ * @property {string[]=} trace
  */
 
 /**
@@ -384,6 +393,9 @@ class Compilation extends Tapable {
 				"compilerIndex"
 			]),
 
+			/** @type {SyncBailHook<string, LogEntry>} */
+			log: new SyncBailHook(["origin", "logEntry"]),
+
 			// TODO the following hooks are weirdly located here
 			// TODO move them for webpack 5
 			/** @type {SyncHook<object, Module>} */
@@ -469,6 +481,8 @@ class Compilation extends Tapable {
 		this.warnings = [];
 		/** @type {Compilation[]} */
 		this.children = [];
+		/** @type {Map<string, LogEntry[]>} */
+		this.logging = new Map();
 		/** @type {Map<DepConstructor, ModuleFactory>} */
 		this.dependencyFactories = new Map();
 		/** @type {Map<DepConstructor, DependencyTemplate>} */
@@ -497,6 +511,67 @@ class Compilation extends Tapable {
 
 	getStats() {
 		return new Stats(this);
+	}
+
+	/**
+	 * @param {string | (function(): string)} name name of the logger, or function called once to get the logger name
+	 * @returns {Logger} a logger with that name
+	 */
+	getLogger(name) {
+		if (!name) {
+			throw new TypeError("Compilation.getLogger(name) called without a name");
+		}
+		let logEntries;
+		return new Logger((type, args) => {
+			if (typeof name === "function") {
+				name = name();
+				if (!name) {
+					throw new TypeError(
+						"Compilation.getLogger(name) called with a function not returning a name"
+					);
+				}
+			}
+			let trace;
+			switch (type) {
+				case LogType.profile:
+					// eslint-disable-next-line node/no-unsupported-features/node-builtins
+					if (typeof console.profile === "function") {
+						// eslint-disable-next-line node/no-unsupported-features/node-builtins
+						console.profile(`[${name}] ${args[0]}`);
+					}
+					return;
+				case LogType.profileEnd:
+					// eslint-disable-next-line node/no-unsupported-features/node-builtins
+					if (typeof console.profileEnd === "function") {
+						// eslint-disable-next-line node/no-unsupported-features/node-builtins
+						console.profileEnd(`[${name}] ${args[0]}`);
+					}
+					return;
+				case LogType.warn:
+				case LogType.error:
+				case LogType.trace:
+					trace = ErrorHelpers.cutOffLoaderExecution(new Error("Trace").stack)
+						.split("\n")
+						.slice(3);
+					break;
+			}
+			const logEntry = {
+				time: Date.now(),
+				type,
+				args,
+				trace
+			};
+			if (this.hooks.log.call(name, logEntry) === undefined) {
+				if (logEntries === undefined) {
+					logEntries = this.logging.get(name);
+					if (logEntries === undefined) {
+						logEntries = [];
+						this.logging.set(name, logEntries);
+					}
+				}
+				logEntries.push(logEntry);
+			}
+		});
 	}
 
 	/**

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -533,20 +533,6 @@ class Compilation extends Tapable {
 			}
 			let trace;
 			switch (type) {
-				case LogType.profile:
-					// eslint-disable-next-line node/no-unsupported-features/node-builtins
-					if (typeof console.profile === "function") {
-						// eslint-disable-next-line node/no-unsupported-features/node-builtins
-						console.profile(`[${name}] ${args[0]}`);
-					}
-					return;
-				case LogType.profileEnd:
-					// eslint-disable-next-line node/no-unsupported-features/node-builtins
-					if (typeof console.profileEnd === "function") {
-						// eslint-disable-next-line node/no-unsupported-features/node-builtins
-						console.profileEnd(`[${name}] ${args[0]}`);
-					}
-					return;
 				case LogType.warn:
 				case LogType.error:
 				case LogType.trace:
@@ -562,6 +548,13 @@ class Compilation extends Tapable {
 				trace
 			};
 			if (this.hooks.log.call(name, logEntry) === undefined) {
+				if (logEntry.type === LogType.profileEnd) {
+					// eslint-disable-next-line node/no-unsupported-features/node-builtins
+					if (typeof console.profileEnd === "function") {
+						// eslint-disable-next-line node/no-unsupported-features/node-builtins
+						console.profileEnd(`[${logEntry.name}] ${logEntry.args[0]}`);
+					}
+				}
 				if (logEntries === undefined) {
 					logEntries = this.logging.get(name);
 					if (logEntries === undefined) {
@@ -570,6 +563,13 @@ class Compilation extends Tapable {
 					}
 				}
 				logEntries.push(logEntry);
+				if (logEntry.type === LogType.profile) {
+					// eslint-disable-next-line node/no-unsupported-features/node-builtins
+					if (typeof console.profile === "function") {
+						// eslint-disable-next-line node/no-unsupported-features/node-builtins
+						console.profile(`[${logEntry.name}] ${logEntry.args[0]}`);
+					}
+				}
 			}
 		});
 	}

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -101,6 +101,7 @@ const ErrorHelpers = require("./ErrorHelpers");
  * @typedef {Object} LogEntry
  * @property {string} type
  * @property {any[]} args
+ * @property {number} time
  * @property {string[]=} trace
  */
 
@@ -521,6 +522,7 @@ class Compilation extends Tapable {
 		if (!name) {
 			throw new TypeError("Compilation.getLogger(name) called without a name");
 		}
+		/** @type {LogEntry[] | undefined} */
 		let logEntries;
 		return new Logger((type, args) => {
 			if (typeof name === "function") {
@@ -541,6 +543,7 @@ class Compilation extends Tapable {
 						.slice(3);
 					break;
 			}
+			/** @type {LogEntry} */
 			const logEntry = {
 				time: Date.now(),
 				type,
@@ -552,7 +555,7 @@ class Compilation extends Tapable {
 					// eslint-disable-next-line node/no-unsupported-features/node-builtins
 					if (typeof console.profileEnd === "function") {
 						// eslint-disable-next-line node/no-unsupported-features/node-builtins
-						console.profileEnd(`[${logEntry.name}] ${logEntry.args[0]}`);
+						console.profileEnd(`[${name}] ${logEntry.args[0]}`);
 					}
 				}
 				if (logEntries === undefined) {
@@ -567,7 +570,7 @@ class Compilation extends Tapable {
 					// eslint-disable-next-line node/no-unsupported-features/node-builtins
 					if (typeof console.profile === "function") {
 						// eslint-disable-next-line node/no-unsupported-features/node-builtins
-						console.profile(`[${logEntry.name}] ${logEntry.args[0]}`);
+						console.profile(`[${name}] ${logEntry.args[0]}`);
 					}
 				}
 			}

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -28,15 +28,9 @@ const RequestShortener = require("./RequestShortener");
 const { makePathsRelative } = require("./util/identifier");
 const ConcurrentCompilationError = require("./ConcurrentCompilationError");
 const { Logger } = require("./logging/Logger");
-const logToConsole = require("./logging/logToConsole");
 
 /** @typedef {import("../declarations/WebpackOptions").Entry} Entry */
 /** @typedef {import("../declarations/WebpackOptions").WebpackOptions} WebpackOptions */
-
-const infrastructureLogger = logToConsole({
-	level: "log",
-	debug: false
-});
 
 /**
  * @typedef {Object} CompilationParams
@@ -147,6 +141,8 @@ class Compiler extends Tapable {
 		/** @type {ResolverFactory} */
 		this.resolverFactory = new ResolverFactory();
 
+		this.infrastructureLogger = undefined;
+
 		// TODO remove in webpack 5
 		this.resolvers = {
 			normal: {
@@ -226,7 +222,9 @@ class Compiler extends Tapable {
 				}
 			}
 			if (this.hooks.log.call(name, type, args) === undefined) {
-				infrastructureLogger(name, type, args);
+				if (this.infrastructureLogger !== undefined) {
+					this.infrastructureLogger(name, type, args);
+				}
 			}
 		});
 	}

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -27,11 +27,16 @@ const ResolverFactory = require("./ResolverFactory");
 const RequestShortener = require("./RequestShortener");
 const { makePathsRelative } = require("./util/identifier");
 const ConcurrentCompilationError = require("./ConcurrentCompilationError");
-const { Logger, LogType } = require("./logging/Logger");
+const { Logger } = require("./logging/Logger");
 const logToConsole = require("./logging/logToConsole");
 
 /** @typedef {import("../declarations/WebpackOptions").Entry} Entry */
 /** @typedef {import("../declarations/WebpackOptions").WebpackOptions} WebpackOptions */
+
+const infrastructureLogger = logToConsole({
+	level: "log",
+	debug: false
+});
 
 /**
  * @typedef {Object} CompilationParams
@@ -221,9 +226,7 @@ class Compiler extends Tapable {
 				}
 			}
 			if (this.hooks.log.call(name, type, args) === undefined) {
-				// ignore debug logging by default
-				if (type === LogType.debug) return;
-				logToConsole(name, type, args);
+				infrastructureLogger(name, type, args);
 			}
 		});
 	}

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -86,7 +86,7 @@ class Compiler extends Tapable {
 			watchClose: new SyncHook([]),
 
 			/** @type {SyncBailHook<string, string, any[]>} */
-			log: new SyncBailHook(["origin", "type", "args"]),
+			infrastructurelog: new SyncBailHook(["origin", "type", "args"]),
 
 			// TODO the following hooks are weirdly located here
 			// TODO move them for webpack 5
@@ -221,7 +221,7 @@ class Compiler extends Tapable {
 					);
 				}
 			}
-			if (this.hooks.log.call(name, type, args) === undefined) {
+			if (this.hooks.infrastructurelog.call(name, type, args) === undefined) {
 				if (this.infrastructureLogger !== undefined) {
 					this.infrastructureLogger(name, type, args);
 				}

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -28,6 +28,7 @@ const RequestShortener = require("./RequestShortener");
 const { makePathsRelative } = require("./util/identifier");
 const ConcurrentCompilationError = require("./ConcurrentCompilationError");
 const { Logger, LogType } = require("./logging/Logger");
+const logToConsole = require("./logging/logToConsole");
 
 /** @typedef {import("../declarations/WebpackOptions").Entry} Entry */
 /** @typedef {import("../declarations/WebpackOptions").WebpackOptions} WebpackOptions */
@@ -220,92 +221,9 @@ class Compiler extends Tapable {
 				}
 			}
 			if (this.hooks.log.call(name, type, args) === undefined) {
-				const labeledArgs = (prefix = "") => {
-					if (Array.isArray(args)) {
-						if (args.length > 0 && typeof args[0] === "string") {
-							return [`${prefix}[${name}] ${args[0]}`, ...args.slice(1)];
-						} else {
-							return [`${prefix}[${name}]`, ...args];
-						}
-					} else {
-						return [];
-					}
-				};
-				switch (type) {
-					case LogType.debug:
-						// ignore
-						break;
-					case LogType.log:
-						console.log(...labeledArgs());
-						break;
-					case LogType.info:
-						console.info(...labeledArgs("<i> "));
-						break;
-					case LogType.warn:
-						console.warn(...labeledArgs("<w> "));
-						break;
-					case LogType.error:
-						console.error(...labeledArgs("<e> "));
-						break;
-					case LogType.trace:
-						console.trace();
-						break;
-					case LogType.group:
-						// eslint-disable-next-line node/no-unsupported-features/node-builtins
-						if (typeof console.group === "function") {
-							// eslint-disable-next-line node/no-unsupported-features/node-builtins
-							console.group(...labeledArgs());
-						} else {
-							console.log(...labeledArgs());
-						}
-						break;
-					case LogType.groupCollapsed:
-						// eslint-disable-next-line node/no-unsupported-features/node-builtins
-						if (typeof console.groupCollapsed === "function") {
-							// eslint-disable-next-line node/no-unsupported-features/node-builtins
-							console.groupCollapsed(...labeledArgs());
-						} else {
-							console.log(...labeledArgs("<g> "));
-						}
-						break;
-					case LogType.groupEnd:
-						// eslint-disable-next-line node/no-unsupported-features/node-builtins
-						if (typeof console.groupEnd === "function") {
-							// eslint-disable-next-line node/no-unsupported-features/node-builtins
-							console.groupEnd();
-						} else {
-							console.log(...labeledArgs("</g> "));
-						}
-						break;
-					case LogType.time:
-						console.log(
-							`[${name}] ${args[0]}: ${args[1] * 1000 + args[2] / 1000000}ms`
-						);
-						break;
-					case LogType.profile:
-						// eslint-disable-next-line node/no-unsupported-features/node-builtins
-						if (typeof console.profile === "function") {
-							// eslint-disable-next-line node/no-unsupported-features/node-builtins
-							console.profile(...labeledArgs());
-						}
-						break;
-					case LogType.profileEnd:
-						// eslint-disable-next-line node/no-unsupported-features/node-builtins
-						if (typeof console.profileEnd === "function") {
-							// eslint-disable-next-line node/no-unsupported-features/node-builtins
-							console.profileEnd(...labeledArgs());
-						}
-						break;
-					case LogType.clear:
-						// eslint-disable-next-line node/no-unsupported-features/node-builtins
-						if (typeof console.clear === "function") {
-							// eslint-disable-next-line node/no-unsupported-features/node-builtins
-							console.clear();
-						}
-						break;
-					default:
-						throw new Error(`Unexpected LogType ${type}`);
-				}
+				// ignore debug logging by default
+				if (type === LogType.debug) return;
+				logToConsole(name, type, args);
 			}
 		});
 	}

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -27,6 +27,7 @@ const ResolverFactory = require("./ResolverFactory");
 const RequestShortener = require("./RequestShortener");
 const { makePathsRelative } = require("./util/identifier");
 const ConcurrentCompilationError = require("./ConcurrentCompilationError");
+const { Logger, LogType } = require("./logging/Logger");
 
 /** @typedef {import("../declarations/WebpackOptions").Entry} Entry */
 /** @typedef {import("../declarations/WebpackOptions").WebpackOptions} WebpackOptions */
@@ -83,6 +84,9 @@ class Compiler extends Tapable {
 			invalid: new SyncHook(["filename", "changeTime"]),
 			/** @type {SyncHook} */
 			watchClose: new SyncHook([]),
+
+			/** @type {SyncBailHook<string, string, any[]>} */
+			log: new SyncBailHook(["origin", "type", "args"]),
 
 			// TODO the following hooks are weirdly located here
 			// TODO move them for webpack 5
@@ -194,6 +198,116 @@ class Compiler extends Tapable {
 		this._assetEmittingSourceCache = new WeakMap();
 		/** @private @type {Map<string, number>} */
 		this._assetEmittingWrittenFiles = new Map();
+	}
+
+	/**
+	 * @param {string | (function(): string)} name name of the logger, or function called once to get the logger name
+	 * @returns {Logger} a logger with that name
+	 */
+	getInfrastructureLogger(name) {
+		if (!name) {
+			throw new TypeError(
+				"Compiler.getInfrastructureLogger(name) called without a name"
+			);
+		}
+		return new Logger((type, args) => {
+			if (typeof name === "function") {
+				name = name();
+				if (!name) {
+					throw new TypeError(
+						"Compiler.getInfrastructureLogger(name) called with a function not returning a name"
+					);
+				}
+			}
+			if (this.hooks.log.call(name, type, args) === undefined) {
+				const labeledArgs = (prefix = "") => {
+					if (Array.isArray(args)) {
+						if (args.length > 0 && typeof args[0] === "string") {
+							return [`${prefix}[${name}] ${args[0]}`, ...args.slice(1)];
+						} else {
+							return [`${prefix}[${name}]`, ...args];
+						}
+					} else {
+						return [];
+					}
+				};
+				switch (type) {
+					case LogType.debug:
+						// ignore
+						break;
+					case LogType.log:
+						console.log(...labeledArgs());
+						break;
+					case LogType.info:
+						console.info(...labeledArgs("<i> "));
+						break;
+					case LogType.warn:
+						console.warn(...labeledArgs("<w> "));
+						break;
+					case LogType.error:
+						console.error(...labeledArgs("<e> "));
+						break;
+					case LogType.trace:
+						console.trace();
+						break;
+					case LogType.group:
+						// eslint-disable-next-line node/no-unsupported-features/node-builtins
+						if (typeof console.group === "function") {
+							// eslint-disable-next-line node/no-unsupported-features/node-builtins
+							console.group(...labeledArgs());
+						} else {
+							console.log(...labeledArgs());
+						}
+						break;
+					case LogType.groupCollapsed:
+						// eslint-disable-next-line node/no-unsupported-features/node-builtins
+						if (typeof console.groupCollapsed === "function") {
+							// eslint-disable-next-line node/no-unsupported-features/node-builtins
+							console.groupCollapsed(...labeledArgs());
+						} else {
+							console.log(...labeledArgs("<g> "));
+						}
+						break;
+					case LogType.groupEnd:
+						// eslint-disable-next-line node/no-unsupported-features/node-builtins
+						if (typeof console.groupEnd === "function") {
+							// eslint-disable-next-line node/no-unsupported-features/node-builtins
+							console.groupEnd();
+						} else {
+							console.log(...labeledArgs("</g> "));
+						}
+						break;
+					case LogType.time:
+						console.log(
+							`[${name}] ${args[0]}: ${args[1] * 1000 + args[2] / 1000000}ms`
+						);
+						break;
+					case LogType.profile:
+						// eslint-disable-next-line node/no-unsupported-features/node-builtins
+						if (typeof console.profile === "function") {
+							// eslint-disable-next-line node/no-unsupported-features/node-builtins
+							console.profile(...labeledArgs());
+						}
+						break;
+					case LogType.profileEnd:
+						// eslint-disable-next-line node/no-unsupported-features/node-builtins
+						if (typeof console.profileEnd === "function") {
+							// eslint-disable-next-line node/no-unsupported-features/node-builtins
+							console.profileEnd(...labeledArgs());
+						}
+						break;
+					case LogType.clear:
+						// eslint-disable-next-line node/no-unsupported-features/node-builtins
+						if (typeof console.clear === "function") {
+							// eslint-disable-next-line node/no-unsupported-features/node-builtins
+							console.clear();
+						}
+						break;
+					default:
+						throw new Error(`Unexpected LogType ${type}`);
+				}
+			}
+		});
 	}
 
 	watch(watchOptions, handler) {

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -147,16 +147,20 @@ class NormalModule extends Module {
 
 	createLoaderContext(resolver, options, compilation, fs) {
 		const requestShortener = compilation.runtimeTemplate.requestShortener;
+		const getCurrentLoaderName = () => {
+			const currentLoader = this.getCurrentLoader(loaderContext);
+			if (!currentLoader) return "(not in loader scope)";
+			return requestShortener.shorten(currentLoader.loader);
+		};
 		const loaderContext = {
 			version: 2,
 			emitWarning: warning => {
 				if (!(warning instanceof Error)) {
 					warning = new NonErrorEmittedError(warning);
 				}
-				const currentLoader = this.getCurrentLoader(loaderContext);
 				this.warnings.push(
 					new ModuleWarning(this, warning, {
-						from: requestShortener.shorten(currentLoader.loader)
+						from: getCurrentLoaderName()
 					})
 				);
 			},
@@ -164,11 +168,18 @@ class NormalModule extends Module {
 				if (!(error instanceof Error)) {
 					error = new NonErrorEmittedError(error);
 				}
-				const currentLoader = this.getCurrentLoader(loaderContext);
 				this.errors.push(
 					new ModuleError(this, error, {
-						from: requestShortener.shorten(currentLoader.loader)
+						from: getCurrentLoaderName()
 					})
+				);
+			},
+			getLogger: name => {
+				const currentLoader = this.getCurrentLoader(loaderContext);
+				return compilation.getLogger(() =>
+					[currentLoader && currentLoader.loader, name, this.identifier()]
+						.filter(Boolean)
+						.join(" ")
 				);
 			},
 			// TODO remove in webpack 5

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -179,7 +179,7 @@ class NormalModule extends Module {
 				return compilation.getLogger(() =>
 					[currentLoader && currentLoader.loader, name, this.identifier()]
 						.filter(Boolean)
-						.join(" ")
+						.join("|")
 				);
 			},
 			// TODO remove in webpack 5

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -199,7 +199,10 @@ class Stats {
 			options.publicPath,
 			!forToString
 		);
-		const showLogging = optionOrLocalFallback(options.logging, !forToString);
+		const showLogging = optionOrLocalFallback(
+			options.logging,
+			forToString ? "info" : true
+		);
 		const showLoggingTrace = optionOrLocalFallback(
 			options.loggingTrace,
 			!forToString

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -207,8 +207,8 @@ class Stats {
 			options.loggingTrace,
 			!forToString
 		);
-		const includeDebugLogging = []
-			.concat(optionsOrFallback(options.includeDebugLogging, []))
+		const loggingDebug = []
+			.concat(optionsOrFallback(options.loggingDebug, []))
 			.map(testAgainstGivenOption);
 
 		const excludeModules = []
@@ -758,7 +758,7 @@ class Stats {
 					break;
 			}
 			for (const [origin, logEntries] of compilation.logging) {
-				const debugMode = includeDebugLogging.some(fn => fn(origin));
+				const debugMode = loggingDebug.some(fn => fn(origin));
 				let collapseCounter = 0;
 				let processedLogEntries = logEntries;
 				if (!debugMode) {

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -749,6 +749,8 @@ class Stats {
 						LogType.group,
 						LogType.groupEnd,
 						LogType.groupCollapsed,
+						LogType.profile,
+						LogType.profileEnd,
 						LogType.time,
 						LogType.clear
 					]);
@@ -1450,6 +1452,14 @@ class Stats {
 							case LogType.trace:
 							case LogType.debug:
 								color = colors.normal;
+								break;
+							case LogType.profile:
+								color = colors.magenta;
+								prefix = "<p> ";
+								break;
+							case LogType.profileEnd:
+								color = colors.magenta;
+								prefix = "</p> ";
 								break;
 							case LogType.time:
 								color = colors.magenta;

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -718,6 +718,9 @@ class Stats {
 			let acceptedTypes;
 			let collapsedGroups = false;
 			switch (showLogging) {
+				case "none":
+					acceptedTypes = new Set([]);
+					break;
 				case "error":
 					acceptedTypes = new Set([LogType.error]);
 					break;
@@ -763,7 +766,7 @@ class Stats {
 				let processedLogEntries = logEntries;
 				if (!debugMode) {
 					processedLogEntries = processedLogEntries.filter(entry => {
-						if (acceptedTypes && !acceptedTypes.has(entry.type)) return false;
+						if (!acceptedTypes.has(entry.type)) return false;
 						if (!collapsedGroups) {
 							switch (entry.type) {
 								case LogType.groupCollapsed:

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -9,6 +9,7 @@ const SizeFormatHelpers = require("./SizeFormatHelpers");
 const formatLocation = require("./formatLocation");
 const identifierUtils = require("./util/identifier");
 const compareLocations = require("./compareLocations");
+const { LogType } = require("./logging/Logger");
 
 const optionsOrFallback = (...args) => {
 	let optionValues = [];
@@ -198,6 +199,15 @@ class Stats {
 			options.publicPath,
 			!forToString
 		);
+		const showLogging = optionOrLocalFallback(options.logging, !forToString);
+		const showLoggingTrace = optionOrLocalFallback(
+			options.loggingTrace,
+			!forToString
+		);
+		const includeDebugLogging = []
+			.concat(optionsOrFallback(options.includeDebugLogging, []))
+			.map(testAgainstGivenOption);
+
 		const excludeModules = []
 			.concat(optionsOrFallback(options.excludeModules, options.exclude, []))
 			.map(testAgainstGivenOption);
@@ -698,6 +708,48 @@ class Stats {
 				.map(fnModule);
 			obj.filteredModules = compilation.modules.length - obj.modules.length;
 			obj.modules.sort(sortByField(sortModules, obj.modules));
+		}
+		if (showLogging) {
+			const util = require("util");
+			obj.logging = {};
+			let acceptedTypes;
+			switch (showLogging) {
+				case "error":
+					acceptedTypes = new Set(["error"]);
+					break;
+				case "warn":
+					acceptedTypes = new Set(["error", "warn"]);
+					break;
+			}
+			for (const [origin, logEntries] of compilation.logging) {
+				obj.logging[
+					identifierUtils.makePathsRelative(context, origin, compilation.cache)
+				] = logEntries
+					.filter(entry => {
+						if (acceptedTypes && !acceptedTypes.has(entry.type)) return false;
+						if (
+							entry.type === "debug" &&
+							!includeDebugLogging.some(fn => fn(origin))
+						)
+							return false;
+						return true;
+					})
+					// eslint-disable-next-line no-loop-func
+					.map(entry => {
+						let message = undefined;
+						if (entry.type === "time") {
+							message = `${entry.args[0]}: ${entry.args[1] * 1000 +
+								entry.args[2] / 1000000}ms`;
+						} else if (entry.args && entry.args.length > 0) {
+							message = util.format(entry.args[0], ...entry.args.slice(1));
+						}
+						return {
+							type: entry.type,
+							message,
+							trace: showLoggingTrace && entry.trace ? entry.trace : undefined
+						};
+					});
+			}
 		}
 		if (showChildren) {
 			obj.children = compilation.children.map((child, idx) => {
@@ -1304,6 +1356,76 @@ class Stats {
 		}
 
 		processModulesList(obj, "");
+
+		if (obj.logging) {
+			for (const origin of Object.keys(obj.logging)) {
+				newline();
+				colors.bold("LOG from " + origin);
+				newline();
+				let indent = "";
+				for (const entry of obj.logging[origin]) {
+					let color = colors.normal;
+					let prefix = "";
+					switch (entry.type) {
+						case LogType.clear:
+							colors.normal(`${indent}-------`);
+							newline();
+							continue;
+						case LogType.error:
+							color = colors.red;
+							prefix = "<e> ";
+							break;
+						case LogType.warn:
+							color = colors.yellow;
+							prefix = "<w> ";
+							break;
+						case LogType.info:
+							color = colors.green;
+							prefix = "<i> ";
+							break;
+						case LogType.log:
+							color = colors.bold;
+							break;
+						case LogType.trace:
+						case LogType.debug:
+							color = colors.normal;
+							break;
+						case LogType.time:
+							color = colors.magenta;
+							prefix = "<t> ";
+							break;
+						case LogType.group:
+						case LogType.groupCollapsed:
+							color = colors.cyan;
+							prefix = "<g> ";
+							break;
+						case LogType.groupEnd:
+							if (indent.length > 2)
+								indent = indent.slice(0, indent.length - 2);
+							continue;
+					}
+					if (entry.message) {
+						for (const line of entry.message.split("\n")) {
+							colors.normal(`${indent}${prefix}`);
+							color(line);
+							newline();
+						}
+					}
+					if (entry.trace) {
+						for (const line of entry.trace) {
+							colors.normal(`${indent}| ${line}`);
+							newline();
+						}
+					}
+					switch (entry.type) {
+						case LogType.group:
+						case LogType.groupCollapsed:
+							indent += "  ";
+							break;
+					}
+				}
+			}
+		}
 
 		if (obj._showWarnings && obj.warnings) {
 			for (const warning of obj.warnings) {

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -776,8 +776,11 @@ class Stats {
 									if (collapseCounter > 0) collapseCounter++;
 									return collapseCounter === 0;
 								case LogType.groupEnd:
-									collapseCounter--;
-									return collapseCounter === 0;
+									if (collapseCounter > 0) {
+										collapseCounter--;
+										return false;
+									}
+									return true;
 								default:
 									return collapseCounter === 0;
 							}
@@ -803,9 +806,17 @@ class Stats {
 						trace: showLoggingTrace && entry.trace ? entry.trace : undefined
 					};
 				});
-				obj.logging[
-					identifierUtils.makePathsRelative(context, origin, compilation.cache)
-				] = {
+				let name = identifierUtils
+					.makePathsRelative(context, origin, compilation.cache)
+					.replace(/\|/g, " ");
+				if (name in obj.logging) {
+					let i = 1;
+					while (`${name}#${i}` in obj.logging) {
+						i++;
+					}
+					name = `${name}#${i}`;
+				}
+				obj.logging[name] = {
 					entries: processedLogEntries,
 					filteredEntries: logEntries.length - processedLogEntries.length,
 					debug: debugMode

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -713,42 +713,95 @@ class Stats {
 			const util = require("util");
 			obj.logging = {};
 			let acceptedTypes;
+			let collapsedGroups = false;
 			switch (showLogging) {
 				case "error":
-					acceptedTypes = new Set(["error"]);
+					acceptedTypes = new Set([LogType.error]);
 					break;
 				case "warn":
-					acceptedTypes = new Set(["error", "warn"]);
+					acceptedTypes = new Set([LogType.error, LogType.warn]);
+					break;
+				case "info":
+					acceptedTypes = new Set([LogType.error, LogType.warn, LogType.info]);
+					break;
+				case true:
+				case "log":
+					acceptedTypes = new Set([
+						LogType.error,
+						LogType.warn,
+						LogType.info,
+						LogType.log,
+						LogType.group,
+						LogType.groupEnd,
+						LogType.groupCollapsed,
+						LogType.clear
+					]);
+					break;
+				case "verbose":
+					acceptedTypes = new Set([
+						LogType.error,
+						LogType.warn,
+						LogType.info,
+						LogType.log,
+						LogType.group,
+						LogType.groupEnd,
+						LogType.groupCollapsed,
+						LogType.time,
+						LogType.clear
+					]);
+					collapsedGroups = true;
 					break;
 			}
 			for (const [origin, logEntries] of compilation.logging) {
+				const debugMode = includeDebugLogging.some(fn => fn(origin));
+				let collapseCounter = 0;
+				let processedLogEntries = logEntries;
+				if (!debugMode) {
+					processedLogEntries = processedLogEntries.filter(entry => {
+						if (acceptedTypes && !acceptedTypes.has(entry.type)) return false;
+						if (!collapsedGroups) {
+							switch (entry.type) {
+								case LogType.groupCollapsed:
+									collapseCounter++;
+									return collapseCounter === 1;
+								case LogType.group:
+									if (collapseCounter > 0) collapseCounter++;
+									return collapseCounter === 0;
+								case LogType.groupEnd:
+									collapseCounter--;
+									return collapseCounter === 0;
+								default:
+									return collapseCounter === 0;
+							}
+						}
+						return true;
+					});
+				}
+				processedLogEntries = processedLogEntries.map(entry => {
+					let message = undefined;
+					if (entry.type === LogType.time) {
+						message = `${entry.args[0]}: ${entry.args[1] * 1000 +
+							entry.args[2] / 1000000}ms`;
+					} else if (entry.args && entry.args.length > 0) {
+						message = util.format(entry.args[0], ...entry.args.slice(1));
+					}
+					return {
+						type:
+							(debugMode || collapsedGroups) &&
+							entry.type === LogType.groupCollapsed
+								? LogType.group
+								: entry.type,
+						message,
+						trace: showLoggingTrace && entry.trace ? entry.trace : undefined
+					};
+				});
 				obj.logging[
 					identifierUtils.makePathsRelative(context, origin, compilation.cache)
-				] = logEntries
-					.filter(entry => {
-						if (acceptedTypes && !acceptedTypes.has(entry.type)) return false;
-						if (
-							entry.type === "debug" &&
-							!includeDebugLogging.some(fn => fn(origin))
-						)
-							return false;
-						return true;
-					})
-					// eslint-disable-next-line no-loop-func
-					.map(entry => {
-						let message = undefined;
-						if (entry.type === "time") {
-							message = `${entry.args[0]}: ${entry.args[1] * 1000 +
-								entry.args[2] / 1000000}ms`;
-						} else if (entry.args && entry.args.length > 0) {
-							message = util.format(entry.args[0], ...entry.args.slice(1));
-						}
-						return {
-							type: entry.type,
-							message,
-							trace: showLoggingTrace && entry.trace ? entry.trace : undefined
-						};
-					});
+				] = {
+					entries: processedLogEntries,
+					filteredEntries: logEntries.length - processedLogEntries.length,
+					debug: debugMode
+				};
 			}
 		}
 		if (showChildren) {
@@ -1359,69 +1412,80 @@ class Stats {
 
 		if (obj.logging) {
 			for (const origin of Object.keys(obj.logging)) {
-				newline();
-				colors.bold("LOG from " + origin);
-				newline();
-				let indent = "";
-				for (const entry of obj.logging[origin]) {
-					let color = colors.normal;
-					let prefix = "";
-					switch (entry.type) {
-						case LogType.clear:
-							colors.normal(`${indent}-------`);
-							newline();
-							continue;
-						case LogType.error:
-							color = colors.red;
-							prefix = "<e> ";
-							break;
-						case LogType.warn:
-							color = colors.yellow;
-							prefix = "<w> ";
-							break;
-						case LogType.info:
-							color = colors.green;
-							prefix = "<i> ";
-							break;
-						case LogType.log:
-							color = colors.bold;
-							break;
-						case LogType.trace:
-						case LogType.debug:
-							color = colors.normal;
-							break;
-						case LogType.time:
-							color = colors.magenta;
-							prefix = "<t> ";
-							break;
-						case LogType.group:
-						case LogType.groupCollapsed:
-							color = colors.cyan;
-							prefix = "<g> ";
-							break;
-						case LogType.groupEnd:
-							if (indent.length > 2)
-								indent = indent.slice(0, indent.length - 2);
-							continue;
+				const logData = obj.logging[origin];
+				if (logData.entries.length > 0) {
+					newline();
+					if (logData.debug) {
+						colors.red("DEBUG ");
 					}
-					if (entry.message) {
-						for (const line of entry.message.split("\n")) {
-							colors.normal(`${indent}${prefix}`);
-							color(line);
-							newline();
+					colors.bold("LOG from " + origin);
+					newline();
+					let indent = "";
+					for (const entry of logData.entries) {
+						let color = colors.normal;
+						let prefix = "";
+						switch (entry.type) {
+							case LogType.clear:
+								colors.normal(`${indent}-------`);
+								newline();
+								continue;
+							case LogType.error:
+								color = colors.red;
+								prefix = "<e> ";
+								break;
+							case LogType.warn:
+								color = colors.yellow;
+								prefix = "<w> ";
+								break;
+							case LogType.info:
+								color = colors.green;
+								prefix = "<i> ";
+								break;
+							case LogType.log:
+								color = colors.bold;
+								break;
+							case LogType.trace:
+							case LogType.debug:
+								color = colors.normal;
+								break;
+							case LogType.time:
+								color = colors.magenta;
+								prefix = "<t> ";
+								break;
+							case LogType.group:
+								color = colors.cyan;
+								break;
+							case LogType.groupCollapsed:
+								color = colors.cyan;
+								prefix = "<+> ";
+								break;
+							case LogType.groupEnd:
+								if (indent.length > 2)
+									indent = indent.slice(0, indent.length - 2);
+								continue;
+						}
+						if (entry.message) {
+							for (const line of entry.message.split("\n")) {
+								colors.normal(`${indent}${prefix}`);
+								color(line);
+								newline();
+							}
+						}
+						if (entry.trace) {
+							for (const line of entry.trace) {
+								colors.normal(`${indent}| ${line}`);
+								newline();
+							}
+						}
+						switch (entry.type) {
+							case LogType.group:
+								indent += "  ";
+								break;
 						}
 					}
-					if (entry.trace) {
-						for (const line of entry.trace) {
-							colors.normal(`${indent}| ${line}`);
-							newline();
-						}
-					}
-					switch (entry.type) {
-						case LogType.group:
-						case LogType.groupCollapsed:
-							indent += "  ";
-							break;
+					if (logData.filteredEntries) {
+						colors.normal(`+ ${logData.filteredEntries} hidden lines`);
+						newline();
 					}
 				}
 			}
@@ -1497,6 +1561,7 @@ class Stats {
 					optimizationBailout: true,
 					errorDetails: true,
 					publicPath: true,
+					logging: "verbose",
 					exclude: false,
 					maxModules: Infinity
 				};
@@ -1513,6 +1578,7 @@ class Stats {
 					optimizationBailout: true,
 					errorDetails: true,
 					publicPath: true,
+					logging: true,
 					exclude: false,
 					maxModules: Infinity
 				};
@@ -1522,19 +1588,22 @@ class Stats {
 					modules: true,
 					maxModules: 0,
 					errors: true,
-					warnings: true
+					warnings: true,
+					logging: "warn"
 				};
 			case "errors-only":
 				return {
 					all: false,
 					errors: true,
-					moduleTrace: true
+					moduleTrace: true,
+					logging: "error"
 				};
 			case "errors-warnings":
 				return {
 					all: false,
 					errors: true,
-					warnings: true
+					warnings: true,
+					logging: "warn"
 				};
 			default:
 				return {};

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -363,6 +363,12 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 				options.resolveLoader.plugins.length > 0
 			);
 		});
+
+		this.set("infrastructureLogging", "call", value =>
+			Object.assign({}, value)
+		);
+		this.set("infrastructureLogging.level", "info");
+		this.set("infrastructureLogging.debug", false);
 	}
 }
 

--- a/lib/logging/Logger.js
+++ b/lib/logging/Logger.js
@@ -1,0 +1,124 @@
+/*
+ MIT License http://www.opensource.org/licenses/mit-license.php
+ Author Tobias Koppers @sokra
+ */
+
+"use strict";
+
+/**
+ * @enum {string}
+ */
+const LogType = Object.freeze({
+	error: "error", // message, c style arguments
+	warn: "warn", // message, c style arguments
+	info: "info", // message, c style arguments
+	log: "log", // message, c style arguments
+	debug: "debug", // message, c style arguments
+
+	trace: "trace", // no arguments
+
+	group: "group", // [label]
+	groupCollapsed: "groupCollapsed", // [label]
+	groupEnd: "groupEnd", // [label]
+
+	profile: "profile", // [profileName]
+	profileEnd: "profileEnd", // [profileName]
+
+	time: "time", // name, time as [seconds, nanoseconds]
+
+	clear: "clear" // no arguments
+});
+
+exports.LogType = LogType;
+
+const LOG_SYMBOL = Symbol("webpack logger raw log method");
+const TIMERS_SYMBOL = Symbol("webpack logger times");
+
+class WebpackLogger {
+	/**
+	 * @param {function(LogType, any[]=): void} log log function
+	 */
+	constructor(log) {
+		this[LOG_SYMBOL] = log;
+	}
+
+	error(...args) {
+		this[LOG_SYMBOL](LogType.error, args);
+	}
+
+	warn(...args) {
+		this[LOG_SYMBOL](LogType.warn, args);
+	}
+
+	info(...args) {
+		this[LOG_SYMBOL](LogType.info, args);
+	}
+
+	log(...args) {
+		this[LOG_SYMBOL](LogType.log, args);
+	}
+
+	debug(...args) {
+		this[LOG_SYMBOL](LogType.debug, args);
+	}
+
+	assert(assertion, ...args) {
+		if (!assertion) {
+			this[LOG_SYMBOL](LogType.error, args);
+		}
+	}
+
+	trace() {
+		this[LOG_SYMBOL](LogType.trace, ["Trace"]);
+	}
+
+	clear() {
+		this[LOG_SYMBOL](LogType.clear);
+	}
+
+	group(...args) {
+		this[LOG_SYMBOL](LogType.group, args);
+	}
+
+	groupCollapsed(...args) {
+		this[LOG_SYMBOL](LogType.groupCollapsed, args);
+	}
+
+	groupEnd(...args) {
+		this[LOG_SYMBOL](LogType.groupEnd, args);
+	}
+
+	profile(label) {
+		this[LOG_SYMBOL](LogType.profile, [label]);
+	}
+
+	profileEnd(label) {
+		this[LOG_SYMBOL](LogType.profileEnd, [label]);
+	}
+
+	time(label) {
+		this[TIMERS_SYMBOL] = this[TIMERS_SYMBOL] || new Map();
+		this[TIMERS_SYMBOL].set(label, process.hrtime());
+	}
+
+	timeLog(label) {
+		const prev = this[TIMERS_SYMBOL] && this[TIMERS_SYMBOL].get(label);
+		if (!prev) {
+			throw new Error(`No such label '${label}' for WebpackLogger.timeLog()`);
+		}
+		const time = process.hrtime(prev);
+		this[LOG_SYMBOL](LogType.time, [label, ...time]);
+	}
+
+	timeEnd(label) {
+		const prev = this[TIMERS_SYMBOL] && this[TIMERS_SYMBOL].get(label);
+		if (!prev) {
+			throw new Error(`No such label '${label}' for WebpackLogger.timeEnd()`);
+		}
+		const time = process.hrtime(prev);
+		this[TIMERS_SYMBOL].delete(label);
+		this[LOG_SYMBOL](LogType.time, [label, ...time]);
+	}
+}
+
+exports.Logger = WebpackLogger;

--- a/lib/logging/Logger.js
+++ b/lib/logging/Logger.js
@@ -31,6 +31,8 @@ const LogType = Object.freeze({
 
 exports.LogType = LogType;
 
+/** @typedef {LogType} LogTypeEnum */
+
 const LOG_SYMBOL = Symbol("webpack logger raw log method");
 const TIMERS_SYMBOL = Symbol("webpack logger times");
 

--- a/lib/logging/createConsoleLogger.js
+++ b/lib/logging/createConsoleLogger.js
@@ -8,19 +8,20 @@
 const { LogType } = require("./Logger");
 
 /** @typedef {import("./Logger").LogTypeEnum} LogTypeEnum */
+/** @typedef {import("../../declarations/WebpackOptions").FilterTypes} FilterTypes */
+/** @typedef {import("../../declarations/WebpackOptions").FilterItemTypes} FilterItemTypes */
+
 /** @typedef {function(string): boolean} FilterFunction */
-/** @typedef {RegExp|FilterFunction|string|boolean} FilterInputItem */
-/** @typedef {FilterInputItem[]|FilterInputItem} FilterInput */
 
 /**
  * @typedef {Object} LoggerOptions
  * @property {false|true|"error"|"warn"|"info"|"log"|"verbose"} options.level loglevel
- * @property {FilterInput} options.debug filter for debug logging
+ * @property {FilterTypes|boolean} options.debug filter for debug logging
  */
 
 /**
- * @param {FilterInputItem} item an input item
- * @returns {function(string): boolean} filter funtion
+ * @param {FilterItemTypes} item an input item
+ * @returns {FilterFunction} filter funtion
  */
 const filterToFunction = item => {
 	if (typeof item === "string") {
@@ -61,9 +62,12 @@ const LogLevel = {
  * @returns {function(string, LogTypeEnum, any[]): void} logging function
  */
 module.exports = ({ level = "info", debug = false }) => {
-	const debugFilters = /** @type {FilterInputItem[]} */ ([])
-		.concat(debug)
-		.map(filterToFunction);
+	const debugFilters =
+		typeof debug === "boolean"
+			? [() => debug]
+			: /** @type {FilterItemTypes[]} */ ([])
+					.concat(debug)
+					.map(filterToFunction);
 	/** @type {number} */
 	const loglevel = LogLevel[`${level}`] || 0;
 

--- a/lib/logging/createConsoleLogger.js
+++ b/lib/logging/createConsoleLogger.js
@@ -15,7 +15,7 @@ const { LogType } = require("./Logger");
 
 /**
  * @typedef {Object} LoggerOptions
- * @property {false|true|"error"|"warn"|"info"|"log"|"verbose"} options.level loglevel
+ * @property {false|true|"none"|"error"|"warn"|"info"|"log"|"verbose"} options.level loglevel
  * @property {FilterTypes|boolean} options.debug filter for debug logging
  */
 

--- a/lib/logging/createConsoleLogger.js
+++ b/lib/logging/createConsoleLogger.js
@@ -48,6 +48,7 @@ const filterToFunction = item => {
 /**
  * @enum {number} */
 const LogLevel = {
+	none: 6,
 	false: 6,
 	error: 5,
 	warn: 4,

--- a/lib/logging/logToConsole.js
+++ b/lib/logging/logToConsole.js
@@ -1,0 +1,110 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const { LogType } = require("./Logger");
+
+/** @typedef {import("./Logger").LogTypeEnum} LogTypeEnum */
+
+/**
+ * @param {string} name name of the logger
+ * @param {LogTypeEnum} type type of the log entry
+ * @param {any[]} args arguments of the log entry
+ */
+module.exports = (name, type, args) => {
+	const labeledArgs = (prefix = "") => {
+		if (Array.isArray(args)) {
+			if (args.length > 0 && typeof args[0] === "string") {
+				return [`${prefix}[${name}] ${args[0]}`, ...args.slice(1)];
+			} else {
+				return [`${prefix}[${name}]`, ...args];
+			}
+		} else {
+			return [];
+		}
+	};
+	switch (type) {
+		case LogType.debug:
+			// eslint-disable-next-line node/no-unsupported-features/node-builtins
+			if (typeof console.debug === "function") {
+				// eslint-disable-next-line node/no-unsupported-features/node-builtins
+				console.debug(...labeledArgs());
+			} else {
+				console.log(...labeledArgs());
+			}
+			break;
+		case LogType.log:
+			console.log(...labeledArgs());
+			break;
+		case LogType.info:
+			console.info(...labeledArgs("<i> "));
+			break;
+		case LogType.warn:
+			console.warn(...labeledArgs("<w> "));
+			break;
+		case LogType.error:
+			console.error(...labeledArgs("<e> "));
+			break;
+		case LogType.trace:
+			console.trace();
+			break;
+		case LogType.group:
+			// eslint-disable-next-line node/no-unsupported-features/node-builtins
+			if (typeof console.group === "function") {
+				// eslint-disable-next-line node/no-unsupported-features/node-builtins
+				console.group(...labeledArgs());
+			} else {
+				console.log(...labeledArgs());
+			}
+			break;
+		case LogType.groupCollapsed:
+			// eslint-disable-next-line node/no-unsupported-features/node-builtins
+			if (typeof console.groupCollapsed === "function") {
+				// eslint-disable-next-line node/no-unsupported-features/node-builtins
+				console.groupCollapsed(...labeledArgs());
+			} else {
+				console.log(...labeledArgs("<g> "));
+			}
+			break;
+		case LogType.groupEnd:
+			// eslint-disable-next-line node/no-unsupported-features/node-builtins
+			if (typeof console.groupEnd === "function") {
+				// eslint-disable-next-line node/no-unsupported-features/node-builtins
+				console.groupEnd();
+			} else {
+				console.log(...labeledArgs("</g> "));
+			}
+			break;
+		case LogType.time:
+			console.log(
+				`[${name}] ${args[0]}: ${args[1] * 1000 + args[2] / 1000000}ms`
+			);
+			break;
+		case LogType.profile:
+			// eslint-disable-next-line node/no-unsupported-features/node-builtins
+			if (typeof console.profile === "function") {
+				// eslint-disable-next-line node/no-unsupported-features/node-builtins
+				console.profile(...labeledArgs());
+			}
+			break;
+		case LogType.profileEnd:
+			// eslint-disable-next-line node/no-unsupported-features/node-builtins
+			if (typeof console.profileEnd === "function") {
+				// eslint-disable-next-line node/no-unsupported-features/node-builtins
+				console.profileEnd(...labeledArgs());
+			}
+			break;
+		case LogType.clear:
+			// eslint-disable-next-line node/no-unsupported-features/node-builtins
+			if (typeof console.clear === "function") {
+				// eslint-disable-next-line node/no-unsupported-features/node-builtins
+				console.clear();
+			}
+			break;
+		default:
+			throw new Error(`Unexpected LogType ${type}`);
+	}
+};

--- a/lib/logging/logToConsole.js
+++ b/lib/logging/logToConsole.js
@@ -8,103 +8,176 @@
 const { LogType } = require("./Logger");
 
 /** @typedef {import("./Logger").LogTypeEnum} LogTypeEnum */
+/** @typedef {function(string): boolean} FilterFunction */
+/** @typedef {RegExp|FilterFunction|string|boolean} FilterInputItem */
+/** @typedef {FilterInputItem[]|FilterInputItem} FilterInput */
 
 /**
- * @param {string} name name of the logger
- * @param {LogTypeEnum} type type of the log entry
- * @param {any[]} args arguments of the log entry
+ * @typedef {Object} LoggerOptions
+ * @property {false|true|"error"|"warn"|"info"|"log"|"verbose"} options.level loglevel
+ * @property {FilterInput} options.debug filter for debug logging
  */
-module.exports = (name, type, args) => {
-	const labeledArgs = (prefix = "") => {
-		if (Array.isArray(args)) {
-			if (args.length > 0 && typeof args[0] === "string") {
-				return [`${prefix}[${name}] ${args[0]}`, ...args.slice(1)];
+
+/**
+ * @param {FilterInputItem} item an input item
+ * @returns {function(string): boolean} filter funtion
+ */
+const filterToFunction = item => {
+	if (typeof item === "string") {
+		const regExp = new RegExp(
+			`[\\\\/]${item.replace(
+				// eslint-disable-next-line no-useless-escape
+				/[-[\]{}()*+?.\\^$|]/g,
+				"\\$&"
+			)}([\\\\/]|$|!|\\?)`
+		);
+		return ident => regExp.test(ident);
+	}
+	if (item && typeof item === "object" && typeof item.test === "function") {
+		return ident => item.test(ident);
+	}
+	if (typeof item === "function") {
+		return item;
+	}
+	if (typeof item === "boolean") {
+		return () => item;
+	}
+};
+
+/**
+ * @enum {number} */
+const LogLevel = {
+	false: 6,
+	error: 5,
+	warn: 4,
+	info: 3,
+	log: 2,
+	true: 2,
+	verbose: 1
+};
+
+/**
+ * @param {LoggerOptions} options options object
+ * @returns {function(string, LogTypeEnum, any[]): void} logging function
+ */
+module.exports = ({ level = "info", debug = false }) => {
+	const debugFilters = /** @type {FilterInputItem[]} */ ([])
+		.concat(debug)
+		.map(filterToFunction);
+	/** @type {number} */
+	const loglevel = LogLevel[`${level}`] || 0;
+
+	/**
+	 * @param {string} name name of the logger
+	 * @param {LogTypeEnum} type type of the log entry
+	 * @param {any[]} args arguments of the log entry
+	 * @returns {void}
+	 */
+	const logger = (name, type, args) => {
+		const labeledArgs = (prefix = "") => {
+			if (Array.isArray(args)) {
+				if (args.length > 0 && typeof args[0] === "string") {
+					return [`${prefix}[${name}] ${args[0]}`, ...args.slice(1)];
+				} else {
+					return [`${prefix}[${name}]`, ...args];
+				}
 			} else {
-				return [`${prefix}[${name}]`, ...args];
+				return [];
 			}
-		} else {
-			return [];
+		};
+		const debug = debugFilters.some(f => f(name));
+		switch (type) {
+			case LogType.debug:
+				if (!debug) return;
+				// eslint-disable-next-line node/no-unsupported-features/node-builtins
+				if (typeof console.debug === "function") {
+					// eslint-disable-next-line node/no-unsupported-features/node-builtins
+					console.debug(...labeledArgs());
+				} else {
+					console.log(...labeledArgs());
+				}
+				break;
+			case LogType.log:
+				if (!debug && loglevel > LogLevel.log) return;
+				console.log(...labeledArgs());
+				break;
+			case LogType.info:
+				if (!debug && loglevel > LogLevel.info) return;
+				console.info(...labeledArgs("<i> "));
+				break;
+			case LogType.warn:
+				if (!debug && loglevel > LogLevel.warn) return;
+				console.warn(...labeledArgs("<w> "));
+				break;
+			case LogType.error:
+				if (!debug && loglevel > LogLevel.error) return;
+				console.error(...labeledArgs("<e> "));
+				break;
+			case LogType.trace:
+				if (!debug) return;
+				console.trace();
+				break;
+			case LogType.group:
+				if (!debug && loglevel > LogLevel.log) return;
+				// eslint-disable-next-line node/no-unsupported-features/node-builtins
+				if (typeof console.group === "function") {
+					// eslint-disable-next-line node/no-unsupported-features/node-builtins
+					console.group(...labeledArgs());
+				} else {
+					console.log(...labeledArgs());
+				}
+				break;
+			case LogType.groupCollapsed:
+				if (!debug && loglevel > LogLevel.log) return;
+				// eslint-disable-next-line node/no-unsupported-features/node-builtins
+				if (typeof console.groupCollapsed === "function") {
+					// eslint-disable-next-line node/no-unsupported-features/node-builtins
+					console.groupCollapsed(...labeledArgs());
+				} else {
+					console.log(...labeledArgs("<g> "));
+				}
+				break;
+			case LogType.groupEnd:
+				if (!debug && loglevel > LogLevel.log) return;
+				// eslint-disable-next-line node/no-unsupported-features/node-builtins
+				if (typeof console.groupEnd === "function") {
+					// eslint-disable-next-line node/no-unsupported-features/node-builtins
+					console.groupEnd();
+				} else {
+					console.log(...labeledArgs("</g> "));
+				}
+				break;
+			case LogType.time:
+				if (!debug && loglevel > LogLevel.log) return;
+				console.log(
+					`[${name}] ${args[0]}: ${args[1] * 1000 + args[2] / 1000000}ms`
+				);
+				break;
+			case LogType.profile:
+				// eslint-disable-next-line node/no-unsupported-features/node-builtins
+				if (typeof console.profile === "function") {
+					// eslint-disable-next-line node/no-unsupported-features/node-builtins
+					console.profile(...labeledArgs());
+				}
+				break;
+			case LogType.profileEnd:
+				// eslint-disable-next-line node/no-unsupported-features/node-builtins
+				if (typeof console.profileEnd === "function") {
+					// eslint-disable-next-line node/no-unsupported-features/node-builtins
+					console.profileEnd(...labeledArgs());
+				}
+				break;
+			case LogType.clear:
+				if (!debug && loglevel > LogLevel.log) return;
+				// eslint-disable-next-line node/no-unsupported-features/node-builtins
+				if (typeof console.clear === "function") {
+					// eslint-disable-next-line node/no-unsupported-features/node-builtins
+					console.clear();
+				}
+				break;
+			default:
+				throw new Error(`Unexpected LogType ${type}`);
 		}
 	};
-	switch (type) {
-		case LogType.debug:
-			// eslint-disable-next-line node/no-unsupported-features/node-builtins
-			if (typeof console.debug === "function") {
-				// eslint-disable-next-line node/no-unsupported-features/node-builtins
-				console.debug(...labeledArgs());
-			} else {
-				console.log(...labeledArgs());
-			}
-			break;
-		case LogType.log:
-			console.log(...labeledArgs());
-			break;
-		case LogType.info:
-			console.info(...labeledArgs("<i> "));
-			break;
-		case LogType.warn:
-			console.warn(...labeledArgs("<w> "));
-			break;
-		case LogType.error:
-			console.error(...labeledArgs("<e> "));
-			break;
-		case LogType.trace:
-			console.trace();
-			break;
-		case LogType.group:
-			// eslint-disable-next-line node/no-unsupported-features/node-builtins
-			if (typeof console.group === "function") {
-				// eslint-disable-next-line node/no-unsupported-features/node-builtins
-				console.group(...labeledArgs());
-			} else {
-				console.log(...labeledArgs());
-			}
-			break;
-		case LogType.groupCollapsed:
-			// eslint-disable-next-line node/no-unsupported-features/node-builtins
-			if (typeof console.groupCollapsed === "function") {
-				// eslint-disable-next-line node/no-unsupported-features/node-builtins
-				console.groupCollapsed(...labeledArgs());
-			} else {
-				console.log(...labeledArgs("<g> "));
-			}
-			break;
-		case LogType.groupEnd:
-			// eslint-disable-next-line node/no-unsupported-features/node-builtins
-			if (typeof console.groupEnd === "function") {
-				// eslint-disable-next-line node/no-unsupported-features/node-builtins
-				console.groupEnd();
-			} else {
-				console.log(...labeledArgs("</g> "));
-			}
-			break;
-		case LogType.time:
-			console.log(
-				`[${name}] ${args[0]}: ${args[1] * 1000 + args[2] / 1000000}ms`
-			);
-			break;
-		case LogType.profile:
-			// eslint-disable-next-line node/no-unsupported-features/node-builtins
-			if (typeof console.profile === "function") {
-				// eslint-disable-next-line node/no-unsupported-features/node-builtins
-				console.profile(...labeledArgs());
-			}
-			break;
-		case LogType.profileEnd:
-			// eslint-disable-next-line node/no-unsupported-features/node-builtins
-			if (typeof console.profileEnd === "function") {
-				// eslint-disable-next-line node/no-unsupported-features/node-builtins
-				console.profileEnd(...labeledArgs());
-			}
-			break;
-		case LogType.clear:
-			// eslint-disable-next-line node/no-unsupported-features/node-builtins
-			if (typeof console.clear === "function") {
-				// eslint-disable-next-line node/no-unsupported-features/node-builtins
-				console.clear();
-			}
-			break;
-		default:
-			throw new Error(`Unexpected LogType ${type}`);
-	}
+	return logger;
 };

--- a/lib/logging/runtime.js
+++ b/lib/logging/runtime.js
@@ -2,12 +2,32 @@ const SyncBailHook = require("tapable/lib/SyncBailHook");
 const { Logger } = require("./Logger");
 const logToConsole = require("./logToConsole");
 
+/** @type {logToConsole.LoggerOptions} */
+let currentDefaultLoggerOptions = {
+	level: "info",
+	debug: false
+};
+let currentDefaultLogger = logToConsole(currentDefaultLoggerOptions);
+
+/**
+ * @param {string} name name of the logger
+ * @returns {Logger} a logger
+ */
 exports.getLogger = name => {
 	return new Logger((type, args) => {
 		if (exports.hooks.log.call(name, type, args) === undefined) {
-			logToConsole(name, type, args);
+			currentDefaultLogger(name, type, args);
 		}
 	});
+};
+
+/**
+ * @param {logToConsole.LoggerOptions} options new options, merge with old options
+ * @returns {void}
+ */
+exports.configureDefaultLogger = options => {
+	Object.assign(currentDefaultLoggerOptions, options);
+	currentDefaultLogger = logToConsole(currentDefaultLoggerOptions);
 };
 
 exports.hooks = {

--- a/lib/logging/runtime.js
+++ b/lib/logging/runtime.js
@@ -1,13 +1,13 @@
 const SyncBailHook = require("tapable/lib/SyncBailHook");
 const { Logger } = require("./Logger");
-const logToConsole = require("./logToConsole");
+const createConsoleLogger = require("./createConsoleLogger");
 
-/** @type {logToConsole.LoggerOptions} */
+/** @type {createConsoleLogger.LoggerOptions} */
 let currentDefaultLoggerOptions = {
 	level: "info",
 	debug: false
 };
-let currentDefaultLogger = logToConsole(currentDefaultLoggerOptions);
+let currentDefaultLogger = createConsoleLogger(currentDefaultLoggerOptions);
 
 /**
  * @param {string} name name of the logger
@@ -22,12 +22,12 @@ exports.getLogger = name => {
 };
 
 /**
- * @param {logToConsole.LoggerOptions} options new options, merge with old options
+ * @param {createConsoleLogger.LoggerOptions} options new options, merge with old options
  * @returns {void}
  */
 exports.configureDefaultLogger = options => {
 	Object.assign(currentDefaultLoggerOptions, options);
-	currentDefaultLogger = logToConsole(currentDefaultLoggerOptions);
+	currentDefaultLogger = createConsoleLogger(currentDefaultLoggerOptions);
 };
 
 exports.hooks = {

--- a/lib/logging/runtime.js
+++ b/lib/logging/runtime.js
@@ -1,0 +1,15 @@
+const SyncBailHook = require("tapable/lib/SyncBailHook");
+const { Logger } = require("./Logger");
+const logToConsole = require("./logToConsole");
+
+exports.getLogger = name => {
+	return new Logger((type, args) => {
+		if (exports.hooks.log.call(name, type, args) === undefined) {
+			logToConsole(name, type, args);
+		}
+	});
+};
+
+exports.hooks = {
+	log: new SyncBailHook(["origin", "type", "args"])
+};

--- a/lib/node/NodeEnvironmentPlugin.js
+++ b/lib/node/NodeEnvironmentPlugin.js
@@ -8,9 +8,23 @@ const NodeWatchFileSystem = require("./NodeWatchFileSystem");
 const NodeOutputFileSystem = require("./NodeOutputFileSystem");
 const NodeJsInputFileSystem = require("enhanced-resolve/lib/NodeJsInputFileSystem");
 const CachedInputFileSystem = require("enhanced-resolve/lib/CachedInputFileSystem");
+const createConsoleLogger = require("../logging/createConsoleLogger");
 
 class NodeEnvironmentPlugin {
+	constructor(options) {
+		this.options = options || {};
+	}
+
 	apply(compiler) {
+		compiler.infrastructureLogger = createConsoleLogger(
+			Object.assign(
+				{
+					level: "info",
+					debug: false
+				},
+				this.options.infrastructureLogging
+			)
+		);
 		compiler.inputFileSystem = new CachedInputFileSystem(
 			new NodeJsInputFileSystem(),
 			60000

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -40,7 +40,9 @@ const webpack = (options, callback) => {
 
 		compiler = new Compiler(options.context);
 		compiler.options = options;
-		new NodeEnvironmentPlugin().apply(compiler);
+		new NodeEnvironmentPlugin({
+			infrastructureLogging: options.infrastructureLogging
+		}).apply(compiler);
 		if (options.plugins && Array.isArray(options.plugins)) {
 			for (const plugin of options.plugins) {
 				if (typeof plugin === "function") {

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -166,7 +166,7 @@
         },
         {
           "instanceof": "Function",
-          "tsType": "Function"
+          "tsType": "((value: string) => boolean)"
         }
       ]
     },
@@ -1822,14 +1822,6 @@
           "description": "add the hash of the compilation",
           "type": "boolean"
         },
-        "includeDebugLogging": {
-          "description": "Include debug logging of specified modules (plugins/loaders). Filters can be Strings, RegExps or Functions",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/FilterTypes"
-            }
-          ]
-        },
         "logging": {
           "description": "add logging output",
           "anyOf": [
@@ -1840,6 +1832,18 @@
             {
               "description": "specify log level of logging output",
               "enum": ["error", "warn", "info", "log", "verbose"]
+            }
+          ]
+        },
+        "loggingDebug": {
+          "description": "Include debug logging of specified loggers (i. e. for plugins or loaders). Filters can be Strings, RegExps or Functions",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FilterTypes"
+            },
+            {
+              "description": "Enable/Disable debug logging for all loggers",
+              "type": "boolean"
             }
           ]
         },
@@ -2020,6 +2024,29 @@
           "$ref": "#/definitions/Externals"
         }
       ]
+    },
+    "infrastructureLogging": {
+      "description": "Options for infrastructure level logging",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "debug": {
+          "description": "Enable debug logging for specific loggers",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FilterTypes"
+            },
+            {
+              "description": "Enable/Disable debug logging for all loggers",
+              "type": "boolean"
+            }
+          ]
+        },
+        "level": {
+          "description": "Log level",
+          "enum": ["error", "warn", "info", "log", "verbose"]
+        }
+      }
     },
     "loader": {
       "description": "Custom values available in the loader context.",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1831,7 +1831,7 @@
             },
             {
               "description": "specify log level of logging output",
-              "enum": ["error", "warn", "info", "log", "verbose"]
+              "enum": ["none", "error", "warn", "info", "log", "verbose"]
             }
           ]
         },
@@ -2044,7 +2044,7 @@
         },
         "level": {
           "description": "Log level",
-          "enum": ["error", "warn", "info", "log", "verbose"]
+          "enum": ["none", "error", "warn", "info", "log", "verbose"]
         }
       }
     },

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1832,7 +1832,16 @@
         },
         "logging": {
           "description": "add logging output",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "description": "enable/disable logging output (true: shows normal logging output, loglevel: log)",
+              "type": "boolean"
+            },
+            {
+              "description": "specify log level of logging output",
+              "enum": ["error", "warn", "info", "log", "verbose"]
+            }
+          ]
         },
         "loggingTrace": {
           "description": "add stack traces to logging output",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1822,6 +1822,22 @@
           "description": "add the hash of the compilation",
           "type": "boolean"
         },
+        "includeDebugLogging": {
+          "description": "Include debug logging of specified modules (plugins/loaders). Filters can be Strings, RegExps or Functions",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FilterTypes"
+            }
+          ]
+        },
+        "logging": {
+          "description": "add logging output",
+          "type": "boolean"
+        },
+        "loggingTrace": {
+          "description": "add stack traces to logging output",
+          "type": "boolean"
+        },
         "maxModules": {
           "description": "Set the maximum number of modules to be shown",
           "type": "number"

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -514,4 +514,85 @@ describe("Compiler", () => {
 			done();
 		});
 	});
+	describe("infrastructure logging", () => {
+		const CONSOLE_METHODS = [
+			"error",
+			"warn",
+			"info",
+			"log",
+			"debug",
+			"trace",
+			"profile",
+			"profileEnd",
+			"group",
+			"groupEnd",
+			"groupCollapsed"
+		];
+		const spies = {};
+		beforeEach(() => {
+			for (const method of CONSOLE_METHODS) {
+				if (console[method]) {
+					spies[method] = jest.spyOn(console, method).mockImplementation();
+				}
+			}
+		});
+		afterEach(() => {
+			for (const method in spies) {
+				spies[method].mockRestore();
+				delete spies[method];
+			}
+		});
+		it("should log to the console", done => {
+			class MyPlugin {
+				apply(compiler) {
+					const logger = compiler.getInfrastructureLogger("MyPlugin");
+					logger.group("Group");
+					logger.error("Error");
+					logger.warn("Warning");
+					logger.info("Info");
+					logger.log("Log");
+					logger.debug("Debug");
+					logger.groupCollapsed("Collaped group");
+					logger.log("Log inside collapsed group");
+					logger.groupEnd();
+					logger.groupEnd();
+				}
+			}
+			const compiler = webpack({
+				context: path.join(__dirname, "fixtures"),
+				entry: "./a",
+				output: {
+					path: "/",
+					filename: "bundle.js"
+				},
+				infrastructureLogging: {
+					level: "verbose"
+				},
+				plugins: [new MyPlugin()]
+			});
+			compiler.outputFileSystem = new MemoryFs();
+			compiler.run((err, stats) => {
+				expect(spies.group).toHaveBeenCalledTimes(1);
+				expect(spies.group).toHaveBeenCalledWith("[MyPlugin] Group");
+				expect(spies.groupCollapsed).toHaveBeenCalledTimes(1);
+				expect(spies.groupCollapsed).toHaveBeenCalledWith(
+					"[MyPlugin] Collaped group"
+				);
+				expect(spies.error).toHaveBeenCalledTimes(1);
+				expect(spies.error).toHaveBeenCalledWith("<e> [MyPlugin] Error");
+				expect(spies.warn).toHaveBeenCalledTimes(1);
+				expect(spies.warn).toHaveBeenCalledWith("<w> [MyPlugin] Warning");
+				expect(spies.info).toHaveBeenCalledTimes(1);
+				expect(spies.info).toHaveBeenCalledWith("<i> [MyPlugin] Info");
+				expect(spies.log).toHaveBeenCalledTimes(2);
+				expect(spies.log).toHaveBeenCalledWith("[MyPlugin] Log");
+				expect(spies.log).toHaveBeenCalledWith(
+					"[MyPlugin] Log inside collapsed group"
+				);
+				expect(spies.debug).toHaveBeenCalledTimes(0);
+				expect(spies.groupEnd).toHaveBeenCalledTimes(2);
+				done();
+			});
+		});
+	});
 });

--- a/test/Stats.unittest.js
+++ b/test/Stats.unittest.js
@@ -11,6 +11,7 @@ describe("Stats", () => {
 				children: [],
 				errors: ["firstError"],
 				hash: "1234",
+				logging: new Map(),
 				compiler: {
 					context: ""
 				}
@@ -30,6 +31,7 @@ describe("Stats", () => {
 					children: [],
 					errors: ["firstError"],
 					hash: "1234",
+					logging: new Map(),
 					compiler: {
 						context: ""
 					}
@@ -41,6 +43,7 @@ describe("Stats", () => {
 					children: [],
 					warnings: ["firstError"],
 					hash: "1234",
+					logging: new Map(),
 					compiler: {
 						context: ""
 					}
@@ -54,6 +57,7 @@ describe("Stats", () => {
 					children: [],
 					errors: [],
 					hash: "1234",
+					logging: new Map(),
 					compiler: {
 						context: ""
 					}
@@ -65,6 +69,7 @@ describe("Stats", () => {
 					children: [],
 					warnings: [],
 					hash: "1234",
+					logging: new Map(),
 					compiler: {
 						context: ""
 					}
@@ -123,6 +128,7 @@ describe("Stats", () => {
 					},
 					getPublicPath: () => "path"
 				},
+				logging: new Map(),
 				compiler: {
 					context: ""
 				}
@@ -149,6 +155,7 @@ describe("Stats", () => {
 					},
 					getPublicPath: () => "path"
 				},
+				logging: new Map(),
 				compiler: {
 					context: ""
 				}
@@ -165,6 +172,7 @@ describe("Stats", () => {
 				filteredModules: 0,
 				errors: [],
 				hash: "1234",
+				logging: {},
 				modules: [],
 				outputPath: "/",
 				publicPath: "path",

--- a/test/StatsTestCases.test.js
+++ b/test/StatsTestCases.test.js
@@ -7,6 +7,15 @@ const fs = require("fs");
 const webpack = require("../lib/webpack");
 const Stats = require("../lib/Stats");
 
+/**
+ * Escapes regular expression metacharacters
+ * @param {string} str String to quote
+ * @returns {string} Escaped string
+ */
+const quotemeta = str => {
+	return str.replace(/[-[\]\\/{}()*+?.^$|]/g, "\\$&");
+};
+
 const base = path.join(__dirname, "statsCases");
 const outputBase = path.join(__dirname, "js", "stats");
 const tests = fs
@@ -104,7 +113,7 @@ describe("StatsTestCases", () => {
 				if (!hasColorSetting) {
 					actual = actual
 						.replace(/\u001b\[[0-9;]*m/g, "")
-						.replace(/[0-9]+(\s?ms)/g, "X$1")
+						.replace(/[.0-9]+(\s?ms)/g, "X$1")
 						.replace(
 							/^(\s*Built at:) (.*)$/gm,
 							"$1 Thu Jan 01 1970 00:00:00 GMT"
@@ -115,7 +124,7 @@ describe("StatsTestCases", () => {
 						.replace(/\u001b\[1m/g, "<CLR=BOLD>")
 						.replace(/\u001b\[39m\u001b\[22m/g, "</CLR>")
 						.replace(/\u001b\[([0-9;]*)m/g, "<CLR=$1>")
-						.replace(/[0-9]+(<\/CLR>)?(\s?ms)/g, "X$1$2")
+						.replace(/[.0-9]+(<\/CLR>)?(\s?ms)/g, "X$1$2")
 						.replace(
 							/^(\s*Built at:) (.*)$/gm,
 							"$1 Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT"
@@ -124,7 +133,11 @@ describe("StatsTestCases", () => {
 				actual = actual
 					.replace(/\r\n?/g, "\n")
 					.replace(/[\t ]*Version:.+\n/g, "")
-					.replace(path.join(base, testName), "Xdir/" + testName)
+					.replace(
+						new RegExp(quotemeta(path.join(base, testName)), "g"),
+						"Xdir/" + testName
+					)
+					.replace(/(\w)\\(\w)/g, "$1/$2")
 					.replace(/ dependencies:Xms/g, "");
 				expect(actual).toMatchSnapshot();
 				done();

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -193,7 +193,7 @@ describe("Validation", () => {
 			expect(msg).toMatchInlineSnapshot(`
 "Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
  - configuration has an unknown property 'postcss'. These properties are valid:
-   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, externals?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, serve?, stats?, target?, watch?, watchOptions? }
+   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, externals?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, serve?, stats?, target?, watch?, watchOptions? }
    For typos: please correct them.
    For loader options: webpack >= v2.0.0 no longer allows custom properties in configuration.
      Loaders should be updated to allow passing options via loader options in module.rules.

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1246,26 +1246,28 @@ Entrypoint <CLR=BOLD>main</CLR> = <CLR=32,BOLD>main.js</CLR>
 
 <CLR=BOLD>LOG from MyPlugin</CLR>
 <i> <CLR=32,BOLD>Plugin is now active</CLR>
+<+> <CLR=36,BOLD>Nested</CLR>
++ 2 hidden lines
 
-<CLR=BOLD>LOG from node_modules/custom-loader/index.js node_modules/custom-loader/index.js!index.js</CLR>
+<CLR=31,BOLD>DEBUG </CLR><CLR=BOLD>LOG from node_modules/custom-loader/index.js node_modules/custom-loader/index.js!index.js</CLR>
 <e> <CLR=31,BOLD>An error</CLR>
 |     at Object.<anonymous>.module.exports (Xdir/logging/node_modules/custom-loader/index.js:5:9)
 <w> <CLR=33,BOLD>A warning</CLR>
 |     at Object.<anonymous>.module.exports (Xdir/logging/node_modules/custom-loader/index.js:6:9)
-<g> <CLR=36,BOLD>Unimportant</CLR>
+<CLR=36,BOLD>Unimportant</CLR>
   <i> <CLR=32,BOLD>Info message</CLR>
   <CLR=BOLD>Just log</CLR>
   Just debug
   <t> <CLR=35,BOLD>Measure: Xms</CLR>
-  <g> <CLR=36,BOLD>Nested</CLR>
-    <CLR=BOLD>Just another log</CLR>
+  <CLR=36,BOLD>Nested</CLR>
+    <CLR=BOLD>Log inside collapsed group</CLR>
   Trace
   |     at Object.<anonymous>.module.exports (Xdir/logging/node_modules/custom-loader/index.js:15:9)
   <t> <CLR=35,BOLD>Measure: Xms</CLR>
   -------
   <CLR=BOLD>After clear</CLR>
 
-<CLR=BOLD>LOG from node_modules/custom-loader/index.js Named Logger node_modules/custom-loader/index.js!index.js</CLR>
+<CLR=31,BOLD>DEBUG </CLR><CLR=BOLD>LOG from node_modules/custom-loader/index.js Named Logger node_modules/custom-loader/index.js!index.js</CLR>
 Message with named logger"
 `;
 
@@ -1937,21 +1939,47 @@ chunk    {3} 3.js 54 bytes <{0}> >{1}< [rendered]
 [4] ./d.js 22 bytes {1} [depth 2] [built]
     ModuleConcatenation bailout: Module is not an ECMAScript module
 [5] ./e.js 22 bytes {1} [depth 2] [built]
-    ModuleConcatenation bailout: Module is not an ECMAScript module"
+    ModuleConcatenation bailout: Module is not an ECMAScript module
+
+LOG from MyPlugin
+Group
+  <e> Error
+  <w> Warning
+  <i> Info
+  Log
+  <+> Collaped group
++ 3 hidden lines"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-errors-only 1`] = `""`;
 
 exports[`StatsTestCases should print correct stats for preset-errors-only-error 1`] = `
 "
+LOG from MyPlugin
+<e> Error
++ 9 hidden lines
+
 ERROR in ./index.js
 Module not found: Error: Can't resolve 'does-not-exist' in 'Xdir/preset-errors-only-error'
  @ ./index.js 1:0-25"
 `;
 
-exports[`StatsTestCases should print correct stats for preset-errors-warnings 1`] = `""`;
+exports[`StatsTestCases should print correct stats for preset-errors-warnings 1`] = `
+"
+LOG from MyPlugin
+<e> Error
+<w> Warning
++ 8 hidden lines"
+`;
 
-exports[`StatsTestCases should print correct stats for preset-minimal 1`] = `"   6 modules"`;
+exports[`StatsTestCases should print correct stats for preset-minimal 1`] = `
+"   6 modules
+
+LOG from MyPlugin
+<e> Error
+<w> Warning
++ 8 hidden lines"
+`;
 
 exports[`StatsTestCases should print correct stats for preset-minimal-simple 1`] = `"   1 module"`;
 
@@ -2088,7 +2116,17 @@ chunk    {3} 3.js 54 bytes <{0}> >{1}< [rendered]
  [3] ./c.js 54 bytes {3} [depth 1] [built]
      ModuleConcatenation bailout: Module is not an ECMAScript module
      amd require ./c [0] ./index.js 3:0-16
-     [0] Xms -> factory:Xms building:Xms = Xms"
+     [0] Xms -> factory:Xms building:Xms = Xms
+
+LOG from MyPlugin
+Group
+  <e> Error
+  <w> Warning
+  <i> Info
+  Log
+  Collaped group
+    Log inside collapsed group
++ 1 hidden lines"
 `;
 
 exports[`StatsTestCases should print correct stats for resolve-plugin-context 1`] = `

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1247,7 +1247,7 @@ Entrypoint <CLR=BOLD>main</CLR> = <CLR=32,BOLD>main.js</CLR>
 <CLR=BOLD>LOG from MyPlugin</CLR>
 <i> <CLR=32,BOLD>Plugin is now active</CLR>
 <+> <CLR=36,BOLD>Nested</CLR>
-+ 2 hidden lines
++ 3 hidden lines
 
 <CLR=31,BOLD>DEBUG </CLR><CLR=BOLD>LOG from node_modules/custom-loader/index.js node_modules/custom-loader/index.js!index.js</CLR>
 <e> <CLR=31,BOLD>An error</CLR>

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -2012,7 +2012,13 @@ Entrypoint main = main.js
 [2] ./b.js 22 bytes {2} [built]
 [3] ./c.js 54 bytes {3} [built]
 [4] ./d.js 22 bytes {1} [built]
-[5] ./e.js 22 bytes {1} [built]"
+[5] ./e.js 22 bytes {1} [built]
+
+LOG from MyPlugin
+<e> Error
+<w> Warning
+<i> Info
++ 7 hidden lines"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-normal-performance 1`] = `

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1235,6 +1235,40 @@ Child 4 chunks:
      [5] ./e.js 22 bytes {3} [built]"
 `;
 
+exports[`StatsTestCases should print correct stats for logging 1`] = `
+"Hash: <CLR=BOLD>aa5b75cccf66cd9b1ffa</CLR>
+Time: <CLR=BOLD>X</CLR>ms
+Built at: Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT
+  <CLR=BOLD>Asset</CLR>      <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22><CLR=BOLD>Chunk Names</CLR>
+<CLR=32,BOLD>main.js</CLR>  3.57 KiB       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>  main
+Entrypoint <CLR=BOLD>main</CLR> = <CLR=32,BOLD>main.js</CLR>
+[0] <CLR=BOLD>./index.js</CLR> 0 bytes {<CLR=33,BOLD>0</CLR>}<CLR=32,BOLD> [built]</CLR>
+
+<CLR=BOLD>LOG from MyPlugin</CLR>
+<i> <CLR=32,BOLD>Plugin is now active</CLR>
+
+<CLR=BOLD>LOG from node_modules/custom-loader/index.js node_modules/custom-loader/index.js!index.js</CLR>
+<e> <CLR=31,BOLD>An error</CLR>
+|     at Object.<anonymous>.module.exports (Xdir/logging/node_modules/custom-loader/index.js:5:9)
+<w> <CLR=33,BOLD>A warning</CLR>
+|     at Object.<anonymous>.module.exports (Xdir/logging/node_modules/custom-loader/index.js:6:9)
+<g> <CLR=36,BOLD>Unimportant</CLR>
+  <i> <CLR=32,BOLD>Info message</CLR>
+  <CLR=BOLD>Just log</CLR>
+  Just debug
+  <t> <CLR=35,BOLD>Measure: Xms</CLR>
+  <g> <CLR=36,BOLD>Nested</CLR>
+    <CLR=BOLD>Just another log</CLR>
+  Trace
+  |     at Object.<anonymous>.module.exports (Xdir/logging/node_modules/custom-loader/index.js:15:9)
+  <t> <CLR=35,BOLD>Measure: Xms</CLR>
+  -------
+  <CLR=BOLD>After clear</CLR>
+
+<CLR=BOLD>LOG from node_modules/custom-loader/index.js Named Logger node_modules/custom-loader/index.js!index.js</CLR>
+Message with named logger"
+`;
+
 exports[`StatsTestCases should print correct stats for max-modules 1`] = `
 "Hash: d0b29852af8ccc4949b7
 Time: Xms

--- a/test/statsCases/logging/node_modules/custom-loader/index.js
+++ b/test/statsCases/logging/node_modules/custom-loader/index.js
@@ -10,7 +10,7 @@ module.exports = function(source) {
 	logger.debug("Just debug");
 	logger.timeLog("Measure");
 	logger.groupCollapsed("Nested");
-	logger.log("Just another log");
+	logger.log("Log inside collapsed group");
 	logger.groupEnd("Nested");
 	logger.trace();
 	logger.timeEnd("Measure");

--- a/test/statsCases/logging/node_modules/custom-loader/index.js
+++ b/test/statsCases/logging/node_modules/custom-loader/index.js
@@ -1,0 +1,21 @@
+/* eslint-disable node/no-unsupported-features/node-builtins */
+module.exports = function(source) {
+	const logger = this.getLogger ? this.getLogger() : console;
+	logger.time("Measure");
+	logger.error("An error");
+	logger.warn("A %s", "warning");
+	logger.group("Unimportant");
+	logger.info("Info message");
+	logger.log("Just log");
+	logger.debug("Just debug");
+	logger.timeLog("Measure");
+	logger.groupCollapsed("Nested");
+	logger.log("Just another log");
+	logger.groupEnd("Nested");
+	logger.trace();
+	logger.timeEnd("Measure");
+	logger.clear();
+	logger.log("After clear");
+	this.getLogger("Named Logger").debug("Message with named logger");
+	return source;
+};

--- a/test/statsCases/logging/webpack.config.js
+++ b/test/statsCases/logging/webpack.config.js
@@ -1,0 +1,30 @@
+class MyPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("MyPlugin", compilation => {
+			const logger = compilation.getLogger("MyPlugin");
+			logger.info("Plugin is now active");
+			logger.debug("Debug message should not be visible");
+		});
+	}
+}
+
+module.exports = {
+	mode: "production",
+	entry: "./index",
+	performance: false,
+	module: {
+		rules: [
+			{
+				test: /index\.js$/,
+				use: "custom-loader"
+			}
+		]
+	},
+	plugins: [new MyPlugin()],
+	stats: {
+		colors: true,
+		logging: true,
+		includeDebugLogging: "custom-loader",
+		loggingTrace: true
+	}
+};

--- a/test/statsCases/logging/webpack.config.js
+++ b/test/statsCases/logging/webpack.config.js
@@ -4,6 +4,12 @@ class MyPlugin {
 			const logger = compilation.getLogger("MyPlugin");
 			logger.info("Plugin is now active");
 			logger.debug("Debug message should not be visible");
+			logger.groupCollapsed("Nested");
+			logger.log("Log inside collapsed group");
+			logger.groupEnd("Nested");
+
+			const otherLogger = compilation.getLogger("MyOtherPlugin");
+			otherLogger.debug("debug message only");
 		});
 	}
 }

--- a/test/statsCases/logging/webpack.config.js
+++ b/test/statsCases/logging/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = {
 	stats: {
 		colors: true,
 		logging: true,
-		includeDebugLogging: "custom-loader",
+		loggingDebug: "custom-loader",
 		loggingTrace: true
 	}
 };

--- a/test/statsCases/preset-detailed/webpack.config.js
+++ b/test/statsCases/preset-detailed/webpack.config.js
@@ -1,5 +1,24 @@
+class MyPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("MyPlugin", compilation => {
+			const logger = compilation.getLogger("MyPlugin");
+			logger.group("Group");
+			logger.error("Error");
+			logger.warn("Warning");
+			logger.info("Info");
+			logger.log("Log");
+			logger.debug("Debug");
+			logger.groupCollapsed("Collaped group");
+			logger.log("Log inside collapsed group");
+			logger.groupEnd();
+			logger.groupEnd();
+		});
+	}
+}
+
 module.exports = {
 	mode: "production",
 	entry: "./index",
-	stats: "detailed"
+	stats: "detailed",
+	plugins: [new MyPlugin()]
 };

--- a/test/statsCases/preset-errors-only-error/webpack.config.js
+++ b/test/statsCases/preset-errors-only-error/webpack.config.js
@@ -1,5 +1,24 @@
+class MyPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("MyPlugin", compilation => {
+			const logger = compilation.getLogger("MyPlugin");
+			logger.group("Group");
+			logger.error("Error");
+			logger.warn("Warning");
+			logger.info("Info");
+			logger.log("Log");
+			logger.debug("Debug");
+			logger.groupCollapsed("Collaped group");
+			logger.log("Log inside collapsed group");
+			logger.groupEnd();
+			logger.groupEnd();
+		});
+	}
+}
+
 module.exports = {
 	mode: "production",
 	entry: "./index",
-	stats: "errors-only"
+	stats: "errors-only",
+	plugins: [new MyPlugin()]
 };

--- a/test/statsCases/preset-errors-warnings/webpack.config.js
+++ b/test/statsCases/preset-errors-warnings/webpack.config.js
@@ -1,5 +1,24 @@
+class MyPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("MyPlugin", compilation => {
+			const logger = compilation.getLogger("MyPlugin");
+			logger.group("Group");
+			logger.error("Error");
+			logger.warn("Warning");
+			logger.info("Info");
+			logger.log("Log");
+			logger.debug("Debug");
+			logger.groupCollapsed("Collaped group");
+			logger.log("Log inside collapsed group");
+			logger.groupEnd();
+			logger.groupEnd();
+		});
+	}
+}
+
 module.exports = {
 	mode: "production",
 	entry: "./index",
-	stats: "errors-warnings"
+	stats: "errors-warnings",
+	plugins: [new MyPlugin()]
 };

--- a/test/statsCases/preset-minimal/webpack.config.js
+++ b/test/statsCases/preset-minimal/webpack.config.js
@@ -1,5 +1,24 @@
+class MyPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("MyPlugin", compilation => {
+			const logger = compilation.getLogger("MyPlugin");
+			logger.group("Group");
+			logger.error("Error");
+			logger.warn("Warning");
+			logger.info("Info");
+			logger.log("Log");
+			logger.debug("Debug");
+			logger.groupCollapsed("Collaped group");
+			logger.log("Log inside collapsed group");
+			logger.groupEnd();
+			logger.groupEnd();
+		});
+	}
+}
+
 module.exports = {
 	mode: "production",
 	entry: "./index",
-	stats: "minimal"
+	stats: "minimal",
+	plugins: [new MyPlugin()]
 };

--- a/test/statsCases/preset-none/webpack.config.js
+++ b/test/statsCases/preset-none/webpack.config.js
@@ -1,5 +1,24 @@
+class MyPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("MyPlugin", compilation => {
+			const logger = compilation.getLogger("MyPlugin");
+			logger.group("Group");
+			logger.error("Error");
+			logger.warn("Warning");
+			logger.info("Info");
+			logger.log("Log");
+			logger.debug("Debug");
+			logger.groupCollapsed("Collaped group");
+			logger.log("Log inside collapsed group");
+			logger.groupEnd();
+			logger.groupEnd();
+		});
+	}
+}
+
 module.exports = {
 	mode: "production",
 	entry: "./index",
-	stats: false
+	stats: false,
+	plugins: [new MyPlugin()]
 };

--- a/test/statsCases/preset-normal/webpack.config.js
+++ b/test/statsCases/preset-normal/webpack.config.js
@@ -1,5 +1,24 @@
+class MyPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("MyPlugin", compilation => {
+			const logger = compilation.getLogger("MyPlugin");
+			logger.group("Group");
+			logger.error("Error");
+			logger.warn("Warning");
+			logger.info("Info");
+			logger.log("Log");
+			logger.debug("Debug");
+			logger.groupCollapsed("Collaped group");
+			logger.log("Log inside collapsed group");
+			logger.groupEnd();
+			logger.groupEnd();
+		});
+	}
+}
+
 module.exports = {
 	mode: "production",
 	entry: "./index",
-	stats: "normal"
+	stats: "normal",
+	plugins: [new MyPlugin()]
 };

--- a/test/statsCases/preset-verbose/webpack.config.js
+++ b/test/statsCases/preset-verbose/webpack.config.js
@@ -1,6 +1,25 @@
+class MyPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("MyPlugin", compilation => {
+			const logger = compilation.getLogger("MyPlugin");
+			logger.group("Group");
+			logger.error("Error");
+			logger.warn("Warning");
+			logger.info("Info");
+			logger.log("Log");
+			logger.debug("Debug");
+			logger.groupCollapsed("Collaped group");
+			logger.log("Log inside collapsed group");
+			logger.groupEnd();
+			logger.groupEnd();
+		});
+	}
+}
+
 module.exports = {
 	mode: "production",
 	entry: "./index",
 	profile: true,
-	stats: "verbose"
+	stats: "verbose",
+	plugins: [new MyPlugin()]
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
* Plugins should prefer to use `compilation.getLogger("PluginName")` for logging. This kind of logging is stored to the Stats and formatted in this way. It can be filtered and exported by the user.
* Plugins may use the `compiler.getInfrastructureLogger("PluginName")` for logging to, but logging to this is not stored in the Stats and therefore not formatted this way. Instead it's usually logged to the console/dashboard/gui directly. It can be filtered by the user.
* Loaders should prefer to use `this.getLogger()`. This is a shortcut to `compilation.getLogger()` with loader path and processed file.
* Loaders may use `this.getLogger("name")` to get an independent logger with a child name. Loader path and processed file is still added.
* Plugins may use `compilation.getLogger ? compilation.getLogger("PluginName") : console` to provide a fallback for webpack version not supporting getLogger. Similar for Loaders.

* Logger API
  * Important hint: Avoid noise in the log! Keep in mind that multiple plugins and loaders are used together. Loader usually process multiple files and are invoked for every file. Choose a log level as low as possible to keep log output informative.
  * Use `logger.error(...)` for error messages
  * Use `logger.warn(...)` for warnings
  * Use `logger.info(...)` for important information messages (they are displayed in the default settings, only use them for things the user really need to know)
  * Use `logger.log(...)` for unimportant information messages (they are only displayed when opt-in into displaying them)
  * Use `logger.debug(...)` for debugging information (they are only displayed when opt-in into debug logging for specific modules)
  * Use `logger.trace()` to display a stack trace (displayed like `logger.debug`)
  * Use `logger.group(...)` to group messages together (displayed like `logger.log`)
  * Use `logger.groupEnd()` to end a group
  * Use `logger.groupCollapsed(...)` to group messages together (displayed collapsed like `logger.log`, displayed expanded when verbose logging or debug logging is enabled)
  * Use `logger.clear()` to clear the log (it may only print a horizontal line instead) (displayed like `logger.log`)
  * Use `logger.profile(...)` and `logger.profileEnd(...)` to capture a profile (delegated to `console.profile` when supported)
* Logging configuration
  * `stats.logging: "none"|"error"|"warn"|"info"|"log"|"verbose"` to choose displayed log level
    * none: nothing
    * error: only errors
    * warn: errors and warnings
    * info: errors, warnings, and info messages (default)
    * log: errors, warnings, info messages, log messages, groups, clear. Collapsed groups are displayed collapsed.
    * verbose: all except debug and trace. Collapsed groups are displayed expanded
  * `stats.logging: false` to disable *all* log output
  * `stats.logging: true` alias to `stats.logging: "log"`
  * `stats.loggingDebug: true|false|/regexp/|"string"|(name) => true` to enable debug output for specific items (intended for plugin/loader developer)
    * When `stats.logging: false`: `stats.loggingDebug` is ignored.
  * `stats.loggingTrace: true` enable stack traces in log output for `error`s, `warning`s and `trace`s.
  * `infrastructureLogging.level: "none"|"error"|"warn"|"info"|"log"|"verbose"`
    * like `stats.logging` but for infrastructure logging
  * `infrastructureLogging.debug: true|false|/regexp/|"string"|(name) => true`
    * like `stats.loggingDebug` but for infrastructure logging
* Plugins
  * `Compiler.hooks.infrastructureLog` and `Compilation.hooks.log` for plugins
  * With webpack 5 there will be plugins for the Stats to modify the log display in stats too
* Runtime Logger API
  * Only for devtooling. Not intended to be included in production mode.
  * `const logging = require("webpack/logging/runtime")`
  * `logging.getLogger("name")`
  * `logging.configureDefaultLogger({ level: "log", debug: /something/ })`
  * `logging.hooks.log` to apply plugins to the runtime logger
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
