### PR TITLE
fix: Rule with issuer is not applied when importing via require.context #9309 fix

### DIFF
--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -288,6 +288,17 @@ class ContextModule extends Module {
 	}
 
 	/**
+	 * @returns {string | null} absolute path which should be used for condition matching (usually the resource path)
+	 */
+	nameForCondition() {
+		return (
+			this.issuer &&
+			this.issuer.nameForCondition &&
+			this.issuer.nameForCondition()
+		);
+	}
+
+	/**
 	 * @returns {void}
 	 */
 	invalidateBuild() {


### PR DESCRIPTION
Currently ContextModule.nameForCondition returns null. Because ContextModule just inherits the default behavior of Module.nameForCondition. This leads to the situation that rules with defined `issuer` would not apply to such type of Module. 

To fix this problem I rewrite the behavior of nameForConditition for ContextModule and return a value of `issuers.nameForCondition`. But `issuer` is **deprecated** in Module so I would be glad if someone suggests a better way

#9309 fix