### PR TITLE
AssignLibraryPlugin: don't include library name in the accessor when target is commonjs2 / commonjs-module

### DIFF
--- a/lib/library/AssignLibraryPlugin.js
+++ b/lib/library/AssignLibraryPlugin.js
@@ -87,6 +87,7 @@ const accessWithInit = (accessor, existingLength, initLast = false) => {
  * @property {string[] | "global"} prefix name prefix
  * @property {string | false} declare declare name as variable
  * @property {"error"|"copy"|"assign"} unnamed behavior for unnamed library name
+ * @property {boolean} ignoreLibraryName do not include library name in the accessor
  */
 
 /**
@@ -110,6 +111,7 @@ class AssignLibraryPlugin extends AbstractLibraryPlugin {
 		this.prefix = options.prefix;
 		this.declare = options.declare;
 		this.unnamed = options.unnamed;
+		this.ignoreLibraryName = options.ignoreLibraryName;
 	}
 
 	/**
@@ -143,7 +145,10 @@ class AssignLibraryPlugin extends AbstractLibraryPlugin {
 			this.prefix === "global"
 				? [compilation.outputOptions.globalObject]
 				: this.prefix;
-		const fullName = options.name ? prefix.concat(options.name) : prefix;
+		const fullName =
+			options.name && this.ignoreLibraryName !== true
+				? prefix.concat(options.name)
+				: prefix;
 		const fullNameResolved = fullName.map(n =>
 			compilation.getPath(n, {
 				chunk

--- a/lib/library/EnableLibraryPlugin.js
+++ b/lib/library/EnableLibraryPlugin.js
@@ -83,7 +83,8 @@ class EnableLibraryPlugin {
 						type,
 						prefix: [],
 						declare: "var",
-						unnamed: "error"
+						unnamed: "error",
+						ignoreLibraryName: false
 					}).apply(compiler);
 					break;
 				}
@@ -94,7 +95,8 @@ class EnableLibraryPlugin {
 						type,
 						prefix: [],
 						declare: false,
-						unnamed: "error"
+						unnamed: "error",
+						ignoreLibraryName: false
 					}).apply(compiler);
 					break;
 				}
@@ -105,7 +107,8 @@ class EnableLibraryPlugin {
 						type,
 						prefix: ["this"],
 						declare: false,
-						unnamed: "copy"
+						unnamed: "copy",
+						ignoreLibraryName: false
 					}).apply(compiler);
 					break;
 				}
@@ -116,7 +119,8 @@ class EnableLibraryPlugin {
 						type,
 						prefix: ["window"],
 						declare: false,
-						unnamed: "copy"
+						unnamed: "copy",
+						ignoreLibraryName: false
 					}).apply(compiler);
 					break;
 				}
@@ -127,7 +131,8 @@ class EnableLibraryPlugin {
 						type,
 						prefix: ["self"],
 						declare: false,
-						unnamed: "copy"
+						unnamed: "copy",
+						ignoreLibraryName: false
 					}).apply(compiler);
 					break;
 				}
@@ -138,7 +143,8 @@ class EnableLibraryPlugin {
 						type,
 						prefix: "global",
 						declare: false,
-						unnamed: "copy"
+						unnamed: "copy",
+						ignoreLibraryName: false
 					}).apply(compiler);
 					break;
 				}
@@ -149,7 +155,8 @@ class EnableLibraryPlugin {
 						type,
 						prefix: ["exports"],
 						declare: false,
-						unnamed: "copy"
+						unnamed: "copy",
+						ignoreLibraryName: false
 					}).apply(compiler);
 					break;
 				}
@@ -161,7 +168,8 @@ class EnableLibraryPlugin {
 						type,
 						prefix: ["module", "exports"],
 						declare: false,
-						unnamed: "assign"
+						unnamed: "assign",
+						ignoreLibraryName: true
 					}).apply(compiler);
 					break;
 				}

--- a/test/configCases/library/0-create-library/webpack.config.js
+++ b/test/configCases/library/0-create-library/webpack.config.js
@@ -66,6 +66,18 @@ module.exports = (env, { testPath }) => [
 	},
 	{
 		output: {
+			filename: "commonjs2-named.js",
+			libraryTarget: "commonjs2",
+			library: "MyLibrary"
+		},
+		resolve: {
+			alias: {
+				external: "./non-external"
+			}
+		}
+	},
+	{
+		output: {
 			filename: "commonjs2-external.js",
 			libraryTarget: "commonjs2"
 		},

--- a/test/configCases/library/1-use-library/webpack.config.js
+++ b/test/configCases/library/1-use-library/webpack.config.js
@@ -110,6 +110,21 @@ module.exports = (env, { testPath }) => [
 			alias: {
 				library: path.resolve(
 					testPath,
+					"../0-create-library/commonjs2-named.js"
+				)
+			}
+		},
+		plugins: [
+			new webpack.DefinePlugin({
+				NAME: JSON.stringify("commonjs2 named")
+			})
+		]
+	},
+	{
+		resolve: {
+			alias: {
+				library: path.resolve(
+					testPath,
 					"../0-create-library/commonjs2-split-chunks/"
 				),
 				external: path.resolve(__dirname, "node_modules/external.js")


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Hi! Thanks for the great package.

I'm a library author and webpack@5 breaks my library because (unlike in webpack@4) the library exports are placed inside a namespace when target is `commonjs2`.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

This PR fixes #11688.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

Nothing (presumably).