### PR TITLE
improve compatibly with node.js ESM

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1004,6 +1004,12 @@ export interface RuleSetRule {
 	 */
 	compiler?: RuleSetConditionOrConditions;
 	/**
+	 * Match values of properties in the description file (usually package.json).
+	 */
+	descriptionData?: {
+		[k: string]: RuleSetConditionOrConditions;
+	};
+	/**
 	 * Enforce this rule as pre or post step.
 	 */
 	enforce?: "pre" | "post";
@@ -1152,7 +1158,7 @@ export interface ResolveOptions {
 	 */
 	descriptionFiles?: string[];
 	/**
-	 * Enforce using one of the extensions from the extensions option.
+	 * Enforce the resolver to use one of the extensions from the extensions option (User must specify requests without extension).
 	 */
 	enforceExtension?: boolean;
 	/**
@@ -1167,6 +1173,10 @@ export interface ResolveOptions {
 	 * Filesystem for the resolver.
 	 */
 	fileSystem?: import("../lib/util/fs").InputFileSystem;
+	/**
+	 * Treats the request specified by the user as fully specified, meaning no extensions are added and the mainFiles in directories are not resolved (This doesn't affect requests from mainFields, aliasFields or aliases).
+	 */
+	fullySpecified?: boolean;
 	/**
 	 * Field names from the description file (package.json) which are used to find the default entry point.
 	 */

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -88,40 +88,31 @@ class ContextModule extends Module {
 	 * @param {ContextModuleOptions} options options object
 	 */
 	constructor(resolveDependencies, options) {
-		const parsed = parseResource(options.resource);
+		const parsed = parseResource(options ? options.resource : "");
 		const resource = parsed.path;
-		const resourceQuery = options.resourceQuery || parsed.query;
-		const resourceFragment = options.resourceFragment || parsed.fragment;
+		const resourceQuery = (options && options.resourceQuery) || parsed.query;
+		const resourceFragment =
+			(options && options.resourceFragment) || parsed.fragment;
 
 		super("javascript/dynamic", resource);
 
 		// Info from Factory
 		this.resolveDependencies = resolveDependencies;
-		/** @type {Omit<ContextModuleOptions, "resolveOptions">} */
+		/** @type {ContextModuleOptions} */
 		this.options = {
+			...options,
 			resource,
 			resourceQuery,
-			resourceFragment,
-			mode: options.mode,
-			recursive: options.recursive,
-			addon: options.addon,
-			regExp: options.regExp,
-			include: options.include,
-			exclude: options.exclude,
-			chunkName: options.chunkName,
-			groupOptions: options.groupOptions,
-			category: options.category,
-			referencedExports: options.referencedExports,
-			namespaceObject: options.namespaceObject
+			resourceFragment
 		};
-		if (options.resolveOptions !== undefined) {
+		if (options && options.resolveOptions !== undefined) {
 			this.resolveOptions = options.resolveOptions;
 		}
 
 		// Info from Build
 		this._contextDependencies = new Set([this.context]);
 
-		if (typeof options.mode !== "string") {
+		if (options && typeof options.mode !== "string") {
 			throw new Error("options.mode is a required option");
 		}
 
@@ -1036,22 +1027,14 @@ module.exports = webpackEmptyAsyncContext;`;
 
 	serialize(context) {
 		const { write } = context;
-		// constructor
-		write(this.options);
-		// deserialize
+		write(this._identifier);
 		write(this._forceBuild);
 		super.serialize(context);
 	}
 
-	static deserialize(context) {
-		const { read } = context;
-		const obj = new ContextModule(null, read());
-		obj.deserialize(context);
-		return obj;
-	}
-
 	deserialize(context) {
 		const { read } = context;
+		this._identifier = read();
 		this._forceBuild = read();
 		super.deserialize(context);
 	}

--- a/lib/ModuleFactory.js
+++ b/lib/ModuleFactory.js
@@ -5,6 +5,7 @@
 
 "use strict";
 
+/** @typedef {import("../declarations/WebpackOptions").ResolveOptions} ResolveOptions */
 /** @typedef {import("./Dependency")} Dependency */
 /** @typedef {import("./Module")} Module */
 
@@ -25,7 +26,7 @@
 /**
  * @typedef {Object} ModuleFactoryCreateData
  * @property {ModuleFactoryCreateDataContextInfo} contextInfo
- * @property {any=} resolveOptions
+ * @property {ResolveOptions=} resolveOptions
  * @property {string} context
  * @property {Dependency[]} dependencies
  */

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -19,6 +19,7 @@ const NormalModule = require("./NormalModule");
 const RawModule = require("./RawModule");
 const BasicEffectRulePlugin = require("./rules/BasicEffectRulePlugin");
 const BasicMatcherRulePlugin = require("./rules/BasicMatcherRulePlugin");
+const DescriptionDataMatcherRulePlugin = require("./rules/DescriptionDataMatcherRulePlugin");
 const RuleSetCompiler = require("./rules/RuleSetCompiler");
 const UseEffectRulePlugin = require("./rules/UseEffectRulePlugin");
 const LazySet = require("./util/LazySet");
@@ -139,6 +140,7 @@ const ruleSetCompiler = new RuleSetCompiler([
 	new BasicMatcherRulePlugin("realResource"),
 	new BasicMatcherRulePlugin("issuer"),
 	new BasicMatcherRulePlugin("compiler"),
+	new DescriptionDataMatcherRulePlugin(),
 	new BasicEffectRulePlugin("type"),
 	new BasicEffectRulePlugin("sideEffects"),
 	new BasicEffectRulePlugin("parser"),
@@ -401,6 +403,9 @@ class NormalModuleFactory extends ModuleFactory {
 						resourceQuery: resourceDataForRules.query,
 						resourceFragment: resourceDataForRules.fragment,
 						mimetype: matchResourceData ? "" : resourceData.data.mimetype || "",
+						descriptionData: matchResourceData
+							? undefined
+							: resourceData.data.descriptionFileData,
 						issuer: contextInfo.issuer,
 						compiler: contextInfo.compiler
 					});

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -351,8 +351,11 @@ const applyModuleDefaults = (
 		/** @type {RuleSetRules} */
 		const rules = [
 			{
-				type: "javascript/auto",
-				resolve: {}
+				type: "javascript/auto"
+			},
+			{
+				mimetype: "application/node",
+				type: "javascript/auto"
 			},
 			{
 				test: /\.json$/i,
@@ -364,16 +367,56 @@ const applyModuleDefaults = (
 			}
 		];
 		if (mjs) {
-			rules.push({
-				test: /\.mjs$/i,
+			const esm = {
 				type: "javascript/esm",
 				resolve: {
-					mainFields: webTarget ? ["browser", "main"] : ["main"]
+					byDependency: {
+						esm: {
+							fullySpecified: true
+						},
+						wasm: {
+							fullySpecified: true
+						}
+					}
 				}
-			});
+			};
+			const commonjs = {
+				type: "javascript/dynamic"
+			};
+			rules.push(
+				{
+					test: /\.mjs$/i,
+					...esm
+				},
+				{
+					test: /\.js$/i,
+					descriptionData: {
+						type: "module"
+					},
+					...esm
+				},
+				{
+					test: /\.cjs$/i,
+					...commonjs
+				},
+				{
+					test: /\.js$/i,
+					descriptionData: {
+						type: "commonjs"
+					},
+					...commonjs
+				},
+				{
+					mimetype: {
+						or: ["text/javascript", "application/javascript"]
+					},
+					...esm
+				}
+			);
+		} else {
 			rules.push({
 				mimetype: {
-					or: ["text/javascript", "application/javascript", "application/node"]
+					or: ["text/javascript", "application/javascript"]
 				},
 				type: "javascript/auto"
 			});

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -200,7 +200,6 @@ const applyWebpackOptionsDefaults = options => {
 		getResolveDefaults({
 			cache,
 			context: options.context,
-			mjs: options.experiments.mjs,
 			webTarget,
 			target,
 			mode: options.mode
@@ -373,9 +372,6 @@ const applyModuleDefaults = (
 					byDependency: {
 						esm: {
 							fullySpecified: true
-						},
-						wasm: {
-							fullySpecified: true
 						}
 					}
 				}
@@ -422,22 +418,52 @@ const applyModuleDefaults = (
 			});
 		}
 		if (asyncWebAssembly) {
+			const wasm = {
+				type: "webassembly/async"
+			};
+			if (mjs) {
+				wasm.rules = [
+					{
+						descriptionData: {
+							type: "module"
+						},
+						resolve: {
+							fullySpecified: true
+						}
+					}
+				];
+			}
 			rules.push({
 				test: /\.wasm$/i,
-				type: "webassembly/async"
+				...wasm
 			});
 			rules.push({
 				mimetype: "application/wasm",
-				type: "webassembly/async"
+				...wasm
 			});
 		} else if (syncWebAssembly) {
+			const wasm = {
+				type: "webassembly/sync"
+			};
+			if (mjs) {
+				wasm.rules = [
+					{
+						descriptionData: {
+							type: "module"
+						},
+						resolve: {
+							fullySpecified: true
+						}
+					}
+				];
+			}
 			rules.push({
 				test: /\.wasm$/i,
-				type: "webassembly/sync"
+				...wasm
 			});
 			rules.push({
 				mimetype: "application/wasm",
-				type: "webassembly/sync"
+				...wasm
 			});
 		}
 		return rules;
@@ -696,20 +722,12 @@ const applyOptimizationDefaults = (
  * @param {Object} options options
  * @param {boolean} options.cache is cache enable
  * @param {string} options.context build context
- * @param {boolean} options.mjs is mjs enabled
  * @param {boolean} options.webTarget is a web-like target
  * @param {Target} options.target target
  * @param {Mode} options.mode mode
  * @returns {ResolveOptions} resolve options
  */
-const getResolveDefaults = ({
-	cache,
-	context,
-	mjs,
-	webTarget,
-	target,
-	mode
-}) => {
+const getResolveDefaults = ({ cache, context, webTarget, target, mode }) => {
 	/** @type {string[]} */
 	const conditions = ["webpack"];
 
@@ -734,9 +752,7 @@ const getResolveDefaults = ({
 			break;
 	}
 
-	const jsExtensions = [];
-	if (mjs) jsExtensions.push(".mjs");
-	jsExtensions.push(".js", ".json", ".wasm");
+	const jsExtensions = [".js", ".json", ".wasm"];
 
 	/** @type {function(): ResolveOptions} */
 	const cjsDeps = () => ({

--- a/lib/dependencies/RequireContextPlugin.js
+++ b/lib/dependencies/RequireContextPlugin.js
@@ -71,41 +71,44 @@ class RequireContextPlugin {
 							)
 						).options;
 
-						let newItems = [];
-						for (const item of items) {
-							const { request, context } = item;
-							for (const ext of finalResolveOptions.extensions) {
-								if (request.endsWith(ext)) {
-									newItems.push({
-										context,
-										request: request.slice(0, -ext.length)
-									});
+						let newItems;
+						if (!finalResolveOptions.fullySpecified) {
+							newItems = [];
+							for (const item of items) {
+								const { request, context } = item;
+								for (const ext of finalResolveOptions.extensions) {
+									if (request.endsWith(ext)) {
+										newItems.push({
+											context,
+											request: request.slice(0, -ext.length)
+										});
+									}
+								}
+								if (!finalResolveOptions.enforceExtension) {
+									newItems.push(item);
 								}
 							}
-							if (!finalResolveOptions.enforceExtension) {
-								newItems.push(item);
-							}
-						}
-						items = newItems;
+							items = newItems;
 
-						newItems = [];
-						for (const obj of items) {
-							const { request, context } = obj;
-							for (const mainFile of finalResolveOptions.mainFiles) {
-								if (request.endsWith(`/${mainFile}`)) {
-									newItems.push({
-										context,
-										request: request.slice(0, -mainFile.length)
-									});
-									newItems.push({
-										context,
-										request: request.slice(0, -mainFile.length - 1)
-									});
+							newItems = [];
+							for (const obj of items) {
+								const { request, context } = obj;
+								for (const mainFile of finalResolveOptions.mainFiles) {
+									if (request.endsWith(`/${mainFile}`)) {
+										newItems.push({
+											context,
+											request: request.slice(0, -mainFile.length)
+										});
+										newItems.push({
+											context,
+											request: request.slice(0, -mainFile.length - 1)
+										});
+									}
 								}
+								newItems.push(obj);
 							}
-							newItems.push(obj);
+							items = newItems;
 						}
-						items = newItems;
 
 						return items.map(item => {
 							for (const modulesItems of finalResolveOptions.modules) {

--- a/lib/rules/DescriptionDataMatcherRulePlugin.js
+++ b/lib/rules/DescriptionDataMatcherRulePlugin.js
@@ -1,0 +1,43 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+/** @typedef {import("./RuleSetCompiler")} RuleSetCompiler */
+/** @typedef {import("./RuleSetCompiler").RuleCondition} RuleCondition */
+
+const RULE_PROPERTY = "descriptionData";
+
+class DescriptionDataMatcherRulePlugin {
+	/**
+	 * @param {RuleSetCompiler} ruleSetCompiler the rule set compiler
+	 * @returns {void}
+	 */
+	apply(ruleSetCompiler) {
+		ruleSetCompiler.hooks.rule.tap(
+			"DescriptionDataMatcherRulePlugin",
+			(path, rule, unhandledProperties, result) => {
+				if (unhandledProperties.has(RULE_PROPERTY)) {
+					unhandledProperties.delete(RULE_PROPERTY);
+					const value = rule[RULE_PROPERTY];
+					for (const property of Object.keys(value)) {
+						const dataProperty = property.split(".");
+						const condition = ruleSetCompiler.compileCondition(
+							`${path}.${RULE_PROPERTY}.${property}`,
+							value[property]
+						);
+						result.conditions.push({
+							property: ["descriptionData", ...dataProperty],
+							matchWhenEmpty: condition.matchWhenEmpty,
+							fn: condition.fn
+						});
+					}
+				}
+			}
+		);
+	}
+}
+
+module.exports = DescriptionDataMatcherRulePlugin;

--- a/lib/rules/RuleSetCompiler.js
+++ b/lib/rules/RuleSetCompiler.js
@@ -9,7 +9,7 @@ const { SyncHook } = require("tapable");
 
 /**
  * @typedef {Object} RuleCondition
- * @property {string} property
+ * @property {string | string[]} property
  * @property {boolean} matchWhenEmpty
  * @property {function(string): boolean} fn
  */
@@ -76,10 +76,26 @@ class RuleSetCompiler {
 		const execRule = (data, rule, effects) => {
 			for (const condition of rule.conditions) {
 				const p = condition.property;
-				if (p in data) {
+				if (Array.isArray(p)) {
+					let current = data;
+					for (const subProperty of p) {
+						if (typeof current === "object" && subProperty in current) {
+							current = current[subProperty];
+						} else {
+							current = undefined;
+							break;
+						}
+					}
+					if (current !== undefined) {
+						if (!condition.fn(current)) return false;
+						continue;
+					}
+				} else if (p in data) {
 					const value = data[p];
 					if (!condition.fn(value)) return false;
-				} else if (!condition.matchWhenEmpty) {
+					continue;
+				}
+				if (!condition.matchWhenEmpty) {
 					return false;
 				}
 			}

--- a/lib/rules/RuleSetCompiler.js
+++ b/lib/rules/RuleSetCompiler.js
@@ -79,7 +79,11 @@ class RuleSetCompiler {
 				if (Array.isArray(p)) {
 					let current = data;
 					for (const subProperty of p) {
-						if (typeof current === "object" && subProperty in current) {
+						if (
+							current &&
+							typeof current === "object" &&
+							Object.prototype.hasOwnProperty.call(current, subProperty)
+						) {
 							current = current[subProperty];
 						} else {
 							current = undefined;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@webassemblyjs/wasm-parser": "1.9.0",
     "acorn": "^7.3.0",
     "chrome-trace-event": "^1.0.2",
-    "enhanced-resolve": "5.0.0-beta.8",
+    "enhanced-resolve": "5.0.0-beta.10",
     "eslint-scope": "^5.0.0",
     "events": "^3.0.0",
     "glob-to-regexp": "^0.4.1",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2174,7 +2174,7 @@
           }
         },
         "enforceExtension": {
-          "description": "Enforce using one of the extensions from the extensions option.",
+          "description": "Enforce the resolver to use one of the extensions from the extensions option (User must specify requests without extension).",
           "type": "boolean"
         },
         "exportsFields": {
@@ -2197,6 +2197,10 @@
         "fileSystem": {
           "description": "Filesystem for the resolver.",
           "tsType": "(import('../lib/util/fs').InputFileSystem)"
+        },
+        "fullySpecified": {
+          "description": "Treats the request specified by the user as fully specified, meaning no extensions are added and the mainFiles in directories are not resolved (This doesn't affect requests from mainFields, aliasFields or aliases).",
+          "type": "boolean"
         },
         "mainFields": {
           "description": "Field names from the description file (package.json) which are used to find the default entry point.",
@@ -2506,6 +2510,13 @@
               "$ref": "#/definitions/RuleSetConditionOrConditions"
             }
           ]
+        },
+        "descriptionData": {
+          "description": "Match values of properties in the description file (usually package.json).",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/RuleSetConditionOrConditions"
+          }
         },
         "enforce": {
           "description": "Enforce this rule as pre or post step.",

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -109,7 +109,10 @@ describe("Defaults", () => {
 		  "module": Object {
 		    "defaultRules": Array [
 		      Object {
-		        "resolve": Object {},
+		        "type": "javascript/auto",
+		      },
+		      Object {
+		        "mimetype": "application/node",
 		        "type": "javascript/auto",
 		      },
 		      Object {
@@ -119,6 +122,15 @@ describe("Defaults", () => {
 		      Object {
 		        "mimetype": "application/json",
 		        "type": "json",
+		      },
+		      Object {
+		        "mimetype": Object {
+		          "or": Array [
+		            "text/javascript",
+		            "application/javascript",
+		          ],
+		        },
+		        "type": "javascript/auto",
 		      },
 		    ],
 		    "exprContextCritical": true,
@@ -645,27 +657,62 @@ describe("Defaults", () => {
 		-     "mjs": false,
 		+     "mjs": true,
 		@@ ... @@
-		+       Object {
 		+         "resolve": Object {
-		+           "mainFields": Array [
-		+             "browser",
-		+             "main",
-		@@ ... @@
+		+           "byDependency": Object {
+		+             "esm": Object {
+		+               "fullySpecified": true,
+		+             },
+		+             "wasm": Object {
+		+               "fullySpecified": true,
+		+             },
+		+           },
 		+         },
 		+         "test": /\\.mjs$/i,
 		+         "type": "javascript/esm",
 		+       },
 		+       Object {
-		+         "mimetype": Object {
-		+           "or": Array [
-		+             "text/javascript",
-		+             "application/javascript",
-		+             "application/node",
-		+           ],
+		+         "descriptionData": Object {
+		+           "type": "module",
 		+         },
-		+         "type": "javascript/auto",
+		+         "resolve": Object {
+		+           "byDependency": Object {
+		+             "esm": Object {
+		+               "fullySpecified": true,
+		+             },
+		+             "wasm": Object {
+		+               "fullySpecified": true,
+		+             },
+		+           },
+		+         },
+		+         "test": /\\.js$/i,
+		+         "type": "javascript/esm",
 		+       },
-		+     ],
+		+       Object {
+		+         "test": /\\.cjs$/i,
+		+         "type": "javascript/dynamic",
+		+       },
+		+       Object {
+		+         "descriptionData": Object {
+		+           "type": "commonjs",
+		+         },
+		+         "test": /\\.js$/i,
+		+         "type": "javascript/dynamic",
+		+       },
+		+       Object {
+		@@ ... @@
+		-         "type": "javascript/auto",
+		+         "resolve": Object {
+		+           "byDependency": Object {
+		+             "esm": Object {
+		+               "fullySpecified": true,
+		+             },
+		+             "wasm": Object {
+		+               "fullySpecified": true,
+		+             },
+		@@ ... @@
+		+         },
+		+         "type": "javascript/esm",
+		+       },
 		@@ ... @@
 		+           ".mjs",
 		@@ ... @@

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -662,9 +662,6 @@ describe("Defaults", () => {
 		+             "esm": Object {
 		+               "fullySpecified": true,
 		+             },
-		+             "wasm": Object {
-		+               "fullySpecified": true,
-		+             },
 		+           },
 		+         },
 		+         "test": /\\.mjs$/i,
@@ -677,9 +674,6 @@ describe("Defaults", () => {
 		+         "resolve": Object {
 		+           "byDependency": Object {
 		+             "esm": Object {
-		+               "fullySpecified": true,
-		+             },
-		+             "wasm": Object {
 		+               "fullySpecified": true,
 		+             },
 		+           },
@@ -706,28 +700,102 @@ describe("Defaults", () => {
 		+             "esm": Object {
 		+               "fullySpecified": true,
 		+             },
-		+             "wasm": Object {
-		+               "fullySpecified": true,
-		+             },
-		@@ ... @@
+		+           },
 		+         },
 		+         "type": "javascript/esm",
-		+       },
-		@@ ... @@
-		+           ".mjs",
-		@@ ... @@
-		+           ".mjs",
-		@@ ... @@
-		+           ".mjs",
-		@@ ... @@
-		+           ".mjs",
-		@@ ... @@
-		+           ".mjs",
-		@@ ... @@
-		+           ".mjs",
-		@@ ... @@
-		+           ".mjs",
 	`)
+	);
+	test(
+		"mjs + async wasm",
+		{ experiments: { mjs: true, asyncWebAssembly: true } },
+		e =>
+			e.toMatchInlineSnapshot(`
+			- Expected
+			+ Received
+
+			@@ ... @@
+			-     "asyncWebAssembly": false,
+			+     "asyncWebAssembly": true,
+			@@ ... @@
+			-     "mjs": false,
+			+     "mjs": true,
+			@@ ... @@
+			+       },
+			+       Object {
+			+         "resolve": Object {
+			+           "byDependency": Object {
+			+             "esm": Object {
+			+               "fullySpecified": true,
+			+             },
+			+           },
+			+         },
+			+         "test": /\\.mjs$/i,
+			+         "type": "javascript/esm",
+			+       },
+			+       Object {
+			+         "descriptionData": Object {
+			+           "type": "module",
+			+         },
+			+         "resolve": Object {
+			+           "byDependency": Object {
+			+             "esm": Object {
+			+               "fullySpecified": true,
+			+             },
+			+           },
+			+         },
+			+         "test": /\\.js$/i,
+			+         "type": "javascript/esm",
+			+       },
+			+       Object {
+			+         "test": /\\.cjs$/i,
+			+         "type": "javascript/dynamic",
+			@@ ... @@
+			+         "descriptionData": Object {
+			+           "type": "commonjs",
+			+         },
+			+         "test": /\\.js$/i,
+			+         "type": "javascript/dynamic",
+			+       },
+			+       Object {
+			@@ ... @@
+			-         "type": "javascript/auto",
+			+         "resolve": Object {
+			+           "byDependency": Object {
+			+             "esm": Object {
+			+               "fullySpecified": true,
+			+             },
+			+           },
+			+         },
+			+         "type": "javascript/esm",
+			+       },
+			+       Object {
+			+         "rules": Array [
+			+           Object {
+			+             "descriptionData": Object {
+			+               "type": "module",
+			+             },
+			+             "resolve": Object {
+			+               "fullySpecified": true,
+			+             },
+			+           },
+			+         ],
+			+         "test": /\\.wasm$/i,
+			+         "type": "webassembly/async",
+			+       },
+			+       Object {
+			+         "mimetype": "application/wasm",
+			+         "rules": Array [
+			+           Object {
+			+             "descriptionData": Object {
+			+               "type": "module",
+			+             },
+			+             "resolve": Object {
+			+               "fullySpecified": true,
+			+             },
+			+           },
+			+         ],
+			+         "type": "webassembly/async",
+		`)
 	);
 	test("output module", { experiments: { outputModule: true } }, e =>
 		e.toMatchInlineSnapshot(`

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -90,7 +90,7 @@ const describeCases = config => {
 							);
 							const options = {
 								context: casesPath,
-								entry: "./" + category.name + "/" + testName + "/index",
+								entry: "./" + category.name + "/" + testName + "/",
 								target: "async-node",
 								devtool: config.devtool,
 								mode: config.mode || "none",
@@ -127,7 +127,7 @@ const describeCases = config => {
 										"main"
 									],
 									aliasFields: ["browser"],
-									extensions: [".mjs", ".webpack.js", ".web.js", ".js", ".json"]
+									extensions: [".webpack.js", ".web.js", ".js", ".json"]
 								},
 								resolveLoader: {
 									modules: [

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -181,7 +181,7 @@ describe("Validation", () => {
 			expect(msg).toMatchInlineSnapshot(`
 			"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 			 - configuration.module.rules[0].oneOf[0] has an unknown property 'passer'. These properties are valid:
-			   object { compiler?, enforce?, exclude?, generator?, include?, issuer?, loader?, mimetype?, oneOf?, options?, parser?, realResource?, resolve?, resource?, resourceFragment?, resourceQuery?, rules?, sideEffects?, test?, type?, use? }
+			   object { compiler?, descriptionData?, enforce?, exclude?, generator?, include?, issuer?, loader?, mimetype?, oneOf?, options?, parser?, realResource?, resolve?, resource?, resourceFragment?, resourceQuery?, rules?, sideEffects?, test?, type?, use? }
 			   -> A rule description with conditions and effects for modules."
 		`)
 	);

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -2865,13 +2865,13 @@ Object {
   "resolve-enforce-extension": Object {
     "configs": Array [
       Object {
-        "description": "Enforce using one of the extensions from the extensions option.",
+        "description": "Enforce the resolver to use one of the extensions from the extensions option (User must specify requests without extension).",
         "multiple": false,
         "path": "resolve.enforceExtension",
         "type": "boolean",
       },
     ],
-    "description": "Enforce using one of the extensions from the extensions option.",
+    "description": "Enforce the resolver to use one of the extensions from the extensions option (User must specify requests without extension).",
     "multiple": false,
     "simpleType": "boolean",
   },
@@ -2924,6 +2924,19 @@ Object {
       },
     ],
     "description": "Clear all items provided in configuration. Extensions added to the request when trying to find the file.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "resolve-fully-specified": Object {
+    "configs": Array [
+      Object {
+        "description": "Treats the request specified by the user as fully specified, meaning no extensions are added and the mainFiles in directories are not resolved (This doesn't affect requests from mainFields, aliasFields or aliases).",
+        "multiple": false,
+        "path": "resolve.fullySpecified",
+        "type": "boolean",
+      },
+    ],
+    "description": "Treats the request specified by the user as fully specified, meaning no extensions are added and the mainFiles in directories are not resolved (This doesn't affect requests from mainFields, aliasFields or aliases).",
     "multiple": false,
     "simpleType": "boolean",
   },
@@ -3095,13 +3108,13 @@ Object {
   "resolve-loader-enforce-extension": Object {
     "configs": Array [
       Object {
-        "description": "Enforce using one of the extensions from the extensions option.",
+        "description": "Enforce the resolver to use one of the extensions from the extensions option (User must specify requests without extension).",
         "multiple": false,
         "path": "resolveLoader.enforceExtension",
         "type": "boolean",
       },
     ],
-    "description": "Enforce using one of the extensions from the extensions option.",
+    "description": "Enforce the resolver to use one of the extensions from the extensions option (User must specify requests without extension).",
     "multiple": false,
     "simpleType": "boolean",
   },
@@ -3154,6 +3167,19 @@ Object {
       },
     ],
     "description": "Clear all items provided in configuration. Extensions added to the request when trying to find the file.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "resolve-loader-fully-specified": Object {
+    "configs": Array [
+      Object {
+        "description": "Treats the request specified by the user as fully specified, meaning no extensions are added and the mainFiles in directories are not resolved (This doesn't affect requests from mainFields, aliasFields or aliases).",
+        "multiple": false,
+        "path": "resolveLoader.fullySpecified",
+        "type": "boolean",
+      },
+    ],
+    "description": "Treats the request specified by the user as fully specified, meaning no extensions are added and the mainFiles in directories are not resolved (This doesn't affect requests from mainFields, aliasFields or aliases).",
     "multiple": false,
     "simpleType": "boolean",
   },

--- a/test/cases/mjs/cjs-import-default/package.json
+++ b/test/cases/mjs/cjs-import-default/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "index.mjs"
+}

--- a/test/cases/mjs/esm-by-default/package.json
+++ b/test/cases/mjs/esm-by-default/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "index.mjs"
+}

--- a/test/cases/mjs/namespace-object-lazy/index.mjs
+++ b/test/cases/mjs/namespace-object-lazy/index.mjs
@@ -1,85 +1,135 @@
-it("should receive a namespace object when importing commonjs", function(done) {
-	import("./cjs.js").then(function(result) {
-		expect(result).toEqual(nsObj({ default: { named: "named", default: "default" } }));
-		done();
-	}).catch(done);
+it("should receive a namespace object when importing commonjs", function (done) {
+	import("./cjs.js")
+		.then(function (result) {
+			expect(result).toEqual(
+				nsObj({ default: { named: "named", default: "default" } })
+			);
+			done();
+		})
+		.catch(done);
 });
 
-it("should receive a namespace object when importing commonjs with __esModule", function(done) {
-	import("./cjs-esmodule.js").then(function(result) {
-		expect(result).toEqual(nsObj({ default: { __esModule: true, named: "named", default: "default" } }));
-		done();
-	}).catch(done);
+it("should receive a namespace object when importing commonjs with __esModule", function (done) {
+	import("./cjs-esmodule.js")
+		.then(function (result) {
+			expect(result).toEqual(
+				nsObj({
+					default: { __esModule: true, named: "named", default: "default" }
+				})
+			);
+			done();
+		})
+		.catch(done);
 });
 
 function contextCJS(name) {
 	return Promise.all([
 		import(`./dir-cjs/${name}.js`),
-		import(/* webpackMode: "lazy-once" */`./dir-cjs?1/${name}.js`),
-		import(/* webpackMode: "eager" */`./dir-cjs?2/${name}.js`)
-	]).then(function(results) {
-		return import(/* webpackMode: "weak" */`./dir-cjs/${name}.js`).then(function(r) {
-			results.push(r);
-			return results;
-		});
+		import(/* webpackMode: "lazy-once" */ `./dir-cjs?1/${name}.js`),
+		import(/* webpackMode: "eager" */ `./dir-cjs?2/${name}.js`)
+	]).then(function (results) {
+		return import(/* webpackMode: "weak" */ `./dir-cjs/${name}.js`).then(
+			function (r) {
+				results.push(r);
+				return results;
+			}
+		);
 	});
 }
 
 function contextHarmony(name) {
 	return Promise.all([
 		import(`./dir-harmony/${name}.js`),
-		import(/* webpackMode: "lazy-once" */`./dir-harmony?1/${name}.js`),
-		import(/* webpackMode: "eager" */`./dir-harmony?2/${name}.js`)
-	]).then(function(results) {
-		return import(/* webpackMode: "weak" */`./dir-harmony/${name}.js`).then(function(r) {
-			results.push(r);
-			return results;
-		});
+		import(/* webpackMode: "lazy-once" */ `./dir-harmony?1/${name}.js`),
+		import(/* webpackMode: "eager" */ `./dir-harmony?2/${name}.js`)
+	]).then(function (results) {
+		return import(/* webpackMode: "weak" */ `./dir-harmony/${name}.js`).then(
+			function (r) {
+				results.push(r);
+				return results;
+			}
+		);
 	});
 }
 
 function contextMixed(name) {
 	return Promise.all([
 		import(`./dir-mixed/${name}`),
-		import(/* webpackMode: "lazy-once" */`./dir-mixed?1/${name}`),
-		import(/* webpackMode: "eager" */`./dir-mixed?2/${name}`)
-	]).then(function(results) {
-		return import(/* webpackMode: "weak" */`./dir-mixed/${name}`).then(function(r) {
-			results.push(r);
-			return results;
-		});
+		import(/* webpackMode: "lazy-once" */ `./dir-mixed?1/${name}`),
+		import(/* webpackMode: "eager" */ `./dir-mixed?2/${name}`)
+	]).then(function (results) {
+		return import(/* webpackMode: "weak" */ `./dir-mixed/${name}`).then(
+			function (r) {
+				results.push(r);
+				return results;
+			}
+		);
 	});
 }
 
 function promiseTest(promise, equalsTo) {
-	return promise.then(function(results) {
+	return promise.then(function (results) {
 		expect(results).toEqual(results.map(() => equalsTo));
 	});
 }
 
-it("should receive a namespace object when importing commonjs via context", function() {
+it("should receive a namespace object when importing commonjs via context", function () {
 	return Promise.all([
-		promiseTest(contextCJS("one"), nsObj({ default: { named: "named", default: "default" } })),
-		promiseTest(contextCJS("two"), nsObj({ default: { __esModule: true, named: "named", default: "default" } })),
-		promiseTest(contextCJS("three"), nsObj({ default: { named: "named", default: "default" } })),
+		promiseTest(
+			contextCJS("one"),
+			nsObj({ default: { named: "named", default: "default" } })
+		),
+		promiseTest(
+			contextCJS("two"),
+			nsObj({
+				default: { __esModule: true, named: "named", default: "default" }
+			})
+		),
+		promiseTest(
+			contextCJS("three"),
+			nsObj({ default: { named: "named", default: "default" } })
+		),
 		promiseTest(contextCJS("null"), nsObj({ default: null }))
 	]);
 });
 
-it("should receive a namespace object when importing harmony via context", function() {
+it("should receive a namespace object when importing harmony via context", function () {
 	return Promise.all([
-		promiseTest(contextHarmony("one"), nsObj({ named: "named", default: "default" })),
-		promiseTest(contextHarmony("two"), nsObj({ named: "named", default: "default" })),
-		promiseTest(contextHarmony("three"), nsObj({ named: "named", default: "default" }))
+		promiseTest(
+			contextHarmony("one"),
+			nsObj({ named: "named", default: "default" })
+		),
+		promiseTest(
+			contextHarmony("two"),
+			nsObj({ named: "named", default: "default" })
+		),
+		promiseTest(
+			contextHarmony("three"),
+			nsObj({ named: "named", default: "default" })
+		)
 	]);
 });
 
-it("should receive a namespace object when importing mixed content via context", function() {
+it("should receive a namespace object when importing mixed content via context", function () {
 	return Promise.all([
-		promiseTest(contextMixed("one"), nsObj({ default: { named: "named", default: "default" } })),
-		promiseTest(contextMixed("two"), nsObj({ default: { __esModule: true, named: "named", default: "default" } })),
-		promiseTest(contextMixed("three"), nsObj({ named: "named", default: "default" })),
-		promiseTest(contextMixed("null"), nsObj({ default: null })),
-		promiseTest(contextMixed("json.json"), nsObj({ default: { named: "named", default: "default" } }))
+		promiseTest(
+			contextMixed("one.js"),
+			nsObj({ default: { named: "named", default: "default" } })
+		),
+		promiseTest(
+			contextMixed("two.js"),
+			nsObj({
+				default: { __esModule: true, named: "named", default: "default" }
+			})
+		),
+		promiseTest(
+			contextMixed("three.js"),
+			nsObj({ named: "named", default: "default" })
+		),
+		promiseTest(contextMixed("null.js"), nsObj({ default: null })),
+		promiseTest(
+			contextMixed("json.json"),
+			nsObj({ default: { named: "named", default: "default" } })
+		)
 	]);
 });

--- a/test/cases/mjs/namespace-object-lazy/package.json
+++ b/test/cases/mjs/namespace-object-lazy/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "index.mjs"
+}

--- a/test/cases/mjs/no-module-main-field/node_modules/m/a.js
+++ b/test/cases/mjs/no-module-main-field/node_modules/m/a.js
@@ -1,1 +1,1 @@
-export default "nope1";
+export default "yep";

--- a/test/cases/mjs/no-module-main-field/node_modules/m/a.mjs
+++ b/test/cases/mjs/no-module-main-field/node_modules/m/a.mjs
@@ -1,1 +1,1 @@
-export default "yep";
+export default "nope1";

--- a/test/cases/mjs/no-module-main-field/package.json
+++ b/test/cases/mjs/no-module-main-field/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "index.mjs"
+}

--- a/test/cases/mjs/type-module/index.js
+++ b/test/cases/mjs/type-module/index.js
@@ -1,0 +1,5 @@
+it("should not have access to require, module and define", () => {
+	expect(require.webpackTestSuiteRequire).toBe(true);
+	expect(module.webpackTestSuiteModule).toBe(true);
+	expect(typeof define).toBe("undefined");
+});

--- a/test/cases/mjs/type-module/package.json
+++ b/test/cases/mjs/type-module/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/cases/resolving/data-uri/index.js
+++ b/test/cases/resolving/data-uri/index.js
@@ -1,29 +1,29 @@
-it("should require js module from base64 data-uri", function() {
-	const mod = require("data:text/javascript;charset=utf-8;base64,bW9kdWxlLmV4cG9ydHMgPSB7CiAgbnVtYmVyOiA0MiwKICBmbjogKCkgPT4gIkhlbGxvIHdvcmxkIgp9Ow==");
+it("should require js module from base64 data-uri", function () {
+	const mod = require("data:text/javascript;charset=utf-8;base64,ZXhwb3J0IGNvbnN0IG51bWJlciA9IDQyOwpleHBvcnQgZnVuY3Rpb24gZm4oKSB7CiAgcmV0dXJuICJIZWxsbyB3b3JsZCI7Cn0=");
 	expect(mod.number).toBe(42);
 	expect(mod.fn()).toBe("Hello world");
 });
 
-it("should require js module from ascii data-uri", function() {
-	const mod = require("data:text/javascript;charset=utf-8,module.exports={number:42,fn:()=>\"Hello world\"}");
+it("should require js module from ascii data-uri", function () {
+	const mod = require('data:application/node;charset=utf-8,module.exports={number:42,fn:()=>"Hello world"}');
 	expect(mod.number).toBe(42);
 	expect(mod.fn()).toBe("Hello world");
 });
 
-it("should import js module from base64 data-uri", function() {
-	const mod = require('./module-with-imports');
+it("should import js module from base64 data-uri", function () {
+	const mod = require("./module-with-imports");
 	expect(mod.number).toBe(42);
 	expect(mod.fn()).toBe("Hello world");
 });
 
-it("should require coffee module from base64 data-uri", function() {
-	const mod = require('coffee-loader!Data:text/javascript;charset=utf-8;base64,bW9kdWxlLmV4cG9ydHMgPQogIG51bWJlcjogNDIKICBmbjogKCkgLT4gIkhlbGxvIHdvcmxkIg==');
+it("should require coffee module from base64 data-uri", function () {
+	const mod = require("coffee-loader!Data:application/node;charset=utf-8;base64,bW9kdWxlLmV4cG9ydHMgPQogIG51bWJlcjogNDIKICBmbjogKCkgLT4gIkhlbGxvIHdvcmxkIg==");
 	expect(mod.number).toBe(42);
 	expect(mod.fn()).toBe("Hello world");
 });
 
-it("should require json module from base64 data-uri", function() {
-	const mod = require('DATA:application/json;charset=utf-8;base64,ewogICJpdCI6ICJ3b3JrcyIsCiAgIm51bWJlciI6IDQyCn0K');
+it("should require json module from base64 data-uri", function () {
+	const mod = require("DATA:application/json;charset=utf-8;base64,ewogICJpdCI6ICJ3b3JrcyIsCiAgIm51bWJlciI6IDQyCn0K");
 	expect(mod.it).toBe("works");
 	expect(mod.number).toBe(42);
-})
+});

--- a/test/configCases/mjs/esm-by-default/webpack.config.js
+++ b/test/configCases/mjs/esm-by-default/webpack.config.js
@@ -1,2 +1,6 @@
 /** @type {import("../../../../").Configuration} */
-module.exports = {};
+module.exports = {
+	experiments: {
+		mjs: true
+	}
+};

--- a/test/configCases/plugins/provide-plugin/webpack.config.js
+++ b/test/configCases/plugins/provide-plugin/webpack.config.js
@@ -12,7 +12,10 @@ module.exports = {
 			es2015_alias: ["./harmony", "alias"],
 			es2015_year: ["./harmony", "year"],
 			"this.aaa": "./aaa",
-			esm: "./esm"
+			esm: "./esm.js"
 		})
-	]
+	],
+	experiments: {
+		mjs: true
+	}
 };

--- a/types.d.ts
+++ b/types.d.ts
@@ -2722,22 +2722,41 @@ declare interface FileCacheOptions {
 	version?: string;
 }
 declare interface FileSystem {
-	readFile: (
-		arg0: string,
-		arg1: (arg0: PossibleFileSystemError & Error, arg1: string | Buffer) => void
-	) => void;
-	readJson?: (
-		arg0: string,
-		arg1: (arg0: PossibleFileSystemError & Error, arg1?: any) => void
-	) => void;
-	readlink: (
-		arg0: string,
-		arg1: (arg0: PossibleFileSystemError & Error, arg1: string | Buffer) => void
-	) => void;
-	stat: (
-		arg0: string,
-		arg1: (arg0: PossibleFileSystemError & Error, arg1: FileSystemStats) => void
-	) => void;
+	readFile: {
+		(arg0: string, arg1: FileSystemCallback<string | Buffer>): void;
+		(arg0: string, arg1: any, arg2: FileSystemCallback<string | Buffer>): void;
+	};
+	readdir: {
+		(
+			arg0: string,
+			arg1: FileSystemCallback<(string | Buffer)[] | FileSystemDirent[]>
+		): void;
+		(
+			arg0: string,
+			arg1: any,
+			arg2: FileSystemCallback<(string | Buffer)[] | FileSystemDirent[]>
+		): void;
+	};
+	readJson?: {
+		(arg0: string, arg1: FileSystemCallback<any>): void;
+		(arg0: string, arg1: any, arg2: FileSystemCallback<any>): void;
+	};
+	readlink: {
+		(arg0: string, arg1: FileSystemCallback<string | Buffer>): void;
+		(arg0: string, arg1: any, arg2: FileSystemCallback<string | Buffer>): void;
+	};
+	stat: {
+		(arg0: string, arg1: FileSystemCallback<FileSystemStats>): void;
+		(arg0: string, arg1: any, arg2: FileSystemCallback<string | Buffer>): void;
+	};
+}
+declare interface FileSystemCallback<T> {
+	(err: PossibleFileSystemError & Error, result: T): any;
+}
+declare interface FileSystemDirent {
+	name: string | Buffer;
+	isDirectory: () => boolean;
+	isFile: () => boolean;
 }
 declare abstract class FileSystemInfo {
 	fs: InputFileSystem;
@@ -4047,7 +4066,7 @@ declare abstract class ModuleFactory {
 }
 declare interface ModuleFactoryCreateData {
 	contextInfo: ModuleFactoryCreateDataContextInfo;
-	resolveOptions?: any;
+	resolveOptions?: ResolveOptionsWebpackOptions;
 	context: string;
 	dependencies: Dependency[];
 }
@@ -5952,7 +5971,7 @@ declare interface ResolveContext {
 }
 declare interface ResolveData {
 	contextInfo: ModuleFactoryCreateDataContextInfo;
-	resolveOptions: any;
+	resolveOptions: ResolveOptionsWebpackOptions;
 	context: string;
 	request: string;
 	dependencies: ModuleDependency[];
@@ -6006,6 +6025,7 @@ declare interface ResolveOptionsTypes {
 	)[];
 	pnpApi: PnpApiImpl;
 	roots: Set<string>;
+	fullySpecified: boolean;
 	resolveToContext: boolean;
 	restrictions: Set<string | RegExp>;
 }
@@ -6070,7 +6090,7 @@ declare interface ResolveOptionsWebpackOptions {
 	descriptionFiles?: string[];
 
 	/**
-	 * Enforce using one of the extensions from the extensions option.
+	 * Enforce the resolver to use one of the extensions from the extensions option (User must specify requests without extension).
 	 */
 	enforceExtension?: boolean;
 
@@ -6088,6 +6108,11 @@ declare interface ResolveOptionsWebpackOptions {
 	 * Filesystem for the resolver.
 	 */
 	fileSystem?: InputFileSystem;
+
+	/**
+	 * Treats the request specified by the user as fully specified, meaning no extensions are added and the mainFiles in directories are not resolved (This doesn't affect requests from mainFields, aliasFields or aliases).
+	 */
+	fullySpecified?: boolean;
 
 	/**
 	 * Field names from the description file (package.json) which are used to find the default entry point.
@@ -6163,6 +6188,7 @@ declare interface ResolveRequest {
 	descriptionFileData?: any;
 	relativePath?: string;
 	ignoreSymlinks?: boolean;
+	fullySpecified?: boolean;
 }
 declare abstract class Resolver {
 	fileSystem: FileSystem;
@@ -6271,7 +6297,7 @@ declare abstract class ResolverFactory {
 						 */
 						descriptionFiles?: string[];
 						/**
-						 * Enforce using one of the extensions from the extensions option.
+						 * Enforce the resolver to use one of the extensions from the extensions option (User must specify requests without extension).
 						 */
 						enforceExtension?: boolean;
 						/**
@@ -6286,6 +6312,10 @@ declare abstract class ResolverFactory {
 						 * Filesystem for the resolver.
 						 */
 						fileSystem?: InputFileSystem;
+						/**
+						 * Treats the request specified by the user as fully specified, meaning no extensions are added and the mainFiles in directories are not resolved (This doesn't affect requests from mainFields, aliasFields or aliases).
+						 */
+						fullySpecified?: boolean;
 						/**
 						 * Field names from the description file (package.json) which are used to find the default entry point.
 						 */
@@ -6386,7 +6416,7 @@ declare abstract class ResolverFactory {
 						 */
 						descriptionFiles?: string[];
 						/**
-						 * Enforce using one of the extensions from the extensions option.
+						 * Enforce the resolver to use one of the extensions from the extensions option (User must specify requests without extension).
 						 */
 						enforceExtension?: boolean;
 						/**
@@ -6401,6 +6431,10 @@ declare abstract class ResolverFactory {
 						 * Filesystem for the resolver.
 						 */
 						fileSystem?: InputFileSystem;
+						/**
+						 * Treats the request specified by the user as fully specified, meaning no extensions are added and the mainFiles in directories are not resolved (This doesn't affect requests from mainFields, aliasFields or aliases).
+						 */
+						fullySpecified?: boolean;
 						/**
 						 * Field names from the description file (package.json) which are used to find the default entry point.
 						 */
@@ -6501,7 +6535,7 @@ declare abstract class ResolverFactory {
 			 */
 			descriptionFiles?: string[];
 			/**
-			 * Enforce using one of the extensions from the extensions option.
+			 * Enforce the resolver to use one of the extensions from the extensions option (User must specify requests without extension).
 			 */
 			enforceExtension?: boolean;
 			/**
@@ -6516,6 +6550,10 @@ declare abstract class ResolverFactory {
 			 * Filesystem for the resolver.
 			 */
 			fileSystem?: InputFileSystem;
+			/**
+			 * Treats the request specified by the user as fully specified, meaning no extensions are added and the mainFiles in directories are not resolved (This doesn't affect requests from mainFields, aliasFields or aliases).
+			 */
+			fullySpecified?: boolean;
 			/**
 			 * Field names from the description file (package.json) which are used to find the default entry point.
 			 */
@@ -6620,6 +6658,11 @@ declare interface RuleSetRule {
 	 * Match the child compiler name.
 	 */
 	compiler?: RuleSetCondition;
+
+	/**
+	 * Match values of properties in the description file (usually package.json).
+	 */
+	descriptionData?: { [index: string]: RuleSetCondition };
 
 	/**
 	 * Enforce this rule as pre or post step.
@@ -8033,6 +8076,11 @@ declare interface UserResolveOptions {
 	roots?: string[];
 
 	/**
+	 * The request is already fully specified and no extensions or directories are resolved for it
+	 */
+	fullySpecified?: boolean;
+
+	/**
 	 * Resolve to a context instead of a file
 	 */
 	resolveToContext?: boolean;
@@ -8448,7 +8496,7 @@ declare interface WithOptions {
 			 */
 			descriptionFiles?: string[];
 			/**
-			 * Enforce using one of the extensions from the extensions option.
+			 * Enforce the resolver to use one of the extensions from the extensions option (User must specify requests without extension).
 			 */
 			enforceExtension?: boolean;
 			/**
@@ -8463,6 +8511,10 @@ declare interface WithOptions {
 			 * Filesystem for the resolver.
 			 */
 			fileSystem?: InputFileSystem;
+			/**
+			 * Treats the request specified by the user as fully specified, meaning no extensions are added and the mainFiles in directories are not resolved (This doesn't affect requests from mainFields, aliasFields or aliases).
+			 */
+			fullySpecified?: boolean;
 			/**
 			 * Field names from the description file (package.json) which are used to find the default entry point.
 			 */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2396,10 +2396,10 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@5.0.0-beta.8:
-  version "5.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.0.0-beta.8.tgz#f399920cb9f73350e61ab10bf2c7f36c37dbf032"
-  integrity sha512-6MteIR5h29V8UAsBVXkW7P2cAf+5p/c+Gu79xNCpBPt+hgKcJ0vujcX4vAiMGJjyq3SCHaY5N64C8HXwwRS3gQ==
+enhanced-resolve@5.0.0-beta.10:
+  version "5.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.0.0-beta.10.tgz#3907c034f8e59446dfa5a89a1fd73db29aa0f246"
+  integrity sha512-vEyxvHv3f8xl7i7QmTQ6BqKY32acSPQ4dTZo8WRMtcqTDYH9YyXnDxqXsQqBLvdRHUiwl9nVivESiM1RcrxbKQ==
   dependencies:
     graceful-fs "^4.2.0"
     tapable "^2.0.0-beta.10"


### PR DESCRIPTION
improve experiments.mjs to be more compatibly with node.js ESM
  - add support for `type: "module"` in package.json
  - add support for `*.cjs`
  - enable strict ESM for data uris with `text/javascript` or `application/javascript`
  - disallow not fully specified requests in imports `*.mjs` or `type: "module"`

add `descriptionData` rule condition to match package.json info
fix passing resolveOptions along context modules

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature, experiment
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes to the experiment
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Using `*.js` with `"type": "module"` in package.json or `*.mjs` moves webpack into a strict ESM mode where more limitations are applied:
* Importing named exports from non-esm modules (e. g. CommonJs, JSON) is no longer possible. Only the default export can be used.
  * `import * as X from "commonjs"` creates a namespace object with default export instead of behaving like `const X = require("commonjs")
* Requests has to be fully specified, with filename and extension (expect for bare modules without subpath)
* CommonJs Syntax is not available: `require`, `module`, `exports`, `__filename`, `__dirname`
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
