### PR TITLE
Add chunkModulesSpace property to stats schema

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -2118,6 +2118,10 @@ export interface StatsOptions {
 	 */
 	chunkModules?: boolean;
 	/**
+	 * Space to display chunk modules (groups will be collapsed to fit this space, value is in number of modules/group).
+	 */
+	chunkModulesSpace?: number;
+	/**
 	 * Add the origins of chunks and chunk merging info.
 	 */
 	chunkOrigins?: boolean;

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -3542,6 +3542,10 @@
           "description": "Add built modules information to chunk information.",
           "type": "boolean"
         },
+        "chunkModulesSpace": {
+          "description": "Space to display chunk modules (groups will be collapsed to fit this space, value is in number of modules/group).",
+          "type": "number"
+        },
         "chunkOrigins": {
           "description": "Add the origins of chunks and chunk merging info.",
           "type": "boolean"

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -5813,6 +5813,19 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
+  "stats-chunk-modules-space": Object {
+    "configs": Array [
+      Object {
+        "description": "Space to display chunk modules (groups will be collapsed to fit this space, value is in number of modules/group).",
+        "multiple": false,
+        "path": "stats.chunkModulesSpace",
+        "type": "number",
+      },
+    ],
+    "description": "Space to display chunk modules (groups will be collapsed to fit this space, value is in number of modules/group).",
+    "multiple": false,
+    "simpleType": "number",
+  },
   "stats-chunk-origins": Object {
     "configs": Array [
       Object {

--- a/types.d.ts
+++ b/types.d.ts
@@ -9550,6 +9550,11 @@ declare interface StatsOptions {
 	chunkModules?: boolean;
 
 	/**
+	 * Space to display chunk modules (groups will be collapsed to fit this space, value is in number of modules/group).
+	 */
+	chunkModulesSpace?: number;
+
+	/**
 	 * Add the origins of chunks and chunk merging info.
 	 */
 	chunkOrigins?: boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
`Stats` doesn't have a `chunkModulesSpace` property as mentioned in the docs. I have added the property to schema and updated the types. This PR closes #12411.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
It adds ```chunkModulesSpace``` property to `stats`.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->


**Did you add tests for your changes?**
Yes. I've updated the test snapshots.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->


**What needs to be documented once your changes are merged?**
None. It's already documented [here](https://webpack.js.org/configuration/stats/#statschunkmodulesspace). 
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
