### PR TITLE
add resolve.preferAbsolute option

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1362,6 +1362,10 @@ export interface ResolveOptions {
 	 */
 	plugins?: ("..." | ResolvePluginInstance)[];
 	/**
+	 * Prefer to resolve server-relative URLs (starting with '/') as absolute paths before falling back to resolve in 'resolve.roots'.
+	 */
+	preferAbsolute?: boolean;
+	/**
 	 * Prefer to resolve module requests as relative request and fallback to resolving as module.
 	 */
 	preferRelative?: boolean;
@@ -1374,7 +1378,7 @@ export interface ResolveOptions {
 	 */
 	restrictions?: (RegExp | string)[];
 	/**
-	 * A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.
+	 * A list of directories in which requests that are server-relative URLs (starting with '/') are resolved.
 	 */
 	roots?: string[];
 	/**

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "acorn": "^8.0.4",
     "browserslist": "^4.14.5",
     "chrome-trace-event": "^1.0.2",
-    "enhanced-resolve": "^5.3.1",
+    "enhanced-resolve": "^5.5.0",
     "eslint-scope": "^5.1.1",
     "events": "^3.2.0",
     "glob-to-regexp": "^0.4.1",

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -2861,6 +2861,10 @@
             ]
           }
         },
+        "preferAbsolute": {
+          "description": "Prefer to resolve server-relative URLs (starting with '/') as absolute paths before falling back to resolve in 'resolve.roots'.",
+          "type": "boolean"
+        },
         "preferRelative": {
           "description": "Prefer to resolve module requests as relative request and fallback to resolving as module.",
           "type": "boolean"
@@ -2888,7 +2892,7 @@
           }
         },
         "roots": {
-          "description": "A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.",
+          "description": "A list of directories in which requests that are server-relative URLs (starting with '/') are resolved.",
           "type": "array",
           "items": {
             "description": "Directory in which requests that are server-relative URLs (starting with '/') are resolved.",

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -5122,6 +5122,19 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
+  "resolve-loader-prefer-absolute": Object {
+    "configs": Array [
+      Object {
+        "description": "Prefer to resolve server-relative URLs (starting with '/') as absolute paths before falling back to resolve in 'resolve.roots'.",
+        "multiple": false,
+        "path": "resolveLoader.preferAbsolute",
+        "type": "boolean",
+      },
+    ],
+    "description": "Prefer to resolve server-relative URLs (starting with '/') as absolute paths before falling back to resolve in 'resolve.roots'.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "resolve-loader-prefer-relative": Object {
     "configs": Array [
       Object {
@@ -5183,13 +5196,13 @@ Object {
   "resolve-loader-roots-reset": Object {
     "configs": Array [
       Object {
-        "description": "Clear all items provided in configuration. A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.",
+        "description": "Clear all items provided in configuration. A list of directories in which requests that are server-relative URLs (starting with '/') are resolved.",
         "multiple": false,
         "path": "resolveLoader.roots",
         "type": "reset",
       },
     ],
-    "description": "Clear all items provided in configuration. A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.",
+    "description": "Clear all items provided in configuration. A list of directories in which requests that are server-relative URLs (starting with '/') are resolved.",
     "multiple": false,
     "simpleType": "boolean",
   },
@@ -5310,6 +5323,19 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
+  "resolve-prefer-absolute": Object {
+    "configs": Array [
+      Object {
+        "description": "Prefer to resolve server-relative URLs (starting with '/') as absolute paths before falling back to resolve in 'resolve.roots'.",
+        "multiple": false,
+        "path": "resolve.preferAbsolute",
+        "type": "boolean",
+      },
+    ],
+    "description": "Prefer to resolve server-relative URLs (starting with '/') as absolute paths before falling back to resolve in 'resolve.roots'.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "resolve-prefer-relative": Object {
     "configs": Array [
       Object {
@@ -5371,13 +5397,13 @@ Object {
   "resolve-roots-reset": Object {
     "configs": Array [
       Object {
-        "description": "Clear all items provided in configuration. A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.",
+        "description": "Clear all items provided in configuration. A list of directories in which requests that are server-relative URLs (starting with '/') are resolved.",
         "multiple": false,
         "path": "resolve.roots",
         "type": "reset",
       },
     ],
-    "description": "Clear all items provided in configuration. A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.",
+    "description": "Clear all items provided in configuration. A list of directories in which requests that are server-relative URLs (starting with '/') are resolved.",
     "multiple": false,
     "simpleType": "boolean",
   },

--- a/test/configCases/resolving/prefer-absolute/index.js
+++ b/test/configCases/resolving/prefer-absolute/index.js
@@ -1,0 +1,3 @@
+it("should be possible to import an absolute path", () => {
+	require(__filename);
+});

--- a/test/configCases/resolving/prefer-absolute/webpack.config.js
+++ b/test/configCases/resolving/prefer-absolute/webpack.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+	resolve: {
+		preferAbsolute: true,
+		plugins: [
+			{
+				apply(resolver) {
+					resolver.hooks.file.tap("Test", (request, resolverContext) => {
+						if (/test.configCases.*test.configCases/.test(request.path))
+							throw new Error("Trying to resolve as root path");
+					});
+				}
+			}
+		]
+	}
+};

--- a/test/configCases/resolving/prefer-root/index.js
+++ b/test/configCases/resolving/prefer-root/index.js
@@ -1,0 +1,3 @@
+it("should be possible to import an root path", () => {
+	require("/index.js");
+});

--- a/test/configCases/resolving/prefer-root/webpack.config.js
+++ b/test/configCases/resolving/prefer-root/webpack.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+	resolve: {
+		plugins: [
+			{
+				apply(resolver) {
+					resolver.hooks.file.tap("Test", (request, resolverContext) => {
+						if (request.path === "/index.js")
+							throw new Error("Trying to resolve as absolute path");
+					});
+				}
+			}
+		]
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -7666,6 +7666,7 @@ declare interface ResolveOptionsTypes {
 	resolveToContext: boolean;
 	restrictions: Set<string | RegExp>;
 	preferRelative: boolean;
+	preferAbsolute: boolean;
 }
 
 /**
@@ -7798,6 +7799,11 @@ declare interface ResolveOptionsWebpackOptions {
 	plugins?: ("..." | ResolvePluginInstance)[];
 
 	/**
+	 * Prefer to resolve server-relative URLs (starting with '/') as absolute paths before falling back to resolve in 'resolve.roots'.
+	 */
+	preferAbsolute?: boolean;
+
+	/**
 	 * Prefer to resolve module requests as relative request and fallback to resolving as module.
 	 */
 	preferRelative?: boolean;
@@ -7813,7 +7819,7 @@ declare interface ResolveOptionsWebpackOptions {
 	restrictions?: (string | RegExp)[];
 
 	/**
-	 * A list of directories in which requests that are server-relative URLs (starting with '/') are resolved. On non-windows system these requests are tried to resolve as absolute path first.
+	 * A list of directories in which requests that are server-relative URLs (starting with '/') are resolved.
 	 */
 	roots?: string[];
 
@@ -10050,6 +10056,11 @@ declare interface UserResolveOptions {
 	 * Prefer to resolve module requests as relative requests before falling back to modules
 	 */
 	preferRelative?: boolean;
+
+	/**
+	 * Prefer to resolve server-relative urls as absolute paths before falling back to resolve in roots
+	 */
+	preferAbsolute?: boolean;
 }
 declare abstract class VariableInfo {
 	declaredScope: ScopeInfo;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2304,10 +2304,10 @@ enhanced-resolve@^4.0.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^5.3.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.4.1.tgz#c89b0c34f17f931902ef2913a125d4b825b49b6f"
-  integrity sha512-4GbyIMzYktTFoRSmkbgZ1LU+RXwf4AQ8Z+rSuuh1dC8plp0PPeaWvx6+G4hh4KnUJ48VoxKbNyA1QQQIUpXjYA==
+enhanced-resolve@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.5.0.tgz#5f2ca7d511076541e2a30dc364a40c4f6c027bcd"
+  integrity sha512-b4a6BasBCoLzri4MdaeOlDMpls2oioI28CF17csMiav9dq46yvQaKPFNUrCHB6VqQokBDG2VIEEL81jMiQ6Wtw==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
new option `resolve.preferAbsolute`
it changes the order of `resolve.roots` and absolute paths. Usually `resolve.roots` is tried first and falling back to absolute paths. This option reverses the order.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
