### PR TITLE
fix bug where ExportInfo uses inactive connections to find the target of an export

### DIFF
--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -1179,7 +1179,13 @@ class ExportInfo {
 	 */
 	_findTarget(moduleGraph, validTargetModuleFilter, alreadyVisited) {
 		if (!this._target || this._target.size === 0) return undefined;
-		let rawTarget = this._target.values().next().value;
+		let rawTarget;
+		for (const target of this._target.values()) {
+			if (target.connection.isTargetActive(undefined)) {
+				rawTarget = target;
+				break;
+			}
+		}
 		if (!rawTarget) return undefined;
 		/** @type {{ module: Module, export: string[] | undefined }} */
 		let target = {
@@ -1223,7 +1229,7 @@ class ExportInfo {
 
 	/**
 	 * @param {ModuleGraph} moduleGraph the module graph
-	 * @param {function({ module: Module, export: string[] | undefined }): boolean} resolveTargetFilter filter function to further resolve target
+	 * @param {function({ module: Module, connection: ModuleGraphConnection, export: string[] | undefined }): boolean} resolveTargetFilter filter function to further resolve target
 	 * @param {Set<ExportInfo> | undefined} alreadyVisited set of already visited export info to avoid circular references
 	 * @returns {{ module: Module, connection: ModuleGraphConnection, export: string[] | undefined } | CIRCULAR | undefined} the target
 	 */
@@ -1291,9 +1297,6 @@ class ExportInfo {
 		const target = resolveTarget(values.next().value, newAlreadyVisited);
 		if (target === CIRCULAR) return CIRCULAR;
 		if (target === null) return undefined;
-		if (this._target.size === 1) {
-			return target;
-		}
 		let result = values.next();
 		while (!result.done) {
 			const t = resolveTarget(result.value, newAlreadyVisited);
@@ -1311,15 +1314,25 @@ class ExportInfo {
 	 * Move the target forward as long resolveTargetFilter is fulfilled
 	 * @param {ModuleGraph} moduleGraph the module graph
 	 * @param {function({ module: Module, export: string[] | undefined }): boolean} resolveTargetFilter filter function to further resolve target
-	 * @returns {{ module: Module, export: string[] | undefined } | undefined} the target
+	 * @param {function({ module: Module, export: string[] | undefined }): ModuleGraphConnection=} updateOriginalConnection updates the original connection instead of using the target connection
+	 * @returns {{ module: Module, export: string[] | undefined } | undefined} the resolved target when moved
 	 */
-	moveTarget(moduleGraph, resolveTargetFilter) {
+	moveTarget(moduleGraph, resolveTargetFilter, updateOriginalConnection) {
 		const target = this._getTarget(moduleGraph, resolveTargetFilter, undefined);
 		if (target === CIRCULAR) return undefined;
 		if (!target) return undefined;
+		const originalTarget = this._target.values().next().value;
+		if (
+			originalTarget.connection === target.connection &&
+			originalTarget.export === target.export
+		) {
+			return undefined;
+		}
 		this._target.clear();
 		this._target.set(undefined, {
-			connection: target.connection,
+			connection: updateOriginalConnection
+				? updateOriginalConnection(target)
+				: target.connection,
 			export: target.export
 		});
 		return target;

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -264,8 +264,24 @@ class SideEffectsFlagPlugin {
 												moduleGraph,
 												({ module }) =>
 													module.getSideEffectsConnectionState(moduleGraph) ===
-													false
+													false,
+												({ module: newModule, export: exportName }) => {
+													moduleGraph.updateModule(dep, newModule);
+													moduleGraph.addExplanation(
+														dep,
+														"(skipped side-effect-free modules)"
+													);
+													const ids = dep.getIds(moduleGraph);
+													dep.setIds(
+														moduleGraph,
+														exportName
+															? [...exportName, ...ids.slice(1)]
+															: ids.slice(1)
+													);
+													return moduleGraph.getConnection(dep);
+												}
 											);
+											continue;
 										}
 										// TODO improve for nested imports
 										const ids = dep.getIds(moduleGraph);

--- a/test/cases/side-effects/issue-12570/chunk.js
+++ b/test/cases/side-effects/issue-12570/chunk.js
@@ -1,0 +1,3 @@
+import { other } from "./inner-reexport";
+
+console.log.bind(console, other);

--- a/test/cases/side-effects/issue-12570/index.js
+++ b/test/cases/side-effects/issue-12570/index.js
@@ -1,0 +1,4 @@
+it("should compile", () => {
+	require("./module");
+	require("./chunk");
+});

--- a/test/cases/side-effects/issue-12570/inner-module.js
+++ b/test/cases/side-effects/issue-12570/inner-module.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/test/cases/side-effects/issue-12570/inner-reexport.js
+++ b/test/cases/side-effects/issue-12570/inner-reexport.js
@@ -1,0 +1,2 @@
+export * from "./inner-module.js";
+export var other = 1;

--- a/test/cases/side-effects/issue-12570/module.js
+++ b/test/cases/side-effects/issue-12570/module.js
@@ -1,0 +1,1 @@
+export * from "./reexport";

--- a/test/cases/side-effects/issue-12570/package.json
+++ b/test/cases/side-effects/issue-12570/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/test/cases/side-effects/issue-12570/reexport.js
+++ b/test/cases/side-effects/issue-12570/reexport.js
@@ -1,0 +1,2 @@
+export * from "./inner-reexport";
+export * from "./inner-module";

--- a/types.d.ts
+++ b/types.d.ts
@@ -3176,7 +3176,11 @@ declare abstract class ExportInfo {
 		resolveTargetFilter: (arg0: {
 			module: Module;
 			export?: string[];
-		}) => boolean
+		}) => boolean,
+		updateOriginalConnection?: (arg0: {
+			module: Module;
+			export?: string[];
+		}) => ModuleGraphConnection
 	): undefined | { module: Module; export?: string[] };
 	createNestedExportsInfo(): undefined | ExportsInfo;
 	getNestedExportsInfo(): undefined | ExportsInfo;


### PR DESCRIPTION
This happens when multiple exports * export the same name but the first one is discovered later in the process
In this case the ExportInfo contains both connections, but the second one is inactive.

thanks to @MLoughry for helping to debug that issue

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
