### PR TITLE
fix: avoid duplicate chunks in template's chunkLoadingGlobal #12128

### DIFF
--- a/lib/web/JsonpChunkLoadingPlugin.js
+++ b/lib/web/JsonpChunkLoadingPlugin.js
@@ -62,6 +62,7 @@ class JsonpChunkLoadingPlugin {
 						set.add(RuntimeGlobals.publicPath);
 						set.add(RuntimeGlobals.loadScript);
 						set.add(RuntimeGlobals.getChunkScriptFilename);
+						set.add(RuntimeGlobals.startup);
 					});
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.hmrDownloadUpdateHandlers)

--- a/lib/web/JsonpChunkLoadingRuntimeModule.js
+++ b/lib/web/JsonpChunkLoadingRuntimeModule.js
@@ -423,6 +423,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 							)}`,
 							"chunkLoadingGlobal = chunkLoadingGlobal.slice();",
 							"for(var i = 0; i < chunkLoadingGlobal.length; i++) webpackJsonpCallback(chunkLoadingGlobal[i]);",
+							"parentChunkLoadingFunction = preChunkLoadingFunction;",
 							"return (checkDeferredModules = checkDeferredModulesImpl)();"
 						])};`
 				  ])
@@ -467,7 +468,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 								]),
 								"}",
 								"if(runtime) runtime(__webpack_require__);",
-								"parentChunkLoadingFunction(data);",
+								"if (parentChunkLoadingFunction) parentChunkLoadingFunction(data);",
 								"while(resolves.length) {",
 								Template.indent("resolves.shift()();"),
 								"}",
@@ -485,7 +486,14 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 						)}`,
 						"",
 						`var chunkLoadingGlobal = ${chunkLoadingGlobalExpr} = ${chunkLoadingGlobalExpr} || [];`,
-						"var parentChunkLoadingFunction = chunkLoadingGlobal.push.bind(chunkLoadingGlobal);",
+						withDefer
+							? Template.asString([
+									"var preChunkLoadingFunction = chunkLoadingGlobal.push.bind(chunkLoadingGlobal);",
+									"var parentChunkLoadingFunction;"
+							  ])
+							: Template.asString([
+									"var parentChunkLoadingFunction = chunkLoadingGlobal.push.bind(chunkLoadingGlobal);"
+							  ]),
 						"chunkLoadingGlobal.push = webpackJsonpCallback;"
 				  ])
 				: "// no jsonp function"

--- a/lib/web/JsonpChunkLoadingRuntimeModule.js
+++ b/lib/web/JsonpChunkLoadingRuntimeModule.js
@@ -421,10 +421,21 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 								"",
 								""
 							)}`,
-							"chunkLoadingGlobal = chunkLoadingGlobal.slice();",
-							"for(var i = 0; i < chunkLoadingGlobal.length; i++) webpackJsonpCallback(chunkLoadingGlobal[i]);",
-							"parentChunkLoadingFunction = preChunkLoadingFunction;",
+							"for(var i = 0; i < chunkLoadingGlobal.length; i++) webpackJsonpCallback(0, chunkLoadingGlobal[i]);",
 							"return (checkDeferredModules = checkDeferredModulesImpl)();"
+						])};`
+				  ])
+				: withLoading
+				? Template.asString([
+						`var next = ${RuntimeGlobals.startup};`,
+						`${RuntimeGlobals.startup} = ${runtimeTemplate.basicFunction("", [
+							"// reset startup function so it can be called again when more startup code is added",
+							`${RuntimeGlobals.startup} = ${runtimeTemplate.basicFunction(
+								"",
+								""
+							)}`,
+							"for(var i = 0; i < chunkLoadingGlobal.length; i++) webpackJsonpCallback(0, chunkLoadingGlobal[i]);",
+							"return next();"
 						])};`
 				  ])
 				: "// no deferred startup",
@@ -433,7 +444,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 				? Template.asString([
 						"// install a JSONP callback for chunk loading",
 						`var webpackJsonpCallback = ${runtimeTemplate.basicFunction(
-							"data",
+							"parentChunkLoadingFunction, data",
 							[
 								runtimeTemplate.destructureArray(
 									[
@@ -468,7 +479,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 								]),
 								"}",
 								"if(runtime) runtime(__webpack_require__);",
-								"if (parentChunkLoadingFunction) parentChunkLoadingFunction(data);",
+								"if(parentChunkLoadingFunction) parentChunkLoadingFunction(data);",
 								"while(resolves.length) {",
 								Template.indent("resolves.shift()();"),
 								"}",
@@ -486,15 +497,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 						)}`,
 						"",
 						`var chunkLoadingGlobal = ${chunkLoadingGlobalExpr} = ${chunkLoadingGlobalExpr} || [];`,
-						withDefer
-							? Template.asString([
-									"var preChunkLoadingFunction = chunkLoadingGlobal.push.bind(chunkLoadingGlobal);",
-									"var parentChunkLoadingFunction;"
-							  ])
-							: Template.asString([
-									"var parentChunkLoadingFunction = chunkLoadingGlobal.push.bind(chunkLoadingGlobal);"
-							  ]),
-						"chunkLoadingGlobal.push = webpackJsonpCallback;"
+						"chunkLoadingGlobal.push = webpackJsonpCallback.bind(null, chunkLoadingGlobal.push.bind(chunkLoadingGlobal));"
 				  ])
 				: "// no jsonp function"
 		]);

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -173,10 +173,10 @@ describe("Stats", () => {
 			      "assets": Array [
 			        Object {
 			          "name": "entryB.js",
-			          "size": 2913,
+			          "size": 3025,
 			        },
 			      ],
-			      "assetsSize": 2913,
+			      "assetsSize": 3025,
 			      "auxiliaryAssets": undefined,
 			      "auxiliaryAssetsSize": 0,
 			      "childAssets": undefined,
@@ -221,10 +221,10 @@ describe("Stats", () => {
 			      "info": Object {
 			        "javascriptModule": false,
 			        "minimized": true,
-			        "size": 2913,
+			        "size": 3025,
 			      },
 			      "name": "entryB.js",
-			      "size": 2913,
+			      "size": 3025,
 			      "type": "asset",
 			    },
 			    Object {

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -173,10 +173,10 @@ describe("Stats", () => {
 			      "assets": Array [
 			        Object {
 			          "name": "entryB.js",
-			          "size": 2910,
+			          "size": 2913,
 			        },
 			      ],
-			      "assetsSize": 2910,
+			      "assetsSize": 2913,
 			      "auxiliaryAssets": undefined,
 			      "auxiliaryAssetsSize": 0,
 			      "childAssets": undefined,
@@ -221,10 +221,10 @@ describe("Stats", () => {
 			      "info": Object {
 			        "javascriptModule": false,
 			        "minimized": true,
-			        "size": 2910,
+			        "size": 2913,
 			      },
 			      "name": "entryB.js",
-			      "size": 2910,
+			      "size": 2913,
 			      "type": "asset",
 			    },
 			    Object {

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -3,14 +3,14 @@
 exports[`StatsTestCases should print correct stats for aggressive-splitting-entry 1`] = `
 "fitting:
   PublicPath: auto
-  asset fitting-a23a7abdb3e2501c5723.js 16.1 KiB [emitted] [immutable]
+  asset fitting-24ff132ace061c94fbef.js 15.9 KiB [emitted] [immutable]
   asset fitting-34542f2d6e4f073117f4.js 1.9 KiB [emitted] [immutable]
   asset fitting-db0927f4ef7838186003.js 1.9 KiB [emitted] [immutable]
   asset fitting-648f8b05ea1214c52404.js 1.08 KiB [emitted] [immutable]
-  Entrypoint main 19.9 KiB = fitting-db0927f4ef7838186003.js 1.9 KiB fitting-34542f2d6e4f073117f4.js 1.9 KiB fitting-a23a7abdb3e2501c5723.js 16.1 KiB
-  chunk (runtime: main) fitting-a23a7abdb3e2501c5723.js 1.87 KiB (javascript) 8.88 KiB (runtime) [entry] [rendered]
+  Entrypoint main 19.7 KiB = fitting-db0927f4ef7838186003.js 1.9 KiB fitting-34542f2d6e4f073117f4.js 1.9 KiB fitting-24ff132ace061c94fbef.js 15.9 KiB
+  chunk (runtime: main) fitting-24ff132ace061c94fbef.js 1.87 KiB (javascript) 8.75 KiB (runtime) [entry] [rendered]
     > ./index main
-    runtime modules 8.88 KiB 10 modules
+    runtime modules 8.75 KiB 10 modules
     cacheable modules 1.87 KiB
       ./e.js 899 bytes [dependent] [built] [code generated]
       ./f.js 900 bytes [dependent] [built] [code generated]
@@ -30,14 +30,14 @@ exports[`StatsTestCases should print correct stats for aggressive-splitting-entr
 
 content-change:
   PublicPath: auto
-  asset content-change-0bc04332ecd9606e34ea.js 16.1 KiB [emitted] [immutable]
+  asset content-change-28d7d245fb7bf9a3dfae.js 15.9 KiB [emitted] [immutable]
   asset content-change-34542f2d6e4f073117f4.js 1.9 KiB [emitted] [immutable]
   asset content-change-db0927f4ef7838186003.js 1.9 KiB [emitted] [immutable]
   asset content-change-648f8b05ea1214c52404.js 1.08 KiB [emitted] [immutable]
-  Entrypoint main 19.9 KiB = content-change-db0927f4ef7838186003.js 1.9 KiB content-change-34542f2d6e4f073117f4.js 1.9 KiB content-change-0bc04332ecd9606e34ea.js 16.1 KiB
-  chunk (runtime: main) content-change-0bc04332ecd9606e34ea.js 1.87 KiB (javascript) 8.88 KiB (runtime) [entry] [rendered]
+  Entrypoint main 19.7 KiB = content-change-db0927f4ef7838186003.js 1.9 KiB content-change-34542f2d6e4f073117f4.js 1.9 KiB content-change-28d7d245fb7bf9a3dfae.js 15.9 KiB
+  chunk (runtime: main) content-change-28d7d245fb7bf9a3dfae.js 1.87 KiB (javascript) 8.76 KiB (runtime) [entry] [rendered]
     > ./index main
-    runtime modules 8.88 KiB 10 modules
+    runtime modules 8.76 KiB 10 modules
     cacheable modules 1.87 KiB
       ./e.js 899 bytes [dependent] [built] [code generated]
       ./f.js 900 bytes [dependent] [built] [code generated]
@@ -58,7 +58,7 @@ content-change:
 
 exports[`StatsTestCases should print correct stats for aggressive-splitting-on-demand 1`] = `
 "PublicPath: auto
-asset 7706b22c902378f64378.js 11.5 KiB [emitted] [immutable] (name: main)
+asset 78d3d45b98de2ddf3b3f.js 12.2 KiB [emitted] [immutable] (name: main)
 asset daf4c888556b29be016d.js 1.91 KiB [emitted] [immutable]
 asset 8c077ced7fa52f135e3c.js 1.91 KiB [emitted] [immutable]
 asset 661f4167d7706ba28ded.js 1.9 KiB [emitted] [immutable]
@@ -70,14 +70,14 @@ asset cd87f005f9b4ddde3af0.js 1.9 KiB [emitted] [immutable]
 asset 0a9a29eb4cf1cfec6e7f.js 1010 bytes [emitted] [immutable]
 asset d861dc604cacc82b16e2.js 1010 bytes [emitted] [immutable]
 asset d9498542c42d67f86bab.js 1010 bytes [emitted] [immutable]
-Entrypoint main 11.5 KiB = 7706b22c902378f64378.js
+Entrypoint main 12.2 KiB = 78d3d45b98de2ddf3b3f.js
 chunk (runtime: main) 34542f2d6e4f073117f4.js 1.76 KiB [rendered] [recorded] aggressive splitted
   > ./c ./d ./e ./index.js 3:0-30
   ./c.js 899 bytes [built] [code generated]
   ./d.js 899 bytes [built] [code generated]
-chunk (runtime: main) 7706b22c902378f64378.js (main) 248 bytes (javascript) 6.22 KiB (runtime) [entry] [rendered]
+chunk (runtime: main) 78d3d45b98de2ddf3b3f.js (main) 248 bytes (javascript) 6.5 KiB (runtime) [entry] [rendered]
   > ./index main
-  runtime modules 6.22 KiB 7 modules
+  runtime modules 6.5 KiB 7 modules
   ./index.js 248 bytes [built] [code generated]
 chunk (runtime: main) daf4c888556b29be016d.js 1.76 KiB [rendered]
   > ./f ./g ./h ./i ./j ./k ./index.js 4:0-51
@@ -138,9 +138,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for async-commons-chunk 1`] = `
-"chunk (runtime: main) main.js (main) 515 bytes (javascript) 5.9 KiB (runtime) >{460}< >{847}< >{996}< [entry] [rendered]
+"chunk (runtime: main) main.js (main) 515 bytes (javascript) 6.19 KiB (runtime) >{460}< >{847}< >{996}< [entry] [rendered]
   > ./ main
-  runtime modules 5.9 KiB 7 modules
+  runtime modules 6.19 KiB 7 modules
   ./index.js 515 bytes [built] [code generated]
 chunk (runtime: main) 460.js 21 bytes <{179}> ={847}= [rendered]
   > ./index.js 17:1-21:3
@@ -167,9 +167,9 @@ exports[`StatsTestCases should print correct stats for async-commons-chunk-auto 
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) disabled/main.js (main) 147 bytes (javascript) 6.55 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) disabled/main.js (main) 147 bytes (javascript) 6.84 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.55 KiB 9 modules
+    runtime modules 6.84 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) disabled/async-b.js (async-b) 196 bytes [rendered]
     > ./b ./index.js 2:0-47
@@ -184,9 +184,9 @@ exports[`StatsTestCases should print correct stats for async-commons-chunk-auto 
     dependent modules 60 bytes [dependent] 3 modules
     runtime modules 394 bytes 2 modules
     ./c.js + 1 modules 136 bytes [built] [code generated]
-  chunk (runtime: a) disabled/a.js (a) 245 bytes (javascript) 6.5 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) disabled/a.js (a) 245 bytes (javascript) 6.78 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 6.5 KiB 9 modules
+    runtime modules 6.78 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) disabled/async-a.js (async-a) 245 bytes [rendered]
@@ -204,9 +204,9 @@ default:
   chunk (runtime: a, main) default/async-g.js (async-g) 45 bytes [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.57 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.85 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.57 KiB 9 modules
+    runtime modules 6.85 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) default/282.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -237,9 +237,9 @@ default:
   chunk (runtime: main) default/769.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
     > ./c ./index.js 3:0-47
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.55 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.84 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 6.55 KiB 9 modules
+    runtime modules 6.84 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) default/async-a.js (async-a) 185 bytes [rendered]
@@ -252,22 +252,22 @@ default:
   default (webpack x.x.x) compiled successfully
 
 vendors:
-  Entrypoint main 11 KiB = vendors/main.js
-  Entrypoint a 14.5 KiB = vendors/vendors.js 1.07 KiB vendors/a.js 13.4 KiB
-  Entrypoint b 8.17 KiB = vendors/vendors.js 1.07 KiB vendors/b.js 7.1 KiB
-  Entrypoint c 8.17 KiB = vendors/vendors.js 1.07 KiB vendors/c.js 7.1 KiB
-  chunk (runtime: b) vendors/b.js (b) 156 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
+  Entrypoint main 11.7 KiB = vendors/main.js
+  Entrypoint a 14.3 KiB = vendors/vendors.js 1.07 KiB vendors/a.js 13.3 KiB
+  Entrypoint b 8.01 KiB = vendors/vendors.js 1.07 KiB vendors/b.js 6.94 KiB
+  Entrypoint c 8.01 KiB = vendors/vendors.js 1.07 KiB vendors/c.js 6.94 KiB
+  chunk (runtime: b) vendors/b.js (b) 156 bytes (javascript) 2.87 KiB (runtime) [entry] [rendered]
     > ./b b
-    runtime modules 2.99 KiB 3 modules
+    runtime modules 2.87 KiB 3 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./b.js 116 bytes [built] [code generated]
   chunk (runtime: a, main) vendors/async-g.js (async-g) 65 bytes [rendered]
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) vendors/main.js (main) 147 bytes (javascript) 6.55 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) vendors/main.js (main) 147 bytes (javascript) 6.83 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.55 KiB 9 modules
+    runtime modules 6.83 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: a, b, c) vendors/vendors.js (vendors) (id hint: vendors) 60 bytes [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
     > ./a a
@@ -284,14 +284,14 @@ vendors:
     > ./c ./index.js 3:0-47
     dependent modules 80 bytes [dependent] 4 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: c) vendors/c.js (c) 156 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
+  chunk (runtime: c) vendors/c.js (c) 156 bytes (javascript) 2.87 KiB (runtime) [entry] [rendered]
     > ./c c
-    runtime modules 2.99 KiB 3 modules
+    runtime modules 2.87 KiB 3 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: a) vendors/a.js (a) 205 bytes (javascript) 7.77 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) vendors/a.js (a) 205 bytes (javascript) 7.64 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 7.77 KiB 9 modules
+    runtime modules 7.64 KiB 9 modules
     dependent modules 20 bytes [dependent] 1 module
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) vendors/async-a.js (async-a) 245 bytes [rendered]
@@ -301,10 +301,10 @@ vendors:
   vendors (webpack x.x.x) compiled successfully
 
 multiple-vendors:
-  Entrypoint main 11.4 KiB = multiple-vendors/main.js
-  Entrypoint a 15 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/954.js 412 bytes multiple-vendors/767.js 412 bytes multiple-vendors/390.js 412 bytes multiple-vendors/a.js 13.4 KiB
-  Entrypoint b 8.1 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/954.js 412 bytes multiple-vendors/767.js 412 bytes multiple-vendors/568.js 412 bytes multiple-vendors/b.js 6.49 KiB
-  Entrypoint c 8.1 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/769.js 412 bytes multiple-vendors/767.js 412 bytes multiple-vendors/568.js 412 bytes multiple-vendors/c.js 6.49 KiB
+  Entrypoint main 12.1 KiB = multiple-vendors/main.js
+  Entrypoint a 14.8 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/954.js 412 bytes multiple-vendors/767.js 412 bytes multiple-vendors/390.js 412 bytes multiple-vendors/a.js 13.2 KiB
+  Entrypoint b 7.94 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/954.js 412 bytes multiple-vendors/767.js 412 bytes multiple-vendors/568.js 412 bytes multiple-vendors/b.js 6.33 KiB
+  Entrypoint c 7.94 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/769.js 412 bytes multiple-vendors/767.js 412 bytes multiple-vendors/568.js 412 bytes multiple-vendors/c.js 6.33 KiB
   chunk (runtime: a, b, c, main) multiple-vendors/libs-x.js (libs-x) (id hint: libs) 20 bytes [initial] [rendered] split chunk (cache group: libs) (name: libs-x)
     > ./a ./index.js 1:0-47
     > ./b ./index.js 2:0-47
@@ -313,16 +313,16 @@ multiple-vendors:
     > ./b b
     > ./c c
     ./node_modules/x.js 20 bytes [built] [code generated]
-  chunk (runtime: b) multiple-vendors/b.js (b) 116 bytes (javascript) 3.01 KiB (runtime) [entry] [rendered]
+  chunk (runtime: b) multiple-vendors/b.js (b) 116 bytes (javascript) 2.89 KiB (runtime) [entry] [rendered]
     > ./b b
-    runtime modules 3.01 KiB 3 modules
+    runtime modules 2.89 KiB 3 modules
     ./b.js 116 bytes [built] [code generated]
   chunk (runtime: a, main) multiple-vendors/async-g.js (async-g) 45 bytes [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) multiple-vendors/main.js (main) 147 bytes (javascript) 6.59 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) multiple-vendors/main.js (main) 147 bytes (javascript) 6.87 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.59 KiB 9 modules
+    runtime modules 6.87 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) multiple-vendors/async-b.js (async-b) 116 bytes [rendered]
     > ./b ./index.js 2:0-47
@@ -334,9 +334,9 @@ multiple-vendors:
     > ./a ./index.js 1:0-47
     > ./a a
     ./e.js 20 bytes [built] [code generated]
-  chunk (runtime: c) multiple-vendors/c.js (c) 116 bytes (javascript) 3.01 KiB (runtime) [entry] [rendered]
+  chunk (runtime: c) multiple-vendors/c.js (c) 116 bytes (javascript) 2.89 KiB (runtime) [entry] [rendered]
     > ./c c
-    runtime modules 3.01 KiB 3 modules
+    runtime modules 2.89 KiB 3 modules
     ./c.js 116 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) multiple-vendors/568.js 20 bytes [initial] [rendered] split chunk (cache group: default)
     > ./b ./index.js 2:0-47
@@ -357,9 +357,9 @@ multiple-vendors:
     > ./c ./index.js 3:0-47
     > ./c c
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) multiple-vendors/a.js (a) 165 bytes (javascript) 7.83 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) multiple-vendors/a.js (a) 165 bytes (javascript) 7.7 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 7.83 KiB 9 modules
+    runtime modules 7.7 KiB 9 modules
     ./a.js 165 bytes [built] [code generated]
   chunk (runtime: main) multiple-vendors/async-a.js (async-a) 165 bytes [rendered]
     > ./a ./index.js 1:0-47
@@ -373,20 +373,20 @@ multiple-vendors:
   multiple-vendors (webpack x.x.x) compiled successfully
 
 all:
-  Entrypoint main 11.4 KiB = all/main.js
-  Entrypoint a 15 KiB = all/282.js 412 bytes all/954.js 412 bytes all/767.js 412 bytes all/390.js 412 bytes all/a.js 13.3 KiB
-  Entrypoint b 8.1 KiB = all/282.js 412 bytes all/954.js 412 bytes all/767.js 412 bytes all/568.js 412 bytes all/b.js 6.49 KiB
-  Entrypoint c 8.1 KiB = all/282.js 412 bytes all/769.js 412 bytes all/767.js 412 bytes all/568.js 412 bytes all/c.js 6.49 KiB
-  chunk (runtime: b) all/b.js (b) 116 bytes (javascript) 3.01 KiB (runtime) [entry] [rendered]
+  Entrypoint main 12.1 KiB = all/main.js
+  Entrypoint a 14.8 KiB = all/282.js 412 bytes all/954.js 412 bytes all/767.js 412 bytes all/390.js 412 bytes all/a.js 13.2 KiB
+  Entrypoint b 7.94 KiB = all/282.js 412 bytes all/954.js 412 bytes all/767.js 412 bytes all/568.js 412 bytes all/b.js 6.33 KiB
+  Entrypoint c 7.94 KiB = all/282.js 412 bytes all/769.js 412 bytes all/767.js 412 bytes all/568.js 412 bytes all/c.js 6.33 KiB
+  chunk (runtime: b) all/b.js (b) 116 bytes (javascript) 2.89 KiB (runtime) [entry] [rendered]
     > ./b b
-    runtime modules 3.01 KiB 3 modules
+    runtime modules 2.89 KiB 3 modules
     ./b.js 116 bytes [built] [code generated]
   chunk (runtime: a, main) all/async-g.js (async-g) 45 bytes [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) all/main.js (main) 147 bytes (javascript) 6.56 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) all/main.js (main) 147 bytes (javascript) 6.84 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.56 KiB 9 modules
+    runtime modules 6.84 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) all/282.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
     > ./a ./index.js 1:0-47
@@ -406,9 +406,9 @@ all:
     > ./a ./index.js 1:0-47
     > ./a a
     ./e.js 20 bytes [built] [code generated]
-  chunk (runtime: c) all/c.js (c) 116 bytes (javascript) 3.01 KiB (runtime) [entry] [rendered]
+  chunk (runtime: c) all/c.js (c) 116 bytes (javascript) 2.89 KiB (runtime) [entry] [rendered]
     > ./c c
-    runtime modules 3.01 KiB 3 modules
+    runtime modules 2.89 KiB 3 modules
     ./c.js 116 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) all/568.js 20 bytes [initial] [rendered] split chunk (cache group: default)
     > ./b ./index.js 2:0-47
@@ -429,9 +429,9 @@ all:
     > ./c ./index.js 3:0-47
     > ./c c
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) all/a.js (a) 165 bytes (javascript) 7.81 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) all/a.js (a) 165 bytes (javascript) 7.69 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 7.81 KiB 9 modules
+    runtime modules 7.69 KiB 9 modules
     ./a.js 165 bytes [built] [code generated]
   chunk (runtime: main) all/async-a.js (async-a) 165 bytes [rendered]
     > ./a ./index.js 1:0-47
@@ -491,13 +491,13 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for chunks 1`] = `
 "PublicPath: auto
-asset bundle.js 10 KiB [emitted] (name: main)
+asset bundle.js 10.7 KiB [emitted] (name: main)
 asset 460.bundle.js 320 bytes [emitted]
 asset 524.bundle.js 206 bytes [emitted]
 asset 996.bundle.js 138 bytes [emitted]
-chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 5.91 KiB (runtime) >{460}< >{996}< [entry] [rendered]
+chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 6.19 KiB (runtime) >{460}< >{996}< [entry] [rendered]
   > ./index main
-  runtime modules 5.91 KiB 7 modules
+  runtime modules 6.19 KiB 7 modules
   cacheable modules 73 bytes
     ./a.js 22 bytes [dependent] [built] [code generated]
       cjs self exports reference ./a.js 1:0-14
@@ -537,7 +537,7 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for chunks-development 1`] = `
 "PublicPath: auto
-asset bundle.js 10.9 KiB [emitted] (name: main)
+asset bundle.js 11.6 KiB [emitted] (name: main)
 asset d_js-e_js.bundle.js 1.07 KiB [emitted]
 asset c_js.bundle.js 1010 bytes [emitted]
 asset b_js.bundle.js 819 bytes [emitted]
@@ -566,9 +566,9 @@ chunk (runtime: main) d_js-e_js.bundle.js 60 bytes <{c_js}> [rendered]
     cjs self exports reference ./e.js 2:0-14
     X ms -> X ms ->
     X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
-chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 5.91 KiB (runtime) >{b_js}< >{c_js}< [entry] [rendered]
+chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 6.2 KiB (runtime) >{b_js}< >{c_js}< [entry] [rendered]
   > ./index main
-  runtime modules 5.91 KiB 7 modules
+  runtime modules 6.2 KiB 7 modules
   cacheable modules 73 bytes
     ./a.js 22 bytes [dependent] [built] [code generated]
       cjs self exports reference ./a.js 1:0-14
@@ -585,8 +585,8 @@ webpack x.x.x compiled successfully in X ms"
 exports[`StatsTestCases should print correct stats for circular-correctness 1`] = `
 "chunk (runtime: main) 128.bundle.js (b) 49 bytes <{179}> <{459}> >{459}< [rendered]
   ./module-b.js 49 bytes [built] [code generated]
-chunk (runtime: main) bundle.js (main) 98 bytes (javascript) 7.58 KiB (runtime) >{128}< >{786}< [entry] [rendered]
-  runtime modules 7.58 KiB 10 modules
+chunk (runtime: main) bundle.js (main) 98 bytes (javascript) 7.86 KiB (runtime) >{128}< >{786}< [entry] [rendered]
+  runtime modules 7.86 KiB 10 modules
   ./index.js 98 bytes [built] [code generated]
 chunk (runtime: main) 459.bundle.js (c) 98 bytes <{128}> <{786}> >{128}< >{786}< [rendered]
   ./module-c.js 98 bytes [built] [code generated]
@@ -624,10 +624,10 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for commons-chunk-min-size-0 1`] = `
-"asset entry-1.js 5.69 KiB [emitted] (name: entry-1)
+"asset entry-1.js 5.52 KiB [emitted] (name: entry-1)
 asset 429.js 274 bytes [emitted] (id hint: vendor-1)
-Entrypoint entry-1 5.95 KiB = 429.js 274 bytes entry-1.js 5.69 KiB
-runtime modules 2.69 KiB 2 modules
+Entrypoint entry-1 5.79 KiB = 429.js 274 bytes entry-1.js 5.52 KiB
+runtime modules 2.57 KiB 2 modules
 modules by path ./modules/*.js 132 bytes
   ./modules/a.js 22 bytes [built] [code generated]
   ./modules/b.js 22 bytes [built] [code generated]
@@ -640,10 +640,10 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for commons-chunk-min-size-Infinity 1`] = `
-"asset entry-1.js 5.69 KiB [emitted] (name: entry-1)
+"asset entry-1.js 5.52 KiB [emitted] (name: entry-1)
 asset vendor-1.js 274 bytes [emitted] (name: vendor-1) (id hint: vendor-1)
-Entrypoint entry-1 5.95 KiB = vendor-1.js 274 bytes entry-1.js 5.69 KiB
-runtime modules 2.69 KiB 2 modules
+Entrypoint entry-1 5.79 KiB = vendor-1.js 274 bytes entry-1.js 5.52 KiB
+runtime modules 2.57 KiB 2 modules
 modules by path ./modules/*.js 132 bytes
   ./modules/a.js 22 bytes [built] [code generated]
   ./modules/b.js 22 bytes [built] [code generated]
@@ -656,20 +656,20 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for commons-plugin-issue-4980 1`] = `
-"asset app.153d1335892ba0759464-1.js 6.22 KiB [emitted] [immutable] (name: app)
+"asset app.ab2a9bbc9d570a8deee1-1.js 6.05 KiB [emitted] [immutable] (name: app)
 asset vendor.c715f5ed2754861797e1-1.js 611 bytes [emitted] [immutable] (name: vendor) (id hint: vendor)
-Entrypoint app 6.82 KiB = vendor.c715f5ed2754861797e1-1.js 611 bytes app.153d1335892ba0759464-1.js 6.22 KiB
-runtime modules 2.99 KiB 3 modules
+Entrypoint app 6.65 KiB = vendor.c715f5ed2754861797e1-1.js 611 bytes app.ab2a9bbc9d570a8deee1-1.js 6.05 KiB
+runtime modules 2.87 KiB 3 modules
 orphan modules 118 bytes [orphan] 2 modules
 cacheable modules 272 bytes
   ./entry-1.js + 2 modules 185 bytes [built] [code generated]
   ./constants.js 87 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset app.ab0fb380ee471fac6658-2.js 6.24 KiB [emitted] [immutable] (name: app)
+asset app.e81f0737d638bce7f5f8-2.js 6.07 KiB [emitted] [immutable] (name: app)
 asset vendor.c715f5ed2754861797e1-2.js 611 bytes [emitted] [immutable] (name: vendor) (id hint: vendor)
-Entrypoint app 6.83 KiB = vendor.c715f5ed2754861797e1-2.js 611 bytes app.ab0fb380ee471fac6658-2.js 6.24 KiB
-runtime modules 2.99 KiB 3 modules
+Entrypoint app 6.67 KiB = vendor.c715f5ed2754861797e1-2.js 611 bytes app.e81f0737d638bce7f5f8-2.js 6.07 KiB
+runtime modules 2.87 KiB 3 modules
 orphan modules 125 bytes [orphan] 2 modules
 cacheable modules 279 bytes
   ./entry-2.js + 2 modules 192 bytes [built] [code generated]
@@ -698,40 +698,40 @@ exports[`StatsTestCases should print correct stats for concat-and-sideeffects 1`
 `;
 
 exports[`StatsTestCases should print correct stats for context-independence 1`] = `
-"asset main-4e72d6e6698b7935e2b0.js 10.3 KiB [emitted] [immutable] (name: main)
-  sourceMap main-4e72d6e6698b7935e2b0.js.map 9.19 KiB [emitted] [dev] (auxiliary name: main)
+"asset main-e28b377d0a1b6b217724.js 11 KiB [emitted] [immutable] (name: main)
+  sourceMap main-e28b377d0a1b6b217724.js.map 9.77 KiB [emitted] [dev] (auxiliary name: main)
 asset 664-cb106d2f6263642c0727.js 455 bytes [emitted] [immutable]
   sourceMap 664-cb106d2f6263642c0727.js.map 344 bytes [emitted] [dev]
-runtime modules 6.2 KiB 8 modules
+runtime modules 6.48 KiB 8 modules
 orphan modules 19 bytes [orphan] 1 module
 cacheable modules 106 bytes
   ./a/index.js 40 bytes [built] [code generated]
   ./a/chunk.js + 1 modules 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-4e72d6e6698b7935e2b0.js 10.3 KiB [emitted] [immutable] (name: main)
-  sourceMap main-4e72d6e6698b7935e2b0.js.map 9.19 KiB [emitted] [dev] (auxiliary name: main)
+asset main-e28b377d0a1b6b217724.js 11 KiB [emitted] [immutable] (name: main)
+  sourceMap main-e28b377d0a1b6b217724.js.map 9.77 KiB [emitted] [dev] (auxiliary name: main)
 asset 664-cb106d2f6263642c0727.js 455 bytes [emitted] [immutable]
   sourceMap 664-cb106d2f6263642c0727.js.map 344 bytes [emitted] [dev]
-runtime modules 6.2 KiB 8 modules
+runtime modules 6.48 KiB 8 modules
 orphan modules 19 bytes [orphan] 1 module
 cacheable modules 106 bytes
   ./b/index.js 40 bytes [built] [code generated]
   ./b/chunk.js + 1 modules 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-a335726731d18f0e2468.js 11.2 KiB [emitted] [immutable] (name: main)
+asset main-093a121e4653182ea248.js 11.9 KiB [emitted] [immutable] (name: main)
 asset 664-12bf7254f5c08e0ac9e9.js 1.51 KiB [emitted] [immutable]
-runtime modules 6.2 KiB 8 modules
+runtime modules 6.48 KiB 8 modules
 orphan modules 19 bytes [orphan] 1 module
 cacheable modules 106 bytes
   ./a/index.js 40 bytes [built] [code generated]
   ./a/chunk.js + 1 modules 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-a335726731d18f0e2468.js 11.2 KiB [emitted] [immutable] (name: main)
+asset main-093a121e4653182ea248.js 11.9 KiB [emitted] [immutable] (name: main)
 asset 664-12bf7254f5c08e0ac9e9.js 1.51 KiB [emitted] [immutable]
-runtime modules 6.2 KiB 8 modules
+runtime modules 6.48 KiB 8 modules
 orphan modules 19 bytes [orphan] 1 module
 cacheable modules 106 bytes
   ./b/index.js 40 bytes [built] [code generated]
@@ -819,16 +819,16 @@ exports[`StatsTestCases should print correct stats for graph-correctness-entries
 "chunk (runtime: e1, e2) b.js (b) 49 bytes <{786}> >{459}< [rendered]
   ./module-b.js 49 bytes [built] [code generated]
     import() ./module-b ./module-a.js 1:0-47
-chunk (runtime: e1) e1.js (e1) 49 bytes (javascript) 7.61 KiB (runtime) >{786}< [entry] [rendered]
-  runtime modules 7.61 KiB 10 modules
+chunk (runtime: e1) e1.js (e1) 49 bytes (javascript) 7.89 KiB (runtime) >{786}< [entry] [rendered]
+  runtime modules 7.89 KiB 10 modules
   ./e1.js 49 bytes [built] [code generated]
     entry ./e1 e1
 chunk (runtime: e1, e2) c.js (c) 49 bytes <{128}> <{621}> >{786}< [rendered]
   ./module-c.js 49 bytes [built] [code generated]
     import() ./module-c ./e2.js 1:0-47
     import() ./module-c ./module-b.js 1:0-47
-chunk (runtime: e2) e2.js (e2) 49 bytes (javascript) 7.61 KiB (runtime) >{459}< [entry] [rendered]
-  runtime modules 7.61 KiB 10 modules
+chunk (runtime: e2) e2.js (e2) 49 bytes (javascript) 7.89 KiB (runtime) >{459}< [entry] [rendered]
+  runtime modules 7.89 KiB 10 modules
   ./e2.js 49 bytes [built] [code generated]
     entry ./e2 e2
 chunk (runtime: e1, e2) a.js (a) 49 bytes <{257}> <{459}> >{128}< [rendered]
