### PR TITLE
change Module Federation API to be more similar to exports field

### DIFF
--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -123,7 +123,7 @@ class ContainerReferencePlugin {
 														i ? `/fallback-${i}` : ""
 												  }`
 										),
-										data.request.slice(key.length + 1)
+										`.${data.request.slice(key.length)}`
 									);
 								}
 							}

--- a/lib/container/options.js
+++ b/lib/container/options.js
@@ -20,7 +20,7 @@ const process = (options, normalizeSimple, normalizeOptions, fn) => {
 	const array = items => {
 		for (const item of items) {
 			if (typeof item === "string") {
-				fn(item.replace(/^([^\w]+\/)+/, ""), normalizeSimple(item));
+				fn(item, normalizeSimple(item));
 			} else if (item && typeof item === "object") {
 				object(item);
 			} else {
@@ -72,7 +72,6 @@ const parseOptions = (options, normalizeSimple, normalizeOptions) => {
  * @returns {Record<string, string | string[] | T>} options to spread or pass
  */
 const scope = (scope, options) => {
-	const prefix = `${scope}/`;
 	/** @type {Record<string, string | string[] | T>} */
 	const obj = {};
 	process(
@@ -80,7 +79,9 @@ const scope = (scope, options) => {
 		item => /** @type {string | string[] | T} */ (item),
 		item => /** @type {string | string[] | T} */ (item),
 		(key, value) => {
-			obj[prefix + key] = value;
+			obj[
+				key.startsWith("./") ? `${scope}${key.slice(1)}` : `${scope}/${key}`
+			] = value;
 		}
 	);
 	return obj;

--- a/test/PersistentCaching.test.js
+++ b/test/PersistentCaching.test.js
@@ -147,7 +147,9 @@ export default ${files.map((_, i) => `f${i}`).join(" + ")};
 					name: "container",
 					library: { type: "commonjs-module" },
 					exposes: ["./src/exposed"],
-					remotes: ["./container"]
+					remotes: {
+						container: "./container"
+					}
 				})
 			]
 		};

--- a/test/configCases/container/0-container-full/webpack.config.js
+++ b/test/configCases/container/0-container-full/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
 			library: { type: "commonjs-module" },
 			filename: "container.js",
 			exposes: {
-				ComponentA: {
+				"./ComponentA": {
 					import: "./ComponentA"
 				}
 			},

--- a/test/configCases/container/0-transitive-overriding/webpack.config.js
+++ b/test/configCases/container/0-transitive-overriding/webpack.config.js
@@ -15,7 +15,9 @@ module.exports = {
 			remotes: {
 				"container-with-shared": "./container-with-shared.js"
 			},
-			shared: ["./shared"]
+			shared: {
+				shared: "./shared"
+			}
 		})
 	]
 };

--- a/test/configCases/container/1-container-full/webpack.config.js
+++ b/test/configCases/container/1-container-full/webpack.config.js
@@ -8,8 +8,8 @@ module.exports = {
 			library: { type: "commonjs-module" },
 			filename: "container.js",
 			exposes: {
-				ComponentB: "./ComponentB",
-				ComponentC: "./ComponentC"
+				"./ComponentB": "./ComponentB",
+				"./ComponentC": "./ComponentC"
 			},
 			remotes: {
 				containerA: "../0-container-full/container.js",

--- a/test/configCases/container/2-transitive-overriding/webpack.config.js
+++ b/test/configCases/container/2-transitive-overriding/webpack.config.js
@@ -13,7 +13,9 @@ module.exports = {
 				"container-no-shared":
 					"../1-transitive-overriding/container-no-shared.js"
 			},
-			shared: ["./shared"]
+			shared: {
+				shared: "./shared"
+			}
 		})
 	]
 };

--- a/test/configCases/container/container-entry-overridables/index.js
+++ b/test/configCases/container/container-entry-overridables/index.js
@@ -13,7 +13,7 @@ it("should expose modules from the container", async () => {
 				}, 100);
 			})
 	});
-	const testFactory = await container.get("test");
+	const testFactory = await container.get("./test");
 	expect(testFactory).toBeTypeOf("function");
 	expect(testFactory()).toEqual(
 		nsObj({

--- a/test/configCases/container/container-entry-overridables/webpack.config.js
+++ b/test/configCases/container/container-entry-overridables/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
 				type: "commonjs-module"
 			},
 			exposes: {
-				test: "./test"
+				"./test": "./test"
 			},
 			overridables: {
 				value: "./value"

--- a/test/configCases/container/container-entry/index.js
+++ b/test/configCases/container/container-entry/index.js
@@ -2,13 +2,13 @@ it("should expose modules from the container", async () => {
 	const container = __non_webpack_require__("./container-file.js");
 	expect(container).toBeTypeOf("object");
 	expect(container.get).toBeTypeOf("function");
-	const testFactory = await container.get("test");
+	const testFactory = await container.get("./test");
 	expect(testFactory).toBeTypeOf("function");
 	expect(testFactory()).toBe("test");
-	const mainFactory = await container.get("");
+	const mainFactory = await container.get(".");
 	expect(mainFactory).toBeTypeOf("function");
 	expect(mainFactory()).toBe("main");
-	const test2Factory = await container.get("test2");
+	const test2Factory = await container.get("./test2");
 	expect(test2Factory).toBeTypeOf("function");
 	expect(test2Factory()).toEqual(
 		nsObj({

--- a/test/configCases/container/container-entry/webpack.config.js
+++ b/test/configCases/container/container-entry/webpack.config.js
@@ -13,9 +13,9 @@ module.exports = {
 				type: "commonjs-module"
 			},
 			exposes: {
-				test: "./test",
-				test2: ["./init-module", "./test2"],
-				"": "./main"
+				"./test": "./test",
+				"./test2": ["./init-module", "./test2"],
+				".": "./main"
 			}
 		})
 	]

--- a/test/configCases/container/container-reference-override/module.js
+++ b/test/configCases/container/container-reference-override/module.js
@@ -2,6 +2,6 @@ import abc from "abc/hello-world";
 import other from "abc/other";
 
 export function test() {
-	expect(abc).toBe("ok hello-world");
-	expect(other).toBe("ok other");
+	expect(abc).toBe("ok ./hello-world");
+	expect(other).toBe("ok ./other");
 }

--- a/test/configCases/container/container-reference/module.js
+++ b/test/configCases/container/container-reference/module.js
@@ -4,10 +4,10 @@ import def, { module } from "def/hello-world";
 import def2, { module as module2 } from "def/hello/other/world";
 
 export function test() {
-	expect(abc).toBe("abc hello-world");
-	expect(main).toBe("abc ");
+	expect(abc).toBe("abc ./hello-world");
+	expect(main).toBe("abc .");
 	expect(def).toBe("def");
 	expect(def2).toBe("def");
-	expect(module).toBe("hello-world");
-	expect(module2).toBe("hello/other/world");
+	expect(module).toBe("./hello-world");
+	expect(module2).toBe("./hello/other/world");
 }

--- a/test/configCases/container/error-handling/index.js
+++ b/test/configCases/container/error-handling/index.js
@@ -30,7 +30,7 @@ it("should allow to handle invalid remote module error with import()", async () 
 	await expect(import("./invalid-module")).rejects.toEqual(
 		expect.objectContaining({
 			message:
-				'Module "invalid" does not exist in container.\nwhile loading "invalid" from webpack/container/reference/remote'
+				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
 		})
 	);
 });
@@ -40,7 +40,7 @@ it("should allow to handle invalid remote module error with require", async () =
 	expect(error).toEqual(
 		expect.objectContaining({
 			message:
-				'Module "invalid" does not exist in container.\nwhile loading "invalid" from webpack/container/reference/remote'
+				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
 		})
 	);
 });
@@ -50,7 +50,7 @@ it("should allow to handle invalid remote module error with top-level-await impo
 	expect(error).toEqual(
 		expect.objectContaining({
 			message:
-				'Module "invalid" does not exist in container.\nwhile loading "invalid" from webpack/container/reference/remote'
+				'Module "./invalid" does not exist in container.\nwhile loading "./invalid" from webpack/container/reference/remote'
 		})
 	);
 });

--- a/test/configCases/container/exposed-overridables/webpack.config.js
+++ b/test/configCases/container/exposed-overridables/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
 			name: "container",
 			filename: "container.js",
 			exposes: {
-				Button: "./Button"
+				"./Button": "./Button"
 			},
 			shared: ["react"]
 		})

--- a/test/configCases/container/module-federation/module.js
+++ b/test/configCases/container/module-federation/module.js
@@ -7,11 +7,11 @@ import self from "self/self";
 import selfOther from "self/other";
 
 export function test() {
-	expect(abc).toBe("abc system-hello-world");
+	expect(abc).toBe("abc ./system-hello-world");
 	expect(def).toBe("def");
 	expect(def2).toBe("def");
-	expect(module).toBe("system-hello-world");
-	expect(module2).toBe("system-hello/other/world");
+	expect(module).toBe("./system-hello-world");
+	expect(module2).toBe("./system-hello/other/world");
 	expect(other).toBe("other and dep");
 	expect(otherSelf).toBe("self and dep");
 	expect(self).toBe("self and dep");

--- a/test/configCases/container/overridables/index.js
+++ b/test/configCases/container/overridables/index.js
@@ -15,7 +15,7 @@ __webpack_override__({
 				resolve(() => "overriden-package");
 			}, 100);
 		}),
-	"options/test1": () => () => "1",
+	"././options/test1": () => () => "1",
 	"nested1/options/test2": () => () => "2",
 	"nested2/deep/deep": () => () => "3"
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
API change
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
existing tests
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
In Module Federation:
* keys of the `exposes` option should be prefixed with `./`. The `.` key exposes a module as index module. (`ModuleFederationPlugin` and `ContainerPlugin`)
* Automatically inferred keys for `shared` `overridable` `overrides` `remotes` `exposes` do no longer do any modifications to the key. (no `./` removal)
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
