### PR TITLE
Change the Implementation of get() in MultiItemCache to Prevent Stack Exhaustion

### DIFF
--- a/lib/CacheFacade.js
+++ b/lib/CacheFacade.js
@@ -46,15 +46,23 @@ class MultiItemCache {
 	 * @returns {void}
 	 */
 	get(callback) {
-		const next = i => {
-			this._items[i].get((err, result) => {
+		let i = 0;
+		let resultFound = false;
+		const generateGetCallback = (/** @type {Boolean} */ lastItem) => {
+			return (
+				/** @type {import("./WebpackError")} */ err,
+				/** @type {T} */ res
+			) => {
+				if (resultFound) return;
+				resultFound = !!(err || res || false);
 				if (err) return callback(err);
-				if (result !== undefined) return callback(null, result);
-				if (++i >= this._items.length) return callback();
-				next(i);
-			});
+				if (res !== undefined) return callback(null, res);
+				if (lastItem) return callback();
+			};
 		};
-		next(0);
+		do {
+			this._items[i].get(generateGetCallback(i === this._items.length - 1));
+		} while (++i < this._items.length);
 	}
 
 	/**

--- a/lib/CacheFacade.js
+++ b/lib/CacheFacade.js
@@ -5,6 +5,7 @@
 
 "use strict";
 
+const { forEachBail } = require("enhanced-resolve");
 const asyncLib = require("neo-async");
 const getLazyHashedEtag = require("./cache/getLazyHashedEtag");
 const mergeEtags = require("./cache/mergeEtags");
@@ -46,23 +47,7 @@ class MultiItemCache {
 	 * @returns {void}
 	 */
 	get(callback) {
-		let i = 0;
-		let resultFound = false;
-		const generateGetCallback = (/** @type {Boolean} */ lastItem) => {
-			return (
-				/** @type {import("./WebpackError")} */ err,
-				/** @type {T} */ res
-			) => {
-				if (resultFound) return;
-				resultFound = !!(err || res || false);
-				if (err) return callback(err);
-				if (res !== undefined) return callback(null, res);
-				if (lastItem) return callback();
-			};
-		};
-		do {
-			this._items[i].get(generateGetCallback(i === this._items.length - 1));
-		} while (++i < this._items.length);
+		forEachBail(this._items, (item, callback) => item.get(callback), callback);
 	}
 
 	/**

--- a/test/MultiItemCache.unittest.js
+++ b/test/MultiItemCache.unittest.js
@@ -32,7 +32,7 @@ describe("MultiItemCache", () => {
 		const multiItemCache = new MultiItemCache(itemCaches);
 		let callbacks = 0;
 		const callback = (err, res) => {
-			expect(err).toBeUndefined();
+			expect(err).toBeNull();
 			expect(res).toBeUndefined();
 			++callbacks;
 		};

--- a/test/MultiItemCache.unittest.js
+++ b/test/MultiItemCache.unittest.js
@@ -1,0 +1,65 @@
+"use strict";
+
+const Cache = require("../lib/Cache");
+const { ItemCacheFacade, MultiItemCache } = require("../lib/CacheFacade");
+
+describe("MultiItemCache", () => {
+	it("Throws when getting items from an empty Cache", () => {
+		const multiItemCache = new MultiItemCache(generateItemCaches(0));
+		expect(() => multiItemCache.get(_ => _())).toThrowError();
+	});
+
+	it("Returns the single ItemCacheFacade when passed an array of length 1", () => {
+		const itemCaches = generateItemCaches(1);
+		const multiItemCache = new MultiItemCache(itemCaches);
+		expect(multiItemCache).toBe(itemCaches[0]);
+	});
+
+	it("Retrieves items from the underlying Cache when get is called", () => {
+		const itemCaches = generateItemCaches(10);
+		const multiItemCache = new MultiItemCache(itemCaches);
+		const callback = (err, res) => {
+			expect(err).toBeNull();
+			expect(res).toBeInstanceOf(Object);
+		};
+		for (let i = 0; i < 10; ++i) {
+			multiItemCache.get(callback);
+		}
+	});
+
+	it("Can get() a large number of items without exhausting the stack", () => {
+		const itemCaches = generateItemCaches(10000, () => undefined);
+		const multiItemCache = new MultiItemCache(itemCaches);
+		let callbacks = 0;
+		const callback = (err, res) => {
+			expect(err).toBeUndefined();
+			expect(res).toBeUndefined();
+			++callbacks;
+		};
+		multiItemCache.get(callback);
+		expect(callbacks).toEqual(1);
+	});
+
+	function generateItemCaches(howMany, dataGenerator) {
+		const ret = [];
+		for (let i = 0; i < howMany; ++i) {
+			const name = `ItemCache${i}`;
+			const tag = `ItemTag${i}`;
+			const dataGen =
+				dataGenerator ||
+				(() => {
+					return { name: tag };
+				});
+			const cache = new Cache();
+			cache.hooks.get.tapAsync(
+				"DataReturner",
+				(_identifier, _etag, _gotHandlers, callback) => {
+					callback(undefined, dataGen());
+				}
+			);
+			const itemCache = new ItemCacheFacade(cache, name, tag);
+			ret[i] = itemCache;
+		}
+		return ret;
+	}
+});


### PR DESCRIPTION
One of the projects I'm on at work has such a large number of outputs (currently 1400 and growing) and that is causing webpack to crash during compilation. You can [see in the stack trace](https://gist.github.com/dtanders/b244f9d58757b2ad57486a2981a88097#file-webpack_stack_trace-txt-L7942) starting here that the same 6 lines repeat a little over 1200 times until the stack is exhausted. This is because the MultiItemCache in lib/CacheFacade.js uses recursion to iterate over it's item list when you call get().  This implementation prevents stack exhaustion both in the included unit test and in my testing with our project. I'm sure it could be more elegantly written but I've taken care to avoid behavioral changes other than preventing our use case from blowing the stack.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

This is a bugfix for a probably-rare case in which a large number of outputs causes compilation to exhaust the interpreter stack.

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing that I'm aware of
