### PR TITLE
Add options arg to EnvironmentPlugin, fixes #10296

### DIFF
--- a/lib/EnvironmentPlugin.js
+++ b/lib/EnvironmentPlugin.js
@@ -13,16 +13,6 @@ const WebpackError = require("./WebpackError");
 
 class EnvironmentPlugin {
 	constructor(...keys) {
-		this.options = {};
-		if (keys.length > 1) {
-			const options = keys[keys.length - 1];
-			if (typeof options === "object") {
-				this.options = options;
-				// remove options object from env keys
-				keys.pop();
-			}
-		}
-
 		if (keys.length === 1 && Array.isArray(keys[0])) {
 			this.keys = keys[0];
 			this.defaultValues = {};
@@ -57,11 +47,7 @@ class EnvironmentPlugin {
 					);
 
 					error.name = "EnvVariableNotDefinedError";
-					if (this.options["errorLevel"] === "error") {
-						compilation.errors.push(error);
-					} else {
-						compilation.warnings.push(error);
-					}
+					compilation.errors.push(error);
 				});
 			}
 

--- a/lib/EnvironmentPlugin.js
+++ b/lib/EnvironmentPlugin.js
@@ -13,6 +13,16 @@ const WebpackError = require("./WebpackError");
 
 class EnvironmentPlugin {
 	constructor(...keys) {
+		this.options = {};
+		if (keys.length > 1) {
+			const options = keys[keys.length - 1];
+			if (typeof options === "object") {
+				this.options = options;
+				// remove options object from env keys
+				keys.pop();
+			}
+		}
+
 		if (keys.length === 1 && Array.isArray(keys[0])) {
 			this.keys = keys[0];
 			this.defaultValues = {};
@@ -47,7 +57,11 @@ class EnvironmentPlugin {
 					);
 
 					error.name = "EnvVariableNotDefinedError";
-					compilation.warnings.push(error);
+					if (this.options["errorLevel"] === "error") {
+						compilation.errors.push(error);
+					} else {
+						compilation.warnings.push(error);
+					}
 				});
 			}
 

