### PR TITLE
re-add chunkId to script loading when available

### DIFF
--- a/lib/RuntimeGlobals.js
+++ b/lib/RuntimeGlobals.js
@@ -162,7 +162,7 @@ exports.scriptNonce = "__webpack_require__.nc";
 
 /**
  * function to load a script tag.
- * Arguments: (url: string, done: (event) => void), key?: string | number) => void
+ * Arguments: (url: string, done: (event) => void), key?: string | number, chunkId?: string | number) => void
  * done function is called when loading has finished or timeout occurred.
  * It will attach to existing script tags with data-webpack == key or src == url.
  */

--- a/lib/runtime/LoadScriptRuntimeModule.js
+++ b/lib/runtime/LoadScriptRuntimeModule.js
@@ -96,7 +96,7 @@ class LoadScriptRuntimeModule extends HelperRuntimeModule {
 				? `var dataWebpackPrefix = ${JSON.stringify(uniqueName + ":")};`
 				: "// data-webpack is not used as build has no uniqueName",
 			"// loadScript function to load a script via script tag",
-			`${fn} = ${runtimeTemplate.basicFunction("url, done, key", [
+			`${fn} = ${runtimeTemplate.basicFunction("url, done, key, chunkId", [
 				"if(inProgress[url]) { inProgress[url].push(done); return; }",
 				"var script, needAttach;",
 				"if(key !== undefined) {",

--- a/lib/web/JsonpChunkLoadingRuntimeModule.js
+++ b/lib/web/JsonpChunkLoadingRuntimeModule.js
@@ -178,7 +178,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 															"}"
 														]
 													)};`,
-													`${RuntimeGlobals.loadScript}(url, loadingEnded, "chunk-" + chunkId);`
+													`${RuntimeGlobals.loadScript}(url, loadingEnded, "chunk-" + chunkId, chunkId);`
 												]),
 												"} else installedChunks[chunkId] = 0;"
 											]),

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -173,10 +173,10 @@ describe("Stats", () => {
 			      "assets": Array [
 			        Object {
 			          "name": "entryB.js",
-			          "size": 2956,
+			          "size": 2960,
 			        },
 			      ],
-			      "assetsSize": 2956,
+			      "assetsSize": 2960,
 			      "auxiliaryAssets": undefined,
 			      "auxiliaryAssetsSize": 0,
 			      "childAssets": undefined,
@@ -221,10 +221,10 @@ describe("Stats", () => {
 			      "info": Object {
 			        "javascriptModule": false,
 			        "minimized": true,
-			        "size": 2956,
+			        "size": 2960,
 			      },
 			      "name": "entryB.js",
-			      "size": 2956,
+			      "size": 2960,
 			      "type": "asset",
 			    },
 			    Object {

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -3,14 +3,14 @@
 exports[`StatsTestCases should print correct stats for aggressive-splitting-entry 1`] = `
 "fitting:
   PublicPath: auto
-  asset fitting-9b8a5d1350459367de69.js 16 KiB [emitted] [immutable]
+  asset fitting-1cae105b381ccb28a4ef.js 16 KiB [emitted] [immutable]
   asset fitting-1bcc27c827d1564d3703.js 1.9 KiB [emitted] [immutable]
   asset fitting-b993a079b21885c8fe58.js 1.9 KiB [emitted] [immutable]
   asset fitting-0774b7847a706e47b664.js 1.08 KiB [emitted] [immutable]
-  Entrypoint main 19.8 KiB = fitting-1bcc27c827d1564d3703.js 1.9 KiB fitting-b993a079b21885c8fe58.js 1.9 KiB fitting-9b8a5d1350459367de69.js 16 KiB
-  chunk (runtime: main) fitting-9b8a5d1350459367de69.js 1.87 KiB (javascript) 8.76 KiB (runtime) [entry] [rendered]
+  Entrypoint main 19.9 KiB = fitting-1bcc27c827d1564d3703.js 1.9 KiB fitting-b993a079b21885c8fe58.js 1.9 KiB fitting-1cae105b381ccb28a4ef.js 16 KiB
+  chunk (runtime: main) fitting-1cae105b381ccb28a4ef.js 1.87 KiB (javascript) 8.78 KiB (runtime) [entry] [rendered]
     > ./index main
-    runtime modules 8.76 KiB 10 modules
+    runtime modules 8.78 KiB 10 modules
     cacheable modules 1.87 KiB
       ./e.js 899 bytes [dependent] [built] [code generated]
       ./f.js 900 bytes [dependent] [built] [code generated]
@@ -30,14 +30,14 @@ exports[`StatsTestCases should print correct stats for aggressive-splitting-entr
 
 content-change:
   PublicPath: auto
-  asset content-change-bfcb5244d26223c96a81.js 16 KiB [emitted] [immutable]
+  asset content-change-cee1b1b92882f2d670ce.js 16.1 KiB [emitted] [immutable]
   asset content-change-1bcc27c827d1564d3703.js 1.9 KiB [emitted] [immutable]
   asset content-change-b993a079b21885c8fe58.js 1.9 KiB [emitted] [immutable]
   asset content-change-0774b7847a706e47b664.js 1.08 KiB [emitted] [immutable]
-  Entrypoint main 19.8 KiB = content-change-1bcc27c827d1564d3703.js 1.9 KiB content-change-b993a079b21885c8fe58.js 1.9 KiB content-change-bfcb5244d26223c96a81.js 16 KiB
-  chunk (runtime: main) content-change-bfcb5244d26223c96a81.js 1.87 KiB (javascript) 8.76 KiB (runtime) [entry] [rendered]
+  Entrypoint main 19.9 KiB = content-change-1bcc27c827d1564d3703.js 1.9 KiB content-change-b993a079b21885c8fe58.js 1.9 KiB content-change-cee1b1b92882f2d670ce.js 16.1 KiB
+  chunk (runtime: main) content-change-cee1b1b92882f2d670ce.js 1.87 KiB (javascript) 8.78 KiB (runtime) [entry] [rendered]
     > ./index main
-    runtime modules 8.76 KiB 10 modules
+    runtime modules 8.78 KiB 10 modules
     cacheable modules 1.87 KiB
       ./e.js 899 bytes [dependent] [built] [code generated]
       ./f.js 900 bytes [dependent] [built] [code generated]
@@ -58,7 +58,7 @@ content-change:
 
 exports[`StatsTestCases should print correct stats for aggressive-splitting-on-demand 1`] = `
 "PublicPath: auto
-asset 8596272123aafca35084.js 11.6 KiB [emitted] [immutable] (name: main)
+asset f744e0e7c7d8d4c4c9c3.js 11.6 KiB [emitted] [immutable] (name: main)
 asset 95f6c9e223fe52d2c61c.js 1.91 KiB [emitted] [immutable]
 asset 7e706b5f05f0fc798d98.js 1.91 KiB [emitted] [immutable]
 asset 33bae5032b6d590a0460.js 1.9 KiB [emitted] [immutable]
@@ -70,14 +70,14 @@ asset ddea22d99afc20447b50.js 1.9 KiB [emitted] [immutable]
 asset 231393e27a139e7d96e1.js 1010 bytes [emitted] [immutable]
 asset 9c8bbdffc2a1a9125e6c.js 1010 bytes [emitted] [immutable]
 asset e156080e73721dfb8a7a.js 1010 bytes [emitted] [immutable]
-Entrypoint main 11.6 KiB = 8596272123aafca35084.js
+Entrypoint main 11.6 KiB = f744e0e7c7d8d4c4c9c3.js
 chunk (runtime: main) b993a079b21885c8fe58.js 1.76 KiB [rendered] [recorded] aggressive splitted
   > ./c ./d ./e ./index.js 3:0-30
   ./c.js 899 bytes [built] [code generated]
   ./d.js 899 bytes [built] [code generated]
-chunk (runtime: main) 8596272123aafca35084.js (main) 248 bytes (javascript) 6.31 KiB (runtime) [entry] [rendered]
+chunk (runtime: main) f744e0e7c7d8d4c4c9c3.js (main) 248 bytes (javascript) 6.33 KiB (runtime) [entry] [rendered]
   > ./index main
-  runtime modules 6.31 KiB 7 modules
+  runtime modules 6.33 KiB 7 modules
   ./index.js 248 bytes [built] [code generated]
 chunk (runtime: main) 95f6c9e223fe52d2c61c.js 1.76 KiB [rendered]
   > ./f ./g ./h ./i ./j ./k ./index.js 4:0-51
@@ -138,9 +138,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for async-commons-chunk 1`] = `
-"chunk (runtime: main) main.js (main) 515 bytes (javascript) 5.99 KiB (runtime) >{460}< >{847}< >{996}< [entry] [rendered]
+"chunk (runtime: main) main.js (main) 515 bytes (javascript) 6.01 KiB (runtime) >{460}< >{847}< >{996}< [entry] [rendered]
   > ./ main
-  runtime modules 5.99 KiB 7 modules
+  runtime modules 6.01 KiB 7 modules
   ./index.js 515 bytes [built] [code generated]
 chunk (runtime: main) 460.js 21 bytes <{179}> ={847}= [rendered]
   > ./index.js 17:1-21:3
@@ -167,9 +167,9 @@ exports[`StatsTestCases should print correct stats for async-commons-chunk-auto 
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) disabled/main.js (main) 147 bytes (javascript) 6.64 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) disabled/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.64 KiB 9 modules
+    runtime modules 6.66 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) disabled/async-b.js (async-b) 196 bytes [rendered]
     > ./b ./index.js 2:0-47
@@ -184,9 +184,9 @@ exports[`StatsTestCases should print correct stats for async-commons-chunk-auto 
     dependent modules 60 bytes [dependent] 3 modules
     runtime modules 394 bytes 2 modules
     ./c.js + 1 modules 136 bytes [built] [code generated]
-  chunk (runtime: a) disabled/a.js (a) 245 bytes (javascript) 6.59 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) disabled/a.js (a) 245 bytes (javascript) 6.61 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 6.59 KiB 9 modules
+    runtime modules 6.61 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) disabled/async-a.js (async-a) 245 bytes [rendered]
@@ -204,9 +204,9 @@ default:
   chunk (runtime: a, main) default/async-g.js (async-g) 45 bytes [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.67 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.66 KiB 9 modules
+    runtime modules 6.67 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) default/282.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -237,9 +237,9 @@ default:
   chunk (runtime: main) default/769.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
     > ./c ./index.js 3:0-47
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.64 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.66 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 6.64 KiB 9 modules
+    runtime modules 6.66 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) default/async-a.js (async-a) 185 bytes [rendered]
@@ -265,9 +265,9 @@ vendors:
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) vendors/main.js (main) 147 bytes (javascript) 6.64 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) vendors/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.64 KiB 9 modules
+    runtime modules 6.66 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: a, b, c) vendors/vendors.js (vendors) (id hint: vendors) 60 bytes [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
     > ./a a
@@ -289,9 +289,9 @@ vendors:
     runtime modules 2.87 KiB 3 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: a) vendors/a.js (a) 205 bytes (javascript) 7.65 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) vendors/a.js (a) 205 bytes (javascript) 7.67 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 7.65 KiB 9 modules
