### PR TITLE
add missing loaders to moduleFilenameTemplate function call

### DIFF
--- a/lib/ModuleFilenameHelpers.js
+++ b/lib/ModuleFilenameHelpers.js
@@ -162,6 +162,7 @@ ModuleFilenameHelpers.createFilename = (
 				resource: resource,
 				resourcePath: memoize(resourcePath),
 				absoluteResourcePath: memoize(absoluteResourcePath),
+				loaders: memoize(loaders),
 				allLoaders: memoize(allLoaders),
 				query: memoize(query),
 				moduleId: memoize(moduleId),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fixing `loaders` not being passed to the `output.devtoolModuleFilenameTemplate` function as mentioned in the docs: https://webpack.js.org/configuration/output/#outputdevtoolmodulefilenametemplate

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
