### PR TITLE
fix: Replace deprecated String.prototype.substr()

### DIFF
--- a/examples/template-common.js
+++ b/examples/template-common.js
@@ -60,7 +60,7 @@ exports.replaceResults = (template, baseDir, stdout, prefix) => {
 	const regexp = new RegExp("_\\{\\{" + (prefix ? prefix + ":" : "") + "([^:\\}]+)\\}\\}_", "g");
 
 	return template.replace(regexp, function(match) {
-		match = match.substr(3 + (prefix ? prefix.length + 1 : 0), match.length - 6 - (prefix ? prefix.length + 1 : 0));
+		match = match.slice(3 + (prefix ? prefix.length + 1 : 0), -3);
 		if(match === "stdout")
 			return stdout;
 		try {

--- a/hot/poll.js
+++ b/hot/poll.js
@@ -4,7 +4,7 @@
 */
 /*globals __resourceQuery */
 if (module.hot) {
-	var hotPollInterval = +__resourceQuery.substr(1) || 10 * 60 * 1000;
+	var hotPollInterval = +__resourceQuery.slice(1) || 10 * 60 * 1000;
 	var log = require("./log");
 
 	var checkForUpdate = function checkForUpdate(fromUpdate) {

--- a/hot/signal.js
+++ b/hot/signal.js
@@ -45,7 +45,7 @@ if (module.hot) {
 			});
 	};
 
-	process.on(__resourceQuery.substr(1) || "SIGUSR2", function () {
+	process.on(__resourceQuery.slice(1) || "SIGUSR2", function () {
 		if (module.hot.status() !== "idle") {
 			log(
 				"warning",

--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -690,7 +690,7 @@ class Chunk {
 				for (const childGroup of group.childrenIterable) {
 					for (const key of Object.keys(childGroup.options)) {
 						if (key.endsWith("Order")) {
-							const name = key.substr(0, key.length - "Order".length);
+							const name = key.slice(0, key.length - "Order".length);
 							let list = lists.get(name);
 							if (list === undefined) {
 								list = [];

--- a/lib/ChunkGroup.js
+++ b/lib/ChunkGroup.js
@@ -486,7 +486,7 @@ class ChunkGroup {
 		for (const childGroup of this._children) {
 			for (const key of Object.keys(childGroup.options)) {
 				if (key.endsWith("Order")) {
-					const name = key.substr(0, key.length - "Order".length);
+					const name = key.slice(0, key.length - "Order".length);
 					let list = lists.get(name);
 					if (list === undefined) {
 						lists.set(name, (list = []));

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -3896,7 +3896,7 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 							module,
 							runtime,
 							digest,
-							digest.substr(0, hashDigestLength)
+							digest.slice(0, hashDigestLength)
 						);
 						statModulesFromCache++;
 						continue;
@@ -3960,7 +3960,7 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 			module,
 			runtime,
 			moduleHashDigest,
-			moduleHashDigest.substr(0, hashDigestLength)
+			moduleHashDigest.slice(0, hashDigestLength)
 		);
 		return moduleHashDigest;
 	}
@@ -4164,7 +4164,7 @@ This prevents using hashes of each other and should be avoided.`);
 				);
 				hash.update(chunkHashDigest);
 				chunk.hash = chunkHashDigest;
-				chunk.renderedHash = chunk.hash.substr(0, hashDigestLength);
+				chunk.renderedHash = chunk.hash.slice(0, hashDigestLength);
 				const fullHashModules =
 					chunkGraph.getChunkFullHashModulesIterable(chunk);
 				if (fullHashModules) {
@@ -4191,7 +4191,7 @@ This prevents using hashes of each other and should be avoided.`);
 		this.logger.time("hashing: hash digest");
 		this.hooks.fullHash.call(hash);
 		this.fullHash = /** @type {string} */ (hash.digest(hashDigest));
-		this.hash = this.fullHash.substr(0, hashDigestLength);
+		this.hash = this.fullHash.slice(0, hashDigestLength);
 		this.logger.timeEnd("hashing: hash digest");
 
 		this.logger.time("hashing: process full hash modules");
@@ -4211,7 +4211,7 @@ This prevents using hashes of each other and should be avoided.`);
 					module,
 					chunk.runtime,
 					moduleHashDigest,
-					moduleHashDigest.substr(0, hashDigestLength)
+					moduleHashDigest.slice(0, hashDigestLength)
 				);
 				codeGenerationJobsMap.get(oldHash).get(module).hash = moduleHashDigest;
 			}
@@ -4222,7 +4222,7 @@ This prevents using hashes of each other and should be avoided.`);
 				chunkHash.digest(hashDigest)
 			);
 			chunk.hash = chunkHashDigest;
-			chunk.renderedHash = chunk.hash.substr(0, hashDigestLength);
+			chunk.renderedHash = chunk.hash.slice(0, hashDigestLength);
 			this.hooks.contentHash.call(chunk);
 		}
 		this.logger.timeEnd("hashing: process full hash modules");

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -596,7 +596,7 @@ class Compiler {
 					let immutable = info.immutable;
 					const queryStringIdx = targetFile.indexOf("?");
 					if (queryStringIdx >= 0) {
-						targetFile = targetFile.substr(0, queryStringIdx);
+						targetFile = targetFile.slice(0, queryStringIdx);
 						// We may remove the hash, which is in the query string
 						// So we recheck if the file is immutable
 						// This doesn't cover all cases, but immutable is only a performance optimization anyway

--- a/lib/ContextModuleFactory.js
+++ b/lib/ContextModuleFactory.js
@@ -128,7 +128,7 @@ module.exports = class ContextModuleFactory extends ModuleFactory {
 					loadersPrefix = "";
 				const idx = request.lastIndexOf("!");
 				if (idx >= 0) {
-					let loadersRequest = request.substr(0, idx + 1);
+					let loadersRequest = request.slice(0, idx + 1);
 					let i;
 					for (
 						i = 0;
@@ -138,7 +138,7 @@ module.exports = class ContextModuleFactory extends ModuleFactory {
 						loadersPrefix += "!";
 					}
 					loadersRequest = loadersRequest
-						.substr(i)
+						.slice(i)
 						.replace(/!+$/, "")
 						.replace(/!!+/g, "!");
 					if (loadersRequest === "") {
@@ -146,7 +146,7 @@ module.exports = class ContextModuleFactory extends ModuleFactory {
 					} else {
 						loaders = loadersRequest.split("!");
 					}
-					resource = request.substr(idx + 1);
+					resource = request.slice(idx + 1);
 				} else {
 					loaders = [];
 					resource = request;
@@ -348,7 +348,7 @@ module.exports = class ContextModuleFactory extends ModuleFactory {
 									const obj = {
 										context: ctx,
 										request:
-											"." + subResource.substr(ctx.length).replace(/\\/g, "/")
+											"." + subResource.slice(ctx.length).replace(/\\/g, "/")
 									};
 
 									this.hooks.alternativeRequests.callAsync(

--- a/lib/DelegatedModuleFactoryPlugin.js
+++ b/lib/DelegatedModuleFactoryPlugin.js
@@ -29,7 +29,7 @@ class DelegatedModuleFactoryPlugin {
 					const [dependency] = data.dependencies;
 					const { request } = dependency;
 					if (request && request.startsWith(`${scope}/`)) {
-						const innerRequest = "." + request.substr(scope.length);
+						const innerRequest = "." + request.slice(scope.length);
 						let resolved;
 						if (innerRequest in this.options.content) {
 							resolved = this.options.content[innerRequest];

--- a/lib/ErrorHelpers.js
+++ b/lib/ErrorHelpers.js
@@ -43,8 +43,8 @@ exports.cutOffMessage = (stack, message) => {
 	if (nextLine === -1) {
 		return stack === message ? "" : stack;
 	} else {
-		const firstLine = stack.substr(0, nextLine);
-		return firstLine === message ? stack.substr(nextLine + 1) : stack;
+		const firstLine = stack.slice(0, nextLine);
+		return firstLine === message ? stack.slice(nextLine + 1) : stack;
 	}
 };
 

--- a/lib/ExternalModuleFactoryPlugin.js
+++ b/lib/ExternalModuleFactoryPlugin.js
@@ -89,8 +89,8 @@ class ExternalModuleFactoryPlugin {
 							UNSPECIFIED_EXTERNAL_TYPE_REGEXP.test(externalConfig)
 						) {
 							const idx = externalConfig.indexOf(" ");
-							type = externalConfig.substr(0, idx);
-							externalConfig = externalConfig.substr(idx + 1);
+							type = externalConfig.slice(0, idx);
+							externalConfig = externalConfig.slice(idx + 1);
 						} else if (
 							Array.isArray(externalConfig) &&
 							externalConfig.length > 0 &&
@@ -98,9 +98,9 @@ class ExternalModuleFactoryPlugin {
 						) {
 							const firstItem = externalConfig[0];
 							const idx = firstItem.indexOf(" ");
-							type = firstItem.substr(0, idx);
+							type = firstItem.slice(0, idx);
 							externalConfig = [
-								firstItem.substr(idx + 1),
+								firstItem.slice(idx + 1),
 								...externalConfig.slice(1)
 							];
 						}

--- a/lib/LoaderOptionsPlugin.js
+++ b/lib/LoaderOptionsPlugin.js
@@ -52,7 +52,7 @@ class LoaderOptionsPlugin {
 					if (
 						ModuleFilenameHelpers.matchObject(
 							options,
-							i < 0 ? resource : resource.substr(0, i)
+							i < 0 ? resource : resource.slice(0, i)
 						)
 					) {
 						for (const key of Object.keys(options)) {

--- a/lib/ModuleFilenameHelpers.js
+++ b/lib/ModuleFilenameHelpers.js
@@ -47,7 +47,7 @@ const getAfter = (strFn, token) => {
 	return () => {
 		const str = strFn();
 		const idx = str.indexOf(token);
-		return idx < 0 ? "" : str.substr(idx);
+		return idx < 0 ? "" : str.slice(idx);
 	};
 };
 
@@ -55,7 +55,7 @@ const getBefore = (strFn, token) => {
 	return () => {
 		const str = strFn();
 		const idx = str.lastIndexOf(token);
-		return idx < 0 ? "" : str.substr(0, idx);
+		return idx < 0 ? "" : str.slice(0, idx);
 	};
 };
 
@@ -64,7 +64,7 @@ const getHash = (strFn, hashFunction) => {
 		const hash = createHash(hashFunction);
 		hash.update(strFn());
 		const digest = /** @type {string} */ (hash.digest("hex"));
-		return digest.substr(0, 4);
+		return digest.slice(0, 4);
 	};
 };
 

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -375,7 +375,7 @@ class NormalModule extends Module {
 	nameForCondition() {
 		const resource = this.matchResource || this.resource;
 		const idx = resource.indexOf("?");
-		if (idx >= 0) return resource.substr(0, idx);
+		if (idx >= 0) return resource.slice(0, idx);
 		return resource;
 	}
 
@@ -558,7 +558,7 @@ class NormalModule extends Module {
 				let { options } = loader;
 
 				if (typeof options === "string") {
-					if (options.substr(0, 1) === "{" && options.substr(-1) === "}") {
+					if (options.startsWith("{") && options.endsWith("}")) {
 						try {
 							options = parseJson(options);
 						} catch (e) {

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -379,7 +379,7 @@ class NormalModuleFactory extends ModuleFactory {
 							resource: matchResource,
 							...cacheParseResource(matchResource)
 						};
-						requestWithoutMatchResource = request.substr(
+						requestWithoutMatchResource = request.slice(
 							matchResourceMatch[0].length
 						);
 					}
@@ -437,7 +437,7 @@ class NormalModuleFactory extends ModuleFactory {
 					try {
 						for (const item of loaders) {
 							if (typeof item.options === "string" && item.options[0] === "?") {
-								const ident = item.options.substr(1);
+								const ident = item.options.slice(1);
 								if (ident === "[[missing ident]]") {
 									throw new Error(
 										"No ident is provided by referenced loader. " +

--- a/lib/dependencies/ContextDependencyHelpers.js
+++ b/lib/dependencies/ContextDependencyHelpers.js
@@ -28,8 +28,8 @@ const splitContextFromPrefix = prefix => {
 	const idx = prefix.lastIndexOf("/");
 	let context = ".";
 	if (idx >= 0) {
-		context = prefix.substr(0, idx);
-		prefix = `.${prefix.substr(idx)}`;
+		context = prefix.slice(0, idx);
+		prefix = `.${prefix.slice(idx)}`;
 	}
 	return {
 		context,

--- a/lib/ids/HashedModuleIdsPlugin.js
+++ b/lib/ids/HashedModuleIdsPlugin.js
@@ -64,8 +64,8 @@ class HashedModuleIdsPlugin {
 						hash.digest(options.hashDigest)
 					);
 					let len = options.hashDigestLength;
-					while (usedIds.has(hashId.substr(0, len))) len++;
-					const moduleId = hashId.substr(0, len);
+					while (usedIds.has(hashId.slice(0, len))) len++;
+					const moduleId = hashId.slice(0, len);
 					chunkGraph.setModuleId(module, moduleId);
 					usedIds.add(moduleId);
 				}

--- a/lib/ids/IdHelpers.js
+++ b/lib/ids/IdHelpers.js
@@ -25,7 +25,7 @@ const getHash = (str, len, hashFunction) => {
 	const hash = createHash(hashFunction);
 	hash.update(str);
 	const digest = /** @type {string} */ (hash.digest("hex"));
-	return digest.substr(0, len);
+	return digest.slice(0, len);
 };
 
 /**

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -2155,7 +2155,7 @@ const RESULT_GROUPERS = {
 // remove a prefixed "!" that can be specified to reverse sort order
 const normalizeFieldKey = field => {
 	if (field[0] === "!") {
-		return field.substr(1);
+		return field.slice(1);
 	}
 	return field;
 };

--- a/test/Examples.test.js
+++ b/test/Examples.test.js
@@ -22,8 +22,8 @@ describe("Examples", () => {
 				let options = {};
 				let webpackConfigPath = path.join(examplePath, "webpack.config.js");
 				webpackConfigPath =
-					webpackConfigPath.substr(0, 1).toUpperCase() +
-					webpackConfigPath.substr(1);
+					webpackConfigPath.slice(0, 1).toUpperCase() +
+					webpackConfigPath.slice(1);
 				if (fs.existsSync(webpackConfigPath))
 					options = require(webpackConfigPath);
 				if (typeof options === "function") options = options();

--- a/test/HotTestCases.template.js
+++ b/test/HotTestCases.template.js
@@ -249,7 +249,7 @@ const describeCases = config => {
 									}
 
 									function _require(module) {
-										if (module.substr(0, 2) === "./") {
+										if (module.startsWith("./")) {
 											const p = path.join(outputDirectory, module);
 											if (module.endsWith(".json")) {
 												return JSON.parse(fs.readFileSync(p, "utf-8"));

--- a/test/JavascriptParser.unittest.js
+++ b/test/JavascriptParser.unittest.js
@@ -256,7 +256,7 @@ describe("JavascriptParser", () => {
 	Object.keys(testCases).forEach(name => {
 		it("should parse " + name, () => {
 			let source = testCases[name][0].toString();
-			source = source.substr(13, source.length - 14).trim();
+			source = source.slice(13, -1).trim();
 			const state = testCases[name][1];
 
 			const testParser = new JavascriptParser({});
@@ -541,12 +541,12 @@ describe("JavascriptParser", () => {
 			"`start${'str'}mid${obj2}end`":
 				// eslint-disable-next-line no-template-curly-in-string
 				"template=[start${'str'}mid string=startstrmid],[end string=end]",
-			"'abc'.substr(1)": "string=bc",
-			"'abcdef'.substr(2, 3)": "string=cde",
+			"'abc'.slice(1)": "string=bc",
+			"'abcdef'.slice(2, 5)": "string=cde",
 			"'abcdef'.substring(2, 3)": "string=c",
 			"'abcdef'.substring(2, 3, 4)": "",
-			"'abc'[\"substr\"](1)": "string=bc",
-			"'abc'[substr](1)": "",
+			"'abc'[\"slice\"](1)": "string=bc",
+			"'abc'[slice](1)": "",
 			"'1,2+3'.split(/[,+]/)": "array=[1],[2],[3]",
 			"'1,2+3'.split(expr)": "",
 			"'a' + (expr + 'c')": "wrapped=['a' string=a]+['c' string=c]",
@@ -596,7 +596,7 @@ describe("JavascriptParser", () => {
 						const start = evalExpr.range[0] - 5;
 						const end = evalExpr.range[1] - 5;
 						return (
-							key.substr(start, end - start) +
+							key.slice(start, end) +
 							(result.length > 0 ? " " + result.join(" ") : "")
 						);
 					}

--- a/test/TestCases.template.js
+++ b/test/TestCases.template.js
@@ -427,7 +427,7 @@ const describeCases = config => {
 									});
 									cleanups.push(() => (esmContext.it = undefined));
 									function _require(module, esmMode) {
-										if (module.substr(0, 2) === "./") {
+										if (module.startsWith("./")) {
 											const p = path.join(outputDirectory, module);
 											const content = fs.readFileSync(p, "utf-8");
 											if (p.endsWith(".mjs")) {

--- a/test/benchmarkCases/many-chunks/b.js
+++ b/test/benchmarkCases/many-chunks/b.js
@@ -3,4 +3,4 @@ import("./c?1" + __resourceQuery);
 import("./c?2" + __resourceQuery);
 import("./c?3" + __resourceQuery);
 import("./c?4" + __resourceQuery);
-import("./a" + __resourceQuery.substr(0, 2));
+import("./a" + __resourceQuery.slice(0, 2));

--- a/test/benchmarkCases/many-modules-source-map/b.js
+++ b/test/benchmarkCases/many-modules-source-map/b.js
@@ -8,4 +8,4 @@ require("./c?6" + __resourceQuery);
 require("./c?7" + __resourceQuery);
 require("./c?8" + __resourceQuery);
 require("./c?9" + __resourceQuery);
-require("./a" + __resourceQuery.substr(0, 2));
+require("./a" + __resourceQuery.slice(0, 2));

--- a/test/benchmarkCases/many-modules/b.js
+++ b/test/benchmarkCases/many-modules/b.js
@@ -8,4 +8,4 @@ require("./c?6" + __resourceQuery);
 require("./c?7" + __resourceQuery);
 require("./c?8" + __resourceQuery);
 require("./c?9" + __resourceQuery);
-require("./a" + __resourceQuery.substr(0, 2));
+require("./a" + __resourceQuery.slice(0, 2));

--- a/test/benchmarkCases/many-stuff-harmony/a.js
+++ b/test/benchmarkCases/many-stuff-harmony/a.js
@@ -1,7 +1,7 @@
 module.exports = function() {
 	let str = "";
 	let sum = ["1"];
-	const query = +this.query.substr(1);
+	const query = +this.query.slice(1);
 	for(let i = 0; i < query; i++) {
 		str += `import b${i} from "./b?${Math.floor(i/2)}!";\n`;
 		sum.push(`b${i}`);

--- a/test/cases/compile/long-module-chain/module.js
+++ b/test/cases/compile/long-module-chain/module.js
@@ -1,5 +1,5 @@
 if(__resourceQuery === "?0") {
 	module.exports = "module";
 } else {
-	module.exports = require("./module?" + (+__resourceQuery.substr(1) - 1));
+	module.exports = require("./module?" + (+__resourceQuery.slice(1) - 1));
 }

--- a/test/cases/errors/loader-error-warning/error-loader.js
+++ b/test/cases/errors/loader-error-warning/error-loader.js
@@ -1,6 +1,6 @@
 /** @type {import("../../../../").LoaderDefinition<string>} */
 module.exports = function (source) {
 	//@ts-expect-error errors must be Errors, string is not recommended and should lead to type error
-	this.emitError(this.query.substr(1));
+	this.emitError(this.query.slice(1));
 	return source;
 };

--- a/test/cases/errors/loader-error-warning/warning-loader.js
+++ b/test/cases/errors/loader-error-warning/warning-loader.js
@@ -1,6 +1,6 @@
 /** @type {import("../../../../").LoaderDefinition<string>} */
 module.exports = function (source) {
 	//@ts-expect-error warnings must be Errors, string is not recommended and should lead to type error
-	this.emitWarning(this.query.substr(1));
+	this.emitWarning(this.query.slice(1));
 	return source;
 };

--- a/test/cases/parsing/evaluate/resourceFragment/index.js
+++ b/test/cases/parsing/evaluate/resourceFragment/index.js
@@ -1,3 +1,3 @@
 module.exports = require((
-	__resourceFragment.substr(1) + "/resourceFragment/returnRF#XXXFragment"
+	__resourceFragment.slice(1) + "/resourceFragment/returnRF#XXXFragment"
 ).replace(/XXX/g, "resource"));

--- a/test/cases/parsing/evaluate/resourceQuery/index.js
+++ b/test/cases/parsing/evaluate/resourceQuery/index.js
@@ -1,1 +1,1 @@
-module.exports = require((__resourceQuery.substr(1) + "/resourceQuery/returnRQ?XXXQuery").replace(/XXX/g, "resource"));
+module.exports = require((__resourceQuery.slice(1) + "/resourceQuery/returnRQ?XXXQuery").replace(/XXX/g, "resource"));

--- a/test/cases/parsing/extract-amd.nominimize/index.js
+++ b/test/cases/parsing/extract-amd.nominimize/index.js
@@ -17,7 +17,7 @@ it("should parse fancy function calls with arrow functions", function() {
 
 it("should parse fancy AMD calls with arrow functions", function() {
 	require("./constructor ./a".split(" "));
-	require("-> module module exports *constructor *a".replace("module", "require").substr(3).replace(/\*/g, "./").split(" "), (require, module, exports, constructor, a) => {
+	require("-> module module exports *constructor *a".replace("module", "require").slice(3).replace(/\*/g, "./").split(" "), (require, module, exports, constructor, a) => {
 		expect((typeof require)).toBe("function");
 		expect((typeof module)).toBe("object");
 		expect((typeof exports)).toBe("object");
@@ -25,7 +25,7 @@ it("should parse fancy AMD calls with arrow functions", function() {
 		expect((typeof constructor)).toBe("function");
 		expect(a).toBe("a");
 	});
-	define("-> module module exports *constructor *a".replace("module", "require").substr(3).replace(/\*/g, "./").split(" "), (require, module, exports, constructor, a) => {
+	define("-> module module exports *constructor *a".replace("module", "require").slice(3).replace(/\*/g, "./").split(" "), (require, module, exports, constructor, a) => {
 		expect((typeof require)).toBe("function");
 		expect((typeof module)).toBe("object");
 		expect((typeof exports)).toBe("object");

--- a/test/cases/parsing/extract-amd/index.js
+++ b/test/cases/parsing/extract-amd/index.js
@@ -17,7 +17,7 @@ it("should parse fancy function calls", function() {
 
 it("should parse fancy AMD calls", function() {
 	require("./constructor ./a".split(" "));
-	require("-> module module exports *constructor *a".replace("module", "require").substr(3).replace(/\*/g, "./").split(" "), function(require, module, exports, constructor, a) {
+	require("-> module module exports *constructor *a".replace("module", "require").slice(3).replace(/\*/g, "./").split(" "), function(require, module, exports, constructor, a) {
 		expect((typeof require)).toBe("function");
 		expect((typeof module)).toBe("object");
 		expect((typeof exports)).toBe("object");
@@ -25,7 +25,7 @@ it("should parse fancy AMD calls", function() {
 		expect((typeof constructor)).toBe("function");
 		expect(a).toBe("a");
 	});
-	define("-> module module exports *constructor *a".replace("module", "require").substr(3).replace(/\*/g, "./").split(" "), function(require, module, exports, constructor, a) {
+	define("-> module module exports *constructor *a".replace("module", "require").slice(3).replace(/\*/g, "./").split(" "), function(require, module, exports, constructor, a) {
 		expect((typeof require)).toBe("function");
 		expect((typeof module)).toBe("object");
 		expect((typeof exports)).toBe("object");

--- a/test/helpers/FakeDocument.js
+++ b/test/helpers/FakeDocument.js
@@ -104,9 +104,9 @@ class FakeElement {
 		if (/^\//.test(value)) {
 			return `https://test.cases${value}`;
 		} else if (/^\.\.\//.test(value)) {
-			return `https://test.cases${value.substr(2)}`;
+			return `https://test.cases${value.slice(2)}`;
 		} else if (/^\.\//.test(value)) {
-			return `https://test.cases/path${value.substr(1)}`;
+			return `https://test.cases/path${value.slice(1)}`;
 		} else if (/^\w+:\/\//.test(value)) {
 			return value;
 		} else if (/^\/\//.test(value)) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

**Did you add tests for your changes?**

No new tests but current test would fail if the returned values would have changed

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

I don't think anything will need to be documented as all changes are "internal"
