### PR TITLE
More intelligently guess the required version of shared modules

### DIFF
--- a/lib/sharing/ConsumeSharedPlugin.js
+++ b/lib/sharing/ConsumeSharedPlugin.js
@@ -12,6 +12,7 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 const WebpackError = require("../WebpackError");
 const { parseOptions } = require("../container/options");
 const LazySet = require("../util/LazySet");
+const { resolve: pathResolve } = require("../util/fs");
 const { parseRange } = require("../util/semver");
 const ConsumeSharedFallbackDependency = require("./ConsumeSharedFallbackDependency");
 const ConsumeSharedModule = require("./ConsumeSharedModule");
@@ -222,9 +223,53 @@ class ConsumeSharedPlugin {
 									);
 									if (typeof requiredVersion !== "string") {
 										requiredVersionWarning(
-											`Unable to find required version for "${packageName}" in description file (${descriptionPath}). It need to be in dependencies, devDependencies or peerDependencies.`
+											`Unable to find required version for "${packageName}" in description file (${descriptionPath}). It needs to be in optionalDependencies, dependencies, devDependencies or peerDependencies.`
 										);
 										return resolve();
+									}
+									if (!isRequiredVersion(requiredVersion)) {
+										// Check if requiredVersion is a path on the filesystem
+										return getDescriptionFile(
+											compilation.inputFileSystem,
+											pathResolve(
+												compilation.inputFileSystem,
+												context,
+												requiredVersion
+											),
+											["package.json"],
+											(err, result) => {
+												if (err) {
+													requiredVersionWarning(
+														`Unable to find required version for "${packageName}" in description file (${descriptionPath}). It needs to be in optionalDependencies, dependencies, devDependencies or peerDependencies.`
+													);
+													return resolve();
+												}
+												const { data, path: filePath } = result;
+												if (!data) {
+													requiredVersionWarning(
+														`Unable to find required version for "${packageName}" in description file (${descriptionPath}). It needs to be in optionalDependencies, dependencies, devDependencies or peerDependencies.`
+													);
+													return resolve();
+												}
+												if (data.name !== packageName) {
+													requiredVersionWarning(
+														`Unable to find required version for "${packageName}". The description file (${filePath}) pointed to for ${packageName} is for ${data.name} instead.`
+													);
+													return resolve();
+												}
+												const requiredVersion = data.version;
+												if (
+													typeof requiredVersion !== "string" ||
+													!isRequiredVersion(requiredVersion)
+												) {
+													requiredVersionWarning(
+														`Unable to find valid version string for "${packageName}" in description file (${filePath}).`
+													);
+													return resolve();
+												}
+												resolve(parseRange(requiredVersion));
+											}
+										);
 									}
 									resolve(parseRange(requiredVersion));
 								}

--- a/lib/sharing/ConsumeSharedPlugin.js
+++ b/lib/sharing/ConsumeSharedPlugin.js
@@ -180,8 +180,18 @@ class ConsumeSharedPlugin {
 							);
 						}),
 						new Promise(resolve => {
-							if (config.requiredVersion !== undefined)
+							if (config.requiredVersion !== undefined) {
+								if (
+									typeof config.requiredVersion === "string" &&
+									!isRequiredVersion(config.requiredVersion)
+								) {
+									requiredVersionWarning(
+										`Invalid required version specified (${config.requiredVersion}).`
+									);
+									return resolve();
+								}
 								return resolve(config.requiredVersion);
+							}
 							let packageName = config.packageName;
 							if (packageName === undefined) {
 								if (/^(\/|[A-Za-z]:|\\\\)/.test(request)) {

--- a/lib/sharing/utils.js
+++ b/lib/sharing/utils.js
@@ -74,17 +74,17 @@ exports.getRequiredVersionFromDescriptionFile = (data, packageName) => {
 		return data.dependencies[packageName];
 	}
 	if (
-		data.peerDependencies &&
-		typeof data.peerDependencies === "object" &&
-		packageName in data.peerDependencies
-	) {
-		return data.peerDependencies[packageName];
-	}
-	if (
 		data.devDependencies &&
 		typeof data.devDependencies === "object" &&
 		packageName in data.devDependencies
 	) {
 		return data.devDependencies[packageName];
+	}
+	if (
+		data.peerDependencies &&
+		typeof data.peerDependencies === "object" &&
+		packageName in data.peerDependencies
+	) {
+		return data.peerDependencies[packageName];
 	}
 };

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -47,6 +47,7 @@ const path = require("path");
  * @property {function(string, BufferCallback): void} readFile
  * @property {(function(string, string): string)=} join
  * @property {(function(string, string): string)=} relative
+ * @property {(function(string, string): string)=} resolve
  * @property {(function(string): string)=} dirname
  */
 
@@ -61,6 +62,7 @@ const path = require("path");
  * @property {(function(string=): void)=} purge
  * @property {(function(string, string): string)=} join
  * @property {(function(string, string): string)=} relative
+ * @property {(function(string, string): string)=} resolve
  * @property {(function(string): string)=} dirname
  */
 
@@ -120,6 +122,27 @@ const join = (fs, rootPath, filename) => {
 	}
 };
 exports.join = join;
+
+/**
+ * @param {InputFileSystem|OutputFileSystem|undefined} fs a file system
+ * @param {string} absPath absolute path segment
+ * @param {string} p path segment
+ * @returns {string} the resolved path
+ */
+const resolve = (fs, absPath, p) => {
+	if (fs && fs.resolve) {
+		return fs.resolve(absPath, p);
+	} else if (absPath.startsWith("/")) {
+		return path.posix.resolve(absPath, p);
+	} else if (absPath.length > 1 && absPath[1] === ":") {
+		return path.win32.resolve(absPath, p);
+	} else {
+		throw new Error(
+			`${absPath} is neither a posix nor a windows absolute path, and there is no 'resolve' method defined in the file system`
+		);
+	}
+};
+exports.resolve = resolve;
 
 /**
  * @param {InputFileSystem|OutputFileSystem|undefined} fs a file system

--- a/types.d.ts
+++ b/types.d.ts
@@ -3328,6 +3328,7 @@ declare interface InputFileSystem {
 	purge?: (arg0: string) => void;
 	join?: (arg0: string, arg1: string) => string;
 	relative?: (arg0: string, arg1: string) => string;
+	resolve?: (arg0: string, arg1: string) => string;
 	dirname?: (arg0: string) => string;
 }
 declare interface IntermediateFileSystemExtras {
@@ -5754,6 +5755,7 @@ declare interface OutputFileSystem {
 	) => void;
 	join?: (arg0: string, arg1: string) => string;
 	relative?: (arg0: string, arg1: string) => string;
+	resolve?: (arg0: string, arg1: string) => string;
 	dirname?: (arg0: string) => string;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

In current module federation, the required version of a shared module defaults to the version requirement in package.json. However, sometimes a module is installed from the local filesystem (for example, when testing a local copy). 

Currently, if the dependency in package.json looks like `"mypackage": "../mypackage"`, then the string is parsed as a version number leading to a nonsensical required version. This is a bug in master.

This change first checks to see if the required version is a valid range, and if not, tries to resolve the path on disk and get the version number from the path on disk.

This does not handle more exotic ways of installing packages, such as with github urls, etc. Perhaps an even better approach is to try to resolve the package name to find the version installed, and use that version number.

In order to resolve paths on the filesystem, I also added a simplified optional `resolve` method to the filesystem interface. Join does not work since paths can be relative or absolute.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix and feature enhancement

**Did you add tests for your changes?**

I don't know where I should add a test. Where should one go?

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
