### PR TITLE
Upgrade graceful-fs to support throwIfNoEntry in input/output filesystem

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eslint-scope": "5.1.1",
     "events": "^3.2.0",
     "glob-to-regexp": "^0.4.1",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "json-parse-better-errors": "^1.0.2",
     "loader-runner": "^4.2.0",
     "mime-types": "^2.1.27",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2958,10 +2958,10 @@ globby@^11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
-  integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
+graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
+  integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
 handlebars@^4.0.1:
   version "4.7.7"


### PR DESCRIPTION
First step in being able to complete:
https://github.com/webpack/enhanced-resolve/issues/316
https://github.com/xz64/license-webpack-plugin/issues/109

**What kind of change does this PR introduce?**
deps upgrade to support https://github.com/isaacs/node-graceful-fs/issues/221

**Did you add tests for your changes?**
no

**Does this PR introduce a breaking change?**
no

**What needs to be documented once your changes are merged?**
nothing
