### PR TITLE
override filename for asset modules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 * text=auto
-test/statsCases/* eol=lf
+test/statsCases/** eol=lf
 examples/* eol=lf
 bin/* eol=lf
 *.svg eol=lf

--- a/declarations/plugins/AssetModulesPluginGenerator.d.ts
+++ b/declarations/plugins/AssetModulesPluginGenerator.d.ts
@@ -17,13 +17,13 @@ export type DataUrlFunction = (
 
 export interface AssetModulesPluginGeneratorOptions {
 	/**
-	 * Override for output.assetModuleFilename
-	 */
-	assetFilename?: string;
-	/**
 	 * The options for data url generator
 	 */
 	dataUrl?: DataUrlOptions | DataUrlFunction;
+	/**
+	 * Override for output.assetModuleFilename
+	 */
+	filename?: string;
 }
 /**
  * This interface was referenced by `AssetModulesPluginGeneratorOptions`'s JSON-Schema

--- a/declarations/plugins/AssetModulesPluginGenerator.d.ts
+++ b/declarations/plugins/AssetModulesPluginGenerator.d.ts
@@ -23,7 +23,12 @@ export interface AssetModulesPluginGeneratorOptions {
 	/**
 	 * Override for output.assetModuleFilename
 	 */
-	filename?: string;
+	filename?:
+		| string
+		| ((
+				pathData: import("../../lib/Compilation").PathData,
+				assetInfo?: import("../../lib/Compilation").AssetInfo
+		  ) => string);
 }
 /**
  * This interface was referenced by `AssetModulesPluginGeneratorOptions`'s JSON-Schema

--- a/declarations/plugins/AssetModulesPluginGenerator.d.ts
+++ b/declarations/plugins/AssetModulesPluginGenerator.d.ts
@@ -17,6 +17,10 @@ export type DataUrlFunction = (
 
 export interface AssetModulesPluginGeneratorOptions {
 	/**
+	 * Override for output.assetModuleFilename
+	 */
+	assetFilename?: string;
+	/**
 	 * The options for data url generator
 	 */
 	dataUrl?: DataUrlOptions | DataUrlFunction;

