### PR TITLE
feat(compiler): kill watcher by ending compilation early

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -658,6 +658,8 @@ class Compilation {
 				"DEP_WEBPACK_COMPILATION_COMPILATION_DEPENDENCIES"
 			)
 		};
+
+		this.stopped = false;
 	}
 
 	getStats() {
@@ -1212,6 +1214,10 @@ class Compilation {
 							return callback(err);
 						}
 
+						if (this.stopped) {
+							return callback();
+						}
+
 						if (!recursive) {
 							callback(null, module);
 							return;
@@ -1455,6 +1461,9 @@ class Compilation {
 	}
 
 	finish(callback) {
+		if (this.stopped) {
+			return callback();
+		}
 		const { moduleGraph, modules } = this;
 		for (const module of modules) {
 			moduleGraph.finishModule(module);
@@ -1516,6 +1525,9 @@ class Compilation {
 	 * @returns {void}
 	 */
 	seal(callback) {
+		if (this.stopped) {
+			return callback();
+		}
 		const chunkGraph = new ChunkGraph(this.moduleGraph);
 		this.chunkGraph = chunkGraph;
 
@@ -2620,6 +2632,10 @@ class Compilation {
 		for (const chunkGroup of this.chunkGroups) {
 			chunkGroup.checkConstraints();
 		}
+	}
+
+	endEarly() {
+		this.stopped = true;
 	}
 }
 

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -203,6 +203,8 @@ class Compiler {
 
 		this.infrastructureLogger = undefined;
 
+		this.compilation = null;
+
 		/** @type {WebpackOptions} */
 		this.options = /** @type {WebpackOptions} */ ({});
 
@@ -896,6 +898,7 @@ class Compiler {
 			this.hooks.compile.call(params);
 
 			const compilation = this.newCompilation(params);
+			this.compilation = compilation;
 
 			const logger = compilation.getLogger("webpack.Compiler");
 
@@ -935,6 +938,12 @@ class Compiler {
 	 */
 	close(callback) {
 		this.cache.shutdown(callback);
+	}
+
+	endCompilationEarly() {
+		if (this.compilation) {
+			this.compilation.endEarly();
+		}
 	}
 }
 

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -404,4 +404,10 @@ module.exports = class MultiCompiler {
 			callback
 		);
 	}
+
+	endCompilationEarly() {
+		this.compilers.forEach(compiler => {
+			compiler.endCompilationEarly();
+		});
+	}
 };

--- a/lib/MultiWatching.js
+++ b/lib/MultiWatching.js
@@ -56,11 +56,27 @@ class MultiWatching {
 				watching.close(finishedCallback);
 			},
 			err => {
-				this.compiler.hooks.watchClose.call();
-				if (typeof callback === "function") {
-					this.compiler.running = false;
-					callback(err);
-				}
+				this._closeOnError(err, callback);
+			}
+		);
+	}
+
+	_closeOnError(err, callback) {
+		this.compiler.hooks.watchClose.call();
+		if (typeof callback === "function") {
+			this.compiler.running = false;
+			callback(err);
+		}
+	}
+
+	kill(callback) {
+		asyncLib.forEach(
+			this.watchings,
+			(watching, finishedCallback) => {
+				watching.kill(finishedCallback);
+			},
+			err => {
+				this._closeOnError(err, callback);
 			}
 		);
 	}

--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -150,7 +150,7 @@ class Watching {
 			logger.timeEnd("beginIdle");
 			this.handler(null, stats);
 			process.nextTick(() => {
-				if (!this.closed) {
+				if (!this.closed && !compilation.stopped) {
 					this.watch(
 						compilation.fileDependencies,
 						compilation.contextDependencies,
@@ -284,6 +284,11 @@ class Watching {
 		} else {
 			finalCallback();
 		}
+	}
+
+	kill(callback) {
+		this.close(callback);
+		this.compiler.endCompilationEarly();
 	}
 }
 

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -3,6 +3,7 @@
 const path = require("path");
 const MemoryFs = require("memory-fs");
 const webpack = require("..");
+const largeCompilationMultiConfig = require("./fixtures/large-compilation/webpack-dependency/multi.webpack.config");
 
 const createMultiCompiler = () => {
 	const compiler = webpack([
@@ -154,6 +155,69 @@ describe("MultiCompiler", function() {
 				if (err) return done(err);
 				watcher.close(done);
 			});
+		});
+	});
+
+	describe("compiler.endCompilationEarly", () => {
+		it("should end a long compilation (compile)", done => {
+			const compiler = webpack(largeCompilationMultiConfig);
+			compiler.outputFileSystem = new MemoryFs();
+			setTimeout(() => {
+				compiler.endCompilationEarly();
+			}, 1000);
+			compiler.run((err, stats) => {
+				if (err) return done(err);
+				if (compiler.compilers[0].outputFileSystem.existsSync("/bundle.js"))
+					return done(
+						new Error("Bundle should not be created on killed compilation")
+					);
+				// the other bundle in this multi compilation should exist, because
+				// it is a small compilation and should finish compiling quickly
+				expect(
+					compiler.compilers[1].outputFileSystem.existsSync("/bundle2.js")
+				).toBeTruthy();
+				done();
+			});
+		});
+
+		it("should end a long compilation (watch)", done => {
+			const compiler = webpack(largeCompilationMultiConfig);
+			compiler.outputFileSystem = new MemoryFs();
+			setTimeout(() => {
+				compiler.endCompilationEarly();
+			}, 1000);
+			const watcher = compiler.watch({}, (err, stats) => {
+				watcher.close();
+
+				if (err) return done(err);
+				if (compiler.compilers[0].outputFileSystem.existsSync("/bundle.js"))
+					return done(
+						new Error("Bundle should not be created on killed compilation")
+					);
+				// the other bundle in this multi compilation should exist, because
+				// it is a small compilation and should finish compiling quickly
+				expect(
+					compiler.compilers[1].outputFileSystem.existsSync("/bundle2.js")
+				).toBeTruthy();
+				done();
+			});
+		});
+	});
+
+	describe("watcher.kill", () => {
+		it("should end a long compilation", done => {
+			const compiler = webpack(largeCompilationMultiConfig);
+			compiler.outputFileSystem = new MemoryFs();
+			const cb = jest.fn();
+			setTimeout(() => {
+				watcher.kill(() => {
+					// the watcher callback should not be called because the
+					// compilation is stopped, not completed
+					expect(cb).not.toHaveBeenCalled();
+					done();
+				});
+			}, 1000);
+			const watcher = compiler.watch({}, cb);
 		});
 	});
 });

--- a/test/fixtures/large-compilation/webpack-dependency/index.js
+++ b/test/fixtures/large-compilation/webpack-dependency/index.js
@@ -1,0 +1,3 @@
+// this creates a big compilation, the use of webpack to accomplish this
+// is not relevant here
+require("../../../../lib/webpack");

--- a/test/fixtures/large-compilation/webpack-dependency/multi.webpack.config.js
+++ b/test/fixtures/large-compilation/webpack-dependency/multi.webpack.config.js
@@ -1,0 +1,20 @@
+module.exports = [
+    {
+        context: __dirname,
+        mode: "development",
+        entry: "./index",
+        output: {
+            path: "/",
+            filename: "bundle.js"
+        },
+    },
+    {
+        context: __dirname,
+        mode: "development",
+        entry: "./simple",
+        output: {
+            path: "/",
+            filename: "bundle2.js"
+        },
+    },
+];

--- a/test/fixtures/large-compilation/webpack-dependency/simple.js
+++ b/test/fixtures/large-compilation/webpack-dependency/simple.js
@@ -1,0 +1,1 @@
+console.log("hello world");

--- a/test/fixtures/large-compilation/webpack-dependency/webpack.config.js
+++ b/test/fixtures/large-compilation/webpack-dependency/webpack.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    context: __dirname,
+    mode: "development",
+    entry: "./index",
+    output: {
+        path: "/",
+        filename: "bundle.js"
+    },
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

/cc @hiroppy @evilebottnawi 

This is an updated version of the PR: https://github.com/webpack/webpack/pull/9656

The motivation behind this is to make it possible to end a large compilation quickly. See https://github.com/webpack/webpack-dev-server/issues/1479#issuecomment-442492922

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feature

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Possibly new `kill` method for watcher

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
