### PR TITLE
Exit with an error if we can't prompt for webpack-cli installation.

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -87,15 +87,10 @@ if (!cli.installed) {
 		output: process.stderr
 	});
 
-	// If we're not in terminal mode, readline won't execute the callback function below. Return here
-	// so that we can set the exit code properly.
-	if (!questionInterface.terminal) {
-		console.error(
-			"You need to install 'webpack-cli' to use webpack via CLI.\n" +
-				"You can also install the CLI manually."
-		);
-		process.exit(1);
-	}
+	// In certain scenarios (e.g. when STDIN is not in terminal mode), the callback function will not be
+	// executed. Setting the exit code here to ensure the script exits correctly in those cases. The callback
+	// function is responsible for clearing the exit code if the user wishes to install webpack-cli.
+	process.exitCode = 1;
 	questionInterface.question(question, answer => {
 		questionInterface.close();
 
@@ -106,10 +101,10 @@ if (!cli.installed) {
 				"You need to install 'webpack-cli' to use webpack via CLI.\n" +
 					"You can also install the CLI manually."
 			);
-			process.exitCode = 1;
 
 			return;
 		}
+		process.exitCode = 0;
 
 		console.log(
 			`Installing '${

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -86,6 +86,16 @@ if (!cli.installed) {
 		input: process.stdin,
 		output: process.stderr
 	});
+
+	// If we're not in terminal mode, readline won't execute the callback function below.  Return here
+	// so that we can set the exit code properly.
+	if (!questionInterface.terminal) {
+		console.error(
+			"You need to install 'webpack-cli' to use webpack via CLI.\n" +
+				"You can also install the CLI manually."
+		);
+		process.exit(1);
+	}
 	questionInterface.question(question, answer => {
 		questionInterface.close();
 

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -87,7 +87,7 @@ if (!cli.installed) {
 		output: process.stderr
 	});
 
-	// If we're not in terminal mode, readline won't execute the callback function below.  Return here
+	// If we're not in terminal mode, readline won't execute the callback function below. Return here
 	// so that we can set the exit code properly.
 	if (!questionInterface.terminal) {
 		console.error(


### PR DESCRIPTION
If STDIN is not in terminal mode when the webpack script is executed, the readline module will never execute the callback passed to question and the script will exit successfully, without ever building the pack.  An example of this is Rails' webpacker gem, which executes the webpack script in a subshell: https://github.com/rails/webpacker/blob/0b550a0ed66f2c01baa5f05f1126abada47a6c6f/lib/webpacker/compiler.rb#L67-L71

**What kind of change does this PR introduce?**

Bugfix.  If STDIN is not in terminal mode, we should exit with an error immediately, instead of attempting to ask a question to which we'll never receive an answer.

**Did you add tests for your changes?**

I did not see any existing tests for the `webpack.js` script, but will happily write some if there's an example of how they should work.

**Does this PR introduce a breaking change?**

I suppose it is possible that someone is relying on running `webpack` not in terminal mode not breaking if the pack isn't built, but it's hard to think of a scenario where that would happen.

**What needs to be documented once your changes are merged?**

I don't think this needs to be documented anywhere.