### PR TITLE
Guarantee order of `providedExports` between builds

### DIFF
--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -401,7 +401,9 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 
 		const stringifiedUsedExport = JSON.stringify(importedModule.usedExports);
 		const stringifiedProvidedExport = JSON.stringify(
-			importedModule.buildMeta.providedExports
+			Array.isArray(importedModule.buildMeta.providedExports)
+				? importedModule.buildMeta.providedExports.slice().sort()
+				: importedModule.buildMeta.providedExports
 		);
 		return (
 			importedModule.used + stringifiedUsedExport + stringifiedProvidedExport

--- a/test/HarmonyExportImportedSpecifierDependency.unittest.js
+++ b/test/HarmonyExportImportedSpecifierDependency.unittest.js
@@ -11,5 +11,23 @@ describe("HarmonyExportImportedSpecifierDependency", () => {
 			expect(instance.getHashValue(undefined)).toBe("");
 			expect(instance.getHashValue(null)).toBe("");
 		});
+
+		it("should sort providedExports", () => {
+			var instance = new HarmonyExportImportedSpecifierDependency();
+
+			expect(
+				instance.getHashValue({
+					used: "",
+					usedExports: "",
+					buildMeta: { providedExports: ["a", "c", "b"] }
+				})
+			).toEqual(
+				instance.getHashValue({
+					used: "",
+					usedExports: "",
+					buildMeta: { providedExports: ["a", "b", "c"] }
+				})
+			);
+		});
 	});
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This branch guarantees `providedExports` will have the same order for the same source files over multiple builds. The desired effect is more stable hashing, for fewer cache misses at the minification step.

In certain circumstances, the order of this array differs between an uncached build vs. one with cache when source files are the same. The notable difference was the location of the `default` entry: sometimes it was first, other times it was last. This led to unnecessary cache misses in terser-webpack-plugin and, subsequently, worse production build performance.

**Did you add tests for your changes?**

Yes.

**Does this PR introduce a breaking change?**

No breaking change.

**What needs to be documented once your changes are merged?**

As far as I know, nothing.
