### PR TITLE
fix: fixed work of the non-system type externals for "system" library…

### DIFF
--- a/lib/SystemMainTemplatePlugin.js
+++ b/lib/SystemMainTemplatePlugin.js
@@ -31,7 +31,9 @@ class SystemMainTemplatePlugin {
 		const { mainTemplate, chunkTemplate } = compilation;
 
 		const onRenderWithEntry = (source, chunk, hash) => {
-			const externals = chunk.getModules().filter(m => m.external);
+			const externals = chunk
+				.getModules()
+				.filter(m => m.external && m.externalType === "system");
 
 			// The name this bundle should be registered as with System
 			const name = this.name

--- a/test/configCases/externals/externals-system-custom/index.js
+++ b/test/configCases/externals/externals-system-custom/index.js
@@ -1,0 +1,8 @@
+/* This test verifies that webpack externals that have different to System type are properly
+ * accessible within System.js bundle.
+ */
+it("should correctly handle externals of different type", function() {
+	expect(require("rootExt")).toEqual("works");
+	expect(require("varExt")).toEqual("works");
+	expect(require("windowExt")).toEqual("works");
+});

--- a/test/configCases/externals/externals-system-custom/test.config.js
+++ b/test/configCases/externals/externals-system-custom/test.config.js
@@ -1,0 +1,16 @@
+const System = require("../../../helpers/fakeSystem");
+
+module.exports = {
+	beforeExecute: () => {
+		System.init();
+	},
+	moduleScope(scope) {
+		scope.window.windowExt = "works";
+		scope.rootExt = "works";
+		scope.varExt = "works";
+		scope.System = System;
+	},
+	afterExecute: () => {
+		System.execute("(anonym)");
+	}
+};

--- a/test/configCases/externals/externals-system-custom/webpack.config.js
+++ b/test/configCases/externals/externals-system-custom/webpack.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	output: {
+		libraryTarget: "system"
+	},
+	target: "web",
+	externals: {
+		rootExt: "root rootExt",
+		varExt: "var varExt",
+		windowExt: "window windowExt"
+	}
+};


### PR DESCRIPTION
Hi!
This is a backport of the #13754 PR to v4 branch.

Remainder of the changes description:

This tiny change makes externals with custom type specified work correctly with "system" library target.

Now they only work with "umd" library target because of these lines:
https://github.com/webpack/webpack/blob/c181294865dca01b28e6e316636fef5f2aad4eb6/lib/library/UmdLibraryPlugin.js#L126-L133

I see similar issue with AMD bundle type too, but let's start with System.js first ;)

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

yes

**Does this PR introduce a breaking change?**

I believe not :)

**What needs to be documented once your changes are merged?**

Nothing :)
