### PR TITLE
Persistent Caching fixes

### DIFF
--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -19,7 +19,7 @@ const {
 } = require("./util/comparators");
 const { compareModulesById } = require("./util/comparators");
 const { contextify } = require("./util/identifier");
-const { registerNotSerializable } = require("./util/serialization");
+const makeSerializable = require("./util/makeSerializable");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("./ChunkGraph")} ChunkGraph */
@@ -79,13 +79,18 @@ class ContextModule extends Module {
 	constructor(resolveDependencies, options) {
 		let resource;
 		let resourceQuery;
-		const queryIdx = options.resource.indexOf("?");
-		if (queryIdx >= 0) {
-			resource = options.resource.substr(0, queryIdx);
-			resourceQuery = options.resource.substr(queryIdx);
-		} else {
+		if (options.resourceQuery) {
 			resource = options.resource;
-			resourceQuery = "";
+			resourceQuery = options.resourceQuery;
+		} else {
+			const queryIdx = options.resource.indexOf("?");
+			if (queryIdx >= 0) {
+				resource = options.resource.substr(0, queryIdx);
+				resourceQuery = options.resource.substr(queryIdx);
+			} else {
+				resource = options.resource;
+				resourceQuery = "";
+			}
 		}
 
 		super("javascript/dynamic", resource);
@@ -94,9 +99,17 @@ class ContextModule extends Module {
 		this.resolveDependencies = resolveDependencies;
 		/** @type {ContextModuleOptions} */
 		this.options = ({
-			...options,
 			resource: resource,
-			resourceQuery: resourceQuery
+			resourceQuery: resourceQuery,
+			mode: options.mode,
+			recursive: options.recursive,
+			addon: options.addon,
+			regExp: options.regExp,
+			include: options.include,
+			exclude: options.exclude,
+			chunkName: options.chunkName,
+			groupOptions: options.groupOptions,
+			namespaceObject: options.namespaceObject
 		});
 		if (options.resolveOptions !== undefined) {
 			this.resolveOptions = options.resolveOptions;
@@ -156,6 +169,9 @@ class ContextModule extends Module {
 		if (this.options.exclude) {
 			identifier += `|exclude: ${this.options.exclude}`;
 		}
+		if (this.options.chunkName) {
+			identifier += `|chunkName: ${this.options.chunkName}`;
+		}
 		if (this.options.groupOptions) {
 			identifier += `|groupOptions: ${JSON.stringify(
 				this.options.groupOptions
@@ -203,6 +219,9 @@ class ContextModule extends Module {
 		}
 		if (this.options.exclude) {
 			identifier += ` exclude: ${this.prettyRegExp(this.options.exclude + "")}`;
+		}
+		if (this.options.chunkName) {
+			identifier += ` chunkName: ${this.options.chunkName}`;
 		}
 		if (this.options.groupOptions) {
 			const groupOptions = this.options.groupOptions;
@@ -268,11 +287,14 @@ class ContextModule extends Module {
 	 * @returns {void}
 	 */
 	needBuild({ fileSystemInfo }, callback) {
+		// build if enforced
 		if (this._forceBuild) return callback(null, true);
-		fileSystemInfo.getContextTimestamp(this.context, (err, info) => {
-			if (err || !info) return callback(null, true);
 
-			return callback(null, info.safeTime >= this.buildInfo.builtTime);
+		// always build when we have no snapshot
+		if (!this.buildInfo.snapshot) return callback(null, true);
+
+		fileSystemInfo.checkSnapshotValid(this.buildInfo.snapshot, (err, valid) => {
+			callback(err, !valid);
 		});
 	}
 
@@ -288,11 +310,12 @@ class ContextModule extends Module {
 		this._forceBuild = false;
 		this.buildMeta = {};
 		this.buildInfo = {
-			builtTime: Date.now(),
+			snapshot: undefined,
 			contextDependencies: this._contextDependencies
 		};
 		this.dependencies.length = 0;
 		this.blocks.length = 0;
+		const startTime = Date.now();
 		this.resolveDependencies(fs, this.options, (err, dependencies) => {
 			if (err) return callback(err);
 
@@ -376,7 +399,18 @@ class ContextModule extends Module {
 				);
 				return;
 			}
-			callback();
+			compilation.fileSystemInfo.createSnapshot(
+				startTime,
+				null,
+				[this.context],
+				null,
+				{},
+				(err, snapshot) => {
+					if (err) return callback(err);
+					this.buildInfo.snapshot = snapshot;
+					callback();
+				}
+			);
 		});
 	}
 
@@ -952,8 +986,30 @@ module.exports = webpackEmptyAsyncContext;`;
 			return size + 5 + element.userRequest.length;
 		}, initialSize);
 	}
+
+	serialize(context) {
+		const { write } = context;
+		// constructor
+		write(this.options);
+		// deserialize
+		write(this._forceBuild);
+		super.serialize(context);
+	}
+
+	static deserialize(context) {
+		const { read } = context;
+		const obj = new ContextModule(null, read());
+		obj.deserialize(context);
+		return obj;
+	}
+
+	deserialize(context) {
+		const { read } = context;
+		this._forceBuild = read();
+		super.deserialize(context);
+	}
 }
 
-registerNotSerializable(ContextModule);
+makeSerializable(ContextModule, "webpack/lib/ContextModule");
 
 module.exports = ContextModule;

--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -33,7 +33,8 @@ const INVALID = Symbol("invalid");
 /**
  * @typedef {Object} FileSystemInfoEntry
  * @property {number} safeTime
- * @property {number} timestamp
+ * @property {number=} timestamp
+ * @property {string=} timestampHash
  */
 
 /**
@@ -45,6 +46,18 @@ const INVALID = Symbol("invalid");
  * @property {Map<string, string | "error">=} contextHashes
  * @property {Map<string, FileSystemInfoEntry | "error">=} missingTimestamps
  * @property {Map<string, string | "error">=} managedItemInfo
+ */
+
+/**
+ * @typedef {Object} ResolveBuildDependenciesResult
+ * @property {Set<string>} files list of files
+ * @property {Set<string>} directories list of directories
+ * @property {Set<string>} missing list of missing entries
+ * @property {Map<string, string>} resolveResults stored resolve results
+ * @property {Object} resolveDependencies dependencies of the resolving
+ * @property {Set<string>} resolveDependencies.files list of files
+ * @property {Set<string>} resolveDependencies.directories list of directories
+ * @property {Set<string>} resolveDependencies.missing list of missing entries
  */
 
 /* istanbul ignore next */
@@ -80,6 +93,9 @@ const getManagedItem = (managedPath, path) => {
 		}
 		i++;
 	}
+	if (i === path.length) slashes--;
+	// return null when path is incomplete
+	if (slashes !== 0) return null;
 	// if (path.slice(i + 1, i + 13) === "node_modules")
 	if (
 		path.charCodeAt(i + 1) === 110 &&
@@ -222,6 +238,12 @@ class FileSystemInfo {
 		this.contextHashQueue.add(path, callback);
 	}
 
+	/**
+	 * @param {string} context context directory
+	 * @param {Iterable<string>} deps dependencies
+	 * @param {function(Error=, ResolveBuildDependenciesResult=): void} callback callback function
+	 * @returns {void}
+	 */
 	resolveBuildDependencies(context, deps, callback) {
 		const files = new Set();
 		const directories = new Set();
@@ -475,12 +497,18 @@ class FileSystemInfo {
 			callback(err);
 			callback = () => {};
 		};
+		let jobQueued = false;
 		for (const dep of deps) {
 			queue.push({
 				type: RBDT_RESOLVE,
 				context,
 				path: dep
 			});
+			jobQueued = true;
+		}
+		if (!jobQueued) {
+			// queue won't call drain when no jobs are queue
+			queue.drain();
 		}
 	}
 
@@ -584,8 +612,11 @@ class FileSystemInfo {
 					}
 					for (const managedPath of this.managedPathsWithSlash) {
 						if (path.startsWith(managedPath)) {
-							managedItems.add(getManagedItem(managedPath, path));
-							continue files;
+							const managedItem = getManagedItem(managedPath, path);
+							if (managedItem) {
+								managedItems.add(managedItem);
+								continue files;
+							}
 						}
 					}
 					const cache = this._fileHashes.get(path);
@@ -612,8 +643,11 @@ class FileSystemInfo {
 					}
 					for (const managedPath of this.managedPathsWithSlash) {
 						if (path.startsWith(managedPath)) {
-							managedItems.add(getManagedItem(managedPath, path));
-							continue files;
+							const managedItem = getManagedItem(managedPath, path);
+							if (managedItem) {
+								managedItems.add(managedItem);
+								continue files;
+							}
 						}
 					}
 					const cache = this._fileTimestamps.get(path);
@@ -643,8 +677,11 @@ class FileSystemInfo {
 					}
 					for (const managedPath of this.managedPathsWithSlash) {
 						if (path.startsWith(managedPath)) {
-							managedItems.add(getManagedItem(managedPath, path));
-							continue directories;
+							const managedItem = getManagedItem(managedPath, path);
+							if (managedItem) {
+								managedItems.add(managedItem);
+								continue directories;
+							}
 						}
 					}
 					const cache = this._contextHashes.get(path);
@@ -671,12 +708,27 @@ class FileSystemInfo {
 					}
 					for (const managedPath of this.managedPathsWithSlash) {
 						if (path.startsWith(managedPath)) {
-							managedItems.add(getManagedItem(managedPath, path));
-							continue directories;
+							const managedItem = getManagedItem(managedPath, path);
+							if (managedItem) {
+								managedItems.add(managedItem);
+								continue directories;
+							}
 						}
 					}
-					contextTimestamps.set(path, "error");
-					// TODO: getContextTimestamp is not implemented yet
+					const cache = this._contextTimestamps.get(path);
+					if (cache !== undefined) {
+						contextTimestamps.set(path, cache);
+					} else {
+						jobs++;
+						this.contextTimestampQueue.add(path, (err, entry) => {
+							if (err) {
+								contextTimestamps.set(path, "error");
+							} else {
+								contextTimestamps.set(path, entry);
+							}
+							jobDone();
+						});
+					}
 				}
 			}
 		}
