### PR TITLE
Improve watch performance by using stable identities for Snapshot iterables

### DIFF
--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -208,6 +208,12 @@ class SnapshotIterable {
 class Snapshot {
 	constructor() {
 		this._flags = 0;
+		/** @type {Iterable<string> | undefined} */
+		this._cachedFileIterable = undefined;
+		/** @type {Iterable<string> | undefined} */
+		this._cachedContextIterable = undefined;
+		/** @type {Iterable<string> | undefined} */
+		this._cachedMissingIterable = undefined;
 		/** @type {number | undefined} */
 		this.startTime = undefined;
 		/** @type {Map<string, FileSystemInfoEntry | null> | undefined} */
@@ -418,31 +424,43 @@ class Snapshot {
 	 * @returns {Iterable<string>} iterable
 	 */
 	getFileIterable() {
-		return this._createIterable(s => [
-			s.fileTimestamps,
-			s.fileHashes,
-			s.fileTshs,
-			s.managedFiles
-		]);
+		if (this._cachedFileIterable === undefined) {
+			this._cachedFileIterable = this._createIterable(s => [
+				s.fileTimestamps,
+				s.fileHashes,
+				s.fileTshs,
+				s.managedFiles
+			]);
+		}
+		return this._cachedFileIterable;
 	}
 
 	/**
 	 * @returns {Iterable<string>} iterable
 	 */
 	getContextIterable() {
-		return this._createIterable(s => [
-			s.contextTimestamps,
-			s.contextHashes,
-			s.contextTshs,
-			s.managedContexts
-		]);
+		if (this._cachedContextIterable === undefined) {
+			this._cachedContextIterable = this._createIterable(s => [
+				s.contextTimestamps,
+				s.contextHashes,
+				s.contextTshs,
+				s.managedContexts
+			]);
+		}
+		return this._cachedContextIterable;
 	}
 
 	/**
 	 * @returns {Iterable<string>} iterable
 	 */
 	getMissingIterable() {
-		return this._createIterable(s => [s.missingExistence, s.managedMissing]);
+		if (this._cachedMissingIterable === undefined) {
+			this._cachedMissingIterable = this._createIterable(s => [
+				s.missingExistence,
+				s.managedMissing
+			]);
+		}
+		return this._cachedMissingIterable;
 	}
 }
 

--- a/test/FileSystemInfo.unittest.js
+++ b/test/FileSystemInfo.unittest.js
@@ -363,4 +363,50 @@ ${details(snapshot)}`)
 			}
 		});
 	}
+
+	describe("stable iterables identity", () => {
+		const options = { timestamp: true };
+
+		/**
+		 * @param {function((WebpackError | null)=, (Snapshot | null)=): void} callback callback function
+		 */
+		function getSnapshot(callback) {
+			const fs = createFs();
+			const fsInfo = createFsInfo(fs);
+			fsInfo.createSnapshot(
+				Date.now() + 10000,
+				files,
+				directories,
+				missing,
+				options,
+				callback
+			);
+		}
+
+		it("should return same iterable for getFileIterable()", done => {
+			getSnapshot((err, snapshot) => {
+				if (err) done(err);
+				expect(snapshot.getFileIterable()).toEqual(snapshot.getFileIterable());
+				done();
+			});
+		});
+
+		it("should return same iterable for getContextIterable()", done => {
+			getSnapshot((err, snapshot) => {
+				if (err) done(err);
+				expect(snapshot.getContextIterable()).toEqual(
+					snapshot.getContextIterable()
+				);
+				done();
+			});
+		});
+
+		it("should return same iterable for getMissingIterable()", done => {
+			getSnapshot((err, snapshot) => {
+				if (err) done(err);
+				expect(snapshot.getFileIterable()).toEqual(snapshot.getFileIterable());
+				done();
+			});
+		});
+	});
 });


### PR DESCRIPTION
A large monorepo my team works on is seeing an issue where Webpack rebuilds report as finished, but `webpack-dev-server` doesn't respond until a minute later.

## Summary

Starting with performance changes up front. (See below for a description of what we were seeing.) Here's the `LazySet` [`merge`](https://github.com/webpack/webpack/blob/93ce24d2dc40ee972a2ea5138f3c181563c913fd/lib/util/LazySet.js#L16-L22) performance for `compilation.fileDependencies` in this monorepo before/after:

| |`merge` Loop Iterations|Timing(ms)|
|-|-|-|
|Before|1,198,677|23,045.10|
|After|464,918|1,726.25|

These aren't scientific timings ran over multiple trials. I can perform that if needed.

## Investigation

### CPU Profiling

Running the build in a CPU profiler revealed a large amount of time spent calling watchpack's `watch` function. This is after the initial Webpack build. The white space in the profile below is in between the initial build, and saving a file in the repo that has just been modified.

https://github.com/webpack/webpack/blob/e2f1592f7e4d8f0578e5bb23d6a863b4a2b5f309/lib/Watching.js#L303-L307

![Screen Shot 2022-06-22 at 5 51 29 PM](https://user-images.githubusercontent.com/906558/176036043-5053f7fa-6f9d-4b56-a558-3a2effa0b3fa.png)

Going down the call stack, it looks like watchpack iterates over `compilation.fileDependencies`, triggering `LazySet`'s `merge` function.

https://github.com/webpack/webpack/blob/93ce24d2dc40ee972a2ea5138f3c181563c913fd/lib/util/LazySet.js#L16-L22

I patched the `merge` function to output how many items were being iterated over and their time.
```js
const { performance } = require("perf_hooks");
const merge = (targetSet, toMerge) => {
    let count = 0;
    const before = performance.now();
    for (const set of toMerge) {
        for (const item of set) {
            targetSet.add(item);
            count++
        }
    }
    if (count > 5000) {
        const duration = performance.now() - before;
        console.log(`Items iterated during merge: ${count}, ${duration} ms`)
    }
};
```

The results:

```
Items iterated during merge: 1198677, 23045.103875994682 ms
Items iterated during merge: 726370, 8386.988652005792 ms
```

The 1st set iterated corresponds to `compilation.fileDependencies`.

### LazySet toMerge Duplicates

Inspecting `compilation.fileDependencies` in an interactive debugger shows that this `LazySet` has a lot of duplicates in its `toMerge` field.

Adding a breakpoint to the `merge` function commented on above and inspecting the `toMerge` argument:

```
❯ toMerge.size
128116
❯ new Set([...toMerge].map(snapshotIterable => snapshotIterable.snapshot)).size
62175
```

This is after `LazySet._toMerge` has had its contents moved from `LazySet._toDeepMerge`. Attaching a screenshot of the call stack in VS Code's debugger if that helps.

![Screen Shot 2022-06-27 at 6 29 16 PM](https://user-images.githubusercontent.com/906558/176046681-5bf87ded-d991-4b53-a6ab-5053f604f9ce.png)

---

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

One of the reasons `_toMerge` gets so large is because every `SnapshotIterable` is uniquely constructed, even if they're derived from the same underlying `Snapshot` class.

This PR gives snapshot iterables stable identifiers, which reduces the items in the `_toMerge` set and significantly improved performance in this app.

After this change, the log output from above becomes:

```
Items iterated during merge: 464918, 1726.2539209723473 ms
Items iterated during merge: 561334, 222.49260300397873 ms
```

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

I added tests to ensure the snapshot iterables returned are stable across multiple calls, but the tests could probably be written better. I'd appreciate a gut check from the Webpack team that this change makes sense before improving tests more.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

It does not.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

## Questions for Reviewers

Thanks for looking at this!

- Does this change make sense, or should I investigate improving performance of this `watch` call in a different way?
- Would it make sense to use [`WeakRef`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) to prevent these saved iterable objects from living longer than necessary? I think we'd have to check for the API's existence and gracefully fallback to support older Node.js versions.

fixes #15231