### PR TITLE
refactor: simplify lazy compilation communication

### DIFF
--- a/hot/lazy-compilation-node.js
+++ b/hot/lazy-compilation-node.js
@@ -12,8 +12,7 @@ exports.keepAlive = function (options) {
 	var request = require("http").request(
 		urlBase + data,
 		{
-			agent: false,
-			headers: { accept: "text/event-stream" }
+			agent: false
 		},
 		function (res) {
 			response = res;

--- a/lib/hmr/lazyCompilationBackend.js
+++ b/lib/hmr/lazyCompilationBackend.js
@@ -36,11 +36,8 @@ module.exports = (compiler, client, callback) => {
 			}, 120000);
 		});
 		req.socket.setNoDelay(true);
-		res.writeHead(200, {
-			"content-type": "text/event-stream",
-			"Access-Control-Allow-Origin": "*"
-		});
-		res.write("\n");
+		res.writeHead(200);
+		res.end();
 		let moduleActivated = false;
 		for (const key of keys) {
 			const oldValue = activeModules.get(key) || 0;


### PR DESCRIPTION
Use http get request instead of SSE in lazy compilation communication.

Server Sent Events have a limitation when is used over http connection. 

> When not used over HTTP/2, SSE suffers from a limitation to the maximum number of open connections, which can be especially painful when opening multiple tabs, as the limit is per browser and is set to a very low number (6). The issue has been marked as "Won't fix" in Chrome and Firefox.
– From: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events

This limitation is probably the root cause of one sporadic issue that we are seeing in some engs laptops:

<img width="547" alt="Screen Shot 2021-03-08 at 8 33 27 PM" src="https://user-images.githubusercontent.com/7464663/110395775-8f4da680-804d-11eb-9090-d18733daa6dd.png">

**What kind of change does this PR introduce?**

refactoring, maybe bugfix.

**Did you add tests for your changes?**

No

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

Nothing