### PR TITLE
Fix letter spelling of missing a 's'

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -491,7 +491,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 						);
 					}
 				},
-				`${name} is deprecated (use Compilation.hook.processAssets instead and use one of Compilation.PROCESS_ASSETS_STAGE_* as stage option)`,
+				`${name} is deprecated (use Compilation.hooks.processAssets instead and use one of Compilation.PROCESS_ASSETS_STAGE_* as stage option)`,
 				code
 			);
 		};


### PR DESCRIPTION
Fix letter spelling of missing a 's'.

Just a spelling problem, please review the code.