### PR TITLE
feat(chunk): provide chunkId in script tag

### DIFF
--- a/lib/web/JsonpTemplatePlugin.js
+++ b/lib/web/JsonpTemplatePlugin.js
@@ -138,6 +138,7 @@ class JsonpTemplatePlugin {
 						? `script.type = ${JSON.stringify(jsonpScriptType)};`
 						: "",
 					"script.charset = 'utf-8';",
+					`script.setAttribute("chunkid", ${chunkId});`,
 					`script.timeout = ${chunkLoadTimeout / 1000};`,
 					`if (${RuntimeGlobals.scriptNonce}) {`,
 					Template.indent(


### PR DESCRIPTION
I am facing a lot of chunkloaderrors and want to manually fetch the chunk url again in order to get more network information like the status code.

Since the `jsonpScriptSrc` function is not available in my app code, I need a place to retrieve the url of a specific chunk.