### PR TITLE
Ignores differences of only a null escape char

### DIFF
--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -1248,7 +1248,7 @@ class FileSystemInfo {
 					resolveResults.set(key, undefined);
 					resolve(context, path, resolverContext, (err, result) => {
 						if (typeof expected === "string") {
-							if (result === expected) {
+							if (result.replace(/\0/g, "") === expected.replace(/\0/g, "")) {
 								resolveResults.set(key, result);
 							} else {
 								invalidResolveResults.add(key);


### PR DESCRIPTION
when comparing expected paths

closes #13148

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

i did not. this is a proposal fix for a bug that i whipped up quickly. if this is the right answer I can spend the time to add a test.

**Does this PR introduce a breaking change?**

i don't think so

**What needs to be documented once your changes are merged?**

nothing
