### PR TITLE
make errors nullable for call signatures of filesystem types

### DIFF
--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -51,14 +51,14 @@ const path = require("path");
  * @property {string | Buffer} name
  */
 
-/** @typedef {function(NodeJS.ErrnoException=): void} Callback */
-/** @typedef {function(NodeJS.ErrnoException=, Buffer=): void} BufferCallback */
-/** @typedef {function(NodeJS.ErrnoException=, Buffer|string=): void} BufferOrStringCallback */
-/** @typedef {function(NodeJS.ErrnoException=, (string | Buffer)[] | IDirent[]=): void} DirentArrayCallback */
-/** @typedef {function(NodeJS.ErrnoException=, string=): void} StringCallback */
-/** @typedef {function(NodeJS.ErrnoException=, number=): void} NumberCallback */
-/** @typedef {function(NodeJS.ErrnoException=, IStats=): void} StatsCallback */
-/** @typedef {function((NodeJS.ErrnoException | Error)=, any=): void} ReadJsonCallback */
+/** @typedef {function((NodeJS.ErrnoException | null)=): void} Callback */
+/** @typedef {function((NodeJS.ErrnoException | null)=, Buffer=): void} BufferCallback */
+/** @typedef {function((NodeJS.ErrnoException | null)=, Buffer|string=): void} BufferOrStringCallback */
+/** @typedef {function((NodeJS.ErrnoException | null)=, (string | Buffer)[] | IDirent[]=): void} DirentArrayCallback */
+/** @typedef {function((NodeJS.ErrnoException | null)=, string=): void} StringCallback */
+/** @typedef {function((NodeJS.ErrnoException | null)=, number=): void} NumberCallback */
+/** @typedef {function((NodeJS.ErrnoException | null)=, IStats=): void} StatsCallback */
+/** @typedef {function((NodeJS.ErrnoException | Error | null)=, any=): void} ReadJsonCallback */
 
 /**
  * @typedef {Object} Watcher

--- a/types.d.ts
+++ b/types.d.ts
@@ -4383,30 +4383,30 @@ declare abstract class InitFragment {
 declare interface InputFileSystem {
 	readFile: (
 		arg0: string,
-		arg1: (arg0?: NodeJS.ErrnoException, arg1?: string | Buffer) => void
+		arg1: (arg0?: null | NodeJS.ErrnoException, arg1?: string | Buffer) => void
 	) => void;
 	readJson?: (
 		arg0: string,
-		arg1: (arg0?: Error | NodeJS.ErrnoException, arg1?: any) => void
+		arg1: (arg0?: null | Error | NodeJS.ErrnoException, arg1?: any) => void
 	) => void;
 	readlink: (
 		arg0: string,
-		arg1: (arg0?: NodeJS.ErrnoException, arg1?: string | Buffer) => void
+		arg1: (arg0?: null | NodeJS.ErrnoException, arg1?: string | Buffer) => void
 	) => void;
 	readdir: (
 		arg0: string,
 		arg1: (
-			arg0?: NodeJS.ErrnoException,
+			arg0?: null | NodeJS.ErrnoException,
 			arg1?: (string | Buffer)[] | IDirent[]
 		) => void
 	) => void;
 	stat: (
 		arg0: string,
-		arg1: (arg0?: NodeJS.ErrnoException, arg1?: IStats) => void
+		arg1: (arg0?: null | NodeJS.ErrnoException, arg1?: IStats) => void
 	) => void;
 	realpath?: (
 		arg0: string,
-		arg1: (arg0?: NodeJS.ErrnoException, arg1?: string | Buffer) => void
+		arg1: (arg0?: null | NodeJS.ErrnoException, arg1?: string | Buffer) => void
 	) => void;
 	purge?: (arg0?: string) => void;
 	join?: (arg0: string, arg1: string) => string;
@@ -4422,7 +4422,7 @@ declare interface IntermediateFileSystemExtras {
 	open: (
 		arg0: string,
 		arg1: string,
-		arg2: (arg0?: NodeJS.ErrnoException, arg1?: number) => void
+		arg2: (arg0?: null | NodeJS.ErrnoException, arg1?: number) => void
 	) => void;
 	read: (
 		arg0: number,
@@ -4430,13 +4430,16 @@ declare interface IntermediateFileSystemExtras {
 		arg2: number,
 		arg3: number,
 		arg4: number,
-		arg5: (arg0?: NodeJS.ErrnoException, arg1?: number) => void
+		arg5: (arg0?: null | NodeJS.ErrnoException, arg1?: number) => void
 	) => void;
-	close: (arg0: number, arg1: (arg0?: NodeJS.ErrnoException) => void) => void;
+	close: (
+		arg0: number,
+		arg1: (arg0?: null | NodeJS.ErrnoException) => void
+	) => void;
 	rename: (
 		arg0: string,
 		arg1: string,
-		arg2: (arg0?: NodeJS.ErrnoException) => void
+		arg2: (arg0?: null | NodeJS.ErrnoException) => void
 	) => void;
 }
 type InternalCell<T> = T | typeof TOMBSTONE | typeof UNDEFINED_MARKER;
@@ -7973,25 +7976,34 @@ declare interface OutputFileSystem {
 	writeFile: (
 		arg0: string,
 		arg1: string | Buffer,
-		arg2: (arg0?: NodeJS.ErrnoException) => void
+		arg2: (arg0?: null | NodeJS.ErrnoException) => void
 	) => void;
-	mkdir: (arg0: string, arg1: (arg0?: NodeJS.ErrnoException) => void) => void;
+	mkdir: (
+		arg0: string,
+		arg1: (arg0?: null | NodeJS.ErrnoException) => void
+	) => void;
 	readdir?: (
 		arg0: string,
 		arg1: (
-			arg0?: NodeJS.ErrnoException,
+			arg0?: null | NodeJS.ErrnoException,
 			arg1?: (string | Buffer)[] | IDirent[]
 		) => void
 	) => void;
-	rmdir?: (arg0: string, arg1: (arg0?: NodeJS.ErrnoException) => void) => void;
-	unlink?: (arg0: string, arg1: (arg0?: NodeJS.ErrnoException) => void) => void;
+	rmdir?: (
+		arg0: string,
+		arg1: (arg0?: null | NodeJS.ErrnoException) => void
+	) => void;
+	unlink?: (
+		arg0: string,
+		arg1: (arg0?: null | NodeJS.ErrnoException) => void
+	) => void;
 	stat: (
 		arg0: string,
-		arg1: (arg0?: NodeJS.ErrnoException, arg1?: IStats) => void
+		arg1: (arg0?: null | NodeJS.ErrnoException, arg1?: IStats) => void
 	) => void;
 	readFile: (
 		arg0: string,
-		arg1: (arg0?: NodeJS.ErrnoException, arg1?: string | Buffer) => void
+		arg1: (arg0?: null | NodeJS.ErrnoException, arg1?: string | Buffer) => void
 	) => void;
 	join?: (arg0: string, arg1: string) => string;
 	relative?: (arg0: string, arg1: string) => string;


### PR DESCRIPTION
Ref: #11630 
Fixes callback signature types for InputFileSystem and OutputFileSystem. Errors in the callback may be null, but were not marked as such. This PR fixes that.

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

not needed

**Does this PR introduce a breaking change?**

no

**What needs to be documented once your changes are merged?**

nothing
