### PR TITLE
fix: module federation plugin library should be optional

### DIFF
--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -43,7 +43,7 @@ module.exports = class ContainerReferencePlugin {
 			remoteExternals[`container-reference/${key}`] = value;
 		}
 
-		new ExternalsPlugin(remoteType, remoteExternals).apply(compiler);
+		new ExternalsPlugin(remoteType || "var", remoteExternals).apply(compiler);
 
 		compiler.hooks.compilation.tap(
 			"ContainerReferencePlugin",

--- a/lib/container/ModuleFederationPlugin.js
+++ b/lib/container/ModuleFederationPlugin.js
@@ -32,7 +32,7 @@ class ModuleFederationPlugin {
 		}).apply(compiler);
 		new ContainerReferencePlugin({
 			remoteType:
-				options.remoteType || options.library.type || output.library.type,
+				options.remoteType || compiler.options.externalsType,
 			remotes: options.remotes,
 			overrides: options.shared
 		}).apply(compiler);

--- a/lib/container/ModuleFederationPlugin.js
+++ b/lib/container/ModuleFederationPlugin.js
@@ -22,17 +22,19 @@ class ModuleFederationPlugin {
 	 */
 	apply(compiler) {
 		const { options } = this;
+		const { output } = compiler.options;
 		new ContainerPlugin({
 			name: options.name,
-			library: options.library,
+			library: options.library || options.library.type || output.library.type,
 			filename: options.filename,
 			exposes: options.exposes,
-			overridables: options.shared
+			overridables: options.shared,
 		}).apply(compiler);
 		new ContainerReferencePlugin({
-			remoteType: options.remoteType || options.library.type,
+			remoteType:
+				options.remoteType || options.library.type || output.library.type,
 			remotes: options.remotes,
-			overrides: options.shared
+			overrides: options.shared,
 		}).apply(compiler);
 	}
 }

