### PR TITLE
fix(resolve): allows filesysteminfo to resolve files that have #'s

### DIFF
--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -1219,7 +1219,7 @@ class FileSystemInfo {
 						return callback();
 					}
 					resolveResults.set(key, undefined);
-					resolveContext(context, path, resolverContext, (err, result) => {
+					resolveContext(context, path, resolverContext, (err, _, result) => {
 						if (err) {
 							if (expected === false) {
 								resolveResults.set(key, false);
@@ -1229,11 +1229,12 @@ class FileSystemInfo {
 							err.message += `\nwhile resolving '${path}' in ${context} to a directory`;
 							return callback(err);
 						}
-						resolveResults.set(key, result);
+						const resultPath = result.path;
+						resolveResults.set(key, resultPath);
 						push({
 							type: RBDT_DIRECTORY,
 							context: undefined,
-							path: result,
+							path: resultPath,
 							expected: undefined,
 							issuer: job
 						});
@@ -1246,18 +1247,16 @@ class FileSystemInfo {
 						return callback();
 					}
 					resolveResults.set(key, undefined);
-					resolve(context, path, resolverContext, (err, _result) => {
-						const result =
-							typeof _result === "string"
-								? _result.replace(/\0/g, "")
-								: _result;
+					resolve(context, path, resolverContext, (err, _, result) => {
 						if (typeof expected === "string") {
-							if (result === expected) {
-								resolveResults.set(key, result);
+							if (!err && result && result.path === expected) {
+								resolveResults.set(key, result.path);
 							} else {
 								invalidResolveResults.add(key);
 								this.logger.warn(
-									`Resolving '${path}' in ${context} for build dependencies doesn't lead to expected result '${expected}', but to '${result}' instead. Resolving dependencies are ignored for this path.\n${pathToString(
+									`Resolving '${path}' in ${context} for build dependencies doesn't lead to expected result '${expected}', but to '${
+										err || (result && result.path)
+									}' instead. Resolving dependencies are ignored for this path.\n${pathToString(
 										job
 									)}`
 								);
@@ -1274,11 +1273,12 @@ class FileSystemInfo {
 								)}`;
 								return callback(err);
 							}
-							resolveResults.set(key, result);
+							const resultPath = result.path;
+							resolveResults.set(key, resultPath);
 							push({
 								type: RBDT_FILE,
 								context: undefined,
-								path: result,
+								path: resultPath,
 								expected: undefined,
 								issuer: job
 							});
@@ -1620,38 +1620,42 @@ class FileSystemInfo {
 				const [type, context, path] = key.split("\n");
 				switch (type) {
 					case "d":
-						resolveContext(context, path, {}, (err, result) => {
+						resolveContext(context, path, {}, (err, _, result) => {
 							if (expectedResult === false)
 								return callback(err ? undefined : INVALID);
 							if (err) return callback(err);
-							if (result !== expectedResult) return callback(INVALID);
+							const resultPath = result.path;
+							if (resultPath !== expectedResult) return callback(INVALID);
 							callback();
 						});
 						break;
 					case "f":
-						resolveCjs(context, path, {}, (err, result) => {
+						resolveCjs(context, path, {}, (err, _, result) => {
 							if (expectedResult === false)
 								return callback(err ? undefined : INVALID);
 							if (err) return callback(err);
-							if (result !== expectedResult) return callback(INVALID);
+							const resultPath = result.path;
+							if (resultPath !== expectedResult) return callback(INVALID);
 							callback();
 						});
 						break;
 					case "c":
-						resolveCjsAsChild(context, path, {}, (err, result) => {
+						resolveCjsAsChild(context, path, {}, (err, _, result) => {
 							if (expectedResult === false)
 								return callback(err ? undefined : INVALID);
 							if (err) return callback(err);
-							if (result !== expectedResult) return callback(INVALID);
+							const resultPath = result.path;
+							if (resultPath !== expectedResult) return callback(INVALID);
 							callback();
 						});
 						break;
 					case "e":
-						resolveEsm(context, path, {}, (err, result) => {
+						resolveEsm(context, path, {}, (err, _, result) => {
 							if (expectedResult === false)
 								return callback(err ? undefined : INVALID);
 							if (err) return callback(err);
-							if (result !== expectedResult) return callback(INVALID);
+							const resultPath = result.path;
+							if (resultPath !== expectedResult) return callback(INVALID);
 							callback();
 						});
 						break;

--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -1246,7 +1246,11 @@ class FileSystemInfo {
 						return callback();
 					}
 					resolveResults.set(key, undefined);
-					resolve(context, path, resolverContext, (err, result) => {
+					resolve(context, path, resolverContext, (err, _result) => {
+						const result =
+							typeof _result === "string"
+								? _result.replace(/\0/g, "")
+								: _result;
 						if (typeof expected === "string") {
 							if (result === expected) {
 								resolveResults.set(key, result);

--- a/test/fixtures/buildDependencies/index.js
+++ b/test/fixtures/buildDependencies/index.js
@@ -1,5 +1,6 @@
 /* global VALUE */
 
+require("dep#with#hash/#.js");
 module.exports = {
 	loader: require("./loader!"),
 	config: VALUE,

--- a/test/fixtures/buildDependencies/run.js
+++ b/test/fixtures/buildDependencies/run.js
@@ -3,6 +3,8 @@ const webpack = require("../../..");
 // eslint-disable-next-line node/no-missing-require
 const value = require("../../js/buildDepsInput/config-dependency");
 
+require("dep#with#hash/#.js");
+
 process.exitCode = 1;
 
 const options = JSON.parse(process.argv[3]);


### PR DESCRIPTION
escaped with \0

i don't understand the reasoning behind @sokra's escaping in enhanced resolve well enough to know if this makes sense or is basically just undoing the hard work he did to distinguish these characters from fragments. maybe he can chime in if this makes no sense to do

closes #13148
closes #12156

@sokra  not sure if the escaping in the commit below was meant to be used in other places but it breaks here. i'm very new to all of this code so let me know if this direction is wrong. 
https://github.com/webpack/enhanced-resolve/commit/17cf8fee0769cafce3067aa4d169cefad26e107a

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

not yet. once again not sure if this is the right direction or just a regression of the fragment work in enhanced resolve

**Does this PR introduce a breaking change?**

nope

**What needs to be documented once your changes are merged?**

nada