+    runtime modules 7.67 KiB 9 modules
     dependent modules 20 bytes [dependent] 1 module
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) vendors/async-a.js (async-a) 245 bytes [rendered]
@@ -320,9 +320,9 @@ multiple-vendors:
   chunk (runtime: a, main) multiple-vendors/async-g.js (async-g) 45 bytes [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) multiple-vendors/main.js (main) 147 bytes (javascript) 6.68 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) multiple-vendors/main.js (main) 147 bytes (javascript) 6.7 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.68 KiB 9 modules
+    runtime modules 6.7 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) multiple-vendors/async-b.js (async-b) 116 bytes [rendered]
     > ./b ./index.js 2:0-47
@@ -357,9 +357,9 @@ multiple-vendors:
     > ./c ./index.js 3:0-47
     > ./c c
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) multiple-vendors/a.js (a) 165 bytes (javascript) 7.71 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) multiple-vendors/a.js (a) 165 bytes (javascript) 7.72 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 7.71 KiB 9 modules
+    runtime modules 7.72 KiB 9 modules
     ./a.js 165 bytes [built] [code generated]
   chunk (runtime: main) multiple-vendors/async-a.js (async-a) 165 bytes [rendered]
     > ./a ./index.js 1:0-47
@@ -384,9 +384,9 @@ all:
   chunk (runtime: a, main) all/async-g.js (async-g) 45 bytes [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) all/main.js (main) 147 bytes (javascript) 6.65 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) all/main.js (main) 147 bytes (javascript) 6.67 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.65 KiB 9 modules
+    runtime modules 6.67 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) all/282.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
     > ./a ./index.js 1:0-47
@@ -429,9 +429,9 @@ all:
     > ./c ./index.js 3:0-47
     > ./c c
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) all/a.js (a) 165 bytes (javascript) 7.69 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) all/a.js (a) 165 bytes (javascript) 7.71 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 7.69 KiB 9 modules
+    runtime modules 7.71 KiB 9 modules
     ./a.js 165 bytes [built] [code generated]
   chunk (runtime: main) all/async-a.js (async-a) 165 bytes [rendered]
     > ./a ./index.js 1:0-47
@@ -495,9 +495,9 @@ asset bundle.js 10.1 KiB [emitted] (name: main)
 asset 460.bundle.js 320 bytes [emitted]
 asset 524.bundle.js 206 bytes [emitted]
 asset 996.bundle.js 138 bytes [emitted]
-chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 6 KiB (runtime) >{460}< >{996}< [entry] [rendered]
+chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 6.02 KiB (runtime) >{460}< >{996}< [entry] [rendered]
   > ./index main
-  runtime modules 6 KiB 7 modules
+  runtime modules 6.02 KiB 7 modules
   cacheable modules 73 bytes
     ./a.js 22 bytes [dependent] [built] [code generated]
       cjs self exports reference ./a.js 1:0-14
@@ -566,9 +566,9 @@ chunk (runtime: main) d_js-e_js.bundle.js 60 bytes <{c_js}> [rendered]
     cjs self exports reference ./e.js 2:0-14
     X ms -> X ms ->
     X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
-chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 6 KiB (runtime) >{b_js}< >{c_js}< [entry] [rendered]
+chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 6.02 KiB (runtime) >{b_js}< >{c_js}< [entry] [rendered]
   > ./index main
-  runtime modules 6 KiB 7 modules
+  runtime modules 6.02 KiB 7 modules
   cacheable modules 73 bytes
     ./a.js 22 bytes [dependent] [built] [code generated]
       cjs self exports reference ./a.js 1:0-14
@@ -585,8 +585,8 @@ webpack x.x.x compiled successfully in X ms"
 exports[`StatsTestCases should print correct stats for circular-correctness 1`] = `
 "chunk (runtime: main) 128.bundle.js (b) 49 bytes <{179}> <{459}> >{459}< [rendered]
   ./module-b.js 49 bytes [built] [code generated]
-chunk (runtime: main) bundle.js (main) 98 bytes (javascript) 7.67 KiB (runtime) >{128}< >{786}< [entry] [rendered]
-  runtime modules 7.67 KiB 10 modules
+chunk (runtime: main) bundle.js (main) 98 bytes (javascript) 7.69 KiB (runtime) >{128}< >{786}< [entry] [rendered]
+  runtime modules 7.69 KiB 10 modules
   ./index.js 98 bytes [built] [code generated]
 chunk (runtime: main) 459.bundle.js (c) 98 bytes <{128}> <{786}> >{128}< >{786}< [rendered]
   ./module-c.js 98 bytes [built] [code generated]
@@ -698,40 +698,40 @@ exports[`StatsTestCases should print correct stats for concat-and-sideeffects 1`
 `;
 
 exports[`StatsTestCases should print correct stats for context-independence 1`] = `
-"asset main-cb419f5b3b45bffaf5ee.js 10.4 KiB [emitted] [immutable] (name: main)
-  sourceMap main-cb419f5b3b45bffaf5ee.js.map 9.29 KiB [emitted] [dev] (auxiliary name: main)
+"asset main-a99c4b0415661253dc84.js 10.4 KiB [emitted] [immutable] (name: main)
+  sourceMap main-a99c4b0415661253dc84.js.map 9.31 KiB [emitted] [dev] (auxiliary name: main)
 asset 664-3ff01e96ecafa7f78b72.js 455 bytes [emitted] [immutable]
   sourceMap 664-3ff01e96ecafa7f78b72.js.map 344 bytes [emitted] [dev]
-runtime modules 6.29 KiB 8 modules
+runtime modules 6.31 KiB 8 modules
 orphan modules 19 bytes [orphan] 1 module
 cacheable modules 106 bytes
   ./a/index.js 40 bytes [built] [code generated]
   ./a/chunk.js + 1 modules 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-cb419f5b3b45bffaf5ee.js 10.4 KiB [emitted] [immutable] (name: main)
-  sourceMap main-cb419f5b3b45bffaf5ee.js.map 9.29 KiB [emitted] [dev] (auxiliary name: main)
+asset main-a99c4b0415661253dc84.js 10.4 KiB [emitted] [immutable] (name: main)
+  sourceMap main-a99c4b0415661253dc84.js.map 9.31 KiB [emitted] [dev] (auxiliary name: main)
 asset 664-3ff01e96ecafa7f78b72.js 455 bytes [emitted] [immutable]
   sourceMap 664-3ff01e96ecafa7f78b72.js.map 344 bytes [emitted] [dev]
-runtime modules 6.29 KiB 8 modules
+runtime modules 6.31 KiB 8 modules
 orphan modules 19 bytes [orphan] 1 module
 cacheable modules 106 bytes
   ./b/index.js 40 bytes [built] [code generated]
   ./b/chunk.js + 1 modules 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-07633f2178e71f86d7f4.js 11.3 KiB [emitted] [immutable] (name: main)
+asset main-32f3b12dcedee5e61c4a.js 11.3 KiB [emitted] [immutable] (name: main)
 asset 664-9b0875d15bd23acf607c.js 1.5 KiB [emitted] [immutable]
-runtime modules 6.29 KiB 8 modules
+runtime modules 6.31 KiB 8 modules
 orphan modules 19 bytes [orphan] 1 module
 cacheable modules 106 bytes
   ./a/index.js 40 bytes [built] [code generated]
   ./a/chunk.js + 1 modules 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-07633f2178e71f86d7f4.js 11.3 KiB [emitted] [immutable] (name: main)
+asset main-32f3b12dcedee5e61c4a.js 11.3 KiB [emitted] [immutable] (name: main)
 asset 664-9b0875d15bd23acf607c.js 1.5 KiB [emitted] [immutable]
-runtime modules 6.29 KiB 8 modules
+runtime modules 6.31 KiB 8 modules
 orphan modules 19 bytes [orphan] 1 module
 cacheable modules 106 bytes
   ./b/index.js 40 bytes [built] [code generated]
@@ -819,16 +819,16 @@ exports[`StatsTestCases should print correct stats for graph-correctness-entries
 "chunk (runtime: e1, e2) b.js (b) 49 bytes <{786}> >{459}< [rendered]
   ./module-b.js 49 bytes [built] [code generated]
     import() ./module-b ./module-a.js 1:0-47
-chunk (runtime: e1) e1.js (e1) 49 bytes (javascript) 7.7 KiB (runtime) >{786}< [entry] [rendered]
-  runtime modules 7.7 KiB 10 modules
+chunk (runtime: e1) e1.js (e1) 49 bytes (javascript) 7.71 KiB (runtime) >{786}< [entry] [rendered]
+  runtime modules 7.71 KiB 10 modules
   ./e1.js 49 bytes [built] [code generated]
     entry ./e1 e1
 chunk (runtime: e1, e2) c.js (c) 49 bytes <{128}> <{621}> >{786}< [rendered]
   ./module-c.js 49 bytes [built] [code generated]
     import() ./module-c ./e2.js 1:0-47
     import() ./module-c ./module-b.js 1:0-47
-chunk (runtime: e2) e2.js (e2) 49 bytes (javascript) 7.7 KiB (runtime) >{459}< [entry] [rendered]
-  runtime modules 7.7 KiB 10 modules
+chunk (runtime: e2) e2.js (e2) 49 bytes (javascript) 7.71 KiB (runtime) >{459}< [entry] [rendered]
+  runtime modules 7.71 KiB 10 modules
   ./e2.js 49 bytes [built] [code generated]
     entry ./e2 e2
 chunk (runtime: e1, e2) a.js (a) 49 bytes <{257}> <{459}> >{128}< [rendered]
