### PR TITLE
Fix runtime type error in WatchIgnorePlugin

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -222,9 +222,9 @@ class Compiler {
 		this.modifiedFiles = undefined;
 		/** @type {Set<string>} */
 		this.removedFiles = undefined;
-		/** @type {Map<string, FileSystemInfoEntry | null>} */
+		/** @type {Map<string, FileSystemInfoEntry | "ignore" | null>} */
 		this.fileTimestamps = undefined;
-		/** @type {Map<string, FileSystemInfoEntry | null>} */
+		/** @type {Map<string, FileSystemInfoEntry | "ignore" | null>} */
 		this.contextTimestamps = undefined;
 
 		/** @type {ResolverFactory} */

--- a/lib/WatchIgnorePlugin.js
+++ b/lib/WatchIgnorePlugin.js
@@ -63,7 +63,7 @@ class IgnoringWatchFileSystem {
 			close: () => watcher.close(),
 			pause: () => watcher.pause(),
 			getContextTimeInfoEntries: () => {
-				const dirTimestamps = watcher.getContextInfoEntries();
+				const dirTimestamps = watcher.getContextTimeInfoEntries();
 				for (const path of ignoredDirs) {
 					dirTimestamps.set(path, IGNORE_TIME_ENTRY);
 				}

--- a/lib/WatchIgnorePlugin.js
+++ b/lib/WatchIgnorePlugin.js
@@ -10,10 +10,15 @@ const schema = require("../schemas/plugins/WatchIgnorePlugin.json");
 
 /** @typedef {import("../declarations/plugins/WatchIgnorePlugin").WatchIgnorePluginOptions} WatchIgnorePluginOptions */
 /** @typedef {import("./Compiler")} Compiler */
+/** @typedef {import("./util/fs").WatchFileSystem} WatchFileSystem */
 
 const IGNORE_TIME_ENTRY = "ignore";
 
 class IgnoringWatchFileSystem {
+	/**
+	 * @param {WatchFileSystem} wfs original file system
+	 * @param {(string|RegExp)[]} paths ignored paths
+	 */
 	constructor(wfs, paths) {
 		this.wfs = wfs;
 		this.paths = paths;

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -24,8 +24,8 @@ const path = require("path");
  * @typedef {Object} Watcher
  * @property {function(): void} close closes the watcher and all underlying file watchers
  * @property {function(): void} pause closes the watcher, but keeps underlying file watchers alive until the next watch call
- * @property {function(): Map<string, FileSystemInfoEntry>} getFileTimeInfoEntries get info about files
- * @property {function(): Map<string, FileSystemInfoEntry>} getContextTimeInfoEntries get info about directories
+ * @property {function(): Map<string, FileSystemInfoEntry | "ignore">} getFileTimeInfoEntries get info about files
+ * @property {function(): Map<string, FileSystemInfoEntry | "ignore">} getContextTimeInfoEntries get info about directories
  */
 
 /**
@@ -35,7 +35,7 @@ const path = require("path");
  * @param {Iterable<string>} missing watched exitance entries
  * @param {number} startTime timestamp of start time
  * @param {WatchOptions} options options object
- * @param {function(Error=, Map<string, FileSystemInfoEntry>, Map<string, FileSystemInfoEntry>, Set<string>, Set<string>): void} callback aggregated callback
+ * @param {function(Error=, Map<string, FileSystemInfoEntry | "ignore">, Map<string, FileSystemInfoEntry | "ignore">, Set<string>, Set<string>): void} callback aggregated callback
  * @param {function(string, number): void} callbackUndelayed callback when the first change was detected
  * @returns {Watcher} a watcher
  */

--- a/types.d.ts
+++ b/types.d.ts
@@ -1600,8 +1600,8 @@ declare class Compiler {
 	immutablePaths: Set<string>;
 	modifiedFiles: Set<string>;
 	removedFiles: Set<string>;
-	fileTimestamps: Map<string, null | FileSystemInfoEntry>;
-	contextTimestamps: Map<string, null | FileSystemInfoEntry>;
+	fileTimestamps: Map<string, null | FileSystemInfoEntry | "ignore">;
+	contextTimestamps: Map<string, null | FileSystemInfoEntry | "ignore">;
 	resolverFactory: ResolverFactory;
 	infrastructureLogger: any;
 	options: WebpackOptionsNormalized;
@@ -10070,8 +10070,8 @@ declare interface WatchFileSystem {
 		options: WatchOptions,
 		callback: (
 			arg0: undefined | Error,
-			arg1: Map<string, FileSystemInfoEntry>,
-			arg2: Map<string, FileSystemInfoEntry>,
+			arg1: Map<string, FileSystemInfoEntry | "ignore">,
+			arg2: Map<string, FileSystemInfoEntry | "ignore">,
 			arg3: Set<string>,
 			arg4: Set<string>
 		) => void,
@@ -10137,12 +10137,12 @@ declare interface Watcher {
 	/**
 	 * get info about files
 	 */
-	getFileTimeInfoEntries: () => Map<string, FileSystemInfoEntry>;
+	getFileTimeInfoEntries: () => Map<string, FileSystemInfoEntry | "ignore">;
 
 	/**
 	 * get info about directories
 	 */
-	getContextTimeInfoEntries: () => Map<string, FileSystemInfoEntry>;
+	getContextTimeInfoEntries: () => Map<string, FileSystemInfoEntry | "ignore">;
 }
 declare abstract class Watching {
 	startTime: null | number;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
I started using WatchIgnorePlugin and it generates a runtime error like
```
TypeError: watcher.getContextInfoEntries is not a function
    at Object.getContextTimeInfoEntries
    at Watching.invalidate
```
<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
This PR changes a callsite to use the correct function name
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
This is a blatant type error in master, as demonstrated by these searches: https://github.com/webpack/webpack/search?q=getContextInfoEntries
https://github.com/webpack/webpack/search?q=getContextTimeInfoEntries
I do not consider adding a test for this to be necessary.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
There is nothing to add to the documentation
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
