### PR TITLE
MultiCompiler parallelism and dependencies

### DIFF
--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -11,6 +11,7 @@ const { SyncHook, MultiHook } = require("tapable");
 const ConcurrentCompilationError = require("./ConcurrentCompilationError");
 const MultiStats = require("./MultiStats");
 const MultiWatching = require("./MultiWatching");
+const ArrayQueue = require("./util/ArrayQueue");
 
 /** @template T @typedef {import("tapable").AsyncSeriesHook<T>} AsyncSeriesHook<T> */
 /** @template T @template R @typedef {import("tapable").SyncBailHook<T, R>} SyncBailHook<T, R> */
@@ -22,12 +23,6 @@ const MultiWatching = require("./MultiWatching");
 /** @typedef {import("./util/fs").IntermediateFileSystem} IntermediateFileSystem */
 /** @typedef {import("./util/fs").OutputFileSystem} OutputFileSystem */
 /** @typedef {import("./util/fs").WatchFileSystem} WatchFileSystem */
-
-/** @typedef {number} CompilerStatus */
-
-const STATUS_PENDING = 0;
-const STATUS_DONE = 1;
-const STATUS_NEW = 2;
 
 /**
  * @template T
@@ -42,11 +37,17 @@ const STATUS_NEW = 2;
  * @param {Callback<MultiStats>} callback
  */
 
