### PR TITLE
schemas: Allow empty array for dependOn, entry, import, noParse

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -54,7 +54,7 @@ export type EntryStatic = EntryObject | EntryUnnamed;
 /**
  * Module(s) that are loaded upon startup.
  */
-export type EntryItem = [string, ...string[]] | string;
+export type EntryItem = string[] | string;
 /**
  * The method of loading chunks (methods included by default are 'jsonp' (web), 'importScripts' (WebWorker), 'require' (sync node.js), 'async-node' (async node.js), but others might be added by plugins).
  */
@@ -883,7 +883,7 @@ export interface EntryDescription {
 	/**
 	 * The entrypoints that the current entrypoint depend on. They must be loaded when this entrypoint is loaded.
 	 */
-	dependOn?: [string, ...string[]] | string;
+	dependOn?: string[] | string;
 	/**
 	 * Specifies the name of each output file on disk. You must **not** specify an absolute path here! The `output.path` option determines the location on disk the files are written to, filename is used solely for naming the individual files.
 	 */
@@ -1076,11 +1076,7 @@ export interface ModuleOptions {
 	/**
 	 * Don't parse files matching. It's matched against the full resolved request.
 	 */
-	noParse?:
-		| [RegExp | string | Function, ...(RegExp | string | Function)[]]
-		| RegExp
-		| string
-		| Function;
+	noParse?: (RegExp | string | Function)[] | RegExp | string | Function;
 	/**
 	 * An array of rules applied for modules.
 	 */
@@ -2344,15 +2340,15 @@ export interface EntryDescriptionNormalized {
 	/**
 	 * The entrypoints that the current entrypoint depend on. They must be loaded when this entrypoint is loaded.
 	 */
-	dependOn?: [string, ...string[]];
+	dependOn?: string[];
 	/**
 	 * Specifies the name of each output file on disk. You must **not** specify an absolute path here! The `output.path` option determines the location on disk the files are written to, filename is used solely for naming the individual files.
 	 */
 	filename?: Filename;
 	/**
-	 * Module(s) that are loaded upon startup. The last one is exported.
+	 * Module(s) that are loaded upon startup. Only the last one is exported.
 	 */
-	import?: [string, ...string[]];
+	import?: string[];
 	/**
 	 * Options for library.
 	 */

--- a/declarations/plugins/WatchIgnorePlugin.d.ts
+++ b/declarations/plugins/WatchIgnorePlugin.d.ts
@@ -8,5 +8,5 @@ export interface WatchIgnorePluginOptions {
 	/**
 	 * A list of RegExps or absolute paths to directories or files that should be ignored.
 	 */
-	paths: [RegExp | string, ...(RegExp | string)[]];
+	paths: (RegExp | string)[];
 }

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -244,7 +244,6 @@
                 "type": "string",
                 "minLength": 1
               },
-              "minItems": 1,
               "uniqueItems": true
             },
             {
@@ -288,21 +287,19 @@
             "type": "string",
             "minLength": 1
           },
-          "minItems": 1,
           "uniqueItems": true
         },
         "filename": {
           "$ref": "#/definitions/Filename"
         },
         "import": {
-          "description": "Module(s) that are loaded upon startup. The last one is exported.",
+          "description": "Module(s) that are loaded upon startup. Only the last one is exported.",
           "type": "array",
           "items": {
             "description": "Module that is loaded upon startup. Only the last one is exported.",
             "type": "string",
             "minLength": 1
           },
-          "minItems": 1,
           "uniqueItems": true
         },
         "library": {
@@ -337,7 +334,6 @@
             "type": "string",
             "minLength": 1
           },
-          "minItems": 1,
           "uniqueItems": true
         },
         {
@@ -1104,8 +1100,7 @@
                     "tsType": "Function"
                   }
                 ]
-              },
-              "minItems": 1
+              }
             },
             {
               "description": "A regular expression, when matched the module is not parsed.",

--- a/schemas/plugins/WatchIgnorePlugin.json
+++ b/schemas/plugins/WatchIgnorePlugin.json
@@ -17,8 +17,7 @@
             "type": "string"
           }
         ]
