### PR TITLE
Allow webpack's module output to be consumed by webpack

### DIFF
--- a/lib/esm/ModuleChunkLoadingRuntimeModule.js
+++ b/lib/esm/ModuleChunkLoadingRuntimeModule.js
@@ -193,7 +193,7 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 													: `if(${hasJsMatcher("chunkId")}) {`,
 												Template.indent([
 													"// setup Promise in chunk cache",
-													`var promise = ${importFunctionName}(${JSON.stringify(
+													`var promise = ${importFunctionName}(/* webpackInclude: /.js$/ */ ${JSON.stringify(
 														rootOutputDir
 													)} + ${
 														RuntimeGlobals.getChunkScriptFilename


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

This is probably not the right way to do this, but I wanted to start a discussion about making this an official possibility.
Right now this makes it possible to consume webpack's module output by another webpack compilation.

Without this change, if you have any file that is not recognized by webpack (like `.map` or `.d.ts` files), webpack would issue warnings:

```
WARNING in ./node_modules/mymodule/file.d.ts 9:103
Module parse failed: Unexpected token (9:103)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
```

I specifically want to support webpack 4, so this needed to be combined with a few things to work correctly:
- had to set `output.importModuleName: "({url: 'https://_'})"` so that webpack 4 doesn't crash on the otherwise generated `import.meta`
- had to make sure every asset is inlined (including css having to use style-loader), since loading won't work
- manually rename all references of the compiled output of `__webpack_require__` to something else (would trip up webpack otherwise)

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No, starting a discussion.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

How to consume webpack's output in another webpack compilation
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
