### PR TITLE
emit a warning when require.include is used

### DIFF
--- a/lib/dependencies/RequireIncludeDependencyParserPlugin.js
+++ b/lib/dependencies/RequireIncludeDependencyParserPlugin.js
@@ -5,20 +5,68 @@
 
 "use strict";
 
+const WebpackError = require("../WebpackError");
+const {
+	evaluateToString,
+	toConstantDependency
+} = require("../javascript/JavascriptParserHelpers");
 const RequireIncludeDependency = require("./RequireIncludeDependency");
 
 module.exports = class RequireIncludeDependencyParserPlugin {
+	constructor(warn) {
+		this.warn = warn;
+	}
 	apply(parser) {
+		const { warn } = this;
 		parser.hooks.call
 			.for("require.include")
 			.tap("RequireIncludeDependencyParserPlugin", expr => {
 				if (expr.arguments.length !== 1) return;
 				const param = parser.evaluateExpression(expr.arguments[0]);
 				if (!param.isString()) return;
+
+				if (warn) {
+					parser.state.module.warnings.push(
+						new RequireIncludeDeprecationWarning(expr.loc)
+					);
+				}
+
 				const dep = new RequireIncludeDependency(param.string, expr.range);
 				dep.loc = expr.loc;
 				parser.state.current.addDependency(dep);
 				return true;
 			});
+		parser.hooks.evaluateTypeof
+			.for("require.include")
+			.tap("RequireIncludePlugin", expr => {
+				if (warn) {
+					parser.state.module.warnings.push(
+						new RequireIncludeDeprecationWarning(expr.loc)
+					);
+				}
+				return evaluateToString("function")(expr);
+			});
+		parser.hooks.typeof
+			.for("require.include")
+			.tap("RequireIncludePlugin", expr => {
+				if (warn) {
+					parser.state.module.warnings.push(
+						new RequireIncludeDeprecationWarning(expr.loc)
+					);
+				}
+				return toConstantDependency(parser, JSON.stringify("function"))(expr);
+			});
 	}
 };
+
+class RequireIncludeDeprecationWarning extends WebpackError {
+	constructor(loc) {
+		super("require.include() is deprecated and will be removed soon.");
+
+		this.name = "RequireIncludeDeprecationWarning";
+
+		this.loc = loc;
+
+		Error.captureStackTrace(this, this.constructor);
+	}
+}

--- a/lib/dependencies/RequireIncludePlugin.js
+++ b/lib/dependencies/RequireIncludePlugin.js
@@ -8,11 +8,6 @@
 const RequireIncludeDependency = require("./RequireIncludeDependency");
 const RequireIncludeDependencyParserPlugin = require("./RequireIncludeDependencyParserPlugin");
 
