### PR TITLE
add: modules property to be used as import modules from remove/module to get all the components exported from the module

### DIFF
--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -146,6 +146,7 @@ class ContainerEntryModule extends Module {
 			RuntimeGlobals.exports
 		]);
 		const getters = [];
+		const modulesNames = [];
 
 		for (const block of this.blocks) {
 			const { dependencies } = block;
@@ -194,7 +195,15 @@ class ContainerEntryModule extends Module {
 					str
 				)}`
 			);
+			modulesNames.push(`${JSON.stringify(modules[0].name)}`)
 		}
+
+		getters.push(
+			`"./modules": ${runtimeTemplate.basicFunction(
+				"",
+				` return function () { return [${modulesNames.join(', ')}]; } `
+			)}`
+		);
 
 		const source = Template.asString([
 			`var moduleMap = {`,


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Introduce a new prop at `window.remotemodule` alongside with `get` and `init` to be used to get all name components inside a module federation remote.

**Did you add tests for your changes?**

Yes i have the build locally and tested on a module federation example.

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**

I Havento found any documentation to explain the use of `window.remote` so i have a doubt if it need to be documented.
