### PR TITLE
Added missing semicolon on the final output

### DIFF
--- a/lib/web/JsonpChunkLoadingRuntimeModule.js
+++ b/lib/web/JsonpChunkLoadingRuntimeModule.js
@@ -439,7 +439,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 									? `return ${RuntimeGlobals.onChunksLoaded}(result);`
 									: ""
 							]
-						)}`,
+						)};`,
 						"",
 						`var chunkLoadingGlobal = ${chunkLoadingGlobalExpr} = ${chunkLoadingGlobalExpr} || [];`,
 						"chunkLoadingGlobal.forEach(webpackJsonpCallback.bind(null, 0));",


### PR DESCRIPTION
On some external libraries, there is and issue with the minifications of the JS code with this missing semicolon. 

**Related issue**
- https://github.com/wp-media/wp-rocket/issues/5512

**What kind of change does this PR introduce?**

- Added missing semicolon on the final output.

**Did you add tests for your changes?**

- No.

**Does this PR introduce a breaking change?**

- No it doesn't.

**What needs to be documented once your changes are merged?**

- Nothing.