--- a/lib/container/ModuleFederationPlugin.js
+++ b/lib/container/ModuleFederationPlugin.js
@@ -22,7 +22,6 @@ class ModuleFederationPlugin {
 	 */
 	apply(compiler) {
 		const { options } = this;
-		const { output } = compiler.options;
 		new ContainerPlugin({
 			name: options.name,
 			library: options.library,
@@ -32,7 +31,9 @@ class ModuleFederationPlugin {
 		}).apply(compiler);
 		new ContainerReferencePlugin({
 			remoteType:
-				options.remoteType || (options.library && options.library.type) || compiler.options.externalsType,
+				options.remoteType ||
+				(options.library && options.library.type) ||
+				compiler.options.externalsType,
 			remotes: options.remotes,
 			overrides: options.shared
 		}).apply(compiler);

--- a/lib/container/ModuleFederationPlugin.js
+++ b/lib/container/ModuleFederationPlugin.js
@@ -32,7 +32,7 @@ class ModuleFederationPlugin {
 		}).apply(compiler);
 		new ContainerReferencePlugin({
 			remoteType:
-				options.remoteType || compiler.options.externalsType,
+				options.remoteType || (options.library && options.library.type) || compiler.options.externalsType,
 			remotes: options.remotes,
 			overrides: options.shared
 		}).apply(compiler);

--- a/lib/container/ModuleFederationPlugin.js
+++ b/lib/container/ModuleFederationPlugin.js
@@ -25,7 +25,7 @@ class ModuleFederationPlugin {
 		const { output } = compiler.options;
 		new ContainerPlugin({
 			name: options.name,
-			library: options.library || options.library.type || output.library.type,
+			library: options.library,
 			filename: options.filename,
 			exposes: options.exposes,
 			overridables: options.shared

--- a/lib/container/ModuleFederationPlugin.js
+++ b/lib/container/ModuleFederationPlugin.js
@@ -28,13 +28,13 @@ class ModuleFederationPlugin {
 			library: options.library || options.library.type || output.library.type,
 			filename: options.filename,
 			exposes: options.exposes,
-			overridables: options.shared,
+			overridables: options.shared
 		}).apply(compiler);
 		new ContainerReferencePlugin({
 			remoteType:
 				options.remoteType || options.library.type || output.library.type,
 			remotes: options.remotes,
-			overrides: options.shared,
+			overrides: options.shared
 		}).apply(compiler);
 	}
 }

--- a/lib/container/ModuleFederationPlugin.js
+++ b/lib/container/ModuleFederationPlugin.js
@@ -22,21 +22,31 @@ class ModuleFederationPlugin {
 	 */
 	apply(compiler) {
 		const { options } = this;
-		new ContainerPlugin({
-			name: options.name,
-			library: options.library,
-			filename: options.filename,
-			exposes: options.exposes,
-			overridables: options.shared
-		}).apply(compiler);
-		new ContainerReferencePlugin({
-			remoteType:
-				options.remoteType ||
-				(options.library && options.library.type) ||
-				compiler.options.externalsType,
-			remotes: options.remotes,
-			overrides: options.shared
-		}).apply(compiler);
+		if (
+			options.library &&
+			!compiler.options.output.enabledLibraryTypes.includes(
+				options.library.type
+			)
+		) {
+			compiler.options.output.enabledLibraryTypes.push(options.library.type);
+		}
+		compiler.hooks.afterPlugins.tap("ModuleFederationPlugin", () => {
+			new ContainerPlugin({
+				name: options.name,
+				library: options.library || compiler.options.output.library,
+				filename: options.filename,
+				exposes: options.exposes,
+				overridables: options.shared
+			}).apply(compiler);
+			new ContainerReferencePlugin({
+				remoteType:
+					options.remoteType ||
+					(options.library && options.library.type) ||
+					compiler.options.externalsType,
+				remotes: options.remotes,
+				overrides: options.shared
+			}).apply(compiler);
+		});
 	}
 }
 

--- a/test/configCases/container/module-federation/dep.js
+++ b/test/configCases/container/module-federation/dep.js
@@ -1,0 +1,1 @@
+module.exports = "dep";

--- a/test/configCases/container/module-federation/index.js
+++ b/test/configCases/container/module-federation/index.js
@@ -1,0 +1,3 @@
+it("should import the correct modules", () => {
+	return import("./module").then(({ test }) => test());
+});

--- a/test/configCases/container/module-federation/index.js
+++ b/test/configCases/container/module-federation/index.js
@@ -1,3 +1,3 @@
 it("should import the correct modules", () => {
-	return 	System.import("./module").then(({ test }) => test());
+	return System.import("./module").then(({ test }) => test());
 });

--- a/test/configCases/container/module-federation/index.js
+++ b/test/configCases/container/module-federation/index.js
@@ -1,3 +1,3 @@
 it("should import the correct modules", () => {
-	return import("./module").then(({ test }) => test());
+	return 	System.import("./module").then(({ test }) => test());
 });

--- a/test/configCases/container/module-federation/index.js
+++ b/test/configCases/container/module-federation/index.js
@@ -1,3 +1,4 @@
 it("should import the correct modules", () => {
-	return System.import("./module").then(({ test }) => test());
+	return import("./module").then(({ test }) => test());
 });
+

--- a/test/configCases/container/module-federation/index.js
+++ b/test/configCases/container/module-federation/index.js
@@ -1,4 +1,3 @@
 it("should import the correct modules", () => {
 	return import("./module").then(({ test }) => test());
 });
-

--- a/test/configCases/container/module-federation/module.js
+++ b/test/configCases/container/module-federation/module.js
@@ -1,0 +1,11 @@
+import abc from "abc/hello-world";
+import def, { module } from "def/hello-world";
+import def2, { module as module2 } from "def/hello/other/world";
+
+export function test() {
+	expect(abc).toBe("abc hello-world");
+	expect(def).toBe("def");
+	expect(def2).toBe("def");
+	expect(module).toBe("hello-world");
+	expect(module2).toBe("hello/other/world");
+}

--- a/test/configCases/container/module-federation/module.js
+++ b/test/configCases/container/module-federation/module.js
@@ -1,11 +1,11 @@
-import abc from "abc/hello-world";
-import def, { module } from "def/hello-world";
-import def2, { module as module2 } from "def/hello/other/world";
+import abc from "abc/system-hello-world";
+import def, { module } from "def/system-hello-world";
+import def2, { module as module2 } from "def/system-hello/other/world";
 
 export function test() {
-	expect(abc).toBe("abc hello-world");
+	expect(abc).toBe("abc system-hello-world");
 	expect(def).toBe("def");
 	expect(def2).toBe("def");
-	expect(module).toBe("hello-world");
-	expect(module2).toBe("hello/other/world");
+	expect(module).toBe("system-hello-world");
+	expect(module2).toBe("system-hello/other/world");
 }

--- a/test/configCases/container/module-federation/module.js
+++ b/test/configCases/container/module-federation/module.js
@@ -1,5 +1,3 @@
-const System = require("../../../helpers/fakeSystem");
-
 import abc from "abc/hello-world";
 import def, { module } from "def/hello-world";
 import def2, { module as module2 } from "def/hello/other/world";

--- a/test/configCases/container/module-federation/module.js
+++ b/test/configCases/container/module-federation/module.js
@@ -1,3 +1,5 @@
+const System = require("../../../helpers/fakeSystem");
+
 import abc from "abc/hello-world";
 import def, { module } from "def/hello-world";
 import def2, { module as module2 } from "def/hello/other/world";

--- a/test/configCases/container/module-federation/module.js
+++ b/test/configCases/container/module-federation/module.js
@@ -1,6 +1,10 @@
 import abc from "abc/system-hello-world";
 import def, { module } from "def/system-hello-world";
 import def2, { module as module2 } from "def/system-hello/other/world";
+import other from "other/other";
+import otherSelf from "other/self";
+import self from "self/self";
+import selfOther from "self/other";
 
 export function test() {
 	expect(abc).toBe("abc system-hello-world");
@@ -8,4 +12,8 @@ export function test() {
 	expect(def2).toBe("def");
 	expect(module).toBe("system-hello-world");
 	expect(module2).toBe("system-hello/other/world");
+	expect(other).toBe("other and dep");
+	expect(otherSelf).toBe("self and dep");
+	expect(self).toBe("self and dep");
+	expect(selfOther).toBe("other and dep");
 }

--- a/test/configCases/container/module-federation/other.js
+++ b/test/configCases/container/module-federation/other.js
@@ -1,0 +1,3 @@
+import andBack from "other/dep";
+
+export default `other and ${andBack}`;

--- a/test/configCases/container/module-federation/self.js
+++ b/test/configCases/container/module-federation/self.js
@@ -1,0 +1,3 @@
+import andBack from "self/dep";
+
+export default `self and ${andBack}`;

--- a/test/configCases/container/module-federation/test.config.js
+++ b/test/configCases/container/module-federation/test.config.js
@@ -1,0 +1,26 @@
+module.exports = {
+	moduleScope(scope) {
+		scope.ABC = {
+			get(module) {
+				return new Promise(resolve => {
+					setTimeout(() => {
+						resolve(() => "abc " + module);
+					}, 100);
+				});
+			}
+		};
+		scope.DEF = {
+			get(module) {
+				return new Promise(resolve => {
+					setTimeout(() => {
+						resolve(() => ({
+							__esModule: true,
+							module,
+							default: "def"
+						}));
+					}, 100);
+				});
+			}
+		};
+	}
+};

--- a/test/configCases/container/module-federation/test.config.js
+++ b/test/configCases/container/module-federation/test.config.js
@@ -1,7 +1,11 @@
 const System = require("../../../helpers/fakeSystem");
 
 module.exports = {
+	beforeExecute: () => {
+		System.init();
+	},
 	moduleScope(scope) {
+		scope.System = System;
 		scope.ABC = {
 			get(module) {
 				return new Promise(resolve => {
@@ -24,5 +28,8 @@ module.exports = {
 				});
 			}
 		};
+	},
+	afterExecute: () => {
+		System.execute("(anonym)");
 	}
 };

--- a/test/configCases/container/module-federation/test.config.js
+++ b/test/configCases/container/module-federation/test.config.js
@@ -32,19 +32,6 @@ module.exports = {
 				}
 			});
 		});
