### PR TITLE
show deprecation for additionalAssets hook

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -517,7 +517,8 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			additionalAssets: createProcessAssetsHook(
 				"additionalAssets",
 				Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
-				() => []
+				() => [],
+				"dep_webpack_compilation_additional_assets".toUpperCase()
 			),
 			// TODO webpack 6 remove
 			/** @deprecated */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Show deprecation when users use `additionalAssets` hook:

> (node:29478) [DEP_WEBPACK_COMPILATION_ADDITIONAL_ASSETS] DeprecationWarning: additionalAssets is deprecated (use Compilation.hook.processAssets instead and use one of Compilation.PROCESS_ASSETS_STAGE_* as stage option)

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

no

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
no

**What needs to be documented once your changes are merged?**

I'll add a notice to document for the hook.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
