### PR TITLE
Make external modules of type 'this' work with module concatenation

### DIFF
--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -36,7 +36,6 @@ const propertyAccess = require("./util/propertyAccess");
 
 /**
  * @typedef {Object} SourceData
- * @property {boolean=} iife
  * @property {string=} init
  * @property {string} expression
  */
@@ -54,10 +53,12 @@ const getSourceForGlobalVariableExternal = (variableName, type) => {
 
 	// needed for e.g. window["some"]["thing"]
 	const objectLookup = variableName.map(r => `[${JSON.stringify(r)}]`).join("");
-	return {
-		iife: type === "this",
-		expression: `${type}${objectLookup}`
-	};
+	let expression = `${type}${objectLookup}`;
+	if (type === "this") {
+		expression = `(function() { return ${expression}; })()`;
+	}
+
+	return { expression };
 };
 
 /**
@@ -293,7 +294,7 @@ class ExternalModule extends Module {
 			exportsType: undefined
 		};
 		this.buildInfo = {
-			strict: true
+			strict: this.externalType !== "this"
 		};
 		this.buildMeta.exportsType = "dynamic";
 		let canMangle = false;
@@ -423,7 +424,6 @@ class ExternalModule extends Module {
 		} else {
 			sourceString = `module.exports = ${sourceData.expression};`;
 		}
-		if (sourceData.iife) sourceString = `(function() { ${sourceString} })();`;
 		if (sourceData.init) sourceString = `${sourceData.init}\n${sourceString}`;
 
 		const sources = new Map();

--- a/test/configCases/externals/this/index.js
+++ b/test/configCases/externals/this/index.js
@@ -1,0 +1,11 @@
+afterEach(done => {
+	(function() { delete this.EXTERNAL_TEST_GLOBAL; })();
+	done();
+});
+
+it("should import an external value assigned to global this", function() {
+	(function() { this.EXTERNAL_TEST_GLOBAL = 42; })();
+	// eslint-disable-next-line node/no-missing-require
+	const result = require("external");
+	expect(result).toBe(42);
+});

--- a/test/configCases/externals/this/webpack.config.js
+++ b/test/configCases/externals/this/webpack.config.js
@@ -1,0 +1,9 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	optimization: {
+		concatenateModules: true
+	},
+	externals: {
+		external: "this EXTERNAL_TEST_GLOBAL"
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -8644,7 +8644,6 @@ declare class Source {
 	buffer(): Buffer;
 }
 declare interface SourceData {
-	iife?: boolean;
 	init?: string;
 	expression: string;
 }


### PR DESCRIPTION
Fixes #11724.

Changes how the object lookup is wrapped in an IIFE to avoid hiding the left side of the assignment inside a function.

When concatenating modules, the module exports are assigned to a local variable, not to `module.exports`. Therefore, the generated code of the module is:
```js
(function() { const lodash_namespace = this['lodash']; })();
```
But because the local variable is scoped inside the function, it's not visible outside it and can't be used by other modules.

If the assignment is to `module.export`, wrapping inside a function doesn't do any harm, that's why it always worked before external modules concatenation started to be supported.

After this patch, the IIFE wraps only the object lookup:
```js
const lodash_namespace = (function() { return this['lodash']; })();
```

The second change is that the external module of type `this` is forced to be in non-strict mode .That's the only mode where the `this` lookup has any meaningful behavior, accessing the global object. In strict mode the default `this` is `undefined` and the external lookup never works.
