### PR TITLE
fix: Check whether plugin names are valid Javascript identifiers

### DIFF
--- a/lib/library/AssignLibraryPlugin.js
+++ b/lib/library/AssignLibraryPlugin.js
@@ -19,6 +19,68 @@ const AbstractLibraryPlugin = require("./AbstractLibraryPlugin");
 /** @typedef {import("../util/Hash")} Hash */
 /** @template T @typedef {import("./AbstractLibraryPlugin").LibraryContext<T>} LibraryContext<T> */
 
+/* Validates the plugin name by checking for keywords and invalid characters */
+const isNameValid = pluginName => {
+	const keywords = [
+		"await",
+		"break",
+		"case",
+		"catch",
+		"class",
+		"const",
+		"continue",
+		"debugger",
+		"default",
+		"delete",
+		"do",
+		"else",
+		"enum",
+		"export",
+		"extends",
+		"false",
+		"finally",
+		"for",
+		"function",
+		"if",
+		"implements",
+		"import",
+		"in",
+		"instanceof",
+		"interface",
+		"let",
+		"new",
+		"null",
+		"package",
+		"private",
+		"protected",
+		"public",
+		"return",
+		"super",
+		"switch",
+		"static",
+		"this",
+		"throw",
+		"try",
+		"true",
+		"typeof",
+		"var",
+		"void",
+		"while",
+		"with",
+		"yield"
+	];
+	const validRegex = new RegExp(/^[$A-Z_][0-9A-Z_$]*$/i);
+	let isKeyword = false,
+		isValid = true;
+	keywords.map(keyword => {
+		if (keyword.localeCompare(pluginName) === 0) {
+			isKeyword = true;
+		}
+	});
+	isValid = validRegex.test(pluginName);
+	return !isKeyword && isValid;
+};
+
 /**
  * @param {string[]} accessor variable plus properties
  * @param {number} existingLength items of accessor that are existing already
@@ -139,6 +201,11 @@ class AssignLibraryPlugin extends AbstractLibraryPlugin {
 		const result = new ConcatSource();
 		if (this.declare) {
 			const base = fullNameResolved[0];
+			if (!isNameValid(base)) {
+				throw new Error(
+					`Library name (${base}) must be a valid identifier when using a var declaring library type. Either use a valid identifier (e. g. 'Template.toIdentifier(${base})' or use a different library type (e. g. 'type: "global"', which assign a property on the global scope instead of declaring a variable). Common configuration options that specific library names are 'output.library[.name]', 'entry.xyz.library[.name]', 'ModuleFederationPlugin.name' and 'ModuleFederationPlugin.library[.name]'.`
+				);
+			}
 			result.add(`${this.declare} ${base};`);
 		}
 		if (!options.name && this.unnamed === "copy") {

--- a/lib/library/AssignLibraryPlugin.js
+++ b/lib/library/AssignLibraryPlugin.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const { ConcatSource } = require("webpack-sources");
+const Template = require("../Template");
 const propertyAccess = require("../util/propertyAccess");
 const AbstractLibraryPlugin = require("./AbstractLibraryPlugin");
 
@@ -19,66 +20,16 @@ const AbstractLibraryPlugin = require("./AbstractLibraryPlugin");
 /** @typedef {import("../util/Hash")} Hash */
 /** @template T @typedef {import("./AbstractLibraryPlugin").LibraryContext<T>} LibraryContext<T> */
 
