### PR TITLE
Feat improve ecma version option

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1199,7 +1199,7 @@ export interface OutputOptions {
 	/**
 	 * The maximum EcmaScript version of the webpack generated code (doesn't include input source code from modules).
 	 */
-	ecmaVersion?: 5 | number;
+	ecmaVersion?: number | 2009;
 	/**
 	 * Specifies the name of each output file on disk. You must **not** specify an absolute path here! The `output.path` option determines the location on disk the files are written to, filename is used solely for naming the individual files.
 	 */

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -40,15 +40,15 @@ class RuntimeTemplate {
 	}
 
 	supportsConst() {
-		return this.outputOptions.ecmaVersion >= 2015;
+		return this.outputOptions.ecmaVersion >= 6;
 	}
 
 	supportsArrowFunction() {
-		return this.outputOptions.ecmaVersion >= 2015;
+		return this.outputOptions.ecmaVersion >= 6;
 	}
 
 	supportsForOf() {
-		return this.outputOptions.ecmaVersion >= 2015;
+		return this.outputOptions.ecmaVersion >= 6;
 	}
 
 	returningFunction(returnValue, args = "") {

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -9,6 +9,7 @@ const path = require("path");
 const pkgDir = require("pkg-dir");
 const OptionsDefaulter = require("./OptionsDefaulter");
 const Template = require("./Template");
+const normalizeEcmaVersion = require("./util/normalizeEcmaVersion");
 
 const NODE_MODULES_REGEXP = /[\\/]node_modules[\\/]/i;
 
@@ -206,7 +207,13 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 			options => options.experiments.outputModule
 		);
 		this.set("output.iife", "make", options => !options.output.module);
-		this.set("output.ecmaVersion", 2015);
+		this.set("output.ecmaVersion", "call", value => {
+			if (value) {
+				return normalizeEcmaVersion(value);
+			}
+
+			return 6;
+		});
 		this.set("output.chunkFilename", "make", options => {
 			const filename = options.output.filename;
 			if (typeof filename !== "function") {
@@ -446,10 +453,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 								options.plugins.some(p => p instanceof SourceMapDevToolPlugin)),
 						terserOptions: {
 							module: options.output.module,
-							ecma:
-								options.output.ecmaVersion > 2000
-									? options.output.ecmaVersion - 2009
-									: options.output.ecmaVersion
+							ecma: options.output.ecmaVersion
 						}
 					}).apply(compiler);
 				}

--- a/lib/util/normalizeEcmaVersion.js
+++ b/lib/util/normalizeEcmaVersion.js
@@ -1,0 +1,25 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+/**
+ * Normalize ECMAScript version
+ * @param {number} ecmaVersion ECMAScript version
+ * @returns {number} normalized ECMAScript version
+ */
+module.exports = ecmaVersion => {
+	let version = ecmaVersion;
+
+	if (version === 2009) {
+		return 5;
+	}
+
+	if (version >= 2015) {
+		version -= 2009;
+	}
+
+	return version;
+};

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1159,11 +1159,17 @@
           "description": "The maximum EcmaScript version of the webpack generated code (doesn't include input source code from modules).",
           "anyOf": [
             {
-              "enum": [5]
+              "type": "number",
+              "minimum": 5,
+              "maximum": 11
+            },
+            {
+              "enum": [2009]
             },
             {
               "type": "number",
-              "minimum": 2015
+              "minimum": 2015,
+              "maximum": 2020
             }
           ]
         },

