### PR TITLE
deprecate stats.warningsFilter in favor of ignoreWarnings

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -181,6 +181,30 @@ export type ExternalsType =
 	| "import"
 	| "script";
 /**
+ * Ignore specific warnings.
+ */
+export type IgnoreWarnings = (
+	| RegExp
+	| {
+			/**
+			 * A RegExp to select the origin file for the warning.
+			 */
+			file?: RegExp;
+			/**
+			 * A RegExp to select the warning message.
+			 */
+			message?: RegExp;
+			/**
+			 * A RegExp to select the origin module for the warning.
+			 */
+			module?: RegExp;
+	  }
+	| ((
+			warning: import("../lib/WebpackError"),
+			compilation: import("../lib/Compilation")
+	  ) => boolean)
+)[];
+/**
  * Filtering values.
  */
 export type FilterTypes = FilterItemTypes[] | FilterItemTypes;
@@ -589,6 +613,13 @@ export type EntryDynamicNormalized = () => Promise<EntryStaticNormalized>;
  */
 export type EntryNormalized = EntryDynamicNormalized | EntryStaticNormalized;
 /**
+ * Ignore specific warnings.
+ */
+export type IgnoreWarningsNormalized = ((
+	warning: import("../lib/WebpackError"),
+	compilation: import("../lib/Compilation")
+) => boolean)[];
+/**
  * Create an additional chunk which contains only the webpack runtime and chunk hash maps.
  */
 export type OptimizationRuntimeChunkNormalized =
