### PR TITLE
Fix bug when dynamically change the loaders

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -601,13 +601,13 @@ class NormalModule extends Module {
 
 	getCurrentLoader(loaderContext, index = loaderContext.loaderIndex) {
 		if (
-			this.loaders &&
-			this.loaders.length &&
-			index < this.loaders.length &&
+			loaderContext &&
+			loaderContext.length &&
+			index < loaderContext.length &&
 			index >= 0 &&
-			this.loaders[index]
+			loaderContext[index]
 		) {
-			return this.loaders[index];
+			return loaderContext[index];
 		}
 		return null;
 	}

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -601,13 +601,13 @@ class NormalModule extends Module {
 
 	getCurrentLoader(loaderContext, index = loaderContext.loaderIndex) {
 		if (
-			loaderContext &&
-			loaderContext.length &&
-			index < loaderContext.length &&
+			loaderContext.loaders &&
+			loaderContext.loaders.length &&
+			index < loaderContext.loaders.length &&
 			index >= 0 &&
-			loaderContext[index]
+			loaderContext.loaders[index]
 		) {
-			return loaderContext[index];
+			return loaderContext.loaders[index];
 		}
 		return null;
 	}


### PR DESCRIPTION
If a loader tries to add another loader with :
```
module.exports.pitch = function() {
        loaders.unshift({....});
}
```

And another loader (like HTML loader) is calling `this.getOptions()`.
Then `getCurrentLoader()` is called, however `this.loaders` is different from `loaderContext`. `this.loaders` is the initial loader list, when `loaderContext` contains the newly inserted loader.

**What kind of change does this PR introduce?**

Bugfix.

**Did you add tests for your changes?**

No

**Does this PR introduce a breaking change?**

I don't think.

**What needs to be documented once your changes are merged?**

Nothing.


