### PR TITLE
add `__webpack_base_uri__` to change base URI at runtime

### DIFF
--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -33,6 +33,12 @@ const REPLACEMENTS = {
 		type: "string",
 		assign: true
 	},
+	__webpack_base_uri__: {
+		expr: RuntimeGlobals.baseURI,
+		req: [RuntimeGlobals.baseURI],
+		type: "string",
+		assign: true
+	},
 	__webpack_modules__: {
 		expr: RuntimeGlobals.moduleFactories,
 		req: [RuntimeGlobals.moduleFactories],

--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -47,6 +47,7 @@ const GLOBALS_ON_REQUIRE = [
 	RuntimeGlobals.moduleFactoriesAddOnly,
 	RuntimeGlobals.interceptModuleExecution,
 	RuntimeGlobals.publicPath,
+	RuntimeGlobals.baseURI,
 	RuntimeGlobals.scriptNonce,
 	RuntimeGlobals.uncaughtErrorHandler,
 	RuntimeGlobals.asyncModule,

--- a/test/configCases/asset-modules/base-uri/index.js
+++ b/test/configCases/asset-modules/base-uri/index.js
@@ -1,0 +1,5 @@
+it("should handle different querystrings for assets correctly", () => {
+	__webpack_base_uri__ = "https://example.com";
+	const file = new URL("../_images/file.png", import.meta.url);
+	expect(file.href).toMatch(/^https:\/\/example.com\/path\/[0-9a-f]+.png$/);
+});

--- a/test/configCases/asset-modules/base-uri/webpack.config.js
+++ b/test/configCases/asset-modules/base-uri/webpack.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	mode: "development",
+	target: "web",
+	output: {
+		publicPath: "/path/"
+	}
+};


### PR DESCRIPTION
fix missing runtime requirement for base uri

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

fixes #12589

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature, bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
New API available in modules: `__webpack_base_uri__`.
allows to read/write the base URI for the running application. Type is `string | URL`.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
