### PR TITLE
docs: update in readme the list of plugins and loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ within webpack itself use this plugin interface. This makes webpack very
 |    [mini-css-extract-plugin][mini-css]    |  ![mini-css-npm]   |  ![mini-css-size]   | Extracts CSS into separate files. It creates a CSS file per JS file which contains CSS. |
 | [compression-webpack-plugin][compression] | ![compression-npm] | ![compression-size] | Prepares compressed versions of assets to serve them with Content-Encoding              |
 |    [html-webpack-plugin][html-plugin]     | ![html-plugin-npm] | ![html-plugin-size] | Simplifies creation of HTML files (`index.html`) to serve your bundles                  |
+| [pug-plugin][pug-plugin]                  | ![pug-plugin-npm]  | ![pug-plugin-size]  | Renders Pug files to HTML, extracts JS and CSS from sources specified directly in Pug.  |
 
 [common-npm]: https://img.shields.io/npm/v/webpack.svg
 [mini-css]: https://github.com/webpack-contrib/mini-css-extract-plugin
@@ -124,6 +125,9 @@ within webpack itself use this plugin interface. This makes webpack very
 [html-plugin]: https://github.com/jantimon/html-webpack-plugin
 [html-plugin-npm]: https://img.shields.io/npm/v/html-webpack-plugin.svg
 [html-plugin-size]: https://packagephobia.com/badge?p=html-webpack-plugin
+[pug-plugin]: https://github.com/webdiscus/pug-plugin
+[pug-plugin-npm]: https://img.shields.io/npm/v/pug-plugin.svg
+[pug-plugin-size]: https://packagephobia.com/badge?p=pug-plugin
 
 ### [Loaders](https://webpack.js.org/loaders/)
 
@@ -170,18 +174,21 @@ or are automatically applied via regex from your webpack configuration.
 
 #### Templating
 
