### PR TITLE
getSize() throws errors if no module.buildInfo

### DIFF
--- a/lib/json/JsonGenerator.js
+++ b/lib/json/JsonGenerator.js
@@ -116,7 +116,9 @@ class JsonGenerator extends Generator {
 	 * @returns {number} estimate size of the module
 	 */
 	getSize(module, type) {
-		let data = module.buildInfo.jsonData;
+		const buildInfo = module.buildInfo;
+		if (!buildInfo) return 0;
+		let data = buildInfo.jsonData;
 		if (!data) return 0;
 		return stringifySafe(data).length + 10;
 	}


### PR DESCRIPTION
Building my project, I can see that sometimes a module has no buildInfo. In this case, it would be better to also return a size = 0 than to throw an error. 

I currently experience these errors a lot, which disappear with this simple fix: 

>> [...]/node_modules/webpack/lib/json/JsonGenerator.js:119
>>   let data = module.buildInfo.jsonData;
>>                                               ^
>>   TypeError: Cannot read property 'jsonData' of undefined

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
