### PR TITLE
flag all modules as used for Dll

### DIFF
--- a/lib/DllPlugin.js
+++ b/lib/DllPlugin.js
@@ -5,8 +5,8 @@
 "use strict";
 
 const DllEntryPlugin = require("./DllEntryPlugin");
+const FlagAllModulesAsUsedPlugin = require("./FlagAllModulesAsUsedPlugin");
 const LibManifestPlugin = require("./LibManifestPlugin");
-const FlagInitialModulesAsUsedPlugin = require("./FlagInitialModulesAsUsedPlugin");
 
 const validateOptions = require("schema-utils");
 const schema = require("../schemas/plugins/DllPlugin.json");
@@ -41,7 +41,7 @@ class DllPlugin {
 		});
 		new LibManifestPlugin(this.options).apply(compiler);
 		if (!this.options.entryOnly) {
-			new FlagInitialModulesAsUsedPlugin("DllPlugin").apply(compiler);
+			new FlagAllModulesAsUsedPlugin("DllPlugin").apply(compiler);
 		}
 	}
 }

--- a/lib/FlagAllModulesAsUsedPlugin.js
+++ b/lib/FlagAllModulesAsUsedPlugin.js
@@ -1,0 +1,38 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+/** @typedef {import("./Compiler")} Compiler */
+
+class FlagAllModulesAsUsedPlugin {
+	constructor(explanation) {
+		this.explanation = explanation;
+	}
+
+	/**
+	 * @param {Compiler} compiler webpack compiler
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap(
+			"FlagAllModulesAsUsedPlugin",
+			compilation => {
+				compilation.hooks.optimizeDependencies.tap(
+					"FlagAllModulesAsUsedPlugin",
+					modules => {
+						for (const module of modules) {
+							module.used = true;
+							module.usedExports = true;
+							module.addReason(null, null, this.explanation);
+						}
+					}
+				);
+			}
+		);
+	}
+}
+
+module.exports = FlagAllModulesAsUsedPlugin;

--- a/lib/FlagDependencyUsagePlugin.js
+++ b/lib/FlagDependencyUsagePlugin.js
@@ -93,7 +93,7 @@ class FlagDependencyUsagePlugin {
 					};
 
 					for (const module of modules) {
-						module.used = false;
+						if (!module.used) module.used = false;
 					}
 
 					/** @type {[Module, DependenciesBlock, UsedExports][]} */

--- a/test/configCases/dll-plugin-side-effects/0-create-dll/dependency.js
+++ b/test/configCases/dll-plugin-side-effects/0-create-dll/dependency.js
@@ -1,0 +1,3 @@
+export default function createB() {
+	return "b";
+}

--- a/test/configCases/dll-plugin-side-effects/0-create-dll/dependency2.js
+++ b/test/configCases/dll-plugin-side-effects/0-create-dll/dependency2.js
@@ -1,0 +1,3 @@
+export default function createC() {
+	return "c";
+}

--- a/test/configCases/dll-plugin-side-effects/0-create-dll/index.js
+++ b/test/configCases/dll-plugin-side-effects/0-create-dll/index.js
@@ -1,0 +1,3 @@
+import { a } from "./module";
+
+export default a();

--- a/test/configCases/dll-plugin-side-effects/0-create-dll/module.js
+++ b/test/configCases/dll-plugin-side-effects/0-create-dll/module.js
@@ -1,0 +1,12 @@
+import createB from "./dependency";
+import createC from "./dependency2";
+
+export function a() {
+	return "a";
+}
+
+export { createB as b };
+
+export function c() {
+	return createC();
+}

--- a/test/configCases/dll-plugin-side-effects/0-create-dll/test.config.js
+++ b/test/configCases/dll-plugin-side-effects/0-create-dll/test.config.js
@@ -1,0 +1,1 @@
+exports.noTests = true;

--- a/test/configCases/dll-plugin-side-effects/0-create-dll/webpack.config.js
+++ b/test/configCases/dll-plugin-side-effects/0-create-dll/webpack.config.js
@@ -2,10 +2,7 @@ var path = require("path");
 var webpack = require("../../../../");
 
 module.exports = {
-	entry: ["./a", "./b", "./_d", "./_e", "./f", "./g.abc", "./h"],
-	resolve: {
-		extensions: [".js", ".jsx"]
-	},
+	entry: ["./index"],
 	output: {
 		filename: "dll.js",
 		chunkFilename: "[id].dll.js",
@@ -14,14 +11,7 @@ module.exports = {
 	module: {
 		rules: [
 			{
-				test: /\.abc\.js$/,
-				loader: "./g-loader.js",
-				options: {
-					test: 1
-				}
-			},
-			{
-				test: /0-create-dll.h/,
+				test: /0-create-dll.(module|dependency)/,
 				sideEffects: false
 			}
 		]
@@ -34,7 +24,7 @@ module.exports = {
 		new webpack.DllPlugin({
 			path: path.resolve(
 				__dirname,
-				"../../../js/config/dll-plugin/manifest0.json"
+				"../../../js/config/dll-plugin-side-effects/manifest0.json"
 			)
 		})
 	]

--- a/test/configCases/dll-plugin-side-effects/1-use-dll/index.js
+++ b/test/configCases/dll-plugin-side-effects/1-use-dll/index.js
@@ -1,0 +1,9 @@
+it("should include all exports and modules in the dll", function() {
+	const { a, b, c } = require("dll/module");
+	expect(typeof a).toBe("function");
+	expect(a()).toBe("a");
+	expect(typeof b).toBe("function");
+	expect(b()).toBe("b");
+	expect(typeof c).toBe("function");
+	expect(c()).toBe("c");
+});

--- a/test/configCases/dll-plugin-side-effects/1-use-dll/webpack.config.js
+++ b/test/configCases/dll-plugin-side-effects/1-use-dll/webpack.config.js
@@ -1,0 +1,12 @@
+var webpack = require("../../../../");
+
+module.exports = {
+	plugins: [
+		new webpack.DllReferencePlugin({
+			manifest: require("../../../js/config/dll-plugin-side-effects/manifest0.json"), // eslint-disable-line node/no-missing-require
+			name: "../0-create-dll/dll.js",
+			scope: "dll",
+			sourceType: "commonjs2"
+		})
+	]
+};

--- a/test/configCases/dll-plugin/0-issue-10475/index.js
+++ b/test/configCases/dll-plugin/0-issue-10475/index.js
@@ -1,0 +1,3 @@
+import { constants } from "test-package";
+
+var x = constants;

--- a/test/configCases/dll-plugin/0-issue-10475/node_modules/test-package/constants.js
+++ b/test/configCases/dll-plugin/0-issue-10475/node_modules/test-package/constants.js
@@ -1,0 +1,2 @@
+export const constant1 = 'constant1';
+export const constant2 = 'constant2';

--- a/test/configCases/dll-plugin/0-issue-10475/node_modules/test-package/index.js
+++ b/test/configCases/dll-plugin/0-issue-10475/node_modules/test-package/index.js
@@ -1,0 +1,5 @@
+import * as _constants from './constants';
+export var constants = _constants;
+export { default as someFunction } from './someFunction';
+
+console.log(constants);

--- a/test/configCases/dll-plugin/0-issue-10475/node_modules/test-package/package.json
+++ b/test/configCases/dll-plugin/0-issue-10475/node_modules/test-package/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "index.js",
+  "sideEffects": false
+}

--- a/test/configCases/dll-plugin/0-issue-10475/node_modules/test-package/someFunction.js
+++ b/test/configCases/dll-plugin/0-issue-10475/node_modules/test-package/someFunction.js
@@ -1,0 +1,3 @@
+export default function someFunction() {
+  console.log('This is some function');
+}

--- a/test/configCases/dll-plugin/0-issue-10475/node_modules/test-package/working-constants.js
+++ b/test/configCases/dll-plugin/0-issue-10475/node_modules/test-package/working-constants.js
@@ -1,0 +1,7 @@
+export const constant1 = 'constant1';
+export const constant2 = 'constant2';
+
+export default {
+  constant1,
+  constant2,
+};

--- a/test/configCases/dll-plugin/0-issue-10475/test.config.js
+++ b/test/configCases/dll-plugin/0-issue-10475/test.config.js
@@ -1,0 +1,1 @@
+exports.noTests = true;

--- a/test/configCases/dll-plugin/0-issue-10475/webpack.config.js
+++ b/test/configCases/dll-plugin/0-issue-10475/webpack.config.js
@@ -1,0 +1,19 @@
+var path = require("path");
+var webpack = require("../../../../");
+
+module.exports = {
+	entry: ["./index.js"],
+	output: {
+		filename: "dll.js",
+		chunkFilename: "[id].dll.js",
+		libraryTarget: "commonjs2"
+	},
+	plugins: [
+		new webpack.DllPlugin({
+			path: path.resolve(
+				__dirname,
+				"../../../js/config/dll-plugin/issue-10475.json"
+			)
+		})
+	]
+};

--- a/test/configCases/dll-plugin/1-issue-10475/index.js
+++ b/test/configCases/dll-plugin/1-issue-10475/index.js
@@ -1,0 +1,3 @@
+it("should have all modules", () => {
+	require("dll/index.js");
+});

--- a/test/configCases/dll-plugin/1-issue-10475/webpack.config.js
+++ b/test/configCases/dll-plugin/1-issue-10475/webpack.config.js
@@ -1,0 +1,12 @@
+var webpack = require("../../../../");
+
+module.exports = {
+	plugins: [
+		new webpack.DllReferencePlugin({
+			manifest: require("../../../js/config/dll-plugin/issue-10475.json"), // eslint-disable-line node/no-missing-require
+			name: "../0-issue-10475/dll.js",
+			scope: "dll",
+			sourceType: "commonjs2"
+		})
+	]
+};


### PR DESCRIPTION
fix problem that modules were removed before they were flagged as used

fixes #10189

backport of #10205

fixes #10475

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes, dlls might be larger
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
