### PR TITLE
fix: add missing optional peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,18 @@
     "watchpack": "^1.6.1",
     "webpack-sources": "^1.4.1"
   },
+  "peerDependencies": {
+    "webpack-cli": "*",
+    "webpack-command": "*"
+  },
+  "peerDependenciesMeta": {
+    "webpack-cli": {
+      "optional": true
+    },
+    "webpack-command": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@babel/core": "^7.7.2",
     "@types/node": "^10.12.21",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,6 @@
     "watchpack": "^1.6.1",
     "webpack-sources": "^1.4.1"
   },
-  "peerDependencies": {
-    "webpack-cli": "*",
-    "webpack-command": "*"
-  },
   "peerDependenciesMeta": {
     "webpack-cli": {
       "optional": true


### PR DESCRIPTION
Webpack is trying to access `webpack-cli` and `webpack-command` without declaring them as optional peer dependencies which causes it to not get access to either of them under Yarn PnP

PR for Webpack 5: https://github.com/webpack/webpack/pull/11189

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
No

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
N/A