### PR TITLE
Remove code duplication

### DIFF
--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -457,7 +457,6 @@ class ExportsInfo {
 				case UsageState.NoInfo:
 					return null;
 				case UsageState.Unknown:
-					return true;
 				case UsageState.OnlyPropertiesUsed:
 				case UsageState.Used:
 					return true;


### PR DESCRIPTION
The body of this case clause 'UsageState.Unknown' duplicates the body of this case clause 'case UsageState.Used'. This may be caused by a copy-paste error. If this usage is intentional, consider using fall-through to remove code duplication.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Refactoring

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No. This PR doesn't need any new test.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

There is no need to document anything.
