### PR TITLE
allow to specify `publicPath` for each entrypoint

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -123,6 +123,19 @@ export type LibraryType =
  */
 export type UmdNamedDefine = boolean;
 /**
+ * The 'publicPath' specifies the public URL address of the output files when referenced in a browser.
+ */
+export type PublicPath = "auto" | RawPublicPath;
+/**
+ * The 'publicPath' specifies the public URL address of the output files when referenced in a browser.
+ */
+export type RawPublicPath =
+	| string
+	| ((
+			pathData: import("../lib/Compilation").PathData,
+			assetInfo?: import("../lib/Compilation").AssetInfo
+	  ) => string);
+/**
  * The name of the runtime chunk. If set a runtime chunk with this name is created or an existing entrypoint is used as runtime.
  */
 export type EntryRuntime = string;
@@ -537,19 +550,6 @@ export type Path = string;
  * Include comments with information about the modules.
  */
 export type Pathinfo = "verbose" | boolean;
-/**
- * The 'publicPath' specifies the public URL address of the output files when referenced in a browser.
- */
-export type PublicPath = "auto" | RawPublicPath;
-/**
- * The 'publicPath' specifies the public URL address of the output files when referenced in a browser.
- */
-export type RawPublicPath =
-	| string
-	| ((
-			pathData: import("../lib/Compilation").PathData,
-			assetInfo?: import("../lib/Compilation").AssetInfo
-	  ) => string);
 /**
  * This option enables loading async chunks via a custom script type, such as script type="module".
  */
@@ -1021,6 +1021,10 @@ export interface EntryDescription {
 	 * Options for library.
 	 */
 	library?: LibraryOptions;
+	/**
+	 * The 'publicPath' specifies the public URL address of the output files when referenced in a browser.
+	 */
+	publicPath?: PublicPath;
 	/**
 	 * The name of the runtime chunk. If set a runtime chunk with this name is created or an existing entrypoint is used as runtime.
 	 */
@@ -2672,6 +2676,10 @@ export interface EntryDescriptionNormalized {
 	 * Options for library.
 	 */
 	library?: LibraryOptions;
+	/**
+	 * The 'publicPath' specifies the public URL address of the output files when referenced in a browser.
+	 */
+	publicPath?: PublicPath;
 	/**
 	 * The name of the runtime chunk. If set a runtime chunk with this name is created or an existing entrypoint is used as runtime.
 	 */

--- a/lib/EntryOptionPlugin.js
+++ b/lib/EntryOptionPlugin.js
@@ -62,6 +62,7 @@ class EntryOptionPlugin {
 			runtime: desc.runtime,
 			layer: desc.layer,
 			dependOn: desc.dependOn,
+			publicPath: desc.publicPath,
 			chunkLoading: desc.chunkLoading,
 			wasmLoading: desc.wasmLoading,
 			library: desc.library

--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -176,14 +176,17 @@ class RuntimePlugin {
 				.for(RuntimeGlobals.publicPath)
 				.tap("RuntimePlugin", (chunk, set) => {
 					const { outputOptions } = compilation;
-					const { publicPath, scriptType } = outputOptions;
+					const { publicPath: globalPublicPath, scriptType } = outputOptions;
+					const entryOptions = chunk.getEntryOptions();
+					const publicPath =
+						(entryOptions && entryOptions.publicPath) || globalPublicPath;
 
 					if (publicPath === "auto") {
 						const module = new AutoPublicPathRuntimeModule();
 						if (scriptType !== "module") set.add(RuntimeGlobals.global);
 						compilation.addRuntimeModule(chunk, module);
 					} else {
-						const module = new PublicPathRuntimeModule();
+						const module = new PublicPathRuntimeModule(publicPath);
 
 						if (
 							typeof publicPath !== "string" ||

--- a/lib/config/normalization.js
+++ b/lib/config/normalization.js
@@ -458,6 +458,7 @@ const getNormalizedEntryStatic = entry => {
 				filename: value.filename,
 				layer: value.layer,
 				runtime: value.runtime,
+				publicPath: value.publicPath,
 				chunkLoading: value.chunkLoading,
 				wasmLoading: value.wasmLoading,
 				dependOn:

--- a/lib/runtime/PublicPathRuntimeModule.js
+++ b/lib/runtime/PublicPathRuntimeModule.js
@@ -8,20 +8,20 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 
 class PublicPathRuntimeModule extends RuntimeModule {
-	constructor() {
+	constructor(publicPath) {
 		super("publicPath", RuntimeModule.STAGE_BASIC);
+		this.publicPath = publicPath;
 	}
 
 	/**
 	 * @returns {string} runtime code
 	 */
 	generate() {
-		const { compilation } = this;
-		const { publicPath } = compilation.outputOptions;
+		const { compilation, publicPath } = this;
 
 		return `${RuntimeGlobals.publicPath} = ${JSON.stringify(
-			this.compilation.getPath(publicPath || "", {
-				hash: this.compilation.hash || "XXXX"
+			compilation.getPath(publicPath || "", {
+				hash: compilation.hash || "XXXX"
 			})
 		)};`;
 	}

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -470,6 +470,9 @@
         "library": {
           "$ref": "#/definitions/LibraryOptions"
         },
+        "publicPath": {
+          "$ref": "#/definitions/PublicPath"
+        },
         "runtime": {
           "$ref": "#/definitions/EntryRuntime"
         },
@@ -517,6 +520,9 @@
         },
         "library": {
           "$ref": "#/definitions/LibraryOptions"
+        },
+        "publicPath": {
+          "$ref": "#/definitions/PublicPath"
         },
         "runtime": {
           "$ref": "#/definitions/EntryRuntime"

--- a/test/configCases/output/publicPath-web/c.js
+++ b/test/configCases/output/publicPath-web/c.js
@@ -1,0 +1,5 @@
+import asset from "./asset.jpg";
+
+it("should define public path", () => {
+	expect(asset).toBe("/other/inner1/inner2/../../asset.jpg");
+});

--- a/test/configCases/output/publicPath-web/d.js
+++ b/test/configCases/output/publicPath-web/d.js
@@ -1,0 +1,5 @@
+import asset from "./asset.jpg";
+
+it("should define public path", () => {
+	expect(asset).toBe("/other/asset.jpg");
+});

--- a/test/configCases/output/publicPath-web/webpack.config.js
+++ b/test/configCases/output/publicPath-web/webpack.config.js
@@ -5,12 +5,22 @@ module.exports = {
 	entry() {
 		return {
 			a: "./a",
-			b: "./b"
+			b: "./b",
+			c: {
+				import: "./c",
+				publicPath: "/other/"
+			},
+			d: {
+				import: "./d",
+				publicPath: "/other/"
+			}
 		};
 	},
 	output: {
 		filename: data => {
-			return data.chunk.name === "a" ? `inner1/inner2/[name].js` : "[name].js";
+			return /^[ac]$/.test(data.chunk.name)
+				? `inner1/inner2/[name].js`
+				: "[name].js";
 		},
 		assetModuleFilename: "[name][ext]"
 	},

--- a/types.d.ts
+++ b/types.d.ts
@@ -2927,6 +2927,11 @@ declare interface EntryDescription {
 	library?: LibraryOptions;
 
 	/**
+	 * The 'publicPath' specifies the public URL address of the output files when referenced in a browser.
+	 */
+	publicPath?: string | ((pathData: PathData, assetInfo?: AssetInfo) => string);
+
+	/**
 	 * The name of the runtime chunk. If set a runtime chunk with this name is created or an existing entrypoint is used as runtime.
 	 */
 	runtime?: string;
@@ -2970,6 +2975,11 @@ declare interface EntryDescriptionNormalized {
 	 * Options for library.
 	 */
 	library?: LibraryOptions;
+
+	/**
+	 * The 'publicPath' specifies the public URL address of the output files when referenced in a browser.
+	 */
+	publicPath?: string | ((pathData: PathData, assetInfo?: AssetInfo) => string);
 
 	/**
 	 * The name of the runtime chunk. If set a runtime chunk with this name is created or an existing entrypoint is used as runtime.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

related to https://github.com/webpack-contrib/mini-css-extract-plugin/pull/737

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
* `entry.xxx.publicPath` allows to set the public path per entry (see also `output.publicPath`)
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
