### PR TITLE
expose webpack from Compiler

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -14,6 +14,7 @@ const {
 	AsyncSeriesHook
 } = require("tapable");
 const { SizeOnlySource } = require("webpack-sources");
+const webpack = require("./");
 const Cache = require("./Cache");
 const CacheFacade = require("./CacheFacade");
 const Compilation = require("./Compilation");
@@ -169,6 +170,8 @@ class Compiler {
 			/** @type {SyncBailHook<[string, Entry], boolean>} */
 			entryOption: new SyncBailHook(["context", "entry"])
 		});
+
+		this.webpack = webpack;
 
 		/** @type {string=} */
 		this.name = undefined;

--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -104,8 +104,8 @@ class Dependency {
 	}
 
 	/**
-	 * @deprecated
 	 * Returns the referenced module and export
+	 * @deprecated
 	 * @param {ModuleGraph} moduleGraph module graph
 	 * @returns {never} throws error
 	 */

--- a/lib/index.js
+++ b/lib/index.js
@@ -480,6 +480,9 @@ module.exports = mergeExports(fn, {
 		},
 		get serialization() {
 			return require("./util/serialization");
+		},
+		get cleverMerge() {
+			return require("./util/cleverMerge").cachedCleverMerge;
 		}
 	},
 

--- a/lib/stats/StatsPrinter.js
+++ b/lib/stats/StatsPrinter.js
@@ -46,9 +46,9 @@ class StatsPrinter {
 	}
 
 	/**
+	 * get all level hooks
 	 * @private
 	 * @template {Hook} T
-	 * get all level hooks
 	 * @param {HookMap<T>} hookMap HookMap
 	 * @param {string} type type
 	 * @returns {T[]} hooks
@@ -79,10 +79,10 @@ class StatsPrinter {
 	}
 
 	/**
+	 * Run `fn` for each level
 	 * @private
 	 * @template T
 	 * @template R
-	 * Run `fn` for each level
 	 * @param {HookMap<SyncBailHook<T, R>>} hookMap HookMap
 	 * @param {string} type type
 	 * @param {(hook: SyncBailHook<T, R>) => R} fn function

--- a/lib/util/Hash.js
+++ b/lib/util/Hash.js
@@ -8,8 +8,8 @@
 class Hash {
 	/* istanbul ignore next */
 	/**
-	 * @abstract
 	 * Update hash {@link https://nodejs.org/api/crypto.html#crypto_hash_update_data_inputencoding}
+	 * @abstract
 	 * @param {string|Buffer} data data
 	 * @param {string=} inputEncoding data encoding
 	 * @returns {this} updated hash
@@ -21,8 +21,8 @@ class Hash {
 
 	/* istanbul ignore next */
 	/**
-	 * @abstract
 	 * Calculates the digest {@link https://nodejs.org/api/crypto.html#crypto_hash_digest_encoding}
+	 * @abstract
 	 * @param {string=} encoding encoding of the return value
 	 * @returns {string|Buffer} digest
 	 */

--- a/lib/util/LazyBucketSortedSet.js
+++ b/lib/util/LazyBucketSortedSet.js
@@ -8,16 +8,16 @@
 const SortableSet = require("./SortableSet");
 
 /**
+ * Multi layer bucket sorted set:
+ * Supports adding non-existing items (DO NOT ADD ITEM TWICE),
+ * Supports removing exiting items (DO NOT REMOVE ITEM NOT IN SET),
+ * Supports popping the first items according to defined order,
+ * Supports iterating all items without order,
+ * Supports updating an item in an efficient way,
+ * Supports size property, which is the number of items,
+ * Items are lazy partially sorted when needed
  * @template T
  * @template K
- * Multi layer bucket sorted set
- * Supports adding non-existing items (DO NOT ADD ITEM TWICE)
- * Supports removing exiting items (DO NOT REMOVE ITEM NOT IN SET)
- * Supports popping the first items according to defined order
- * Supports iterating all items without order
- * Supports updating an item in an efficient way
- * Supports size property, which is the number of items
- * Items are lazy partially sorted when needed
  */
 class LazyBucketSortedSet {
 	/**

--- a/lib/util/cleverMerge.js
+++ b/lib/util/cleverMerge.js
@@ -12,9 +12,9 @@ const setPropertyCache = new WeakMap();
 const DELETE = Symbol("DELETE");
 
 /**
+ * Merges two given objects and caches the result to avoid computation if same objects passed as arguments again.
  * @template T
  * @template O
- * Merges two given objects and caches the result to avoid computation if same objects passed as arguments again.
  * @example
  * // performs cleverMerge(first, second), stores the result in WeakMap and returns result
  * cachedCleverMerge({a: 1}, {a: 2})

--- a/types.d.ts
+++ b/types.d.ts
@@ -1618,6 +1618,7 @@ declare class Compiler {
 		afterResolvers: SyncHook<[Compiler], void>;
 		entryOption: SyncBailHook<[string, EntryNormalized], boolean>;
 	}>;
+	webpack: typeof exports;
 	name: string;
 	parentCompilation: Compilation;
 	root: Compiler;
@@ -2222,6 +2223,10 @@ declare class Dependency {
 	readonly type: string;
 	readonly category: string;
 	getResourceIdentifier(): string;
+
+	/**
+	 * Returns the referenced module and export
+	 */
 	getReference(moduleGraph: ModuleGraph): never;
 
 	/**
@@ -3566,7 +3571,15 @@ declare interface HandleModuleCreationOptions {
 }
 declare class Hash {
 	constructor();
+
+	/**
+	 * Update hash {@link https://nodejs.org/api/crypto.html#crypto_hash_update_data_inputencoding}
+	 */
 	update(data: string | Buffer, inputEncoding?: string): Hash;
+
+	/**
+	 * Calculates the digest {@link https://nodejs.org/api/crypto.html#crypto_hash_digest_encoding}
+	 */
 	digest(encoding?: string): string | Buffer;
 }
 type HashFunction = string | typeof Hash;
@@ -10254,6 +10267,7 @@ declare namespace exports {
 			export let createFileSerializer: (fs?: any) => Serializer;
 			export { MEASURE_START_OPERATION, MEASURE_END_OPERATION };
 		}
+		export const cleverMerge: <T, O>(first: T, second: O) => T & O;
 	}
 	export namespace sources {
 		export {


### PR DESCRIPTION
fix some jsdoc descriptions

fixes #11651

exposes webpack for https://github.com/webpack-contrib/mini-css-extract-plugin/issues/600
exposes cleverMerge for #11635

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
expose, types
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
nothing
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Plugins can access webpack from the `webpack` property of the Compiler. This allows to remove the webpack peerDependency from the plugin.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
