### PR TITLE
Group entrypoint and assets in an output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 .cache
 .eslintcache
 package-lock.json
+/events.json

--- a/lib/CleanPlugin.js
+++ b/lib/CleanPlugin.js
@@ -44,7 +44,7 @@ const validate = createSchemaValidation(
 const _10sec = 10 * 1000;
 
 /**
- * marge assets map 2 into map 1
+ * merge assets map 2 into map 1
  * @param {Assets} as1 assets
  * @param {Assets} as2 assets
  * @returns {void}

--- a/lib/GroupAssetsPlugin.js
+++ b/lib/GroupAssetsPlugin.js
@@ -1,0 +1,98 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author David Tanner @DavidTanner
+*/
+
+"use strict";
+
+const path = require("path");
+const { mkdirpAsync, copyFileAsync } = require("./util/fs");
+
+/** @typedef {import("./Compiler")} Compiler */
+/** @typedef {import("./Stats")} Stats */
+/** @typedef {import("./logging/Logger").Logger} Logger */
+/** @typedef {import("./util/fs").OutputFileSystem} OutputFileSystem */
+
+/** @typedef {Object.<string, string[]>} GroupAssetsResources */
+
+/**
+ * Process the stats to extract entrypoint resources
+ * @param {Logger} logger The logger
+ * @param {OutputFileSystem} fs filesystem
+ * @param {Stats} stats Stats from the build
+ * @returns {Promise<void>}
+ */
+const processStats = async (logger, fs, stats) => {
+	const {
+		compilation: {
+			errors,
+			entrypoints,
+			outputOptions: { path: outputDir = process.cwd() }
+		}
+	} = stats;
+
+	if (errors.length) {
+		logger.warn("AssetsDirectoryPlugin: Not running because of errors");
+		return;
+	}
+
+	/** @type {GroupAssetsResources} */
+	const resources = {};
+	for (const [name, entrypoint] of entrypoints) {
+		const filesToCopy = [];
+		entrypoint.chunks.forEach(({ files, auxiliaryFiles }) => {
+			filesToCopy.push(...files);
+			filesToCopy.push(...auxiliaryFiles);
+		});
+		resources[name] = filesToCopy;
+	}
+
+	await copyAssets(logger, fs, outputDir, resources);
+};
+
+/**
+ * Copy the required assets to the directory
+ * @param {Logger} logger The logger
+ * @param {OutputFileSystem} fs filesystem
+ * @param {String} outputDir The output directory
+ * @param {GroupAssetsResources} resources The resources to be copied
+ * @returns {Promise<void>}
+ */
+const copyAssets = async (logger, fs, outputDir, resources) => {
+	await Promise.all(
+		Object.entries(resources).map(async ([entryName, filesToCopy]) => {
+			// Now, write a zip file for each entry
+			logger.info(`Adding entries for ${entryName}...`);
+			const outDir = path.join(outputDir, `${entryName}.dir`);
+			await Promise.all(
+				filesToCopy.map(async file => {
+					const destDir = path.join(outDir, file);
+					await mkdirpAsync(fs, path.dirname(destDir));
+					await copyFileAsync(fs, path.join(outputDir, file), destDir);
+				})
+			);
+			logger.info(`Finished adding entries for ${entryName}.`);
+		})
+	);
+};
+
+class GroupAssetsPlugin {
+	constructor() {}
+	/**
+	 * Apply the plugin
+	 * @param {Compiler} compiler the compiler instance
+	 * @returns {void}
+	 */
+	apply(compiler) {
+		/** @type {Logger} */
+		const logger = compiler.getInfrastructureLogger(
+			"webpack.GroupAssetsPlugin"
+		);
+		const fs = compiler.outputFileSystem;
+		compiler.hooks.done.tapPromise("GroupAssetsPlugin", stats =>
+			processStats(logger, fs, stats)
+		);
+	}
+}
+
+module.exports = GroupAssetsPlugin;

--- a/lib/index.js
+++ b/lib/index.js
@@ -206,6 +206,9 @@ module.exports = mergeExports(fn, {
 	get Generator() {
 		return require("./Generator");
 	},
+	get GroupAssetsPlugin() {
+		return require("./GroupAssetsPlugin");
+	},
 	get HotUpdateChunk() {
 		return require("./HotUpdateChunk");
 	},

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -108,6 +108,7 @@ const path = require("path");
  * @property {(function(string, string): string)=} join
  * @property {(function(string, string): string)=} relative
  * @property {(function(string): string)=} dirname
+ * @property {(function(string, string, Callback): void)} copyFile
  */
 
 /**
@@ -251,6 +252,21 @@ const mkdirp = (fs, p, callback) => {
 exports.mkdirp = mkdirp;
 
 /**
+ * @param {OutputFileSystem} fs a file system
+ * @param {string} p an absolute path
+ * @returns {Promise<void>}
+ */
+const mkdirpAsync = async (fs, p) => {
+	return new Promise((resolve, reject) => {
+		mkdirp(fs, p, (err, res) => {
+			if (err) return reject(err);
+			resolve(res);
+		});
+	});
+};
+exports.mkdirpAsync = mkdirpAsync;
+
+/**
  * @param {IntermediateFileSystem} fs a file system
  * @param {string} p an absolute path
  * @returns {void}
@@ -335,3 +351,18 @@ const lstatReadlinkAbsolute = (fs, p, callback) => {
 	doReadLink();
 };
 exports.lstatReadlinkAbsolute = lstatReadlinkAbsolute;
+
+/**
+ * @param {OutputFileSystem} fs a file system
+ * @param {string} source an absolute path
+ * @param {string} dest an absolute path
+ * @returns {Promise<void>}
+ */
+const copyFileAsync = async (fs, source, dest) =>
+	new Promise((resolve, reject) => {
+		fs.copyFile(source, dest, (err, res) => {
+			if (err) return reject(err);
+			resolve(res);
+		});
+	});
+exports.copyFileAsync = copyFileAsync;

--- a/test/GroupAssetsPlugin.test.js
+++ b/test/GroupAssetsPlugin.test.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const path = require("path");
+const fs = require("graceful-fs");
+const webpack = require("..");
+
+const pluginDir = path.join(__dirname, "js", "GroupAssetsPlugin");
+const outputDir = path.join(pluginDir, "output");
+
+it("will group all assets into a folder", async () => {
+	try {
+		fs.mkdirSync(path.join(pluginDir), {
+			recursive: true
+		});
+	} catch (e) {
+		// empty
+	}
+
+	const groupAssetsPlugin = new webpack.GroupAssetsPlugin();
+
+	const compiler = webpack({
+		mode: "development",
+		entry: {
+			chunk: "./grouped.js"
+		},
+		target: "node",
+		context: path.join(__dirname, "fixtures"),
+		optimization: {
+			splitChunks: {
+				chunks: "all"
+			}
+		},
+		output: {
+			path: outputDir
+		},
+		plugins: [groupAssetsPlugin]
+	});
+	await new Promise((resolve, reject) =>
+		compiler.run((err, result) => {
+			if (err) {
+				reject(err);
+			} else {
+				resolve(result);
+			}
+		})
+	);
+
+	expect(fs.existsSync(path.join(outputDir, "chunk.js"))).toBe(true);
+	expect(
+		fs.existsSync(
+			path.join(outputDir, "vendors-node_modules_lodash_countBy_js.js")
+		)
+	).toBe(true);
+
+	expect(fs.existsSync(path.join(outputDir, "chunk.dir"))).toBe(true);
+	expect(fs.existsSync(path.join(outputDir, "chunk.dir", "chunk.js"))).toBe(
+		true
+	);
+	expect(
+		fs.existsSync(
+			path.join(
+				outputDir,
+				"chunk.dir",
+				"vendors-node_modules_lodash_countBy_js.js"
+			)
+		)
+	).toBe(true);
+});

--- a/test/fixtures/grouped.js
+++ b/test/fixtures/grouped.js
@@ -1,0 +1,3 @@
+const countBy = require('lodash/countBy');
+
+console.log(countBy([6.1, 4.2, 6.3]));

--- a/types.d.ts
+++ b/types.d.ts
@@ -4478,6 +4478,14 @@ declare class GetChunkFilenameRuntimeModule extends RuntimeModule {
 	 */
 	static STAGE_TRIGGER: number;
 }
+declare class GroupAssetsPlugin {
+	constructor();
+
+	/**
+	 * Apply the plugin
+	 */
+	apply(compiler: Compiler): void;
+}
 declare interface GroupConfig {
 	getKeys: (arg0?: any) => string[];
 	createGroup: (arg0: string, arg1: any[], arg2: any[]) => object;
@@ -8708,6 +8716,11 @@ declare interface OutputFileSystem {
 	join?: (arg0: string, arg1: string) => string;
 	relative?: (arg0: string, arg1: string) => string;
 	dirname?: (arg0: string) => string;
+	copyFile: (
+		arg0: string,
+		arg1: string,
+		arg2: (arg0?: null | NodeJS.ErrnoException) => void
+	) => void;
 }
 
 /**
@@ -13103,6 +13116,7 @@ declare namespace exports {
 		ExternalModule,
 		ExternalsPlugin,
 		Generator,
+		GroupAssetsPlugin,
 		HotUpdateChunk,
 		HotModuleReplacementPlugin,
 		IgnorePlugin,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
My company builds webpacked js files to deploy to AWS Lambda.  When building zip files, metadata is included for each file, causing every new build to have a different hash, despite the contents not changing.  This is fine as long as there are no additional files to be included.

The build breaks down when using native built files, like sharp.js for example.  Webpack can bundle the `*.node` file, but the file natively imports compiled c++ files from a hard coded relative path.  

<details>
  <summary>Sharp.js structure</summary>

```
.
├── build
│   └── Release
│       ├── sharp-linux-x64.node
└── vendor
    └── 8.12.2
        └── linux-x64
            ├── THIRD-PARTY-NOTICES.md
            ├── lib
            │   ├── glib-2.0
            │   └── libvips-cpp.so.42
            ├── platform.json
            └── versions.json

```

</details>

<details>
  <summary>Example webpack config</summary>

```javascript
{
  entry: {
    'webpackedFile1.js': ['/ab/path/to/file.js'],
    'webpackedFile2.js': ['/ab/path/to/file2.js']
  },
  optimization: {
    splitChunks: {
      chunks: 'all',
    },
  },
  module: {
    rules: [
      {
        test: /\.node$/,
        loader: 'node-loader',
        options: {
          name: 'build/release/[contenthash].[ext]',
        }
      }
    ]
  }
}
```

```
.
├── 154
├── 441
├── 627
├── 801
├── webpackFile1.js
├── webpackFile1.js.dir
│ ├── 154
│ ├── 441
│ ├── 627
│ ├── 801
│ ├── build
│ │ └── release
│ │     └── 7f78ad932475bd68d340e9c07c1e9a4e.node
│ ├── webpackFile1.js
│ └── vendor
│     └── 8.12.2
│         └── linux-x64
│             ├── THIRD-PARTY-NOTICES.md
│             ├── lib
│             │ ├── glib-2.0
│             │ └── libvips-cpp.so.42
│             ├── platform.json
│             └── versions.json
├── webpackFile2.js
├── webpackFile2.js.dir
│ ├── 441
│ ├── 608
│ └── webpackFile2.js
```
</details>

<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Yes.

**Did you add tests for your changes?**

A test was added to bundle lodash as a chunk with the main resource.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
A new file will need to be added to `https://github.com/webpack/webpack.js.org/tree/master/src/content/plugins` that describes the plugin, and can hold future configuration information.
