### PR TITLE
fix: warnUnexpectedRequire binds wrong variable in for-loop

### DIFF
--- a/lib/hmr/HotModuleReplacement.runtime.js
+++ b/lib/hmr/HotModuleReplacement.runtime.js
@@ -66,7 +66,7 @@ module.exports = function () {
 					me.children.push(request);
 				}
 			} else {
-				console.trace(
+				console.warn(
 					"[HMR] unexpected require(" +
 						request +
 						") from disposed module " +

--- a/lib/hmr/JavascriptHotModuleReplacement.runtime.js
+++ b/lib/hmr/JavascriptHotModuleReplacement.runtime.js
@@ -107,9 +107,9 @@ module.exports = function () {
 		var outdatedModules = [];
 		var appliedUpdate = {};
 
-		var warnUnexpectedRequire = function warnUnexpectedRequire(moduleId) {
+		var warnUnexpectedRequire = function warnUnexpectedRequire(module) {
 			console.warn(
-				"[HMR] unexpected require(" + moduleId + ") to disposed module"
+				"[HMR] unexpected require(" + module.id + ") to disposed module"
 			);
 		};
 
@@ -194,11 +194,7 @@ module.exports = function () {
 				}
 				if (doDispose) {
 					addAllToSet(outdatedModules, [result.moduleId]);
-					appliedUpdate[moduleId] = warnUnexpectedRequire.bind(
-						null,
-						result.moduleId
-					);
-					appliedUpdate[moduleId].isDisposed = true;
+					appliedUpdate[moduleId] = warnUnexpectedRequire;
 				}
 			}
 		}
@@ -212,8 +208,7 @@ module.exports = function () {
 				$moduleCache$[outdatedModuleId] &&
 				$moduleCache$[outdatedModuleId].hot._selfAccepted &&
 				// removed self-accepted modules should not be required
-				(!appliedUpdate[outdatedModuleId] ||
-					!appliedUpdate[outdatedModuleId].isDisposed) &&
+				appliedUpdate[outdatedModuleId] !== warnUnexpectedRequire &&
 				// when called invalidate self-accepting is not possible
 				!$moduleCache$[outdatedModuleId].hot._selfInvalidated
 			) {

--- a/lib/hmr/JavascriptHotModuleReplacement.runtime.js
+++ b/lib/hmr/JavascriptHotModuleReplacement.runtime.js
@@ -107,9 +107,9 @@ module.exports = function () {
 		var outdatedModules = [];
 		var appliedUpdate = {};
 
-		var warnUnexpectedRequire = function warnUnexpectedRequire() {
+		var warnUnexpectedRequire = function warnUnexpectedRequire(moduleId) {
 			console.warn(
-				"[HMR] unexpected require(" + result.moduleId + ") to disposed module"
+				"[HMR] unexpected require(" + moduleId + ") to disposed module"
 			);
 		};
 
@@ -194,7 +194,11 @@ module.exports = function () {
 				}
 				if (doDispose) {
 					addAllToSet(outdatedModules, [result.moduleId]);
-					appliedUpdate[moduleId] = warnUnexpectedRequire;
+					appliedUpdate[moduleId] = warnUnexpectedRequire.bind(
+						null,
+						result.moduleId
+					);
+					appliedUpdate[moduleId].isDisposed = true;
 				}
 			}
 		}
@@ -208,7 +212,8 @@ module.exports = function () {
 				$moduleCache$[outdatedModuleId] &&
 				$moduleCache$[outdatedModuleId].hot._selfAccepted &&
 				// removed self-accepted modules should not be required
-				appliedUpdate[outdatedModuleId] !== warnUnexpectedRequire &&
+				(!appliedUpdate[outdatedModuleId] ||
+					!appliedUpdate[outdatedModuleId].isDisposed) &&
 				// when called invalidate self-accepting is not possible
 				!$moduleCache$[outdatedModuleId].hot._selfInvalidated
 			) {

--- a/test/HotTestCases.template.js
+++ b/test/HotTestCases.template.js
@@ -208,7 +208,7 @@ const describeCases = config => {
 												return JSON.parse(fs.readFileSync(p, "utf-8"));
 											} else {
 												const fn = vm.runInThisContext(
-													"(function(require, module, exports, __dirname, __filename, it, expect, self, window, fetch, document, importScripts, NEXT, STATS) {" +
+													"(function(require, module, exports, __dirname, __filename, it, beforeEach, afterEach, expect, self, window, fetch, document, importScripts, NEXT, STATS) {" +
 														"global.expect = expect;" +
 														'function nsObj(m) { Object.defineProperty(m, Symbol.toStringTag, { value: "Module" }); return m; }' +
 														fs.readFileSync(p, "utf-8") +
@@ -226,6 +226,8 @@ const describeCases = config => {
 													outputDirectory,
 													p,
 													_it,
+													_beforeEach,
+													_afterEach,
 													expect,
 													window,
 													window,
@@ -271,10 +273,12 @@ const describeCases = config => {
 							20000
 						);
 
-						const { it: _it, getNumberOfTests } = createLazyTestEnv(
-							jasmine.getEnv(),
-							20000
-						);
+						const {
+							it: _it,
+							beforeEach: _beforeEach,
+							afterEach: _afterEach,
+							getNumberOfTests
+						} = createLazyTestEnv(jasmine.getEnv(), 20000);
 					});
 				});
 			});

--- a/test/configCases/sharing/consume-multiple-versions/index.js
+++ b/test/configCases/sharing/consume-multiple-versions/index.js
@@ -1,31 +1,6 @@
-let warnings = [];
-let oldWarn;
+const expectWarningFactory = require('../../../helpers/expectWarningFactory');
 
-beforeEach(done => {
-	oldWarn = console.warn;
-	console.warn = m => warnings.push(m);
-	done();
-});
-
-afterEach(done => {
-	expectWarning();
-	console.warn = oldWarn;
-	done();
-});
-
-const expectWarning = regexp => {
-	if (!regexp) {
-		expect(warnings).toEqual([]);
-	} else {
-		expect(warnings).toEqual(
-			expect.objectContaining({
-				0: expect.stringMatching(regexp),
-				length: 1
-			})
-		);
-	}
-	warnings.length = 0;
-};
+const expectWarning = expectWarningFactory();
 
 it("should be able to consume different shared module version depending on context", async () => {
 	__webpack_share_scopes__["default"] = {

--- a/test/configCases/sharing/consume-multiple-versions/index.js
+++ b/test/configCases/sharing/consume-multiple-versions/index.js
@@ -1,6 +1,4 @@
-const expectWarningFactory = require('../../../helpers/expectWarningFactory');
-
-const expectWarning = expectWarningFactory();
+const expectWarning = require("../../../helpers/expectWarningFactory")();
 
 it("should be able to consume different shared module version depending on context", async () => {
 	__webpack_share_scopes__["default"] = {

--- a/test/helpers/expectWarningFactory.js
+++ b/test/helpers/expectWarningFactory.js
@@ -14,17 +14,8 @@ module.exports = () => {
 		done();
 	});
 
-	const expectWarning = regexp => {
-		if (!regexp) {
-			expect(warnings).toEqual([]);
-		} else {
-			expect(warnings).toEqual(
-				expect.objectContaining({
-					0: expect.stringMatching(regexp),
-					length: 1
-				})
-			);
-		}
+	const expectWarning = (...regexp) => {
+		expect(warnings).toEqual(regexp.map(r => expect.stringMatching(r)));
 		warnings.length = 0;
 	};
 

--- a/test/helpers/expectWarningFactory.js
+++ b/test/helpers/expectWarningFactory.js
@@ -1,0 +1,32 @@
+module.exports = () => {
+	let warnings = [];
+	let oldWarn;
+
+	beforeEach(done => {
+		oldWarn = console.warn;
+		console.warn = m => warnings.push(m);
+		done();
+	});
+
+	afterEach(done => {
+		expectWarning();
+		console.warn = oldWarn;
+		done();
+	});
+
+	const expectWarning = regexp => {
+		if (!regexp) {
+			expect(warnings).toEqual([]);
+		} else {
+			expect(warnings).toEqual(
+				expect.objectContaining({
+					0: expect.stringMatching(regexp),
+					length: 1
+				})
+			);
+		}
+		warnings.length = 0;
+	};
+
+	return expectWarning;
+};

--- a/test/hotCases/runtime/require-disposed-module-warning/a.js
+++ b/test/hotCases/runtime/require-disposed-module-warning/a.js
@@ -1,4 +1,1 @@
 export default module;
----
----
-export default "a2";

--- a/test/hotCases/runtime/require-disposed-module-warning/a.js
+++ b/test/hotCases/runtime/require-disposed-module-warning/a.js
@@ -1,0 +1,4 @@
+export default "a1";
+---
+---
+export default "a2";

--- a/test/hotCases/runtime/require-disposed-module-warning/a.js
+++ b/test/hotCases/runtime/require-disposed-module-warning/a.js
@@ -1,4 +1,4 @@
-export default "a1";
+export default module;
 ---
 ---
 export default "a2";

--- a/test/hotCases/runtime/require-disposed-module-warning/b.js
+++ b/test/hotCases/runtime/require-disposed-module-warning/b.js
@@ -1,0 +1,1 @@
+export default "b";

--- a/test/hotCases/runtime/require-disposed-module-warning/index.js
+++ b/test/hotCases/runtime/require-disposed-module-warning/index.js
@@ -1,9 +1,11 @@
 const expectWarning = require("../../../helpers/expectWarningFactory")();
-require("./module");
+const {aModule} = require("./module");
 
 it("should print correct warning messages when a disposed module is required", (done) => {
 	NEXT(require("../../update")(done, true, () => {
 		require("./module");
+		__webpack_modules__[aModule.id].call(aModule.exports, aModule);
+		expectWarning(/^\[HMR] unexpected require\(\.\/a.js\) to disposed module$/);
 		done();
 	}));
 });

--- a/test/hotCases/runtime/require-disposed-module-warning/index.js
+++ b/test/hotCases/runtime/require-disposed-module-warning/index.js
@@ -1,15 +1,22 @@
 const expectWarning = require("../../../helpers/expectWarningFactory")();
-const {aModule} = require("./module");
+const getInner = require("./module");
 
-it("should print correct warning messages when a disposed module is required", (done) => {
-	NEXT(require("../../update")(done, true, () => {
-		require("./module");
-		__webpack_modules__[aModule.id].call(aModule.exports, aModule);
-		expectWarning(/^\[HMR] unexpected require\(\.\/a.js\) to disposed module$/);
-		done();
-	}));
+it("should print correct warning messages when a disposed module is required", done => {
+	NEXT(
+		require("../../update")(done, true, () => {
+			getInner();
+			expectWarning(
+				/^\[HMR] unexpected require\(\.\/a.js\) from disposed module \.\/module\.js$/,
+				/^\[HMR] unexpected require\(\.\/a.js\) to disposed module$/
+			);
+			const getInnerUpdated = require("./module");
+			getInnerUpdated();
+			expectWarning();
+			done();
+		})
+	);
 });
 
-if(module.hot) {
+if (module.hot) {
 	module.hot.accept("./module");
 }

--- a/test/hotCases/runtime/require-disposed-module-warning/index.js
+++ b/test/hotCases/runtime/require-disposed-module-warning/index.js
@@ -1,0 +1,13 @@
+const expectWarning = require("../../../helpers/expectWarningFactory")();
+require("./module");
+
+it("should print correct warning messages when a disposed module is required", (done) => {
+	NEXT(require("../../update")(done, true, () => {
+		require("./module");
+		done();
+	}));
+});
+
+if(module.hot) {
+	module.hot.accept("./module");
+}

--- a/test/hotCases/runtime/require-disposed-module-warning/module.js
+++ b/test/hotCases/runtime/require-disposed-module-warning/module.js
@@ -1,3 +1,3 @@
-export {default as aModule} from "./a";
+module.exports = () => require("./a");
 ---
-import "./b";
+module.exports = () => require("./b");

--- a/test/hotCases/runtime/require-disposed-module-warning/module.js
+++ b/test/hotCases/runtime/require-disposed-module-warning/module.js
@@ -1,0 +1,3 @@
+import "./a";
+---
+import "./b";

--- a/test/hotCases/runtime/require-disposed-module-warning/module.js
+++ b/test/hotCases/runtime/require-disposed-module-warning/module.js
@@ -1,3 +1,3 @@
-import "./a";
+export {default as aModule} from "./a";
 ---
 import "./b";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Fix the warnUnexpectedRequire function where it uses a hoisted variable in a for-loop.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No. The bugfix is for a warning. I think tests are unnecessary.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Nothing.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
