### PR TITLE
update enhanced-resolve

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -267,6 +267,30 @@ export type RuleSetLoaderOptions =
 			[k: string]: any;
 	  };
 /**
+ * Redirect module requests.
+ */
+export type ResolveAlias =
+	| {
+			/**
+			 * New request.
+			 */
+			alias: string[] | false | string;
+			/**
+			 * Request to be redirected.
+			 */
+			name: string;
+			/**
+			 * Redirect only exact matching request.
+			 */
+			onlyModule?: boolean;
+	  }[]
+	| {
+			/**
+			 * New request.
+			 */
+			[k: string]: string[] | false | string;
+	  };
+/**
  * A list of descriptions of loaders applied.
  */
 export type RuleSetUse =
@@ -1167,27 +1191,7 @@ export interface ResolveOptions {
 	/**
 	 * Redirect module requests.
 	 */
-	alias?:
-		| {
-				/**
-				 * New request.
-				 */
-				alias: string[] | false | string;
-				/**
-				 * Request to be redirected.
-				 */
-				name: string;
-				/**
-				 * Redirect only exact matching request.
-				 */
-				onlyModule?: boolean;
-		  }[]
-		| {
-				/**
-				 * New request.
-				 */
-				[k: string]: string[] | false | string;
-		  };
+	alias?: ResolveAlias;
 	/**
 	 * Fields in the description file (usually package.json) which are used to redirect requests inside the module.
 	 */
@@ -1236,6 +1240,10 @@ export interface ResolveOptions {
 	 */
 	extensions?: string[];
 	/**
+	 * Redirect module requests when normal resolving fails.
+	 */
+	fallback?: ResolveAlias;
+	/**
 	 * Filesystem for the resolver.
 	 */
 	fileSystem?: import("../lib/util/fs").InputFileSystem;
@@ -1243,6 +1251,10 @@ export interface ResolveOptions {
 	 * Treats the request specified by the user as fully specified, meaning no extensions are added and the mainFiles in directories are not resolved (This doesn't affect requests from mainFields, aliasFields or aliases).
 	 */
 	fullySpecified?: boolean;
+	/**
+	 * Field names from the description file (usually package.json) which are used to provide internal request of a package (requests starting with # are considered as internal).
+	 */
+	importsFields?: string[];
 	/**
 	 * Field names from the description file (package.json) which are used to find the default entry point.
 	 */

--- a/lib/ModuleNotFoundError.js
+++ b/lib/ModuleNotFoundError.js
@@ -66,14 +66,14 @@ class ModuleNotFoundError extends WebpackError {
 				if (request !== alias) {
 					message +=
 						"If you want to include a polyfill, you need to:\n" +
-						`\t- add an alias 'resolve.alias: { "${request}": "${alias}" }'\n` +
+						`\t- add an fallback 'resolve.fallback: { "${request}": "${alias}" }'\n` +
 						`\t- install '${dependency}'\n`;
 				} else {
 					message += `If you want to include a polyfill, you need to install '${dependency}'.\n`;
 				}
 				message +=
 					"If you don't want to include a polyfill, you can use an empty module like this:\n" +
-					`\tresolve.alias: { "${request}": false }`;
+					`\tresolve.fallback: { "${request}": false }`;
 			}
 		}
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@webassemblyjs/wasm-parser": "1.9.0",
     "acorn": "^7.4.0",
     "chrome-trace-event": "^1.0.2",
-    "enhanced-resolve": "5.0.0-beta.10",
+    "enhanced-resolve": "5.0.0-beta.12",
     "eslint-scope": "^5.1.0",
     "events": "^3.2.0",
     "glob-to-regexp": "^0.4.1",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2200,67 +2200,17 @@
         }
       ]
     },
