### PR TITLE
feat: add colors flag to infrastructureLogging

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1200,9 +1200,17 @@ export interface ExternalsPresets {
  */
 export interface InfrastructureLogging {
 	/**
-	 * Enables/Disables colorful output.
+	 * Only appends lines to the output. Avoids updating existing output e. g. for status messages. This option is only used when no custom console is provided.
+	 */
+	appendOnly?: boolean;
+	/**
+	 * Enables/Disables colorful output. This option is only used when no custom console is provided.
 	 */
 	colors?: boolean;
+	/**
+	 * Custom console used for logging.
+	 */
+	console?: Console;
 	/**
 	 * Enable debug logging for specific loggers.
 	 */
@@ -1211,6 +1219,10 @@ export interface InfrastructureLogging {
 	 * Log level.
 	 */
 	level?: "none" | "error" | "warn" | "info" | "log" | "verbose";
+	/**
+	 * Stream used for logging output. Defaults to process.stderr. This option is only used when no custom console is provided.
+	 */
+	stream?: NodeJS.WritableStream;
 }
 /**
  * Custom values available in the loader context.

--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1200,6 +1200,10 @@ export interface ExternalsPresets {
  */
 export interface InfrastructureLogging {
 	/**
+	 * Enables/Disables colorful output.
+	 */
+	colors?: boolean;
+	/**
 	 * Enable debug logging for specific loggers.
 	 */
 	debug?: boolean | FilterTypes;

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -117,6 +117,7 @@ const A = (obj, prop, factory) => {
  */
 const applyWebpackOptionsBaseDefaults = options => {
 	F(options, "context", () => process.cwd());
+	applyInfrastructureLoggingDefaults(options.infrastructureLogging);
 };
 
 /**
@@ -235,8 +236,6 @@ const applyWebpackOptionsDefaults = options => {
 		getResolveLoaderDefaults({ cache }),
 		options.resolveLoader
 	);
-
-	applyInfrastructureLoggingDefaults(options.infrastructureLogging);
 };
 
 /**
@@ -1077,13 +1076,12 @@ const getResolveLoaderDefaults = ({ cache }) => {
  * @returns {void}
  */
 const applyInfrastructureLoggingDefaults = infrastructureLogging => {
+	const tty = process.stderr.isTTY && process.env.TERM !== "dumb";
 	D(infrastructureLogging, "level", "info");
 	D(infrastructureLogging, "debug", false);
-	D(
-		infrastructureLogging,
-		"colors",
-		process.stderr.isTTY && process.env.TERM !== "dumb"
-	);
+	D(infrastructureLogging, "colors", tty);
+	D(infrastructureLogging, "appendOnly", !tty);
+	F(infrastructureLogging, "stream", () => process.stderr);
 };
 
 exports.applyWebpackOptionsBaseDefaults = applyWebpackOptionsBaseDefaults;

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -1076,12 +1076,14 @@ const getResolveLoaderDefaults = ({ cache }) => {
  * @returns {void}
  */
 const applyInfrastructureLoggingDefaults = infrastructureLogging => {
-	const tty = process.stderr.isTTY && process.env.TERM !== "dumb";
+	F(infrastructureLogging, "stream", () => process.stderr);
+	const tty =
+		/** @type {any} */ (infrastructureLogging.stream).isTTY &&
+		process.env.TERM !== "dumb";
 	D(infrastructureLogging, "level", "info");
 	D(infrastructureLogging, "debug", false);
 	D(infrastructureLogging, "colors", tty);
 	D(infrastructureLogging, "appendOnly", !tty);
-	F(infrastructureLogging, "stream", () => process.stderr);
 };
 
 exports.applyWebpackOptionsBaseDefaults = applyWebpackOptionsBaseDefaults;

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -1079,6 +1079,11 @@ const getResolveLoaderDefaults = ({ cache }) => {
 const applyInfrastructureLoggingDefaults = infrastructureLogging => {
 	D(infrastructureLogging, "level", "info");
 	D(infrastructureLogging, "debug", false);
+	D(
+		infrastructureLogging,
+		"colors",
+		process.stderr.isTTY && process.env.TERM !== "dumb"
+	);
 };
 
 exports.applyWebpackOptionsBaseDefaults = applyWebpackOptionsBaseDefaults;

--- a/lib/logging/createConsoleLogger.js
+++ b/lib/logging/createConsoleLogger.js
@@ -14,10 +14,28 @@ const { LogType } = require("./Logger");
 /** @typedef {function(string): boolean} FilterFunction */
 
 /**
+ * @typedef {Object} LoggerConsole
+ * @property {function(): void} clear
+ * @property {function(): void} trace
+ * @property {(...args: any[]) => void} info
+ * @property {(...args: any[]) => void} log
+ * @property {(...args: any[]) => void} warn
+ * @property {(...args: any[]) => void} error
+ * @property {(...args: any[]) => void=} debug
+ * @property {(...args: any[]) => void=} group
+ * @property {(...args: any[]) => void=} groupCollapsed
+ * @property {(...args: any[]) => void=} groupEnd
+ * @property {(...args: any[]) => void=} status
+ * @property {(...args: any[]) => void=} profile
+ * @property {(...args: any[]) => void=} profileEnd
+ * @property {(...args: any[]) => void=} logTime
+ */
+
+/**
  * @typedef {Object} LoggerOptions
  * @property {false|true|"none"|"error"|"warn"|"info"|"log"|"verbose"} level loglevel
  * @property {FilterTypes|boolean} debug filter for debug logging
- * @property {Console & { status?: Function, logTime?: Function }} console the console to log to
+ * @property {LoggerConsole} console the console to log to
  */
 
 /**

--- a/lib/node/NodeEnvironmentPlugin.js
+++ b/lib/node/NodeEnvironmentPlugin.js
@@ -11,11 +11,16 @@ const createConsoleLogger = require("../logging/createConsoleLogger");
 const NodeWatchFileSystem = require("./NodeWatchFileSystem");
 const nodeConsole = require("./nodeConsole");
 
+/** @typedef {import("../../declarations/WebpackOptions").InfrastructureLogging} InfrastructureLogging */
 /** @typedef {import("../Compiler")} Compiler */
 
 class NodeEnvironmentPlugin {
+	/**
+	 * @param {Object} options options
+	 * @param {InfrastructureLogging} options.infrastructureLogging infrastructure logging options
+	 */
 	constructor(options) {
-		this.options = options || {};
+		this.options = options;
 	}
 
 	/**
@@ -24,22 +29,18 @@ class NodeEnvironmentPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
-		const console = nodeConsole(
-			this.options.infrastructureLogging.colors !== undefined
-				? this.options.infrastructureLogging.colors
-				: process.stderr.isTTY && process.env.TERM !== "dumb"
-		);
-		delete this.options.infrastructureLogging.colors;
-		compiler.infrastructureLogger = createConsoleLogger(
-			Object.assign(
-				{
-					level: "info",
-					debug: false,
-					console
-				},
-				this.options.infrastructureLogging
-			)
-		);
+		const { infrastructureLogging } = this.options;
+		compiler.infrastructureLogger = createConsoleLogger({
+			level: infrastructureLogging.level || "info",
+			debug: infrastructureLogging.debug || false,
+			console:
+				infrastructureLogging.console ||
+				nodeConsole({
+					colors: infrastructureLogging.colors,
+					appendOnly: infrastructureLogging.appendOnly,
+					stream: infrastructureLogging.stream
+				})
+		});
 		compiler.inputFileSystem = new CachedInputFileSystem(fs, 60000);
 		const inputFileSystem = compiler.inputFileSystem;
 		compiler.outputFileSystem = fs;

--- a/lib/node/NodeEnvironmentPlugin.js
+++ b/lib/node/NodeEnvironmentPlugin.js
@@ -24,12 +24,18 @@ class NodeEnvironmentPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
+		const console = nodeConsole(
+			this.options.infrastructureLogging.colors !== undefined
+				? this.options.infrastructureLogging.colors
+				: process.stderr.isTTY && process.env.TERM !== "dumb"
+		);
+		delete this.options.infrastructureLogging.colors;
 		compiler.infrastructureLogger = createConsoleLogger(
 			Object.assign(
 				{
 					level: "info",
 					debug: false,
-					console: nodeConsole
+					console
 				},
 				this.options.infrastructureLogging
 			)

--- a/lib/node/nodeConsole.js
+++ b/lib/node/nodeConsole.js
@@ -15,10 +15,10 @@ let hasStatusMessage = false;
 let currentIndent = "";
 let currentCollapsed = 0;
 
-const indent = (str, prefix, colorPrefix, colorSuffix) => {
+const indent = (colors, str, prefix, colorPrefix, colorSuffix) => {
 	if (str === "") return str;
 	prefix = currentIndent + prefix;
-	if (tty) {
+	if (colors) {
 		return (
 			prefix +
 			colorPrefix +
@@ -49,86 +49,116 @@ const writeStatusMessage = () => {
 	hasStatusMessage = true;
 };
 
-const writeColored = (prefix, colorPrefix, colorSuffix) => {
+const writeColored = (colors, prefix, colorPrefix, colorSuffix) => {
 	return (...args) => {
 		if (currentCollapsed > 0) return;
 		clearStatusMessage();
-		const str = indent(util.format(...args), prefix, colorPrefix, colorSuffix);
+		const str = indent(
+			colors,
+			util.format(...args),
+			prefix,
+			colorPrefix,
+			colorSuffix
+		);
 		process.stderr.write(str + "\n");
 		writeStatusMessage();
 	};
 };
 
-const writeGroupMessage = writeColored(
-	"<-> ",
-	"\u001b[1m\u001b[36m",
-	"\u001b[39m\u001b[22m"
-);
+module.exports = colors => {
+	const writeGroupMessage = writeColored(
+		colors,
+		"<-> ",
+		"\u001b[1m\u001b[36m",
+		"\u001b[39m\u001b[22m"
+	);
 
-const writeGroupCollapsedMessage = writeColored(
-	"<+> ",
-	"\u001b[1m\u001b[36m",
-	"\u001b[39m\u001b[22m"
-);
+	const writeGroupCollapsedMessage = writeColored(
+		colors,
+		"<+> ",
+		"\u001b[1m\u001b[36m",
+		"\u001b[39m\u001b[22m"
+	);
 
-module.exports = {
-	log: writeColored("    ", "\u001b[1m", "\u001b[22m"),
-	debug: writeColored("    ", "", ""),
-	trace: writeColored("    ", "", ""),
-	info: writeColored("<i> ", "\u001b[1m\u001b[32m", "\u001b[39m\u001b[22m"),
-	warn: writeColored("<w> ", "\u001b[1m\u001b[33m", "\u001b[39m\u001b[22m"),
-	error: writeColored("<e> ", "\u001b[1m\u001b[31m", "\u001b[39m\u001b[22m"),
-	logTime: writeColored("<t> ", "\u001b[1m\u001b[35m", "\u001b[39m\u001b[22m"),
-	group: (...args) => {
-		writeGroupMessage(...args);
-		if (currentCollapsed > 0) {
+	return {
+		log: writeColored(colors, "    ", "\u001b[1m", "\u001b[22m"),
+		debug: writeColored(colors, "    ", "", ""),
+		trace: writeColored(colors, "    ", "", ""),
+		info: writeColored(
+			colors,
+			"<i> ",
+			"\u001b[1m\u001b[32m",
+			"\u001b[39m\u001b[22m"
+		),
+		warn: writeColored(
+			colors,
+			"<w> ",
+			"\u001b[1m\u001b[33m",
+			"\u001b[39m\u001b[22m"
+		),
+		error: writeColored(
+			colors,
+			"<e> ",
+			"\u001b[1m\u001b[31m",
+			"\u001b[39m\u001b[22m"
+		),
+		logTime: writeColored(
+			colors,
+			"<t> ",
+			"\u001b[1m\u001b[35m",
+			"\u001b[39m\u001b[22m"
+		),
+		group: (...args) => {
+			writeGroupMessage(...args);
+			if (currentCollapsed > 0) {
+				currentCollapsed++;
+			} else {
+				currentIndent += "  ";
+			}
+		},
+		groupCollapsed: (...args) => {
+			writeGroupCollapsedMessage(...args);
 			currentCollapsed++;
-		} else {
-			currentIndent += "  ";
-		}
-	},
-	groupCollapsed: (...args) => {
-		writeGroupCollapsedMessage(...args);
-		currentCollapsed++;
-	},
-	groupEnd: () => {
-		if (currentCollapsed > 0) currentCollapsed--;
-		else if (currentIndent.length >= 2)
-			currentIndent = currentIndent.slice(0, currentIndent.length - 2);
-	},
-	// eslint-disable-next-line node/no-unsupported-features/node-builtins
-	profile: console.profile && (name => console.profile(name)),
-	// eslint-disable-next-line node/no-unsupported-features/node-builtins
-	profileEnd: console.profileEnd && (name => console.profileEnd(name)),
-	clear:
-		tty &&
+		},
+		groupEnd: () => {
+			if (currentCollapsed > 0) currentCollapsed--;
+			else if (currentIndent.length >= 2)
+				currentIndent = currentIndent.slice(0, currentIndent.length - 2);
+		},
 		// eslint-disable-next-line node/no-unsupported-features/node-builtins
-		console.clear &&
-		(() => {
-			clearStatusMessage();
+		profile: console.profile && (name => console.profile(name)),
+		// eslint-disable-next-line node/no-unsupported-features/node-builtins
+		profileEnd: console.profileEnd && (name => console.profileEnd(name)),
+		clear:
+			tty &&
 			// eslint-disable-next-line node/no-unsupported-features/node-builtins
-			console.clear();
-			writeStatusMessage();
-		}),
-	status: tty
-		? (name, ...args) => {
-				args = args.filter(Boolean);
-				if (name === undefined && args.length === 0) {
-					clearStatusMessage();
-					currentStatusMessage = undefined;
-				} else if (
-					typeof name === "string" &&
-					name.startsWith("[webpack.Progress] ")
-				) {
-					currentStatusMessage = [name.slice(19), ...args];
-					writeStatusMessage();
-				} else if (name === "[webpack.Progress]") {
-					currentStatusMessage = [...args];
-					writeStatusMessage();
-				} else {
-					currentStatusMessage = [name, ...args];
-					writeStatusMessage();
-				}
-		  }
-		: writeColored("<s> ", "", "")
+			console.clear &&
+			(() => {
+				clearStatusMessage();
+				// eslint-disable-next-line node/no-unsupported-features/node-builtins
+				console.clear();
+				writeStatusMessage();
+			}),
+		status: tty
+			? (name, ...args) => {
+					args = args.filter(Boolean);
+					if (name === undefined && args.length === 0) {
+						clearStatusMessage();
+						currentStatusMessage = undefined;
+					} else if (
+						typeof name === "string" &&
+						name.startsWith("[webpack.Progress] ")
+					) {
+						currentStatusMessage = [name.slice(19), ...args];
+						writeStatusMessage();
+					} else if (name === "[webpack.Progress]") {
+						currentStatusMessage = [...args];
+						writeStatusMessage();
+					} else {
+						currentStatusMessage = [name, ...args];
+						writeStatusMessage();
+					}
+			  }
+			: writeColored(colors, "<s> ", "", "")
+	};
 };

--- a/lib/node/nodeConsole.js
+++ b/lib/node/nodeConsole.js
@@ -8,102 +8,81 @@
 const util = require("util");
 const truncateArgs = require("../logging/truncateArgs");
 
-const tty = process.stderr.isTTY && process.env.TERM !== "dumb";
+module.exports = ({ colors, appendOnly, stream }) => {
+	let currentStatusMessage = undefined;
+	let hasStatusMessage = false;
+	let currentIndent = "";
+	let currentCollapsed = 0;
 
-let currentStatusMessage = undefined;
-let hasStatusMessage = false;
-let currentIndent = "";
-let currentCollapsed = 0;
-
-const indent = (colors, str, prefix, colorPrefix, colorSuffix) => {
-	if (str === "") return str;
-	prefix = currentIndent + prefix;
-	if (colors) {
-		return (
-			prefix +
-			colorPrefix +
-			str.replace(/\n/g, colorSuffix + "\n" + prefix + colorPrefix) +
-			colorSuffix
-		);
-	} else {
-		return prefix + str.replace(/\n/g, "\n" + prefix);
-	}
-};
-
-const clearStatusMessage = () => {
-	if (hasStatusMessage) {
-		process.stderr.write("\x1b[2K\r");
-		hasStatusMessage = false;
-	}
-};
-
-const writeStatusMessage = () => {
-	if (!currentStatusMessage) return;
-	const l = process.stderr.columns;
-	const args = l
-		? truncateArgs(currentStatusMessage, l - 1)
-		: currentStatusMessage;
-	const str = args.join(" ");
-	const coloredStr = `\u001b[1m${str}\u001b[39m\u001b[22m`;
-	process.stderr.write(`\x1b[2K\r${coloredStr}`);
-	hasStatusMessage = true;
-};
-
-const writeColored = (colors, prefix, colorPrefix, colorSuffix) => {
-	return (...args) => {
-		if (currentCollapsed > 0) return;
-		clearStatusMessage();
-		const str = indent(
-			colors,
-			util.format(...args),
-			prefix,
-			colorPrefix,
-			colorSuffix
-		);
-		process.stderr.write(str + "\n");
-		writeStatusMessage();
+	const indent = (str, prefix, colorPrefix, colorSuffix) => {
+		if (str === "") return str;
+		prefix = currentIndent + prefix;
+		if (colors) {
+			return (
+				prefix +
+				colorPrefix +
+				str.replace(/\n/g, colorSuffix + "\n" + prefix + colorPrefix) +
+				colorSuffix
+			);
+		} else {
+			return prefix + str.replace(/\n/g, "\n" + prefix);
+		}
 	};
-};
 
-module.exports = colors => {
+	const clearStatusMessage = () => {
+		if (hasStatusMessage) {
+			stream.write("\x1b[2K\r");
+			hasStatusMessage = false;
+		}
+	};
+
+	const writeStatusMessage = () => {
+		if (!currentStatusMessage) return;
+		const l = stream.columns;
+		const args = l
+			? truncateArgs(currentStatusMessage, l - 1)
+			: currentStatusMessage;
+		const str = args.join(" ");
+		const coloredStr = `\u001b[1m${str}\u001b[39m\u001b[22m`;
+		stream.write(`\x1b[2K\r${coloredStr}`);
+		hasStatusMessage = true;
+	};
+
+	const writeColored = (prefix, colorPrefix, colorSuffix) => {
+		return (...args) => {
+			if (currentCollapsed > 0) return;
+			clearStatusMessage();
+			const str = indent(
+				util.format(...args),
+				prefix,
+				colorPrefix,
+				colorSuffix
+			);
+			stream.write(str + "\n");
+			writeStatusMessage();
+		};
+	};
+
 	const writeGroupMessage = writeColored(
-		colors,
 		"<-> ",
 		"\u001b[1m\u001b[36m",
 		"\u001b[39m\u001b[22m"
 	);
 
 	const writeGroupCollapsedMessage = writeColored(
-		colors,
 		"<+> ",
 		"\u001b[1m\u001b[36m",
 		"\u001b[39m\u001b[22m"
 	);
 
 	return {
-		log: writeColored(colors, "    ", "\u001b[1m", "\u001b[22m"),
-		debug: writeColored(colors, "    ", "", ""),
-		trace: writeColored(colors, "    ", "", ""),
-		info: writeColored(
-			colors,
-			"<i> ",
-			"\u001b[1m\u001b[32m",
-			"\u001b[39m\u001b[22m"
-		),
-		warn: writeColored(
-			colors,
-			"<w> ",
-			"\u001b[1m\u001b[33m",
-			"\u001b[39m\u001b[22m"
-		),
-		error: writeColored(
-			colors,
-			"<e> ",
-			"\u001b[1m\u001b[31m",
-			"\u001b[39m\u001b[22m"
-		),
+		log: writeColored("    ", "\u001b[1m", "\u001b[22m"),
+		debug: writeColored("    ", "", ""),
+		trace: writeColored("    ", "", ""),
+		info: writeColored("<i> ", "\u001b[1m\u001b[32m", "\u001b[39m\u001b[22m"),
+		warn: writeColored("<w> ", "\u001b[1m\u001b[33m", "\u001b[39m\u001b[22m"),
+		error: writeColored("<e> ", "\u001b[1m\u001b[31m", "\u001b[39m\u001b[22m"),
 		logTime: writeColored(
-			colors,
 			"<t> ",
 			"\u001b[1m\u001b[35m",
 			"\u001b[39m\u001b[22m"
@@ -130,7 +109,7 @@ module.exports = colors => {
 		// eslint-disable-next-line node/no-unsupported-features/node-builtins
 		profileEnd: console.profileEnd && (name => console.profileEnd(name)),
 		clear:
-			tty &&
+			!appendOnly &&
 			// eslint-disable-next-line node/no-unsupported-features/node-builtins
 			console.clear &&
 			(() => {
@@ -139,8 +118,9 @@ module.exports = colors => {
 				console.clear();
 				writeStatusMessage();
 			}),
-		status: tty
-			? (name, ...args) => {
+		status: appendOnly
+			? writeColored("<s> ", "", "")
+			: (name, ...args) => {
 					args = args.filter(Boolean);
 					if (name === undefined && args.length === 0) {
 						clearStatusMessage();
@@ -159,6 +139,5 @@ module.exports = colors => {
 						writeStatusMessage();
 					}
 			  }
-			: writeColored(colors, "<s> ", "", "")
 	};
 };

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1211,9 +1211,17 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "colors": {
-          "description": "Enables/Disables colorful output.",
+        "appendOnly": {
+          "description": "Only appends lines to the output. Avoids updating existing output e. g. for status messages. This option is only used when no custom console is provided.",
           "type": "boolean"
+        },
+        "colors": {
+          "description": "Enables/Disables colorful output. This option is only used when no custom console is provided.",
+          "type": "boolean"
+        },
+        "console": {
+          "description": "Custom console used for logging.",
+          "tsType": "Console"
         },
         "debug": {
           "description": "Enable debug logging for specific loggers.",
@@ -1230,6 +1238,10 @@
         "level": {
           "description": "Log level.",
           "enum": ["none", "error", "warn", "info", "log", "verbose"]
+        },
+        "stream": {
+          "description": "Stream used for logging output. Defaults to process.stderr. This option is only used when no custom console is provided.",
+          "tsType": "NodeJS.WritableStream"
         }
       }
     },

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -1211,6 +1211,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "colors": {
+          "description": "Enables/Disables colorful output.",
+          "type": "boolean"
+        },
         "debug": {
           "description": "Enable debug logging for specific loggers.",
           "anyOf": [

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -788,7 +788,7 @@ describe("Compiler", () => {
 				logger.info("Info");
 				logger.log("Log");
 				logger.debug("Debug");
-				logger.groupCollapsed("Collaped group");
+				logger.groupCollapsed("Collapsed group");
 				logger.log("Log inside collapsed group");
 				logger.groupEnd();
 				logger.groupEnd();
@@ -817,7 +817,7 @@ describe("Compiler", () => {
   <w> [MyPlugin] Warning
   <i> [MyPlugin] Info
       [MyPlugin] Log
-  <-> [MyPlugin] Collaped group
+  <-> [MyPlugin] Collapsed group
         [MyPlugin] Log inside collapsed group
 <t> [MyPlugin] Time: X ms
 "
@@ -849,7 +849,7 @@ describe("Compiler", () => {
   <i> [MyPlugin] Info
       [MyPlugin] Log
       [MyPlugin] Debug
-  <-> [MyPlugin] Collaped group
+  <-> [MyPlugin] Collapsed group
         [MyPlugin] Log inside collapsed group
 <t> [MyPlugin] Time: X ms
 "

--- a/test/ConfigTestCases.template.js
+++ b/test/ConfigTestCases.template.js
@@ -5,6 +5,7 @@ const fs = require("graceful-fs");
 const vm = require("vm");
 const { URL } = require("url");
 const rimraf = require("rimraf");
+const webpack = require("..");
 const TerserPlugin = require("terser-webpack-plugin");
 const checkArrayExpectation = require("./checkArrayExpectation");
 const createLazyTestEnv = require("./helpers/createLazyTestEnv");
@@ -15,8 +16,6 @@ const CurrentScript = require("./helpers/CurrentScript");
 const prepareOptions = require("./helpers/prepareOptions");
 const { parseResource } = require("../lib/util/identifier");
 const captureStdio = require("./helpers/captureStdio");
-
-let webpack;
 
 const casesPath = path.join(__dirname, "configCases");
 const categories = fs.readdirSync(casesPath).map(cat => {
@@ -34,7 +33,6 @@ const describeCases = config => {
 		let stderr;
 		beforeEach(() => {
 			stderr = captureStdio(process.stderr, true);
-			webpack = require("..");
 		});
 		afterEach(() => {
 			stderr.restore();

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -108,11 +108,7 @@ describe("Defaults", () => {
 		  },
 		  "externalsType": "var",
 		  "ignoreWarnings": undefined,
-		  "infrastructureLogging": Object {
-		    "colors": undefined,
-		    "debug": false,
-		    "level": "info",
-		  },
+		  "infrastructureLogging": Object {},
 		  "loader": Object {
 		    "target": "web",
 		  },

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -109,6 +109,7 @@ describe("Defaults", () => {
 		  "externalsType": "var",
 		  "ignoreWarnings": undefined,
 		  "infrastructureLogging": Object {
+		    "colors": undefined,
 		    "debug": false,
 		    "level": "info",
 		  },

--- a/test/ProgressPlugin.test.js
+++ b/test/ProgressPlugin.test.js
@@ -3,9 +3,8 @@
 const _ = require("lodash");
 const path = require("path");
 const { createFsFromVolume, Volume } = require("memfs");
+const webpack = require("..");
 const captureStdio = require("./helpers/captureStdio");
-
-let webpack;
 
 const createMultiCompiler = (progressOptions, configOptions) => {
 	const compiler = webpack(
@@ -86,7 +85,6 @@ describe("ProgressPlugin", function () {
 	beforeEach(() => {
 		stderr = captureStdio(process.stderr, true);
 		stdout = captureStdio(process.stdout, true);
-		webpack = require("..");
 	});
 	afterEach(() => {
 		stderr && stderr.restore();

--- a/test/StatsTestCases.test.js
+++ b/test/StatsTestCases.test.js
@@ -4,8 +4,7 @@ const path = require("path");
 const fs = require("graceful-fs");
 const rimraf = require("rimraf");
 const captureStdio = require("./helpers/captureStdio");
-
-let webpack;
+const webpack = require("..");
 
 /**
  * Escapes regular expression metacharacters
@@ -39,7 +38,6 @@ describe("StatsTestCases", () => {
 	let stderr;
 	beforeEach(() => {
 		stderr = captureStdio(process.stderr, true);
-		webpack = require("..");
 	});
 	afterEach(() => {
 		stderr.restore();

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -4,13 +4,12 @@ const path = require("path");
 const fs = require("graceful-fs");
 const vm = require("vm");
 const rimraf = require("rimraf");
+const webpack = require("..");
 const TerserPlugin = require("terser-webpack-plugin");
 const checkArrayExpectation = require("./checkArrayExpectation");
 const createLazyTestEnv = require("./helpers/createLazyTestEnv");
 const deprecationTracking = require("./helpers/deprecationTracking");
 const captureStdio = require("./helpers/captureStdio");
-
-let webpack;
 
 const terserForTesting = new TerserPlugin({
 	parallel: false
@@ -53,7 +52,6 @@ const describeCases = config => {
 		let stderr;
 		beforeEach(() => {
 			stderr = captureStdio(process.stderr, true);
-			webpack = require("..");
 		});
 		afterEach(() => {
 			stderr.restore();

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -751,6 +751,19 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
+  "infrastructure-logging-colors": Object {
+    "configs": Array [
+      Object {
+        "description": "Enables/Disables colorful output.",
+        "multiple": false,
+        "path": "infrastructureLogging.colors",
+        "type": "boolean",
+      },
+    ],
+    "description": "Enables/Disables colorful output.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "infrastructure-logging-debug": Object {
     "configs": Array [
       Object {

--- a/test/__snapshots__/Cli.test.js.snap
+++ b/test/__snapshots__/Cli.test.js.snap
@@ -751,16 +751,29 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
+  "infrastructure-logging-append-only": Object {
+    "configs": Array [
+      Object {
+        "description": "Only appends lines to the output. Avoids updating existing output e. g. for status messages. This option is only used when no custom console is provided.",
+        "multiple": false,
+        "path": "infrastructureLogging.appendOnly",
+        "type": "boolean",
+      },
+    ],
+    "description": "Only appends lines to the output. Avoids updating existing output e. g. for status messages. This option is only used when no custom console is provided.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "infrastructure-logging-colors": Object {
     "configs": Array [
       Object {
-        "description": "Enables/Disables colorful output.",
+        "description": "Enables/Disables colorful output. This option is only used when no custom console is provided.",
         "multiple": false,
         "path": "infrastructureLogging.colors",
         "type": "boolean",
       },
     ],
-    "description": "Enables/Disables colorful output.",
+    "description": "Enables/Disables colorful output. This option is only used when no custom console is provided.",
     "multiple": false,
     "simpleType": "boolean",
   },

--- a/test/__snapshots__/StatsTestCases.test.js.snap
+++ b/test/__snapshots__/StatsTestCases.test.js.snap
@@ -1224,7 +1224,7 @@ asset <CLR=32,BOLD>main.js</CLR> 84 bytes <CLR=32,BOLD>[emitted]</CLR> (name: ma
 <-> <CLR=36,BOLD>Group</CLR>
   <i> <CLR=32,BOLD>Info</CLR>
       <CLR=BOLD>Log</CLR>
-  <+> <CLR=36,BOLD>Collaped group</CLR>
+  <+> <CLR=36,BOLD>Collapsed group</CLR>
       <CLR=BOLD>Log</CLR>
     <CLR=BOLD>End</CLR>
 + 6 hidden lines
@@ -1959,7 +1959,7 @@ exports[`StatsTestCases should print correct stats for preset-detailed 1`] = `
   <w> [LogTestPlugin] Warning
   <i> [LogTestPlugin] Info
       [LogTestPlugin] Log
-  <+> [LogTestPlugin] Collaped group
+  <+> [LogTestPlugin] Collapsed group
       [LogTestPlugin] Log
     [LogTestPlugin] End
 PublicPath: auto
@@ -2034,7 +2034,7 @@ LOG from LogTestPlugin
   <w> Warning
   <i> Info
       Log
-  <+> Collaped group
+  <+> Collapsed group
       Log
     End
 + 6 hidden lines
@@ -2232,7 +2232,7 @@ exports[`StatsTestCases should print correct stats for preset-verbose 1`] = `
   <w> [LogTestPlugin] Warning
   <i> [LogTestPlugin] Info
       [LogTestPlugin] Log
-  <-> [LogTestPlugin] Collaped group
+  <-> [LogTestPlugin] Collapsed group
         [LogTestPlugin] Log inside collapsed group
     <-> [LogTestPlugin] Inner group
           [LogTestPlugin] Inner inner message
@@ -2332,7 +2332,7 @@ LOG from LogTestPlugin
   <w> Warning
   <i> Info
       Log
-  <-> Collaped group
+  <-> Collapsed group
         Log inside collapsed group
     <-> Inner group
           Inner inner message

--- a/test/helpers/LogTestPlugin.js
+++ b/test/helpers/LogTestPlugin.js
@@ -12,7 +12,7 @@ module.exports = class LogTestPlugin {
 			logger.info("Info");
 			logger.log("Log");
 			logger.debug("Debug");
-			logger.groupCollapsed("Collaped group");
+			logger.groupCollapsed("Collapsed group");
 			logger.log("Log inside collapsed group");
 			logger.group("Inner group");
 			logger.log("Inner inner message");

--- a/test/helpers/captureStdio.js
+++ b/test/helpers/captureStdio.js
@@ -11,13 +11,6 @@ module.exports = (stdio, tty) => {
 	};
 	if (tty !== undefined) stdio.isTTY = tty;
 
-	// isTTY flag is only read once on initialization
-	// therefore we need to clear some module caches
-	// to get the mocked value
-	delete require.cache[require.resolve("../../")];
-	delete require.cache[require.resolve("../../lib/node/NodeEnvironmentPlugin")];
-	delete require.cache[require.resolve("../../lib/node/nodeConsole")];
-
 	return {
 		data: logs,
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -4185,9 +4185,19 @@ type ImportSource = undefined | null | string | SimpleLiteral | RegExpLiteral;
  */
 declare interface InfrastructureLogging {
 	/**
-	 * Enables/Disables colorful output.
+	 * Only appends lines to the output. Avoids updating existing output e. g. for status messages. This option is only used when no custom console is provided.
+	 */
+	appendOnly?: boolean;
+
+	/**
+	 * Enables/Disables colorful output. This option is only used when no custom console is provided.
 	 */
 	colors?: boolean;
+
+	/**
+	 * Custom console used for logging.
+	 */
+	console?: Console;
 
 	/**
 	 * Enable debug logging for specific loggers.
@@ -4203,6 +4213,11 @@ declare interface InfrastructureLogging {
 	 * Log level.
 	 */
 	level?: "none" | "verbose" | "error" | "warn" | "info" | "log";
+
+	/**
+	 * Stream used for logging output. Defaults to process.stderr. This option is only used when no custom console is provided.
+	 */
+	stream?: NodeJS.WritableStream;
 }
 declare abstract class InitFragment {
 	content: string | Source;
@@ -6498,8 +6513,18 @@ declare class NoEmitOnErrorsPlugin {
 	apply(compiler: Compiler): void;
 }
 declare class NodeEnvironmentPlugin {
-	constructor(options?: any);
-	options: any;
+	constructor(options: {
+		/**
+		 * infrastructure logging options
+		 */
+		infrastructureLogging: InfrastructureLogging;
+	});
+	options: {
+		/**
+		 * infrastructure logging options
+		 */
+		infrastructureLogging: InfrastructureLogging;
+	};
 
 	/**
 	 * Apply the plugin

--- a/types.d.ts
+++ b/types.d.ts
@@ -4185,6 +4185,11 @@ type ImportSource = undefined | null | string | SimpleLiteral | RegExpLiteral;
  */
 declare interface InfrastructureLogging {
 	/**
+	 * Enables/Disables colorful output.
+	 */
+	colors?: boolean;
+
+	/**
 	 * Enable debug logging for specific loggers.
 	 */
 	debug?:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Fixes #12899

Since it's my first try of contribution to webpack, even if I looked carefully for impacted default values etc, there can exists some missed parts. Please review carefully for me to fix things. Thanks!

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
feature

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
Yes

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**What needs to be documented once your changes are merged?**
* `infrastructureLogging.colors` Enables/Disables colorful output.
* `infrastructureLogging.appendOnly` Only appends lines to the output. Avoids updating existing output e. g. for status messages.
* `infrastructureLogging.stream` Stream used for logging output. Defaults to process.stderr.
* `infrastructureLogging.console` Custom console used for logging.
* When stream is an TTY colors is enabled and appendOnly is disabled. Otherwise it's flipped.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
