### PR TITLE
fix: Only add timeZone if toLocaleString throws with initial timeZone

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -974,18 +974,15 @@ class Stats {
 		}
 		if (typeof obj.builtAt === "number") {
 			const builtAtDate = new Date(obj.builtAt);
-			let timeZone = null;
+			let timeZone;
 
 			try {
-				timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+				builtAtDate.toLocaleTimeString();
 			} catch (err) {
-				// disregard the RangeError
-			}
-
-			// Force UTC if runtime timezone could not be detected.
-			if (!timeZone || timeZone.toLowerCase() === "etc/unknown") {
+				// Force UTC if runtime timezone is unsupported
 				timeZone = "UTC";
 			}
+
 			colors.normal("Built at: ");
 			colors.normal(
 				builtAtDate.toLocaleDateString(undefined, {

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -974,7 +974,7 @@ class Stats {
 		}
 		if (typeof obj.builtAt === "number") {
 			const builtAtDate = new Date(obj.builtAt);
-			let timeZone;
+			let timeZone = undefined;
 
 			try {
 				builtAtDate.toLocaleTimeString();


### PR DESCRIPTION
Fixes #9818 

cc @billneff79 @AndyOGo

Signed-off-by: petetnt <pete.a.nykanen@gmail.com>
