### PR TITLE
Backport of resolve.roots for webpack 4

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -710,7 +710,7 @@ export interface ResolveOptions {
 		[k: string]: any;
 	};
 	/**
-	 * A list of root paths.
+	 * A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.
 	 */
 	roots?: string[];
 	/**

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -710,6 +710,10 @@ export interface ResolveOptions {
 		[k: string]: any;
 	};
 	/**
+	 * A list of root paths.
+	 */
+	roots?: string[];
+	/**
 	 * Enable resolving symlinks to the original location
 	 */
 	symlinks?: boolean;

--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -362,6 +362,7 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 		this.set("resolveLoader.mainFields", ["loader", "main"]);
 		this.set("resolveLoader.extensions", [".js", ".json"]);
 		this.set("resolveLoader.mainFiles", ["index"]);
+		this.set("resolveLoader.roots", "make", options => [options.context]);
 		this.set("resolveLoader.cacheWithContext", "make", options => {
 			return (
 				Array.isArray(options.resolveLoader.plugins) &&

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ajv": "^6.10.2",
     "ajv-keywords": "^3.4.1",
     "chrome-trace-event": "^1.0.2",
-    "enhanced-resolve": "^4.1.0",
+    "enhanced-resolve": "^4.3.0",
     "eslint-scope": "^4.0.3",
     "json-parse-better-errors": "^1.0.2",
     "loader-runner": "^2.4.0",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1230,10 +1230,10 @@
           "description": "Custom resolver"
         },
         "roots": {
-          "description": "A list of root paths.",
+          "description": "A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.",
           "type": "array",
           "items": {
-            "description": "Root path.",
+            "description": "Directory in which requests that are server-relative URLs (starting with '/') are resolved.",
             "type": "string"
           }
         },

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1229,6 +1229,14 @@
         "resolver": {
           "description": "Custom resolver"
         },
+        "roots": {
+          "description": "A list of root paths.",
+          "type": "array",
+          "items": {
+            "description": "Root path.",
+            "type": "string"
+          }
+        },
         "symlinks": {
           "description": "Enable resolving symlinks to the original location",
           "type": "boolean"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1980,10 +1980,10 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz#2937e2b8066cd0fe7ce0990a98f0d71a35189f66"
-  integrity sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==
+enhanced-resolve@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz#3b806f3bfafc1ec7de69551ef93cca46c1704126"
+  integrity sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==
   dependencies:
     graceful-fs "^4.1.2"
     memory-fs "^0.5.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


backport of #11143 
fixes #11206

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
Invalid absolute paths that produced an error before may know resolved correctly, but I won't consider this as breaking
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
webpack supports `options.resolve.roots` option. Defaults to `options.context`. 

If request is an server-relative URL (starting with `/`)  `webpack` will try to resolve `path.join(root[i], request)` after trying to resolve the path as absolute path on non-windows systems
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
