### PR TITLE
Fix TS 3.9 & 4.0 compile errors

### DIFF
--- a/lib/AbstractMethodError.js
+++ b/lib/AbstractMethodError.js
@@ -23,7 +23,9 @@ function Message() {
 	this.stack = undefined;
 	Error.captureStackTrace(this);
 	/** @type {RegExpMatchArray} */
-	const match = this.stack.split("\n")[3].match(CURRENT_METHOD_REGEXP);
+	const match = /** @type {*} */ (this.stack)
+		.split("\n")[3]
+		.match(CURRENT_METHOD_REGEXP);
 
 	this.message = match && match[1] ? createMessage(match[1]) : createMessage();
 }

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -64,7 +64,7 @@ const makeSerializable = require("./util/makeSerializable");
 
 /**
  * @callback ResolveDependenciesCallback
- * @param {Error=} err
+ * @param {WebpackError=} err
  * @param {ContextElementDependency[]} dependencies
  */
 

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -302,7 +302,7 @@ class ExternalModule extends Module {
 			const exportsInfo = chunkGraph.moduleGraph.getExportsInfo(this);
 			for (const exportInfo of exportsInfo.orderedExports) {
 				hash.update(exportInfo.name);
-				hash.update(exportInfo.getUsedName() || "");
+				hash.update(/** @type {string} */ (exportInfo.getUsedName()) || "");
 			}
 		}
 		super.updateHash(hash, chunkGraph);

