### PR TITLE
memory usage improvements, add GC support for memory cache, persistent cache only mode

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -904,6 +904,10 @@ export interface WebpackOptions {
  */
 export interface MemoryCacheOptions {
 	/**
+	 * Number of generations unused cache entries stay in memory cache at minimum (1 = may be removed after unused for a single compilation, ..., Infinity: kept forever).
+	 */
+	maxGenerations?: number;
+	/**
 	 * In memory caching.
 	 */
 	type: "memory";
@@ -949,6 +953,14 @@ export interface FileCacheOptions {
 	 * List of paths that are managed by a package manager and can be trusted to not be modified otherwise.
 	 */
 	managedPaths?: string[];
+	/**
+	 * Time for which unused cache entries stay in the filesystem cache at minimum (in milliseconds).
+	 */
+	maxAge?: number;
+	/**
+	 * Number of generations unused cache entries stay in memory cache at minimum (0 = no memory cache used, 1 = may be removed after unused for a single compilation, ..., Infinity: kept forever). Cache entries will be deserialized from disk when removed from memory cache.
+	 */
+	maxMemoryGenerations?: number;
 	/**
 	 * Name for the cache. Different names will lead to different coexisting caches.
 	 */

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -1101,6 +1101,10 @@ ${other}`);
 	close(callback) {
 		this.hooks.shutdown.callAsync(err => {
 			if (err) return callback(err);
+			// Get rid of reference to last compilation to avoid leaking memory
+			// We can't run this._cleanupLastCompilation() as the Stats to this compilation
+			// might be still in use. We try to get rid for the reference to the cache instead.
+			this._lastCompilation = undefined;
 			this.cache.shutdown(callback);
 		});
 	}

--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -412,6 +412,14 @@ class SnapshotOptimization {
 		} times referenced)`;
 	}
 
+	clear() {
+		this._map.clear();
+		this._statItemsShared = 0;
+		this._statItemsUnshared = 0;
+		this._statSharedSnapshots = 0;
+		this._statReusedSharedSnapshots = 0;
+	}
+
 	storeUnsharedSnapshot(snapshot, locations) {
 		if (locations === undefined) return;
 		const optimizationEntry = {
@@ -982,6 +990,42 @@ class FileSystemInfo {
 				"Logging limit has been reached and no further logging will be emitted by FileSystemInfo"
 			);
 		}
+	}
+
+	clear() {
+		this._remainingLogs = this.logger ? 40 : 0;
+		if (this._loggedPaths !== undefined) this._loggedPaths.clear();
+
+		this._snapshotCache = new WeakMap();
+		this._fileTimestampsOptimization.clear();
+		this._fileHashesOptimization.clear();
+		this._fileTshsOptimization.clear();
+		this._contextTimestampsOptimization.clear();
+		this._contextHashesOptimization.clear();
+		this._contextTshsOptimization.clear();
+		this._missingExistenceOptimization.clear();
+		this._managedItemInfoOptimization.clear();
+		this._managedFilesOptimization.clear();
+		this._managedContextsOptimization.clear();
+		this._managedMissingOptimization.clear();
+		this._fileTimestamps.clear();
+		this._fileHashes.clear();
+		this._fileTshs.clear();
+		this._contextTimestamps.clear();
+		this._contextHashes.clear();
+		this._contextTshs.clear();
+		this._managedItems.clear();
+		this._managedItems.clear();
+
+		this._cachedDeprecatedFileTimestamps = undefined;
+		this._cachedDeprecatedContextTimestamps = undefined;
+
+		this._statCreatedSnapshots = 0;
+		this._statTestedSnapshotsCached = 0;
+		this._statTestedSnapshotsNotCached = 0;
+		this._statTestedChildrenCached = 0;
+		this._statTestedChildrenNotCached = 0;
+		this._statTestedEntries = 0;
 	}
 
 	/**

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -749,6 +749,9 @@ class NormalModule extends Module {
 				}
 			},
 			(err, result) => {
+				// Cleanup loaderContext to avoid leaking memory in ICs
+				loaderContext._compilation = loaderContext._compiler = loaderContext._module = loaderContext.fs = undefined;
+
 				if (!result) {
 					return processResult(
 						err || new Error("No result from loader-runner processing"),

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -521,9 +521,17 @@ class WebpackOptionsApply extends OptionsApply {
 			const cacheOptions = options.cache;
 			switch (cacheOptions.type) {
 				case "memory": {
-					//@ts-expect-error https://github.com/microsoft/TypeScript/issues/41697
-					const MemoryCachePlugin = require("./cache/MemoryCachePlugin");
-					new MemoryCachePlugin().apply(compiler);
+					if (isFinite(cacheOptions.maxGenerations)) {
+						//@ts-expect-error https://github.com/microsoft/TypeScript/issues/41697
+						const MemoryWithGcCachePlugin = require("./cache/MemoryWithGcCachePlugin");
+						new MemoryWithGcCachePlugin({
+							maxGenerations: cacheOptions.maxGenerations
+						}).apply(compiler);
+					} else {
+						//@ts-expect-error https://github.com/microsoft/TypeScript/issues/41697
+						const MemoryCachePlugin = require("./cache/MemoryCachePlugin");
+						new MemoryCachePlugin().apply(compiler);
+					}
 					break;
 				}
 				case "filesystem": {
@@ -532,9 +540,17 @@ class WebpackOptionsApply extends OptionsApply {
 						const list = cacheOptions.buildDependencies[key];
 						new AddBuildDependenciesPlugin(list).apply(compiler);
 					}
-					//@ts-expect-error https://github.com/microsoft/TypeScript/issues/41697
-					const MemoryCachePlugin = require("./cache/MemoryCachePlugin");
-					new MemoryCachePlugin().apply(compiler);
+					if (!isFinite(cacheOptions.maxMemoryGenerations)) {
+						//@ts-expect-error https://github.com/microsoft/TypeScript/issues/41697
+						const MemoryCachePlugin = require("./cache/MemoryCachePlugin");
+						new MemoryCachePlugin().apply(compiler);
+					} else if (cacheOptions.maxMemoryGenerations !== 0) {
+						//@ts-expect-error https://github.com/microsoft/TypeScript/issues/41697
+						const MemoryWithGcCachePlugin = require("./cache/MemoryWithGcCachePlugin");
+						new MemoryWithGcCachePlugin({
+							maxGenerations: cacheOptions.maxMemoryGenerations
+						}).apply(compiler);
+					}
 					switch (cacheOptions.store) {
 						case "pack": {
 							const IdleFileCachePlugin = require("./cache/IdleFileCachePlugin");
@@ -549,7 +565,8 @@ class WebpackOptionsApply extends OptionsApply {
 									logger: compiler.getInfrastructureLogger(
 										"webpack.cache.PackFileCacheStrategy"
 									),
-									snapshot: options.snapshot
+									snapshot: options.snapshot,
+									maxAge: cacheOptions.maxAge
 								}),
 								cacheOptions.idleTimeout,
 								cacheOptions.idleTimeoutForInitialStore

--- a/lib/cache/IdleFileCachePlugin.js
+++ b/lib/cache/IdleFileCachePlugin.js
@@ -54,20 +54,27 @@ class IdleFileCachePlugin {
 		compiler.cache.hooks.get.tapPromise(
 			{ name: "IdleFileCachePlugin", stage: Cache.STAGE_DISK },
 			(identifier, etag, gotHandlers) => {
-				return strategy.restore(identifier, etag).then(cacheEntry => {
-					if (cacheEntry === undefined) {
-						gotHandlers.push((result, callback) => {
-							if (result !== undefined) {
-								pendingIdleTasks.set(identifier, () =>
-									strategy.store(identifier, etag, result)
-								);
-							}
-							callback();
-						});
-					} else {
-						return cacheEntry;
-					}
-				});
+				const restore = () =>
+					strategy.restore(identifier, etag).then(cacheEntry => {
+						if (cacheEntry === undefined) {
+							gotHandlers.push((result, callback) => {
+								if (result !== undefined) {
+									pendingIdleTasks.set(identifier, () =>
+										strategy.store(identifier, etag, result)
+									);
+								}
+								callback();
+							});
+						} else {
+							return cacheEntry;
+						}
+					});
+				const pendingTask = pendingIdleTasks.get(identifier);
+				if (pendingTask !== undefined) {
+					pendingIdleTasks.delete(identifier);
+					return pendingTask().then(restore);
+				}
+				return restore();
 			}
 		);
 

--- a/lib/cache/IdleFileCachePlugin.js
+++ b/lib/cache/IdleFileCachePlugin.js
@@ -30,7 +30,7 @@ class IdleFileCachePlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
-		const strategy = this.strategy;
+		let strategy = this.strategy;
 		const idleTimeout = this.idleTimeout;
 		const idleTimeoutForInitialStore = Math.min(
 			idleTimeout,
@@ -101,7 +101,10 @@ class IdleFileCachePlugin {
 						reportProgress(1, `stored`);
 					});
 				}
-				return currentIdlePromise;
+				return currentIdlePromise.then(() => {
+					// Reset strategy
+					if (strategy.clear) strategy.clear();
+				});
 			}
 		);
 

--- a/lib/cache/MemoryCachePlugin.js
+++ b/lib/cache/MemoryCachePlugin.js
@@ -46,6 +46,12 @@ class MemoryCachePlugin {
 				});
 			}
 		);
+		compiler.cache.hooks.shutdown.tap(
+			{ name: "MemoryCachePlugin", stage: Cache.STAGE_MEMORY },
+			() => {
+				cache.clear();
+			}
+		);
 	}
 }
 module.exports = MemoryCachePlugin;

--- a/lib/cache/MemoryWithGcCachePlugin.js
+++ b/lib/cache/MemoryWithGcCachePlugin.js
@@ -1,0 +1,129 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const Cache = require("../Cache");
+
+/** @typedef {import("webpack-sources").Source} Source */
+/** @typedef {import("../Cache").Etag} Etag */
+/** @typedef {import("../Compiler")} Compiler */
+/** @typedef {import("../Module")} Module */
+
+class MemoryWithGcCachePlugin {
+	constructor({ maxGenerations }) {
+		this._maxGenerations = maxGenerations;
+	}
+	/**
+	 * Apply the plugin
+	 * @param {Compiler} compiler the compiler instance
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		const maxGenerations = this._maxGenerations;
+		/** @type {Map<string, { etag: Etag | null, data: any }>} */
+		const cache = new Map();
+		/** @type {Map<string, { entry: { etag: Etag | null, data: any }, until: number }>} */
+		const oldCache = new Map();
+		let generation = 0;
+		let cachePosition = 0;
+		const logger = compiler.getInfrastructureLogger("MemoryWithGcCachePlugin");
+		compiler.hooks.afterDone.tap("MemoryWithGcCachePlugin", () => {
+			generation++;
+			let clearedEntries = 0;
+			let lastClearedIdentifier;
+			for (const [identifier, entry] of oldCache) {
+				if (entry.until > generation) break;
+
+				oldCache.delete(identifier);
+				if (cache.get(identifier) === undefined) {
+					cache.delete(identifier);
+					clearedEntries++;
+					lastClearedIdentifier = identifier;
+				}
+			}
+			if (clearedEntries > 0 || oldCache.size > 0) {
+				logger.log(
+					`${cache.size - oldCache.size} active entries, ${
+						oldCache.size
+					} recently unused cached entries${
+						clearedEntries > 0
+							? `, ${clearedEntries} old unused cache entries removed e. g. ${lastClearedIdentifier}`
+							: ""
+					}`
+				);
+			}
+			let i = (cache.size / maxGenerations) | 0;
+			let j = cachePosition >= cache.size ? 0 : cachePosition;
+			cachePosition = j + i;
+			for (const [identifier, entry] of cache) {
+				if (j !== 0) {
+					j--;
+					continue;
+				}
+				if (entry !== undefined) {
+					// We don't delete the cache entry, but set it to undefined instead
+					// This reserves the location in the data table and avoids rehashing
+					// when constantly adding and removing entries.
+					// It will be deleted when removed from oldCache.
+					cache.set(identifier, undefined);
+					oldCache.delete(identifier);
+					oldCache.set(identifier, {
+						entry,
+						until: generation + maxGenerations
+					});
+					if (i-- === 0) break;
+				}
+			}
+		});
+		compiler.cache.hooks.store.tap(
+			{ name: "MemoryWithGcCachePlugin", stage: Cache.STAGE_MEMORY },
+			(identifier, etag, data) => {
+				cache.set(identifier, { etag, data });
+			}
+		);
+		compiler.cache.hooks.get.tap(
+			{ name: "MemoryWithGcCachePlugin", stage: Cache.STAGE_MEMORY },
+			(identifier, etag, gotHandlers) => {
+				const cacheEntry = cache.get(identifier);
+				if (cacheEntry === null) {
+					return null;
+				} else if (cacheEntry !== undefined) {
+					return cacheEntry.etag === etag ? cacheEntry.data : null;
+				}
+				const oldCacheEntry = oldCache.get(identifier);
+				if (oldCacheEntry !== undefined) {
+					const cacheEntry = oldCacheEntry.entry;
+					if (cacheEntry === null) {
+						oldCache.delete(identifier);
+						cache.set(identifier, cacheEntry);
+						return null;
+					} else {
+						if (cacheEntry.etag !== etag) return null;
+						oldCache.delete(identifier);
+						cache.set(identifier, cacheEntry);
+						return cacheEntry.data;
+					}
+				}
+				gotHandlers.push((result, callback) => {
+					if (result === undefined) {
+						cache.set(identifier, null);
+					} else {
+						cache.set(identifier, { etag, data: result });
+					}
+					return callback();
+				});
+			}
+		);
+		compiler.cache.hooks.shutdown.tap(
+			{ name: "MemoryWithGcCachePlugin", stage: Cache.STAGE_MEMORY },
+			() => {
+				cache.clear();
+				oldCache.clear();
+			}
+		);
+	}
+}
+module.exports = MemoryWithGcCachePlugin;

--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -763,6 +763,11 @@ class PackFileCacheStrategy {
 		this.packPromise = this._openPack();
 	}
 
+	_getPack() {
+		if (this.packPromise === undefined) this.packPromise = this._openPack();
+		return this.packPromise;
+	}
+
 	/**
 	 * @returns {Promise<Pack>} the pack
 	 */
@@ -925,7 +930,7 @@ class PackFileCacheStrategy {
 	 * @returns {Promise<void>} promise
 	 */
 	store(identifier, etag, data) {
-		return this.packPromise.then(pack => {
+		return this._getPack().then(pack => {
 			pack.set(identifier, etag === null ? null : etag.toString(), data);
 		});
 	}
@@ -936,7 +941,7 @@ class PackFileCacheStrategy {
 	 * @returns {Promise<any>} promise to the cached content
 	 */
 	restore(identifier, etag) {
-		return this.packPromise
+		return this._getPack()
 			.then(pack =>
 				pack.get(identifier, etag === null ? null : etag.toString())
 			)
@@ -955,6 +960,7 @@ class PackFileCacheStrategy {
 	}
 
 	afterAllStored() {
+		if (this.packPromise === undefined) return Promise.resolve();
 		const reportProgress = ProgressPlugin.getReporter(this.compiler);
 		return this.packPromise
 			.then(pack => {
@@ -1113,6 +1119,16 @@ class PackFileCacheStrategy {
 				this.logger.warn(`Caching failed for pack: ${err}`);
 				this.logger.debug(err.stack);
 			});
+	}
+
+	clear() {
+		this.fileSystemInfo.clear();
+		this.buildDependencies.clear();
+		this.newBuildDependencies.clear();
+		this.resolveBuildDependenciesSnapshot = undefined;
+		this.resolveResults = undefined;
+		this.buildSnapshot = undefined;
+		this.packPromise = undefined;
 	}
 }
 

--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -75,7 +75,6 @@ makeSerializable(
 
 const MIN_CONTENT_SIZE = 1024 * 1024; // 1 MB
 const CONTENT_COUNT_TO_MERGE = 10;
-const MAX_AGE = 1000 * 60 * 60 * 24 * 60; // 1 month
 const MAX_ITEMS_IN_FRESH_PACK = 50000;
 
 class PackItemInfo {
@@ -94,7 +93,7 @@ class PackItemInfo {
 }
 
 class Pack {
-	constructor(logger) {
+	constructor(logger, maxAge) {
 		/** @type {Map<string, PackItemInfo>} */
 		this.itemInfo = new Map();
 		/** @type {string[]} */
@@ -105,6 +104,7 @@ class Pack {
 		this.content = [];
 		this.invalid = false;
 		this.logger = logger;
+		this.maxAge = maxAge;
 	}
 
 	/**
@@ -167,6 +167,21 @@ class Pack {
 		}
 	}
 
+	getContentStats() {
+		let count = 0;
+		let size = 0;
+		for (const content of this.content) {
+			if (content !== undefined) {
+				count++;
+				const s = content.getSize();
+				if (s > 0) {
+					size += s;
+				}
+			}
+		}
+		return { count, size };
+	}
+
 	/**
 	 * @returns {number} new location of data entries
 	 */
@@ -182,7 +197,7 @@ class Pack {
 		const now = Date.now();
 		for (const identifier of items) {
 			const info = this.itemInfo.get(identifier);
-			if (now - info.lastAccess > MAX_AGE) {
+			if (now - info.lastAccess > this.maxAge) {
 				this.itemInfo.delete(identifier);
 				items.delete(identifier);
 				usedItems.delete(identifier);
@@ -194,9 +209,10 @@ class Pack {
 		}
 		if (count > 0) {
 			this.logger.log(
-				"Garbage Collected %d old items at pack %d e. g. %s",
+				"Garbage Collected %d old items at pack %d (%d items remaining) e. g. %s",
 				count,
 				newLoc,
+				items.size,
 				lastGC
 			);
 		}
@@ -426,10 +442,45 @@ class Pack {
 		}
 	}
 
+	/**
+	 * Find the content with the oldest item and run GC on that.
+	 * Only runs for one content to avoid large invalidation.
+	 */
+	_gcOldestContent() {
+		/** @type {PackItemInfo} */
+		let oldest = undefined;
+		for (const info of this.itemInfo.values()) {
+			if (oldest === undefined || info.lastAccess < oldest.lastAccess) {
+				oldest = info;
+			}
+		}
+		if (Date.now() - oldest.lastAccess > this.maxAge) {
+			const loc = oldest.location;
+			if (loc < 0) return;
+			const content = this.content[loc];
+			const items = new Set(content.items);
+			const usedItems = new Set(content.used);
+			this._gcAndUpdateLocation(items, usedItems, loc);
+
+			this.content[loc] =
+				items.size > 0
+					? new PackContent(items, usedItems, async () => {
+							await content.unpack();
+							const map = new Map();
+							for (const identifier of items) {
+								map.set(identifier, content.content.get(identifier));
+							}
+							return new PackContentItems(map);
+					  })
+					: undefined;
+		}
+	}
+
 	serialize({ write, writeSeparate }) {
 		this._persistFreshContent();
 		this._optimizeSmallContent();
 		this._optimizeUnusedContent();
+		this._gcOldestContent();
 		for (const identifier of this.itemInfo.keys()) {
 			write(identifier);
 		}
@@ -727,6 +778,7 @@ class PackFileCacheStrategy {
 	 * @param {string} options.version version identifier
 	 * @param {Logger} options.logger a logger
 	 * @param {SnapshotOptions} options.snapshot options regarding snapshotting
+	 * @param {number} options.maxAge max age of cache items
 	 */
 	constructor({
 		compiler,
@@ -735,7 +787,8 @@ class PackFileCacheStrategy {
 		cacheLocation,
 		version,
 		logger,
-		snapshot
+		snapshot,
+		maxAge
 	}) {
 		this.fileSerializer = createFileSerializer(fs);
 		this.fileSystemInfo = new FileSystemInfo(fs, {
@@ -748,6 +801,7 @@ class PackFileCacheStrategy {
 		this.cacheLocation = cacheLocation;
 		this.version = version;
 		this.logger = logger;
+		this.maxAge = maxAge;
 		this.snapshot = snapshot;
 		/** @type {Set<string>} */
 		this.buildDependencies = new Set();
@@ -761,10 +815,13 @@ class PackFileCacheStrategy {
 		this.buildSnapshot = undefined;
 		/** @type {Promise<Pack>} */
 		this.packPromise = this._openPack();
+		this.storePromise = Promise.resolve();
 	}
 
 	_getPack() {
-		if (this.packPromise === undefined) this.packPromise = this._openPack();
+		if (this.packPromise === undefined) {
+			this.packPromise = this.storePromise.then(() => this._openPack());
+		}
 		return this.packPromise;
 	}
 
@@ -904,6 +961,7 @@ class PackFileCacheStrategy {
 			})
 			.then(pack => {
 				if (pack) {
+					pack.maxAge = this.maxAge;
 					this.buildSnapshot = buildSnapshot;
 					if (buildDependencies) this.buildDependencies = buildDependencies;
 					if (newBuildDependencies)
@@ -912,14 +970,14 @@ class PackFileCacheStrategy {
 					this.resolveBuildDependenciesSnapshot = resolveBuildDependenciesSnapshot;
 					return pack;
 				}
-				return new Pack(logger);
+				return new Pack(logger, this.maxAge);
 			})
 			.catch(err => {
 				this.logger.warn(
 					`Restoring pack from ${cacheLocation}.pack failed: ${err}`
 				);
 				this.logger.debug(err.stack);
-				return new Pack(logger);
+				return new Pack(logger, this.maxAge);
 			});
 	}
 
@@ -960,9 +1018,11 @@ class PackFileCacheStrategy {
 	}
 
 	afterAllStored() {
-		if (this.packPromise === undefined) return Promise.resolve();
+		const packPromise = this.packPromise;
+		if (packPromise === undefined) return Promise.resolve();
 		const reportProgress = ProgressPlugin.getReporter(this.compiler);
-		return this.packPromise
+		this.packPromise = undefined;
+		return (this.storePromise = packPromise
 			.then(pack => {
 				if (!pack.invalid) return;
 				this.logger.log(`Storing pack...`);
@@ -1106,7 +1166,13 @@ class PackFileCacheStrategy {
 							}
 							this.newBuildDependencies.clear();
 							this.logger.timeEnd(`store pack`);
-							this.logger.log(`Stored pack`);
+							const stats = pack.getContentStats();
+							this.logger.log(
+								"Stored pack (%d items, %d files, %d MiB)",
+								pack.itemInfo.size,
+								stats.count,
+								Math.round(stats.size / 1024 / 1024)
+							);
 						})
 						.catch(err => {
 							this.logger.timeEnd(`store pack`);
@@ -1118,7 +1184,7 @@ class PackFileCacheStrategy {
 			.catch(err => {
 				this.logger.warn(`Caching failed for pack: ${err}`);
 				this.logger.debug(err.stack);
-			});
+			}));
 	}
 
 	clear() {

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -163,7 +163,8 @@ const applyWebpackOptionsDefaults = options => {
 	);
 	applyCacheDefaults(options.cache, {
 		name: name || "default",
-		mode: mode || "production"
+		mode: mode || "production",
+		development
 	});
 	const cache = !!options.cache;
 
@@ -254,9 +255,10 @@ const applyExperimentsDefaults = experiments => {
  * @param {Object} options options
  * @param {string} options.name name
  * @param {string} options.mode mode
+ * @param {boolean} options.development is development mode
  * @returns {void}
  */
-const applyCacheDefaults = (cache, { name, mode }) => {
+const applyCacheDefaults = (cache, { name, mode, development }) => {
 	if (cache === false) return;
 	switch (cache.type) {
 		case "filesystem":
@@ -294,9 +296,14 @@ const applyCacheDefaults = (cache, { name, mode }) => {
 			D(cache, "store", "pack");
 			D(cache, "idleTimeout", 60000);
 			D(cache, "idleTimeoutForInitialStore", 0);
+			D(cache, "maxMemoryGenerations", development ? 10 : Infinity);
+			D(cache, "maxAge", 1000 * 60 * 60 * 24 * 60); // 1 month
 			D(cache.buildDependencies, "defaultWebpack", [
 				path.resolve(__dirname, "..") + path.sep
 			]);
+			break;
+		case "memory":
+			D(cache, "maxGenerations", Infinity);
 			break;
 	}
 };

--- a/lib/config/normalization.js
+++ b/lib/config/normalization.js
@@ -121,13 +121,16 @@ const getNormalizedWebpackOptions = config => {
 			if (cache === false) return false;
 			if (cache === true) {
 				return {
-					type: "memory"
+					type: "memory",
+					maxGenerations: undefined
 				};
 			}
 			switch (cache.type) {
 				case "filesystem":
 					return {
 						type: "filesystem",
+						maxMemoryGenerations: cache.maxMemoryGenerations,
+						maxAge: cache.maxAge,
 						buildDependencies: cloneObject(cache.buildDependencies),
 						cacheDirectory: cache.cacheDirectory,
 						cacheLocation: cache.cacheLocation,
@@ -141,7 +144,8 @@ const getNormalizedWebpackOptions = config => {
 				case undefined:
 				case "memory":
 					return {
-						type: "memory"
+						type: "memory",
+						maxGenerations: cache.maxGenerations
 					};
 				default:
 					// @ts-expect-error Property 'type' does not exist on type 'never'. ts(2339)

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -942,6 +942,10 @@ class JavascriptParser extends Parser {
 							.setRange(expr.range);
 					}
 				});
+			this.hooks.finish.tap("JavascriptParser", () => {
+				// Cleanup for GC
+				cachedExpression = cachedInfo = undefined;
+			});
 		};
 		tapEvaluateWithVariableInfo("Identifier", expr => {
 			const info = this.getVariableInfo(

--- a/lib/serialization/ObjectMiddleware.js
+++ b/lib/serialization/ObjectMiddleware.js
@@ -253,13 +253,13 @@ class ObjectMiddleware extends SerializerMiddleware {
 	 */
 	serialize(data, context) {
 		/** @type {any[]} */
-		const result = [CURRENT_VERSION];
+		let result = [CURRENT_VERSION];
 		let currentPos = 0;
-		const referenceable = new Map();
+		let referenceable = new Map();
 		const addReferenceable = item => {
 			referenceable.set(item, currentPos++);
 		};
-		const bufferDedupeMap = new Map();
+		let bufferDedupeMap = new Map();
 		const dedupeBuffer = buf => {
 			const len = buf.length;
 			const entry = bufferDedupeMap.get(len);
@@ -322,7 +322,7 @@ class ObjectMiddleware extends SerializerMiddleware {
 			}
 		};
 		let currentPosTypeLookup = 0;
-		const objectTypeLookup = new Map();
+		let objectTypeLookup = new Map();
 		const cycleStack = new Set();
 		const stackToString = item => {
 			const arr = Array.from(cycleStack);
@@ -370,7 +370,7 @@ class ObjectMiddleware extends SerializerMiddleware {
 				.join(" -> ");
 		};
 		let hasDebugInfoAttached;
-		const ctx = {
+		let ctx = {
 			write(value, key) {
 				try {
 					process(value);
@@ -524,13 +524,18 @@ class ObjectMiddleware extends SerializerMiddleware {
 			for (const item of data) {
 				process(item);
 			}
+			return result;
 		} catch (e) {
 			if (e === NOT_SERIALIZABLE) return null;
 
 			throw e;
+		} finally {
+			// Get rid of these references to avoid leaking memory
+			// This happens because the optimized code v8 generates
+			// is optimized for our "ctx.write" method so it will reference
+			// it from e. g. Dependency.prototype.serialize -(IC)-> ctx.write
+			data = result = referenceable = bufferDedupeMap = objectTypeLookup = ctx = undefined;
 		}
-
-		return result;
 	}
 
 	/**
@@ -558,8 +563,8 @@ class ObjectMiddleware extends SerializerMiddleware {
 		};
 		let currentPosTypeLookup = 0;
 		let objectTypeLookup = [];
-		const result = [];
-		const ctx = {
+		let result = [];
+		let ctx = {
 			read() {
 				return decodeValue();
 			},
@@ -686,16 +691,18 @@ class ObjectMiddleware extends SerializerMiddleware {
 			}
 		};
 
-		while (currentDataPos < data.length) {
-			result.push(decodeValue());
+		try {
+			while (currentDataPos < data.length) {
+				result.push(decodeValue());
+			}
+			return result;
+		} finally {
+			// Get rid of these references to avoid leaking memory
+			// This happens because the optimized code v8 generates
+			// is optimized for our "ctx.read" method so it will reference
+			// it from e. g. Dependency.prototype.deserialize -(IC)-> ctx.read
+			result = referenceable = data = objectTypeLookup = ctx = undefined;
 		}
-
-		// Help the GC, as functions above might be cached in inline caches
-		referenceable = undefined;
-		objectTypeLookup = undefined;
-		data = undefined;
-
-		return result;
 	}
 }
 

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -971,6 +971,16 @@
             "minLength": 1
           }
         },
+        "maxAge": {
+          "description": "Time for which unused cache entries stay in the filesystem cache at minimum (in milliseconds).",
+          "type": "number",
+          "minimum": 0
+        },
+        "maxMemoryGenerations": {
+          "description": "Number of generations unused cache entries stay in memory cache at minimum (0 = no memory cache used, 1 = may be removed after unused for a single compilation, ..., Infinity: kept forever). Cache entries will be deserialized from disk when removed from memory cache.",
+          "type": "number",
+          "minimum": 0
+        },
         "name": {
           "description": "Name for the cache. Different names will lead to different coexisting caches.",
           "type": "string"
@@ -1547,6 +1557,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "maxGenerations": {
+          "description": "Number of generations unused cache entries stay in memory cache at minimum (1 = may be removed after unused for a single compilation, ..., Infinity: kept forever).",
+          "type": "number",
+          "minimum": 1
+        },
         "type": {
           "description": "In memory caching.",
           "enum": ["memory"]

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -746,6 +746,7 @@ describe("Defaults", () => {
 		@@ ... @@
 		-   "cache": false,
 		+   "cache": Object {
+		+     "maxGenerations": Infinity,
 		+     "type": "memory",
 		+   },
 		@@ ... @@
@@ -1417,6 +1418,7 @@ describe("Defaults", () => {
 		@@ ... @@
 		-   "cache": false,
 		+   "cache": Object {
+		+     "maxGenerations": Infinity,
 		+     "type": "memory",
 		+   },
 		@@ ... @@
@@ -1448,6 +1450,8 @@ describe("Defaults", () => {
 		+     "hashAlgorithm": "md4",
 		+     "idleTimeout": 60000,
 		+     "idleTimeoutForInitialStore": 0,
+		+     "maxAge": 5184000000,
+		+     "maxMemoryGenerations": Infinity,
 		+     "name": "default-none",
 		+     "store": "pack",
 		+     "type": "filesystem",
@@ -1662,6 +1666,8 @@ describe("Defaults", () => {
 			+     "hashAlgorithm": "md4",
 			+     "idleTimeout": 60000,
 			+     "idleTimeoutForInitialStore": 0,
+			+     "maxAge": 5184000000,
+			+     "maxMemoryGenerations": Infinity,
 			+     "name": "default-none",
 			+     "store": "pack",
 			+     "type": "filesystem",

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -173,6 +173,45 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
+  "cache-max-age": Object {
+    "configs": Array [
+      Object {
+        "description": "Time for which unused cache entries stay in the filesystem cache at minimum (in milliseconds).",
+        "multiple": false,
+        "path": "cache.maxAge",
+        "type": "number",
+      },
+    ],
+    "description": "Time for which unused cache entries stay in the filesystem cache at minimum (in milliseconds).",
+    "multiple": false,
+    "simpleType": "number",
+  },
+  "cache-max-generations": Object {
+    "configs": Array [
+      Object {
+        "description": "Number of generations unused cache entries stay in memory cache at minimum (1 = may be removed after unused for a single compilation, ..., Infinity: kept forever).",
+        "multiple": false,
+        "path": "cache.maxGenerations",
+        "type": "number",
+      },
+    ],
+    "description": "Number of generations unused cache entries stay in memory cache at minimum (1 = may be removed after unused for a single compilation, ..., Infinity: kept forever).",
+    "multiple": false,
+    "simpleType": "number",
+  },
+  "cache-max-memory-generations": Object {
+    "configs": Array [
+      Object {
+        "description": "Number of generations unused cache entries stay in memory cache at minimum (0 = no memory cache used, 1 = may be removed after unused for a single compilation, ..., Infinity: kept forever). Cache entries will be deserialized from disk when removed from memory cache.",
+        "multiple": false,
+        "path": "cache.maxMemoryGenerations",
+        "type": "number",
+      },
+    ],
+    "description": "Number of generations unused cache entries stay in memory cache at minimum (0 = no memory cache used, 1 = may be removed after unused for a single compilation, ..., Infinity: kept forever). Cache entries will be deserialized from disk when removed from memory cache.",
+    "multiple": false,
+    "simpleType": "number",
+  },
   "cache-name": Object {
     "configs": Array [
       Object {

--- a/types.d.ts
+++ b/types.d.ts
@@ -3670,6 +3670,16 @@ declare interface FileCacheOptions {
 	managedPaths?: string[];
 
 	/**
+	 * Time for which unused cache entries stay in the filesystem cache at minimum (in milliseconds).
+	 */
+	maxAge?: number;
+
+	/**
+	 * Number of generations unused cache entries stay in memory cache at minimum (0 = no memory cache used, 1 = may be removed after unused for a single compilation, ..., Infinity: kept forever). Cache entries will be deserialized from disk when removed from memory cache.
+	 */
+	maxMemoryGenerations?: number;
+
+	/**
 	 * Name for the cache. Different names will lead to different coexisting caches.
 	 */
 	name?: string;
@@ -5704,6 +5714,11 @@ declare interface MapOptions {
  * Options object for in-memory caching.
  */
 declare interface MemoryCacheOptions {
+	/**
+	 * Number of generations unused cache entries stay in memory cache at minimum (1 = may be removed after unused for a single compilation, ..., Infinity: kept forever).
+	 */
+	maxGenerations?: number;
+
 	/**
 	 * In memory caching.
 	 */

--- a/types.d.ts
+++ b/types.d.ts
@@ -3760,6 +3760,7 @@ declare abstract class FileSystemInfo {
 	immutablePaths: string[];
 	immutablePathsWithSlash: string[];
 	logStatistics(): void;
+	clear(): void;
 	addFileTimestamps(
 		map: Map<string, null | FileSystemInfoEntry | "ignore">
 	): void;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

* adds workaround for a v8 memory leak problem in ICs when code becomes optimized
* add GC to the memory cache and make it configurable
  * memory GC happens by default when persistent cache is enabled and in development mode
  * otherwise memory cache is kept forever
* make maxAge for persistent cache configurable
* GC the oldest content file even if it's not touched (to keep cache size small)
* filesystem cache will now no longer cache in memory, but restore items from disk again when it was persisted
* Caches will be cleared on shutdown. That should allow to GC cache items once they are serialized.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix, memory leak, feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
n/a
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
* new option for `cache.type === "memory"`: `cache.maxGenerations`: Number of generations unused cache entries stay in memory cache at minimum (1 = may be removed after unused for a single compilation, ..., Infinity: kept forever).
* new options for `cache.type === "filesystem"`:
  * `cache.maxMemoryGenerations`: Number of generations unused cache entries stay in memory cache at minimum (0 = no memory cache used, 1 = may be removed after unused for a single compilation, ..., Infinity: kept forever). Cache entries will be deserialized from disk when removed from memory cache.
    * `cache.maxMemoryGenerations: 0`: Persistent cache will not use an additional memory cache. It will only cache items in memory until they are serialized to disk. Once serialized the next read will deserialize them from disk again. This mode will minimize memory usage, but introduces a performance cost.
    * `cache.maxMemoryGenerations: 1`: This will clear items from memory cache once they are serialized and unused for at least one compilation. When they are used again they will be deserialized from disk. This mode will minimize the memory usage while still keeping active items in memory cache.
    * `cache.maxMemoryGenerations` small numbers > 0 will have a performance cost for the GC operation. It gets lower as the number increases.
    * `cache.maxMemoryGenerations` default to 10 in development mode and to `Infinity` in production mode.
  * `cache.maxAge`: Time for which unused cache entries stay in the filesystem cache at minimum (in milliseconds).
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
