### PR TITLE
Fix ResolveOptions.plugins types

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -231,6 +231,11 @@ export type RuleSetLoaderOptions =
  */
 export type ArrayOfStringOrStringArrayValues = (string | string[])[];
 /**
+ * This interface was referenced by `WebpackOptions`'s JSON-Schema
+ * via the `definition` "RuleSetRules".
+ */
+export type RuleSetRules = RuleSetRule[];
+/**
  * Function acting as plugin
  *
  * This interface was referenced by `WebpackOptions`'s JSON-Schema
@@ -240,11 +245,6 @@ export type WebpackPluginFunction = (
 	this: import("../lib/Compiler"),
 	compiler: import("../lib/Compiler")
 ) => void;
-/**
- * This interface was referenced by `WebpackOptions`'s JSON-Schema
- * via the `definition` "RuleSetRules".
- */
-export type RuleSetRules = RuleSetRule[];
 /**
  * This interface was referenced by `WebpackOptions`'s JSON-Schema
  * via the `definition` "OptimizationSplitChunksGetCacheGroups".
@@ -811,7 +811,7 @@ export interface ResolveOptions {
 	/**
 	 * Plugins for the resolver
 	 */
-	plugins?: (WebpackPluginInstance | WebpackPluginFunction)[];
+	plugins?: ResolvePluginInstance[];
 	/**
 	 * Custom resolver
 	 */
@@ -839,13 +839,13 @@ export interface ResolveOptions {
  * Plugin instance
  *
  * This interface was referenced by `WebpackOptions`'s JSON-Schema
- * via the `definition` "WebpackPluginInstance".
+ * via the `definition` "ResolvePluginInstance".
  */
-export interface WebpackPluginInstance {
+export interface ResolvePluginInstance {
 	/**
 	 * The run point of the plugin, required method.
 	 */
-	apply: (compiler: import("../lib/Compiler")) => void;
+	apply: (resolver: import("enhanced-resolve/lib/Resolver")) => void;
 	[k: string]: any;
 }
 /**
@@ -971,6 +971,19 @@ export interface OptimizationOptions {
 	 * Figure out which exports are used by modules to mangle export names, omit unused exports and generate more efficient code
 	 */
 	usedExports?: boolean;
+}
+/**
+ * Plugin instance
+ *
+ * This interface was referenced by `WebpackOptions`'s JSON-Schema
+ * via the `definition` "WebpackPluginInstance".
+ */
+export interface WebpackPluginInstance {
+	/**
+	 * The run point of the plugin, required method.
+	 */
+	apply: (compiler: import("../lib/Compiler")) => void;
+	[k: string]: any;
 }
 /**
  * This interface was referenced by `WebpackOptions`'s JSON-Schema

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1523,10 +1523,7 @@
             "description": "Plugin of type object or instanceof Function",
             "anyOf": [
               {
-                "$ref": "#/definitions/WebpackPluginInstance"
-              },
-              {
-                "$ref": "#/definitions/WebpackPluginFunction"
+                "$ref": "#/definitions/ResolvePluginInstance"
               }
             ]
           }
@@ -1555,6 +1552,19 @@
           "type": "boolean"
         }
       }
+    },
+    "ResolvePluginInstance": {
+      "description": "Plugin instance",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "apply": {
+          "description": "The run point of the plugin, required method.",
+          "instanceof": "Function",
+          "tsType": "(resolver: import('enhanced-resolve/lib/Resolver')) => void"
+        }
+      },
+      "required": ["apply"]
     },
     "RuleSetCondition": {
       "anyOf": [


### PR DESCRIPTION
Fixes the `ResolveOptions.plugins` types to use a plugin that takes in a resolver plugin instead of a compiler plugin.

While working on this I noticed that `enhance-resolver` doesn't allow passing in a function, unlike webpack and with its plugins. Not sure if you will want to address this in the future but still pointing it out.

Closes #10073

**What kind of change does this PR introduce?**

Fixes types.

**Did you add tests for your changes?**

N/A

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

Nothing. This is a types fix only.
