### PR TITLE
move default externals from target into externalsPresets option

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -640,6 +640,10 @@ export interface WebpackOptions {
 	 */
 	externals?: Externals;
 	/**
+	 * Enable presets of externals for specific targets.
+	 */
+	externalsPresets?: ExternalsPresets;
+	/**
 	 * Specifies the default type of externals ('amd*', 'umd*', 'system' and 'jsonp' depend on output.libraryTarget set to the same value).
 	 */
 	externalsType?: ExternalsType;
@@ -938,6 +942,35 @@ export interface Experiments {
 	 * Allow using top-level-await in EcmaScript Modules.
 	 */
 	topLevelAwait?: boolean;
+}
+/**
+ * Enable presets of externals for specific targets.
+ */
+export interface ExternalsPresets {
+	/**
+	 * Treat electron built-in modules in the main context like 'app', 'ipc-main' or 'shell' as external and load them via require() when used.
+	 */
+	electronMain?: boolean;
+	/**
+	 * Treat electron built-in modules in the preload context like 'web-frame', 'ipc-renderer' or 'shell' as external and load them via require() when used.
+	 */
+	electronPreload?: boolean;
+	/**
+	 * Treat node.js built-in modules like fs, path or vm as external and load them via require() when used.
+	 */
+	node?: boolean;
+	/**
+	 * Treat node-webkit legacy nw.gui module as external and load it via require() when used.
+	 */
+	nodeWebkit?: boolean;
+	/**
+	 * Treat references to 'http(s)://...' and 'std:...' as external and load them via import when used (Note that this changes execution order as externals are executed before any other code in the chunk).
+	 */
+	web?: boolean;
+	/**
+	 * Treat references to 'http(s)://...' and 'std:...' as external and load them via async import() when used (Note that this external type is an async module, which has various effects on the execution).
+	 */
+	webAsync?: boolean;
 }
 /**
  * Options for infrastructure level logging.
@@ -2460,6 +2493,10 @@ export interface WebpackOptionsNormalized {
 	 * Specify dependencies that shouldn't be resolved by webpack, but should become dependencies of the resulting bundle. The kind of the dependency depends on `output.libraryTarget`.
 	 */
 	externals: Externals;
+	/**
+	 * Enable presets of externals for specific targets.
+	 */
+	externalsPresets: ExternalsPresets;
 	/**
 	 * Specifies the default type of externals ('amd*', 'umd*', 'system' and 'jsonp' depend on output.libraryTarget set to the same value).
 	 */

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -87,31 +87,19 @@ class WebpackOptionsApply extends OptionsApply {
 				}
 				case "node":
 				case "async-node": {
-					const NodeTargetPlugin = require("./node/NodeTargetPlugin");
-					new NodeTargetPlugin().apply(compiler);
 					new LoaderTargetPlugin("node").apply(compiler);
 					break;
 				}
 				case "node-webkit": {
-					const NodeTargetPlugin = require("./node/NodeTargetPlugin");
-					const ExternalsPlugin = require("./ExternalsPlugin");
-					new NodeTargetPlugin().apply(compiler);
-					new ExternalsPlugin("commonjs", "nw.gui").apply(compiler);
 					new LoaderTargetPlugin(options.target).apply(compiler);
 					break;
 				}
 				case "electron-main": {
-					const NodeTargetPlugin = require("./node/NodeTargetPlugin");
-					const ElectronTargetPlugin = require("./electron/ElectronTargetPlugin");
-					new NodeTargetPlugin().apply(compiler);
-					new ElectronTargetPlugin(true).apply(compiler);
 					new LoaderTargetPlugin(options.target).apply(compiler);
 					break;
 				}
 				case "electron-renderer":
 				case "electron-preload": {
-					const ElectronTargetPlugin = require("./electron/ElectronTargetPlugin");
-					new ElectronTargetPlugin(false).apply(compiler);
 					new LoaderTargetPlugin(options.target).apply(compiler);
 					break;
 				}
@@ -120,6 +108,30 @@ class WebpackOptionsApply extends OptionsApply {
 			}
 		} else {
 			options.target(compiler);
+		}
+
+		if (options.externalsPresets.node) {
+			const NodeTargetPlugin = require("./node/NodeTargetPlugin");
+			new NodeTargetPlugin().apply(compiler);
+		}
+		if (options.externalsPresets.electronMain) {
+			const ElectronTargetPlugin = require("./electron/ElectronTargetPlugin");
+			new ElectronTargetPlugin(true).apply(compiler);
+		}
+		if (options.externalsPresets.electronPreload) {
+			const ElectronTargetPlugin = require("./electron/ElectronTargetPlugin");
+			new ElectronTargetPlugin(false).apply(compiler);
+		}
+		if (options.externalsPresets.nodeWebkit) {
+			const ExternalsPlugin = require("./ExternalsPlugin");
+			new ExternalsPlugin("commonjs", "nw.gui").apply(compiler);
+		}
+		if (options.externalsPresets.webAsync) {
+			const ExternalsPlugin = require("./ExternalsPlugin");
+			new ExternalsPlugin("import", /^(https?:\/\/|std:)/).apply(compiler);
+		} else if (options.externalsPresets.web) {
+			const ExternalsPlugin = require("./ExternalsPlugin");
+			new ExternalsPlugin("module", /^(https?:\/\/|std:)/).apply(compiler);
 		}
 
 		new ChunkPrefetchPreloadPlugin().apply(compiler);

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -10,7 +10,9 @@ const Template = require("../Template");
 const { cleverMerge } = require("../util/cleverMerge");
 
 /** @typedef {import("../../declarations/WebpackOptions").CacheOptionsNormalized} CacheOptions */
