### PR TITLE
lower default aggregateTimeout to 20ms

### DIFF
--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -49,7 +49,7 @@ class Watching {
 			this.watchOptions = {};
 		}
 		if (typeof this.watchOptions.aggregateTimeout !== "number") {
-			this.watchOptions.aggregateTimeout = 200;
+			this.watchOptions.aggregateTimeout = 20;
 		}
 		this.compiler = compiler;
 		this.running = false;


### PR DESCRIPTION
Resolves #15040 

**What kind of change does this PR introduce?**
default config change

**Did you add tests for your changes?**
no, all tests pass though

**Does this PR introduce a breaking change?**
no

**What needs to be documented once your changes are merged?**
https://webpack.js.org/configuration/watch/#watchoptionsaggregatetimeout
above default should be updated. not sure if docs defaults are updated automatically
