### PR TITLE
introduce async-webworker target

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -401,6 +401,7 @@ export interface WebpackOptions {
 		| (
 				| "web"
 				| "webworker"
+				| "async-webworker"
 				| "node"
 				| "async-node"
 				| "node-webkit"

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -83,11 +83,14 @@ class WebpackOptionsApply extends OptionsApply {
 					new NodeSourcePlugin(options.node).apply(compiler);
 					new LoaderTargetPlugin(options.target).apply(compiler);
 					break;
-				case "webworker": {
+				case "webworker":
+				case "async-webworker": {
 					let WebWorkerTemplatePlugin = require("./webworker/WebWorkerTemplatePlugin");
 					FetchCompileWasmTemplatePlugin = require("./web/FetchCompileWasmTemplatePlugin");
 					NodeSourcePlugin = require("./node/NodeSourcePlugin");
-					new WebWorkerTemplatePlugin().apply(compiler);
+					new WebWorkerTemplatePlugin({
+						asyncChunkLoading: options.target === "async-webworker"
+					}).apply(compiler);
 					new FetchCompileWasmTemplatePlugin({
 						mangleImports: options.optimization.mangleWasmImports
 					}).apply(compiler);

--- a/lib/webworker/WebWorkerMainTemplatePlugin.js
+++ b/lib/webworker/WebWorkerMainTemplatePlugin.js
@@ -7,6 +7,10 @@
 const Template = require("../Template");
 
 class WebWorkerMainTemplatePlugin {
+	constructor(asyncChunkLoading) {
+		this.asyncChunkLoading = asyncChunkLoading;
+	}
+
 	apply(mainTemplate) {
 		const needChunkOnDemandLoadingCode = chunk => {
 			for (const chunkGroup of chunk.groupsIterable) {
@@ -14,6 +18,7 @@ class WebWorkerMainTemplatePlugin {
 			}
 			return false;
 		};
+		const asyncChunkLoading = this.asyncChunkLoading;
 		mainTemplate.hooks.localVars.tap(
 			"WebWorkerMainTemplatePlugin",
 			(source, chunk) => {
@@ -44,7 +49,7 @@ class WebWorkerMainTemplatePlugin {
 						'// "1" is the signal for "already loaded"',
 						"if(!installedChunks[chunkId]) {",
 						Template.indent([
-							"importScripts(" +
+							(asyncChunkLoading ? "return fetch(" : "importScripts(") +
 								"__webpack_require__.p + " +
 								mainTemplate.getAssetPath(JSON.stringify(chunkFilename), {
 									hash: `" + ${mainTemplate.renderCurrentHashCode(hash)} + "`,
@@ -96,7 +101,19 @@ class WebWorkerMainTemplatePlugin {
 									},
 									contentHashType: "javascript"
 								}) +
-								");"
+								(asyncChunkLoading ? ")" : ");"),
+							...(!asyncChunkLoading
+								? []
+								: [
+										Template.indent([
+											".then(function(resp) {",
+											Template.indent("return resp.text();"),
+											"})",
+											".then(function(moduleContent) {",
+											Template.indent("Function(moduleContent)()"),
+											"});"
+										])
+								  ])
 						]),
 						"}"
 					]),

--- a/lib/webworker/WebWorkerTemplatePlugin.js
+++ b/lib/webworker/WebWorkerTemplatePlugin.js
@@ -9,11 +9,18 @@ const WebWorkerChunkTemplatePlugin = require("./WebWorkerChunkTemplatePlugin");
 const WebWorkerHotUpdateChunkTemplatePlugin = require("./WebWorkerHotUpdateChunkTemplatePlugin");
 
 class WebWorkerTemplatePlugin {
+	constructor(options) {
+		options = options || {};
+		this.asyncChunkLoading = options.asyncChunkLoading;
+	}
+
 	apply(compiler) {
 		compiler.hooks.thisCompilation.tap(
 			"WebWorkerTemplatePlugin",
 			compilation => {
-				new WebWorkerMainTemplatePlugin().apply(compilation.mainTemplate);
+				new WebWorkerMainTemplatePlugin(this.asyncChunkLoading).apply(
+					compilation.mainTemplate
+				);
 				new WebWorkerChunkTemplatePlugin().apply(compilation.chunkTemplate);
 				new WebWorkerHotUpdateChunkTemplatePlugin().apply(
 					compilation.hotUpdateChunkTemplate

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2216,6 +2216,7 @@
           "enum": [
             "web",
             "webworker",
+            "async-webworker",
             "node",
             "async-node",
             "node-webkit",


### PR DESCRIPTION
Following the discussion in #6472, this PR introduces a new `target` called `async-webworker`.
Dynamic import statements in web workers are transpiled by default into importScripts statements. Those statements are synchronous and yield bad performance. The aforementioned target transpiles dynamic imports into `fetch` followed by dynamic code evaluation. Using this technique the chunks can be downloaded asynchronously.

If you think I'm in the right direction I will also contribute this code to webpack 5

**What kind of change does this PR introduce?**
New feature

**Did you add tests for your changes?**
I will add tests once we agree on the implementation details

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
[Targets table](https://webpack.js.org/configuration/target/)
