### PR TITLE
chore: bump acorn to 8.0.1

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -24,7 +24,7 @@ const joinRanges = (startRange, endRange) => {
 const defaultParserOptions = {
 	ranges: true,
 	locations: true,
-	ecmaVersion: 11,
+	ecmaVersion: "latest",
 	sourceType: "module",
 	onComment: null
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@webassemblyjs/helper-module-context": "1.9.0",
     "@webassemblyjs/wasm-edit": "1.9.0",
     "@webassemblyjs/wasm-parser": "1.9.0",
-    "acorn": "^6.4.1",
+    "acorn": "^8.0.1",
     "ajv": "^6.10.2",
     "ajv-keywords": "^3.4.1",
     "chrome-trace-event": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -688,10 +688,15 @@ acorn@^5.5.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
   integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
 
-acorn@^6.0.1, acorn@^6.0.7, acorn@^6.4.1:
+acorn@^6.0.1, acorn@^6.0.7:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
+
+acorn@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.0.1.tgz#d7e8eca9b71d5840db0e7e415b3b2b20e250f938"
+  integrity sha512-dmKn4pqZ29iQl2Pvze1zTrps2luvls2PBY//neO2WJ0s10B3AxJXshN+Ph7B4GrhfGhHXrl4dnUwyNNXQcnWGQ==
 
 ajv-errors@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

closes #11186
closes #10227

This PR aims to bump `acorn` so `?.`, `??`, `4_2`, `x ??= y` should not throw syntax error: It is part of ES2021.

This PR does _not_ backport evaluations support in #11221. I think it is good enough for webpack@4. To further optimize expression related to these new syntax features, please upgrade to webpack@5. But the bottom line here is that webpack@4 should not throw for ES2021 syntax, especially when webpack 5 is not released yet.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No. The acorn tests itself should be sufficient.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

Yes. See https://github.com/acornjs/acorn/blob/master/acorn/CHANGELOG.md#700-2019-08-13 Though acorn v7 to v8 is not breaking webpack 4.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Nothing.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
