### PR TITLE
perf: remove assignDeterministic verbose Math.ceil code to improve performance

### DIFF
--- a/lib/ids/IdHelpers.js
+++ b/lib/ids/IdHelpers.js
@@ -387,7 +387,7 @@ const assignDeterministicIds = (
 
 	// max 5% fill rate
 	const optimalRange = Math.min(
-		Math.ceil(items.length * 20) + extraSpace,
+		items.length * 20 + extraSpace,
 		Number.MAX_SAFE_INTEGER
 	);
 


### PR DESCRIPTION
…ance

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

performance

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No need

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

No.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

## Introduce about this PR

The old code about assignDeterministicIds fill rate is:

```js
Math.ceil(items.length * 1.25)
```

but in this [PR](https://github.com/webpack/webpack/pull/9849), it changed to

```js
Math.ceil(items.length * 20)
```

Because `items` is an array, and its length will never be a decimal. So it's not necessary to add `Math.ceil` now.

I removed `Math.ceil` to improve the performance.

And this change will not cause any Breaking Change, I ran all tests.
