### PR TITLE
Fix generator publicPath behavior when empty string

### DIFF
--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -229,7 +229,7 @@ class AssetGenerator extends Generator {
 							}
 						);
 					let publicPath;
-					if (this.publicPath) {
+					if (this.publicPath !== undefined) {
 						const { path, info } =
 							runtimeTemplate.compilation.getAssetPathWithInfo(
 								this.publicPath,

--- a/test/configCases/asset-modules/rule-generator-publicPath-override/index.js
+++ b/test/configCases/asset-modules/rule-generator-publicPath-override/index.js
@@ -1,0 +1,5 @@
+import url from "../_images/file.png";
+
+it("should import asset with empty string rule.generator.publicPath", () => {
+	expect(url).toEqual("file.png");
+});

--- a/test/configCases/asset-modules/rule-generator-publicPath-override/webpack.config.js
+++ b/test/configCases/asset-modules/rule-generator-publicPath-override/webpack.config.js
@@ -1,0 +1,19 @@
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	mode: "development",
+	output: {
+		assetModuleFilename: "file[ext]",
+		publicPath: "assets/"
+	},
+	module: {
+		rules: [
+			{
+				test: /\.png$/,
+				type: "asset",
+				generator: {
+					publicPath: ""
+				}
+			}
+		]
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Fixing the second issue described in this PR https://github.com/vercel/next.js/pull/27413#issue-695368311
empty string in `rule.generator.publicPath` gets ignored.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

yep

**Does this PR introduce a breaking change?**

nope

**What needs to be documented once your changes are merged?**

nothing
