### PR TITLE
feat: Expose a way to set `publicPath` in `remoteEntry`

### DIFF
--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -181,12 +181,19 @@ module.exports = class ContainerEntryModule extends Module {
 				"override",
 				`Object.assign(${RuntimeGlobals.overrides}, override);`
 			)}`,
+			`var setOptions = ${runtimeTemplate.basicFunction("options", [
+				"options = options || {};",
+				`if (${RuntimeGlobals.hasOwnProperty}(options, "publicPath")) {`,
+				Template.indent([`${RuntimeGlobals.publicPath} = options.publicPath;`]),
+				"}"
+			])}`,
 			"",
 			"// This exports getters to disallow modifications",
 			`${RuntimeGlobals.definePropertyGetters}(exports, {`,
 			Template.indent([
 				`get: ${runtimeTemplate.returningFunction("get")},`,
-				`override: ${runtimeTemplate.returningFunction("override")}`
+				`override: ${runtimeTemplate.returningFunction("override")},`,
+				`setOptions: ${runtimeTemplate.returningFunction("setOptions")}`
 			]),
 			"});"
 		]);

--- a/test/configCases/container/container-entry-options/index.js
+++ b/test/configCases/container/container-entry-options/index.js
@@ -1,0 +1,29 @@
+it("should expose `setOptions` API from the container", async () => {
+	const container = __non_webpack_require__("./container-file.js");
+	expect(container).toBeTypeOf("object");
+	expect(container.setOptions).toBeTypeOf("function");
+	container.setOptions({ publicPath: "/abc/def/" });
+	const publicPathFactory = await container.get("publicPath");
+	expect(publicPathFactory).toBeTypeOf("function");
+	expect(publicPathFactory()).toBe("/abc/def/");
+});
+
+it("should not crash if no options are passed into `setOptions` API from the container", async () => {
+	const container = __non_webpack_require__("./container-file.js");
+	expect(container).toBeTypeOf("object");
+	expect(container.setOptions).toBeTypeOf("function");
+	container.setOptions();
+	const publicPathFactory = await container.get("publicPath");
+	expect(publicPathFactory).toBeTypeOf("function");
+	expect(publicPathFactory()).toBe("");
+});
+
+it("should not crash if an empty options object is passed into `setOptions` API from the container", async () => {
+	const container = __non_webpack_require__("./container-file.js");
+	expect(container).toBeTypeOf("object");
+	expect(container.setOptions).toBeTypeOf("function");
+	container.setOptions({});
+	const publicPathFactory = await container.get("publicPath");
+	expect(publicPathFactory).toBeTypeOf("function");
+	expect(publicPathFactory()).toBe("");
+});

--- a/test/configCases/container/container-entry-options/publicPath.js
+++ b/test/configCases/container/container-entry-options/publicPath.js
@@ -1,0 +1,1 @@
+module.exports = __webpack_public_path__;

--- a/test/configCases/container/container-entry-options/webpack.config.js
+++ b/test/configCases/container/container-entry-options/webpack.config.js
@@ -1,0 +1,16 @@
+const ContainerPlugin = require("../../../../lib/container/ContainerPlugin");
+
+module.exports = {
+	plugins: [
+		new ContainerPlugin({
+			name: "container",
+			filename: "container-file.js",
+			library: {
+				type: "commonjs-module"
+			},
+			exposes: {
+				publicPath: "./publicPath"
+			}
+		})
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

This change exposes a way to set `publicPath` (see https://webpack.js.org/guides/public-path/#on-the-fly) on a remote so that the remote can still be deployed separately and hosted from `/`, but when it's hosted from say `app/${appName}` (with requests still being routed to the root of the remote host, i.e. `remoteHost/` - that's where all the assets live, like JS, CSS etc.), it could be configured to make asset requests to `/app/${appName}`.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Not yet, opening this draft PR to facilitate a discussion.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

How to make use of this feature, what it enables.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

## Alternative Design

An alternative design would be to expose a mutable property called `__webpack_public_path__` instead of `setPublicPath`, in order to match the semantics of webpack core more (see https://webpack.js.org/guides/public-path/#on-the-fly). This has the benefit of it being a getter as well, without having to define a matching `getPublicPath()`.

## Open Questions

### Where to invoke

Once this feature is exposed, what would be the best place to invoke this? In mine and @sebinsua's experiments, we're dynamically loading `remoteEntry.js` in the host app code so we have a way of knowing when it's loaded, and can then check `window[remoteIdentifier] !== undefined` and call ``window[remoteIdentifier].setPublicPath(`/app/${appName}`)``.

@ScriptedAlchemy has suggested this kind of config:

```js
remotes: {
  'some-app': {
    publicPath: '/app/some-app/'
  }
}
```

### CommonJS

How would this work in CommonJS environments, would we just ignore it (likely would)?