--- a/lib/MainTemplate.js
+++ b/lib/MainTemplate.js
@@ -34,11 +34,11 @@ const getJavascriptModulesPlugin = memorize(() =>
 class MainTemplate {
 	/**
 	 *
-	 * @param {TODO=} outputOptions output options for the MainTemplate
+	 * @param {TODO|undefined} outputOptions output options for the MainTemplate
 	 * @param {Compilation} compilation the compilation
 	 */
 	constructor(outputOptions, compilation) {
-		/** @type {TODO?} */
+		/** @type {TODO|undefined} */
 		this._outputOptions = outputOptions || {};
 		this.hooks = Object.freeze({
 			renderManifest: {

--- a/lib/ModuleGraph.js
+++ b/lib/ModuleGraph.js
@@ -509,7 +509,7 @@ class ExportsInfo {
 			}
 		} else {
 			let info = this.getReadOnlyExportInfo(name);
-			return info.getUsedName(name);
+			return /** @type {string | false} */ (info.getUsedName(name));
 		}
 	}
 
@@ -620,6 +620,10 @@ class ExportInfo {
 		);
 	}
 
+	/**
+	 * @param {string} [fallbackName] fallback name for used exports with no name
+	 * @returns {string | false | SKIP_OVER_NAME} The name, if used
+	 */
 	getUsedName(fallbackName) {
 		if (this.used === UsageState.Unused) return false;
 		if (this.usedName !== null) return this.usedName;

--- a/lib/ModuleGraphConnection.js
+++ b/lib/ModuleGraphConnection.js
@@ -10,10 +10,10 @@
 
 class ModuleGraphConnection {
 	/**
-	 * @param {Module=} originModule the referencing module
-	 * @param {Dependency=} dependency the referencing dependency
+	 * @param {Module|undefined} originModule the referencing module
+	 * @param {Dependency|undefined} dependency the referencing dependency
 	 * @param {Module} module the referenced module
-	 * @param {string=} explanation some extra detail
+	 * @param {string|undefined} explanation some extra detail
 	 * @param {boolean=} weak the reference is weak
 	 * @param {function(ModuleGraphConnection): boolean=} condition condition for the connection
 	 */

--- a/lib/config/normalization.js
+++ b/lib/config/normalization.js
@@ -20,7 +20,7 @@ const normalizeEcmaVersion = require("../util/normalizeEcmaVersion");
 /**
  * @template T
  * @template R
- * @param {T=} value value or not
+ * @param {T|undefined} value value or not
  * @param {function(T): R} fn nested handler
  * @returns {R} result value
  */
@@ -30,9 +30,9 @@ const nestedConfig = (value, fn) =>
 /**
  * @template T
  * @template R
- * @param {T=} value value or not
+ * @param {T|undefined} value value or not
  * @param {function(T): R} fn nested handler
- * @returns {R=} result value
+ * @returns {R|undefined} result value
  */
 const optionalNestedConfig = (value, fn) =>
 	value === undefined ? undefined : fn(value);
@@ -40,18 +40,18 @@ const optionalNestedConfig = (value, fn) =>
 /**
  * @template T
  * @template R
- * @param {T[]=} value array or not
+ * @param {T[]|undefined} value array or not
  * @param {function(T[]): R[]} fn nested handler
- * @returns {R[]=} cloned value
+ * @returns {R[]|undefined} cloned value
  */
 const nestedArray = (value, fn) => (Array.isArray(value) ? fn(value) : fn([]));
 
 /**
  * @template T
  * @template R
- * @param {T[]=} value array or not
+ * @param {T[]|undefined} value array or not
  * @param {function(T[]): R[]} fn nested handler
- * @returns {R[]=} cloned value
+ * @returns {R[]|undefined} cloned value
  */
 const optionalNestedArray = (value, fn) =>
 	Array.isArray(value) ? fn(value) : undefined;

--- a/lib/library/UmdLibraryPlugin.js
+++ b/lib/library/UmdLibraryPlugin.js
@@ -30,7 +30,7 @@ const accessorToObjectAccess = accessor => {
 };
 
 /**
- * @param {string=} base the path prefix
+ * @param {string|undefined} base the path prefix
  * @param {string|string[]} accessor the accessor
  * @param {string=} joinWith the element separator
  * @returns {string} the path

--- a/lib/stats/StatsPrinter.js
+++ b/lib/stats/StatsPrinter.js
@@ -78,6 +78,12 @@ class StatsPrinter {
 		return data;
 	}
 
+	/**
+	 * @param {any} type The type
+	 * @param {any} object Object to print
+	 * @param {any} [baseContext] The base context
+	 * @returns {any} Not sure what to put here
+	 */
 	print(type, object, baseContext) {
 		if (this._inPrint) {
 			return this._print(type, object, baseContext);

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -49,7 +49,7 @@ const path = require("path");
 
 /**
  *
- * @param {(InputFileSystem|OutputFileSystem)=} fs a file system
+ * @param {InputFileSystem|OutputFileSystem|undefined} fs a file system
  * @param {string} rootPath the root path
  * @param {string} targetPath the target path
  * @returns {string} location of targetPath relative to rootPath
@@ -70,7 +70,7 @@ const relative = (fs, rootPath, targetPath) => {
 exports.relative = relative;
 
 /**
- * @param {(InputFileSystem|OutputFileSystem)=} fs a file system
+ * @param {InputFileSystem|OutputFileSystem|undefined} fs a file system
  * @param {string} rootPath a path
  * @param {string} filename a filename
  * @returns {string} the joined path
@@ -91,7 +91,7 @@ const join = (fs, rootPath, filename) => {
 exports.join = join;
 
 /**
- * @param {(InputFileSystem|OutputFileSystem)=} fs a file system
+ * @param {InputFileSystem|OutputFileSystem|undefined} fs a file system
  * @param {string} absPath an absolute path
  * @returns {string} the parent directory of the absolute path
  */

--- a/lib/wasm-async/AsyncWebAssemblyModulesPlugin.js
+++ b/lib/wasm-async/AsyncWebAssemblyModulesPlugin.js
@@ -15,9 +15,14 @@ const memorize = require("../util/memorize");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../Compilation")} Compilation */
+/** @typedef {import("../Chunk")} Chunk */
+/** @typedef {import("../ChunkGraph")} ChunkGraph */
 /** @typedef {import("../Compiler")} Compiler */
+/** @typedef {import("../DependencyTemplates")} DependencyTemplates */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../Module").CodeGenerationResult} CodeGenerationResult */
+/** @typedef {import("../ModuleGraph")} ModuleGraph */
+/** @typedef {import("../RuntimeTemplate")} RuntimeTemplate */
 /** @typedef {import("../Template").RenderManifestEntry} RenderManifestEntry */
 /** @typedef {import("../Template").RenderManifestOptions} RenderManifestOptions */
 

--- a/lib/wasm-async/AsyncWebAssemblyModulesPlugin.js
+++ b/lib/wasm-async/AsyncWebAssemblyModulesPlugin.js
@@ -14,9 +14,9 @@ const { compareModulesByIdentifier } = require("../util/comparators");
 const memorize = require("../util/memorize");
 
 /** @typedef {import("webpack-sources").Source} Source */
-/** @typedef {import("../Compilation")} Compilation */
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
+/** @typedef {import("../Compilation")} Compilation */
 /** @typedef {import("../Compiler")} Compiler */
 /** @typedef {import("../DependencyTemplates")} DependencyTemplates */
 /** @typedef {import("../Module")} Module */

--- a/types.d.ts
+++ b/types.d.ts
@@ -100,7 +100,7 @@ declare class AbstractLibraryPlugin<T> {
 	): void;
 	render(
 		source: Source,
-		renderContext: RenderContextJavascriptModulesPlugin,
+		renderContext: RenderContextObject,
 		libraryContext: LibraryContext<T>
 	): Source;
 	chunkHash(
@@ -1183,25 +1183,17 @@ declare class Compilation {
 	checkConstraints(): void;
 }
 declare interface CompilationHooksAsyncWebAssemblyModulesPlugin {
-	renderModuleContent: SyncWaterfallHook<
-		[Source, Module, RenderContextAsyncWebAssemblyModulesPlugin]
-	>;
+	renderModuleContent: SyncWaterfallHook<[Source, Module, RenderContextObject]>;
 }
 declare interface CompilationHooksJavascriptModulesPlugin {
-	renderModuleContent: SyncWaterfallHook<
-		[Source, Module, RenderContextJavascriptModulesPlugin]
-	>;
+	renderModuleContent: SyncWaterfallHook<[Source, Module, RenderContextObject]>;
 	renderModuleContainer: SyncWaterfallHook<
-		[Source, Module, RenderContextJavascriptModulesPlugin]
+		[Source, Module, RenderContextObject]
 	>;
-	renderModulePackage: SyncWaterfallHook<
-		[Source, Module, RenderContextJavascriptModulesPlugin]
-	>;
-	renderChunk: SyncWaterfallHook<
-		[Source, RenderContextJavascriptModulesPlugin]
-	>;
-	renderMain: SyncWaterfallHook<[Source, RenderContextJavascriptModulesPlugin]>;
-	render: SyncWaterfallHook<[Source, RenderContextJavascriptModulesPlugin]>;
+	renderModulePackage: SyncWaterfallHook<[Source, Module, RenderContextObject]>;
+	renderChunk: SyncWaterfallHook<[Source, RenderContextObject]>;
+	renderMain: SyncWaterfallHook<[Source, RenderContextObject]>;
+	render: SyncWaterfallHook<[Source, RenderContextObject]>;
 	renderRequire: SyncWaterfallHook<[string, RenderBootstrapContext]>;
 	chunkHash: SyncHook<[Chunk, Hash, ChunkHashContext], void>;
 }
@@ -2181,7 +2173,7 @@ declare class ExportInfo {
 	exportsInfoOwned: boolean;
 	exportsInfo: ExportsInfo;
 	readonly canMangle: boolean;
-	getUsedName(fallbackName?: any): any;
+	getUsedName(fallbackName: string): string | false | typeof SKIP_OVER_NAME;
 	createNestedExportsInfo(): ExportsInfo;
 	getNestedExportsInfo(): ExportsInfo;
 	getUsedInfo():
@@ -2709,12 +2701,12 @@ declare class JavascriptModulesPlugin {
 	apply(compiler: Compiler): void;
 	renderModule(
 		module: Module,
-		renderContext: RenderContextJavascriptModulesPlugin,
+		renderContext: RenderContextObject,
 		hooks: CompilationHooksJavascriptModulesPlugin,
 		factory: boolean | "strict"
 	): Source;
 	renderChunk(
-		renderContext: RenderContextJavascriptModulesPlugin,
+		renderContext: RenderContextObject,
 		hooks: CompilationHooksJavascriptModulesPlugin
 	): Source;
 	renderMain(
@@ -3856,7 +3848,7 @@ declare class ModuleGraphConnection {
 		originModule: Module,
 		dependency: Dependency,
 		module: Module,
-		explanation?: string,
+		explanation: string,
 		weak?: boolean,
 		condition?: (arg0: ModuleGraphConnection) => boolean
 	);
@@ -5329,68 +5321,6 @@ declare interface RenderBootstrapContext {
 	 */
 	hash: string;
 }
-declare interface RenderContextAsyncWebAssemblyModulesPlugin {
-	/**
-	 * the chunk
-	 */
-	chunk: any;
-
-	/**
-	 * the dependency templates
-	 */
-	dependencyTemplates: any;
-
-	/**
-	 * the runtime template
-	 */
-	runtimeTemplate: any;
-
-	/**
-	 * the module graph
-	 */
-	moduleGraph: any;
-
-	/**
-	 * the chunk graph
-	 */
-	chunkGraph: any;
-
-	/**
-	 * results of code generation
-	 */
-	codeGenerationResults: Map<Module, CodeGenerationResult>;
-}
-declare interface RenderContextJavascriptModulesPlugin {
-	/**
-	 * the chunk
-	 */
-	chunk: Chunk;
-
-	/**
-	 * the dependency templates
-	 */
-	dependencyTemplates: DependencyTemplates;
-
-	/**
-	 * the runtime template
-	 */
-	runtimeTemplate: RuntimeTemplate;
-
-	/**
-	 * the module graph
-	 */
-	moduleGraph: ModuleGraph;
-
-	/**
-	 * the chunk graph
-	 */
-	chunkGraph: ChunkGraph;
-
-	/**
-	 * results of code generation
-	 */
-	codeGenerationResults: Map<Module, CodeGenerationResult>;
-}
 declare interface RenderContextModuleTemplate {
 	/**
 	 * the chunk
@@ -5416,6 +5346,37 @@ declare interface RenderContextModuleTemplate {
 	 * the chunk graph
 	 */
 	chunkGraph: ChunkGraph;
+}
+declare interface RenderContextObject {
+	/**
+	 * the chunk
+	 */
+	chunk: Chunk;
+
+	/**
+	 * the dependency templates
+	 */
+	dependencyTemplates: DependencyTemplates;
+
+	/**
+	 * the runtime template
+	 */
+	runtimeTemplate: RuntimeTemplate;
+
+	/**
+	 * the module graph
+	 */
+	moduleGraph: ModuleGraph;
+
+	/**
+	 * the chunk graph
+	 */
+	chunkGraph: ChunkGraph;
+
+	/**
+	 * results of code generation
+	 */
+	codeGenerationResults: Map<Module, CodeGenerationResult>;
 }
 declare interface RenderManifestEntry {
 	render: () => Source;


### PR DESCRIPTION
Fix compile errors with TS 3.9 and TS 4.0 (nightly version).
Fixes webpack/webpack#10855

**What kind of change does this PR introduce?**

Change type annotations.

**Did you add tests for your changes?**

No; since only type annotations change, if the code builds then it's safe.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

I wasn't sure what to put for `@returns` in a StatsPrinter method. The linter requires text there, but I need advice on what to write.