### PR TITLE
generate the exported part at the end of the module #16888

### DIFF
--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -1477,10 +1477,10 @@ class ConcatenatedModule extends Module {
 		}
 
 		// define exports
+		let definitions = [];
 		if (exportsMap.size > 0) {
 			runtimeRequirements.add(RuntimeGlobals.exports);
 			runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
-			const definitions = [];
 			for (const [key, value] of exportsMap) {
 				definitions.push(
 					`\n  ${JSON.stringify(key)}: ${runtimeTemplate.returningFunction(
@@ -1488,12 +1488,6 @@ class ConcatenatedModule extends Module {
 					)}`
 				);
 			}
-			result.add(`\n// EXPORTS\n`);
-			result.add(
-				`${RuntimeGlobals.definePropertyGetters}(${
-					this.exportsArgument
-				}, {${definitions.join(",")}\n});\n`
-			);
 		}
 
 		// list unused exports
@@ -1641,6 +1635,16 @@ ${defineGetters}`
 			if (isConditional) {
 				result.add("\n}");
 			}
+		}
+
+		// generate exports at the end of the source code
+		if (definitions[0]) {
+			result.add(`\n// EXPORTS\n`);
+			result.add(
+				`${RuntimeGlobals.definePropertyGetters}(${
+					this.exportsArgument
+				}, {${definitions.join(",")}\n});\n`
+			);
 		}
 
 		const data = new Map();


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary 

related to #16888 

## Details 

If there is no reason to verify the significance of the position, just put it at the end of the module to make it more reasonable as it accesses the scope. Could you just break it without supporting any options?
