### PR TITLE
Fix: HotModuleReplacement runtime property bug

### DIFF
--- a/lib/runtime/GetChunkFilenameRuntimeModule.js
+++ b/lib/runtime/GetChunkFilenameRuntimeModule.js
@@ -142,6 +142,7 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 					  )
 					: JSON.stringify(chunkFilename);
 			const staticChunkFilename = compilation.getPath(chunkFilenameValue, {
+				runtime: `" + "${c.runtime}" + "`,
 				hash: `" + ${RuntimeGlobals.getFullHash}() + "`,
 				hashWithLength: length =>
 					`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,
@@ -227,6 +228,7 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 		const url =
 			dynamicFilename &&
 			compilation.getPath(JSON.stringify(dynamicFilename), {
+				runtime: `" + "${chunk.runtime}" + "`,
 				hash: `" + ${RuntimeGlobals.getFullHash}() + "`,
 				hashWithLength: length =>
 					`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,

--- a/lib/runtime/GetChunkFilenameRuntimeModule.js
+++ b/lib/runtime/GetChunkFilenameRuntimeModule.js
@@ -142,7 +142,7 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 					  )
 					: JSON.stringify(chunkFilename);
 			const staticChunkFilename = compilation.getPath(chunkFilenameValue, {
-				runtime: `" + "${c.runtime}" + "`,
+				runtime: `" + ${JSON.stringify(c.runtime)} + "`,
 				hash: `" + ${RuntimeGlobals.getFullHash}() + "`,
 				hashWithLength: length =>
 					`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,
@@ -228,7 +228,7 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 		const url =
 			dynamicFilename &&
 			compilation.getPath(JSON.stringify(dynamicFilename), {
-				runtime: `" + "${chunk.runtime}" + "`,
+				runtime: `" + ${JSON.stringify(c.runtime)} + "`,
 				hash: `" + ${RuntimeGlobals.getFullHash}() + "`,
 				hashWithLength: length =>
 					`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,

--- a/lib/runtime/GetChunkFilenameRuntimeModule.js
+++ b/lib/runtime/GetChunkFilenameRuntimeModule.js
@@ -228,7 +228,7 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 		const url =
 			dynamicFilename &&
 			compilation.getPath(JSON.stringify(dynamicFilename), {
-				runtime: `" + ${JSON.stringify(c.runtime)} + "`,
+				runtime: `" + ${JSON.stringify(chunk.runtime)} + "`,
 				hash: `" + ${RuntimeGlobals.getFullHash}() + "`,
 				hashWithLength: length =>
 					`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
*HotModuleReplacementPlugin* raise warning:

*HotModuleReplacementPlugin*
> The configured output.hotUpdateMainFilename doesn't lead to unique filenames per runtime and HMR update differs between runtimes.
> This might lead to incorrect runtime behavior of the applied update.
> To fix this, make sure to include [runtime] in the output.hotUpdateMainFilename option, or use the default config.

but when adding the [runtime] parameter to the **hotUpdateMainFilename** and **hotUpdateChunkFilename** string, this property is absent in the Data object passed to the filename function

```js
getAssetPath(filename, data) {
   return this.hooks.assetPath.call(
     typeof filename === "function"? filename(data): filename,
     data,
     undefined
   );
}
```

This PR proposes to add a "runtime" property to the Data object

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Bugfix

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
No

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
No