@@ -842,8 +842,8 @@ exports[`StatsTestCases should print correct stats for graph-correctness-modules
 "chunk (runtime: e1, e2) b.js (b) 179 bytes <{786}> >{459}< [rendered]
   ./module-b.js 179 bytes [built] [code generated]
     import() ./module-b ./module-a.js 1:0-47
-chunk (runtime: e1) e1.js (e1) 119 bytes (javascript) 7.96 KiB (runtime) >{786}< >{892}< [entry] [rendered]
-  runtime modules 7.96 KiB 11 modules
+chunk (runtime: e1) e1.js (e1) 119 bytes (javascript) 7.98 KiB (runtime) >{786}< >{892}< [entry] [rendered]
+  runtime modules 7.98 KiB 11 modules
   cacheable modules 119 bytes
     ./e1.js 70 bytes [built] [code generated]
       entry ./e1 e1
@@ -855,8 +855,8 @@ chunk (runtime: e1, e2) c.js (c) 49 bytes <{128}> <{621}> >{786}< [rendered]
   ./module-c.js 49 bytes [built] [code generated]
     import() ./module-c ./e2.js 2:0-47
     import() ./module-c ./module-b.js 1:0-47
-chunk (runtime: e2) e2.js (e2) 119 bytes (javascript) 7.96 KiB (runtime) >{459}< >{892}< [entry] [rendered]
-  runtime modules 7.96 KiB 11 modules
+chunk (runtime: e2) e2.js (e2) 119 bytes (javascript) 7.98 KiB (runtime) >{459}< >{892}< [entry] [rendered]
+  runtime modules 7.98 KiB 11 modules
   cacheable modules 119 bytes
     ./e2.js 70 bytes [built] [code generated]
       entry ./e2 e2
@@ -895,8 +895,8 @@ chunk (runtime: main) id-equals-name_js0.js 21 bytes [rendered]
   ./id-equals-name.js 21 bytes [built] [code generated]
 chunk (runtime: main) id-equals-name_js_3.js 21 bytes [rendered]
   ./id-equals-name.js?3 21 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 639 bytes (javascript) 6.57 KiB (runtime) [entry] [rendered]
-  runtime modules 6.57 KiB 9 modules
+chunk (runtime: main) main.js (main) 639 bytes (javascript) 6.58 KiB (runtime) [entry] [rendered]
+  runtime modules 6.58 KiB 9 modules
   ./index.js 639 bytes [built] [code generated]
 chunk (runtime: main) tree.js (tree) 137 bytes [rendered]
   dependent modules 98 bytes [dependent] 3 modules
@@ -925,7 +925,7 @@ webpack x.x.x compiled with 2 warnings in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for immutable 1`] = `
-"asset 1ec1637f65b08def90da.js 13 KiB [emitted] [immutable] (name: main)
+"asset 891cf719145527e9bc8a.js 13 KiB [emitted] [immutable] (name: main)
 asset fb6af8aa7f2f734e1bc5.js 809 bytes [emitted] [immutable]"
 `;
 
@@ -934,7 +934,7 @@ exports[`StatsTestCases should print correct stats for import-context-filter 1`]
 asset 398.js 480 bytes [emitted]
 asset 544.js 480 bytes [emitted]
 asset 718.js 480 bytes [emitted]
