### PR TITLE
feat: Add `target` to `LoaderContext` type

### DIFF
--- a/declarations/LoaderContext.d.ts
+++ b/declarations/LoaderContext.d.ts
@@ -212,6 +212,12 @@ export interface LoaderRunnerLoaderContext<OptionsType> {
 	 * Example: "/abc/resource.js?query#frag"
 	 */
 	resource: string;
+
+	/**
+	 * Target of compilation.
+	 * Example: "web"
+	 */
+	target: string;
 }
 
 type AdditionalData = {

--- a/types.d.ts
+++ b/types.d.ts
@@ -6595,6 +6595,12 @@ declare interface LoaderRunnerLoaderContext<OptionsType> {
 	 * Example: "/abc/resource.js?query#frag"
 	 */
 	resource: string;
+
+	/**
+	 * Target of compilation.
+	 * Example: "web"
+	 */
+	target: string;
 }
 declare class LoaderTargetPlugin {
 	constructor(target: string);


### PR DESCRIPTION
The `LoaderContext` type does not contain a `target` property, but [the documentation](https://webpack.js.org/api/loaders/#thistarget) mentions it on the loader context.

See #16753 for more information. Fixes #16753.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Adds a missing `target` property to the `LoaderContext` type.

**Did you add tests for your changes?**

Not exactly sure whether tests are needed for a tiny type change like this, also wouldn't really know where to begin to add a test for something like this, though I'm happy to add some if requested.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

N/A. Documentation for `target` on the `LoaderContext` [already exists](https://webpack.js.org/api/loaders/#thistarget).