-      },
-      "minItems": 1
+      }
     }
   },
   "required": ["paths"]

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -52,21 +52,6 @@ describe("Validation", () => {
 	);
 
 	createTestCase(
-		"empty entry bundle array",
-		{
-			entry: {
-				bundle: []
-			}
-		},
-		msg =>
-			expect(msg).toMatchInlineSnapshot(`
-			"Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
-			 - configuration.entry['bundle'] should be an non-empty array.
-			   -> All modules are loaded upon startup. The last one is exported."
-		`)
-	);
-
-	createTestCase(
 		"invalid instanceof",
 		{
 			entry: "a",

--- a/test/configCases/entry/empty-entries/a.js
+++ b/test/configCases/entry/empty-entries/a.js
@@ -1,0 +1,3 @@
+it("should compile", (done) => {
+	done()
+});

--- a/test/configCases/entry/empty-entries/webpack.config.js
+++ b/test/configCases/entry/empty-entries/webpack.config.js
@@ -1,0 +1,11 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		nonempty: ["./a.js"],
+		empty: [],
+		"empty-import-dependOn": {
+			import: [],
+			dependOn: []
+		}
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -217,22 +217,22 @@ declare interface AssetInfo {
 	/**
 	 * the value(s) of the full hash used for this asset
 	 */
-	fullhash?: LibraryExport;
+	fullhash?: EntryItem;
 
 	/**
 	 * the value(s) of the chunk hash used for this asset
 	 */
-	chunkhash?: LibraryExport;
+	chunkhash?: EntryItem;
 
 	/**
 	 * the value(s) of the module hash used for this asset
 	 */
-	modulehash?: LibraryExport;
+	modulehash?: EntryItem;
 
 	/**
 	 * the value(s) of the content hash used for this asset
 	 */
-	contenthash?: LibraryExport;
+	contenthash?: EntryItem;
 
 	/**
 	 * when asset was created from a source file (potentially transformed), the original filename relative to compilation context
@@ -262,7 +262,7 @@ declare interface AssetInfo {
 	/**
 	 * object of pointers to other assets, keyed by type of relation (only points from parent to child)
 	 */
-	related?: Record<string, LibraryExport>;
+	related?: Record<string, EntryItem>;
 }
 type AssetModuleFilename =
 	| string
@@ -2610,9 +2610,9 @@ declare class EnableLibraryPlugin {
 }
 type Entry =
 	| string
-	| (() => string | EntryObject | [string, ...string[]] | Promise<EntryStatic>)
+	| (() => string | EntryObject | string[] | Promise<EntryStatic>)
 	| EntryObject
-	| [string, ...string[]];
+	| string[];
 declare interface EntryData {
 	/**
 	 * dependencies of the entrypoint that should be evaluated at startup
@@ -2691,7 +2691,7 @@ declare interface EntryDescriptionNormalized {
 	/**
 	 * The entrypoints that the current entrypoint depend on. They must be loaded when this entrypoint is loaded.
 	 */
-	dependOn?: [string, ...string[]];
+	dependOn?: string[];
 
 	/**
 	 * Specifies the name of each output file on disk. You must **not** specify an absolute path here! The `output.path` option determines the location on disk the files are written to, filename is used solely for naming the individual files.
@@ -2699,9 +2699,9 @@ declare interface EntryDescriptionNormalized {
 	filename?: Filename;
 
 	/**
-	 * Module(s) that are loaded upon startup. The last one is exported.
+	 * Module(s) that are loaded upon startup. Only the last one is exported.
 	 */
-	import?: [string, ...string[]];
+	import?: string[];
 
 	/**
 	 * Options for library.
@@ -2718,7 +2718,7 @@ declare interface EntryDescriptionNormalized {
 	 */
 	wasmLoading?: DevTool;
 }
-type EntryItem = string | [string, ...string[]];
+type EntryItem = string | string[];
 type EntryNormalized =
 	| (() => Promise<EntryStaticNormalized>)
 	| EntryStaticNormalized;
@@ -2727,7 +2727,7 @@ type EntryNormalized =
  * Multiple entry bundles are created. The key is the entry name. The value can be a string, an array or an entry description object.
  */
 declare interface EntryObject {
-	[index: string]: string | [string, ...string[]] | EntryDescription;
+	[index: string]: string | string[] | EntryDescription;
 }
 declare class EntryOptionPlugin {
 	constructor();
@@ -2804,7 +2804,7 @@ declare class EntryPlugin {
 			  >)
 	): EntryDependency;
 }
-type EntryStatic = string | EntryObject | [string, ...string[]];
+type EntryStatic = string | EntryObject | string[];
 
 /**
  * Multiple entry bundles are created. The key is the entry name. The value is an entry description object.
@@ -3096,18 +3096,18 @@ declare abstract class ExportsInfo {
 	): boolean | SortableSet<string>;
 	getProvidedExports(): true | string[];
 	getRelevantExports(runtime: string | SortableSet<string>): ExportInfo[];
-	isExportProvided(name: LibraryExport): boolean;
+	isExportProvided(name: EntryItem): boolean;
 	getUsageKey(runtime: string | SortableSet<string>): string;
 	isEquallyUsed(
 		runtimeA: string | SortableSet<string>,
 		runtimeB: string | SortableSet<string>
 	): boolean;
 	getUsed(
-		name: LibraryExport,
+		name: EntryItem,
 		runtime: string | SortableSet<string>
 	): 0 | 1 | 2 | 3 | 4;
 	getUsedName(
-		name: LibraryExport,
+		name: EntryItem,
 		runtime: string | SortableSet<string>
 	): string | false | string[];
 	updateHash(hash: Hash, runtime: string | SortableSet<string>): void;
@@ -3205,7 +3205,7 @@ type ExternalItem =
 	  ) => void);
 declare class ExternalModule extends Module {
 	constructor(request?: any, type?: any, userRequest?: any);
-	request: string | string[] | Record<string, LibraryExport>;
+	request: string | string[] | Record<string, EntryItem>;
 	externalType: string;
 	userRequest: string;
 	getSourceData(
@@ -4517,9 +4517,8 @@ declare interface LibraryCustomUmdObject {
 	/**
 	 * Name of the property exposed globally by a UMD library.
 	 */
-	root?: LibraryExport;
+	root?: EntryItem;
 }
-type LibraryExport = string | string[];
 type LibraryName = string | string[] | LibraryCustomUmdObject;
 
 /**
@@ -4534,7 +4533,7 @@ declare interface LibraryOptions {
 	/**
 	 * Specify which export should be exposed as library.
 	 */
-	export?: LibraryExport;
+	export?: EntryItem;
 
 	/**
 	 * The name of the library (some types allow unnamed libraries too).
@@ -4557,14 +4556,14 @@ declare class LibraryTemplatePlugin {
 		target: string,
 		umdNamedDefine: boolean,
 		auxiliaryComment: AuxiliaryComment,
-		exportProperty: LibraryExport
+		exportProperty: EntryItem
 	);
 	library: {
 		type: string;
 		name: LibraryName;
 		umdNamedDefine: boolean;
 		auxiliaryComment: AuxiliaryComment;
-		export: LibraryExport;
+		export: EntryItem;
 	};
 
 	/**
@@ -5052,7 +5051,7 @@ declare class ModuleGraph {
 		module: Module
 	): (string | ((requestShortener: RequestShortener) => string))[];
 	getProvidedExports(module: Module): true | string[];
-	isExportProvided(module: Module, exportName: LibraryExport): boolean;
+	isExportProvided(module: Module, exportName: EntryItem): boolean;
 	getExportsInfo(module: Module): ExportsInfo;
 	getExportInfo(module: Module, exportName: string): ExportInfo;
 	getReadOnlyExportInfo(module: Module, exportName: string): ExportInfo;
@@ -5163,11 +5162,7 @@ declare interface ModuleOptions {
 	/**
 	 * Don't parse files matching. It's matched against the full resolved request.
 	 */
-	noParse?:
-		| string
-		| Function
-		| RegExp
-		| [string | Function | RegExp, ...(string | Function | RegExp)[]];
+	noParse?: string | Function | RegExp | (string | Function | RegExp)[];
 
 	/**
 	 * An array of rules applied for modules.
@@ -6265,7 +6260,7 @@ declare interface Output {
 	/**
 	 * Specify which export should be exposed as library.
 	 */
-	libraryExport?: LibraryExport;
+	libraryExport?: EntryItem;
 
 	/**
 	 * Type of library (types included by default are 'var', 'module', 'assign', 'this', 'window', 'self', 'global', 'commonjs', 'commonjs2', 'commonjs-module', 'amd', 'amd-require', 'umd', 'umd2', 'jsonp', 'system', but others might be added by plugins).
@@ -6785,8 +6780,8 @@ declare interface ProgressPluginOptions {
 	profile?: boolean;
 }
 declare class ProvidePlugin {
-	constructor(definitions: Record<string, LibraryExport>);
-	definitions: Record<string, LibraryExport>;
+	constructor(definitions: Record<string, EntryItem>);
+	definitions: Record<string, EntryItem>;
 
 	/**
 	 * Apply the plugin
@@ -7174,7 +7169,7 @@ declare interface ResolveOptionsTypes {
 		 */
 		onlyModule?: boolean;
 	}[];