@@ -842,8 +842,8 @@ exports[`StatsTestCases should print correct stats for graph-correctness-modules
 "chunk (runtime: e1, e2) b.js (b) 179 bytes <{786}> >{459}< [rendered]
   ./module-b.js 179 bytes [built] [code generated]
     import() ./module-b ./module-a.js 1:0-47
-chunk (runtime: e1) e1.js (e1) 119 bytes (javascript) 7.87 KiB (runtime) >{786}< >{892}< [entry] [rendered]
-  runtime modules 7.87 KiB 11 modules
+chunk (runtime: e1) e1.js (e1) 119 bytes (javascript) 8.16 KiB (runtime) >{786}< >{892}< [entry] [rendered]
+  runtime modules 8.16 KiB 11 modules
   cacheable modules 119 bytes
     ./e1.js 70 bytes [built] [code generated]
       entry ./e1 e1
@@ -855,8 +855,8 @@ chunk (runtime: e1, e2) c.js (c) 49 bytes <{128}> <{621}> >{786}< [rendered]
   ./module-c.js 49 bytes [built] [code generated]
     import() ./module-c ./e2.js 2:0-47
     import() ./module-c ./module-b.js 1:0-47
-chunk (runtime: e2) e2.js (e2) 119 bytes (javascript) 7.87 KiB (runtime) >{459}< >{892}< [entry] [rendered]
-  runtime modules 7.87 KiB 11 modules
+chunk (runtime: e2) e2.js (e2) 119 bytes (javascript) 8.16 KiB (runtime) >{459}< >{892}< [entry] [rendered]
+  runtime modules 8.16 KiB 11 modules
   cacheable modules 119 bytes
     ./e2.js 70 bytes [built] [code generated]
       entry ./e2 e2
@@ -895,8 +895,8 @@ chunk (runtime: main) id-equals-name_js0.js 21 bytes [rendered]
   ./id-equals-name.js 21 bytes [built] [code generated]
 chunk (runtime: main) id-equals-name_js_3.js 21 bytes [rendered]
   ./id-equals-name.js?3 21 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 639 bytes (javascript) 6.47 KiB (runtime) [entry] [rendered]
-  runtime modules 6.47 KiB 9 modules
+chunk (runtime: main) main.js (main) 639 bytes (javascript) 6.76 KiB (runtime) [entry] [rendered]
+  runtime modules 6.76 KiB 9 modules
   ./index.js 639 bytes [built] [code generated]
 chunk (runtime: main) tree.js (tree) 137 bytes [rendered]
   dependent modules 98 bytes [dependent] 3 modules
@@ -925,16 +925,16 @@ webpack x.x.x compiled with 2 warnings in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for immutable 1`] = `
-"asset b16d4e2608b35d3294c5.js 12.9 KiB [emitted] [immutable] (name: main)
+"asset 9fd14e1b626fd90bb64b.js 13.6 KiB [emitted] [immutable] (name: main)
 asset cd9e349e4fe2a6d0d4d0.js 812 bytes [emitted] [immutable]"
 `;
 
 exports[`StatsTestCases should print correct stats for import-context-filter 1`] = `
-"asset entry.js 11.7 KiB [emitted] (name: entry)
+"asset entry.js 12.4 KiB [emitted] (name: entry)
 asset 398.js 480 bytes [emitted]
 asset 544.js 480 bytes [emitted]
 asset 718.js 480 bytes [emitted]
-runtime modules 6.47 KiB 9 modules
+runtime modules 6.75 KiB 9 modules
 built modules 724 bytes [built]
   modules by path ./templates/*.js 114 bytes
     ./templates/bar.js 38 bytes [optional] [built] [code generated]
@@ -946,9 +946,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for import-weak 1`] = `
-"asset entry.js 12.8 KiB [emitted] (name: entry)
+"asset entry.js 13.3 KiB [emitted] (name: entry)
 asset 836.js 138 bytes [emitted]
-runtime modules 7.57 KiB 10 modules
+runtime modules 7.86 KiB 10 modules
 orphan modules 37 bytes [orphan] 1 module
 cacheable modules 142 bytes
   ./entry.js 120 bytes [built] [code generated]
@@ -957,7 +957,7 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for import-with-invalid-options-comments 1`] = `
-"runtime modules 8.55 KiB 12 modules
+"runtime modules 8.83 KiB 12 modules
 cacheable modules 559 bytes
   ./index.js 50 bytes [built] [code generated]
   ./chunk.js 401 bytes [built] [code generated] [3 warnings]
@@ -982,20 +982,20 @@ webpack x.x.x compiled with 3 warnings"
 `;
 
 exports[`StatsTestCases should print correct stats for issue-7577 1`] = `
-"asset a-runtime~main-43399c7277260678413a.js 5.24 KiB [emitted] [immutable] (name: runtime~main)
+"asset a-runtime~main-f66111840fb506880361.js 5.07 KiB [emitted] [immutable] (name: runtime~main)
 asset a-all-a_js-2245ace798fe63ddba13.js 140 bytes [emitted] [immutable] (id hint: all)
 asset a-main-b1eee3373fffb0185d2b.js 114 bytes [emitted] [immutable] (name: main)
-Entrypoint main 5.49 KiB = a-runtime~main-43399c7277260678413a.js 5.24 KiB a-all-a_js-2245ace798fe63ddba13.js 140 bytes a-main-b1eee3373fffb0185d2b.js 114 bytes
-runtime modules 2.69 KiB 2 modules
+Entrypoint main 5.32 KiB = a-runtime~main-f66111840fb506880361.js 5.07 KiB a-all-a_js-2245ace798fe63ddba13.js 140 bytes a-main-b1eee3373fffb0185d2b.js 114 bytes
+runtime modules 2.57 KiB 2 modules
 ./a.js 18 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset b-runtime~main-bfa1df9c60dbe26a0c28.js 6.17 KiB [emitted] [immutable] (name: runtime~main)
+asset b-runtime~main-07b88c42e53fab457d88.js 6.01 KiB [emitted] [immutable] (name: runtime~main)
 asset b-all-b_js-5f2f43e942828cce49a7.js 475 bytes [emitted] [immutable] (id hint: all)
 asset b-vendors-node_modules_vendor_js-bf78b376ab124e2d5ed3.js 185 bytes [emitted] [immutable] (id hint: vendors)
 asset b-main-0780253982d2b99627d2.js 147 bytes [emitted] [immutable] (name: main)
-Entrypoint main 6.96 KiB = b-runtime~main-bfa1df9c60dbe26a0c28.js 6.17 KiB b-vendors-node_modules_vendor_js-bf78b376ab124e2d5ed3.js 185 bytes b-all-b_js-5f2f43e942828cce49a7.js 475 bytes b-main-0780253982d2b99627d2.js 147 bytes
-runtime modules 3.25 KiB 4 modules
+Entrypoint main 6.79 KiB = b-runtime~main-07b88c42e53fab457d88.js 6.01 KiB b-vendors-node_modules_vendor_js-bf78b376ab124e2d5ed3.js 185 bytes b-all-b_js-5f2f43e942828cce49a7.js 475 bytes b-main-0780253982d2b99627d2.js 147 bytes
+runtime modules 3.13 KiB 4 modules
 cacheable modules 40 bytes
   ./b.js 17 bytes [built] [code generated]
   ./node_modules/vendor.js 23 bytes [built] [code generated]
@@ -1004,11 +1004,11 @@ webpack x.x.x compiled successfully in X ms
 assets by chunk 895 bytes (id hint: all)
   asset c-all-b_js-128dddb8321697614d16.js 502 bytes [emitted] [immutable] (id hint: all)
   asset c-all-c_js-5fc6d532ca1ac022819e.js 393 bytes [emitted] [immutable] (id hint: all)
-asset c-runtime~main-52dcac7bccba962ab90a.js 13.9 KiB [emitted] [immutable] (name: runtime~main)
+asset c-runtime~main-13e22f5be14a57f311ce.js 13.7 KiB [emitted] [immutable] (name: runtime~main)
 asset c-main-3737497cd09f5bd99fe3.js 603 bytes [emitted] [immutable] (name: main)
 asset c-vendors-node_modules_vendor_js-bf78b376ab124e2d5ed3.js 185 bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main 14.8 KiB = c-runtime~main-52dcac7bccba962ab90a.js 13.9 KiB c-all-c_js-5fc6d532ca1ac022819e.js 393 bytes c-main-3737497cd09f5bd99fe3.js 603 bytes
-runtime modules 8.93 KiB 12 modules
+Entrypoint main 14.7 KiB = c-runtime~main-13e22f5be14a57f311ce.js 13.7 KiB c-all-c_js-5fc6d532ca1ac022819e.js 393 bytes c-main-3737497cd09f5bd99fe3.js 603 bytes
+runtime modules 8.8 KiB 12 modules
 cacheable modules 101 bytes
   ./c.js 61 bytes [built] [code generated]
   ./b.js 17 bytes [built] [code generated]
@@ -1031,10 +1031,10 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   1 chunks (webpack x.x.x) compiled successfully in X ms
 
 2 chunks:
-  asset bundle2.js 12.4 KiB [emitted] (name: main)
+  asset bundle2.js 13.1 KiB [emitted] (name: main)
   asset 459.bundle2.js 664 bytes [emitted] (name: c)
-  chunk (runtime: main) bundle2.js (main) 101 bytes (javascript) 7.58 KiB (runtime) >{459}< [entry] [rendered]
-    runtime modules 7.58 KiB 10 modules
+  chunk (runtime: main) bundle2.js (main) 101 bytes (javascript) 7.86 KiB (runtime) >{459}< [entry] [rendered]
+    runtime modules 7.86 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
   chunk (runtime: main) 459.bundle2.js (c) 118 bytes <{179}> <{459}> >{459}< [rendered]
     dependent modules 44 bytes [dependent]
@@ -1046,11 +1046,11 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   2 chunks (webpack x.x.x) compiled successfully in X ms
 
 3 chunks:
-  asset bundle3.js 12.4 KiB [emitted] (name: main)
+  asset bundle3.js 13.1 KiB [emitted] (name: main)
   asset 459.bundle3.js 528 bytes [emitted] (name: c)
   asset 524.bundle3.js 206 bytes [emitted]
-  chunk (runtime: main) bundle3.js (main) 101 bytes (javascript) 7.58 KiB (runtime) >{459}< [entry] [rendered]
-    runtime modules 7.58 KiB 10 modules
+  chunk (runtime: main) bundle3.js (main) 101 bytes (javascript) 7.86 KiB (runtime) >{459}< [entry] [rendered]
+    runtime modules 7.86 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
   chunk (runtime: main) 459.bundle3.js (c) 74 bytes <{179}> >{524}< [rendered]
     ./a.js 22 bytes [built] [code generated]
@@ -1062,12 +1062,12 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   3 chunks (webpack x.x.x) compiled successfully in X ms
 
 4 chunks:
-  asset bundle4.js 12.4 KiB [emitted] (name: main)
+  asset bundle4.js 13.1 KiB [emitted] (name: main)
   asset 459.bundle4.js 392 bytes [emitted] (name: c)
   asset 394.bundle4.js 206 bytes [emitted]
   asset 524.bundle4.js 206 bytes [emitted]
-  chunk (runtime: main) bundle4.js (main) 101 bytes (javascript) 7.58 KiB (runtime) >{394}< >{459}< [entry] [rendered]
-    runtime modules 7.58 KiB 10 modules
+  chunk (runtime: main) bundle4.js (main) 101 bytes (javascript) 7.86 KiB (runtime) >{394}< >{459}< [entry] [rendered]
+    runtime modules 7.86 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
   chunk (runtime: main) 394.bundle4.js 44 bytes <{179}> [rendered]
     ./a.js 22 bytes [built] [code generated]
@@ -1157,26 +1157,26 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for module-assets 1`] = `
-"assets by path *.js 11.6 KiB
-  asset main.js 10.3 KiB [emitted] (name: main)
+"assets by path *.js 12.3 KiB
+  asset main.js 11 KiB [emitted] (name: main)
   asset a.js 746 bytes [emitted] (name: a)
   asset b.js 563 bytes [emitted] (name: b)
 assets by path *.png 42 KiB
   asset 1.png 21 KiB [emitted] [from: node_modules/a/1.png] (auxiliary name: a)
   asset 2.png 21 KiB [emitted] [from: node_modules/a/2.png] (auxiliary name: a, b)
-Entrypoint main 10.3 KiB = main.js
+Entrypoint main 11 KiB = main.js
 Chunk Group a 746 bytes (42 KiB) = a.js 746 bytes (1.png 21 KiB 2.png 21 KiB)
 Chunk Group b 563 bytes (21 KiB) = b.js 563 bytes (2.png 21 KiB)
 chunk (runtime: main) b.js (b) 67 bytes [rendered]
   ./node_modules/a/2.png 49 bytes [dependent] [built] [code generated] [1 asset]
   ./node_modules/b/index.js 18 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 82 bytes (javascript) 6.19 KiB (runtime) [entry] [rendered]
-  runtime modules 6.19 KiB 8 modules
+chunk (runtime: main) main.js (main) 82 bytes (javascript) 6.48 KiB (runtime) [entry] [rendered]
+  runtime modules 6.48 KiB 8 modules
   ./index.js 82 bytes [built] [code generated]
 chunk (runtime: main) a.js (a) 134 bytes [rendered]
   ./node_modules/a/2.png 49 bytes [dependent] [built] [code generated] [1 asset]
   ./node_modules/a/index.js + 1 modules 85 bytes [built] [code generated] [1 asset]
-runtime modules 6.19 KiB 8 modules
+runtime modules 6.48 KiB 8 modules
 orphan modules 49 bytes [orphan] 1 module
 modules with assets 234 bytes
   modules by path ./node_modules/a/ 134 bytes
@@ -1188,9 +1188,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for module-deduplication 1`] = `
-"asset e1.js 11.9 KiB [emitted] (name: e1)
-asset e2.js 11.9 KiB [emitted] (name: e2)
-asset e3.js 11.9 KiB [emitted] (name: e3)
+"asset e1.js 12.6 KiB [emitted] (name: e1)
+asset e2.js 12.6 KiB [emitted] (name: e2)
+asset e3.js 12.6 KiB [emitted] (name: e3)
 asset 172.js 864 bytes [emitted]
 asset 326.js 864 bytes [emitted]
 asset 923.js 864 bytes [emitted]
@@ -1199,8 +1199,8 @@ asset 593.js 518 bytes [emitted]
 asset 716.js 518 bytes [emitted]
 chunk (runtime: e1) 114.js 61 bytes [rendered]
   ./async1.js 61 bytes [built] [code generated]
-chunk (runtime: e3) e3.js (e3) 249 bytes (javascript) 6.47 KiB (runtime) [entry] [rendered]
-  runtime modules 6.47 KiB 9 modules
+chunk (runtime: e3) e3.js (e3) 249 bytes (javascript) 6.75 KiB (runtime) [entry] [rendered]
+  runtime modules 6.75 KiB 9 modules
   cacheable modules 249 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e3.js + 2 modules 209 bytes [built] [code generated]
@@ -1208,8 +1208,8 @@ chunk (runtime: e3) e3.js (e3) 249 bytes (javascript) 6.47 KiB (runtime) [entry]
 chunk (runtime: e1, e3) 172.js 81 bytes [rendered]
   ./async2.js 61 bytes [built] [code generated]
   ./f.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e1) e1.js (e1) 249 bytes (javascript) 6.47 KiB (runtime) [entry] [rendered]
-  runtime modules 6.47 KiB 9 modules
+chunk (runtime: e1) e1.js (e1) 249 bytes (javascript) 6.75 KiB (runtime) [entry] [rendered]
+  runtime modules 6.75 KiB 9 modules
   cacheable modules 249 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./d.js 20 bytes [dependent] [built] [code generated]
@@ -1219,8 +1219,8 @@ chunk (runtime: e1, e2) 326.js 81 bytes [rendered]
   ./h.js 20 bytes [dependent] [built] [code generated]
 chunk (runtime: e3) 593.js 61 bytes [rendered]
   ./async3.js 61 bytes [built] [code generated]
-chunk (runtime: e2) e2.js (e2) 249 bytes (javascript) 6.47 KiB (runtime) [entry] [rendered]
-  runtime modules 6.47 KiB 9 modules
+chunk (runtime: e2) e2.js (e2) 249 bytes (javascript) 6.75 KiB (runtime) [entry] [rendered]
+  runtime modules 6.75 KiB 9 modules
   cacheable modules 249 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e2.js + 2 modules 209 bytes [built] [code generated]
@@ -1234,20 +1234,20 @@ webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for module-deduplication-named 1`] = `
-"asset e1.js 11.8 KiB [emitted] (name: e1)
-asset e2.js 11.8 KiB [emitted] (name: e2)
-asset e3.js 11.8 KiB [emitted] (name: e3)
+"asset e1.js 12.5 KiB [emitted] (name: e1)
+asset e2.js 12.5 KiB [emitted] (name: e2)
+asset e3.js 12.5 KiB [emitted] (name: e3)
 asset async1.js 970 bytes [emitted] (name: async1)
 asset async2.js 970 bytes [emitted] (name: async2)
 asset async3.js 970 bytes [emitted] (name: async3)
-chunk (runtime: e3) e3.js (e3) 242 bytes (javascript) 6.52 KiB (runtime) [entry] [rendered]
-  runtime modules 6.52 KiB 9 modules
+chunk (runtime: e3) e3.js (e3) 242 bytes (javascript) 6.8 KiB (runtime) [entry] [rendered]
+  runtime modules 6.8 KiB 9 modules
   cacheable modules 242 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e3.js + 2 modules 202 bytes [built] [code generated]
     ./h.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e1) e1.js (e1) 242 bytes (javascript) 6.52 KiB (runtime) [entry] [rendered]
-  runtime modules 6.52 KiB 9 modules
+chunk (runtime: e1) e1.js (e1) 242 bytes (javascript) 6.8 KiB (runtime) [entry] [rendered]
+  runtime modules 6.8 KiB 9 modules
   cacheable modules 242 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./d.js 20 bytes [dependent] [built] [code generated]
@@ -1258,8 +1258,8 @@ chunk (runtime: e1, e2, e3) async1.js (async1) 135 bytes [rendered]
 chunk (runtime: e1, e2, e3) async3.js (async3) 135 bytes [rendered]
   ./async3.js 115 bytes [built] [code generated]
   ./h.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e2) e2.js (e2) 242 bytes (javascript) 6.52 KiB (runtime) [entry] [rendered]
-  runtime modules 6.52 KiB 9 modules
+chunk (runtime: e2) e2.js (e2) 242 bytes (javascript) 6.8 KiB (runtime) [entry] [rendered]
+  runtime modules 6.8 KiB 9 modules
   cacheable modules 242 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e2.js + 2 modules 202 bytes [built] [code generated]
@@ -1359,7 +1359,7 @@ webpack x.x.x compiled with 2 errors in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for named-chunk-groups 1`] = `
-"Chunk Group main 11.5 KiB = a-main.js
+"Chunk Group main 12.2 KiB = a-main.js
 Chunk Group async-a 1.07 KiB = a-52.js 257 bytes a-async-a.js 834 bytes
 Chunk Group async-b 1.07 KiB = a-52.js 257 bytes a-async-b.js 834 bytes
 Chunk Group async-c 1.45 KiB = a-vendors.js 754 bytes a-async-c.js 733 bytes
@@ -1367,9 +1367,9 @@ chunk (runtime: main) a-52.js 149 bytes [rendered] split chunk (cache group: def
   > ./a ./index.js 1:0-47
   > ./b ./index.js 2:0-47
   ./shared.js 149 bytes [built] [code generated]
-chunk (runtime: main) a-main.js (main) 146 bytes (javascript) 6.81 KiB (runtime) [entry] [rendered]
+chunk (runtime: main) a-main.js (main) 146 bytes (javascript) 7.09 KiB (runtime) [entry] [rendered]
   > ./ main
-  runtime modules 6.81 KiB 10 modules
+  runtime modules 7.09 KiB 10 modules
   ./index.js 146 bytes [built] [code generated]
 chunk (runtime: main) a-vendors.js (vendors) (id hint: vendors) 40 bytes [rendered] split chunk (cache group: vendors) (name: vendors)
   > ./c ./index.js 3:0-47
@@ -1386,7 +1386,7 @@ chunk (runtime: main) a-async-a.js (async-a) 175 bytes [rendered]
   ./a.js 175 bytes [built] [code generated]
 webpack x.x.x compiled successfully
 
-Entrypoint main 11.5 KiB = b-main.js
+Entrypoint main 12.2 KiB = b-main.js
 Chunk Group async-a 1.07 KiB = b-52.js 257 bytes b-async-a.js 834 bytes
 Chunk Group async-b 1.07 KiB = b-52.js 257 bytes b-async-b.js 834 bytes
 Chunk Group async-c 1.45 KiB = b-vendors.js 754 bytes b-async-c.js 733 bytes
@@ -1394,9 +1394,9 @@ chunk (runtime: main) b-52.js 149 bytes [rendered] split chunk (cache group: def
   > ./a ./index.js 1:0-47
   > ./b ./index.js 2:0-47
   ./shared.js 149 bytes [built] [code generated]
-chunk (runtime: main) b-main.js (main) 146 bytes (javascript) 6.81 KiB (runtime) [entry] [rendered]
+chunk (runtime: main) b-main.js (main) 146 bytes (javascript) 7.09 KiB (runtime) [entry] [rendered]
   > ./ main
-  runtime modules 6.81 KiB 10 modules
+  runtime modules 7.09 KiB 10 modules
   ./index.js 146 bytes [built] [code generated]
 chunk (runtime: main) b-vendors.js (vendors) (id hint: vendors) 40 bytes [rendered] split chunk (cache group: vendors) (name: vendors)
   > ./c ./index.js 3:0-47
@@ -1415,10 +1415,10 @@ webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for named-chunks-plugin 1`] = `
-"asset entry.js 5.55 KiB [emitted] (name: entry)
+"asset entry.js 5.39 KiB [emitted] (name: entry)
 asset vendor.js 237 bytes [emitted] (name: vendor) (id hint: vendor)
-Entrypoint entry 5.78 KiB = vendor.js 237 bytes entry.js 5.55 KiB
-runtime modules 2.71 KiB 2 modules
+Entrypoint entry 5.62 KiB = vendor.js 237 bytes entry.js 5.39 KiB
+runtime modules 2.59 KiB 2 modules
 cacheable modules 138 bytes
   ./entry.js 72 bytes [built] [code generated]
   ./modules/a.js 22 bytes [built] [code generated]
@@ -1428,10 +1428,10 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for named-chunks-plugin-async 1`] = `
-"asset entry.js 12.3 KiB [emitted] (name: entry)
+"asset entry.js 13 KiB [emitted] (name: entry)
 asset modules_a_js.js 313 bytes [emitted]
 asset modules_b_js.js 149 bytes [emitted]
-runtime modules 7.58 KiB 10 modules
+runtime modules 7.86 KiB 10 modules
 cacheable modules 106 bytes
   ./entry.js 47 bytes [built] [code generated]
   ./modules/a.js 37 bytes [built] [code generated]
@@ -1452,7 +1452,7 @@ webpack x.x.x compiled with 1 error and 1 warning in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for optimize-chunks 1`] = `
-"asset main.js 10.8 KiB {179} [emitted] (name: main)
+"asset main.js 11.5 KiB {179} [emitted] (name: main)
 asset cir2 from cir1.js 374 bytes {288}, {289} [emitted] (name: cir2 from cir1)
 asset cir1.js 330 bytes {592} [emitted] (name: cir1)
 asset cir2.js 330 bytes {289} [emitted] (name: cir2)
@@ -1464,9 +1464,9 @@ chunk {90} (runtime: main) ab.js (ab) 2 bytes <{179}> >{753}< [rendered]
   > [10] ./index.js 1:0-6:8
   ./modules/a.js [839] 1 bytes {90} {374} [built] [code generated]
   ./modules/b.js [836] 1 bytes {90} {374} [built] [code generated]
-chunk {179} (runtime: main) main.js (main) 524 bytes (javascript) 6.01 KiB (runtime) >{90}< >{289}< >{374}< >{592}< [entry] [rendered]
+chunk {179} (runtime: main) main.js (main) 524 bytes (javascript) 6.29 KiB (runtime) >{90}< >{289}< >{374}< >{592}< [entry] [rendered]
   > ./index main
-  runtime modules 6.01 KiB 7 modules
+  runtime modules 6.29 KiB 7 modules
   cacheable modules 524 bytes
     ./index.js [10] 523 bytes {179} [built] [code generated]
     ./modules/f.js [544] 1 bytes {179} [dependent] [built] [code generated]
@@ -1498,9 +1498,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for output-module 1`] = `
-"asset main.js 9.91 KiB [emitted] [javascript module] (name: main)
+"asset main.js 10.6 KiB [emitted] [javascript module] (name: main)
 asset 52.js 415 bytes [emitted] [javascript module]
-runtime modules 5.97 KiB 8 modules
+runtime modules 6.26 KiB 8 modules
 orphan modules 38 bytes [orphan] 1 module
 cacheable modules 263 bytes
   ./index.js + 1 modules 225 bytes [built] [code generated]
@@ -1604,12 +1604,12 @@ webpack x.x.x compiled with 3 warnings in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for performance-disabled 1`] = `
-"asset <CLR=32,BOLD>main.js</CLR> 303 KiB <CLR=32,BOLD>[emitted]</CLR> (name: main)
+"asset <CLR=32,BOLD>main.js</CLR> 304 KiB <CLR=32,BOLD>[emitted]</CLR> (name: main)
 asset <CLR=32,BOLD>460.js</CLR> 320 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
-Entrypoint <CLR=BOLD>main</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
-runtime modules 5.9 KiB 7 modules
+Entrypoint <CLR=BOLD>main</CLR> 304 KiB = <CLR=32,BOLD>main.js</CLR>
+runtime modules 6.19 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -1621,12 +1621,12 @@ webpack x.x.x compiled <CLR=32,BOLD>successfully</CLR> in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for performance-error 1`] = `
-"asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>303 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main)
+"asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>304 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main)
 asset <CLR=32,BOLD>460.js</CLR> 320 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
-Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
-runtime modules 5.9 KiB 7 modules
+Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> 304 KiB = <CLR=32,BOLD>main.js</CLR>
+runtime modules 6.19 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -1638,11 +1638,11 @@ cacheable modules 293 KiB
 <CLR=31,BOLD>ERROR</CLR> in <CLR=BOLD>asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
 This can impact web performance.
 Assets: 
-  main.js (303 KiB)</CLR>
+  main.js (304 KiB)</CLR>
 
 <CLR=31,BOLD>ERROR</CLR> in <CLR=BOLD>entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
 Entrypoints:
-  main (303 KiB)
+  main (304 KiB)
       main.js
 </CLR>
 
@@ -1680,12 +1680,12 @@ webpack x.x.x compiled with <CLR=33,BOLD>3 warnings</CLR> in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for performance-no-hints 1`] = `
-"asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>303 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main)
+"asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>304 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main)
 asset <CLR=32,BOLD>460.js</CLR> 320 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
-Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
-runtime modules 5.9 KiB 7 modules
+Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> 304 KiB = <CLR=32,BOLD>main.js</CLR>
+runtime modules 6.19 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -1727,17 +1727,17 @@ webpack x.x.x compiled with <CLR=31,BOLD>3 errors</CLR> in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for prefetch 1`] = `
-"asset main.js 15.7 KiB {179} [emitted] (name: main)
+"asset main.js 16.1 KiB {179} [emitted] (name: main)
 asset prefetched.js 556 bytes {505} [emitted] (name: prefetched)
 asset inner2.js 150 bytes {641} [emitted] (name: inner2)
 asset inner.js 110 bytes {746} [emitted] (name: inner)
 asset prefetched2.js 110 bytes {379} [emitted] (name: prefetched2)
 asset prefetched3.js 110 bytes {220} [emitted] (name: prefetched3)
 asset normal.js 109 bytes {30} [emitted] (name: normal)
-Entrypoint main 15.7 KiB = main.js
+Entrypoint main 16.1 KiB = main.js
   prefetch: prefetched2.js {379} (name: prefetched2), prefetched.js {505} (name: prefetched), prefetched3.js {220} (name: prefetched3)
 chunk {30} (runtime: main) normal.js (normal) 1 bytes <{179}> [rendered]
-chunk {179} (runtime: main) main.js (main) 436 bytes (javascript) 9 KiB (runtime) >{30}< >{220}< >{379}< >{505}< (prefetch: {379} {505} {220}) [entry] [rendered]
+chunk {179} (runtime: main) main.js (main) 436 bytes (javascript) 9.28 KiB (runtime) >{30}< >{220}< >{379}< >{505}< (prefetch: {379} {505} {220}) [entry] [rendered]
 chunk {220} (runtime: main) prefetched3.js (prefetched3) 1 bytes <{179}> [rendered]
 chunk {379} (runtime: main) prefetched2.js (prefetched2) 1 bytes <{179}> [rendered]
 chunk {505} (runtime: main) prefetched.js (prefetched) 228 bytes <{179}> >{641}< >{746}< (prefetch: {641} {746}) [rendered]
@@ -1752,7 +1752,7 @@ chunk (runtime: main) c1.js (c1) 1 bytes <{459}> [rendered]
 chunk (runtime: main) b.js (b) 203 bytes <{179}> >{132}< >{751}< >{978}< (prefetch: {751} {132}) (preload: {978}) [rendered]
 chunk (runtime: main) b3.js (b3) 1 bytes <{128}> [rendered]
 chunk (runtime: main) a2.js (a2) 1 bytes <{786}> [rendered]
-chunk (runtime: main) main.js (main) 195 bytes (javascript) 9.67 KiB (runtime) >{128}< >{459}< >{786}< (prefetch: {786} {128} {459}) [entry] [rendered]
+chunk (runtime: main) main.js (main) 195 bytes (javascript) 9.95 KiB (runtime) >{128}< >{459}< >{786}< (prefetch: {786} {128} {459}) [entry] [rendered]
 chunk (runtime: main) c.js (c) 134 bytes <{179}> >{3}< >{76}< (preload: {76} {3}) [rendered]
 chunk (runtime: main) b1.js (b1) 1 bytes <{128}> [rendered]
 chunk (runtime: main) a.js (a) 136 bytes <{179}> >{74}< >{178}< (prefetch: {74} {178}) [rendered]
@@ -1760,17 +1760,17 @@ chunk (runtime: main) b2.js (b2) 1 bytes <{128}> [rendered]"
 `;
 
 exports[`StatsTestCases should print correct stats for preload 1`] = `
-"asset main.js 15 KiB [emitted] (name: main)
+"asset main.js 15.7 KiB [emitted] (name: main)
 asset preloaded.js 556 bytes [emitted] (name: preloaded)
 asset inner2.js 150 bytes [emitted] (name: inner2)
 asset inner.js 110 bytes [emitted] (name: inner)
 asset normal.js 109 bytes [emitted] (name: normal)
 asset preloaded2.js 109 bytes [emitted] (name: preloaded2)
 asset preloaded3.js 108 bytes [emitted] (name: preloaded3)
-Entrypoint main 15 KiB = main.js
+Entrypoint main 15.7 KiB = main.js
   preload: preloaded2.js (name: preloaded2), preloaded.js (name: preloaded), preloaded3.js (name: preloaded3)
 chunk (runtime: main) normal.js (normal) 1 bytes [rendered]
-chunk (runtime: main) main.js (main) 424 bytes (javascript) 8.82 KiB (runtime) (preload: {363} {851} {355}) [entry] [rendered]
+chunk (runtime: main) main.js (main) 424 bytes (javascript) 9.1 KiB (runtime) (preload: {363} {851} {355}) [entry] [rendered]
 chunk (runtime: main) preloaded3.js (preloaded3) 1 bytes [rendered]
 chunk (runtime: main) preloaded2.js (preloaded2) 1 bytes [rendered]
 chunk (runtime: main) inner2.js (inner2) 2 bytes [rendered]
@@ -1788,12 +1788,12 @@ exports[`StatsTestCases should print correct stats for preset-detailed 1`] = `
       [LogTestPlugin] Log
     [LogTestPlugin] End
 PublicPath: auto
-asset main.js 10 KiB {179} [emitted] (name: main)
+asset main.js 10.7 KiB {179} [emitted] (name: main)
 asset 460.js 320 bytes {460} [emitted]
 asset 524.js 206 bytes {524} [emitted]
 asset 996.js 138 bytes {996} [emitted]
-Entrypoint main 10 KiB = main.js
-chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 5.9 KiB (runtime) >{460}< >{996}< [entry] [rendered]
+Entrypoint main 10.7 KiB = main.js
+chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 6.19 KiB (runtime) >{460}< >{996}< [entry] [rendered]
   > ./index main
 chunk {460} (runtime: main) 460.js 54 bytes <{179}> >{524}< [rendered]
   > ./c [10] ./index.js 3:0-16
@@ -1801,7 +1801,7 @@ chunk {524} (runtime: main) 524.js 44 bytes <{460}> [rendered]
   > [460] ./c.js 1:0-52
 chunk {996} (runtime: main) 996.js 22 bytes <{179}> [rendered]
   > ./b [10] ./index.js 2:0-16
-runtime modules 5.9 KiB
+runtime modules 6.19 KiB
   webpack/runtime/ensure chunk 326 bytes {179} [code generated]
     [no exports]
     [used exports unknown]
@@ -1814,7 +1814,7 @@ runtime modules 5.9 KiB
   webpack/runtime/hasOwnProperty shorthand 86 bytes {179} [code generated]
     [no exports]
     [used exports unknown]
-  webpack/runtime/jsonp chunk loading 2.92 KiB {179} [code generated]
+  webpack/runtime/jsonp chunk loading 3.2 KiB {179} [code generated]
     [no exports]
     [used exports unknown]
   webpack/runtime/load script 1.36 KiB {179} [code generated]
@@ -1890,7 +1890,7 @@ LOG from webpack.FileSystemInfo
     Directory info in cache: 0 timestamps 0 hashes 0 timestamp hash combinations
     Managed items info in cache: 0 items
 
-1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (06e9b525908b24d12b22)"
+1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (c2040a0b7f914b5ac7d3)"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-errors-only 1`] = `""`;
@@ -1964,11 +1964,11 @@ exports[`StatsTestCases should print correct stats for preset-normal 1`] = `
 "<e> [LogTestPlugin] Error
 <w> [LogTestPlugin] Warning
 <i> [LogTestPlugin] Info
-asset main.js 10 KiB [emitted] (name: main)
+asset main.js 10.7 KiB [emitted] (name: main)
 asset 460.js 320 bytes [emitted]
 asset 524.js 206 bytes [emitted]
 asset 996.js 138 bytes [emitted]
-runtime modules 5.9 KiB 7 modules
+runtime modules 6.19 KiB 7 modules
 cacheable modules 193 bytes
   ./index.js 51 bytes [built] [code generated]
   ./a.js 22 bytes [built] [code generated]
@@ -1987,11 +1987,11 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-normal-performance 1`] = `
-"asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>303 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main)
+"asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>304 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main)
 asset <CLR=32,BOLD>460.js</CLR> 320 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
-runtime modules 5.9 KiB 7 modules
+runtime modules 6.19 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2003,11 +2003,11 @@ cacheable modules 293 KiB
 <CLR=33,BOLD>WARNING</CLR> in <CLR=BOLD>asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
 This can impact web performance.
 Assets: 
-  main.js (303 KiB)</CLR>
+  main.js (304 KiB)</CLR>
 
 <CLR=33,BOLD>WARNING</CLR> in <CLR=BOLD>entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
 Entrypoints:
-  main (303 KiB)
+  main (304 KiB)
       main.js
 </CLR>
 
@@ -2015,11 +2015,11 @@ webpack x.x.x compiled with <CLR=33,BOLD>2 warnings</CLR> in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-normal-performance-ensure-filter-sourcemaps 1`] = `
-"asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>303 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main) 1 related asset
+"asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>304 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main) 1 related asset
 asset <CLR=32,BOLD>460.js</CLR> 352 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
 asset <CLR=32,BOLD>524.js</CLR> 238 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
 asset <CLR=32,BOLD>996.js</CLR> 170 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
-runtime modules 5.9 KiB 7 modules
+runtime modules 6.19 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2031,11 +2031,11 @@ cacheable modules 293 KiB
 <CLR=33,BOLD>WARNING</CLR> in <CLR=BOLD>asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
 This can impact web performance.
 Assets: 
-  main.js (303 KiB)</CLR>
+  main.js (304 KiB)</CLR>
 
 <CLR=33,BOLD>WARNING</CLR> in <CLR=BOLD>entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
 Entrypoints:
-  main (303 KiB)
+  main (304 KiB)
       main.js
 </CLR>
 
@@ -2062,14 +2062,14 @@ exports[`StatsTestCases should print correct stats for preset-verbose 1`] = `
       [LogTestPlugin] Log
     [LogTestPlugin] End
 PublicPath: auto
