### PR TITLE
Enable GitHub Copilot for PR's into default Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,13 @@
+<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->
+
 <!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
 <!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
 <!-- Try to link to an open issue for more information. -->
 
+## Summary 
+<!-- cspell:disable-next-line -->
+copilot:summary
 
-<!-- In addition to that please answer these questions: -->
-
-**What kind of change does this PR introduce?**
-
-<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
-
-**Did you add tests for your changes?**
-
-<!-- Note that we won't merge your changes if you don't add tests -->
-
-**Does this PR introduce a breaking change?**
-
-<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
-
-**What needs to be documented once your changes are merged?**
-
-<!-- List all the information that needs to be added to the documentation after merge -->
-<!-- When your changes are merged you will be asked to contribute this to the documentation -->
+## Details 
+<!-- cspell:disable-next-line -->
+copliot:walkthrough

--- a/.github/PULL_REQUEST_TEMPLATE_ORIGINAL.md
+++ b/.github/PULL_REQUEST_TEMPLATE_ORIGINAL.md
@@ -1,0 +1,23 @@
+<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
+<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
+<!-- Try to link to an open issue for more information. -->
+
+
+<!-- In addition to that please answer these questions: -->
+
+**What kind of change does this PR introduce?**
+
+<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
+
+**Did you add tests for your changes?**
+
+<!-- Note that we won't merge your changes if you don't add tests -->
+
+**Does this PR introduce a breaking change?**
+
+<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
+
+**What needs to be documented once your changes are merged?**
+
+<!-- List all the information that needs to be added to the documentation after merge -->
+<!-- When your changes are merged you will be asked to contribute this to the documentation -->


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fdcdc2d</samp>

### Summary
📄🤖🧪

<!--
1.  📄 for moving the original pull request template to a new file
2.  🤖 for using GitHub Copilot for Pull Requests in the new template
3.  🧪 for experimenting with a new format and style for pull requests
-->
The pull request updates the pull request template to use GitHub Copilot for Pull Requests. It also moves the original template to a new file for backup.

> _`copilot` guides us_
> _a new template for pull requests_
> _autumn of changes_

### Walkthrough
* Replace original pull request template with new one using GitHub Copilot for Pull Requests ([link](https://github.com/webpack/webpack/pull/16881/files?diff=unified&w=0#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35L1-R13))
  - Move original template to `.github/PULL_REQUEST_TEMPLATE_ORIGINAL.md` for backup ([link](https://github.com/webpack/webpack/pull/16881/files?diff=unified&w=0#diff-dbc40c3f647dee87da050353ad33a1def3d167afb71292fcdafa867b5a487458R1-R23))

