### PR TITLE
Cover missing branches in AbstractMethodError

### DIFF
--- a/test/AbstractMethodError.unittest.js
+++ b/test/AbstractMethodError.unittest.js
@@ -12,6 +12,7 @@ describe("WebpackError", () => {
 	class Child extends Foo {}
 
 	const expectedMessage = "Abstract method $1. Must be overridden.";
+	const expectedNoMethodMessage = "Abstract method. Must be overridden.";
 
 	it("Should construct message with caller info", () => {
 		const fooClassError = new Foo().abstractMethod();
@@ -23,5 +24,13 @@ describe("WebpackError", () => {
 		expect(childClassError.message).toBe(
 			expectedMessage.replace("$1", "Child.abstractMethod")
 		);
+	});
+
+	it("Should handle no method name found in stack trace", () => {
+		Error.captureStackTrace = jest.fn(ref => {
+			ref.stack = "Error:\na\nb\nc";
+		});
+		const fooClassError = new Foo().abstractMethod();
+		expect(fooClassError.message).toBe(expectedNoMethodMessage);
 	});
 });


### PR DESCRIPTION
AbstractMethodError testing didn't cover branches 100%. There are conditions that handle not finding the method name in the stack trace where we expect to. This commit covers those missing branches.

Not too sure about how I've named the test case itself, feel like it could be better but I can't come up with anything, happy to change it if anyone feels particularly strongly about it.

**What kind of change does this PR introduce?**

Increase unit test coverage

**Did you add tests for your changes?**

✔️ 

**Does this PR introduce a breaking change?**

❌ 

**What needs to be documented once your changes are merged?**

Nothing.
