### PR TITLE
fix: when the jobs parameter is an empty array, block unnecessary runCodeGenerationJobs

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -3192,6 +3192,9 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 	}
 
 	_runCodeGenerationJobs(jobs, callback) {
+		if (jobs.length === 0) {
+			return callback();
+		}
 		let statModulesFromCache = 0;
 		let statModulesGenerated = 0;
 		const { chunkGraph, moduleGraph, dependencyTemplates, runtimeTemplate } =

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -1365,7 +1365,6 @@ asset <CLR=32,BOLD>main.js</CLR> 84 bytes <CLR=32,BOLD>[emitted]</CLR> (name: ma
 <CLR=BOLD>LOG from webpack.Compilation</CLR>
     <CLR=BOLD>1 modules hashed, 0 from cache (1 variants per module in average)</CLR>
     <CLR=BOLD>100% code generated (1 generated, 0 from cache)</CLR>
-    <CLR=BOLD>NaN% code generated (0 generated, 0 from cache)</CLR>
 + 24 hidden lines
 
 <CLR=BOLD>LOG from webpack.FlagDependencyExportsPlugin</CLR>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
fixed sometimes log will be NaN%

**Did you add tests for your changes?**
no 

**Does this PR introduce a breaking change?**
no

**What needs to be documented once your changes are merged?**
no

