### PR TITLE
replace require.resolve'error with exitcode 1

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -47,7 +47,14 @@ const isInstalled = packageName => {
  */
 const runCli = cli => {
 	const path = require("path");
-	const pkgPath = require.resolve(`${cli.package}/package.json`);
+	let pkgPath;
+	try {
+		pkgPath = require.resolve(`${cli.package}/package.json`);
+	} catch (error) {
+		console.error(`Cannot find module ${cli.package}/package.json`);
+		process.exitCode = 1;
+		return;
+	}
 	// eslint-disable-next-line node/no-missing-require
 	const pkg = require(pkgPath);
 	// eslint-disable-next-line node/no-missing-require


### PR DESCRIPTION
If you get the error of  require.resolve, Exit via process.exitcode 1.