### PR TITLE
feat(contextMode): add config option for setting default webpackMode

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -166,6 +166,16 @@ export type FilterItemTypes = RegExp | string | ((value: string) => boolean);
  */
 export type Mode = "development" | "production" | "none";
 /**
+ * A mode in which to load modules asynchronously.
+ */
+export type ContextMode =
+	| "sync"
+	| "eager"
+	| "weak"
+	| "async-weak"
+	| "lazy"
+	| "lazy-once";
+/**
  * One or multiple rule conditions.
  */
 export type RuleSetConditionOrConditions = RuleSetCondition | RuleSetConditions;
@@ -922,6 +932,10 @@ export interface Loader {
  * Options affecting the normal modules (`NormalModuleFactory`).
  */
 export interface ModuleOptions {
+	/**
+	 * Sets the default context mode for asynchronously loading modules.
+	 */
+	contextMode?: ContextMode;
 	/**
 	 * An array of rules applied by default for modules.
 	 */

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -40,7 +40,7 @@ const makeSerializable = require("./util/makeSerializable");
 /** @typedef {import("./dependencies/ContextElementDependency")} ContextElementDependency */
 /** @typedef {import("./util/fs").InputFileSystem} InputFileSystem */
 
-/** @typedef {"sync" | "eager" | "weak" | "async-weak" | "lazy" | "lazy-once"} ContextMode Context mode */
+/** @typedef {import("../declarations/WebpackOptions").ContextMode} ContextMode Context mode */
 
 /**
  * @typedef {Object} ContextOptions

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -322,6 +322,7 @@ const applyModuleDefaults = (
 	module,
 	{ cache, mjs, syncWebAssembly, asyncWebAssembly, webTarget }
 ) => {
+	D(module, "contextMode", "lazy");
 	D(module, "unknownContextRequest", ".");
 	D(module, "unknownContextRegExp", false);
 	D(module, "unknownContextRecursive", true);

--- a/lib/dependencies/ImportParserPlugin.js
+++ b/lib/dependencies/ImportParserPlugin.js
@@ -28,7 +28,7 @@ class ImportParserPlugin {
 
 			let chunkName = null;
 			/** @type {ContextMode} */
-			let mode = "lazy";
+			let mode = this.options.contextMode;
 			let include = null;
 			let exclude = null;
 			/** @type {string[][] | null} */

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -91,6 +91,10 @@
       "type": "string",
       "absolutePath": true
     },
+    "ContextMode": {
+      "description": "A mode in which to load modules asynchronously.",
+      "enum": ["sync", "eager", "weak", "async-weak", "lazy", "lazy-once"]
+    },
     "CrossOriginLoading": {
       "description": "This option enables cross-origin loading of chunks.",
       "enum": [false, "anonymous", "use-credentials"]
@@ -883,6 +887,17 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "contextMode": {
+          "description": "Sets the default context mode for asynchronously loading modules.",
+          "cli": {
+            "exclude": true
+          },
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ContextMode"
+            }
+          ]
+        },
         "defaultRules": {
           "description": "An array of rules applied by default for modules.",
           "cli": {

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -107,6 +107,7 @@ describe("Defaults", () => {
 		  "loader": undefined,
 		  "mode": "none",
 		  "module": Object {
+		    "contextMode": "lazy",
 		    "defaultRules": Array [
 		      Object {
 		        "type": "javascript/auto",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1726,6 +1726,13 @@ declare class ContextExclusionPlugin {
 	 */
 	apply(compiler: Compiler): void;
 }
+type ContextMode =
+	| "sync"
+	| "eager"
+	| "weak"
+	| "async-weak"
+	| "lazy"
+	| "lazy-once";
 declare abstract class ContextModuleFactory extends ModuleFactory {
 	hooks: Readonly<{
 		beforeResolve: AsyncSeriesWaterfallHook<[any]>;
@@ -1740,7 +1747,7 @@ declare abstract class ContextModuleFactory extends ModuleFactory {
 			[
 				any[],
 				{
-					mode: "sync" | "eager" | "weak" | "async-weak" | "lazy" | "lazy-once";
+					mode: ContextMode;
 					recursive: boolean;
 					regExp: RegExp;
 					namespaceObject?: boolean | "strict";
@@ -1766,7 +1773,7 @@ declare abstract class ContextModuleFactory extends ModuleFactory {
 	resolveDependencies(
 		fs: InputFileSystem,
 		options: {
-			mode: "sync" | "eager" | "weak" | "async-weak" | "lazy" | "lazy-once";
+			mode: ContextMode;
 			recursive: boolean;
 			regExp: RegExp;
 			namespaceObject?: boolean | "strict";
@@ -4244,6 +4251,11 @@ declare class ModuleGraphConnection {
  * Options affecting the normal modules (`NormalModuleFactory`).
  */
 declare interface ModuleOptions {
+	/**
+	 * Sets the default context mode for asynchronously loading modules.
+	 */
+	contextMode?: ContextMode;
+
 	/**
 	 * An array of rules applied by default for modules.
 	 */


### PR DESCRIPTION
Based on this suggestion https://github.com/webpack/webpack/issues/11012 we should allow for a default `webpackMode` to be set on the config level, that can then be overridden by a magic comment. It's set to `lazy` by default, to match what the current default is.

I made the option available under `module.contextMode`, as in the code it's referred to as the context mode. I think `module.webpackMode` may lead to confusion with `module.mode`, as the name implies it's the mode for webpack.

We could, however, allow for all of the values for the all the supported magic comments https://webpack.js.org/api/module-methods/#magic-comments. Instead of `module.contextMode`, we could add `module.importDefaults` or `module.import` being an object with defaults for all of the magic comments. `module.(import|importDefaults).exclude`, `module.(import|importDefaults).(webpackMode|mode)`?

I'm leaving this as a draft PR for now so we can discuss.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Adds a new configuration option to set the default `webpackMode` (context mode) when using `import()`.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Added a test for the default config, but will add more once I've talked about how this should be tested.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

It does not, as this keeps the default value the same as it was before, and just reads the value from the config instead of being hard coded.

**What needs to be documented once your changes are merged?**

The ability to define the default mode/possibly all the default magic comment options will need to be documented, I'll add a follow up PR to the docs once this PR has been approved.