### PR TITLE
Fix module concatenation renaming bug

### DIFF
--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -1239,24 +1239,18 @@ class ConcatenatedModule extends Module {
 							for (const identifier of allIdentifiers) {
 								const r = identifier.range;
 								const path = getPathInAst(info.ast, identifier);
-								if (
-									path &&
-									path.length > 1 &&
-									path[1].type === "Property" &&
-									path[1].shorthand
-								) {
-									source.insert(r[1], `: ${newName}`);
-								} else if (
-									path &&
-									path.length &&
-									path[1].type === "AssignmentPattern" &&
-									path[2].type === "Property" &&
-									path[2].shorthand
-								) {
-									source.insert(r[1], `: ${newName}`);
-								} else {
-									source.replace(r[0], r[1] - 1, newName);
+								if (path && path.length > 1) {
+									const maybeProperty =
+										path[1].type === "AssignmentPattern" ? path[2] : path[1];
+									if (
+										maybeProperty.type === "Property" &&
+										maybeProperty.shorthand
+									) {
+										source.insert(r[1], `: ${newName}`);
+										continue;
+									}
 								}
+								source.replace(r[0], r[1] - 1, newName);
 							}
 						} else {
 							allUsedNames.add(name);

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -1246,6 +1246,14 @@ class ConcatenatedModule extends Module {
 									path[1].shorthand
 								) {
 									source.insert(r[1], `: ${newName}`);
+								} else if (
+									path &&
+									path.length &&
+									path[1].type === "AssignmentPattern" &&
+									path[2].type === "Property" &&
+									path[2].shorthand
+								) {
+									source.insert(r[1], `: ${newName}`);
 								} else {
 									source.replace(r[0], r[1] - 1, newName);
 								}

--- a/test/configCases/concatenate-modules/destructuring-assignment-with-default-value-and-variable-collision-nested/config.js
+++ b/test/configCases/concatenate-modules/destructuring-assignment-with-default-value-and-variable-collision-nested/config.js
@@ -1,0 +1,7 @@
+export default {
+  deeply: {
+    nested: {
+      thing: 'Correct value',
+    },
+  },
+};

--- a/test/configCases/concatenate-modules/destructuring-assignment-with-default-value-and-variable-collision-nested/index.js
+++ b/test/configCases/concatenate-modules/destructuring-assignment-with-default-value-and-variable-collision-nested/index.js
@@ -1,0 +1,16 @@
+import * as modA from "./module-a";
+import config from "./config";
+
+const {
+	deeply: {
+		nested: { thing = "defaultValue" }
+	}
+} = config;
+
+it("renames a nested destructured assignment with default value correctly", () => {
+	expect(modA.deeply).toBe("Ignore me please");
+	expect(modA.nested).toBe("Ignore me please");
+	expect(modA.thing).toBe("Ignore me please");
+
+	expect(thing).toBe("Correct value");
+});

--- a/test/configCases/concatenate-modules/destructuring-assignment-with-default-value-and-variable-collision-nested/module-a.js
+++ b/test/configCases/concatenate-modules/destructuring-assignment-with-default-value-and-variable-collision-nested/module-a.js
@@ -1,0 +1,3 @@
+export const deeply = "Ignore me please";
+export const nested = "Ignore me please";
+export const thing = "Ignore me please";

--- a/test/configCases/concatenate-modules/destructuring-assignment-with-default-value-and-variable-collision-nested/webpack.config.js
+++ b/test/configCases/concatenate-modules/destructuring-assignment-with-default-value-and-variable-collision-nested/webpack.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	optimization: {
+		concatenateModules: true
+	}
+};

--- a/test/configCases/concatenate-modules/destructuring-assignment-with-default-value-and-variable-collision-simple/config.js
+++ b/test/configCases/concatenate-modules/destructuring-assignment-with-default-value-and-variable-collision-simple/config.js
@@ -1,0 +1,3 @@
+export default {
+	variableClash: "Correct value"
+};

--- a/test/configCases/concatenate-modules/destructuring-assignment-with-default-value-and-variable-collision-simple/index.js
+++ b/test/configCases/concatenate-modules/destructuring-assignment-with-default-value-and-variable-collision-simple/index.js
@@ -1,0 +1,9 @@
+import modA from "./module-a";
+import config from "./config";
+
+const { variableClash = "defaultValue" } = config;
+
+it("renames a destructured assignment with default value correctly", () => {
+	expect(modA).toBe("valueFromSomeFile");
+	expect(variableClash).toBe("Correct value");
+});

--- a/test/configCases/concatenate-modules/destructuring-assignment-with-default-value-and-variable-collision-simple/module-a.js
+++ b/test/configCases/concatenate-modules/destructuring-assignment-with-default-value-and-variable-collision-simple/module-a.js
@@ -1,0 +1,3 @@
+const variableClash = "valueFromSomeFile";
+
+export default variableClash;

--- a/test/configCases/concatenate-modules/destructuring-assignment-with-default-value-and-variable-collision-simple/webpack.config.js
+++ b/test/configCases/concatenate-modules/destructuring-assignment-with-default-value-and-variable-collision-simple/webpack.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	optimization: {
+		concatenateModules: true
+	}
+};


