### PR TITLE
fix resource name when filename is data uri

### DIFF
--- a/lib/TemplatedPathPlugin.js
+++ b/lib/TemplatedPathPlugin.js
@@ -5,6 +5,7 @@
 
 "use strict";
 
+const mime = require("mime-types");
 const { basename, extname } = require("path");
 const util = require("util");
 const Chunk = require("./Chunk");
@@ -117,29 +118,53 @@ const replacePathVariables = (path, data, assetInfo) => {
 	// [name] - file
 	// [ext] - .js
 	if (typeof data.filename === "string") {
-		const { path: file, query, fragment } = parseResource(data.filename);
+		// check that filename is data uri
+		let match = data.filename.match(/^data:([^;,]+)/);
+		if (match) {
+			const ext = mime.extension(match[1]);
+			const emptyReplacer = replacer("", true);
 
-		const ext = extname(file);
-		const base = basename(file);
-		const name = base.slice(0, base.length - ext.length);
-		const path = file.slice(0, file.length - base.length);
+			replacements.set("file", emptyReplacer);
+			replacements.set("query", emptyReplacer);
+			replacements.set("fragment", emptyReplacer);
+			replacements.set("path", emptyReplacer);
+			replacements.set("base", emptyReplacer);
+			replacements.set("name", emptyReplacer);
+			replacements.set("ext", replacer(ext ? `.${ext}` : "", true));
+			// Legacy
+			replacements.set(
+				"filebase",
+				deprecated(
+					emptyReplacer,
+					"[filebase] is now [base]",
+					"DEP_WEBPACK_TEMPLATE_PATH_PLUGIN_REPLACE_PATH_VARIABLES_FILENAME"
+				)
+			);
+		} else {
+			const { path: file, query, fragment } = parseResource(data.filename);
 
-		replacements.set("file", replacer(file));
-		replacements.set("query", replacer(query, true));
-		replacements.set("fragment", replacer(fragment, true));
-		replacements.set("path", replacer(path, true));
-		replacements.set("base", replacer(base));
-		replacements.set("name", replacer(name));
-		replacements.set("ext", replacer(ext, true));
-		// Legacy
-		replacements.set(
-			"filebase",
-			deprecated(
-				replacer(base),
-				"[filebase] is now [base]",
-				"DEP_WEBPACK_TEMPLATE_PATH_PLUGIN_REPLACE_PATH_VARIABLES_FILENAME"
-			)
-		);
+			const ext = extname(file);
+			const base = basename(file);
+			const name = base.slice(0, base.length - ext.length);
+			const path = file.slice(0, file.length - base.length);
+
+			replacements.set("file", replacer(file));
+			replacements.set("query", replacer(query, true));
+			replacements.set("fragment", replacer(fragment, true));
+			replacements.set("path", replacer(path, true));
+			replacements.set("base", replacer(base));
+			replacements.set("name", replacer(name));
+			replacements.set("ext", replacer(ext, true));
+			// Legacy
+			replacements.set(
+				"filebase",
+				deprecated(
+					replacer(base),
+					"[filebase] is now [base]",
+					"DEP_WEBPACK_TEMPLATE_PATH_PLUGIN_REPLACE_PATH_VARIABLES_FILENAME"
+				)
+			);
+		}
 	}
 
 	// Compilation context

--- a/test/configCases/asset-modules/resource-from-data-uri/index.js
+++ b/test/configCases/asset-modules/resource-from-data-uri/index.js
@@ -1,0 +1,5 @@
+import asset from "data:image/svg+xml;utf8,<svg><title>icon-square-small</title></svg>"
+
+it("should compile with correct filename", () => {
+	expect(asset).toMatch(/public\/media\/\.[0-9a-zA-Z]{8}\.svg/);
+});

--- a/test/configCases/asset-modules/resource-from-data-uri/webpack.config.js
+++ b/test/configCases/asset-modules/resource-from-data-uri/webpack.config.js
@@ -1,0 +1,16 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		assetModuleFilename: "media/[name].[contenthash:8][ext]",
+		publicPath: "public/"
+	},
+	module: {
+		rules: [
+			{
+				mimetype: "image/svg+xml",
+				type: "asset/resource"
+			}
+		]
+	},
+	target: "web"
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fixes #13835 

- infer extension from mime type
- set path like replacement to empty string
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

for assets builded from data uri replacements:
`[name]`, `[file]`, `[query]`, `[fragment]`, `[base]`, `[path]` set to empty string
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
