### PR TITLE
fix: do not skip changes when compilation is suspended 

### DIFF
--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -266,7 +266,11 @@ class Watching {
 					this.watcher.pause();
 					this.watcher = null;
 				}
-				this._invalidate();
+				if (!this.suspended) {
+					this._invalidate();
+				} else {
+					this.watch(files, dirs, missing);
+				}
 				this._onChange();
 			},
 			(fileName, changeTime) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This PR aims to solve an issue with skipped changes in Watching.js (when compilation is suspended). See #12898 for details.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

A bugfix.

**Did you add tests for your changes?**

Yes.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

This PR doesn't require documentation.

Fixes #12898