### PR TITLE
add percentBy options to ProgressPlugin

### DIFF
--- a/declarations/plugins/ProgressPlugin.d.ts
+++ b/declarations/plugins/ProgressPlugin.d.ts
@@ -44,6 +44,10 @@ export interface ProgressPluginOptions {
 	 */
 	modulesCount?: number;
 	/**
+	 * Collect percent algorithm. By default it calculates by a median from modules, entries and dependencies percent
+	 */
+	percentBy?: "entries" | "modules" | "dependencies" | null;
+	/**
 	 * Collect profile data for progress steps. Default: false
 	 */
 	profile?: true | false | null;

--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -129,6 +129,7 @@ class ProgressPlugin {
 		this.showModules = options.modules;
 		this.showDependencies = options.dependencies;
 		this.showActiveModules = options.activeModules;
+		this.percentBy = options.percentBy;
 	}
 
 	/**
@@ -204,10 +205,27 @@ class ProgressPlugin {
 				doneEntries / Math.max(lastEntriesCount, entriesCount);
 			const percentByDependencies =
 				doneDependencies / Math.max(lastDependenciesCount, dependenciesCount);
-			const percentage =
-				0.1 +
-				median3(percentByModules, percentByEntries, percentByDependencies) *
-					0.6;
+			let percentageFactor;
+
+			switch (this.percentBy) {
+				case "entries":
+					percentageFactor = percentByEntries;
+					break;
+				case "dependencies":
+					percentageFactor = percentByDependencies;
+					break;
+				case "modules":
+					percentageFactor = percentByModules;
+					break;
+				default:
+					percentageFactor = median3(
+						percentByModules,
+						percentByEntries,
+						percentByDependencies
+					);
+			}
+
+			const percentage = 0.1 + percentageFactor * 0.6;
 
 			if (showEntries) {
 				items.push(`${doneEntries}/${entriesCount} entries`);

--- a/schemas/plugins/ProgressPlugin.json
+++ b/schemas/plugins/ProgressPlugin.json
@@ -41,6 +41,10 @@
           "description": "Minimum modules count to start with. For better progress calculation. Default: 5000",
           "type": "number"
         },
+        "percentBy": {
+          "description": "Collect percent algorithm. By default it calculates by a median from modules, entries and dependencies percent",
+          "enum": ["entries", "modules", "dependencies", null]
+        },
         "profile": {
           "description": "Collect profile data for progress steps. Default: false",
           "enum": [true, false, null]

--- a/test/ProgressPlugin.test.js
+++ b/test/ProgressPlugin.test.js
@@ -60,6 +60,24 @@ describe("ProgressPlugin", function() {
 			expect(_.maxBy(logs, "length").length).toBeGreaterThan(50);
 		});
 	});
+
+	it("should display all type of percentage when it is applied to SingleCompiler", () => {
+		const compiler = createSimpleCompiler({
+			entries: true,
+			modules: true,
+			dependencies: true,
+			activeModules: true
+		});
+
+		return RunCompilerAsync(compiler).then(() => {
+			const logs = stderr.toString();
+
+			expect(logs).toEqual(expect.stringMatching(/\d+\/\d+ entries/));
+			expect(logs).toEqual(expect.stringMatching(/\d+\/\d+ dependencies/));
+			expect(logs).toEqual(expect.stringMatching(/\d+\/\d+ modules/));
+			expect(logs).toEqual(expect.stringMatching(/\d+ active/));
+		});
+	});
 });
 
 const createMultiCompiler = () => {
@@ -80,7 +98,7 @@ const createMultiCompiler = () => {
 	return compiler;
 };
 
-const createSimpleCompiler = () => {
+const createSimpleCompiler = progressOptions => {
 	const compiler = webpack({
 		context: path.join(__dirname, "fixtures"),
 		entry: "./a.js"
@@ -89,7 +107,8 @@ const createSimpleCompiler = () => {
 	compiler.outputFileSystem = new MemoryFs();
 
 	new webpack.ProgressPlugin({
-		activeModules: true
+		activeModules: true,
+		...progressOptions
 	}).apply(compiler);
 
 	return compiler;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feature

**Motivation:** on huge projects, there is super incorrect percent value. This feature makes possible to specify the percent calculation algorithm. For example on huge projects `percentBy: "entries"` gives more correctly percent value cause there are much entrypoints and they are known in advance

**Did you add tests for your changes?**

no, but added some other tests

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**
ProgressPlugins has a new option `percentBy` which can take `"entries"` `"dependencies"` `"modules"` or `null` (default).
