### PR TITLE
core: add resource type of Module

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -6702,7 +6702,7 @@ declare class Module extends DependenciesBlock {
 		callback: (arg0?: WebpackError) => void
 	): void;
 	getSourceTypes(): Set<string>;
-	resource: string;
+	resource?: string;
 	source(
 		dependencyTemplates: DependencyTemplates,
 		runtimeTemplate: RuntimeTemplate,

--- a/types.d.ts
+++ b/types.d.ts
@@ -6702,6 +6702,7 @@ declare class Module extends DependenciesBlock {
 		callback: (arg0?: WebpackError) => void
 	): void;
 	getSourceTypes(): Set<string>;
+	resource: string;
 	source(
 		dependencyTemplates: DependencyTemplates,
 		runtimeTemplate: RuntimeTemplate,


### PR DESCRIPTION
### Add a type in Module.

I find the `class Module` declare missing the resource type.

When I developing a webpack plugin, I what get the resource in the module,
the demo typescript code like this:

```ts
compilation.chunks.forEach((chunk) => {
  compilation.chunkGraph.getChunkModules(chunk).forEach((module) => {
    // NOTE: I must use “as any” 
    console.log((module as any).resource)) // the resource is not empty，bug the  Module in types.d.ts has not the type defined
  });
});
```