### PR TITLE
Add entrypoint descriptor with `import` property

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -526,7 +526,19 @@ export interface EntryObject {
 	/**
 	 * An entry point with name
 	 */
-	[k: string]: string | NonEmptyArrayOfUniqueStringValues;
+	[k: string]: string | NonEmptyArrayOfUniqueStringValues | EntryDescription;
+}
+/**
+ * An object with entry point description.
+ *
+ * This interface was referenced by `WebpackOptions`'s JSON-Schema
+ * via the `definition` "EntryDescription".
+ */
+export interface EntryDescription {
+	/**
+	 * Entrypoint modules.
+	 */
+	import: EntryItem;
 }
 /**
  * Enables/Disables experiments (experiemental features with relax SemVer compatibility)

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -20,7 +20,12 @@ export type EntryDynamic = () => EntryStatic | Promise<EntryStatic>;
  * This interface was referenced by `WebpackOptions`'s JSON-Schema
  * via the `definition` "EntryStatic".
  */
-export type EntryStatic = EntryObject | EntryItem;
+export type EntryStatic = EntryObject | EntryUnnamed;
+/**
+ * This interface was referenced by `WebpackOptions`'s JSON-Schema
+ * via the `definition` "EntryItem".
+ */
+export type EntryItem = string | NonEmptyArrayOfUniqueStringValues;
 /**
  * A non-empty array of non-empty strings
  *
@@ -29,10 +34,12 @@ export type EntryStatic = EntryObject | EntryItem;
  */
 export type NonEmptyArrayOfUniqueStringValues = [string, ...string[]];
 /**
+ * An entry point without name.
+ *
  * This interface was referenced by `WebpackOptions`'s JSON-Schema
- * via the `definition` "EntryItem".
+ * via the `definition` "EntryUnnamed".
  */
-export type EntryItem = string | NonEmptyArrayOfUniqueStringValues;
+export type EntryUnnamed = EntryItem;
 /**
  * This interface was referenced by `WebpackOptions`'s JSON-Schema
  * via the `definition` "Externals".
@@ -526,7 +533,7 @@ export interface EntryObject {
 	/**
 	 * An entry point with name
 	 */
-	[k: string]: string | NonEmptyArrayOfUniqueStringValues | EntryDescription;
+	[k: string]: EntryItem | EntryDescription;
 }
 /**
  * An object with entry point description.
@@ -536,7 +543,7 @@ export interface EntryObject {
  */
 export interface EntryDescription {
 	/**
-	 * Entrypoint modules.
+	 * The module(s) loaded at startup.
 	 */
 	import: EntryItem;
 }

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -145,6 +145,12 @@ const { arrayToSetDeprecation } = require("./util/deprecation");
  */
 
 /**
+ * @typedef {Object} EntryData
+ * @property {EntryDependency[]} dependencies dependencies of the entrypoint
+ * @property {EntryOptions} options options of the entrypoint
+ */
+
+/**
  * @typedef {Object} LogEntry
  * @property {string} type
  * @property {any[]} args
@@ -597,8 +603,8 @@ class Compilation {
 		 */
 		this.creatingModuleDuringBuild = new WeakMap();
 
-		/** @type {Map<string, EntryDependency[]>} */
-		this.entryDependencies = new Map();
+		/** @type {Map<string, EntryData>} */
+		this.entries = new Map();
 		/** @type {Map<string, Entrypoint>} */
 		this.entrypoints = new Map();
 		/** @type {Set<Chunk>} */
