### PR TITLE
fix: add Plugin to built-in d.ts from @types/webpack

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ const memorize = require("./util/memorize");
 /** @typedef {import("../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptionsNormalized */
 /** @typedef {import("../declarations/WebpackOptions").WebpackPluginFunction} WebpackPluginFunction */
 /** @typedef {import("../declarations/WebpackOptions").WebpackPluginInstance} WebpackPluginInstance */
+/** @typedef {import("../declarations/WebpackOptions").WebpackPluginInstance} Plugin */
 /** @typedef {import("./Parser").ParserState} ParserState */
 
 /**

--- a/types.d.ts
+++ b/types.d.ts
@@ -10389,7 +10389,8 @@ declare namespace exports {
 		RuleSetUseItem,
 		Configuration,
 		WebpackOptionsNormalized,
-		WebpackPluginInstance
+		WebpackPluginInstance,
+		WebpackPluginInstance as Plugin
 	};
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

ref: https://github.com/webpack/webpack/issues/11630

Many typings of packages use `Plugin` now. If they have to change it to use `WebpackPluginInstance` they treat it as a breaking change. This is a large impact on packages even if webpack@5 is a major update version and a breaking change (ex: https://github.com/getsentry/sentry-webpack-plugin/pull/233 ) . Could you avoid this situation?

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
no

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
