### PR TITLE
feat: nonManagedPaths option to allow better yarn workspace integration #12112

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -845,6 +845,10 @@ export interface FileCacheOptions {
 	 */
 	name?: string;
 	/**
+	 * List of paths that are not managed by a package manager and can not be trusted to be modified otherwise.
+	 */
+	nonManagedPaths?: string[];
+	/**
 	 * When to store data to the filesystem. (pack: Store data when compiler is idle in a single file).
 	 */
 	store?: "pack";
@@ -1973,6 +1977,10 @@ export interface SnapshotOptions {
 		 */
 		timestamp?: boolean;
 	};
+	/**
+	 * List of paths that are not managed by a package manager and can not be trusted to be modified otherwise.
+	 */
+	nonManagedPaths?: string[];
 	/**
 	 * Options for snapshotting dependencies of request resolving to determine if requests need to be re-resolved.
 	 */

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -721,6 +721,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		this.inputFileSystem = compiler.inputFileSystem;
 		this.fileSystemInfo = new FileSystemInfo(this.inputFileSystem, {
 			managedPaths: compiler.managedPaths,
+			nonManagedPaths: compiler.nonManagedPaths,
 			immutablePaths: compiler.immutablePaths,
 			logger: this.getLogger("webpack.FileSystemInfo")
 		});

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -215,6 +215,8 @@ class Compiler {
 		/** @type {Set<string>} */
 		this.managedPaths = new Set();
 		/** @type {Set<string>} */
+		this.nonManagedPaths = new Set();
+		/** @type {Set<string>} */
 		this.immutablePaths = new Set();
 
 		/** @type {Set<string>} */

--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -750,10 +750,19 @@ class FileSystemInfo {
 	 * @param {InputFileSystem} fs file system
 	 * @param {Object} options options
 	 * @param {Iterable<string>=} options.managedPaths paths that are only managed by a package manager
+	 * @param {Iterable<string>=} options.nonManagedPaths paths that are only managed by a package manager
 	 * @param {Iterable<string>=} options.immutablePaths paths that are immutable
 	 * @param {Logger=} options.logger logger used to log invalid snapshots
 	 */
-	constructor(fs, { managedPaths = [], immutablePaths = [], logger } = {}) {
+	constructor(
+		fs,
+		{
+			managedPaths = [],
+			nonManagedPaths = [],
+			immutablePaths = [],
+			logger
+		} = {}
+	) {
 		this.fs = fs;
 		this.logger = logger;
 		this._remainingLogs = logger ? 40 : 0;
@@ -870,6 +879,10 @@ class FileSystemInfo {
 		});
 		this.managedPaths = Array.from(managedPaths);
 		this.managedPathsWithSlash = this.managedPaths.map(p =>
+			join(fs, p, "_").slice(0, -1)
+		);
+		this.nonManagedPaths = Array.from(nonManagedPaths);
+		this.nonManagedPathsWithSlash = this.managedPaths.map(p =>
 			join(fs, p, "_").slice(0, -1)
 		);
 		this.immutablePaths = Array.from(immutablePaths);
@@ -1560,6 +1573,11 @@ class FileSystemInfo {
 			}
 		};
 		const checkManaged = (path, managedSet) => {
+			for (const nonManagedPath of this.nonManagedPathsWithSlash) {
+				if (path.startsWith(nonManagedPath)) {
+					return false;
+				}
+			}
 			for (const immutablePath of this.immutablePathsWithSlash) {
 				if (path.startsWith(immutablePath)) {
 					managedSet.add(path);
@@ -2425,24 +2443,37 @@ class FileSystemInfo {
 					this.fs.stat(child, (err, stat) => {
 						if (err) return callback(err);
 
-						for (const immutablePath of this.immutablePathsWithSlash) {
-							if (path.startsWith(immutablePath)) {
-								// ignore any immutable path for timestamping
-								return callback(null, null);
+						let isNonManagedPath = false;
+						for (const nonManagedPath of this.nonManagedPathsWithSlash) {
+							if (path.startsWith(nonManagedPath)) {
+								isNonManagedPath = true;
+								break;
 							}
 						}
-						for (const managedPath of this.managedPathsWithSlash) {
-							if (path.startsWith(managedPath)) {
-								const managedItem = getManagedItem(managedPath, child);
-								if (managedItem) {
-									// construct timestampHash from managed info
-									return this.managedItemQueue.add(managedItem, (err, info) => {
-										if (err) return callback(err);
-										return callback(null, {
-											safeTime: 0,
-											timestampHash: info
-										});
-									});
+
+						if (!isNonManagedPath) {
+							for (const immutablePath of this.immutablePathsWithSlash) {
+								if (path.startsWith(immutablePath)) {
+									// ignore any immutable path for timestamping
+									return callback(null, null);
+								}
+							}
+							for (const managedPath of this.managedPathsWithSlash) {
+								if (path.startsWith(managedPath)) {
+									const managedItem = getManagedItem(managedPath, child);
+									if (managedItem) {
+										// construct timestampHash from managed info
+										return this.managedItemQueue.add(
+											managedItem,
+											(err, info) => {
+												if (err) return callback(err);
+												return callback(null, {
+													safeTime: 0,
+													timestampHash: info
+												});
+											}
+										);
+									}
 								}
 							}
 						}
@@ -2520,21 +2551,34 @@ class FileSystemInfo {
 					this.fs.stat(child, (err, stat) => {
 						if (err) return callback(err);
 
-						for (const immutablePath of this.immutablePathsWithSlash) {
-							if (path.startsWith(immutablePath)) {
-								// ignore any immutable path for hashing
-								return callback(null, "");
+						let isNonManagedPath = false;
+						for (const nonManagedPath of this.nonManagedPathsWithSlash) {
+							if (path.startsWith(nonManagedPath)) {
+								isNonManagedPath = true;
+								break;
 							}
 						}
-						for (const managedPath of this.managedPathsWithSlash) {
-							if (path.startsWith(managedPath)) {
-								const managedItem = getManagedItem(managedPath, child);
-								if (managedItem) {
-									// construct hash from managed info
-									return this.managedItemQueue.add(managedItem, (err, info) => {
-										if (err) return callback(err);
-										callback(null, info || "");
-									});
+
+						if (!isNonManagedPath) {
+							for (const immutablePath of this.immutablePathsWithSlash) {
+								if (path.startsWith(immutablePath)) {
+									// ignore any immutable path for hashing
+									return callback(null, "");
+								}
+							}
+							for (const managedPath of this.managedPathsWithSlash) {
+								if (path.startsWith(managedPath)) {
+									const managedItem = getManagedItem(managedPath, child);
+									if (managedItem) {
+										// construct hash from managed info
+										return this.managedItemQueue.add(
+											managedItem,
+											(err, info) => {
+												if (err) return callback(err);
+												callback(null, info || "");
+											}
+										);
+									}
 								}
 							}
 						}

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -481,6 +481,7 @@ class WebpackOptionsApply extends OptionsApply {
 		const AddManagedPathsPlugin = require("./cache/AddManagedPathsPlugin");
 		new AddManagedPathsPlugin(
 			options.snapshot.managedPaths,
+			options.snapshot.nonManagedPaths,
 			options.snapshot.immutablePaths
 		).apply(compiler);
 

--- a/lib/cache/AddManagedPathsPlugin.js
+++ b/lib/cache/AddManagedPathsPlugin.js
@@ -10,10 +10,12 @@
 class AddManagedPathsPlugin {
 	/**
 	 * @param {Iterable<string>} managedPaths list of managed paths
+	 * @param {Iterable<string>} nonManagedPaths list of managed paths
 	 * @param {Iterable<string>} immutablePaths list of immutable paths
 	 */
-	constructor(managedPaths, immutablePaths) {
+	constructor(managedPaths, nonManagedPaths, immutablePaths) {
 		this.managedPaths = new Set(managedPaths);
+		this.nonManagedPaths = new Set(nonManagedPaths);
 		this.immutablePaths = new Set(immutablePaths);
 	}
 
@@ -25,6 +27,9 @@ class AddManagedPathsPlugin {
 	apply(compiler) {
 		for (const managedPath of this.managedPaths) {
 			compiler.managedPaths.add(managedPath);
+		}
+		for (const nonManagedPath of this.nonManagedPaths) {
+			compiler.nonManagedPaths.add(nonManagedPath);
 		}
 		for (const immutablePath of this.immutablePaths) {
 			compiler.immutablePaths.add(immutablePath);

--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -736,6 +736,7 @@ class PackFileCacheStrategy {
 		this.fileSerializer = createFileSerializer(fs);
 		this.fileSystemInfo = new FileSystemInfo(fs, {
 			managedPaths: snapshot.managedPaths,
+			nonManagedPaths: snapshot.nonManagedPaths,
 			immutablePaths: snapshot.immutablePaths,
 			logger: logger.getChildLogger("webpack.FileSystemInfo")
 		});

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -312,6 +312,7 @@ const applySnapshotDefaults = (snapshot, { production }) => {
 		}
 		return [];
 	});
+	A(snapshot, "nonManagedPaths", () => []);
 	A(snapshot, "immutablePaths", () => {
 		if (process.versions.pnp === "1") {
 			const match = /^(.+?[\\/]v4)[\\/]npm-watchpack-[^\\/]+-[\da-f]{40}[\\/]node_modules[\\/]/.exec(

--- a/lib/config/normalization.js
+++ b/lib/config/normalization.js
@@ -366,7 +366,10 @@ const getNormalizedWebpackOptions = config => {
 				hash: module.hash
 			})),
 			immutablePaths: optionalNestedArray(snapshot.immutablePaths, p => [...p]),
-			managedPaths: optionalNestedArray(snapshot.managedPaths, p => [...p])
+			managedPaths: optionalNestedArray(snapshot.managedPaths, p => [...p]),
+			nonManagedPaths: optionalNestedArray(snapshot.nonManagedPaths, p => [
+				...p
+			])
 		})),
 		stats: nestedConfig(config.stats, stats => {
 			if (stats === false) {

--- a/lib/validateSchema.js
+++ b/lib/validateSchema.js
@@ -33,6 +33,7 @@ const DID_YOU_MEAN = {
 	hotUpdateFunction: "output.hotUpdateGlobal (BREAKING CHANGE since webpack 5)",
 	splitChunks: "optimization.splitChunks",
 	immutablePaths: "snapshot.immutablePaths",
+	nonManagedPaths: "snapshot.nonManagedPaths",
 	managedPaths: "snapshot.managedPaths",
 	maxModules: "stats.modulesSpace (BREAKING CHANGE since webpack 5)",
 	hashedModuleIds:

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -661,6 +661,16 @@
           "description": "Name for the cache. Different names will lead to different coexisting caches.",
           "type": "string"
         },
+        "nonManagedPaths": {
+          "description": "List of paths that are not managed by a package manager and can not be trusted to be modified otherwise.",
+          "type": "array",
+          "items": {
+            "description": "A list of paths not to be managed (usually some package inside a node_modules directory).",
+            "type": "string",
+            "absolutePath": true,
+            "minLength": 1
+          }
+        },
         "store": {
           "description": "When to store data to the filesystem. (pack: Store data when compiler is idle in a single file).",
           "enum": ["pack"]
@@ -3103,6 +3113,16 @@
               "description": "Use timestamps of the files/directories to determine invalidation.",
               "type": "boolean"
             }
+          }
+        },
+        "nonManagedPaths": {
+          "description": "List of paths that are not managed by a package manager and can not be trusted to be modified otherwise.",
+          "type": "array",
+          "items": {
+            "description": "A list of paths not to be managed (usually some package inside a node_modules directory).",
+            "type": "string",
+            "absolutePath": true,
+            "minLength": 1
           }
         },
         "resolve": {

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -555,6 +555,7 @@ describe("Defaults", () => {
 		    "module": Object {
 		      "timestamp": true,
 		    },
+		    "nonManagedPaths": Array [],
 		    "resolve": Object {
 		      "timestamp": true,
 		    },

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -186,6 +186,32 @@ Object {
     "multiple": false,
     "simpleType": "string",
   },
+  "cache-non-managed-paths": Object {
+    "configs": Array [
+      Object {
+        "description": "A list of paths not to be managed (usually some package inside a node_modules directory).",
+        "multiple": true,
+        "path": "cache.nonManagedPaths[]",
+        "type": "path",
+      },
+    ],
+    "description": "A list of paths not to be managed (usually some package inside a node_modules directory).",
+    "multiple": true,
+    "simpleType": "string",
+  },
+  "cache-non-managed-paths-reset": Object {
+    "configs": Array [
+      Object {
+        "description": "Clear all items provided in configuration. List of paths that are not managed by a package manager and can not be trusted to be modified otherwise.",
+        "multiple": false,
+        "path": "cache.nonManagedPaths",
+        "type": "reset",
+      },
+    ],
+    "description": "Clear all items provided in configuration. List of paths that are not managed by a package manager and can not be trusted to be modified otherwise.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "cache-store": Object {
     "configs": Array [
       Object {
@@ -4388,6 +4414,32 @@ Object {
       },
     ],
     "description": "Use timestamps of the files/directories to determine invalidation.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "snapshot-non-managed-paths": Object {
+    "configs": Array [
+      Object {
+        "description": "A list of paths not to be managed (usually some package inside a node_modules directory).",
+        "multiple": true,
+        "path": "snapshot.nonManagedPaths[]",
+        "type": "path",
+      },
+    ],
+    "description": "A list of paths not to be managed (usually some package inside a node_modules directory).",
+    "multiple": true,
+    "simpleType": "string",
+  },
+  "snapshot-non-managed-paths-reset": Object {
+    "configs": Array [
+      Object {
+        "description": "Clear all items provided in configuration. List of paths that are not managed by a package manager and can not be trusted to be modified otherwise.",
+        "multiple": false,
+        "path": "snapshot.nonManagedPaths",
+        "type": "reset",
+      },
+    ],
+    "description": "Clear all items provided in configuration. List of paths that are not managed by a package manager and can not be trusted to be modified otherwise.",
     "multiple": false,
     "simpleType": "boolean",
   },

--- a/types.d.ts
+++ b/types.d.ts
@@ -1555,6 +1555,7 @@ declare class Compiler {
 	recordsOutputPath: string;
 	records: {};
 	managedPaths: Set<string>;
+	nonManagedPaths: Set<string>;
 	immutablePaths: Set<string>;
 	modifiedFiles: Set<string>;
 	removedFiles: Set<string>;
@@ -3264,6 +3265,11 @@ declare interface FileCacheOptions {
 	name?: string;
 
 	/**
+	 * List of paths that are not managed by a package manager and can not be trusted to be modified otherwise.
+	 */
+	nonManagedPaths?: string[];
+
+	/**
 	 * When to store data to the filesystem. (pack: Store data when compiler is idle in a single file).
 	 */
 	store?: "pack";
@@ -3330,6 +3336,8 @@ declare abstract class FileSystemInfo {
 	managedItemDirectoryQueue: AsyncQueue<string, string, Set<string>>;
 	managedPaths: string[];
 	managedPathsWithSlash: string[];
+	nonManagedPaths: string[];
+	nonManagedPathsWithSlash: string[];
 	immutablePaths: string[];
 	immutablePathsWithSlash: string[];
 	logStatistics(): void;
@@ -8291,6 +8299,11 @@ declare interface SnapshotOptions {
 		 */
 		timestamp?: boolean;
 	};
+
+	/**
+	 * List of paths that are not managed by a package manager and can not be trusted to be modified otherwise.
+	 */
+	nonManagedPaths?: string[];
 
 	/**
 	 * Options for snapshotting dependencies of request resolving to determine if requests need to be re-resolved.


### PR DESCRIPTION
Changes as proposed here #12112 

**What kind of change does this PR introduce?**

I've introduced `snapshot.nonManagedPaths` and tried to integrate it everywhere I could find.

**Did you add tests for your changes?**

I'm having trouble adding tests, maybe someone can point me in the right direction. I can't find any tests that actually test the `managedPaths` or the `immutablePaths` feature. Maybe someone can help me find a suitable location/place to add a test?

**Does this PR introduce a breaking change?**
Nope

**What needs to be documented once your changes are merged?**
Document the `nonManagedPaths` functionality
