### PR TITLE
fix: add Stats toJson typings

### DIFF
--- a/lib/MultiStats.js
+++ b/lib/MultiStats.js
@@ -70,8 +70,13 @@ class MultiStats {
 		};
 	}
 
+	/**
+	 * @param {*} options options
+	 * @returns {import("./Stats").ToJsonOutput} JSON output
+	 */
 	toJson(options) {
 		options = this._createChildOptions(options, { forToString: false });
+		/** @type import("./Stats").ToJsonOutput */
 		const obj = {};
 		obj.children = this.stats.map((stat, idx) => {
 			const obj = stat.toJson(options.children[idx]);

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -7,6 +7,25 @@
 
 /** @typedef {import("./Compilation")} Compilation */
 
+/**
+ * @typedef {Object} ToJsonOutput
+ * @property {string=} version
+ * @property {string=} name
+ * @property {string=} hash
+ * @property {number=} time
+ * @property {number=} filteredModules
+ * @property {string=} outputPath
+ * @property {Record<string, string[]>=} assetsByChunkName
+ * @property {import("./Compilation").Asset[]=} assets
+ * @property {import("./Chunk")[]=} chunks
+ * @property {import("./Module")[]=} modules
+ * @property {import("./WebpackError")[]=} errors
+ * @property {number=} errorsCount
+ * @property {import("./WebpackError")[]=} warnings
+ * @property {number=} warningsCount
+ * @property {ToJsonOutput[]=} children
+ */
+
 class Stats {
 	/**
 	 * @param {Compilation} compilation webpack compilation
@@ -47,6 +66,10 @@ class Stats {
 		);
 	}
 
+	/**
+	 * @param {(boolean|string|import("../declarations/WebpackOptions").StatsOptions)=} options stats options
+	 * @returns {ToJsonOutput} json output
+	 */
 	toJson(options) {
 		options = this.compilation.createStatsOptions(options, {
 			forToString: false

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -61,11 +61,11 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @typedef {Object} UsualOptions
  * @property {string} context
  * @property {RequestShortener} requestShortener
- * @property {string} chunksSort
- * @property {string} modulesSort
- * @property {string} chunkModulesSort
- * @property {string} nestedModulesSort
- * @property {string} assetsSort
+ * @property {SortingField} chunksSort
+ * @property {SortingField} modulesSort
+ * @property {SortingField} chunkModulesSort
+ * @property {SortingField} nestedModulesSort
+ * @property {SortingField} assetsSort
  * @property {boolean} ids
  * @property {boolean} cachedAssets
  * @property {boolean} groupAssetsByEmitStatus
@@ -116,6 +116,48 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @property {ExtractorsByOption<{ origin: Module, module: Module }>} moduleTraceItem
  * @property {ExtractorsByOption<Dependency>} moduleTraceDependency
  */
+
+/**
+ * @typedef {
+	"id" |
+	"!id" |
+	"name" |
+	"!name" |
+	"size" |
+	"!size" |
+	"chunks" |
+	"!chunks" |
+	"errors" |
+	"!errors" |
+	"warnings" |
+	"!warnings" |
+	"failed" |
+	"!failed" |
+	"cacheable" |
+	"!cacheable" |
+	"built" |
+	"!built" |
+	"prefetched" |
+	"!prefetched" |
+	"optional" |
+	"!optional" |
+	"identifier" |
+	"!identifier" |
+	"index" |
+	"!index" |
+	"index2" |
+	"!index2" |
+	"profile" |
+	"!profile" |
+	"issuer" |
+	"!issuer" |
+	"issuerId" |
+	"!issuerId" |
+	"issuerName" |
+	"!issuerName" |
+	"issuerPath" |
+	"!issuerPath" } SortingField
+*/
 
 /**
  * @template T
@@ -1777,7 +1819,7 @@ const sortOrderRegular = field => {
 };
 
 /**
- * @param {string} field field name
+ * @param {SortingField} field field name
  * @returns {function(Object, Object): number} comparators
  */
 const sortByField = field => {
@@ -1807,6 +1849,7 @@ const sortByField = field => {
 };
 
 const ASSET_SORTERS = {
+	/** @type {(comparators: Function[], context: UsualContext, options: UsualOptions) => void} */
 	assetsSort: (comparators, context, { assetsSort }) => {
 		comparators.push(sortByField(assetsSort));
 	},

--- a/types.d.ts
+++ b/types.d.ts
@@ -5189,17 +5189,7 @@ declare abstract class MultiStats {
 	readonly hash: string;
 	hasErrors(): boolean;
 	hasWarnings(): boolean;
-	toJson(
-		options?: any
-	): {
-		children: any[];
-		version: any;
-		hash: string;
-		errors: any[];
-		warnings: any[];
-		errorsCount: number;
-		warningsCount: number;
-	};
+	toJson(options?: any): ToJsonOutput;
 	toString(options?: any): string;
 }
 declare abstract class MultiWatching {
@@ -8535,7 +8525,7 @@ declare class Stats {
 	readonly endTime: any;
 	hasWarnings(): boolean;
 	hasErrors(): boolean;
-	toJson(options?: any): any;
+	toJson(options?: string | boolean | StatsOptions): ToJsonOutput;
 	toString(options?: any): string;
 }
 declare abstract class StatsFactory {
@@ -9015,6 +9005,23 @@ declare interface TimestampAndHash {
 	timestamp?: number;
 	timestampHash?: string;
 	hash: string;
+}
+declare interface ToJsonOutput {
+	version?: string;
+	name?: string;
+	hash?: string;
+	time?: number;
+	filteredModules?: number;
+	outputPath?: string;
+	assetsByChunkName?: Record<string, string[]>;
+	assets?: Asset[];
+	chunks?: Chunk[];
+	modules?: Module[];
+	errors?: WebpackError[];
+	errorsCount?: number;
+	warnings?: WebpackError[];
+	warningsCount?: number;
+	children?: ToJsonOutput[];
 }
 declare const UNDEFINED_MARKER: unique symbol;
 declare interface UpdateHashContextDependency {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Add typings for `Stats['toJson']` method, and typings for the sort field.

Resolving a part of https://github.com/webpack/webpack/issues/11630.

**Did you add tests for your changes?**

No tests added as this is simply type definitions.

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

In `@types/webpack@^4` we would originally get the structure of the JSON output as `webpack.Stats.ToJsonOutput`.
In version 5, we would now do `ReturnType<webpack.Stats['toJson']>` as this appears to be the present limitation of using `jsdoc` to document typings with the present webpack approach.