### PR TITLE
SplitChunksPlugin: Add newly created chunk to keys index map

### DIFF
--- a/lib/optimize/SplitChunksPlugin.js
+++ b/lib/optimize/SplitChunksPlugin.js
@@ -701,9 +701,13 @@ module.exports = class SplitChunksPlugin {
 					const ZERO = BigInt("0");
 					const ONE = BigInt("1");
 					let index = ONE;
-					for (const chunk of chunks) {
+					const setChunkInIndexMap = chunk => {
 						chunkIndexMap.set(chunk, index);
 						index = index << ONE;
+					};
+
+					for (const chunk of chunks) {
+						setChunkInIndexMap(chunk);
 					}
 					/**
 					 * @param {Iterable<Chunk>} chunks list of chunks
@@ -1274,6 +1278,7 @@ module.exports = class SplitChunksPlugin {
 						// Create the new chunk if not reusing one
 						if (!isExistingChunk) {
 							newChunk = compilation.addChunk(chunkName);
+							setChunkInIndexMap(newChunk);
 						}
 						// Walk through all chunks
 						for (const chunk of usedChunks) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Hello 👋 
Usure whether that's a fix to the actual cause of the error, or just fixing it's symptom.
However PR is better than an issue, so here's my take at it 🙂  

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix

In webpack@5 beta-26 (and also previous versions), in certain scenarios, webpack would crash with the following:
```
../node_modules/webpack/lib/optimize/SplitChunksPlugin.js:722
							key = key | chunkIndexMap.get(result.value);
							          ^

TypeError: Cannot mix BigInt and other types, use explicit conversions
    at getKey (../node_modules/webpack/lib/optimize/SplitChunksPlugin.js:722:18)
    at compilation.hooks.optimizeChunks.tap.chunks (../node_modules/webpack/lib/optimize/SplitChunksPlugin.js:1245:11)
    at Hook.eval [as call] (eval at create (../node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:25:16)
    at Hook.CALL_DELEGATE [as _call] (../node_modules/tapable/lib/Hook.js:14:14)
    at Compilation.seal (../node_modules/webpack/lib/Compilation.js:1877:36)
    at compilation.finish.err (../node_modules/webpack/lib/Compiler.js:972:20)
    at hooks.finishModules.callAsync.err (../node_modules/webpack/lib/Compilation.js:1700:4)
    at _next4 (eval at create (../node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:25:1)
    at _err4 (eval at create (../node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:70:1)
    at asyncLib.each.err (../node_modules/webpack/lib/FlagDependencyExportsPlugin.js:331:11)
```

What seems to be happening is, a new common chunk is created here:
https://github.com/webpack/webpack/blob/master/lib/optimize/SplitChunksPlugin.js#L1276

Then some `chunk` would be removed from `usedChunks`:
https://github.com/webpack/webpack/blob/master/lib/optimize/SplitChunksPlugin.js#L1231

So this line would hit:
https://github.com/webpack/webpack/blob/master/lib/optimize/SplitChunksPlugin.js#L1241

and call `getKeys()` with a chunk we don't have in the `chunkIndexMap` map, and therefor would
result in calling binary or on `BigInt` and `undefined` and thus fail.


**Did you add tests for your changes?**
Unfortunately I'm unable to reduce this to a minimal repro case, it seems to be somehow related to the order of imports in a big project we have. 

I, however, tested this patch on a project with the above stack trace, and it indeed fixes it.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
I hope no =)
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
