### PR TITLE
feat: support `[query]` for asset modules

### DIFF
--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -105,13 +105,24 @@ const replacePathVariables = (path, data, assetInfo) => {
 	// [ext] - .js
 	if (data.filename) {
 		if (typeof data.filename === "string") {
-			const idx = data.filename.indexOf("?");
+			const queryIdx = data.filename.indexOf("?");
 
 			let file, query;
 
-			if (idx >= 0) {
-				file = data.filename.substr(0, idx);
-				query = data.filename.substr(idx);
+			if (queryIdx >= 0) {
+				file = data.filename.substr(0, queryIdx);
+
+				const maybeQuery = data.filename.substr(queryIdx);
+
+				if (maybeQuery.length > 1) {
+					const hashIdx = maybeQuery.indexOf("#");
+
+					if (hashIdx >= 0) {
+						query = maybeQuery.substr(0, hashIdx);
+					} else {
+						query = maybeQuery;
+					}
+				}
 			} else {
 				file = data.filename;
 				query = "";

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -9,6 +9,7 @@ const { basename, extname } = require("path");
 const util = require("util");
 const Chunk = require("./Chunk");
 const Module = require("./Module");
+const { parseResource } = require("./util/identifier");
 
 /** @typedef {import("./Compilation").AssetInfo} AssetInfo */
 /** @typedef {import("./Compilation").PathData} PathData */
@@ -96,37 +97,17 @@ const replacePathVariables = (path, data, assetInfo) => {
 	//
 	// Placeholders
 	//
-	// for /some/path/file.js?query:
+	// for /some/path/file.js?query#fragment:
 	// [file] - /some/path/file.js
 	// [query] - ?query
+	// [fragment] - #fragment
 	// [base] - file.js
 	// [path] - /some/path/
 	// [name] - file
 	// [ext] - .js
 	if (data.filename) {
 		if (typeof data.filename === "string") {
-			const queryIdx = data.filename.indexOf("?");
-
-			let file, query;
-
-			if (queryIdx >= 0) {
-				file = data.filename.substr(0, queryIdx);
-
-				const maybeQuery = data.filename.substr(queryIdx);
-
-				if (maybeQuery.length > 1) {
-					const hashIdx = maybeQuery.indexOf("#");
-
-					if (hashIdx >= 0) {
-						query = maybeQuery.substr(0, hashIdx);
-					} else {
-						query = maybeQuery;
-					}
-				}
-			} else {
-				file = data.filename;
-				query = "";
-			}
+			const { path: file, query, fragment } = parseResource(data.filename);
 
 			const ext = extname(file);
 			const base = basename(file);
@@ -135,6 +116,7 @@ const replacePathVariables = (path, data, assetInfo) => {
 
 			replacements.set("file", replacer(file));
 			replacements.set("query", replacer(query, true));
+			replacements.set("fragment", replacer(fragment, true));
 			replacements.set("path", replacer(path, true));
 			replacements.set("base", replacer(base));
 			replacements.set("name", replacer(name));

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -62,7 +62,7 @@ class AssetGenerator extends Generator {
 							null,
 							originalSource.source(),
 							{
-								filename: module.nameForCondition(),
+								filename: module.matchResource || module.resource,
 								module
 							}
 						);
@@ -131,7 +131,7 @@ class AssetGenerator extends Generator {
 					} = this.compilation.getAssetPathWithInfo(assetModuleFilename, {
 						module,
 						runtime,
-						filename: module.nameForCondition(),
+						filename: module.matchResource || module.resource,
 						chunkGraph,
 						contentHash
 					});

--- a/lib/asset/AssetParser.js
+++ b/lib/asset/AssetParser.js
@@ -34,7 +34,7 @@ class AssetParser extends Parser {
 
 		if (typeof this.dataUrlCondition === "function") {
 			state.module.buildInfo.dataUrl = this.dataUrlCondition(source, {
-				filename: state.module.nameForCondition(),
+				filename: state.module.matchResource || state.module.resource,
 				module: state.module
 			});
 		} else if (typeof this.dataUrlCondition === "boolean") {

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -535,7 +535,7 @@ const applyOutputDefaults = (
 		}
 		return "[id].js";
 	});
-	D(output, "assetModuleFilename", "[hash][ext]");
+	D(output, "assetModuleFilename", "[hash][ext][query]");
 	D(output, "webassemblyModuleFilename", "[hash].module.wasm");
 	D(output, "publicPath", "");
 	D(output, "compareBeforeEmit", true);

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -1359,7 +1359,7 @@ describe("Defaults", () => {
 			-           "idHint": "vendors",
 			-           "priority": -10,
 			-           "reuseExistingChunk": true,
-			-           "test": /[\\\\\\/]node_modules[\\\\\\/]/i,
+			-           "test": /[\\\\/]node_modules[\\\\/]/i,
 			-         },
 			-       },
 			-       "chunks": "async",

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -208,7 +208,7 @@ describe("Defaults", () => {
 		    "usedExports": false,
 		  },
 		  "output": Object {
-		    "assetModuleFilename": "[hash][ext]",
+		    "assetModuleFilename": "[hash][ext][query]",
 		    "chunkCallbackName": "webpackChunkwebpack",
 		    "chunkFilename": "[name].js",
 		    "chunkLoadTimeout": 120000,
@@ -1359,7 +1359,7 @@ describe("Defaults", () => {
 			-           "idHint": "vendors",
 			-           "priority": -10,
 			-           "reuseExistingChunk": true,
-			-           "test": /[\\\\/]node_modules[\\\\/]/i,
+			-           "test": /[\\\\\\/]node_modules[\\\\\\/]/i,
 			-         },
 			-       },
 			-       "chunks": "async",

--- a/test/configCases/asset-modules/query-and-custom-condition/index.js
+++ b/test/configCases/asset-modules/query-and-custom-condition/index.js
@@ -1,0 +1,9 @@
+import png from "../_images/file.png?foo=bar";
+import svg from "../_images/file.svg";
+import jpg from "../_images/file.jpg?foo=bar#hash";
+
+it("should output various asset types", () => {
+	expect(png).toContain("data:image/png;base64,");
+	expect(svg).toMatch(/^[\da-f]{20}\.svg$/);
+	expect(jpg).toContain("data:image/jpeg;base64,");
+});

--- a/test/configCases/asset-modules/query-and-custom-condition/webpack.config.js
+++ b/test/configCases/asset-modules/query-and-custom-condition/webpack.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+	mode: "development",
+	module: {
+		rules: [
+			{
+				test: /\.(png|svg|jpg)$/,
+				type: "asset",
+				parser: {
+					dataUrlCondition: (source, { filename, module }) => {
+						return filename.includes("?foo=bar");
+					}
+				}
+			}
+		]
+	},
+	experiments: {
+		asset: true
+	}
+};

--- a/test/configCases/asset-modules/query-and-custom-encoder/index.js
+++ b/test/configCases/asset-modules/query-and-custom-encoder/index.js
@@ -1,0 +1,9 @@
+import png from "../_images/file.png";
+import svg from "../_images/file.svg?foo=bar";
+import jpg from "../_images/file.jpg";
+
+it("should output various asset types", () => {
+	expect(png).toMatch(/^data:image\/png;base64,[0-9a-zA-Z+/]+=*$/);
+	expect(svg).toMatch(/^data:image\/svg\+xml,/);
+	expect(jpg).toMatch(/^data:image\/jpeg;base64,[0-9a-zA-Z+/]+=*$/);
+});

--- a/test/configCases/asset-modules/query-and-custom-encoder/webpack.config.js
+++ b/test/configCases/asset-modules/query-and-custom-encoder/webpack.config.js
@@ -1,0 +1,33 @@
+const svgToMiniDataURI = require("mini-svg-data-uri");
+const mimeTypes = require("mime-types");
+
+module.exports = {
+	mode: "development",
+	module: {
+		rules: [
+			{
+				test: /\.(png|svg|jpg)$/,
+				type: "asset/inline",
+				generator: {
+					dataUrl: (source, { filename, module }) => {
+						if (filename.endsWith("?foo=bar")) {
+							if (typeof source !== "string") {
+								source = source.toString();
+							}
+
+							return svgToMiniDataURI(source);
+						}
+
+						const mimeType = mimeTypes.lookup(module.nameForCondition());
+						const encodedContent = source.toString("base64");
+
+						return `data:${mimeType};base64,${encodedContent}`;
+					}
+				}
+			}
+		]
+	},
+	experiments: {
+		asset: true
+	}
+};

--- a/test/configCases/asset-modules/query/index.js
+++ b/test/configCases/asset-modules/query/index.js
@@ -4,6 +4,6 @@ import jpg from "../_images/file.jpg?foo=bar#hash";
 
 it("should output various asset types", () => {
 	expect(png).toMatch(/^[\da-f]{20}\.png\?foo=bar$/);
-	expect(svg).toMatch(/^[\da-f]{20}\.svg$/);
+	expect(svg).toMatch(/^[\da-f]{20}\.svg\?$/);
 	expect(jpg).toMatch(/^[\da-f]{20}\.jpg\?foo=bar$/);
 });

--- a/test/configCases/asset-modules/query/index.js
+++ b/test/configCases/asset-modules/query/index.js
@@ -1,0 +1,9 @@
+import png from "../_images/file.png?foo=bar";
+import svg from "../_images/file.svg?";
+import jpg from "../_images/file.jpg?foo=bar#hash";
+
+it("should output various asset types", () => {
+	expect(png).toMatch(/^[\da-f]{20}\.png\?foo=bar$/);
+	expect(svg).toMatch(/^[\da-f]{20}\.svg$/);
+	expect(jpg).toMatch(/^[\da-f]{20}\.jpg\?foo=bar$/);
+});

--- a/test/configCases/asset-modules/query/webpack.config.js
+++ b/test/configCases/asset-modules/query/webpack.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+	mode: "development",
+	module: {
+		rules: [
+			{
+				test: /\.(png|svg|jpg)$/,
+				type: "asset/resource"
+			}
+		]
+	},
+	experiments: {
+		asset: true
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feature, latest `file-loader` release introduce support the `[query]` replacer in the `name` option for better CDN integration, let's do it for the `asset` module type and respect query string by default for better 0cjs

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

Yes, now we respect `[query]` by default.

**What needs to be documented once your changes are merged?**

Yes.

- the `assetModuleFilename` option has the `[hash][ext][query]` value by default

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
