### PR TITLE
Grouping of assets and modules in stats for readablility

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -2005,7 +2005,7 @@ export interface StatsOptions {
 	 */
 	groupAssetsByPath?: boolean;
 	/**
-	 * Group modules by their attributes (errors, warnings, optional, orphan, or dependent).
+	 * Group modules by their attributes (errors, warnings, assets, optional, orphan, or dependent).
 	 */
 	groupModulesByAttributes?: boolean;
 	/**

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1878,6 +1878,10 @@ export interface StatsOptions {
 	 */
 	cachedAssets?: boolean;
 	/**
+	 * Add information about cached (not built) modules.
+	 */
+	cachedModules?: boolean;
+	/**
 	 * Add children information.
 	 */
 	children?: boolean;
@@ -1897,10 +1901,6 @@ export interface StatsOptions {
 	 * Add information about parent, children and sibling chunks to chunk information.
 	 */
 	chunkRelations?: boolean;
-	/**
-	 * Add root modules information to chunk information.
-	 */
-	chunkRootModules?: boolean;
 	/**
 	 * Add chunk information.
 	 */
@@ -1944,6 +1944,10 @@ export interface StatsOptions {
 	 * Context directory for request shortening.
 	 */
 	context?: string;
+	/**
+	 * Show chunk modules that are dependencies of other modules of the chunk.
+	 */
+	dependentModules?: boolean;
 	/**
 	 * Add module depth in module graph.
 	 */
@@ -2001,6 +2005,22 @@ export interface StatsOptions {
 	 */
 	groupAssetsByStatus?: boolean;
 	/**
+	 * Group modules by their attributes (errors, warnings, optional, orphan, or dependent).
+	 */
+	groupModulesByAttributes?: boolean;
+	/**
+	 * Group modules by their status (cached or built and cacheable).
+	 */
+	groupModulesByCacheStatus?: boolean;
+	/**
+	 * Group modules by their extension.
+	 */
+	groupModulesByExtension?: boolean;
+	/**
+	 * Group modules by their path.
+	 */
+	groupModulesByPath?: boolean;
+	/**
 	 * Add the hash of the compilation.
 	 */
 	hash?: boolean;
@@ -2021,10 +2041,6 @@ export interface StatsOptions {
 	 */
 	loggingTrace?: boolean;
 	/**
-	 * Set the maximum number of modules to be shown.
-	 */
-	maxModules?: number;
-	/**
 	 * Add information about assets inside modules.
 	 */
 	moduleAssets?: boolean;
@@ -2040,6 +2056,10 @@ export interface StatsOptions {
 	 * Sort the modules by that field.
 	 */
 	modulesSort?: string;
+	/**
+	 * Space to display modules (groups will be collapsed to fit this space, values is in number of modules/groups).
+	 */
+	modulesSpace?: number;
 	/**
 	 * Add information about modules nested in other modules (like with module concatenation).
 	 */

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -2103,7 +2103,7 @@ export interface StatsOptions {
 	/**
 	 * Add information about runtime modules.
 	 */
-	runtime?: boolean;
+	runtimeModules?: boolean;
 	/**
 	 * Add the source code of modules.
 	 */

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1862,6 +1862,10 @@ export interface StatsOptions {
 	 */
 	assetsSort?: string;
 	/**
+	 * Space to display assets (groups will be collapsed to fit this space).
+	 */
+	assetsSpace?: number;
+	/**
 	 * Add built at time information.
 	 */
 	builtAt?: boolean;
@@ -1976,6 +1980,26 @@ export interface StatsOptions {
 	 * Suppress modules that match the specified filters. Filters can be Strings, RegExps, Booleans or Functions.
 	 */
 	excludeModules?: boolean | FilterTypes;
+	/**
+	 * Group assets by how their are related to chunks.
+	 */
+	groupAssetsByChunk?: boolean;
+	/**
+	 * Group assets by their extension.
+	 */
+	groupAssetsByExtension?: boolean;
+	/**
+	 * Group assets by their asset info (immutable, development, hotModuleReplacement, etc).
+	 */
+	groupAssetsByInfo?: boolean;
+	/**
+	 * Group assets by their path.
+	 */
+	groupAssetsByPath?: boolean;
+	/**
+	 * Group assets by their status (emitted, compared for emit or cached).
+	 */
+	groupAssetsByStatus?: boolean;
 	/**
 	 * Add the hash of the compilation.
 	 */

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1989,6 +1989,10 @@ export interface StatsOptions {
 	 */
 	groupAssetsByChunk?: boolean;
 	/**
+	 * Group assets by their status (emitted, compared for emit or cached).
+	 */
+	groupAssetsByEmitStatus?: boolean;
+	/**
 	 * Group assets by their extension.
 	 */
 	groupAssetsByExtension?: boolean;
@@ -2000,10 +2004,6 @@ export interface StatsOptions {
 	 * Group assets by their path.
 	 */
 	groupAssetsByPath?: boolean;
-	/**
-	 * Group assets by their status (emitted, compared for emit or cached).
-	 */
-	groupAssetsByStatus?: boolean;
 	/**
 	 * Group modules by their attributes (errors, warnings, optional, orphan, or dependent).
 	 */

--- a/examples/module-federation/webpack.config.js
+++ b/examples/module-federation/webpack.config.js
@@ -19,8 +19,7 @@ const optimization = {
 const stats = {
 	chunks: true,
 	modules: false,
-	chunkModules: false,
-	chunkRootModules: true,
+	chunkModules: true,
 	chunkOrigins: true
 };
 module.exports = (env = "development") => [

--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -128,9 +128,7 @@ class APIPlugin {
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.getFullHash)
 					.tap("APIPlugin", (chunk, set) => {
-						const module = new GetFullHashRuntimeModule();
-						compilation.addRuntimeModule(chunk, module);
-						compilation.chunkGraph.addFullHashModuleToChunk(chunk, module);
+						compilation.addRuntimeModule(chunk, new GetFullHashRuntimeModule());
 						return true;
 					});
 

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -2270,6 +2270,9 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 		// connect to the chunk graph
 		this.chunkGraph.connectChunkAndModule(chunk, module);
 		this.chunkGraph.connectChunkAndRuntimeModule(chunk, module);
+		if (module.fullHash) {
+			this.chunkGraph.addFullHashModuleToChunk(chunk, module);
+		}
 
 		// attach runtime module
 		module.attach(this, chunk);

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -758,6 +758,8 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		this.needAdditionalPass = false;
 		/** @type {WeakSet<Module>} */
 		this.builtModules = new WeakSet();
+		/** @type {WeakSet<Module>} */
+		this.codeGeneratedModules = new WeakSet();
 		/** @private @type {Map<Module, Callback[]>} */
 		this._rebuildingModules = new Map();
 		/** @type {Set<string>} */
@@ -2122,6 +2124,7 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 					if (!cachedResult) {
 						statModulesGenerated++;
 						try {
+							this.codeGeneratedModules.add(module);
 							result = module.codeGeneration({
 								chunkGraph,
 								moduleGraph,

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -207,7 +207,7 @@ class ContextModule extends Module {
 	 * @returns {string} a user readable identifier of the module
 	 */
 	readableIdentifier(requestShortener) {
-		let identifier = requestShortener.shorten(this.context);
+		let identifier = requestShortener.shorten(this.context) + "/";
 		if (this.options.resourceQuery) {
 			identifier += ` ${this.options.resourceQuery}`;
 		}

--- a/lib/RuntimeModule.js
+++ b/lib/RuntimeModule.js
@@ -40,6 +40,7 @@ class RuntimeModule extends Module {
 		this.compilation = undefined;
 		/** @type {Chunk} */
 		this.chunk = undefined;
+		this.fullHash = false;
 		/** @type {string} */
 		this._cachedGeneratedCode = undefined;
 	}
@@ -100,10 +101,14 @@ class RuntimeModule extends Module {
 	updateHash(hash, context) {
 		hash.update(this.name);
 		hash.update(`${this.stage}`);
-		// Do not use getGeneratedCode here, because i. e. compilation hash is not
-		// ready at this point. We will cache it later instead.
 		try {
-			hash.update(this.generate());
+			if (this.fullHash) {
+				// Do not use getGeneratedCode here, because i. e. compilation hash might be not
+				// ready at this point. We will cache it later instead.
+				hash.update(this.generate());
+			} else {
+				hash.update(this.getGeneratedCode());
+			}
 		} catch (err) {
 			hash.update(err.message);
 		}
@@ -141,10 +146,12 @@ class RuntimeModule extends Module {
 	 * @returns {number} the estimated size of the module (must be non-zero)
 	 */
 	size(type) {
-		if (this._cachedGeneratedCode) {
-			return this._cachedGeneratedCode.length;
+		try {
+			const source = this.getGeneratedCode();
+			return source ? source.length : 0;
+		} catch (e) {
+			return 0;
 		}
-		return 0;
 	}
 
 	/* istanbul ignore next */

--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -158,7 +158,15 @@ class RuntimePlugin {
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.publicPath)
 				.tap("RuntimePlugin", chunk => {
-					compilation.addRuntimeModule(chunk, new PublicPathRuntimeModule());
+					const module = new PublicPathRuntimeModule();
+					const publicPath = compilation.outputOptions.publicPath;
+					if (
+						typeof publicPath !== "string" ||
+						/\[(full)?hash\]/.test(publicPath)
+					) {
+						module.fullHash = true;
+					}
+					compilation.addRuntimeModule(chunk, module);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -240,7 +240,8 @@ class JavascriptModulesPlugin {
 										chunkGraph,
 										codeGenerationResults
 									},
-									hooks
+									hooks,
+									compilation
 								);
 						} else {
 							if (!chunkHasJs(chunk, chunkGraph)) {
@@ -518,9 +519,10 @@ class JavascriptModulesPlugin {
 	/**
 	 * @param {MainRenderContext} renderContext options object
 	 * @param {CompilationHooks} hooks hooks
+	 * @param {Compilation} compilation the compilation
 	 * @returns {Source} the newly generated source from rendering
 	 */
-	renderMain(renderContext, hooks) {
+	renderMain(renderContext, hooks, compilation) {
 		const { chunk, chunkGraph, runtimeTemplate } = renderContext;
 
 		const runtimeRequirements = chunkGraph.getTreeRuntimeRequirements(chunk);
@@ -614,6 +616,10 @@ class JavascriptModulesPlugin {
 			source.add(
 				"/************************************************************************/\n"
 			);
+			// runtimeRuntimeModules calls codeGeneration
+			for (const module of runtimeModules) {
+				compilation.codeGeneratedModules.add(module);
+			}
 		}
 		if (inlinedModules) {
 			for (const m of inlinedModules) {

--- a/lib/runtime/CompatRuntimeModule.js
+++ b/lib/runtime/CompatRuntimeModule.js
@@ -12,6 +12,7 @@ const RuntimeModule = require("../RuntimeModule");
 class CompatRuntimeModule extends RuntimeModule {
 	constructor() {
 		super("compat", 10);
+		this.fullHash = true;
 	}
 
 	/**

--- a/lib/runtime/GetFullHashRuntimeModule.js
+++ b/lib/runtime/GetFullHashRuntimeModule.js
@@ -12,6 +12,7 @@ const RuntimeModule = require("../RuntimeModule");
 class GetFullHashRuntimeModule extends RuntimeModule {
 	constructor() {
 		super("getFullHash");
+		this.fullHash = true;
 	}
 
 	/**

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -38,6 +38,7 @@ const identifierUtils = require("../util/identifier");
 /** @typedef {import("../WebpackError")} WebpackError */
 /** @template T @typedef {import("../util/comparators").Comparator<T>} Comparator<T> */
 /** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
+/** @typedef {import("../util/smartGrouping").GroupConfig<any, object>} GroupConfig */
 /** @typedef {import("./StatsFactory")} StatsFactory */
 
 /** @typedef {Asset & { type: string, related: ExtendedAsset[] }} ExtendedAsset */
@@ -63,6 +64,11 @@ const identifierUtils = require("../util/identifier");
  * @property {string} chunkModulesSort
  * @property {string} nestedModulesSort
  * @property {string} assetsSort
+ * @property {boolean} cachedAssets
+ * @property {boolean} groupAssetsByStatus
+ * @property {boolean} groupAssetsByPath
+ * @property {boolean} groupAssetsByExtension
+ * @property {number} assetsSpace
  * @property {Function[]} excludeAssets
  * @property {Function[]} excludeModules
  * @property {Function[]} warningsFilter
@@ -311,15 +317,12 @@ const SIMPLE_EXTRACTORS = {
 					}
 				}
 			}
-			object.assets = factory.create(`${type}.assets`, Array.from(assets), {
-				...context,
-				compilationFileToChunks,
-				compilationAuxiliaryFileToChunks
-			});
-			object.filteredAssets = assets.size - object.assets.length;
+
 			object.assetsByChunkName = {};
-			for (const asset of object.assets) {
-				for (const name of asset.chunkNames) {
+			for (const [file, chunks] of compilationFileToChunks) {
+				for (const chunk of chunks) {
+					const name = chunk.name;
+					if (!name) continue;
 					if (
 						!Object.prototype.hasOwnProperty.call(
 							object.assetsByChunkName,
@@ -328,9 +331,22 @@ const SIMPLE_EXTRACTORS = {
 					) {
 						object.assetsByChunkName[name] = [];
 					}
-					object.assetsByChunkName[name].push(asset.name);
+					object.assetsByChunkName[name].push(file);
 				}
 			}
+
+			const groupedAssets = factory.create(
+				`${type}.assets`,
+				Array.from(assets),
+				{
+					...context,
+					compilationFileToChunks,
+					compilationAuxiliaryFileToChunks
+				}
+			);
+			const limited = spaceLimited(groupedAssets, options.assetsSpace);
+			object.assets = limited.children;
+			object.filteredAssets = limited.filteredChildren;
 		},
 		chunks: (object, compilation, context, options, factory) => {
 			const { type } = context;
@@ -560,6 +576,7 @@ const SIMPLE_EXTRACTORS = {
 			object.comparedForEmit = compilation.comparedForEmitAssets.has(
 				asset.name
 			);
+			object.cached = !object.emitted && !object.comparedForEmit;
 			object.info = asset.info;
 			object.filteredRelated = asset.related ? asset.related.length : undefined;
 		},
@@ -1033,26 +1050,8 @@ const BASE_MODULES_FILTER = {
 	}
 };
 
-const ASSETS_FILTER = {
-	excludeAssets: (asset, context, { excludeAssets }) => {
-		const ident = asset.name;
-		const excluded = excludeAssets.some(fn => fn(ident, asset));
-		if (excluded) return false;
-	},
-	"!cachedAssets": (asset, { compilation }) => {
-		if (
-			!compilation.emittedAssets.has(asset.name) &&
-			!compilation.comparedForEmitAssets.has(asset.name)
-		) {
-			return false;
-		}
-	}
-};
-
 /** @type {Record<string, Record<string, (thing: any, context: UsualContext, options: UsualOptions) => boolean | undefined>>} */
 const FILTER = {
-	"compilation.assets": ASSETS_FILTER,
-	"asset.related": ASSETS_FILTER,
 	"compilation.modules": {
 		excludeModules: EXCLUDE_MODULES_FILTER("module"),
 		"!orphanModules": (module, { compilation: { chunkGraph } }) => {
@@ -1193,6 +1192,271 @@ const SORTERS = {
 			);
 		}
 	}
+};
+
+const getTotalSize = children => {
+	let size = 0;
+	for (const child of children) {
+		size++;
+		if (child.children) size += getTotalSize(child.children);
+	}
+	return size;
+};
+
+const getTotalItems = children => {
+	let count = 0;
+	for (const child of children) {
+		if (child.children) count += getTotalItems(child.children);
+		else if (child.filteredChildren) count += child.filteredChildren;
+		else count++;
+	}
+	return count;
+};
+
+const collapse = children => {
+	const newChildren = [];
+	for (const child of children) {
+		let filteredChildren = child.filteredChildren || 0;
+		if (child.children) {
+			filteredChildren += getTotalItems(child.children);
+		}
+		newChildren.push(
+			filteredChildren
+				? {
+						...child,
+						children: undefined,
+						filteredChildren
+				  }
+				: child
+		);
+	}
+	return newChildren;
+};
+
+const spaceLimited = (children, max) => {
+	const groups = children.filter(c => c.children || c.filteredChildren);
+	const groupSizes = groups.map(g =>
+		g.children ? getTotalSize(g.children) + 1 : 1
+	);
+	const items = children.filter(c => !c.children && !c.filteredChildren);
+	let groupsSize = groupSizes.reduce((a, b) => a + b, 0);
+	if (groupsSize + items.length <= max) {
+		// keep all
+		return {
+			children: groups.concat(items),
+			filteredChildren: undefined
+		};
+	} else if (children.length < max) {
+		// collapse some groups, keep items
+		while (groupsSize + items.length > max) {
+			const oversize = items.length + groupsSize - max;
+			const maxGroupSize = Math.max(...groupSizes);
+			for (let i = 0; i < groups.length; i++) {
+				if (groupSizes[i] === maxGroupSize) {
+					const group = groups[i];
+					const limited = spaceLimited(
+						group.children,
+						groupSizes[i] - 1 - oversize / groups.length
+					);
+					groups[i] = {
+						...group,
+						children: limited.children,
+						filteredChildren:
+							(group.filteredChildren || 0) + limited.filteredChildren
+					};
+					const newSize = groups[i].children
+						? getTotalSize(groups[i].children) + 1
+						: 1;
+					groupsSize -= groupSizes[i] - newSize;
+					groupSizes[i] = newSize;
+					break;
+				}
+			}
+		}
+		return {
+			children: groups.concat(items),
+			filteredChildren: undefined
+		};
+	} else if (children.length === max) {
+		// collapse all groups and keep items
+		return {
+			children: collapse(groups).concat(items),
+			filteredChildren: undefined
+		};
+	} else if (groups.length + 1 <= max) {
+		// collapse all groups and items
+		return {
+			children: collapse(groups),
+			filteredChildren: items.length
+		};
+	} else {
+		// collapse complete group
+		return {
+			children: undefined,
+			filteredChildren: getTotalItems(children)
+		};
+	}
+};
+
+const assetGroup = assets => {
+	let size = 0;
+	for (const asset of assets) {
+		size += asset.size;
+	}
+	return {
+		size
+	};
+};
+
+/** @type {Record<string, (groupConfigs: GroupConfig[], context: UsualContext, options: UsualOptions) => void>} */
+const ASSETS_GROUPERS = {
+	_: (groupConfigs, context, options) => {
+		const groupByFlag = (name, exclude, greedy) => {
+			groupConfigs.push({
+				getKeys: asset => {
+					return asset[name] ? ["1"] : undefined;
+				},
+				getOptions: () => {
+					return {
+						groupChildren: !exclude,
+						force: exclude,
+						greedy
+					};
+				},
+				createGroup: (key, children, assets) => {
+					return exclude
+						? {
+								type: "assets by status",
+								[name]: !!key,
+								filteredChildren: assets.length,
+								...assetGroup(assets)
+						  }
+						: {
+								type: "assets by status",
+								[name]: !!key,
+								children, //...spaceLimited(children, options.assetsSpace),
+								...assetGroup(assets)
+						  };
+				}
+			});
+		};
+		const {
+			groupAssetsByStatus,
+			groupAssetsByPath,
+			groupAssetsByExtension
+		} = options;
+		if (groupAssetsByStatus) {
+			groupByFlag("emitted", false, true);
+			groupByFlag("comparedForEmit", false, true);
+			groupByFlag("isOverSizeLimit", false, true);
+		}
+		if (groupAssetsByStatus || !options.cachedAssets) {
+			groupByFlag("cached", !options.cachedAssets, true);
+		}
+		if (groupAssetsByPath || groupAssetsByExtension) {
+			groupConfigs.push({
+				getKeys: asset => {
+					const extensionMatch =
+						groupAssetsByExtension && /(\.[^.]+)(?:\?.*|$)/.exec(asset.name);
+					const extension = extensionMatch ? extensionMatch[1] : "";
+					const pathMatch =
+						groupAssetsByPath && /(.+)[/\\][^/\\]+(?:\?.*|$)/.exec(asset.name);
+					const path = pathMatch ? pathMatch[1].split(/[/\\]/) : ["."];
+					const keys = [];
+					if (groupAssetsByPath) {
+						keys.push(`${path.join("/")}/`);
+						if (extension) keys.push(`${path.join("/")}/*${extension}`);
+						path.pop();
+						while (path.length > 0) {
+							keys.push(`${path.join("/")}/`);
+							if (extension) keys.push(`${path.join("/")}/**/*${extension}`);
+							path.pop();
+						}
+						if (extension) keys.push(`**/*${extension}`);
+					} else {
+						if (extension) keys.push(`*${extension}`);
+					}
+					return keys;
+				},
+				createGroup: (key, children, assets) => {
+					return {
+						type: "assets by path",
+						name: key,
+						children, //...spaceLimited(children, options.assetsSpace),
+						...assetGroup(assets)
+					};
+				}
+			});
+		}
+	},
+	groupAssetsByInfo: (groupConfigs, context, options) => {
+		const groupByAssetInfoFlag = name => {
+			groupConfigs.push({
+				getKeys: asset => {
+					return asset.info && asset.info[name] ? ["1"] : undefined;
+				},
+				createGroup: (key, children, assets) => {
+					return {
+						type: "assets by info",
+						info: {
+							[name]: !!key
+						},
+						children, //...spaceLimited(children, options.assetsSpace),
+						...assetGroup(assets)
+					};
+				}
+			});
+		};
+		groupByAssetInfoFlag("immutable");
+		groupByAssetInfoFlag("development");
+		groupByAssetInfoFlag("hotModuleReplacement");
+	},
+	groupAssetsByChunk: (groupConfigs, context, options) => {
+		const groupByNames = name => {
+			groupConfigs.push({
+				getKeys: asset => {
+					return asset[name];
+				},
+				createGroup: (key, children, assets) => {
+					return {
+						type: "assets by chunk",
+						[name]: [key],
+						children, //...spaceLimited(children, options.assetsSpace),
+						...assetGroup(assets)
+					};
+				}
+			});
+		};
+		groupByNames("chunkNames");
+		groupByNames("auxiliaryChunkNames");
+		groupByNames("chunkIdHints");
+		groupByNames("auxiliaryChunkIdHints");
+	},
+	excludeAssets: (groupConfigs, context, { excludeAssets }) => {
+		groupConfigs.push({
+			getKeys: asset => {
+				const ident = asset.name;
+				const excluded = excludeAssets.some(fn => fn(ident, asset));
+				if (excluded) return ["excluded"];
+			},
+			getOptions: () => ({
+				groupChildren: false,
+				force: true,
+				greedy: true
+			}),
+			createGroup: (key, assets) => ({
+				type: "excluded assets",
+				filteredChildren: assets.length,
+				...assetGroup(assets)
+			})
+		});
+	}
+};
+
+/** @type {Record<string, Record<string, (groupConfigs: GroupConfig[], context: UsualContext, options: UsualOptions) => void>>} */
+const RESULT_GROUPERS = {
+	"compilation.assets": ASSETS_GROUPERS,
+	"asset.related": ASSETS_GROUPERS
 };
 
 // remove a prefixed "!" that can be specified to reverse sort order
@@ -1392,6 +1656,13 @@ class DefaultStatsFactoryPlugin {
 							.for(hookFor)
 							.tap("DefaultStatsFactoryPlugin", (comparators, ctx) =>
 								fn(comparators, ctx, options)
+							);
+					});
+					iterateConfig(RESULT_GROUPERS, options, (hookFor, fn) => {
+						stats.hooks.groupResults
+							.for(hookFor)
+							.tap("DefaultStatsFactoryPlugin", (groupConfigs, ctx) =>
+								fn(groupConfigs, ctx, options)
 							);
 					});
 					iterateConfig(RESULT_SORTERS, options, (hookFor, fn) => {

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -20,7 +20,7 @@ const {
 	compareSelect,
 	compareModulesByIdentifier
 } = require("../util/comparators");
-const identifierUtils = require("../util/identifier");
+const { makePathsRelative, parseResource } = require("../util/identifier");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../Chunk")} Chunk */
@@ -47,6 +47,7 @@ const identifierUtils = require("../util/identifier");
  * @typedef {Object} UsualContext
  * @property {string} type
  * @property {Compilation} compilation
+ * @property {Set<Module>} rootModules
  * @property {Map<string,Chunk[]>} compilationFileToChunks
  * @property {Map<string,Chunk[]>} compilationAuxiliaryFileToChunks
  * @property {number} startTime
@@ -60,7 +61,6 @@ const identifierUtils = require("../util/identifier");
  * @property {RequestShortener} requestShortener
  * @property {string} chunksSort
  * @property {string} modulesSort
- * @property {string} chunkRootModulesSort
  * @property {string} chunkModulesSort
  * @property {string} nestedModulesSort
  * @property {string} assetsSort
@@ -72,7 +72,18 @@ const identifierUtils = require("../util/identifier");
  * @property {Function[]} excludeAssets
  * @property {Function[]} excludeModules
  * @property {Function[]} warningsFilter
- * @property {number} maxModules
+ * @property {boolean} cachedModules
+ * @property {boolean} orphanModules
+ * @property {boolean} dependentModules
+ * @property {boolean} runtime
+ * @property {boolean} groupModulesByCacheStatus
+ * @property {boolean} groupModulesByAttributes
+ * @property {boolean} groupModulesByPath
+ * @property {boolean} groupModulesByExtension
+ * @property {boolean} groupModulesByType
+ * @property {number} modulesSpace
+ * @property {number} chunkModulesSpace
+ * @property {number} nestedModulesSpace
  * @property {false|"none"|"error"|"warn"|"info"|"log"|"verbose"} logging
  * @property {Function[]} loggingDebug
  * @property {boolean} loggingTrace
@@ -359,8 +370,10 @@ const SIMPLE_EXTRACTORS = {
 		modules: (object, compilation, context, options, factory) => {
 			const { type } = context;
 			const array = Array.from(compilation.modules);
-			object.modules = factory.create(`${type}.modules`, array, context);
-			object.filteredModules = array.length - object.modules.length;
+			const groupedModules = factory.create(`${type}.modules`, array, context);
+			const limited = spaceLimited(groupedModules, options.modulesSpace);
+			object.modules = limited.children;
+			object.filteredModules = limited.filteredChildren;
 		},
 		entrypoints: (object, compilation, context, options, factory) => {
 			const { type } = context;
@@ -454,7 +467,7 @@ const SIMPLE_EXTRACTORS = {
 					collapsedGroups = true;
 					break;
 			}
-			const makePathsRelative = identifierUtils.makePathsRelative.bindContextCache(
+			const cachedMakePathsRelative = makePathsRelative.bindContextCache(
 				context,
 				compilation.compiler.root
 			);
@@ -516,7 +529,7 @@ const SIMPLE_EXTRACTORS = {
 						}
 					}
 				}
-				let name = makePathsRelative(origin).replace(/\|/g, " ");
+				let name = cachedMakePathsRelative(origin).replace(/\|/g, " ");
 				if (name in object.logging) {
 					let i = 1;
 					while (`${name}#${i}` in object.logging) {
@@ -658,7 +671,7 @@ const SIMPLE_EXTRACTORS = {
 	},
 	module: {
 		_: (object, module, context, { requestShortener }, factory) => {
-			const { compilation, type } = context;
+			const { compilation, type, rootModules } = context;
 			const { moduleGraph } = compilation;
 			/** @type {Module[]} */
 			const path = [];
@@ -679,9 +692,14 @@ const SIMPLE_EXTRACTORS = {
 			for (const sourceType of module.getSourceTypes()) {
 				sizes[sourceType] = module.size(sourceType);
 			}
+			const built = compilation.builtModules.has(module);
+			const codeGenerated = compilation.codeGeneratedModules.has(module);
 			Object.assign(object, {
+				type: "module",
+				moduleType: module.type,
 				identifier: module.identifier(),
 				name: module.readableIdentifier(requestShortener),
+				nameForCondition: module.nameForCondition(),
 				index: moduleGraph.getPreOrderIndex(module),
 				preOrderIndex: moduleGraph.getPreOrderIndex(module),
 				index2: moduleGraph.getPostOrderIndex(module),
@@ -689,9 +707,14 @@ const SIMPLE_EXTRACTORS = {
 				size: module.size(),
 				sizes,
 				cacheable: module.buildInfo.cacheable,
-				built: compilation.builtModules.has(module),
+				built,
+				codeGenerated,
+				cached: !built && !codeGenerated,
 				optional: module.isOptional(moduleGraph),
-				runtime: module.type === "runtime",
+				orphan:
+					!type.endsWith("module.modules[].module") &&
+					compilation.chunkGraph.getNumberOfModuleChunks(module) === 0,
+				dependent: rootModules ? !rootModules.has(module) : undefined,
 				issuer: issuer && issuer.identifier(),
 				issuerName: issuer && issuer.readableIdentifier(requestShortener),
 				issuerPath:
@@ -712,12 +735,6 @@ const SIMPLE_EXTRACTORS = {
 				chunkGraph.getOrderedModuleChunksIterable(module, compareChunksById),
 				chunk => chunk.id
 			);
-		},
-		orphanModules: (object, module, { compilation, type }) => {
-			if (!type.endsWith("module.modules[].module")) {
-				object.orphan =
-					compilation.chunkGraph.getNumberOfModuleChunks(module) === 0;
-			}
 		},
 		moduleAssets: (object, module) => {
 			object.assets = module.buildInfo.assets
@@ -775,8 +792,17 @@ const SIMPLE_EXTRACTORS = {
 			const { type } = context;
 			if (module instanceof ConcatenatedModule) {
 				const modules = module.modules;
-				object.modules = factory.create(`${type}.modules`, modules, context);
-				object.filteredModules = modules.length - object.modules.length;
+				const groupedModules = factory.create(
+					`${type}.modules`,
+					modules,
+					context
+				);
+				const limited = spaceLimited(
+					groupedModules,
+					options.nestedModulesSpace
+				);
+				object.modules = limited.children;
+				object.filteredModules = limited.filteredChildren;
 			}
 		},
 		source: (object, module) => {
@@ -930,26 +956,14 @@ const SIMPLE_EXTRACTORS = {
 				compilation: { chunkGraph }
 			} = context;
 			const array = chunkGraph.getChunkModules(chunk);
-			object.modules = factory.create(`${type}.modules`, array, {
+			const groupedModules = factory.create(`${type}.modules`, array, {
 				...context,
-				runtime: chunk.runtime
+				runtime: chunk.runtime,
+				rootModules: new Set(chunkGraph.getChunkRootModules(chunk))
 			});
-			object.filteredModules = array.length - object.modules.length;
-		},
-		chunkRootModules: (object, chunk, context, options, factory) => {
-			const {
-				type,
-				compilation: { chunkGraph }
-			} = context;
-			const array = chunkGraph.getChunkRootModules(chunk);
-			object.rootModules = factory.create(
-				`${type}.rootModules`,
-				array,
-				context
-			);
-			object.filteredRootModules = array.length - object.rootModules.length;
-			object.nonRootModules =
-				chunkGraph.getNumberOfChunkModules(chunk) - array.length;
+			const limited = spaceLimited(groupedModules, options.chunkModulesSpace);
+			object.modules = limited.children;
+			object.filteredModules = limited.filteredChildren;
 		},
 		chunkOrigins: (object, chunk, context, options, factory) => {
 			const {
@@ -1028,49 +1042,8 @@ const SIMPLE_EXTRACTORS = {
 	}
 };
 
-const EXCLUDE_MODULES_FILTER = type => (
-	module,
-	context,
-	{ excludeModules, requestShortener }
-) => {
-	const name = module.nameForCondition();
-	if (!name) return;
-	const ident = requestShortener.shorten(name);
-	const excluded = excludeModules.some(fn => fn(ident, module, type));
-	if (excluded) return false;
-};
-
-/** @type {Record<string, (module: Module, context: UsualContext) => boolean | undefined>} */
-const BASE_MODULES_FILTER = {
-	"!cached": (module, { compilation }) => {
-		if (!compilation.builtModules.has(module)) return false;
-	},
-	"!runtime": module => {
-		if (module.type === "runtime") return false;
-	}
-};
-
 /** @type {Record<string, Record<string, (thing: any, context: UsualContext, options: UsualOptions) => boolean | undefined>>} */
 const FILTER = {
-	"compilation.modules": {
-		excludeModules: EXCLUDE_MODULES_FILTER("module"),
-		"!orphanModules": (module, { compilation: { chunkGraph } }) => {
-			if (chunkGraph.getNumberOfModuleChunks(module) === 0) return false;
-		},
-		...BASE_MODULES_FILTER
-	},
-	"module.modules": {
-		excludeModules: EXCLUDE_MODULES_FILTER("nested"),
-		...BASE_MODULES_FILTER
-	},
-	"chunk.modules": {
-		excludeModules: EXCLUDE_MODULES_FILTER("chunk"),
-		...BASE_MODULES_FILTER
-	},
-	"chunk.rootModules": {
-		excludeModules: EXCLUDE_MODULES_FILTER("root-of-chunk"),
-		...BASE_MODULES_FILTER
-	},
 	"module.reasons": {
 		"!orphanModules": (reason, { compilation: { chunkGraph } }) => {
 			if (
@@ -1081,21 +1054,6 @@ const FILTER = {
 			}
 		}
 	}
-};
-
-/** @type {Record<string, (module: Module, context: UsualContext, options: UsualOptions, idx: number, i: number) => boolean | undefined>} */
-const FILTER_SORTED_MODULES = {
-	maxModules: (module, context, { maxModules }, idx, i) => {
-		if (i >= maxModules) return false;
-	}
-};
-
-/** @type {Record<string, Record<string, (thing: any, context: UsualContext, options: UsualOptions, idx: number, i: number) => boolean | undefined>>} */
-const FILTER_SORTED = {
-	"compilation.modules": FILTER_SORTED_MODULES,
-	"modules.modules": FILTER_SORTED_MODULES,
-	"chunk.modules": FILTER_SORTED_MODULES,
-	"chunk.rootModules": FILTER_SORTED_MODULES
 };
 
 /** @type {Record<string, Record<string, (thing: Object, context: UsualContext, options: UsualOptions) => boolean | undefined>>} */
@@ -1233,20 +1191,21 @@ const collapse = children => {
 	return newChildren;
 };
 
-const spaceLimited = (children, max) => {
-	const groups = children.filter(c => c.children || c.filteredChildren);
+const spaceLimited = (itemsAndGroups, max) => {
+	/** @type {any[] | undefined} */
+	let children = undefined;
+	/** @type {number | undefined} */
+	let filteredChildren = undefined;
+	const groups = itemsAndGroups.filter(c => c.children || c.filteredChildren);
 	const groupSizes = groups.map(g =>
 		g.children ? getTotalSize(g.children) + 1 : 1
 	);
-	const items = children.filter(c => !c.children && !c.filteredChildren);
+	const items = itemsAndGroups.filter(c => !c.children && !c.filteredChildren);
 	let groupsSize = groupSizes.reduce((a, b) => a + b, 0);
 	if (groupsSize + items.length <= max) {
 		// keep all
-		return {
-			children: groups.concat(items),
-			filteredChildren: undefined
-		};
-	} else if (children.length < max) {
+		children = groups.concat(items);
+	} else if (itemsAndGroups.length < max) {
 		// collapse some groups, keep items
 		while (groupsSize + items.length > max) {
 			const oversize = items.length + groupsSize - max;
@@ -1273,34 +1232,27 @@ const spaceLimited = (children, max) => {
 				}
 			}
 		}
-		return {
-			children: groups.concat(items),
-			filteredChildren: undefined
-		};
-	} else if (children.length === max) {
+		children = groups.concat(items);
+	} else if (itemsAndGroups.length === max) {
 		// collapse all groups and keep items
-		return {
-			children: collapse(groups).concat(items),
-			filteredChildren: undefined
-		};
+		children = collapse(groups).concat(items);
 	} else if (groups.length + 1 <= max) {
 		// collapse all groups and items
-		return {
-			children: collapse(groups),
-			filteredChildren: items.length
-		};
+		children = collapse(groups);
+		filteredChildren = items.length;
 	} else {
 		// collapse complete group
-		return {
-			children: undefined,
-			filteredChildren: getTotalItems(children)
-		};
+		filteredChildren = getTotalItems(itemsAndGroups);
 	}
+	return {
+		children,
+		filteredChildren
+	};
 };
 
-const assetGroup = assets => {
+const assetGroup = (children, assets) => {
 	let size = 0;
-	for (const asset of assets) {
+	for (const asset of children) {
 		size += asset.size;
 	}
 	return {
@@ -1308,10 +1260,25 @@ const assetGroup = assets => {
 	};
 };
 
+const moduleGroup = (children, modules) => {
+	let size = 0;
+	const sizes = {};
+	for (const module of children) {
+		size += module.size;
+		for (const key of Object.keys(module.sizes)) {
+			sizes[key] = (sizes[key] || 0) + module.sizes[key];
+		}
+	}
+	return {
+		size,
+		sizes
+	};
+};
+
 /** @type {Record<string, (groupConfigs: GroupConfig[], context: UsualContext, options: UsualOptions) => void>} */
 const ASSETS_GROUPERS = {
 	_: (groupConfigs, context, options) => {
-		const groupByFlag = (name, exclude, greedy) => {
+		const groupByFlag = (name, exclude) => {
 			groupConfigs.push({
 				getKeys: asset => {
 					return asset[name] ? ["1"] : undefined;
@@ -1319,8 +1286,7 @@ const ASSETS_GROUPERS = {
 				getOptions: () => {
 					return {
 						groupChildren: !exclude,
-						force: exclude,
-						greedy
+						force: exclude
 					};
 				},
 				createGroup: (key, children, assets) => {
@@ -1329,13 +1295,13 @@ const ASSETS_GROUPERS = {
 								type: "assets by status",
 								[name]: !!key,
 								filteredChildren: assets.length,
-								...assetGroup(assets)
+								...assetGroup(children, assets)
 						  }
 						: {
 								type: "assets by status",
 								[name]: !!key,
-								children, //...spaceLimited(children, options.assetsSpace),
-								...assetGroup(assets)
+								children,
+								...assetGroup(children, assets)
 						  };
 				}
 			});
@@ -1346,12 +1312,12 @@ const ASSETS_GROUPERS = {
 			groupAssetsByExtension
 		} = options;
 		if (groupAssetsByStatus) {
-			groupByFlag("emitted", false, true);
-			groupByFlag("comparedForEmit", false, true);
-			groupByFlag("isOverSizeLimit", false, true);
+			groupByFlag("emitted");
+			groupByFlag("comparedForEmit");
+			groupByFlag("isOverSizeLimit");
 		}
 		if (groupAssetsByStatus || !options.cachedAssets) {
-			groupByFlag("cached", !options.cachedAssets, true);
+			groupByFlag("cached", !options.cachedAssets);
 		}
 		if (groupAssetsByPath || groupAssetsByExtension) {
 			groupConfigs.push({
@@ -1361,18 +1327,20 @@ const ASSETS_GROUPERS = {
 					const extension = extensionMatch ? extensionMatch[1] : "";
 					const pathMatch =
 						groupAssetsByPath && /(.+)[/\\][^/\\]+(?:\?.*|$)/.exec(asset.name);
-					const path = pathMatch ? pathMatch[1].split(/[/\\]/) : ["."];
+					const path = pathMatch ? pathMatch[1].split(/[/\\]/).concat("") : [];
 					const keys = [];
 					if (groupAssetsByPath) {
-						keys.push(`${path.join("/")}/`);
-						if (extension) keys.push(`${path.join("/")}/*${extension}`);
+						keys.push(path.join("/"));
+						if (extension) keys.push(`${path.join("/")}*${extension}`);
 						path.pop();
-						while (path.length > 0) {
-							keys.push(`${path.join("/")}/`);
-							if (extension) keys.push(`${path.join("/")}/**/*${extension}`);
+						path.pop();
+						path.push("");
+						while (path.length > 1) {
+							keys.push(path.join("/"));
 							path.pop();
+							path.pop();
+							path.push("");
 						}
-						if (extension) keys.push(`**/*${extension}`);
 					} else {
 						if (extension) keys.push(`*${extension}`);
 					}
@@ -1380,10 +1348,10 @@ const ASSETS_GROUPERS = {
 				},
 				createGroup: (key, children, assets) => {
 					return {
-						type: "assets by path",
+						type: groupAssetsByPath ? "assets by path" : "assets by extension",
 						name: key,
-						children, //...spaceLimited(children, options.assetsSpace),
-						...assetGroup(assets)
+						children,
+						...assetGroup(children, assets)
 					};
 				}
 			});
@@ -1401,8 +1369,8 @@ const ASSETS_GROUPERS = {
 						info: {
 							[name]: !!key
 						},
-						children, //...spaceLimited(children, options.assetsSpace),
-						...assetGroup(assets)
+						children,
+						...assetGroup(children, assets)
 					};
 				}
 			});
@@ -1421,8 +1389,8 @@ const ASSETS_GROUPERS = {
 					return {
 						type: "assets by chunk",
 						[name]: [key],
-						children, //...spaceLimited(children, options.assetsSpace),
-						...assetGroup(assets)
+						children,
+						...assetGroup(children, assets)
 					};
 				}
 			});
@@ -1441,22 +1409,162 @@ const ASSETS_GROUPERS = {
 			},
 			getOptions: () => ({
 				groupChildren: false,
-				force: true,
-				greedy: true
+				force: true
 			}),
-			createGroup: (key, assets) => ({
-				type: "excluded assets",
+			createGroup: (key, children, assets) => ({
+				type: "hidden assets",
 				filteredChildren: assets.length,
-				...assetGroup(assets)
+				...assetGroup(children, assets)
 			})
 		});
 	}
 };
 
+/** @type {function(string): Record<string, (groupConfigs: GroupConfig[], context: UsualContext, options: UsualOptions) => void>} */
+const MODULES_GROUPERS = type => ({
+	_: (groupConfigs, context, options) => {
+		const groupByFlag = (name, type, exclude) => {
+			groupConfigs.push({
+				getKeys: module => {
+					return module[name] ? ["1"] : undefined;
+				},
+				getOptions: () => {
+					return {
+						groupChildren: !exclude,
+						force: exclude
+					};
+				},
+				createGroup: (key, children, modules) => {
+					return {
+						type,
+						[name]: !!key,
+						...(exclude ? { filteredChildren: modules.length } : { children }),
+						...moduleGroup(children, modules)
+					};
+				}
+			});
+		};
+		const {
+			groupModulesByCacheStatus,
+			groupModulesByAttributes,
+			groupModulesByType,
+			groupModulesByPath,
+			groupModulesByExtension
+		} = options;
+		if (groupModulesByAttributes) {
+			groupByFlag("errors", "modules with errors");
+			groupByFlag("warnings", "modules with warnings");
+			groupByFlag("assets", "modules with assets");
+			groupByFlag("optional", "optional modules");
+		}
+		if (groupModulesByCacheStatus) {
+			groupByFlag("cacheable", "cacheable modules");
+			groupByFlag("built", "built modules");
+			groupByFlag("codeGenerated", "code generated modules");
+		}
+		if (groupModulesByCacheStatus || !options.cachedModules) {
+			groupByFlag("cached", "cached modules", !options.cachedModules);
+		}
+		if (groupModulesByAttributes || !options.orphanModules) {
+			groupByFlag("orphan", "orphan modules", !options.orphanModules);
+		}
+		if (groupModulesByAttributes || !options.dependentModules) {
+			groupByFlag("dependent", "dependent modules", !options.dependentModules);
+		}
+		if (groupModulesByType || !options.runtime) {
+			groupConfigs.push({
+				getKeys: module => {
+					return [module.moduleType.split("/", 1)[0]];
+				},
+				getOptions: key => {
+					const exclude = key === "runtime" && !options.runtime;
+					return {
+						groupChildren: !exclude,
+						force: exclude
+					};
+				},
+				createGroup: (key, children, modules) => {
+					const exclude = key === "runtime" && !options.runtime;
+					return {
+						type: `${key} modules`,
+						moduleType: key,
+						...(exclude ? { filteredChildren: modules.length } : { children }),
+						...moduleGroup(children, modules)
+					};
+				}
+			});
+		}
+		if (groupModulesByPath || groupModulesByExtension) {
+			groupConfigs.push({
+				getKeys: module => {
+					const resource = parseResource(module.name.split("!").pop()).path;
+					const extensionMatch =
+						groupModulesByExtension && /(\.[^.]+)(?:\?.*|$)/.exec(resource);
+					const extension = extensionMatch ? extensionMatch[1] : "";
+					const pathMatch =
+						groupModulesByPath && /(.+)[/\\][^/\\]+(?:\?.*|$)/.exec(resource);
+					const path = pathMatch ? pathMatch[1].split(/[/\\]/).concat("") : [];
+					const keys = [];
+					if (groupModulesByPath) {
+						keys.push(path.join("/"));
+						if (extension) keys.push(`${path.join("/")}*${extension}`);
+						path.pop();
+						path.pop();
+						path.push("");
+						while (path.length > 1) {
+							keys.push(path.join("/"));
+							path.pop();
+							path.pop();
+							path.push("");
+						}
+					} else {
+						if (extension) keys.push(`*${extension}`);
+					}
+					return keys;
+				},
+				createGroup: (key, children, modules) => {
+					return {
+						type: groupModulesByPath
+							? "modules by path"
+							: "modules by extension",
+						name: key,
+						children,
+						...moduleGroup(children, modules)
+					};
+				}
+			});
+		}
+	},
+	excludeModules: (groupConfigs, context, { excludeModules }) => {
+		groupConfigs.push({
+			getKeys: module => {
+				const name = module.name;
+				if (name) {
+					const excluded = excludeModules.some(fn => fn(name, module, type));
+					if (excluded) return ["1"];
+				}
+			},
+			getOptions: () => ({
+				groupChildren: false,
+				force: true
+			}),
+			createGroup: (key, children, modules) => ({
+				type: "hidden modules",
+				filteredChildren: children.length,
+				...moduleGroup(children, modules)
+			})
+		});
+	}
+});
+
 /** @type {Record<string, Record<string, (groupConfigs: GroupConfig[], context: UsualContext, options: UsualOptions) => void>>} */
 const RESULT_GROUPERS = {
 	"compilation.assets": ASSETS_GROUPERS,
-	"asset.related": ASSETS_GROUPERS
+	"asset.related": ASSETS_GROUPERS,
+	"compilation.modules": MODULES_GROUPERS("module"),
+	"chunk.modules": MODULES_GROUPERS("chunk"),
+	"chunk.rootModules": MODULES_GROUPERS("root-of-chunk"),
+	"module.modules": MODULES_GROUPERS("nested")
 };
 
 // remove a prefixed "!" that can be specified to reverse sort order
@@ -1526,11 +1634,6 @@ const RESULT_SORTERS = {
 			comparators.push(sortByField(modulesSort));
 		}
 	},
-	"chunk.rootModules": {
-		chunkRootModulesSort: (comparators, context, { chunkRootModulesSort }) => {
-			comparators.push(sortByField(chunkRootModulesSort));
-		}
-	},
 	"chunk.modules": {
 		chunkModulesSort: (comparators, context, { chunkModulesSort }) => {
 			comparators.push(sortByField(chunkModulesSort));
@@ -1590,6 +1693,7 @@ const ITEM_NAMES = {
 	"module.issuerPath[]": "moduleIssuer",
 	"module.reasons[]": "moduleReason",
 	"module.modules[]": "module",
+	"module.children[]": "module",
 	"moduleTrace[]": "moduleTraceItem",
 	"moduleTraceItem.dependencies[]": "moduleTraceDependency"
 };
@@ -1637,13 +1741,6 @@ class DefaultStatsFactoryPlugin {
 								fn(item, ctx, options, idx, i)
 							);
 					});
-					iterateConfig(FILTER_SORTED, options, (hookFor, fn) => {
-						stats.hooks.filterSorted
-							.for(hookFor)
-							.tap("DefaultStatsFactoryPlugin", (item, ctx, idx, i) =>
-								fn(item, ctx, options, idx, i)
-							);
-					});
 					iterateConfig(FILTER_RESULTS, options, (hookFor, fn) => {
 						stats.hooks.filterResults
 							.for(hookFor)
@@ -1658,18 +1755,18 @@ class DefaultStatsFactoryPlugin {
 								fn(comparators, ctx, options)
 							);
 					});
-					iterateConfig(RESULT_GROUPERS, options, (hookFor, fn) => {
-						stats.hooks.groupResults
-							.for(hookFor)
-							.tap("DefaultStatsFactoryPlugin", (groupConfigs, ctx) =>
-								fn(groupConfigs, ctx, options)
-							);
-					});
 					iterateConfig(RESULT_SORTERS, options, (hookFor, fn) => {
 						stats.hooks.sortResults
 							.for(hookFor)
 							.tap("DefaultStatsFactoryPlugin", (comparators, ctx) =>
 								fn(comparators, ctx, options)
+							);
+					});
+					iterateConfig(RESULT_GROUPERS, options, (hookFor, fn) => {
+						stats.hooks.groupResults
+							.for(hookFor)
+							.tap("DefaultStatsFactoryPlugin", (groupConfigs, ctx) =>
+								fn(groupConfigs, ctx, options)
 							);
 					});
 					for (const key of Object.keys(ITEM_NAMES)) {

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -75,7 +75,7 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @property {boolean} cachedModules
  * @property {boolean} orphanModules
  * @property {boolean} dependentModules
- * @property {boolean} runtime
+ * @property {boolean} runtimeModules
  * @property {boolean} groupModulesByCacheStatus
  * @property {boolean} groupModulesByAttributes
  * @property {boolean} groupModulesByPath
@@ -1471,20 +1471,24 @@ const MODULES_GROUPERS = type => ({
 		if (groupModulesByAttributes || !options.dependentModules) {
 			groupByFlag("dependent", "dependent modules", !options.dependentModules);
 		}
-		if (groupModulesByType || !options.runtime) {
+		if (groupModulesByType || !options.runtimeModules) {
 			groupConfigs.push({
 				getKeys: module => {
-					return [module.moduleType.split("/", 1)[0]];
+					if (groupModulesByType) {
+						return [module.moduleType.split("/", 1)[0]];
+					} else if (module.moduleType === "runtime") {
+						return ["runtime"];
+					}
 				},
 				getOptions: key => {
-					const exclude = key === "runtime" && !options.runtime;
+					const exclude = key === "runtime" && !options.runtimeModules;
 					return {
 						groupChildren: !exclude,
 						force: exclude
 					};
 				},
 				createGroup: (key, children, modules) => {
-					const exclude = key === "runtime" && !options.runtime;
+					const exclude = key === "runtime" && !options.runtimeModules;
 					return {
 						type: `${key} modules`,
 						moduleType: key,

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -65,7 +65,7 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @property {string} nestedModulesSort
  * @property {string} assetsSort
  * @property {boolean} cachedAssets
- * @property {boolean} groupAssetsByStatus
+ * @property {boolean} groupAssetsByEmitStatus
  * @property {boolean} groupAssetsByPath
  * @property {boolean} groupAssetsByExtension
  * @property {number} assetsSpace
@@ -1307,16 +1307,16 @@ const ASSETS_GROUPERS = {
 			});
 		};
 		const {
-			groupAssetsByStatus,
+			groupAssetsByEmitStatus,
 			groupAssetsByPath,
 			groupAssetsByExtension
 		} = options;
-		if (groupAssetsByStatus) {
+		if (groupAssetsByEmitStatus) {
 			groupByFlag("emitted");
 			groupByFlag("comparedForEmit");
 			groupByFlag("isOverSizeLimit");
 		}
-		if (groupAssetsByStatus || !options.cachedAssets) {
+		if (groupAssetsByEmitStatus || !options.cachedAssets) {
 			groupByFlag("cached", !options.cachedAssets);
 		}
 		if (groupAssetsByPath || groupAssetsByExtension) {

--- a/lib/stats/DefaultStatsPresetPlugin.js
+++ b/lib/stats/DefaultStatsPresetPlugin.js
@@ -94,6 +94,8 @@ const NAMED_PRESETS = {
 
 const NORMAL_ON = ({ all }) => all !== false;
 const NORMAL_OFF = ({ all }) => all === true;
+const ON_FOR_TO_STRING = ({ all }, { forToString }) =>
+	forToString ? all !== false : all === true;
 const OFF_FOR_TO_STRING = ({ all }, { forToString }) =>
 	forToString ? all === true : all !== false;
 
@@ -136,6 +138,12 @@ const DEFAULTS = {
 	},
 	nestedModules: OFF_FOR_TO_STRING,
 	relatedAssets: OFF_FOR_TO_STRING,
+	groupAssetsByStatus: ON_FOR_TO_STRING,
+	groupAssetsByInfo: ON_FOR_TO_STRING,
+	groupAssetsByPath: ON_FOR_TO_STRING,
+	groupAssetsByExtension: ON_FOR_TO_STRING,
+	groupAssetsByChunk: ON_FOR_TO_STRING,
+	assetsSpace: (o, { forToString }) => (forToString ? 15 : Infinity),
 	orphanModules: NORMAL_OFF,
 	moduleAssets: OFF_FOR_TO_STRING,
 	depth: OFF_FOR_TO_STRING,

--- a/lib/stats/DefaultStatsPresetPlugin.js
+++ b/lib/stats/DefaultStatsPresetPlugin.js
@@ -28,7 +28,7 @@ const NAMED_PRESETS = {
 		chunks: true,
 		chunkRelations: true,
 		chunkModules: true,
-		chunkRootModules: false,
+		dependentModules: true,
 		chunkOrigins: true,
 		depth: true,
 		env: true,
@@ -43,7 +43,8 @@ const NAMED_PRESETS = {
 		orphanModules: true,
 		runtime: true,
 		exclude: false,
-		maxModules: Infinity
+		modulesSpace: Infinity,
+		assetsSpace: Infinity
 	},
 	detailed: {
 		relatedAssets: true,
@@ -53,7 +54,6 @@ const NAMED_PRESETS = {
 		chunks: true,
 		chunkRelations: true,
 		chunkModules: false,
-		chunkRootModules: false,
 		chunkOrigins: true,
 		depth: true,
 		usedExports: true,
@@ -65,12 +65,15 @@ const NAMED_PRESETS = {
 		runtimeModules: true,
 		runtime: true,
 		exclude: false,
-		maxModules: Infinity
+		modulesSpace: Infinity,
+		assetsSpace: Infinity
 	},
 	minimal: {
 		all: false,
 		modules: true,
-		maxModules: 0,
+		modulesSpace: 0,
+		assets: true,
+		assetsSpace: 0,
 		errors: true,
 		warnings: true,
 		logging: "warn"
@@ -99,7 +102,7 @@ const ON_FOR_TO_STRING = ({ all }, { forToString }) =>
 const OFF_FOR_TO_STRING = ({ all }, { forToString }) =>
 	forToString ? all === true : all !== false;
 
-/** @type {Record<string, (options: Object, context: { forToString: boolean }, compilation: Compilation) => any>} */
+/** @type {Record<string, (options: Object, context: { forToString: boolean, cached: boolean }, compilation: Compilation) => any>} */
 const DEFAULTS = {
 	context: (options, context, compilation) => compilation.compiler.context,
 	requestShortener: (options, context, compilation) =>
@@ -117,26 +120,25 @@ const DEFAULTS = {
 	chunkGroups: OFF_FOR_TO_STRING,
 	chunks: OFF_FOR_TO_STRING,
 	chunkRelations: OFF_FOR_TO_STRING,
-	chunkModules: OFF_FOR_TO_STRING,
-	chunkRootModules: ({ all, chunkModules }, { forToString }) => {
-		if (all === false) return false;
-		if (all === true) return true;
-		if (forToString && chunkModules) return false;
-		return true;
-	},
+	chunkModules: NORMAL_ON,
+	dependentModules: OFF_FOR_TO_STRING,
 	chunkOrigins: OFF_FOR_TO_STRING,
 	ids: OFF_FOR_TO_STRING,
-	modules: (
-		{ all, chunks, chunkRootModules, chunkModules },
-		{ forToString }
-	) => {
+	modules: ({ all, chunks, chunkModules }, { forToString }) => {
 		if (all === false) return false;
 		if (all === true) return true;
-		if (forToString && chunks && (chunkModules || chunkRootModules))
-			return false;
+		if (forToString && chunks && chunkModules) return false;
 		return true;
 	},
 	nestedModules: OFF_FOR_TO_STRING,
+	groupModulesByType: ON_FOR_TO_STRING,
+	groupModulesByCacheStatus: ON_FOR_TO_STRING,
+	groupModulesByAttributes: ON_FOR_TO_STRING,
+	groupModulesByPath: ON_FOR_TO_STRING,
+	groupModulesByExtension: ON_FOR_TO_STRING,
+	modulesSpace: (o, { forToString }) => (forToString ? 15 : Infinity),
+	chunkModulesSpace: (o, { forToString }) => (forToString ? 10 : Infinity),
+	nestedModulesSpace: (o, { forToString }) => (forToString ? 10 : Infinity),
 	relatedAssets: OFF_FOR_TO_STRING,
 	groupAssetsByStatus: ON_FOR_TO_STRING,
 	groupAssetsByInfo: ON_FOR_TO_STRING,
@@ -147,7 +149,8 @@ const DEFAULTS = {
 	orphanModules: NORMAL_OFF,
 	moduleAssets: OFF_FOR_TO_STRING,
 	depth: OFF_FOR_TO_STRING,
-	cached: NORMAL_ON,
+	cachedModules: ({ all }, { forToString, cached }) =>
+		cached !== undefined ? cached : forToString ? all === true : all !== false,
 	runtime: OFF_FOR_TO_STRING,
 	cachedAssets: OFF_FOR_TO_STRING,
 	reasons: OFF_FOR_TO_STRING,
@@ -168,10 +171,8 @@ const DEFAULTS = {
 	loggingTrace: OFF_FOR_TO_STRING,
 	excludeModules: () => [],
 	excludeAssets: () => [],
-	maxModules: (o, { forToString }) => (forToString ? 15 : Infinity),
 	modulesSort: () => "depth",
 	chunkModulesSort: () => "name",
-	chunkRootModulesSort: () => "name",
 	nestedModulesSort: () => false,
 	chunksSort: () => false,
 	assetsSort: () => "name",

--- a/lib/stats/DefaultStatsPresetPlugin.js
+++ b/lib/stats/DefaultStatsPresetPlugin.js
@@ -140,7 +140,7 @@ const DEFAULTS = {
 	chunkModulesSpace: (o, { forToString }) => (forToString ? 10 : Infinity),
 	nestedModulesSpace: (o, { forToString }) => (forToString ? 10 : Infinity),
 	relatedAssets: OFF_FOR_TO_STRING,
-	groupAssetsByStatus: ON_FOR_TO_STRING,
+	groupAssetsByEmitStatus: ON_FOR_TO_STRING,
 	groupAssetsByInfo: ON_FOR_TO_STRING,
 	groupAssetsByPath: ON_FOR_TO_STRING,
 	groupAssetsByExtension: ON_FOR_TO_STRING,

--- a/lib/stats/DefaultStatsPresetPlugin.js
+++ b/lib/stats/DefaultStatsPresetPlugin.js
@@ -41,7 +41,7 @@ const NAMED_PRESETS = {
 		publicPath: true,
 		logging: "verbose",
 		orphanModules: true,
-		runtime: true,
+		runtimeModules: true,
 		exclude: false,
 		modulesSpace: Infinity,
 		assetsSpace: Infinity
@@ -63,7 +63,6 @@ const NAMED_PRESETS = {
 		publicPath: true,
 		logging: true,
 		runtimeModules: true,
-		runtime: true,
 		exclude: false,
 		modulesSpace: Infinity,
 		assetsSpace: Infinity
@@ -102,7 +101,7 @@ const ON_FOR_TO_STRING = ({ all }, { forToString }) =>
 const OFF_FOR_TO_STRING = ({ all }, { forToString }) =>
 	forToString ? all === true : all !== false;
 
-/** @type {Record<string, (options: Object, context: { forToString: boolean, cached: boolean }, compilation: Compilation) => any>} */
+/** @type {Record<string, (options: Object, context: { forToString: boolean, cached: boolean, runtime: boolean }, compilation: Compilation) => any>} */
 const DEFAULTS = {
 	context: (options, context, compilation) => compilation.compiler.context,
 	requestShortener: (options, context, compilation) =>
@@ -146,12 +145,17 @@ const DEFAULTS = {
 	groupAssetsByExtension: ON_FOR_TO_STRING,
 	groupAssetsByChunk: ON_FOR_TO_STRING,
 	assetsSpace: (o, { forToString }) => (forToString ? 15 : Infinity),
-	orphanModules: NORMAL_OFF,
-	moduleAssets: OFF_FOR_TO_STRING,
-	depth: OFF_FOR_TO_STRING,
+	orphanModules: OFF_FOR_TO_STRING,
+	runtimeModules: ({ all }, { forToString, runtime }) =>
+		runtime !== undefined
+			? runtime
+			: forToString
+			? all === true
+			: all !== false,
 	cachedModules: ({ all }, { forToString, cached }) =>
 		cached !== undefined ? cached : forToString ? all === true : all !== false,
-	runtime: OFF_FOR_TO_STRING,
+	moduleAssets: OFF_FOR_TO_STRING,
+	depth: OFF_FOR_TO_STRING,
 	cachedAssets: OFF_FOR_TO_STRING,
 	reasons: OFF_FOR_TO_STRING,
 	usedExports: OFF_FOR_TO_STRING,

--- a/lib/stats/DefaultStatsPresetPlugin.js
+++ b/lib/stats/DefaultStatsPresetPlugin.js
@@ -119,7 +119,12 @@ const DEFAULTS = {
 	chunkGroups: OFF_FOR_TO_STRING,
 	chunks: OFF_FOR_TO_STRING,
 	chunkRelations: OFF_FOR_TO_STRING,
-	chunkModules: NORMAL_ON,
+	chunkModules: ({ all, modules }) => {
+		if (all === false) return false;
+		if (all === true) return true;
+		if (modules) return false;
+		return true;
+	},
 	dependentModules: OFF_FOR_TO_STRING,
 	chunkOrigins: OFF_FOR_TO_STRING,
 	ids: OFF_FOR_TO_STRING,

--- a/lib/stats/DefaultStatsPrinterPlugin.js
+++ b/lib/stats/DefaultStatsPrinterPlugin.js
@@ -127,11 +127,7 @@ const SIMPLE_PRINTERS = {
 			: undefined,
 	"compilation.filteredAssets": (filteredAssets, { compilation: { assets } }) =>
 		filteredAssets > 0
-			? `${
-					assets && assets.length > 0
-						? ` + ${filteredAssets} hidden`
-						: filteredAssets
-			  } ${plural(filteredAssets, "asset", "assets")}`
+			? `${filteredAssets} ${plural(filteredAssets, "asset", "assets")}`
 			: undefined,
 	"compilation.logging": (logging, context, printer) =>
 		Array.isArray(logging)
@@ -155,6 +151,8 @@ const SIMPLE_PRINTERS = {
 		emitted ? green(formatFlag("emitted")) : undefined,
 	"asset.comparedForEmit": (comparedForEmit, { yellow, formatFlag }) =>
 		comparedForEmit ? yellow(formatFlag("compared for emit")) : undefined,
+	"asset.cached": (cached, { green, formatFlag }) =>
+		cached ? green(formatFlag("cached")) : undefined,
 	"asset.isOverSizeLimit": (isOverSizeLimit, { yellow, formatFlag }) =>
 		isOverSizeLimit ? yellow(formatFlag("big")) : undefined,
 
@@ -169,11 +167,15 @@ const SIMPLE_PRINTERS = {
 	"asset.separator!": () => "\n",
 	"asset.filteredRelated": (filteredRelated, { asset: { related } }) =>
 		filteredRelated > 0
-			? `${
-					related && related.length > 0
-						? ` + ${filteredRelated} hidden`
-						: filteredRelated
-			  } ${plural(filteredRelated, "related asset", "related assets")}`
+			? `${filteredRelated} related ${plural(
+					filteredRelated,
+					"asset",
+					"assets"
+			  )}`
+			: undefined,
+	"asset.filteredChildren": (filteredChildren, { asset: { children } }) =>
+		filteredChildren > 0
+			? `${filteredChildren} ${plural(filteredChildren, "asset", "assets")}`
 			: undefined,
 
 	assetChunk: (id, { formatChunkId }) => formatChunkId(id),
@@ -490,6 +492,7 @@ const ITEM_NAMES = {
 	"compilation.logging[]": "loggingGroup",
 	"compilation.children[]": "compilation",
 	"asset.related[]": "asset",
+	"asset.children[]": "asset",
 	"asset.chunks[]": "assetChunk",
 	"asset.auxiliaryChunks[]": "assetChunk",
 	"asset.chunkNames[]": "assetChunkName",
@@ -562,6 +565,7 @@ const PREFERRED_ORDERS = {
 		"auxiliaryChunks",
 		"emitted",
 		"comparedForEmit",
+		"cached",
 		"info",
 		"isOverSizeLimit",
 		"chunkNames",
@@ -569,6 +573,8 @@ const PREFERRED_ORDERS = {
 		"chunkIdHints",
 		"auxiliaryChunkIdHints",
 		"related",
+		"filteredRelated",
+		"children",
 		"filteredChildren"
 	],
 	"asset.info": ["immutable", "development", "hotModuleReplacement"],
@@ -833,7 +839,10 @@ const SIMPLE_ELEMENT_JOINERS = {
 	asset: items =>
 		joinExplicitNewLine(
 			items.map(item => {
-				if (item.element === "related" && item.content) {
+				if (
+					(item.element === "related" || item.element === "children") &&
+					item.content
+				) {
 					return {
 						content: `\n${item.content}\n`
 					};

--- a/lib/stats/DefaultStatsPrinterPlugin.js
+++ b/lib/stats/DefaultStatsPrinterPlugin.js
@@ -28,7 +28,6 @@
  * @property {(size: number) => string} formatSize
  * @property {(flag: string) => string} formatFlag
  * @property {(time: number, boldQuantity?: boolean) => string} formatTime
- * @property {number} maxModuleId
  * @property {string} chunkGroupKind
  */
 
@@ -105,25 +104,9 @@ const SIMPLE_PRINTERS = {
 	},
 	"compilation.assetsByChunkName": () => "",
 
-	"compilation.modules": (modules, context) => {
-		let maxModuleId = 0;
-		for (const module of modules) {
-			if (typeof module.id === "number") {
-				if (maxModuleId < module.id) maxModuleId = module.id;
-			}
-		}
-		context.maxModuleId = maxModuleId;
-	},
-	"compilation.filteredModules": (
-		filteredModules,
-		{ compilation: { modules } }
-	) =>
+	"compilation.filteredModules": filteredModules =>
 		filteredModules > 0
-			? `   ${
-					modules && modules.length > 0
-						? ` + ${filteredModules} hidden`
-						: filteredModules
-			  } ${plural(filteredModules, "module", "modules")}`
+			? `${filteredModules} ${plural(filteredModules, "module", "modules")}`
 			: undefined,
 	"compilation.filteredAssets": (filteredAssets, { compilation: { assets } }) =>
 		filteredAssets > 0
@@ -173,7 +156,7 @@ const SIMPLE_PRINTERS = {
 					"assets"
 			  )}`
 			: undefined,
-	"asset.filteredChildren": (filteredChildren, { asset: { children } }) =>
+	"asset.filteredChildren": filteredChildren =>
 		filteredChildren > 0
 			? `${filteredChildren} ${plural(filteredChildren, "asset", "assets")}`
 			: undefined,
@@ -183,10 +166,11 @@ const SIMPLE_PRINTERS = {
 	assetChunkName: name => name,
 	assetChunkIdHint: name => name,
 
+	"module.type": type => (type !== "module" ? type : undefined),
 	"module.id": (id, { formatModuleId }) =>
 		isValidId(id) ? formatModuleId(id) : undefined,
 	"module.name": (name, { bold }) => bold(name),
-	"module.identifier": identifier => identifier,
+	"module.identifier": identifier => undefined,
 	"module.sizes": printSizes,
 	"module.chunks[]": (id, { formatChunkId }) => formatChunkId(id),
 	"module.depth": (depth, { formatFlag }) =>
@@ -199,8 +183,14 @@ const SIMPLE_PRINTERS = {
 		runtime ? yellow(formatFlag("runtime")) : undefined,
 	"module.optional": (optional, { formatFlag, yellow }) =>
 		optional ? yellow(formatFlag("optional")) : undefined,
-	"module.built": (built, { formatFlag, green }) =>
-		built ? green(formatFlag("built")) : undefined,
+	"module.dependent": (dependent, { formatFlag, cyan }) =>
+		dependent ? cyan(formatFlag("dependent")) : undefined,
+	"module.built": (built, { formatFlag, yellow }) =>
+		built ? yellow(formatFlag("built")) : undefined,
+	"module.codeGenerated": (codeGenerated, { formatFlag, yellow }) =>
+		codeGenerated ? yellow(formatFlag("code generated")) : undefined,
+	"module.cached": (cached, { formatFlag, green }) =>
+		cached ? green(formatFlag("cached")) : undefined,
 	"module.assets": (assets, { formatFlag, magenta }) =>
 		assets && assets.length
 			? magenta(
@@ -209,16 +199,18 @@ const SIMPLE_PRINTERS = {
 					)
 			  )
 			: undefined,
-	"module.failed": (failed, { formatFlag, red }) =>
-		failed ? red(formatFlag("failed")) : undefined,
 	"module.warnings": (warnings, { formatFlag, yellow }) =>
-		warnings
+		warnings === true
+			? yellow(formatFlag("warnings"))
+			: warnings
 			? yellow(
 					formatFlag(`${warnings} ${plural(warnings, "warning", "warnings")}`)
 			  )
 			: undefined,
 	"module.errors": (errors, { formatFlag, red }) =>
-		errors
+		errors === true
+			? red(formatFlag("errors"))
+			: errors
 			? red(formatFlag(`${errors} ${plural(errors, "error", "errors")}`))
 			: undefined,
 	"module.providedExports": (providedExports, { formatFlag, cyan }) => {
@@ -255,22 +247,17 @@ const SIMPLE_PRINTERS = {
 	"module.issuerPath": (issuerPath, { module }) =>
 		module.profile ? undefined : "",
 	"module.profile": profile => undefined,
-	"module.modules": (modules, context) => {
-		let maxModuleId = 0;
-		for (const module of modules) {
-			if (typeof module.id === "number") {
-				if (maxModuleId < module.id) maxModuleId = module.id;
-			}
-		}
-		context.maxModuleId = maxModuleId;
-	},
-	"module.filteredModules": (filteredModules, { compilation: { modules } }) =>
+	"module.filteredModules": filteredModules =>
 		filteredModules > 0
-			? `   ${
-					modules && modules.length > 0
-						? ` + ${filteredModules} hidden`
-						: filteredModules
-			  } nested ${plural(filteredModules, "module", "modules")}`
+			? `${filteredModules} nested ${plural(
+					filteredModules,
+					"module",
+					"modules"
+			  )}`
+			: undefined,
+	"module.filteredChildren": filteredChildren =>
+		filteredChildren > 0
+			? `${filteredChildren} ${plural(filteredChildren, "module", "modules")}`
 			: undefined,
 	"module.separator!": () => "\n",
 
@@ -361,53 +348,13 @@ const SIMPLE_PRINTERS = {
 	"chunk.recorded": (recorded, { formatFlag, green }) =>
 		recorded ? green(formatFlag("recorded")) : undefined,
 	"chunk.reason": (reason, { yellow }) => (reason ? yellow(reason) : undefined),
-	"chunk.rootModules": (modules, context) => {
-		let maxModuleId = 0;
-		for (const module of modules) {
-			if (typeof module.id === "number") {
-				if (maxModuleId < module.id) maxModuleId = module.id;
-			}
-		}
-		context.maxModuleId = maxModuleId;
-	},
-	"chunk.filteredRootModules": (
-		filteredRootModules,
-		{ chunk: { rootModules } }
-	) =>
-		filteredRootModules > 0
-			? `   ${
-					rootModules && rootModules.length > 0
-						? ` + ${filteredRootModules} hidden`
-						: filteredRootModules
-			  } root ${plural(filteredRootModules, "module", "modules")}`
-			: undefined,
-	"chunk.nonRootModules": (
-		nonRootModules,
-		{ chunk: { filteredRootModules, rootModules } }
-	) =>
-		nonRootModules > 0
-			? `   ${
-					(rootModules && rootModules.length > 0) || filteredRootModules > 0
-						? ` + ${nonRootModules} hidden`
-						: nonRootModules
-			  } dependent ${plural(nonRootModules, "module", "modules")}`
-			: undefined,
-	"chunk.modules": (modules, context) => {
-		let maxModuleId = 0;
-		for (const module of modules) {
-			if (typeof module.id === "number") {
-				if (maxModuleId < module.id) maxModuleId = module.id;
-			}
-		}
-		context.maxModuleId = maxModuleId;
-	},
-	"chunk.filteredModules": (filteredModules, { chunk: { modules } }) =>
+	"chunk.filteredModules": filteredModules =>
 		filteredModules > 0
-			? `   ${
-					modules && modules.length > 0
-						? ` + ${filteredModules} hidden`
-						: filteredModules
-			  } chunk ${plural(filteredModules, "module", "modules")}`
+			? `${filteredModules} chunk ${plural(
+					filteredModules,
+					"module",
+					"modules"
+			  )}`
 			: undefined,
 	"chunk.separator!": () => "\n",
 
@@ -500,10 +447,10 @@ const ITEM_NAMES = {
 	"asset.auxiliaryChunkNames[]": "assetChunkName",
 	"asset.auxiliaryChunkIdHints[]": "assetChunkIdHint",
 	"module.modules[]": "module",
+	"module.children[]": "module",
 	"module.reasons[]": "moduleReason",
 	"module.issuerPath[]": "moduleIssuer",
 	"chunk.origins[]": "chunkOrigin",
-	"chunk.rootModules[]": "module",
 	"chunk.modules[]": "module",
 	"loggingGroup.entries[]": logEntry =>
 		`loggingEntry(${logEntry.type}).loggingEntry`,
@@ -588,9 +535,10 @@ const PREFERRED_ORDERS = {
 		"childAssets"
 	],
 	module: [
-		"id",
+		"type",
 		"name",
 		"identifier",
+		"id",
 		"sizes",
 		"chunks",
 		"depth",
@@ -598,24 +546,24 @@ const PREFERRED_ORDERS = {
 		"orphan",
 		"runtime",
 		"optional",
+		"dependent",
 		"built",
+		"codeGenerated",
+		"cached",
 		"assets",
 		"failed",
 		"warnings",
 		"errors",
-		"separator!",
+		"children",
+		"filteredChildren",
 		"providedExports",
-		"separator!",
 		"usedExports",
-		"separator!",
 		"optimizationBailout",
-		"separator!",
 		"reasons",
-		"separator!",
 		"issuerPath",
 		"profile",
-		"separator!",
-		"modules"
+		"modules",
+		"filteredModules"
 	],
 	moduleReason: [
 		"active",
@@ -656,12 +604,6 @@ const PREFERRED_ORDERS = {
 		"reason",
 		"separator!",
 		"origins",
-		"separator!",
-		"rootModules",
-		"separator!",
-		"filteredRootModules",
-		"separator!",
-		"nonRootModules",
 		"separator!",
 		"modules",
 		"separator!",
@@ -794,7 +736,7 @@ const joinExplicitNewLine = (items, indenter) => {
 	let first = true;
 	return items
 		.map(item => {
-			if (!item.content) return;
+			if (!item || !item.content) return;
 			let content = indent(item.content, first ? "" : indenter, !firstInLine);
 			if (firstInLine) {
 				content = content.replace(/^\n+/, "");
@@ -844,6 +786,7 @@ const SIMPLE_ELEMENT_JOINERS = {
 					item.content
 				) {
 					return {
+						...item,
 						content: `\n${item.content}\n`
 					};
 				}
@@ -852,40 +795,40 @@ const SIMPLE_ELEMENT_JOINERS = {
 			"  "
 		),
 	"asset.info": joinOneLine,
-	module: (items, { module, maxModuleId }) => {
+	module: (items, { module }) => {
 		let hasName = false;
-		let indenter = "    ";
-		if (maxModuleId >= 10) indenter += " ";
-		if (maxModuleId >= 100) indenter += " ";
-		if (maxModuleId >= 1000) indenter += " ";
-		let prefix = "";
-		if (typeof module.id === "number") {
-			if (module.id < 1000 && maxModuleId >= 1000) prefix += " ";
-			if (module.id < 100 && maxModuleId >= 100) prefix += " ";
-			if (module.id < 10 && maxModuleId >= 10) prefix += " ";
-		} else if (typeof module.id === "string" && module.id !== "") {
-			if (maxModuleId >= 1000) prefix += " ";
-			if (maxModuleId >= 100) prefix += " ";
-			if (maxModuleId >= 10) prefix += " ";
-		}
-		return (
-			prefix +
-			joinExplicitNewLine(
-				items.filter(item => {
-					switch (item.element) {
-						case "id":
-							if (module.id === module.name && item.content) hasName = true;
-							break;
-						case "name":
-						case "identifier":
+		return joinExplicitNewLine(
+			items.map(item => {
+				switch (item.element) {
+					case "id":
+						if (module.id === module.name) {
 							if (hasName) return false;
 							if (item.content) hasName = true;
-							break;
-					}
-					return true;
-				}),
-				indenter
-			)
+						}
+						break;
+					case "name":
+						if (hasName) return false;
+						if (item.content) hasName = true;
+						break;
+					case "providedExports":
+					case "usedExports":
+					case "optimizationBailout":
+					case "reasons":
+					case "issuerPath":
+					case "profile":
+					case "children":
+					case "modules":
+						if (item.content) {
+							return {
+								...item,
+								content: `\n${item.content}\n`
+							};
+						}
+						break;
+				}
+				return item;
+			}),
+			"  "
 		);
 	},
 	chunk: items => {
@@ -904,7 +847,7 @@ const SIMPLE_ELEMENT_JOINERS = {
 					}
 					return true;
 				}),
-				" "
+				"  "
 			)
 		);
 	},
@@ -935,7 +878,7 @@ const SIMPLE_ELEMENT_JOINERS = {
 	},
 	"module.profile": joinInBrackets,
 	moduleIssuer: joinOneLine,
-	chunkOrigin: items => "   > " + joinOneLine(items),
+	chunkOrigin: items => "> " + joinOneLine(items),
 	"errors[].error": joinError(true),
 	"warnings[].error": joinError(false),
 	loggingGroup: items => joinExplicitNewLine(items, "").trimRight(),

--- a/lib/stats/StatsFactory.js
+++ b/lib/stats/StatsFactory.js
@@ -7,6 +7,9 @@
 
 const { HookMap, SyncBailHook, SyncWaterfallHook } = require("tapable");
 const { concatComparators, keepOriginalOrder } = require("../util/comparators");
+const smartGrouping = require("../util/smartGrouping");
+
+/** @typedef {import("../util/smartGrouping").GroupConfig<any, object>} GroupConfig */
 
 class StatsFactory {
 	constructor() {
@@ -24,6 +27,10 @@ class StatsFactory {
 			/** @type {HookMap<SyncBailHook<[any, Object, number, number]>>} */
 			filterSorted: new HookMap(
 				() => new SyncBailHook(["item", "context", "index", "unfilteredIndex"])
+			),
+			/** @type {HookMap<SyncBailHook<[GroupConfig[], Object]>>} */
+			groupResults: new HookMap(
+				() => new SyncBailHook(["groupConfigs", "context"])
 			),
 			/** @type {HookMap<SyncBailHook<[(function(any, any): number)[], Object]>>} */
 			sortResults: new HookMap(
@@ -151,7 +158,7 @@ class StatsFactory {
 			);
 
 			// for each item
-			const resultItems = items2.map((item, i) => {
+			let resultItems = items2.map((item, i) => {
 				const itemContext = {
 					...context,
 					_index: i
@@ -175,6 +182,15 @@ class StatsFactory {
 				// run item factory
 				return itemFactory.create(innerType, item, itemContext);
 			});
+
+			// group result items
+			const groupConfigs = [];
+			this._forEachLevel(this.hooks.groupResults, type, h =>
+				h.call(groupConfigs, context)
+			);
+			if (groupConfigs.length > 0) {
+				resultItems = smartGrouping(resultItems, groupConfigs);
+			}
 
 			// sort result items
 			const comparators2 = [];

--- a/lib/stats/StatsFactory.js
+++ b/lib/stats/StatsFactory.js
@@ -183,15 +183,6 @@ class StatsFactory {
 				return itemFactory.create(innerType, item, itemContext);
 			});
 
-			// group result items
-			const groupConfigs = [];
-			this._forEachLevel(this.hooks.groupResults, type, h =>
-				h.call(groupConfigs, context)
-			);
-			if (groupConfigs.length > 0) {
-				resultItems = smartGrouping(resultItems, groupConfigs);
-			}
-
 			// sort result items
 			const comparators2 = [];
 			this._forEachLevel(this.hooks.sortResults, type, h =>
@@ -202,6 +193,15 @@ class StatsFactory {
 					// @ts-expect-error number of arguments is correct
 					concatComparators(...comparators2, keepOriginalOrder(resultItems))
 				);
+			}
+
+			// group result items
+			const groupConfigs = [];
+			this._forEachLevel(this.hooks.groupResults, type, h =>
+				h.call(groupConfigs, context)
+			);
+			if (groupConfigs.length > 0) {
+				resultItems = smartGrouping(resultItems, groupConfigs);
 			}
 
 			// run filter on sorted result items

--- a/lib/stats/StatsPrinter.js
+++ b/lib/stats/StatsPrinter.js
@@ -180,7 +180,9 @@ class StatsPrinter {
 					if (result.length > 0) printResult = result.join("\n");
 				}
 			} else if (object !== null && typeof object === "object") {
-				const elements = Object.keys(object);
+				const elements = Object.keys(object).filter(
+					key => object[key] !== undefined
+				);
 				this._forEachLevel(this.hooks.sortElements, type, h =>
 					h.call(elements, context)
 				);

--- a/lib/util/smartGrouping.js
+++ b/lib/util/smartGrouping.js
@@ -1,0 +1,161 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+/**
+ * @typedef {Object} GroupOptions
+ * @property {boolean=} groupChildren
+ * @property {boolean=} force
+ * @property {boolean=} greedy
+ */
+
+/**
+ * @template T
+ * @template R
+ * @typedef {Object} GroupConfig
+ * @property {function(T): string[]} getKeys
+ * @property {function(string, (R | T)[], T[]): R} createGroup
+ * @property {function(string, T[]): GroupOptions=} getOptions
+ */
+
+/**
+ * @template T
+ * @typedef {Object} ItemWithGroups
+ * @property {T} item
+ * @property {Set<string>} groups
+ */
+
+/**
+ * @template T
+ * @template R
+ * @param {T[]} items the list of items
+ * @param {GroupConfig<T, R>[]} groupConfigs configuration
+ * @returns {(R | T)[]} grouped items
+ */
+const smartGrouping = (items, groupConfigs) => {
+	/** @type {Set<ItemWithGroups<T>>} */
+	const itemsWithGroups = new Set();
+	/** @type {Map<string, [GroupConfig<T, R>, string]>} */
+	const groupConfigMap = new Map();
+	for (const item of items) {
+		const groups = new Set();
+		for (let i = 0; i < groupConfigs.length; i++) {
+			const groupConfig = groupConfigs[i];
+			const keys = groupConfig.getKeys(item);
+			if (keys) {
+				for (const group of keys) {
+					const fullGroup = `${i}:${group}`;
+					if (!groupConfigMap.has(fullGroup)) {
+						groupConfigMap.set(fullGroup, [groupConfig, group]);
+					}
+					groups.add(fullGroup);
+				}
+			}
+		}
+		itemsWithGroups.add({
+			item,
+			groups
+		});
+	}
+	const alreadyGrouped = new Set();
+	/**
+	 * @param {Set<ItemWithGroups<T>>} itemsWithGroups input items with groups
+	 * @returns {(T | R)[]} groups items
+	 */
+	const runGrouping = itemsWithGroups => {
+		const totalSize = itemsWithGroups.size;
+		/** @type {Map<string, Set<ItemWithGroups<T>>>} */
+		const groupMap = new Map();
+		for (const entry of itemsWithGroups) {
+			for (const group of entry.groups) {
+				if (alreadyGrouped.has(group)) continue;
+				const list = groupMap.get(group);
+				if (list === undefined) {
+					groupMap.set(group, new Set([entry]));
+				} else {
+					list.add(entry);
+				}
+			}
+		}
+		/** @type {Set<string>} */
+		const usedGroups = new Set();
+		/** @type {(T | R)[]} */
+		const results = [];
+		for (;;) {
+			let bestGroup = undefined;
+			let bestGroupSize = -1;
+			let bestGroupItems = undefined;
+			let bestGroupOptions = undefined;
+			for (const [group, items] of groupMap) {
+				const [groupConfig, groupKey] = groupConfigMap.get(group);
+				const options =
+					groupConfig.getOptions &&
+					groupConfig.getOptions(
+						groupKey,
+						Array.from(items, ({ item }) => item)
+					);
+				if (items.size === 0) continue;
+				const force = options && options.force;
+				if (!force) {
+					if (usedGroups.has(group)) continue;
+					if (items.size <= 1 || totalSize - items.size <= 1) {
+						continue;
+					}
+				}
+				const greedy = options && options.greedy;
+				let sizeValue = greedy
+					? items.size
+					: Math.min(items.size, totalSize - items.size);
+				if (sizeValue > bestGroupSize) {
+					bestGroup = group;
+					bestGroupSize = sizeValue;
+					bestGroupItems = items;
+					bestGroupOptions = options;
+				}
+			}
+			if (bestGroup === undefined) {
+				break;
+			}
+			const items = new Set(bestGroupItems);
+			for (const item of items) {
+				itemsWithGroups.delete(item);
+				// Remove all groups that items have from the map to not select them again
+				for (const group of item.groups) {
+					const list = groupMap.get(group);
+					if (list !== undefined) list.delete(item);
+					usedGroups.add(group);
+				}
+			}
+			const idx = bestGroup.indexOf(":");
+			const configKey = bestGroup.slice(0, idx);
+			const key = bestGroup.slice(idx + 1);
+			const groupConfig = groupConfigs[+configKey];
+			const options = bestGroupOptions;
+
+			alreadyGrouped.add(bestGroup);
+			const children =
+				options && options.groupChildren === false
+					? Array.from(items, ({ item }) => item)
+					: runGrouping(items);
+			alreadyGrouped.delete(bestGroup);
+
+			results.push(
+				groupConfig.createGroup(
+					key,
+					children,
+					Array.from(items, ({ item }) => item)
+				)
+			);
+		}
+		for (const { item } of itemsWithGroups) {
+			results.push(item);
+		}
+		return results;
+	};
+	return runGrouping(itemsWithGroups);
+};
+
+module.exports = smartGrouping;

--- a/lib/util/smartGrouping.js
+++ b/lib/util/smartGrouping.js
@@ -107,10 +107,14 @@ const smartGrouping = (items, groupConfigs) => {
 					}
 				}
 				const targetGroupCount = (options && options.targetGroupCount) || 4;
-				let sizeValue = Math.min(
-					items.size,
-					(totalSize * 2) / targetGroupCount + itemsWithGroups.size - items.size
-				);
+				let sizeValue = force
+					? items.size
+					: Math.min(
+							items.size,
+							(totalSize * 2) / targetGroupCount +
+								itemsWithGroups.size -
+								items.size
+					  );
 				if (
 					sizeValue > bestGroupSize ||
 					(force && (!bestGroupOptions || !bestGroupOptions.force))

--- a/lib/util/smartGrouping.js
+++ b/lib/util/smartGrouping.js
@@ -9,7 +9,7 @@
  * @typedef {Object} GroupOptions
  * @property {boolean=} groupChildren
  * @property {boolean=} force
- * @property {boolean=} greedy
+ * @property {number=} targetGroupCount
  */
 
 /**
@@ -90,6 +90,7 @@ const smartGrouping = (items, groupConfigs) => {
 			let bestGroupItems = undefined;
 			let bestGroupOptions = undefined;
 			for (const [group, items] of groupMap) {
+				if (items.size === 0) continue;
 				const [groupConfig, groupKey] = groupConfigMap.get(group);
 				const options =
 					groupConfig.getOptions &&
@@ -97,19 +98,23 @@ const smartGrouping = (items, groupConfigs) => {
 						groupKey,
 						Array.from(items, ({ item }) => item)
 					);
-				if (items.size === 0) continue;
 				const force = options && options.force;
 				if (!force) {
+					if (bestGroupOptions && bestGroupOptions.force) continue;
 					if (usedGroups.has(group)) continue;
 					if (items.size <= 1 || totalSize - items.size <= 1) {
 						continue;
 					}
 				}
-				const greedy = options && options.greedy;
-				let sizeValue = greedy
-					? items.size
-					: Math.min(items.size, totalSize - items.size);
-				if (sizeValue > bestGroupSize) {
+				const targetGroupCount = (options && options.targetGroupCount) || 4;
+				let sizeValue = Math.min(
+					items.size,
+					(totalSize * 2) / targetGroupCount + itemsWithGroups.size - items.size
+				);
+				if (
+					sizeValue > bestGroupSize ||
+					(force && (!bestGroupOptions || !bestGroupOptions.force))
+				) {
 					bestGroup = group;
 					bestGroupSize = sizeValue;
 					bestGroupItems = items;
@@ -120,35 +125,35 @@ const smartGrouping = (items, groupConfigs) => {
 				break;
 			}
 			const items = new Set(bestGroupItems);
+			const options = bestGroupOptions;
+
+			const groupChildren = !options || options.groupChildren !== false;
+
 			for (const item of items) {
 				itemsWithGroups.delete(item);
 				// Remove all groups that items have from the map to not select them again
 				for (const group of item.groups) {
 					const list = groupMap.get(group);
 					if (list !== undefined) list.delete(item);
-					usedGroups.add(group);
+					if (groupChildren) {
+						usedGroups.add(group);
+					}
 				}
 			}
+			groupMap.delete(bestGroup);
+
 			const idx = bestGroup.indexOf(":");
 			const configKey = bestGroup.slice(0, idx);
 			const key = bestGroup.slice(idx + 1);
 			const groupConfig = groupConfigs[+configKey];
-			const options = bestGroupOptions;
+
+			const allItems = Array.from(items, ({ item }) => item);
 
 			alreadyGrouped.add(bestGroup);
-			const children =
-				options && options.groupChildren === false
-					? Array.from(items, ({ item }) => item)
-					: runGrouping(items);
+			const children = groupChildren ? runGrouping(items) : allItems;
 			alreadyGrouped.delete(bestGroup);
 
-			results.push(
-				groupConfig.createGroup(
-					key,
-					children,
-					Array.from(items, ({ item }) => item)
-				)
-			);
+			results.push(groupConfig.createGroup(key, children, allItems));
 		}
 		for (const { item } of itemsWithGroups) {
 			results.push(item);

--- a/lib/validateSchema.js
+++ b/lib/validateSchema.js
@@ -28,6 +28,7 @@ const DID_YOU_MEAN = {
 	splitChunks: "optimization.splitChunks",
 	immutablePaths: "snapshot.immutablePaths",
 	managedPaths: "snapshot.managedPaths",
+	maxModules: "stats.modulesSpace",
 	hashedModuleIds:
 		'optimization.moduleIds: "hashed" (BREAKING CHANGE since webpack 5)',
 	namedChunks:

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2980,6 +2980,10 @@
           "description": "Show cached assets (setting this to `false` only shows emitted files).",
           "type": "boolean"
         },
+        "cachedModules": {
+          "description": "Add information about cached (not built) modules.",
+          "type": "boolean"
+        },
         "children": {
           "description": "Add children information.",
           "type": "boolean"
@@ -2998,10 +3002,6 @@
         },
         "chunkRelations": {
           "description": "Add information about parent, children and sibling chunks to chunk information.",
-          "type": "boolean"
-        },
-        "chunkRootModules": {
-          "description": "Add root modules information to chunk information.",
           "type": "boolean"
         },
         "chunks": {
@@ -3055,6 +3055,10 @@
           "description": "Context directory for request shortening.",
           "type": "string",
           "absolutePath": true
+        },
+        "dependentModules": {
+          "description": "Show chunk modules that are dependencies of other modules of the chunk.",
+          "type": "boolean"
         },
         "depth": {
           "description": "Add module depth in module graph.",
@@ -3133,6 +3137,22 @@
           "description": "Group assets by their status (emitted, compared for emit or cached).",
           "type": "boolean"
         },
+        "groupModulesByAttributes": {
+          "description": "Group modules by their attributes (errors, warnings, optional, orphan, or dependent).",
+          "type": "boolean"
+        },
+        "groupModulesByCacheStatus": {
+          "description": "Group modules by their status (cached or built and cacheable).",
+          "type": "boolean"
+        },
+        "groupModulesByExtension": {
+          "description": "Group modules by their extension.",
+          "type": "boolean"
+        },
+        "groupModulesByPath": {
+          "description": "Group modules by their path.",
+          "type": "boolean"
+        },
         "hash": {
           "description": "Add the hash of the compilation.",
           "type": "boolean"
@@ -3170,10 +3190,6 @@
           "description": "Add stack traces to logging output.",
           "type": "boolean"
         },
-        "maxModules": {
-          "description": "Set the maximum number of modules to be shown.",
-          "type": "number"
-        },
         "moduleAssets": {
           "description": "Add information about assets inside modules.",
           "type": "boolean"
@@ -3189,6 +3205,10 @@
         "modulesSort": {
           "description": "Sort the modules by that field.",
           "type": "string"
+        },
+        "modulesSpace": {
+          "description": "Space to display modules (groups will be collapsed to fit this space, values is in number of modules/groups).",
+          "type": "number"
         },
         "nestedModules": {
           "description": "Add information about modules nested in other modules (like with module concatenation).",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -3121,6 +3121,10 @@
           "description": "Group assets by how their are related to chunks.",
           "type": "boolean"
         },
+        "groupAssetsByEmitStatus": {
+          "description": "Group assets by their status (emitted, compared for emit or cached).",
+          "type": "boolean"
+        },
         "groupAssetsByExtension": {
           "description": "Group assets by their extension.",
           "type": "boolean"
@@ -3131,10 +3135,6 @@
         },
         "groupAssetsByPath": {
           "description": "Group assets by their path.",
-          "type": "boolean"
-        },
-        "groupAssetsByStatus": {
-          "description": "Group assets by their status (emitted, compared for emit or cached).",
           "type": "boolean"
         },
         "groupModulesByAttributes": {

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -3138,7 +3138,7 @@
           "type": "boolean"
         },
         "groupModulesByAttributes": {
-          "description": "Group modules by their attributes (errors, warnings, optional, orphan, or dependent).",
+          "description": "Group modules by their attributes (errors, warnings, assets, optional, orphan, or dependent).",
           "type": "boolean"
         },
         "groupModulesByCacheStatus": {

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2964,6 +2964,10 @@
           "description": "Sort the assets by that field.",
           "type": "string"
         },
+        "assetsSpace": {
+          "description": "Space to display assets (groups will be collapsed to fit this space).",
+          "type": "number"
+        },
         "builtAt": {
           "description": "Add built at time information.",
           "type": "boolean"
@@ -3108,6 +3112,26 @@
               "$ref": "#/definitions/FilterTypes"
             }
           ]
+        },
+        "groupAssetsByChunk": {
+          "description": "Group assets by how their are related to chunks.",
+          "type": "boolean"
+        },
+        "groupAssetsByExtension": {
+          "description": "Group assets by their extension.",
+          "type": "boolean"
+        },
+        "groupAssetsByInfo": {
+          "description": "Group assets by their asset info (immutable, development, hotModuleReplacement, etc).",
+          "type": "boolean"
+        },
+        "groupAssetsByPath": {
+          "description": "Group assets by their path.",
+          "type": "boolean"
+        },
+        "groupAssetsByStatus": {
+          "description": "Group assets by their status (emitted, compared for emit or cached).",
+          "type": "boolean"
         },
         "hash": {
           "description": "Add the hash of the compilation.",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -3257,7 +3257,7 @@
           "description": "Add information about assets that are related to other assets (like SourceMaps for assets).",
           "type": "boolean"
         },
-        "runtime": {
+        "runtimeModules": {
           "description": "Add information about runtime modules.",
           "type": "boolean"
         },

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -180,6 +180,7 @@ describe("Stats", () => {
 			    Object {
 			      "auxiliaryChunkIdHints": Array [],
 			      "auxiliaryChunkNames": Array [],
+			      "cached": false,
 			      "chunkIdHints": Array [],
 			      "chunkNames": Array [
 			        "chunkB",
@@ -198,6 +199,7 @@ describe("Stats", () => {
 			    Object {
 			      "auxiliaryChunkIdHints": Array [],
 			      "auxiliaryChunkNames": Array [],
+			      "cached": false,
 			      "chunkIdHints": Array [],
 			      "chunkNames": Array [
 			        "entryA",
@@ -216,6 +218,7 @@ describe("Stats", () => {
 			    Object {
 			      "auxiliaryChunkIdHints": Array [],
 			      "auxiliaryChunkNames": Array [],
+			      "cached": false,
 			      "chunkIdHints": Array [],
 			      "chunkNames": Array [
 			        "entryB",
@@ -243,7 +246,7 @@ describe("Stats", () => {
 			      "entryB.js",
 			    ],
 			  },
-			  "filteredAssets": 0,
+			  "filteredAssets": undefined,
 			}
 		`);
 		});

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -4323,6 +4323,19 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
+  "stats-group-assets-by-emit-status": Object {
+    "configs": Array [
+      Object {
+        "description": "Group assets by their status (emitted, compared for emit or cached).",
+        "multiple": false,
+        "path": "stats.groupAssetsByEmitStatus",
+        "type": "boolean",
+      },
+    ],
+    "description": "Group assets by their status (emitted, compared for emit or cached).",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "stats-group-assets-by-extension": Object {
     "configs": Array [
       Object {
@@ -4362,29 +4375,16 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
-  "stats-group-assets-by-status": Object {
-    "configs": Array [
-      Object {
-        "description": "Group assets by their status (emitted, compared for emit or cached).",
-        "multiple": false,
-        "path": "stats.groupAssetsByStatus",
-        "type": "boolean",
-      },
-    ],
-    "description": "Group assets by their status (emitted, compared for emit or cached).",
-    "multiple": false,
-    "simpleType": "boolean",
-  },
   "stats-group-modules-by-attributes": Object {
     "configs": Array [
       Object {
-        "description": "Group modules by their attributes (errors, warnings, optional, orphan, or dependent).",
+        "description": "Group modules by their attributes (errors, warnings, assets, optional, orphan, or dependent).",
         "multiple": false,
         "path": "stats.groupModulesByAttributes",
         "type": "boolean",
       },
     ],
-    "description": "Group modules by their attributes (errors, warnings, optional, orphan, or dependent).",
+    "description": "Group modules by their attributes (errors, warnings, assets, optional, orphan, or dependent).",
     "multiple": false,
     "simpleType": "boolean",
   },

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -3941,6 +3941,19 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
+  "stats-cached-modules": Object {
+    "configs": Array [
+      Object {
+        "description": "Add information about cached (not built) modules.",
+        "multiple": false,
+        "path": "stats.cachedModules",
+        "type": "boolean",
+      },
+    ],
+    "description": "Add information about cached (not built) modules.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "stats-children": Object {
     "configs": Array [
       Object {
@@ -4003,19 +4016,6 @@ Object {
       },
     ],
     "description": "Add information about parent, children and sibling chunks to chunk information.",
-    "multiple": false,
-    "simpleType": "boolean",
-  },
-  "stats-chunk-root-modules": Object {
-    "configs": Array [
-      Object {
-        "description": "Add root modules information to chunk information.",
-        "multiple": false,
-        "path": "stats.chunkRootModules",
-        "type": "boolean",
-      },
-    ],
-    "description": "Add root modules information to chunk information.",
     "multiple": false,
     "simpleType": "boolean",
   },
@@ -4148,6 +4148,19 @@ Object {
     "description": "Context directory for request shortening.",
     "multiple": false,
     "simpleType": "string",
+  },
+  "stats-dependent-modules": Object {
+    "configs": Array [
+      Object {
+        "description": "Show chunk modules that are dependencies of other modules of the chunk.",
+        "multiple": false,
+        "path": "stats.dependentModules",
+        "type": "boolean",
+      },
+    ],
+    "description": "Show chunk modules that are dependencies of other modules of the chunk.",
+    "multiple": false,
+    "simpleType": "boolean",
   },
   "stats-depth": Object {
     "configs": Array [
@@ -4362,6 +4375,58 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
+  "stats-group-modules-by-attributes": Object {
+    "configs": Array [
+      Object {
+        "description": "Group modules by their attributes (errors, warnings, optional, orphan, or dependent).",
+        "multiple": false,
+        "path": "stats.groupModulesByAttributes",
+        "type": "boolean",
+      },
+    ],
+    "description": "Group modules by their attributes (errors, warnings, optional, orphan, or dependent).",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "stats-group-modules-by-cache-status": Object {
+    "configs": Array [
+      Object {
+        "description": "Group modules by their status (cached or built and cacheable).",
+        "multiple": false,
+        "path": "stats.groupModulesByCacheStatus",
+        "type": "boolean",
+      },
+    ],
+    "description": "Group modules by their status (cached or built and cacheable).",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "stats-group-modules-by-extension": Object {
+    "configs": Array [
+      Object {
+        "description": "Group modules by their extension.",
+        "multiple": false,
+        "path": "stats.groupModulesByExtension",
+        "type": "boolean",
+      },
+    ],
+    "description": "Group modules by their extension.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "stats-group-modules-by-path": Object {
+    "configs": Array [
+      Object {
+        "description": "Group modules by their path.",
+        "multiple": false,
+        "path": "stats.groupModulesByPath",
+        "type": "boolean",
+      },
+    ],
+    "description": "Group modules by their path.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "stats-hash": Object {
     "configs": Array [
       Object {
@@ -4466,19 +4531,6 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
-  "stats-max-modules": Object {
-    "configs": Array [
-      Object {
-        "description": "Set the maximum number of modules to be shown.",
-        "multiple": false,
-        "path": "stats.maxModules",
-        "type": "number",
-      },
-    ],
-    "description": "Set the maximum number of modules to be shown.",
-    "multiple": false,
-    "simpleType": "number",
-  },
   "stats-module-assets": Object {
     "configs": Array [
       Object {
@@ -4530,6 +4582,19 @@ Object {
     "description": "Sort the modules by that field.",
     "multiple": false,
     "simpleType": "string",
+  },
+  "stats-modules-space": Object {
+    "configs": Array [
+      Object {
+        "description": "Space to display modules (groups will be collapsed to fit this space, values is in number of modules/groups).",
+        "multiple": false,
+        "path": "stats.modulesSpace",
+        "type": "number",
+      },
+    ],
+    "description": "Space to display modules (groups will be collapsed to fit this space, values is in number of modules/groups).",
+    "multiple": false,
+    "simpleType": "number",
   },
   "stats-nested-modules": Object {
     "configs": Array [

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -4732,12 +4732,12 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
-  "stats-runtime": Object {
+  "stats-runtime-modules": Object {
     "configs": Array [
       Object {
         "description": "Add information about runtime modules.",
         "multiple": false,
-        "path": "stats.runtime",
+        "path": "stats.runtimeModules",
         "type": "boolean",
       },
     ],

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -3889,6 +3889,19 @@ Object {
     "multiple": false,
     "simpleType": "string",
   },
+  "stats-assets-space": Object {
+    "configs": Array [
+      Object {
+        "description": "Space to display assets (groups will be collapsed to fit this space).",
+        "multiple": false,
+        "path": "stats.assetsSpace",
+        "type": "number",
+      },
+    ],
+    "description": "Space to display assets (groups will be collapsed to fit this space).",
+    "multiple": false,
+    "simpleType": "number",
+  },
   "stats-built-at": Object {
     "configs": Array [
       Object {
@@ -4281,6 +4294,71 @@ Object {
       },
     ],
     "description": "Clear all items provided in configuration. Suppress modules that match the specified filters. Filters can be Strings, RegExps, Booleans or Functions.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "stats-group-assets-by-chunk": Object {
+    "configs": Array [
+      Object {
+        "description": "Group assets by how their are related to chunks.",
+        "multiple": false,
+        "path": "stats.groupAssetsByChunk",
+        "type": "boolean",
+      },
+    ],
+    "description": "Group assets by how their are related to chunks.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "stats-group-assets-by-extension": Object {
+    "configs": Array [
+      Object {
+        "description": "Group assets by their extension.",
+        "multiple": false,
+        "path": "stats.groupAssetsByExtension",
+        "type": "boolean",
+      },
+    ],
+    "description": "Group assets by their extension.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "stats-group-assets-by-info": Object {
+    "configs": Array [
+      Object {
+        "description": "Group assets by their asset info (immutable, development, hotModuleReplacement, etc).",
+        "multiple": false,
+        "path": "stats.groupAssetsByInfo",
+        "type": "boolean",
+      },
+    ],
+    "description": "Group assets by their asset info (immutable, development, hotModuleReplacement, etc).",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "stats-group-assets-by-path": Object {
+    "configs": Array [
+      Object {
+        "description": "Group assets by their path.",
+        "multiple": false,
+        "path": "stats.groupAssetsByPath",
+        "type": "boolean",
+      },
+    ],
+    "description": "Group assets by their path.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "stats-group-assets-by-status": Object {
+    "configs": Array [
+      Object {
+        "description": "Group assets by their status (emitted, compared for emit or cached).",
+        "multiple": false,
+        "path": "stats.groupAssetsByStatus",
+        "type": "boolean",
+      },
+    ],
+    "description": "Group assets by their status (emitted, compared for emit or cached).",
     "multiple": false,
     "simpleType": "boolean",
   },

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -13,22 +13,23 @@ Child fitting:
     asset fitting-e34e676a6c178b5d493b.js 1.08 KiB [emitted] [immutable]
     Entrypoint main = fitting-256876500cd1e11ec846.js fitting-0ef410f237b15bfe113d.js fitting-b173671f478b4f9cb241.js
     chunk (runtime: main) fitting-b173671f478b4f9cb241.js 1.87 KiB (javascript) 7.29 KiB (runtime) [entry] [rendered]
-        > ./index main
-     ./e.js 899 bytes [built]
-     ./f.js 900 bytes [built]
-     ./index.js 111 bytes [built]
-         + 9 hidden chunk modules
+      > ./index main
+      runtime modules 7.29 KiB 9 modules
+      cacheable modules 1.87 KiB
+        ./e.js 899 bytes [dependent] [built] [code generated]
+        ./f.js 900 bytes [dependent] [built] [code generated]
+        ./index.js 111 bytes [built] [code generated]
     chunk (runtime: main) fitting-0ef410f237b15bfe113d.js 1.76 KiB [initial] [rendered] [recorded] aggressive splitted
-        > ./index main
-     ./c.js 899 bytes [built]
-     ./d.js 899 bytes [built]
+      > ./index main
+      ./c.js 899 bytes [built] [code generated]
+      ./d.js 899 bytes [built] [code generated]
     chunk (runtime: main) fitting-256876500cd1e11ec846.js 1.76 KiB [initial] [rendered] [recorded] aggressive splitted
-        > ./index main
-     ./a.js 899 bytes [built]
-     ./b.js 899 bytes [built]
+      > ./index main
+      ./a.js 899 bytes [built] [code generated]
+      ./b.js 899 bytes [built] [code generated]
     chunk (runtime: main) fitting-e34e676a6c178b5d493b.js 916 bytes [rendered]
-        > ./g ./index.js 7:0-13
-     ./g.js 916 bytes [built]
+      > ./g ./index.js 7:0-13
+      ./g.js 916 bytes [built] [code generated]
 Child content-change:
     Hash: 4aaf29f17fd520a4a321
     Time: X ms
@@ -40,22 +41,23 @@ Child content-change:
     asset content-change-e34e676a6c178b5d493b.js 1.08 KiB [emitted] [immutable]
     Entrypoint main = content-change-256876500cd1e11ec846.js content-change-0ef410f237b15bfe113d.js content-change-3a29baa0969d8fe2fa39.js
     chunk (runtime: main) content-change-3a29baa0969d8fe2fa39.js 1.87 KiB (javascript) 7.3 KiB (runtime) [entry] [rendered]
-        > ./index main
-     ./e.js 899 bytes [built]
-     ./f.js 900 bytes [built]
-     ./index.js 111 bytes [built]
-         + 9 hidden chunk modules
+      > ./index main
+      runtime modules 7.3 KiB 9 modules
+      cacheable modules 1.87 KiB
+        ./e.js 899 bytes [dependent] [built] [code generated]
+        ./f.js 900 bytes [dependent] [built] [code generated]
+        ./index.js 111 bytes [built] [code generated]
     chunk (runtime: main) content-change-0ef410f237b15bfe113d.js 1.76 KiB [initial] [rendered] [recorded] aggressive splitted
-        > ./index main
-     ./c.js 899 bytes [built]
-     ./d.js 899 bytes [built]
+      > ./index main
+      ./c.js 899 bytes [built] [code generated]
+      ./d.js 899 bytes [built] [code generated]
     chunk (runtime: main) content-change-256876500cd1e11ec846.js 1.76 KiB [initial] [rendered] [recorded] aggressive splitted
-        > ./index main
-     ./a.js 899 bytes [built]
-     ./b.js 899 bytes [built]
+      > ./index main
+      ./a.js 899 bytes [built] [code generated]
+      ./b.js 899 bytes [built] [code generated]
     chunk (runtime: main) content-change-e34e676a6c178b5d493b.js 916 bytes [rendered]
-        > ./g ./index.js 7:0-13
-     ./g.js 916 bytes [built]"
+      > ./g ./index.js 7:0-13
+      ./g.js 916 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for aggressive-splitting-on-demand 1`] = `
@@ -77,54 +79,54 @@ asset d5a367eaab9f5bb1a8c2.js 1.9 KiB [emitted] [immutable]
 asset d9923f4628103bfc54b5.js 1010 bytes [emitted] [immutable]
 Entrypoint main = d080b8911b72db22f6d4.js
 chunk (runtime: main) 0ef410f237b15bfe113d.js 1.76 KiB [rendered] [recorded] aggressive splitted
-    > ./c ./d ./e ./index.js 3:0-30
- ./c.js 899 bytes [built]
- ./d.js 899 bytes [built]
+  > ./c ./d ./e ./index.js 3:0-30
+  ./c.js 899 bytes [built] [code generated]
+  ./d.js 899 bytes [built] [code generated]
 chunk (runtime: main) d080b8911b72db22f6d4.js (main) 248 bytes (javascript) 5.15 KiB (runtime) [entry] [rendered]
-    > ./index main
- ./index.js 248 bytes [built]
-     + 6 hidden chunk modules
+  > ./index main
+  runtime modules 5.15 KiB 6 modules
+  ./index.js 248 bytes [built] [code generated]
 chunk (runtime: main) 2bc30c0edd0c9fa06940.js 1.76 KiB [rendered]
-    > ./f ./g ./h ./i ./j ./k ./index.js 4:0-51
- ./j.js 901 bytes [built]
- ./k.js 899 bytes [built]
+  > ./f ./g ./h ./i ./j ./k ./index.js 4:0-51
+  ./j.js 901 bytes [built] [code generated]
+  ./k.js 899 bytes [built] [code generated]
 chunk (runtime: main) 268151d0ecbaa017b6b2.js 899 bytes [rendered]
-    > ./c ./d ./e ./index.js 3:0-30
-    > ./b ./d ./e ./f ./g ./index.js 5:0-44
- ./e.js 899 bytes [built]
+  > ./c ./d ./e ./index.js 3:0-30
+  > ./b ./d ./e ./f ./g ./index.js 5:0-44
+  ./e.js 899 bytes [built] [code generated]
 chunk (runtime: main) 3e1803ff13e39980e126.js 1.76 KiB [rendered] [recorded] aggressive splitted
-    > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
- ./i.js 899 bytes [built]
- ./j.js 901 bytes [built]
+  > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
+  ./i.js 899 bytes [built] [code generated]
+  ./j.js 901 bytes [built] [code generated]
 chunk (runtime: main) 6ce2fc05ded2844a80cb.js 1.76 KiB [rendered] [recorded] aggressive splitted
-    > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
- ./e.js 899 bytes [built]
- ./h.js 899 bytes [built]
+  > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
+  ./e.js 899 bytes [built] [code generated]
+  ./h.js 899 bytes [built] [code generated]
 chunk (runtime: main) 2c48ceffba3f9f1b8eeb.js 1.76 KiB [rendered]
-    > ./b ./c ./index.js 2:0-23
- ./b.js 899 bytes [built]
- ./c.js 899 bytes [built]
+  > ./b ./c ./index.js 2:0-23
+  ./b.js 899 bytes [built] [code generated]
+  ./c.js 899 bytes [built] [code generated]
 chunk (runtime: main) 78b089fd6e93e03b503b.js 1.76 KiB [rendered] [recorded] aggressive splitted
-    > ./f ./g ./h ./i ./j ./k ./index.js 4:0-51
- ./h.js 899 bytes [built]
- ./i.js 899 bytes [built]
+  > ./f ./g ./h ./i ./j ./k ./index.js 4:0-51
+  ./h.js 899 bytes [built] [code generated]
+  ./i.js 899 bytes [built] [code generated]
 chunk (runtime: main) 1ec205e8858a643a9384.js 1.76 KiB [rendered] [recorded] aggressive splitted
-    > ./f ./g ./h ./i ./j ./k ./index.js 4:0-51
-    > ./b ./d ./e ./f ./g ./index.js 5:0-44
-    > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
- ./f.js 899 bytes [built]
- ./g.js 901 bytes [built]
+  > ./f ./g ./h ./i ./j ./k ./index.js 4:0-51
+  > ./b ./d ./e ./f ./g ./index.js 5:0-44
+  > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
+  ./f.js 899 bytes [built] [code generated]
+  ./g.js 901 bytes [built] [code generated]
 chunk (runtime: main) d9923f4628103bfc54b5.js 899 bytes [rendered]
-    > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
- ./k.js 899 bytes [built]
+  > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
+  ./k.js 899 bytes [built] [code generated]
 chunk (runtime: main) d5a367eaab9f5bb1a8c2.js 1.76 KiB [rendered] [recorded] aggressive splitted
-    > ./b ./d ./e ./f ./g ./index.js 5:0-44
-    > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
- ./b.js 899 bytes [built]
- ./d.js 899 bytes [built]
+  > ./b ./d ./e ./f ./g ./index.js 5:0-44
+  > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
+  ./b.js 899 bytes [built] [code generated]
+  ./d.js 899 bytes [built] [code generated]
 chunk (runtime: main) d12a3594bf404e747097.js 899 bytes [rendered]
-    > ./a ./index.js 1:0-16
- ./a.js 899 bytes [built]"
+  > ./a ./index.js 1:0-16
+  ./a.js 899 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for asset 1`] = `
@@ -135,31 +137,32 @@ asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] (auxiliary name: m
 asset bundle.js 10.9 KiB [emitted] (name: main)
 asset static/file.html 12 bytes [emitted] (auxiliary name: main)
 Entrypoint main = bundle.js (89a353e9c515885abd8e.png static/file.html)
-./index.js 150 bytes [built]
-./images/file.png 42 bytes (javascript) 14.6 KiB (asset) [built]
-./images/file.svg 915 bytes [built]
-./images/file.jpg 7.92 KiB [built]
-./static/file.html 42 bytes (javascript) 12 bytes (asset) [built]
-    + 1 hidden module"
+runtime modules 27 bytes 1 module
+asset modules 8.9 KiB (javascript) 14.6 KiB (asset)
+  ./images/file.png 42 bytes (javascript) 14.6 KiB (asset) [built] [code generated]
+  ./images/file.svg 915 bytes [built] [code generated]
+  ./images/file.jpg 7.92 KiB [built] [code generated]
+  ./static/file.html 42 bytes (javascript) 12 bytes (asset) [built] [code generated]
+./index.js 150 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for async-commons-chunk 1`] = `
 "Entrypoint main = main.js
 chunk (runtime: main) main.js (main) 515 bytes (javascript) 4.84 KiB (runtime) >{460}< >{847}< >{996}< [entry] [rendered]
-    > ./ main
- ./index.js 515 bytes [built]
-     + 6 hidden root modules
+  > ./ main
+  runtime modules 4.84 KiB 6 modules
+  ./index.js 515 bytes [built] [code generated]
 chunk (runtime: main) 460.js 21 bytes <{179}> ={847}= [rendered]
-    > ./index.js 17:1-21:3
- ./c.js 21 bytes [built]
+  > ./index.js 17:1-21:3
+  ./c.js 21 bytes [built] [code generated]
 chunk (runtime: main) 847.js 21 bytes <{179}> ={460}= ={996}= [rendered] reused as split chunk (cache group: default)
-    > ./index.js 17:1-21:3
-    > ./index.js 2:1-5:3
-    > ./a ./b ./index.js 9:1-13:3
- ./a.js 21 bytes [built]
+  > ./index.js 17:1-21:3
+  > ./index.js 2:1-5:3
+  > ./a ./b ./index.js 9:1-13:3
+  ./a.js 21 bytes [built] [code generated]
 chunk (runtime: main) 996.js 21 bytes <{179}> ={847}= [rendered]
-    > ./a ./b ./index.js 9:1-13:3
- ./b.js 21 bytes [built]"
+  > ./a ./b ./index.js 9:1-13:3
+  ./b.js 21 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for async-commons-chunk-auto 1`] = `
@@ -169,281 +172,281 @@ exports[`StatsTestCases should print correct stats for async-commons-chunk-auto 
     Entrypoint b = disabled/b.js
     Entrypoint c = disabled/c.js
     chunk (runtime: b) disabled/b.js (b) 152 bytes [entry] [rendered]
-        > ./b b
-     ./b.js 72 bytes [built]
-         + 4 hidden dependent modules
+      > ./b b
+      dependent modules 80 bytes [dependent] 4 modules
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: a, main) disabled/async-g.js (async-g) 54 bytes [rendered]
-        > ./g ./a.js 6:0-47
-     ./g.js 34 bytes [built]
-         + 1 hidden dependent module
+      > ./g ./a.js 6:0-47
+      dependent modules 20 bytes [dependent] 1 module
+      ./g.js 34 bytes [built] [code generated]
     chunk (runtime: main) disabled/main.js (main) 147 bytes (javascript) 5.48 KiB (runtime) [entry] [rendered]
-        > ./ main
-     ./index.js 147 bytes [built]
-         + 8 hidden root modules
+      > ./ main
+      runtime modules 5.48 KiB 8 modules
+      ./index.js 147 bytes [built] [code generated]
     chunk (runtime: main) disabled/async-b.js (async-b) 152 bytes [rendered]
-        > ./b ./index.js 2:0-47
-     ./b.js 72 bytes [built]
-         + 4 hidden dependent modules
+      > ./b ./index.js 2:0-47
+      dependent modules 80 bytes [dependent] 4 modules
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: main) disabled/async-c.js (async-c) 152 bytes [rendered]
-        > ./c ./index.js 3:0-47
-     ./c.js + 1 modules 92 bytes [built]
-         + 3 hidden dependent modules
+      > ./c ./index.js 3:0-47
+      dependent modules 60 bytes [dependent] 3 modules
+      ./c.js + 1 modules 92 bytes [built] [code generated]
     chunk (runtime: c) disabled/c.js (c) 152 bytes [entry] [rendered]
-        > ./c c
-     ./c.js + 1 modules 92 bytes [built]
-         + 3 hidden dependent modules
+      > ./c c
+      dependent modules 60 bytes [dependent] 3 modules
+      ./c.js + 1 modules 92 bytes [built] [code generated]
     chunk (runtime: a) disabled/a.js (a) 201 bytes (javascript) 5.42 KiB (runtime) [entry] [rendered]
-        > ./a a
-     ./a.js + 1 modules 141 bytes [built]
-         + 8 hidden root modules
-         + 3 hidden dependent modules
+      > ./a a
+      runtime modules 5.42 KiB 8 modules
+      dependent modules 60 bytes [dependent] 3 modules
+      ./a.js + 1 modules 141 bytes [built] [code generated]
     chunk (runtime: main) disabled/async-a.js (async-a) 201 bytes [rendered]
-        > ./a ./index.js 1:0-47
-     ./a.js + 1 modules 141 bytes [built]
-         + 3 hidden dependent modules
+      > ./a ./index.js 1:0-47
+      dependent modules 60 bytes [dependent] 3 modules
+      ./a.js + 1 modules 141 bytes [built] [code generated]
 Child default:
     Entrypoint main = default/main.js
     Entrypoint a = default/a.js
     Entrypoint b = default/b.js
     Entrypoint c = default/c.js
     chunk (runtime: b) default/b.js (b) 152 bytes [entry] [rendered]
-        > ./b b
-     ./b.js 72 bytes [built]
-         + 4 hidden dependent modules
+      > ./b b
+      dependent modules 80 bytes [dependent] 4 modules
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: a, main) default/async-g.js (async-g) 34 bytes [rendered]
-        > ./g ./a.js 6:0-47
-     ./g.js 34 bytes [built]
+      > ./g ./a.js 6:0-47
+      ./g.js 34 bytes [built] [code generated]
     chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 5.49 KiB (runtime) [entry] [rendered]
-        > ./ main
-     ./index.js 147 bytes [built]
-         + 8 hidden root modules
+      > ./ main
+      runtime modules 5.49 KiB 8 modules
+      ./index.js 147 bytes [built] [code generated]
     chunk (runtime: main) default/282.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-     ./node_modules/x.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      ./node_modules/x.js 20 bytes [built] [code generated]
     chunk (runtime: main) default/async-b.js (async-b) 72 bytes [rendered]
-        > ./b ./index.js 2:0-47
-     ./b.js 72 bytes [built]
+      > ./b ./index.js 2:0-47
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: main) default/async-c.js (async-c) 72 bytes [rendered]
-        > ./c ./index.js 3:0-47
-     ./c.js 72 bytes [built]
+      > ./c ./index.js 3:0-47
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: c) default/c.js (c) 152 bytes [entry] [rendered]
-        > ./c c
-     ./c.js 72 bytes [built]
-         + 4 hidden dependent modules
+      > ./c c
+      dependent modules 80 bytes [dependent] 4 modules
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: a, main) default/568.js 20 bytes [rendered] split chunk (cache group: default)
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./g ./a.js 6:0-47
-     ./f.js 20 bytes [built]
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./g ./a.js 6:0-47
+      ./f.js 20 bytes [built] [code generated]
     chunk (runtime: main) default/767.js 20 bytes [rendered] split chunk (cache group: default)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-     ./d.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      ./d.js 20 bytes [built] [code generated]
     chunk (runtime: main) default/769.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
-        > ./c ./index.js 3:0-47
-     ./node_modules/z.js 20 bytes [built]
+      > ./c ./index.js 3:0-47
+      ./node_modules/z.js 20 bytes [built] [code generated]
     chunk (runtime: a) default/a.js (a) 201 bytes (javascript) 5.48 KiB (runtime) [entry] [rendered]
-        > ./a a
-     ./a.js + 1 modules 141 bytes [built]
-         + 8 hidden root modules
-         + 3 hidden dependent modules
+      > ./a a
+      runtime modules 5.48 KiB 8 modules
+      dependent modules 60 bytes [dependent] 3 modules
+      ./a.js + 1 modules 141 bytes [built] [code generated]
     chunk (runtime: main) default/async-a.js (async-a) 141 bytes [rendered]
-        > ./a ./index.js 1:0-47
-     ./a.js + 1 modules 141 bytes [built]
+      > ./a ./index.js 1:0-47
+      ./a.js + 1 modules 141 bytes [built] [code generated]
     chunk (runtime: main) default/954.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-     ./node_modules/y.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      ./node_modules/y.js 20 bytes [built] [code generated]
 Child vendors:
     Entrypoint main = vendors/main.js
     Entrypoint a = vendors/vendors.js vendors/a.js
     Entrypoint b = vendors/vendors.js vendors/b.js
     Entrypoint c = vendors/vendors.js vendors/c.js
     chunk (runtime: b) vendors/b.js (b) 112 bytes (javascript) 2.58 KiB (runtime) [entry] [rendered]
-        > ./b b
-     ./b.js 72 bytes [built]
-         + 2 hidden root modules
-         + 2 hidden dependent modules
+      > ./b b
+      dependent modules 40 bytes [dependent] 2 modules
+      runtime modules 2.58 KiB 2 modules
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: a, main) vendors/async-g.js (async-g) 54 bytes [rendered]
-        > ./g ./a.js 6:0-47
-     ./g.js 34 bytes [built]
-         + 1 hidden dependent module
+      > ./g ./a.js 6:0-47
+      dependent modules 20 bytes [dependent] 1 module
+      ./g.js 34 bytes [built] [code generated]
     chunk (runtime: main) vendors/main.js (main) 147 bytes (javascript) 5.48 KiB (runtime) [entry] [rendered]
-        > ./ main
-     ./index.js 147 bytes [built]
-         + 8 hidden root modules
+      > ./ main
+      runtime modules 5.48 KiB 8 modules
+      ./index.js 147 bytes [built] [code generated]
     chunk (runtime: a, b, c) vendors/vendors.js (vendors) (id hint: vendors) 60 bytes [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
-        > ./a a
-        > ./b b
-        > ./c c
-     ./node_modules/x.js 20 bytes [built]
-     ./node_modules/y.js 20 bytes [built]
-     ./node_modules/z.js 20 bytes [built]
+      > ./a a
+      > ./b b
+      > ./c c
+      ./node_modules/x.js 20 bytes [built] [code generated]
+      ./node_modules/y.js 20 bytes [built] [code generated]
+      ./node_modules/z.js 20 bytes [built] [code generated]
     chunk (runtime: main) vendors/async-b.js (async-b) 152 bytes [rendered]
-        > ./b ./index.js 2:0-47
-     ./b.js 72 bytes [built]
-         + 4 hidden dependent modules
+      > ./b ./index.js 2:0-47
+      dependent modules 80 bytes [dependent] 4 modules
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: main) vendors/async-c.js (async-c) 152 bytes [rendered]
-        > ./c ./index.js 3:0-47
-     ./c.js 72 bytes [built]
-         + 4 hidden dependent modules
+      > ./c ./index.js 3:0-47
+      dependent modules 80 bytes [dependent] 4 modules
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: c) vendors/c.js (c) 112 bytes (javascript) 2.58 KiB (runtime) [entry] [rendered]
-        > ./c c
-     ./c.js 72 bytes [built]
-         + 2 hidden root modules
-         + 2 hidden dependent modules
+      > ./c c
+      dependent modules 40 bytes [dependent] 2 modules
+      runtime modules 2.58 KiB 2 modules
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: a) vendors/a.js (a) 161 bytes (javascript) 6.61 KiB (runtime) [entry] [rendered]
-        > ./a a
-     ./a.js + 1 modules 141 bytes [built]
-         + 8 hidden root modules
-         + 1 hidden dependent module
+      > ./a a
+      runtime modules 6.61 KiB 8 modules
+      dependent modules 20 bytes [dependent] 1 module
+      ./a.js + 1 modules 141 bytes [built] [code generated]
     chunk (runtime: main) vendors/async-a.js (async-a) 201 bytes [rendered]
-        > ./a ./index.js 1:0-47
-     ./a.js + 1 modules 141 bytes [built]
-         + 3 hidden dependent modules
+      > ./a ./index.js 1:0-47
+      dependent modules 60 bytes [dependent] 3 modules
+      ./a.js + 1 modules 141 bytes [built] [code generated]
 Child multiple-vendors:
     Entrypoint main = multiple-vendors/main.js
     Entrypoint a = multiple-vendors/libs-x.js multiple-vendors/954.js multiple-vendors/767.js multiple-vendors/390.js multiple-vendors/a.js
     Entrypoint b = multiple-vendors/libs-x.js multiple-vendors/954.js multiple-vendors/767.js multiple-vendors/568.js multiple-vendors/b.js
     Entrypoint c = multiple-vendors/libs-x.js multiple-vendors/769.js multiple-vendors/767.js multiple-vendors/568.js multiple-vendors/c.js
     chunk (runtime: a, b, c, main) multiple-vendors/libs-x.js (libs-x) (id hint: libs) 20 bytes [initial] [rendered] split chunk (cache group: libs) (name: libs-x)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./a a
-        > ./b b
-        > ./c c
-     ./node_modules/x.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./a a
+      > ./b b
+      > ./c c
+      ./node_modules/x.js 20 bytes [built] [code generated]
     chunk (runtime: b) multiple-vendors/b.js (b) 72 bytes (javascript) 2.6 KiB (runtime) [entry] [rendered]
-        > ./b b
-     ./b.js 72 bytes [built]
-         + 2 hidden root modules
+      > ./b b
+      runtime modules 2.6 KiB 2 modules
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: a, main) multiple-vendors/async-g.js (async-g) 34 bytes [rendered]
-        > ./g ./a.js 6:0-47
-     ./g.js 34 bytes [built]
+      > ./g ./a.js 6:0-47
+      ./g.js 34 bytes [built] [code generated]
     chunk (runtime: main) multiple-vendors/main.js (main) 147 bytes (javascript) 5.51 KiB (runtime) [entry] [rendered]
-        > ./ main
-     ./index.js 147 bytes [built]
-         + 8 hidden root modules
+      > ./ main
+      runtime modules 5.51 KiB 8 modules
+      ./index.js 147 bytes [built] [code generated]
     chunk (runtime: main) multiple-vendors/async-b.js (async-b) 72 bytes [rendered]
-        > ./b ./index.js 2:0-47
-     ./b.js 72 bytes [built]
+      > ./b ./index.js 2:0-47
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: main) multiple-vendors/async-c.js (async-c) 72 bytes [rendered]
-        > ./c ./index.js 3:0-47
-     ./c.js 72 bytes [built]
+      > ./c ./index.js 3:0-47
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: a, main) multiple-vendors/390.js 20 bytes [initial] [rendered] split chunk (cache group: default)
-        > ./a ./index.js 1:0-47
-        > ./a a
-     ./e.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./a a
+      ./e.js 20 bytes [built] [code generated]
     chunk (runtime: c) multiple-vendors/c.js (c) 72 bytes (javascript) 2.6 KiB (runtime) [entry] [rendered]
-        > ./c c
-     ./c.js 72 bytes [built]
-         + 2 hidden root modules
+      > ./c c
+      runtime modules 2.6 KiB 2 modules
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: a, b, c, main) multiple-vendors/568.js 20 bytes [initial] [rendered] split chunk (cache group: default)
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./g ./a.js 6:0-47
-        > ./b b
-        > ./c c
-     ./f.js 20 bytes [built]
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./g ./a.js 6:0-47
+      > ./b b
+      > ./c c
+      ./f.js 20 bytes [built] [code generated]
     chunk (runtime: a, b, c, main) multiple-vendors/767.js 20 bytes [initial] [rendered] split chunk (cache group: default)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./a a
-        > ./b b
-        > ./c c
-     ./d.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./a a
+      > ./b b
+      > ./c c
+      ./d.js 20 bytes [built] [code generated]
     chunk (runtime: c, main) multiple-vendors/769.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
-        > ./c ./index.js 3:0-47
-        > ./c c
-     ./node_modules/z.js 20 bytes [built]
+      > ./c ./index.js 3:0-47
+      > ./c c
+      ./node_modules/z.js 20 bytes [built] [code generated]
     chunk (runtime: a) multiple-vendors/a.js (a) 121 bytes (javascript) 6.67 KiB (runtime) [entry] [rendered]
-        > ./a a
-     ./a.js 121 bytes [built]
-         + 8 hidden root modules
+      > ./a a
+      runtime modules 6.67 KiB 8 modules
+      ./a.js 121 bytes [built] [code generated]
     chunk (runtime: main) multiple-vendors/async-a.js (async-a) 121 bytes [rendered]
-        > ./a ./index.js 1:0-47
-     ./a.js 121 bytes [built]
+      > ./a ./index.js 1:0-47
+      ./a.js 121 bytes [built] [code generated]
     chunk (runtime: a, b, main) multiple-vendors/954.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./a a
-        > ./b b
-     ./node_modules/y.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./a a
+      > ./b b
+      ./node_modules/y.js 20 bytes [built] [code generated]
 Child all:
     Entrypoint main = all/main.js
     Entrypoint a = all/282.js all/954.js all/767.js all/390.js all/a.js
     Entrypoint b = all/282.js all/954.js all/767.js all/568.js all/b.js
     Entrypoint c = all/282.js all/769.js all/767.js all/568.js all/c.js
     chunk (runtime: b) all/b.js (b) 72 bytes (javascript) 2.6 KiB (runtime) [entry] [rendered]
-        > ./b b
-     ./b.js 72 bytes [built]
-         + 2 hidden root modules
+      > ./b b
+      runtime modules 2.6 KiB 2 modules
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: a, main) all/async-g.js (async-g) 34 bytes [rendered]
-        > ./g ./a.js 6:0-47
-     ./g.js 34 bytes [built]
+      > ./g ./a.js 6:0-47
+      ./g.js 34 bytes [built] [code generated]
     chunk (runtime: main) all/main.js (main) 147 bytes (javascript) 5.49 KiB (runtime) [entry] [rendered]
-        > ./ main
-     ./index.js 147 bytes [built]
-         + 8 hidden root modules
+      > ./ main
+      runtime modules 5.49 KiB 8 modules
+      ./index.js 147 bytes [built] [code generated]
     chunk (runtime: a, b, c, main) all/282.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./a a
-        > ./b b
-        > ./c c
-     ./node_modules/x.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./a a
+      > ./b b
+      > ./c c
+      ./node_modules/x.js 20 bytes [built] [code generated]
     chunk (runtime: main) all/async-b.js (async-b) 72 bytes [rendered]
-        > ./b ./index.js 2:0-47
-     ./b.js 72 bytes [built]
+      > ./b ./index.js 2:0-47
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: main) all/async-c.js (async-c) 72 bytes [rendered]
-        > ./c ./index.js 3:0-47
-     ./c.js 72 bytes [built]
+      > ./c ./index.js 3:0-47
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: a, main) all/390.js 20 bytes [initial] [rendered] split chunk (cache group: default)
-        > ./a ./index.js 1:0-47
-        > ./a a
-     ./e.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./a a
+      ./e.js 20 bytes [built] [code generated]
     chunk (runtime: c) all/c.js (c) 72 bytes (javascript) 2.6 KiB (runtime) [entry] [rendered]
-        > ./c c
-     ./c.js 72 bytes [built]
-         + 2 hidden root modules
+      > ./c c
+      runtime modules 2.6 KiB 2 modules
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: a, b, c, main) all/568.js 20 bytes [initial] [rendered] split chunk (cache group: default)
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./g ./a.js 6:0-47
-        > ./b b
-        > ./c c
-     ./f.js 20 bytes [built]
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./g ./a.js 6:0-47
+      > ./b b
+      > ./c c
+      ./f.js 20 bytes [built] [code generated]
     chunk (runtime: a, b, c, main) all/767.js 20 bytes [initial] [rendered] split chunk (cache group: default)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./a a
-        > ./b b
-        > ./c c
-     ./d.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./a a
+      > ./b b
+      > ./c c
+      ./d.js 20 bytes [built] [code generated]
     chunk (runtime: c, main) all/769.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
-        > ./c ./index.js 3:0-47
-        > ./c c
-     ./node_modules/z.js 20 bytes [built]
+      > ./c ./index.js 3:0-47
+      > ./c c
+      ./node_modules/z.js 20 bytes [built] [code generated]
     chunk (runtime: a) all/a.js (a) 121 bytes (javascript) 6.66 KiB (runtime) [entry] [rendered]
-        > ./a a
-     ./a.js 121 bytes [built]
-         + 8 hidden root modules
+      > ./a a
+      runtime modules 6.66 KiB 8 modules
+      ./a.js 121 bytes [built] [code generated]
     chunk (runtime: main) all/async-a.js (async-a) 121 bytes [rendered]
-        > ./a ./index.js 1:0-47
-     ./a.js 121 bytes [built]
+      > ./a ./index.js 1:0-47
+      ./a.js 121 bytes [built] [code generated]
     chunk (runtime: a, b, main) all/954.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./a a
-        > ./b b
-     ./node_modules/y.js 20 bytes [built]"
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./a a
+      > ./b b
+      ./node_modules/y.js 20 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for chunk-module-id-range 1`] = `
@@ -456,21 +459,23 @@ asset main2.js 4.38 KiB [emitted] (name: main2)
 Entrypoint main1 = main1.js
 Entrypoint main2 = main2.js
 chunk main1.js (main1) 136 bytes (javascript) 668 bytes (runtime) [entry] [rendered]
-    > ./main1 main1
- ./a.js 20 bytes [built]
- ./b.js 20 bytes [built]
- ./c.js 20 bytes [built]
- ./d.js 20 bytes [built]
- ./main1.js 56 bytes [built]
-     + 3 hidden chunk modules
+  > ./main1 main1
+  runtime modules 668 bytes 3 modules
+  cacheable modules 136 bytes
+    ./a.js 20 bytes [dependent] [built] [code generated]
+    ./b.js 20 bytes [dependent] [built] [code generated]
+    ./c.js 20 bytes [dependent] [built] [code generated]
+    ./d.js 20 bytes [dependent] [built] [code generated]
+    ./main1.js 56 bytes [built] [code generated]
 chunk main2.js (main2) 136 bytes (javascript) 668 bytes (runtime) [entry] [rendered]
-    > ./main2 main2
- ./a.js 20 bytes [built]
- ./d.js 20 bytes [built]
- ./e.js 20 bytes [built]
- ./f.js 20 bytes [built]
- ./main2.js 56 bytes [built]
-     + 3 hidden chunk modules"
+  > ./main2 main2
+  runtime modules 668 bytes 3 modules
+  cacheable modules 136 bytes
+    ./a.js 20 bytes [dependent] [built] [code generated]
+    ./d.js 20 bytes [dependent] [built] [code generated]
+    ./e.js 20 bytes [dependent] [built] [code generated]
+    ./f.js 20 bytes [dependent] [built] [code generated]
+    ./main2.js 56 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for chunks 1`] = `
@@ -484,36 +489,42 @@ asset 996.bundle.js 138 bytes [emitted]
 asset bundle.js 8.61 KiB [emitted] (name: main)
 Entrypoint main = bundle.js
 chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 4.84 KiB (runtime) >{460}< >{996}< [entry] [rendered]
-    > ./index main
- ./a.js 22 bytes [built]
-     cjs self exports reference ./a.js 1:0-14
-     cjs require ./a ./index.js 1:0-14
-     X ms -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
- ./index.js 51 bytes [built]
-     entry ./index main
-     X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
-     + 6 hidden chunk modules
+  > ./index main
+  runtime modules 4.84 KiB 6 modules
+  cacheable modules 73 bytes
+    ./a.js 22 bytes [dependent] [built] [code generated]
+      cjs self exports reference ./a.js 1:0-14
+      cjs require ./a ./index.js 1:0-14
+      X ms ->
+      X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+    ./index.js 51 bytes [built] [code generated]
+      entry ./index main
+      X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
 chunk (runtime: main) 460.bundle.js 54 bytes <{179}> >{524}< [rendered]
-    > ./c ./index.js 3:0-16
- ./c.js 54 bytes [built]
-     amd require ./c ./index.js 3:0-16
-     X ms -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+  > ./c ./index.js 3:0-16
+  ./c.js 54 bytes [built] [code generated]
+    amd require ./c ./index.js 3:0-16
+    X ms ->
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
 chunk (runtime: main) 524.bundle.js 44 bytes <{460}> [rendered]
-    > ./c.js 1:0-52
- ./d.js 22 bytes [built]
-     require.ensure item ./d ./c.js 1:0-52
-     cjs self exports reference ./d.js 1:0-14
-     X ms -> X ms -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
- ./e.js 22 bytes [built]
-     require.ensure item ./e ./c.js 1:0-52
-     cjs self exports reference ./e.js 1:0-14
-     X ms -> X ms -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+  > ./c.js 1:0-52
+  ./d.js 22 bytes [built] [code generated]
+    require.ensure item ./d ./c.js 1:0-52
+    cjs self exports reference ./d.js 1:0-14
+    X ms -> X ms ->
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+  ./e.js 22 bytes [built] [code generated]
+    require.ensure item ./e ./c.js 1:0-52
+    cjs self exports reference ./e.js 1:0-14
+    X ms -> X ms ->
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
 chunk (runtime: main) 996.bundle.js 22 bytes <{179}> [rendered]
-    > ./b ./index.js 2:0-16
- ./b.js 22 bytes [built]
-     cjs self exports reference ./b.js 1:0-14
-     amd require ./b ./index.js 2:0-16
-     X ms -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)"
+  > ./b ./index.js 2:0-16
+  ./b.js 22 bytes [built] [code generated]
+    cjs self exports reference ./b.js 1:0-14
+    amd require ./b ./index.js 2:0-16
+    X ms ->
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)"
 `;
 
 exports[`StatsTestCases should print correct stats for chunks-development 1`] = `
@@ -527,50 +538,56 @@ asset c_js.bundle.js 1.1 KiB [emitted]
 asset d_js-e_js.bundle.js 1.37 KiB [emitted]
 Entrypoint main = bundle.js
 chunk b_js.bundle.js 22 bytes <{main}> [rendered]
-    > ./b ./index.js 2:0-16
- ./b.js 22 bytes [built]
-     cjs self exports reference ./b.js 1:0-14
-     amd require ./b ./index.js 2:0-16
-     X ms -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+  > ./b ./index.js 2:0-16
+  ./b.js 22 bytes [built] [code generated]
+    cjs self exports reference ./b.js 1:0-14
+    amd require ./b ./index.js 2:0-16
+    X ms ->
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
 chunk c_js.bundle.js 54 bytes <{main}> >{d_js-e_js}< [rendered]
-    > ./c ./index.js 3:0-16
- ./c.js 54 bytes [built]
-     amd require ./c ./index.js 3:0-16
-     X ms -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+  > ./c ./index.js 3:0-16
+  ./c.js 54 bytes [built] [code generated]
+    amd require ./c ./index.js 3:0-16
+    X ms ->
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
 chunk d_js-e_js.bundle.js 60 bytes <{c_js}> [rendered]
-    > ./c.js 1:0-52
- ./d.js 22 bytes [built]
-     require.ensure item ./d ./c.js 1:0-52
-     cjs self exports reference ./d.js 1:0-14
-     X ms -> X ms -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
- ./e.js 38 bytes [built]
-     require.ensure item ./e ./c.js 1:0-52
-     cjs self exports reference ./e.js 2:0-14
-     X ms -> X ms -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+  > ./c.js 1:0-52
+  ./d.js 22 bytes [built] [code generated]
+    require.ensure item ./d ./c.js 1:0-52
+    cjs self exports reference ./d.js 1:0-14
+    X ms -> X ms ->
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+  ./e.js 38 bytes [built] [code generated]
+    require.ensure item ./e ./c.js 1:0-52
+    cjs self exports reference ./e.js 2:0-14
+    X ms -> X ms ->
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
 chunk bundle.js (main) 73 bytes (javascript) 4.85 KiB (runtime) >{b_js}< >{c_js}< [entry] [rendered]
-    > ./index main
- ./a.js 22 bytes [built]
-     cjs self exports reference ./a.js 1:0-14
-     cjs require ./a ./e.js 1:0-14
-     cjs require ./a ./index.js 1:0-14
-     X ms -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
- ./index.js 51 bytes [built]
-     entry ./index main
-     X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
-     + 6 hidden chunk modules"
+  > ./index main
+  runtime modules 4.85 KiB 6 modules
+  cacheable modules 73 bytes
+    ./a.js 22 bytes [dependent] [built] [code generated]
+      cjs self exports reference ./a.js 1:0-14
+      cjs require ./a ./e.js 1:0-14
+      cjs require ./a ./index.js 1:0-14
+      X ms ->
+      X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+    ./index.js 51 bytes [built] [code generated]
+      entry ./index main
+      X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)"
 `;
 
 exports[`StatsTestCases should print correct stats for circular-correctness 1`] = `
 "Entrypoint main = bundle.js
 chunk (runtime: main) 128.bundle.js (b) 49 bytes <{179}> <{459}> >{459}< [rendered]
- ./module-b.js 49 bytes [built]
+  ./module-b.js 49 bytes [built] [code generated]
 chunk (runtime: main) bundle.js (main) 98 bytes (javascript) 6.08 KiB (runtime) >{128}< >{786}< [entry] [rendered]
- ./index.js 98 bytes [built]
-     + 9 hidden chunk modules
+  runtime modules 6.08 KiB 9 modules
+  ./index.js 98 bytes [built] [code generated]
 chunk (runtime: main) 459.bundle.js (c) 98 bytes <{128}> <{786}> >{128}< >{786}< [rendered]
- ./module-c.js 98 bytes [built]
+  ./module-c.js 98 bytes [built] [code generated]
 chunk (runtime: main) 786.bundle.js (a) 49 bytes <{179}> <{459}> >{459}< [rendered]
- ./module-a.js 49 bytes [built]"
+  ./module-a.js 49 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for color-disabled 1`] = `
@@ -579,7 +596,7 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 asset main.js 54 bytes [emitted] (name: main)
 Entrypoint main = main.js
-./index.js 1 bytes [built]"
+./index.js 1 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for color-enabled 1`] = `
@@ -588,7 +605,7 @@ Time: <CLR=BOLD>X</CLR> ms
 Built at: 1970-04-20 <CLR=BOLD>12:42:42</CLR>
 asset <CLR=32,BOLD>main.js</CLR> 54 bytes <CLR=32,BOLD>[emitted]</CLR> (name: main)
 Entrypoint <CLR=BOLD>main</CLR> = <CLR=32,BOLD>main.js</CLR>
-<CLR=BOLD>./index.js</CLR> 1 bytes <CLR=32,BOLD>[built]</CLR>"
+<CLR=BOLD>./index.js</CLR> 1 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>"
 `;
 
 exports[`StatsTestCases should print correct stats for color-enabled-custom 1`] = `
@@ -597,7 +614,7 @@ Time: <CLR=BOLD>X</CLR> ms
 Built at: 1970-04-20 <CLR=BOLD>12:42:42</CLR>
 asset <CLR=32>main.js</CLR> 54 bytes <CLR=32>[emitted]</CLR> (name: main)
 Entrypoint <CLR=BOLD>main</CLR> = <CLR=32>main.js</CLR>
-<CLR=BOLD>./index.js</CLR> 1 bytes <CLR=32>[built]</CLR>"
+<CLR=BOLD>./index.js</CLR> 1 bytes <CLR=33>[built]</CLR> <CLR=33>[code generated]</CLR>"
 `;
 
 exports[`StatsTestCases should print correct stats for common-libs 1`] = `
@@ -606,10 +623,11 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 asset react.js 3.12 KiB [emitted] [minimized] (name: react) 1 related asset
 Entrypoint react = react.js
-./react.js 69 bytes [built]
-../../../node_modules/react/index.js 190 bytes [built]
-../../../node_modules/react/cjs/react.production.min.js 6.52 KiB [built]
-../../../node_modules/object-assign/index.js 2.06 KiB [built]"
+modules by path ../../../node_modules/react/ 6.7 KiB
+  ../../../node_modules/react/index.js 190 bytes [built] [code generated]
+  ../../../node_modules/react/cjs/react.production.min.js 6.52 KiB [built] [code generated]
+./react.js 69 bytes [built] [code generated]
+../../../node_modules/object-assign/index.js 2.06 KiB [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for commons-chunk-min-size-0 1`] = `
@@ -619,14 +637,15 @@ Built at: 1970-04-20 12:42:42
 asset 429.js 274 bytes [emitted] (id hint: vendor-1)
 asset entry-1.js 5.55 KiB [emitted] (name: entry-1)
 Entrypoint entry-1 = 429.js entry-1.js
-./entry-1.js 145 bytes [built]
-./modules/a.js 22 bytes [built]
-./modules/b.js 22 bytes [built]
-./modules/c.js 22 bytes [built]
-./modules/d.js 22 bytes [built]
-./modules/e.js 22 bytes [built]
-./modules/f.js 22 bytes [built]
-    + 2 hidden modules"
+runtime modules 2.58 KiB 2 modules
+modules by path ./modules/ 132 bytes
+  ./modules/a.js 22 bytes [built] [code generated]
+  ./modules/b.js 22 bytes [built] [code generated]
+  ./modules/c.js 22 bytes [built] [code generated]
+  ./modules/d.js 22 bytes [built] [code generated]
+  ./modules/e.js 22 bytes [built] [code generated]
+  ./modules/f.js 22 bytes [built] [code generated]
+./entry-1.js 145 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for commons-chunk-min-size-Infinity 1`] = `
@@ -636,14 +655,15 @@ Built at: 1970-04-20 12:42:42
 asset entry-1.js 5.55 KiB [emitted] (name: entry-1)
 asset vendor-1.js 274 bytes [emitted] (name: vendor-1) (id hint: vendor-1)
 Entrypoint entry-1 = vendor-1.js entry-1.js
-./entry-1.js 145 bytes [built]
-./modules/a.js 22 bytes [built]
-./modules/b.js 22 bytes [built]
-./modules/c.js 22 bytes [built]
-./modules/d.js 22 bytes [built]
-./modules/e.js 22 bytes [built]
-./modules/f.js 22 bytes [built]
-    + 2 hidden modules"
+runtime modules 2.58 KiB 2 modules
+modules by path ./modules/ 132 bytes
+  ./modules/a.js 22 bytes [built] [code generated]
+  ./modules/b.js 22 bytes [built] [code generated]
+  ./modules/c.js 22 bytes [built] [code generated]
+  ./modules/d.js 22 bytes [built] [code generated]
+  ./modules/e.js 22 bytes [built] [code generated]
+  ./modules/f.js 22 bytes [built] [code generated]
+./entry-1.js 145 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for commons-plugin-issue-4980 1`] = `
@@ -655,9 +675,11 @@ Child
     asset app.564f768b446854553ea9-1.js 6.08 KiB [emitted] [immutable] (name: app)
     asset vendor.8fb9521629ca9dc82907-1.js 611 bytes [emitted] [immutable] (name: vendor) (id hint: vendor)
     Entrypoint app = vendor.8fb9521629ca9dc82907-1.js app.564f768b446854553ea9-1.js
-    ./entry-1.js + 2 modules 185 bytes [built]
-    ./constants.js 87 bytes [built]
-        + 5 hidden modules
+    runtime modules 2.88 KiB 3 modules
+    orphan modules 118 bytes [orphan] 2 modules
+    cacheable modules 272 bytes
+      ./entry-1.js + 2 modules 185 bytes [built] [code generated]
+      ./constants.js 87 bytes [built] [code generated]
 Child
     Hash: 5e54267cececc0533dd0
     Time: X ms
@@ -665,28 +687,30 @@ Child
     asset app.a8bb86aebcc9997fa601-2.js 6.1 KiB [emitted] [immutable] (name: app)
     asset vendor.8fb9521629ca9dc82907-2.js 611 bytes [emitted] [immutable] (name: vendor) (id hint: vendor)
     Entrypoint app = vendor.8fb9521629ca9dc82907-2.js app.a8bb86aebcc9997fa601-2.js
-    ./entry-2.js + 2 modules 192 bytes [built]
-    ./constants.js 87 bytes [built]
-        + 5 hidden modules"
+    runtime modules 2.88 KiB 3 modules
+    orphan modules 125 bytes [orphan] 2 modules
+    cacheable modules 279 bytes
+      ./entry-2.js + 2 modules 192 bytes [built] [code generated]
+      ./constants.js 87 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for concat-and-sideeffects 1`] = `
-"./index.js + 2 modules 119 bytes [built]
-    | ./index.js 46 bytes [built]
-    | ./node_modules/pmodule/a.js 49 bytes [built]
-    | ./node_modules/pmodule/aa.js 24 bytes [built]
+"./index.js + 2 modules 119 bytes [built] [code generated]
+  | ./index.js 46 bytes [built]
+  | ./node_modules/pmodule/a.js 49 bytes [built]
+  | ./node_modules/pmodule/aa.js 24 bytes [built]
 ./node_modules/pmodule/a.js 49 bytes [orphan] [built]
 ./node_modules/pmodule/index.js 63 bytes [orphan] [built]
-    ModuleConcatenation bailout: Module is not in any chunk
+  ModuleConcatenation bailout: Module is not in any chunk
 ./node_modules/pmodule/aa.js 24 bytes [orphan] [built]
 ./node_modules/pmodule/b.js 49 bytes [orphan] [built]
-    ModuleConcatenation bailout: Module is not in any chunk
+  ModuleConcatenation bailout: Module is not in any chunk
 ./node_modules/pmodule/c.js 49 bytes [orphan] [built]
-    ModuleConcatenation bailout: Module is not in any chunk
+  ModuleConcatenation bailout: Module is not in any chunk
 ./node_modules/pmodule/bb.js 24 bytes [orphan] [built]
-    ModuleConcatenation bailout: Module is not in any chunk
+  ModuleConcatenation bailout: Module is not in any chunk
 ./node_modules/pmodule/cc.js 24 bytes [orphan] [built]
-    ModuleConcatenation bailout: Module is not in any chunk"
+  ModuleConcatenation bailout: Module is not in any chunk"
 `;
 
 exports[`StatsTestCases should print correct stats for context-independence 1`] = `
@@ -700,9 +724,11 @@ Child
     asset main-ed1a19bb8f1e131951b5.js 8.89 KiB [emitted] [immutable] (name: main)
       sourceMap main-ed1a19bb8f1e131951b5.js.map 7.91 KiB [emitted] [dev] (auxiliary name: main)
     Entrypoint main = main-ed1a19bb8f1e131951b5.js (main-ed1a19bb8f1e131951b5.js.map)
-    ./a/index.js 40 bytes [built]
-    ./a/chunk.js + 1 modules 66 bytes [built]
-        + 8 hidden modules
+    runtime modules 5.13 KiB 7 modules
+    orphan modules 19 bytes [orphan] 1 module
+    cacheable modules 106 bytes
+      ./a/index.js 40 bytes [built] [code generated]
+      ./a/chunk.js + 1 modules 66 bytes [built] [code generated]
 Child
     Hash: 244d7feb4c27915a3d13
     Time: X ms
@@ -712,9 +738,11 @@ Child
     asset main-ed1a19bb8f1e131951b5.js 8.89 KiB [emitted] [immutable] (name: main)
       sourceMap main-ed1a19bb8f1e131951b5.js.map 7.91 KiB [emitted] [dev] (auxiliary name: main)
     Entrypoint main = main-ed1a19bb8f1e131951b5.js (main-ed1a19bb8f1e131951b5.js.map)
-    ./b/index.js 40 bytes [built]
-    ./b/chunk.js + 1 modules 66 bytes [built]
-        + 8 hidden modules
+    runtime modules 5.13 KiB 7 modules
+    orphan modules 19 bytes [orphan] 1 module
+    cacheable modules 106 bytes
+      ./b/index.js 40 bytes [built] [code generated]
+      ./b/chunk.js + 1 modules 66 bytes [built] [code generated]
 Child
     Hash: 4f369b0f27bec1344d18
     Time: X ms
@@ -722,9 +750,11 @@ Child
     asset 664-621821b58c4f6e28e877.js 1.51 KiB [emitted] [immutable]
     asset main-ccfb305c2978d8db7719.js 9.78 KiB [emitted] [immutable] (name: main)
     Entrypoint main = main-ccfb305c2978d8db7719.js
-    ./a/index.js 40 bytes [built]
-    ./a/chunk.js + 1 modules 66 bytes [built]
-        + 8 hidden modules
+    runtime modules 5.13 KiB 7 modules
+    orphan modules 19 bytes [orphan] 1 module
+    cacheable modules 106 bytes
+      ./a/index.js 40 bytes [built] [code generated]
+      ./a/chunk.js + 1 modules 66 bytes [built] [code generated]
 Child
     Hash: 4f369b0f27bec1344d18
     Time: X ms
@@ -732,9 +762,11 @@ Child
     asset 664-621821b58c4f6e28e877.js 1.51 KiB [emitted] [immutable]
     asset main-ccfb305c2978d8db7719.js 9.78 KiB [emitted] [immutable] (name: main)
     Entrypoint main = main-ccfb305c2978d8db7719.js
-    ./b/index.js 40 bytes [built]
-    ./b/chunk.js + 1 modules 66 bytes [built]
-        + 8 hidden modules"
+    runtime modules 5.13 KiB 7 modules
+    orphan modules 19 bytes [orphan] 1 module
+    cacheable modules 106 bytes
+      ./b/index.js 40 bytes [built] [code generated]
+      ./b/chunk.js + 1 modules 66 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for custom-terser 1`] = `
@@ -743,10 +775,10 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 asset bundle.js 556 bytes [emitted] [minimized] (name: main)
 Entrypoint main = bundle.js
-./index.js 128 bytes [built]
-    [no exports used]
-./a.js 49 bytes [built]
-    [used exports unknown]"
+./index.js 128 bytes [built] [code generated]
+  [no exports used]
+./a.js 49 bytes [built] [code generated]
+  [used exports unknown]"
 `;
 
 exports[`StatsTestCases should print correct stats for define-plugin 1`] = `
@@ -757,21 +789,21 @@ Child
     Built at: 1970-04-20 12:42:42
     asset 123.js 1.3 KiB [emitted] (name: main)
     Entrypoint main = 123.js
-    ./index.js 24 bytes [built]
+    ./index.js 24 bytes [built] [code generated]
 Child
     Hash: b5147bffa61d4b3a9228
     Time: X ms
     Built at: 1970-04-20 12:42:42
     asset 321.js 1.3 KiB [emitted] (name: main)
     Entrypoint main = 321.js
-    ./index.js 24 bytes [built]
+    ./index.js 24 bytes [built] [code generated]
 Child
     Hash: 40b14025738b0f86d581
     Time: X ms
     Built at: 1970-04-20 12:42:42
     asset both.js 1.3 KiB [emitted] (name: main)
     Entrypoint main = both.js
-    ./index.js 24 bytes [built]"
+    ./index.js 24 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for dll-reference-plugin-issue-7624 1`] = `
@@ -780,7 +812,7 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 asset bundle.js 83 bytes [emitted] (name: main)
 Entrypoint main = bundle.js
-./entry.js 29 bytes [built]"
+./entry.js 29 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for dll-reference-plugin-issue-7624-error 1`] = `
@@ -789,7 +821,7 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 assets by status 83 bytes [cached] 1 asset
 Entrypoint main = bundle.js
-./entry.js 29 bytes [built]
+./entry.js 29 bytes [built] [code generated]
 
 ERROR in Dll manifest ./blank-manifest.json
 Unexpected end of JSON input while parsing near ''
@@ -806,29 +838,31 @@ asset c.js 1.3 KiB [emitted] (name: b)
 Entrypoint a = a.js
 Entrypoint b = c.js
 chunk (runtime: b) c.js (b) 22 bytes [entry] [rendered]
-    > ./b.js b
- ./b.js 22 bytes [built]
-     cjs self exports reference ./b.js 1:0-14
-     entry ./b.js b
-     X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+  > ./b.js b
+  ./b.js 22 bytes [built] [code generated]
+    cjs self exports reference ./b.js 1:0-14
+    entry ./b.js b
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
 chunk (runtime: a) a.js (a) 22 bytes [entry] [rendered]
-    > ./a.js a
- ./a.js 22 bytes [built]
-     cjs self exports reference ./a.js 1:0-14
-     entry ./a.js a
-     X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)"
+  > ./a.js a
+  ./a.js 22 bytes [built] [code generated]
+    cjs self exports reference ./a.js 1:0-14
+    entry ./a.js a
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)"
 `;
 
 exports[`StatsTestCases should print correct stats for exclude-with-loader 1`] = `
 "Hash: 0f9eb63e65113c4a3960
 Time: X ms
 Built at: 1970-04-20 12:42:42
-excluded assets 34 bytes 1 asset
+hidden assets 34 bytes 1 asset
 asset bundle.js 3.73 KiB [emitted] (name: main)
 Entrypoint main = bundle.js (89245aae14d2d745f85a29195aa6ffc1.json)
-./index.js 77 bytes [built]
-./a.txt 42 bytes [built]
-    + 6 hidden modules"
+runtime modules 695 bytes 4 modules
+hidden modules 123 bytes 2 modules
+cacheable modules 119 bytes
+  ./index.js 77 bytes [built] [code generated]
+  ./a.txt 42 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for external 1`] = `
@@ -837,101 +871,105 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 asset main.js 1.2 KiB [emitted] (name: main)
 Entrypoint main = main.js
-./index.js 17 bytes [built]
-external \\"test\\" 42 bytes [built]"
+./index.js 17 bytes [built] [code generated]
+external \\"test\\" 42 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for graph-correctness-entries 1`] = `
 "Entrypoint e1 = e1.js
 Entrypoint e2 = e2.js
 chunk (runtime: e1, e2) b.js (b) 49 bytes <{786}> >{459}< [rendered]
- ./module-b.js 49 bytes [built]
-     import() ./module-b ./module-a.js 1:0-47
+  ./module-b.js 49 bytes [built] [code generated]
+    import() ./module-b ./module-a.js 1:0-47
 chunk (runtime: e1) e1.js (e1) 49 bytes (javascript) 6.1 KiB (runtime) >{786}< [entry] [rendered]
- ./e1.js 49 bytes [built]
-     entry ./e1 e1
-     + 9 hidden chunk modules
+  runtime modules 6.1 KiB 9 modules
+  ./e1.js 49 bytes [built] [code generated]
+    entry ./e1 e1
 chunk (runtime: e1, e2) c.js (c) 49 bytes <{128}> <{621}> >{786}< [rendered]
- ./module-c.js 49 bytes [built]
-     import() ./module-c ./e2.js 1:0-47
-     import() ./module-c ./module-b.js 1:0-47
+  ./module-c.js 49 bytes [built] [code generated]
+    import() ./module-c ./e2.js 1:0-47
+    import() ./module-c ./module-b.js 1:0-47
 chunk (runtime: e2) e2.js (e2) 49 bytes (javascript) 6.1 KiB (runtime) >{459}< [entry] [rendered]
- ./e2.js 49 bytes [built]
-     entry ./e2 e2
-     + 9 hidden chunk modules
+  runtime modules 6.1 KiB 9 modules
+  ./e2.js 49 bytes [built] [code generated]
+    entry ./e2 e2
 chunk (runtime: e1, e2) a.js (a) 49 bytes <{257}> <{459}> >{128}< [rendered]
- ./module-a.js 49 bytes [built]
-     import() ./module-a ./e1.js 1:0-47
-     import() ./module-a ./module-c.js 1:0-47"
+  ./module-a.js 49 bytes [built] [code generated]
+    import() ./module-a ./e1.js 1:0-47
+    import() ./module-a ./module-c.js 1:0-47"
 `;
 
 exports[`StatsTestCases should print correct stats for graph-correctness-modules 1`] = `
 "Entrypoint e1 = e1.js
 Entrypoint e2 = e2.js
 chunk (runtime: e1, e2) b.js (b) 179 bytes <{786}> >{459}< [rendered]
- ./module-b.js 179 bytes [built]
-     import() ./module-b ./module-a.js 1:0-47
+  ./module-b.js 179 bytes [built] [code generated]
+    import() ./module-b ./module-a.js 1:0-47
 chunk (runtime: e1) e1.js (e1) 119 bytes (javascript) 6.37 KiB (runtime) >{786}< >{892}< [entry] [rendered]
- ./e1.js 70 bytes [built]
-     entry ./e1 e1
- ./module-x.js 49 bytes [built]
-     harmony side effect evaluation ./module-x ./e1.js 1:0-20
-     harmony side effect evaluation ./module-x ./e2.js 1:0-20
-     import() ./module-x ./module-b.js 2:0-20
-     + 10 hidden chunk modules
+  runtime modules 6.37 KiB 10 modules
+  cacheable modules 119 bytes
+    ./e1.js 70 bytes [built] [code generated]
+      entry ./e1 e1
+    ./module-x.js 49 bytes [dependent] [built] [code generated]
+      harmony side effect evaluation ./module-x ./e1.js 1:0-20
+      harmony side effect evaluation ./module-x ./e2.js 1:0-20
+      import() ./module-x ./module-b.js 2:0-20
 chunk (runtime: e1, e2) c.js (c) 49 bytes <{128}> <{621}> >{786}< [rendered]
- ./module-c.js 49 bytes [built]
-     import() ./module-c ./e2.js 2:0-47
-     import() ./module-c ./module-b.js 1:0-47
+  ./module-c.js 49 bytes [built] [code generated]
+    import() ./module-c ./e2.js 2:0-47
+    import() ./module-c ./module-b.js 1:0-47
 chunk (runtime: e2) e2.js (e2) 119 bytes (javascript) 6.37 KiB (runtime) >{459}< >{892}< [entry] [rendered]
- ./e2.js 70 bytes [built]
-     entry ./e2 e2
- ./module-x.js 49 bytes [built]
-     harmony side effect evaluation ./module-x ./e1.js 1:0-20
-     harmony side effect evaluation ./module-x ./e2.js 1:0-20
-     import() ./module-x ./module-b.js 2:0-20
-     + 10 hidden chunk modules
+  runtime modules 6.37 KiB 10 modules
+  cacheable modules 119 bytes
+    ./e2.js 70 bytes [built] [code generated]
+      entry ./e2 e2
+    ./module-x.js 49 bytes [dependent] [built] [code generated]
+      harmony side effect evaluation ./module-x ./e1.js 1:0-20
+      harmony side effect evaluation ./module-x ./e2.js 1:0-20
+      import() ./module-x ./module-b.js 2:0-20
 chunk (runtime: e1, e2) a.js (a) 49 bytes <{257}> <{459}> >{128}< [rendered]
- ./module-a.js 49 bytes [built]
-     import() ./module-a ./e1.js 2:0-47
-     import() ./module-a ./module-c.js 1:0-47
+  ./module-a.js 49 bytes [built] [code generated]
+    import() ./module-a ./e1.js 2:0-47
+    import() ./module-a ./module-c.js 1:0-47
 chunk (runtime: e1, e2) y.js (y) 1 bytes <{257}> <{621}> [rendered]
- ./module-y.js 1 bytes [built]
-     import() ./module-y ./module-x.js 1:0-47"
+  ./module-y.js 1 bytes [built] [code generated]
+    import() ./module-y ./module-x.js 1:0-47"
 `;
 
 exports[`StatsTestCases should print correct stats for graph-roots 1`] = `
 "chunk cycle.js (cycle) 60 bytes [rendered]
- ./cycle/a.js 14 bytes [built]
- ./cycle/b.js 14 bytes [built]
- ./cycle/c.js 18 bytes [built]
- ./cycle/index.js 14 bytes [built]
+  ./cycle/a.js 14 bytes [built] [code generated]
+  ./cycle/b.js 14 bytes [built] [code generated]
+  ./cycle/c.js 18 bytes [built] [code generated]
+  ./cycle/index.js 14 bytes [built] [code generated]
 chunk cycle2.js (cycle2) 78 bytes [rendered]
- ./cycle2/index.js 14 bytes [built]
-     + 3 hidden dependent modules
+  dependent modules 64 bytes [dependent] 3 modules
+  ./cycle2/index.js 14 bytes [built] [code generated]
 chunk cycles.js (cycles) 156 bytes [rendered]
- ./cycles/1/index.js 14 bytes [built]
- ./cycles/2/index.js 14 bytes [built]
-     + 6 hidden dependent modules
+  dependent modules 128 bytes [dependent] 6 modules
+  javascript modules 28 bytes
+    ./cycles/1/index.js 14 bytes [built] [code generated]
+    ./cycles/2/index.js 14 bytes [built] [code generated]
 chunk id-equals-name_js.js (id-equals-name_js) 1 bytes [rendered]
- ./id-equals-name.js?1 1 bytes [built]
+  ./id-equals-name.js?1 1 bytes [built] [code generated]
 chunk id-equals-name_js-_70e2.js (id-equals-name_js-_70e2) 1 bytes [rendered]
- ./id-equals-name.js?2 1 bytes [built]
+  ./id-equals-name.js?2 1 bytes [built] [code generated]
 chunk id-equals-name_js0.js 1 bytes [rendered]
- ./id-equals-name.js 1 bytes [built]
+  ./id-equals-name.js 1 bytes [built] [code generated]
 chunk id-equals-name_js_3.js 1 bytes [rendered]
- ./id-equals-name.js?3 1 bytes [built]
+  ./id-equals-name.js?3 1 bytes [built] [code generated]
 chunk main.js (main) 639 bytes (javascript) 6.33 KiB (runtime) [entry] [rendered]
- ./index.js 639 bytes [built]
-     + 10 hidden root modules
+  runtime modules 6.33 KiB 10 modules
+  ./index.js 639 bytes [built] [code generated]
 chunk tree.js (tree) 43 bytes [rendered]
- ./tree/index.js 14 bytes [built]
-     + 3 hidden dependent modules
+  dependent modules 29 bytes [dependent] 3 modules
+  ./tree/index.js 14 bytes [built] [code generated]
 chunk trees.js (trees) 71 bytes [rendered]
- ./trees/1.js 14 bytes [built]
- ./trees/2.js 14 bytes [built]
- ./trees/3.js 14 bytes [built]
-     + 3 hidden dependent modules"
+  dependent modules 29 bytes [dependent] 3 modules
+  javascript modules 42 bytes
+    ./trees/1.js 14 bytes [built] [code generated]
+    ./trees/2.js 14 bytes [built] [code generated]
+    ./trees/3.js 14 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for immutable 1`] = `
@@ -948,12 +986,14 @@ asset 544.js 480 bytes [emitted]
 asset 718.js 480 bytes [emitted]
 asset entry.js 10.3 KiB [emitted] (name: entry)
 Entrypoint entry = entry.js
-./entry.js 450 bytes [built]
-./templates lazy ^\\\\.\\\\/.*$ include: \\\\.js$ exclude: \\\\.noimport\\\\.js$ namespace object 160 bytes [optional] [built]
-./templates/bar.js 38 bytes [optional] [built]
-./templates/baz.js 38 bytes [optional] [built]
-./templates/foo.js 38 bytes [optional] [built]
-    + 8 hidden modules"
+runtime modules 5.4 KiB 8 modules
+built modules 724 bytes [built]
+  modules by path ./templates/*.js 114 bytes
+    ./templates/bar.js 38 bytes [optional] [built] [code generated]
+    ./templates/baz.js 38 bytes [optional] [built] [code generated]
+    ./templates/foo.js 38 bytes [optional] [built] [code generated]
+  ./entry.js 450 bytes [built] [code generated]
+  ./templates/ lazy ^\\\\.\\\\/.*$ include: \\\\.js$ exclude: \\\\.noimport\\\\.js$ namespace object 160 bytes [optional] [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for import-weak 1`] = `
@@ -963,20 +1003,23 @@ Built at: 1970-04-20 12:42:42
 asset 836.js 138 bytes [emitted]
 asset entry.js 10.9 KiB [emitted] (name: entry)
 Entrypoint entry = entry.js
-./entry.js 120 bytes [built]
-./modules/b.js 22 bytes [built]
-    + 10 hidden modules"
+runtime modules 6.07 KiB 9 modules
+orphan modules 37 bytes [orphan] 1 module
+cacheable modules 142 bytes
+  ./entry.js 120 bytes [built] [code generated]
+  ./modules/b.js 22 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for import-with-invalid-options-comments 1`] = `
 "Built at: 1970-04-20 12:42:42
-./index.js 50 bytes [built]
-./chunk.js 401 bytes [built] [3 warnings]
-./chunk-a.js 27 bytes [built]
-./chunk-b.js 27 bytes [built]
-./chunk-c.js 27 bytes [built]
-./chunk-d.js 27 bytes [built]
-    + 11 hidden modules
+runtime modules 7.05 KiB 11 modules
+cacheable modules 559 bytes
+  ./index.js 50 bytes [built] [code generated]
+  ./chunk.js 401 bytes [built] [code generated] [3 warnings]
+  ./chunk-a.js 27 bytes [built] [code generated]
+  ./chunk-b.js 27 bytes [built] [code generated]
+  ./chunk-c.js 27 bytes [built] [code generated]
+  ./chunk-d.js 27 bytes [built] [code generated]
 
 WARNING in ./chunk.js 2:11-84
 Compilation error while processing magic comment(-s): /* webpackPrefetch: true, webpackChunkName: notGoingToCompileChunkName */: notGoingToCompileChunkName is not defined
@@ -1002,8 +1045,8 @@ Child
     asset a-main-b1eee3373fffb0185d2b.js 114 bytes [emitted] [immutable] (name: main)
     asset a-runtime~main-1c25d32f5799aad03d03.js 5.1 KiB [emitted] [immutable] (name: runtime~main)
     Entrypoint main = a-runtime~main-1c25d32f5799aad03d03.js a-all-a_js-d34afd21aa7977571016.js a-main-b1eee3373fffb0185d2b.js
-    ./a.js 18 bytes [built]
-        + 2 hidden modules
+    runtime modules 2.58 KiB 2 modules
+    ./a.js 18 bytes [built] [code generated]
 Child
     Hash: ef3ef6c48a5e636a1d92
     Time: X ms
@@ -1013,24 +1056,26 @@ Child
     asset b-runtime~main-599255de31b112c7d98b.js 6.04 KiB [emitted] [immutable] (name: runtime~main)
     asset b-vendors-node_modules_vendor_js-93fc2ac2d261c82b4448.js 185 bytes [emitted] [immutable] (id hint: vendors)
     Entrypoint main = b-runtime~main-599255de31b112c7d98b.js b-vendors-node_modules_vendor_js-93fc2ac2d261c82b4448.js b-all-b_js-2c51416a14123ef7c0b7.js b-main-0780253982d2b99627d2.js
-    ./b.js 17 bytes [built]
-    ./node_modules/vendor.js 23 bytes [built]
-        + 4 hidden modules
+    runtime modules 3.14 KiB 4 modules
+    cacheable modules 40 bytes
+      ./b.js 17 bytes [built] [code generated]
+      ./node_modules/vendor.js 23 bytes [built] [code generated]
 Child
     Hash: 79ce0ce957b373f01199
     Time: X ms
     Built at: 1970-04-20 12:42:42
     assets by chunk 895 bytes (id hint: all)
-      asset c-all-c_js-3f22b3dd1aa1ecb5f45e.js 393 bytes [emitted] [immutable] (id hint: all)
       asset c-all-b_js-5d2ee8f74cbe1c7c24e8.js 502 bytes [emitted] [immutable] (id hint: all)
+      asset c-all-c_js-3f22b3dd1aa1ecb5f45e.js 393 bytes [emitted] [immutable] (id hint: all)
     asset c-main-3737497cd09f5bd99fe3.js 603 bytes [emitted] [immutable] (name: main)
     asset c-runtime~main-2769e1f5da93c44c8a70.js 12.4 KiB [emitted] [immutable] (name: runtime~main)
     asset c-vendors-node_modules_vendor_js-93fc2ac2d261c82b4448.js 185 bytes [emitted] [immutable] (id hint: vendors)
     Entrypoint main = c-runtime~main-2769e1f5da93c44c8a70.js c-all-c_js-3f22b3dd1aa1ecb5f45e.js c-main-3737497cd09f5bd99fe3.js (prefetch: c-vendors-node_modules_vendor_js-93fc2ac2d261c82b4448.js c-all-b_js-5d2ee8f74cbe1c7c24e8.js)
-    ./c.js 61 bytes [built]
-    ./b.js 17 bytes [built]
-    ./node_modules/vendor.js 23 bytes [built]
-        + 11 hidden modules"
+    runtime modules 7.78 KiB 11 modules
+    cacheable modules 101 bytes
+      ./c.js 61 bytes [built] [code generated]
+      ./b.js 17 bytes [built] [code generated]
+      ./node_modules/vendor.js 23 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 1`] = `
@@ -1042,13 +1087,14 @@ Child 1 chunks:
     asset bundle1.js 4.14 KiB [emitted] (name: main)
     Entrypoint main = bundle1.js
     chunk (runtime: main) bundle1.js (main) 219 bytes (javascript) 1.32 KiB (runtime) <{179}> >{179}< [entry] [rendered]
-     ./a.js 22 bytes [built]
-     ./b.js 22 bytes [built]
-     ./c.js 30 bytes [built]
-     ./d.js 22 bytes [built]
-     ./e.js 22 bytes [built]
-     ./index.js 101 bytes [built]
-         + 4 hidden chunk modules
+      runtime modules 1.32 KiB 4 modules
+      cacheable modules 219 bytes
+        ./a.js 22 bytes [dependent] [built] [code generated]
+        ./b.js 22 bytes [dependent] [built] [code generated]
+        ./c.js 30 bytes [dependent] [built] [code generated]
+        ./d.js 22 bytes [dependent] [built] [code generated]
+        ./e.js 22 bytes [dependent] [built] [code generated]
+        ./index.js 101 bytes [built] [code generated]
 Child 2 chunks:
     Hash: 141642683fbc5fd0c428
     Time: X ms
@@ -1057,14 +1103,15 @@ Child 2 chunks:
     asset bundle2.js 10.5 KiB [emitted] (name: main)
     Entrypoint main = bundle2.js
     chunk (runtime: main) bundle2.js (main) 101 bytes (javascript) 6.08 KiB (runtime) >{459}< [entry] [rendered]
-     ./index.js 101 bytes [built]
-         + 9 hidden chunk modules
+      runtime modules 6.08 KiB 9 modules
+      ./index.js 101 bytes [built] [code generated]
     chunk (runtime: main) 459.bundle2.js (c) 118 bytes <{179}> <{459}> >{459}< [rendered]
-     ./a.js 22 bytes [built]
-     ./b.js 22 bytes [built]
-     ./c.js 30 bytes [built]
-     ./d.js 22 bytes [built]
-     ./e.js 22 bytes [built]
+      dependent modules 44 bytes [dependent]
+        ./d.js 22 bytes [dependent] [built] [code generated]
+        ./e.js 22 bytes [dependent] [built] [code generated]
+      ./a.js 22 bytes [built] [code generated]
+      ./b.js 22 bytes [built] [code generated]
+      ./c.js 30 bytes [built] [code generated]
 Child 3 chunks:
     Hash: 06263c7fd9d674479b10
     Time: X ms
@@ -1074,15 +1121,15 @@ Child 3 chunks:
     asset bundle3.js 10.5 KiB [emitted] (name: main)
     Entrypoint main = bundle3.js
     chunk (runtime: main) bundle3.js (main) 101 bytes (javascript) 6.08 KiB (runtime) >{459}< [entry] [rendered]
-     ./index.js 101 bytes [built]
-         + 9 hidden chunk modules
+      runtime modules 6.08 KiB 9 modules
+      ./index.js 101 bytes [built] [code generated]
     chunk (runtime: main) 459.bundle3.js (c) 74 bytes <{179}> >{524}< [rendered]
-     ./a.js 22 bytes [built]
-     ./b.js 22 bytes [built]
-     ./c.js 30 bytes [built]
+      ./a.js 22 bytes [built] [code generated]
+      ./b.js 22 bytes [built] [code generated]
+      ./c.js 30 bytes [built] [code generated]
     chunk (runtime: main) 524.bundle3.js 44 bytes <{459}> [rendered]
-     ./d.js 22 bytes [built]
-     ./e.js 22 bytes [built]
+      ./d.js 22 bytes [built] [code generated]
+      ./e.js 22 bytes [built] [code generated]
 Child 4 chunks:
     Hash: a0b5126c1681bf9f7900
     Time: X ms
@@ -1093,16 +1140,16 @@ Child 4 chunks:
     asset bundle4.js 10.5 KiB [emitted] (name: main)
     Entrypoint main = bundle4.js
     chunk (runtime: main) bundle4.js (main) 101 bytes (javascript) 6.08 KiB (runtime) >{394}< >{459}< [entry] [rendered]
-     ./index.js 101 bytes [built]
-         + 9 hidden chunk modules
+      runtime modules 6.08 KiB 9 modules
+      ./index.js 101 bytes [built] [code generated]
     chunk (runtime: main) 394.bundle4.js 44 bytes <{179}> [rendered]
-     ./a.js 22 bytes [built]
-     ./b.js 22 bytes [built]
+      ./a.js 22 bytes [built] [code generated]
+      ./b.js 22 bytes [built] [code generated]
     chunk (runtime: main) 459.bundle4.js (c) 30 bytes <{179}> >{524}< [rendered]
-     ./c.js 30 bytes [built]
+      ./c.js 30 bytes [built] [code generated]
     chunk (runtime: main) 524.bundle4.js 44 bytes <{459}> [rendered]
-     ./d.js 22 bytes [built]
-     ./e.js 22 bytes [built]"
+      ./d.js 22 bytes [built] [code generated]
+      ./e.js 22 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for logging 1`] = `
@@ -1112,7 +1159,7 @@ Time: <CLR=BOLD>X</CLR> ms
 Built at: 1970-04-20 <CLR=BOLD>12:42:42</CLR>
 asset <CLR=32,BOLD>main.js</CLR> 54 bytes <CLR=32,BOLD>[emitted]</CLR> (name: main)
 Entrypoint <CLR=BOLD>main</CLR> = <CLR=32,BOLD>main.js</CLR>
-<CLR=BOLD>./index.js</CLR> 1 bytes <CLR=32,BOLD>[built]</CLR>
+<CLR=BOLD>./index.js</CLR> 1 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
 
 <CLR=BOLD>LOG from LogTestPlugin</CLR>
 <-> <CLR=36,BOLD>Group</CLR>
@@ -1178,27 +1225,7 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 asset main.js 5.29 KiB [emitted] (name: main)
 Entrypoint main = main.js
-./index.js 181 bytes [built]
-./a.js?1 33 bytes [built]
-./a.js?2 33 bytes [built]
-./a.js?3 33 bytes [built]
-./a.js?4 33 bytes [built]
-./a.js?5 33 bytes [built]
-./a.js?6 33 bytes [built]
-./a.js?7 33 bytes [built]
-./a.js?8 33 bytes [built]
-./a.js?9 33 bytes [built]
-./a.js?10 33 bytes [built]
-./c.js?1 33 bytes [built]
-./c.js?2 33 bytes [built]
-./c.js?3 33 bytes [built]
-./c.js?4 33 bytes [built]
-./c.js?5 33 bytes [built]
-./c.js?6 33 bytes [built]
-./c.js?7 33 bytes [built]
-./c.js?8 33 bytes [built]
-./c.js?9 33 bytes [built]
-    + 11 hidden modules"
+31 modules"
 `;
 
 exports[`StatsTestCases should print correct stats for max-modules-default 1`] = `
@@ -1207,52 +1234,40 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 asset main.js 5.29 KiB [emitted] (name: main)
 Entrypoint main = main.js
-./index.js 181 bytes [built]
-./a.js?1 33 bytes [built]
-./a.js?2 33 bytes [built]
-./a.js?3 33 bytes [built]
-./a.js?4 33 bytes [built]
-./a.js?5 33 bytes [built]
-./a.js?6 33 bytes [built]
-./a.js?7 33 bytes [built]
-./a.js?8 33 bytes [built]
-./a.js?9 33 bytes [built]
-./a.js?10 33 bytes [built]
-./c.js?1 33 bytes [built]
-./c.js?2 33 bytes [built]
-./c.js?3 33 bytes [built]
-./c.js?4 33 bytes [built]
-    + 16 hidden modules"
+31 modules"
 `;
 
 exports[`StatsTestCases should print correct stats for module-assets 1`] = `
 "Hash: 7ef32e0d65af21479a68
 Time: X ms
 Built at: 1970-04-20 12:42:42
-assets by path ./*.js 10.2 KiB
-  asset main.js 8.92 KiB [emitted] (name: main)
+assets by path *.js 10.2 KiB
   asset a.js 749 bytes [emitted] (name: a)
   asset b.js 567 bytes [emitted] (name: b)
-assets by path ./*.png 42 KiB
+  asset main.js 8.92 KiB [emitted] (name: main)
+assets by path *.png 42 KiB
   asset 1.png 21 KiB [emitted] (auxiliary name: a)
   asset 2.png 21 KiB [emitted] (auxiliary name: a, b)
 Entrypoint main = main.js
 Chunk Group a = a.js (1.png 2.png)
 Chunk Group b = b.js (2.png)
 chunk (runtime: main) b.js (b) 67 bytes [rendered]
- ./node_modules/a/2.png 49 bytes [built] [1 asset]
- ./node_modules/b/index.js 18 bytes [built]
+  ./node_modules/a/2.png 49 bytes [dependent] [built] [code generated] [1 asset]
+  ./node_modules/b/index.js 18 bytes [built] [code generated]
 chunk (runtime: main) main.js (main) 82 bytes (javascript) 5.13 KiB (runtime) [entry] [rendered]
- ./index.js 82 bytes [built]
-     + 7 hidden chunk modules
+  runtime modules 5.13 KiB 7 modules
+  ./index.js 82 bytes [built] [code generated]
 chunk (runtime: main) a.js (a) 134 bytes [rendered]
- ./node_modules/a/2.png 49 bytes [built] [1 asset]
- ./node_modules/a/index.js + 1 modules 85 bytes [built] [1 asset]
-./index.js 82 bytes [built]
-./node_modules/a/index.js + 1 modules 85 bytes [built] [1 asset]
-./node_modules/b/index.js 18 bytes [built]
-./node_modules/a/2.png 49 bytes [built] [1 asset]
-    + 8 hidden modules"
+  ./node_modules/a/2.png 49 bytes [dependent] [built] [code generated] [1 asset]
+  ./node_modules/a/index.js + 1 modules 85 bytes [built] [code generated] [1 asset]
+runtime modules 5.13 KiB 7 modules
+orphan modules 49 bytes [orphan] 1 module
+modules with assets 234 bytes
+  modules by path ./node_modules/a/ 134 bytes
+    ./node_modules/a/index.js + 1 modules 85 bytes [built] [code generated] [1 asset]
+    ./node_modules/a/2.png 49 bytes [built] [code generated] [1 asset]
+  ./index.js 82 bytes [built] [code generated]
+  ./node_modules/b/index.js 18 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for module-deduplication 1`] = `
@@ -1269,41 +1284,44 @@ Entrypoint e1 = e1.js
 Entrypoint e2 = e2.js
 Entrypoint e3 = e3.js
 chunk (runtime: e1) 114.js 28 bytes [rendered]
- ./async1.js 28 bytes [built]
+  ./async1.js 28 bytes [built] [code generated]
 chunk (runtime: e3) e3.js (e3) 152 bytes (javascript) 5.66 KiB (runtime) [entry] [rendered]
- ./a.js 9 bytes [built]
- ./b.js 9 bytes [built]
- ./e3.js 116 bytes [built]
- ./g.js 9 bytes [built]
- ./h.js 9 bytes [built]
-     + 9 hidden chunk modules
+  runtime modules 5.66 KiB 9 modules
+  cacheable modules 152 bytes
+    ./a.js 9 bytes [dependent] [built] [code generated]
+    ./b.js 9 bytes [dependent] [built] [code generated]
+    ./e3.js 116 bytes [built] [code generated]
+    ./g.js 9 bytes [dependent] [built] [code generated]
+    ./h.js 9 bytes [dependent] [built] [code generated]
 chunk (runtime: e1, e3) 172.js 37 bytes [rendered]
- ./async2.js 28 bytes [built]
- ./f.js 9 bytes [built]
+  ./async2.js 28 bytes [built] [code generated]
+  ./f.js 9 bytes [dependent] [built] [code generated]
 chunk (runtime: e1) e1.js (e1) 152 bytes (javascript) 5.66 KiB (runtime) [entry] [rendered]
- ./a.js 9 bytes [built]
- ./b.js 9 bytes [built]
- ./c.js 9 bytes [built]
- ./d.js 9 bytes [built]
- ./e1.js 116 bytes [built]
-     + 9 hidden chunk modules
+  runtime modules 5.66 KiB 9 modules
+  cacheable modules 152 bytes
+    ./a.js 9 bytes [dependent] [built] [code generated]
+    ./b.js 9 bytes [dependent] [built] [code generated]
+    ./c.js 9 bytes [dependent] [built] [code generated]
+    ./d.js 9 bytes [dependent] [built] [code generated]
+    ./e1.js 116 bytes [built] [code generated]
 chunk (runtime: e1, e2) 326.js 37 bytes [rendered]
- ./async3.js 28 bytes [built]
- ./h.js 9 bytes [built]
+  ./async3.js 28 bytes [built] [code generated]
+  ./h.js 9 bytes [dependent] [built] [code generated]
 chunk (runtime: e3) 593.js 28 bytes [rendered]
- ./async3.js 28 bytes [built]
+  ./async3.js 28 bytes [built] [code generated]
 chunk (runtime: e2) e2.js (e2) 152 bytes (javascript) 5.66 KiB (runtime) [entry] [rendered]
- ./a.js 9 bytes [built]
- ./b.js 9 bytes [built]
- ./e.js 9 bytes [built]
- ./e2.js 116 bytes [built]
- ./f.js 9 bytes [built]
-     + 9 hidden chunk modules
+  runtime modules 5.66 KiB 9 modules
+  cacheable modules 152 bytes
+    ./a.js 9 bytes [dependent] [built] [code generated]
+    ./b.js 9 bytes [dependent] [built] [code generated]
+    ./e.js 9 bytes [dependent] [built] [code generated]
+    ./e2.js 116 bytes [built] [code generated]
+    ./f.js 9 bytes [dependent] [built] [code generated]
 chunk (runtime: e2) 716.js 28 bytes [rendered]
- ./async2.js 28 bytes [built]
+  ./async2.js 28 bytes [built] [code generated]
 chunk (runtime: e2, e3) 923.js 37 bytes [rendered]
- ./async1.js 28 bytes [built]
- ./d.js 9 bytes [built]"
+  ./async1.js 28 bytes [built] [code generated]
+  ./d.js 9 bytes [dependent] [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for module-deduplication-named 1`] = `
@@ -1317,35 +1335,38 @@ Entrypoint e1 = e1.js
 Entrypoint e2 = e2.js
 Entrypoint e3 = e3.js
 chunk (runtime: e3) e3.js (e3) 144 bytes (javascript) 5.71 KiB (runtime) [entry] [rendered]
- ./a.js 9 bytes [built]
- ./b.js 9 bytes [built]
- ./e3.js 108 bytes [built]
- ./g.js 9 bytes [built]
- ./h.js 9 bytes [built]
-     + 9 hidden chunk modules
+  runtime modules 5.71 KiB 9 modules
+  cacheable modules 144 bytes
+    ./a.js 9 bytes [dependent] [built] [code generated]
+    ./b.js 9 bytes [dependent] [built] [code generated]
+    ./e3.js 108 bytes [built] [code generated]
+    ./g.js 9 bytes [dependent] [built] [code generated]
+    ./h.js 9 bytes [dependent] [built] [code generated]
 chunk (runtime: e1) e1.js (e1) 144 bytes (javascript) 5.71 KiB (runtime) [entry] [rendered]
- ./a.js 9 bytes [built]
- ./b.js 9 bytes [built]
- ./c.js 9 bytes [built]
- ./d.js 9 bytes [built]
- ./e1.js 108 bytes [built]
-     + 9 hidden chunk modules
+  runtime modules 5.71 KiB 9 modules
+  cacheable modules 144 bytes
+    ./a.js 9 bytes [dependent] [built] [code generated]
+    ./b.js 9 bytes [dependent] [built] [code generated]
+    ./c.js 9 bytes [dependent] [built] [code generated]
+    ./d.js 9 bytes [dependent] [built] [code generated]
+    ./e1.js 108 bytes [built] [code generated]
 chunk (runtime: e1, e2, e3) async1.js (async1) 89 bytes [rendered]
- ./async1.js 80 bytes [built]
- ./d.js 9 bytes [built]
+  ./async1.js 80 bytes [built] [code generated]
+  ./d.js 9 bytes [dependent] [built] [code generated]
 chunk (runtime: e1, e2, e3) async3.js (async3) 89 bytes [rendered]
- ./async3.js 80 bytes [built]
- ./h.js 9 bytes [built]
+  ./async3.js 80 bytes [built] [code generated]
+  ./h.js 9 bytes [dependent] [built] [code generated]
 chunk (runtime: e2) e2.js (e2) 144 bytes (javascript) 5.71 KiB (runtime) [entry] [rendered]
- ./a.js 9 bytes [built]
- ./b.js 9 bytes [built]
- ./e.js 9 bytes [built]
- ./e2.js 108 bytes [built]
- ./f.js 9 bytes [built]
-     + 9 hidden chunk modules
+  runtime modules 5.71 KiB 9 modules
+  cacheable modules 144 bytes
+    ./a.js 9 bytes [dependent] [built] [code generated]
+    ./b.js 9 bytes [dependent] [built] [code generated]
+    ./e.js 9 bytes [dependent] [built] [code generated]
+    ./e2.js 108 bytes [built] [code generated]
+    ./f.js 9 bytes [dependent] [built] [code generated]
 chunk (runtime: e1, e2, e3) async2.js (async2) 89 bytes [rendered]
- ./async2.js 80 bytes [built]
- ./f.js 9 bytes [built]"
+  ./async2.js 80 bytes [built] [code generated]
+  ./f.js 9 bytes [dependent] [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for module-not-found-error 1`] = `
@@ -1379,12 +1400,13 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 asset main.js 1.32 KiB [emitted] (name: main)
 Entrypoint main = main.js
-./index.js + 2 modules 102 bytes [built]
+orphan modules 75 bytes [orphan] 2 modules
+cacheable modules 110 bytes
+  ./index.js + 2 modules 102 bytes [built] [code generated]
     entry ./index main
-./c.js 8 bytes [built]
+  ./c.js 8 bytes [built] [code generated]
     cjs require ./c ./index.js + 2 modules ./a.js 1:0-14
-    cjs require ./c ./index.js + 2 modules ./b.js 1:0-14
-    + 2 hidden modules"
+    cjs require ./c ./index.js + 2 modules ./b.js 1:0-14"
 `;
 
 exports[`StatsTestCases should print correct stats for module-trace-disabled-in-error 1`] = `
@@ -1392,10 +1414,10 @@ exports[`StatsTestCases should print correct stats for module-trace-disabled-in-
 Built at: 1970-04-20 12:42:42
 assets by status 1.83 KiB [cached] 1 asset
 Entrypoint main = main.js
-./index.js 19 bytes [built]
-./inner.js 53 bytes [built]
-./not-existing.js 26 bytes [built]
-./parse-error.js 27 bytes [built] [failed] [1 error]
+./index.js 19 bytes [built] [code generated]
+./inner.js 53 bytes [built] [code generated]
+./not-existing.js 26 bytes [built] [code generated]
+./parse-error.js 27 bytes [built] [code generated] [1 error]
 
 ERROR in ./not-existing.js 1:0-25
 Module not found: Error: Can't resolve 'does-not-exist' in 'Xdir/module-trace-disabled-in-error'
@@ -1416,10 +1438,10 @@ exports[`StatsTestCases should print correct stats for module-trace-enabled-in-e
 Built at: 1970-04-20 12:42:42
 assets by status 1.83 KiB [cached] 1 asset
 Entrypoint main = main.js
-./index.js 19 bytes [built]
-./inner.js 53 bytes [built]
-./not-existing.js 26 bytes [built]
-./parse-error.js 27 bytes [built] [failed] [1 error]
+./index.js 19 bytes [built] [code generated]
+./inner.js 53 bytes [built] [code generated]
+./not-existing.js 26 bytes [built] [code generated]
+./parse-error.js 27 bytes [built] [code generated] [1 error]
 
 ERROR in ./not-existing.js 1:0-25
 Module not found: Error: Can't resolve 'does-not-exist' in 'Xdir/module-trace-enabled-in-error'
@@ -1446,52 +1468,52 @@ exports[`StatsTestCases should print correct stats for named-chunk-groups 1`] = 
     Chunk Group async-b = a-52.js a-async-b.js
     Chunk Group async-c = a-vendors.js a-async-c.js
     chunk (runtime: main) a-52.js 133 bytes [rendered] split chunk (cache group: default)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-     ./shared.js 133 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      ./shared.js 133 bytes [built] [code generated]
     chunk (runtime: main) a-main.js (main) 146 bytes (javascript) 5.74 KiB (runtime) [entry] [rendered]
-        > ./ main
-     ./index.js 146 bytes [built]
-         + 9 hidden root modules
+      > ./ main
+      runtime modules 5.74 KiB 9 modules
+      ./index.js 146 bytes [built] [code generated]
     chunk (runtime: main) a-vendors.js (vendors) (id hint: vendors) 40 bytes [rendered] split chunk (cache group: vendors) (name: vendors)
-        > ./c ./index.js 3:0-47
-     ./node_modules/x.js 20 bytes [built]
-     ./node_modules/y.js 20 bytes [built]
+      > ./c ./index.js 3:0-47
+      ./node_modules/x.js 20 bytes [built] [code generated]
+      ./node_modules/y.js 20 bytes [built] [code generated]
     chunk (runtime: main) a-async-b.js (async-b) 175 bytes [rendered]
-        > ./b ./index.js 2:0-47
-     ./b.js 175 bytes [built]
+      > ./b ./index.js 2:0-47
+      ./b.js 175 bytes [built] [code generated]
     chunk (runtime: main) a-async-c.js (async-c) 45 bytes [rendered]
-        > ./c ./index.js 3:0-47
-     ./c.js 45 bytes [built]
+      > ./c ./index.js 3:0-47
+      ./c.js 45 bytes [built] [code generated]
     chunk (runtime: main) a-async-a.js (async-a) 175 bytes [rendered]
-        > ./a ./index.js 1:0-47
-     ./a.js 175 bytes [built]
+      > ./a ./index.js 1:0-47
+      ./a.js 175 bytes [built] [code generated]
 Child
     Entrypoint main = b-main.js
     Chunk Group async-a = b-52.js b-async-a.js
     Chunk Group async-b = b-52.js b-async-b.js
     Chunk Group async-c = b-vendors.js b-async-c.js
     chunk (runtime: main) b-52.js 133 bytes [rendered] split chunk (cache group: default)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-     ./shared.js 133 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      ./shared.js 133 bytes [built] [code generated]
     chunk (runtime: main) b-main.js (main) 146 bytes (javascript) 5.74 KiB (runtime) [entry] [rendered]
-        > ./ main
-     ./index.js 146 bytes [built]
-         + 9 hidden root modules
+      > ./ main
+      runtime modules 5.74 KiB 9 modules
+      ./index.js 146 bytes [built] [code generated]
     chunk (runtime: main) b-vendors.js (vendors) (id hint: vendors) 40 bytes [rendered] split chunk (cache group: vendors) (name: vendors)
-        > ./c ./index.js 3:0-47
-     ./node_modules/x.js 20 bytes [built]
-     ./node_modules/y.js 20 bytes [built]
+      > ./c ./index.js 3:0-47
+      ./node_modules/x.js 20 bytes [built] [code generated]
+      ./node_modules/y.js 20 bytes [built] [code generated]
     chunk (runtime: main) b-async-b.js (async-b) 175 bytes [rendered]
-        > ./b ./index.js 2:0-47
-     ./b.js 175 bytes [built]
+      > ./b ./index.js 2:0-47
+      ./b.js 175 bytes [built] [code generated]
     chunk (runtime: main) b-async-c.js (async-c) 45 bytes [rendered]
-        > ./c ./index.js 3:0-47
-     ./c.js 45 bytes [built]
+      > ./c ./index.js 3:0-47
+      ./c.js 45 bytes [built] [code generated]
     chunk (runtime: main) b-async-a.js (async-a) 175 bytes [rendered]
-        > ./a ./index.js 1:0-47
-     ./a.js 175 bytes [built]"
+      > ./a ./index.js 1:0-47
+      ./a.js 175 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for named-chunks-plugin 1`] = `
@@ -1501,11 +1523,12 @@ Built at: 1970-04-20 12:42:42
 asset entry.js 5.42 KiB [emitted] (name: entry)
 asset vendor.js 237 bytes [emitted] (name: vendor) (id hint: vendor)
 Entrypoint entry = vendor.js entry.js
-./entry.js 72 bytes [built]
-./modules/a.js 22 bytes [built]
-./modules/b.js 22 bytes [built]
-./modules/c.js 22 bytes [built]
-    + 2 hidden modules"
+runtime modules 2.6 KiB 2 modules
+cacheable modules 138 bytes
+  ./entry.js 72 bytes [built] [code generated]
+  ./modules/a.js 22 bytes [built] [code generated]
+  ./modules/b.js 22 bytes [built] [code generated]
+  ./modules/c.js 22 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for named-chunks-plugin-async 1`] = `
@@ -1516,10 +1539,11 @@ asset entry.js 10.4 KiB [emitted] (name: entry)
 asset modules_a_js.js 312 bytes [emitted]
 asset modules_b_js.js 149 bytes [emitted]
 Entrypoint entry = entry.js
-./entry.js 47 bytes [built]
-./modules/a.js 37 bytes [built]
-./modules/b.js 22 bytes [built]
-    + 9 hidden modules"
+runtime modules 6.07 KiB 9 modules
+cacheable modules 106 bytes
+  ./entry.js 47 bytes [built] [code generated]
+  ./modules/a.js 37 bytes [built] [code generated]
+  ./modules/b.js 22 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for no-emit-on-errors-plugin-with-child-error 1`] = `
@@ -1528,7 +1552,7 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 assets by status 108 bytes [cached] 2 assets
 Entrypoint main = bundle.js
-./index.js 1 bytes [built]
+./index.js 1 bytes [built] [code generated]
 
 WARNING in configuration
 The 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
@@ -1550,46 +1574,47 @@ asset cir2.js 330 bytes {289} [emitted] (name: cir2)
 asset main.js 9.41 KiB {179} [emitted] (name: main)
 Entrypoint main = main.js
 chunk {90} (runtime: main) ab.js (ab) 2 bytes <{179}> >{753}< [rendered]
-    > [10] ./index.js 1:0-6:8
- [839] ./modules/a.js 1 bytes {90} {374} [built]
- [836] ./modules/b.js 1 bytes {90} {374} [built]
+  > [10] ./index.js 1:0-6:8
+  ./modules/a.js [839] 1 bytes {90} {374} [built] [code generated]
+  ./modules/b.js [836] 1 bytes {90} {374} [built] [code generated]
 chunk {179} (runtime: main) main.js (main) 524 bytes (javascript) 4.94 KiB (runtime) >{90}< >{289}< >{374}< >{592}< [entry] [rendered]
-    > ./index main
-  [10] ./index.js 523 bytes {179} [built]
- [544] ./modules/f.js 1 bytes {179} [built]
-     + 6 hidden chunk modules
+  > ./index main
+  runtime modules 4.94 KiB 6 modules
+  cacheable modules 524 bytes
+    ./index.js [10] 523 bytes {179} [built] [code generated]
+    ./modules/f.js [544] 1 bytes {179} [dependent] [built] [code generated]
 chunk {284} (runtime: main) chunk.js (chunk) 2 bytes <{374}> <{753}> [rendered]
-    > [10] ./index.js 3:2-4:13
-    > [10] ./index.js 9:1-10:12
- [115] ./modules/c.js 1 bytes {284} {753} [built]
- [928] ./modules/d.js 1 bytes {284} {374} [built]
+  > [10] ./index.js 3:2-4:13
+  > [10] ./index.js 9:1-10:12
+  ./modules/c.js [115] 1 bytes {284} {753} [built] [code generated]
+  ./modules/d.js [928] 1 bytes {284} {374} [built] [code generated]
 chunk {288} (runtime: main) cir2 from cir1.js (cir2 from cir1) 82 bytes <{592}> [rendered]
-    > [655] ./circular1.js 1:0-79
- [193] ./circular2.js 81 bytes {288} {289} [built]
- [798] ./modules/e.js 1 bytes {288} [built]
+  > [655] ./circular1.js 1:0-79
+  ./circular2.js [193] 81 bytes {288} {289} [built] [code generated]
+  ./modules/e.js [798] 1 bytes {288} [built] [code generated]
 chunk {289} (runtime: main) cir2.js (cir2) 81 bytes <{179}> >{592}< [rendered]
-    > [10] ./index.js 14:0-54
- [193] ./circular2.js 81 bytes {288} {289} [built]
+  > [10] ./index.js 14:0-54
+  ./circular2.js [193] 81 bytes {288} {289} [built] [code generated]
 chunk {374} (runtime: main) abd.js (abd) 3 bytes <{179}> >{284}< [rendered]
-    > [10] ./index.js 8:0-11:9
- [839] ./modules/a.js 1 bytes {90} {374} [built]
- [836] ./modules/b.js 1 bytes {90} {374} [built]
- [928] ./modules/d.js 1 bytes {284} {374} [built]
+  > [10] ./index.js 8:0-11:9
+  ./modules/a.js [839] 1 bytes {90} {374} [built] [code generated]
+  ./modules/b.js [836] 1 bytes {90} {374} [built] [code generated]
+  ./modules/d.js [928] 1 bytes {284} {374} [built] [code generated]
 chunk {592} (runtime: main) cir1.js (cir1) 81 bytes <{179}> <{289}> >{288}< [rendered]
-    > [10] ./index.js 13:0-54
-    > [193] ./circular2.js 1:0-79
- [655] ./circular1.js 81 bytes {592} [built]
+  > [10] ./index.js 13:0-54
+  > [193] ./circular2.js 1:0-79
+  ./circular1.js [655] 81 bytes {592} [built] [code generated]
 chunk {753} (runtime: main) ac in ab.js (ac in ab) 1 bytes <{90}> >{284}< [rendered]
-    > [10] ./index.js 2:1-5:15
- [115] ./modules/c.js 1 bytes {284} {753} [built]"
+  > [10] ./index.js 2:1-5:15
+  ./modules/c.js [115] 1 bytes {284} {753} [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for parse-error 1`] = `
 "assets by status 1.53 KiB [cached] 1 asset
 Entrypoint main = main.js
-./index.js + 1 modules 30 bytes [built]
-./b.js 55 bytes [built] [failed] [1 error]
-    + 1 hidden module
+orphan modules 15 bytes [orphan] 1 module
+./index.js + 1 modules 30 bytes [built] [code generated]
+./b.js 55 bytes [built] [code generated] [1 error]
 
 ERROR in ./b.js 6:7
 Module parse failed: Unexpected token (6:7)
@@ -1612,7 +1637,7 @@ Child
     Built at: 1970-04-20 12:42:42
     asset warning.pro-web.js 294 KiB [emitted] [big] (name: main)
     Entrypoint main [big] = warning.pro-web.js
-    ./index.js 293 KiB [built]
+    ./index.js 293 KiB [built] [code generated]
 
     WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
     This can impact web performance.
@@ -1634,7 +1659,7 @@ Child
     Built at: 1970-04-20 12:42:42
     asset warning.pro-webworker.js 294 KiB [emitted] [big] (name: main)
     Entrypoint main [big] = warning.pro-webworker.js
-    ./index.js 293 KiB [built]
+    ./index.js 293 KiB [built] [code generated]
 
     WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
     This can impact web performance.
@@ -1656,35 +1681,35 @@ Child
     Built at: 1970-04-20 12:42:42
     asset no-warning.pro-node.js 294 KiB [emitted] (name: main)
     Entrypoint main = no-warning.pro-node.js
-    ./index.js 293 KiB [built]
+    ./index.js 293 KiB [built] [code generated]
 Child
     Hash: 85007824036ef06d33eb
     Time: X ms
     Built at: 1970-04-20 12:42:42
     asset no-warning.dev-web.js 1.72 MiB [emitted] (name: main)
     Entrypoint main = no-warning.dev-web.js
-    ./index.js 293 KiB [built]
+    ./index.js 293 KiB [built] [code generated]
 Child
     Hash: 85007824036ef06d33eb
     Time: X ms
     Built at: 1970-04-20 12:42:42
     asset no-warning.dev-node.js 1.72 MiB [emitted] (name: main)
     Entrypoint main = no-warning.dev-node.js
-    ./index.js 293 KiB [built]
+    ./index.js 293 KiB [built] [code generated]
 Child
     Hash: 85007824036ef06d33eb
     Time: X ms
     Built at: 1970-04-20 12:42:42
     asset no-warning.dev-web-with-limit-set.js 1.72 MiB [emitted] [big] (name: main)
     Entrypoint main [big] = no-warning.dev-web-with-limit-set.js
-    ./index.js 293 KiB [built]
+    ./index.js 293 KiB [built] [code generated]
 Child
     Hash: 3a80617b1b52264204bc
     Time: X ms
     Built at: 1970-04-20 12:42:42
     asset warning.pro-node-with-hints-set.js 294 KiB [emitted] [big] (name: main)
     Entrypoint main [big] = warning.pro-node-with-hints-set.js
-    ./index.js 293 KiB [built]
+    ./index.js 293 KiB [built] [code generated]
 
     WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
     This can impact web performance.
@@ -1710,13 +1735,14 @@ asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>main.js</CLR> 302 KiB <CLR=32,BOLD>[emitted]</CLR> (name: main)
 Entrypoint <CLR=BOLD>main</CLR> = <CLR=32,BOLD>main.js</CLR>
-<CLR=BOLD>./index.js</CLR> 52 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./a.js</CLR> 293 KiB <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./b.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./c.js</CLR> 54 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./d.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./e.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-    + 6 hidden modules"
+runtime modules 4.84 KiB 6 modules
+cacheable modules 293 KiB
+  <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./b.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./c.js</CLR> 54 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./d.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./e.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>"
 `;
 
 exports[`StatsTestCases should print correct stats for performance-error 1`] = `
@@ -1727,13 +1753,14 @@ asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>302 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main)
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> = <CLR=32,BOLD>main.js</CLR>
-<CLR=BOLD>./index.js</CLR> 52 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./a.js</CLR> 293 KiB <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./b.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./c.js</CLR> 54 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./d.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./e.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-    + 6 hidden modules
+runtime modules 4.84 KiB 6 modules
+cacheable modules 293 KiB
+  <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./b.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./c.js</CLR> 54 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./d.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./e.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
 
 <CLR=31,BOLD>ERROR</CLR> in <CLR=BOLD>asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
 This can impact web performance.
@@ -1755,12 +1782,12 @@ asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>294 KiB</CLR> <CLR=32,BOLD>[emitte
 asset <CLR=32,BOLD>sec.js</CLR> 1.36 KiB <CLR=32,BOLD>[emitted]</CLR> (name: sec)
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> = <CLR=32,BOLD>main.js</CLR>
 Entrypoint <CLR=BOLD>sec</CLR> = <CLR=32,BOLD>sec.js</CLR>
-<CLR=BOLD>./index.js</CLR> 32 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./index2.js</CLR> 48 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./a.js</CLR> 293 KiB <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./b.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./c.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./d.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
+<CLR=BOLD>./index.js</CLR> 32 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+<CLR=BOLD>./index2.js</CLR> 48 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+<CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+<CLR=BOLD>./b.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+<CLR=BOLD>./c.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+<CLR=BOLD>./d.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
 
 <CLR=33,BOLD>WARNING</CLR> in <CLR=BOLD>asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
 This can impact web performance.
@@ -1787,13 +1814,14 @@ asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>302 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main)
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> = <CLR=32,BOLD>main.js</CLR>
-<CLR=BOLD>./index.js</CLR> 52 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./a.js</CLR> 293 KiB <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./b.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./c.js</CLR> 54 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./d.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./e.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-    + 6 hidden modules"
+runtime modules 4.84 KiB 6 modules
+cacheable modules 293 KiB
+  <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./b.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./c.js</CLR> 54 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./d.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./e.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>"
 `;
 
 exports[`StatsTestCases should print correct stats for performance-oversize-limit-error 1`] = `
@@ -1803,9 +1831,9 @@ asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>294 KiB</CLR> <CLR=32,BOLD>[emitte
 asset <CLR=33,BOLD>sec.js</CLR> <CLR=33,BOLD>294 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: sec)
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> = <CLR=32,BOLD>main.js</CLR>
 Entrypoint <CLR=BOLD>sec</CLR> <CLR=33,BOLD>[big]</CLR> = <CLR=32,BOLD>sec.js</CLR>
-<CLR=BOLD>./index.js</CLR> 16 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./index2.js</CLR> 16 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./a.js</CLR> 293 KiB <CLR=32,BOLD>[built]</CLR>
+<CLR=BOLD>./index.js</CLR> 16 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+<CLR=BOLD>./index2.js</CLR> 16 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+<CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
 
 <CLR=31,BOLD>ERROR</CLR> in <CLR=BOLD>asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
 This can impact web performance.
@@ -1896,53 +1924,55 @@ asset 996.js 138 bytes {996} [emitted]
 asset main.js 8.61 KiB {179} [emitted] (name: main)
 Entrypoint main = main.js
 chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 4.84 KiB (runtime) >{460}< >{996}< [entry] [rendered]
-    > ./index main
+  > ./index main
 chunk {460} (runtime: main) 460.js 54 bytes <{179}> >{524}< [rendered]
-    > ./c [10] ./index.js 3:0-16
+  > ./c [10] ./index.js 3:0-16
 chunk {524} (runtime: main) 524.js 44 bytes <{460}> [rendered]
-    > [460] ./c.js 1:0-52
+  > [460] ./c.js 1:0-52
 chunk {996} (runtime: main) 996.js 22 bytes <{179}> [rendered]
-    > ./b [10] ./index.js 2:0-16
- [10] ./index.js 51 bytes {179} [depth 0] [built]
-      [no exports used]
-      ModuleConcatenation bailout: Module is not an ECMAScript module
-[847] ./a.js 22 bytes {179} [depth 1] [built]
-      [used exports unknown]
-      CommonJS bailout: module.exports is used directly at 1:0-14
-      ModuleConcatenation bailout: Module is not an ECMAScript module
-[996] ./b.js 22 bytes {996} [depth 1] [built]
-      [used exports unknown]
-      CommonJS bailout: module.exports is used directly at 1:0-14
-      ModuleConcatenation bailout: Module is not an ECMAScript module
-[460] ./c.js 54 bytes {460} [depth 1] [built]
-      [used exports unknown]
-      ModuleConcatenation bailout: Module is not an ECMAScript module
-[767] ./d.js 22 bytes {524} [depth 2] [built]
-      [used exports unknown]
-      CommonJS bailout: module.exports is used directly at 1:0-14
-      ModuleConcatenation bailout: Module is not an ECMAScript module
-[390] ./e.js 22 bytes {524} [depth 2] [built]
-      [used exports unknown]
-      CommonJS bailout: module.exports is used directly at 1:0-14
-      ModuleConcatenation bailout: Module is not an ECMAScript module
-webpack/runtime/ensure chunk 326 bytes {179} [runtime]
-      [no exports]
-      [used exports unknown]
-webpack/runtime/get javascript chunk filename 167 bytes {179} [runtime]
-      [no exports]
-      [used exports unknown]
-webpack/runtime/hasOwnProperty shorthand 86 bytes {179} [runtime]
-      [no exports]
-      [used exports unknown]
-webpack/runtime/jsonp chunk loading 2.89 KiB {179} [runtime]
-      [no exports]
-      [used exports unknown]
-webpack/runtime/load script 1.36 KiB {179} [runtime]
-      [no exports]
-      [used exports unknown]
-webpack/runtime/publicPath 27 bytes {179} [runtime]
-      [no exports]
-      [used exports unknown]
+  > ./b [10] ./index.js 2:0-16
+cacheable modules 193 bytes
+  ./index.js [10] 51 bytes {179} [depth 0] [built] [code generated]
+    [no exports used]
+    ModuleConcatenation bailout: Module is not an ECMAScript module
+  ./a.js [847] 22 bytes {179} [depth 1] [built] [code generated]
+    [used exports unknown]
+    CommonJS bailout: module.exports is used directly at 1:0-14
+    ModuleConcatenation bailout: Module is not an ECMAScript module
+  ./b.js [996] 22 bytes {996} [depth 1] [built] [code generated]
+    [used exports unknown]
+    CommonJS bailout: module.exports is used directly at 1:0-14
+    ModuleConcatenation bailout: Module is not an ECMAScript module
+  ./c.js [460] 54 bytes {460} [depth 1] [built] [code generated]
+    [used exports unknown]
+    ModuleConcatenation bailout: Module is not an ECMAScript module
+  ./d.js [767] 22 bytes {524} [depth 2] [built] [code generated]
+    [used exports unknown]
+    CommonJS bailout: module.exports is used directly at 1:0-14
+    ModuleConcatenation bailout: Module is not an ECMAScript module
+  ./e.js [390] 22 bytes {524} [depth 2] [built] [code generated]
+    [used exports unknown]
+    CommonJS bailout: module.exports is used directly at 1:0-14
+    ModuleConcatenation bailout: Module is not an ECMAScript module
+runtime modules 4.84 KiB
+  webpack/runtime/ensure chunk 326 bytes {179} [code generated]
+    [no exports]
+    [used exports unknown]
+  webpack/runtime/get javascript chunk filename 167 bytes {179} [code generated]
+    [no exports]
+    [used exports unknown]
+  webpack/runtime/hasOwnProperty shorthand 86 bytes {179} [code generated]
+    [no exports]
+    [used exports unknown]
+  webpack/runtime/jsonp chunk loading 2.89 KiB {179} [code generated]
+    [no exports]
+    [used exports unknown]
+  webpack/runtime/load script 1.36 KiB {179} [code generated]
+    [no exports]
+    [used exports unknown]
+  webpack/runtime/publicPath 27 bytes {179} [code generated]
+    [no exports]
+    [used exports unknown]
 
 LOG from LogTestPlugin
 <-> Group
@@ -2009,7 +2039,8 @@ LOG from LogTestPlugin
 exports[`StatsTestCases should print correct stats for preset-minimal 1`] = `
 "<e> [LogTestPlugin] Error
 <w> [LogTestPlugin] Warning
-   12 modules
+4 assets
+12 modules
 
 LOG from LogTestPlugin
 <e> Error
@@ -2018,14 +2049,18 @@ LOG from LogTestPlugin
 "
 `;
 
-exports[`StatsTestCases should print correct stats for preset-minimal-simple 1`] = `"   1 module"`;
+exports[`StatsTestCases should print correct stats for preset-minimal-simple 1`] = `
+"1 asset
+1 module"
+`;
 
 exports[`StatsTestCases should print correct stats for preset-mixed-array 1`] = `
 "Child minimal:
-       1 module
+    1 asset
+    1 module
 Child verbose:
     Entrypoint main = verbose.js
-    ./index.js 8 bytes [built]"
+    ./index.js 8 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-none 1`] = `
@@ -2051,13 +2086,14 @@ asset 524.js 206 bytes [emitted]
 asset 996.js 138 bytes [emitted]
 asset main.js 8.61 KiB [emitted] (name: main)
 Entrypoint main = main.js
-./index.js 51 bytes [built]
-./a.js 22 bytes [built]
-./b.js 22 bytes [built]
-./c.js 54 bytes [built]
-./d.js 22 bytes [built]
-./e.js 22 bytes [built]
-    + 6 hidden modules
+runtime modules 4.84 KiB 6 modules
+cacheable modules 193 bytes
+  ./index.js 51 bytes [built] [code generated]
+  ./a.js 22 bytes [built] [code generated]
+  ./b.js 22 bytes [built] [code generated]
+  ./c.js 54 bytes [built] [code generated]
+  ./d.js 22 bytes [built] [code generated]
+  ./e.js 22 bytes [built] [code generated]
 
 LOG from LogTestPlugin
 <e> Error
@@ -2075,13 +2111,14 @@ asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>302 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main)
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> = <CLR=32,BOLD>main.js</CLR>
-<CLR=BOLD>./index.js</CLR> 52 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./a.js</CLR> 293 KiB <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./b.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./c.js</CLR> 54 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./d.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./e.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-    + 6 hidden modules
+runtime modules 4.84 KiB 6 modules
+cacheable modules 293 KiB
+  <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./b.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./c.js</CLR> 54 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./d.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./e.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
 
 <CLR=33,BOLD>WARNING</CLR> in <CLR=BOLD>asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
 This can impact web performance.
@@ -2104,13 +2141,14 @@ asset <CLR=32,BOLD>524.js</CLR> 238 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related
 asset <CLR=32,BOLD>996.js</CLR> 170 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
 asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>302 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main) 1 related asset
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> = <CLR=32,BOLD>main.js</CLR> (<CLR=32,BOLD>main.js.map</CLR>)
-<CLR=BOLD>./index.js</CLR> 52 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./a.js</CLR> 293 KiB <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./b.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./c.js</CLR> 54 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./d.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-<CLR=BOLD>./e.js</CLR> 22 bytes <CLR=32,BOLD>[built]</CLR>
-    + 6 hidden modules
+runtime modules 4.84 KiB 6 modules
+cacheable modules 293 KiB
+  <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./b.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./c.js</CLR> 54 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./d.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
+  <CLR=BOLD>./e.js</CLR> 22 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
 
 <CLR=33,BOLD>WARNING</CLR> in <CLR=BOLD>asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
 This can impact web performance.
@@ -2147,69 +2185,76 @@ asset 996.js 138 bytes {996} [emitted]
 asset main.js 8.61 KiB {179} [emitted] (name: main)
 Entrypoint main = main.js
 chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 4.84 KiB (runtime) >{460}< >{996}< [entry] [rendered]
-    > ./index main
- [847] ./a.js 22 bytes {179} [depth 1] [built]
-       [used exports unknown]
-       CommonJS bailout: module.exports is used directly at 1:0-14
-       ModuleConcatenation bailout: Module is not an ECMAScript module
-       cjs self exports reference [847] ./a.js 1:0-14
-       cjs require ./a [10] ./index.js 1:0-14
-       X ms [10] -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
-  [10] ./index.js 51 bytes {179} [depth 0] [built]
-       [no exports used]
-       ModuleConcatenation bailout: Module is not an ECMAScript module
-       entry ./index main
-       X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
- webpack/runtime/ensure chunk 326 bytes {179} [runtime]
-       [no exports]
-       [used exports unknown]
- webpack/runtime/get javascript chunk filename 167 bytes {179} [runtime]
-       [no exports]
-       [used exports unknown]
- webpack/runtime/hasOwnProperty shorthand 86 bytes {179} [runtime]
-       [no exports]
-       [used exports unknown]
- webpack/runtime/jsonp chunk loading 2.89 KiB {179} [runtime]
-       [no exports]
-       [used exports unknown]
- webpack/runtime/load script 1.36 KiB {179} [runtime]
-       [no exports]
-       [used exports unknown]
- webpack/runtime/publicPath 27 bytes {179} [runtime]
-       [no exports]
-       [used exports unknown]
+  > ./index main
+  runtime modules 4.84 KiB
+    webpack/runtime/ensure chunk 326 bytes {179} [code generated]
+      [no exports]
+      [used exports unknown]
+    webpack/runtime/get javascript chunk filename 167 bytes {179} [code generated]
+      [no exports]
+      [used exports unknown]
+    webpack/runtime/hasOwnProperty shorthand 86 bytes {179} [code generated]
+      [no exports]
+      [used exports unknown]
+    webpack/runtime/jsonp chunk loading 2.89 KiB {179} [code generated]
+      [no exports]
+      [used exports unknown]
+    webpack/runtime/load script 1.36 KiB {179} [code generated]
+      [no exports]
+      [used exports unknown]
+    webpack/runtime/publicPath 27 bytes {179} [code generated]
+      [no exports]
+      [used exports unknown]
+  cacheable modules 73 bytes
+    ./a.js [847] 22 bytes {179} [depth 1] [dependent] [built] [code generated]
+      [used exports unknown]
+      CommonJS bailout: module.exports is used directly at 1:0-14
+      ModuleConcatenation bailout: Module is not an ECMAScript module
+      cjs self exports reference [847] ./a.js 1:0-14
+      cjs require ./a [10] ./index.js 1:0-14
+      X ms [10] ->
+      X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+    ./index.js [10] 51 bytes {179} [depth 0] [built] [code generated]
+      [no exports used]
+      ModuleConcatenation bailout: Module is not an ECMAScript module
+      entry ./index main
+      X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
 chunk {460} (runtime: main) 460.js 54 bytes <{179}> >{524}< [rendered]
-    > ./c [10] ./index.js 3:0-16
- [460] ./c.js 54 bytes {460} [depth 1] [built]
-       [used exports unknown]
-       ModuleConcatenation bailout: Module is not an ECMAScript module
-       amd require ./c [10] ./index.js 3:0-16
-       X ms [10] -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+  > ./c [10] ./index.js 3:0-16
+  ./c.js [460] 54 bytes {460} [depth 1] [built] [code generated]
+    [used exports unknown]
+    ModuleConcatenation bailout: Module is not an ECMAScript module
+    amd require ./c [10] ./index.js 3:0-16
+    X ms [10] ->
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
 chunk {524} (runtime: main) 524.js 44 bytes <{460}> [rendered]
-    > [460] ./c.js 1:0-52
- [767] ./d.js 22 bytes {524} [depth 2] [built]
-       [used exports unknown]
-       CommonJS bailout: module.exports is used directly at 1:0-14
-       ModuleConcatenation bailout: Module is not an ECMAScript module
-       require.ensure item ./d [460] ./c.js 1:0-52
-       cjs self exports reference [767] ./d.js 1:0-14
-       X ms [10] -> X ms [460] -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
- [390] ./e.js 22 bytes {524} [depth 2] [built]
-       [used exports unknown]
-       CommonJS bailout: module.exports is used directly at 1:0-14
-       ModuleConcatenation bailout: Module is not an ECMAScript module
-       require.ensure item ./e [460] ./c.js 1:0-52
-       cjs self exports reference [390] ./e.js 1:0-14
-       X ms [10] -> X ms [460] -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+  > [460] ./c.js 1:0-52
+  ./d.js [767] 22 bytes {524} [depth 2] [built] [code generated]
+    [used exports unknown]
+    CommonJS bailout: module.exports is used directly at 1:0-14
+    ModuleConcatenation bailout: Module is not an ECMAScript module
+    require.ensure item ./d [460] ./c.js 1:0-52
+    cjs self exports reference [767] ./d.js 1:0-14
+    X ms [10] -> X ms [460] ->
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+  ./e.js [390] 22 bytes {524} [depth 2] [built] [code generated]
+    [used exports unknown]
+    CommonJS bailout: module.exports is used directly at 1:0-14
+    ModuleConcatenation bailout: Module is not an ECMAScript module
+    require.ensure item ./e [460] ./c.js 1:0-52
+    cjs self exports reference [390] ./e.js 1:0-14
+    X ms [10] -> X ms [460] ->
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
 chunk {996} (runtime: main) 996.js 22 bytes <{179}> [rendered]
-    > ./b [10] ./index.js 2:0-16
- [996] ./b.js 22 bytes {996} [depth 1] [built]
-       [used exports unknown]
-       CommonJS bailout: module.exports is used directly at 1:0-14
-       ModuleConcatenation bailout: Module is not an ECMAScript module
-       cjs self exports reference [996] ./b.js 1:0-14
-       amd require ./b [10] ./index.js 2:0-16
-       X ms [10] -> X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+  > ./b [10] ./index.js 2:0-16
+  ./b.js [996] 22 bytes {996} [depth 1] [built] [code generated]
+    [used exports unknown]
+    CommonJS bailout: module.exports is used directly at 1:0-14
+    ModuleConcatenation bailout: Module is not an ECMAScript module
+    cjs self exports reference [996] ./b.js 1:0-14
+    amd require ./b [10] ./index.js 2:0-16
+    X ms [10] ->
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
 
 LOG from LogTestPlugin
 <-> Group
@@ -2326,166 +2371,180 @@ Child a-normal:
     Hash: dc13e801b7da230b06ce
     Time: X ms
     Built at: 1970-04-20 12:42:42
-    assets by path ./*.js 2.48 KiB
+    assets by path *.js 2.48 KiB
       asset 3cc8faad16137711c07e-3cc8fa.js 210 bytes [emitted] [immutable] [minimized] (name: main)
       asset 603191853c81e758567a-603191.js 2.09 KiB [emitted] [immutable] [minimized] (name: runtime~main)
       asset b6f77787a670e97d47b5-b6f777.js 193 bytes [emitted] [immutable] [minimized] (name: lazy)
     asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] (auxiliary name: main)
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] (auxiliary name: lazy)
     Entrypoint main = 603191853c81e758567a-603191.js 3cc8faad16137711c07e-3cc8fa.js (7382fad5b015914e0811.jpg)
-    ./a/index.js 150 bytes [built]
-    ./a/file.jpg 42 bytes (javascript) 5.89 KiB (asset) [built]
-    ./a/lazy.js + 1 modules 106 bytes [built]
-    ./a/file.png 42 bytes (javascript) 14.6 KiB (asset) [built]
-        + 8 hidden modules
+    runtime modules 6.32 KiB 7 modules
+    orphan modules 23 bytes [orphan] 1 module
+    cacheable modules 340 bytes (javascript) 20.4 KiB (asset)
+      javascript modules 256 bytes
+        ./a/index.js 150 bytes [built] [code generated]
+        ./a/lazy.js + 1 modules 106 bytes [built] [code generated]
+      asset modules 84 bytes (javascript) 20.4 KiB (asset)
+        ./a/file.jpg 42 bytes (javascript) 5.89 KiB (asset) [built] [code generated]
+        ./a/file.png 42 bytes (javascript) 14.6 KiB (asset) [built] [code generated]
 Child b-normal:
     Hash: 5782ba854a23a6c889d0
     Time: X ms
     Built at: 1970-04-20 12:42:42
-    assets by path ./*.js 2.48 KiB
+    assets by path *.js 2.48 KiB
       asset 3cc8faad16137711c07e-3cc8fa.js 210 bytes [emitted] [immutable] [minimized] (name: main)
       asset 724d7409f0fb4e0b3145-724d74.js 2.09 KiB [emitted] [immutable] [minimized] (name: runtime~main)
       asset b6f77787a670e97d47b5-b6f777.js 193 bytes [emitted] [immutable] [minimized] (name: lazy)
     asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] (auxiliary name: main)
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] (auxiliary name: lazy)
     Entrypoint main = 724d7409f0fb4e0b3145-724d74.js 3cc8faad16137711c07e-3cc8fa.js (7382fad5b015914e0811.jpg)
-    ./b/index.js 109 bytes [built]
-    ./b/file.jpg 42 bytes (javascript) 5.89 KiB (asset) [built]
-    ./b/lazy.js + 1 modules 102 bytes [built]
-    ./b/file.png 42 bytes (javascript) 14.6 KiB (asset) [built]
-        + 8 hidden modules
+    runtime modules 6.32 KiB 7 modules
+    orphan modules 19 bytes [orphan] 1 module
+    cacheable modules 295 bytes (javascript) 20.4 KiB (asset)
+      javascript modules 211 bytes
+        ./b/index.js 109 bytes [built] [code generated]
+        ./b/lazy.js + 1 modules 102 bytes [built] [code generated]
+      asset modules 84 bytes (javascript) 20.4 KiB (asset)
+        ./b/file.jpg 42 bytes (javascript) 5.89 KiB (asset) [built] [code generated]
+        ./b/file.png 42 bytes (javascript) 14.6 KiB (asset) [built] [code generated]
 Child a-source-map:
     Hash: dc13e801b7da230b06ce
     Time: X ms
     Built at: 1970-04-20 12:42:42
-    assets by path ./*.js 2.65 KiB
-      asset b8bfcec62cdd15c9a840-b8bfce.js 266 bytes [emitted] [immutable] [minimized] (name: main)
-        sourceMap b8bfcec62cdd15c9a840-b8bfce.js.map 366 bytes [emitted] [dev]
+    assets by path *.js 2.65 KiB
       asset 2d2b84d5cc58d8742e65-2d2b84.js 2.14 KiB [emitted] [immutable] [minimized] (name: runtime~main)
         sourceMap 2d2b84d5cc58d8742e65-2d2b84.js.map 12.6 KiB [emitted] [dev]
+      asset b8bfcec62cdd15c9a840-b8bfce.js 266 bytes [emitted] [immutable] [minimized] (name: main)
+        sourceMap b8bfcec62cdd15c9a840-b8bfce.js.map 366 bytes [emitted] [dev]
       asset c7c0f8bb2e61b59a89f5-c7c0f8.js 249 bytes [emitted] [immutable] [minimized] (name: lazy)
         sourceMap c7c0f8bb2e61b59a89f5-c7c0f8.js.map 331 bytes [emitted] [dev]
     asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] (auxiliary name: main)
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] (auxiliary name: lazy)
     Entrypoint main = 2d2b84d5cc58d8742e65-2d2b84.js b8bfcec62cdd15c9a840-b8bfce.js (608a3931b5c0c7b2c21f-608a39.js.map 7382fad5b015914e0811.jpg aff11f17e02d24be34cc-aff11f.js.map)
-    ./a/index.js 150 bytes [built]
-    ./a/file.jpg 42 bytes (javascript) 5.89 KiB (asset) [built]
-    ./a/lazy.js + 1 modules 106 bytes [built]
-    ./a/file.png 42 bytes (javascript) 14.6 KiB (asset) [built]
-        + 8 hidden modules
+    runtime modules 6.32 KiB 7 modules
+    orphan modules 23 bytes [orphan] 1 module
+    cacheable modules 340 bytes (javascript) 20.4 KiB (asset)
+      javascript modules 256 bytes
+        ./a/index.js 150 bytes [built] [code generated]
+        ./a/lazy.js + 1 modules 106 bytes [built] [code generated]
+      asset modules 84 bytes (javascript) 20.4 KiB (asset)
+        ./a/file.jpg 42 bytes (javascript) 5.89 KiB (asset) [built] [code generated]
+        ./a/file.png 42 bytes (javascript) 14.6 KiB (asset) [built] [code generated]
 Child b-source-map:
     Hash: 5782ba854a23a6c889d0
     Time: X ms
     Built at: 1970-04-20 12:42:42
-    assets by path ./*.js 2.65 KiB
+    assets by path *.js 2.65 KiB
       asset b8bfcec62cdd15c9a840-b8bfce.js 266 bytes [emitted] [immutable] [minimized] (name: main)
         sourceMap b8bfcec62cdd15c9a840-b8bfce.js.map 323 bytes [emitted] [dev]
-      asset ffe92bc2786746a99419-ffe92b.js 2.14 KiB [emitted] [immutable] [minimized] (name: runtime~main)
-        sourceMap ffe92bc2786746a99419-ffe92b.js.map 12.6 KiB [emitted] [dev]
       asset c7c0f8bb2e61b59a89f5-c7c0f8.js 249 bytes [emitted] [immutable] [minimized] (name: lazy)
         sourceMap c7c0f8bb2e61b59a89f5-c7c0f8.js.map 327 bytes [emitted] [dev]
+      asset ffe92bc2786746a99419-ffe92b.js 2.14 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+        sourceMap ffe92bc2786746a99419-ffe92b.js.map 12.6 KiB [emitted] [dev]
     asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] (auxiliary name: main)
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] (auxiliary name: lazy)
     Entrypoint main = ffe92bc2786746a99419-ffe92b.js b8bfcec62cdd15c9a840-b8bfce.js (342ff4b0850c24f24b15-342ff4.js.map 6625d7a5b3c0dfc493c6-6625d7.js.map 7382fad5b015914e0811.jpg)
-    ./b/index.js 109 bytes [built]
-    ./b/file.jpg 42 bytes (javascript) 5.89 KiB (asset) [built]
-    ./b/lazy.js + 1 modules 102 bytes [built]
-    ./b/file.png 42 bytes (javascript) 14.6 KiB (asset) [built]
-        + 8 hidden modules"
+    runtime modules 6.32 KiB 7 modules
+    orphan modules 19 bytes [orphan] 1 module
+    cacheable modules 295 bytes (javascript) 20.4 KiB (asset)
+      javascript modules 211 bytes
+        ./b/index.js 109 bytes [built] [code generated]
+        ./b/lazy.js + 1 modules 102 bytes [built] [code generated]
+      asset modules 84 bytes (javascript) 20.4 KiB (asset)
+        ./b/file.jpg 42 bytes (javascript) 5.89 KiB (asset) [built] [code generated]
+        ./b/file.png 42 bytes (javascript) 14.6 KiB (asset) [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for related-assets 1`] = `
 "Child default:
-    assets by path ./*.css 142 bytes
-      asset default-main.css 69 bytes [emitted] (name: main) 3 related assets
+    assets by path *.css 142 bytes
       asset default-chunk_js.css 73 bytes [emitted] 3 related assets
-    assets by path ./*.js 14.4 KiB
-      asset default-main.js 13.3 KiB [emitted] (name: main) 3 related assets
+      asset default-main.css 69 bytes [emitted] (name: main) 3 related assets
+    assets by path *.js 14.4 KiB
       asset default-chunk_js.js 1.11 KiB [emitted] 3 related assets
+      asset default-main.js 13.3 KiB [emitted] (name: main) 3 related assets
 Child relatedAssets:
-    assets by path ./*.css 154 bytes
-      asset relatedAssets-main.css 75 bytes [emitted] (name: main)
-        compressed relatedAssets-main.css.br 75 bytes [emitted]
-        compressed relatedAssets-main.css.gz 75 bytes [emitted]
-        sourceMap relatedAssets-main.css.map 187 bytes [emitted] [dev] (auxiliary name: main)
-          compressed relatedAssets-main.css.map.br 187 bytes [emitted]
-          compressed relatedAssets-main.css.map.gz 187 bytes [emitted]
+    assets by path *.css 154 bytes
       asset relatedAssets-chunk_js.css 79 bytes [emitted]
         compressed relatedAssets-chunk_js.css.br 79 bytes [emitted]
         compressed relatedAssets-chunk_js.css.gz 79 bytes [emitted]
         sourceMap relatedAssets-chunk_js.css.map 197 bytes [emitted] [dev]
           compressed relatedAssets-chunk_js.css.map.br 197 bytes [emitted]
           compressed relatedAssets-chunk_js.css.map.gz 197 bytes [emitted]
-    assets by path ./*.js 14.4 KiB
-      asset relatedAssets-main.js 13.3 KiB [emitted] (name: main)
-        compressed relatedAssets-main.js.br 13.3 KiB [emitted]
-        compressed relatedAssets-main.js.gz 13.3 KiB [emitted]
-        sourceMap relatedAssets-main.js.map 11.3 KiB [emitted] [dev] (auxiliary name: main)
-          compressed relatedAssets-main.js.map.br 11.3 KiB [emitted]
-          compressed relatedAssets-main.js.map.gz 11.3 KiB [emitted]
+      asset relatedAssets-main.css 75 bytes [emitted] (name: main)
+        compressed relatedAssets-main.css.br 75 bytes [emitted]
+        compressed relatedAssets-main.css.gz 75 bytes [emitted]
+        sourceMap relatedAssets-main.css.map 187 bytes [emitted] [dev] (auxiliary name: main)
+          compressed relatedAssets-main.css.map.br 187 bytes [emitted]
+          compressed relatedAssets-main.css.map.gz 187 bytes [emitted]
+    assets by path *.js 14.4 KiB
       asset relatedAssets-chunk_js.js 1.12 KiB [emitted]
         compressed relatedAssets-chunk_js.js.br 1.12 KiB [emitted]
         compressed relatedAssets-chunk_js.js.gz 1.12 KiB [emitted]
         sourceMap relatedAssets-chunk_js.js.map 295 bytes [emitted] [dev]
           compressed relatedAssets-chunk_js.js.map.br 295 bytes [emitted]
           compressed relatedAssets-chunk_js.js.map.gz 295 bytes [emitted]
+      asset relatedAssets-main.js 13.3 KiB [emitted] (name: main)
+        compressed relatedAssets-main.js.br 13.3 KiB [emitted]
+        compressed relatedAssets-main.js.gz 13.3 KiB [emitted]
+        sourceMap relatedAssets-main.js.map 11.3 KiB [emitted] [dev] (auxiliary name: main)
+          compressed relatedAssets-main.js.map.br 11.3 KiB [emitted]
+          compressed relatedAssets-main.js.map.gz 11.3 KiB [emitted]
 Child exclude1:
-    assets by path ./*.css 144 bytes
-      asset exclude1-main.css 70 bytes [emitted] (name: main)
-        sourceMap exclude1-main.css.map 182 bytes [emitted] [dev] (auxiliary name: main)
-          excluded assets 364 bytes 2 assets
-          1 related asset
-        excluded assets 140 bytes 2 assets
-        1 related asset
+    assets by path *.css 144 bytes
       asset exclude1-chunk_js.css 74 bytes [emitted]
+        hidden assets 148 bytes 2 assets
         sourceMap exclude1-chunk_js.css.map 192 bytes [emitted] [dev]
-          excluded assets 384 bytes 2 assets
+          hidden assets 384 bytes 2 assets
           1 related asset
-        excluded assets 148 bytes 2 assets
         1 related asset
-    assets by path ./*.js 14.4 KiB
-      asset exclude1-main.js 13.3 KiB [emitted] (name: main)
-        sourceMap exclude1-main.js.map 11.3 KiB [emitted] [dev] (auxiliary name: main)
-          excluded assets 22.7 KiB 2 assets
+      asset exclude1-main.css 70 bytes [emitted] (name: main)
+        hidden assets 140 bytes 2 assets
+        sourceMap exclude1-main.css.map 182 bytes [emitted] [dev] (auxiliary name: main)
+          hidden assets 364 bytes 2 assets
           1 related asset
-        excluded assets 26.6 KiB 2 assets
         1 related asset
+    assets by path *.js 14.4 KiB
       asset exclude1-chunk_js.js 1.11 KiB [emitted]
+        hidden assets 2.22 KiB 2 assets
         sourceMap exclude1-chunk_js.js.map 290 bytes [emitted] [dev]
-          excluded assets 580 bytes 2 assets
+          hidden assets 580 bytes 2 assets
           1 related asset
-        excluded assets 2.22 KiB 2 assets
+        1 related asset
+      asset exclude1-main.js 13.3 KiB [emitted] (name: main)
+        hidden assets 26.6 KiB 2 assets
+        sourceMap exclude1-main.js.map 11.3 KiB [emitted] [dev] (auxiliary name: main)
+          hidden assets 22.7 KiB 2 assets
+          1 related asset
         1 related asset
 Child exclude2:
-    assets by path ./*.css 144 bytes
-      asset exclude2-main.css 70 bytes [emitted] (name: main)
-        compressed exclude2-main.css.br 70 bytes [emitted]
-        compressed exclude2-main.css.gz 70 bytes [emitted]
-        excluded assets 182 bytes 1 asset
+    assets by path *.css 144 bytes
       asset exclude2-chunk_js.css 74 bytes [emitted]
+        hidden assets 192 bytes 1 asset
         compressed exclude2-chunk_js.css.br 74 bytes [emitted]
         compressed exclude2-chunk_js.css.gz 74 bytes [emitted]
-        excluded assets 192 bytes 1 asset
-    assets by path ./*.js 14.4 KiB
-      asset exclude2-main.js 13.3 KiB [emitted] (name: main)
-        compressed exclude2-main.js.br 13.3 KiB [emitted]
-        compressed exclude2-main.js.gz 13.3 KiB [emitted]
-        excluded assets 11.3 KiB 1 asset
+      asset exclude2-main.css 70 bytes [emitted] (name: main)
+        hidden assets 182 bytes 1 asset
+        compressed exclude2-main.css.br 70 bytes [emitted]
+        compressed exclude2-main.css.gz 70 bytes [emitted]
+    assets by path *.js 14.4 KiB
       asset exclude2-chunk_js.js 1.11 KiB [emitted]
+        hidden assets 290 bytes 1 asset
         compressed exclude2-chunk_js.js.br 1.11 KiB [emitted]
         compressed exclude2-chunk_js.js.gz 1.11 KiB [emitted]
-        excluded assets 290 bytes 1 asset
+      asset exclude2-main.js 13.3 KiB [emitted] (name: main)
+        hidden assets 11.3 KiB 1 asset
+        compressed exclude2-main.js.br 13.3 KiB [emitted]
+        compressed exclude2-main.js.gz 13.3 KiB [emitted]
 Child exclude3:
-    assets by path ./*.css 70 bytes
-      excluded assets 74 bytes 1 asset
+    hidden assets 1.18 KiB 2 assets
+    assets by status 13.3 KiB [emitted]
       asset exclude3-main.css 70 bytes [emitted] (name: main)
         compressed exclude3-main.css.br 70 bytes [emitted]
         compressed exclude3-main.css.gz 70 bytes [emitted]
         sourceMap exclude3-main.css.map 182 bytes [emitted] [dev] (auxiliary name: main)
           compressed exclude3-main.css.map.br 182 bytes [emitted]
           compressed exclude3-main.css.map.gz 182 bytes [emitted]
-    assets by path ./*.js 13.3 KiB
-      excluded assets 1.11 KiB 1 asset
       asset exclude3-main.js 13.3 KiB [emitted] (name: main)
         compressed exclude3-main.js.br 13.3 KiB [emitted]
         compressed exclude3-main.js.gz 13.3 KiB [emitted]
@@ -2500,11 +2559,12 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 asset bundle.js 1.5 KiB [emitted] (name: main)
 Entrypoint main = bundle.js
-./index.js 48 bytes [built]
-./node_modules/abc/index.js 16 bytes [built]
-./node_modules/xyz/index.js 1 bytes [built]
-./node_modules/def/index.js 16 bytes [built]
-./node_modules/def/node_modules/xyz/index.js 1 bytes [built]"
+modules by path ./node_modules/def/ 17 bytes
+  ./node_modules/def/index.js 16 bytes [built] [code generated]
+  ./node_modules/def/node_modules/xyz/index.js 1 bytes [built] [code generated]
+./index.js 48 bytes [built] [code generated]
+./node_modules/abc/index.js 16 bytes [built] [code generated]
+./node_modules/xyz/index.js 1 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for reverse-sort-modules 1`] = `
@@ -2513,27 +2573,37 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 asset main.js 5.29 KiB [emitted] (name: main)
 Entrypoint main = main.js
-./index.js 181 bytes [built]
-./a.js?1 33 bytes [built]
-./a.js?2 33 bytes [built]
-./a.js?3 33 bytes [built]
-./a.js?4 33 bytes [built]
-./a.js?5 33 bytes [built]
-./a.js?6 33 bytes [built]
-./a.js?7 33 bytes [built]
-./a.js?8 33 bytes [built]
-./a.js?9 33 bytes [built]
-./a.js?10 33 bytes [built]
-./c.js?1 33 bytes [built]
-./c.js?2 33 bytes [built]
-./c.js?3 33 bytes [built]
-./c.js?4 33 bytes [built]
-./c.js?5 33 bytes [built]
-./c.js?6 33 bytes [built]
-./c.js?7 33 bytes [built]
-./c.js?8 33 bytes [built]
-./c.js?9 33 bytes [built]
-    + 11 hidden modules"
+./index.js 181 bytes [built] [code generated]
+./c.js?9 33 bytes [built] [code generated]
+./c.js?8 33 bytes [built] [code generated]
+./c.js?7 33 bytes [built] [code generated]
+./c.js?6 33 bytes [built] [code generated]
+./c.js?5 33 bytes [built] [code generated]
+./c.js?4 33 bytes [built] [code generated]
+./c.js?3 33 bytes [built] [code generated]
+./c.js?2 33 bytes [built] [code generated]
+./c.js?10 33 bytes [built] [code generated]
+./c.js?1 33 bytes [built] [code generated]
+./b.js?9 34 bytes [built] [code generated]
+./b.js?8 34 bytes [built] [code generated]
+./b.js?7 34 bytes [built] [code generated]
+./b.js?6 34 bytes [built] [code generated]
+./b.js?5 34 bytes [built] [code generated]
+./b.js?4 34 bytes [built] [code generated]
+./b.js?3 34 bytes [built] [code generated]
+./b.js?2 34 bytes [built] [code generated]
+./b.js?10 34 bytes [built] [code generated]
+./b.js?1 34 bytes [built] [code generated]
+./a.js?9 33 bytes [built] [code generated]
+./a.js?8 33 bytes [built] [code generated]
+./a.js?7 33 bytes [built] [code generated]
+./a.js?6 33 bytes [built] [code generated]
+./a.js?5 33 bytes [built] [code generated]
+./a.js?4 33 bytes [built] [code generated]
+./a.js?3 33 bytes [built] [code generated]
+./a.js?2 33 bytes [built] [code generated]
+./a.js?10 33 bytes [built] [code generated]
+./a.js?1 33 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for runtime-chunk 1`] = `
@@ -2547,11 +2617,12 @@ exports[`StatsTestCases should print correct stats for runtime-chunk-integration
     asset without-main1.js 600 bytes [emitted] (name: main1)
     asset without-runtime.js 10.9 KiB [emitted] (name: runtime)
     Entrypoint main1 = without-runtime.js without-main1.js
-    ./main1.js 66 bytes [built]
-    ./b.js 20 bytes [built]
-    ./c.js 20 bytes [built]
-    ./d.js 20 bytes [built]
-        + 8 hidden modules
+    runtime modules 6.6 KiB 8 modules
+    cacheable modules 126 bytes
+      ./main1.js 66 bytes [built] [code generated]
+      ./b.js 20 bytes [built] [code generated]
+      ./c.js 20 bytes [built] [code generated]
+      ./d.js 20 bytes [built] [code generated]
 Child static custom name:
     asset with-505.js 1.22 KiB [emitted]
     asset with-main1.js 600 bytes [emitted] (name: main1)
@@ -2561,13 +2632,14 @@ Child static custom name:
     Entrypoint main1 = with-manifest.js with-main1.js
     Entrypoint main2 = with-manifest.js with-main2.js
     Entrypoint main3 = with-manifest.js with-main3.js
-    ./main1.js 66 bytes [built]
-    ./main2.js 20 bytes [built]
-    ./main3.js 20 bytes [built]
-    ./b.js 20 bytes [built]
-    ./c.js 20 bytes [built]
-    ./d.js 20 bytes [built]
-        + 8 hidden modules
+    runtime modules 6.59 KiB 8 modules
+    cacheable modules 166 bytes
+      ./main1.js 66 bytes [built] [code generated]
+      ./main2.js 20 bytes [built] [code generated]
+      ./main3.js 20 bytes [built] [code generated]
+      ./b.js 20 bytes [built] [code generated]
+      ./c.js 20 bytes [built] [code generated]
+      ./d.js 20 bytes [built] [code generated]
 Child dynamic custom name:
     asset func-505.js 1.22 KiB [emitted]
     asset func-a.js 5.09 KiB [emitted] (name: a)
@@ -2578,13 +2650,14 @@ Child dynamic custom name:
     Entrypoint main1 = func-b.js func-main1.js
     Entrypoint main2 = func-b.js func-main2.js
     Entrypoint main3 = func-a.js func-main3.js
-    ./main1.js 66 bytes [built]
-    ./main2.js 20 bytes [built]
-    ./main3.js 20 bytes [built]
-    ./b.js 20 bytes [built]
-    ./c.js 20 bytes [built]
-    ./d.js 20 bytes [built]
-        + 10 hidden modules"
+    runtime modules 9.16 KiB 10 modules
+    cacheable modules 166 bytes
+      ./main1.js 66 bytes [built] [code generated]
+      ./main2.js 20 bytes [built] [code generated]
+      ./main3.js 20 bytes [built] [code generated]
+      ./b.js 20 bytes [built] [code generated]
+      ./c.js 20 bytes [built] [code generated]
+      ./d.js 20 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for runtime-chunk-issue-7382 1`] = `
@@ -2615,73 +2688,76 @@ Child production:
     Entrypoint b = production-b.js
     Entrypoint c = production-c.js
     chunk (runtime: a) production-a.js (a) 605 bytes (javascript) 5.42 KiB (runtime) [entry] [rendered]
-     ./a.js 261 bytes [built]
-         [no exports used]
-     ./dx-importer.js 63 bytes [built]
-         [only some exports used: default]
-     ./module.js 122 bytes [built]
-         [only some exports used: x]
-     ./module.js?reexported 122 bytes [built]
-         [only some exports used: x]
-     ./reexport.js 37 bytes [built]
-         [only some exports used: x]
-         + 8 hidden chunk modules
+      runtime modules 5.42 KiB 8 modules
+      cacheable modules 605 bytes
+        ./a.js 261 bytes [built] [code generated]
+          [no exports used]
+        ./dx-importer.js 63 bytes [dependent] [built] [code generated]
+          [only some exports used: default]
+        ./module.js 122 bytes [dependent] [built] [code generated]
+          [only some exports used: x]
+        ./module.js?reexported 122 bytes [dependent] [built] [code generated]
+          [only some exports used: x]
+        ./reexport.js 37 bytes [dependent] [built] [code generated]
+          [only some exports used: x]
     chunk (runtime: b) production-b.js (b) 605 bytes (javascript) 5.42 KiB (runtime) [entry] [rendered]
-     ./b.js 261 bytes [built]
-         [no exports used]
-     ./dx-importer.js 63 bytes [built]
-         [only some exports used: default]
-     ./module.js 122 bytes [built]
-         [only some exports used: y]
-     ./module.js?reexported 122 bytes [built]
-         [only some exports used: y]
-     ./reexport.js 37 bytes [built]
-         [only some exports used: y]
-         + 8 hidden chunk modules
+      runtime modules 5.42 KiB 8 modules
+      cacheable modules 605 bytes
+        ./b.js 261 bytes [built] [code generated]
+          [no exports used]
+        ./dx-importer.js 63 bytes [dependent] [built] [code generated]
+          [only some exports used: default]
+        ./module.js 122 bytes [dependent] [built] [code generated]
+          [only some exports used: y]
+        ./module.js?reexported 122 bytes [dependent] [built] [code generated]
+          [only some exports used: y]
+        ./reexport.js 37 bytes [dependent] [built] [code generated]
+          [only some exports used: y]
     chunk (runtime: c) production-c.js (c) 9 bytes [entry] [rendered]
-     ./c.js 9 bytes [built]
-         [no exports used]
+      ./c.js 9 bytes [built] [code generated]
+        [no exports used]
     chunk (runtime: a) production-dw_js-_a6170.js 168 bytes [rendered]
-     ./dw.js 46 bytes [built]
-     ./module.js?chunk 122 bytes [built]
-         [only some exports used: identity, w, x, y]
+      ./dw.js 46 bytes [built] [code generated]
+      ./module.js?chunk 122 bytes [dependent] [built] [code generated]
+        [only some exports used: identity, w, x, y]
     chunk (runtime: b) production-dw_js-_a6171.js 168 bytes [rendered]
-     ./dw.js 46 bytes [built]
-     ./module.js?chunk 122 bytes [built]
-         [only some exports used: identity, w, x, z]
+      ./dw.js 46 bytes [built] [code generated]
+      ./module.js?chunk 122 bytes [dependent] [built] [code generated]
+        [only some exports used: identity, w, x, z]
     chunk (runtime: a, b) production-dx_js.js 168 bytes [rendered]
-     ./dx.js 46 bytes [built]
-     ./module.js?chunk 122 bytes [built]
-         [only some exports used: identity, w, x, y, z]
-    chunk (runtime: a) production-dy_js.js 168 bytes [rendered]
-     ./dy.js 46 bytes [built]
-     ./module.js?chunk 122 bytes [built]
-         [only some exports used: identity, w, x, y]
-    chunk (runtime: b) production-dz_js.js 168 bytes [rendered]
-     ./dz.js 46 bytes [built]
-     ./module.js?chunk 122 bytes [built]
-         [only some exports used: identity, w, x, z]
-    ./a.js 261 bytes [built]
-        [no exports used]
-    ./b.js 261 bytes [built]
-        [no exports used]
-    ./c.js 9 bytes [built]
-        [no exports used]
-    ./module.js 122 bytes [built]
-        [only some exports used: x, y]
-    ./reexport.js 37 bytes [built]
-        [only some exports used: x, y]
-    ./dx-importer.js 63 bytes [built]
-        [only some exports used: default]
-    ./dy.js 46 bytes [built]
-    ./dw.js 46 bytes [built]
-    ./dz.js 46 bytes [built]
-    ./module.js?reexported 122 bytes [built]
-        [only some exports used: x, y]
-    ./module.js?chunk 122 bytes [built]
+      ./dx.js 46 bytes [built] [code generated]
+      ./module.js?chunk 122 bytes [dependent] [built] [code generated]
         [only some exports used: identity, w, x, y, z]
-    ./dx.js 46 bytes [built]
-        + 16 hidden modules
+    chunk (runtime: a) production-dy_js.js 168 bytes [rendered]
+      ./dy.js 46 bytes [built] [code generated]
+      ./module.js?chunk 122 bytes [dependent] [built] [code generated]
+        [only some exports used: identity, w, x, y]
+    chunk (runtime: b) production-dz_js.js 168 bytes [rendered]
+      ./dz.js 46 bytes [built] [code generated]
+      ./module.js?chunk 122 bytes [dependent] [built] [code generated]
+        [only some exports used: identity, w, x, z]
+    runtime modules 10.8 KiB 16 modules
+    cacheable modules 1.15 KiB
+      ./a.js 261 bytes [built] [code generated]
+        [no exports used]
+      ./b.js 261 bytes [built] [code generated]
+        [no exports used]
+      ./c.js 9 bytes [built] [code generated]
+        [no exports used]
+      ./module.js 122 bytes [built] [code generated]
+        [only some exports used: x, y]
+      ./reexport.js 37 bytes [built] [code generated]
+        [only some exports used: x, y]
+      ./dx-importer.js 63 bytes [built] [code generated]
+        [only some exports used: default]
+      ./dy.js 46 bytes [built] [code generated]
+      ./dw.js 46 bytes [built] [code generated]
+      ./dz.js 46 bytes [built] [code generated]
+      ./module.js?reexported 122 bytes [built] [code generated]
+        [only some exports used: x, y]
+      ./module.js?chunk 122 bytes [built] [code generated]
+        [only some exports used: identity, w, x, y, z]
+      ./dx.js 46 bytes [built] [code generated]
 Child development:
     Hash: b2e650b33f118fc676e4
     Time: X ms
@@ -2697,77 +2773,80 @@ Child development:
     Entrypoint b = development-b.js
     Entrypoint c = development-c.js
     chunk development-a.js (a) 605 bytes (javascript) 5.42 KiB (runtime) [entry] [rendered]
-     ./a.js 261 bytes [built]
-         [used exports unknown]
-     ./dx-importer.js 63 bytes [built]
-         [used exports unknown]
-     ./module.js 122 bytes [built]
-         [used exports unknown]
-     ./module.js?reexported 122 bytes [built]
-         [used exports unknown]
-     ./reexport.js 37 bytes [built]
-         [used exports unknown]
-         + 8 hidden chunk modules
+      runtime modules 5.42 KiB 8 modules
+      cacheable modules 605 bytes
+        ./a.js 261 bytes [built] [code generated]
+          [used exports unknown]
+        ./dx-importer.js 63 bytes [dependent] [built] [code generated]
+          [used exports unknown]
+        ./module.js 122 bytes [dependent] [built] [code generated]
+          [used exports unknown]
+        ./module.js?reexported 122 bytes [dependent] [built] [code generated]
+          [used exports unknown]
+        ./reexport.js 37 bytes [dependent] [built] [code generated]
+          [used exports unknown]
     chunk development-b.js (b) 605 bytes (javascript) 5.42 KiB (runtime) [entry] [rendered]
-     ./b.js 261 bytes [built]
-         [used exports unknown]
-     ./dx-importer.js 63 bytes [built]
-         [used exports unknown]
-     ./module.js 122 bytes [built]
-         [used exports unknown]
-     ./module.js?reexported 122 bytes [built]
-         [used exports unknown]
-     ./reexport.js 37 bytes [built]
-         [used exports unknown]
-         + 8 hidden chunk modules
+      runtime modules 5.42 KiB 8 modules
+      cacheable modules 605 bytes
+        ./b.js 261 bytes [built] [code generated]
+          [used exports unknown]
+        ./dx-importer.js 63 bytes [dependent] [built] [code generated]
+          [used exports unknown]
+        ./module.js 122 bytes [dependent] [built] [code generated]
+          [used exports unknown]
+        ./module.js?reexported 122 bytes [dependent] [built] [code generated]
+          [used exports unknown]
+        ./reexport.js 37 bytes [dependent] [built] [code generated]
+          [used exports unknown]
     chunk development-c.js (c) 9 bytes [entry] [rendered]
-     ./c.js 9 bytes [built]
-         [used exports unknown]
+      ./c.js 9 bytes [built] [code generated]
+        [used exports unknown]
     chunk development-dw_js.js 168 bytes [rendered]
-     ./dw.js 46 bytes [built]
-         [used exports unknown]
-     ./module.js?chunk 122 bytes [built]
-         [used exports unknown]
+      ./dw.js 46 bytes [built] [code generated]
+        [used exports unknown]
+      ./module.js?chunk 122 bytes [dependent] [built] [code generated]
+        [used exports unknown]
     chunk development-dx_js.js 168 bytes [rendered]
-     ./dx.js 46 bytes [built]
-         [used exports unknown]
-     ./module.js?chunk 122 bytes [built]
-         [used exports unknown]
+      ./dx.js 46 bytes [built] [code generated]
+        [used exports unknown]
+      ./module.js?chunk 122 bytes [dependent] [built] [code generated]
+        [used exports unknown]
     chunk development-dy_js.js 168 bytes [rendered]
-     ./dy.js 46 bytes [built]
-         [used exports unknown]
-     ./module.js?chunk 122 bytes [built]
-         [used exports unknown]
+      ./dy.js 46 bytes [built] [code generated]
+        [used exports unknown]
+      ./module.js?chunk 122 bytes [dependent] [built] [code generated]
+        [used exports unknown]
     chunk development-dz_js.js 168 bytes [rendered]
-     ./dz.js 46 bytes [built]
-         [used exports unknown]
-     ./module.js?chunk 122 bytes [built]
-         [used exports unknown]
-    ./a.js 261 bytes [built]
+      ./dz.js 46 bytes [built] [code generated]
         [used exports unknown]
-    ./b.js 261 bytes [built]
+      ./module.js?chunk 122 bytes [dependent] [built] [code generated]
         [used exports unknown]
-    ./c.js 9 bytes [built]
+    runtime modules 10.8 KiB 16 modules
+    cacheable modules 1.15 KiB
+      ./a.js 261 bytes [built] [code generated]
         [used exports unknown]
-    ./module.js 122 bytes [built]
+      ./b.js 261 bytes [built] [code generated]
         [used exports unknown]
-    ./reexport.js 37 bytes [built]
+      ./c.js 9 bytes [built] [code generated]
         [used exports unknown]
-    ./dx-importer.js 63 bytes [built]
+      ./module.js 122 bytes [built] [code generated]
         [used exports unknown]
-    ./dy.js 46 bytes [built]
+      ./reexport.js 37 bytes [built] [code generated]
         [used exports unknown]
-    ./dw.js 46 bytes [built]
+      ./dx-importer.js 63 bytes [built] [code generated]
         [used exports unknown]
-    ./dz.js 46 bytes [built]
+      ./dy.js 46 bytes [built] [code generated]
         [used exports unknown]
-    ./module.js?reexported 122 bytes [built]
+      ./dw.js 46 bytes [built] [code generated]
         [used exports unknown]
-    ./module.js?chunk 122 bytes [built]
+      ./dz.js 46 bytes [built] [code generated]
         [used exports unknown]
-    ./dx.js 46 bytes [built]
+      ./module.js?reexported 122 bytes [built] [code generated]
         [used exports unknown]
-        + 16 hidden modules
+      ./module.js?chunk 122 bytes [built] [code generated]
+        [used exports unknown]
+      ./dx.js 46 bytes [built] [code generated]
+        [used exports unknown]
 Child global:
     Hash: fd06ec917bf197b7ce4d
     Time: X ms
@@ -2783,69 +2862,72 @@ Child global:
     Entrypoint b = global-b.js
     Entrypoint c = global-c.js
     chunk global-a.js (a) 605 bytes (javascript) 5.41 KiB (runtime) [entry] [rendered]
-     ./a.js 261 bytes [built]
-         [no exports used]
-     ./dx-importer.js 63 bytes [built]
-         [only some exports used: default]
-     ./module.js 122 bytes [built]
-         [only some exports used: x, y]
-     ./module.js?reexported 122 bytes [built]
-         [only some exports used: x, y]
-     ./reexport.js 37 bytes [built]
-         [only some exports used: x, y]
-         + 8 hidden chunk modules
+      runtime modules 5.41 KiB 8 modules
+      cacheable modules 605 bytes
+        ./a.js 261 bytes [built] [code generated]
+          [no exports used]
+        ./dx-importer.js 63 bytes [dependent] [built] [code generated]
+          [only some exports used: default]
+        ./module.js 122 bytes [dependent] [built] [code generated]
+          [only some exports used: x, y]
+        ./module.js?reexported 122 bytes [dependent] [built] [code generated]
+          [only some exports used: x, y]
+        ./reexport.js 37 bytes [dependent] [built] [code generated]
+          [only some exports used: x, y]
     chunk global-b.js (b) 605 bytes (javascript) 5.41 KiB (runtime) [entry] [rendered]
-     ./b.js 261 bytes [built]
-         [no exports used]
-     ./dx-importer.js 63 bytes [built]
-         [only some exports used: default]
-     ./module.js 122 bytes [built]
-         [only some exports used: x, y]
-     ./module.js?reexported 122 bytes [built]
-         [only some exports used: x, y]
-     ./reexport.js 37 bytes [built]
-         [only some exports used: x, y]
-         + 8 hidden chunk modules
+      runtime modules 5.41 KiB 8 modules
+      cacheable modules 605 bytes
+        ./b.js 261 bytes [built] [code generated]
+          [no exports used]
+        ./dx-importer.js 63 bytes [dependent] [built] [code generated]
+          [only some exports used: default]
+        ./module.js 122 bytes [dependent] [built] [code generated]
+          [only some exports used: x, y]
+        ./module.js?reexported 122 bytes [dependent] [built] [code generated]
+          [only some exports used: x, y]
+        ./reexport.js 37 bytes [dependent] [built] [code generated]
+          [only some exports used: x, y]
     chunk global-c.js (c) 9 bytes [entry] [rendered]
-     ./c.js 9 bytes [built]
-         [no exports used]
+      ./c.js 9 bytes [built] [code generated]
+        [no exports used]
     chunk global-dw_js.js 168 bytes [rendered]
-     ./dw.js 46 bytes [built]
-     ./module.js?chunk 122 bytes [built]
-         [only some exports used: identity, w, x, y, z]
-    chunk global-dx_js.js 168 bytes [rendered]
-     ./dx.js 46 bytes [built]
-     ./module.js?chunk 122 bytes [built]
-         [only some exports used: identity, w, x, y, z]
-    chunk global-dy_js.js 168 bytes [rendered]
-     ./dy.js 46 bytes [built]
-     ./module.js?chunk 122 bytes [built]
-         [only some exports used: identity, w, x, y, z]
-    chunk global-dz_js.js 168 bytes [rendered]
-     ./dz.js 46 bytes [built]
-     ./module.js?chunk 122 bytes [built]
-         [only some exports used: identity, w, x, y, z]
-    ./a.js 261 bytes [built]
-        [no exports used]
-    ./b.js 261 bytes [built]
-        [no exports used]
-    ./c.js 9 bytes [built]
-        [no exports used]
-    ./module.js 122 bytes [built]
-        [only some exports used: x, y]
-    ./reexport.js 37 bytes [built]
-        [only some exports used: x, y]
-    ./dx-importer.js 63 bytes [built]
-        [only some exports used: default]
-    ./dy.js 46 bytes [built]
-    ./dw.js 46 bytes [built]
-    ./dz.js 46 bytes [built]
-    ./module.js?reexported 122 bytes [built]
-        [only some exports used: x, y]
-    ./module.js?chunk 122 bytes [built]
+      ./dw.js 46 bytes [built] [code generated]
+      ./module.js?chunk 122 bytes [dependent] [built] [code generated]
         [only some exports used: identity, w, x, y, z]
-    ./dx.js 46 bytes [built]
-        + 16 hidden modules"
+    chunk global-dx_js.js 168 bytes [rendered]
+      ./dx.js 46 bytes [built] [code generated]
+      ./module.js?chunk 122 bytes [dependent] [built] [code generated]
+        [only some exports used: identity, w, x, y, z]
+    chunk global-dy_js.js 168 bytes [rendered]
+      ./dy.js 46 bytes [built] [code generated]
+      ./module.js?chunk 122 bytes [dependent] [built] [code generated]
+        [only some exports used: identity, w, x, y, z]
+    chunk global-dz_js.js 168 bytes [rendered]
+      ./dz.js 46 bytes [built] [code generated]
+      ./module.js?chunk 122 bytes [dependent] [built] [code generated]
+        [only some exports used: identity, w, x, y, z]
+    runtime modules 10.8 KiB 16 modules
+    cacheable modules 1.15 KiB
+      ./a.js 261 bytes [built] [code generated]
+        [no exports used]
+      ./b.js 261 bytes [built] [code generated]
+        [no exports used]
+      ./c.js 9 bytes [built] [code generated]
+        [no exports used]
+      ./module.js 122 bytes [built] [code generated]
+        [only some exports used: x, y]
+      ./reexport.js 37 bytes [built] [code generated]
+        [only some exports used: x, y]
+      ./dx-importer.js 63 bytes [built] [code generated]
+        [only some exports used: default]
+      ./dy.js 46 bytes [built] [code generated]
+      ./dw.js 46 bytes [built] [code generated]
+      ./dz.js 46 bytes [built] [code generated]
+      ./module.js?reexported 122 bytes [built] [code generated]
+        [only some exports used: x, y]
+      ./module.js?chunk 122 bytes [built] [code generated]
+        [only some exports used: identity, w, x, y, z]
+      ./dx.js 46 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for scope-hoisting-bailouts 1`] = `
@@ -2854,31 +2936,34 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 Entrypoint index = index.js
 Entrypoint entry = entry.js
-./index.js 150 bytes [built]
-    ModuleConcatenation bailout: Cannot concat with ./cjs.js: Module is not an ECMAScript module
-    ModuleConcatenation bailout: Cannot concat with ./entry.js: Module is an entry point
-    ModuleConcatenation bailout: Cannot concat with ./eval.js: Module uses eval()
-    ModuleConcatenation bailout: Cannot concat with ./module-id.js: Module uses module.id
-    ModuleConcatenation bailout: Cannot concat with ./module-loaded.js: Module uses module.loaded
-    ModuleConcatenation bailout: Cannot concat with ./ref-from-cjs.js: Module ./ref-from-cjs.js is referenced from these modules with unsupported syntax: ./cjs.js (referenced with cjs require)
-./entry.js 32 bytes [built]
-./cjs.js 59 bytes [built]
-    CommonJS bailout: module.exports is used directly at 3:0-14
-    ModuleConcatenation bailout: Module is not an ECMAScript module
-./ref-from-cjs.js 45 bytes [built]
-./eval.js 35 bytes [built]
-    ModuleConcatenation bailout: Module uses eval()
-./module-id.js 26 bytes [built]
-    ModuleConcatenation bailout: Module uses module.id
-./module-loaded.js 30 bytes [built]
-    ModuleConcatenation bailout: Module uses module.loaded
-./concatenated.js + 2 modules 111 bytes [built]
-    ModuleConcatenation bailout: Cannot concat with external \\"external\\": Module is not an ECMAScript module
-./concatenated1.js 37 bytes [orphan] [built]
-./concatenated2.js 48 bytes [orphan] [built]
-external \\"external\\" 42 bytes [built]
-    ModuleConcatenation bailout: Module is not an ECMAScript module
-    + 9 hidden modules"
+runtime modules 5.67 KiB 9 modules
+cacheable modules 573 bytes
+  code generated modules 488 bytes [code generated]
+    ./index.js 150 bytes [built] [code generated]
+      ModuleConcatenation bailout: Cannot concat with ./cjs.js: Module is not an ECMAScript module
+      ModuleConcatenation bailout: Cannot concat with ./entry.js: Module is an entry point
+      ModuleConcatenation bailout: Cannot concat with ./eval.js: Module uses eval()
+      ModuleConcatenation bailout: Cannot concat with ./module-id.js: Module uses module.id
+      ModuleConcatenation bailout: Cannot concat with ./module-loaded.js: Module uses module.loaded
+      ModuleConcatenation bailout: Cannot concat with ./ref-from-cjs.js: Module ./ref-from-cjs.js is referenced from these modules with unsupported syntax: ./cjs.js (referenced with cjs require)
+    ./entry.js 32 bytes [built] [code generated]
+    ./cjs.js 59 bytes [built] [code generated]
+      CommonJS bailout: module.exports is used directly at 3:0-14
+      ModuleConcatenation bailout: Module is not an ECMAScript module
+    ./ref-from-cjs.js 45 bytes [built] [code generated]
+    ./eval.js 35 bytes [built] [code generated]
+      ModuleConcatenation bailout: Module uses eval()
+    ./module-id.js 26 bytes [built] [code generated]
+      ModuleConcatenation bailout: Module uses module.id
+    ./module-loaded.js 30 bytes [built] [code generated]
+      ModuleConcatenation bailout: Module uses module.loaded
+    ./concatenated.js + 2 modules 111 bytes [built] [code generated]
+      ModuleConcatenation bailout: Cannot concat with external \\"external\\": Module is not an ECMAScript module
+  orphan modules 85 bytes [orphan]
+    ./concatenated1.js 37 bytes [orphan] [built]
+    ./concatenated2.js 48 bytes [orphan] [built]
+external \\"external\\" 42 bytes [built] [code generated]
+  ModuleConcatenation bailout: Module is not an ECMAScript module"
 `;
 
 exports[`StatsTestCases should print correct stats for scope-hoisting-multi 1`] = `
@@ -2889,41 +2974,43 @@ Child
     Built at: 1970-04-20 12:42:42
     Entrypoint first = a-vendor.js a-first.js
     Entrypoint second = a-vendor.js a-second.js
-    ./first.js 207 bytes [built]
-    ./second.js 177 bytes [built]
-    ./vendor.js 25 bytes [built]
-    ./common.js 37 bytes [built]
-    ./module_first.js 31 bytes [built]
-    ./lazy_first.js 55 bytes [built]
-    ./lazy_shared.js 31 bytes [built]
-    ./lazy_second.js 55 bytes [built]
-    ./common2.js 25 bytes [built]
-    ./common_lazy.js 25 bytes [built]
-    ./common_lazy_shared.js 25 bytes [built]
-        + 14 hidden modules
+    runtime modules 12.7 KiB 14 modules
+    cacheable modules 693 bytes
+      ./first.js 207 bytes [built] [code generated]
+      ./second.js 177 bytes [built] [code generated]
+      ./vendor.js 25 bytes [built] [code generated]
+      ./common.js 37 bytes [built] [code generated]
+      ./module_first.js 31 bytes [built] [code generated]
+      ./lazy_first.js 55 bytes [built] [code generated]
+      ./lazy_shared.js 31 bytes [built] [code generated]
+      ./lazy_second.js 55 bytes [built] [code generated]
+      ./common2.js 25 bytes [built] [code generated]
+      ./common_lazy.js 25 bytes [built] [code generated]
+      ./common_lazy_shared.js 25 bytes [built] [code generated]
 Child
     Hash: ff4c1f6f253f71e936ce
     Time: X ms
     Built at: 1970-04-20 12:42:42
     Entrypoint first = b-vendor.js b-first.js
     Entrypoint second = b-vendor.js b-second.js
-    ./first.js + 3 modules 300 bytes [built]
-        ModuleConcatenation bailout: Cannot concat with ./vendor.js: Module ./vendor.js is not in the same chunk(s) (expected in chunk(s) first, module is in chunk(s) vendor)
-    ./second.js + 2 modules 239 bytes [built]
-        ModuleConcatenation bailout: Cannot concat with ./vendor.js: Module ./vendor.js is not in the same chunk(s) (expected in chunk(s) second, module is in chunk(s) vendor)
-    ./vendor.js 25 bytes [built]
-    ./common.js 37 bytes [orphan] [built]
-    ./module_first.js 31 bytes [orphan] [built]
-    ./lazy_first.js + 1 modules 80 bytes [built]
-        ModuleConcatenation bailout: Cannot concat with ./common_lazy_shared.js: Module ./common_lazy_shared.js is referenced from different chunks by these modules: ./lazy_shared.js
-    ./lazy_shared.js 31 bytes [built]
-        ModuleConcatenation bailout: Cannot concat with ./common_lazy_shared.js: Module ./common_lazy_shared.js is referenced from different chunks by these modules: ./lazy_first.js + 1 modules, ./lazy_second.js + 1 modules
-    ./lazy_second.js + 1 modules 80 bytes [built]
-        ModuleConcatenation bailout: Cannot concat with ./common_lazy_shared.js: Module ./common_lazy_shared.js is referenced from different chunks by these modules: ./lazy_shared.js
-    ./common2.js 25 bytes [orphan] [built]
-    ./common_lazy.js 25 bytes [orphan] [built]
-    ./common_lazy_shared.js 25 bytes [built]
-        + 14 hidden modules"
+    runtime modules 12.7 KiB 14 modules
+    cacheable modules 898 bytes
+      code generated modules 780 bytes [code generated]
+        modules by path ./*.js 81 bytes 3 modules
+        modules by path ./*.js + 1 modules 160 bytes
+          ./lazy_first.js + 1 modules 80 bytes [built] [code generated]
+            ModuleConcatenation bailout: Cannot concat with ./common_lazy_shared.js: Module ./common_lazy_shared.js is referenced from different chunks by these modules: ./lazy_shared.js
+          ./lazy_second.js + 1 modules 80 bytes [built] [code generated]
+            ModuleConcatenation bailout: Cannot concat with ./common_lazy_shared.js: Module ./common_lazy_shared.js is referenced from different chunks by these modules: ./lazy_shared.js
+        ./first.js + 3 modules 300 bytes [built] [code generated]
+          ModuleConcatenation bailout: Cannot concat with ./vendor.js: Module ./vendor.js is not in the same chunk(s) (expected in chunk(s) first, module is in chunk(s) vendor)
+        ./second.js + 2 modules 239 bytes [built] [code generated]
+          ModuleConcatenation bailout: Cannot concat with ./vendor.js: Module ./vendor.js is not in the same chunk(s) (expected in chunk(s) second, module is in chunk(s) vendor)
+      orphan modules 118 bytes [orphan]
+        ./common.js 37 bytes [orphan] [built]
+        ./module_first.js 31 bytes [orphan] [built]
+        ./common2.js 25 bytes [orphan] [built]
+        ./common_lazy.js 25 bytes [orphan] [built]"
 `;
 
 exports[`StatsTestCases should print correct stats for side-effects-issue-7428 1`] = `
@@ -2933,55 +3020,52 @@ Built at: 1970-04-20 12:42:42
 asset 1.js 638 bytes [emitted]
 asset main.js 10.7 KiB [emitted] (name: main)
 Entrypoint main = main.js
-./main.js + 1 modules 221 bytes [built]
+runtime modules 5.4 KiB 8 modules
+cacheable modules 823 bytes
+  modules by path ./components/src/ 501 bytes
+    orphan modules 315 bytes [orphan]
+      modules by path ./components/src/CompAB/ 164 bytes 2 modules
+      modules by path ./components/src/CompC/ 67 bytes
+        ./components/src/CompC/CompC.js 33 bytes [orphan] [built]
+          [module unused]
+          [inactive] harmony side effect evaluation ./CompC ./components/src/CompC/index.js 1:0-34
+          [inactive] harmony export imported specifier ./CompC ./components/src/CompC/index.js 1:0-34
+          [inactive] harmony export imported specifier ./CompC ./components/src/index.js 2:0-43 (skipped side-effect-free modules)
+        ./components/src/CompC/index.js 34 bytes [orphan] [built]
+          [module unused]
+          [inactive] harmony side effect evaluation ./CompC ./components/src/index.js 2:0-43
+      ./components/src/index.js 84 bytes [orphan] [built]
+        [module unused]
+        [inactive] harmony side effect evaluation ./components ./foo.js 1:0-37
+        [inactive] harmony side effect evaluation ./components ./main.js + 1 modules ./main.js 1:0-44
+    code generated modules 186 bytes [code generated]
+      ./components/src/CompAB/CompA.js 89 bytes [built] [code generated]
+        [only some exports used: default]
+        [inactive] harmony side effect evaluation ./CompA ./components/src/CompAB/index.js 1:0-43
+        [inactive] harmony export imported specifier ./CompA ./components/src/CompAB/index.js 1:0-43
+        [inactive] harmony export imported specifier ./CompAB ./components/src/index.js 1:0-40 (skipped side-effect-free modules)
+        harmony import specifier ./components ./foo.js 3:20-25 (skipped side-effect-free modules)
+        harmony import specifier ./components ./main.js + 1 modules ./main.js 3:15-20 (skipped side-effect-free modules)
+      ./components/src/CompAB/utils.js 97 bytes [built] [code generated]
+        [inactive] harmony side effect evaluation ./utils ./components/src/CompAB/CompA.js 1:0-35
+        harmony import specifier ./utils ./components/src/CompAB/CompA.js 5:5-12
+        [inactive] harmony side effect evaluation ./utils ./components/src/CompAB/CompB.js 1:0-30
+        harmony import specifier ./utils ./components/src/CompAB/CompB.js 5:2-5
+        [inactive] harmony side effect evaluation ./utils ./main.js + 1 modules ./components/src/CompAB/CompB.js 1:0-30
+        harmony import specifier ./utils ./main.js + 1 modules ./components/src/CompAB/CompB.js 5:2-5
+  ./main.js + 1 modules 221 bytes [built] [code generated]
     [no exports used]
     entry ./main.js main
     | ./main.js 144 bytes [built]
-    |     [no exports used]
+    |   [no exports used]
     | ./components/src/CompAB/CompB.js 77 bytes [built]
-    |     [only some exports used: default]
-    |     [inactive] harmony side effect evaluation ./CompB ./components/src/CompAB/index.js 2:0-43
-    |     [inactive] harmony export imported specifier ./CompB ./components/src/CompAB/index.js 2:0-43
-    |     [inactive] harmony export imported specifier ./CompAB ./components/src/index.js 1:0-40 (skipped side-effect-free modules)
-    |     harmony import specifier ./components ./main.js 4:15-20 (skipped side-effect-free modules)
-./components/src/CompAB/CompA.js 89 bytes [built]
-    [only some exports used: default]
-    [inactive] harmony side effect evaluation ./CompA ./components/src/CompAB/index.js 1:0-43
-    [inactive] harmony export imported specifier ./CompA ./components/src/CompAB/index.js 1:0-43
-    [inactive] harmony export imported specifier ./CompAB ./components/src/index.js 1:0-40 (skipped side-effect-free modules)
-    harmony import specifier ./components ./foo.js 3:20-25 (skipped side-effect-free modules)
-    harmony import specifier ./components ./main.js + 1 modules ./main.js 3:15-20 (skipped side-effect-free modules)
-./components/src/CompAB/CompB.js 77 bytes [orphan] [built]
-    [only some exports used: default]
-    [inactive] harmony side effect evaluation ./CompB ./components/src/CompAB/index.js 2:0-43
-    [inactive] harmony export imported specifier ./CompB ./components/src/CompAB/index.js 2:0-43
-    [inactive] harmony export imported specifier ./CompAB ./components/src/index.js 1:0-40 (skipped side-effect-free modules)
-    harmony import specifier ./components ./main.js 4:15-20 (skipped side-effect-free modules)
-./foo.js 101 bytes [built]
-    import() ./foo ./main.js + 1 modules ./main.js 6:0-15
-./components/src/index.js 84 bytes [orphan] [built]
-    [module unused]
-    [inactive] harmony side effect evaluation ./components ./foo.js 1:0-37
-    [inactive] harmony side effect evaluation ./components ./main.js + 1 modules ./main.js 1:0-44
-./components/src/CompAB/utils.js 97 bytes [built]
-    [inactive] harmony side effect evaluation ./utils ./components/src/CompAB/CompA.js 1:0-35
-    harmony import specifier ./utils ./components/src/CompAB/CompA.js 5:5-12
-    [inactive] harmony side effect evaluation ./utils ./components/src/CompAB/CompB.js 1:0-30
-    harmony import specifier ./utils ./components/src/CompAB/CompB.js 5:2-5
-    [inactive] harmony side effect evaluation ./utils ./main.js + 1 modules ./components/src/CompAB/CompB.js 1:0-30
-    harmony import specifier ./utils ./main.js + 1 modules ./components/src/CompAB/CompB.js 5:2-5
-./components/src/CompAB/index.js 87 bytes [orphan] [built]
-    [module unused]
-    [inactive] harmony side effect evaluation ./CompAB ./components/src/index.js 1:0-40
-./components/src/CompC/CompC.js 33 bytes [orphan] [built]
-    [module unused]
-    [inactive] harmony side effect evaluation ./CompC ./components/src/CompC/index.js 1:0-34
-    [inactive] harmony export imported specifier ./CompC ./components/src/CompC/index.js 1:0-34
-    [inactive] harmony export imported specifier ./CompC ./components/src/index.js 2:0-43 (skipped side-effect-free modules)
-./components/src/CompC/index.js 34 bytes [orphan] [built]
-    [module unused]
-    [inactive] harmony side effect evaluation ./CompC ./components/src/index.js 2:0-43
-    + 8 hidden modules"
+    |   [only some exports used: default]
+    |   [inactive] harmony side effect evaluation ./CompB ./components/src/CompAB/index.js 2:0-43
+    |   [inactive] harmony export imported specifier ./CompB ./components/src/CompAB/index.js 2:0-43
+    |   [inactive] harmony export imported specifier ./CompAB ./components/src/index.js 1:0-40 (skipped side-effect-free modules)
+    |   harmony import specifier ./components ./main.js 4:15-20 (skipped side-effect-free modules)
+  ./foo.js 101 bytes [built] [code generated]
+    import() ./foo ./main.js + 1 modules ./main.js 6:0-15"
 `;
 
 exports[`StatsTestCases should print correct stats for side-effects-optimization 1`] = `
@@ -2992,48 +3076,52 @@ Child
     Built at: 1970-04-20 12:42:42
     asset main.js 207 bytes [emitted] [minimized] (name: main)
     Entrypoint main = main.js
-    ./index.js + 2 modules 1.18 KiB [built]
+    orphan modules 1.2 KiB [orphan] 4 modules
+    cacheable modules 1.22 KiB
+      ./index.js + 2 modules 1.18 KiB [built] [code generated]
         [no exports]
         [no exports used]
         ModuleConcatenation bailout: Cannot concat with ./node_modules/module-with-export/emptyModule.js: Module is not an ECMAScript module
         | ./index.js 116 bytes [built]
-        |     [no exports]
-        |     [no exports used]
+        |   [no exports]
+        |   [no exports used]
         | ./node_modules/big-module/a.js 58 bytes [built]
-        |     [only some exports used: a]
+        |   [only some exports used: a]
         | ./node_modules/module-with-export/index.js 1.01 KiB [built]
-        |     [only some exports used: smallVar]
-    ./node_modules/module-with-export/emptyModule.js 43 bytes [built]
+        |   [only some exports used: smallVar]
+      ./node_modules/module-with-export/emptyModule.js 43 bytes [built] [code generated]
         [used exports unknown]
         ModuleConcatenation bailout: Module is not an ECMAScript module
-        + 4 hidden modules
 Child
     Hash: 562edbc000f1181edacd
     Time: X ms
     Built at: 1970-04-20 12:42:42
     asset main.no-side.js 1.24 KiB [emitted] [minimized] (name: main)
     Entrypoint main = main.no-side.js
-    ./index.js 116 bytes [built]
+    runtime modules 1000 bytes 4 modules
+    cacheable modules 1.35 KiB
+      modules by path ./node_modules/big-module/ 194 bytes
+        ./node_modules/big-module/index.js 44 bytes [built] [code generated]
+          [only some exports used: a, huh]
+          ModuleConcatenation bailout: Module exports are unknown
+        ./node_modules/big-module/a.js 58 bytes [built] [code generated]
+          [only some exports used: a, huh]
+          ModuleConcatenation bailout: Module exports are unknown
+        ./node_modules/big-module/log.js 92 bytes [built] [code generated]
+          [only some exports used: huh]
+          ModuleConcatenation bailout: Module exports are unknown
+      modules by path ./node_modules/module-with-export/ 1.05 KiB
+        ./node_modules/module-with-export/index.js 1.01 KiB [built] [code generated]
+          [only some exports used: huh, smallVar]
+          ModuleConcatenation bailout: Module exports are unknown
+        ./node_modules/module-with-export/emptyModule.js 43 bytes [built] [code generated]
+          [used exports unknown]
+          ModuleConcatenation bailout: Module is not an ECMAScript module
+      ./index.js 116 bytes [built] [code generated]
         [no exports]
         [no exports used]
         ModuleConcatenation bailout: Cannot concat with ./node_modules/big-module/index.js: Module exports are unknown
-        ModuleConcatenation bailout: Cannot concat with ./node_modules/module-with-export/index.js: Module exports are unknown
-    ./node_modules/big-module/index.js 44 bytes [built]
-        [only some exports used: a, huh]
-        ModuleConcatenation bailout: Module exports are unknown
-    ./node_modules/module-with-export/index.js 1.01 KiB [built]
-        [only some exports used: huh, smallVar]
-        ModuleConcatenation bailout: Module exports are unknown
-    ./node_modules/big-module/a.js 58 bytes [built]
-        [only some exports used: a, huh]
-        ModuleConcatenation bailout: Module exports are unknown
-    ./node_modules/module-with-export/emptyModule.js 43 bytes [built]
-        [used exports unknown]
-        ModuleConcatenation bailout: Module is not an ECMAScript module
-    ./node_modules/big-module/log.js 92 bytes [built]
-        [only some exports used: huh]
-        ModuleConcatenation bailout: Module exports are unknown
-        + 4 hidden modules"
+        ModuleConcatenation bailout: Cannot concat with ./node_modules/module-with-export/index.js: Module exports are unknown"
 `;
 
 exports[`StatsTestCases should print correct stats for side-effects-simple-unused 1`] = `
@@ -3042,45 +3130,45 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 asset main.js 322 bytes [emitted] (name: main)
 Entrypoint main = main.js
-./index.js + 2 modules 158 bytes [built]
-    [no exports used]
-    entry ./index main
-    | ./index.js 55 bytes [built]
-    |     [no exports used]
-    | ./node_modules/pmodule/index.js 75 bytes [built]
-    |     [only some exports used: default]
-    |     [inactive] harmony side effect evaluation pmodule ./index.js 1:0-33
-    |     harmony import specifier pmodule ./index.js 3:12-15
-    | ./node_modules/pmodule/c.js 28 bytes [built]
-    |     [only some exports used: z]
-    |     harmony import specifier pmodule ./index.js 3:17-18 (skipped side-effect-free modules)
-    |     [inactive] harmony side effect evaluation ./c ./node_modules/pmodule/b.js 5:0-24
-    |     [inactive] harmony export imported specifier ./c ./node_modules/pmodule/b.js 5:0-24
-    |     [inactive] harmony export imported specifier ./b ./node_modules/pmodule/index.js 2:0-30 (skipped side-effect-free modules)
+./index.js + 2 modules 158 bytes [built] [code generated]
+  [no exports used]
+  entry ./index main
+  | ./index.js 55 bytes [built]
+  |   [no exports used]
+  | ./node_modules/pmodule/index.js 75 bytes [built]
+  |   [only some exports used: default]
+  |   [inactive] harmony side effect evaluation pmodule ./index.js 1:0-33
+  |   harmony import specifier pmodule ./index.js 3:12-15
+  | ./node_modules/pmodule/c.js 28 bytes [built]
+  |   [only some exports used: z]
+  |   harmony import specifier pmodule ./index.js 3:17-18 (skipped side-effect-free modules)
+  |   [inactive] harmony side effect evaluation ./c ./node_modules/pmodule/b.js 5:0-24
+  |   [inactive] harmony export imported specifier ./c ./node_modules/pmodule/b.js 5:0-24
+  |   [inactive] harmony export imported specifier ./b ./node_modules/pmodule/index.js 2:0-30 (skipped side-effect-free modules)
 ./node_modules/pmodule/index.js 75 bytes [orphan] [built]
-    [only some exports used: default]
-    [inactive] harmony side effect evaluation pmodule ./index.js 1:0-33
-    harmony import specifier pmodule ./index.js 3:12-15
+  [only some exports used: default]
+  [inactive] harmony side effect evaluation pmodule ./index.js 1:0-33
+  harmony import specifier pmodule ./index.js 3:12-15
 ./node_modules/pmodule/c.js 28 bytes [orphan] [built]
-    [only some exports used: z]
-    harmony import specifier pmodule ./index.js 3:17-18 (skipped side-effect-free modules)
-    [inactive] harmony side effect evaluation ./c ./node_modules/pmodule/b.js 5:0-24
-    [inactive] harmony export imported specifier ./c ./node_modules/pmodule/b.js 5:0-24
-    [inactive] harmony export imported specifier ./b ./node_modules/pmodule/index.js 2:0-30 (skipped side-effect-free modules)
+  [only some exports used: z]
+  harmony import specifier pmodule ./index.js 3:17-18 (skipped side-effect-free modules)
+  [inactive] harmony side effect evaluation ./c ./node_modules/pmodule/b.js 5:0-24
+  [inactive] harmony export imported specifier ./c ./node_modules/pmodule/b.js 5:0-24
+  [inactive] harmony export imported specifier ./b ./node_modules/pmodule/index.js 2:0-30 (skipped side-effect-free modules)
 ./node_modules/pmodule/a.js 60 bytes [orphan] [built]
-    [module unused]
-    [inactive] harmony side effect evaluation ./a ./index.js + 2 modules ./node_modules/pmodule/index.js 1:0-20
-    [inactive] harmony export imported specifier ./a ./index.js + 2 modules ./node_modules/pmodule/index.js 1:0-20
-    [inactive] harmony side effect evaluation ./a ./node_modules/pmodule/index.js 1:0-20
-    [inactive] harmony export imported specifier ./a ./node_modules/pmodule/index.js 1:0-20
+  [module unused]
+  [inactive] harmony side effect evaluation ./a ./index.js + 2 modules ./node_modules/pmodule/index.js 1:0-20
+  [inactive] harmony export imported specifier ./a ./index.js + 2 modules ./node_modules/pmodule/index.js 1:0-20
+  [inactive] harmony side effect evaluation ./a ./node_modules/pmodule/index.js 1:0-20
+  [inactive] harmony export imported specifier ./a ./node_modules/pmodule/index.js 1:0-20
 ./node_modules/pmodule/b.js 69 bytes [orphan] [built]
-    [module unused]
-    [inactive] harmony side effect evaluation ./b ./index.js + 2 modules ./node_modules/pmodule/index.js 2:0-30
-    [inactive] harmony export imported specifier ./b ./index.js + 2 modules ./node_modules/pmodule/index.js 2:0-30
-    [inactive] harmony export imported specifier ./b ./index.js + 2 modules ./node_modules/pmodule/index.js 2:0-30
-    [inactive] harmony side effect evaluation ./b ./node_modules/pmodule/index.js 2:0-30
-    [inactive] harmony export imported specifier ./b ./node_modules/pmodule/index.js 2:0-30
-    [inactive] harmony export imported specifier ./b ./node_modules/pmodule/index.js 2:0-30"
+  [module unused]
+  [inactive] harmony side effect evaluation ./b ./index.js + 2 modules ./node_modules/pmodule/index.js 2:0-30
+  [inactive] harmony export imported specifier ./b ./index.js + 2 modules ./node_modules/pmodule/index.js 2:0-30
+  [inactive] harmony export imported specifier ./b ./index.js + 2 modules ./node_modules/pmodule/index.js 2:0-30
+  [inactive] harmony side effect evaluation ./b ./node_modules/pmodule/index.js 2:0-30
+  [inactive] harmony export imported specifier ./b ./node_modules/pmodule/index.js 2:0-30
+  [inactive] harmony export imported specifier ./b ./node_modules/pmodule/index.js 2:0-30"
 `;
 
 exports[`StatsTestCases should print correct stats for simple 1`] = `
@@ -3089,7 +3177,7 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 asset bundle.js 812 bytes [emitted] (name: main)
 Entrypoint main = bundle.js
-./index.js 1 bytes [built]"
+./index.js 1 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for simple-more-info 1`] = `
@@ -3099,9 +3187,9 @@ Built at: 1970-04-20 12:42:42
 PublicPath: (none)
 asset bundle.js 54 bytes [emitted] (name: main)
 Entrypoint main = bundle.js
-./index.js 1 bytes [built]
-    entry ./index main
-    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)"
+./index.js 1 bytes [built] [code generated]
+  entry ./index main
+  X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
@@ -3111,541 +3199,541 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
     Entrypoint b = default/b.js
     Entrypoint c = default/c.js
     chunk (runtime: b) default/b.js (b) 152 bytes [entry] [rendered]
-        > ./b b
-     ./b.js 72 bytes [built]
-         + 4 hidden dependent modules
+      > ./b b
+      dependent modules 80 bytes [dependent] 4 modules
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: a, main) default/async-g.js (async-g) 34 bytes <{282}> <{767}> <{786}> <{794}> <{954}> ={568}= [rendered]
-        > ./g ./a.js 6:0-47
-     ./g.js 34 bytes [built]
+      > ./g ./a.js 6:0-47
+      ./g.js 34 bytes [built] [code generated]
     chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 5.49 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
-        > ./ main
-     ./index.js 147 bytes [built]
-         + 8 hidden root modules
+      > ./ main
+      runtime modules 5.49 KiB 8 modules
+      ./index.js 147 bytes [built] [code generated]
     chunk (runtime: main) default/282.js (id hint: vendors) 20 bytes <{179}> ={334}= ={383}= ={568}= ={767}= ={769}= ={794}= ={954}= >{137}< >{568}< [rendered] split chunk (cache group: defaultVendors)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-     ./node_modules/x.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      ./node_modules/x.js 20 bytes [built] [code generated]
     chunk (runtime: main) default/async-b.js (async-b) 72 bytes <{179}> ={282}= ={568}= ={767}= ={954}= [rendered]
-        > ./b ./index.js 2:0-47
-     ./b.js 72 bytes [built]
+      > ./b ./index.js 2:0-47
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: main) default/async-c.js (async-c) 72 bytes <{179}> ={282}= ={568}= ={767}= ={769}= [rendered]
-        > ./c ./index.js 3:0-47
-     ./c.js 72 bytes [built]
+      > ./c ./index.js 3:0-47
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: c) default/c.js (c) 152 bytes [entry] [rendered]
-        > ./c c
-     ./c.js 72 bytes [built]
-         + 4 hidden dependent modules
+      > ./c c
+      dependent modules 80 bytes [dependent] 4 modules
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: a, main) default/568.js 20 bytes <{179}> <{282}> <{767}> <{786}> <{794}> <{954}> ={137}= ={282}= ={334}= ={383}= ={767}= ={769}= ={954}= [rendered] split chunk (cache group: default)
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./g ./a.js 6:0-47
-     ./f.js 20 bytes [built]
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./g ./a.js 6:0-47
+      ./f.js 20 bytes [built] [code generated]
     chunk (runtime: main) default/767.js 20 bytes <{179}> ={282}= ={334}= ={383}= ={568}= ={769}= ={794}= ={954}= >{137}< >{568}< [rendered] split chunk (cache group: default)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-     ./d.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      ./d.js 20 bytes [built] [code generated]
     chunk (runtime: main) default/769.js (id hint: vendors) 20 bytes <{179}> ={282}= ={383}= ={568}= ={767}= [rendered] split chunk (cache group: defaultVendors)
-        > ./c ./index.js 3:0-47
-     ./node_modules/z.js 20 bytes [built]
+      > ./c ./index.js 3:0-47
+      ./node_modules/z.js 20 bytes [built] [code generated]
     chunk (runtime: a) default/a.js (a) 201 bytes (javascript) 5.48 KiB (runtime) >{137}< >{568}< [entry] [rendered]
-        > ./a a
-     ./a.js + 1 modules 141 bytes [built]
-         + 8 hidden root modules
-         + 3 hidden dependent modules
+      > ./a a
+      runtime modules 5.48 KiB 8 modules
+      dependent modules 60 bytes [dependent] 3 modules
+      ./a.js + 1 modules 141 bytes [built] [code generated]
     chunk (runtime: main) default/async-a.js (async-a) 141 bytes <{179}> ={282}= ={767}= ={954}= >{137}< >{568}< [rendered]
-        > ./a ./index.js 1:0-47
-     ./a.js + 1 modules 141 bytes [built]
+      > ./a ./index.js 1:0-47
+      ./a.js + 1 modules 141 bytes [built] [code generated]
     chunk (runtime: main) default/954.js (id hint: vendors) 20 bytes <{179}> ={282}= ={334}= ={568}= ={767}= ={794}= >{137}< >{568}< [rendered] split chunk (cache group: defaultVendors)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-     ./node_modules/y.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      ./node_modules/y.js 20 bytes [built] [code generated]
 Child all-chunks:
     Entrypoint main = all-chunks/main.js
     Entrypoint a = all-chunks/282.js all-chunks/954.js all-chunks/767.js all-chunks/390.js all-chunks/a.js
     Entrypoint b = all-chunks/282.js all-chunks/954.js all-chunks/767.js all-chunks/568.js all-chunks/b.js
     Entrypoint c = all-chunks/282.js all-chunks/769.js all-chunks/767.js all-chunks/568.js all-chunks/c.js
     chunk (runtime: b) all-chunks/b.js (b) 72 bytes (javascript) 2.6 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
-        > ./b b
-     ./b.js 72 bytes [built]
-         + 2 hidden root modules
+      > ./b b
+      runtime modules 2.6 KiB 2 modules
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: a, main) all-chunks/async-g.js (async-g) 34 bytes <{282}> <{390}> <{767}> <{786}> <{794}> <{954}> ={568}= [rendered]
-        > ./g ./a.js 6:0-47
-     ./g.js 34 bytes [built]
+      > ./g ./a.js 6:0-47
+      ./g.js 34 bytes [built] [code generated]
     chunk (runtime: main) all-chunks/main.js (main) 147 bytes (javascript) 5.49 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
-        > ./ main
-     ./index.js 147 bytes [built]
-         + 8 hidden root modules
+      > ./ main
+      runtime modules 5.49 KiB 8 modules
+      ./index.js 147 bytes [built] [code generated]
     chunk (runtime: a, b, c, main) all-chunks/282.js (id hint: vendors) 20 bytes <{179}> ={128}= ={334}= ={383}= ={390}= ={459}= ={568}= ={767}= ={769}= ={786}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./a a
-        > ./b b
-        > ./c c
-     ./node_modules/x.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./a a
+      > ./b b
+      > ./c c
+      ./node_modules/x.js 20 bytes [built] [code generated]
     chunk (runtime: main) all-chunks/async-b.js (async-b) 72 bytes <{179}> ={282}= ={568}= ={767}= ={954}= [rendered]
-        > ./b ./index.js 2:0-47
-     ./b.js 72 bytes [built]
+      > ./b ./index.js 2:0-47
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: main) all-chunks/async-c.js (async-c) 72 bytes <{179}> ={282}= ={568}= ={767}= ={769}= [rendered]
-        > ./c ./index.js 3:0-47
-     ./c.js 72 bytes [built]
+      > ./c ./index.js 3:0-47
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: a, main) all-chunks/390.js 20 bytes <{179}> ={282}= ={767}= ={786}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: default)
-        > ./a ./index.js 1:0-47
-        > ./a a
-     ./e.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./a a
+      ./e.js 20 bytes [built] [code generated]
     chunk (runtime: c) all-chunks/c.js (c) 72 bytes (javascript) 2.6 KiB (runtime) ={282}= ={568}= ={767}= ={769}= [entry] [rendered]
-        > ./c c
-     ./c.js 72 bytes [built]
-         + 2 hidden root modules
+      > ./c c
+      runtime modules 2.6 KiB 2 modules
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: a, b, c, main) all-chunks/568.js 20 bytes <{179}> <{282}> <{390}> <{767}> <{786}> <{794}> <{954}> ={128}= ={137}= ={282}= ={334}= ={383}= ={459}= ={767}= ={769}= ={954}= [initial] [rendered] split chunk (cache group: default)
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./g ./a.js 6:0-47
-        > ./b b
-        > ./c c
-     ./f.js 20 bytes [built]
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./g ./a.js 6:0-47
+      > ./b b
+      > ./c c
+      ./f.js 20 bytes [built] [code generated]
     chunk (runtime: a, b, c, main) all-chunks/767.js 20 bytes <{179}> ={128}= ={282}= ={334}= ={383}= ={390}= ={459}= ={568}= ={769}= ={786}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: default)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./a a
-        > ./b b
-        > ./c c
-     ./d.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./a a
+      > ./b b
+      > ./c c
+      ./d.js 20 bytes [built] [code generated]
     chunk (runtime: c, main) all-chunks/769.js (id hint: vendors) 20 bytes <{179}> ={282}= ={383}= ={459}= ={568}= ={767}= [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./c ./index.js 3:0-47
-        > ./c c
-     ./node_modules/z.js 20 bytes [built]
+      > ./c ./index.js 3:0-47
+      > ./c c
+      ./node_modules/z.js 20 bytes [built] [code generated]
     chunk (runtime: a) all-chunks/a.js (a) 121 bytes (javascript) 6.66 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
-        > ./a a
-     ./a.js 121 bytes [built]
-         + 8 hidden root modules
+      > ./a a
+      runtime modules 6.66 KiB 8 modules
+      ./a.js 121 bytes [built] [code generated]
     chunk (runtime: main) all-chunks/async-a.js (async-a) 121 bytes <{179}> ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [rendered]
-        > ./a ./index.js 1:0-47
-     ./a.js 121 bytes [built]
+      > ./a ./index.js 1:0-47
+      ./a.js 121 bytes [built] [code generated]
     chunk (runtime: a, b, main) all-chunks/954.js (id hint: vendors) 20 bytes <{179}> ={128}= ={282}= ={334}= ={390}= ={568}= ={767}= ={786}= ={794}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./a a
-        > ./b b
-     ./node_modules/y.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./a a
+      > ./b b
+      ./node_modules/y.js 20 bytes [built] [code generated]
 Child manual:
     Entrypoint main = manual/main.js
     Entrypoint a = manual/vendors.js manual/a.js
     Entrypoint b = manual/vendors.js manual/b.js
     Entrypoint c = manual/vendors.js manual/c.js
     chunk (runtime: b) manual/b.js (b) 112 bytes (javascript) 2.62 KiB (runtime) ={216}= [entry] [rendered]
-        > ./b b
-        > x b
-        > y b
-        > z b
-     ./b.js 72 bytes [built]
-         + 2 hidden root modules
-         + 2 hidden dependent modules
+      > ./b b
+      > x b
+      > y b
+      > z b
+      dependent modules 40 bytes [dependent] 2 modules
+      runtime modules 2.62 KiB 2 modules
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: a, main) manual/async-g.js (async-g) 54 bytes <{216}> <{786}> <{794}> [rendered]
-        > ./g ./a.js 6:0-47
-     ./g.js 34 bytes [built]
-         + 1 hidden dependent module
+      > ./g ./a.js 6:0-47
+      dependent modules 20 bytes [dependent] 1 module
+      ./g.js 34 bytes [built] [code generated]
     chunk (runtime: main) manual/main.js (main) 147 bytes (javascript) 5.49 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
-        > ./ main
-     ./index.js 147 bytes [built]
-         + 8 hidden root modules
+      > ./ main
+      runtime modules 5.49 KiB 8 modules
+      ./index.js 147 bytes [built] [code generated]
     chunk (runtime: a, b, c, main) manual/vendors.js (vendors) (id hint: vendors) 60 bytes <{179}> ={128}= ={334}= ={383}= ={459}= ={786}= ={794}= >{137}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./a a
-        > x a
-        > y a
-        > z a
-        > ./b b
-        > x b
-        > y b
-        > z b
-        > ./c c
-        > x c
-        > y c
-        > z c
-     ./node_modules/x.js 20 bytes [built]
-     ./node_modules/y.js 20 bytes [built]
-     ./node_modules/z.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./a a
+      > x a
+      > y a
+      > z a
+      > ./b b
+      > x b
+      > y b
+      > z b
+      > ./c c
+      > x c
+      > y c
+      > z c
+      ./node_modules/x.js 20 bytes [built] [code generated]
+      ./node_modules/y.js 20 bytes [built] [code generated]
+      ./node_modules/z.js 20 bytes [built] [code generated]
     chunk (runtime: main) manual/async-b.js (async-b) 112 bytes <{179}> ={216}= [rendered]
-        > ./b ./index.js 2:0-47
-     ./b.js 72 bytes [built]
-         + 2 hidden dependent modules
+      > ./b ./index.js 2:0-47
+      dependent modules 40 bytes [dependent] 2 modules
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: main) manual/async-c.js (async-c) 112 bytes <{179}> ={216}= [rendered]
-        > ./c ./index.js 3:0-47
-     ./c.js 72 bytes [built]
-         + 2 hidden dependent modules
+      > ./c ./index.js 3:0-47
+      dependent modules 40 bytes [dependent] 2 modules
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: c) manual/c.js (c) 112 bytes (javascript) 2.62 KiB (runtime) ={216}= [entry] [rendered]
-        > ./c c
-        > x c
-        > y c
-        > z c
-     ./c.js 72 bytes [built]
-         + 2 hidden root modules
-         + 2 hidden dependent modules
+      > ./c c
+      > x c
+      > y c
+      > z c
+      dependent modules 40 bytes [dependent] 2 modules
+      runtime modules 2.62 KiB 2 modules
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: a) manual/a.js (a) 161 bytes (javascript) 6.65 KiB (runtime) ={216}= >{137}< [entry] [rendered]
-        > ./a a
-        > x a
-        > y a
-        > z a
-     ./a.js + 1 modules 141 bytes [built]
-         + 8 hidden root modules
-         + 1 hidden dependent module
+      > ./a a
+      > x a
+      > y a
+      > z a
+      runtime modules 6.65 KiB 8 modules
+      dependent modules 20 bytes [dependent] 1 module
+      ./a.js + 1 modules 141 bytes [built] [code generated]
     chunk (runtime: main) manual/async-a.js (async-a) 161 bytes <{179}> ={216}= >{137}< [rendered]
-        > ./a ./index.js 1:0-47
-     ./a.js + 1 modules 141 bytes [built]
-         + 1 hidden dependent module
+      > ./a ./index.js 1:0-47
+      dependent modules 20 bytes [dependent] 1 module
+      ./a.js + 1 modules 141 bytes [built] [code generated]
 Child name-too-long:
     Entrypoint main = name-too-long/main.js
     Entrypoint aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = name-too-long/282.js name-too-long/954.js name-too-long/767.js name-too-long/390.js name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js
     Entrypoint bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = name-too-long/282.js name-too-long/954.js name-too-long/767.js name-too-long/568.js name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js
     Entrypoint cccccccccccccccccccccccccccccc = name-too-long/282.js name-too-long/769.js name-too-long/767.js name-too-long/568.js name-too-long/cccccccccccccccccccccccccccccc.js
     chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, main) name-too-long/async-g.js (async-g) 34 bytes <{282}> <{390}> <{751}> <{767}> <{794}> <{954}> ={568}= [rendered]
-        > ./g ./a.js 6:0-47
-     ./g.js 34 bytes [built]
+      > ./g ./a.js 6:0-47
+      ./g.js 34 bytes [built] [code generated]
     chunk (runtime: main) name-too-long/main.js (main) 147 bytes (javascript) 5.5 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
-        > ./ main
-     ./index.js 147 bytes [built]
-         + 8 hidden root modules
+      > ./ main
+      runtime modules 5.5 KiB 8 modules
+      ./index.js 147 bytes [built] [code generated]
     chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc, main) name-too-long/282.js (id hint: vendors) 20 bytes <{179}> ={334}= ={383}= ={390}= ={568}= ={658}= ={751}= ={766}= ={767}= ={769}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-        > ./c cccccccccccccccccccccccccccccc
-     ./node_modules/x.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      > ./c cccccccccccccccccccccccccccccc
+      ./node_modules/x.js 20 bytes [built] [code generated]
     chunk (runtime: main) name-too-long/async-b.js (async-b) 72 bytes <{179}> ={282}= ={568}= ={767}= ={954}= [rendered]
-        > ./b ./index.js 2:0-47
-     ./b.js 72 bytes [built]
+      > ./b ./index.js 2:0-47
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: main) name-too-long/async-c.js (async-c) 72 bytes <{179}> ={282}= ={568}= ={767}= ={769}= [rendered]
-        > ./c ./index.js 3:0-47
-     ./c.js 72 bytes [built]
+      > ./c ./index.js 3:0-47
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, main) name-too-long/390.js 20 bytes <{179}> ={282}= ={751}= ={767}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: default)
-        > ./a ./index.js 1:0-47
-        > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-     ./e.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      ./e.js 20 bytes [built] [code generated]
     chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc, main) name-too-long/568.js 20 bytes <{179}> <{282}> <{390}> <{751}> <{767}> <{794}> <{954}> ={137}= ={282}= ={334}= ={383}= ={658}= ={766}= ={767}= ={769}= ={954}= [initial] [rendered] split chunk (cache group: default)
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./g ./a.js 6:0-47
-        > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-        > ./c cccccccccccccccccccccccccccccc
-     ./f.js 20 bytes [built]
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./g ./a.js 6:0-47
+      > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      > ./c cccccccccccccccccccccccccccccc
+      ./f.js 20 bytes [built] [code generated]
     chunk (runtime: cccccccccccccccccccccccccccccc) name-too-long/cccccccccccccccccccccccccccccc.js (cccccccccccccccccccccccccccccc) 72 bytes (javascript) 2.6 KiB (runtime) ={282}= ={568}= ={767}= ={769}= [entry] [rendered]
-        > ./c cccccccccccccccccccccccccccccc
-     ./c.js 72 bytes [built]
-         + 2 hidden root modules
+      > ./c cccccccccccccccccccccccccccccc
+      runtime modules 2.6 KiB 2 modules
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) 121 bytes (javascript) 6.67 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
-        > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-     ./a.js 121 bytes [built]
-         + 8 hidden root modules
+      > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      runtime modules 6.67 KiB 8 modules
+      ./a.js 121 bytes [built] [code generated]
     chunk (runtime: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) 72 bytes (javascript) 2.6 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
-        > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-     ./b.js 72 bytes [built]
-         + 2 hidden root modules
+      > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      runtime modules 2.6 KiB 2 modules
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc, main) name-too-long/767.js 20 bytes <{179}> ={282}= ={334}= ={383}= ={390}= ={568}= ={658}= ={751}= ={766}= ={769}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: default)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-        > ./c cccccccccccccccccccccccccccccc
-     ./d.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      > ./c cccccccccccccccccccccccccccccc
+      ./d.js 20 bytes [built] [code generated]
     chunk (runtime: cccccccccccccccccccccccccccccc, main) name-too-long/769.js (id hint: vendors) 20 bytes <{179}> ={282}= ={383}= ={568}= ={658}= ={767}= [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./c ./index.js 3:0-47
-        > ./c cccccccccccccccccccccccccccccc
-     ./node_modules/z.js 20 bytes [built]
+      > ./c ./index.js 3:0-47
+      > ./c cccccccccccccccccccccccccccccc
+      ./node_modules/z.js 20 bytes [built] [code generated]
     chunk (runtime: main) name-too-long/async-a.js (async-a) 121 bytes <{179}> ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [rendered]
-        > ./a ./index.js 1:0-47
-     ./a.js 121 bytes [built]
+      > ./a ./index.js 1:0-47
+      ./a.js 121 bytes [built] [code generated]
     chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, main) name-too-long/954.js (id hint: vendors) 20 bytes <{179}> ={282}= ={334}= ={390}= ={568}= ={751}= ={766}= ={767}= ={794}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-     ./node_modules/y.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      ./node_modules/y.js 20 bytes [built] [code generated]
 Child custom-chunks-filter:
     Entrypoint main = custom-chunks-filter/main.js
     Entrypoint a = custom-chunks-filter/a.js
     Entrypoint b = custom-chunks-filter/282.js custom-chunks-filter/954.js custom-chunks-filter/568.js custom-chunks-filter/767.js custom-chunks-filter/b.js
     Entrypoint c = custom-chunks-filter/282.js custom-chunks-filter/769.js custom-chunks-filter/568.js custom-chunks-filter/767.js custom-chunks-filter/c.js
     chunk (runtime: b) custom-chunks-filter/b.js (b) 72 bytes (javascript) 2.6 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
-        > ./b b
-     ./b.js 72 bytes [built]
-         + 2 hidden root modules
+      > ./b b
+      runtime modules 2.6 KiB 2 modules
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: a, main) custom-chunks-filter/async-g.js (async-g) 34 bytes <{282}> <{767}> <{786}> <{794}> <{954}> ={568}= [rendered]
-        > ./g ./a.js 6:0-47
-     ./g.js 34 bytes [built]
+      > ./g ./a.js 6:0-47
+      ./g.js 34 bytes [built] [code generated]
     chunk (runtime: main) custom-chunks-filter/main.js (main) 147 bytes (javascript) 5.5 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
-        > ./ main
-     ./index.js 147 bytes [built]
-         + 8 hidden root modules
+      > ./ main
+      runtime modules 5.5 KiB 8 modules
+      ./index.js 147 bytes [built] [code generated]
     chunk (runtime: b, c, main) custom-chunks-filter/282.js (id hint: vendors) 20 bytes <{179}> ={128}= ={334}= ={383}= ={459}= ={568}= ={767}= ={769}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./b b
-        > ./c c
-     ./node_modules/x.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./b b
+      > ./c c
+      ./node_modules/x.js 20 bytes [built] [code generated]
     chunk (runtime: main) custom-chunks-filter/async-b.js (async-b) 72 bytes <{179}> ={282}= ={568}= ={767}= ={954}= [rendered]
-        > ./b ./index.js 2:0-47
-     ./b.js 72 bytes [built]
+      > ./b ./index.js 2:0-47
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: main) custom-chunks-filter/async-c.js (async-c) 72 bytes <{179}> ={282}= ={568}= ={767}= ={769}= [rendered]
-        > ./c ./index.js 3:0-47
-     ./c.js 72 bytes [built]
+      > ./c ./index.js 3:0-47
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: c) custom-chunks-filter/c.js (c) 72 bytes (javascript) 2.6 KiB (runtime) ={282}= ={568}= ={767}= ={769}= [entry] [rendered]
-        > ./c c
-     ./c.js 72 bytes [built]
-         + 2 hidden root modules
+      > ./c c
+      runtime modules 2.6 KiB 2 modules
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: a, b, c, main) custom-chunks-filter/568.js 20 bytes <{179}> <{282}> <{767}> <{786}> <{794}> <{954}> ={128}= ={137}= ={282}= ={334}= ={383}= ={459}= ={767}= ={769}= ={954}= [initial] [rendered] split chunk (cache group: default)
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./g ./a.js 6:0-47
-        > ./b b
-        > ./c c
-     ./f.js 20 bytes [built]
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./g ./a.js 6:0-47
+      > ./b b
+      > ./c c
+      ./f.js 20 bytes [built] [code generated]
     chunk (runtime: b, c, main) custom-chunks-filter/767.js 20 bytes <{179}> ={128}= ={282}= ={334}= ={383}= ={459}= ={568}= ={769}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: default)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./b b
-        > ./c c
-     ./d.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./b b
+      > ./c c
+      ./d.js 20 bytes [built] [code generated]
     chunk (runtime: c, main) custom-chunks-filter/769.js (id hint: vendors) 20 bytes <{179}> ={282}= ={383}= ={459}= ={568}= ={767}= [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./c ./index.js 3:0-47
-        > ./c c
-     ./node_modules/z.js 20 bytes [built]
+      > ./c ./index.js 3:0-47
+      > ./c c
+      ./node_modules/z.js 20 bytes [built] [code generated]
     chunk (runtime: a) custom-chunks-filter/a.js (a) 201 bytes (javascript) 5.49 KiB (runtime) >{137}< >{568}< [entry] [rendered]
-        > ./a a
-     ./a.js + 1 modules 141 bytes [built]
-         + 8 hidden root modules
-         + 3 hidden dependent modules
+      > ./a a
+      runtime modules 5.49 KiB 8 modules
+      dependent modules 60 bytes [dependent] 3 modules
+      ./a.js + 1 modules 141 bytes [built] [code generated]
     chunk (runtime: main) custom-chunks-filter/async-a.js (async-a) 141 bytes <{179}> ={282}= ={767}= ={954}= >{137}< >{568}< [rendered]
-        > ./a ./index.js 1:0-47
-     ./a.js + 1 modules 141 bytes [built]
+      > ./a ./index.js 1:0-47
+      ./a.js + 1 modules 141 bytes [built] [code generated]
     chunk (runtime: b, main) custom-chunks-filter/954.js (id hint: vendors) 20 bytes <{179}> ={128}= ={282}= ={334}= ={568}= ={767}= ={794}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./b b
-     ./node_modules/y.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./b b
+      ./node_modules/y.js 20 bytes [built] [code generated]
 Child custom-chunks-filter-in-cache-groups:
     Entrypoint main = custom-chunks-filter-in-cache-groups/main.js
     Entrypoint a = custom-chunks-filter-in-cache-groups/176.js custom-chunks-filter-in-cache-groups/a.js
     Entrypoint b = custom-chunks-filter-in-cache-groups/vendors.js custom-chunks-filter-in-cache-groups/b.js
     Entrypoint c = custom-chunks-filter-in-cache-groups/vendors.js custom-chunks-filter-in-cache-groups/c.js
     chunk (runtime: b) custom-chunks-filter-in-cache-groups/b.js (b) 112 bytes (javascript) 2.62 KiB (runtime) ={216}= [entry] [rendered]
-        > ./b b
-        > x b
-        > y b
-        > z b
-     ./b.js 72 bytes [built]
-         + 2 hidden root modules
-         + 2 hidden dependent modules
+      > ./b b
+      > x b
+      > y b
+      > z b
+      dependent modules 40 bytes [dependent] 2 modules
+      runtime modules 2.62 KiB 2 modules
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: a, main) custom-chunks-filter-in-cache-groups/async-g.js (async-g) 54 bytes <{176}> <{216}> <{786}> <{794}> [rendered]
-        > ./g ./a.js 6:0-47
-     ./g.js 34 bytes [built]
-         + 1 hidden dependent module
+      > ./g ./a.js 6:0-47
+      dependent modules 20 bytes [dependent] 1 module
+      ./g.js 34 bytes [built] [code generated]
     chunk (runtime: a) custom-chunks-filter-in-cache-groups/176.js (id hint: vendors) 60 bytes ={786}= >{137}< [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./a a
-        > x a
-        > y a
-        > z a
-     ./node_modules/x.js 20 bytes [built]
-     ./node_modules/y.js 20 bytes [built]
-     ./node_modules/z.js 20 bytes [built]
+      > ./a a
+      > x a
+      > y a
+      > z a
+      ./node_modules/x.js 20 bytes [built] [code generated]
+      ./node_modules/y.js 20 bytes [built] [code generated]
+      ./node_modules/z.js 20 bytes [built] [code generated]
     chunk (runtime: main) custom-chunks-filter-in-cache-groups/main.js (main) 147 bytes (javascript) 5.52 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
-        > ./ main
-     ./index.js 147 bytes [built]
-         + 8 hidden root modules
+      > ./ main
+      runtime modules 5.52 KiB 8 modules
+      ./index.js 147 bytes [built] [code generated]
     chunk (runtime: b, c, main) custom-chunks-filter-in-cache-groups/vendors.js (vendors) (id hint: vendors) 60 bytes <{179}> ={128}= ={334}= ={383}= ={459}= ={794}= >{137}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
-        > ./a ./index.js 1:0-47
-        > ./b ./index.js 2:0-47
-        > ./c ./index.js 3:0-47
-        > ./b b
-        > x b
-        > y b
-        > z b
-        > ./c c
-        > x c
-        > y c
-        > z c
-     ./node_modules/x.js 20 bytes [built]
-     ./node_modules/y.js 20 bytes [built]
-     ./node_modules/z.js 20 bytes [built]
+      > ./a ./index.js 1:0-47
+      > ./b ./index.js 2:0-47
+      > ./c ./index.js 3:0-47
+      > ./b b
+      > x b
+      > y b
+      > z b
+      > ./c c
+      > x c
+      > y c
+      > z c
+      ./node_modules/x.js 20 bytes [built] [code generated]
+      ./node_modules/y.js 20 bytes [built] [code generated]
+      ./node_modules/z.js 20 bytes [built] [code generated]
     chunk (runtime: main) custom-chunks-filter-in-cache-groups/async-b.js (async-b) 112 bytes <{179}> ={216}= [rendered]
-        > ./b ./index.js 2:0-47
-     ./b.js 72 bytes [built]
-         + 2 hidden dependent modules
+      > ./b ./index.js 2:0-47
+      dependent modules 40 bytes [dependent] 2 modules
+      ./b.js 72 bytes [built] [code generated]
     chunk (runtime: main) custom-chunks-filter-in-cache-groups/async-c.js (async-c) 112 bytes <{179}> ={216}= [rendered]
-        > ./c ./index.js 3:0-47
-     ./c.js 72 bytes [built]
-         + 2 hidden dependent modules
+      > ./c ./index.js 3:0-47
+      dependent modules 40 bytes [dependent] 2 modules
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: c) custom-chunks-filter-in-cache-groups/c.js (c) 112 bytes (javascript) 2.62 KiB (runtime) ={216}= [entry] [rendered]
-        > ./c c
-        > x c
-        > y c
-        > z c
-     ./c.js 72 bytes [built]
-         + 2 hidden root modules
-         + 2 hidden dependent modules
+      > ./c c
+      > x c
+      > y c
+      > z c
+      dependent modules 40 bytes [dependent] 2 modules
+      runtime modules 2.62 KiB 2 modules
+      ./c.js 72 bytes [built] [code generated]
     chunk (runtime: a) custom-chunks-filter-in-cache-groups/a.js (a) 161 bytes (javascript) 6.68 KiB (runtime) ={176}= >{137}< [entry] [rendered]
-        > ./a a
-        > x a
-        > y a
-        > z a
-     ./a.js + 1 modules 141 bytes [built]
-         + 8 hidden root modules
-         + 1 hidden dependent module
+      > ./a a
+      > x a
+      > y a
+      > z a
+      runtime modules 6.68 KiB 8 modules
+      dependent modules 20 bytes [dependent] 1 module
+      ./a.js + 1 modules 141 bytes [built] [code generated]
     chunk (runtime: main) custom-chunks-filter-in-cache-groups/async-a.js (async-a) 161 bytes <{179}> ={216}= >{137}< [rendered]
-        > ./a ./index.js 1:0-47
-     ./a.js + 1 modules 141 bytes [built]
-         + 1 hidden dependent module"
+      > ./a ./index.js 1:0-47
+      dependent modules 20 bytes [dependent] 1 module
+      ./a.js + 1 modules 141 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-automatic-name 1`] = `
 "Entrypoint main = main.js
 chunk (runtime: main) async-a.js (async-a) 92 bytes <{main}> ={common-d_js}= ={common-node_modules_x_js}= ={common-node_modules_y_js}= [rendered]
-    > ./a ./index.js 1:0-47
- ./a.js + 1 modules 92 bytes [built]
+  > ./a ./index.js 1:0-47
+  ./a.js + 1 modules 92 bytes [built] [code generated]
 chunk (runtime: main) async-b.js (async-b) 72 bytes <{main}> ={common-d_js}= ={common-f_js}= ={common-node_modules_x_js}= ={common-node_modules_y_js}= [rendered]
-    > ./b ./index.js 2:0-47
- ./b.js 72 bytes [built]
+  > ./b ./index.js 2:0-47
+  ./b.js 72 bytes [built] [code generated]
 chunk (runtime: main) async-c.js (async-c) 72 bytes <{main}> ={common-d_js}= ={common-f_js}= ={common-node_modules_x_js}= ={common-node_modules_z_js}= [rendered]
-    > ./c ./index.js 3:0-47
- ./c.js 72 bytes [built]
+  > ./c ./index.js 3:0-47
+  ./c.js 72 bytes [built] [code generated]
 chunk (runtime: main) common-d_js.js (id hint: common) 20 bytes <{main}> ={async-a}= ={async-b}= ={async-c}= ={common-f_js}= ={common-node_modules_x_js}= ={common-node_modules_y_js}= ={common-node_modules_z_js}= [rendered] split chunk (cache group: a)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
- ./d.js 20 bytes [built]
+  > ./a ./index.js 1:0-47
+  > ./b ./index.js 2:0-47
+  > ./c ./index.js 3:0-47
+  ./d.js 20 bytes [built] [code generated]
 chunk (runtime: main) common-f_js.js (id hint: common) 20 bytes <{main}> ={async-b}= ={async-c}= ={common-d_js}= ={common-node_modules_x_js}= ={common-node_modules_y_js}= ={common-node_modules_z_js}= [rendered] split chunk (cache group: a)
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
- ./f.js 20 bytes [built]
+  > ./b ./index.js 2:0-47
+  > ./c ./index.js 3:0-47
+  ./f.js 20 bytes [built] [code generated]
 chunk (runtime: main) common-node_modules_x_js.js (id hint: common) 20 bytes <{main}> ={async-a}= ={async-b}= ={async-c}= ={common-d_js}= ={common-f_js}= ={common-node_modules_y_js}= ={common-node_modules_z_js}= [rendered] split chunk (cache group: b)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
- ./node_modules/x.js 20 bytes [built]
+  > ./a ./index.js 1:0-47
+  > ./b ./index.js 2:0-47
+  > ./c ./index.js 3:0-47
+  ./node_modules/x.js 20 bytes [built] [code generated]
 chunk (runtime: main) common-node_modules_y_js.js (id hint: common) 20 bytes <{main}> ={async-a}= ={async-b}= ={common-d_js}= ={common-f_js}= ={common-node_modules_x_js}= [rendered] split chunk (cache group: b)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
- ./node_modules/y.js 20 bytes [built]
+  > ./a ./index.js 1:0-47
+  > ./b ./index.js 2:0-47
+  ./node_modules/y.js 20 bytes [built] [code generated]
 chunk (runtime: main) common-node_modules_z_js.js (id hint: common) 20 bytes <{main}> ={async-c}= ={common-d_js}= ={common-f_js}= ={common-node_modules_x_js}= [rendered] split chunk (cache group: b)
-    > ./c ./index.js 3:0-47
- ./node_modules/z.js 20 bytes [built]
+  > ./c ./index.js 3:0-47
+  ./node_modules/z.js 20 bytes [built] [code generated]
 chunk (runtime: main) main.js (main) 147 bytes (javascript) 5.41 KiB (runtime) >{async-a}< >{async-b}< >{async-c}< >{common-d_js}< >{common-f_js}< >{common-node_modules_x_js}< >{common-node_modules_y_js}< >{common-node_modules_z_js}< [entry] [rendered]
-    > ./ main
- ./index.js 147 bytes [built]
-     + 8 hidden root modules"
+  > ./ main
+  runtime modules 5.41 KiB 8 modules
+  ./index.js 147 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-chunk-name 1`] = `
 "Entrypoint main = default/main.js
 chunk (runtime: main) default/main.js (main) 192 bytes (javascript) 5.46 KiB (runtime) >{334}< >{709}< >{794}< [entry] [rendered]
-    > ./ main
- ./index.js 192 bytes [built]
-     + 8 hidden chunk modules
+  > ./ main
+  runtime modules 5.46 KiB 8 modules
+  ./index.js 192 bytes [built] [code generated]
 chunk (runtime: main) default/async-b.js (async-b) (id hint: vendors) 122 bytes <{179}> [rendered] reused as split chunk (cache group: defaultVendors)
-    > b ./index.js 2:0-45
- ./node_modules/b.js 122 bytes [built]
+  > b ./index.js 2:0-45
+  ./node_modules/b.js 122 bytes [built] [code generated]
 chunk (runtime: main) default/async-c-1.js (async-c-1) (id hint: vendors) 122 bytes <{179}> [rendered] reused as split chunk (cache group: defaultVendors)
-    > c ./index.js 3:0-47
-    > c ./index.js 4:0-47
- ./node_modules/c.js 122 bytes [built]
+  > c ./index.js 3:0-47
+  > c ./index.js 4:0-47
+  ./node_modules/c.js 122 bytes [built] [code generated]
 chunk (runtime: main) default/async-a.js (async-a) 20 bytes <{179}> [rendered]
-    > a ./index.js 1:0-45
- ./node_modules/a.js 20 bytes [built]"
+  > a ./index.js 1:0-45
+  ./node_modules/a.js 20 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-combinations 1`] = `
 "Entrypoint main = main.js
 chunk (runtime: main) async-d.js (async-d) 101 bytes <{179}> [rendered]
-    > ./d ./index.js 4:0-47
- ./d.js 34 bytes [built]
-     + 1 hidden dependent module
+  > ./d ./index.js 4:0-47
+  dependent modules 67 bytes [dependent] 1 module
+  ./d.js 34 bytes [built] [code generated]
 chunk (runtime: main) async-g.js (async-g) 101 bytes <{179}> [rendered]
-    > ./g ./index.js 7:0-47
- ./g.js 34 bytes [built]
-     + 1 hidden dependent module
+  > ./g ./index.js 7:0-47
+  dependent modules 67 bytes [dependent] 1 module
+  ./g.js 34 bytes [built] [code generated]
 chunk (runtime: main) main.js (main) 343 bytes (javascript) 5.79 KiB (runtime) >{31}< >{137}< >{206}< >{334}< >{383}< >{449}< >{794}< >{804}< [entry] [rendered]
-    > ./ main
- ./index.js 343 bytes [built]
-     + 9 hidden root modules
+  > ./ main
+  runtime modules 5.79 KiB 9 modules
+  ./index.js 343 bytes [built] [code generated]
 chunk (runtime: main) async-f.js (async-f) 101 bytes <{179}> [rendered]
-    > ./f ./index.js 6:0-47
- ./f.js 34 bytes [built]
-     + 1 hidden dependent module
+  > ./f ./index.js 6:0-47
+  dependent modules 67 bytes [dependent] 1 module
+  ./f.js 34 bytes [built] [code generated]
 chunk (runtime: main) async-b.js (async-b) 48 bytes <{179}> ={804}= [rendered]
-    > ./b ./index.js 2:0-47
- ./b.js 48 bytes [built]
+  > ./b ./index.js 2:0-47
+  ./b.js 48 bytes [built] [code generated]
 chunk (runtime: main) async-c.js (async-c) 101 bytes <{179}> [rendered]
-    > ./c ./index.js 3:0-47
- ./c.js 34 bytes [built]
-     + 1 hidden dependent module
+  > ./c ./index.js 3:0-47
+  dependent modules 67 bytes [dependent] 1 module
+  ./c.js 34 bytes [built] [code generated]
 chunk (runtime: main) async-e.js (async-e) 101 bytes <{179}> [rendered]
-    > ./e ./index.js 5:0-47
- ./e.js 34 bytes [built]
-     + 1 hidden dependent module
+  > ./e ./index.js 5:0-47
+  dependent modules 67 bytes [dependent] 1 module
+  ./e.js 34 bytes [built] [code generated]
 chunk (runtime: main) async-a.js (async-a) 48 bytes <{179}> ={804}= [rendered]
-    > ./a ./index.js 1:0-47
- ./a.js 48 bytes [built]
+  > ./a ./index.js 1:0-47
+  ./a.js 48 bytes [built] [code generated]
 chunk (runtime: main) 804.js 134 bytes <{179}> ={334}= ={794}= [rendered] split chunk (cache group: default)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
- ./x.js 67 bytes [built]
- ./y.js 67 bytes [built]"
+  > ./a ./index.js 1:0-47
+  > ./b ./index.js 2:0-47
+  ./x.js 67 bytes [built] [code generated]
+  ./y.js 67 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-6413 1`] = `
 "Entrypoint main = main.js
 chunk (runtime: main) main.js (main) 147 bytes (javascript) 5.17 KiB (runtime) >{282}< >{334}< >{383}< >{543}< >{794}< [entry] [rendered]
-    > ./ main
- ./index.js 147 bytes [built]
-     + 7 hidden root modules
+  > ./ main
+  runtime modules 5.17 KiB 7 modules
+  ./index.js 147 bytes [built] [code generated]
 chunk (runtime: main) 282.js (id hint: vendors) 20 bytes <{179}> ={334}= ={383}= ={543}= ={794}= [rendered] split chunk (cache group: defaultVendors)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
- ./node_modules/x.js 20 bytes [built]
+  > ./a ./index.js 1:0-47
+  > ./b ./index.js 2:0-47
+  > ./c ./index.js 3:0-47
+  ./node_modules/x.js 20 bytes [built] [code generated]
 chunk (runtime: main) async-b.js (async-b) 19 bytes <{179}> ={282}= ={543}= [rendered]
-    > ./b ./index.js 2:0-47
- ./b.js 19 bytes [built]
+  > ./b ./index.js 2:0-47
+  ./b.js 19 bytes [built] [code generated]
 chunk (runtime: main) async-c.js (async-c) 19 bytes <{179}> ={282}= ={543}= [rendered]
-    > ./c ./index.js 3:0-47
- ./c.js 19 bytes [built]
+  > ./c ./index.js 3:0-47
+  ./c.js 19 bytes [built] [code generated]
 chunk (runtime: main) 543.js 11 bytes <{179}> ={282}= ={334}= ={383}= ={794}= [rendered] split chunk (cache group: default)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
- ./common.js 11 bytes [built]
+  > ./a ./index.js 1:0-47
+  > ./b ./index.js 2:0-47
+  > ./c ./index.js 3:0-47
+  ./common.js 11 bytes [built] [code generated]
 chunk (runtime: main) async-a.js (async-a) 19 bytes <{179}> ={282}= ={543}= [rendered]
-    > ./a ./index.js 1:0-47
- ./a.js 19 bytes [built]"
+  > ./a ./index.js 1:0-47
+  ./a.js 19 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-6696 1`] = `
 "Entrypoint main = vendors.js main.js
 chunk (runtime: main) main.js (main) 110 bytes (javascript) 6.33 KiB (runtime) ={216}= >{334}< >{794}< [entry] [rendered]
-    > ./ main
- ./index.js 110 bytes [built]
-     + 7 hidden root modules
+  > ./ main
+  runtime modules 6.33 KiB 7 modules
+  ./index.js 110 bytes [built] [code generated]
 chunk (runtime: main) vendors.js (vendors) (id hint: vendors) 20 bytes ={179}= >{334}< >{794}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
-    > ./ main
- ./node_modules/y.js 20 bytes [built]
+  > ./ main
+  ./node_modules/y.js 20 bytes [built] [code generated]
 chunk (runtime: main) async-b.js (async-b) 32 bytes <{179}> <{216}> [rendered]
-    > ./b ./index.js 3:0-47
- ./b.js 12 bytes [built]
-     + 1 hidden dependent module
+  > ./b ./index.js 3:0-47
+  dependent modules 20 bytes [dependent] 1 module
+  ./b.js 12 bytes [built] [code generated]
 chunk (runtime: main) async-a.js (async-a) 32 bytes <{179}> <{216}> [rendered]
-    > ./a ./index.js 2:0-47
- ./a.js 12 bytes [built]
-     + 1 hidden dependent module"
+  > ./a ./index.js 2:0-47
+  dependent modules 20 bytes [dependent] 1 module
+  ./a.js 12 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-7401 1`] = `
@@ -3653,260 +3741,240 @@ exports[`StatsTestCases should print correct stats for split-chunks-issue-7401 1
 Entrypoint b = b.js
 Chunk Group c = 282.js c.js
 chunk (runtime: b) b.js (b) 43 bytes (javascript) 5.13 KiB (runtime) >{282}< >{459}< [entry] [rendered]
-    > ./b b
- ./b.js 43 bytes [built]
-     + 7 hidden root modules
+  > ./b b
+  runtime modules 5.13 KiB 7 modules
+  ./b.js 43 bytes [built] [code generated]
 chunk (runtime: a, b) 282.js (id hint: vendors) 20 bytes <{128}> ={459}= ={786}= [initial] [rendered] split chunk (cache group: defaultVendors)
-    > ./c ./b.js 1:0-41
-    > ./a a
- ./node_modules/x.js 20 bytes [built]
+  > ./c ./b.js 1:0-41
+  > ./a a
+  ./node_modules/x.js 20 bytes [built] [code generated]
 chunk (runtime: b) c.js (c) 12 bytes <{128}> ={282}= [rendered]
-    > ./c ./b.js 1:0-41
- ./c.js 12 bytes [built]
+  > ./c ./b.js 1:0-41
+  ./c.js 12 bytes [built] [code generated]
 chunk (runtime: a) a.js (a) 12 bytes (javascript) 2.58 KiB (runtime) ={282}= [entry] [rendered]
-    > ./a a
- ./a.js 12 bytes [built]
-     + 2 hidden root modules"
+  > ./a a
+  runtime modules 2.58 KiB 2 modules
+  ./a.js 12 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-keep-remaining-size 1`] = `
 "Entrypoint main = default/main.js
 chunk (runtime: main) default/async-d.js (async-d) 58 bytes <{179}> ={782}= [rendered]
-    > ./d ./index.js 4:0-47
- ./d.js 58 bytes [built]
+  > ./d ./index.js 4:0-47
+  ./d.js 58 bytes [built] [code generated]
 chunk (runtime: main) default/main.js (main) 196 bytes (javascript) 5.75 KiB (runtime) >{31}< >{334}< >{383}< >{782}< >{794}< >{821}< [entry] [rendered]
-    > ./ main
- ./index.js 196 bytes [built]
-     + 9 hidden chunk modules
+  > ./ main
+  runtime modules 5.75 KiB 9 modules
+  ./index.js 196 bytes [built] [code generated]
 chunk (runtime: main) default/async-b.js (async-b) 39 bytes <{179}> ={821}= [rendered]
-    > ./b ./index.js 2:0-47
- ./b.js 39 bytes [built]
+  > ./b ./index.js 2:0-47
+  ./b.js 39 bytes [built] [code generated]
 chunk (runtime: main) default/async-c.js (async-c) 39 bytes <{179}> ={821}= [rendered]
-    > ./c ./index.js 3:0-47
- ./c.js 39 bytes [built]
+  > ./c ./index.js 3:0-47
+  ./c.js 39 bytes [built] [code generated]
 chunk (runtime: main) default/782.js (id hint: vendors) 204 bytes <{179}> ={31}= [rendered] split chunk (cache group: defaultVendors)
-    > ./d ./index.js 4:0-47
- ./node_modules/shared.js?3 102 bytes [built]
- ./node_modules/shared.js?4 102 bytes [built]
+  > ./d ./index.js 4:0-47
+  ./node_modules/shared.js?3 102 bytes [built] [code generated]
+  ./node_modules/shared.js?4 102 bytes [built] [code generated]
 chunk (runtime: main) default/async-a.js (async-a) 141 bytes <{179}> [rendered]
-    > ./a ./index.js 1:0-47
- ./a.js 39 bytes [built]
- ./node_modules/shared.js?1 102 bytes [built]
+  > ./a ./index.js 1:0-47
+  ./a.js 39 bytes [built] [code generated]
+  ./node_modules/shared.js?1 102 bytes [dependent] [built] [code generated]
 chunk (runtime: main) default/821.js (id hint: vendors) 102 bytes <{179}> ={334}= ={383}= [rendered] split chunk (cache group: defaultVendors)
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
- ./node_modules/shared.js?2 102 bytes [built]"
+  > ./b ./index.js 2:0-47
+  > ./c ./index.js 3:0-47
+  ./node_modules/shared.js?2 102 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-max-size 1`] = `
 "Child production:
     Entrypoint main = prod-869.js prod-410.js prod-main-10f51d07.js prod-main-3c98d7c3.js prod-main-6bb16544.js prod-main-1df31ce3.js prod-main-2f7dcf2e.js prod-main-e7c5ace7.js prod-main-5cfff2c6.js prod-main-1443e336.js prod-main-77a8c116.js prod-main-89a43a0f.js prod-main-12217e1d.js
     chunk (runtime: main) prod-main-6bb16544.js (main-6bb16544) 1.57 KiB ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./in-some-directory/very-big.js?1 1.57 KiB [built]
+      > ./ main
+      ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
     chunk (runtime: main) prod-main-77a8c116.js (main-77a8c116) 1.57 KiB ={1}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./very-big.js?2 1.57 KiB [built]
+      > ./ main
+      ./very-big.js?2 1.57 KiB [built] [code generated]
     chunk (runtime: main) prod-main-3c98d7c3.js (main-3c98d7c3) 536 bytes ={1}= ={59}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./in-some-directory/big.js?1 268 bytes [built]
-     ./in-some-directory/small.js?1 67 bytes [built]
-     ./in-some-directory/small.js?2 67 bytes [built]
-     ./in-some-directory/small.js?3 67 bytes [built]
-     ./in-some-directory/small.js?4 67 bytes [built]
+      > ./ main
+      ./in-some-directory/big.js?1 268 bytes [built] [code generated]
+      ./in-some-directory/small.js?1 67 bytes [built] [code generated]
+      ./in-some-directory/small.js?2 67 bytes [built] [code generated]
+      ./in-some-directory/small.js?3 67 bytes [built] [code generated]
+      ./in-some-directory/small.js?4 67 bytes [built] [code generated]
     chunk (runtime: main) prod-main-2f7dcf2e.js (main-2f7dcf2e) 603 bytes ={1}= ={59}= ={198}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./inner-module/small.js?1 67 bytes [built]
-     ./inner-module/small.js?2 67 bytes [built]
-     ./inner-module/small.js?3 67 bytes [built]
-     ./inner-module/small.js?4 67 bytes [built]
-     ./inner-module/small.js?5 67 bytes [built]
-     ./inner-module/small.js?6 67 bytes [built]
-     ./inner-module/small.js?7 67 bytes [built]
-     ./inner-module/small.js?8 67 bytes [built]
-     ./inner-module/small.js?9 67 bytes [built]
+      > ./ main
+      ./inner-module/small.js?1 67 bytes [built] [code generated]
+      ./inner-module/small.js?2 67 bytes [built] [code generated]
+      ./inner-module/small.js?3 67 bytes [built] [code generated]
+      ./inner-module/small.js?4 67 bytes [built] [code generated]
+      ./inner-module/small.js?5 67 bytes [built] [code generated]
+      ./inner-module/small.js?6 67 bytes [built] [code generated]
+      ./inner-module/small.js?7 67 bytes [built] [code generated]
+      ./inner-module/small.js?8 67 bytes [built] [code generated]
+      ./inner-module/small.js?9 67 bytes [built] [code generated]
     chunk (runtime: main) prod-main-89a43a0f.js (main-89a43a0f) 1.57 KiB ={1}= ={59}= ={198}= ={204}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./very-big.js?3 1.57 KiB [built]
+      > ./ main
+      ./very-big.js?3 1.57 KiB [built] [code generated]
     chunk (runtime: main) prod-main-e7c5ace7.js (main-e7c5ace7) 603 bytes ={1}= ={59}= ={198}= ={204}= ={318}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./small.js?1 67 bytes [built]
-     ./small.js?2 67 bytes [built]
-     ./small.js?3 67 bytes [built]
-     ./small.js?4 67 bytes [built]
-     ./small.js?5 67 bytes [built]
-     ./small.js?6 67 bytes [built]
-     ./small.js?7 67 bytes [built]
-     ./small.js?8 67 bytes [built]
-     ./small.js?9 67 bytes [built]
+      > ./ main
+      ./small.js?1 67 bytes [built] [code generated]
+      ./small.js?2 67 bytes [built] [code generated]
+      ./small.js?3 67 bytes [built] [code generated]
+      ./small.js?4 67 bytes [built] [code generated]
+      ./small.js?5 67 bytes [built] [code generated]
+      ./small.js?6 67 bytes [built] [code generated]
+      ./small.js?7 67 bytes [built] [code generated]
+      ./small.js?8 67 bytes [built] [code generated]
+      ./small.js?9 67 bytes [built] [code generated]
     chunk (runtime: main) prod-main-1443e336.js (main-1443e336) 603 bytes ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./subfolder/small.js?1 67 bytes [built]
-     ./subfolder/small.js?2 67 bytes [built]
-     ./subfolder/small.js?3 67 bytes [built]
-     ./subfolder/small.js?4 67 bytes [built]
-     ./subfolder/small.js?5 67 bytes [built]
-     ./subfolder/small.js?6 67 bytes [built]
-     ./subfolder/small.js?7 67 bytes [built]
-     ./subfolder/small.js?8 67 bytes [built]
-     ./subfolder/small.js?9 67 bytes [built]
+      > ./ main
+      ./subfolder/small.js?1 67 bytes [built] [code generated]
+      ./subfolder/small.js?2 67 bytes [built] [code generated]
+      ./subfolder/small.js?3 67 bytes [built] [code generated]
+      ./subfolder/small.js?4 67 bytes [built] [code generated]
+      ./subfolder/small.js?5 67 bytes [built] [code generated]
+      ./subfolder/small.js?6 67 bytes [built] [code generated]
+      ./subfolder/small.js?7 67 bytes [built] [code generated]
+      ./subfolder/small.js?8 67 bytes [built] [code generated]
+      ./subfolder/small.js?9 67 bytes [built] [code generated]
     chunk (runtime: main) prod-410.js (id hint: vendors) 1.57 KiB ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./ main
-     ./node_modules/very-big.js?1 1.57 KiB [built]
+      > ./ main
+      ./node_modules/very-big.js?1 1.57 KiB [built] [code generated]
     chunk (runtime: main) prod-main-5cfff2c6.js (main-5cfff2c6) 536 bytes ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./subfolder/big.js?1 268 bytes [built]
-     ./subfolder/big.js?2 268 bytes [built]
+      > ./ main
+      ./subfolder/big.js?1 268 bytes [built] [code generated]
+      ./subfolder/big.js?2 268 bytes [built] [code generated]
     chunk (runtime: main) prod-main-1df31ce3.js (main-1df31ce3) 1.19 KiB ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./index.js 1.19 KiB [built]
+      > ./ main
+      ./index.js 1.19 KiB [built] [code generated]
     chunk (runtime: main) prod-main-10f51d07.js (main-10f51d07) 536 bytes ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./big.js?1 268 bytes [built]
-     ./big.js?2 268 bytes [built]
+      > ./ main
+      ./big.js?1 268 bytes [built] [code generated]
+      ./big.js?2 268 bytes [built] [code generated]
     chunk (runtime: main) prod-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.17 KiB (runtime) ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={869}= [entry] [rendered]
-        > ./ main
-     ./very-big.js?1 1.57 KiB [built]
-         + 4 hidden root modules
+      > ./ main
+      runtime modules 3.17 KiB 4 modules
+      ./very-big.js?1 1.57 KiB [built] [code generated]
     chunk (runtime: main) prod-869.js (id hint: vendors) 402 bytes ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./ main
-     ./node_modules/big.js?1 268 bytes [built]
-     ./node_modules/small.js?1 67 bytes [built]
-     ./node_modules/small.js?2 67 bytes [built]
+      > ./ main
+      ./node_modules/big.js?1 268 bytes [built] [code generated]
+      ./node_modules/small.js?1 67 bytes [built] [code generated]
+      ./node_modules/small.js?2 67 bytes [built] [code generated]
 Child development:
     Entrypoint main = dev-vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2.js dev-vendors-node_modules_very-big_js_1.js dev-main-big_js-1.js dev-main-in-some-directory_b.js dev-main-in-some-directory_very-big_js-8d76cf03.js dev-main-index_js-41f5a26e.js dev-main-inner-module_small_js-3.js dev-main-small_js-1.js dev-main-subfolder_big_js-b.js dev-main-subfolder_small_js-1.js dev-main-very-big_js-08cf55cf.js dev-main-very-big_js-4647fb9d.js dev-main-very-big_js-62f7f644.js
     chunk dev-main-big_js-1.js (main-big_js-1) 536 bytes ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
-        > ./ main
-     ./big.js?1 268 bytes [built]
-     ./big.js?2 268 bytes [built]
+      > ./ main
+      ./big.js?1 268 bytes [built] [code generated]
+      ./big.js?2 268 bytes [built] [code generated]
     chunk dev-main-in-some-directory_b.js (main-in-some-directory_b) 536 bytes ={main-big_js-1}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
-        > ./ main
-     ./in-some-directory/big.js?1 268 bytes [built]
-     ./in-some-directory/small.js?1 67 bytes [built]
-     ./in-some-directory/small.js?2 67 bytes [built]
-     ./in-some-directory/small.js?3 67 bytes [built]
-     ./in-some-directory/small.js?4 67 bytes [built]
+      > ./ main
+      ./in-some-directory/big.js?1 268 bytes [built] [code generated]
+      ./in-some-directory/small.js?1 67 bytes [built] [code generated]
+      ./in-some-directory/small.js?2 67 bytes [built] [code generated]
+      ./in-some-directory/small.js?3 67 bytes [built] [code generated]
+      ./in-some-directory/small.js?4 67 bytes [built] [code generated]
     chunk dev-main-in-some-directory_very-big_js-8d76cf03.js (main-in-some-directory_very-big_js-8d76cf03) 1.57 KiB ={main-big_js-1}= ={main-in-some-directory_b}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
-        > ./ main
-     ./in-some-directory/very-big.js?1 1.57 KiB [built]
+      > ./ main
+      ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
     chunk dev-main-index_js-41f5a26e.js (main-index_js-41f5a26e) 1.19 KiB ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
-        > ./ main
-     ./index.js 1.19 KiB [built]
+      > ./ main
+      ./index.js 1.19 KiB [built] [code generated]
     chunk dev-main-inner-module_small_js-3.js (main-inner-module_small_js-3) 603 bytes ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
-        > ./ main
-     ./inner-module/small.js?1 67 bytes [built]
-     ./inner-module/small.js?2 67 bytes [built]
-     ./inner-module/small.js?3 67 bytes [built]
-     ./inner-module/small.js?4 67 bytes [built]
-     ./inner-module/small.js?5 67 bytes [built]
-     ./inner-module/small.js?6 67 bytes [built]
-     ./inner-module/small.js?7 67 bytes [built]
-     ./inner-module/small.js?8 67 bytes [built]
-     ./inner-module/small.js?9 67 bytes [built]
+      > ./ main
+      ./inner-module/small.js?1 67 bytes [built] [code generated]
+      ./inner-module/small.js?2 67 bytes [built] [code generated]
+      ./inner-module/small.js?3 67 bytes [built] [code generated]
+      ./inner-module/small.js?4 67 bytes [built] [code generated]
+      ./inner-module/small.js?5 67 bytes [built] [code generated]
+      ./inner-module/small.js?6 67 bytes [built] [code generated]
+      ./inner-module/small.js?7 67 bytes [built] [code generated]
+      ./inner-module/small.js?8 67 bytes [built] [code generated]
+      ./inner-module/small.js?9 67 bytes [built] [code generated]
     chunk dev-main-small_js-1.js (main-small_js-1) 603 bytes ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
-        > ./ main
-     ./small.js?1 67 bytes [built]
-     ./small.js?2 67 bytes [built]
-     ./small.js?3 67 bytes [built]
-     ./small.js?4 67 bytes [built]
-     ./small.js?5 67 bytes [built]
-     ./small.js?6 67 bytes [built]
-     ./small.js?7 67 bytes [built]
-     ./small.js?8 67 bytes [built]
-     ./small.js?9 67 bytes [built]
+      > ./ main
+      ./small.js?1 67 bytes [built] [code generated]
+      ./small.js?2 67 bytes [built] [code generated]
+      ./small.js?3 67 bytes [built] [code generated]
+      ./small.js?4 67 bytes [built] [code generated]
+      ./small.js?5 67 bytes [built] [code generated]
+      ./small.js?6 67 bytes [built] [code generated]
+      ./small.js?7 67 bytes [built] [code generated]
+      ./small.js?8 67 bytes [built] [code generated]
+      ./small.js?9 67 bytes [built] [code generated]
     chunk dev-main-subfolder_big_js-b.js (main-subfolder_big_js-b) 536 bytes ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
-        > ./ main
-     ./subfolder/big.js?1 268 bytes [built]
-     ./subfolder/big.js?2 268 bytes [built]
+      > ./ main
+      ./subfolder/big.js?1 268 bytes [built] [code generated]
+      ./subfolder/big.js?2 268 bytes [built] [code generated]
     chunk dev-main-subfolder_small_js-1.js (main-subfolder_small_js-1) 603 bytes ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
-        > ./ main
-     ./subfolder/small.js?1 67 bytes [built]
-     ./subfolder/small.js?2 67 bytes [built]
-     ./subfolder/small.js?3 67 bytes [built]
-     ./subfolder/small.js?4 67 bytes [built]
-     ./subfolder/small.js?5 67 bytes [built]
-     ./subfolder/small.js?6 67 bytes [built]
-     ./subfolder/small.js?7 67 bytes [built]
-     ./subfolder/small.js?8 67 bytes [built]
-     ./subfolder/small.js?9 67 bytes [built]
+      > ./ main
+      ./subfolder/small.js?1 67 bytes [built] [code generated]
+      ./subfolder/small.js?2 67 bytes [built] [code generated]
+      ./subfolder/small.js?3 67 bytes [built] [code generated]
+      ./subfolder/small.js?4 67 bytes [built] [code generated]
+      ./subfolder/small.js?5 67 bytes [built] [code generated]
+      ./subfolder/small.js?6 67 bytes [built] [code generated]
+      ./subfolder/small.js?7 67 bytes [built] [code generated]
+      ./subfolder/small.js?8 67 bytes [built] [code generated]
+      ./subfolder/small.js?9 67 bytes [built] [code generated]
     chunk dev-main-very-big_js-08cf55cf.js (main-very-big_js-08cf55cf) 1.57 KiB ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-4647fb9d}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
-        > ./ main
-     ./very-big.js?2 1.57 KiB [built]
+      > ./ main
+      ./very-big.js?2 1.57 KiB [built] [code generated]
     chunk dev-main-very-big_js-4647fb9d.js (main-very-big_js-4647fb9d) 1.57 KiB ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
-        > ./ main
-     ./very-big.js?3 1.57 KiB [built]
+      > ./ main
+      ./very-big.js?3 1.57 KiB [built] [code generated]
     chunk dev-main-very-big_js-62f7f644.js (main-very-big_js-62f7f644) 1.57 KiB (javascript) 3.81 KiB (runtime) ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [entry] [rendered]
-        > ./ main
-     ./very-big.js?1 1.57 KiB [built]
-         + 5 hidden root modules
+      > ./ main
+      runtime modules 3.81 KiB 5 modules
+      ./very-big.js?1 1.57 KiB [built] [code generated]
     chunk dev-vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2.js (id hint: vendors) 402 bytes ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./ main
-     ./node_modules/big.js?1 268 bytes [built]
-     ./node_modules/small.js?1 67 bytes [built]
-     ./node_modules/small.js?2 67 bytes [built]
+      > ./ main
+      ./node_modules/big.js?1 268 bytes [built] [code generated]
+      ./node_modules/small.js?1 67 bytes [built] [code generated]
+      ./node_modules/small.js?2 67 bytes [built] [code generated]
     chunk dev-vendors-node_modules_very-big_js_1.js (id hint: vendors) 1.57 KiB ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./ main
-     ./node_modules/very-big.js?1 1.57 KiB [built]
+      > ./ main
+      ./node_modules/very-big.js?1 1.57 KiB [built] [code generated]
 Child switched:
     Entrypoint main = switched-247.js switched-main-7aeafcb2.js switched-main-6bb16544.js switched-main-1df31ce3.js switched-main-879072e3.js switched-main-77a8c116.js switched-main-89a43a0f.js switched-main-12217e1d.js
     chunk (runtime: main) switched-main-6bb16544.js (main-6bb16544) 1.57 KiB ={59}= ={247}= ={318}= ={520}= ={581}= ={663}= ={997}= [initial] [rendered]
-        > ./ main
-     ./in-some-directory/very-big.js?1 1.57 KiB [built]
+      > ./ main
+      ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
     chunk (runtime: main) switched-main-77a8c116.js (main-77a8c116) 1.57 KiB ={1}= ={247}= ={318}= ={520}= ={581}= ={663}= ={997}= [initial] [rendered]
-        > ./ main
-     ./very-big.js?2 1.57 KiB [built]
+      > ./ main
+      ./very-big.js?2 1.57 KiB [built] [code generated]
     chunk (runtime: main) switched-247.js (id hint: vendors) 1.96 KiB ={1}= ={59}= ={318}= ={520}= ={581}= ={663}= ={997}= [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./ main
-     ./node_modules/big.js?1 268 bytes [built]
-     ./node_modules/small.js?1 67 bytes [built]
-     ./node_modules/small.js?2 67 bytes [built]
-     ./node_modules/very-big.js?1 1.57 KiB [built]
+      > ./ main
+      ./node_modules/big.js?1 268 bytes [built] [code generated]
+      ./node_modules/small.js?1 67 bytes [built] [code generated]
+      ./node_modules/small.js?2 67 bytes [built] [code generated]
+      ./node_modules/very-big.js?1 1.57 KiB [built] [code generated]
     chunk (runtime: main) switched-main-89a43a0f.js (main-89a43a0f) 1.57 KiB ={1}= ={59}= ={247}= ={520}= ={581}= ={663}= ={997}= [initial] [rendered]
-        > ./ main
-     ./very-big.js?3 1.57 KiB [built]
+      > ./ main
+      ./very-big.js?3 1.57 KiB [built] [code generated]
     chunk (runtime: main) switched-main-1df31ce3.js (main-1df31ce3) 1.19 KiB ={1}= ={59}= ={247}= ={318}= ={581}= ={663}= ={997}= [initial] [rendered]
-        > ./ main
-     ./index.js 1.19 KiB [built]
+      > ./ main
+      ./index.js 1.19 KiB [built] [code generated]
     chunk (runtime: main) switched-main-879072e3.js (main-879072e3) 1.7 KiB ={1}= ={59}= ={247}= ={318}= ={520}= ={663}= ={997}= [initial] [rendered]
-        > ./ main
-     ./small.js?1 67 bytes [built]
-     ./small.js?2 67 bytes [built]
-     ./small.js?3 67 bytes [built]
-     ./small.js?4 67 bytes [built]
-     ./small.js?5 67 bytes [built]
-     ./small.js?6 67 bytes [built]
-     ./small.js?7 67 bytes [built]
-     ./small.js?8 67 bytes [built]
-     ./small.js?9 67 bytes [built]
-     ./subfolder/big.js?1 268 bytes [built]
-     ./subfolder/big.js?2 268 bytes [built]
-     ./subfolder/small.js?1 67 bytes [built]
-     ./subfolder/small.js?2 67 bytes [built]
-     ./subfolder/small.js?3 67 bytes [built]
-     ./subfolder/small.js?4 67 bytes [built]
-         + 5 hidden root modules
+      > ./ main
+      modules by path ./subfolder/ 1.11 KiB 11 modules
+      modules by path ./*.js 603 bytes 9 modules
     chunk (runtime: main) switched-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.16 KiB (runtime) ={1}= ={59}= ={247}= ={318}= ={520}= ={581}= ={997}= [entry] [rendered]
-        > ./ main
-     ./very-big.js?1 1.57 KiB [built]
-         + 4 hidden root modules
+      > ./ main
+      runtime modules 3.16 KiB 4 modules
+      ./very-big.js?1 1.57 KiB [built] [code generated]
     chunk (runtime: main) switched-main-7aeafcb2.js (main-7aeafcb2) 1.64 KiB ={1}= ={59}= ={247}= ={318}= ={520}= ={581}= ={663}= [initial] [rendered]
-        > ./ main
-     ./big.js?1 268 bytes [built]
-     ./big.js?2 268 bytes [built]
-     ./in-some-directory/big.js?1 268 bytes [built]
-     ./in-some-directory/small.js?1 67 bytes [built]
-     ./in-some-directory/small.js?2 67 bytes [built]
-     ./in-some-directory/small.js?3 67 bytes [built]
-     ./inner-module/small.js?1 67 bytes [built]
-     ./inner-module/small.js?2 67 bytes [built]
-     ./inner-module/small.js?3 67 bytes [built]
-     ./inner-module/small.js?4 67 bytes [built]
-     ./inner-module/small.js?5 67 bytes [built]
-     ./inner-module/small.js?6 67 bytes [built]
-     ./inner-module/small.js?7 67 bytes [built]
-     ./inner-module/small.js?8 67 bytes [built]
-     ./inner-module/small.js?9 67 bytes [built]
-         + 1 hidden root module
+      > ./ main
+      modules by path ./inner-module/ 603 bytes 9 modules
+      modules by path ./in-some-directory/ 536 bytes
+        ./in-some-directory/big.js?1 268 bytes [built] [code generated]
+        ./in-some-directory/small.js?1 67 bytes [built] [code generated]
+        ./in-some-directory/small.js?2 67 bytes [built] [code generated]
+        ./in-some-directory/small.js?3 67 bytes [built] [code generated]
+        ./in-some-directory/small.js?4 67 bytes [built] [code generated]
+      modules by path ./*.js 536 bytes
+        ./big.js?1 268 bytes [built] [code generated]
+        ./big.js?2 268 bytes [built] [code generated]
 
     WARNING in SplitChunksPlugin
     Cache group defaultVendors
@@ -3921,202 +3989,203 @@ Child switched:
 Child zero-min:
     Entrypoint main = zero-min-869.js zero-min-410.js zero-min-main-10f51d07.js zero-min-main-3c98d7c3.js zero-min-main-6bb16544.js zero-min-main-1df31ce3.js zero-min-main-2f7dcf2e.js zero-min-main-e7c5ace7.js zero-min-main-5cfff2c6.js zero-min-main-1443e336.js zero-min-main-77a8c116.js zero-min-main-89a43a0f.js zero-min-main-12217e1d.js
     chunk (runtime: main) zero-min-main-6bb16544.js (main-6bb16544) 1.57 KiB ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./in-some-directory/very-big.js?1 1.57 KiB [built]
+      > ./ main
+      ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
     chunk (runtime: main) zero-min-main-77a8c116.js (main-77a8c116) 1.57 KiB ={1}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./very-big.js?2 1.57 KiB [built]
+      > ./ main
+      ./very-big.js?2 1.57 KiB [built] [code generated]
     chunk (runtime: main) zero-min-main-3c98d7c3.js (main-3c98d7c3) 536 bytes ={1}= ={59}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./in-some-directory/big.js?1 268 bytes [built]
-     ./in-some-directory/small.js?1 67 bytes [built]
-     ./in-some-directory/small.js?2 67 bytes [built]
-     ./in-some-directory/small.js?3 67 bytes [built]
-     ./in-some-directory/small.js?4 67 bytes [built]
+      > ./ main
+      ./in-some-directory/big.js?1 268 bytes [built] [code generated]
+      ./in-some-directory/small.js?1 67 bytes [built] [code generated]
+      ./in-some-directory/small.js?2 67 bytes [built] [code generated]
+      ./in-some-directory/small.js?3 67 bytes [built] [code generated]
+      ./in-some-directory/small.js?4 67 bytes [built] [code generated]
     chunk (runtime: main) zero-min-main-2f7dcf2e.js (main-2f7dcf2e) 603 bytes ={1}= ={59}= ={198}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./inner-module/small.js?1 67 bytes [built]
-     ./inner-module/small.js?2 67 bytes [built]
-     ./inner-module/small.js?3 67 bytes [built]
-     ./inner-module/small.js?4 67 bytes [built]
-     ./inner-module/small.js?5 67 bytes [built]
-     ./inner-module/small.js?6 67 bytes [built]
-     ./inner-module/small.js?7 67 bytes [built]
-     ./inner-module/small.js?8 67 bytes [built]
-     ./inner-module/small.js?9 67 bytes [built]
+      > ./ main
+      ./inner-module/small.js?1 67 bytes [built] [code generated]
+      ./inner-module/small.js?2 67 bytes [built] [code generated]
+      ./inner-module/small.js?3 67 bytes [built] [code generated]
+      ./inner-module/small.js?4 67 bytes [built] [code generated]
+      ./inner-module/small.js?5 67 bytes [built] [code generated]
+      ./inner-module/small.js?6 67 bytes [built] [code generated]
+      ./inner-module/small.js?7 67 bytes [built] [code generated]
+      ./inner-module/small.js?8 67 bytes [built] [code generated]
+      ./inner-module/small.js?9 67 bytes [built] [code generated]
     chunk (runtime: main) zero-min-main-89a43a0f.js (main-89a43a0f) 1.57 KiB ={1}= ={59}= ={198}= ={204}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./very-big.js?3 1.57 KiB [built]
+      > ./ main
+      ./very-big.js?3 1.57 KiB [built] [code generated]
     chunk (runtime: main) zero-min-main-e7c5ace7.js (main-e7c5ace7) 603 bytes ={1}= ={59}= ={198}= ={204}= ={318}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./small.js?1 67 bytes [built]
-     ./small.js?2 67 bytes [built]
-     ./small.js?3 67 bytes [built]
-     ./small.js?4 67 bytes [built]
-     ./small.js?5 67 bytes [built]
-     ./small.js?6 67 bytes [built]
-     ./small.js?7 67 bytes [built]
-     ./small.js?8 67 bytes [built]
-     ./small.js?9 67 bytes [built]
+      > ./ main
+      ./small.js?1 67 bytes [built] [code generated]
+      ./small.js?2 67 bytes [built] [code generated]
+      ./small.js?3 67 bytes [built] [code generated]
+      ./small.js?4 67 bytes [built] [code generated]
+      ./small.js?5 67 bytes [built] [code generated]
+      ./small.js?6 67 bytes [built] [code generated]
+      ./small.js?7 67 bytes [built] [code generated]
+      ./small.js?8 67 bytes [built] [code generated]
+      ./small.js?9 67 bytes [built] [code generated]
     chunk (runtime: main) zero-min-main-1443e336.js (main-1443e336) 603 bytes ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./subfolder/small.js?1 67 bytes [built]
-     ./subfolder/small.js?2 67 bytes [built]
-     ./subfolder/small.js?3 67 bytes [built]
-     ./subfolder/small.js?4 67 bytes [built]
-     ./subfolder/small.js?5 67 bytes [built]
-     ./subfolder/small.js?6 67 bytes [built]
-     ./subfolder/small.js?7 67 bytes [built]
-     ./subfolder/small.js?8 67 bytes [built]
-     ./subfolder/small.js?9 67 bytes [built]
+      > ./ main
+      ./subfolder/small.js?1 67 bytes [built] [code generated]
+      ./subfolder/small.js?2 67 bytes [built] [code generated]
+      ./subfolder/small.js?3 67 bytes [built] [code generated]
+      ./subfolder/small.js?4 67 bytes [built] [code generated]
+      ./subfolder/small.js?5 67 bytes [built] [code generated]
+      ./subfolder/small.js?6 67 bytes [built] [code generated]
+      ./subfolder/small.js?7 67 bytes [built] [code generated]
+      ./subfolder/small.js?8 67 bytes [built] [code generated]
+      ./subfolder/small.js?9 67 bytes [built] [code generated]
     chunk (runtime: main) zero-min-410.js (id hint: vendors) 1.57 KiB ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./ main
-     ./node_modules/very-big.js?1 1.57 KiB [built]
+      > ./ main
+      ./node_modules/very-big.js?1 1.57 KiB [built] [code generated]
     chunk (runtime: main) zero-min-main-5cfff2c6.js (main-5cfff2c6) 536 bytes ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./subfolder/big.js?1 268 bytes [built]
-     ./subfolder/big.js?2 268 bytes [built]
+      > ./ main
+      ./subfolder/big.js?1 268 bytes [built] [code generated]
+      ./subfolder/big.js?2 268 bytes [built] [code generated]
     chunk (runtime: main) zero-min-main-1df31ce3.js (main-1df31ce3) 1.19 KiB ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={662}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./index.js 1.19 KiB [built]
+      > ./ main
+      ./index.js 1.19 KiB [built] [code generated]
     chunk (runtime: main) zero-min-main-10f51d07.js (main-10f51d07) 536 bytes ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={663}= ={869}= [initial] [rendered]
-        > ./ main
-     ./big.js?1 268 bytes [built]
-     ./big.js?2 268 bytes [built]
+      > ./ main
+      ./big.js?1 268 bytes [built] [code generated]
+      ./big.js?2 268 bytes [built] [code generated]
     chunk (runtime: main) zero-min-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.17 KiB (runtime) ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={869}= [entry] [rendered]
-        > ./ main
-     ./very-big.js?1 1.57 KiB [built]
-         + 4 hidden root modules
+      > ./ main
+      runtime modules 3.17 KiB 4 modules
+      ./very-big.js?1 1.57 KiB [built] [code generated]
     chunk (runtime: main) zero-min-869.js (id hint: vendors) 402 bytes ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= [initial] [rendered] split chunk (cache group: defaultVendors)
-        > ./ main
-     ./node_modules/big.js?1 268 bytes [built]
-     ./node_modules/small.js?1 67 bytes [built]
-     ./node_modules/small.js?2 67 bytes [built]
+      > ./ main
+      ./node_modules/big.js?1 268 bytes [built] [code generated]
+      ./node_modules/small.js?1 67 bytes [built] [code generated]
+      ./node_modules/small.js?2 67 bytes [built] [code generated]
 Child max-async-size:
     Entrypoint main = max-async-size-main.js
     chunk (runtime: main) max-async-size-main.js (main) 2.47 KiB (javascript) 5.78 KiB (runtime) >{342}< >{385}< >{820}< >{920}< [entry] [rendered]
-        > ./async main
-     ./async/index.js 386 bytes [built]
-         + 9 hidden root modules
-         + 6 hidden dependent modules
+      > ./async main
+      runtime modules 5.78 KiB 9 modules
+      dependent modules 2.09 KiB [dependent] 6 modules
+      ./async/index.js 386 bytes [built] [code generated]
     chunk (runtime: main) max-async-size-async-b-77a8c116.js (async-b-77a8c116) 1.57 KiB <{179}> ={385}= ={820}= ={920}= [rendered]
-        > ./b ./async/index.js 10:2-49
-        > ./a ./async/index.js 9:2-49
-     ./very-big.js?2 1.57 KiB [built]
+      > ./b ./async/index.js 10:2-49
+      > ./a ./async/index.js 9:2-49
+      ./very-big.js?2 1.57 KiB [built] [code generated]
     chunk (runtime: main) max-async-size-async-b-12217e1d.js (async-b-12217e1d) 1.57 KiB <{179}> ={342}= ={820}= ={920}= [rendered]
-        > ./b ./async/index.js 10:2-49
-        > ./a ./async/index.js 9:2-49
-     ./very-big.js?1 1.57 KiB [built]
+      > ./b ./async/index.js 10:2-49
+      > ./a ./async/index.js 9:2-49
+      ./very-big.js?1 1.57 KiB [built] [code generated]
     chunk (runtime: main) max-async-size-async-b-89a43a0f.js (async-b-89a43a0f) 1.57 KiB <{179}> ={342}= ={385}= ={920}= [rendered]
-        > ./b ./async/index.js 10:2-49
-        > ./a ./async/index.js 9:2-49
-     ./very-big.js?3 1.57 KiB [built]
+      > ./b ./async/index.js 10:2-49
+      > ./a ./async/index.js 9:2-49
+      ./very-big.js?3 1.57 KiB [built] [code generated]
     chunk (runtime: main) max-async-size-async-b-bde52cb3.js (async-b-bde52cb3) 864 bytes <{179}> ={342}= ={385}= ={820}= [rendered]
-        > ./b ./async/index.js 10:2-49
-        > ./a ./async/index.js 9:2-49
-     ./async/a.js 189 bytes [built]
-     ./async/b.js 72 bytes [built]
-         + 9 hidden dependent modules
+      > ./b ./async/index.js 10:2-49
+      > ./a ./async/index.js 9:2-49
+      dependent modules 603 bytes [dependent] 9 modules
+      cacheable modules 261 bytes
+        ./async/a.js 189 bytes [built] [code generated]
+        ./async/b.js 72 bytes [built] [code generated]
 Child enforce-min-size:
     Entrypoint main = enforce-min-size-519.js enforce-min-size-614.js enforce-min-size-262.js enforce-min-size-10.js enforce-min-size-434.js enforce-min-size-869.js enforce-min-size-410.js enforce-min-size-692.js enforce-min-size-825.js enforce-min-size-822.js enforce-min-size-575.js enforce-min-size-221.js enforce-min-size-463.js enforce-min-size-main.js
     chunk (runtime: main) enforce-min-size-10.js (id hint: all) 1.19 KiB ={179}= ={221}= ={262}= ={410}= ={434}= ={463}= ={519}= ={575}= ={614}= ={692}= ={822}= ={825}= ={869}= [initial] [rendered] split chunk (cache group: all)
-        > ./ main
-     ./index.js 1.19 KiB [built]
+      > ./ main
+      ./index.js 1.19 KiB [built] [code generated]
     chunk (runtime: main) enforce-min-size-main.js (main) 3.18 KiB ={10}= ={221}= ={262}= ={410}= ={434}= ={463}= ={519}= ={575}= ={614}= ={692}= ={822}= ={825}= ={869}= [entry] [rendered]
-        > ./ main
-        4 root modules
+      > ./ main
+      runtime modules 3.18 KiB 4 modules
     chunk (runtime: main) enforce-min-size-221.js (id hint: all) 1.57 KiB ={10}= ={179}= ={262}= ={410}= ={434}= ={463}= ={519}= ={575}= ={614}= ={692}= ={822}= ={825}= ={869}= [initial] [rendered] split chunk (cache group: all)
-        > ./ main
-     ./very-big.js?3 1.57 KiB [built]
+      > ./ main
+      ./very-big.js?3 1.57 KiB [built] [code generated]
     chunk (runtime: main) enforce-min-size-262.js (id hint: all) 1.57 KiB ={10}= ={179}= ={221}= ={410}= ={434}= ={463}= ={519}= ={575}= ={614}= ={692}= ={822}= ={825}= ={869}= [initial] [rendered] split chunk (cache group: all)
-        > ./ main
-     ./in-some-directory/very-big.js?1 1.57 KiB [built]
+      > ./ main
+      ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
     chunk (runtime: main) enforce-min-size-410.js (id hint: all) 1.57 KiB ={10}= ={179}= ={221}= ={262}= ={434}= ={463}= ={519}= ={575}= ={614}= ={692}= ={822}= ={825}= ={869}= [initial] [rendered] split chunk (cache group: all)
-        > ./ main
-     ./node_modules/very-big.js?1 1.57 KiB [built]
+      > ./ main
+      ./node_modules/very-big.js?1 1.57 KiB [built] [code generated]
     chunk (runtime: main) enforce-min-size-434.js (id hint: all) 603 bytes ={10}= ={179}= ={221}= ={262}= ={410}= ={463}= ={519}= ={575}= ={614}= ={692}= ={822}= ={825}= ={869}= [initial] [rendered] split chunk (cache group: all)
-        > ./ main
-     ./inner-module/small.js?1 67 bytes [built]
-     ./inner-module/small.js?2 67 bytes [built]
-     ./inner-module/small.js?3 67 bytes [built]
-     ./inner-module/small.js?4 67 bytes [built]
-     ./inner-module/small.js?5 67 bytes [built]
-     ./inner-module/small.js?6 67 bytes [built]
-     ./inner-module/small.js?7 67 bytes [built]
-     ./inner-module/small.js?8 67 bytes [built]
-     ./inner-module/small.js?9 67 bytes [built]
+      > ./ main
+      ./inner-module/small.js?1 67 bytes [built] [code generated]
+      ./inner-module/small.js?2 67 bytes [built] [code generated]
+      ./inner-module/small.js?3 67 bytes [built] [code generated]
+      ./inner-module/small.js?4 67 bytes [built] [code generated]
+      ./inner-module/small.js?5 67 bytes [built] [code generated]
+      ./inner-module/small.js?6 67 bytes [built] [code generated]
+      ./inner-module/small.js?7 67 bytes [built] [code generated]
+      ./inner-module/small.js?8 67 bytes [built] [code generated]
+      ./inner-module/small.js?9 67 bytes [built] [code generated]
     chunk (runtime: main) enforce-min-size-463.js (id hint: all) 1.57 KiB ={10}= ={179}= ={221}= ={262}= ={410}= ={434}= ={519}= ={575}= ={614}= ={692}= ={822}= ={825}= ={869}= [initial] [rendered] split chunk (cache group: all)
-        > ./ main
-     ./very-big.js?1 1.57 KiB [built]
+      > ./ main
+      ./very-big.js?1 1.57 KiB [built] [code generated]
     chunk (runtime: main) enforce-min-size-519.js (id hint: all) 536 bytes ={10}= ={179}= ={221}= ={262}= ={410}= ={434}= ={463}= ={575}= ={614}= ={692}= ={822}= ={825}= ={869}= [initial] [rendered] split chunk (cache group: all)
-        > ./ main
-     ./big.js?1 268 bytes [built]
-     ./big.js?2 268 bytes [built]
+      > ./ main
+      ./big.js?1 268 bytes [built] [code generated]
+      ./big.js?2 268 bytes [built] [code generated]
     chunk (runtime: main) enforce-min-size-575.js (id hint: all) 1.57 KiB ={10}= ={179}= ={221}= ={262}= ={410}= ={434}= ={463}= ={519}= ={614}= ={692}= ={822}= ={825}= ={869}= [initial] [rendered] split chunk (cache group: all)
-        > ./ main
-     ./very-big.js?2 1.57 KiB [built]
+      > ./ main
+      ./very-big.js?2 1.57 KiB [built] [code generated]
     chunk (runtime: main) enforce-min-size-614.js (id hint: all) 536 bytes ={10}= ={179}= ={221}= ={262}= ={410}= ={434}= ={463}= ={519}= ={575}= ={692}= ={822}= ={825}= ={869}= [initial] [rendered] split chunk (cache group: all)
-        > ./ main
-     ./in-some-directory/big.js?1 268 bytes [built]
-     ./in-some-directory/small.js?1 67 bytes [built]
-     ./in-some-directory/small.js?2 67 bytes [built]
-     ./in-some-directory/small.js?3 67 bytes [built]
-     ./in-some-directory/small.js?4 67 bytes [built]
+      > ./ main
+      ./in-some-directory/big.js?1 268 bytes [built] [code generated]
+      ./in-some-directory/small.js?1 67 bytes [built] [code generated]
+      ./in-some-directory/small.js?2 67 bytes [built] [code generated]
+      ./in-some-directory/small.js?3 67 bytes [built] [code generated]
+      ./in-some-directory/small.js?4 67 bytes [built] [code generated]
     chunk (runtime: main) enforce-min-size-692.js (id hint: all) 603 bytes ={10}= ={179}= ={221}= ={262}= ={410}= ={434}= ={463}= ={519}= ={575}= ={614}= ={822}= ={825}= ={869}= [initial] [rendered] split chunk (cache group: all)
-        > ./ main
-     ./small.js?1 67 bytes [built]
-     ./small.js?2 67 bytes [built]
-     ./small.js?3 67 bytes [built]
-     ./small.js?4 67 bytes [built]
-     ./small.js?5 67 bytes [built]
-     ./small.js?6 67 bytes [built]
-     ./small.js?7 67 bytes [built]
-     ./small.js?8 67 bytes [built]
-     ./small.js?9 67 bytes [built]
+      > ./ main
+      ./small.js?1 67 bytes [built] [code generated]
+      ./small.js?2 67 bytes [built] [code generated]
+      ./small.js?3 67 bytes [built] [code generated]
+      ./small.js?4 67 bytes [built] [code generated]
+      ./small.js?5 67 bytes [built] [code generated]
+      ./small.js?6 67 bytes [built] [code generated]
+      ./small.js?7 67 bytes [built] [code generated]
+      ./small.js?8 67 bytes [built] [code generated]
+      ./small.js?9 67 bytes [built] [code generated]
     chunk (runtime: main) enforce-min-size-822.js (id hint: all) 603 bytes ={10}= ={179}= ={221}= ={262}= ={410}= ={434}= ={463}= ={519}= ={575}= ={614}= ={692}= ={825}= ={869}= [initial] [rendered] split chunk (cache group: all)
-        > ./ main
-     ./subfolder/small.js?1 67 bytes [built]
-     ./subfolder/small.js?2 67 bytes [built]
-     ./subfolder/small.js?3 67 bytes [built]
-     ./subfolder/small.js?4 67 bytes [built]
-     ./subfolder/small.js?5 67 bytes [built]
-     ./subfolder/small.js?6 67 bytes [built]
-     ./subfolder/small.js?7 67 bytes [built]
-     ./subfolder/small.js?8 67 bytes [built]
-     ./subfolder/small.js?9 67 bytes [built]
+      > ./ main
+      ./subfolder/small.js?1 67 bytes [built] [code generated]
+      ./subfolder/small.js?2 67 bytes [built] [code generated]
+      ./subfolder/small.js?3 67 bytes [built] [code generated]
+      ./subfolder/small.js?4 67 bytes [built] [code generated]
+      ./subfolder/small.js?5 67 bytes [built] [code generated]
+      ./subfolder/small.js?6 67 bytes [built] [code generated]
+      ./subfolder/small.js?7 67 bytes [built] [code generated]
+      ./subfolder/small.js?8 67 bytes [built] [code generated]
+      ./subfolder/small.js?9 67 bytes [built] [code generated]
     chunk (runtime: main) enforce-min-size-825.js (id hint: all) 536 bytes ={10}= ={179}= ={221}= ={262}= ={410}= ={434}= ={463}= ={519}= ={575}= ={614}= ={692}= ={822}= ={869}= [initial] [rendered] split chunk (cache group: all)
-        > ./ main
-     ./subfolder/big.js?1 268 bytes [built]
-     ./subfolder/big.js?2 268 bytes [built]
+      > ./ main
+      ./subfolder/big.js?1 268 bytes [built] [code generated]
+      ./subfolder/big.js?2 268 bytes [built] [code generated]
     chunk (runtime: main) enforce-min-size-869.js (id hint: all) 402 bytes ={10}= ={179}= ={221}= ={262}= ={410}= ={434}= ={463}= ={519}= ={575}= ={614}= ={692}= ={822}= ={825}= [initial] [rendered] split chunk (cache group: all)
-        > ./ main
-     ./node_modules/big.js?1 268 bytes [built]
-     ./node_modules/small.js?1 67 bytes [built]
-     ./node_modules/small.js?2 67 bytes [built]"
+      > ./ main
+      ./node_modules/big.js?1 268 bytes [built] [code generated]
+      ./node_modules/small.js?1 67 bytes [built] [code generated]
+      ./node_modules/small.js?2 67 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-prefer-bigger-splits 1`] = `
 "Entrypoint main = default/main.js
 chunk (runtime: main) default/118.js 110 bytes <{179}> ={334}= ={383}= [rendered] split chunk (cache group: default)
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
- ./d.js 43 bytes [built]
- ./f.js 67 bytes [built]
+  > ./b ./index.js 2:0-47
+  > ./c ./index.js 3:0-47
+  ./d.js 43 bytes [built] [code generated]
+  ./f.js 67 bytes [built] [code generated]
 chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 5.73 KiB (runtime) >{118}< >{334}< >{383}< >{794}< [entry] [rendered]
-    > ./ main
- ./index.js 147 bytes [built]
-     + 9 hidden root modules
+  > ./ main
+  runtime modules 5.73 KiB 9 modules
+  ./index.js 147 bytes [built] [code generated]
 chunk (runtime: main) default/async-b.js (async-b) 105 bytes <{179}> ={118}= [rendered]
-    > ./b ./index.js 2:0-47
- ./b.js 62 bytes [built]
-     + 1 hidden dependent module
+  > ./b ./index.js 2:0-47
+  dependent modules 43 bytes [dependent] 1 module
+  ./b.js 62 bytes [built] [code generated]
 chunk (runtime: main) default/async-c.js (async-c) 48 bytes <{179}> ={118}= [rendered]
-    > ./c ./index.js 3:0-47
- ./c.js 48 bytes [built]
+  > ./c ./index.js 3:0-47
+  ./c.js 48 bytes [built] [code generated]
 chunk (runtime: main) default/async-a.js (async-a) 134 bytes <{179}> [rendered]
-    > ./a ./index.js 1:0-47
- ./a.js 48 bytes [built]
-     + 2 hidden dependent modules"
+  > ./a ./index.js 1:0-47
+  dependent modules 86 bytes [dependent] 2 modules
+  ./a.js 48 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-runtime-specific 1`] = `
@@ -4133,15 +4202,15 @@ Child used-exports:
     Entrypoint b = used-exports-332.js used-exports-b.js
     Entrypoint c = used-exports-332.js used-exports-c.js
     chunk (runtime: b) used-exports-b.js (b) 54 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
-     ./b.js 54 bytes [built]
-         + 3 hidden root modules
+      runtime modules 2.88 KiB 3 modules
+      ./b.js 54 bytes [built] [code generated]
     chunk (runtime: b, c) used-exports-332.js 72 bytes [initial] [rendered] split chunk (cache group: default)
-     ./objects.js 72 bytes [built]
+      ./objects.js 72 bytes [built] [code generated]
     chunk (runtime: c) used-exports-c.js (c) 59 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
-     ./c.js 59 bytes [built]
-         + 3 hidden root modules
+      runtime modules 2.88 KiB 3 modules
+      ./c.js 59 bytes [built] [code generated]
     chunk (runtime: a) used-exports-a.js (a) 126 bytes [entry] [rendered]
-     ./a.js + 1 modules 126 bytes [built]
+      ./a.js + 1 modules 126 bytes [built] [code generated]
 Child no-used-exports:
     Hash: ffb0356ac67ed3277b65
     Time: X ms
@@ -4154,16 +4223,16 @@ Child no-used-exports:
     Entrypoint b = no-used-exports-332.js no-used-exports-b.js
     Entrypoint c = no-used-exports-332.js no-used-exports-c.js
     chunk (runtime: b) no-used-exports-b.js (b) 54 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
-     ./b.js 54 bytes [built]
-         + 3 hidden root modules
+      runtime modules 2.88 KiB 3 modules
+      ./b.js 54 bytes [built] [code generated]
     chunk (runtime: a, b, c) no-used-exports-332.js 72 bytes [initial] [rendered] split chunk (cache group: default)
-     ./objects.js 72 bytes [built]
+      ./objects.js 72 bytes [built] [code generated]
     chunk (runtime: c) no-used-exports-c.js (c) 59 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
-     ./c.js 59 bytes [built]
-         + 3 hidden root modules
+      runtime modules 2.88 KiB 3 modules
+      ./c.js 59 bytes [built] [code generated]
     chunk (runtime: a) no-used-exports-a.js (a) 54 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
-     ./a.js 54 bytes [built]
-         + 3 hidden root modules
+      runtime modules 2.88 KiB 3 modules
+      ./a.js 54 bytes [built] [code generated]
 Child global:
     Hash: ffb0356ac67ed3277b65
     Time: X ms
@@ -4176,16 +4245,16 @@ Child global:
     Entrypoint b = global-332.js global-b.js
     Entrypoint c = global-332.js global-c.js
     chunk global-b.js (b) 54 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
-     ./b.js 54 bytes [built]
-         + 3 hidden root modules
+      runtime modules 2.88 KiB 3 modules
+      ./b.js 54 bytes [built] [code generated]
     chunk global-332.js 72 bytes [initial] [rendered] split chunk (cache group: default)
-     ./objects.js 72 bytes [built]
+      ./objects.js 72 bytes [built] [code generated]
     chunk global-c.js (c) 59 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
-     ./c.js 59 bytes [built]
-         + 3 hidden root modules
+      runtime modules 2.88 KiB 3 modules
+      ./c.js 59 bytes [built] [code generated]
     chunk global-a.js (a) 54 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
-     ./a.js 54 bytes [built]
-         + 3 hidden root modules"
+      runtime modules 2.88 KiB 3 modules
+      ./a.js 54 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for tree-shaking 1`] = `
@@ -4194,36 +4263,37 @@ Time: X ms
 Built at: 1970-04-20 12:42:42
 asset bundle.js 7.09 KiB [emitted] (name: main)
 Entrypoint main = bundle.js
-./index.js 316 bytes [built] [1 warning]
+runtime modules 657 bytes 3 modules
+cacheable modules 666 bytes
+  ./index.js 316 bytes [built] [code generated] [1 warning]
     [no exports]
     [no exports used]
-./reexport-known.js 49 bytes [built]
+  ./reexport-known.js 49 bytes [built] [code generated]
     [exports: a, b]
     [only some exports used: a]
-./reexport-unknown.js 83 bytes [built]
+  ./reexport-unknown.js 83 bytes [built] [code generated]
     [exports: a, b, c, d]
     [only some exports used: a, c]
-./reexport-star-known.js 41 bytes [built]
+  ./reexport-star-known.js 41 bytes [built] [code generated]
     [exports: a, b]
     [only some exports used: a]
-./reexport-star-unknown.js 68 bytes [built]
+  ./reexport-star-unknown.js 68 bytes [built] [code generated]
     [only some exports used: a, c]
-./edge.js 45 bytes [built]
+  ./edge.js 45 bytes [built] [code generated]
     [only some exports used: y]
-./require.include.js 36 bytes [built]
+  ./require.include.js 36 bytes [built] [code generated]
     [exports: a, default]
     [no exports used]
-./a.js 13 bytes [built]
+  ./a.js 13 bytes [built] [code generated]
     [exports: a]
     [all exports used]
-./b.js 13 bytes [built]
+  ./b.js 13 bytes [built] [code generated]
     [exports: b]
     [no exports used]
-./unknown.js 1 bytes [built]
+  ./unknown.js 1 bytes [built] [code generated]
     [used exports unknown]
-./unknown2.js 1 bytes [built]
+  ./unknown2.js 1 bytes [built] [code generated]
     [used exports unknown]
-    + 3 hidden modules
 
 WARNING in ./index.js 9:0-36
 require.include() is deprecated and will be removed soon.
@@ -4234,45 +4304,48 @@ exports[`StatsTestCases should print correct stats for wasm-explorer-examples-sy
 "Hash: c96673e79f37716c681c
 Time: X ms
 Built at: 1970-04-20 12:42:42
-assets by path ./*.js 16.8 KiB
-  asset bundle.js 11.7 KiB [emitted] (name: main)
+assets by path *.js 16.8 KiB
+  asset 230.bundle.js 242 bytes [emitted]
   asset 325.bundle.js 3.78 KiB [emitted]
   asset 526.bundle.js 364 bytes [emitted] (id hint: vendors)
-  asset 230.bundle.js 242 bytes [emitted]
-  asset 99.bundle.js 240 bytes [emitted]
   asset 780.bundle.js 569 bytes [emitted]
-assets by path ./*.wasm 1.37 KiB
-  asset 71ba3c2b7af4ee0e4b5c.module.wasm 120 bytes [emitted] [immutable]
-  asset a938d40645ba21696ec8.module.wasm 154 bytes [emitted] [immutable]
+  asset 99.bundle.js 240 bytes [emitted]
+  asset bundle.js 11.7 KiB [emitted] (name: main)
+assets by path *.wasm 1.37 KiB
   asset 32796a220f44b00723d7.module.wasm 156 bytes [emitted] [immutable]
   asset 52ce624dd5de9c91cd19.module.wasm 531 bytes [emitted] [immutable]
+  asset 71ba3c2b7af4ee0e4b5c.module.wasm 120 bytes [emitted] [immutable]
   asset 86f222634054d2a3b20f.module.wasm 154 bytes [emitted] [immutable]
   asset 986b1b3cbdd7749989ee.module.wasm 290 bytes [emitted] [immutable]
+  asset a938d40645ba21696ec8.module.wasm 154 bytes [emitted] [immutable]
 Entrypoint main = bundle.js
 chunk (runtime: main) 99.bundle.js 50 bytes (javascript) 531 bytes (webassembly) [rendered]
- ./duff.wasm 50 bytes (javascript) 531 bytes (webassembly) [built]
+  ./duff.wasm 50 bytes (javascript) 531 bytes (webassembly) [built] [code generated]
 chunk (runtime: main) bundle.js (main) 586 bytes (javascript) 5.92 KiB (runtime) [entry] [rendered]
- ./index.js 586 bytes [built]
-     + 9 hidden chunk modules
+  runtime modules 5.92 KiB 9 modules
+  ./index.js 586 bytes [built] [code generated]
 chunk (runtime: main) 230.bundle.js 50 bytes (javascript) 156 bytes (webassembly) [rendered]
- ./Q_rsqrt.wasm 50 bytes (javascript) 156 bytes (webassembly) [built]
+  ./Q_rsqrt.wasm 50 bytes (javascript) 156 bytes (webassembly) [built] [code generated]
 chunk (runtime: main) 325.bundle.js 1.5 KiB (javascript) 274 bytes (webassembly) [rendered]
- ./popcnt.wasm 50 bytes (javascript) 120 bytes (webassembly) [built]
- ./testFunction.wasm 50 bytes (javascript) 154 bytes (webassembly) [built]
- ./tests.js 1.4 KiB [built]
+  ./popcnt.wasm 50 bytes (javascript) 120 bytes (webassembly) [dependent] [built] [code generated]
+  ./testFunction.wasm 50 bytes (javascript) 154 bytes (webassembly) [dependent] [built] [code generated]
+  ./tests.js 1.4 KiB [built] [code generated]
 chunk (runtime: main) 526.bundle.js (id hint: vendors) 34 bytes [rendered] split chunk (cache group: defaultVendors)
- ./node_modules/env.js 34 bytes [built]
+  ./node_modules/env.js 34 bytes [built] [code generated]
 chunk (runtime: main) 780.bundle.js 110 bytes (javascript) 444 bytes (webassembly) [rendered]
- ./fact.wasm 50 bytes (javascript) 154 bytes (webassembly) [built]
- ./fast-math.wasm 60 bytes (javascript) 290 bytes (webassembly) [built]
-./index.js 586 bytes [built]
-./tests.js 1.4 KiB [built]
-./Q_rsqrt.wasm 50 bytes (javascript) 156 bytes (webassembly) [built]
-./testFunction.wasm 50 bytes (javascript) 154 bytes (webassembly) [built]
-./fact.wasm 50 bytes (javascript) 154 bytes (webassembly) [built]
-./popcnt.wasm 50 bytes (javascript) 120 bytes (webassembly) [built]
-./fast-math.wasm 60 bytes (javascript) 290 bytes (webassembly) [built]
-./duff.wasm 50 bytes (javascript) 531 bytes (webassembly) [built]
-./node_modules/env.js 34 bytes [built]
-    + 9 hidden modules"
+  ./fact.wasm 50 bytes (javascript) 154 bytes (webassembly) [built] [code generated]
+  ./fast-math.wasm 60 bytes (javascript) 290 bytes (webassembly) [built] [code generated]
+runtime modules 5.92 KiB 9 modules
+cacheable modules 2.31 KiB (javascript) 1.37 KiB (webassembly)
+  webassembly modules 310 bytes (javascript) 1.37 KiB (webassembly)
+    ./Q_rsqrt.wasm 50 bytes (javascript) 156 bytes (webassembly) [built] [code generated]
+    ./testFunction.wasm 50 bytes (javascript) 154 bytes (webassembly) [built] [code generated]
+    ./fact.wasm 50 bytes (javascript) 154 bytes (webassembly) [built] [code generated]
+    ./popcnt.wasm 50 bytes (javascript) 120 bytes (webassembly) [built] [code generated]
+    ./fast-math.wasm 60 bytes (javascript) 290 bytes (webassembly) [built] [code generated]
+    ./duff.wasm 50 bytes (javascript) 531 bytes (webassembly) [built] [code generated]
+  javascript modules 2.01 KiB
+    ./index.js 586 bytes [built] [code generated]
+    ./tests.js 1.4 KiB [built] [code generated]
+    ./node_modules/env.js 34 bytes [built] [code generated]"
 `;

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -787,7 +787,7 @@ exports[`StatsTestCases should print correct stats for dll-reference-plugin-issu
 "Hash: b838deba915153e63f86
 Time: X ms
 Built at: 1970-04-20 12:42:42
-1 asset
+assets by status 83 bytes [cached] 1 asset
 Entrypoint main = bundle.js
 ./entry.js 29 bytes [built]
 
@@ -823,8 +823,8 @@ exports[`StatsTestCases should print correct stats for exclude-with-loader 1`] =
 "Hash: 0f9eb63e65113c4a3960
 Time: X ms
 Built at: 1970-04-20 12:42:42
+excluded assets 34 bytes 1 asset
 asset bundle.js 3.73 KiB [emitted] (name: main)
- + 1 hidden asset
 Entrypoint main = bundle.js (89245aae14d2d745f85a29195aa6ffc1.json)
 ./index.js 77 bytes [built]
 ./a.txt 42 bytes [built]
@@ -1020,8 +1020,9 @@ Child
     Hash: 79ce0ce957b373f01199
     Time: X ms
     Built at: 1970-04-20 12:42:42
-    asset c-all-b_js-5d2ee8f74cbe1c7c24e8.js 502 bytes [emitted] [immutable] (id hint: all)
-    asset c-all-c_js-3f22b3dd1aa1ecb5f45e.js 393 bytes [emitted] [immutable] (id hint: all)
+    assets by chunk 895 bytes (id hint: all)
+      asset c-all-c_js-3f22b3dd1aa1ecb5f45e.js 393 bytes [emitted] [immutable] (id hint: all)
+      asset c-all-b_js-5d2ee8f74cbe1c7c24e8.js 502 bytes [emitted] [immutable] (id hint: all)
     asset c-main-3737497cd09f5bd99fe3.js 603 bytes [emitted] [immutable] (name: main)
     asset c-runtime~main-2769e1f5da93c44c8a70.js 12.4 KiB [emitted] [immutable] (name: runtime~main)
     asset c-vendors-node_modules_vendor_js-93fc2ac2d261c82b4448.js 185 bytes [emitted] [immutable] (id hint: vendors)
@@ -1228,11 +1229,13 @@ exports[`StatsTestCases should print correct stats for module-assets 1`] = `
 "Hash: 7ef32e0d65af21479a68
 Time: X ms
 Built at: 1970-04-20 12:42:42
-asset 1.png 21 KiB [emitted] (auxiliary name: a)
-asset 2.png 21 KiB [emitted] (auxiliary name: a, b)
-asset a.js 749 bytes [emitted] (name: a)
-asset b.js 567 bytes [emitted] (name: b)
-asset main.js 8.92 KiB [emitted] (name: main)
+assets by path ./*.js 10.2 KiB
+  asset main.js 8.92 KiB [emitted] (name: main)
+  asset a.js 749 bytes [emitted] (name: a)
+  asset b.js 567 bytes [emitted] (name: b)
+assets by path ./*.png 42 KiB
+  asset 1.png 21 KiB [emitted] (auxiliary name: a)
+  asset 2.png 21 KiB [emitted] (auxiliary name: a, b)
 Entrypoint main = main.js
 Chunk Group a = a.js (1.png 2.png)
 Chunk Group b = b.js (2.png)
@@ -1387,7 +1390,7 @@ Entrypoint main = main.js
 exports[`StatsTestCases should print correct stats for module-trace-disabled-in-error 1`] = `
 "Time: X ms
 Built at: 1970-04-20 12:42:42
-1 asset
+assets by status 1.83 KiB [cached] 1 asset
 Entrypoint main = main.js
 ./index.js 19 bytes [built]
 ./inner.js 53 bytes [built]
@@ -1411,7 +1414,7 @@ You may need an appropriate loader to handle this file type, currently no loader
 exports[`StatsTestCases should print correct stats for module-trace-enabled-in-error 1`] = `
 "Time: X ms
 Built at: 1970-04-20 12:42:42
-1 asset
+assets by status 1.83 KiB [cached] 1 asset
 Entrypoint main = main.js
 ./index.js 19 bytes [built]
 ./inner.js 53 bytes [built]
@@ -1523,7 +1526,7 @@ exports[`StatsTestCases should print correct stats for no-emit-on-errors-plugin-
 "Hash: f140966bfd98188578d5
 Time: X ms
 Built at: 1970-04-20 12:42:42
-2 assets
+assets by status 108 bytes [cached] 2 assets
 Entrypoint main = bundle.js
 ./index.js 1 bytes [built]
 
@@ -1582,7 +1585,7 @@ chunk {753} (runtime: main) ac in ab.js (ac in ab) 1 bytes <{90}> >{284}< [rende
 `;
 
 exports[`StatsTestCases should print correct stats for parse-error 1`] = `
-"1 asset
+"assets by status 1.53 KiB [cached] 1 asset
 Entrypoint main = main.js
 ./index.js + 1 modules 30 bytes [built]
 ./b.js 55 bytes [built] [failed] [1 error]
@@ -2323,11 +2326,12 @@ Child a-normal:
     Hash: dc13e801b7da230b06ce
     Time: X ms
     Built at: 1970-04-20 12:42:42
-    asset 3cc8faad16137711c07e-3cc8fa.js 210 bytes [emitted] [immutable] [minimized] (name: main)
-    asset 603191853c81e758567a-603191.js 2.09 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+    assets by path ./*.js 2.48 KiB
+      asset 3cc8faad16137711c07e-3cc8fa.js 210 bytes [emitted] [immutable] [minimized] (name: main)
+      asset 603191853c81e758567a-603191.js 2.09 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+      asset b6f77787a670e97d47b5-b6f777.js 193 bytes [emitted] [immutable] [minimized] (name: lazy)
     asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] (auxiliary name: main)
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] (auxiliary name: lazy)
-    asset b6f77787a670e97d47b5-b6f777.js 193 bytes [emitted] [immutable] [minimized] (name: lazy)
     Entrypoint main = 603191853c81e758567a-603191.js 3cc8faad16137711c07e-3cc8fa.js (7382fad5b015914e0811.jpg)
     ./a/index.js 150 bytes [built]
     ./a/file.jpg 42 bytes (javascript) 5.89 KiB (asset) [built]
@@ -2338,11 +2342,12 @@ Child b-normal:
     Hash: 5782ba854a23a6c889d0
     Time: X ms
     Built at: 1970-04-20 12:42:42
-    asset 3cc8faad16137711c07e-3cc8fa.js 210 bytes [emitted] [immutable] [minimized] (name: main)
-    asset 724d7409f0fb4e0b3145-724d74.js 2.09 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+    assets by path ./*.js 2.48 KiB
+      asset 3cc8faad16137711c07e-3cc8fa.js 210 bytes [emitted] [immutable] [minimized] (name: main)
+      asset 724d7409f0fb4e0b3145-724d74.js 2.09 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+      asset b6f77787a670e97d47b5-b6f777.js 193 bytes [emitted] [immutable] [minimized] (name: lazy)
     asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] (auxiliary name: main)
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] (auxiliary name: lazy)
-    asset b6f77787a670e97d47b5-b6f777.js 193 bytes [emitted] [immutable] [minimized] (name: lazy)
     Entrypoint main = 724d7409f0fb4e0b3145-724d74.js 3cc8faad16137711c07e-3cc8fa.js (7382fad5b015914e0811.jpg)
     ./b/index.js 109 bytes [built]
     ./b/file.jpg 42 bytes (javascript) 5.89 KiB (asset) [built]
@@ -2353,14 +2358,15 @@ Child a-source-map:
     Hash: dc13e801b7da230b06ce
     Time: X ms
     Built at: 1970-04-20 12:42:42
-    asset 2d2b84d5cc58d8742e65-2d2b84.js 2.14 KiB [emitted] [immutable] [minimized] (name: runtime~main)
-      sourceMap 2d2b84d5cc58d8742e65-2d2b84.js.map 12.6 KiB [emitted] [dev]
+    assets by path ./*.js 2.65 KiB
+      asset b8bfcec62cdd15c9a840-b8bfce.js 266 bytes [emitted] [immutable] [minimized] (name: main)
+        sourceMap b8bfcec62cdd15c9a840-b8bfce.js.map 366 bytes [emitted] [dev]
+      asset 2d2b84d5cc58d8742e65-2d2b84.js 2.14 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+        sourceMap 2d2b84d5cc58d8742e65-2d2b84.js.map 12.6 KiB [emitted] [dev]
+      asset c7c0f8bb2e61b59a89f5-c7c0f8.js 249 bytes [emitted] [immutable] [minimized] (name: lazy)
+        sourceMap c7c0f8bb2e61b59a89f5-c7c0f8.js.map 331 bytes [emitted] [dev]
     asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] (auxiliary name: main)
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] (auxiliary name: lazy)
-    asset b8bfcec62cdd15c9a840-b8bfce.js 266 bytes [emitted] [immutable] [minimized] (name: main)
-      sourceMap b8bfcec62cdd15c9a840-b8bfce.js.map 366 bytes [emitted] [dev]
-    asset c7c0f8bb2e61b59a89f5-c7c0f8.js 249 bytes [emitted] [immutable] [minimized] (name: lazy)
-      sourceMap c7c0f8bb2e61b59a89f5-c7c0f8.js.map 331 bytes [emitted] [dev]
     Entrypoint main = 2d2b84d5cc58d8742e65-2d2b84.js b8bfcec62cdd15c9a840-b8bfce.js (608a3931b5c0c7b2c21f-608a39.js.map 7382fad5b015914e0811.jpg aff11f17e02d24be34cc-aff11f.js.map)
     ./a/index.js 150 bytes [built]
     ./a/file.jpg 42 bytes (javascript) 5.89 KiB (asset) [built]
@@ -2371,14 +2377,15 @@ Child b-source-map:
     Hash: 5782ba854a23a6c889d0
     Time: X ms
     Built at: 1970-04-20 12:42:42
+    assets by path ./*.js 2.65 KiB
+      asset b8bfcec62cdd15c9a840-b8bfce.js 266 bytes [emitted] [immutable] [minimized] (name: main)
+        sourceMap b8bfcec62cdd15c9a840-b8bfce.js.map 323 bytes [emitted] [dev]
+      asset ffe92bc2786746a99419-ffe92b.js 2.14 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+        sourceMap ffe92bc2786746a99419-ffe92b.js.map 12.6 KiB [emitted] [dev]
+      asset c7c0f8bb2e61b59a89f5-c7c0f8.js 249 bytes [emitted] [immutable] [minimized] (name: lazy)
+        sourceMap c7c0f8bb2e61b59a89f5-c7c0f8.js.map 327 bytes [emitted] [dev]
     asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] (auxiliary name: main)
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] (auxiliary name: lazy)
-    asset b8bfcec62cdd15c9a840-b8bfce.js 266 bytes [emitted] [immutable] [minimized] (name: main)
-      sourceMap b8bfcec62cdd15c9a840-b8bfce.js.map 323 bytes [emitted] [dev]
-    asset c7c0f8bb2e61b59a89f5-c7c0f8.js 249 bytes [emitted] [immutable] [minimized] (name: lazy)
-      sourceMap c7c0f8bb2e61b59a89f5-c7c0f8.js.map 327 bytes [emitted] [dev]
-    asset ffe92bc2786746a99419-ffe92b.js 2.14 KiB [emitted] [immutable] [minimized] (name: runtime~main)
-      sourceMap ffe92bc2786746a99419-ffe92b.js.map 12.6 KiB [emitted] [dev]
     Entrypoint main = ffe92bc2786746a99419-ffe92b.js b8bfcec62cdd15c9a840-b8bfce.js (342ff4b0850c24f24b15-342ff4.js.map 6625d7a5b3c0dfc493c6-6625d7.js.map 7382fad5b015914e0811.jpg)
     ./b/index.js 109 bytes [built]
     ./b/file.jpg 42 bytes (javascript) 5.89 KiB (asset) [built]
@@ -2389,79 +2396,102 @@ Child b-source-map:
 
 exports[`StatsTestCases should print correct stats for related-assets 1`] = `
 "Child default:
-    asset default-chunk_js.css 73 bytes [emitted] 3 related assets
-    asset default-chunk_js.js 1.11 KiB [emitted] 3 related assets
-    asset default-main.css 69 bytes [emitted] (name: main) 3 related assets
-    asset default-main.js 13.3 KiB [emitted] (name: main) 3 related assets
+    assets by path ./*.css 142 bytes
+      asset default-main.css 69 bytes [emitted] (name: main) 3 related assets
+      asset default-chunk_js.css 73 bytes [emitted] 3 related assets
+    assets by path ./*.js 14.4 KiB
+      asset default-main.js 13.3 KiB [emitted] (name: main) 3 related assets
+      asset default-chunk_js.js 1.11 KiB [emitted] 3 related assets
 Child relatedAssets:
-    asset relatedAssets-chunk_js.css 79 bytes [emitted]
-      compressed relatedAssets-chunk_js.css.br 79 bytes [emitted]
-      compressed relatedAssets-chunk_js.css.gz 79 bytes [emitted]
-      sourceMap relatedAssets-chunk_js.css.map 197 bytes [emitted] [dev]
-        compressed relatedAssets-chunk_js.css.map.br 197 bytes [emitted]
-        compressed relatedAssets-chunk_js.css.map.gz 197 bytes [emitted]
-    asset relatedAssets-chunk_js.js 1.12 KiB [emitted]
-      compressed relatedAssets-chunk_js.js.br 1.12 KiB [emitted]
-      compressed relatedAssets-chunk_js.js.gz 1.12 KiB [emitted]
-      sourceMap relatedAssets-chunk_js.js.map 295 bytes [emitted] [dev]
-        compressed relatedAssets-chunk_js.js.map.br 295 bytes [emitted]
-        compressed relatedAssets-chunk_js.js.map.gz 295 bytes [emitted]
-    asset relatedAssets-main.css 75 bytes [emitted] (name: main)
-      compressed relatedAssets-main.css.br 75 bytes [emitted]
-      compressed relatedAssets-main.css.gz 75 bytes [emitted]
-      sourceMap relatedAssets-main.css.map 187 bytes [emitted] [dev] (auxiliary name: main)
-        compressed relatedAssets-main.css.map.br 187 bytes [emitted]
-        compressed relatedAssets-main.css.map.gz 187 bytes [emitted]
-    asset relatedAssets-main.js 13.3 KiB [emitted] (name: main)
-      compressed relatedAssets-main.js.br 13.3 KiB [emitted]
-      compressed relatedAssets-main.js.gz 13.3 KiB [emitted]
-      sourceMap relatedAssets-main.js.map 11.3 KiB [emitted] [dev] (auxiliary name: main)
-        compressed relatedAssets-main.js.map.br 11.3 KiB [emitted]
-        compressed relatedAssets-main.js.map.gz 11.3 KiB [emitted]
+    assets by path ./*.css 154 bytes
+      asset relatedAssets-main.css 75 bytes [emitted] (name: main)
+        compressed relatedAssets-main.css.br 75 bytes [emitted]
+        compressed relatedAssets-main.css.gz 75 bytes [emitted]
+        sourceMap relatedAssets-main.css.map 187 bytes [emitted] [dev] (auxiliary name: main)
+          compressed relatedAssets-main.css.map.br 187 bytes [emitted]
+          compressed relatedAssets-main.css.map.gz 187 bytes [emitted]
+      asset relatedAssets-chunk_js.css 79 bytes [emitted]
+        compressed relatedAssets-chunk_js.css.br 79 bytes [emitted]
+        compressed relatedAssets-chunk_js.css.gz 79 bytes [emitted]
+        sourceMap relatedAssets-chunk_js.css.map 197 bytes [emitted] [dev]
+          compressed relatedAssets-chunk_js.css.map.br 197 bytes [emitted]
+          compressed relatedAssets-chunk_js.css.map.gz 197 bytes [emitted]
+    assets by path ./*.js 14.4 KiB
+      asset relatedAssets-main.js 13.3 KiB [emitted] (name: main)
+        compressed relatedAssets-main.js.br 13.3 KiB [emitted]
+        compressed relatedAssets-main.js.gz 13.3 KiB [emitted]
+        sourceMap relatedAssets-main.js.map 11.3 KiB [emitted] [dev] (auxiliary name: main)
+          compressed relatedAssets-main.js.map.br 11.3 KiB [emitted]
+          compressed relatedAssets-main.js.map.gz 11.3 KiB [emitted]
+      asset relatedAssets-chunk_js.js 1.12 KiB [emitted]
+        compressed relatedAssets-chunk_js.js.br 1.12 KiB [emitted]
+        compressed relatedAssets-chunk_js.js.gz 1.12 KiB [emitted]
+        sourceMap relatedAssets-chunk_js.js.map 295 bytes [emitted] [dev]
+          compressed relatedAssets-chunk_js.js.map.br 295 bytes [emitted]
+          compressed relatedAssets-chunk_js.js.map.gz 295 bytes [emitted]
 Child exclude1:
-    asset exclude1-chunk_js.css 74 bytes [emitted]
-      sourceMap exclude1-chunk_js.css.map 192 bytes [emitted] [dev] 2 related assets
-       + 2 hidden related assets
-    asset exclude1-chunk_js.js 1.11 KiB [emitted]
-      sourceMap exclude1-chunk_js.js.map 290 bytes [emitted] [dev] 2 related assets
-       + 2 hidden related assets
-    asset exclude1-main.css 70 bytes [emitted] (name: main)
-      sourceMap exclude1-main.css.map 182 bytes [emitted] [dev] (auxiliary name: main) 2 related assets
-       + 2 hidden related assets
-    asset exclude1-main.js 13.3 KiB [emitted] (name: main)
-      sourceMap exclude1-main.js.map 11.3 KiB [emitted] [dev] (auxiliary name: main) 2 related assets
-       + 2 hidden related assets
+    assets by path ./*.css 144 bytes
+      asset exclude1-main.css 70 bytes [emitted] (name: main)
+        sourceMap exclude1-main.css.map 182 bytes [emitted] [dev] (auxiliary name: main)
+          excluded assets 364 bytes 2 assets
+          1 related asset
+        excluded assets 140 bytes 2 assets
+        1 related asset
+      asset exclude1-chunk_js.css 74 bytes [emitted]
+        sourceMap exclude1-chunk_js.css.map 192 bytes [emitted] [dev]
+          excluded assets 384 bytes 2 assets
+          1 related asset
+        excluded assets 148 bytes 2 assets
+        1 related asset
+    assets by path ./*.js 14.4 KiB
+      asset exclude1-main.js 13.3 KiB [emitted] (name: main)
+        sourceMap exclude1-main.js.map 11.3 KiB [emitted] [dev] (auxiliary name: main)
+          excluded assets 22.7 KiB 2 assets
+          1 related asset
+        excluded assets 26.6 KiB 2 assets
+        1 related asset
+      asset exclude1-chunk_js.js 1.11 KiB [emitted]
+        sourceMap exclude1-chunk_js.js.map 290 bytes [emitted] [dev]
+          excluded assets 580 bytes 2 assets
+          1 related asset
+        excluded assets 2.22 KiB 2 assets
+        1 related asset
 Child exclude2:
-    asset exclude2-chunk_js.css 74 bytes [emitted]
-      compressed exclude2-chunk_js.css.br 74 bytes [emitted]
-      compressed exclude2-chunk_js.css.gz 74 bytes [emitted]
-       + 1 hidden related asset
-    asset exclude2-chunk_js.js 1.11 KiB [emitted]
-      compressed exclude2-chunk_js.js.br 1.11 KiB [emitted]
-      compressed exclude2-chunk_js.js.gz 1.11 KiB [emitted]
-       + 1 hidden related asset
-    asset exclude2-main.css 70 bytes [emitted] (name: main)
-      compressed exclude2-main.css.br 70 bytes [emitted]
-      compressed exclude2-main.css.gz 70 bytes [emitted]
-       + 1 hidden related asset
-    asset exclude2-main.js 13.3 KiB [emitted] (name: main)
-      compressed exclude2-main.js.br 13.3 KiB [emitted]
-      compressed exclude2-main.js.gz 13.3 KiB [emitted]
-       + 1 hidden related asset
+    assets by path ./*.css 144 bytes
+      asset exclude2-main.css 70 bytes [emitted] (name: main)
+        compressed exclude2-main.css.br 70 bytes [emitted]
+        compressed exclude2-main.css.gz 70 bytes [emitted]
+        excluded assets 182 bytes 1 asset
+      asset exclude2-chunk_js.css 74 bytes [emitted]
+        compressed exclude2-chunk_js.css.br 74 bytes [emitted]
+        compressed exclude2-chunk_js.css.gz 74 bytes [emitted]
+        excluded assets 192 bytes 1 asset
+    assets by path ./*.js 14.4 KiB
+      asset exclude2-main.js 13.3 KiB [emitted] (name: main)
+        compressed exclude2-main.js.br 13.3 KiB [emitted]
+        compressed exclude2-main.js.gz 13.3 KiB [emitted]
+        excluded assets 11.3 KiB 1 asset
+      asset exclude2-chunk_js.js 1.11 KiB [emitted]
+        compressed exclude2-chunk_js.js.br 1.11 KiB [emitted]
+        compressed exclude2-chunk_js.js.gz 1.11 KiB [emitted]
+        excluded assets 290 bytes 1 asset
 Child exclude3:
-    asset exclude3-main.css 70 bytes [emitted] (name: main)
-      compressed exclude3-main.css.br 70 bytes [emitted]
-      compressed exclude3-main.css.gz 70 bytes [emitted]
-      sourceMap exclude3-main.css.map 182 bytes [emitted] [dev] (auxiliary name: main)
-        compressed exclude3-main.css.map.br 182 bytes [emitted]
-        compressed exclude3-main.css.map.gz 182 bytes [emitted]
-    asset exclude3-main.js 13.3 KiB [emitted] (name: main)
-      compressed exclude3-main.js.br 13.3 KiB [emitted]
-      compressed exclude3-main.js.gz 13.3 KiB [emitted]
-      sourceMap exclude3-main.js.map 11.3 KiB [emitted] [dev] (auxiliary name: main)
-        compressed exclude3-main.js.map.br 11.3 KiB [emitted]
-        compressed exclude3-main.js.map.gz 11.3 KiB [emitted]
-     + 2 hidden assets"
+    assets by path ./*.css 70 bytes
+      excluded assets 74 bytes 1 asset
+      asset exclude3-main.css 70 bytes [emitted] (name: main)
+        compressed exclude3-main.css.br 70 bytes [emitted]
+        compressed exclude3-main.css.gz 70 bytes [emitted]
+        sourceMap exclude3-main.css.map 182 bytes [emitted] [dev] (auxiliary name: main)
+          compressed exclude3-main.css.map.br 182 bytes [emitted]
+          compressed exclude3-main.css.map.gz 182 bytes [emitted]
+    assets by path ./*.js 13.3 KiB
+      excluded assets 1.11 KiB 1 asset
+      asset exclude3-main.js 13.3 KiB [emitted] (name: main)
+        compressed exclude3-main.js.br 13.3 KiB [emitted]
+        compressed exclude3-main.js.gz 13.3 KiB [emitted]
+        sourceMap exclude3-main.js.map 11.3 KiB [emitted] [dev] (auxiliary name: main)
+          compressed exclude3-main.js.map.br 11.3 KiB [emitted]
+          compressed exclude3-main.js.map.gz 11.3 KiB [emitted]"
 `;
 
 exports[`StatsTestCases should print correct stats for resolve-plugin-context 1`] = `
@@ -4204,18 +4234,20 @@ exports[`StatsTestCases should print correct stats for wasm-explorer-examples-sy
 "Hash: c96673e79f37716c681c
 Time: X ms
 Built at: 1970-04-20 12:42:42
-asset 230.bundle.js 242 bytes [emitted]
-asset 325.bundle.js 3.78 KiB [emitted]
-asset 32796a220f44b00723d7.module.wasm 156 bytes [emitted] [immutable]
-asset 526.bundle.js 364 bytes [emitted] (id hint: vendors)
-asset 52ce624dd5de9c91cd19.module.wasm 531 bytes [emitted] [immutable]
-asset 71ba3c2b7af4ee0e4b5c.module.wasm 120 bytes [emitted] [immutable]
-asset 780.bundle.js 569 bytes [emitted]
-asset 86f222634054d2a3b20f.module.wasm 154 bytes [emitted] [immutable]
-asset 986b1b3cbdd7749989ee.module.wasm 290 bytes [emitted] [immutable]
-asset 99.bundle.js 240 bytes [emitted]
-asset a938d40645ba21696ec8.module.wasm 154 bytes [emitted] [immutable]
-asset bundle.js 11.7 KiB [emitted] (name: main)
+assets by path ./*.js 16.8 KiB
+  asset bundle.js 11.7 KiB [emitted] (name: main)
+  asset 325.bundle.js 3.78 KiB [emitted]
+  asset 526.bundle.js 364 bytes [emitted] (id hint: vendors)
+  asset 230.bundle.js 242 bytes [emitted]
+  asset 99.bundle.js 240 bytes [emitted]
+  asset 780.bundle.js 569 bytes [emitted]
+assets by path ./*.wasm 1.37 KiB
+  asset 71ba3c2b7af4ee0e4b5c.module.wasm 120 bytes [emitted] [immutable]
+  asset a938d40645ba21696ec8.module.wasm 154 bytes [emitted] [immutable]
+  asset 32796a220f44b00723d7.module.wasm 156 bytes [emitted] [immutable]
+  asset 52ce624dd5de9c91cd19.module.wasm 531 bytes [emitted] [immutable]
+  asset 86f222634054d2a3b20f.module.wasm 154 bytes [emitted] [immutable]
+  asset 986b1b3cbdd7749989ee.module.wasm 290 bytes [emitted] [immutable]
 Entrypoint main = bundle.js
 chunk (runtime: main) 99.bundle.js 50 bytes (javascript) 531 bytes (webassembly) [rendered]
  ./duff.wasm 50 bytes (javascript) 531 bytes (webassembly) [built]

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -947,9 +947,8 @@ chunk cycle2.js (cycle2) 78 bytes [rendered]
   ./cycle2/index.js 14 bytes [built] [code generated]
 chunk cycles.js (cycles) 156 bytes [rendered]
   dependent modules 128 bytes [dependent] 6 modules
-  javascript modules 28 bytes
-    ./cycles/1/index.js 14 bytes [built] [code generated]
-    ./cycles/2/index.js 14 bytes [built] [code generated]
+  ./cycles/1/index.js 14 bytes [built] [code generated]
+  ./cycles/2/index.js 14 bytes [built] [code generated]
 chunk id-equals-name_js.js (id-equals-name_js) 1 bytes [rendered]
   ./id-equals-name.js?1 1 bytes [built] [code generated]
 chunk id-equals-name_js-_70e2.js (id-equals-name_js-_70e2) 1 bytes [rendered]
@@ -966,10 +965,9 @@ chunk tree.js (tree) 43 bytes [rendered]
   ./tree/index.js 14 bytes [built] [code generated]
 chunk trees.js (trees) 71 bytes [rendered]
   dependent modules 29 bytes [dependent] 3 modules
-  javascript modules 42 bytes
-    ./trees/1.js 14 bytes [built] [code generated]
-    ./trees/2.js 14 bytes [built] [code generated]
-    ./trees/3.js 14 bytes [built] [code generated]"
+  ./trees/1.js 14 bytes [built] [code generated]
+  ./trees/2.js 14 bytes [built] [code generated]
+  ./trees/3.js 14 bytes [built] [code generated]"
 `;
 
 exports[`StatsTestCases should print correct stats for immutable 1`] = `

--- a/test/cases/parsing/context/errors.js
+++ b/test/cases/parsing/context/errors.js
@@ -2,6 +2,6 @@ module.exports = [
 	[
 		/Module parse failed/,
 		{ moduleName: /dump-file\.txt/ },
-		{ moduleTrace: /templates sync/ }
+		{ moduleTrace: /templates\/ sync/ }
 	]
 ];

--- a/test/configCases/parsing/context/errors.js
+++ b/test/configCases/parsing/context/errors.js
@@ -1,3 +1,7 @@
 module.exports = [
-	[/Module parse failed/, {moduleName: /dump-file\.txt/}, {moduleTrace: /templates sync/}]
+	[
+		/Module parse failed/,
+		{ moduleName: /dump-file\.txt/ },
+		{ moduleTrace: /templates\/ sync/ }
+	]
 ];

--- a/test/smartGrouping.unittest.js
+++ b/test/smartGrouping.unittest.js
@@ -1,0 +1,84 @@
+"use strict";
+
+const smartGrouping = require("../lib/util/smartGrouping");
+
+describe("util/smartGrouping", () => {
+	it("should group correctly", () => {
+		const groupConfigs = [
+			{
+				getKeys(item) {
+					return item.match(/\d+/g);
+				},
+				createGroup(key, items) {
+					return {
+						name: `has number ${key}`,
+						items
+					};
+				}
+			},
+			{
+				getKeys(item) {
+					return item.match(/\w+/g);
+				},
+				createGroup(key, items) {
+					return {
+						name: `has word ${key}`,
+						items
+					};
+				}
+			}
+		];
+		expect(
+			smartGrouping(
+				[
+					"hello world a",
+					"hello world b 2",
+					"hello world c",
+					"hello world d",
+					"hello test",
+					"hello more test",
+					"more test",
+					"more tests",
+					"1 2 3",
+					"2 3 4",
+					"3 4 5"
+				],
+				groupConfigs
+			)
+		).toMatchInlineSnapshot(`
+		Array [
+		  Object {
+		    "items": Array [
+		      Object {
+		        "items": Array [
+		          "hello world a",
+		          "hello world b 2",
+		          "hello world c",
+		          "hello world d",
+		        ],
+		        "name": "has word world",
+		      },
+		      Object {
+		        "items": Array [
+		          "hello test",
+		          "hello more test",
+		        ],
+		        "name": "has word test",
+		      },
+		    ],
+		    "name": "has word hello",
+		  },
+		  Object {
+		    "items": Array [
+		      "1 2 3",
+		      "2 3 4",
+		      "3 4 5",
+		    ],
+		    "name": "has number 3",
+		  },
+		  "more test",
+		  "more tests",
+		]
+	`);
+	});
+});

--- a/test/statsCases/aggressive-splitting-entry/webpack.config.js
+++ b/test/statsCases/aggressive-splitting-entry/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = ["fitting", "content-change"].map(type => ({
 	stats: {
 		chunks: true,
 		chunkModules: true,
+		dependentModules: true,
 		chunkOrigins: true,
 		entrypoints: true,
 		modules: false,

--- a/test/statsCases/aggressive-splitting-on-demand/webpack.config.js
+++ b/test/statsCases/aggressive-splitting-on-demand/webpack.config.js
@@ -19,6 +19,7 @@ module.exports = {
 	stats: {
 		chunks: true,
 		chunkModules: true,
+		dependentModules: true,
 		chunkOrigins: true,
 		entrypoints: true,
 		modules: false,

--- a/test/statsCases/chunk-module-id-range/webpack.config.js
+++ b/test/statsCases/chunk-module-id-range/webpack.config.js
@@ -21,6 +21,7 @@ module.exports = {
 	stats: {
 		chunks: true,
 		chunkModules: true,
+		dependentModules: true,
 		chunkOrigins: true,
 		entrypoints: true,
 		modules: false,

--- a/test/statsCases/chunks-development/webpack.config.js
+++ b/test/statsCases/chunks-development/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
 		reasons: true,
 		chunks: true,
 		chunkModules: true,
+		dependentModules: true,
 		chunkRelations: true,
 		chunkOrigins: true,
 		modules: false,

--- a/test/statsCases/chunks/webpack.config.js
+++ b/test/statsCases/chunks/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
 		reasons: true,
 		chunks: true,
 		chunkModules: true,
+		dependentModules: true,
 		chunkRelations: true,
 		chunkOrigins: true,
 		modules: false,

--- a/test/statsCases/circular-correctness/webpack.config.js
+++ b/test/statsCases/circular-correctness/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
 		chunks: true,
 		chunkRelations: true,
 		chunkModules: true,
+		dependentModules: true,
 		modules: false
 	}
 };

--- a/test/statsCases/entry-filename/webpack.config.js
+++ b/test/statsCases/entry-filename/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
 		reasons: true,
 		chunks: true,
 		chunkModules: true,
+		dependentModules: true,
 		chunkRelations: true,
 		chunkOrigins: true,
 		modules: false,

--- a/test/statsCases/graph-correctness-entries/webpack.config.js
+++ b/test/statsCases/graph-correctness-entries/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
 		chunks: true,
 		chunkRelations: true,
 		chunkModules: true,
+		dependentModules: true,
 		modules: false,
 		reasons: true
 	}

--- a/test/statsCases/graph-correctness-modules/webpack.config.js
+++ b/test/statsCases/graph-correctness-modules/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
 		chunks: true,
 		chunkRelations: true,
 		chunkModules: true,
+		dependentModules: true,
 		modules: false,
 		reasons: true
 	}

--- a/test/statsCases/graph-roots/webpack.config.js
+++ b/test/statsCases/graph-roots/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
 	stats: {
 		all: false,
 		chunks: true,
-		chunkRootModules: true
+		chunkModules: true,
+		dependentModules: false
 	}
 };

--- a/test/statsCases/limit-chunk-count-plugin/webpack.config.js
+++ b/test/statsCases/limit-chunk-count-plugin/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = [1, 2, 3, 4].map(n => ({
 	],
 	stats: {
 		chunkModules: true,
+		dependentModules: true,
 		chunkRelations: true,
 		modules: false,
 		chunks: true

--- a/test/statsCases/max-modules/webpack.config.js
+++ b/test/statsCases/max-modules/webpack.config.js
@@ -4,6 +4,6 @@ module.exports = {
 	entry: "./index",
 	performance: false,
 	stats: {
-		maxModules: 20
+		modulesSpace: 20
 	}
 };

--- a/test/statsCases/module-assets/webpack.config.js
+++ b/test/statsCases/module-assets/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
 		chunkGroups: true,
 		chunks: true,
 		chunkModules: true,
+		dependentModules: true,
 		modules: true,
 		moduleAssets: true
 	},

--- a/test/statsCases/module-deduplication-named/webpack.config.js
+++ b/test/statsCases/module-deduplication-named/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = {
 		builtAt: false,
 		chunks: true,
 		chunkModules: true,
+		dependentModules: true,
 		modules: false
 	}
 };

--- a/test/statsCases/module-deduplication/webpack.config.js
+++ b/test/statsCases/module-deduplication/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = {
 		builtAt: false,
 		chunks: true,
 		chunkModules: true,
+		dependentModules: true,
 		modules: false
 	}
 };

--- a/test/statsCases/optimize-chunks/webpack.config.js
+++ b/test/statsCases/optimize-chunks/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
 		chunks: true,
 		chunkRelations: true,
 		chunkModules: true,
+		dependentModules: true,
 		chunkOrigins: true
 	}
 };

--- a/test/statsCases/reverse-sort-modules/webpack.config.js
+++ b/test/statsCases/reverse-sort-modules/webpack.config.js
@@ -4,7 +4,7 @@ module.exports = {
 	entry: "./index",
 	performance: false,
 	stats: {
-		maxModules: 20,
-		modulesSort: "!id"
+		modulesSpace: Infinity,
+		modulesSort: "!name"
 	}
 };

--- a/test/statsCases/runtime-specific-used-exports/webpack.config.js
+++ b/test/statsCases/runtime-specific-used-exports/webpack.config.js
@@ -8,6 +8,7 @@ const stats = {
 	usedExports: true,
 	chunks: true,
 	chunkModules: true,
+	dependentModules: true,
 	modules: true,
 	orphanModules: true,
 	nestedModules: true

--- a/test/statsCases/side-effects-optimization/webpack.config.js
+++ b/test/statsCases/side-effects-optimization/webpack.config.js
@@ -3,7 +3,7 @@ const baseConfig = {
 	mode: "production",
 	entry: "./index",
 	stats: {
-		maxModules: Infinity,
+		modulesSpace: Infinity,
 		optimizationBailout: true,
 		nestedModules: true,
 		usedExports: true,

--- a/test/statsCases/simple-more-info/webpack.config.js
+++ b/test/statsCases/simple-more-info/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
 	stats: {
 		reasons: true,
 		chunkModules: true,
+		dependentModules: true,
 		chunkOrigins: true,
 		modules: true,
 		cached: true,

--- a/test/statsCases/split-chunks-chunk-name/webpack.config.js
+++ b/test/statsCases/split-chunks-chunk-name/webpack.config.js
@@ -6,6 +6,7 @@ const stats = {
 	chunks: true,
 	chunkRelations: true,
 	chunkModules: true,
+	dependentModules: true,
 	chunkOrigins: true,
 	entrypoints: true,
 	modules: false

--- a/test/statsCases/split-chunks-keep-remaining-size/webpack.config.js
+++ b/test/statsCases/split-chunks-keep-remaining-size/webpack.config.js
@@ -6,6 +6,7 @@ const stats = {
 	chunks: true,
 	chunkRelations: true,
 	chunkModules: true,
+	dependentModules: true,
 	chunkOrigins: true,
 	entrypoints: true,
 	modules: false

--- a/test/statsCases/wasm-explorer-examples-sync/webpack.config.js
+++ b/test/statsCases/wasm-explorer-examples-sync/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
 	stats: {
 		chunks: true,
 		chunkModules: true,
+		dependentModules: true,
 		modules: true
 	},
 	experiments: {

--- a/test/watchCases/plugins/module-concatenation-plugin/0/index.js
+++ b/test/watchCases/plugins/module-concatenation-plugin/0/index.js
@@ -1,13 +1,20 @@
-it("should watch for changes", function() {
-	if(WATCH_STEP === '0') {
-		expect(require("./foo/" + WATCH_STEP)).toBe('This is only a test.' + WATCH_STEP);
-	}
-	else if(WATCH_STEP === '1') {
-		expect(require("./foo/" + WATCH_STEP)).toBe('This should be a test.' + WATCH_STEP);
-	}
-	else if(WATCH_STEP === '2') {
-		expect(require("./foo/" + WATCH_STEP)).toBe('This should be working.' + WATCH_STEP);
+it("should watch for changes", function () {
+	if (WATCH_STEP === "0") {
+		expect(require("./foo/" + WATCH_STEP)).toBe(
+			"This is only a test." + WATCH_STEP
+		);
+	} else if (WATCH_STEP === "1") {
+		expect(require("./foo/" + WATCH_STEP)).toBe(
+			"This should be a test." + WATCH_STEP
+		);
+	} else if (WATCH_STEP === "2") {
+		expect(require("./foo/" + WATCH_STEP)).toBe(
+			"This should be working." + WATCH_STEP
+		);
 	}
 
-	expect(STATS_JSON.modules.filter(m => !m.runtime).length).toBe(4 + Number(WATCH_STEP));
+	const realModule = m => m.moduleType !== "runtime" && !m.orphan;
+	expect(STATS_JSON.modules.filter(realModule).length).toBe(
+		4 + Number(WATCH_STEP)
+	);
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -3195,6 +3195,16 @@ declare class Generator {
 	updateHash(hash: Hash, __1: UpdateHashContextGenerator): void;
 	static byType(map?: any): ByTypeGenerator;
 }
+declare interface GroupConfig<T, R> {
+	getKeys: (arg0: T) => string[];
+	createGroup: (arg0: string, arg1: (T | R)[], arg2: T[]) => R;
+	getOptions?: (arg0: string, arg1: T[]) => GroupOptions;
+}
+declare interface GroupOptions {
+	groupChildren?: boolean;
+	force?: boolean;
+	greedy?: boolean;
+}
 declare interface HMRJavascriptParserHooks {
 	hotAcceptCallback: SyncBailHook<[any, string[]], void>;
 	hotAcceptWithoutCallback: SyncBailHook<[any, string[]], void>;
@@ -8227,6 +8237,7 @@ declare abstract class StatsFactory {
 			SyncBailHook<[((arg0?: any, arg1?: any) => number)[], any], any>
 		>;
 		filterSorted: HookMap<SyncBailHook<[any, any, number, number], any>>;
+		groupResults: HookMap<SyncBailHook<[GroupConfig<any, any>[], any], any>>;
 		sortResults: HookMap<
 			SyncBailHook<[((arg0?: any, arg1?: any) => number)[], any], any>
 		>;
@@ -8257,6 +8268,11 @@ declare interface StatsOptions {
 	 * Sort the assets by that field.
 	 */
 	assetsSort?: string;
+
+	/**
+	 * Space to display assets (groups will be collapsed to fit this space).
+	 */
+	assetsSpace?: number;
 
 	/**
 	 * Add built at time information.
@@ -8404,6 +8420,31 @@ declare interface StatsOptions {
 		| RegExp
 		| FilterItemTypes[]
 		| ((value: string) => boolean);
+
+	/**
+	 * Group assets by how their are related to chunks.
+	 */
+	groupAssetsByChunk?: boolean;
+
+	/**
+	 * Group assets by their extension.
+	 */
+	groupAssetsByExtension?: boolean;
+
+	/**
+	 * Group assets by their asset info (immutable, development, hotModuleReplacement, etc).
+	 */
+	groupAssetsByInfo?: boolean;
+
+	/**
+	 * Group assets by their path.
+	 */
+	groupAssetsByPath?: boolean;
+
+	/**
+	 * Group assets by their status (emitted, compared for emit or cached).
+	 */
+	groupAssetsByStatus?: boolean;
 
 	/**
 	 * Add the hash of the compilation.

--- a/types.d.ts
+++ b/types.d.ts
@@ -8435,6 +8435,11 @@ declare interface StatsOptions {
 	groupAssetsByChunk?: boolean;
 
 	/**
+	 * Group assets by their status (emitted, compared for emit or cached).
+	 */
+	groupAssetsByEmitStatus?: boolean;
+
+	/**
 	 * Group assets by their extension.
 	 */
 	groupAssetsByExtension?: boolean;
@@ -8448,11 +8453,6 @@ declare interface StatsOptions {
 	 * Group assets by their path.
 	 */
 	groupAssetsByPath?: boolean;
-
-	/**
-	 * Group assets by their status (emitted, compared for emit or cached).
-	 */
-	groupAssetsByStatus?: boolean;
 
 	/**
 	 * Group modules by their attributes (errors, warnings, optional, orphan, or dependent).

--- a/types.d.ts
+++ b/types.d.ts
@@ -8455,7 +8455,7 @@ declare interface StatsOptions {
 	groupAssetsByPath?: boolean;
 
 	/**
-	 * Group modules by their attributes (errors, warnings, optional, orphan, or dependent).
+	 * Group modules by their attributes (errors, warnings, assets, optional, orphan, or dependent).
 	 */
 	groupModulesByAttributes?: boolean;
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -8582,7 +8582,7 @@ declare interface StatsOptions {
 	/**
 	 * Add information about runtime modules.
 	 */
-	runtime?: boolean;
+	runtimeModules?: boolean;
 
 	/**
 	 * Add the source code of modules.

--- a/types.d.ts
+++ b/types.d.ts
@@ -1245,6 +1245,7 @@ declare class Compilation {
 	usedModuleIds: Set<number>;
 	needAdditionalPass: boolean;
 	builtModules: WeakSet<Module>;
+	codeGeneratedModules: WeakSet<Module>;
 	emittedAssets: Set<string>;
 	comparedForEmitAssets: Set<string>;
 	fileDependencies: LazySet<string>;
@@ -3203,7 +3204,7 @@ declare interface GroupConfig<T, R> {
 declare interface GroupOptions {
 	groupChildren?: boolean;
 	force?: boolean;
-	greedy?: boolean;
+	targetGroupCount?: number;
 }
 declare interface HMRJavascriptParserHooks {
 	hotAcceptCallback: SyncBailHook<[any, string[]], void>;
@@ -3414,7 +3415,8 @@ declare class JavascriptModulesPlugin {
 	): Source;
 	renderMain(
 		renderContext: MainRenderContext,
-		hooks: CompilationHooksJavascriptModulesPlugin
+		hooks: CompilationHooksJavascriptModulesPlugin,
+		compilation: Compilation
 	): Source;
 	renderBootstrap(
 		renderContext: RenderBootstrapContext,
@@ -7395,6 +7397,7 @@ declare class RuntimeModule extends Module {
 	stage: number;
 	compilation: Compilation;
 	chunk: Chunk;
+	fullHash: boolean;
 	attach(compilation: Compilation, chunk: Chunk): void;
 	generate(): string;
 	getGeneratedCode(): string;
@@ -8290,6 +8293,11 @@ declare interface StatsOptions {
 	cachedAssets?: boolean;
 
 	/**
+	 * Add information about cached (not built) modules.
+	 */
+	cachedModules?: boolean;
+
+	/**
 	 * Add children information.
 	 */
 	children?: boolean;
@@ -8313,11 +8321,6 @@ declare interface StatsOptions {
 	 * Add information about parent, children and sibling chunks to chunk information.
 	 */
 	chunkRelations?: boolean;
-
-	/**
-	 * Add root modules information to chunk information.
-	 */
-	chunkRootModules?: boolean;
 
 	/**
 	 * Add chunk information.
@@ -8365,6 +8368,11 @@ declare interface StatsOptions {
 	 * Context directory for request shortening.
 	 */
 	context?: string;
+
+	/**
+	 * Show chunk modules that are dependencies of other modules of the chunk.
+	 */
+	dependentModules?: boolean;
 
 	/**
 	 * Add module depth in module graph.
@@ -8447,6 +8455,26 @@ declare interface StatsOptions {
 	groupAssetsByStatus?: boolean;
 
 	/**
+	 * Group modules by their attributes (errors, warnings, optional, orphan, or dependent).
+	 */
+	groupModulesByAttributes?: boolean;
+
+	/**
+	 * Group modules by their status (cached or built and cacheable).
+	 */
+	groupModulesByCacheStatus?: boolean;
+
+	/**
+	 * Group modules by their extension.
+	 */
+	groupModulesByExtension?: boolean;
+
+	/**
+	 * Group modules by their path.
+	 */
+	groupModulesByPath?: boolean;
+
+	/**
 	 * Add the hash of the compilation.
 	 */
 	hash?: boolean;
@@ -8477,11 +8505,6 @@ declare interface StatsOptions {
 	loggingTrace?: boolean;
 
 	/**
-	 * Set the maximum number of modules to be shown.
-	 */
-	maxModules?: number;
-
-	/**
 	 * Add information about assets inside modules.
 	 */
 	moduleAssets?: boolean;
@@ -8500,6 +8523,11 @@ declare interface StatsOptions {
 	 * Sort the modules by that field.
 	 */
 	modulesSort?: string;
+
+	/**
+	 * Space to display modules (groups will be collapsed to fit this space, values is in number of modules/groups).
+	 */
+	modulesSpace?: number;
 
 	/**
 	 * Add information about modules nested in other modules (like with module concatenation).


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
existing tests updates
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
New options:
* `stats.assetsSpace` how many items of assets should be displayed (groups will be collapsed to fit this space)
* `stats.modulesSpace` how many items of modules should be displayed (groups will be collapsed to fit this space)
* `stats.chunkModulesSpace` how many items of chunk modules should be displayed (groups will be collapsed to fit this space)
* `stats.nestedModulesSpace` how many items of nested modules should be displayed (groups will be collapsed to fit this space)
* `stats.cachedModules` (better named variant of `stats.cached`) should cached modules be displayed
* `stats.runtimeModules` (better named variant of `stats.runtime`) should runtime modules be displayed
* `stats.dependentModules` should chunk modules that are dependencies of other modules of the chunk be displayed (only for `stats.chunkModules`)
* `stats.groupAssetsByChunk` assets are grouped by chunk names
* `stats.groupAssetsByPath` and `stats.groupAssetsByExtension` assets are groups by path and/or extension
* `stats.groupAssetsByInfo` Group assets by their asset info (immutable, development, hotModuleReplacement, etc).
* `stats.groupAssetsByEmitStatus` Group assets by their emit status (emitted, compared for emit or cached).
* `stats.groupModulesByAttributes` Group modules by their attributes (errors, warnings, assets, optional, orphan, or dependent).
* `stats.groupModulesByCacheStatus` Group modules by their status (cached or built and cacheable).
* `stats.groupModulesByPath` and `stats.groupModulesByExtension` modules are groups by path and/or extension of the resource

Changed defaults:
* `stats.preset: "minimal"` shows number of assets
* for the text format all group options are enabled and assetsSpace: 15, modulesSpace: 15, nested/chunkModulesSpace: 10
* cachedModules defaults to false in the text format

Removed options:
* `stats.chunkRootModules` removed
* `stats.maxModules` removed
* `stats.runtime` removed
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
