### PR TITLE
chore: remove GitHub workflow permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
 name: Test
+permissions: {}
 
 # cspell:word Ignus
 # cspell:word eslintcache


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Disabling unused permissions should prevent compromised dependencies
from exploiting the CI API.

Setting the top permssion object to empty disables permissions for
all available scopes:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
CI configurationchange.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No, because the change does not affect the webpack code base itself.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No breaking change.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
No documentation needed.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
