### PR TITLE
expose Stats types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,19 @@ const memoize = require("./util/memoize");
 /** @typedef {import("./Parser").ParserState} ParserState */
 /** @typedef {import("./Watching")} Watching */
 /** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsAsset} StatsAsset */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsChunk} StatsChunk */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsChunkGroup} StatsChunkGroup */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsChunkOrigin} StatsChunkOrigin */
 /** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsCompilation} StatsCompilation */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsError} StatsError */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsLogging} StatsLogging */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsLoggingEntry} StatsLoggingEntry */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsModule} StatsModule */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsModuleIssuer} StatsModuleIssuer */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsModuleReason} StatsModuleReason */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsModuleTraceDependency} StatsModuleTraceDependency */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsModuleTraceItem} StatsModuleTraceItem */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsProfile} StatsProfile */
 
 /**
  * @template {Function} T

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,7 @@ const memoize = require("./util/memoize");
 /** @typedef {import("./MultiStats")} MultiStats */
 /** @typedef {import("./Parser").ParserState} ParserState */
 /** @typedef {import("./Watching")} Watching */
+/** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsAsset} StatsAsset */
 /** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsCompilation} StatsCompilation */
 
 /**

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -282,9 +282,9 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @property {string=} loc
  * @property {string|number=} chunkId
  * @property {string|number=} moduleId
- * @property {any=} moduleTrace
+ * @property {StatsModuleTraceItem[]=} moduleTrace
  * @property {any=} details
- * @property {any=} stack
+ * @property {string=} stack
  */
 
 /** @typedef {Asset & { type: string, related: PreprocessedAsset[] }} PreprocessedAsset */

--- a/types.d.ts
+++ b/types.d.ts
@@ -5237,9 +5237,9 @@ declare interface KnownStatsError {
 	loc?: string;
 	chunkId?: string | number;
 	moduleId?: string | number;
-	moduleTrace?: any;
+	moduleTrace?: StatsModuleTraceItem[];
 	details?: any;
-	stack?: any;
+	stack?: string;
 }
 declare interface KnownStatsFactoryContext {
 	type: string;
@@ -5324,6 +5324,18 @@ declare interface KnownStatsModuleReason {
 	loc?: string;
 	moduleId?: string | number;
 	resolvedModuleId?: string | number;
+}
+declare interface KnownStatsModuleTraceDependency {
+	loc?: string;
+}
+declare interface KnownStatsModuleTraceItem {
+	originIdentifier?: string;
+	originName?: string;
+	moduleIdentifier?: string;
+	moduleName?: string;
+	dependencies?: StatsModuleTraceDependency[];
+	originId?: string | number;
+	moduleId?: string | number;
 }
 declare interface KnownStatsPrinterContext {
 	type?: string;
@@ -10141,6 +10153,9 @@ type StatsLoggingEntry = KnownStatsLoggingEntry & Record<string, any>;
 type StatsModule = KnownStatsModule & Record<string, any>;
 type StatsModuleIssuer = KnownStatsModuleIssuer & Record<string, any>;
 type StatsModuleReason = KnownStatsModuleReason & Record<string, any>;
+type StatsModuleTraceDependency = KnownStatsModuleTraceDependency &
+	Record<string, any>;
+type StatsModuleTraceItem = KnownStatsModuleTraceItem & Record<string, any>;
 
 /**
  * Stats options object.
@@ -11682,7 +11697,19 @@ declare namespace exports {
 		ParserState,
 		Watching,
 		StatsAsset,
-		StatsCompilation
+		StatsChunk,
+		StatsChunkGroup,
+		StatsChunkOrigin,
+		StatsCompilation,
+		StatsError,
+		StatsLogging,
+		StatsLoggingEntry,
+		StatsModule,
+		StatsModuleIssuer,
+		StatsModuleReason,
+		StatsModuleTraceDependency,
+		StatsModuleTraceItem,
+		StatsProfile
 	};
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -3236,7 +3236,17 @@ declare abstract class ExportInfo {
 		| "maybe provided (runtime-defined)"
 		| "provided"
 		| "not provided";
-	getRenameInfo(): string;
+	getRenameInfo():
+		| string
+		| "missing provision and use info prevents renaming"
+		| "usage prevents renaming (no provision info)"
+		| "missing provision info prevents renaming"
+		| "missing usage info prevents renaming"
+		| "usage prevents renaming"
+		| "could be renamed"
+		| "provision prevents renaming (no use info)"
+		| "usage and provision prevents renaming"
+		| "provision prevents renaming";
 }
 declare interface ExportSpec {
 	/**

--- a/types.d.ts
+++ b/types.d.ts
@@ -3236,17 +3236,7 @@ declare abstract class ExportInfo {
 		| "maybe provided (runtime-defined)"
 		| "provided"
 		| "not provided";
-	getRenameInfo():
-		| string
-		| "missing provision and use info prevents renaming"
-		| "usage prevents renaming (no provision info)"
-		| "missing provision info prevents renaming"
-		| "missing usage info prevents renaming"
-		| "usage prevents renaming"
-		| "could be renamed"
-		| "provision prevents renaming (no use info)"
-		| "usage and provision prevents renaming"
-		| "provision prevents renaming";
+	getRenameInfo(): string;
 }
 declare interface ExportSpec {
 	/**
@@ -11681,6 +11671,7 @@ declare namespace exports {
 		MultiStats,
 		ParserState,
 		Watching,
+		StatsAsset,
 		StatsCompilation
 	};
 }


### PR DESCRIPTION
Fixes #13014

**What kind of change does this PR introduce?**

Typescript types improvement.

**Did you add tests for your changes?**

There don't appear to be tests for asserting typescript exports. if someone can point me at some, happy to update them.

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

N/A

---

As @alexander-akait mentioned, `StatsAsset` has so far been considered internal.

However, any type referenced by an exported type is also indirectly public/exposed, so we already had access to this type anyway and needed it when dealing with `assets`:

```ts
const fn = (asset: StatsAsset) => { ... };

stats.assets.map(fn);
```

One suggestion I had to reduce the surface we expose was to introduce a subset of the interface like so:

```ts
interface ExposedStatsAsset {
  type: string;
  name: string;
  size: number;
  chunkNames?: Array<string|number>;
}
```

However, this would mean introducing a "fake" type for the sole purpose of being exported, which feels worse than just exposing the type itself.

IMO there's nothing wrong with exposing it as even if you consider it fairly internal, any changes must happen in a new version anyway so it could be an acceptable risk for those of us consuming it.

This will also allow us to fix bundlephobia's webpack 5 integration.

If you'd rather me tackle this another way, just let me know and i will update.