-/* Validates the plugin name by checking for keywords and invalid characters */
-const isNameValid = pluginName => {
-	const keywords = [
-		"await",
-		"break",
-		"case",
-		"catch",
-		"class",
-		"const",
-		"continue",
-		"debugger",
-		"default",
-		"delete",
-		"do",
-		"else",
-		"enum",
-		"export",
-		"extends",
-		"false",
-		"finally",
-		"for",
-		"function",
-		"if",
-		"implements",
-		"import",
-		"in",
-		"instanceof",
-		"interface",
-		"let",
-		"new",
-		"null",
-		"package",
-		"private",
-		"protected",
-		"public",
-		"return",
-		"super",
-		"switch",
-		"static",
-		"this",
-		"throw",
-		"try",
-		"true",
-		"typeof",
-		"var",
-		"void",
-		"while",
-		"with",
-		"yield"
-	];
-	const validRegex = new RegExp(/^[$A-Z_][0-9A-Z_$]*$/i);
-	let isKeyword = false,
-		isValid = true;
-	keywords.map(keyword => {
-		if (keyword.localeCompare(pluginName) === 0) {
-			isKeyword = true;
-		}
-	});
-	isValid = validRegex.test(pluginName);
-	return !isKeyword && isValid;
+const KEYWORD_REGEX = /^(await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|false|finally|for|function|if|implements|import|in|instanceof|interface|let|new|null|package|private|protected|public|return|super|switch|static|this|throw|try|true|typeof|var|void|while|with|yield)$/;
+const IDENTIFIER_REGEX = /^[\p{L}\p{Nl}$_][\p{L}\p{Nl}$\p{Mn}\p{Mc}\p{Nd}\p{Pc}]*$/iu;
+
+/**
+ * Validates the library name by checking for keywords and valid characters
+ * @param {string} name name to be validated
+ * @returns {boolean} true, when valid
+ */
+const isNameValid = name => {
+	return !KEYWORD_REGEX.test(name) && IDENTIFIER_REGEX.test(name);
 };
 
 /**
@@ -203,7 +154,9 @@ class AssignLibraryPlugin extends AbstractLibraryPlugin {
 			const base = fullNameResolved[0];
 			if (!isNameValid(base)) {
 				throw new Error(
-					`Library name (${base}) must be a valid identifier when using a var declaring library type. Either use a valid identifier (e. g. 'Template.toIdentifier(${base})' or use a different library type (e. g. 'type: "global"', which assign a property on the global scope instead of declaring a variable). Common configuration options that specific library names are 'output.library[.name]', 'entry.xyz.library[.name]', 'ModuleFederationPlugin.name' and 'ModuleFederationPlugin.library[.name]'.`
+					`Library name base (${base}) must be a valid identifier when using a var declaring library type. Either use a valid identifier (e. g. ${Template.toIdentifier(
+						base
+					)}) or use a different library type (e. g. 'type: "global"', which assign a property on the global scope instead of declaring a variable). Common configuration options that specific library names are 'output.library[.name]', 'entry.xyz.library[.name]', 'ModuleFederationPlugin.name' and 'ModuleFederationPlugin.library[.name]'.`
 				);
 			}
 			result.add(`${this.declare} ${base};`);

--- a/test/configCases/library/invalid-name/errors.js
+++ b/test/configCases/library/invalid-name/errors.js
@@ -1,0 +1,6 @@
+module.exports = [
+	[
+		/Library name base \(123-hello world\) must be a valid identifier/,
+		/use a valid identifier \(e\. g\. _123_hello_world\)/
+	]
+];

--- a/test/configCases/library/invalid-name/index.js
+++ b/test/configCases/library/invalid-name/index.js
@@ -1,0 +1,3 @@
+it("should error", function () {
+	throw new Error("should not be executed");
+});

--- a/test/configCases/library/invalid-name/webpack.config.js
+++ b/test/configCases/library/invalid-name/webpack.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		library: ["123-hello world", "hello world"]
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
`bugfix` related to #11923

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No, it does not introduce a breaking change, but only validation for `ModuleFederationPlugin`'s name property

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
In the documentation for `ModuleFederationPlugin`, it might be worth mentioning the change made by this PR.

<!-- List all the information that needs to be added to the documentation after merge -->
As the library type for `ModuleFederationPlugin.name` is `var`by default, dashes(-) should not be included in it, as these are not allowed in Javascript declarations. Doing so will explicitly throw an error.
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