--- a/declarations/plugins/AssetModulesPluginGenerator.d.ts
+++ b/declarations/plugins/AssetModulesPluginGenerator.d.ts
@@ -21,7 +21,7 @@ export interface AssetModulesPluginGeneratorOptions {
 	 */
 	dataUrl?: DataUrlOptions | DataUrlFunction;
 	/**
-	 * Override for output.assetModuleFilename
+	 * Template for asset filename
 	 */
 	filename?:
 		| string

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -29,11 +29,13 @@ class AssetGenerator extends Generator {
 	/**
 	 * @param {Compilation} compilation the compilation
 	 * @param {AssetModulesPluginGeneratorOptions["dataUrl"]=} dataUrlOptions the options for the data url
+	 * @param {string=} assetFilename override for output.assetModuleFilename
 	 */
-	constructor(compilation, dataUrlOptions) {
+	constructor(compilation, dataUrlOptions, assetFilename) {
 		super();
 		this.compilation = compilation;
 		this.dataUrlOptions = dataUrlOptions;
+		this.assetFilename = assetFilename;
 	}
 
 	/**
@@ -44,11 +46,12 @@ class AssetGenerator extends Generator {
 	generate(module, { chunkGraph, runtimeTemplate, runtimeRequirements, type }) {
 		switch (type) {
 			case "asset":
+				module.buildInfo.assetFilename = this.assetFilename;
 				return module.originalSource();
 			default: {
 				runtimeRequirements.add(RuntimeGlobals.module);
 
-				if (module.buildInfo.dataUrl) {
+				if (module.buildInfo.dataUrl && !this.assetFilename) {
 					const originalSource = module.originalSource();
 
 					let encodedSource;
@@ -105,7 +108,9 @@ class AssetGenerator extends Generator {
 					);
 				} else {
 					const filename = module.nameForCondition();
-					const { assetModuleFilename } = runtimeTemplate.outputOptions;
+					const assetModuleFilename =
+						this.assetFilename ||
+						runtimeTemplate.outputOptions.assetModuleFilename;
 					const url = this.compilation.getAssetPath(assetModuleFilename, {
 						module,
 						filename,
@@ -129,7 +134,7 @@ class AssetGenerator extends Generator {
 	 * @returns {Set<string>} available types (do not mutate)
 	 */
 	getTypes(module) {
-		if (module.buildInfo.dataUrl) {
+		if (module.buildInfo.dataUrl && !this.assetFilename) {
 			return JS_TYPES;
 		} else {
 			return JS_AND_ASSET_TYPES;
@@ -153,7 +158,7 @@ class AssetGenerator extends Generator {
 				return originalSource.size();
 			}
 			default:
-				if (module.buildInfo.dataUrl) {
+				if (module.buildInfo.dataUrl && !this.assetFilename) {
 					const originalSource = module.originalSource();
 
 					if (!originalSource) {
@@ -178,7 +183,9 @@ class AssetGenerator extends Generator {
 	 * @param {UpdateHashContext} updateHashContext context for updating hash
 	 */
 	updateHash(hash, { module }) {
-		hash.update(module.buildInfo.dataUrl ? "data-url" : "resource");
+		hash.update(
+			module.buildInfo.dataUrl && !this.assetFilename ? "data-url" : "resource"
+		);
 	}
 }
 

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -51,7 +51,7 @@ class AssetGenerator extends Generator {
 			default: {
 				runtimeRequirements.add(RuntimeGlobals.module);
 
-				if (module.buildInfo.dataUrl && !this.filename) {
+				if (module.buildInfo.dataUrl) {
 					const originalSource = module.originalSource();
 
 					let encodedSource;
@@ -133,7 +133,7 @@ class AssetGenerator extends Generator {
 	 * @returns {Set<string>} available types (do not mutate)
 	 */
 	getTypes(module) {
-		if (module.buildInfo.dataUrl && !this.filename) {
+		if (module.buildInfo.dataUrl) {
 			return JS_TYPES;
 		} else {
 			return JS_AND_ASSET_TYPES;
@@ -157,7 +157,7 @@ class AssetGenerator extends Generator {
 				return originalSource.size();
 			}
 			default:
-				if (module.buildInfo.dataUrl && !this.filename) {
+				if (module.buildInfo.dataUrl) {
 					const originalSource = module.originalSource();
 
 					if (!originalSource) {
@@ -182,9 +182,7 @@ class AssetGenerator extends Generator {
 	 * @param {UpdateHashContext} updateHashContext context for updating hash
 	 */
 	updateHash(hash, { module }) {
-		hash.update(
-			module.buildInfo.dataUrl && !this.filename ? "data-url" : "resource"
-		);
+		hash.update(module.buildInfo.dataUrl ? "data-url" : "resource");
 	}
 }
 

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -29,13 +29,13 @@ class AssetGenerator extends Generator {
 	/**
 	 * @param {Compilation} compilation the compilation
 	 * @param {AssetModulesPluginGeneratorOptions["dataUrl"]=} dataUrlOptions the options for the data url
-	 * @param {string=} assetFilename override for output.assetModuleFilename
+	 * @param {string=} filename override for output.assetModuleFilename
 	 */
-	constructor(compilation, dataUrlOptions, assetFilename) {
+	constructor(compilation, dataUrlOptions, filename) {
 		super();
 		this.compilation = compilation;
 		this.dataUrlOptions = dataUrlOptions;
-		this.assetFilename = assetFilename;
+		this.filename = filename;
 	}
 
 	/**
@@ -46,12 +46,12 @@ class AssetGenerator extends Generator {
 	generate(module, { chunkGraph, runtimeTemplate, runtimeRequirements, type }) {
 		switch (type) {
 			case "asset":
-				module.buildInfo.assetFilename = this.assetFilename;
+				module.buildInfo.assetFilename = this.filename;
 				return module.originalSource();
 			default: {
 				runtimeRequirements.add(RuntimeGlobals.module);
 
-				if (module.buildInfo.dataUrl && !this.assetFilename) {
+				if (module.buildInfo.dataUrl && !this.filename) {
 					const originalSource = module.originalSource();
 
 					let encodedSource;
@@ -109,8 +109,7 @@ class AssetGenerator extends Generator {
 				} else {
 					const filename = module.nameForCondition();
 					const assetModuleFilename =
-						this.assetFilename ||
-						runtimeTemplate.outputOptions.assetModuleFilename;
+						this.filename || runtimeTemplate.outputOptions.assetModuleFilename;
 					const url = this.compilation.getAssetPath(assetModuleFilename, {
 						module,
 						filename,
@@ -134,7 +133,7 @@ class AssetGenerator extends Generator {
 	 * @returns {Set<string>} available types (do not mutate)
 	 */
 	getTypes(module) {
-		if (module.buildInfo.dataUrl && !this.assetFilename) {
+		if (module.buildInfo.dataUrl && !this.filename) {
 			return JS_TYPES;
 		} else {
 			return JS_AND_ASSET_TYPES;
@@ -158,7 +157,7 @@ class AssetGenerator extends Generator {
 				return originalSource.size();
 			}
 			default:
-				if (module.buildInfo.dataUrl && !this.assetFilename) {
+				if (module.buildInfo.dataUrl && !this.filename) {
 					const originalSource = module.originalSource();
 
 					if (!originalSource) {
@@ -184,7 +183,7 @@ class AssetGenerator extends Generator {
 	 */
 	updateHash(hash, { module }) {
 		hash.update(
-			module.buildInfo.dataUrl && !this.assetFilename ? "data-url" : "resource"
+			module.buildInfo.dataUrl && !this.filename ? "data-url" : "resource"
 		);
 	}
 }

--- a/lib/asset/AssetModulesPlugin.js
+++ b/lib/asset/AssetModulesPlugin.js
@@ -17,6 +17,33 @@ const memorize = require("../util/memorize");
 const getGeneratorSchema = memorize(() =>
 	require("../../schemas/plugins/AssetModulesPluginGenerator.json")
 );
+
+const getGeneratorSchemaMap = {
+	asset: memorize(() =>
+		require("../../schemas/plugins/AssetModulesPluginGenerator.json")
+	),
+	"asset/resource": memorize(() => {
+		const base = getGeneratorSchema();
+		return {
+			...base,
+			properties: {
+				...base.properties,
+				dataUrl: false
+			}
+		};
+	}),
+	"asset/inline": memorize(() => {
+		const base = getGeneratorSchema();
+		return {
+			...base,
+			properties: {
+				...base.properties,
+				filename: false
+			}
+		};
+	})
+};
+
 const getParserSchema = memorize(() =>
 	require("../../schemas/plugins/AssetModulesPluginParser.json")
 );
@@ -85,7 +112,7 @@ class AssetModulesPlugin {
 						.for(type)
 						// eslint-disable-next-line no-loop-func
 						.tap(plugin, generatorOptions => {
-							validateOptions(getGeneratorSchema(), generatorOptions, {
+							validateOptions(getGeneratorSchemaMap[type](), generatorOptions, {
 								name: "Asset Modules Plugin",
 								baseDataPath: "generator"
 							});
@@ -111,10 +138,14 @@ class AssetModulesPlugin {
 				normalModuleFactory.hooks.createGenerator
 					.for("asset/resource")
 					.tap(plugin, generatorOptions => {
-						validateOptions(getGeneratorSchema(), generatorOptions, {
-							name: "Asset Modules Plugin",
-							baseDataPath: "generator"
-						});
+						validateOptions(
+							getGeneratorSchemaMap["asset/resource"](),
+							generatorOptions,
+							{
+								name: "Asset Modules Plugin",
+								baseDataPath: "generator"
+							}
+						);
 
 						const AssetGenerator = getAssetGenerator();
 

--- a/lib/asset/AssetModulesPlugin.js
+++ b/lib/asset/AssetModulesPlugin.js
@@ -19,9 +19,7 @@ const getGeneratorSchema = memorize(() =>
 );
 
 const getGeneratorSchemaMap = {
-	asset: memorize(() =>
-		require("../../schemas/plugins/AssetModulesPluginGenerator.json")
-	),
+	asset: getGeneratorSchema,
 	"asset/resource": memorize(() => {
 		const base = getGeneratorSchema();
 		return {
@@ -107,7 +105,7 @@ class AssetModulesPlugin {
 						return new AssetParser(false);
 					});
 
-				for (const type of ["asset", "asset/inline"]) {
+				for (const type of ["asset", "asset/inline", "asset/resource"]) {
 					normalModuleFactory.hooks.createGenerator
 						.for(type)
 						// eslint-disable-next-line no-loop-func
@@ -117,44 +115,28 @@ class AssetModulesPlugin {
 								baseDataPath: "generator"
 							});
 
-							let dataUrl = generatorOptions.dataUrl;
-							if (!dataUrl || typeof dataUrl === "object") {
-								dataUrl = {
-									encoding: "base64",
-									mimetype: undefined,
-									...dataUrl
-								};
+							let dataUrl = undefined;
+							if (type !== "asset/resource") {
+								dataUrl = generatorOptions.dataUrl;
+								if (!dataUrl || typeof dataUrl === "object") {
+									dataUrl = {
+										encoding: "base64",
+										mimetype: undefined,
+										...dataUrl
+									};
+								}
+							}
+
+							let filename = undefined;
+							if (type !== "asset/inline") {
+								filename = generatorOptions.filename;
 							}
 
 							const AssetGenerator = getAssetGenerator();
 
-							return new AssetGenerator(
-								compilation,
-								dataUrl,
-								type === "asset" ? generatorOptions.filename : null
-							);
+							return new AssetGenerator(compilation, dataUrl, filename);
 						});
 				}
-				normalModuleFactory.hooks.createGenerator
-					.for("asset/resource")
-					.tap(plugin, generatorOptions => {
-						validateOptions(
-							getGeneratorSchemaMap["asset/resource"](),
-							generatorOptions,
-							{
-								name: "Asset Modules Plugin",
-								baseDataPath: "generator"
-							}
-						);
-
-						const AssetGenerator = getAssetGenerator();
-
-						return new AssetGenerator(
-							compilation,
-							null,
-							generatorOptions.filename
-						);
-					});
 				normalModuleFactory.hooks.createGenerator
 					.for("asset/source")
 					.tap(plugin, () => {

--- a/lib/asset/AssetModulesPlugin.js
+++ b/lib/asset/AssetModulesPlugin.js
@@ -101,15 +101,28 @@ class AssetModulesPlugin {
 
 							const AssetGenerator = getAssetGenerator();
 
-							return new AssetGenerator(compilation, dataUrl);
+							return new AssetGenerator(
+								compilation,
+								dataUrl,
+								type === "asset" ? generatorOptions.assetFilename : null
+							);
 						});
 				}
 				normalModuleFactory.hooks.createGenerator
 					.for("asset/resource")
-					.tap(plugin, () => {
+					.tap(plugin, generatorOptions => {
+						validateOptions(getGeneratorSchema(), generatorOptions, {
+							name: "Asset Modules Plugin",
+							baseDataPath: "generator"
+						});
+
 						const AssetGenerator = getAssetGenerator();
 
-						return new AssetGenerator(compilation);
+						return new AssetGenerator(
+							compilation,
+							null,
+							generatorOptions.assetFilename
+						);
 					});
 				normalModuleFactory.hooks.createGenerator
 					.for("asset/source")
@@ -133,7 +146,9 @@ class AssetModulesPlugin {
 					if (modules) {
 						for (const module of modules) {
 							const filename = module.nameForCondition();
-							const filenameTemplate = outputOptions.assetModuleFilename;
+							const filenameTemplate =
+								module.buildInfo.assetFilename ||
+								outputOptions.assetModuleFilename;
 
 							result.push({
 								render: () =>

--- a/lib/asset/AssetModulesPlugin.js
+++ b/lib/asset/AssetModulesPlugin.js
@@ -104,7 +104,7 @@ class AssetModulesPlugin {
 							return new AssetGenerator(
 								compilation,
 								dataUrl,
-								type === "asset" ? generatorOptions.assetFilename : null
+								type === "asset" ? generatorOptions.filename : null
 							);
 						});
 				}
@@ -121,7 +121,7 @@ class AssetModulesPlugin {
 						return new AssetGenerator(
 							compilation,
 							null,
-							generatorOptions.assetFilename
+							generatorOptions.filename
 						);
 					});
 				normalModuleFactory.hooks.createGenerator

--- a/schemas/plugins/AssetModulesPluginGenerator.json
+++ b/schemas/plugins/AssetModulesPluginGenerator.json
@@ -24,10 +24,6 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "assetFilename": {
-      "description": "Override for output.assetModuleFilename",
-      "type": "string"
-    },
     "dataUrl": {
       "description": "The options for data url generator",
       "oneOf": [
@@ -38,6 +34,10 @@
           "$ref": "#/definitions/DataUrlFunction"
         }
       ]
+    },
+    "filename": {
+      "description": "Override for output.assetModuleFilename",
+      "type": "string"
     }
   }
 }

--- a/schemas/plugins/AssetModulesPluginGenerator.json
+++ b/schemas/plugins/AssetModulesPluginGenerator.json
@@ -36,7 +36,7 @@
       ]
     },
     "filename": {
-      "description": "Override for output.assetModuleFilename",
+      "description": "Template for asset filename",
       "anyOf": [
         {
           "type": "string",

--- a/schemas/plugins/AssetModulesPluginGenerator.json
+++ b/schemas/plugins/AssetModulesPluginGenerator.json
@@ -37,7 +37,16 @@
     },
     "filename": {
       "description": "Override for output.assetModuleFilename",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string",
+          "absolutePath": false
+        },
+        {
+          "instanceof": "Function",
+          "tsType": "((pathData: import(\"../../lib/Compilation\").PathData, assetInfo?: import(\"../../lib/Compilation\").AssetInfo) => string)"
+        }
+      ]
     }
   }
 }

--- a/schemas/plugins/AssetModulesPluginGenerator.json
+++ b/schemas/plugins/AssetModulesPluginGenerator.json
@@ -24,6 +24,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "assetFilename": {
+      "description": "Override for output.assetModuleFilename",
+      "type": "string"
+    },
     "dataUrl": {
       "description": "The options for data url generator",
       "oneOf": [

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -131,17 +131,19 @@ chunk b4a95c5544295741de67.js 899 bytes [rendered]
 `;
 
 exports[`StatsTestCases should print correct stats for asset 1`] = `
-"Hash: af0de91ff8df9396500e
+"Hash: 06c0cd2ae48907c7b433
 Time: Xms
 Built at: 1970-04-20 12:42:42
-                   Asset      Size
-6eef074bdaf47143a239.png  14.6 KiB  [emitted] [immutable]  [name: (main)]
-               bundle.js  10.6 KiB  [emitted]              [name: main]
-Entrypoint main = bundle.js (6eef074bdaf47143a239.png)
-./index.js 111 bytes [built]
+                   Asset       Size
+6eef074bdaf47143a239.png   14.6 KiB  [emitted] [immutable]  [name: (main)]
+               bundle.js   10.9 KiB  [emitted]              [name: main]
+        static/file.html  124 bytes  [emitted]              [name: (main)]
+Entrypoint main = bundle.js (6eef074bdaf47143a239.png static/file.html)
+./index.js 150 bytes [built]
 ./images/file.png 42 bytes (javascript) 14.6 KiB (asset) [built]
 ./images/file.svg 915 bytes [built]
 ./images/file.jpg 7.92 KiB [built]
+./static/file.html 42 bytes (javascript) 124 bytes (asset) [built]
     + 1 hidden module"
 `;
 

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -131,19 +131,19 @@ chunk b4a95c5544295741de67.js 899 bytes [rendered]
 `;
 
 exports[`StatsTestCases should print correct stats for asset 1`] = `
-"Hash: 06c0cd2ae48907c7b433
+"Hash: ccfed10a060986668b48
 Time: Xms
 Built at: 1970-04-20 12:42:42
-                   Asset       Size
-6eef074bdaf47143a239.png   14.6 KiB  [emitted] [immutable]  [name: (main)]
-               bundle.js   10.9 KiB  [emitted]              [name: main]
-        static/file.html  124 bytes  [emitted]              [name: (main)]
+                   Asset      Size
+6eef074bdaf47143a239.png  14.6 KiB  [emitted] [immutable]  [name: (main)]
+               bundle.js  10.9 KiB  [emitted]              [name: main]
+        static/file.html  12 bytes  [emitted]              [name: (main)]
 Entrypoint main = bundle.js (6eef074bdaf47143a239.png static/file.html)
 ./index.js 150 bytes [built]
 ./images/file.png 42 bytes (javascript) 14.6 KiB (asset) [built]
 ./images/file.svg 915 bytes [built]
 ./images/file.jpg 7.92 KiB [built]
-./static/file.html 42 bytes (javascript) 124 bytes (asset) [built]
+./static/file.html 42 bytes (javascript) 12 bytes (asset) [built]
     + 1 hidden module"
 `;
 

--- a/test/configCases/asset-modules/_static/file.html
+++ b/test/configCases/asset-modules/_static/file.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/test/configCases/asset-modules/overridePath/index.js
+++ b/test/configCases/asset-modules/overridePath/index.js
@@ -1,0 +1,7 @@
+import url from "../_images/file.png";
+import index from "../_static/file.html";
+
+it("should output asset with path", () => {
+	expect(url).toEqual("images/file.png");
+	expect(index).toEqual("static/index.html");
+});

--- a/test/configCases/asset-modules/overridePath/webpack.config.js
+++ b/test/configCases/asset-modules/overridePath/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
 				test: /\.html$/,
 				type: "asset",
 				generator: {
-					assetFilename: "static/index.html"
+					filename: "static/index.html"
 				}
 			}
 		]

--- a/test/configCases/asset-modules/overridePath/webpack.config.js
+++ b/test/configCases/asset-modules/overridePath/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
 			},
 			{
 				test: /\.html$/,
-				type: "asset",
+				type: "asset/resource",
 				generator: {
 					filename: "static/index.html"
 				}

--- a/test/configCases/asset-modules/overridePath/webpack.config.js
+++ b/test/configCases/asset-modules/overridePath/webpack.config.js
@@ -1,23 +1,22 @@
 module.exports = {
-	mode: "production",
-	entry: "./index.js",
+	mode: "development",
+	output: {
+		assetModuleFilename: "images/file[ext]"
+	},
 	module: {
 		rules: [
 			{
-				test: /\.(png|jpg|svg)$/,
+				test: /\.png$/,
 				type: "asset"
 			},
 			{
 				test: /\.html$/,
 				type: "asset",
 				generator: {
-					assetFilename: "static/[name][ext]"
+					assetFilename: "static/index.html"
 				}
 			}
 		]
-	},
-	output: {
-		filename: "bundle.js"
 	},
 	experiments: {
 		asset: true

--- a/test/statsCases/asset/index.js
+++ b/test/statsCases/asset/index.js
@@ -1,3 +1,4 @@
 import png from "./images/file.png";
 import svg from "./images/file.svg";
 import jpg from "./images/file.jpg";
+import html from "./static/file.html";

--- a/test/statsCases/asset/static/file.html
+++ b/test/statsCases/asset/static/file.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/test/statsCases/asset/static/file.html
+++ b/test/statsCases/asset/static/file.html
@@ -1,10 +1,1 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Title</title>
-</head>
-<body>
-
-</body>
-</html>
+<div></div>

--- a/test/statsCases/asset/webpack.config.js
+++ b/test/statsCases/asset/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
 			},
 			{
 				test: /\.html$/,
-				type: "asset",
+				type: "asset/resource",
 				generator: {
 					filename: "static/[name][ext]"
 				}

--- a/test/statsCases/asset/webpack.config.js
+++ b/test/statsCases/asset/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
 				test: /\.html$/,
 				type: "asset",
 				generator: {
-					assetFilename: "static/[name][ext]"
+					filename: "static/[name][ext]"
 				}
 			}
 		]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feature

```js
module.exports = {
	output: {
		assetModuleFilename: "images/[hash][ext]"
	},
	module: {
		rules: [
			{
				test: /\.(png|jpg)$/,
				type: "asset"
			},
			{
				test: /\.html$/,
				type: "asset",
				generator: {
					filename: "static/[name][ext]"
				}
			}
		]
	},
	experiments: {
		asset: true
	}
};
```

**Did you add tests for your changes?**

yes

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

about `generator.assetFilename`