### PR TITLE
Show error details automatically when only 2 or less errors are there

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -2276,7 +2276,7 @@ export interface StatsOptions {
 	/**
 	 * Add details to errors (like resolving log).
 	 */
-	errorDetails?: boolean;
+	errorDetails?: "auto" | boolean;
 	/**
 	 * Add internal stack trace to errors.
 	 */

--- a/lib/ModuleDependencyError.js
+++ b/lib/ModuleDependencyError.js
@@ -21,12 +21,21 @@ class ModuleDependencyError extends WebpackError {
 		super(err.message);
 
 		this.name = "ModuleDependencyError";
-		this.details = err.stack.split("\n").slice(1).join("\n");
+		this.details =
+			err && !(/** @type {any} */ (err).hideStack)
+				? err.stack.split("\n").slice(1).join("\n")
+				: undefined;
 		this.module = module;
 		this.loc = loc;
+		/** error is not (de)serialized, so it might be undefined after deserialization */
 		this.error = err;
 
 		Error.captureStackTrace(this, this.constructor);
+
+		if (err && /** @type {any} */ (err).hideStack) {
+			this.stack =
+				err.stack.split("\n").slice(1).join("\n") + "\n\n" + this.stack;
+		}
 	}
 }
 

--- a/lib/ModuleDependencyWarning.js
+++ b/lib/ModuleDependencyWarning.js
@@ -21,13 +21,21 @@ class ModuleDependencyWarning extends WebpackError {
 		super(err ? err.message : "");
 
 		this.name = "ModuleDependencyWarning";
-		this.details = err && err.stack.split("\n").slice(1).join("\n");
+		this.details =
+			err && !(/** @type {any} */ (err).hideStack)
+				? err.stack.split("\n").slice(1).join("\n")
+				: undefined;
 		this.module = module;
 		this.loc = loc;
 		/** error is not (de)serialized, so it might be undefined after deserialization */
 		this.error = err;
 
 		Error.captureStackTrace(this, this.constructor);
+
+		if (err && /** @type {any} */ (err).hideStack) {
+			this.stack =
+				err.stack.split("\n").slice(1).join("\n") + "\n\n" + this.stack;
+		}
 	}
 }
 

