### PR TITLE
fix(css): do not bundle leading slash url images

### DIFF
--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -122,9 +122,15 @@ class WebpackOptionsApply extends OptionsApply {
 			new ExternalsPlugin(
 				"import",
 				options.experiments.css
-					? ({ request, dependencyType }, callback) => {
+					? (
+							{ request, dependencyType, contextInfo: { issuer } },
+							callback
+					  ) => {
 							if (dependencyType === "url") {
-								if (/^(\/\/|https?:\/\/)/.test(request))
+								if (
+									/^(\/\/|https?:\/\/)/.test(request) ||
+									(/\.css(\?|$)/.test(issuer) && /^(\/)/.test(request))
+								)
 									return callback(null, `asset ${request}`);
 							} else if (dependencyType === "css-import") {
 								if (/^(\/\/|https?:\/\/)/.test(request))
@@ -144,9 +150,15 @@ class WebpackOptionsApply extends OptionsApply {
 			new ExternalsPlugin(
 				"module",
 				options.experiments.css
-					? ({ request, dependencyType }, callback) => {
+					? (
+							{ request, dependencyType, contextInfo: { issuer } },
+							callback
+					  ) => {
 							if (dependencyType === "url") {
-								if (/^(\/\/|https?:\/\/)/.test(request))
+								if (
+									/^(\/\/|https?:\/\/)/.test(request) ||
+									(/\.css(\?|$)/.test(issuer) && /^(\/)/.test(request))
+								)
 									return callback(null, `asset ${request}`);
 							} else if (dependencyType === "css-import") {
 								if (/^(\/\/|https?:\/\/)/.test(request))

--- a/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
+++ b/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
@@ -14,7 +14,7 @@ Object {
   "i": " green url(img.09a1a1112c577c279435.png) url(img.09a1a1112c577c279435.png) xyz",
   "j": " green url(img\\\\ img.09a1a1112c577c279435.png) xyz",
   "k": " green url(img\\\\ img.09a1a1112c577c279435.png) xyz",
-  "l": " green url(img.09a1a1112c577c279435.png) xyz",
+  "l": " green url(/img.png) xyz",
 }
 `;
 

--- a/test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -14,7 +14,7 @@ Object {
   "i": " green url(img.09a1a1112c577c279435.png) url(img.09a1a1112c577c279435.png) xyz",
   "j": " green url(img\\\\ img.09a1a1112c577c279435.png) xyz",
   "k": " green url(img\\\\ img.09a1a1112c577c279435.png) xyz",
-  "l": " green url(img.09a1a1112c577c279435.png) xyz",
+  "l": " green url(/img.png) xyz",
 }
 `;
 

--- a/test/configCases/css/external/index.js
+++ b/test/configCases/css/external/index.js
@@ -7,7 +7,7 @@ it("should import an external css", done => {
 			" url(//example.com/image.png) url(https://example.com/image.png)"
 		);
 		expect(style.getPropertyValue("background-image")).toBe(
-			" url(http://example.com/image.png)"
+			" url(http://example.com/image.png) url(/custom-path/image.png)"
 		);
 		done();
 	}, done);

--- a/test/configCases/css/external/style2.css
+++ b/test/configCases/css/external/style2.css
@@ -1,4 +1,4 @@
 body {
 	background: url(//example.com/image.png) url(https://example.com/image.png);
-	background-image: url(http://example.com/image.png);
+	background-image: url(http://example.com/image.png) url(/custom-path/image.png);
 }


### PR DESCRIPTION
In CSS, urls with leading slash are considered absolute urls.
If we want to bundle an asset with an absolute path, `file://` protocol should be used instead.

**Issue:**
When using the CSS experiments and using absolute urls for in `url()`, the compiler considers the url as an absolute path and wants to bundle the image.

**Changes:**
Change behavior for CSS files containing usage of `url()` with a leading slash.

**CSS input code:**
```css
.media {
  background-image: url(/img.png);
}
```

**The compiled CSS code with the issue:**
 You can see that the url has been replaced with the bundled image name.
```css
.media {
  background-image: url(img.09a1a1112c577c279435.png);
}
```

**The compiled CSS code thanks to the fix:**

```css
.media {
  background-image: url(/img.png);
}
```