### PR TITLE
respect entry-specific library.type when exposing system context

### DIFF
--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -218,7 +218,15 @@ class RuntimePlugin {
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.systemContext)
 				.tap("RuntimePlugin", chunk => {
-					if (compilation.outputOptions.library.type === "system") {
+					const { outputOptions } = compilation;
+					const { library: globalLibrary } = outputOptions;
+					const entryOptions = chunk.getEntryOptions();
+					const libraryType =
+						entryOptions && entryOptions.library !== undefined
+							? entryOptions.library.type
+							: globalLibrary.type;
+
+					if (libraryType === "system") {
 						compilation.addRuntimeModule(
 							chunk,
 							new SystemContextRuntimeModule()

--- a/test/configCases/entry/issue-13637/index-system.js
+++ b/test/configCases/entry/issue-13637/index-system.js
@@ -1,0 +1,8 @@
+// This test verifies that the System.register context is made available to webpack bundles
+
+it("should be able to use the System.register context in entries where library.type is system", function() {
+  expect(__system_context__).toBeTruthy();
+  expect(__system_context__.meta).toBeTruthy();
+  expect(typeof __system_context__.import).toBe("function");
+  expect(typeof __system_context__.meta.url).toBe("string");
+});

--- a/test/configCases/entry/issue-13637/index-umd.js
+++ b/test/configCases/entry/issue-13637/index-umd.js
@@ -1,0 +1,5 @@
+// This test verifies that the System.register context is not available for non-system entries
+
+it("should not be able to use the System.register context in entries where library.type is not system", function() {
+  expect(__system_context__).toBeUndefined();
+});

--- a/test/configCases/entry/issue-13637/test.config.js
+++ b/test/configCases/entry/issue-13637/test.config.js
@@ -1,0 +1,16 @@
+const System = require("../../../helpers/fakeSystem");
+
+module.exports = {
+	beforeExecute: () => {
+		System.init();
+	},
+	moduleScope(scope) {
+		scope.System = System;
+	},
+	afterExecute: () => {
+		System.execute("(anonym)");
+	},
+	findBundle: function () {
+		return ["./main.system.js", "./main.umd.js"];
+	}
+};

--- a/test/configCases/entry/issue-13637/webpack.config.js
+++ b/test/configCases/entry/issue-13637/webpack.config.js
@@ -1,0 +1,23 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		"main-system": {
+			import: "./index-system.js",
+			library: {
+				type: "system"
+			},
+			filename: "main.system.js"
+		},
+		"main-umd": {
+			import: "./index-umd.js",
+			library: {
+				type: "umd"
+			},
+			filename: "main.umd.js"
+		}
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};

--- a/test/configCases/target/system-context/webpack.config.js
+++ b/test/configCases/target/system-context/webpack.config.js
@@ -1,7 +1,9 @@
 /** @type {import("../../../../").Configuration} */
 module.exports = {
 	output: {
-		libraryTarget: "system"
+		library: {
+			type: "system"
+		}
 	},
 	node: {
 		__dirname: false,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fixes #13637. The `__system_context__` injection was not working when using entries with different `library.type` values.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
