### PR TITLE
Fix asyncHook callback interceptor for ProfilingPlugin

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -391,8 +391,8 @@ const makeNewProfiledTapFn = (hookName, tracer, { name, type, fn }) => {
 					id,
 					cat: defaultCategory
 				});
+				const callback = args.pop();
 				fn(...args, (...r) => {
-					const callback = args.pop();
 					tracer.trace.end({
 						name,
 						id,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

While writing a custom profiler I ran into the issue that TerserPlugin never called it’s `end` trace. Eventually I tracked it down to the callback function. Instead of being overwritten it was being appended to the end of the function arguments. The callback has to be popped first because the added argument is a wrapper for the original callback.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

I can investigate adding a test if needed.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

No changes to documentation needed.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

---
 
### OLD

<img width="1415" alt="Screenshot 2019-08-12 at 21 03 22" src="https://user-images.githubusercontent.com/6324199/62890880-a8dd1e00-bd44-11e9-8233-c77c705d743f.png">


### NEW

<img width="1416" alt="Screenshot 2019-08-12 at 21 03 29" src="https://user-images.githubusercontent.com/6324199/62890888-aed2ff00-bd44-11e9-987f-0b1f22c34ebb.png">
