### PR TITLE
perf: Prevent running regexs over the same strings twice

### DIFF
--- a/lib/WatchIgnorePlugin.js
+++ b/lib/WatchIgnorePlugin.js
@@ -5,6 +5,7 @@
 
 "use strict";
 
+const { groupBy } = require("./util/ArrayHelpers");
 const createSchemaValidation = require("./util/create-schema-validation");
 
 /** @typedef {import("../declarations/plugins/WatchIgnorePlugin").WatchIgnorePluginOptions} WatchIgnorePluginOptions */
@@ -40,14 +41,12 @@ class IgnoringWatchFileSystem {
 				p instanceof RegExp ? p.test(path) : path.indexOf(p) === 0
 			);
 
-		const notIgnored = path => !ignored(path);
-
-		const ignoredFiles = files.filter(ignored);
-		const ignoredDirs = dirs.filter(ignored);
+		const [ignoredFiles, notIgnoredFiles] = groupBy(files, ignored);
+		const [ignoredDirs, notIgnoredDirs] = groupBy(dirs, ignored);
 
 		const watcher = this.wfs.watch(
-			files.filter(notIgnored),
-			dirs.filter(notIgnored),
+			notIgnoredFiles,
+			notIgnoredDirs,
 			missing,
 			startTime,
 			options,

--- a/lib/util/ArrayHelpers.js
+++ b/lib/util/ArrayHelpers.js
@@ -12,3 +12,19 @@ exports.equals = (a, b) => {
 	}
 	return true;
 };
+
+/**
+ *
+ * @param {Array} arr Array of values to be partitioned
+ * @param {(value: any) => boolean} fn Partition function which partitions based on truthiness of result.
+ * @returns {[Array, Array]} returns the values of `arr` partitioned into two new arrays based on fn predicate.
+ */
+exports.groupBy = (arr = [], fn) => {
+	return arr.reduce(
+		(groups, value) => {
+			groups[fn(value) ? 0 : 1].push(value);
+			return groups;
+		},
+		[[], []]
+	);
+};

--- a/test/ArrayHelpers.unittest.js
+++ b/test/ArrayHelpers.unittest.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const ArrayHelpers = require("../lib/util/ArrayHelpers");
+
+describe("ArrayHelpers", () => {
+	it("groupBy should partition into two arrays", () => {
+		expect(
+			ArrayHelpers.groupBy([1, 2, 3, 4, 5, 6], x => x % 2 === 0)
+		).toStrictEqual([
+			[2, 4, 6],
+			[1, 3, 5]
+		]);
+	});
+	it("groupBy works with empty array", () => {
+		expect(ArrayHelpers.groupBy([], x => x % 2 === 0)).toStrictEqual([[], []]);
+	});
+});


### PR DESCRIPTION
Another small perf win I found from our CPU profiles. Seems there are a few other optimizations available in the watching setup and teardown in each invalidation cycle. In large projects, especially in monorepos which may even just ignore most files), there is a bunch of repeated work per entry. While I am still spending time ramping up in the area, I will try to take out some quick wins.

Based on CPU profiles, this change improves our recompile time by about 50ms. Not a lot, but its free!

**What kind of change does this PR introduce?**
perf

**Did you add tests for your changes?**
yes
**Does this PR introduce a breaking change?**
no

**What needs to be documented once your changes are merged?**
no
