### PR TITLE
Improve getFullChunkName readability

### DIFF
--- a/lib/ids/IdHelpers.js
+++ b/lib/ids/IdHelpers.js
@@ -209,7 +209,7 @@ const getFullChunkName = (
 	if (chunk.name) return chunk.name;
 	const modules = chunkGraph.getChunkRootModules(chunk);
 	const fullModuleNames = modules.map(m =>
-		makePathsRelative(context, m.identifier(), associatedObjectForCache)
+		getFullModuleName(m, context, associatedObjectForCache)
 	);
 	return fullModuleNames.join();
 };


### PR DESCRIPTION
…getFullChunkName

What kind of change does this PR introduce?

refactor

Did you add tests for your changes?

No need

Does this PR introduce a breaking change?

No.

What needs to be documented once your changes are merged?

No.

Introduce about this PR
The old code about getFullChunkName is:

```js
const getFullChunkName = (
	chunk,
	chunkGraph,
	context,
	associatedObjectForCache
) => {
	if (chunk.name) return chunk.name;
	const modules = chunkGraph.getChunkRootModules(chunk);
	const fullModuleNames = modules.map(m =>
		makePathsRelative(context, m.identifier(), associatedObjectForCache)
	);
	return fullModuleNames.join();
};
```

but in this https://github.com/webpack/webpack/pull/16261,it changed to

```js
const getFullChunkName = (
	chunk,
	chunkGraph,
	context,
	associatedObjectForCache
) => {
	if (chunk.name) return chunk.name;
	const modules = chunkGraph.getChunkRootModules(chunk);
	const fullModuleNames = modules.map(m =>
		getFullModuleName(m, context, associatedObjectForCache)
	);
	return fullModuleNames.join();
};
```
This is more semantic and easier to understand logically