### PR TITLE
Fix ModuleTemplate.hooks.hash deprecation message

### DIFF
--- a/lib/ModuleTemplate.js
+++ b/lib/ModuleTemplate.js
@@ -126,7 +126,7 @@ class ModuleTemplate {
 					(options, fn) => {
 						compilation.hooks.fullHash.tap(options, fn);
 					},
-					"ModuleTemplate.hooks.package is deprecated (use Compilation.hooks.fullHash instead)",
+					"ModuleTemplate.hooks.hash is deprecated (use Compilation.hooks.fullHash instead)",
 					"DEP_MODULE_TEMPLATE_HASH"
 				)
 			}


### PR DESCRIPTION
Current deprecation message for ModuleTemplate.hooks.hash is saying about ModuleTemplate.hooks.package. This PR fixes the message.

**What kind of change does this PR introduce?**
bug fix

**Did you add tests for your changes?**
No (Seems there are no tests related to deprecation messages)

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
I guess it doesn't need any documentation changes.
