### PR TITLE
Pass shareScope through to ContainerPlugin & ContainerReferencePlugin

### DIFF
--- a/lib/container/ModuleFederationPlugin.js
+++ b/lib/container/ModuleFederationPlugin.js
@@ -65,6 +65,7 @@ class ModuleFederationPlugin {
 					library,
 					filename: options.filename,
 					runtime: options.runtime,
+					shareScope: options.shareScope,
 					exposes: options.exposes
 				}).apply(compiler);
 			}
@@ -76,6 +77,7 @@ class ModuleFederationPlugin {
 			) {
 				new ContainerReferencePlugin({
 					remoteType,
+					shareScope: options.shareScope,
 					remotes: options.remotes
 				}).apply(compiler);
 			}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
It looks to me like setting `shareScope` for `ModuleFederationPlugin` doesn't work without this change, because `ContainerPlugin` still tries to use `default`.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

No, but I didn't see any other tests for `ModuleFederationPlugin` either.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

I don't think so.

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

I believe this change makes it more closely match existing documentation.