### PR TITLE
chore: update prettier globs for lint-staged 

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 <!-- Before creating an issue please make sure you are using the latest version of webpack. -->
 <!-- Also consider trying the webpack@beta version, maybe it's already fixed. -->
 
-**Do you want to request a *feature* or report a *bug*?**
+**Do you want to request a _feature_ or report a _bug_?**
 
 <!-- Please ask questions on StackOverflow or the webpack Gitter (https://gitter.im/webpack/webpack). -->
 <!-- Issues which contain questions or support requests will be closed. -->

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -15,9 +15,7 @@ about: Create a report to help us improve
 
 **What is the current behavior?**
 
-
 **If the current behavior is a bug, please provide the steps to reproduce.**
-
 
 <!-- A great way to do this is to provide your configuration via a GitHub repository -->
 <!-- The most helpful is a minimal reproduction with instructions on how to reproduce -->
@@ -28,12 +26,11 @@ about: Create a report to help us improve
 
 **What is the expected behavior?**
 
-
 <!-- "It should work" is not a helpful explanation -->
 <!-- Explain exactly how it should behave -->
 
 **Other relevant information:**
-webpack version:  
-Node.js version: 
-Operating System: 
+webpack version:
+Node.js version:
+Operating System:
 Additional tools:

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,7 +1,6 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-
 ---
 
 <!-- Please don't delete this template or we'll close your issue -->
@@ -16,12 +15,9 @@ about: Suggest an idea for this project
 
 **What is the expected behavior?**
 
-
 **What is motivation or use case for adding/changing the behavior?**
 
-
 **How should this be implemented in your opinion?**
-
 
 **Are you willing to work on this yourself?**
 yes

--- a/.github/ISSUE_TEMPLATE/Other.md
+++ b/.github/ISSUE_TEMPLATE/Other.md
@@ -1,7 +1,6 @@
 ---
 name: Other
 about: Something else
-
 ---
 
 <!-- Bug reports and Feature requests must use other templates, or will be closed -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,6 @@
 <!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
 <!-- Try to link to an open issue for more information. -->
 
-
 <!-- In addition to that please answer these questions: -->
 
 **What kind of change does this PR introduce?**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,12 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-    timezone: Europe/Berlin
-  open-pull-requests-limit: 20
-  labels:
-  - dependencies
-  versioning-strategy: widen
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "04:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 20
+    labels:
+      - dependencies
+    versioning-strategy: widen

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,14 +1,15 @@
 package.json
 
 # Ignore test fixtures
-test/*.*
+test/
 !test/*.js
 !test/**/webpack.config.js
 !test/**/deprecations.js
 
 # Ignore example fixtures
-examples/*.*
+examples/
 !examples/**/webpack.config.js
 
 # Ignore generated files
 *.check.js
+*.d.ts

--- a/assembly/tsconfig.json
+++ b/assembly/tsconfig.json
@@ -1,6 +1,4 @@
 {
   "extends": "assemblyscript/std/assembly.json",
-  "include": [
-    "./**/*.asm.ts"
-  ]
+  "include": ["./**/*.asm.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "fix": "yarn code-lint --fix && yarn special-lint-fix && yarn pretty-lint-fix",
     "prepare": "husky install",
     "pretty-lint-base": "prettier \"*.{ts,json,yml,yaml,md}\" \"{setup,lib,bin,hot,benchmark,tooling,schemas}/**/*.json\" \"examples/*.md\"",
-    "pretty-lint-base-all": "yarn pretty-lint-base \"*.js\" \"{setup,lib,bin,hot,benchmark,tooling,schemas}/**/*.js\" \"module.d.ts\" \"test/*.js\" \"test/helpers/*.js\" \"test/{configCases,watchCases,statsCases,hotCases,benchmarkCases}/**/webpack.config.js\" \"examples/**/webpack.config.js\"",
+    "pretty-lint-base-all": "prettier -c .",
     "pretty-lint-fix": "yarn pretty-lint-base-all --loglevel warn --write",
     "pretty-lint": "yarn pretty-lint-base --check",
     "yarn-lint": "yarn-deduplicate --fail --list -s highest yarn.lock",
@@ -187,8 +187,8 @@
     "*.js|{lib,setup,bin,hot,tooling,schemas}/**/*.js|test/*.js|{test,examples}/**/webpack.config.js}": [
       "eslint --cache"
     ],
-    "*.{ts,json,yml,yaml,md}|examples/*.md": [
-      "prettier --check"
+    "*": [
+      "prettier --check --ignore-unknown"
     ],
     "*.md|{.github,benchmark,bin,examples,hot,lib,schemas,setup,tooling}/**/*.{md,yml,yaml,js,json}": [
       "cspell"


### PR DESCRIPTION
Update `.prettierignore` so `prettier -w .` only produces the current diff.
Updated the lint-staged hook now that only intended files are caught.

**What kind of change does this PR introduce?**

Chore/whitespace changes for moving forward

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

None
