### PR TITLE
fix: allow invalidation after first watch run

### DIFF
--- a/lib/MultiCompiler.js
+++ b/lib/MultiCompiler.js
@@ -457,7 +457,7 @@ module.exports = class MultiCompiler {
 					node.compiler,
 					i,
 					nodeDone.bind(null, node),
-					() => node.state !== "running",
+					() => node.state !== "done" && node.state !== "running",
 					() => nodeChange(node),
 					() => nodeInvalid(node)
 				)

--- a/test/MultiCompiler.test.js
+++ b/test/MultiCompiler.test.js
@@ -363,6 +363,41 @@ describe("MultiCompiler", function () {
 			}
 		});
 	});
+
+	it("shouldn't hang when invalidating watchers", done => {
+		const entriesA = { a: "./a.js" };
+		const entriesB = { b: "./b.js" };
+		const compiler = webpack([
+			{
+				name: "a",
+				mode: "development",
+				entry: () => entriesA,
+				context: path.join(__dirname, "fixtures")
+			},
+			{
+				name: "b",
+				mode: "development",
+				entry: () => entriesB,
+				context: path.join(__dirname, "fixtures")
+			}
+		]);
+
+		compiler.watchFileSystem = { watch() {} };
+		compiler.outputFileSystem = createFsFromVolume(new Volume());
+
+		const watching = compiler.watch({}, error => {
+			if (error) {
+				done(error);
+				return;
+			}
+
+			entriesA.b = "./b.js";
+			entriesB.a = "./a.js";
+
+			watching.invalidate(done);
+		});
+	}, 2000);
+
 	it("shouldn't hang when invalidating during build", done => {
 		const compiler = webpack(
 			Object.assign([


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

#12915 introduced a bug that causes watchers to remain blocked when a `MultiCompiler` is watched. This PR ensures that when an invalidation occurs after a successful watch-run the subsequent build does not hang.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

It shouldn't. 

**What needs to be documented once your changes are merged?**

Nothing, this is an internals change.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
