### PR TITLE
Fixed typo

### DIFF
--- a/lib/ModuleNotFoundError.js
+++ b/lib/ModuleNotFoundError.js
@@ -61,7 +61,7 @@ class ModuleNotFoundError extends WebpackError {
 					"\n\n" +
 					"BREAKING CHANGE: " +
 					"webpack < 5 used to include polyfills for node.js core modules by default.\n" +
-					"This is no longer the case. Verify if you need these module and configure a polyfill for it.\n\n";
+					"This is no longer the case. Verify if you need this module and configure a polyfill for it.\n\n";
 				if (request !== alias) {
 					message +=
 						"If you want to include a polyfill, you need to:\n" +

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1591,7 +1591,7 @@ exports[`StatsTestCases should print correct stats for module-not-found-error 1`
 Module not found: Error: Can't resolve 'buffer' in 'Xdir/module-not-found-error'
 
 BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
-This is no longer the case. Verify if you need these module and configure a polyfill for it.
+This is no longer the case. Verify if you need this module and configure a polyfill for it.
 
 If you want to include a polyfill, you need to install 'buffer'.
 If you don't want to include a polyfill, you can use an empty module like this:
@@ -1601,7 +1601,7 @@ ERROR in ./index.js 2:0-13
 Module not found: Error: Can't resolve 'os' in 'Xdir/module-not-found-error'
 
 BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
-This is no longer the case. Verify if you need these module and configure a polyfill for it.
+This is no longer the case. Verify if you need this module and configure a polyfill for it.
 
 If you want to include a polyfill, you need to:
 	- add an alias 'resolve.alias: { \\"os\\": \\"os-browserify/browser\\" }'


### PR DESCRIPTION
Perhaps this would be even clearer: "webpack no longer includes polyfills for node.js core modules by default. If you need this module, configure a polyfill for it."

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
