### PR TITLE
perf: cache module size in NormalModule

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -87,6 +87,7 @@ class NormalModule extends Module {
 		// Info from Build
 		this.error = null;
 		this._source = null;
+		this._sourceSize = null;
 		this._buildHash = "";
 		this.buildTimestamp = undefined;
 		/** @private @type {Map<string, CachedSourceEntry>} */
@@ -347,6 +348,7 @@ class NormalModule extends Module {
 					resourceBuffer,
 					sourceMap
 				);
+				this._sourceSize = null;
 				this._ast =
 					typeof extraInfo === "object" &&
 					extraInfo !== null &&
@@ -366,6 +368,7 @@ class NormalModule extends Module {
 		this._source = new RawSource(
 			"throw new Error(" + JSON.stringify(this.error.message) + ");"
 		);
+		this._sourceSize = null;
 		this._ast = null;
 	}
 
@@ -425,6 +428,7 @@ class NormalModule extends Module {
 		this.buildTimestamp = Date.now();
 		this.built = true;
 		this._source = null;
+		this._sourceSize = null;
 		this._ast = null;
 		this._buildHash = "";
 		this.error = null;
@@ -559,7 +563,10 @@ class NormalModule extends Module {
 	}
 
 	size() {
-		return this._source ? this._source.size() : -1;
+		if (this._sourceSize === null) {
+			this._sourceSize = this._source ? this._source.size() : -1;
+		}
+		return this._sourceSize;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

As documented in https://github.com/webpack/webpack/issues/9718, the size function in NormalModule is a critical path with slows down watch mode recompilation. By caching the module size, this performance hit in watch mode can be avoided for modules that have not changed.


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Refactor to improve performance

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
No

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
Nothing

**Profile**
As expected, this shaved about 2s off my incremental compile time (from ~6.5s to ~4.5s)
Before:
![image](https://user-images.githubusercontent.com/1217649/65289575-96999f80-db8e-11e9-9c59-b47439c09b88.png)
After:
![image](https://user-images.githubusercontent.com/1217649/65291327-40305f00-db96-11e9-814b-1858eaed046b.png)