@@ -689,8 +741,11 @@ class FileSystemInfo {
 				}
 				for (const managedPath of this.managedPathsWithSlash) {
 					if (path.startsWith(managedPath)) {
-						managedItems.add(getManagedItem(managedPath, path));
-						continue missing;
+						const managedItem = getManagedItem(managedPath, path);
+						if (managedItem) {
+							managedItems.add(managedItem);
+							continue missing;
+						}
 					}
 				}
 				const cache = this._fileTimestamps.get(path);
@@ -858,6 +913,14 @@ class FileSystemInfo {
 					// it's invalid
 					return false;
 				}
+				if (
+					snap.timestampHash !== undefined &&
+					current.timestampHash !== snap.timestampHash
+				) {
+					// If we have a timestampHash (it was a directory) and it differs from current timestampHash
+					// it's invalid
+					return false;
+				}
 			}
 			return true;
 		};
@@ -902,8 +965,24 @@ class FileSystemInfo {
 			}
 		}
 		if (contextTimestamps && contextTimestamps.size > 0) {
-			// TODO: getContextTimestamp is not implemented yet
-			invalid();
+			for (const [path, ts] of contextTimestamps) {
+				const cache = this._contextTimestamps.get(path);
+				if (cache !== undefined) {
+					if (!checkFile(cache, ts)) {
+						invalid();
+					}
+				} else {
+					jobs++;
+					this.contextTimestampQueue.add(path, (err, entry) => {
+						if (err) return invalid();
+						if (!checkFile(entry, ts)) {
+							invalid();
+						} else {
+							jobDone();
+						}
+					});
+				}
+			}
 		}
 		if (contextHashes) {
 			for (const [path, hash] of contextHashes) {
@@ -1016,9 +1095,96 @@ class FileSystemInfo {
 	}
 
 	_readContextTimestamp(path, callback) {
-		// TODO read whole folder
-		this._contextTimestamps.set(path, null);
-		callback(null, null);
+		this.fs.readdir(path, (err, files) => {
+			if (err) {
+				if (err.code === "ENOENT") {
+					this._contextTimestamps.set(path, null);
+					return callback(null, null);
+				}
+				return callback(err);
+			}
+			files = files
+				.map(file => file.normalize("NFC"))
+				.filter(file => !/^\./.test(file))
+				.sort();
+			asyncLib.map(
+				files,
+				(file, callback) => {
+					const child = join(this.fs, path, file);
+					this.fs.stat(child, (err, stat) => {
+						if (err) return callback(err);
+
+						for (const immutablePath of this.immutablePathsWithSlash) {
+							if (path.startsWith(immutablePath)) {
+								// ignore any immutable path for timestamping
+								return callback(null, null);
+							}
+						}
+						for (const managedPath of this.managedPathsWithSlash) {
+							if (path.startsWith(managedPath)) {
+								const managedItem = getManagedItem(managedPath, child);
+								if (managedItem) {
+									// construct timestampHash from managed info
+									return this.managedItemQueue.add(child, (err, info) => {
+										if (err) return callback(err);
+										return callback(null, {
+											safeTime: 0,
+											timestampHash: info
+										});
+									});
+								}
+							}
+						}
+
+						if (stat.isFile()) {
+							return this.getFileTimestamp(child, callback);
+						}
+						if (stat.isDirectory()) {
+							this.contextTimestampQueue.increaseParallelism();
+							this.getContextTimestamp(child, (err, tsEntry) => {
+								this.contextTimestampQueue.decreaseParallelism();
+								callback(err, tsEntry);
+							});
+							return;
+						}
+						callback(null, null);
+					});
+				},
+				(err, tsEntries) => {
+					const hash = createHash("md4");
+
+					for (const file of files) hash.update(file);
+					let safeTime = 0;
+					for (const entry of tsEntries) {
+						if (!entry) {
+							hash.update("n");
+							continue;
+						}
+						if (entry.timestamp) {
+							hash.update("f");
+							hash.update(`${entry.timestamp}`);
+						} else if (entry.timestampHash) {
+							hash.update("d");
+							hash.update(`${entry.timestampHash}`);
+						}
+						if (entry.safeTime) {
+							safeTime = Math.max(safeTime, entry.safeTime);
+						}
+					}
+
+					const digest = /** @type {string} */ (hash.digest("hex"));
+
+					const result = {
+						safeTime,
+						timestampHash: digest
+					};
+
+					this._contextTimestamps.set(path, result);
+
+					callback(null, result);
+				}
+			);
+		});
 	}
 
 	_readContextHash(path, callback) {
@@ -1040,6 +1206,25 @@ class FileSystemInfo {
 					const child = join(this.fs, path, file);
 					this.fs.stat(child, (err, stat) => {
 						if (err) return callback(err);
+
+						for (const immutablePath of this.immutablePathsWithSlash) {
+							if (path.startsWith(immutablePath)) {
+								// ignore any immutable path for hashing
+								return callback(null, "");
+							}
+						}
+						for (const managedPath of this.managedPathsWithSlash) {
+							if (path.startsWith(managedPath)) {
+								const managedItem = getManagedItem(managedPath, child);
+								if (managedItem) {
+									// construct hash from managed info
+									return this.managedItemQueue.add(child, (err, info) => {
+										if (err) return callback(err);
+										callback(null, info || "");
+									});
+								}
+							}
+						}
 
 						if (stat.isFile()) {
 							return this.getFileHash(child, callback);
@@ -1074,7 +1259,13 @@ class FileSystemInfo {
 	_getManagedItemInfo(path, callback) {
 		const packageJsonPath = join(this.fs, path, "package.json");
 		this.fs.readFile(packageJsonPath, (err, content) => {
-			if (err) return callback(err);
+			if (err) {
+				if (err.code === "ENOENT") {
+					this._managedItems.set(path, null);
+					return callback(null, null);
+				}
+				return callback(err);
+			}
 			let data;
 			try {
 				data = JSON.parse(content.toString("utf-8"));
@@ -1082,6 +1273,7 @@ class FileSystemInfo {
 				return callback(e);
 			}
 			const info = `${data.name || ""}@${data.version || ""}`;
+			this._managedItems.set(path, info);
 			callback(null, info);
 		});
 	}

--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -15,9 +15,20 @@ const {
 	MEASURE_END_OPERATION
 } = require("../util/serialization");
 
+/** @typedef {import("../logging/Logger").Logger} Logger */
+/** @typedef {import("../util/fs").IntermediateFileSystem} IntermediateFileSystem */
+
 const MAX_INLINE_SIZE = 20000;
 
 class PackContainer {
+	/**
+	 * @param {Object} data stored data
+	 * @param {string} version version identifier
+	 * @param {FileSystemInfo.Snapshot} buildSnapshot snapshot of all build dependencies
+	 * @param {Set<string>} buildDependencies list of all unresolved build dependencies captured
+	 * @param {Map<string, string>} resolveResults result of the resolved build dependencies
+	 * @param {FileSystemInfo.Snapshot} resolveBuildDependenciesSnapshot snapshot of the dependencies of the build dependencies resolving
+	 */
 	constructor(
 		data,
 		version,
@@ -151,6 +162,16 @@ class Pack {
 		this.logger = logger;
 		this.etags = read();
 		this.unserializable = read();
+		// Mark the first 1% of the items for retry
+		// If they still fail they are added to the back again
+		// Eventually all items are retried, but not too many at the same time
+		if (this.unserializable.size > 0) {
+			let i = Math.ceil(this.unserializable.size / 100);
+			for (const item of this.unserializable) {
+				this.unserializable.delete(item);
+				if (--i <= 0) break;
+			}
+		}
 		this.lastAccess = read();
 		this.content = new Map();
 		let identifier = read();
@@ -220,7 +241,8 @@ class PackEntry {
 		} catch (err) {
 			if (err !== NOT_SERIALIZABLE) {
 				logger.warn(
-					`Caching failed for ${this.identifier}: ${err}\nWe will not try to cache this entry again until the cache file is deleted.`
+					`Caching failed for ${this.identifier}: ${err}\n` +
+						"We will try to cache this entry again once in a while or when the cache file is deleted."
 				);
 				logger.debug(err.stack);
 			}
@@ -244,6 +266,16 @@ makeSerializable(
 );
 
 class PackFileCacheStrategy {
+	/**
+	 * @param {Object} options options
+	 * @param {IntermediateFileSystem} options.fs the filesystem
+	 * @param {string} options.context the context directory
+	 * @param {string} options.cacheLocation the location of the cache data
+	 * @param {string} options.version version identifier
+	 * @param {Logger} options.logger a logger
+	 * @param {Iterable<string>} options.managedPaths paths managed only by package manager
+	 * @param {Iterable<string>} options.immutablePaths immutable paths
+	 */
 	constructor({
 		fs,
 		context,
@@ -262,20 +294,34 @@ class PackFileCacheStrategy {
 		this.cacheLocation = cacheLocation;
 		this.version = version;
 		this.logger = logger;
+		/** @type {Set<string>} */
 		this.buildDependencies = new Set();
+		/** @type {LazySet<string>} */
 		this.newBuildDependencies = new LazySet();
+		/** @type {FileSystemInfo.Snapshot} */
 		this.resolveBuildDependenciesSnapshot = undefined;
+		/** @type {Map<string, string>} */
 		this.resolveResults = undefined;
+		/** @type {FileSystemInfo.Snapshot} */
 		this.buildSnapshot = undefined;
+		/** @type {Promise<Pack>} */
 		this.packPromise = this._openPack();
 	}
 
+	/**
+	 * @returns {Promise<Pack>} the pack
+	 */
 	_openPack() {
 		const { logger, cacheLocation, version } = this;
+		/** @type {FileSystemInfo.Snapshot} */
 		let buildSnapshot;
+		/** @type {Set<string>} */
 		let buildDependencies;
+		/** @type {Set<string>} */
 		let newBuildDependencies;
+		/** @type {FileSystemInfo.Snapshot} */
 		let resolveBuildDependenciesSnapshot;
+		/** @type {Map<string, string>} */
 		let resolveResults;
 		logger.time("restore pack container");
 		return this.fileSerializer
@@ -404,6 +450,13 @@ class PackFileCacheStrategy {
 					return pack;
 				}
 				return new Pack(logger);
+			})
+			.catch(err => {
+				this.logger.warn(
+					`Restoring pack from ${cacheLocation}.pack failed: ${err}`
+				);
+				this.logger.debug(err.stack);
+				return new Pack(logger);
 			});
 	}
 
@@ -432,129 +485,134 @@ class PackFileCacheStrategy {
 	}
 
 	afterAllStored() {
-		return this.packPromise.then(pack => {
-			if (!pack.invalid) return;
-			this.logger.log(`Storing pack...`);
-			let promise;
-			const newBuildDependencies = new Set();
-			for (const dep of this.newBuildDependencies) {
-				if (!this.buildDependencies.has(dep)) {
-					newBuildDependencies.add(dep);
-					this.buildDependencies.add(dep);
+		return this.packPromise
+			.then(pack => {
+				if (!pack.invalid) return;
+				this.logger.log(`Storing pack...`);
+				let promise;
+				const newBuildDependencies = new Set();
+				for (const dep of this.newBuildDependencies) {
+					if (!this.buildDependencies.has(dep)) {
+						newBuildDependencies.add(dep);
+						this.buildDependencies.add(dep);
+					}
 				}
-			}
-			this.newBuildDependencies.clear();
-			if (newBuildDependencies.size > 0) {
-				this.logger.debug(
-					`Capturing build dependencies... (${Array.from(
-						newBuildDependencies
-					).join(", ")})`
-				);
-				promise = new Promise((resolve, reject) => {
-					this.logger.time("resolve build dependencies");
-					this.fileSystemInfo.resolveBuildDependencies(
-						this.context,
-						newBuildDependencies,
-						(err, result) => {
-							if (err) return reject(err);
-							this.logger.timeEnd("resolve build dependencies");
-
-							this.logger.time("snapshot build dependencies");
-							const {
-								files,
-								directories,
-								missing,
-								resolveResults,
-								resolveDependencies
-							} = result;
-							if (this.resolveResults) {
-								for (const [key, value] of resolveResults) {
-									this.resolveResults.set(key, value);
-								}
-							} else {
-								this.resolveResults = resolveResults;
-							}
-							this.fileSystemInfo.createSnapshot(
-								undefined,
-								resolveDependencies.files,
-								resolveDependencies.directories,
-								resolveDependencies.missing,
-								{},
-								(err, snapshot) => {
-									if (err) {
-										this.logger.timeEnd("snapshot build dependencies");
-										return reject(err);
-									}
-									if (this.resolveBuildDependenciesSnapshot) {
-										this.resolveBuildDependenciesSnapshot = this.fileSystemInfo.mergeSnapshots(
-											this.resolveBuildDependenciesSnapshot,
-											snapshot
-										);
-									} else {
-										this.resolveBuildDependenciesSnapshot = snapshot;
-									}
-									this.fileSystemInfo.createSnapshot(
-										undefined,
-										files,
-										directories,
-										missing,
-										{ hash: true },
-										(err, snapshot) => {
-											this.logger.timeEnd("snapshot build dependencies");
-											if (err) return reject(err);
-											this.logger.debug("Captured build dependencies");
-
-											if (this.buildSnapshot) {
-												this.buildSnapshot = this.fileSystemInfo.mergeSnapshots(
-													this.buildSnapshot,
-													snapshot
-												);
-											} else {
-												this.buildSnapshot = snapshot;
-											}
-
-											resolve();
-										}
-									);
-								}
-							);
-						}
+				this.newBuildDependencies.clear();
+				if (newBuildDependencies.size > 0 || !this.buildSnapshot) {
+					this.logger.debug(
+						`Capturing build dependencies... (${Array.from(
+							newBuildDependencies
+						).join(", ")})`
 					);
-				});
-			} else {
-				promise = Promise.resolve();
-			}
-			return promise.then(() => {
-				this.logger.time(`store pack`);
-				pack.collectGarbage(1000 * 60 * 60 * 24 * 2);
-				const content = new PackContainer(
-					() => pack,
-					this.version,
-					this.buildSnapshot,
-					this.buildDependencies,
-					this.resolveResults,
-					this.resolveBuildDependenciesSnapshot
-				);
-				// You might think this breaks all access to the existing pack
-				// which are still referenced, but serializing the pack memorizes
-				// all data in the pack and makes it no longer need the backing file
-				// So it's safe to replace the pack file
-				return this.fileSerializer
-					.serialize(content, {
-						filename: `${this.cacheLocation}.pack`,
-						logger: this.logger
-					})
-					.then(() => {
-						this.logger.timeEnd(`store pack`);
-						this.logger.log(`Stored pack`);
-					})
-					.catch(err => {
-						this.logger.timeEnd(`store pack`);
-						this.logger.warn(`Caching failed for pack: ${err}`);
-						this.logger.debug(err.stack);
+					promise = new Promise((resolve, reject) => {
+						this.logger.time("resolve build dependencies");
+						this.fileSystemInfo.resolveBuildDependencies(
+							this.context,
+							newBuildDependencies,
+							(err, result) => {
+								this.logger.timeEnd("resolve build dependencies");
+								if (err) return reject(err);
+
+								this.logger.time("snapshot build dependencies");
+								const {
+									files,
+									directories,
+									missing,
+									resolveResults,
+									resolveDependencies
+								} = result;
+								if (this.resolveResults) {
+									for (const [key, value] of resolveResults) {
+										this.resolveResults.set(key, value);
+									}
+								} else {
+									this.resolveResults = resolveResults;
+								}
+								this.fileSystemInfo.createSnapshot(
+									undefined,
+									resolveDependencies.files,
+									resolveDependencies.directories,
+									resolveDependencies.missing,
+									{},
+									(err, snapshot) => {
+										if (err) {
+											this.logger.timeEnd("snapshot build dependencies");
+											return reject(err);
+										}
+										if (this.resolveBuildDependenciesSnapshot) {
+											this.resolveBuildDependenciesSnapshot = this.fileSystemInfo.mergeSnapshots(
+												this.resolveBuildDependenciesSnapshot,
+												snapshot
+											);
+										} else {
+											this.resolveBuildDependenciesSnapshot = snapshot;
+										}
+										this.fileSystemInfo.createSnapshot(
+											undefined,
+											files,
+											directories,
+											missing,
+											{ hash: true },
+											(err, snapshot) => {
+												this.logger.timeEnd("snapshot build dependencies");
+												if (err) return reject(err);
+												this.logger.debug("Captured build dependencies");
+
+												if (this.buildSnapshot) {
+													this.buildSnapshot = this.fileSystemInfo.mergeSnapshots(
+														this.buildSnapshot,
+														snapshot
+													);
+												} else {
+													this.buildSnapshot = snapshot;
+												}
+
+												resolve();
+											}
+										);
+									}
+								);
+							}
+						);
 					});
+				} else {
+					promise = Promise.resolve();
+				}
+				return promise.then(() => {
+					this.logger.time(`store pack`);
+					pack.collectGarbage(1000 * 60 * 60 * 24 * 2);
+					const content = new PackContainer(
+						() => pack,
+						this.version,
+						this.buildSnapshot,
+						this.buildDependencies,
+						this.resolveResults,
+						this.resolveBuildDependenciesSnapshot
+					);
+					// You might think this breaks all access to the existing pack
+					// which are still referenced, but serializing the pack memorizes
+					// all data in the pack and makes it no longer need the backing file
+					// So it's safe to replace the pack file
+					return this.fileSerializer
+						.serialize(content, {
+							filename: `${this.cacheLocation}.pack`,
+							logger: this.logger
+						})
+						.then(() => {
+							this.logger.timeEnd(`store pack`);
+							this.logger.log(`Stored pack`);
+						})
+						.catch(err => {
+							this.logger.timeEnd(`store pack`);
+							this.logger.warn(`Caching failed for pack: ${err}`);
+							this.logger.debug(err.stack);
+						});
+				});
+			})
+			.catch(err => {
+				this.logger.warn(`Caching failed for pack: ${err}`);
+				this.logger.debug(err.stack);
 			});
-		});
 	}
 }
 

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -23,14 +23,6 @@ const path = require("path");
  */
 
 /**
- * @typedef {Object} IntermediateFileSystemExtras
- * @property {function(string): void} mkdirSync
- * @property {function(string): import("fs").WriteStream} createWriteStream
- */
-
-/** @typedef {OutputFileSystem & IntermediateFileSystemExtras} IntermediateFileSystem */
-
-/**
  * @typedef {Object} InputFileSystem
  * @property {function(string, BufferCallback): void} readFile
  * @property {function(string, StringArrayCallback): void} readdir
@@ -41,6 +33,14 @@ const path = require("path");
  * @property {(function(string, string): string)=} relative
  * @property {(function(string): string)=} dirname
  */
+
+/**
+ * @typedef {Object} IntermediateFileSystemExtras
+ * @property {function(string): void} mkdirSync
+ * @property {function(string): import("fs").WriteStream} createWriteStream
+ */
+
+/** @typedef {InputFileSystem & OutputFileSystem & IntermediateFileSystemExtras} IntermediateFileSystem */
 
 /**
  *

--- a/test/TestCasesCacheInstant.test.js
+++ b/test/TestCasesCacheInstant.test.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const { describeCases } = require("./TestCases.template");
 
 describe("TestCases", () => {
@@ -5,7 +6,8 @@ describe("TestCases", () => {
 		name: "cache instant",
 		cache: {
 			type: "filesystem",
-			store: "instant"
+			store: "instant",
+			managedPaths: [path.resolve(__dirname, "../node_modules")]
 		}
 	});
 });

--- a/test/TestCasesCachePack.test.js
+++ b/test/TestCasesCachePack.test.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const { describeCases } = require("./TestCases.template");
 
 describe("TestCases", () => {
@@ -5,7 +6,8 @@ describe("TestCases", () => {
 		name: "cache pack",
 		cache: {
 			type: "filesystem",
-			store: "pack"
+			store: "pack",
+			managedPaths: [path.resolve(__dirname, "../node_modules")]
 		},
 		optimization: {
 			innerGraph: true,


### PR DESCRIPTION
improve error handling in pack file cache strategy
support context timestamp snapshot
make ContextModule serializable
fix snapshotting bug of managed paths
use managed and immutable path info for context hashes and timestamps
enabled managedPaths for node_modules during cache tests

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfixes
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
existing tests
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
