### PR TITLE
Honor `hashFunction` option for createFileSerializer

### DIFF
--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -991,7 +991,10 @@ class PackFileCacheStrategy {
 		allowCollectingMemory,
 		compression
 	}) {
-		this.fileSerializer = createFileSerializer(fs, compiler.options.output.hashFunction);
+		this.fileSerializer = createFileSerializer(
+			fs,
+			compiler.options.output.hashFunction
+		);
 		this.fileSystemInfo = new FileSystemInfo(fs, {
 			managedPaths: snapshot.managedPaths,
 			immutablePaths: snapshot.immutablePaths,


### PR DESCRIPTION
In addition to the main breakage of Node.JS 17, we also experienced this one:
Caching fails because the hashing function for serializing being used is always the default one.

Changing it so that the hash function also gets passed to createFileSerializer() which accepts a second parameter, the hash function. Using that change, I was able to change the hash function in my webpack config and get filesystem caching working on Node 17 without any errors.