### PR TITLE
Run CI in Node 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 17.x
+          node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
       - uses: actions/cache@v1
@@ -37,7 +37,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 17.x
+          node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
       - run: yarn link --frozen-lockfile || true
@@ -54,7 +54,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 17.x
+          node-version: 18.x
           cache: "yarn"
       - run: yarn --frozen-lockfile
       - run: yarn link --frozen-lockfile || true
@@ -75,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [10.x, 17.x]
+        node-version: [10.x, 18.x]
         part: [a, b]
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
Node 18 was released today and is available to use in Github Actions.

- Add Node 18 to CI
- Drop Node 17