### PR TITLE
fix: safeguard against `undefined` entry

### DIFF
--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -1161,9 +1161,10 @@ class FileSystemInfo {
 		if (cache !== undefined) {
 			const resolved = getResolvedTimestamp(cache);
 			if (resolved !== undefined) return callback(null, resolved);
-			this._resolveContextTimestamp(cache, callback);
+			return this._resolveContextTimestamp(cache, callback);
 		}
 		this.contextTimestampQueue.add(path, (err, entry) => {
+			if (err) return callback(err);
 			const resolved = getResolvedTimestamp(entry);
 			if (resolved !== undefined) return callback(null, resolved);
 			this._resolveContextTimestamp(entry, callback);
@@ -1178,9 +1179,7 @@ class FileSystemInfo {
 	_getUnresolvedContextTimestamp(path, callback) {
 		const cache = this._contextTimestamps.get(path);
 		if (cache !== undefined) return callback(null, cache);
-		this.contextTimestampQueue.add(path, (err, entry) => {
-			return callback(null, entry);
-		});
+		this.contextTimestampQueue.add(path, callback);
 	}
 
 	/**
@@ -1204,9 +1203,10 @@ class FileSystemInfo {
 		if (cache !== undefined) {
 			const resolved = getResolvedHash(cache);
 			if (resolved !== undefined) return callback(null, resolved);
-			this._resolveContextHash(cache, callback);
+			return this._resolveContextHash(cache, callback);
 		}
 		this.contextHashQueue.add(path, (err, entry) => {
+			if (err) return callback(err);
 			const resolved = getResolvedHash(entry);
 			if (resolved !== undefined) return callback(null, resolved);
 			this._resolveContextHash(entry, callback);
@@ -1221,9 +1221,7 @@ class FileSystemInfo {
 	_getUnresolvedContextHash(path, callback) {
 		const cache = this._contextHashes.get(path);
 		if (cache !== undefined) return callback(null, cache);
-		this.contextHashQueue.add(path, (err, entry) => {
-			return callback(null, entry);
-		});
+		this.contextHashQueue.add(path, callback);
 	}
 
 	/**
@@ -1236,9 +1234,10 @@ class FileSystemInfo {
 		if (cache !== undefined) {
 			const resolved = getResolvedTimestamp(cache);
 			if (resolved !== undefined) return callback(null, resolved);
-			this._resolveContextTsh(cache, callback);
+			return this._resolveContextTsh(cache, callback);
 		}
 		this.contextTshQueue.add(path, (err, entry) => {
+			if (err) return callback(err);
 			const resolved = getResolvedTimestamp(entry);
 			if (resolved !== undefined) return callback(null, resolved);
 			this._resolveContextTsh(entry, callback);
@@ -1253,9 +1252,7 @@ class FileSystemInfo {
 	_getUnresolvedContextTsh(path, callback) {
 		const cache = this._contextTshs.get(path);
 		if (cache !== undefined) return callback(null, cache);
-		this.contextTshQueue.add(path, (err, entry) => {
-			return callback(null, entry);
-		});
+		this.contextTshQueue.add(path, callback);
 	}
 
 	_createBuildDependenciesResolvers() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
The fix for https://github.com/webpack/webpack/issues/14028 added in https://github.com/webpack/webpack/pull/14030 does not catch cases where `entry` may be `undefined`. 

Starting with `5.51.0` we're seeing errors like this one (even with `5.51.1`):

```
/test/node_modules/webpack/lib/FileSystemInfo.js:817
if (entry.resolved !== undefined) return entry.resolved;
^

TypeError: Cannot read property 'resolved' of undefined
at getResolvedTimestamp (/test/node_modules/webpack/lib/FileSystemInfo.js:817:12)
at /test/node_modules/webpack/lib/FileSystemInfo.js:1167:21
at /test/node_modules/webpack/lib/util/AsyncQueue.js:352:5
at Hook.eval [as callAsync] (eval at create (/test/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), :4:1)
at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/test/node_modules/webpack/node_modules/tapable/lib/Hook.js:18:14)
at AsyncQueue._handleResult (/test/node_modules/webpack/lib/util/AsyncQueue.js:322:21)
at /test/node_modules/webpack/lib/util/AsyncQueue.js:305:11
at /test/node_modules/webpack/lib/FileSystemInfo.js:3098:21
at /test/node_modules/webpack/lib/FileSystemInfo.js:3010:22
at /test/node_modules/neo-async/async.js:2830:7
at done (/test/node_modules/neo-async/async.js:2925:13)
at /test/node_modules/webpack/lib/FileSystemInfo.js:2994:23
at Array. (/test/node_modules/webpack/lib/util/fs.js:311:21)
at runCallbacks (/test/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:27:15)
at /test/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:200:4
at callback (/test/node_modules/graceful-fs/polyfills.js:299:20)
```

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

N/A
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

N/A
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
