### PR TITLE
add typings for the resolveData parameter

### DIFF
--- a/lib/NormalModuleReplacementPlugin.js
+++ b/lib/NormalModuleReplacementPlugin.js
@@ -9,6 +9,7 @@ const { join, dirname } = require("./util/fs");
 
 /** @typedef {import("./Compiler")} Compiler */
 /** @typedef {function(TODO): void} ModuleReplacer */
+/** @typedef {import("./NormalModuleFactory").ResolveData} ResolveData */
 
 class NormalModuleReplacementPlugin {
 	/**
@@ -32,37 +33,43 @@ class NormalModuleReplacementPlugin {
 		compiler.hooks.normalModuleFactory.tap(
 			"NormalModuleReplacementPlugin",
 			nmf => {
-				nmf.hooks.beforeResolve.tap("NormalModuleReplacementPlugin", result => {
-					if (resourceRegExp.test(result.request)) {
-						if (typeof newResource === "function") {
-							newResource(result);
-						} else {
-							result.request = newResource;
-						}
-					}
-				});
-				nmf.hooks.afterResolve.tap("NormalModuleReplacementPlugin", result => {
-					const createData = result.createData;
-					if (resourceRegExp.test(createData.resource)) {
-						if (typeof newResource === "function") {
-							newResource(result);
-						} else {
-							const fs = compiler.inputFileSystem;
-							if (
-								newResource.startsWith("/") ||
-								(newResource.length > 1 && newResource[1] === ":")
-							) {
-								createData.resource = newResource;
+				nmf.hooks.beforeResolve.tap(
+					"NormalModuleReplacementPlugin",
+					/** @type {ResolveData} */ resolveData => {
+						if (resourceRegExp.test(resolveData.request)) {
+							if (typeof newResource === "function") {
+								newResource(resolveData);
 							} else {
-								createData.resource = join(
-									fs,
-									dirname(fs, createData.resource),
-									newResource
-								);
+								resolveData.request = newResource;
 							}
 						}
 					}
-				});
+				);
+				nmf.hooks.afterResolve.tap(
+					"NormalModuleReplacementPlugin",
+					/** @type {ResolveData} */ resolveData => {
+						const createData = resolveData.createData;
+						if (resourceRegExp.test(createData.resource)) {
+							if (typeof newResource === "function") {
+								newResource(resolveData);
+							} else {
+								const fs = compiler.inputFileSystem;
+								if (
+									newResource.startsWith("/") ||
+									(newResource.length > 1 && newResource[1] === ":")
+								) {
+									createData.resource = newResource;
+								} else {
+									createData.resource = join(
+										fs,
+										dirname(fs, createData.resource),
+										newResource
+									);
+								}
+							}
+						}
+					}
+				);
 			}
 		);
 	}

--- a/lib/NormalModuleReplacementPlugin.js
+++ b/lib/NormalModuleReplacementPlugin.js
@@ -8,8 +8,8 @@
 const { join, dirname } = require("./util/fs");
 
 /** @typedef {import("./Compiler")} Compiler */
-/** @typedef {function(TODO): void} ModuleReplacer */
 /** @typedef {import("./NormalModuleFactory").ResolveData} ResolveData */
+/** @typedef {function(TODO): void} ModuleReplacer */
 
 class NormalModuleReplacementPlugin {
 	/**
@@ -35,7 +35,7 @@ class NormalModuleReplacementPlugin {
 			nmf => {
 				nmf.hooks.beforeResolve.tap(
 					"NormalModuleReplacementPlugin",
-					/** @type {ResolveData} */ resolveData => {
+					/** @type {(resolveData: ResolveData) => void} */ resolveData => {
 						if (resourceRegExp.test(resolveData.request)) {
 							if (typeof newResource === "function") {
 								newResource(resolveData);
@@ -47,7 +47,7 @@ class NormalModuleReplacementPlugin {
 				);
 				nmf.hooks.afterResolve.tap(
 					"NormalModuleReplacementPlugin",
-					/** @type {ResolveData} */ resolveData => {
+					/** @type {(resolveData: ResolveData) => void} */ resolveData => {
 						const createData = resolveData.createData;
 						if (resourceRegExp.test(createData.resource)) {
 							if (typeof newResource === "function") {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

1. rename `result` to `resolveData` to keep consistency, e.g., the `IgnorePlugin` tapping the `hooks.beforeResolve` uses `resolveData` for the parameter per https://github.com/webpack/webpack/blob/main/lib/IgnorePlugin.js#L42
2. Include the typing for `resolveData` which can be helpful for anyone reading the source code.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Internal changes, so it won't break anything as far as I see.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

Nope, just small internal changes.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
Nothing.