### PR TITLE
Remove overrides/overridables option for ModuleFederationPlugin

### DIFF
--- a/declarations/plugins/container/ModuleFederationPlugin.d.ts
+++ b/declarations/plugins/container/ModuleFederationPlugin.d.ts
@@ -53,28 +53,6 @@ export type LibraryType =
  */
 export type UmdNamedDefine = boolean;
 /**
- * Modules in this container that should be able to be overridden by the host. When provided, property name is used as override key, otherwise override key is automatically inferred from request.
- */
-export type Overridables =
-	| (OverridablesItem | OverridablesObject)[]
-	| OverridablesObject;
-/**
- * Request to a module in this container that should be able to be overridden by the host.
- */
-export type OverridablesItem = string;
-/**
- * Requests to modules in this container that should be able to be overridden by the host.
- */
-export type OverridablesItems = OverridablesItem[];
-/**
- * Modules in this container that should override overridable modules in the remote container. When provided, property name is used as override key, otherwise override key is automatically inferred from request.
- */
-export type Overrides = (OverridesItem | OverridesObject)[] | OverridesObject;
-/**
- * Request to a module in this container that should override overridable modules in the remote container.
- */
-export type OverridesItem = string;
-/**
  * Specifies the default type of externals ('amd*', 'umd*', 'system' and 'jsonp' depend on output.libraryTarget set to the same value).
  */
 export type ExternalsType =
@@ -116,6 +94,28 @@ export type Shared = (SharedItem | SharedObject)[] | SharedObject;
  * Module that should be shared with remotes and/or host.
  */
 export type SharedItem = string;
