### PR TITLE
ProgressPlugin: save and restore total module count

### DIFF
--- a/lib/ProgressPlugin.js
+++ b/lib/ProgressPlugin.js
@@ -191,6 +191,7 @@ class ProgressPlugin {
 		let doneEntries = 0;
 		const activeModules = new Set();
 		let lastUpdate = 0;
+		const cacheName = `${compiler.compilerPath}/progress-plugin`;
 
 		const updateThrottled = () => {
 			if (lastUpdate + 500 < Date.now()) update();
@@ -298,6 +299,37 @@ class ProgressPlugin {
 			doneEntries++;
 			update();
 		};
+
+		compiler.hooks.beforeCompile.tapAsync(
+			"ProgressPlugin",
+			(params, callback) => {
+				compiler.cache.get(cacheName, null, (err, data) => {
+					if (err) {
+						return callback(err);
+					}
+
+					if (data) {
+						lastModulesCount = lastModulesCount || data.modulesCount;
+						lastDependenciesCount =
+							lastDependenciesCount || data.dependenciesCount;
+					}
+
+					callback();
+				});
+			}
+		);
+
+		compiler.hooks.afterCompile.tapAsync(
+			"ProgressPlugin",
+			(compilation, callback) => {
+				compiler.cache.store(
+					cacheName,
+					null,
+					{ modulesCount, dependenciesCount },
+					callback
+				);
+			}
+		);
 
 		compiler.hooks.compilation.tap("ProgressPlugin", compilation => {
 			if (compilation.compiler.isChild()) return;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**
ProgressPlugin uses the persistent cache to save last modules and dependencies count to make progress calculation more accurate.