### PR TITLE
Don't warn for `import` of optional dependencies

### DIFF
--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -1685,7 +1685,7 @@ class FileSystemInfo {
 													type: RBDT_RESOLVE_ESM_FILE,
 													context,
 													path: dependency,
-													expected: undefined,
+													expected: false,
 													issuer: job
 												});
 											} catch (e) {


### PR DESCRIPTION
Based on @sokra's suggestion, this PR silences warnings like the below of `import` statements of optional dependencies.

![image](https://user-images.githubusercontent.com/1567498/164206753-d3b26383-9ad1-4ddd-bdd5-20b32e589557.png)

![image](https://user-images.githubusercontent.com/1567498/164206766-272cd669-d597-4cec-ac0a-e59373f314f5.png)
