### PR TITLE
Allow to change module types from loaders

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -211,6 +211,11 @@ class NormalModule extends Module {
 		this._lastSuccessfulBuildMeta = {};
 		this._forceBuild = true;
 
+		// Keep track of overridden type/parser/generator
+		this._overriddenType = undefined;
+		this._overriddenParser = undefined;
+		this._overriddenGenerator = undefined;
+
 		// TODO refactor this -> options object filled from Factory
 		this.useSourceMap = false;
 	}
@@ -668,6 +673,7 @@ class NormalModule extends Module {
 		this.error = null;
 		this.clearWarningsAndErrors();
 		this.clearDependenciesAndBlocks();
+		this.resetModuleType();
 		this.buildMeta = {};
 		this.buildInfo = {
 			cacheable: false,
@@ -874,6 +880,31 @@ class NormalModule extends Module {
 	updateHash(hash, chunkGraph) {
 		hash.update(this.buildInfo.hash);
 		super.updateHash(hash, chunkGraph);
+	}
+
+	/**
+	 * @param {string=} type the new module type
+	 * @param {Parser=} parser the new module parser
+	 * @param {Generator=} generator the new module generator
+	 * @returns {void}
+	 */
+	setModuleType(type, parser, generator) {
+		this._overriddenType = this._overriddenType || this.type;
+		this._overriddenParser = this._overriddenParser || this.parser;
+		this._overriddenGenerator = this._overriddenGenerator || this.generator;
+
+		this.type = type || this.type;
+		this.parser = parser || this.parser;
+		this.generator = generator || this.generator;
+	}
+
+	/**
+	 * @returns {void}
+	 */
+	resetModuleType() {
+		this.type = this._overriddenType || this.type;
+		this.parser = this._overriddenParser || this.parser;
+		this.generator = this._overriddenGenerator || this.generator;
 	}
 
 	serialize(context) {

--- a/lib/dependencies/LoaderPlugin.js
+++ b/lib/dependencies/LoaderPlugin.js
@@ -30,81 +30,97 @@ class LoaderPlugin {
 			}
 		);
 
-		compiler.hooks.compilation.tap("LoaderPlugin", compilation => {
-			const moduleGraph = compilation.moduleGraph;
-			NormalModule.getCompilationHooks(compilation).loader.tap(
-				"LoaderPlugin",
-				loaderContext => {
-					/**
-					 * @param {string} request the request string to load the module from
-					 * @param {LoadModuleCallback} callback callback returning the loaded module or error
-					 * @returns {void}
-					 */
-					loaderContext.loadModule = (request, callback) => {
-						const dep = new LoaderDependency(request);
-						dep.loc = {
-							name: request
-						};
-						const factory = compilation.dependencyFactories.get(
-							dep.constructor
-						);
-						if (factory === undefined) {
-							return callback(
-								new Error(
-									`No module factory available for dependency type: ${dep.constructor.name}`
-								)
+		compiler.hooks.compilation.tap(
+			"LoaderPlugin",
+			(compilation, { normalModuleFactory }) => {
+				const moduleGraph = compilation.moduleGraph;
+				NormalModule.getCompilationHooks(compilation).loader.tap(
+					"LoaderPlugin",
+					loaderContext => {
+						/**
+						 * @param {string} request the request string to load the module from
+						 * @param {LoadModuleCallback} callback callback returning the loaded module or error
+						 * @returns {void}
+						 */
+						loaderContext.loadModule = (request, callback) => {
+							const dep = new LoaderDependency(request);
+							dep.loc = {
+								name: request
+							};
+							const factory = compilation.dependencyFactories.get(
+								dep.constructor
 							);
-						}
-						compilation.buildQueue.increaseParallelism();
-						compilation.handleModuleCreation(
-							{
-								factory,
-								dependencies: [dep],
-								originModule: loaderContext._module,
-								context: loaderContext.context
-							},
-							err => {
-								compilation.buildQueue.decreaseParallelism();
-								if (err) {
-									return callback(err);
-								}
-								const referencedModule = moduleGraph.getModule(dep);
-								if (!referencedModule) {
-									return callback(new Error("Cannot load the module"));
-								}
-								const moduleSource = referencedModule.originalSource();
-								if (!moduleSource) {
-									throw new Error(
-										"The module created for a LoaderDependency must have an original source"
-									);
-								}
-								let source, map;
-								if (moduleSource.sourceAndMap) {
-									const sourceAndMap = moduleSource.sourceAndMap();
-									map = sourceAndMap.map;
-									source = sourceAndMap.source;
-								} else {
-									map = moduleSource.map();
-									source = moduleSource.source();
-								}
-								if (referencedModule.buildInfo.fileDependencies) {
-									for (const d of referencedModule.buildInfo.fileDependencies) {
-										loaderContext.addDependency(d);
-									}
-								}
-								if (referencedModule.buildInfo.contextDependencies) {
-									for (const d of referencedModule.buildInfo
-										.contextDependencies) {
-										loaderContext.addContextDependency(d);
-									}
-								}
-								return callback(null, source, map, referencedModule);
+							if (factory === undefined) {
+								return callback(
+									new Error(
+										`No module factory available for dependency type: ${dep.constructor.name}`
+									)
+								);
 							}
-						);
-					};
-				}
-			);
-		});
+							compilation.buildQueue.increaseParallelism();
+							compilation.handleModuleCreation(
+								{
+									factory,
+									dependencies: [dep],
+									originModule: loaderContext._module,
+									context: loaderContext.context
+								},
+								err => {
+									compilation.buildQueue.decreaseParallelism();
+									if (err) {
+										return callback(err);
+									}
+									const referencedModule = moduleGraph.getModule(dep);
+									if (!referencedModule) {
+										return callback(new Error("Cannot load the module"));
+									}
+									const moduleSource = referencedModule.originalSource();
+									if (!moduleSource) {
+										throw new Error(
+											"The module created for a LoaderDependency must have an original source"
+										);
+									}
+									let source, map;
+									if (moduleSource.sourceAndMap) {
+										const sourceAndMap = moduleSource.sourceAndMap();
+										map = sourceAndMap.map;
+										source = sourceAndMap.source;
+									} else {
+										map = moduleSource.map();
+										source = moduleSource.source();
+									}
+									if (referencedModule.buildInfo.fileDependencies) {
+										for (const d of referencedModule.buildInfo
+											.fileDependencies) {
+											loaderContext.addDependency(d);
+										}
+									}
+									if (referencedModule.buildInfo.contextDependencies) {
+										for (const d of referencedModule.buildInfo
+											.contextDependencies) {
+											loaderContext.addContextDependency(d);
+										}
+									}
+									return callback(null, source, map, referencedModule);
+								}
+							);
+						};
+
+						/**
+						 * @param {string} moduleType the module type to use
+						 * @returns {void}
+						 */
+						loaderContext.setModuleType = moduleType => {
+							loaderContext._module.setModuleType(
+								moduleType,
+								normalModuleFactory.getParser(moduleType),
+								normalModuleFactory.getGenerator(moduleType)
+							);
+						};
+					}
+				);
+			}
+		);
 	}
 }
 module.exports = LoaderPlugin;

--- a/test/cases/loaders/module-type/foo.json
+++ b/test/cases/loaders/module-type/foo.json
@@ -1,0 +1,1 @@
+it-should-not-use-json-parser

--- a/test/cases/loaders/module-type/index.js
+++ b/test/cases/loaders/module-type/index.js
@@ -1,0 +1,4 @@
+it("should use the type set by the loader", function() {
+	const jsonContent = require("./loader/index.js!./foo.json");
+	expect(jsonContent).toBe("it-should-not-use-json-parser");
+});

--- a/test/cases/loaders/module-type/loader/index.js
+++ b/test/cases/loaders/module-type/loader/index.js
@@ -1,0 +1,4 @@
+module.exports = function(content) {
+	this.setModuleType("javascript/auto");
+	return "module.exports = " + JSON.stringify(content);
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This PR adds a `setModuleType(type)` method to the Loader interface that allows to change the type, parser and generator of the related module (closes #7057).

For instance:

```js
module.exports = function(content) {
	this.setModuleType('javascript/auto');
	return "module.exports = " + JSON.stringify(content);
};
```

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Feature

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes, let me know if I need to add more.

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

The new method should be added to the following page: https://webpack.js.org/api/loaders/