### PR TITLE
fix passing publicPath to `this.importModule`

### DIFF
--- a/lib/dependencies/LoaderPlugin.js
+++ b/lib/dependencies/LoaderPlugin.js
@@ -31,6 +31,7 @@ const LoaderImportDependency = require("./LoaderImportDependency");
 /**
  * @typedef {Object} ImportModuleOptions
  * @property {string=} layer the target layer
+ * @property {string=} publicPath the target public path
  */
 
 class LoaderPlugin {
@@ -199,7 +200,11 @@ class LoaderPlugin {
 									}
 									compilation.executeModule(
 										referencedModule,
-										{},
+										{
+											entryOptions: {
+												publicPath: options.publicPath
+											}
+										},
 										(err, result) => {
 											if (err) return callback(err);
 											for (const d of result.fileDependencies) {

--- a/test/configCases/loader-import-module/css/index.js
+++ b/test/configCases/loader-import-module/css/index.js
@@ -10,6 +10,6 @@ it("should be able to use build-time code", () => {
 		'body { background: url("/public/assets/file.png?1"); color: #f00; }'
 	);
 	expect(otherStylesheet).toBe(
-		'body { background: url("/public/assets/file.jpg"); color: #0f0; }'
+		'body { background: url("/other/assets/file.jpg"); color: #0f0; }'
 	);
 });

--- a/test/configCases/loader-import-module/css/loader.js
+++ b/test/configCases/loader-import-module/css/loader.js
@@ -1,6 +1,7 @@
 exports.pitch = async function (remaining) {
 	const result = await this.importModule(
-		this.resourcePath + ".webpack[javascript/auto]" + "!=!" + remaining
+		this.resourcePath + ".webpack[javascript/auto]" + "!=!" + remaining,
+		this.getOptions()
 	);
 	return result.default || result;
 };

--- a/test/configCases/loader-import-module/css/webpack.config.js
+++ b/test/configCases/loader-import-module/css/webpack.config.js
@@ -16,9 +16,21 @@ module.exports = {
 		},
 		rules: [
 			{
-				test: /stylesheet\.js$/,
-				use: "./loader",
-				type: "asset/source"
+				oneOf: [
+					{
+						test: /other-stylesheet\.js$/,
+						loader: "./loader",
+						options: {
+							publicPath: "/other/"
+						},
+						type: "asset/source"
+					},
+					{
+						test: /stylesheet\.js$/,
+						use: "./loader",
+						type: "asset/source"
+					}
+				]
 			},
 			{
 				test: /\.jpg$/,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
* Second argument to `this.importModule` is an `options` object with
  * `options.layer` module layer in which modules should be built
  * `options.publicPath` the public path used for the built modules
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
