### PR TITLE
Fix Uncaught TypeError: Cannot read properties of undefined (reading …

### DIFF
--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -111,11 +111,11 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 				? crossOriginLoading === "use-credentials"
 					? 'link.crossOrigin = "use-credentials";'
 					: Template.asString([
-						"if (link.href.indexOf(window.location.origin + '/') !== 0) {",
+					"if (link.href.indexOf(window.location.origin + '/') !== 0) {",
 							Template.indent(
 								`link.crossOrigin = ${JSON.stringify(crossOriginLoading)};`
 							),
-						"}"
+					"}"
 					  ])
 				: ""
 		]);

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -111,11 +111,11 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 				? crossOriginLoading === "use-credentials"
 					? 'link.crossOrigin = "use-credentials";'
 					: Template.asString([
-						"if (link.href.indexOf(window.location.origin + '/') !== 0) {",
+							"if (link.href.indexOf(window.location.origin + '/') !== 0) {",
 							Template.indent(
 								`link.crossOrigin = ${JSON.stringify(crossOriginLoading)};`
 							),
-						"}"
+							"}"
 					  ])
 				: ""
 		]);

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -111,7 +111,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 				? crossOriginLoading === "use-credentials"
 					? 'link.crossOrigin = "use-credentials";'
 					: Template.asString([
-							"if (link.src.indexOf(window.location.origin + '/') !== 0) {",
+						    "if (new URL(link.href).origin.indexOf(window.location.origin + '/') !== 0) {",
 							Template.indent(
 								`link.crossOrigin = ${JSON.stringify(crossOriginLoading)};`
 							),

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -111,11 +111,11 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 				? crossOriginLoading === "use-credentials"
 					? 'link.crossOrigin = "use-credentials";'
 					: Template.asString([
-						    "if (new URL(link.href).origin.indexOf(window.location.origin + '/') !== 0) {",
+						"if (link.href.indexOf(window.location.origin + '/') !== 0) {",
 							Template.indent(
 								`link.crossOrigin = ${JSON.stringify(crossOriginLoading)};`
 							),
-							"}"
+						"}"
 					  ])
 				: ""
 		]);

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -111,11 +111,11 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 				? crossOriginLoading === "use-credentials"
 					? 'link.crossOrigin = "use-credentials";'
 					: Template.asString([
-					"if (link.href.indexOf(window.location.origin + '/') !== 0) {",
+						"if (link.href.indexOf(window.location.origin + '/') !== 0) {",
 							Template.indent(
 								`link.crossOrigin = ${JSON.stringify(crossOriginLoading)};`
 							),
-					"}"
+						"}"
 					  ])
 				: ""
 		]);


### PR DESCRIPTION
…‘indexOf’)

When creating a link for a css chunk to be loaded, src is missing. The href is set previously, so we can get via the URL the origin, which is what we need to compare here.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Bugfix
**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
