### PR TITLE
fix: copilot command typo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,4 @@ copilot:summary
 
 ## Details 
 <!-- cspell:disable-next-line -->
-copliot:walkthrough
+copilot:walkthrough


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary 
<!-- cspell:disable-next-line -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f3f991</samp>

Fixed a typo in the pull request template comment for GitHub Copilot. The file `.github/PULL_REQUEST_TEMPLATE.md` was updated to spell `copilot` correctly.

## Details 
<!-- cspell:disable-next-line -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f3f991</samp>

* Fix spelling of `copilot` in pull request template comment ([link](https://github.com/webpack/webpack/pull/16890/files?diff=unified&w=0#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35L13-R13))