@@ -661,6 +692,10 @@ export interface WebpackOptions {
 	 * Specifies the default type of externals ('amd*', 'umd*', 'system' and 'jsonp' depend on output.libraryTarget set to the same value).
 	 */
 	externalsType?: ExternalsType;
+	/**
+	 * Ignore specific warnings.
+	 */
+	ignoreWarnings?: IgnoreWarnings;
 	/**
 	 * Options for infrastructure level logging.
 	 */
@@ -2548,6 +2583,10 @@ export interface WebpackOptionsNormalized {
 	 * Specifies the default type of externals ('amd*', 'umd*', 'system' and 'jsonp' depend on output.libraryTarget set to the same value).
 	 */
 	externalsType?: ExternalsType;
+	/**
+	 * Ignore specific warnings.
+	 */
+	ignoreWarnings?: IgnoreWarningsNormalized;
 	/**
 	 * Options for infrastructure level logging.
 	 */

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -582,6 +582,11 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			/** @type {SyncBailHook<[string, LogEntry], true>} */
 			log: new SyncBailHook(["origin", "logEntry"]),
 
+			/** @type {SyncWaterfallHook<[WebpackError[]]>} */
+			processWarnings: new SyncWaterfallHook(["warnings"]),
+			/** @type {SyncWaterfallHook<[WebpackError[]]>} */
+			processErrors: new SyncWaterfallHook(["errors"]),
+
 			/** @type {HookMap<SyncHook<[Object, Object]>>} */
 			statsPreset: new HookMap(() => new SyncHook(["options", "context"])),
 			/** @type {SyncHook<[Object, Object]>} */
@@ -3230,6 +3235,14 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 			assetInfo
 		);
 		return { path: newPath, info: assetInfo };
+	}
+
+	getWarnings() {
+		return this.hooks.processWarnings.call(this.warnings);
+	}
+
+	getErrors() {
+		return this.hooks.processErrors.call(this.errors);
 	}
 
 	/**

--- a/lib/IgnoreWarningsPlugin.js
+++ b/lib/IgnoreWarningsPlugin.js
@@ -1,0 +1,39 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+/** @typedef {import("../declarations/WebpackOptions").IgnoreWarningsNormalized} IgnoreWarningsNormalized */
+/** @typedef {import("./Compiler")} Compiler */
+
+class IgnoreWarningsPlugin {
+	/**
+	 * @param {IgnoreWarningsNormalized} ignoreWarnings conditions to ignore warnings
+	 */
+	constructor(ignoreWarnings) {
+		this._ignoreWarnings = ignoreWarnings;
+	}
+	/**
+	 * Apply the plugin
+	 * @param {Compiler} compiler the compiler instance
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap("IgnoreWarningsPlugin", compilation => {
+			compilation.hooks.processWarnings.tap(
+				"IgnoreWarningsPlugin",
+				warnings => {
+					return warnings.filter(warning => {
+						return !this._ignoreWarnings.some(ignore =>
+							ignore(warning, compilation)
+						);
+					});
+				}
+			);
+		});
+	}
+}
+
+module.exports = IgnoreWarningsPlugin;

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -521,6 +521,11 @@ class WebpackOptionsApply extends OptionsApply {
 		}
 		new ResolverCachePlugin().apply(compiler);
 
+		if (options.ignoreWarnings && options.ignoreWarnings.length > 0) {
+			const IgnoreWarningsPlugin = require("./IgnoreWarningsPlugin");
+			new IgnoreWarningsPlugin(options.ignoreWarnings).apply(compiler);
+		}
+
 		compiler.hooks.afterPlugins.call(compiler);
 		if (!compiler.inputFileSystem) {
 			throw new Error("No input filesystem provided");

--- a/lib/config/normalization.js
+++ b/lib/config/normalization.js
@@ -152,6 +152,31 @@ const getNormalizedWebpackOptions = config => {
 			externalsPresets => ({ ...externalsPresets })
 		),
 		externalsType: config.externalsType,
+		ignoreWarnings: config.ignoreWarnings
+			? config.ignoreWarnings.map(ignore => {
+					if (typeof ignore === "function") return ignore;
+					const i = ignore instanceof RegExp ? { message: ignore } : ignore;
+					return (warning, { requestShortener }) => {
+						if (!i.message && !i.module && !i.file) return false;
+						if (i.message && !i.message.test(warning.message)) {
+							return false;
+						}
+						if (
+							i.module &&
+							(!warning.module ||
+								!i.module.test(
+									warning.module.readableIdentifier(requestShortener)
+								))
+						) {
+							return false;
+						}
+						if (i.file && (!warning.file || !i.file.test(warning.file))) {
+							return false;
+						}
+						return true;
+					};
+			  })
+			: undefined,
 		infrastructureLogging: nestedConfig(
 			config.infrastructureLogging,
 			infrastructureLogging => ({

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -52,6 +52,8 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @property {Map<string,Chunk[]>} compilationFileToChunks
  * @property {Map<string,Chunk[]>} compilationAuxiliaryFileToChunks
  * @property {RuntimeSpec} runtime
+ * @property {function(Compilation): WebpackError[]} cachedGetErrors
+ * @property {function(Compilation): WebpackError[]} cachedGetWarnings
  */
 
 /**
@@ -173,6 +175,21 @@ const countIterable = iterable => {
 	return i;
 };
 
+/**
+ * @param {Compilation} compilation the compilation
+ * @param {function(Compilation, string): any[]} getItems get items
+ * @returns {number} total number
+ */
+const countWithChildren = (compilation, getItems) => {
+	let count = getItems(compilation, "").length;
+	for (const child of compilation.children) {
+		count += countWithChildren(child, (c, type) =>
+			getItems(c, `.children[].compilation${type}`)
+		);
+	}
+	return count;
+};
+
 /** @type {ExtractorsByOption<WebpackError | string>} */
 const EXTRACT_ERROR = {
 	_: (object, error, context, { requestShortener }) => {
@@ -249,10 +266,34 @@ const EXTRACT_ERROR = {
 const SIMPLE_EXTRACTORS = {
 	compilation: {
 		_: (object, compilation, context) => {
-			context.makePathsRelative = makePathsRelative.bindContextCache(
-				compilation.compiler.context,
-				compilation.compiler.root
-			);
+			if (!context.makePathsRelative) {
+				context.makePathsRelative = makePathsRelative.bindContextCache(
+					compilation.compiler.context,
+					compilation.compiler.root
+				);
+			}
+			if (!context.cachedGetErrors) {
+				const map = new WeakMap();
+				context.cachedGetErrors = compilation => {
+					return (
+						map.get(compilation) ||
+						(errors => (map.set(compilation, errors), errors))(
+							compilation.getErrors()
+						)
+					);
+				};
+			}
+			if (!context.cachedGetWarnings) {
+				const map = new WeakMap();
+				context.cachedGetWarnings = compilation => {
+					return (
+						map.get(compilation) ||
+						(warnings => (map.set(compilation, warnings), warnings))(
+							compilation.getWarnings()
+						)
+					);
+				};
+			}
 			if (compilation.name) {
 				object.name = compilation.name;
 			}
@@ -434,26 +475,48 @@ const SIMPLE_EXTRACTORS = {
 			);
 		},
 		errors: (object, compilation, context, options, factory) => {
-			const { type } = context;
+			const { type, cachedGetErrors } = context;
 			object.errors = factory.create(
 				`${type}.errors`,
-				compilation.errors,
+				cachedGetErrors(compilation),
 				context
 			);
 		},
-		errorsCount: (object, compilation) => {
-			object.errorsCount = compilation.errors.length;
+		errorsCount: (object, compilation, { cachedGetErrors }) => {
+			object.errorsCount = countWithChildren(compilation, c =>
+				cachedGetErrors(c)
+			);
 		},
 		warnings: (object, compilation, context, options, factory) => {
-			const { type } = context;
+			const { type, cachedGetWarnings } = context;
 			object.warnings = factory.create(
 				`${type}.warnings`,
-				compilation.warnings,
+				cachedGetWarnings(compilation),
 				context
 			);
 		},
-		warningsCount: (object, compilation) => {
-			object.warningsCount = compilation.warnings.length;
+		warningsCount: (
+			object,
+			compilation,
+			context,
+			{ warningsFilter },
+			factory
+		) => {
+			const { type, cachedGetWarnings } = context;
+			object.warningsCount = countWithChildren(compilation, (c, childType) => {
+				if (!warningsFilter && warningsFilter.length === 0)
+					return cachedGetWarnings(c);
+				return factory
+					.create(`${type}${childType}.warnings`, cachedGetWarnings(c), context)
+					.filter(warning => {
+						const warningString = Object.keys(warning)
+							.map(key => `${warning[key]}`)
+							.join("\n");
+						return !warningsFilter.some(filter =>
+							filter(warning, warningString)
+						);
+					});
+			});
 		},
 		logging: (object, compilation, _context, options, factory) => {
 			const util = require("util");

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -5,6 +5,7 @@
 
 "use strict";
 
+const util = require("util");
 const ModuleDependency = require("../dependencies/ModuleDependency");
 const formatLocation = require("../formatLocation");
 const { LogType } = require("../logging/Logger");
@@ -1207,12 +1208,16 @@ const FILTER = {
 /** @type {Record<string, Record<string, (thing: Object, context: UsualContext, options: UsualOptions) => boolean | undefined>>} */
 const FILTER_RESULTS = {
 	"compilation.warnings": {
-		warningsFilter: (warning, context, { warningsFilter }) => {
-			const warningString = Object.keys(warning)
-				.map(key => `${warning[key]}`)
-				.join("\n");
-			return !warningsFilter.some(filter => filter(warning, warningString));
-		}
+		warningsFilter: util.deprecate(
+			(warning, context, { warningsFilter }) => {
+				const warningString = Object.keys(warning)
+					.map(key => `${warning[key]}`)
+					.join("\n");
+				return !warningsFilter.some(filter => filter(warning, warningString));
+			},
+			"config.stats.warningsFilter is deprecated in favor of config.ignoreWarnings",
+			"DEP_WEBPACK_STATS_WARNINGS_FILTER"
+		)
 	}
 };
 

--- a/lib/stats/DefaultStatsPrinterPlugin.js
+++ b/lib/stats/DefaultStatsPrinterPlugin.js
@@ -178,6 +178,43 @@ const SIMPLE_PRINTERS = {
 					Object.entries(logging).map(([name, value]) => ({ ...value, name })),
 					context
 			  ),
+	"compilation.warningsInChildren!": (_, { yellow, compilation }) => {
+		if (
+			!compilation.children &&
+			compilation.warningsCount > 0 &&
+			compilation.warnings
+		) {
+			const childWarnings =
+				compilation.warningsCount - compilation.warnings.length;
+			if (childWarnings > 0) {
+				return yellow(
+					`${childWarnings} ${plural(
+						childWarnings,
+						"WARNING",
+						"WARNINGS"
+					)} in child compilations`
+				);
+			}
+		}
+	},
+	"compilation.errorsInChildren!": (_, { red, compilation }) => {
+		if (
+			!compilation.children &&
+			compilation.errorsCount > 0 &&
+			compilation.errors
+		) {
+			const childErrors = compilation.errorsCount - compilation.errors.length;
+			if (childErrors > 0) {
+				return red(
+					`${childErrors} ${plural(
+						childErrors,
+						"ERROR",
+						"ERRORS"
+					)} in child compilations`
+				);
+			}
+		}
+	},
 
 	"asset.type": type => type,
 	"asset.name": (name, { formatFilename, asset: { isOverSizeLimit } }) =>
@@ -578,7 +615,9 @@ const PREFERRED_ORDERS = {
 		"children",
 		"logging",
 		"warnings",
+		"warningsInChildren!",
 		"errors",
+		"errorsInChildren!",
 		"summary!",
 		"needAdditionalPass"
 	],

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -772,6 +772,55 @@
       "type": "string",
       "absolutePath": false
     },
+    "IgnoreWarnings": {
+      "description": "Ignore specific warnings.",
+      "type": "array",
+      "items": {
+        "description": "Ignore specific warnings.",
+        "anyOf": [
+          {
+            "description": "A RegExp to select the warning message.",
+            "instanceof": "RegExp",
+            "tsType": "RegExp"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "file": {
+                "description": "A RegExp to select the origin file for the warning.",
+                "instanceof": "RegExp",
+                "tsType": "RegExp"
+              },
+              "message": {
+                "description": "A RegExp to select the warning message.",
+                "instanceof": "RegExp",
+                "tsType": "RegExp"
+              },
+              "module": {
+                "description": "A RegExp to select the origin module for the warning.",
+                "instanceof": "RegExp",
+                "tsType": "RegExp"
+              }
+            }
+          },
+          {
+            "description": "A custom function to select warnings based on the raw warning instance.",
+            "instanceof": "Function",
+            "tsType": "((warning: import('../lib/WebpackError'), compilation: import('../lib/Compilation')) => boolean)"
+          }
+        ]
+      }
+    },
+    "IgnoreWarningsNormalized": {
+      "description": "Ignore specific warnings.",
+      "type": "array",
+      "items": {
+        "description": "A function to select warnings based on the raw warning instance.",
+        "instanceof": "Function",
+        "tsType": "((warning: import('../lib/WebpackError'), compilation: import('../lib/Compilation')) => boolean)"
+      }
+    },
     "Iife": {
       "description": "Wrap javascript code into IIFE's to avoid leaking into global scope.",
       "type": "boolean"
@@ -3614,6 +3663,9 @@
         "externalsType": {
           "$ref": "#/definitions/ExternalsType"
         },
+        "ignoreWarnings": {
+          "$ref": "#/definitions/IgnoreWarningsNormalized"
+        },
         "infrastructureLogging": {
           "$ref": "#/definitions/InfrastructureLogging"
         },
@@ -3755,6 +3807,9 @@
     },
     "externalsType": {
       "$ref": "#/definitions/ExternalsType"
+    },
+    "ignoreWarnings": {
+      "$ref": "#/definitions/IgnoreWarnings"
     },
     "infrastructureLogging": {
       "$ref": "#/definitions/InfrastructureLogging"

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -105,6 +105,7 @@ describe("Defaults", () => {
 		    "web": true,
 		  },
 		  "externalsType": "var",
+		  "ignoreWarnings": undefined,
 		  "infrastructureLogging": Object {
 		    "debug": false,
 		    "level": "info",

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -24,7 +24,7 @@ describe("Validation", () => {
 		expect(msg).toMatchInlineSnapshot(`
 		"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 		 - configuration should be an object:
-		   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
+		   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, ignoreWarnings?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
 		   -> Options object as provided by the user."
 	`)
 	);
@@ -33,7 +33,7 @@ describe("Validation", () => {
 		expect(msg).toMatchInlineSnapshot(`
 		"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 		 - configuration should be an object:
-		   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
+		   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, ignoreWarnings?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
 		   -> Options object as provided by the user."
 	`)
 	);
@@ -196,7 +196,7 @@ describe("Validation", () => {
 			expect(msg).toMatchInlineSnapshot(`
 			"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 			 - configuration has an unknown property 'postcss'. These properties are valid:
-			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
+			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, ignoreWarnings?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
 			   -> Options object as provided by the user.
 			   For typos: please correct them.
 			   For loader options: webpack >= v2.0.0 no longer allows custom properties in configuration.
@@ -426,7 +426,7 @@ describe("Validation", () => {
 			expect(msg).toMatchInlineSnapshot(`
 			"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 			 - configuration has an unknown property 'debug'. These properties are valid:
-			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
+			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, ignoreWarnings?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
 			   -> Options object as provided by the user.
 			   The 'debug' property was removed in webpack 2.0.0.
 			   Loaders should be updated to allow passing this option via loader options in module.rules.
@@ -482,7 +482,7 @@ describe("Validation", () => {
 			expect(msg).toMatchInlineSnapshot(`
 			"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 			 - configuration[1] should be an object:
-			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
+			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, ignoreWarnings?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
 			   -> Options object as provided by the user."
 		`)
 	);
@@ -568,7 +568,7 @@ describe("Validation", () => {
 				expect(msg).toMatchInlineSnapshot(`
 			"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 			 - configuration has an unknown property 'rules'. These properties are valid:
-			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
+			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, ignoreWarnings?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
 			   -> Options object as provided by the user.
 			   Did you mean module.rules?"
 		`)
@@ -582,7 +582,7 @@ describe("Validation", () => {
 				expect(msg).toMatchInlineSnapshot(`
 			"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 			 - configuration has an unknown property 'splitChunks'. These properties are valid:
-			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
+			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, ignoreWarnings?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
 			   -> Options object as provided by the user.
 			   Did you mean optimization.splitChunks?"
 		`)
@@ -596,7 +596,7 @@ describe("Validation", () => {
 				expect(msg).toMatchInlineSnapshot(`
 			"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 			 - configuration has an unknown property 'noParse'. These properties are valid:
-			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
+			   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry?, experiments?, externals?, externalsPresets?, externalsType?, ignoreWarnings?, infrastructureLogging?, loader?, mode?, module?, name?, node?, optimization?, output?, parallelism?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, snapshot?, stats?, target?, watch?, watchOptions? }
 			   -> Options object as provided by the user.
 			   Did you mean module.noParse?"
 		`)

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -563,6 +563,71 @@ Object {
     "multiple": false,
     "simpleType": "string",
   },
+  "ignore-warnings": Object {
+    "configs": Array [
+      Object {
+        "description": "A RegExp to select the warning message.",
+        "multiple": true,
+        "path": "ignoreWarnings[]",
+        "type": "RegExp",
+      },
+    ],
+    "description": "A RegExp to select the warning message.",
+    "multiple": true,
+    "simpleType": "string",
+  },
+  "ignore-warnings-file": Object {
+    "configs": Array [
+      Object {
+        "description": "A RegExp to select the origin file for the warning.",
+        "multiple": true,
+        "path": "ignoreWarnings[].file",
+        "type": "RegExp",
+      },
+    ],
+    "description": "A RegExp to select the origin file for the warning.",
+    "multiple": true,
+    "simpleType": "string",
+  },
+  "ignore-warnings-message": Object {
+    "configs": Array [
+      Object {
+        "description": "A RegExp to select the warning message.",
+        "multiple": true,
+        "path": "ignoreWarnings[].message",
+        "type": "RegExp",
+      },
+    ],
+    "description": "A RegExp to select the warning message.",
+    "multiple": true,
+    "simpleType": "string",
+  },
+  "ignore-warnings-module": Object {
+    "configs": Array [
+      Object {
+        "description": "A RegExp to select the origin module for the warning.",
+        "multiple": true,
+        "path": "ignoreWarnings[].module",
+        "type": "RegExp",
+      },
+    ],
+    "description": "A RegExp to select the origin module for the warning.",
+    "multiple": true,
+    "simpleType": "string",
+  },
+  "ignore-warnings-reset": Object {
+    "configs": Array [
+      Object {
+        "description": "Clear all items provided in configuration. Ignore specific warnings.",
+        "multiple": false,
+        "path": "ignoreWarnings",
+        "type": "reset",
+      },
+    ],
+    "description": "Clear all items provided in configuration. Ignore specific warnings.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "infrastructure-logging-debug": Object {
     "configs": Array [
       Object {

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -886,6 +886,22 @@ chunk trees.js (trees) 71 bytes [rendered]
   ./trees/3.js 14 bytes [built] [code generated]"
 `;
 
+exports[`StatsTestCases should print correct stats for ignore-warnings 1`] = `
+"asset main.js 943 bytes [emitted] (name: main)
+orphan modules 8.53 KiB [orphan] 9 modules
+./index.js + 9 modules 8.7 KiB [built] [code generated]
+
+WARNING in ./module.js?4 3:12-20
+Should not import the named export 'homepage' (imported as 'homepage') from default-exporting module (only default export is available soon)
+ @ ./index.js 4:0-20
+
+WARNING in ./module2.js?1 3:12-16
+Should not import the named export 'name' (imported as 'name') from default-exporting module (only default export is available soon)
+ @ ./index.js 6:0-21
+
+webpack x.x.x compiled with 2 warnings in X ms"
+`;
+
 exports[`StatsTestCases should print correct stats for immutable 1`] = `
 "asset c30341ca2ed860460ce7.js 12.5 KiB [emitted] [immutable] (name: main)
 asset b815a02217b4cae51059.js 884 bytes [emitted] [immutable]"

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1419,7 +1419,8 @@ WARNING in configuration
 The 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
 You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/
 
-webpack x.x.x compiled with 1 warning in X ms"
+1 ERROR in child compilations
+webpack x.x.x compiled with 1 error and 1 warning in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for optimize-chunks 1`] = `

--- a/test/statsCases/ignore-warnings/index.js
+++ b/test/statsCases/ignore-warnings/index.js
@@ -1,0 +1,9 @@
+import "./module?1";
+import "./module?2";
+import "./module?3";
+import "./module?4";
+
+import "./module2?1";
+import "./module2?2";
+import "./module2?3";
+import "./module2?4";

--- a/test/statsCases/ignore-warnings/module.js
+++ b/test/statsCases/ignore-warnings/module.js
@@ -1,0 +1,3 @@
+import { homepage } from "../../../package.json";
+
+console.log(homepage);

--- a/test/statsCases/ignore-warnings/module2.js
+++ b/test/statsCases/ignore-warnings/module2.js
@@ -1,0 +1,3 @@
+import { name } from "../../../package.json";
+
+console.log(name);

--- a/test/statsCases/ignore-warnings/webpack.config.js
+++ b/test/statsCases/ignore-warnings/webpack.config.js
@@ -1,0 +1,17 @@
+/** @type {import("../../../").Configuration} */
+module.exports = {
+	entry: "./index.js",
+	ignoreWarnings: [
+		{
+			module: /module2\.js\?[34]/
+		},
+		{
+			module: /[13]/,
+			message: /homepage/
+		},
+		/The 'mode' option has not been set/,
+		warning => {
+			return warning.module.identifier().endsWith("?2");
+		}
+	]
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -1234,6 +1234,8 @@ declare class Compilation {
 		needAdditionalPass: SyncBailHook<[], boolean>;
 		childCompiler: SyncHook<[Compiler, string, number], void>;
 		log: SyncBailHook<[string, LogEntry], true>;
+		processWarnings: SyncWaterfallHook<[WebpackError[]]>;
+		processErrors: SyncWaterfallHook<[WebpackError[]]>;
 		statsPreset: HookMap<SyncHook<[any, any], void>>;
 		statsNormalize: SyncHook<[any, any], void>;
 		statsFactory: SyncHook<[StatsFactory, any], void>;
@@ -1472,6 +1474,8 @@ declare class Compilation {
 		filename: string | ((arg0: PathData, arg1: AssetInfo) => string),
 		data: PathData
 	): { path: string; info: AssetInfo };
+	getWarnings(): WebpackError[];
+	getErrors(): WebpackError[];
 
 	/**
 	 * This function allows you to run another instance of webpack inside of webpack however as

--- a/types.d.ts
+++ b/types.d.ts
@@ -1804,6 +1804,28 @@ declare interface Configuration {
 	externalsType?: ExternalsType;
 
 	/**
+	 * Ignore specific warnings.
+	 */
+	ignoreWarnings?: (
+		| RegExp
+		| {
+				/**
+				 * A RegExp to select the origin file for the warning.
+				 */
+				file?: RegExp;
+				/**
+				 * A RegExp to select the warning message.
+				 */
+				message?: RegExp;
+				/**
+				 * A RegExp to select the origin module for the warning.
+				 */
+				module?: RegExp;
+		  }
+		| ((warning: WebpackError, compilation: Compilation) => boolean)
+	)[];
+
+	/**
 	 * Options for infrastructure level logging.
 	 */
 	infrastructureLogging?: InfrastructureLogging;
@@ -9498,6 +9520,14 @@ declare interface WebpackOptionsNormalized {
 	 * Specifies the default type of externals ('amd*', 'umd*', 'system' and 'jsonp' depend on output.libraryTarget set to the same value).
 	 */
 	externalsType?: ExternalsType;
+
+	/**
+	 * Ignore specific warnings.
+	 */
+	ignoreWarnings?: ((
+		warning: WebpackError,
+		compilation: Compilation
+	) => boolean)[];
 
 	/**
 	 * Options for infrastructure level logging.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

improve warnings and errors handling in stats
respect warningsFilter for warnings count
include child compilation warnings and errors in count
show hint for child compilation errors and warnings
add config.ignoreWarnings
deprecate stats.warningsFilter

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
refactoring
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no, only deprecation
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
* `stats.warningsFilter` is deprecated
* `ignoreWarnings` is the new option
  * `RegExp`
  * `{module?: RegExp, file?: RegExp, message?: RegExp}`
  * `function(WebpackError, Compilation): boolean`
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
