### PR TITLE
Fixed resolve.roots default value

### DIFF
--- a/lib/WebpackOptionsDefaulter.js
+++ b/lib/WebpackOptionsDefaulter.js
@@ -356,13 +356,13 @@ class WebpackOptionsDefaulter extends OptionsDefaulter {
 				options.resolve.plugins.length > 0
 			);
 		});
+		this.set("resolve.roots", "make", options => [options.context]);
 
 		this.set("resolveLoader", "call", value => Object.assign({}, value));
 		this.set("resolveLoader.unsafeCache", true);
 		this.set("resolveLoader.mainFields", ["loader", "main"]);
 		this.set("resolveLoader.extensions", [".js", ".json"]);
 		this.set("resolveLoader.mainFiles", ["index"]);
-		this.set("resolveLoader.roots", "make", options => [options.context]);
 		this.set("resolveLoader.cacheWithContext", "make", options => {
 			return (
 				Array.isArray(options.resolveLoader.plugins) &&


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

#11207 intended for `resolve.roots` to have a default value, but was typo'd. See https://twitter.com/wSokra/status/1320840828412198913

This prevents `import Thing from '/thing-in-root'` from working out of the box.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No, but was discovered when testing it https://twitter.com/pyrolistical/status/1320825188175376384

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

Not in a meaningful way. Its technically breaking since `import Thing from '/thing-in-root'` would no longer error, but its unlikely anybody would have relied on that behaviour.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Mostly documented by #11207 but ideally would have more documentation describing the default value and hence the feature webpack v4 would now offer.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
