### PR TITLE
Fixes #5392 - Allow destructuring using EnvironmentPlugin

### DIFF
--- a/lib/EnvironmentPlugin.js
+++ b/lib/EnvironmentPlugin.js
@@ -59,11 +59,13 @@ class EnvironmentPlugin {
 				});
 			}
 
-			defs[`process.env.${key}`] =
-				value === undefined ? "undefined" : JSON.stringify(value);
+			const envValue = value === undefined ? "undefined" : JSON.stringify(value);
+
+			defs[`process.env.${key}`] = envValue;
+			defs["process.env"][key] = envValue;
 
 			return defs;
-		}, {});
+		}, { "process.env": {} });
 
 		new DefinePlugin(definitions).apply(compiler);
 	}

--- a/lib/EnvironmentPlugin.js
+++ b/lib/EnvironmentPlugin.js
@@ -33,39 +33,46 @@ class EnvironmentPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
-		const definitions = this.keys.reduce((defs, key) => {
-			// NOTE remove once the required node version is >=8.10.0.
-			// Work around https://github.com/nodejs/node/pull/18463,
-			// affecting Node 8 & 9 by performing an OS-level
-			// operation that always succeeds before reading
-			// environment variables:
-			if (needsEnvVarFix) require("os").cpus();
+		const definitions = this.keys.reduce(
+			(defs, key) => {
+				// NOTE remove once the required node version is >=8.10.0.
+				// Work around https://github.com/nodejs/node/pull/18463,
+				// affecting Node 8 & 9 by performing an OS-level
+				// operation that always succeeds before reading
+				// environment variables:
+				if (needsEnvVarFix) require("os").cpus();
 
-			const value =
-				process.env[key] !== undefined
-					? process.env[key]
-					: this.defaultValues[key];
+				const value =
+					process.env[key] !== undefined
+						? process.env[key]
+						: this.defaultValues[key];
 
-			if (value === undefined) {
-				compiler.hooks.thisCompilation.tap("EnvironmentPlugin", compilation => {
-					const error = new WebpackError(
-						`EnvironmentPlugin - ${key} environment variable is undefined.\n\n` +
-							"You can pass an object with default values to suppress this warning.\n" +
-							"See https://webpack.js.org/plugins/environment-plugin for example."
+				if (value === undefined) {
+					compiler.hooks.thisCompilation.tap(
+						"EnvironmentPlugin",
+						compilation => {
+							const error = new WebpackError(
+								`EnvironmentPlugin - ${key} environment variable is undefined.\n\n` +
+									"You can pass an object with default values to suppress this warning.\n" +
+									"See https://webpack.js.org/plugins/environment-plugin for example."
+							);
+
+							error.name = "EnvVariableNotDefinedError";
+							compilation.warnings.push(error);
+						}
 					);
+				}
 
-					error.name = "EnvVariableNotDefinedError";
-					compilation.warnings.push(error);
-				});
-			}
+				const envValue =
+					value === undefined ? "undefined" : JSON.stringify(value);
 
-			const envValue = value === undefined ? "undefined" : JSON.stringify(value);
+				defs[`process.env.${key}`] = envValue;
+				defs["process.env"][key] = envValue;
 
-			defs[`process.env.${key}`] = envValue;
-			defs["process.env"][key] = envValue;
-
-			return defs;
-		}, { "process.env": {} });
+				return defs;
+			},
+			{ "process.env": {} }
+		);
 
 		new DefinePlugin(definitions).apply(compiler);
 	}

--- a/test/configCases/plugins/environment-plugin/errors.js
+++ b/test/configCases/plugins/environment-plugin/errors.js
@@ -17,6 +17,9 @@ const modules = [{
 }, {
 	name: 'iii',
 	variables: ['iii']
+}, {
+	name: 'jjj',
+	variables: ['jjj']
 }];
 
 // build an array of regular expressions of expected errors

--- a/test/configCases/plugins/environment-plugin/index.js
+++ b/test/configCases/plugins/environment-plugin/index.js
@@ -26,3 +26,8 @@ it("should import multiple process.env var with default values", () => {
 it("should import process.env var with empty value", () => {
 	if (process.env.III !== "") if (never) require("iii");
 });
+
+it("should import process.env var using destructuring", () => {
+	const { JJJ } = process.env;
+	if (JJJ !== "jjj") if (never) require("jjj");
+});

--- a/test/configCases/plugins/environment-plugin/webpack.config.js
+++ b/test/configCases/plugins/environment-plugin/webpack.config.js
@@ -9,6 +9,7 @@ process.env.EEE = "eee";
 process.env.FFF = "fff";
 process.env.GGG = "ggg";
 process.env.III = "";
+process.env.JJJ = "jjj";
 
 module.exports = [
 	{
@@ -63,5 +64,13 @@ module.exports = [
 			unknownContextCritical: false
 		},
 		plugins: [new EnvironmentPlugin("III")]
+	},
+	{
+		name: "jjj",
+		module: {
+			unknownContextRegExp: /$^/,
+			unknownContextCritical: false
+		},
+		plugins: [new EnvironmentPlugin("JJJ")]
 	}
 ];


### PR DESCRIPTION
I'm getting the exact same problem described in the issue (#5392). So I review the previous approaches to solve it (#8721), but I think is not necessary to change the current behavior. Just need to add destructured info to DefinePlugin.

**What kind of change does this PR introduce?**

It's a bugfix

**Did you add tests for your changes?**

Not yet... Just need help how to do that and I will make the tests

**Does this PR introduce a breaking change?**

No, just adding more elements to the array of env definitions that we want to use. After that we will use DefinePlugin as always.

**What needs to be documented once your changes are merged?**

Improve EnvironmentPlugin documentation adding examples using object destructuring.