### PR TITLE
match resource should not include special `.webpack[...]` extension

### DIFF
--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -540,15 +540,18 @@ class NormalModuleFactory extends ModuleFactory {
 						for (const loader of preLoaders) allLoaders.push(loader);
 						let type = settings.type;
 						if (!type) {
-							const resource =
-								(matchResourceData && matchResourceData.resource) ||
-								resourceData.resource;
+							let resource;
 							let match;
 							if (
-								typeof resource === "string" &&
+								matchResourceData &&
+								typeof (resource = matchResourceData.resource) === "string" &&
 								(match = /\.webpack\[([^\]]+)\]$/.exec(resource))
 							) {
 								type = match[1];
+								matchResourceData.resource = matchResourceData.resource.slice(
+									0,
+									-type.length - 10
+								);
 							} else {
 								type = "javascript/auto";
 							}

--- a/test/configCases/loader-import-module/css/webpack.config.js
+++ b/test/configCases/loader-import-module/css/webpack.config.js
@@ -9,12 +9,15 @@ module.exports = {
 				url: "relative"
 			}
 		},
-		generator: {
-			asset: {
-				filename: "assets/[name][ext][query]"
-			}
-		},
 		rules: [
+			{
+				dependency: "url",
+				issuer: /stylesheet\.js$/,
+				type: "asset/resource",
+				generator: {
+					filename: "assets/[name][ext][query]"
+				}
+			},
 			{
 				oneOf: [
 					{
@@ -44,18 +47,23 @@ module.exports = {
 	plugins: [
 		compiler =>
 			compiler.hooks.done.tap("test case", stats => {
-				expect(stats.compilation.getAsset("assets/file.png")).toHaveProperty(
-					"info",
-					expect.objectContaining({ sourceFilename: "file.png" })
-				);
-				expect(stats.compilation.getAsset("assets/file.jpg")).toHaveProperty(
-					"info",
-					expect.objectContaining({ sourceFilename: "file.jpg" })
-				);
-				const { auxiliaryFiles } = stats.compilation.namedChunks.get("main");
-				expect(auxiliaryFiles).toContain("assets/file.png");
-				expect(auxiliaryFiles).toContain("assets/file.png?1");
-				expect(auxiliaryFiles).toContain("assets/file.jpg");
+				try {
+					expect(stats.compilation.getAsset("assets/file.png")).toHaveProperty(
+						"info",
+						expect.objectContaining({ sourceFilename: "file.png" })
+					);
+					expect(stats.compilation.getAsset("assets/file.jpg")).toHaveProperty(
+						"info",
+						expect.objectContaining({ sourceFilename: "file.jpg" })
+					);
+					const { auxiliaryFiles } = stats.compilation.namedChunks.get("main");
+					expect(auxiliaryFiles).toContain("assets/file.png");
+					expect(auxiliaryFiles).toContain("assets/file.png?1");
+					expect(auxiliaryFiles).toContain("assets/file.jpg");
+				} catch (e) {
+					console.log(stats.toString({ colors: true, orphanModules: true }));
+					throw e;
+				}
 			})
 	]
 };


### PR DESCRIPTION
`.webpack[]` should not be used for resource path

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
fixes https://github.com/webpack-contrib/mini-css-extract-plugin/issues/755
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
