### PR TITLE
fix: limit progress bar length to 40 when no columns provided

### DIFF
--- a/lib/node/nodeConsole.js
+++ b/lib/node/nodeConsole.js
@@ -39,10 +39,8 @@ const clearStatusMessage = () => {
 
 const writeStatusMessage = () => {
 	if (!currentStatusMessage) return;
-	const l = process.stderr.columns;
-	const args = l
-		? truncateArgs(currentStatusMessage, l - 1)
-		: currentStatusMessage;
+	const l = process.stderr.columns || 40;
+	const args = truncateArgs(currentStatusMessage, l - 1);
 	const str = args.join(" ");
 	const coloredStr = `\u001b[1m${str}\u001b[39m\u001b[22m`;
 	process.stderr.write(`\x1b[2K\r${coloredStr}`);

--- a/test/ProgressPlugin.test.js
+++ b/test/ProgressPlugin.test.js
@@ -61,7 +61,7 @@ describe("ProgressPlugin", function() {
 			const logs = getLogs(stderr.toString());
 
 			expect(logs.length).toBeGreaterThan(20);
-			expect(_.maxBy(logs, "length").length).toBeGreaterThan(50);
+			expect(_.maxBy(logs, "length").length).not.toBeGreaterThan(40);
 		});
 	});
 });


### PR DESCRIPTION
See the comment here: https://github.com/webpack/webpack/pull/9225#issuecomment-536501366
There are several cases where `process.stderr.columns` could be `undefined`. Like, in the Vue CLI UI console, or in a CI log page. But that doesn't mean there's infinity room to display the lines. In these cases, we should fall back to **the old behavior** of the `40` max length.

**What kind of change does this PR introduce?**

A bugfix

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing.