### PR TITLE
fix types: accept a readonly array for configuration options

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -33,7 +33,7 @@ const validateSchema = require("./validateSchema");
  */
 
 /**
- * @param {WebpackOptions[]} childOptions options array
+ * @param {ReadonlyArray<WebpackOptions>} childOptions options array
  * @param {MultiCompilerOptions} options options
  * @returns {MultiCompiler} a multi-compiler
  */
@@ -89,14 +89,14 @@ const createCompiler = rawOptions => {
 
 /**
  * @callback WebpackFunctionMulti
- * @param {WebpackOptions[] & MultiCompilerOptions} options options objects
+ * @param {ReadonlyArray<WebpackOptions> & MultiCompilerOptions} options options objects
  * @param {Callback<MultiStats>=} callback callback
  * @returns {MultiCompiler} the multi compiler object
  */
 
 const webpack = /** @type {WebpackFunctionSingle & WebpackFunctionMulti} */ (
 	/**
-	 * @param {WebpackOptions | (WebpackOptions[] & MultiCompilerOptions)} options options
+	 * @param {WebpackOptions | (ReadonlyArray<WebpackOptions> & MultiCompilerOptions)} options options
 	 * @param {Callback<Stats> & Callback<MultiStats>=} callback callback
 	 * @returns {Compiler | MultiCompiler}
 	 */
@@ -114,10 +114,12 @@ const webpack = /** @type {WebpackFunctionSingle & WebpackFunctionMulti} */ (
 				watch = options.some(options => options.watch);
 				watchOptions = options.map(options => options.watchOptions || {});
 			} else {
+				/** @type {WebpackOptions} */
+				const webpackOptions = /** @type {WebpackOptions} */ options;
 				/** @type {Compiler} */
-				compiler = createCompiler(options);
-				watch = options.watch;
-				watchOptions = options.watchOptions || {};
+				compiler = createCompiler(webpackOptions);
+				watch = webpackOptions.watch;
+				watchOptions = webpackOptions.watchOptions || {};
 			}
 			return { compiler, watch, watchOptions };
 		};

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -114,8 +114,7 @@ const webpack = /** @type {WebpackFunctionSingle & WebpackFunctionMulti} */ (
 				watch = options.some(options => options.watch);
 				watchOptions = options.map(options => options.watchOptions || {});
 			} else {
-				/** @type {WebpackOptions} */
-				const webpackOptions = /** @type {WebpackOptions} */ options;
+				const webpackOptions = /** @type {WebpackOptions} */ (options);
 				/** @type {Compiler} */
 				compiler = createCompiler(webpackOptions);
 				watch = webpackOptions.watch;

--- a/types.d.ts
+++ b/types.d.ts
@@ -11169,14 +11169,14 @@ declare function exports(
 	callback?: CallbackWebpack<Stats>
 ): Compiler;
 declare function exports(
-	options: Configuration[] & MultiCompilerOptions,
+	options: ReadonlyArray<Configuration> & MultiCompilerOptions,
 	callback?: CallbackWebpack<MultiStats>
 ): MultiCompiler;
 declare namespace exports {
 	export const webpack: {
 		(options: Configuration, callback?: CallbackWebpack<Stats>): Compiler;
 		(
-			options: Configuration[] & MultiCompilerOptions,
+			options: ReadonlyArray<Configuration> & MultiCompilerOptions,
 			callback?: CallbackWebpack<MultiStats>
 		): MultiCompiler;
 	};


### PR DESCRIPTION
The webpack main function can get multiple configuration as an array. However this array doesn't need to be mutable. This fix makes it accept readonly arrays.

**What kind of change does this PR introduce?**

bugfix for typescript types declaration

**Did you add tests for your changes?**

No: I couldn't find typing tests.

**Does this PR introduce a breaking change?**

No: all types that were accepted before are still accepted, it accepts new types.

**What needs to be documented once your changes are merged?**

Nothing, this is a fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/webpack/webpack/12818)
<!-- Reviewable:end -->
