### PR TITLE
add `diagnostics_channel` to NodeTargetPlugin

### DIFF
--- a/lib/node/NodeTargetPlugin.js
+++ b/lib/node/NodeTargetPlugin.js
@@ -19,6 +19,7 @@ const builtins = [
 	"constants",
 	"crypto",
 	"dgram",
+	"diagnostics_channel",
 	"dns",
 	"dns/promises",
 	"domain",


### PR DESCRIPTION
Add `diagnostics_channel` to `NodeTargetPlugin` since it's a built-in module for node: https://nodejs.org/api/diagnostics_channel.html.

Context:
When I try to bundle https://github.com/nodejs/undici with webpack, it logs an error:
`node_modules/undici/lib/client.js: Module not found: Can't resolve 'diagnostics_channel' in 'node_modules/undici/lib'`


