### PR TITLE
Run compiler in nextTick when callback provided

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -122,6 +122,9 @@ const webpack = /** @type {WebpackFunctionSingle & WebpackFunctionMulti} */ ((
 		try {
 			const { compiler, watch, watchOptions } = create();
 			process.nextTick(() => {
+				if (compiler.running) {
+					return;
+				}
 				if (watch) {
 					compiler.watch(watchOptions, callback);
 				} else {

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -121,15 +121,17 @@ const webpack = /** @type {WebpackFunctionSingle & WebpackFunctionMulti} */ ((
 	if (callback) {
 		try {
 			const { compiler, watch, watchOptions } = create();
-			if (watch) {
-				compiler.watch(watchOptions, callback);
-			} else {
-				compiler.run((err, stats) => {
-					compiler.close(err2 => {
-						callback(err || err2, stats);
+			process.nextTick(() => {
+				if (watch) {
+					compiler.watch(watchOptions, callback);
+				} else {
+					compiler.run((err, stats) => {
+						compiler.close(err2 => {
+							callback(err || err2, stats);
+						});
 					});
-				});
-			}
+				}
+			});
 			return compiler;
 		} catch (err) {
 			process.nextTick(() => callback(err));

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -377,9 +377,7 @@ describe("Compiler", () => {
 			}
 		});
 		compiler.outputFileSystem = createFsFromVolume(new Volume());
-		compiler.run((err, stats) => {
-			if (err) return done(err);
-		});
+		compiler.run((err, stats) => {});
 		compiler.run((err, stats) => {
 			if (err) return done();
 		});
@@ -395,9 +393,7 @@ describe("Compiler", () => {
 			}
 		});
 		compiler.outputFileSystem = createFsFromVolume(new Volume());
-		compiler.watch({}, (err, stats) => {
-			if (err) return done(err);
-		});
+		compiler.watch({}, (err, stats) => {});
 		compiler.watch({}, (err, stats) => {
 			if (err) return done();
 		});
@@ -452,6 +448,7 @@ describe("Compiler", () => {
 			() => {}
 		);
 		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.run((err, stats) => {});
 		compiler.run((err, stats) => {
 			if (err) return done();
 		});

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -107,6 +107,7 @@ describe("MultiCompiler", function () {
 			() => {}
 		);
 		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		compiler.run((err, stats) => {});
 		compiler.run((err, stats) => {
 			if (err) return done();
 		});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
With this change it would be possible to register event on compiler when callback is provided. 

For example with current implementation, this will not log for first run as webpack already started

```js
let compiler = webpack(options, callback);

compiler.hooks.watchRun.tap('Foo', (compilation) => {
  logger.success(`Compilation starting...`);
});
```   

Would suggest to wrap with `process.nextTick`. Having this would be possible to refactor webpack-cli `watch` logic and fix the DeprecationWarning on callback https://github.com/webpack/webpack-cli/issues/1918

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
There is any