### PR TITLE
add restore only flag

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -970,6 +970,10 @@ export interface FileCacheOptions {
 	 * Version of the cache data. Different versions won't allow to reuse the cache and override existing content. Update the version when config changed in a way which doesn't allow to reuse cache. This will invalidate the cache.
 	 */
 	version?: string;
+	/**
+	 * When you want to only restore file caches and not store them, possible optimization when you only want to read cache.
+	 */
+	restoreOnly?: boolean;
 }
 /**
  * Options for the webpack-dev-server.

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -583,6 +583,7 @@ class WebpackOptionsApply extends OptionsApply {
 									allowCollectingMemory: cacheOptions.allowCollectingMemory,
 									compression: cacheOptions.compression
 								}),
+								cacheOptions.restoreOnly,
 								cacheOptions.idleTimeout,
 								cacheOptions.idleTimeoutForInitialStore,
 								cacheOptions.idleTimeoutAfterLargeChanges

--- a/lib/cache/IdleFileCachePlugin.js
+++ b/lib/cache/IdleFileCachePlugin.js
@@ -15,17 +15,20 @@ const BUILD_DEPENDENCIES_KEY = Symbol();
 class IdleFileCachePlugin {
 	/**
 	 * @param {TODO} strategy cache strategy
+	 * @param {boolean} restoreOnly only restore caches
 	 * @param {number} idleTimeout timeout
 	 * @param {number} idleTimeoutForInitialStore initial timeout
 	 * @param {number} idleTimeoutAfterLargeChanges timeout after changes
 	 */
 	constructor(
 		strategy,
+		restoreOnly,
 		idleTimeout,
 		idleTimeoutForInitialStore,
 		idleTimeoutAfterLargeChanges
 	) {
 		this.strategy = strategy;
+		this.restoreOnly = restoreOnly;
 		this.idleTimeout = idleTimeout;
 		this.idleTimeoutForInitialStore = idleTimeoutForInitialStore;
 		this.idleTimeoutAfterLargeChanges = idleTimeoutAfterLargeChanges;
@@ -56,6 +59,10 @@ class IdleFileCachePlugin {
 		compiler.cache.hooks.store.tap(
 			{ name: "IdleFileCachePlugin", stage: Cache.STAGE_DISK },
 			(identifier, etag, data) => {
+				if (this.restoreOnly) {
+					return;
+				}
+
 				pendingIdleTasks.set(identifier, () =>
 					strategy.store(identifier, etag, data)
 				);
@@ -67,7 +74,7 @@ class IdleFileCachePlugin {
 			(identifier, etag, gotHandlers) => {
 				const restore = () =>
 					strategy.restore(identifier, etag).then(cacheEntry => {
-						if (cacheEntry === undefined) {
+						if (cacheEntry === undefined && !this.restoreOnly) {
 							gotHandlers.push((result, callback) => {
 								if (result !== undefined) {
 									pendingIdleTasks.set(identifier, () =>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR adds a possible config change (this would need some edits to the docs as well).

The new config value would be `.cache.restoreOnly`, which would allow users to use an existing cache entity but not write to it.

We can tackle this new config value in two ways, we could either stop the process from writing new pack files or stop the process from writing to the store at all, I did the second.

Let me know if this works for you and then I can expand on this PR with documentation and tests!

**Did you add tests for your changes?**

Not yet, but will if the change will be considered for a new release.

**Does this PR introduce a breaking change?**

No it does not.

**What needs to be documented once your changes are merged?**

We need to add the documentation for the `.cache.restoreOnly` value.
