### PR TITLE
add roots option

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1192,6 +1192,10 @@ export interface ResolveOptions {
 	 */
 	restrictions?: (RegExp | string)[];
 	/**
+	 * A list of root paths.
+	 */
+	roots?: string[];
+	/**
 	 * Enable resolving symlinks to the original location.
 	 */
 	symlinks?: boolean;

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1188,11 +1188,11 @@ export interface ResolveOptions {
 	 */
 	resolver?: import("enhanced-resolve").Resolver;
 	/**
-	 * A list of resolve restrictions.
+	 * A list of resolve restrictions. Resolve results must fulfill all of these restrictions to resolve successfully. Other resolve paths are taken when restrictions are not met.
 	 */
 	restrictions?: (RegExp | string)[];
 	/**
-	 * A list of root paths.
+	 * A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.
 	 */
 	roots?: string[];
 	/**

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -158,6 +158,7 @@ const applyWebpackOptionsDefaults = options => {
 
 	applyResolveDefaults(options.resolve, {
 		cache,
+		context: options.context,
 		mjs: options.experiments.mjs,
 		webTarget,
 		target,
@@ -604,6 +605,7 @@ const applyOptimizationDefaults = (
  * @param {ResolveOptions} resolve options
  * @param {Object} options options
  * @param {boolean} options.cache is cache enable
+ * @param {string} options.context build context
  * @param {boolean} options.mjs is mjs enabled
  * @param {boolean} options.webTarget is a web-like target
  * @param {Target} options.target target
@@ -612,7 +614,7 @@ const applyOptimizationDefaults = (
  */
 const applyResolveDefaults = (
 	resolve,
-	{ cache, mjs, webTarget, target, mode }
+	{ cache, context, mjs, webTarget, target, mode }
 ) => {
 	D(resolve, "cache", cache);
 	D(resolve, "modules", ["node_modules"]);
@@ -656,6 +658,7 @@ const applyResolveDefaults = (
 	F(resolve, "mainFields", () =>
 		webTarget ? ["browser", "module", "main"] : ["module", "main"]
 	);
+	D(resolve, "roots", [context]);
 	F(resolve.byDependency, "commonjs", () => ({}));
 	F(resolve.byDependency.commonjs, "conditionNames", () => [
 		"require",

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -658,7 +658,7 @@ const applyResolveDefaults = (
 	F(resolve, "mainFields", () =>
 		webTarget ? ["browser", "module", "main"] : ["module", "main"]
 	);
-	D(resolve, "roots", [context]);
+	F(resolve, "roots", () => [context]);
 	F(resolve.byDependency, "commonjs", () => ({}));
 	F(resolve.byDependency.commonjs, "conditionNames", () => [
 		"require",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@webassemblyjs/wasm-parser": "1.9.0",
     "acorn": "^7.3.0",
     "chrome-trace-event": "^1.0.2",
-    "enhanced-resolve": "5.0.0-beta.7",
+    "enhanced-resolve": "5.0.0-beta.8",
     "eslint-scope": "^5.0.0",
     "events": "^3.0.0",
     "glob-to-regexp": "^0.4.1",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2247,6 +2247,14 @@
             ]
           }
         },
+        "roots": {
+          "description": "A list of root paths.",
+          "type": "array",
+          "items": {
+            "description": "Root path.",
+            "type": "string"
+          }
+        },
         "symlinks": {
           "description": "Enable resolving symlinks to the original location.",
           "type": "boolean"

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2232,10 +2232,10 @@
           "tsType": "(import('enhanced-resolve').Resolver)"
         },
         "restrictions": {
-          "description": "A list of resolve restrictions.",
+          "description": "A list of resolve restrictions. Resolve results must fulfill all of these restrictions to resolve successfully. Other resolve paths are taken when restrictions are not met.",
           "type": "array",
           "items": {
-            "description": "Resolve restriction.",
+            "description": "Resolve restriction. Resolve result must fulfill this restriction.",
             "anyOf": [
               {
                 "instanceof": "RegExp",
@@ -2248,10 +2248,10 @@
           }
         },
         "roots": {
-          "description": "A list of root paths.",
+          "description": "A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.",
           "type": "array",
           "items": {
-            "description": "Root path.",
+            "description": "Directory in which requests that are server-relative URLs (starting with '/') are resolved.",
             "type": "string"
           }
         },

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -295,6 +295,9 @@ describe("Defaults", () => {
 		    "modules": Array [
 		      "node_modules",
 		    ],
+		    "roots": Array [
+		      "<cwd>",
+		    ],
 		  },
 		  "resolveLoader": Object {
 		    "cache": false,

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -3225,58 +3225,58 @@ Object {
   "resolve-loader-restrictions": Object {
     "configs": Array [
       Object {
-        "description": "Resolve restriction.",
+        "description": "Resolve restriction. Resolve result must fulfill this restriction.",
         "multiple": true,
         "path": "resolveLoader.restrictions[]",
         "type": "RegExp",
       },
       Object {
-        "description": "Resolve restriction.",
+        "description": "Resolve restriction. Resolve result must fulfill this restriction.",
         "multiple": true,
         "path": "resolveLoader.restrictions[]",
         "type": "string",
       },
     ],
-    "description": "Resolve restriction.",
+    "description": "Resolve restriction. Resolve result must fulfill this restriction.",
     "multiple": true,
     "simpleType": "string",
   },
   "resolve-loader-restrictions-reset": Object {
     "configs": Array [
       Object {
-        "description": "Clear all items provided in configuration. A list of resolve restrictions.",
+        "description": "Clear all items provided in configuration. A list of resolve restrictions. Resolve results must fulfill all of these restrictions to resolve successfully. Other resolve paths are taken when restrictions are not met.",
         "multiple": false,
         "path": "resolveLoader.restrictions",
         "type": "reset",
       },
     ],
-    "description": "Clear all items provided in configuration. A list of resolve restrictions.",
+    "description": "Clear all items provided in configuration. A list of resolve restrictions. Resolve results must fulfill all of these restrictions to resolve successfully. Other resolve paths are taken when restrictions are not met.",
     "multiple": false,
     "simpleType": "boolean",
   },
   "resolve-loader-roots": Object {
     "configs": Array [
       Object {
-        "description": "Root path.",
+        "description": "Directory in which requests that are server-relative URLs (starting with '/') are resolved.",
         "multiple": true,
         "path": "resolveLoader.roots[]",
         "type": "string",
       },
     ],
-    "description": "Root path.",
+    "description": "Directory in which requests that are server-relative URLs (starting with '/') are resolved.",
     "multiple": true,
     "simpleType": "string",
   },
   "resolve-loader-roots-reset": Object {
     "configs": Array [
       Object {
-        "description": "Clear all items provided in configuration. A list of root paths.",
+        "description": "Clear all items provided in configuration. A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.",
         "multiple": false,
         "path": "resolveLoader.roots",
         "type": "reset",
       },
     ],
-    "description": "Clear all items provided in configuration. A list of root paths.",
+    "description": "Clear all items provided in configuration. A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.",
     "multiple": false,
     "simpleType": "boolean",
   },
@@ -3400,58 +3400,58 @@ Object {
   "resolve-restrictions": Object {
     "configs": Array [
       Object {
-        "description": "Resolve restriction.",
+        "description": "Resolve restriction. Resolve result must fulfill this restriction.",
         "multiple": true,
         "path": "resolve.restrictions[]",
         "type": "RegExp",
       },
       Object {
-        "description": "Resolve restriction.",
+        "description": "Resolve restriction. Resolve result must fulfill this restriction.",
         "multiple": true,
         "path": "resolve.restrictions[]",
         "type": "string",
       },
     ],
-    "description": "Resolve restriction.",
+    "description": "Resolve restriction. Resolve result must fulfill this restriction.",
     "multiple": true,
     "simpleType": "string",
   },
   "resolve-restrictions-reset": Object {
     "configs": Array [
       Object {
-        "description": "Clear all items provided in configuration. A list of resolve restrictions.",
+        "description": "Clear all items provided in configuration. A list of resolve restrictions. Resolve results must fulfill all of these restrictions to resolve successfully. Other resolve paths are taken when restrictions are not met.",
         "multiple": false,
         "path": "resolve.restrictions",
         "type": "reset",
       },
     ],
-    "description": "Clear all items provided in configuration. A list of resolve restrictions.",
+    "description": "Clear all items provided in configuration. A list of resolve restrictions. Resolve results must fulfill all of these restrictions to resolve successfully. Other resolve paths are taken when restrictions are not met.",
     "multiple": false,
     "simpleType": "boolean",
   },
   "resolve-roots": Object {
     "configs": Array [
       Object {
-        "description": "Root path.",
+        "description": "Directory in which requests that are server-relative URLs (starting with '/') are resolved.",
         "multiple": true,
         "path": "resolve.roots[]",
         "type": "string",
       },
     ],
-    "description": "Root path.",
+    "description": "Directory in which requests that are server-relative URLs (starting with '/') are resolved.",
     "multiple": true,
     "simpleType": "string",
   },
   "resolve-roots-reset": Object {
     "configs": Array [
       Object {
-        "description": "Clear all items provided in configuration. A list of root paths.",
+        "description": "Clear all items provided in configuration. A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.",
         "multiple": false,
         "path": "resolve.roots",
         "type": "reset",
       },
     ],
-    "description": "Clear all items provided in configuration. A list of root paths.",
+    "description": "Clear all items provided in configuration. A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.",
     "multiple": false,
     "simpleType": "boolean",
   },

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -3254,6 +3254,32 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
+  "resolve-loader-roots": Object {
+    "configs": Array [
+      Object {
+        "description": "Root path.",
+        "multiple": true,
+        "path": "resolveLoader.roots[]",
+        "type": "string",
+      },
+    ],
+    "description": "Root path.",
+    "multiple": true,
+    "simpleType": "string",
+  },
+  "resolve-loader-roots-reset": Object {
+    "configs": Array [
+      Object {
+        "description": "Clear all items provided in configuration. A list of root paths.",
+        "multiple": false,
+        "path": "resolveLoader.roots",
+        "type": "reset",
+      },
+    ],
+    "description": "Clear all items provided in configuration. A list of root paths.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "resolve-loader-symlinks": Object {
     "configs": Array [
       Object {
@@ -3400,6 +3426,32 @@ Object {
       },
     ],
     "description": "Clear all items provided in configuration. A list of resolve restrictions.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "resolve-roots": Object {
+    "configs": Array [
+      Object {
+        "description": "Root path.",
+        "multiple": true,
+        "path": "resolve.roots[]",
+        "type": "string",
+      },
+    ],
+    "description": "Root path.",
+    "multiple": true,
+    "simpleType": "string",
+  },
+  "resolve-roots-reset": Object {
+    "configs": Array [
+      Object {
+        "description": "Clear all items provided in configuration. A list of root paths.",
+        "multiple": false,
+        "path": "resolve.roots",
+        "type": "reset",
+      },
+    ],
+    "description": "Clear all items provided in configuration. A list of root paths.",
     "multiple": false,
     "simpleType": "boolean",
   },

--- a/types.d.ts
+++ b/types.d.ts
@@ -6047,12 +6047,12 @@ declare interface ResolveOptionsWebpackOptions {
 	resolver?: Resolver;
 
 	/**
-	 * A list of resolve restrictions.
+	 * A list of resolve restrictions. Resolve results must fulfill all of these restrictions to resolve successfully. Other resolve paths are taken when restrictions are not met.
 	 */
 	restrictions?: (string | RegExp)[];
 
 	/**
-	 * A list of root paths.
+	 * A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.
 	 */
 	roots?: string[];
 
@@ -6239,11 +6239,11 @@ declare abstract class ResolverFactory {
 						 */
 						resolver?: Resolver;
 						/**
-						 * A list of resolve restrictions.
+						 * A list of resolve restrictions. Resolve results must fulfill all of these restrictions to resolve successfully. Other resolve paths are taken when restrictions are not met.
 						 */
 						restrictions?: (string | RegExp)[];
 						/**
-						 * A list of root paths.
+						 * A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.
 						 */
 						roots?: string[];
 						/**
@@ -6354,11 +6354,11 @@ declare abstract class ResolverFactory {
 						 */
 						resolver?: Resolver;
 						/**
-						 * A list of resolve restrictions.
+						 * A list of resolve restrictions. Resolve results must fulfill all of these restrictions to resolve successfully. Other resolve paths are taken when restrictions are not met.
 						 */
 						restrictions?: (string | RegExp)[];
 						/**
-						 * A list of root paths.
+						 * A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.
 						 */
 						roots?: string[];
 						/**
@@ -6469,11 +6469,11 @@ declare abstract class ResolverFactory {
 			 */
 			resolver?: Resolver;
 			/**
-			 * A list of resolve restrictions.
+			 * A list of resolve restrictions. Resolve results must fulfill all of these restrictions to resolve successfully. Other resolve paths are taken when restrictions are not met.
 			 */
 			restrictions?: (string | RegExp)[];
 			/**
-			 * A list of root paths.
+			 * A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.
 			 */
 			roots?: string[];
 			/**
@@ -8415,11 +8415,11 @@ declare interface WithOptions {
 			 */
 			resolver?: Resolver;
 			/**
-			 * A list of resolve restrictions.
+			 * A list of resolve restrictions. Resolve results must fulfill all of these restrictions to resolve successfully. Other resolve paths are taken when restrictions are not met.
 			 */
 			restrictions?: (string | RegExp)[];
 			/**
-			 * A list of root paths.
+			 * A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.
 			 */
 			roots?: string[];
 			/**

--- a/types.d.ts
+++ b/types.d.ts
@@ -5937,6 +5937,7 @@ declare interface ResolveOptionsTypes {
 		| ((this: Resolver, arg1: Resolver) => void)
 	)[];
 	pnpApi: PnpApiImpl;
+	roots: Set<string>;
 	resolveToContext: boolean;
 	restrictions: Set<string | RegExp>;
 }
@@ -6049,6 +6050,11 @@ declare interface ResolveOptionsWebpackOptions {
 	 * A list of resolve restrictions.
 	 */
 	restrictions?: (string | RegExp)[];
+
+	/**
+	 * A list of root paths.
+	 */
+	roots?: string[];
 
 	/**
 	 * Enable resolving symlinks to the original location.
@@ -6237,6 +6243,10 @@ declare abstract class ResolverFactory {
 						 */
 						restrictions?: (string | RegExp)[];
 						/**
+						 * A list of root paths.
+						 */
+						roots?: string[];
+						/**
 						 * Enable resolving symlinks to the original location.
 						 */
 						symlinks?: boolean;
@@ -6348,6 +6358,10 @@ declare abstract class ResolverFactory {
 						 */
 						restrictions?: (string | RegExp)[];
 						/**
+						 * A list of root paths.
+						 */
+						roots?: string[];
+						/**
 						 * Enable resolving symlinks to the original location.
 						 */
 						symlinks?: boolean;
@@ -6458,6 +6472,10 @@ declare abstract class ResolverFactory {
 			 * A list of resolve restrictions.
 			 */
 			restrictions?: (string | RegExp)[];
+			/**
+			 * A list of root paths.
+			 */
+			roots?: string[];
 			/**
 			 * Enable resolving symlinks to the original location.
 			 */
@@ -7941,6 +7959,11 @@ declare interface UserResolveOptions {
 	pnpApi?: PnpApiImpl;
 
 	/**
+	 * A list of root paths
+	 */
+	roots?: string[];
+
+	/**
 	 * Resolve to a context instead of a file
 	 */
 	resolveToContext?: boolean;
@@ -8395,6 +8418,10 @@ declare interface WithOptions {
 			 * A list of resolve restrictions.
 			 */
 			restrictions?: (string | RegExp)[];
+			/**
+			 * A list of root paths.
+			 */
+			roots?: string[];
 			/**
 			 * Enable resolving symlinks to the original location.
 			 */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2402,10 +2402,10 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@5.0.0-beta.7:
-  version "5.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.0.0-beta.7.tgz#174f085396ac8edc734253f5b6aa9a05cb0d73b2"
-  integrity sha512-4r9mhIEedx7IsNgutSPyFtD0hKukbknr8Fuee36IXg9dYcAeDLb7l6LzBAeiDBgUKeFv+OgMSkCyp/SGCZ5Xag==
+enhanced-resolve@5.0.0-beta.8:
+  version "5.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.0.0-beta.8.tgz#f399920cb9f73350e61ab10bf2c7f36c37dbf032"
+  integrity sha512-6MteIR5h29V8UAsBVXkW7P2cAf+5p/c+Gu79xNCpBPt+hgKcJ0vujcX4vAiMGJjyq3SCHaY5N64C8HXwwRS3gQ==
   dependencies:
     graceful-fs "^4.2.0"
     tapable "^2.0.0-beta.10"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

updated snapshots
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

webpack supports `options.resolve.roots` option. Defaults to `options.context`. 

If request is an server-relative URL (starting with `/`)  `webpack` will try to resolve `path.join(root[i], request)` after trying to resolve the path as absolute path on non-windows systems
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
