### PR TITLE
Added nestedModulesSpace to schema and updated the types

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -2236,6 +2236,10 @@ export interface StatsOptions {
 	 */
 	nestedModules?: boolean;
 	/**
+	 * Tells stats how many items of nested modules should be displayed (groups will be collapsed to fit this space).
+	 */
+	nestedModulesSpace?: number;
+	/**
 	 * Show reasons why optimization bailed out for modules.
 	 */
 	optimizationBailout?: boolean;

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -2228,7 +2228,7 @@ export interface StatsOptions {
 	 */
 	modulesSort?: string;
 	/**
-	 * Space to display modules (groups will be collapsed to fit this space, values is in number of modules/groups).
+	 * Space to display modules (groups will be collapsed to fit this space, value is in number of modules/groups).
 	 */
 	modulesSpace?: number;
 	/**
@@ -2236,7 +2236,7 @@ export interface StatsOptions {
 	 */
 	nestedModules?: boolean;
 	/**
-	 * Tells stats how many items of nested modules should be displayed (groups will be collapsed to fit this space).
+	 * Space to display modules nested within other modules (groups will be collapsed to fit this space, value is in number of modules/group).
 	 */
 	nestedModulesSpace?: number;
 	/**

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -137,10 +137,10 @@ console.log(__webpack_require__(/*! ./index */ 1));
 ## Unoptimized
 
 ```
-asset output.js 2.17 KiB [emitted] (name: main)
-chunk (runtime: main) output.js (main) 634 bytes [entry] [rendered]
+asset output.js 2.18 KiB [emitted] (name: main)
+chunk (runtime: main) output.js (main) 652 bytes [entry] [rendered]
   > ./example.js main
-  dependent modules 601 bytes [dependent] 1 module
+  dependent modules 619 bytes [dependent] 1 module
   ./example.js 33 bytes [built] [code generated]
     [used exports unknown]
     entry ./example.js main
@@ -151,9 +151,9 @@ webpack 5.11.1 compiled successfully
 
 ```
 asset output.js 524 bytes [emitted] [minimized] (name: main)
-chunk (runtime: main) output.js (main) 634 bytes [entry] [rendered]
+chunk (runtime: main) output.js (main) 652 bytes [entry] [rendered]
   > ./example.js main
-  dependent modules 601 bytes [dependent] 1 module
+  dependent modules 619 bytes [dependent] 1 module
   ./example.js 33 bytes [built] [code generated]
     [no exports used]
     entry ./example.js main

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -137,10 +137,10 @@ console.log(__webpack_require__(/*! ./index */ 1));
 ## Unoptimized
 
 ```
-asset output.js 2.18 KiB [emitted] (name: main)
-chunk (runtime: main) output.js (main) 652 bytes [entry] [rendered]
+asset output.js 2.17 KiB [emitted] (name: main)
+chunk (runtime: main) output.js (main) 634 bytes [entry] [rendered]
   > ./example.js main
-  dependent modules 619 bytes [dependent] 1 module
+  dependent modules 601 bytes [dependent] 1 module
   ./example.js 33 bytes [built] [code generated]
     [used exports unknown]
     entry ./example.js main
@@ -151,9 +151,9 @@ webpack 5.11.1 compiled successfully
 
 ```
 asset output.js 524 bytes [emitted] [minimized] (name: main)
-chunk (runtime: main) output.js (main) 652 bytes [entry] [rendered]
+chunk (runtime: main) output.js (main) 634 bytes [entry] [rendered]
   > ./example.js main
-  dependent modules 619 bytes [dependent] 1 module
+  dependent modules 601 bytes [dependent] 1 module
   ./example.js 33 bytes [built] [code generated]
     [no exports used]
     entry ./example.js main

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -3436,7 +3436,7 @@
           "type": "string"
         },
         "modulesSpace": {
-          "description": "Space to display modules (groups will be collapsed to fit this space, values is in number of modules/groups).",
+          "description": "Space to display modules (groups will be collapsed to fit this space, value is in number of modules/groups).",
           "type": "number"
         },
         "nestedModules": {
@@ -3444,7 +3444,7 @@
           "type": "boolean"
         },
         "nestedModulesSpace": {
-          "description": "Tells stats how many items of nested modules should be displayed (groups will be collapsed to fit this space).",
+          "description": "Space to display modules nested within other modules (groups will be collapsed to fit this space, value is in number of modules/group).",
           "type": "number"
         },
         "optimizationBailout": {

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -3443,6 +3443,10 @@
           "description": "Add information about modules nested in other modules (like with module concatenation).",
           "type": "boolean"
         },
