### PR TITLE
use propertyAccess to generate .catch code

### DIFF
--- a/lib/dependencies/AMDRequireDependency.js
+++ b/lib/dependencies/AMDRequireDependency.js
@@ -7,7 +7,6 @@
 
 const RuntimeGlobals = require("../RuntimeGlobals");
 const makeSerializable = require("../util/makeSerializable");
-const propertyAccess = require("../util/propertyAccess");
 const NullDependency = require("./NullDependency");
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
@@ -91,9 +90,7 @@ AMDRequireDependency.Template = class AMDRequireDependencyTemplate extends (
 		// has array range but no function range
 		if (dep.arrayRange && !dep.functionRange) {
 			const startBlock = `${promise}.then(function() {`;
-			const endBlock = `;})${propertyAccess("catch")}(${
-				RuntimeGlobals.uncaughtErrorHandler
-			})`;
+			const endBlock = `;})['catch'](${RuntimeGlobals.uncaughtErrorHandler})`;
 			runtimeRequirements.add(RuntimeGlobals.uncaughtErrorHandler);
 
 			source.replace(dep.outerRange[0], dep.arrayRange[0] - 1, startBlock);
@@ -106,9 +103,7 @@ AMDRequireDependency.Template = class AMDRequireDependencyTemplate extends (
 		// has function range but no array range
 		if (dep.functionRange && !dep.arrayRange) {
 			const startBlock = `${promise}.then((`;
-			const endBlock = `).bind(exports, __webpack_require__, exports, module))${propertyAccess(
-				"catch"
-			)}(${RuntimeGlobals.uncaughtErrorHandler})`;
+			const endBlock = `).bind(exports, __webpack_require__, exports, module))['catch'](${RuntimeGlobals.uncaughtErrorHandler})`;
 			runtimeRequirements.add(RuntimeGlobals.uncaughtErrorHandler);
 
 			source.replace(dep.outerRange[0], dep.functionRange[0] - 1, startBlock);
@@ -123,7 +118,7 @@ AMDRequireDependency.Template = class AMDRequireDependencyTemplate extends (
 			const startBlock = `${promise}.then(function() { `;
 			const errorRangeBlock = `}${
 				dep.functionBindThis ? ".bind(this)" : ""
-			})${propertyAccess("catch")}(`;
+			})['catch'](`;
 			const endBlock = `${dep.errorCallbackBindThis ? ".bind(this)" : ""})`;
 
 			source.replace(dep.outerRange[0], dep.arrayRange[0] - 1, startBlock);
@@ -157,7 +152,7 @@ AMDRequireDependency.Template = class AMDRequireDependencyTemplate extends (
 			const startBlock = `${promise}.then(function() { `;
 			const endBlock = `}${
 				dep.functionBindThis ? ".bind(this)" : ""
-			})${propertyAccess("catch")}(${RuntimeGlobals.uncaughtErrorHandler})`;
+			})['catch'](${RuntimeGlobals.uncaughtErrorHandler})`;
 			runtimeRequirements.add(RuntimeGlobals.uncaughtErrorHandler);
 
 			source.replace(dep.outerRange[0], dep.arrayRange[0] - 1, startBlock);

--- a/lib/dependencies/AMDRequireDependency.js
+++ b/lib/dependencies/AMDRequireDependency.js
@@ -7,6 +7,7 @@
 
 const RuntimeGlobals = require("../RuntimeGlobals");
 const makeSerializable = require("../util/makeSerializable");
+const propertyAccess = require("../util/propertyAccess");
 const NullDependency = require("./NullDependency");
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
@@ -90,7 +91,9 @@ AMDRequireDependency.Template = class AMDRequireDependencyTemplate extends (
 		// has array range but no function range
 		if (dep.arrayRange && !dep.functionRange) {
 			const startBlock = `${promise}.then(function() {`;
-			const endBlock = `;}).catch(${RuntimeGlobals.uncaughtErrorHandler})`;
+			const endBlock = `;})${propertyAccess("catch")}(${
+				RuntimeGlobals.uncaughtErrorHandler
+			})`;
 			runtimeRequirements.add(RuntimeGlobals.uncaughtErrorHandler);
 
 			source.replace(dep.outerRange[0], dep.arrayRange[0] - 1, startBlock);
@@ -103,7 +106,9 @@ AMDRequireDependency.Template = class AMDRequireDependencyTemplate extends (
 		// has function range but no array range
 		if (dep.functionRange && !dep.arrayRange) {
 			const startBlock = `${promise}.then((`;
-			const endBlock = `).bind(exports, __webpack_require__, exports, module)).catch(${RuntimeGlobals.uncaughtErrorHandler})`;
+			const endBlock = `).bind(exports, __webpack_require__, exports, module))${propertyAccess(
+				"catch"
+			)}(${RuntimeGlobals.uncaughtErrorHandler})`;
 			runtimeRequirements.add(RuntimeGlobals.uncaughtErrorHandler);
 
 			source.replace(dep.outerRange[0], dep.functionRange[0] - 1, startBlock);
@@ -118,7 +123,7 @@ AMDRequireDependency.Template = class AMDRequireDependencyTemplate extends (
 			const startBlock = `${promise}.then(function() { `;
 			const errorRangeBlock = `}${
 				dep.functionBindThis ? ".bind(this)" : ""
-			}).catch(`;
+			})${propertyAccess("catch")}(`;
 			const endBlock = `${dep.errorCallbackBindThis ? ".bind(this)" : ""})`;
 
 			source.replace(dep.outerRange[0], dep.arrayRange[0] - 1, startBlock);
@@ -150,9 +155,9 @@ AMDRequireDependency.Template = class AMDRequireDependencyTemplate extends (
 		// has array range, function range, but no errorCallbackRange
 		if (dep.arrayRange && dep.functionRange) {
 			const startBlock = `${promise}.then(function() { `;
-			const endBlock = `}${dep.functionBindThis ? ".bind(this)" : ""}).catch(${
-				RuntimeGlobals.uncaughtErrorHandler
-			})`;
+			const endBlock = `}${
+				dep.functionBindThis ? ".bind(this)" : ""
+			})${propertyAccess("catch")}(${RuntimeGlobals.uncaughtErrorHandler})`;
 			runtimeRequirements.add(RuntimeGlobals.uncaughtErrorHandler);
 
 			source.replace(dep.outerRange[0], dep.arrayRange[0] - 1, startBlock);

--- a/lib/dependencies/RequireEnsureDependency.js
+++ b/lib/dependencies/RequireEnsureDependency.js
@@ -7,6 +7,7 @@
 
 const RuntimeGlobals = require("../RuntimeGlobals");
 const makeSerializable = require("../util/makeSerializable");
+const propertyAccess = require("../util/propertyAccess");
 const NullDependency = require("./NullDependency");
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
@@ -85,14 +86,16 @@ RequireEnsureDependency.Template = class RequireEnsureDependencyTemplate extends
 			source.replace(
 				contentRange[1],
 				errorHandlerRange[0] - 1,
-				").bind(null, __webpack_require__)).catch("
+				`).bind(null, __webpack_require__))${propertyAccess("catch")}(`
 			);
 			source.replace(errorHandlerRange[1], range[1] - 1, ")");
 		} else {
 			source.replace(
 				contentRange[1],
 				range[1] - 1,
-				`).bind(null, __webpack_require__)).catch(${RuntimeGlobals.uncaughtErrorHandler})`
+				`).bind(null, __webpack_require__))${propertyAccess("catch")}(${
+					RuntimeGlobals.uncaughtErrorHandler
+				})`
 			);
 		}
 	}

--- a/lib/dependencies/RequireEnsureDependency.js
+++ b/lib/dependencies/RequireEnsureDependency.js
@@ -7,7 +7,6 @@
 
 const RuntimeGlobals = require("../RuntimeGlobals");
 const makeSerializable = require("../util/makeSerializable");
-const propertyAccess = require("../util/propertyAccess");
 const NullDependency = require("./NullDependency");
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
@@ -86,16 +85,14 @@ RequireEnsureDependency.Template = class RequireEnsureDependencyTemplate extends
 			source.replace(
 				contentRange[1],
 				errorHandlerRange[0] - 1,
-				`).bind(null, __webpack_require__))${propertyAccess("catch")}(`
+				").bind(null, __webpack_require__))['catch']("
 			);
 			source.replace(errorHandlerRange[1], range[1] - 1, ")");
 		} else {
 			source.replace(
 				contentRange[1],
 				range[1] - 1,
-				`).bind(null, __webpack_require__))${propertyAccess("catch")}(${
-					RuntimeGlobals.uncaughtErrorHandler
-				})`
+				`).bind(null, __webpack_require__))['catch'](${RuntimeGlobals.uncaughtErrorHandler})`
 			);
 		}
 	}

--- a/lib/node/RequireChunkLoadingRuntimeModule.js
+++ b/lib/node/RequireChunkLoadingRuntimeModule.js
@@ -14,7 +14,6 @@ const {
 const { getInitialChunkIds } = require("../javascript/StartupHelpers");
 const compileBooleanMatcher = require("../util/compileBooleanMatcher");
 const { getUndoPath } = require("../util/identifier");
-const propertyAccess = require("../util/propertyAccess");
 
 class RequireChunkLoadingRuntimeModule extends RuntimeModule {
 	constructor(runtimeRequirements) {
@@ -212,9 +211,7 @@ class RequireChunkLoadingRuntimeModule extends RuntimeModule {
 									RuntimeGlobals.getUpdateManifestFilename
 								}());`
 							]),
