### PR TITLE
Rely on Node `builtinModules` instead of maintaining a list manually

### DIFF
--- a/lib/node/NodeTargetPlugin.js
+++ b/lib/node/NodeTargetPlugin.js
@@ -5,61 +5,14 @@
 
 "use strict";
 
+const { builtinModules } = require("module");
 const ExternalsPlugin = require("../ExternalsPlugin");
 
 /** @typedef {import("../Compiler")} Compiler */
 
 const builtins = [
-	"assert",
-	"async_hooks",
-	"buffer",
-	"child_process",
-	"cluster",
-	"console",
-	"constants",
-	"crypto",
-	"dgram",
-	"diagnostics_channel",
-	"dns",
-	"dns/promises",
-	"domain",
-	"events",
-	"fs",
-	"fs/promises",
-	"http",
-	"http2",
-	"https",
-	"inspector",
-	"module",
-	"net",
-	"os",
-	"path",
-	"path/posix",
-	"path/win32",
-	"perf_hooks",
-	"process",
-	"punycode",
-	"querystring",
-	"readline",
-	"repl",
-	"stream",
-	"stream/promises",
-	"stream/web",
-	"string_decoder",
-	"sys",
-	"timers",
-	"timers/promises",
-	"tls",
-	"trace_events",
-	"tty",
-	"url",
-	"util",
-	"util/types",
-	"v8",
-	"vm",
-	"wasi",
-	"worker_threads",
-	"zlib",
+	...builtinModules,
+
 	/^node:/,
 
 	// cspell:word pnpapi


### PR DESCRIPTION
Currently webpack maintains a list of builtin Node.js modules that evolve over time. This PR changes that behavior to get the list of builtin modules from the Node.js `module` module.

The motivation for this was attempting to build a project that uses the `diagnostics_channel` polyfill package - webpack treats it as external even on Node<14.17, where it needs to be not externalized. It's possible to work around this in webpack's configuration by setting `externalsPresets.node = false` and then specifying node externals manually.

**What kind of change does this PR introduce?**

Refactoring and maintainability for future Node.js versions

**Did you add tests for your changes?**

I did not see any tests referencing the affected code (`NodeTargetPlugin`)

**Does this PR introduce a breaking change?**

If the target runtime is the same version of Node as what webpack is being run in, no.

Otherwise, there may be issues (e.g. if you're building on Node<14.17, but the resulting bundle will run on Node 16+, you would want `diagnostics_channel` to be externalized but it would not be). It's unclear to me if this is a supported use case, or if it's widely used anyway.  Any input on this point is appreciated!

**What needs to be documented once your changes are merged?**

Webpack documentation does not have a comprehensive list of packages externalized by `NodeTargetPlugin`. If this is merged, the docs should be updated to specify that the list of externalized packages will be derived from `require('module').builtinPlugins`
