### PR TITLE
Update HotModuleReplacement.runtime.js

### DIFF
--- a/lib/hmr/HotModuleReplacement.runtime.js
+++ b/lib/hmr/HotModuleReplacement.runtime.js
@@ -76,26 +76,28 @@ module.exports = function () {
 			}
 			return require(request);
 		};
-		var createPropertyDescriptor = function (name) {
-			return {
-				configurable: true,
-				enumerable: true,
-				get: function () {
-					return require[name];
-				},
-				set: function (value) {
-					require[name] = value;
-				}
-			};
-		};
-		for (var name in require) {
-			if (Object.prototype.hasOwnProperty.call(require, name) && name !== "e") {
-				Object.defineProperty(fn, name, createPropertyDescriptor(name));
-			}
-		}
+		
 		fn.e = function (chunkId) {
 			return trackBlockingPromise(require.e(chunkId));
 		};
+		
+		fn = new Proxy(fn, {
+			set(object, property, value){
+				if (!object.hasOwnProperty(property)) {
+					return require[property] = value
+				}else{
+					return object[property] = value
+				}
+			},
+			get(object, property){
+				if (!object.hasOwnProperty(property)) {
+					return require[property]
+				}else{
+					return object[property]
+				}
+			}
+		});
+		
 		return fn;
 	}
 


### PR DESCRIPTION
Add support for __webpack_require__.nc and other properties on __webpack_require__ that are non-existent when HMR is injected.  


**What kind of change does this PR introduce?**

This resolves issues such as https://github.com/webpack-contrib/style-loader/issues/427

**Does this PR introduce a breaking change?**

This feature will not work on IE as it does not support Proxy, but IE should not be supported anyways.