+/** @typedef {import("../../declarations/WebpackOptions").EntryNormalized} Entry */
 /** @typedef {import("../../declarations/WebpackOptions").Experiments} Experiments */
+/** @typedef {import("../../declarations/WebpackOptions").ExternalsPresets} ExternalsPresets */
 /** @typedef {import("../../declarations/WebpackOptions").ExternalsType} ExternalsType */
 /** @typedef {import("../../declarations/WebpackOptions").InfrastructureLogging} InfrastructureLogging */
 /** @typedef {import("../../declarations/WebpackOptions").Library} Library */
@@ -20,7 +22,7 @@ const { cleverMerge } = require("../util/cleverMerge");
 /** @typedef {import("../../declarations/WebpackOptions").ModuleOptions} ModuleOptions */
 /** @typedef {import("../../declarations/WebpackOptions").Node} WebpackNode */
 /** @typedef {import("../../declarations/WebpackOptions").Optimization} Optimization */
-/** @typedef {import("../../declarations/WebpackOptions").Output} Output */
+/** @typedef {import("../../declarations/WebpackOptions").OutputNormalized} Output */
 /** @typedef {import("../../declarations/WebpackOptions").Performance} Performance */
 /** @typedef {import("../../declarations/WebpackOptions").ResolveOptions} ResolveOptions */
 /** @typedef {import("../../declarations/WebpackOptions").RuleSetRules} RuleSetRules */
@@ -120,7 +122,8 @@ const applyWebpackOptionsDefaults = options => {
 	const webTarget =
 		target === "web" ||
 		target === "webworker" ||
-		target === "electron-renderer";
+		target === "electron-renderer" ||
+		target === "electron-preload";
 	const development = mode === "development";
 	const production = mode === "production" || !mode;
 
@@ -166,56 +169,11 @@ const applyWebpackOptionsDefaults = options => {
 		context: options.context,
 		target,
 		outputModule: options.experiments.outputModule,
-		development
+		development,
+		entry: options.entry
 	});
 
