### PR TITLE
refactor Persistent Cache

### DIFF
--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -235,35 +235,35 @@ class Pack {
 			}
 		}
 
-		let mergedContent;
 		// 2. Check if minimium number is reached
+		let mergedIndices;
 		if (
 			smallUsedContents.length >= CONTENT_COUNT_TO_MERGE ||
 			smallUsedContentSize > MIN_CONTENT_SIZE
 		) {
-			mergedContent = smallUsedContents.map(i => this.content[i]);
-
-			// 3. Remove old content entries
-			for (const i of smallUsedContents) {
-				this.content[i] = undefined;
-			}
+			mergedIndices = smallUsedContents;
 		} else if (
 			smallUnusedContents.length >= CONTENT_COUNT_TO_MERGE ||
 			smallUnusedContentSize > MIN_CONTENT_SIZE
 		) {
-			mergedContent = smallUnusedContents.map(i => this.content[i]);
-
-			// 3. Remove old content entries
-			for (const i of smallUnusedContents) {
-				this.content[i] = undefined;
-			}
+			mergedIndices = smallUnusedContents;
 		} else return;
+
+		const mergedContent = [];
+
+		// 3. Remove old content entries
+		for (const i of mergedIndices) {
+			mergedContent.push(this.content[i]);
+			this.content[i] = undefined;
+		}
 
 		// 4. Determine merged items
 		/** @type {Set<string>} */
 		const mergedItems = new Set();
 		/** @type {Set<string>} */
 		const mergedUsedItems = new Set();
