### PR TITLE
enable --detectOpenHandles for jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "test:update-snapshots": "yarn jest -u",
     "test:integration": "node --max-old-space-size=4096 --trace-deprecation node_modules/jest-cli/bin/jest --testMatch \"<rootDir>/test/*.test.js\"",
     "test:basic": "node --max-old-space-size=4096 --trace-deprecation node_modules/jest-cli/bin/jest --testMatch \"<rootDir>/te{st/TestCasesNormal,st/StatsTestCases,st/ConfigTestCases}.test.js\"",
-    "test:unit": "node --max-old-space-size=4096 --trace-deprecation node_modules/jest-cli/bin/jest --testMatch \"<rootDir>/test/*.unittest.js\"",
+    "test:unit": "node --max-old-space-size=4096 --trace-deprecation node_modules/jest-cli/bin/jest --detectOpenHandles --testMatch \"<rootDir>/test/*.unittest.js\"",
     "travis:integration": "yarn cover:integration --ci $JEST",
     "travis:basic": "yarn cover:basic --ci $JEST",
     "travis:lintunit": "yarn lint && yarn cover:unit --ci $JEST",

--- a/test/ProfilingPlugin.unittest.js
+++ b/test/ProfilingPlugin.unittest.js
@@ -29,7 +29,7 @@ describe("Profiling Plugin", () => {
 			}
 		});
 
-		return profiler.startProfiling();
+		return profiler.startProfiling().then(() => profiler.destroy());
 	});
 
 	it("handles sending a profiling message when no session", () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

We have this warning when running `yarn test:unit`:

> Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
It's annoying, enabling [`--detectOpenHandles`](https://jestjs.io/docs/en/cli#--detectopenhandles) would eliminate it, also it can help jest to catch potential issues in unit tests.

E.g.:

```
Jest has detected the following 1 open handle potentially keeping Jest from exiting:

  ●  INSPECTORJSBINDING

      39 |              try {
      40 |                      this.session = new inspector.Session();
    > 41 |                      this.session.connect();
         |                                   ^
      42 |              } catch (_) {
      43 |                      this.session = undefined;
      44 |                      return Promise.resolve();

      at Profiler.startProfiling (lib/debug/ProfilingPlugin.js:41:17)
      at Object.<anonymous> (test/ProfilingPlugin.unittest.js:32:19)
```

Although it's not really a bug at all, but I still think it's good to enable `--detectOpenHandles`. Anyway, feel free to close it if you don't agree.

**Did you add tests for your changes?**

No need.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
Nothing.