### PR TITLE
feat(DefinePlugin): Support array as value in DefinePlugin

### DIFF
--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -43,7 +43,7 @@ class RuntimeValue {
 
 const stringifyObj = (obj, parser) => {
 	if (Array.isArray(obj)) {
-		return "[" + obj.map(code => toCode(code, parser)).join(",") + "]";
+		return "Object([" + obj.map(code => toCode(code, parser)).join(",") + "])";
 	}
 
 	return (

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -42,6 +42,10 @@ class RuntimeValue {
 }
 
 const stringifyObj = (obj, parser) => {
+	if (Array.isArray(obj)) {
+		return "[" + obj.map(code => toCode(code, parser)).join(",") + "]";
+	}
+
 	return (
 		"Object({" +
 		Object.keys(obj)

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -52,6 +52,18 @@ it("should define OBJECT.SUB.STRING", function() {
 		expect(sub.STRING).toBe("string");
 	}(OBJECT.SUB));
 });
+it("should define ARRAY", function() {
+	expect(Array.isArray(ARRAY)).toBeTruthy();
+	expect(ARRAY).toHaveLength(2);
+});
+it("should define ARRAY[0]", function() {
+	expect(ARRAY[0]).toBe(2);
+});
+it("should define ARRAY[1][0]", function() {
+	expect(Array.isArray(ARRAY[1])).toBeTruthy();
+	expect(ARRAY[1]).toHaveLength(1);
+	expect(ARRAY[1][0]).toBe("six");
+});
 it("should define process.env.DEFINED_NESTED_KEY", function() {
 	expect((process.env.DEFINED_NESTED_KEY)).toBe(5);
 	expect((typeof process.env.DEFINED_NESTED_KEY)).toBe("number");

--- a/test/configCases/plugins/define-plugin/webpack.config.js
+++ b/test/configCases/plugins/define-plugin/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = {
 					STRING: JSON.stringify("string")
 				}
 			},
+			ARRAY: [2, [JSON.stringify("six")]],
 			"process.env.DEFINED_NESTED_KEY": 5,
 			"process.env.DEFINED_NESTED_KEY_STRING": '"string"',
 			"typeof wurst": "typeof suppe",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Currently, _DefinePlugin_ doesn't support array as value. Let's see this example:

```js
new DefinePlugin({ ITEMS: [1, 2, 3] })
```

We get:

```js
{ '0': 1, '1': 2, '2': 3 }
```

With these changes, we get:

```js
[1, 2, 3]
```

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

Potentially, yes. Because before, an array was handled as an object

**What needs to be documented once your changes are merged?**

We can add information about using array in _DefinePlugin_, [here](https://webpack.js.org/plugins/define-plugin/#usage)