### PR TITLE
Update browserslist in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@webassemblyjs/wasm-edit": "1.11.0",
     "@webassemblyjs/wasm-parser": "1.11.0",
     "acorn": "^8.2.1",
-    "browserslist": "^4.14.5",
+    "browserslist": "^4.16.6",
     "chrome-trace-event": "^1.0.2",
     "enhanced-resolve": "^5.8.0",
     "es-module-lexer": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1585,7 +1585,7 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-browserslist@^4.14.5:
+browserslist@^4.14.5, browserslist@^4.16.6:
   version "4.16.6"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.6.tgz#d7901277a5a88e554ed305b183ec9b0c08f66fa2"
   integrity sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==


### PR DESCRIPTION
I update `browserslist` in `package.json` so that CVE-2021-23364 will be fixed when we install `webpack` as a package.