### PR TITLE
Feat: re-export `schema-utils` from webpack

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -278,6 +278,10 @@ module.exports = mergeExports(fn, {
 		return require("schema-utils").ValidationError;
 	},
 
+	get schemaUtils() {
+		return require("schema-utils");
+	},
+
 	cache: {
 		get MemoryCachePlugin() {
 			return require("./cache/MemoryCachePlugin");

--- a/types.d.ts
+++ b/types.d.ts
@@ -79,6 +79,7 @@ import {
 } from "estree";
 import { Stats as FsStats, WriteStream } from "fs";
 import { default as ValidationError } from "schema-utils/declarations/ValidationError";
+import { validate } from "schema-utils/declarations/validate";
 import {
 	AsArray,
 	AsyncParallelHook,
@@ -9742,6 +9743,10 @@ declare namespace exports {
 	}>;
 	export const WebpackOptionsValidationError: ValidationError;
 	export const ValidationError: ValidationError;
+	export namespace schemaUtils {
+		export let validate: validate;
+		export let ValidationError: ValidationError;
+	}
 	export namespace cache {
 		export { MemoryCachePlugin };
 	}


### PR DESCRIPTION
Now every plugin has a "schema-utils" package in its dependencies. When new versions of this package are released, we have to update it everywhere.

This PR will allow to drop the "schema-utils" package from the loaders and plugins dependencies.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Feature

**Did you add tests for your changes?**

No

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing
