### PR TITLE
Fix module rebuilds that add new dependencies

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1871,6 +1871,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 				});
 			}
 
+			this.processDependenciesQueue.invalidate(module);
 			this.processModuleDependencies(module, err => {
 				if (err) return callback(err);
 				this.removeReasonsOfDependencyBlock(module, {

--- a/test/configCases/rebuild/rebuildWithNewDependencies/a.js
+++ b/test/configCases/rebuild/rebuildWithNewDependencies/a.js
@@ -1,0 +1,1 @@
+export default "a.js";

--- a/test/configCases/rebuild/rebuildWithNewDependencies/index.js
+++ b/test/configCases/rebuild/rebuildWithNewDependencies/index.js
@@ -1,0 +1,7 @@
+import A from "./a";
+
+it("should compile", function (done) {
+	expect(A).toBe("other-file.js");
+
+	done();
+});

--- a/test/configCases/rebuild/rebuildWithNewDependencies/loader.js
+++ b/test/configCases/rebuild/rebuildWithNewDependencies/loader.js
@@ -1,0 +1,7 @@
+module.exports = function (source) {
+	if (this.shouldReplace)
+		return `import otherFile from './other-file.js';
+		export default otherFile;
+		`;
+	return source;
+};

--- a/test/configCases/rebuild/rebuildWithNewDependencies/other-file.js
+++ b/test/configCases/rebuild/rebuildWithNewDependencies/other-file.js
@@ -1,0 +1,1 @@
+export default "other-file.js";

--- a/test/configCases/rebuild/rebuildWithNewDependencies/webpack.config.js
+++ b/test/configCases/rebuild/rebuildWithNewDependencies/webpack.config.js
@@ -13,33 +13,33 @@ var testPlugin = compiler => {
 				/** @type {any} */ (loaderContext).shouldReplace = shouldReplace;
 			}
 		);
-		compilation.hooks.finishModules.tapAsync("TestPlugin", function (
-			modules,
-			callback
-		) {
-			const src = resolve(join(__dirname, "a.js"));
+		compilation.hooks.finishModules.tapAsync(
+			"TestPlugin",
+			function (modules, callback) {
+				const src = resolve(join(__dirname, "a.js"));
 
-			/**
-			 *
-			 * @param {any} m test
-			 * @returns {boolean} test
-			 */
-			function matcher(m) {
-				return m.resource && m.resource === src;
+				/**
+				 *
+				 * @param {any} m test
+				 * @returns {boolean} test
+				 */
+				function matcher(m) {
+					return m.resource && m.resource === src;
+				}
+
+				const module = Array.from(modules).find(matcher);
+
+				if (!module) {
+					throw new Error("something went wrong");
+				}
+
+				shouldReplace = true;
+				compilation.rebuildModule(module, err => {
+					shouldReplace = false;
+					callback(err);
+				});
 			}
-
-			const module = Array.from(modules).find(matcher);
-
-			if (!module) {
-				throw new Error("something went wrong");
-			}
-
-			shouldReplace = true;
-			compilation.rebuildModule(module, err => {
-				shouldReplace = false;
-				callback(err);
-			});
-		});
+		);
 	});
 };
 

--- a/test/configCases/rebuild/rebuildWithNewDependencies/webpack.config.js
+++ b/test/configCases/rebuild/rebuildWithNewDependencies/webpack.config.js
@@ -1,0 +1,60 @@
+const { resolve, join } = require("path");
+const { NormalModule } = require("../../../../");
+
+/**
+ * @param {import("../../../../").Compiler} compiler the compiler
+ */
+var testPlugin = compiler => {
+	compiler.hooks.compilation.tap("TestPlugin", compilation => {
+		let shouldReplace = false;
+		NormalModule.getCompilationHooks(compilation).loader.tap(
+			"TestPlugin",
+			loaderContext => {
+				/** @type {any} */ (loaderContext).shouldReplace = shouldReplace;
+			}
+		);
+		compilation.hooks.finishModules.tapAsync("TestPlugin", function (
+			modules,
+			callback
+		) {
+			const src = resolve(join(__dirname, "a.js"));
+
+			/**
+			 *
+			 * @param {any} m test
+			 * @returns {boolean} test
+			 */
+			function matcher(m) {
+				return m.resource && m.resource === src;
+			}
+
+			const module = Array.from(modules).find(matcher);
+
+			if (!module) {
+				throw new Error("something went wrong");
+			}
+
+			shouldReplace = true;
+			compilation.rebuildModule(module, err => {
+				shouldReplace = false;
+				callback(err);
+			});
+		});
+	});
+};
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /a.js/,
+				use: "./loader"
+			}
+		]
+	},
+	optimization: {
+		concatenateModules: false
+	},
+	plugins: [testPlugin]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Currently, module rebuilds that add new dependencies to the compilation are broken. This is due to the `processDependeciesQueue` returning the already processed module entry from the queue, rather than re-processing the module. 

The fix is to invalidate the module on the queue before calling `processModuleDependencies` so that it is correctly re-processed.


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?** 

bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes 👍 

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Nothing

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
