### PR TITLE
Add typedef for `ResolveData["createData"]`

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -64,6 +64,8 @@ const memoize = require("./util/memoize");
 /** @typedef {import("./ModuleGraph")} ModuleGraph */
 /** @typedef {import("./ModuleGraphConnection").ConnectionState} ConnectionState */
 /** @typedef {import("./NormalModuleFactory")} NormalModuleFactory */
+/** @typedef {import("./NormalModuleFactory").LoaderItem} LoaderItem */
+/** @typedef {import("./NormalModuleFactory").NormalModuleCreateData} NormalModuleCreateData */
 /** @typedef {import("./Parser")} Parser */
 /** @typedef {import("./RequestShortener")} RequestShortener */
 /** @typedef {import("./ResolverFactory").ResolverWithOptions} ResolverWithOptions */
@@ -90,14 +92,6 @@ const getInvalidDependenciesModuleWarning = memoize(() =>
 const getValidate = memoize(() => require("schema-utils").validate);
 
 const ABSOLUTE_PATH_REGEX = /^([a-zA-Z]:\\|\\\\|\/)/;
-
-/**
- * @typedef {Object} LoaderItem
- * @property {string} loader
- * @property {any} options
- * @property {string?} ident
- * @property {string?} type
- */
 
 /**
  * @param {string} context absolute context path
@@ -246,22 +240,7 @@ class NormalModule extends Module {
 	}
 
 	/**
-	 * @param {Object} options options object
-	 * @param {string=} options.layer an optional layer in which the module is
-	 * @param {string} options.type module type
-	 * @param {string} options.request request string
-	 * @param {string} options.userRequest request intended by user (without loaders from config)
-	 * @param {string} options.rawRequest request without resolving
-	 * @param {LoaderItem[]} options.loaders list of loaders
-	 * @param {string} options.resource path + query of the real resource
-	 * @param {Record<string, any>=} options.resourceResolveData resource resolve data
-	 * @param {string} options.context context directory for resolving
-	 * @param {string | undefined} options.matchResource path + query of the matched resource (virtual)
-	 * @param {Parser} options.parser the parser used
-	 * @param {object} options.parserOptions the options of the parser used
-	 * @param {Generator} options.generator the generator used
-	 * @param {object} options.generatorOptions the options of the generator used
-	 * @param {Object} options.resolveOptions options used for resolving requests from this module
+	 * @param {NormalModuleCreateData} options options object
 	 */
 	constructor({
 		layer,

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -65,7 +65,6 @@ const memoize = require("./util/memoize");
 /** @typedef {import("./ModuleGraphConnection").ConnectionState} ConnectionState */
 /** @typedef {import("./NormalModuleFactory")} NormalModuleFactory */
 /** @typedef {import("./NormalModuleFactory").LoaderItem} LoaderItem */
-/** @typedef {import("./NormalModuleFactory").NormalModuleCreateData} NormalModuleCreateData */
 /** @typedef {import("./Parser")} Parser */
 /** @typedef {import("./RequestShortener")} RequestShortener */
 /** @typedef {import("./ResolverFactory").ResolverWithOptions} ResolverWithOptions */
@@ -74,6 +73,25 @@ const memoize = require("./util/memoize");
 /** @typedef {import("./util/Hash")} Hash */
 /** @typedef {import("./util/fs").InputFileSystem} InputFileSystem */
 /** @typedef {import("./util/runtime").RuntimeSpec} RuntimeSpec */
+
+/**
+ * @typedef {Object} NormalModuleCreateData
+ * @property {string=} layer an optional layer in which the module is
+ * @property {string} type module type
+ * @property {string} request request string
+ * @property {string} userRequest request intended by user (without loaders from config)
+ * @property {string} rawRequest request without resolving
+ * @property {LoaderItem[]} loaders list of loaders
+ * @property {string} resource path + query of the real resource
+ * @property {Record<string, any>=} resourceResolveData resource resolve data
+ * @property {string} context context directory for resolving
+ * @property {string | undefined} matchResource path + query of the matched resource (virtual)
+ * @property {Parser} parser the parser used
+ * @property {object} parserOptions the options of the parser used
+ * @property {Generator} generator the generator used
+ * @property {object} generatorOptions the options of the generator used
+ * @property {Object} resolveOptions options used for resolving requests from this module
+ */
 
 /**
  * @typedef {Object} SourceMap

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -34,6 +34,7 @@ const { parseResource } = require("./util/identifier");
 /** @typedef {import("./Generator")} Generator */
 /** @typedef {import("./ModuleFactory").ModuleFactoryCreateData} ModuleFactoryCreateData */
 /** @typedef {import("./ModuleFactory").ModuleFactoryResult} ModuleFactoryResult */
+/** @typedef {import("./NormalModule").NormalModuleCreateData} NormalModuleCreateData */
 /** @typedef {import("./Parser")} Parser */
 /** @typedef {import("./ResolverFactory")} ResolverFactory */
 /** @typedef {import("./dependencies/ModuleDependency")} ModuleDependency */
@@ -45,25 +46,6 @@ const { parseResource } = require("./util/identifier");
  * @property {any} options
  * @property {string?} ident
  * @property {string?} type
- */
-
-/**
- * @typedef {Object} NormalModuleCreateData
- * @property {string=} layer an optional layer in which the module is
- * @property {string} type module type
- * @property {string} request request string
- * @property {string} userRequest request intended by user (without loaders from config)
- * @property {string} rawRequest request without resolving
- * @property {LoaderItem[]} loaders list of loaders
- * @property {string} resource path + query of the real resource
- * @property {Record<string, any>=} resourceResolveData resource resolve data
- * @property {string} context context directory for resolving
- * @property {string | undefined} matchResource path + query of the matched resource (virtual)
- * @property {Parser} parser the parser used
- * @property {object} parserOptions the options of the parser used
- * @property {Generator} generator the generator used
- * @property {object} generatorOptions the options of the generator used
- * @property {Object} resolveOptions options used for resolving requests from this module
  */
 
 /**

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -40,6 +40,33 @@ const { parseResource } = require("./util/identifier");
 /** @typedef {import("./util/fs").InputFileSystem} InputFileSystem */
 
 /**
+ * @typedef {Object} LoaderItem
+ * @property {string} loader
+ * @property {any} options
+ * @property {string?} ident
+ * @property {string?} type
+ */
+
+/**
+ * @typedef {Object} NormalModuleCreateData
+ * @property {string=} layer an optional layer in which the module is
+ * @property {string} type module type
+ * @property {string} request request string
+ * @property {string} userRequest request intended by user (without loaders from config)
+ * @property {string} rawRequest request without resolving
+ * @property {LoaderItem[]} loaders list of loaders
+ * @property {string} resource path + query of the real resource
+ * @property {Record<string, any>=} resourceResolveData resource resolve data
+ * @property {string} context context directory for resolving
+ * @property {string | undefined} matchResource path + query of the matched resource (virtual)
+ * @property {Parser} parser the parser used
+ * @property {object} parserOptions the options of the parser used
+ * @property {Generator} generator the generator used
+ * @property {object} generatorOptions the options of the generator used
+ * @property {Object} resolveOptions options used for resolving requests from this module
+ */
+
+/**
  * @typedef {Object} ResolveData
  * @property {ModuleFactoryCreateData["contextInfo"]} contextInfo
  * @property {ModuleFactoryCreateData["resolveOptions"]} resolveOptions
@@ -48,7 +75,7 @@ const { parseResource } = require("./util/identifier");
  * @property {Record<string, any> | undefined} assertions
  * @property {ModuleDependency[]} dependencies
  * @property {string} dependencyType
- * @property {Object} createData
+ * @property {NormalModuleCreateData} createData
  * @property {LazySet<string>} fileDependencies
  * @property {LazySet<string>} missingDependencies
  * @property {LazySet<string>} contextDependencies

--- a/types.d.ts
+++ b/types.d.ts
@@ -7378,68 +7378,7 @@ declare class NodeTemplatePlugin {
 }
 type NodeWebpackOptions = false | NodeOptions;
 declare class NormalModule extends Module {
-	constructor(__0: {
-		/**
-		 * an optional layer in which the module is
-		 */
-		layer?: string;
-		/**
-		 * module type
-		 */
-		type: string;
-		/**
-		 * request string
-		 */
-		request: string;
-		/**
-		 * request intended by user (without loaders from config)
-		 */
-		userRequest: string;
-		/**
-		 * request without resolving
-		 */
-		rawRequest: string;
-		/**
-		 * list of loaders
-		 */
-		loaders: LoaderItem[];
-		/**
-		 * path + query of the real resource
-		 */
-		resource: string;
-		/**
-		 * resource resolve data
-		 */
-		resourceResolveData?: Record<string, any>;
-		/**
-		 * context directory for resolving
-		 */
-		context: string;
-		/**
-		 * path + query of the matched resource (virtual)
-		 */
-		matchResource?: string;
-		/**
-		 * the parser used
-		 */
-		parser: Parser;
-		/**
-		 * the options of the parser used
-		 */
-		parserOptions: object;
-		/**
-		 * the generator used
-		 */
-		generator: Generator;
-		/**
-		 * the options of the generator used
-		 */
-		generatorOptions: object;
-		/**
-		 * options used for resolving requests from this module
-		 */
-		resolveOptions: Object;
-	});
+	constructor(__0: NormalModuleCreateData);
 	request: string;
 	userRequest: string;
 	rawRequest: string;
@@ -7490,6 +7429,82 @@ declare interface NormalModuleCompilationHooks {
 	readResource: HookMap<AsyncSeriesBailHook<[object], string | Buffer>>;
 	needBuild: AsyncSeriesBailHook<[NormalModule, NeedBuildContext], boolean>;
 }
+declare interface NormalModuleCreateData {
+	/**
+	 * an optional layer in which the module is
+	 */
+	layer?: string;
+
+	/**
+	 * module type
+	 */
+	type: string;
+
+	/**
+	 * request string
+	 */
+	request: string;
+
+	/**
+	 * request intended by user (without loaders from config)
+	 */
+	userRequest: string;
+
+	/**
+	 * request without resolving
+	 */
+	rawRequest: string;
+
+	/**
+	 * list of loaders
+	 */
+	loaders: LoaderItem[];
+
+	/**
+	 * path + query of the real resource
+	 */
+	resource: string;
+
+	/**
+	 * resource resolve data
+	 */
+	resourceResolveData?: Record<string, any>;
+
+	/**
+	 * context directory for resolving
+	 */
+	context: string;
+
+	/**
+	 * path + query of the matched resource (virtual)
+	 */
+	matchResource?: string;
+
+	/**
+	 * the parser used
+	 */
+	parser: Parser;
+
+	/**
+	 * the options of the parser used
+	 */
+	parserOptions: object;
+
+	/**
+	 * the generator used
+	 */
+	generator: Generator;
+
+	/**
+	 * the options of the generator used
+	 */
+	generatorOptions: object;
+
+	/**
+	 * options used for resolving requests from this module
+	 */
+	resolveOptions: Object;
+}
 declare abstract class NormalModuleFactory extends ModuleFactory {
 	hooks: Readonly<{
 		resolve: AsyncSeriesBailHook<[ResolveData], any>;
@@ -7502,8 +7517,14 @@ declare abstract class NormalModuleFactory extends ModuleFactory {
 		factorize: AsyncSeriesBailHook<[ResolveData], any>;
 		beforeResolve: AsyncSeriesBailHook<[ResolveData], any>;
 		afterResolve: AsyncSeriesBailHook<[ResolveData], any>;
-		createModule: AsyncSeriesBailHook<[Object, ResolveData], any>;
-		module: SyncWaterfallHook<[Module, Object, ResolveData], any>;
+		createModule: AsyncSeriesBailHook<
+			[NormalModuleCreateData, ResolveData],
+			any
+		>;
+		module: SyncWaterfallHook<
+			[Module, NormalModuleCreateData, ResolveData],
+			any
+		>;
 		createParser: HookMap<SyncBailHook<any, any>>;
 		parser: HookMap<SyncHook<any>>;
 		createGenerator: HookMap<SyncBailHook<any, any>>;
@@ -9300,7 +9321,7 @@ declare interface ResolveData {
 	assertions?: Record<string, any>;
 	dependencies: ModuleDependency[];
 	dependencyType: string;
-	createData: Object;
+	createData: NormalModuleCreateData;
 	fileDependencies: LazySet<string>;
 	missingDependencies: LazySet<string>;
 	contextDependencies: LazySet<string>;


### PR DESCRIPTION
Fixes #15112

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Internal type documentation. Only external impact should be consumers of `types.d.ts` who will now have more accurate typing.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No - not entirely sure if that's applicable here. Happy to add any if there's particular areas which are testable here.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

Potentially for Typescript users who consume types for affected hooks (i.e. `NormalModuleFactory`'s `createModule` and `module` hooks) and incorrectly read properties from `createData`.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

n/a

## Lingering issues

I've opened this as a draft PR since these changes have surfaced a type error:

https://github.com/webpack/webpack/blob/ccecc17c01af96edddb931a76e7a3b21ef2969d8/lib/NormalModuleFactory.js#L750-L764

```
Type '{}' is missing the following properties from type 'NormalModuleCreateData': type, request, userRequest, rawRequest, and 9 more.ts(2740)

NormalModuleFactory.js(78, 4): The expected type comes from property 'createData' which is declared here on type 'ResolveData'
```

The error is correct - according to the typing of `ResolveData`, the initial `resolveData` object _should_ have a fully complete `createData` object. Any suggestions on how to best address this? Perhaps there's some reasonable defaults that can be applied here?