### PR TITLE
add ContainerReferencePlugin

### DIFF
--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -9,6 +9,7 @@ const ExternalsPlugin = require("../ExternalsPlugin");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RemoteModule = require("./RemoteModule");
 const RemoteRuntimeModule = require("./RemoteRuntimeModule");
+const RemoteOverrideModule = require("./RemoteOverrideModule");
 const RemoteToExternalDependency = require("./RemoteToExternalDependency");
 const parseOptions = require("./parseOptions");
 
@@ -18,7 +19,7 @@ module.exports = class ContainerReferencePlugin {
 	constructor(options) {
 		this.remoteType = options.remoteType || "global";
 		this.remotes = parseOptions(options.remotes || []);
-		this.override = parseOptions(options.override || {});
+		this.overrides = parseOptions(options.overrides || {});
 
 		// TODO: Apply some validation around what was passed in.
 	}
@@ -53,11 +54,26 @@ module.exports = class ContainerReferencePlugin {
 								if (data.request.startsWith(`${key}/`)) {
 									return new RemoteModule(
 										data.request,
-										`container-reference/${key}`,
+										`${
+											this.overrides.length ? "remote-override-module/" : ""
+										}container-reference/${key}`,
 										data.request.slice(key.length + 1)
 									);
 								}
 							}
+						}
+					}
+				);
+
+				normalModuleFactory.hooks.factorize.tap(
+					"ContainerReferencePlugin",
+					data => {
+						// TODO use a custom dependency and factory instead
+						if (data.request.startsWith(`remote-override-module/`)) {
+							return new RemoteOverrideModule(
+								data.request.slice(`remote-override-module/`.length),
+								this.overrides
+							);
 						}
 					}
 				);

--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -1,0 +1,78 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra and Zackary Jackson @ScriptedAlchemy
+*/
+
+"use strict";
+
+const ExternalsPlugin = require("../ExternalsPlugin");
+const RuntimeGlobals = require("../RuntimeGlobals");
+const RemoteModule = require("./RemoteModule");
+const RemoteRuntimeModule = require("./RemoteRuntimeModule");
+const RemoteToExternalDependency = require("./RemoteToExternalDependency");
+const parseOptions = require("./parseOptions");
+
+/** @typedef {import("../Compiler")} Compiler */
+
+module.exports = class ContainerReferencePlugin {
+	constructor(options) {
+		this.remoteType = options.remoteType || "global";
+		this.remotes = parseOptions(options.remotes || []);
+		this.override = parseOptions(options.override || {});
+
+		// TODO: Apply some validation around what was passed in.
+	}
+
+	/**
+	 * @param {Compiler} compiler webpack compiler
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		const { remotes, remoteType } = this;
+
+		const remoteExternals = {};
+		for (const [key, value] of remotes) {
+			remoteExternals[`container-reference/${key}`] = value;
+		}
+
+		new ExternalsPlugin(remoteType, remoteExternals).apply(compiler);
+
+		compiler.hooks.compilation.tap(
+			"ContainerReferencePlugin",
+			(compilation, { normalModuleFactory }) => {
+				compilation.dependencyFactories.set(
+					RemoteToExternalDependency,
+					normalModuleFactory
+				);
+
+				normalModuleFactory.hooks.factorize.tap(
+					"ContainerReferencePlugin",
+					data => {
+						if (!data.request.includes("!")) {
+							for (const [key] of remotes) {
+								if (data.request.startsWith(`${key}/`)) {
+									return new RemoteModule(
+										data.request,
+										`container-reference/${key}`,
+										data.request.slice(key.length + 1)
+									);
+								}
+							}
+						}
+					}
+				);
+
+				compilation.hooks.additionalTreeRuntimeRequirements.tap(
+					"OverridablesPlugin",
+					(chunk, set) => {
+						set.add(RuntimeGlobals.module);
+						set.add(RuntimeGlobals.moduleFactories);
+						set.add(RuntimeGlobals.hasOwnProperty);
+						set.add(RuntimeGlobals.ensureChunkHandlers);
+						compilation.addRuntimeModule(chunk, new RemoteRuntimeModule());
+					}
+				);
+			}
+		);
+	}
+};

--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -8,9 +8,10 @@
 const ExternalsPlugin = require("../ExternalsPlugin");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RemoteModule = require("./RemoteModule");
+const RemoteOverrideModuleFactory = require("./RemoteOverrideModuleFactory");
 const RemoteRuntimeModule = require("./RemoteRuntimeModule");
-const RemoteOverrideModule = require("./RemoteOverrideModule");
 const RemoteToExternalDependency = require("./RemoteToExternalDependency");
+const RemoteToOverrideDependency = require("./RemoteToOverrideDependency");
 const parseOptions = require("./parseOptions");
 
 /** @typedef {import("../Compiler")} Compiler */
@@ -46,6 +47,11 @@ module.exports = class ContainerReferencePlugin {
 					normalModuleFactory
 				);
 
+				compilation.dependencyFactories.set(
+					RemoteToOverrideDependency,
+					new RemoteOverrideModuleFactory()
+				);
+
 				normalModuleFactory.hooks.factorize.tap(
 					"ContainerReferencePlugin",
 					data => {
@@ -54,26 +60,12 @@ module.exports = class ContainerReferencePlugin {
 								if (data.request.startsWith(`${key}/`)) {
 									return new RemoteModule(
 										data.request,
-										`${
-											this.overrides.length ? "remote-override-module/" : ""
-										}container-reference/${key}`,
+										this.overrides,
+										`container-reference/${key}`,
 										data.request.slice(key.length + 1)
 									);
 								}
 							}
-						}
-					}
-				);
-
-				normalModuleFactory.hooks.factorize.tap(
-					"ContainerReferencePlugin",
-					data => {
-						// TODO use a custom dependency and factory instead
-						if (data.request.startsWith(`remote-override-module/`)) {
-							return new RemoteOverrideModule(
-								data.request.slice(`remote-override-module/`.length),
-								this.overrides
-							);
 						}
 					}
 				);

