### PR TITLE
dont count optional chaining in import specifier

### DIFF
--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -83,6 +83,18 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 	 */
 	apply(parser) {
 		const { exportPresenceMode } = this;
+
+		function getNonOptionalPart(members, membersOptions) {
+			let i = 0;
+			while (i < members.length && membersOptions[i] === false) i++;
+			return i !== members.length ? members.slice(0, i) : members;
+		}
+
+		function getNonOptionalMemberChain(node, count) {
+			while (count--) node = node.object;
+			return node;
+		}
+
 		parser.hooks.isPure
 			.for("Identifier")
 			.tap("HarmonyImportDependencyParserPlugin", expression => {
@@ -154,51 +166,83 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			});
 		parser.hooks.expressionMemberChain
 			.for(harmonySpecifierTag)
-			.tap("HarmonyImportDependencyParserPlugin", (expr, members) => {
-				const settings = /** @type {HarmonySettings} */ (parser.currentTagData);
-				const ids = settings.ids.concat(members);
-				const dep = new HarmonyImportSpecifierDependency(
-					settings.source,
-					settings.sourceOrder,
-					ids,
-					settings.name,
-					expr.range,
-					exportPresenceMode,
-					settings.assertions
-				);
-				dep.asiSafe = !parser.isAsiPosition(expr.range[0]);
-				dep.loc = expr.loc;
-				parser.state.module.addDependency(dep);
-				InnerGraph.onUsage(parser.state, e => (dep.usedByExports = e));
-				return true;
-			});
+			.tap(
+				"HarmonyImportDependencyParserPlugin",
+				(expression, members, membersOptions) => {
+					const settings = /** @type {HarmonySettings} */ (
+						parser.currentTagData
+					);
+					const nonOptionalMembers = getNonOptionalPart(
+						members,
+						membersOptions
+					);
+					const expr =
+						nonOptionalMembers !== members
+							? getNonOptionalMemberChain(
+									expression,
+									members.length - nonOptionalMembers.length
+							  )
+							: expression;
+					const ids = settings.ids.concat(nonOptionalMembers);
+					const dep = new HarmonyImportSpecifierDependency(
+						settings.source,
+						settings.sourceOrder,
+						ids,
+						settings.name,
+						expr.range,
+						exportPresenceMode,
+						settings.assertions
+					);
+					dep.asiSafe = !parser.isAsiPosition(expr.range[0]);
+					dep.loc = expr.loc;
+					parser.state.module.addDependency(dep);
+					InnerGraph.onUsage(parser.state, e => (dep.usedByExports = e));
+					return true;
+				}
+			);
 		parser.hooks.callMemberChain
 			.for(harmonySpecifierTag)
-			.tap("HarmonyImportDependencyParserPlugin", (expr, members) => {
-				const { arguments: args, callee } = expr;
-				const settings = /** @type {HarmonySettings} */ (parser.currentTagData);
-				const ids = settings.ids.concat(members);
-				const dep = new HarmonyImportSpecifierDependency(
-					settings.source,
-					settings.sourceOrder,
-					ids,
-					settings.name,
-					callee.range,
-					exportPresenceMode,
-					settings.assertions
-				);
-				dep.directImport = members.length === 0;
-				dep.call = true;
-				dep.asiSafe = !parser.isAsiPosition(callee.range[0]);
-				// only in case when we strictly follow the spec we need a special case here
-				dep.namespaceObjectAsContext =
-					members.length > 0 && this.strictThisContextOnImports;
-				dep.loc = callee.loc;
-				parser.state.module.addDependency(dep);
-				if (args) parser.walkExpressions(args);
-				InnerGraph.onUsage(parser.state, e => (dep.usedByExports = e));
-				return true;
-			});
+			.tap(
+				"HarmonyImportDependencyParserPlugin",
+				(expression, members, membersOptions) => {
+					const { arguments: args, callee } = expression;
+					const settings = /** @type {HarmonySettings} */ (
+						parser.currentTagData
+					);
+					const nonOptionalMembers = getNonOptionalPart(
+						members,
+						membersOptions
+					);
+					const expr =
+						nonOptionalMembers !== members
+							? getNonOptionalMemberChain(
+									callee,
+									members.length - nonOptionalMembers.length
+							  )
+							: callee;
+					const ids = settings.ids.concat(nonOptionalMembers);
+					const dep = new HarmonyImportSpecifierDependency(
+						settings.source,
+						settings.sourceOrder,
+						ids,
+						settings.name,
+						expr.range,
+						exportPresenceMode,
+						settings.assertions
+					);
+					dep.directImport = members.length === 0;
+					dep.call = true;
+					dep.asiSafe = !parser.isAsiPosition(expr.range[0]);
+					// only in case when we strictly follow the spec we need a special case here
+					dep.namespaceObjectAsContext =
+						members.length > 0 && this.strictThisContextOnImports;
+					dep.loc = expr.loc;
+					parser.state.module.addDependency(dep);
+					if (args) parser.walkExpressions(args);
+					InnerGraph.onUsage(parser.state, e => (dep.usedByExports = e));
+					return true;
+				}
+			);
 		const { hotAcceptCallback, hotAcceptWithoutCallback } =
 			HotModuleReplacementPlugin.getParserHooks(parser);
 		hotAcceptCallback.tap(

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -84,9 +84,9 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 	apply(parser) {
 		const { exportPresenceMode } = this;
 
-		function getNonOptionalPart(members, membersOptions) {
+		function getNonOptionalPart(members, membersOptionals) {
 			let i = 0;
-			while (i < members.length && membersOptions[i] === false) i++;
+			while (i < members.length && membersOptionals[i] === false) i++;
 			return i !== members.length ? members.slice(0, i) : members;
 		}
 
@@ -168,13 +168,13 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			.for(harmonySpecifierTag)
 			.tap(
 				"HarmonyImportDependencyParserPlugin",
-				(expression, members, membersOptions) => {
+				(expression, members, membersOptionals) => {
 					const settings = /** @type {HarmonySettings} */ (
 						parser.currentTagData
 					);
 					const nonOptionalMembers = getNonOptionalPart(
 						members,
-						membersOptions
+						membersOptionals
 					);
 					const expr =
 						nonOptionalMembers !== members
@@ -204,14 +204,14 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			.for(harmonySpecifierTag)
 			.tap(
 				"HarmonyImportDependencyParserPlugin",
-				(expression, members, membersOptions) => {
+				(expression, members, membersOptionals) => {
 					const { arguments: args, callee } = expression;
 					const settings = /** @type {HarmonySettings} */ (
 						parser.currentTagData
 					);
 					const nonOptionalMembers = getNonOptionalPart(
 						members,
-						membersOptions
+						membersOptionals
 					);
 					const expr =
 						nonOptionalMembers !== members

--- a/lib/javascript/BasicEvaluatedExpression.js
+++ b/lib/javascript/BasicEvaluatedExpression.js
@@ -67,6 +67,8 @@ class BasicEvaluatedExpression {
 		this.rootInfo = undefined;
 		/** @type {() => string[]} */
 		this.getMembers = undefined;
+		/** @type {() => boolean[]} */
+		this.getMembersOptions = undefined;
 		/** @type {EsTreeNode} */
 		this.expression = undefined;
 	}
@@ -342,11 +344,12 @@ class BasicEvaluatedExpression {
 		return this;
 	}
 
-	setIdentifier(identifier, rootInfo, getMembers) {
+	setIdentifier(identifier, rootInfo, getMembers, getMembersOptions) {
 		this.type = TypeIdentifier;
 		this.identifier = identifier;
 		this.rootInfo = rootInfo;
 		this.getMembers = getMembers;
+		this.getMembersOptions = getMembersOptions;
 		this.sideEffects = true;
 		return this;
 	}

--- a/lib/javascript/BasicEvaluatedExpression.js
+++ b/lib/javascript/BasicEvaluatedExpression.js
@@ -68,7 +68,7 @@ class BasicEvaluatedExpression {
 		/** @type {() => string[]} */
 		this.getMembers = undefined;
 		/** @type {() => boolean[]} */
-		this.getMembersOptions = undefined;
+		this.getMembersOptionals = undefined;
 		/** @type {EsTreeNode} */
 		this.expression = undefined;
 	}
@@ -344,12 +344,12 @@ class BasicEvaluatedExpression {
 		return this;
 	}
 
-	setIdentifier(identifier, rootInfo, getMembers, getMembersOptions) {
+	setIdentifier(identifier, rootInfo, getMembers, getMembersOptionals) {
 		this.type = TypeIdentifier;
 		this.identifier = identifier;
 		this.rootInfo = rootInfo;
 		this.getMembers = getMembers;
-		this.getMembersOptions = getMembersOptions;
+		this.getMembersOptionals = getMembersOptionals;
 		this.sideEffects = true;
 		return this;
 	}

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -57,7 +57,7 @@ const BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
 /** @typedef {import("../Parser").ParserState} ParserState */
 /** @typedef {import("../Parser").PreparsedAst} PreparsedAst */
 /** @typedef {{declaredScope: ScopeInfo, freeName: string | true, tagInfo: TagInfo | undefined}} VariableInfoInterface */
-/** @typedef {{ name: string | VariableInfo, rootInfo: string | VariableInfo, getMembers: () => string[] }} GetInfoResult */
+/** @typedef {{ name: string | VariableInfo, rootInfo: string | VariableInfo, getMembers: () => string[], getMembersOptions: () => boolean[] }} GetInfoResult */
 
 const EMPTY_ARRAY = [];
 const ALLOWED_MEMBER_TYPES_CALL_EXPRESSION = 0b01;
@@ -262,9 +262,9 @@ class JavascriptParser extends Parser {
 			/** @type {HookMap<SyncBailHook<[ExpressionNode], boolean | void>>} */
 			call: new HookMap(() => new SyncBailHook(["expression"])),
 			/** Something like "a.b()" */
-			/** @type {HookMap<SyncBailHook<[CallExpressionNode, string[]], boolean | void>>} */
+			/** @type {HookMap<SyncBailHook<[CallExpressionNode, string[], boolean[]], boolean | void>>} */
 			callMemberChain: new HookMap(
-				() => new SyncBailHook(["expression", "members"])
+				() => new SyncBailHook(["expression", "members", "membersOptions"])
 			),
 			/** Something like "a.b().c.d" */
 			/** @type {HookMap<SyncBailHook<[ExpressionNode, string[], CallExpressionNode, string[]], boolean | void>>} */
@@ -294,9 +294,9 @@ class JavascriptParser extends Parser {
 			new: new HookMap(() => new SyncBailHook(["expression"])),
 			/** @type {HookMap<SyncBailHook<[ExpressionNode], boolean | void>>} */
 			expression: new HookMap(() => new SyncBailHook(["expression"])),
-			/** @type {HookMap<SyncBailHook<[ExpressionNode, string[]], boolean | void>>} */
+			/** @type {HookMap<SyncBailHook<[ExpressionNode, string[], boolean[]], boolean | void>>} */
 			expressionMemberChain: new HookMap(
-				() => new SyncBailHook(["expression", "members"])
+				() => new SyncBailHook(["expression", "members", "membersOptions"])
 			),
 			/** @type {HookMap<SyncBailHook<[ExpressionNode, string[]], boolean | void>>} */
 			unhandledExpressionMemberChain: new HookMap(
@@ -980,7 +980,12 @@ class JavascriptParser extends Parser {
 					const info = cachedExpression === expr ? cachedInfo : getInfo(expr);
 					if (info !== undefined) {
 						return new BasicEvaluatedExpression()
-							.setIdentifier(info.name, info.rootInfo, info.getMembers)
+							.setIdentifier(
+								info.name,
+								info.rootInfo,
+								info.getMembers,
+								info.getMembersOptions
+							)
 							.setRange(expr.range);
 					}
 				});
@@ -997,7 +1002,12 @@ class JavascriptParser extends Parser {
 				typeof info === "string" ||
 				(info instanceof VariableInfo && typeof info.freeName === "string")
 			) {
-				return { name: info, rootInfo: info, getMembers: () => [] };
+				return {
+					name: info,
+					rootInfo: info,
+					getMembers: () => [],
+					getMembersOptions: () => []
+				};
 			}
 		});
 		tapEvaluateWithVariableInfo("ThisExpression", expr => {
@@ -1006,7 +1016,12 @@ class JavascriptParser extends Parser {
 				typeof info === "string" ||
 				(info instanceof VariableInfo && typeof info.freeName === "string")
 			) {
-				return { name: info, rootInfo: info, getMembers: () => [] };
+				return {
+					name: info,
+					rootInfo: info,
+					getMembers: () => [],
+					getMembersOptions: () => []
+				};
 			}
 		});
 		this.hooks.evaluate.for("MetaProperty").tap("JavascriptParser", expr => {
@@ -2727,7 +2742,10 @@ class JavascriptParser extends Parser {
 					this.hooks.callMemberChain,
 					callee.rootInfo,
 					expression,
-					callee.getMembers()
+					callee.getMembers(),
+					callee.getMembersOptions
+						? callee.getMembersOptions()
+						: callee.getMembers().map(() => false)
 				);
 				if (result1 === true) return;
 				const result2 = this.callHooksForInfo(
@@ -2767,11 +2785,13 @@ class JavascriptParser extends Parser {
 					);
 					if (result1 === true) return;
 					const members = exprInfo.getMembers();
+					const membersOptions = exprInfo.getMembersOptions();
 					const result2 = this.callHooksForInfo(
 						this.hooks.expressionMemberChain,
 						exprInfo.rootInfo,
 						expression,
-						members
+						members,
+						membersOptions
 					);
 					if (result2 === true) return;
 					this.walkMemberExpressionWithExpressionName(
@@ -3609,12 +3629,13 @@ class JavascriptParser extends Parser {
 
 	/**
 	 * @param {MemberExpressionNode} expression a member expression
-	 * @returns {{ members: string[], object: ExpressionNode | SuperNode }} member names (reverse order) and remaining object
+	 * @returns {{ members: string[], object: ExpressionNode | SuperNode, membersOptions: boolean[] }} member names (reverse order) and remaining object
 	 */
 	extractMemberExpressionChain(expression) {
 		/** @type {AnyNode} */
 		let expr = expression;
 		const members = [];
+		const membersOptions = [];
 		while (expr.type === "MemberExpression") {
 			if (expr.computed) {
 				if (expr.property.type !== "Literal") break;
@@ -3623,10 +3644,13 @@ class JavascriptParser extends Parser {
 				if (expr.property.type !== "Identifier") break;
 				members.push(expr.property.name);
 			}
+			membersOptions.push(expr.optional);
 			expr = expr.object;
 		}
+
 		return {
 			members,
+			membersOptions,
 			object: expr
 		};
 	}
@@ -3649,8 +3673,8 @@ class JavascriptParser extends Parser {
 		return { info, name };
 	}
 
-	/** @typedef {{ type: "call", call: CallExpressionNode, calleeName: string, rootInfo: string | VariableInfo, getCalleeMembers: () => string[], name: string, getMembers: () => string[]}} CallExpressionInfo */
-	/** @typedef {{ type: "expression", rootInfo: string | VariableInfo, name: string, getMembers: () => string[]}} ExpressionExpressionInfo */
+	/** @typedef {{ type: "call", call: CallExpressionNode, calleeName: string, rootInfo: string | VariableInfo, getCalleeMembers: () => string[], name: string, getMembers: () => string[], getMembersOptions: () => boolean[]}} CallExpressionInfo */
+	/** @typedef {{ type: "expression", rootInfo: string | VariableInfo, name: string, getMembers: () => string[], getMembersOptions: () => boolean[]}} ExpressionExpressionInfo */
 
 	/**
 	 * @param {MemberExpressionNode} expression a member expression
@@ -3658,7 +3682,8 @@ class JavascriptParser extends Parser {
 	 * @returns {CallExpressionInfo | ExpressionExpressionInfo | undefined} expression info
 	 */
 	getMemberExpressionInfo(expression, allowedTypes) {
-		const { object, members } = this.extractMemberExpressionChain(expression);
+		const { object, members, membersOptions } =
+			this.extractMemberExpressionChain(expression);
 		switch (object.type) {
 			case "CallExpression": {
 				if ((allowedTypes & ALLOWED_MEMBER_TYPES_CALL_EXPRESSION) === 0)
@@ -3682,7 +3707,8 @@ class JavascriptParser extends Parser {
 					rootInfo,
 					getCalleeMembers: memoize(() => rootMembers.reverse()),
 					name: objectAndMembersToName(`${calleeName}()`, members),
-					getMembers: memoize(() => members.reverse())
+					getMembers: memoize(() => members.reverse()),
+					getMembersOptions: memoize(() => membersOptions.reverse())
 				};
 			}
 			case "Identifier":
@@ -3700,7 +3726,8 @@ class JavascriptParser extends Parser {
 					type: "expression",
 					name: objectAndMembersToName(resolvedRoot, members),
 					rootInfo,
-					getMembers: memoize(() => members.reverse())
+					getMembers: memoize(() => members.reverse()),
+					getMembersOptions: memoize(() => membersOptions.reverse())
 				};
 			}
 		}

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -57,7 +57,7 @@ const BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
 /** @typedef {import("../Parser").ParserState} ParserState */
 /** @typedef {import("../Parser").PreparsedAst} PreparsedAst */
 /** @typedef {{declaredScope: ScopeInfo, freeName: string | true, tagInfo: TagInfo | undefined}} VariableInfoInterface */
-/** @typedef {{ name: string | VariableInfo, rootInfo: string | VariableInfo, getMembers: () => string[], getMembersOptions: () => boolean[] }} GetInfoResult */
+/** @typedef {{ name: string | VariableInfo, rootInfo: string | VariableInfo, getMembers: () => string[], getMembersOptionals: () => boolean[] }} GetInfoResult */
 
 const EMPTY_ARRAY = [];
 const ALLOWED_MEMBER_TYPES_CALL_EXPRESSION = 0b01;
@@ -264,7 +264,7 @@ class JavascriptParser extends Parser {
 			/** Something like "a.b()" */
 			/** @type {HookMap<SyncBailHook<[CallExpressionNode, string[], boolean[]], boolean | void>>} */
 			callMemberChain: new HookMap(
-				() => new SyncBailHook(["expression", "members", "membersOptions"])
+				() => new SyncBailHook(["expression", "members", "membersOptionals"])
 			),
 			/** Something like "a.b().c.d" */
 			/** @type {HookMap<SyncBailHook<[ExpressionNode, string[], CallExpressionNode, string[]], boolean | void>>} */
@@ -296,7 +296,7 @@ class JavascriptParser extends Parser {
 			expression: new HookMap(() => new SyncBailHook(["expression"])),
 			/** @type {HookMap<SyncBailHook<[ExpressionNode, string[], boolean[]], boolean | void>>} */
 			expressionMemberChain: new HookMap(
-				() => new SyncBailHook(["expression", "members", "membersOptions"])
+				() => new SyncBailHook(["expression", "members", "membersOptionals"])
 			),
 			/** @type {HookMap<SyncBailHook<[ExpressionNode, string[]], boolean | void>>} */
 			unhandledExpressionMemberChain: new HookMap(
@@ -984,7 +984,7 @@ class JavascriptParser extends Parser {
 								info.name,
 								info.rootInfo,
 								info.getMembers,
-								info.getMembersOptions
+								info.getMembersOptionals
 							)
 							.setRange(expr.range);
 					}
@@ -1006,7 +1006,7 @@ class JavascriptParser extends Parser {
 					name: info,
 					rootInfo: info,
 					getMembers: () => [],
-					getMembersOptions: () => []
+					getMembersOptionals: () => []
 				};
 			}
 		});
@@ -1020,7 +1020,7 @@ class JavascriptParser extends Parser {
 					name: info,
 					rootInfo: info,
 					getMembers: () => [],
-					getMembersOptions: () => []
+					getMembersOptionals: () => []
 				};
 			}
 		});
@@ -2743,8 +2743,8 @@ class JavascriptParser extends Parser {
 					callee.rootInfo,
 					expression,
 					callee.getMembers(),
-					callee.getMembersOptions
-						? callee.getMembersOptions()
+					callee.getMembersOptionals
+						? callee.getMembersOptionals()
 						: callee.getMembers().map(() => false)
 				);
 				if (result1 === true) return;
@@ -2785,13 +2785,13 @@ class JavascriptParser extends Parser {
 					);
 					if (result1 === true) return;
 					const members = exprInfo.getMembers();
-					const membersOptions = exprInfo.getMembersOptions();
+					const membersOptionals = exprInfo.getMembersOptionals();
 					const result2 = this.callHooksForInfo(
 						this.hooks.expressionMemberChain,
 						exprInfo.rootInfo,
 						expression,
 						members,
-						membersOptions
+						membersOptionals
 					);
 					if (result2 === true) return;
 					this.walkMemberExpressionWithExpressionName(
@@ -3629,13 +3629,13 @@ class JavascriptParser extends Parser {
 
 	/**
 	 * @param {MemberExpressionNode} expression a member expression
-	 * @returns {{ members: string[], object: ExpressionNode | SuperNode, membersOptions: boolean[] }} member names (reverse order) and remaining object
+	 * @returns {{ members: string[], object: ExpressionNode | SuperNode, membersOptionals: boolean[] }} member names (reverse order) and remaining object
 	 */
 	extractMemberExpressionChain(expression) {
 		/** @type {AnyNode} */
 		let expr = expression;
 		const members = [];
-		const membersOptions = [];
+		const membersOptionals = [];
 		while (expr.type === "MemberExpression") {
 			if (expr.computed) {
 				if (expr.property.type !== "Literal") break;
@@ -3644,13 +3644,13 @@ class JavascriptParser extends Parser {
 				if (expr.property.type !== "Identifier") break;
 				members.push(expr.property.name);
 			}
-			membersOptions.push(expr.optional);
+			membersOptionals.push(expr.optional);
 			expr = expr.object;
 		}
 
 		return {
 			members,
-			membersOptions,
+			membersOptionals,
 			object: expr
 		};
 	}
@@ -3673,8 +3673,8 @@ class JavascriptParser extends Parser {
 		return { info, name };
 	}
 
-	/** @typedef {{ type: "call", call: CallExpressionNode, calleeName: string, rootInfo: string | VariableInfo, getCalleeMembers: () => string[], name: string, getMembers: () => string[], getMembersOptions: () => boolean[]}} CallExpressionInfo */
-	/** @typedef {{ type: "expression", rootInfo: string | VariableInfo, name: string, getMembers: () => string[], getMembersOptions: () => boolean[]}} ExpressionExpressionInfo */
+	/** @typedef {{ type: "call", call: CallExpressionNode, calleeName: string, rootInfo: string | VariableInfo, getCalleeMembers: () => string[], name: string, getMembers: () => string[], getMembersOptionals: () => boolean[]}} CallExpressionInfo */
+	/** @typedef {{ type: "expression", rootInfo: string | VariableInfo, name: string, getMembers: () => string[], getMembersOptionals: () => boolean[]}} ExpressionExpressionInfo */
 
 	/**
 	 * @param {MemberExpressionNode} expression a member expression
@@ -3682,7 +3682,7 @@ class JavascriptParser extends Parser {
 	 * @returns {CallExpressionInfo | ExpressionExpressionInfo | undefined} expression info
 	 */
 	getMemberExpressionInfo(expression, allowedTypes) {
-		const { object, members, membersOptions } =
+		const { object, members, membersOptionals } =
 			this.extractMemberExpressionChain(expression);
 		switch (object.type) {
 			case "CallExpression": {
@@ -3708,7 +3708,7 @@ class JavascriptParser extends Parser {
 					getCalleeMembers: memoize(() => rootMembers.reverse()),
 					name: objectAndMembersToName(`${calleeName}()`, members),
 					getMembers: memoize(() => members.reverse()),
-					getMembersOptions: memoize(() => membersOptions.reverse())
+					getMembersOptionals: memoize(() => membersOptionals.reverse())
 				};
 			}
 			case "Identifier":
@@ -3727,7 +3727,7 @@ class JavascriptParser extends Parser {
 					name: objectAndMembersToName(resolvedRoot, members),
 					rootInfo,
 					getMembers: memoize(() => members.reverse()),
-					getMembersOptions: memoize(() => membersOptions.reverse())
+					getMembersOptionals: memoize(() => membersOptionals.reverse())
 				};
 			}
 		}

--- a/test/cases/parsing/optional-chaining/b.js
+++ b/test/cases/parsing/optional-chaining/b.js
@@ -1,0 +1,3 @@
+export default {};
+export * as a from "./c";
+export const call = () => ({ c: 1 });

--- a/test/cases/parsing/optional-chaining/c.js
+++ b/test/cases/parsing/optional-chaining/c.js
@@ -1,0 +1,2 @@
+const call = () => 2;
+export { call };

--- a/test/cases/parsing/optional-chaining/index.js
+++ b/test/cases/parsing/optional-chaining/index.js
@@ -1,3 +1,15 @@
+import b, * as bb from "./b";
+
+it("should keep optional chaining", () => {
+	expect(b?.a?.a).toBe(undefined);
+	expect(b?.a).toBe(undefined);
+	expect(typeof bb?.a).toBe("object");
+	expect(bb.call?.().c).toBe(1);
+	expect(bb.call?.().b?.a).toBe(undefined);
+	expect(bb.a?.call()).toBe(2);
+	expect(bb.a?.c?.b).toBe(undefined);
+});
+
 it("should evaluate optional members", () => {
 	if (!module.hot) {
 		expect(

--- a/types.d.ts
+++ b/types.d.ts
@@ -475,7 +475,7 @@ declare abstract class BasicEvaluatedExpression {
 	identifier?: string;
 	rootInfo: VariableInfoInterface;
 	getMembers: () => string[];
-	getMembersOptions: () => boolean[];
+	getMembersOptionals: () => boolean[];
 	expression: NodeEstreeIndex;
 	isUnknown(): boolean;
 	isNull(): boolean;
@@ -528,7 +528,7 @@ declare abstract class BasicEvaluatedExpression {
 		identifier?: any,
 		rootInfo?: any,
 		getMembers?: any,
-		getMembersOptions?: any
+		getMembersOptionals?: any
 	): BasicEvaluatedExpression;
 	setWrapped(
 		prefix?: any,
@@ -681,7 +681,7 @@ declare interface CallExpressionInfo {
 	getCalleeMembers: () => string[];
 	name: string;
 	getMembers: () => string[];
-	getMembersOptions: () => boolean[];
+	getMembersOptionals: () => boolean[];
 }
 declare interface CallbackAsyncQueue<T> {
 	(err?: null | WebpackError, result?: T): any;
@@ -3805,7 +3805,7 @@ declare interface ExpressionExpressionInfo {
 	rootInfo: string | VariableInfo;
 	name: string;
 	getMembers: () => string[];
-	getMembersOptions: () => boolean[];
+	getMembersOptionals: () => boolean[];
 }
 type ExternalItem =
 	| string
@@ -5391,7 +5391,7 @@ declare class JavascriptParser extends Parser {
 			| ImportExpression
 			| ChainExpression
 			| Super;
-		membersOptions: boolean[];
+		membersOptionals: boolean[];
 	};
 	getFreeInfoFromVariable(varName: string): {
 		name: string;

--- a/types.d.ts
+++ b/types.d.ts
@@ -475,6 +475,7 @@ declare abstract class BasicEvaluatedExpression {
 	identifier?: string;
 	rootInfo: VariableInfoInterface;
 	getMembers: () => string[];
+	getMembersOptions: () => boolean[];
 	expression: NodeEstreeIndex;
 	isUnknown(): boolean;
 	isNull(): boolean;
@@ -526,7 +527,8 @@ declare abstract class BasicEvaluatedExpression {
 	setIdentifier(
 		identifier?: any,
 		rootInfo?: any,
-		getMembers?: any
+		getMembers?: any,
+		getMembersOptions?: any
 	): BasicEvaluatedExpression;
 	setWrapped(
 		prefix?: any,
@@ -679,6 +681,7 @@ declare interface CallExpressionInfo {
 	getCalleeMembers: () => string[];
 	name: string;
 	getMembers: () => string[];
+	getMembersOptions: () => boolean[];
 }
 declare interface CallbackAsyncQueue<T> {
 	(err?: null | WebpackError, result?: T): any;
@@ -3802,6 +3805,7 @@ declare interface ExpressionExpressionInfo {
 	rootInfo: string | VariableInfo;
 	name: string;
 	getMembers: () => string[];
+	getMembersOptions: () => boolean[];
 }
 type ExternalItem =
 	| string
@@ -5067,7 +5071,7 @@ declare class JavascriptParser extends Parser {
 		topLevelAwait: SyncBailHook<[Expression], boolean | void>;
 		call: HookMap<SyncBailHook<[Expression], boolean | void>>;
 		callMemberChain: HookMap<
-			SyncBailHook<[CallExpression, string[]], boolean | void>
+			SyncBailHook<[CallExpression, string[], boolean[]], boolean | void>
 		>;
 		memberChainOfCallMemberChain: HookMap<
 			SyncBailHook<
@@ -5085,7 +5089,7 @@ declare class JavascriptParser extends Parser {
 		new: HookMap<SyncBailHook<[NewExpression], boolean | void>>;
 		expression: HookMap<SyncBailHook<[Expression], boolean | void>>;
 		expressionMemberChain: HookMap<
-			SyncBailHook<[Expression, string[]], boolean | void>
+			SyncBailHook<[Expression, string[], boolean[]], boolean | void>
 		>;
 		unhandledExpressionMemberChain: HookMap<
 			SyncBailHook<[Expression, string[]], boolean | void>
@@ -5387,6 +5391,7 @@ declare class JavascriptParser extends Parser {
 			| ImportExpression
 			| ChainExpression
 			| Super;
+		membersOptions: boolean[];
 	};
 	getFreeInfoFromVariable(varName: string): {
 		name: string;


### PR DESCRIPTION
instead of full member expression use only non-optional member expression part

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

I have added extra argument `membersOptions: boolean[]` to hooks `expressionMemberChain` and `callMemberChain`. it shows which member is optional (Could be used later to fully support optional chaining)


**What kind of change does this PR introduce?**

bugfix #12960 
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