--- a/test/configCases/plugins/environment-plugin/errors.js
+++ b/test/configCases/plugins/environment-plugin/errors.js
@@ -1,4 +1,4 @@
-const variables = ['aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff', 'ggg', 'hhh', 'iii', 'jjj', 'lll', 'mmm'];
+const variables = ['aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff', 'ggg', 'hhh', 'iii'];
 const modules = [{
 	name: 'aaa',
 	variables: ['aaa']
@@ -7,7 +7,10 @@ const modules = [{
 	variables: ['bbb', 'ccc']
 }, {
 	name: 'ddd',
-	variables: []
+	variables: [],
+	allowedErrors: [
+		[{compilerPath: /ddd/}, /DDD environment variable is undefined./]
+	]
 }, {
 	name: 'eeefff',
 	variables: ['eee', 'fff']
@@ -17,15 +20,6 @@ const modules = [{
 }, {
 	name: 'iii',
 	variables: ['iii']
-}, {
-	name: 'jjj',
-	variables: [],
-	allowedErrors: [
-		[{compilerPath: /jjj/}, /JJJ environment variable is undefined./]
-	]
-}, {
-	name: 'lllmmm',
-	variables: ['lll', 'mmm']
 }];
 
 // build an array of regular expressions of expected errors

--- a/test/configCases/plugins/environment-plugin/errors.js
+++ b/test/configCases/plugins/environment-plugin/errors.js
@@ -1,4 +1,4 @@
-const variables = ['aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff', 'ggg', 'hhh', 'iii'];
+const variables = ['aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff', 'ggg', 'hhh', 'iii', 'jjj', 'lll', 'mmm'];
 const modules = [{
 	name: 'aaa',
 	variables: ['aaa']
@@ -17,6 +17,15 @@ const modules = [{
 }, {
 	name: 'iii',
 	variables: ['iii']
+}, {
+	name: 'jjj',
+	variables: [],
+	allowedErrors: [
+		[{compilerPath: /jjj/}, /JJJ environment variable is undefined./]
+	]
+}, {
+	name: 'lllmmm',
+	variables: ['lll', 'mmm']
 }];
 
 // build an array of regular expressions of expected errors
@@ -31,6 +40,10 @@ modules.forEach(module => {
 			]);
 		}
 	});
+	
+	if (module.allowedErrors) {
+		regex.push(...module.allowedErrors)
+	}
 });
 
 module.exports = regex;

--- a/test/configCases/plugins/environment-plugin/index.js
+++ b/test/configCases/plugins/environment-plugin/index.js
@@ -26,3 +26,12 @@ it("should import multiple process.env var with default values", () => {
 it("should import process.env var with empty value", () => {
 	if (process.env.III !== "") if (never) require("iii");
 });
+
+it("should error when a process.env variable is undefined", () => {
+	if (process.env.JJJ !== "jjj") if (never) require("jjj");
+});
+
+it("should import multiple process.env var with default values even with errorLevel set to error", () => {
+	if (process.env.LLL !== "lll") if (never) require("lll");
+	if (process.env.MMM !== "mmm") if (never) require("mmm");
+});

--- a/test/configCases/plugins/environment-plugin/index.js
+++ b/test/configCases/plugins/environment-plugin/index.js
@@ -9,7 +9,7 @@ it("should import multiple process.env vars", () => {
 	if (process.env.CCC !== "ccc") if (never) require("ccc");
 });
 
-it("should warn when a process.env variable is undefined", () => {
+it("should error when a process.env variable is undefined", () => {
 	if (process.env.DDD !== "ddd") if (never) require("ddd");
 });
 
@@ -25,13 +25,4 @@ it("should import multiple process.env var with default values", () => {
 
 it("should import process.env var with empty value", () => {
 	if (process.env.III !== "") if (never) require("iii");
-});
-
-it("should error when a process.env variable is undefined", () => {
-	if (process.env.JJJ !== "jjj") if (never) require("jjj");
-});
-
-it("should import multiple process.env var with default values even with errorLevel set to error", () => {
-	if (process.env.LLL !== "lll") if (never) require("lll");
-	if (process.env.MMM !== "mmm") if (never) require("mmm");
 });

--- a/test/configCases/plugins/environment-plugin/warnings.js
+++ b/test/configCases/plugins/environment-plugin/warnings.js
@@ -1,3 +1,0 @@
-module.exports = [
-	[{compilerPath: /ddd/}, /DDD environment variable is undefined./]
-];

--- a/test/configCases/plugins/environment-plugin/webpack.config.js
+++ b/test/configCases/plugins/environment-plugin/webpack.config.js
@@ -9,6 +9,7 @@ process.env.EEE = "eee";
 process.env.FFF = "fff";
 process.env.GGG = "ggg";
 process.env.III = "";
+process.env.LLL = "lll";
 
 module.exports = [
 	{
@@ -63,5 +64,29 @@ module.exports = [
 			unknownContextCritical: false
 		},
 		plugins: [new EnvironmentPlugin("III")]
+	},
+	{
+		name: "jjj",
+		module: {
+			unknownContextRegExp: /$^/,
+			unknownContextCritical: false
+		},
+		plugins: [new EnvironmentPlugin("JJJ", { errorLevel: "error" })]
+	},
+	{
+		name: "lllmmm",
+		module: {
+			unknownContextRegExp: /$^/,
+			unknownContextCritical: false
+		},
+		plugins: [
+			new EnvironmentPlugin(
+				{
+					LLL: "lll-default",
+					MMM: "mmm"
+				},
+				{ errorLevel: "error" }
+			)
+		]
 	}
 ];

--- a/test/configCases/plugins/environment-plugin/webpack.config.js
+++ b/test/configCases/plugins/environment-plugin/webpack.config.js
@@ -9,7 +9,6 @@ process.env.EEE = "eee";
 process.env.FFF = "fff";
 process.env.GGG = "ggg";
 process.env.III = "";
-process.env.LLL = "lll";
 
 module.exports = [
 	{
@@ -64,29 +63,5 @@ module.exports = [
 			unknownContextCritical: false
 		},
 		plugins: [new EnvironmentPlugin("III")]
-	},
-	{
-		name: "jjj",
-		module: {
-			unknownContextRegExp: /$^/,
-			unknownContextCritical: false
-		},
-		plugins: [new EnvironmentPlugin("JJJ", { errorLevel: "error" })]
-	},
-	{
-		name: "lllmmm",
-		module: {
-			unknownContextRegExp: /$^/,
-			unknownContextCritical: false
-		},
-		plugins: [
-			new EnvironmentPlugin(
-				{
-					LLL: "lll-default",
-					MMM: "mmm"
-				},
-				{ errorLevel: "error" }
-			)
-		]
 	}
 ];


### PR DESCRIPTION
Currently, the EnvironmentPlugin adds a warning to the build if an environment variable is undefined and no default value was provided. This pull request changes webpack to error instead, if an expected environment variable is not found it is more likely that the user would want webpack to error.

This addresses issue #10296

**What kind of change does this PR introduce?**
feature

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
Yes, as per the review by @sokra this is a breaking change. If an environment variable is not found during build webpack will now error rather than warn

**What needs to be documented once your changes are merged?**
If an environment variable is not found during bundling and no default was provided webpack will now error instead of warn

<!-- When your changes are merged you will be asked to contribute this to the documentation -->
