### PR TITLE
fix compile twice in watch mode after addDependency in a compilation

### DIFF
--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -139,13 +139,12 @@ class Watching {
 	 * @returns {void}
 	 */
 	_done(err, compilation) {
-		this.running = false;
-
 		const logger = compilation && compilation.getLogger("webpack.Watching");
 
 		let stats = null;
 
 		const handleError = err => {
+			this.running = false;
 			this.compiler.hooks.failed.call(err);
 			this.compiler.cache.beginIdle();
 			this.compiler.idle = true;
@@ -247,6 +246,7 @@ class Watching {
 				if (!this.suspended) {
 					this._invalidate();
 				}
+				this.running = false;
 			},
 			(fileName, changeTime) => {
 				this.compiler.hooks.invalid.call(fileName, changeTime);


### PR DESCRIPTION
<!-- Please don't delete this template because we'll close your issue -->
<!-- Before creating an issue please make sure you are using the latest version of webpack. -->

# Bug report

<!-- Please ask questions on StackOverflow or the webpack Gitter. -->
<!-- https://stackoverflow.com/questions/ask?tags=webpack -->
<!-- https://gitter.im/webpack/webpack -->
<!-- Issues which contain questions or support requests will be closed. -->

**What is the current behavior?**

In watch mode, webpack will compile twice  after addDependency in a compilation

**If the current behavior is a bug, please provide the steps to reproduce.**

1. git clone git@github.com:JayFate/joyful-webpack5-demo.git
2. cd joyful-webpack5-demo && npm install
3. cd joyful-webpack5-demo/packages/joyful && npm install
4. cd joyful-webpack5-demo/demo
5. node ../packages/joyful/bin/joy.js build

webpack will compile twice in watch mode after addDependency in a compilation. Errors in compilation will be printed twice.
![image](https://user-images.githubusercontent.com/48240828/103603330-56a82880-4f49-11eb-86d8-15b615af21f8.png)

please look into this [demo](https://github.com/JayFate/joyful-webpack5-demo)

<!-- A great way to do this is to provide your configuration via a GitHub repository -->
<!-- The most helpful is a minimal reproduction with instructions on how to reproduce -->
<!-- Repositories with too many files or large `webpack.config.js` files are not suitable -->
<!-- Please only add small code snippets directly into this issue -->
<!-- https://gist.github.com is a good place for longer code snippets -->
<!-- If your issue is caused by a plugin or loader, please create an issue on the loader/plugin repository instead -->

**What is the expected behavior?**

webpack should not compile again  after addDependency in a compilation. Errors in compilation should be printed once only.
![image](https://user-images.githubusercontent.com/48240828/103603709-3462da80-4f4a-11eb-80fb-550777db4a73.png)


<!-- "It should work" is not a helpful explanation -->
<!-- Explain exactly how it should behave -->

**Other relevant information:**
webpack version:  5.11.1
Node.js version: 12.0.0
Operating System: macOs big sur
Additional tools:
