### PR TITLE
fix: add typings for DefaultStatsFactoryPlugin, Stats, and MultiStats

### DIFF
--- a/lib/MultiStats.js
+++ b/lib/MultiStats.js
@@ -7,7 +7,9 @@
 
 const identifierUtils = require("./util/identifier");
 
+/** @typedef {import("../declarations/WebpackOptions").StatsOptions} StatsOptions */
 /** @typedef {import("./Stats")} Stats */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsCompilation} ToJsonOutput */
 
 const indent = (str, prefix) => {
 	const rem = str.replace(/\n([^\n])/g, "\n" + prefix + "$1");
@@ -70,8 +72,13 @@ class MultiStats {
 		};
 	}
 
+	/**
+	 * @param {any} options stats options
+	 * @returns {ToJsonOutput} json output
+	 */
 	toJson(options) {
 		options = this._createChildOptions(options, { forToString: false });
+		/** @type ToJsonOutput */
 		const obj = {};
 		obj.children = this.stats.map((stat, idx) => {
 			const obj = stat.toJson(options.children[idx]);

--- a/lib/MultiStats.js
+++ b/lib/MultiStats.js
@@ -9,7 +9,8 @@ const identifierUtils = require("./util/identifier");
 
 /** @typedef {import("../declarations/WebpackOptions").StatsOptions} StatsOptions */
 /** @typedef {import("./Stats")} Stats */
-/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsCompilation} ToJsonOutput */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").KnownStatsCompilation} KnownStatsCompilation */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsCompilation} StatsCompilation */
 
 const indent = (str, prefix) => {
 	const rem = str.replace(/\n([^\n])/g, "\n" + prefix + "$1");
@@ -74,11 +75,11 @@ class MultiStats {
 
 	/**
 	 * @param {any} options stats options
-	 * @returns {ToJsonOutput} json output
+	 * @returns {StatsCompilation} json output
 	 */
 	toJson(options) {
 		options = this._createChildOptions(options, { forToString: false });
-		/** @type ToJsonOutput */
+		/** @type {KnownStatsCompilation} */
 		const obj = {};
 		obj.children = this.stats.map((stat, idx) => {
 			const obj = stat.toJson(options.children[idx]);

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -7,7 +7,7 @@
 
 /** @typedef {import("../declarations/WebpackOptions").StatsOptions} StatsOptions */
 /** @typedef {import("./Compilation")} Compilation */
-/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsCompilation} ToJsonOutput */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsCompilation} StatsCompilation */
 
 class Stats {
 	/**
@@ -51,7 +51,7 @@ class Stats {
 
 	/**
 	 * @param {(string|StatsOptions)=} options stats options
-	 * @returns {ToJsonOutput} json output
+	 * @returns {StatsCompilation} json output
 	 */
 	toJson(options) {
 		options = this.compilation.createStatsOptions(options, {

--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -5,7 +5,9 @@
 
 "use strict";
 
+/** @typedef {import("../declarations/WebpackOptions").StatsOptions} StatsOptions */
 /** @typedef {import("./Compilation")} Compilation */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsCompilation} ToJsonOutput */
 
 class Stats {
 	/**
@@ -47,6 +49,10 @@ class Stats {
 		);
 	}
 
+	/**
+	 * @param {(string|StatsOptions)=} options stats options
+	 * @returns {ToJsonOutput} json output
+	 */
 	toJson(options) {
 		options = this.compilation.createStatsOptions(options, {
 			forToString: false

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,7 @@ const memoize = require("./util/memoize");
 /** @typedef {import("./Compilation").Asset} Asset */
 /** @typedef {import("./Compilation").AssetInfo} AssetInfo */
 /** @typedef {import("./Parser").ParserState} ParserState */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsCompilation} StatsCompilation */
 
 /**
  * @template {Function} T

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -29,6 +29,7 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
 /** @typedef {import("../ChunkGroup").OriginRecord} OriginRecord */
 /** @typedef {import("../Compilation")} Compilation */
 /** @typedef {import("../Compilation").Asset} Asset */
+/** @typedef {import("../Compilation").AssetInfo} AssetInfo */
 /** @typedef {import("../Compilation").NormalizedStatsOptions} NormalizedStatsOptions */
 /** @typedef {import("../Compiler")} Compiler */
 /** @typedef {import("../Dependency")} Dependency */
@@ -44,8 +45,9 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
 /** @typedef {import("./StatsFactory")} StatsFactory */
 /** @typedef {import("./StatsFactory").StatsFactoryContext} StatsFactoryContext */
 
+/** @typedef {KnownStatsCompilation & Record<string, any>} StatsCompilation */
 /**
- * @typedef {Object} StatsCompilation
+ * @typedef {Object} KnownStatsCompilation
  * @property {any=} env
  * @property {string=} name
  * @property {string=} hash
@@ -68,30 +70,52 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @property {StatsError[]=} warnings
  * @property {number=} warningsCount
  * @property {StatsCompilation[]=} children
- * @property {any=} logging
+ * @property {Record<string, StatsLogging>=} logging
  */
 
+/** @typedef {KnownStatsLogging & Record<string, any>} StatsLogging */
 /**
- * @typedef {Partial<Asset> & {
- * type: string,
- * size?: number,
- * related?: StatsAsset[] | {}, // TODO fix empty resolving as {}
- * chunkNames?: (string|number)[],
- * chunkIdHints?: (string|number)[],
- * chunks?: (string|number)[],
- * auxiliaryChunkNames?: (string|number)[],
- * auxiliaryChunks?: (string|number)[],
- * auxiliaryChunkIdHints?: (string|number)[],
- * emitted?: boolean,
- * comparedForEmit?: boolean,
- * cached?: boolean,
- * filteredRelated?: number,
- * isOverSizeLimit?: boolean
- * }} StatsAsset
+ * @typedef {Object} KnownStatsLogging
+ * @property {StatsLoggingEntry[]} entries
+ * @property {number} filteredEntries
+ * @property {boolean} debug
  */
 
+/** @typedef {KnownStatsLoggingEntry & Record<string, any>} StatsLoggingEntry */
 /**
- * @typedef {Object} StatsChunkGroup
+ * @typedef {Object} KnownStatsLoggingEntry
+ * @property {string} type
+ * @property {string} message
+ * @property {string[]=} trace
+ * @property {StatsLoggingEntry[]=} children
+ * @property {any[]=} args
+ * @property {number=} time
+ */
+
+/** @typedef {KnownStatsAsset & Record<string, any>} StatsAsset */
+/**
+ * @typedef {Object} KnownStatsAsset
+ * @property {string} type
+ * @property {string} name
+ * @property {AssetInfo} info
+ * @property {number} size
+ * @property {boolean} emitted
+ * @property {boolean} comparedForEmit
+ * @property {boolean} cached
+ * @property {StatsAsset[]=} related
+ * @property {(string|number)[]=} chunkNames
+ * @property {(string|number)[]=} chunkIdHints
+ * @property {(string|number)[]=} chunks
+ * @property {(string|number)[]=} auxiliaryChunkNames
+ * @property {(string|number)[]=} auxiliaryChunks
+ * @property {(string|number)[]=} auxiliaryChunkIdHints
+ * @property {number=} filteredRelated
+ * @property {boolean=} isOverSizeLimit
+ */
+
+/** @typedef {KnownStatsChunkGroup & Record<string, any>} StatsChunkGroup */
+/**
+ * @typedef {Object} KnownStatsChunkGroup
  * @property {string=} name
  * @property {(string|number)[]=} chunks
  * @property {({ name: string, size?: number })[]=} assets
@@ -105,8 +129,9 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @property {boolean=} isOverSizeLimit
  */
 
+/** @typedef {KnownStatsModule & Record<string, any>} StatsModule */
 /**
- * @typedef {Object} StatsModule
+ * @typedef {Object} KnownStatsModule
  * @property {string=} type
  * @property {string=} moduleType
  * @property {string=} layer
@@ -147,8 +172,9 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @property {ReturnType<Source["source"]>=} source
  */
 
+/** @typedef {KnownStatsProfile & Record<string, any>} StatsProfile */
 /**
- * @typedef {Object} StatsProfile
+ * @typedef {Object} KnownStatsProfile
  * @property {number} total
  * @property {number} resolving
  * @property {number} restoring
@@ -161,16 +187,18 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @property {number} dependencies
  */
 
+/** @typedef {KnownStatsModuleIssuer & Record<string, any>} StatsModuleIssuer */
 /**
- * @typedef {Object} StatsModuleIssuer
+ * @typedef {Object} KnownStatsModuleIssuer
  * @property {string=} identifier
  * @property {string=} name
  * @property {(string|number)=} id
  * @property {StatsProfile=} profile
  */
 
+/** @typedef {KnownStatsModuleReason & Record<string, any>} StatsModuleReason */
 /**
- * @typedef {Object} StatsModuleReason
+ * @typedef {Object} KnownStatsModuleReason
  * @property {string=} moduleIdentifier
  * @property {string=} module
  * @property {string=} moduleName
@@ -185,8 +213,9 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @property {(string|number)=} resolvedModuleId
  */
 
+/** @typedef {KnownStatsChunk & Record<string, any>} StatsChunk */
 /**
- * @typedef {Object} StatsChunk
+ * @typedef {Object} KnownStatsChunk
  * @property {boolean} rendered
  * @property {boolean} initial
  * @property {boolean} entry
@@ -210,8 +239,9 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @property {StatsChunkOrigin[]=} origins
  */
 
+/** @typedef {KnownStatsChunkOrigin & Record<string, any>} StatsChunkOrigin */
 /**
- * @typedef {Object} StatsChunkOrigin
+ * @typedef {Object} KnownStatsChunkOrigin
  * @property {string=} module
  * @property {string=} moduleIdentifier
  * @property {string=} moduleName
@@ -220,8 +250,9 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @property {(string|number)=} moduleId
  */
 
+/** @typedef {KnownStatsModuleTraceItem & Record<string, any>} StatsModuleTraceItem */
 /**
- * @typedef {Object} StatsModuleTraceItem
+ * @typedef {Object} KnownStatsModuleTraceItem
  * @property {string=} originIdentifier
  * @property {string=} originName
  * @property {string=} moduleIdentifier
@@ -231,13 +262,15 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @property {(string|number)=} moduleId
  */
 
+/** @typedef {KnownStatsModuleTraceDependency & Record<string, any>} StatsModuleTraceDependency */
 /**
- * @typedef {Object} StatsModuleTraceDependency
+ * @typedef {Object} KnownStatsModuleTraceDependency
  * @property {string=} loc
  */
 
+/** @typedef {KnownStatsError & Record<string, any>} StatsError */
 /**
- * @typedef {Object} StatsError
+ * @typedef {Object} KnownStatsError
  * @property {string} message
  * @property {string=} chunkName
  * @property {boolean=} chunkEntry
@@ -253,6 +286,8 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @property {any=} stack
  */
 
+/** @typedef {Asset & { type: string, related: PreprocessedAsset[] }} PreprocessedAsset */
+
 /**
  * @template T
  * @template O
@@ -262,8 +297,8 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
 /**
  * @typedef {Object} SimpleExtractors
  * @property {ExtractorsByOption<Compilation, StatsCompilation>} compilation
- * @property {ExtractorsByOption<StatsAsset, StatsAsset>} asset
- * @property {ExtractorsByOption<StatsAsset, StatsAsset>} asset$visible
+ * @property {ExtractorsByOption<PreprocessedAsset, StatsAsset>} asset
+ * @property {ExtractorsByOption<PreprocessedAsset, StatsAsset>} asset$visible
  * @property {ExtractorsByOption<{ name: string, chunkGroup: ChunkGroup }, StatsChunkGroup>} chunkGroup
  * @property {ExtractorsByOption<Module, StatsModule>} module
  * @property {ExtractorsByOption<Module, StatsModule>} module$visible
@@ -510,12 +545,12 @@ const SIMPLE_EXTRACTORS = {
 					array.push(chunk);
 				}
 			}
-			/** @type {Map<string, StatsAsset>} */
+			/** @type {Map<string, PreprocessedAsset>} */
 			const assetMap = new Map();
-			/** @type {Set<StatsAsset>} */
+			/** @type {Set<PreprocessedAsset>} */
 			const assets = new Set();
 			for (const asset of compilation.getAssets()) {
-				/** @type {StatsAsset} */
+				/** @type {PreprocessedAsset} */
 				const item = {
 					...asset,
 					type: "asset",
@@ -538,7 +573,7 @@ const SIMPLE_EXTRACTORS = {
 						assets.delete(depItem);
 						depItem.type = type;
 						item.related = item.related || [];
-						/** @type StatsAsset[] */ (item.related).push(depItem);
+						item.related.push(depItem);
 					}
 				}
 			}
@@ -738,7 +773,9 @@ const SIMPLE_EXTRACTORS = {
 			let depthInCollapsedGroup = 0;
 			for (const [origin, logEntries] of compilation.logging) {
 				const debugMode = loggingDebug.some(fn => fn(origin));
+				/** @type {KnownStatsLoggingEntry[]} */
 				const groupStack = [];
+				/** @type {KnownStatsLoggingEntry[]} */
 				const rootList = [];
 				let currentList = rootList;
 				let processedLogEntries = 0;
@@ -772,6 +809,7 @@ const SIMPLE_EXTRACTORS = {
 					} else if (entry.args && entry.args.length > 0) {
 						message = util.format(entry.args[0], ...entry.args.slice(1));
 					}
+					/** @type {KnownStatsLoggingEntry} */
 					const newEntry = {
 						...entry,
 						type,
@@ -867,9 +905,7 @@ const SIMPLE_EXTRACTORS = {
 				c => Array.from(c.idNameHints),
 				compareIds
 			);
-			object.filteredRelated = asset.related
-				? /** @type StatsAsset[] */ (asset.related).length
-				: undefined;
+			object.filteredRelated = asset.related ? asset.related.length : undefined;
 		},
 		relatedAssets: (object, asset, context, options, factory) => {
 			const { type } = context;
@@ -879,8 +915,7 @@ const SIMPLE_EXTRACTORS = {
 				context
 			);
 			object.filteredRelated = asset.related
-				? /** @type StatsAsset[] */ (asset.related).length -
-				  /** @type StatsAsset[] */ (object.related).length
+				? asset.related.length - object.related.length
 				: undefined;
 		},
 		ids: (
@@ -933,7 +968,7 @@ const SIMPLE_EXTRACTORS = {
 			).map(toAsset);
 			const assetsSize = assets.reduce(sizeReducer, 0);
 			const auxiliaryAssetsSize = auxiliaryAssets.reduce(sizeReducer, 0);
-			/** @type StatsChunkGroup */
+			/** @type {KnownStatsChunkGroup} */
 			const statsChunkGroup = {
 				name,
 				chunks: ids ? chunkGroup.chunks.map(c => c.id) : undefined,
@@ -962,7 +997,7 @@ const SIMPLE_EXTRACTORS = {
 									compareIds
 								).map(toAsset);
 
-								/** @type StatsChunkGroup */
+								/** @type {KnownStatsChunkGroup} */
 								const childStatsChunkGroup = {
 									name: group.name,
 									chunks: ids ? group.chunks.map(c => c.id) : undefined,
@@ -1017,7 +1052,7 @@ const SIMPLE_EXTRACTORS = {
 			for (const sourceType of module.getSourceTypes()) {
 				sizes[sourceType] = module.size(sourceType);
 			}
-			/** @type StatsModule */
+			/** @type {KnownStatsModule} */
 			const statsModule = {
 				type: "module",
 				moduleType: module.type,
@@ -1062,7 +1097,7 @@ const SIMPLE_EXTRACTORS = {
 			for (const sourceType of module.getSourceTypes()) {
 				sizes[sourceType] = module.size(sourceType);
 			}
-			/** @type StatsModule */
+			/** @type {KnownStatsModule} */
 			const statsModule = {
 				identifier: module.identifier(),
 				name: module.readableIdentifier(requestShortener),
@@ -1182,7 +1217,7 @@ const SIMPLE_EXTRACTORS = {
 	},
 	profile: {
 		_: (object, profile) => {
-			/** @type StatsProfile */
+			/** @type {KnownStatsProfile} */
 			const statsProfile = {
 				total:
 					profile.factory +
@@ -1210,7 +1245,7 @@ const SIMPLE_EXTRACTORS = {
 			const { compilation, type } = context;
 			const { moduleGraph } = compilation;
 			const profile = moduleGraph.getProfile(module);
-			/** @type StatsModuleIssuer */
+			/** @type {KnownStatsModuleIssuer} */
 			const statsModuleIssuer = {
 				identifier: module.identifier(),
 				name: module.readableIdentifier(requestShortener)
@@ -1229,7 +1264,7 @@ const SIMPLE_EXTRACTORS = {
 			const dep = reason.dependency;
 			const moduleDep =
 				dep && dep instanceof ModuleDependency ? dep : undefined;
-			/** @type StatsModuleReason */
+			/** @type {KnownStatsModuleReason} */
 			const statsModuleReason = {
 				moduleIdentifier: reason.originModule
 					? reason.originModule.identifier()
@@ -1272,7 +1307,7 @@ const SIMPLE_EXTRACTORS = {
 		_: (object, chunk, { makePathsRelative, compilation: { chunkGraph } }) => {
 			const childIdByOrder = chunk.getChildIdsByOrders(chunkGraph);
 
-			/** @type StatsChunk */
+			/** @type {KnownStatsChunk} */
 			const statsChunk = {
 				rendered: chunk.rendered,
 				initial: chunk.canBeInitial(),
@@ -1367,7 +1402,7 @@ const SIMPLE_EXTRACTORS = {
 	},
 	chunkOrigin: {
 		_: (object, origin, context, { requestShortener }) => {
-			/** @type StatsChunkOrigin */
+			/** @type {KnownStatsChunkOrigin} */
 			const statsChunkOrigin = {
 				module: origin.module ? origin.module.identifier() : "",
 				moduleIdentifier: origin.module ? origin.module.identifier() : "",

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -44,27 +44,238 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
 /** @typedef {import("./StatsFactory")} StatsFactory */
 /** @typedef {import("./StatsFactory").StatsFactoryContext} StatsFactoryContext */
 
-/** @typedef {Asset & { type: string, related: ExtendedAsset[] }} ExtendedAsset */
+/**
+ * @typedef {Object} StatsCompilation
+ * @property {any=} env
+ * @property {string=} name
+ * @property {string=} hash
+ * @property {string=} version
+ * @property {number=} time
+ * @property {number=} builtAt
+ * @property {boolean=} needAdditionalPass
+ * @property {string=} publicPath
+ * @property {string=} outputPath
+ * @property {Record<string, string[]>=} assetsByChunkName
+ * @property {StatsAsset[]=} assets
+ * @property {number=} filteredAssets
+ * @property {StatsChunk[]=} chunks
+ * @property {StatsModule[]=} modules
+ * @property {number=} filteredModules
+ * @property {Record<string, StatsChunkGroup>=} entrypoints
+ * @property {Record<string, StatsChunkGroup>=} namedChunkGroups
+ * @property {StatsError[]=} errors
+ * @property {number=} errorsCount
+ * @property {StatsError[]=} warnings
+ * @property {number=} warningsCount
+ * @property {StatsCompilation[]=} children
+ * @property {any=} logging
+ */
 
-/** @template T @typedef {Record<string, (object: Object, data: T, context: StatsFactoryContext, options: NormalizedStatsOptions, factory: StatsFactory) => void>} ExtractorsByOption */
+/**
+ * @typedef {Partial<Asset> & {
+ * type: string,
+ * size?: number,
+ * related?: StatsAsset[] | {}, // TODO fix empty resolving as {}
+ * chunkNames?: (string|number)[],
+ * chunkIdHints?: (string|number)[],
+ * chunks?: (string|number)[],
+ * auxiliaryChunkNames?: (string|number)[],
+ * auxiliaryChunks?: (string|number)[],
+ * auxiliaryChunkIdHints?: (string|number)[],
+ * emitted?: boolean,
+ * comparedForEmit?: boolean,
+ * cached?: boolean,
+ * filteredRelated?: number,
+ * isOverSizeLimit?: boolean
+ * }} StatsAsset
+ */
+
+/**
+ * @typedef {Object} StatsChunkGroup
+ * @property {string=} name
+ * @property {(string|number)[]=} chunks
+ * @property {({ name: string, size?: number })[]=} assets
+ * @property {number=} filteredAssets
+ * @property {number=} assetsSize
+ * @property {({ name: string, size?: number })[]=} auxiliaryAssets
+ * @property {number=} filteredAuxiliaryAssets
+ * @property {number=} auxiliaryAssetsSize
+ * @property {{ [x: string]: StatsChunkGroup[] }=} children
+ * @property {{ [x: string]: string[] }=} childAssets
+ * @property {boolean=} isOverSizeLimit
+ */
+
+/**
+ * @typedef {Object} StatsModule
+ * @property {string=} type
+ * @property {string=} moduleType
+ * @property {string=} layer
+ * @property {string=} identifier
+ * @property {string=} name
+ * @property {string=} nameForCondition
+ * @property {number=} index
+ * @property {number=} preOrderIndex
+ * @property {number=} index2
+ * @property {number=} postOrderIndex
+ * @property {number=} size
+ * @property {{[x: string]: number}=} sizes
+ * @property {boolean=} cacheable
+ * @property {boolean=} built
+ * @property {boolean=} codeGenerated
+ * @property {boolean=} cached
+ * @property {boolean=} optional
+ * @property {boolean=} orphan
+ * @property {string|number=} id
+ * @property {string|number=} issuerId
+ * @property {(string|number)[]=} chunks
+ * @property {(string|number)[]=} assets
+ * @property {boolean=} dependent
+ * @property {string=} issuer
+ * @property {string=} issuerName
+ * @property {StatsModuleIssuer[]=} issuerPath
+ * @property {boolean=} failed
+ * @property {number=} errors
+ * @property {number=} warnings
+ * @property {StatsProfile=} profile
+ * @property {StatsModuleReason[]=} reasons
+ * @property {(boolean | string[])=} usedExports
+ * @property {string[]=} providedExports
+ * @property {string[]=} optimizationBailout
+ * @property {number=} depth
+ * @property {StatsModule[]=} modules
+ * @property {number=} filteredModules
+ * @property {ReturnType<Source["source"]>=} source
+ */
+
+/**
+ * @typedef {Object} StatsProfile
+ * @property {number} total
+ * @property {number} resolving
+ * @property {number} restoring
+ * @property {number} building
+ * @property {number} integration
+ * @property {number} storing
+ * @property {number} additionalResolving
+ * @property {number} additionalIntegration
+ * @property {number} factory
+ * @property {number} dependencies
+ */
+
+/**
+ * @typedef {Object} StatsModuleIssuer
+ * @property {string=} identifier
+ * @property {string=} name
+ * @property {(string|number)=} id
+ * @property {StatsProfile=} profile
+ */
+
+/**
+ * @typedef {Object} StatsModuleReason
+ * @property {string=} moduleIdentifier
+ * @property {string=} module
+ * @property {string=} moduleName
+ * @property {string=} resolvedModuleIdentifier
+ * @property {string=} resolvedModule
+ * @property {string=} type
+ * @property {boolean} active
+ * @property {string=} explanation
+ * @property {string=} userRequest
+ * @property {string=} loc
+ * @property {(string|number)=} moduleId
+ * @property {(string|number)=} resolvedModuleId
+ */
+
+/**
+ * @typedef {Object} StatsChunk
+ * @property {boolean} rendered
+ * @property {boolean} initial
+ * @property {boolean} entry
+ * @property {boolean} recorded
+ * @property {string=} reason
+ * @property {number} size
+ * @property {Record<string, number>=} sizes
+ * @property {string[]=} names
+ * @property {string[]=} idHints
+ * @property {string[]=} runtime
+ * @property {string[]=} files
+ * @property {string[]=} auxiliaryFiles
+ * @property {string} hash
+ * @property {Record<string, (string|number)[]>=} childrenByOrder
+ * @property {(string|number)=} id
+ * @property {(string|number)[]=} siblings
+ * @property {(string|number)[]=} parents
+ * @property {(string|number)[]=} children
+ * @property {StatsModule[]=} modules
+ * @property {number=} filteredModules
+ * @property {StatsChunkOrigin[]=} origins
+ */
+
+/**
+ * @typedef {Object} StatsChunkOrigin
+ * @property {string=} module
+ * @property {string=} moduleIdentifier
+ * @property {string=} moduleName
+ * @property {string=} loc
+ * @property {string=} request
+ * @property {(string|number)=} moduleId
+ */
+
+/**
+ * @typedef {Object} StatsModuleTraceItem
+ * @property {string=} originIdentifier
+ * @property {string=} originName
+ * @property {string=} moduleIdentifier
+ * @property {string=} moduleName
+ * @property {StatsModuleTraceDependency[]=} dependencies
+ * @property {(string|number)=} originId
+ * @property {(string|number)=} moduleId
+ */
+
+/**
+ * @typedef {Object} StatsModuleTraceDependency
+ * @property {string=} loc
+ */
+
+/**
+ * @typedef {Object} StatsError
+ * @property {string} message
+ * @property {string=} chunkName
+ * @property {boolean=} chunkEntry
+ * @property {boolean=} chunkInitial
+ * @property {string=} file
+ * @property {string=} moduleIdentifier
+ * @property {string=} moduleName
+ * @property {string=} loc
+ * @property {string|number=} chunkId
+ * @property {string|number=} moduleId
+ * @property {any=} moduleTrace
+ * @property {any=} details
+ * @property {any=} stack
+ */
+
+/**
+ * @template T
+ * @template O
+ * @typedef {Record<string, (object: O, data: T, context: StatsFactoryContext, options: NormalizedStatsOptions, factory: StatsFactory) => void>} ExtractorsByOption
+ */
 
 /**
  * @typedef {Object} SimpleExtractors
- * @property {ExtractorsByOption<Compilation>} compilation
- * @property {ExtractorsByOption<ExtendedAsset>} asset
- * @property {ExtractorsByOption<ExtendedAsset>} asset$visible
- * @property {ExtractorsByOption<{ name: string, chunkGroup: ChunkGroup }>} chunkGroup
- * @property {ExtractorsByOption<Module>} module
- * @property {ExtractorsByOption<Module>} module$visible
- * @property {ExtractorsByOption<Module>} moduleIssuer
- * @property {ExtractorsByOption<ModuleProfile>} profile
- * @property {ExtractorsByOption<ModuleGraphConnection>} moduleReason
- * @property {ExtractorsByOption<Chunk>} chunk
- * @property {ExtractorsByOption<OriginRecord>} chunkOrigin
- * @property {ExtractorsByOption<WebpackError>} error
- * @property {ExtractorsByOption<WebpackError>} warning
- * @property {ExtractorsByOption<{ origin: Module, module: Module }>} moduleTraceItem
- * @property {ExtractorsByOption<Dependency>} moduleTraceDependency
+ * @property {ExtractorsByOption<Compilation, StatsCompilation>} compilation
+ * @property {ExtractorsByOption<StatsAsset, StatsAsset>} asset
+ * @property {ExtractorsByOption<StatsAsset, StatsAsset>} asset$visible
+ * @property {ExtractorsByOption<{ name: string, chunkGroup: ChunkGroup }, StatsChunkGroup>} chunkGroup
+ * @property {ExtractorsByOption<Module, StatsModule>} module
+ * @property {ExtractorsByOption<Module, StatsModule>} module$visible
+ * @property {ExtractorsByOption<Module, StatsModuleIssuer>} moduleIssuer
+ * @property {ExtractorsByOption<ModuleProfile, StatsProfile>} profile
+ * @property {ExtractorsByOption<ModuleGraphConnection, StatsModuleReason>} moduleReason
+ * @property {ExtractorsByOption<Chunk, StatsChunk>} chunk
+ * @property {ExtractorsByOption<OriginRecord, StatsChunkOrigin>} chunkOrigin
+ * @property {ExtractorsByOption<WebpackError, StatsError>} error
+ * @property {ExtractorsByOption<WebpackError, StatsError>} warning
+ * @property {ExtractorsByOption<{ origin: Module, module: Module }, StatsModuleTraceItem>} moduleTraceItem
+ * @property {ExtractorsByOption<Dependency, StatsModuleTraceDependency>} moduleTraceDependency
  */
 
 /**
@@ -141,7 +352,7 @@ const countWithChildren = (compilation, getItems) => {
 	return count;
 };
 
-/** @type {ExtractorsByOption<WebpackError | string>} */
+/** @type {ExtractorsByOption<WebpackError | string, StatsError>} */
 const EXTRACT_ERROR = {
 	_: (object, error, context, { requestShortener }) => {
 		// TODO webpack 6 disallow strings in the errors/warnings list
@@ -299,10 +510,12 @@ const SIMPLE_EXTRACTORS = {
 					array.push(chunk);
 				}
 			}
-			/** @type {Map<string, ExtendedAsset>} */
+			/** @type {Map<string, StatsAsset>} */
 			const assetMap = new Map();
+			/** @type {Set<StatsAsset>} */
 			const assets = new Set();
 			for (const asset of compilation.getAssets()) {
+				/** @type {StatsAsset} */
 				const item = {
 					...asset,
 					type: "asset",
@@ -325,7 +538,7 @@ const SIMPLE_EXTRACTORS = {
 						assets.delete(depItem);
 						depItem.type = type;
 						item.related = item.related || [];
-						item.related.push(depItem);
+						/** @type StatsAsset[] */ (item.related).push(depItem);
 					}
 				}
 			}
@@ -654,7 +867,9 @@ const SIMPLE_EXTRACTORS = {
 				c => Array.from(c.idNameHints),
 				compareIds
 			);
-			object.filteredRelated = asset.related ? asset.related.length : undefined;
+			object.filteredRelated = asset.related
+				? /** @type StatsAsset[] */ (asset.related).length
+				: undefined;
 		},
 		relatedAssets: (object, asset, context, options, factory) => {
 			const { type } = context;
@@ -664,7 +879,8 @@ const SIMPLE_EXTRACTORS = {
 				context
 			);
 			object.filteredRelated = asset.related
-				? asset.related.length - object.related.length
+				? /** @type StatsAsset[] */ (asset.related).length -
+				  /** @type StatsAsset[] */ (object.related).length
 				: undefined;
 		},
 		ids: (
@@ -696,6 +912,10 @@ const SIMPLE_EXTRACTORS = {
 			const children =
 				chunkGroupChildren &&
 				chunkGroup.getChildrenByOrders(moduleGraph, chunkGraph);
+			/**
+			 * @param {string} name Name
+			 * @returns {{ name: string, size: number }} Asset object
+			 */
 			const toAsset = name => {
 				const asset = compilation.getAsset(name);
 				return {
@@ -703,6 +923,7 @@ const SIMPLE_EXTRACTORS = {
 					size: asset ? asset.info.size : -1
 				};
 			};
+			/** @type {(total: number, asset: { size: number }) => number} */
 			const sizeReducer = (total, { size }) => total + size;
 			const assets = uniqueArray(chunkGroup.chunks, c => c.files).map(toAsset);
 			const auxiliaryAssets = uniqueOrderedArray(
@@ -712,7 +933,8 @@ const SIMPLE_EXTRACTORS = {
 			).map(toAsset);
 			const assetsSize = assets.reduce(sizeReducer, 0);
 			const auxiliaryAssetsSize = auxiliaryAssets.reduce(sizeReducer, 0);
-			Object.assign(object, {
+			/** @type StatsChunkGroup */
+			const statsChunkGroup = {
 				name,
 				chunks: ids ? chunkGroup.chunks.map(c => c.id) : undefined,
 				assets: assets.length <= chunkGroupMaxAssets ? assets : undefined,
@@ -739,7 +961,9 @@ const SIMPLE_EXTRACTORS = {
 									c => c.auxiliaryFiles,
 									compareIds
 								).map(toAsset);
-								return {
+
+								/** @type StatsChunkGroup */
+								const childStatsChunkGroup = {
 									name: group.name,
 									chunks: ids ? group.chunks.map(c => c.id) : undefined,
 									assets:
@@ -757,6 +981,8 @@ const SIMPLE_EXTRACTORS = {
 											? 0
 											: auxiliaryAssets.length
 								};
+
+								return childStatsChunkGroup;
 							})
 					  )
 					: undefined,
@@ -774,7 +1000,8 @@ const SIMPLE_EXTRACTORS = {
 							return Array.from(set);
 					  })
 					: undefined
-			});
+			};
+			Object.assign(object, statsChunkGroup);
 		},
 		performance: (object, { chunkGroup }) => {
 			object.isOverSizeLimit = SizeLimitsPlugin.isOverSizeLimit(chunkGroup);
@@ -785,11 +1012,13 @@ const SIMPLE_EXTRACTORS = {
 			const { compilation, type } = context;
 			const built = compilation.builtModules.has(module);
 			const codeGenerated = compilation.codeGeneratedModules.has(module);
+			/** @type {{[x: string]: number}} */
 			const sizes = {};
 			for (const sourceType of module.getSourceTypes()) {
 				sizes[sourceType] = module.size(sourceType);
 			}
-			Object.assign(object, {
+			/** @type StatsModule */
+			const statsModule = {
 				type: "module",
 				moduleType: module.type,
 				layer: module.layer,
@@ -798,7 +1027,9 @@ const SIMPLE_EXTRACTORS = {
 				built,
 				codeGenerated,
 				cached: !built && !codeGenerated
-			});
+			};
+			Object.assign(object, statsModule);
+
 			if (built || codeGenerated || options.cachedModules) {
 				Object.assign(
 					object,
@@ -826,11 +1057,13 @@ const SIMPLE_EXTRACTORS = {
 			const warnings = module.getWarnings();
 			const warningsCount =
 				warnings !== undefined ? countIterable(warnings) : 0;
+			/** @type {{[x: string]: number}} */
 			const sizes = {};
 			for (const sourceType of module.getSourceTypes()) {
 				sizes[sourceType] = module.size(sourceType);
 			}
-			Object.assign(object, {
+			/** @type StatsModule */
+			const statsModule = {
 				identifier: module.identifier(),
 				name: module.readableIdentifier(requestShortener),
 				nameForCondition: module.nameForCondition(),
@@ -852,7 +1085,8 @@ const SIMPLE_EXTRACTORS = {
 				failed: errorsCount > 0,
 				errors: errorsCount,
 				warnings: warningsCount
-			});
+			};
+			Object.assign(object, statsModule);
 			if (profile) {
 				object.profile = factory.create(
 					`${type.slice(0, -8)}.profile`,
@@ -948,7 +1182,8 @@ const SIMPLE_EXTRACTORS = {
 	},
 	profile: {
 		_: (object, profile) => {
-			Object.assign(object, {
+			/** @type StatsProfile */
+			const statsProfile = {
 				total:
 					profile.factory +
 					profile.restoring +
@@ -966,7 +1201,8 @@ const SIMPLE_EXTRACTORS = {
 				factory: profile.factory,
 				// TODO remove this in webpack 6
 				dependencies: profile.additionalFactories
-			});
+			};
+			Object.assign(object, statsProfile);
 		}
 	},
 	moduleIssuer: {
@@ -974,10 +1210,12 @@ const SIMPLE_EXTRACTORS = {
 			const { compilation, type } = context;
 			const { moduleGraph } = compilation;
 			const profile = moduleGraph.getProfile(module);
-			Object.assign(object, {
+			/** @type StatsModuleIssuer */
+			const statsModuleIssuer = {
 				identifier: module.identifier(),
 				name: module.readableIdentifier(requestShortener)
-			});
+			};
+			Object.assign(object, statsModuleIssuer);
 			if (profile) {
 				object.profile = factory.create(`${type}.profile`, profile, context);
 			}
@@ -991,7 +1229,8 @@ const SIMPLE_EXTRACTORS = {
 			const dep = reason.dependency;
 			const moduleDep =
 				dep && dep instanceof ModuleDependency ? dep : undefined;
-			Object.assign(object, {
+			/** @type StatsModuleReason */
+			const statsModuleReason = {
 				moduleIdentifier: reason.originModule
 					? reason.originModule.identifier()
 					: null,
@@ -1011,7 +1250,8 @@ const SIMPLE_EXTRACTORS = {
 				active: reason.isActive(runtime),
 				explanation: reason.explanation,
 				userRequest: (moduleDep && moduleDep.userRequest) || null
-			});
+			};
+			Object.assign(object, statsModuleReason);
 			if (reason.dependency) {
 				const locInfo = formatLocation(reason.dependency.loc);
 				if (locInfo) {
@@ -1032,7 +1272,8 @@ const SIMPLE_EXTRACTORS = {
 		_: (object, chunk, { makePathsRelative, compilation: { chunkGraph } }) => {
 			const childIdByOrder = chunk.getChildIdsByOrders(chunkGraph);
 
-			Object.assign(object, {
+			/** @type StatsChunk */
+			const statsChunk = {
 				rendered: chunk.rendered,
 				initial: chunk.canBeInitial(),
 				entry: chunk.hasRuntime(),
@@ -1052,7 +1293,8 @@ const SIMPLE_EXTRACTORS = {
 				auxiliaryFiles: Array.from(chunk.auxiliaryFiles).sort(compareIds),
 				hash: chunk.renderedHash,
 				childrenByOrder: childIdByOrder
-			});
+			};
+			Object.assign(object, statsChunk);
 		},
 		ids: (object, chunk) => {
 			object.id = chunk.id;
@@ -1125,7 +1367,8 @@ const SIMPLE_EXTRACTORS = {
 	},
 	chunkOrigin: {
 		_: (object, origin, context, { requestShortener }) => {
-			Object.assign(object, {
+			/** @type StatsChunkOrigin */
+			const statsChunkOrigin = {
 				module: origin.module ? origin.module.identifier() : "",
 				moduleIdentifier: origin.module ? origin.module.identifier() : "",
 				moduleName: origin.module
@@ -1133,7 +1376,8 @@ const SIMPLE_EXTRACTORS = {
 					: "",
 				loc: formatLocation(origin.loc),
 				request: origin.request
-			});
+			};
+			Object.assign(object, statsChunkOrigin);
 		},
 		ids: (object, origin, { compilation: { chunkGraph } }) => {
 			object.moduleId = origin.module
@@ -1810,6 +2054,7 @@ const sortByField = field => {
 };
 
 const ASSET_SORTERS = {
+	/** @type {(comparators: Function[], context: StatsFactoryContext, options: NormalizedStatsOptions) => void} */
 	assetsSort: (comparators, context, { assetsSort }) => {
 		comparators.push(sortByField(assetsSort));
 	},

--- a/lib/stats/DefaultStatsPrinterPlugin.js
+++ b/lib/stats/DefaultStatsPrinterPlugin.js
@@ -321,7 +321,8 @@ const SIMPLE_PRINTERS = {
 					: null;
 				if (
 					providedExportsCount !== null &&
-					providedExportsCount === module.usedExports.length
+					providedExportsCount ===
+						/** @type string[] */ (module.usedExports).length
 				) {
 					return cyan(formatFlag("all exports used"));
 				} else {

--- a/lib/stats/DefaultStatsPrinterPlugin.js
+++ b/lib/stats/DefaultStatsPrinterPlugin.js
@@ -321,8 +321,7 @@ const SIMPLE_PRINTERS = {
 					: null;
 				if (
 					providedExportsCount !== null &&
-					providedExportsCount ===
-						/** @type string[] */ (module.usedExports).length
+					providedExportsCount === usedExports.length
 				) {
 					return cyan(formatFlag("all exports used"));
 				} else {

--- a/lib/stats/StatsPrinter.js
+++ b/lib/stats/StatsPrinter.js
@@ -9,6 +9,12 @@ const { HookMap, SyncWaterfallHook, SyncBailHook } = require("tapable");
 
 /** @template T @typedef {import("tapable").AsArray<T>} AsArray<T> */
 /** @typedef {import("tapable").Hook} Hook */
+/** @typedef {import("./DefaultStatsFactoryPlugin").StatsAsset} StatsAsset */
+/** @typedef {import("./DefaultStatsFactoryPlugin").StatsChunk} StatsChunk */
+/** @typedef {import("./DefaultStatsFactoryPlugin").StatsChunkGroup} StatsChunkGroup */
+/** @typedef {import("./DefaultStatsFactoryPlugin").StatsCompilation} StatsCompilation */
+/** @typedef {import("./DefaultStatsFactoryPlugin").StatsModule} StatsModule */
+/** @typedef {import("./DefaultStatsFactoryPlugin").StatsModuleReason} StatsModuleReason */
 
 /**
  * @typedef {Object} PrintedElement
@@ -19,12 +25,12 @@ const { HookMap, SyncWaterfallHook, SyncBailHook } = require("tapable");
 /**
  * @typedef {Object} KnownStatsPrinterContext
  * @property {string=} type
- * @property {Object=} compilation
- * @property {Object=} chunkGroup
- * @property {Object=} asset
- * @property {Object=} module
- * @property {Object=} chunk
- * @property {Object=} moduleReason
+ * @property {StatsCompilation=} compilation
+ * @property {StatsChunkGroup=} chunkGroup
+ * @property {StatsAsset=} asset
+ * @property {StatsModule=} module
+ * @property {StatsChunk=} chunk
+ * @property {StatsModuleReason=} moduleReason
  * @property {(str: string) => string=} bold
  * @property {(str: string) => string=} yellow
  * @property {(str: string) => string=} red

--- a/types.d.ts
+++ b/types.d.ts
@@ -4829,6 +4829,108 @@ declare interface KnownNormalizedStatsOptions {
 	loggingDebug: Function[];
 	loggingTrace: boolean;
 }
+declare interface KnownStatsAsset {
+	type: string;
+	name: string;
+	info: AssetInfo;
+	size: number;
+	emitted: boolean;
+	comparedForEmit: boolean;
+	cached: boolean;
+	related?: StatsAsset[];
+	chunkNames?: (string | number)[];
+	chunkIdHints?: (string | number)[];
+	chunks?: (string | number)[];
+	auxiliaryChunkNames?: (string | number)[];
+	auxiliaryChunks?: (string | number)[];
+	auxiliaryChunkIdHints?: (string | number)[];
+	filteredRelated?: number;
+	isOverSizeLimit?: boolean;
+}
+declare interface KnownStatsChunk {
+	rendered: boolean;
+	initial: boolean;
+	entry: boolean;
+	recorded: boolean;
+	reason?: string;
+	size: number;
+	sizes?: Record<string, number>;
+	names?: string[];
+	idHints?: string[];
+	runtime?: string[];
+	files?: string[];
+	auxiliaryFiles?: string[];
+	hash: string;
+	childrenByOrder?: Record<string, (string | number)[]>;
+	id?: string | number;
+	siblings?: (string | number)[];
+	parents?: (string | number)[];
+	children?: (string | number)[];
+	modules?: StatsModule[];
+	filteredModules?: number;
+	origins?: StatsChunkOrigin[];
+}
+declare interface KnownStatsChunkGroup {
+	name?: string;
+	chunks?: (string | number)[];
+	assets?: { name: string; size?: number }[];
+	filteredAssets?: number;
+	assetsSize?: number;
+	auxiliaryAssets?: { name: string; size?: number }[];
+	filteredAuxiliaryAssets?: number;
+	auxiliaryAssetsSize?: number;
+	children?: { [index: string]: StatsChunkGroup[] };
+	childAssets?: { [index: string]: string[] };
+	isOverSizeLimit?: boolean;
+}
+declare interface KnownStatsChunkOrigin {
+	module?: string;
+	moduleIdentifier?: string;
+	moduleName?: string;
+	loc?: string;
+	request?: string;
+	moduleId?: string | number;
+}
+declare interface KnownStatsCompilation {
+	env?: any;
+	name?: string;
+	hash?: string;
+	version?: string;
+	time?: number;
+	builtAt?: number;
+	needAdditionalPass?: boolean;
+	publicPath?: string;
+	outputPath?: string;
+	assetsByChunkName?: Record<string, string[]>;
+	assets?: StatsAsset[];
+	filteredAssets?: number;
+	chunks?: StatsChunk[];
+	modules?: StatsModule[];
+	filteredModules?: number;
+	entrypoints?: Record<string, StatsChunkGroup>;
+	namedChunkGroups?: Record<string, StatsChunkGroup>;
+	errors?: StatsError[];
+	errorsCount?: number;
+	warnings?: StatsError[];
+	warningsCount?: number;
+	children?: StatsCompilation[];
+	logging?: Record<string, StatsLogging>;
+}
+declare interface KnownStatsError {
+	message: string;
+	chunkName?: string;
+	chunkEntry?: boolean;
+	chunkInitial?: boolean;
+	file?: string;
+	moduleIdentifier?: string;
+	moduleName?: string;
+	loc?: string;
+	chunkId?: string | number;
+	moduleId?: string | number;
+	moduleTrace?: any;
+	details?: any;
+	stack?: any;
+}
 declare interface KnownStatsFactoryContext {
 	type: string;
 	makePathsRelative?: (arg0: string) => string;
@@ -4839,6 +4941,79 @@ declare interface KnownStatsFactoryContext {
 	runtime?: RuntimeSpec;
 	cachedGetErrors?: (arg0: Compilation) => WebpackError[];
 	cachedGetWarnings?: (arg0: Compilation) => WebpackError[];
+}
+declare interface KnownStatsLogging {
+	entries: StatsLoggingEntry[];
+	filteredEntries: number;
+	debug: boolean;
+}
+declare interface KnownStatsLoggingEntry {
+	type: string;
+	message: string;
+	trace?: string[];
+	children?: StatsLoggingEntry[];
+	args?: any[];
+	time?: number;
+}
+declare interface KnownStatsModule {
+	type?: string;
+	moduleType?: string;
+	layer?: string;
+	identifier?: string;
+	name?: string;
+	nameForCondition?: string;
+	index?: number;
+	preOrderIndex?: number;
+	index2?: number;
+	postOrderIndex?: number;
+	size?: number;
+	sizes?: { [index: string]: number };
+	cacheable?: boolean;
+	built?: boolean;
+	codeGenerated?: boolean;
+	cached?: boolean;
+	optional?: boolean;
+	orphan?: boolean;
+	id?: string | number;
+	issuerId?: string | number;
+	chunks?: (string | number)[];
+	assets?: (string | number)[];
+	dependent?: boolean;
+	issuer?: string;
+	issuerName?: string;
+	issuerPath?: StatsModuleIssuer[];
+	failed?: boolean;
+	errors?: number;
+	warnings?: number;
+	profile?: StatsProfile;
+	reasons?: StatsModuleReason[];
+	usedExports?: boolean | string[];
+	providedExports?: string[];
+	optimizationBailout?: string[];
+	depth?: number;
+	modules?: StatsModule[];
+	filteredModules?: number;
+	source?: string | Buffer;
+}
+declare interface KnownStatsModuleIssuer {
+	identifier?: string;
+	name?: string;
+	id?: string | number;
+	profile?: StatsProfile;
+}
+declare interface KnownStatsModuleReason {
+	moduleIdentifier?: string;
+	module?: string;
+	moduleName?: string;
+	resolvedModuleIdentifier?: string;
+	resolvedModule?: string;
+	type?: string;
+	active: boolean;
+	explanation?: string;
+	userRequest?: string;
+	loc?: string;
+	moduleId?: string | number;
+	resolvedModuleId?: string | number;
 }
 declare interface KnownStatsPrinterContext {
 	type?: string;
@@ -4865,6 +5040,18 @@ declare interface KnownStatsPrinterContext {
 	formatFlag?: (flag: string) => string;
 	formatTime?: (time: number, boldQuantity?: boolean) => string;
 	chunkGroupKind?: string;
+}
+declare interface KnownStatsProfile {
+	total: number;
+	resolving: number;
+	restoring: number;
+	building: number;
+	integration: number;
+	storing: number;
+	additionalResolving: number;
+	additionalIntegration: number;
+	factory: number;
+	dependencies: number;
 }
 declare class LazySet<T> {
 	constructor(iterable?: Iterable<T>);
@@ -9459,106 +9646,12 @@ declare class Stats {
 	toJson(options?: string | StatsOptions): StatsCompilation;
 	toString(options?: any): string;
 }
-type StatsAsset = Partial<Asset> & {
-	type: string;
-	size?: number;
-	related?: {} | StatsAsset[];
-	chunkNames?: (string | number)[];
-	chunkIdHints?: (string | number)[];
-	chunks?: (string | number)[];
-	auxiliaryChunkNames?: (string | number)[];
-	auxiliaryChunks?: (string | number)[];
-	auxiliaryChunkIdHints?: (string | number)[];
-	emitted?: boolean;
-	comparedForEmit?: boolean;
-	cached?: boolean;
-	filteredRelated?: number;
-	isOverSizeLimit?: boolean;
-};
-declare interface StatsChunk {
-	rendered: boolean;
-	initial: boolean;
-	entry: boolean;
-	recorded: boolean;
-	reason?: string;
-	size: number;
-	sizes?: Record<string, number>;
-	names?: string[];
-	idHints?: string[];
-	runtime?: string[];
-	files?: string[];
-	auxiliaryFiles?: string[];
-	hash: string;
-	childrenByOrder?: Record<string, (string | number)[]>;
-	id?: string | number;
-	siblings?: (string | number)[];
-	parents?: (string | number)[];
-	children?: (string | number)[];
-	modules?: StatsModule[];
-	filteredModules?: number;
-	origins?: StatsChunkOrigin[];
-}
-declare interface StatsChunkGroup {
-	name?: string;
-	chunks?: (string | number)[];
-	assets?: { name: string; size?: number }[];
-	filteredAssets?: number;
-	assetsSize?: number;
-	auxiliaryAssets?: { name: string; size?: number }[];
-	filteredAuxiliaryAssets?: number;
-	auxiliaryAssetsSize?: number;
-	children?: { [index: string]: StatsChunkGroup[] };
-	childAssets?: { [index: string]: string[] };
-	isOverSizeLimit?: boolean;
-}
-declare interface StatsChunkOrigin {
-	module?: string;
-	moduleIdentifier?: string;
-	moduleName?: string;
-	loc?: string;
-	request?: string;
-	moduleId?: string | number;
-}
-declare interface StatsCompilation {
-	env?: any;
-	name?: string;
-	hash?: string;
-	version?: string;
-	time?: number;
-	builtAt?: number;
-	needAdditionalPass?: boolean;
-	publicPath?: string;
-	outputPath?: string;
-	assetsByChunkName?: Record<string, string[]>;
-	assets?: StatsAsset[];
-	filteredAssets?: number;
-	chunks?: StatsChunk[];
-	modules?: StatsModule[];
-	filteredModules?: number;
-	entrypoints?: Record<string, StatsChunkGroup>;
-	namedChunkGroups?: Record<string, StatsChunkGroup>;
-	errors?: StatsError[];
-	errorsCount?: number;
-	warnings?: StatsError[];
-	warningsCount?: number;
-	children?: StatsCompilation[];
-	logging?: any;
-}
-declare interface StatsError {
-	message: string;
-	chunkName?: string;
-	chunkEntry?: boolean;
-	chunkInitial?: boolean;
-	file?: string;
-	moduleIdentifier?: string;
-	moduleName?: string;
-	loc?: string;
-	chunkId?: string | number;
-	moduleId?: string | number;
-	moduleTrace?: any;
-	details?: any;
-	stack?: any;
-}
+type StatsAsset = KnownStatsAsset & Record<string, any>;
+type StatsChunk = KnownStatsChunk & Record<string, any>;
+type StatsChunkGroup = KnownStatsChunkGroup & Record<string, any>;
+type StatsChunkOrigin = KnownStatsChunkOrigin & Record<string, any>;
+type StatsCompilation = KnownStatsCompilation & Record<string, any>;
+type StatsError = KnownStatsError & Record<string, any>;
 declare abstract class StatsFactory {
 	hooks: Readonly<{
 		extract: HookMap<SyncBailHook<[Object, any, StatsFactoryContext], any>>;
@@ -9598,66 +9691,11 @@ declare abstract class StatsFactory {
 	): any;
 }
 type StatsFactoryContext = KnownStatsFactoryContext & Record<string, any>;
-declare interface StatsModule {
-	type?: string;
-	moduleType?: string;
-	layer?: string;
-	identifier?: string;
-	name?: string;
-	nameForCondition?: string;
-	index?: number;
-	preOrderIndex?: number;
-	index2?: number;
-	postOrderIndex?: number;
-	size?: number;
-	sizes?: { [index: string]: number };
-	cacheable?: boolean;
-	built?: boolean;
-	codeGenerated?: boolean;
-	cached?: boolean;
-	optional?: boolean;
-	orphan?: boolean;
-	id?: string | number;
-	issuerId?: string | number;
-	chunks?: (string | number)[];
-	assets?: (string | number)[];
-	dependent?: boolean;
-	issuer?: string;
-	issuerName?: string;
-	issuerPath?: StatsModuleIssuer[];
-	failed?: boolean;
-	errors?: number;
-	warnings?: number;
-	profile?: StatsProfile;
-	reasons?: StatsModuleReason[];
-	usedExports?: boolean | string[];
-	providedExports?: string[];
-	optimizationBailout?: string[];
-	depth?: number;
-	modules?: StatsModule[];
-	filteredModules?: number;
-	source?: string | Buffer;
-}
-declare interface StatsModuleIssuer {
-	identifier?: string;
-	name?: string;
-	id?: string | number;
-	profile?: StatsProfile;
-}
-declare interface StatsModuleReason {
-	moduleIdentifier?: string;
-	module?: string;
-	moduleName?: string;
-	resolvedModuleIdentifier?: string;
-	resolvedModule?: string;
-	type?: string;
-	active: boolean;
-	explanation?: string;
-	userRequest?: string;
-	loc?: string;
-	moduleId?: string | number;
-	resolvedModuleId?: string | number;
-}
+type StatsLogging = KnownStatsLogging & Record<string, any>;
+type StatsLoggingEntry = KnownStatsLoggingEntry & Record<string, any>;
+type StatsModule = KnownStatsModule & Record<string, any>;
+type StatsModuleIssuer = KnownStatsModuleIssuer & Record<string, any>;
+type StatsModuleReason = KnownStatsModuleReason & Record<string, any>;
 
 /**
  * Stats options object.
@@ -10088,18 +10126,7 @@ declare abstract class StatsPrinter {
 	print(type: string, object: Object, baseContext?: Object): string;
 }
 type StatsPrinterContext = KnownStatsPrinterContext & Record<string, any>;
-declare interface StatsProfile {
-	total: number;
-	resolving: number;
-	restoring: number;
-	building: number;
-	integration: number;
-	storing: number;
-	additionalResolving: number;
-	additionalIntegration: number;
-	factory: number;
-	dependencies: number;
-}
+type StatsProfile = KnownStatsProfile & Record<string, any>;
 type StatsValue =
 	| boolean
 	| "none"
@@ -11174,7 +11201,8 @@ declare namespace exports {
 		WebpackPluginInstance,
 		Asset,
 		AssetInfo,
-		ParserState
+		ParserState,
+		StatsCompilation
 	};
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -4842,12 +4842,12 @@ declare interface KnownStatsFactoryContext {
 }
 declare interface KnownStatsPrinterContext {
 	type?: string;
-	compilation?: Object;
-	chunkGroup?: Object;
-	asset?: Object;
-	module?: Object;
-	chunk?: Object;
-	moduleReason?: Object;
+	compilation?: StatsCompilation;
+	chunkGroup?: StatsChunkGroup;
+	asset?: StatsAsset;
+	module?: StatsModule;
+	chunk?: StatsChunk;
+	moduleReason?: StatsModuleReason;
 	bold?: (str: string) => string;
 	yellow?: (str: string) => string;
 	red?: (str: string) => string;
@@ -5914,17 +5914,7 @@ declare abstract class MultiStats {
 	readonly hash: string;
 	hasErrors(): boolean;
 	hasWarnings(): boolean;
-	toJson(
-		options?: any
-	): {
-		children: any[];
-		version: any;
-		hash: string;
-		errors: any[];
-		warnings: any[];
-		errorsCount: number;
-		warningsCount: number;
-	};
+	toJson(options?: any): StatsCompilation;
 	toString(options?: any): string;
 }
 declare abstract class MultiWatching {
@@ -9466,8 +9456,108 @@ declare class Stats {
 	readonly endTime: any;
 	hasWarnings(): boolean;
 	hasErrors(): boolean;
-	toJson(options?: any): any;
+	toJson(options?: string | StatsOptions): StatsCompilation;
 	toString(options?: any): string;
+}
+type StatsAsset = Partial<Asset> & {
+	type: string;
+	size?: number;
+	related?: {} | StatsAsset[];
+	chunkNames?: (string | number)[];
+	chunkIdHints?: (string | number)[];
+	chunks?: (string | number)[];
+	auxiliaryChunkNames?: (string | number)[];
+	auxiliaryChunks?: (string | number)[];
+	auxiliaryChunkIdHints?: (string | number)[];
+	emitted?: boolean;
+	comparedForEmit?: boolean;
+	cached?: boolean;
+	filteredRelated?: number;
+	isOverSizeLimit?: boolean;
+};
+declare interface StatsChunk {
+	rendered: boolean;
+	initial: boolean;
+	entry: boolean;
+	recorded: boolean;
+	reason?: string;
+	size: number;
+	sizes?: Record<string, number>;
+	names?: string[];
+	idHints?: string[];
+	runtime?: string[];
+	files?: string[];
+	auxiliaryFiles?: string[];
+	hash: string;
+	childrenByOrder?: Record<string, (string | number)[]>;
+	id?: string | number;
+	siblings?: (string | number)[];
+	parents?: (string | number)[];
+	children?: (string | number)[];
+	modules?: StatsModule[];
+	filteredModules?: number;
+	origins?: StatsChunkOrigin[];
+}
+declare interface StatsChunkGroup {
+	name?: string;
+	chunks?: (string | number)[];
+	assets?: { name: string; size?: number }[];
+	filteredAssets?: number;
+	assetsSize?: number;
+	auxiliaryAssets?: { name: string; size?: number }[];
+	filteredAuxiliaryAssets?: number;
+	auxiliaryAssetsSize?: number;
+	children?: { [index: string]: StatsChunkGroup[] };
+	childAssets?: { [index: string]: string[] };
+	isOverSizeLimit?: boolean;
+}
+declare interface StatsChunkOrigin {
+	module?: string;
+	moduleIdentifier?: string;
+	moduleName?: string;
+	loc?: string;
+	request?: string;
+	moduleId?: string | number;
+}
+declare interface StatsCompilation {
+	env?: any;
+	name?: string;
+	hash?: string;
+	version?: string;
+	time?: number;
+	builtAt?: number;
+	needAdditionalPass?: boolean;
+	publicPath?: string;
+	outputPath?: string;
+	assetsByChunkName?: Record<string, string[]>;
+	assets?: StatsAsset[];
+	filteredAssets?: number;
+	chunks?: StatsChunk[];
+	modules?: StatsModule[];
+	filteredModules?: number;
+	entrypoints?: Record<string, StatsChunkGroup>;
+	namedChunkGroups?: Record<string, StatsChunkGroup>;
+	errors?: StatsError[];
+	errorsCount?: number;
+	warnings?: StatsError[];
+	warningsCount?: number;
+	children?: StatsCompilation[];
+	logging?: any;
+}
+declare interface StatsError {
+	message: string;
+	chunkName?: string;
+	chunkEntry?: boolean;
+	chunkInitial?: boolean;
+	file?: string;
+	moduleIdentifier?: string;
+	moduleName?: string;
+	loc?: string;
+	chunkId?: string | number;
+	moduleId?: string | number;
+	moduleTrace?: any;
+	details?: any;
+	stack?: any;
 }
 declare abstract class StatsFactory {
 	hooks: Readonly<{
@@ -9508,6 +9598,66 @@ declare abstract class StatsFactory {
 	): any;
 }
 type StatsFactoryContext = KnownStatsFactoryContext & Record<string, any>;
+declare interface StatsModule {
+	type?: string;
+	moduleType?: string;
+	layer?: string;
+	identifier?: string;
+	name?: string;
+	nameForCondition?: string;
+	index?: number;
+	preOrderIndex?: number;
+	index2?: number;
+	postOrderIndex?: number;
+	size?: number;
+	sizes?: { [index: string]: number };
+	cacheable?: boolean;
+	built?: boolean;
+	codeGenerated?: boolean;
+	cached?: boolean;
+	optional?: boolean;
+	orphan?: boolean;
+	id?: string | number;
+	issuerId?: string | number;
+	chunks?: (string | number)[];
+	assets?: (string | number)[];
+	dependent?: boolean;
+	issuer?: string;
+	issuerName?: string;
+	issuerPath?: StatsModuleIssuer[];
+	failed?: boolean;
+	errors?: number;
+	warnings?: number;
+	profile?: StatsProfile;
+	reasons?: StatsModuleReason[];
+	usedExports?: boolean | string[];
+	providedExports?: string[];
+	optimizationBailout?: string[];
+	depth?: number;
+	modules?: StatsModule[];
+	filteredModules?: number;
+	source?: string | Buffer;
+}
+declare interface StatsModuleIssuer {
+	identifier?: string;
+	name?: string;
+	id?: string | number;
+	profile?: StatsProfile;
+}
+declare interface StatsModuleReason {
+	moduleIdentifier?: string;
+	module?: string;
+	moduleName?: string;
+	resolvedModuleIdentifier?: string;
+	resolvedModule?: string;
+	type?: string;
+	active: boolean;
+	explanation?: string;
+	userRequest?: string;
+	loc?: string;
+	moduleId?: string | number;
+	resolvedModuleId?: string | number;
+}
 
 /**
  * Stats options object.
@@ -9938,6 +10088,18 @@ declare abstract class StatsPrinter {
 	print(type: string, object: Object, baseContext?: Object): string;
 }
 type StatsPrinterContext = KnownStatsPrinterContext & Record<string, any>;
+declare interface StatsProfile {
+	total: number;
+	resolving: number;
+	restoring: number;
+	building: number;
+	integration: number;
+	storing: number;
+	additionalResolving: number;
+	additionalIntegration: number;
+	factory: number;
+	dependencies: number;
+}
 type StatsValue =
 	| boolean
 	| "none"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Add typings matching the JSON output.

Note: the types for output are defined as `Stats*` because the types are merged together into the root level `types.d.ts` which might cause issues with other definitions. I know we could use namespaces, but [I don't believe that is possible](https://github.com/microsoft/TypeScript/issues/14233) without fully converting to TypeScript itself.

**Did you add tests for your changes?**

No as it's primarily compile time based, so difficult to add tests. How I've tested this:

- Locally modified `tests/Stats.test.js` so that I captured the output of the `toJson` call into a file
- Locally apply the output to a JS file and do the type cast to verify it's correct.

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

In `@types/webpack@^4` we would originally get the structure of the JSON output as `webpack.Stats.ToJsonOutput`.
In version 5, we would now do `webpack.StatsCompilation`.