### PR TITLE
Remove redundant semicolons after onScriptComplete function close: #16346

### DIFF
--- a/lib/runtime/LoadScriptRuntimeModule.js
+++ b/lib/runtime/LoadScriptRuntimeModule.js
@@ -146,8 +146,7 @@ class LoadScriptRuntimeModule extends HelperRuntimeModule {
 							)});`,
 							"if(prev) return prev(event);"
 						])
-					) +
-					";",
+					),
 				`var timeout = setTimeout(onScriptComplete.bind(null, undefined, { type: 'timeout', target: script }), ${loadTimeout});`,
 				"script.onerror = onScriptComplete.bind(null, script.onerror);",
 				"script.onload = onScriptComplete.bind(null, script.onload);",

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -3,12 +3,12 @@
 exports[`StatsTestCases should print correct stats for aggressive-splitting-entry 1`] = `
 "fitting:
   PublicPath: auto
-  asset fitting-7287b3126510b3ba1197.js 16.1 KiB [emitted] [immutable]
+  asset fitting-27df06fdbf7adbff38d6.js 16.1 KiB [emitted] [immutable]
   asset fitting-50595d23e8f97d7ccd2a.js 1.9 KiB [emitted] [immutable]
   asset fitting-5bc77880fdc9e2bf09ee.js 1.9 KiB [emitted] [immutable]
   asset fitting-72afdc913f6cf884b457.js 1.08 KiB [emitted] [immutable]
-  Entrypoint main 19.9 KiB = fitting-50595d23e8f97d7ccd2a.js 1.9 KiB fitting-5bc77880fdc9e2bf09ee.js 1.9 KiB fitting-7287b3126510b3ba1197.js 16.1 KiB
-  chunk (runtime: main) fitting-7287b3126510b3ba1197.js 1.87 KiB (javascript) 8.65 KiB (runtime) [entry] [rendered]
+  Entrypoint main 19.9 KiB = fitting-50595d23e8f97d7ccd2a.js 1.9 KiB fitting-5bc77880fdc9e2bf09ee.js 1.9 KiB fitting-27df06fdbf7adbff38d6.js 16.1 KiB
+  chunk (runtime: main) fitting-27df06fdbf7adbff38d6.js 1.87 KiB (javascript) 8.65 KiB (runtime) [entry] [rendered]
     > ./index main
     runtime modules 8.65 KiB 11 modules
     cacheable modules 1.87 KiB
