### PR TITLE
[#11670] Adds a warning about incorrect use of HMR chunks

### DIFF
--- a/lib/javascript/ArrayPushCallbackChunkFormatPlugin.js
+++ b/lib/javascript/ArrayPushCallbackChunkFormatPlugin.js
@@ -45,6 +45,16 @@ class ArrayPushCallbackChunkFormatPlugin {
 							const hotUpdateGlobal =
 								runtimeTemplate.outputOptions.hotUpdateGlobal;
 							source.add(
+								"if (document.currentScript && !document.currentScript.getAttribute('data-webpack')) {\n"
+							);
+							source.add(
+								'  var chunk = document.currentScript.getAttribute("src");\n'
+							);
+							source.add(
+								'  throw Error("You loaded HMR chunk " + chunk + " outside the normal HMR flow. Please, don\'t do it!");'
+							);
+							source.add("}\n");
+							source.add(
 								`${globalObject}[${JSON.stringify(hotUpdateGlobal)}](`
 							);
 							source.add(`${JSON.stringify(chunk.id)},`);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This update is related to the discussion in https://github.com/webpack/webpack/issues/11670. When a user generates his HTML template himself, and takes from Webpack stats the names of generated JS chunks to inject them into his HTML, it is easy to overlook that with HMR enabled in development mode the generated `xxx.hot-update.js` chunks will be also listed in the stats alongside the regular JS chunks, and should not be injected into HTML explicitly. If user overlooks it, the issue will be invisible until HMR is enabled, some updates are done, and then something (_e.g._ re-loading the page) injects `xxx.hot-update.js` scripts directly. When that happens, it leads to very obscure errors inside Wepback HMR code.

This update adds a simple check to the beginning of each generated `xxx.hot-update.js` chunk. It checks the chunk was loaded with `<script data-webpack="..." src="..."></script>`, as expected from the Webpack HMR machinery. If it is not the case, it throws error right away, resulting in a clearer error message, than would happen otherwise.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Small internal update.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Nothing.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
