### PR TITLE
Do not show stack trace of errors in stats by default

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1500,6 +1500,10 @@ export interface StatsOptions {
 	 */
 	errorDetails?: boolean;
 	/**
+	 * add internal stack trace to errors
+	 */
+	errorStack?: boolean;
+	/**
 	 * add errors
 	 */
 	errors?: boolean;

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -119,12 +119,7 @@ const uniqueOrderedArray = (items, selector, comparator) => {
 
 /** @type {ExtractorsByOption<WebpackError | string>} */
 const EXTRACT_ERROR = {
-	_: (
-		object,
-		error,
-		{ compilation: { chunkGraph, moduleGraph } },
-		{ requestShortener }
-	) => {
+	_: (object, error, context, { requestShortener }) => {
 		// TODO webpack 6 disallow strings in the errors/warnings list
 		if (typeof error === "string") {
 			object.message = error;
@@ -184,6 +179,10 @@ const EXTRACT_ERROR = {
 	errorDetails: (object, error) => {
 		if (typeof error !== "string") {
 			object.details = error.details;
+		}
+	},
+	errorStack: (object, error) => {
+		if (typeof error !== "string") {
 			object.stack = error.stack;
 		}
 	}

--- a/lib/stats/DefaultStatsPresetPlugin.js
+++ b/lib/stats/DefaultStatsPresetPlugin.js
@@ -36,6 +36,7 @@ const NAMED_PRESETS = {
 		providedExports: true,
 		optimizationBailout: true,
 		errorDetails: true,
+		errorStack: true,
 		publicPath: true,
 		logging: "verbose",
 		orphanModules: true,
@@ -147,6 +148,7 @@ const DEFAULTS = {
 	moduleTrace: NORMAL_ON,
 	errors: NORMAL_ON,
 	errorDetails: OFF_FOR_TO_STRING,
+	errorStack: OFF_FOR_TO_STRING,
 	warnings: NORMAL_ON,
 	publicPath: OFF_FOR_TO_STRING,
 	logging: ({ all }, { forToString }) =>

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2087,6 +2087,10 @@
           "description": "add details to errors (like resolving log)",
           "type": "boolean"
         },
+        "errorStack": {
+          "description": "add internal stack trace to errors",
+          "type": "boolean"
+        },
         "errors": {
           "description": "add errors",
           "type": "boolean"

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -132,84 +132,89 @@ it("should emit warning for missingFile", async () => {
 			entry: "./missingFile"
 		})
 	).resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "loc": "4:0-20",
-      "message": "Module not found: Error: Can't resolve './missing' in '<cwd>/test/fixtures/errors'",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/missingFile.js",
-      "moduleName": "./missingFile.js",
-      "moduleTrace": Array [],
-    },
-    Object {
-      "loc": "12:9-34",
-      "message": "Module not found: Error: Can't resolve './dir/missing2' in '<cwd>/test/fixtures/errors'",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/missingFile.js",
-      "moduleName": "./missingFile.js",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "loc": "4:0-20",
+					      "message": "Module not found: Error: Can't resolve './missing' in '<cwd>/test/fixtures/errors'",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/missingFile.js",
+					      "moduleName": "./missingFile.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleNotFoundError: Module not found: Error: Can't resolve './missing' in '<cwd>/test/fixtures/errors'",
+					    },
+					    Object {
+					      "loc": "12:9-34",
+					      "message": "Module not found: Error: Can't resolve './dir/missing2' in '<cwd>/test/fixtures/errors'",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/missingFile.js",
+					      "moduleName": "./missingFile.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleNotFoundError: Module not found: Error: Can't resolve './dir/missing2' in '<cwd>/test/fixtures/errors'",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 });
 
 it("should emit warning for require.extensions", async () => {
 	await expect(compile({ entry: "./require.extensions" })).resolves
 		.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [],
-  "warnings": Array [
-    Object {
-      "loc": "1:0-18",
-      "message": "require.extensions is not supported by webpack. Use a loader instead.",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/require.extensions.js",
-      "moduleName": "./require.extensions.js",
-      "moduleTrace": Array [],
-    },
-  ],
-}
-`);
+					Object {
+					  "errors": Array [],
+					  "warnings": Array [
+					    Object {
+					      "loc": "1:0-18",
+					      "message": "require.extensions is not supported by webpack. Use a loader instead.",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/require.extensions.js",
+					      "moduleName": "./require.extensions.js",
+					      "moduleTrace": Array [],
+					      "stack": "UnsupportedFeatureWarning: require.extensions is not supported by webpack. Use a loader instead.",
+					    },
+					  ],
+					}
+				`);
 });
 
 it("should emit warning for require.main.require", async () => {
 	await expect(compile({ entry: "./require.main.require" })).resolves
 		.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [],
-  "warnings": Array [
-    Object {
-      "loc": "1:0-20",
-      "message": "require.main.require is not supported by webpack.",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/require.main.require.js",
-      "moduleName": "./require.main.require.js",
-      "moduleTrace": Array [],
-    },
-  ],
-}
-`);
+					Object {
+					  "errors": Array [],
+					  "warnings": Array [
+					    Object {
+					      "loc": "1:0-20",
+					      "message": "require.main.require is not supported by webpack.",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/require.main.require.js",
+					      "moduleName": "./require.main.require.js",
+					      "moduleTrace": Array [],
+					      "stack": "UnsupportedFeatureWarning: require.main.require is not supported by webpack.",
+					    },
+					  ],
+					}
+				`);
 });
 it("should emit warning for module.parent.require", async () => {
 	await expect(compile({ entry: "./module.parent.require" })).resolves
 		.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [],
-  "warnings": Array [
-    Object {
-      "loc": "1:0-21",
-      "message": "module.parent.require is not supported by webpack.",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/module.parent.require.js",
-      "moduleName": "./module.parent.require.js",
-      "moduleTrace": Array [],
-    },
-  ],
-}
-`);
+					Object {
+					  "errors": Array [],
+					  "warnings": Array [
+					    Object {
+					      "loc": "1:0-21",
+					      "message": "module.parent.require is not supported by webpack.",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/module.parent.require.js",
+					      "moduleName": "./module.parent.require.js",
+					      "moduleTrace": Array [],
+					      "stack": "UnsupportedFeatureWarning: module.parent.require is not supported by webpack.",
+					    },
+					  ],
+					}
+				`);
 });
 
 const isCaseInsensitiveFilesystem = fs.existsSync(
@@ -222,33 +227,34 @@ if (isCaseInsensitiveFilesystem) {
 			entry: "./case-sensitive"
 		});
 		expect(result).toMatchInlineSnapshot(`
-Object {
-  "errors": Array [],
-  "warnings": Array [
-    Object {
-      "message": "There are multiple modules with names that only differ in casing.\\nThis can lead to unexpected behavior when compiling on a filesystem with other case-semantic.\\nUse equal casing. Compare these module identifiers:\\n* <cwd>/test/fixtures/errors/FILE.js\\n    Used by 1 module(s), i. e.\\n    <cwd>/test/fixtures/errors/case-sensitive.js\\n* <cwd>/test/fixtures/errors/file.js\\n    Used by 1 module(s), i. e.\\n    <cwd>/test/fixtures/errors/case-sensitive.js",
-      "moduleId": "./FILE.js",
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/FILE.js",
-      "moduleName": "./FILE.js",
-      "moduleTrace": Array [
-        Object {
-          "dependencies": Array [
-            Object {
-              "loc": "2:0-17",
-            },
-          ],
-          "moduleId": "./FILE.js",
-          "moduleIdentifier": "<cwd>/test/fixtures/errors/FILE.js",
-          "moduleName": "./FILE.js",
-          "originId": "./case-sensitive.js",
-          "originIdentifier": "<cwd>/test/fixtures/errors/case-sensitive.js",
-          "originName": "./case-sensitive.js",
-        },
-      ],
-    },
-  ],
-}
-`);
+		Object {
+		  "errors": Array [],
+		  "warnings": Array [
+		    Object {
+		      "message": "There are multiple modules with names that only differ in casing.\\nThis can lead to unexpected behavior when compiling on a filesystem with other case-semantic.\\nUse equal casing. Compare these module identifiers:\\n* <cwd>/test/fixtures/errors/FILE.js\\n    Used by 1 module(s), i. e.\\n    <cwd>/test/fixtures/errors/case-sensitive.js\\n* <cwd>/test/fixtures/errors/file.js\\n    Used by 1 module(s), i. e.\\n    <cwd>/test/fixtures/errors/case-sensitive.js",
+		      "moduleId": "./FILE.js",
+		      "moduleIdentifier": "<cwd>/test/fixtures/errors/FILE.js",
+		      "moduleName": "./FILE.js",
+		      "moduleTrace": Array [
+		        Object {
+		          "dependencies": Array [
+		            Object {
+		              "loc": "2:0-17",
+		            },
+		          ],
+		          "moduleId": "./FILE.js",
+		          "moduleIdentifier": "<cwd>/test/fixtures/errors/FILE.js",
+		          "moduleName": "./FILE.js",
+		          "originId": "./case-sensitive.js",
+		          "originIdentifier": "<cwd>/test/fixtures/errors/case-sensitive.js",
+		          "originName": "./case-sensitive.js",
+		        },
+		      ],
+		      "stack": "CaseSensitiveModulesWarning: There are multiple modules with names that only differ in casing.\\nThis can lead to unexpected behavior when compiling on a filesystem with other case-semantic.\\nUse equal casing. Compare these module identifiers:\\n* <cwd>/test/fixtures/errors/FILE.js\\n    Used by 1 module(s), i. e.\\n    <cwd>/test/fixtures/errors/case-sensitive.js\\n* <cwd>/test/fixtures/errors/file.js\\n    Used by 1 module(s), i. e.\\n    <cwd>/test/fixtures/errors/case-sensitive.js",
+		    },
+		  ],
+		}
+	`);
 	});
 } else {
 	it("should emit error for case-sensitive", async () => {
@@ -257,90 +263,95 @@ Object {
 			entry: "./case-sensitive"
 		});
 		expect(result).toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "loc": "2:0-17",
-      "message": "Module not found: Error: Can't resolve './FILE' in '<cwd>/test/fixtures/errors'",
-      "moduleId": "./case-sensitive.js",
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/case-sensitive.js",
-      "moduleName": "./case-sensitive.js",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+		Object {
+		  "errors": Array [
+		    Object {
+		      "loc": "2:0-17",
+		      "message": "Module not found: Error: Can't resolve './FILE' in '<cwd>/test/fixtures/errors'",
+		      "moduleId": "./case-sensitive.js",
+		      "moduleIdentifier": "<cwd>/test/fixtures/errors/case-sensitive.js",
+		      "moduleName": "./case-sensitive.js",
+		      "moduleTrace": Array [],
+		      "stack": "ModuleNotFoundError: Module not found: Error: Can't resolve './FILE' in '<cwd>/test/fixtures/errors'",
+		    },
+		  ],
+		  "warnings": Array [],
+		}
+	`);
 	});
 }
 
 it("should emit warning for undef mode", async () => {
 	await expect(compile({ mode: undefined, entry: "./entry-point" })).resolves
 		.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [],
-  "warnings": Array [
-    Object {
-      "message": "configuration\\nThe 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.\\nYou can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/",
-    },
-  ],
-}
-`);
+					Object {
+					  "errors": Array [],
+					  "warnings": Array [
+					    Object {
+					      "message": "configuration\\nThe 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.\\nYou can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/",
+					      "stack": "NoModeWarning: configuration\\nThe 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.\\nYou can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/",
+					    },
+					  ],
+					}
+				`);
 });
 it("should emit no errors or warnings for no-errors-deprecate", async () => {
 	await expect(compile({ mode: "production", entry: "./no-errors-deprecate" }))
 		.resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [],
+					  "warnings": Array [],
+					}
+				`);
 });
 
 it("should emit errors for missingFile for production", async () => {
 	await expect(compile({ mode: "production", entry: "./missingFile" })).resolves
 		.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "loc": "4:0-20",
-      "message": "Module not found: Error: Can't resolve './missing' in '<cwd>/test/fixtures/errors'",
-      "moduleId": 814,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/missingFile.js",
-      "moduleName": "./missingFile.js",
-      "moduleTrace": Array [],
-    },
-    Object {
-      "loc": "12:9-34",
-      "message": "Module not found: Error: Can't resolve './dir/missing2' in '<cwd>/test/fixtures/errors'",
-      "moduleId": 814,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/missingFile.js",
-      "moduleName": "./missingFile.js",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "loc": "4:0-20",
+					      "message": "Module not found: Error: Can't resolve './missing' in '<cwd>/test/fixtures/errors'",
+					      "moduleId": 814,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/missingFile.js",
+					      "moduleName": "./missingFile.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleNotFoundError: Module not found: Error: Can't resolve './missing' in '<cwd>/test/fixtures/errors'",
+					    },
+					    Object {
+					      "loc": "12:9-34",
+					      "message": "Module not found: Error: Can't resolve './dir/missing2' in '<cwd>/test/fixtures/errors'",
+					      "moduleId": 814,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/missingFile.js",
+					      "moduleName": "./missingFile.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleNotFoundError: Module not found: Error: Can't resolve './dir/missing2' in '<cwd>/test/fixtures/errors'",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 });
 
 it("should emit module build errors", async () => {
 	await expect(compile({ entry: "./has-syntax-error" })).resolves
 		.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "loc": "2:12",
-      "message": "Module parse failed: Unexpected token (2:12)\\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\\n| window.foo = {\\n>   bar: true,;\\n| };\\n| ",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/has-syntax-error.js",
-      "moduleName": "./has-syntax-error.js",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "loc": "2:12",
+					      "message": "Module parse failed: Unexpected token (2:12)\\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\\n| window.foo = {\\n>   bar: true,;\\n| };\\n| ",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/has-syntax-error.js",
+					      "moduleName": "./has-syntax-error.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleParseError: Module parse failed: Unexpected token (2:12)\\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\\n| window.foo = {\\n>   bar: true,;\\n| };\\n| ",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 });
 
 it("should bao; thrown sync error from plugin", async () => {
@@ -350,11 +361,11 @@ it("should bao; thrown sync error from plugin", async () => {
 			plugins: [require("./fixtures/errors/throw-error-plugin")]
 		})
 	).rejects.toMatchInlineSnapshot(`
-Object {
-  "message": "foo",
-  "stack": "Error: foo",
-}
-`);
+					Object {
+					  "message": "foo",
+					  "stack": "Error: foo",
+					}
+				`);
 });
 
 describe("loaders", () => {
@@ -364,324 +375,344 @@ describe("loaders", () => {
 				entry: "./module-level-throw-error-loader!./no-errors-deprecate"
 			})
 		).resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "message": "Module build failed (from ./module-level-throw-error-loader.js):\\nError: this is a thrown error from module level",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/module-level-throw-error-loader.js!<cwd>/test/fixtures/errors/no-errors-deprecate.js",
-      "moduleName": "./module-level-throw-error-loader.js!./no-errors-deprecate.js",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "message": "Module build failed (from ./module-level-throw-error-loader.js):\\nError: this is a thrown error from module level",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/module-level-throw-error-loader.js!<cwd>/test/fixtures/errors/no-errors-deprecate.js",
+					      "moduleName": "./module-level-throw-error-loader.js!./no-errors-deprecate.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleBuildError: Module build failed (from ./module-level-throw-error-loader.js):\\nError: this is a thrown error from module level",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 	});
 	it("should emit errors & warnings for emit-error-loader", async () => {
 		await expect(compile({ entry: "./entry-point-error-loader-required.js" }))
 			.resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "message": "Module Error (from ./emit-error-loader.js):\\nthis is an error",
-      "moduleId": 1,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/emit-error-loader.js!<cwd>/test/fixtures/errors/file.js",
-      "moduleName": "./emit-error-loader.js!./file.js",
-      "moduleTrace": Array [
-        Object {
-          "dependencies": Array [
-            Object {
-              "loc": "1:0-40",
-            },
-          ],
-          "moduleId": 1,
-          "moduleIdentifier": "<cwd>/test/fixtures/errors/emit-error-loader.js!<cwd>/test/fixtures/errors/file.js",
-          "moduleName": "./emit-error-loader.js!./file.js",
-          "originId": 0,
-          "originIdentifier": "<cwd>/test/fixtures/errors/entry-point-error-loader-required.js",
-          "originName": "./entry-point-error-loader-required.js",
-        },
-      ],
-    },
-  ],
-  "warnings": Array [
-    Object {
-      "message": "Module Warning (from ./emit-error-loader.js):\\nthis is a warning",
-      "moduleId": 1,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/emit-error-loader.js!<cwd>/test/fixtures/errors/file.js",
-      "moduleName": "./emit-error-loader.js!./file.js",
-      "moduleTrace": Array [
-        Object {
-          "dependencies": Array [
-            Object {
-              "loc": "1:0-40",
-            },
-          ],
-          "moduleId": 1,
-          "moduleIdentifier": "<cwd>/test/fixtures/errors/emit-error-loader.js!<cwd>/test/fixtures/errors/file.js",
-          "moduleName": "./emit-error-loader.js!./file.js",
-          "originId": 0,
-          "originIdentifier": "<cwd>/test/fixtures/errors/entry-point-error-loader-required.js",
-          "originName": "./entry-point-error-loader-required.js",
-        },
-      ],
-    },
-  ],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "message": "Module Error (from ./emit-error-loader.js):\\nthis is an error",
+					      "moduleId": 1,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/emit-error-loader.js!<cwd>/test/fixtures/errors/file.js",
+					      "moduleName": "./emit-error-loader.js!./file.js",
+					      "moduleTrace": Array [
+					        Object {
+					          "dependencies": Array [
+					            Object {
+					              "loc": "1:0-40",
+					            },
+					          ],
+					          "moduleId": 1,
+					          "moduleIdentifier": "<cwd>/test/fixtures/errors/emit-error-loader.js!<cwd>/test/fixtures/errors/file.js",
+					          "moduleName": "./emit-error-loader.js!./file.js",
+					          "originId": 0,
+					          "originIdentifier": "<cwd>/test/fixtures/errors/entry-point-error-loader-required.js",
+					          "originName": "./entry-point-error-loader-required.js",
+					        },
+					      ],
+					      "stack": "ModuleError: Module Error (from ./emit-error-loader.js):\\nthis is an error",
+					    },
+					  ],
+					  "warnings": Array [
+					    Object {
+					      "message": "Module Warning (from ./emit-error-loader.js):\\nthis is a warning",
+					      "moduleId": 1,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/emit-error-loader.js!<cwd>/test/fixtures/errors/file.js",
+					      "moduleName": "./emit-error-loader.js!./file.js",
+					      "moduleTrace": Array [
+					        Object {
+					          "dependencies": Array [
+					            Object {
+					              "loc": "1:0-40",
+					            },
+					          ],
+					          "moduleId": 1,
+					          "moduleIdentifier": "<cwd>/test/fixtures/errors/emit-error-loader.js!<cwd>/test/fixtures/errors/file.js",
+					          "moduleName": "./emit-error-loader.js!./file.js",
+					          "originId": 0,
+					          "originIdentifier": "<cwd>/test/fixtures/errors/entry-point-error-loader-required.js",
+					          "originName": "./entry-point-error-loader-required.js",
+					        },
+					      ],
+					      "stack": "ModuleWarning: Module Warning (from ./emit-error-loader.js):\\nthis is a warning",
+					    },
+					  ],
+					}
+				`);
 	});
 
 	it("should emit error & warning for emit-error-loader", async () => {
 		await expect(compile({ entry: "./emit-error-loader!./entry-point.js" }))
 			.resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "message": "Module Error (from ./emit-error-loader.js):\\nthis is an error",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/emit-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
-      "moduleName": "./emit-error-loader.js!./entry-point.js",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [
-    Object {
-      "message": "Module Warning (from ./emit-error-loader.js):\\nthis is a warning",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/emit-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
-      "moduleName": "./emit-error-loader.js!./entry-point.js",
-      "moduleTrace": Array [],
-    },
-  ],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "message": "Module Error (from ./emit-error-loader.js):\\nthis is an error",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/emit-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
+					      "moduleName": "./emit-error-loader.js!./entry-point.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleError: Module Error (from ./emit-error-loader.js):\\nthis is an error",
+					    },
+					  ],
+					  "warnings": Array [
+					    Object {
+					      "message": "Module Warning (from ./emit-error-loader.js):\\nthis is a warning",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/emit-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
+					      "moduleName": "./emit-error-loader.js!./entry-point.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleWarning: Module Warning (from ./emit-error-loader.js):\\nthis is a warning",
+					    },
+					  ],
+					}
+				`);
 	});
 	it("should emit error for json-loader when not json", async () => {
 		await expect(compile({ entry: "json-loader!./not-a-json.js" })).resolves
 			.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "message": "Module build failed (from (webpack)/node_modules/json-loader/index.js):\\nSyntaxError: Unexpected end of JSON input",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/node_modules/json-loader/index.js!<cwd>/test/fixtures/errors/not-a-json.js",
-      "moduleName": "(webpack)/node_modules/json-loader!./not-a-json.js",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "message": "Module build failed (from (webpack)/node_modules/json-loader/index.js):\\nSyntaxError: Unexpected end of JSON input",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/node_modules/json-loader/index.js!<cwd>/test/fixtures/errors/not-a-json.js",
+					      "moduleName": "(webpack)/node_modules/json-loader!./not-a-json.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleBuildError: Module build failed (from (webpack)/node_modules/json-loader/index.js):\\nSyntaxError: Unexpected end of JSON input",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 	});
 
 	it("should emit error for async-error-loader", async () => {
 		await expect(compile({ entry: "./async-error-loader!./entry-point.js" }))
 			.resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "message": "Module build failed (from ./async-error-loader.js):\\nError: this is a callback error",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/async-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
-      "moduleName": "./async-error-loader.js!./entry-point.js",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "message": "Module build failed (from ./async-error-loader.js):\\nError: this is a callback error",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/async-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
+					      "moduleName": "./async-error-loader.js!./entry-point.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleBuildError: Module build failed (from ./async-error-loader.js):\\nError: this is a callback error",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 	});
 
 	it("should emit error thrown from raw loader", async () => {
 		await expect(compile({ entry: "./throw-error-loader!./entry-point.js" }))
 			.resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "message": "Module build failed (from ./throw-error-loader.js):\\nError: this is a thrown error",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/throw-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
-      "moduleName": "./throw-error-loader.js!./entry-point.js",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "message": "Module build failed (from ./throw-error-loader.js):\\nError: this is a thrown error",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/throw-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
+					      "moduleName": "./throw-error-loader.js!./entry-point.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleBuildError: Module build failed (from ./throw-error-loader.js):\\nError: this is a thrown error",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 	});
 
 	it("should emit error thrown from pitch loader", async () => {
 		await expect(compile({ entry: "./throw-error-loader!./entry-point.js" }))
 			.resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "message": "Module build failed (from ./throw-error-loader.js):\\nError: this is a thrown error",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/throw-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
-      "moduleName": "./throw-error-loader.js!./entry-point.js",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "message": "Module build failed (from ./throw-error-loader.js):\\nError: this is a thrown error",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/throw-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
+					      "moduleName": "./throw-error-loader.js!./entry-point.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleBuildError: Module build failed (from ./throw-error-loader.js):\\nError: this is a thrown error",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 	});
 	it("should emit error thrown from yaw loader", async () => {
 		await expect(compile({ entry: "./throw-error-loader!./entry-point.js" }))
 			.resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "message": "Module build failed (from ./throw-error-loader.js):\\nError: this is a thrown error",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/throw-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
-      "moduleName": "./throw-error-loader.js!./entry-point.js",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "message": "Module build failed (from ./throw-error-loader.js):\\nError: this is a thrown error",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/throw-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
+					      "moduleName": "./throw-error-loader.js!./entry-point.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleBuildError: Module build failed (from ./throw-error-loader.js):\\nError: this is a thrown error",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 	});
 
 	it("should emit errors & warnings for irregular-error-loader", async () => {
 		await expect(
 			compile({ entry: "./irregular-error-loader!./entry-point.js" })
 		).resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "message": "Module Error (from ./irregular-error-loader.js):\\n(Emitted value instead of an instance of Error) null",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/irregular-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
-      "moduleName": "./irregular-error-loader.js!./entry-point.js",
-      "moduleTrace": Array [],
-    },
-    Object {
-      "message": "Module Error (from ./irregular-error-loader.js):\\nError",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/irregular-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
-      "moduleName": "./irregular-error-loader.js!./entry-point.js",
-      "moduleTrace": Array [],
-    },
-    Object {
-      "message": "Module build failed (from ./irregular-error-loader.js):\\nNonErrorEmittedError: (Emitted value instead of an instance of Error) a string error",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/irregular-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
-      "moduleName": "./irregular-error-loader.js!./entry-point.js",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [
-    Object {
-      "message": "Module Warning (from ./irregular-error-loader.js):\\n(Emitted value instead of an instance of Error) null",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/irregular-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
-      "moduleName": "./irregular-error-loader.js!./entry-point.js",
-      "moduleTrace": Array [],
-    },
-    Object {
-      "message": "Module Warning (from ./irregular-error-loader.js):\\nError",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/irregular-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
-      "moduleName": "./irregular-error-loader.js!./entry-point.js",
-      "moduleTrace": Array [],
-    },
-  ],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "message": "Module Error (from ./irregular-error-loader.js):\\n(Emitted value instead of an instance of Error) null",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/irregular-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
+					      "moduleName": "./irregular-error-loader.js!./entry-point.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleError: Module Error (from ./irregular-error-loader.js):\\n(Emitted value instead of an instance of Error) null",
+					    },
+					    Object {
+					      "message": "Module Error (from ./irregular-error-loader.js):\\nError",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/irregular-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
+					      "moduleName": "./irregular-error-loader.js!./entry-point.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleError: Module Error (from ./irregular-error-loader.js):\\nError",
+					    },
+					    Object {
+					      "message": "Module build failed (from ./irregular-error-loader.js):\\nNonErrorEmittedError: (Emitted value instead of an instance of Error) a string error",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/irregular-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
+					      "moduleName": "./irregular-error-loader.js!./entry-point.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleBuildError: Module build failed (from ./irregular-error-loader.js):\\nNonErrorEmittedError: (Emitted value instead of an instance of Error) a string error",
+					    },
+					  ],
+					  "warnings": Array [
+					    Object {
+					      "message": "Module Warning (from ./irregular-error-loader.js):\\n(Emitted value instead of an instance of Error) null",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/irregular-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
+					      "moduleName": "./irregular-error-loader.js!./entry-point.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleWarning: Module Warning (from ./irregular-error-loader.js):\\n(Emitted value instead of an instance of Error) null",
+					    },
+					    Object {
+					      "message": "Module Warning (from ./irregular-error-loader.js):\\nError",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/irregular-error-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
+					      "moduleName": "./irregular-error-loader.js!./entry-point.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleWarning: Module Warning (from ./irregular-error-loader.js):\\nError",
+					    },
+					  ],
+					}
+				`);
 	});
 
 	it("should emit error for no-return-loader", async () => {
 		await expect(compile({ entry: "./no-return-loader!./entry-point.js" }))
 			.resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "message": "Module build failed: Error: Final loader (./no-return-loader.js) didn't return a Buffer or String",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/no-return-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
-      "moduleName": "./no-return-loader.js!./entry-point.js",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "message": "Module build failed: Error: Final loader (./no-return-loader.js) didn't return a Buffer or String",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/no-return-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
+					      "moduleName": "./no-return-loader.js!./entry-point.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleBuildError: Module build failed: Error: Final loader (./no-return-loader.js) didn't return a Buffer or String",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 	});
 
 	it("should emit error for doesnt-exist-loader", async () => {
 		await expect(compile({ entry: "./doesnt-exist-loader!./entry-point.js" }))
 			.resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "loc": "main",
-      "message": "Module not found: Error: Can't resolve './doesnt-exist-loader' in '<cwd>/test/fixtures/errors'",
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "loc": "main",
+					      "message": "Module not found: Error: Can't resolve './doesnt-exist-loader' in '<cwd>/test/fixtures/errors'",
+					      "stack": "ModuleNotFoundError: Module not found: Error: Can't resolve './doesnt-exist-loader' in '<cwd>/test/fixtures/errors'",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 	});
 
 	it("should emit error for return-undefined-loader", async () => {
 		await expect(
 			compile({ entry: "./return-undefined-loader!./entry-point.js" })
 		).resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "message": "Module build failed: Error: Final loader (./return-undefined-loader.js) didn't return a Buffer or String",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/return-undefined-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
-      "moduleName": "./return-undefined-loader.js!./entry-point.js",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "message": "Module build failed: Error: Final loader (./return-undefined-loader.js) didn't return a Buffer or String",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/return-undefined-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
+					      "moduleName": "./return-undefined-loader.js!./entry-point.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleBuildError: Module build failed: Error: Final loader (./return-undefined-loader.js) didn't return a Buffer or String",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 	});
 
 	it("should emit error for module-exports-object-loader", async () => {
 		await expect(
 			compile({ entry: "./module-exports-object-loader!./entry-point.js" })
 		).resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "message": "Module build failed (from ./module-exports-object-loader.js):\\nLoaderRunnerError: Module '<cwd>/test/fixtures/errors/module-exports-object-loader.js' is not a loader (must have normal or pitch function)",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/module-exports-object-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
-      "moduleName": "./module-exports-object-loader.js!./entry-point.js",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "message": "Module build failed (from ./module-exports-object-loader.js):\\nLoaderRunnerError: Module '<cwd>/test/fixtures/errors/module-exports-object-loader.js' is not a loader (must have normal or pitch function)",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/module-exports-object-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
+					      "moduleName": "./module-exports-object-loader.js!./entry-point.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleBuildError: Module build failed (from ./module-exports-object-loader.js):\\nLoaderRunnerError: Module '<cwd>/test/fixtures/errors/module-exports-object-loader.js' is not a loader (must have normal or pitch function)",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 	});
 
 	it("should emit error for module-exports-string-loader", async () => {
 		await expect(
 			compile({ entry: "./module-exports-string-loader!./entry-point.js" })
 		).resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "message": "Module build failed (from ./module-exports-string-loader.js):\\nLoaderRunnerError: Module '<cwd>/test/fixtures/errors/module-exports-string-loader.js' is not a loader (export function or es6 module)",
-      "moduleId": 0,
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/module-exports-string-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
-      "moduleName": "./module-exports-string-loader.js!./entry-point.js",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "message": "Module build failed (from ./module-exports-string-loader.js):\\nLoaderRunnerError: Module '<cwd>/test/fixtures/errors/module-exports-string-loader.js' is not a loader (export function or es6 module)",
+					      "moduleId": 0,
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/module-exports-string-loader.js!<cwd>/test/fixtures/errors/entry-point.js",
+					      "moduleName": "./module-exports-string-loader.js!./entry-point.js",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleBuildError: Module build failed (from ./module-exports-string-loader.js):\\nLoaderRunnerError: Module '<cwd>/test/fixtures/errors/module-exports-string-loader.js' is not a loader (export function or es6 module)",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 	});
 
 	const identityLoader = path.resolve(
@@ -708,20 +739,21 @@ Object {
 				}
 			})
 		).resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "loc": "1:0",
-      "message": "Module parse failed: Unexpected token (1:0)\\nFile was processed with these loaders:\\n * ./identity-loader.js\\nYou may need an additional loader to handle the result of these loaders.\\n> <!DOCTYPE html>\\n| <html>\\n| 	<body>",
-      "moduleId": "./abc.html",
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/identity-loader.js!<cwd>/test/fixtures/errors/abc.html",
-      "moduleName": "./abc.html",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "loc": "1:0",
+					      "message": "Module parse failed: Unexpected token (1:0)\\nFile was processed with these loaders:\\n * ./identity-loader.js\\nYou may need an additional loader to handle the result of these loaders.\\n> <!DOCTYPE html>\\n| <html>\\n| 	<body>",
+					      "moduleId": "./abc.html",
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/identity-loader.js!<cwd>/test/fixtures/errors/abc.html",
+					      "moduleName": "./abc.html",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleParseError: Module parse failed: Unexpected token (1:0)\\nFile was processed with these loaders:\\n * ./identity-loader.js\\nYou may need an additional loader to handle the result of these loaders.\\n> <!DOCTYPE html>\\n| <html>\\n| 	<body>",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 	});
 
 	it("should show all loaders used if they are in config when module parsing fails", async () => {
@@ -739,20 +771,21 @@ Object {
 				}
 			})
 		).resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "loc": "1:0",
-      "message": "Module parse failed: Unexpected token (1:0)\\nFile was processed with these loaders:\\n * ./identity-loader.js\\n * ./add-comment-loader.js\\nYou may need an additional loader to handle the result of these loaders.\\n> <!DOCTYPE html>\\n| <html>\\n| 	<body>",
-      "moduleId": "./abc.html",
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/identity-loader.js!<cwd>/test/fixtures/errors/add-comment-loader.js!<cwd>/test/fixtures/errors/abc.html",
-      "moduleName": "./abc.html",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "loc": "1:0",
+					      "message": "Module parse failed: Unexpected token (1:0)\\nFile was processed with these loaders:\\n * ./identity-loader.js\\n * ./add-comment-loader.js\\nYou may need an additional loader to handle the result of these loaders.\\n> <!DOCTYPE html>\\n| <html>\\n| 	<body>",
+					      "moduleId": "./abc.html",
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/identity-loader.js!<cwd>/test/fixtures/errors/add-comment-loader.js!<cwd>/test/fixtures/errors/abc.html",
+					      "moduleName": "./abc.html",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleParseError: Module parse failed: Unexpected token (1:0)\\nFile was processed with these loaders:\\n * ./identity-loader.js\\n * ./add-comment-loader.js\\nYou may need an additional loader to handle the result of these loaders.\\n> <!DOCTYPE html>\\n| <html>\\n| 	<body>",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 	});
 
 	it("should show all loaders used if use is a string", async () => {
@@ -768,20 +801,21 @@ Object {
 				}
 			})
 		).resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "loc": "1:0",
-      "message": "Module parse failed: Unexpected token (1:0)\\nFile was processed with these loaders:\\n * ./identity-loader.js\\n * ./add-comment-loader.js\\nYou may need an additional loader to handle the result of these loaders.\\n> <!DOCTYPE html>\\n| <html>\\n| 	<body>",
-      "moduleId": "./abc.html",
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/identity-loader.js!<cwd>/test/fixtures/errors/add-comment-loader.js!<cwd>/test/fixtures/errors/abc.html",
-      "moduleName": "./abc.html",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "loc": "1:0",
+					      "message": "Module parse failed: Unexpected token (1:0)\\nFile was processed with these loaders:\\n * ./identity-loader.js\\n * ./add-comment-loader.js\\nYou may need an additional loader to handle the result of these loaders.\\n> <!DOCTYPE html>\\n| <html>\\n| 	<body>",
+					      "moduleId": "./abc.html",
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/identity-loader.js!<cwd>/test/fixtures/errors/add-comment-loader.js!<cwd>/test/fixtures/errors/abc.html",
+					      "moduleName": "./abc.html",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleParseError: Module parse failed: Unexpected token (1:0)\\nFile was processed with these loaders:\\n * ./identity-loader.js\\n * ./add-comment-loader.js\\nYou may need an additional loader to handle the result of these loaders.\\n> <!DOCTYPE html>\\n| <html>\\n| 	<body>",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 	});
 
 	it("should show 'no loaders are configured to process this file' if loaders are not included in config when module parsing fails", async () => {
@@ -792,20 +826,21 @@ Object {
 				module: {}
 			})
 		).resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "loc": "1:0",
-      "message": "Module parse failed: Unexpected token (1:0)\\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\\n> <!DOCTYPE html>\\n| <html>\\n| 	<body>",
-      "moduleId": "./abc.html",
-      "moduleIdentifier": "<cwd>/test/fixtures/errors/abc.html",
-      "moduleName": "./abc.html",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "loc": "1:0",
+					      "message": "Module parse failed: Unexpected token (1:0)\\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\\n> <!DOCTYPE html>\\n| <html>\\n| 	<body>",
+					      "moduleId": "./abc.html",
+					      "moduleIdentifier": "<cwd>/test/fixtures/errors/abc.html",
+					      "moduleName": "./abc.html",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleParseError: Module parse failed: Unexpected token (1:0)\\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\\n> <!DOCTYPE html>\\n| <html>\\n| 	<body>",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 	});
 
 	it("should show 'source code omitted for this binary file' when module parsing fails for binary files", async () => {
@@ -817,19 +852,20 @@ Object {
 				module: {}
 			})
 		).resolves.toMatchInlineSnapshot(`