@@ -30,12 +30,12 @@ exports[`StatsTestCases should print correct stats for aggressive-splitting-entr
 
 content-change:
   PublicPath: auto
-  asset content-change-8d02d3f29ce2746961bb.js 16.1 KiB [emitted] [immutable]
+  asset content-change-ea14516bfb79836da4ae.js 16.1 KiB [emitted] [immutable]
   asset content-change-50595d23e8f97d7ccd2a.js 1.9 KiB [emitted] [immutable]
   asset content-change-5bc77880fdc9e2bf09ee.js 1.9 KiB [emitted] [immutable]
   asset content-change-72afdc913f6cf884b457.js 1.08 KiB [emitted] [immutable]
-  Entrypoint main 19.9 KiB = content-change-50595d23e8f97d7ccd2a.js 1.9 KiB content-change-5bc77880fdc9e2bf09ee.js 1.9 KiB content-change-8d02d3f29ce2746961bb.js 16.1 KiB
-  chunk (runtime: main) content-change-8d02d3f29ce2746961bb.js 1.87 KiB (javascript) 8.66 KiB (runtime) [entry] [rendered]
+  Entrypoint main 19.9 KiB = content-change-50595d23e8f97d7ccd2a.js 1.9 KiB content-change-5bc77880fdc9e2bf09ee.js 1.9 KiB content-change-ea14516bfb79836da4ae.js 16.1 KiB
+  chunk (runtime: main) content-change-ea14516bfb79836da4ae.js 1.87 KiB (javascript) 8.66 KiB (runtime) [entry] [rendered]
     > ./index main
     runtime modules 8.66 KiB 11 modules
     cacheable modules 1.87 KiB
@@ -58,7 +58,7 @@ content-change:
 
 exports[`StatsTestCases should print correct stats for aggressive-splitting-on-demand 1`] = `
 "PublicPath: auto
-asset 47d8091c27bf6f3a2e25.js 11.6 KiB [emitted] [immutable] (name: main)
+asset abdecc928f4f9878244e.js 11.6 KiB [emitted] [immutable] (name: main)
 asset 3fc6535262efa7e4fa3b.js 1.91 KiB [emitted] [immutable]
 asset 56815935c535fbc0e462.js 1.91 KiB [emitted] [immutable]
 asset 2b8c8882bd4326b27013.js 1.9 KiB [emitted] [immutable]
@@ -70,12 +70,12 @@ asset f79c60cc3faba968a476.js 1.9 KiB [emitted] [immutable]
 asset 7294786e49319a98f5af.js 1010 bytes [emitted] [immutable]
 asset c5861419d7f3f6ea6c19.js 1010 bytes [emitted] [immutable]
 asset f897ac9956540163d002.js 1010 bytes [emitted] [immutable]
-Entrypoint main 11.6 KiB = 47d8091c27bf6f3a2e25.js
+Entrypoint main 11.6 KiB = abdecc928f4f9878244e.js
 chunk (runtime: main) 5bc77880fdc9e2bf09ee.js 1.76 KiB [rendered] [recorded] aggressive splitted
   > ./c ./d ./e ./index.js 3:0-30
   ./c.js 899 bytes [built] [code generated]
   ./d.js 899 bytes [built] [code generated]
-chunk (runtime: main) 47d8091c27bf6f3a2e25.js (main) 248 bytes (javascript) 6.31 KiB (runtime) [entry] [rendered]
+chunk (runtime: main) abdecc928f4f9878244e.js (main) 248 bytes (javascript) 6.31 KiB (runtime) [entry] [rendered]
   > ./index main
   runtime modules 6.31 KiB 7 modules
   ./index.js 248 bytes [built] [code generated]
@@ -191,9 +191,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for async-commons-chunk 1`] = `
-"chunk (runtime: main) main.js (main) 515 bytes (javascript) 6 KiB (runtime) >{460}< >{847}< >{996}< [entry] [rendered]
+"chunk (runtime: main) main.js (main) 515 bytes (javascript) 5.99 KiB (runtime) >{460}< >{847}< >{996}< [entry] [rendered]
   > ./ main
-  runtime modules 6 KiB 7 modules
+  runtime modules 5.99 KiB 7 modules
   ./index.js 515 bytes [built] [code generated]
 chunk (runtime: main) 460.js 21 bytes <{179}> ={847}= [rendered]
   > ./index.js 17:1-21:3
@@ -220,9 +220,9 @@ exports[`StatsTestCases should print correct stats for async-commons-chunk-auto 
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) disabled/main.js (main) 147 bytes (javascript) 6.65 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) disabled/main.js (main) 147 bytes (javascript) 6.64 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.65 KiB 9 modules
+    runtime modules 6.64 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) disabled/async-b.js (async-b) 196 bytes [rendered]
     > ./b ./index.js 2:0-47
@@ -290,9 +290,9 @@ default:
   chunk (runtime: main) default/769.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
     > ./c ./index.js 3:0-47
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.65 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.64 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 6.65 KiB 9 modules
+    runtime modules 6.64 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) default/async-a.js (async-a) 185 bytes [rendered]
@@ -753,8 +753,8 @@ exports[`StatsTestCases should print correct stats for concat-and-sideeffects 1`
 `;
 
 exports[`StatsTestCases should print correct stats for context-independence 1`] = `
-"asset main-c9ce622840ffef9b8560.js 12.7 KiB [emitted] [immutable] (name: main)
-  sourceMap main-c9ce622840ffef9b8560.js.map 11 KiB [emitted] [dev] (auxiliary name: main)
+"asset main-5fe8293e1c67cc6234cb.js 12.7 KiB [emitted] [immutable] (name: main)
+  sourceMap main-5fe8293e1c67cc6234cb.js.map 11 KiB [emitted] [dev] (auxiliary name: main)
 asset 695-4dd37417c69a0af66bac.js 455 bytes [emitted] [immutable]
   sourceMap 695-4dd37417c69a0af66bac.js.map 342 bytes [emitted] [dev]
 runtime modules 6.59 KiB 9 modules
@@ -769,8 +769,8 @@ built modules 500 bytes [built]
     ./a/chunk.js + 1 modules (in Xdir/context-independence/a) 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-c9ce622840ffef9b8560.js 12.7 KiB [emitted] [immutable] (name: main)
-  sourceMap main-c9ce622840ffef9b8560.js.map 11 KiB [emitted] [dev] (auxiliary name: main)
+asset main-5fe8293e1c67cc6234cb.js 12.7 KiB [emitted] [immutable] (name: main)
+  sourceMap main-5fe8293e1c67cc6234cb.js.map 11 KiB [emitted] [dev] (auxiliary name: main)
 asset 695-4dd37417c69a0af66bac.js 455 bytes [emitted] [immutable]
   sourceMap 695-4dd37417c69a0af66bac.js.map 342 bytes [emitted] [dev]
 runtime modules 6.59 KiB 9 modules
@@ -785,7 +785,7 @@ built modules 500 bytes [built]
     ./b/chunk.js + 1 modules (in Xdir/context-independence/b) 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-6fe9478fbece50724f14.js 14.8 KiB [emitted] [immutable] (name: main)
+asset main-7c4bd4d93894bc8263e9.js 14.8 KiB [emitted] [immutable] (name: main)
 asset 695-828eb5c7418e1b8270bb.js 1.5 KiB [emitted] [immutable]
 runtime modules 6.59 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
@@ -799,7 +799,7 @@ built modules 500 bytes [built]
     ./a/chunk.js + 1 modules (in Xdir/context-independence/a) 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-6fe9478fbece50724f14.js 14.8 KiB [emitted] [immutable] (name: main)
+asset main-7c4bd4d93894bc8263e9.js 14.8 KiB [emitted] [immutable] (name: main)
 asset 695-828eb5c7418e1b8270bb.js 1.5 KiB [emitted] [immutable]
 runtime modules 6.59 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
@@ -813,7 +813,7 @@ built modules 500 bytes [built]
     ./b/chunk.js + 1 modules (in Xdir/context-independence/b) 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-dab0773b873a912c8caa.js 13.7 KiB [emitted] [immutable] (name: main)
+asset main-7dd3306e33267a41ff55.js 13.7 KiB [emitted] [immutable] (name: main)
 asset 695-ace208366ce0ce2556ef.js 1.01 KiB [emitted] [immutable]
 runtime modules 6.59 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
@@ -827,7 +827,7 @@ built modules 500 bytes [built]
     ./a/chunk.js + 1 modules (in Xdir/context-independence/a) 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-dab0773b873a912c8caa.js 13.7 KiB [emitted] [immutable] (name: main)
+asset main-7dd3306e33267a41ff55.js 13.7 KiB [emitted] [immutable] (name: main)
 asset 695-ace208366ce0ce2556ef.js 1.01 KiB [emitted] [immutable]
 runtime modules 6.59 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
@@ -1179,7 +1179,7 @@ webpack x.x.x compiled with 2 warnings in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for immutable 1`] = `
-"asset 3d65ee71fc9f53a687bd.js 13.3 KiB [emitted] [immutable] (name: main)
+"asset 5d45ce8c58c0be47d4b1.js 13.3 KiB [emitted] [immutable] (name: main)
 asset 22c24a3b26d46118dc06.js 809 bytes [emitted] [immutable]"
 `;
 
@@ -1269,10 +1269,10 @@ webpack x.x.x compiled successfully in X ms
 assets by chunk 895 bytes (id hint: all)
   asset c-all-b_js-d2d64fdaadbf1936503b.js 502 bytes [emitted] [immutable] (id hint: all)
   asset c-all-c_js-0552c7cbb8c1a12b6b9c.js 393 bytes [emitted] [immutable] (id hint: all)
-asset c-runtime~main-51dac241c7dc65379790.js 13.5 KiB [emitted] [immutable] (name: runtime~main)
+asset c-runtime~main-39696e33891b24e372db.js 13.5 KiB [emitted] [immutable] (name: runtime~main)
 asset c-main-463838c803f48fe97bb6.js 680 bytes [emitted] [immutable] (name: main)
 asset c-vendors-node_modules_vendor_js-7320f018dbab7e34ead5.js 185 bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main 14.6 KiB = c-runtime~main-51dac241c7dc65379790.js 13.5 KiB c-all-c_js-0552c7cbb8c1a12b6b9c.js 393 bytes c-main-463838c803f48fe97bb6.js 680 bytes
+Entrypoint main 14.6 KiB = c-runtime~main-39696e33891b24e372db.js 13.5 KiB c-all-c_js-0552c7cbb8c1a12b6b9c.js 393 bytes c-main-463838c803f48fe97bb6.js 680 bytes
 runtime modules 8.66 KiB 13 modules
 cacheable modules 101 bytes
   ./c.js 61 bytes [built] [code generated]
@@ -1298,8 +1298,8 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
 2 chunks:
   asset bundle2.js 12.5 KiB [emitted] (name: main)
   asset 459.bundle2.js 664 bytes [emitted] (name: c)
-  chunk (runtime: main) bundle2.js (main) 101 bytes (javascript) 7.69 KiB (runtime) >{459}< [entry] [rendered]
-    runtime modules 7.69 KiB 10 modules
+  chunk (runtime: main) bundle2.js (main) 101 bytes (javascript) 7.68 KiB (runtime) >{459}< [entry] [rendered]
+    runtime modules 7.68 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
   chunk (runtime: main) 459.bundle2.js (c) 118 bytes <{179}> <{459}> >{459}< [rendered]
     dependent modules 44 bytes [dependent]
@@ -1314,8 +1314,8 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   asset bundle3.js 12.5 KiB [emitted] (name: main)
   asset 459.bundle3.js 528 bytes [emitted] (name: c)
   asset 524.bundle3.js 206 bytes [emitted]
-  chunk (runtime: main) bundle3.js (main) 101 bytes (javascript) 7.69 KiB (runtime) >{459}< [entry] [rendered]
-    runtime modules 7.69 KiB 10 modules
+  chunk (runtime: main) bundle3.js (main) 101 bytes (javascript) 7.68 KiB (runtime) >{459}< [entry] [rendered]
+    runtime modules 7.68 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
   chunk (runtime: main) 459.bundle3.js (c) 74 bytes <{179}> >{524}< [rendered]
     ./a.js 22 bytes [built] [code generated]
@@ -1331,8 +1331,8 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   asset 459.bundle4.js 392 bytes [emitted] (name: c)
   asset 394.bundle4.js 206 bytes [emitted]
   asset 524.bundle4.js 206 bytes [emitted]
-  chunk (runtime: main) bundle4.js (main) 101 bytes (javascript) 7.69 KiB (runtime) >{394}< >{459}< [entry] [rendered]
-    runtime modules 7.69 KiB 10 modules
+  chunk (runtime: main) bundle4.js (main) 101 bytes (javascript) 7.68 KiB (runtime) >{394}< >{459}< [entry] [rendered]
+    runtime modules 7.68 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
   chunk (runtime: main) 394.bundle4.js 44 bytes <{179}> [rendered]
     ./a.js 22 bytes [built] [code generated]
@@ -1494,13 +1494,13 @@ Chunk Group b 549 bytes (21 KiB) = b.js 549 bytes (2.png 21 KiB)
 chunk (runtime: main) b.js (b) 67 bytes [rendered]
   ./node_modules/a/2.png 49 bytes [dependent] [built] [code generated] [1 asset]
   ./node_modules/b/index.js 18 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 82 bytes (javascript) 6.29 KiB (runtime) [entry] [rendered]
-  runtime modules 6.29 KiB 8 modules
+chunk (runtime: main) main.js (main) 82 bytes (javascript) 6.28 KiB (runtime) [entry] [rendered]
+  runtime modules 6.28 KiB 8 modules
   ./index.js 82 bytes [built] [code generated]
 chunk (runtime: main) a.js (a) 134 bytes [rendered]
   ./node_modules/a/2.png 49 bytes [dependent] [built] [code generated] [1 asset]
   ./node_modules/a/index.js + 1 modules 85 bytes [built] [code generated] [1 asset]
-runtime modules 6.29 KiB 8 modules
+runtime modules 6.28 KiB 8 modules
 orphan modules 49 bytes [orphan] 1 module
 modules with assets 234 bytes
   modules by path ./node_modules/a/ 134 bytes
@@ -1695,7 +1695,7 @@ webpack x.x.x compiled with 2 errors in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for named-chunk-groups 1`] = `
-"Chunk Group main 11.7 KiB = a-main.js
+"Chunk Group main 11.6 KiB = a-main.js
 Chunk Group async-a 1.07 KiB = a-52.js 257 bytes a-async-a.js 836 bytes
 Chunk Group async-b 1.07 KiB = a-52.js 257 bytes a-async-b.js 836 bytes
 Chunk Group async-c 1.45 KiB = a-vendors.js 744 bytes a-async-c.js 741 bytes
@@ -1722,7 +1722,7 @@ chunk (runtime: main) a-async-a.js (async-a) 175 bytes [rendered]
   ./a.js 175 bytes [built] [code generated]
 webpack x.x.x compiled successfully
 
-Entrypoint main 11.7 KiB = b-main.js
+Entrypoint main 11.6 KiB = b-main.js
 Chunk Group async-a 1.07 KiB = b-52.js 257 bytes b-async-a.js 836 bytes
 Chunk Group async-b 1.07 KiB = b-52.js 257 bytes b-async-b.js 836 bytes
 Chunk Group async-c 1.45 KiB = b-vendors.js 744 bytes b-async-c.js 741 bytes
@@ -1946,7 +1946,7 @@ asset <CLR=32,BOLD>460.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
-runtime modules 6 KiB 7 modules
+runtime modules 5.99 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -1963,7 +1963,7 @@ asset <CLR=32,BOLD>460.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
-runtime modules 6 KiB 7 modules
+runtime modules 5.99 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2022,7 +2022,7 @@ asset <CLR=32,BOLD>460.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
-runtime modules 6 KiB 7 modules
+runtime modules 5.99 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2130,7 +2130,7 @@ asset 460.js 323 bytes {460} [emitted]
 asset 524.js 206 bytes {524} [emitted]
 asset 996.js 138 bytes {996} [emitted]
 Entrypoint main 10.2 KiB = main.js
-chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 6 KiB (runtime) >{460}< >{996}< [entry] [rendered]
+chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 5.99 KiB (runtime) >{460}< >{996}< [entry] [rendered]
   > ./index main
 chunk {460} (runtime: main) 460.js 54 bytes <{179}> >{524}< [rendered]
   > ./c [10] ./index.js 3:0-16
@@ -2138,7 +2138,7 @@ chunk {524} (runtime: main) 524.js 44 bytes <{460}> [rendered]
   > [460] ./c.js 1:0-52
 chunk {996} (runtime: main) 996.js 22 bytes <{179}> [rendered]
   > ./b [10] ./index.js 2:0-16
-runtime modules 6 KiB
+runtime modules 5.99 KiB
   webpack/runtime/ensure chunk 326 bytes {179} [code generated]
     [no exports]
     [used exports unknown]
@@ -2228,7 +2228,7 @@ LOG from webpack.FileSystemInfo
     Directory info in cache: 0 timestamps 0 hashes 0 timestamp hash combinations
     Managed items info in cache: 0 items
 
-1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (5966d7136f537890a286)"
+1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (440eb519eb0c4246cce1)"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-errors-only 1`] = `""`;
@@ -2307,7 +2307,7 @@ asset main.js 10.2 KiB [emitted] (name: main)
 asset 460.js 323 bytes [emitted]
 asset 524.js 206 bytes [emitted]
 asset 996.js 138 bytes [emitted]
-runtime modules 6 KiB 7 modules
+runtime modules 5.99 KiB 7 modules
 cacheable modules 193 bytes
   ./index.js 51 bytes [built] [code generated]
   ./a.js 22 bytes [built] [code generated]
@@ -2330,7 +2330,7 @@ exports[`StatsTestCases should print correct stats for preset-normal-performance
 asset <CLR=32,BOLD>460.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
-runtime modules 6 KiB 7 modules
+runtime modules 5.99 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2358,7 +2358,7 @@ exports[`StatsTestCases should print correct stats for preset-normal-performance
 asset <CLR=32,BOLD>460.js</CLR> 355 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
 asset <CLR=32,BOLD>524.js</CLR> 238 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
 asset <CLR=32,BOLD>996.js</CLR> 170 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
-runtime modules 6 KiB 7 modules
+runtime modules 5.99 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2406,9 +2406,9 @@ asset 460.js 323 bytes {460} [emitted]
 asset 524.js 206 bytes {524} [emitted]
 asset 996.js 138 bytes {996} [emitted]
 Entrypoint main 10.2 KiB = main.js
-chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 6 KiB (runtime) >{460}< >{996}< [entry] [rendered]
+chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 5.99 KiB (runtime) >{460}< >{996}< [entry] [rendered]
   > ./index main
-  runtime modules 6 KiB
+  runtime modules 5.99 KiB
     webpack/runtime/ensure chunk 326 bytes {179} [code generated]
       [no exports]
       [used exports unknown]
@@ -2604,7 +2604,7 @@ LOG from webpack.FileSystemInfo
     Directory info in cache: 0 timestamps 0 hashes 0 timestamp hash combinations
     Managed items info in cache: 0 items
 
-1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (5966d7136f537890a286)"
+1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (440eb519eb0c4246cce1)"
 `;
 
 exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
@@ -3030,15 +3030,15 @@ exports[`StatsTestCases should print correct stats for runtime-specific-used-exp
   production (webpack x.x.x) compiled successfully in X ms
 
 development:
-  asset development-a.js 15.9 KiB [emitted] (name: a)
-  asset development-b.js 15.9 KiB [emitted] (name: b)
+  asset development-a.js 15.8 KiB [emitted] (name: a)
+  asset development-b.js 15.8 KiB [emitted] (name: b)
   asset development-dw_js.js 2.11 KiB [emitted]
   asset development-dx_js.js 2.11 KiB [emitted]
   asset development-dy_js.js 2.11 KiB [emitted]
   asset development-dz_js.js 2.11 KiB [emitted]
   asset development-c.js 1.13 KiB [emitted] (name: c)
-  chunk (runtime: a) development-a.js (a) 605 bytes (javascript) 6.58 KiB (runtime) [entry] [rendered]
-    runtime modules 6.58 KiB 9 modules
+  chunk (runtime: a) development-a.js (a) 605 bytes (javascript) 6.57 KiB (runtime) [entry] [rendered]
+    runtime modules 6.57 KiB 9 modules
     cacheable modules 605 bytes
       ./a.js 261 bytes [built] [code generated]
         [used exports unknown]
@@ -3050,8 +3050,8 @@ development:
         [used exports unknown]
       ./reexport.js 37 bytes [dependent] [built] [code generated]
         [used exports unknown]
-  chunk (runtime: b) development-b.js (b) 605 bytes (javascript) 6.58 KiB (runtime) [entry] [rendered]
-    runtime modules 6.58 KiB 9 modules
+  chunk (runtime: b) development-b.js (b) 605 bytes (javascript) 6.57 KiB (runtime) [entry] [rendered]
+    runtime modules 6.57 KiB 9 modules
     cacheable modules 605 bytes
       ./b.js 261 bytes [built] [code generated]
         [used exports unknown]
@@ -3086,7 +3086,7 @@ development:
       [used exports unknown]
     ./module.js?chunk 122 bytes [dependent] [built] [code generated]
       [used exports unknown]
-  runtime modules 13.2 KiB 18 modules
+  runtime modules 13.1 KiB 18 modules
   cacheable modules 1.15 KiB
     ./a.js 261 bytes [built] [code generated]
       [used exports unknown]
@@ -3495,9 +3495,9 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
   chunk (runtime: main) default/769.js (id hint: vendors) 20 bytes <{179}> ={282}= ={383}= ={568}= ={767}= [rendered] split chunk (cache group: defaultVendors)
     > ./c ./index.js 3:0-47
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.65 KiB (runtime) >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.64 KiB (runtime) >{137}< >{568}< [entry] [rendered]
     > ./a a
-    runtime modules 6.65 KiB 9 modules
+    runtime modules 6.64 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) default/async-a.js (async-a) 185 bytes <{179}> ={282}= ={767}= ={954}= >{137}< >{568}< [rendered]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Remove redundant semicolons after onScriptComplete function  related to https://github.com/webpack/webpack/issues/16346

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
no

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
