### PR TITLE
fix crash when __esModule is called with defineProperty without value

### DIFF
--- a/lib/dependencies/CommonJsExportsParserPlugin.js
+++ b/lib/dependencies/CommonJsExportsParserPlugin.js
@@ -100,7 +100,7 @@ class CommonJsExportsParserPlugin {
 		const checkNamespace = (topLevel, members, valueExpr) => {
 			if (!DynamicExports.isEnabled(parser.state)) return;
 			if (members.length > 0 && members[0] === "__esModule") {
-				if (isTruthyLiteral(valueExpr) && topLevel) {
+				if (valueExpr && isTruthyLiteral(valueExpr) && topLevel) {
 					DynamicExports.setFlagged(parser.state);
 				} else {
 					DynamicExports.setDynamic(parser.state);

--- a/test/cases/cjs-tree-shaking/esModule-getter/index.js
+++ b/test/cases/cjs-tree-shaking/esModule-getter/index.js
@@ -1,0 +1,15 @@
+import def, { named, __esModule } from "./module";
+import * as ns from "./module";
+
+it("should allow to import module with getters", () => {
+	expect(def).toBe("default");
+	expect(named).toBe("named");
+	expect(__esModule).toBe(true);
+	expect(ns.default).toBe("default");
+	expect(ns.named).toBe("named");
+	expect(ns.__esModule).toBe(true);
+	const indirect = Object(ns);
+	expect(indirect.default).toBe("default");
+	expect(indirect.named).toBe("named");
+	expect(indirect.__esModule).toBe(true);
+});

--- a/test/cases/cjs-tree-shaking/esModule-getter/module.js
+++ b/test/cases/cjs-tree-shaking/esModule-getter/module.js
@@ -1,0 +1,3 @@
+Object.defineProperty(exports, "__esModule", { get: () => true });
+Object.defineProperty(exports, "default", { get: () => "default" });
+Object.defineProperty(exports, "named", { get: () => "named" });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
