### PR TITLE
Fix lazy compilation not-supported error message on IE11

### DIFF
--- a/lib/hmr/LazyCompilationPlugin.js
+++ b/lib/hmr/LazyCompilationPlugin.js
@@ -199,9 +199,9 @@ class LazyCompilationProxyModule extends Module {
 			`var data = ${JSON.stringify(this.data)};`
 		]);
 		const keepActive = Template.asString([
-			`var dispose = client.keepAlive({ data, active: ${JSON.stringify(
+			`var dispose = client.keepAlive({ data: data, active: ${JSON.stringify(
 				!!block
-			)}, module, onError });`
+			)}, module: module, onError: onError });`
 		]);
 		let source;
 		if (block) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

mini bugfix for lazy compilation on old browsers.

Previously IE11 showed:
```
SCRIPT1003: Expected ':'
```

With this change the error message is more helpful:
```
Environment doesn't support lazy compilation (requires EventSource)
```


**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

nothing