### PR TITLE
fix(lazy-compilation): support lazy compilation in ios9

### DIFF
--- a/hot/lazy-compilation-web.js
+++ b/hot/lazy-compilation-web.js
@@ -2,7 +2,7 @@
 
 "use strict";
 
-if (typeof EventSource !== "function") {
+if (!/^(function|object)$/.test(typeof EventSource)) {
 	throw new Error(
 		"Environment doesn't support lazy compilation (requires EventSource)"
 	);


### PR DESCRIPTION
bugfix: ios9 `typeof EventSource === 'object'`

![image](https://user-images.githubusercontent.com/3605154/132215737-b60b0529-53a4-4e1c-9978-8ece12f02af8.png)