### PR TITLE
fix: rename non-harmony to non-es

### DIFF
--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -773,7 +773,7 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 				case "reexport-undefined":
 					concatenationScope.registerRawExport(
 						mode.name,
-						"/* reexport non-default export from non-harmony */ undefined"
+						"/* reexport non-default export from non-es */ undefined"
 					);
 			}
 			return;
@@ -872,7 +872,7 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 				initFragments.push(
 					this.getReexportFragment(
 						module,
-						"reexport non-default export from non-harmony",
+						"reexport non-default export from non-es",
 						moduleGraph.getExportsInfo(module).getUsedName(mode.name, runtime),
 						"undefined",
 						"",
@@ -1025,7 +1025,7 @@ HarmonyExportImportedSpecifierDependency.Template = class HarmonyExportImportedS
 		const map = new Map();
 		map.set(
 			key,
-			`/* reexport fake namespace object from non-harmony */ ${name}_namespace_cache || (${name}_namespace_cache = ${
+			`/* reexport fake namespace object from non-es */ ${name}_namespace_cache || (${name}_namespace_cache = ${
 				RuntimeGlobals.createFakeNamespaceObject
 			}(${name}${fakeType ? `, ${fakeType}` : ""}))`
 		);

--- a/lib/runtime/CompatGetDefaultExportRuntimeModule.js
+++ b/lib/runtime/CompatGetDefaultExportRuntimeModule.js
@@ -20,7 +20,7 @@ class CompatGetDefaultExportRuntimeModule extends HelperRuntimeModule {
 		const { runtimeTemplate } = this.compilation;
 		const fn = RuntimeGlobals.compatGetDefaultExport;
 		return Template.asString([
-			"// getDefaultExport function for compatibility with non-harmony modules",
+			"// getDefaultExport function for compatibility with non-es modules",
 			`${fn} = ${runtimeTemplate.basicFunction("module", [
 				"var getter = module && module.__esModule ?",
 				Template.indent([

--- a/test/cases/parsing/harmony-commonjs/index.js
+++ b/test/cases/parsing/harmony-commonjs/index.js
@@ -16,7 +16,7 @@ it("should pass when use babeljs transpiler", function() {
 	expect(test2).toBe("OK");
 });
 
-it("should double reexport from non-harmony modules correctly", function() {
+it("should double reexport from non-es modules correctly", function() {
 	expect(y).toBe("y");
 	expect(x).toBe("x");
 });

--- a/test/hotCases/harmony/auto-import-default/index.js
+++ b/test/hotCases/harmony/auto-import-default/index.js
@@ -1,6 +1,6 @@
 import value from "./file";
 
-it("should auto-import an ES6 imported default value from non-harmony module on accept", (done) => {
+it("should auto-import an ES6 imported default value from non-es module on accept", (done) => {
 	expect(value).toBe(1);
 	module.hot.accept("./file", () => {
 		expect(value).toBe(2);


### PR DESCRIPTION
#### The Reason

The non-harmony concept was so old and difficult to find, it made many ones don't know what it means. This modify can make it more semantic.

I only find it on their websites.

- [Wiki ECMAScript](https://en.wikipedia.org/wiki/ECMAScript#4th_Edition_(abandoned))
- [ES6_plans](https://wiki.mozilla.org/ES6_plans)

So, I made the PR.