### PR TITLE
add `__webpack_exports_info__` API to allow export introspection

### DIFF
--- a/lib/ExportsInfoApiPlugin.js
+++ b/lib/ExportsInfoApiPlugin.js
@@ -1,0 +1,70 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const ConstDependency = require("./dependencies/ConstDependency");
+const ExportsInfoDependency = require("./dependencies/ExportsInfoDependency");
+
+/** @typedef {import("./Compiler")} Compiler */
+/** @typedef {import("./JavascriptParser")} JavascriptParser */
+
+class ExportsInfoApiPlugin {
+	/**
+	 * @param {Compiler} compiler the compiler instance
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap(
+			"ExportsInfoApiPlugin",
+			(compilation, { normalModuleFactory }) => {
+				compilation.dependencyTemplates.set(
+					ExportsInfoDependency,
+					new ExportsInfoDependency.Template()
+				);
+				/**
+				 * @param {JavascriptParser} parser the parser
+				 * @returns {void}
+				 */
+				const handler = parser => {
+					parser.hooks.expressionMemberChain
+						.for("__webpack_exports_info__")
+						.tap("ExportsInfoApiPlugin", (expr, rootRaw, members) => {
+							const dep =
+								members.length >= 2
+									? new ExportsInfoDependency(
+											expr.range,
+											members.slice(0, -1),
+											members[members.length - 1]
+									  )
+									: new ExportsInfoDependency(expr.range, members, null);
+							dep.loc = expr.loc;
+							parser.state.module.addDependency(dep);
+							return true;
+						});
+					parser.hooks.expression
+						.for("__webpack_exports_info__")
+						.tap("ExportsInfoApiPlugin", expr => {
+							const dep = new ConstDependency("true", expr.range);
+							dep.loc = expr.loc;
+							parser.state.module.addDependency(dep);
+							return true;
+						});
+				};
+				normalModuleFactory.hooks.parser
+					.for("javascript/auto")
+					.tap("ExportsInfoApiPlugin", handler);
+				normalModuleFactory.hooks.parser
+					.for("javascript/dynamic")
+					.tap("ExportsInfoApiPlugin", handler);
+				normalModuleFactory.hooks.parser
+					.for("javascript/esm")
+					.tap("ExportsInfoApiPlugin", handler);
+			}
+		);
+	}
+}
+
+module.exports = ExportsInfoApiPlugin;

