### PR TITLE
fix: mf container plugin not get 'shareScope' option

### DIFF
--- a/lib/container/ModuleFederationPlugin.js
+++ b/lib/container/ModuleFederationPlugin.js
@@ -65,7 +65,8 @@ class ModuleFederationPlugin {
 					library,
 					filename: options.filename,
 					runtime: options.runtime,
-					exposes: options.exposes
+					exposes: options.exposes,
+					shareScope: options.shareScope
 				}).apply(compiler);
 			}
 			if (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
`ContainerPlugin` has `shareScope` option , but `ModuleFederationPlugin` not set `shareScope` to `ContainerPlugin`

related to #16398 

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
no
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
