### PR TITLE
Escape path variables in replaced values for TemplatedPathPlugin

### DIFF
--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -47,7 +47,7 @@ const getReplacer = (value, allowEmpty) => {
 			}
 			return "";
 		} else {
-			return `${value}`;
+			return `${escapePathVariables(value)}`;
 		}
 	};
 	return fn;
@@ -55,17 +55,14 @@ const getReplacer = (value, allowEmpty) => {
 
 const escapePathVariables = value => {
 	return typeof value === "string"
-		? value.replace(
-				/\[(\\*[\w:]+\\*)\]/gi,
-				"[\\$1\\]"
-		  )
+		? value.replace(/\[(\\*[\w:]+\\*)\]/gi, "[\\$1\\]")
 		: value;
 };
 
 const replacePathVariables = (path, data) => {
 	const chunk = data.chunk;
-	let chunkId = chunk && chunk.id;
-	let chunkName = chunk && (chunk.name || chunk.id);
+	const chunkId = chunk && chunk.id;
+	const chunkName = chunk && (chunk.name || chunk.id);
 	const chunkHash = chunk && (chunk.renderedHash || chunk.hash);
 	const chunkHashWithLength = chunk && chunk.hashWithLength;
 	const contentHashType = data.contentHashType;
@@ -78,7 +75,7 @@ const replacePathVariables = (path, data) => {
 			chunk.contentHashWithLength[contentHashType]) ||
 		data.contentHashWithLength;
 	const module = data.module;
-	let moduleId = module && module.id;
+	const moduleId = module && module.id;
 	const moduleHash = module && (module.renderedHash || module.hash);
 	const moduleHashWithLength = module && module.hashWithLength;
 
@@ -95,12 +92,6 @@ const replacePathVariables = (path, data) => {
 			`Cannot use [chunkhash] or [contenthash] for chunk in '${path}' (use [hash] instead)`
 		);
 	}
-
-	// we need to escape path variables e.g. [name] in replaced values
-	// to prevent unexpected extra replaces from a filename having the variable
-	chunkId = escapePathVariables(chunkId);
-	moduleId = escapePathVariables(moduleId);
-	chunkName = escapePathVariables(chunkName);
 
 	return (
 		path
@@ -123,14 +114,13 @@ const replacePathVariables = (path, data) => {
 			.replace(REGEXP_ID, getReplacer(chunkId))
 			.replace(REGEXP_MODULEID, getReplacer(moduleId))
 			.replace(REGEXP_NAME, getReplacer(chunkName))
-			.replace(REGEXP_FILE, getReplacer(escapePathVariables(data.filename)))
-			.replace(REGEXP_FILEBASE, getReplacer(escapePathVariables(data.basename)))
+			.replace(REGEXP_FILE, getReplacer(data.filename))
+			.replace(REGEXP_FILEBASE, getReplacer(data.basename))
 			// query is optional, it's OK if it's in a path but there's nothing to replace it with
 			.replace(REGEXP_QUERY, getReplacer(data.query, true))
 			// only available in sourceMappingURLComment
 			.replace(REGEXP_URL, getReplacer(data.url))
-			.replace(/\[\\/g, "[")
-			.replace(/\\\]/g, "]")
+			.replace(/\[\\(\\*[\w:]+\\*)\\\]/gi, "[$1]")
 	);
 };
 

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -53,10 +53,19 @@ const getReplacer = (value, allowEmpty) => {
 	return fn;
 };
 
+const escapePathVariables = value => {
+	return typeof value === "string"
+		? value.replace(
+				/\[(name|id|moduleid|file|query|filebase|url|hash|chunkhash|modulehash|contenthash)\]/g,
+				"[\\$1\\]"
+		  )
+		: value;
+};
+
 const replacePathVariables = (path, data) => {
 	const chunk = data.chunk;
-	const chunkId = chunk && chunk.id;
-	const chunkName = chunk && (chunk.name || chunk.id);
+	let chunkId = chunk && chunk.id;
+	let chunkName = chunk && (chunk.name || chunk.id);
 	const chunkHash = chunk && (chunk.renderedHash || chunk.hash);
 	const chunkHashWithLength = chunk && chunk.hashWithLength;
 	const contentHashType = data.contentHashType;
@@ -69,7 +78,7 @@ const replacePathVariables = (path, data) => {
 			chunk.contentHashWithLength[contentHashType]) ||
 		data.contentHashWithLength;
 	const module = data.module;
-	const moduleId = module && module.id;
+	let moduleId = module && module.id;
 	const moduleHash = module && (module.renderedHash || module.hash);
 	const moduleHashWithLength = module && module.hashWithLength;
 
@@ -86,6 +95,12 @@ const replacePathVariables = (path, data) => {
 			`Cannot use [chunkhash] or [contenthash] for chunk in '${path}' (use [hash] instead)`
 		);
 	}
+
+	// we need to escape path variables e.g. [name] in replaced values
+	// to prevent unexpected extra replaces from a filename having the variable
+	chunkId = escapePathVariables(chunkId);
+	moduleId = escapePathVariables(moduleId);
+	chunkName = escapePathVariables(chunkName);
 
 	return (
 		path
@@ -108,12 +123,14 @@ const replacePathVariables = (path, data) => {
 			.replace(REGEXP_ID, getReplacer(chunkId))
 			.replace(REGEXP_MODULEID, getReplacer(moduleId))
 			.replace(REGEXP_NAME, getReplacer(chunkName))
-			.replace(REGEXP_FILE, getReplacer(data.filename))
-			.replace(REGEXP_FILEBASE, getReplacer(data.basename))
+			.replace(REGEXP_FILE, getReplacer(escapePathVariables(data.filename)))
+			.replace(REGEXP_FILEBASE, getReplacer(escapePathVariables(data.basename)))
 			// query is optional, it's OK if it's in a path but there's nothing to replace it with
 			.replace(REGEXP_QUERY, getReplacer(data.query, true))
 			// only available in sourceMappingURLComment
 			.replace(REGEXP_URL, getReplacer(data.url))
+			.replace(/\[\\/g, "[")
+			.replace(/\\\]/g, "]")
 	);
 };
 

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -56,7 +56,7 @@ const getReplacer = (value, allowEmpty) => {
 const escapePathVariables = value => {
 	return typeof value === "string"
 		? value.replace(
-				/\[(name|id|moduleid|file|query|filebase|url|hash|chunkhash|modulehash|contenthash)\]/g,
+				/\[(\\*[\w:]+\\*)\]/gi,
 				"[\\$1\\]"
 		  )
 		: value;

--- a/test/HotModuleReplacementPlugin.test.js
+++ b/test/HotModuleReplacementPlugin.test.js
@@ -231,14 +231,14 @@ describe("HotModuleReplacementPlugin", () => {
 		});
 		fs.writeFileSync(entryFile, "1", "utf-8");
 		compiler.run((err, stats) => {
-			if (err) throw err;
+			if (err) return done(err);
 			fs.writeFileSync(statsFile3, stats.toString());
 			compiler.run((err, stats) => {
-				if (err) throw err;
+				if (err) return done(err);
 				fs.writeFileSync(statsFile4, stats.toString());
 				fs.writeFileSync(entryFile, "2", "utf-8");
 				compiler.run((err, stats) => {
-					if (err) throw err;
+					if (err) return done(err);
 					fs.writeFileSync(statsFile3, stats.toString());
 
 					let foundUpdates = false;

--- a/test/HotModuleReplacementPlugin.test.js
+++ b/test/HotModuleReplacementPlugin.test.js
@@ -171,4 +171,90 @@ describe("HotModuleReplacementPlugin", () => {
 			});
 		});
 	});
+
+	it("should handle entryFile that contains path variable", done => {
+		const entryFile = path.join(
+			__dirname,
+			"js",
+			"HotModuleReplacementPlugin",
+			"[name]",
+			"entry.js"
+		);
+		const statsFile3 = path.join(
+			__dirname,
+			"js",
+			"HotModuleReplacementPlugin",
+			"HotModuleReplacementPlugin.test.stats3.txt"
+		);
+		const statsFile4 = path.join(
+			__dirname,
+			"js",
+			"HotModuleReplacementPlugin",
+			"HotModuleReplacementPlugin.test.stats4.txt"
+		);
+		const recordsFile = path.join(
+			__dirname,
+			"js",
+			"HotModuleReplacementPlugin",
+			"records.json"
+		);
+		try {
+			mkdirp.sync(
+				path.join(__dirname, "js", "HotModuleReplacementPlugin", "[name]")
+			);
+		} catch (e) {
+			// empty
+		}
+		try {
+			fs.unlinkSync(recordsFile);
+		} catch (e) {
+			// empty
+		}
+		const compiler = webpack({
+			mode: "development",
+			cache: false,
+			entry: {
+				"[name]/entry.js": entryFile
+			},
+			recordsPath: recordsFile,
+			output: {
+				filename: "[name]",
+				chunkFilename: "[name].js",
+				path: path.join(__dirname, "js", "HotModuleReplacementPlugin"),
+				hotUpdateChunkFilename: "static/webpack/[id].[hash].hot-update.js",
+				hotUpdateMainFilename: "static/webpack/[hash].hot-update.json"
+			},
+			plugins: [new webpack.HotModuleReplacementPlugin()],
+			optimization: {
+				namedChunks: true
+			}
+		});
+		fs.writeFileSync(entryFile, "1", "utf-8");
+		compiler.run((err, stats) => {
+			if (err) throw err;
+			fs.writeFileSync(statsFile3, stats.toString());
+			compiler.run((err, stats) => {
+				if (err) throw err;
+				fs.writeFileSync(statsFile4, stats.toString());
+				fs.writeFileSync(entryFile, "2", "utf-8");
+				compiler.run((err, stats) => {
+					if (err) throw err;
+					fs.writeFileSync(statsFile3, stats.toString());
+
+					let foundUpdates = false;
+
+					Object.keys(stats.compilation.assets).forEach(key => {
+						foundUpdates =
+							foundUpdates ||
+							!!key.match(
+								/static\/webpack\/\[name\]\/entry\.js\..*?\.hot-update\.js/
+							);
+					});
+
+					expect(foundUpdates).toBe(true);
+					done();
+				});
+			});
+		});
+	});
 });


### PR DESCRIPTION
After implementing bracket based dynamic routing (`[val]`) in Next.js we noticed that HMR for dynamic routes that used `webpack` path variables were broken due to extra replacing. 

For example, if a user does `pages/blog/[name]/comments.js`, in development when a HMR bundle is created it replaces the path causing `static/webpack/[id].[hash].hot-update.js` 
to output to:
`static/webpack/static/development/pages/static/development/pages/[name]/comments.js/comments.js.f2c9118fd02c6de02824.hot-update.js` 

instead of `static/webpack/static/development/pages/[name]/comments.js.0953cecf31a80df2bd53.hot-update.js`

Related issues: 
https://github.com/zeit/next.js/issues/7775
https://github.com/zeit/next.js/pull/8061

Let me know if you think this needs be handled differently/escaped elsewhere.

**What kind of change does this PR introduce?**
Adds escaping of path variables in `TemplatedPathPlugin` for the values being replaced to prevent extra replacing. 

**Did you add tests for your changes?**
Yes, I added a test to `test/HotModuleReplacementPlugin.test.js`

**Does this PR introduce a breaking change?**
no

**What needs to be documented once your changes are merged?**
At places where placeholders are supported, they could be escaped with `[\...\]` -> `[...]`. Example: `[\id\]` generates `[id]` instead of getting replaced with the id.