-	A(options.output, "enabledLibraryTypes", () => {
-		const enabledLibraryTypes = [];
-		if (options.output.library) {
-			enabledLibraryTypes.push(options.output.library.type);
-		}
-		for (const name of Object.keys(options.entry)) {
-			const desc = options.entry[name];
-			if (desc.library) {
-				enabledLibraryTypes.push(desc.library.type);
-			}
-		}
-		return enabledLibraryTypes;
-	});
-
-	A(options.output, "enabledChunkLoadingTypes", () => {
-		const enabledChunkLoadingTypes = new Set();
-		if (options.output.chunkLoading) {
-			enabledChunkLoadingTypes.add(options.output.chunkLoading);
-		}
-		if (options.output.workerChunkLoading) {
-			enabledChunkLoadingTypes.add(options.output.workerChunkLoading);
-		}
-		for (const name of Object.keys(options.entry)) {
-			const desc = options.entry[name];
-			if (desc.chunkLoading) {
-				enabledChunkLoadingTypes.add(desc.chunkLoading);
-			}
-		}
-		return Array.from(enabledChunkLoadingTypes);
-	});
-
-	A(options.output, "enabledWasmLoadingTypes", () => {
-		const enabledWasmLoadingTypes = new Set();
-		if (options.output.wasmLoading) {
-			enabledWasmLoadingTypes.add(options.output.wasmLoading);
-		}
-		if (options.output.workerWasmLoading) {
-			enabledWasmLoadingTypes.add(options.output.workerWasmLoading);
-		}
-		for (const name of Object.keys(options.entry)) {
-			const desc = options.entry[name];
-			if (desc.wasmLoading) {
-				enabledWasmLoadingTypes.add(desc.wasmLoading);
-			}
-		}
-		return Array.from(enabledWasmLoadingTypes);
-	});
+	applyExternalsPresetsDefaults(options.externalsPresets, { target });
 
 	F(options, "externalsType", () => {
 		const validExternalTypes = require("../../schemas/WebpackOptions.json")
@@ -543,11 +501,12 @@ const applyModuleDefaults = (
  * @param {Target} options.target target
  * @param {boolean} options.outputModule is outputModule experiment enabled
  * @param {boolean} options.development is development mode
+ * @param {Entry} options.entry entry option
  * @returns {void}
  */
 const applyOutputDefaults = (
 	output,
-	{ context, target, outputModule, development }
+	{ context, target, outputModule, development, entry }
 ) => {
 	/**
 	 * @param {Library=} library the library option
@@ -696,7 +655,9 @@ const applyOutputDefaults = (
 	});
 	F(output, "workerWasmLoading", () => output.wasmLoading);
 	F(output, "devtoolNamespace", () => output.uniqueName);
-	F(output, "libraryTarget", () => (output.module ? "module" : "var"));
+	if (output.library) {
+		F(output.library, "type", () => (output.module ? "module" : "var"));
+	}
 	F(output, "path", () => path.join(process.cwd(), "dist"));
 	F(output, "pathinfo", () => development);
 	D(output, "sourceMapFilename", "[file].map[query]");
@@ -709,6 +670,92 @@ const applyOutputDefaults = (
 	D(output, "hashDigest", "hex");
 	D(output, "hashDigestLength", 20);
 	D(output, "strictModuleExceptionHandling", false);
+
+	A(output, "enabledLibraryTypes", () => {
+		const enabledLibraryTypes = [];
+		if (output.library) {
+			enabledLibraryTypes.push(output.library.type);
+		}
+		for (const name of Object.keys(entry)) {
+			const desc = entry[name];
+			if (desc.library) {
+				enabledLibraryTypes.push(desc.library.type);
+			}
+		}
+		return enabledLibraryTypes;
+	});
+
+	A(output, "enabledChunkLoadingTypes", () => {
+		const enabledChunkLoadingTypes = new Set();
+		if (output.chunkLoading) {
+			enabledChunkLoadingTypes.add(output.chunkLoading);
+		}
+		if (output.workerChunkLoading) {
+			enabledChunkLoadingTypes.add(output.workerChunkLoading);
+		}
+		for (const name of Object.keys(entry)) {
+			const desc = entry[name];
+			if (desc.chunkLoading) {
+				enabledChunkLoadingTypes.add(desc.chunkLoading);
+			}
+		}
+		return Array.from(enabledChunkLoadingTypes);
+	});
+
+	A(output, "enabledWasmLoadingTypes", () => {
+		const enabledWasmLoadingTypes = new Set();
+		if (output.wasmLoading) {
+			enabledWasmLoadingTypes.add(output.wasmLoading);
+		}
+		if (output.workerWasmLoading) {
+			enabledWasmLoadingTypes.add(output.workerWasmLoading);
+		}
+		for (const name of Object.keys(entry)) {
+			const desc = entry[name];
+			if (desc.wasmLoading) {
+				enabledWasmLoadingTypes.add(desc.wasmLoading);
+			}
+		}
+		return Array.from(enabledWasmLoadingTypes);
+	});
+};
+
+/**
+ * @param {ExternalsPresets} externalsPresets options
+ * @param {Object} options options
+ * @param {Target} options.target target
+ * @returns {void}
+ */
+const applyExternalsPresetsDefaults = (externalsPresets, { target }) => {
+	switch (target) {
+		case "web":
+			D(externalsPresets, "web", true);
+			break;
+		case "webworker":
+			D(externalsPresets, "web", true);
+			break;
+		case "async-node":
+			D(externalsPresets, "node", true);
+			break;
+		case "node":
+			D(externalsPresets, "node", true);
+			break;
+		case "node-webkit":
+			D(externalsPresets, "web", true);
+			D(externalsPresets, "node", true);
+			D(externalsPresets, "nodeWebkit", true);
+			break;
+		case "electron-main":
+			D(externalsPresets, "node", true);
+			D(externalsPresets, "electronMain", true);
+			break;
+		case "electron-preload":
+		case "electron-renderer":
+			D(externalsPresets, "web", true);
+			D(externalsPresets, "node", true);
+			D(externalsPresets, "electronPreload", true);
+			break;
+	}
 };
 
 /**
@@ -876,10 +923,10 @@ const getResolveDefaults = ({ cache, context, webTarget, target, mode }) => {
 			conditions.push("node");
 			break;
 		case "electron-main":
-		case "electron-preload":
 			conditions.push("node");
 			conditions.push("electron");
 			break;
+		case "electron-preload":
 		case "electron-renderer":
 			conditions.push("electron");
 			break;

--- a/lib/config/normalization.js
+++ b/lib/config/normalization.js
@@ -148,6 +148,10 @@ const getNormalizedWebpackOptions = config => {
 			...experiments
 		})),
 		externals: config.externals,
+		externalsPresets: nestedConfig(
+			config.externalsPresets,
+			externalsPresets => ({ ...externalsPresets })
+		),
 		externalsType: config.externalsType,
 		infrastructureLogging: nestedConfig(
 			config.infrastructureLogging,
@@ -208,7 +212,6 @@ const getNormalizedWebpackOptions = config => {
 					? library
 					: libraryAsName || output.libraryTarget
 					? /** @type {LibraryOptions} */ ({
-							type: "var",
 							name: libraryAsName
 					  })
 					: undefined;

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -510,6 +510,37 @@
         }
       ]
     },
+    "ExternalsPresets": {
+      "description": "Enable presets of externals for specific targets.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "electronMain": {
+          "description": "Treat electron built-in modules in the main context like 'app', 'ipc-main' or 'shell' as external and load them via require() when used.",
+          "type": "boolean"
+        },
+        "electronPreload": {
+          "description": "Treat electron built-in modules in the preload context like 'web-frame', 'ipc-renderer' or 'shell' as external and load them via require() when used.",
+          "type": "boolean"
+        },
+        "node": {
+          "description": "Treat node.js built-in modules like fs, path or vm as external and load them via require() when used.",
+          "type": "boolean"
+        },
+        "nodeWebkit": {
+          "description": "Treat node-webkit legacy nw.gui module as external and load it via require() when used.",
+          "type": "boolean"
+        },
+        "web": {
+          "description": "Treat references to 'http(s)://...' and 'std:...' as external and load them via import when used (Note that this changes execution order as externals are executed before any other code in the chunk).",
+          "type": "boolean"
+        },
+        "webAsync": {
+          "description": "Treat references to 'http(s)://...' and 'std:...' as external and load them via async import() when used (Note that this external type is an async module, which has various effects on the execution).",
+          "type": "boolean"
+        }
+      }
+    },
     "ExternalsType": {
       "description": "Specifies the default type of externals ('amd*', 'umd*', 'system' and 'jsonp' depend on output.libraryTarget set to the same value).",
       "enum": [
@@ -3524,6 +3555,9 @@
         "externals": {
           "$ref": "#/definitions/Externals"
         },
+        "externalsPresets": {
+          "$ref": "#/definitions/ExternalsPresets"
+        },
         "externalsType": {
           "$ref": "#/definitions/ExternalsType"
         },
@@ -3597,6 +3631,7 @@
         "entry",
         "experiments",
         "externals",
+        "externalsPresets",
         "infrastructureLogging",
         "module",
         "node",
@@ -3661,6 +3696,9 @@
     },
     "externals": {
       "$ref": "#/definitions/Externals"
+    },
+    "externalsPresets": {
+      "$ref": "#/definitions/ExternalsPresets"
     },
     "externalsType": {
       "$ref": "#/definitions/ExternalsType"

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -96,6 +96,9 @@ describe("Defaults", () => {
 		    "topLevelAwait": false,
 		  },
 		  "externals": undefined,
+		  "externalsPresets": Object {
+		    "web": true,
+		  },
 		  "externalsType": "var",
 		  "infrastructureLogging": Object {
 		    "debug": false,
@@ -243,7 +246,6 @@ describe("Defaults", () => {
 		    "iife": true,
 		    "importFunctionName": "import",
 		    "library": undefined,
-		    "libraryTarget": "var",
 		    "module": false,
 		    "path": "<cwd>/dist",
 		    "pathinfo": false,
@@ -855,9 +857,7 @@ describe("Defaults", () => {
 		-     "iife": true,
 		+     "iife": false,
 		@@ ... @@
-		-     "libraryTarget": "var",
 		-     "module": false,
-		+     "libraryTarget": "module",
 		+     "module": true,
 		@@ ... @@
 		-     "scriptType": false,
@@ -975,6 +975,9 @@ describe("Defaults", () => {
 		- Expected
 		+ Received
 
+		@@ ... @@
+		-     "web": true,
+		+     "node": true,
 		@@ ... @@
 		-     "__dirname": "mock",
 		-     "__filename": "mock",
@@ -1102,6 +1105,10 @@ describe("Defaults", () => {
 		+ Received
 
 		@@ ... @@
+		-     "web": true,
+		+     "electronMain": true,
+		+     "node": true,
+		@@ ... @@
 		-     "__dirname": "mock",
 		-     "__filename": "mock",
 		-     "global": true,
@@ -1209,6 +1216,9 @@ describe("Defaults", () => {
 		+ Received
 
 		@@ ... @@
+		+     "electronPreload": true,
+		+     "node": true,
+		@@ ... @@
 		-     "chunkFormat": "array-push",
 		+     "chunkFormat": "commonjs",
 		@@ ... @@
@@ -1233,70 +1243,6 @@ describe("Defaults", () => {
 		+     "workerChunkLoading": "require",
 		+     "workerWasmLoading": "async-node",
 		@@ ... @@
-		-         "aliasFields": Array [
-		-           "browser",
-		-         ],
-		+         "aliasFields": Array [],
-		@@ ... @@
-		-           "browser",
-		@@ ... @@
-		-           "browser",
-		@@ ... @@
-		-         "aliasFields": Array [
-		-           "browser",
-		-         ],
-		+         "aliasFields": Array [],
-		@@ ... @@
-		-           "browser",
-		@@ ... @@
-		-           "browser",
-		@@ ... @@
-		-         "aliasFields": Array [
-		-           "browser",
-		-         ],
-		+         "aliasFields": Array [],
-		@@ ... @@
-		-           "browser",
-		@@ ... @@
-		-           "browser",
-		@@ ... @@
-		-         "aliasFields": Array [
-		-           "browser",
-		-         ],
-		+         "aliasFields": Array [],
-		@@ ... @@
-		-           "browser",
-		@@ ... @@
-		-           "browser",
-		@@ ... @@
-		-         "aliasFields": Array [
-		-           "browser",
-		-         ],
-		+         "aliasFields": Array [],
-		@@ ... @@
-		-           "browser",
-		@@ ... @@
-		-           "browser",
-		@@ ... @@
-		-         "aliasFields": Array [
-		-           "browser",
-		-         ],
-		+         "aliasFields": Array [],
-		@@ ... @@
-		-           "browser",
-		@@ ... @@
-		-           "browser",
-		@@ ... @@
-		-         "aliasFields": Array [
-		-           "browser",
-		-         ],
-		+         "aliasFields": Array [],
-		@@ ... @@
-		-           "browser",
-		@@ ... @@
-		-           "browser",
-		@@ ... @@
-		+       "node",
 		+       "electron",
 		@@ ... @@
 		-   "target": "web",

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -24,7 +24,7 @@ describe("Validation", () => {
 		expect(msg).toMatchInlineSnapshot(`
 		"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 		 - configuration should be an object:
-		   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
+		   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
 		   -> Options object as provided by the user."
 	`)
 	);
@@ -33,7 +33,7 @@ describe("Validation", () => {
 		expect(msg).toMatchInlineSnapshot(`
 		"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 		 - configuration should be an object:
-		   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
+		   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
 		   -> Options object as provided by the user."
 	`)
 	);
@@ -196,7 +196,7 @@ describe("Validation", () => {
 			expect(msg).toMatchInlineSnapshot(`
 			"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 			 - configuration has an unknown property 'postcss'. These properties are valid:
-			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
+			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
 			   -> Options object as provided by the user.
 			   For typos: please correct them.
 			   For loader options: webpack >= v2.0.0 no longer allows custom properties in configuration.
@@ -426,7 +426,7 @@ describe("Validation", () => {
 			expect(msg).toMatchInlineSnapshot(`
 			"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 			 - configuration has an unknown property 'debug'. These properties are valid:
-			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
+			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
 			   -> Options object as provided by the user.
 			   The 'debug' property was removed in webpack 2.0.0.
 			   Loaders should be updated to allow passing this option via loader options in module.rules.
@@ -482,7 +482,7 @@ describe("Validation", () => {
 			expect(msg).toMatchInlineSnapshot(`
 			"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 			 - configuration[1] should be an object:
-			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
+			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
 			   -> Options object as provided by the user."
 		`)
 	);
@@ -621,7 +621,7 @@ describe("Validation", () => {
 				expect(msg).toMatchInlineSnapshot(`
 			"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 			 - configuration has an unknown property 'rules'. These properties are valid:
-			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
+			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
 			   -> Options object as provided by the user.
 			   Did you mean module.rules?"
 		`)
@@ -635,7 +635,7 @@ describe("Validation", () => {
 				expect(msg).toMatchInlineSnapshot(`
 			"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 			 - configuration has an unknown property 'splitChunks'. These properties are valid:
-			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
+			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
 			   -> Options object as provided by the user.
 			   Did you mean optimization.splitChunks?"
 		`)
@@ -649,7 +649,7 @@ describe("Validation", () => {
 				expect(msg).toMatchInlineSnapshot(`
 			"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 			 - configuration has an unknown property 'noParse'. These properties are valid:
-			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
+			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
 			   -> Options object as provided by the user.
 			   Did you mean module.noParse?"
 		`)

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -425,6 +425,84 @@ Object {
     "multiple": true,
     "simpleType": "string",
   },
+  "externals-presets-electron-main": Object {
+    "configs": Array [
+      Object {
+        "description": "Treat electron built-in modules in the main context like 'app', 'ipc-main' or 'shell' as external and load them via require() when used.",
+        "multiple": false,
+        "path": "externalsPresets.electronMain",
+        "type": "boolean",
+      },
+    ],
+    "description": "Treat electron built-in modules in the main context like 'app', 'ipc-main' or 'shell' as external and load them via require() when used.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "externals-presets-electron-preload": Object {
+    "configs": Array [
+      Object {
+        "description": "Treat electron built-in modules in the preload context like 'web-frame', 'ipc-renderer' or 'shell' as external and load them via require() when used.",
+        "multiple": false,
+        "path": "externalsPresets.electronPreload",
+        "type": "boolean",
+      },
+    ],
+    "description": "Treat electron built-in modules in the preload context like 'web-frame', 'ipc-renderer' or 'shell' as external and load them via require() when used.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "externals-presets-node": Object {
+    "configs": Array [
+      Object {
+        "description": "Treat node.js built-in modules like fs, path or vm as external and load them via require() when used.",
+        "multiple": false,
+        "path": "externalsPresets.node",
+        "type": "boolean",
+      },
+    ],
+    "description": "Treat node.js built-in modules like fs, path or vm as external and load them via require() when used.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "externals-presets-node-webkit": Object {
+    "configs": Array [
+      Object {
+        "description": "Treat node-webkit legacy nw.gui module as external and load it via require() when used.",
+        "multiple": false,
+        "path": "externalsPresets.nodeWebkit",
+        "type": "boolean",
+      },
+    ],
+    "description": "Treat node-webkit legacy nw.gui module as external and load it via require() when used.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "externals-presets-web": Object {
+    "configs": Array [
+      Object {
+        "description": "Treat references to 'http(s)://...' and 'std:...' as external and load them via import when used (Note that this changes execution order as externals are executed before any other code in the chunk).",
+        "multiple": false,
+        "path": "externalsPresets.web",
+        "type": "boolean",
+      },
+    ],
+    "description": "Treat references to 'http(s)://...' and 'std:...' as external and load them via import when used (Note that this changes execution order as externals are executed before any other code in the chunk).",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "externals-presets-web-async": Object {
+    "configs": Array [
+      Object {
+        "description": "Treat references to 'http(s)://...' and 'std:...' as external and load them via async import() when used (Note that this external type is an async module, which has various effects on the execution).",
+        "multiple": false,
+        "path": "externalsPresets.webAsync",
+        "type": "boolean",
+      },
+    ],
+    "description": "Treat references to 'http(s)://...' and 'std:...' as external and load them via async import() when used (Note that this external type is an async module, which has various effects on the execution).",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "externals-reset": Object {
     "configs": Array [
       Object {

--- a/types.d.ts
+++ b/types.d.ts
@@ -1712,6 +1712,11 @@ declare interface Configuration {
 	externals?: Externals;
 
 	/**
+	 * Enable presets of externals for specific targets.
+	 */
+	externalsPresets?: ExternalsPresets;
+
+	/**
 	 * Specifies the default type of externals ('amd*', 'umd*', 'system' and 'jsonp' depend on output.libraryTarget set to the same value).
 	 */
 	externalsType?: ExternalsType;
@@ -3008,6 +3013,41 @@ declare class ExternalsPlugin {
 	 * Apply the plugin
 	 */
 	apply(compiler: Compiler): void;
+}
+
+/**
+ * Enable presets of externals for specific targets.
+ */
+declare interface ExternalsPresets {
+	/**
+	 * Treat electron built-in modules in the main context like 'app', 'ipc-main' or 'shell' as external and load them via require() when used.
+	 */
+	electronMain?: boolean;
+
+	/**
+	 * Treat electron built-in modules in the preload context like 'web-frame', 'ipc-renderer' or 'shell' as external and load them via require() when used.
+	 */
+	electronPreload?: boolean;
+
+	/**
+	 * Treat node.js built-in modules like fs, path or vm as external and load them via require() when used.
+	 */
+	node?: boolean;
+
+	/**
+	 * Treat node-webkit legacy nw.gui module as external and load it via require() when used.
+	 */
+	nodeWebkit?: boolean;
+
+	/**
+	 * Treat references to 'http(s)://...' and 'std:...' as external and load them via import when used (Note that this changes execution order as externals are executed before any other code in the chunk).
+	 */
+	web?: boolean;
+
+	/**
+	 * Treat references to 'http(s)://...' and 'std:...' as external and load them via async import() when used (Note that this external type is an async module, which has various effects on the execution).
+	 */
+	webAsync?: boolean;
 }
 type ExternalsType =
 	| "var"
@@ -9226,6 +9266,11 @@ declare interface WebpackOptionsNormalized {
 	 * Specify dependencies that shouldn't be resolved by webpack, but should become dependencies of the resulting bundle. The kind of the dependency depends on `output.libraryTarget`.
 	 */
 	externals: Externals;
+
+	/**
+	 * Enable presets of externals for specific targets.
+	 */
+	externalsPresets: ExternalsPresets;
 
 	/**
 	 * Specifies the default type of externals ('amd*', 'umd*', 'system' and 'jsonp' depend on output.libraryTarget set to the same value).


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
refactoring
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
existing tests
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
* new option `externalsPresets` which allows to enable the default externals for various targets. Each is a boolean property in this object:
  * node
  * nodeWebkit (deprecated)
  * electronPreload
  * electronMain
  * web
  * webAsync
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
