### PR TITLE
Add missing support of publicPath for WebWorkers

### DIFF
--- a/lib/webworker/ImportScriptsChunkLoadingRuntimeModule.js
+++ b/lib/webworker/ImportScriptsChunkLoadingRuntimeModule.js
@@ -69,7 +69,7 @@ class ImportScriptsChunkLoadingRuntimeModule extends RuntimeModule {
 									Template.indent("installedChunks[chunkIds.pop()] = 1;")
 								]),
 								"};",
-								`importScripts(${RuntimeGlobals.getChunkScriptFilename}(chunkId));`,
+								`importScripts(${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId));`,
 								"",
 								withHmr
 									? "if(currentUpdateChunks && currentUpdateChunks[chunkId]) loadUpdateChunk(chunkId);"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Support for `publicPath` when loading modules by `importScripts` established in #9270 is now broken on master. Trying to fix it.
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Nothing.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
