### PR TITLE
docs: remove david-dm from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![npm][npm]][npm-url]
 
 [![node][node]][node-url]
-[![deps][deps]][deps-url]
 [![builds2][builds2]][builds2-url]
 [![coverage][cover]][cover-url]
 [![licenses][licenses]][licenses-url]
@@ -706,8 +705,6 @@ src="https://static.monei.net/monei-logo.svg" height="30" alt="MONEI"></a>
 [npm-url]: https://npmjs.com/package/webpack
 [node]: https://img.shields.io/node/v/webpack.svg
 [node-url]: https://nodejs.org
-[deps]: https://img.shields.io/david/webpack/webpack.svg
-[deps-url]: https://david-dm.org/webpack/webpack
 [prs]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg
 [prs-url]: https://webpack.js.org/contribute/
 [builds2]: https://dev.azure.com/webpack/webpack/_apis/build/status/webpack.webpack


### PR DESCRIPTION
The `david-dm.org` website is down for 3 months, and the project `alanshaw/david` is not actively maintained anymore. `david-dm.org` should be considered dead, thus badges should be removed from README.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

README updates.

**Did you add tests for your changes?**

New test cases are not required.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

N/A.