### PR TITLE
add asset info for `sourceFilename` and `javascriptModule`

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -179,9 +179,11 @@ const { getRuntimeKey } = require("./util/runtime");
  * @property {string | string[]=} chunkhash the value(s) of the chunk hash used for this asset
  * @property {string | string[]=} modulehash the value(s) of the module hash used for this asset
  * @property {string | string[]=} contenthash the value(s) of the content hash used for this asset
+ * @property {string=} sourceFilename when asset was created from a source file (potentially transformed), the original filename relative to compilation context
  * @property {number=} size size in bytes, only set after asset has been emitted
  * @property {boolean=} development true, when asset is only used for development and doesn't count towards user-facing assets
  * @property {boolean=} hotModuleReplacement true, when asset ships data for updating an existing application (HMR)
+ * @property {boolean=} javascriptModule true, when asset is javascript and an ESM
  * @property {Record<string, string | string[]>=} related object of pointers to other assets, keyed by type of relation (only points from parent to child)
  */
 
@@ -3148,7 +3150,12 @@ This prevents using hashes of each other and should be avoided.`
 										fileManifest.pathOptions
 									);
 									file = pathAndInfo.path;
-									assetInfo = pathAndInfo.info;
+									assetInfo = fileManifest.info
+										? {
+												...pathAndInfo.info,
+												...fileManifest.info
+										  }
+										: pathAndInfo.info;
 								}
 
 								if (err) {

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -63,6 +63,10 @@ class RuntimeTemplate {
 		return this.outputOptions.iife;
 	}
 
+	isModule() {
+		return this.outputOptions.module;
+	}
+
 	supportsConst() {
 		return this.outputOptions.environment.const;
 	}

--- a/lib/Template.js
+++ b/lib/Template.js
@@ -59,6 +59,7 @@ const MATCH_PADDED_HYPHENS_REPLACE_REGEX = /^-|-$/g;
  * @property {function(): Source} render
  * @property {string | function(PathData, AssetInfo=): string} filenameTemplate
  * @property {PathData=} pathOptions
+ * @property {AssetInfo=} info
  * @property {string} identifier
  * @property {string=} hash
  * @property {boolean=} auxiliary

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -126,22 +126,26 @@ class AssetGenerator extends Generator {
 						runtimeTemplate.outputOptions.hashDigestLength
 					);
 					module.buildInfo.fullContentHash = fullHash;
+					const sourceFilename = makePathsRelative(
+						this.compilation.compiler.context,
+						module.matchResource || module.resource,
+						this.compilation.compiler.root
+					).replace(/^\.\//, "");
 					const {
 						path: filename,
 						info
 					} = this.compilation.getAssetPathWithInfo(assetModuleFilename, {
 						module,
 						runtime,
-						filename: makePathsRelative(
-							this.compilation.compiler.context,
-							module.matchResource || module.resource,
-							this.compilation.compiler.root
-						).replace(/^\.\//, ""),
+						filename: sourceFilename,
 						chunkGraph,
 						contentHash
 					});
 					module.buildInfo.filename = filename;
-					module.buildInfo.assetInfo = info;
+					module.buildInfo.assetInfo = {
+						sourceFilename,
+						...info
+					};
 
 					runtimeRequirements.add(RuntimeGlobals.publicPath); // add __webpack_require__.p
 

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -272,6 +272,9 @@ class JavascriptModulesPlugin {
 								chunk,
 								contentHashType: "javascript"
 							},
+							info: {
+								javascriptModule: compilation.runtimeTemplate.isModule()
+							},
 							identifier: hotUpdateChunk
 								? `hotupdatechunk${chunk.id}`
 								: `chunk${chunk.id}`,

--- a/lib/stats/DefaultStatsPrinterPlugin.js
+++ b/lib/stats/DefaultStatsPrinterPlugin.js
@@ -234,6 +234,16 @@ const SIMPLE_PRINTERS = {
 
 	"asset.info.immutable": (immutable, { green, formatFlag }) =>
 		immutable ? green(formatFlag("immutable")) : undefined,
+	"asset.info.javascriptModule": (javascriptModule, { formatFlag }) =>
+		javascriptModule ? formatFlag("javascript module") : undefined,
+	"asset.info.sourceFilename": (sourceFilename, { formatFlag }) =>
+		sourceFilename
+			? formatFlag(
+					sourceFilename === true
+						? "from source file"
+						: `from: ${sourceFilename}`
+			  )
+			: undefined,
 	"asset.info.development": (development, { green, formatFlag }) =>
 		development ? green(formatFlag("dev")) : undefined,
 	"asset.info.hotModuleReplacement": (
@@ -644,7 +654,13 @@ const PREFERRED_ORDERS = {
 		"children",
 		"filteredChildren"
 	],
-	"asset.info": ["immutable", "development", "hotModuleReplacement"],
+	"asset.info": [
+		"immutable",
+		"sourceFilename",
+		"javascriptModule",
+		"development",
+		"hotModuleReplacement"
+	],
 	chunkGroup: [
 		"kind!",
 		"name",

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -219,6 +219,7 @@ describe("Stats", () => {
 			      "emitted": true,
 			      "filteredRelated": undefined,
 			      "info": Object {
+			        "javascriptModule": false,
 			        "minimized": true,
 			        "size": 2706,
 			      },
@@ -238,6 +239,7 @@ describe("Stats", () => {
 			      "emitted": true,
 			      "filteredRelated": undefined,
 			      "info": Object {
+			        "javascriptModule": false,
 			        "minimized": true,
 			        "size": 182,
 			      },
@@ -257,6 +259,7 @@ describe("Stats", () => {
 			      "emitted": true,
 			      "filteredRelated": undefined,
 			      "info": Object {
+			        "javascriptModule": false,
 			        "minimized": true,
 			        "size": 107,
 			      },

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -124,9 +124,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for asset 1`] = `
-"asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] (auxiliary name: main)
+"asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: images/file.png] (auxiliary name: main)
 asset bundle.js 12.2 KiB [emitted] (name: main)
-asset static/file.html 12 bytes [emitted] (auxiliary name: main)
+asset static/file.html 12 bytes [emitted] [from: static/file.html] (auxiliary name: main)
 runtime modules 1.06 KiB 2 modules
 asset modules 8.9 KiB (javascript) 14.6 KiB (asset)
   ./images/file.png 42 bytes (javascript) 14.6 KiB (asset) [built] [code generated]
@@ -1496,6 +1496,17 @@ chunk {753} (runtime: main) ac in ab.js (ac in ab) 1 bytes <{90}> >{284}< [rende
 webpack x.x.x compiled successfully in X ms"
 `;
 
