### PR TITLE
fix:13797 Pass shareScope to ContainerPugin via ModeuleFederationPlugin

### DIFF
--- a/lib/container/ModuleFederationPlugin.js
+++ b/lib/container/ModuleFederationPlugin.js
@@ -65,7 +65,8 @@ class ModuleFederationPlugin {
 					library,
 					filename: options.filename,
 					runtime: options.runtime,
-					exposes: options.exposes
+					exposes: options.exposes,
+					shareScope: options.shareScope
 				}).apply(compiler);
 			}
 			if (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This is to resolve #13797
This enables `ModuleFederationPlugin` to pass the `shareScope` prop down to `ContainerPlugin` which already knows how to handle it further.

**Motivation**
My office is currently discussing Microfrontends and various alternatives to implement the same. Webpack ModuleFederation was one of the option being discussed. Since ModuleFederation is fairly new, I had my doubts if we could use this and rely on it for our usecase. And so I was trying to read as much about it as I can. During this, I was also checking issues people were facing while using it which led me to #13797 which seemed like a crucial but easy to fix bug.
While that's how I came across this, this is my **first commit** to a open, community driven and public repository. So I'm bit on my nerves raising this PR. Do help me if I'm missing on any tradition. Thanks.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Bigfix for issue #13797 wherein ModuleFederationPlugin was not passing down options.shareScope to ContainerPlugin.
Since ContainerPlugin already accepts and handles`shareScope` as required, no extra changes required on top of it.

**Did you add tests for your changes?**

This does not appear to require any. I ran all existing tests post my changes. Do advice if tests are still needed.

**Does this PR introduce a breaking change?**

Hopefully not.

**What needs to be documented once your changes are merged?**

Ideally, nothing. This just adds what was expected already.

