### PR TITLE
Limits length of readable identifier in default stats

### DIFF
--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const util = require("util");
+const ExternalModule = require("../ExternalModule");
 const ModuleDependency = require("../dependencies/ModuleDependency");
 const formatLocation = require("../formatLocation");
 const { LogType } = require("../logging/Logger");
@@ -315,6 +316,22 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  */
 
 /**
+ * @param {string} readableIdentifier user readable identifier of the module
+ * @param {Module} module base module type
+ * @returns {string} an elided readableIdentifier, when readableIdentifier exceeds a maximum length
+ */
+const truncateLongExternalModuleReadableIdentifier = (
+	readableIdentifier,
+	module
+) => {
+	const maxLength = 80;
+	return module instanceof ExternalModule &&
+		readableIdentifier.length > maxLength
+		? readableIdentifier.substring(0, maxLength) + "..."
+		: readableIdentifier;
+};
+
+/**
  * @template T
  * @template I
  * @param {Iterable<T>} items items to select from
@@ -393,7 +410,10 @@ const EXTRACT_ERROR = {
 			}
 			if (error.module) {
 				object.moduleIdentifier = error.module.identifier();
-				object.moduleName = error.module.readableIdentifier(requestShortener);
+				object.moduleName = truncateLongExternalModuleReadableIdentifier(
+					error.module.readableIdentifier(requestShortener),
+					error.module
+				);
 			}
 			if (error.loc) {
 				object.loc = formatLocation(error.loc);
@@ -1133,7 +1153,10 @@ const SIMPLE_EXTRACTORS = {
 			/** @type {KnownStatsModule} */
 			const statsModule = {
 				identifier: module.identifier(),
-				name: module.readableIdentifier(requestShortener),
+				name: truncateLongExternalModuleReadableIdentifier(
+					module.readableIdentifier(requestShortener),
+					module
+				),
 				nameForCondition: module.nameForCondition(),
 				index: moduleGraph.getPreOrderIndex(module),
 				preOrderIndex: moduleGraph.getPreOrderIndex(module),
@@ -1146,7 +1169,12 @@ const SIMPLE_EXTRACTORS = {
 					compilation.chunkGraph.getNumberOfModuleChunks(module) === 0,
 				dependent: rootModules ? !rootModules.has(module) : undefined,
 				issuer: issuer && issuer.identifier(),
-				issuerName: issuer && issuer.readableIdentifier(requestShortener),
+				issuerName:
+					issuer &&
+					truncateLongExternalModuleReadableIdentifier(
+						issuer.readableIdentifier(requestShortener),
+						issuer
+					),
 				issuerPath:
 					issuer &&
 					factory.create(`${type.slice(0, -8)}.issuerPath`, path, context),
@@ -1286,7 +1314,10 @@ const SIMPLE_EXTRACTORS = {
 			/** @type {KnownStatsModuleIssuer} */
 			const statsModuleIssuer = {
 				identifier: module.identifier(),
-				name: module.readableIdentifier(requestShortener)
+				name: truncateLongExternalModuleReadableIdentifier(
+					module.readableIdentifier(requestShortener),
+					module
+				)
 			};
 			Object.assign(object, statsModuleIssuer);
 			if (profile) {
@@ -1308,16 +1339,25 @@ const SIMPLE_EXTRACTORS = {
 					? reason.originModule.identifier()
 					: null,
 				module: reason.originModule
-					? reason.originModule.readableIdentifier(requestShortener)
+					? truncateLongExternalModuleReadableIdentifier(
+							reason.originModule.readableIdentifier(requestShortener),
+							reason.originModule
+					  )
 					: null,
 				moduleName: reason.originModule
-					? reason.originModule.readableIdentifier(requestShortener)
+					? truncateLongExternalModuleReadableIdentifier(
+							reason.originModule.readableIdentifier(requestShortener),
+							reason.originModule
+					  )
 					: null,
 				resolvedModuleIdentifier: reason.resolvedOriginModule
 					? reason.resolvedOriginModule.identifier()
 					: null,
 				resolvedModule: reason.resolvedOriginModule
-					? reason.resolvedOriginModule.readableIdentifier(requestShortener)
+					? truncateLongExternalModuleReadableIdentifier(
+							reason.resolvedOriginModule.readableIdentifier(requestShortener),
+							reason.resolvedOriginModule
+					  )
 					: null,
 				type: reason.dependency ? reason.dependency.type : null,
 				active: reason.isActive(runtime),
@@ -1445,7 +1485,10 @@ const SIMPLE_EXTRACTORS = {
 				module: origin.module ? origin.module.identifier() : "",
 				moduleIdentifier: origin.module ? origin.module.identifier() : "",
 				moduleName: origin.module
-					? origin.module.readableIdentifier(requestShortener)
+					? truncateLongExternalModuleReadableIdentifier(
+							origin.module.readableIdentifier(requestShortener),
+							origin.module
+					  )
 					: "",
 				loc: formatLocation(origin.loc),
 				request: origin.request
@@ -1467,9 +1510,15 @@ const SIMPLE_EXTRACTORS = {
 				compilation: { moduleGraph }
 			} = context;
 			object.originIdentifier = origin.identifier();
-			object.originName = origin.readableIdentifier(requestShortener);
+			object.originName = truncateLongExternalModuleReadableIdentifier(
+				origin.readableIdentifier(requestShortener),
+				origin
+			);
 			object.moduleIdentifier = module.identifier();
-			object.moduleName = module.readableIdentifier(requestShortener);
+			object.moduleName = truncateLongExternalModuleReadableIdentifier(
+				module.readableIdentifier(requestShortener),
+				module
+			);
 			const dependencies = Array.from(
 				moduleGraph.getIncomingConnections(module)
 			)


### PR DESCRIPTION
Reduces the length of the readable identifier shown in webpack output, so the user is not overwhelmed with large blocks of text.  Fixes # 16475

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Please see issue #16475 

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Changes the build output so that long strings are truncated (elided) to make more readable
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No. Please advise where I would add tests.  I looked in the project for tests of DefaultStatsFactoryPlugin.js, but I couldn't find any tests.

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

I'm not sure anything needs to be documented.  I suppose somewhere it could say that identifiers in the build output will be truncated after hitting a maximum length, and truncation will be indicated by the presence of some ellipsis