### PR TITLE
Handle case insensitive Windows paths better in unit tests

### DIFF
--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -5,7 +5,10 @@ const fs = require("graceful-fs");
 const webpack = require("..");
 const prettyFormat = require("pretty-format");
 
-const CWD_PATTERN = new RegExp(process.cwd().replace(/\\/g, "/"), "gm");
+const CWD_PATTERN = new RegExp(
+	process.cwd().replace(/\\/g, "/"),
+	process.platform === "win32" ? "gmi" : "gm"
+);
 const ERROR_STACK_PATTERN = /(?:\n\s+at\s.*)+/gm;
 
 function cleanError(err) {

--- a/test/cases/esm/import-meta/index.js
+++ b/test/cases/esm/import-meta/index.js
@@ -23,9 +23,18 @@ it('typeof import.meta.webpack === "number"', () => {
 });
 
 it("should return correct import.meta.url", () => {
-	expect(import.meta.url).toBe(url);
-	expect(import.meta["url"]).toBe(url);
-	expect("my" + import.meta.url).toBe("my" + url);
+	let expectedUrl = url;
+	if (process.platform === "win32") {
+		// on Windows this test might need to compare `file:///C:/folder/...` with `file:///c:/folder/...`
+		const actualDrive = import.meta.url.substr(0, 9);
+		const expectedDrive = expectedUrl.substr(0, 9);
+		expect(actualDrive.toUpperCase()).toBe(expectedDrive.toUpperCase());
+		expectedUrl = actualDrive + expectedUrl.substr(9);
+	}
+
+	expect(import.meta.url).toBe(expectedUrl);
+	expect(import.meta["url"]).toBe(expectedUrl);
+	expect("my" + import.meta.url).toBe("my" + expectedUrl);
 	if (import.meta.url.indexOf("index.js") === -1) require("fail");
 });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Improve Windows compatibility in unit tests in cases where `c:\Folder\file` is being compared to `C:\Folder\file` - the paths should be considered identical and not fail tests.

**Did you add tests for your changes?**

Existing tests were failing.

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

nothing