### PR TITLE
perf: Limit frequency of LazySet flattening by shortcircuiting empty LazySets

### DIFF
--- a/lib/util/LazySet.js
+++ b/lib/util/LazySet.js
@@ -106,12 +106,11 @@ class LazySet {
 			}
 		} else {
 			if (iterable instanceof LazySet) {
-				if (!iterable._isEmpty()) {
-					this._toDeepMerge.push(iterable);
-					this._needMerge = true;
-					if (this._toDeepMerge.length > 100000) {
-						this._flatten();
-					}
+				if (iterable._isEmpty()) return this;
+				this._toDeepMerge.push(iterable);
+				this._needMerge = true;
+				if (this._toDeepMerge.length > 100000) {
+					this._flatten();
 				}
 			} else {
 				this._toMerge.add(iterable);

--- a/lib/util/LazySet.js
+++ b/lib/util/LazySet.js
@@ -24,21 +24,17 @@ const merge = (targetSet, toMerge) => {
 /**
  * @template T
  * @param {Set<Iterable<T>>} targetSet set where iterables should be added
- * @param {Array<Iterable<T> | LazySet<T>>} toDeepMerge iterables or lazy set to be flattened
+ * @param {Array<LazySet<T>>} toDeepMerge lazy sets to be flattened
  * @returns {void}
  */
 const flatten = (targetSet, toDeepMerge) => {
 	for (const set of toDeepMerge) {
-		if (set instanceof LazySet) {
-			if (set._set.size > 0) targetSet.add(set._set);
-			if (set._needMerge) {
-				for (const mergedSet of set._toMerge) {
-					targetSet.add(mergedSet);
-				}
-				flatten(targetSet, set._toDeepMerge);
+		if (set._set.size > 0) targetSet.add(set._set);
+		if (set._needMerge) {
+			for (const mergedSet of set._toMerge) {
+				targetSet.add(mergedSet);
 			}
-		} else {
-			targetSet.add(set);
+			flatten(targetSet, set._toDeepMerge);
 		}
 	}
 };
@@ -58,7 +54,7 @@ class LazySet {
 		this._set = new Set(iterable);
 		/** @type {Set<Iterable<T>>} */
 		this._toMerge = new Set();
-		/** @type {Array<Iterable<T> | LazySet<T>>} */
+		/** @type {Array<LazySet<T>>} */
 		this._toDeepMerge = [];
 		this._needMerge = false;
 		this._deopt = false;
@@ -74,6 +70,14 @@ class LazySet {
 		merge(this._set, this._toMerge);
 		this._toMerge.clear();
 		this._needMerge = false;
+	}
+
+	_isEmpty() {
+		return (
+			this._set.size === 0 &&
+			this._toMerge.size === 0 &&
+			this._toDeepMerge.length === 0
+		);
 	}
 
 	get size() {
@@ -101,13 +105,19 @@ class LazySet {
 				_set.add(item);
 			}
 		} else {
-			this._toDeepMerge.push(iterable);
-			this._needMerge = true;
-			// Avoid being too memory hungry
-			if (this._toDeepMerge.length > 100000) {
-				this._flatten();
-				if (this._toMerge.size > 100000) this._merge();
+			if (iterable instanceof LazySet) {
+				if (!iterable._isEmpty()) {
+					this._toDeepMerge.push(iterable);
+					this._needMerge = true;
+					if (this._toDeepMerge.length > 100000) {
+						this._flatten();
+					}
+				}
+			} else {
+				this._toMerge.add(iterable);
+				this._needMerge = true;
 			}
+			if (this._toMerge.size > 100000) this._merge();
 		}
 		return this;
 	}

--- a/test/LazySet.unittest.js
+++ b/test/LazySet.unittest.js
@@ -1,0 +1,22 @@
+const LazySet = require("../lib/util/LazySet");
+
+describe("LazySet", () => {
+	it("addAll", () => {
+		const a = new Set(["a"]);
+		const sut = new LazySet(a);
+		const empty = new LazySet([]);
+		expect(sut.size).toBe(1);
+		sut.addAll(empty);
+		expect(sut._toDeepMerge).toStrictEqual([]);
+		expect(sut.size).toBe(1);
+		const b = new Set(["b"]);
+		sut.addAll(b);
+		expect(sut._toMerge).toContain(b);
+		expect(sut.size).toBe(2);
+		const c = new LazySet(["c"]);
+		sut.addAll(c);
+		expect(sut._toDeepMerge).toContain(c);
+		expect(sut.size).toBe(3);
+		expect(sut._toDeepMerge).toStrictEqual([]);
+	});
+});


### PR DESCRIPTION
Closes #13573
The summarizeDependencies call is very expensive in large projects because of the huge merge/flatten cycle required by LazySet. I notice that many of these LazySets are empty, so lets short circuit those to limit the number of times the `size > 100000` trigger is met for merging.

**What kind of change does this PR introduce?**
performance improvement to LazySet in large projects

**Did you add tests for your changes?**
yep, and also regressions show in multiple tests due to high usage of LazySet

**Does this PR introduce a breaking change?**
no

**What needs to be documented once your changes are merged?**
no