+exports[`StatsTestCases should print correct stats for output-module 1`] = `
+"asset main.js 9.88 KiB [emitted] [javascript module] (name: main)
+asset 52.js 415 bytes [emitted] [javascript module]
+runtime modules 5.94 KiB 8 modules
+orphan modules 38 bytes [orphan] 1 module
+cacheable modules 263 bytes
+  ./index.js + 1 modules 225 bytes [built] [code generated]
+  ./chunk.js 38 bytes [built] [code generated]
+webpack x.x.x compiled successfully in X ms"
+`;
+
 exports[`StatsTestCases should print correct stats for parse-error 1`] = `
 "assets by status 1.53 KiB [cached] 1 asset
 orphan modules 15 bytes [orphan] 1 module
@@ -2220,8 +2231,8 @@ exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
     asset 92a0a394f8459d57eed5-92a0a3.js 2.6 KiB [emitted] [immutable] [minimized] (name: runtime~main)
     asset 3cc8faad16137711c07e-3cc8fa.js 210 bytes [emitted] [immutable] [minimized] (name: main)
     asset b6f77787a670e97d47b5-b6f777.js 193 bytes [emitted] [immutable] [minimized] (name: lazy)
-  asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] (auxiliary name: lazy)
-  asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] (auxiliary name: main)
+  asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
+  asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: main)
   Entrypoint main 2.8 KiB (5.89 KiB) = 92a0a394f8459d57eed5-92a0a3.js 2.6 KiB 3cc8faad16137711c07e-3cc8fa.js 210 bytes 1 auxiliary asset
   runtime modules 7.36 KiB 8 modules
   orphan modules 23 bytes [orphan] 1 module
@@ -2239,8 +2250,8 @@ b-normal:
     asset a2c7bddec46d4afc817c-a2c7bd.js 2.6 KiB [emitted] [immutable] [minimized] (name: runtime~main)
     asset 3cc8faad16137711c07e-3cc8fa.js 210 bytes [emitted] [immutable] [minimized] (name: main)
     asset b6f77787a670e97d47b5-b6f777.js 193 bytes [emitted] [immutable] [minimized] (name: lazy)
-  asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] (auxiliary name: lazy)
-  asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] (auxiliary name: main)
+  asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
+  asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: main)
   Entrypoint main 2.8 KiB (5.89 KiB) = a2c7bddec46d4afc817c-a2c7bd.js 2.6 KiB 3cc8faad16137711c07e-3cc8fa.js 210 bytes 1 auxiliary asset
   runtime modules 7.36 KiB 8 modules
   orphan modules 19 bytes [orphan] 1 module
@@ -2261,8 +2272,8 @@ a-source-map:
       sourceMap b8bfcec62cdd15c9a840-b8bfce.js.map 366 bytes [emitted] [dev] (auxiliary name: main)
     asset c7c0f8bb2e61b59a89f5-c7c0f8.js 249 bytes [emitted] [immutable] [minimized] (name: lazy)
       sourceMap c7c0f8bb2e61b59a89f5-c7c0f8.js.map 331 bytes [emitted] [dev] (auxiliary name: lazy)
-  asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] (auxiliary name: lazy)
-  asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] (auxiliary name: main)
+  asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
+  asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: main)
   Entrypoint main 2.91 KiB (20.5 KiB) = 6d482476dfc44d9f4352-6d4824.js 2.65 KiB b8bfcec62cdd15c9a840-b8bfce.js 266 bytes 3 auxiliary assets
   runtime modules 7.36 KiB 8 modules
   orphan modules 23 bytes [orphan] 1 module
@@ -2283,8 +2294,8 @@ b-source-map:
       sourceMap b8bfcec62cdd15c9a840-b8bfce.js.map 323 bytes [emitted] [dev] (auxiliary name: main)
     asset c7c0f8bb2e61b59a89f5-c7c0f8.js 249 bytes [emitted] [immutable] [minimized] (name: lazy)
       sourceMap c7c0f8bb2e61b59a89f5-c7c0f8.js.map 327 bytes [emitted] [dev] (auxiliary name: lazy)
-  asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] (auxiliary name: lazy)
-  asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] (auxiliary name: main)
+  asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
+  asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: main)
   Entrypoint main 2.91 KiB (20.5 KiB) = 34a1f137ab6013192ef7-34a1f1.js 2.65 KiB b8bfcec62cdd15c9a840-b8bfce.js 266 bytes 3 auxiliary assets
   runtime modules 7.36 KiB 8 modules
   orphan modules 19 bytes [orphan] 1 module

--- a/test/statsCases/output-module/chunk.js
+++ b/test/statsCases/output-module/chunk.js
@@ -1,0 +1,1 @@
+export const message = "Hello Chunk";

--- a/test/statsCases/output-module/index.js
+++ b/test/statsCases/output-module/index.js
@@ -1,0 +1,10 @@
+import { message } from "./module";
+
+console.log(message);
+
+export async function printMessage() {
+	const { message } = await import("./chunk");
+	console.log(message);
+}
+
+printMessage();

--- a/test/statsCases/output-module/module.js
+++ b/test/statsCases/output-module/module.js
@@ -1,0 +1,1 @@
+export const message = "Hello World";

--- a/test/statsCases/output-module/webpack.config.js
+++ b/test/statsCases/output-module/webpack.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	mode: "production",
+	entry: "./index",
+	experiments: {
+		outputModule: true
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -235,6 +235,11 @@ declare interface AssetInfo {
 	contenthash?: LibraryExport;
 
 	/**
+	 * when asset was created from a source file (potentially transformed), the original filename relative to compilation context
+	 */
+	sourceFilename?: string;
+
+	/**
 	 * size in bytes, only set after asset has been emitted
 	 */
 	size?: number;
@@ -248,6 +253,11 @@ declare interface AssetInfo {
 	 * true, when asset ships data for updating an existing application (HMR)
 	 */
 	hotModuleReplacement?: boolean;
+
+	/**
+	 * true, when asset is javascript and an ESM
+	 */
+	javascriptModule?: boolean;
 
 	/**
 	 * object of pointers to other assets, keyed by type of relation (only points from parent to child)
@@ -6994,6 +7004,7 @@ declare interface RenderManifestEntryTemplated {
 	render: () => Source;
 	filenameTemplate: string | ((arg0: PathData, arg1: AssetInfo) => string);
 	pathOptions?: PathData;
+	info?: AssetInfo;
 	identifier: string;
 	hash?: string;
 	auxiliary?: boolean;
@@ -8007,6 +8018,7 @@ declare abstract class RuntimeTemplate {
 	outputOptions: OutputNormalized;
 	requestShortener: RequestShortener;
 	isIIFE(): boolean;
+	isModule(): boolean;
 	supportsConst(): boolean;
 	supportsArrowFunction(): boolean;
 	supportsForOf(): boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
two more properties in `info` (https://webpack.js.org/api/stats/#asset-objects)
* `sourceFilename` when asset was created from a source file (potentially transformed), the original filename relative to compilation context
* `javascriptModule` true, when asset is javascript and an ESM
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