-							`})${propertyAccess(
-								"catch"
-							)}(function(err) { if(err.code !== "MODULE_NOT_FOUND") throw err; });`
+							"})['catch'](function(err) { if(err.code !== 'MODULE_NOT_FOUND') throw err; });"
 						]),
 						"}"
 				  ])

--- a/lib/node/RequireChunkLoadingRuntimeModule.js
+++ b/lib/node/RequireChunkLoadingRuntimeModule.js
@@ -14,6 +14,7 @@ const {
 const { getInitialChunkIds } = require("../javascript/StartupHelpers");
 const compileBooleanMatcher = require("../util/compileBooleanMatcher");
 const { getUndoPath } = require("../util/identifier");
+const propertyAccess = require("../util/propertyAccess");
 
 class RequireChunkLoadingRuntimeModule extends RuntimeModule {
 	constructor(runtimeRequirements) {
@@ -211,7 +212,9 @@ class RequireChunkLoadingRuntimeModule extends RuntimeModule {
 									RuntimeGlobals.getUpdateManifestFilename
 								}());`
 							]),
-							'}).catch(function(err) { if(err.code !== "MODULE_NOT_FOUND") throw err; });'
+							`})${propertyAccess(
+								"catch"
+							)}(function(err) { if(err.code !== "MODULE_NOT_FOUND") throw err; });`
 						]),
 						"}"
 				  ])

--- a/lib/runtime/AsyncModuleRuntimeModule.js
+++ b/lib/runtime/AsyncModuleRuntimeModule.js
@@ -6,6 +6,7 @@
 
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
+const propertyAccess = require("../util/propertyAccess");
 const HelperRuntimeModule = require("./HelperRuntimeModule");
 
 class AsyncModuleRuntimeModule extends HelperRuntimeModule {
@@ -59,7 +60,9 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 							])});`,
 							`var obj = {};
 							obj[webpackThen] = ${runtimeTemplate.expressionFunction(
-								"queueFunction(queue, fn), dep.catch(reject)",
+								`queueFunction(queue, fn), dep${propertyAccess(
+									"catch"
+								)}(reject)`,
 								"fn, reject"
 							)};`,
 							"return obj;"
