### PR TITLE
Allow SourceMapDevToolPlugin.append option to be a function

### DIFF
--- a/declarations/plugins/SourceMapDevToolPlugin.d.ts
+++ b/declarations/plugins/SourceMapDevToolPlugin.d.ts
@@ -17,7 +17,13 @@ export interface SourceMapDevToolPluginOptions {
 	/**
 	 * Appends the given value to the original asset. Usually the #sourceMappingURL comment. [url] is replaced with a URL to the source map file. false disables the appending.
 	 */
-	append?: (false | null) | string;
+	append?:
+		| (false | null)
+		| string
+		| ((
+				pathData: import("../../lib/Compilation").PathData,
+				assetInfo?: import("../../lib/Compilation").AssetInfo
+		  ) => string);
 	/**
 	 * Indicates whether column mappings should be used (defaults to true).
 	 */

--- a/lib/EvalSourceMapDevToolPlugin.js
+++ b/lib/EvalSourceMapDevToolPlugin.js
@@ -46,7 +46,9 @@ class EvalSourceMapDevToolPlugin {
 			options = inputOptions;
 		}
 		this.sourceMapComment =
-			options.append || "//# sourceURL=[module]\n//# sourceMappingURL=[url]";
+			options.append && typeof options.append !== "function"
+				? options.append
+				: "//# sourceURL=[module]\n//# sourceMappingURL=[url]";
 		this.moduleFilenameTemplate =
 			options.moduleFilenameTemplate ||
 			"webpack://[namespace]/[resource-path]?[hash]";

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -117,7 +117,7 @@ class SourceMapDevToolPlugin {
 
 		/** @type {string | false} */
 		this.sourceMapFilename = options.filename;
-		/** @type {string | (function(PathData, AssetInfo=): string) | false} */
+		/** @type {string | false | (function(PathData, AssetInfo=): string)} */
 		this.sourceMappingURLComment =
 			options.append === false
 				? false
@@ -414,7 +414,7 @@ class SourceMapDevToolPlugin {
 										);
 									}
 
-									/** @type {string | (function(PathData, AssetInfo=): string) | false} */
+									/** @type {string | false | (function(PathData, AssetInfo=): string)} */
 									let currentSourceMappingURLComment = sourceMappingURLComment;
 									if (
 										currentSourceMappingURLComment !== false &&

--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -25,6 +25,7 @@ const schema = require("../schemas/plugins/SourceMapDevToolPlugin.json");
 /** @typedef {import("./CacheFacade").ItemCacheFacade} ItemCacheFacade */
 /** @typedef {import("./Chunk")} Chunk */
 /** @typedef {import("./Compilation").AssetInfo} AssetInfo */
+/** @typedef {import("./Compilation").PathData} PathData */
 /** @typedef {import("./Compiler")} Compiler */
 /** @typedef {import("./Module")} Module */
 /** @typedef {import("./util/Hash")} Hash */
@@ -116,7 +117,7 @@ class SourceMapDevToolPlugin {
 
 		/** @type {string | false} */
 		this.sourceMapFilename = options.filename;
-		/** @type {string | false} */
+		/** @type {string | (function(PathData, AssetInfo=): string) | false} */
 		this.sourceMappingURLComment =
 			options.append === false
 				? false
@@ -413,10 +414,11 @@ class SourceMapDevToolPlugin {
 										);
 									}
 
-									/** @type {string | false} */
+									/** @type {string | (function(PathData, AssetInfo=): string) | false} */
 									let currentSourceMappingURLComment = sourceMappingURLComment;
 									if (
 										currentSourceMappingURLComment !== false &&
+										typeof currentSourceMappingURLComment !== "function" &&
 										/\.css($|\?)/i.test(file)
 									) {
 										currentSourceMappingURLComment = currentSourceMappingURLComment.replace(
@@ -494,6 +496,11 @@ class SourceMapDevToolPlugin {
 										if (currentSourceMappingURLComment === false) {
 											throw new Error(
 												"SourceMapDevToolPlugin: append can't be false when no filename is provided"
+											);
+										}
+										if (typeof currentSourceMappingURLComment === "function") {
+											throw new Error(
+												"SourceMapDevToolPlugin: append can't be a function when no filename is provided"
 											);
 										}
 										/**

--- a/schemas/plugins/SourceMapDevToolPlugin.json
+++ b/schemas/plugins/SourceMapDevToolPlugin.json
@@ -47,6 +47,10 @@
         {
           "type": "string",
           "minLength": 1
+        },
+        {
+          "instanceof": "Function",
+          "tsType": "((pathData: import(\"../../lib/Compilation\").PathData, assetInfo?: import(\"../../lib/Compilation\").AssetInfo) => string)"
         }
       ]
     },

--- a/test/configCases/plugins/source-map-dev-tool-plugin-append-with-function/index.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin-append-with-function/index.js
@@ -1,0 +1,6 @@
+it("should have ${data.filename} replaced with chunk filename in append", function() {
+	var fs = require("fs"),
+			path = require("path");
+	var source = fs.readFileSync(path.join(__dirname, "some-test.js"), "utf-8");
+	expect(source).toMatch("//# sourceMappingURL=http://localhost:50505/some-test.js.map");
+});

--- a/test/configCases/plugins/source-map-dev-tool-plugin-append-with-function/test.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin-append-with-function/test.js
@@ -1,0 +1,5 @@
+var testObject = {
+	a: 1
+};
+
+module.exports = testObject;

--- a/test/configCases/plugins/source-map-dev-tool-plugin-append-with-function/webpack.config.js
+++ b/test/configCases/plugins/source-map-dev-tool-plugin-append-with-function/webpack.config.js
@@ -1,0 +1,30 @@
+var webpack = require("../../../../");
+var TerserPlugin = require("terser-webpack-plugin");
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	entry: {
+		bundle0: ["./index.js"],
+		"some-test": ["./test.js"]
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		minimizer: [
+			new TerserPlugin({
+				sourceMap: true
+			})
+		]
+	},
+	plugins: [
+		new webpack.SourceMapDevToolPlugin({
+			filename: "sourcemaps/[file].map",
+			append: data =>
+				`\n//# sourceMappingURL=http://localhost:50505/${data.filename}.map`
+		})
+	]
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -8435,7 +8435,10 @@ declare interface SourceLike {
 declare class SourceMapDevToolPlugin {
 	constructor(options?: SourceMapDevToolPluginOptions);
 	sourceMapFilename: DevTool;
-	sourceMappingURLComment: DevTool;
+	sourceMappingURLComment:
+		| string
+		| false
+		| ((arg0: PathData, arg1: AssetInfo) => string);
 	moduleFilenameTemplate: DevtoolFallbackModuleFilenameTemplate;
 	fallbackModuleFilenameTemplate: DevtoolFallbackModuleFilenameTemplate;
 	namespace: string;
@@ -8450,7 +8453,10 @@ declare interface SourceMapDevToolPluginOptions {
 	/**
 	 * Appends the given value to the original asset. Usually the #sourceMappingURL comment. [url] is replaced with a URL to the source map file. false disables the appending.
 	 */
-	append?: DevTool;
+	append?:
+		| string
+		| false
+		| ((pathData: PathData, assetInfo: AssetInfo) => string);
 
 	/**
 	 * Indicates whether column mappings should be used (defaults to true).

--- a/types.d.ts
+++ b/types.d.ts
@@ -2815,7 +2815,9 @@ declare class EvalDevToolModulePlugin {
 }
 declare class EvalSourceMapDevToolPlugin {
 	constructor(inputOptions: string | SourceMapDevToolPluginOptions);
-	sourceMapComment: string;
+	sourceMapComment:
+		| string
+		| ((pathData: PathData, assetInfo: AssetInfo) => string);
 	moduleFilenameTemplate: DevtoolFallbackModuleFilenameTemplate;
 	namespace: string;
 	options: SourceMapDevToolPluginOptions;

--- a/types.d.ts
+++ b/types.d.ts
@@ -2815,9 +2815,7 @@ declare class EvalDevToolModulePlugin {
 }
 declare class EvalSourceMapDevToolPlugin {
 	constructor(inputOptions: string | SourceMapDevToolPluginOptions);
-	sourceMapComment:
-		| string
-		| ((pathData: PathData, assetInfo: AssetInfo) => string);
+	sourceMapComment: string;
 	moduleFilenameTemplate: DevtoolFallbackModuleFilenameTemplate;
 	namespace: string;
 	options: SourceMapDevToolPluginOptions;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

https://github.com/webpack/webpack/issues/783

Allow `SourceMapDevToolPlugin`'s `append` option to be a function so that source-map could be better customized. https://github.com/webpack/webpack/issues/783#issuecomment-671410045

(Though it seems that `SourceMapDevToolPlugin` might be able to solve the URL issue with the `publicPath` and `append` options).

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
feature

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
Yes

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

Allow `SourceMapDevToolPlugin`'s `append` option to be a function
https://webpack.js.org/plugins/source-map-dev-tool-plugin/#options

I didn't change the behavior, but maybe `EvalSourceMapDevToolPlugin` also.  Because setting `append` option to `false` doesn't disable the appending but just set the default value (`"//# sourceURL=[module]\n//# sourceMappingURL=[url]"`).
https://webpack.js.org/plugins/eval-source-map-dev-tool-plugin/