### PR TITLE
fix: prevent undefined data when update

### DIFF
--- a/lib/util/hash/wasm-hash.js
+++ b/lib/util/hash/wasm-hash.js
@@ -47,8 +47,9 @@ class WasmHash {
 			}
 			this._updateWithShortString(data, encoding);
 			return this;
+		} else if (typeof data !== "undefined") {
+			this._updateWithBuffer(data);
 		}
-		this._updateWithBuffer(data);
 		return this;
 	}
 


### PR DESCRIPTION
When there is a code hydration, like nextjs, and an npm package contains references to use window, used only in the client part, like twilio-video, the update with buffer sends an undefined value in the data parameter

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

No, the case occurs when using next with twilio-video and there is rehydration. The test can start talking as soon as twilio-video changes parts of the code, that is, it is something external.

**Does this PR introduce a breaking change?**

No 

**What needs to be documented once your changes are merged?**

Nothing