### PR TITLE
fix(ProfilingPlugin): crash under watch mode (fix #9114)

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -5,6 +5,7 @@
 "use strict";
 
 const { Tracer } = require("chrome-trace-event");
+const path = require("path");
 const validateOptions = require("schema-utils");
 const schema = require("../../schemas/plugins/debug/ProfilingPlugin.json");
 const { dirname, mkdirpSync } = require("../util/fs");
@@ -168,10 +169,26 @@ class ProfilingPlugin {
 			name: "Profiling Plugin",
 			baseDataPath: "options"
 		});
-		this.outputPath = options.outputPath || "events.json";
+		this.tracer = null;
+		this.compilationIndex = 1;
+		this.outputPath = this.originalOutputPath =
+			options.outputPath || "events.json";
+		this.bailForFirstCompilation = true;
 	}
 
-	apply(compiler) {
+	increaseCompilationIndex() {
+		const { dir, name, ext } = path.parse(this.originalOutputPath);
+		const nextOutputPath = path.format({
+			dir,
+			name: `${name}_${this.compilationIndex}`,
+			ext
+		});
+		this.outputPath = nextOutputPath;
+		this.compilationIndex++;
+		return nextOutputPath;
+	}
+
+	createTraceAndInterceptComplier(compiler) {
 		const tracer = createTrace(
 			compiler.intermediateFileSystem,
 			this.outputPath
@@ -191,9 +208,16 @@ class ProfilingPlugin {
 			);
 		});
 
+		this.tracer = tracer;
+	}
+
+	apply(compiler) {
+		this.createTraceAndInterceptComplier(compiler);
+
 		compiler.hooks.compilation.tap(
 			pluginName,
 			(compilation, { normalModuleFactory, contextModuleFactory }) => {
+				const { tracer } = this;
 				interceptAllHooksFor(compilation, tracer, "Compilation");
 				interceptAllHooksFor(
 					normalModuleFactory,
@@ -210,6 +234,20 @@ class ProfilingPlugin {
 			}
 		);
 
+		compiler.hooks.watchRun.tapAsync(pluginName, (compiler, callback) => {
+			// Tracer for first compilation has been created above.
+			// Only create tracer on incremental build here.
+			if (this.bailForFirstCompilation) {
+				this.bailForFirstCompilation = false;
+				callback();
+				return;
+			}
+
+			this.increaseCompilationIndex();
+			this.createTraceAndInterceptComplier(compiler);
+			callback();
+		});
+
 		// We need to write out the CPU profile when we are all done.
 		compiler.hooks.done.tapAsync(
 			{
@@ -217,6 +255,7 @@ class ProfilingPlugin {
 				stage: Infinity
 			},
 			(stats, callback) => {
+				const { tracer } = this;
 				tracer.profiler.stopProfiling().then(parsedResults => {
 					if (parsedResults === undefined) {
 						tracer.profiler.destroy();

--- a/test/ProfilingPlugin.test.js
+++ b/test/ProfilingPlugin.test.js
@@ -6,7 +6,7 @@ const webpack = require("../");
 const rimraf = require("rimraf");
 
 describe("Profiling Plugin", function () {
-	jest.setTimeout(15000);
+	jest.setTimeout(30000);
 
 	it("should handle output path with folder creation", done => {
 		const outputPath = path.join(__dirname, "js/profilingPath");
@@ -29,6 +29,87 @@ describe("Profiling Plugin", function () {
 				if (!fs.existsSync(outputPath))
 					return done(new Error("Folder should be created."));
 				done();
+			});
+		});
+	});
+
+	it("should profiling on every compilation under watch mode", done => {
+		const fixturePath = path.join(
+			__dirname,
+			"fixtures",
+			"temp-watch-" + Date.now()
+		);
+		const filePath = path.join(fixturePath, "file.js");
+
+		try {
+			fs.mkdirSync(fixturePath);
+		} catch (e) {
+			// skip
+		}
+		try {
+			fs.writeFileSync(filePath, "'foo'", "utf-8");
+		} catch (e) {
+			// skip
+		}
+
+		const outputPath = path.join(__dirname, "js/profilingPathUnderWatchMode");
+		const finalPath = path.join(outputPath, "events.json");
+		const finalPath1 = path.join(outputPath, "events_1.json");
+		const finalPath2 = path.join(outputPath, "events_2.json");
+		let compilationIndex = 1;
+
+		rimraf(outputPath, () => {
+			const compiler = webpack({
+				mode: "development",
+				context: __dirname,
+				entry: filePath,
+				output: {
+					path: path.join(__dirname, "js/profilingOut")
+				},
+				plugins: [
+					new webpack.debug.ProfilingPlugin({
+						outputPath: finalPath
+					})
+				]
+			});
+
+			const watching = compiler.watch({ aggregateTimeout: 50 }, () => {});
+
+			setTimeout(() => {
+				fs.writeFileSync(filePath, "'bar'", "utf-8");
+			}, 1500);
+
+			setTimeout(() => {
+				fs.writeFileSync(filePath, "'baz'", "utf-8");
+			}, 3000);
+
+			compiler.hooks.done.tap("ProfilingUnderWatchTest", () => {
+				if (compilationIndex === 1) {
+					if (
+						!fs.existsSync(finalPath) ||
+						fs.existsSync(finalPath1) ||
+						fs.existsSync(finalPath2)
+					)
+						return done(new Error("Initial build output should be created."));
+				}
+
+				if (compilationIndex === 2) {
+					if (!fs.existsSync(finalPath1) || fs.existsSync(finalPath2))
+						return done(
+							new Error("Incremental build output should be created 1.")
+						);
+				}
+
+				if (compilationIndex === 3) {
+					if (!fs.existsSync(finalPath2))
+						return done(
+							new Error("Incremental build output should be created 2.")
+						);
+					watching.close();
+					done();
+				}
+
+				compilationIndex++;
 			});
 		});
 	});

--- a/test/ProfilingPlugin.unittest.js
+++ b/test/ProfilingPlugin.unittest.js
@@ -12,6 +12,31 @@ describe("Profiling Plugin", () => {
 		expect(plugin.outputPath).toBe(outputPath);
 	});
 
+	it("should bump output filename on incremental build", () => {
+		const outputPath1 = path.join(__dirname, "invest_in_doge_coin");
+		const outputPath2 = path.join(__dirname, "hello.world.json");
+
+		const plugin1 = new ProfilingPlugin({
+			outputPath: outputPath1
+		});
+
+		expect(plugin1.outputPath).toBe(outputPath1);
+		plugin1.increaseCompilationIndex();
+		expect(plugin1.outputPath).toBe(`${outputPath1}_1`);
+		plugin1.increaseCompilationIndex();
+		expect(plugin1.outputPath).toBe(`${outputPath1}_2`);
+
+		const plugin2 = new ProfilingPlugin({
+			outputPath: outputPath2
+		});
+
+		expect(plugin2.outputPath).toBe(outputPath2);
+		plugin2.increaseCompilationIndex();
+		expect(plugin2.outputPath).toBe(path.join(__dirname, "hello.world_1.json"));
+		plugin2.increaseCompilationIndex();
+		expect(plugin2.outputPath).toBe(path.join(__dirname, "hello.world_2.json"));
+	});
+
 	it("should handle no options", () => {
 		const plugin = new ProfilingPlugin();
 		expect(plugin.outputPath).toBe("events.json");


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

fix #9114 , allow ProfilingPlugin works under watchMode. It will keep recording until stop watching.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

bugfix

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

No, but I can add in following commits. 😀

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**What needs to be documented once your changes are merged?**

The plugin will listen to ctrl + c and throw an error to exit process (maybe there's a better way to do this) and it may affect plugins after it.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