-Object {
-  "errors": Array [
-    Object {
-      "loc": "1:0",
-      "message": "Module parse failed: Unexpected character ' ' (1:0)\\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\\n(Source code omitted for this binary file)",
-      "moduleId": "../font.ttf",
-      "moduleIdentifier": "<cwd>/test/fixtures/font.ttf",
-      "moduleName": "../font.ttf",
-      "moduleTrace": Array [],
-    },
-  ],
-  "warnings": Array [],
-}
-`);
+					Object {
+					  "errors": Array [
+					    Object {
+					      "loc": "1:0",
+					      "message": "Module parse failed: Unexpected character ' ' (1:0)\\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\\n(Source code omitted for this binary file)",
+					      "moduleId": "../font.ttf",
+					      "moduleIdentifier": "<cwd>/test/fixtures/font.ttf",
+					      "moduleName": "../font.ttf",
+					      "moduleTrace": Array [],
+					      "stack": "ModuleParseError: Module parse failed: Unexpected character ' ' (1:0)\\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\\n(Source code omitted for this binary file)",
+					    },
+					  ],
+					  "warnings": Array [],
+					}
+				`);
 	});
 });


### PR DESCRIPTION
Add new `stats.errorStack` option to display it anyway.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
* new `stats.errorStack` option to display webpack-internal stack trace of errors
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
