### PR TITLE
Handle shebang/hashbang

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -183,6 +183,7 @@
     "nwjs",
     "redeclaration",
     "kaios",
+    "hashbang",
 
     "webassemblyjs",
     "fsevents",

--- a/lib/HashbangPlugin.js
+++ b/lib/HashbangPlugin.js
@@ -33,7 +33,7 @@ class HashbangPlugin {
 								) === "#!"
 						) {
 							// We usually render into a template that wraps the source in
-							// something, where hashbangs won't be valid. Remove them from
+							// something, where a hashbang won't be valid. Remove them from
 							// sources. Use BannerPlugin to add a new on to the result.
 							const dep = new ConstDependency("", firstComment.range);
 							dep.loc = firstComment.loc;

--- a/lib/HashbangPlugin.js
+++ b/lib/HashbangPlugin.js
@@ -20,26 +20,27 @@ class HashbangPlugin {
 			"HashbangPlugin",
 			(compilation, { normalModuleFactory }) => {
 				const handler = parser => {
-					parser.hooks.program.tap("HashbangPlugin", (ast, comments) => {
-						const firstComment = comments[0];
-						if (
-							firstComment &&
-							parser.state.module
-								.originalSource()
-								.source()
-								.slice(
+					parser.hooks.program.tap(
+						"HashbangPlugin",
+						(ast, comments, parsedSource) => {
+							const firstComment = comments[0];
+							if (
+								firstComment &&
+								parsedSource &&
+								parsedSource.slice(
 									firstComment.start,
 									Math.min(firstComment.start + 2, firstComment.end)
 								) === "#!"
-						) {
-							// We usually render into a template that wraps the source in
-							// something, where a hashbang won't be valid. Remove them from
-							// sources. Use BannerPlugin to add a new on to the result.
-							const dep = new ConstDependency("", firstComment.range);
-							dep.loc = firstComment.loc;
-							parser.state.module.addPresentationalDependency(dep);
+							) {
+								// We usually render into a template that wraps the source in
+								// something, where a hashbang won't be valid. Remove them from
+								// sources. Use BannerPlugin to add a new on to the result.
+								const dep = new ConstDependency("", firstComment.range);
+								dep.loc = firstComment.loc;
+								parser.state.module.addPresentationalDependency(dep);
+							}
 						}
-					});
+					);
 				};
 
 				normalModuleFactory.hooks.parser

--- a/lib/HashbangPlugin.js
+++ b/lib/HashbangPlugin.js
@@ -1,0 +1,59 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author @wh0
+*/
+
+"use strict";
+
+const ConstDependency = require("./dependencies/ConstDependency");
+
+/** @typedef {import("./Compiler")} Compiler */
+
+class HashbangPlugin {
+	/**
+	 * Apply the plugin
+	 * @param {Compiler} compiler the compiler instance
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		compiler.hooks.compilation.tap(
+			"HashbangPlugin",
+			(compilation, { normalModuleFactory }) => {
+				const handler = parser => {
+					parser.hooks.program.tap("HashbangPlugin", (ast, comments) => {
+						const firstComment = comments[0];
+						if (
+							firstComment &&
+							parser.state.module
+								.originalSource()
+								.source()
+								.slice(
+									firstComment.start,
+									Math.min(firstComment.start + 2, firstComment.end)
+								) === "#!"
+						) {
+							// We usually render into a template that wraps the source in
+							// something, where hashbangs won't be valid. Remove them from
+							// sources. Use BannerPlugin to add a new on to the result.
+							const dep = new ConstDependency("", firstComment.range);
+							dep.loc = firstComment.loc;
+							parser.state.module.addPresentationalDependency(dep);
+						}
+					});
+				};
+
+				normalModuleFactory.hooks.parser
+					.for("javascript/auto")
+					.tap("UseStrictPlugin", handler);
+				normalModuleFactory.hooks.parser
+					.for("javascript/dynamic")
+					.tap("UseStrictPlugin", handler);
+				normalModuleFactory.hooks.parser
+					.for("javascript/esm")
+					.tap("UseStrictPlugin", handler);
+			}
+		);
+	}
+}
+
+module.exports = HashbangPlugin;

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -23,6 +23,7 @@ const CompatibilityPlugin = require("./CompatibilityPlugin");
 const ConstPlugin = require("./ConstPlugin");
 const ExportsInfoApiPlugin = require("./ExportsInfoApiPlugin");
 
+const HashbangPlugin = require("./HashbangPlugin");
 const TemplatedPathPlugin = require("./TemplatedPathPlugin");
 const UseStrictPlugin = require("./UseStrictPlugin");
 const WarnCaseSensitiveModulesPlugin = require("./WarnCaseSensitiveModulesPlugin");
@@ -273,6 +274,7 @@ class WebpackOptionsApply extends OptionsApply {
 		new APIPlugin().apply(compiler);
 		new ExportsInfoApiPlugin().apply(compiler);
 		new ConstPlugin().apply(compiler);
+		new HashbangPlugin().apply(compiler);
 		new UseStrictPlugin().apply(compiler);
 		new RequireIncludePlugin().apply(compiler);
 		new RequireEnsurePlugin().apply(compiler);

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -288,8 +288,8 @@ class JavascriptParser extends Parser {
 			expressionConditionalOperator: new SyncBailHook(["expression"]),
 			/** @type {SyncBailHook<[ExpressionNode], boolean | void>} */
 			expressionLogicalOperator: new SyncBailHook(["expression"]),
-			/** @type {SyncBailHook<[ProgramNode, CommentNode[]], boolean | void>} */
-			program: new SyncBailHook(["ast", "comments"]),
+			/** @type {SyncBailHook<[ProgramNode, CommentNode[], string | undefined], boolean | void>} */
+			program: new SyncBailHook(["ast", "comments", "parsedSource"]),
 			/** @type {SyncBailHook<[ProgramNode, CommentNode[]], boolean | void>} */
 			finish: new SyncBailHook(["ast", "comments"])
 		});
@@ -3234,6 +3234,7 @@ class JavascriptParser extends Parser {
 		if (source === null) {
 			throw new Error("source must not be null");
 		}
+		let parsedSource;
 		if (Buffer.isBuffer(source)) {
 			source = source.toString("utf-8");
 		}
@@ -3242,6 +3243,7 @@ class JavascriptParser extends Parser {
 			comments = source.comments;
 		} else {
 			comments = [];
+			parsedSource = source;
 			ast = JavascriptParser._parse(source, {
 				sourceType: this.sourceType,
 				onComment: comments,
@@ -3269,7 +3271,7 @@ class JavascriptParser extends Parser {
 		this.semicolons = semicolons;
 		this.statementPath = [];
 		this.prevStatement = undefined;
-		if (this.hooks.program.call(ast, comments) === undefined) {
+		if (this.hooks.program.call(ast, comments, parsedSource) === undefined) {
 			this.detectMode(ast.body);
 			this.preWalkStatements(ast.body);
 			this.prevStatement = undefined;

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -128,6 +128,7 @@ const defaultParserOptions = {
 	ecmaVersion: "latest",
 	sourceType: "module",
 	allowAwaitOutsideFunction: true,
+	allowHashBang: true,
 	onComment: null
 };
 

--- a/test/cases/parsing/hashbang/hashbang.js
+++ b/test/cases/parsing/hashbang/hashbang.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+module.exports = "ok";

--- a/test/cases/parsing/hashbang/index.js
+++ b/test/cases/parsing/hashbang/index.js
@@ -1,0 +1,4 @@
+it("should load a file with a hashbang", function() {
+	var result = require("./hashbang");
+	expect(result).toEqual("ok");
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -4060,7 +4060,10 @@ declare class JavascriptParser extends Parser {
 		>;
 		expressionConditionalOperator: SyncBailHook<[Expression], boolean | void>;
 		expressionLogicalOperator: SyncBailHook<[Expression], boolean | void>;
-		program: SyncBailHook<[Program, Comment[]], boolean | void>;
+		program: SyncBailHook<
+			[Program, Comment[], undefined | string],
+			boolean | void
+		>;
 		finish: SyncBailHook<[Program, Comment[]], boolean | void>;
 	}>;
 	sourceType: "module" | "script" | "auto";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Fixes #4603

The above is closed, with BannerPlugin taking care of adding a shebang to the output, but the problem of handling a shebang on the input remained. A workaround with a custom loader is proposed in the discussion.

Several popular interpreters already support shebangs, and there's a proposal to formalize existing behavior in the language spec https://github.com/tc39/proposal-hashbang. Given that, I was wondering if the project would like to add native support as well.

Our parser dependency Acorn supports it already, so in this PR I've turned that option on and added a plugin similar to UseStrictPlugin to stamp out the shebang.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

It adds support for a language feature.

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

Yes

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

Not unless people relied on webpack crashing on files with shebangs

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

Just add a little note at the end of the changelog, I think.
