### PR TITLE
Bugfix [HMR] hot-update.json /on/deep/paths

### DIFF
--- a/lib/web/JsonpMainTemplate.runtime.js
+++ b/lib/web/JsonpMainTemplate.runtime.js
@@ -5,12 +5,11 @@
 // eslint-disable-next-line no-unused-vars
 var hotAddUpdateChunk = undefined;
 var parentHotUpdateCallback = undefined;
-var $require$ = undefined;
 var $hotMainFilename$ = undefined;
 var $hotChunkFilename$ = undefined;
 var $crossOriginLoading$ = undefined;
 
-module.exports = function() {
+module.exports = function () {
 	// eslint-disable-next-line no-unused-vars
 	function webpackHotUpdateCallback(chunkId, moreModules) {
 		hotAddUpdateChunk(chunkId, moreModules);
@@ -21,7 +20,7 @@ module.exports = function() {
 	function hotDownloadUpdateChunk(chunkId) {
 		var script = document.createElement("script");
 		script.charset = "utf-8";
-		script.src = $require$.p + $hotChunkFilename$;
+		script.src = window.location.origin + "/" + $hotChunkFilename$;
 		if ($crossOriginLoading$) script.crossOrigin = $crossOriginLoading$;
 		document.head.appendChild(script);
 	}
@@ -29,20 +28,20 @@ module.exports = function() {
 	// eslint-disable-next-line no-unused-vars
 	function hotDownloadManifest(requestTimeout) {
 		requestTimeout = requestTimeout || 10000;
-		return new Promise(function(resolve, reject) {
+		return new Promise(function (resolve, reject) {
 			if (typeof XMLHttpRequest === "undefined") {
 				return reject(new Error("No browser support"));
 			}
 			try {
 				var request = new XMLHttpRequest();
-				var requestPath = $require$.p + $hotMainFilename$;
+				var requestPath = window.location.origin + "/" + $hotMainFilename$;
 				request.open("GET", requestPath, true);
 				request.timeout = requestTimeout;
 				request.send(null);
 			} catch (err) {
 				return reject(err);
 			}
-			request.onreadystatechange = function() {
+			request.onreadystatechange = function () {
 				if (request.readyState !== 4) return;
 				if (request.status === 0) {
 					// timeout


### PR DESCRIPTION
Related issue: https://github.com/webpack/webpack-dev-server/issues/1385

I only found that hot module loading worked on `/` and any sub page `/foo` or `/bar` but if you go one level deeper say `/foo/bar` then it will try to load `/foo/hash.hot-update.json` while the server would be hosting it at `/hash.hot-update.json` and the GET would fail. Once I solved that path issue the same was happening with `/foo/main.hash.hot-update.js`

Some experimenting later I found `node_modules\webpack\lib\web\JsonpMainTemplate.runtime.js` to be the culprit.

line 40:
```js
// script.src = $require$.p + $hotChunkFilename$;
script.src = window.location.origin + '/' + $hotChunkFilename$;
```

line 24. I swapped 

```js
// script.src = $require$.p + $hotChunkFilename$;
script.src = window.location.origin + '/' + $hotChunkFilename$;
```

I want to prepare this for a PR but can anyone advise if I'm fixing this correctly and what is `$require$.p` ?

yarn and eslint made it difficult to make the commits, so I hope this is good.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Not sure how to build tests for this, but I did test in browser, trying to get this fix upstream.

**Does this PR introduce a breaking change?**

I don't know. eslint wants me to delete `.` which doesn't make sense.