+        "nestedModulesSpace": {
+          "description": "Tells stats how many items of nested modules should be displayed (groups will be collapsed to fit this space).",
+          "type": "number"
+        },
         "optimizationBailout": {
           "description": "Show reasons why optimization bailed out for modules.",
           "type": "boolean"

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -5278,13 +5278,13 @@ Object {
   "stats-modules-space": Object {
     "configs": Array [
       Object {
-        "description": "Space to display modules (groups will be collapsed to fit this space, values is in number of modules/groups).",
+        "description": "Space to display modules (groups will be collapsed to fit this space, value is in number of modules/groups).",
         "multiple": false,
         "path": "stats.modulesSpace",
         "type": "number",
       },
     ],
-    "description": "Space to display modules (groups will be collapsed to fit this space, values is in number of modules/groups).",
+    "description": "Space to display modules (groups will be collapsed to fit this space, value is in number of modules/groups).",
     "multiple": false,
     "simpleType": "number",
   },
@@ -5304,13 +5304,13 @@ Object {
   "stats-nested-modules-space": Object {
     "configs": Array [
       Object {
-        "description": "Tells stats how many items of nested modules should be displayed (groups will be collapsed to fit this space).",
+        "description": "Space to display modules nested within other modules (groups will be collapsed to fit this space, value is in number of modules/group).",
         "multiple": false,
         "path": "stats.nestedModulesSpace",
         "type": "number",
       },
     ],
-    "description": "Tells stats how many items of nested modules should be displayed (groups will be collapsed to fit this space).",
+    "description": "Space to display modules nested within other modules (groups will be collapsed to fit this space, value is in number of modules/group).",
     "multiple": false,
     "simpleType": "number",
   },

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -5301,6 +5301,19 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
+  "stats-nested-modules-space": Object {
+    "configs": Array [
+      Object {
+        "description": "Tells stats how many items of nested modules should be displayed (groups will be collapsed to fit this space).",
+        "multiple": false,
+        "path": "stats.nestedModulesSpace",
+        "type": "number",
+      },
+    ],
+    "description": "Tells stats how many items of nested modules should be displayed (groups will be collapsed to fit this space).",
+    "multiple": false,
+    "simpleType": "number",
+  },
   "stats-optimization-bailout": Object {
     "configs": Array [
       Object {

--- a/types.d.ts
+++ b/types.d.ts
@@ -9506,7 +9506,7 @@ declare interface StatsOptions {
 	modulesSort?: string;
 
 	/**
-	 * Space to display modules (groups will be collapsed to fit this space, values is in number of modules/groups).
+	 * Space to display modules (groups will be collapsed to fit this space, value is in number of modules/groups).
 	 */
 	modulesSpace?: number;
 
@@ -9516,7 +9516,7 @@ declare interface StatsOptions {
 	nestedModules?: boolean;
 
 	/**
-	 * Tells stats how many items of nested modules should be displayed (groups will be collapsed to fit this space).
+	 * Space to display modules nested within other modules (groups will be collapsed to fit this space, value is in number of modules/group).
 	 */
 	nestedModulesSpace?: number;
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -9516,6 +9516,11 @@ declare interface StatsOptions {
 	nestedModules?: boolean;
 
 	/**
+	 * Tells stats how many items of nested modules should be displayed (groups will be collapsed to fit this space).
+	 */
+	nestedModulesSpace?: number;
+
+	/**
 	 * Show reasons why optimization bailed out for modules.
 	 */
 	optimizationBailout?: boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
`Stats` doesn't have a `nestedModulesSpace` property as mentioned in the [docs](https://webpack.js.org/configuration/stats/#statsnestedmodulesspace). I have added the property to schema and updated the types. Also, this PR closes #12163.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
It adds ```nestedModulesSpace``` property to `stats`.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->


**Did you add tests for your changes?**
Yes. I have added the tests.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->


**What needs to be documented once your changes are merged?**
None. It's already documented [here](https://webpack.js.org/configuration/stats/#statsnestedmodulesspace). 
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
