### PR TITLE
fix(template): Syntax error caused by runtime template

### DIFF
--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -53,7 +53,7 @@ module.exports = class RuntimeTemplate {
 	}
 
 	missingModule({ request }) {
-		return `!(${this.throwMissingModuleErrorFunction({ request })}())`;
+		return `(${this.throwMissingModuleErrorFunction({ request })}())`;
 	}
 
 	missingModuleStatement({ request }) {


### PR DESCRIPTION
The motivation of this PR is to fix syntax errors caused by MissingModuleTemplate:

https://github.com/webpack/webpack/blob/master/declarations.d.ts#L10-L17

A: (function(){   }()) 
B: !(function(){   }())
A and B are the same effect

issue:
https://github.com/webpack/webpack/issues/9187
https://github.com/webpack/webpack/issues/6191
https://github.com/webpack/webpack/issues/8762

What kind of change does this PR introduce?

refactor

Did you add tests for your changes?

No

Does this PR introduce a breaking change?

No

What needs to be documented once your changes are merged?

I don't think this should require any doc updates
