### PR TITLE
Align node defaults with docs

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -142,7 +142,7 @@ const applyWebpackOptionsDefaults = options => {
 			: "var"
 	);
 
-	applyNodeDefaults(options.node, { target });
+	applyNodeDefaults(options.node);
 
 	F(options, "performance", () => (production && webTarget ? {} : false));
 	applyPerformanceDefaults(options.performance, {
@@ -450,42 +450,13 @@ const applyOutputDefaults = (
 
 /**
  * @param {WebpackNode} node options
- * @param {Object} options options
- * @param {Target} options.target target
  * @returns {void}
  */
-const applyNodeDefaults = (node, { target }) => {
+const applyNodeDefaults = node => {
 	if (node === false) return;
-	F(node, "global", () => {
-		switch (target) {
-			case "node":
-			case "async-node":
-			case "electron-main":
-				return false;
-			default:
-				return true;
-		}
-	});
-	F(node, "__filename", () => {
-		switch (target) {
-			case "node":
-			case "async-node":
-			case "electron-main":
-				return false;
-			default:
-				return "mock";
-		}
-	});
-	F(node, "__dirname", () => {
-		switch (target) {
-			case "node":
-			case "async-node":
-			case "electron-main":
-				return false;
-			default:
-				return "mock";
-		}
-	});
+	F(node, "global", () => false);
+	F(node, "__filename", () => false);
+	F(node, "__dirname", () => false);
 };
 
 /**

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -135,9 +135,9 @@ describe("Defaults", () => {
 		  },
 		  "name": undefined,
 		  "node": Object {
-		    "__dirname": "mock",
-		    "__filename": "mock",
-		    "global": true,
+		    "__dirname": false,
+		    "__filename": false,
+		    "global": false,
 		  },
 		  "optimization": Object {
 		    "checkWasmTypes": false,
@@ -608,13 +608,6 @@ describe("Defaults", () => {
 		+ Received
 
 		@@ ... @@
-		-     "__dirname": "mock",
-		-     "__filename": "mock",
-		-     "global": true,
-		+     "__dirname": false,
-		+     "__filename": false,
-		+     "global": false,
-		@@ ... @@
 		-     "globalObject": "window",
 		+     "globalObject": "global",
 		@@ ... @@
@@ -788,9 +781,9 @@ describe("Defaults", () => {
 			+   "amd": false,
 			@@ ... @@
 			-   "node": Object {
-			-     "__dirname": "mock",
-			-     "__filename": "mock",
-			-     "global": true,
+			-     "__dirname": false,
+			-     "__filename": false,
+			-     "global": false,
 			-   },
 			+   "node": false,
 			@@ ... @@

--- a/test/configCases/code-generation/use-strict/webpack.config.js
+++ b/test/configCases/code-generation/use-strict/webpack.config.js
@@ -1,9 +1,5 @@
 /** @type {import("../../../../").Configuration} */
 module.exports = {
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	optimization: {
 		concatenateModules: false,
 		minimize: false

--- a/test/configCases/custom-source-type/localization/webpack.config.js
+++ b/test/configCases/custom-source-type/localization/webpack.config.js
@@ -189,8 +189,5 @@ module.exports = definitions.map((defs, i) => ({
 				}
 			);
 		}
-	],
-	node: {
-		__dirname: false
-	}
+	]
 }));

--- a/test/configCases/externals/externals-in-chunk/webpack.config.js
+++ b/test/configCases/externals/externals-in-chunk/webpack.config.js
@@ -4,9 +4,5 @@ module.exports = {
 		external: "1+2",
 		external2: "3+4",
 		external3: "5+6"
-	},
-	node: {
-		__dirname: false,
-		__filename: false
 	}
 };

