### PR TITLE
Fix: managedPaths/snapshot is expected to return absolute paths.

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -345,7 +345,7 @@ const applySnapshotDefaults = (snapshot, { production }) => {
 				/^(.+?)[\\/]cache[\\/]watchpack-npm-[^\\/]+\.zip[\\/]node_modules[\\/]/.exec(
 					require.resolve("watchpack")
 				);
-			if (match) {
+			if (match && path.isAbsolute(match[1])) {
 				return [path.resolve(match[1], "unplugged")];
 			}
 		} else {
@@ -353,7 +353,7 @@ const applySnapshotDefaults = (snapshot, { production }) => {
 				// eslint-disable-next-line node/no-extraneous-require
 				require.resolve("watchpack")
 			);
-			if (match) {
+			if (match && path.isAbsolute(match[1])) {
 				return [match[1]];
 			}
 		}


### PR DESCRIPTION
Webpack throws when `applySnapshotDefaults` resolves watchpack and it returns a relative path rather than absolute.

**What kind of change does this PR introduce?**

`applySnapshotDefaults` already does a regex check. This PR adds an `isAbsolute` check if there's a match.

**Did you add tests for your changes?**

No.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

No.
