### PR TITLE
Fix "window is not defined" when using HMR on worker

### DIFF
--- a/hot/dev-server.js
+++ b/hot/dev-server.js
@@ -38,10 +38,16 @@ if (module.hot) {
 				if (["abort", "fail"].indexOf(status) >= 0) {
 					log(
 						"warning",
-						"[HMR] Cannot apply update. Need to do a full reload!"
+						`[HMR] Cannot apply update. ${(
+							typeof window !== "undefined"
+								? "Need to do a full reload!"
+								: "Please reload manually!"
+						)}`
 					);
 					log("warning", "[HMR] " + log.formatError(err));
-					window.location.reload();
+					if (typeof window !== "undefined") {
+						window.location.reload();
+					}
 				} else {
 					log("warning", "[HMR] Update failed: " + log.formatError(err));
 				}

--- a/hot/dev-server.js
+++ b/hot/dev-server.js
@@ -16,9 +16,10 @@ if (module.hot) {
 				if (!updatedModules) {
 					log(
 						"warning",
-						"[HMR] Cannot find update. " + typeof window !== "undefined"
-							? "Need to do a full reload!"
-							: "Please reload manually!"
+						"[HMR] Cannot find update. " +
+							(typeof window !== "undefined"
+								? "Need to do a full reload!"
+								: "Please reload manually!")
 					);
 					log(
 						"warning",
@@ -45,9 +46,10 @@ if (module.hot) {
 				if (["abort", "fail"].indexOf(status) >= 0) {
 					log(
 						"warning",
-						"[HMR] Cannot apply update. " + typeof window !== "undefined"
-							? "Need to do a full reload!"
-							: "Please reload manually!"
+						"[HMR] Cannot apply update. " +
+							(typeof window !== "undefined"
+								? "Need to do a full reload!"
+								: "Please reload manually!")
 					);
 					log("warning", "[HMR] " + log.formatError(err));
 					if (typeof window !== "undefined") {

--- a/hot/dev-server.js
+++ b/hot/dev-server.js
@@ -38,11 +38,9 @@ if (module.hot) {
 				if (["abort", "fail"].indexOf(status) >= 0) {
 					log(
 						"warning",
-						`[HMR] Cannot apply update. ${(
-							typeof window !== "undefined"
-								? "Need to do a full reload!"
-								: "Please reload manually!"
-						)}`
+						"[HMR] Cannot apply update. " + typeof window !== "undefined"
+							? "Need to do a full reload!"
+							: "Please reload manually!"
 					);
 					log("warning", "[HMR] " + log.formatError(err));
 					if (typeof window !== "undefined") {

--- a/hot/dev-server.js
+++ b/hot/dev-server.js
@@ -14,12 +14,19 @@ if (module.hot) {
 			.check(true)
 			.then(function (updatedModules) {
 				if (!updatedModules) {
-					log("warning", "[HMR] Cannot find update. Need to do a full reload!");
+					log(
+						"warning",
+						"[HMR] Cannot find update. " + typeof window !== "undefined"
+							? "Need to do a full reload!"
+							: "Please reload manually!"
+					);
 					log(
 						"warning",
 						"[HMR] (Probably because of restarting the webpack-dev-server)"
 					);
-					window.location.reload();
+					if (typeof window !== "undefined") {
+						window.location.reload();
+					}
 					return;
 				}
 


### PR DESCRIPTION
This fixes an error message that I got while using HMR in webpack-dev-server with `target: "webworker"`. The error message can be reproduced with the example linked in [this comment](https://github.com/webpack/webpack/issues/14722#issuecomment-1134888597). @alexander-akait suggested to make a PR with a fix.

This PR just checks `typeof window` before calling `window.location.reload()` and changes the warning messages slightly when the page cannot be reloaded by webpack.

**What kind of change does this PR introduce?**

bugfix.

**Did you add tests for your changes?**

I tried to, but then I realized that the file `/hot/dev-server.js` is not tested anywhere, yet. Setting up a test scenario from scratch seems like a very hard thing to do :wink:.

I tested this manually with the example above to make sure it works as intended.
![image](https://user-images.githubusercontent.com/33040347/170118405-b85aa7db-fb07-47ae-b0fe-3d903dc6d41e.png)

**Does this PR introduce a breaking change?**

no.

**What needs to be documented once your changes are merged?**

nothing.

PS: Thank you all for your fantastic work with this project!