### PR TITLE
fix problems with auto-generated runtime name for workers

### DIFF
--- a/lib/dependencies/WorkerPlugin.js
+++ b/lib/dependencies/WorkerPlugin.js
@@ -9,9 +9,9 @@ const { pathToFileURL } = require("url");
 const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
 const CommentCompilationWarning = require("../CommentCompilationWarning");
 const UnsupportedFeatureWarning = require("../UnsupportedFeatureWarning");
-const formatLocation = require("../formatLocation");
 const EnableChunkLoadingPlugin = require("../javascript/EnableChunkLoadingPlugin");
 const { equals } = require("../util/ArrayHelpers");
+const createHash = require("../util/createHash");
 const { contextify } = require("../util/identifier");
 const EnableWasmLoadingPlugin = require("../wasm/EnableWasmLoadingPlugin");
 const ConstDependency = require("./ConstDependency");
@@ -27,6 +27,7 @@ const WorkerDependency = require("./WorkerDependency");
 /** @typedef {import("estree").SpreadElement} SpreadElement */
 /** @typedef {import("../Compiler")} Compiler */
 /** @typedef {import("../Entrypoint").EntryOptions} EntryOptions */
+/** @typedef {import("../Parser").ParserState} ParserState */
 /** @typedef {import("../javascript/BasicEvaluatedExpression")} BasicEvaluatedExpression */
 /** @typedef {import("../javascript/JavascriptParser")} JavascriptParser */
 /** @typedef {import("./HarmonyImportDependencyParserPlugin").HarmonySettings} HarmonySettings */
@@ -41,6 +42,9 @@ const DEFAULT_SYNTAX = [
 	"navigator.serviceWorker.register()",
 	"Worker from worker_threads"
 ];
+
+/** @type {WeakMap<ParserState, number>} */
+const workerIndexMap = new WeakMap();
 
 class WorkerPlugin {
 	constructor(chunkLoading, wasmLoading) {
@@ -264,9 +268,20 @@ class WorkerPlugin {
 						}
 
 						if (!entryOptions.runtime) {
-							entryOptions.runtime = `${cachedContextify(
+							let i = workerIndexMap.get(parser.state) || 0;
+							workerIndexMap.set(parser.state, i + 1);
+							let name = `${cachedContextify(
 								parser.state.module.identifier()
-							)}|${formatLocation(expr.loc)}`;
+							)}|${i}`;
+							const hash = createHash(compilation.outputOptions.hashFunction);
+							hash.update(name);
+							const digest = /** @type {string} */ (hash.digest(
+								compilation.outputOptions.hashDigest
+							));
+							entryOptions.runtime = digest.slice(
+								0,
+								compilation.outputOptions.hashDigestLength
+							);
 						}
 
 						const block = new AsyncDependenciesBlock({


### PR DESCRIPTION
Make auto-generated runtime name a hash instead of leaking pathinfo
Make auto-generated runtime name more stable by using index instead of source code location

fixes #12883

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