@@ -114,7 +117,7 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 						"if (isEvaluating) { return completeFunction(fn); }",
 						"if (currentDeps) whenAll(currentDeps, fn, rejectFn);",
 						"queueFunction(queue, fn);",
-						"promise.catch(rejectFn);"
+						`promise${propertyAccess("catch")}(rejectFn);`
 					]
 				)};`,
 				"module.exports = promise;",

--- a/lib/runtime/AsyncModuleRuntimeModule.js
+++ b/lib/runtime/AsyncModuleRuntimeModule.js
@@ -6,7 +6,6 @@
 
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
-const propertyAccess = require("../util/propertyAccess");
 const HelperRuntimeModule = require("./HelperRuntimeModule");
 
 class AsyncModuleRuntimeModule extends HelperRuntimeModule {
@@ -60,9 +59,7 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 							])});`,
 							`var obj = {};
 							obj[webpackThen] = ${runtimeTemplate.expressionFunction(
-								`queueFunction(queue, fn), dep${propertyAccess(
-									"catch"
-								)}(reject)`,
+								"queueFunction(queue, fn), dep['catch'](reject)",
 								"fn, reject"
 							)};`,
 							"return obj;"
@@ -117,7 +114,7 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 						"if (isEvaluating) { return completeFunction(fn); }",
 						"if (currentDeps) whenAll(currentDeps, fn, rejectFn);",
 						"queueFunction(queue, fn);",
