### PR TITLE
Fix grammar of warning message

### DIFF
--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -64,7 +64,7 @@ class NodeStuffPlugin {
 										new NodeStuffInWebError(
 											dep.loc,
 											"global",
-											"The global namespace object is Node.js feature and doesn't present in browser."
+											"The global namespace object is a Node.js feature and isn't available in browsers."
 										)
 									);
 								}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
The current warning message can be hard to understand since it's grammatically incorrect.
1. if used with 'does' or 'doesn't' 'present' means to 'make a presentation' (https://www.quora.com/Which-one-is-correct-she-is-not-present-today-or-she-doesnt-present-today). I've changed to 'isnt't available' because 'available' seems a lot more used than 'present' in web development contexts. For example 'present in ES modules' returns only 1 Google search result (in the webpack documentation!) while 'available in ES modules' returns many pages.
2. Except in special cases like names of languages, a singular countable word takes an article. 'browser' is countable (https://dictionary.cambridge.org/dictionary/english/browser)
 See for example https://owl.purdue.edu/owl/general_writing/grammar/using_articles.html
I've preferred 'in browsers`' to 'in the browser' since it's shorter.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Corrects the grammar of an error message.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No tests since it is just a string change.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No breaking change.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
The changes are self-documenting.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