+/**
+ * @typedef {Object} MultiCompilerOptions
+ * @property {number=} parallelism how many Compilers are allows to run at the same time in parallel
+ */
+
 module.exports = class MultiCompiler {
 	/**
 	 * @param {Compiler[] | Record<string, Compiler>} compilers child compilers
+	 * @param {MultiCompilerOptions} options options
 	 */
-	constructor(compilers) {
+	constructor(compilers, options) {
 		if (!Array.isArray(compilers)) {
 			compilers = Object.keys(compilers).map(name => {
 				compilers[name].name = name;
@@ -71,6 +72,10 @@ module.exports = class MultiCompiler {
 			)
 		});
 		this.compilers = compilers;
+		/** @type {MultiCompilerOptions} */
+		this._options = {
+			parallelism: options.parallelism || Infinity
+		};
 		/** @type {WeakMap<Compiler, string[]>} */
 		this.dependencies = new WeakMap();
 		this.running = false;
@@ -104,7 +109,10 @@ module.exports = class MultiCompiler {
 	}
 
 	get options() {
-		return this.compilers.map(c => c.options);
+		return Object.assign(
+			this.compilers.map(c => c.options),
+			this._options
+		);
 	}
 
 	get outputPath() {
@@ -257,7 +265,9 @@ module.exports = class MultiCompiler {
 		return true;
 	}
 
+	// TODO webpack 6 remove
 	/**
+	 * @deprecated This method should have been private
 	 * @param {Compiler[]} compilers the child compilers
 	 * @param {RunWithDependenciesHandler} fn a handler to run for each compiler
 	 * @param {Callback<MultiStats>} callback the compiler's handler
@@ -301,6 +311,134 @@ module.exports = class MultiCompiler {
 	}
 
 	/**
+	 * @template SetupResult
+	 * @param {function(Compiler, number, Callback<Stats>, function(): boolean, function(): void, function(): void): SetupResult} setup setup a single compiler
+	 * @param {function(Compiler, Callback<Stats>): void} run run/continue a single compiler
+	 * @param {Callback<MultiStats>} callback callback when all compilers are done, result includes Stats of all changed compilers
+	 * @returns {SetupResult[]} result of setup
+	 */
+	_runGraph(setup, run, callback) {
+		/** @typedef {{ compiler: Compiler, result: Stats, state: "blocked" | "queued" | "running" | "done", children: Node[], parents: Node[] }} Node */
+
+		/** @type {Node[]} */
+		const nodes = this.compilers.map(compiler => ({
+			compiler,
+			result: undefined,
+			state: "blocked",
+			children: [],
+			parents: []
+		}));
+		/** @type {Map<string, Node>} */
+		const compilerToNode = new Map();
+		for (const node of nodes) compilerToNode.set(node.compiler.name, node);
+		for (const node of nodes) {
+			const dependencies = this.dependencies.get(node.compiler);
+			if (!dependencies) continue;
+			for (const dep of dependencies) {
+				const parent = compilerToNode.get(dep);
+				node.parents.push(parent);
+				parent.children.push(node);
+			}
+		}
+		const queue = new ArrayQueue();
+		for (const node of nodes) {
+			if (node.parents.length === 0) {
+				node.state = "queued";
+				queue.enqueue(node);
+			}
+		}
+		let errored = false;
+		let running = 0;
+		const parallelism = this.options.parallelism;
+		const nodeDone = (node, err, stats) => {
+			if (errored) return;
+			if (err) {
+				errored = true;
+				return asyncLib.each(
+					nodes,
+					(node, callback) => {
+						if (node.compiler.watching) {
+							node.compiler.watching.close(callback);
+						} else {
+							callback();
+						}
+					},
+					() => callback(err)
+				);
+			}
+			node.result = stats;
+			if (node.state === "running") {
+				running--;
+				node.state = "done";
+				for (const child of node.children) {
+					if (child.state !== "blocked") continue;
+					if (child.parents.every(p => p.state === "done")) {
+						child.state = "queued";
+						queue.enqueue(child);
+					}
+				}
+				process.nextTick(processQueue);
+			}
+		};
+		const nodeInvalid = node => {
+			if (node.state === "done") {
+				node.state = "blocked";
+				for (const child of node.children) {
+					nodeInvalid(child);
+				}
+			}
+		};
+		const nodeChange = node => {
+			nodeInvalid(node);
+			if (
+				node.state === "blocked" &&
+				node.parents.every(p => p.state === "done")
+			) {
+				node.state = "queued";
+				queue.enqueue(node);
+				processQueue();
+			}
+		};
+		const setupResults = [];
+		nodes.forEach((node, i) => {
+			setupResults.push(
+				setup(
+					node.compiler,
+					i,
+					nodeDone.bind(null, node),
+					() => node.state === "blocked" || node.state === "queued",
+					() => nodeChange(node),
+					() => nodeInvalid(node)
+				)
+			);
+		});
+		const processQueue = () => {
+			while (running < parallelism && queue.length > 0 && !errored) {
+				const node = queue.dequeue();
+				running++;
+				node.state = "running";
+				run(node.compiler, nodeDone.bind(null, node));
+			}
+			if (!errored && running === 0) {
+				callback(
+					null,
+					new MultiStats(
+						nodes
+							.map(node => {
+								const result = node.result;
+								node.result = undefined;
+								return result;
+							})
+							.filter(Boolean)
+					)
+				);
+			}
+		};
+		processQueue();
+		return setupResults;
+	}
+
+	/**
 	 * @param {WatchOptions|WatchOptions[]} watchOptions the watcher's options
 	 * @param {Callback<MultiStats>} handler signals when the call finishes
 	 * @returns {MultiWatching} a compiler watcher
@@ -310,55 +448,29 @@ module.exports = class MultiCompiler {
 			return handler(new ConcurrentCompilationError());
 		}
 
-		/** @type {Watching[]} */
-		const watchings = [];
-
-		/** @type {Stats[]} */
-		const allStats = this.compilers.map(() => null);
-
-		/** @type {CompilerStatus[]} */
-		const compilerStatus = this.compilers.map(() => STATUS_PENDING);
-
 		if (this.validateDependencies(handler)) {
-			this.running = true;
-			this.runWithDependencies(
-				this.compilers,
-				(compiler, callback) => {
-					const compilerIdx = this.compilers.indexOf(compiler);
-					let firstRun = true;
-					let watching = compiler.watch(
-						Array.isArray(watchOptions)
-							? watchOptions[compilerIdx]
-							: watchOptions,
-						(err, stats) => {
-							if (err) handler(err);
-							if (stats) {
-								allStats[compilerIdx] = stats;
-								compilerStatus[compilerIdx] = STATUS_NEW;
-								if (compilerStatus.every(status => status !== STATUS_PENDING)) {
-									const freshStats = allStats.filter((s, idx) => {
-										return compilerStatus[idx] === STATUS_NEW;
-									});
-									compilerStatus.fill(STATUS_DONE);
-									const multiStats = new MultiStats(freshStats);
-									handler(null, multiStats);
-								}
-							}
-							if (firstRun && !err) {
-								firstRun = false;
-								callback();
-							}
-						}
+			const watchings = this._runGraph(
+				(compiler, idx, callback, isBlocked, setChanged, setInvalid) => {
+					const watching = compiler.watch(
+						Array.isArray(watchOptions) ? watchOptions[idx] : watchOptions,
+						callback
 					);
-					watchings.push(watching);
+					if (watching) {
+						watching._onInvalid = setInvalid;
+						watching._onChange = setChanged;
+						watching._isBlocked = isBlocked;
+					}
+					return watching;
 				},
-				() => {
-					// ignore
-				}
+				(compiler, initial, callback) => {
+					if (!compiler.watching.running) compiler.watching.invalidate();
+				},
+				handler
 			);
+			return new MultiWatching(watchings, this);
 		}
 
-		return new MultiWatching(watchings, this);
+		return new MultiWatching([], this);
 	}
 
 	/**
@@ -370,34 +482,16 @@ module.exports = class MultiCompiler {
 			return callback(new ConcurrentCompilationError());
 		}
 
-		const finalCallback = (err, stats) => {
-			this.running = false;
-
-			if (callback !== undefined) {
-				return callback(err, stats);
-			}
-		};
-
-		const allStats = this.compilers.map(() => null);
 		if (this.validateDependencies(callback)) {
-			this.running = true;
-			this.runWithDependencies(
-				this.compilers,
-				(compiler, callback) => {
-					const compilerIdx = this.compilers.indexOf(compiler);
-					compiler.run((err, stats) => {
-						if (err) {
-							return callback(err);
-						}
-						allStats[compilerIdx] = stats;
-						callback();
-					});
-				},
-				err => {
-					if (err) {
-						return finalCallback(err);
+			this._runGraph(
+				() => {},
+				(compiler, callback) => compiler.run(callback),
+				(err, stats) => {
+					this.running = false;
+
+					if (callback !== undefined) {
+						return callback(err, stats);
 					}
-					finalCallback(null, new MultiStats(allStats));
 				}
 			);
 		}

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -420,18 +420,17 @@ module.exports = class MultiCompiler {
 				run(node.compiler, nodeDone.bind(null, node));
 			}
 			if (!errored && running === 0) {
-				callback(
-					null,
-					new MultiStats(
-						nodes
-							.map(node => {
-								const result = node.result;
-								node.result = undefined;
-								return result;
-							})
-							.filter(Boolean)
-					)
-				);
+				const stats = [];
+				for (const node of nodes) {
+					const result = node.result;
+					if (result) {
+						node.result = undefined;
+						stats.push(result);
+					}
+				}
+				if (stats.length > 0) {
+					callback(null, new MultiStats(stats));
+				}
 			}
 		};
 		processQueue();

--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -349,7 +349,7 @@ module.exports = class MultiCompiler {
 		}
 		let errored = false;
 		let running = 0;
-		const parallelism = this.options.parallelism;
+		const parallelism = this._options.parallelism;
 		const nodeDone = (node, err, stats) => {
 			if (errored) return;
 			if (err) {

--- a/lib/MultiStats.js
+++ b/lib/MultiStats.js
@@ -47,17 +47,20 @@ class MultiStats {
 		if (!options) {
 			options = {};
 		}
-		const { children: _, ...baseOptions } = options;
+		const { children: childrenOptions = undefined, ...baseOptions } =
+			typeof options === "string" ? { preset: options } : options;
 		const children = this.stats.map((stat, idx) => {
-			const childOptions = Array.isArray(options.children)
-				? options.children[idx]
-				: options.children;
+			const childOptions = Array.isArray(childrenOptions)
+				? childrenOptions[idx]
+				: childrenOptions;
 			return stat.compilation.createStatsOptions(
 				{
 					...baseOptions,
-					...(childOptions && typeof childOptions === "object"
+					...(typeof childOptions === "string"
+						? { preset: childOptions }
+						: childOptions && typeof childOptions === "object"
 						? childOptions
-						: { preset: childOptions })
+						: undefined)
 				},
 				context
 			);

--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -34,6 +34,10 @@ class Watching {
 		this._closeCallbacks = undefined;
 		this.closed = false;
 		this.suspended = false;
+		this.blocked = false;
+		this._isBlocked = () => false;
+		this._onChange = () => {};
+		this._onInvalid = () => {};
 		if (typeof watchOptions === "number") {
 			this.watchOptions = {
 				aggregateTimeout: watchOptions
@@ -47,27 +51,59 @@ class Watching {
 			this.watchOptions.aggregateTimeout = 200;
 		}
 		this.compiler = compiler;
-		this.running = true;
+		this.running = false;
+		this._initial = true;
+		this._needRecords = true;
+		this._needWatcherInfo = false;
 		this.watcher = undefined;
 		this.pausedWatcher = undefined;
 		this._done = this._done.bind(this);
-		this.compiler.readRecords(err => {
-			if (err) return this._done(err);
-
-			this._go();
+		process.nextTick(() => {
+			if (this._initial) this._invalidate();
 		});
 	}
 
 	_go() {
+		this._initial = false;
 		this.startTime = Date.now();
 		this.running = true;
-		this.invalid = false;
 		const run = () => {
+			if (this.compiler.idle) {
+				return this.compiler.cache.endIdle(err => {
+					if (err) return this._done(err);
+					this.compiler.idle = false;
+					run();
+				});
+			}
+			if (this._needRecords) {
+				return this.compiler.readRecords(err => {
+					if (err) return this._done(err);
+
+					this._needRecords = false;
+					run();
+				});
+			}
+			this.invalid = false;
+			if (this._needWatcherInfo) {
+				this._needWatcherInfo = false;
+				const watcher = this.pausedWatcher;
+				if (watcher) {
+					this.compiler.modifiedFiles = watcher.aggregatedChanges;
+					this.compiler.removedFiles = watcher.aggregatedRemovals;
+					this.compiler.fileTimestamps = watcher.getFileTimeInfoEntries();
+					this.compiler.contextTimestamps = watcher.getContextTimeInfoEntries();
+				} else {
+					this.compiler.modifiedFiles = undefined;
+					this.compiler.removedFiles = undefined;
+					this.compiler.fileTimestamps = undefined;
+					this.compiler.contextTimestamps = undefined;
+				}
+			}
 			this.compiler.hooks.watchRun.callAsync(this.compiler, err => {
 				if (err) return this._done(err);
 				const onCompiled = (err, compilation) => {
 					if (err) return this._done(err, compilation);
-					if (this.invalid) return this._done();
+					if (this.invalid) return this._done(null, compilation);
 
 					if (this.compiler.hooks.shouldEmit.call(compilation) === false) {
 						return this._done(null, compilation);
@@ -113,15 +149,7 @@ class Watching {
 			});
 		};
 
-		if (this.compiler.idle) {
-			this.compiler.cache.endIdle(err => {
-				if (err) return this._done(err);
-				this.compiler.idle = false;
-				run();
-			});
-		} else {
-			run();
-		}
+		run();
 	}
 
 	/**
@@ -154,7 +182,12 @@ class Watching {
 			this.callbacks.length = 0;
 		};
 
-		if (this.invalid) {
+		if (
+			this.invalid &&
+			!this.suspended &&
+			!this.blocked &&
+			!(this._isBlocked() && (this.blocked = true))
+		) {
 			if (compilation) {
 				logger.time("storeBuildDependencies");
 				this.compiler.cache.storeBuildDependencies(
@@ -244,12 +277,12 @@ class Watching {
 				this.compiler.contextTimestamps = contextTimeInfoEntries;
 				this.compiler.removedFiles = removedFiles;
 				this.compiler.modifiedFiles = changedFiles;
-				if (!this.suspended) {
-					this._invalidate();
-				}
+				this._invalidate();
+				this._onChange();
 			},
 			(fileName, changeTime) => {
 				this.compiler.hooks.invalid.call(fileName, changeTime);
+				this._onInvalid();
 			}
 		);
 	}
@@ -262,17 +295,19 @@ class Watching {
 		if (callback) {
 			this.callbacks.push(callback);
 		}
-		if (this.watcher) {
-			this.compiler.modifiedFiles = this.watcher.aggregatedChanges;
-			this.compiler.removedFiles = this.watcher.aggregatedRemovals;
-			this.compiler.fileTimestamps = this.watcher.getFileTimeInfoEntries();
-			this.compiler.contextTimestamps = this.watcher.getContextTimeInfoEntries();
+		if (!this._initial) {
+			this.compiler.hooks.invalid.call(null, Date.now());
+			this._needWatcherInfo = true;
 		}
-		this.compiler.hooks.invalid.call(null, Date.now());
 		this._invalidate();
 	}
 
 	_invalidate() {
+		if (this.suspended) return;
+		if (this._isBlocked()) {
+			this.blocked = true;
+			return;
+		}
 		if (this.watcher) {
 			this.pausedWatcher = this.watcher;
 			this.watcher.pause();
@@ -288,12 +323,20 @@ class Watching {
 
 	suspend() {
 		this.suspended = true;
-		this.invalid = false;
 	}
 
 	resume() {
 		if (this.suspended) {
 			this.suspended = false;
+			this._needWatcherInfo = true;
+			this._invalidate();
+		}
+	}
+
+	_checkUnblocked() {
+		if (this.blocked && !this._isBlocked()) {
+			this.blocked = false;
+			this._needWatcherInfo = true;
 			this._invalidate();
 		}
 	}

--- a/lib/stats/DefaultStatsPrinterPlugin.js
+++ b/lib/stats/DefaultStatsPrinterPlugin.js
@@ -106,6 +106,7 @@ const SIMPLE_PRINTERS = {
 			versionMessage ||
 			errorsMessage ||
 			warningsMessage ||
+			(errorsCount === 0 && warningsCount === 0) ||
 			timeMessage ||
 			hashMessage
 		)

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -20,6 +20,7 @@ const validateSchema = require("./validateSchema");
 
 /** @typedef {import("../declarations/WebpackOptions").WebpackOptions} WebpackOptions */
 /** @typedef {import("./Compiler").WatchOptions} WatchOptions */
+/** @typedef {import("./MultiCompiler").MultiCompilerOptions} MultiCompilerOptions */
 /** @typedef {import("./MultiStats")} MultiStats */
 /** @typedef {import("./Stats")} Stats */
 
@@ -33,11 +34,12 @@ const validateSchema = require("./validateSchema");
 
 /**
  * @param {WebpackOptions[]} childOptions options array
+ * @param {MultiCompilerOptions} options options
  * @returns {MultiCompiler} a multi-compiler
  */
-const createMultiCompiler = childOptions => {
+const createMultiCompiler = (childOptions, options) => {
 	const compilers = childOptions.map(options => createCompiler(options));
-	const compiler = new MultiCompiler(compilers);
+	const compiler = new MultiCompiler(compilers, options);
 	for (const childCompiler of compilers) {
 		if (childCompiler.options.dependencies) {
 			compiler.setDependencies(
@@ -87,63 +89,67 @@ const createCompiler = rawOptions => {
 
 /**
  * @callback WebpackFunctionMulti
- * @param {WebpackOptions[]} options options objects
+ * @param {WebpackOptions[] & MultiCompilerOptions} options options objects
  * @param {Callback<MultiStats>=} callback callback
  * @returns {MultiCompiler} the multi compiler object
  */
 
-const webpack = /** @type {WebpackFunctionSingle & WebpackFunctionMulti} */ ((
-	options,
-	callback
-) => {
-	const create = () => {
-		validateSchema(webpackOptionsSchema, options);
-		/** @type {MultiCompiler|Compiler} */
-		let compiler;
-		let watch = false;
-		/** @type {WatchOptions|WatchOptions[]} */
-		let watchOptions;
-		if (Array.isArray(options)) {
-			/** @type {MultiCompiler} */
-			compiler = createMultiCompiler(options);
-			watch = options.some(options => options.watch);
-			watchOptions = options.map(options => options.watchOptions || {});
-		} else {
-			/** @type {Compiler} */
-			compiler = createCompiler(options);
-			watch = options.watch;
-			watchOptions = options.watchOptions || {};
-		}
-		return { compiler, watch, watchOptions };
-	};
-	if (callback) {
-		try {
-			const { compiler, watch, watchOptions } = create();
-			if (watch) {
-				compiler.watch(watchOptions, callback);
+const webpack = /** @type {WebpackFunctionSingle & WebpackFunctionMulti} */ (
+	/**
+	 * @param {WebpackOptions | (WebpackOptions[] & MultiCompilerOptions)} options options
+	 * @param {Callback<Stats> & Callback<MultiStats>=} callback callback
+	 * @returns {Compiler | MultiCompiler}
+	 */
+	(options, callback) => {
+		const create = () => {
+			validateSchema(webpackOptionsSchema, options);
+			/** @type {MultiCompiler|Compiler} */
+			let compiler;
+			let watch = false;
+			/** @type {WatchOptions|WatchOptions[]} */
+			let watchOptions;
+			if (Array.isArray(options)) {
+				/** @type {MultiCompiler} */
+				compiler = createMultiCompiler(options, options);
+				watch = options.some(options => options.watch);
+				watchOptions = options.map(options => options.watchOptions || {});
 			} else {
-				compiler.run((err, stats) => {
-					compiler.close(err2 => {
-						callback(err || err2, stats);
+				/** @type {Compiler} */
+				compiler = createCompiler(options);
+				watch = options.watch;
+				watchOptions = options.watchOptions || {};
+			}
+			return { compiler, watch, watchOptions };
+		};
+		if (callback) {
+			try {
+				const { compiler, watch, watchOptions } = create();
+				if (watch) {
+					compiler.watch(watchOptions, callback);
+				} else {
+					compiler.run((err, stats) => {
+						compiler.close(err2 => {
+							callback(err || err2, stats);
+						});
 					});
-				});
+				}
+				return compiler;
+			} catch (err) {
+				process.nextTick(() => callback(err));
+				return null;
+			}
+		} else {
+			const { compiler, watch } = create();
+			if (watch) {
+				util.deprecate(
+					() => {},
+					"A 'callback' argument need to be provided to the 'webpack(options, callback)' function when the 'watch' option is set. There is no way to handle the 'watch' option without a callback.",
+					"DEP_WEBPACK_WATCH_WITHOUT_CALLBACK"
+				)();
 			}
 			return compiler;
-		} catch (err) {
-			process.nextTick(() => callback(err));
-			return null;
 		}
-	} else {
-		const { compiler, watch } = create();
-		if (watch) {
-			util.deprecate(
-				() => {},
-				"A 'callback' argument need to be provided to the 'webpack(options, callback)' function when the 'watch' option is set. There is no way to handle the 'watch' option without a callback.",
-				"DEP_WEBPACK_WATCH_WITHOUT_CALLBACK"
-			)();
-		}
-		return compiler;
 	}
-});
+);
 
 module.exports = webpack;

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -657,7 +657,9 @@ describe("Compiler", () => {
 			if (err) return done(err);
 			watchCb();
 		});
-		watch.invalidate(invalidateCb);
+		process.nextTick(() => {
+			watch.invalidate(invalidateCb);
+		});
 	});
 	it("should call afterDone hook after other callbacks (watch close)", done => {
 		const compiler = webpack({
@@ -687,7 +689,9 @@ describe("Compiler", () => {
 			if (err) return done(err);
 			watch.close(watchCloseCb);
 		});
-		watch.invalidate(invalidateCb);
+		process.nextTick(() => {
+			watch.invalidate(invalidateCb);
+		});
 	});
 	it("should flag watchMode as true in watch", done => {
 		const compiler = webpack({

--- a/test/WatchClose.test.js
+++ b/test/WatchClose.test.js
@@ -23,9 +23,7 @@ describe("WatchClose", () => {
 					filename: "bundle.js"
 				}
 			});
-			watcher = compiler.watch({
-				poll: 300
-			});
+			watcher = compiler.watch({ poll: 300 }, () => {});
 		});
 
 		afterEach(() => {

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -454,6 +454,7 @@ Entrypoint parent 84 bytes = parent.js
   Entrypoint child = child.js
   ./child.js 1 bytes [built] [code generated]
     
+  Child TestApplyEntryOptionPlugin compiled successfully
 
 WARNING in configuration
 The 'mode' option has not been set, webpack will fallback to 'production' for this value.
@@ -2063,7 +2064,8 @@ LOG from LogTestPlugin
 <e> Error
 <w> Warning
 + 13 hidden lines
-"
+
+webpack compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-minimal 1`] = `

--- a/test/statsCases/related-assets/webpack.config.js
+++ b/test/statsCases/related-assets/webpack.config.js
@@ -63,7 +63,9 @@ const baseStats = {
 	timings: false,
 	version: false,
 	hash: false,
-	builtAt: false
+	builtAt: false,
+	errorsCount: false,
+	warningsCount: false
 };
 
 /** @type {import("../../../").Configuration} */

--- a/types.d.ts
+++ b/types.d.ts
@@ -6252,7 +6252,10 @@ declare abstract class ModuleTemplate {
 	readonly runtimeTemplate: any;
 }
 declare class MultiCompiler {
-	constructor(compilers: Compiler[] | Record<string, Compiler>);
+	constructor(
+		compilers: Compiler[] | Record<string, Compiler>,
+		options: MultiCompilerOptions
+	);
 	hooks: Readonly<{
 		done: SyncHook<[MultiStats]>;
 		invalid: MultiHook<SyncHook<[null | string, number]>>;
@@ -6264,7 +6267,7 @@ declare class MultiCompiler {
 	compilers: Compiler[];
 	dependencies: WeakMap<Compiler, string[]>;
 	running: boolean;
-	readonly options: WebpackOptionsNormalized[];
+	readonly options: WebpackOptionsNormalized[] & MultiCompilerOptions;
 	readonly outputPath: string;
 	inputFileSystem: InputFileSystem;
 	outputFileSystem: OutputFileSystem;
@@ -6285,6 +6288,12 @@ declare class MultiCompiler {
 	run(callback: CallbackFunction<MultiStats>): void;
 	purgeInputFileSystem(): void;
 	close(callback: CallbackFunction<void>): void;
+}
+declare interface MultiCompilerOptions {
+	/**
+	 * how many Compilers are allows to run at the same time in parallel
+	 */
+	parallelism?: number;
 }
 declare abstract class MultiStats {
 	stats: Stats[];
@@ -10708,6 +10717,7 @@ declare abstract class Watching {
 	callbacks: CallbackFunction<void>[];
 	closed: boolean;
 	suspended: boolean;
+	blocked: boolean;
 	watchOptions: {
 		/**
 		 * Delay the rebuilt after the first change. Value is a time in ms.
@@ -11063,14 +11073,14 @@ declare function exports(
 	callback?: CallbackWebpack<Stats>
 ): Compiler;
 declare function exports(
-	options: Configuration[],
+	options: Configuration[] & MultiCompilerOptions,
 	callback?: CallbackWebpack<MultiStats>
 ): MultiCompiler;
 declare namespace exports {
 	export const webpack: {
 		(options: Configuration, callback?: CallbackWebpack<Stats>): Compiler;
 		(
-			options: Configuration[],
+			options: Configuration[] & MultiCompilerOptions,
 			callback?: CallbackWebpack<MultiStats>
 		): MultiCompiler;
 	};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature, bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no a butfix.
dependencies is now handled in watch mode, which changes behavior a bit
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
* The `dependencies` config option is largely undocumented
  * It is an array of `name`s of other configs in the same array of configs. All dependencies need to be compiled before this config starts compiling.
  * In watch mode `dependencies` will invalidate the compiler when the dependency has changed and when a dependency is currently compiling or invalid this config will not compile until the dependency is done.
* There is a `parallelism: number` option on the configuration array now
  * It specifies the maximum of compilers that will compile in parallel.

``` js
module.exports = [
  { ... },
  { ... }
];
module.exports.parallelism = 1;
```
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
