### PR TITLE
export EnableWasmLoadingPlugin to enable writing of wasm loading plugins, as documented

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -495,6 +495,9 @@ module.exports = mergeExports(fn, {
 	wasm: {
 		get AsyncWebAssemblyModulesPlugin() {
 			return require("./wasm-async/AsyncWebAssemblyModulesPlugin");
+		},
+		get EnableWasmLoadingPlugin() {
+			return require("./wasm/EnableWasmLoadingPlugin");
 		}
 	},
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -3133,6 +3133,17 @@ declare class EnableLibraryPlugin {
 	static setEnabled(compiler: Compiler, type: string): void;
 	static checkEnabled(compiler: Compiler, type: string): void;
 }
+declare class EnableWasmLoadingPlugin {
+	constructor(type: string);
+	type: string;
+
+	/**
+	 * Apply the plugin
+	 */
+	apply(compiler: Compiler): void;
+	static setEnabled(compiler: Compiler, type: string): void;
+	static checkEnabled(compiler: Compiler, type: string): void;
+}
 type Entry =
 	| string
 	| (() => string | EntryObject | string[] | Promise<EntryStatic>)
@@ -12891,7 +12902,7 @@ declare namespace exports {
 		export { ElectronTargetPlugin };
 	}
 	export namespace wasm {
-		export { AsyncWebAssemblyModulesPlugin };
+		export { AsyncWebAssemblyModulesPlugin, EnableWasmLoadingPlugin };
 	}
 	export namespace library {
 		export { AbstractLibraryPlugin, EnableLibraryPlugin };


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

After fighting for a long time with webpack to get it to generate WASM loading code that would work with `vscode` web extensions (see https://code.visualstudio.com/api/extension-guides/web-extensions#web-extension-main-file for why this is non-trivial), I understood that I will need to change the `webpack` WASM loading code. I even found [documentation](https://webpack.js.org/configuration/output/#outputwasmloading) saying it's possible. When I tried, I got an error message saying I just need to call `EnableWasmLoadingPlugin.setEnabled()`, which was very encouraging, however, I couldn't find a way to do that, so I had to patch `webpack` to export it.

Here is the plugin I wrote, in case anyone googles how to do the same:

https://github.com/SonOfLilit/vscode-web-wasm-rust

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Irrelevant, no new functionality

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

I fixed the code to correspond to existing documentation :)

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
