### PR TITLE
EnvironmentPlugin: function for defaultValues

### DIFF
--- a/lib/EnvironmentPlugin.js
+++ b/lib/EnvironmentPlugin.js
@@ -34,10 +34,12 @@ class EnvironmentPlugin {
 		/** @type {Record<string, CodeValue>} */
 		const definitions = {};
 		for (const key of this.keys) {
-			const value =
-				process.env[key] !== undefined
-					? process.env[key]
-					: this.defaultValues[key];
+			let value = process.env[key];
+
+			if (value === undefined) {
+				const def = this.defaultValues[key];
+				value = typeof def === "function" ? def() : def;
+			}
 
 			if (value === undefined) {
 				compiler.hooks.thisCompilation.tap("EnvironmentPlugin", compilation => {

--- a/test/configCases/plugins/environment-plugin/errors.js
+++ b/test/configCases/plugins/environment-plugin/errors.js
@@ -1,4 +1,4 @@
-const variables = ['aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff', 'ggg', 'hhh', 'iii'];
+const variables = ['aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff', 'ggg', 'hhh', 'iii', 'jjj'];
 const modules = [{
 	name: 'aaa',
 	variables: ['aaa']
@@ -20,6 +20,9 @@ const modules = [{
 }, {
 	name: 'iii',
 	variables: ['iii']
+}, {
+	name: 'jjj',
+	variables: ['jjj']
 }];
 
 // build an array of regular expressions of expected errors

--- a/test/configCases/plugins/environment-plugin/index.js
+++ b/test/configCases/plugins/environment-plugin/index.js
@@ -26,3 +26,7 @@ it("should import multiple process.env var with default values", () => {
 it("should import process.env var with empty value", () => {
 	if (process.env.III !== "") if (never) require("iii");
 });
+
+it("should import process.env var with default value functions", () => {
+	if (process.env.JJJ !== "jjj-default") if (never) require("jjj");
+});

--- a/test/configCases/plugins/environment-plugin/webpack.config.js
+++ b/test/configCases/plugins/environment-plugin/webpack.config.js
@@ -64,5 +64,17 @@ module.exports = [
 			unknownContextCritical: false
 		},
 		plugins: [new EnvironmentPlugin("III")]
+	},
+	{
+		name: "jjj",
+		module: {
+			unknownContextRegExp: /$^/,
+			unknownContextCritical: false
+		},
+		plugins: [
+			new EnvironmentPlugin({
+				JJJ: () => "jjj-default"
+			})
+		]
 	}
 ];


### PR DESCRIPTION
EnvironmentPlugin: allow `defaultValues` to be computed from a function.

This is useful when the computation of the defaultValue is expensive, such as `CI_COMMIT_TAG` requiring an invocation of `git rev-parse HEAD`.

**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

not yet

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

* https://webpack.js.org/plugins/environment-plugin