### PR TITLE
refactor(ErrorHelpers): Make error helpers named functions; add types

### DIFF
--- a/lib/ErrorHelpers.js
+++ b/lib/ErrorHelpers.js
@@ -9,36 +9,57 @@ const loaderFlag = "LOADER_EXECUTION";
 
 const webpackOptionsFlag = "WEBPACK_OPTIONS";
 
-exports.cutOffByFlag = (stack, flag) => {
-	stack = stack.split("\n");
-	for (let i = 0; i < stack.length; i++) {
-		if (stack[i].includes(flag)) {
-			stack.length = i;
+/**
+ * @param {string} stack stack trace
+ * @param {string} flag flag to cut off
+ * @returns {string} stack trace without the specified flag included
+ */
+const cutOffByFlag = (stack, flag) => {
+	const errorStack = stack.split("\n");
+	for (let i = 0; i < errorStack.length; i++) {
+		if (errorStack[i].includes(flag)) {
+			errorStack.length = i;
 		}
 	}
-	return stack.join("\n");
+	return errorStack.join("\n");
 };
 
-exports.cutOffLoaderExecution = stack =>
-	exports.cutOffByFlag(stack, loaderFlag);
+/**
+ * @param {string} stack stack trace
+ * @returns {string} stack trace without the loader execution flag included
+ */
+const cutOffLoaderExecution = stack => cutOffByFlag(stack, loaderFlag);
 
-exports.cutOffWebpackOptions = stack =>
-	exports.cutOffByFlag(stack, webpackOptionsFlag);
+/**
+ * @param {string} stack stack trace
+ * @returns {string} stack trace without the webpack options flag included
+ */
+const cutOffWebpackOptions = stack => cutOffByFlag(stack, webpackOptionsFlag);
 
-exports.cutOffMultilineMessage = (stack, message) => {
-	stack = stack.split("\n");
-	message = message.split("\n");
+/**
+ * @param {string} stack stack trace
+ * @param {string} message error message
+ * @returns {string} stack trace without the message included
+ */
+const cutOffMultilineMessage = (stack, message) => {
+	const stackSplitByLines = stack.split("\n");
+	const messageSplitByLines = message.split("\n");
 
 	const result = [];
 
-	stack.forEach((line, idx) => {
-		if (!line.includes(message[idx])) result.push(line);
+	stackSplitByLines.forEach((line, idx) => {
+		if (!line.includes(messageSplitByLines[idx])) result.push(line);
 	});
 
 	return result.join("\n");
 };
 
-exports.cutOffMessage = (stack, message) => {
+/**
+ * @param {string} stack stack trace
+ * @param {string} message error message
+ * @returns {string} stack trace without the message included
+ */
+const cutOffMessage = (stack, message) => {
 	const nextLine = stack.indexOf("\n");
 	if (nextLine === -1) {
 		return stack === message ? "" : stack;
@@ -48,14 +69,32 @@ exports.cutOffMessage = (stack, message) => {
 	}
 };
 
-exports.cleanUp = (stack, message) => {
-	stack = exports.cutOffLoaderExecution(stack);
-	stack = exports.cutOffMessage(stack, message);
+/**
+ * @param {string} stack stack trace
+ * @param {string} message error message
+ * @returns {string} stack trace without the loader execution flag and message included
+ */
+const cleanUp = (stack, message) => {
+	stack = cutOffLoaderExecution(stack);
+	stack = cutOffMessage(stack, message);
 	return stack;
 };
 
-exports.cleanUpWebpackOptions = (stack, message) => {
-	stack = exports.cutOffWebpackOptions(stack);
-	stack = exports.cutOffMultilineMessage(stack, message);
+/**
+ * @param {string} stack stack trace
+ * @param {string} message error message
+ * @returns {string} stack trace without the webpack options flag and message included
+ */
+const cleanUpWebpackOptions = (stack, message) => {
+	stack = cutOffWebpackOptions(stack);
+	stack = cutOffMultilineMessage(stack, message);
 	return stack;
 };
+
+exports.cutOffByFlag = cutOffByFlag;
+exports.cutOffLoaderExecution = cutOffLoaderExecution;
+exports.cutOffWebpackOptions = cutOffWebpackOptions;
+exports.cutOffMultilineMessage = cutOffMultilineMessage;
+exports.cutOffMessage = cutOffMessage;
+exports.cleanUp = cleanUp;
+exports.cleanUpWebpackOptions = cleanUpWebpackOptions;


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary 
<!-- cspell:disable-next-line -->
Refactors Error helpers in a few ways

## Details 
<!-- cspell:disable-next-line -->
* Removes variable shadowing in replacement of easier type safety with comments
* Improve readability of function by renaming variables
* Add JSDoc comments and descriptions for each function
* Drop module exports to bottom of file in one location for ease of readability

## Semver
- [x] Patch
- [ ] Minor
- [ ] Major