### PR TITLE
fix memory leak when using the unsafe cache

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -260,6 +260,8 @@ class Compiler {
 
 		/** @type {Compilation} */
 		this._lastCompilation = undefined;
+		/** @type {NormalModuleFactory} */
+		this._lastNormalModuleFactory = undefined;
 
 		/** @private @type {WeakMap<Source, { sizeOnlySource: SizeOnlySource, writtenTo: Map<string, number> }>} */
 		this._assetEmittingSourceCache = new WeakMap();
@@ -372,6 +374,14 @@ class Compiler {
 				ChunkGraph.clearChunkGraphForChunk(chunk);
 			}
 			this._lastCompilation = undefined;
+		}
+	}
+
+	// TODO webpack 6: solve this in a better way
+	_cleanupLastNormalModuleFactory() {
+		if (this._lastNormalModuleFactory !== undefined) {
+			this._lastNormalModuleFactory.cleanupForCache();
+			this._lastNormalModuleFactory = undefined;
 		}
 	}
 
@@ -1036,6 +1046,7 @@ ${other}`);
 	}
 
 	createNormalModuleFactory() {
+		this._cleanupLastNormalModuleFactory();
 		const normalModuleFactory = new NormalModuleFactory({
 			context: this.options.context,
 			fs: this.inputFileSystem,
@@ -1044,6 +1055,7 @@ ${other}`);
 			associatedObjectForCache: this.root,
 			layers: this.options.experiments.layers
 		});
+		this._lastNormalModuleFactory = normalModuleFactory;
 		this.hooks.normalModuleFactory.call(normalModuleFactory);
 		return normalModuleFactory;
 	}
@@ -1122,8 +1134,9 @@ ${other}`);
 			if (err) return callback(err);
 			// Get rid of reference to last compilation to avoid leaking memory
 			// We can't run this._cleanupLastCompilation() as the Stats to this compilation
-			// might be still in use. We try to get rid for the reference to the cache instead.
+			// might be still in use. We try to get rid of the reference to the cache instead.
 			this._lastCompilation = undefined;
+			this._lastNormalModuleFactory = undefined;
 			this.cache.shutdown(callback);
 		});
 	}

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -13,8 +13,10 @@ const {
 	SyncHook,
 	HookMap
 } = require("tapable");
+const ChunkGraph = require("./ChunkGraph");
 const Module = require("./Module");
 const ModuleFactory = require("./ModuleFactory");
+const ModuleGraph = require("./ModuleGraph");
 const NormalModule = require("./NormalModule");
 const BasicEffectRulePlugin = require("./rules/BasicEffectRulePlugin");
 const BasicMatcherRulePlugin = require("./rules/BasicMatcherRulePlugin");
@@ -257,8 +259,8 @@ class NormalModuleFactory extends ModuleFactory {
 		this.parserCache = new Map();
 		/** @type {Map<string, WeakMap<Object, Generator>>} */
 		this.generatorCache = new Map();
-		/** @type {WeakSet<Module>} */
-		this._restoredUnsafeCacheEntries = new WeakSet();
+		/** @type {Set<Module>} */
+		this._restoredUnsafeCacheEntries = new Set();
 
 		const cacheParseResource = parseResource.bindCache(
 			associatedObjectForCache
@@ -659,6 +661,14 @@ class NormalModuleFactory extends ModuleFactory {
 				}
 			}
 		);
+	}
+
+	cleanupForCache() {
+		for (const module of this._restoredUnsafeCacheEntries) {
+			ChunkGraph.clearChunkGraphForModule(module);
+			ModuleGraph.clearModuleGraphForModule(module);
+			module.cleanupForCache();
+		}
 	}
 
 	/**

--- a/types.d.ts
+++ b/types.d.ts
@@ -7198,6 +7198,7 @@ declare abstract class NormalModuleFactory extends ModuleFactory {
 	fs: InputFileSystem;
 	parserCache: Map<string, WeakMap<Object, any>>;
 	generatorCache: Map<string, WeakMap<Object, Generator>>;
+	cleanupForCache(): void;
 	resolveResource(
 		contextInfo?: any,
 		context?: any,


### PR DESCRIPTION
this is a workaround to remove compilation-specific references from modules in the unsafe cache

I'm not proud of this solution, but it fixes it for now
Long term we might move these kind of references out of the module
into some kind of compilation/module graph specific store.
But that's not yet possible for backward-compat reasons.

#13127

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
