### PR TITLE
fix bug for maxCallStack in ContextModuleFactory

### DIFF
--- a/lib/ContextModuleFactory.js
+++ b/lib/ContextModuleFactory.js
@@ -276,7 +276,26 @@ module.exports = class ContextModuleFactory extends ModuleFactory {
 		} = options;
 		if (!regExp || !resource) return callback(null, []);
 
-		const addDirectory = (directory, callback) => {
+		const addDirectoryChecked = (directory, visited, callback) => {
+			fs.realpath(directory, (err, realPath) => {
+				if (err) return callback(err);
+				if (visited.has(realPath)) return callback(null, []);
+				let recursionStack;
+				addDirectory(
+					directory,
+					(dir, callback) => {
+						if (recursionStack === undefined) {
+							recursionStack = new Set(visited);
+							recursionStack.add(realPath);
+						}
+						addDirectoryChecked(dir, recursionStack, callback);
+					},
+					callback
+				);
+			});
+		};
+
+		const addDirectory = (directory, addSubDirectory, callback) => {
 			fs.readdir(directory, (err, files) => {
 				if (err) return callback(err);
 				files = files.map(file => file.normalize("NFC"));
@@ -301,7 +320,7 @@ module.exports = class ContextModuleFactory extends ModuleFactory {
 
 								if (stat.isDirectory()) {
 									if (!recursive) return callback();
-									addDirectory.call(this, subResource, callback);
+									addSubDirectory(subResource, callback);
 								} else if (
 									stat.isFile() &&
 									(!include || subResource.match(include))
@@ -358,6 +377,12 @@ module.exports = class ContextModuleFactory extends ModuleFactory {
 			});
 		};
 
-		addDirectory(resource, callback);
+		if (typeof fs.realpath === "function") {
+			addDirectoryChecked(resource, new Set(), callback);
+		} else {
+			const addSubDirectory = (dir, callback) =>
+				addDirectory(dir, addSubDirectory, callback);
+			addDirectory(resource, addSubDirectory, callback);
+		}
 	}
 };


### PR DESCRIPTION
What existing problem does the pull request solve?
max call stack error when resolving dependencies
Resolves #11378 [Webpack 5] ContextModuleFactory - RangeError: Maximum call stack size exceeded
**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
None
