### PR TITLE
fix(lazy-compilation): support lazy compilation in ios9

### DIFF
--- a/hot/lazy-compilation-web.js
+++ b/hot/lazy-compilation-web.js
@@ -2,7 +2,7 @@
 
 "use strict";
 
-if (typeof EventSource !== "function") {
+if (!/^function|object$/.test(typeof EventSource)) {
 	throw new Error(
 		"Environment doesn't support lazy compilation (requires EventSource)"
 	);


### PR DESCRIPTION
bugfix: ios9 `typeof EventSource === 'object'`

![wecom-temp-5c9c9bfa950c4c338d3778f96352d4ff](https://user-images.githubusercontent.com/3605154/132214419-3dfbee30-3e12-4a31-8cff-6d54cde37483.png)
