### PR TITLE
add OverridablesPlugin

### DIFF
--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -73,6 +73,12 @@ const REPLACEMENTS = {
 		type: "function",
 		assign: true
 	},
+	__webpack_override__: {
+		expr: `Object.assign.bind(Object, ${RuntimeGlobals.overrides})`,
+		req: [RuntimeGlobals.overrides],
+		type: "function",
+		assign: false
+	},
 	"require.onError": {
 		expr: RuntimeGlobals.uncaughtErrorHandler,
 		req: [RuntimeGlobals.uncaughtErrorHandler],

--- a/lib/ChunkGroup.js
+++ b/lib/ChunkGroup.js
@@ -29,7 +29,7 @@ const {
  * @property {number=} prefetchOrder
  */
 
-/** @typedef {RawChunkGroupOptions & { name: string }} ChunkGroupOptions */
+/** @typedef {RawChunkGroupOptions & { name?: string }} ChunkGroupOptions */
 
 let debugId = 5000;
 

--- a/lib/RuntimeGlobals.js
+++ b/lib/RuntimeGlobals.js
@@ -196,6 +196,11 @@ exports.interceptModuleExecution = "__webpack_require__.i";
 exports.global = "__webpack_require__.g";
 
 /**
+ * the overrides mapping
+ */
+exports.overrides = "__webpack_require__.O";
+
+/**
  * the filename of the HMR manifest
  */
 exports.getUpdateManifestFilename = "__webpack_require__.hmrF";

--- a/lib/container/OverridableModule.js
+++ b/lib/container/OverridableModule.js
@@ -1,0 +1,166 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const { RawSource } = require("webpack-sources");
+const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
+const Module = require("../Module");
+const RuntimeGlobals = require("../RuntimeGlobals");
+const Template = require("../Template");
+const makeSerializable = require("../util/makeSerializable");
+const OverridableOriginalDependency = require("./OverridableOriginalDependency");
+
+/** @typedef {import("../../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
+/** @typedef {import("../ChunkGraph")} ChunkGraph */
+/** @typedef {import("../ChunkGroup")} ChunkGroup */
+/** @typedef {import("../Compilation")} Compilation */
+/** @typedef {import("../Module").CodeGenerationContext} CodeGenerationContext */
+/** @typedef {import("../Module").CodeGenerationResult} CodeGenerationResult */
+/** @typedef {import("../RequestShortener")} RequestShortener */
+/** @typedef {import("../ResolverFactory").ResolverWithOptions} ResolverWithOptions */
+/** @typedef {import("../WebpackError")} WebpackError */
+/** @typedef {import("../util/Hash")} Hash */
+/** @typedef {import("../util/fs").InputFileSystem} InputFileSystem */
+
+const TYPES = new Set(["overridable"]);
+
+class OverridableModule extends Module {
+	/**
+	 * @param {Module} originalModule original module
+	 * @param {string} name global overridable name
+	 */
+	constructor(originalModule, name) {
+		super("overridable-module", originalModule.context);
+		this.originalModule = originalModule;
+		this.name = name;
+	}
+
+	/**
+	 * @returns {string} a unique identifier of the module
+	 */
+	identifier() {
+		return `overridable|${this.name}|${this.originalModule.identifier()}`;
+	}
+
+	/**
+	 * @param {RequestShortener} requestShortener the request shortener
+	 * @returns {string} a user readable identifier of the module
+	 */
+	readableIdentifier(requestShortener) {
+		return `overridable ${
+			this.name
+		} -> ${this.originalModule.readableIdentifier(requestShortener)}`;
+	}
+
+	/**
+	 * @param {WebpackOptions} options webpack options
+	 * @param {Compilation} compilation the compilation
+	 * @param {ResolverWithOptions} resolver the resolver
+	 * @param {InputFileSystem} fs the file system
+	 * @param {function(WebpackError=): void} callback callback function
+	 * @returns {void}
+	 */
+	build(options, compilation, resolver, fs, callback) {
+		this.buildMeta = {};
+		this.buildInfo = {};
+		const block = new AsyncDependenciesBlock({});
+		const dep = new OverridableOriginalDependency(this.originalModule);
+		block.addDependency(dep);
+		this.addBlock(block);
+		callback();
+	}
+
+	/**
+	 * @returns {Set<string>} types availiable (do not mutate)
+	 */
+	getSourceTypes() {
+		return TYPES;
+	}
+
+	/**
+	 * @param {string=} type the source type for which the size should be estimated
+	 * @returns {number} the estimated size of the module (must be non-zero)
+	 */
+	size(type) {
+		return 42;
+	}
+
+	/**
+	 * Assuming this module is in the cache. Update the (cached) module with
+	 * the fresh module from the factory. Usually updates internal references
+	 * and properties.
+	 * @param {Module} module fresh module
+	 * @returns {void}
+	 */
+	updateCacheModule(module) {
+		super.updateCacheModule(module);
+		this.originalModule =
+			/** @type {OverridableModule} */ (module).originalModule;
+	}
+
+	/**
+	 * @param {Hash} hash the hash used to track dependencies
+	 * @param {ChunkGraph} chunkGraph the chunk graph
+	 * @returns {void}
+	 */
+	updateHash(hash, chunkGraph) {
+		hash.update(this.name);
+		super.updateHash(hash, chunkGraph);
+	}
+
+	/**
+	 * @param {CodeGenerationContext} context context for code generation
+	 * @returns {CodeGenerationResult} result
+	 */
+	codeGeneration({ chunkGraph, moduleGraph, runtimeTemplate }) {
+		const runtimeRequirements = new Set([RuntimeGlobals.overrides]);
+		const originalBlock = this.blocks[0];
+		const originalDep = originalBlock.dependencies[0];
+		const originalModule = moduleGraph.getModule(originalDep);
+		const ensureChunk = runtimeTemplate.blockPromise({
+			block: originalBlock,
+			message: "",
+			chunkGraph,
+			runtimeRequirements
+		});
+		const sources = new Map();
+		sources.set(
+			"overridable",
+			new RawSource(
+				Template.asString([
+					`return ${ensureChunk}.then(${runtimeTemplate.returningFunction(
+						runtimeTemplate.returningFunction(
+							runtimeTemplate.moduleRaw({
+								module: originalModule,
+								chunkGraph,
+								request: "",
+								runtimeRequirements
+							})
+						)
+					)})`
+				])
+			)
+		);
+		return {
+			runtimeRequirements,
+			sources
+		};
+	}
+
+	serialize(context) {
+		context.write(this.name);
+		super.serialize(context);
+	}
+
+	deserialize(context) {
+		this.name = context.read();
+		super.deserialize(context);
+	}
+}
+
+makeSerializable(OverridableModule, "webpack/lib/container/OverridableModule");
+
+module.exports = OverridableModule;

--- a/lib/container/OverridableOriginalDependency.js
+++ b/lib/container/OverridableOriginalDependency.js
@@ -1,0 +1,44 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const Dependency = require("../Dependency");
+const makeSerializable = require("../util/makeSerializable");
+
+class OverridableOriginalDependency extends Dependency {
+	constructor(originalModule) {
+		super();
+		this.originalModule = originalModule;
+	}
+
+	/**
+	 * @returns {string | null} an identifier to merge equal requests
+	 */
+	getResourceIdentifier() {
+		return this.originalModule.identifier();
+	}
+
+	get type() {
+		return "overridable original";
+	}
+
+	serialize(context) {
+		context.write(this.originalModule);
+		super.serialize(context);
+	}
+
+	deserialize(context) {
+		this.originalModule = context.read();
+		super.deserialize(context);
+	}
+}
+
+makeSerializable(
+	OverridableOriginalDependency,
+	"webpack/lib/container/OverridableOriginalDependency"
+);
+
+module.exports = OverridableOriginalDependency;

--- a/lib/container/OverridableOriginalModuleFactory.js
+++ b/lib/container/OverridableOriginalModuleFactory.js
@@ -1,0 +1,29 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const ModuleFactory = require("../ModuleFactory");
+
+/** @typedef {import("../ModuleFactory").ModuleFactoryCreateData} ModuleFactoryCreateData */
+/** @typedef {import("../ModuleFactory").ModuleFactoryResult} ModuleFactoryResult */
+/** @typedef {import("./OverridableOriginalDependency")} OverridableOriginalDependency */
+
+class OverridableOriginalModuleFactory extends ModuleFactory {
+	/**
+	 * @param {ModuleFactoryCreateData} data data object
+	 * @param {function(Error=, ModuleFactoryResult=): void} callback callback
+	 * @returns {void}
+	 */
+	create(data, callback) {
+		const dep =
+			/** @type {OverridableOriginalDependency} */ (data.dependencies[0]);
+		callback(null, {
+			module: dep.originalModule
+		});
+	}
+}
+
+module.exports = OverridableOriginalModuleFactory;

--- a/lib/container/OverridablesPlugin.js
+++ b/lib/container/OverridablesPlugin.js
@@ -1,0 +1,111 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const ModuleNotFoundError = require("../ModuleNotFoundError");
+const RuntimeGlobals = require("../RuntimeGlobals");
+const OverridableModule = require("./OverridableModule");
+const OverridableOriginalDependency = require("./OverridableOriginalDependency");
+const OverridableOriginalModuleFactory = require("./OverridableOriginalModuleFactory");
+const OverridablesRuntimeModule = require("./OverridablesRuntimeModule");
+
+/** @typedef {import("../Compiler")} Compiler */
+
+const parseOptions = (prefix, options, result) => {
+	if (Array.isArray(options)) {
+		for (const item of options) {
+			parseOptions(prefix, item, result);
+		}
+	} else if (typeof options === "string") {
+		result.push([prefix + options.replace(/^([^\w]+\/)+/, ""), options]);
+	} else if (options && typeof options === "object") {
+		for (const key of Object.keys(options)) {
+			const value = options[key];
+			if (typeof value === "string") {
+				result.push([prefix + key, value]);
+			} else {
+				parseOptions(prefix + key + "/", value, result);
+			}
+		}
+	}
+};
+
+class OverridablesPlugin {
+	constructor(options) {
+		this.overridables = [];
+		parseOptions("", options, this.overridables);
+	}
+	/**
+	 * @param {Compiler} compiler webpack compiler
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap(
+			"OverridablesPlugin",
+			(compilation, { normalModuleFactory }) => {
+				compilation.dependencyFactories.set(
+					OverridableOriginalDependency,
+					new OverridableOriginalModuleFactory()
+				);
+
+				const resolvedOverridables = new Map();
+				const promise = Promise.all(
+					this.overridables.map(([key, request]) => {
+						const resolver = compilation.resolverFactory.get("normal");
+						return new Promise((resolve, reject) => {
+							resolver.resolve(
+								{},
+								compiler.context,
+								request,
+								{},
+								(err, result) => {
+									if (err) {
+										compilation.errors.push(
+											new ModuleNotFoundError(null, err, {
+												name: `overridable ${key}`
+											})
+										);
+										return resolve();
+									}
+									resolvedOverridables.set(result, key);
+									resolve();
+								}
+							);
+						});
+					})
+				);
+				normalModuleFactory.hooks.afterResolve.tapAsync(
+					"OverridablesPlugin",
+					(resolveData, callback) => {
+						// wait for resolving to be complete
+						promise.then(() => callback());
+					}
+				);
+				normalModuleFactory.hooks.module.tap(
+					"OverridablesPlugin",
+					(module, createData) => {
+						const key = resolvedOverridables.get(createData.resource);
+						if (key !== undefined) return new OverridableModule(module, key);
+					}
+				);
+				compilation.hooks.additionalTreeRuntimeRequirements.tap(
+					"OverridablesPlugin",
+					(chunk, set) => {
+						set.add(RuntimeGlobals.module);
+						set.add(RuntimeGlobals.hasOwnProperty);
+						set.add(RuntimeGlobals.ensureChunkHandlers);
+						compilation.addRuntimeModule(
+							chunk,
+							new OverridablesRuntimeModule()
+						);
+					}
+				);
+			}
+		);
+	}
+}
+
+module.exports = OverridablesPlugin;

--- a/lib/container/OverridablesPlugin.js
+++ b/lib/container/OverridablesPlugin.js
@@ -11,32 +11,13 @@ const OverridableModule = require("./OverridableModule");
 const OverridableOriginalDependency = require("./OverridableOriginalDependency");
 const OverridableOriginalModuleFactory = require("./OverridableOriginalModuleFactory");
 const OverridablesRuntimeModule = require("./OverridablesRuntimeModule");
+const parseOptions = require("./parseOptions");
 
 /** @typedef {import("../Compiler")} Compiler */
 
-const parseOptions = (prefix, options, result) => {
-	if (Array.isArray(options)) {
-		for (const item of options) {
-			parseOptions(prefix, item, result);
-		}
-	} else if (typeof options === "string") {
-		result.push([prefix + options.replace(/^([^\w]+\/)+/, ""), options]);
-	} else if (options && typeof options === "object") {
-		for (const key of Object.keys(options)) {
-			const value = options[key];
-			if (typeof value === "string") {
-				result.push([prefix + key, value]);
-			} else {
-				parseOptions(prefix + key + "/", value, result);
-			}
-		}
-	}
-};
-
 class OverridablesPlugin {
 	constructor(options) {
-		this.overridables = [];
-		parseOptions("", options, this.overridables);
+		this.overridables = parseOptions(options);
 	}
 	/**
 	 * @param {Compiler} compiler webpack compiler
@@ -95,6 +76,7 @@ class OverridablesPlugin {
 					"OverridablesPlugin",
 					(chunk, set) => {
 						set.add(RuntimeGlobals.module);
+						set.add(RuntimeGlobals.moduleFactories);
 						set.add(RuntimeGlobals.hasOwnProperty);
 						set.add(RuntimeGlobals.ensureChunkHandlers);
 						compilation.addRuntimeModule(

--- a/lib/container/OverridablesRuntimeModule.js
+++ b/lib/container/OverridablesRuntimeModule.js
@@ -73,6 +73,7 @@ class OverridablesRuntimeModule extends RuntimeModule {
 				`if(${RuntimeGlobals.hasOwnProperty}(chunkMapping, chunkId)) {`,
 				Template.indent([
 					`chunkMapping[chunkId].forEach(${runtimeTemplate.basicFunction("id", [
+						"if(__webpack_modules__[id]) return;",
 						`promises.push(Promise.resolve((${
 							RuntimeGlobals.overrides
 						}[idToNameMapping[id]] || fallbackMapping[id])()).then(${runtimeTemplate.basicFunction(

--- a/lib/container/OverridablesRuntimeModule.js
+++ b/lib/container/OverridablesRuntimeModule.js
@@ -1,0 +1,95 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const RuntimeGlobals = require("../RuntimeGlobals");
+const RuntimeModule = require("../RuntimeModule");
+const Template = require("../Template");
+
+/** @typedef {import("./OverridableModule")} OverridableModule */
+
+class OverridablesRuntimeModule extends RuntimeModule {
+	constructor() {
+		super("overridables");
+	}
+
+	/**
+	 * @returns {string} runtime code
+	 */
+	generate() {
+		const {
+			runtimeTemplate,
+			chunkGraph,
+			codeGenerationResults
+		} = this.compilation;
+		const chunkToOverridableMapping = {};
+		const idToNameMapping = {};
+		const overridableToFallbackMapping = new Map();
+		for (const chunk of this.chunk.getAllAsyncChunks()) {
+			const modules = chunkGraph.getChunkModulesIterableBySourceType(
+				chunk,
+				"overridable"
+			);
+			if (!modules) continue;
+			const overridables = (chunkToOverridableMapping[chunk.id] = []);
+			for (const m of modules) {
+				const module = /** @type {OverridableModule} */ (m);
+				const name = module.name;
+				const id = chunkGraph.getModuleId(module);
+				overridables.push(id);
+				idToNameMapping[id] = name;
+				const source = codeGenerationResults
+					.get(module)
+					.sources.get("overridable");
+				overridableToFallbackMapping.set(id, source.source());
+			}
+		}
+		return Template.asString([
+			`${RuntimeGlobals.overrides} = {};`,
+			`var chunkMapping = ${JSON.stringify(
+				chunkToOverridableMapping,
+				null,
+				"\t"
+			)};`,
+			`var idToNameMapping = ${JSON.stringify(idToNameMapping, null, "\t")};`,
+			"var fallbackMapping = {",
+			Template.indent(
+				Array.from(
+					overridableToFallbackMapping,
+					([id, source]) =>
+						`${JSON.stringify(id)}: ${runtimeTemplate.basicFunction(
+							"",
+							source
+						)}`
+				).join(",\n")
+			),
+			"};",
+			`${
+				RuntimeGlobals.ensureChunkHandlers
+			}.overridables = ${runtimeTemplate.basicFunction("chunkId, promises", [
+				`if(${RuntimeGlobals.hasOwnProperty}(chunkMapping, chunkId)) {`,
+				Template.indent([
+					`chunkMapping[chunkId].forEach(${runtimeTemplate.basicFunction("id", [
+						`promises.push(Promise.resolve((${
+							RuntimeGlobals.overrides
+						}[idToNameMapping[id]] || fallbackMapping[id])()).then(${runtimeTemplate.basicFunction(
+							"factory",
+							[
+								`__webpack_modules__[id] = ${runtimeTemplate.basicFunction(
+									"module",
+									["module.exports = factory();"]
+								)}`
+							]
+						)}))`
+					])});`
+				]),
+				"}"
+			])}`
+		]);
+	}
+}
+
+module.exports = OverridablesRuntimeModule;

--- a/lib/container/parseOptions.js
+++ b/lib/container/parseOptions.js
@@ -1,0 +1,31 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const parseOptions = (prefix, options, result) => {
+	if (Array.isArray(options)) {
+		for (const item of options) {
+			parseOptions(prefix, item, result);
+		}
+	} else if (typeof options === "string") {
+		result.push([prefix + options.replace(/^([^\w]+\/)+/, ""), options]);
+	} else if (options && typeof options === "object") {
+		for (const key of Object.keys(options)) {
+			const value = options[key];
+			if (typeof value === "string") {
+				result.push([prefix + key, value]);
+			} else {
+				parseOptions(prefix + key + "/", value, result);
+			}
+		}
+	}
+};
+
+module.exports = options => {
+	const result = [];
+	parseOptions("", options, result);
+	return result;
+};

--- a/lib/util/internalSerializables.js
+++ b/lib/util/internalSerializables.js
@@ -17,6 +17,10 @@ module.exports = {
 	"cache/PackFileCacheStrategy": () =>
 		require("../cache/PackFileCacheStrategy"),
 	"cache/ResolverCachePlugin": () => require("../cache/ResolverCachePlugin"),
+	"container/OverridableModule": () =>
+		require("../container/OverridableModule"),
+	"container/OverridableOriginalDependency": () =>
+		require("../container/OverridableOriginalDependency"),
 	"dependencies/AMDDefineDependency": () =>
 		require("../dependencies/AMDDefineDependency"),
 	"dependencies/AMDRequireArrayDependency": () =>

--- a/test/configCases/container/overridables/cjs/test1.js
+++ b/test/configCases/container/overridables/cjs/test1.js
@@ -1,0 +1,1 @@
+module.exports = "original1-cjs";

--- a/test/configCases/container/overridables/cjs/test2.js
+++ b/test/configCases/container/overridables/cjs/test2.js
@@ -1,0 +1,1 @@
+module.exports = "original2-cjs";

--- a/test/configCases/container/overridables/index.js
+++ b/test/configCases/container/overridables/index.js
@@ -1,0 +1,76 @@
+__webpack_override__({
+	test1: () =>
+		new Promise(resolve => {
+			setTimeout(() => {
+				resolve(() => ({
+					__esModule: true,
+					default: "overriden1"
+				}));
+			}, 100);
+		}),
+	package: () =>
+		new Promise(resolve => {
+			setTimeout(() => {
+				resolve(() => "overriden-package");
+			}, 100);
+		}),
+	"options/test1": () => () => "1",
+	"nested1/options/test2": () => () => "2",
+	"nested2/deep/deep": () => () => "3"
+});
+
+it("should be able to override a esm overridable", () => {
+	return import("./modules/test1").then(m => {
+		expect(m.default).toBe("overriden1");
+	});
+});
+
+it("should be able to not override a esm overridable", () => {
+	return import("./modules/test2").then(m => {
+		expect(m.default).toBe("original2");
+	});
+});
+
+it("should be able to override a cjs overridable", () => {
+	return import("./cjs/test1").then(m => {
+		expect(m.default).toBe("overriden1");
+	});
+});
+
+it("should be able to not override a cjs overridable", () => {
+	return import("./cjs/test2").then(m => {
+		expect(m.default).toBe("original2-cjs");
+	});
+});
+
+it("should be able to override with a package name shortcut", () => {
+	return import("package").then(m => {
+		expect(m.default).toBe("overriden-package");
+	});
+});
+
+it("should be able to override a relative request via shortcut", () => {
+	return import("./options/test1").then(m => {
+		expect(m.default).toBe("1");
+	});
+});
+
+it("should be able to override a nested relative request via shortcut", () => {
+	return import("./options/test2").then(m => {
+		expect(m.default).toBe("2");
+	});
+});
+
+it("should be able to override a deep nested request", () => {
+	return import("./options/test3").then(m => {
+		expect(m.default).toBe("3");
+	});
+});
+
+it("should be able to override when fallback module has multiple chunks", () => {
+	return import("./splitChunks").then(m => {
+		expect(m.default).toBe(
+			"index+app+vendor+shared+shared-separate+shared+shared-separate"
+		);
+	});
+});

--- a/test/configCases/container/overridables/modules/test1.js
+++ b/test/configCases/container/overridables/modules/test1.js
@@ -1,0 +1,1 @@
+export default "original1";

--- a/test/configCases/container/overridables/modules/test2.js
+++ b/test/configCases/container/overridables/modules/test2.js
@@ -1,0 +1,1 @@
+export default "original2";

--- a/test/configCases/container/overridables/node_modules/package/index.js
+++ b/test/configCases/container/overridables/node_modules/package/index.js
@@ -1,0 +1,1 @@
+module.exports = "original-package";

--- a/test/configCases/container/overridables/options/test1.js
+++ b/test/configCases/container/overridables/options/test1.js
@@ -1,0 +1,1 @@
+module.exports = "test1";

--- a/test/configCases/container/overridables/options/test2.js
+++ b/test/configCases/container/overridables/options/test2.js
@@ -1,0 +1,1 @@
+module.exports = "test2";

--- a/test/configCases/container/overridables/options/test3.js
+++ b/test/configCases/container/overridables/options/test3.js
@@ -1,0 +1,1 @@
+module.exports = "test3";

--- a/test/configCases/container/overridables/splitChunks/app.js
+++ b/test/configCases/container/overridables/splitChunks/app.js
@@ -1,0 +1,4 @@
+import vendor from "./vendor";
+import shared from "./shared";
+import shared2 from "./shared-separate";
+export default "app+" + vendor + "+" + shared + "+" + shared2;

--- a/test/configCases/container/overridables/splitChunks/index.js
+++ b/test/configCases/container/overridables/splitChunks/index.js
@@ -1,0 +1,4 @@
+import app from "./app";
+import shared from "./shared";
+import shared2 from "./shared-separate";
+export default "index+" + app + "+" + shared + "+" + shared2;

--- a/test/configCases/container/overridables/splitChunks/shared-separate.js
+++ b/test/configCases/container/overridables/splitChunks/shared-separate.js
@@ -1,0 +1,1 @@
+export default "shared-separate";

--- a/test/configCases/container/overridables/splitChunks/shared.js
+++ b/test/configCases/container/overridables/splitChunks/shared.js
@@ -1,0 +1,1 @@
+export default "shared";

--- a/test/configCases/container/overridables/splitChunks/vendor.js
+++ b/test/configCases/container/overridables/splitChunks/vendor.js
@@ -1,0 +1,1 @@
+export default "vendor";

--- a/test/configCases/container/overridables/webpack.config.js
+++ b/test/configCases/container/overridables/webpack.config.js
@@ -1,0 +1,39 @@
+const OverridablesPlugin = require("../../../../lib/container/OverridablesPlugin");
+
+module.exports = {
+	plugins: [
+		new OverridablesPlugin([
+			{
+				test1: "./modules/test1.js",
+				test2: "./modules/test2"
+			},
+			{
+				test1: "./cjs/test1",
+				test2: "./cjs/test2.js",
+				nested1: ["./options/test2"],
+				nested2: {
+					deep: {
+						deep: "./options/test3"
+					}
+				}
+			},
+			"package",
+			"././options/test1",
+			"./splitChunks/app"
+		])
+	],
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				vendorTest: {
+					test: /splitChunks.vendor/,
+					enforce: true
+				},
+				sharedTest: {
+					test: /splitChunks.shared-separate/,
+					enforce: true
+				}
+			}
+		}
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Adds an `OverridablesPlugin` which allows to mark modules as overridable. These modules must only be used in on demand loaded chunks. An `__webpack_override__` API allows to replace these modules.

The `OverridablesPlugin` constructor takes a description of overridable modules and their global name for overriding.

The following argument types are allowed:

* Object
  * key is the override name
  * value is a request pointing to a module
  * when value is not an string it's treated as nested description and the listed argument types are handled in the same way, but with `key` plus `/` as prefix
* Array
  * Items are requests pointing to modules
  * override name is automatically determined by removing all `[^\w]+/` from the start of the request.
  * Examples: "./some/module" -> "some/module", "../../other" -> "other", "~/module" -> "module", "package" -> "package"

TODOs:

* [ ] error when used in entry chunk
* [ ] test for same instance when required multiple times from different chunks (and fix it)
* [ ] expose `__webpack_override__` only when OverridablesPlugin is used
* [ ] expose `OverridablesPlugin` from API
* [ ] Does it make sense to have `OverridablesPlugin` below a container folder?
* [ ] Add resolving dependencies to compilation
* [ ] Should getChunkModulesIterableBySourceType be sorted in general?
* [ ] Test persistent caching
* [ ] move block + module factory factory into runtimeTemplate for reuse

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
OverridablesPlugin is not yet exposed and should not yet be documentated
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
