### PR TITLE
adding watching to the list of exported types in types.d.ts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,7 @@ const memoize = require("./util/memoize");
 /** @typedef {import("./MultiStats")} MultiStats */
 /** @typedef {import("./Parser").ParserState} ParserState */
 /** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsCompilation} StatsCompilation */
+/** @typedef {import("./Watching")} Watching */
 
 /**
  * @template {Function} T

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,8 +27,8 @@ const memoize = require("./util/memoize");
 /** @typedef {import("./Compilation").AssetInfo} AssetInfo */
 /** @typedef {import("./MultiStats")} MultiStats */
 /** @typedef {import("./Parser").ParserState} ParserState */
-/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsCompilation} StatsCompilation */
 /** @typedef {import("./Watching")} Watching */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsCompilation} StatsCompilation */
 
 /**
  * @template {Function} T

--- a/types.d.ts
+++ b/types.d.ts
@@ -11485,8 +11485,8 @@ declare namespace exports {
 		AssetInfo,
 		MultiStats,
 		ParserState,
-		StatsCompilation,
-	  Watching
+	  Watching,
+		StatsCompilation
 	};
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -11485,7 +11485,7 @@ declare namespace exports {
 		AssetInfo,
 		MultiStats,
 		ParserState,
-	  Watching,
+		Watching,
 		StatsCompilation
 	};
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -11485,7 +11485,8 @@ declare namespace exports {
 		AssetInfo,
 		MultiStats,
 		ParserState,
-		StatsCompilation
+		StatsCompilation,
+	  Watching
 	};
 }
 


### PR DESCRIPTION
adding watching to the list of exported types

I am using webback watching capability in my project, but since v5, types are being provided, but Watching type is not exposed, breaking my typescript project

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix for typescript projects leveraging watching capability
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Nothing, this is just a missing exported type.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
