### PR TITLE
List module names from Module Federation Container

### DIFF
--- a/examples/module-federation/README.md
+++ b/examples/module-federation/README.md
@@ -1021,11 +1021,15 @@ var init = (shareScope, initScope) => {
 	__webpack_require__.S[name] = shareScope;
 	return __webpack_require__.I(name, initScope);
 };
+var getExposedModules = () => {
+	return Object.keys(moduleMap);
+};
 
 // This exports getters to disallow modifications
 __webpack_require__.d(exports, {
 	get: () => (get),
-	init: () => (init)
+	init: () => (init),
+	getExposedModules: () => (getExposedModules)
 });
 
 /***/ })
@@ -1541,11 +1545,15 @@ var init = (shareScope, initScope) => {
 	__webpack_require__.S[name] = shareScope;
 	return __webpack_require__.I(name, initScope);
 };
+var getExposedModules = () => {
+	return Object.keys(moduleMap);
+};
 
 // This exports getters to disallow modifications
 __webpack_require__.d(exports, {
 	get: () => (get),
-	init: () => (init)
+	init: () => (init),
+	getExposedModules: () => (getExposedModules)
 });
 
 /***/ })

--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -228,12 +228,18 @@ class ContainerEntryModule extends Module {
 				`${RuntimeGlobals.shareScopeMap}[name] = shareScope;`,
 				`return ${RuntimeGlobals.initializeSharing}(name, initScope);`
 			])};`,
+			`var getExposedModules = ${runtimeTemplate.basicFunction("", [
+				"return Object.keys(moduleMap);"
+			])};`,
 			"",
 			"// This exports getters to disallow modifications",
 			`${RuntimeGlobals.definePropertyGetters}(exports, {`,
 			Template.indent([
 				`get: ${runtimeTemplate.returningFunction("get")},`,
-				`init: ${runtimeTemplate.returningFunction("init")}`
+				`init: ${runtimeTemplate.returningFunction("init")},`,
+				`getExposedModules: ${runtimeTemplate.returningFunction(
+					"getExposedModules"
+				)}`
 			]),
 			"});"
 		]);

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -1578,7 +1578,7 @@ webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for module-federation-custom-exposed-module-name 1`] = `
-"asset container_bundle.js 11.9 KiB [emitted] (name: container)
+"asset container_bundle.js 12 KiB [emitted] (name: container)
 asset custom-entry_bundle.js 414 bytes [emitted] (name: custom-entry)
 asset main_bundle.js 84 bytes [emitted] (name: main)
 runtime modules 6.58 KiB 9 modules

--- a/test/configCases/container/container-exposed-modules/index.js
+++ b/test/configCases/container/container-exposed-modules/index.js
@@ -1,0 +1,6 @@
+it("should allow to get the exposed modules by the container", async () => {
+	const container = __non_webpack_require__("./container.js");
+	expect(typeof container.getExposedModules).toBe("function");
+	const exposedModules = container.getExposedModules();
+	expect(exposedModules).toEqual(["./moduleA", "./moduleB"]);
+});

--- a/test/configCases/container/container-exposed-modules/moduleA.js
+++ b/test/configCases/container/container-exposed-modules/moduleA.js
@@ -1,0 +1,1 @@
+export const ok = true;

--- a/test/configCases/container/container-exposed-modules/moduleB.js
+++ b/test/configCases/container/container-exposed-modules/moduleB.js
@@ -1,0 +1,1 @@
+export const ok = true;

--- a/test/configCases/container/container-exposed-modules/webpack.config.js
+++ b/test/configCases/container/container-exposed-modules/webpack.config.js
@@ -1,0 +1,13 @@
+const { ModuleFederationPlugin } = require("../../../../").container;
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	plugins: [
+		new ModuleFederationPlugin({
+			name: "container",
+			filename: "container.js",
+			library: { type: "commonjs-module" },
+			exposes: ["./moduleA", "./moduleB"]
+		})
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This pull request adds a simple convenience function to the Module Federation Container which is called `getExposedModules()`. With this function the consumer of a remote container will be able to programatically get an array of the names of the modules exposed by the ModuleFederationPlugin instead of having to look through the Webpack configuration of the remote. The function is especially useful if the consumer is not sure which version of a container is deployed and what is actually exposed by it.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
It provides a convenience function which enables getting the names of the modules exposed by the Module Federation plugin in runtime.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
The new function could be added to the example on this page [Dynamic Remote Containers](https://webpack.js.org/concepts/module-federation/#dynamic-remote-containers)
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