-const {
-	evaluateToString,
-	toConstantDependency
-} = require("../javascript/JavascriptParserHelpers");
-
 class RequireIncludePlugin {
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
@@ -28,22 +23,10 @@ class RequireIncludePlugin {
 				);
 
 				const handler = (parser, parserOptions) => {
-					if (
-						parserOptions.requireInclude !== undefined &&
-						!parserOptions.requireInclude
-					)
-						return;
+					if (parserOptions.requireInclude === false) return;
+					const warn = parserOptions.requireInclude === undefined;
 
-					new RequireIncludeDependencyParserPlugin().apply(parser);
-					parser.hooks.evaluateTypeof
-						.for("require.include")
-						.tap("RequireIncludePlugin", evaluateToString("function"));
-					parser.hooks.typeof
-						.for("require.include")
-						.tap(
-							"RequireIncludePlugin",
-							toConstantDependency(parser, JSON.stringify("function"))
-						);
+					new RequireIncludeDependencyParserPlugin(warn).apply(parser);
 				};
 
 				normalModuleFactory.hooks.parser

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -3624,13 +3624,13 @@ chunk default/async-a.js (async-a) 134 bytes <{179}> [rendered]
 `;
 
 exports[`StatsTestCases should print correct stats for tree-shaking 1`] = `
-"Hash: 7d7dad4422b7ff62309c
+"Hash: 555c0be8eff50e0d063c
 Time: Xms
 Built at: 1970-04-20 12:42:42
     Asset      Size
 bundle.js  7.13 KiB  [emitted]  [name: main]
 Entrypoint main = bundle.js
-./index.js 315 bytes [built]
+./index.js 316 bytes [built] [1 warning]
     [no exports]
     [no exports used]
 ./reexport-known.js 49 bytes [built]
@@ -3659,7 +3659,11 @@ Entrypoint main = bundle.js
     [only some exports used: c]
 ./unknown2.js 1 bytes [built]
     [only some exports used: y]
-    + 2 hidden modules"
+    + 2 hidden modules
+
+WARNING in ./index.js 9:0-36
+require.include() is deprecated and will be removed soon.
+"
 `;
 
 exports[`StatsTestCases should print correct stats for warnings-terser 1`] = `

--- a/test/cases/chunks/issue-2443/index.js
+++ b/test/cases/chunks/issue-2443/index.js
@@ -1,15 +1,19 @@
 it("should be able to use expressions in import (directory)", function(done) {
 	function load(name, expected, callback) {
-		import("./dir/" + name + "/file.js").then(function(result) {
-			expect(result).toEqual(nsObj({
-				default: expected
-			}));
-			callback();
-		}).catch(function(err) {
-			done(err);
-		});
+		import("./dir/" + name + "/file.js")
+			.then(function(result) {
+				expect(result).toEqual(
+					nsObj({
+						default: expected
+					})
+				);
+				callback();
+			})
+			.catch(function(err) {
+				done(err);
+			});
 	}
-	require.include("./dir/three/file");
+	if (Math.random() < 0) require("./dir/three/file");
 	load("one", 1, function() {
 		load("two", 2, function() {
 			load("three", 3, function() {

--- a/test/cases/chunks/parsing/index.js
+++ b/test/cases/chunks/parsing/index.js
@@ -1,13 +1,19 @@
 it("should handle bound function expressions", function(done) {
-	require.ensure([], function(require) {
-		expect(this).toEqual({ test: true });
-		require("./empty?test");
-		expect(process.nextTick).toBeTypeOf("function"); // check if injection still works
-		require.ensure([], function(require) {
+	require.ensure(
+		[],
+		function(require) {
 			expect(this).toEqual({ test: true });
-			done();
-		}.bind(this));
-	}.bind({test: true}));
+			require("./empty?test");
+			expect(process.nextTick).toBeTypeOf("function"); // check if injection still works
+			require.ensure(
+				[],
+				function(require) {
+					expect(this).toEqual({ test: true });
+					done();
+				}.bind(this)
+			);
+		}.bind({ test: true })
+	);
 });
 
 it("should handle require.ensure without function expression", function(done) {
@@ -18,16 +24,19 @@ it("should handle require.ensure without function expression", function(done) {
 });
 
 it("should parse expression in require.ensure, which isn't a function expression", function(done) {
-	require.ensure([], (function() {
-		expect(require("./empty?require.ensure:test")).toEqual({});
-		return function f() {
-			done();
-		};
-	}()));
+	require.ensure(
+		[],
+		(function() {
+			expect(require("./empty?require.ensure:test")).toEqual({});
+			return function f() {
+				done();
+			};
+		})()
+	);
 });
 
-it("should accept a require.include call", function(done) {
-	require.include("./require.include");
+it("should accept an already included module", function(done) {
+	if (Math.random() < 0) require("./require.include");
 	var value = null;
 	require.ensure([], function(require) {
 		value = require("./require.include");

--- a/test/cases/errors/crash-missing-import/index.js
+++ b/test/cases/errors/crash-missing-import/index.js
@@ -1,4 +1,3 @@
-it("should not crash when imported module is missing", function() {
-});
+it("should not crash when imported module is missing", function() {});
 
-require.include("./a");
+if (Math.random() < 0) require("./a");

--- a/test/cases/parsing/typeof/warnings.js
+++ b/test/cases/parsing/typeof/warnings.js
@@ -1,0 +1,4 @@
+module.exports = [
+	[/require.include\(\) is deprecated and will be removed soon/],
+	[/require.include\(\) is deprecated and will be removed soon/]
+];

--- a/test/cases/resolving/browser-field/index.js
+++ b/test/cases/resolving/browser-field/index.js
@@ -31,11 +31,13 @@ it("should ignore recursive module mappings", function() {
 it("should use empty modules for ignored modules", function() {
 	expect(require("ignoring-module").module).toEqual({});
 	expect(require("ignoring-module").file).toEqual({});
-	expect(require("ignoring-module").module).not.toBe(require("ignoring-module").file);
+	expect(require("ignoring-module").module).not.toBe(
+		require("ignoring-module").file
+	);
 });
 
 // Errors
-require.include("recursive-file/a");
-require.include("recursive-file/b");
-require.include("recursive-file/c");
-require.include("recursive-file/d");
+if (Math.random() < 0) require("recursive-file/a");
+if (Math.random() < 0) require("recursive-file/b");
+if (Math.random() < 0) require("recursive-file/c");
+if (Math.random() < 0) require("recursive-file/d");

--- a/test/cases/resolving/issue-2986/index.js
+++ b/test/cases/resolving/issue-2986/index.js
@@ -1,4 +1,4 @@
-require.include("any!");
-require.include("other!");
+if (Math.random() < 0) require("any!");
+if (Math.random() < 0) require("other!");
 
-it("should have correct errors", function() {})
+it("should have correct errors", function() {});

--- a/test/configCases/errors/import-missing/index.js
+++ b/test/configCases/errors/import-missing/index.js
@@ -1,16 +1,20 @@
+var never = false;
+
 it("should not crash on missing requires", function() {
-	require.include("./a");
-	require.include("./b");
-	require.include("./c");
-	require.include("./d");
-	require.include("./e");
-	require.include("./f");
-	require.include("./h");
-	require.include("./i");
-	require.include("./j");
-	require.include("./k");
-	require.include("./l");
-	require.include("./m");
-	require.include("./n");
-	require.include("./o");
+	if (never) {
+		require("./a");
+		require("./b");
+		require("./c");
+		require("./d");
+		require("./e");
+		require("./f");
+		require("./h");
+		require("./i");
+		require("./j");
+		require("./k");
+		require("./l");
+		require("./m");
+		require("./n");
+		require("./o");
+	}
 });

--- a/test/configCases/filename-template/module-filename-template/index.js
+++ b/test/configCases/filename-template/module-filename-template/index.js
@@ -5,5 +5,4 @@ it("should include test.js in SourceMap", function() {
 	expect(map.sources).toContain("dummy:///./test.js");
 });
 
-require.include("./test.js");
-
+if (Math.random() < 0) require("./test.js");

--- a/test/configCases/inner-graph/_helpers/entryLoader.js
+++ b/test/configCases/inner-graph/_helpers/entryLoader.js
@@ -1,7 +1,7 @@
 module.exports = function() {
 	const { name, expect, usedExports } = JSON.parse(this.query.slice(1));
 	return [
-		`require.include(${JSON.stringify(
+		`if (Math.random() < 0) require(${JSON.stringify(
 			`../_helpers/testModuleLoader?${JSON.stringify(usedExports)}!`
 		)});`,
 		"",

--- a/test/configCases/plugins/banner-plugin-hashing/index.js
+++ b/test/configCases/plugins/banner-plugin-hashing/index.js
@@ -1,6 +1,6 @@
-const parseBanner = (banner) => {
+const parseBanner = banner => {
 	return banner
-		.slice(4,-3)
+		.slice(4, -3)
 		.split(", ")
 		.map(n => n.split(":"))
 		.reduce((acc, val) => {
@@ -12,10 +12,10 @@ const parseBanner = (banner) => {
 var source = require("fs")
 	.readFileSync(__filename, "utf-8")
 	.split("\n")
-	.slice(0,1)[0];
+	.slice(0, 1)[0];
 
-const banner = parseBanner(source)
-const REGEXP_HASH = /^[A-Za-z0-9]{20}$/
+const banner = parseBanner(source);
+const REGEXP_HASH = /^[A-Za-z0-9]{20}$/;
 
 it("should interpolate file hash in chunk banner", () => {
 	expect(REGEXP_HASH.test(banner["fullhash"])).toBe(true);
@@ -57,4 +57,4 @@ it("should parse entry into name in chunk banner", () => {
 	expect(banner["base"]).not.toBe(banner["name"]);
 });
 
-require.include("./test.js");
+if (Math.random() < 0) require("./test.js");

--- a/test/configCases/plugins/banner-plugin/index.js
+++ b/test/configCases/plugins/banner-plugin/index.js
@@ -7,8 +7,12 @@ it("should contain banner in bundle0 chunk", () => {
 	expect(source).toMatch("banner is a string");
 	expect(source).toMatch("banner is a function");
 	expect(source).toMatch("/*!\n * multiline\n * banner\n * bundle0\n */");
-	expect(source).toMatch("/*!\n * trim trailing whitespace\n *\n * trailing whitespace\n */");
-	expect(source).toMatch("/*!\n * trim trailing whitespace\n *\n * no trailing whitespace\n */");
+	expect(source).toMatch(
+		"/*!\n * trim trailing whitespace\n *\n * trailing whitespace\n */"
+	);
+	expect(source).toMatch(
+		"/*!\n * trim trailing whitespace\n *\n * no trailing whitespace\n */"
+	);
 });
 
 it("should not contain banner in vendors chunk", () => {
@@ -16,4 +20,4 @@ it("should not contain banner in vendors chunk", () => {
 	expect(source).not.toMatch("A test value");
 });
 
-require.include("./test.js");
+if (Math.random() < 0) require("./test.js");

--- a/test/configCases/plugins/environment-plugin/index.js
+++ b/test/configCases/plugins/environment-plugin/index.js
@@ -1,35 +1,28 @@
+var never = false;
+
 it("should import a single process.env var", () => {
-	if(process.env.AAA !== "aaa")
-		require.include("aaa");
+	if (process.env.AAA !== "aaa") if (never) require("aaa");
 });
 
 it("should import multiple process.env vars", () => {
-	if(process.env.BBB !== "bbb")
-		require.include("bbb");
-	if(process.env.CCC !== "ccc")
-		require.include("ccc");
+	if (process.env.BBB !== "bbb") if (never) require("bbb");
+	if (process.env.CCC !== "ccc") if (never) require("ccc");
 });
 
 it("should warn when a process.env variable is undefined", () => {
-	if(process.env.DDD !== "ddd")
-		require.include("ddd");
+	if (process.env.DDD !== "ddd") if (never) require("ddd");
 });
 
 it("should import an array of process.env vars", () => {
-	if(process.env.EEE !== "eee")
-		require.include("eee");
-	if(process.env.FFF !== "fff")
-		require.include("fff");
+	if (process.env.EEE !== "eee") if (never) require("eee");
+	if (process.env.FFF !== "fff") if (never) require("fff");
 });
 
 it("should import multiple process.env var with default values", () => {
-	if(process.env.GGG !== "ggg")
-		require.include("ggg");
-	if(process.env.HHH !== "hhh")
-		require.include("hhh");
+	if (process.env.GGG !== "ggg") if (never) require("ggg");
+	if (process.env.HHH !== "hhh") if (never) require("hhh");
 });
 
 it("should import process.env var with empty value", () => {
-	if(process.env.III !== "")
-		require.include("iii");
+	if (process.env.III !== "") if (never) require("iii");
 });

--- a/test/configCases/plugins/terser-plugin/index.js
+++ b/test/configCases/plugins/terser-plugin/index.js
@@ -23,7 +23,10 @@ it("should extract comments to separate file", function() {
 	const fs = require("fs");
 	const path = require("path");
 
-	const source = fs.readFileSync(path.join(__dirname, "extract.js.LICENSE"), "utf-8");
+	const source = fs.readFileSync(
+		path.join(__dirname, "extract.js.LICENSE"),
+		"utf-8"
+	);
 
 	expect(source).toMatch("comment should be extracted extract-test.1");
 	expect(source).not.toMatch("comment should be stripped extract-test.2");
@@ -41,7 +44,9 @@ it("should remove extracted comments and insert a banner", function() {
 	expect(source).not.toMatch("comment should be stripped extract-test.2");
 	expect(source).not.toMatch("comment should be extracted extract-test.3");
 	expect(source).not.toMatch("comment should be stripped extract-test.4");
-	expect(source).toMatch("/*! For license information please see extract.js.LICENSE */");
+	expect(source).toMatch(
+		"/*! For license information please see extract.js.LICENSE */"
+	);
 });
 
 it("should pass mangle options", function() {
@@ -50,7 +55,9 @@ it("should pass mangle options", function() {
 
 	const source = fs.readFileSync(path.join(__dirname, "ie8.js"), "utf-8");
 
-	expect(source).toMatch(/\.exports=function\((\w)\)\{return function\((\w)\)\{try\{\1\(\)\}catch\(\1\)\{\2\(\1\)\}\}\}/);
+	expect(source).toMatch(
+		/\.exports=function\((\w)\)\{return function\((\w)\)\{try\{\1\(\)\}catch\(\1\)\{\2\(\1\)\}\}\}/
+	);
 });
 
 it("should pass compress options", function() {
@@ -59,7 +66,9 @@ it("should pass compress options", function() {
 
 	const source = fs.readFileSync(path.join(__dirname, "compress.js"), "utf-8");
 
-	expect(source).toMatch(".exports=function(){console.log(4),console.log(6),console.log(4),console.log(7)}");
+	expect(source).toMatch(
+		".exports=function(){console.log(4),console.log(6),console.log(4),console.log(7)}"
+	);
 });
 
-require.include("./test.js");
+if (Math.random() < 0) require("./test.js");

--- a/test/configCases/source-map/exclude-chunks-source-map/index.js
+++ b/test/configCases/source-map/exclude-chunks-source-map/index.js
@@ -7,9 +7,9 @@ it("should include test.js in SourceMap for bundle0 chunk", function() {
 
 it("should not produce a SourceMap for vendors chunk", function() {
 	var fs = require("fs"),
-			path = require("path"),
-			assert = require("assert");
+		path = require("path"),
+		assert = require("assert");
 	expect(fs.existsSync(path.join(__dirname, "vendors.js.map"))).toBe(false);
 });
 
-require.include("./test.js");
+if (Math.random() < 0) require("./test.js");

--- a/test/configCases/source-map/namespace-source-path.library/index.js
+++ b/test/configCases/source-map/namespace-source-path.library/index.js
@@ -5,4 +5,4 @@ it("should include webpack://mylibrary/./test.js in SourceMap", function() {
 	expect(map.sources).toContain("webpack://mylibrary/./test.js");
 });
 
-require.include("./test.js");
+if (Math.random() < 0) require("./test.js");

--- a/test/configCases/source-map/namespace-source-path/index.js
+++ b/test/configCases/source-map/namespace-source-path/index.js
@@ -5,4 +5,4 @@ it("should include webpack://mynamespace/./test.js in SourceMap", function() {
 	expect(map.sources).toContain("webpack://mynamespace/./test.js");
 });
 
-require.include("./test.js");
+if (Math.random() < 0) require("./test.js");

--- a/test/configCases/source-map/nosources/index.js
+++ b/test/configCases/source-map/nosources/index.js
@@ -2,7 +2,7 @@ it("should not include sourcesContent if noSources option is used", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	expect(map).not.toHaveProperty('sourcesContent');
+	expect(map).not.toHaveProperty("sourcesContent");
 });
 
-require.include("./test.js");
+if (Math.random() < 0) require("./test.js");

--- a/test/configCases/source-map/source-map-with-profiling-plugin/index.js
+++ b/test/configCases/source-map/source-map-with-profiling-plugin/index.js
@@ -5,4 +5,4 @@ it("bundle0 should include sourcemapped test.js", function() {
 	expect(map.sources).toContain("webpack:///./test.js");
 });
 
-require.include("./test.js");
+if (Math.random() < 0) require("./test.js");

--- a/test/configCases/source-map/sources-array-production/index.js
+++ b/test/configCases/source-map/sources-array-production/index.js
@@ -5,4 +5,4 @@ it("should include test.js in SourceMap", function() {
 	expect(map.sources).toContain("webpack:///./test.js");
 });
 
-require.include("./test.js");
+if (Math.random() < 0) require("./test.js");

--- a/test/configCases/split-chunks-common/library/index.js
+++ b/test/configCases/split-chunks-common/library/index.js
@@ -1,11 +1,11 @@
-require.include("external1");
+if (Math.random() < 0) require("external1");
 require.ensure([], function() {
-	require.include("external2");
-})
+	if (Math.random() < 0) require("external2");
+});
 
 it("should have externals in main file", function() {
 	var a = require("./a");
-	expect(a.vendor).toMatch("require(\"external0\")");
-	expect(a.main).toMatch("require(\"external1\")");
-	expect(a.main).toMatch("require(\"external2\")");
+	expect(a.vendor).toMatch('require("external0")');
+	expect(a.main).toMatch('require("external1")');
+	expect(a.main).toMatch('require("external2")');
 });

--- a/test/statsCases/tree-shaking/index.js
+++ b/test/statsCases/tree-shaking/index.js
@@ -1,6 +1,6 @@
 import { a as a1 } from "./reexport-known";
 import { a as a2, c as c2 } from "./reexport-unknown";
-import { a as a3} from "./reexport-star-known";
+import { a as a3 } from "./reexport-star-known";
 import { a as a4, c as c4 } from "./reexport-star-unknown";
 import { y } from "./edge";
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
deprecation
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
* `require.include` is depreacted and will trigger a warning.
* `parser.requireInclude: true` will disable the warning
* `parser.requireInclude: false` will disable `require.include`
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