+		/** @type {(function(Map<string, any>): Promise)[]} */
+		const addToMergedMap = [];
 		for (const content of mergedContent) {
 			for (const identifier of content.items) {
 				mergedItems.add(identifier);
@@ -271,6 +271,14 @@ class Pack {
 			for (const identifer of content.used) {
 				mergedUsedItems.add(identifer);
 			}
+			addToMergedMap.push(async map => {
+				// unpack existing content
+				// after that values are accessible in .content
+				await content.unpack();
+				for (const [identifier, value] of content.content) {
+					map.set(identifier, value);
+				}
+			});
 		}
 
 		// 5. GC and update location of merged items
@@ -283,18 +291,9 @@ class Pack {
 				mergedItems,
 				mergedUsedItems,
 				memorize(async () => {
-					// unpack existing content in parallel
-					// after that values are accessible in .content
-					await Promise.all(mergedContent.map(c => c.unpack()));
 					/** @type {Map<string, any>} */
 					const map = new Map();
-					for (const content of mergedContent) {
-						for (const [identifier, value] of content.content) {
-							if (mergedItems.has(identifier)) {
-								map.set(identifier, value);
-							}
-						}
-					}
+					await Promise.all(addToMergedMap.map(fn => fn(map)));
 					return map;
 				})
 			);

--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -392,7 +392,7 @@ class Pack {
 		for (const identifier of this.itemInfo.keys()) {
 			write(identifier);
 		}
-		write(null);
+		write(null); // null as marker of the end of keys
 		for (const info of this.itemInfo.values()) {
 			write(info.etag);
 		}
@@ -405,10 +405,10 @@ class Pack {
 				write(content.items);
 				writeSeparate(content.getMap(), { name: `${i}` });
 			} else {
-				write(undefined);
+				write(undefined); // undefined marks an empty content slot
 			}
 		}
-		write(null);
+		write(null); // null as marker of the end of items
 	}
 
 	deserialize({ read, logger }) {

--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -8,18 +8,12 @@
 const FileSystemInfo = require("../FileSystemInfo");
 const LazySet = require("../util/LazySet");
 const makeSerializable = require("../util/makeSerializable");
-const {
-	createFileSerializer,
-	NOT_SERIALIZABLE,
-	MEASURE_START_OPERATION,
-	MEASURE_END_OPERATION
-} = require("../util/serialization");
+const memorize = require("../util/memorize");
+const { createFileSerializer } = require("../util/serialization");
 
 /** @typedef {import("../Cache").Etag} Etag */
 /** @typedef {import("../logging/Logger").Logger} Logger */
 /** @typedef {import("../util/fs").IntermediateFileSystem} IntermediateFileSystem */
-
-const MAX_INLINE_SIZE = 20000;
 
 class PackContainer {
 	/**
@@ -46,13 +40,13 @@ class PackContainer {
 		this.resolveBuildDependenciesSnapshot = resolveBuildDependenciesSnapshot;
 	}
 
-	serialize({ write }) {
+	serialize({ write, writeLazy }) {
 		write(this.version);
 		write(this.buildSnapshot);
 		write(this.buildDependencies);
 		write(this.resolveResults);
 		write(this.resolveBuildDependenciesSnapshot);
-		write(this.data);
+		writeLazy(this.data);
 	}
 
 	deserialize({ read }) {
@@ -71,16 +65,33 @@ makeSerializable(
 	"PackContainer"
 );
 
+const MIN_CONTENT_SIZE = 1024 * 1024; // 1 MB
+const CONTENT_COUNT_TO_MERGE = 10;
+const MAX_AGE = 1000 * 60 * 60 * 24 * 60; // 1 month
+
+class PackItemInfo {
+	/**
+	 * @param {string} identifier identifier of item
+	 * @param {string | null} etag etag of item
+	 * @param {any} value fresh value of item
+	 */
+	constructor(identifier, etag, value) {
+		this.identifier = identifier;
+		this.etag = etag;
+		this.location = -1;
+		this.lastAccess = Date.now();
+		this.freshValue = value;
+	}
+}
+
 class Pack {
 	constructor(logger) {
-		/** @type {Map<string, string | null>} */
-		this.etags = new Map();
-		/** @type {Map<string, any | (() => Promise<PackEntry>)>} */
-		this.content = new Map();
-		this.lastAccess = new Map();
-		this.lastSizes = new Map();
-		this.unserializable = new Set();
-		this.used = new Set();
+		/** @type {Map<string, PackItemInfo>} */
+		this.itemInfo = new Map();
+		/** @type {PackItemInfo[]} */
+		this.freshContent = [];
+		/** @type {(undefined | PackContent)[]} */
+		this.content = [];
 		this.invalid = false;
 		this.logger = logger;
 	}
@@ -91,17 +102,18 @@ class Pack {
 	 * @returns {any} cached content
 	 */
 	get(identifier, etag) {
-		const etagInCache = this.etags.get(identifier);
-		if (etagInCache === undefined) return undefined;
-		if (etagInCache !== etag) return null;
-		this.used.add(identifier);
-		const content = this.content.get(identifier);
-		if (typeof content === "function") {
-			return Promise.resolve(content()).then(entry =>
-				this._unpack(identifier, entry, false)
-			);
+		const info = this.itemInfo.get(identifier);
+		if (info === undefined) return undefined;
+		if (info.etag !== etag) return null;
+		info.lastAccess = Date.now();
+		const loc = info.location;
+		if (loc === -1) {
+			return info.freshValue;
 		} else {
-			return content;
+			if (!this.content[loc]) {
+				return undefined;
+			}
+			return this.content[loc].get(identifier);
 		}
 	}
 
@@ -112,60 +124,289 @@ class Pack {
 	 * @returns {void}
 	 */
 	set(identifier, etag, data) {
-		if (this.unserializable.has(identifier)) return;
-		this.used.add(identifier);
 		if (!this.invalid) {
-			if (
-				this.content.get(identifier) === data &&
-				this.etags.get(identifier) === etag
-			) {
-				return;
-			}
 			this.invalid = true;
 			this.logger.debug(`Pack got invalid because of ${identifier}`);
 		}
-		this.etags.set(identifier, etag);
-		this.content.set(identifier, data);
+		const info = this.itemInfo.get(identifier);
+		if (info === undefined) {
+			const newInfo = new PackItemInfo(identifier, etag, data);
+			this.itemInfo.set(identifier, newInfo);
+			this.freshContent.push(newInfo);
+		} else {
+			const loc = info.location;
+			if (loc >= 0) {
+				this.freshContent.push(info);
+				const content = this.content[loc];
+				content.delete(identifier);
+				if (content.items.size === 0) {
+					this.content[loc] = undefined;
+					this.logger.debug("Pack %d got empty and is removed", loc);
+				}
+			}
+			info.freshValue = data;
+			info.lastAccess = Date.now();
+			info.etag = etag;
+			info.location = -1;
+		}
 	}
 
-	collectGarbage(maxAge) {
-		this._updateLastAccess();
+	/**
+	 * @returns {number} new location of data entries
+	 */
+	_findLocation() {
+		let i;
+		for (i = 0; i < this.content.length && this.content[i] !== undefined; i++);
+		return i;
+	}
+
+	_gcAndUpdateLocation(items, usedItems, newLoc) {
+		let count = 0;
+		let lastGC;
 		const now = Date.now();
-		for (const [identifier, lastAccess] of this.lastAccess) {
-			if (now - lastAccess > maxAge) {
-				this.lastAccess.delete(identifier);
-				this.etags.delete(identifier);
-				this.content.delete(identifier);
+		for (const identifier of items) {
+			const info = this.itemInfo.get(identifier);
+			if (now - info.lastAccess > MAX_AGE) {
+				this.itemInfo.delete(identifier);
+				items.delete(identifier);
+				usedItems.delete(identifier);
+				count++;
+				lastGC = identifier;
+			} else {
+				info.location = newLoc;
+			}
+		}
+		if (count > 0) {
+			this.logger.log(
+				"Garbage Collected %d old items at pack %d e. g. %s",
+				count,
+				newLoc,
+				lastGC
+			);
+		}
+	}
+
+	_persistFreshContent() {
+		if (this.freshContent.length > 0) {
+			/** @type {Set<string>} */
+			const items = new Set();
+			/** @type {Map<string, any>} */
+			const map = new Map();
+			const loc = this._findLocation();
+			for (const info of this.freshContent) {
+				const { identifier } = info;
+				items.add(identifier);
+				map.set(identifier, info.freshValue);
+				info.location = loc;
+				info.freshValue = undefined;
+			}
+			this.content[loc] = new PackContent(items, new Set(items), map);
+			this.freshContent.length = 0;
+		}
+	}
+
+	/**
+	 * Merges small content files to a single content file
+	 */
+	_optimizeSmallContent() {
+		// 1. Find all small content files
+		// Treat unused content files separatly to avoid
+		// a merge-split cycle
+		/** @type {number[]} */
+		const smallUsedContents = [];
+		/** @type {number} */
+		let smallUsedContentSize = 0;
+		/** @type {number[]} */
+		const smallUnusedContents = [];
+		/** @type {number} */
+		let smallUnusedContentSize = 0;
+		for (let i = 0; i < this.content.length; i++) {
+			const content = this.content[i];
+			if (content === undefined) continue;
+			if (content.outdated) continue;
+			const size = content.getSize();
+			if (size < 0 || size > MIN_CONTENT_SIZE) continue;
+			if (content.used.size > 0) {
+				smallUsedContents.push(i);
+				smallUsedContentSize += size;
+			} else {
+				smallUnusedContents.push(i);
+				smallUnusedContentSize += size;
+			}
+		}
+
+		let mergedContent;
+		// 2. Check if minimium number is reached
+		if (
+			smallUsedContents.length >= CONTENT_COUNT_TO_MERGE ||
+			smallUsedContentSize > MIN_CONTENT_SIZE
+		) {
+			mergedContent = smallUsedContents.map(i => this.content[i]);
+
+			// 3. Remove old content entries
+			for (const i of smallUsedContents) {
+				this.content[i] = undefined;
+			}
+		} else if (
+			smallUnusedContents.length >= CONTENT_COUNT_TO_MERGE ||
+			smallUnusedContentSize > MIN_CONTENT_SIZE
+		) {
+			mergedContent = smallUnusedContents.map(i => this.content[i]);
+
+			// 3. Remove old content entries
+			for (const i of smallUnusedContents) {
+				this.content[i] = undefined;
+			}
+		} else return;
+
+		// 4. Determine merged items
+		/** @type {Set<string>} */
+		const mergedItems = new Set();
+		/** @type {Set<string>} */
+		const mergedUsedItems = new Set();
+		for (const content of mergedContent) {
+			for (const identifier of content.items) {
+				mergedItems.add(identifier);
+			}
+			for (const identifer of content.used) {
+				mergedUsedItems.add(identifer);
+			}
+		}
+
+		// 5. GC and update location of merged items
+		const newLoc = this._findLocation();
+		this._gcAndUpdateLocation(mergedItems, mergedUsedItems, newLoc);
+
+		// 6. If not empty, store content somewhere
+		if (mergedItems.size > 0) {
+			this.content[newLoc] = new PackContent(
+				mergedItems,
+				mergedUsedItems,
+				memorize(async () => {
+					// unpack existing content in parallel
+					// after that values are accessible in .content
+					await Promise.all(mergedContent.map(c => c.unpack()));
+					/** @type {Map<string, any>} */
+					const map = new Map();
+					for (const content of mergedContent) {
+						for (const [identifier, value] of content.content) {
+							if (mergedItems.has(identifier)) {
+								map.set(identifier, value);
+							}
+						}
+					}
+					return map;
+				})
+			);
+			this.logger.log(
+				"Merged %d small files with %d cache items into pack %d",
+				mergedContent.length,
+				mergedItems.size,
+				newLoc
+			);
+		}
+	}
+
+	/**
+	 * Split large content files with used and unused items
+	 * into two parts to separate used from unused items
+	 */
+	_optimizeUnusedContent() {
+		// 1. Find a large content file with used and unused items
+		for (let i = 0; i < this.content.length; i++) {
+			const content = this.content[i];
+			if (content === undefined) continue;
+			const size = content.getSize();
+			if (size < MIN_CONTENT_SIZE) continue;
+			const used = content.used.size;
+			const total = content.items.size;
+			if (used > 0 && used < total) {
+				// 2. Remove this content
+				this.content[i] = undefined;
+
+				// 3. Determine items for the used content file
+				const usedItems = new Set(content.used);
+				const newLoc = this._findLocation();
+				this._gcAndUpdateLocation(usedItems, usedItems, newLoc);
+
+				// 4. Create content file for used items
+				if (usedItems.size > 0) {
+					this.content[newLoc] = new PackContent(
+						usedItems,
+						new Set(usedItems),
+						async () => {
+							await content.unpack();
+							const map = new Map();
+							for (const identifier of usedItems) {
+								map.set(identifier, content.content.get(identifier));
+							}
+							return map;
+						}
+					);
+				}
+
+				// 5. Determine items for the unused content file
+				const unusedItems = new Set(content.items);
+				const usedOfUnusedItems = new Set();
+				for (const identifier of usedItems) {
+					unusedItems.delete(identifier);
+				}
+				const newUnusedLoc = this._findLocation();
+				this._gcAndUpdateLocation(unusedItems, usedOfUnusedItems, newUnusedLoc);
+
+				// 6. Create content file for unused items
+				if (unusedItems.size > 0) {
+					this.content[newUnusedLoc] = new PackContent(
+						unusedItems,
+						usedOfUnusedItems,
+						async () => {
+							await content.unpack();
+							const map = new Map();
+							for (const identifier of unusedItems) {
+								map.set(identifier, content.content.get(identifier));
+							}
+							return map;
+						}
+					);
+				}
+
+				this.logger.log(
+					"Split pack %d into pack %d with %d used items and pack %d with %d unused items",
+					i,
+					newLoc,
+					usedItems.size,
+					newUnusedLoc,
+					unusedItems.size
+				);
+
+				// optimizing only one of them is good enough and
+				// reduces the amount of serialization needed
+				return;
 			}
 		}
 	}
 
-	_updateLastAccess() {
-		const now = Date.now();
-		for (const identifier of this.used) {
-			this.lastAccess.set(identifier, now);
-		}
-		this.used.clear();
-	}
-
-	serialize({ write }) {
-		this._updateLastAccess();
-		write(this.etags);
-		write(this.unserializable);
-		write(this.lastAccess);
-		for (const [identifier, data] of this.content) {
-			if (this.unserializable.has(identifier)) continue;
+	serialize({ write, writeSeparate }) {
+		this._persistFreshContent();
+		this._optimizeSmallContent();
+		this._optimizeUnusedContent();
+		for (const identifier of this.itemInfo.keys()) {
 			write(identifier);
-			if (typeof data === "function") {
-				write(data);
+		}
+		write(null);
+		for (const info of this.itemInfo.values()) {
+			write(info.etag);
+		}
+		for (const info of this.itemInfo.values()) {
+			write(info.lastAccess);
+		}
+		for (let i = 0; i < this.content.length; i++) {
+			const content = this.content[i];
+			if (content !== undefined) {
+				write(content.items);
+				writeSeparate(content.getMap(), { name: `${i}` });
 			} else {
-				const packEntry = new PackEntry(data, identifier);
-				const lastSize = this.lastSizes.get(identifier);
-				if (lastSize > MAX_INLINE_SIZE) {
-					write(() => packEntry);
-				} else {
-					write(packEntry);
-				}
+				write(undefined);
 			}
 		}
 		write(null);
@@ -173,108 +414,157 @@ class Pack {
 
 	deserialize({ read, logger }) {
 		this.logger = logger;
-		this.etags = read();
-		this.unserializable = read();
-		// Mark the first 1% of the items for retry
-		// If they still fail they are added to the back again
-		// Eventually all items are retried, but not too many at the same time
-		if (this.unserializable.size > 0) {
-			let i = Math.ceil(this.unserializable.size / 100);
-			for (const item of this.unserializable) {
-				this.unserializable.delete(item);
-				if (--i <= 0) break;
+		{
+			const items = [];
+			let item = read();
+			while (item !== null) {
+				items.push(item);
+				item = read();
+			}
+			this.itemInfo.clear();
+			const infoItems = items.map(identifier => {
+				const info = new PackItemInfo(identifier, undefined, undefined);
+				this.itemInfo.set(identifier, info);
+				return info;
+			});
+			for (const info of infoItems) {
+				info.etag = read();
+			}
+			for (const info of infoItems) {
+				info.lastAccess = read();
 			}
 		}
-		this.lastAccess = read();
-		this.content = new Map();
-		let identifier = read();
-		while (identifier !== null) {
-			const entry = read();
-			if (typeof entry === "function") {
-				this.content.set(identifier, entry);
+		this.content.length = 0;
+		let items = read();
+		while (items !== null) {
+			if (items === undefined) {
+				this.content.push(items);
 			} else {
-				this.content.set(identifier, this._unpack(identifier, entry, true));
-			}
-			identifier = read();
-		}
-	}
-
-	_unpack(identifier, entry, currentlyInline) {
-		const { data, size } = entry;
-		if (data === undefined) {
-			this.unserializable.add(identifier);
-			this.lastSizes.delete(identifier);
-			return undefined;
-		} else {
-			this.lastSizes.set(identifier, size);
-			if (currentlyInline) {
-				if (size > MAX_INLINE_SIZE) {
-					this.logger.debug(
-						`Moved ${identifier} from inline to lazy section for better performance (${(
-							size / 1048576
-						).toFixed(1)} MiB).`
-					);
-				}
-			} else {
-				if (size <= MAX_INLINE_SIZE) {
-					this.content.set(identifier, data);
-					this.logger.debug(
-						`Moved ${identifier} from lazy to inline section for better performance.`
-					);
+				const idx = this.content.length;
+				const lazy = read();
+				this.content.push(new PackContent(items, new Set(), lazy));
+				for (const identifier of items) {
+					this.itemInfo.get(identifier).location = idx;
 				}
 			}
-			return data;
+			items = read();
 		}
 	}
 }
 
 makeSerializable(Pack, "webpack/lib/cache/PackFileCacheStrategy", "Pack");
 
-class PackEntry {
-	constructor(data, identifier) {
-		this.data = data;
-		this.size = undefined;
-		this.identifier = identifier;
+class PackContent {
+	/**
+	 * @param {Set<string>} items keys
+	 * @param {Set<string>} usedItems used keys
+	 * @param {Map<string, any> | function(): Promise<Map<string, any>>} dataOrFn sync or async content
+	 */
+	constructor(items, usedItems, dataOrFn) {
+		this.items = items;
+		/** @type {function(): Map<string, any> | Promise<Map<string, any>>} */
+		this.lazy = typeof dataOrFn === "function" ? dataOrFn : undefined;
+		/** @type {Map<string, any>} */
+		this.content = typeof dataOrFn === "function" ? undefined : dataOrFn;
+		this.outdated = false;
+		this.used = usedItems;
 	}
 
-	serialize({ write, snapshot, rollback, logger }) {
-		const s = snapshot();
-		try {
-			write(true);
-			if (this.size === undefined) {
-				write(MEASURE_START_OPERATION);
-				write(this.data);
-				write(MEASURE_END_OPERATION);
+	get(identifier) {
+		this.used.add(identifier);
+		if (this.content) {
+			return this.content.get(identifier);
+		}
+		const value = this.lazy();
+		if (value instanceof Promise) {
+			return value.then(data => {
+				this.content = data;
+				return data.get(identifier);
+			});
+		} else {
+			this.content = value;
+			return value.get(identifier);
+		}
+	}
+
+	/**
+	 * @returns {void | Promise} maybe a promise if lazy
+	 */
+	unpack() {
+		if (this.content) return;
+		if (this.lazy) {
+			const value = this.lazy();
+			if (value instanceof Promise) {
+				return value.then(data => {
+					this.content = data;
+				});
 			} else {
-				write(this.data);
-				write(this.size);
+				this.content = value;
 			}
-		} catch (err) {
-			if (err !== NOT_SERIALIZABLE) {
-				logger.warn(
-					`Caching failed for ${this.identifier}: ${err}\n` +
-						"We will try to cache this entry again once in a while or when the cache file is deleted."
-				);
-				logger.debug(err.stack);
-			}
-			rollback(s);
-			write(false);
 		}
 	}
 
-	deserialize({ read }) {
-		if (read()) {
-			this.data = read();
-			this.size = read();
+	/**
+	 * @returns {number} size of the content or -1 if not known
+	 */
+	getSize() {
+		if (!this.lazy) return -1;
+		const options = /** @type {any} */ (this.lazy).options;
+		if (!options) return -1;
+		const size = options.size;
+		if (typeof size !== "number") return -1;
+		return size;
+	}
+
+	delete(identifier) {
+		this.items.delete(identifier);
+		this.used.delete(identifier);
+		this.outdated = true;
+	}
+
+	/**
+	 * @returns {function(): Map<string, any> | Promise<Map<string, any>>} lazy map
+	 */
+	getMap() {
+		if (!this.outdated && this.lazy) return this.lazy;
+		if (!this.outdated && this.content) {
+			const map = new Map(this.content);
+			return (this.lazy = () => map);
 		}
+		this.outdated = false;
+		if (this.content) {
+			return (this.lazy = memorize(() => {
+				/** @type {Map<string, any>} */
+				const map = new Map();
+				for (const item of this.items) {
+					map.set(item, this.content.get(item));
+				}
+				return map;
+			}));
+		}
+		const lazy = this.lazy;
+		return (this.lazy = () => {
+			const value = lazy();
+			if (value instanceof Promise) {
+				return value.then(data => {
+					/** @type {Map<string, any>} */
+					const map = new Map();
+					for (const item of this.items) {
+						map.set(item, data.get(item));
+					}
+					return map;
+				});
+			} else {
+				/** @type {Map<string, any>} */
+				const map = new Map();
+				for (const item of this.items) {
+					map.set(item, value.get(item));
+				}
+				return map;
+			}
+		});
 	}
 }
-
-makeSerializable(
-	PackEntry,
-	"webpack/lib/cache/PackFileCacheStrategy",
-	"PackEntry"
-);
 
 class PackFileCacheStrategy {
 	/**
@@ -335,9 +625,13 @@ class PackFileCacheStrategy {
 		let resolveBuildDependenciesSnapshot;
 		/** @type {Map<string, string>} */
 		let resolveResults;
-		logger.time("restore pack container");
+		logger.time("restore cache container");
 		return this.fileSerializer
-			.deserialize({ filename: `${cacheLocation}.pack`, logger })
+			.deserialize(null, {
+				filename: `${cacheLocation}/index.pack`,
+				extension: ".pack",
+				logger
+			})
 			.catch(err => {
 				if (err.code !== "ENOENT") {
 					logger.warn(
@@ -350,7 +644,7 @@ class PackFileCacheStrategy {
 				return undefined;
 			})
 			.then(packContainer => {
-				logger.timeEnd("restore pack container");
+				logger.timeEnd("restore cache container");
 				if (!packContainer) return undefined;
 				if (!(packContainer instanceof PackContainer)) {
 					logger.warn(
@@ -407,7 +701,7 @@ class PackFileCacheStrategy {
 									resolveResults = packContainer.resolveResults;
 									return resolve(true);
 								}
-								logger.debug(
+								logger.log(
 									"resolving of build dependencies is invalid, will re-resolve build dependencies"
 								);
 								this.fileSystemInfo.checkResolveResultsValid(
@@ -442,11 +736,10 @@ class PackFileCacheStrategy {
 					.then(([buildSnapshotValid, resolveValid]) => {
 						logger.timeEnd("check build dependencies");
 						if (buildSnapshotValid && resolveValid) {
-							logger.time("restore pack");
-							return packContainer.data().then(d => {
-								logger.timeEnd("restore pack");
-								return d;
-							});
+							logger.time("restore cache content metadata");
+							const d = packContainer.data();
+							logger.timeEnd("restore cache content metadata");
+							return d;
 						}
 						return undefined;
 					});
@@ -605,9 +898,8 @@ class PackFileCacheStrategy {
 				}
 				return promise.then(() => {
 					this.logger.time(`store pack`);
-					pack.collectGarbage(1000 * 60 * 60 * 24 * 2);
 					const content = new PackContainer(
-						() => pack,
+						pack,
 						this.version,
 						this.buildSnapshot,
 						this.buildDependencies,
@@ -620,7 +912,8 @@ class PackFileCacheStrategy {
 					// So it's safe to replace the pack file
 					return this.fileSerializer
 						.serialize(content, {
-							filename: `${this.cacheLocation}.pack`,
+							filename: `${this.cacheLocation}/index.pack`,
+							extension: ".pack",
 							logger: this.logger
 						})
 						.then(() => {

--- a/lib/cache/ResolverCachePlugin.js
+++ b/lib/cache/ResolverCachePlugin.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const LazySet = require("../util/LazySet");
+const makeSerializable = require("../util/makeSerializable");
 
 /** @typedef {import("enhanced-resolve/lib/Resolver")} Resolver */
 /** @typedef {import("../Compiler")} Compiler */
@@ -13,14 +14,39 @@ const LazySet = require("../util/LazySet");
 /** @typedef {import("../FileSystemInfo").Snapshot} Snapshot */
 /** @template T @typedef {import("../util/LazySet")<T>} LazySet<T> */
 
-/**
- * @typedef {Object} CacheEntry
- * @property {Object} result
- * @property {LazySet<string>} fileDependencies
- * @property {LazySet<string>} contextDependencies
- * @property {LazySet<string>} missingDependencies
- * @property {Snapshot} snapshot
- */
+class CacheEntry {
+	constructor(
+		result,
+		fileDependencies,
+		contextDependencies,
+		missingDependencies,
+		snapshot
+	) {
+		this.result = result;
+		this.fileDependencies = fileDependencies;
+		this.contextDependencies = contextDependencies;
+		this.missingDependencies = missingDependencies;
+		this.snapshot = snapshot;
+	}
+
+	serialize({ write }) {
+		write(this.result);
+		write(this.fileDependencies);
+		write(this.contextDependencies);
+		write(this.missingDependencies);
+		write(this.snapshot);
+	}
+
+	deserialize({ read }) {
+		this.result = read();
+		this.fileDependencies = read();
+		this.contextDependencies = read();
+		this.missingDependencies = read();
+		this.snapshot = read();
+	}
+}
+
+makeSerializable(CacheEntry, "webpack/lib/cache/ResolverCachePlugin");
 
 /**
  * @template T
@@ -146,13 +172,13 @@ class ResolverCachePlugin {
 							cache.store(
 								identifier,
 								null,
-								/** @type {CacheEntry} */ {
+								new CacheEntry(
 									result,
-									fileDependencies: newResolveContext.fileDependencies,
-									contextDependencies: newResolveContext.contextDependencies,
-									missingDependencies: newResolveContext.missingDependencies,
+									newResolveContext.fileDependencies,
+									newResolveContext.contextDependencies,
+									newResolveContext.missingDependencies,
 									snapshot
-								},
+								),
 								storeErr => {
 									if (storeErr) return callback(storeErr);
 									if (result) return callback(null, result);

--- a/lib/optimize/ModuleConcatenationPlugin.js
+++ b/lib/optimize/ModuleConcatenationPlugin.js
@@ -440,6 +440,7 @@ class ModuleConcatenationPlugin {
 									// add concatenated module to the compilation
 									compilation.modules.add(newModule);
 
+									// TODO check if module needs build to avoid caching it without change
 									compilation.cache.store(cacheName, null, newModule, err => {
 										if (err) {
 											return callback(new ModuleStoreError(newModule, err));

--- a/lib/serialization/ArraySerializer.js
+++ b/lib/serialization/ArraySerializer.js
@@ -1,0 +1,22 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+*/
+
+"use strict";
+
+class ArraySerializer {
+	serialize(array, { write }) {
+		write(array.length);
+		for (const item of array) write(item);
+	}
+	deserialize({ read }) {
+		const length = read();
+		const array = [];
+		for (let i = 0; i < length; i++) {
+			array.push(read());
+		}
+		return array;
+	}
+}
+
+module.exports = ArraySerializer;

--- a/lib/serialization/BinaryMiddleware.js
+++ b/lib/serialization/BinaryMiddleware.js
@@ -10,8 +10,6 @@ const SerializerMiddleware = require("./SerializerMiddleware");
 /** @typedef {import("./types").BufferSerializableType} BufferSerializableType */
 /** @typedef {import("./types").PrimitiveSerializableType} PrimitiveSerializableType */
 
-const SERIALIZED_INFO = Symbol("serialized info");
-
 /*
 Format:
 
@@ -57,7 +55,7 @@ RawNumber -> n (n <= 10)
 
 */
 
-const NOP_HEADER = 0x0b;
+const LAZY_HEADER = 0x0b;
 const TRUE_HEADER = 0x0c;
 const FALSE_HEADER = 0x0d;
 const STRING_HEADER = 0x0e;
@@ -87,35 +85,21 @@ const identifyNumber = n => {
  * @extends {SerializerMiddleware<DeserializedType, SerializedType>}
  */
 class BinaryMiddleware extends SerializerMiddleware {
-	_handleFunctionSerialization(fn, context) {
-		const serializedInfo = fn[SERIALIZED_INFO];
-		if (serializedInfo) return serializedInfo;
-		return memorize(() => {
-			const r = fn();
-			if (r instanceof Promise)
-				return r.then(data => data && this.serialize(data, context));
-			if (r) return this.serialize(r, context);
-			return null;
-		});
-	}
-
-	_handleFunctionDeserialization(fn, context) {
-		const result = memorize(() => {
-			const r = fn();
-			if (r instanceof Promise)
-				return r.then(data => this.deserialize(data, context));
-			return this.deserialize(r, context);
-		});
-		result[SERIALIZED_INFO] = fn;
-		return result;
-	}
-
 	/**
 	 * @param {DeserializedType} data data
 	 * @param {Object} context context object
 	 * @returns {SerializedType|Promise<SerializedType>} serialized data
 	 */
 	serialize(data, context) {
+		return this._serialize(data, context);
+	}
+
+	/**
+	 * @param {DeserializedType} data data
+	 * @param {Object} context context object
+	 * @returns {SerializedType} serialized data
+	 */
+	_serialize(data, context) {
 		/** @type {Buffer} */
 		let currentBuffer = null;
 		let currentPosition = 0;
@@ -157,133 +141,156 @@ class BinaryMiddleware extends SerializerMiddleware {
 			}
 			return size;
 		};
-		for (let i = 0; i < data.length; i++) {
-			const thing = data[i];
-			switch (typeof thing) {
-				case "function": {
-					flush();
-					buffers.push(this._handleFunctionSerialization(thing, context));
-					break;
-				}
-				case "string": {
-					const len = Buffer.byteLength(thing);
-					if (len >= 128) {
-						allocate(len + 5);
-						writeU8(STRING_HEADER);
-						writeU32(len);
-					} else {
-						allocate(len + 1);
-						writeU8(SHORT_STRING_HEADER | len);
-					}
-					currentBuffer.write(thing, currentPosition);
-					currentPosition += len;
-					if (len > 102400 && context.logger) {
-						context.logger.warn(
-							`Serializing big strings (${Math.round(
-								len / 1024
-							)}kiB) impacts deserialization performance (consider Buffer instead): ${thing.slice(
-								0,
-								100
-							)}...\n`
+		const serializeData = data => {
+			for (let i = 0; i < data.length; i++) {
+				const thing = data[i];
+				switch (typeof thing) {
+					case "function": {
+						if (!SerializerMiddleware.isLazy(thing))
+							throw new Error("Unexpected function " + thing);
+						/** @type {SerializedType[0]} */
+						const serializedData = SerializerMiddleware.getLazySerializedValue(
+							thing
 						);
-					}
-					break;
-				}
-				case "number": {
-					const type = identifyNumber(thing);
-					if (type === 0 && thing >= 0 && thing <= 10) {
-						// shortcut for very small numbers
-						allocate(1);
-						writeU8(thing);
+						if (serializedData !== undefined) {
+							if (typeof serializedData === "function") {
+								flush();
+								buffers.push(serializedData);
+							} else {
+								serializeData(serializedData);
+								allocate(5);
+								writeU8(LAZY_HEADER);
+								writeU32(serializedData.length);
+							}
+						} else if (SerializerMiddleware.isLazy(thing, this)) {
+							/** @type {SerializedType} */
+							const data = this._serialize(thing(), context);
+							SerializerMiddleware.setLazySerializedValue(thing, data);
+							serializeData(data);
+							allocate(5);
+							writeU8(LAZY_HEADER);
+							writeU32(data.length);
+						} else {
+							flush();
+							buffers.push(
+								SerializerMiddleware.serializeLazy(thing, data =>
+									this._serialize(data, context)
+								)
+							);
+						}
 						break;
 					}
-					let n;
-					for (n = 1; n < 32 && i + n < data.length; n++) {
-						const item = data[i + n];
-						if (typeof item !== "number") break;
-						if (identifyNumber(item) !== type) break;
-					}
-					switch (type) {
-						case 0:
-							allocate(1 + n);
-							writeU8(I8_HEADER | (n - 1));
-							while (n > 0) {
-								currentBuffer.writeInt8(
-									/** @type {number} */ (data[i]),
-									currentPosition
-								);
-								currentPosition++;
-								n--;
-								i++;
-							}
-							break;
-						case 1:
-							allocate(1 + 4 * n);
-							writeU8(I32_HEADER | (n - 1));
-							while (n > 0) {
-								currentBuffer.writeInt32LE(
-									/** @type {number} */ (data[i]),
-									currentPosition
-								);
-								currentPosition += 4;
-								n--;
-								i++;
-							}
-							break;
-						case 2:
-							allocate(1 + 8 * n);
-							writeU8(F64_HEADER | (n - 1));
-							while (n > 0) {
-								currentBuffer.writeDoubleLE(
-									/** @type {number} */ (data[i]),
-									currentPosition
-								);
-								currentPosition += 8;
-								n--;
-								i++;
-							}
-							break;
-					}
-					i--;
-					break;
-				}
-				case "boolean":
-					allocate(1);
-					writeU8(thing === true ? TRUE_HEADER : FALSE_HEADER);
-					break;
-				case "object": {
-					if (thing === null) {
-						let n;
-						for (n = 1; n < 16 && i + n < data.length; n++) {
-							const item = data[i + n];
-							if (item !== null) break;
+					case "string": {
+						const len = Buffer.byteLength(thing);
+						if (len >= 128) {
+							allocate(len + 5);
+							writeU8(STRING_HEADER);
+							writeU32(len);
+						} else {
+							allocate(len + 1);
+							writeU8(SHORT_STRING_HEADER | len);
 						}
+						currentBuffer.write(thing, currentPosition);
+						currentPosition += len;
+						break;
+					}
+					case "number": {
+						const type = identifyNumber(thing);
+						if (type === 0 && thing >= 0 && thing <= 10) {
+							// shortcut for very small numbers
+							allocate(1);
+							writeU8(thing);
+							break;
+						}
+						let n;
+						for (n = 1; n < 32 && i + n < data.length; n++) {
+							const item = data[i + n];
+							if (typeof item !== "number") break;
+							if (identifyNumber(item) !== type) break;
+						}
+						switch (type) {
+							case 0:
+								allocate(1 + n);
+								writeU8(I8_HEADER | (n - 1));
+								while (n > 0) {
+									currentBuffer.writeInt8(
+										/** @type {number} */ (data[i]),
+										currentPosition
+									);
+									currentPosition++;
+									n--;
+									i++;
+								}
+								break;
+							case 1:
+								allocate(1 + 4 * n);
+								writeU8(I32_HEADER | (n - 1));
+								while (n > 0) {
+									currentBuffer.writeInt32LE(
+										/** @type {number} */ (data[i]),
+										currentPosition
+									);
+									currentPosition += 4;
+									n--;
+									i++;
+								}
+								break;
+							case 2:
+								allocate(1 + 8 * n);
+								writeU8(F64_HEADER | (n - 1));
+								while (n > 0) {
+									currentBuffer.writeDoubleLE(
+										/** @type {number} */ (data[i]),
+										currentPosition
+									);
+									currentPosition += 8;
+									n--;
+									i++;
+								}
+								break;
+						}
+						i--;
+						break;
+					}
+					case "boolean":
 						allocate(1);
-						writeU8(NULLS_HEADER | (n - 1));
-						i += n - 1;
-					} else if (Buffer.isBuffer(thing)) {
-						allocate(5, true);
-						writeU8(BUFFER_HEADER);
-						writeU32(thing.length);
-						flush();
-						buffers.push(thing);
+						writeU8(thing === true ? TRUE_HEADER : FALSE_HEADER);
+						break;
+					case "object": {
+						if (thing === null) {
+							let n;
+							for (n = 1; n < 16 && i + n < data.length; n++) {
+								const item = data[i + n];
+								if (item !== null) break;
+							}
+							allocate(1);
+							writeU8(NULLS_HEADER | (n - 1));
+							i += n - 1;
+						} else if (Buffer.isBuffer(thing)) {
+							allocate(5, true);
+							writeU8(BUFFER_HEADER);
+							writeU32(thing.length);
+							flush();
+							buffers.push(thing);
+						}
+						break;
 					}
-					break;
-				}
-				case "symbol": {
-					if (thing === MEASURE_START_OPERATION) {
-						measureStart();
-					} else if (thing === MEASURE_END_OPERATION) {
-						const size = measureEnd();
-						allocate(5);
-						writeU8(I32_HEADER);
-						currentBuffer.writeInt32LE(size, currentPosition);
-						currentPosition += 4;
+					case "symbol": {
+						if (thing === MEASURE_START_OPERATION) {
+							measureStart();
+						} else if (thing === MEASURE_END_OPERATION) {
+							const size = measureEnd();
+							allocate(5);
+							writeU8(I32_HEADER);
+							currentBuffer.writeInt32LE(size, currentPosition);
+							currentPosition += 4;
+						}
+						break;
 					}
-					break;
 				}
 			}
-		}
+		};
+		serializeData(data);
 		flush();
 		return buffers;
 	}
@@ -294,6 +301,15 @@ class BinaryMiddleware extends SerializerMiddleware {
 	 * @returns {DeserializedType|Promise<DeserializedType>} deserialized data
 	 */
 	deserialize(data, context) {
+		return this._deserialize(data, context);
+	}
+
+	/**
+	 * @param {SerializedType} data data
+	 * @param {Object} context context object
+	 * @returns {DeserializedType} deserialized data
+	 */
+	_deserialize(data, context) {
 		let currentDataItem = 0;
 		let currentBuffer = data[0];
 		let currentIsBuffer = Buffer.isBuffer(currentBuffer);
@@ -342,11 +358,14 @@ class BinaryMiddleware extends SerializerMiddleware {
 		const readU32 = () => {
 			return read(4).readUInt32LE(0);
 		};
+		/** @type {DeserializedType} */
 		const result = [];
 		while (currentBuffer !== null) {
 			if (typeof currentBuffer === "function") {
 				result.push(
-					this._handleFunctionDeserialization(currentBuffer, context)
+					SerializerMiddleware.deserializeLazy(currentBuffer, data =>
+						this._deserialize(data, context)
+					)
 				);
 				currentDataItem++;
 				currentBuffer =
@@ -356,8 +375,21 @@ class BinaryMiddleware extends SerializerMiddleware {
 			}
 			const header = readU8();
 			switch (header) {
-				case NOP_HEADER:
+				case LAZY_HEADER: {
+					const count = readU32();
+					const start = result.length - count;
+					const data = /** @type {SerializedType} */ (result.slice(start));
+					result.length = start;
+					result.push(
+						SerializerMiddleware.createLazy(
+							memorize(() => this._deserialize(data, context)),
+							this,
+							undefined,
+							data
+						)
+					);
 					break;
+				}
 				case BUFFER_HEADER: {
 					const len = readU32();
 					result.push(read(len));

--- a/lib/serialization/FileMiddleware.js
+++ b/lib/serialization/FileMiddleware.js
@@ -4,341 +4,199 @@
 
 "use strict";
 
-const Queue = require("../util/Queue");
-const { dirname, mkdirp } = require("../util/fs");
+const createHash = require("../util/createHash");
+const { dirname, join, mkdirp } = require("../util/fs");
 const memorize = require("../util/memorize");
 const SerializerMiddleware = require("./SerializerMiddleware");
 
+/** @typedef {import("../util/fs").IntermediateFileSystem} IntermediateFileSystem */
 /** @typedef {import("./types").BufferSerializableType} BufferSerializableType */
 
-class Section {
-	constructor(items) {
-		this.items = items;
-		this.parts = undefined;
-		this.length = NaN;
-		this.offset = NaN;
-	}
-
-	resolve() {
-		let hasPromise = false;
-		let lastPart = undefined;
-		const parts = [];
-		let length = 0;
-		for (const item of this.items) {
-			if (typeof item === "function") {
-				const r = item();
-				if (r instanceof Promise) {
-					parts.push(r.then(items => new Section(items).resolve()));
-					hasPromise = true;
-				} else if (r) {
-					const part = new Section(r).resolve();
-					if (part instanceof Promise) hasPromise = true;
-					parts.push(part);
-				} else {
-					return null;
-				}
-				length += 12; // 0, offset, size
-				lastPart = undefined;
-			} else if (lastPart) {
-				lastPart.push(item);
-				length += item.length;
-			} else {
-				length += 4; // size
-				length += item.length;
-				lastPart = [item];
-				parts.push(lastPart);
-			}
-		}
-		this.length = length;
-		if (hasPromise) {
-			return Promise.all(parts).then(parts => {
-				this.parts = parts;
-				if (!parts.every(Boolean)) return null;
-				return this;
-			});
-		} else {
-			this.parts = parts;
-			return this;
-		}
-	}
-
-	getSections() {
-		return this.parts.filter(p => p instanceof Section);
-	}
-
-	emit(out) {
-		for (const part of this.parts) {
-			if (part instanceof Section) {
-				const pointerBuf = Buffer.allocUnsafe(12);
-				pointerBuf.writeUInt32LE(0, 0);
-				pointerBuf.writeUInt32LE(part.offset, 4);
-				pointerBuf.writeUInt32LE(part.length, 8);
-				out.push(pointerBuf);
-			} else {
-				const sizeBuf = Buffer.allocUnsafe(4);
-				out.push(sizeBuf);
-				let len = 0;
-				for (const buf of part) {
-					len += buf.length;
-					out.push(buf);
-				}
-				sizeBuf.writeUInt32LE(len, 0);
-			}
-		}
-	}
-}
+const hashForName = buffers => {
+	const hash = createHash("md4");
+	for (const buf of buffers) hash.update(buf);
+	return /** @type {string} */ (hash.digest("hex"));
+};
 
 /**
- * @typedef {Object} FileJob
- * @property {boolean} write
- * @property {(fileHandle: number, callback: (err: Error?) => void) => void} fn
- * @property {(err: Error?) => void} errorHandler
+ * @typedef {Object} SerializeResult
+ * @property {string | false} name
+ * @property {number} size
+ * @property {Promise=} backgroundJob
  */
 
-class FileManager {
-	constructor(fs) {
-		this.fs = fs;
-		/** @type {Map<string, Queue<FileJob>>} */
-		this.jobs = new Map();
-		this.processing = new Map();
-	}
-
-	addJob(filename, write, fn, errorHandler) {
-		let queue = this.jobs.get(filename);
-		let start = false;
-		if (queue === undefined) {
-			queue = new Queue();
-			this.jobs.set(filename, queue);
-			start = true;
-		}
-		queue.enqueue({
-			write,
-			fn,
-			errorHandler
-		});
-		if (start) {
-			this._startProcessing(filename, queue);
-		}
-	}
-
-	/**
-	 * @param {string} filename the filename
-	 * @param {Queue<FileJob>} queue the job queue
-	 * @returns {void}
-	 */
-	_startProcessing(filename, queue) {
-		let fileHandle;
-		let write = false;
-		/** @type {FileJob | undefined} */
-		let currentJob = undefined;
-		/**
-		 * Pull the next job from the queue, and process it
-		 * When queue empty and file open, close it
-		 * When queue (still) empty and file closed, exit processing
-		 * @returns {void}
-		 */
-		const next = () => {
-			if (queue.length === 0) {
-				if (fileHandle !== undefined) {
-					closeFile(next);
-				} else {
-					this.jobs.delete(filename);
-					this.processing.delete(filename);
-				}
-				return;
+/**
+ * @param {FileMiddleware} middleware this
+ * @param {BufferSerializableType[] | Promise<BufferSerializableType[]>} data data to be serialized
+ * @param {string | boolean} name file base name
+ * @param {function(string | false, Buffer[]): Promise} writeFile writes a file
+ * @returns {Promise<SerializeResult>} resulting file pointer and promise
+ */
+const serialize = async (middleware, data, name, writeFile) => {
+	/** @type {(Buffer[] | Buffer | SerializeResult | Promise<SerializeResult>)[]} */
+	const processedData = [];
+	/** @type {WeakMap<SerializeResult, function(): any | Promise<any>>} */
+	const resultToLazy = new WeakMap();
+	/** @type {Buffer[]} */
+	let lastBuffers = undefined;
+	for (const item of await data) {
+		if (typeof item === "function") {
+			if (!SerializerMiddleware.isLazy(item))
+				throw new Error("Unexpected function");
+			if (!SerializerMiddleware.isLazy(item, middleware)) {
+				throw new Error(
+					"Unexpected lazy value with non-this target (can't pass through lazy values)"
+				);
 			}
-			currentJob = queue.dequeue();
-			// If file is already open but in the wrong mode
-			// close it and open it the other way
-			if (fileHandle !== undefined && write !== currentJob.write) {
-				closeFile(openFile);
-			} else {
-				openFile();
-			}
-		};
-		/**
-		 * Close the file and continue with the passed next step
-		 * @param {function(): void} next next step
-		 * @returns {void}
-		 */
-		const closeFile = next => {
-			this.fs.close(fileHandle, err => {
-				if (err) return handleError(err);
-				fileHandle = undefined;
-				next();
-			});
-		};
-		/**
-		 * Open the file if needed and continue with job processing
-		 * @returns {void}
-		 */
-		const openFile = () => {
-			if (fileHandle === undefined) {
-				write = currentJob.write;
-				this.fs.open(filename, write ? "w" : "r", (err, file) => {
-					if (err) return handleError(err);
-					fileHandle = file;
-					process();
-				});
-			} else {
-				process();
-			}
-		};
-		/**
-		 * Process the job function and continue with the next job
-		 * @returns {void}
-		 */
-		const process = () => {
-			currentJob.fn(fileHandle, err => {
-				if (err) return handleError(err);
-				currentJob = undefined;
-				next();
-			});
-		};
-		/**
-		 * Handle any error, continue with the next job
-		 * @param {Error} err occured error
-		 * @returns {void}
-		 */
-		const handleError = err => {
-			if (currentJob !== undefined) {
-				currentJob.errorHandler(err);
-			} else {
-				console.error(`Error in FileManager: ${err.message}`);
-			}
-			next();
-		};
-		next();
-	}
-}
-
-const fileManagers = new WeakMap();
-
-const getFileManager = fs => {
-	const fm = fileManagers.get(fs);
-	if (fm !== undefined) return fm;
-	const fileManager = new FileManager(fs);
-	fileManagers.set(fs, fileManager);
-	return fileManager;
-};
-
-const createPointer = (fs, fileManager, filename, offset, size) => {
-	return memorize(() => {
-		return new Promise((resolve, reject) => {
-			fileManager.addJob(
-				filename,
-				false,
-				(file, callback) => {
-					readSection(
-						fs,
-						fileManager,
-						filename,
-						file,
-						offset,
-						size,
-						(err, parts) => {
-							if (err) return callback(err);
-							resolve(parts);
-							callback();
-						}
+			lastBuffers = undefined;
+			const serializedInfo = SerializerMiddleware.getLazySerializedValue(item);
+			if (serializedInfo) {
+				if (typeof serializedInfo === "function") {
+					throw new Error(
+						"Unexpected lazy value with non-this target (can't pass through lazy values)"
 					);
-				},
-				reject
-			);
-		});
-	});
-};
-
-const readFileSectionToBuffer = (
-	fs,
-	fd,
-	buffer,
-	offset,
-	position,
-	callback
-) => {
-	const remaining = buffer.length - offset;
-	fs.read(fd, buffer, offset, remaining, position, (err, bytesRead) => {
-		if (err) return callback(err);
-		if (bytesRead === 0) {
-			return callback(
-				new Error(
-					`Unexpected end of file (${remaining} bytes missing at pos ${position}`
-				)
-			);
-		}
-		if (bytesRead < remaining) {
-			return readFileSectionToBuffer(
-				fs,
-				fd,
-				buffer,
-				offset + bytesRead,
-				position + bytesRead,
-				callback
-			);
-		}
-		return callback();
-	});
-};
-
-const readSection = (
-	fs,
-	fileManager,
-	filename,
-	file,
-	offset,
-	size,
-	callback
-) => {
-	const buffer = Buffer.allocUnsafe(size);
-	readFileSectionToBuffer(fs, file, buffer, 0, offset, err => {
-		if (err) return callback(err);
-
-		const result = [];
-		let pos = 0;
-		while (pos < buffer.length) {
-			const len = buffer.readUInt32LE(pos);
-			pos += 4;
-			if (len === 0) {
-				const pOffset = buffer.readUInt32LE(pos);
-				pos += 4;
-				const pSize = buffer.readUInt32LE(pos);
-				pos += 4;
-				result.push(createPointer(fs, fileManager, filename, pOffset, pSize));
+				} else {
+					processedData.push(serializedInfo);
+				}
 			} else {
-				const buf = buffer.slice(pos, pos + len);
-				pos += len;
-				result.push(buf);
+				const content = item();
+				if (content) {
+					const options = SerializerMiddleware.getLazyOptions(item);
+					processedData.push(
+						serialize(
+							middleware,
+							content,
+							(options && options.name) || true,
+							writeFile
+						).then(result => {
+							/** @type {any} */ (item).options.size = result.size;
+							resultToLazy.set(result, item);
+							return result;
+						})
+					);
+				} else {
+					throw new Error(
+						"Unexpected falsy value returned by lazy value function"
+					);
+				}
 			}
+		} else if (item) {
+			if (lastBuffers) {
+				lastBuffers.push(item);
+			} else {
+				lastBuffers = [item];
+				processedData.push(lastBuffers);
+			}
+		} else {
+			throw new Error("Unexpected falsy value in items array");
 		}
-		callback(null, result);
+	}
+	/** @type {Promise<any>[]} */
+	const backgroundJobs = [];
+	const resolvedData = (
+		await Promise.all(
+			/** @type {Promise<Buffer[] | Buffer | SerializeResult>[]} */ (processedData)
+		)
+	).map(item => {
+		if (Array.isArray(item)) return item;
+		if (Buffer.isBuffer(item)) return item;
+
+		backgroundJobs.push(item.backgroundJob);
+		// create pointer buffer from size and name
+		const name = /** @type {string} */ (item.name);
+		const nameBuffer = Buffer.from(name);
+		const buf = Buffer.allocUnsafe(4 + nameBuffer.length);
+		buf.writeUInt32LE(item.size, 0);
+		nameBuffer.copy(buf, 4, 0);
+		const lazy = resultToLazy.get(item);
+		SerializerMiddleware.setLazySerializedValue(lazy, buf);
+		return buf;
 	});
+	const lengths = resolvedData.map(item => {
+		if (Array.isArray(item)) {
+			let l = 0;
+			for (const b of item) l += b.length;
+			return l;
+		} else if (item) {
+			return -item.length;
+		} else {
+			throw new Error("Unexpected falsy value in resolved data " + item);
+		}
+	});
+	const header = Buffer.allocUnsafe(8 + lengths.length * 4);
+	header.writeUInt32LE(0x00637077, 0);
+	header.writeUInt32LE(lengths.length, 4);
+	for (let i = 0; i < lengths.length; i++) {
+		header.writeInt32LE(lengths[i], 8 + i * 4);
+	}
+	const buf = [header];
+	for (const item of resolvedData) {
+		if (Array.isArray(item)) {
+			for (const b of item) buf.push(b);
+		} else if (item) {
+			buf.push(item);
+		}
+	}
+	if (name === true) {
+		name = hashForName(buf);
+	}
+	backgroundJobs.push(writeFile(name, buf));
+	let size = 0;
+	for (const b of buf) size += b.length;
+	return {
+		size,
+		name,
+		backgroundJob:
+			backgroundJobs.length === 1
+				? backgroundJobs[0]
+				: Promise.all(backgroundJobs)
+	};
 };
 
-const writeBuffers = (fs, fileHandle, buffers, callback) => {
-	const stream = fs.createWriteStream(null, {
-		fd: fileHandle,
-		autoClose: false
-	});
-	let index = 0;
-
-	const doWrite = function() {
-		let canWriteMore = true;
-		while (canWriteMore && index < buffers.length) {
-			const chunk = buffers[index++];
-			canWriteMore = stream.write(chunk);
-		}
-
-		if (index < buffers.length) {
-			stream.once("drain", doWrite);
+/**
+ * @param {FileMiddleware} middleware this
+ * @param {string | false} name filename
+ * @param {function(string | false): Promise<Buffer>} readFile read content of a file
+ * @returns {Promise<BufferSerializableType[]>} deserialized data
+ */
+const deserialize = async (middleware, name, readFile) => {
+	const content = await readFile(name);
+	if (content.length === 0) throw new Error("Empty file " + name);
+	const version = content.readUInt32LE(0);
+	if (version !== 0x00637077) {
+		// "wpc" + 0
+		throw new Error("Invalid file version");
+	}
+	const sectionCount = content.readUInt32LE(4);
+	const lengths = [];
+	for (let i = 0; i < sectionCount; i++) {
+		lengths.push(content.readInt32LE(8 + 4 * i));
+	}
+	let position = sectionCount * 4 + 8;
+	const result = lengths.map(length => {
+		const l = Math.abs(length);
+		const section = content.slice(position, position + l);
+		position += l;
+		if (length < 0) {
+			// we clone the buffer here to allow the original content to be garbage collected
+			const clone = Buffer.from(section);
+			const size = section.readUInt32LE(0);
+			const nameBuffer = clone.slice(4);
+			const name = nameBuffer.toString();
+			return SerializerMiddleware.createLazy(
+				memorize(() => deserialize(middleware, name, readFile)),
+				middleware,
+				{
+					name,
+					size
+				},
+				clone
+			);
 		} else {
-			stream.end();
+			return section;
 		}
-	};
-
-	stream.on("error", err => callback(err));
-	stream.on("finish", () => callback(null));
-	doWrite();
+	});
+	return result;
 };
 
 /**
@@ -347,58 +205,77 @@ const writeBuffers = (fs, fileHandle, buffers, callback) => {
  * @extends {SerializerMiddleware<DeserializedType, SerializedType>}
  */
 class FileMiddleware extends SerializerMiddleware {
+	/**
+	 * @param {IntermediateFileSystem} fs filesystem
+	 */
 	constructor(fs) {
 		super();
 		this.fs = fs;
-		this.fileManager = getFileManager(fs);
 	}
 	/**
 	 * @param {DeserializedType} data data
 	 * @param {Object} context context object
 	 * @returns {SerializedType|Promise<SerializedType>} serialized data
 	 */
-	serialize(data, { filename }) {
-		const root = new Section(data);
+	serialize(data, { filename, extension = "" }) {
+		return new Promise((resolve, reject) => {
+			mkdirp(this.fs, dirname(this.fs, filename), err => {
+				if (err) return reject(err);
 
-		const r = root.resolve();
-
-		return Promise.resolve(r).then(root => {
-			if (!root) return null;
-			// calc positions in file
-			let currentOffset = 4;
-			const processOffsets = section => {
-				section.offset = currentOffset;
-				currentOffset += section.length;
-				for (const child of section.getSections()) {
-					processOffsets(child);
-				}
-			};
-			processOffsets(root);
-
-			// get buffers to write
-			const sizeBuf = Buffer.allocUnsafe(4);
-			sizeBuf.writeUInt32LE(root.length, 0);
-			const buffers = [sizeBuf];
-			const emit = (section, out) => {
-				section.emit(out);
-				for (const child of section.getSections()) {
-					emit(child, out);
-				}
-			};
-			emit(root, buffers);
-
-			// write to file
-			return new Promise((resolve, reject) => {
-				mkdirp(this.fs, dirname(this.fs, filename), err => {
-					if (err) return reject(err);
-					this.fileManager.addJob(filename, true, (file, callback) => {
-						writeBuffers(this.fs, file, buffers, err => {
-							if (err) return callback(err);
-							resolve(true);
-							callback();
-						});
+				// It's important that we don't touch existing files during serialization
+				// because serialize may read existing files (when deserializing)
+				const allWrittenFiles = new Set();
+				const writeFile = async (name, content) => {
+					const file = name
+						? join(this.fs, filename, `../${name}${extension}`)
+						: filename;
+					await new Promise((resolve, reject) => {
+						const stream = this.fs.createWriteStream(file + "_");
+						for (const b of content) stream.write(b);
+						stream.end();
+						stream.on("error", err => reject(err));
+						stream.on("finish", () => resolve());
 					});
-				});
+					if (name) allWrittenFiles.add(file);
+				};
+
+				resolve(
+					serialize(this, data, false, writeFile).then(
+						async ({ backgroundJob }) => {
+							await backgroundJob;
+
+							// Rename the index file to disallow access during inconsistent file state
+							await new Promise(resolve =>
+								this.fs.rename(filename, filename + ".old", err => {
+									resolve();
+								})
+							);
+
+							// update all written files
+							await Promise.all(
+								Array.from(
+									allWrittenFiles,
+									file =>
+										new Promise((resolve, reject) => {
+											this.fs.rename(file + "_", file, err => {
+												if (err) return reject(err);
+												resolve();
+											});
+										})
+								)
+							);
+
+							// As final step atomatically update the index file to have a consistent pack again
+							await new Promise(resolve => {
+								this.fs.rename(filename + "_", filename, err => {
+									if (err) return reject(err);
+									resolve();
+								});
+							});
+							return /** @type {true} */ (true);
+						}
+					)
+				);
 			});
 		});
 	}
@@ -408,37 +285,18 @@ class FileMiddleware extends SerializerMiddleware {
 	 * @param {Object} context context object
 	 * @returns {DeserializedType|Promise<DeserializedType>} deserialized data
 	 */
-	deserialize(data, { filename }) {
-		return new Promise((resolve, reject) => {
-			this.fileManager.addJob(
-				filename,
-				false,
-				(file, callback) => {
-					const sizeBuf = Buffer.allocUnsafe(4);
-					readFileSectionToBuffer(this.fs, file, sizeBuf, 0, 0, err => {
-						if (err) return callback(err);
-
-						const rootSize = sizeBuf.readUInt32LE(0);
-
-						readSection(
-							this.fs,
-							this.fileManager,
-							filename,
-							file,
-							4,
-							rootSize,
-							(err, parts) => {
-								if (err) return callback(err);
-
-								resolve(parts);
-								callback();
-							}
-						);
-					});
-				},
-				reject
-			);
-		});
+	deserialize(data, { filename, extension = "" }) {
+		const readFile = name =>
+			new Promise((resolve, reject) => {
+				const file = name
+					? join(this.fs, filename, `../${name}${extension}`)
+					: filename;
+				return this.fs.readFile(file, (err, content) => {
+					if (err) return reject(err);
+					resolve(content);
+				});
+			});
+		return deserialize(this, false, readFile);
 	}
 }
 

--- a/lib/serialization/ObjectMiddleware.js
+++ b/lib/serialization/ObjectMiddleware.js
@@ -89,17 +89,14 @@ const loadedRequests = new Set();
 
 const NOT_SERIALIZABLE = {};
 
-serializers.set(Object, {
+const plainObjectConfig = {
 	request: "",
 	name: null,
 	serializer: plainObjectSerializer
-});
+};
 
-serializers.set(Array, {
-	request: "",
-	name: null,
-	serializer: plainObjectSerializer
-});
+serializers.set(Object, plainObjectConfig);
+serializers.set(Array, plainObjectConfig);
 
 const jsTypes = new Map();
 jsTypes.set(null, new NullPrototypeObjectSerializer());
@@ -112,6 +109,22 @@ jsTypes.set(RangeError, new ErrorObjectSerializer(RangeError));
 jsTypes.set(ReferenceError, new ErrorObjectSerializer(ReferenceError));
 jsTypes.set(SyntaxError, new ErrorObjectSerializer(SyntaxError));
 jsTypes.set(TypeError, new ErrorObjectSerializer(TypeError));
+
+// If in a sandboxed environment (e. g. jest), this escapes the sandbox and registers
+// real Object and Array types to. These types may occur in the wild too, e. g. when
+// using Structured Clone in postMessage.
+if (exports.constructor !== Object) {
+	const Obj = /** @type {typeof Object} */ (exports.constructor);
+	serializers.set(Obj, plainObjectConfig);
+	serializers.set(Obj.values({}).constructor, plainObjectConfig);
+	const Fn = /** @type {typeof Function} */ (Obj.constructor);
+	for (const [type, config] of Array.from(jsTypes)) {
+		if (type) {
+			const Type = new Fn(`return ${type.name};`)();
+			jsTypes.set(Type, config);
+		}
+	}
+}
 
 {
 	let i = 1;
@@ -243,8 +256,9 @@ class ObjectMiddleware extends SerializerMiddleware {
 		const objectTypeLookup = new Map();
 		const cycleStack = new Set();
 		const stackToString = item => {
-			return Array.from(cycleStack)
-				.concat([item])
+			const arr = Array.from(cycleStack);
+			arr.push(item);
+			return arr
 				.map(item => {
 					if (typeof item === "string") {
 						if (item.length > 100) {
@@ -255,8 +269,15 @@ class ObjectMiddleware extends SerializerMiddleware {
 						}
 						return `String ${JSON.stringify(item)}`;
 					}
-					const { request, name } = ObjectMiddleware.getSerializerFor(item);
-					if (!request) {
+					try {
+						const { request, name } = ObjectMiddleware.getSerializerFor(item);
+						if (request) {
+							return `${request}${name ? `.${name}` : ""}`;
+						}
+					} catch (e) {
+						// ignore -> fallback
+					}
+					if (typeof item === "object" && item !== null && item.constructor) {
 						if (item.constructor === Object)
 							return `Object { ${Object.keys(item).join(", ")} }`;
 						if (item.constructor === Map) return `Map { ${item.size} items }`;
@@ -264,16 +285,26 @@ class ObjectMiddleware extends SerializerMiddleware {
 							return `Array { ${item.length} items }`;
 						if (item.constructor === Set) return `Set { ${item.size} items }`;
 						if (item.constructor === RegExp) return item.toString();
-						return item.constructor.name;
-					} else {
-						return `${request}${name ? `.${name}` : ""}`;
+						return `${item.constructor.name}`;
 					}
+					return `${item}`;
 				})
 				.join(" -> ");
 		};
+		let hasDebugInfoAttached;
 		const ctx = {
-			write(value) {
-				process(value);
+			write(value, key) {
+				try {
+					process(value);
+				} catch (e) {
+					if (hasDebugInfoAttached === undefined)
+						hasDebugInfoAttached = new WeakSet();
+					if (!hasDebugInfoAttached.has(e)) {
+						e.message += `\nwhile serializing ${stackToString(value)}`;
+						hasDebugInfoAttached.add(e);
+					}
+					throw e;
+				}
 			},
 			snapshot() {
 				return {
@@ -312,9 +343,7 @@ class ObjectMiddleware extends SerializerMiddleware {
 				result.push(item);
 			} else if (typeof item === "object" && item !== null) {
 				if (cycleStack.has(item)) {
-					throw new Error(
-						`Circular references can't be serialized (${stackToString(item)})`
-					);
+					throw new Error(`Circular references can't be serialized`);
 				}
 
 				const { request, name, serializer } = ObjectMiddleware.getSerializerFor(
@@ -333,9 +362,11 @@ class ObjectMiddleware extends SerializerMiddleware {
 
 				cycleStack.add(item);
 
-				serializer.serialize(item, ctx);
-
-				cycleStack.delete(item);
+				try {
+					serializer.serialize(item, ctx);
+				} finally {
+					cycleStack.delete(item);
+				}
 
 				result.push(ESCAPE, ESCAPE_END_OBJECT);
 
@@ -350,9 +381,7 @@ class ObjectMiddleware extends SerializerMiddleware {
 					context.logger.warn(
 						`Serializing big strings (${Math.round(
 							item.length / 1024
-						)}kiB) impacts deserialization performance (consider using Buffer instead and decode when needed):\n${stackToString(
-							item
-						)}`
+						)}kiB) impacts deserialization performance (consider using Buffer instead and decode when needed)`
 					);
 				}
 

--- a/lib/serialization/ObjectMiddleware.js
+++ b/lib/serialization/ObjectMiddleware.js
@@ -4,6 +4,7 @@
 
 "use strict";
 
+const ArraySerializer = require("./ArraySerializer");
 const ErrorObjectSerializer = require("./ErrorObjectSerializer");
 const MapObjectSerializer = require("./MapObjectSerializer");
 const NullPrototypeObjectSerializer = require("./NullPrototypeObjectSerializer");
@@ -80,8 +81,6 @@ const ESCAPE_UNDEFINED = false;
 
 const CURRENT_VERSION = 2;
 
-const plainObjectSerializer = new PlainObjectSerializer();
-
 const serializers = new Map();
 const serializerInversed = new Map();
 
@@ -89,16 +88,9 @@ const loadedRequests = new Set();
 
 const NOT_SERIALIZABLE = {};
 
-const plainObjectConfig = {
-	request: "",
-	name: null,
-	serializer: plainObjectSerializer
-};
-
-serializers.set(Object, plainObjectConfig);
-serializers.set(Array, plainObjectConfig);
-
 const jsTypes = new Map();
+jsTypes.set(Object, new PlainObjectSerializer());
+jsTypes.set(Array, new ArraySerializer());
 jsTypes.set(null, new NullPrototypeObjectSerializer());
 jsTypes.set(Map, new MapObjectSerializer());
 jsTypes.set(Set, new SetObjectSerializer());
@@ -115,8 +107,6 @@ jsTypes.set(TypeError, new ErrorObjectSerializer(TypeError));
 // using Structured Clone in postMessage.
 if (exports.constructor !== Object) {
 	const Obj = /** @type {typeof Object} */ (exports.constructor);
-	serializers.set(Obj, plainObjectConfig);
-	serializers.set(Obj.values({}).constructor, plainObjectConfig);
 	const Fn = /** @type {typeof Function} */ (Obj.constructor);
 	for (const [type, config] of Array.from(jsTypes)) {
 		if (type) {

--- a/lib/serialization/ObjectMiddleware.js
+++ b/lib/serialization/ObjectMiddleware.js
@@ -4,7 +4,6 @@
 
 "use strict";
 
-const memorize = require("../util/memorize");
 const ErrorObjectSerializer = require("./ErrorObjectSerializer");
 const MapObjectSerializer = require("./MapObjectSerializer");
 const NullPrototypeObjectSerializer = require("./NullPrototypeObjectSerializer");
@@ -17,8 +16,6 @@ const SetObjectSerializer = require("./SetObjectSerializer");
 /** @typedef {import("./types").PrimitiveSerializableType} PrimitiveSerializableType */
 
 /** @typedef {new (...params: any[]) => any} Constructor */
-
-const SERIALIZED_INFO = Symbol("serialized info");
 
 /*
 
@@ -140,6 +137,10 @@ const loaders = new Map();
  * @extends {SerializerMiddleware<DeserializedType, SerializedType>}
  */
 class ObjectMiddleware extends SerializerMiddleware {
+	constructor(extendContext) {
+		super();
+		this.extendContext = extendContext;
+	}
 	/**
 	 * @param {RegExp} regExp RegExp for which the request is tested
 	 * @param {function(string): boolean} loader loader to load the request, returns true when successful
@@ -225,32 +226,6 @@ class ObjectMiddleware extends SerializerMiddleware {
 		return serializer;
 	}
 
-	_handleFunctionSerialization(fn, context) {
-		const serializedInfo = fn[SERIALIZED_INFO];
-		if (serializedInfo) return serializedInfo;
-		return memorize(() => {
-			const r = fn();
-
-			if (r instanceof Promise)
-				return r.then(data => this.serialize([data], context));
-
-			return this.serialize([r], context);
-		});
-	}
-
-	_handleFunctionDeserialization(fn, context) {
-		const result = memorize(() => {
-			const r = fn();
-
-			if (r instanceof Promise)
-				return r.then(data => this.deserialize(data, context)[0]);
-
-			return this.deserialize(r, context)[0];
-		});
-		result[SERIALIZED_INFO] = fn;
-		return result;
-	}
-
 	/**
 	 * @param {DeserializedType} data data
 	 * @param {Object} context context object
@@ -267,6 +242,35 @@ class ObjectMiddleware extends SerializerMiddleware {
 		let currentPosTypeLookup = 0;
 		const objectTypeLookup = new Map();
 		const cycleStack = new Set();
+		const stackToString = item => {
+			return Array.from(cycleStack)
+				.concat([item])
+				.map(item => {
+					if (typeof item === "string") {
+						if (item.length > 100) {
+							return `String ${JSON.stringify(item.slice(0, 100)).slice(
+								0,
+								-1
+							)}..."`;
+						}
+						return `String ${JSON.stringify(item)}`;
+					}
+					const { request, name } = ObjectMiddleware.getSerializerFor(item);
+					if (!request) {
+						if (item.constructor === Object)
+							return `Object { ${Object.keys(item).join(", ")} }`;
+						if (item.constructor === Map) return `Map { ${item.size} items }`;
+						if (item.constructor === Array)
+							return `Array { ${item.length} items }`;
+						if (item.constructor === Set) return `Set { ${item.size} items }`;
+						if (item.constructor === RegExp) return item.toString();
+						return item.constructor.name;
+					} else {
+						return `${request}${name ? `.${name}` : ""}`;
+					}
+				})
+				.join(" -> ");
+		};
 		const ctx = {
 			write(value) {
 				process(value);
@@ -291,6 +295,7 @@ class ObjectMiddleware extends SerializerMiddleware {
 			},
 			...context
 		};
+		this.extendContext(ctx);
 		const process = item => {
 			// check if we can emit a reference
 			const ref = referenceable.get(item);
@@ -308,14 +313,7 @@ class ObjectMiddleware extends SerializerMiddleware {
 			} else if (typeof item === "object" && item !== null) {
 				if (cycleStack.has(item)) {
 					throw new Error(
-						`Circular references can't be serialized (${Array.from(cycleStack)
-							.concat([item])
-							.map(obj => {
-								if (obj.constructor === Object)
-									return `Object { ${Object.keys(obj).join(", ")} }`;
-								return obj.constructor.name;
-							})
-							.join(" -> ")})`
+						`Circular references can't be serialized (${stackToString(item)})`
 					);
 				}
 
@@ -348,11 +346,41 @@ class ObjectMiddleware extends SerializerMiddleware {
 					addReferenceable(item);
 				}
 
+				if (item.length > 102400 && context.logger) {
+					context.logger.warn(
+						`Serializing big strings (${Math.round(
+							item.length / 1024
+						)}kiB) impacts deserialization performance (consider using Buffer instead and decode when needed):\n${stackToString(
+							item
+						)}`
+					);
+				}
+
 				result.push(item);
 			} else if (item === ESCAPE) {
 				result.push(ESCAPE, ESCAPE_ESCAPE_VALUE);
 			} else if (typeof item === "function") {
-				result.push(this._handleFunctionSerialization(item, context));
+				if (!SerializerMiddleware.isLazy(item))
+					throw new Error("Unexpected function " + item);
+				/** @type {SerializedType} */
+				const serializedData = SerializerMiddleware.getLazySerializedValue(
+					item
+				);
+				if (serializedData !== undefined) {
+					if (typeof serializedData === "function") {
+						result.push(serializedData);
+					} else {
+						throw new Error("Not implemented");
+					}
+				} else if (SerializerMiddleware.isLazy(item, this)) {
+					throw new Error("Not implemented");
+				} else {
+					result.push(
+						SerializerMiddleware.serializeLazy(item, data =>
+							this.serialize([data], context)
+						)
+					);
+				}
 			} else if (item === undefined) {
 				result.push(ESCAPE, ESCAPE_UNDEFINED);
 			} else {
@@ -405,6 +433,7 @@ class ObjectMiddleware extends SerializerMiddleware {
 			},
 			...context
 		};
+		this.extendContext(ctx);
 		const decodeValue = () => {
 			const item = read();
 
@@ -509,7 +538,10 @@ class ObjectMiddleware extends SerializerMiddleware {
 
 				return item;
 			} else if (typeof item === "function") {
-				return this._handleFunctionDeserialization(item, context);
+				return SerializerMiddleware.deserializeLazy(
+					item,
+					data => this.deserialize(data, context)[0]
+				);
 			} else {
 				return item;
 			}

--- a/lib/serialization/PlainObjectSerializer.js
+++ b/lib/serialization/PlainObjectSerializer.js
@@ -4,82 +4,67 @@
 
 "use strict";
 
-const writeObject = (obj, write, values) => {
-	const keys = Object.keys(obj);
-	for (const key of keys) {
-		const value = obj[key];
-		if (
-			value !== null &&
-			typeof value === "object" &&
-			value.constructor &&
-			value.constructor === Object
-		) {
-			// nested object
-			write(true);
-			write(key);
-			writeObject(value, write, values);
-			write(false);
-		} else {
-			write(key);
-			values.push(value);
-		}
+const cache = new WeakMap();
+
+class ObjectStructure {
+	constructor(keys) {
+		this.keys = keys;
+		this.children = new Map();
 	}
+
+	getKeys() {
+		return this.keys;
+	}
+
+	key(key) {
+		const child = this.children.get(key);
+		if (child !== undefined) return child;
+		const newChild = new ObjectStructure(this.keys.concat(key));
+		this.children.set(key, newChild);
+		return newChild;
+	}
+}
+
+const getCachedKeys = (keys, cacheAssoc) => {
+	let root = cache.get(cacheAssoc);
+	if (root === undefined) {
+		root = new ObjectStructure([]);
+		cache.set(cacheAssoc, root);
+	}
+	let current = root;
+	for (const key of keys) {
+		current = current.key(key);
+	}
+	return current.getKeys();
 };
 
 class PlainObjectSerializer {
 	serialize(obj, { write }) {
-		if (Array.isArray(obj)) {
-			write(obj.length);
-			for (const item of obj) {
-				write(item);
+		const keys = Object.keys(obj);
+		if (keys.length > 1) {
+			write(getCachedKeys(keys, write));
+			for (const key of keys) {
+				write(obj[key]);
 			}
+		} else if (keys.length === 1) {
+			const key = keys[0];
+			write(key);
+			write(obj[key]);
 		} else {
-			const values = [];
-			writeObject(obj, write, values);
 			write(null);
-			for (const value of values) {
-				write(value);
-			}
 		}
 	}
 	deserialize({ read }) {
-		let key = read();
-		if (typeof key === "number") {
-			const array = [];
-			for (let i = 0; i < key; i++) {
-				array.push(read());
+		const keys = read();
+		const obj = {};
+		if (Array.isArray(keys)) {
+			for (const key of keys) {
+				obj[key] = read();
 			}
-			return array;
-		} else {
-			const keys = [];
-			let hasNested = key === true;
-			while (key !== null) {
-				keys.push(key);
-				key = read();
-				if (key === true) {
-					hasNested = true;
-				}
-			}
-			let currentObj = {};
-			const stack = hasNested && [];
-			for (let i = 0; i < keys.length; i++) {
-				const key = keys[i];
-				if (key === true) {
-					// enter nested object
-					const objectKey = keys[++i];
-					const newObj = {};
-					currentObj[objectKey] = newObj;
-					stack.push(currentObj);
-					currentObj = newObj;
-				} else if (key === false) {
-					// leave nested object
-					currentObj = stack.pop();
-				} else {
-					currentObj[key] = read();
-				}
-			}
-			return currentObj;
+		} else if (keys !== null) {
+			obj[keys] = read();
 		}
+		return obj;
 	}
 }
 

--- a/lib/serialization/Serializer.js
+++ b/lib/serialization/Serializer.js
@@ -6,40 +6,42 @@
 
 class Serializer {
 	constructor(middlewares, context) {
-		this.middlewares = middlewares;
+		this.serializeMiddlewares = middlewares.slice();
+		this.deserializeMiddlewares = middlewares.slice().reverse();
 		this.context = context;
 	}
 
 	serialize(obj, context) {
 		const ctx = { ...context, ...this.context };
-		return new Promise((resolve, reject) => {
-			let current = obj;
-			for (const middleware of this.middlewares) {
-				if (current instanceof Promise) {
-					current = current.then(
-						data => data && middleware.serialize(data, context)
-					);
-				} else if (current) {
-					try {
-						current = middleware.serialize(current, ctx);
-					} catch (err) {
-						current = Promise.reject(err);
-					}
-				} else break;
-			}
-			resolve(current);
-		});
+		let current = obj;
+		for (const middleware of this.serializeMiddlewares) {
+			if (current instanceof Promise) {
+				current = current.then(
+					data => data && middleware.serialize(data, context)
+				);
+			} else if (current) {
+				try {
+					current = middleware.serialize(current, ctx);
+				} catch (err) {
+					current = Promise.reject(err);
+				}
+			} else break;
+		}
+		return current;
 	}
 
-	deserialize(context) {
+	deserialize(value, context) {
 		const ctx = { ...context, ...this.context };
-		return Promise.resolve().then(() =>
-			this.middlewares.reduceRight((last, middleware) => {
-				if (last instanceof Promise)
-					return last.then(data => middleware.deserialize(data, context));
-				else return middleware.deserialize(last, ctx);
-			}, [])
-		);
+		/** @type {any} */
+		let current = value;
+		for (const middleware of this.deserializeMiddlewares) {
+			if (current instanceof Promise) {
+				current = current.then(data => middleware.deserialize(data, context));
+			} else {
+				current = middleware.deserialize(current, ctx);
+			}
+		}
+		return current;
 	}
 }
 

--- a/lib/serialization/SerializerMiddleware.js
+++ b/lib/serialization/SerializerMiddleware.js
@@ -4,6 +4,11 @@
 
 "use strict";
 
+const memorize = require("../util/memorize");
+
+const LAZY_TARGET = Symbol("lazy serialization target");
+const LAZY_SERIALIZED_VALUE = Symbol("lazy serialization data");
+
 /**
  * @template DeserializedType
  * @template SerializedType
@@ -29,6 +34,95 @@ class SerializerMiddleware {
 		throw new Error(
 			"Serializer.deserialize is abstract and need to be overwritten"
 		);
+	}
+
+	/**
+	 * @param {any | function(): Promise<any> | any} value contained value or function to value
+	 * @param {SerializerMiddleware<any, any>} target target middleware
+	 * @param {object=} options lazy options
+	 * @param {any=} serializedValue serialized value
+	 * @returns {function(): Promise<any> | any} lazy function
+	 */
+	static createLazy(value, target, options = {}, serializedValue) {
+		if (SerializerMiddleware.isLazy(value, target)) return value;
+		const fn = typeof value === "function" ? value : () => value;
+		fn[LAZY_TARGET] = target;
+		/** @type {any} */ (fn).options = options;
+		fn[LAZY_SERIALIZED_VALUE] = serializedValue;
+		return fn;
+	}
+
+	/**
+	 * @param {function(): Promise<any> | any} fn lazy function
+	 * @param {SerializerMiddleware<any, any>=} target target middleware
+	 * @returns {boolean} true, when fn is a lazy function (optionally of that target)
+	 */
+	static isLazy(fn, target) {
+		if (typeof fn !== "function") return false;
+		const t = fn[LAZY_TARGET];
+		return target ? t === target : !!t;
+	}
+
+	/**
+	 * @param {function(): Promise<any> | any} fn lazy function
+	 * @returns {object} options
+	 */
+	static getLazyOptions(fn) {
+		if (typeof fn !== "function") return undefined;
+		return /** @type {any} */ (fn).options;
+	}
+
+	/**
+	 * @param {function(): Promise<any> | any} fn lazy function
+	 * @returns {any} serialized value
+	 */
+	static getLazySerializedValue(fn) {
+		if (typeof fn !== "function") return undefined;
+		return fn[LAZY_SERIALIZED_VALUE];
+	}
+
+	/**
+	 * @param {function(): Promise<any> | any} fn lazy function
+	 * @param {any} value serialized value
+	 * @returns {void}
+	 */
+	static setLazySerializedValue(fn, value) {
+		fn[LAZY_SERIALIZED_VALUE] = value;
+	}
+
+	/**
+	 * @param {function(): Promise<any> | any} lazy lazy function
+	 * @param {function(any): Promise<any> | any} serialize serialize function
+	 * @returns {function(): Promise<any> | any} new lazy
+	 */
+	static serializeLazy(lazy, serialize) {
+		const fn = memorize(() => {
+			const r = lazy();
+			if (r instanceof Promise) return r.then(data => data && serialize(data));
+			if (r) return serialize(r);
+			return null;
+		});
+		fn[LAZY_TARGET] = lazy[LAZY_TARGET];
+		/** @type {any} */ (fn).options = /** @type {any} */ (lazy).options;
+		lazy[LAZY_SERIALIZED_VALUE] = fn;
+		return fn;
+	}
+
+	/**
+	 * @param {function(): Promise<any> | any} lazy lazy function
+	 * @param {function(any): Promise<any> | any} deserialize deserialize function
+	 * @returns {function(): Promise<any> | any} new lazy
+	 */
+	static deserializeLazy(lazy, deserialize) {
+		const fn = memorize(() => {
+			const r = lazy();
+			if (r instanceof Promise) return r.then(data => deserialize(data));
+			return deserialize(r);
+		});
+		fn[LAZY_TARGET] = lazy[LAZY_TARGET];
+		/** @type {any} */ (fn).options = /** @type {any} */ (lazy).options;
+		fn[LAZY_SERIALIZED_VALUE] = lazy;
+		return fn;
 	}
 }
 

--- a/lib/util/LazySet.js
+++ b/lib/util/LazySet.js
@@ -179,11 +179,17 @@ class LazySet {
 
 	serialize({ write }) {
 		if (this._needMerge) this._merge();
-		write(this._set);
+		write(this._set.size);
+		for (const item of this._set) write(item);
 	}
 
 	static deserialize({ read }) {
-		return new LazySet(read());
+		const count = read();
+		const items = [];
+		for (let i = 0; i < count; i++) {
+			items.push(read());
+		}
+		return new LazySet(items);
 	}
 }
 

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -40,6 +40,7 @@ const path = require("path");
  * @typedef {Object} IntermediateFileSystemExtras
  * @property {function(string): void} mkdirSync
  * @property {function(string): import("fs").WriteStream} createWriteStream
+ * @property {function(string, string, Callback): void} rename
  */
 
 /** @typedef {InputFileSystem & OutputFileSystem & IntermediateFileSystemExtras} IntermediateFileSystem */

--- a/lib/util/internalSerializables.js
+++ b/lib/util/internalSerializables.js
@@ -16,6 +16,7 @@ module.exports = {
 	ContextModule: () => require("../ContextModule"),
 	"cache/PackFileCacheStrategy": () =>
 		require("../cache/PackFileCacheStrategy"),
+	"cache/ResolverCachePlugin": () => require("../cache/ResolverCachePlugin"),
 	"dependencies/AMDDefineDependency": () =>
 		require("../dependencies/AMDDefineDependency"),
 	"dependencies/AMDRequireArrayDependency": () =>

--- a/lib/util/serialization.js
+++ b/lib/util/serialization.js
@@ -8,6 +8,7 @@ const BinaryMiddleware = require("../serialization/BinaryMiddleware");
 const FileMiddleware = require("../serialization/FileMiddleware");
 const ObjectMiddleware = require("../serialization/ObjectMiddleware");
 const Serializer = require("../serialization/Serializer");
+const SerializerMiddleware = require("../serialization/SerializerMiddleware");
 const SingleItemMiddleware = require("../serialization/SingleItemMiddleware");
 const internalSerializables = require("./internalSerializables");
 
@@ -16,6 +17,8 @@ const internalSerializables = require("./internalSerializables");
 
 const { register, registerLoader, registerNotSerializable } = ObjectMiddleware;
 
+const binaryMiddleware = new BinaryMiddleware();
+
 // Expose serialization API
 exports.register = register;
 exports.registerLoader = registerLoader;
@@ -23,18 +26,39 @@ exports.registerNotSerializable = registerNotSerializable;
 exports.NOT_SERIALIZABLE = ObjectMiddleware.NOT_SERIALIZABLE;
 exports.MEASURE_START_OPERATION = BinaryMiddleware.MEASURE_START_OPERATION;
 exports.MEASURE_END_OPERATION = BinaryMiddleware.MEASURE_END_OPERATION;
-exports.createFileSerializer = fs =>
-	new Serializer([
-		new SingleItemMiddleware(),
-		new ObjectMiddleware(),
-		new BinaryMiddleware(),
-		new FileMiddleware(fs)
-	]);
 exports.buffersSerializer = new Serializer([
 	new SingleItemMiddleware(),
-	new ObjectMiddleware(),
-	new BinaryMiddleware()
+	new ObjectMiddleware(context => {
+		if (context.write) {
+			context.writeLazy = value => {
+				context.write(SerializerMiddleware.createLazy(value, binaryMiddleware));
+			};
+		}
+	}),
+	binaryMiddleware
 ]);
+exports.createFileSerializer = fs => {
+	const fileMiddleware = new FileMiddleware(fs);
+	return new Serializer([
+		new SingleItemMiddleware(),
+		new ObjectMiddleware(context => {
+			if (context.write) {
+				context.writeLazy = value => {
+					context.write(
+						SerializerMiddleware.createLazy(value, binaryMiddleware)
+					);
+				};
+				context.writeSeparate = (value, options) => {
+					context.write(
+						SerializerMiddleware.createLazy(value, fileMiddleware, options)
+					);
+				};
+			}
+		}),
+		binaryMiddleware,
+		fileMiddleware
+	]);
+};
 
 require("./registerExternalSerializer");
 

--- a/test/PersistentCaching.test.js
+++ b/test/PersistentCaching.test.js
@@ -1,0 +1,102 @@
+const path = require("path");
+const util = require("util");
+const fs = require("fs");
+const rimraf = require("rimraf");
+const vm = require("vm");
+const webpack = require("../");
+
+const readFile = util.promisify(fs.readFile);
+const readdir = util.promisify(fs.readdir);
+const writeFile = util.promisify(fs.writeFile);
+const utimes = util.promisify(fs.utimes);
+const mkdir = util.promisify(fs.mkdir);
+
+describe("Persistent Caching", () => {
+	const tempPath = path.resolve(__dirname, "js", "persistent-caching");
+	const outputPath = path.resolve(tempPath, "output");
+	const cachePath = path.resolve(tempPath, "cache");
+	const srcPath = path.resolve(tempPath, "src");
+
+	const config = {
+		mode: "none",
+		context: tempPath,
+		cache: {
+			type: "filesystem",
+			buildDependencies: {
+				// avoid rechecking build dependencies
+				// for performance
+				// this is already covered by another test case
+				defaultWebpack: []
+			},
+			cacheLocation: cachePath
+		},
+		target: "node",
+		output: {
+			library: "result",
+			libraryExport: "default",
+			path: outputPath
+		}
+	};
+
+	beforeAll(done => {
+		rimraf(tempPath, done);
+	});
+
+	const updateSrc = async data => {
+		const ts = new Date(Date.now() - 10000);
+		await mkdir(srcPath, { recursive: true });
+		for (const key of Object.keys(data)) {
+			const p = path.resolve(srcPath, key);
+			await writeFile(p, data[key]);
+			await utimes(p, ts, ts);
+		}
+	};
+
+	const compile = async () => {
+		return new Promise((resolve, reject) => {
+			webpack(config, (err, stats) => {
+				if (err) return reject(err);
+				resolve(stats);
+			});
+		});
+	};
+
+	const execute = async () => {
+		const p = path.resolve(outputPath, "main.js");
+		const source = await readFile(p, "utf-8");
+		const context = {};
+		const fn = vm.runInThisContext(
+			`(function() { ${source}\nreturn result; })`,
+			context,
+			p
+		);
+		return fn();
+	};
+
+	it("should merge multiple small files", async () => {
+		const files = Array.from({ length: 30 }).map((_, i) => `file${i}.js`);
+		const data = {
+			"index.js": `
+${files.map((f, i) => `import f${i} from "./${f}";`).join("\n")}
+
+export default ${files.map((_, i) => `f${i}`).join(" + ")};
+`
+		};
+		for (const file of files) {
+			data[file] = `export default 1;`;
+		}
+		await updateSrc(data);
+		await compile();
+		expect(await execute()).toBe(30);
+		for (let i = 0; i < 30; i++) {
+			updateSrc({
+				[files[i]]: `export default 2;`
+			});
+			await compile();
+			expect(await execute()).toBe(31 + i);
+		}
+		const cacheFiles = await readdir(cachePath);
+		expect(cacheFiles.length).toBeLessThan(20);
+		expect(cacheFiles.length).toBeGreaterThan(10);
+	}, 60000);
+});

--- a/tooling/print-cache-file.js
+++ b/tooling/print-cache-file.js
@@ -56,6 +56,7 @@ const printData = async (data, indent) => {
 		return;
 	}
 	const referencedValues = new Map();
+	const referencedValuesCounters = new Map();
 	const referencedTypes = new Map();
 	let currentReference = 0;
 	let currentTypeReference = 0;
@@ -81,6 +82,10 @@ const printData = async (data, indent) => {
 			} else if (typeof nextItem === "number" && nextItem < 0) {
 				const ref = currentReference + nextItem;
 				const value = referencedValues.get(ref);
+				referencedValuesCounters.set(
+					ref,
+					(referencedValuesCounters.get(ref) || 0) + 1
+				);
 				if (value) {
 					printLine(
 						`Reference ${nextItem} => ${JSON.stringify(value)} #${ref}`
@@ -130,6 +135,19 @@ const printData = async (data, indent) => {
 			printLine(`}`);
 		} else {
 			printLine(`${item}`);
+		}
+	}
+	const refCounters = Array.from(referencedValuesCounters);
+	refCounters.sort(([a, A], [b, B]) => {
+		return B - A;
+	});
+	printLine("SUMMARY: top references:");
+	for (const [ref, count] of refCounters.slice(10)) {
+		const value = referencedValues.get(ref);
+		if (value) {
+			printLine(`- #${ref} x ${count} = ${JSON.stringify(value)}`);
+		} else {
+			printLine(`- #${ref} x ${count}`);
 		}
 	}
 };


### PR DESCRIPTION
cache is split into multiple .pack files which represent usage of cache items
this allows to only read/deserialize files that are needed
and reduces the need to rewrite .pack files
while still packaging multiple cache items together

lazy (de)serialization system has changed to allow writeLazy and writeSeparate

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
refactoring, feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
existing tests
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
