### PR TITLE
fix: limit module readable identifier length in stats

### DIFF
--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const util = require("util");
+const ExternalModule = require("../ExternalModule");
 const ModuleDependency = require("../dependencies/ModuleDependency");
 const formatLocation = require("../formatLocation");
 const { LogType } = require("../logging/Logger");
@@ -22,6 +23,8 @@ const {
 	compareModulesByIdentifier
 } = require("../util/comparators");
 const { makePathsRelative, parseResource } = require("../util/identifier");
+
+const MAX_EXTERNAL_MODULE_READABLE_IDENTIFIER_LENGTH = 80;
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../Chunk")} Chunk */
@@ -315,6 +318,24 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  */
 
 /**
+ * @param {string} readableIdentifier user readable identifier of the module
+ * @param {Module} module base module type
+ * @returns {string} an elided readableIdentifier, when readableIdentifier exceeds a maximum length
+ */
+const truncateLongExternalModuleReadableIdentifier = (
+	readableIdentifier,
+	module
+) => {
+	return module instanceof ExternalModule &&
+		readableIdentifier.length > MAX_EXTERNAL_MODULE_READABLE_IDENTIFIER_LENGTH
+		? readableIdentifier.substring(
+				0,
+				MAX_EXTERNAL_MODULE_READABLE_IDENTIFIER_LENGTH
+		  ) + "...(truncated)"
+		: readableIdentifier;
+};
+
+/**
  * @template T
  * @template I
  * @param {Iterable<T>} items items to select from
@@ -393,7 +414,10 @@ const EXTRACT_ERROR = {
 			}
 			if (error.module) {
 				object.moduleIdentifier = error.module.identifier();
-				object.moduleName = error.module.readableIdentifier(requestShortener);
+				object.moduleName = truncateLongExternalModuleReadableIdentifier(
+					error.module.readableIdentifier(requestShortener),
+					error.module
+				);
 			}
 			if (error.loc) {
 				object.loc = formatLocation(error.loc);
@@ -1133,7 +1157,10 @@ const SIMPLE_EXTRACTORS = {
 			/** @type {KnownStatsModule} */
 			const statsModule = {
 				identifier: module.identifier(),
-				name: module.readableIdentifier(requestShortener),
+				name: truncateLongExternalModuleReadableIdentifier(
+					module.readableIdentifier(requestShortener),
+					module
+				),
 				nameForCondition: module.nameForCondition(),
 				index: moduleGraph.getPreOrderIndex(module),
 				preOrderIndex: moduleGraph.getPreOrderIndex(module),
@@ -1146,7 +1173,12 @@ const SIMPLE_EXTRACTORS = {
 					compilation.chunkGraph.getNumberOfModuleChunks(module) === 0,
 				dependent: rootModules ? !rootModules.has(module) : undefined,
 				issuer: issuer && issuer.identifier(),
-				issuerName: issuer && issuer.readableIdentifier(requestShortener),
+				issuerName:
+					issuer &&
+					truncateLongExternalModuleReadableIdentifier(
+						issuer.readableIdentifier(requestShortener),
+						issuer
+					),
 				issuerPath:
 					issuer &&
 					factory.create(`${type.slice(0, -8)}.issuerPath`, path, context),
@@ -1286,7 +1318,10 @@ const SIMPLE_EXTRACTORS = {
 			/** @type {KnownStatsModuleIssuer} */
 			const statsModuleIssuer = {
 				identifier: module.identifier(),
-				name: module.readableIdentifier(requestShortener)
+				name: truncateLongExternalModuleReadableIdentifier(
+					module.readableIdentifier(requestShortener),
+					module
+				)
 			};
 			Object.assign(object, statsModuleIssuer);
 			if (profile) {
@@ -1308,16 +1343,25 @@ const SIMPLE_EXTRACTORS = {
 					? reason.originModule.identifier()
 					: null,
 				module: reason.originModule
-					? reason.originModule.readableIdentifier(requestShortener)
+					? truncateLongExternalModuleReadableIdentifier(
+							reason.originModule.readableIdentifier(requestShortener),
+							reason.originModule
+					  )
 					: null,
 				moduleName: reason.originModule
-					? reason.originModule.readableIdentifier(requestShortener)
+					? truncateLongExternalModuleReadableIdentifier(
+							reason.originModule.readableIdentifier(requestShortener),
+							reason.originModule
+					  )
 					: null,
 				resolvedModuleIdentifier: reason.resolvedOriginModule
 					? reason.resolvedOriginModule.identifier()
 					: null,
 				resolvedModule: reason.resolvedOriginModule
-					? reason.resolvedOriginModule.readableIdentifier(requestShortener)
+					? truncateLongExternalModuleReadableIdentifier(
+							reason.resolvedOriginModule.readableIdentifier(requestShortener),
+							reason.resolvedOriginModule
+					  )
 					: null,
 				type: reason.dependency ? reason.dependency.type : null,
 				active: reason.isActive(runtime),
@@ -1445,7 +1489,10 @@ const SIMPLE_EXTRACTORS = {
 				module: origin.module ? origin.module.identifier() : "",
 				moduleIdentifier: origin.module ? origin.module.identifier() : "",
 				moduleName: origin.module
-					? origin.module.readableIdentifier(requestShortener)
+					? truncateLongExternalModuleReadableIdentifier(
+							origin.module.readableIdentifier(requestShortener),
+							origin.module
+					  )
 					: "",
 				loc: formatLocation(origin.loc),
 				request: origin.request
@@ -1468,8 +1515,15 @@ const SIMPLE_EXTRACTORS = {
 			} = context;
 			object.originIdentifier = origin.identifier();
 			object.originName = origin.readableIdentifier(requestShortener);
+			object.originName = truncateLongExternalModuleReadableIdentifier(
+				origin.readableIdentifier(requestShortener),
+				origin
+			);
 			object.moduleIdentifier = module.identifier();
-			object.moduleName = module.readableIdentifier(requestShortener);
+			object.moduleName = truncateLongExternalModuleReadableIdentifier(
+				module.readableIdentifier(requestShortener),
+				module
+			);
 			const dependencies = Array.from(
 				moduleGraph.getIncomingConnections(module)
 			)

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -24,8 +24,6 @@ const {
 } = require("../util/comparators");
 const { makePathsRelative, parseResource } = require("../util/identifier");
 
-const MAX_EXTERNAL_MODULE_READABLE_IDENTIFIER_LENGTH = 80;
-
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../ChunkGroup")} ChunkGroup */
@@ -316,6 +314,8 @@ const MAX_EXTERNAL_MODULE_READABLE_IDENTIFIER_LENGTH = 80;
  * @property {ExtractorsByOption<{ origin: Module, module: Module }, StatsModuleTraceItem>} moduleTraceItem
  * @property {ExtractorsByOption<Dependency, StatsModuleTraceDependency>} moduleTraceDependency
  */
+
+const MAX_EXTERNAL_MODULE_READABLE_IDENTIFIER_LENGTH = 80;
 
 /**
  * @param {string} readableIdentifier user readable identifier of the module

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -6,7 +6,6 @@
 "use strict";
 
 const util = require("util");
-const ExternalModule = require("../ExternalModule");
 const ModuleDependency = require("../dependencies/ModuleDependency");
 const formatLocation = require("../formatLocation");
 const { LogType } = require("../logging/Logger");
@@ -315,26 +314,6 @@ const { makePathsRelative, parseResource } = require("../util/identifier");
  * @property {ExtractorsByOption<Dependency, StatsModuleTraceDependency>} moduleTraceDependency
  */
 
-const MAX_EXTERNAL_MODULE_READABLE_IDENTIFIER_LENGTH = 80;
-
-/**
- * @param {string} readableIdentifier user readable identifier of the module
- * @param {Module} module base module type
- * @returns {string} an elided readableIdentifier, when readableIdentifier exceeds a maximum length
- */
-const truncateLongExternalModuleReadableIdentifier = (
-	readableIdentifier,
-	module
-) => {
-	return module instanceof ExternalModule &&
-		readableIdentifier.length > MAX_EXTERNAL_MODULE_READABLE_IDENTIFIER_LENGTH
-		? readableIdentifier.substring(
-				0,
-				MAX_EXTERNAL_MODULE_READABLE_IDENTIFIER_LENGTH
-		  ) + "...(truncated)"
-		: readableIdentifier;
-};
-
 /**
  * @template T
  * @template I
@@ -414,10 +393,7 @@ const EXTRACT_ERROR = {
 			}
 			if (error.module) {
 				object.moduleIdentifier = error.module.identifier();
-				object.moduleName = truncateLongExternalModuleReadableIdentifier(
-					error.module.readableIdentifier(requestShortener),
-					error.module
-				);
+				object.moduleName = error.module.readableIdentifier(requestShortener);
 			}
 			if (error.loc) {
 				object.loc = formatLocation(error.loc);
@@ -1157,10 +1133,7 @@ const SIMPLE_EXTRACTORS = {
 			/** @type {KnownStatsModule} */
 			const statsModule = {
 				identifier: module.identifier(),
-				name: truncateLongExternalModuleReadableIdentifier(
-					module.readableIdentifier(requestShortener),
-					module
-				),
+				name: module.readableIdentifier(requestShortener),
 				nameForCondition: module.nameForCondition(),
 				index: moduleGraph.getPreOrderIndex(module),
 				preOrderIndex: moduleGraph.getPreOrderIndex(module),
@@ -1173,12 +1146,7 @@ const SIMPLE_EXTRACTORS = {
 					compilation.chunkGraph.getNumberOfModuleChunks(module) === 0,
 				dependent: rootModules ? !rootModules.has(module) : undefined,
 				issuer: issuer && issuer.identifier(),
-				issuerName:
-					issuer &&
-					truncateLongExternalModuleReadableIdentifier(
-						issuer.readableIdentifier(requestShortener),
-						issuer
-					),
+				issuerName: issuer && issuer.readableIdentifier(requestShortener),
 				issuerPath:
 					issuer &&
 					factory.create(`${type.slice(0, -8)}.issuerPath`, path, context),
@@ -1318,10 +1286,7 @@ const SIMPLE_EXTRACTORS = {
 			/** @type {KnownStatsModuleIssuer} */
 			const statsModuleIssuer = {
 				identifier: module.identifier(),
-				name: truncateLongExternalModuleReadableIdentifier(
-					module.readableIdentifier(requestShortener),
-					module
-				)
+				name: module.readableIdentifier(requestShortener)
 			};
 			Object.assign(object, statsModuleIssuer);
 			if (profile) {
@@ -1343,25 +1308,16 @@ const SIMPLE_EXTRACTORS = {
 					? reason.originModule.identifier()
 					: null,
 				module: reason.originModule
-					? truncateLongExternalModuleReadableIdentifier(
-							reason.originModule.readableIdentifier(requestShortener),
-							reason.originModule
-					  )
+					? reason.originModule.readableIdentifier(requestShortener)
 					: null,
 				moduleName: reason.originModule
-					? truncateLongExternalModuleReadableIdentifier(
-							reason.originModule.readableIdentifier(requestShortener),
-							reason.originModule
-					  )
+					? reason.originModule.readableIdentifier(requestShortener)
 					: null,
 				resolvedModuleIdentifier: reason.resolvedOriginModule
 					? reason.resolvedOriginModule.identifier()
 					: null,
 				resolvedModule: reason.resolvedOriginModule
-					? truncateLongExternalModuleReadableIdentifier(
-							reason.resolvedOriginModule.readableIdentifier(requestShortener),
-							reason.resolvedOriginModule
-					  )
+					? reason.resolvedOriginModule.readableIdentifier(requestShortener)
 					: null,
 				type: reason.dependency ? reason.dependency.type : null,
 				active: reason.isActive(runtime),
@@ -1489,10 +1445,7 @@ const SIMPLE_EXTRACTORS = {
 				module: origin.module ? origin.module.identifier() : "",
 				moduleIdentifier: origin.module ? origin.module.identifier() : "",
 				moduleName: origin.module
-					? truncateLongExternalModuleReadableIdentifier(
-							origin.module.readableIdentifier(requestShortener),
-							origin.module
-					  )
+					? origin.module.readableIdentifier(requestShortener)
 					: "",
 				loc: formatLocation(origin.loc),
 				request: origin.request
@@ -1515,15 +1468,8 @@ const SIMPLE_EXTRACTORS = {
 			} = context;
 			object.originIdentifier = origin.identifier();
 			object.originName = origin.readableIdentifier(requestShortener);
-			object.originName = truncateLongExternalModuleReadableIdentifier(
-				origin.readableIdentifier(requestShortener),
-				origin
-			);
 			object.moduleIdentifier = module.identifier();
-			object.moduleName = truncateLongExternalModuleReadableIdentifier(
-				module.readableIdentifier(requestShortener),
-				module
-			);
+			object.moduleName = module.readableIdentifier(requestShortener);
 			const dependencies = Array.from(
 				moduleGraph.getIncomingConnections(module)
 			)

--- a/lib/stats/DefaultStatsPrinterPlugin.js
+++ b/lib/stats/DefaultStatsPrinterPlugin.js
@@ -31,17 +31,7 @@ const printSizes = (sizes, { formatSize = n => `${n}` }) => {
 
 const getResourceName = resource => {
 	const dataUrl = /^data:[^,]+,/.exec(resource);
-
-	if (!dataUrl) {
-		if (resource.length < MAX_MODULE_IDENTIFIER_LENGTH) return resource;
-		return `${resource.slice(
-			0,
-			Math.min(
-				resource.length - /* '...(truncated)'.length */ 14,
-				MAX_MODULE_IDENTIFIER_LENGTH
-			)
-		)}...(truncated)`;
-	}
+	if (!dataUrl) return resource;
 
 	const len = dataUrl[0].length + DATA_URI_CONTENT_LENGTH;
 	if (resource.length < len) return resource;
@@ -53,6 +43,19 @@ const getResourceName = resource => {
 
 const getModuleName = name => {
 	const [, prefix, resource] = /^(.*!)?([^!]*)$/.exec(name);
+
+	if (resource.length > MAX_MODULE_IDENTIFIER_LENGTH) {
+		const truncatedResource = `${resource.slice(
+			0,
+			Math.min(
+				resource.length - /* '...(truncated)'.length */ 14,
+				MAX_MODULE_IDENTIFIER_LENGTH
+			)
+		)}...(truncated)`;
+
+		return [prefix, getResourceName(truncatedResource)];
+	}
+
 	return [prefix, getResourceName(resource)];
 };
 

--- a/lib/stats/DefaultStatsPrinterPlugin.js
+++ b/lib/stats/DefaultStatsPrinterPlugin.js
@@ -10,6 +10,7 @@
 /** @typedef {import("./StatsPrinter").StatsPrinterContext} StatsPrinterContext */
 
 const DATA_URI_CONTENT_LENGTH = 16;
+const MAX_MODULE_IDENTIFIER_LENGTH = 80;
 
 const plural = (n, singular, plural) => (n === 1 ? singular : plural);
 
@@ -30,7 +31,17 @@ const printSizes = (sizes, { formatSize = n => `${n}` }) => {
 
 const getResourceName = resource => {
 	const dataUrl = /^data:[^,]+,/.exec(resource);
-	if (!dataUrl) return resource;
+
+	if (!dataUrl) {
+		if (resource.length < MAX_MODULE_IDENTIFIER_LENGTH) return resource;
+		return `${resource.slice(
+			0,
+			Math.min(
+				resource.length - /* '...(truncated)'.length */ 14,
+				MAX_MODULE_IDENTIFIER_LENGTH
+			)
+		)}...(truncated)`;
+	}
 
 	const len = dataUrl[0].length + DATA_URI_CONTENT_LENGTH;
 	if (resource.length < len) return resource;

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -1435,6 +1435,13 @@ asset <CLR=32,BOLD>main.js</CLR> 84 bytes <CLR=32,BOLD>[emitted]</CLR> (name: ma
 webpack x.x.x compiled <CLR=32,BOLD>successfully</CLR> in X ms"
 `;
 
+exports[`StatsTestCases should print correct stats for max-external-module-readable-identifier 1`] = `
+"asset main.js 1.45 KiB [emitted] (name: main)
+./index.js 17 bytes [built] [code generated]
+external \\"very-very-very-very-long-external-module-readable-identifier-it-should...(truncated) 42 bytes [built] [code generated]
+webpack x.x.x compiled successfully in X ms"
+`;
+
 exports[`StatsTestCases should print correct stats for max-modules 1`] = `
 "asset main.js 5.47 KiB [emitted] (name: main)
 ./index.js 181 bytes [built] [code generated]

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -1195,7 +1195,7 @@ built modules 724 bytes [built]
     ./templates/baz.js 38 bytes [optional] [built] [code generated]
     ./templates/foo.js 38 bytes [optional] [built] [code generated]
   ./entry.js 450 bytes [built] [code generated]
-  ./templates/ lazy ^\\\\.\\\\/.*$ include: \\\\.js$ exclude: \\\\.noimport\\\\.js$ namespace object 160 bytes [optional] [built] [code generated]
+  ./templates/ lazy ^\\\\.\\\\/.*$ include: \\\\.js$ exclude: \\\\.noimport\\\\.js$ na...(truncated) 160 bytes [optional] [built] [code generated]
 webpack x.x.x compiled successfully in X ms"
 `;
 

--- a/test/statsCases/max-external-module-readable-identifier/index.js
+++ b/test/statsCases/max-external-module-readable-identifier/index.js
@@ -1,0 +1,1 @@
+require("test");

--- a/test/statsCases/max-external-module-readable-identifier/webpack.config.js
+++ b/test/statsCases/max-external-module-readable-identifier/webpack.config.js
@@ -1,0 +1,8 @@
+/** @type {import("../../../types").Configuration} */
+module.exports = {
+	mode: "production",
+	entry: "./index",
+	externals: {
+		test: "commonjs very-very-very-very-long-external-module-readable-identifier-it-should-be-truncated"
+	}
+};


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary 
Fixes https://github.com/webpack/webpack/pull/16479
<!-- cspell:disable-next-line -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f11b06</samp>

Add a test case for webpack's truncation of long external module names. The test case uses a `test` module with a very long name as an external dependency in `index.js` and `webpack.config.js`.




## Details 
<!-- cspell:disable-next-line -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f11b06</samp>

* Add a test case to check how webpack truncates long external module names to fit the `maxModuleReadableIdentifierLength` option (F0,F1)
  - Create an `index.js` file that requires the `test` module, which is declared as an external dependency ([link](https://github.com/webpack/webpack/pull/16882/files?diff=unified&w=0#diff-ad4adca0d5941f48be74e9d21c020de735b6329e305b68a05d45b2d389196937R1))
  - Create a `webpack.config.js` file that sets the mode, entry point, and external module options ([link](https://github.com/webpack/webpack/pull/16882/files?diff=unified&w=0#diff-a4393996a2a2a2afb8d4d78d3efe3d6d94622851bf77bb781ffda7c5027ce8e9R1-R8))
    - Use a very long name for the external module, which is expected to be shortened by webpack ([link](https://github.com/webpack/webpack/pull/16882/files?diff=unified&w=0#diff-a4393996a2a2a2afb8d4d78d3efe3d6d94622851bf77bb781ffda7c5027ce8e9R1-R8))