--- a/lib/container/RemoteModule.js
+++ b/lib/container/RemoteModule.js
@@ -1,0 +1,104 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra and Zackary Jackson @ScriptedAlchemy
+*/
+
+"use strict";
+
+const { RawSource } = require("webpack-sources");
+const Module = require("../Module");
+const RuntimeGlobals = require("../RuntimeGlobals");
+const RemoteToExternalDependency = require("./RemoteToExternalDependency");
+
+/** @typedef {import("../../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
+/** @typedef {import("../ChunkGraph")} ChunkGraph */
+/** @typedef {import("../ChunkGroup")} ChunkGroup */
+/** @typedef {import("../Compilation")} Compilation */
+/** @typedef {import("../Module").CodeGenerationContext} CodeGenerationContext */
+/** @typedef {import("../Module").CodeGenerationResult} CodeGenerationResult */
+/** @typedef {import("../RequestShortener")} RequestShortener */
+/** @typedef {import("../ResolverFactory").ResolverWithOptions} ResolverWithOptions */
+/** @typedef {import("../WebpackError")} WebpackError */
+/** @typedef {import("../util/Hash")} Hash */
+/** @typedef {import("../util/fs").InputFileSystem} InputFileSystem */
+
+const TYPES = new Set(["remote"]);
+const RUNTIME_REQUIREMENTS = new Set([RuntimeGlobals.module]);
+
+class RemoteModule extends Module {
+	constructor(request, externalRequest, internalRequest) {
+		super("remote-module");
+		this.request = request;
+		this.externalRequest = externalRequest;
+		this.internalRequest = internalRequest;
+	}
+
+	/**
+	 * @returns {string} a unique identifier of the module
+	 */
+	identifier() {
+		return `remote ${this.externalRequest} ${this.internalRequest}`;
+	}
+
+	/**
+	 * @param {RequestShortener} requestShortener the request shortener
+	 * @returns {string} a user readable identifier of the module
+	 */
+	readableIdentifier(requestShortener) {
+		return `remote ${this.request}`;
+	}
+
+	/**
+	 * @param {WebpackOptions} options webpack options
+	 * @param {Compilation} compilation the compilation
+	 * @param {ResolverWithOptions} resolver the resolver
+	 * @param {InputFileSystem} fs the file system
+	 * @param {function(WebpackError=): void} callback callback function
+	 * @returns {void}
+	 */
+	build(options, compilation, resolver, fs, callback) {
+		this.buildMeta = {};
+		this.buildInfo = {
+			strict: true
+		};
+
+		this.clearDependenciesAndBlocks();
+		this.addDependency(new RemoteToExternalDependency(this.externalRequest));
+
+		callback();
+	}
+
+	/**
+	 * @param {string=} type the source type for which the size should be estimated
+	 * @returns {number} the estimated size of the module (must be non-zero)
+	 */
+	size(type) {
+		return 42;
+	}
+
+	/**
+	 * @returns {Set<string>} types availiable (do not mutate)
+	 */
+	getSourceTypes() {
+		return TYPES;
+	}
+
+	/**
+	 * @returns {string | null} absolute path which should be used for condition matching (usually the resource path)
+	 */
+	nameForCondition() {
+		return this.request;
+	}
+
+	/**
+	 * @param {CodeGenerationContext} context context for code generation
+	 * @returns {CodeGenerationResult} result
+	 */
+	codeGeneration({ runtimeTemplate, moduleGraph, chunkGraph }) {
+		const sources = new Map();
+		sources.set("remote", new RawSource(""));
+		return { sources, runtimeRequirements: RUNTIME_REQUIREMENTS };
+	}
+}
+
+module.exports = RemoteModule;

