### PR TITLE
Adding types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ const memoize = require("./util/memoize");
 /** @typedef {import("../declarations/WebpackOptions").RuleSetRule} RuleSetRule */
 /** @typedef {import("../declarations/WebpackOptions").RuleSetUse} RuleSetUse */
 /** @typedef {import("../declarations/WebpackOptions").RuleSetUseItem} RuleSetUseItem */
+/** @typedef {import("../declarations/WebpackOptions").StatsOptions} StatsOptions */
 /** @typedef {import("../declarations/WebpackOptions").WebpackOptions} Configuration */
 /** @typedef {import("../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptionsNormalized */
 /** @typedef {import("../declarations/WebpackOptions").WebpackPluginFunction} WebpackPluginFunction */
@@ -27,6 +28,8 @@ const memoize = require("./util/memoize");
 /** @typedef {import("./Compilation").AssetInfo} AssetInfo */
 /** @typedef {import("./MultiStats")} MultiStats */
 /** @typedef {import("./Parser").ParserState} ParserState */
+/** @typedef {import("./ResolverFactory").ResolvePluginInstance} ResolvePluginInstance */
+/** @typedef {import("./ResolverFactory").Resolver} Resolver */
 /** @typedef {import("./Watching")} Watching */
 /** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsAsset} StatsAsset */
 /** @typedef {import("./stats/DefaultStatsFactoryPlugin").StatsChunk} StatsChunk */