-asset main.js 10 KiB {179} [emitted] (name: main)
+asset main.js 10.7 KiB {179} [emitted] (name: main)
 asset 460.js 320 bytes {460} [emitted]
 asset 524.js 206 bytes {524} [emitted]
 asset 996.js 138 bytes {996} [emitted]
-Entrypoint main 10 KiB = main.js
-chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 5.9 KiB (runtime) >{460}< >{996}< [entry] [rendered]
+Entrypoint main 10.7 KiB = main.js
+chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 6.19 KiB (runtime) >{460}< >{996}< [entry] [rendered]
   > ./index main
-  runtime modules 5.9 KiB 7 modules
+  runtime modules 6.19 KiB 7 modules
   cacheable modules 73 bytes
     ./a.js [847] 22 bytes {179} [depth 1] [dependent] [built] [code generated]
       [used exports unknown]
@@ -2235,19 +2235,19 @@ LOG from webpack.FileSystemInfo
     Directory info in cache: 0 timestamps 0 hashes 0 timestamp hash combinations
     Managed items info in cache: 0 items
 
-1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (06e9b525908b24d12b22)"
+1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (c2040a0b7f914b5ac7d3)"
 `;
 
 exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
 "a-normal:
   assets by path *.js 3 KiB
-    asset d334fee2a36188e0a09c-d334fe.js 2.61 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+    asset f18a3ec14dd86babfb9f-f18a3e.js 2.6 KiB [emitted] [immutable] [minimized] (name: runtime~main)
     asset 3cc8faad16137711c07e-3cc8fa.js 210 bytes [emitted] [immutable] [minimized] (name: main)
     asset b6f77787a670e97d47b5-b6f777.js 193 bytes [emitted] [immutable] [minimized] (name: lazy)
   asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: main)
-  Entrypoint main 2.81 KiB (5.89 KiB) = d334fee2a36188e0a09c-d334fe.js 2.61 KiB 3cc8faad16137711c07e-3cc8fa.js 210 bytes 1 auxiliary asset
-  runtime modules 7.47 KiB 8 modules
+  Entrypoint main 2.81 KiB (5.89 KiB) = f18a3ec14dd86babfb9f-f18a3e.js 2.6 KiB 3cc8faad16137711c07e-3cc8fa.js 210 bytes 1 auxiliary asset
+  runtime modules 7.35 KiB 8 modules
   orphan modules 23 bytes [orphan] 1 module
   cacheable modules 340 bytes (javascript) 20.4 KiB (asset)
     javascript modules 256 bytes
@@ -2260,13 +2260,13 @@ exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
 
 b-normal:
   assets by path *.js 3 KiB
-    asset d334fee2a36188e0a09c-d334fe.js 2.61 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+    asset f18a3ec14dd86babfb9f-f18a3e.js 2.6 KiB [emitted] [immutable] [minimized] (name: runtime~main)
     asset 3cc8faad16137711c07e-3cc8fa.js 210 bytes [emitted] [immutable] [minimized] (name: main)
     asset b6f77787a670e97d47b5-b6f777.js 193 bytes [emitted] [immutable] [minimized] (name: lazy)
   asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: main)
-  Entrypoint main 2.81 KiB (5.89 KiB) = d334fee2a36188e0a09c-d334fe.js 2.61 KiB 3cc8faad16137711c07e-3cc8fa.js 210 bytes 1 auxiliary asset
-  runtime modules 7.47 KiB 8 modules
+  Entrypoint main 2.81 KiB (5.89 KiB) = f18a3ec14dd86babfb9f-f18a3e.js 2.6 KiB 3cc8faad16137711c07e-3cc8fa.js 210 bytes 1 auxiliary asset
+  runtime modules 7.35 KiB 8 modules
   orphan modules 19 bytes [orphan] 1 module
   cacheable modules 295 bytes (javascript) 20.4 KiB (asset)
     javascript modules 211 bytes
@@ -2278,17 +2278,17 @@ b-normal:
   b-normal (webpack x.x.x) compiled successfully in X ms
 
 a-source-map:
-  assets by path *.js 3.17 KiB
-    asset 05313e28d7795f776fc1-05313e.js 2.66 KiB [emitted] [immutable] [minimized] (name: runtime~main)
-      sourceMap 05313e28d7795f776fc1-05313e.js.map 14.5 KiB [emitted] [dev] (auxiliary name: runtime~main)
+  assets by path *.js 3.16 KiB
+    asset 77826605dda4b8b1919e-778266.js 2.66 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+      sourceMap 77826605dda4b8b1919e-778266.js.map 14.3 KiB [emitted] [dev] (auxiliary name: runtime~main)
     asset b8bfcec62cdd15c9a840-b8bfce.js 266 bytes [emitted] [immutable] [minimized] (name: main)
       sourceMap b8bfcec62cdd15c9a840-b8bfce.js.map 366 bytes [emitted] [dev] (auxiliary name: main)
     asset c7c0f8bb2e61b59a89f5-c7c0f8.js 249 bytes [emitted] [immutable] [minimized] (name: lazy)
       sourceMap c7c0f8bb2e61b59a89f5-c7c0f8.js.map 331 bytes [emitted] [dev] (auxiliary name: lazy)
   asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: main)
-  Entrypoint main 2.92 KiB (20.7 KiB) = 05313e28d7795f776fc1-05313e.js 2.66 KiB b8bfcec62cdd15c9a840-b8bfce.js 266 bytes 3 auxiliary assets
-  runtime modules 7.47 KiB 8 modules
+  Entrypoint main 2.92 KiB (20.5 KiB) = 77826605dda4b8b1919e-778266.js 2.66 KiB b8bfcec62cdd15c9a840-b8bfce.js 266 bytes 3 auxiliary assets
+  runtime modules 7.35 KiB 8 modules
   orphan modules 23 bytes [orphan] 1 module
   cacheable modules 340 bytes (javascript) 20.4 KiB (asset)
     javascript modules 256 bytes
@@ -2300,17 +2300,17 @@ a-source-map:
   a-source-map (webpack x.x.x) compiled successfully in X ms
 
 b-source-map:
-  assets by path *.js 3.17 KiB
-    asset 06b6acb94efe9f618ff4-06b6ac.js 2.66 KiB [emitted] [immutable] [minimized] (name: runtime~main)
-      sourceMap 06b6acb94efe9f618ff4-06b6ac.js.map 14.5 KiB [emitted] [dev] (auxiliary name: runtime~main)
+  assets by path *.js 3.16 KiB
+    asset 7810f06c1d11aa51e2f4-7810f0.js 2.66 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+      sourceMap 7810f06c1d11aa51e2f4-7810f0.js.map 14.3 KiB [emitted] [dev] (auxiliary name: runtime~main)
     asset b8bfcec62cdd15c9a840-b8bfce.js 266 bytes [emitted] [immutable] [minimized] (name: main)
       sourceMap b8bfcec62cdd15c9a840-b8bfce.js.map 323 bytes [emitted] [dev] (auxiliary name: main)
     asset c7c0f8bb2e61b59a89f5-c7c0f8.js 249 bytes [emitted] [immutable] [minimized] (name: lazy)
       sourceMap c7c0f8bb2e61b59a89f5-c7c0f8.js.map 327 bytes [emitted] [dev] (auxiliary name: lazy)
   asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: main)
-  Entrypoint main 2.92 KiB (20.7 KiB) = 06b6acb94efe9f618ff4-06b6ac.js 2.66 KiB b8bfcec62cdd15c9a840-b8bfce.js 266 bytes 3 auxiliary assets
-  runtime modules 7.47 KiB 8 modules
+  Entrypoint main 2.92 KiB (20.5 KiB) = 7810f06c1d11aa51e2f4-7810f0.js 2.66 KiB b8bfcec62cdd15c9a840-b8bfce.js 266 bytes 3 auxiliary assets
+  runtime modules 7.35 KiB 8 modules
   orphan modules 19 bytes [orphan] 1 module
   cacheable modules 295 bytes (javascript) 20.4 KiB (asset)
     javascript modules 211 bytes
@@ -2324,21 +2324,21 @@ b-source-map:
 
 exports[`StatsTestCases should print correct stats for related-assets 1`] = `
 "default:
-  assets by path *.js 15.1 KiB
-    asset default-main.js 14.4 KiB [emitted] (name: main) 3 related assets
+  assets by path *.js 15.7 KiB
+    asset default-main.js 14.9 KiB [emitted] (name: main) 3 related assets
     asset default-chunk_js.js 815 bytes [emitted] 3 related assets
   assets by path *.css 142 bytes
     asset default-chunk_js.css 73 bytes [emitted] 3 related assets
     asset default-main.css 69 bytes [emitted] (name: main) 3 related assets
 
 relatedAssets:
-  assets by path *.js 15.2 KiB
-    asset relatedAssets-main.js 14.4 KiB [emitted] (name: main)
-      compressed relatedAssets-main.js.br 14.4 KiB [emitted]
-      compressed relatedAssets-main.js.gz 14.4 KiB [emitted]
-      sourceMap relatedAssets-main.js.map 12.5 KiB [emitted] [dev] (auxiliary name: main)
-        compressed relatedAssets-main.js.map.br 12.5 KiB [emitted]
-        compressed relatedAssets-main.js.map.gz 12.5 KiB [emitted]
+  assets by path *.js 15.7 KiB
+    asset relatedAssets-main.js 14.9 KiB [emitted] (name: main)
+      compressed relatedAssets-main.js.br 14.9 KiB [emitted]
+      compressed relatedAssets-main.js.gz 14.9 KiB [emitted]
+      sourceMap relatedAssets-main.js.map 12.9 KiB [emitted] [dev] (auxiliary name: main)
+        compressed relatedAssets-main.js.map.br 12.9 KiB [emitted]
+        compressed relatedAssets-main.js.map.gz 12.9 KiB [emitted]
     asset relatedAssets-chunk_js.js 821 bytes [emitted]
       compressed relatedAssets-chunk_js.js.br 821 bytes [emitted]
       compressed relatedAssets-chunk_js.js.gz 821 bytes [emitted]
@@ -2360,11 +2360,11 @@ relatedAssets:
       compressed relatedAssets-main.css.gz 75 bytes [emitted]
 
 exclude1:
-  assets by path *.js 15.2 KiB
-    asset exclude1-main.js 14.4 KiB [emitted] (name: main)
-      hidden assets 28.7 KiB 2 assets
-      sourceMap exclude1-main.js.map 12.5 KiB [emitted] [dev] (auxiliary name: main)
-        hidden assets 24.9 KiB 2 assets
+  assets by path *.js 15.7 KiB
+    asset exclude1-main.js 14.9 KiB [emitted] (name: main)
+      hidden assets 29.7 KiB 2 assets
+      sourceMap exclude1-main.js.map 12.9 KiB [emitted] [dev] (auxiliary name: main)
+        hidden assets 25.9 KiB 2 assets
         1 related asset
       1 related asset
     asset exclude1-chunk_js.js 816 bytes [emitted]
@@ -2388,11 +2388,11 @@ exclude1:
       1 related asset
 
 exclude2:
-  assets by path *.js 15.2 KiB
-    asset exclude2-main.js 14.4 KiB [emitted] (name: main)
-      hidden assets 12.5 KiB 1 asset
-      compressed exclude2-main.js.br 14.4 KiB [emitted]
-      compressed exclude2-main.js.gz 14.4 KiB [emitted]
+  assets by path *.js 15.7 KiB
+    asset exclude2-main.js 14.9 KiB [emitted] (name: main)
+      hidden assets 12.9 KiB 1 asset
+      compressed exclude2-main.js.br 14.9 KiB [emitted]
+      compressed exclude2-main.js.gz 14.9 KiB [emitted]
     asset exclude2-chunk_js.js 816 bytes [emitted]
       hidden assets 296 bytes 1 asset
       compressed exclude2-chunk_js.js.br 816 bytes [emitted]
@@ -2409,13 +2409,13 @@ exclude2:
 
 exclude3:
   hidden assets 890 bytes 2 assets
-  assets by status 14.4 KiB [emitted]
-    asset exclude3-main.js 14.4 KiB [emitted] (name: main)
-      compressed exclude3-main.js.br 14.4 KiB [emitted]
-      compressed exclude3-main.js.gz 14.4 KiB [emitted]
-      sourceMap exclude3-main.js.map 12.5 KiB [emitted] [dev] (auxiliary name: main)
-        compressed exclude3-main.js.map.br 12.5 KiB [emitted]
-        compressed exclude3-main.js.map.gz 12.5 KiB [emitted]
+  assets by status 14.9 KiB [emitted]
+    asset exclude3-main.js 14.9 KiB [emitted] (name: main)
+      compressed exclude3-main.js.br 14.9 KiB [emitted]
+      compressed exclude3-main.js.gz 14.9 KiB [emitted]
+      sourceMap exclude3-main.js.map 12.9 KiB [emitted] [dev] (auxiliary name: main)
+        compressed exclude3-main.js.map.br 12.9 KiB [emitted]
+        compressed exclude3-main.js.map.gz 12.9 KiB [emitted]
     asset exclude3-main.css 70 bytes [emitted] (name: main)
       sourceMap exclude3-main.css.map 182 bytes [emitted] [dev] (auxiliary name: main)
         compressed exclude3-main.css.map.br 182 bytes [emitted]
@@ -2472,18 +2472,18 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for runtime-chunk 1`] = `
-"Entrypoint e1 6.63 KiB = runtime~e1.js 5.79 KiB e1.js 857 bytes
-Entrypoint e2 6.63 KiB = runtime~e2.js 5.79 KiB e2.js 857 bytes
+"Entrypoint e1 6.46 KiB = runtime~e1.js 5.63 KiB e1.js 857 bytes
+Entrypoint e2 6.46 KiB = runtime~e2.js 5.63 KiB e2.js 857 bytes
 webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for runtime-chunk-integration 1`] = `
 "base:
-  asset without-runtime.js 12.4 KiB [emitted] (name: runtime)
+  asset without-runtime.js 12.2 KiB [emitted] (name: runtime)
   asset without-505.js 1.22 KiB [emitted]
   asset without-main1.js 596 bytes [emitted] (name: main1)
-  Entrypoint main1 13 KiB = without-runtime.js 12.4 KiB without-main1.js 596 bytes
-  runtime modules 7.75 KiB 9 modules
+  Entrypoint main1 12.8 KiB = without-runtime.js 12.2 KiB without-main1.js 596 bytes
+  runtime modules 7.62 KiB 9 modules
   cacheable modules 126 bytes
     ./main1.js 66 bytes [built] [code generated]
     ./b.js 20 bytes [built] [code generated]
@@ -2492,15 +2492,15 @@ exports[`StatsTestCases should print correct stats for runtime-chunk-integration
   base (webpack x.x.x) compiled successfully
 
 static custom name:
-  asset with-manifest.js 12.4 KiB [emitted] (name: manifest)
+  asset with-manifest.js 12.2 KiB [emitted] (name: manifest)
   asset with-505.js 1.22 KiB [emitted]
   asset with-main1.js 596 bytes [emitted] (name: main1)
   asset with-main2.js 215 bytes [emitted] (name: main2)
   asset with-main3.js 215 bytes [emitted] (name: main3)
-  Entrypoint main1 13 KiB = with-manifest.js 12.4 KiB with-main1.js 596 bytes
-  Entrypoint main2 12.6 KiB = with-manifest.js 12.4 KiB with-main2.js 215 bytes
-  Entrypoint main3 12.6 KiB = with-manifest.js 12.4 KiB with-main3.js 215 bytes
-  runtime modules 7.74 KiB 9 modules
+  Entrypoint main1 12.8 KiB = with-manifest.js 12.2 KiB with-main1.js 596 bytes
+  Entrypoint main2 12.4 KiB = with-manifest.js 12.2 KiB with-main2.js 215 bytes
+  Entrypoint main3 12.4 KiB = with-manifest.js 12.2 KiB with-main3.js 215 bytes
+  runtime modules 7.62 KiB 9 modules
   cacheable modules 166 bytes
     ./main1.js 66 bytes [built] [code generated]
     ./main2.js 20 bytes [built] [code generated]
@@ -2511,16 +2511,16 @@ static custom name:
   static custom name (webpack x.x.x) compiled successfully
 
 dynamic custom name:
-  asset func-b.js 12.4 KiB [emitted] (name: b)
-  asset func-a.js 5.23 KiB [emitted] (name: a)
+  asset func-b.js 12.2 KiB [emitted] (name: b)
+  asset func-a.js 5.06 KiB [emitted] (name: a)
   asset func-505.js 1.22 KiB [emitted]
   asset func-main1.js 596 bytes [emitted] (name: main1)
   asset func-main2.js 215 bytes [emitted] (name: main2)
   asset func-main3.js 215 bytes [emitted] (name: main3)
-  Entrypoint main1 13 KiB = func-b.js 12.4 KiB func-main1.js 596 bytes
-  Entrypoint main2 12.6 KiB = func-b.js 12.4 KiB func-main2.js 215 bytes
-  Entrypoint main3 5.44 KiB = func-a.js 5.23 KiB func-main3.js 215 bytes
-  runtime modules 10.4 KiB 11 modules
+  Entrypoint main1 12.8 KiB = func-b.js 12.2 KiB func-main1.js 596 bytes
+  Entrypoint main2 12.4 KiB = func-b.js 12.2 KiB func-main2.js 215 bytes
+  Entrypoint main3 5.27 KiB = func-a.js 5.06 KiB func-main3.js 215 bytes
+  runtime modules 10.2 KiB 11 modules
   cacheable modules 166 bytes
     ./main1.js 66 bytes [built] [code generated]
     ./main2.js 20 bytes [built] [code generated]
@@ -2532,29 +2532,29 @@ dynamic custom name:
 `;
 
 exports[`StatsTestCases should print correct stats for runtime-chunk-issue-7382 1`] = `
-"Entrypoint e1 7.44 KiB = runtime.js 5.79 KiB all.js 1020 bytes e1.js 670 bytes
-Entrypoint e2 7.44 KiB = runtime.js 5.79 KiB all.js 1020 bytes e2.js 670 bytes
+"Entrypoint e1 7.27 KiB = runtime.js 5.62 KiB all.js 1020 bytes e1.js 670 bytes
+Entrypoint e2 7.27 KiB = runtime.js 5.62 KiB all.js 1020 bytes e2.js 670 bytes
 webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for runtime-chunk-single 1`] = `
-"Entrypoint e1 6.62 KiB = runtime.js 5.79 KiB e1.js 854 bytes
-Entrypoint e2 6.62 KiB = runtime.js 5.79 KiB e2.js 854 bytes
+"Entrypoint e1 6.46 KiB = runtime.js 5.62 KiB e1.js 854 bytes
+Entrypoint e2 6.46 KiB = runtime.js 5.62 KiB e2.js 854 bytes
 webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for runtime-specific-used-exports 1`] = `
 "production:
-  asset production-a.js 12.9 KiB [emitted] (name: a)
-  asset production-b.js 12.9 KiB [emitted] (name: b)
+  asset production-a.js 13.6 KiB [emitted] (name: a)
+  asset production-b.js 13.6 KiB [emitted] (name: b)
   asset production-dw_js-_a6170.js 1.16 KiB [emitted]
   asset production-dw_js-_a6171.js 1.16 KiB [emitted]
   asset production-dx_js.js 1.16 KiB [emitted]
   asset production-dy_js.js 1.14 KiB [emitted]
   asset production-dz_js.js 1.14 KiB [emitted]
   asset production-c.js 63 bytes [emitted] (name: c)
-  chunk (runtime: a) production-a.js (a) 605 bytes (javascript) 6.48 KiB (runtime) [entry] [rendered]
-    runtime modules 6.48 KiB 9 modules
+  chunk (runtime: a) production-a.js (a) 605 bytes (javascript) 6.76 KiB (runtime) [entry] [rendered]
+    runtime modules 6.76 KiB 9 modules
     cacheable modules 605 bytes
       ./a.js 261 bytes [built] [code generated]
         [no exports used]
@@ -2566,8 +2566,8 @@ exports[`StatsTestCases should print correct stats for runtime-specific-used-exp
         [only some exports used: x]
       ./reexport.js 37 bytes [dependent] [built] [code generated]
         [only some exports used: x]
-  chunk (runtime: b) production-b.js (b) 605 bytes (javascript) 6.48 KiB (runtime) [entry] [rendered]
-    runtime modules 6.48 KiB 9 modules
+  chunk (runtime: b) production-b.js (b) 605 bytes (javascript) 6.76 KiB (runtime) [entry] [rendered]
+    runtime modules 6.76 KiB 9 modules
     cacheable modules 605 bytes
       ./b.js 261 bytes [built] [code generated]
         [no exports used]
