### PR TITLE
Respect output.hashSalt in RealContentHashPlugin

### DIFF
--- a/lib/optimize/RealContentHashPlugin.js
+++ b/lib/optimize/RealContentHashPlugin.js
@@ -363,6 +363,9 @@ ${referencingAssets
 						let newHash = hooks.updateHash.call(assetsContent, oldHash);
 						if (!newHash) {
 							const hash = createHash(this._hashFunction);
+							if (compilation.outputOptions.hashSalt) {
+								hash.update(compilation.outputOptions.hashSalt);
+							}
 							for (const content of assetsContent) {
 								hash.update(content);
 							}

--- a/test/configCases/contenthash/salt/index.js
+++ b/test/configCases/contenthash/salt/index.js
@@ -1,0 +1,5 @@
+import img from "./img.jpg";
+
+it("should compile", () => {
+	expect(typeof img).toBe("string");
+});

--- a/test/configCases/contenthash/salt/test.config.js
+++ b/test/configCases/contenthash/salt/test.config.js
@@ -1,0 +1,24 @@
+const findOutputFiles = require("../../../helpers/findOutputFiles");
+
+const allAssets = new Set();
+const allBundles = new Set();
+
+module.exports = {
+	findBundle: function(i, options) {
+		const bundle = findOutputFiles(options, new RegExp(`^bundle${i}`))[0];
+		allBundles.add(/\.([^.]+)\./.exec(bundle)[1]);
+
+		const assets = findOutputFiles(options, /^img/);
+		for (const asset of assets) {
+			allAssets.add(asset);
+		}
+
+		return `./${bundle}`;
+	},
+	afterExecute: () => {
+		// Since there are exactly 2 unique values of output.hashSalt,
+		// there should be exactly 2 unique output hashes for each file.
+		expect(allBundles.size).toBe(2);
+		expect(allAssets.size).toBe(2);
+	}
+};

--- a/test/configCases/contenthash/salt/webpack.config.js
+++ b/test/configCases/contenthash/salt/webpack.config.js
@@ -1,0 +1,48 @@
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		output: {
+			filename: "bundle0.[contenthash].js",
+			assetModuleFilename: "[name].[contenthash][ext]",
+			hashSalt: "1"
+		},
+		module: {
+			rules: [
+				{
+					test: /\.jpg$/,
+					type: "asset/resource"
+				}
+			]
+		}
+	},
+	{
+		output: {
+			filename: "bundle1.[contenthash].js",
+			assetModuleFilename: "[name].[contenthash][ext]",
+			hashSalt: "1"
+		},
+		module: {
+			rules: [
+				{
+					test: /\.jpg$/,
+					type: "asset/resource"
+				}
+			]
+		}
+	},
+	{
+		output: {
+			filename: "bundle2.[contenthash].js",
+			assetModuleFilename: "[name].[contenthash][ext]",
+			hashSalt: "2"
+		},
+		module: {
+			rules: [
+				{
+					test: /\.jpg$/,
+					type: "asset/resource"
+				}
+			]
+		}
+	}
+];


### PR DESCRIPTION
Update `RealContentHashPlugin` to initialize hash instances with the value of `output.hashSalt`, if provided. This allows developers to use the `output.hashSalt` property to force all emitted webpack assets to have new hashes, even though the content has not changed, for example to deliberately cache break a CDN.

Note that if the `optimization.realContentHash` property was set to `false`, the value of `[contenthash]` already included `output.hashSalt` in the calculation.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Fix #16788

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes. Changes verify that running three configs with identical source files and two different values of `output.hashSalt` produce exactly 2 unique output hashes.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
This could be considered a breaking change if a consumer is using the `output.hashSalt` property and depending on the value of `[contenthash]` not changing when `optimization.realContentHash` is set.

Plugins that provide a custom implementation of the content hash (e.g. for Sub-Resource Integrity) will not be impacted, because this change only applies when the `RealContentHashPlugin` is the entity that generates the content hash.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Documentation of `optimization.realContentHash` should be updated to explicitly call out that it does include `output.hashSalt` if set. The current state of the documentation is unclear on whether or not it is expected.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
