### PR TITLE
allow plugins to modify the default size types for splitChunks

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1518,6 +1518,10 @@ export interface OptimizationSplitChunksOptions {
 		| ("initial" | "async" | "all")
 		| ((chunk: import("../lib/Chunk")) => boolean);
 	/**
+	 * Sets the size types which are used when a number is used for sizes.
+	 */
+	defaultSizeTypes?: string[];
+	/**
 	 * Size threshold at which splitting is enforced and other restrictions (minRemainingSize, maxAsyncRequests, maxInitialRequests) are ignored.
 	 */
 	enforceSizeThreshold?: OptimizationSplitChunksSizes;

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -883,6 +883,7 @@ const applyOptimizationDefaults = (
 	});
 	const { splitChunks } = optimization;
 	if (splitChunks) {
+		A(splitChunks, "defaultSizeTypes", () => ["javascript", "unknown"]);
 		D(splitChunks, "hidePathInfo", production);
 		D(splitChunks, "chunks", "async");
 		D(splitChunks, "usedExports", true);

--- a/lib/config/normalization.js
+++ b/lib/config/normalization.js
@@ -208,6 +208,9 @@ const getNormalizedWebpackOptions = config => {
 					splitChunks =>
 						splitChunks && {
 							...splitChunks,
+							defaultSizeTypes: splitChunks.defaultSizeTypes
+								? [...splitChunks.defaultSizeTypes]
+								: ["..."],
 							cacheGroups: nestedConfig(
 								splitChunks.cacheGroups,
 								cacheGroups => ({

--- a/lib/optimize/SplitChunksPlugin.js
+++ b/lib/optimize/SplitChunksPlugin.js
@@ -131,6 +131,7 @@ const MinMaxSizeWarning = require("./MinMaxSizeWarning");
 /**
  * @typedef {Object} SplitChunksOptions
  * @property {ChunkFilterFunction} chunksFilter
+ * @property {string[]} defaultSizeTypes
  * @property {SplitChunksSizes} minSize
  * @property {SplitChunksSizes} minRemainingSize
  * @property {SplitChunksSizes} enforceSizeThreshold
@@ -251,14 +252,15 @@ const ALL_CHUNK_FILTER = chunk => true;
 
 /**
  * @param {OptimizationSplitChunksSizes} value the sizes
+ * @param {string[]} defaultSizeTypes the default size types
  * @returns {SplitChunksSizes} normalized representation
  */
-const normalizeSizes = value => {
+const normalizeSizes = (value, defaultSizeTypes) => {
 	if (typeof value === "number") {
-		return {
-			javascript: value,
-			unknown: value
-		};
+		/** @type {Record<string, number>} */
+		const o = {};
+		for (const sizeType of defaultSizeTypes) o[sizeType] = value;
+		return o;
 	} else if (typeof value === "object" && value !== null) {
 		return { ...value };
 	} else {
@@ -267,14 +269,14 @@ const normalizeSizes = value => {
 };
 
 /**
- * @param {...OptimizationSplitChunksSizes} sizes the sizes
+ * @param {...SplitChunksSizes} sizes the sizes
  * @returns {SplitChunksSizes} the merged sizes
  */
 const mergeSizes = (...sizes) => {
 	/** @type {SplitChunksSizes} */
 	let merged = {};
 	for (let i = sizes.length - 1; i >= 0; i--) {
-		merged = Object.assign(merged, normalizeSizes(sizes[i]));
+		merged = Object.assign(merged, sizes[i]);
 	}
 	return merged;
 };
@@ -394,9 +396,10 @@ const normalizeChunksFilter = chunks => {
 
 /**
  * @param {GetCacheGroups | Record<string, false|string|RegExp|OptimizationSplitChunksGetCacheGroups|OptimizationSplitChunksCacheGroup>} cacheGroups the cache group options
+ * @param {string[]} defaultSizeTypes the default size types
  * @returns {GetCacheGroups} a function to get the cache groups
  */
-const normalizeCacheGroups = cacheGroups => {
+const normalizeCacheGroups = (cacheGroups, defaultSizeTypes) => {
 	if (typeof cacheGroups === "function") {
 		return cacheGroups;
 	}
@@ -409,24 +412,36 @@ const normalizeCacheGroups = cacheGroups => {
 				continue;
 			}
 			if (typeof option === "string" || option instanceof RegExp) {
-				const source = createCacheGroupSource({}, key);
+				const source = createCacheGroupSource({}, key, defaultSizeTypes);
 				handlers.push((module, context, results) => {
 					if (checkTest(option, module, context)) {
 						results.push(source);
 					}
 				});
 			} else if (typeof option === "function") {
+				const cache = new WeakMap();
 				handlers.push((module, context, results) => {
 					const result = option(module);
 					if (result) {
 						const groups = Array.isArray(result) ? result : [result];
 						for (const group of groups) {
-							results.push(createCacheGroupSourceCached(group, key));
+							const cachedSource = cache.get(group);
+							if (cachedSource !== undefined) {
+								results.push(cachedSource);
+							} else {
+								const source = createCacheGroupSource(
+									group,
+									key,
+									defaultSizeTypes
+								);
+								cache.set(group, source);
+								results.push(source);
+							}
 						}
 					}
 				});
 			} else {
-				const source = createCacheGroupSource(option, key);
+				const source = createCacheGroupSource(option, key, defaultSizeTypes);
 				handlers.push((module, context, results) => {
 					if (
 						checkTest(option.test, module, context) &&
@@ -500,48 +515,37 @@ const checkModuleType = (test, module) => {
 };
 
 /**
- * @typedef {Object} CacheGroupKey
- * @property {string} key
- */
-
-const cacheGroupSourceCache = new WeakMap();
-
-/**
  * @param {OptimizationSplitChunksCacheGroup} options the group options
  * @param {string} key key of cache group
+ * @param {string[]} defaultSizeTypes the default size types
  * @returns {CacheGroupSource} the normalized cached group
  */
-const createCacheGroupSourceCached = (options, key) => {
-	let cacheMap = cacheGroupSourceCache.get(options);
-	if (cacheMap !== undefined) {
-		const cacheEntry = cacheMap.get(key);
-		if (cacheEntry !== undefined) return cacheEntry;
-	} else {
-		cacheMap = new Map();
-		cacheGroupSourceCache.set(options, cacheMap);
-	}
-	const result = createCacheGroupSource(options, key);
-	cacheMap.set(key, result);
-	return result;
-};
-
-/**
- * @param {OptimizationSplitChunksCacheGroup} options the group options
- * @param {string} key key of cache group
- * @returns {CacheGroupSource} the normalized cached group
- */
-const createCacheGroupSource = (options, key) => {
+const createCacheGroupSource = (options, key, defaultSizeTypes) => {
+	const minSize = normalizeSizes(options.minSize, defaultSizeTypes);
+	const maxSize = normalizeSizes(options.maxSize, defaultSizeTypes);
 	return {
 		key,
 		priority: options.priority,
 		getName: normalizeName(options.name),
 		chunksFilter: normalizeChunksFilter(options.chunks),
 		enforce: options.enforce,
-		minSize: normalizeSizes(options.minSize),
-		minRemainingSize: mergeSizes(options.minRemainingSize, options.minSize),
-		enforceSizeThreshold: normalizeSizes(options.enforceSizeThreshold),
-		maxAsyncSize: mergeSizes(options.maxAsyncSize, options.maxSize),
-		maxInitialSize: mergeSizes(options.maxInitialSize, options.maxSize),
+		minSize,
+		minRemainingSize: mergeSizes(
+			normalizeSizes(options.minRemainingSize, defaultSizeTypes),
+			minSize
+		),
+		enforceSizeThreshold: normalizeSizes(
+			options.enforceSizeThreshold,
+			defaultSizeTypes
+		),
+		maxAsyncSize: mergeSizes(
+			normalizeSizes(options.maxAsyncSize, defaultSizeTypes),
+			maxSize
+		),
+		maxInitialSize: mergeSizes(
+			normalizeSizes(options.maxInitialSize, defaultSizeTypes),
+			maxSize
+		),
 		minChunks: options.minChunks,
 		maxAsyncRequests: options.maxAsyncRequests,
 		maxInitialRequests: options.maxInitialRequests,
@@ -558,38 +562,63 @@ module.exports = class SplitChunksPlugin {
 	 * @param {OptimizationSplitChunksOptions=} options plugin options
 	 */
 	constructor(options = {}) {
+		const defaultSizeTypes = options.defaultSizeTypes || [
+			"javascript",
+			"unknown"
+		];
 		const fallbackCacheGroup = options.fallbackCacheGroup || {};
+		const minSize = normalizeSizes(options.minSize, defaultSizeTypes);
+		const maxSize = normalizeSizes(options.maxSize, defaultSizeTypes);
 
 		/** @type {SplitChunksOptions} */
 		this.options = {
 			chunksFilter: normalizeChunksFilter(options.chunks || "all"),
-			minSize: normalizeSizes(options.minSize),
-			minRemainingSize: mergeSizes(options.minRemainingSize, options.minSize),
-			enforceSizeThreshold: normalizeSizes(options.enforceSizeThreshold),
-			maxAsyncSize: mergeSizes(options.maxAsyncSize, options.maxSize),
-			maxInitialSize: mergeSizes(options.maxInitialSize, options.maxSize),
+			defaultSizeTypes,
+			minSize,
+			minRemainingSize: mergeSizes(
+				normalizeSizes(options.minRemainingSize, defaultSizeTypes),
+				minSize
+			),
+			enforceSizeThreshold: normalizeSizes(
+				options.enforceSizeThreshold,
+				defaultSizeTypes
+			),
+			maxAsyncSize: mergeSizes(
+				normalizeSizes(options.maxAsyncSize, defaultSizeTypes),
+				maxSize
+			),
+			maxInitialSize: mergeSizes(
+				normalizeSizes(options.maxInitialSize, defaultSizeTypes),
+				maxSize
+			),
 			minChunks: options.minChunks || 1,
 			maxAsyncRequests: options.maxAsyncRequests || 1,
 			maxInitialRequests: options.maxInitialRequests || 1,
 			hidePathInfo: options.hidePathInfo || false,
 			filename: options.filename || undefined,
-			getCacheGroups: normalizeCacheGroups(options.cacheGroups),
+			getCacheGroups: normalizeCacheGroups(
+				options.cacheGroups,
+				defaultSizeTypes
+			),
 			getName: options.name ? normalizeName(options.name) : defaultGetName,
 			automaticNameDelimiter: options.automaticNameDelimiter,
 			usedExports: options.usedExports,
 			fallbackCacheGroup: {
-				minSize: mergeSizes(fallbackCacheGroup.minSize, options.minSize),
+				minSize: mergeSizes(
+					normalizeSizes(fallbackCacheGroup.minSize, defaultSizeTypes),
+					minSize
+				),
 				maxAsyncSize: mergeSizes(
-					fallbackCacheGroup.maxAsyncSize,
-					fallbackCacheGroup.maxSize,
-					options.maxAsyncSize,
-					options.maxSize
+					normalizeSizes(fallbackCacheGroup.maxAsyncSize, defaultSizeTypes),
+					normalizeSizes(fallbackCacheGroup.maxSize, defaultSizeTypes),
+					normalizeSizes(options.maxAsyncSize, defaultSizeTypes),
+					normalizeSizes(options.maxSize, defaultSizeTypes)
 				),
 				maxInitialSize: mergeSizes(
-					fallbackCacheGroup.maxInitialSize,
-					fallbackCacheGroup.maxSize,
-					options.maxInitialSize,
-					options.maxSize
+					normalizeSizes(fallbackCacheGroup.maxInitialSize, defaultSizeTypes),
+					normalizeSizes(fallbackCacheGroup.maxSize, defaultSizeTypes),
+					normalizeSizes(options.maxInitialSize, defaultSizeTypes),
+					normalizeSizes(options.maxSize, defaultSizeTypes)
 				),
 				automaticNameDelimiter:
 					fallbackCacheGroup.automaticNameDelimiter ||

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1670,6 +1670,15 @@
             }
           ]
         },
+        "defaultSizeTypes": {
+          "description": "Sets the size types which are used when a number is used for sizes.",
+          "type": "array",
+          "items": {
+            "description": "Size type, like 'javascript', 'webassembly'.",
+            "type": "string"
+          },
+          "minLength": 1
+        },
         "enforceSizeThreshold": {
           "description": "Size threshold at which splitting is enforced and other restrictions (minRemainingSize, maxAsyncRequests, maxInitialRequests) are ignored.",
           "oneOf": [

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -253,6 +253,10 @@ describe("Defaults", () => {
 		        },
 		      },
 		      "chunks": "async",
+		      "defaultSizeTypes": Array [
+		        "javascript",
+		        "unknown",
+		      ],
 		      "enforceSizeThreshold": 30000,
 		      "hidePathInfo": false,
 		      "maxAsyncRequests": Infinity,
@@ -1478,6 +1482,10 @@ describe("Defaults", () => {
 			-         },
 			-       },
 			-       "chunks": "async",
+			-       "defaultSizeTypes": Array [
+			-         "javascript",
+			-         "unknown",
+			-       ],
 			-       "enforceSizeThreshold": 30000,
 			-       "hidePathInfo": false,
 			-       "maxAsyncRequests": Infinity,

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -662,7 +662,7 @@ describe("Validation", () => {
 				expect(msg).toMatchInlineSnapshot(`
 			"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 			 - configuration.optimization.splitChunks has an unknown property 'automaticNamePrefix'. These properties are valid:
-			   object { automaticNameDelimiter?, cacheGroups?, chunks?, enforceSizeThreshold?, fallbackCacheGroup?, filename?, hidePathInfo?, maxAsyncRequests?, maxAsyncSize?, maxInitialRequests?, maxInitialSize?, maxSize?, minChunks?, minRemainingSize?, minSize?, name?, usedExports? }
+			   object { automaticNameDelimiter?, cacheGroups?, chunks?, defaultSizeTypes?, enforceSizeThreshold?, fallbackCacheGroup?, filename?, hidePathInfo?, maxAsyncRequests?, maxAsyncSize?, maxInitialRequests?, maxInitialSize?, maxSize?, minChunks?, minRemainingSize?, minSize?, name?, usedExports? }
 			   -> Options object for splitting chunks into smaller chunks."
 		`)
 		);

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -1693,6 +1693,32 @@ Object {
     "multiple": false,
     "simpleType": "string",
   },
+  "optimization-split-chunks-default-size-types": Object {
+    "configs": Array [
+      Object {
+        "description": "Size type, like 'javascript', 'webassembly'.",
+        "multiple": true,
+        "path": "optimization.splitChunks.defaultSizeTypes[]",
+        "type": "string",
+      },
+    ],
+    "description": "Size type, like 'javascript', 'webassembly'.",
+    "multiple": true,
+    "simpleType": "string",
+  },
+  "optimization-split-chunks-default-size-types-reset": Object {
+    "configs": Array [
+      Object {
+        "description": "Clear all items provided in configuration. Sets the size types which are used when a number is used for sizes.",
+        "multiple": false,
+        "path": "optimization.splitChunks.defaultSizeTypes",
+        "type": "reset",
+      },
+    ],
+    "description": "Clear all items provided in configuration. Sets the size types which are used when a number is used for sizes.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "optimization-split-chunks-enforce-size-threshold": Object {
     "configs": Array [
       Object {

--- a/types.d.ts
+++ b/types.d.ts
@@ -5848,6 +5848,11 @@ declare interface OptimizationSplitChunksOptions {
 	chunks?: "initial" | "async" | "all" | ((chunk: Chunk) => boolean);
 
 	/**
+	 * Sets the size types which are used when a number is used for sizes.
+	 */
+	defaultSizeTypes?: string[];
+
+	/**
 	 * Size threshold at which splitting is enforced and other restrictions (minRemainingSize, maxAsyncRequests, maxInitialRequests) are ignored.
 	 */
 	enforceSizeThreshold?: OptimizationSplitChunksSizes;
@@ -8606,6 +8611,7 @@ declare interface SourcePosition {
 }
 declare interface SplitChunksOptions {
 	chunksFilter: (chunk: Chunk) => boolean;
+	defaultSizeTypes: string[];
 	minSize: Record<string, number>;
 	minRemainingSize: Record<string, number>;
 	enforceSizeThreshold: Record<string, number>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature for plugins
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
