### PR TITLE
make browserslist the default target when browserslist config is available

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -8,7 +8,11 @@
 const path = require("path");
 const Template = require("../Template");
 const { cleverMerge } = require("../util/cleverMerge");
-const { getTargetsProperties, getTargetProperties } = require("./target");
+const {
+	getTargetsProperties,
+	getTargetProperties,
+	getDefaultTarget
+} = require("./target");
 
 /** @typedef {import("../../declarations/WebpackOptions").CacheOptionsNormalized} CacheOptions */
 /** @typedef {import("../../declarations/WebpackOptions").EntryNormalized} Entry */
@@ -118,9 +122,9 @@ const applyWebpackOptionsBaseDefaults = options => {
  */
 const applyWebpackOptionsDefaults = options => {
 	F(options, "context", () => process.cwd());
-	// todo webpack 6: make ["web", "browserslist"] by default
-	// todo webpack 6: infer platform from target (target: 'browserslist:last 2 node version')
-	D(options, "target", "web");
+	F(options, "target", () => {
+		return getDefaultTarget(options.context);
+	});
 
 	const { mode, name, target } = options;
 

--- a/lib/config/target.js
+++ b/lib/config/target.js
@@ -8,6 +8,15 @@
 const browserslistTargetHandler = require("./browserslistTargetHandler");
 
 /**
+ * @param {string} context the context directory
+ * @returns {string} default target
+ */
+const getDefaultTarget = context => {
+	const browsers = browserslistTargetHandler.load(null, context);
+	return browsers ? "browserslist" : "web";
+};
+
+/**
  * @typedef {Object} PlatformTargetProperties
  * @property {boolean | null} web web platform, importing of http(s) and std: is available
  * @property {boolean | null} browser browser platform, running in a normal web browser
@@ -319,5 +328,6 @@ const getTargetsProperties = (targets, context) => {
 	);
 };
 
+exports.getDefaultTarget = getDefaultTarget;
 exports.getTargetProperties = getTargetProperties;
 exports.getTargetsProperties = getTargetsProperties;

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const jestDiff = require("jest-diff").default;
 const stripAnsi = require("strip-ansi");
 const {
@@ -1508,6 +1509,53 @@ describe("Defaults", () => {
 		+   "stats": Object {
 		+     "preset": "minimal",
 		+   },
+		`)
+	);
+
+	test(
+		"browserslist",
+		{ context: path.resolve(__dirname, "fixtures/browserslist") },
+		e =>
+			e.toMatchInlineSnapshot(`
+			- Expected
+			+ Received
+
+			@@ ... @@
+			-   "context": "<cwd>",
+			+   "context": "<cwd>/test/fixtures/browserslist",
+			@@ ... @@
+			-     "chunkLoadingGlobal": "webpackChunkwebpack",
+			+     "chunkLoadingGlobal": "webpackChunkbrowserslist_test",
+			@@ ... @@
+			-     "devtoolNamespace": "webpack",
+			+     "devtoolNamespace": "browserslist-test",
+			@@ ... @@
+			-       "arrowFunction": true,
+			-       "bigIntLiteral": undefined,
+			-       "const": true,
+			-       "destructuring": true,
+			-       "dynamicImport": undefined,
+			-       "forOf": true,
+			-       "module": undefined,
+			+       "arrowFunction": false,
+			+       "bigIntLiteral": false,
+			+       "const": false,
+			+       "destructuring": false,
+			+       "dynamicImport": false,
+			+       "forOf": false,
+			+       "module": false,
+			@@ ... @@
+			-     "hotUpdateGlobal": "webpackHotUpdatewebpack",
+			+     "hotUpdateGlobal": "webpackHotUpdatebrowserslist_test",
+			@@ ... @@
+			-     "uniqueName": "webpack",
+			+     "uniqueName": "browserslist-test",
+			@@ ... @@
+			-       "<cwd>",
+			+       "<cwd>/test/fixtures/browserslist",
+			@@ ... @@
+			-   "target": "web",
+			+   "target": "browserslist",
 		`)
 	);
 });

--- a/test/fixtures/browserslist/package.json
+++ b/test/fixtures/browserslist/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "browserslist-test",
+  "browserslist": [
+    "ie >= 9"
+  ]
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
defaults change
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
yes
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
when browserslist info is available, this will be used by default
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
