### PR TITLE
Assign fallback ChunkGraph to HotUpdateChunks

### DIFF
--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -7,6 +7,7 @@
 
 const { SyncBailHook } = require("tapable");
 const { RawSource } = require("webpack-sources");
+const ChunkGraph = require("./ChunkGraph");
 const HotUpdateChunk = require("./HotUpdateChunk");
 const NormalModule = require("./NormalModule");
 const RuntimeGlobals = require("./RuntimeGlobals");
@@ -331,6 +332,7 @@ class HotModuleReplacementPlugin {
 								);
 								if (newModules.length > 0 || removedModules.length > 0) {
 									const hotUpdateChunk = new HotUpdateChunk();
+									ChunkGraph.setChunkGraphForChunk(hotUpdateChunk, chunkGraph);
 									hotUpdateChunk.id = chunkId;
 									chunkGraph.attachModules(hotUpdateChunk, newModules);
 									chunkGraph.attachRuntimeModules(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Hi, this is my first attempt at a PR for webpack. 
It seems there was no ChunckGraph fallback assigned to this plugin. I took the instructions from https://github.com/webpack-contrib/mini-css-extract-plugin/issues/462#issuecomment-551221049 and applied it here as well.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Adding ChunckGraph fallback to HotModuleReplacementPlugin. Fixes https://github.com/webpack-contrib/mini-css-extract-plugin/issues/462

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Nothing as far as I can tell
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
