### PR TITLE
add `"...": DELETE` syntax to delete properties during merge

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -541,6 +541,15 @@ module.exports = mergeExports(fn, {
 		get cleverMerge() {
 			return require("./util/cleverMerge").cachedCleverMerge;
 		},
+		get DELETE() {
+			return require("./util/cleverMerge").DELETE;
+		},
+		get setProperty() {
+			return require("./util/cleverMerge").cachedSetProperty;
+		},
+		get removeOperations() {
+			return require("./util/cleverMerge").removeOperations;
+		},
 		get LazySet() {
 			return require("./util/LazySet");
 		}

--- a/lib/util/cleverMerge.js
+++ b/lib/util/cleverMerge.js
@@ -134,6 +134,8 @@ const parseObject = obj => {
 				for (const byValue of Object.keys(byObj)) {
 					const obj = byObj[byValue];
 					for (const key of Object.keys(obj)) {
+						const value = obj[key];
+						if (value === undefined) continue;
 						const entry = getInfo(key);
 						if (entry.byProperty === undefined) {
 							entry.byProperty = byProperty;
@@ -164,12 +166,18 @@ const parseObject = obj => {
 					);
 				}
 			} else {
-				const entry = getInfo(key);
-				entry.base = obj[key];
+				const value = obj[key];
+				if (value !== undefined) {
+					const entry = getInfo(key);
+					entry.base = value;
+				}
 			}
 		} else {
-			const entry = getInfo(key);
-			entry.base = obj[key];
+			const value = obj[key];
+			if (value !== undefined) {
+				const entry = getInfo(key);
+				entry.base = value;
+			}
 		}
 	}
 	return {
@@ -271,7 +279,7 @@ const _cleverMerge = (first, second, internalCaching = false) => {
 	const firstObject = internalCaching
 		? cachedParseObject(first)
 		: parseObject(first);
-	const { static: firstInfo, dynamic: firstDynamicInfo } = firstObject;
+	let { static: firstInfo, dynamic: firstDynamicInfo } = firstObject;
 
 	// If the first argument has a dynamic part we modify the dynamic part to merge the second argument
 	if (firstDynamicInfo !== undefined) {
@@ -298,6 +306,19 @@ const _cleverMerge = (first, second, internalCaching = false) => {
 		? cachedParseObject(second)
 		: parseObject(second);
 	const { static: secondInfo, dynamic: secondDynamicInfo } = secondObject;
+	const overrideEntry = secondInfo.get("...");
+	if (overrideEntry) {
+		if (overrideEntry.base === DELETE) {
+			return serializeObject(secondInfo, secondDynamicInfo);
+		}
+		firstInfo = new Map(firstInfo);
+		for (const [key, firstEntry] of firstInfo) {
+			firstInfo.set(
+				key,
+				mergeEntries(firstEntry, overrideEntry, internalCaching)
+			);
+		}
+	}
 	/** @type {Map<string, ObjectParsedPropertyEntry>} */
 	const resultInfo = new Map();
 	for (const [key, firstEntry] of firstInfo) {
@@ -339,6 +360,7 @@ const mergeEntries = (firstEntry, secondEntry, internalCaching) => {
 					byValues: secondEntry.byValues
 				};
 			} else if (firstEntry.byProperty !== secondEntry.byProperty) {
+				console.log(firstEntry, secondEntry);
 				throw new Error(
 					`${firstEntry.byProperty} and ${secondEntry.byProperty} for a single property is not supported`
 				);
@@ -505,6 +527,7 @@ const mergeSingleValue = (a, b, internalCaching) => {
 const removeOperations = obj => {
 	const newObj = /** @type {T} */ ({});
 	for (const key of Object.keys(obj)) {
+		if (key === "...") continue;
 		const value = obj[key];
 		const type = getValueType(value);
 		switch (type) {

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -761,6 +761,9 @@
       "description": "Specify dependency that shouldn't be resolved by webpack, but should become dependencies of the resulting bundle. The kind of the dependency depends on `output.libraryTarget`.",
       "anyOf": [
         {
+          "type": "symbol"
+        },
+        {
           "description": "Every matched dependency becomes external.",
           "instanceof": "RegExp",
           "tsType": "RegExp"

--- a/test/cleverMerge.unittest.js
+++ b/test/cleverMerge.unittest.js
@@ -520,6 +520,57 @@ describe("cleverMerge", () => {
 				}
 			}
 		],
+		"clear objects": [
+			{
+				nested1: base,
+				nested2: base,
+				nested3: {
+					a: 1,
+					b: 2,
+					c: 3
+				},
+				nested4: {
+					a: 1,
+					b: 2,
+					c: 3
+				}
+			},
+			{
+				nested1: {
+					"...": DELETE
+				},
+				nested2: {
+					"...": undefined
+				},
+				nested3: {
+					a: 11,
+					"...": DELETE,
+					c: 33
+				},
+				nested4: {
+					a: 11,
+					"...": 0,
+					c: 33
+				}
+			},
+			{
+				nested1: {
+					"...": DELETE
+				},
+				nested2: base,
+				nested3: {
+					a: 11,
+					"...": DELETE,
+					c: 33
+				},
+				nested4: {
+					a: 11,
+					b: 0,
+					c: 33,
+					"...": 0
+				}
+			}
+		],
 		dynamicSecond: [
 			{
 				a: 4, // keep

--- a/test/configCases/externals/delete-by-layer/a.js
+++ b/test/configCases/externals/delete-by-layer/a.js
@@ -1,0 +1,3 @@
+it("should define the external", () => {
+	expect(require("external")).toBe(Array.isArray);
+});

--- a/test/configCases/externals/delete-by-layer/b.js
+++ b/test/configCases/externals/delete-by-layer/b.js
@@ -1,0 +1,3 @@
+it("should not define the external", () => {
+	expect(require("external")).toBe("internal");
+});

--- a/test/configCases/externals/delete-by-layer/node_modules/external.js
+++ b/test/configCases/externals/delete-by-layer/node_modules/external.js
@@ -1,0 +1,1 @@
+module.exports = "internal"

--- a/test/configCases/externals/delete-by-layer/test.config.js
+++ b/test/configCases/externals/delete-by-layer/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["./a.js", "./b.js"];
+	}
+};

--- a/test/configCases/externals/delete-by-layer/webpack.config.js
+++ b/test/configCases/externals/delete-by-layer/webpack.config.js
@@ -1,0 +1,25 @@
+const webpack = require("../../../../");
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		a: "./a",
+		b: {
+			import: "./b",
+			layer: "someLayer"
+		}
+	},
+	output: {
+		filename: "[name].js"
+	},
+	externals: {
+		external: ["Array", "isArray"],
+		byLayer: {
+			someLayer: {
+				"...": webpack.util.DELETE
+			}
+		}
+	},
+	experiments: {
+		layers: true
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

blocked by ajv supporting `"type": "symbol"`


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
In all merged objects the special key `"..."` can be used to override all existing keys. `webpack.utils.DELETE` can be used as value for this key or all others to remove a property.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
