### PR TITLE
Multiple UMD libraries sharing the same namespace change not to compete each other

### DIFF
--- a/lib/library/UmdLibraryPlugin.js
+++ b/lib/library/UmdLibraryPlugin.js
@@ -292,14 +292,25 @@ class UmdLibraryPlugin extends AbstractLibraryPlugin {
 						  externalsRequireArray("commonjs") +
 						  ");\n" +
 						  getAuxiliaryComment("root") +
-						  "	else\n" +
+						  "	else{\n" +
+						  "		var a = factory(" +
+						  externalsRootArray(externals) +
+						  ");\n" +
 						  "		" +
 						  replaceKeys(
-								accessorAccess("root", names.root || names.commonjs)
+							  accessorAccess("root", names.root || names.commonjs)
+							  ) +
+						  " = " +
+						  replaceKeys(
+							  accessorAccess("root", names.root || names.commonjs)
 						  ) +
-						  " = factory(" +
-						  externalsRootArray(externals) +
-						  ");\n"
+						  " || {};\n" +
+						  "		for(var i in a) " +
+						  replaceKeys(
+							  accessorAccess("root", names.root || names.commonjs)
+						  ) +
+						  "[i] = a[i];\n" +
+						  "	}\n"
 						: "	else {\n" +
 						  (externals.length > 0
 								? "		var a = typeof exports === 'object' ? factory(" +

--- a/lib/library/UmdLibraryPlugin.js
+++ b/lib/library/UmdLibraryPlugin.js
@@ -298,16 +298,16 @@ class UmdLibraryPlugin extends AbstractLibraryPlugin {
 						  ");\n" +
 						  "		" +
 						  replaceKeys(
-							  accessorAccess("root", names.root || names.commonjs)
-							  ) +
+								accessorAccess("root", names.root || names.commonjs)
+						  ) +
 						  " = " +
 						  replaceKeys(
-							  accessorAccess("root", names.root || names.commonjs)
+								accessorAccess("root", names.root || names.commonjs)
 						  ) +
 						  " || {};\n" +
 						  "		for(var i in a) " +
 						  replaceKeys(
-							  accessorAccess("root", names.root || names.commonjs)
+								accessorAccess("root", names.root || names.commonjs)
 						  ) +
 						  "[i] = a[i];\n" +
 						  "	}\n"


### PR DESCRIPTION
## Summary
When building UMD module with multiple output sharing the same library namespace, those output modules cannot be loaded into browser at the same time
because UMD loader does not care whether global object already assigned or not.

## Example
```js
// webpack.config.js
const path = require("path");

module.exports = {
  mode: "development",
  entry: {
    moduleA: "./src/moduleA.js",
    moduleB: "./src/moduleB.js",
  },
  output: {
    path: path.resolve(__dirname, "dist"),
    filename: "[name].js",
    library: ["MyLibrary"],
    libraryTarget: "umd",
    globalObject: "this",
  },
};
```

If you load moduleA and moduleB into <script> tag
```html
<script src="./moduleA.js" ></script>
<script src="./moduleB.js"></script>
<script type="text/javascript">
MyLibrary.moduleA; // === undefined
MyLibrary.moduleB; // !== undefined
</script>
```
I created working sample here.
https://hinaser.github.io/webpack-pr-example/current/index.html
https://github.com/Hinaser/webpack-pr-example/tree/master/current

This is because UMD loader always assigns exported module into global object.
```js
(function webpackUniversalModuleDefinition(root, factory) {
	if(typeof exports === 'object' && typeof module === 'object')
		module.exports = factory();
	else if(typeof define === 'function' && define.amd)
		define([], factory);
	else if(typeof exports === 'object')
		exports["MyLibrary"] = factory();
	else
		root["MyLibrary"] = factory(); // <- This always clears module previously loaded.
})(this, function() {
```

So I propose UMD loader to be like this.
```js
(function webpackUniversalModuleDefinition(root, factory) {
	if(typeof exports === 'object' && typeof module === 'object')
		module.exports = factory();
	else if(typeof define === 'function' && define.amd)
		define([], factory);
	else if(typeof exports === 'object')
		exports["MyLibrary"] = factory();
	else{
		var a = factory();
		root["MyLibrary"] = root["MyLibrary"] || {};
		for(var i in a) root["MyLibrary"][i] = a[i];
	}
})(this, function() {
```

The working example of this proposal is here.
https://hinaser.github.io/webpack-pr-example/proposing/index.html
https://github.com/Hinaser/webpack-pr-example/tree/master/proposing


**What kind of change does this PR introduce?**
Multiple UMD libraries sharing the same namespace change not to compete each other.

**Did you add tests for your changes?**
I couldn't find any existing UMD library test in webpack repository.
So I created working example.
https://github.com/Hinaser/webpack-pr-example

**Does this PR introduce a breaking change?**
No. This PR will preserve modules previously loaded.

**What needs to be documented once your changes are merged?**
I don't think additional documentation is required because the original behaviour might not be expected/cared by many developers.