### PR TITLE
fix: initialize `this._cacheStage` in ModuleGraph constructor

### DIFF
--- a/lib/ModuleGraph.js
+++ b/lib/ModuleGraph.js
@@ -128,6 +128,9 @@ class ModuleGraph {
 
 		/** @type {Map<Module, WeakTupleMap<any, any>>} */
 		this._moduleMemCaches = undefined;
+
+		/** @type {string} */
+		this._cacheStage = undefined;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Fixes https://github.com/webpack/webpack/issues/16829
<!-- E.g. a bugfix, feature, refactoring, build-related change, etc… -->

**Did you add tests for your changes?**
No

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Nothing.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