-						`promise${propertyAccess("catch")}(rejectFn);`
+						"promise['catch'](rejectFn);"
 					]
 				)};`,
 				"module.exports = promise;",

--- a/lib/sharing/ConsumeSharedRuntimeModule.js
+++ b/lib/sharing/ConsumeSharedRuntimeModule.js
@@ -8,7 +8,6 @@
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
-const propertyAccess = require("../util/propertyAccess");
 const {
 	parseVersionRuntimeCode,
 	versionLtRuntimeCode,
@@ -321,9 +320,7 @@ class ConsumeSharedRuntimeModule extends RuntimeModule {
 											"var promise = moduleToHandlerMapping[id]();",
 											"if(promise.then) {",
 											Template.indent(
-												`promises.push(installedModules[id] = promise.then(onFactory)${propertyAccess(
-													"catch"
-												)}(onError));`
+												"promises.push(installedModules[id] = promise.then(onFactory)['catch'](onError));"
 											),
 											"} else onFactory(promise);"
 										]),

--- a/lib/sharing/ConsumeSharedRuntimeModule.js
+++ b/lib/sharing/ConsumeSharedRuntimeModule.js
@@ -8,6 +8,7 @@
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
+const propertyAccess = require("../util/propertyAccess");
 const {
 	parseVersionRuntimeCode,
 	versionLtRuntimeCode,
@@ -320,7 +321,9 @@ class ConsumeSharedRuntimeModule extends RuntimeModule {
 											"var promise = moduleToHandlerMapping[id]();",
 											"if(promise.then) {",
 											Template.indent(
-												`promises.push(installedModules[id] = promise.then(onFactory).catch(onError));`
+												`promises.push(installedModules[id] = promise.then(onFactory)${propertyAccess(
+													"catch"
+												)}(onError));`
 											),
 											"} else onFactory(promise);"
 										]),

--- a/lib/sharing/ShareRuntimeModule.js
+++ b/lib/sharing/ShareRuntimeModule.js
@@ -12,6 +12,7 @@ const {
 	compareModulesByIdentifier,
 	compareStrings
 } = require("../util/comparators");
+const propertyAccess = require("../util/propertyAccess");
 
 class ShareRuntimeModule extends RuntimeModule {
 	constructor() {
@@ -105,7 +106,9 @@ class ShareRuntimeModule extends RuntimeModule {
 							)}`,
 							"if(module.then) return promises.push(module.then(initFn, handleError));",
 							"var initResult = initFn(module);",
-							"if(initResult && initResult.then) return promises.push(initResult.catch(handleError));"
+							`if(initResult && initResult.then) return promises.push(initResult${propertyAccess(
+								"catch"
+							)}(handleError));`
 						]),
 						"} catch(err) { handleError(err); }"
 					])}`,

--- a/lib/sharing/ShareRuntimeModule.js
+++ b/lib/sharing/ShareRuntimeModule.js
@@ -12,7 +12,6 @@ const {
 	compareModulesByIdentifier,
 	compareStrings
 } = require("../util/comparators");
-const propertyAccess = require("../util/propertyAccess");
 
 class ShareRuntimeModule extends RuntimeModule {
 	constructor() {
@@ -106,9 +105,7 @@ class ShareRuntimeModule extends RuntimeModule {
 							)}`,
 							"if(module.then) return promises.push(module.then(initFn, handleError));",
 							"var initResult = initFn(module);",
-							`if(initResult && initResult.then) return promises.push(initResult${propertyAccess(
-								"catch"
-							)}(handleError));`
+							"if(initResult && initResult.then) return promises.push(initResult['catch'](handleError));"
 						]),
 						"} catch(err) { handleError(err); }"
 					])}`,

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -494,7 +494,7 @@ webpack x.x.x compiled successfully in X ms"
 exports[`StatsTestCases should print correct stats for chunks 1`] = `
 "PublicPath: auto
 asset bundle.js 10.2 KiB [emitted] (name: main)
-asset 460.bundle.js 320 bytes [emitted]
+asset 460.bundle.js 323 bytes [emitted]
 asset 524.bundle.js 206 bytes [emitted]
 asset 996.bundle.js 138 bytes [emitted]
 chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 6.01 KiB (runtime) >{460}< >{996}< [entry] [rendered]
@@ -1171,7 +1171,7 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 1`] = `
 "1 chunks:
-  asset bundle1.js 4.84 KiB [emitted] (name: main)
+  asset bundle1.js 4.85 KiB [emitted] (name: main)
   chunk (runtime: main) bundle1.js (main) 219 bytes (javascript) 1.77 KiB (runtime) <{179}> >{179}< [entry] [rendered]
     runtime modules 1.77 KiB 4 modules
     cacheable modules 219 bytes
