### PR TITLE
bugfixes for exports and mangling

### DIFF
--- a/lib/dependencies/CommonJsExportsDependency.js
+++ b/lib/dependencies/CommonJsExportsDependency.js
@@ -18,10 +18,13 @@ const NullDependency = require("./NullDependency");
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
 
+const EMPTY_OBJECT = {};
+
 class CommonJsExportsDependency extends NullDependency {
-	constructor(range, base, names) {
+	constructor(range, valueRange, base, names) {
 		super();
 		this.range = range;
+		this.valueRange = valueRange;
 		this.base = base;
 		this.names = names;
 	}
@@ -36,8 +39,17 @@ class CommonJsExportsDependency extends NullDependency {
 	 * @returns {ExportsSpec | undefined} export names
 	 */
 	getExports(moduleGraph) {
+		const name = this.names[0];
 		return {
-			exports: [this.names[0]],
+			exports: [
+				{
+					name,
+					// we can't mangle names that are in an empty object
+					// because one could access the prototype property
+					// when export isn't set yet
+					canMangle: !(name in EMPTY_OBJECT)
+				}
+			],
 			dependencies: undefined
 		};
 	}
@@ -45,6 +57,7 @@ class CommonJsExportsDependency extends NullDependency {
 	serialize(context) {
 		const { write } = context;
 		write(this.range);
+		write(this.valueRange);
 		write(this.base);
 		write(this.names);
 		super.serialize(context);
@@ -53,6 +66,7 @@ class CommonJsExportsDependency extends NullDependency {
 	deserialize(context) {
 		const { read } = context;
 		this.range = read();
+		this.valueRange = read();
 		this.base = read();
 		this.names = read();
 		super.deserialize(context);
@@ -162,18 +176,20 @@ CommonJsExportsDependency.Template = class CommonJsExportsDependencyTemplate ext
 					);
 					source.replace(
 						dep.range[0],
-						dep.range[1] - 1,
+						dep.valueRange[0] - 1,
 						"__webpack_unused_export__ = ("
 					);
+					source.replace(dep.valueRange[1], dep.range[1] - 1, ")");
 					return;
 				}
 				source.replace(
 					dep.range[0],
-					dep.range[1] - 1,
+					dep.valueRange[0] - 1,
 					`Object.defineProperty(${base}${propertyAccess(
 						used.slice(0, -1)
-					)}, ${JSON.stringify(used[used.length - 1])}, `
+					)}, ${JSON.stringify(used[used.length - 1])}, (`
 				);
+				source.replace(dep.valueRange[1], dep.range[1] - 1, "))");
 				return;
 		}
 	}

--- a/lib/dependencies/CommonJsExportsParserPlugin.js
+++ b/lib/dependencies/CommonJsExportsParserPlugin.js
@@ -97,6 +97,7 @@ class CommonJsExportsParserPlugin {
 				checkNamespace(members, expr.right);
 				const dep = new CommonJsExportsDependency(
 					expr.left.range,
+					null,
 					"exports",
 					members
 				);
@@ -113,6 +114,7 @@ class CommonJsExportsParserPlugin {
 				checkNamespace(members, expr.right);
 				const dep = new CommonJsExportsDependency(
 					expr.left.range,
+					null,
 					"this",
 					members
 				);
@@ -129,6 +131,7 @@ class CommonJsExportsParserPlugin {
 				checkNamespace(members, expr.right);
 				const dep = new CommonJsExportsDependency(
 					expr.left.range,
+					null,
 					"module.exports",
 					members.slice(1)
 				);
@@ -149,7 +152,7 @@ class CommonJsExportsParserPlugin {
 				if (
 					exportsArg.identifier !== "exports" &&
 					exportsArg.identifier !== "module.exports" &&
-					exportsArg.identifier !== "this"
+					(exportsArg.identifier !== "this" || !parser.scope.topLevelScope)
 				) {
 					return;
 				}
@@ -161,7 +164,8 @@ class CommonJsExportsParserPlugin {
 				const descArg = expr.arguments[2];
 				checkNamespace([property], getValueOfPropertyDescription(descArg));
 				const dep = new CommonJsExportsDependency(
-					[expr.callee.range[0], expr.arguments[2].range[0]],
+					expr.range,
+					expr.arguments[2].range,
 					`Object.defineProperty(${exportsArg.identifier})`,
 					[property]
 				);

--- a/lib/optimize/MangleExportsPlugin.js
+++ b/lib/optimize/MangleExportsPlugin.js
@@ -26,17 +26,12 @@ const ARRAY = [];
 
 /**
  * @param {ExportsInfo} exportsInfo exports info
- * @param {boolean} canBeArray can be exports info point to an array
  * @returns {boolean} mangle is possible
  */
-const canMangle = (exportsInfo, canBeArray) => {
+const canMangle = exportsInfo => {
 	if (exportsInfo.otherExportsInfo.used !== UsageState.Unused) return false;
 	let hasSomethingToMangle = false;
-	const empty = canBeArray ? ARRAY : OBJECT;
 	for (const exportInfo of exportsInfo.exports) {
-		if (exportInfo.name in empty) {
-			return false;
-		}
 		if (exportInfo.canMangle === true) {
 			hasSomethingToMangle = true;
 		}
@@ -60,9 +55,10 @@ const comparator = concatComparators(
  * @returns {void}
  */
 const mangleExportsInfo = (exportsInfo, canBeArray) => {
-	if (!canMangle(exportsInfo, canBeArray)) return;
+	if (!canMangle(exportsInfo)) return;
 	const usedNames = new Set();
 	const mangleableExports = [];
+	const empty = canBeArray ? ARRAY : OBJECT;
 	// Don't rename 1-2 char exports or exports that can't be mangled
 	for (const exportInfo of exportsInfo.ownedExports) {
 		const name = exportInfo.name;
@@ -70,7 +66,9 @@ const mangleExportsInfo = (exportsInfo, canBeArray) => {
 			if (
 				exportInfo.canMangle !== true ||
 				(name.length === 1 && /^[a-zA-Z0-9_$]/.test(name)) ||
-				(name.length === 2 && /^[a-zA-Z_$][a-zA-Z0-9_$]|^[1-9][0-9]/.test(name))
+				(name.length === 2 &&
+					/^[a-zA-Z_$][a-zA-Z0-9_$]|^[1-9][0-9]/.test(name)) ||
+				(exportInfo.provided !== true && exportInfo.name in empty)
 			) {
 				exportInfo.usedName = name;
 				usedNames.add(name);

--- a/test/cases/cjs-tree-shaking/non-root-this/index.js
+++ b/test/cases/cjs-tree-shaking/non-root-this/index.js
@@ -1,0 +1,5 @@
+it("should not rewrite this nested in functions", () => {
+	const f = require("./module").fff;
+	expect(f.test1).toBe(true);
+	expect(f.test2).toBe(true);
+});

--- a/test/cases/cjs-tree-shaking/non-root-this/module.js
+++ b/test/cases/cjs-tree-shaking/non-root-this/module.js
@@ -1,0 +1,6 @@
+function F() {
+	this.test1 = true;
+	Object.defineProperty(this, "test2", { value: true });
+}
+
+exports.fff = new F();

--- a/test/cases/cjs-tree-shaking/object-define-property-replace/index.js
+++ b/test/cases/cjs-tree-shaking/object-define-property-replace/index.js
@@ -1,0 +1,3 @@
+it("should replace Object.defineProperty correctly with brakets", () => {
+	expect(require("./module").test).toBe(true);
+});

--- a/test/cases/cjs-tree-shaking/object-define-property-replace/module.js
+++ b/test/cases/cjs-tree-shaking/object-define-property-replace/module.js
@@ -1,0 +1,1 @@
+Object.defineProperty(((this)), "test", (((0, { value : true}))));

--- a/test/configCases/mangle/mangle-with-object-prop/commonjs.js
+++ b/test/configCases/mangle/mangle-with-object-prop/commonjs.js
@@ -1,0 +1,4 @@
+exports.abc = "abc";
+exports.def = "def";
+exports.toString = () => "toString";
+exports.moduleId = module.id;

--- a/test/configCases/mangle/mangle-with-object-prop/index.js
+++ b/test/configCases/mangle/mangle-with-object-prop/index.js
@@ -1,0 +1,24 @@
+import { moduleId, toString, abc } from "./module";
+const moduleId2 = require("./commonjs").moduleId;
+const toString2 = require("./commonjs").toString;
+const abc2 = require("./commonjs").abc;
+
+it("should mangle names and remove exports even with toString named export (ESM)", () => {
+	expect(abc).toBe("abc");
+	expect(toString()).toBe("toString");
+	expect(
+		Object.keys(require.cache[moduleId].exports)
+			.map(p => p.length)
+			.sort()
+	).toEqual([2, 2, 2]);
+});
+
+it("should mangle names and remove exports even with toString named export (CJS)", () => {
+	expect(abc2).toBe("abc");
+	expect(toString2()).toBe("toString");
+	expect(
+		Object.keys(require.cache[moduleId2].exports)
+			.map(p => p.length)
+			.sort()
+	).toEqual([2, 2, 8]);
+});

--- a/test/configCases/mangle/mangle-with-object-prop/module.js
+++ b/test/configCases/mangle/mangle-with-object-prop/module.js
@@ -1,0 +1,4 @@
+export const abc = "abc";
+export const def = "def";
+export const toString = () => "toString";
+export const moduleId = module.id;

--- a/test/configCases/mangle/mangle-with-object-prop/webpack.config.js
+++ b/test/configCases/mangle/mangle-with-object-prop/webpack.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	optimization: {
+		mangleExports: true,
+		usedExports: true,
+		providedExports: true
+	}
+};


### PR DESCRIPTION
allow mangle even if object prototype export names are used
prevent mangling for object prototype export names in CommonJS
only treat Object.defineProperty for top-level this as export
replace Object.defineProperty correctly when value is in brakets

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
