### PR TITLE
Export Optimization interface in types.d.ts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ const memorize = require("./util/memorize");
 /** @typedef {import("../declarations/WebpackOptions").EntryNormalized} EntryNormalized */
 /** @typedef {import("../declarations/WebpackOptions").LibraryOptions} LibraryOptions */
 /** @typedef {import("../declarations/WebpackOptions").ModuleOptions} ModuleOptions */
+/** @typedef {import("../declarations/WebpackOptions").Optimization} Optimization */
 /** @typedef {import("../declarations/WebpackOptions").ResolveOptions} ResolveOptions */
 /** @typedef {import("../declarations/WebpackOptions").RuleSetCondition} RuleSetCondition */
 /** @typedef {import("../declarations/WebpackOptions").RuleSetConditionAbsolute} RuleSetConditionAbsolute */

--- a/types.d.ts
+++ b/types.d.ts
@@ -10436,6 +10436,7 @@ declare namespace exports {
 		EntryNormalized,
 		LibraryOptions,
 		ModuleOptions,
+		Optimization,
 		ResolveOptionsWebpackOptions as ResolveOptions,
 		RuleSetCondition,
 		RuleSetConditionAbsolute,


### PR DESCRIPTION
Ref: #11630

Add `Optimization` interface export in `types.d.ts`.
This is a port based on `@types/webpack`.

Unlike in #11964 now I use script to  autogenerate `types.d.ts`.
I'm not sure if it is the right place to insert export.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Bugfix.

**Did you add tests for your changes?**
**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Maybe there should be a guide how add more types to project.
