### PR TITLE
New option to "skip initial emit" during watch mode

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -431,7 +431,7 @@ export interface WebpackOptions {
 		/**
 		 * Do not emit an output for the initial build
 		 */
-		skipInitialBuild?: {
+		skipInitialEmit?: {
 			[k: string]: any;
 		};
 		/**

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -429,6 +429,12 @@ export interface WebpackOptions {
 		 */
 		poll?: boolean | number;
 		/**
+		 * Do not emit an output for the initial build
+		 */
+		skipInitialBuild?: {
+			[k: string]: any;
+		};
+		/**
 		 * Stop watching when stdin stream has ended
 		 */
 		stdin?: boolean;

--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -22,9 +22,9 @@ class Watching {
 			this.watchOptions = Object.assign({}, watchOptions);
 		} else {
 			this.watchOptions = {};
-    }
-    this.skipInitialBuild = watchOptions.skipInitialBuild || false
-    this.isInitialBuild = true
+		}
+		this.skipInitialBuild = watchOptions.skipInitialBuild || false;
+		this.isInitialBuild = true;
 		this.watchOptions.aggregateTimeout =
 			this.watchOptions.aggregateTimeout || 200;
 		this.compiler = compiler;
@@ -48,12 +48,12 @@ class Watching {
 
 				if (this.compiler.hooks.shouldEmit.call(compilation) === false) {
 					return this._done(null, compilation);
-        }
-        
-        if (this.skipInitialBuild && this.isInitialBuild) {
-          this.isInitialBuild = false
-          return this._done(null, compilation);
-        }
+				}
+
+				if (this.skipInitialBuild && this.isInitialBuild) {
+					this.isInitialBuild = false;
+					return this._done(null, compilation);
+				}
 
 				this.compiler.emitAssets(compilation, err => {
 					if (err) return this._done(err);

--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -22,7 +22,9 @@ class Watching {
 			this.watchOptions = Object.assign({}, watchOptions);
 		} else {
 			this.watchOptions = {};
-		}
+    }
+    this.skipInitialBuild = watchOptions.skipInitialBuild || false
+    this.isInitialBuild = true
 		this.watchOptions.aggregateTimeout =
 			this.watchOptions.aggregateTimeout || 200;
 		this.compiler = compiler;
@@ -46,7 +48,12 @@ class Watching {
 
 				if (this.compiler.hooks.shouldEmit.call(compilation) === false) {
 					return this._done(null, compilation);
-				}
+        }
+        
+        if (this.skipInitialBuild && this.isInitialBuild) {
+          this.isInitialBuild = false
+          return this._done(null, compilation);
+        }
 
 				this.compiler.emitAssets(compilation, err => {
 					if (err) return this._done(err);

--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -23,7 +23,7 @@ class Watching {
 		} else {
 			this.watchOptions = {};
 		}
-		this.skipInitialBuild = watchOptions.skipInitialBuild || false;
+		this.skipInitialEmit = watchOptions.skipInitialEmit || false;
 		this.isInitialBuild = true;
 		this.watchOptions.aggregateTimeout =
 			this.watchOptions.aggregateTimeout || 200;
@@ -50,7 +50,7 @@ class Watching {
 					return this._done(null, compilation);
 				}
 
-				if (this.skipInitialBuild && this.isInitialBuild) {
+				if (this.skipInitialEmit && this.isInitialBuild) {
 					this.isInitialBuild = false;
 					return this._done(null, compilation);
 				}

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2248,9 +2248,6 @@
         "ignored": {
           "description": "Ignore some files from watching"
         },
-        "skipInitialBuild": {
-          "description": "Do not emit an output for the initial build"
-        },
         "poll": {
           "description": "Enable polling mode for watching",
           "anyOf": [
@@ -2263,6 +2260,9 @@
               "type": "number"
             }
           ]
+        },
+        "skipInitialBuild": {
+          "description": "Do not emit an output for the initial build"
         },
         "stdin": {
           "description": "Stop watching when stdin stream has ended",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2261,7 +2261,7 @@
             }
           ]
         },
-        "skipInitialBuild": {
+        "skipInitialEmit": {
           "description": "Do not emit an output for the initial build"
         },
         "stdin": {

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2248,6 +2248,9 @@
         "ignored": {
           "description": "Ignore some files from watching"
         },
+        "skipInitialBuild": {
+          "description": "Do not emit an output for the initial build"
+        },
         "poll": {
           "description": "Enable polling mode for watching",
           "anyOf": [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This pull request introduces a new option to the watchOptions allowing users to skip the initial emit when using webpack in watch mode.

The use case for this is developers which work on projects that build multiple packages using multiple watch instances of webpack. In these scenarios it's important to get the initial compilation order correct. 

Currently, webpack in watch mode will emit assets along with the initial build. When working with multiple packages which depend on each other, the initial emit can cause a waterfall of packages building and rebuilding as their dependencies build out of order. 

While the situation eventually stabilizes, it does result in long startup times and many unnecessary package rebuilds.

Babel provides a --skip-initial-build flag to solve this issue:
![image](https://user-images.githubusercontent.com/12656294/65605034-c19b4d80-dfeb-11e9-887c-f2ea9d36cb44.png) 

https://github.com/webpack/webpack/issues/9730

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Feature

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No breaking changes

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

https://webpack.js.org/configuration/watch/

needs to be updated with a new option

`watchOptions.skipInitialEmit`

`boolean = false`

Turn on skipping the initial assets emit when running the initial build. This means that webpack won't output any assets on the first pass, but will continue to watch for changes in any of the resolved files, building normally after it detects a change.

webpack.config.js

```javascript
module.exports = {
  //...
  watchOptions: {
    skipInitialEmit: false
  }
};
```

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