--- a/lib/ModuleGraph.js
+++ b/lib/ModuleGraph.js
@@ -333,8 +333,12 @@ class ExportsInfo {
 	 */
 	isExportProvided(name) {
 		if (Array.isArray(name)) {
-			// TODO follow nested exports
-			return this.isExportProvided(name[0]);
+			let info = this._exports.get(name[0]);
+			if (info === undefined) info = this._otherExportsInfo;
+			if (info.exportsInfo && name.length > 1) {
+				return info.exportsInfo.isExportProvided(name.slice(1));
+			}
+			return info.provided;
 		}
 		let info = this._exports.get(name);
 		if (info === undefined) info = this._otherExportsInfo;
@@ -348,8 +352,12 @@ class ExportsInfo {
 	isExportUsed(name) {
 		if (Array.isArray(name)) {
 			if (name.length === 0) return this.otherExportsInfo.used;
-			// TODO follow nested exports
-			return this.isExportUsed(name[0]);
+			let info = this._exports.get(name[0]);
+			if (info === undefined) info = this._otherExportsInfo;
+			if (info.exportsInfo && name.length > 1) {
+				return info.exportsInfo.isExportUsed(name.slice(1));
+			}
+			return info.used;
 		}
 		let info = this._exports.get(name);
 		if (info === undefined) info = this._otherExportsInfo;

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -25,6 +25,7 @@ const APIPlugin = require("./APIPlugin");
 const CommonJsStuffPlugin = require("./CommonJsStuffPlugin");
 const CompatibilityPlugin = require("./CompatibilityPlugin");
 const ConstPlugin = require("./ConstPlugin");
+const ExportsInfoApiPlugin = require("./ExportsInfoApiPlugin");
 
 const TemplatedPathPlugin = require("./TemplatedPathPlugin");
 const UseStrictPlugin = require("./UseStrictPlugin");
@@ -358,6 +359,7 @@ class WebpackOptionsApply extends OptionsApply {
 		}
 		new CommonJsStuffPlugin().apply(compiler);
 		new APIPlugin().apply(compiler);
+		new ExportsInfoApiPlugin().apply(compiler);
 		new ConstPlugin().apply(compiler);
 		new UseStrictPlugin().apply(compiler);
 		new RequireIncludePlugin().apply(compiler);

--- a/lib/dependencies/ExportsInfoDependency.js
+++ b/lib/dependencies/ExportsInfoDependency.js
@@ -1,0 +1,127 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const { UsageState } = require("../ModuleGraph");
+const makeSerializable = require("../util/makeSerializable");
+const NullDependency = require("./NullDependency");
+
+/** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
+/** @typedef {import("../ChunkGraph")} ChunkGraph */
+/** @typedef {import("../Dependency")} Dependency */
+/** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
+/** @typedef {import("../util/Hash")} Hash */
+
+const getProperty = (moduleGraph, module, exportName, property) => {
+	switch (property) {
+		case null:
+			return {
+				used: getProperty(moduleGraph, module, exportName, "used"),
+				useInfo: getProperty(moduleGraph, module, exportName, "useInfo"),
+				provideInfo: getProperty(moduleGraph, module, exportName, "provideInfo")
+			};
+		case "used":
+			return (
+				moduleGraph.getExportsInfo(module).isExportUsed(exportName) !==
+				UsageState.Unused
+			);
+		case "useInfo": {
+			const state = moduleGraph.getExportsInfo(module).isExportUsed(exportName);
+			switch (state) {
+				case UsageState.Used:
+				case UsageState.OnlyPropertiesUsed:
+					return true;
+				case UsageState.Unused:
+					return false;
+				case UsageState.NoInfo:
+					return undefined;
+				case UsageState.Unknown:
+					return null;
+				default:
+					throw new Error(`Unexpected UsageState ${state}`);
+			}
+		}
+		case "provideInfo":
+			return moduleGraph.getExportsInfo(module).isExportProvided(exportName);
+	}
+	return undefined;
+};
+
+class ExportsInfoDependency extends NullDependency {
+	constructor(range, exportName, property) {
+		super();
+		this.range = range;
+		this.exportName = exportName;
+		this.property = property;
+	}
+
+	/**
+	 * Update the hash
+	 * @param {Hash} hash hash to be updated
+	 * @param {ChunkGraph} chunkGraph chunk graph
+	 * @returns {void}
+	 */
+	updateHash(hash, chunkGraph) {
+		const { moduleGraph } = chunkGraph;
+		const module = moduleGraph.getParentModule(this);
+		const value = getProperty(
+			moduleGraph,
+			module,
+			this.exportName,
+			this.property
+		);
+		hash.update(value === undefined ? "undefined" : JSON.stringify(value));
+	}
+
+	serialize(context) {
+		const { write } = context;
+		write(this.range);
+		write(this.exportName);
+		write(this.property);
+		super.serialize(context);
+	}
+
+	static deserialize(context) {
+		const obj = new ExportsInfoDependency(
+			context.read(),
+			context.read(),
+			context.read()
+		);
+		obj.deserialize(context);
+		return obj;
+	}
+}
+
+makeSerializable(
+	ExportsInfoDependency,
+	"webpack/lib/dependencies/ExportsInfoDependency"
+);
+
+ExportsInfoDependency.Template = class ExportsInfoDependencyTemplate extends NullDependency.Template {
+	/**
+	 * @param {Dependency} dependency the dependency for which the template should be applied
+	 * @param {ReplaceSource} source the current replace source which can be modified
+	 * @param {DependencyTemplateContext} templateContext the context object
+	 * @returns {void}
+	 */
+	apply(dependency, source, { module, moduleGraph, runtimeRequirements }) {
+		const dep = /** @type {ExportsInfoDependency} */ (dependency);
+
+		const value = getProperty(
+			moduleGraph,
+			module,
+			dep.exportName,
+			dep.property
+		);
+		source.replace(
+			dep.range[0],
+			dep.range[1] - 1,
+			value === undefined ? "undefined" : JSON.stringify(value)
+		);
+	}
+};
+
+module.exports = ExportsInfoDependency;

--- a/test/cases/parsing/harmony-deep-exports/counter.js
+++ b/test/cases/parsing/harmony-deep-exports/counter.js
@@ -4,5 +4,20 @@ export const increment = () => {
 };
 export function reset() {
 	counter = 0;
-};
+}
 export const unusedExport = 42;
+
+export const exportsInfo = {
+	increment: __webpack_exports_info__.increment.used,
+	counter: __webpack_exports_info__.counter.used,
+	reset: __webpack_exports_info__.reset.used,
+	unusedExport: __webpack_exports_info__.unusedExport.used,
+	somethingElse: __webpack_exports_info__.somethingElse.used,
+	incrementInfo: __webpack_exports_info__.increment.useInfo,
+	counterInfo: __webpack_exports_info__.counter.useInfo,
+	resetInfo: __webpack_exports_info__.reset.useInfo,
+	unusedExportInfo: __webpack_exports_info__.unusedExport.useInfo,
+	somethingElseInfo: __webpack_exports_info__.somethingElse.useInfo,
+	incrementProvideInfo: __webpack_exports_info__.increment.provideInfo,
+	somethingElseProvideInfo: __webpack_exports_info__.somethingElse.provideInfo
+};

--- a/test/cases/parsing/harmony-deep-exports/index.js
+++ b/test/cases/parsing/harmony-deep-exports/index.js
@@ -28,3 +28,51 @@ import CJS from "./cjs";
 it("should be able to call a deep function in commonjs", () => {
 	expect(CJS.a.b.c.d()).toBe(42);
 });
+
+it("should report consistent exports info", () => {
+	const x1 = counter.exportsInfo;
+
+	if (process.env.NODE_ENV === "production") {
+		expect(x1.incrementInfo).toBe(true);
+		expect(x1.counterInfo).toBe(true);
+		expect(x1.resetInfo).toBe(true);
+		expect(x1.unusedExport).toBe(false);
+		expect(x1.unusedExportInfo).toBe(false);
+		expect(x1.somethingElse).toBe(false);
+		expect(x1.somethingElseInfo).toBe(false);
+		expect(C.exportsInfo.nsInfo).toBe(true);
+		expect(C.exportsInfo.ns2).toBe(false);
+		expect(C.exportsInfo.ns2Info).toBe(false);
+	} else if (process.env.NODE_ENV === "development") {
+		expect(x1.incrementInfo).toBe(undefined);
+		expect(x1.counterInfo).toBe(undefined);
+		expect(x1.resetInfo).toBe(undefined);
+		expect(x1.unusedExport).toBe(true);
+		expect(x1.unusedExportInfo).toBe(undefined);
+		expect(x1.somethingElse).toBe(true);
+		expect(x1.somethingElseInfo).toBe(undefined);
+		expect(C.exportsInfo.nsInfo).toBe(undefined);
+		expect(C.exportsInfo.ns2).toBe(true);
+		expect(C.exportsInfo.ns2Info).toBe(undefined);
+	}
+	expect(x1.increment).toBe(true);
+	expect(x1.counter).toBe(true);
+	expect(x1.reset).toBe(true);
+	expect(x1.incrementProvideInfo).toBe(true);
+	expect(x1.somethingElseProvideInfo).toBe(false);
+	expect(C.exportsInfo.increment).toBe(x1.increment);
+	expect(C.exportsInfo.counter).toBe(x1.counter);
+	expect(C.exportsInfo.reset).toBe(x1.reset);
+	expect(C.exportsInfo.unusedExport).toBe(x1.unusedExport);
+	expect(C.exportsInfo.incrementInfo).toBe(x1.incrementInfo);
+	expect(C.exportsInfo.counterInfo).toBe(x1.counterInfo);
+	expect(C.exportsInfo.resetInfo).toBe(x1.resetInfo);
+	expect(C.exportsInfo.unusedExportInfo).toBe(x1.unusedExportInfo);
+	expect(C.exportsInfo.incrementProvideInfo).toBe(x1.incrementProvideInfo);
+	expect(C.exportsInfo.somethingElseProvideInfo).toBe(
+		x1.somethingElseProvideInfo
+	);
+	expect(C.exportsInfo.ns).toBe(true);
+	expect(C2.exportsInfo).toBe(true);
+	expect(__webpack_exports_info__).toBe(true);
+});

--- a/test/cases/parsing/harmony-deep-exports/reexport-namespace-again.js
+++ b/test/cases/parsing/harmony-deep-exports/reexport-namespace-again.js
@@ -1,2 +1,4 @@
 import * as CC from "./reexport-namespace";
 export { CC };
+
+export const exportsInfo = __webpack_exports_info__;

--- a/test/cases/parsing/harmony-deep-exports/reexport-namespace.js
+++ b/test/cases/parsing/harmony-deep-exports/reexport-namespace.js
@@ -1,2 +1,24 @@
 import * as counter from "./counter";
 export { counter };
+import * as counter2 from "./counter";
+export { counter2 };
+
+export const exportsInfo = {
+	increment: __webpack_exports_info__.counter.increment.used,
+	counter: __webpack_exports_info__.counter.counter.used,
+	reset: __webpack_exports_info__.counter.reset.used,
+	unusedExport: __webpack_exports_info__.counter.unusedExport.used,
+	somethingElse: __webpack_exports_info__.counter.somethingElse.used,
+	incrementInfo: __webpack_exports_info__.counter.increment.useInfo,
+	counterInfo: __webpack_exports_info__.counter.counter.useInfo,
+	resetInfo: __webpack_exports_info__.counter.reset.useInfo,
+	unusedExportInfo: __webpack_exports_info__.counter.unusedExport.useInfo,
+	somethingElseInfo: __webpack_exports_info__.counter.somethingElse.useInfo,
+	incrementProvideInfo: __webpack_exports_info__.counter.increment.provideInfo,
+	somethingElseProvideInfo:
+		__webpack_exports_info__.counter.somethingElse.provideInfo,
+	ns: __webpack_exports_info__.counter.used,
+	nsInfo: __webpack_exports_info__.counter.useInfo,
+	ns2: __webpack_exports_info__.counter2.used,
+	ns2Info: __webpack_exports_info__.counter2.useInfo
+};


### PR DESCRIPTION
improve usage/provide information for nested exports

improve tests for deep exports

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
In modules `__webpack_exports_info__` is available:
* `__webpack_exports_info__` is always true
* `__webpack_exports_info__.<exportName>.used` is `false` when the export is known to be unused, true otherwise
* `__webpack_exports_info__.<exportName>.useInfo` is
  * `false` when the export is known to be unused
  * `true` when the export is known to be used
  * `null` when the export usage could depend on runtime conditions
  * `undefined` when no info is available
* `__webpack_exports_info__.<exportName>.provideInfo` is
  * `false` when the export is known to be not provided
  * `true` when the export is known to be provided
  * `null` when the export provision could depend on runtime conditions
  * `undefined` when no info is available
* Accessing the info from nested exports is possible: i. e. `__webpack_exports_info__.<exportName>.<exportName>.<exportName>.used`
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