@@ -1645,10 +1645,10 @@ webpack x.x.x compiled with 1 error and 1 warning in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for optimize-chunks 1`] = `
-"asset main.js 11 KiB {179} [emitted] (name: main)
-asset cir2 from cir1.js 374 bytes {288}, {289} [emitted] (name: cir2 from cir1)
-asset cir1.js 330 bytes {592} [emitted] (name: cir1)
-asset cir2.js 330 bytes {289} [emitted] (name: cir2)
+"asset main.js 11.1 KiB {179} [emitted] (name: main)
+asset cir2 from cir1.js 377 bytes {288}, {289} [emitted] (name: cir2 from cir1)
+asset cir1.js 333 bytes {592} [emitted] (name: cir1)
+asset cir2.js 333 bytes {289} [emitted] (name: cir2)
 asset abd.js 193 bytes {90}, {374} [emitted] (name: abd)
 asset chunk.js 154 bytes {284}, {753} [emitted] (name: chunk)
 asset ab.js 149 bytes {90} [emitted] (name: ab)
@@ -1798,7 +1798,7 @@ webpack x.x.x compiled with 3 warnings in X ms"
 
 exports[`StatsTestCases should print correct stats for performance-disabled 1`] = `
 "asset <CLR=32,BOLD>main.js</CLR> 303 KiB <CLR=32,BOLD>[emitted]</CLR> (name: main)
-asset <CLR=32,BOLD>460.js</CLR> 320 bytes <CLR=32,BOLD>[emitted]</CLR>
+asset <CLR=32,BOLD>460.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
@@ -1815,7 +1815,7 @@ webpack x.x.x compiled <CLR=32,BOLD>successfully</CLR> in X ms"
 
 exports[`StatsTestCases should print correct stats for performance-error 1`] = `
 "asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>303 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main)
-asset <CLR=32,BOLD>460.js</CLR> 320 bytes <CLR=32,BOLD>[emitted]</CLR>
+asset <CLR=32,BOLD>460.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
@@ -1874,7 +1874,7 @@ webpack x.x.x compiled with <CLR=33,BOLD>3 warnings</CLR> in X ms"
 
 exports[`StatsTestCases should print correct stats for performance-no-hints 1`] = `
 "asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>303 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main)
-asset <CLR=32,BOLD>460.js</CLR> 320 bytes <CLR=32,BOLD>[emitted]</CLR>
+asset <CLR=32,BOLD>460.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
@@ -1982,7 +1982,7 @@ exports[`StatsTestCases should print correct stats for preset-detailed 1`] = `
     [LogTestPlugin] End
 PublicPath: auto
 asset main.js 10.2 KiB {179} [emitted] (name: main)
-asset 460.js 320 bytes {460} [emitted]
+asset 460.js 323 bytes {460} [emitted]
 asset 524.js 206 bytes {524} [emitted]
 asset 996.js 138 bytes {996} [emitted]
 Entrypoint main 10.2 KiB = main.js
@@ -2160,7 +2160,7 @@ exports[`StatsTestCases should print correct stats for preset-normal 1`] = `
 <w> [LogTestPlugin] Warning
 <i> [LogTestPlugin] Info
 asset main.js 10.2 KiB [emitted] (name: main)
-asset 460.js 320 bytes [emitted]
+asset 460.js 323 bytes [emitted]
 asset 524.js 206 bytes [emitted]
 asset 996.js 138 bytes [emitted]
 runtime modules 6 KiB 7 modules
@@ -2183,7 +2183,7 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for preset-normal-performance 1`] = `
 "asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>303 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main)
-asset <CLR=32,BOLD>460.js</CLR> 320 bytes <CLR=32,BOLD>[emitted]</CLR>
+asset <CLR=32,BOLD>460.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 runtime modules 6 KiB 7 modules
@@ -2211,7 +2211,7 @@ webpack x.x.x compiled with <CLR=33,BOLD>2 warnings</CLR> in X ms"
 
 exports[`StatsTestCases should print correct stats for preset-normal-performance-ensure-filter-sourcemaps 1`] = `
 "asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>303 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main) 1 related asset
-asset <CLR=32,BOLD>460.js</CLR> 352 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
+asset <CLR=32,BOLD>460.js</CLR> 355 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
 asset <CLR=32,BOLD>524.js</CLR> 238 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
 asset <CLR=32,BOLD>996.js</CLR> 170 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
 runtime modules 6 KiB 7 modules
@@ -2258,7 +2258,7 @@ exports[`StatsTestCases should print correct stats for preset-verbose 1`] = `
     [LogTestPlugin] End
 PublicPath: auto
 asset main.js 10.2 KiB {179} [emitted] (name: main)
-asset 460.js 320 bytes {460} [emitted]
+asset 460.js 323 bytes {460} [emitted]
 asset 524.js 206 bytes {524} [emitted]
 asset 996.js 138 bytes {996} [emitted]
 Entrypoint main 10.2 KiB = main.js


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix for breaking code under ES3 when access `.catch` of promises, which is related to #13972