-		scope.DEF = {
-			get(module) {
-				return new Promise(resolve => {
-					setTimeout(() => {
-						resolve(() => ({
-							__esModule: true,
-							module,
-							default: "def"
-						}));
-					}, 100);
-				});
-			}
-		};
 	},
 	afterExecute: () => {
 		System.execute("(anonym)");

--- a/test/configCases/container/module-federation/test.config.js
+++ b/test/configCases/container/module-federation/test.config.js
@@ -6,29 +6,37 @@ module.exports = {
 	},
 	moduleScope(scope) {
 		scope.System = System;
-		System.register("´ABC", [], {
-			get(module) {
-				return new Promise(resolve => {
-					setTimeout(() => {
-						resolve(() => "abc " + module);
-					}, 100);
-				});
-			}
-		});
-		System.register("´DEF", [], {
+		// System.register("´ABC", [], ($__export)=>{
+		// 	$__export()
+		//
+		// );
 
-			get(module) {
-				return new Promise(resolve => {
-					setTimeout(() => {
-						resolve(() => ({
-							__esModule: true,
-							module,
-							default: "def"
-						}));
-					}, 100);
-				});
-			}
-		})
+		System.register("´ABC", [], $__export => {
+			$__export({
+				get(module) {
+					return new Promise(resolve => {
+						setTimeout(() => {
+							resolve(() => "abc " + module);
+						}, 100);
+					});
+				}
+			});
+		});
+		System.register("´DEF", [], $__export => {
+			$__export({
+				get(module) {
+					return new Promise(resolve => {
+						setTimeout(() => {
+							resolve(() => ({
+								__esModule: true,
+								module,
+								default: "def"
+							}));
+						}, 100);
+					});
+				}
+			});
+		});
 		scope.DEF = {
 			get(module) {
 				return new Promise(resolve => {

--- a/test/configCases/container/module-federation/test.config.js
+++ b/test/configCases/container/module-federation/test.config.js
@@ -16,6 +16,19 @@ module.exports = {
 					});
 				}
 			});
+			return {
+				execute() {
+					$__export({
+						get(module) {
+							return new Promise(resolve => {
+								setTimeout(() => {
+									resolve(() => "abc " + module);
+								}, 100);
+							});
+						}
+					});
+				}
+			};
 		});
 		System.register("DEF", [], $__export => {
 			$__export({
@@ -31,6 +44,23 @@ module.exports = {
 					});
 				}
 			});