-    "ResolveLoader": {
-      "description": "Options for the resolver when resolving loaders.",
-      "oneOf": [
+    "ResolveAlias": {
+      "description": "Redirect module requests.",
+      "anyOf": [
         {
-          "$ref": "#/definitions/ResolveOptions"
-        }
-      ]
-    },
-    "ResolveOptions": {
-      "description": "Options object for resolving requests.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "alias": {
-          "description": "Redirect module requests.",
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "description": "Alias configuration.",
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "alias": {
-                    "description": "New request.",
-                    "anyOf": [
-                      {
-                        "description": "Multiple alternative requests.",
-                        "type": "array",
-                        "items": {
-                          "description": "One choice of request.",
-                          "type": "string",
-                          "minLength": 1
-                        }
-                      },
-                      {
-                        "description": "Ignore request (replace with empty module).",
-                        "enum": [false]
-                      },
-                      {
-                        "description": "New request.",
-                        "type": "string",
-                        "minLength": 1
-                      }
-                    ]
-                  },
-                  "name": {
-                    "description": "Request to be redirected.",
-                    "type": "string"
-                  },
-                  "onlyModule": {
-                    "description": "Redirect only exact matching request.",
-                    "type": "boolean"
-                  }
-                },
-                "required": ["alias", "name"]
-              }
-            },
-            {
-              "type": "object",
-              "additionalProperties": {
+          "type": "array",
+          "items": {
+            "description": "Alias configuration.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "alias": {
                 "description": "New request.",
                 "anyOf": [
                   {
@@ -2282,9 +2232,62 @@
                     "minLength": 1
                   }
                 ]
+              },
+              "name": {
+                "description": "Request to be redirected.",
+                "type": "string"
+              },
+              "onlyModule": {
+                "description": "Redirect only exact matching request.",
+                "type": "boolean"
               }
-            }
-          ]
+            },
+            "required": ["alias", "name"]
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "description": "New request.",
+            "anyOf": [
+              {
+                "description": "Multiple alternative requests.",
+                "type": "array",
+                "items": {
+                  "description": "One choice of request.",
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              {
+                "description": "Ignore request (replace with empty module).",
+                "enum": [false]
+              },
+              {
+                "description": "New request.",
+                "type": "string",
+                "minLength": 1
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "ResolveLoader": {
+      "description": "Options for the resolver when resolving loaders.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ResolveOptions"
+        }
+      ]
+    },
+    "ResolveOptions": {
+      "description": "Options object for resolving requests.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "alias": {
+          "$ref": "#/definitions/ResolveAlias"
         },
         "aliasFields": {
           "description": "Fields in the description file (usually package.json) which are used to redirect requests inside the module.",
@@ -2370,6 +2373,14 @@
             "minLength": 1
           }
         },
+        "fallback": {
+          "description": "Redirect module requests when normal resolving fails.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ResolveAlias"
+            }
+          ]
+        },
         "fileSystem": {
           "description": "Filesystem for the resolver.",
           "tsType": "(import('../lib/util/fs').InputFileSystem)"
@@ -2377,6 +2388,14 @@
         "fullySpecified": {
           "description": "Treats the request specified by the user as fully specified, meaning no extensions are added and the mainFiles in directories are not resolved (This doesn't affect requests from mainFields, aliasFields or aliases).",
           "type": "boolean"
+        },
+        "importsFields": {
+          "description": "Field names from the description file (usually package.json) which are used to provide internal request of a package (requests starting with # are considered as internal).",
+          "type": "array",
+          "items": {
+            "description": "Field name from the description file (usually package.json) which is used to provide internal request of a package (requests starting with # are considered as internal).",
+            "type": "string"
+          }
         },
         "mainFields": {
           "description": "Field names from the description file (package.json) which are used to find the default entry point.",

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -3359,6 +3359,67 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
+  "resolve-fallback-alias": Object {
+    "configs": Array [
+      Object {
+        "description": "Ignore request (replace with empty module).",
+        "multiple": true,
+        "path": "resolve.fallback[].alias",
+        "type": "enum",
+        "values": Array [
+          false,
+        ],
+      },
+      Object {
+        "description": "New request.",
+        "multiple": true,
+        "path": "resolve.fallback[].alias",
+        "type": "string",
+      },
+    ],
+    "description": "Ignore request (replace with empty module). New request.",
+    "multiple": true,
+    "simpleType": "string",
+  },
+  "resolve-fallback-name": Object {
+    "configs": Array [
+      Object {
+        "description": "Request to be redirected.",
+        "multiple": true,
+        "path": "resolve.fallback[].name",
+        "type": "string",
+      },
+    ],
+    "description": "Request to be redirected.",
+    "multiple": true,
+    "simpleType": "string",
+  },
+  "resolve-fallback-only-module": Object {
+    "configs": Array [
+      Object {
+        "description": "Redirect only exact matching request.",
+        "multiple": true,
+        "path": "resolve.fallback[].onlyModule",
+        "type": "boolean",
+      },
+    ],
+    "description": "Redirect only exact matching request.",
+    "multiple": true,
+    "simpleType": "boolean",
+  },
+  "resolve-fallback-reset": Object {
+    "configs": Array [
+      Object {
+        "description": "Clear all items provided in configuration. Redirect module requests.",
+        "multiple": false,
+        "path": "resolve.fallback",
+        "type": "reset",
+      },
+    ],
+    "description": "Clear all items provided in configuration. Redirect module requests.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "resolve-fully-specified": Object {
     "configs": Array [
       Object {
@@ -3369,6 +3430,32 @@ Object {
       },
     ],
     "description": "Treats the request specified by the user as fully specified, meaning no extensions are added and the mainFiles in directories are not resolved (This doesn't affect requests from mainFields, aliasFields or aliases).",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "resolve-imports-fields": Object {
+    "configs": Array [
+      Object {
+        "description": "Field name from the description file (usually package.json) which is used to provide internal request of a package (requests starting with # are considered as internal).",
+        "multiple": true,
+        "path": "resolve.importsFields[]",
+        "type": "string",
+      },
+    ],
+    "description": "Field name from the description file (usually package.json) which is used to provide internal request of a package (requests starting with # are considered as internal).",
+    "multiple": true,
+    "simpleType": "string",
+  },
+  "resolve-imports-fields-reset": Object {
+    "configs": Array [
+      Object {
+        "description": "Clear all items provided in configuration. Field names from the description file (usually package.json) which are used to provide internal request of a package (requests starting with # are considered as internal).",
+        "multiple": false,
+        "path": "resolve.importsFields",
+        "type": "reset",
+      },
+    ],
+    "description": "Clear all items provided in configuration. Field names from the description file (usually package.json) which are used to provide internal request of a package (requests starting with # are considered as internal).",
     "multiple": false,
     "simpleType": "boolean",
   },
@@ -3602,6 +3689,67 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
+  "resolve-loader-fallback-alias": Object {
+    "configs": Array [
+      Object {
+        "description": "Ignore request (replace with empty module).",
+        "multiple": true,
+        "path": "resolveLoader.fallback[].alias",
+        "type": "enum",
+        "values": Array [
+          false,
+        ],
+      },
+      Object {
+        "description": "New request.",
+        "multiple": true,
+        "path": "resolveLoader.fallback[].alias",
+        "type": "string",
+      },
+    ],
+    "description": "Ignore request (replace with empty module). New request.",
+    "multiple": true,
+    "simpleType": "string",
+  },
+  "resolve-loader-fallback-name": Object {
+    "configs": Array [
+      Object {
+        "description": "Request to be redirected.",
+        "multiple": true,
+        "path": "resolveLoader.fallback[].name",
+        "type": "string",
+      },
+    ],
+    "description": "Request to be redirected.",
+    "multiple": true,
+    "simpleType": "string",
+  },
+  "resolve-loader-fallback-only-module": Object {
+    "configs": Array [
+      Object {
+        "description": "Redirect only exact matching request.",
+        "multiple": true,
+        "path": "resolveLoader.fallback[].onlyModule",
+        "type": "boolean",
+      },
+    ],
+    "description": "Redirect only exact matching request.",
+    "multiple": true,
+    "simpleType": "boolean",
+  },
+  "resolve-loader-fallback-reset": Object {
+    "configs": Array [
+      Object {
+        "description": "Clear all items provided in configuration. Redirect module requests.",
+        "multiple": false,
+        "path": "resolveLoader.fallback",
+        "type": "reset",
+      },
+    ],
+    "description": "Clear all items provided in configuration. Redirect module requests.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "resolve-loader-fully-specified": Object {
     "configs": Array [
       Object {
@@ -3612,6 +3760,32 @@ Object {
       },
     ],
     "description": "Treats the request specified by the user as fully specified, meaning no extensions are added and the mainFiles in directories are not resolved (This doesn't affect requests from mainFields, aliasFields or aliases).",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "resolve-loader-imports-fields": Object {
+    "configs": Array [
+      Object {
+        "description": "Field name from the description file (usually package.json) which is used to provide internal request of a package (requests starting with # are considered as internal).",
+        "multiple": true,
+        "path": "resolveLoader.importsFields[]",
+        "type": "string",
+      },
+    ],
+    "description": "Field name from the description file (usually package.json) which is used to provide internal request of a package (requests starting with # are considered as internal).",
+    "multiple": true,
+    "simpleType": "string",
+  },
+  "resolve-loader-imports-fields-reset": Object {
+    "configs": Array [
+      Object {
+        "description": "Clear all items provided in configuration. Field names from the description file (usually package.json) which are used to provide internal request of a package (requests starting with # are considered as internal).",
+        "multiple": false,
+        "path": "resolveLoader.importsFields",
+        "type": "reset",
+      },
+    ],
+    "description": "Clear all items provided in configuration. Field names from the description file (usually package.json) which are used to provide internal request of a package (requests starting with # are considered as internal).",
     "multiple": false,
     "simpleType": "boolean",
   },

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1253,7 +1253,7 @@ This is no longer the case. Verify if you need this module and configure a polyf
 
 If you want to include a polyfill, you need to install 'buffer'.
 If you don't want to include a polyfill, you can use an empty module like this:
-	resolve.alias: { \\"buffer\\": false }
+	resolve.fallback: { \\"buffer\\": false }
 
 ERROR in ./index.js 2:0-13
 Module not found: Error: Can't resolve 'os' in 'Xdir/module-not-found-error'
@@ -1262,10 +1262,10 @@ BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules 
 This is no longer the case. Verify if you need this module and configure a polyfill for it.
 
 If you want to include a polyfill, you need to:
-	- add an alias 'resolve.alias: { \\"os\\": \\"os-browserify/browser\\" }'
+	- add an fallback 'resolve.fallback: { \\"os\\": \\"os-browserify/browser\\" }'
 	- install 'os-browserify'
 If you don't want to include a polyfill, you can use an empty module like this:
-	resolve.alias: { \\"os\\": false }
+	resolve.fallback: { \\"os\\": false }
 
 webpack compiled with 2 errors"
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2304,10 +2304,10 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@5.0.0-beta.10:
-  version "5.0.0-beta.10"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.0.0-beta.10.tgz#3907c034f8e59446dfa5a89a1fd73db29aa0f246"
-  integrity sha512-vEyxvHv3f8xl7i7QmTQ6BqKY32acSPQ4dTZo8WRMtcqTDYH9YyXnDxqXsQqBLvdRHUiwl9nVivESiM1RcrxbKQ==
+enhanced-resolve@5.0.0-beta.12:
+  version "5.0.0-beta.12"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.0.0-beta.12.tgz#ddc2eab710a5f973e1350fd3c0f721df550ec59b"
+  integrity sha512-lEjGWKw3CAvoCZcXP2QBf74D7azAqSop2uOSN2nqOiqmy9h4F3Ci2OaGkxfifrnltv7MAtQApWycZOmzGwDovg==
   dependencies:
     graceful-fs "^4.2.0"
     tapable "^2.0.0-beta.10"


### PR DESCRIPTION
- imports field support
- resolve.fallback option

recommend resolve.fallback for polyfills

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
deps, feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
in enhanced-resolve
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
- `imports` field in package.json is supported
  - new `resolve.importsFields` option to list the field names
- new `resolve.fallback` option: like alias but only when normal resolving fails
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
