### PR TITLE
fix file extension in source map when using eval-source-map

### DIFF
--- a/lib/EvalSourceMapDevToolPlugin.js
+++ b/lib/EvalSourceMapDevToolPlugin.js
@@ -5,7 +5,6 @@
 
 "use strict";
 
-const { extname } = require("path");
 const { ConcatSource, RawSource } = require("webpack-sources");
 const ModuleFilenameHelpers = require("./ModuleFilenameHelpers");
 const NormalModule = require("./NormalModule");
@@ -14,6 +13,7 @@ const SourceMapDevToolModuleOptionsPlugin = require("./SourceMapDevToolModuleOpt
 const JavascriptModulesPlugin = require("./javascript/JavascriptModulesPlugin");
 const ConcatenatedModule = require("./optimize/ConcatenatedModule");
 const { makePathsAbsolute } = require("./util/identifier");
+const extractExtension = require("./util/extractExtension");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../declarations/WebpackOptions").DevTool} DevToolOptions */
@@ -155,11 +155,9 @@ class EvalSourceMapDevToolPlugin {
 						sourceMap.sources = moduleFilenames;
 						sourceMap.sourceRoot = options.sourceRoot || "";
 						const moduleId = chunkGraph.getModuleId(m).toString();
-						const moduleIdExtension = extname(moduleId);
+						const moduleIdExtension = extractExtension(moduleId);
 						if (moduleIdExtension === "") {
 							sourceMap.file = `${moduleId}.js`;
-						} else if (moduleIdExtension === ".") {
-							sourceMap.file = `${moduleId}js`;
 						} else {
 							sourceMap.file = moduleId;
 						}

--- a/lib/EvalSourceMapDevToolPlugin.js
+++ b/lib/EvalSourceMapDevToolPlugin.js
@@ -154,7 +154,6 @@ class EvalSourceMapDevToolPlugin {
 						sourceMap.sources = moduleFilenames;
 						sourceMap.sourceRoot = options.sourceRoot || "";
 						const moduleId = chunkGraph.getModuleId(m);
-						sourceMap.file = `${moduleId}.js`;
 
 						const footer =
 							this.sourceMapComment.replace(

--- a/lib/EvalSourceMapDevToolPlugin.js
+++ b/lib/EvalSourceMapDevToolPlugin.js
@@ -12,8 +12,8 @@ const RuntimeGlobals = require("./RuntimeGlobals");
 const SourceMapDevToolModuleOptionsPlugin = require("./SourceMapDevToolModuleOptionsPlugin");
 const JavascriptModulesPlugin = require("./javascript/JavascriptModulesPlugin");
 const ConcatenatedModule = require("./optimize/ConcatenatedModule");
-const { makePathsAbsolute } = require("./util/identifier");
 const extractExtension = require("./util/extractExtension");
+const { makePathsAbsolute } = require("./util/identifier");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../declarations/WebpackOptions").DevTool} DevToolOptions */

--- a/lib/EvalSourceMapDevToolPlugin.js
+++ b/lib/EvalSourceMapDevToolPlugin.js
@@ -5,6 +5,7 @@
 
 "use strict";
 
+const { extname } = require("path");
 const { ConcatSource, RawSource } = require("webpack-sources");
 const ModuleFilenameHelpers = require("./ModuleFilenameHelpers");
 const NormalModule = require("./NormalModule");
@@ -153,7 +154,15 @@ class EvalSourceMapDevToolPlugin {
 						);
 						sourceMap.sources = moduleFilenames;
 						sourceMap.sourceRoot = options.sourceRoot || "";
-						const moduleId = chunkGraph.getModuleId(m);
+						const moduleId = chunkGraph.getModuleId(m).toString();
+						const moduleIdExtension = extname(moduleId);
+						if (moduleIdExtension === "") {
+							sourceMap.file = `${moduleId}.js`;
+						} else if (moduleIdExtension === ".") {
+							sourceMap.file = `${moduleId}js`;
+						} else {
+							sourceMap.file = moduleId;
+						}
 
 						const footer =
 							this.sourceMapComment.replace(

--- a/lib/util/extractExtension.js
+++ b/lib/util/extractExtension.js
@@ -1,0 +1,43 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+*/
+
+"use strict";
+
+/**
+ * @param {string} path path to the file (including pseudo url, like `index.js?foo=bar`)
+ * @returns {string} file extension or an empty string, in case no extension was found
+ */
+module.exports = function extractExtension(path) {
+	// for handling paths, like "file.ext//"
+	let slashIndex = path.length - 1;
+	while (path[slashIndex] === "/") {
+		slashIndex--;
+	}
+	const filename = path.slice(0, slashIndex + 1).replace(/^.*[\\/]/, "");
+
+	// for handling paths, like ".file", "/path.to/.file"
+	if (filename.charAt(0) === ".") {
+		let amountOfDots = 1;
+		for (let i = 1; i < filename.length; i++) {
+			if (filename[i] === ".") {
+				amountOfDots++;
+			}
+
+			if (amountOfDots > 1) {
+				break;
+			}
+		}
+
+		if (amountOfDots === 1) {
+			return "";
+		}
+	}
+
+	const extArray = filename.match(/\.([^.]*?)(?=\?|#|$)/);
+	if (Array.isArray(extArray) && extArray.length >= 2) {
+		return extArray[1];
+	}
+
+	return "";
+};

--- a/test/extractExtension.unittest.js
+++ b/test/extractExtension.unittest.js
@@ -1,0 +1,60 @@
+"use strict";
+
+const extractExtension = require("../lib/util/extractExtension");
+
+describe("extractExtension", () => {
+	const testCases = [
+		["", ""],
+		["/path/to/file", ""],
+		["/path/to/file.ext", "ext"],
+		["/path.to/file.ext", "ext"],
+		["/path.to/file", ""],
+		["/path.to/.file", ""],
+		["/path.to/.file.ext", "ext"],
+		["/path/to/f.ext", "ext"],
+		["/path/to/..ext", "ext"],
+		["/path/to/..", ""],
+		["file", ""],
+		["file.ext", "ext"],
+		[".file", ""],
+		[".file.ext", "ext"],
+		["/file", ""],
+		["/file.ext", "ext"],
+		["/.file", ""],
+		["/.file.ext", "ext"],
+		[".path/file.ext", "ext"],
+		["file.ext.ext", "ext"],
+		["file.", ""],
+		[".", ""],
+		["./", ""],
+		[".file.ext", "ext"],
+		[".file", ""],
+		[".file.", ""],
+		[".file..", ""],
+		["..", ""],
+		["../", ""],
+		["..file.ext", "ext"],
+		["..file", "file"],
+		["..file.", ""],
+		["..file..", ""],
+		["...", ""],
+		["...ext", "ext"],
+		["....", ""],
+		["file.ext/", "ext"],
+		["file.ext//", "ext"],
+		["file/", ""],
+		["file//", ""],
+		["file./", ""],
+		["file.//", ""],
+		["/path/to/file/file.ext?foo=bar", "ext"],
+		["/path/to/file/file.ext?bar=foo", "ext"]
+	];
+
+	testCases.forEach(([path, ext]) => {
+		const extension = extractExtension(path);
+
+		it(`should return the "${ext}" for the "${path}", get "${extension}"`, () => {
+			expect(extension).toEqual(ext);
+		});
+	});
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

I fixed bug from issue #16415

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
It's a bugfix. It removes redundant `.js` file extension from file property of the `sourceMappingURL`.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
I didn't add any new tests, because it's a fairly straightforward fix. Let me know, If it's necessary

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
Probably not, I just removed unneeded thing.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Probably nothing.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
