### PR TITLE
Fix ProfilingPlugin for watch scenarios

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -344,11 +344,15 @@ const interceptAllJavascriptModulesPluginHooks = (compilation, tracer) => {
 
 const makeInterceptorFor = (instance, tracer) => hookName => ({
 	register: ({ name, type, context, fn }) => {
-		const newFn = makeNewProfiledTapFn(hookName, tracer, {
-			name,
-			type,
-			fn
-		});
+		const newFn =
+			// Don't tap our own hooks to ensure stream can close cleanly
+			name === pluginName
+				? fn
+				: makeNewProfiledTapFn(hookName, tracer, {
+						name,
+						type,
+						fn
+				  });
 		return {
 			name,
 			type,

--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -123,9 +123,7 @@ class Profiler {
  * @returns {Trace} The trace object
  */
 const createTrace = (fs, outputPath) => {
-	const trace = new Tracer({
-		noStream: true
-	});
+	const trace = new Tracer();
 	const profiler = new Profiler(inspector);
 	if (/\/|\\/.test(outputPath)) {
 		const dirPath = dirname(fs, outputPath);
@@ -173,6 +171,7 @@ const createTrace = (fs, outputPath) => {
 		counter,
 		profiler,
 		end: callback => {
+			trace.push("]");
 			// Wait until the write stream finishes.
 			fsStream.on("close", () => {
 				callback();
@@ -242,10 +241,10 @@ class ProfilingPlugin {
 				stage: Infinity
 			},
 			(stats, callback) => {
+				if (compiler.watchMode) return callback();
 				tracer.profiler.stopProfiling().then(parsedResults => {
 					if (parsedResults === undefined) {
 						tracer.profiler.destroy();
-						tracer.trace.flush();
 						tracer.end(callback);
 						return;
 					}
@@ -293,7 +292,6 @@ class ProfilingPlugin {
 					});
 
 					tracer.profiler.destroy();
-					tracer.trace.flush();
 					tracer.end(callback);
 				});
 			}

--- a/test/WatchTestCases.template.js
+++ b/test/WatchTestCases.template.js
@@ -396,7 +396,7 @@ const describeCases = config => {
 																done
 															)
 														) {
-															compiler.close();
+															compiler.close(() => {});
 															return;
 														}
 														compiler.close(done);

--- a/test/watchCases/plugins/profiling-plugin/0/index.js
+++ b/test/watchCases/plugins/profiling-plugin/0/index.js
@@ -1,0 +1,3 @@
+it("compiles", function() {
+	expect(WATCH_STEP).toBe("0");
+})

--- a/test/watchCases/plugins/profiling-plugin/1/index.js
+++ b/test/watchCases/plugins/profiling-plugin/1/index.js
@@ -1,0 +1,3 @@
+it("should not crash on recompile", function() {
+	expect(WATCH_STEP).toBe("1");
+})

--- a/test/watchCases/plugins/profiling-plugin/deprecations.js
+++ b/test/watchCases/plugins/profiling-plugin/deprecations.js
@@ -1,0 +1,3 @@
+module.exports = [
+	{ code: /DEP_WEBPACK_COMPILATION_NORMAL_MODULE_LOADER_HOOK/ }
+];

--- a/test/watchCases/plugins/profiling-plugin/webpack.config.js
+++ b/test/watchCases/plugins/profiling-plugin/webpack.config.js
@@ -1,0 +1,6 @@
+var webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	plugins: [new webpack.debug.ProfilingPlugin()]
+};


### PR DESCRIPTION
Fixes #9114
By moving away from noStream mode, we get the same functionality (by pushing the fine "]" to make valid JSON) in non-watch scenario. In the watch scenario, we continue to keep the tracer running until the watch process ends. This will typically result in a near-complete JSON (missing a final "]"). Since streaming traces is so common, common stream inspectors (chrome://inspect) will fix up near-valid JSON for you.

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
yes

**Does this PR introduce a breaking change?**
no

**What needs to be documented once your changes are merged?**
nothing
