### PR TITLE
chore: expand ESLint globs for .mjs files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,8 +6,6 @@ benchmark
 coverage
 
 # Ignore not supported files
-!.*.js
-.eslintrc.js
 *.d.ts
 
 # Ignore precompiled schemas

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
 		"eol-last": "error",
 		"no-extra-bind": "warn",
 		"no-process-exit": "warn",
-		"no-use-before-define": "off",
 		"no-unused-vars": ["error", { args: "none", ignoreRestSiblings: true }],
 		"no-loop-func": "off",
 		"node/no-missing-require": ["error", { allowModules: ["webpack"] }],
@@ -91,13 +90,31 @@ module.exports = {
 			}
 		},
 		{
-			files: ["test/**/*.js"],
+			files: ["test/**/*.js", "test/**/*.mjs"],
 			env: {
 				"jest/globals": true
 			},
 			globals: {
 				nsObj: false,
 				jasmine: false
+			}
+		},
+		{
+			files: ["test/**/*.mjs"],
+			parser: "@babel/eslint-parser",
+			parserOptions: {
+				requireConfigFile: false,
+				ecmaVersion: 2021
+			},
+			rules: {
+				"node/no-missing-import": "off",
+				"node/no-unsupported-features/es-syntax": "off"
+			}
+		},
+		{
+			files: ["test/cases/parsing/hashbang/file.mjs"],
+			rules: {
+				"node/shebang": "off"
 			}
 		}
 	]

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.11.1",
+    "@babel/eslint-parser": "^7.16.3",
     "@babel/preset-react": "^7.10.4",
     "@types/es-module-lexer": "^0.4.1",
     "@types/jest": "^27.0.2",
@@ -155,7 +156,7 @@
     "pretest": "yarn lint",
     "prelint": "yarn setup",
     "lint": "yarn code-lint && yarn special-lint && yarn type-lint && yarn typings-test && yarn module-typings-test && yarn yarn-lint && yarn pretty-lint && yarn spellcheck",
-    "code-lint": "eslint . --ext '.js' --cache",
+    "code-lint": "eslint . --cache",
     "type-lint": "tsc",
     "typings-test": "tsc -p tsconfig.types.test.json",
     "module-typings-test": "tsc -p tsconfig.module.test.json",
@@ -184,7 +185,7 @@
     "cover:report": "nyc report -t coverage"
   },
   "lint-staged": {
-    "*.js|{lib,setup,bin,hot,tooling,schemas}/**/*.js|test/*.js|{test,examples}/**/webpack.config.js}": [
+    "*.js|*.mjs": [
       "eslint --cache"
     ],
     "*.{ts,json,yml,yaml,md}|examples/*.md": [

--- a/test/cases/entry-exports-field/imports/pkg.mjs
+++ b/test/cases/entry-exports-field/imports/pkg.mjs
@@ -1,1 +1,1 @@
-export default 'pkg';
+export default "pkg";

--- a/test/cases/mjs/esm-by-default/index.mjs
+++ b/test/cases/mjs/esm-by-default/index.mjs
@@ -7,10 +7,12 @@ it("should not use mjs extension by default", () => {
 it("should not have commonjs stuff available", function () {
 	if (typeof module !== "undefined") {
 		// If module is available
+		// eslint-disable-next-line no-undef
 		expect(module).toHaveProperty("webpackTestSuiteModule"); // it must be the node.js module
 	}
 	if (typeof require !== "undefined") {
 		// If require is available
+		// eslint-disable-next-line no-undef
 		expect(require).toHaveProperty("webpackTestSuiteRequire"); // it must be the node.js require
 	}
 });

--- a/test/cases/mjs/no-module-main-field/index.mjs
+++ b/test/cases/mjs/no-module-main-field/index.mjs
@@ -1,5 +1,6 @@
+// eslint-disable-next-line node/no-extraneous-import
 import result from "m";
 
-it("should use the correct entry point", function() {
+it("should use the correct entry point", function () {
 	expect(result).toBe("yep");
 });

--- a/test/configCases/plugins/provide-plugin/foo.mjs
+++ b/test/configCases/plugins/provide-plugin/foo.mjs
@@ -1,3 +1,4 @@
 export default function foo() {
-    return esm;
+	// eslint-disable-next-line no-undef
+	return esm;
 }

--- a/test/configCases/web/node-source/index.mjs
+++ b/test/configCases/web/node-source/index.mjs
@@ -1,12 +1,12 @@
 // Block `require`, but keep webpack from trying to work around it.
-eval("require = undefined")
+eval("require = undefined");
 
 it("should compile fine", () => {
-    // It's okay if this executes fine or if `global` is not defined. If it
-    // results in a `require()` call, this will throw a `TypeError` instead.
-    try {
-        global
-    } catch (e) {
-        if (!(e instanceof ReferenceError)) throw e
-    }
-})
+	// It's okay if this executes fine or if `global` is not defined. If it
+	// results in a `require()` call, this will throw a `TypeError` instead.
+	try {
+		global;
+	} catch (e) {
+		if (!(e instanceof ReferenceError)) throw e;
+	}
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,6 +51,15 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
+"@babel/eslint-parser@^7.16.3":
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.16.3.tgz#2a6b1702f3f5aea48e00cea5a5bcc241c437e459"
+  integrity sha512-iB4ElZT0jAt7PKVaeVulOECdGe6UnmA/O0P9jlF5g5GBOwDVbna8AXhHRu4s27xQf6OkveyA8iTDv1jHdDejgQ==
+  dependencies:
+    eslint-scope "^5.1.1"
+    eslint-visitor-keys "^2.1.0"
+    semver "^6.3.0"
+
 "@babel/generator@^7.16.0", "@babel/generator@^7.7.2":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.16.0.tgz#d40f3d1d5075e62d3500bccb67f3daa8a95265b2"
@@ -2463,6 +2472,11 @@ eslint-visitor-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
+
+eslint-visitor-keys@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
+  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
 eslint@^7.14.0:
   version "7.32.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Update the build so that all supported files are linted by ESLint. Added the babel-eslint parser so the newer `.mjs` and top level import/await could be parsed. That might not be needed with ESLint 8, but that requires dropping Node 10.

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
