### PR TITLE
Add async-webworker target

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -429,6 +429,7 @@ export interface WebpackOptions {
 		| (
 				| "web"
 				| "webworker"
+				| "async-webworker"
 				| "node"
 				| "async-node"
 				| "node-webkit"

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -81,13 +81,16 @@ class WebpackOptionsApply extends OptionsApply {
 					new ChunkPrefetchPreloadPlugin().apply(compiler);
 					break;
 				}
-				case "webworker": {
+				case "webworker":
+				case "async-webworker": {
 					const WebWorkerTemplatePlugin = require("./webworker/WebWorkerTemplatePlugin");
 					const FetchCompileWasmPlugin = require("./web/FetchCompileWasmPlugin");
 					const FetchCompileAsyncWasmPlugin = require("./web/FetchCompileAsyncWasmPlugin");
 					const NodeSourcePlugin = require("./node/NodeSourcePlugin");
 					const StartupChunkDependenciesPlugin = require("./runtime/StartupChunkDependenciesPlugin");
-					new WebWorkerTemplatePlugin().apply(compiler);
+					new WebWorkerTemplatePlugin({
+						asyncChunkLoading: options.target === "async-webworker"
+					}).apply(compiler);
 					new FetchCompileWasmPlugin({
 						mangleImports: options.optimization.mangleWasmImports
 					}).apply(compiler);

--- a/lib/webworker/WebWorkerChunkLoadingRuntimeModule.js
+++ b/lib/webworker/WebWorkerChunkLoadingRuntimeModule.js
@@ -8,10 +8,12 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
 
-class ImportScriptsChunkLoadingRuntimeModule extends RuntimeModule {
-	constructor(runtimeRequirements) {
-		super("importScripts chunk loading", 10);
+class WebWorkerChunkLoadingRuntimeModule extends RuntimeModule {
+	constructor(runtimeRequirements, options) {
+		super("webworker chunk loading", 10);
+		options = options || {};
 		this.runtimeRequirements = runtimeRequirements;
+		this.asyncChunkLoading = options.asyncChunkLoading;
 	}
 
 	/**
@@ -37,46 +39,114 @@ class ImportScriptsChunkLoadingRuntimeModule extends RuntimeModule {
 		return Template.asString([
 			"// object to store loaded chunks",
 			'// "1" means "already loaded"',
+			...(this.asyncChunkLoading ? ["// Promise meaning loading started"] : []),
 			"var installedChunks = {",
 			Template.indent(
 				chunk.ids.map(id => `${JSON.stringify(id)}: 1`).join(",\n")
 			),
 			"};",
+			...(this.asyncChunkLoading
+				? [
+						"",
+						"// object to store chunk callbacks",
+						`${globalObject}[${JSON.stringify(
+							chunkCallbackName
+						)}] = ${globalObject}[${JSON.stringify(chunkCallbackName)}] || {};`
+				  ]
+				: []),
 			"",
 			withLoading
 				? Template.asString([
-						"// importScripts chunk loading",
+						`// ${
+							this.asyncChunkLoading ? "fetch" : "importScripts"
+						} chunk loading`,
 						`${fn}.i = function(chunkId, promises) {`,
-						Template.indent([
-							'// "1" is the signal for "already loaded"',
-							"if(!installedChunks[chunkId]) {",
-							Template.indent([
-								`${globalObject}[${JSON.stringify(
-									chunkCallbackName
-								)}] = function webpackChunkCallback(chunkIds, moreModules, runtime) {`,
-								Template.indent([
-									"for(var moduleId in moreModules) {",
-									Template.indent([
-										`if(${RuntimeGlobals.hasOwnProperty}(moreModules, moduleId)) {`,
-										Template.indent(
-											`${RuntimeGlobals.moduleFactories}[moduleId] = moreModules[moduleId];`
-										),
+						Template.indent(
+							this.asyncChunkLoading
+								? [
+										'// "1" is the signal for "already loaded"',
+										"if(installedChunks[chunkId] === 1) return;",
+										'// "Promise" is the signal for "already loading"',
+										"if(installedChunks[chunkId] instanceof Promise) promises.push(installedChunks[chunkId]);",
+										"if(!installedChunks[chunkId]) {",
+										Template.indent([
+											"promises.push(installedChunks[chunkId] = new Promise(function(resolve, reject) {",
+											Template.indent([
+												`${globalObject}[${JSON.stringify(
+													chunkCallbackName
+												)}][chunkId] = function webpackChunkCallback(chunkIds, moreModules, runtime) {`,
+												Template.indent([
+													"for(var moduleId in moreModules) {",
+													Template.indent([
+														`if(${RuntimeGlobals.hasOwnProperty}(moreModules, moduleId)) {`,
+														Template.indent(
+															`${RuntimeGlobals.moduleFactories}[moduleId] = moreModules[moduleId];`
+														),
+														"}"
+													]),
+													"}",
+													"if(runtime) runtime(__webpack_require__);",
+													"while(chunkIds.length)",
+													Template.indent(
+														"installedChunks[chunkIds.pop()] = 1;"
+													),
+													"",
+													`delete ${globalObject}[${JSON.stringify(
+														chunkCallbackName
+													)}][chunkId];`,
+													"resolve();"
+												]),
+												"};",
+												`fetch(${RuntimeGlobals.getChunkScriptFilename}(chunkId))`,
+												Template.indent([
+													".then(function(resp) {",
+													Template.indent("return resp.text();"),
+													"})",
+													".then(function(moduleContent) {",
+													Template.indent("Function(moduleContent)();"),
+													"})",
+													".catch(reject);"
+												]),
+												"",
+												withHmr
+													? "if(currentUpdateChunks && currentUpdateChunks[chunkId]) loadUpdateChunk(chunkId);"
+													: "// no HMR"
+											]),
+											"}));"
+										]),
 										"}"
-									]),
-									"}",
-									"if(runtime) runtime(__webpack_require__);",
-									"while(chunkIds.length)",
-									Template.indent("installedChunks[chunkIds.pop()] = 1;")
-								]),
-								"};",
-								`importScripts(${RuntimeGlobals.getChunkScriptFilename}(chunkId));`,
-								"",
-								withHmr
-									? "if(currentUpdateChunks && currentUpdateChunks[chunkId]) loadUpdateChunk(chunkId);"
-									: "// no HMR"
-							]),
-							"}"
-						]),
+								  ]
+								: [
+										'// "1" is the signal for "already loaded"',
+										"if(!installedChunks[chunkId]) {",
+										Template.indent([
+											`${globalObject}[${JSON.stringify(
+												chunkCallbackName
+											)}] = function webpackChunkCallback(chunkIds, moreModules, runtime) {`,
+											Template.indent([
+												"for(var moduleId in moreModules) {",
+												Template.indent([
+													`if(${RuntimeGlobals.hasOwnProperty}(moreModules, moduleId)) {`,
+													Template.indent(
+														`${RuntimeGlobals.moduleFactories}[moduleId] = moreModules[moduleId];`
+													),
+													"}"
+												]),
+												"}",
+												"if(runtime) runtime(__webpack_require__);",
+												"while(chunkIds.length)",
+												Template.indent("installedChunks[chunkIds.pop()] = 1;")
+											]),
+											"};",
+											`importScripts(${RuntimeGlobals.getChunkScriptFilename}(chunkId));`,
+											"",
+											withHmr
+												? "if(currentUpdateChunks && currentUpdateChunks[chunkId]) loadUpdateChunk(chunkId);"
+												: "// no HMR"
+										]),
+										"}"
+								  ]
+						),
 						"};"
 				  ])
 				: "// no chunk loading",
@@ -176,4 +246,4 @@ class ImportScriptsChunkLoadingRuntimeModule extends RuntimeModule {
 	}
 }
 
-module.exports = ImportScriptsChunkLoadingRuntimeModule;
+module.exports = WebWorkerChunkLoadingRuntimeModule;

--- a/lib/webworker/WebWorkerTemplatePlugin.js
+++ b/lib/webworker/WebWorkerTemplatePlugin.js
@@ -10,11 +10,16 @@ const HotUpdateChunk = require("../HotUpdateChunk");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
 const JavascriptModulesPlugin = require("../javascript/JavascriptModulesPlugin");
-const ImportScriptsChunkLoadingRuntimeModule = require("./ImportScriptsChunkLoadingRuntimeModule");
+const WebWorkerChunkLoadingRuntimeModule = require("./WebWorkerChunkLoadingRuntimeModule");
 
 /** @typedef {import("../Compiler")} Compiler */
 
 class WebWorkerTemplatePlugin {
+	constructor(options) {
+		options = options || {};
+		this.asyncChunkLoading = options.asyncChunkLoading;
+	}
+
 	/**
 	 * @param {Compiler} compiler the compiler instance
 	 * @returns {void}
@@ -52,7 +57,9 @@ class WebWorkerTemplatePlugin {
 							const chunkCallbackName =
 								runtimeTemplate.outputOptions.chunkCallbackName;
 							source.add(
-								`${globalObject}[${JSON.stringify(chunkCallbackName)}](`
+								`${globalObject}[${JSON.stringify(chunkCallbackName)}]${
+									this.asyncChunkLoading ? `["${chunk.id}"]` : ""
+								}(`
 							);
 							source.add(`${JSON.stringify(chunk.ids)},`);
 							source.add(modules);
@@ -85,7 +92,9 @@ class WebWorkerTemplatePlugin {
 					set.add(RuntimeGlobals.hasOwnProperty);
 					compilation.addRuntimeModule(
 						chunk,
-						new ImportScriptsChunkLoadingRuntimeModule(set)
+						new WebWorkerChunkLoadingRuntimeModule(set, {
+							asyncChunkLoading: this.asyncChunkLoading
+						})
 					);
 				};
 				compilation.hooks.runtimeRequirementInTree

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2632,6 +2632,7 @@
           "enum": [
             "web",
             "webworker",
+            "async-webworker",
             "node",
             "async-node",
             "node-webkit",


### PR DESCRIPTION
As asked at #10320 and following the discussion in #6472, this PR introduces a new target called `async-webworker` for webpack 5.
Dynamic import statements in web workers are transpiled by default into importScripts statements. Those statements are synchronous and yield bad performance. The aforementioned target transpiles dynamic imports into fetch followed by dynamic code evaluation. Using this technique the chunks can be downloaded asynchronously.

Additional changes that has been made to support this feature:
* `self["webpackChunk"]` was changed to an object that maps chunk IDs to their corrosponding execution completion callback
* `installedChunks` stores chunk loading state: 
  * `1` for loaded chunks
  * `Promise` for a chunk that is already loading (can be reused for different requests)
* Chunks invoke `self["webpackChunk"][chunk.id]` instead of `self["webpackChunk"]`

Not yet implemented:
* Timeout handling - what should happen if fetch takes more than X seconds
* Verifying fetch return code to assert success
* Make sure redirect return codes (3XX) works as expected

What kind of change does this PR introduce?
New feature

Did you add tests for your changes?
I will add tests once we agree on the implementation details

Does this PR introduce a breaking change?
No

What needs to be documented once your changes are merged?
Targets table

