### PR TITLE
Set correct exit code when question not answered

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -81,22 +81,27 @@ if (!cli.installed) {
 	);
 
 	const question = `Do you want to install 'webpack-cli' (yes/no): `;
+	const failBecauseCliNotInstalled = () => {
+		console.error(
+			"You need to install 'webpack-cli' to use webpack via CLI.\n" +
+				"You can also install the CLI manually."
+		);
+		process.exitCode = 1;
+	};
 
 	const questionInterface = readLine.createInterface({
 		input: process.stdin,
 		output: process.stderr
 	});
+	let questionAnswered = false;
 	questionInterface.question(question, answer => {
+		questionAnswered = true;
 		questionInterface.close();
 
 		const normalizedAnswer = answer.toLowerCase().startsWith("y");
 
 		if (!normalizedAnswer) {
-			console.error(
-				"You need to install 'webpack-cli' to use webpack via CLI.\n" +
-					"You can also install the CLI manually."
-			);
-			process.exitCode = 1;
+			failBecauseCliNotInstalled();
 
 			return;
 		}
@@ -117,6 +122,11 @@ if (!cli.installed) {
 				console.error(error);
 				process.exitCode = 1;
 			});
+	});
+	questionInterface.on("close", () => {
+		if (!questionAnswered) {
+			failBecauseCliNotInstalled();
+		}
 	});
 } else {
 	const path = require("path");


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Apparently, questionInterface.question() never calls the answer callback when the end of the (non-interactive) input stream is reached. To ensure a correct exit status in this scenario we listen for the question interface closing, check if the question was actually answered, and fall back to the failure scenario if it was not.

Fixes #10076, see that issue for more details.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Bugfix.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No; there currently seem to be no tests for `bin/webpack.js`.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
No documentation changes needed.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
