### PR TITLE
Multi-module support to identifier in ProvidedPlugin.

### DIFF
--- a/lib/ProvidePlugin.js
+++ b/lib/ProvidePlugin.js
@@ -16,6 +16,7 @@ class ProvidePlugin {
 
 	apply(compiler) {
 		const definitions = this.definitions;
+
 		compiler.hooks.compilation.tap(
 			"ProvidePlugin",
 			(compilation, { normalModuleFactory }) => {
@@ -24,34 +25,22 @@ class ProvidePlugin {
 					ConstDependency,
 					new ConstDependency.Template()
 				);
+
 				const handler = (parser, parserOptions) => {
 					Object.keys(definitions).forEach(name => {
 						var request = [].concat(definitions[name]);
 						var splittedName = name.split(".");
-						if (splittedName.length > 0) {
-							splittedName.slice(1).forEach((_, i) => {
-								const name = splittedName.slice(0, i + 1).join(".");
-								parser.hooks.canRename
-									.for(name)
-									.tap("ProvidePlugin", ParserHelpers.approve);
-							});
-						}
+
+						approveCanRename(parser, splittedName);
+
 						parser.hooks.expression.for(name).tap("ProvidePlugin", expr => {
-							let nameIdentifier = name;
-							const scopedName = name.includes(".");
-							let expression = `require(${JSON.stringify(request[0])})`;
-							if (scopedName) {
-								nameIdentifier = `__webpack_provided_${name.replace(
-									/\./g,
-									"_dot_"
-								)}`;
-							}
-							if (request.length > 1) {
-								expression += request
-									.slice(1)
-									.map(r => `[${JSON.stringify(r)}]`)
-									.join("");
-							}
+							const scopedName = valueFactory.scopedName(name);
+							const nameIdentifier = valueFactory.nameIdentifier(
+								name,
+								scopedName
+							);
+							const expression = valueFactory.expression(request);
+
 							if (
 								!ParserHelpers.addParsedVariableToModule(
 									parser,
@@ -61,19 +50,23 @@ class ProvidePlugin {
 							) {
 								return false;
 							}
+
 							if (scopedName) {
 								ParserHelpers.toConstantDependency(
 									parser,
 									nameIdentifier
 								)(expr);
 							}
+
 							return true;
 						});
 					});
 				};
+
 				normalModuleFactory.hooks.parser
 					.for("javascript/auto")
 					.tap("ProvidePlugin", handler);
+
 				normalModuleFactory.hooks.parser
 					.for("javascript/dynamic")
 					.tap("ProvidePlugin", handler);
@@ -83,4 +76,55 @@ class ProvidePlugin {
 		);
 	}
 }
+
+const approveCanRename = (parser, names) => {
+	if (names.length > 0) {
+		names.slice(1).forEach((_, i) => {
+			const targetName = names.slice(0, i + 1).join(".");
+
+			parser.hooks.canRename
+				.for(targetName)
+				.tap("ProvidePlugin", ParserHelpers.approve);
+		});
+	}
+};
+
+const valueFactory = {
+	scopedName: name => {
+		return name.includes(".");
+	},
+	nameIdentifier: (name, scopedName) => {
+		var value = name;
+
+		if (scopedName) {
+			value = `__webpack_provided_${name.replace(/\./g, "_dot_")}`;
+		}
+
+		return value;
+	},
+	expression: request => {
+		const buildRequireStatement = modules =>
+			modules.map(module => `require(${JSON.stringify(module)})`).join(", ");
+
+		let requireStatement = (() => {
+			if (request[0] instanceof Array) {
+				return buildRequireStatement(request[0]);
+			} else {
+				return buildRequireStatement([request[0]]);
+			}
+		})();
+
+		if (request.length > 1) {
+			let propertyAccessor = request
+				.slice(1)
+				.map(property => `[${JSON.stringify(property)}]`)
+				.join("");
+
+			return requireStatement.concat(propertyAccessor);
+		} else {
+			return requireStatement;
+		}
+	}
+};
+
 module.exports = ProvidePlugin;


### PR DESCRIPTION
In case of needs to use "jquery" and "jquery-ui" by a same identifier like "$",

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature, refactoring

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

It is be able to add webpack config file by declaring first element as array like below.

```
new webpack.ProvidePlugin({
            $: [["jquery", "jquery-ui"]]
)}
```

And also it can be available to get specific property by adding elements like below.

```
new webpack.ProvidePlugin({
            UI : [["jquery", "jquery-ui"], "ui"]
)}
```

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