--- a/lib/container/RemoteModule.js
+++ b/lib/container/RemoteModule.js
@@ -9,6 +9,7 @@ const { RawSource } = require("webpack-sources");
 const Module = require("../Module");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RemoteToExternalDependency = require("./RemoteToExternalDependency");
+const RemoteToOverrideDependency = require("./RemoteToOverrideDependency");
 
 /** @typedef {import("../../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
@@ -26,9 +27,10 @@ const TYPES = new Set(["remote"]);
 const RUNTIME_REQUIREMENTS = new Set([RuntimeGlobals.module]);
 
 class RemoteModule extends Module {
-	constructor(request, externalRequest, internalRequest) {
+	constructor(request, overrides, externalRequest, internalRequest) {
 		super("remote-module");
 		this.request = request;
+		this.overrides = overrides;
 		this.externalRequest = externalRequest;
 		this.internalRequest = internalRequest;
 	}
@@ -63,7 +65,13 @@ class RemoteModule extends Module {
 		};
 
 		this.clearDependenciesAndBlocks();
-		this.addDependency(new RemoteToExternalDependency(this.externalRequest));
+		if (this.overrides.length > 0) {
+			this.addDependency(
+				new RemoteToOverrideDependency(this.externalRequest, this.overrides)
+			);
+		} else {
+			this.addDependency(new RemoteToExternalDependency(this.externalRequest));
+		}
 
 		callback();
 	}

--- a/lib/container/RemoteOverrideModule.js
+++ b/lib/container/RemoteOverrideModule.js
@@ -1,0 +1,155 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra and Zackary Jackson @ScriptedAlchemy
+*/
+
+"use strict";
+
+const { RawSource } = require("webpack-sources");
+const Module = require("../Module");
+const RuntimeGlobals = require("../RuntimeGlobals");
+const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
+const RemoteToExternalDependency = require("./RemoteToExternalDependency");
+const Template = require("../Template");
+
+/** @typedef {import("../../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
+/** @typedef {import("../ChunkGraph")} ChunkGraph */
+/** @typedef {import("../ChunkGroup")} ChunkGroup */
+/** @typedef {import("../Compilation")} Compilation */
+/** @typedef {import("../Module").CodeGenerationContext} CodeGenerationContext */
+/** @typedef {import("../Module").CodeGenerationResult} CodeGenerationResult */
+/** @typedef {import("../RequestShortener")} RequestShortener */
+/** @typedef {import("../ResolverFactory").ResolverWithOptions} ResolverWithOptions */
+/** @typedef {import("../WebpackError")} WebpackError */
+/** @typedef {import("../util/Hash")} Hash */
+/** @typedef {import("../util/fs").InputFileSystem} InputFileSystem */
+
+const TYPES = new Set(["javascript"]);
+
+class RemoteModule extends Module {
+	constructor(request, overrides) {
+		super("remote-override-module");
+		this.request = request;
+		this.overrides = overrides;
+	}
+
+	/**
+	 * @returns {string} a unique identifier of the module
+	 */
+	identifier() {
+		return `remote override ${this.request}`;
+	}
+
+	/**
+	 * @param {RequestShortener} requestShortener the request shortener
+	 * @returns {string} a user readable identifier of the module
+	 */
+	readableIdentifier(requestShortener) {
+		return `remote override ${this.request}`;
+	}
+
+	/**
+	 * @param {WebpackOptions} options webpack options
+	 * @param {Compilation} compilation the compilation
+	 * @param {ResolverWithOptions} resolver the resolver
+	 * @param {InputFileSystem} fs the file system
+	 * @param {function(WebpackError=): void} callback callback function
+	 * @returns {void}
+	 */
+	build(options, compilation, resolver, fs, callback) {
+		this.buildMeta = {};
+		this.buildInfo = {
+			strict: true
+		};
+
+		this.clearDependenciesAndBlocks();
+		this.addDependency(new RemoteToExternalDependency(this.request));
+
+		for (const [, value] of this.overrides) {
+			const block = new AsyncDependenciesBlock({});
+			const dep = new RemoteToExternalDependency(value);
+			block.addDependency(dep);
+			this.addBlock(block);
+		}
+
+		callback();
+	}
+
+	/**
+	 * @param {Chunk} chunk the chunk which condition should be checked
+	 * @param {Compilation} compilation the compilation
+	 * @returns {boolean} true, if the chunk is ok for the module
+	 */
+	chunkCondition(chunk, { chunkGraph }) {
+		return chunkGraph.getNumberOfEntryModules(chunk) > 0;
+	}
+
+	size(type) {
+		return 42;
+	}
+
+	/**
+	 * @returns {Set<string>} types availiable (do not mutate)
+	 */
+	getSourceTypes() {
+		return TYPES;
+	}
+
+	/**
+	 * @returns {string | null} absolute path which should be used for condition matching (usually the resource path)
+	 */
+	nameForCondition() {
+		return this.request;
+	}
+
+	/**
+	 * @param {CodeGenerationContext} context context for code generation
+	 * @returns {CodeGenerationResult} result
+	 */
+	codeGeneration({ runtimeTemplate, moduleGraph, chunkGraph }) {
+		const runtimeRequirements = new Set([RuntimeGlobals.module]);
+		const externalDep = this.dependencies[0];
+		const externalModule = moduleGraph.getModule(externalDep);
+		const externalModuleId = chunkGraph.getModuleId(externalModule);
+		let i = 0;
+		const source = Template.asString([
+			`var external = __webpack_require__(${externalModuleId});`,
+			"var overrides = {};",
+			Template.asString(
+				this.overrides.map(([key, value]) => {
+					const block = this.blocks[i++];
+					const dep = block.dependencies[0];
+					const module = moduleGraph.getModule(dep);
+					return `overrides[${JSON.stringify(
+						key
+					)}] = ${runtimeTemplate.basicFunction(
+						"",
+						`return ${runtimeTemplate.blockPromise({
+							block,
+							message: "",
+							chunkGraph,
+							runtimeRequirements
+						})}.then(${runtimeTemplate.basicFunction(
+							"",
+							`return ${runtimeTemplate.returningFunction(
+								runtimeTemplate.moduleRaw({
+									module,
+									chunkGraph,
+									request: "",
+									runtimeRequirements
+								})
+							)}`
+						)})`
+					)}`;
+				})
+			),
+			"external.override(overrides);",
+			"module.exports = external;"
+		]);
+		const sources = new Map();
+		sources.set("javascript", new RawSource(source));
+		return { sources, runtimeRequirements };
+	}
+}
+
+module.exports = RemoteModule;

