### PR TITLE
Initialize hash conditionally

### DIFF
--- a/lib/optimize/RealContentHashPlugin.js
+++ b/lib/optimize/RealContentHashPlugin.js
@@ -342,7 +342,6 @@ ${referencingAssets
 					for (const oldHash of hashesInOrder) {
 						const assets = hashToAssets.get(oldHash);
 						assets.sort(comparator);
-						const hash = createHash(this._hashFunction);
 						await Promise.all(
 							assets.map(asset =>
 								asset.ownHashes.has(oldHash)
@@ -363,6 +362,7 @@ ${referencingAssets
 						});
 						let newHash = hooks.updateHash.call(assetsContent, oldHash);
 						if (!newHash) {
+							const hash = createHash(this._hashFunction);
 							for (const content of assetsContent) {
 								hash.update(content);
 							}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Hello,

We're working on a relatively big app:
~ 2M LOC
~ 10k assets
~ 10k hashes to compute

`RealContentHashPlugin` was taking substantial time to seal the compilation. After profiling the code, I've found that `createHash` was adding most of the time to the processing.

I wasn't able to reproduce it in synthetic tests. My current assumption is that high memory pressure and GC are involved. I can investigate it later but would like the fix to be checked in.

We use `webpack-subresource-integrity` plugin, half of the hashes come form it and are recalculated through the hook. Since `hash` is only needed when there wasn't one generated by an external plugin, it's safe to move its creation into the same conditional block, where it's used. 

This minor change improved `RealContentHashPlugin` processing time by **5x**:

_Note: timing is provided by `ProfilingPlugin`_

Setup:
_OS:_ Ubuntu 18.04.1
_CPU:_ Intel Xeon Platinum 8272CL @ 2.60Ghz
_MEM:_ 64GB
_Node.js:_ 14.20.0
_Hashing Algorithm:_ `xxhash64`

Before:
Run 1: `RealContentHashPlugin(sealing) - 34% (559s)`
Run 2: `RealContentHashPlugin(sealing) - 31% (741s)`
Run 3: `RealContentHashPlugin(sealing) - 33% (587s)`

After:
Run 1: `RealContentHashPlugin(sealing) - 7% (93s)`
Run 2: `RealContentHashPlugin(sealing) - 7% (95s)`

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Refactoring. No logic changes.

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
No additional tests required

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
N/A