### PR TITLE
Respect browserslist env on config.target if browerslist config extends

### DIFF
--- a/lib/config/browserslistTargetHandler.js
+++ b/lib/config/browserslistTargetHandler.js
@@ -39,8 +39,20 @@ const parse = (input, context) => {
 
 	const config = browserslist.findConfig(context);
 
-	if (config && Object.keys(config).includes(input)) {
-		return { env: input };
+	if (config) {
+		if (Object.keys(config).includes(input)) {
+			return { env: input };
+		}
+
+		if (Object.keys(config).includes('defaults')) {
+			const regexp = /^extends (.+)$/i;
+
+			for (const item of config.defaults) {
+				if (item.match(regexp)) {
+					return { env: input };
+				}
+			}
+		}
 	}
 
 	return { query: input };
@@ -67,7 +79,7 @@ const load = (input, context) => {
 		: browserslist.loadConfig({ path: context, env });
 
 	if (!config) return null;
-	return browserslist(config);
+	return env ? browserslist(config, { env }) : browserslist(config);
 };
 
 /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

If the browserslist config references an exported Browserslist like
`extends @foo/browserslist-config` with configs for two or more environments

```
module.exports = {
    production: [
        '>= 0.5%',
        'not Explorer <= 11'
    ],
    legacy: [
        '>= 1%',
        'Explorer >= 11'
    ]
}
```

the environment will not be respected if you set config.target like
`config.target = 'browserslist:production'`


<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
I don't think so

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
Nothing
