### PR TITLE
Proposed fix to module federation to stop ignoring the singleton flag when requiredVersion is false

### DIFF
--- a/lib/sharing/ConsumeSharedModule.js
+++ b/lib/sharing/ConsumeSharedModule.js
@@ -210,6 +210,10 @@ class ConsumeSharedModule extends Module {
 			}
 			args.push(stringifyHoley(requiredVersion));
 			fn += "VersionCheck";
+		} else {
+			if (singleton) {
+				fn += "Singleton";
+			}
 		}
 		if (fallbackCode) {
 			fn += "Fallback";

--- a/lib/sharing/ConsumeSharedRuntimeModule.js
+++ b/lib/sharing/ConsumeSharedRuntimeModule.js
@@ -248,7 +248,7 @@ class ConsumeSharedRuntimeModule extends RuntimeModule {
 				"scopeName, scope, key, fallback",
 				[
 					`if(!scope || !${RuntimeGlobals.hasOwnProperty}(scope, key)) return fallback();`,
-					"return getSingletonVersion(scope, scopeName, key);"
+					"return getSingleton(scope, scopeName, key);"
 				]
 			)});`,
 			`var loadSingletonVersionCheckFallback = /*#__PURE__*/ init(${runtimeTemplate.basicFunction(

--- a/lib/sharing/ConsumeSharedRuntimeModule.js
+++ b/lib/sharing/ConsumeSharedRuntimeModule.js
@@ -108,6 +108,13 @@ class ConsumeSharedRuntimeModule extends RuntimeModule {
 					`return "Unsatisfied version " + version + " from " + (version && scope[key][version].from) + " of shared singleton module " + key + " (required " + rangeToString(requiredVersion) + ")"`
 				]
 			)};`,
+			`var getSingleton = ${runtimeTemplate.basicFunction(
+				"scope, scopeName, key, requiredVersion",
+				[
+					"var version = findSingletonVersionKey(scope, key);",
+					"return get(scope[key][version]);"
+				]
+			)};`,
 			`var getSingletonVersion = ${runtimeTemplate.basicFunction(
 				"scope, scopeName, key, requiredVersion",
 				[
@@ -202,6 +209,13 @@ class ConsumeSharedRuntimeModule extends RuntimeModule {
 					"return get(findValidVersion(scope, key, version) || warnInvalidVersion(scope, scopeName, key, version) || findVersion(scope, key));"
 				]
 			)});`,
+			`var loadSingleton = /*#__PURE__*/ init(${runtimeTemplate.basicFunction(
+				"scopeName, scope, key",
+				[
+					"ensureExistence(scopeName, key);",
+					"return getSingleton(scope, scopeName, key);"
+				]
+			)});`,
 			`var loadSingletonVersionCheck = /*#__PURE__*/ init(${runtimeTemplate.basicFunction(
 				"scopeName, scope, key, version",
 				[
@@ -228,6 +242,13 @@ class ConsumeSharedRuntimeModule extends RuntimeModule {
 				[
 					`if(!scope || !${RuntimeGlobals.hasOwnProperty}(scope, key)) return fallback();`,
 					"return get(findValidVersion(scope, key, version) || warnInvalidVersion(scope, scopeName, key, version) || findVersion(scope, key));"
+				]
+			)});`,
+			`var loadSingletonFallback = /*#__PURE__*/ init(${runtimeTemplate.basicFunction(
+				"scopeName, scope, key, fallback",
+				[
+					`if(!scope || !${RuntimeGlobals.hasOwnProperty}(scope, key)) return fallback();`,
+					"return getSingletonVersion(scope, scopeName, key);"
 				]
 			)});`,
 			`var loadSingletonVersionCheckFallback = /*#__PURE__*/ init(${runtimeTemplate.basicFunction(

--- a/test/configCases/sharing/consume-module/index.js
+++ b/test/configCases/sharing/consume-module/index.js
@@ -196,6 +196,15 @@ it("should handle version matching correctly in strict and singleton mode", asyn
 				get: () => () => "shared singleton",
 				from: 'container-a'
 			}
+		},
+		singletonWithoutVersion: {
+			"1.0.0": {
+				get: () => () => "shared singleton v1.0.0",
+				loaded: true
+			},
+			"2.0.0": {
+				get: () => () => "shared singleton v2.0.0"
+			}
 		}
 	};
 	{
@@ -233,5 +242,23 @@ it("should handle version matching correctly in strict and singleton mode", asyn
 		expectWarning(
 			/Unsatisfied version 1\.1\.1 from container-a of shared singleton module singleton \(required =1\.1\.0\)/
 		);
+	}
+});
+
+it("should not instantiate multiple singletons even if a higher version exists", async () => {
+	__webpack_share_scopes__["default"] = {
+		singletonWithoutVersion: {
+			"1.0.0": {
+				get: () => () => "shared singleton v1.0.0",
+				loaded: true
+			},
+			"2.0.0": {
+				get: () => () => "shared singleton v2.0.0"
+			}
+		}
+	};
+	{
+		const result = await import("singletonWithoutVersion");
+		expect(result.default).toBe("shared singleton v1.0.0");
 	}
 });

--- a/test/configCases/sharing/consume-module/node_modules/singletonWithoutVersion.js
+++ b/test/configCases/sharing/consume-module/node_modules/singletonWithoutVersion.js
@@ -1,0 +1,1 @@
+module.exports = "singleton without version";

--- a/test/configCases/sharing/consume-module/webpack.config.js
+++ b/test/configCases/sharing/consume-module/webpack.config.js
@@ -54,6 +54,10 @@ module.exports = {
 					requiredVersion: "1.1.0",
 					singleton: true,
 					strictVersion: false
+				},
+				singletonWithoutVersion: {
+					requiredVersion: false,
+					singleton: true
 				}
 			}
 		})


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This addresses (fixes #14795) . Previously, when using module federation, if requiredVersion was false, the singleton flag would be entirely ignored. Since it's entirely valid to require one instance of a package be instantiated, but not care at all what version it is, this seems like an oversight.


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

The core of this change is in `ConsumeSharedModule.codeGeneration`, which now includes logic for when requiredVersion is false but singleton is true. Specifically, it causes the generated code to call one of two new functions - loadSingleton, or loadSingletonFallback if a fallback is present. The code for these new functions is located in `ConsumeSharedRuntimeModule.generate`, along with a helper function, getSingleton, which acts similarly to getSingletonVersion but without doing a semver check.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

I did not. Pardon my ignorance, but I can't figure out where or how to add a test for this. 

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No, or at least, I wouldn't think so. This technically changes the behavior of webpack, but I'd be shocked if anyone was depending on the existing behavior, given how this appears to be a bug instead of an intended feature.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Nothing, I don't think - this code change makes the code work as I'd expect from the current documentation, so I don't think any changes would be needed.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
