### PR TITLE
Fix experiments.css normalization

### DIFF
--- a/lib/config/normalization.js
+++ b/lib/config/normalization.js
@@ -182,7 +182,7 @@ const getNormalizedWebpackOptions = config => {
 					options === true ? {} : options === false ? undefined : options
 			),
 			css: optionalNestedConfig(experiments.css, options =>
-				options === true ? {} : options === false ? undefined : options
+				options === true ? {} : options
 			)
 		})),
 		externals: config.externals,


### PR DESCRIPTION
If `experiments.css` is set as `false`, it is ignored after #15200.
I think this is the copy-paste problem (see [L182](https://github.com/webpack/webpack/blob/181a2f032ac57d7efda67c2b2fd0dccd14790588/lib/config/normalization.js#L182)).

**What kind of change does this PR introduce?**

Bugfix.

**Did you add tests for your changes?**

No, but maybe we need failing test.

**Does this PR introduce a breaking change?**

Literally prevents breaking change.

**What needs to be documented once your changes are merged?**

No.
