### PR TITLE
Move `generator` control from suffix to prefix

### DIFF
--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -88,8 +88,8 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 										? expr.params[0].range[0]
 										: expr.body.range[0]
 								],
-								prefix: `${expr.async ? "async " : ""}function `,
-								suffix: `${expr.generator ? "*" : ""}(${
+								prefix: `${expr.async ? "async " : ""}function${expr.generator ? "*" : ""} `,
+								suffix: `(${
 									expr.params.length > 0 ? "" : ") "
 								}`
 						  }

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -88,10 +88,10 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 										? expr.params[0].range[0]
 										: expr.body.range[0]
 								],
-								prefix: `${expr.async ? "async " : ""}function${expr.generator ? "*" : ""} `,
-								suffix: `(${
-									expr.params.length > 0 ? "" : ") "
-								}`
+								prefix: `${expr.async ? "async " : ""}function${
+									expr.generator ? "*" : ""
+								} `,
+								suffix: `(${expr.params.length > 0 ? "" : ") "}`
 						  }
 						: undefined
 				);

--- a/test/cases/parsing/issue-11353/async_generator_function.js
+++ b/test/cases/parsing/issue-11353/async_generator_function.js
@@ -3,7 +3,6 @@
 export default async function* asyncIdMaker(start = 1, end = 5){
 	for (let i = start; i <= end; i++) {
 
-		// yay, can use await!
 		await new Promise(resolve => setTimeout(resolve, 1000));
 
 		yield i;

--- a/test/cases/parsing/issue-11353/async_generator_function.js
+++ b/test/cases/parsing/issue-11353/async_generator_function.js
@@ -1,0 +1,11 @@
+"use strict";
+
+export default async function* asyncIdMaker(start = 1, end = 5){
+	for (let i = start; i <= end; i++) {
+
+		// yay, can use await!
+		await new Promise(resolve => setTimeout(resolve, 1000));
+
+		yield i;
+	}
+}

--- a/test/cases/parsing/issue-11353/generator_function.js
+++ b/test/cases/parsing/issue-11353/generator_function.js
@@ -1,0 +1,7 @@
+"use strict";
+
+export default function* idMaker(){
+	var index = 0;
+	while(true)
+		yield index++;
+}

--- a/test/cases/parsing/issue-11353/index.js
+++ b/test/cases/parsing/issue-11353/index.js
@@ -8,7 +8,7 @@ it('should correctly import generator function', () => {
 });
 
 it('should correctly build the correct function string', () => {
-	expect(generator.toString().indexOf('function* ')).toBe(0); // 0
+	expect(generator.toString().indexOf('function*')).toBe(0); // 0
 });
 
 it('should correctly provide the generator function interface', () => {
@@ -23,7 +23,7 @@ it('should correctly import async generator function', () => {
 });
 
 it('should correctly build the correct async function string', () => {
-	expect(asyncGenerator.toString().indexOf('async function* ')).toBe(0);
+	expect(asyncGenerator.toString().indexOf('async function*')).toBe(0);
 });
 
 it('should correctly provide the async generator function interface', async () => {

--- a/test/cases/parsing/issue-11353/index.js
+++ b/test/cases/parsing/issue-11353/index.js
@@ -10,10 +10,10 @@ it('should correctly build the correct function string', () => {
 });
 
 it('should correctly provide the generator function interface', () => {
-	var gen = generator(); // "Generator { }"
-	expect(gen.next().value).toBe(0); // 0
-	expect(gen.next().value).toBe(1); // 0
-	expect(gen.next().value).toBe(2); // 0
+	var gen = generator();
+	expect(gen.next().value).toBe(0);
+	expect(gen.next().value).toBe(1);
+	expect(gen.next().value).toBe(2);
 });
 
 it('should correctly import async generator function', () => {
@@ -21,7 +21,7 @@ it('should correctly import async generator function', () => {
 });
 
 it('should correctly build the correct async function string', () => {
-	expect(asyncGenerator.toString().indexOf('async function* ')).toBe(0); // 0
+	expect(asyncGenerator.toString().indexOf('async function* ')).toBe(0);
 });
 
 it('should correctly provide the async generator function interface', async () => {

--- a/test/cases/parsing/issue-11353/index.js
+++ b/test/cases/parsing/issue-11353/index.js
@@ -1,0 +1,34 @@
+import generator from "./generator_function.js";
+import asyncGenerator from "./async_generator_function";
+
+it('should correctly import generator function', () => {
+	expect(typeof generator).toBe("function");
+});
+
+it('should correctly build the correct function string', () => {
+	expect(generator.toString().indexOf('function* ')).toBe(0); // 0
+});
+
+it('should correctly provide the generator function interface', () => {
+	var gen = generator(); // "Generator { }"
+	expect(gen.next().value).toBe(0); // 0
+	expect(gen.next().value).toBe(1); // 0
+	expect(gen.next().value).toBe(2); // 0
+});
+
+it('should correctly import async generator function', () => {
+	expect(typeof asyncGenerator).toBe("function");
+});
+
+it('should correctly build the correct async function string', () => {
+	expect(asyncGenerator.toString().indexOf('async function* ')).toBe(0); // 0
+});
+
+it('should correctly provide the async generator function interface', async () => {
+	let gen = asyncGenerator(1, 5);
+	let start = 0;
+	for await (let value of gen) {
+		start += 1;
+		expect(value).toBe(start);
+	}
+});

--- a/test/cases/parsing/issue-11353/index.js
+++ b/test/cases/parsing/issue-11353/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 import generator from "./generator_function.js";
 import asyncGenerator from "./async_generator_function";
 
@@ -10,7 +12,7 @@ it('should correctly build the correct function string', () => {
 });
 
 it('should correctly provide the generator function interface', () => {
-	var gen = generator();
+	let gen = generator();
 	expect(gen.next().value).toBe(0);
 	expect(gen.next().value).toBe(1);
 	expect(gen.next().value).toBe(2);


### PR DESCRIPTION
The generator `*` control needs to be placed after the `function` keyword instead of suffixing the whole function body.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes, created 9 test cases under `test\cases\parsing\issue-11353`

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No, the API should remain the same.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Fix an issue when dealing with generator functions whereas the `*` character was being attached to the function body instead of the function keyword.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
