### PR TITLE
HookMap: replace .tap() with .for().tap()

### DIFF
--- a/lib/ResolverFactory.js
+++ b/lib/ResolverFactory.js
@@ -25,20 +25,16 @@ module.exports = class ResolverFactory extends Tapable {
 			let match;
 			match = /^resolve-options (.+)$/.exec(options.name);
 			if (match) {
-				this.hooks.resolveOptions.tap(
-					match[1],
-					options.fn.name || "unnamed compat plugin",
-					options.fn
-				);
+				this.hooks.resolveOptions
+					.for(match[1])
+					.tap(options.fn.name || "unnamed compat plugin", options.fn);
 				return true;
 			}
 			match = /^resolver (.+)$/.exec(options.name);
 			if (match) {
-				this.hooks.resolver.tap(
-					match[1],
-					options.fn.name || "unnamed compat plugin",
-					options.fn
-				);
+				this.hooks.resolver
+					.for(match[1])
+					.tap(options.fn.name || "unnamed compat plugin", options.fn);
 				return true;
 			}
 		});

--- a/test/Parser.unittest.js
+++ b/test/Parser.unittest.js
@@ -259,48 +259,48 @@ describe("Parser", () => {
 			const state = testCases[name][1];
 
 			const testParser = new Parser({});
-			testParser.hooks.canRename.tap("abc", "ParserTest", expr => true);
-			testParser.hooks.canRename.tap("ijk", "ParserTest", expr => true);
-			testParser.hooks.call.tap("abc", "ParserTest", expr => {
+			testParser.hooks.canRename.for("abc").tap("ParserTest", expr => true);
+			testParser.hooks.canRename.for("ijk").tap("ParserTest", expr => true);
+			testParser.hooks.call.for("abc").tap("ParserTest", expr => {
 				if (!testParser.state.abc) testParser.state.abc = [];
 				testParser.state.abc.push(testParser.parseString(expr.arguments[0]));
 				return true;
 			});
-			testParser.hooks.call.tap("cde.abc", "ParserTest", expr => {
+			testParser.hooks.call.for("cde.abc").tap("ParserTest", expr => {
 				if (!testParser.state.cdeabc) testParser.state.cdeabc = [];
 				testParser.state.cdeabc.push(testParser.parseString(expr.arguments[0]));
 				return true;
 			});
-			testParser.hooks.call.tap("cde.ddd.abc", "ParserTest", expr => {
+			testParser.hooks.call.for("cde.ddd.abc").tap("ParserTest", expr => {
 				if (!testParser.state.cdedddabc) testParser.state.cdedddabc = [];
 				testParser.state.cdedddabc.push(
 					testParser.parseString(expr.arguments[0])
 				);
 				return true;
 			});
-			testParser.hooks.expression.tap("fgh", "ParserTest", expr => {
+			testParser.hooks.expression.for("fgh").tap("ParserTest", expr => {
 				if (!testParser.state.fgh) testParser.state.fgh = [];
 				testParser.state.fgh.push(
 					Array.from(testParser.scope.definitions.asSet()).join(" ")
 				);
 				return true;
 			});
-			testParser.hooks.expression.tap("fgh.sub", "ParserTest", expr => {
+			testParser.hooks.expression.for("fgh.sub").tap("ParserTest", expr => {
 				if (!testParser.state.fghsub) testParser.state.fghsub = [];
 				testParser.state.fghsub.push(testParser.scope.inTry ? "try" : "notry");
 				return true;
 			});
-			testParser.hooks.expression.tap("ijk.sub", "ParserTest", expr => {
+			testParser.hooks.expression.for("ijk.sub").tap("ParserTest", expr => {
 				if (!testParser.state.ijksub) testParser.state.ijksub = [];
 				testParser.state.ijksub.push("test");
 				return true;
 			});
-			testParser.hooks.expression.tap("memberExpr", "ParserTest", expr => {
+			testParser.hooks.expression.for("memberExpr").tap("ParserTest", expr => {
 				if (!testParser.state.expressions) testParser.state.expressions = [];
 				testParser.state.expressions.push(expr.name);
 				return true;
 			});
-			testParser.hooks.new.tap("xyz", "ParserTest", expr => {
+			testParser.hooks.new.for("xyz").tap("ParserTest", expr => {
 				if (!testParser.state.xyz) testParser.state.xyz = [];
 				testParser.state.xyz.push(testParser.parseString(expr.arguments[0]));
 				return true;
@@ -345,15 +345,21 @@ describe("Parser", () => {
 	describe("expression evaluation", () => {
 		function evaluateInParser(source) {
 			const parser = new Parser();
-			parser.hooks.call.tap("test", "ParserTest", expr => {
+			parser.hooks.call.for("test").tap("ParserTest", expr => {
 				parser.state.result = parser.evaluateExpression(expr.arguments[0]);
 			});
-			parser.hooks.evaluateIdentifier.tap("aString", "ParserTest", expr =>
-				new BasicEvaluatedExpression().setString("aString").setRange(expr.range)
-			);
-			parser.hooks.evaluateIdentifier.tap("b.Number", "ParserTest", expr =>
-				new BasicEvaluatedExpression().setNumber(123).setRange(expr.range)
-			);
+			parser.hooks.evaluateIdentifier
+				.for("aString")
+				.tap("ParserTest", expr =>
+					new BasicEvaluatedExpression()
+						.setString("aString")
+						.setRange(expr.range)
+				);
+			parser.hooks.evaluateIdentifier
+				.for("b.Number")
+				.tap("ParserTest", expr =>
+					new BasicEvaluatedExpression().setNumber(123).setRange(expr.range)
+				);
 			return parser.parse("test(" + source + ");").result;
 		}
 
@@ -585,7 +591,7 @@ describe("Parser", () => {
 			};
 
 			const parser = new Parser();
-			parser.hooks.call.tap("require", "ParserTest", expr => {
+			parser.hooks.call.for("require").tap("ParserTest", expr => {
 				const param = parser.evaluateExpression(expr.arguments[0]);
 				parser.state.param = param.string;
 			});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
`Tapable` will deprecate HookMap's `tap tapAsync tapPromise` API, so I make this PR to replace the HookMap instance use `.tap()` API with `.for().tap()` API.

**What kind of change does this PR introduce?**

This PR is refactoring the HookMap API.

**Did you add tests for your changes?**

Yes.

**Does this PR introduce a breaking change?**
No.

**What needs to be documented once your changes are merged?**
The pr has no perception of the user, do not need to be documented.