@@ -1385,24 +1391,45 @@ class Compilation {
 	 *
 	 * @param {string} context context path for entry
 	 * @param {EntryDependency} entry entry dependency being created
-	 * @param {string | EntryOptions} options options or deprecated name of entry
+	 * @param {string | EntryOptions} optionsOrName options or deprecated name of entry
 	 * @param {ModuleCallback} callback callback function
 	 * @returns {void} returns
 	 */
-	addEntry(context, entry, options, callback) {
+	addEntry(context, entry, optionsOrName, callback) {
 		// TODO webpack 6 remove
-		if (typeof options !== "object") {
-			options = { name: options };
-		}
-		this.hooks.addEntry.call(entry, options);
+		const options =
+			typeof optionsOrName === "object"
+				? optionsOrName
+				: { name: optionsOrName };
 
 		const { name } = options;
-		let entriesArray = this.entryDependencies.get(name);
-		if (entriesArray === undefined) {
-			entriesArray = [];
-			this.entryDependencies.set(name, entriesArray);
+		let entryData = this.entries.get(name);
+		if (entryData === undefined) {
+			entryData = {
+				dependencies: [entry],
+				options: {
+					name: undefined,
+					...options
+				}
+			};
+			this.entries.set(name, entryData);
+		} else {
+			entryData.dependencies.push(entry);
+			for (const key of Object.keys(options)) {
+				if (entryData.options[key] === options[key]) continue;
+				if (entryData.options[key] === undefined) {
+					entryData.options[key] = options[key];
+				} else {
+					return callback(
+						new WebpackError(
+							`Conflicting entry option ${key} = ${entryData.options[key]} vs ${options[key]}`
+						)
+					);
+				}
+			}
 		}
-		entriesArray.push(entry);
+
+		this.hooks.addEntry.call(entry, options);
 
 		this.addModuleChain(context, entry, (err, module) => {
 			if (err) {
@@ -1550,7 +1577,7 @@ class Compilation {
 
 		this.logger.time("create chunks");
 		this.hooks.beforeChunks.call();
-		for (const [name, dependencies] of this.entryDependencies) {
+		for (const [name, { dependencies }] of this.entries) {
 			const chunk = this.addChunk(name);
 			chunk.name = name;
 			const entrypoint = new Entrypoint(name);

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -140,6 +140,11 @@ const { arrayToSetDeprecation } = require("./util/deprecation");
  */
 
 /**
+ * @typedef {Object} EntryOptions
+ * @property {string} name name of the entrypoint
+ */
+
+/**
  * @typedef {Object} LogEntry
  * @property {string} type
  * @property {any[]} args
@@ -270,12 +275,12 @@ class Compilation {
 			/** @type {SyncHook<[Module]>} */
 			stillValidModule: new SyncHook(["module"]),
 
-			/** @type {SyncHook<[Dependency, string]>} */
-			addEntry: new SyncHook(["entry", "name"]),
-			/** @type {SyncHook<[Dependency, string, Error]>} */
-			failedEntry: new SyncHook(["entry", "name", "error"]),
-			/** @type {SyncHook<[Dependency, string, Module]>} */
-			succeedEntry: new SyncHook(["entry", "name", "module"]),
+			/** @type {SyncHook<[Dependency, EntryOptions]>} */
+			addEntry: new SyncHook(["entry", "options"]),
+			/** @type {SyncHook<[Dependency, EntryOptions, Error]>} */
+			failedEntry: new SyncHook(["entry", "options", "error"]),
+			/** @type {SyncHook<[Dependency, EntryOptions, Module]>} */
+			succeedEntry: new SyncHook(["entry", "options", "module"]),
 
 			/** @type {SyncWaterfallHook<[string[][], Dependency]>} */
 			dependencyReferencedExports: new SyncWaterfallHook([
@@ -1380,13 +1385,18 @@ class Compilation {
 	 *
 	 * @param {string} context context path for entry
 	 * @param {EntryDependency} entry entry dependency being created
-	 * @param {string} name name of entry
+	 * @param {string | EntryOptions} options options or deprecated name of entry
 	 * @param {ModuleCallback} callback callback function
 	 * @returns {void} returns
 	 */
-	addEntry(context, entry, name, callback) {
-		this.hooks.addEntry.call(entry, name);
+	addEntry(context, entry, options, callback) {
+		// TODO webpack 6 remove
+		if (typeof options !== "object") {
+			options = { name: options };
+		}
+		this.hooks.addEntry.call(entry, options);
 
+		const { name } = options;
 		let entriesArray = this.entryDependencies.get(name);
 		if (entriesArray === undefined) {
 			entriesArray = [];
@@ -1396,10 +1406,10 @@ class Compilation {
 
 		this.addModuleChain(context, entry, (err, module) => {
 			if (err) {
-				this.hooks.failedEntry.call(entry, name, err);
+				this.hooks.failedEntry.call(entry, options, err);
 				return callback(err);
 			}
-			this.hooks.succeedEntry.call(entry, name, module);
+			this.hooks.succeedEntry.call(entry, options, module);
 			return callback(null, module);
 		});
 	}

--- a/lib/DllEntryPlugin.js
+++ b/lib/DllEntryPlugin.js
@@ -45,7 +45,7 @@ class DllEntryPlugin {
 					}),
 					this.name
 				),
-				this.name,
+				{ name: this.name },
 				callback
 			);
 		});

--- a/lib/DynamicEntryPlugin.js
+++ b/lib/DynamicEntryPlugin.js
@@ -9,6 +9,7 @@ const EntryPlugin = require("./EntryPlugin");
 const EntryDependency = require("./dependencies/EntryDependency");
 
 /** @typedef {import("../declarations/WebpackOptions").EntryDynamic} EntryDynamic */
+/** @typedef {import("../declarations/WebpackOptions").EntryItem} EntryItem */
 /** @typedef {import("../declarations/WebpackOptions").EntryStatic} EntryStatic */
 /** @typedef {import("./Compiler")} Compiler */
 
@@ -65,7 +66,13 @@ class DynamicEntryPlugin {
 					} else if (typeof entry === "object") {
 						Promise.all(
 							Object.keys(entry).map(name => {
-								return addEntry(entry[name], name);
+								const entryItem = entry[name];
+
+								if (typeof entryItem === "string" || Array.isArray(entryItem)) {
+									return addEntry(entryItem, name);
+								}
+
+								return addEntry(entryItem.import, name);
 							})
 						).then(() => {
 							callback();

--- a/lib/DynamicEntryPlugin.js
+++ b/lib/DynamicEntryPlugin.js
@@ -5,6 +5,7 @@
 
 "use strict";
 
+const EntryOptionPlugin = require("./EntryOptionPlugin");
 const EntryPlugin = require("./EntryPlugin");
 const EntryDependency = require("./dependencies/EntryDependency");
 
@@ -38,59 +39,31 @@ class DynamicEntryPlugin {
 			}
 		);
 
-		compiler.hooks.make.tapAsync(
+		compiler.hooks.make.tapPromise(
 			"DynamicEntryPlugin",
-			(compilation, callback) => {
-				/**
-				 * @param {string|string[]} entry entry value or array of entry values
-				 * @param {string} name name of entry
-				 * @returns {Promise<EntryStatic>} returns the promise resolving the Compilation#addEntry function
-				 */
-				const addEntry = (entry, name) => {
-					const deps = DynamicEntryPlugin.createDependencies(entry, name);
-					return new Promise((resolve, reject) => {
-						for (const dep of deps) {
-							compilation.addEntry(this.context, dep, name, err => {
-								if (err) return reject(err);
-								resolve();
-							});
-						}
-					});
-				};
-
-				Promise.resolve(this.entry()).then(entry => {
-					if (typeof entry === "string" || Array.isArray(entry)) {
-						addEntry(entry, "main").then(() => {
-							callback();
-						}, callback);
-					} else if (typeof entry === "object") {
-						Promise.all(
-							Object.keys(entry).map(name => {
-								const entryItem = entry[name];
-
-								if (typeof entryItem === "string" || Array.isArray(entryItem)) {
-									return addEntry(entryItem, name);
-								}
-
-								return addEntry(entryItem.import, name);
-							})
-						).then(() => {
-							callback();
-						}, callback);
-					}
-				}, callback);
-			}
+			(compilation, callback) =>
+				Promise.resolve(this.entry())
+					.then(entry => {
+						const promises = [];
+						EntryOptionPlugin.processEntryStatic(entry, (entry, options) => {
+							promises.push(
+								new Promise((resolve, reject) => {
+									compilation.addEntry(
+										this.context,
+										EntryPlugin.createDependency(entry, options),
+										options,
+										err => {
+											if (err) return reject(err);
+											resolve();
+										}
+									);
+								})
+							);
+						});
+						return Promise.all(promises);
+					})
+					.then(x => {})
 		);
-	}
-
-	/**
-	 * @param {string|string[]} entry entry value or array of entry paths
-	 * @param {string} name name of entry
-	 * @returns {EntryDependency[]} dependencies
-	 */
-	static createDependencies(entry, name) {
-		const entryArray = Array.isArray(entry) ? entry : [entry];
-		return entryArray.map(entry => EntryPlugin.createDependency(entry, name));
 	}
 }
 

--- a/lib/EntryOptionPlugin.js
+++ b/lib/EntryOptionPlugin.js
@@ -8,6 +8,7 @@
 const DynamicEntryPlugin = require("./DynamicEntryPlugin");
 const EntryPlugin = require("./EntryPlugin");
 
+/** @typedef {import("../declarations/WebpackOptions").EntryDescription} EntryDescription */
 /** @typedef {import("../declarations/WebpackOptions").EntryItem} EntryItem */
 /** @typedef {import("./Compiler")} Compiler */
 
@@ -19,7 +20,7 @@ module.exports = class EntryOptionPlugin {
 	apply(compiler) {
 		compiler.hooks.entryOption.tap("EntryOptionPlugin", (context, entry) => {
 			/**
-			 * @param {EntryItem} entry entry array or single path
+			 * @param {EntryItem|EntryDescription} entry entry array or single path
 			 * @param {string} name entry key name
 			 * @returns {void}
 			 */
@@ -30,6 +31,8 @@ module.exports = class EntryOptionPlugin {
 					for (const item of entry) {
 						applyEntryPlugins(item, name);
 					}
+				} else if (entry && typeof entry === "object") {
+					applyEntryPlugins(entry.import, name);
 				}
 			};
 

--- a/lib/EntryOptionPlugin.js
+++ b/lib/EntryOptionPlugin.js
@@ -5,47 +5,76 @@
 
 "use strict";
 
-const DynamicEntryPlugin = require("./DynamicEntryPlugin");
-const EntryPlugin = require("./EntryPlugin");
-
+/** @typedef {import("../declarations/WebpackOptions").Entry} Entry */
 /** @typedef {import("../declarations/WebpackOptions").EntryDescription} EntryDescription */
 /** @typedef {import("../declarations/WebpackOptions").EntryItem} EntryItem */
+/** @typedef {import("../declarations/WebpackOptions").EntryStatic} EntryStatic */
+/** @typedef {import("./Compilation").EntryOptions} EntryOptions */
 /** @typedef {import("./Compiler")} Compiler */
 
-module.exports = class EntryOptionPlugin {
+class EntryOptionPlugin {
 	/**
 	 * @param {Compiler} compiler the compiler instance one is tapping into
 	 * @returns {void}
 	 */
 	apply(compiler) {
 		compiler.hooks.entryOption.tap("EntryOptionPlugin", (context, entry) => {
-			/**
-			 * @param {EntryItem|EntryDescription} entry entry array or single path
-			 * @param {string} name entry key name
-			 * @returns {void}
-			 */
-			const applyEntryPlugins = (entry, name) => {
-				if (typeof entry === "string") {
-					new EntryPlugin(context, entry, name).apply(compiler);
-				} else if (Array.isArray(entry)) {
-					for (const item of entry) {
-						applyEntryPlugins(item, name);
-					}
-				} else if (entry && typeof entry === "object") {
-					applyEntryPlugins(entry.import, name);
-				}
-			};
-
-			if (typeof entry === "string" || Array.isArray(entry)) {
-				applyEntryPlugins(entry, "main");
-			} else if (typeof entry === "object") {
-				for (const name of Object.keys(entry)) {
-					applyEntryPlugins(entry[name], name);
-				}
-			} else if (typeof entry === "function") {
+			if (typeof entry === "function") {
+				const DynamicEntryPlugin = require("./DynamicEntryPlugin");
 				new DynamicEntryPlugin(context, entry).apply(compiler);
+			} else {
+				const EntryPlugin = require("./EntryPlugin");
+				EntryOptionPlugin.processEntryStatic(entry, (entry, options) => {
+					new EntryPlugin(context, entry, options).apply(compiler);
+				});
 			}
 			return true;
 		});
 	}
-};
+
+	/**
+	 * @param {EntryStatic} entry entry array or single path
+	 * @param {function(string, EntryOptions): void} onEntry callback for each entry
+	 * @returns {void}
+	 */
+	static processEntryStatic(entry, onEntry) {
+		/**
+		 * @param {EntryItem} entry entry array or single path
+		 * @param {EntryOptions} options entry options
+		 * @returns {void}
+		 */
+		const applyEntryItemPlugins = (entry, options) => {
+			if (typeof entry === "string") {
+				onEntry(entry, options);
+			} else if (Array.isArray(entry)) {
+				for (const item of entry) {
+					applyEntryItemPlugins(item, options);
+				}
+			}
+		};
+
+		/**
+		 * @param {EntryDescription} entry entry array or single path
+		 * @param {EntryOptions} options entry options
+		 * @returns {void}
+		 */
+		const applyEntryDescriptionPlugins = (entry, options) => {
+			applyEntryItemPlugins(entry.import, options);
+		};
+
+		if (typeof entry === "string" || Array.isArray(entry)) {
+			applyEntryItemPlugins(entry, { name: "main" });
+		} else if (entry && typeof entry === "object") {
+			for (const name of Object.keys(entry)) {
+				const value = entry[name];
+				if (typeof value === "string" || Array.isArray(value)) {
+					applyEntryItemPlugins(value, { name });
+				} else {
+					applyEntryDescriptionPlugins(value, { name });
+				}
+			}
+		}
+	}
+}
+
+module.exports = EntryOptionPlugin;

--- a/lib/EntryPlugin.js
+++ b/lib/EntryPlugin.js
@@ -7,6 +7,7 @@
 
 const EntryDependency = require("./dependencies/EntryDependency");
 
+/** @typedef {import("./Compilation").EntryOptions} EntryOptions */
 /** @typedef {import("./Compiler")} Compiler */
 
 class EntryPlugin {
@@ -16,12 +17,12 @@ class EntryPlugin {
 	 *
 	 * @param {string} context context path
 	 * @param {string} entry entry path
-	 * @param {string} name entry key name
+	 * @param {EntryOptions | string} options entry options (passing a string is deprecated)
 	 */
-	constructor(context, entry, name) {
+	constructor(context, entry, options) {
 		this.context = context;
 		this.entry = entry;
-		this.name = name;
+		this.options = options;
 	}
 
 	/**
@@ -40,10 +41,10 @@ class EntryPlugin {
 		);
 
 		compiler.hooks.make.tapAsync("EntryPlugin", (compilation, callback) => {
-			const { entry, name, context } = this;
+			const { entry, options, context } = this;
 
-			const dep = EntryPlugin.createDependency(entry, name);
-			compilation.addEntry(context, dep, name, err => {
+			const dep = EntryPlugin.createDependency(entry, options);
+			compilation.addEntry(context, dep, options, err => {
 				callback(err);
 			});
 		});
@@ -51,12 +52,13 @@ class EntryPlugin {
 
 	/**
 	 * @param {string} entry entry request
-	 * @param {string} name entry name
+	 * @param {EntryOptions | string} options entry options (passing string is deprecated)
 	 * @returns {EntryDependency} the dependency
 	 */
-	static createDependency(entry, name) {
+	static createDependency(entry, options) {
 		const dep = new EntryDependency(entry);
-		dep.loc = { name };
+		// TODO webpack 6 remove string option
+		dep.loc = { name: typeof options === "object" ? options.name : options };
 		return dep;
 	}
 }

--- a/lib/ExportPropertyTemplatePlugin.js
+++ b/lib/ExportPropertyTemplatePlugin.js
@@ -39,7 +39,7 @@ class ExportPropertyTemplatePlugin {
 			compilation => {
 				const moduleGraph = compilation.moduleGraph;
 				compilation.hooks.seal.tap("ExportPropertyTemplatePlugin", () => {
-					for (const deps of compilation.entryDependencies.values()) {
+					for (const { dependencies: deps } of compilation.entries.values()) {
 						const dep = deps[deps.length - 1];
 						if (dep) {
 							const module = moduleGraph.getModule(dep);

--- a/lib/FlagDependencyUsagePlugin.js
+++ b/lib/FlagDependencyUsagePlugin.js
@@ -146,7 +146,7 @@ class FlagDependencyUsagePlugin {
 					/** @type {Queue<DependenciesBlock>} */
 					const queue = new Queue();
 
-					for (const deps of compilation.entryDependencies.values()) {
+					for (const { dependencies: deps } of compilation.entries.values()) {
 						for (const dep of deps) {
 							const module = moduleGraph.getModule(dep);
 							if (module) {

--- a/lib/FlagEntryExportAsUsedPlugin.js
+++ b/lib/FlagEntryExportAsUsedPlugin.js
@@ -23,7 +23,7 @@ class FlagEntryExportAsUsedPlugin {
 			compilation => {
 				const moduleGraph = compilation.moduleGraph;
 				compilation.hooks.seal.tap("FlagEntryExportAsUsedPlugin", () => {
-					for (const deps of compilation.entryDependencies.values()) {
+					for (const { dependencies: deps } of compilation.entries.values()) {
 						for (const dep of deps) {
 							const module = moduleGraph.getModule(dep);
 							if (module) {

--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -252,7 +252,7 @@ class ProgressPlugin {
 			}
 		};
 
-		const entryAdd = (entry, name) => {
+		const entryAdd = (entry, options) => {
 			entriesCount++;
 			if (entriesCount % 10 === 0) updateThrottled();
 		};
@@ -276,7 +276,7 @@ class ProgressPlugin {
 			if (doneModules % 100 === 0) updateThrottled();
 		};
 
-		const entryDone = (entry, name) => {
+		const entryDone = (entry, options) => {
 			doneEntries++;
 			update();
 		};

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -38,6 +38,22 @@
         }
       ]
     },
+    "EntryDescription": {
+      "description": "An object with entry point description.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "import": {
+          "description": "Entrypoint modules.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/EntryItem"
+            }
+          ]
+        }
+      },
+      "required": ["import"]
+    },
     "EntryDynamic": {
       "description": "A Function returning an entry object, an entry string, an entry array or a promise to these things.",
       "instanceof": "Function",
@@ -76,6 +92,14 @@
             "anyOf": [
               {
                 "$ref": "#/definitions/NonEmptyArrayOfUniqueStringValues"
+              }
+            ]
+          },
+          {
+            "description": "An object with entry point description.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/EntryDescription"
               }
             ]
           }

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -44,7 +44,7 @@
       "additionalProperties": false,
       "properties": {
         "import": {
-          "description": "Entrypoint modules.",
+          "description": "The module(s) loaded at startup.",
           "oneOf": [
             {
               "$ref": "#/definitions/EntryItem"
@@ -62,12 +62,12 @@
     "EntryItem": {
       "oneOf": [
         {
-          "description": "An entry point without name. The string is resolved to a module which is loaded upon startup.",
+          "description": "The string is resolved to a module which is loaded upon startup.",
           "type": "string",
           "minLength": 1
         },
         {
-          "description": "An entry point without name. All modules are loaded upon startup. The last one is exported.",
+          "description": "All modules are loaded upon startup. The last one is exported.",
           "anyOf": [
             {
               "$ref": "#/definitions/NonEmptyArrayOfUniqueStringValues"
@@ -83,15 +83,10 @@
         "description": "An entry point with name",
         "oneOf": [
           {
-            "description": "The string is resolved to a module which is loaded upon startup.",
-            "type": "string",
-            "minLength": 1
-          },
-          {
-            "description": "All modules are loaded upon startup. The last one is exported.",
+            "description": "The module(s) loaded at startup.",
             "anyOf": [
               {
-                "$ref": "#/definitions/NonEmptyArrayOfUniqueStringValues"
+                "$ref": "#/definitions/EntryItem"
               }
             ]
           },
@@ -112,6 +107,14 @@
         {
           "$ref": "#/definitions/EntryObject"
         },
+        {
+          "$ref": "#/definitions/EntryUnnamed"
+        }
+      ]
+    },
+    "EntryUnnamed": {
+      "description": "An entry point without name.",
+      "anyOf": [
         {
           "$ref": "#/definitions/EntryItem"
         }

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -45,7 +45,7 @@ describe("Validation", () => {
 			expect(msg).toMatchInlineSnapshot(`
 			"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 			 - configuration.entry should be an non-empty string.
-			   -> An entry point without name. The string is resolved to a module which is loaded upon startup."
+			   -> The string is resolved to a module which is loaded upon startup."
 		`)
 	);
 

--- a/test/configCases/entry/descriptor/a.js
+++ b/test/configCases/entry/descriptor/a.js
@@ -1,0 +1,3 @@
+it("should compile", (done) => {
+	done()
+});

--- a/test/configCases/entry/descriptor/b.js
+++ b/test/configCases/entry/descriptor/b.js
@@ -1,0 +1,3 @@
+it("should compile", (done) => {
+	done()
+});

--- a/test/configCases/entry/descriptor/test.config.js
+++ b/test/configCases/entry/descriptor/test.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	findBundle: function() {
+		return [
+			"./a.js",
+			"./b.js"
+		]
+	}
+};

--- a/test/configCases/entry/descriptor/webpack.config.js
+++ b/test/configCases/entry/descriptor/webpack.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	entry() {
+		return {
+			a: { import: "./a" },
+			b: { import: ["./b"] }
+		};
+	},
+	output: {
+		filename: "[name].js"
+	}
+};


### PR DESCRIPTION
some preparations to other cool features

**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

yes

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**
`entry` configuration option.

When using an object for the `entry` configuration options advanced options can be provided with the following syntax:

``` js
entry: {
  main: {
    import: ["./entry1", "./entry2"], // or import: "./single-entry"
    // advanced configuration here
  }
}
```

Currently no advanced configuration is available. This will be added in later PRs.