### PR TITLE
fix: limit progress bar length to 40 when no columns provided

### DIFF
--- a/lib/node/nodeConsole.js
+++ b/lib/node/nodeConsole.js
@@ -38,7 +38,7 @@ module.exports = ({ colors, appendOnly, stream }) => {
 
 	const writeStatusMessage = () => {
 		if (!currentStatusMessage) return;
-		const l = process.stderr.columns || 40;
+		const l = stream.columns || 40;
 		const args = truncateArgs(currentStatusMessage, l - 1);
 		const str = args.join(" ");
 		const coloredStr = `\u001b[1m${str}\u001b[39m\u001b[22m`;

--- a/lib/node/nodeConsole.js
+++ b/lib/node/nodeConsole.js
@@ -38,10 +38,8 @@ module.exports = ({ colors, appendOnly, stream }) => {
 
 	const writeStatusMessage = () => {
 		if (!currentStatusMessage) return;
-		const l = stream.columns;
-		const args = l
-			? truncateArgs(currentStatusMessage, l - 1)
-			: currentStatusMessage;
+		const l = process.stderr.columns || 40;
+		const args = truncateArgs(currentStatusMessage, l - 1);
 		const str = args.join(" ");
 		const coloredStr = `\u001b[1m${str}\u001b[39m\u001b[22m`;
 		stream.write(`\x1b[2K\r${coloredStr}`);

--- a/test/ProgressPlugin.test.js
+++ b/test/ProgressPlugin.test.js
@@ -242,6 +242,7 @@ describe("ProgressPlugin", function () {
 			activeModules: true
 		});
 
+		process.stderr.columns = 70;
 		return RunCompilerAsync(compiler).then(() => {
 			const logs = stderr.toString();
 
@@ -255,6 +256,7 @@ describe("ProgressPlugin", function () {
 	it("should get the custom handler text from the log", () => {
 		const compiler = createSimpleCompilerWithCustomHandler();
 
+		process.stderr.columns = 70;
 		return RunCompilerAsync(compiler).then(() => {
 			const logs = stderr.toString();
 			expect(logs).toEqual(

--- a/test/ProgressPlugin.test.js
+++ b/test/ProgressPlugin.test.js
@@ -218,7 +218,7 @@ describe("ProgressPlugin", function () {
 			const logs = getLogs(stderr.toString());
 
 			expect(logs.length).toBeGreaterThan(20);
-			expect(_.maxBy(logs, "length").length).toBeGreaterThan(50);
+			expect(_.maxBy(logs, "length").length).not.toBeGreaterThan(40);
 		});
 	});
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fixes https://github.com/webpack/webpack/pull/9815

> See the comment here: https://github.com/webpack/webpack/pull/9225#issuecomment-536501366
>
>There are several cases where process.stderr.columns could be undefined. Like, in the Vue CLI UI console, or in a CI log page. But that doesn't mean there's infinity room to display the lines. In these cases, we should fall back to the old behavior of the 40 max length.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
