### PR TITLE
Revert "Improve performance of hashRegExp lookup"

### DIFF
--- a/lib/optimize/RealContentHashPlugin.js
+++ b/lib/optimize/RealContentHashPlugin.js
@@ -178,43 +178,10 @@ class RealContentHashPlugin {
 						}
 					}
 					if (hashToAssets.size === 0) return;
-					const hashRegExps = Array.from(hashToAssets.keys(), quoteMeta).map(
-						hash => new RegExp(hash, "g")
+					const hashRegExp = new RegExp(
+						Array.from(hashToAssets.keys(), quoteMeta).join("|"),
+						"g"
 					);
-
-					/**
-					 * @param {string} str string to be matched against all hashRegExps
-					 * @returns {string[] | null} matches found
-					 */
-					const hashMatch = str => {
-						/** @type {string[]} */
-						const results = [];
-						for (const hashRegExp of hashRegExps) {
-							const matches = str.match(hashRegExp);
-							if (matches) {
-								matches.forEach(match => results.push(match));
-							}
-						}
-						if (results.length) {
-							return results;
-						} else {
-							return null;
-						}
-					};
-
-					/**
-					 * @param {string} str string to be replaced with all hashRegExps
-					 * @param {function(string): string} fn replacement function to use when a hash is found
-					 * @returns {string} replaced content
-					 */
-					const hashReplace = (str, fn) => {
-						let result = str;
-						for (const hashRegExp of hashRegExps) {
-							result = result.replace(hashRegExp, fn);
-						}
-						return result;
-					};
-
 					await Promise.all(
 						assetsWithInfo.map(async asset => {
 							const { name, source, content, hashes } = asset;
@@ -231,7 +198,7 @@ class RealContentHashPlugin {
 								await cacheAnalyse.providePromise(name, etag, () => {
 									const referencedHashes = new Set();
 									let ownHashes = new Set();
-									const inContent = hashMatch(content);
+									const inContent = content.match(hashRegExp);
 									if (inContent) {
 										for (const hash of inContent) {
 											if (hashes.has(hash)) {
@@ -331,7 +298,7 @@ ${referencingAssets
 									identifier,
 									etag,
 									() => {
-										const newContent = hashReplace(asset.content, hash =>
+										const newContent = asset.content.replace(hashRegExp, hash =>
 											hashToNewHash.get(hash)
 										);
 										return new RawSource(newContent);
@@ -356,12 +323,15 @@ ${referencingAssets
 									identifier,
 									etag,
 									() => {
-										const newContent = hashReplace(asset.content, hash => {
-											if (asset.ownHashes.has(hash)) {
-												return "";
+										const newContent = asset.content.replace(
+											hashRegExp,
+											hash => {
+												if (asset.ownHashes.has(hash)) {
+													return "";
+												}
+												return hashToNewHash.get(hash);
 											}
-											return hashToNewHash.get(hash);
-										});
+										);
 										return new RawSource(newContent);
 									}
 								);
@@ -407,7 +377,7 @@ ${referencingAssets
 					await Promise.all(
 						assetsWithInfo.map(async asset => {
 							await computeNewContent(asset);
-							const newName = hashReplace(asset.name, hash =>
+							const newName = asset.name.replace(hashRegExp, hash =>
 								hashToNewHash.get(hash)
 							);
 


### PR DESCRIPTION
Reverts webpack/webpack#16759

Discussion here: https://github.com/webpack/webpack/pull/16759#issuecomment-1463933903

Performance benchmarks showing the improvement were calculated on an M1 Macbook Pro, subsequent performance benchmarks performed on more powerful machines running an Intel architecture show a substantial regression from these changes. I'd suggest that we revert this feature and cut a patch release.