### PR TITLE
Fix #12255: compileBooleanMatcher fails when prefix and suffix overlap

### DIFF
--- a/lib/util/compileBooleanMatcher.js
+++ b/lib/util/compileBooleanMatcher.js
@@ -134,7 +134,9 @@ const itemsToRegexp = itemsArr => {
 	// special case for 2 items with common prefix/suffix
 	if (finishedItems.length === 0 && items.size === 2) {
 		const prefix = getCommonPrefix(itemsArr);
-		const suffix = getCommonSuffix(itemsArr);
+		const suffix = getCommonSuffix(
+			itemsArr.map(item => item.substring(prefix.length))
+		);
 		if (prefix.length > 0 || suffix.length > 0) {
 			return `${quoteMeta(prefix)}${itemsToRegexp(
 				itemsArr.map(i => i.slice(prefix.length, -suffix.length || undefined))

--- a/lib/util/compileBooleanMatcher.js
+++ b/lib/util/compileBooleanMatcher.js
@@ -135,7 +135,7 @@ const itemsToRegexp = itemsArr => {
 	if (finishedItems.length === 0 && items.size === 2) {
 		const prefix = getCommonPrefix(itemsArr);
 		const suffix = getCommonSuffix(
-			itemsArr.map(item => item.substring(prefix.length))
+			itemsArr.map(item => item.slice(prefix.length))
 		);
 		if (prefix.length > 0 || suffix.length > 0) {
 			return `${quoteMeta(prefix)}${itemsToRegexp(

--- a/test/compileBooleanMatcher.unittest.js
+++ b/test/compileBooleanMatcher.unittest.js
@@ -77,4 +77,16 @@ describe("itemsToRegexp", () => {
 				`(\\.\\/path\\/to\\/(directory\\/with\\/(file\\.(js(|on)|css)|module\\.css)|file\\.(|m)js|other\\-file\\.js)|webpack\\/runtime\\/module)`
 			)
 	);
+
+	expectCompiled(
+		"prefix and suffix overlap",
+		[
+			"webpack_sharing_consume_default_react_react",
+			"webpack_sharing_consume_default_classnames_classnames-webpack_sharing_consume_default_react_react"
+		],
+		e =>
+			e.toMatchInlineSnapshot(
+				`webpack_sharing_consume_default_(|classnames_classnames\\-webpack_sharing_consume_default_)react_react`
+			)
+	);
 });


### PR DESCRIPTION
See #12255 for more info.