### PR TITLE
Handle Windows UNC paths as Windows paths

### DIFF
--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -137,7 +137,10 @@ const relative = (fs, rootPath, targetPath) => {
 		return fs.relative(rootPath, targetPath);
 	} else if (rootPath.startsWith("/")) {
 		return path.posix.relative(rootPath, targetPath);
-	} else if ((rootPath.length > 1 && rootPath[1] === ":") || rootPath.startsWith("\\\\")) {
+	} else if (
+		(rootPath.length > 1 && rootPath[1] === ":") ||
+		rootPath.startsWith("\\\\")
+	) {
 		return path.win32.relative(rootPath, targetPath);
 	} else {
 		throw new Error(
@@ -158,7 +161,10 @@ const join = (fs, rootPath, filename) => {
 		return fs.join(rootPath, filename);
 	} else if (rootPath.startsWith("/")) {
 		return path.posix.join(rootPath, filename);
-	} else if ((rootPath.length > 1 && rootPath[1] === ":") || rootPath.startsWith("\\\\")) {
+	} else if (
+		(rootPath.length > 1 && rootPath[1] === ":") ||
+		rootPath.startsWith("\\\\")
+	) {
 		return path.win32.join(rootPath, filename);
 	} else {
 		throw new Error(
@@ -178,7 +184,10 @@ const dirname = (fs, absPath) => {
 		return fs.dirname(absPath);
 	} else if (absPath.startsWith("/")) {
 		return path.posix.dirname(absPath);
-	} else if ((absPath.length > 1 && absPath[1] === ":") || absPath.startsWith("\\\\")) {
+	} else if (
+		(absPath.length > 1 && absPath[1] === ":") ||
+		absPath.startsWith("\\\\")
+	) {
 		return path.win32.dirname(absPath);
 	} else {
 		throw new Error(

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -135,12 +135,9 @@ const path = require("path");
 const relative = (fs, rootPath, targetPath) => {
 	if (fs && fs.relative) {
 		return fs.relative(rootPath, targetPath);
-	} else if (rootPath.startsWith("/")) {
+	} else if (path.posix.isAbsolute(rootPath)) {
 		return path.posix.relative(rootPath, targetPath);
-	} else if (
-		(rootPath.length > 1 && rootPath[1] === ":") ||
-		rootPath.startsWith("\\\\")
-	) {
+	} else if (path.win32.isAbsolute(rootPath)) {
 		return path.win32.relative(rootPath, targetPath);
 	} else {
 		throw new Error(
@@ -159,12 +156,9 @@ exports.relative = relative;
 const join = (fs, rootPath, filename) => {
 	if (fs && fs.join) {
 		return fs.join(rootPath, filename);
-	} else if (rootPath.startsWith("/")) {
+	} else if (path.posix.isAbsolute(rootPath)) {
 		return path.posix.join(rootPath, filename);
-	} else if (
-		(rootPath.length > 1 && rootPath[1] === ":") ||
-		rootPath.startsWith("\\\\")
-	) {
+	} else if (path.win32.isAbsolute(rootPath)) {
 		return path.win32.join(rootPath, filename);
 	} else {
 		throw new Error(
@@ -182,12 +176,9 @@ exports.join = join;
 const dirname = (fs, absPath) => {
 	if (fs && fs.dirname) {
 		return fs.dirname(absPath);
-	} else if (absPath.startsWith("/")) {
+	} else if (path.posix.isAbsolute(absPath)) {
 		return path.posix.dirname(absPath);
-	} else if (
-		(absPath.length > 1 && absPath[1] === ":") ||
-		absPath.startsWith("\\\\")
-	) {
+	} else if (path.win32.isAbsolute(absPath)) {
 		return path.win32.dirname(absPath);
 	} else {
 		throw new Error(

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -137,7 +137,7 @@ const relative = (fs, rootPath, targetPath) => {
 		return fs.relative(rootPath, targetPath);
 	} else if (rootPath.startsWith("/")) {
 		return path.posix.relative(rootPath, targetPath);
-	} else if (rootPath.length > 1 && rootPath[1] === ":") {
+	} else if ((rootPath.length > 1 && rootPath[1] === ":") || rootPath.startsWith("\\\\")) {
 		return path.win32.relative(rootPath, targetPath);
 	} else {
 		throw new Error(
@@ -158,7 +158,7 @@ const join = (fs, rootPath, filename) => {
 		return fs.join(rootPath, filename);
 	} else if (rootPath.startsWith("/")) {
 		return path.posix.join(rootPath, filename);
-	} else if (rootPath.length > 1 && rootPath[1] === ":") {
+	} else if ((rootPath.length > 1 && rootPath[1] === ":") || rootPath.startsWith("\\\\")) {
 		return path.win32.join(rootPath, filename);
 	} else {
 		throw new Error(
@@ -178,7 +178,7 @@ const dirname = (fs, absPath) => {
 		return fs.dirname(absPath);
 	} else if (absPath.startsWith("/")) {
 		return path.posix.dirname(absPath);
-	} else if (absPath.length > 1 && absPath[1] === ":") {
+	} else if ((absPath.length > 1 && absPath[1] === ":") || absPath.startsWith("\\\\")) {
 		return path.win32.dirname(absPath);
 	} else {
 		throw new Error(


### PR DESCRIPTION
Fixes https://github.com/webpack/webpack/issues/12305

UNC paths, of the form `\\hostname\path\to\file` are defined in section 2.2.57 of https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-DTYP/%5bMS-DTYP%5d.pdf. See also https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats#unc-paths, for example.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

I don't know where the tests for these filesystem functions are. I'm happy to add tests if someone points to where they should go.

Also, I'm writing this a bit blind--I don't have a windows system set up to test this. This is very similar to the fix reported to work in practice from https://github.com/webpack/webpack/issues/12305, except it fixes the code given there to check for *two* backslashes instead of just one.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

I'm not sure anything needs to be documented (except a changelog entry, maybe?)