### PR TITLE
Fix names of options to match the exported types

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -449,7 +449,7 @@ const applyJavascriptParserOptionsDefaults = (
 	D(parserOptions, "wrappedContextRecursive", true);
 	D(parserOptions, "wrappedContextCritical", false);
 	D(parserOptions, "strictThisContextOnImports", false);
-	if (futureDefaults) D(parserOptions, "exportPresence", "error");
+	if (futureDefaults) D(parserOptions, "exportsPresence", "error");
 };
 
 /**

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -23,10 +23,10 @@ const { HarmonyStarExportsList } = HarmonyExportImportedSpecifierDependency;
 module.exports = class HarmonyExportDependencyParserPlugin {
 	constructor(options) {
 		this.exportPresenceMode =
-			options.reexportExportPresence !== undefined
-				? ExportPresenceModes.fromUserOption(options.reexportExportPresence)
-				: options.exportPresence !== undefined
-				? ExportPresenceModes.fromUserOption(options.exportPresence)
+			options.reexportExportsPresence !== undefined
+				? ExportPresenceModes.fromUserOption(options.reexportExportsPresence)
+				: options.exportsPresence !== undefined
+				? ExportPresenceModes.fromUserOption(options.exportsPresence)
 				: options.strictExportPresence
 				? ExportPresenceModes.ERROR
 				: ExportPresenceModes.AUTO;

--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -755,8 +755,8 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 	 * @returns {WebpackError[]} warnings
 	 */
 	getWarnings(moduleGraph) {
-		const exportPresence = this._getEffectiveExportPresenceLevel(moduleGraph);
-		if (exportPresence === ExportPresenceModes.WARN) {
+		const exportsPresence = this._getEffectiveExportPresenceLevel(moduleGraph);
+		if (exportsPresence === ExportPresenceModes.WARN) {
 			return this._getErrors(moduleGraph);
 		}
 		return null;
@@ -768,8 +768,8 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 	 * @returns {WebpackError[]} errors
 	 */
 	getErrors(moduleGraph) {
-		const exportPresence = this._getEffectiveExportPresenceLevel(moduleGraph);
-		if (exportPresence === ExportPresenceModes.ERROR) {
+		const exportsPresence = this._getEffectiveExportPresenceLevel(moduleGraph);
+		if (exportsPresence === ExportPresenceModes.ERROR) {
 			return this._getErrors(moduleGraph);
 		}
 		return null;

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -67,10 +67,10 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 	 */
 	constructor(options) {
 		this.exportPresenceMode =
-			options.importExportPresence !== undefined
-				? ExportPresenceModes.fromUserOption(options.importExportPresence)
-				: options.exportPresence !== undefined
-				? ExportPresenceModes.fromUserOption(options.exportPresence)
+			options.importExportsPresence !== undefined
+				? ExportPresenceModes.fromUserOption(options.importExportsPresence)
+				: options.exportsPresence !== undefined
+				? ExportPresenceModes.fromUserOption(options.exportsPresence)
 				: options.strictExportPresence
 				? ExportPresenceModes.ERROR
 				: ExportPresenceModes.AUTO;

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -173,8 +173,8 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 	 * @returns {WebpackError[]} warnings
 	 */
 	getWarnings(moduleGraph) {
-		const exportPresence = this._getEffectiveExportPresenceLevel(moduleGraph);
-		if (exportPresence === ExportPresenceModes.WARN) {
+		const exportsPresence = this._getEffectiveExportPresenceLevel(moduleGraph);
+		if (exportsPresence === ExportPresenceModes.WARN) {
 			return this._getErrors(moduleGraph);
 		}
 		return null;
@@ -186,8 +186,8 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 	 * @returns {WebpackError[]} errors
 	 */
 	getErrors(moduleGraph) {
-		const exportPresence = this._getEffectiveExportPresenceLevel(moduleGraph);
-		if (exportPresence === ExportPresenceModes.ERROR) {
+		const exportsPresence = this._getEffectiveExportPresenceLevel(moduleGraph);
+		if (exportsPresence === ExportPresenceModes.ERROR) {
 			return this._getErrors(moduleGraph);
 		}
 		return null;

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -1939,7 +1939,7 @@ describe("Defaults", () => {
 			+       },
 			+       Object {
 			@@ ... @@
-			+         "exportPresence": "error",
+			+         "exportsPresence": "error",
 			@@ ... @@
 			-     "__dirname": "mock",
 			-     "__filename": "mock",

--- a/test/configCases/compiletime/exports-presence/webpack.config.js
+++ b/test/configCases/compiletime/exports-presence/webpack.config.js
@@ -6,27 +6,27 @@ module.exports = {
 			{
 				test: /aaa/,
 				parser: {
-					exportPresence: false
+					exportsPresence: false
 				}
 			},
 			{
 				test: /bbb/,
 				parser: {
-					exportPresence: "warn"
+					exportsPresence: "warn"
 				}
 			},
 			{
 				test: /ccc/,
 				parser: {
-					exportPresence: "error"
+					exportsPresence: "error"
 				}
 			},
 			{
 				test: /ddd/,
 				parser: {
-					exportPresence: "error",
-					importExportPresence: "warn",
-					reexportExportPresence: false
+					exportsPresence: "error",
+					importExportsPresence: "warn",
+					reexportExportsPresence: false
 				}
 			}
 		]


### PR DESCRIPTION
The names of the new export options do not match the names present in the options schema. Note how different places have an "s" after exports while some don't. This change simply fixes all cases where the options used in webpack didn't match the outward display names.

https://github.com/webpack/webpack/blob/14dd4f912c013f060bf7843a3d5462a51ff3051b/types.d.ts#L5341

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
no, but fixes recently added tests

**Does this PR introduce a breaking change?**
kind of, but more fixes the options values introduced this morning

**What needs to be documented once your changes are merged?**
nothing beyond what needs to be documented for initial change
