### PR TITLE
bugfixed: Webpack 5 is compiling twice in watch mode sometimes

### DIFF
--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -49,7 +49,7 @@ class Watching {
 			this.watchOptions = {};
 		}
 		if (typeof this.watchOptions.aggregateTimeout !== "number") {
-			this.watchOptions.aggregateTimeout = 20;
+			this.watchOptions.aggregateTimeout = 88;
 		}
 		this.compiler = compiler;
 		this.running = false;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
a bugfix. Webpack 5 is compiling twice in watch mode sometimes. I think aggregateTimeout should be increased. 
https://github.com/webpack/webpack/issues/12140
https://github.com/jantimon/html-webpack-plugin/issues/1576

![image](https://user-images.githubusercontent.com/30360513/167194557-73dfb012-2e98-462c-8537-4e535644e4e1.png)

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes. In my own project.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
No.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