--- a/lib/container/RemoteOverrideModule.js
+++ b/lib/container/RemoteOverrideModule.js
@@ -6,13 +6,14 @@
 "use strict";
 
 const { RawSource } = require("webpack-sources");
+const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
 const Module = require("../Module");
 const RuntimeGlobals = require("../RuntimeGlobals");
-const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
-const RemoteToExternalDependency = require("./RemoteToExternalDependency");
 const Template = require("../Template");
+const RemoteToExternalDependency = require("./RemoteToExternalDependency");
 
 /** @typedef {import("../../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
+/** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
 /** @typedef {import("../ChunkGroup")} ChunkGroup */
 /** @typedef {import("../Compilation")} Compilation */
@@ -84,6 +85,10 @@ class RemoteModule extends Module {
 		return chunkGraph.getNumberOfEntryModules(chunk) > 0;
 	}
 
+	/**
+	 * @param {string=} type the source type for which the size should be estimated
+	 * @returns {number} the estimated size of the module (must be non-zero)
+	 */
 	size(type) {
 		return 42;
 	}

--- a/lib/container/RemoteOverrideModuleFactory.js
+++ b/lib/container/RemoteOverrideModuleFactory.js
@@ -1,0 +1,30 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra and Zackary Jackson @ScriptedAlchemy
+*/
+
+"use strict";
+
+const ModuleFactory = require("../ModuleFactory");
+const RemoteOverrideModule = require("./RemoteOverrideModule");
+
+/** @typedef {import("../ModuleFactory").ModuleFactoryCreateData} ModuleFactoryCreateData */
+/** @typedef {import("../ModuleFactory").ModuleFactoryResult} ModuleFactoryResult */
+/** @typedef {import("./RemoteToOverrideDependency")} RemoteToOverrideDependency */
+
+class RemoteOverrideModuleFactory extends ModuleFactory {
+	/**
+	 * @param {ModuleFactoryCreateData} data data object
+	 * @param {function(Error=, ModuleFactoryResult=): void} callback callback
+	 * @returns {void}
+	 */
+	create(data, callback) {
+		const dep =
+			/** @type {RemoteToOverrideDependency} */ (data.dependencies[0]);
+		callback(null, {
+			module: new RemoteOverrideModule(dep.request, dep.overrides)
+		});
+	}
+}
+
+module.exports = RemoteOverrideModuleFactory;

