### PR TITLE
Avoid tracking/printing detailed usage info for modules without exportsType

### DIFF
--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -28,6 +28,7 @@ const makeSerializable = require("./util/makeSerializable");
 /** @typedef {import("./ChunkGroup").RawChunkGroupOptions} RawChunkGroupOptions */
 /** @typedef {import("./Compilation")} Compilation */
 /** @typedef {import("./DependencyTemplates")} DependencyTemplates */
+/** @typedef {import("./Module").BuildMeta} BuildMeta */
 /** @typedef {import("./Module").CodeGenerationContext} CodeGenerationContext */
 /** @typedef {import("./Module").CodeGenerationResult} CodeGenerationResult */
 /** @typedef {import("./Module").LibIdentOptions} LibIdentOptions */
@@ -335,7 +336,11 @@ class ContextModule extends Module {
 	 */
 	build(options, compilation, resolver, fs, callback) {
 		this._forceBuild = false;
-		this.buildMeta = {};
+		/** @type {BuildMeta} */
+		this.buildMeta = {
+			exportsType: "default",
+			defaultObject: "redirect-warn"
+		};
 		this.buildInfo = {
 			snapshot: undefined,
 			contextDependencies: this._contextDependencies

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -267,17 +267,20 @@ class ExternalModule extends Module {
 		this.clearDependenciesAndBlocks();
 		switch (this.externalType) {
 			case "system":
-				if (!Array.isArray(this.request) || this.request.length === 1)
+				if (!Array.isArray(this.request) || this.request.length === 1) {
 					this.buildMeta.exportsType = "namespace";
-				this.addDependency(new StaticExportsDependency(true, true));
+					this.addDependency(new StaticExportsDependency(true, true));
+				}
 				break;
 			case "promise":
 				this.buildMeta.async = true;
 				break;
 			case "import":
 				this.buildMeta.async = true;
-				if (!Array.isArray(this.request) || this.request.length === 1)
+				if (!Array.isArray(this.request) || this.request.length === 1) {
 					this.buildMeta.exportsType = "namespace";
+					this.addDependency(new StaticExportsDependency(true, false));
+				}
 				break;
 			case "script":
 				this.buildMeta.async = true;
@@ -386,13 +389,6 @@ class ExternalModule extends Module {
 		hash.update(
 			JSON.stringify(Boolean(this.isOptional(chunkGraph.moduleGraph)))
 		);
-		if (this.externalType === "system") {
-			const exportsInfo = chunkGraph.moduleGraph.getExportsInfo(this);
-			for (const exportInfo of exportsInfo.orderedExports) {
-				hash.update(exportInfo.name);
-				hash.update(`${exportsInfo.getUsedName(exportInfo.name)}`);
-			}
-		}
 		super.updateHash(hash, chunkGraph);
 	}
 

--- a/lib/FlagDependencyUsagePlugin.js
+++ b/lib/FlagDependencyUsagePlugin.js
@@ -47,6 +47,12 @@ class FlagDependencyUsagePlugin {
 					const processModule = (module, usedExports) => {
 						const exportsInfo = moduleGraph.getExportsInfo(module);
 						if (usedExports.length > 0) {
+							if (!module.buildMeta || !module.buildMeta.exportsType) {
+								if (exportsInfo.setUsedWithoutInfo()) {
+									queue.enqueue(module);
+								}
+								return;
+							}
 							for (const usedExportInfo of usedExports) {
 								let usedExport;
 								let canMangle = true;

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -66,7 +66,7 @@ const makeSerializable = require("./util/makeSerializable");
  * @property {boolean=} strict
  * @property {string=} moduleConcatenationBailout
  * @property {("default" | "namespace" | "flagged")=} exportsType
- * @property {(boolean | "redirect" | "redirect-warn")=} defaultObject
+ * @property {(false | "redirect" | "redirect-warn")=} defaultObject
  * @property {boolean=} strictHarmonyModule
  * @property {boolean=} async
  */

--- a/lib/ModuleGraph.js
+++ b/lib/ModuleGraph.js
@@ -326,6 +326,39 @@ class ExportsInfo {
 		return changed;
 	}
 
+	setUsedWithoutInfo() {
+		let changed = false;
+		if (this._isUsed === false) {
+			this._isUsed = true;
+			changed = true;
+		}
+		for (const exportInfo of this._exports.values()) {
+			if (exportInfo.used !== UsageState.NoInfo) {
+				exportInfo.used = UsageState.NoInfo;
+				changed = true;
+			}
+			if (exportInfo.canMangleUse !== false) {
+				exportInfo.canMangleUse = false;
+				changed = true;
+			}
+		}
+		if (this._redirectTo) {
+			if (this._redirectTo.setUsedWithoutInfo()) {
+				changed = true;
+			}
+		} else {
+			if (this._otherExportsInfo.used !== UsageState.NoInfo) {
+				this._otherExportsInfo.used = UsageState.NoInfo;
+				changed = true;
+			}
+			if (this._otherExportsInfo.canMangleUse !== false) {
+				this._otherExportsInfo.canMangleUse = false;
+				changed = true;
+			}
+		}
+		return changed;
+	}
+
 	setAllKnownExportsUsed() {
 		let changed = false;
 		if (this._isUsed === false) {

--- a/lib/ModuleInfoHeaderPlugin.js
+++ b/lib/ModuleInfoHeaderPlugin.js
@@ -134,8 +134,10 @@ class ModuleInfoHeaderPlugin {
 								: "unknown exports (runtime-defined)"
 						) + "\n"
 					);
-					const exportsInfo = moduleGraph.getExportsInfo(module);
-					printExportsInfoToSource(source, "", exportsInfo);
+					if (exportsType) {
+						const exportsInfo = moduleGraph.getExportsInfo(module);
+						printExportsInfoToSource(source, "", exportsInfo);
+					}
 					source.add(
 						Template.toComment(
 							`runtime requirements: ${joinIterableWithComma(

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -522,10 +522,10 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 PublicPath: (none)
               Asset       Size
-     b_js.bundle.js  982 bytes  [emitted]
-          bundle.js   9.84 KiB  [emitted]  [name: main]
-     c_js.bundle.js   1.18 KiB  [emitted]
-d_js-e_js.bundle.js    1.4 KiB  [emitted]
+     b_js.bundle.js  901 bytes  [emitted]
+          bundle.js    9.7 KiB  [emitted]  [name: main]
+     c_js.bundle.js    1.1 KiB  [emitted]
+d_js-e_js.bundle.js   1.25 KiB  [emitted]
 Entrypoint main = bundle.js
 chunk b_js.bundle.js 22 bytes <{main}> [rendered]
     > ./b ./index.js 2:0-16
@@ -1185,8 +1185,8 @@ chunk trees.js (trees) 71 bytes [rendered]
 
 exports[`StatsTestCases should print correct stats for immutable 1`] = `
 "                  Asset       Size
-459e878fcc68e6bc31b5.js  969 bytes  [emitted] [immutable]
-c18bb01ef66b87000725.js   11.2 KiB  [emitted] [immutable]  [name: main]"
+459e878fcc68e6bc31b5.js  888 bytes  [emitted] [immutable]
+c18bb01ef66b87000725.js   11.1 KiB  [emitted] [immutable]  [name: main]"
 `;
 
 exports[`StatsTestCases should print correct stats for import-context-filter 1`] = `
@@ -2160,14 +2160,19 @@ chunk {996} 996.js 22 bytes <{179}> [rendered]
       [no exports used]
       ModuleConcatenation bailout: Module is not an ECMAScript module
 [847] ./a.js 22 bytes {179} [depth 1] [built]
+      [used exports unknown]
       ModuleConcatenation bailout: Module is not an ECMAScript module
 [996] ./b.js 22 bytes {996} [depth 1] [built]
+      [used exports unknown]
       ModuleConcatenation bailout: Module is not an ECMAScript module
 [460] ./c.js 54 bytes {460} [depth 1] [built]
+      [used exports unknown]
       ModuleConcatenation bailout: Module is not an ECMAScript module
 [767] ./d.js 22 bytes {524} [depth 2] [built]
+      [used exports unknown]
       ModuleConcatenation bailout: Module is not an ECMAScript module
 [390] ./e.js 22 bytes {524} [depth 2] [built]
+      [used exports unknown]
       ModuleConcatenation bailout: Module is not an ECMAScript module
 webpack/runtime/ensure chunk 326 bytes {179} [runtime]
       [no exports]
@@ -2375,6 +2380,7 @@ Entrypoint main = main.js
 chunk {179} main.js (main) 73 bytes (javascript) 4.79 KiB (runtime) >{460}< >{996}< [entry] [rendered]
     > ./index main
  [847] ./a.js 22 bytes {179} [depth 1] [built]
+       [used exports unknown]
        ModuleConcatenation bailout: Module is not an ECMAScript module
        cjs self exports reference [847] ./a.js 1:0-14
        cjs require ./a [10] ./index.js 1:0-14
@@ -2405,17 +2411,20 @@ chunk {179} main.js (main) 73 bytes (javascript) 4.79 KiB (runtime) >{460}< >{99
 chunk {460} 460.js 54 bytes <{179}> >{524}< [rendered]
     > ./c [10] ./index.js 3:0-16
  [460] ./c.js 54 bytes {460} [depth 1] [built]
+       [used exports unknown]
        ModuleConcatenation bailout: Module is not an ECMAScript module
        amd require ./c [10] ./index.js 3:0-16
        X ms [10] -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
 chunk {524} 524.js 44 bytes <{460}> [rendered]
     > [460] ./c.js 1:0-52
  [767] ./d.js 22 bytes {524} [depth 2] [built]
+       [used exports unknown]
        ModuleConcatenation bailout: Module is not an ECMAScript module
        require.ensure item ./d [460] ./c.js 1:0-52
        cjs self exports reference [767] ./d.js 1:0-14
        X ms [10] -> X ms [460] -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
  [390] ./e.js 22 bytes {524} [depth 2] [built]
+       [used exports unknown]
        ModuleConcatenation bailout: Module is not an ECMAScript module
        require.ensure item ./e [460] ./c.js 1:0-52
        cjs self exports reference [390] ./e.js 1:0-14
@@ -2423,6 +2432,7 @@ chunk {524} 524.js 44 bytes <{460}> [rendered]
 chunk {996} 996.js 22 bytes <{179}> [rendered]
     > ./b [10] ./index.js 2:0-16
  [996] ./b.js 22 bytes {996} [depth 1] [built]
+       [used exports unknown]
        ModuleConcatenation bailout: Module is not an ECMAScript module
        cjs self exports reference [996] ./b.js 1:0-14
        amd require ./b [10] ./index.js 2:0-16
@@ -2738,9 +2748,9 @@ Entrypoint main = main.js
 `;
 
 exports[`StatsTestCases should print correct stats for side-effects-optimization 1`] = `
-"Hash: d7d1b4f45cd90d4abdb6d61ad7aea717eb8e1363
+"Hash: 74f7a18156dea6b050585bee8a28eec71e4d3a65
 Child
-    Hash: d7d1b4f45cd90d4abdb6
+    Hash: 74f7a18156dea6b05058
     Time: X ms
     Built at: 1970-04-20 12:42:42
       Asset       Size
@@ -2758,11 +2768,11 @@ Child
         |     [no exports]
         |     [no exports used]
     ./node_modules/module-with-export/emptyModule.js 43 bytes [built]
-        [only some exports used: huh]
+        [used exports unknown]
         ModuleConcatenation bailout: Module is not an ECMAScript module
         + 2 hidden modules
 Child
-    Hash: d61ad7aea717eb8e1363
+    Hash: 5bee8a28eec71e4d3a65
     Time: X ms
     Built at: 1970-04-20 12:42:42
               Asset      Size
@@ -2783,7 +2793,7 @@ Child
         [only some exports used: a, huh]
         ModuleConcatenation bailout: Module exports are unknown
     ./node_modules/module-with-export/emptyModule.js 43 bytes [built]
-        [only some exports used: a, huh]
+        [used exports unknown]
         ModuleConcatenation bailout: Module is not an ECMAScript module
     ./node_modules/big-module/log.js 92 bytes [built]
         [only some exports used: a, huh]
@@ -2829,7 +2839,7 @@ exports[`StatsTestCases should print correct stats for simple 1`] = `
 Time: X ms
 Built at: 1970-04-20 12:42:42
     Asset       Size
-bundle.js  871 bytes  [emitted]  [name: main]
+bundle.js  812 bytes  [emitted]  [name: main]
 Entrypoint main = bundle.js
 ./index.js 1 bytes [built]"
 `;
@@ -3843,7 +3853,7 @@ chunk default/async-a.js (async-a) 134 bytes <{179}> [rendered]
 `;
 
 exports[`StatsTestCases should print correct stats for tree-shaking 1`] = `
-"Hash: cd2fbd230872570f58af
+"Hash: 0130ebd4985475ae1c1b
 Time: X ms
 Built at: 1970-04-20 12:42:42
     Asset      Size
@@ -3875,9 +3885,9 @@ Entrypoint main = bundle.js
     [exports: b]
     [no exports used]
 ./unknown.js 1 bytes [built]
-    [only some exports used: c]
+    [used exports unknown]
 ./unknown2.js 1 bytes [built]
-    [only some exports used: y]
+    [used exports unknown]
     + 3 hidden modules
 
 WARNING in ./index.js 9:0-36
@@ -3895,6 +3905,7 @@ Entrypoint main = bundle.js
 ./index.js 299 bytes [built]
     [no exports used]
 ./a.js 249 bytes [built]
+    [used exports unknown]
     + 1 hidden module
 
 WARNING in Terser Plugin: Dropping unused function someUnRemoteUsedFunction1 [webpack://./a.js:3,0]

--- a/types.d.ts
+++ b/types.d.ts
@@ -2444,6 +2444,7 @@ declare class ExportsInfo {
 		excludeExports?: Set<string>
 	): boolean;
 	setUsedInUnknownWay(): boolean;
+	setUsedWithoutInfo(): boolean;
 	setAllKnownExportsUsed(): boolean;
 	setUsedForSideEffectsOnly(): boolean;
 	isUsed(): boolean;
@@ -3472,7 +3473,7 @@ declare interface KnownBuildMeta {
 	strict?: boolean;
 	moduleConcatenationBailout?: string;
 	exportsType?: "namespace" | "default" | "flagged";
-	defaultObject?: boolean | "redirect" | "redirect-warn";
+	defaultObject?: false | "redirect" | "redirect-warn";
 	strictHarmonyModule?: boolean;
 	async?: boolean;
 }


### PR DESCRIPTION
Make ContextModule a static default exporting module
fix provided exports info for ExternalModule

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This avoid invalidating these modules when used exports change, even while this makes no difference in the module

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
improvement
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
exiting tests
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