-runtime modules 6.56 KiB 9 modules
+runtime modules 6.58 KiB 9 modules
 built modules 724 bytes [built]
   modules by path ./templates/*.js 114 bytes
     ./templates/bar.js 38 bytes [optional] [built] [code generated]
@@ -948,7 +948,7 @@ webpack x.x.x compiled successfully in X ms"
 exports[`StatsTestCases should print correct stats for import-weak 1`] = `
 "asset entry.js 13 KiB [emitted] (name: entry)
 asset 836.js 138 bytes [emitted]
-runtime modules 7.67 KiB 10 modules
+runtime modules 7.68 KiB 10 modules
 orphan modules 37 bytes [orphan] 1 module
 cacheable modules 142 bytes
   ./entry.js 120 bytes [built] [code generated]
@@ -957,7 +957,7 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for import-with-invalid-options-comments 1`] = `
-"runtime modules 8.64 KiB 12 modules
+"runtime modules 8.66 KiB 12 modules
 cacheable modules 559 bytes
   ./index.js 50 bytes [built] [code generated]
   ./chunk.js 401 bytes [built] [code generated] [3 warnings]
@@ -1004,11 +1004,11 @@ webpack x.x.x compiled successfully in X ms
 assets by chunk 895 bytes (id hint: all)
   asset c-all-b_js-dc3c6087ec7f68d726e7.js 502 bytes [emitted] [immutable] (id hint: all)
   asset c-all-c_js-0a8ce0d1bd0a1806e2fe.js 393 bytes [emitted] [immutable] (id hint: all)
-asset c-runtime~main-b3465c70c754222f9341.js 13.8 KiB [emitted] [immutable] (name: runtime~main)
+asset c-runtime~main-a999375651857f35d33d.js 13.8 KiB [emitted] [immutable] (name: runtime~main)
 asset c-main-142c4b047af79cfa6bbd.js 603 bytes [emitted] [immutable] (name: main)
 asset c-vendors-node_modules_vendor_js-8312cbaa60f0829f9942.js 185 bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main 14.8 KiB = c-runtime~main-b3465c70c754222f9341.js 13.8 KiB c-all-c_js-0a8ce0d1bd0a1806e2fe.js 393 bytes c-main-142c4b047af79cfa6bbd.js 603 bytes
-runtime modules 8.81 KiB 12 modules
+Entrypoint main 14.8 KiB = c-runtime~main-a999375651857f35d33d.js 13.8 KiB c-all-c_js-0a8ce0d1bd0a1806e2fe.js 393 bytes c-main-142c4b047af79cfa6bbd.js 603 bytes
+runtime modules 8.83 KiB 12 modules
 cacheable modules 101 bytes
   ./c.js 61 bytes [built] [code generated]
   ./b.js 17 bytes [built] [code generated]
@@ -1031,10 +1031,10 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   1 chunks (webpack x.x.x) compiled successfully in X ms
 
 2 chunks:
-  asset bundle2.js 12.5 KiB [emitted] (name: main)
+  asset bundle2.js 12.6 KiB [emitted] (name: main)
   asset 459.bundle2.js 664 bytes [emitted] (name: c)
-  chunk (runtime: main) bundle2.js (main) 101 bytes (javascript) 7.67 KiB (runtime) >{459}< [entry] [rendered]
-    runtime modules 7.67 KiB 10 modules
+  chunk (runtime: main) bundle2.js (main) 101 bytes (javascript) 7.69 KiB (runtime) >{459}< [entry] [rendered]
+    runtime modules 7.69 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
   chunk (runtime: main) 459.bundle2.js (c) 118 bytes <{179}> <{459}> >{459}< [rendered]
     dependent modules 44 bytes [dependent]
@@ -1046,11 +1046,11 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   2 chunks (webpack x.x.x) compiled successfully in X ms
 
 3 chunks:
-  asset bundle3.js 12.5 KiB [emitted] (name: main)
+  asset bundle3.js 12.6 KiB [emitted] (name: main)
   asset 459.bundle3.js 528 bytes [emitted] (name: c)
   asset 524.bundle3.js 206 bytes [emitted]
-  chunk (runtime: main) bundle3.js (main) 101 bytes (javascript) 7.67 KiB (runtime) >{459}< [entry] [rendered]
-    runtime modules 7.67 KiB 10 modules
+  chunk (runtime: main) bundle3.js (main) 101 bytes (javascript) 7.69 KiB (runtime) >{459}< [entry] [rendered]
+    runtime modules 7.69 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
   chunk (runtime: main) 459.bundle3.js (c) 74 bytes <{179}> >{524}< [rendered]
     ./a.js 22 bytes [built] [code generated]
@@ -1062,12 +1062,12 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   3 chunks (webpack x.x.x) compiled successfully in X ms
 
 4 chunks:
-  asset bundle4.js 12.5 KiB [emitted] (name: main)
+  asset bundle4.js 12.6 KiB [emitted] (name: main)
   asset 459.bundle4.js 392 bytes [emitted] (name: c)
   asset 394.bundle4.js 206 bytes [emitted]
   asset 524.bundle4.js 206 bytes [emitted]
-  chunk (runtime: main) bundle4.js (main) 101 bytes (javascript) 7.67 KiB (runtime) >{394}< >{459}< [entry] [rendered]
-    runtime modules 7.67 KiB 10 modules
+  chunk (runtime: main) bundle4.js (main) 101 bytes (javascript) 7.69 KiB (runtime) >{394}< >{459}< [entry] [rendered]
+    runtime modules 7.69 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
   chunk (runtime: main) 394.bundle4.js 44 bytes <{179}> [rendered]
     ./a.js 22 bytes [built] [code generated]
@@ -1170,13 +1170,13 @@ Chunk Group b 563 bytes (21 KiB) = b.js 563 bytes (2.png 21 KiB)
 chunk (runtime: main) b.js (b) 67 bytes [rendered]
   ./node_modules/a/2.png 49 bytes [dependent] [built] [code generated] [1 asset]
   ./node_modules/b/index.js 18 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 82 bytes (javascript) 6.28 KiB (runtime) [entry] [rendered]
-  runtime modules 6.28 KiB 8 modules
+chunk (runtime: main) main.js (main) 82 bytes (javascript) 6.3 KiB (runtime) [entry] [rendered]
+  runtime modules 6.3 KiB 8 modules
   ./index.js 82 bytes [built] [code generated]
 chunk (runtime: main) a.js (a) 134 bytes [rendered]
   ./node_modules/a/2.png 49 bytes [dependent] [built] [code generated] [1 asset]
   ./node_modules/a/index.js + 1 modules 85 bytes [built] [code generated] [1 asset]
-runtime modules 6.28 KiB 8 modules
+runtime modules 6.3 KiB 8 modules
 orphan modules 49 bytes [orphan] 1 module
 modules with assets 234 bytes
   modules by path ./node_modules/a/ 134 bytes
@@ -1188,9 +1188,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for module-deduplication 1`] = `
-"asset e1.js 12 KiB [emitted] (name: e1)
-asset e2.js 12 KiB [emitted] (name: e2)
-asset e3.js 12 KiB [emitted] (name: e3)
+"asset e1.js 12.1 KiB [emitted] (name: e1)
+asset e2.js 12.1 KiB [emitted] (name: e2)
+asset e3.js 12.1 KiB [emitted] (name: e3)
 asset 172.js 864 bytes [emitted]
 asset 326.js 864 bytes [emitted]
 asset 923.js 864 bytes [emitted]
@@ -1199,8 +1199,8 @@ asset 593.js 518 bytes [emitted]
 asset 716.js 518 bytes [emitted]
 chunk (runtime: e1) 114.js 61 bytes [rendered]
   ./async1.js 61 bytes [built] [code generated]
-chunk (runtime: e3) e3.js (e3) 249 bytes (javascript) 6.56 KiB (runtime) [entry] [rendered]
-  runtime modules 6.56 KiB 9 modules
+chunk (runtime: e3) e3.js (e3) 249 bytes (javascript) 6.58 KiB (runtime) [entry] [rendered]
+  runtime modules 6.58 KiB 9 modules
   cacheable modules 249 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e3.js + 2 modules 209 bytes [built] [code generated]
@@ -1208,8 +1208,8 @@ chunk (runtime: e3) e3.js (e3) 249 bytes (javascript) 6.56 KiB (runtime) [entry]
 chunk (runtime: e1, e3) 172.js 81 bytes [rendered]
   ./async2.js 61 bytes [built] [code generated]
   ./f.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e1) e1.js (e1) 249 bytes (javascript) 6.56 KiB (runtime) [entry] [rendered]
-  runtime modules 6.56 KiB 9 modules
+chunk (runtime: e1) e1.js (e1) 249 bytes (javascript) 6.58 KiB (runtime) [entry] [rendered]
+  runtime modules 6.58 KiB 9 modules
   cacheable modules 249 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./d.js 20 bytes [dependent] [built] [code generated]
@@ -1219,8 +1219,8 @@ chunk (runtime: e1, e2) 326.js 81 bytes [rendered]
   ./h.js 20 bytes [dependent] [built] [code generated]
 chunk (runtime: e3) 593.js 61 bytes [rendered]
   ./async3.js 61 bytes [built] [code generated]
-chunk (runtime: e2) e2.js (e2) 249 bytes (javascript) 6.56 KiB (runtime) [entry] [rendered]
-  runtime modules 6.56 KiB 9 modules
+chunk (runtime: e2) e2.js (e2) 249 bytes (javascript) 6.58 KiB (runtime) [entry] [rendered]
+  runtime modules 6.58 KiB 9 modules
   cacheable modules 249 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e2.js + 2 modules 209 bytes [built] [code generated]
@@ -1240,14 +1240,14 @@ asset e3.js 11.9 KiB [emitted] (name: e3)
 asset async1.js 970 bytes [emitted] (name: async1)
 asset async2.js 970 bytes [emitted] (name: async2)
 asset async3.js 970 bytes [emitted] (name: async3)
-chunk (runtime: e3) e3.js (e3) 242 bytes (javascript) 6.61 KiB (runtime) [entry] [rendered]
-  runtime modules 6.61 KiB 9 modules
+chunk (runtime: e3) e3.js (e3) 242 bytes (javascript) 6.63 KiB (runtime) [entry] [rendered]
+  runtime modules 6.63 KiB 9 modules
   cacheable modules 242 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e3.js + 2 modules 202 bytes [built] [code generated]
     ./h.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e1) e1.js (e1) 242 bytes (javascript) 6.61 KiB (runtime) [entry] [rendered]
-  runtime modules 6.61 KiB 9 modules
+chunk (runtime: e1) e1.js (e1) 242 bytes (javascript) 6.63 KiB (runtime) [entry] [rendered]
+  runtime modules 6.63 KiB 9 modules
   cacheable modules 242 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./d.js 20 bytes [dependent] [built] [code generated]
@@ -1258,8 +1258,8 @@ chunk (runtime: e1, e2, e3) async1.js (async1) 135 bytes [rendered]
 chunk (runtime: e1, e2, e3) async3.js (async3) 135 bytes [rendered]
   ./async3.js 115 bytes [built] [code generated]
   ./h.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e2) e2.js (e2) 242 bytes (javascript) 6.61 KiB (runtime) [entry] [rendered]
-  runtime modules 6.61 KiB 9 modules
+chunk (runtime: e2) e2.js (e2) 242 bytes (javascript) 6.63 KiB (runtime) [entry] [rendered]
+  runtime modules 6.63 KiB 9 modules
   cacheable modules 242 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e2.js + 2 modules 202 bytes [built] [code generated]
@@ -1367,9 +1367,9 @@ chunk (runtime: main) a-52.js 149 bytes [rendered] split chunk (cache group: def
   > ./a ./index.js 1:0-47
   > ./b ./index.js 2:0-47
   ./shared.js 149 bytes [built] [code generated]
-chunk (runtime: main) a-main.js (main) 146 bytes (javascript) 6.9 KiB (runtime) [entry] [rendered]
+chunk (runtime: main) a-main.js (main) 146 bytes (javascript) 6.92 KiB (runtime) [entry] [rendered]
   > ./ main
-  runtime modules 6.9 KiB 10 modules
+  runtime modules 6.92 KiB 10 modules
   ./index.js 146 bytes [built] [code generated]
 chunk (runtime: main) a-vendors.js (vendors) (id hint: vendors) 40 bytes [rendered] split chunk (cache group: vendors) (name: vendors)
   > ./c ./index.js 3:0-47
@@ -1394,9 +1394,9 @@ chunk (runtime: main) b-52.js 149 bytes [rendered] split chunk (cache group: def
   > ./a ./index.js 1:0-47
   > ./b ./index.js 2:0-47
   ./shared.js 149 bytes [built] [code generated]
-chunk (runtime: main) b-main.js (main) 146 bytes (javascript) 6.9 KiB (runtime) [entry] [rendered]
+chunk (runtime: main) b-main.js (main) 146 bytes (javascript) 6.92 KiB (runtime) [entry] [rendered]
   > ./ main
-  runtime modules 6.9 KiB 10 modules
+  runtime modules 6.92 KiB 10 modules
   ./index.js 146 bytes [built] [code generated]
 chunk (runtime: main) b-vendors.js (vendors) (id hint: vendors) 40 bytes [rendered] split chunk (cache group: vendors) (name: vendors)
   > ./c ./index.js 3:0-47
@@ -1431,7 +1431,7 @@ exports[`StatsTestCases should print correct stats for named-chunks-plugin-async
 "asset entry.js 12.4 KiB [emitted] (name: entry)
 asset modules_a_js.js 313 bytes [emitted]
 asset modules_b_js.js 149 bytes [emitted]
-runtime modules 7.67 KiB 10 modules
+runtime modules 7.69 KiB 10 modules
 cacheable modules 106 bytes
   ./entry.js 47 bytes [built] [code generated]
   ./modules/a.js 37 bytes [built] [code generated]
@@ -1464,9 +1464,9 @@ chunk {90} (runtime: main) ab.js (ab) 2 bytes <{179}> >{753}< [rendered]
   > [10] ./index.js 1:0-6:8
   ./modules/a.js [839] 1 bytes {90} {374} [built] [code generated]
   ./modules/b.js [836] 1 bytes {90} {374} [built] [code generated]
-chunk {179} (runtime: main) main.js (main) 524 bytes (javascript) 6.1 KiB (runtime) >{90}< >{289}< >{374}< >{592}< [entry] [rendered]
+chunk {179} (runtime: main) main.js (main) 524 bytes (javascript) 6.11 KiB (runtime) >{90}< >{289}< >{374}< >{592}< [entry] [rendered]
   > ./index main
-  runtime modules 6.1 KiB 7 modules
+  runtime modules 6.11 KiB 7 modules
   cacheable modules 524 bytes
     ./index.js [10] 523 bytes {179} [built] [code generated]
     ./modules/f.js [544] 1 bytes {179} [dependent] [built] [code generated]
@@ -1500,7 +1500,7 @@ webpack x.x.x compiled successfully in X ms"
 exports[`StatsTestCases should print correct stats for output-module 1`] = `
 "asset main.js 10 KiB [emitted] [javascript module] (name: main)
 asset 52.js 415 bytes [emitted] [javascript module]
-runtime modules 6.06 KiB 8 modules
+runtime modules 6.08 KiB 8 modules
 orphan modules 38 bytes [orphan] 1 module
 cacheable modules 263 bytes
   ./index.js + 1 modules 225 bytes [built] [code generated]
@@ -1609,7 +1609,7 @@ asset <CLR=32,BOLD>460.js</CLR> 320 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
-runtime modules 5.99 KiB 7 modules
+runtime modules 6.01 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -1626,7 +1626,7 @@ asset <CLR=32,BOLD>460.js</CLR> 320 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
-runtime modules 5.99 KiB 7 modules
+runtime modules 6.01 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -1685,7 +1685,7 @@ asset <CLR=32,BOLD>460.js</CLR> 320 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
-runtime modules 5.99 KiB 7 modules
+runtime modules 6.01 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -1727,17 +1727,17 @@ webpack x.x.x compiled with <CLR=31,BOLD>3 errors</CLR> in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for prefetch 1`] = `
-"asset main.js 15.6 KiB {179} [emitted] (name: main)
+"asset main.js 15.7 KiB {179} [emitted] (name: main)
 asset prefetched.js 556 bytes {505} [emitted] (name: prefetched)
 asset inner2.js 150 bytes {641} [emitted] (name: inner2)
 asset inner.js 110 bytes {746} [emitted] (name: inner)
 asset prefetched2.js 110 bytes {379} [emitted] (name: prefetched2)
 asset prefetched3.js 110 bytes {220} [emitted] (name: prefetched3)
 asset normal.js 109 bytes {30} [emitted] (name: normal)
-Entrypoint main 15.6 KiB = main.js
+Entrypoint main 15.7 KiB = main.js
   prefetch: prefetched2.js {379} (name: prefetched2), prefetched.js {505} (name: prefetched), prefetched3.js {220} (name: prefetched3)
 chunk {30} (runtime: main) normal.js (normal) 1 bytes <{179}> [rendered]
-chunk {179} (runtime: main) main.js (main) 436 bytes (javascript) 9.09 KiB (runtime) >{30}< >{220}< >{379}< >{505}< (prefetch: {379} {505} {220}) [entry] [rendered]
+chunk {179} (runtime: main) main.js (main) 436 bytes (javascript) 9.11 KiB (runtime) >{30}< >{220}< >{379}< >{505}< (prefetch: {379} {505} {220}) [entry] [rendered]
 chunk {220} (runtime: main) prefetched3.js (prefetched3) 1 bytes <{179}> [rendered]
 chunk {379} (runtime: main) prefetched2.js (prefetched2) 1 bytes <{179}> [rendered]
 chunk {505} (runtime: main) prefetched.js (prefetched) 228 bytes <{179}> >{641}< >{746}< (prefetch: {641} {746}) [rendered]
@@ -1752,7 +1752,7 @@ chunk (runtime: main) c1.js (c1) 1 bytes <{459}> [rendered]
 chunk (runtime: main) b.js (b) 203 bytes <{179}> >{132}< >{751}< >{978}< (prefetch: {751} {132}) (preload: {978}) [rendered]
 chunk (runtime: main) b3.js (b3) 1 bytes <{128}> [rendered]
 chunk (runtime: main) a2.js (a2) 1 bytes <{786}> [rendered]
-chunk (runtime: main) main.js (main) 195 bytes (javascript) 9.76 KiB (runtime) >{128}< >{459}< >{786}< (prefetch: {786} {128} {459}) [entry] [rendered]
+chunk (runtime: main) main.js (main) 195 bytes (javascript) 9.78 KiB (runtime) >{128}< >{459}< >{786}< (prefetch: {786} {128} {459}) [entry] [rendered]
 chunk (runtime: main) c.js (c) 134 bytes <{179}> >{3}< >{76}< (preload: {76} {3}) [rendered]
 chunk (runtime: main) b1.js (b1) 1 bytes <{128}> [rendered]
 chunk (runtime: main) a.js (a) 136 bytes <{179}> >{74}< >{178}< (prefetch: {74} {178}) [rendered]
@@ -1760,17 +1760,17 @@ chunk (runtime: main) b2.js (b2) 1 bytes <{128}> [rendered]"
 `;
 
 exports[`StatsTestCases should print correct stats for preload 1`] = `
-"asset main.js 15.1 KiB [emitted] (name: main)
+"asset main.js 15.2 KiB [emitted] (name: main)
 asset preloaded.js 556 bytes [emitted] (name: preloaded)
 asset inner2.js 150 bytes [emitted] (name: inner2)
 asset inner.js 110 bytes [emitted] (name: inner)
 asset normal.js 109 bytes [emitted] (name: normal)
 asset preloaded2.js 109 bytes [emitted] (name: preloaded2)
 asset preloaded3.js 108 bytes [emitted] (name: preloaded3)
-Entrypoint main 15.1 KiB = main.js
+Entrypoint main 15.2 KiB = main.js
   preload: preloaded2.js (name: preloaded2), preloaded.js (name: preloaded), preloaded3.js (name: preloaded3)
 chunk (runtime: main) normal.js (normal) 1 bytes [rendered]
-chunk (runtime: main) main.js (main) 424 bytes (javascript) 8.91 KiB (runtime) (preload: {363} {851} {355}) [entry] [rendered]
+chunk (runtime: main) main.js (main) 424 bytes (javascript) 8.92 KiB (runtime) (preload: {363} {851} {355}) [entry] [rendered]
 chunk (runtime: main) preloaded3.js (preloaded3) 1 bytes [rendered]
 chunk (runtime: main) preloaded2.js (preloaded2) 1 bytes [rendered]
 chunk (runtime: main) inner2.js (inner2) 2 bytes [rendered]
@@ -1793,7 +1793,7 @@ asset 460.js 320 bytes {460} [emitted]
 asset 524.js 206 bytes {524} [emitted]
 asset 996.js 138 bytes {996} [emitted]
 Entrypoint main 10.1 KiB = main.js
-chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 5.99 KiB (runtime) >{460}< >{996}< [entry] [rendered]
+chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 6.01 KiB (runtime) >{460}< >{996}< [entry] [rendered]
   > ./index main
 chunk {460} (runtime: main) 460.js 54 bytes <{179}> >{524}< [rendered]
   > ./c [10] ./index.js 3:0-16
@@ -1801,7 +1801,7 @@ chunk {524} (runtime: main) 524.js 44 bytes <{460}> [rendered]
   > [460] ./c.js 1:0-52
 chunk {996} (runtime: main) 996.js 22 bytes <{179}> [rendered]
   > ./b [10] ./index.js 2:0-16
-runtime modules 5.99 KiB
+runtime modules 6.01 KiB
   webpack/runtime/ensure chunk 326 bytes {179} [code generated]
     [no exports]
     [used exports unknown]
@@ -1814,7 +1814,7 @@ runtime modules 5.99 KiB
   webpack/runtime/hasOwnProperty shorthand 86 bytes {179} [code generated]
     [no exports]
     [used exports unknown]
-  webpack/runtime/jsonp chunk loading 3.01 KiB {179} [code generated]
+  webpack/runtime/jsonp chunk loading 3.02 KiB {179} [code generated]
     [no exports]
     [used exports unknown]
   webpack/runtime/load script 1.36 KiB {179} [code generated]
@@ -1890,7 +1890,7 @@ LOG from webpack.FileSystemInfo
     Directory info in cache: 0 timestamps 0 hashes 0 timestamp hash combinations
     Managed items info in cache: 0 items
 
-1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (9161deeaf441fe82e533)"
+1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (616f694e9b3f7a8615d7)"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-errors-only 1`] = `""`;
@@ -1968,7 +1968,7 @@ asset main.js 10.1 KiB [emitted] (name: main)
 asset 460.js 320 bytes [emitted]
 asset 524.js 206 bytes [emitted]
 asset 996.js 138 bytes [emitted]
-runtime modules 5.99 KiB 7 modules
+runtime modules 6.01 KiB 7 modules
 cacheable modules 193 bytes
   ./index.js 51 bytes [built] [code generated]
   ./a.js 22 bytes [built] [code generated]
@@ -1991,7 +1991,7 @@ exports[`StatsTestCases should print correct stats for preset-normal-performance
 asset <CLR=32,BOLD>460.js</CLR> 320 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
-runtime modules 5.99 KiB 7 modules
+runtime modules 6.01 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2019,7 +2019,7 @@ exports[`StatsTestCases should print correct stats for preset-normal-performance
 asset <CLR=32,BOLD>460.js</CLR> 352 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
 asset <CLR=32,BOLD>524.js</CLR> 238 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
 asset <CLR=32,BOLD>996.js</CLR> 170 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
-runtime modules 5.99 KiB 7 modules
+runtime modules 6.01 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2067,9 +2067,9 @@ asset 460.js 320 bytes {460} [emitted]
 asset 524.js 206 bytes {524} [emitted]
 asset 996.js 138 bytes {996} [emitted]
 Entrypoint main 10.1 KiB = main.js
-chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 5.99 KiB (runtime) >{460}< >{996}< [entry] [rendered]
+chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 6.01 KiB (runtime) >{460}< >{996}< [entry] [rendered]
   > ./index main
-  runtime modules 5.99 KiB 7 modules
+  runtime modules 6.01 KiB 7 modules
   cacheable modules 73 bytes
     ./a.js [847] 22 bytes {179} [depth 1] [dependent] [built] [code generated]
       [used exports unknown]
@@ -2235,19 +2235,19 @@ LOG from webpack.FileSystemInfo
     Directory info in cache: 0 timestamps 0 hashes 0 timestamp hash combinations
     Managed items info in cache: 0 items
 
-1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (9161deeaf441fe82e533)"
+1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (616f694e9b3f7a8615d7)"
 `;
 
 exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
 "a-normal:
   assets by path *.js 3 KiB
-    asset fbedf9db73ad6f3789a7-fbedf9.js 2.61 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+    asset 4408ab3a86604e4c16e2-4408ab.js 2.61 KiB [emitted] [immutable] [minimized] (name: runtime~main)
     asset 3cc8faad16137711c07e-3cc8fa.js 210 bytes [emitted] [immutable] [minimized] (name: main)
     asset b6f77787a670e97d47b5-b6f777.js 193 bytes [emitted] [immutable] [minimized] (name: lazy)
   asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: main)
-  Entrypoint main 2.81 KiB (5.89 KiB) = fbedf9db73ad6f3789a7-fbedf9.js 2.61 KiB 3cc8faad16137711c07e-3cc8fa.js 210 bytes 1 auxiliary asset
-  runtime modules 7.35 KiB 8 modules
+  Entrypoint main 2.81 KiB (5.89 KiB) = 4408ab3a86604e4c16e2-4408ab.js 2.61 KiB 3cc8faad16137711c07e-3cc8fa.js 210 bytes 1 auxiliary asset
+  runtime modules 7.37 KiB 8 modules
   orphan modules 23 bytes [orphan] 1 module
   cacheable modules 340 bytes (javascript) 20.4 KiB (asset)
     javascript modules 256 bytes
@@ -2260,13 +2260,13 @@ exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
 
 b-normal:
   assets by path *.js 3 KiB
-    asset ffab72941998653f26cb-ffab72.js 2.61 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+    asset b43f5614326bae5a6e28-b43f56.js 2.61 KiB [emitted] [immutable] [minimized] (name: runtime~main)
     asset 3cc8faad16137711c07e-3cc8fa.js 210 bytes [emitted] [immutable] [minimized] (name: main)
     asset b6f77787a670e97d47b5-b6f777.js 193 bytes [emitted] [immutable] [minimized] (name: lazy)
   asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: main)
-  Entrypoint main 2.81 KiB (5.89 KiB) = ffab72941998653f26cb-ffab72.js 2.61 KiB 3cc8faad16137711c07e-3cc8fa.js 210 bytes 1 auxiliary asset
-  runtime modules 7.35 KiB 8 modules
+  Entrypoint main 2.81 KiB (5.89 KiB) = b43f5614326bae5a6e28-b43f56.js 2.61 KiB 3cc8faad16137711c07e-3cc8fa.js 210 bytes 1 auxiliary asset
+  runtime modules 7.37 KiB 8 modules
   orphan modules 19 bytes [orphan] 1 module
   cacheable modules 295 bytes (javascript) 20.4 KiB (asset)
     javascript modules 211 bytes
@@ -2278,17 +2278,17 @@ b-normal:
   b-normal (webpack x.x.x) compiled successfully in X ms
 
 a-source-map:
-  assets by path *.js 3.16 KiB
-    asset ea299ee3bdf4418c6c3b-ea299e.js 2.66 KiB [emitted] [immutable] [minimized] (name: runtime~main)
-      sourceMap ea299ee3bdf4418c6c3b-ea299e.js.map 14.4 KiB [emitted] [dev] (auxiliary name: runtime~main)
+  assets by path *.js 3.17 KiB
+    asset 9351b9819e587de6a617-9351b9.js 2.66 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+      sourceMap 9351b9819e587de6a617-9351b9.js.map 14.4 KiB [emitted] [dev] (auxiliary name: runtime~main)
     asset b8bfcec62cdd15c9a840-b8bfce.js 266 bytes [emitted] [immutable] [minimized] (name: main)
       sourceMap b8bfcec62cdd15c9a840-b8bfce.js.map 366 bytes [emitted] [dev] (auxiliary name: main)
     asset c7c0f8bb2e61b59a89f5-c7c0f8.js 249 bytes [emitted] [immutable] [minimized] (name: lazy)
       sourceMap c7c0f8bb2e61b59a89f5-c7c0f8.js.map 331 bytes [emitted] [dev] (auxiliary name: lazy)
   asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: main)
-  Entrypoint main 2.92 KiB (20.7 KiB) = ea299ee3bdf4418c6c3b-ea299e.js 2.66 KiB b8bfcec62cdd15c9a840-b8bfce.js 266 bytes 3 auxiliary assets
-  runtime modules 7.35 KiB 8 modules
+  Entrypoint main 2.92 KiB (20.7 KiB) = 9351b9819e587de6a617-9351b9.js 2.66 KiB b8bfcec62cdd15c9a840-b8bfce.js 266 bytes 3 auxiliary assets
+  runtime modules 7.37 KiB 8 modules
   orphan modules 23 bytes [orphan] 1 module
   cacheable modules 340 bytes (javascript) 20.4 KiB (asset)
     javascript modules 256 bytes
@@ -2300,17 +2300,17 @@ a-source-map:
   a-source-map (webpack x.x.x) compiled successfully in X ms
 
 b-source-map:
-  assets by path *.js 3.16 KiB
-    asset 55323249ff490241dcb1-553232.js 2.66 KiB [emitted] [immutable] [minimized] (name: runtime~main)
-      sourceMap 55323249ff490241dcb1-553232.js.map 14.4 KiB [emitted] [dev] (auxiliary name: runtime~main)
+  assets by path *.js 3.17 KiB
+    asset fb3225ff81afeaa66787-fb3225.js 2.66 KiB [emitted] [immutable] [minimized] (name: runtime~main)
+      sourceMap fb3225ff81afeaa66787-fb3225.js.map 14.4 KiB [emitted] [dev] (auxiliary name: runtime~main)
     asset b8bfcec62cdd15c9a840-b8bfce.js 266 bytes [emitted] [immutable] [minimized] (name: main)
       sourceMap b8bfcec62cdd15c9a840-b8bfce.js.map 323 bytes [emitted] [dev] (auxiliary name: main)
     asset c7c0f8bb2e61b59a89f5-c7c0f8.js 249 bytes [emitted] [immutable] [minimized] (name: lazy)
       sourceMap c7c0f8bb2e61b59a89f5-c7c0f8.js.map 327 bytes [emitted] [dev] (auxiliary name: lazy)
   asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: main)
-  Entrypoint main 2.92 KiB (20.6 KiB) = 55323249ff490241dcb1-553232.js 2.66 KiB b8bfcec62cdd15c9a840-b8bfce.js 266 bytes 3 auxiliary assets
-  runtime modules 7.35 KiB 8 modules
+  Entrypoint main 2.92 KiB (20.6 KiB) = fb3225ff81afeaa66787-fb3225.js 2.66 KiB b8bfcec62cdd15c9a840-b8bfce.js 266 bytes 3 auxiliary assets
+  runtime modules 7.37 KiB 8 modules
   orphan modules 19 bytes [orphan] 1 module
   cacheable modules 295 bytes (javascript) 20.4 KiB (asset)
     javascript modules 211 bytes
@@ -2479,11 +2479,11 @@ webpack x.x.x compiled successfully"
 
 exports[`StatsTestCases should print correct stats for runtime-chunk-integration 1`] = `
 "base:
-  asset without-runtime.js 12.3 KiB [emitted] (name: runtime)
+  asset without-runtime.js 12.4 KiB [emitted] (name: runtime)
   asset without-505.js 1.22 KiB [emitted]
   asset without-main1.js 596 bytes [emitted] (name: main1)
-  Entrypoint main1 12.9 KiB = without-runtime.js 12.3 KiB without-main1.js 596 bytes
-  runtime modules 7.63 KiB 9 modules
+  Entrypoint main1 12.9 KiB = without-runtime.js 12.4 KiB without-main1.js 596 bytes
+  runtime modules 7.65 KiB 9 modules
   cacheable modules 126 bytes
     ./main1.js 66 bytes [built] [code generated]
     ./b.js 20 bytes [built] [code generated]
@@ -2498,9 +2498,9 @@ static custom name:
   asset with-main2.js 215 bytes [emitted] (name: main2)
   asset with-main3.js 215 bytes [emitted] (name: main3)
   Entrypoint main1 12.9 KiB = with-manifest.js 12.3 KiB with-main1.js 596 bytes
-  Entrypoint main2 12.5 KiB = with-manifest.js 12.3 KiB with-main2.js 215 bytes
-  Entrypoint main3 12.5 KiB = with-manifest.js 12.3 KiB with-main3.js 215 bytes
-  runtime modules 7.63 KiB 9 modules
+  Entrypoint main2 12.6 KiB = with-manifest.js 12.3 KiB with-main2.js 215 bytes
+  Entrypoint main3 12.6 KiB = with-manifest.js 12.3 KiB with-main3.js 215 bytes
+  runtime modules 7.64 KiB 9 modules
   cacheable modules 166 bytes
     ./main1.js 66 bytes [built] [code generated]
     ./main2.js 20 bytes [built] [code generated]
@@ -2518,7 +2518,7 @@ dynamic custom name:
   asset func-main2.js 215 bytes [emitted] (name: main2)
   asset func-main3.js 215 bytes [emitted] (name: main3)
   Entrypoint main1 12.9 KiB = func-b.js 12.3 KiB func-main1.js 596 bytes
-  Entrypoint main2 12.5 KiB = func-b.js 12.3 KiB func-main2.js 215 bytes
+  Entrypoint main2 12.6 KiB = func-b.js 12.3 KiB func-main2.js 215 bytes
   Entrypoint main3 5.38 KiB = func-a.js 5.17 KiB func-main3.js 215 bytes
   runtime modules 10.2 KiB 11 modules
   cacheable modules 166 bytes
@@ -2553,8 +2553,8 @@ exports[`StatsTestCases should print correct stats for runtime-specific-used-exp
   asset production-dy_js.js 1.14 KiB [emitted]
   asset production-dz_js.js 1.14 KiB [emitted]
   asset production-c.js 63 bytes [emitted] (name: c)
-  chunk (runtime: a) production-a.js (a) 605 bytes (javascript) 6.57 KiB (runtime) [entry] [rendered]
-    runtime modules 6.57 KiB 9 modules
+  chunk (runtime: a) production-a.js (a) 605 bytes (javascript) 6.59 KiB (runtime) [entry] [rendered]
+    runtime modules 6.59 KiB 9 modules
     cacheable modules 605 bytes
       ./a.js 261 bytes [built] [code generated]
         [no exports used]
@@ -2566,8 +2566,8 @@ exports[`StatsTestCases should print correct stats for runtime-specific-used-exp
         [only some exports used: x]
       ./reexport.js 37 bytes [dependent] [built] [code generated]
         [only some exports used: x]
-  chunk (runtime: b) production-b.js (b) 605 bytes (javascript) 6.57 KiB (runtime) [entry] [rendered]
-    runtime modules 6.57 KiB 9 modules
+  chunk (runtime: b) production-b.js (b) 605 bytes (javascript) 6.59 KiB (runtime) [entry] [rendered]
+    runtime modules 6.59 KiB 9 modules
     cacheable modules 605 bytes
       ./b.js 261 bytes [built] [code generated]
         [no exports used]
@@ -2602,7 +2602,7 @@ exports[`StatsTestCases should print correct stats for runtime-specific-used-exp
     ./dz.js 46 bytes [built] [code generated]
     ./module.js?chunk 122 bytes [dependent] [built] [code generated]
       [only some exports used: identity, w, x, z]
-  runtime modules 13.1 KiB 18 modules
+  runtime modules 13.2 KiB 18 modules
   cacheable modules 1.15 KiB
     ./a.js 261 bytes [built] [code generated]
       [no exports used]
@@ -2634,8 +2634,8 @@ development:
   asset development-dy_js.js 2.11 KiB [emitted]
   asset development-dz_js.js 2.11 KiB [emitted]
   asset development-c.js 731 bytes [emitted] (name: c)
-  chunk (runtime: a) development-a.js (a) 605 bytes (javascript) 6.57 KiB (runtime) [entry] [rendered]
-    runtime modules 6.57 KiB 9 modules
+  chunk (runtime: a) development-a.js (a) 605 bytes (javascript) 6.59 KiB (runtime) [entry] [rendered]
+    runtime modules 6.59 KiB 9 modules
     cacheable modules 605 bytes
       ./a.js 261 bytes [built] [code generated]
         [used exports unknown]
@@ -2647,8 +2647,8 @@ development:
         [used exports unknown]
       ./reexport.js 37 bytes [dependent] [built] [code generated]
         [used exports unknown]
-  chunk (runtime: b) development-b.js (b) 605 bytes (javascript) 6.57 KiB (runtime) [entry] [rendered]
-    runtime modules 6.57 KiB 9 modules
+  chunk (runtime: b) development-b.js (b) 605 bytes (javascript) 6.59 KiB (runtime) [entry] [rendered]
+    runtime modules 6.59 KiB 9 modules
     cacheable modules 605 bytes
       ./b.js 261 bytes [built] [code generated]
         [used exports unknown]
@@ -2683,7 +2683,7 @@ development:
       [used exports unknown]
     ./module.js?chunk 122 bytes [dependent] [built] [code generated]
       [used exports unknown]
-  runtime modules 13.1 KiB 18 modules
+  runtime modules 13.2 KiB 18 modules
   cacheable modules 1.15 KiB
     ./a.js 261 bytes [built] [code generated]
       [used exports unknown]
@@ -2719,8 +2719,8 @@ global:
   asset global-dy_js.js 1.16 KiB [emitted]
   asset global-dz_js.js 1.16 KiB [emitted]
   asset global-c.js 63 bytes [emitted] (name: c)
-  chunk (runtime: a) global-a.js (a) 605 bytes (javascript) 6.57 KiB (runtime) [entry] [rendered]
-    runtime modules 6.57 KiB 9 modules
+  chunk (runtime: a) global-a.js (a) 605 bytes (javascript) 6.59 KiB (runtime) [entry] [rendered]
+    runtime modules 6.59 KiB 9 modules
     cacheable modules 605 bytes
       ./a.js 261 bytes [built] [code generated]
         [no exports used]
@@ -2732,8 +2732,8 @@ global:
         [only some exports used: x, y]
       ./reexport.js 37 bytes [dependent] [built] [code generated]
         [only some exports used: x, y]
-  chunk (runtime: b) global-b.js (b) 605 bytes (javascript) 6.57 KiB (runtime) [entry] [rendered]
-    runtime modules 6.57 KiB 9 modules
+  chunk (runtime: b) global-b.js (b) 605 bytes (javascript) 6.59 KiB (runtime) [entry] [rendered]
+    runtime modules 6.59 KiB 9 modules
     cacheable modules 605 bytes
       ./b.js 261 bytes [built] [code generated]
         [no exports used]
@@ -2764,7 +2764,7 @@ global:
     ./dz.js 46 bytes [built] [code generated]
     ./module.js?chunk 122 bytes [dependent] [built] [code generated]
       [only some exports used: identity, w, x, y, z]
-  runtime modules 13.1 KiB 18 modules
+  runtime modules 13.2 KiB 18 modules
   cacheable modules 1.15 KiB
     ./a.js 261 bytes [built] [code generated]
       [no exports used]
@@ -2790,7 +2790,7 @@ global:
 `;
 
 exports[`StatsTestCases should print correct stats for scope-hoisting-bailouts 1`] = `
-"runtime modules 6.82 KiB 10 modules
+"runtime modules 6.84 KiB 10 modules
 built modules 615 bytes [built]
   code generated modules 530 bytes [code generated]
     modules by path ./*.js 377 bytes 7 modules
@@ -2808,7 +2808,7 @@ webpack x.x.x compiled successfully in X ms"
 exports[`StatsTestCases should print correct stats for scope-hoisting-multi 1`] = `
 "Entrypoint first 14.3 KiB = a-vendor.js 417 bytes a-first.js 13.9 KiB
 Entrypoint second 13.8 KiB = a-vendor.js 417 bytes a-second.js 13.4 KiB
-runtime modules 15.3 KiB 18 modules
+runtime modules 15.4 KiB 18 modules
 orphan modules 37 bytes [orphan] 1 module
 cacheable modules 807 bytes
   ./first.js 236 bytes [built] [code generated]
@@ -2824,8 +2824,8 @@ cacheable modules 807 bytes
 webpack x.x.x compiled successfully in X ms
 
 Entrypoint first 13.6 KiB = b-vendor.js 417 bytes b-first.js 13.2 KiB
-Entrypoint second 13.4 KiB = b-vendor.js 417 bytes b-second.js 13 KiB
-runtime modules 15.3 KiB 18 modules
+Entrypoint second 13.5 KiB = b-vendor.js 417 bytes b-second.js 13.1 KiB
+runtime modules 15.4 KiB 18 modules
 cacheable modules 975 bytes
   code generated modules 857 bytes [code generated]
     modules by path ./*.js + 1 modules 459 bytes 3 modules
@@ -2848,7 +2848,7 @@ webpack x.x.x compiled successfully in X ms"
 exports[`StatsTestCases should print correct stats for side-effects-issue-7428 1`] = `
 "asset main.js 12.2 KiB [emitted] (name: main)
 asset 1.js 638 bytes [emitted]
-runtime modules 6.56 KiB 9 modules
+runtime modules 6.58 KiB 9 modules
 cacheable modules 823 bytes
   modules by path ./components/src/ 501 bytes
     orphan modules 315 bytes [orphan]
@@ -3018,7 +3018,7 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
 "default:
-  Entrypoint main 11.4 KiB = default/main.js
+  Entrypoint main 11.5 KiB = default/main.js
   Entrypoint a 12.4 KiB = default/a.js
   Entrypoint b 3.75 KiB = default/b.js
   Entrypoint c 3.75 KiB = default/c.js
@@ -3030,9 +3030,9 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
   chunk (runtime: a, main) default/async-g.js (async-g) 45 bytes <{282}> <{767}> <{786}> <{794}> <{954}> ={568}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
+  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.67 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
     > ./ main
-    runtime modules 6.66 KiB 9 modules
+    runtime modules 6.67 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) default/282.js (id hint: vendors) 20 bytes <{179}> ={334}= ={383}= ={568}= ={767}= ={769}= ={794}= ={954}= >{137}< >{568}< [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -3063,9 +3063,9 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
   chunk (runtime: main) default/769.js (id hint: vendors) 20 bytes <{179}> ={282}= ={383}= ={568}= ={767}= [rendered] split chunk (cache group: defaultVendors)
     > ./c ./index.js 3:0-47
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.64 KiB (runtime) >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.66 KiB (runtime) >{137}< >{568}< [entry] [rendered]
     > ./a a
-    runtime modules 6.64 KiB 9 modules
+    runtime modules 6.66 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) default/async-a.js (async-a) 185 bytes <{179}> ={282}= ={767}= ={954}= >{137}< >{568}< [rendered]
@@ -3089,9 +3089,9 @@ all-chunks:
   chunk (runtime: a, main) all-chunks/async-g.js (async-g) 45 bytes <{282}> <{390}> <{767}> <{786}> <{794}> <{954}> ={568}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) all-chunks/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
+  chunk (runtime: main) all-chunks/main.js (main) 147 bytes (javascript) 6.68 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
     > ./ main
-    runtime modules 6.66 KiB 9 modules
+    runtime modules 6.68 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) all-chunks/282.js (id hint: vendors) 20 bytes <{179}> ={128}= ={334}= ={383}= ={390}= ={459}= ={568}= ={767}= ={769}= ={786}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -3134,9 +3134,9 @@ all-chunks:
     > ./c ./index.js 3:0-47
     > ./c c
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) all-chunks/a.js (a) 165 bytes (javascript) 7.7 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: a) all-chunks/a.js (a) 165 bytes (javascript) 7.72 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
     > ./a a
-    runtime modules 7.7 KiB 9 modules
+    runtime modules 7.72 KiB 9 modules
     ./a.js 165 bytes [built] [code generated]
   chunk (runtime: main) all-chunks/async-a.js (async-a) 165 bytes <{179}> ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [rendered]
     > ./a ./index.js 1:0-47
@@ -3151,7 +3151,7 @@ all-chunks:
 
 manual:
   Entrypoint main 11.2 KiB = manual/main.js
-  Entrypoint a 14.5 KiB = manual/vendors.js 1.07 KiB manual/a.js 13.4 KiB
+  Entrypoint a 14.5 KiB = manual/vendors.js 1.07 KiB manual/a.js 13.5 KiB
   Entrypoint b 8.2 KiB = manual/vendors.js 1.07 KiB manual/b.js 7.13 KiB
   Entrypoint c 8.2 KiB = manual/vendors.js 1.07 KiB manual/c.js 7.13 KiB
   chunk (runtime: b) manual/b.js (b) 156 bytes (javascript) 2.92 KiB (runtime) ={216}= [entry] [rendered]
@@ -3166,9 +3166,9 @@ manual:
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) manual/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
+  chunk (runtime: main) manual/main.js (main) 147 bytes (javascript) 6.68 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
     > ./ main
-    runtime modules 6.66 KiB 9 modules
+    runtime modules 6.68 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) manual/vendors.js (vendors) (id hint: vendors) 60 bytes <{179}> ={128}= ={334}= ={383}= ={459}= ={786}= ={794}= >{137}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
     > ./a ./index.js 1:0-47
@@ -3205,12 +3205,12 @@ manual:
     runtime modules 2.92 KiB 3 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: a) manual/a.js (a) 205 bytes (javascript) 7.69 KiB (runtime) ={216}= >{137}< [entry] [rendered]
+  chunk (runtime: a) manual/a.js (a) 205 bytes (javascript) 7.71 KiB (runtime) ={216}= >{137}< [entry] [rendered]
     > ./a a
     > x a
     > y a
     > z a
-    runtime modules 7.69 KiB 9 modules
+    runtime modules 7.71 KiB 9 modules
     dependent modules 20 bytes [dependent] 1 module
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) manual/async-a.js (async-a) 205 bytes <{179}> ={216}= >{137}< [rendered]
@@ -3227,9 +3227,9 @@ name-too-long:
   chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, main) name-too-long/async-g.js (async-g) 45 bytes <{282}> <{390}> <{751}> <{767}> <{794}> <{954}> ={568}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) name-too-long/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
+  chunk (runtime: main) name-too-long/main.js (main) 147 bytes (javascript) 6.68 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
     > ./ main
-    runtime modules 6.66 KiB 9 modules
+    runtime modules 6.68 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc, main) name-too-long/282.js (id hint: vendors) 20 bytes <{179}> ={334}= ={383}= ={390}= ={568}= ={658}= ={751}= ={766}= ={767}= ={769}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -3260,9 +3260,9 @@ name-too-long:
     > ./c cccccccccccccccccccccccccccccc
     runtime modules 2.89 KiB 3 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) 165 bytes (javascript) 7.7 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) 165 bytes (javascript) 7.72 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
     > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    runtime modules 7.7 KiB 9 modules
+    runtime modules 7.72 KiB 9 modules
     ./a.js 165 bytes [built] [code generated]
   chunk (runtime: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) 116 bytes (javascript) 2.89 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
     > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
@@ -3293,7 +3293,7 @@ name-too-long:
 
 custom-chunks-filter:
   Entrypoint main 11.5 KiB = custom-chunks-filter/main.js
-  Entrypoint a 12.4 KiB = custom-chunks-filter/a.js
+  Entrypoint a 12.5 KiB = custom-chunks-filter/a.js
   Entrypoint b 8.05 KiB = custom-chunks-filter/282.js 412 bytes custom-chunks-filter/954.js 412 bytes custom-chunks-filter/568.js 412 bytes custom-chunks-filter/767.js 412 bytes custom-chunks-filter/b.js 6.44 KiB
   Entrypoint c 8.05 KiB = custom-chunks-filter/282.js 412 bytes custom-chunks-filter/769.js 412 bytes custom-chunks-filter/568.js 412 bytes custom-chunks-filter/767.js 412 bytes custom-chunks-filter/c.js 6.44 KiB
   chunk (runtime: b) custom-chunks-filter/b.js (b) 116 bytes (javascript) 2.89 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
@@ -3303,9 +3303,9 @@ custom-chunks-filter:
   chunk (runtime: a, main) custom-chunks-filter/async-g.js (async-g) 45 bytes <{282}> <{767}> <{786}> <{794}> <{954}> ={568}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) custom-chunks-filter/main.js (main) 147 bytes (javascript) 6.67 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
+  chunk (runtime: main) custom-chunks-filter/main.js (main) 147 bytes (javascript) 6.69 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
     > ./ main
-    runtime modules 6.67 KiB 9 modules
+    runtime modules 6.69 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: b, c, main) custom-chunks-filter/282.js (id hint: vendors) 20 bytes <{179}> ={128}= ={334}= ={383}= ={459}= ={568}= ={767}= ={769}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -3342,9 +3342,9 @@ custom-chunks-filter:
     > ./c ./index.js 3:0-47
     > ./c c
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) custom-chunks-filter/a.js (a) 245 bytes (javascript) 6.66 KiB (runtime) >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: a) custom-chunks-filter/a.js (a) 245 bytes (javascript) 6.67 KiB (runtime) >{137}< >{568}< [entry] [rendered]
     > ./a a
-    runtime modules 6.66 KiB 9 modules
+    runtime modules 6.67 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) custom-chunks-filter/async-a.js (async-a) 185 bytes <{179}> ={282}= ={767}= ={954}= >{137}< >{568}< [rendered]
@@ -3359,7 +3359,7 @@ custom-chunks-filter:
 
 custom-chunks-filter-in-cache-groups:
   Entrypoint main 11.3 KiB = custom-chunks-filter-in-cache-groups/main.js
-  Entrypoint a 14.3 KiB = custom-chunks-filter-in-cache-groups/176.js 888 bytes custom-chunks-filter-in-cache-groups/a.js 13.5 KiB
+  Entrypoint a 14.4 KiB = custom-chunks-filter-in-cache-groups/176.js 888 bytes custom-chunks-filter-in-cache-groups/a.js 13.5 KiB
   Entrypoint b 8.21 KiB = custom-chunks-filter-in-cache-groups/vendors.js 1.07 KiB custom-chunks-filter-in-cache-groups/b.js 7.13 KiB
   Entrypoint c 8.21 KiB = custom-chunks-filter-in-cache-groups/vendors.js 1.07 KiB custom-chunks-filter-in-cache-groups/c.js 7.13 KiB
   chunk (runtime: b) custom-chunks-filter-in-cache-groups/b.js (b) 156 bytes (javascript) 2.92 KiB (runtime) ={216}= [entry] [rendered]
@@ -3382,9 +3382,9 @@ custom-chunks-filter-in-cache-groups:
     ./node_modules/x.js 20 bytes [built] [code generated]
     ./node_modules/y.js 20 bytes [built] [code generated]
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: main) custom-chunks-filter-in-cache-groups/main.js (main) 147 bytes (javascript) 6.69 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
+  chunk (runtime: main) custom-chunks-filter-in-cache-groups/main.js (main) 147 bytes (javascript) 6.71 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
     > ./ main
-    runtime modules 6.69 KiB 9 modules
+    runtime modules 6.71 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: b, c, main) custom-chunks-filter-in-cache-groups/vendors.js (vendors) (id hint: vendors) 60 bytes <{179}> ={128}= ={334}= ={383}= ={459}= ={794}= >{137}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
     > ./a ./index.js 1:0-47
@@ -3417,12 +3417,12 @@ custom-chunks-filter-in-cache-groups:
     runtime modules 2.92 KiB 3 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: a) custom-chunks-filter-in-cache-groups/a.js (a) 205 bytes (javascript) 7.72 KiB (runtime) ={176}= >{137}< [entry] [rendered]
+  chunk (runtime: a) custom-chunks-filter-in-cache-groups/a.js (a) 205 bytes (javascript) 7.74 KiB (runtime) ={176}= >{137}< [entry] [rendered]
     > ./a a
     > x a
     > y a
     > z a
-    runtime modules 7.72 KiB 9 modules
+    runtime modules 7.74 KiB 9 modules
     dependent modules 20 bytes [dependent] 1 module
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) custom-chunks-filter-in-cache-groups/async-a.js (async-a) 205 bytes <{179}> ={216}= >{137}< [rendered]
@@ -3464,18 +3464,18 @@ chunk (runtime: main) common-node_modules_y_js.js (id hint: common) 20 bytes <{m
 chunk (runtime: main) common-node_modules_z_js.js (id hint: common) 20 bytes <{main}> ={async-c}= ={common-d_js}= ={common-f_js}= ={common-node_modules_x_js}= [rendered] split chunk (cache group: b)
   > ./c ./index.js 3:0-47
   ./node_modules/z.js 20 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.57 KiB (runtime) >{async-a}< >{async-b}< >{async-c}< >{common-d_js}< >{common-f_js}< >{common-node_modules_x_js}< >{common-node_modules_y_js}< >{common-node_modules_z_js}< [entry] [rendered]
+chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.58 KiB (runtime) >{async-a}< >{async-b}< >{async-c}< >{common-d_js}< >{common-f_js}< >{common-node_modules_x_js}< >{common-node_modules_y_js}< >{common-node_modules_z_js}< [entry] [rendered]
   > ./ main
-  runtime modules 6.57 KiB 9 modules
+  runtime modules 6.58 KiB 9 modules
   ./index.js 147 bytes [built] [code generated]
 production (webpack x.x.x) compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-chunk-name 1`] = `
 "Entrypoint main 11.2 KiB = default/main.js
-chunk (runtime: main) default/main.js (main) 192 bytes (javascript) 6.63 KiB (runtime) >{334}< >{709}< >{794}< [entry] [rendered]
+chunk (runtime: main) default/main.js (main) 192 bytes (javascript) 6.65 KiB (runtime) >{334}< >{709}< >{794}< [entry] [rendered]
   > ./ main
-  runtime modules 6.63 KiB 9 modules
+  runtime modules 6.65 KiB 9 modules
   ./index.js 192 bytes [built] [code generated]
 chunk (runtime: main) default/async-b.js (async-b) (id hint: vendors) 122 bytes <{179}> [rendered] reused as split chunk (cache group: defaultVendors)
   > b ./index.js 2:0-45
@@ -3491,7 +3491,7 @@ webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-combinations 1`] = `
-"Entrypoint main 11.6 KiB = main.js
+"Entrypoint main 11.7 KiB = main.js
 chunk (runtime: main) async-d.js (async-d) 132 bytes <{179}> [rendered]
   > ./d ./index.js 4:0-47
   dependent modules 87 bytes [dependent] 1 module
@@ -3500,9 +3500,9 @@ chunk (runtime: main) async-g.js (async-g) 132 bytes <{179}> [rendered]
   > ./g ./index.js 7:0-47
   dependent modules 87 bytes [dependent] 1 module
   ./g.js 45 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 343 bytes (javascript) 6.69 KiB (runtime) >{31}< >{137}< >{206}< >{334}< >{383}< >{449}< >{794}< >{804}< [entry] [rendered]
+chunk (runtime: main) main.js (main) 343 bytes (javascript) 6.7 KiB (runtime) >{31}< >{137}< >{206}< >{334}< >{383}< >{449}< >{794}< >{804}< [entry] [rendered]
   > ./ main
-  runtime modules 6.69 KiB 9 modules
+  runtime modules 6.7 KiB 9 modules
   ./index.js 343 bytes [built] [code generated]
 chunk (runtime: main) async-f.js (async-f) 132 bytes <{179}> [rendered]
   > ./f ./index.js 6:0-47
@@ -3532,9 +3532,9 @@ webpack x.x.x compiled successfully"
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-6413 1`] = `
 "Entrypoint main 11.3 KiB = main.js
-chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.63 KiB (runtime) >{282}< >{334}< >{383}< >{543}< >{794}< [entry] [rendered]
+chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.64 KiB (runtime) >{282}< >{334}< >{383}< >{543}< >{794}< [entry] [rendered]
   > ./ main
-  runtime modules 6.63 KiB 9 modules
+  runtime modules 6.64 KiB 9 modules
   ./index.js 147 bytes [built] [code generated]
 chunk (runtime: main) 282.js (id hint: vendors) 20 bytes <{179}> ={334}= ={383}= ={543}= ={794}= [rendered] split chunk (cache group: defaultVendors)
   > ./a ./index.js 1:0-47
@@ -3560,9 +3560,9 @@ default (webpack x.x.x) compiled successfully"
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-6696 1`] = `
 "Entrypoint main 13.3 KiB = vendors.js 412 bytes main.js 12.9 KiB
-chunk (runtime: main) main.js (main) 134 bytes (javascript) 7.66 KiB (runtime) ={216}= >{334}< >{794}< [entry] [rendered]
+chunk (runtime: main) main.js (main) 134 bytes (javascript) 7.68 KiB (runtime) ={216}= >{334}< >{794}< [entry] [rendered]
   > ./ main
-  runtime modules 7.66 KiB 9 modules
+  runtime modules 7.68 KiB 9 modules
   ./index.js 134 bytes [built] [code generated]
 chunk (runtime: main) vendors.js (vendors) (id hint: vendors) 20 bytes ={179}= >{334}< >{794}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
   > ./ main
@@ -3582,9 +3582,9 @@ exports[`StatsTestCases should print correct stats for split-chunks-issue-7401 1
 "Entrypoint a 6.35 KiB = 282.js 412 bytes a.js 5.94 KiB
 Entrypoint b 10.9 KiB = b.js
 Chunk Group c 792 bytes = 282.js 412 bytes c.js 380 bytes
-chunk (runtime: b) b.js (b) 43 bytes (javascript) 6.59 KiB (runtime) >{282}< >{459}< [entry] [rendered]
+chunk (runtime: b) b.js (b) 43 bytes (javascript) 6.61 KiB (runtime) >{282}< >{459}< [entry] [rendered]
   > ./b b
-  runtime modules 6.59 KiB 9 modules
+  runtime modules 6.61 KiB 9 modules
   ./b.js 43 bytes [built] [code generated]
 chunk (runtime: a, b) 282.js (id hint: vendors) 20 bytes <{128}> ={459}= ={786}= [initial] [rendered] split chunk (cache group: defaultVendors)
   > ./c ./b.js 1:0-41
@@ -3605,9 +3605,9 @@ exports[`StatsTestCases should print correct stats for split-chunks-keep-remaini
 chunk (runtime: main) default/async-d.js (async-d) 84 bytes <{179}> ={782}= [rendered]
   > ./d ./index.js 4:0-47
   ./d.js 84 bytes [built] [code generated]
-chunk (runtime: main) default/main.js (main) 196 bytes (javascript) 6.66 KiB (runtime) >{31}< >{334}< >{383}< >{782}< >{794}< >{821}< [entry] [rendered]
+chunk (runtime: main) default/main.js (main) 196 bytes (javascript) 6.67 KiB (runtime) >{31}< >{334}< >{383}< >{782}< >{794}< >{821}< [entry] [rendered]
   > ./ main
-  runtime modules 6.66 KiB 9 modules
+  runtime modules 6.67 KiB 9 modules
   ./index.js 196 bytes [built] [code generated]
 chunk (runtime: main) default/async-b.js (async-b) 50 bytes <{179}> ={821}= [rendered]
   > ./b ./index.js 2:0-47
@@ -3913,9 +3913,9 @@ zero-min:
 
 max-async-size:
   Entrypoint main 15.8 KiB = max-async-size-main.js
-  chunk (runtime: main) max-async-size-main.js (main) 2.46 KiB (javascript) 6.93 KiB (runtime) >{342}< >{385}< >{820}< >{920}< [entry] [rendered]
+  chunk (runtime: main) max-async-size-main.js (main) 2.46 KiB (javascript) 6.95 KiB (runtime) >{342}< >{385}< >{820}< >{920}< [entry] [rendered]
     > ./async main
-    runtime modules 6.93 KiB 10 modules
+    runtime modules 6.95 KiB 10 modules
     dependent modules 2.09 KiB [dependent] 6 modules
     ./async/index.js 386 bytes [built] [code generated]
   chunk (runtime: main) max-async-size-async-b-77a8c116.js (async-b-77a8c116) 1.57 KiB <{179}> ={385}= ={820}= ={920}= [rendered]
@@ -4025,9 +4025,9 @@ chunk (runtime: main) default/118.js 150 bytes <{179}> ={334}= ={383}= [rendered
   > ./c ./index.js 3:0-47
   ./d.js 63 bytes [built] [code generated]
   ./f.js 87 bytes [built] [code generated]
-chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.64 KiB (runtime) >{118}< >{334}< >{383}< >{794}< [entry] [rendered]
+chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) >{118}< >{334}< >{383}< >{794}< [entry] [rendered]
   > ./ main
-  runtime modules 6.64 KiB 9 modules
+  runtime modules 6.66 KiB 9 modules
   ./index.js 147 bytes [built] [code generated]
 chunk (runtime: main) default/async-b.js (async-b) 158 bytes <{179}> ={118}= [rendered]
   > ./b ./index.js 2:0-47
@@ -4162,8 +4162,8 @@ assets by path *.wasm 1.37 KiB
   asset 27eb6405bf771edbf2bd.module.wasm 120 bytes [emitted] [immutable]
 chunk (runtime: main) 99.bundle.js 50 bytes (javascript) 531 bytes (webassembly) [rendered]
   ./duff.wasm 50 bytes (javascript) 531 bytes (webassembly) [built] [code generated]
-chunk (runtime: main) bundle.js (main) 586 bytes (javascript) 7.08 KiB (runtime) [entry] [rendered]
-  runtime modules 7.08 KiB 10 modules
+chunk (runtime: main) bundle.js (main) 586 bytes (javascript) 7.1 KiB (runtime) [entry] [rendered]
+  runtime modules 7.1 KiB 10 modules
   ./index.js 586 bytes [built] [code generated]
 chunk (runtime: main) 230.bundle.js 50 bytes (javascript) 156 bytes (webassembly) [rendered]
   ./Q_rsqrt.wasm 50 bytes (javascript) 156 bytes (webassembly) [built] [code generated]
@@ -4176,7 +4176,7 @@ chunk (runtime: main) 526.bundle.js (id hint: vendors) 34 bytes [rendered] split
 chunk (runtime: main) 780.bundle.js 110 bytes (javascript) 444 bytes (webassembly) [rendered]
   ./fact.wasm 50 bytes (javascript) 154 bytes (webassembly) [built] [code generated]
   ./fast-math.wasm 60 bytes (javascript) 290 bytes (webassembly) [built] [code generated]
-runtime modules 7.08 KiB 10 modules
+runtime modules 7.1 KiB 10 modules
 cacheable modules 2.31 KiB (javascript) 1.37 KiB (webassembly)
   webassembly modules 310 bytes (javascript) 1.37 KiB (webassembly)
     ./Q_rsqrt.wasm 50 bytes (javascript) 156 bytes (webassembly) [built] [code generated]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

`chunkId` was available in webpack 4 and to improve migration it should be available in webapck 5 too.

#10826

cc @jscheid 

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