--- a/lib/container/RemoteRuntimeModule.js
+++ b/lib/container/RemoteRuntimeModule.js
@@ -1,0 +1,83 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const RuntimeGlobals = require("../RuntimeGlobals");
+const RuntimeModule = require("../RuntimeModule");
+const Template = require("../Template");
+
+/** @typedef {import("./RemoteModule")} RemoteModule */
+
+class RemoteRuntimeModule extends RuntimeModule {
+	constructor() {
+		super("remotes loading");
+	}
+
+	/**
+	 * @returns {string} runtime code
+	 */
+	generate() {
+		const { runtimeTemplate, chunkGraph, moduleGraph } = this.compilation;
+		const chunkToRemotesMapping = {};
+		const idToExternalAndNameMapping = {};
+		for (const chunk of this.chunk.getAllAsyncChunks()) {
+			const modules = chunkGraph.getChunkModulesIterableBySourceType(
+				chunk,
+				"remote"
+			);
+			if (!modules) continue;
+			const remotes = (chunkToRemotesMapping[chunk.id] = []);
+			for (const m of modules) {
+				const module = /** @type {RemoteModule} */ (m);
+				const name = module.internalRequest;
+				const id = chunkGraph.getModuleId(module);
+				const externalModule = moduleGraph.getModule(module.dependencies[0]);
+				const externalModuleId = chunkGraph.getModuleId(externalModule);
+				remotes.push(id);
+				idToExternalAndNameMapping[id] = [externalModuleId, name];
+			}
+		}
+		return Template.asString([
+			`var chunkMapping = ${JSON.stringify(
+				chunkToRemotesMapping,
+				null,
+				"\t"
+			)};`,
+			`var idToExternalAndNameMapping = ${JSON.stringify(
+				idToExternalAndNameMapping,
+				null,
+				"\t"
+			)};`,
+			`${
+				RuntimeGlobals.ensureChunkHandlers
+			}.remotes = ${runtimeTemplate.basicFunction("chunkId, promises", [
+				`if(${RuntimeGlobals.hasOwnProperty}(chunkMapping, chunkId)) {`,
+				Template.indent([
+					`chunkMapping[chunkId].forEach(${runtimeTemplate.basicFunction("id", [
+						"if(__webpack_modules__[id]) return;",
+						"var data = idToExternalAndNameMapping[id];",
+						"console.log(data);",
+						`promises.push(Promise.resolve(__webpack_require__(data[0]).get(data[1])).then(${runtimeTemplate.basicFunction(
+							"factory",
+							[
+								`__webpack_modules__[id] = ${runtimeTemplate.basicFunction(
+									"module",
+									[
+										"console.log(factory.toString());",
+										"module.exports = factory();"
+									]
+								)}`
+							]
+						)}))`
+					])});`
+				]),
+				"}"
+			])}`
+		]);
+	}
+}
+
+module.exports = RemoteRuntimeModule;

--- a/lib/container/RemoteRuntimeModule.js
+++ b/lib/container/RemoteRuntimeModule.js
@@ -59,16 +59,12 @@ class RemoteRuntimeModule extends RuntimeModule {
 					`chunkMapping[chunkId].forEach(${runtimeTemplate.basicFunction("id", [
 						"if(__webpack_modules__[id]) return;",
 						"var data = idToExternalAndNameMapping[id];",
-						"console.log(data);",
 						`promises.push(Promise.resolve(__webpack_require__(data[0]).get(data[1])).then(${runtimeTemplate.basicFunction(
 							"factory",
 							[
 								`__webpack_modules__[id] = ${runtimeTemplate.basicFunction(
 									"module",
-									[
-										"console.log(factory.toString());",
-										"module.exports = factory();"
-									]
+									["module.exports = factory();"]
 								)}`
 							]
 						)}))`

--- a/lib/container/RemoteToExternalDependency.js
+++ b/lib/container/RemoteToExternalDependency.js
@@ -1,0 +1,26 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const ModuleDependency = require("../dependencies/ModuleDependency");
+const makeSerializable = require("../util/makeSerializable");
+
+class RemoteToExternalDependency extends ModuleDependency {
+	constructor(request) {
+		super(request);
+	}
+
+	get type() {
+		return "remote to external";
+	}
+}
+
+makeSerializable(
+	RemoteToExternalDependency,
+	"webpack/lib/container/RemoteToExternalDependency"
+);
+
+module.exports = RemoteToExternalDependency;

--- a/lib/container/RemoteToOverrideDependency.js
+++ b/lib/container/RemoteToOverrideDependency.js
@@ -1,0 +1,37 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const ModuleDependency = require("../dependencies/ModuleDependency");
+const makeSerializable = require("../util/makeSerializable");
+
+class RemoteToOverrideDependency extends ModuleDependency {
+	constructor(request, overrides) {
+		super(request);
+		this.overrides = overrides;
+	}
+
+	get type() {
+		return "remote to override";
+	}
+
+	serialize(context) {
+		context.write(this.overrides);
+		super.serialize(context);
+	}
+
+	deserialize(context) {
+		this.overrides = context.read();
+		super.deserialize(context);
+	}
+}
+
+makeSerializable(
+	RemoteToOverrideDependency,
+	"webpack/lib/container/RemoteToOverrideDependency"
+);
+
+module.exports = RemoteToOverrideDependency;

--- a/lib/util/internalSerializables.js
+++ b/lib/util/internalSerializables.js
@@ -21,6 +21,8 @@ module.exports = {
 		require("../container/OverridableModule"),
 	"container/OverridableOriginalDependency": () =>
 		require("../container/OverridableOriginalDependency"),
+	"container/RemoteToExternalDependency": () =>
+		require("../container/RemoteToExternalDependency"),
 	"dependencies/AMDDefineDependency": () =>
 		require("../dependencies/AMDDefineDependency"),
 	"dependencies/AMDRequireArrayDependency": () =>

--- a/lib/util/internalSerializables.js
+++ b/lib/util/internalSerializables.js
@@ -23,6 +23,8 @@ module.exports = {
 		require("../container/OverridableOriginalDependency"),
 	"container/RemoteToExternalDependency": () =>
 		require("../container/RemoteToExternalDependency"),
+	"container/RemoteToOverrideDependency": () =>
+		require("../container/RemoteToOverrideDependency"),
 	"dependencies/AMDDefineDependency": () =>
 		require("../dependencies/AMDDefineDependency"),
 	"dependencies/AMDRequireArrayDependency": () =>

--- a/test/configCases/container/container-reference-override/index.js
+++ b/test/configCases/container/container-reference-override/index.js
@@ -1,0 +1,3 @@
+it("should import the correct modules", () => {
+	return import("./module").then(({ test }) => test());
+});

--- a/test/configCases/container/container-reference-override/module.js
+++ b/test/configCases/container/container-reference-override/module.js
@@ -1,0 +1,7 @@
+import abc from "abc/hello-world";
+import other from "abc/other";
+
+export function test() {
+	expect(abc).toBe("ok hello-world");
+	expect(other).toBe("ok other");
+}

--- a/test/configCases/container/container-reference-override/new-test.js
+++ b/test/configCases/container/container-reference-override/new-test.js
@@ -1,0 +1,1 @@
+module.exports = x => `ok ${x}`;

--- a/test/configCases/container/container-reference-override/test.config.js
+++ b/test/configCases/container/container-reference-override/test.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+	moduleScope(scope) {
+		const o = {
+			test: () => () => x => `wrong ${x}`
+		};
+		scope.ABC = {
+			async get(module) {
+				const testFactory = await o["test"]();
+				const test = testFactory();
+				return () => {
+					return test(module);
+				};
+			},
+			override(overrides) {
+				Object.assign(o, overrides);
+			}
+		};
+	}
+};

--- a/test/configCases/container/container-reference-override/webpack.config.js
+++ b/test/configCases/container/container-reference-override/webpack.config.js
@@ -1,0 +1,15 @@
+const ContainerReferencePlugin = require("../../../../lib/container/ContainerReferencePlugin");
+
+module.exports = {
+	plugins: [
+		new ContainerReferencePlugin({
+			remoteType: "var",
+			remotes: {
+				abc: "ABC"
+			},
+			overrides: {
+				test: "./new-test"
+			}
+		})
+	]
+};

--- a/test/configCases/container/container-reference/index.js
+++ b/test/configCases/container/container-reference/index.js
@@ -1,0 +1,3 @@
+it("should import the correct modules", () => {
+	return import("./module").then(({ test }) => test());
+});

--- a/test/configCases/container/container-reference/module.js
+++ b/test/configCases/container/container-reference/module.js
@@ -1,0 +1,11 @@
+import abc from "abc/hello-world";
+import def, { module } from "def/hello-world";
+import def2, { module as module2 } from "def/hello/other/world";
+
+export function test() {
+	expect(abc).toBe("abc hello-world");
+	expect(def).toBe("def");
+	expect(def2).toBe("def");
+	expect(module).toBe("hello-world");
+	expect(module2).toBe("hello/other/world");
+}

--- a/test/configCases/container/container-reference/test.config.js
+++ b/test/configCases/container/container-reference/test.config.js
@@ -1,0 +1,26 @@
+module.exports = {
+	moduleScope(scope) {
+		scope.ABC = {
+			get(module) {
+				return new Promise(resolve => {
+					setTimeout(() => {
+						resolve(() => "abc " + module);
+					}, 100);
+				});
+			}
+		};
+		scope.DEF = {
+			get(module) {
+				return new Promise(resolve => {
+					setTimeout(() => {
+						resolve(() => ({
+							__esModule: true,
+							module,
+							default: "def"
+						}));
+					}, 100);
+				});
+			}
+		};
+	}
+};

--- a/test/configCases/container/container-reference/webpack.config.js
+++ b/test/configCases/container/container-reference/webpack.config.js
@@ -1,0 +1,13 @@
+const ContainerReferencePlugin = require("../../../../lib/container/ContainerReferencePlugin");
+
+module.exports = {
+	plugins: [
+		new ContainerReferencePlugin({
+			remoteType: "var",
+			remotes: {
+				abc: "ABC",
+				def: "DEF"
+			}
+		})
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

add a ContainerReferencePlugin which allows to reference another container and consume modules from this container. It also allows to override overridable modules in that container.

``` js
new ContainerReferencePlugin({
  remoteType: "var", // any supported external type
  remotes: {
    abc: "abcExternal"
  }, // like externals, but key is the scope used for the container reference
  overrides: {
    react: "./lib/my-react.js"
  } // keys is the overridable key, value the request in this build
})
```

TODOs:

* [ ] Use a custom dependency class and module factory to create the RemoteOverridesModule
* [ ] Schema validation
* [ ] Test persistent caching
* [ ] expose `ContainerReferencePlugin` from API
* [ ] test multiple instances of the `ContainerReferencePlugin`
* [ ] error when used in entry chunk
* [ ] move block + module factory factory into runtimeTemplate for reuse

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
TODO: not exposed yet
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
