### PR TITLE
fix: fix false path call on importScripts

### DIFF
--- a/lib/webworker/ImportScriptsChunkLoadingRuntimeModule.js
+++ b/lib/webworker/ImportScriptsChunkLoadingRuntimeModule.js
@@ -97,7 +97,7 @@ class ImportScriptsChunkLoadingRuntimeModule extends RuntimeModule {
 							'// "1" is the signal for "already loaded"',
 							"if(!installedChunks[chunkId]) {",
 							Template.indent([
-								`importScripts(${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId));`
+								`importScripts((${RuntimeGlobals.publicPath} ? ${RuntimeGlobals.publicPath} : '') + ${RuntimeGlobals.getChunkScriptFilename}(chunkId));`
 							]),
 							"}"
 						])};`,
@@ -130,7 +130,7 @@ class ImportScriptsChunkLoadingRuntimeModule extends RuntimeModule {
 								"success = true;"
 							])};`,
 							"// start update chunk loading",
-							`importScripts(${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkUpdateScriptFilename}(chunkId));`,
+							`importScripts((${RuntimeGlobals.publicPath} ? ${RuntimeGlobals.publicPath} : '') + ${RuntimeGlobals.getChunkUpdateScriptFilename}(chunkId));`,
 							'if(!success) throw new Error("Loading update chunk failed for unknown reason");'
 						]),
 						"}",

--- a/lib/webworker/ImportScriptsChunkLoadingRuntimeModule.js
+++ b/lib/webworker/ImportScriptsChunkLoadingRuntimeModule.js
@@ -97,9 +97,7 @@ class ImportScriptsChunkLoadingRuntimeModule extends RuntimeModule {
 							'// "1" is the signal for "already loaded"',
 							"if(!installedChunks[chunkId]) {",
 							Template.indent([
-								`importScripts(${JSON.stringify(rootOutputDir)} + ${
-									RuntimeGlobals.getChunkScriptFilename
-								}(chunkId));`
+								`importScripts(${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId));`
 							]),
 							"}"
 						])};`,
@@ -132,9 +130,7 @@ class ImportScriptsChunkLoadingRuntimeModule extends RuntimeModule {
 								"success = true;"
 							])};`,
 							"// start update chunk loading",
-							`importScripts(${JSON.stringify(rootOutputDir)} + ${
-								RuntimeGlobals.getChunkUpdateScriptFilename
-							}(chunkId));`,
+							`importScripts(${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkUpdateScriptFilename}(chunkId));`,
 							'if(!success) throw new Error("Loading update chunk failed for unknown reason");'
 						]),
 						"}",

--- a/test/ConfigTestCases.template.js
+++ b/test/ConfigTestCases.template.js
@@ -323,18 +323,12 @@ const describeCases = config => {
 														options
 													),
 													importScripts: url => {
-														let importPathDir;
-														let urlTestMatch = /https:\/\/{0,1}test.cases\/path\//gm;
-														if (url.match(urlTestMatch)) {
-															importPathDir = outputDirectory.replace(
-																urlTestMatch,
-																""
-															);
-														} else {
-															importPathDir = p;
+														let urlTestMatch = /(https:[\\/]{1,2}test\.cases[\\/]{1,2}path[\\/]{1,2})/gm;
+														if (url && url.match(urlTestMatch)) {
+															url = url.replace(urlTestMatch, "");
 														}
 														_require(
-															path.dirname(importPathDir),
+															outputDirectory ? outputDirectory : "",
 															options,
 															`./${url}`
 														);

--- a/test/ConfigTestCases.template.js
+++ b/test/ConfigTestCases.template.js
@@ -323,7 +323,21 @@ const describeCases = config => {
 														options
 													),
 													importScripts: url => {
-														_require(path.dirname(p), options, `./${url}`);
+														let importPathDir;
+														let urlTestMatch = /https:\/\/{0,1}test.cases\/path\//gm;
+														if (url.match(urlTestMatch)) {
+															importPathDir = outputDirectory.replace(
+																urlTestMatch,
+																""
+															);
+														} else {
+															importPathDir = p;
+														}
+														_require(
+															path.dirname(importPathDir),
+															options,
+															`./${url}`
+														);
 													},
 													module: m,
 													exports: m.exports,


### PR DESCRIPTION
When importing from an web worker entry point,
the documents path was used instead of the public path.
This is now fixed to use the public path as normal
behaviour in previous import calls.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
fixes #12502 and fixes #12577
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
