### PR TITLE
:children_crossing: resolve #11695

### DIFF
--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -675,6 +675,53 @@ class NormalModuleFactory extends ModuleFactory {
 		});
 	}
 
+	/*
+	 * Check if at least one (non-empty) of resolve.extensions is missing a leading dot
+	 * And if so - notify user if it would cause the resolver to find the module
+	 */
+	tryResolvingWithLeadingExtensionDot(
+		contextInfo,
+		context,
+		unresolvedResource,
+		resolver,
+		resolveContext,
+		callback,
+		err
+	) {
+		const addLeadingDot = arr =>
+			arr.map(ext => (ext.match(/^[^.]/) ? `.${ext}` : ext));
+		const extArr = Array.from(resolver.options.extensions);
+
+		if (!extArr.find(ext => ext.match(/^[^.]/))) {
+			callback(err);
+			return;
+		}
+
+		resolver
+			.withOptions({
+				extensions: addLeadingDot(extArr)
+			})
+			.resolve(
+				contextInfo,
+				context,
+				unresolvedResource,
+				resolveContext,
+				(err2, resolvedResource) => {
+					if (!err2 && resolvedResource) {
+						err.message += `
+
+Did you miss the leading dot in resolve.extensions?
+Your config value is ${JSON.stringify(extArr)}. Did you mean ${JSON.stringify(
+							addLeadingDot(extArr)
+						)}?
+
+`;
+					}
+					callback(err);
+				}
+			);
+	}
+
 	resolveResource(
 		contextInfo,
 		context,
@@ -711,10 +758,32 @@ BREAKING CHANGE: The request '${unresolvedResource}' failed to resolve only beca
 (probably because the origin is a '*.mjs' file or a '*.js' file where the package.json contains '"type": "module"').
 The extension in the request is mandatory for it to be fully specified.
 Add the extension to the request.`;
+										callback(err);
+									} else {
+										this.tryResolvingWithLeadingExtensionDot(
+											contextInfo,
+											context,
+											unresolvedResource,
+											resolver,
+											resolveContext,
+											callback,
+											err
+										);
 									}
-									callback(err);
 								}
 							);
+
+						return;
+					} else {
+						this.tryResolvingWithLeadingExtensionDot(
+							contextInfo,
+							context,
+							unresolvedResource,
+							resolver,
+							resolveContext,
+							callback,
+							err
+						);
 						return;
 					}
 				}

--- a/test/configCases/resolve/extensions-missing-leading-dot/errors.js
+++ b/test/configCases/resolve/extensions-missing-leading-dot/errors.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[/Can't resolve '.\/dependency'/, /Did you miss the leading dot in resolve.extensions?/]
+];

--- a/test/configCases/resolve/extensions-missing-leading-dot/index.js
+++ b/test/configCases/resolve/extensions-missing-leading-dot/index.js
@@ -1,0 +1,3 @@
+it("Should warn if resolving fails and adding a leading dot to resolve.extensions would have fix that", () => {
+		require('./dependency');
+});

--- a/test/configCases/resolve/extensions-missing-leading-dot/webpack.config.js
+++ b/test/configCases/resolve/extensions-missing-leading-dot/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	resolve: {
+		extensions: ["js"]
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -5638,6 +5638,15 @@ declare abstract class NormalModuleFactory extends ModuleFactory {
 	fs: InputFileSystem;
 	parserCache: Map<string, WeakMap<any, any>>;
 	generatorCache: Map<string, WeakMap<any, Generator>>;
+	tryResolvingWithLeadingExtensionDot(
+		contextInfo?: any,
+		context?: any,
+		unresolvedResource?: any,
+		resolver?: any,
+		resolveContext?: any,
+		callback?: any,
+		err?: any
+	): void;
 	resolveResource(
 		contextInfo?: any,
 		context?: any,


### PR DESCRIPTION
Add a warning while user configured resolve.extensions without a leading dot (e.g. ["js", "jsx"]), and a module resolution fails because of that

Fixing CI build errors from PR #11734

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Developer Experience

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
