### PR TITLE
fix: add missing optional peer dependency webpack-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
     "watchpack": "2.0.0-beta.13",
     "webpack-sources": "2.0.0-beta.8"
   },
-  "peerDependencies": {
-    "webpack-cli": "*"
-  },
   "peerDependenciesMeta": {
     "webpack-cli": {
       "optional": true

--- a/package.json
+++ b/package.json
@@ -28,6 +28,14 @@
     "watchpack": "2.0.0-beta.13",
     "webpack-sources": "2.0.0-beta.8"
   },
+  "peerDependencies": {
+    "webpack-cli": "*"
+  },
+  "peerDependenciesMeta": {
+    "webpack-cli": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@babel/core": "^7.7.2",
     "@babel/preset-react": "^7.10.1",


### PR DESCRIPTION
Webpack tries to require `webpack-cli` without declaring it as a optional peer dependency which causes it to not get access to it under Yarn PnP

Fixes half of https://github.com/yarnpkg/berry/issues/1452

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
No

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
N/A