### PR TITLE
recognition of root path if it has the format of a network directory

### DIFF
--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -115,7 +115,7 @@ const join = (fs, rootPath, filename) => {
 		return fs.join(rootPath, filename);
 	} else if (rootPath.startsWith("/")) {
 		return path.posix.join(rootPath, filename);
-	} else if (rootPath.length > 1 && rootPath[1] === ":") {
+	} else if (rootPath.length > 1 && (rootPath[1] === ":" || rootPath.startsWith("\\\\"))) {
 		return path.win32.join(rootPath, filename);
 	} else {
 		throw new Error(


### PR DESCRIPTION
Issue: Webpack did not recognize network directory paths. 

Network paths do not have ":" as second character. Unfortunately the code only tests this case for windows paths.
The consequence was the following error: 
`\\... is neither a posix nor a windows path, and there is no 'join' method defined in the file system`

To fix this issue I inserted the following condition in the if clause: 
|| rootPath.startsWith("\\\\")


**What kind of change does this PR introduce?**
- bugfix


**Does this PR introduce a breaking change?**
- No


**What needs to be documented once your changes are merged?**
- Nothing
