### PR TITLE
fix deterministicGrouping looping over group.nodes's negative indexes

### DIFF
--- a/lib/util/deterministicGrouping.js
+++ b/lib/util/deterministicGrouping.js
@@ -83,6 +83,17 @@ const addSizeTo = (total, size) => {
 };
 
 /**
+ * @param {Record<string, number>} total total size
+ * @param {Record<string, number>} size single size
+ * @returns {void}
+ */
+const subtractSizeFrom = (total, size) => {
+	for (const key of Object.keys(size)) {
+		total[key] -= size[key];
+	}
+};
+
+/**
  * @param {Iterable<Node>} nodes some nodes
  * @returns {Record<string, number>} total size
  */
@@ -96,9 +107,11 @@ const sumSize = nodes => {
 
 const isTooBig = (size, maxSize) => {
 	for (const key of Object.keys(size)) {
+		const s = size[key];
+		if (s === 0) continue;
 		const maxSizeValue = maxSize[key];
 		if (typeof maxSizeValue === "number") {
-			if (size[key] > maxSizeValue) return true;
+			if (s > maxSizeValue) return true;
 		}
 	}
 	return false;
@@ -106,20 +119,24 @@ const isTooBig = (size, maxSize) => {
 
 const isTooSmall = (size, minSize) => {
 	for (const key of Object.keys(size)) {
+		const s = size[key];
+		if (s === 0) continue;
 		const minSizeValue = minSize[key];
 		if (typeof minSizeValue === "number") {
-			if (size[key] < minSizeValue) return true;
+			if (s < minSizeValue) return true;
 		}
 	}
 	return false;
 };
 
-const getToSmallTypes = (size, minSize) => {
+const getTooSmallTypes = (size, minSize) => {
 	const types = new Set();
 	for (const key of Object.keys(size)) {
+		const s = size[key];
+		if (s === 0) continue;
 		const minSizeValue = minSize[key];
 		if (typeof minSizeValue === "number") {
-			if (size[key] < minSizeValue) types.add(key);
+			if (s < minSizeValue) types.add(key);
 		}
 	}
 	return types;
@@ -128,7 +145,7 @@ const getToSmallTypes = (size, minSize) => {
 const getNumberOfMatchingSizeTypes = (size, types) => {
 	let i = 0;
 	for (const key of Object.keys(size)) {
-		if (types.has(key)) i++;
+		if (size[key] !== 0 && types.has(key)) i++;
 	}
 	return i;
 };
@@ -136,7 +153,7 @@ const getNumberOfMatchingSizeTypes = (size, types) => {
 const selectiveSizeSum = (size, types) => {
 	let sum = 0;
 	for (const key of Object.keys(size)) {
-		if (types.has(key)) sum += size[key];
+		if (size[key] !== 0 && types.has(key)) sum += size[key];
 	}
 	return sum;
 };
@@ -279,45 +296,51 @@ module.exports = ({ maxSize, minSize, items, getSize, getKey }) => {
 	if (initialNodes.length > 0) {
 		const initialGroup = new Group(initialNodes, getSimilarities(initialNodes));
 
-		const problemTypes = getToSmallTypes(initialGroup.size, minSize);
-		if (problemTypes.size > 0) {
-			// We hit an edge case where the working set is already smaller than minSize
-			// We merge problematic nodes with the smallest result node to keep minSize intact
-			const problemNodes = initialGroup.popNodes(
-				n => getNumberOfMatchingSizeTypes(n.size, problemTypes) > 0
-			);
-			// Only merge it with result nodes that have the problematic size type
-			const possibleResultGroups = result.filter(
-				n => getNumberOfMatchingSizeTypes(n.size, problemTypes) > 0
-			);
-			if (possibleResultGroups.length > 0) {
-				const bestGroup = possibleResultGroups.reduce((min, group) => {
-					const minMatches = getNumberOfMatchingSizeTypes(min, problemTypes);
-					const groupMatches = getNumberOfMatchingSizeTypes(
-						group,
-						problemTypes
-					);
-					if (minMatches !== groupMatches)
-						return minMatches < groupMatches ? group : min;
-					if (
-						selectiveSizeSum(min.size, problemTypes) >
-						selectiveSizeSum(group.size, problemTypes)
-					)
-						return group;
-					return min;
-				});
-				for (const node of problemNodes) bestGroup.nodes.push(node);
-				bestGroup.nodes.sort((a, b) => {
-					if (a.key < b.key) return -1;
-					if (a.key > b.key) return 1;
-					return 0;
-				});
+		const removeProblematicNodes = group => {
+			const problemTypes = getTooSmallTypes(group.size, minSize);
+			if (problemTypes.size > 0) {
+				// We hit an edge case where the working set is already smaller than minSize
+				// We merge problematic nodes with the smallest result node to keep minSize intact
+				const problemNodes = group.popNodes(
+					n => getNumberOfMatchingSizeTypes(n.size, problemTypes) > 0
+				);
+				// Only merge it with result nodes that have the problematic size type
+				const possibleResultGroups = result.filter(
+					n => getNumberOfMatchingSizeTypes(n.size, problemTypes) > 0
+				);
+				if (possibleResultGroups.length > 0) {
+					const bestGroup = possibleResultGroups.reduce((min, group) => {
+						const minMatches = getNumberOfMatchingSizeTypes(min, problemTypes);
+						const groupMatches = getNumberOfMatchingSizeTypes(
+							group,
+							problemTypes
+						);
+						if (minMatches !== groupMatches)
+							return minMatches < groupMatches ? group : min;
+						if (
+							selectiveSizeSum(min.size, problemTypes) >
+							selectiveSizeSum(group.size, problemTypes)
+						)
+							return group;
+						return min;
+					});
+					for (const node of problemNodes) bestGroup.nodes.push(node);
+					bestGroup.nodes.sort((a, b) => {
+						if (a.key < b.key) return -1;
+						if (a.key > b.key) return 1;
+						return 0;
+					});
+				} else {
+					// There are no other nodes with the same size types
+					// We create a new group and have to accept that it's smaller than minSize
+					result.push(new Group(problemNodes, null));
+				}
+				return true;
 			} else {
-				// There are no other nodes with the same size types
-				// We create a new group and have to accept that it's smaller than minSize
-				result.push(new Group(problemNodes, null));
+				return false;
 			}
-		}
+		};
+
 		if (initialGroup.nodes.length > 0) {
 			const queue = [initialGroup];
 
@@ -328,6 +351,13 @@ module.exports = ({ maxSize, minSize, items, getSize, getKey }) => {
 					result.push(group);
 					continue;
 				}
+				// If the group is already too small
+				// we try to work only with the unproblematic nodes
+				if (removeProblematicNodes(group)) {
+					// This changed something, so we try this group again
+					queue.push(group);
+					continue;
+				}
 
 				// find unsplittable area from left and right
 				// going minSize from left and right
@@ -335,7 +365,7 @@ module.exports = ({ maxSize, minSize, items, getSize, getKey }) => {
 				let left = 1;
 				let leftSize = Object.create(null);
 				addSizeTo(leftSize, group.nodes[0].size);
-				while (isTooSmall(leftSize, minSize)) {
+				while (left < group.nodes.length && isTooSmall(leftSize, minSize)) {
 					addSizeTo(leftSize, group.nodes[left].size);
 					left++;
 				}
@@ -360,17 +390,32 @@ module.exports = ({ maxSize, minSize, items, getSize, getKey }) => {
 					// we look for best split point
 					// we split at the minimum similarity
 					// here key space is separated the most
-					let best = left - 1;
-					let bestSimilarity = group.similarities[best];
-					for (let i = left; i <= right; i++) {
-						const similarity = group.similarities[i];
-						if (similarity < bestSimilarity) {
-							best = i;
+					// But we also need to make sure to not create too small groups
+					let best = -1;
+					let bestSimilarity = Infinity;
+					let pos = left;
+					let rightSize = sumSize(group.nodes.slice(pos));
+					while (pos <= right) {
+						const similarity = group.similarities[pos - 1];
+						if (
+							similarity < bestSimilarity &&
+							!isTooSmall(leftSize, minSize) &&
+							!isTooSmall(rightSize, minSize)
+						) {
+							best = pos;
 							bestSimilarity = similarity;
 						}
+						addSizeTo(leftSize, group.nodes[pos].size);
+						subtractSizeFrom(rightSize, group.nodes[pos].size);
+						pos++;
 					}
-					left = best + 1;
-					right = best;
+					if (best < 0) {
+						// can't split group while holding minSize
+						result.push(group);
+						continue;
+					}
+					left = best;
+					right = best - 1;
 				}
 
 				// create two new groups for left and right area

--- a/lib/util/deterministicGrouping.js
+++ b/lib/util/deterministicGrouping.js
@@ -342,7 +342,7 @@ module.exports = ({ maxSize, minSize, items, getSize, getKey }) => {
 				let right = group.nodes.length - 2;
 				let rightSize = Object.create(null);
 				addSizeTo(rightSize, group.nodes[group.nodes.length - 1].size);
-				while (isTooSmall(rightSize, minSize)) {
+				while (right >= 0 && isTooSmall(rightSize, minSize)) {
 					addSizeTo(rightSize, group.nodes[right].size);
 					right--;
 				}

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -4017,34 +4017,36 @@ development:
   development (webpack x.x.x) compiled successfully
 
 switched:
-  Entrypoint main 31.3 KiB = 8 assets
-  chunk (runtime: main) switched-main-6bb16544.js (main-6bb16544) 1.57 KiB ={59}= ={247}= ={318}= ={520}= ={581}= ={663}= ={997}= [initial] [rendered]
+  Entrypoint main 31.3 KiB = 9 assets
+  chunk (runtime: main) switched-main-6bb16544.js (main-6bb16544) 1.57 KiB ={59}= ={318}= ={410}= ={520}= ={581}= ={663}= ={869}= ={997}= [initial] [rendered]
     > ./ main
     ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
-  chunk (runtime: main) switched-main-77a8c116.js (main-77a8c116) 1.57 KiB ={1}= ={247}= ={318}= ={520}= ={581}= ={663}= ={997}= [initial] [rendered]
+  chunk (runtime: main) switched-main-77a8c116.js (main-77a8c116) 1.57 KiB ={1}= ={318}= ={410}= ={520}= ={581}= ={663}= ={869}= ={997}= [initial] [rendered]
     > ./ main
     ./very-big.js?2 1.57 KiB [built] [code generated]
-  chunk (runtime: main) switched-247.js (id hint: vendors) 1.96 KiB ={1}= ={59}= ={318}= ={520}= ={581}= ={663}= ={997}= [initial] [rendered] split chunk (cache group: defaultVendors)
+  chunk (runtime: main) switched-main-89a43a0f.js (main-89a43a0f) 1.57 KiB ={1}= ={59}= ={410}= ={520}= ={581}= ={663}= ={869}= ={997}= [initial] [rendered]
+    > ./ main
+    ./very-big.js?3 1.57 KiB [built] [code generated]
+  chunk (runtime: main) switched-410.js (id hint: vendors) 1.57 KiB ={1}= ={59}= ={318}= ={520}= ={581}= ={663}= ={869}= ={997}= [initial] [rendered] split chunk (cache group: defaultVendors)
+    > ./ main
+    ./node_modules/very-big.js?1 1.57 KiB [built] [code generated]
+  chunk (runtime: main) switched-main-1df31ce3.js (main-1df31ce3) 1.19 KiB ={1}= ={59}= ={318}= ={410}= ={581}= ={663}= ={869}= ={997}= [initial] [rendered]
+    > ./ main
+    ./index.js 1.19 KiB [built] [code generated]
+  chunk (runtime: main) switched-main-879072e3.js (main-879072e3) 1.68 KiB ={1}= ={59}= ={318}= ={410}= ={520}= ={663}= ={869}= ={997}= [initial] [rendered]
+    > ./ main
+    modules by path ./subfolder/*.js 1.1 KiB 11 modules
+    modules by path ./*.js 594 bytes 9 modules
+  chunk (runtime: main) switched-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 2.89 KiB (runtime) ={1}= ={59}= ={318}= ={410}= ={520}= ={581}= ={869}= ={997}= [entry] [rendered]
+    > ./ main
+    runtime modules 2.89 KiB 5 modules
+    ./very-big.js?1 1.57 KiB [built] [code generated]
+  chunk (runtime: main) switched-869.js (id hint: vendors) 399 bytes ={1}= ={59}= ={318}= ={410}= ={520}= ={581}= ={663}= ={997}= [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./ main
     ./node_modules/big.js?1 267 bytes [built] [code generated]
     ./node_modules/small.js?1 66 bytes [built] [code generated]
     ./node_modules/small.js?2 66 bytes [built] [code generated]
-    ./node_modules/very-big.js?1 1.57 KiB [built] [code generated]
-  chunk (runtime: main) switched-main-89a43a0f.js (main-89a43a0f) 1.57 KiB ={1}= ={59}= ={247}= ={520}= ={581}= ={663}= ={997}= [initial] [rendered]
-    > ./ main
-    ./very-big.js?3 1.57 KiB [built] [code generated]
-  chunk (runtime: main) switched-main-1df31ce3.js (main-1df31ce3) 1.19 KiB ={1}= ={59}= ={247}= ={318}= ={581}= ={663}= ={997}= [initial] [rendered]
-    > ./ main
-    ./index.js 1.19 KiB [built] [code generated]
-  chunk (runtime: main) switched-main-879072e3.js (main-879072e3) 1.68 KiB ={1}= ={59}= ={247}= ={318}= ={520}= ={663}= ={997}= [initial] [rendered]
-    > ./ main
-    modules by path ./subfolder/*.js 1.1 KiB 11 modules
-    modules by path ./*.js 594 bytes 9 modules
-  chunk (runtime: main) switched-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 2.89 KiB (runtime) ={1}= ={59}= ={247}= ={318}= ={520}= ={581}= ={997}= [entry] [rendered]
-    > ./ main
-    runtime modules 2.89 KiB 5 modules
-    ./very-big.js?1 1.57 KiB [built] [code generated]
-  chunk (runtime: main) switched-main-7aeafcb2.js (main-7aeafcb2) 1.62 KiB ={1}= ={59}= ={247}= ={318}= ={520}= ={581}= ={663}= [initial] [rendered]
+  chunk (runtime: main) switched-main-7aeafcb2.js (main-7aeafcb2) 1.62 KiB ={1}= ={59}= ={318}= ={410}= ={520}= ={581}= ={663}= ={869}= [initial] [rendered]
     > ./ main
     modules by path ./inner-module/*.js 594 bytes 9 modules
     modules by path ./in-some-directory/*.js 531 bytes


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Please see https://github.com/webpack/webpack/issues/12487#issuecomment-792747387 for explanation.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Bugfix, fixes #12487

This may, I guess, cause build to produce files smaller than `minSize`, but that's better than crashing in such cases.

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

Nope, I don't know this repo well enough to create them. Happy to work with anyone willing to come up with some.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

Nothing