### PR TITLE
Fix externals interop within SystemLibraryPlugin.

### DIFF
--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -44,6 +44,7 @@
 /**
  * @typedef {Object} ExportsSpec
  * @property {(string | ExportSpec)[] | true | null} exports exported names, true for unknown exports or null for no exports
+ * @property {boolean=} canMangle can the export be renamed (defaults to true)
  * @property {Module[]=} dependencies module on which the result depends on
  */
 

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -9,6 +9,7 @@ const { OriginalSource, RawSource } = require("webpack-sources");
 const Module = require("./Module");
 const RuntimeGlobals = require("./RuntimeGlobals");
 const Template = require("./Template");
+const StaticExportsDependency = require("./dependencies/StaticExportsDependency");
 const makeSerializable = require("./util/makeSerializable");
 const propertyAccess = require("./util/propertyAccess");
 
@@ -194,10 +195,17 @@ class ExternalModule extends Module {
 	 * @returns {void}
 	 */
 	build(options, compilation, resolver, fs, callback) {
-		this.buildMeta = {};
+		this.buildMeta = {
+			exportsType: undefined
+		};
 		this.buildInfo = {
 			strict: true
 		};
+		this.clearDependenciesAndBlocks();
+		if (this.externalType === "system") {
+			this.buildMeta.exportsType = "namespace";
+			this.addDependency(new StaticExportsDependency(true, true));
+		}
 		callback();
 	}
 
@@ -290,6 +298,13 @@ class ExternalModule extends Module {
 		hash.update(
 			JSON.stringify(Boolean(this.isOptional(chunkGraph.moduleGraph)))
 		);
+		if (this.externalType === "system") {
+			const exportsInfo = chunkGraph.moduleGraph.getExportsInfo(this);
+			for (const exportInfo of exportsInfo.orderedExports) {
+				hash.update(exportInfo.name);
+				hash.update(exportInfo.getUsedName() || "");
+			}
+		}
 		super.updateHash(hash, chunkGraph);
 	}
 

--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -113,10 +113,11 @@ class FlagDependencyExportsPlugin {
 									const exportDesc = dep.getExports(moduleGraph);
 									if (!exportDesc) return;
 									const exports = exportDesc.exports;
+									const canMangle = exportDesc.canMangle;
 									const exportDeps = exportDesc.dependencies;
 									if (exports === true) {
 										// unknown exports
-										if (exportsInfo.setUnknownExportsProvided()) {
+										if (exportsInfo.setUnknownExportsProvided(canMangle)) {
 											changed = true;
 										}
 									} else if (Array.isArray(exports)) {
@@ -131,6 +132,13 @@ class FlagDependencyExportsPlugin {
 														exportInfo.provided = true;
 														changed = true;
 													}
+													if (
+														canMangle === false &&
+														exportInfo.canMangleProvide !== false
+													) {
+														exportInfo.canMangleProvide = false;
+														changed = true;
+													}
 												} else {
 													const exportInfo = exportsInfo.getExportInfo(
 														exportNameOrSpec.name
@@ -139,11 +147,14 @@ class FlagDependencyExportsPlugin {
 														exportInfo.provided = true;
 														changed = true;
 													}
-													if (exportNameOrSpec.canMangle === false) {
-														if (exportInfo.canMangleProvide !== false) {
-															exportInfo.canMangleProvide = false;
-															changed = true;
-														}
+													if (
+														exportInfo.canMangleProvide !== false &&
+														(exportNameOrSpec.canMangle === false ||
+															(canMangle === false &&
+																exportNameOrSpec.canMangle === undefined))
+													) {
+														exportInfo.canMangleProvide = false;
+														changed = true;
 													}
 													if (exportNameOrSpec.exports) {
 														const nestedExportsInfo = exportInfo.createNestedExportsInfo();

--- a/lib/ModuleGraph.js
+++ b/lib/ModuleGraph.js
@@ -70,10 +70,16 @@ class ExportsInfo {
 		this._redirectTo = undefined;
 	}
 
+	/**
+	 * @returns {Iterable<ExportInfo>} all owned exports in any order
+	 */
 	get ownedExports() {
 		return this._exports.values();
 	}
 
+	/**
+	 * @returns {Iterable<ExportInfo>} all exports in any order
+	 */
 	get exports() {
 		if (this._redirectTo) {
 			const map = new Map(this._redirectTo._exports);
@@ -85,6 +91,9 @@ class ExportsInfo {
 		return this._exports.values();
 	}
 
+	/**
+	 * @returns {Iterable<ExportInfo>} all exports in order
+	 */
 	get orderedExports() {
 		if (!this._exportsAreOrdered) {
 			this._sortExports();
@@ -104,6 +113,9 @@ class ExportsInfo {
 		return this._exports.values();
 	}
 
+	/**
+	 * @returns {ExportInfo} the export info of unlisted exports
+	 */
 	get otherExportsInfo() {
 		if (this._redirectTo) return this._redirectTo.otherExportsInfo;
 		return this._otherExportsInfo;
@@ -223,16 +235,17 @@ class ExportsInfo {
 	}
 
 	/**
+	 * @param {boolean=} canMangle true, if exports can still be mangled (defaults to false)
 	 * @returns {boolean} true, if this call changed something
 	 */
-	setUnknownExportsProvided() {
+	setUnknownExportsProvided(canMangle) {
 		let changed = false;
 		for (const exportInfo of this._exports.values()) {
 			if (exportInfo.provided !== true && exportInfo.provided !== null) {
 				exportInfo.provided = null;
 				changed = true;
 			}
-			if (exportInfo.canMangleProvide !== false) {
+			if (!canMangle && exportInfo.canMangleProvide !== false) {
 				exportInfo.canMangleProvide = false;
 				changed = true;
 			}
@@ -249,7 +262,7 @@ class ExportsInfo {
 				this._otherExportsInfo.provided = null;
 				changed = true;
 			}
-			if (this._otherExportsInfo.canMangleProvide !== false) {
+			if (!canMangle && this._otherExportsInfo.canMangleProvide !== false) {
 				this._otherExportsInfo.canMangleProvide = false;
 				changed = true;
 			}

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -466,6 +466,7 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 			case "dynamic-reexport":
 				return {
 					exports: true,
+					canMangle: false,
 					// TODO: consider passing `ignored` from `dynamic-reexport`
 					dependencies: [moduleGraph.getModule(this)]
 				};

--- a/lib/dependencies/StaticExportsDependency.js
+++ b/lib/dependencies/StaticExportsDependency.js
@@ -35,20 +35,11 @@ class StaticExportsDependency extends NullDependency {
 	 * @returns {ExportsSpec | undefined} export names
 	 */
 	getExports(moduleGraph) {
-		if (!this.canMangle && this.exports !== true) {
-			return {
-				exports: this.exports.map(name => ({
-					name,
-					canMangle: false
-				})),
-				dependencies: undefined
-			};
-		} else {
-			return {
-				exports: this.exports,
-				dependencies: undefined
-			};
-		}
+		return {
+			exports: this.exports,
+			canMangle: this.canMangle,
+			dependencies: undefined
+		};
 	}
 
 	/**

--- a/lib/library/SystemLibraryPlugin.js
+++ b/lib/library/SystemLibraryPlugin.js
@@ -7,7 +7,9 @@
 
 const { ConcatSource } = require("webpack-sources");
 const ExternalModule = require("../ExternalModule");
+const { UsageState } = require("../ModuleGraph");
 const Template = require("../Template");
+const propertyAccess = require("../util/propertyAccess");
 const AbstractLibraryPlugin = require("./AbstractLibraryPlugin");
 
 /** @typedef {import("webpack-sources").Source} Source */
@@ -67,7 +69,7 @@ class SystemLibraryPlugin extends AbstractLibraryPlugin {
 	 * @param {LibraryContext<T>} libraryContext context
 	 * @returns {Source} source with library export
 	 */
-	render(source, { chunkGraph, chunk }, { options, compilation }) {
+	render(source, { chunkGraph, moduleGraph, chunk }, { options, compilation }) {
 		const modules = chunkGraph
 			.getChunkModules(chunk)
 			.filter(m => m instanceof ExternalModule);
@@ -99,10 +101,12 @@ class SystemLibraryPlugin extends AbstractLibraryPlugin {
 		);
 
 		// Declaring variables for the internal variable names for the webpack externals
-		const externalVarDeclarations =
-			externalWebpackNames.length > 0
-				? `var ${externalWebpackNames.join(", ")};`
-				: "";
+		const externalVarDeclarations = externalWebpackNames
+			.map(name => `var ${name} = {};`)
+			.join("\n");
+
+		// Define __esModule flag on all internal variables and helpers
+		const externalVarInitialization = [];
 
 		// The system.register format requires an array of setter functions for externals.
 		const setters =
@@ -111,24 +115,65 @@ class SystemLibraryPlugin extends AbstractLibraryPlugin {
 				: Template.asString([
 						"setters: [",
 						Template.indent(
-							externalWebpackNames
-								.map(external =>
-									Template.asString([
+							externals
+								.map((module, i) => {
+									const external = externalWebpackNames[i];
+									const exportsInfo = moduleGraph.getExportsInfo(module);
+									const otherUnused =
+										exportsInfo.otherExportsInfo.used === UsageState.Unused;
+									const instructions = [];
+									const handledNames = [];
+									for (const exportInfo of exportsInfo.orderedExports) {
+										const used = exportInfo.getUsedName();
+										if (used) {
+											if (otherUnused || used !== exportInfo.name) {
+												instructions.push(
+													`${external}${propertyAccess([
+														used
+													])} = module${propertyAccess([exportInfo.name])};`
+												);
+												handledNames.push(exportInfo.name);
+											}
+										} else {
+											handledNames.push(exportInfo.name);
+										}
+									}
+									if (!otherUnused) {
+										externalVarInitialization.push(
+											`Object.defineProperty(${external}, "__esModule", { value: true });`
+										);
+										if (handledNames.length > 0) {
+											const name = `${external}handledNames`;
+											externalVarInitialization.push(
+												`var ${name} = ${JSON.stringify(handledNames)};`
+											);
+											instructions.push(
+												Template.asString([
+													"Object.keys(module).forEach(function(key) {",
+													Template.indent([
+														`if(${name}.indexOf(key) >= 0)`,
+														Template.indent(`${external}[key] = module[key];`)
+													]),
+													"});"
+												])
+											);
+										} else {
+											instructions.push(
+												Template.asString([
+													"Object.keys(module).forEach(function(key) {",
+													Template.indent([`${external}[key] = module[key];`]),
+													"});"
+												])
+											);
+										}
+									}
+									if (instructions.length === 0) return "undefined";
+									return Template.asString([
 										"function(module) {",
-										Template.indent(`${external} = {__esModule: true};`),
-										Template.indent([
-											"for (var key in module) {",
-											Template.indent("defineGetter(key, module[key]);"),
-											"}",
-											"function defineGetter(key, value) {",
-											Template.indent([
-												`Object.defineProperty(${external}, key, {get: function() {return value;}, enumerable: true});`
-											]),
-											"}"
-										]),
+										Template.indent(instructions),
 										"}"
-									])
-								)
+									]);
+								})
 								.join(",\n")
 						),
 						"],"
@@ -139,23 +184,25 @@ class SystemLibraryPlugin extends AbstractLibraryPlugin {
 				`System.register(${name}${systemDependencies}, function(${dynamicExport}) {`,
 				Template.indent([
 					externalVarDeclarations,
+					Template.asString(externalVarInitialization),
 					"return {",
 					Template.indent([
 						setters,
 						"execute: function() {",
 						Template.indent(`${dynamicExport}(`)
 					])
-				])
-			]) + "\n",
+				]),
+				""
+			]),
 			source,
-			"\n" +
-				Template.asString([
-					Template.indent([
-						Template.indent([Template.indent([");"]), "}"]),
-						"};"
-					]),
-					"})"
-				])
+			Template.asString([
+				"",
+				Template.indent([
+					Template.indent([Template.indent([");"]), "}"]),
+					"};"
+				]),
+				"})"
+			])
 		);
 	}
 

--- a/lib/library/SystemLibraryPlugin.js
+++ b/lib/library/SystemLibraryPlugin.js
@@ -116,6 +116,13 @@ class SystemLibraryPlugin extends AbstractLibraryPlugin {
 									Template.asString([
 										"function(module) {",
 										Template.indent(`${external} = module;`),
+										Template.indent([
+											"if (!Object.hasOwnProperty.call(module, '__esModule')) {",
+											Template.indent(
+												`Object.defineProperty(${external}, "__esModule", {value: true});`
+											),
+											"}"
+										]),
 										"}"
 									])
 								)

--- a/lib/library/SystemLibraryPlugin.js
+++ b/lib/library/SystemLibraryPlugin.js
@@ -115,12 +115,15 @@ class SystemLibraryPlugin extends AbstractLibraryPlugin {
 								.map(external =>
 									Template.asString([
 										"function(module) {",
-										Template.indent(`${external} = module;`),
+										Template.indent(`${external} = {__esModule: true};`),
 										Template.indent([
-											"if (!Object.hasOwnProperty.call(module, '__esModule')) {",
-											Template.indent(
-												`Object.defineProperty(${external}, "__esModule", {value: true});`
-											),
+											"for (var key in module) {",
+											Template.indent("defineGetter(key, module[key]);"),
+											"}",
+											"function defineGetter(key, value) {",
+											Template.indent([
+												`Object.defineProperty(${external}, key, {get: function() {return value;}, enumerable: true});`
+											]),
 											"}"
 										]),
 										"}"

--- a/lib/library/SystemLibraryPlugin.js
+++ b/lib/library/SystemLibraryPlugin.js
@@ -167,7 +167,7 @@ class SystemLibraryPlugin extends AbstractLibraryPlugin {
 											);
 										}
 									}
-									if (instructions.length === 0) return "undefined";
+									if (instructions.length === 0) return "function() {}";
 									return Template.asString([
 										"function(module) {",
 										Template.indent(instructions),

--- a/lib/wasm/WebAssemblyParser.js
+++ b/lib/wasm/WebAssemblyParser.js
@@ -184,7 +184,7 @@ class WebAssemblyParser extends Parser {
 			}
 		});
 
-		state.module.addDependency(new StaticExportsDependency(exports, true));
+		state.module.addDependency(new StaticExportsDependency(exports, false));
 
 		return state;
 	}

--- a/test/configCases/externals/externals-system/index.js
+++ b/test/configCases/externals/externals-system/index.js
@@ -1,15 +1,16 @@
-import external3Default from 'external3';
+import external3Default, { namedThing } from 'external3';
 
 /* This test verifies that webpack externals are properly indicated as dependencies to System.
  * Also that when System provides the external variables to webpack that the variables get plumbed
  * through correctly and are usable by the webpack bundle.
  */
 it("should get an external from System", function() {
-	const external1 = require("external1").default;
-	expect(external1).toBe("the external1 value");
+	const external1 = require("external1");
+	expect(external1.default).toBe("the external1 value");
 
-	const external2 = require("external2").default;
-	expect(external2).toBe("the external2 value");
+	const external2 = require("external2");
+	expect(external2.default).toBe("the external2 value");
 
 	expect(external3Default).toBe("the external3 default export");
+	expect(namedThing).toBe("the external3 named export");
 });

--- a/test/configCases/externals/externals-system/index.js
+++ b/test/configCases/externals/externals-system/index.js
@@ -1,4 +1,5 @@
-import external3Default, { namedThing } from 'external3';
+import external3Default, { namedThing } from "external3";
+import "external4";
 
 /* This test verifies that webpack externals are properly indicated as dependencies to System.
  * Also that when System provides the external variables to webpack that the variables get plumbed

--- a/test/configCases/externals/externals-system/index.js
+++ b/test/configCases/externals/externals-system/index.js
@@ -5,10 +5,10 @@ import external3Default from 'external3';
  * through correctly and are usable by the webpack bundle.
  */
 it("should get an external from System", function() {
-	const external1 = require("external1");
+	const external1 = require("external1").default;
 	expect(external1).toBe("the external1 value");
 
-	const external2 = require("external2");
+	const external2 = require("external2").default;
 	expect(external2).toBe("the external2 value");
 
 	expect(external3Default).toBe("the external3 default export");

--- a/test/configCases/externals/externals-system/index.js
+++ b/test/configCases/externals/externals-system/index.js
@@ -1,3 +1,5 @@
+import external3Default from 'external3';
+
 /* This test verifies that webpack externals are properly indicated as dependencies to System.
  * Also that when System provides the external variables to webpack that the variables get plumbed
  * through correctly and are usable by the webpack bundle.
@@ -8,4 +10,6 @@ it("should get an external from System", function() {
 
 	const external2 = require("external2");
 	expect(external2).toBe("the external2 value");
+
+	expect(external3Default).toBe("the external3 default export");
 });

--- a/test/configCases/externals/externals-system/test.config.js
+++ b/test/configCases/externals/externals-system/test.config.js
@@ -11,6 +11,7 @@ module.exports = {
 			},
 			external3: {
 				default: "the external3 default export",
+				namedThing: "the external3 named export"
 			}
 		});
 	},

--- a/test/configCases/externals/externals-system/test.config.js
+++ b/test/configCases/externals/externals-system/test.config.js
@@ -4,14 +4,18 @@ module.exports = {
 	beforeExecute: () => {
 		System.init({
 			external1: {
-				default: "the external1 value",
+				default: "the external1 value"
 			},
 			external2: {
-				default: "the external2 value",
+				default: "the external2 value"
 			},
 			external3: {
 				default: "the external3 default export",
 				namedThing: "the external3 named export"
+			},
+			external4: {
+				default: "the external4 default export",
+				namedThing: "the external4 named export"
 			}
 		});
 	},

--- a/test/configCases/externals/externals-system/test.config.js
+++ b/test/configCases/externals/externals-system/test.config.js
@@ -3,8 +3,12 @@ const System = require("../../../helpers/fakeSystem");
 module.exports = {
 	beforeExecute: () => {
 		System.init({
-			external1: "the external1 value",
-			external2: "the external2 value",
+			external1: {
+				default: "the external1 value",
+			},
+			external2: {
+				default: "the external2 value",
+			},
 			external3: {
 				default: "the external3 default export",
 			}

--- a/test/configCases/externals/externals-system/test.config.js
+++ b/test/configCases/externals/externals-system/test.config.js
@@ -4,7 +4,10 @@ module.exports = {
 	beforeExecute: () => {
 		System.init({
 			external1: "the external1 value",
-			external2: "the external2 value"
+			external2: "the external2 value",
+			external3: {
+				default: "the external3 default export",
+			}
 		});
 	},
 	moduleScope(scope) {

--- a/test/configCases/externals/externals-system/webpack.config.js
+++ b/test/configCases/externals/externals-system/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	externals: {
 		external1: "external1",
 		external2: "external2",
-		external3: "external3"
+		external3: "external3",
+		external4: "external4"
 	}
 };

--- a/test/configCases/externals/externals-system/webpack.config.js
+++ b/test/configCases/externals/externals-system/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
 	},
 	externals: {
 		external1: "external1",
-		external2: "external2"
+		external2: "external2",
+		external3: "external3"
 	}
 };

--- a/test/helpers/fakeSystem.js
+++ b/test/helpers/fakeSystem.js
@@ -69,8 +69,9 @@ const System = {
 			m.executed = true;
 			for (let i = 0; i < m.deps.length; i++) {
 				const dep = m.deps[i];
+				const setters = m.mod.setters[i];
 				System.ensureExecuted(dep);
-				m.mod.setters[i](System.registry[dep].exports);
+				if (setters) setters(System.registry[dep].exports);
 			}
 			m.mod.execute();
 		}

--- a/test/helpers/fakeSystem.js
+++ b/test/helpers/fakeSystem.js
@@ -71,7 +71,7 @@ const System = {
 				const dep = m.deps[i];
 				const setters = m.mod.setters[i];
 				System.ensureExecuted(dep);
-				if (setters) setters(System.registry[dep].exports);
+				setters(System.registry[dep].exports);
 			}
 			m.mod.execute();
 		}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

[Codepen showing problem](https://codesandbox.io/s/reverent-rosalind-zei2s)

This fixes a bug where webpack currently treats SystemJS external modules as commonjs instead of ES modules. The bug means that the default export of a SystemJS external module is not accessible via `import defaultThing from 'external-thing';`.

Without exception, all modules in the SystemJS registry are ES module objects. Webpack should treat them as ES modules when determining default vs named exports.

I am a primary maintainer of SystemJS and have discussed this change with the other SystemJS maintainers, including @guybedford. We believe it best for webpack to treat all modules originating from SystemJS as ES modules.

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

It is possible people are currently working around the broken behavior and will have to update their code when upgrading. I consider this to be a bug fix and that dependent code should not be relying on the broken behavior.

```js
// with current webpack
import foo from 'external-from-systemjs';

// This is a work around of broken behavior
foo = foo.default;

console.log(foo);
```

```js
// after the change in this pull request
import foo from 'external-from-systemjs';

// No workaround needed
console.log(foo);
```

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

I don't think any documentation should be updated. If so it would be in https://webpack.js.org/configuration/output/#outputlibrarytarget