### PR TITLE
Remove trailing whitespace from banners

### DIFF
--- a/lib/BannerPlugin.js
+++ b/lib/BannerPlugin.js
@@ -22,7 +22,9 @@ const wrapComment = str => {
 	return `/*!\n * ${str
 		.replace(/\*\//g, "* /")
 		.split("\n")
-		.join("\n * ")}\n */`;
+		.join("\n * ")
+		.replace(/\s+\n/g, "\n")
+		.trimRight()}\n */`;
 };
 
 class BannerPlugin {

--- a/test/configCases/plugins/banner-plugin/index.js
+++ b/test/configCases/plugins/banner-plugin/index.js
@@ -7,6 +7,8 @@ it("should contain banner in bundle0 chunk", () => {
 	expect(source).toMatch("banner is a string");
 	expect(source).toMatch("banner is a function");
 	expect(source).toMatch("/*!\n * multiline\n * banner\n * bundle0\n */");
+	expect(source).toMatch("/*!\n * trim trailing whitespace\n *\n * trailing whitespace\n */");
+	expect(source).toMatch("/*!\n * trim trailing whitespace\n *\n * no trailing whitespace\n */");
 });
 
 it("should not contain banner in vendors chunk", () => {

--- a/test/configCases/plugins/banner-plugin/webpack.config.js
+++ b/test/configCases/plugins/banner-plugin/webpack.config.js
@@ -20,6 +20,12 @@ module.exports = {
 		}),
 		new webpack.BannerPlugin({
 			banner: ({ chunk }) => `multiline\nbanner\n${chunk.name}`
-		})
+		}),
+		new webpack.BannerPlugin(
+			"trim trailing whitespace\t \n\ntrailing whitespace "
+		),
+		new webpack.BannerPlugin(
+			"trim trailing whitespace\t \n\nno trailing whitespace"
+		)
 	]
 };


### PR DESCRIPTION
- Trailing whitespace isn't trimmed from the banners.
- The banner plugin itself generates a trailing space when an empty newline is added. You can see this in the generated clipboard.js file: https://github.com/zenorocha/clipboard.js/blob/d17eca050e705ae4932fd1be3e96abe38bd3397c/dist/clipboard.js#L4 (caused by the whiteline here https://github.com/zenorocha/clipboard.js/blob/85981026d1f464c9f645ffe543a3ba0d40c9b6c4/webpack.config.js#L10)

Advantages of removing the trailing whitespaces:
- Minor file size improvements
- Prevention of linting errors
- No conflicts when `trim_trailing_whitespace: true` is defined in `.editorconfig`