--- a/types.d.ts
+++ b/types.d.ts
@@ -2141,7 +2141,7 @@ declare interface Configuration {
 	/**
 	 * Enable production optimizations or development hints.
 	 */
-	mode?: "development" | "production" | "none";
+	mode?: "none" | "development" | "production";
 
 	/**
 	 * Options affecting the normal modules (`NormalModuleFactory`).
@@ -2226,15 +2226,15 @@ declare interface Configuration {
 	 */
 	stats?:
 		| boolean
+		| StatsOptions
 		| "none"
+		| "verbose"
 		| "summary"
 		| "errors-only"
 		| "errors-warnings"
 		| "minimal"
 		| "normal"
-		| "detailed"
-		| "verbose"
-		| StatsOptions;
+		| "detailed";
 
 	/**
 	 * Environment to build for. An array of environments to build for all of them when possible.
@@ -4557,7 +4557,7 @@ declare interface InfrastructureLogging {
 	/**
 	 * Log level.
 	 */
-	level?: "none" | "verbose" | "error" | "warn" | "info" | "log";
+	level?: "none" | "error" | "warn" | "info" | "log" | "verbose";
 
 	/**
 	 * Stream used for logging output. Defaults to process.stderr. This option is only used when no custom console is provided.
@@ -4703,7 +4703,7 @@ declare class JavascriptModulesPlugin {
 	static chunkHasJs: (chunk: Chunk, chunkGraph: ChunkGraph) => boolean;
 }
 declare class JavascriptParser extends Parser {
-	constructor(sourceType?: "module" | "script" | "auto");
+	constructor(sourceType?: "module" | "auto" | "script");
 	hooks: Readonly<{
 		evaluateTypeof: HookMap<
 			SyncBailHook<
@@ -4973,7 +4973,7 @@ declare class JavascriptParser extends Parser {
 		program: SyncBailHook<[Program, Comment[]], boolean | void>;
 		finish: SyncBailHook<[Program, Comment[]], boolean | void>;
 	}>;
-	sourceType: "module" | "script" | "auto";
+	sourceType: "module" | "auto" | "script";
 	scope: ScopeInfo;
 	state: ParserState;
 	comments: any;
@@ -5313,7 +5313,7 @@ declare interface JavascriptParserOptions {
 	/**
 	 * Specifies the behavior of invalid export names in "import ... from ..." and "export ... from ...".
 	 */
-	exportsPresence?: false | "error" | "warn" | "auto";
+	exportsPresence?: false | "auto" | "error" | "warn";
 
 	/**
 	 * Enable warnings for full dynamic dependencies.
@@ -5348,7 +5348,7 @@ declare interface JavascriptParserOptions {
 	/**
 	 * Specifies the behavior of invalid export names in "import ... from ...".
 	 */
-	importExportsPresence?: false | "error" | "warn" | "auto";
+	importExportsPresence?: false | "auto" | "error" | "warn";
 
 	/**
 	 * Include polyfills or mocks for various node stuff.
@@ -5358,7 +5358,7 @@ declare interface JavascriptParserOptions {
 	/**
 	 * Specifies the behavior of invalid export names in "export ... from ...". This might be useful to disable during the migration from "export ... from ..." to "export type ... from ..." when reexporting types in TypeScript.
 	 */
-	reexportExportsPresence?: false | "error" | "warn" | "auto";
+	reexportExportsPresence?: false | "auto" | "error" | "warn";
 
 	/**
 	 * Enable/disable parsing of require.context syntax.
@@ -5595,7 +5595,7 @@ declare interface KnownNormalizedStatsOptions {
 	modulesSpace: number;
 	chunkModulesSpace: number;
 	nestedModulesSpace: number;
-	logging: false | "none" | "verbose" | "error" | "warn" | "info" | "log";
+	logging: false | "none" | "error" | "warn" | "info" | "log" | "verbose";
 	loggingDebug: ((value: string) => boolean)[];
 	loggingTrace: boolean;
 }
@@ -7553,7 +7553,7 @@ declare interface NormalModuleLoaderContext<OptionsType> {
 	rootContext: string;
 	fs: InputFileSystem;
 	sourceMap?: boolean;
-	mode: "development" | "production" | "none";
+	mode: "none" | "development" | "production";
 	webpack?: boolean;
 	_module?: NormalModule;
 	_compilation?: Compilation;
@@ -9410,7 +9410,7 @@ declare interface ResolveOptionsWebpackOptions {
 	/**
 	 * Plugins for the resolver.
 	 */
-	plugins?: ("..." | ResolvePluginInstance)[];
+	plugins?: (ResolvePluginInstance | "...")[];
 
 	/**
 	 * Prefer to resolve server-relative URLs (starting with '/') as absolute paths before falling back to resolve in 'resolve.roots'.
@@ -11252,7 +11252,7 @@ declare interface StatsOptions {
 	/**
 	 * Add logging output.
 	 */
-	logging?: boolean | "none" | "verbose" | "error" | "warn" | "info" | "log";
+	logging?: boolean | "none" | "error" | "warn" | "info" | "log" | "verbose";
 
 	/**
 	 * Include debug logging of specified loggers (i. e. for plugins or loaders). Filters can be Strings, RegExps or Functions.
@@ -11421,15 +11421,15 @@ type StatsPrinterContext = KnownStatsPrinterContext & Record<string, any>;
 type StatsProfile = KnownStatsProfile & Record<string, any>;
 type StatsValue =
 	| boolean
+	| StatsOptions
 	| "none"
+	| "verbose"
 	| "summary"
 	| "errors-only"
 	| "errors-warnings"
 	| "minimal"
 	| "normal"
-	| "detailed"
-	| "verbose"
-	| StatsOptions;
+	| "detailed";
 declare interface SyntheticDependencyLocation {
 	name: string;
 	index?: number;
@@ -12039,7 +12039,7 @@ declare interface WebpackOptionsNormalized {
 	/**
 	 * Enable production optimizations or development hints.
 	 */
-	mode?: "development" | "production" | "none";
+	mode?: "none" | "development" | "production";
 
 	/**
 	 * Options affecting the normal modules (`NormalModuleFactory`).
@@ -12711,6 +12711,7 @@ declare namespace exports {
 		RuleSetRule,
 		RuleSetUse,
 		RuleSetUseItem,
+		StatsOptions,
 		Configuration,
 		WebpackOptionsNormalized,
 		WebpackPluginInstance,
@@ -12718,6 +12719,8 @@ declare namespace exports {
 		AssetInfo,
 		MultiStats,
 		ParserState,
+		ResolvePluginInstance,
+		Resolver,
 		Watching,
 		StatsAsset,
 		StatsChunk,


### PR DESCRIPTION
@Brian-McBride rebase of https://github.com/webpack/webpack/pull/12875

**What kind of change does this PR introduce?**

This exposes more type definitions that are required for proper plugin development using Typescript.

**Did you add tests for your changes?**

There are no existing type tests. Added the types and ran the `fix` script as directed.

**Does this PR introduce a breaking change?**

Np, there are no type changes, just adding to the final export. The `fix` script changed the actual definition file. My edit was only to `lib/index.js`

**What needs to be documented once your changes are merged?**

Nothing. Typescript is self documentation.
