### PR TITLE
feat: add salt support for DeterministicChunkIdsPlugin

### DIFF
--- a/lib/ids/DeterministicChunkIdsPlugin.js
+++ b/lib/ids/DeterministicChunkIdsPlugin.js
@@ -16,6 +16,12 @@ const {
 /** @typedef {import("../Module")} Module */
 
 class DeterministicChunkIdsPlugin {
+	/**
+	 * @param {Object} options options
+	 * @param {string=} options.context context relative to which module identifiers are computed
+	 * @param {number=} options.maxLength maximum id length in digits (used as starting point)
+	 * @param {number=} options.salt hash salt for ids
+	 */
 	constructor(options) {
 		this.options = options || {};
 	}
@@ -41,6 +47,7 @@ class DeterministicChunkIdsPlugin {
 						const compareNatural = compareChunksNatural(chunkGraph);
 
 						const usedIds = getUsedChunkIds(compilation);
+						const salt = this.options.salt || 0;
 						assignDeterministicIds(
 							Array.from(chunks).filter(chunk => {
 								return chunk.id === null;
@@ -58,7 +65,8 @@ class DeterministicChunkIdsPlugin {
 							},
 							[Math.pow(10, maxLength)],
 							10,
-							usedIds.size
+							usedIds.size,
+							salt
 						);
 					}
 				);

--- a/types.d.ts
+++ b/types.d.ts
@@ -2795,8 +2795,34 @@ declare abstract class DependencyTemplates {
 	clone(): DependencyTemplates;
 }
 declare class DeterministicChunkIdsPlugin {
-	constructor(options?: any);
-	options: any;
+	constructor(options: {
+		/**
+		 * context relative to which module identifiers are computed
+		 */
+		context?: string;
+		/**
+		 * maximum id length in digits (used as starting point)
+		 */
+		maxLength?: number;
+		/**
+		 * hash salt for ids
+		 */
+		salt?: number;
+	});
+	options: {
+		/**
+		 * context relative to which module identifiers are computed
+		 */
+		context?: string;
+		/**
+		 * maximum id length in digits (used as starting point)
+		 */
+		maxLength?: number;
+		/**
+		 * hash salt for ids
+		 */
+		salt?: number;
+	};
 
 	/**
 	 * Apply the plugin


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
# Add "salt" option for `DeterministicChunkIdsPlugin`

When running multiple projects with Module Federation I've noticed it's possible to have a collision either in the `moduleIds` and chunkIds generation.
For `moduleIds` this issue can be bypassed by using the `DeterministicModuleIdsPlugin`. Although there's no clean solution for the chunk ids generation, then here's my PR.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
The support for an option that is already available in the internal id generation.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
I was aiming to add tests, but I've noticed the suite is currently empty => https://github.com/webpack/webpack/blob/main/test/configCases/optimization/chunk/index.js
I'm happy to add tests if I get some assistance.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
https://webpack.js.org/configuration/optimization/#optimizationchunkids

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
