### PR TITLE
chore: upgrade terser-webpack-plugin to 2.3.1 to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pkg-dir": "^4.2.0",
     "schema-utils": "^2.5.0",
     "tapable": "2.0.0-beta.9",
-    "terser-webpack-plugin": "^2.2.1",
+    "terser-webpack-plugin": "^2.3.1",
     "watchpack": "2.0.0-beta.10",
     "webpack-sources": "2.0.0-beta.8"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6061,7 +6061,7 @@ temp-write@^4.0.0:
     temp-dir "^1.0.0"
     uuid "^3.3.2"
 
-terser-webpack-plugin@^2.2.1:
+terser-webpack-plugin@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-2.3.1.tgz#6a63c27debc15b25ffd2588562ee2eeabdcab923"
   integrity sha512-dNxivOXmDgZqrGxOttBH6B4xaxT4zNC+Xd+2K8jwGDMK5q2CZI+KZMA1AAnSRT+BTRvuzKsDx+fpxzPAmAMVcA==


### PR DESCRIPTION
Upgrade `terser-webpack-plugin` to latest to fix vulnerability issue on `serialize-javascript`

This is the original error:
https://github.com/advisories/GHSA-h9rv-jmmf-4pgx

This release include the fix:
https://github.com/webpack-contrib/terser-webpack-plugin/releases/tag/v2.2.3