### PR TITLE
fixes for electron target

### DIFF
--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -43,6 +43,7 @@ const RequireEnsurePlugin = require("./dependencies/RequireEnsurePlugin");
 const RequireIncludePlugin = require("./dependencies/RequireIncludePlugin");
 const SystemPlugin = require("./dependencies/SystemPlugin");
 const URLPlugin = require("./dependencies/URLPlugin");
+const WorkerPlugin = require("./dependencies/WorkerPlugin");
 
 const InferAsyncModulesPlugin = require("./async-modules/InferAsyncModulesPlugin");
 
@@ -312,11 +313,10 @@ class WebpackOptionsApply extends OptionsApply {
 		new SystemPlugin().apply(compiler);
 		new ImportMetaPlugin().apply(compiler);
 		new URLPlugin().apply(compiler);
-
-		if (options.output.workerChunkLoading) {
-			const WorkerPlugin = require("./dependencies/WorkerPlugin");
-			new WorkerPlugin(options.output.workerChunkLoading).apply(compiler);
-		}
+		new WorkerPlugin(
+			options.output.workerChunkLoading,
+			options.output.workerWasmLoading
+		).apply(compiler);
 
 		new DefaultStatsFactoryPlugin().apply(compiler);
 		new DefaultStatsPresetPlugin().apply(compiler);

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -622,11 +622,19 @@ const applyOutputDefaults = (
 	});
 	F(output, "chunkLoading", () => {
 		if (tp) {
-			if (tp.document) return "jsonp";
-			if (tp.require) return "require";
-			if (tp.nodeBuiltins) return "async-node";
-			if (tp.importScripts) return "import-scripts";
-			if (tp.dynamicImport && output.module) return "import";
+			switch (output.chunkFormat) {
+				case "array-push":
+					if (tp.document) return "jsonp";
+					if (tp.importScripts) return "import-scripts";
+					break;
+				case "commonjs":
+					if (tp.require) return "require";
+					if (tp.nodeBuiltins) return "async-node";
+					break;
+				case "module":
+					if (tp.dynamicImport) return "import";
+					break;
+			}
 			if (
 				tp.require === null ||
 				tp.nodeBuiltins === null ||
@@ -640,10 +648,18 @@ const applyOutputDefaults = (
 	});
 	F(output, "workerChunkLoading", () => {
 		if (tp) {
-			if (tp.require) return "require";
-			if (tp.nodeBuiltins) return "async-node";
-			if (tp.importScriptsInWorker) return "import-scripts";
-			if (tp.dynamicImportInWorker && output.module) return "import";
+			switch (output.chunkFormat) {
+				case "array-push":
+					if (tp.importScriptsInWorker) return "import-scripts";
+					break;
+				case "commonjs":
+					if (tp.require) return "require";
+					if (tp.nodeBuiltins) return "async-node";
+					break;
+				case "module":
+					if (tp.dynamicImportInWorker) return "import";
+					break;
+			}
 			if (
 				tp.require === null ||
 				tp.nodeBuiltins === null ||
@@ -656,8 +672,8 @@ const applyOutputDefaults = (
 	});
 	F(output, "wasmLoading", () => {
 		if (tp) {
-			if (tp.nodeBuiltins) return "async-node";
 			if (tp.fetchWasm) return "fetch";
+			if (tp.nodeBuiltins) return "async-node";
 			if (tp.nodeBuiltins === null || tp.fetchWasm === null) {
 				return "universal";
 			}

--- a/lib/config/target.js
+++ b/lib/config/target.js
@@ -197,7 +197,7 @@ You can also more options via the 'target' option: 'browserslist' / 'browserslis
 				document: context === "renderer",
 				fetchWasm: context === "renderer",
 				importScripts: false,
-				importScriptsInWorker: false,
+				importScriptsInWorker: true,
 
 				globalThis: v(5),
 				const: v(1, 1),

--- a/lib/dependencies/WorkerPlugin.js
+++ b/lib/dependencies/WorkerPlugin.js
@@ -13,6 +13,7 @@ const formatLocation = require("../formatLocation");
 const EnableChunkLoadingPlugin = require("../javascript/EnableChunkLoadingPlugin");
 const { equals } = require("../util/ArrayHelpers");
 const { contextify } = require("../util/identifier");
+const EnableWasmLoadingPlugin = require("../wasm/EnableWasmLoadingPlugin");
 const {
 	harmonySpecifierTag
 } = require("./HarmonyImportDependencyParserPlugin");
@@ -37,8 +38,9 @@ const DEFAULT_SYNTAX = [
 ];
 
 class WorkerPlugin {
-	constructor(chunkLoading) {
+	constructor(chunkLoading, wasmLoading) {
 		this._chunkLoading = chunkLoading;
+		this._wasmLoading = wasmLoading;
 	}
 	/**
 	 * Apply the plugin
@@ -48,6 +50,9 @@ class WorkerPlugin {
 	apply(compiler) {
 		if (this._chunkLoading) {
 			new EnableChunkLoadingPlugin(this._chunkLoading).apply(compiler);
+		}
+		if (this._wasmLoading) {
+			new EnableWasmLoadingPlugin(this._wasmLoading).apply(compiler);
 		}
 		const cachedContextify = contextify.bindContextCache(
 			compiler.context,
@@ -227,6 +232,7 @@ class WorkerPlugin {
 								name: entryOptions.name,
 								entryOptions: {
 									chunkLoading: this._chunkLoading,
+									wasmLoading: this._wasmLoading,
 									...entryOptions
 								}
 							});


### PR DESCRIPTION
electron has `importScripts` in worker
only choose a chunkLoading which fits to the chunkFormat
prefer fetch wasm loading over node wasm loading

fixes #12683
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
there are no electron tests sadly
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
