### PR TITLE
fix: check the asset's existence before running filter

### DIFF
--- a/lib/performance/SizeLimitsPlugin.js
+++ b/lib/performance/SizeLimitsPlugin.js
@@ -40,6 +40,7 @@ module.exports = class SizeLimitsPlugin {
 				entrypoint.getFiles().reduce((currentSize, file) => {
 					const asset = compilation.getAsset(file);
 					if (
+						asset &&
 						assetFilter(asset.name, asset.source, asset.info) &&
 						asset.source
 					) {


### PR DESCRIPTION
Fixes https://github.com/vuejs/vue-cli/issues/4572

Apparently, the `getAsset()` call is possible to return an `undefined` value.
https://github.com/webpack/webpack/blob/9c6b36787fe43581d6c568e64b71656274c04881/lib/Compilation.js#L2058-L2060

**What kind of change does this PR introduce?**

A bugfix

**Did you add tests for your changes?**

Not sure how to get a minimum reproduction of this case but it's an emergency fix.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

Nothing.