@@ -2602,7 +2602,7 @@ exports[`StatsTestCases should print correct stats for runtime-specific-used-exp
     ./dz.js 46 bytes [built] [code generated]
     ./module.js?chunk 122 bytes [dependent] [built] [code generated]
       [only some exports used: identity, w, x, z]
-  runtime modules 13 KiB 18 modules
+  runtime modules 13.5 KiB 18 modules
   cacheable modules 1.15 KiB
     ./a.js 261 bytes [built] [code generated]
       [no exports used]
@@ -2627,15 +2627,15 @@ exports[`StatsTestCases should print correct stats for runtime-specific-used-exp
   production (webpack x.x.x) compiled successfully in X ms
 
 development:
-  asset development-a.js 15.7 KiB [emitted] (name: a)
-  asset development-b.js 15.7 KiB [emitted] (name: b)
+  asset development-a.js 16.2 KiB [emitted] (name: a)
+  asset development-b.js 16.2 KiB [emitted] (name: b)
   asset development-dw_js.js 2.12 KiB [emitted]
   asset development-dx_js.js 2.12 KiB [emitted]
   asset development-dy_js.js 2.12 KiB [emitted]
   asset development-dz_js.js 2.12 KiB [emitted]
   asset development-c.js 734 bytes [emitted] (name: c)
-  chunk (runtime: a) development-a.js (a) 605 bytes (javascript) 6.48 KiB (runtime) [entry] [rendered]
-    runtime modules 6.48 KiB 9 modules
+  chunk (runtime: a) development-a.js (a) 605 bytes (javascript) 6.77 KiB (runtime) [entry] [rendered]
+    runtime modules 6.77 KiB 9 modules
     cacheable modules 605 bytes
       ./a.js 261 bytes [built] [code generated]
         [used exports unknown]
@@ -2647,8 +2647,8 @@ development:
         [used exports unknown]
       ./reexport.js 37 bytes [dependent] [built] [code generated]
         [used exports unknown]
-  chunk (runtime: b) development-b.js (b) 605 bytes (javascript) 6.48 KiB (runtime) [entry] [rendered]
-    runtime modules 6.48 KiB 9 modules
+  chunk (runtime: b) development-b.js (b) 605 bytes (javascript) 6.77 KiB (runtime) [entry] [rendered]
+    runtime modules 6.77 KiB 9 modules
     cacheable modules 605 bytes
       ./b.js 261 bytes [built] [code generated]
         [used exports unknown]
@@ -2683,7 +2683,7 @@ development:
       [used exports unknown]
     ./module.js?chunk 122 bytes [dependent] [built] [code generated]
       [used exports unknown]
-  runtime modules 13 KiB 18 modules
+  runtime modules 13.5 KiB 18 modules
   cacheable modules 1.15 KiB
     ./a.js 261 bytes [built] [code generated]
       [used exports unknown]
@@ -2712,15 +2712,15 @@ development:
   development (webpack x.x.x) compiled successfully in X ms
 
 global:
-  asset global-a.js 13.1 KiB [emitted] (name: a)
-  asset global-b.js 13.1 KiB [emitted] (name: b)
+  asset global-a.js 13.8 KiB [emitted] (name: a)
+  asset global-b.js 13.8 KiB [emitted] (name: b)
   asset global-dw_js.js 1.16 KiB [emitted]
   asset global-dx_js.js 1.16 KiB [emitted]
   asset global-dy_js.js 1.16 KiB [emitted]
   asset global-dz_js.js 1.16 KiB [emitted]
   asset global-c.js 63 bytes [emitted] (name: c)
-  chunk (runtime: a) global-a.js (a) 605 bytes (javascript) 6.48 KiB (runtime) [entry] [rendered]
-    runtime modules 6.48 KiB 9 modules
+  chunk (runtime: a) global-a.js (a) 605 bytes (javascript) 6.76 KiB (runtime) [entry] [rendered]
+    runtime modules 6.76 KiB 9 modules
     cacheable modules 605 bytes
       ./a.js 261 bytes [built] [code generated]
         [no exports used]
@@ -2732,8 +2732,8 @@ global:
         [only some exports used: x, y]
       ./reexport.js 37 bytes [dependent] [built] [code generated]
         [only some exports used: x, y]
-  chunk (runtime: b) global-b.js (b) 605 bytes (javascript) 6.48 KiB (runtime) [entry] [rendered]
-    runtime modules 6.48 KiB 9 modules
+  chunk (runtime: b) global-b.js (b) 605 bytes (javascript) 6.76 KiB (runtime) [entry] [rendered]
+    runtime modules 6.76 KiB 9 modules
     cacheable modules 605 bytes
       ./b.js 261 bytes [built] [code generated]
         [no exports used]
@@ -2764,7 +2764,7 @@ global:
     ./dz.js 46 bytes [built] [code generated]
     ./module.js?chunk 122 bytes [dependent] [built] [code generated]
       [only some exports used: identity, w, x, y, z]
-  runtime modules 13 KiB 18 modules
+  runtime modules 13.5 KiB 18 modules
   cacheable modules 1.15 KiB
     ./a.js 261 bytes [built] [code generated]
       [no exports used]
@@ -2790,7 +2790,7 @@ global:
 `;
 
 exports[`StatsTestCases should print correct stats for scope-hoisting-bailouts 1`] = `
-"runtime modules 6.73 KiB 10 modules
+"runtime modules 7.01 KiB 10 modules
 built modules 615 bytes [built]
   code generated modules 530 bytes [code generated]
     modules by path ./*.js 377 bytes 7 modules
@@ -2806,9 +2806,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for scope-hoisting-multi 1`] = `
-"Entrypoint first 14.4 KiB = a-vendor.js 417 bytes a-first.js 14 KiB
-Entrypoint second 13.9 KiB = a-vendor.js 417 bytes a-second.js 13.5 KiB
-runtime modules 15.6 KiB 18 modules
+"Entrypoint first 14.2 KiB = a-vendor.js 417 bytes a-first.js 13.8 KiB
+Entrypoint second 13.7 KiB = a-vendor.js 417 bytes a-second.js 13.3 KiB
+runtime modules 15.3 KiB 18 modules
 orphan modules 37 bytes [orphan] 1 module
 cacheable modules 807 bytes
   ./first.js 236 bytes [built] [code generated]
@@ -2823,9 +2823,9 @@ cacheable modules 807 bytes
   ./common_lazy_shared.js 25 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-Entrypoint first 13.6 KiB = b-vendor.js 417 bytes b-first.js 13.2 KiB
-Entrypoint second 13.5 KiB = b-vendor.js 417 bytes b-second.js 13.1 KiB
-runtime modules 15.6 KiB 18 modules
+Entrypoint first 13.5 KiB = b-vendor.js 417 bytes b-first.js 13 KiB
+Entrypoint second 13.3 KiB = b-vendor.js 417 bytes b-second.js 12.9 KiB
+runtime modules 15.3 KiB 18 modules
 cacheable modules 975 bytes
   code generated modules 857 bytes [code generated]
     modules by path ./*.js + 1 modules 459 bytes 3 modules
@@ -2846,9 +2846,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for side-effects-issue-7428 1`] = `
-"asset main.js 12.1 KiB [emitted] (name: main)
+"asset main.js 12.7 KiB [emitted] (name: main)
 asset 1.js 638 bytes [emitted]
-runtime modules 6.47 KiB 9 modules
+runtime modules 6.75 KiB 9 modules
 cacheable modules 823 bytes
   modules by path ./components/src/ 501 bytes
     orphan modules 315 bytes [orphan]
@@ -3018,8 +3018,8 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
 "default:
-  Entrypoint main 11.3 KiB = default/main.js
-  Entrypoint a 12.3 KiB = default/a.js
+  Entrypoint main 12 KiB = default/main.js
+  Entrypoint a 13 KiB = default/a.js
   Entrypoint b 3.75 KiB = default/b.js
   Entrypoint c 3.75 KiB = default/c.js
   chunk (runtime: b) default/b.js (b) 196 bytes (javascript) 394 bytes (runtime) [entry] [rendered]
@@ -3030,9 +3030,9 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
   chunk (runtime: a, main) default/async-g.js (async-g) 45 bytes <{282}> <{767}> <{786}> <{794}> <{954}> ={568}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.57 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
+  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.85 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
     > ./ main
-    runtime modules 6.57 KiB 9 modules
+    runtime modules 6.85 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) default/282.js (id hint: vendors) 20 bytes <{179}> ={334}= ={383}= ={568}= ={767}= ={769}= ={794}= ={954}= >{137}< >{568}< [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -3063,9 +3063,9 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
   chunk (runtime: main) default/769.js (id hint: vendors) 20 bytes <{179}> ={282}= ={383}= ={568}= ={767}= [rendered] split chunk (cache group: defaultVendors)
     > ./c ./index.js 3:0-47
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.55 KiB (runtime) >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.84 KiB (runtime) >{137}< >{568}< [entry] [rendered]
     > ./a a
-    runtime modules 6.55 KiB 9 modules
+    runtime modules 6.84 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) default/async-a.js (async-a) 185 bytes <{179}> ={282}= ={767}= ={954}= >{137}< >{568}< [rendered]
@@ -3078,20 +3078,20 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
   default (webpack x.x.x) compiled successfully
 
 all-chunks:
-  Entrypoint main 11.4 KiB = all-chunks/main.js
-  Entrypoint a 15 KiB = all-chunks/282.js 412 bytes all-chunks/954.js 412 bytes all-chunks/767.js 412 bytes all-chunks/390.js 412 bytes all-chunks/a.js 13.4 KiB
-  Entrypoint b 8.1 KiB = all-chunks/282.js 412 bytes all-chunks/954.js 412 bytes all-chunks/767.js 412 bytes all-chunks/568.js 412 bytes all-chunks/b.js 6.49 KiB
-  Entrypoint c 8.1 KiB = all-chunks/282.js 412 bytes all-chunks/769.js 412 bytes all-chunks/767.js 412 bytes all-chunks/568.js 412 bytes all-chunks/c.js 6.49 KiB
-  chunk (runtime: b) all-chunks/b.js (b) 116 bytes (javascript) 3.01 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
+  Entrypoint main 12.1 KiB = all-chunks/main.js
+  Entrypoint a 14.8 KiB = all-chunks/282.js 412 bytes all-chunks/954.js 412 bytes all-chunks/767.js 412 bytes all-chunks/390.js 412 bytes all-chunks/a.js 13.2 KiB
+  Entrypoint b 7.94 KiB = all-chunks/282.js 412 bytes all-chunks/954.js 412 bytes all-chunks/767.js 412 bytes all-chunks/568.js 412 bytes all-chunks/b.js 6.33 KiB
+  Entrypoint c 7.94 KiB = all-chunks/282.js 412 bytes all-chunks/769.js 412 bytes all-chunks/767.js 412 bytes all-chunks/568.js 412 bytes all-chunks/c.js 6.33 KiB
+  chunk (runtime: b) all-chunks/b.js (b) 116 bytes (javascript) 2.89 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
     > ./b b
-    runtime modules 3.01 KiB 3 modules
+    runtime modules 2.89 KiB 3 modules
     ./b.js 116 bytes [built] [code generated]
   chunk (runtime: a, main) all-chunks/async-g.js (async-g) 45 bytes <{282}> <{390}> <{767}> <{786}> <{794}> <{954}> ={568}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) all-chunks/main.js (main) 147 bytes (javascript) 6.57 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
+  chunk (runtime: main) all-chunks/main.js (main) 147 bytes (javascript) 6.85 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
     > ./ main
-    runtime modules 6.57 KiB 9 modules
+    runtime modules 6.85 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) all-chunks/282.js (id hint: vendors) 20 bytes <{179}> ={128}= ={334}= ={383}= ={390}= ={459}= ={568}= ={767}= ={769}= ={786}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -3111,9 +3111,9 @@ all-chunks:
     > ./a ./index.js 1:0-47
     > ./a a
     ./e.js 20 bytes [built] [code generated]
-  chunk (runtime: c) all-chunks/c.js (c) 116 bytes (javascript) 3.01 KiB (runtime) ={282}= ={568}= ={767}= ={769}= [entry] [rendered]
+  chunk (runtime: c) all-chunks/c.js (c) 116 bytes (javascript) 2.89 KiB (runtime) ={282}= ={568}= ={767}= ={769}= [entry] [rendered]
     > ./c c
-    runtime modules 3.01 KiB 3 modules
+    runtime modules 2.89 KiB 3 modules
     ./c.js 116 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) all-chunks/568.js 20 bytes <{179}> <{282}> <{390}> <{767}> <{786}> <{794}> <{954}> ={128}= ={137}= ={282}= ={334}= ={383}= ={459}= ={767}= ={769}= ={954}= [initial] [rendered] split chunk (cache group: default)
     > ./b ./index.js 2:0-47
@@ -3134,9 +3134,9 @@ all-chunks:
     > ./c ./index.js 3:0-47
     > ./c c
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) all-chunks/a.js (a) 165 bytes (javascript) 7.82 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: a) all-chunks/a.js (a) 165 bytes (javascript) 7.7 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
     > ./a a
-    runtime modules 7.82 KiB 9 modules
+    runtime modules 7.7 KiB 9 modules
     ./a.js 165 bytes [built] [code generated]
   chunk (runtime: main) all-chunks/async-a.js (async-a) 165 bytes <{179}> ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [rendered]
     > ./a ./index.js 1:0-47
@@ -3150,25 +3150,25 @@ all-chunks:
   all-chunks (webpack x.x.x) compiled successfully
 
 manual:
-  Entrypoint main 11.1 KiB = manual/main.js
-  Entrypoint a 14.6 KiB = manual/vendors.js 1.07 KiB manual/a.js 13.5 KiB
-  Entrypoint b 8.26 KiB = manual/vendors.js 1.07 KiB manual/b.js 7.19 KiB
-  Entrypoint c 8.26 KiB = manual/vendors.js 1.07 KiB manual/c.js 7.19 KiB
-  chunk (runtime: b) manual/b.js (b) 156 bytes (javascript) 3.04 KiB (runtime) ={216}= [entry] [rendered]
+  Entrypoint main 11.8 KiB = manual/main.js
+  Entrypoint a 14.4 KiB = manual/vendors.js 1.07 KiB manual/a.js 13.3 KiB
+  Entrypoint b 8.09 KiB = manual/vendors.js 1.07 KiB manual/b.js 7.02 KiB
+  Entrypoint c 8.09 KiB = manual/vendors.js 1.07 KiB manual/c.js 7.02 KiB
+  chunk (runtime: b) manual/b.js (b) 156 bytes (javascript) 2.91 KiB (runtime) ={216}= [entry] [rendered]
     > ./b b
     > x b
     > y b
     > z b
-    runtime modules 3.04 KiB 3 modules
+    runtime modules 2.91 KiB 3 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./b.js 116 bytes [built] [code generated]
   chunk (runtime: a, main) manual/async-g.js (async-g) 65 bytes <{216}> <{786}> <{794}> [rendered]
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) manual/main.js (main) 147 bytes (javascript) 6.57 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
+  chunk (runtime: main) manual/main.js (main) 147 bytes (javascript) 6.85 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
     > ./ main
-    runtime modules 6.57 KiB 9 modules
+    runtime modules 6.85 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) manual/vendors.js (vendors) (id hint: vendors) 60 bytes <{179}> ={128}= ={334}= ={383}= ={459}= ={786}= ={794}= >{137}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
     > ./a ./index.js 1:0-47
@@ -3197,20 +3197,20 @@ manual:
     > ./c ./index.js 3:0-47
     dependent modules 40 bytes [dependent] 2 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: c) manual/c.js (c) 156 bytes (javascript) 3.04 KiB (runtime) ={216}= [entry] [rendered]
+  chunk (runtime: c) manual/c.js (c) 156 bytes (javascript) 2.91 KiB (runtime) ={216}= [entry] [rendered]
     > ./c c
     > x c
     > y c
     > z c
-    runtime modules 3.04 KiB 3 modules
+    runtime modules 2.91 KiB 3 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: a) manual/a.js (a) 205 bytes (javascript) 7.81 KiB (runtime) ={216}= >{137}< [entry] [rendered]
+  chunk (runtime: a) manual/a.js (a) 205 bytes (javascript) 7.69 KiB (runtime) ={216}= >{137}< [entry] [rendered]
     > ./a a
     > x a
     > y a
     > z a
-    runtime modules 7.81 KiB 9 modules
+    runtime modules 7.69 KiB 9 modules
     dependent modules 20 bytes [dependent] 1 module
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) manual/async-a.js (async-a) 205 bytes <{179}> ={216}= >{137}< [rendered]
@@ -3220,16 +3220,16 @@ manual:
   manual (webpack x.x.x) compiled successfully
 
 name-too-long:
-  Entrypoint main 11.4 KiB = name-too-long/main.js
-  Entrypoint aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 15 KiB = name-too-long/282.js 412 bytes name-too-long/954.js 412 bytes name-too-long/767.js 412 bytes name-too-long/390.js 412 bytes name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js 13.4 KiB
-  Entrypoint bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb 8.1 KiB = name-too-long/282.js 412 bytes name-too-long/954.js 412 bytes name-too-long/767.js 412 bytes name-too-long/568.js 412 bytes name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js 6.49 KiB
-  Entrypoint cccccccccccccccccccccccccccccc 8.1 KiB = name-too-long/282.js 412 bytes name-too-long/769.js 412 bytes name-too-long/767.js 412 bytes name-too-long/568.js 412 bytes name-too-long/cccccccccccccccccccccccccccccc.js 6.49 KiB
+  Entrypoint main 12.1 KiB = name-too-long/main.js
+  Entrypoint aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 14.8 KiB = name-too-long/282.js 412 bytes name-too-long/954.js 412 bytes name-too-long/767.js 412 bytes name-too-long/390.js 412 bytes name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js 13.2 KiB
+  Entrypoint bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb 7.94 KiB = name-too-long/282.js 412 bytes name-too-long/954.js 412 bytes name-too-long/767.js 412 bytes name-too-long/568.js 412 bytes name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js 6.33 KiB
+  Entrypoint cccccccccccccccccccccccccccccc 7.94 KiB = name-too-long/282.js 412 bytes name-too-long/769.js 412 bytes name-too-long/767.js 412 bytes name-too-long/568.js 412 bytes name-too-long/cccccccccccccccccccccccccccccc.js 6.33 KiB
   chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, main) name-too-long/async-g.js (async-g) 45 bytes <{282}> <{390}> <{751}> <{767}> <{794}> <{954}> ={568}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) name-too-long/main.js (main) 147 bytes (javascript) 6.57 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
+  chunk (runtime: main) name-too-long/main.js (main) 147 bytes (javascript) 6.85 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
     > ./ main
-    runtime modules 6.57 KiB 9 modules
+    runtime modules 6.85 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc, main) name-too-long/282.js (id hint: vendors) 20 bytes <{179}> ={334}= ={383}= ={390}= ={568}= ={658}= ={751}= ={766}= ={767}= ={769}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -3256,17 +3256,17 @@ name-too-long:
     > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     > ./c cccccccccccccccccccccccccccccc
     ./f.js 20 bytes [built] [code generated]
-  chunk (runtime: cccccccccccccccccccccccccccccc) name-too-long/cccccccccccccccccccccccccccccc.js (cccccccccccccccccccccccccccccc) 116 bytes (javascript) 3.01 KiB (runtime) ={282}= ={568}= ={767}= ={769}= [entry] [rendered]
+  chunk (runtime: cccccccccccccccccccccccccccccc) name-too-long/cccccccccccccccccccccccccccccc.js (cccccccccccccccccccccccccccccc) 116 bytes (javascript) 2.89 KiB (runtime) ={282}= ={568}= ={767}= ={769}= [entry] [rendered]
     > ./c cccccccccccccccccccccccccccccc
-    runtime modules 3.01 KiB 3 modules
+    runtime modules 2.89 KiB 3 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) 165 bytes (javascript) 7.82 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) 165 bytes (javascript) 7.7 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
     > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    runtime modules 7.82 KiB 9 modules
+    runtime modules 7.7 KiB 9 modules
     ./a.js 165 bytes [built] [code generated]
-  chunk (runtime: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) 116 bytes (javascript) 3.01 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
+  chunk (runtime: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) 116 bytes (javascript) 2.89 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
     > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-    runtime modules 3.01 KiB 3 modules
+    runtime modules 2.89 KiB 3 modules
     ./b.js 116 bytes [built] [code generated]
   chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc, main) name-too-long/767.js 20 bytes <{179}> ={282}= ={334}= ={383}= ={390}= ={568}= ={658}= ={751}= ={766}= ={769}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: default)
     > ./a ./index.js 1:0-47
@@ -3292,20 +3292,20 @@ name-too-long:
   name-too-long (webpack x.x.x) compiled successfully
 
 custom-chunks-filter:
-  Entrypoint main 11.3 KiB = custom-chunks-filter/main.js
-  Entrypoint a 12.3 KiB = custom-chunks-filter/a.js
-  Entrypoint b 8.1 KiB = custom-chunks-filter/282.js 412 bytes custom-chunks-filter/954.js 412 bytes custom-chunks-filter/568.js 412 bytes custom-chunks-filter/767.js 412 bytes custom-chunks-filter/b.js 6.49 KiB
-  Entrypoint c 8.1 KiB = custom-chunks-filter/282.js 412 bytes custom-chunks-filter/769.js 412 bytes custom-chunks-filter/568.js 412 bytes custom-chunks-filter/767.js 412 bytes custom-chunks-filter/c.js 6.49 KiB
-  chunk (runtime: b) custom-chunks-filter/b.js (b) 116 bytes (javascript) 3.01 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
+  Entrypoint main 12 KiB = custom-chunks-filter/main.js
+  Entrypoint a 13 KiB = custom-chunks-filter/a.js
+  Entrypoint b 7.94 KiB = custom-chunks-filter/282.js 412 bytes custom-chunks-filter/954.js 412 bytes custom-chunks-filter/568.js 412 bytes custom-chunks-filter/767.js 412 bytes custom-chunks-filter/b.js 6.33 KiB
+  Entrypoint c 7.94 KiB = custom-chunks-filter/282.js 412 bytes custom-chunks-filter/769.js 412 bytes custom-chunks-filter/568.js 412 bytes custom-chunks-filter/767.js 412 bytes custom-chunks-filter/c.js 6.33 KiB
+  chunk (runtime: b) custom-chunks-filter/b.js (b) 116 bytes (javascript) 2.89 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
     > ./b b
-    runtime modules 3.01 KiB 3 modules
+    runtime modules 2.89 KiB 3 modules
     ./b.js 116 bytes [built] [code generated]
   chunk (runtime: a, main) custom-chunks-filter/async-g.js (async-g) 45 bytes <{282}> <{767}> <{786}> <{794}> <{954}> ={568}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) custom-chunks-filter/main.js (main) 147 bytes (javascript) 6.58 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
+  chunk (runtime: main) custom-chunks-filter/main.js (main) 147 bytes (javascript) 6.86 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
     > ./ main
-    runtime modules 6.58 KiB 9 modules
+    runtime modules 6.86 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: b, c, main) custom-chunks-filter/282.js (id hint: vendors) 20 bytes <{179}> ={128}= ={334}= ={383}= ={459}= ={568}= ={767}= ={769}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -3320,9 +3320,9 @@ custom-chunks-filter:
   chunk (runtime: main) custom-chunks-filter/async-c.js (async-c) 116 bytes <{179}> ={282}= ={568}= ={767}= ={769}= [rendered]
     > ./c ./index.js 3:0-47
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: c) custom-chunks-filter/c.js (c) 116 bytes (javascript) 3.01 KiB (runtime) ={282}= ={568}= ={767}= ={769}= [entry] [rendered]
+  chunk (runtime: c) custom-chunks-filter/c.js (c) 116 bytes (javascript) 2.89 KiB (runtime) ={282}= ={568}= ={767}= ={769}= [entry] [rendered]
     > ./c c
-    runtime modules 3.01 KiB 3 modules
+    runtime modules 2.89 KiB 3 modules
     ./c.js 116 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) custom-chunks-filter/568.js 20 bytes <{179}> <{282}> <{767}> <{786}> <{794}> <{954}> ={128}= ={137}= ={282}= ={334}= ={383}= ={459}= ={767}= ={769}= ={954}= [initial] [rendered] split chunk (cache group: default)
     > ./b ./index.js 2:0-47
@@ -3342,9 +3342,9 @@ custom-chunks-filter:
     > ./c ./index.js 3:0-47
     > ./c c
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) custom-chunks-filter/a.js (a) 245 bytes (javascript) 6.57 KiB (runtime) >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: a) custom-chunks-filter/a.js (a) 245 bytes (javascript) 6.85 KiB (runtime) >{137}< >{568}< [entry] [rendered]
     > ./a a
-    runtime modules 6.57 KiB 9 modules
+    runtime modules 6.85 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) custom-chunks-filter/async-a.js (async-a) 185 bytes <{179}> ={282}= ={767}= ={954}= >{137}< >{568}< [rendered]
@@ -3358,16 +3358,16 @@ custom-chunks-filter:
   custom-chunks-filter (webpack x.x.x) compiled successfully
 
 custom-chunks-filter-in-cache-groups:
-  Entrypoint main 11.1 KiB = custom-chunks-filter-in-cache-groups/main.js
-  Entrypoint a 14.4 KiB = custom-chunks-filter-in-cache-groups/176.js 888 bytes custom-chunks-filter-in-cache-groups/a.js 13.5 KiB
-  Entrypoint b 8.26 KiB = custom-chunks-filter-in-cache-groups/vendors.js 1.07 KiB custom-chunks-filter-in-cache-groups/b.js 7.19 KiB
-  Entrypoint c 8.26 KiB = custom-chunks-filter-in-cache-groups/vendors.js 1.07 KiB custom-chunks-filter-in-cache-groups/c.js 7.19 KiB
-  chunk (runtime: b) custom-chunks-filter-in-cache-groups/b.js (b) 156 bytes (javascript) 3.04 KiB (runtime) ={216}= [entry] [rendered]
+  Entrypoint main 11.8 KiB = custom-chunks-filter-in-cache-groups/main.js
+  Entrypoint a 14.2 KiB = custom-chunks-filter-in-cache-groups/176.js 888 bytes custom-chunks-filter-in-cache-groups/a.js 13.4 KiB
+  Entrypoint b 8.1 KiB = custom-chunks-filter-in-cache-groups/vendors.js 1.07 KiB custom-chunks-filter-in-cache-groups/b.js 7.02 KiB
+  Entrypoint c 8.1 KiB = custom-chunks-filter-in-cache-groups/vendors.js 1.07 KiB custom-chunks-filter-in-cache-groups/c.js 7.02 KiB
+  chunk (runtime: b) custom-chunks-filter-in-cache-groups/b.js (b) 156 bytes (javascript) 2.91 KiB (runtime) ={216}= [entry] [rendered]
     > ./b b
     > x b
     > y b
     > z b
-    runtime modules 3.04 KiB 3 modules
+    runtime modules 2.91 KiB 3 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./b.js 116 bytes [built] [code generated]
   chunk (runtime: a, main) custom-chunks-filter-in-cache-groups/async-g.js (async-g) 65 bytes <{176}> <{216}> <{786}> <{794}> [rendered]
@@ -3382,9 +3382,9 @@ custom-chunks-filter-in-cache-groups:
     ./node_modules/x.js 20 bytes [built] [code generated]
     ./node_modules/y.js 20 bytes [built] [code generated]
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: main) custom-chunks-filter-in-cache-groups/main.js (main) 147 bytes (javascript) 6.6 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
+  chunk (runtime: main) custom-chunks-filter-in-cache-groups/main.js (main) 147 bytes (javascript) 6.88 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
     > ./ main
-    runtime modules 6.6 KiB 9 modules
+    runtime modules 6.88 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: b, c, main) custom-chunks-filter-in-cache-groups/vendors.js (vendors) (id hint: vendors) 60 bytes <{179}> ={128}= ={334}= ={383}= ={459}= ={794}= >{137}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
     > ./a ./index.js 1:0-47
@@ -3409,20 +3409,20 @@ custom-chunks-filter-in-cache-groups:
     > ./c ./index.js 3:0-47
     dependent modules 40 bytes [dependent] 2 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: c) custom-chunks-filter-in-cache-groups/c.js (c) 156 bytes (javascript) 3.04 KiB (runtime) ={216}= [entry] [rendered]
+  chunk (runtime: c) custom-chunks-filter-in-cache-groups/c.js (c) 156 bytes (javascript) 2.91 KiB (runtime) ={216}= [entry] [rendered]
     > ./c c
     > x c
     > y c
     > z c
-    runtime modules 3.04 KiB 3 modules
+    runtime modules 2.91 KiB 3 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: a) custom-chunks-filter-in-cache-groups/a.js (a) 205 bytes (javascript) 7.84 KiB (runtime) ={176}= >{137}< [entry] [rendered]
+  chunk (runtime: a) custom-chunks-filter-in-cache-groups/a.js (a) 205 bytes (javascript) 7.72 KiB (runtime) ={176}= >{137}< [entry] [rendered]
     > ./a a
     > x a
     > y a
     > z a
-    runtime modules 7.84 KiB 9 modules
+    runtime modules 7.72 KiB 9 modules
     dependent modules 20 bytes [dependent] 1 module
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) custom-chunks-filter-in-cache-groups/async-a.js (async-a) 205 bytes <{179}> ={216}= >{137}< [rendered]
@@ -3433,7 +3433,7 @@ custom-chunks-filter-in-cache-groups:
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-automatic-name 1`] = `
-"Entrypoint main 11.4 KiB = main.js
+"Entrypoint main 12.1 KiB = main.js
 chunk (runtime: main) async-a.js (async-a) 136 bytes <{main}> ={common-d_js}= ={common-node_modules_x_js}= ={common-node_modules_y_js}= [rendered]
   > ./a ./index.js 1:0-47
   ./a.js + 1 modules 136 bytes [built] [code generated]
@@ -3464,18 +3464,18 @@ chunk (runtime: main) common-node_modules_y_js.js (id hint: common) 20 bytes <{m
 chunk (runtime: main) common-node_modules_z_js.js (id hint: common) 20 bytes <{main}> ={async-c}= ={common-d_js}= ={common-f_js}= ={common-node_modules_x_js}= [rendered] split chunk (cache group: b)
   > ./c ./index.js 3:0-47
   ./node_modules/z.js 20 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.47 KiB (runtime) >{async-a}< >{async-b}< >{async-c}< >{common-d_js}< >{common-f_js}< >{common-node_modules_x_js}< >{common-node_modules_y_js}< >{common-node_modules_z_js}< [entry] [rendered]
+chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.76 KiB (runtime) >{async-a}< >{async-b}< >{async-c}< >{common-d_js}< >{common-f_js}< >{common-node_modules_x_js}< >{common-node_modules_y_js}< >{common-node_modules_z_js}< [entry] [rendered]
   > ./ main
-  runtime modules 6.47 KiB 9 modules
+  runtime modules 6.76 KiB 9 modules
   ./index.js 147 bytes [built] [code generated]
 production (webpack x.x.x) compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-chunk-name 1`] = `
-"Entrypoint main 11.1 KiB = default/main.js
-chunk (runtime: main) default/main.js (main) 192 bytes (javascript) 6.54 KiB (runtime) >{334}< >{709}< >{794}< [entry] [rendered]
+"Entrypoint main 11.8 KiB = default/main.js
+chunk (runtime: main) default/main.js (main) 192 bytes (javascript) 6.82 KiB (runtime) >{334}< >{709}< >{794}< [entry] [rendered]
   > ./ main
-  runtime modules 6.54 KiB 9 modules
+  runtime modules 6.82 KiB 9 modules
   ./index.js 192 bytes [built] [code generated]
 chunk (runtime: main) default/async-b.js (async-b) (id hint: vendors) 122 bytes <{179}> [rendered] reused as split chunk (cache group: defaultVendors)
   > b ./index.js 2:0-45
@@ -3491,7 +3491,7 @@ webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-combinations 1`] = `
-"Entrypoint main 11.5 KiB = main.js
+"Entrypoint main 12.2 KiB = main.js
 chunk (runtime: main) async-d.js (async-d) 132 bytes <{179}> [rendered]
   > ./d ./index.js 4:0-47
   dependent modules 87 bytes [dependent] 1 module
@@ -3500,9 +3500,9 @@ chunk (runtime: main) async-g.js (async-g) 132 bytes <{179}> [rendered]
   > ./g ./index.js 7:0-47
   dependent modules 87 bytes [dependent] 1 module
   ./g.js 45 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 343 bytes (javascript) 6.6 KiB (runtime) >{31}< >{137}< >{206}< >{334}< >{383}< >{449}< >{794}< >{804}< [entry] [rendered]
+chunk (runtime: main) main.js (main) 343 bytes (javascript) 6.88 KiB (runtime) >{31}< >{137}< >{206}< >{334}< >{383}< >{449}< >{794}< >{804}< [entry] [rendered]
   > ./ main
-  runtime modules 6.6 KiB 9 modules
+  runtime modules 6.88 KiB 9 modules
   ./index.js 343 bytes [built] [code generated]
 chunk (runtime: main) async-f.js (async-f) 132 bytes <{179}> [rendered]
   > ./f ./index.js 6:0-47
@@ -3531,10 +3531,10 @@ webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-6413 1`] = `
-"Entrypoint main 11.2 KiB = main.js
-chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.53 KiB (runtime) >{282}< >{334}< >{383}< >{543}< >{794}< [entry] [rendered]
+"Entrypoint main 11.9 KiB = main.js
+chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.82 KiB (runtime) >{282}< >{334}< >{383}< >{543}< >{794}< [entry] [rendered]
   > ./ main
-  runtime modules 6.53 KiB 9 modules
+  runtime modules 6.82 KiB 9 modules
   ./index.js 147 bytes [built] [code generated]
 chunk (runtime: main) 282.js (id hint: vendors) 20 bytes <{179}> ={334}= ={383}= ={543}= ={794}= [rendered] split chunk (cache group: defaultVendors)
   > ./a ./index.js 1:0-47
@@ -3559,10 +3559,10 @@ default (webpack x.x.x) compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-6696 1`] = `
-"Entrypoint main 13.3 KiB = vendors.js 412 bytes main.js 12.9 KiB
-chunk (runtime: main) main.js (main) 134 bytes (javascript) 7.78 KiB (runtime) ={216}= >{334}< >{794}< [entry] [rendered]
+"Entrypoint main 13.1 KiB = vendors.js 412 bytes main.js 12.7 KiB
+chunk (runtime: main) main.js (main) 134 bytes (javascript) 7.66 KiB (runtime) ={216}= >{334}< >{794}< [entry] [rendered]
   > ./ main
-  runtime modules 7.78 KiB 9 modules
+  runtime modules 7.66 KiB 9 modules
   ./index.js 134 bytes [built] [code generated]
 chunk (runtime: main) vendors.js (vendors) (id hint: vendors) 20 bytes ={179}= >{334}< >{794}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
   > ./ main
@@ -3579,12 +3579,12 @@ default (webpack x.x.x) compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-7401 1`] = `
-"Entrypoint a 6.4 KiB = 282.js 412 bytes a.js 6 KiB
-Entrypoint b 10.7 KiB = b.js
+"Entrypoint a 6.24 KiB = 282.js 412 bytes a.js 5.83 KiB
+Entrypoint b 11.4 KiB = b.js
 Chunk Group c 792 bytes = 282.js 412 bytes c.js 380 bytes
-chunk (runtime: b) b.js (b) 43 bytes (javascript) 6.5 KiB (runtime) >{282}< >{459}< [entry] [rendered]
+chunk (runtime: b) b.js (b) 43 bytes (javascript) 6.78 KiB (runtime) >{282}< >{459}< [entry] [rendered]
   > ./b b
-  runtime modules 6.5 KiB 9 modules
+  runtime modules 6.78 KiB 9 modules
   ./b.js 43 bytes [built] [code generated]
 chunk (runtime: a, b) 282.js (id hint: vendors) 20 bytes <{128}> ={459}= ={786}= [initial] [rendered] split chunk (cache group: defaultVendors)
   > ./c ./b.js 1:0-41
@@ -3593,21 +3593,21 @@ chunk (runtime: a, b) 282.js (id hint: vendors) 20 bytes <{128}> ={459}= ={786}=
 chunk (runtime: b) c.js (c) 35 bytes <{128}> ={282}= [rendered]
   > ./c ./b.js 1:0-41
   ./c.js 35 bytes [built] [code generated]
-chunk (runtime: a) a.js (a) 35 bytes (javascript) 2.99 KiB (runtime) ={282}= [entry] [rendered]
+chunk (runtime: a) a.js (a) 35 bytes (javascript) 2.87 KiB (runtime) ={282}= [entry] [rendered]
   > ./a a
-  runtime modules 2.99 KiB 3 modules
+  runtime modules 2.87 KiB 3 modules
   ./a.js 35 bytes [built] [code generated]
 default (webpack x.x.x) compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-keep-remaining-size 1`] = `
-"Entrypoint main 11.2 KiB = default/main.js
+"Entrypoint main 11.9 KiB = default/main.js
 chunk (runtime: main) default/async-d.js (async-d) 84 bytes <{179}> ={782}= [rendered]
   > ./d ./index.js 4:0-47
   ./d.js 84 bytes [built] [code generated]
-chunk (runtime: main) default/main.js (main) 196 bytes (javascript) 6.56 KiB (runtime) >{31}< >{334}< >{383}< >{782}< >{794}< >{821}< [entry] [rendered]
+chunk (runtime: main) default/main.js (main) 196 bytes (javascript) 6.85 KiB (runtime) >{31}< >{334}< >{383}< >{782}< >{794}< >{821}< [entry] [rendered]
   > ./ main
-  runtime modules 6.56 KiB 9 modules
+  runtime modules 6.85 KiB 9 modules
   ./index.js 196 bytes [built] [code generated]
 chunk (runtime: main) default/async-b.js (async-b) 50 bytes <{179}> ={821}= [rendered]
   > ./b ./index.js 2:0-47
@@ -3631,7 +3631,7 @@ webpack x.x.x compiled successfully"
 
 exports[`StatsTestCases should print correct stats for split-chunks-max-size 1`] = `
 "production:
-  Entrypoint main 31.8 KiB = 13 assets
+  Entrypoint main 31.6 KiB = 13 assets
   chunk (runtime: main) prod-main-6bb16544.js (main-6bb16544) 1.57 KiB ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
     > ./ main
     ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
@@ -3695,9 +3695,9 @@ exports[`StatsTestCases should print correct stats for split-chunks-max-size 1`]
     > ./ main
     ./big.js?1 267 bytes [built] [code generated]
     ./big.js?2 267 bytes [built] [code generated]
-  chunk (runtime: main) prod-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.29 KiB (runtime) ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={869}= [entry] [rendered]
+  chunk (runtime: main) prod-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.17 KiB (runtime) ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={869}= [entry] [rendered]
     > ./ main
-    runtime modules 3.29 KiB 4 modules
+    runtime modules 3.17 KiB 4 modules
     ./very-big.js?1 1.57 KiB [built] [code generated]
   chunk (runtime: main) prod-869.js (id hint: vendors) 399 bytes ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./ main
@@ -3707,7 +3707,7 @@ exports[`StatsTestCases should print correct stats for split-chunks-max-size 1`]
   production (webpack x.x.x) compiled successfully
 
 development:
-  Entrypoint main 50.4 KiB = 13 assets
+  Entrypoint main 50.2 KiB = 13 assets
   chunk (runtime: main) dev-main-big_js-1.js (main-big_js-1) 534 bytes ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
     > ./ main
     ./big.js?1 267 bytes [built] [code generated]
@@ -3768,9 +3768,9 @@ development:
   chunk (runtime: main) dev-main-very-big_js-4647fb9d.js (main-very-big_js-4647fb9d) 1.57 KiB ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
     > ./ main
     ./very-big.js?3 1.57 KiB [built] [code generated]
-  chunk (runtime: main) dev-main-very-big_js-62f7f644.js (main-very-big_js-62f7f644) 1.57 KiB (javascript) 3.93 KiB (runtime) ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [entry] [rendered]
+  chunk (runtime: main) dev-main-very-big_js-62f7f644.js (main-very-big_js-62f7f644) 1.57 KiB (javascript) 3.8 KiB (runtime) ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [entry] [rendered]
     > ./ main
-    runtime modules 3.93 KiB 5 modules
+    runtime modules 3.8 KiB 5 modules
     ./very-big.js?1 1.57 KiB [built] [code generated]
   chunk (runtime: main) dev-vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2.js (id hint: vendors) 399 bytes ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./ main
@@ -3783,7 +3783,7 @@ development:
   development (webpack x.x.x) compiled successfully
 
 switched:
-  Entrypoint main 31.4 KiB = 8 assets
+  Entrypoint main 31.3 KiB = 8 assets
   chunk (runtime: main) switched-main-6bb16544.js (main-6bb16544) 1.57 KiB ={59}= ={247}= ={318}= ={520}= ={581}= ={663}= ={997}= [initial] [rendered]
     > ./ main
     ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
@@ -3806,9 +3806,9 @@ switched:
     > ./ main
     modules by path ./subfolder/*.js 1.1 KiB 11 modules
     modules by path ./*.js 594 bytes 9 modules
-  chunk (runtime: main) switched-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.27 KiB (runtime) ={1}= ={59}= ={247}= ={318}= ={520}= ={581}= ={997}= [entry] [rendered]
+  chunk (runtime: main) switched-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.15 KiB (runtime) ={1}= ={59}= ={247}= ={318}= ={520}= ={581}= ={997}= [entry] [rendered]
     > ./ main
-    runtime modules 3.27 KiB 4 modules
+    runtime modules 3.15 KiB 4 modules
     ./very-big.js?1 1.57 KiB [built] [code generated]
   chunk (runtime: main) switched-main-7aeafcb2.js (main-7aeafcb2) 1.62 KiB ={1}= ={59}= ={247}= ={318}= ={520}= ={581}= ={663}= [initial] [rendered]
     > ./ main
@@ -3836,7 +3836,7 @@ switched:
   switched (webpack x.x.x) compiled with 2 warnings
 
 zero-min:
-  Entrypoint main 31.8 KiB = 13 assets
+  Entrypoint main 31.6 KiB = 13 assets
   chunk (runtime: main) zero-min-main-6bb16544.js (main-6bb16544) 1.57 KiB ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
     > ./ main
     ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
@@ -3900,9 +3900,9 @@ zero-min:
     > ./ main
     ./big.js?1 267 bytes [built] [code generated]
     ./big.js?2 267 bytes [built] [code generated]
-  chunk (runtime: main) zero-min-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.29 KiB (runtime) ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={869}= [entry] [rendered]
+  chunk (runtime: main) zero-min-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.17 KiB (runtime) ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={869}= [entry] [rendered]
     > ./ main
-    runtime modules 3.29 KiB 4 modules
+    runtime modules 3.17 KiB 4 modules
     ./very-big.js?1 1.57 KiB [built] [code generated]
   chunk (runtime: main) zero-min-869.js (id hint: vendors) 399 bytes ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./ main
@@ -3912,10 +3912,10 @@ zero-min:
   zero-min (webpack x.x.x) compiled successfully
 
 max-async-size:
-  Entrypoint main 15.7 KiB = max-async-size-main.js
-  chunk (runtime: main) max-async-size-main.js (main) 2.46 KiB (javascript) 6.84 KiB (runtime) >{342}< >{385}< >{820}< >{920}< [entry] [rendered]
+  Entrypoint main 16.4 KiB = max-async-size-main.js
+  chunk (runtime: main) max-async-size-main.js (main) 2.46 KiB (javascript) 7.13 KiB (runtime) >{342}< >{385}< >{820}< >{920}< [entry] [rendered]
     > ./async main
-    runtime modules 6.84 KiB 10 modules
+    runtime modules 7.13 KiB 10 modules
     dependent modules 2.09 KiB [dependent] 6 modules
     ./async/index.js 386 bytes [built] [code generated]
   chunk (runtime: main) max-async-size-async-b-77a8c116.js (async-b-77a8c116) 1.57 KiB <{179}> ={385}= ={820}= ={920}= [rendered]
@@ -3940,13 +3940,13 @@ max-async-size:
   max-async-size (webpack x.x.x) compiled successfully
 
 enforce-min-size:
-  Entrypoint main 31.9 KiB = 14 assets
+  Entrypoint main 31.7 KiB = 14 assets
   chunk (runtime: main) enforce-min-size-10.js (id hint: all) 1.19 KiB ={179}= ={221}= ={262}= ={410}= ={434}= ={463}= ={519}= ={575}= ={614}= ={692}= ={822}= ={825}= ={869}= [initial] [rendered] split chunk (cache group: all)
     > ./ main
     ./index.js 1.19 KiB [built] [code generated]
-  chunk (runtime: main) enforce-min-size-main.js (main) 3.29 KiB ={10}= ={221}= ={262}= ={410}= ={434}= ={463}= ={519}= ={575}= ={614}= ={692}= ={822}= ={825}= ={869}= [entry] [rendered]
+  chunk (runtime: main) enforce-min-size-main.js (main) 3.17 KiB ={10}= ={221}= ={262}= ={410}= ={434}= ={463}= ={519}= ={575}= ={614}= ={692}= ={822}= ={825}= ={869}= [entry] [rendered]
     > ./ main
-    runtime modules 3.29 KiB 4 modules
+    runtime modules 3.17 KiB 4 modules
   chunk (runtime: main) enforce-min-size-221.js (id hint: all) 1.57 KiB ={10}= ={179}= ={262}= ={410}= ={434}= ={463}= ={519}= ={575}= ={614}= ={692}= ={822}= ={825}= ={869}= [initial] [rendered] split chunk (cache group: all)
     > ./ main
     ./very-big.js?3 1.57 KiB [built] [code generated]
@@ -4019,15 +4019,15 @@ enforce-min-size:
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-prefer-bigger-splits 1`] = `
-"Entrypoint main 11.1 KiB = default/main.js
+"Entrypoint main 11.8 KiB = default/main.js
 chunk (runtime: main) default/118.js 150 bytes <{179}> ={334}= ={383}= [rendered] split chunk (cache group: default)
   > ./b ./index.js 2:0-47
   > ./c ./index.js 3:0-47
   ./d.js 63 bytes [built] [code generated]
   ./f.js 87 bytes [built] [code generated]
-chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.55 KiB (runtime) >{118}< >{334}< >{383}< >{794}< [entry] [rendered]
+chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.83 KiB (runtime) >{118}< >{334}< >{383}< >{794}< [entry] [rendered]
   > ./ main
-  runtime modules 6.55 KiB 9 modules
+  runtime modules 6.83 KiB 9 modules
   ./index.js 147 bytes [built] [code generated]
 chunk (runtime: main) default/async-b.js (async-b) 158 bytes <{179}> ={118}= [rendered]
   > ./b ./index.js 2:0-47
@@ -4045,64 +4045,64 @@ webpack x.x.x compiled successfully"
 
 exports[`StatsTestCases should print correct stats for split-chunks-runtime-specific 1`] = `
 "used-exports:
-  asset used-exports-c.js 6.02 KiB [emitted] (name: c)
-  asset used-exports-b.js 6.01 KiB [emitted] (name: b)
+  asset used-exports-c.js 5.85 KiB [emitted] (name: c)
+  asset used-exports-b.js 5.85 KiB [emitted] (name: b)
   asset used-exports-332.js 422 bytes [emitted]
   asset used-exports-a.js 227 bytes [emitted] (name: a)
   Entrypoint a 227 bytes = used-exports-a.js
-  Entrypoint b 6.43 KiB = used-exports-332.js 422 bytes used-exports-b.js 6.01 KiB
-  Entrypoint c 6.43 KiB = used-exports-332.js 422 bytes used-exports-c.js 6.02 KiB
-  chunk (runtime: b) used-exports-b.js (b) 54 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
-    runtime modules 2.99 KiB 3 modules
+  Entrypoint b 6.26 KiB = used-exports-332.js 422 bytes used-exports-b.js 5.85 KiB
+  Entrypoint c 6.27 KiB = used-exports-332.js 422 bytes used-exports-c.js 5.85 KiB
+  chunk (runtime: b) used-exports-b.js (b) 54 bytes (javascript) 2.87 KiB (runtime) [entry] [rendered]
+    runtime modules 2.87 KiB 3 modules
     ./b.js 54 bytes [built] [code generated]
   chunk (runtime: b, c) used-exports-332.js 72 bytes [initial] [rendered] split chunk (cache group: default)
     ./objects.js 72 bytes [built] [code generated]
-  chunk (runtime: c) used-exports-c.js (c) 59 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
-    runtime modules 2.99 KiB 3 modules
+  chunk (runtime: c) used-exports-c.js (c) 59 bytes (javascript) 2.87 KiB (runtime) [entry] [rendered]
+    runtime modules 2.87 KiB 3 modules
     ./c.js 59 bytes [built] [code generated]
   chunk (runtime: a) used-exports-a.js (a) 126 bytes [entry] [rendered]
     ./a.js + 1 modules 126 bytes [built] [code generated]
   used-exports (webpack x.x.x) compiled successfully in X ms
 
 no-used-exports:
-  asset no-used-exports-c.js 6.02 KiB [emitted] (name: c)
-  asset no-used-exports-a.js 6.01 KiB [emitted] (name: a)
-  asset no-used-exports-b.js 6.01 KiB [emitted] (name: b)
+  asset no-used-exports-c.js 5.85 KiB [emitted] (name: c)
+  asset no-used-exports-a.js 5.85 KiB [emitted] (name: a)
+  asset no-used-exports-b.js 5.85 KiB [emitted] (name: b)
   asset no-used-exports-332.js 443 bytes [emitted]
-  Entrypoint a 6.45 KiB = no-used-exports-332.js 443 bytes no-used-exports-a.js 6.01 KiB
-  Entrypoint b 6.45 KiB = no-used-exports-332.js 443 bytes no-used-exports-b.js 6.01 KiB
-  Entrypoint c 6.45 KiB = no-used-exports-332.js 443 bytes no-used-exports-c.js 6.02 KiB
-  chunk (runtime: b) no-used-exports-b.js (b) 54 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
-    runtime modules 2.99 KiB 3 modules
+  Entrypoint a 6.28 KiB = no-used-exports-332.js 443 bytes no-used-exports-a.js 5.85 KiB
+  Entrypoint b 6.28 KiB = no-used-exports-332.js 443 bytes no-used-exports-b.js 5.85 KiB
+  Entrypoint c 6.29 KiB = no-used-exports-332.js 443 bytes no-used-exports-c.js 5.85 KiB
+  chunk (runtime: b) no-used-exports-b.js (b) 54 bytes (javascript) 2.87 KiB (runtime) [entry] [rendered]
+    runtime modules 2.87 KiB 3 modules
     ./b.js 54 bytes [built] [code generated]
   chunk (runtime: a, b, c) no-used-exports-332.js 72 bytes [initial] [rendered] split chunk (cache group: default)
     ./objects.js 72 bytes [built] [code generated]
-  chunk (runtime: c) no-used-exports-c.js (c) 59 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
-    runtime modules 2.99 KiB 3 modules
+  chunk (runtime: c) no-used-exports-c.js (c) 59 bytes (javascript) 2.87 KiB (runtime) [entry] [rendered]
+    runtime modules 2.87 KiB 3 modules
     ./c.js 59 bytes [built] [code generated]
-  chunk (runtime: a) no-used-exports-a.js (a) 54 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
-    runtime modules 2.99 KiB 3 modules
+  chunk (runtime: a) no-used-exports-a.js (a) 54 bytes (javascript) 2.87 KiB (runtime) [entry] [rendered]
+    runtime modules 2.87 KiB 3 modules
     ./a.js 54 bytes [built] [code generated]
   no-used-exports (webpack x.x.x) compiled successfully in X ms
 
 global:
-  asset global-c.js 6.02 KiB [emitted] (name: c)
-  asset global-a.js 6.01 KiB [emitted] (name: a)
-  asset global-b.js 6.01 KiB [emitted] (name: b)
+  asset global-c.js 5.85 KiB [emitted] (name: c)
+  asset global-a.js 5.85 KiB [emitted] (name: a)
+  asset global-b.js 5.85 KiB [emitted] (name: b)
   asset global-332.js 443 bytes [emitted]
-  Entrypoint a 6.45 KiB = global-332.js 443 bytes global-a.js 6.01 KiB
-  Entrypoint b 6.45 KiB = global-332.js 443 bytes global-b.js 6.01 KiB
-  Entrypoint c 6.45 KiB = global-332.js 443 bytes global-c.js 6.02 KiB
-  chunk (runtime: b) global-b.js (b) 54 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
-    runtime modules 2.99 KiB 3 modules
+  Entrypoint a 6.28 KiB = global-332.js 443 bytes global-a.js 5.85 KiB
+  Entrypoint b 6.28 KiB = global-332.js 443 bytes global-b.js 5.85 KiB
+  Entrypoint c 6.29 KiB = global-332.js 443 bytes global-c.js 5.85 KiB
+  chunk (runtime: b) global-b.js (b) 54 bytes (javascript) 2.87 KiB (runtime) [entry] [rendered]
+    runtime modules 2.87 KiB 3 modules
     ./b.js 54 bytes [built] [code generated]
   chunk (runtime: a, b, c) global-332.js 72 bytes [initial] [rendered] split chunk (cache group: default)
     ./objects.js 72 bytes [built] [code generated]
-  chunk (runtime: c) global-c.js (c) 59 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
-    runtime modules 2.99 KiB 3 modules
+  chunk (runtime: c) global-c.js (c) 59 bytes (javascript) 2.87 KiB (runtime) [entry] [rendered]
+    runtime modules 2.87 KiB 3 modules
     ./c.js 59 bytes [built] [code generated]
-  chunk (runtime: a) global-a.js (a) 54 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
-    runtime modules 2.99 KiB 3 modules
+  chunk (runtime: a) global-a.js (a) 54 bytes (javascript) 2.87 KiB (runtime) [entry] [rendered]
+    runtime modules 2.87 KiB 3 modules
     ./a.js 54 bytes [built] [code generated]
   global (webpack x.x.x) compiled successfully in X ms"
 `;
@@ -4146,8 +4146,8 @@ webpack x.x.x compiled with 1 warning in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for wasm-explorer-examples-sync 1`] = `
-"assets by path *.js 18.2 KiB
-  asset bundle.js 13.1 KiB [emitted] (name: main)
+"assets by path *.js 18.9 KiB
+  asset bundle.js 13.8 KiB [emitted] (name: main)
   asset 325.bundle.js 3.78 KiB [emitted]
   asset 780.bundle.js 569 bytes [emitted]
   asset 526.bundle.js 364 bytes [emitted] (id hint: vendors)
@@ -4162,8 +4162,8 @@ assets by path *.wasm 1.37 KiB
   asset 71ba3c2b7af4ee0e4b5c.module.wasm 120 bytes [emitted] [immutable]
 chunk (runtime: main) 99.bundle.js 50 bytes (javascript) 531 bytes (webassembly) [rendered]
   ./duff.wasm 50 bytes (javascript) 531 bytes (webassembly) [built] [code generated]
-chunk (runtime: main) bundle.js (main) 586 bytes (javascript) 6.99 KiB (runtime) [entry] [rendered]
-  runtime modules 6.99 KiB 10 modules
+chunk (runtime: main) bundle.js (main) 586 bytes (javascript) 7.27 KiB (runtime) [entry] [rendered]
+  runtime modules 7.27 KiB 10 modules
   ./index.js 586 bytes [built] [code generated]
 chunk (runtime: main) 230.bundle.js 50 bytes (javascript) 156 bytes (webassembly) [rendered]
   ./Q_rsqrt.wasm 50 bytes (javascript) 156 bytes (webassembly) [built] [code generated]
@@ -4176,7 +4176,7 @@ chunk (runtime: main) 526.bundle.js (id hint: vendors) 34 bytes [rendered] split
 chunk (runtime: main) 780.bundle.js 110 bytes (javascript) 444 bytes (webassembly) [rendered]
   ./fact.wasm 50 bytes (javascript) 154 bytes (webassembly) [built] [code generated]
   ./fast-math.wasm 60 bytes (javascript) 290 bytes (webassembly) [built] [code generated]
-runtime modules 6.99 KiB 10 modules
+runtime modules 7.27 KiB 10 modules
 cacheable modules 2.31 KiB (javascript) 1.37 KiB (webassembly)
   webassembly modules 310 bytes (javascript) 1.37 KiB (webassembly)
     ./Q_rsqrt.wasm 50 bytes (javascript) 156 bytes (webassembly) [built] [code generated]

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -3,14 +3,14 @@
 exports[`StatsTestCases should print correct stats for aggressive-splitting-entry 1`] = `
 "fitting:
   PublicPath: auto
-  asset fitting-9492cad25a13fbc8e7a7.js 16 KiB [emitted] [immutable]
+  asset fitting-a23a7abdb3e2501c5723.js 16.1 KiB [emitted] [immutable]
   asset fitting-34542f2d6e4f073117f4.js 1.9 KiB [emitted] [immutable]
   asset fitting-db0927f4ef7838186003.js 1.9 KiB [emitted] [immutable]
   asset fitting-648f8b05ea1214c52404.js 1.08 KiB [emitted] [immutable]
-  Entrypoint main 19.8 KiB = fitting-db0927f4ef7838186003.js 1.9 KiB fitting-34542f2d6e4f073117f4.js 1.9 KiB fitting-9492cad25a13fbc8e7a7.js 16 KiB
-  chunk (runtime: main) fitting-9492cad25a13fbc8e7a7.js 1.87 KiB (javascript) 8.76 KiB (runtime) [entry] [rendered]
+  Entrypoint main 19.9 KiB = fitting-db0927f4ef7838186003.js 1.9 KiB fitting-34542f2d6e4f073117f4.js 1.9 KiB fitting-a23a7abdb3e2501c5723.js 16.1 KiB
+  chunk (runtime: main) fitting-a23a7abdb3e2501c5723.js 1.87 KiB (javascript) 8.88 KiB (runtime) [entry] [rendered]
     > ./index main
-    runtime modules 8.76 KiB 10 modules
+    runtime modules 8.88 KiB 10 modules
     cacheable modules 1.87 KiB
       ./e.js 899 bytes [dependent] [built] [code generated]
       ./f.js 900 bytes [dependent] [built] [code generated]
@@ -30,14 +30,14 @@ exports[`StatsTestCases should print correct stats for aggressive-splitting-entr
 
 content-change:
   PublicPath: auto
-  asset content-change-2ceac52d6bb8a7443486.js 16 KiB [emitted] [immutable]
+  asset content-change-0bc04332ecd9606e34ea.js 16.1 KiB [emitted] [immutable]
   asset content-change-34542f2d6e4f073117f4.js 1.9 KiB [emitted] [immutable]
   asset content-change-db0927f4ef7838186003.js 1.9 KiB [emitted] [immutable]
   asset content-change-648f8b05ea1214c52404.js 1.08 KiB [emitted] [immutable]
-  Entrypoint main 19.8 KiB = content-change-db0927f4ef7838186003.js 1.9 KiB content-change-34542f2d6e4f073117f4.js 1.9 KiB content-change-2ceac52d6bb8a7443486.js 16 KiB
-  chunk (runtime: main) content-change-2ceac52d6bb8a7443486.js 1.87 KiB (javascript) 8.77 KiB (runtime) [entry] [rendered]
+  Entrypoint main 19.9 KiB = content-change-db0927f4ef7838186003.js 1.9 KiB content-change-34542f2d6e4f073117f4.js 1.9 KiB content-change-0bc04332ecd9606e34ea.js 16.1 KiB
+  chunk (runtime: main) content-change-0bc04332ecd9606e34ea.js 1.87 KiB (javascript) 8.88 KiB (runtime) [entry] [rendered]
     > ./index main
-    runtime modules 8.77 KiB 10 modules
+    runtime modules 8.88 KiB 10 modules
     cacheable modules 1.87 KiB
       ./e.js 899 bytes [dependent] [built] [code generated]
       ./f.js 900 bytes [dependent] [built] [code generated]
@@ -58,7 +58,7 @@ content-change:
 
 exports[`StatsTestCases should print correct stats for aggressive-splitting-on-demand 1`] = `
 "PublicPath: auto
-asset 05089f534db24cffb08d.js 11.5 KiB [emitted] [immutable] (name: main)
+asset 7706b22c902378f64378.js 11.5 KiB [emitted] [immutable] (name: main)
 asset daf4c888556b29be016d.js 1.91 KiB [emitted] [immutable]
 asset 8c077ced7fa52f135e3c.js 1.91 KiB [emitted] [immutable]
 asset 661f4167d7706ba28ded.js 1.9 KiB [emitted] [immutable]
@@ -70,14 +70,14 @@ asset cd87f005f9b4ddde3af0.js 1.9 KiB [emitted] [immutable]
 asset 0a9a29eb4cf1cfec6e7f.js 1010 bytes [emitted] [immutable]
 asset d861dc604cacc82b16e2.js 1010 bytes [emitted] [immutable]
 asset d9498542c42d67f86bab.js 1010 bytes [emitted] [immutable]
-Entrypoint main 11.5 KiB = 05089f534db24cffb08d.js
+Entrypoint main 11.5 KiB = 7706b22c902378f64378.js
 chunk (runtime: main) 34542f2d6e4f073117f4.js 1.76 KiB [rendered] [recorded] aggressive splitted
   > ./c ./d ./e ./index.js 3:0-30
   ./c.js 899 bytes [built] [code generated]
   ./d.js 899 bytes [built] [code generated]
-chunk (runtime: main) 05089f534db24cffb08d.js (main) 248 bytes (javascript) 6.19 KiB (runtime) [entry] [rendered]
+chunk (runtime: main) 7706b22c902378f64378.js (main) 248 bytes (javascript) 6.22 KiB (runtime) [entry] [rendered]
   > ./index main
-  runtime modules 6.19 KiB 7 modules
+  runtime modules 6.22 KiB 7 modules
   ./index.js 248 bytes [built] [code generated]
 chunk (runtime: main) daf4c888556b29be016d.js 1.76 KiB [rendered]
   > ./f ./g ./h ./i ./j ./k ./index.js 4:0-51
@@ -138,9 +138,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for async-commons-chunk 1`] = `
-"chunk (runtime: main) main.js (main) 515 bytes (javascript) 5.87 KiB (runtime) >{460}< >{847}< >{996}< [entry] [rendered]
+"chunk (runtime: main) main.js (main) 515 bytes (javascript) 5.9 KiB (runtime) >{460}< >{847}< >{996}< [entry] [rendered]
   > ./ main
-  runtime modules 5.87 KiB 7 modules
+  runtime modules 5.9 KiB 7 modules
   ./index.js 515 bytes [built] [code generated]
 chunk (runtime: main) 460.js 21 bytes <{179}> ={847}= [rendered]
   > ./index.js 17:1-21:3
@@ -167,9 +167,9 @@ exports[`StatsTestCases should print correct stats for async-commons-chunk-auto 
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) disabled/main.js (main) 147 bytes (javascript) 6.52 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) disabled/main.js (main) 147 bytes (javascript) 6.55 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.52 KiB 9 modules
+    runtime modules 6.55 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) disabled/async-b.js (async-b) 196 bytes [rendered]
     > ./b ./index.js 2:0-47
@@ -184,9 +184,9 @@ exports[`StatsTestCases should print correct stats for async-commons-chunk-auto 
     dependent modules 60 bytes [dependent] 3 modules
     runtime modules 394 bytes 2 modules
     ./c.js + 1 modules 136 bytes [built] [code generated]
-  chunk (runtime: a) disabled/a.js (a) 245 bytes (javascript) 6.47 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) disabled/a.js (a) 245 bytes (javascript) 6.5 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 6.47 KiB 9 modules
+    runtime modules 6.5 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) disabled/async-a.js (async-a) 245 bytes [rendered]
@@ -204,9 +204,9 @@ default:
   chunk (runtime: a, main) default/async-g.js (async-g) 45 bytes [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.53 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.57 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.53 KiB 9 modules
+    runtime modules 6.57 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) default/282.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -237,9 +237,9 @@ default:
   chunk (runtime: main) default/769.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
     > ./c ./index.js 3:0-47
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.52 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.55 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 6.52 KiB 9 modules
+    runtime modules 6.55 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) default/async-a.js (async-a) 185 bytes [rendered]
@@ -252,22 +252,22 @@ default:
   default (webpack x.x.x) compiled successfully
 
 vendors:
-  Entrypoint main 10.9 KiB = vendors/main.js
-  Entrypoint a 14.4 KiB = vendors/vendors.js 1.07 KiB vendors/a.js 13.3 KiB
-  Entrypoint b 8.04 KiB = vendors/vendors.js 1.07 KiB vendors/b.js 6.97 KiB
-  Entrypoint c 8.04 KiB = vendors/vendors.js 1.07 KiB vendors/c.js 6.97 KiB
-  chunk (runtime: b) vendors/b.js (b) 156 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
+  Entrypoint main 11 KiB = vendors/main.js
+  Entrypoint a 14.5 KiB = vendors/vendors.js 1.07 KiB vendors/a.js 13.4 KiB
+  Entrypoint b 8.17 KiB = vendors/vendors.js 1.07 KiB vendors/b.js 7.1 KiB
+  Entrypoint c 8.17 KiB = vendors/vendors.js 1.07 KiB vendors/c.js 7.1 KiB
+  chunk (runtime: b) vendors/b.js (b) 156 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
     > ./b b
-    runtime modules 2.88 KiB 3 modules
+    runtime modules 2.99 KiB 3 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./b.js 116 bytes [built] [code generated]
   chunk (runtime: a, main) vendors/async-g.js (async-g) 65 bytes [rendered]
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) vendors/main.js (main) 147 bytes (javascript) 6.52 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) vendors/main.js (main) 147 bytes (javascript) 6.55 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.52 KiB 9 modules
+    runtime modules 6.55 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: a, b, c) vendors/vendors.js (vendors) (id hint: vendors) 60 bytes [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
     > ./a a
@@ -284,14 +284,14 @@ vendors:
     > ./c ./index.js 3:0-47
     dependent modules 80 bytes [dependent] 4 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: c) vendors/c.js (c) 156 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
+  chunk (runtime: c) vendors/c.js (c) 156 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
     > ./c c
-    runtime modules 2.88 KiB 3 modules
+    runtime modules 2.99 KiB 3 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: a) vendors/a.js (a) 205 bytes (javascript) 7.65 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) vendors/a.js (a) 205 bytes (javascript) 7.77 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 7.65 KiB 9 modules
+    runtime modules 7.77 KiB 9 modules
     dependent modules 20 bytes [dependent] 1 module
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) vendors/async-a.js (async-a) 245 bytes [rendered]
@@ -302,9 +302,9 @@ vendors:
 
 multiple-vendors:
   Entrypoint main 11.4 KiB = multiple-vendors/main.js
-  Entrypoint a 14.8 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/954.js 412 bytes multiple-vendors/767.js 412 bytes multiple-vendors/390.js 412 bytes multiple-vendors/a.js 13.2 KiB
-  Entrypoint b 7.97 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/954.js 412 bytes multiple-vendors/767.js 412 bytes multiple-vendors/568.js 412 bytes multiple-vendors/b.js 6.36 KiB
-  Entrypoint c 7.97 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/769.js 412 bytes multiple-vendors/767.js 412 bytes multiple-vendors/568.js 412 bytes multiple-vendors/c.js 6.36 KiB
+  Entrypoint a 15 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/954.js 412 bytes multiple-vendors/767.js 412 bytes multiple-vendors/390.js 412 bytes multiple-vendors/a.js 13.4 KiB
+  Entrypoint b 8.1 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/954.js 412 bytes multiple-vendors/767.js 412 bytes multiple-vendors/568.js 412 bytes multiple-vendors/b.js 6.49 KiB
+  Entrypoint c 8.1 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/769.js 412 bytes multiple-vendors/767.js 412 bytes multiple-vendors/568.js 412 bytes multiple-vendors/c.js 6.49 KiB
   chunk (runtime: a, b, c, main) multiple-vendors/libs-x.js (libs-x) (id hint: libs) 20 bytes [initial] [rendered] split chunk (cache group: libs) (name: libs-x)
     > ./a ./index.js 1:0-47
     > ./b ./index.js 2:0-47
@@ -313,16 +313,16 @@ multiple-vendors:
     > ./b b
     > ./c c
     ./node_modules/x.js 20 bytes [built] [code generated]
-  chunk (runtime: b) multiple-vendors/b.js (b) 116 bytes (javascript) 2.9 KiB (runtime) [entry] [rendered]
+  chunk (runtime: b) multiple-vendors/b.js (b) 116 bytes (javascript) 3.01 KiB (runtime) [entry] [rendered]
     > ./b b
-    runtime modules 2.9 KiB 3 modules
+    runtime modules 3.01 KiB 3 modules
     ./b.js 116 bytes [built] [code generated]
   chunk (runtime: a, main) multiple-vendors/async-g.js (async-g) 45 bytes [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) multiple-vendors/main.js (main) 147 bytes (javascript) 6.56 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) multiple-vendors/main.js (main) 147 bytes (javascript) 6.59 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.56 KiB 9 modules
+    runtime modules 6.59 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) multiple-vendors/async-b.js (async-b) 116 bytes [rendered]
     > ./b ./index.js 2:0-47
@@ -334,9 +334,9 @@ multiple-vendors:
     > ./a ./index.js 1:0-47
     > ./a a
     ./e.js 20 bytes [built] [code generated]
-  chunk (runtime: c) multiple-vendors/c.js (c) 116 bytes (javascript) 2.9 KiB (runtime) [entry] [rendered]
+  chunk (runtime: c) multiple-vendors/c.js (c) 116 bytes (javascript) 3.01 KiB (runtime) [entry] [rendered]
     > ./c c
-    runtime modules 2.9 KiB 3 modules
+    runtime modules 3.01 KiB 3 modules
     ./c.js 116 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) multiple-vendors/568.js 20 bytes [initial] [rendered] split chunk (cache group: default)
     > ./b ./index.js 2:0-47
@@ -357,9 +357,9 @@ multiple-vendors:
     > ./c ./index.js 3:0-47
     > ./c c
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) multiple-vendors/a.js (a) 165 bytes (javascript) 7.71 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) multiple-vendors/a.js (a) 165 bytes (javascript) 7.83 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 7.71 KiB 9 modules
+    runtime modules 7.83 KiB 9 modules
     ./a.js 165 bytes [built] [code generated]
   chunk (runtime: main) multiple-vendors/async-a.js (async-a) 165 bytes [rendered]
     > ./a ./index.js 1:0-47
@@ -373,20 +373,20 @@ multiple-vendors:
   multiple-vendors (webpack x.x.x) compiled successfully
 
 all:
-  Entrypoint main 11.3 KiB = all/main.js
-  Entrypoint a 14.8 KiB = all/282.js 412 bytes all/954.js 412 bytes all/767.js 412 bytes all/390.js 412 bytes all/a.js 13.2 KiB
-  Entrypoint b 7.97 KiB = all/282.js 412 bytes all/954.js 412 bytes all/767.js 412 bytes all/568.js 412 bytes all/b.js 6.36 KiB
-  Entrypoint c 7.97 KiB = all/282.js 412 bytes all/769.js 412 bytes all/767.js 412 bytes all/568.js 412 bytes all/c.js 6.36 KiB
-  chunk (runtime: b) all/b.js (b) 116 bytes (javascript) 2.9 KiB (runtime) [entry] [rendered]
+  Entrypoint main 11.4 KiB = all/main.js
+  Entrypoint a 15 KiB = all/282.js 412 bytes all/954.js 412 bytes all/767.js 412 bytes all/390.js 412 bytes all/a.js 13.3 KiB
+  Entrypoint b 8.1 KiB = all/282.js 412 bytes all/954.js 412 bytes all/767.js 412 bytes all/568.js 412 bytes all/b.js 6.49 KiB
+  Entrypoint c 8.1 KiB = all/282.js 412 bytes all/769.js 412 bytes all/767.js 412 bytes all/568.js 412 bytes all/c.js 6.49 KiB
+  chunk (runtime: b) all/b.js (b) 116 bytes (javascript) 3.01 KiB (runtime) [entry] [rendered]
     > ./b b
-    runtime modules 2.9 KiB 3 modules
+    runtime modules 3.01 KiB 3 modules
     ./b.js 116 bytes [built] [code generated]
   chunk (runtime: a, main) all/async-g.js (async-g) 45 bytes [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) all/main.js (main) 147 bytes (javascript) 6.53 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) all/main.js (main) 147 bytes (javascript) 6.56 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.53 KiB 9 modules
+    runtime modules 6.56 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) all/282.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
     > ./a ./index.js 1:0-47
@@ -406,9 +406,9 @@ all:
     > ./a ./index.js 1:0-47
     > ./a a
     ./e.js 20 bytes [built] [code generated]
-  chunk (runtime: c) all/c.js (c) 116 bytes (javascript) 2.9 KiB (runtime) [entry] [rendered]
+  chunk (runtime: c) all/c.js (c) 116 bytes (javascript) 3.01 KiB (runtime) [entry] [rendered]
     > ./c c
-    runtime modules 2.9 KiB 3 modules
+    runtime modules 3.01 KiB 3 modules
     ./c.js 116 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) all/568.js 20 bytes [initial] [rendered] split chunk (cache group: default)
     > ./b ./index.js 2:0-47
@@ -429,9 +429,9 @@ all:
     > ./c ./index.js 3:0-47
     > ./c c
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) all/a.js (a) 165 bytes (javascript) 7.7 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) all/a.js (a) 165 bytes (javascript) 7.81 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 7.7 KiB 9 modules
+    runtime modules 7.81 KiB 9 modules
     ./a.js 165 bytes [built] [code generated]
   chunk (runtime: main) all/async-a.js (async-a) 165 bytes [rendered]
     > ./a ./index.js 1:0-47
@@ -491,13 +491,13 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for chunks 1`] = `
 "PublicPath: auto
-asset bundle.js 9.98 KiB [emitted] (name: main)
+asset bundle.js 10 KiB [emitted] (name: main)
 asset 460.bundle.js 320 bytes [emitted]
 asset 524.bundle.js 206 bytes [emitted]
 asset 996.bundle.js 138 bytes [emitted]
-chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 5.88 KiB (runtime) >{460}< >{996}< [entry] [rendered]
+chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 5.91 KiB (runtime) >{460}< >{996}< [entry] [rendered]
   > ./index main
-  runtime modules 5.88 KiB 7 modules
+  runtime modules 5.91 KiB 7 modules
   cacheable modules 73 bytes
     ./a.js 22 bytes [dependent] [built] [code generated]
       cjs self exports reference ./a.js 1:0-14
@@ -537,7 +537,7 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for chunks-development 1`] = `
 "PublicPath: auto
-asset bundle.js 10.8 KiB [emitted] (name: main)
+asset bundle.js 10.9 KiB [emitted] (name: main)
 asset d_js-e_js.bundle.js 1.07 KiB [emitted]
 asset c_js.bundle.js 1010 bytes [emitted]
 asset b_js.bundle.js 819 bytes [emitted]
@@ -566,9 +566,9 @@ chunk (runtime: main) d_js-e_js.bundle.js 60 bytes <{c_js}> [rendered]
     cjs self exports reference ./e.js 2:0-14
     X ms -> X ms ->
     X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
-chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 5.88 KiB (runtime) >{b_js}< >{c_js}< [entry] [rendered]
+chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 5.91 KiB (runtime) >{b_js}< >{c_js}< [entry] [rendered]
   > ./index main
-  runtime modules 5.88 KiB 7 modules
+  runtime modules 5.91 KiB 7 modules
   cacheable modules 73 bytes
     ./a.js 22 bytes [dependent] [built] [code generated]
       cjs self exports reference ./a.js 1:0-14
@@ -585,8 +585,8 @@ webpack x.x.x compiled successfully in X ms"
 exports[`StatsTestCases should print correct stats for circular-correctness 1`] = `
 "chunk (runtime: main) 128.bundle.js (b) 49 bytes <{179}> <{459}> >{459}< [rendered]
   ./module-b.js 49 bytes [built] [code generated]
-chunk (runtime: main) bundle.js (main) 98 bytes (javascript) 7.55 KiB (runtime) >{128}< >{786}< [entry] [rendered]
-  runtime modules 7.55 KiB 10 modules
+chunk (runtime: main) bundle.js (main) 98 bytes (javascript) 7.58 KiB (runtime) >{128}< >{786}< [entry] [rendered]
+  runtime modules 7.58 KiB 10 modules
   ./index.js 98 bytes [built] [code generated]
 chunk (runtime: main) 459.bundle.js (c) 98 bytes <{128}> <{786}> >{128}< >{786}< [rendered]
   ./module-c.js 98 bytes [built] [code generated]
@@ -624,10 +624,10 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for commons-chunk-min-size-0 1`] = `
-"asset entry-1.js 5.55 KiB [emitted] (name: entry-1)
+"asset entry-1.js 5.69 KiB [emitted] (name: entry-1)
 asset 429.js 274 bytes [emitted] (id hint: vendor-1)
-Entrypoint entry-1 5.82 KiB = 429.js 274 bytes entry-1.js 5.55 KiB
-runtime modules 2.58 KiB 2 modules
+Entrypoint entry-1 5.95 KiB = 429.js 274 bytes entry-1.js 5.69 KiB
+runtime modules 2.69 KiB 2 modules
 modules by path ./modules/*.js 132 bytes
   ./modules/a.js 22 bytes [built] [code generated]
   ./modules/b.js 22 bytes [built] [code generated]
@@ -640,10 +640,10 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for commons-chunk-min-size-Infinity 1`] = `
-"asset entry-1.js 5.55 KiB [emitted] (name: entry-1)
+"asset entry-1.js 5.69 KiB [emitted] (name: entry-1)
 asset vendor-1.js 274 bytes [emitted] (name: vendor-1) (id hint: vendor-1)
-Entrypoint entry-1 5.82 KiB = vendor-1.js 274 bytes entry-1.js 5.55 KiB
-runtime modules 2.58 KiB 2 modules
+Entrypoint entry-1 5.95 KiB = vendor-1.js 274 bytes entry-1.js 5.69 KiB
+runtime modules 2.69 KiB 2 modules
 modules by path ./modules/*.js 132 bytes
   ./modules/a.js 22 bytes [built] [code generated]
   ./modules/b.js 22 bytes [built] [code generated]
@@ -656,20 +656,20 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for commons-plugin-issue-4980 1`] = `
-"asset app.7ba0d8a51deca2bd4789-1.js 6.08 KiB [emitted] [immutable] (name: app)
+"asset app.153d1335892ba0759464-1.js 6.22 KiB [emitted] [immutable] (name: app)
 asset vendor.c715f5ed2754861797e1-1.js 611 bytes [emitted] [immutable] (name: vendor) (id hint: vendor)
-Entrypoint app 6.68 KiB = vendor.c715f5ed2754861797e1-1.js 611 bytes app.7ba0d8a51deca2bd4789-1.js 6.08 KiB
-runtime modules 2.88 KiB 3 modules
+Entrypoint app 6.82 KiB = vendor.c715f5ed2754861797e1-1.js 611 bytes app.153d1335892ba0759464-1.js 6.22 KiB
+runtime modules 2.99 KiB 3 modules
 orphan modules 118 bytes [orphan] 2 modules
 cacheable modules 272 bytes
   ./entry-1.js + 2 modules 185 bytes [built] [code generated]
   ./constants.js 87 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset app.c7d38e079a69fb21e8fe-2.js 6.1 KiB [emitted] [immutable] (name: app)
+asset app.ab0fb380ee471fac6658-2.js 6.24 KiB [emitted] [immutable] (name: app)
 asset vendor.c715f5ed2754861797e1-2.js 611 bytes [emitted] [immutable] (name: vendor) (id hint: vendor)
-Entrypoint app 6.7 KiB = vendor.c715f5ed2754861797e1-2.js 611 bytes app.c7d38e079a69fb21e8fe-2.js 6.1 KiB
-runtime modules 2.88 KiB 3 modules
+Entrypoint app 6.83 KiB = vendor.c715f5ed2754861797e1-2.js 611 bytes app.ab0fb380ee471fac6658-2.js 6.24 KiB
+runtime modules 2.99 KiB 3 modules
 orphan modules 125 bytes [orphan] 2 modules
 cacheable modules 279 bytes
   ./entry-2.js + 2 modules 192 bytes [built] [code generated]
@@ -698,40 +698,40 @@ exports[`StatsTestCases should print correct stats for concat-and-sideeffects 1`
 `;
 
 exports[`StatsTestCases should print correct stats for context-independence 1`] = `
-"asset main-3e770b0a90723d1d9842.js 10.3 KiB [emitted] [immutable] (name: main)
-  sourceMap main-3e770b0a90723d1d9842.js.map 9.16 KiB [emitted] [dev] (auxiliary name: main)
+"asset main-4e72d6e6698b7935e2b0.js 10.3 KiB [emitted] [immutable] (name: main)
+  sourceMap main-4e72d6e6698b7935e2b0.js.map 9.19 KiB [emitted] [dev] (auxiliary name: main)
 asset 664-cb106d2f6263642c0727.js 455 bytes [emitted] [immutable]
   sourceMap 664-cb106d2f6263642c0727.js.map 344 bytes [emitted] [dev]
-runtime modules 6.17 KiB 8 modules
+runtime modules 6.2 KiB 8 modules
 orphan modules 19 bytes [orphan] 1 module
 cacheable modules 106 bytes
   ./a/index.js 40 bytes [built] [code generated]
   ./a/chunk.js + 1 modules 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-3e770b0a90723d1d9842.js 10.3 KiB [emitted] [immutable] (name: main)
-  sourceMap main-3e770b0a90723d1d9842.js.map 9.16 KiB [emitted] [dev] (auxiliary name: main)
+asset main-4e72d6e6698b7935e2b0.js 10.3 KiB [emitted] [immutable] (name: main)
+  sourceMap main-4e72d6e6698b7935e2b0.js.map 9.19 KiB [emitted] [dev] (auxiliary name: main)
 asset 664-cb106d2f6263642c0727.js 455 bytes [emitted] [immutable]
   sourceMap 664-cb106d2f6263642c0727.js.map 344 bytes [emitted] [dev]
-runtime modules 6.17 KiB 8 modules
+runtime modules 6.2 KiB 8 modules
 orphan modules 19 bytes [orphan] 1 module
 cacheable modules 106 bytes
   ./b/index.js 40 bytes [built] [code generated]
   ./b/chunk.js + 1 modules 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-ebaa8fc07a5809ec63a9.js 11.1 KiB [emitted] [immutable] (name: main)
+asset main-a335726731d18f0e2468.js 11.2 KiB [emitted] [immutable] (name: main)
 asset 664-12bf7254f5c08e0ac9e9.js 1.51 KiB [emitted] [immutable]
-runtime modules 6.17 KiB 8 modules
+runtime modules 6.2 KiB 8 modules
 orphan modules 19 bytes [orphan] 1 module
 cacheable modules 106 bytes
   ./a/index.js 40 bytes [built] [code generated]
   ./a/chunk.js + 1 modules 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-ebaa8fc07a5809ec63a9.js 11.1 KiB [emitted] [immutable] (name: main)
+asset main-a335726731d18f0e2468.js 11.2 KiB [emitted] [immutable] (name: main)
 asset 664-12bf7254f5c08e0ac9e9.js 1.51 KiB [emitted] [immutable]
-runtime modules 6.17 KiB 8 modules
+runtime modules 6.2 KiB 8 modules
 orphan modules 19 bytes [orphan] 1 module
 cacheable modules 106 bytes
   ./b/index.js 40 bytes [built] [code generated]
@@ -819,16 +819,16 @@ exports[`StatsTestCases should print correct stats for graph-correctness-entries
 "chunk (runtime: e1, e2) b.js (b) 49 bytes <{786}> >{459}< [rendered]
   ./module-b.js 49 bytes [built] [code generated]
     import() ./module-b ./module-a.js 1:0-47
-chunk (runtime: e1) e1.js (e1) 49 bytes (javascript) 7.58 KiB (runtime) >{786}< [entry] [rendered]
-  runtime modules 7.58 KiB 10 modules
+chunk (runtime: e1) e1.js (e1) 49 bytes (javascript) 7.61 KiB (runtime) >{786}< [entry] [rendered]
+  runtime modules 7.61 KiB 10 modules
   ./e1.js 49 bytes [built] [code generated]
     entry ./e1 e1
 chunk (runtime: e1, e2) c.js (c) 49 bytes <{128}> <{621}> >{786}< [rendered]
   ./module-c.js 49 bytes [built] [code generated]
     import() ./module-c ./e2.js 1:0-47
     import() ./module-c ./module-b.js 1:0-47
-chunk (runtime: e2) e2.js (e2) 49 bytes (javascript) 7.58 KiB (runtime) >{459}< [entry] [rendered]
-  runtime modules 7.58 KiB 10 modules
+chunk (runtime: e2) e2.js (e2) 49 bytes (javascript) 7.61 KiB (runtime) >{459}< [entry] [rendered]
+  runtime modules 7.61 KiB 10 modules
   ./e2.js 49 bytes [built] [code generated]
     entry ./e2 e2
 chunk (runtime: e1, e2) a.js (a) 49 bytes <{257}> <{459}> >{128}< [rendered]
@@ -842,8 +842,8 @@ exports[`StatsTestCases should print correct stats for graph-correctness-modules
 "chunk (runtime: e1, e2) b.js (b) 179 bytes <{786}> >{459}< [rendered]
   ./module-b.js 179 bytes [built] [code generated]
     import() ./module-b ./module-a.js 1:0-47
-chunk (runtime: e1) e1.js (e1) 119 bytes (javascript) 7.84 KiB (runtime) >{786}< >{892}< [entry] [rendered]
-  runtime modules 7.84 KiB 11 modules
+chunk (runtime: e1) e1.js (e1) 119 bytes (javascript) 7.87 KiB (runtime) >{786}< >{892}< [entry] [rendered]
+  runtime modules 7.87 KiB 11 modules
   cacheable modules 119 bytes
     ./e1.js 70 bytes [built] [code generated]
       entry ./e1 e1
@@ -855,8 +855,8 @@ chunk (runtime: e1, e2) c.js (c) 49 bytes <{128}> <{621}> >{786}< [rendered]
   ./module-c.js 49 bytes [built] [code generated]
     import() ./module-c ./e2.js 2:0-47
     import() ./module-c ./module-b.js 1:0-47
-chunk (runtime: e2) e2.js (e2) 119 bytes (javascript) 7.84 KiB (runtime) >{459}< >{892}< [entry] [rendered]
-  runtime modules 7.84 KiB 11 modules
+chunk (runtime: e2) e2.js (e2) 119 bytes (javascript) 7.87 KiB (runtime) >{459}< >{892}< [entry] [rendered]
+  runtime modules 7.87 KiB 11 modules
   cacheable modules 119 bytes
     ./e2.js 70 bytes [built] [code generated]
       entry ./e2 e2
@@ -895,8 +895,8 @@ chunk (runtime: main) id-equals-name_js0.js 21 bytes [rendered]
   ./id-equals-name.js 21 bytes [built] [code generated]
 chunk (runtime: main) id-equals-name_js_3.js 21 bytes [rendered]
   ./id-equals-name.js?3 21 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 639 bytes (javascript) 6.44 KiB (runtime) [entry] [rendered]
-  runtime modules 6.44 KiB 9 modules
+chunk (runtime: main) main.js (main) 639 bytes (javascript) 6.47 KiB (runtime) [entry] [rendered]
+  runtime modules 6.47 KiB 9 modules
   ./index.js 639 bytes [built] [code generated]
 chunk (runtime: main) tree.js (tree) 137 bytes [rendered]
   dependent modules 98 bytes [dependent] 3 modules
@@ -925,7 +925,7 @@ webpack x.x.x compiled with 2 warnings in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for immutable 1`] = `
-"asset deb902e1c6c6d6c31fc1.js 12.9 KiB [emitted] [immutable] (name: main)
+"asset b16d4e2608b35d3294c5.js 12.9 KiB [emitted] [immutable] (name: main)
 asset cd9e349e4fe2a6d0d4d0.js 812 bytes [emitted] [immutable]"
 `;
 
@@ -934,7 +934,7 @@ exports[`StatsTestCases should print correct stats for import-context-filter 1`]
 asset 398.js 480 bytes [emitted]
 asset 544.js 480 bytes [emitted]
 asset 718.js 480 bytes [emitted]
-runtime modules 6.44 KiB 9 modules
+runtime modules 6.47 KiB 9 modules
 built modules 724 bytes [built]
   modules by path ./templates/*.js 114 bytes
     ./templates/bar.js 38 bytes [optional] [built] [code generated]
@@ -948,7 +948,7 @@ webpack x.x.x compiled successfully in X ms"
 exports[`StatsTestCases should print correct stats for import-weak 1`] = `
 "asset entry.js 12.8 KiB [emitted] (name: entry)
 asset 836.js 138 bytes [emitted]
-runtime modules 7.54 KiB 10 modules
+runtime modules 7.57 KiB 10 modules
 orphan modules 37 bytes [orphan] 1 module
 cacheable modules 142 bytes
   ./entry.js 120 bytes [built] [code generated]
@@ -957,7 +957,7 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for import-with-invalid-options-comments 1`] = `
-"runtime modules 8.52 KiB 12 modules
+"runtime modules 8.55 KiB 12 modules
 cacheable modules 559 bytes
   ./index.js 50 bytes [built] [code generated]
   ./chunk.js 401 bytes [built] [code generated] [3 warnings]
@@ -982,20 +982,20 @@ webpack x.x.x compiled with 3 warnings"
 `;
 
 exports[`StatsTestCases should print correct stats for issue-7577 1`] = `
-"asset a-runtime~main-1c25d32f5799aad03d03.js 5.1 KiB [emitted] [immutable] (name: runtime~main)
+"asset a-runtime~main-43399c7277260678413a.js 5.24 KiB [emitted] [immutable] (name: runtime~main)
 asset a-all-a_js-2245ace798fe63ddba13.js 140 bytes [emitted] [immutable] (id hint: all)
 asset a-main-b1eee3373fffb0185d2b.js 114 bytes [emitted] [immutable] (name: main)
-Entrypoint main 5.35 KiB = a-runtime~main-1c25d32f5799aad03d03.js 5.1 KiB a-all-a_js-2245ace798fe63ddba13.js 140 bytes a-main-b1eee3373fffb0185d2b.js 114 bytes
-runtime modules 2.58 KiB 2 modules
+Entrypoint main 5.49 KiB = a-runtime~main-43399c7277260678413a.js 5.24 KiB a-all-a_js-2245ace798fe63ddba13.js 140 bytes a-main-b1eee3373fffb0185d2b.js 114 bytes
+runtime modules 2.69 KiB 2 modules
 ./a.js 18 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset b-runtime~main-599255de31b112c7d98b.js 6.04 KiB [emitted] [immutable] (name: runtime~main)
+asset b-runtime~main-bfa1df9c60dbe26a0c28.js 6.17 KiB [emitted] [immutable] (name: runtime~main)
 asset b-all-b_js-5f2f43e942828cce49a7.js 475 bytes [emitted] [immutable] (id hint: all)
 asset b-vendors-node_modules_vendor_js-bf78b376ab124e2d5ed3.js 185 bytes [emitted] [immutable] (id hint: vendors)
 asset b-main-0780253982d2b99627d2.js 147 bytes [emitted] [immutable] (name: main)
-Entrypoint main 6.83 KiB = b-runtime~main-599255de31b112c7d98b.js 6.04 KiB b-vendors-node_modules_vendor_js-bf78b376ab124e2d5ed3.js 185 bytes b-all-b_js-5f2f43e942828cce49a7.js 475 bytes b-main-0780253982d2b99627d2.js 147 bytes
-runtime modules 3.14 KiB 4 modules
+Entrypoint main 6.96 KiB = b-runtime~main-bfa1df9c60dbe26a0c28.js 6.17 KiB b-vendors-node_modules_vendor_js-bf78b376ab124e2d5ed3.js 185 bytes b-all-b_js-5f2f43e942828cce49a7.js 475 bytes b-main-0780253982d2b99627d2.js 147 bytes
+runtime modules 3.25 KiB 4 modules
 cacheable modules 40 bytes
   ./b.js 17 bytes [built] [code generated]
   ./node_modules/vendor.js 23 bytes [built] [code generated]
@@ -1004,11 +1004,11 @@ webpack x.x.x compiled successfully in X ms
 assets by chunk 895 bytes (id hint: all)
   asset c-all-b_js-128dddb8321697614d16.js 502 bytes [emitted] [immutable] (id hint: all)
   asset c-all-c_js-5fc6d532ca1ac022819e.js 393 bytes [emitted] [immutable] (id hint: all)
-asset c-runtime~main-36cd4e671a91edfac6ab.js 13.7 KiB [emitted] [immutable] (name: runtime~main)
+asset c-runtime~main-52dcac7bccba962ab90a.js 13.9 KiB [emitted] [immutable] (name: runtime~main)
 asset c-main-3737497cd09f5bd99fe3.js 603 bytes [emitted] [immutable] (name: main)
 asset c-vendors-node_modules_vendor_js-bf78b376ab124e2d5ed3.js 185 bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main 14.7 KiB = c-runtime~main-36cd4e671a91edfac6ab.js 13.7 KiB c-all-c_js-5fc6d532ca1ac022819e.js 393 bytes c-main-3737497cd09f5bd99fe3.js 603 bytes
-runtime modules 8.81 KiB 12 modules
+Entrypoint main 14.8 KiB = c-runtime~main-52dcac7bccba962ab90a.js 13.9 KiB c-all-c_js-5fc6d532ca1ac022819e.js 393 bytes c-main-3737497cd09f5bd99fe3.js 603 bytes
+runtime modules 8.93 KiB 12 modules
 cacheable modules 101 bytes
   ./c.js 61 bytes [built] [code generated]
   ./b.js 17 bytes [built] [code generated]
@@ -1033,8 +1033,8 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
 2 chunks:
   asset bundle2.js 12.4 KiB [emitted] (name: main)
   asset 459.bundle2.js 664 bytes [emitted] (name: c)
-  chunk (runtime: main) bundle2.js (main) 101 bytes (javascript) 7.55 KiB (runtime) >{459}< [entry] [rendered]
-    runtime modules 7.55 KiB 10 modules
+  chunk (runtime: main) bundle2.js (main) 101 bytes (javascript) 7.58 KiB (runtime) >{459}< [entry] [rendered]
+    runtime modules 7.58 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
   chunk (runtime: main) 459.bundle2.js (c) 118 bytes <{179}> <{459}> >{459}< [rendered]
     dependent modules 44 bytes [dependent]
@@ -1049,8 +1049,8 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   asset bundle3.js 12.4 KiB [emitted] (name: main)
   asset 459.bundle3.js 528 bytes [emitted] (name: c)
   asset 524.bundle3.js 206 bytes [emitted]
-  chunk (runtime: main) bundle3.js (main) 101 bytes (javascript) 7.55 KiB (runtime) >{459}< [entry] [rendered]
-    runtime modules 7.55 KiB 10 modules
+  chunk (runtime: main) bundle3.js (main) 101 bytes (javascript) 7.58 KiB (runtime) >{459}< [entry] [rendered]
+    runtime modules 7.58 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
   chunk (runtime: main) 459.bundle3.js (c) 74 bytes <{179}> >{524}< [rendered]
     ./a.js 22 bytes [built] [code generated]
@@ -1066,8 +1066,8 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   asset 459.bundle4.js 392 bytes [emitted] (name: c)
   asset 394.bundle4.js 206 bytes [emitted]
   asset 524.bundle4.js 206 bytes [emitted]
-  chunk (runtime: main) bundle4.js (main) 101 bytes (javascript) 7.55 KiB (runtime) >{394}< >{459}< [entry] [rendered]
-    runtime modules 7.55 KiB 10 modules
+  chunk (runtime: main) bundle4.js (main) 101 bytes (javascript) 7.58 KiB (runtime) >{394}< >{459}< [entry] [rendered]
+    runtime modules 7.58 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
   chunk (runtime: main) 394.bundle4.js 44 bytes <{179}> [rendered]
     ./a.js 22 bytes [built] [code generated]
@@ -1170,13 +1170,13 @@ Chunk Group b 563 bytes (21 KiB) = b.js 563 bytes (2.png 21 KiB)
 chunk (runtime: main) b.js (b) 67 bytes [rendered]
   ./node_modules/a/2.png 49 bytes [dependent] [built] [code generated] [1 asset]
   ./node_modules/b/index.js 18 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 82 bytes (javascript) 6.16 KiB (runtime) [entry] [rendered]
-  runtime modules 6.16 KiB 8 modules
+chunk (runtime: main) main.js (main) 82 bytes (javascript) 6.19 KiB (runtime) [entry] [rendered]
+  runtime modules 6.19 KiB 8 modules
   ./index.js 82 bytes [built] [code generated]
 chunk (runtime: main) a.js (a) 134 bytes [rendered]
   ./node_modules/a/2.png 49 bytes [dependent] [built] [code generated] [1 asset]
   ./node_modules/a/index.js + 1 modules 85 bytes [built] [code generated] [1 asset]
-runtime modules 6.16 KiB 8 modules
+runtime modules 6.19 KiB 8 modules
 orphan modules 49 bytes [orphan] 1 module
 modules with assets 234 bytes
   modules by path ./node_modules/a/ 134 bytes
@@ -1199,8 +1199,8 @@ asset 593.js 518 bytes [emitted]
 asset 716.js 518 bytes [emitted]
 chunk (runtime: e1) 114.js 61 bytes [rendered]
   ./async1.js 61 bytes [built] [code generated]
-chunk (runtime: e3) e3.js (e3) 249 bytes (javascript) 6.44 KiB (runtime) [entry] [rendered]
-  runtime modules 6.44 KiB 9 modules
+chunk (runtime: e3) e3.js (e3) 249 bytes (javascript) 6.47 KiB (runtime) [entry] [rendered]
+  runtime modules 6.47 KiB 9 modules
   cacheable modules 249 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e3.js + 2 modules 209 bytes [built] [code generated]
@@ -1208,8 +1208,8 @@ chunk (runtime: e3) e3.js (e3) 249 bytes (javascript) 6.44 KiB (runtime) [entry]
 chunk (runtime: e1, e3) 172.js 81 bytes [rendered]
   ./async2.js 61 bytes [built] [code generated]
   ./f.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e1) e1.js (e1) 249 bytes (javascript) 6.44 KiB (runtime) [entry] [rendered]
-  runtime modules 6.44 KiB 9 modules
+chunk (runtime: e1) e1.js (e1) 249 bytes (javascript) 6.47 KiB (runtime) [entry] [rendered]
+  runtime modules 6.47 KiB 9 modules
   cacheable modules 249 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./d.js 20 bytes [dependent] [built] [code generated]
@@ -1219,8 +1219,8 @@ chunk (runtime: e1, e2) 326.js 81 bytes [rendered]
   ./h.js 20 bytes [dependent] [built] [code generated]
 chunk (runtime: e3) 593.js 61 bytes [rendered]
   ./async3.js 61 bytes [built] [code generated]
-chunk (runtime: e2) e2.js (e2) 249 bytes (javascript) 6.44 KiB (runtime) [entry] [rendered]
-  runtime modules 6.44 KiB 9 modules
+chunk (runtime: e2) e2.js (e2) 249 bytes (javascript) 6.47 KiB (runtime) [entry] [rendered]
+  runtime modules 6.47 KiB 9 modules
   cacheable modules 249 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e2.js + 2 modules 209 bytes [built] [code generated]
@@ -1240,14 +1240,14 @@ asset e3.js 11.8 KiB [emitted] (name: e3)
 asset async1.js 970 bytes [emitted] (name: async1)
 asset async2.js 970 bytes [emitted] (name: async2)
 asset async3.js 970 bytes [emitted] (name: async3)
-chunk (runtime: e3) e3.js (e3) 242 bytes (javascript) 6.49 KiB (runtime) [entry] [rendered]
-  runtime modules 6.49 KiB 9 modules
+chunk (runtime: e3) e3.js (e3) 242 bytes (javascript) 6.52 KiB (runtime) [entry] [rendered]
+  runtime modules 6.52 KiB 9 modules
   cacheable modules 242 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e3.js + 2 modules 202 bytes [built] [code generated]
     ./h.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e1) e1.js (e1) 242 bytes (javascript) 6.49 KiB (runtime) [entry] [rendered]
-  runtime modules 6.49 KiB 9 modules
+chunk (runtime: e1) e1.js (e1) 242 bytes (javascript) 6.52 KiB (runtime) [entry] [rendered]
+  runtime modules 6.52 KiB 9 modules
   cacheable modules 242 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./d.js 20 bytes [dependent] [built] [code generated]
@@ -1258,8 +1258,8 @@ chunk (runtime: e1, e2, e3) async1.js (async1) 135 bytes [rendered]
 chunk (runtime: e1, e2, e3) async3.js (async3) 135 bytes [rendered]
   ./async3.js 115 bytes [built] [code generated]
   ./h.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e2) e2.js (e2) 242 bytes (javascript) 6.49 KiB (runtime) [entry] [rendered]
-  runtime modules 6.49 KiB 9 modules
+chunk (runtime: e2) e2.js (e2) 242 bytes (javascript) 6.52 KiB (runtime) [entry] [rendered]
+  runtime modules 6.52 KiB 9 modules
   cacheable modules 242 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e2.js + 2 modules 202 bytes [built] [code generated]
@@ -1367,9 +1367,9 @@ chunk (runtime: main) a-52.js 149 bytes [rendered] split chunk (cache group: def
   > ./a ./index.js 1:0-47
   > ./b ./index.js 2:0-47
   ./shared.js 149 bytes [built] [code generated]
-chunk (runtime: main) a-main.js (main) 146 bytes (javascript) 6.78 KiB (runtime) [entry] [rendered]
+chunk (runtime: main) a-main.js (main) 146 bytes (javascript) 6.81 KiB (runtime) [entry] [rendered]
   > ./ main
-  runtime modules 6.78 KiB 10 modules
+  runtime modules 6.81 KiB 10 modules
   ./index.js 146 bytes [built] [code generated]
 chunk (runtime: main) a-vendors.js (vendors) (id hint: vendors) 40 bytes [rendered] split chunk (cache group: vendors) (name: vendors)
   > ./c ./index.js 3:0-47
@@ -1394,9 +1394,9 @@ chunk (runtime: main) b-52.js 149 bytes [rendered] split chunk (cache group: def
   > ./a ./index.js 1:0-47
   > ./b ./index.js 2:0-47
   ./shared.js 149 bytes [built] [code generated]
-chunk (runtime: main) b-main.js (main) 146 bytes (javascript) 6.78 KiB (runtime) [entry] [rendered]
+chunk (runtime: main) b-main.js (main) 146 bytes (javascript) 6.81 KiB (runtime) [entry] [rendered]
   > ./ main
-  runtime modules 6.78 KiB 10 modules
+  runtime modules 6.81 KiB 10 modules
   ./index.js 146 bytes [built] [code generated]
 chunk (runtime: main) b-vendors.js (vendors) (id hint: vendors) 40 bytes [rendered] split chunk (cache group: vendors) (name: vendors)
   > ./c ./index.js 3:0-47
@@ -1415,10 +1415,10 @@ webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for named-chunks-plugin 1`] = `
-"asset entry.js 5.42 KiB [emitted] (name: entry)
+"asset entry.js 5.55 KiB [emitted] (name: entry)
 asset vendor.js 237 bytes [emitted] (name: vendor) (id hint: vendor)
-Entrypoint entry 5.65 KiB = vendor.js 237 bytes entry.js 5.42 KiB
-runtime modules 2.6 KiB 2 modules
+Entrypoint entry 5.78 KiB = vendor.js 237 bytes entry.js 5.55 KiB
+runtime modules 2.71 KiB 2 modules
 cacheable modules 138 bytes
   ./entry.js 72 bytes [built] [code generated]
   ./modules/a.js 22 bytes [built] [code generated]
@@ -1431,7 +1431,7 @@ exports[`StatsTestCases should print correct stats for named-chunks-plugin-async
 "asset entry.js 12.3 KiB [emitted] (name: entry)
 asset modules_a_js.js 313 bytes [emitted]
 asset modules_b_js.js 149 bytes [emitted]
-runtime modules 7.55 KiB 10 modules
+runtime modules 7.58 KiB 10 modules
 cacheable modules 106 bytes
   ./entry.js 47 bytes [built] [code generated]
   ./modules/a.js 37 bytes [built] [code generated]
@@ -1464,9 +1464,9 @@ chunk {90} (runtime: main) ab.js (ab) 2 bytes <{179}> >{753}< [rendered]
   > [10] ./index.js 1:0-6:8
   ./modules/a.js [839] 1 bytes {90} {374} [built] [code generated]
   ./modules/b.js [836] 1 bytes {90} {374} [built] [code generated]
-chunk {179} (runtime: main) main.js (main) 524 bytes (javascript) 5.97 KiB (runtime) >{90}< >{289}< >{374}< >{592}< [entry] [rendered]
+chunk {179} (runtime: main) main.js (main) 524 bytes (javascript) 6.01 KiB (runtime) >{90}< >{289}< >{374}< >{592}< [entry] [rendered]
   > ./index main
-  runtime modules 5.97 KiB 7 modules
+  runtime modules 6.01 KiB 7 modules
   cacheable modules 524 bytes
     ./index.js [10] 523 bytes {179} [built] [code generated]
     ./modules/f.js [544] 1 bytes {179} [dependent] [built] [code generated]
@@ -1498,9 +1498,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for output-module 1`] = `
-"asset main.js 9.88 KiB [emitted] [javascript module] (name: main)
+"asset main.js 9.91 KiB [emitted] [javascript module] (name: main)
 asset 52.js 415 bytes [emitted] [javascript module]
-runtime modules 5.94 KiB 8 modules
+runtime modules 5.97 KiB 8 modules
 orphan modules 38 bytes [orphan] 1 module
 cacheable modules 263 bytes
   ./index.js + 1 modules 225 bytes [built] [code generated]
@@ -1609,7 +1609,7 @@ asset <CLR=32,BOLD>460.js</CLR> 320 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
-runtime modules 5.87 KiB 7 modules
+runtime modules 5.9 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -1626,7 +1626,7 @@ asset <CLR=32,BOLD>460.js</CLR> 320 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
-runtime modules 5.87 KiB 7 modules
+runtime modules 5.9 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -1685,7 +1685,7 @@ asset <CLR=32,BOLD>460.js</CLR> 320 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
-runtime modules 5.87 KiB 7 modules
+runtime modules 5.9 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -1737,7 +1737,7 @@ asset normal.js 109 bytes {30} [emitted] (name: normal)
 Entrypoint main 15.7 KiB = main.js
   prefetch: prefetched2.js {379} (name: prefetched2), prefetched.js {505} (name: prefetched), prefetched3.js {220} (name: prefetched3)
 chunk {30} (runtime: main) normal.js (normal) 1 bytes <{179}> [rendered]
-chunk {179} (runtime: main) main.js (main) 436 bytes (javascript) 8.97 KiB (runtime) >{30}< >{220}< >{379}< >{505}< (prefetch: {379} {505} {220}) [entry] [rendered]
+chunk {179} (runtime: main) main.js (main) 436 bytes (javascript) 9 KiB (runtime) >{30}< >{220}< >{379}< >{505}< (prefetch: {379} {505} {220}) [entry] [rendered]
 chunk {220} (runtime: main) prefetched3.js (prefetched3) 1 bytes <{179}> [rendered]
 chunk {379} (runtime: main) prefetched2.js (prefetched2) 1 bytes <{179}> [rendered]
 chunk {505} (runtime: main) prefetched.js (prefetched) 228 bytes <{179}> >{641}< >{746}< (prefetch: {641} {746}) [rendered]
@@ -1752,7 +1752,7 @@ chunk (runtime: main) c1.js (c1) 1 bytes <{459}> [rendered]
 chunk (runtime: main) b.js (b) 203 bytes <{179}> >{132}< >{751}< >{978}< (prefetch: {751} {132}) (preload: {978}) [rendered]
 chunk (runtime: main) b3.js (b3) 1 bytes <{128}> [rendered]
 chunk (runtime: main) a2.js (a2) 1 bytes <{786}> [rendered]
-chunk (runtime: main) main.js (main) 195 bytes (javascript) 9.64 KiB (runtime) >{128}< >{459}< >{786}< (prefetch: {786} {128} {459}) [entry] [rendered]
+chunk (runtime: main) main.js (main) 195 bytes (javascript) 9.67 KiB (runtime) >{128}< >{459}< >{786}< (prefetch: {786} {128} {459}) [entry] [rendered]
 chunk (runtime: main) c.js (c) 134 bytes <{179}> >{3}< >{76}< (preload: {76} {3}) [rendered]
 chunk (runtime: main) b1.js (b1) 1 bytes <{128}> [rendered]
 chunk (runtime: main) a.js (a) 136 bytes <{179}> >{74}< >{178}< (prefetch: {74} {178}) [rendered]
@@ -1770,7 +1770,7 @@ asset preloaded3.js 108 bytes [emitted] (name: preloaded3)
 Entrypoint main 15 KiB = main.js
   preload: preloaded2.js (name: preloaded2), preloaded.js (name: preloaded), preloaded3.js (name: preloaded3)
 chunk (runtime: main) normal.js (normal) 1 bytes [rendered]
-chunk (runtime: main) main.js (main) 424 bytes (javascript) 8.78 KiB (runtime) (preload: {363} {851} {355}) [entry] [rendered]
+chunk (runtime: main) main.js (main) 424 bytes (javascript) 8.82 KiB (runtime) (preload: {363} {851} {355}) [entry] [rendered]
 chunk (runtime: main) preloaded3.js (preloaded3) 1 bytes [rendered]
 chunk (runtime: main) preloaded2.js (preloaded2) 1 bytes [rendered]
 chunk (runtime: main) inner2.js (inner2) 2 bytes [rendered]
@@ -1788,12 +1788,12 @@ exports[`StatsTestCases should print correct stats for preset-detailed 1`] = `
       [LogTestPlugin] Log
     [LogTestPlugin] End
 PublicPath: auto
-asset main.js 9.97 KiB {179} [emitted] (name: main)
+asset main.js 10 KiB {179} [emitted] (name: main)
 asset 460.js 320 bytes {460} [emitted]
 asset 524.js 206 bytes {524} [emitted]
 asset 996.js 138 bytes {996} [emitted]
-Entrypoint main 9.97 KiB = main.js
-chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 5.87 KiB (runtime) >{460}< >{996}< [entry] [rendered]
+Entrypoint main 10 KiB = main.js
+chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 5.9 KiB (runtime) >{460}< >{996}< [entry] [rendered]
   > ./index main
 chunk {460} (runtime: main) 460.js 54 bytes <{179}> >{524}< [rendered]
   > ./c [10] ./index.js 3:0-16
@@ -1801,7 +1801,7 @@ chunk {524} (runtime: main) 524.js 44 bytes <{460}> [rendered]
   > [460] ./c.js 1:0-52
 chunk {996} (runtime: main) 996.js 22 bytes <{179}> [rendered]
   > ./b [10] ./index.js 2:0-16
-runtime modules 5.87 KiB
+runtime modules 5.9 KiB
   webpack/runtime/ensure chunk 326 bytes {179} [code generated]
     [no exports]
     [used exports unknown]
@@ -1814,7 +1814,7 @@ runtime modules 5.87 KiB
   webpack/runtime/hasOwnProperty shorthand 86 bytes {179} [code generated]
     [no exports]
     [used exports unknown]
-  webpack/runtime/jsonp chunk loading 2.89 KiB {179} [code generated]
+  webpack/runtime/jsonp chunk loading 2.92 KiB {179} [code generated]
     [no exports]
     [used exports unknown]
   webpack/runtime/load script 1.36 KiB {179} [code generated]
@@ -1890,7 +1890,7 @@ LOG from webpack.FileSystemInfo
     Directory info in cache: 0 timestamps 0 hashes 0 timestamp hash combinations
     Managed items info in cache: 0 items
 
-1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (b8c292e4f17de2a0559d)"
+1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (06e9b525908b24d12b22)"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-errors-only 1`] = `""`;
@@ -1964,11 +1964,11 @@ exports[`StatsTestCases should print correct stats for preset-normal 1`] = `
 "<e> [LogTestPlugin] Error
 <w> [LogTestPlugin] Warning
 <i> [LogTestPlugin] Info
-asset main.js 9.97 KiB [emitted] (name: main)
+asset main.js 10 KiB [emitted] (name: main)
 asset 460.js 320 bytes [emitted]
 asset 524.js 206 bytes [emitted]
 asset 996.js 138 bytes [emitted]
-runtime modules 5.87 KiB 7 modules
+runtime modules 5.9 KiB 7 modules
 cacheable modules 193 bytes
   ./index.js 51 bytes [built] [code generated]
   ./a.js 22 bytes [built] [code generated]
@@ -1991,7 +1991,7 @@ exports[`StatsTestCases should print correct stats for preset-normal-performance
 asset <CLR=32,BOLD>460.js</CLR> 320 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
-runtime modules 5.87 KiB 7 modules
+runtime modules 5.9 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2019,7 +2019,7 @@ exports[`StatsTestCases should print correct stats for preset-normal-performance
 asset <CLR=32,BOLD>460.js</CLR> 352 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
 asset <CLR=32,BOLD>524.js</CLR> 238 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
 asset <CLR=32,BOLD>996.js</CLR> 170 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
-runtime modules 5.87 KiB 7 modules
+runtime modules 5.9 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2062,14 +2062,14 @@ exports[`StatsTestCases should print correct stats for preset-verbose 1`] = `
       [LogTestPlugin] Log
     [LogTestPlugin] End
 PublicPath: auto
-asset main.js 9.97 KiB {179} [emitted] (name: main)
+asset main.js 10 KiB {179} [emitted] (name: main)
 asset 460.js 320 bytes {460} [emitted]
 asset 524.js 206 bytes {524} [emitted]
 asset 996.js 138 bytes {996} [emitted]
-Entrypoint main 9.97 KiB = main.js
-chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 5.87 KiB (runtime) >{460}< >{996}< [entry] [rendered]
+Entrypoint main 10 KiB = main.js
+chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 5.9 KiB (runtime) >{460}< >{996}< [entry] [rendered]
   > ./index main
-  runtime modules 5.87 KiB 7 modules
+  runtime modules 5.9 KiB 7 modules
   cacheable modules 73 bytes
     ./a.js [847] 22 bytes {179} [depth 1] [dependent] [built] [code generated]
       [used exports unknown]
@@ -2235,19 +2235,19 @@ LOG from webpack.FileSystemInfo
     Directory info in cache: 0 timestamps 0 hashes 0 timestamp hash combinations
     Managed items info in cache: 0 items
 
-1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (b8c292e4f17de2a0559d)"
+1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (06e9b525908b24d12b22)"
 `;
 
 exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
 "a-normal:
-  assets by path *.js 2.99 KiB
-    asset 92a0a394f8459d57eed5-92a0a3.js 2.6 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+  assets by path *.js 3 KiB
+    asset d334fee2a36188e0a09c-d334fe.js 2.61 KiB [emitted] [immutable] [minimized] (name: runtime~main)
     asset 3cc8faad16137711c07e-3cc8fa.js 210 bytes [emitted] [immutable] [minimized] (name: main)
     asset b6f77787a670e97d47b5-b6f777.js 193 bytes [emitted] [immutable] [minimized] (name: lazy)
   asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: main)
-  Entrypoint main 2.8 KiB (5.89 KiB) = 92a0a394f8459d57eed5-92a0a3.js 2.6 KiB 3cc8faad16137711c07e-3cc8fa.js 210 bytes 1 auxiliary asset
-  runtime modules 7.36 KiB 8 modules
+  Entrypoint main 2.81 KiB (5.89 KiB) = d334fee2a36188e0a09c-d334fe.js 2.61 KiB 3cc8faad16137711c07e-3cc8fa.js 210 bytes 1 auxiliary asset
+  runtime modules 7.47 KiB 8 modules
   orphan modules 23 bytes [orphan] 1 module
   cacheable modules 340 bytes (javascript) 20.4 KiB (asset)
     javascript modules 256 bytes
@@ -2259,14 +2259,14 @@ exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
   a-normal (webpack x.x.x) compiled successfully in X ms
 
 b-normal:
-  assets by path *.js 2.99 KiB
-    asset 92a0a394f8459d57eed5-92a0a3.js 2.6 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+  assets by path *.js 3 KiB
+    asset d334fee2a36188e0a09c-d334fe.js 2.61 KiB [emitted] [immutable] [minimized] (name: runtime~main)
     asset 3cc8faad16137711c07e-3cc8fa.js 210 bytes [emitted] [immutable] [minimized] (name: main)
     asset b6f77787a670e97d47b5-b6f777.js 193 bytes [emitted] [immutable] [minimized] (name: lazy)
   asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: main)
-  Entrypoint main 2.8 KiB (5.89 KiB) = 92a0a394f8459d57eed5-92a0a3.js 2.6 KiB 3cc8faad16137711c07e-3cc8fa.js 210 bytes 1 auxiliary asset
-  runtime modules 7.36 KiB 8 modules
+  Entrypoint main 2.81 KiB (5.89 KiB) = d334fee2a36188e0a09c-d334fe.js 2.61 KiB 3cc8faad16137711c07e-3cc8fa.js 210 bytes 1 auxiliary asset
+  runtime modules 7.47 KiB 8 modules
   orphan modules 19 bytes [orphan] 1 module
   cacheable modules 295 bytes (javascript) 20.4 KiB (asset)
     javascript modules 211 bytes
@@ -2278,17 +2278,17 @@ b-normal:
   b-normal (webpack x.x.x) compiled successfully in X ms
 
 a-source-map:
-  assets by path *.js 3.16 KiB
-    asset 6d482476dfc44d9f4352-6d4824.js 2.65 KiB [emitted] [immutable] [minimized] (name: runtime~main)
-      sourceMap 6d482476dfc44d9f4352-6d4824.js.map 14.3 KiB [emitted] [dev] (auxiliary name: runtime~main)
+  assets by path *.js 3.17 KiB
+    asset 05313e28d7795f776fc1-05313e.js 2.66 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+      sourceMap 05313e28d7795f776fc1-05313e.js.map 14.5 KiB [emitted] [dev] (auxiliary name: runtime~main)
     asset b8bfcec62cdd15c9a840-b8bfce.js 266 bytes [emitted] [immutable] [minimized] (name: main)
       sourceMap b8bfcec62cdd15c9a840-b8bfce.js.map 366 bytes [emitted] [dev] (auxiliary name: main)
     asset c7c0f8bb2e61b59a89f5-c7c0f8.js 249 bytes [emitted] [immutable] [minimized] (name: lazy)
       sourceMap c7c0f8bb2e61b59a89f5-c7c0f8.js.map 331 bytes [emitted] [dev] (auxiliary name: lazy)
   asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: main)
-  Entrypoint main 2.91 KiB (20.5 KiB) = 6d482476dfc44d9f4352-6d4824.js 2.65 KiB b8bfcec62cdd15c9a840-b8bfce.js 266 bytes 3 auxiliary assets
-  runtime modules 7.36 KiB 8 modules
+  Entrypoint main 2.92 KiB (20.7 KiB) = 05313e28d7795f776fc1-05313e.js 2.66 KiB b8bfcec62cdd15c9a840-b8bfce.js 266 bytes 3 auxiliary assets
+  runtime modules 7.47 KiB 8 modules
   orphan modules 23 bytes [orphan] 1 module
   cacheable modules 340 bytes (javascript) 20.4 KiB (asset)
     javascript modules 256 bytes
@@ -2300,17 +2300,17 @@ a-source-map:
   a-source-map (webpack x.x.x) compiled successfully in X ms
 
 b-source-map:
-  assets by path *.js 3.16 KiB
-    asset 34a1f137ab6013192ef7-34a1f1.js 2.65 KiB [emitted] [immutable] [minimized] (name: runtime~main)
-      sourceMap 34a1f137ab6013192ef7-34a1f1.js.map 14.3 KiB [emitted] [dev] (auxiliary name: runtime~main)
+  assets by path *.js 3.17 KiB
+    asset 06b6acb94efe9f618ff4-06b6ac.js 2.66 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+      sourceMap 06b6acb94efe9f618ff4-06b6ac.js.map 14.5 KiB [emitted] [dev] (auxiliary name: runtime~main)
     asset b8bfcec62cdd15c9a840-b8bfce.js 266 bytes [emitted] [immutable] [minimized] (name: main)
       sourceMap b8bfcec62cdd15c9a840-b8bfce.js.map 323 bytes [emitted] [dev] (auxiliary name: main)
     asset c7c0f8bb2e61b59a89f5-c7c0f8.js 249 bytes [emitted] [immutable] [minimized] (name: lazy)
       sourceMap c7c0f8bb2e61b59a89f5-c7c0f8.js.map 327 bytes [emitted] [dev] (auxiliary name: lazy)
   asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: main)
-  Entrypoint main 2.91 KiB (20.5 KiB) = 34a1f137ab6013192ef7-34a1f1.js 2.65 KiB b8bfcec62cdd15c9a840-b8bfce.js 266 bytes 3 auxiliary assets
-  runtime modules 7.36 KiB 8 modules
+  Entrypoint main 2.92 KiB (20.7 KiB) = 06b6acb94efe9f618ff4-06b6ac.js 2.66 KiB b8bfcec62cdd15c9a840-b8bfce.js 266 bytes 3 auxiliary assets
+  runtime modules 7.47 KiB 8 modules
   orphan modules 19 bytes [orphan] 1 module
   cacheable modules 295 bytes (javascript) 20.4 KiB (asset)
     javascript modules 211 bytes
@@ -2325,17 +2325,17 @@ b-source-map:
 exports[`StatsTestCases should print correct stats for related-assets 1`] = `
 "default:
   assets by path *.js 15.1 KiB
-    asset default-main.js 14.3 KiB [emitted] (name: main) 3 related assets
+    asset default-main.js 14.4 KiB [emitted] (name: main) 3 related assets
     asset default-chunk_js.js 815 bytes [emitted] 3 related assets
   assets by path *.css 142 bytes
     asset default-chunk_js.css 73 bytes [emitted] 3 related assets
     asset default-main.css 69 bytes [emitted] (name: main) 3 related assets
 
 relatedAssets:
-  assets by path *.js 15.1 KiB
-    asset relatedAssets-main.js 14.3 KiB [emitted] (name: main)
-      compressed relatedAssets-main.js.br 14.3 KiB [emitted]
-      compressed relatedAssets-main.js.gz 14.3 KiB [emitted]
+  assets by path *.js 15.2 KiB
+    asset relatedAssets-main.js 14.4 KiB [emitted] (name: main)
+      compressed relatedAssets-main.js.br 14.4 KiB [emitted]
+      compressed relatedAssets-main.js.gz 14.4 KiB [emitted]
       sourceMap relatedAssets-main.js.map 12.5 KiB [emitted] [dev] (auxiliary name: main)
         compressed relatedAssets-main.js.map.br 12.5 KiB [emitted]
         compressed relatedAssets-main.js.map.gz 12.5 KiB [emitted]
@@ -2360,10 +2360,10 @@ relatedAssets:
       compressed relatedAssets-main.css.gz 75 bytes [emitted]
 
 exclude1:
-  assets by path *.js 15.1 KiB
-    asset exclude1-main.js 14.3 KiB [emitted] (name: main)
-      hidden assets 28.6 KiB 2 assets
-      sourceMap exclude1-main.js.map 12.4 KiB [emitted] [dev] (auxiliary name: main)
+  assets by path *.js 15.2 KiB
+    asset exclude1-main.js 14.4 KiB [emitted] (name: main)
+      hidden assets 28.7 KiB 2 assets
+      sourceMap exclude1-main.js.map 12.5 KiB [emitted] [dev] (auxiliary name: main)
         hidden assets 24.9 KiB 2 assets
         1 related asset
       1 related asset
@@ -2388,11 +2388,11 @@ exclude1:
       1 related asset
 
 exclude2:
-  assets by path *.js 15.1 KiB
-    asset exclude2-main.js 14.3 KiB [emitted] (name: main)
-      hidden assets 12.4 KiB 1 asset
-      compressed exclude2-main.js.br 14.3 KiB [emitted]
-      compressed exclude2-main.js.gz 14.3 KiB [emitted]
+  assets by path *.js 15.2 KiB
+    asset exclude2-main.js 14.4 KiB [emitted] (name: main)
+      hidden assets 12.5 KiB 1 asset
+      compressed exclude2-main.js.br 14.4 KiB [emitted]
+      compressed exclude2-main.js.gz 14.4 KiB [emitted]
     asset exclude2-chunk_js.js 816 bytes [emitted]
       hidden assets 296 bytes 1 asset
       compressed exclude2-chunk_js.js.br 816 bytes [emitted]
@@ -2410,12 +2410,12 @@ exclude2:
 exclude3:
   hidden assets 890 bytes 2 assets
   assets by status 14.4 KiB [emitted]
-    asset exclude3-main.js 14.3 KiB [emitted] (name: main)
-      compressed exclude3-main.js.br 14.3 KiB [emitted]
-      compressed exclude3-main.js.gz 14.3 KiB [emitted]
-      sourceMap exclude3-main.js.map 12.4 KiB [emitted] [dev] (auxiliary name: main)
-        compressed exclude3-main.js.map.br 12.4 KiB [emitted]
-        compressed exclude3-main.js.map.gz 12.4 KiB [emitted]
+    asset exclude3-main.js 14.4 KiB [emitted] (name: main)
+      compressed exclude3-main.js.br 14.4 KiB [emitted]
+      compressed exclude3-main.js.gz 14.4 KiB [emitted]
+      sourceMap exclude3-main.js.map 12.5 KiB [emitted] [dev] (auxiliary name: main)
+        compressed exclude3-main.js.map.br 12.5 KiB [emitted]
+        compressed exclude3-main.js.map.gz 12.5 KiB [emitted]
     asset exclude3-main.css 70 bytes [emitted] (name: main)
       sourceMap exclude3-main.css.map 182 bytes [emitted] [dev] (auxiliary name: main)
         compressed exclude3-main.css.map.br 182 bytes [emitted]
@@ -2472,18 +2472,18 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for runtime-chunk 1`] = `
-"Entrypoint e1 6.49 KiB = runtime~e1.js 5.66 KiB e1.js 857 bytes
-Entrypoint e2 6.49 KiB = runtime~e2.js 5.66 KiB e2.js 857 bytes
+"Entrypoint e1 6.63 KiB = runtime~e1.js 5.79 KiB e1.js 857 bytes
+Entrypoint e2 6.63 KiB = runtime~e2.js 5.79 KiB e2.js 857 bytes
 webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for runtime-chunk-integration 1`] = `
 "base:
-  asset without-runtime.js 12.3 KiB [emitted] (name: runtime)
+  asset without-runtime.js 12.4 KiB [emitted] (name: runtime)
   asset without-505.js 1.22 KiB [emitted]
   asset without-main1.js 596 bytes [emitted] (name: main1)
-  Entrypoint main1 12.8 KiB = without-runtime.js 12.3 KiB without-main1.js 596 bytes
-  runtime modules 7.63 KiB 9 modules
+  Entrypoint main1 13 KiB = without-runtime.js 12.4 KiB without-main1.js 596 bytes
+  runtime modules 7.75 KiB 9 modules
   cacheable modules 126 bytes
     ./main1.js 66 bytes [built] [code generated]
     ./b.js 20 bytes [built] [code generated]
@@ -2492,15 +2492,15 @@ exports[`StatsTestCases should print correct stats for runtime-chunk-integration
   base (webpack x.x.x) compiled successfully
 
 static custom name:
-  asset with-manifest.js 12.3 KiB [emitted] (name: manifest)
+  asset with-manifest.js 12.4 KiB [emitted] (name: manifest)
   asset with-505.js 1.22 KiB [emitted]
   asset with-main1.js 596 bytes [emitted] (name: main1)
   asset with-main2.js 215 bytes [emitted] (name: main2)
   asset with-main3.js 215 bytes [emitted] (name: main3)
-  Entrypoint main1 12.8 KiB = with-manifest.js 12.3 KiB with-main1.js 596 bytes
-  Entrypoint main2 12.5 KiB = with-manifest.js 12.3 KiB with-main2.js 215 bytes
-  Entrypoint main3 12.5 KiB = with-manifest.js 12.3 KiB with-main3.js 215 bytes
-  runtime modules 7.63 KiB 9 modules
+  Entrypoint main1 13 KiB = with-manifest.js 12.4 KiB with-main1.js 596 bytes
+  Entrypoint main2 12.6 KiB = with-manifest.js 12.4 KiB with-main2.js 215 bytes
+  Entrypoint main3 12.6 KiB = with-manifest.js 12.4 KiB with-main3.js 215 bytes
+  runtime modules 7.74 KiB 9 modules
   cacheable modules 166 bytes
     ./main1.js 66 bytes [built] [code generated]
     ./main2.js 20 bytes [built] [code generated]
@@ -2511,16 +2511,16 @@ static custom name:
   static custom name (webpack x.x.x) compiled successfully
 
 dynamic custom name:
-  asset func-b.js 12.3 KiB [emitted] (name: b)
-  asset func-a.js 5.09 KiB [emitted] (name: a)
+  asset func-b.js 12.4 KiB [emitted] (name: b)
+  asset func-a.js 5.23 KiB [emitted] (name: a)
   asset func-505.js 1.22 KiB [emitted]
   asset func-main1.js 596 bytes [emitted] (name: main1)
   asset func-main2.js 215 bytes [emitted] (name: main2)
   asset func-main3.js 215 bytes [emitted] (name: main3)
-  Entrypoint main1 12.8 KiB = func-b.js 12.3 KiB func-main1.js 596 bytes
-  Entrypoint main2 12.5 KiB = func-b.js 12.3 KiB func-main2.js 215 bytes
-  Entrypoint main3 5.3 KiB = func-a.js 5.09 KiB func-main3.js 215 bytes
-  runtime modules 10.2 KiB 11 modules
+  Entrypoint main1 13 KiB = func-b.js 12.4 KiB func-main1.js 596 bytes
+  Entrypoint main2 12.6 KiB = func-b.js 12.4 KiB func-main2.js 215 bytes
+  Entrypoint main3 5.44 KiB = func-a.js 5.23 KiB func-main3.js 215 bytes
+  runtime modules 10.4 KiB 11 modules
   cacheable modules 166 bytes
     ./main1.js 66 bytes [built] [code generated]
     ./main2.js 20 bytes [built] [code generated]
@@ -2532,29 +2532,29 @@ dynamic custom name:
 `;
 
 exports[`StatsTestCases should print correct stats for runtime-chunk-issue-7382 1`] = `
-"Entrypoint e1 7.3 KiB = runtime.js 5.65 KiB all.js 1020 bytes e1.js 670 bytes
-Entrypoint e2 7.3 KiB = runtime.js 5.65 KiB all.js 1020 bytes e2.js 670 bytes
+"Entrypoint e1 7.44 KiB = runtime.js 5.79 KiB all.js 1020 bytes e1.js 670 bytes
+Entrypoint e2 7.44 KiB = runtime.js 5.79 KiB all.js 1020 bytes e2.js 670 bytes
 webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for runtime-chunk-single 1`] = `
-"Entrypoint e1 6.49 KiB = runtime.js 5.65 KiB e1.js 854 bytes
-Entrypoint e2 6.49 KiB = runtime.js 5.65 KiB e2.js 854 bytes
+"Entrypoint e1 6.62 KiB = runtime.js 5.79 KiB e1.js 854 bytes
+Entrypoint e2 6.62 KiB = runtime.js 5.79 KiB e2.js 854 bytes
 webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for runtime-specific-used-exports 1`] = `
 "production:
-  asset production-a.js 12.8 KiB [emitted] (name: a)
-  asset production-b.js 12.8 KiB [emitted] (name: b)
+  asset production-a.js 12.9 KiB [emitted] (name: a)
+  asset production-b.js 12.9 KiB [emitted] (name: b)
   asset production-dw_js-_a6170.js 1.16 KiB [emitted]
   asset production-dw_js-_a6171.js 1.16 KiB [emitted]
   asset production-dx_js.js 1.16 KiB [emitted]
   asset production-dy_js.js 1.14 KiB [emitted]
   asset production-dz_js.js 1.14 KiB [emitted]
   asset production-c.js 63 bytes [emitted] (name: c)
-  chunk (runtime: a) production-a.js (a) 605 bytes (javascript) 6.45 KiB (runtime) [entry] [rendered]
-    runtime modules 6.45 KiB 9 modules
+  chunk (runtime: a) production-a.js (a) 605 bytes (javascript) 6.48 KiB (runtime) [entry] [rendered]
+    runtime modules 6.48 KiB 9 modules
     cacheable modules 605 bytes
       ./a.js 261 bytes [built] [code generated]
         [no exports used]
@@ -2566,8 +2566,8 @@ exports[`StatsTestCases should print correct stats for runtime-specific-used-exp
         [only some exports used: x]
       ./reexport.js 37 bytes [dependent] [built] [code generated]
         [only some exports used: x]
-  chunk (runtime: b) production-b.js (b) 605 bytes (javascript) 6.45 KiB (runtime) [entry] [rendered]
-    runtime modules 6.45 KiB 9 modules
+  chunk (runtime: b) production-b.js (b) 605 bytes (javascript) 6.48 KiB (runtime) [entry] [rendered]
+    runtime modules 6.48 KiB 9 modules
     cacheable modules 605 bytes
       ./b.js 261 bytes [built] [code generated]
         [no exports used]
@@ -2602,7 +2602,7 @@ exports[`StatsTestCases should print correct stats for runtime-specific-used-exp
     ./dz.js 46 bytes [built] [code generated]
     ./module.js?chunk 122 bytes [dependent] [built] [code generated]
       [only some exports used: identity, w, x, z]
-  runtime modules 12.9 KiB 18 modules
+  runtime modules 13 KiB 18 modules
   cacheable modules 1.15 KiB
     ./a.js 261 bytes [built] [code generated]
       [no exports used]
@@ -2627,15 +2627,15 @@ exports[`StatsTestCases should print correct stats for runtime-specific-used-exp
   production (webpack x.x.x) compiled successfully in X ms
 
 development:
-  asset development-a.js 15.6 KiB [emitted] (name: a)
-  asset development-b.js 15.6 KiB [emitted] (name: b)
+  asset development-a.js 15.7 KiB [emitted] (name: a)
+  asset development-b.js 15.7 KiB [emitted] (name: b)
   asset development-dw_js.js 2.12 KiB [emitted]
   asset development-dx_js.js 2.12 KiB [emitted]
   asset development-dy_js.js 2.12 KiB [emitted]
   asset development-dz_js.js 2.12 KiB [emitted]
   asset development-c.js 734 bytes [emitted] (name: c)
-  chunk (runtime: a) development-a.js (a) 605 bytes (javascript) 6.45 KiB (runtime) [entry] [rendered]
-    runtime modules 6.45 KiB 9 modules
+  chunk (runtime: a) development-a.js (a) 605 bytes (javascript) 6.48 KiB (runtime) [entry] [rendered]
+    runtime modules 6.48 KiB 9 modules
     cacheable modules 605 bytes
       ./a.js 261 bytes [built] [code generated]
         [used exports unknown]
@@ -2647,8 +2647,8 @@ development:
         [used exports unknown]
       ./reexport.js 37 bytes [dependent] [built] [code generated]
         [used exports unknown]
-  chunk (runtime: b) development-b.js (b) 605 bytes (javascript) 6.45 KiB (runtime) [entry] [rendered]
-    runtime modules 6.45 KiB 9 modules
+  chunk (runtime: b) development-b.js (b) 605 bytes (javascript) 6.48 KiB (runtime) [entry] [rendered]
+    runtime modules 6.48 KiB 9 modules
     cacheable modules 605 bytes
       ./b.js 261 bytes [built] [code generated]
         [used exports unknown]
@@ -2683,7 +2683,7 @@ development:
       [used exports unknown]
     ./module.js?chunk 122 bytes [dependent] [built] [code generated]
       [used exports unknown]
-  runtime modules 12.9 KiB 18 modules
+  runtime modules 13 KiB 18 modules
   cacheable modules 1.15 KiB
     ./a.js 261 bytes [built] [code generated]
       [used exports unknown]
@@ -2712,15 +2712,15 @@ development:
   development (webpack x.x.x) compiled successfully in X ms
 
 global:
-  asset global-a.js 13 KiB [emitted] (name: a)
-  asset global-b.js 13 KiB [emitted] (name: b)
+  asset global-a.js 13.1 KiB [emitted] (name: a)
+  asset global-b.js 13.1 KiB [emitted] (name: b)
   asset global-dw_js.js 1.16 KiB [emitted]
   asset global-dx_js.js 1.16 KiB [emitted]
   asset global-dy_js.js 1.16 KiB [emitted]
   asset global-dz_js.js 1.16 KiB [emitted]
   asset global-c.js 63 bytes [emitted] (name: c)
-  chunk (runtime: a) global-a.js (a) 605 bytes (javascript) 6.45 KiB (runtime) [entry] [rendered]
-    runtime modules 6.45 KiB 9 modules
+  chunk (runtime: a) global-a.js (a) 605 bytes (javascript) 6.48 KiB (runtime) [entry] [rendered]
+    runtime modules 6.48 KiB 9 modules
     cacheable modules 605 bytes
       ./a.js 261 bytes [built] [code generated]
         [no exports used]
@@ -2732,8 +2732,8 @@ global:
         [only some exports used: x, y]
       ./reexport.js 37 bytes [dependent] [built] [code generated]
         [only some exports used: x, y]
-  chunk (runtime: b) global-b.js (b) 605 bytes (javascript) 6.45 KiB (runtime) [entry] [rendered]
-    runtime modules 6.45 KiB 9 modules
+  chunk (runtime: b) global-b.js (b) 605 bytes (javascript) 6.48 KiB (runtime) [entry] [rendered]
+    runtime modules 6.48 KiB 9 modules
     cacheable modules 605 bytes
       ./b.js 261 bytes [built] [code generated]
         [no exports used]
@@ -2764,7 +2764,7 @@ global:
     ./dz.js 46 bytes [built] [code generated]
     ./module.js?chunk 122 bytes [dependent] [built] [code generated]
       [only some exports used: identity, w, x, y, z]
-  runtime modules 12.9 KiB 18 modules
+  runtime modules 13 KiB 18 modules
   cacheable modules 1.15 KiB
     ./a.js 261 bytes [built] [code generated]
       [no exports used]
@@ -2790,7 +2790,7 @@ global:
 `;
 
 exports[`StatsTestCases should print correct stats for scope-hoisting-bailouts 1`] = `
-"runtime modules 6.7 KiB 10 modules
+"runtime modules 6.73 KiB 10 modules
 built modules 615 bytes [built]
   code generated modules 530 bytes [code generated]
     modules by path ./*.js 377 bytes 7 modules
@@ -2806,9 +2806,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for scope-hoisting-multi 1`] = `
-"Entrypoint first 14.2 KiB = a-vendor.js 417 bytes a-first.js 13.8 KiB
-Entrypoint second 13.7 KiB = a-vendor.js 417 bytes a-second.js 13.3 KiB
-runtime modules 15.4 KiB 18 modules
+"Entrypoint first 14.4 KiB = a-vendor.js 417 bytes a-first.js 14 KiB
+Entrypoint second 13.9 KiB = a-vendor.js 417 bytes a-second.js 13.5 KiB
+runtime modules 15.6 KiB 18 modules
 orphan modules 37 bytes [orphan] 1 module
 cacheable modules 807 bytes
   ./first.js 236 bytes [built] [code generated]
@@ -2823,9 +2823,9 @@ cacheable modules 807 bytes
   ./common_lazy_shared.js 25 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-Entrypoint first 13.5 KiB = b-vendor.js 417 bytes b-first.js 13.1 KiB
-Entrypoint second 13.4 KiB = b-vendor.js 417 bytes b-second.js 13 KiB
-runtime modules 15.4 KiB 18 modules
+Entrypoint first 13.6 KiB = b-vendor.js 417 bytes b-first.js 13.2 KiB
+Entrypoint second 13.5 KiB = b-vendor.js 417 bytes b-second.js 13.1 KiB
+runtime modules 15.6 KiB 18 modules
 cacheable modules 975 bytes
   code generated modules 857 bytes [code generated]
     modules by path ./*.js + 1 modules 459 bytes 3 modules
@@ -2846,9 +2846,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for side-effects-issue-7428 1`] = `
-"asset main.js 12 KiB [emitted] (name: main)
+"asset main.js 12.1 KiB [emitted] (name: main)
 asset 1.js 638 bytes [emitted]
-runtime modules 6.44 KiB 9 modules
+runtime modules 6.47 KiB 9 modules
 cacheable modules 823 bytes
   modules by path ./components/src/ 501 bytes
     orphan modules 315 bytes [orphan]
@@ -3030,9 +3030,9 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
   chunk (runtime: a, main) default/async-g.js (async-g) 45 bytes <{282}> <{767}> <{786}> <{794}> <{954}> ={568}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.53 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
+  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.57 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
     > ./ main
-    runtime modules 6.53 KiB 9 modules
+    runtime modules 6.57 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) default/282.js (id hint: vendors) 20 bytes <{179}> ={334}= ={383}= ={568}= ={767}= ={769}= ={794}= ={954}= >{137}< >{568}< [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -3063,9 +3063,9 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
   chunk (runtime: main) default/769.js (id hint: vendors) 20 bytes <{179}> ={282}= ={383}= ={568}= ={767}= [rendered] split chunk (cache group: defaultVendors)
     > ./c ./index.js 3:0-47
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.52 KiB (runtime) >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.55 KiB (runtime) >{137}< >{568}< [entry] [rendered]
     > ./a a
-    runtime modules 6.52 KiB 9 modules
+    runtime modules 6.55 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) default/async-a.js (async-a) 185 bytes <{179}> ={282}= ={767}= ={954}= >{137}< >{568}< [rendered]
@@ -3078,20 +3078,20 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
   default (webpack x.x.x) compiled successfully
 
 all-chunks:
-  Entrypoint main 11.3 KiB = all-chunks/main.js
-  Entrypoint a 14.8 KiB = all-chunks/282.js 412 bytes all-chunks/954.js 412 bytes all-chunks/767.js 412 bytes all-chunks/390.js 412 bytes all-chunks/a.js 13.2 KiB
-  Entrypoint b 7.97 KiB = all-chunks/282.js 412 bytes all-chunks/954.js 412 bytes all-chunks/767.js 412 bytes all-chunks/568.js 412 bytes all-chunks/b.js 6.36 KiB
-  Entrypoint c 7.97 KiB = all-chunks/282.js 412 bytes all-chunks/769.js 412 bytes all-chunks/767.js 412 bytes all-chunks/568.js 412 bytes all-chunks/c.js 6.36 KiB
-  chunk (runtime: b) all-chunks/b.js (b) 116 bytes (javascript) 2.9 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
+  Entrypoint main 11.4 KiB = all-chunks/main.js
+  Entrypoint a 15 KiB = all-chunks/282.js 412 bytes all-chunks/954.js 412 bytes all-chunks/767.js 412 bytes all-chunks/390.js 412 bytes all-chunks/a.js 13.4 KiB
+  Entrypoint b 8.1 KiB = all-chunks/282.js 412 bytes all-chunks/954.js 412 bytes all-chunks/767.js 412 bytes all-chunks/568.js 412 bytes all-chunks/b.js 6.49 KiB
+  Entrypoint c 8.1 KiB = all-chunks/282.js 412 bytes all-chunks/769.js 412 bytes all-chunks/767.js 412 bytes all-chunks/568.js 412 bytes all-chunks/c.js 6.49 KiB
+  chunk (runtime: b) all-chunks/b.js (b) 116 bytes (javascript) 3.01 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
     > ./b b
-    runtime modules 2.9 KiB 3 modules
+    runtime modules 3.01 KiB 3 modules
     ./b.js 116 bytes [built] [code generated]
   chunk (runtime: a, main) all-chunks/async-g.js (async-g) 45 bytes <{282}> <{390}> <{767}> <{786}> <{794}> <{954}> ={568}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) all-chunks/main.js (main) 147 bytes (javascript) 6.54 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
+  chunk (runtime: main) all-chunks/main.js (main) 147 bytes (javascript) 6.57 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
     > ./ main
-    runtime modules 6.54 KiB 9 modules
+    runtime modules 6.57 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) all-chunks/282.js (id hint: vendors) 20 bytes <{179}> ={128}= ={334}= ={383}= ={390}= ={459}= ={568}= ={767}= ={769}= ={786}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -3111,9 +3111,9 @@ all-chunks:
     > ./a ./index.js 1:0-47
     > ./a a
     ./e.js 20 bytes [built] [code generated]
-  chunk (runtime: c) all-chunks/c.js (c) 116 bytes (javascript) 2.9 KiB (runtime) ={282}= ={568}= ={767}= ={769}= [entry] [rendered]
+  chunk (runtime: c) all-chunks/c.js (c) 116 bytes (javascript) 3.01 KiB (runtime) ={282}= ={568}= ={767}= ={769}= [entry] [rendered]
     > ./c c
-    runtime modules 2.9 KiB 3 modules
+    runtime modules 3.01 KiB 3 modules
     ./c.js 116 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) all-chunks/568.js 20 bytes <{179}> <{282}> <{390}> <{767}> <{786}> <{794}> <{954}> ={128}= ={137}= ={282}= ={334}= ={383}= ={459}= ={767}= ={769}= ={954}= [initial] [rendered] split chunk (cache group: default)
     > ./b ./index.js 2:0-47
@@ -3134,9 +3134,9 @@ all-chunks:
     > ./c ./index.js 3:0-47
     > ./c c
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) all-chunks/a.js (a) 165 bytes (javascript) 7.71 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: a) all-chunks/a.js (a) 165 bytes (javascript) 7.82 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
     > ./a a
-    runtime modules 7.71 KiB 9 modules
+    runtime modules 7.82 KiB 9 modules
     ./a.js 165 bytes [built] [code generated]
   chunk (runtime: main) all-chunks/async-a.js (async-a) 165 bytes <{179}> ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [rendered]
     > ./a ./index.js 1:0-47
@@ -3151,24 +3151,24 @@ all-chunks:
 
 manual:
   Entrypoint main 11.1 KiB = manual/main.js
-  Entrypoint a 14.4 KiB = manual/vendors.js 1.07 KiB manual/a.js 13.4 KiB
-  Entrypoint b 8.12 KiB = manual/vendors.js 1.07 KiB manual/b.js 7.05 KiB
-  Entrypoint c 8.12 KiB = manual/vendors.js 1.07 KiB manual/c.js 7.05 KiB
-  chunk (runtime: b) manual/b.js (b) 156 bytes (javascript) 2.92 KiB (runtime) ={216}= [entry] [rendered]
+  Entrypoint a 14.6 KiB = manual/vendors.js 1.07 KiB manual/a.js 13.5 KiB
+  Entrypoint b 8.26 KiB = manual/vendors.js 1.07 KiB manual/b.js 7.19 KiB
+  Entrypoint c 8.26 KiB = manual/vendors.js 1.07 KiB manual/c.js 7.19 KiB
+  chunk (runtime: b) manual/b.js (b) 156 bytes (javascript) 3.04 KiB (runtime) ={216}= [entry] [rendered]
     > ./b b
     > x b
     > y b
     > z b
-    runtime modules 2.92 KiB 3 modules
+    runtime modules 3.04 KiB 3 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./b.js 116 bytes [built] [code generated]
   chunk (runtime: a, main) manual/async-g.js (async-g) 65 bytes <{216}> <{786}> <{794}> [rendered]
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) manual/main.js (main) 147 bytes (javascript) 6.54 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
+  chunk (runtime: main) manual/main.js (main) 147 bytes (javascript) 6.57 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
     > ./ main
-    runtime modules 6.54 KiB 9 modules
+    runtime modules 6.57 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) manual/vendors.js (vendors) (id hint: vendors) 60 bytes <{179}> ={128}= ={334}= ={383}= ={459}= ={786}= ={794}= >{137}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
     > ./a ./index.js 1:0-47
@@ -3197,20 +3197,20 @@ manual:
     > ./c ./index.js 3:0-47
     dependent modules 40 bytes [dependent] 2 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: c) manual/c.js (c) 156 bytes (javascript) 2.92 KiB (runtime) ={216}= [entry] [rendered]
+  chunk (runtime: c) manual/c.js (c) 156 bytes (javascript) 3.04 KiB (runtime) ={216}= [entry] [rendered]
     > ./c c
     > x c
     > y c
     > z c
-    runtime modules 2.92 KiB 3 modules
+    runtime modules 3.04 KiB 3 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: a) manual/a.js (a) 205 bytes (javascript) 7.7 KiB (runtime) ={216}= >{137}< [entry] [rendered]
+  chunk (runtime: a) manual/a.js (a) 205 bytes (javascript) 7.81 KiB (runtime) ={216}= >{137}< [entry] [rendered]
     > ./a a
     > x a
     > y a
     > z a
-    runtime modules 7.7 KiB 9 modules
+    runtime modules 7.81 KiB 9 modules
     dependent modules 20 bytes [dependent] 1 module
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) manual/async-a.js (async-a) 205 bytes <{179}> ={216}= >{137}< [rendered]
@@ -3220,16 +3220,16 @@ manual:
   manual (webpack x.x.x) compiled successfully
 
 name-too-long:
-  Entrypoint main 11.3 KiB = name-too-long/main.js
-  Entrypoint aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 14.8 KiB = name-too-long/282.js 412 bytes name-too-long/954.js 412 bytes name-too-long/767.js 412 bytes name-too-long/390.js 412 bytes name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js 13.2 KiB
-  Entrypoint bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb 7.97 KiB = name-too-long/282.js 412 bytes name-too-long/954.js 412 bytes name-too-long/767.js 412 bytes name-too-long/568.js 412 bytes name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js 6.36 KiB
-  Entrypoint cccccccccccccccccccccccccccccc 7.97 KiB = name-too-long/282.js 412 bytes name-too-long/769.js 412 bytes name-too-long/767.js 412 bytes name-too-long/568.js 412 bytes name-too-long/cccccccccccccccccccccccccccccc.js 6.36 KiB
+  Entrypoint main 11.4 KiB = name-too-long/main.js
+  Entrypoint aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 15 KiB = name-too-long/282.js 412 bytes name-too-long/954.js 412 bytes name-too-long/767.js 412 bytes name-too-long/390.js 412 bytes name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js 13.4 KiB
+  Entrypoint bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb 8.1 KiB = name-too-long/282.js 412 bytes name-too-long/954.js 412 bytes name-too-long/767.js 412 bytes name-too-long/568.js 412 bytes name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js 6.49 KiB
+  Entrypoint cccccccccccccccccccccccccccccc 8.1 KiB = name-too-long/282.js 412 bytes name-too-long/769.js 412 bytes name-too-long/767.js 412 bytes name-too-long/568.js 412 bytes name-too-long/cccccccccccccccccccccccccccccc.js 6.49 KiB
   chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, main) name-too-long/async-g.js (async-g) 45 bytes <{282}> <{390}> <{751}> <{767}> <{794}> <{954}> ={568}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) name-too-long/main.js (main) 147 bytes (javascript) 6.54 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
+  chunk (runtime: main) name-too-long/main.js (main) 147 bytes (javascript) 6.57 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
     > ./ main
-    runtime modules 6.54 KiB 9 modules
+    runtime modules 6.57 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc, main) name-too-long/282.js (id hint: vendors) 20 bytes <{179}> ={334}= ={383}= ={390}= ={568}= ={658}= ={751}= ={766}= ={767}= ={769}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -3256,17 +3256,17 @@ name-too-long:
     > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     > ./c cccccccccccccccccccccccccccccc
     ./f.js 20 bytes [built] [code generated]
-  chunk (runtime: cccccccccccccccccccccccccccccc) name-too-long/cccccccccccccccccccccccccccccc.js (cccccccccccccccccccccccccccccc) 116 bytes (javascript) 2.9 KiB (runtime) ={282}= ={568}= ={767}= ={769}= [entry] [rendered]
+  chunk (runtime: cccccccccccccccccccccccccccccc) name-too-long/cccccccccccccccccccccccccccccc.js (cccccccccccccccccccccccccccccc) 116 bytes (javascript) 3.01 KiB (runtime) ={282}= ={568}= ={767}= ={769}= [entry] [rendered]
     > ./c cccccccccccccccccccccccccccccc
-    runtime modules 2.9 KiB 3 modules
+    runtime modules 3.01 KiB 3 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) 165 bytes (javascript) 7.71 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) 165 bytes (javascript) 7.82 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
     > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    runtime modules 7.71 KiB 9 modules
+    runtime modules 7.82 KiB 9 modules
     ./a.js 165 bytes [built] [code generated]
-  chunk (runtime: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) 116 bytes (javascript) 2.9 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
+  chunk (runtime: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) 116 bytes (javascript) 3.01 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
     > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-    runtime modules 2.9 KiB 3 modules
+    runtime modules 3.01 KiB 3 modules
     ./b.js 116 bytes [built] [code generated]
   chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc, main) name-too-long/767.js 20 bytes <{179}> ={282}= ={334}= ={383}= ={390}= ={568}= ={658}= ={751}= ={766}= ={769}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: default)
     > ./a ./index.js 1:0-47
@@ -3294,18 +3294,18 @@ name-too-long:
 custom-chunks-filter:
   Entrypoint main 11.3 KiB = custom-chunks-filter/main.js
   Entrypoint a 12.3 KiB = custom-chunks-filter/a.js
-  Entrypoint b 7.97 KiB = custom-chunks-filter/282.js 412 bytes custom-chunks-filter/954.js 412 bytes custom-chunks-filter/568.js 412 bytes custom-chunks-filter/767.js 412 bytes custom-chunks-filter/b.js 6.36 KiB
-  Entrypoint c 7.97 KiB = custom-chunks-filter/282.js 412 bytes custom-chunks-filter/769.js 412 bytes custom-chunks-filter/568.js 412 bytes custom-chunks-filter/767.js 412 bytes custom-chunks-filter/c.js 6.36 KiB
-  chunk (runtime: b) custom-chunks-filter/b.js (b) 116 bytes (javascript) 2.9 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
+  Entrypoint b 8.1 KiB = custom-chunks-filter/282.js 412 bytes custom-chunks-filter/954.js 412 bytes custom-chunks-filter/568.js 412 bytes custom-chunks-filter/767.js 412 bytes custom-chunks-filter/b.js 6.49 KiB
+  Entrypoint c 8.1 KiB = custom-chunks-filter/282.js 412 bytes custom-chunks-filter/769.js 412 bytes custom-chunks-filter/568.js 412 bytes custom-chunks-filter/767.js 412 bytes custom-chunks-filter/c.js 6.49 KiB
+  chunk (runtime: b) custom-chunks-filter/b.js (b) 116 bytes (javascript) 3.01 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
     > ./b b
-    runtime modules 2.9 KiB 3 modules
+    runtime modules 3.01 KiB 3 modules
     ./b.js 116 bytes [built] [code generated]
   chunk (runtime: a, main) custom-chunks-filter/async-g.js (async-g) 45 bytes <{282}> <{767}> <{786}> <{794}> <{954}> ={568}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) custom-chunks-filter/main.js (main) 147 bytes (javascript) 6.55 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
+  chunk (runtime: main) custom-chunks-filter/main.js (main) 147 bytes (javascript) 6.58 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
     > ./ main
-    runtime modules 6.55 KiB 9 modules
+    runtime modules 6.58 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: b, c, main) custom-chunks-filter/282.js (id hint: vendors) 20 bytes <{179}> ={128}= ={334}= ={383}= ={459}= ={568}= ={767}= ={769}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -3320,9 +3320,9 @@ custom-chunks-filter:
   chunk (runtime: main) custom-chunks-filter/async-c.js (async-c) 116 bytes <{179}> ={282}= ={568}= ={767}= ={769}= [rendered]
     > ./c ./index.js 3:0-47
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: c) custom-chunks-filter/c.js (c) 116 bytes (javascript) 2.9 KiB (runtime) ={282}= ={568}= ={767}= ={769}= [entry] [rendered]
+  chunk (runtime: c) custom-chunks-filter/c.js (c) 116 bytes (javascript) 3.01 KiB (runtime) ={282}= ={568}= ={767}= ={769}= [entry] [rendered]
     > ./c c
-    runtime modules 2.9 KiB 3 modules
+    runtime modules 3.01 KiB 3 modules
     ./c.js 116 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) custom-chunks-filter/568.js 20 bytes <{179}> <{282}> <{767}> <{786}> <{794}> <{954}> ={128}= ={137}= ={282}= ={334}= ={383}= ={459}= ={767}= ={769}= ={954}= [initial] [rendered] split chunk (cache group: default)
     > ./b ./index.js 2:0-47
@@ -3342,9 +3342,9 @@ custom-chunks-filter:
     > ./c ./index.js 3:0-47
     > ./c c
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) custom-chunks-filter/a.js (a) 245 bytes (javascript) 6.54 KiB (runtime) >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: a) custom-chunks-filter/a.js (a) 245 bytes (javascript) 6.57 KiB (runtime) >{137}< >{568}< [entry] [rendered]
     > ./a a
-    runtime modules 6.54 KiB 9 modules
+    runtime modules 6.57 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) custom-chunks-filter/async-a.js (async-a) 185 bytes <{179}> ={282}= ={767}= ={954}= >{137}< >{568}< [rendered]
@@ -3359,15 +3359,15 @@ custom-chunks-filter:
 
 custom-chunks-filter-in-cache-groups:
   Entrypoint main 11.1 KiB = custom-chunks-filter-in-cache-groups/main.js
-  Entrypoint a 14.3 KiB = custom-chunks-filter-in-cache-groups/176.js 888 bytes custom-chunks-filter-in-cache-groups/a.js 13.4 KiB
-  Entrypoint b 8.13 KiB = custom-chunks-filter-in-cache-groups/vendors.js 1.07 KiB custom-chunks-filter-in-cache-groups/b.js 7.05 KiB
-  Entrypoint c 8.13 KiB = custom-chunks-filter-in-cache-groups/vendors.js 1.07 KiB custom-chunks-filter-in-cache-groups/c.js 7.05 KiB
-  chunk (runtime: b) custom-chunks-filter-in-cache-groups/b.js (b) 156 bytes (javascript) 2.92 KiB (runtime) ={216}= [entry] [rendered]
+  Entrypoint a 14.4 KiB = custom-chunks-filter-in-cache-groups/176.js 888 bytes custom-chunks-filter-in-cache-groups/a.js 13.5 KiB
+  Entrypoint b 8.26 KiB = custom-chunks-filter-in-cache-groups/vendors.js 1.07 KiB custom-chunks-filter-in-cache-groups/b.js 7.19 KiB
+  Entrypoint c 8.26 KiB = custom-chunks-filter-in-cache-groups/vendors.js 1.07 KiB custom-chunks-filter-in-cache-groups/c.js 7.19 KiB
+  chunk (runtime: b) custom-chunks-filter-in-cache-groups/b.js (b) 156 bytes (javascript) 3.04 KiB (runtime) ={216}= [entry] [rendered]
     > ./b b
     > x b
     > y b
     > z b
-    runtime modules 2.92 KiB 3 modules
+    runtime modules 3.04 KiB 3 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./b.js 116 bytes [built] [code generated]
   chunk (runtime: a, main) custom-chunks-filter-in-cache-groups/async-g.js (async-g) 65 bytes <{176}> <{216}> <{786}> <{794}> [rendered]
@@ -3382,9 +3382,9 @@ custom-chunks-filter-in-cache-groups:
     ./node_modules/x.js 20 bytes [built] [code generated]
     ./node_modules/y.js 20 bytes [built] [code generated]
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: main) custom-chunks-filter-in-cache-groups/main.js (main) 147 bytes (javascript) 6.57 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
+  chunk (runtime: main) custom-chunks-filter-in-cache-groups/main.js (main) 147 bytes (javascript) 6.6 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
     > ./ main
-    runtime modules 6.57 KiB 9 modules
+    runtime modules 6.6 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: b, c, main) custom-chunks-filter-in-cache-groups/vendors.js (vendors) (id hint: vendors) 60 bytes <{179}> ={128}= ={334}= ={383}= ={459}= ={794}= >{137}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
     > ./a ./index.js 1:0-47
@@ -3409,20 +3409,20 @@ custom-chunks-filter-in-cache-groups:
     > ./c ./index.js 3:0-47
     dependent modules 40 bytes [dependent] 2 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: c) custom-chunks-filter-in-cache-groups/c.js (c) 156 bytes (javascript) 2.92 KiB (runtime) ={216}= [entry] [rendered]
+  chunk (runtime: c) custom-chunks-filter-in-cache-groups/c.js (c) 156 bytes (javascript) 3.04 KiB (runtime) ={216}= [entry] [rendered]
     > ./c c
     > x c
     > y c
     > z c
-    runtime modules 2.92 KiB 3 modules
+    runtime modules 3.04 KiB 3 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: a) custom-chunks-filter-in-cache-groups/a.js (a) 205 bytes (javascript) 7.73 KiB (runtime) ={176}= >{137}< [entry] [rendered]
+  chunk (runtime: a) custom-chunks-filter-in-cache-groups/a.js (a) 205 bytes (javascript) 7.84 KiB (runtime) ={176}= >{137}< [entry] [rendered]
     > ./a a
     > x a
     > y a
     > z a
-    runtime modules 7.73 KiB 9 modules
+    runtime modules 7.84 KiB 9 modules
     dependent modules 20 bytes [dependent] 1 module
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) custom-chunks-filter-in-cache-groups/async-a.js (async-a) 205 bytes <{179}> ={216}= >{137}< [rendered]
@@ -3464,18 +3464,18 @@ chunk (runtime: main) common-node_modules_y_js.js (id hint: common) 20 bytes <{m
 chunk (runtime: main) common-node_modules_z_js.js (id hint: common) 20 bytes <{main}> ={async-c}= ={common-d_js}= ={common-f_js}= ={common-node_modules_x_js}= [rendered] split chunk (cache group: b)
   > ./c ./index.js 3:0-47
   ./node_modules/z.js 20 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.44 KiB (runtime) >{async-a}< >{async-b}< >{async-c}< >{common-d_js}< >{common-f_js}< >{common-node_modules_x_js}< >{common-node_modules_y_js}< >{common-node_modules_z_js}< [entry] [rendered]
+chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.47 KiB (runtime) >{async-a}< >{async-b}< >{async-c}< >{common-d_js}< >{common-f_js}< >{common-node_modules_x_js}< >{common-node_modules_y_js}< >{common-node_modules_z_js}< [entry] [rendered]
   > ./ main
-  runtime modules 6.44 KiB 9 modules
+  runtime modules 6.47 KiB 9 modules
   ./index.js 147 bytes [built] [code generated]
 production (webpack x.x.x) compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-chunk-name 1`] = `
-"Entrypoint main 11 KiB = default/main.js
-chunk (runtime: main) default/main.js (main) 192 bytes (javascript) 6.51 KiB (runtime) >{334}< >{709}< >{794}< [entry] [rendered]
+"Entrypoint main 11.1 KiB = default/main.js
+chunk (runtime: main) default/main.js (main) 192 bytes (javascript) 6.54 KiB (runtime) >{334}< >{709}< >{794}< [entry] [rendered]
   > ./ main
-  runtime modules 6.51 KiB 9 modules
+  runtime modules 6.54 KiB 9 modules
   ./index.js 192 bytes [built] [code generated]
 chunk (runtime: main) default/async-b.js (async-b) (id hint: vendors) 122 bytes <{179}> [rendered] reused as split chunk (cache group: defaultVendors)
   > b ./index.js 2:0-45
@@ -3500,9 +3500,9 @@ chunk (runtime: main) async-g.js (async-g) 132 bytes <{179}> [rendered]
   > ./g ./index.js 7:0-47
   dependent modules 87 bytes [dependent] 1 module
   ./g.js 45 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 343 bytes (javascript) 6.56 KiB (runtime) >{31}< >{137}< >{206}< >{334}< >{383}< >{449}< >{794}< >{804}< [entry] [rendered]
+chunk (runtime: main) main.js (main) 343 bytes (javascript) 6.6 KiB (runtime) >{31}< >{137}< >{206}< >{334}< >{383}< >{449}< >{794}< >{804}< [entry] [rendered]
   > ./ main
-  runtime modules 6.56 KiB 9 modules
+  runtime modules 6.6 KiB 9 modules
   ./index.js 343 bytes [built] [code generated]
 chunk (runtime: main) async-f.js (async-f) 132 bytes <{179}> [rendered]
   > ./f ./index.js 6:0-47
@@ -3531,10 +3531,10 @@ webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-6413 1`] = `
-"Entrypoint main 11.1 KiB = main.js
-chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.5 KiB (runtime) >{282}< >{334}< >{383}< >{543}< >{794}< [entry] [rendered]
+"Entrypoint main 11.2 KiB = main.js
+chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.53 KiB (runtime) >{282}< >{334}< >{383}< >{543}< >{794}< [entry] [rendered]
   > ./ main
-  runtime modules 6.5 KiB 9 modules
+  runtime modules 6.53 KiB 9 modules
   ./index.js 147 bytes [built] [code generated]
 chunk (runtime: main) 282.js (id hint: vendors) 20 bytes <{179}> ={334}= ={383}= ={543}= ={794}= [rendered] split chunk (cache group: defaultVendors)
   > ./a ./index.js 1:0-47
@@ -3559,10 +3559,10 @@ default (webpack x.x.x) compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-6696 1`] = `
-"Entrypoint main 13.2 KiB = vendors.js 412 bytes main.js 12.8 KiB
-chunk (runtime: main) main.js (main) 134 bytes (javascript) 7.67 KiB (runtime) ={216}= >{334}< >{794}< [entry] [rendered]
+"Entrypoint main 13.3 KiB = vendors.js 412 bytes main.js 12.9 KiB
+chunk (runtime: main) main.js (main) 134 bytes (javascript) 7.78 KiB (runtime) ={216}= >{334}< >{794}< [entry] [rendered]
   > ./ main
-  runtime modules 7.67 KiB 9 modules
+  runtime modules 7.78 KiB 9 modules
   ./index.js 134 bytes [built] [code generated]
 chunk (runtime: main) vendors.js (vendors) (id hint: vendors) 20 bytes ={179}= >{334}< >{794}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
   > ./ main
@@ -3579,12 +3579,12 @@ default (webpack x.x.x) compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-7401 1`] = `
-"Entrypoint a 6.27 KiB = 282.js 412 bytes a.js 5.86 KiB
+"Entrypoint a 6.4 KiB = 282.js 412 bytes a.js 6 KiB
 Entrypoint b 10.7 KiB = b.js
 Chunk Group c 792 bytes = 282.js 412 bytes c.js 380 bytes
-chunk (runtime: b) b.js (b) 43 bytes (javascript) 6.47 KiB (runtime) >{282}< >{459}< [entry] [rendered]
+chunk (runtime: b) b.js (b) 43 bytes (javascript) 6.5 KiB (runtime) >{282}< >{459}< [entry] [rendered]
   > ./b b
-  runtime modules 6.47 KiB 9 modules
+  runtime modules 6.5 KiB 9 modules
   ./b.js 43 bytes [built] [code generated]
 chunk (runtime: a, b) 282.js (id hint: vendors) 20 bytes <{128}> ={459}= ={786}= [initial] [rendered] split chunk (cache group: defaultVendors)
   > ./c ./b.js 1:0-41
@@ -3593,9 +3593,9 @@ chunk (runtime: a, b) 282.js (id hint: vendors) 20 bytes <{128}> ={459}= ={786}=
 chunk (runtime: b) c.js (c) 35 bytes <{128}> ={282}= [rendered]
   > ./c ./b.js 1:0-41
   ./c.js 35 bytes [built] [code generated]
-chunk (runtime: a) a.js (a) 35 bytes (javascript) 2.88 KiB (runtime) ={282}= [entry] [rendered]
+chunk (runtime: a) a.js (a) 35 bytes (javascript) 2.99 KiB (runtime) ={282}= [entry] [rendered]
   > ./a a
-  runtime modules 2.88 KiB 3 modules
+  runtime modules 2.99 KiB 3 modules
   ./a.js 35 bytes [built] [code generated]
 default (webpack x.x.x) compiled successfully"
 `;
@@ -3605,9 +3605,9 @@ exports[`StatsTestCases should print correct stats for split-chunks-keep-remaini
 chunk (runtime: main) default/async-d.js (async-d) 84 bytes <{179}> ={782}= [rendered]
   > ./d ./index.js 4:0-47
   ./d.js 84 bytes [built] [code generated]
-chunk (runtime: main) default/main.js (main) 196 bytes (javascript) 6.53 KiB (runtime) >{31}< >{334}< >{383}< >{782}< >{794}< >{821}< [entry] [rendered]
+chunk (runtime: main) default/main.js (main) 196 bytes (javascript) 6.56 KiB (runtime) >{31}< >{334}< >{383}< >{782}< >{794}< >{821}< [entry] [rendered]
   > ./ main
-  runtime modules 6.53 KiB 9 modules
+  runtime modules 6.56 KiB 9 modules
   ./index.js 196 bytes [built] [code generated]
 chunk (runtime: main) default/async-b.js (async-b) 50 bytes <{179}> ={821}= [rendered]
   > ./b ./index.js 2:0-47
@@ -3631,7 +3631,7 @@ webpack x.x.x compiled successfully"
 
 exports[`StatsTestCases should print correct stats for split-chunks-max-size 1`] = `
 "production:
-  Entrypoint main 31.7 KiB = 13 assets
+  Entrypoint main 31.8 KiB = 13 assets
   chunk (runtime: main) prod-main-6bb16544.js (main-6bb16544) 1.57 KiB ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
     > ./ main
     ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
@@ -3695,9 +3695,9 @@ exports[`StatsTestCases should print correct stats for split-chunks-max-size 1`]
     > ./ main
     ./big.js?1 267 bytes [built] [code generated]
     ./big.js?2 267 bytes [built] [code generated]
-  chunk (runtime: main) prod-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.17 KiB (runtime) ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={869}= [entry] [rendered]
+  chunk (runtime: main) prod-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.29 KiB (runtime) ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={869}= [entry] [rendered]
     > ./ main
-    runtime modules 3.17 KiB 4 modules
+    runtime modules 3.29 KiB 4 modules
     ./very-big.js?1 1.57 KiB [built] [code generated]
   chunk (runtime: main) prod-869.js (id hint: vendors) 399 bytes ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./ main
@@ -3707,7 +3707,7 @@ exports[`StatsTestCases should print correct stats for split-chunks-max-size 1`]
   production (webpack x.x.x) compiled successfully
 
 development:
-  Entrypoint main 50.3 KiB = 13 assets
+  Entrypoint main 50.4 KiB = 13 assets
   chunk (runtime: main) dev-main-big_js-1.js (main-big_js-1) 534 bytes ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
     > ./ main
     ./big.js?1 267 bytes [built] [code generated]
@@ -3768,9 +3768,9 @@ development:
   chunk (runtime: main) dev-main-very-big_js-4647fb9d.js (main-very-big_js-4647fb9d) 1.57 KiB ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered]
     > ./ main
     ./very-big.js?3 1.57 KiB [built] [code generated]
-  chunk (runtime: main) dev-main-very-big_js-62f7f644.js (main-very-big_js-62f7f644) 1.57 KiB (javascript) 3.81 KiB (runtime) ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [entry] [rendered]
+  chunk (runtime: main) dev-main-very-big_js-62f7f644.js (main-very-big_js-62f7f644) 1.57 KiB (javascript) 3.93 KiB (runtime) ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2}= ={vendors-node_modules_very-big_js_1}= [entry] [rendered]
     > ./ main
-    runtime modules 3.81 KiB 5 modules
+    runtime modules 3.93 KiB 5 modules
     ./very-big.js?1 1.57 KiB [built] [code generated]
   chunk (runtime: main) dev-vendors-node_modules_big_js_1-node_modules_small_js_1-node_modules_small_js_2.js (id hint: vendors) 399 bytes ={main-big_js-1}= ={main-in-some-directory_b}= ={main-in-some-directory_very-big_js-8d76cf03}= ={main-index_js-41f5a26e}= ={main-inner-module_small_js-3}= ={main-small_js-1}= ={main-subfolder_big_js-b}= ={main-subfolder_small_js-1}= ={main-very-big_js-08cf55cf}= ={main-very-big_js-4647fb9d}= ={main-very-big_js-62f7f644}= ={vendors-node_modules_very-big_js_1}= [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./ main
@@ -3783,7 +3783,7 @@ development:
   development (webpack x.x.x) compiled successfully
 
 switched:
-  Entrypoint main 31.3 KiB = 8 assets
+  Entrypoint main 31.4 KiB = 8 assets
   chunk (runtime: main) switched-main-6bb16544.js (main-6bb16544) 1.57 KiB ={59}= ={247}= ={318}= ={520}= ={581}= ={663}= ={997}= [initial] [rendered]
     > ./ main
     ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
@@ -3806,9 +3806,9 @@ switched:
     > ./ main
     modules by path ./subfolder/*.js 1.1 KiB 11 modules
     modules by path ./*.js 594 bytes 9 modules
-  chunk (runtime: main) switched-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.16 KiB (runtime) ={1}= ={59}= ={247}= ={318}= ={520}= ={581}= ={997}= [entry] [rendered]
+  chunk (runtime: main) switched-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.27 KiB (runtime) ={1}= ={59}= ={247}= ={318}= ={520}= ={581}= ={997}= [entry] [rendered]
     > ./ main
-    runtime modules 3.16 KiB 4 modules
+    runtime modules 3.27 KiB 4 modules
     ./very-big.js?1 1.57 KiB [built] [code generated]
   chunk (runtime: main) switched-main-7aeafcb2.js (main-7aeafcb2) 1.62 KiB ={1}= ={59}= ={247}= ={318}= ={520}= ={581}= ={663}= [initial] [rendered]
     > ./ main
@@ -3836,7 +3836,7 @@ switched:
   switched (webpack x.x.x) compiled with 2 warnings
 
 zero-min:
-  Entrypoint main 31.7 KiB = 13 assets
+  Entrypoint main 31.8 KiB = 13 assets
   chunk (runtime: main) zero-min-main-6bb16544.js (main-6bb16544) 1.57 KiB ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= ={869}= [initial] [rendered]
     > ./ main
     ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
@@ -3900,9 +3900,9 @@ zero-min:
     > ./ main
     ./big.js?1 267 bytes [built] [code generated]
     ./big.js?2 267 bytes [built] [code generated]
-  chunk (runtime: main) zero-min-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.17 KiB (runtime) ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={869}= [entry] [rendered]
+  chunk (runtime: main) zero-min-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.29 KiB (runtime) ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={869}= [entry] [rendered]
     > ./ main
-    runtime modules 3.17 KiB 4 modules
+    runtime modules 3.29 KiB 4 modules
     ./very-big.js?1 1.57 KiB [built] [code generated]
   chunk (runtime: main) zero-min-869.js (id hint: vendors) 399 bytes ={1}= ={59}= ={198}= ={204}= ={318}= ={358}= ={400}= ={410}= ={490}= ={520}= ={662}= ={663}= [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./ main
@@ -3912,10 +3912,10 @@ zero-min:
   zero-min (webpack x.x.x) compiled successfully
 
 max-async-size:
-  Entrypoint main 15.6 KiB = max-async-size-main.js
-  chunk (runtime: main) max-async-size-main.js (main) 2.46 KiB (javascript) 6.81 KiB (runtime) >{342}< >{385}< >{820}< >{920}< [entry] [rendered]
+  Entrypoint main 15.7 KiB = max-async-size-main.js
+  chunk (runtime: main) max-async-size-main.js (main) 2.46 KiB (javascript) 6.84 KiB (runtime) >{342}< >{385}< >{820}< >{920}< [entry] [rendered]
     > ./async main
-    runtime modules 6.81 KiB 10 modules
+    runtime modules 6.84 KiB 10 modules
     dependent modules 2.09 KiB [dependent] 6 modules
     ./async/index.js 386 bytes [built] [code generated]
   chunk (runtime: main) max-async-size-async-b-77a8c116.js (async-b-77a8c116) 1.57 KiB <{179}> ={385}= ={820}= ={920}= [rendered]
@@ -3940,13 +3940,13 @@ max-async-size:
   max-async-size (webpack x.x.x) compiled successfully
 
 enforce-min-size:
-  Entrypoint main 31.7 KiB = 14 assets
+  Entrypoint main 31.9 KiB = 14 assets
   chunk (runtime: main) enforce-min-size-10.js (id hint: all) 1.19 KiB ={179}= ={221}= ={262}= ={410}= ={434}= ={463}= ={519}= ={575}= ={614}= ={692}= ={822}= ={825}= ={869}= [initial] [rendered] split chunk (cache group: all)
     > ./ main
     ./index.js 1.19 KiB [built] [code generated]
-  chunk (runtime: main) enforce-min-size-main.js (main) 3.18 KiB ={10}= ={221}= ={262}= ={410}= ={434}= ={463}= ={519}= ={575}= ={614}= ={692}= ={822}= ={825}= ={869}= [entry] [rendered]
+  chunk (runtime: main) enforce-min-size-main.js (main) 3.29 KiB ={10}= ={221}= ={262}= ={410}= ={434}= ={463}= ={519}= ={575}= ={614}= ={692}= ={822}= ={825}= ={869}= [entry] [rendered]
     > ./ main
-    runtime modules 3.18 KiB 4 modules
+    runtime modules 3.29 KiB 4 modules
   chunk (runtime: main) enforce-min-size-221.js (id hint: all) 1.57 KiB ={10}= ={179}= ={262}= ={410}= ={434}= ={463}= ={519}= ={575}= ={614}= ={692}= ={822}= ={825}= ={869}= [initial] [rendered] split chunk (cache group: all)
     > ./ main
     ./very-big.js?3 1.57 KiB [built] [code generated]
@@ -4019,15 +4019,15 @@ enforce-min-size:
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-prefer-bigger-splits 1`] = `
-"Entrypoint main 11 KiB = default/main.js
+"Entrypoint main 11.1 KiB = default/main.js
 chunk (runtime: main) default/118.js 150 bytes <{179}> ={334}= ={383}= [rendered] split chunk (cache group: default)
   > ./b ./index.js 2:0-47
   > ./c ./index.js 3:0-47
   ./d.js 63 bytes [built] [code generated]
   ./f.js 87 bytes [built] [code generated]
-chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.52 KiB (runtime) >{118}< >{334}< >{383}< >{794}< [entry] [rendered]
+chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.55 KiB (runtime) >{118}< >{334}< >{383}< >{794}< [entry] [rendered]
   > ./ main
-  runtime modules 6.52 KiB 9 modules
+  runtime modules 6.55 KiB 9 modules
   ./index.js 147 bytes [built] [code generated]
 chunk (runtime: main) default/async-b.js (async-b) 158 bytes <{179}> ={118}= [rendered]
   > ./b ./index.js 2:0-47
@@ -4045,64 +4045,64 @@ webpack x.x.x compiled successfully"
 
 exports[`StatsTestCases should print correct stats for split-chunks-runtime-specific 1`] = `
 "used-exports:
-  asset used-exports-c.js 5.88 KiB [emitted] (name: c)
-  asset used-exports-b.js 5.88 KiB [emitted] (name: b)
+  asset used-exports-c.js 6.02 KiB [emitted] (name: c)
+  asset used-exports-b.js 6.01 KiB [emitted] (name: b)
   asset used-exports-332.js 422 bytes [emitted]
   asset used-exports-a.js 227 bytes [emitted] (name: a)
   Entrypoint a 227 bytes = used-exports-a.js
-  Entrypoint b 6.29 KiB = used-exports-332.js 422 bytes used-exports-b.js 5.88 KiB
-  Entrypoint c 6.3 KiB = used-exports-332.js 422 bytes used-exports-c.js 5.88 KiB
-  chunk (runtime: b) used-exports-b.js (b) 54 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
-    runtime modules 2.88 KiB 3 modules
+  Entrypoint b 6.43 KiB = used-exports-332.js 422 bytes used-exports-b.js 6.01 KiB
+  Entrypoint c 6.43 KiB = used-exports-332.js 422 bytes used-exports-c.js 6.02 KiB
+  chunk (runtime: b) used-exports-b.js (b) 54 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
+    runtime modules 2.99 KiB 3 modules
     ./b.js 54 bytes [built] [code generated]
   chunk (runtime: b, c) used-exports-332.js 72 bytes [initial] [rendered] split chunk (cache group: default)
     ./objects.js 72 bytes [built] [code generated]
-  chunk (runtime: c) used-exports-c.js (c) 59 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
-    runtime modules 2.88 KiB 3 modules
+  chunk (runtime: c) used-exports-c.js (c) 59 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
+    runtime modules 2.99 KiB 3 modules
     ./c.js 59 bytes [built] [code generated]
   chunk (runtime: a) used-exports-a.js (a) 126 bytes [entry] [rendered]
     ./a.js + 1 modules 126 bytes [built] [code generated]
   used-exports (webpack x.x.x) compiled successfully in X ms
 
 no-used-exports:
-  asset no-used-exports-c.js 5.88 KiB [emitted] (name: c)
-  asset no-used-exports-a.js 5.88 KiB [emitted] (name: a)
-  asset no-used-exports-b.js 5.88 KiB [emitted] (name: b)
+  asset no-used-exports-c.js 6.02 KiB [emitted] (name: c)
+  asset no-used-exports-a.js 6.01 KiB [emitted] (name: a)
+  asset no-used-exports-b.js 6.01 KiB [emitted] (name: b)
   asset no-used-exports-332.js 443 bytes [emitted]
-  Entrypoint a 6.31 KiB = no-used-exports-332.js 443 bytes no-used-exports-a.js 5.88 KiB
-  Entrypoint b 6.31 KiB = no-used-exports-332.js 443 bytes no-used-exports-b.js 5.88 KiB
-  Entrypoint c 6.32 KiB = no-used-exports-332.js 443 bytes no-used-exports-c.js 5.88 KiB
-  chunk (runtime: b) no-used-exports-b.js (b) 54 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
-    runtime modules 2.88 KiB 3 modules
+  Entrypoint a 6.45 KiB = no-used-exports-332.js 443 bytes no-used-exports-a.js 6.01 KiB
+  Entrypoint b 6.45 KiB = no-used-exports-332.js 443 bytes no-used-exports-b.js 6.01 KiB
+  Entrypoint c 6.45 KiB = no-used-exports-332.js 443 bytes no-used-exports-c.js 6.02 KiB
+  chunk (runtime: b) no-used-exports-b.js (b) 54 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
+    runtime modules 2.99 KiB 3 modules
     ./b.js 54 bytes [built] [code generated]
   chunk (runtime: a, b, c) no-used-exports-332.js 72 bytes [initial] [rendered] split chunk (cache group: default)
     ./objects.js 72 bytes [built] [code generated]
-  chunk (runtime: c) no-used-exports-c.js (c) 59 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
-    runtime modules 2.88 KiB 3 modules
+  chunk (runtime: c) no-used-exports-c.js (c) 59 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
+    runtime modules 2.99 KiB 3 modules
     ./c.js 59 bytes [built] [code generated]
-  chunk (runtime: a) no-used-exports-a.js (a) 54 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
-    runtime modules 2.88 KiB 3 modules
+  chunk (runtime: a) no-used-exports-a.js (a) 54 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
+    runtime modules 2.99 KiB 3 modules
     ./a.js 54 bytes [built] [code generated]
   no-used-exports (webpack x.x.x) compiled successfully in X ms
 
 global:
-  asset global-c.js 5.88 KiB [emitted] (name: c)
-  asset global-a.js 5.88 KiB [emitted] (name: a)
-  asset global-b.js 5.88 KiB [emitted] (name: b)
+  asset global-c.js 6.02 KiB [emitted] (name: c)
+  asset global-a.js 6.01 KiB [emitted] (name: a)
+  asset global-b.js 6.01 KiB [emitted] (name: b)
   asset global-332.js 443 bytes [emitted]
-  Entrypoint a 6.31 KiB = global-332.js 443 bytes global-a.js 5.88 KiB
-  Entrypoint b 6.31 KiB = global-332.js 443 bytes global-b.js 5.88 KiB
-  Entrypoint c 6.32 KiB = global-332.js 443 bytes global-c.js 5.88 KiB
-  chunk (runtime: b) global-b.js (b) 54 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
-    runtime modules 2.88 KiB 3 modules
+  Entrypoint a 6.45 KiB = global-332.js 443 bytes global-a.js 6.01 KiB
+  Entrypoint b 6.45 KiB = global-332.js 443 bytes global-b.js 6.01 KiB
+  Entrypoint c 6.45 KiB = global-332.js 443 bytes global-c.js 6.02 KiB
+  chunk (runtime: b) global-b.js (b) 54 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
+    runtime modules 2.99 KiB 3 modules
     ./b.js 54 bytes [built] [code generated]
   chunk (runtime: a, b, c) global-332.js 72 bytes [initial] [rendered] split chunk (cache group: default)
     ./objects.js 72 bytes [built] [code generated]
-  chunk (runtime: c) global-c.js (c) 59 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
-    runtime modules 2.88 KiB 3 modules
+  chunk (runtime: c) global-c.js (c) 59 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
+    runtime modules 2.99 KiB 3 modules
     ./c.js 59 bytes [built] [code generated]
-  chunk (runtime: a) global-a.js (a) 54 bytes (javascript) 2.88 KiB (runtime) [entry] [rendered]
-    runtime modules 2.88 KiB 3 modules
+  chunk (runtime: a) global-a.js (a) 54 bytes (javascript) 2.99 KiB (runtime) [entry] [rendered]
+    runtime modules 2.99 KiB 3 modules
     ./a.js 54 bytes [built] [code generated]
   global (webpack x.x.x) compiled successfully in X ms"
 `;
@@ -4147,7 +4147,7 @@ webpack x.x.x compiled with 1 warning in X ms"
 
 exports[`StatsTestCases should print correct stats for wasm-explorer-examples-sync 1`] = `
 "assets by path *.js 18.2 KiB
-  asset bundle.js 13 KiB [emitted] (name: main)
+  asset bundle.js 13.1 KiB [emitted] (name: main)
   asset 325.bundle.js 3.78 KiB [emitted]
   asset 780.bundle.js 569 bytes [emitted]
   asset 526.bundle.js 364 bytes [emitted] (id hint: vendors)
@@ -4162,8 +4162,8 @@ assets by path *.wasm 1.37 KiB
   asset 71ba3c2b7af4ee0e4b5c.module.wasm 120 bytes [emitted] [immutable]
 chunk (runtime: main) 99.bundle.js 50 bytes (javascript) 531 bytes (webassembly) [rendered]
   ./duff.wasm 50 bytes (javascript) 531 bytes (webassembly) [built] [code generated]
-chunk (runtime: main) bundle.js (main) 586 bytes (javascript) 6.96 KiB (runtime) [entry] [rendered]
-  runtime modules 6.96 KiB 10 modules
+chunk (runtime: main) bundle.js (main) 586 bytes (javascript) 6.99 KiB (runtime) [entry] [rendered]
+  runtime modules 6.99 KiB 10 modules
   ./index.js 586 bytes [built] [code generated]
 chunk (runtime: main) 230.bundle.js 50 bytes (javascript) 156 bytes (webassembly) [rendered]
   ./Q_rsqrt.wasm 50 bytes (javascript) 156 bytes (webassembly) [built] [code generated]
@@ -4176,7 +4176,7 @@ chunk (runtime: main) 526.bundle.js (id hint: vendors) 34 bytes [rendered] split
 chunk (runtime: main) 780.bundle.js 110 bytes (javascript) 444 bytes (webassembly) [rendered]
   ./fact.wasm 50 bytes (javascript) 154 bytes (webassembly) [built] [code generated]
   ./fast-math.wasm 60 bytes (javascript) 290 bytes (webassembly) [built] [code generated]
-runtime modules 6.96 KiB 10 modules
+runtime modules 6.99 KiB 10 modules
 cacheable modules 2.31 KiB (javascript) 1.37 KiB (webassembly)
   webassembly modules 310 bytes (javascript) 1.37 KiB (webassembly)
     ./Q_rsqrt.wasm 50 bytes (javascript) 156 bytes (webassembly) [built] [code generated]

--- a/test/configCases/split-chunks-common/issue-12128/a.js
+++ b/test/configCases/split-chunks-common/issue-12128/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/test/configCases/split-chunks-common/issue-12128/b.js
+++ b/test/configCases/split-chunks-common/issue-12128/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/test/configCases/split-chunks-common/issue-12128/index.js
+++ b/test/configCases/split-chunks-common/issue-12128/index.js
@@ -1,0 +1,6 @@
+it("should be main", function () {
+	require("./a");
+	require("./b");
+
+	expect(window["webpackChunk"].length).toBe(1);
+});

--- a/test/configCases/split-chunks-common/issue-12128/index2.js
+++ b/test/configCases/split-chunks-common/issue-12128/index2.js
@@ -1,0 +1,6 @@
+it("should run", function() {
+	var a = require("./a");
+	var b = require("./b");
+	expect(a).toBe("a");
+	expect(b).toBe("b");
+});

--- a/test/configCases/split-chunks-common/issue-12128/test.config.js
+++ b/test/configCases/split-chunks-common/issue-12128/test.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	findBundle: function(i, options) {
+		return [
+			"./common.js",
+			"./main.js",
+			"./main2.js"
+		]
+	}
+};

--- a/test/configCases/split-chunks-common/issue-12128/webpack.config.js
+++ b/test/configCases/split-chunks-common/issue-12128/webpack.config.js
@@ -1,0 +1,22 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		main: "./index",
+		main2: "./index2"
+	},
+	target: "web",
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				common: {
+					chunks: "initial",
+					minSize: 0,
+					name: "common"
+				}
+			}
+		}
+	}
+};

--- a/test/configCases/web/preexecuted-chunk/chunk.js
+++ b/test/configCases/web/preexecuted-chunk/chunk.js
@@ -1,0 +1,1 @@
+export default "ok";

--- a/test/configCases/web/preexecuted-chunk/index.js
+++ b/test/configCases/web/preexecuted-chunk/index.js
@@ -1,0 +1,4 @@
+it("should be able load the chunk", async () => {
+	const module = await import(/* webpackChunkName: "the-chunk" */ "./chunk");
+	expect(module.default).toBe("ok");
+});

