### PR TITLE
fixed possible collision with addAll es proposal

### DIFF
--- a/lib/cache/ResolverCachePlugin.js
+++ b/lib/cache/ResolverCachePlugin.js
@@ -40,7 +40,7 @@ makeSerializable(CacheEntry, "webpack/lib/cache/ResolverCachePlugin");
  * @returns {void}
  */
 const addAllToSet = (set, otherSet) => {
-	if ("addAll" in set) {
+	if (set instanceof LazySet) {
 		set.addAll(otherSet);
 	} else {
 		for (const item of otherSet) {


### PR DESCRIPTION
When upgrading to v5, I ran into this issue https://github.com/webpack/webpack/issues/12701, which is caused by `core-js` and `babel` polyfilling the `addAll` method to all collection prototypes. webpack's use the existence of an `addAll` method to determine whether or not it's dealing with a `LazySet`, then it calls this method. Unfortunately, because the ES Proposal version expects `addAll(...items)` and `LazySet` expects `addAll(Iterable)`, this causes all sorts of issues.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
This PR changes the `in` check for `addAll` in `addAllToSet` to an `instanceof` check for `LazySet`.

fixes #12701

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
I would like to add tests, but it wasn't clear to me where a test for this should go as none of the test files reference `ResolveCachePlugin`. Is there a file I should use?

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
This is a very simple fix for a weird issue. It shouldn't affect any existing or future installations.
