### PR TITLE
WIP: reorder entries such that first registered entry is exported module

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1591,7 +1591,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			entryData[target].push(entry);
 			this.entries.set(name, entryData);
 		} else {
-			entryData[target].push(entry);
+			entryData[target].unshift(entry);
 			for (const key of Object.keys(options)) {
 				if (options[key] === undefined) continue;
 				if (entryData.options[key] === options[key]) continue;


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

The issue is explained here: https://github.com/webpack/webpack-dev-server/issues/2692#issuecomment-682223721

My idea is that the very first entry in the compilation should be the one that is exported, so that if a user or webpack-dev-server registers more entries later, those will not be exported when a user has a config like:

```
output: {
  library: 'main',
  libraryTarget: 'window'
},
```

This would result in a breaking change which I thinks make sense, but it can be adjusted if others find this to be a problematic breaking change. Consider the config:

```
entry: [
  './entry1.js',
  './entry2.js',
]
```

**Current behavior:** `entry2.js` is the exported module.

**With my changes:** `entry1.js` is the exported module (This seems more intuitive to me, feel free to disagree)

If we don't want this breaking change, then I can reorder the entry config again here: https://github.com/webpack/webpack/blob/00634bb0adc6a642eb05f501ba2046033f2010c5/lib/WebpackOptionsApply.js#L267

So that the last entry is the one exported. 

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix (related to webpack-dev-server)

**Did you add tests for your changes?**

Not yet

**Does this PR introduce a breaking change?**

Yes, ordering of entries internally in webpack

**What needs to be documented once your changes are merged?**

How webpack entries work when exporting as a module
