### PR TITLE
Correct emitFile content argument type

### DIFF
--- a/declarations/LoaderContext.d.ts
+++ b/declarations/LoaderContext.d.ts
@@ -31,7 +31,7 @@ export interface NormalModuleLoaderContext<OptionsType> {
 		((context: string, request: string) => Promise<string>);
 	emitFile(
 		name: string,
-		content: string,
+		content: string | Buffer,
 		sourceMap?: string,
 		assetInfo?: AssetInfo
 	): void;

--- a/types.d.ts
+++ b/types.d.ts
@@ -7203,7 +7203,7 @@ declare interface NormalModuleLoaderContext<OptionsType> {
 	};
 	emitFile(
 		name: string,
-		content: string,
+		content: string | Buffer,
 		sourceMap?: string,
 		assetInfo?: AssetInfo
 	): void;


### PR DESCRIPTION
As stated in the [documentation](https://webpack.js.org/api/loaders/#thisemitfile), and proven in practice, `emitFile` accepts a buffer for the content argument. Currently, passing one results in a type error. This corrects the argument type.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bug fix

**Did you add tests for your changes?**

No

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing, this updates the type to match the documentation.
