### PR TITLE
fix: emit correctly hot-update files when noEmitOnErrors is true

### DIFF
--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -256,6 +256,7 @@ module.exports = class HotModuleReplacementPlugin {
 							h: compilation.hash,
 							c: {}
 						};
+						let shouldEmitMainHotUpdateFile = false;
 						for (const key of Object.keys(records.chunkHashs)) {
 							const chunkId = isNaN(+key) ? key : +key;
 							const currentChunk = compilation.chunks.find(
@@ -273,6 +274,7 @@ module.exports = class HotModuleReplacementPlugin {
 									id => !allModules.has(id)
 								);
 								if (newModules.length > 0 || removedModules.length > 0) {
+									shouldEmitMainHotUpdateFile = true;
 									const source = hotUpdateChunkTemplate.render(
 										chunkId,
 										newModules,
@@ -302,18 +304,21 @@ module.exports = class HotModuleReplacementPlugin {
 								hotUpdateMainContent.c[chunkId] = false;
 							}
 						}
-						const source = new RawSource(JSON.stringify(hotUpdateMainContent));
-						const {
-							path: filename,
-							info: assetInfo
-						} = compilation.getPathWithInfo(hotUpdateMainFilename, {
-							hash: records.hash
-						});
-						compilation.emitAsset(
-							filename,
-							source,
-							Object.assign({ hotModuleReplacement: true }, assetInfo)
-						);
+
+						if (shouldEmitMainHotUpdateFile) {
+							const source = new RawSource(JSON.stringify(hotUpdateMainContent));
+							const {
+								path: filename,
+								info: assetInfo
+							} = compilation.getPathWithInfo(hotUpdateMainFilename, {
+								hash: records.hash
+							});
+							compilation.emitAsset(
+								filename,
+								source,
+								Object.assign({ hotModuleReplacement: true }, assetInfo)
+							);
+						}
 					}
 				);
 


### PR DESCRIPTION
When `noEmitOnErrors` is true, there are situations when only `.hot-update.json` file is emitted but `.hot-update.js` is not emitted.

The issue happens using the following steps:
1. Set `noEmitOnErrors` to true inside `webpack.config.js`
2. Start webpack compilation in `watch` mode
3. Change whatever import to something invalid -> you'll see the webpack compilation stops
4. Fix the import -> only `.hot-update.json` file is emitted, `hot-update.js` file is not emitted

Expected behavior:
It should be emitted either both files `.hot-update.json` and `.hot-update.js` or no hot-update files.

**What kind of change does this PR introduce?**

A bugfix

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing.