--- a/lib/NoModeWarning.js
+++ b/lib/NoModeWarning.js
@@ -8,13 +8,13 @@
 const WebpackError = require("./WebpackError");
 
 module.exports = class NoModeWarning extends WebpackError {
-	constructor(modules) {
+	constructor() {
 		super();
 
 		this.name = "NoModeWarning";
 		this.message =
 			"configuration\n" +
-			"The 'mode' option has not been set, webpack will fallback to 'production' for this value. " +
+			"The 'mode' option has not been set, webpack will fallback to 'production' for this value.\n" +
 			"Set 'mode' option to 'development' or 'production' to enable defaults for each environment.\n" +
 			"You can also set it to 'none' to disable any default behavior. " +
 			"Learn more: https://webpack.js.org/configuration/mode/";

--- a/lib/dependencies/HarmonyImportDependency.js
+++ b/lib/dependencies/HarmonyImportDependency.js
@@ -128,9 +128,11 @@ class HarmonyImportDependency extends ModuleDependency {
 					if (exportInfo.provided === false) {
 						// We are sure that it's not provided
 						const providedExports = exportsInfo.getProvidedExports();
-						const moreInfo = Array.isArray(providedExports)
-							? ` (possible exports: ${providedExports.join(", ")})`
-							: " (possible exports unknown)";
+						const moreInfo = !Array.isArray(providedExports)
+							? " (possible exports unknown)"
+							: providedExports.length === 0
+							? " (module has no exports)"
+							: ` (possible exports: ${providedExports.join(", ")})`;
 						return [
 							new HarmonyLinkingError(
 								`export ${ids

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -201,8 +201,17 @@ const EXTRACT_ERROR = {
 			);
 		}
 	},
-	errorDetails: (object, error) => {
-		if (typeof error !== "string") {
+	errorDetails: (
+		object,
+		error,
+		{ type, compilation, cachedGetErrors, cachedGetWarnings },
+		{ errorDetails }
+	) => {
+		if (
+			typeof error !== "string" &&
+			(errorDetails === true ||
+				(type.endsWith(".error") && cachedGetErrors(compilation).length < 3))
+		) {
 			object.details = error.details;
 		}
 	},
@@ -468,6 +477,29 @@ const SIMPLE_EXTRACTORS = {
 						);
 					});
 			});
+		},
+		errorDetails: (
+			object,
+			compilation,
+			{ cachedGetErrors, cachedGetWarnings },
+			{ errorDetails, errors, warnings }
+		) => {
+			if (errorDetails === "auto") {
+				if (warnings) {
+					const warnings = cachedGetWarnings(compilation);
+					object.filteredWarningDetailsCount = warnings
+						.map(e => typeof e !== "string" && e.details)
+						.filter(Boolean).length;
+				}
+				if (errors) {
+					const errors = cachedGetErrors(compilation);
+					if (errors.length >= 3) {
+						object.filteredErrorDetailsCount = errors
+							.map(e => typeof e !== "string" && e.details)
+							.filter(Boolean).length;
+					}
+				}
+			}
 		},
 		logging: (object, compilation, _context, options, factory) => {
 			const util = require("util");

--- a/lib/stats/DefaultStatsPresetPlugin.js
+++ b/lib/stats/DefaultStatsPresetPlugin.js
@@ -121,6 +121,12 @@ const ON_FOR_TO_STRING = ({ all }, { forToString }) =>
 	forToString ? all !== false : all === true;
 const OFF_FOR_TO_STRING = ({ all }, { forToString }) =>
 	forToString ? all === true : all !== false;
+const AUTO_FOR_TO_STRING = ({ all }, { forToString }) => {
+	if (all === false) return false;
+	if (all === true) return true;
+	if (forToString) return "auto";
+	return true;
+};
 
 /** @type {Record<string, (options: StatsOptions, context: CreateStatsOptionsContext, compilation: Compilation) => any>} */
 const DEFAULTS = {
@@ -136,12 +142,7 @@ const DEFAULTS = {
 	timings: NORMAL_ON,
 	builtAt: OFF_FOR_TO_STRING,
 	assets: NORMAL_ON,
-	entrypoints: ({ all }, { forToString }) => {
-		if (all === false) return false;
-		if (all === true) return true;
-		if (forToString) return "auto";
-		return true;
-	},
+	entrypoints: AUTO_FOR_TO_STRING,
 	chunkGroups: OFF_FOR_TO_STRING,
 	chunkGroupAuxiliary: OFF_FOR_TO_STRING,
 	chunkGroupChildren: OFF_FOR_TO_STRING,
@@ -201,7 +202,7 @@ const DEFAULTS = {
 	moduleTrace: NORMAL_ON,
 	errors: NORMAL_ON,
 	errorsCount: NORMAL_ON,
-	errorDetails: OFF_FOR_TO_STRING,
+	errorDetails: AUTO_FOR_TO_STRING,
 	errorStack: OFF_FOR_TO_STRING,
 	warnings: NORMAL_ON,
 	warningsCount: NORMAL_ON,

--- a/lib/stats/DefaultStatsPrinterPlugin.js
+++ b/lib/stats/DefaultStatsPrinterPlugin.js
@@ -111,6 +111,24 @@ const SIMPLE_PRINTERS = {
 		)
 			return `${builtAtMessage}${subjectMessage} ${statusMessage}${timeMessage}${hashMessage}`;
 	},
+	"compilation.filteredWarningDetailsCount": count =>
+		count
+			? `${count} ${plural(
+					count,
+					"warning has",
+					"warnings have"
+			  )} detailed information that is not shown.\nUse 'stats.errorDetails: true' resp. '--stats-error-details' to show it.`
+			: undefined,
+	"compilation.filteredErrorDetailsCount": (count, { yellow }) =>
+		count
+			? yellow(
+					`${count} ${plural(
+						count,
+						"error has",
+						"errors have"
+					)} detailed information that is not shown.\nUse 'stats.errorDetails: true' resp. '--stats-error-details' to show it.`
+			  )
+			: undefined,
 	"compilation.env": (env, { bold }) =>
 		env
 			? `Environment (--env): ${bold(JSON.stringify(env, null, 2))}`
@@ -484,8 +502,9 @@ const SIMPLE_PRINTERS = {
 			: `${bold(moduleName)}`;
 	},
 	"error.loc": (loc, { green }) => green(loc),
-	"error.message": (message, { bold }) => bold(message),
-	"error.details": details => details,
+	"error.message": (message, { bold, formatError }) =>
+		message.includes("\u001b[") ? message : bold(formatError(message)),
+	"error.details": (details, { formatError }) => formatError(details),
 	"error.stack": stack => stack,
 	"error.moduleTrace": moduleTrace => undefined,
 	"error.separator!": () => "\n",
@@ -613,8 +632,10 @@ const PREFERRED_ORDERS = {
 		"logging",
 		"warnings",
 		"warningsInChildren!",
+		"filteredWarningDetailsCount",
 		"errors",
 		"errorsInChildren!",
+		"filteredErrorDetailsCount",
 		"summary!",
 		"needAdditionalPass"
 	],
@@ -895,7 +916,9 @@ const SIMPLE_ELEMENT_JOINERS = {
 			if (!item.content) continue;
 			const needMoreSpace =
 				item.element === "warnings" ||
+				item.element === "filteredWarningDetailsCount" ||
 				item.element === "errors" ||
+				item.element === "filteredErrorDetailsCount" ||
 				item.element === "logging";
 			if (result.length !== 0) {
 				result.push(needMoreSpace || lastNeedMore ? "\n\n" : "\n");
@@ -1072,6 +1095,40 @@ const AVAILABLE_FORMATS = {
 		} else {
 			return `${boldQuantity ? bold(time) : time}${unit}`;
 		}
+	},
+	formatError: (message, { green, yellow, red }) => {
+		if (message.includes("\u001b[")) return message;
+		const highlights = [
+			{ regExp: /(Did you mean .+)/g, format: green },
+			{
+				regExp: /(Set 'mode' option to 'development' or 'production')/g,
+				format: green
+			},
+			{ regExp: /(\(module has no exports\))/g, format: red },
+			{ regExp: /\(possible exports: (.+)\)/g, format: green },
+			{ regExp: /\s*(.+ doesn't exist)/g, format: red },
+			{ regExp: /('\w+' option has not been set)/g, format: red },
+			{
+				regExp: /(Emitted value instead of an instance of Error)/g,
+				format: yellow
+			},
+			{ regExp: /(Used? .+ instead)/gi, format: yellow },
+			{ regExp: /\b(deprecated|must|required)\b/g, format: yellow },
+			{
+				regExp: /\b(BREAKING CHANGE)\b/gi,
+				format: red
+			},
+			{
+				regExp: /\b(error|failed|unexpected|invalid|not found|not supported|not available|not possible|not implemented|doesn't support|conflict|conflicting|not existing|duplicate)\b/gi,
+				format: red
+			}
+		];
+		for (const { regExp, format } of highlights) {
+			message = message.replace(regExp, (match, content) => {
+				return match.replace(content, format(content));
+			});
+		}
+		return message;
 	}
 };
 
@@ -1128,7 +1185,11 @@ class DefaultStatsPrinterPlugin {
 									}
 								}
 								if (start) {
-									context[color] = str => `${start}${str}\u001b[39m\u001b[22m`;
+									context[color] = str =>
+										`${start}${str.replace(
+											/((\u001b\[39m|\u001b\[22m|\u001b\[0m)+)/g,
+											`$1${start}`
+										)}\u001b[39m\u001b[22m`;
 								} else {
 									context[color] = str => str;
 								}

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -3882,7 +3882,14 @@
         },
         "errorDetails": {
           "description": "Add details to errors (like resolving log).",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "enum": ["auto"]
+            },
+            {
+              "type": "boolean"
+            }
+          ]
         },
         "errorStack": {
           "description": "Add internal stack trace to errors.",

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -291,8 +291,8 @@ it("should emit warning for undef mode", async () => {
 					  "errors": Array [],
 					  "warnings": Array [
 					    Object {
-					      "message": "configuration\\nThe 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.\\nYou can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/",
-					      "stack": "NoModeWarning: configuration\\nThe 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.\\nYou can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/",
+					      "message": "configuration\\nThe 'mode' option has not been set, webpack will fallback to 'production' for this value.\\nSet 'mode' option to 'development' or 'production' to enable defaults for each environment.\\nYou can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/",
+					      "stack": "NoModeWarning: configuration\\nThe 'mode' option has not been set, webpack will fallback to 'production' for this value.\\nSet 'mode' option to 'development' or 'production' to enable defaults for each environment.\\nYou can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/",
 					    },
 					  ],
 					}

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -6943,12 +6943,21 @@ Object {
         "description": "Add details to errors (like resolving log).",
         "multiple": false,
         "path": "stats.errorDetails",
+        "type": "enum",
+        "values": Array [
+          "auto",
+        ],
+      },
+      Object {
+        "description": "Add details to errors (like resolving log).",
+        "multiple": false,
+        "path": "stats.errorDetails",
         "type": "boolean",
       },
     ],
     "description": "Add details to errors (like resolving log).",
     "multiple": false,
-    "simpleType": "boolean",
+    "simpleType": "string",
   },
   "stats-error-stack": Object {
     "configs": Array [

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -456,7 +456,8 @@ Entrypoint parent 54 bytes = parent.js
     
 
 WARNING in configuration
-The 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
+The 'mode' option has not been set, webpack will fallback to 'production' for this value.
+Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
 You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/
 
 webpack x.x.x compiled with 1 warning in X ms"
@@ -760,6 +761,139 @@ webpack x.x.x compiled successfully in X ms
 asset both.js 1.3 KiB [emitted] (name: main)
 ./index.js 24 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms"
+`;
+
+exports[`StatsTestCases should print correct stats for details-error 1`] = `
+"0 errors 0 warnings:
+  asset 0.js 737 bytes [emitted] (name: main)
+  ./index.js 1 bytes [built] [code generated]
+  0 errors 0 warnings (webpack x.x.x) compiled successfully in X ms
+
+1 errors 0 warnings:
+  asset 1.js 737 bytes [emitted] (name: main)
+  ./index.js 1 bytes [built] [code generated]
+
+  ERROR in Test
+  Error details
+
+  1 errors 0 warnings (webpack x.x.x) compiled with 1 error in X ms
+
+0 errors 1 warnings:
+  asset 10.js 737 bytes [emitted] (name: main)
+  ./index.js 1 bytes [built] [code generated]
+
+  WARNING in Test
+
+  1 warning has detailed information that is not shown.
+  Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.
+
+  0 errors 1 warnings (webpack x.x.x) compiled with 1 warning in X ms
+
+2 errors 0 warnings:
+  asset 2.js 737 bytes [emitted] (name: main)
+  ./index.js 1 bytes [built] [code generated]
+
+  ERROR in Test
+  Error details
+
+  ERROR in Test
+  Error details
+
+  2 errors 0 warnings (webpack x.x.x) compiled with 2 errors in X ms
+
+0 errors 2 warnings:
+  asset 20.js 737 bytes [emitted] (name: main)
+  ./index.js 1 bytes [built] [code generated]
+
+  WARNING in Test
+
+  WARNING in Test
+
+  2 warnings have detailed information that is not shown.
+  Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.
+
+  0 errors 2 warnings (webpack x.x.x) compiled with 2 warnings in X ms
+
+1 errors 1 warnings:
+  asset 11.js 737 bytes [emitted] (name: main)
+  ./index.js 1 bytes [built] [code generated]
+
+  WARNING in Test
+
+  1 warning has detailed information that is not shown.
+  Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.
+
+  ERROR in Test
+  Error details
+
+  1 errors 1 warnings (webpack x.x.x) compiled with 1 error and 1 warning in X ms
+
+2 errors 1 warnings:
+  asset 12.js 737 bytes [emitted] (name: main)
+  ./index.js 1 bytes [built] [code generated]
+
+  WARNING in Test
+
+  1 warning has detailed information that is not shown.
+  Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.
+
+  ERROR in Test
+  Error details
+
+  ERROR in Test
+  Error details
+
+  2 errors 1 warnings (webpack x.x.x) compiled with 2 errors and 1 warning in X ms
+
+3 errors 1 warnings:
+  asset 13.js 737 bytes [emitted] (name: main)
+  ./index.js 1 bytes [built] [code generated]
+
+  WARNING in Test
+
+  1 warning has detailed information that is not shown.
+  Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.
+
+  ERROR in Test
+
+  ERROR in Test
+
+  ERROR in Test
+
+  3 errors have detailed information that is not shown.
+  Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.
+
+  3 errors 1 warnings (webpack x.x.x) compiled with 3 errors and 1 warning in X ms
+
+3 errors 0 warnings:
+  asset 3.js 737 bytes [emitted] (name: main)
+  ./index.js 1 bytes [built] [code generated]
+
+  ERROR in Test
+
+  ERROR in Test
+
+  ERROR in Test
+
+  3 errors have detailed information that is not shown.
+  Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.
+
+  3 errors 0 warnings (webpack x.x.x) compiled with 3 errors in X ms
+
+0 errors 3 warnings:
+  asset 30.js 737 bytes [emitted] (name: main)
+  ./index.js 1 bytes [built] [code generated]
+
+  WARNING in Test
+
+  WARNING in Test
+
+  WARNING in Test
+
+  3 warnings have detailed information that is not shown.
+  Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.
+
+  0 errors 3 warnings (webpack x.x.x) compiled with 3 warnings in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for dll-reference-plugin-issue-7624 1`] = `
@@ -1457,7 +1591,8 @@ exports[`StatsTestCases should print correct stats for no-emit-on-errors-plugin-
 ./index.js 1 bytes [built] [code generated]
 
 WARNING in configuration
-The 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
+The 'mode' option has not been set, webpack will fallback to 'production' for this value.
+Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
 You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/
 
 1 ERROR in child compilations

--- a/test/statsCases/details-error/webpack.config.js
+++ b/test/statsCases/details-error/webpack.config.js
@@ -1,0 +1,21 @@
+const { WebpackError } = require("../../../");
+
+/** @type {import("../../../").Configuration[]} */
+module.exports = [0, 1, 10, 2, 20, 11, 12, 13, 3, 30].map(n => ({
+	name: `${n % 10} errors ${(n / 10) | 0} warnings`,
+	mode: "development",
+	output: {
+		filename: `${n}.js`
+	},
+	entry: "./index.js",
+	plugins: [
+		compiler => {
+			compiler.hooks.compilation.tap("Test", compilation => {
+				const err = new WebpackError("Test");
+				err.details = "Error details";
+				for (let i = n % 10; i > 0; i--) compilation.errors.push(err);
+				for (let i = (n / 10) | 0; i > 0; i--) compilation.warnings.push(err);
+			});
+		}
+	]
+}));

--- a/test/statsCases/module-trace-disabled-in-error/webpack.config.js
+++ b/test/statsCases/module-trace-disabled-in-error/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
 	entry: "./index",
 	stats: {
 		hash: false,
-		moduleTrace: false
+		moduleTrace: false,
+		errorDetails: false
 	}
 };

--- a/test/statsCases/module-trace-enabled-in-error/webpack.config.js
+++ b/test/statsCases/module-trace-enabled-in-error/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
 	entry: "./index",
 	stats: {
 		hash: false,
-		moduleTrace: true
+		moduleTrace: true,
+		errorDetails: false
 	}
 };

--- a/types.d.ts
+++ b/types.d.ts
@@ -9915,7 +9915,7 @@ declare interface StatsOptions {
 	/**
 	 * Add details to errors (like resolving log).
 	 */
-	errorDetails?: boolean;
+	errorDetails?: boolean | "auto";
 
 	/**
 	 * Add internal stack trace to errors.


### PR DESCRIPTION
fixes #12456

* Show error details automatically when only 2 or less errors are there
* Show message that points you to errorsDetails when error details are hidden
* Improve some error messages
* Highlight important parts of error message with colors

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature, dx
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
`errorDetails: "auto"` is a new value and its the default. It will show error details for errors when there are only 1 or 2 errors.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
