### PR TITLE
Separate 'experiments.lazyCompilation.backend.client' configuration from server configuration.

### DIFF
--- a/lib/hmr/lazyCompilationBackend.js
+++ b/lib/hmr/lazyCompilationBackend.js
@@ -131,8 +131,10 @@ module.exports = options => (compiler, callback) => {
 					originalModule.identifier().replace(/\\/g, "/").replace(/@/g, "_")
 				).replace(/%(2F|3A|24|26|2B|2C|3B|3D|3A)/g, decodeURIComponent)}`;
 				const active = activeModules.get(key) > 0;
+
+				const clientUrlBase = options.client === undefined ? urlBase : options.client;
 				return {
-					client: `${options.client}?${encodeURIComponent(urlBase + prefix)}`,
+					client: `?${encodeURIComponent(clientUrlBase + prefix)}`,
 					data: key,
 					active
 				};


### PR DESCRIPTION
A minor fix for the development environment:

```javascript
lazyCompilation: {
  backend: {
    client: 'http://my-local-hostname.localhost',
    listen: {
      host: '127.0.0.1',
      port: 44444,
    }
  }
}
```

The configuration `backend.listen` is provided to constomize the server listening for requests proving lazyCompilation.

An option `backend.client` is provided for customization, so the client knows where to place requests, but it's not implemented correctly.

**What kind of change does this PR introduce?**
A minor configuration issue

**Does this PR introduce a breaking change?**
Only to people having made a workaround for which this will be a fix.