### PR TITLE
Pass module to `compilation.addModuleChain()` callback when applicable

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1839,13 +1839,15 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 				contextInfo,
 				context
 			},
-			err => {
+			(err, result) => {
 				if (err && this.bail) {
 					callback(err);
 					this.buildQueue.stop();
 					this.rebuildQueue.stop();
 					this.processDependenciesQueue.stop();
 					this.factorizeQueue.stop();
+				} else if (!err && result) {
+					callback(null, result);
 				} else {
 					callback();
 				}


### PR DESCRIPTION
Although the callbacks for the `addModuleChain` and `addModuleTree` methods are of type `ModuleCallback`, the `result` parameter is always `undefined`. We are migrating some internal plugins from webpack 4 that use the `compilation._addModuleChain` method and rely on the callback to get the created module.

Thanks.

**What kind of change does this PR introduce?**

This fixes inconsistency between types and implementation. I'm not sure it's a bugfix since nothing internally was relying on the `result` parameter but it doesn't seem like a feature.

**Did you add tests for your changes?**

I did not add tests but I am open to recommendations about what to test here.

**Does this PR introduce a breaking change?**

This change should be backwards compatible and all of the `compilation.addModuleChain` usage within webpack only checks for the `err` parameter.

**What needs to be documented once your changes are merged?**

No documentation changes are needed and the types will be more accurate since `result` will now actually be populated
