### PR TITLE
Remove usage of removed API in rebuildModule

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -2683,17 +2683,9 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 	 * @returns {void}
 	 */
 	removeReasonsOfDependencyBlock(module, block) {
-		const chunkGraph = this.chunkGraph;
-		const iteratorDependency = d => {
-			if (!d.module) {
-				return;
-			}
-			if (d.module.removeReason(module, d)) {
-				for (const chunk of chunkGraph.getModuleChunksIterable(d.module)) {
-					this.patchChunksAfterReasonRemoval(d.module, chunk);
-				}
-			}
-		};
+
+
+
 
 		if (block.blocks) {
 			for (const b of block.blocks) {
@@ -2702,7 +2694,13 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 		}
 
 		if (block.dependencies) {
-			for (const dep of block.dependencies) iteratorDependency(dep);
+			for (const dep of block.dependencies) {
+
+				const originalModule = this.moduleGraph.getModule(dep);
+				if (originalModule) {
+					this.moduleGraph.removeConnection(dep);
+				}
+			}
 		}
 	}
 
@@ -2730,11 +2728,15 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 	 * @returns {void}
 	 */
 	removeChunkFromDependencies(block, chunk) {
+		/**
+		 * @param {Dependency} d
+		 */
 		const iteratorDependency = d => {
-			if (!d.module) {
+			const depModule = this.moduleGraph.getModule(d);
+			if (!depModule) {
 				return;
 			}
-			this.patchChunksAfterReasonRemoval(d.module, chunk);
+			this.patchChunksAfterReasonRemoval(depModule, chunk);
 		};
 
 		const blocks = block.blocks;

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -2694,6 +2694,14 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 				const originalModule = this.moduleGraph.getModule(dep);
 				if (originalModule) {
 					this.moduleGraph.removeConnection(dep);
+
+					if (this.chunkGraph) {
+						for (const chunk of this.chunkGraph.getModuleChunks(
+							originalModule
+						)) {
+							this.patchChunksAfterReasonRemoval(originalModule, chunk);
+						}
+					}
 				}
 			}
 		}

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -2683,10 +2683,6 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 	 * @returns {void}
 	 */
 	removeReasonsOfDependencyBlock(module, block) {
-
-
-
-
 		if (block.blocks) {
 			for (const b of block.blocks) {
 				this.removeReasonsOfDependencyBlock(module, b);
@@ -2695,7 +2691,6 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 
 		if (block.dependencies) {
 			for (const dep of block.dependencies) {
-
 				const originalModule = this.moduleGraph.getModule(dep);
 				if (originalModule) {
 					this.moduleGraph.removeConnection(dep);
@@ -2729,7 +2724,7 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 	 */
 	removeChunkFromDependencies(block, chunk) {
 		/**
-		 * @param {Dependency} d
+		 * @param {Dependency} d dependency to (maybe) patch up
 		 */
 		const iteratorDependency = d => {
 			const depModule = this.moduleGraph.getModule(d);

--- a/test/configCases/rebuild/finishModules/a.js
+++ b/test/configCases/rebuild/finishModules/a.js
@@ -1,0 +1,9 @@
+
+import { doThings, foo } from './other-file';
+
+export {
+	doThings,
+	foo,
+}
+
+export const valueFromA = 'A';

--- a/test/configCases/rebuild/finishModules/a.js
+++ b/test/configCases/rebuild/finishModules/a.js
@@ -1,9 +1,5 @@
+import { doThings, foo } from "./other-file";
 
-import { doThings, foo } from './other-file';
+export { doThings, foo };
 
-export {
-	doThings,
-	foo,
-}
-
-export const valueFromA = 'A';
+export const valueFromA = "A";

--- a/test/configCases/rebuild/finishModules/index.js
+++ b/test/configCases/rebuild/finishModules/index.js
@@ -1,13 +1,20 @@
-
-import { doThings, foo, valueFromA } from './a';
+import { doThings, foo, valueFromA } from "./a";
 it("should compile", function (done) {
-	doThings(true);
+	expect(doThings("ok")).toBe("ok");
 
 	// Should be replaced by the code in the config.
-	expect(foo.foo).toBe('bar');
-	expect(valueFromA).toBe('A')
+	expect(foo.foo).toBe("bar");
+	expect(valueFromA).toBe("A");
 
 	done();
 });
 
-
+it("should not reference the chunk", () => {
+	expect(__STATS__.chunks.length).toEqual(1);
+	expect(
+		__STATS__.modules
+			.filter(m => m.moduleType !== "runtime")
+			.map(m => m.name)
+			.sort()
+	).toEqual(["./a.js", "./index.js", "./other-file.js"]);
+});

--- a/test/configCases/rebuild/finishModules/index.js
+++ b/test/configCases/rebuild/finishModules/index.js
@@ -1,0 +1,12 @@
+import { doThings, foo }from "./other-file";
+
+it("should compile", function (done) {
+	doThings(true);
+
+	expect(foo.foo).toBe('bar');
+
+
+	done();
+});
+
+

--- a/test/configCases/rebuild/finishModules/index.js
+++ b/test/configCases/rebuild/finishModules/index.js
@@ -1,10 +1,11 @@
-import { doThings, foo }from "./other-file";
 
+import { doThings, foo, valueFromA } from './a';
 it("should compile", function (done) {
 	doThings(true);
 
+	// Should be replaced by the code in the config.
 	expect(foo.foo).toBe('bar');
-
+	expect(valueFromA).toBe('A')
 
 	done();
 });

--- a/test/configCases/rebuild/finishModules/loader.js
+++ b/test/configCases/rebuild/finishModules/loader.js
@@ -1,0 +1,5 @@
+module.exports = function (source) {
+	if (this.shouldReplace)
+		return "module.exports = { foo: { foo: 'bar' }, doThings: (v) => v}";
+	return source;
+};

--- a/test/configCases/rebuild/finishModules/module.js
+++ b/test/configCases/rebuild/finishModules/module.js
@@ -1,0 +1,1 @@
+export default "foo";

--- a/test/configCases/rebuild/finishModules/other-file.js
+++ b/test/configCases/rebuild/finishModules/other-file.js
@@ -1,0 +1,8 @@
+export function doThings(stuff) {
+	return stuff;
+}
+
+
+export const foo = {
+	foo: 'foo',
+}

--- a/test/configCases/rebuild/finishModules/other-file.js
+++ b/test/configCases/rebuild/finishModules/other-file.js
@@ -1,8 +1,9 @@
-export function doThings(stuff) {
-	return stuff;
-}
+import foo from "./module";
 
+export function doThings(stuff) {
+	return import("./chunk");
+}
 
 export const foo = {
-	foo: 'foo',
-}
+	foo
+};

--- a/test/configCases/rebuild/finishModules/webpack.config.js
+++ b/test/configCases/rebuild/finishModules/webpack.config.js
@@ -10,7 +10,7 @@ var testPlugin = compiler => {
 		NormalModule.getCompilationHooks(compilation).loader.tap(
 			"TestPlugin",
 			loaderContext => {
-				loaderContext.shouldReplace = shouldReplace;
+				/** @type {any} */ (loaderContext).shouldReplace = shouldReplace;
 			}
 		);
 		compilation.hooks.finishModules.tapAsync(

--- a/test/configCases/rebuild/finishModules/webpack.config.js
+++ b/test/configCases/rebuild/finishModules/webpack.config.js
@@ -20,11 +20,17 @@ var testPlugin = function () {
 				return m.resource && m.resource === src;
 			}
 
+			const newSrc = `module.exports = { foo: { foo: 'bar' }, doThings: () => { }}`;
+
 			const module = Array.from(compilation.modules).find(matcher);
 			/** @type {any} */
 			const inputFileSystem = compilation.inputFileSystem;
 			const cachedFileInput = inputFileSystem._readFileBackend._data.get(src);
-			cachedFileInput.result = `module.exports = { foo: { foo: 'bar' }, doThings: () => { }}`;
+			if (!cachedFileInput) {
+				inputFileSystem._readFileBackend._data.set(src, newSrc);
+			} else {
+				cachedFileInput.result = `module.exports = { foo: { foo: 'bar' }, doThings: () => { }}`;
+			}
 
 			if (!module) {
 				throw new Error("something went wrong");

--- a/test/configCases/rebuild/finishModules/webpack.config.js
+++ b/test/configCases/rebuild/finishModules/webpack.config.js
@@ -1,5 +1,4 @@
-const { Source } = require("webpack-sources");
-const { resolve, join } = require('path');
+const { resolve, join } = require("path");
 
 /**
  * @this {import("../../../../").Compiler} the compiler
@@ -10,12 +9,22 @@ var testPlugin = function () {
 			modules,
 			callback
 		) {
-			const src = resolve(join(__dirname, 'other-file.js'));
-			const module = Array.from(compilation.modules).find(m => m.resource == src)
-			const cachedFileInput = compilation.inputFileSystem._readFileBackend._data.get(src)
+			const src = resolve(join(__dirname, "other-file.js"));
 
-			cachedFileInput.result = `module.exports = { foo: { foo: 'bar' }, doThings: () => { }}`
+			/**
+			 *
+			 * @param {any} m test
+			 * @returns {boolean} test
+			 */
+			function matcher(m) {
+				return m.resource && m.resource === src;
+			}
 
+			const module = Array.from(compilation.modules).find(matcher);
+			/** @type {any} */
+			const inputFileSystem = compilation.inputFileSystem;
+			const cachedFileInput = inputFileSystem._readFileBackend._data.get(src);
+			cachedFileInput.result = `module.exports = { foo: { foo: 'bar' }, doThings: () => { }}`;
 
 			if (!module) {
 				throw new Error("something went wrong");

--- a/test/configCases/rebuild/finishModules/webpack.config.js
+++ b/test/configCases/rebuild/finishModules/webpack.config.js
@@ -1,0 +1,34 @@
+const { Source } = require("webpack-sources");
+const { resolve, join } = require('path');
+
+/**
+ * @this {import("../../../../").Compiler} the compiler
+ */
+var testPlugin = function () {
+	this.hooks.compilation.tap("TestPlugin", compilation => {
+		compilation.hooks.finishModules.tapAsync("TestPlugin", function (
+			modules,
+			callback
+		) {
+			const src = resolve(join(__dirname, 'other-file.js'));
+			const module = Array.from(compilation.modules).find(m => m.resource == src)
+			const cachedFileInput = compilation.inputFileSystem._readFileBackend._data.get(src)
+
+			cachedFileInput.result = `module.exports = { foo: { foo: 'bar' }, doThings: () => { }}`
+
+
+			if (!module) {
+				throw new Error("something went wrong");
+			}
+
+			compilation.rebuildModule(module, () => {
+				callback();
+			});
+		});
+	});
+};
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	plugins: [testPlugin]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This PR is to address the issue raised here: https://github.com/webpack/webpack/issues/11269 - The `removeReasonsOfDependencyBlock` method was calling the removed `dependency.module` 

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Bugfix. 

**Did you add tests for your changes?**

Yes. I'm not very happy with the method of the testing here, but I'm not familiar enough with webpack to do it in a better way. 

The test works by replacing the contents of the `other-file`, and change the exports. The test then asserts that the exports have changed.

One idea I had was to use a loader to change the `other-file`.. However I struggled with writing a custom loader.

Very open to suggestions and improvements here. 

**Does this PR introduce a breaking change?**

I don't believe so. 

**What needs to be documented once your changes are merged?**

None, I believe? 

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
