### PR TITLE
fix: split-chunks-plugin, validation of filename in cacheGroup in webpack4

### DIFF
--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -614,7 +614,16 @@
                   },
                   "filename": {
                     "description": "Sets the template for the filename for created chunks (Only works for initial chunks)",
-                    "type": "string",
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "absolutePath": false
+                      },
+                      {
+                        "instanceof": "Function",
+                        "tsType": "Function"
+                      }
+                    ],
                     "minLength": 1
                   },
                   "maxAsyncRequests": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**This PR proposes to fix #10159**

[Docs](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkscachegroupscachegroupfilename) mention filename param can be a function, but I get schema validation error like this:

![image](https://user-images.githubusercontent.com/42975051/71278063-75437d80-234e-11ea-8a5c-351e7a281b00.png)

If I change [schemas/WebpackOptions.json](https://github.com/vankop/webpack/blob/27d7d0acedcbce3b8099f9c4e21dff93c177a35b/schemas/WebpackOptions.json#L615-L618) for the filename attr to accept a function it does actually work.

It also seems like webpack5 is correctly setup already.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

a change in validation of a property in options schema. I'd say bugfix.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Nope, didn't find tests covering schema options.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

Gosh no!

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

None, this will actually fix an inconstistency in the documentation.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
