### PR TITLE
fix typo

### DIFF
--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -770,7 +770,7 @@ class PackContent {
 
 const allowCollectingMemory = buf => {
 	const wasted = buf.buffer.byteLength - buf.byteLength;
-	if ((wasted > 8192 && wasted > 1048576) || wasted > buf.byteLength) {
+	if (wasted > 8192 && (wasted > 1048576 || wasted > buf.byteLength)) {
 		return Buffer.from(buf);
 	}
 	return buf;


### PR DESCRIPTION
thanks @markjm

It should not optimize the buffer when less than 8kB are wasted.
It should always optimize the buffer when more than 1MB are wasted.
In between it should optimize the buffer when it would use more than the double amount.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
