### PR TITLE
Fix new Worker() compatibility check in unit tests for older node versions

### DIFF
--- a/test/helpers/supportsWorker.js
+++ b/test/helpers/supportsWorker.js
@@ -1,8 +1,14 @@
+const nodeVersion = process.versions.node.split(".").map(Number);
+
 module.exports = function supportsWorker() {
-	try {
-		// eslint-disable-next-line node/no-unsupported-features/node-builtins
-		return require("worker_threads") !== undefined;
-	} catch (e) {
-		return false;
+	// Verify that in the current node version new Worker() accepts URL as the first parameter:
+	// https://nodejs.org/api/worker_threads.html#worker_threads_new_worker_filename_options
+	if (nodeVersion[0] >= 14) {
+		return true;
+	} else if (nodeVersion[0] === 13 && nodeVersion[1] >= 12) {
+		return true;
+	} else if (nodeVersion[0] === 12 && nodeVersion[1] >= 17) {
+		return true;
 	}
+	return false;
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

compatibility fix for unit tests when running on older node.js versions that do not support `new Worker(new Url())`

**Did you add tests for your changes?**

existing tests were failing on older node versions

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

nothing