### PR TITLE
Improve suggested Node.js polyfill config

### DIFF
--- a/lib/ModuleNotFoundError.js
+++ b/lib/ModuleNotFoundError.js
@@ -11,18 +11,18 @@ const WebpackError = require("./WebpackError");
 /** @typedef {import("./Module")} Module */
 
 const previouslyPolyfilledBuiltinModules = {
-	assert: "assert",
-	buffer: "buffer",
+	assert: "assert/",
+	buffer: "buffer/",
 	console: "console-browserify",
 	constants: "constants-browserify",
 	crypto: "crypto-browserify",
 	domain: "domain-browser",
-	events: "events",
+	events: "events/",
 	http: "stream-http",
 	https: "https-browserify",
 	os: "os-browserify/browser",
 	path: "path-browserify",
-	punycode: "punycode",
+	punycode: "punycode/",
 	process: "process/browser",
 	querystring: "querystring-es3",
 	stream: "stream-browserify",
@@ -31,12 +31,12 @@ const previouslyPolyfilledBuiltinModules = {
 	_stream_readable: "readable-stream/readable",
 	_stream_transform: "readable-stream/transform",
 	_stream_writable: "readable-stream/writable",
-	string_decoder: "string_decoder",
-	sys: "util",
+	string_decoder: "string_decoder/",
+	sys: "util/",
 	timers: "timers-browserify",
 	tty: "tty-browserify",
-	url: "url",
-	util: "util",
+	url: "url/",
+	util: "util/",
 	vm: "vm-browserify",
 	zlib: "browserify-zlib"
 };
@@ -63,14 +63,10 @@ class ModuleNotFoundError extends WebpackError {
 					"BREAKING CHANGE: " +
 					"webpack < 5 used to include polyfills for node.js core modules by default.\n" +
 					"This is no longer the case. Verify if you need this module and configure a polyfill for it.\n\n";
-				if (request !== alias) {
-					message +=
-						"If you want to include a polyfill, you need to:\n" +
-						`\t- add an fallback 'resolve.fallback: { "${request}": "${alias}" }'\n` +
-						`\t- install '${dependency}'\n`;
-				} else {
-					message += `If you want to include a polyfill, you need to install '${dependency}'.\n`;
-				}
+				message +=
+					"If you want to include a polyfill, you need to:\n" +
+					`\t- add a fallback 'resolve.fallback: { "${request}": require.resolve("${alias}") }'\n` +
+					`\t- install '${dependency}'\n`;
 				message +=
 					"If you don't want to include a polyfill, you can use an empty module like this:\n" +
 					`\tresolve.fallback: { "${request}": false }`;

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1259,7 +1259,9 @@ Module not found: Error: Can't resolve 'buffer' in 'Xdir/module-not-found-error'
 BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
 This is no longer the case. Verify if you need this module and configure a polyfill for it.
 
-If you want to include a polyfill, you need to install 'buffer'.
+If you want to include a polyfill, you need to:
+	- add a fallback 'resolve.fallback: { \\"buffer\\": require.resolve(\\"buffer/\\") }'
+	- install 'buffer'
 If you don't want to include a polyfill, you can use an empty module like this:
 	resolve.fallback: { \\"buffer\\": false }
 
@@ -1270,7 +1272,7 @@ BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules 
 This is no longer the case. Verify if you need this module and configure a polyfill for it.
 
 If you want to include a polyfill, you need to:
-	- add an fallback 'resolve.fallback: { \\"os\\": \\"os-browserify/browser\\" }'
+	- add a fallback 'resolve.fallback: { \\"os\\": require.resolve(\\"os-browserify/browser\\") }'
 	- install 'os-browserify'
 If you don't want to include a polyfill, you can use an empty module like this:
 	resolve.fallback: { \\"os\\": false }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Give instructions suitable for more environments in the ModuleNotFoundError for Node.js polyfills.  Before this change, requiring a builtin module like `buffer` from a package symlinked from somewhere would give the following suggestion:

```
If you want to include a polyfill, you need to install 'buffer'.
```

However, installing `buffer` is not enough to resolve the issue as the package would not be reachable from place it was symlinked from and the same error would still be shown.  This PR changes the error message to be:

```
If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "buffer": require.resolve("buffer/") }'
        - install 'buffer'
```

By setting the fallback to an absolute path the replacement is found from symlinked packages.

Resolves #11600.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Rewording of error message.

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
Changes are covered by existing tests.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No breaking changes.

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

Nothing I am aware of.