### PR TITLE
Allow initialising a container with a named share scope

### DIFF
--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -217,12 +217,13 @@ class ContainerEntryModule extends Module {
 			])};`,
 			`var init = ${runtimeTemplate.basicFunction("shareScope, initScope", [
 				`if (!${RuntimeGlobals.shareScopeMap}) return;`,
-				`var oldScope = ${RuntimeGlobals.shareScopeMap}[${JSON.stringify(
+				`var isOptionsObject = shareScope && typeof shareScope.name === "string" && typeof shareScope.shareScope === "object"`,
+				`var name = isOptionsObject ? shareScope.name : ${JSON.stringify(
 					this._shareScope
-				)}];`,
-				`var name = ${JSON.stringify(this._shareScope)}`,
+				)}`,
+				`var oldScope = ${RuntimeGlobals.shareScopeMap}[name];`,
 				`if(oldScope && oldScope !== shareScope) throw new Error("Container initialization failed as it has already been initialized with a different share scope");`,
-				`${RuntimeGlobals.shareScopeMap}[name] = shareScope;`,
+				`${RuntimeGlobals.shareScopeMap}[name] = isOptionsObject ? shareScope.shareScope : shareScope;`,
 				`return ${RuntimeGlobals.initializeSharing}(name, initScope);`
 			])};`,
 			"",

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -1433,7 +1433,7 @@ webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for module-federation-custom-exposed-module-name 1`] = `
-"asset container_bundle.js 11.8 KiB [emitted] (name: container)
+"asset container_bundle.js 12 KiB [emitted] (name: container)
 asset custom-entry_bundle.js 414 bytes [emitted] (name: custom-entry)
 asset main_bundle.js 84 bytes [emitted] (name: main)
 runtime modules 6.52 KiB 9 modules

--- a/test/configCases/container/initialize-custom-share-scope/index.js
+++ b/test/configCases/container/initialize-custom-share-scope/index.js
@@ -1,0 +1,31 @@
+it("should allow sharing between share scopes", async () => {
+	await __webpack_init_sharing__("default");
+	await __webpack_init_sharing__("example");
+
+	const container1 = __non_webpack_require__("./container1.js");
+	await container1.init({
+		name: "default",
+		shareScope: __webpack_share_scopes__.default
+	});
+	await container1.init({
+		name: "example",
+		shareScope: __webpack_share_scopes__.example
+	});
+	const moduleFactory1 = await container1.get("./module");
+	const module1 = moduleFactory1();
+
+	const container2 = __non_webpack_require__("./container2.js");
+	await container2.init({
+		name: "default",
+		shareScope: __webpack_share_scopes__.default
+	});
+	await container2.init({
+		name: "example",
+		shareScope: __webpack_share_scopes__.example
+	});
+	const moduleFactory2 = await container2.get("./module");
+	const module2 = moduleFactory2();
+
+	expect(module1.default).toBeDefined();
+	expect(module1.default).toBe(module2.default);
+});

--- a/test/configCases/container/initialize-custom-share-scope/module.js
+++ b/test/configCases/container/initialize-custom-share-scope/module.js
@@ -1,0 +1,1 @@
+export { default } from "package";

--- a/test/configCases/container/initialize-custom-share-scope/node_modules/package.js
+++ b/test/configCases/container/initialize-custom-share-scope/node_modules/package.js
@@ -1,0 +1,3 @@
+module.exports = {
+  unique: Math.random()
+};

--- a/test/configCases/container/initialize-custom-share-scope/webpack.config.js
+++ b/test/configCases/container/initialize-custom-share-scope/webpack.config.js
@@ -1,0 +1,39 @@
+const { ModuleFederationPlugin } = require("../../../../").container;
+
+/** @type {import("../../../../").Configuration} */
+module.exports = [
+	{
+		plugins: [
+			new ModuleFederationPlugin({
+				name: "container1",
+				filename: "container1.js",
+				library: { type: "commonjs-module" },
+				exposes: ["./module"],
+				shared: {
+					package: {
+						version: "1.0.0",
+						requiredVersion: "1.0.0",
+						shareScope: "example"
+					}
+				}
+			})
+		]
+	},
+	{
+		plugins: [
+			new ModuleFederationPlugin({
+				name: "container2",
+				filename: "container2.js",
+				library: { type: "commonjs-module" },
+				exposes: ["./module"],
+				shared: {
+					package: {
+						version: "1.0.0",
+						requiredVersion: "1.0.0",
+						shareScope: "example"
+					}
+				}
+			})
+		]
+	}
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fixes #13834

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

It should be fully backwards compatible. You can still do,

```js
container.init(__webpack_share_scopes__.default);
```

In addition to the new form,


```js
container.init({
  name: 'default',
  shareScope: __webpack_share_scopes__.default
});
```

The new object format is strict to achieve backwards compatibility - it **must** have a string for `name` and an object for `shareScope`.

**What needs to be documented once your changes are merged?**

We could give an example of the new container init form in https://webpack.js.org/concepts/module-federation/#dynamic-remote-containers