-|                                                                                 Name                                                                                  |     Status      |   Install Size   | Description                                                                             |
-| :-------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------------: | :--------------: | :-------------------------------------------------------------------------------------- |
-|              <a href="https://github.com/webpack-contrib/html-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/html5.svg"></a>              |   ![html-npm]   |   ![html-size]   | Exports HTML as string, requires references to static resources                         |
-| <a href="https://github.com/pugjs/pug-loader"><img width="48" height="48" src="https://cdn.rawgit.com/pugjs/pug-logo/master/SVG/pug-final-logo-_-colour-128.svg"></a> |   ![pug-npm]    |   ![pug-size]    | Loads Pug templates and returns a function                                              |
-|              <a href="https://github.com/peerigon/markdown-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/markdown.svg"></a>              |    ![md-npm]    |    ![md-size]    | Compiles Markdown to HTML                                                               |
-|               <a href="https://github.com/posthtml/posthtml-loader"><img width="48" height="48" src="https://posthtml.github.io/posthtml/logo.svg"></a>               | ![posthtml-npm] | ![posthtml-size] | Loads and transforms a HTML file using [PostHTML](https://github.com/posthtml/posthtml) |
-|           <a href="https://github.com/pcardune/handlebars-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/handlebars-1.svg"></a>           |   ![hbs-npm]    |   ![hbs-size]    | Compiles Handlebars to HTML                                                             |
+|                                                                                 Name                                                                                      |     Status      |   Install Size   | Description                                                                             |
+| :-----------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------------: | :--------------: | :-------------------------------------------------------------------------------------- |
+|              <a href="https://github.com/webpack-contrib/html-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/html5.svg"></a>                  |   ![html-npm]   |   ![html-size]   | Exports HTML as string, requires references to static resources                         |
+| <a href="https://github.com/pugjs/pug-loader"><img width="48" height="48" src="https://cdn.rawgit.com/pugjs/pug-logo/master/SVG/pug-final-logo-_-colour-128.svg"></a>     |   ![pug-npm]    |   ![pug-size]    | Loads Pug templates and returns a function                                              |
+| <a href="https://github.com/webdiscus/pug-loader"><img width="48" height="48" src="https://cdn.rawgit.com/pugjs/pug-logo/master/SVG/pug-final-logo-_-colour-128.svg"></a> |   ![pug3-npm]   |   ![pug3-size]   | Compiles Pug to a function or HTML string, useful for use with Vue, React, Angular      |
+|              <a href="https://github.com/peerigon/markdown-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/markdown.svg"></a>                  |    ![md-npm]    |    ![md-size]    | Compiles Markdown to HTML                                                               |
+|               <a href="https://github.com/posthtml/posthtml-loader"><img width="48" height="48" src="https://posthtml.github.io/posthtml/logo.svg"></a>                   | ![posthtml-npm] | ![posthtml-size] | Loads and transforms a HTML file using [PostHTML](https://github.com/posthtml/posthtml) |
+|           <a href="https://github.com/pcardune/handlebars-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/handlebars-1.svg"></a>               |   ![hbs-npm]    |   ![hbs-size]    | Compiles Handlebars to HTML                                                             |
 
 [html-npm]: https://img.shields.io/npm/v/html-loader.svg
 [html-size]: https://packagephobia.com/badge?p=html-loader
 [pug-npm]: https://img.shields.io/npm/v/pug-loader.svg
 [pug-size]: https://packagephobia.com/badge?p=pug-loader
+[pug3-npm]: https://img.shields.io/npm/v/@webdiscus/pug-loader.svg
+[pug3-size]: https://packagephobia.com/badge?p=@webdiscus/pug-loader
 [jade-npm]: https://img.shields.io/npm/v/jade-loader.svg
 [jade-size]: https://packagephobia.com/badge?p=jade-loader
 [md-npm]: https://img.shields.io/npm/v/markdown-loader.svg

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ within webpack itself use this plugin interface. This makes webpack very
 |    [mini-css-extract-plugin][mini-css]    |  ![mini-css-npm]   |  ![mini-css-size]   | Extracts CSS into separate files. It creates a CSS file per JS file which contains CSS. |
 | [compression-webpack-plugin][compression] | ![compression-npm] | ![compression-size] | Prepares compressed versions of assets to serve them with Content-Encoding              |
 |    [html-webpack-plugin][html-plugin]     | ![html-plugin-npm] | ![html-plugin-size] | Simplifies creation of HTML files (`index.html`) to serve your bundles                  |
-| [pug-plugin][pug-plugin]                  | ![pug-plugin-npm]  | ![pug-plugin-size]  | Renders Pug files to HTML, extracts JS and CSS from sources specified directly in Pug.  |
+|         [pug-plugin][pug-plugin]          | ![pug-plugin-npm]  | ![pug-plugin-size]  | Renders Pug files to HTML, extracts JS and CSS from sources specified directly in Pug.  |
 
 [common-npm]: https://img.shields.io/npm/v/webpack.svg
 [mini-css]: https://github.com/webpack-contrib/mini-css-extract-plugin
@@ -174,14 +174,14 @@ or are automatically applied via regex from your webpack configuration.
 
 #### Templating
 
-|                                                                                 Name                                                                                      |     Status      |   Install Size   | Description                                                                             |
+|                                                                                   Name                                                                                    |     Status      |   Install Size   | Description                                                                             |
 | :-----------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------------: | :--------------: | :-------------------------------------------------------------------------------------- |
-|              <a href="https://github.com/webpack-contrib/html-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/html5.svg"></a>                  |   ![html-npm]   |   ![html-size]   | Exports HTML as string, requires references to static resources                         |
-| <a href="https://github.com/pugjs/pug-loader"><img width="48" height="48" src="https://cdn.rawgit.com/pugjs/pug-logo/master/SVG/pug-final-logo-_-colour-128.svg"></a>     |   ![pug-npm]    |   ![pug-size]    | Loads Pug templates and returns a function                                              |
+|                <a href="https://github.com/webpack-contrib/html-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/html5.svg"></a>                |   ![html-npm]   |   ![html-size]   | Exports HTML as string, requires references to static resources                         |
+|   <a href="https://github.com/pugjs/pug-loader"><img width="48" height="48" src="https://cdn.rawgit.com/pugjs/pug-logo/master/SVG/pug-final-logo-_-colour-128.svg"></a>   |   ![pug-npm]    |   ![pug-size]    | Loads Pug templates and returns a function                                              |
 | <a href="https://github.com/webdiscus/pug-loader"><img width="48" height="48" src="https://cdn.rawgit.com/pugjs/pug-logo/master/SVG/pug-final-logo-_-colour-128.svg"></a> |   ![pug3-npm]   |   ![pug3-size]   | Compiles Pug to a function or HTML string, useful for use with Vue, React, Angular      |
-|              <a href="https://github.com/peerigon/markdown-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/markdown.svg"></a>                  |    ![md-npm]    |    ![md-size]    | Compiles Markdown to HTML                                                               |
-|               <a href="https://github.com/posthtml/posthtml-loader"><img width="48" height="48" src="https://posthtml.github.io/posthtml/logo.svg"></a>                   | ![posthtml-npm] | ![posthtml-size] | Loads and transforms a HTML file using [PostHTML](https://github.com/posthtml/posthtml) |
-|           <a href="https://github.com/pcardune/handlebars-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/handlebars-1.svg"></a>               |   ![hbs-npm]    |   ![hbs-size]    | Compiles Handlebars to HTML                                                             |
+|                <a href="https://github.com/peerigon/markdown-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/markdown.svg"></a>                |    ![md-npm]    |    ![md-size]    | Compiles Markdown to HTML                                                               |
+|                 <a href="https://github.com/posthtml/posthtml-loader"><img width="48" height="48" src="https://posthtml.github.io/posthtml/logo.svg"></a>                 | ![posthtml-npm] | ![posthtml-size] | Loads and transforms a HTML file using [PostHTML](https://github.com/posthtml/posthtml) |
+|             <a href="https://github.com/pcardune/handlebars-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/handlebars-1.svg"></a>             |   ![hbs-npm]    |   ![hbs-size]    | Compiles Handlebars to HTML                                                             |
 
 [html-npm]: https://img.shields.io/npm/v/html-loader.svg
 [html-size]: https://packagephobia.com/badge?p=html-loader


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Motivation

In README.md are added `pug-plugin` and modern powerful `pug-loader`.

### [pug-plugin](https://github.com/webdiscus/pug-plugin)
This plugin enable to define Pug files in Webpack entry, extracts JS and CSS from sources specified directly in Pug:
```js
const PugPlugin = require('pug-plugin');
module.exports = {
  entry: {
    index: './src/views/index.pug',      // output index.html
    about: './src/views/about/index.pug' // output about.html
    // ..
  },
  plugins: [
    new PugPlugin(/* options */), // enable using Pug files in webpack entry
  ],
};
```
All source scripts and styles can be required in Pug, e.g.:
```pug
link(href=require('./styles.scss') rel='stylesheet')
script(src=require('./main.js'))
```
Generated HTML contains hashed CSS and JS output filenames:
```html
<link href="/assets/css/styles.05e4dd86.css" rel="stylesheet">
<script src="/assets/js/main.f4b855d8.js"></script>
```

This plugin make much easy the usage Pug with Webpack.
Test coverage > 99%.

### [@webdiscus/pug-loader](https://github.com/webdiscus/pug-loader)
The original [pugjs/pug-loader](https://github.com/pugjs/pug-loader) has problems:
- since 4 years not updated [Is this package still being maintained?](https://github.com/pugjs/pug-loader/issues/124)
- by install occurs deprecation ERROR and can be installed only with force `npm i pug-loader --force`

The alternative `@webdiscus/pug-loader` can do absolutely everything that `pugjs/pug-loader` can (100% compatible with pugjs/pug-loader), plus:
- compiles Pug to template function (as pugjs/pug-loader), but in CommonJS or ESM
- renders Pug to JS module with exports as HTML string, useful for use in JS
- renders Pug to pure HTML string, useful for use with Vue, React, Angular
- pass custom data in Pug templates
- supports for indent in templates of Vue, React:
  ```html
  <template lang='pug'>
    h1 Hello Pug!
    p Use the '@webdiscus/pug-loader'
  </template>
  ```
- resolves all required resoures
- watching of changes in all dependencies
- test coverage > 98%

---

## Suggestion
Instead of `install size` display `publish size` of a package. 
E.g. the  pug-plugin have `public size` only 100 KB, but `install size` is 8 MB, becase contains `docs` with many resources, has much tests with real files to test: images, fonts, etc.

---

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
docs: update readme

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
tests are not needs for readme

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Nothing

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
