### PR TITLE
feat: allow specific description for CLI options

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -37,6 +37,7 @@ const webpackSchema = require("../schemas/WebpackOptions.json");
 /**
  * @typedef {Object} ArgumentConfig
  * @property {string} description
+ * @property {string} [negatedDescription]
  * @property {string} path
  * @property {boolean} multiple
  * @property {"enum"|"string"|"path"|"number"|"boolean"|"RegExp"|"reset"} type
@@ -99,6 +100,18 @@ const getArguments = (schema = webpackSchema) => {
 			if (schema.cli && schema.cli.helper) continue;
 			if (schema.cliDescription) return schema.cliDescription;
 			if (schema.description) return schema.description;
+		}
+	};
+
+	/**
+	 *
+	 * @param {PathItem[]} path path in the schema
+	 * @returns {string | undefined} negative description
+	 */
+	const getNegatedDescription = path => {
+		for (const { schema } of path) {
+			if (schema.cli && schema.cli.helper) continue;
+			if (schema.negatedDescription) return schema.negatedDescription;
 		}
 	};
 
@@ -168,6 +181,7 @@ const getArguments = (schema = webpackSchema) => {
 		const argConfigBase = schemaToArgumentConfig(path[0].schema);
 		if (!argConfigBase) return 0;
 
+		const negatedDescription = getNegatedDescription(path);
 		const name = pathToArgumentName(path[0].path);
 		/** @type {ArgumentConfig} */
 		const argConfig = {
@@ -176,6 +190,10 @@ const getArguments = (schema = webpackSchema) => {
 			description: getDescription(path),
 			path: path[0].path
 		};
+
+		if (negatedDescription) {
+			argConfig.negatedDescription = negatedDescription;
+		}
 
 		if (!flags[name]) {
 			flags[name] = {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -97,6 +97,7 @@ const getArguments = (schema = webpackSchema) => {
 	const getDescription = path => {
 		for (const { schema } of path) {
 			if (schema.cli && schema.cli.helper) continue;
+			if (schema.cliDescription) return schema.cliDescription;
 			if (schema.description) return schema.description;
 		}
 	};

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -97,8 +97,10 @@ const getArguments = (schema = webpackSchema) => {
 	 */
 	const getDescription = path => {
 		for (const { schema } of path) {
-			if (schema.cli && schema.cli.helper) continue;
-			if (schema.cliDescription) return schema.cliDescription;
+			if (schema.cli) {
+				if (schema.cli.helper) continue;
+				if (schema.cli.description) return schema.cli.description;
+			}
 			if (schema.description) return schema.description;
 		}
 	};
@@ -110,8 +112,24 @@ const getArguments = (schema = webpackSchema) => {
 	 */
 	const getNegatedDescription = path => {
 		for (const { schema } of path) {
-			if (schema.cli && schema.cli.helper) continue;
-			if (schema.negatedDescription) return schema.negatedDescription;
+			if (schema.cli) {
+				if (schema.cli.helper) continue;
+				if (schema.cli.negatedDescription) return schema.cli.negatedDescription;
+			}
+		}
+	};
+
+	/**
+	 *
+	 * @param {PathItem[]} path path in the schema
+	 * @returns {string | undefined} reset description
+	 */
+	const getResetDescription = path => {
+		for (const { schema } of path) {
+			if (schema.cli) {
+				if (schema.cli.helper) continue;
+				if (schema.cli.resetDescription) return schema.cli.resetDescription;
+			}
 		}
 	};
 
@@ -156,13 +174,17 @@ const getArguments = (schema = webpackSchema) => {
 	const addResetFlag = path => {
 		const schemaPath = path[0].path;
 		const name = pathToArgumentName(`${schemaPath}.reset`);
-		const description = getDescription(path);
+		const description =
+			getResetDescription(path) ||
+			`Clear all items provided in '${schemaPath}' configuration. ${getDescription(
+				path
+			)}`;
 		flags[name] = {
 			configs: [
 				{
 					type: "reset",
 					multiple: false,
-					description: `Clear all items provided in '${schemaPath}' configuration. ${description}`,
+					description,
 					path: schemaPath
 				}
 			],

--- a/test/Cli.basictest.js
+++ b/test/Cli.basictest.js
@@ -5,6 +5,34 @@ describe("Cli", () => {
 		expect(getArguments()).toMatchSnapshot();
 	});
 
+	it("should generate the correct cli flags with custom schema", () => {
+		const schema = {
+			title: "custom CLI options",
+			type: "object",
+			additionalProperties: false,
+			properties: {
+				"with-cli-description": {
+					type: "string",
+					description: "original description",
+					cliDescription: "description for CLI option"
+				},
+				"with-negative-description": {
+					type: "boolean",
+					description: "original description",
+					negatedDescription: "custom negative description"
+				},
+				"with-both-cli-and-negative-description": {
+					type: "boolean",
+					description: "original description",
+					cliDescription: "description for CLI option",
+					negatedDescription: "custom negative description"
+				}
+			}
+		};
+
+		expect(getArguments(schema)).toMatchSnapshot();
+	});
+
 	const test = (name, values, config, fn) => {
 		it(`should correctly process arguments for ${name}`, () => {
 			const args = getArguments();

--- a/test/Cli.basictest.js
+++ b/test/Cli.basictest.js
@@ -11,21 +11,37 @@ describe("Cli", () => {
 			type: "object",
 			additionalProperties: false,
 			properties: {
+				"with-reset-description": {
+					type: "array",
+					items: {
+						type: "string"
+					},
+					description: "original description",
+					cli: {
+						resetDescription: "custom reset"
+					}
+				},
 				"with-cli-description": {
 					type: "string",
 					description: "original description",
-					cliDescription: "description for CLI option"
+					cli: {
+						description: "description for CLI option"
+					}
 				},
 				"with-negative-description": {
 					type: "boolean",
 					description: "original description",
-					negatedDescription: "custom negative description"
+					cli: {
+						negatedDescription: "custom negative description"
+					}
 				},
 				"with-both-cli-and-negative-description": {
 					type: "boolean",
 					description: "original description",
-					cliDescription: "description for CLI option",
-					negatedDescription: "custom negative description"
+					cli: {
+						description: "description for CLI option",
+						negatedDescription: "custom negative description"
+					}
 				}
 			}
 		};

--- a/test/__snapshots__/Cli.basictest.js.snap
+++ b/test/__snapshots__/Cli.basictest.js.snap
@@ -8931,3 +8931,49 @@ Object {
   },
 }
 `;
+
+exports[`Cli should generate the correct cli flags with custom schema 1`] = `
+Object {
+  "with-both-cli-and-negative-description": Object {
+    "configs": Array [
+      Object {
+        "description": "description for CLI option",
+        "multiple": false,
+        "negatedDescription": "custom negative description",
+        "path": "with-both-cli-and-negative-description",
+        "type": "boolean",
+      },
+    ],
+    "description": "description for CLI option",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+  "with-cli-description": Object {
+    "configs": Array [
+      Object {
+        "description": "description for CLI option",
+        "multiple": false,
+        "path": "with-cli-description",
+        "type": "string",
+      },
+    ],
+    "description": "description for CLI option",
+    "multiple": false,
+    "simpleType": "string",
+  },
+  "with-negative-description": Object {
+    "configs": Array [
+      Object {
+        "description": "original description",
+        "multiple": false,
+        "negatedDescription": "custom negative description",
+        "path": "with-negative-description",
+        "type": "boolean",
+      },
+    ],
+    "description": "original description",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
+}
+`;

--- a/test/__snapshots__/Cli.basictest.js.snap
+++ b/test/__snapshots__/Cli.basictest.js.snap
@@ -8975,5 +8975,31 @@ Object {
     "multiple": false,
     "simpleType": "boolean",
   },
+  "with-reset-description": Object {
+    "configs": Array [
+      Object {
+        "description": "original description",
+        "multiple": true,
+        "path": "with-reset-description[]",
+        "type": "string",
+      },
+    ],
+    "description": "original description",
+    "multiple": true,
+    "simpleType": "string",
+  },
+  "with-reset-description-reset": Object {
+    "configs": Array [
+      Object {
+        "description": "custom reset",
+        "multiple": false,
+        "path": "with-reset-description",
+        "type": "reset",
+      },
+    ],
+    "description": "custom reset",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
 }
 `;

--- a/types.d.ts
+++ b/types.d.ts
@@ -215,6 +215,7 @@ declare interface Argument {
 }
 declare interface ArgumentConfig {
 	description: string;
+	negatedDescription?: string;
 	path: string;
 	multiple: boolean;
 	type: "string" | "number" | "boolean" | "path" | "enum" | "RegExp" | "reset";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Feature

 - add `cliDescription` -  Sometimes we need specific descriptions for CLI options, for example when we are deprecating a CLI option only in favor of another  
   - https://github.com/webpack/webpack-dev-server/pull/4091 
   - https://github.com/webpack/webpack-dev-server/pull/4098
 
 - add `negatedDescription` - `webpack-cli` creates a negative flag for each `boolean` flag, it uses [`negatedDescription` property for description if available](https://github.com/webpack/webpack-cli/blob/ebf665344079489f2b4f36d7d1c5e46b36550985/packages/webpack-cli/lib/webpack-cli.js#L467).
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

It is for internal usage, nothing to be documented.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
