### PR TITLE
Export the ResolvePluginInstance type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ const memoize = require("./util/memoize");
 /** @typedef {import("../declarations/WebpackOptions").LibraryOptions} LibraryOptions */
 /** @typedef {import("../declarations/WebpackOptions").ModuleOptions} ModuleOptions */
 /** @typedef {import("../declarations/WebpackOptions").ResolveOptions} ResolveOptions */
+/** @typedef {import("../declarations/WebpackOptions").ResolvePluginInstance} ResolvePluginInstance */
 /** @typedef {import("../declarations/WebpackOptions").RuleSetCondition} RuleSetCondition */
 /** @typedef {import("../declarations/WebpackOptions").RuleSetConditionAbsolute} RuleSetConditionAbsolute */
 /** @typedef {import("../declarations/WebpackOptions").RuleSetRule} RuleSetRule */

--- a/types.d.ts
+++ b/types.d.ts
@@ -9229,7 +9229,7 @@ declare interface ResolveOptionsWebpackOptions {
 	/**
 	 * Plugins for the resolver.
 	 */
-	plugins?: ("..." | ResolvePluginInstance)[];
+	plugins?: (ResolvePluginInstance | "...")[];
 
 	/**
 	 * Prefer to resolve server-relative URLs (starting with '/') as absolute paths before falling back to resolve in 'resolve.roots'.
@@ -12360,6 +12360,7 @@ declare namespace exports {
 		LibraryOptions,
 		ModuleOptions,
 		ResolveOptionsWebpackOptions as ResolveOptions,
+		ResolvePluginInstance,
 		RuleSetCondition,
 		RuleSetConditionAbsolute,
 		RuleSetRule,


### PR DESCRIPTION
Related to https://github.com/webpack/webpack/issues/11630

**What kind of change does this PR introduce?**

Exposing the `ResolvePluginInstance` type for public use.

**Did you add tests for your changes?**

No tests required.

**Does this PR introduce a breaking change?**

No, just adding a new type.

**What needs to be documented once your changes are merged?**

No new documentation required.