### PR TITLE
fix: Add proper callback handling to Compiler readRecords function

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -970,10 +970,13 @@ ${other}`);
 	readRecords(callback) {
 		if (this.hooks.readRecords.isUsed()) {
 			if (this.recordsInputPath) {
-				asyncLib.parallel([
-					cb => this.hooks.readRecords.callAsync(cb),
-					this._readRecords.bind(this)
-				]);
+				asyncLib.parallel(
+					[
+						cb => this.hooks.readRecords.callAsync(cb),
+						this._readRecords.bind(this)
+					],
+					err => callback(err)
+				);
 			} else {
 				this.records = {};
 				this.hooks.readRecords.callAsync(callback);


### PR DESCRIPTION
If you run a Webpack build with the [recordsPath](https://webpack.js.org/configuration/other-options/#recordspath) setting enabled and a readRecords hook set, Webpack will hang forever because the callback is not properly being passed to the `asyncLib.parallel` call in this code path in readRecords.

**What kind of change does this PR introduce?**

A very small bug fix.

**Did you add tests for your changes?**

No.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

Nothing.
