### PR TITLE
Fix deprecations in LimitChunkCountPlugin

### DIFF
--- a/lib/optimize/LimitChunkCountPlugin.js
+++ b/lib/optimize/LimitChunkCountPlugin.js
@@ -175,7 +175,9 @@ class LimitChunkCountPlugin {
 						}
 
 						// merge the chunks
-						if (a.integrate(b, "limit")) {
+						const canIntegrate = chunkGraph.canChunksBeIntegrated(a, b);
+						if (canIntegrate) {
+							chunkGraph.integrateChunks(a, b);
 							compilation.chunks.delete(b);
 
 							// flag chunk a as modified as further optimization are possible for all children here
@@ -204,7 +206,8 @@ class LimitChunkCountPlugin {
 										continue;
 									}
 									// Update size
-									const newIntegratedSize = a.integratedSize(
+									const newIntegratedSize = chunkGraph.getIntegratedChunksSize(
+										a,
 										combination.b,
 										options
 									);
@@ -222,7 +225,8 @@ class LimitChunkCountPlugin {
 										continue;
 									}
 									// Update size
-									const newIntegratedSize = combination.a.integratedSize(
+									const newIntegratedSize = chunkGraph.getIntegratedChunksSize(
+										combination.a,
 										a,
 										options
 									);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Using the LimitChunkCountPlugin in webpack 5 emits deprecation warnings:
```
[DEP_WEBPACK_CHUNK_INTEGRATE] DeprecationWarning: Chunk.integrate: Use new ChunkGraph API
[DEP_WEBPACK_CHUNK_INTEGRATED_SIZE] DeprecationWarning: Chunk.integratedSize: Use new ChunkGraph API
```
<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
refactoring
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
none
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