+			return {
+				execute() {
+					$__export({
+						get(module) {
+							return new Promise(resolve => {
+								setTimeout(() => {
+									resolve(() => ({
+										__esModule: true,
+										module,
+										default: "def"
+									}));
+								}, 100);
+							});
+						}
+					});
+				}
+			};
 		});
 	},
 	afterExecute: () => {

--- a/test/configCases/container/module-federation/test.config.js
+++ b/test/configCases/container/module-federation/test.config.js
@@ -6,7 +6,7 @@ module.exports = {
 	},
 	moduleScope(scope) {
 		scope.System = System;
-		scope.ABC = {
+		System.register("´ABC", [], {
 			get(module) {
 				return new Promise(resolve => {
 					setTimeout(() => {
@@ -14,7 +14,21 @@ module.exports = {
 					}, 100);
 				});
 			}
-		};
+		});
+		System.register("´DEF", [], {
+
+			get(module) {
+				return new Promise(resolve => {
+					setTimeout(() => {
+						resolve(() => ({
+							__esModule: true,
+							module,
+							default: "def"
+						}));
+					}, 100);
+				});
+			}
+		})
 		scope.DEF = {
 			get(module) {
 				return new Promise(resolve => {

--- a/test/configCases/container/module-federation/test.config.js
+++ b/test/configCases/container/module-federation/test.config.js
@@ -6,12 +6,7 @@ module.exports = {
 	},
 	moduleScope(scope) {
 		scope.System = System;
-		// System.register("´ABC", [], ($__export)=>{
-		// 	$__export()
-		//
-		// );
-
-		System.register("´ABC", [], $__export => {
+		System.register("ABC", [], $__export => {
 			$__export({
 				get(module) {
 					return new Promise(resolve => {
@@ -22,7 +17,7 @@ module.exports = {
 				}
 			});
 		});
-		System.register("´DEF", [], $__export => {
+		System.register("DEF", [], $__export => {
 			$__export({
 				get(module) {
 					return new Promise(resolve => {

--- a/test/configCases/container/module-federation/test.config.js
+++ b/test/configCases/container/module-federation/test.config.js
@@ -1,3 +1,5 @@
+const System = require("../../../helpers/fakeSystem");
+
 module.exports = {
 	moduleScope(scope) {
 		scope.ABC = {

--- a/test/configCases/container/module-federation/test.config.js
+++ b/test/configCases/container/module-federation/test.config.js
@@ -5,62 +5,29 @@ module.exports = {
 		System.init();
 	},
 	moduleScope(scope) {
+		System.setRequire(scope.require);
 		scope.System = System;
-		System.register("ABC", [], $__export => {
-			$__export({
-				get(module) {
-					return new Promise(resolve => {
-						setTimeout(() => {
-							resolve(() => "abc " + module);
-						}, 100);
-					});
-				}
-			});
-			return {
-				execute() {
-					$__export({
-						get(module) {
-							return new Promise(resolve => {
-								setTimeout(() => {
-									resolve(() => "abc " + module);
-								}, 100);
-							});
-						}
-					});
-				}
-			};
+		System.set("ABC", {
+			get(module) {
+				return new Promise(resolve => {
+					setTimeout(() => {
+						resolve(() => "abc " + module);
+					}, 100);
+				});
+			}
 		});
-		System.register("DEF", [], $__export => {
-			$__export({
-				get(module) {
-					return new Promise(resolve => {
-						setTimeout(() => {
-							resolve(() => ({
-								__esModule: true,
-								module,
-								default: "def"
-							}));
-						}, 100);
-					});
-				}
-			});
-			return {
-				execute() {
-					$__export({
-						get(module) {
-							return new Promise(resolve => {
-								setTimeout(() => {
-									resolve(() => ({
-										__esModule: true,
-										module,
-										default: "def"
-									}));
-								}, 100);
-							});
-						}
-					});
-				}
-			};
+		System.set("DEF", {
+			get(module) {
+				return new Promise(resolve => {
+					setTimeout(() => {
+						resolve(() => ({
+							__esModule: true,
+							module,
+							default: "def"
+						}));
+					}, 100);
+				});
+			}
 		});
 	},
 	afterExecute: () => {

--- a/test/configCases/container/module-federation/webpack.config.js
+++ b/test/configCases/container/module-federation/webpack.config.js
@@ -1,19 +1,40 @@
 const ModuleFederationPlugin = require("../../../../lib/container/ModuleFederationPlugin");
 
-module.exports = {
-	externalsType: "system",
-	plugins: [
-		new ModuleFederationPlugin({
-			name: "container",
-			library: { type: "commonjs-module" },
-			filename: "container.js",
-			exposes: {
-				ComponentA: "./ComponentA"
-			},
-			remotes: {
-				containerA: "./container.js"
-			},
-			shared: ["react"]
-		})
-	]
-};
+const webpack = require("../../../../");
+
+function createConfig(system) {
+	const systemString = "" + system;
+	return {
+		externalsType: "system",
+		name: `system_${systemString}`,
+		module: {
+			rules: [
+				{
+					test: /\.js$/,
+					parser: {
+						system
+					}
+				}
+			]
+		},
+		plugins: [
+			new webpack.DefinePlugin({
+				__SYSTEM__: systemString
+			}),
+			new ModuleFederationPlugin({
+				name: "container",
+				filename: "container.js",
+				remotes: {
+					abc: "ABC",
+					def: "DEF"
+				}
+			})
+		]
+	};
+}
+
+module.exports = [
+	createConfig(undefined),
+	createConfig(true),
+	createConfig(false)
+];

--- a/test/configCases/container/module-federation/webpack.config.js
+++ b/test/configCases/container/module-federation/webpack.config.js
@@ -1,0 +1,19 @@
+const ModuleFederationPlugin = require("../../../../lib/container/ModuleFederationPlugin");
+
+module.exports = {
+	externalsType: "system",
+	plugins: [
+		new ModuleFederationPlugin({
+			name: "container",
+			library: { type: "commonjs-module" },
+			filename: "container.js",
+			exposes: {
+				ComponentA: "./ComponentA"
+			},
+			remotes: {
+				containerA: "./container.js"
+			},
+			shared: ["react"]
+		})
+	]
+};

--- a/test/configCases/container/module-federation/webpack.config.js
+++ b/test/configCases/container/module-federation/webpack.config.js
@@ -5,12 +5,14 @@ function createConfig() {
 		output: {
 			libraryTarget: "system"
 		},
-		externalsType: "system",
-		name: `system_js_build`,
+		//externalsType: "system",
 		module: {
 			rules: [
 				{
-					test: /\.js$/
+					test: /\.js$/,
+					parser: {
+						system: false
+					}
 				}
 			]
 		},

--- a/test/configCases/container/module-federation/webpack.config.js
+++ b/test/configCases/container/module-federation/webpack.config.js
@@ -1,26 +1,20 @@
 const ModuleFederationPlugin = require("../../../../lib/container/ModuleFederationPlugin");
 
-const webpack = require("../../../../");
-
-function createConfig(system) {
-	const systemString = "" + system;
+function createConfig() {
 	return {
+		output: {
+			libraryTarget: "system"
+		},
 		externalsType: "system",
-		name: `system_${systemString}`,
+		name: `system_js_build`,
 		module: {
 			rules: [
 				{
-					test: /\.js$/,
-					parser: {
-						system
-					}
+					test: /\.js$/
 				}
 			]
 		},
 		plugins: [
-			new webpack.DefinePlugin({
-				__SYSTEM__: systemString
-			}),
 			new ModuleFederationPlugin({
 				name: "container",
 				filename: "container.js",
@@ -33,8 +27,4 @@ function createConfig(system) {
 	};
 }
 
-module.exports = [
-	createConfig(undefined),
-	createConfig(true),
-	createConfig(false)
-];
+module.exports = createConfig();

--- a/test/configCases/container/module-federation/webpack.config.js
+++ b/test/configCases/container/module-federation/webpack.config.js
@@ -5,24 +5,27 @@ function createConfig() {
 		output: {
 			libraryTarget: "system"
 		},
-		//externalsType: "system",
-		module: {
-			rules: [
-				{
-					test: /\.js$/,
-					parser: {
-						system: false
-					}
-				}
-			]
-		},
 		plugins: [
 			new ModuleFederationPlugin({
 				name: "container",
 				filename: "container.js",
+				exposes: ["./other", "./self", "./dep"],
 				remotes: {
 					abc: "ABC",
-					def: "DEF"
+					def: "DEF",
+					self: "./container.js",
+					other: "./container2.js"
+				}
+			}),
+			new ModuleFederationPlugin({
+				name: "container2",
+				filename: "container2.js",
+				exposes: ["./other", "./self", "./dep"],
+				remotes: {
+					abc: "ABC",
+					def: "DEF",
+					self: "./container2.js",
+					other: "./container.js"
 				}
 			})
 		]

--- a/test/helpers/fakeSystem.js
+++ b/test/helpers/fakeSystem.js
@@ -76,7 +76,6 @@ const System = {
 	},
 	ensureExecuted: name => {
 		const m = System.registry[name];
-		console.log(m);
 		if (!m) throw new Error(`Module ${name} not registered`);
 		if (!m.executed) {
 			m.executed = true;
@@ -88,6 +87,7 @@ const System = {
 			}
 			m.mod.execute();
 		}
+
 		return m.exports;
 	}
 };

--- a/test/helpers/fakeSystem.js
+++ b/test/helpers/fakeSystem.js
@@ -12,6 +12,15 @@ const System = {
 			fn = deps;
 			deps = [];
 		}
+
+		let entry = {
+			name,
+			deps,
+			fn,
+			executed: false,
+			exports: undefined
+		};
+
 		const dynamicExport = result => {
 			if (System.registry[name] !== entry) {
 				throw new Error(`Module ${name} calls dynamicExport too late`);
@@ -26,30 +35,25 @@ const System = {
 				return Promise.resolve();
 			}
 		};
+
 		if (name in System.registry) {
 			throw new Error(`Module ${name} is already registered`);
 		}
-		const mod = fn(dynamicExport, systemContext);
+
+		System.registry[name] = entry;
+		entry.mod = fn(dynamicExport, systemContext);
 		if (deps.length > 0) {
-			if (!Array.isArray(mod.setters)) {
+			if (!Array.isArray(entry.mod.setters)) {
 				throw new Error(
 					`Module ${name} must have setters, because it has dependencies`
 				);
 			}
-			if (mod.setters.length !== deps.length) {
+			if (entry.mod.setters.length !== deps.length) {
 				throw new Error(
 					`Module ${name} has incorrect number of setters for the dependencies`
 				);
 			}
 		}
-		const entry = {
-			name,
-			deps,
-			fn,
-			mod,
-			executed: false,
-			exports: undefined
-		};
 		System.registry[name] = entry;
 	},
 	registry: undefined,
@@ -72,6 +76,7 @@ const System = {
 	},
 	ensureExecuted: name => {
 		const m = System.registry[name];
+		console.log(m);
 		if (!m) throw new Error(`Module ${name} not registered`);
 		if (!m.executed) {
 			m.executed = true;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Addressing subtask on the Module Federation Project board
<!-- Try to link to an open issue for more information. -->

https://github.com/webpack/webpack/projects/6#card-33743655
<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Defaulting options from webpack core output config
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
fix/enhancement
**Did you add tests for your changes?**
none required?
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
ModuleFederationPlugin options and their default states
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
