### PR TITLE
refactor(target): remove unnecessary judgment

### DIFF
--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -218,12 +218,8 @@ class WebpackOptionsApply extends OptionsApply {
 				default:
 					throw new Error("Unsupported target '" + options.target + "'.");
 			}
-		}
-		// @ts-ignore This is always true, which is good this way
-		else if (options.target !== false) {
-			options.target(compiler);
 		} else {
-			throw new Error("Unsupported target '" + options.target + "'.");
+			options.target(compiler);
 		}
 
 		if (options.output.library || options.output.libraryTarget !== "var") {


### PR DESCRIPTION
options.target must be string or function, otherwise will throw WebpackOptionsValidationError when run webpack(options) .

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
refactoring
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
