### PR TITLE
upgrade tooling, expose container plugins, fix typings tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -373,6 +373,21 @@ module.exports = mergeExports(fn, {
 		}
 	},
 
+	container: {
+		get ContainerPlugin() {
+			return require("./container/ContainerPlugin");
+		},
+		get ContainerReferencePlugin() {
+			return require("./container/ContainerReferencePlugin");
+		},
+		get ModuleFederationPlugin() {
+			return require("./container/ModuleFederationPlugin");
+		},
+		get OverridablesPlugin() {
+			return require("./container/OverridablesPlugin");
+		}
+	},
+
 	debug: {
 		get ProfilingPlugin() {
 			return require("./debug/ProfilingPlugin");

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "strip-ansi": "^6.0.0",
     "style-loader": "^1.0.0",
     "toml": "^3.0.0",
-    "tooling": "webpack/tooling#v1.2.0",
+    "tooling": "webpack/tooling#v1.5.0",
     "ts-loader": "^6.0.4",
     "typescript": "^3.6.4",
     "url-loader": "^2.1.0",

--- a/test/configCases/container/0-container-full/webpack.config.js
+++ b/test/configCases/container/0-container-full/webpack.config.js
@@ -1,5 +1,6 @@
-const ModuleFederationPlugin = require("../../../../lib/container/ModuleFederationPlugin");
+const { ModuleFederationPlugin } = require("../../../../").container;
 
+/** @type {import("../../../../").Configuration} */
 module.exports = {
 	plugins: [
 		new ModuleFederationPlugin({

--- a/test/configCases/container/1-container-full/webpack.config.js
+++ b/test/configCases/container/1-container-full/webpack.config.js
@@ -1,5 +1,6 @@
-const ModuleFederationPlugin = require("../../../../lib/container/ModuleFederationPlugin");
+const { ModuleFederationPlugin } = require("../../../../").container;
 
+/** @type {import("../../../../").Configuration} */
 module.exports = {
 	plugins: [
 		new ModuleFederationPlugin({

--- a/test/configCases/container/2-container-full/webpack.config.js
+++ b/test/configCases/container/2-container-full/webpack.config.js
@@ -1,5 +1,6 @@
-const ModuleFederationPlugin = require("../../../../lib/container/ModuleFederationPlugin");
+const { ModuleFederationPlugin } = require("../../../../").container;
 
+/** @type {import("../../../../").Configuration} */
 module.exports = {
 	plugins: [
 		new ModuleFederationPlugin({

--- a/test/configCases/container/container-entry-overridables/webpack.config.js
+++ b/test/configCases/container/container-entry-overridables/webpack.config.js
@@ -1,5 +1,6 @@
-const ContainerPlugin = require("../../../../lib/container/ContainerPlugin");
+const { ContainerPlugin } = require("../../../../").container;
 
+/** @type {import("../../../../").Configuration} */
 module.exports = {
 	plugins: [
 		new ContainerPlugin({

--- a/test/configCases/container/container-entry/webpack.config.js
+++ b/test/configCases/container/container-entry/webpack.config.js
@@ -1,5 +1,6 @@
-const ContainerPlugin = require("../../../../lib/container/ContainerPlugin");
+const { ContainerPlugin } = require("../../../../").container;
 
+/** @type {import("../../../../").Configuration} */
 module.exports = {
 	plugins: [
 		new ContainerPlugin({

--- a/test/configCases/container/container-reference-override/webpack.config.js
+++ b/test/configCases/container/container-reference-override/webpack.config.js
@@ -1,5 +1,6 @@
-const ContainerReferencePlugin = require("../../../../lib/container/ContainerReferencePlugin");
+const { ContainerReferencePlugin } = require("../../../../").container;
 
+/** @type {import("../../../../").Configuration} */
 module.exports = {
 	plugins: [
 		new ContainerReferencePlugin({

--- a/test/configCases/container/container-reference/webpack.config.js
+++ b/test/configCases/container/container-reference/webpack.config.js
@@ -1,5 +1,6 @@
-const ContainerReferencePlugin = require("../../../../lib/container/ContainerReferencePlugin");
+const { ContainerReferencePlugin } = require("../../../../").container;
 
+/** @type {import("../../../../").Configuration} */
 module.exports = {
 	plugins: [
 		new ContainerReferencePlugin({

--- a/test/configCases/container/module-federation/webpack.config.js
+++ b/test/configCases/container/module-federation/webpack.config.js
@@ -1,4 +1,4 @@
-const ModuleFederationPlugin = require("../../../../lib/container/ModuleFederationPlugin");
+const { ModuleFederationPlugin } = require("../../../../").container;
 
 function createConfig() {
 	return {

--- a/test/configCases/container/overridables/webpack.config.js
+++ b/test/configCases/container/overridables/webpack.config.js
@@ -1,5 +1,6 @@
-const OverridablesPlugin = require("../../../../lib/container/OverridablesPlugin");
+const { OverridablesPlugin } = require("../../../../").container;
 
+/** @type {import("../../../../").Configuration} */
 module.exports = {
 	plugins: [
 		new OverridablesPlugin([

--- a/types.d.ts
+++ b/types.d.ts
@@ -86,10 +86,6 @@ declare class AbstractLibraryPlugin<T> {
 		 */
 		type: ExternalsType;
 	});
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 	parseOptions(library: LibraryOptions): false | T;
 	finishEntryModule(module: Module, libraryContext: LibraryContext<T>): void;
@@ -113,19 +109,11 @@ declare class AbstractLibraryPlugin<T> {
 declare class AggressiveMergingPlugin {
 	constructor(options?: any);
 	options: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare class AggressiveSplittingPlugin {
 	constructor(options?: AggressiveSplittingPluginOptions);
 	options: AggressiveSplittingPluginOptions;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 	static wasChunkRecorded(chunk: Chunk): boolean;
 }
@@ -161,14 +149,14 @@ declare interface Argument {
 	description: string;
 	simpleType: "string" | "number" | "boolean";
 	multiple: boolean;
-	configs: Array<ArgumentConfig>;
+	configs: ArgumentConfig[];
 }
 declare interface ArgumentConfig {
 	description: string;
 	path: string;
 	multiple: boolean;
 	type: "string" | "number" | "boolean" | "path" | "enum" | "RegExp" | "reset";
-	values?: Array<any>;
+	values?: any[];
 }
 declare interface Asset {
 	/**
@@ -237,7 +225,7 @@ declare abstract class AsyncQueue<T, K, R> {
 		started: SyncHook<[T], void>;
 		result: SyncHook<[T, Error, R], void>;
 	};
-	add(item: T, callback: CallbackFunction<R>): void;
+	add(item: T, callback: CallbackAsyncQueue<R>): void;
 	invalidate(item: T): void;
 	stop(): void;
 	increaseParallelism(): void;
@@ -249,10 +237,6 @@ declare abstract class AsyncQueue<T, K, R> {
 declare class AsyncWebAssemblyModulesPlugin {
 	constructor(options?: any);
 	options: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 	renderModule(module?: any, renderContext?: any, hooks?: any): any;
 	static getCompilationHooks(
@@ -272,10 +256,6 @@ declare class BannerPlugin {
 	constructor(options: BannerPluginArgument);
 	options: BannerPluginOptions;
 	banner: (data: { hash: string; chunk: Chunk; filename: string }) => string;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 type BannerPluginArgument =
@@ -298,12 +278,12 @@ declare interface BannerPluginOptions {
 	/**
 	 * Exclude all modules matching any of these conditions.
 	 */
-	exclude?: RulesBannerPlugin;
+	exclude?: Rules;
 
 	/**
 	 * Include all modules matching any of these conditions.
 	 */
-	include?: RulesBannerPlugin;
+	include?: Rules;
 
 	/**
 	 * If true, banner will not be wrapped in a comment.
@@ -313,7 +293,7 @@ declare interface BannerPluginOptions {
 	/**
 	 * Include all modules that pass test assertion.
 	 */
-	test?: RulesBannerPlugin;
+	test?: Rules;
 }
 declare abstract class BasicEvaluatedExpression {
 	type: number;
@@ -391,7 +371,7 @@ declare class Cache {
 	constructor();
 	hooks: {
 		get: AsyncSeriesBailHook<
-			[string, Etag, Array<(result: any, stats: CallbackCache<void>) => void>],
+			[string, Etag, ((result: any, stats: CallbackCache<void>) => void)[]],
 			any
 		>;
 		store: AsyncParallelHook<[string, Etag, any]>;
@@ -426,7 +406,7 @@ declare class Cache {
 declare interface CacheGroupSource {
 	key?: string;
 	priority?: number;
-	getName?: (module?: Module, chunks?: Array<Chunk>, key?: string) => string;
+	getName?: (module?: Module, chunks?: Chunk[], key?: string) => string;
 	chunksFilter?: (chunk: Chunk) => boolean;
 	enforce?: boolean;
 	minSize: Record<string, number>;
@@ -448,6 +428,13 @@ declare interface CacheGroupsContext {
 type CacheOptions = boolean | MemoryCacheOptions | FileCacheOptions;
 type CacheOptionsNormalized = false | MemoryCacheOptions | FileCacheOptions;
 type CallExpression = SimpleCallExpression | NewExpression;
+
+/**
+ * <T>
+ */
+declare interface CallbackAsyncQueue<T> {
+	(err?: Error, result?: T): any;
+}
 declare interface CallbackCache<T> {
 	(err?: WebpackError, stats?: T): void;
 }
@@ -460,7 +447,7 @@ declare interface CallbackWebpack<T> {
 declare class Chunk {
 	constructor(name?: string);
 	id: string | number;
-	ids: Array<string | number>;
+	ids: (string | number)[];
 	debugId: number;
 	name: string;
 	idNameHints: SortableSet<string>;
@@ -482,7 +469,7 @@ declare class Chunk {
 	readonly modulesIterable: Iterable<Module>;
 	compareTo(otherChunk: Chunk): 0 | 1 | -1;
 	containsModule(module: Module): boolean;
-	getModules(): Array<Module>;
+	getModules(): Module[];
 	remove(): void;
 	moveModule(module: Module, otherChunk: Chunk): void;
 	integrate(otherChunk: Chunk): boolean;
@@ -514,12 +501,12 @@ declare class Chunk {
 	getChildIdsByOrders(
 		chunkGraph: ChunkGraph,
 		filterFn?: (c: Chunk, chunkGraph: ChunkGraph) => boolean
-	): Record<string, Array<string | number>>;
+	): Record<string, (string | number)[]>;
 	getChildIdsByOrdersMap(
 		chunkGraph: ChunkGraph,
 		includeDirectChildren?: boolean,
 		filterFn?: (c: Chunk, chunkGraph: ChunkGraph) => boolean
-	): Record<string | number, Record<string, Array<string | number>>>;
+	): Record<string | number, Record<string, (string | number)[]>>;
 }
 declare class ChunkGraph {
 	constructor(moduleGraph: ModuleGraph);
@@ -538,7 +525,7 @@ declare class ChunkGraph {
 		module: Module,
 		sortFn: (arg0: Chunk, arg1: Chunk) => 0 | 1 | -1
 	): Iterable<Chunk>;
-	getModuleChunks(module: Module): Array<Chunk>;
+	getModuleChunks(module: Module): Chunk[];
 	getNumberOfModuleChunks(module: Module): number;
 	haveModulesEqualChunks(moduleA: Module, moduleB: Module): boolean;
 	getNumberOfChunkModules(chunk: Chunk): number;
@@ -556,11 +543,11 @@ declare class ChunkGraph {
 		sourceType: string,
 		comparator: (arg0: Module, arg1: Module) => 0 | 1 | -1
 	): Iterable<Module>;
-	getChunkModules(chunk: Chunk): Array<Module>;
+	getChunkModules(chunk: Chunk): Module[];
 	getOrderedChunkModules(
 		chunk: Chunk,
 		comparator: (arg0: Module, arg1: Module) => 0 | 1 | -1
-	): Array<Module>;
+	): Module[];
 	getChunkModuleMaps(
 		chunk: Chunk,
 		filterFn: (m: Module) => boolean,
@@ -579,7 +566,7 @@ declare class ChunkGraph {
 	compareChunks(chunkA: Chunk, chunkB: Chunk): 0 | 1 | -1;
 	getChunkModulesSize(chunk: Chunk): number;
 	getChunkModulesSizes(chunk: Chunk): Record<string, number>;
-	getChunkRootModules(chunk: Chunk): Array<Module>;
+	getChunkRootModules(chunk: Chunk): Module[];
 	getChunkSize(chunk: Chunk, options?: ChunkSizeOptions): number;
 	getIntegratedChunksSize(
 		chunkA: Chunk,
@@ -605,7 +592,7 @@ declare class ChunkGraph {
 	getChunkEntryDependentChunksIterable(chunk: Chunk): Iterable<Chunk>;
 	hasChunkEntryDependentChunks(chunk: Chunk): boolean;
 	getChunkRuntimeModulesIterable(chunk: Chunk): Iterable<RuntimeModule>;
-	getChunkRuntimeModulesInOrder(chunk: Chunk): Array<RuntimeModule>;
+	getChunkRuntimeModulesInOrder(chunk: Chunk): RuntimeModule[];
 	getChunkEntryModulesWithChunkGroupIterable(
 		chunk: Chunk
 	): Iterable<[Module, Entrypoint]>;
@@ -642,12 +629,12 @@ declare class ChunkGraph {
 declare abstract class ChunkGroup {
 	groupDebugId: number;
 	options: { preloadOrder?: number; prefetchOrder?: number; name?: string };
-	chunks: Array<Chunk>;
-	origins: Array<{
+	chunks: Chunk[];
+	origins: {
 		module: Module;
 		loc: SyntheticDependencyLocation | RealDependencyLocation;
 		request: string;
-	}>;
+	}[];
 	index: number;
 
 	/**
@@ -661,8 +648,6 @@ declare abstract class ChunkGroup {
 
 	/**
 	 * returns the name of current ChunkGroup
-	 *
-	 *
 	 * sets a new name for current ChunkGroup
 	 */
 	name: string;
@@ -695,17 +680,17 @@ declare abstract class ChunkGroup {
 	removeChunk(chunk: Chunk): boolean;
 	isInitial(): boolean;
 	addChild(group: ChunkGroup): boolean;
-	getChildren(): Array<ChunkGroup>;
+	getChildren(): ChunkGroup[];
 	getNumberOfChildren(): number;
 	readonly childrenIterable: SortableSet<ChunkGroup>;
 	removeChild(group: ChunkGroup): boolean;
 	addParent(parentChunk: ChunkGroup): boolean;
-	getParents(): Array<ChunkGroup>;
+	getParents(): ChunkGroup[];
 	getNumberOfParents(): number;
 	hasParent(parent: ChunkGroup): boolean;
 	readonly parentsIterable: SortableSet<ChunkGroup>;
 	removeParent(chunkGroup: ChunkGroup): boolean;
-	getBlocks(): Array<any>;
+	getBlocks(): any[];
 	getNumberOfBlocks(): number;
 	hasBlock(block?: any): boolean;
 	readonly blocksIterable: Iterable<AsyncDependenciesBlock>;
@@ -715,7 +700,7 @@ declare abstract class ChunkGroup {
 		loc: SyntheticDependencyLocation | RealDependencyLocation,
 		request: string
 	): void;
-	getFiles(): Array<string>;
+	getFiles(): string[];
 	remove(): void;
 	sortItems(): void;
 
@@ -727,7 +712,7 @@ declare abstract class ChunkGroup {
 	getChildrenByOrders(
 		moduleGraph: ModuleGraph,
 		chunkGraph: ChunkGraph
-	): Record<string, Array<ChunkGroup>>;
+	): Record<string, ChunkGroup[]>;
 
 	/**
 	 * Sets the top-down index of a module in this ChunkGroup
@@ -768,10 +753,6 @@ declare interface ChunkHashContext {
 	 */
 	chunkGraph: ChunkGraph;
 }
-
-/**
- * Compare two Modules based on their ids for sorting
- */
 declare interface ChunkMaps {
 	hash: Record<string | number, string>;
 	contentHash: Record<string | number, Record<string, string>>;
@@ -780,14 +761,10 @@ declare interface ChunkMaps {
 declare class ChunkModuleIdRangePlugin {
 	constructor(options?: any);
 	options: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare interface ChunkModuleMaps {
-	id: Record<string | number, Array<string | number>>;
+	id: Record<string | number, (string | number)[]>;
 	hash: Record<string | number, string>;
 }
 declare interface ChunkPathData {
@@ -895,9 +872,7 @@ declare class Compilation {
 			],
 			void
 		>;
-		dependencyReferencedExports: SyncWaterfallHook<
-			[Array<Array<string>>, Dependency]
-		>;
+		dependencyReferencedExports: SyncWaterfallHook<[string[][], Dependency]>;
 		finishModules: AsyncSeriesHook<[Iterable<Module>]>;
 		finishRebuildingModule: AsyncSeriesHook<[Module]>;
 		unseal: SyncHook<[], void>;
@@ -909,8 +884,8 @@ declare class Compilation {
 		optimize: SyncHook<[], void>;
 		optimizeModules: SyncBailHook<[Iterable<Module>], any>;
 		afterOptimizeModules: SyncHook<[Iterable<Module>], void>;
-		optimizeChunks: SyncBailHook<[Iterable<Chunk>, Array<ChunkGroup>], any>;
-		afterOptimizeChunks: SyncHook<[Iterable<Chunk>, Array<ChunkGroup>], void>;
+		optimizeChunks: SyncBailHook<[Iterable<Chunk>, ChunkGroup[]], any>;
+		afterOptimizeChunks: SyncHook<[Iterable<Chunk>, ChunkGroup[]], void>;
 		optimizeTree: AsyncSeriesHook<[Iterable<Chunk>, Iterable<Module>]>;
 		afterOptimizeTree: SyncHook<[Iterable<Chunk>, Iterable<Module>], void>;
 		optimizeChunkModules: AsyncSeriesBailHook<
@@ -969,7 +944,7 @@ declare class Compilation {
 		needAdditionalSeal: SyncBailHook<[], boolean>;
 		afterSeal: AsyncSeriesHook<[]>;
 		renderManifest: SyncWaterfallHook<
-			[Array<RenderManifestEntry>, RenderManifestOptions]
+			[RenderManifestEntry[], RenderManifestOptions]
 		>;
 		fullHash: SyncHook<[Hash], void>;
 		chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext], void>;
@@ -1020,22 +995,19 @@ declare class Compilation {
 	entries: Map<string, EntryData>;
 	entrypoints: Map<string, Entrypoint>;
 	chunks: Set<Chunk>;
-	chunkGroups: Array<ChunkGroup>;
+	chunkGroups: ChunkGroup[];
 	namedChunkGroups: Map<string, ChunkGroup>;
 	namedChunks: Map<string, Chunk>;
 	modules: Set<Module>;
 	records: any;
-	additionalChunkAssets: Array<string>;
+	additionalChunkAssets: string[];
 	assets: Record<string, Source>;
 	assetsInfo: Map<string, AssetInfo>;
-	errors: Array<WebpackError>;
-	warnings: Array<WebpackError>;
-	children: Array<Compilation>;
-	logging: Map<string, Array<LogEntry>>;
-	dependencyFactories: Map<
-		{ new (...args: Array<any>): Dependency },
-		ModuleFactory
-	>;
+	errors: WebpackError[];
+	warnings: WebpackError[];
+	children: Compilation[];
+	logging: Map<string, LogEntry[]>;
+	dependencyFactories: Map<{ new (...args: any[]): Dependency }, ModuleFactory>;
 	dependencyTemplates: DependencyTemplates;
 	childrenCounters: {};
 	usedChunkIds: Set<string | number>;
@@ -1113,7 +1085,7 @@ declare class Compilation {
 	seal(callback: (err?: WebpackError) => void): void;
 	reportDependencyErrorsAndWarnings(
 		module: Module,
-		blocks: Array<DependenciesBlock>
+		blocks: DependenciesBlock[]
 	): void;
 	codeGeneration(): Map<any, any>;
 	processRuntimeRequirements(entrypoints: Iterable<Entrypoint>): void;
@@ -1133,7 +1105,7 @@ declare class Compilation {
 	 */
 	addChunk(name?: string): Chunk;
 	assignDepth(module: Module): void;
-	getDependencyReferencedExports(dependency: Dependency): Array<Array<string>>;
+	getDependencyReferencedExports(dependency: Dependency): string[][];
 	removeReasonsOfDependencyBlock(
 		module: Module,
 		block: DependenciesBlockLike
@@ -1153,11 +1125,11 @@ declare class Compilation {
 		newSourceOrFunction: Source | ((arg0: Source) => Source),
 		assetInfoUpdateOrFunction?: AssetInfo | ((arg0: AssetInfo) => AssetInfo)
 	): void;
-	getAssets(): Array<Asset>;
+	getAssets(): Asset[];
 	getAsset(name: string): Asset;
 	clearAssets(): void;
 	createModuleAssets(): void;
-	getRenderManifest(options: RenderManifestOptions): Array<RenderManifestEntry>;
+	getRenderManifest(options: RenderManifestOptions): RenderManifestEntry[];
 	createChunkAssets(callback: (err?: WebpackError) => void): void;
 	getPath(
 		filename: string | ((arg0: PathData, arg1: AssetInfo) => string),
@@ -1184,7 +1156,7 @@ declare class Compilation {
 	createChildCompiler(
 		name: string,
 		outputOptions: OutputNormalized,
-		plugins: Array<Plugin>
+		plugins: Plugin[]
 	): Compiler;
 	checkConstraints(): void;
 }
@@ -1240,7 +1212,7 @@ declare class Compiler {
 		failed: SyncHook<[Error], void>;
 		invalid: SyncHook<[string, string], void>;
 		watchClose: SyncHook<[], void>;
-		infrastructureLog: SyncBailHook<[string, string, Array<any>], true>;
+		infrastructureLog: SyncBailHook<[string, string, any[]], true>;
 		environment: SyncHook<[], void>;
 		afterEnvironment: SyncHook<[], void>;
 		afterPlugins: SyncHook<[Compiler], void>;
@@ -1279,11 +1251,7 @@ declare class Compiler {
 	watch(watchOptions: WatchOptions, handler: CallbackFunction<Stats>): Watching;
 	run(callback: CallbackFunction<Stats>): void;
 	runAsChild(
-		callback: (
-			err?: Error,
-			entries?: Array<Chunk>,
-			compilation?: Compilation
-		) => any
+		callback: (err?: Error, entries?: Chunk[], compilation?: Compilation) => any
 	): void;
 	purgeInputFileSystem(): void;
 	emitAssets(compilation: Compilation, callback: CallbackFunction<void>): void;
@@ -1294,7 +1262,7 @@ declare class Compiler {
 		compilerName: string,
 		compilerIndex: number,
 		outputOptions: OutputNormalized,
-		plugins: Array<WebpackPluginInstance>
+		plugins: WebpackPluginInstance[]
 	): Compiler;
 	isChild(): boolean;
 	createCompilation(): Compilation;
@@ -1336,7 +1304,7 @@ declare interface Configuration {
 	/**
 	 * References to other configurations to depend on.
 	 */
-	dependencies?: Array<string>;
+	dependencies?: string[];
 
 	/**
 	 * A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
@@ -1416,9 +1384,10 @@ declare interface Configuration {
 	/**
 	 * Add additional plugins to the compiler.
 	 */
-	plugins?: Array<
-		((this: Compiler, compiler: Compiler) => void) | WebpackPluginInstance
-	>;
+	plugins?: (
+		| ((this: Compiler, compiler: Compiler) => void)
+		| WebpackPluginInstance
+	)[];
 
 	/**
 	 * Capture timing information for each module.
@@ -1470,6 +1439,50 @@ declare interface Configuration {
 	 */
 	watchOptions?: WatchOptions;
 }
+declare class ContainerPlugin {
+	constructor(options: ContainerPluginOptions);
+	options: {
+		overridables: any[] | { [index: string]: any };
+		name: string;
+		library: LibraryOptions;
+		filename: string;
+		exposes: [string, string][];
+	};
+	apply(compiler: Compiler): void;
+}
+declare interface ContainerPluginOptions {
+	/**
+	 * A map of modules you wish to expose.
+	 */
+	exposes?: any[] | { [index: string]: any };
+
+	/**
+	 * The filename for this container relative path inside the `output.path` directory.
+	 */
+	filename?: string;
+
+	/**
+	 * Options for library.
+	 */
+	library?: LibraryOptions;
+
+	/**
+	 * The name for this container.
+	 */
+	name: string;
+
+	/**
+	 * An object for requests to override from host to this container.
+	 */
+	overridables?: any[] | { [index: string]: any };
+}
+declare class ContainerReferencePlugin {
+	constructor(options?: any);
+	remoteType: any;
+	remotes: [string, string][];
+	overrides: [string, string][];
+	apply(compiler: Compiler): void;
+}
 declare class ContextExclusionPlugin {
 	constructor(negativeMatcher: RegExp);
 	negativeMatcher: RegExp;
@@ -1483,8 +1496,8 @@ declare abstract class ContextModuleFactory extends ModuleFactory {
 	hooks: Readonly<{
 		beforeResolve: AsyncSeriesWaterfallHook<[any]>;
 		afterResolve: AsyncSeriesWaterfallHook<[any]>;
-		contextModuleFiles: SyncWaterfallHook<[Array<string>]>;
-		alternatives: AsyncSeriesWaterfallHook<[Array<any>]>;
+		contextModuleFiles: SyncWaterfallHook<[string[]]>;
+		alternatives: AsyncSeriesWaterfallHook<[any[]]>;
 	}>;
 	resolverFactory: any;
 	resolveDependencies(fs?: any, options?: any, callback?: any): any;
@@ -1529,8 +1542,8 @@ declare class DelegatedPlugin {
 	apply(compiler: Compiler): void;
 }
 declare abstract class DependenciesBlock {
-	dependencies: Array<Dependency>;
-	blocks: Array<AsyncDependenciesBlock>;
+	dependencies: Dependency[];
+	blocks: AsyncDependenciesBlock[];
 
 	/**
 	 * Adds a DependencyBlock to DependencyBlock relationship.
@@ -1549,8 +1562,8 @@ declare abstract class DependenciesBlock {
 	deserialize(__0: { read: any }): void;
 }
 declare interface DependenciesBlockLike {
-	dependencies: Array<Dependency>;
-	blocks: Array<AsyncDependenciesBlock>;
+	dependencies: Dependency[];
+	blocks: AsyncDependenciesBlock[];
 }
 declare class Dependency {
 	constructor();
@@ -1564,7 +1577,7 @@ declare class Dependency {
 	/**
 	 * Returns list of exports referenced by this dependency
 	 */
-	getReferencedExports(moduleGraph: ModuleGraph): Array<Array<string>>;
+	getReferencedExports(moduleGraph: ModuleGraph): string[][];
 	getCondition(moduleGraph: ModuleGraph): () => boolean;
 
 	/**
@@ -1575,12 +1588,16 @@ declare class Dependency {
 	/**
 	 * Returns warnings
 	 */
-	getWarnings(moduleGraph: ModuleGraph): Array<WebpackError>;
+	getWarnings(moduleGraph: ModuleGraph): WebpackError[];
 
 	/**
 	 * Returns errors
 	 */
-	getErrors(moduleGraph: ModuleGraph): Array<WebpackError>;
+	getErrors(moduleGraph: ModuleGraph): WebpackError[];
+
+	/**
+	 * Update the hash
+	 */
 	updateHash(hash: Hash, chunkGraph: ChunkGraph): void;
 
 	/**
@@ -1591,9 +1608,9 @@ declare class Dependency {
 	deserialize(__0: { read: any }): void;
 	module: any;
 	readonly disconnect: any;
-	static NO_EXPORTS_REFERENCED: Array<any>;
-	static NS_OBJECT_REFERENCED: Array<Array<any>>;
-	static DEFAULT_EXPORT_REFERENCED: Array<Array<string>>;
+	static NO_EXPORTS_REFERENCED: any[];
+	static NS_OBJECT_REFERENCED: any[][];
+	static DEFAULT_EXPORT_REFERENCED: string[][];
 }
 declare abstract class DependencyTemplate {
 	apply(
@@ -1636,14 +1653,12 @@ declare interface DependencyTemplateContext {
 	/**
 	 * mutable array of init fragments for the current module
 	 */
-	initFragments: Array<InitFragment>;
+	initFragments: InitFragment[];
 }
 declare abstract class DependencyTemplates {
-	get(dependency: {
-		new (...args: Array<any>): Dependency;
-	}): DependencyTemplate;
+	get(dependency: { new (...args: any[]): Dependency }): DependencyTemplate;
 	set(
-		dependency: { new (...args: Array<any>): Dependency },
+		dependency: { new (...args: any[]): Dependency },
 		dependencyTemplate: DependencyTemplate
 	): void;
 	updateHash(part: string): void;
@@ -1653,19 +1668,11 @@ declare abstract class DependencyTemplates {
 declare class DeterministicChunkIdsPlugin {
 	constructor(options?: any);
 	options: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare class DeterministicModuleIdsPlugin {
 	constructor(options?: any);
 	options: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 
@@ -1702,10 +1709,6 @@ declare class DllPlugin {
 		 */
 		type?: string;
 	};
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 
@@ -1759,7 +1762,7 @@ type DllReferencePluginOptions =
 			/**
 			 * Extensions used to resolve modules in the dll bundle (only used when using 'scope').
 			 */
-			extensions?: Array<string>;
+			extensions?: string[];
 			/**
 			 * An object containing content and name or a string to the absolute path of the JSON manifest to be loaded upon compilation.
 			 */
@@ -1793,7 +1796,7 @@ type DllReferencePluginOptions =
 			/**
 			 * Extensions used to resolve modules in the dll bundle (only used when using 'scope').
 			 */
-			extensions?: Array<string>;
+			extensions?: string[];
 			/**
 			 * The name where the dll is exposed (external name).
 			 */
@@ -1824,7 +1827,7 @@ declare interface DllReferencePluginOptionsContent {
 		/**
 		 * Information about the provided exports of the module.
 		 */
-		exports?: true | Array<string>;
+		exports?: true | string[];
 		/**
 		 * Module ID.
 		 */
@@ -1873,23 +1876,19 @@ declare interface Effect {
 declare class EnableLibraryPlugin {
 	constructor(type: ExternalsType);
 	type: ExternalsType;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 	static checkEnabled(compiler: Compiler, type: ExternalsType): void;
 }
 type Entry =
 	| string
-	| (() => string | EntryObject | [string, string] | Promise<EntryStatic>)
+	| (() => string | EntryObject | [string, ...string[]] | Promise<EntryStatic>)
 	| EntryObject
-	| [string, string];
+	| [string, ...string[]];
 declare interface EntryData {
 	/**
 	 * dependencies of the entrypoint
 	 */
-	dependencies: Array<EntryDependency>;
+	dependencies: EntryDependency[];
 
 	/**
 	 * options of the entrypoint
@@ -1908,7 +1907,7 @@ declare interface EntryDescription {
 	/**
 	 * The entrypoints that the current entrypoint depend on. They must be loaded when this entrypoint is loaded.
 	 */
-	dependOn?: string | [string, string];
+	dependOn?: string | [string, ...string[]];
 
 	/**
 	 * Specifies the name of each output file on disk. You must **not** specify an absolute path here! The `output.path` option determines the location on disk the files are written to, filename is used solely for naming the individual files.
@@ -1933,7 +1932,7 @@ declare interface EntryDescriptionNormalized {
 	/**
 	 * The entrypoints that the current entrypoint depend on. They must be loaded when this entrypoint is loaded.
 	 */
-	dependOn?: [string, string];
+	dependOn?: [string, ...string[]];
 
 	/**
 	 * Specifies the name of each output file on disk. You must **not** specify an absolute path here! The `output.path` option determines the location on disk the files are written to, filename is used solely for naming the individual files.
@@ -1943,14 +1942,14 @@ declare interface EntryDescriptionNormalized {
 	/**
 	 * Module(s) that are loaded upon startup. The last one is exported.
 	 */
-	import: [string, string];
+	import: [string, ...string[]];
 
 	/**
 	 * Options for library.
 	 */
 	library?: LibraryOptions;
 }
-type EntryItem = string | [string, string];
+type EntryItem = string | [string, ...string[]];
 type EntryNormalized =
 	| (() => Promise<EntryStaticNormalized>)
 	| EntryStaticNormalized;
@@ -1959,7 +1958,7 @@ type EntryNormalized =
  * Multiple entry bundles are created. The key is the entry name. The value can be a string, an array or an entry description object.
  */
 declare interface EntryObject {
-	[index: string]: string | [string, string] | EntryDescription;
+	[index: string]: string | [string, ...string[]] | EntryDescription;
 }
 declare class EntryPlugin {
 	/**
@@ -1984,10 +1983,6 @@ declare class EntryPlugin {
 				EntryDescriptionNormalized,
 				"filename" | "dependOn" | "library"
 		  >);
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 	static createDependency(
 		entry: string,
@@ -1999,7 +1994,7 @@ declare class EntryPlugin {
 			  >)
 	): EntryDependency;
 }
-type EntryStatic = string | EntryObject | [string, string];
+type EntryStatic = string | EntryObject | [string, ...string[]];
 
 /**
  * Multiple entry bundles are created. The key is the entry name. The value is an entry description object.
@@ -2021,13 +2016,9 @@ declare abstract class Entrypoint extends ChunkGroup {
 	getRuntimeChunk(): Chunk;
 }
 declare class EnvironmentPlugin {
-	constructor(...keys: Array<any>);
-	keys: Array<any>;
+	constructor(...keys: any[]);
+	keys: any[];
 	defaultValues: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare interface Etag {
@@ -2038,10 +2029,6 @@ declare class EvalDevToolModulePlugin {
 	namespace: any;
 	sourceUrlComment: any;
 	moduleFilenameTemplate: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare class EvalSourceMapDevToolPlugin {
@@ -2050,10 +2037,6 @@ declare class EvalSourceMapDevToolPlugin {
 	moduleFilenameTemplate: any;
 	namespace: any;
 	options: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 
@@ -2161,7 +2144,7 @@ declare interface ExportSpec {
 	/**
 	 * nested exports
 	 */
-	exports?: Array<string | ExportSpec>;
+	exports?: (string | ExportSpec)[];
 
 	/**
 	 * when reexported: from which module
@@ -2171,7 +2154,7 @@ declare interface ExportSpec {
 	/**
 	 * when reexported: from which export
 	 */
-	export?: Array<string>;
+	export?: string[];
 }
 declare class ExportsInfo {
 	constructor();
@@ -2184,17 +2167,17 @@ declare class ExportsInfo {
 	setHasUseInfo(): void;
 	getExportInfo(name: string): ExportInfo;
 	getReadOnlyExportInfo(name: string): ExportInfo;
-	getNestedExportsInfo(name?: Array<string>): ExportsInfo;
+	getNestedExportsInfo(name?: string[]): ExportsInfo;
 	setUnknownExportsProvided(canMangle?: boolean): boolean;
 	setUsedInUnknownWay(): boolean;
 	setAllKnownExportsUsed(): boolean;
 	setUsedForSideEffectsOnly(): boolean;
 	isUsed(): boolean;
 	getUsedExports(): any;
-	getProvidedExports(): true | Array<string>;
-	isExportProvided(name: string | Array<string>): boolean;
-	isExportUsed(name: string | Array<string>): 0 | 1 | 2 | 3 | 4;
-	getUsedName(name: string | Array<string>): string | false | Array<string>;
+	getProvidedExports(): true | string[];
+	isExportProvided(name: string | string[]): boolean;
+	isExportUsed(name: string | string[]): 0 | 1 | 2 | 3 | 4;
+	getUsedName(name: string | string[]): string | false | string[];
 	getRestoreProvidedData(): any;
 	restoreProvided(__0: {
 		otherProvided: any;
@@ -2206,7 +2189,7 @@ declare interface ExportsSpec {
 	/**
 	 * exported names, true for unknown exports or null for no exports
 	 */
-	exports: true | Array<string | ExportSpec>;
+	exports: true | (string | ExportSpec)[];
 
 	/**
 	 * can the export be renamed (defaults to true)
@@ -2216,7 +2199,7 @@ declare interface ExportsSpec {
 	/**
 	 * module on which the result depends on
 	 */
-	dependencies?: Array<Module>;
+	dependencies?: Module[];
 }
 type Expression =
 	| UnaryExpression
@@ -2246,13 +2229,7 @@ type Expression =
 type ExternalItem =
 	| string
 	| RegExp
-	| {
-			[index: string]:
-				| string
-				| boolean
-				| Array<string>
-				| { [index: string]: any };
-	  }
+	| { [index: string]: string | boolean | string[] | { [index: string]: any } }
 	| ((
 			context: string,
 			request: string,
@@ -2260,7 +2237,7 @@ type ExternalItem =
 	  ) => void);
 declare class ExternalModule extends Module {
 	constructor(request?: any, type?: any, userRequest?: any);
-	request: string | Array<string> | Record<string, string | Array<string>>;
+	request: string | string[] | Record<string, string | string[]>;
 	externalType: string;
 	userRequest: string;
 	getSourceString(
@@ -2272,14 +2249,8 @@ declare class ExternalModule extends Module {
 type Externals =
 	| string
 	| RegExp
-	| Array<ExternalItem>
-	| {
-			[index: string]:
-				| string
-				| boolean
-				| Array<string>
-				| { [index: string]: any };
-	  }
+	| ExternalItem[]
+	| { [index: string]: string | boolean | string[] | { [index: string]: any } }
 	| ((
 			context: string,
 			request: string,
@@ -2289,10 +2260,6 @@ declare class ExternalsPlugin {
 	constructor(type?: any, externals?: any);
 	type: any;
 	externals: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 type ExternalsType =
@@ -2315,7 +2282,7 @@ type ExternalsType =
 declare interface FactorizeModuleOptions {
 	currentProfile: ModuleProfile;
 	factory: ModuleFactory;
-	dependencies: Array<Dependency>;
+	dependencies: Dependency[];
 	originModule: Module;
 	context?: string;
 }
@@ -2328,10 +2295,6 @@ declare interface FallbackCacheGroup {
 declare class FetchCompileWasmPlugin {
 	constructor(options?: any);
 	options: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 
@@ -2342,7 +2305,7 @@ declare interface FileCacheOptions {
 	/**
 	 * Dependencies the build depends on (in multiple categories, default categories: 'defaultWebpack').
 	 */
-	buildDependencies?: { [index: string]: Array<string> };
+	buildDependencies?: { [index: string]: string[] };
 
 	/**
 	 * Base directory for the cache (defaults to node_modules/.cache/webpack).
@@ -2372,12 +2335,12 @@ declare interface FileCacheOptions {
 	/**
 	 * List of paths that are managed by a package manager and contain a version or hash in it's path so all files are immutable.
 	 */
-	immutablePaths?: Array<string>;
+	immutablePaths?: string[];
 
 	/**
 	 * List of paths that are managed by a package manager and can be trusted to not be modified otherwise.
 	 */
-	managedPaths?: Array<string>;
+	managedPaths?: string[];
 
 	/**
 	 * Name for the cache. Different names will lead to different coexisting caches.
@@ -2408,10 +2371,10 @@ declare abstract class FileSystemInfo {
 	contextHashQueue: AsyncQueue<string, string, string>;
 	managedItemQueue: AsyncQueue<string, string, string>;
 	managedItemDirectoryQueue: AsyncQueue<string, string, Set<string>>;
-	managedPaths: Array<string>;
-	managedPathsWithSlash: Array<string>;
-	immutablePaths: Array<string>;
-	immutablePathsWithSlash: Array<string>;
+	managedPaths: string[];
+	managedPathsWithSlash: string[];
+	immutablePaths: string[];
+	immutablePathsWithSlash: string[];
 	addFileTimestamps(map: Map<string, FileSystemInfoEntry | "ignore">): void;
 	addContextTimestamps(map: Map<string, FileSystemInfoEntry | "ignore">): void;
 	getFileTimestamp(
@@ -2460,10 +2423,6 @@ declare abstract class FileSystemInfo {
 	getDeprecatedFileTimestamps(): Map<any, any>;
 	getDeprecatedContextTimestamps(): Map<any, any>;
 }
-
-/**
- * istanbul ignore next
- */
 declare interface FileSystemInfoEntry {
 	safeTime: number;
 	timestamp?: number;
@@ -2474,7 +2433,7 @@ type FilterItemTypes = string | RegExp | ((value: string) => boolean);
 type FilterTypes =
 	| string
 	| RegExp
-	| Array<FilterItemTypes>
+	| FilterItemTypes[]
 	| ((value: string) => boolean);
 declare interface GenerateContext {
 	/**
@@ -2516,12 +2475,12 @@ declare class Generator {
 	static byType(map?: any): ByTypeGenerator;
 }
 declare interface HMRJavascriptParserHooks {
-	hotAcceptCallback: SyncBailHook<[any, Array<string>], void>;
-	hotAcceptWithoutCallback: SyncBailHook<[any, Array<string>], void>;
+	hotAcceptCallback: SyncBailHook<[any, string[]], void>;
+	hotAcceptWithoutCallback: SyncBailHook<[any, string[]], void>;
 }
 declare interface HandleModuleCreationOptions {
 	factory: ModuleFactory;
-	dependencies: Array<Dependency>;
+	dependencies: Dependency[];
 	originModule: Module;
 	context?: string;
 
@@ -2573,10 +2532,6 @@ declare class HotModuleReplacementPlugin {
 	options: any;
 	multiStep: any;
 	fullBuildTimeout: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 	static getParserHooks(parser: JavascriptParser): HMRJavascriptParserHooks;
 }
@@ -2589,10 +2544,6 @@ declare class IgnorePlugin {
 	 * and "contextRegExp" have to match.
 	 */
 	checkIgnore(resolveData: ResolveData): false;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 type IgnorePluginOptions =
@@ -2624,7 +2575,7 @@ declare interface InfrastructureLogging {
 		| string
 		| boolean
 		| RegExp
-		| Array<FilterItemTypes>
+		| FilterItemTypes[]
 		| ((value: string) => boolean);
 
 	/**
@@ -2649,7 +2600,7 @@ declare interface InputFileSystem {
 	) => void;
 	readdir: (
 		arg0: string,
-		arg1: (arg0: NodeJS.ErrnoException, arg1: Array<string>) => void
+		arg1: (arg0: NodeJS.ErrnoException, arg1: string[]) => void
 	) => void;
 	stat: (
 		arg0: string,
@@ -2676,10 +2627,6 @@ declare interface IntermediateFileSystemExtras {
 declare class JavascriptModulesPlugin {
 	constructor(options?: {});
 	options: {};
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 	renderModule(
 		module: Module,
@@ -2698,11 +2645,7 @@ declare class JavascriptModulesPlugin {
 	renderBootstrap(
 		renderContext: RenderBootstrapContext,
 		hooks: CompilationHooksJavascriptModulesPlugin
-	): {
-		header: Array<string>;
-		startup: Array<string>;
-		allowInlineStartup: boolean;
-	};
+	): { header: string[]; startup: string[]; allowInlineStartup: boolean };
 	renderRequire(
 		renderContext: RenderBootstrapContext,
 		hooks: CompilationHooksJavascriptModulesPlugin
@@ -2880,36 +2823,36 @@ declare abstract class JavascriptParser extends Parser {
 		rename: HookMap<SyncBailHook<[Expression], boolean | void>>;
 		assign: HookMap<SyncBailHook<[AssignmentExpression], boolean | void>>;
 		assignMemberChain: HookMap<
-			SyncBailHook<[AssignmentExpression, Array<string>], boolean | void>
+			SyncBailHook<[AssignmentExpression, string[]], boolean | void>
 		>;
 		typeof: HookMap<SyncBailHook<[Expression], boolean | void>>;
 		importCall: SyncBailHook<[Expression], boolean | void>;
 		topLevelAwait: SyncBailHook<[Expression], boolean | void>;
 		call: HookMap<SyncBailHook<[Expression], boolean | void>>;
 		callMemberChain: HookMap<
-			SyncBailHook<[Expression, Array<string>], boolean | void>
+			SyncBailHook<[Expression, string[]], boolean | void>
 		>;
 		memberChainOfCallMemberChain: HookMap<
 			SyncBailHook<
-				[Expression, Array<string>, CallExpression, Array<string>],
+				[Expression, string[], CallExpression, string[]],
 				boolean | void
 			>
 		>;
 		callMemberChainOfCallMemberChain: HookMap<
 			SyncBailHook<
-				[Expression, Array<string>, CallExpression, Array<string>],
+				[Expression, string[], CallExpression, string[]],
 				boolean | void
 			>
 		>;
 		new: HookMap<SyncBailHook<[Expression], boolean | void>>;
 		expression: HookMap<SyncBailHook<[Expression], boolean | void>>;
 		expressionMemberChain: HookMap<
-			SyncBailHook<[Expression, Array<string>], boolean | void>
+			SyncBailHook<[Expression, string[]], boolean | void>
 		>;
 		expressionConditionalOperator: SyncBailHook<[Expression], boolean | void>;
 		expressionLogicalOperator: SyncBailHook<[Expression], boolean | void>;
-		program: SyncBailHook<[Program, Array<Comment>], boolean | void>;
-		finish: SyncBailHook<[Program, Array<Comment>], boolean | void>;
+		program: SyncBailHook<[Program, Comment[]], boolean | void>;
+		finish: SyncBailHook<[Program, Comment[]], boolean | void>;
 	}>;
 	options: any;
 	sourceType: "module" | "script" | "auto";
@@ -3012,14 +2955,14 @@ declare abstract class JavascriptParser extends Parser {
 	): void;
 	walkThisExpression(expression?: any): void;
 	walkIdentifier(expression?: any): void;
-	callHooksForExpression(hookMap: any, expr: any, ...args: Array<any>): any;
+	callHooksForExpression(hookMap: any, expr: any, ...args: any[]): any;
 	callHooksForExpressionWithFallback<T, R>(
 		hookMap: HookMap<SyncBailHook<T, R>>,
 		expr: MemberExpression,
 		fallback: (
 			arg0: string,
 			arg1: string | ScopeInfo | VariableInfo,
-			arg2: () => Array<string>
+			arg2: () => string[]
 		) => any,
 		defined: (arg0: string) => any,
 		...args: AsArray<T>
@@ -3079,7 +3022,7 @@ declare abstract class JavascriptParser extends Parser {
 	extractMemberExpressionChain(
 		expression: MemberExpression
 	): {
-		members: Array<string>;
+		members: string[];
 		object:
 			| UnaryExpression
 			| ThisExpression
@@ -3112,29 +3055,29 @@ declare abstract class JavascriptParser extends Parser {
 	): { name: string; info: string | VariableInfo };
 	getMemberExpressionInfo(
 		expression: MemberExpression,
-		allowedTypes: Array<"expression" | "call">
+		allowedTypes: ("expression" | "call")[]
 	):
 		| {
 				type: "call";
 				call: CallExpression;
 				calleeName: string;
 				rootInfo: string | VariableInfo;
-				getCalleeMembers: () => Array<string>;
+				getCalleeMembers: () => string[];
 				name: string;
-				getMembers: () => Array<string>;
+				getMembers: () => string[];
 		  }
 		| {
 				type: "expression";
 				rootInfo: string | VariableInfo;
 				name: string;
-				getMembers: () => Array<string>;
+				getMembers: () => string[];
 		  };
 	getNameForExpression(
 		expression: MemberExpression
 	): {
 		name: string;
 		rootInfo: string | ScopeInfo | VariableInfo;
-		getMembers: () => Array<string>;
+		getMembers: () => string[];
 	};
 }
 declare interface JsonpCompilationPluginHooks {
@@ -3145,10 +3088,6 @@ declare interface JsonpCompilationPluginHooks {
 type JsonpScriptType = false | "module" | "text/javascript";
 declare class JsonpTemplatePlugin {
 	constructor();
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 	static getCompilationHooks(
 		compilation: Compilation
@@ -3196,13 +3135,9 @@ declare interface LibIdentOptions {
 declare class LibManifestPlugin {
 	constructor(options?: any);
 	options: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
-type Library = string | Array<string> | LibraryCustomUmdObject | LibraryOptions;
+type Library = string | string[] | LibraryCustomUmdObject | LibraryOptions;
 declare interface LibraryContext<T> {
 	compilation: Compilation;
 	options: T;
@@ -3250,10 +3185,10 @@ declare interface LibraryCustomUmdObject {
 	/**
 	 * Name of the property exposed globally by a UMD library.
 	 */
-	root?: string | Array<string>;
+	root?: string | string[];
 }
-type LibraryExport = string | Array<string>;
-type LibraryName = string | Array<string> | LibraryCustomUmdObject;
+type LibraryExport = string | string[];
+type LibraryName = string | string[] | LibraryCustomUmdObject;
 
 /**
  * Options for library.
@@ -3299,19 +3234,11 @@ declare class LibraryTemplatePlugin {
 		auxiliaryComment: AuxiliaryComment;
 		export: LibraryExport;
 	};
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare class LimitChunkCountPlugin {
 	constructor(options?: LimitChunkCountPluginOptions);
 	options: LimitChunkCountPluginOptions;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 
@@ -3351,10 +3278,6 @@ declare interface LoaderItem {
 declare class LoaderOptionsPlugin {
 	constructor(options?: LoaderOptionsPluginOptions);
 	options: LoaderOptionsPluginOptions;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 
@@ -3390,17 +3313,13 @@ declare interface LoaderOptionsPluginOptions {
 declare class LoaderTargetPlugin {
 	constructor(target: string);
 	target: string;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare interface LogEntry {
 	type: string;
-	args: Array<any>;
+	args: any[];
 	time: number;
-	trace?: Array<string>;
+	trace?: string[];
 }
 declare const MEASURE_END_OPERATION: unique symbol;
 declare const MEASURE_START_OPERATION: unique symbol;
@@ -3489,12 +3408,12 @@ declare interface MemoryCacheOptions {
 	/**
 	 * List of paths that are managed by a package manager and contain a version or hash in it's path so all files are immutable.
 	 */
-	immutablePaths?: Array<string>;
+	immutablePaths?: string[];
 
 	/**
 	 * List of paths that are managed by a package manager and can be trusted to not be modified otherwise.
 	 */
-	managedPaths?: Array<string>;
+	managedPaths?: string[];
 
 	/**
 	 * In memory caching.
@@ -3503,19 +3422,11 @@ declare interface MemoryCacheOptions {
 }
 declare class MemoryCachePlugin {
 	constructor();
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare class MinChunkSizePlugin {
 	constructor(options: MinChunkSizePluginOptions);
 	options: MinChunkSizePluginOptions;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 
@@ -3551,7 +3462,7 @@ declare class Module extends DependenciesBlock {
 	factoryMeta: any;
 	buildMeta: KnownBuildMeta & Record<string, any>;
 	buildInfo: any;
-	presentationalDependencies: Array<Dependency>;
+	presentationalDependencies: Dependency[];
 	id: string | number;
 	readonly hash: string;
 	readonly renderedHash: string;
@@ -3561,15 +3472,16 @@ declare class Module extends DependenciesBlock {
 	depth: number;
 	issuer: Module;
 	readonly usedExports: boolean | SortableSet<string>;
-	readonly optimizationBailout: Array<
-		string | ((requestShortener: RequestShortener) => string)
-	>;
+	readonly optimizationBailout: (
+		| string
+		| ((requestShortener: RequestShortener) => string)
+	)[];
 	readonly optional: boolean;
 	addChunk(chunk?: any): boolean;
 	removeChunk(chunk?: any): void;
 	isInChunk(chunk?: any): boolean;
 	isEntryModule(): boolean;
-	getChunks(): Array<Chunk>;
+	getChunks(): Chunk[];
 	getNumberOfChunks(): number;
 	readonly chunksIterable: Iterable<Chunk>;
 	isProvided(exportName: string): boolean;
@@ -3613,12 +3525,12 @@ declare class Module extends DependenciesBlock {
 	isModuleUsed(moduleGraph: ModuleGraph): boolean;
 	isExportUsed(
 		moduleGraph: ModuleGraph,
-		exportName: string | Array<string>
+		exportName: string | string[]
 	): 0 | 1 | 2 | 3 | 4;
 	getUsedName(
 		moduleGraph: ModuleGraph,
-		exportName: string | Array<string>
-	): string | false | Array<string>;
+		exportName: string | string[]
+	): string | false | string[];
 	needBuild(
 		context: NeedBuildContext,
 		callback: (arg0: WebpackError, arg1: boolean) => void
@@ -3660,10 +3572,6 @@ declare class Module extends DependenciesBlock {
 declare class ModuleConcatenationPlugin {
 	constructor(options?: any);
 	options: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare abstract class ModuleDependency extends Dependency {
@@ -3681,7 +3589,7 @@ declare interface ModuleFactoryCreateData {
 	contextInfo: ModuleFactoryCreateDataContextInfo;
 	resolveOptions?: any;
 	context: string;
-	dependencies: Array<Dependency>;
+	dependencies: Dependency[];
 }
 declare interface ModuleFactoryCreateDataContextInfo {
 	issuer: string;
@@ -3695,6 +3603,11 @@ declare interface ModuleFactoryResult {
 	fileDependencies?: Set<string>;
 	contextDependencies?: Set<string>;
 	missingDependencies?: Set<string>;
+}
+declare class ModuleFederationPlugin {
+	constructor(options?: any);
+	options: any;
+	apply(compiler: Compiler): void;
 }
 declare class ModuleGraph {
 	constructor();
@@ -3737,9 +3650,9 @@ declare class ModuleGraph {
 	setIssuerIfUnset(module: Module, issuer: Module): void;
 	getOptimizationBailout(
 		module: Module
-	): Array<string | ((requestShortener: RequestShortener) => string)>;
-	getProvidedExports(module: Module): true | Array<string>;
-	isExportProvided(module: Module, exportName: string | Array<string>): boolean;
+	): (string | ((requestShortener: RequestShortener) => string))[];
+	getProvidedExports(module: Module): true | string[];
+	isExportProvided(module: Module, exportName: string | string[]): boolean;
 	getExportsInfo(module: Module): ExportsInfo;
 	getExportInfo(module: Module, exportName: string): ExportInfo;
 	getReadOnlyExportInfo(module: Module, exportName: string): ExportInfo;
@@ -3808,7 +3721,7 @@ declare interface ModuleOptions {
 	/**
 	 * An array of rules applied by default for modules.
 	 */
-	defaultRules?: Array<RuleSetRule>;
+	defaultRules?: RuleSetRule[];
 
 	/**
 	 * Enable warnings for full dynamic dependencies.
@@ -3837,12 +3750,12 @@ declare interface ModuleOptions {
 		| string
 		| Function
 		| RegExp
-		| [string | Function | RegExp, string | Function | RegExp];
+		| [string | Function | RegExp, ...(string | Function | RegExp)[]];
 
 	/**
 	 * An array of rules applied for modules.
 	 */
-	rules?: Array<RuleSetRule>;
+	rules?: RuleSetRule[];
 
 	/**
 	 * Emit errors instead of warnings when imported names don't exist in imported module.
@@ -3946,21 +3859,19 @@ declare abstract class ModuleTemplate {
 	readonly runtimeTemplate: any;
 }
 declare class MultiCompiler {
-	constructor(compilers: Array<Compiler> | Record<string, Compiler>);
+	constructor(compilers: Compiler[] | Record<string, Compiler>);
 	hooks: Readonly<{
 		done: SyncHook<[MultiStats], void>;
 		invalid: MultiHook<SyncHook<[string, string], void>>;
 		run: MultiHook<AsyncSeriesHook<[Compiler]>>;
 		watchClose: SyncHook<[], void>;
 		watchRun: MultiHook<AsyncSeriesHook<[Compiler]>>;
-		infrastructureLog: MultiHook<
-			SyncBailHook<[string, string, Array<any>], true>
-		>;
+		infrastructureLog: MultiHook<SyncBailHook<[string, string, any[]], true>>;
 	}>;
-	compilers: Array<Compiler>;
-	dependencies: WeakMap<Compiler, Array<string>>;
+	compilers: Compiler[];
+	dependencies: WeakMap<Compiler, string[]>;
 	running: boolean;
-	readonly options: Array<WebpackOptionsNormalized>;
+	readonly options: WebpackOptionsNormalized[];
 	readonly outputPath: string;
 	inputFileSystem: InputFileSystem;
 	outputFileSystem: OutputFileSystem;
@@ -3968,15 +3879,15 @@ declare class MultiCompiler {
 		OutputFileSystem &
 		IntermediateFileSystemExtras;
 	getInfrastructureLogger(name?: any): WebpackLogger;
-	setDependencies(compiler: Compiler, dependencies: Array<string>): void;
+	setDependencies(compiler: Compiler, dependencies: string[]): void;
 	validateDependencies(callback: CallbackFunction<MultiStats>): boolean;
 	runWithDependencies(
-		compilers: Array<Compiler>,
+		compilers: Compiler[],
 		fn: (compiler: Compiler, callback: CallbackFunction<MultiStats>) => any,
 		callback: CallbackFunction<MultiStats>
 	): void;
 	watch(
-		watchOptions: WatchOptions | Array<WatchOptions>,
+		watchOptions: WatchOptions | WatchOptions[],
 		handler: CallbackFunction<MultiStats>
 	): MultiWatching;
 	run(callback: CallbackFunction<MultiStats>): void;
@@ -3984,23 +3895,23 @@ declare class MultiCompiler {
 	close(callback: CallbackFunction<void>): void;
 }
 declare abstract class MultiStats {
-	stats: Array<Stats>;
+	stats: Stats[];
 	hash: string;
 	hasErrors(): boolean;
 	hasWarnings(): boolean;
 	toJson(
 		options?: any
 	): {
-		children: Array<any>;
+		children: any[];
 		version: any;
 		hash: string;
-		errors: Array<any>;
-		warnings: Array<any>;
+		errors: any[];
+		warnings: any[];
 	};
 	toString(options?: any): string;
 }
 declare abstract class MultiWatching {
-	watchings: Array<Watching>;
+	watchings: Watching[];
 	compiler: MultiCompiler;
 	invalidate(): void;
 	suspend(): void;
@@ -4011,27 +3922,15 @@ declare class NamedChunkIdsPlugin {
 	constructor(options?: any);
 	delimiter: any;
 	context: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare class NamedModuleIdsPlugin {
 	constructor(options?: any);
 	options: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare class NaturalModuleIdsPlugin {
 	constructor();
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare interface NeedBuildContext {
@@ -4049,10 +3948,6 @@ type Node = false | NodeOptions;
 declare class NodeEnvironmentPlugin {
 	constructor(options?: any);
 	options: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 
@@ -4068,10 +3963,6 @@ declare interface NodeOptions {
 declare class NodeTemplatePlugin {
 	constructor(options?: any);
 	asyncChunkLoading: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare class NormalModule extends Module {
@@ -4095,7 +3986,7 @@ declare class NormalModule extends Module {
 		/**
 		 * list of loaders
 		 */
-		loaders: Array<LoaderItem>;
+		loaders: LoaderItem[];
 		/**
 		 * path + query of the real resource
 		 */
@@ -4125,7 +4016,7 @@ declare class NormalModule extends Module {
 	generator: Generator;
 	resource: string;
 	matchResource: string;
-	loaders: Array<LoaderItem>;
+	loaders: LoaderItem[];
 	error: WebpackError;
 	createSourceForAsset(
 		context: string,
@@ -4229,10 +4120,6 @@ declare interface ObjectSerializerContext {
 declare class OccurrenceChunkIdsPlugin {
 	constructor(options?: OccurrenceChunkIdsPluginOptions);
 	options: OccurrenceChunkIdsPluginOptions;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 
@@ -4250,10 +4137,6 @@ declare interface OccurrenceChunkIdsPluginOptions {
 declare class OccurrenceModuleIdsPlugin {
 	constructor(options?: OccurrenceModuleIdsPluginOptions);
 	options: OccurrenceModuleIdsPluginOptions;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 
@@ -4327,9 +4210,10 @@ declare interface Optimization {
 	/**
 	 * Minimizer(s) to use for minimizing the output.
 	 */
-	minimizer?: Array<
-		((this: Compiler, compiler: Compiler) => void) | WebpackPluginInstance
-	>;
+	minimizer?: (
+		| ((this: Compiler, compiler: Compiler) => void)
+		| WebpackPluginInstance
+	)[];
 
 	/**
 	 * Define the algorithm to choose module ids (natural: numeric ids in order of usage, named: readable ids for better debugging, hashed: (deprecated) short hashes as ids for better long term caching, deterministic: numeric hash ids for better long term caching, size: numeric ids focused on minimal initial download size, false: no algorithm used, as custom one can be provided via plugin).
@@ -4666,7 +4550,7 @@ declare interface Output {
 	/**
 	 * List of library types enabled for use by entry points.
 	 */
-	enabledLibraryTypes?: Array<ExternalsType>;
+	enabledLibraryTypes?: ExternalsType[];
 
 	/**
 	 * Specifies the name of each output file on disk. You must **not** specify an absolute path here! The `output.path` option determines the location on disk the files are written to, filename is used solely for naming the individual files.
@@ -4870,7 +4754,7 @@ declare interface OutputNormalized {
 	/**
 	 * List of library types enabled for use by entry points.
 	 */
-	enabledLibraryTypes?: Array<ExternalsType>;
+	enabledLibraryTypes?: ExternalsType[];
 
 	/**
 	 * Specifies the name of each output file on disk. You must **not** specify an absolute path here! The `output.path` option determines the location on disk the files are written to, filename is used solely for naming the individual files.
@@ -4981,6 +4865,11 @@ declare interface OutputNormalized {
 	 * The filename of WebAssembly modules as relative path inside the `output.path` directory.
 	 */
 	webassemblyModuleFilename?: string;
+}
+declare class OverridablesPlugin {
+	constructor(options?: any);
+	overridables: [string, string][];
+	apply(compiler: Compiler): void;
 }
 declare class Parser {
 	constructor();
@@ -5097,7 +4986,7 @@ declare interface ProfilingPluginOptions {
 declare class ProgressPlugin {
 	constructor(options: ProgressPluginArgument);
 	profile: boolean;
-	handler: (percentage: number, msg: string, ...args: Array<string>) => void;
+	handler: (percentage: number, msg: string, ...args: string[]) => void;
 	modulesCount: number;
 	dependenciesCount: number;
 	showEntries: boolean;
@@ -5108,7 +4997,7 @@ declare class ProgressPlugin {
 	apply(compiler: Compiler | MultiCompiler): void;
 	static getReporter(
 		compiler: Compiler
-	): (p: number, ...args: Array<string>) => void;
+	): (p: number, ...args: string[]) => void;
 	static defaultOptions: {
 		profile: boolean;
 		modulesCount: number;
@@ -5121,7 +5010,7 @@ declare class ProgressPlugin {
 }
 type ProgressPluginArgument =
 	| ProgressPluginOptions
-	| ((percentage: number, msg: string, ...args: Array<string>) => void);
+	| ((percentage: number, msg: string, ...args: string[]) => void);
 
 /**
  * Options object for the ProgressPlugin.
@@ -5150,7 +5039,7 @@ declare interface ProgressPluginOptions {
 	/**
 	 * Function that executes for every progress step.
 	 */
-	handler?: (percentage: number, msg: string, ...args: Array<string>) => void;
+	handler?: (percentage: number, msg: string, ...args: string[]) => void;
 
 	/**
 	 * Show modules count in progress message.
@@ -5173,12 +5062,8 @@ declare interface ProgressPluginOptions {
 	profile?: boolean;
 }
 declare class ProvidePlugin {
-	constructor(definitions: Record<string, string | Array<string>>);
-	definitions: Record<string, string | Array<string>>;
-
-	/**
-	 * Apply the plugin
-	 */
+	constructor(definitions: Record<string, string | string[]>);
+	definitions: Record<string, string | string[]>;
 	apply(compiler: Compiler): void;
 }
 type PublicPath =
@@ -5187,10 +5072,6 @@ type PublicPath =
 declare class ReadFileCompileWasmPlugin {
 	constructor(options?: any);
 	options: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare interface RealDependencyLocation {
@@ -5207,7 +5088,7 @@ type RecursiveArrayOrRecord =
 	| RegExp
 	| RuntimeValue
 	| { [index: string]: RecursiveArrayOrRecord }
-	| Array<RecursiveArrayOrRecord>;
+	| RecursiveArrayOrRecord[];
 declare interface RenderBootstrapContext {
 	/**
 	 * the chunk
@@ -5350,22 +5231,18 @@ declare abstract class ReplaceSource extends Source {
 	insert(pos: number, newValue: string, name: string): void;
 	getName(): string;
 	original(): string;
-	getReplacements(): Array<{
+	getReplacements(): {
 		start: number;
 		end: number;
 		content: string;
 		insertIndex: number;
 		name: string;
-	}>;
+	}[];
 }
 declare abstract class RequestShortener {
 	contextify: (arg0: string) => string;
 	shorten(request: string): string;
 }
-
-/**
- * istanbul ignore next
- */
 declare interface ResolveBuildDependenciesResult {
 	/**
 	 * list of files
@@ -5417,7 +5294,7 @@ declare interface ResolveData {
 	resolveOptions: any;
 	context: string;
 	request: string;
-	dependencies: Array<ModuleDependency>;
+	dependencies: ModuleDependency[];
 	createData: any;
 	fileDependencies: LazySet<string>;
 	missingDependencies: LazySet<string>;
@@ -5432,11 +5309,11 @@ declare interface ResolveOptions {
 	 * Redirect module requests.
 	 */
 	alias?:
-		| Array<{
+		| {
 				/**
 				 * New request.
 				 */
-				alias: string | false | Array<string>;
+				alias: string | false | string[];
 				/**
 				 * Request to be redirected.
 				 */
@@ -5445,13 +5322,13 @@ declare interface ResolveOptions {
 				 * Redirect only exact matching request.
 				 */
 				onlyModule?: boolean;
-		  }>
-		| { [index: string]: string | false | Array<string> };
+		  }[]
+		| { [index: string]: string | false | string[] };
 
 	/**
 	 * Fields in the description file (usually package.json) which are used to redirect requests inside the module.
 	 */
-	aliasFields?: Array<string | Array<string>>;
+	aliasFields?: (string | string[])[];
 
 	/**
 	 * Enable caching of successfully resolved requests (cache entries are revalidated).
@@ -5471,7 +5348,7 @@ declare interface ResolveOptions {
 	/**
 	 * Filenames used to find a description file (like a package.json).
 	 */
-	descriptionFiles?: Array<string>;
+	descriptionFiles?: string[];
 
 	/**
 	 * Enforce using one of the extensions from the extensions option.
@@ -5481,7 +5358,7 @@ declare interface ResolveOptions {
 	/**
 	 * Extensions added to the request when trying to find the file.
 	 */
-	extensions?: Array<string>;
+	extensions?: string[];
 
 	/**
 	 * Filesystem for the resolver.
@@ -5491,22 +5368,22 @@ declare interface ResolveOptions {
 	/**
 	 * Field names from the description file (package.json) which are used to find the default entry point.
 	 */
-	mainFields?: Array<string | Array<string>>;
+	mainFields?: (string | string[])[];
 
 	/**
 	 * Filenames used to find the default entry point if there is no description file or main field.
 	 */
-	mainFiles?: Array<string>;
+	mainFiles?: string[];
 
 	/**
 	 * Folder names or directory paths where to find modules.
 	 */
-	modules?: Array<string>;
+	modules?: string[];
 
 	/**
 	 * Plugins for the resolver.
 	 */
-	plugins?: Array<ResolvePluginInstance>;
+	plugins?: ResolvePluginInstance[];
 
 	/**
 	 * Custom resolver.
@@ -5574,7 +5451,7 @@ declare interface RuleSet {
 	/**
 	 * execute the rule set
 	 */
-	exec: (arg0?: any) => Array<Effect>;
+	exec: (arg0?: any) => Effect[];
 }
 type RuleSetCondition =
 	| string
@@ -5583,18 +5460,18 @@ type RuleSetCondition =
 			/**
 			 * Logical AND.
 			 */
-			and?: Array<RuleSetCondition>;
+			and?: RuleSetCondition[];
 			/**
 			 * Logical NOT.
 			 */
-			not?: Array<RuleSetCondition>;
+			not?: RuleSetCondition[];
 			/**
 			 * Logical OR.
 			 */
-			or?: Array<RuleSetCondition>;
+			or?: RuleSetCondition[];
 	  }
 	| ((value: string) => boolean)
-	| Array<RuleSetCondition>;
+	| RuleSetCondition[];
 type RuleSetConditionAbsolute =
 	| string
 	| RegExp
@@ -5602,18 +5479,18 @@ type RuleSetConditionAbsolute =
 			/**
 			 * Logical AND.
 			 */
-			and?: Array<RuleSetConditionAbsolute>;
+			and?: RuleSetConditionAbsolute[];
 			/**
 			 * Logical NOT.
 			 */
-			not?: Array<RuleSetConditionAbsolute>;
+			not?: RuleSetConditionAbsolute[];
 			/**
 			 * Logical OR.
 			 */
-			or?: Array<RuleSetConditionAbsolute>;
+			or?: RuleSetConditionAbsolute[];
 	  }
 	| ((value: string) => boolean)
-	| Array<RuleSetConditionAbsolute>;
+	| RuleSetConditionAbsolute[];
 type RuleSetLoaderOptions = string | { [index: string]: any };
 
 /**
@@ -5658,7 +5535,7 @@ declare interface RuleSetRule {
 	/**
 	 * Only execute the first matching rule in this array.
 	 */
-	oneOf?: Array<RuleSetRule>;
+	oneOf?: RuleSetRule[];
 
 	/**
 	 * Shortcut for use.options.
@@ -5693,7 +5570,7 @@ declare interface RuleSetRule {
 	/**
 	 * Match and execute these rules when this rule is matched.
 	 */
-	rules?: Array<RuleSetRule>;
+	rules?: RuleSetRule[];
 
 	/**
 	 * Flags a module as with or without side effects.
@@ -5717,14 +5594,14 @@ declare interface RuleSetRule {
 }
 type RuleSetUse =
 	| string
-	| Array<RuleSetUseItem>
+	| RuleSetUseItem[]
 	| ((data: {
 			resource: string;
 			realResource: string;
 			resourceQuery: string;
 			issuer: string;
 			compiler: string;
-	  }) => Array<RuleSetUseItem>)
+	  }) => RuleSetUseItem[])
 	| {
 			/**
 			 * Unique loader options identifier.
@@ -5756,7 +5633,7 @@ type RuleSetUse =
 					options?: RuleSetLoaderOptions;
 			  }
 			| __TypeWebpackOptions
-			| Array<RuleSetUseItem>);
+			| RuleSetUseItem[]);
 type RuleSetUseItem =
 	| string
 	| {
@@ -5774,15 +5651,10 @@ type RuleSetUseItem =
 			options?: RuleSetLoaderOptions;
 	  }
 	| __TypeWebpackOptions;
-type RulesBannerPlugin = string | RegExp | Array<string | RegExp>;
-type RulesSourceMapDevToolPlugin = string | RegExp | Array<string | RegExp>;
+type Rules = string | RegExp | (string | RegExp)[];
 declare class RuntimeChunkPlugin {
 	constructor(options?: any);
 	options: any;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare class RuntimeModule extends Module {
@@ -6056,7 +5928,7 @@ declare abstract class RuntimeTemplate {
 		/**
 		 * the export name
 		 */
-		exportName: string | Array<string>;
+		exportName: string | string[];
 		/**
 		 * the origin module
 		 */
@@ -6084,7 +5956,7 @@ declare abstract class RuntimeTemplate {
 		/**
 		 * init fragments will be added here
 		 */
-		initFragments: Array<InitFragment>;
+		initFragments: InitFragment[];
 		/**
 		 * if set, will be filled with runtime requirements
 		 */
@@ -6142,10 +6014,6 @@ declare abstract class Serializer {
 }
 declare class SideEffectsFlagPlugin {
 	constructor();
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 	static moduleHasSideEffects(
 		moduleName?: any,
@@ -6153,10 +6021,6 @@ declare class SideEffectsFlagPlugin {
 		cache?: any
 	): any;
 }
-
-/**
- * istanbul ignore next
- */
 declare interface Snapshot {
 	startTime?: number;
 	fileTimestamps?: Map<string, FileSystemInfoEntry>;
@@ -6183,7 +6047,7 @@ declare abstract class SortableSet<T> extends Set<T> {
 	 * Get data from cache (ignoring sorting)
 	 */
 	getFromUnorderedCache<R>(fn: (arg0: SortableSet<T>) => R): R;
-	toJSON(): Array<T>;
+	toJSON(): T[];
 
 	/**
 	 * Iterates over values in the set.
@@ -6235,7 +6099,7 @@ declare class SourceMapDevToolPlugin {
 	options: SourceMapDevToolPluginOptions;
 
 	/**
-	 * Apply the plugin
+	 * Apply compiler
 	 */
 	apply(compiler: Compiler): void;
 }
@@ -6253,7 +6117,7 @@ declare interface SourceMapDevToolPluginOptions {
 	/**
 	 * Exclude modules that match the given value from source map generation.
 	 */
-	exclude?: RulesSourceMapDevToolPlugin;
+	exclude?: Rules;
 
 	/**
 	 * Generator string or function to create identifiers of modules for the 'sources' array in the SourceMap used only if 'moduleFilenameTemplate' would result in a conflict.
@@ -6273,7 +6137,7 @@ declare interface SourceMapDevToolPluginOptions {
 	/**
 	 * Include source maps for module paths that match the given value.
 	 */
-	include?: RulesSourceMapDevToolPlugin;
+	include?: Rules;
 
 	/**
 	 * Indicates whether SourceMaps from loaders should be used (defaults to true).
@@ -6308,7 +6172,7 @@ declare interface SourceMapDevToolPluginOptions {
 	/**
 	 * Include source maps for modules based on their extension (defaults to .js and .css).
 	 */
-	test?: RulesSourceMapDevToolPlugin;
+	test?: Rules;
 }
 declare interface SourcePosition {
 	line: number;
@@ -6329,29 +6193,25 @@ declare interface SplitChunksOptions {
 	getCacheGroups: (
 		module: Module,
 		context: CacheGroupsContext
-	) => Array<CacheGroupSource>;
-	getName: (module?: Module, chunks?: Array<Chunk>, key?: string) => string;
+	) => CacheGroupSource[];
+	getName: (module?: Module, chunks?: Chunk[], key?: string) => string;
 	fallbackCacheGroup: FallbackCacheGroup;
 }
 declare class SplitChunksPlugin {
 	constructor(options?: OptimizationSplitChunksOptions);
 	options: SplitChunksOptions;
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare abstract class StackedMap<K, V> {
 	map: Map<K, V | typeof TOMBSTONE | typeof UNDEFINED_MARKER>;
-	stack: Array<Map<K, V | typeof TOMBSTONE | typeof UNDEFINED_MARKER>>;
+	stack: Map<K, V | typeof TOMBSTONE | typeof UNDEFINED_MARKER>[];
 	set(item: K, value: V): void;
 	delete(item: K): void;
 	has(item: K): boolean;
 	get(item: K): V;
-	asArray(): Array<K>;
+	asArray(): K[];
 	asSet(): Set<K>;
-	asPairArray(): Array<[K, V]>;
+	asPairArray(): [K, V][];
 	asMap(): Map<K, V>;
 	readonly size: number;
 	createChild(): StackedMap<K, V>;
@@ -6394,15 +6254,15 @@ declare abstract class StatsFactory {
 		extract: HookMap<SyncBailHook<[any, any, any], any>>;
 		filter: HookMap<SyncBailHook<[any, any, number, number], any>>;
 		sort: HookMap<
-			SyncBailHook<[Array<(arg0?: any, arg1?: any) => number>, any], any>
+			SyncBailHook<[((arg0?: any, arg1?: any) => number)[], any], any>
 		>;
 		filterSorted: HookMap<SyncBailHook<[any, any, number, number], any>>;
 		sortResults: HookMap<
-			SyncBailHook<[Array<(arg0?: any, arg1?: any) => number>, any], any>
+			SyncBailHook<[((arg0?: any, arg1?: any) => number)[], any], any>
 		>;
 		filterResults: HookMap<SyncBailHook<any, any>>;
-		merge: HookMap<SyncBailHook<[Array<any>, any], any>>;
-		result: HookMap<SyncBailHook<[Array<any>, any], any>>;
+		merge: HookMap<SyncBailHook<[any[], any], any>>;
+		result: HookMap<SyncBailHook<[any[], any], any>>;
 		getItemName: HookMap<SyncBailHook<[any, any], any>>;
 		getItemFactory: HookMap<SyncBailHook<[any, any], any>>;
 	}>;
@@ -6557,7 +6417,7 @@ declare interface StatsOptions {
 		| string
 		| boolean
 		| RegExp
-		| Array<FilterItemTypes>
+		| FilterItemTypes[]
 		| ((value: string) => boolean);
 
 	/**
@@ -6572,7 +6432,7 @@ declare interface StatsOptions {
 		| string
 		| boolean
 		| RegExp
-		| Array<FilterItemTypes>
+		| FilterItemTypes[]
 		| ((value: string) => boolean);
 
 	/**
@@ -6597,7 +6457,7 @@ declare interface StatsOptions {
 		| string
 		| boolean
 		| RegExp
-		| Array<FilterItemTypes>
+		| FilterItemTypes[]
 		| ((value: string) => boolean);
 
 	/**
@@ -6712,11 +6572,11 @@ declare interface StatsOptions {
 }
 declare abstract class StatsPrinter {
 	hooks: Readonly<{
-		sortElements: HookMap<SyncBailHook<[Array<string>, any], any>>;
-		printElements: HookMap<SyncBailHook<[Array<PrintedElement>, any], any>>;
-		sortItems: HookMap<SyncBailHook<[Array<any>, any], any>>;
+		sortElements: HookMap<SyncBailHook<[string[], any], any>>;
+		printElements: HookMap<SyncBailHook<[PrintedElement[], any], any>>;
+		sortItems: HookMap<SyncBailHook<[any[], any], any>>;
 		getItemName: HookMap<SyncBailHook<[any, any], any>>;
-		printItems: HookMap<SyncBailHook<[Array<string>, any], any>>;
+		printItems: HookMap<SyncBailHook<[string[], any], any>>;
 		print: HookMap<SyncBailHook<[any, any], any>>;
 		result: HookMap<SyncWaterfallHook<[string, any]>>;
 	}>;
@@ -6761,24 +6621,22 @@ declare class Template {
 	static toPath(str: string): string;
 	static numberToIdentifier(n: number): string;
 	static numberToIdentifierContinuation(n: number): string;
-	static indent(s: string | Array<string>): string;
-	static prefix(s: string | Array<string>, prefix: string): string;
-	static asString(str: string | Array<string>): string;
-	static getModulesArrayBounds(
-		modules: Array<WithId>
-	): false | [number, number];
+	static indent(s: string | string[]): string;
+	static prefix(s: string | string[], prefix: string): string;
+	static asString(str: string | string[]): string;
+	static getModulesArrayBounds(modules: WithId[]): false | [number, number];
 	static renderChunkModules(
 		renderContext: RenderContextModuleTemplate,
-		modules: Array<Module>,
+		modules: Module[],
 		renderModule: (arg0: Module) => Source,
 		prefix?: string
 	): Source;
 	static renderRuntimeModules(
-		runtimeModules: Array<RuntimeModule>,
+		runtimeModules: RuntimeModule[],
 		renderContext: RenderContextModuleTemplate
 	): Source;
 	static renderChunkRuntimeModules(
-		runtimeModules: Array<RuntimeModule>,
+		runtimeModules: RuntimeModule[],
 		renderContext: RenderContextModuleTemplate
 	): Source;
 	static NUMBER_OF_IDENTIFIER_START_CHARS: number;
@@ -6803,11 +6661,7 @@ declare abstract class VariableInfo {
 }
 declare class WatchIgnorePlugin {
 	constructor(options: WatchIgnorePluginOptions);
-	paths: [string | RegExp, string | RegExp];
-
-	/**
-	 * Apply the plugin
-	 */
+	paths: [string | RegExp, ...(string | RegExp)[]];
 	apply(compiler: Compiler): void;
 }
 
@@ -6820,7 +6674,7 @@ declare interface WatchIgnorePluginOptions {
 	/**
 	 * A list of RegExps or absolute paths to directories or files that should be ignored.
 	 */
-	paths: [string | RegExp, string | RegExp];
+	paths: [string | RegExp, ...(string | RegExp)[]];
 }
 
 /**
@@ -6835,7 +6689,7 @@ declare interface WatchOptions {
 	/**
 	 * Ignore some files from watching (glob pattern).
 	 */
-	ignored?: string | Array<string>;
+	ignored?: string | string[];
 
 	/**
 	 * Enable polling mode for watching.
@@ -6851,7 +6705,7 @@ declare abstract class Watching {
 	startTime: number;
 	invalid: boolean;
 	handler: CallbackFunction<Stats>;
-	callbacks: Array<CallbackFunction<void>>;
+	callbacks: CallbackFunction<void>[];
 	closed: boolean;
 	suspended: boolean;
 	watchOptions: {
@@ -6862,7 +6716,7 @@ declare abstract class Watching {
 		/**
 		 * Ignore some files from watching (glob pattern).
 		 */
-		ignored?: string | Array<string>;
+		ignored?: string | string[];
 		/**
 		 * Enable polling mode for watching.
 		 */
@@ -6888,10 +6742,6 @@ declare abstract class Watching {
 }
 declare class WebWorkerTemplatePlugin {
 	constructor();
-
-	/**
-	 * Apply the plugin
-	 */
 	apply(compiler: Compiler): void;
 }
 declare interface WebpackError extends Error {
@@ -6906,18 +6756,18 @@ declare interface WebpackError extends Error {
 }
 declare abstract class WebpackLogger {
 	getChildLogger: (arg0: string | (() => string)) => WebpackLogger;
-	error(...args: Array<any>): void;
-	warn(...args: Array<any>): void;
-	info(...args: Array<any>): void;
-	log(...args: Array<any>): void;
-	debug(...args: Array<any>): void;
-	assert(assertion: any, ...args: Array<any>): void;
+	error(...args: any[]): void;
+	warn(...args: any[]): void;
+	info(...args: any[]): void;
+	log(...args: any[]): void;
+	debug(...args: any[]): void;
+	assert(assertion: any, ...args: any[]): void;
 	trace(): void;
 	clear(): void;
-	status(...args: Array<any>): void;
-	group(...args: Array<any>): void;
-	groupCollapsed(...args: Array<any>): void;
-	groupEnd(...args: Array<any>): void;
+	status(...args: any[]): void;
+	group(...args: any[]): void;
+	groupCollapsed(...args: any[]): void;
+	groupEnd(...args: any[]): void;
 	profile(label?: any): void;
 	profileEnd(label?: any): void;
 	time(label?: any): void;
@@ -6961,7 +6811,7 @@ declare interface WebpackOptionsNormalized {
 	/**
 	 * References to other configurations to depend on.
 	 */
-	dependencies?: Array<string>;
+	dependencies?: string[];
 
 	/**
 	 * Options for the webpack-dev-server.
@@ -7046,9 +6896,10 @@ declare interface WebpackOptionsNormalized {
 	/**
 	 * Add additional plugins to the compiler.
 	 */
-	plugins: Array<
-		((this: Compiler, compiler: Compiler) => void) | WebpackPluginInstance
-	>;
+	plugins: (
+		| ((this: Compiler, compiler: Compiler) => void)
+		| WebpackPluginInstance
+	)[];
 
 	/**
 	 * Capture timing information for each module.
@@ -7136,20 +6987,20 @@ type __TypeWebpackOptions = (data: {}) =>
 			options?: RuleSetLoaderOptions;
 	  }
 	| __TypeWebpackOptions
-	| Array<RuleSetUseItem>;
+	| RuleSetUseItem[];
 declare function exports(
 	options: Configuration,
 	callback?: CallbackWebpack<Stats>
 ): Compiler;
 declare function exports(
-	options: Array<Configuration>,
+	options: Configuration[],
 	callback?: CallbackWebpack<MultiStats>
 ): MultiCompiler;
 declare namespace exports {
 	export const webpack: {
 		(options: Configuration, callback?: CallbackWebpack<Stats>): Compiler;
 		(
-			options: Array<Configuration>,
+			options: Configuration[],
 			callback?: CallbackWebpack<MultiStats>
 		): MultiCompiler;
 	};
@@ -7167,9 +7018,9 @@ declare namespace exports {
 				| number
 				| boolean
 				| RegExp
-				| Array<string | number | boolean | RegExp>
+				| (string | number | boolean | RegExp)[]
 			>
-		) => Array<Problem>;
+		) => Problem[];
 	}
 	export namespace ModuleFilenameHelpers {
 		export let ALL_LOADERS_RESOURCE: string;
@@ -7318,6 +7169,14 @@ declare namespace exports {
 	export namespace library {
 		export { AbstractLibraryPlugin, EnableLibraryPlugin };
 	}
+	export namespace container {
+		export {
+			ContainerPlugin,
+			ContainerReferencePlugin,
+			ModuleFederationPlugin,
+			OverridablesPlugin
+		};
+	}
 	export namespace debug {
 		export { ProfilingPlugin };
 	}
@@ -7357,7 +7216,7 @@ declare namespace exports {
 			export let concatComparators: <T>(
 				c1: (arg0: T, arg1: T) => 0 | 1 | -1,
 				c2: (arg0: T, arg1: T) => 0 | 1 | -1,
-				...cRest: Array<(arg0: T, arg1: T) => 0 | 1 | -1>
+				...cRest: ((arg0: T, arg1: T) => 0 | 1 | -1)[]
 			) => (arg0: T, arg1: T) => 0 | 1 | -1;
 			export let compareSelect: <T, R>(
 				getter: (input: T) => R,
@@ -7379,7 +7238,7 @@ declare namespace exports {
 		}
 		export namespace serialization {
 			export let register: (
-				Constructor: { new (...params: Array<any>): any },
+				Constructor: { new (...params: any[]): any },
 				request: string,
 				name: string,
 				serializer: ObjectSerializer
@@ -7389,7 +7248,7 @@ declare namespace exports {
 				loader: (arg0: string) => boolean
 			) => void;
 			export let registerNotSerializable: (Constructor: {
-				new (...params: Array<any>): any;
+				new (...params: any[]): any;
 			}) => void;
 			export let NOT_SERIALIZABLE: {};
 			export let buffersSerializer: Serializer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6765,9 +6765,9 @@ toml@^3.0.0:
   resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
   integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
 
-tooling@webpack/tooling#v1.2.0:
-  version "1.0.0"
-  resolved "https://codeload.github.com/webpack/tooling/tar.gz/aafba4458d969ae360c1d2d30d0a132f5c0815d8"
+tooling@webpack/tooling#v1.5.0:
+  version "1.5.0"
+  resolved "https://codeload.github.com/webpack/tooling/tar.gz/6e3fdd36b63a2904031fd00140aaf9bcc0911989"
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     commondir "^1.0.1"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
fix merge issues
expose plugins
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
* The following plugins need to be documented:
  * `webpack.container.OverridablesPlugin`
  * `webpack.container.ContainerPlugin`
  * `webpack.container.ContainerReferencePlugin`
  * `webpack.container.ModuleFederationPlugin`
* Containers as general concept need to be documented
  * separate compilation
  * container entry is a manifest to load exposed modules
  * But the compilation could be configured to have additional intialization logic when the container entry is loaded.
  * exposed modules are loaded async
  * overrides allow to replace modules in the container
  * overridable modules will only load when not overriden
  * overriding does not have an effect when overridable module is used in initial chunks
  * the consumer can override with an async reference to a module, which will only be loaded when the container uses the overridable module
  * exposed modules will expose all exports. No Tree-Shaking or other optimization on module boundary
* Container References
  * Uses the externals concept to point to a container
  * Because module are loaded async from the container, references to modules in containers can not be used in initial chunks.
  * Despite that they can be used with normal import or require when there is a code-split point somewhere between the container reference and the entry point.
  * The path in the container is not checked at compile-time. It's not known at compile-time.
  * Errors while loading the container or the module of the container will reject the Promise of `import()` in ESM resp. let the `require()` throw an Error in CJS.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
