### PR TITLE
Fix numbers being reported as the keys of objects to TypeScript - this is invalid.

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -42,16 +42,16 @@ const ChunkFilesSet = createArrayToSetDeprecationSet("chunk.files");
 /**
  * @deprecated
  * @typedef {Object} ChunkMaps
- * @property {Record<string|number, string>} hash
- * @property {Record<string|number, Record<string, string>>} contentHash
- * @property {Record<string|number, string>} name
+ * @property {Record<string, string>} hash
+ * @property {Record<string, Record<string, string>>} contentHash
+ * @property {Record<string, string>} name
  */
 
 /**
  * @deprecated
  * @typedef {Object} ChunkModuleMaps
- * @property {Record<string|number, (string|number)[]>} id
- * @property {Record<string|number, string>} hash
+ * @property {Record<string, (string|number)[]>} id
+ * @property {Record<string, string>} hash
  */
 
 let debugId = 1000;
@@ -341,9 +341,9 @@ class Chunk {
 			"Chunk.getChunkModuleMaps",
 			"DEP_WEBPACK_CHUNK_GET_CHUNK_MODULE_MAPS"
 		);
-		/** @type {Record<string|number, (string|number)[]>} */
+		/** @type {Record<string, (string|number)[]>} */
 		const chunkModuleIdMap = Object.create(null);
