### PR TITLE
(fix): add missing scheme property stats.groupModulesByType

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -2395,6 +2395,10 @@ export interface StatsOptions {
 	 */
 	groupModulesByPath?: boolean;
 	/**
+	 * Group modules by their type.
+	 */
+	groupModulesByType?: boolean;
+	/**
 	 * Add the hash of the compilation.
 	 */
 	hash?: boolean;

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -4088,6 +4088,10 @@
           "description": "Group modules by their path.",
           "type": "boolean"
         },
+        "groupModulesByType": {
+          "description": "Group modules by their type.",
+          "type": "boolean"
+        },
         "hash": {
           "description": "Add the hash of the compilation.",
           "type": "boolean"

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -7273,6 +7273,19 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
+  "stats-group-modules-by-type": Object {
+    "configs": Array [
+      Object {
+        "description": "Group modules by their type.",
+        "multiple": false,
+        "path": "stats.groupModulesByType",
+        "type": "boolean",
+      },
+    ],
+    "description": "Group modules by their type.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "stats-hash": Object {
     "configs": Array [
       Object {

--- a/types.d.ts
+++ b/types.d.ts
@@ -10401,6 +10401,11 @@ declare interface StatsOptions {
 	groupModulesByPath?: boolean;
 
 	/**
+	 * Group modules by their type.
+	 */
+	groupModulesByType?: boolean;
+
+	/**
 	 * Add the hash of the compilation.
 	 */
 	hash?: boolean;


### PR DESCRIPTION
I can't add `groupModulesByType: true` in the stats options or
```
all: true
groupModulesByType: false
```
But `groupModulesByType` is available in StatsPlugin
This PR fixes this.

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

no

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

about groupModulesByType