### PR TITLE
Fix compilation of projects where dependsOn is an array

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1576,6 +1576,14 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			callback
 		);
 	}
+	
+	_arraysAreEqual(a, b) {
+		if (a.length !== b.length) return false;
+		for (var i = 0; i < a.length; i++) {
+			if (a[i] !== b[i]) return false;
+		}
+		return true;
+	}
 
 	/**
 	 * @param {string} context context path for entry
@@ -1605,6 +1613,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			for (const key of Object.keys(options)) {
 				if (options[key] === undefined) continue;
 				if (entryData.options[key] === options[key]) continue;
+				if (Array.isArray(entryData.options[key]) && Array.isArray(options[key]) && this._arraysAreEqual(entryData.options[key], options[key])) continue;
 				if (entryData.options[key] === undefined) {
 					entryData.options[key] = options[key];
 				} else {

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -70,6 +70,7 @@ const {
 	createFakeHook
 } = require("./util/deprecation");
 const { getRuntimeKey } = require("./util/runtime");
+const { equals: arrayEquals } = require("./util/ArrayHelpers");
 
 /** @template T @typedef {import("tapable").AsArray<T>} AsArray<T> */
 /** @typedef {import("webpack-sources").Source} Source */
@@ -1577,14 +1578,6 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		);
 	}
 
-	_arraysAreEqual(a, b) {
-		if (a.length !== b.length) return false;
-		for (var i = 0; i < a.length; i++) {
-			if (a[i] !== b[i]) return false;
-		}
-		return true;
-	}
-
 	/**
 	 * @param {string} context context path for entry
 	 * @param {Dependency} entry entry dependency that should be followed
@@ -1616,7 +1609,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 				if (
 					Array.isArray(entryData.options[key]) &&
 					Array.isArray(options[key]) &&
-					this._arraysAreEqual(entryData.options[key], options[key])
+					arrayEquals(entryData.options[key], options[key])
 				) {
 					continue;
 				}

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1576,7 +1576,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			callback
 		);
 	}
-	
+
 	_arraysAreEqual(a, b) {
 		if (a.length !== b.length) return false;
 		for (var i = 0; i < a.length; i++) {
@@ -1613,7 +1613,13 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			for (const key of Object.keys(options)) {
 				if (options[key] === undefined) continue;
 				if (entryData.options[key] === options[key]) continue;
-				if (Array.isArray(entryData.options[key]) && Array.isArray(options[key]) && this._arraysAreEqual(entryData.options[key], options[key])) continue;
+				if (
+					Array.isArray(entryData.options[key]) &&
+					Array.isArray(options[key]) &&
+					this._arraysAreEqual(entryData.options[key], options[key])
+				) {
+					continue;
+				}
 				if (entryData.options[key] === undefined) {
 					entryData.options[key] = options[key];
 				} else {

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -52,6 +52,7 @@ const BuildCycleError = require("./errors/BuildCycleError");
 const { Logger, LogType } = require("./logging/Logger");
 const StatsFactory = require("./stats/StatsFactory");
 const StatsPrinter = require("./stats/StatsPrinter");
+const { equals: arrayEquals } = require("./util/ArrayHelpers");
 const AsyncQueue = require("./util/AsyncQueue");
 const LazySet = require("./util/LazySet");
 const { cachedCleverMerge } = require("./util/cleverMerge");
@@ -70,7 +71,6 @@ const {
 	createFakeHook
 } = require("./util/deprecation");
 const { getRuntimeKey } = require("./util/runtime");
-const { equals: arrayEquals } = require("./util/ArrayHelpers");
 
 /** @template T @typedef {import("tapable").AsArray<T>} AsArray<T> */
 /** @typedef {import("webpack-sources").Source} Source */


### PR DESCRIPTION
An entrypoint can be defined with `dependOn` specified as an array [see docs](https://webpack.js.org/configuration/entry-context/#entry), for example:

```javascript
 splitmodule1: {
                import: scanSourceFiles('./src/splitmodule1'),
                dependOn: [ 'pluginregistry'] // Note that we could specify multiple dependencies here, e.g. dependOn: ['core', 'pluginregistry']
 }
```
Using the Webpack Watcher results in the following error:

```
× ｢wdm｣: Error: Conflicting entry option dependOn = pluginregistry vs pluginregistry
    at Compilation._addEntryItem (C:\Users\c.brueggemann\Documents\Projects\codesplit\node_modules\webpack\lib\Compilation.js:1616:7)
    at Compilation.addEntry (C:\Users\c.brueggemann\Documents\Projects\codesplit\node_modules\webpack\lib\Compilation.js:1560:8)
    at C:\Users\c.brueggemann\Documents\Projects\codesplit\node_modules\webpack\lib\DynamicEntryPlugin.js:59:23
    at new Promise (<anonymous>)
    at C:\Users\c.brueggemann\Documents\Projects\codesplit\node_modules\webpack\lib\DynamicEntryPlugin.js:58:10
```

This PR fixes the crash by comparing the arrays deeply instead of using incorrectly comparing them using `===`. I'm not too familiar with Webpack, so I'll be happy to adjust according to feedback.

**What kind of change does this PR introduce?**
Bugfix.

**Did you add tests for your changes?**
I'm not really sure where to start, plus it's a relatively trivial change. If adding a test for this is required, I'd appreciate a pointer where it should be added.

**Does this PR introduce a breaking change?**
No.

**What needs to be documented once your changes are merged?**
Nothing.
