### PR TITLE
avoid rewriting source from "module.exports"

### DIFF
--- a/lib/CommonJsStuffPlugin.js
+++ b/lib/CommonJsStuffPlugin.js
@@ -14,6 +14,7 @@ const RuntimeGlobals = require("./RuntimeGlobals");
 const RuntimeModule = require("./RuntimeModule");
 const Template = require("./Template");
 const ModuleDecoratorDependency = require("./dependencies/ModuleDecoratorDependency");
+const RuntimeRequirementsDependency = require("./dependencies/RuntimeRequirementsDependency");
 
 class CommonJsStuffPlugin {
 	apply(compiler) {
@@ -119,9 +120,18 @@ class CommonJsStuffPlugin {
 							const isHarmony =
 								module.buildMeta && module.buildMeta.exportsType;
 							if (!isHarmony) {
+								if (module.moduleArgument === "module") {
+									// avoid rewriting module.exports for backward-compat
+									const dep = new RuntimeRequirementsDependency([
+										RuntimeGlobals.module
+									]);
+									dep.loc = expr.loc;
+									module.addDependency(dep);
+									return true;
+								}
 								return toConstantDependency(
 									parser,
-									`${RuntimeGlobals.module}.exports`,
+									`${module.moduleArgument}.exports`,
 									[RuntimeGlobals.module]
 								)(expr);
 							}

--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const RuntimeGlobals = require("./RuntimeGlobals");
+const RuntimeRequirementsDependency = require("./dependencies/RuntimeRequirementsDependency");
 const CompatGetDefaultExportRuntimeModule = require("./runtime/CompatGetDefaultExportRuntimeModule");
 const CompatRuntimePlugin = require("./runtime/CompatRuntimePlugin");
 const CreateFakeNamespaceObjectRuntimeModule = require("./runtime/CreateFakeNamespaceObjectRuntimeModule");
@@ -57,6 +58,10 @@ class RuntimePlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap("RuntimePlugin", compilation => {
+			compilation.dependencyTemplates.set(
+				RuntimeRequirementsDependency,
+				new RuntimeRequirementsDependency.Template()
+			);
 			for (const req of GLOBALS_ON_REQUIRE) {
 				compilation.hooks.runtimeRequirementInModule
 					.for(req)

--- a/lib/dependencies/RuntimeRequirementsDependency.js
+++ b/lib/dependencies/RuntimeRequirementsDependency.js
@@ -15,19 +15,13 @@ const NullDependency = require("./NullDependency");
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../util/Hash")} Hash */
 
-class ConstDependency extends NullDependency {
+class RuntimeRequirementsDependency extends NullDependency {
 	/**
-	 * @param {string} expression the expression
-	 * @param {TODO} range the source range
-	 * @param {string[]=} runtimeRequirements runtime requirements
+	 * @param {string[]} runtimeRequirements runtime requirements
 	 */
-	constructor(expression, range, runtimeRequirements) {
+	constructor(runtimeRequirements) {
 		super();
-		this.expression = expression;
-		this.range = range;
-		this.runtimeRequirements = runtimeRequirements
-			? new Set(runtimeRequirements)
-			: null;
+		this.runtimeRequirements = new Set(runtimeRequirements);
 	}
 
 	/**
@@ -37,52 +31,40 @@ class ConstDependency extends NullDependency {
 	 * @returns {void}
 	 */
 	updateHash(hash, chunkGraph) {
-		hash.update(this.range + "");
-		hash.update(this.expression + "");
-		if (this.runtimeRequirements)
-			hash.update(Array.from(this.runtimeRequirements).join() + "");
+		hash.update(Array.from(this.runtimeRequirements).join() + "");
 	}
 
 	serialize(context) {
 		const { write } = context;
-		write(this.expression);
-		write(this.range);
 		write(this.runtimeRequirements);
 		super.serialize(context);
 	}
 
 	deserialize(context) {
 		const { read } = context;
-		this.expression = read();
-		this.range = read();
 		this.runtimeRequirements = read();
 		super.deserialize(context);
 	}
 }
 
-makeSerializable(ConstDependency, "webpack/lib/dependencies/ConstDependency");
+makeSerializable(
+	RuntimeRequirementsDependency,
+	"webpack/lib/dependencies/RuntimeRequirementsDependency"
+);
 
-ConstDependency.Template = class ConstDependencyTemplate extends NullDependency.Template {
+RuntimeRequirementsDependency.Template = class RuntimeRequirementsDependencyTemplate extends NullDependency.Template {
 	/**
 	 * @param {Dependency} dependency the dependency for which the template should be applied
 	 * @param {ReplaceSource} source the current replace source which can be modified
 	 * @param {DependencyTemplateContext} templateContext the context object
 	 * @returns {void}
 	 */
-	apply(dependency, source, templateContext) {
-		const dep = /** @type {ConstDependency} */ (dependency);
-		if (dep.runtimeRequirements) {
-			for (const req of dep.runtimeRequirements) {
-				templateContext.runtimeRequirements.add(req);
-			}
+	apply(dependency, source, { runtimeRequirements }) {
+		const dep = /** @type {RuntimeRequirementsDependency} */ (dependency);
+		for (const req of dep.runtimeRequirements) {
+			runtimeRequirements.add(req);
 		}
-		if (typeof dep.range === "number") {
-			source.insert(dep.range, dep.expression);
-			return;
-		}
-
-		source.replace(dep.range[0], dep.range[1] - 1, dep.expression);
 	}
 };
 
-module.exports = ConstDependency;
+module.exports = RuntimeRequirementsDependency;

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -475,7 +475,7 @@ chunk {1} main1.js (main1) 136 bytes (javascript) 632 bytes (runtime) [entry] [r
 `;
 
 exports[`StatsTestCases should print correct stats for chunks 1`] = `
-"Hash: 4436439cc8131820149b
+"Hash: 5756cbf8f707f0d5a5f1
 Time: Xms
 Built at: 1970-04-20 12:42:42
 PublicPath: (none)
@@ -515,7 +515,7 @@ chunk {996} 996.bundle.js 22 bytes <{179}> [rendered]
 `;
 
 exports[`StatsTestCases should print correct stats for chunks-development 1`] = `
-"Hash: 77b8bbe2660211544dac
+"Hash: 98527c7c3217f70970e4
 Time: Xms
 Built at: 1970-04-20 12:42:42
 PublicPath: (none)
@@ -599,7 +599,7 @@ Entrypoint <CLR=BOLD>main</CLR> = <CLR=32>main.js</CLR>
 `;
 
 exports[`StatsTestCases should print correct stats for commons-chunk-min-size-0 1`] = `
-"Hash: 0e635861a0f036e051de
+"Hash: d1649f587002354fd5a7
 Time: Xms
 Built at: 1970-04-20 12:42:42
      Asset       Size  Chunks             Chunk Names
@@ -617,7 +617,7 @@ Entrypoint entry-1 = 429.js entry-1.js
 `;
 
 exports[`StatsTestCases should print correct stats for commons-chunk-min-size-Infinity 1`] = `
-"Hash: c18975c04889dae882be
+"Hash: 4b5c78f51fdc38e21b0c
 Time: Xms
 Built at: 1970-04-20 12:42:42
       Asset       Size  Chunks             Chunk Names
@@ -679,9 +679,9 @@ exports[`StatsTestCases should print correct stats for concat-and-sideeffects 1`
 `;
 
 exports[`StatsTestCases should print correct stats for define-plugin 1`] = `
-"Hash: 0894c8ceded152ef0c3617be7ff34c7a4d0a9952b59e04dfce932199f468
+"Hash: b7433686819002ff5557e30abb0a27b23e5ef5f810a12ab5a88b72ba8949
 Child
-    Hash: 0894c8ceded152ef0c36
+    Hash: b7433686819002ff5557
     Time: Xms
     Built at: 1970-04-20 12:42:42
       Asset      Size  Chunks             Chunk Names
@@ -689,7 +689,7 @@ Child
     Entrypoint main = main.js
     [10] ./index.js 24 bytes {179} [built]
 Child
-    Hash: 17be7ff34c7a4d0a9952
+    Hash: e30abb0a27b23e5ef5f8
     Time: Xms
     Built at: 1970-04-20 12:42:42
       Asset      Size  Chunks             Chunk Names
@@ -697,7 +697,7 @@ Child
     Entrypoint main = main.js
     [10] ./index.js 24 bytes {179} [built]
 Child
-    Hash: b59e04dfce932199f468
+    Hash: 10a12ab5a88b72ba8949
     Time: Xms
     Built at: 1970-04-20 12:42:42
       Asset      Size  Chunks             Chunk Names
@@ -730,7 +730,7 @@ Unexpected end of JSON input while parsing near ''
 `;
 
 exports[`StatsTestCases should print correct stats for exclude-with-loader 1`] = `
-"Hash: e7241cbada0eeb05f717
+"Hash: 050794affc0ffe94f520
 Time: Xms
 Built at: 1970-04-20 12:42:42
     Asset      Size  Chunks             Chunk Names
@@ -1127,7 +1127,7 @@ Entrypoint entry = entry.js
 `;
 
 exports[`StatsTestCases should print correct stats for import-weak 1`] = `
-"Hash: 2a841d7deec397de60bd
+"Hash: e3660a0cc6734fbb1505
 Time: Xms
 Built at: 1970-04-20 12:42:42
    Asset       Size  Chunks             Chunk Names
@@ -1207,9 +1207,9 @@ Child
 `;
 
 exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 1`] = `
-"Hash: 3a558376d6859ae4fee5cace93b985cb238d6a349cfb067d50d9182c1a3e58dff26218f0a5c2a313
+"Hash: 72e3afd3c8f1c78df1fe3d4bfe87eb6dcaf3bdda995f686c43f5572d40bb51e0b68951b55844679f
 Child 1 chunks:
-    Hash: 3a558376d6859ae4fee5
+    Hash: 72e3afd3c8f1c78df1fe
     Time: Xms
     Built at: 1970-04-20 12:42:42
         Asset      Size  Chunks             Chunk Names
@@ -1224,7 +1224,7 @@ Child 1 chunks:
      [996] ./b.js 22 bytes {179} [built]
          + 3 hidden chunk modules
 Child 2 chunks:
-    Hash: cace93b985cb238d6a34
+    Hash: 3d4bfe87eb6dcaf3bdda
     Time: Xms
     Built at: 1970-04-20 12:42:42
             Asset       Size  Chunks             Chunk Names
@@ -1241,7 +1241,7 @@ Child 2 chunks:
      [847] ./a.js 22 bytes {459} [built]
      [996] ./b.js 22 bytes {459} [built]
 Child 3 chunks:
-    Hash: 9cfb067d50d9182c1a3e
+    Hash: 995f686c43f5572d40bb
     Time: Xms
     Built at: 1970-04-20 12:42:42
             Asset       Size  Chunks             Chunk Names
@@ -1260,7 +1260,7 @@ Child 3 chunks:
      [390] ./e.js 22 bytes {524} [built]
      [767] ./d.js 22 bytes {524} [built]
 Child 4 chunks:
-    Hash: 58dff26218f0a5c2a313
+    Hash: 51e0b68951b55844679f
     Time: Xms
     Built at: 1970-04-20 12:42:42
             Asset       Size  Chunks             Chunk Names
@@ -1380,7 +1380,7 @@ Entrypoint main = main.js
 `;
 
 exports[`StatsTestCases should print correct stats for module-assets 1`] = `
-"Hash: a026b5a7dcf66c58e74d
+"Hash: a1a36956f7f4fca9630a
 Time: Xms
 Built at: 1970-04-20 12:42:42
   Asset       Size          Chunks             Chunk Names
@@ -1653,7 +1653,7 @@ Child
 `;
 
 exports[`StatsTestCases should print correct stats for named-chunks-plugin 1`] = `
-"Hash: e094972a803b1b027bf5
+"Hash: 960063efd6e79ebd259a
 Time: Xms
 Built at: 1970-04-20 12:42:42
     Asset       Size    Chunks             Chunk Names
@@ -1668,7 +1668,7 @@ Entrypoint entry = vendor.js entry.js
 `;
 
 exports[`StatsTestCases should print correct stats for named-chunks-plugin-async 1`] = `
-"Hash: 0e265d28132d3ae56bd9
+"Hash: 3437ccb9f49043d502df
 Time: Xms
 Built at: 1970-04-20 12:42:42
           Asset       Size          Chunks             Chunk Names
@@ -1775,9 +1775,9 @@ You may need an appropriate loader to handle this file type, currently no loader
 `;
 
 exports[`StatsTestCases should print correct stats for performance-different-mode-and-target 1`] = `
-"Hash: 950450432c532ddade1d3b8a89823c06acf09e4e51a0d78bf427aba41f1befbd897dbc4fa1909880281e265e99d4bce5a6b4efbd897dbc4fa190988051a0d78bf427aba41f1b
+"Hash: dbaec22adac82c86940d179928f3901e6d3ca12217195e054032125fa93172df876dbad6789945e72a35b72f00a0da65cde172df876dbad6789945e717195e054032125fa931
 Child
-    Hash: 950450432c532ddade1d
+    Hash: dbaec22adac82c86940d
     Time: Xms
     Built at: 1970-04-20 12:42:42
                  Asset     Size  Chunks                    Chunk Names
@@ -1800,7 +1800,7 @@ Child
     For more info visit https://webpack.js.org/guides/code-splitting/
 
 Child
-    Hash: 3b8a89823c06acf09e4e
+    Hash: 179928f3901e6d3ca122
     Time: Xms
     Built at: 1970-04-20 12:42:42
                        Asset     Size  Chunks                    Chunk Names
@@ -1823,7 +1823,7 @@ Child
     For more info visit https://webpack.js.org/guides/code-splitting/
 
 Child
-    Hash: 51a0d78bf427aba41f1b
+    Hash: 17195e054032125fa931
     Time: Xms
     Built at: 1970-04-20 12:42:42
                      Asset     Size  Chunks             Chunk Names
@@ -1831,7 +1831,7 @@ Child
     Entrypoint main = no-warning.pro-node.js
     [10] ./index.js 293 KiB {179} [built]
 Child
-    Hash: efbd897dbc4fa1909880
+    Hash: 72df876dbad6789945e7
     Time: Xms
     Built at: 1970-04-20 12:42:42
                     Asset      Size  Chunks             Chunk Names
@@ -1839,7 +1839,7 @@ Child
     Entrypoint main = no-warning.dev-web.js
     [./index.js] 293 KiB {main} [built]
 Child
-    Hash: 281e265e99d4bce5a6b4
+    Hash: 2a35b72f00a0da65cde1
     Time: Xms
     Built at: 1970-04-20 12:42:42
                      Asset      Size  Chunks             Chunk Names
@@ -1847,7 +1847,7 @@ Child
     Entrypoint main = no-warning.dev-node.js
     [./index.js] 293 KiB {main} [built]
 Child
-    Hash: efbd897dbc4fa1909880
+    Hash: 72df876dbad6789945e7
     Time: Xms
     Built at: 1970-04-20 12:42:42
                                    Asset      Size  Chunks                    Chunk Names
@@ -1855,7 +1855,7 @@ Child
     Entrypoint main [big] = no-warning.dev-web-with-limit-set.js
     [./index.js] 293 KiB {main} [built]
 Child
-    Hash: 51a0d78bf427aba41f1b
+    Hash: 17195e054032125fa931
     Time: Xms
     Built at: 1970-04-20 12:42:42
                                  Asset     Size  Chunks                    Chunk Names
@@ -2070,7 +2070,7 @@ exports[`StatsTestCases should print correct stats for preset-detailed 1`] = `
   <+> [LogTestPlugin] Collaped group
       [LogTestPlugin] Log
     [LogTestPlugin] End
-Hash: 1c1fd7ec63fc869590d5
+Hash: 0a20d6f125d2b18d53a4
 Time: Xms
 Built at: 1970-04-20 12:42:42
 PublicPath: (none)
@@ -2186,7 +2186,7 @@ exports[`StatsTestCases should print correct stats for preset-normal 1`] = `
 "<e> [LogTestPlugin] Error
 <w> [LogTestPlugin] Warning
 <i> [LogTestPlugin] Info
-Hash: 1c1fd7ec63fc869590d5
+Hash: 0a20d6f125d2b18d53a4
 Time: Xms
 Built at: 1970-04-20 12:42:42
   Asset       Size  Chunks             Chunk Names
@@ -2248,9 +2248,9 @@ Built at: 1970-04-20 <CLR=BOLD>12:42:42</CLR>
      <CLR=32,BOLD>460.js</CLR>  338 bytes    {<CLR=33,BOLD>460</CLR>}  <CLR=32,BOLD>[emitted]</CLR>
  <CLR=32,BOLD>460.js.map</CLR>  212 bytes  ({<CLR=33,BOLD>460</CLR>})  <CLR=32,BOLD>[emitted]</CLR> <CLR=32,BOLD>[dev]</CLR>
      <CLR=32,BOLD>524.js</CLR>  242 bytes    {<CLR=33,BOLD>524</CLR>}  <CLR=32,BOLD>[emitted]</CLR>
- <CLR=32,BOLD>524.js.map</CLR>  228 bytes  ({<CLR=33,BOLD>524</CLR>})  <CLR=32,BOLD>[emitted]</CLR> <CLR=32,BOLD>[dev]</CLR>
+ <CLR=32,BOLD>524.js.map</CLR>  218 bytes  ({<CLR=33,BOLD>524</CLR>})  <CLR=32,BOLD>[emitted]</CLR> <CLR=32,BOLD>[dev]</CLR>
      <CLR=32,BOLD>996.js</CLR>  174 bytes    {<CLR=33,BOLD>996</CLR>}  <CLR=32,BOLD>[emitted]</CLR>
- <CLR=32,BOLD>996.js.map</CLR>  163 bytes  ({<CLR=33,BOLD>996</CLR>})  <CLR=32,BOLD>[emitted]</CLR> <CLR=32,BOLD>[dev]</CLR>
+ <CLR=32,BOLD>996.js.map</CLR>  158 bytes  ({<CLR=33,BOLD>996</CLR>})  <CLR=32,BOLD>[emitted]</CLR> <CLR=32,BOLD>[dev]</CLR>
     <CLR=33,BOLD>main.js</CLR>    <CLR=33,BOLD>301 KiB</CLR>    {<CLR=33,BOLD>179</CLR>}  <CLR=32,BOLD>[emitted]</CLR>        <CLR=33,BOLD>[big]</CLR>  main
 <CLR=32,BOLD>main.js.map</CLR>   1.72 MiB  ({<CLR=33,BOLD>179</CLR>})  <CLR=32,BOLD>[emitted]</CLR> <CLR=32,BOLD>[dev]</CLR>         (main)
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> = <CLR=32,BOLD>main.js</CLR> (<CLR=32,BOLD>main.js.map</CLR>)
@@ -2287,7 +2287,7 @@ exports[`StatsTestCases should print correct stats for preset-verbose 1`] = `
           [LogTestPlugin] Inner inner message
       [LogTestPlugin] Log
     [LogTestPlugin] End
-Hash: 1c1fd7ec63fc869590d5
+Hash: 0a20d6f125d2b18d53a4
 Time: Xms
 Built at: 1970-04-20 12:42:42
 PublicPath: (none)
@@ -2473,7 +2473,7 @@ Entrypoint e2 = runtime.js e2.js"
 `;
 
 exports[`StatsTestCases should print correct stats for scope-hoisting-bailouts 1`] = `
-"Hash: 80e6a6b8445b89224799
+"Hash: 0666d0385f5a64917df0
 Time: Xms
 Built at: 1970-04-20 12:42:42
 Entrypoint index = index.js


### PR DESCRIPTION
this ensures backward-compat for plugins that
rewrite `module._source` after a simple module
is already parsed and dependencies point to
ranges in the old source.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
compat
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