--- a/test/configCases/externals/externals-in-commons-chunk/webpack.config.js
+++ b/test/configCases/externals/externals-in-commons-chunk/webpack.config.js
@@ -14,10 +14,6 @@ module.exports = {
 	output: {
 		filename: "[name].js"
 	},
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	optimization: {
 		minimize: false,
 		splitChunks: {

--- a/test/configCases/externals/non-umd-externals-umd/webpack.config.js
+++ b/test/configCases/externals/non-umd-externals-umd/webpack.config.js
@@ -6,9 +6,5 @@ module.exports = {
 	externals: {
 		external0: "external0",
 		external1: "var 'abc'"
-	},
-	node: {
-		__dirname: false,
-		__filename: false
 	}
 };

--- a/test/configCases/externals/non-umd-externals-umd2/webpack.config.js
+++ b/test/configCases/externals/non-umd-externals-umd2/webpack.config.js
@@ -6,9 +6,5 @@ module.exports = {
 	externals: {
 		external0: "external0",
 		external1: "var 'abc'"
-	},
-	node: {
-		__dirname: false,
-		__filename: false
 	}
 };

--- a/test/configCases/filename-template/module-filename-template/webpack.config.js
+++ b/test/configCases/filename-template/module-filename-template/webpack.config.js
@@ -6,9 +6,5 @@ module.exports = {
 			return "dummy:///" + info.resourcePath;
 		}
 	},
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	devtool: "cheap-source-map"
 };

--- a/test/configCases/filename-template/split-chunks-filename/webpack.config.js
+++ b/test/configCases/filename-template/split-chunks-filename/webpack.config.js
@@ -1,10 +1,6 @@
 /** @type {import("../../../../").Configuration} */
 module.exports = {
 	mode: "development",
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	output: {
 		libraryTarget: "commonjs2"
 	},

--- a/test/configCases/json/tree-shaking-default/webpack.config.js
+++ b/test/configCases/json/tree-shaking-default/webpack.config.js
@@ -1,8 +1,4 @@
 /** @type {import("../../../../").Configuration} */
 module.exports = {
-	mode: "production",
-	node: {
-		__dirname: false,
-		__filename: false
-	}
+	mode: "production"
 };

--- a/test/configCases/parsing/harmony-global/webpack.config.js
+++ b/test/configCases/parsing/harmony-global/webpack.config.js
@@ -1,6 +1,9 @@
 /** @type {import("../../../../").Configuration} */
 module.exports = {
 	target: "web",
+	node: {
+		global: true
+	},
 	performance: {
 		hints: false
 	}

--- a/test/configCases/parsing/import-ignore/webpack.config.js
+++ b/test/configCases/parsing/import-ignore/webpack.config.js
@@ -6,8 +6,5 @@ module.exports = {
 	},
 	output: {
 		filename: "[name].js"
-	},
-	node: {
-		__dirname: false
 	}
 };

--- a/test/configCases/parsing/issue-8293/webpack.config.js
+++ b/test/configCases/parsing/issue-8293/webpack.config.js
@@ -16,9 +16,6 @@ module.exports = {
 	module: {
 		exprContextCritical: false
 	},
-	node: {
-		__dirname: false
-	},
 	plugins: [
 		new webpack.DefinePlugin({
 			CONST_PREFIX0: JSON.stringify("prefix0"),

--- a/test/configCases/parsing/issue-9042/webpack.config.js
+++ b/test/configCases/parsing/issue-9042/webpack.config.js
@@ -1,8 +1,4 @@
 /** @type {import("../../../../").Configuration} */
 module.exports = {
-	target: "web",
-	node: {
-		__filename: false,
-		__dirname: false
-	}
+	target: "web"
 };

--- a/test/configCases/plugins/banner-plugin-hashing/webpack.config.js
+++ b/test/configCases/plugins/banner-plugin-hashing/webpack.config.js
@@ -4,10 +4,6 @@ const webpack = require("../../../../");
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	entry: {
 		"dist/banner": ["./index.js"],
 		vendors: ["./vendors.js"]

--- a/test/configCases/plugins/banner-plugin/webpack.config.js
+++ b/test/configCases/plugins/banner-plugin/webpack.config.js
@@ -1,10 +1,6 @@
 var webpack = require("../../../../");
 /** @type {import("../../../../").Configuration} */
 module.exports = {
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	entry: {
 		bundle0: ["./index.js"],
 		vendors: ["./vendors.js"]

--- a/test/configCases/plugins/lib-manifest-plugin/webpack.config.js
+++ b/test/configCases/plugins/lib-manifest-plugin/webpack.config.js
@@ -11,8 +11,5 @@ module.exports = (env, { testPath }) => ({
 			path: path.resolve(testPath, "[name]-manifest.json"),
 			name: "[name]_[fullhash]"
 		})
-	],
-	node: {
-		__dirname: false
-	}
+	]
 });

--- a/test/configCases/plugins/mini-css-extract-plugin/webpack.config.js
+++ b/test/configCases/plugins/mini-css-extract-plugin/webpack.config.js
@@ -19,8 +19,5 @@ module.exports = {
 		]
 	},
 	target: "web",
-	node: {
-		__dirname: false
-	},
 	plugins: [new MCEP()]
 };

--- a/test/configCases/plugins/profiling-plugin/webpack.config.js
+++ b/test/configCases/plugins/profiling-plugin/webpack.config.js
@@ -7,9 +7,5 @@ module.exports = (env, { testPath }) => ({
 		new webpack.debug.ProfilingPlugin({
 			outputPath: path.join(testPath, "in/directory/events.json")
 		})
-	],
-	node: {
-		__dirname: false,
-		__filename: false
-	}
+	]
 });

--- a/test/configCases/plugins/source-map-dev-tool-plugin/webpack.config.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin/webpack.config.js
@@ -2,10 +2,6 @@ var webpack = require("../../../../");
 var TerserPlugin = require("terser-webpack-plugin");
 /** @type {import("../../../../").Configuration} */
 module.exports = {
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	entry: {
 		bundle0: ["./index.js"],
 		"public/test": ["./test.js"]

--- a/test/configCases/plugins/source-map-dev-tool-plugin~append/webpack.config.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin~append/webpack.config.js
@@ -2,10 +2,6 @@ var webpack = require("../../../../");
 var TerserPlugin = require("terser-webpack-plugin");
 /** @type {import("../../../../").Configuration} */
 module.exports = {
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	entry: {
 		bundle0: ["./index.js"],
 		"some-test": ["./test.js"]

--- a/test/configCases/plugins/terser-plugin/webpack.config.js
+++ b/test/configCases/plugins/terser-plugin/webpack.config.js
@@ -1,10 +1,6 @@
 const TerserPlugin = require("terser-webpack-plugin");
 /** @type {import("../../../../").Configuration} */
 module.exports = {
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	entry: {
 		ie8: ["./ie8.js"],
 		bundle0: ["./index.js"],

--- a/test/configCases/records/issue-295/webpack.config.js
+++ b/test/configCases/records/issue-295/webpack.config.js
@@ -4,8 +4,5 @@ var path = require("path");
 module.exports = (env, { testPath }) => ({
 	entry: "./test",
 	recordsPath: path.resolve(testPath, "records.json"),
-	target: "node",
-	node: {
-		__dirname: false
-	}
+	target: "node"
 });

--- a/test/configCases/records/issue-2991/webpack.config.js
+++ b/test/configCases/records/issue-2991/webpack.config.js
@@ -5,9 +5,6 @@ module.exports = (env, { testPath }) => ({
 	entry: "./test",
 	recordsOutputPath: path.resolve(testPath, "records.json"),
 	target: "node",
-	node: {
-		__dirname: false
-	},
 	resolve: {
 		aliasFields: ["browser"],
 		alias: {

--- a/test/configCases/records/issue-7339/webpack.config.js
+++ b/test/configCases/records/issue-7339/webpack.config.js
@@ -4,8 +4,5 @@ var path = require("path");
 module.exports = (env, { testPath }) => ({
 	entry: "./test",
 	recordsOutputPath: path.resolve(testPath, "records.json"),
-	target: "node",
-	node: {
-		__dirname: false
-	}
+	target: "node"
 });

--- a/test/configCases/records/stable-sort/webpack.config.js
+++ b/test/configCases/records/stable-sort/webpack.config.js
@@ -8,8 +8,5 @@ module.exports = (env, { testPath }) => ({
 	optimization: {
 		chunkIds: "size"
 	},
-	target: "node",
-	node: {
-		__dirname: false
-	}
+	target: "node"
 });

--- a/test/configCases/runtime/node-global/index.js
+++ b/test/configCases/runtime/node-global/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-it("should be able to use global in strict mode", function() {
+it("should be able to use global if `node.global` is set to `true`", function() {
 	expect((typeof global)).toBe("object");
 	expect((global === null)).toBe(false)
 });

--- a/test/configCases/runtime/node-global/webpack.config.js
+++ b/test/configCases/runtime/node-global/webpack.config.js
@@ -1,4 +1,6 @@
 /** @type {import("../../../../").Configuration} */
 module.exports = {
-	target: "web"
+	node: {
+		global: true
+	}
 };

--- a/test/configCases/source-map/default-filename-extensions-css/webpack.config.js
+++ b/test/configCases/source-map/default-filename-extensions-css/webpack.config.js
@@ -4,9 +4,5 @@ module.exports = {
 	output: {
 		filename: "bundle0.css"
 	},
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	devtool: "source-map"
 };

--- a/test/configCases/source-map/default-filename-extensions-js/webpack.config.js
+++ b/test/configCases/source-map/default-filename-extensions-js/webpack.config.js
@@ -4,9 +4,5 @@ module.exports = {
 	output: {
 		filename: "bundle0.js"
 	},
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	devtool: "source-map"
 };

--- a/test/configCases/source-map/default-filename-extensions-mjs/webpack.config.js
+++ b/test/configCases/source-map/default-filename-extensions-mjs/webpack.config.js
@@ -4,9 +4,5 @@ module.exports = {
 	output: {
 		filename: "bundle0.mjs"
 	},
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	devtool: "source-map"
 };

--- a/test/configCases/source-map/exclude-chunks-source-map/webpack.config.js
+++ b/test/configCases/source-map/exclude-chunks-source-map/webpack.config.js
@@ -3,10 +3,6 @@ var webpack = require("../../../../");
 module.exports = {
 	mode: "development",
 	devtool: false,
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	entry: {
 		bundle0: ["./index.js"],
 		vendors: ["./vendors.js"]

--- a/test/configCases/source-map/exclude-modules-source-map/webpack.config.js
+++ b/test/configCases/source-map/exclude-modules-source-map/webpack.config.js
@@ -1,10 +1,6 @@
 var webpack = require("../../../../");
 /** @type {import("../../../../").Configuration} */
 module.exports = {
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	entry: {
 		bundle0: ["./index.js"],
 		bundle1: ["./test1.js", "./test2.js"]

--- a/test/configCases/source-map/module-names/webpack.config.js
+++ b/test/configCases/source-map/module-names/webpack.config.js
@@ -6,9 +6,5 @@ module.exports = {
 		devtoolModuleFilenameTemplate: "module",
 		devtoolFallbackModuleFilenameTemplate: "fallback"
 	},
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	devtool: "source-map"
 };

--- a/test/configCases/source-map/namespace-source-path.library/webpack.config.js
+++ b/test/configCases/source-map/namespace-source-path.library/webpack.config.js
@@ -4,9 +4,5 @@ module.exports = {
 	output: {
 		library: "mylibrary"
 	},
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	devtool: "cheap-source-map"
 };

--- a/test/configCases/source-map/namespace-source-path/webpack.config.js
+++ b/test/configCases/source-map/namespace-source-path/webpack.config.js
@@ -4,9 +4,5 @@ module.exports = {
 	output: {
 		devtoolNamespace: "mynamespace"
 	},
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	devtool: "cheap-source-map"
 };

--- a/test/configCases/source-map/nosources/webpack.config.js
+++ b/test/configCases/source-map/nosources/webpack.config.js
@@ -1,9 +1,5 @@
 /** @type {import("../../../../").Configuration} */
 module.exports = {
 	mode: "development",
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	devtool: "nosources-source-map"
 };

--- a/test/configCases/source-map/relative-source-map-path/webpack.config.js
+++ b/test/configCases/source-map/relative-source-map-path/webpack.config.js
@@ -4,9 +4,5 @@ module.exports = {
 	output: {
 		chunkFilename: "js/chunks/c.js"
 	},
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	devtool: "source-map"
 };

--- a/test/configCases/source-map/relative-source-maps-by-loader/webpack.config.js
+++ b/test/configCases/source-map/relative-source-maps-by-loader/webpack.config.js
@@ -1,9 +1,5 @@
 /** @type {import("../../../../").Configuration} */
 module.exports = {
 	mode: "development",
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	devtool: "source-map"
 };

--- a/test/configCases/source-map/source-map-filename-contenthash/webpack.config.js
+++ b/test/configCases/source-map/source-map-filename-contenthash/webpack.config.js
@@ -1,10 +1,6 @@
 /** @type {import("../../../../").Configuration} */
 module.exports = {
 	mode: "development",
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	devtool: "source-map",
 	output: {
 		sourceMapFilename: "[file]-[contenthash].map?[contenthash]-[contenthash]"

--- a/test/configCases/source-map/source-map-with-profiling-plugin/webpack.config.js
+++ b/test/configCases/source-map/source-map-with-profiling-plugin/webpack.config.js
@@ -4,10 +4,6 @@ var os = require("os");
 
 /** @type {import("../../../../").Configuration} */
 module.exports = {
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	entry: {
 		bundle0: ["./index.js"]
 	},

--- a/test/configCases/source-map/sources-array-production/webpack.config.js
+++ b/test/configCases/source-map/sources-array-production/webpack.config.js
@@ -1,9 +1,5 @@
 /** @type {import("../../../../").Configuration} */
 module.exports = {
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	devtool: "source-map",
 	optimization: {
 		minimize: true

--- a/test/configCases/split-chunks-common/library/webpack.config.js
+++ b/test/configCases/split-chunks-common/library/webpack.config.js
@@ -20,9 +20,5 @@ module.exports = {
 				}
 			}
 		}
-	},
-	node: {
-		__filename: false,
-		__dirname: false
 	}
 };

--- a/test/configCases/split-chunks/chunk-filename-delimiter-default/webpack.config.js
+++ b/test/configCases/split-chunks/chunk-filename-delimiter-default/webpack.config.js
@@ -4,10 +4,6 @@ module.exports = {
 	entry: {
 		main: "./index"
 	},
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	output: {
 		filename: "[name].js",
 		chunkFilename: "[name].bundle.js",

--- a/test/configCases/split-chunks/chunk-filename-delimiter/webpack.config.js
+++ b/test/configCases/split-chunks/chunk-filename-delimiter/webpack.config.js
@@ -4,10 +4,6 @@ module.exports = {
 	entry: {
 		main: "./index"
 	},
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	output: {
 		filename: "[name].js",
 		chunkFilename: "[name].bundle.js",

--- a/test/configCases/target/amd-named/webpack.config.js
+++ b/test/configCases/target/amd-named/webpack.config.js
@@ -5,10 +5,6 @@ module.exports = {
 		library: "NamedLibrary",
 		libraryTarget: "amd"
 	},
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	plugins: [
 		new webpack.BannerPlugin({
 			raw: true,

--- a/test/configCases/target/amd-require/webpack.config.js
+++ b/test/configCases/target/amd-require/webpack.config.js
@@ -4,10 +4,6 @@ module.exports = {
 	output: {
 		libraryTarget: "amd-require"
 	},
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	plugins: [
 		new webpack.BannerPlugin({
 			raw: true,

--- a/test/configCases/target/amd-unnamed/webpack.config.js
+++ b/test/configCases/target/amd-unnamed/webpack.config.js
@@ -4,10 +4,6 @@ module.exports = {
 	output: {
 		libraryTarget: "amd"
 	},
-	node: {
-		__dirname: false,
-		__filename: false
-	},
 	plugins: [
 		new webpack.BannerPlugin({
 			raw: true,

--- a/test/configCases/target/system-context/webpack.config.js
+++ b/test/configCases/target/system-context/webpack.config.js
@@ -2,9 +2,5 @@
 module.exports = {
 	output: {
 		libraryTarget: "system"
-	},
-	node: {
-		__dirname: false,
-		__filename: false
 	}
 };

--- a/test/configCases/target/system-export/webpack.config.js
+++ b/test/configCases/target/system-export/webpack.config.js
@@ -2,9 +2,5 @@
 module.exports = {
 	output: {
 		libraryTarget: "system"
-	},
-	node: {
-		__dirname: false,
-		__filename: false
 	}
 };

--- a/test/configCases/target/system-named-assets-path/webpack.config.js
+++ b/test/configCases/target/system-named-assets-path/webpack.config.js
@@ -3,9 +3,5 @@ module.exports = {
 	output: {
 		library: "named-system-module-[name]",
 		libraryTarget: "system"
-	},
-	node: {
-		__dirname: false,
-		__filename: false
 	}
 };

--- a/test/configCases/target/system-named/webpack.config.js
+++ b/test/configCases/target/system-named/webpack.config.js
@@ -3,9 +3,5 @@ module.exports = {
 	output: {
 		library: "named-system-module",
 		libraryTarget: "system"
-	},
-	node: {
-		__dirname: false,
-		__filename: false
 	}
 };

--- a/test/configCases/target/system-unnamed/webpack.config.js
+++ b/test/configCases/target/system-unnamed/webpack.config.js
@@ -2,9 +2,5 @@
 module.exports = {
 	output: {
 		libraryTarget: "system"
-	},
-	node: {
-		__dirname: false,
-		__filename: false
 	}
 };

--- a/test/configCases/target/umd-auxiliary-comments-object/webpack.config.js
+++ b/test/configCases/target/umd-auxiliary-comments-object/webpack.config.js
@@ -10,9 +10,5 @@ module.exports = {
 			amd: "test comment amd",
 			root: "test comment root"
 		}
-	},
-	node: {
-		__dirname: false,
-		__filename: false
 	}
 };

--- a/test/configCases/target/umd-auxiliary-comments-string/webpack.config.js
+++ b/test/configCases/target/umd-auxiliary-comments-string/webpack.config.js
@@ -5,9 +5,5 @@ module.exports = {
 		libraryTarget: "umd",
 		umdNamedDefine: true,
 		auxiliaryComment: "test comment"
-	},
-	node: {
-		__dirname: false,
-		__filename: false
 	}
 };

--- a/test/configCases/target/umd-named-define/webpack.config.js
+++ b/test/configCases/target/umd-named-define/webpack.config.js
@@ -4,9 +4,5 @@ module.exports = {
 		library: "NamedLibrary",
 		libraryTarget: "umd",
 		umdNamedDefine: true
-	},
-	node: {
-		__dirname: false,
-		__filename: false
 	}
 };

--- a/test/configCases/web/unique-jsonp/webpack.config.js
+++ b/test/configCases/web/unique-jsonp/webpack.config.js
@@ -6,9 +6,5 @@ module.exports = {
 	},
 	externals: {
 		fs: "commonjs2 fs"
-	},
-	node: {
-		__filename: false,
-		__dirname: false
 	}
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

The docs state that all node options are disabled by default (see https://github.com/webpack/webpack.js.org/pull/3602).
This change aligns the default node options with the documentation.

Either I'm missing something, or it was forgotten to change the defaults when merging https://github.com/webpack/webpack/pull/8460.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
yes

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
yes, but it was communicated already: https://github.com/webpack/webpack.js.org/pull/3602

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

This is already documented: https://github.com/webpack/webpack.js.org/pull/3602   
But the code didn't match.