### PR TITLE
Fix error caused by request is an absolute path in Windows

### DIFF
--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -8,12 +8,14 @@
 const { create: createResolver } = require("enhanced-resolve");
 const nodeModule = require("module");
 const asyncLib = require("neo-async");
+const { isAbsolute } = require('path');
 const AsyncQueue = require("./util/AsyncQueue");
 const StackedCacheMap = require("./util/StackedCacheMap");
 const createHash = require("./util/createHash");
 const { join, dirname, relative, lstatReadlinkAbsolute } = require("./util/fs");
 const makeSerializable = require("./util/makeSerializable");
 const processAsyncTree = require("./util/processAsyncTree");
+const { require } = require("./RuntimeGlobals");
 
 /** @typedef {import("./WebpackError")} WebpackError */
 /** @typedef {import("./logging/Logger").Logger} Logger */
@@ -1633,7 +1635,7 @@ class FileSystemInfo {
 									let request = relative(this.fs, context, childPath);
 									if (request.endsWith(".js")) request = request.slice(0, -3);
 									request = request.replace(/\\/g, "/");
-									if (!request.startsWith("../")) request = `./${request}`;
+									if (!request.startsWith("../") && !isAbsolute(request)) request = `./${request}`;
 									push({
 										type: RBDT_RESOLVE_CJS_FILE,
 										context,

--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -15,7 +15,6 @@ const createHash = require("./util/createHash");
 const { join, dirname, relative, lstatReadlinkAbsolute } = require("./util/fs");
 const makeSerializable = require("./util/makeSerializable");
 const processAsyncTree = require("./util/processAsyncTree");
-const { require } = require("./RuntimeGlobals");
 
 /** @typedef {import("./WebpackError")} WebpackError */
 /** @typedef {import("./logging/Logger").Logger} Logger */

--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -8,7 +8,7 @@
 const { create: createResolver } = require("enhanced-resolve");
 const nodeModule = require("module");
 const asyncLib = require("neo-async");
-const { isAbsolute } = require('path');
+const { isAbsolute } = require("path");
 const AsyncQueue = require("./util/AsyncQueue");
 const StackedCacheMap = require("./util/StackedCacheMap");
 const createHash = require("./util/createHash");
@@ -1634,7 +1634,9 @@ class FileSystemInfo {
 									let request = relative(this.fs, context, childPath);
 									if (request.endsWith(".js")) request = request.slice(0, -3);
 									request = request.replace(/\\/g, "/");
-									if (!request.startsWith("../") && !isAbsolute(request)) request = `./${request}`;
+									if (!request.startsWith("../") && !isAbsolute(request)) {
+										request = `./${request}`;
+									}
 									push({
 										type: RBDT_RESOLVE_CJS_FILE,
 										context,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Bug reproduce:

In windows, we got `request = "D:\\c\\d"` when `conetxt = "C:\\a\\b"` and `childPath = "D:\\c\\d"`.

`request` is an absolute path, but it's handled with a relative path.


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

I not found any unit test for `checkResolveResultsValid` method.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

None, just a bugfix in a special scene

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