### PR DESCRIPTION
## Background
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

When using destructuring assignment in a module, in combination with a default assignment, it can cause the property looked up in the generated code to be different than the one in the source code _(it uses `newName`)_ if there's a identifier collision.

```js
// index.js
import modA from "./module-a";
import modB from "./config";

const { testProp = "defaultValue" } = modB;

modA();
console.log(testProp);
```
```js
// module-a.js

// In the real code, `stats` is read from another Webpack build
// for the client bundle, generated by `@loadable/webpack-plugin`
const stats = { testProp: 'valueFromSomeFile' };

const { testProp } = stats;

export default function printModuleAProp() {
  console.log(testProp);
}
```
```js
// config.js
export default {
  testProp: "configuredValue",
};
```

Generated code:

```js

/******/ (() => { // webpackBootstrap
/******/ 	"use strict";
var __webpack_exports__ = {};

;// CONCATENATED MODULE: ./src/module-a.js
// In the real code, `stats` is read from another Webpack build
// for the client bundle, generated by `@loadable/webpack-plugin`
const stats = { testProp: 'valueFromSomeFile' };

const { testProp } = stats;

function printModuleAProp() {
  console.log(testProp);
}

;// CONCATENATED MODULE: ./src/config.js
/* harmony default export */ const config = ({
	testProp: "configuredValue",
});

;// CONCATENATED MODULE: ./src/index.js



const { src_testProp = "defaultValue" } = config;

printModuleAProp();
console.log(src_testProp);

/******/ })()
;
```

## Analysis

If the code looks like in the following picture
![image](https://user-images.githubusercontent.com/463105/108497666-1956ea80-72ac-11eb-94b7-0dc2d0e33d9f.png)

we get a AST tree with paths that look like this:
![ConcatenatedModule_js_—_concatenate-bug](https://user-images.githubusercontent.com/463105/108497611-ff1d0c80-72ab-11eb-95ef-c555b128b101.png)

In this case, the `Property` we want to change is at index `1`, which the code handles just fine.

However, the bug appears when you've got code that looks like this:
![image](https://user-images.githubusercontent.com/463105/108497702-2b388d80-72ac-11eb-8076-6f895eadeecf.png)

In that case, you get an AST that looks like the following:
![ConcatenatedModule_js_—_concatenate-bug](https://user-images.githubusercontent.com/463105/108497851-5fac4980-72ac-11eb-86fa-68de1c57198a.png)

In this case, the code generator will take the second branch inside of `lib/optimize/ConcatenatedModule.js`, and change the name of the property without aliasing it, causing the semantics to change. The reason for that is that we have an `AssignmentPattern` at index `1`, while the `Property` we want to change is now at index `2`.

## The fix

This PR simply adds an additional check for this condition, and creates output like this instead:

```diff
- const { src_testProp = "defaultValue" } = config;
+ const { testProp: src_testProp = "defaultValue" } = config;
```

Closes #12712 

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

None, this is expected behaviour
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
