### PR TITLE
Remove mkdirp package from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "memory-fs": "~0.5.0",
     "mini-css-extract-plugin": "^0.8.0",
     "mini-svg-data-uri": "^1.1.3",
-    "mkdirp": "^0.5.1",
     "open-cli": "^5.0.0",
     "prettier": "^1.14.3",
     "pretty-format": "^24.8.0",

--- a/test/ConfigTestCases.test.js
+++ b/test/ConfigTestCases.test.js
@@ -3,7 +3,6 @@
 const path = require("path");
 const fs = require("graceful-fs");
 const vm = require("vm");
-const mkdirp = require("mkdirp");
 const rimraf = require("rimraf");
 const checkArrayExpectation = require("./checkArrayExpectation");
 const createLazyTestEnv = require("./helpers/createLazyTestEnv");
@@ -62,7 +61,7 @@ describe("ConfigTestCases", () => {
 									resolve();
 								};
 								rimraf.sync(outputDirectory);
-								mkdirp.sync(outputDirectory);
+								fs.mkdirSync(outputDirectory, { recursive: true });
 								const options = prepareOptions(
 									require(path.join(testDirectory, "webpack.config.js")),
 									{ testPath: outputDirectory }
@@ -136,7 +135,7 @@ describe("ConfigTestCases", () => {
 										preset: "verbose",
 										colors: false
 									};
-									mkdirp.sync(outputDirectory);
+									fs.mkdirSync(outputDirectory, { recursive: true });
 									fs.writeFileSync(
 										path.join(outputDirectory, "stats.txt"),
 										stats.toString(statOptions),

--- a/test/HotModuleReplacementPlugin.test.js
+++ b/test/HotModuleReplacementPlugin.test.js
@@ -2,7 +2,6 @@
 
 const path = require("path");
 const fs = require("graceful-fs");
-const mkdirp = require("mkdirp");
 
 const webpack = require("..");
 
@@ -34,7 +33,9 @@ describe("HotModuleReplacementPlugin", () => {
 			"records.json"
 		);
 		try {
-			mkdirp.sync(path.join(__dirname, "js", "HotModuleReplacementPlugin"));
+			fs.mkdirSync(path.join(__dirname, "js", "HotModuleReplacementPlugin"), {
+				recursive: true
+			});
 		} catch (e) {
 			// empty
 		}
@@ -111,7 +112,7 @@ describe("HotModuleReplacementPlugin", () => {
 		);
 		const recordsFile = path.join(outputPath, "records.json");
 		try {
-			mkdirp.sync(outputPath);
+			fs.mkdirSync(outputPath, { recursive: true });
 		} catch (e) {
 			// empty
 		}
@@ -189,8 +190,11 @@ describe("HotModuleReplacementPlugin", () => {
 			"records.json"
 		);
 		try {
-			mkdirp.sync(
-				path.join(__dirname, "js", "HotModuleReplacementPlugin", "[name]")
+			fs.mkdirSync(
+				path.join(__dirname, "js", "HotModuleReplacementPlugin", "[name]"),
+				{
+					recursive: true
+				}
 			);
 		} catch (e) {
 			// empty

--- a/test/StatsTestCases.test.js
+++ b/test/StatsTestCases.test.js
@@ -2,7 +2,6 @@
 
 const path = require("path");
 const fs = require("graceful-fs");
-const mkdirp = require("mkdirp");
 const rimraf = require("rimraf");
 const captureStdio = require("./helpers/captureStdio");
 
@@ -50,7 +49,7 @@ describe("StatsTestCases", () => {
 			jest.setTimeout(30000);
 			const outputDirectory = path.join(outputBase, testName);
 			rimraf.sync(outputDirectory);
-			mkdirp.sync(outputDirectory);
+			fs.mkdirSync(outputDirectory, { recursive: true });
 			let options = {
 				mode: "development",
 				entry: "./index",

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -3,7 +3,6 @@
 const path = require("path");
 const fs = require("graceful-fs");
 const vm = require("vm");
-const mkdirp = require("mkdirp");
 const rimraf = require("rimraf");
 const TerserPlugin = require("terser-webpack-plugin");
 const checkArrayExpectation = require("./checkArrayExpectation");
@@ -226,7 +225,7 @@ const describeCases = config => {
 													preset: "verbose",
 													colors: false
 												};
-												mkdirp.sync(outputDirectory);
+												fs.mkdirSync(outputDirectory, { recursive: true });
 												fs.writeFileSync(
 													path.join(outputDirectory, "stats.txt"),
 													stats.toString(statOptions),

--- a/test/WatchTestCases.test.js
+++ b/test/WatchTestCases.test.js
@@ -3,7 +3,6 @@
 const path = require("path");
 const fs = require("graceful-fs");
 const vm = require("vm");
-const mkdirp = require("mkdirp");
 const rimraf = require("rimraf");
 const checkArrayExpectation = require("./checkArrayExpectation");
 const createLazyTestEnv = require("./helpers/createLazyTestEnv");
@@ -187,7 +186,7 @@ describe("WatchTestCases", () => {
 											preset: "verbose",
 											colors: false
 										};
-										mkdirp.sync(outputDirectory);
+										fs.mkdirSync(outputDirectory, { recursive: true });
 										fs.writeFileSync(
 											path.join(outputDirectory, "stats.txt"),
 											stats.toString(statOptions),

--- a/tooling/compile-to-definitions.js
+++ b/tooling/compile-to-definitions.js
@@ -1,6 +1,5 @@
 const fs = require("fs");
 const path = require("path");
-const mkdirp = require("mkdirp");
 const prettierrc = require("../.prettierrc.js"); // eslint-disable-line
 const { compileFromFile } = require("json-schema-to-typescript");
 
@@ -53,7 +52,7 @@ const makeDefinitionsForSchema = absSchemaPath => {
 			}
 			if (normalizedContent.trim() !== ts.trim()) {
 				if (doWrite) {
-					mkdirp.sync(path.dirname(filename));
+					fs.mkdirSync(path.dirname(filename), { recursive: true });
 					fs.writeFileSync(filename, ts, "utf-8");
 					console.error(
 						`declarations/${basename.replace(/\\/g, "/")}.d.ts updated`

--- a/tooling/type-coverage.js
+++ b/tooling/type-coverage.js
@@ -2,7 +2,6 @@
 
 const path = require("path");
 const fs = require("fs");
-const mkdirp = require("mkdirp");
 const ts = require("typescript");
 const program = require("./typescript-program");
 
@@ -125,7 +124,7 @@ for (const sourceFile of program.getSourceFiles()) {
 }
 
 const outputDirectory = path.resolve(__dirname, "../coverage");
-mkdirp.sync(outputDirectory);
+fs.mkdirSync(outputDirectory, { recursive: true });
 fs.writeFileSync(
 	path.resolve(outputDirectory, "coverage-types.json"),
 	JSON.stringify(coverageReport),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
webpack supports Node.js 10.13.0 as minimum Node.js version now.
Node.js 10.13.0 provides recursive option for fs.mkdirSync.
So, mkdirp package is not needed.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
refactoring

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
change tests

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