-		/** @type {Record<string|number, string>} */
+		/** @type {Record<string, string>} */
 		const chunkModuleHashMap = Object.create(null);
 
 		for (const asyncChunk of this.getAllAsyncChunks()) {
@@ -394,11 +394,11 @@ class Chunk {
 	 * @returns {ChunkMaps} the chunk map information
 	 */
 	getChunkMaps(realHash) {
-		/** @type {Record<string|number, string>} */
+		/** @type {Record<string, string>} */
 		const chunkHashMap = Object.create(null);
-		/** @type {Record<string|number, Record<string, string>>} */
+		/** @type {Record<string, Record<string, string>>} */
 		const chunkContentHashMap = Object.create(null);
-		/** @type {Record<string|number, string>} */
+		/** @type {Record<string, string>} */
 		const chunkNameMap = Object.create(null);
 
 		for (const chunk of this.getAllAsyncChunks()) {
@@ -765,10 +765,10 @@ class Chunk {
 	 * @param {ChunkGraph} chunkGraph the chunk graph
 	 * @param {boolean=} includeDirectChildren include direct children (by default only children of async children are included)
 	 * @param {ChunkFilterPredicate=} filterFn function used to filter chunks
-	 * @returns {Record<string|number, Record<string, (string | number)[]>>} a record object of names to lists of child ids(?) by chunk id
+	 * @returns {Record<string, Record<string, (string | number)[]>>} a record object of names to lists of child ids(?) by chunk id
 	 */
 	getChildIdsByOrdersMap(chunkGraph, includeDirectChildren, filterFn) {
-		/** @type {Record<string|number, Record<string, (string | number)[]>>} */
+		/** @type {Record<string, Record<string, (string | number)[]>>} */
 		const chunkMaps = Object.create(null);
 
 		/**

--- a/lib/ChunkGraph.js
+++ b/lib/ChunkGraph.js
@@ -608,10 +608,10 @@ class ChunkGraph {
 	 * @param {Chunk} chunk the chunk
 	 * @param {ModuleFilterPredicate} filterFn function used to filter modules
 	 * @param {boolean} includeAllChunks all chunks or only async chunks
-	 * @returns {Record<string|number, (string|number)[]>} chunk to module ids object
+	 * @returns {Record<string, (string|number)[]>} chunk to module ids object
 	 */
 	getChunkModuleIdMap(chunk, filterFn, includeAllChunks = false) {
-		/** @type {Record<string|number, (string|number)[]>} */
+		/** @type {Record<string, (string|number)[]>} */
 		const chunkModuleIdMap = Object.create(null);
 
 		for (const asyncChunk of includeAllChunks
@@ -642,7 +642,7 @@ class ChunkGraph {
 	 * @param {ModuleFilterPredicate} filterFn function used to filter modules
 	 * @param {number} hashLength length of the hash
 	 * @param {boolean} includeAllChunks all chunks or only async chunks
-	 * @returns {Record<string|number, Record<string|number, string>>} chunk to module id to module hash object
+	 * @returns {Record<string, Record<string, string>>} chunk to module id to module hash object
 	 */
 	getChunkModuleRenderedHashMap(
 		chunk,
@@ -650,13 +650,13 @@ class ChunkGraph {
 		hashLength = 0,
 		includeAllChunks = false
 	) {
-		/** @type {Record<string|number, Record<string|number, string>>} */
+		/** @type {Record<string, Record<string, string>>} */
 		const chunkModuleHashMap = Object.create(null);
 
 		for (const asyncChunk of includeAllChunks
 			? chunk.getAllReferencedChunks()
 			: chunk.getAllAsyncChunks()) {
-			/** @type {Record<string|number, string>} */
+			/** @type {Record<string, string>} */
 			let idToHashMap;
 			for (const module of this.getOrderedChunkModulesIterable(
 				asyncChunk,
@@ -680,7 +680,7 @@ class ChunkGraph {
 	/**
 	 * @param {Chunk} chunk the chunk
 	 * @param {ChunkFilterPredicate} filterFn function used to filter chunks
-	 * @returns {Record<string|number, boolean>} chunk map
+	 * @returns {Record<string, boolean>} chunk map
 	 */
 	getChunkConditionMap(chunk, filterFn) {
 		const map = Object.create(null);

--- a/lib/prefetch/ChunkPrefetchTriggerRuntimeModule.js
+++ b/lib/prefetch/ChunkPrefetchTriggerRuntimeModule.js
@@ -12,7 +12,7 @@ const Template = require("../Template");
 
 class ChunkPrefetchTriggerRuntimeModule extends RuntimeModule {
 	/**
-	 * @param {Record<string|number, (string|number)[]>} chunkMap map from chunk to
+	 * @param {Record<string, (string|number)[]>} chunkMap map from chunk to
 	 */
 	constructor(chunkMap) {
 		super(`chunk prefetch trigger`, RuntimeModule.STAGE_TRIGGER);

--- a/lib/prefetch/ChunkPreloadTriggerRuntimeModule.js
+++ b/lib/prefetch/ChunkPreloadTriggerRuntimeModule.js
@@ -12,7 +12,7 @@ const Template = require("../Template");
 
 class ChunkPreloadTriggerRuntimeModule extends RuntimeModule {
 	/**
-	 * @param {Record<string|number, (string|number)[]>} chunkMap map from chunk to chunks
+	 * @param {Record<string, (string|number)[]>} chunkMap map from chunk to chunks
 	 */
 	constructor(chunkMap) {
 		super(`chunk preload trigger`, RuntimeModule.STAGE_TRIGGER);

--- a/lib/util/compileBooleanMatcher.js
+++ b/lib/util/compileBooleanMatcher.js
@@ -17,7 +17,7 @@ const toSimpleString = str => {
 };
 
 /**
- * @param {Record<string|number, boolean>} map value map
+ * @param {Record<string, boolean>} map value map
  * @returns {true|false|function(string): string} true/false, when unconditionally true/false, or a template function to determine the value at runtime
  */
 const compileBooleanMatcher = map => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -743,7 +743,7 @@ declare class Chunk {
 		chunkGraph: ChunkGraph,
 		includeDirectChildren?: boolean,
 		filterFn?: (c: Chunk, chunkGraph: ChunkGraph) => boolean
-	): Record<string | number, Record<string, (string | number)[]>>;
+	): Record<string, Record<string, (string | number)[]>>;
 }
 declare class ChunkGraph {
 	constructor(moduleGraph: ModuleGraph);
@@ -790,17 +790,17 @@ declare class ChunkGraph {
 		chunk: Chunk,
 		filterFn: (m: Module) => boolean,
 		includeAllChunks?: boolean
-	): Record<string | number, (string | number)[]>;
+	): Record<string, (string | number)[]>;
 	getChunkModuleRenderedHashMap(
 		chunk: Chunk,
 		filterFn: (m: Module) => boolean,
 		hashLength?: number,
 		includeAllChunks?: boolean
-	): Record<string | number, Record<string | number, string>>;
+	): Record<string, Record<string, string>>;
 	getChunkConditionMap(
 		chunk: Chunk,
 		filterFn: (c: Chunk, chunkGraph: ChunkGraph) => boolean
-	): Record<string | number, boolean>;
+	): Record<string, boolean>;
 	hasModuleInGraph(
 		chunk: Chunk,
 		filterFn: (m: Module) => boolean,
@@ -1017,9 +1017,9 @@ declare interface ChunkHashContext {
 	chunkGraph: ChunkGraph;
 }
 declare interface ChunkMaps {
-	hash: Record<string | number, string>;
-	contentHash: Record<string | number, Record<string, string>>;
-	name: Record<string | number, string>;
+	hash: Record<string, string>;
+	contentHash: Record<string, Record<string, string>>;
+	name: Record<string, string>;
 }
 declare class ChunkModuleIdRangePlugin {
 	constructor(options?: any);
@@ -1031,8 +1031,8 @@ declare class ChunkModuleIdRangePlugin {
 	apply(compiler: Compiler): void;
 }
 declare interface ChunkModuleMaps {
-	id: Record<string | number, (string | number)[]>;
-	hash: Record<string | number, string>;
+	id: Record<string, (string | number)[]>;
+	hash: Record<string, string>;
 }
 declare interface ChunkPathData {
 	id: string | number;
@@ -3260,17 +3260,7 @@ declare abstract class ExportInfo {
 		| "maybe provided (runtime-defined)"
 		| "provided"
 		| "not provided";
-	getRenameInfo():
-		| string
-		| "missing provision and use info prevents renaming"
-		| "usage prevents renaming (no provision info)"
-		| "missing provision info prevents renaming"
-		| "missing usage info prevents renaming"
-		| "usage prevents renaming"
-		| "could be renamed"
-		| "provision prevents renaming (no use info)"
-		| "usage and provision prevents renaming"
-		| "provision prevents renaming";
+	getRenameInfo(): string;
 }
 declare interface ExportSpec {
 	/**

--- a/types.d.ts
+++ b/types.d.ts
@@ -3260,7 +3260,17 @@ declare abstract class ExportInfo {
 		| "maybe provided (runtime-defined)"
 		| "provided"
 		| "not provided";
-	getRenameInfo(): string;
+	getRenameInfo():
+		| string
+		| "missing provision and use info prevents renaming"
+		| "usage prevents renaming (no provision info)"
+		| "missing provision info prevents renaming"
+		| "missing usage info prevents renaming"
+		| "usage prevents renaming"
+		| "could be renamed"
+		| "provision prevents renaming (no use info)"
+		| "usage and provision prevents renaming"
+		| "provision prevents renaming";
 }
 declare interface ExportSpec {
 	/**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Currently, the TypeScript definitions include a number of `Record<string|number, ...>`.  This is invalid as the keys of an object can't be numbers - if you put a number in, the key is coerced to a string.  This causes a build error on depending upon `webpack` if `skipLibCheck` isn't enabled in your `tsconfig.json`.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

I've removed the `number` option from the key type parameter of every `Record<...>` I can find.

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

I do not believe that the TypeScript definitions have test coverage to update.  I am not sure how I would do this without adding a large number of build dependencies.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

This is a type change, but shouldn't break anything - type checks for libraries must have been turned off to use these types up until now anyway.

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

I am unaware of a need to document these changes.
