### PR TITLE
WIP: ignore exportsFields in context resolver

### DIFF
--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -640,6 +640,7 @@ class WebpackOptionsApply extends OptionsApply {
 				resolveOptions = cleverMerge(options.resolve, resolveOptions);
 				resolveOptions.fileSystem = compiler.inputFileSystem;
 				resolveOptions.resolveToContext = true;
+				resolveOptions.exportsFields = [];
 				return resolveOptions;
 			});
 		compiler.resolverFactory.hooks.resolveOptions


### PR DESCRIPTION
Fixes #13865.

When resolving dynamic imports the prefix of the import will be resolved as a context first.
This prefix is not the full path and may therefore not show up in the exports fields.

For example
```
import(`highlight.js/lib/languages/${lang}`)
```
will try to import `highlight.js/lib/languages` but the key in the exports field is `./lib/languages/*`

This commit disables checking the exports field for context resolution.

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
no. For now curious to see which tests break.

**Does this PR introduce a breaking change?**
probably... will refine once i know which.

**What needs to be documented once your changes are merged?**

If this works as intended i don't think additional documentation is needed. Maybe it should be pointed out though that context resolution will not respect exports and why.
