### PR TITLE
fix: fixed work of the non-system type externals for "system" library target

### DIFF
--- a/lib/library/SystemLibraryPlugin.js
+++ b/lib/library/SystemLibraryPlugin.js
@@ -72,7 +72,7 @@ class SystemLibraryPlugin extends AbstractLibraryPlugin {
 	render(source, { chunkGraph, moduleGraph, chunk }, { options, compilation }) {
 		const modules = chunkGraph
 			.getChunkModules(chunk)
-			.filter(m => m instanceof ExternalModule);
+			.filter(m => m instanceof ExternalModule && m.externalType === "system");
 		const externals = /** @type {ExternalModule[]} */ (modules);
 
 		// The name this bundle should be registered as with System

--- a/test/configCases/externals/externals-system-custom/index.js
+++ b/test/configCases/externals/externals-system-custom/index.js
@@ -1,0 +1,7 @@
+// This test verifies that the System.register context is made available to webpack bundles
+
+it("should correctly handle externals of different type", function() {
+	expect(require("rootExt")).toEqual("works");
+	expect(require("varExt")).toEqual("works");
+	expect(require("windowExt")).toEqual("works");
+});

--- a/test/configCases/externals/externals-system-custom/test.config.js
+++ b/test/configCases/externals/externals-system-custom/test.config.js
@@ -1,0 +1,17 @@
+const System = require("../../../helpers/fakeSystem");
+
+module.exports = {
+	target: 'web',
+	beforeExecute: () => {
+		System.init();
+	},
+	moduleScope(scope) {
+		scope.window.windowExt = 'works';
+		scope.rootExt = 'works';
+		scope.varExt = 'works';
+		scope.System = System;
+	},
+	afterExecute: () => {
+		System.execute("(anonym)");
+	}
+};

--- a/test/configCases/externals/externals-system-custom/webpack.config.js
+++ b/test/configCases/externals/externals-system-custom/webpack.config.js
@@ -1,0 +1,16 @@
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	output: {
+		libraryTarget: "system"
+	},
+	target: "web",
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	externals: {
+		rootExt: "root rootExt",
+		varExt: "var varExt",
+		windowExt: "window windowExt"
+	}
+};


### PR DESCRIPTION
Hi!
This tiny change makes externals with custom type specified work correctly with "system" library target.

Now they only work with "umd" library target because of these lines:
https://github.com/webpack/webpack/blob/c181294865dca01b28e6e316636fef5f2aad4eb6/lib/library/UmdLibraryPlugin.js#L126-L133

I see similar issue with AMD bundle type too, but let's start with System.js first ;)

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

yes

**Does this PR introduce a breaking change?**

I believe not :)

**What needs to be documented once your changes are merged?**

Nothing :)
