### PR TITLE
chore(deps): bump terser-webpack-plugin to 1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node-libs-browser": "^2.2.1",
     "schema-utils": "^1.0.0",
     "tapable": "^1.1.3",
-    "terser-webpack-plugin": "^1.4.1",
+    "terser-webpack-plugin": "^1.4.2",
     "watchpack": "^1.6.0",
     "webpack-sources": "^1.4.1"
   },


### PR DESCRIPTION
The version `1.4.2` is required to mitigate to mitigate npm audit warning:

```
# Run  npm update terser-webpack-plugin --depth 2  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Cross-Site Scripting                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ serialize-javascript                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ webpack [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ webpack > terser-webpack-plugin > serialize-javascript       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1426                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

See also https://github.com/webpack-contrib/terser-webpack-plugin/releases/tag/v1.4.2