-	aliasFields: Set<LibraryExport>;
+	aliasFields: Set<EntryItem>;
 	cachePredicate: (arg0: ResolveRequest) => boolean;
 	cacheWithContext: boolean;
 
@@ -7184,14 +7179,14 @@ declare interface ResolveOptionsTypes {
 	conditionNames: Set<string>;
 	descriptionFiles: string[];
 	enforceExtension: boolean;
-	exportsFields: Set<LibraryExport>;
-	importsFields: Set<LibraryExport>;
+	exportsFields: Set<EntryItem>;
+	importsFields: Set<EntryItem>;
 	extensions: Set<string>;
 	fileSystem: FileSystem;
 	unsafeCache: any;
 	symlinks: boolean;
 	resolver?: Resolver;
-	modules: LibraryExport[];
+	modules: EntryItem[];
 	mainFields: { name: string[]; forceRelative: boolean }[];
 	mainFiles: Set<string>;
 	plugins: (
@@ -7218,7 +7213,7 @@ declare interface ResolveOptionsWebpackOptions {
 	/**
 	 * Fields in the description file (usually package.json) which are used to redirect requests inside the module.
 	 */
-	aliasFields?: LibraryExport[];
+	aliasFields?: EntryItem[];
 
 	/**
 	 * Extra resolve options per dependency category. Typical categories are "commonjs", "amd", "esm".
@@ -7288,7 +7283,7 @@ declare interface ResolveOptionsWebpackOptions {
 	/**
 	 * Field names from the description file (package.json) which are used to find the default entry point.
 	 */
-	mainFields?: LibraryExport[];
+	mainFields?: EntryItem[];
 
 	/**
 	 * Filenames used to find the default entry point if there is no description file or main field.
@@ -7420,7 +7415,7 @@ declare abstract class ResolverFactory {
 						/**
 						 * Fields in the description file (usually package.json) which are used to redirect requests inside the module.
 						 */
-						aliasFields?: LibraryExport[];
+						aliasFields?: EntryItem[];
 						/**
 						 * Extra resolve options per dependency category. Typical categories are "commonjs", "amd", "esm".
 						 */
@@ -7476,7 +7471,7 @@ declare abstract class ResolverFactory {
 						/**
 						 * Field names from the description file (package.json) which are used to find the default entry point.
 						 */
-						mainFields?: LibraryExport[];
+						mainFields?: EntryItem[];
 						/**
 						 * Filenames used to find the default entry point if there is no description file or main field.
 						 */
@@ -7536,7 +7531,7 @@ declare abstract class ResolverFactory {
 						/**
 						 * Fields in the description file (usually package.json) which are used to redirect requests inside the module.
 						 */
-						aliasFields?: LibraryExport[];
+						aliasFields?: EntryItem[];
 						/**
 						 * Extra resolve options per dependency category. Typical categories are "commonjs", "amd", "esm".
 						 */
@@ -7592,7 +7587,7 @@ declare abstract class ResolverFactory {
 						/**
 						 * Field names from the description file (package.json) which are used to find the default entry point.
 						 */
-						mainFields?: LibraryExport[];
+						mainFields?: EntryItem[];
 						/**
 						 * Filenames used to find the default entry point if there is no description file or main field.
 						 */
@@ -7652,7 +7647,7 @@ declare abstract class ResolverFactory {
 			/**
 			 * Fields in the description file (usually package.json) which are used to redirect requests inside the module.
 			 */
-			aliasFields?: LibraryExport[];
+			aliasFields?: EntryItem[];
 			/**
 			 * Extra resolve options per dependency category. Typical categories are "commonjs", "amd", "esm".
 			 */
@@ -7708,7 +7703,7 @@ declare abstract class ResolverFactory {
 			/**
 			 * Field names from the description file (package.json) which are used to find the default entry point.
 			 */
-			mainFields?: LibraryExport[];
+			mainFields?: EntryItem[];
 			/**
 			 * Filenames used to find the default entry point if there is no description file or main field.
 			 */
@@ -8313,7 +8308,7 @@ declare abstract class RuntimeTemplate {
 		/**
 		 * the export name
 		 */
-		exportName: LibraryExport;
+		exportName: EntryItem;
 		/**
 		 * the origin module
 		 */
@@ -9322,9 +9317,9 @@ declare class Template {
 	static toPath(str: string): string;
 	static numberToIdentifier(n: number): string;
 	static numberToIdentifierContinuation(n: number): string;
-	static indent(s: LibraryExport): string;
-	static prefix(s: LibraryExport, prefix: string): string;
-	static asString(str: LibraryExport): string;
+	static indent(s: EntryItem): string;
+	static prefix(s: EntryItem, prefix: string): string;
+	static asString(str: EntryItem): string;
 	static getModulesArrayBounds(modules: WithId[]): false | [number, number];
 	static renderChunkModules(
 		renderContext: RenderContextModuleTemplate,
@@ -9407,7 +9402,7 @@ declare interface UserResolveOptions {
 	/**
 	 * A list of alias fields in description files
 	 */
-	aliasFields?: LibraryExport[];
+	aliasFields?: EntryItem[];
 
 	/**
 	 * A function which decides whether a request should be cached or not. An object is passed with at least `path` and `request` properties.
@@ -9437,12 +9432,12 @@ declare interface UserResolveOptions {
 	/**
 	 * A list of exports fields in description files
 	 */
-	exportsFields?: LibraryExport[];
+	exportsFields?: EntryItem[];
 
 	/**
 	 * A list of imports fields in description files
 	 */
-	importsFields?: LibraryExport[];
+	importsFields?: EntryItem[];
 
 	/**
 	 * A list of extensions which should be tried for files
@@ -9472,7 +9467,7 @@ declare interface UserResolveOptions {
 	/**
 	 * A list of directories to resolve modules from, can be absolute path or folder name
 	 */
-	modules?: LibraryExport;
+	modules?: EntryItem;
 
 	/**
 	 * A list of main fields in description files
@@ -9480,7 +9475,7 @@ declare interface UserResolveOptions {
 	mainFields?: (
 		| string
 		| string[]
-		| { name: LibraryExport; forceRelative: boolean }
+		| { name: EntryItem; forceRelative: boolean }
 	)[];
 
 	/**
@@ -9555,7 +9550,7 @@ declare interface WatchFileSystem {
 }
 declare class WatchIgnorePlugin {
 	constructor(options: WatchIgnorePluginOptions);
-	paths: [string | RegExp, ...(string | RegExp)[]];
+	paths: (string | RegExp)[];
 
 	/**
 	 * Apply the plugin
@@ -9566,7 +9561,7 @@ declare interface WatchIgnorePluginOptions {
 	/**
 	 * A list of RegExps or absolute paths to directories or files that should be ignored.
 	 */
-	paths: [string | RegExp, ...(string | RegExp)[]];
+	paths: (string | RegExp)[];
 }
 
 /**
@@ -9918,7 +9913,7 @@ declare interface WithOptions {
 			/**
 			 * Fields in the description file (usually package.json) which are used to redirect requests inside the module.
 			 */
-			aliasFields?: LibraryExport[];
+			aliasFields?: EntryItem[];
 			/**
 			 * Extra resolve options per dependency category. Typical categories are "commonjs", "amd", "esm".
 			 */
@@ -9974,7 +9969,7 @@ declare interface WithOptions {
 			/**
 			 * Field names from the description file (package.json) which are used to find the default entry point.
 			 */
-			mainFields?: LibraryExport[];
+			mainFields?: EntryItem[];
 			/**
 			 * Filenames used to find the default entry point if there is no description file or main field.
 			 */


### PR DESCRIPTION
There may be no practical reason to use an empty array here, but it’s not harmful, and allowing it makes the TypeScript typings more convenient, e.g. `string[]` instead of `[string, ...string[]]`.

The `[string, ...string[]]` type was annoying to work with because it’s incompatible with almost every nontrivial way you might compute the value other than writing it out literally. For example, using `filter` or `map` or importing from a .json file all give you a `string[]`, which cannot be assigned to `[string, ...string[]]` without an unchecked cast, even if the programmer “knows” the result will be nonempty.

Fixes #11801.

**What kind of change does this PR introduce?**

Feature, I guess.

**Did you add tests for your changes?**

Yes.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

Nothing, I think—the documentation did not suggest that empty arrays were forbidden.
