### PR TITLE
Set port 41000 for lazy compilation backend

### DIFF
--- a/lib/hmr/lazyCompilationBackend.js
+++ b/lib/hmr/lazyCompilationBackend.js
@@ -63,7 +63,7 @@ module.exports = (compiler, client, callback) => {
 		});
 		if (isClosing) socket.destroy();
 	});
-	server.listen(err => {
+	server.listen(41000, err => {
 		if (err) return callback(err);
 		const addr = server.address();
 		if (typeof addr === "string") throw new Error("addr must not be a string");


### PR DESCRIPTION
Instead of using a random port, defining a port 41000. Due this it can be used in a server, where the ports are closed by default  (ie: Docker).

Link to the issue: https://github.com/webpack/webpack/issues/14053


**What kind of change does this PR introduce?**

feature improvement

**Did you add tests for your changes?**

No, there were no underlying tests related to it afaik. 

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

https://webpack.js.org/configuration/experiments/#experimentslazycompilation - add a note. The Lazy Compilation Backend will be running on port 41000. 