--- a/test/configCases/web/preexecuted-chunk/test.config.js
+++ b/test/configCases/web/preexecuted-chunk/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["the-chunk.js", "bundle0.js"];
+	}
+};

--- a/test/configCases/web/preexecuted-chunk/webpack.config.js
+++ b/test/configCases/web/preexecuted-chunk/webpack.config.js
@@ -1,0 +1,14 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	output: {
+		chunkFilename: "[name].js"
+	},
+	performance: {
+		hints: false
+	},
+	optimization: {
+		chunkIds: "named",
+		minimize: false
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Avoid duplicate chunks in template's `chunkLoadingGlobal`, its the issue #12128 which I reproduce in this repo https://github.com/zphhhhh/webpack-bug.

In`lib/web/JsonpChunkLoadingRuntimeModule.js`, we put all the common chunks to the global array `chunkLoadingGlobal` in template, but the array contains duplicate chunks because [this file's L470](https://github.com/webpack/webpack/blob/master/lib/web/JsonpChunkLoadingRuntimeModule.js#L470) and [L488](https://github.com/webpack/webpack/blob/master/lib/web/JsonpChunkLoadingRuntimeModule.js#L488).

We shouldn't make `parentChunkLoadingFunction` be `chunkLoadingGlobal.push`until `webpackJsonpCallback` execute completely. Just like it in webpack 4 [lib/web/JsonpMainTemplatePlugin.js#L500](https://github.com/webpack/webpack/blob/webpack-4/lib/web/JsonpMainTemplatePlugin.js#L500)

fixes #12128
fixes #12130

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Avoid duplicate chunks be pushed in `chunkLoadingGlobal`.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
