### PR TITLE
Make errorHandler optional in accept(self)

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -104,7 +104,7 @@ declare namespace webpack {
 				) => void
 			): void;
 			(
-				errorHandler: (
+				errorHandler?: (
 					err: Error,
 					ids: { moduleId: string | number; module: NodeJS.Module }
 				) => void


### PR DESCRIPTION
I changed `webpack/module` types to make sure that calling `import.meta.webpackHot.accept()` without arguments still works.

I used `@types/webpack-env` before and there the error handler parameter is optional. Error typing itself is not helpful though.

See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2026ab9fbd33457124a0a6a55d5c1d1e3f696764/types/webpack-env/index.d.ts#L145

**What kind of change does this PR introduce?**

Types change.

**Did you add tests for your changes?**

Does webpack have tests for these type definitions? If not, then I would propose a tool called [expect-type](https://www.npmjs.com/package/expect-type), which looks pretty convenient. Here are some examples of what it could look like https://github.com/faergeek/typed-forms/blob/03d73b0964e47ac9a4984d74b0800b53a4d783f1/src/index.spec.ts. `typed-forms` is still a work in progress though))

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

I'm not sure if using `webpack/module` for types is documented anywhere aside from release notes, where I saw it. If it does, the link would be helpful.