### PR TITLE
cleanup: gitignore examples/node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules
+/examples/node_modules
 /test/js
 /test/browsertest/js
 /test/fixtures/temp-*


### PR DESCRIPTION
After building examples, git status shows lots of untracked files under examples/node_modules. This fixes that.

(The leading slash is unnecessary for a line containing slash, but I kept it for consistency with other lines in this .gitignore)

**What kind of change does this PR introduce?**

Housekeeping.

**Did you add tests for your changes?**

Not applicable.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

Nothing.