### PR TITLE
make compiler/compilation.cache read-only

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -505,6 +505,11 @@ class Compilation {
 		this.requestShortener = compiler.requestShortener;
 		this.compilerPath = compiler.compilerPath;
 		this.cache = compiler.cache;
+		// Make this.cache readonly, to make it easier to find incompatible plugins
+		Object.defineProperty(this, "cache", {
+			writable: false,
+			value: this.cache
+		});
 
 		this.logger = this.getLogger("webpack.Compilation");
 

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -212,6 +212,11 @@ class Compiler {
 		this.requestShortener = new RequestShortener(context, this.root);
 
 		this.cache = new Cache();
+		// Make this.cache readonly, to make it easier to find incompatible plugins
+		Object.defineProperty(this, "cache", {
+			writable: false,
+			value: this.cache
+		});
 
 		this.compilerPath = "";
 


### PR DESCRIPTION
to make it easier to find incompatible plugins

fixes #10341

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
compatibility
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
