### PR TITLE
fix(FlagDependencyUsagePlugin): add falsey check to referenceModule

### DIFF
--- a/lib/FlagDependencyUsagePlugin.js
+++ b/lib/FlagDependencyUsagePlugin.js
@@ -80,6 +80,7 @@ class FlagDependencyUsagePlugin {
 						const reference = compilation.getDependencyReference(module, dep);
 						if (!reference) return;
 						const referenceModule = reference.module;
+						if (!referenceModule) return;
 						const importedNames = reference.importedNames;
 						const oldUsed = referenceModule.used;
 						const oldUsedExports = referenceModule.usedExports;


### PR DESCRIPTION
**Why make this change?**
Currently if a user doesn't have "ts-loader" or similar alongside `AureliaPlugin`, an error occurs that doesn't really inform you as to what the problem is.

eg.
```
javascript\node_modules\webpack\lib\FlagDependencyUsagePlugin.js:84
                                                const oldUsed = referenceModule.used;
                                                                                ^

TypeError: Cannot read property 'used' of null
    at processDependency (javascript\node_modules\webpack\lib\FlagDependencyUsagePlugin.js:84:39)
    at processDependenciesBlock (javascript\node_modules\webpack\lib\FlagDependencyUsagePlugin.js:67:8)
```

If I add a falsey check in, then I get an error message that actually helps me resolve the problem I hit.
```
ERROR in ./node_modules/aurelia-webpack-plugin/runtime/empty-entry.js
Module not found: Error: Can't resolve 'tslint-loader' in 'javascript'
 @ ./node_modules/aurelia-webpack-plugin/runtime/empty-entry.js
 @ multi aurelia-webpack-plugin/runtime/empty-entry aurelia-webpack-plugin/runtime/pal-loader-entry aurelia-bootstrapper
Child html-webpack-plugin for "index.html":
```

**Links to related issues**
https://github.com/aurelia/webpack-plugin/issues/95
https://github.com/webpack/webpack/issues/6757

**What kind of change does this PR introduce?**
Bugfix.

**Did you add tests for your changes?**
No.

**Does this PR introduce a breaking change?**
No.

**What needs to be documented once your changes are merged?**
Nothing.