### PR TITLE
add `emit` option for asset modules

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -706,11 +706,6 @@ export type AssetParserDataUrlFunction = (
 	context: {filename: string; module: import("../lib/Module")}
 ) => boolean;
 /**
- * Parser options for asset modules.
- */
-export type AssetParserOptions = AssetResourceParserOptions &
-	AssetParserOptionsExtra;
-/**
  * A Function returning a Promise resolving to a normalized entry.
  */
 export type EntryDynamicNormalized = () => Promise<EntryStaticNormalized>;
@@ -2577,18 +2572,18 @@ export interface AssetParserDataUrlOptions {
 	maxSize?: number;
 }
 /**
+ * Parser options for asset modules.
+ */
+export interface AssetParserOptions {
+	/**
+	 * The condition for inlining the asset as DataUrl.
+	 */
+	dataUrlCondition?: AssetParserDataUrlOptions | AssetParserDataUrlFunction;
+}
+/**
  * Generator options for asset/resource modules.
  */
 export interface AssetResourceGeneratorOptions {
-	/**
-	 * This is deprecated and has moved to 'parser.filename'.
-	 */
-	filename?: FilenameTemplate;
-}
-/**
- * Parser options for asset/resource modules.
- */
-export interface AssetResourceParserOptions {
 	/**
 	 * Specifies the filename template of output files on disk. You must **not** specify an absolute path here, but the path may contain folders separated by '/'! The specified path is joined with the value of the 'output.path' option to determine the location on disk.
 	 */
@@ -3143,15 +3138,6 @@ export interface WebpackOptionsNormalized {
 	watchOptions: WatchOptions;
 }
 /**
- * Parser options for asset modules.
- */
-export interface AssetParserOptionsExtra {
-	/**
-	 * The condition for inlining the asset as DataUrl.
-	 */
-	dataUrlCondition?: AssetParserDataUrlOptions | AssetParserDataUrlFunction;
-}
-/**
  * If an dependency matches exactly a property of the object, the property value is used as dependency.
  */
 export interface ExternalItemObjectKnown {
@@ -3227,9 +3213,9 @@ export interface ParserOptionsByModuleTypeKnown {
 	 */
 	"asset/inline"?: EmptyParserOptions;
 	/**
-	 * Parser options for asset/resource modules.
+	 * No parser options are supported for this module type.
 	 */
-	"asset/resource"?: AssetResourceParserOptions;
+	"asset/resource"?: EmptyParserOptions;
 	/**
 	 * No parser options are supported for this module type.
 	 */

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -2585,6 +2585,10 @@ export interface AssetParserOptions {
  */
 export interface AssetResourceGeneratorOptions {
 	/**
+	 * Emit an output asset from this asset module. This can be set to 'false' to omit emitting e. g. for SSR.
+	 */
+	emit?: boolean;
+	/**
 	 * Specifies the filename template of output files on disk. You must **not** specify an absolute path here, but the path may contain folders separated by '/'! The specified path is joined with the value of the 'output.path' option to determine the location on disk.
 	 */
 	filename?: FilenameTemplate;

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -788,6 +788,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		this.mainTemplate = new MainTemplate(this.outputOptions, this);
 		this.chunkTemplate = new ChunkTemplate(this.outputOptions, this);
 		this.runtimeTemplate = new RuntimeTemplate(
+			this,
 			this.outputOptions,
 			this.requestShortener
 		);

--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -16,6 +16,7 @@ const { forEachRuntime, subtractRuntime } = require("./util/runtime");
 /** @typedef {import("../declarations/WebpackOptions").OutputNormalized} OutputOptions */
 /** @typedef {import("./AsyncDependenciesBlock")} AsyncDependenciesBlock */
 /** @typedef {import("./ChunkGraph")} ChunkGraph */
+/** @typedef {import("./Compilation")} Compilation */
 /** @typedef {import("./Dependency")} Dependency */
 /** @typedef {import("./Module")} Module */
 /** @typedef {import("./ModuleGraph")} ModuleGraph */
@@ -51,12 +52,13 @@ Module has these incoming connections: ${Array.from(
 
 class RuntimeTemplate {
 	/**
+	 * @param {Compilation} compilation the compilation
 	 * @param {OutputOptions} outputOptions the compilation output options
 	 * @param {RequestShortener} requestShortener the request shortener
 	 */
-	constructor(outputOptions, requestShortener) {
+	constructor(compilation, outputOptions, requestShortener) {
+		this.compilation = compilation;
 		this.outputOptions = outputOptions || {};
-		/** @type {RequestShortener} */
 		this.requestShortener = requestShortener;
 	}
 

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -10,6 +10,8 @@ const path = require("path");
 const { RawSource } = require("webpack-sources");
 const Generator = require("../Generator");
 const RuntimeGlobals = require("../RuntimeGlobals");
+const createHash = require("../util/createHash");
+const { makePathsRelative } = require("../util/identifier");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../../declarations/WebpackOptions").AssetGeneratorOptions} AssetGeneratorOptions */
@@ -107,14 +109,52 @@ class AssetGenerator extends Generator {
 						)};`
 					);
 				} else {
+					const assetModuleFilename =
+						this.filename || runtimeTemplate.outputOptions.assetModuleFilename;
+					const hash = createHash(runtimeTemplate.outputOptions.hashFunction);
+					if (runtimeTemplate.outputOptions.hashSalt) {
+						hash.update(runtimeTemplate.outputOptions.hashSalt);
+					}
+					hash.update(originalSource.buffer());
+					const fullHash = /** @type {string} */ (hash.digest(
+						runtimeTemplate.outputOptions.hashDigest
+					));
+					const contentHash = fullHash.slice(
+						0,
+						runtimeTemplate.outputOptions.hashDigestLength
+					);
+					module.buildInfo.fullContentHash = fullHash;
+					const sourceFilename = makePathsRelative(
+						runtimeTemplate.compilation.compiler.context,
+						module.matchResource || module.resource,
+						runtimeTemplate.compilation.compiler.root
+					).replace(/^\.\//, "");
+					const {
+						path: filename,
+						info
+					} = runtimeTemplate.compilation.getAssetPathWithInfo(
+						assetModuleFilename,
+						{
+							module,
+							runtime,
+							filename: sourceFilename,
+							chunkGraph,
+							contentHash
+						}
+					);
+					module.buildInfo.filename = filename;
+					module.buildInfo.assetInfo = {
+						sourceFilename,
+						...info
+					};
 					if (getData) {
-						// We did a mistake in some minor version of 5.x
-						// Now we have to keep it for backward-compat reasons
-						// TODO webpack 6 remove
+						// Due to code generation caching module.buildInfo.XXX can't used to store such information
+						// It need to be stored in the code generation results instead, where it's cached too
+						// TODO webpack 6 For back-compat reasons we also store in on module.buildInfo
 						const data = getData();
-						data.set("fullContentHash", module.buildInfo.fullContentHash);
-						data.set("filename", module.buildInfo.filename);
-						data.set("assetInfo", module.buildInfo.assetInfo);
+						data.set("fullContentHash", fullHash);
+						data.set("filename", filename);
+						data.set("assetInfo", info);
 					}
 
 					runtimeRequirements.add(RuntimeGlobals.publicPath); // add __webpack_require__.p
@@ -122,7 +162,7 @@ class AssetGenerator extends Generator {
 					return new RawSource(
 						`${RuntimeGlobals.module}.exports = ${
 							RuntimeGlobals.publicPath
-						} + ${JSON.stringify(module.buildInfo.filename)};`
+						} + ${JSON.stringify(filename)};`
 					);
 				}
 			}

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -31,11 +31,13 @@ class AssetGenerator extends Generator {
 	/**
 	 * @param {AssetGeneratorOptions["dataUrl"]=} dataUrlOptions the options for the data url
 	 * @param {string=} filename override for output.assetModuleFilename
+	 * @param {boolean=} emit generate output asset
 	 */
-	constructor(dataUrlOptions, filename) {
+	constructor(dataUrlOptions, filename, emit) {
 		super();
 		this.dataUrlOptions = dataUrlOptions;
 		this.filename = filename;
+		this.emit = emit;
 	}
 
 	/**
@@ -174,7 +176,7 @@ class AssetGenerator extends Generator {
 	 * @returns {Set<string>} available types (do not mutate)
 	 */
 	getTypes(module) {
-		if (module.buildInfo.dataUrl) {
+		if (module.buildInfo.dataUrl || this.emit === false) {
 			return JS_TYPES;
 		} else {
 			return JS_AND_ASSET_TYPES;

--- a/lib/asset/AssetModulesPlugin.js
+++ b/lib/asset/AssetModulesPlugin.js
@@ -124,7 +124,11 @@ class AssetModulesPlugin {
 
 							const AssetGenerator = getAssetGenerator();
 
-							return new AssetGenerator(dataUrl, filename);
+							return new AssetGenerator(
+								dataUrl,
+								filename,
+								generatorOptions.emit !== false
+							);
 						});
 				}
 				normalModuleFactory.hooks.createGenerator

--- a/lib/asset/AssetModulesPlugin.js
+++ b/lib/asset/AssetModulesPlugin.js
@@ -71,7 +71,7 @@ class AssetModulesPlugin {
 
 						const AssetParser = getAssetParser();
 
-						return new AssetParser(dataUrlCondition, parserOptions.filename);
+						return new AssetParser(dataUrlCondition);
 					});
 				normalModuleFactory.hooks.createParser
 					.for("asset/inline")
@@ -85,7 +85,7 @@ class AssetModulesPlugin {
 					.tap(plugin, parserOptions => {
 						const AssetParser = getAssetParser();
 
-						return new AssetParser(false, parserOptions.filename);
+						return new AssetParser(false);
 					});
 				normalModuleFactory.hooks.createParser
 					.for("asset/source")
@@ -152,11 +152,17 @@ class AssetModulesPlugin {
 							);
 							result.push({
 								render: () => codeGenResult.sources.get(type),
-								filename: module.buildInfo.filename,
-								info: module.buildInfo.assetInfo,
+								filename:
+									module.buildInfo.filename ||
+									codeGenResult.data.get("filename"),
+								info:
+									module.buildInfo.assetInfo ||
+									codeGenResult.data.get("assetInfo"),
 								auxiliary: true,
 								identifier: `assetModule${chunkGraph.getModuleId(module)}`,
-								hash: module.buildInfo.fullContentHash
+								hash:
+									module.buildInfo.fullContentHash ||
+									codeGenResult.data.get("fullContentHash")
 							});
 						}
 					}

--- a/lib/asset/AssetParser.js
+++ b/lib/asset/AssetParser.js
@@ -6,9 +6,6 @@
 "use strict";
 
 const Parser = require("../Parser");
-const createHash = require("../util/createHash");
-const { makePathsRelative } = require("../util/identifier");
-const AssetGenerator = require("./AssetGenerator");
 
 /** @typedef {import("../../declarations/WebpackOptions").AssetParserOptions} AssetParserOptions */
 /** @typedef {import("../Parser").ParserState} ParserState */
@@ -17,12 +14,10 @@ const AssetGenerator = require("./AssetGenerator");
 class AssetParser extends Parser {
 	/**
 	 * @param {AssetParserOptions["dataUrlCondition"] | boolean} dataUrlCondition condition for inlining as DataUrl
-	 * @param {string=} filename override for output.assetModuleFilename
 	 */
-	constructor(dataUrlCondition, filename) {
+	constructor(dataUrlCondition) {
 		super();
 		this.dataUrlCondition = dataUrlCondition;
-		this.filename = filename;
 	}
 
 	/**
@@ -34,63 +29,24 @@ class AssetParser extends Parser {
 		if (typeof source === "object" && !Buffer.isBuffer(source)) {
 			throw new Error("AssetParser doesn't accept preparsed AST");
 		}
-		const { module, compilation } = state;
-		module.buildInfo.strict = true;
-		module.buildMeta.exportsType = "default";
+		state.module.buildInfo.strict = true;
+		state.module.buildMeta.exportsType = "default";
 
 		if (typeof this.dataUrlCondition === "function") {
-			module.buildInfo.dataUrl = this.dataUrlCondition(source, {
-				filename: module.matchResource || module.resource,
-				module: module
+			state.module.buildInfo.dataUrl = this.dataUrlCondition(source, {
+				filename: state.module.matchResource || state.module.resource,
+				module: state.module
 			});
 		} else if (typeof this.dataUrlCondition === "boolean") {
-			module.buildInfo.dataUrl = this.dataUrlCondition;
+			state.module.buildInfo.dataUrl = this.dataUrlCondition;
 		} else if (
 			this.dataUrlCondition &&
 			typeof this.dataUrlCondition === "object"
 		) {
-			module.buildInfo.dataUrl =
+			state.module.buildInfo.dataUrl =
 				Buffer.byteLength(source) <= this.dataUrlCondition.maxSize;
 		} else {
 			throw new Error("Unexpected dataUrlCondition type");
-		}
-
-		if (!module.buildInfo.dataUrl) {
-			const outputOptions = compilation.outputOptions;
-			const assetModuleFilename =
-				this.filename ||
-				// TODO webpack 6 remove
-				(module.generator instanceof AssetGenerator &&
-					module.generator.filename) ||
-				outputOptions.assetModuleFilename;
-			const hash = createHash(outputOptions.hashFunction);
-			if (outputOptions.hashSalt) {
-				hash.update(outputOptions.hashSalt);
-			}
-			hash.update(source);
-			const fullHash = /** @type {string} */ (hash.digest(
-				outputOptions.hashDigest
-			));
-			const contentHash = fullHash.slice(0, outputOptions.hashDigestLength);
-			module.buildInfo.fullContentHash = fullHash;
-			const sourceFilename = makePathsRelative(
-				compilation.compiler.context,
-				module.matchResource || module.resource,
-				compilation.compiler.root
-			).replace(/^\.\//, "");
-			const { path: filename, info } = compilation.getAssetPathWithInfo(
-				assetModuleFilename,
-				{
-					module,
-					filename: sourceFilename,
-					contentHash
-				}
-			);
-			module.buildInfo.filename = filename;
-			module.buildInfo.assetInfo = {
-				sourceFilename,
-				...info
-			};
 		}
 
 		return state;

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -101,6 +101,10 @@
         "dataUrl": {
           "$ref": "#/definitions/AssetGeneratorDataUrl"
         },
+        "emit": {
+          "description": "Emit an output asset from this asset module. This can be set to 'false' to omit emitting e. g. for SSR.",
+          "type": "boolean"
+        },
         "filename": {
           "$ref": "#/definitions/FilenameTemplate"
         }
@@ -168,6 +172,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "emit": {
+          "description": "Emit an output asset from this asset module. This can be set to 'false' to omit emitting e. g. for SSR.",
+          "type": "boolean"
+        },
         "filename": {
           "$ref": "#/definitions/FilenameTemplate"
         }

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -102,12 +102,7 @@
           "$ref": "#/definitions/AssetGeneratorDataUrl"
         },
         "filename": {
-          "description": "This is deprecated and has moved to 'parser.filename'.",
-          "oneOf": [
-            {
-              "$ref": "#/definitions/FilenameTemplate"
-            }
-          ]
+          "$ref": "#/definitions/FilenameTemplate"
         }
       }
     },
@@ -153,7 +148,6 @@
     "AssetParserOptions": {
       "description": "Parser options for asset modules.",
       "type": "object",
-      "implements": ["#/definitions/AssetResourceParserOptions"],
       "additionalProperties": false,
       "properties": {
         "dataUrlCondition": {
@@ -166,29 +160,11 @@
               "$ref": "#/definitions/AssetParserDataUrlFunction"
             }
           ]
-        },
-        "filename": {
-          "$ref": "#/definitions/FilenameTemplate"
         }
       }
     },
     "AssetResourceGeneratorOptions": {
       "description": "Generator options for asset/resource modules.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "filename": {
-          "description": "This is deprecated and has moved to 'parser.filename'.",
-          "oneOf": [
-            {
-              "$ref": "#/definitions/FilenameTemplate"
-            }
-          ]
-        }
-      }
-    },
-    "AssetResourceParserOptions": {
-      "description": "Parser options for asset/resource modules.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -2838,7 +2814,7 @@
           "$ref": "#/definitions/EmptyParserOptions"
         },
         "asset/resource": {
-          "$ref": "#/definitions/AssetResourceParserOptions"
+          "$ref": "#/definitions/EmptyParserOptions"
         },
         "asset/source": {
           "$ref": "#/definitions/EmptyParserOptions"

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -978,32 +978,6 @@ Object {
     "multiple": false,
     "simpleType": "number",
   },
-  "module-parser-asset-filename": Object {
-    "configs": Array [
-      Object {
-        "description": "Specifies the filename template of output files on disk. You must **not** specify an absolute path here, but the path may contain folders separated by '/'! The specified path is joined with the value of the 'output.path' option to determine the location on disk.",
-        "multiple": false,
-        "path": "module.parser.asset.filename",
-        "type": "string",
-      },
-    ],
-    "description": "Specifies the filename template of output files on disk. You must **not** specify an absolute path here, but the path may contain folders separated by '/'! The specified path is joined with the value of the 'output.path' option to determine the location on disk.",
-    "multiple": false,
-    "simpleType": "string",
-  },
-  "module-parser-asset-resource-filename": Object {
-    "configs": Array [
-      Object {
-        "description": "Specifies the filename template of output files on disk. You must **not** specify an absolute path here, but the path may contain folders separated by '/'! The specified path is joined with the value of the 'output.path' option to determine the location on disk.",
-        "multiple": false,
-        "path": "module.parser.asset/resource.filename",
-        "type": "string",
-      },
-    ],
-    "description": "Specifies the filename template of output files on disk. You must **not** specify an absolute path here, but the path may contain folders separated by '/'! The specified path is joined with the value of the 'output.path' option to determine the location on disk.",
-    "multiple": false,
-    "simpleType": "string",
-  },
   "module-parser-javascript-amd": Object {
     "configs": Array [
       Object {

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -877,6 +877,19 @@ Object {
     "multiple": false,
     "simpleType": "string",
   },
+  "module-generator-asset-emit": Object {
+    "configs": Array [
+      Object {
+        "description": "Emit an output asset from this asset module. This can be set to 'false' to omit emitting e. g. for SSR.",
+        "multiple": false,
+        "path": "module.generator.asset.emit",
+        "type": "boolean",
+      },
+    ],
+    "description": "Emit an output asset from this asset module. This can be set to 'false' to omit emitting e. g. for SSR.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "module-generator-asset-filename": Object {
     "configs": Array [
       Object {
@@ -919,6 +932,19 @@ Object {
     "description": "Asset mimetype (getting from file extension by default).",
     "multiple": false,
     "simpleType": "string",
+  },
+  "module-generator-asset-resource-emit": Object {
+    "configs": Array [
+      Object {
+        "description": "Emit an output asset from this asset module. This can be set to 'false' to omit emitting e. g. for SSR.",
+        "multiple": false,
+        "path": "module.generator.asset/resource.emit",
+        "type": "boolean",
+      },
+    ],
+    "description": "Emit an output asset from this asset module. This can be set to 'false' to omit emitting e. g. for SSR.",
+    "multiple": false,
+    "simpleType": "boolean",
   },
   "module-generator-asset-resource-filename": Object {
     "configs": Array [

--- a/test/configCases/asset-modules/assetModuleFilename/index.js
+++ b/test/configCases/asset-modules/assetModuleFilename/index.js
@@ -1,11 +1,9 @@
 import png from "../_images/file.png";
 import svg from "../_images/file.svg";
 import svg2 from "../_images/file.svg?custom2";
-import svg3 from "../_images/file.svg?custom3";
 
 it("should change filenames", () => {
 	expect(png).toEqual("images/[ext]/success-png.png");
 	expect(svg).toEqual("images/success-svg.svg");
 	expect(svg2).toEqual("custom-images/success.svg");
-	expect(svg3).toEqual("images/custom/success.svg");
 });

--- a/test/configCases/asset-modules/assetModuleFilename/webpack.config.js
+++ b/test/configCases/asset-modules/assetModuleFilename/webpack.config.js
@@ -21,14 +21,7 @@ module.exports = {
 					{
 						resourceQuery: "?custom2",
 						generator: {
-							// TODO webpack 6: remove generator.filename
 							filename: "custom-images/success[ext]"
-						}
-					},
-					{
-						resourceQuery: "?custom3",
-						parser: {
-							filename: "images/custom/success[ext]"
 						}
 					}
 				]

--- a/test/configCases/asset-modules/emit/index.js
+++ b/test/configCases/asset-modules/emit/index.js
@@ -1,0 +1,11 @@
+import url from "../_images/file.png";
+import fs from "fs";
+
+it("should output asset with path", () => {
+	expect(url).toEqual("images/file.png");
+	expect(() => fs.statSync(url)).toThrowError(
+		expect.objectContaining({
+			code: "ENOENT"
+		})
+	);
+});

--- a/test/configCases/asset-modules/emit/webpack.config.js
+++ b/test/configCases/asset-modules/emit/webpack.config.js
@@ -1,0 +1,18 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	output: {
+		assetModuleFilename: "images/file[ext]"
+	},
+	module: {
+		rules: [
+			{
+				test: /\.png$/,
+				type: "asset",
+				generator: {
+					emit: false
+				}
+			}
+		]
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -300,6 +300,11 @@ declare interface AssetParserOptions {
  */
 declare interface AssetResourceGeneratorOptions {
 	/**
+	 * Emit an output asset from this asset module. This can be set to 'false' to omit emitting e. g. for SSR.
+	 */
+	emit?: boolean;
+
+	/**
 	 * Specifies the filename template of output files on disk. You must **not** specify an absolute path here, but the path may contain folders separated by '/'! The specified path is joined with the value of the 'output.path' option to determine the location on disk.
 	 */
 	filename?: string | ((pathData: PathData, assetInfo?: AssetInfo) => string);

--- a/types.d.ts
+++ b/types.d.ts
@@ -279,12 +279,11 @@ declare interface AssetParserDataUrlOptions {
 	 */
 	maxSize?: number;
 }
-type AssetParserOptions = AssetResourceParserOptions & AssetParserOptionsExtra;
 
 /**
  * Parser options for asset modules.
  */
-declare interface AssetParserOptionsExtra {
+declare interface AssetParserOptions {
 	/**
 	 * The condition for inlining the asset as DataUrl.
 	 */
@@ -300,16 +299,6 @@ declare interface AssetParserOptionsExtra {
  * Generator options for asset/resource modules.
  */
 declare interface AssetResourceGeneratorOptions {
-	/**
-	 * This is deprecated and has moved to 'parser.filename'.
-	 */
-	filename?: string | ((pathData: PathData, assetInfo?: AssetInfo) => string);
-}
-
-/**
- * Parser options for asset/resource modules.
- */
-declare interface AssetResourceParserOptions {
 	/**
 	 * Specifies the filename template of output files on disk. You must **not** specify an absolute path here, but the path may contain folders separated by '/'! The specified path is joined with the value of the 'output.path' option to determine the location on disk.
 	 */
@@ -7694,9 +7683,9 @@ declare interface ParserOptionsByModuleTypeKnown {
 	"asset/inline"?: EmptyParserOptions;
 
 	/**
-	 * Parser options for asset/resource modules.
+	 * No parser options are supported for this module type.
 	 */
-	"asset/resource"?: AssetResourceParserOptions;
+	"asset/resource"?: EmptyParserOptions;
 
 	/**
 	 * No parser options are supported for this module type.
@@ -9154,6 +9143,7 @@ declare abstract class RuntimeSpecSet {
 	readonly size: number;
 }
 declare abstract class RuntimeTemplate {
+	compilation: Compilation;
 	outputOptions: OutputNormalized;
 	requestShortener: RequestShortener;
 	isIIFE(): undefined | boolean;


### PR DESCRIPTION
fixes #12474

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
* the parser options for asset modules have a new `emit` option. Defaults to true. Setting it to false will opt-out from writing assets from asset modules.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
