### PR TITLE
support node: prefix in esm build dependencies

### DIFF
--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -1673,6 +1673,10 @@ class FileSystemInfo {
 													// e.g. import.meta
 													continue;
 												}
+
+												// we should not track Node.js build dependencies
+												if (dependency.startsWith("node:")) continue;
+
 												push({
 													type: RBDT_RESOLVE_ESM_FILE,
 													context,

--- a/test/BuildDependencies.longtest.js
+++ b/test/BuildDependencies.longtest.js
@@ -133,7 +133,7 @@ describe("BuildDependencies", () => {
 		);
 		fs.writeFileSync(
 			path.resolve(inputDirectory, "esm-async-dependency.mjs"),
-			"export default 0;"
+			'import path from "node:path"; export default 0;'
 		);
 		await exec("0", {
 			invalidBuildDependencies: true,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
feature/bugfix
closes #15574 
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
in esm build dependencies webpack supports only `node:` prefixed Node.js modules (like `node:url`)
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
