### PR TITLE
fix: stringify error value in RuleSetCompiler

### DIFF
--- a/lib/rules/RuleSetCompiler.js
+++ b/lib/rules/RuleSetCompiler.js
@@ -343,7 +343,7 @@ class RuleSetCompiler {
 	 */
 	error(path, value, message) {
 		return new Error(
-			`Compiling RuleSet failed: ${message} (at ${path}: ${value})`
+			`Compiling RuleSet failed: ${message} (at ${path}: ${JSON.stringify(value)})`
 		);
 	}
 }

--- a/lib/rules/RuleSetCompiler.js
+++ b/lib/rules/RuleSetCompiler.js
@@ -343,7 +343,9 @@ class RuleSetCompiler {
 	 */
 	error(path, value, message) {
 		return new Error(
-			`Compiling RuleSet failed: ${message} (at ${path}: ${JSON.stringify(value)})`
+			`Compiling RuleSet failed: ${message} (at ${path}: ${JSON.stringify(
+				value
+			)})`
 		);
 	}
 }


### PR DESCRIPTION
Before
```
 Error: Compiling RuleSet failed: Properties enforce are unknown (at ruleSet[1].rules[5]: [object Object])
```

After
```
Error: Compiling RuleSet failed: Properties enforce are unknown (at ruleSet[1].rules[5]: {"test":{},"exclude":{},"enforce":"pre"})
```

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
