### PR TITLE
caniuse es6 doesn't report arrow-functions correctly

### DIFF
--- a/lib/config/browserslistTargetHandler.js
+++ b/lib/config/browserslistTargetHandler.js
@@ -119,11 +119,13 @@ const resolve = browsers => {
 	const browserProperty = !anyBrowser ? false : anyNode ? null : true;
 	const nodeProperty = !anyNode ? false : anyBrowser ? null : true;
 	const es6 = browserslistChecker("es6");
+	const letConst = browserslistChecker("let");
+	const arrowFunctions = browserslistChecker("arrow-functions");
 	const es6DynamicImport = browserslistChecker("es6-module-dynamic-import");
 	const node6 = nodeChecker(6);
 	return {
-		const: es6 && node6,
-		arrowFunction: es6 && node6,
+		const: letConst && node6,
+		arrowFunction: arrowFunctions && node6,
 		forOf: es6 && nodeChecker(5),
 		destructuring: es6 && node6,
 		bigIntLiteral: browserslistChecker("bigint") && nodeChecker(10, 4),


### PR DESCRIPTION
ie11 is an exception

fixes #11753

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
