### PR TITLE
feat: export HarmonyImportDependency and generate types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -342,6 +342,9 @@ module.exports = mergeExports(fn, {
 		get ModuleDependency() {
 			return require("./dependencies/ModuleDependency");
 		},
+		get HarmonyImportDependency() {
+			return require("./dependencies/HarmonyImportDependency");
+		},
 		get ConstDependency() {
 			return require("./dependencies/ConstDependency");
 		},

--- a/types.d.ts
+++ b/types.d.ts
@@ -4509,6 +4509,42 @@ declare interface HandleModuleCreationOptions {
 	 */
 	connectOrigin?: boolean;
 }
+declare class HarmonyImportDependency extends ModuleDependency {
+	constructor(
+		request: string,
+		sourceOrder: number,
+		assertions?: Record<string, any>
+	);
+	sourceOrder: number;
+	getImportVar(moduleGraph: ModuleGraph): string;
+	getImportStatement(
+		update: boolean,
+		__1: DependencyTemplateContext
+	): [string, string];
+	getLinkingErrors(
+		moduleGraph: ModuleGraph,
+		ids: string[],
+		additionalMessage: string
+	): undefined | WebpackError[];
+	static Template: typeof HarmonyImportDependencyTemplate;
+	static ExportPresenceModes: {
+		NONE: 0;
+		WARN: 1;
+		AUTO: 2;
+		ERROR: 3;
+		fromUserOption(str?: any): 0 | 1 | 2 | 3;
+	};
+	static NO_EXPORTS_REFERENCED: string[][];
+	static EXPORTS_OBJECT_REFERENCED: string[][];
+	static TRANSITIVE: typeof TRANSITIVE;
+}
+declare class HarmonyImportDependencyTemplate extends DependencyTemplate {
+	constructor();
+	static getImportEmittedRuntime(
+		module: Module,
+		referencedModule: Module
+	): undefined | string | boolean | SortableSet<string>;
+}
 declare class Hash {
 	constructor();
 
@@ -12734,7 +12770,12 @@ declare namespace exports {
 		) => void;
 	}
 	export namespace dependencies {
-		export { ModuleDependency, ConstDependency, NullDependency };
+		export {
+			ModuleDependency,
+			HarmonyImportDependency,
+			ConstDependency,
+			NullDependency
+		};
 	}
 	export namespace ids {
 		export {


### PR DESCRIPTION
This PR adds the ability for plugins to create custom dependencies that play nicely with `ModuleConcatenationPlugin`.
Currently, module concatenation uses `instanceof HarmonyImportDependency ` to check if a dependency is applicable.
because of that, it's preferred to not import `HarmonyImportDependency ` directly and use it from the injected webpack inside the plugin. In this PR I just exported the `HarmonyImportDependency` so it can be used via injection.

Note: 
Usually, dependencies have an effect on the generated code. but when dependencies are used just for information and do not have an effect on output code they could play nice with module `ModuleConcatenationPlugin` without bail out by default.

Another way to solve this is to not use `instanceof` and use some static/public key like `allowConcatination` on the dependency that any dependency can implement.

Info:
* Not a breaking change. 
* Not sure if the index exports are tested so no tests were added
