### PR TITLE
support loaders implemented in ESM

### DIFF
--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -1050,6 +1050,7 @@ If changing the source code is not an option there is also a resolve options cal
 						const parsedResult = identToLoaderRequest(result);
 						const resolved = {
 							loader: parsedResult.loader,
+							type: "module",
 							options:
 								item.options === undefined
 									? parsedResult.options


### PR DESCRIPTION
Passing `type: "module"` to [loader-runner](https://github.com/webpack/loader-runner) will load all loaders with [`import()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports) vs. `require()`: https://github.com/webpack/loader-runner/blob/6221befd031563e130f59d171e732950ee4402c6/lib/loadLoader.js#L5-L9

`import()` supports both ESM and CJS whereas `require()` was CJS only.

Fixes #13233