### PR TITLE
fix(css): add node support for external @import

### DIFF
--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -160,6 +160,28 @@ class WebpackOptionsApply extends OptionsApply {
 					  }
 					: /^(\/\/|https?:\/\/|std:)/
 			).apply(compiler);
+		} else if (options.externalsPresets.node) {
+			if (options.experiments.css) {
+				//@ts-expect-error https://github.com/microsoft/TypeScript/issues/41697
+				const ExternalsPlugin = require("./ExternalsPlugin");
+				new ExternalsPlugin(
+					"module",
+					({ request, dependencyType }, callback) => {
+						if (dependencyType === "url") {
+							if (/^(\/\/|https?:\/\/)/.test(request))
+								return callback(null, `asset ${request}`);
+						} else if (dependencyType === "css-import") {
+							if (/^(\/\/|https?:\/\/)/.test(request))
+								return callback(null, `css-import ${request}`);
+						} else if (/^(\/\/|https?:\/\/|std:)/.test(request)) {
+							if (/^\.css(\?|$)/.test(request))
+								return callback(null, `css-import ${request}`);
+							return callback(null, `module ${request}`);
+						}
+						callback();
+					}
+				).apply(compiler);
+			}
 		}
 
 		new ChunkPrefetchPreloadPlugin().apply(compiler);

--- a/test/configCases/css/external-in-node/index.js
+++ b/test/configCases/css/external-in-node/index.js
@@ -1,0 +1,6 @@
+it("should import an external css", done => {
+	import("../external/style.css").then(x => {
+		expect(x).toEqual(nsObj({}));
+		done();
+	}, done);
+});

--- a/test/configCases/css/external-in-node/webpack.config.js
+++ b/test/configCases/css/external-in-node/webpack.config.js
@@ -1,0 +1,11 @@
+const path = require("path");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	context: path.join(__dirname, "../external"),
+	entry: "../external-in-node/index.js",
+	target: "node",
+	experiments: {
+		css: true
+	}
+};


### PR DESCRIPTION
**Issue:**
When using the CSS experiments and using @import in CSS code, the compilation fails with these error messages: 
```sh
Module build failed: UnhandledSchemeError: Reading from "http://example.com/image.png" is not handled by plugins (Unhandled scheme).
Webpack supports "data:" and "file:" URIs by default.
You may need an additional plugin to handle "http:" URIs.
```

**Changes:**
This PR will handle the @import rules for node and add a dedicated test.

**CSS example code:**
```css
@import "https://test.cases/path/../../../../configCases/css/external/external.css";
```
