### PR TITLE
Fix spelling of `dependOn` in the SplitChunksPlugin

### DIFF
--- a/lib/optimize/SplitChunksPlugin.js
+++ b/lib/optimize/SplitChunksPlugin.js
@@ -1073,7 +1073,7 @@ module.exports = class SplitChunksPlugin {
 												"SplitChunksPlugin\n" +
 													`Cache group "${cacheGroup.key}" conflicts with existing chunk.\n` +
 													`Both have the same name "${name}" and existing chunk is not a parent of the selected modules.\n` +
-													"Use a different name for the cache group or make sure that the existing chunk is a parent (e. g. via dependsOn).\n" +
+													"Use a different name for the cache group or make sure that the existing chunk is a parent (e. g. via dependOn).\n" +
 													'HINT: You can omit "name" to automatically create a name.\n' +
 													"BREAKING CHANGE: webpack < 5 used to allow to use an entrypoint as splitChunk. " +
 													"This is no longer allowed when the entrypoint is not a parent of the selected modules.\n" +


### PR DESCRIPTION
**What kind of change does this PR introduce?**

The help text suggests using `dependsOn`, but the `s` is a typo.

The correct property is called `dependOn`: https://webpack.js.org/concepts/entry-points/#entrydescription-object

**Did you add tests for your changes?**

None needed.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

Nothing.