+/**
+ * Modules in this container that should be able to be overridden by the host. When provided, property name is used as override key, otherwise override key is automatically inferred from request.
+ */
+export type Overridables =
+	| (OverridablesItem | OverridablesObject)[]
+	| OverridablesObject;
+/**
+ * Request to a module in this container that should be able to be overridden by the host.
+ */
+export type OverridablesItem = string;
+/**
+ * Requests to modules in this container that should be able to be overridden by the host.
+ */
+export type OverridablesItems = OverridablesItem[];
+/**
+ * Modules in this container that should override overridable modules in the remote container. When provided, property name is used as override key, otherwise override key is automatically inferred from request.
+ */
+export type Overrides = (OverridesItem | OverridesObject)[] | OverridesObject;
+/**
+ * Request to a module in this container that should override overridable modules in the remote container.
+ */
+export type OverridesItem = string;
 
 export interface ModuleFederationPluginOptions {
 	/**
@@ -134,14 +134,6 @@ export interface ModuleFederationPluginOptions {
 	 * The name of the container.
 	 */
 	name?: string;
-	/**
-	 * Modules in this container that should be able to be overridden by the host. When provided, property name is used as override key, otherwise override key is automatically inferred from request.
-	 */
-	overridables?: Overridables;
-	/**
-	 * Modules in this container that should override overridable modules in the remote container. When provided, property name is used as override key, otherwise override key is automatically inferred from request.
-	 */
-	overrides?: Overrides;
 	/**
 	 * The external type of the remote containers.
 	 */
@@ -237,42 +229,6 @@ export interface LibraryCustomUmdObject {
 	root?: string[] | string;
 }
 /**
- * Requests to modules in this container that should be able to be overridden by the host. Property names are used as override keys.
- */
-export interface OverridablesObject {
-	/**
-	 * Requests to modules in this container that should be able to be overridden by the host.
-	 */
-	[k: string]: OverridablesConfig | OverridablesItem | OverridablesItems;
-}
-/**
- * Advanced configuration for modules in this container that should be able to be overridden by the host.
- */
-export interface OverridablesConfig {
-	/**
-	 * Requests to modules in this container that should be able to be overridden by the host.
-	 */
-	import: OverridablesItem | OverridablesItems;
-}
-/**
- * Requests to modules in this container that should override overridable modules in the remote container. Property names are used as override keys.
- */
-export interface OverridesObject {
-	/**
-	 * Requests to modules in this container that should override overridable modules in the remote container.
-	 */
-	[k: string]: OverridesConfig | OverridesItem;
-}
-/**
- * Advanced configuration for modules in this container that should override overridable modules in the remote container.
- */
-export interface OverridesConfig {
-	/**
-	 * Request to a module in this container that should override overridable modules in the remote container.
-	 */
-	import: OverridesItem;
-}
-/**
  * Container locations from which modules should be resolved and loaded at runtime. Property names are used as request scopes.
  */
 export interface RemotesObject {
@@ -307,4 +263,40 @@ export interface SharedConfig {
 	 * Module that should be shared with remotes and/or host.
 	 */
 	import: SharedItem;
+}
+/**
+ * Requests to modules in this container that should be able to be overridden by the host. Property names are used as override keys.
+ */
+export interface OverridablesObject {
+	/**
+	 * Requests to modules in this container that should be able to be overridden by the host.
+	 */
+	[k: string]: OverridablesConfig | OverridablesItem | OverridablesItems;
+}
+/**
+ * Advanced configuration for modules in this container that should be able to be overridden by the host.
+ */
+export interface OverridablesConfig {
+	/**
+	 * Requests to modules in this container that should be able to be overridden by the host.
+	 */
+	import: OverridablesItem | OverridablesItems;
+}
+/**
+ * Requests to modules in this container that should override overridable modules in the remote container. Property names are used as override keys.
+ */
+export interface OverridesObject {
+	/**
+	 * Requests to modules in this container that should override overridable modules in the remote container.
+	 */
+	[k: string]: OverridesConfig | OverridesItem;
+}
+/**
+ * Advanced configuration for modules in this container that should override overridable modules in the remote container.
+ */
+export interface OverridesConfig {
+	/**
+	 * Request to a module in this container that should override overridable modules in the remote container.
+	 */
+	import: OverridesItem;
 }

--- a/lib/container/ModuleFederationPlugin.js
+++ b/lib/container/ModuleFederationPlugin.js
@@ -14,31 +14,6 @@ const ContainerReferencePlugin = require("./ContainerReferencePlugin");
 /** @typedef {import("../../declarations/plugins/container/ModuleFederationPlugin").Shared} Shared */
 /** @typedef {import("../Compiler")} Compiler */
 
-/**
- * @template T
- * @template O
- * @param {T[] | O} a first
- * @param {T[] | O} b second
- * @returns {(T | O)[] | O} merged
- */
-const merge = (a, b) => {
-	if (!b) return a;
-	if (!a) return b;
-	if (Array.isArray(a)) {
-		if (Array.isArray(b)) {
-			return [...a, ...b];
-		} else {
-			return [...a, b];
-		}
-	} else {
-		if (Array.isArray(b)) {
-			return [a, ...b];
-		} else {
-			return [a, b];
-		}
-	}
-};
-
 class ModuleFederationPlugin {
 	/**
 	 * @param {ModuleFederationPluginOptions} options options
@@ -76,7 +51,7 @@ class ModuleFederationPlugin {
 					library: options.library || compiler.options.output.library,
 					filename: options.filename,
 					exposes: options.exposes,
-					overridables: merge(options.shared, options.overridables)
+					overridables: options.shared
 				}).apply(compiler);
 			}
 			if (
@@ -91,7 +66,7 @@ class ModuleFederationPlugin {
 						(options.library && options.library.type) ||
 						compiler.options.externalsType,
 					remotes: options.remotes,
-					overrides: merge(options.shared, options.overrides)
+					overrides: options.shared
 				}).apply(compiler);
 			}
 		});

--- a/schemas/plugins/container/ModuleFederationPlugin.json
+++ b/schemas/plugins/container/ModuleFederationPlugin.json
@@ -516,12 +516,6 @@
       "description": "The name of the container.",
       "type": "string"
     },
-    "overridables": {
-      "$ref": "#/definitions/Overridables"
-    },
-    "overrides": {
-      "$ref": "#/definitions/Overrides"
-    },
     "remoteType": {
       "description": "The external type of the remote containers.",
       "oneOf": [

--- a/types.d.ts
+++ b/types.d.ts
@@ -3838,16 +3838,6 @@ declare interface ModuleFederationPluginOptions {
 	name?: string;
 
 	/**
-	 * Modules in this container that should be able to be overridden by the host. When provided, property name is used as override key, otherwise override key is automatically inferred from request.
-	 */
-	overridables?: Overridables;
-
-	/**
-	 * Modules in this container that should override overridable modules in the remote container. When provided, property name is used as override key, otherwise override key is automatically inferred from request.
-	 */
-	overrides?: Overrides;
-
-	/**
 	 * The external type of the remote containers.
 	 */
 	remoteType?: ExternalsType;


### PR DESCRIPTION
@sokra @ScriptedAlchemy 
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

It looks like that `ModuleFederationPlugin` has options, `overrides` and `overridables`.
https://github.com/webpack/webpack/blob/master/types.d.ts#L3840-L3848
https://github.com/webpack/webpack/blob/master/lib/container/ModuleFederationPlugin.js#L79
https://github.com/webpack/webpack/blob/master/lib/container/ModuleFederationPlugin.js#L94

But shouldn't these options be removed for `ModuleFederationPlugin` (=high level API)?

<!-- Try to link to an open issue for more information. -->

We don't need these options anymore because we have the `shared` option already.
https://github.com/webpack/webpack/issues/10352#issuecomment-584822116

(This PR keeps low level API (like `ContainerPlugin`/`ContainerReferencePlugin`) have `overrides`/`overridables` internally)

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

refactoring

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Existing & No need
(I don't see any tests for `ModuleFederationPlugin` with `overrides`/`overridables` option. So this PR should increase test coverage)

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

Maybe yes, but I suppose we have never used `overrides`/`overridables` anywhere for `ModuleFederationPlugin`.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

No need
https://webpack.js.org/concepts/module-federation/#building-blocks

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
