### PR TITLE
fix problem when HMR and different runtimes

### DIFF
--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -12,6 +12,7 @@ const Compilation = require("./Compilation");
 const HotUpdateChunk = require("./HotUpdateChunk");
 const NormalModule = require("./NormalModule");
 const RuntimeGlobals = require("./RuntimeGlobals");
+const WebpackError = require("./WebpackError");
 const ConstDependency = require("./dependencies/ConstDependency");
 const ImportMetaHotAcceptDependency = require("./dependencies/ImportMetaHotAcceptDependency");
 const ImportMetaHotDeclineDependency = require("./dependencies/ImportMetaHotDeclineDependency");
@@ -22,7 +23,7 @@ const JavascriptParser = require("./javascript/JavascriptParser");
 const {
 	evaluateToIdentifier
 } = require("./javascript/JavascriptParserHelpers");
-const { find } = require("./util/SetHelpers");
+const { find, isSubset } = require("./util/SetHelpers");
 const TupleSet = require("./util/TupleSet");
 const { compareModulesById } = require("./util/comparators");
 const {
@@ -396,7 +397,7 @@ class HotModuleReplacementPlugin {
 							chunkModuleHashes[key] = hash;
 						}
 
-						/** @type {Map<string, { updatedChunkIds: (string|number)[], removedChunkIds: (string|number)[], removedModules: Set<Module> }>} */
+						/** @type {Map<string, { updatedChunkIds: Set<string|number>, removedChunkIds: Set<string|number>, removedModules: Set<Module>, filename: string, assetInfo: AssetInfo }>} */
 						const hotUpdateMainContentByRuntime = new Map();
 						let allOldRuntime;
 						for (const key of Object.keys(records.chunkRuntime)) {
@@ -404,10 +405,22 @@ class HotModuleReplacementPlugin {
 							allOldRuntime = mergeRuntimeOwned(allOldRuntime, runtime);
 						}
 						forEachRuntime(allOldRuntime, runtime => {
+							const {
+								path: filename,
+								info: assetInfo
+							} = compilation.getPathWithInfo(
+								compilation.outputOptions.hotUpdateMainFilename,
+								{
+									hash: records.hash,
+									runtime
+								}
+							);
 							hotUpdateMainContentByRuntime.set(runtime, {
-								updatedChunkIds: [],
-								removedChunkIds: [],
-								removedModules: new Set()
+								updatedChunkIds: new Set(),
+								removedChunkIds: new Set(),
+								removedModules: new Set(),
+								filename,
+								assetInfo
 							});
 						});
 						if (hotUpdateMainContentByRuntime.size === 0) return;
@@ -477,7 +490,7 @@ class HotModuleReplacementPlugin {
 								forEachRuntime(removedFromRuntime, runtime => {
 									hotUpdateMainContentByRuntime
 										.get(runtime)
-										.removedChunkIds.push(chunkId);
+										.removedChunkIds.add(chunkId);
 								});
 								// dispose modules from the chunk in these runtimes
 								// where they are no longer in this runtime
@@ -589,20 +602,56 @@ class HotModuleReplacementPlugin {
 								forEachRuntime(newRuntime, runtime => {
 									hotUpdateMainContentByRuntime
 										.get(runtime)
-										.updatedChunkIds.push(chunkId);
+										.updatedChunkIds.add(chunkId);
 								});
 							}
 						}
 						const completelyRemovedModulesArray = Array.from(
 							completelyRemovedModules
 						);
+						const hotUpdateMainContentByFilename = new Map();
+						for (const {
+							removedChunkIds,
+							removedModules,
+							updatedChunkIds,
+							filename,
+							assetInfo
+						} of hotUpdateMainContentByRuntime.values()) {
+							const old = hotUpdateMainContentByFilename.get(filename);
+							if (
+								old &&
+								(!isSubset(old.removedChunkIds, removedChunkIds) ||
+									!isSubset(old.removedModules, removedModules) ||
+									!isSubset(old.updatedChunkIds, updatedChunkIds))
+							) {
+								compilation.warnings.push(
+									new WebpackError(`HotModuleReplacementPlugin
+The configured output.hotUpdateMainFilename doesn't lead to unique filenames per runtime and HMR update differs between runtimes.
+This might lead to incorrect runtime behavior of the applied update.
+To fix this, make sure to include [runtime] in the output.hotUpdateMainFilename option, or use the default config.`)
+								);
+								for (const chunkId of removedChunkIds)
+									old.removedChunkIds.add(chunkId);
+								for (const chunkId of removedModules)
+									old.removedModules.add(chunkId);
+								for (const chunkId of updatedChunkIds)
+									old.updatedChunkIds.add(chunkId);
+								continue;
+							}
+							hotUpdateMainContentByFilename.set(filename, {
+								removedChunkIds,
+								removedModules,
+								updatedChunkIds,
+								assetInfo
+							});
+						}
 						for (const [
-							runtime,
-							{ removedChunkIds, removedModules, updatedChunkIds }
-						] of hotUpdateMainContentByRuntime) {
+							filename,
+							{ removedChunkIds, removedModules, updatedChunkIds, assetInfo }
+						] of hotUpdateMainContentByFilename) {
 							const hotUpdateMainJson = {
-								c: updatedChunkIds,
-								r: removedChunkIds,
+								c: Array.from(updatedChunkIds),
+								r: Array.from(removedChunkIds),
 								m:
 									removedModules.size === 0
 										? completelyRemovedModulesArray
@@ -614,16 +663,6 @@ class HotModuleReplacementPlugin {
 							};
 
 							const source = new RawSource(JSON.stringify(hotUpdateMainJson));
-							const {
-								path: filename,
-								info: assetInfo
-							} = compilation.getPathWithInfo(
-								compilation.outputOptions.hotUpdateMainFilename,
-								{
-									hash: records.hash,
-									runtime
-								}
-							);
 							compilation.emitAsset(filename, source, {
 								hotModuleReplacement: true,
 								...assetInfo

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -25,12 +25,19 @@ const {
 const { find } = require("./util/SetHelpers");
 const TupleSet = require("./util/TupleSet");
 const { compareModulesById } = require("./util/comparators");
-const { getRuntimeKey, keyToRuntime } = require("./util/runtime");
+const {
+	getRuntimeKey,
+	keyToRuntime,
+	forEachRuntime,
+	mergeRuntimeOwned,
+	subtractRuntime
+} = require("./util/runtime");
 
 /** @typedef {import("./Chunk")} Chunk */
 /** @typedef {import("./Compilation").AssetInfo} AssetInfo */
 /** @typedef {import("./Compiler")} Compiler */
 /** @typedef {import("./Module")} Module */
+/** @typedef {import("./RuntimeModule")} RuntimeModule */
 
 /**
  * @typedef {Object} HMRJavascriptParserHooks
@@ -388,27 +395,46 @@ class HotModuleReplacementPlugin {
 							}
 							chunkModuleHashes[key] = hash;
 						}
-						const hotUpdateMainContent = {
-							c: [],
-							r: [],
-							m: undefined
-						};
+
+						/** @type {Map<string, { updatedChunkIds: (string|number)[], removedChunkIds: (string|number)[], removedModules: Set<Module> }>} */
+						const hotUpdateMainContentByRuntime = new Map();
+						let allOldRuntime;
+						for (const key of Object.keys(records.chunkRuntime)) {
+							const runtime = keyToRuntime(records.chunkRuntime[key]);
+							allOldRuntime = mergeRuntimeOwned(allOldRuntime, runtime);
+						}
+						forEachRuntime(allOldRuntime, runtime => {
+							hotUpdateMainContentByRuntime.set(runtime, {
+								updatedChunkIds: [],
+								removedChunkIds: [],
+								removedModules: new Set()
+							});
+						});
+						if (hotUpdateMainContentByRuntime.size === 0) return;
 
 						// Create a list of all active modules to verify which modules are removed completely
 						/** @type {Map<number|string, Module>} */
 						const allModules = new Map();
 						for (const module of compilation.modules) {
-							allModules.set(chunkGraph.getModuleId(module), module);
+							const id = chunkGraph.getModuleId(module);
+							allModules.set(id, module);
 						}
 
 						// List of completely removed modules
-						const allRemovedModules = new Set();
+						/** @type {Set<string | number>} */
+						const completelyRemovedModules = new Set();
 
 						for (const key of Object.keys(records.chunkHashs)) {
-							// Check which modules are completely removed
+							const oldRuntime = keyToRuntime(records.chunkRuntime[key]);
+							/** @type {Module[]} */
+							const remainingModules = [];
+							// Check which modules are removed
 							for (const id of records.chunkModuleIds[key]) {
-								if (!allModules.has(id)) {
-									allRemovedModules.add(id);
+								const module = allModules.get(id);
+								if (module === undefined) {
+									completelyRemovedModules.add(id);
+								} else {
+									remainingModules.push(module);
 								}
 							}
 
@@ -417,6 +443,7 @@ class HotModuleReplacementPlugin {
 							let newRuntimeModules;
 							let newFullHashModules;
 							let newRuntime;
+							let removedFromRuntime;
 							const currentChunk = find(
 								compilation.chunks,
 								chunk => `${chunk.id}` === key
@@ -438,18 +465,61 @@ class HotModuleReplacementPlugin {
 									Array.from(fullHashModules).filter(module =>
 										updatedModules.has(module, currentChunk)
 									);
+								removedFromRuntime = subtractRuntime(oldRuntime, newRuntime);
 							} else {
+								// chunk has completely removed
 								chunkId = `${+key}` === key ? +key : key;
-								hotUpdateMainContent.r.push(chunkId);
-								const runtime = keyToRuntime(records.chunkRuntime[key]);
-								for (const id of records.chunkModuleIds[key]) {
-									const module = allModules.get(id);
-									if (!module) continue;
-									const hash = chunkGraph.getModuleHash(module, runtime);
+								removedFromRuntime = oldRuntime;
+								newRuntime = oldRuntime;
+							}
+							if (removedFromRuntime) {
+								// chunk was removed from some runtimes
+								forEachRuntime(removedFromRuntime, runtime => {
+									hotUpdateMainContentByRuntime
+										.get(runtime)
+										.removedChunkIds.push(chunkId);
+								});
+								// dispose modules from the chunk in these runtimes
+								// where they are no longer in this runtime
+								for (const module of remainingModules) {
 									const moduleKey = `${key}|${module.identifier()}`;
-									if (hash !== records.chunkModuleHashes[moduleKey]) {
-										newModules = newModules || [];
-										newModules.push(module);
+									const oldHash = records.chunkModuleHashes[moduleKey];
+									const runtimes = chunkGraph.getModuleRuntimes(module);
+									if (oldRuntime === newRuntime && runtimes.has(newRuntime)) {
+										// Module is still in the same runtime combination
+										const hash = chunkGraph.getModuleHash(module, newRuntime);
+										if (hash !== oldHash) {
+											if (module.type === "runtime") {
+												newRuntimeModules = newRuntimeModules || [];
+												newRuntimeModules.push(
+													/** @type {RuntimeModule} */ (module)
+												);
+											} else {
+												newModules = newModules || [];
+												newModules.push(module);
+											}
+										}
+									} else {
+										// module is no longer in this runtime combination
+										// We (incorrectly) assume that it's not in an overlapping runtime combination
+										// and dispose it from the main runtimes the chunk was removed from
+										forEachRuntime(removedFromRuntime, runtime => {
+											// If the module is still used in this runtime, do not dispose it
+											// This could create a bad runtime state where the module is still loaded,
+											// but no chunk which contains it. This means we don't receive further HMR updates
+											// to this module and that's bad.
+											// TODO force load one of the chunks which contains the module
+											for (const moduleRuntime of runtimes) {
+												if (typeof moduleRuntime === "string") {
+													if (moduleRuntime === runtime) return;
+												} else if (moduleRuntime !== undefined) {
+													if (moduleRuntime.has(runtime)) return;
+												}
+											}
+											hotUpdateMainContentByRuntime
+												.get(runtime)
+												.removedModules.add(module);
+										});
 									}
 								}
 							}
@@ -516,24 +586,49 @@ class HotModuleReplacementPlugin {
 										compilation.hooks.chunkAsset.call(currentChunk, filename);
 									}
 								}
-								hotUpdateMainContent.c.push(chunkId);
+								forEachRuntime(newRuntime, runtime => {
+									hotUpdateMainContentByRuntime
+										.get(runtime)
+										.updatedChunkIds.push(chunkId);
+								});
 							}
 						}
-						hotUpdateMainContent.m = Array.from(allRemovedModules);
-						const source = new RawSource(JSON.stringify(hotUpdateMainContent));
-						const {
-							path: filename,
-							info: assetInfo
-						} = compilation.getPathWithInfo(
-							compilation.outputOptions.hotUpdateMainFilename,
-							{
-								hash: records.hash
-							}
+						const completelyRemovedModulesArray = Array.from(
+							completelyRemovedModules
 						);
-						compilation.emitAsset(filename, source, {
-							hotModuleReplacement: true,
-							...assetInfo
-						});
+						for (const [
+							runtime,
+							{ removedChunkIds, removedModules, updatedChunkIds }
+						] of hotUpdateMainContentByRuntime) {
+							const hotUpdateMainJson = {
+								c: updatedChunkIds,
+								r: removedChunkIds,
+								m:
+									removedModules.size === 0
+										? completelyRemovedModulesArray
+										: completelyRemovedModulesArray.concat(
+												Array.from(removedModules, m =>
+													chunkGraph.getModuleId(m)
+												)
+										  )
+							};
+
+							const source = new RawSource(JSON.stringify(hotUpdateMainJson));
+							const {
+								path: filename,
+								info: assetInfo
+							} = compilation.getPathWithInfo(
+								compilation.outputOptions.hotUpdateMainFilename,
+								{
+									hash: records.hash,
+									runtime
+								}
+							);
+							compilation.emitAsset(filename, source, {
+								hotModuleReplacement: true,
+								...assetInfo
+							});
+						}
 					}
 				);
 

--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -274,6 +274,14 @@ const replacePathVariables = (path, data, assetInfo) => {
 	if (data.url) {
 		replacements.set("url", replacer(data.url));
 	}
+	if (typeof data.runtime === "string") {
+		replacements.set(
+			"runtime",
+			replacer(() => prepareId(data.runtime))
+		);
+	} else {
+		replacements.set("runtime", replacer("_"));
+	}
 
 	if (typeof path === "function") {
 		path = path(data, assetInfo);

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -642,7 +642,7 @@ const applyOutputDefaults = (
 	F(output, "pathinfo", () => development);
 	D(output, "sourceMapFilename", "[file].map[query]");
 	D(output, "hotUpdateChunkFilename", "[id].[fullhash].hot-update.js");
-	D(output, "hotUpdateMainFilename", "[fullhash].hot-update.json");
+	D(output, "hotUpdateMainFilename", "[runtime].[fullhash].hot-update.json");
 	D(output, "crossOriginLoading", false);
 	F(output, "scriptType", () => (output.module ? "module" : false));
 	D(

--- a/lib/runtime/GetMainFilenameRuntimeModule.js
+++ b/lib/runtime/GetMainFilenameRuntimeModule.js
@@ -26,12 +26,14 @@ class GetMainFilenameRuntimeModule extends RuntimeModule {
 	 * @returns {string} runtime code
 	 */
 	generate() {
-		const { global, filename, compilation } = this;
+		const { global, filename, compilation, chunk } = this;
 		const { runtimeTemplate } = compilation;
 		const url = compilation.getPath(JSON.stringify(filename), {
 			hash: `" + ${RuntimeGlobals.getFullHash}() + "`,
 			hashWithLength: length =>
-				`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`
+				`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,
+			chunk,
+			runtime: chunk.runtime
 		});
 		return Template.asString([
 			`${global} = ${runtimeTemplate.returningFunction(url)};`

--- a/lib/util/runtime.js
+++ b/lib/util/runtime.js
@@ -485,6 +485,10 @@ class RuntimeSpecSet {
 		this._map.set(getRuntimeKey(runtime), runtime);
 	}
 
+	has(runtime) {
+		return this._map.has(getRuntimeKey(runtime));
+	}
+
 	[Symbol.iterator]() {
 		return this._map.values();
 	}

--- a/test/ConfigTestCases.template.js
+++ b/test/ConfigTestCases.template.js
@@ -322,54 +322,9 @@ const describeCases = config => {
 													moduleScope.window = globalContext;
 													moduleScope.self = globalContext;
 													moduleScope.URL = URL;
-													moduleScope.Worker = class Worker {
-														constructor(url, options) {
-															expect(url).toBeInstanceOf(URL);
-															expect(url.origin).toBe("https://test.cases");
-															expect(url.pathname.startsWith("/path/")).toBe(
-																true
-															);
-															const file = url.pathname.slice(6);
-															const workerBootstrap = `
-															const { parentPort } = require("worker_threads");
-															const { URL } = require("url");
-															const path = require("path");
-															global.self = global;
-															self.URL = URL;
-															self.importScripts = url => {
-																require(path.resolve(${JSON.stringify(outputDirectory)}, \`./\${url}\`));
-															};
-															parentPort.on("message", data => {
-																if(self.onmessage) self.onmessage({
-																	data
-																});
-															});
-															self.postMessage = data => {
-																parentPort.postMessage(data);
-															};
-															require(${JSON.stringify(path.resolve(outputDirectory, file))});
-															`;
-															// eslint-disable-next-line node/no-unsupported-features/node-builtins
-															this.worker = new (require("worker_threads").Worker)(
-																workerBootstrap,
-																{
-																	eval: true
-																}
-															);
-														}
-
-														set onmessage(value) {
-															this.worker.on("message", data => {
-																value({
-																	data
-																});
-															});
-														}
-
-														postMessage(data) {
-															this.worker.postMessage(data);
-														}
-													};
+													moduleScope.Worker = require("./helpers/createFakeWorker")(
+														{ outputDirectory }
+													);
 													runInNewContext = true;
 												}
 												if (testConfig.moduleScope) {

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -306,7 +306,7 @@ describe("Defaults", () => {
 		    "hashSalt": undefined,
 		    "hotUpdateChunkFilename": "[id].[fullhash].hot-update.js",
 		    "hotUpdateGlobal": "webpackHotUpdatewebpack",
-		    "hotUpdateMainFilename": "[fullhash].hot-update.json",
+		    "hotUpdateMainFilename": "[runtime].[fullhash].hot-update.json",
 		    "iife": true,
 		    "importFunctionName": "import",
 		    "importMetaName": "import.meta",

--- a/test/HotModuleReplacementPlugin.test.js
+++ b/test/HotModuleReplacementPlugin.test.js
@@ -152,7 +152,7 @@ describe("HotModuleReplacementPlugin", () => {
 					fs.writeFileSync(statsFile3, stats.toString());
 					const result = JSON.parse(
 						fs.readFileSync(
-							path.join(outputPath, `${hash}.hot-update.json`),
+							path.join(outputPath, `0.${hash}.hot-update.json`),
 							"utf-8"
 						)
 					)["c"];

--- a/test/HotTestCases.template.js
+++ b/test/HotTestCases.template.js
@@ -27,15 +27,18 @@ const describeCases = config => {
 		categories.forEach(category => {
 			describe(category.name, () => {
 				category.tests.forEach(testName => {
+					const testDirectory = path.join(casesPath, category.name, testName);
+					const filterPath = path.join(testDirectory, "test.filter.js");
+					if (fs.existsSync(filterPath) && !require(filterPath)()) {
+						describe.skip(testName, () => {
+							it("filtered", () => {});
+						});
+						return;
+					}
 					describe(testName, () => {
 						it(
 							testName + " should compile",
 							done => {
-								const testDirectory = path.join(
-									casesPath,
-									category.name,
-									testName
-								);
 								const outputDirectory = path.join(
 									__dirname,
 									"js",

--- a/test/HotTestCases.template.js
+++ b/test/HotTestCases.template.js
@@ -67,7 +67,7 @@ const describeCases = config => {
 								if (options.output.pathinfo === undefined)
 									options.output.pathinfo = true;
 								if (options.output.publicPath === undefined)
-									options.output.publicPath = "";
+									options.output.publicPath = "https://test.cases/path/";
 								if (options.output.library === undefined)
 									options.output.library = { type: "commonjs2" };
 								if (!options.optimization) options.optimization = {};
@@ -119,16 +119,38 @@ const describeCases = config => {
 										return;
 									}
 
+									const urlToPath = url => {
+										if (url.startsWith("https://test.cases/path/"))
+											url = url.slice(24);
+										return path.resolve(outputDirectory, `./${url}`);
+									};
+									const urlToRelativePath = url => {
+										if (url.startsWith("https://test.cases/path/"))
+											url = url.slice(24);
+										return `./${url}`;
+									};
 									const window = {
-										fetch: url => {
-											return Promise.resolve({
-												ok: true,
-												json() {
-													return Promise.resolve(
-														require(path.resolve(outputDirectory, url))
-													);
+										fetch: async url => {
+											try {
+												const buffer = await new Promise((resolve, reject) =>
+													fs.readFile(urlToPath(url), (err, b) =>
+														err ? reject(err) : resolve(b)
+													)
+												);
+												return {
+													status: 200,
+													ok: true,
+													json: async () => JSON.parse(buffer.toString("utf-8"))
+												};
+											} catch (err) {
+												if (err.code === "ENOENT") {
+													return {
+														status: 404,
+														ok: false
+													};
 												}
-											});
+												throw err;
+											}
 										},
 										importScripts: url => {
 											_require("./" + url);
@@ -153,7 +175,7 @@ const describeCases = config => {
 													if (element._type === "script") {
 														// run it
 														Promise.resolve().then(() => {
-															_require("./" + element.src);
+															_require(urlToRelativePath(element.src));
 														});
 													}
 												}
@@ -164,6 +186,9 @@ const describeCases = config => {
 												throw new Error("Not supported");
 											}
 										},
+										Worker: require("./helpers/createFakeWorker")({
+											outputDirectory
+										}),
 										location: {
 											href: "https://test.cases/path/index.html",
 											origin: "https://test.cases",
@@ -215,7 +240,7 @@ const describeCases = config => {
 												return JSON.parse(fs.readFileSync(p, "utf-8"));
 											} else {
 												const fn = vm.runInThisContext(
-													"(function(require, module, exports, __dirname, __filename, it, beforeEach, afterEach, expect, self, window, fetch, document, importScripts, NEXT, STATS) {" +
+													"(function(require, module, exports, __dirname, __filename, it, beforeEach, afterEach, expect, self, window, fetch, document, importScripts, Worker, NEXT, STATS) {" +
 														"global.expect = expect;" +
 														'function nsObj(m) { Object.defineProperty(m, Symbol.toStringTag, { value: "Module" }); return m; }' +
 														fs.readFileSync(p, "utf-8") +
@@ -241,6 +266,7 @@ const describeCases = config => {
 													window.fetch,
 													window.document,
 													window.importScripts,
+													window.Worker,
 													_next,
 													jsonStats
 												);

--- a/test/helpers/createFakeWorker.js
+++ b/test/helpers/createFakeWorker.js
@@ -1,0 +1,73 @@
+const path = require("path");
+
+module.exports = ({ outputDirectory }) =>
+	class Worker {
+		constructor(url, options) {
+			expect(url).toBeInstanceOf(URL);
+			expect(url.origin).toBe("https://test.cases");
+			expect(url.pathname.startsWith("/path/")).toBe(true);
+			const file = url.pathname.slice(6);
+			const workerBootstrap = `
+const { parentPort } = require("worker_threads");
+const { URL } = require("url");
+const path = require("path");
+const fs = require("fs");
+global.self = global;
+self.URL = URL;
+const urlToPath = url => {
+	if(url.startsWith("https://test.cases/path/")) url = url.slice(24);
+	return path.resolve(${JSON.stringify(outputDirectory)}, \`./\${url}\`);
+};
+self.importScripts = url => {
+	require(urlToPath(url));
+};
+self.fetch = async url => {
+	try {
+		const buffer = await new Promise((resolve, reject) =>
+			fs.readFile(urlToPath(url), (err, b) =>
+				err ? reject(err) : resolve(b)
+			)
+		);
+		return {
+			status: 200,
+			ok: true,
+			json: async () => JSON.parse(buffer.toString("utf-8"))
+		};
+	} catch(err) {
+		if(err.code === "ENOENT") {
+			return {
+				status: 404,
+				ok: false
+			};
+		}
+		throw err;
+	}
+};
+parentPort.on("message", data => {
+	if(self.onmessage) self.onmessage({
+		data
+	});
+});
+self.postMessage = data => {
+	parentPort.postMessage(data);
+};
+require(${JSON.stringify(path.resolve(outputDirectory, file))});
+`;
+			// eslint-disable-next-line node/no-unsupported-features/node-builtins
+			this.worker = new (require("worker_threads").Worker)(workerBootstrap, {
+				eval: true
+			});
+		}
+
+		set onmessage(value) {
+			this.worker.on("message", data => {
+				value({
+					data
+				});
+			});
+		}
+
+		postMessage(data) {
+			this.worker.postMessage(data);
+		}
+	};

--- a/test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/chunk1.js
+++ b/test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/chunk1.js
@@ -1,0 +1,2 @@
+export * from "./shared";
+import.meta.webpackHot.accept("./shared");

--- a/test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/chunk2.js
+++ b/test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/chunk2.js
@@ -1,0 +1,2 @@
+export * from "./shared";
+import.meta.webpackHot.accept("./shared");

--- a/test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/index.js
+++ b/test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/index.js
@@ -1,6 +1,6 @@
 import module from "./module";
 
-it("should not dispose shared modules when a chunk is removed", done => {
+it("should not dispose shared modules when a chunk from a different runtime is removed", done => {
 	import("./chunk1").then(chunk1 => {
 		import.meta.webpackHot.accept("./module", async () => {
 			expect(module).toBe(42);

--- a/test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/module.js
+++ b/test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/module.js
@@ -1,0 +1,3 @@
+export default () => new Worker(new URL("./chunk2", import.meta.url));
+---
+export default 42;

--- a/test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/shared.js
+++ b/test/hotCases/disposing/remove-chunk-with-shared-in-other-runtime/shared.js
@@ -1,0 +1,5 @@
+export let active = true;
+
+import.meta.webpackHot.dispose(() => {
+	active = false;
+});

--- a/test/hotCases/disposing/runtime-independent-filename/chunk1.js
+++ b/test/hotCases/disposing/runtime-independent-filename/chunk1.js
@@ -1,0 +1,2 @@
+export * from "./shared";
+import.meta.webpackHot.accept("./shared");

--- a/test/hotCases/disposing/runtime-independent-filename/chunk2.js
+++ b/test/hotCases/disposing/runtime-independent-filename/chunk2.js
@@ -1,0 +1,2 @@
+export * from "./shared";
+import.meta.webpackHot.accept("./shared");

--- a/test/hotCases/disposing/runtime-independent-filename/index.js
+++ b/test/hotCases/disposing/runtime-independent-filename/index.js
@@ -1,0 +1,14 @@
+import module from "./module";
+
+it("should not dispose shared modules when a chunk from a different runtime is removed", done => {
+	import("./chunk1").then(chunk1 => {
+		import.meta.webpackHot.accept("./module", async () => {
+			expect(module).toBe(42);
+			expect(chunk1).toMatchObject({
+				active: false // This get incorrectly disposed, due to the runtime-independent filename
+			});
+			done();
+		});
+		NEXT(require("../../update")(done));
+	}, done);
+});

--- a/test/hotCases/disposing/runtime-independent-filename/module.js
+++ b/test/hotCases/disposing/runtime-independent-filename/module.js
@@ -1,0 +1,3 @@
+export default () => new Worker(new URL("./chunk2", import.meta.url));
+---
+export default 42;

--- a/test/hotCases/disposing/runtime-independent-filename/shared.js
+++ b/test/hotCases/disposing/runtime-independent-filename/shared.js
@@ -1,0 +1,5 @@
+export let active = true;
+
+import.meta.webpackHot.dispose(() => {
+	active = false;
+});

--- a/test/hotCases/disposing/runtime-independent-filename/warnings1.js
+++ b/test/hotCases/disposing/runtime-independent-filename/warnings1.js
@@ -1,0 +1,5 @@
+module.exports = [
+	[
+		/The configured output\.hotUpdateMainFilename doesn't lead to unique filenames per runtime/
+	]
+];

--- a/test/hotCases/disposing/runtime-independent-filename/webpack.config.js
+++ b/test/hotCases/disposing/runtime-independent-filename/webpack.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		hotUpdateMainFilename: "[hash].main-filename.json"
+	}
+};

--- a/test/hotCases/worker/update-in-worker/index.js
+++ b/test/hotCases/worker/update-in-worker/index.js
@@ -1,0 +1,16 @@
+it("should support hot module replacement in WebWorkers", done => {
+	const worker = new Worker(new URL("worker.js", import.meta.url));
+	worker.onmessage = ({ data: msg }) => {
+		switch (msg) {
+			case "next":
+				NEXT(() => {
+					worker.postMessage("next");
+				});
+				break;
+			case "done":
+				done();
+				break;
+		}
+	};
+	worker.postMessage("test");
+});

--- a/test/hotCases/worker/update-in-worker/module.js
+++ b/test/hotCases/worker/update-in-worker/module.js
@@ -1,0 +1,7 @@
+export default 1;
+---
+export default 2;
+---
+export default 3;
+---
+export default 42;

--- a/test/hotCases/worker/update-in-worker/test.filter.js
+++ b/test/hotCases/worker/update-in-worker/test.filter.js
@@ -1,0 +1,5 @@
+var supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = function (config) {
+	return supportsWorker();
+};

--- a/test/hotCases/worker/update-in-worker/worker.js
+++ b/test/hotCases/worker/update-in-worker/worker.js
@@ -1,0 +1,24 @@
+import module from "./module";
+
+let counter = 1;
+
+self.onmessage = async ({ data: msg }) => {
+	switch (msg) {
+		case "next":
+			await import.meta.webpackHot.check(true);
+		case "test":
+			if (module === 42 && counter === 4) {
+				self.postMessage("done");
+				break;
+			}
+			if (module !== counter)
+				throw new Error(`module (${module}) should be ${counter}`);
+			counter++;
+			self.postMessage("next");
+			break;
+		default:
+			throw new Error("Unexpected message");
+	}
+};
+
+import.meta.webpackHot.accept("./module");

--- a/types.d.ts
+++ b/types.d.ts
@@ -8060,6 +8060,7 @@ declare abstract class RuntimeSpecMap<T> {
 }
 declare abstract class RuntimeSpecSet {
 	add(runtime?: any): void;
+	has(runtime?: any): boolean;
 	[Symbol.iterator](): IterableIterator<string | SortableSet<string>>;
 	readonly size: number;
 }


### PR DESCRIPTION
allow HMR to work in WebWorkers too

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no. There is a new warning when using a bad config which hints you to change your config to avoid the bug.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
* `[runtime]` can be used a placeholder in `output.hotUpdateMainFilename`.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
