### PR TITLE
add output.uniqueName option

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1427,6 +1427,10 @@ export interface Output {
 	 */
 	umdNamedDefine?: boolean;
 	/**
+	 * A unique name of the webpack build to avoid multiple webpack runtimes to conflict when using globals.
+	 */
+	uniqueName?: string;
+	/**
 	 * The filename of WebAssembly modules as relative path inside the `output.path` directory.
 	 */
 	webassemblyModuleFilename?: string;

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -112,6 +112,7 @@ const applyWebpackOptionsDefaults = options => {
 	});
 
 	applyOutputDefaults(options.output, {
+		context: options.context,
 		target,
 		outputModule: options.experiments.outputModule,
 		development
@@ -310,12 +311,16 @@ const applyModuleDefaults = (
 /**
  * @param {Output} output options
  * @param {Object} options options
+ * @param {string} options.context context
  * @param {Target} options.target target
  * @param {boolean} options.outputModule is outputModule experiment enabled
  * @param {boolean} options.development is development mode
  * @returns {void}
  */
-const applyOutputDefaults = (output, { target, outputModule, development }) => {
+const applyOutputDefaults = (
+	output,
+	{ context, target, outputModule, development }
+) => {
 	const getLibraryName = library => {
 		// if options.output.library is a string
 		if (Array.isArray(library)) {
@@ -326,9 +331,16 @@ const applyOutputDefaults = (output, { target, outputModule, development }) => {
 		return library || "";
 	};
 
-	const getLibraryIdentifier = library => {
-		return Template.toIdentifier(getLibraryName(library));
-	};
+	F(output, "uniqueName", () => {
+		const libraryName = getLibraryName(output.library);
+		if (libraryName) return libraryName;
+		try {
+			const packageInfo = require(`${context}/package.json`);
+			return packageInfo.name || "";
+		} catch (e) {
+			return "";
+		}
+	});
 
 	D(output, "filename", "[name].js");
 	F(output, "module", () => !!outputModule);
@@ -355,14 +367,18 @@ const applyOutputDefaults = (output, { target, outputModule, development }) => {
 	D(output, "compareBeforeEmit", true);
 	F(output, "hotUpdateFunction", () =>
 		Template.toIdentifier(
-			"webpackHotUpdate" + getLibraryIdentifier(output.library)
+			"webpackHotUpdate" + Template.toIdentifier(output.uniqueName)
 		)
 	);
 	F(output, "jsonpFunction", () =>
-		Template.toIdentifier("webpackJsonp" + getLibraryIdentifier(output.library))
+		Template.toIdentifier(
+			"webpackJsonp" + Template.toIdentifier(output.uniqueName)
+		)
 	);
 	F(output, "chunkCallbackName", () =>
-		Template.toIdentifier("webpackChunk" + getLibraryIdentifier(output.library))
+		Template.toIdentifier(
+			"webpackChunk" + Template.toIdentifier(output.uniqueName)
+		)
 	);
 	F(output, "globalObject", () => {
 		switch (target) {
@@ -380,7 +396,7 @@ const applyOutputDefaults = (output, { target, outputModule, development }) => {
 				return "self";
 		}
 	});
-	F(output, "devtoolNamespace", () => getLibraryName(output.library));
+	F(output, "devtoolNamespace", () => output.uniqueName);
 	F(output, "libraryTarget", () => (output.module ? "module" : "var"));
 	F(output, "path", () => path.join(process.cwd(), "dist"));
 	F(output, "pathinfo", () => development);

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1590,6 +1590,11 @@
           "description": "If `output.libraryTarget` is set to umd and `output.library` is set, setting this to true will name the AMD module.",
           "type": "boolean"
         },
+        "uniqueName": {
+          "description": "A unique name of the webpack build to avoid multiple webpack runtimes to conflict when using globals.",
+          "type": "string",
+          "minLength": 1
+        },
         "webassemblyModuleFilename": {
           "description": "The filename of WebAssembly modules as relative path inside the `output.path` directory.",
           "type": "string",

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -189,12 +189,12 @@ describe("Defaults", () => {
 		  },
 		  "output": Object {
 		    "assetModuleFilename": "[hash][ext]",
-		    "chunkCallbackName": "webpackChunk",
+		    "chunkCallbackName": "webpackChunkwebpack",
 		    "chunkFilename": "[name].js",
 		    "chunkLoadTimeout": 120000,
 		    "compareBeforeEmit": true,
 		    "crossOriginLoading": false,
-		    "devtoolNamespace": "",
+		    "devtoolNamespace": "webpack",
 		    "ecmaVersion": 6,
 		    "filename": "[name].js",
 		    "globalObject": "window",
@@ -202,10 +202,10 @@ describe("Defaults", () => {
 		    "hashDigestLength": 20,
 		    "hashFunction": "md4",
 		    "hotUpdateChunkFilename": "[id].[fullhash].hot-update.js",
-		    "hotUpdateFunction": "webpackHotUpdate",
+		    "hotUpdateFunction": "webpackHotUpdatewebpack",
 		    "hotUpdateMainFilename": "[fullhash].hot-update.json",
 		    "iife": true,
-		    "jsonpFunction": "webpackJsonp",
+		    "jsonpFunction": "webpackJsonpwebpack",
 		    "jsonpScriptType": false,
 		    "library": "",
 		    "libraryTarget": "var",
@@ -215,6 +215,7 @@ describe("Defaults", () => {
 		    "publicPath": "",
 		    "sourceMapFilename": "[file].map[query]",
 		    "strictModuleExceptionHandling": false,
+		    "uniqueName": "webpack",
 		    "webassemblyModuleFilename": "[hash].module.wasm",
 		  },
 		  "parallelism": 100,
@@ -325,7 +326,7 @@ describe("Defaults", () => {
 		@@ -112,1 +112,1 @@
 		-       "minSize": 10000,
 		+       "minSize": 30000,
-		@@ -147,1 +147,5 @@
+		@@ -148,1 +148,5 @@
 		-   "performance": false,
 		+   "performance": Object {
 		+     "hints": "warning",
@@ -374,7 +375,7 @@ describe("Defaults", () => {
 		@@ -112,1 +112,1 @@
 		-       "minSize": 10000,
 		+       "minSize": 30000,
-		@@ -147,1 +147,5 @@
+		@@ -148,1 +148,5 @@
 		-   "performance": false,
 		+   "performance": Object {
 		+     "hints": "warning",
@@ -421,10 +422,10 @@ describe("Defaults", () => {
 		@@ -140,1 +146,1 @@
 		-     "pathinfo": false,
 		+     "pathinfo": true,
-		@@ -156,1 +162,1 @@
+		@@ -157,1 +163,1 @@
 		-     "cache": false,
 		+     "cache": true,
-		@@ -175,1 +181,1 @@
+		@@ -176,1 +182,1 @@
 		-     "cache": false,
 		+     "cache": true,
 	`)
@@ -464,7 +465,7 @@ describe("Defaults", () => {
 		+         "type": "javascript/esm",
 		+       },
 		+     ],
-		@@ -158,0 +168,1 @@
+		@@ -159,0 +169,1 @@
 		+       ".mjs",
 	`)
 	);
@@ -557,16 +558,16 @@ describe("Defaults", () => {
 		+ Received
 
 		@@ -118,1 +118,1 @@
-		-     "chunkCallbackName": "webpackChunk",
+		-     "chunkCallbackName": "webpackChunkwebpack",
 		+     "chunkCallbackName": "webpackChunkmyLib_awesome",
 		@@ -123,1 +123,1 @@
-		-     "devtoolNamespace": "",
+		-     "devtoolNamespace": "webpack",
 		+     "devtoolNamespace": "myLib.awesome",
 		@@ -131,1 +131,1 @@
-		-     "hotUpdateFunction": "webpackHotUpdate",
+		-     "hotUpdateFunction": "webpackHotUpdatewebpack",
 		+     "hotUpdateFunction": "webpackHotUpdatemyLib_awesome",
 		@@ -134,1 +134,1 @@
-		-     "jsonpFunction": "webpackJsonp",
+		-     "jsonpFunction": "webpackJsonpwebpack",
 		+     "jsonpFunction": "webpackJsonpmyLib_awesome",
 		@@ -136,1 +136,4 @@
 		-     "library": "",
@@ -574,6 +575,9 @@ describe("Defaults", () => {
 		+       "myLib",
 		+       "awesome",
 		+     ],
+		@@ -144,1 +147,1 @@
+		-     "uniqueName": "webpack",
+		+     "uniqueName": "myLib.awesome",
 	`)
 	);
 	test("target node", { target: "node" }, e =>
@@ -591,14 +595,14 @@ describe("Defaults", () => {
 		@@ -126,1 +126,1 @@
 		-     "globalObject": "window",
 		+     "globalObject": "global",
-		@@ -153,3 +153,1 @@
+		@@ -154,3 +154,1 @@
 		-     "aliasFields": Array [
 		-       "browser",
 		-     ],
 		+     "aliasFields": Array [],
-		@@ -163,1 +161,0 @@
+		@@ -164,1 +162,0 @@
 		-       "browser",
-		@@ -188,1 +185,1 @@
+		@@ -189,1 +186,1 @@
 		-   "target": "web",
 		+   "target": "node",
 	`)
@@ -611,7 +615,7 @@ describe("Defaults", () => {
 		@@ -126,1 +126,1 @@
 		-     "globalObject": "window",
 		+     "globalObject": "self",
-		@@ -188,1 +188,1 @@
+		@@ -189,1 +189,1 @@
 		-   "target": "web",
 		+   "target": "webworker",
 	`)
@@ -624,7 +628,7 @@ describe("Defaults", () => {
 		@@ -84,1 +84,1 @@
 		-     "portableRecords": false,
 		+     "portableRecords": true,
-		@@ -150,2 +150,2 @@
+		@@ -151,2 +151,2 @@
 		-   "recordsInputPath": false,
 		-   "recordsOutputPath": false,
 		+   "recordsInputPath": "some-path",
@@ -697,10 +701,10 @@ describe("Defaults", () => {
 		@@ -55,1 +61,1 @@
 		-     "unsafeCache": false,
 		+     "unsafeCache": [Function anonymous],
-		@@ -156,1 +162,1 @@
+		@@ -157,1 +163,1 @@
 		-     "cache": false,
 		+     "cache": true,
-		@@ -175,1 +181,1 @@
+		@@ -176,1 +182,1 @@
 		-     "cache": false,
 		+     "cache": true,
 	`)
@@ -735,10 +739,10 @@ describe("Defaults", () => {
 		@@ -55,1 +74,1 @@
 		-     "unsafeCache": false,
 		+     "unsafeCache": [Function anonymous],
-		@@ -156,1 +175,1 @@
+		@@ -157,1 +176,1 @@
 		-     "cache": false,
 		+     "cache": true,
-		@@ -175,1 +194,1 @@
+		@@ -176,1 +195,1 @@
 		-     "cache": false,
 		+     "cache": true,
 	`)

--- a/test/configCases/web/unique-jsonp/index.js
+++ b/test/configCases/web/unique-jsonp/index.js
@@ -1,0 +1,7 @@
+it("should do something", () => {
+	const fs = require("fs");
+	const source = fs.readFileSync(__dirname + "/module.js", "utf-8");
+	expect(source).toMatch(/^\(window\[\"webpackJsonpsomething\"\]/);
+});
+
+if (Math.random() < 0) import(/* webpackChunkName: "module" */ "./module");

--- a/test/configCases/web/unique-jsonp/package.json
+++ b/test/configCases/web/unique-jsonp/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "something"
+}

--- a/test/configCases/web/unique-jsonp/test.config.js
+++ b/test/configCases/web/unique-jsonp/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function(i, options) {
+		return ["main.js"];
+	}
+};

--- a/test/configCases/web/unique-jsonp/webpack.config.js
+++ b/test/configCases/web/unique-jsonp/webpack.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+	target: "web",
+	output: {
+		filename: "[name].js"
+	},
+	externals: {
+		fs: "commonjs2 fs"
+	},
+	node: {
+		__filename: false,
+		__dirname: false
+	}
+};


### PR DESCRIPTION
It defaults to library name or name from package.json in context

output.uniqueName will be used to generate unique globals for
* output.jsonpFunction
* output.chunkCallbackName
* etc.

fixes #10441

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
new option output.uniqueName
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
