### PR TITLE
fix: should not fail when output directory is the root directory

### DIFF
--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -115,6 +115,11 @@ exports.dirname = dirname;
  * @returns {void}
  */
 const mkdirp = (fs, p, callback) => {
+	if (path.resolve(p) === path.resolve("/")) {
+		callback();
+		return;
+	}
+
 	fs.mkdir(p, err => {
 		if (err) {
 			if (err.code === "ENOENT") {
@@ -141,7 +146,7 @@ const mkdirp = (fs, p, callback) => {
 					});
 				});
 				return;
-			} else if (err.code === "EEXIST" || err.code === "EISDIR") {
+			} else if (err.code === "EEXIST") {
 				callback();
 				return;
 			}

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -115,13 +115,14 @@ exports.dirname = dirname;
  * @returns {void}
  */
 const mkdirp = (fs, p, callback) => {
-	if (path.resolve(p) === path.resolve("/")) {
-		callback();
-		return;
-	}
-
 	fs.mkdir(p, err => {
 		if (err) {
+			if (path.resolve(p) === path.resolve("/")) {
+				// whatever the error code is, calling mkdirp on the roor directory should not throw
+				callback();
+				return;
+			}
+
 			if (err.code === "ENOENT") {
 				const dir = dirname(fs, p);
 				if (dir === p) {

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -141,7 +141,7 @@ const mkdirp = (fs, p, callback) => {
 					});
 				});
 				return;
-			} else if (err.code === "EEXIST") {
+			} else if (err.code === "EEXIST" || err.code === "EISDIR") {
 				callback();
 				return;
 			}

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -118,7 +118,7 @@ const mkdirp = (fs, p, callback) => {
 	fs.mkdir(p, err => {
 		if (err) {
 			if (path.resolve(p) === path.resolve("/")) {
-				// whatever the error code is, calling mkdirp on the roor directory should not throw
+				// whatever the error code is, calling mkdirp on the root directory should not throw
 				callback();
 				return;
 			}

--- a/test/configCases/output/root-dir/index.js
+++ b/test/configCases/output/root-dir/index.js
@@ -1,0 +1,3 @@
+it("should compile", done => {
+	done();
+});

--- a/test/configCases/output/root-dir/test.config.js
+++ b/test/configCases/output/root-dir/test.config.js
@@ -1,0 +1,8 @@
+const path = require("path");
+const outputDirectory = __dirname.replace("configCases", "js/config");
+
+module.exports = {
+	findBundle: function() {
+		return [path.relative(outputDirectory, "/tmp/bundle.js")];
+	}
+};

--- a/test/configCases/output/root-dir/webpack.config.js
+++ b/test/configCases/output/root-dir/webpack.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	entry: "./index.js",
+	output: {
+		path: "/",
+		filename: "tmp/bundle.js"
+	}
+};


### PR DESCRIPTION
Fixes #10544.

Though the `EISDIR` error code is not mentioned in the POSIX standard,
FreeBSD and `memfs` both throw this error when trying to run `mkdir` on
`/`. So essentially we should treat it the same as `EEXIST`.

References:
* https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=59739
* https://github.com/streamich/memfs/pull/326/


**What kind of change does this PR introduce?**

A bugfix

**Did you add tests for your changes?**

I'm not sure how I should add tests, because this issue only happens on BSD systems.

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing