### PR TITLE
DefinePlugin cross-compatibility

### DIFF
--- a/lib/util/MapHelpers.js
+++ b/lib/util/MapHelpers.js
@@ -17,6 +17,6 @@ exports.provide = (map, key, computer) => {
 	const value = map && map.get(key);
 	if (value !== undefined) return value;
 	const newValue = computer();
-	map &&& map.set(key, newValue);
+	map && map.set(key, newValue);
 	return newValue;
 };

--- a/lib/util/MapHelpers.js
+++ b/lib/util/MapHelpers.js
@@ -14,9 +14,9 @@
  * @returns {V} value
  */
 exports.provide = (map, key, computer) => {
-	const value = map.get(key);
+	const value = map && map.get(key);
 	if (value !== undefined) return value;
 	const newValue = computer();
-	map.set(key, newValue);
+	map &&& map.set(key, newValue);
 	return newValue;
 };


### PR DESCRIPTION
Just updated node modules today, and Storybook started crashing.. the newer webpack exposed where my webpack config used builtin plugins shared to the webpack config of their builder (and presumably their core). My config's plugin instances come from webpack5... However, storybook-core still builds on webpack 4... (its nested under storybook's node_modules) 

This change allows the plugin to continue functioning in webpack 4.