### PR TITLE
Respect allowCollectingMemory setting (being normalized away right now)

### DIFF
--- a/lib/config/normalization.js
+++ b/lib/config/normalization.js
@@ -129,6 +129,7 @@ const getNormalizedWebpackOptions = config => {
 				case "filesystem":
 					return {
 						type: "filesystem",
+						allowCollectingMemory: cache.allowCollectingMemory,
 						maxMemoryGenerations: cache.maxMemoryGenerations,
 						maxAge: cache.maxAge,
 						profile: cache.profile,


### PR DESCRIPTION
Fixes #13491 13491
allowCollectingMemory is being normalized away in options normalization. Small fix to pass it through from config.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
no, if there are tests that could have caught this, can update

**Does this PR introduce a breaking change?**
no

**What needs to be documented once your changes are merged?**
no