--- a/test/Schemas.lint.js
+++ b/test/Schemas.lint.js
@@ -45,6 +45,7 @@ describe("Schemas", () => {
 					"enum",
 					"minLength",
 					"minimum",
+					"maximum",
 					"required",
 					"uniqueItems",
 					"minItems",

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -479,4 +479,72 @@ describe("Validation", () => {
 			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, serve?, stats?, target?, watch?, watchOptions? }"
 		`)
 	);
+
+	createTestCase(
+		"ecmaVersion",
+		{
+			output: { ecmaVersion: 2008 }
+		},
+		msg =>
+			expect(msg).toMatchInlineSnapshot(`
+			"Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
+			 - configuration.output.ecmaVersion should be one of these:
+			   number (should be >= 5, should be <= 11) | 2009 | number (should be >= 2015, should be <= 2020)
+			   -> The maximum EcmaScript version of the webpack generated code (doesn't include input source code from modules).
+			   Details:
+			    * configuration.output.ecmaVersion should be <= 11.
+			    * configuration.output.ecmaVersion should be >= 2015."
+		`)
+	);
+
+	createTestCase(
+		"ecmaVersion",
+		{
+			output: { ecmaVersion: 20008 }
+		},
+		msg =>
+			expect(msg).toMatchInlineSnapshot(`
+			"Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
+			 - configuration.output.ecmaVersion should be one of these:
+			   number (should be >= 5, should be <= 11) | 2009 | number (should be >= 2015, should be <= 2020)
+			   -> The maximum EcmaScript version of the webpack generated code (doesn't include input source code from modules).
+			   Details:
+			    * configuration.output.ecmaVersion should be <= 11.
+			    * configuration.output.ecmaVersion should be <= 2020."
+		`)
+	);
+
+	createTestCase(
+		"ecmaVersion",
+		{
+			output: { ecmaVersion: 4 }
+		},
+		msg =>
+			expect(msg).toMatchInlineSnapshot(`
+			"Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
+			 - configuration.output.ecmaVersion should be one of these:
+			   number (should be >= 5, should be <= 11) | 2009 | number (should be >= 2015, should be <= 2020)
+			   -> The maximum EcmaScript version of the webpack generated code (doesn't include input source code from modules).
+			   Details:
+			    * configuration.output.ecmaVersion should be >= 5.
+			    * configuration.output.ecmaVersion should be >= 2015."
+		`)
+	);
+
+	createTestCase(
+		"ecmaVersion",
+		{
+			output: { ecmaVersion: 40 }
+		},
+		msg =>
+			expect(msg).toMatchInlineSnapshot(`
+			"Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
+			 - configuration.output.ecmaVersion should be one of these:
+			   number (should be >= 5, should be <= 11) | 2009 | number (should be >= 2015, should be <= 2020)
+			   -> The maximum EcmaScript version of the webpack generated code (doesn't include input source code from modules).
+			   Details:
+			    * configuration.output.ecmaVersion should be <= 11.
+			    * configuration.output.ecmaVersion should be >= 2015."
+		`)
+	);
 });

--- a/test/configCases/ecmaVersion/2009/index.js
+++ b/test/configCases/ecmaVersion/2009/index.js
@@ -1,0 +1,1 @@
+it("should compile and run the test", function() {});

--- a/test/configCases/ecmaVersion/2009/webpack.config.js
+++ b/test/configCases/ecmaVersion/2009/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	output: {
+		ecmaVersion: 2009
+	}
+};

--- a/test/configCases/ecmaVersion/2015/index.js
+++ b/test/configCases/ecmaVersion/2015/index.js
@@ -1,0 +1,1 @@
+it("should compile and run the test", function() {});

--- a/test/configCases/ecmaVersion/2015/webpack.config.js
+++ b/test/configCases/ecmaVersion/2015/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	output: {
+		ecmaVersion: 2015
+	}
+};

--- a/test/configCases/ecmaVersion/5/index.js
+++ b/test/configCases/ecmaVersion/5/index.js
@@ -1,0 +1,1 @@
+it("should compile and run the test", function() {});

--- a/test/configCases/ecmaVersion/5/webpack.config.js
+++ b/test/configCases/ecmaVersion/5/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	output: {
+		ecmaVersion: 5
+	}
+};

--- a/test/configCases/ecmaVersion/6/index.js
+++ b/test/configCases/ecmaVersion/6/index.js
@@ -1,0 +1,1 @@
+it("should compile and run the test", function() {});

--- a/test/configCases/ecmaVersion/6/webpack.config.js
+++ b/test/configCases/ecmaVersion/6/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	output: {
+		ecmaVersion: 6
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feature

Improvements:
- Allow set `5`-`11` values for `output.ecmaVersion` (better DX, many other tools, like eslint, use the same logic)
- Allow set `2009`-`2020` values for `output.ecmaVersion` (better DX, many other tools, like eslint, use the same logic)
- Always normalize `output.ecmaVersion` - Why? This is very important for those who write plugins because you can set `output.ecmaVersion: 2019` or `output.ecmaVersion: 10` and it will require write own normalize logic, it is often very uncomfortable. We have a similar problem with `devtool` - you can setup words (`cheap`, `inline`, etc) in any order and this forces you to write additional logic, which negatively affects on performance and code look ugly.
- Also number notation (for example `5`/`6`/etc) is easy to understand

**Did you add tests for your changes?**

yes

**Does this PR introduce a breaking change?**

Should be no, one note

It will be a breaking change if developer using `output.ecmaVersion` in plugin and wait year notation
Also maximum yarn notation is `2020`.

**What needs to be documented once your changes are merged?**

- `ecmaVersion` can be `5` - `11`
- `ecmaVersion` can be `2009` - `2020`
