### PR TITLE
fix egde case where a HMR chunk is incorrectly downloaded 

### DIFF
--- a/lib/hmr/JavascriptHotModuleReplacement.runtime.js
+++ b/lib/hmr/JavascriptHotModuleReplacement.runtime.js
@@ -443,15 +443,16 @@ module.exports = function () {
 			) {
 				promises.push($loadUpdateChunk$(chunkId, updatedModulesList));
 				currentUpdateChunks[chunkId] = true;
+			} else {
+				currentUpdateChunks[chunkId] = false;
 			}
 		});
 		if ($ensureChunkHandlers$) {
 			$ensureChunkHandlers$.$key$Hmr = function (chunkId, promises) {
 				if (
 					currentUpdateChunks &&
-					!$hasOwnProperty$(currentUpdateChunks, chunkId) &&
-					$hasOwnProperty$($installedChunks$, chunkId) &&
-					$installedChunks$[chunkId] !== undefined
+					$hasOwnProperty$(currentUpdateChunks, chunkId) &&
+					!currentUpdateChunks[chunkId]
 				) {
 					promises.push($loadUpdateChunk$(chunkId));
 					currentUpdateChunks[chunkId] = true;

--- a/lib/web/JsonpChunkLoadingRuntimeModule.js
+++ b/lib/web/JsonpChunkLoadingRuntimeModule.js
@@ -286,8 +286,9 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 				? Template.asString([
 						"var currentUpdatedModulesList;",
 						"var waitingUpdateResolves = {};",
-						"function loadUpdateChunk(chunkId) {",
+						"function loadUpdateChunk(chunkId, updatedModulesList) {",
 						Template.indent([
+							"currentUpdatedModulesList = updatedModulesList;",
 							`return new Promise(${runtimeTemplate.basicFunction(
 								"resolve, reject",
 								[

--- a/test/hotCases/runtime/import-after-download/index.js
+++ b/test/hotCases/runtime/import-after-download/index.js
@@ -5,22 +5,27 @@ module.hot.accept("./file");
 const asyncNext = () => {
 	return new Promise((resolve, reject) => {
 		NEXT((err, stats) => {
-			if(err) return reject(err);
+			if (err) return reject(err);
 			resolve(stats);
 		});
 	});
-}
+};
 
 it("should download the missing update chunk on import", () => {
 	expect(value).toBe(1);
 	return asyncNext().then(() => {
 		return module.hot.check().then(() => {
-			return import("./chunk").then(chunk => {
+			return Promise.all([
+				import("./chunk"),
+				import("./unaffected-chunk")
+			]).then(([chunk, unaffectedChunk]) => {
 				expect(value).toBe(1);
 				expect(chunk.default).toBe(10);
+				expect(unaffectedChunk.default).toBe(10);
 				return module.hot.apply().then(() => {
 					expect(value).toBe(2);
 					expect(chunk.default).toBe(20);
+					expect(unaffectedChunk.default).toBe(10);
 				});
 			});
 		});

--- a/test/hotCases/runtime/import-after-download/unaffected-chunk.js
+++ b/test/hotCases/runtime/import-after-download/unaffected-chunk.js
@@ -1,0 +1,5 @@
+import value from "./unaffected-inner";
+
+module.hot.accept("./unaffected-inner");
+
+export { value as default };

--- a/test/hotCases/runtime/import-after-download/unaffected-inner.js
+++ b/test/hotCases/runtime/import-after-download/unaffected-inner.js
@@ -1,0 +1,1 @@
+export default 10;


### PR DESCRIPTION
fix egde case where a HMR chunk is incorrectly downloaded when loading a unchanged chunk during HMR downloading

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
