### PR TITLE
only execute loader/require when no serializer is registered yet

### DIFF
--- a/lib/serialization/ObjectMiddleware.js
+++ b/lib/serialization/ObjectMiddleware.js
@@ -240,6 +240,12 @@ class ObjectMiddleware extends SerializerMiddleware {
 		return serializer;
 	}
 
+	static _getDeserializerForWithoutError(request, name) {
+		const key = request + "/" + name;
+		const serializer = serializerInversed.get(key);
+		return serializer;
+	}
+
 	/**
 	 * @param {DeserializedType} data data
 	 * @param {Object} context context object
@@ -579,24 +585,31 @@ class ObjectMiddleware extends SerializerMiddleware {
 						}
 						const name = read();
 
-						if (request && !loadedRequests.has(request)) {
-							let loaded = false;
-							for (const [regExp, loader] of loaders) {
-								if (regExp.test(request)) {
-									if (loader(request)) {
-										loaded = true;
-										break;
+						serializer = ObjectMiddleware._getDeserializerForWithoutError(
+							request,
+							name
+						);
+
+						if (serializer === undefined) {
+							if (request && !loadedRequests.has(request)) {
+								let loaded = false;
+								for (const [regExp, loader] of loaders) {
+									if (regExp.test(request)) {
+										if (loader(request)) {
+											loaded = true;
+											break;
+										}
 									}
 								}
-							}
-							if (!loaded) {
-								require(request);
+								if (!loaded) {
+									require(request);
+								}
+
+								loadedRequests.add(request);
 							}
 
-							loadedRequests.add(request);
+							serializer = ObjectMiddleware.getDeserializerFor(request, name);
 						}
-
-						serializer = ObjectMiddleware.getDeserializerFor(request, name);
 
 						objectTypeLookup.push(serializer);
 						currentPosTypeLookup++;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This avoid unnecessary calls to loaders when serializer are already registered.
It should also improve performance a bit

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
