### PR TITLE
export getNormalizedEntryStatic

### DIFF
--- a/lib/config/normalization.js
+++ b/lib/config/normalization.js
@@ -355,3 +355,4 @@ const getNormalizedOptimizationRuntimeChunk = runtimeChunk => {
 };
 
 exports.getNormalizedWebpackOptions = getNormalizedWebpackOptions;
+exports.getNormalizedEntryStatic = getNormalizedEntryStatic;

--- a/test/getNormalizedEntryStatic.unittest.js
+++ b/test/getNormalizedEntryStatic.unittest.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const { getNormalizedEntryStatic } = require("../lib/config/normalization");
+
+describe("getNormalizedEntryStatic", () => {
+	it("should return normalized entry for entry of string type", () => {
+		expect(getNormalizedEntryStatic("./index.js")).toEqual({
+			main: {
+				import: ["./index.js"]
+			}
+		});
+	});
+
+	it("should return normalized entry for entries of array type", () => {
+		expect(getNormalizedEntryStatic(["./index.js", "./client.js"])).toEqual({
+			main: {
+				import: ["./index.js", "./client.js"]
+			}
+		});
+	});
+
+	it("should return normalized entry for entries of object type", () => {
+		expect(
+			getNormalizedEntryStatic({
+				main: "./index.js",
+				client: "./client.js"
+			})
+		).toEqual({
+			main: {
+				import: ["./index.js"]
+			},
+			client: {
+				import: ["./client.js"]
+			}
+		});
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feature (I guess? Not quite sure.)

I'm developing a [tool](https://github.com/chenxsan/htmlgaga/pull/2/commits/d446fc9bbab2a0c68e5b667cee4f83c6c54da028) using the [DynamicEntryPlugin from webpack 4](https://github.com/webpack/webpack/blob/webpack-4/lib/DynamicEntryPlugin.js) which works just fine under webpack 4:

```js
new DynamicEntryPlugin(this.#cwd, () => ({ ...entries })).apply(
              compiler
            )
```
But something changed in webpack 5 requires me to [normalize my entries](https://github.com/webpack/webpack/blob/master/lib/config/normalization.js#L291) first before passing them to [DynamicEntryPlugin from webpack 5](https://github.com/webpack/webpack/blob/master/lib/DynamicEntryPlugin.js):

```js
new DynamicEntryPlugin(this.#cwd, () =>
              getNormalizedEntryStatic(entries) // <- should normalize entries first
            ).apply(compiler)
```
Unfortunately `getNormalizedEntryStatic` is not exported yet. This pull request will export it for use cases like mine.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Seems no need to add a test.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Nothing.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
