### PR TITLE
Pass all attributes of old tap with only overidden fn

### DIFF
--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -343,7 +343,8 @@ const interceptAllJavascriptModulesPluginHooks = (compilation, tracer) => {
 };
 
 const makeInterceptorFor = (instance, tracer) => hookName => ({
-	register: ({ name, type, context, fn }) => {
+	register: tapInfo => {
+		const { name, type, fn } = tapInfo;
 		const newFn =
 			// Don't tap our own hooks to ensure stream can close cleanly
 			name === pluginName
@@ -354,9 +355,7 @@ const makeInterceptorFor = (instance, tracer) => hookName => ({
 						fn
 				  });
 		return {
-			name,
-			type,
-			context,
+			...tapInfo,
 			fn: newFn
 		};
 	}

--- a/test/ProfilingPlugin.test.js
+++ b/test/ProfilingPlugin.test.js
@@ -13,6 +13,7 @@ describe("Profiling Plugin", function () {
 		const webpack = require("../");
 		const outputPath = path.join(__dirname, "js/profilingPath");
 		const finalPath = path.join(outputPath, "events.json");
+		let counter = 0;
 		rimraf(outputPath, () => {
 			const startTime = process.hrtime();
 			const compiler = webpack({
@@ -24,7 +25,27 @@ describe("Profiling Plugin", function () {
 				plugins: [
 					new webpack.debug.ProfilingPlugin({
 						outputPath: finalPath
-					})
+					}),
+					{
+						apply(compiler) {
+							const hook = compiler.hooks.make;
+							[
+								{ stage: 0, order: 1 },
+								{ stage: 1, order: 2 },
+								{ stage: -1, order: 0 }
+							].forEach(({ stage, order }) => {
+								hook.tap(
+									{
+										name: "RespectStageCheckerPlugin",
+										stage
+									},
+									() => {
+										expect(counter++).toBe(order);
+									}
+								);
+							});
+						}
+					}
 				],
 				experiments: {
 					backCompat: false


### PR DESCRIPTION
Fixes #15378

`ProfilingPlugin` wasnt passing along the `stage` attribute, which caused tap on the same hook to incorrectly order themselves based on their chosen stage. With fix, we are passing whole old tap info (with replaced function) so that we dont miss any other parameters. `stage` is the only other thing I know of, but I guess it also solves if someone attaches arbitrary data to a hook?

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
yes

**Does this PR introduce a breaking change?**
no

**What needs to be documented once your changes are merged?**
nothing
