### PR TITLE
add more module type constants, use them across codebase

### DIFF
--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -5,6 +5,11 @@
 
 "use strict";
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("./ModuleTypeConstants");
 const RuntimeGlobals = require("./RuntimeGlobals");
 const WebpackError = require("./WebpackError");
 const ConstDependency = require("./dependencies/ConstDependency");
@@ -113,6 +118,8 @@ const REPLACEMENTS = {
 };
 /* eslint-enable camelcase */
 
+const PLUGIN_NAME = "APIPlugin";
+
 class APIPlugin {
 	/**
 	 * Apply the plugin
@@ -121,7 +128,7 @@ class APIPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"APIPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				compilation.dependencyTemplates.set(
 					ConstDependency,
@@ -130,7 +137,7 @@ class APIPlugin {
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.chunkName)
-					.tap("APIPlugin", chunk => {
+					.tap(PLUGIN_NAME, chunk => {
 						compilation.addRuntimeModule(
 							chunk,
 							new ChunkNameRuntimeModule(chunk.name)
@@ -140,7 +147,7 @@ class APIPlugin {
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.getFullHash)
-					.tap("APIPlugin", (chunk, set) => {
+					.tap(PLUGIN_NAME, (chunk, set) => {
 						compilation.addRuntimeModule(chunk, new GetFullHashRuntimeModule());
 						return true;
 					});
@@ -154,11 +161,11 @@ class APIPlugin {
 						parser.hooks.expression
 							.for(key)
 							.tap(
-								"APIPlugin",
+								PLUGIN_NAME,
 								toConstantDependency(parser, info.expr, info.req)
 							);
 						if (info.assign === false) {
-							parser.hooks.assign.for(key).tap("APIPlugin", expr => {
+							parser.hooks.assign.for(key).tap(PLUGIN_NAME, expr => {
 								const err = new WebpackError(`${key} must not be assigned`);
 								err.loc = expr.loc;
 								throw err;
@@ -167,13 +174,13 @@ class APIPlugin {
 						if (info.type) {
 							parser.hooks.evaluateTypeof
 								.for(key)
-								.tap("APIPlugin", evaluateToString(info.type));
+								.tap(PLUGIN_NAME, evaluateToString(info.type));
 						}
 					});
 
 					parser.hooks.expression
 						.for("__webpack_layer__")
-						.tap("APIPlugin", expr => {
+						.tap(PLUGIN_NAME, expr => {
 							const dep = new ConstDependency(
 								JSON.stringify(parser.state.module.layer),
 								expr.range
@@ -184,7 +191,7 @@ class APIPlugin {
 						});
 					parser.hooks.evaluateIdentifier
 						.for("__webpack_layer__")
-						.tap("APIPlugin", expr =>
+						.tap(PLUGIN_NAME, expr =>
 							(parser.state.module.layer === null
 								? new BasicEvaluatedExpression().setNull()
 								: new BasicEvaluatedExpression().setString(
@@ -194,7 +201,7 @@ class APIPlugin {
 						);
 					parser.hooks.evaluateTypeof
 						.for("__webpack_layer__")
-						.tap("APIPlugin", expr =>
+						.tap(PLUGIN_NAME, expr =>
 							new BasicEvaluatedExpression()
 								.setString(
 									parser.state.module.layer === null ? "object" : "string"
@@ -204,7 +211,7 @@ class APIPlugin {
 
 					parser.hooks.expression
 						.for("__webpack_module__.id")
-						.tap("APIPlugin", expr => {
+						.tap(PLUGIN_NAME, expr => {
 							parser.state.module.buildInfo.moduleConcatenationBailout =
 								"__webpack_module__.id";
 							const dep = new ConstDependency(
@@ -219,7 +226,7 @@ class APIPlugin {
 
 					parser.hooks.expression
 						.for("__webpack_module__")
-						.tap("APIPlugin", expr => {
+						.tap(PLUGIN_NAME, expr => {
 							parser.state.module.buildInfo.moduleConcatenationBailout =
 								"__webpack_module__";
 							const dep = new ConstDependency(
@@ -233,18 +240,18 @@ class APIPlugin {
 						});
 					parser.hooks.evaluateTypeof
 						.for("__webpack_module__")
-						.tap("APIPlugin", evaluateToString("object"));
+						.tap(PLUGIN_NAME, evaluateToString("object"));
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("APIPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("APIPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/esm")
-					.tap("APIPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/CompatibilityPlugin.js
+++ b/lib/CompatibilityPlugin.js
@@ -5,12 +5,18 @@
 
 "use strict";
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("./ModuleTypeConstants");
 const ConstDependency = require("./dependencies/ConstDependency");
 
 /** @typedef {import("./Compiler")} Compiler */
 /** @typedef {import("./javascript/JavascriptParser")} JavascriptParser */
 
 const nestedWebpackRequireTag = Symbol("nested __webpack_require__");
+const PLUGIN_NAME = "CompatibilityPlugin";
 
 class CompatibilityPlugin {
 	/**
@@ -20,7 +26,7 @@ class CompatibilityPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"CompatibilityPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				compilation.dependencyTemplates.set(
 					ConstDependency,
@@ -28,41 +34,39 @@ class CompatibilityPlugin {
 				);
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("CompatibilityPlugin", (parser, parserOptions) => {
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, (parser, parserOptions) => {
 						if (
 							parserOptions.browserify !== undefined &&
 							!parserOptions.browserify
 						)
 							return;
 
-						parser.hooks.call
-							.for("require")
-							.tap("CompatibilityPlugin", expr => {
-								// support for browserify style require delegator: "require(o, !0)"
-								if (expr.arguments.length !== 2) return;
-								const second = parser.evaluateExpression(expr.arguments[1]);
-								if (!second.isBoolean()) return;
-								if (second.asBool() !== true) return;
-								const dep = new ConstDependency("require", expr.callee.range);
-								dep.loc = expr.loc;
-								if (parser.state.current.dependencies.length > 0) {
-									const last =
-										parser.state.current.dependencies[
-											parser.state.current.dependencies.length - 1
-										];
-									if (
-										last.critical &&
-										last.options &&
-										last.options.request === "." &&
-										last.userRequest === "." &&
-										last.options.recursive
-									)
-										parser.state.current.dependencies.pop();
-								}
-								parser.state.module.addPresentationalDependency(dep);
-								return true;
-							});
+						parser.hooks.call.for("require").tap(PLUGIN_NAME, expr => {
+							// support for browserify style require delegator: "require(o, !0)"
+							if (expr.arguments.length !== 2) return;
+							const second = parser.evaluateExpression(expr.arguments[1]);
+							if (!second.isBoolean()) return;
+							if (second.asBool() !== true) return;
+							const dep = new ConstDependency("require", expr.callee.range);
+							dep.loc = expr.loc;
+							if (parser.state.current.dependencies.length > 0) {
+								const last =
+									parser.state.current.dependencies[
+										parser.state.current.dependencies.length - 1
+									];
+								if (
+									last.critical &&
+									last.options &&
+									last.options.request === "." &&
+									last.userRequest === "." &&
+									last.options.recursive
+								)
+									parser.state.current.dependencies.pop();
+							}
+							parser.state.module.addPresentationalDependency(dep);
+							return true;
+						});
 					});
 
 				/**
@@ -71,7 +75,7 @@ class CompatibilityPlugin {
 				 */
 				const handler = parser => {
 					// Handle nested requires
-					parser.hooks.preStatement.tap("CompatibilityPlugin", statement => {
+					parser.hooks.preStatement.tap(PLUGIN_NAME, statement => {
 						if (
 							statement.type === "FunctionDeclaration" &&
 							statement.id &&
@@ -91,7 +95,7 @@ class CompatibilityPlugin {
 					});
 					parser.hooks.pattern
 						.for("__webpack_require__")
-						.tap("CompatibilityPlugin", pattern => {
+						.tap(PLUGIN_NAME, pattern => {
 							const newName = `__nested_webpack_require_${pattern.range[0]}__`;
 							parser.tagVariable(pattern.name, nestedWebpackRequireTag, {
 								name: newName,
@@ -105,7 +109,7 @@ class CompatibilityPlugin {
 						});
 					parser.hooks.expression
 						.for(nestedWebpackRequireTag)
-						.tap("CompatibilityPlugin", expr => {
+						.tap(PLUGIN_NAME, expr => {
 							const { name, declaration } = parser.currentTagData;
 							if (!declaration.updated) {
 								const dep = new ConstDependency(name, declaration.range);
@@ -120,31 +124,28 @@ class CompatibilityPlugin {
 						});
 
 					// Handle hashbang
-					parser.hooks.program.tap(
-						"CompatibilityPlugin",
-						(program, comments) => {
-							if (comments.length === 0) return;
-							const c = comments[0];
-							if (c.type === "Line" && c.range[0] === 0) {
-								if (parser.state.source.slice(0, 2).toString() !== "#!") return;
-								// this is a hashbang comment
-								const dep = new ConstDependency("//", 0);
-								dep.loc = c.loc;
-								parser.state.module.addPresentationalDependency(dep);
-							}
+					parser.hooks.program.tap(PLUGIN_NAME, (program, comments) => {
+						if (comments.length === 0) return;
+						const c = comments[0];
+						if (c.type === "Line" && c.range[0] === 0) {
+							if (parser.state.source.slice(0, 2).toString() !== "#!") return;
+							// this is a hashbang comment
+							const dep = new ConstDependency("//", 0);
+							dep.loc = c.loc;
+							parser.state.module.addPresentationalDependency(dep);
 						}
-					);
+					});
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("CompatibilityPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("CompatibilityPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/esm")
-					.tap("CompatibilityPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/ConstPlugin.js
+++ b/lib/ConstPlugin.js
@@ -5,6 +5,11 @@
 
 "use strict";
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("./ModuleTypeConstants");
 const CachedConstDependency = require("./dependencies/CachedConstDependency");
 const ConstDependency = require("./dependencies/ConstDependency");
 const { evaluateToString } = require("./javascript/JavascriptParserHelpers");
@@ -108,6 +113,8 @@ const getHoistedDeclarations = (branch, includeFunctionDeclarations) => {
 	return Array.from(declarations);
 };
 
+const PLUGIN_NAME = "ConstPlugin";
+
 class ConstPlugin {
 	/**
 	 * Apply the plugin
@@ -117,7 +124,7 @@ class ConstPlugin {
 	apply(compiler) {
 		const cachedParseResource = parseResource.bindCache(compiler.root);
 		compiler.hooks.compilation.tap(
-			"ConstPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				compilation.dependencyTemplates.set(
 					ConstDependency,
@@ -130,7 +137,7 @@ class ConstPlugin {
 				);
 
 				const handler = parser => {
-					parser.hooks.statementIf.tap("ConstPlugin", statement => {
+					parser.hooks.statementIf.tap(PLUGIN_NAME, statement => {
 						if (parser.scope.isAsmJs) return;
 						const param = parser.evaluateExpression(statement.test);
 						const bool = param.asBool();
@@ -202,7 +209,7 @@ class ConstPlugin {
 						}
 					});
 					parser.hooks.expressionConditionalOperator.tap(
-						"ConstPlugin",
+						PLUGIN_NAME,
 						expression => {
 							if (parser.scope.isAsmJs) return;
 							const param = parser.evaluateExpression(expression.test);
@@ -237,7 +244,7 @@ class ConstPlugin {
 						}
 					);
 					parser.hooks.expressionLogicalOperator.tap(
-						"ConstPlugin",
+						PLUGIN_NAME,
 						expression => {
 							if (parser.scope.isAsmJs) return;
 							if (
@@ -374,7 +381,7 @@ class ConstPlugin {
 							}
 						}
 					);
-					parser.hooks.optionalChaining.tap("ConstPlugin", expr => {
+					parser.hooks.optionalChaining.tap(PLUGIN_NAME, expr => {
 						/** @type {ExpressionNode[]} */
 						const optionalExpressionsStack = [];
 						/** @type {ExpressionNode|SuperNode} */
@@ -429,7 +436,7 @@ class ConstPlugin {
 					});
 					parser.hooks.evaluateIdentifier
 						.for("__resourceQuery")
-						.tap("ConstPlugin", expr => {
+						.tap(PLUGIN_NAME, expr => {
 							if (parser.scope.isAsmJs) return;
 							if (!parser.state.module) return;
 							return evaluateToString(
@@ -438,7 +445,7 @@ class ConstPlugin {
 						});
 					parser.hooks.expression
 						.for("__resourceQuery")
-						.tap("ConstPlugin", expr => {
+						.tap(PLUGIN_NAME, expr => {
 							if (parser.scope.isAsmJs) return;
 							if (!parser.state.module) return;
 							const dep = new CachedConstDependency(
@@ -455,7 +462,7 @@ class ConstPlugin {
 
 					parser.hooks.evaluateIdentifier
 						.for("__resourceFragment")
-						.tap("ConstPlugin", expr => {
+						.tap(PLUGIN_NAME, expr => {
 							if (parser.scope.isAsmJs) return;
 							if (!parser.state.module) return;
 							return evaluateToString(
@@ -464,7 +471,7 @@ class ConstPlugin {
 						});
 					parser.hooks.expression
 						.for("__resourceFragment")
-						.tap("ConstPlugin", expr => {
+						.tap(PLUGIN_NAME, expr => {
 							if (parser.scope.isAsmJs) return;
 							if (!parser.state.module) return;
 							const dep = new CachedConstDependency(
@@ -481,14 +488,14 @@ class ConstPlugin {
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("ConstPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("ConstPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/esm")
-					.tap("ConstPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -9,6 +9,7 @@ const { OriginalSource, RawSource } = require("webpack-sources");
 const AsyncDependenciesBlock = require("./AsyncDependenciesBlock");
 const { makeWebpackError } = require("./HookWebpackError");
 const Module = require("./Module");
+const { JAVASCRIPT_MODULE_TYPE_DYNAMIC } = require("./ModuleTypeConstants");
 const RuntimeGlobals = require("./RuntimeGlobals");
 const Template = require("./Template");
 const WebpackError = require("./WebpackError");
@@ -105,7 +106,7 @@ class ContextModule extends Module {
 			const resourceFragment =
 				(options && options.resourceFragment) || parsed.fragment;
 
-			super("javascript/dynamic", resource);
+			super(JAVASCRIPT_MODULE_TYPE_DYNAMIC, resource);
 			/** @type {ContextModuleOptions} */
 			this.options = {
 				...options,
@@ -114,7 +115,7 @@ class ContextModule extends Module {
 				resourceFragment
 			};
 		} else {
-			super("javascript/dynamic");
+			super(JAVASCRIPT_MODULE_TYPE_DYNAMIC);
 			/** @type {ContextModuleOptions} */
 			this.options = {
 				...options,

--- a/lib/DelegatedModule.js
+++ b/lib/DelegatedModule.js
@@ -7,6 +7,7 @@
 
 const { OriginalSource, RawSource } = require("webpack-sources");
 const Module = require("./Module");
+const { JAVASCRIPT_MODULE_TYPE_DYNAMIC } = require("./ModuleTypeConstants");
 const RuntimeGlobals = require("./RuntimeGlobals");
 const DelegatedSourceDependency = require("./dependencies/DelegatedSourceDependency");
 const StaticExportsDependency = require("./dependencies/StaticExportsDependency");
@@ -40,7 +41,7 @@ const RUNTIME_REQUIREMENTS = new Set([
 
 class DelegatedModule extends Module {
 	constructor(sourceRequest, data, type, userRequest, originalRequest) {
-		super("javascript/dynamic", null);
+		super(JAVASCRIPT_MODULE_TYPE_DYNAMIC, null);
 
 		// Info from Factory
 		this.sourceRequest = sourceRequest;

--- a/lib/DllModule.js
+++ b/lib/DllModule.js
@@ -7,6 +7,7 @@
 
 const { RawSource } = require("webpack-sources");
 const Module = require("./Module");
+const { JAVASCRIPT_MODULE_TYPE_DYNAMIC } = require("./ModuleTypeConstants");
 const RuntimeGlobals = require("./RuntimeGlobals");
 const makeSerializable = require("./util/makeSerializable");
 
@@ -35,7 +36,7 @@ const RUNTIME_REQUIREMENTS = new Set([
 
 class DllModule extends Module {
 	constructor(context, dependencies, name) {
-		super("javascript/dynamic", context);
+		super(JAVASCRIPT_MODULE_TYPE_DYNAMIC, context);
 
 		// Info from Factory
 		this.dependencies = dependencies;

--- a/lib/ExportsInfoApiPlugin.js
+++ b/lib/ExportsInfoApiPlugin.js
@@ -5,11 +5,18 @@
 
 "use strict";
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("./ModuleTypeConstants");
 const ConstDependency = require("./dependencies/ConstDependency");
 const ExportsInfoDependency = require("./dependencies/ExportsInfoDependency");
 
 /** @typedef {import("./Compiler")} Compiler */
 /** @typedef {import("./javascript/JavascriptParser")} JavascriptParser */
+
+const PLUGIN_NAME = "ExportsInfoApiPlugin";
 
 class ExportsInfoApiPlugin {
 	/**
@@ -19,7 +26,7 @@ class ExportsInfoApiPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"ExportsInfoApiPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				compilation.dependencyTemplates.set(
 					ExportsInfoDependency,
@@ -32,7 +39,7 @@ class ExportsInfoApiPlugin {
 				const handler = parser => {
 					parser.hooks.expressionMemberChain
 						.for("__webpack_exports_info__")
-						.tap("ExportsInfoApiPlugin", (expr, members) => {
+						.tap(PLUGIN_NAME, (expr, members) => {
 							const dep =
 								members.length >= 2
 									? new ExportsInfoDependency(
@@ -47,7 +54,7 @@ class ExportsInfoApiPlugin {
 						});
 					parser.hooks.expression
 						.for("__webpack_exports_info__")
-						.tap("ExportsInfoApiPlugin", expr => {
+						.tap(PLUGIN_NAME, expr => {
 							const dep = new ConstDependency("true", expr.range);
 							dep.loc = expr.loc;
 							parser.state.module.addPresentationalDependency(dep);
@@ -55,14 +62,14 @@ class ExportsInfoApiPlugin {
 						});
 				};
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("ExportsInfoApiPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("ExportsInfoApiPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/esm")
-					.tap("ExportsInfoApiPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -10,6 +10,7 @@ const ConcatenationScope = require("./ConcatenationScope");
 const { UsageState } = require("./ExportsInfo");
 const InitFragment = require("./InitFragment");
 const Module = require("./Module");
+const { JAVASCRIPT_MODULE_TYPE_DYNAMIC } = require("./ModuleTypeConstants");
 const RuntimeGlobals = require("./RuntimeGlobals");
 const Template = require("./Template");
 const StaticExportsDependency = require("./dependencies/StaticExportsDependency");
@@ -378,7 +379,7 @@ const getSourceForDefaultCase = (optional, request, runtimeTemplate) => {
 
 class ExternalModule extends Module {
 	constructor(request, type, userRequest) {
-		super("javascript/dynamic", null);
+		super(JAVASCRIPT_MODULE_TYPE_DYNAMIC, null);
 
 		// Info from Factory
 		/** @type {string | string[] | Record<string, string | string[]>} */

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -35,6 +35,12 @@ const {
 	intersectRuntime
 } = require("./util/runtime");
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("./ModuleTypeConstants");
+
 /** @typedef {import("./Chunk")} Chunk */
 /** @typedef {import("./Compilation").AssetInfo} AssetInfo */
 /** @typedef {import("./Compiler")} Compiler */
@@ -50,6 +56,8 @@ const {
 
 /** @type {WeakMap<JavascriptParser, HMRJavascriptParserHooks>} */
 const parserHooksMap = new WeakMap();
+
+const PLUGIN_NAME = "HotModuleReplacementPlugin";
 
 class HotModuleReplacementPlugin {
 	/**
@@ -183,7 +191,7 @@ class HotModuleReplacementPlugin {
 		const applyModuleHot = parser => {
 			parser.hooks.evaluateIdentifier.for("module.hot").tap(
 				{
-					name: "HotModuleReplacementPlugin",
+					name: PLUGIN_NAME,
 					before: "NodeStuffPlugin"
 				},
 				expr => {
@@ -198,24 +206,24 @@ class HotModuleReplacementPlugin {
 			parser.hooks.call
 				.for("module.hot.accept")
 				.tap(
-					"HotModuleReplacementPlugin",
+					PLUGIN_NAME,
 					createAcceptHandler(parser, ModuleHotAcceptDependency)
 				);
 			parser.hooks.call
 				.for("module.hot.decline")
 				.tap(
-					"HotModuleReplacementPlugin",
+					PLUGIN_NAME,
 					createDeclineHandler(parser, ModuleHotDeclineDependency)
 				);
 			parser.hooks.expression
 				.for("module.hot")
-				.tap("HotModuleReplacementPlugin", createHMRExpressionHandler(parser));
+				.tap(PLUGIN_NAME, createHMRExpressionHandler(parser));
 		};
 
 		const applyImportMetaHot = parser => {
 			parser.hooks.evaluateIdentifier
 				.for("import.meta.webpackHot")
-				.tap("HotModuleReplacementPlugin", expr => {
+				.tap(PLUGIN_NAME, expr => {
 					return evaluateToIdentifier(
 						"import.meta.webpackHot",
 						"import.meta",
@@ -226,22 +234,22 @@ class HotModuleReplacementPlugin {
 			parser.hooks.call
 				.for("import.meta.webpackHot.accept")
 				.tap(
-					"HotModuleReplacementPlugin",
+					PLUGIN_NAME,
 					createAcceptHandler(parser, ImportMetaHotAcceptDependency)
 				);
 			parser.hooks.call
 				.for("import.meta.webpackHot.decline")
 				.tap(
-					"HotModuleReplacementPlugin",
+					PLUGIN_NAME,
 					createDeclineHandler(parser, ImportMetaHotDeclineDependency)
 				);
 			parser.hooks.expression
 				.for("import.meta.webpackHot")
-				.tap("HotModuleReplacementPlugin", createHMRExpressionHandler(parser));
+				.tap(PLUGIN_NAME, createHMRExpressionHandler(parser));
 		};
 
 		compiler.hooks.compilation.tap(
-			"HotModuleReplacementPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				// This applies the HMR plugin only to the targeted compiler
 				// It should not affect child compilations
@@ -289,40 +297,37 @@ class HotModuleReplacementPlugin {
 				const fullHashChunkModuleHashes = {};
 				const chunkModuleHashes = {};
 
-				compilation.hooks.record.tap(
-					"HotModuleReplacementPlugin",
-					(compilation, records) => {
-						if (records.hash === compilation.hash) return;
-						const chunkGraph = compilation.chunkGraph;
-						records.hash = compilation.hash;
-						records.hotIndex = hotIndex;
-						records.fullHashChunkModuleHashes = fullHashChunkModuleHashes;
-						records.chunkModuleHashes = chunkModuleHashes;
-						records.chunkHashes = {};
-						records.chunkRuntime = {};
-						for (const chunk of compilation.chunks) {
-							records.chunkHashes[chunk.id] = chunk.hash;
-							records.chunkRuntime[chunk.id] = getRuntimeKey(chunk.runtime);
-						}
-						records.chunkModuleIds = {};
-						for (const chunk of compilation.chunks) {
-							records.chunkModuleIds[chunk.id] = Array.from(
-								chunkGraph.getOrderedChunkModulesIterable(
-									chunk,
-									compareModulesById(chunkGraph)
-								),
-								m => chunkGraph.getModuleId(m)
-							);
-						}
+				compilation.hooks.record.tap(PLUGIN_NAME, (compilation, records) => {
+					if (records.hash === compilation.hash) return;
+					const chunkGraph = compilation.chunkGraph;
+					records.hash = compilation.hash;
+					records.hotIndex = hotIndex;
+					records.fullHashChunkModuleHashes = fullHashChunkModuleHashes;
+					records.chunkModuleHashes = chunkModuleHashes;
+					records.chunkHashes = {};
+					records.chunkRuntime = {};
+					for (const chunk of compilation.chunks) {
+						records.chunkHashes[chunk.id] = chunk.hash;
+						records.chunkRuntime[chunk.id] = getRuntimeKey(chunk.runtime);
 					}
-				);
+					records.chunkModuleIds = {};
+					for (const chunk of compilation.chunks) {
+						records.chunkModuleIds[chunk.id] = Array.from(
+							chunkGraph.getOrderedChunkModulesIterable(
+								chunk,
+								compareModulesById(chunkGraph)
+							),
+							m => chunkGraph.getModuleId(m)
+						);
+					}
+				});
 				/** @type {TupleSet<[Module, Chunk]>} */
 				const updatedModules = new TupleSet();
 				/** @type {TupleSet<[Module, Chunk]>} */
 				const fullHashModules = new TupleSet();
 				/** @type {TupleSet<[Module, RuntimeSpec]>} */
 				const nonCodeGeneratedModules = new TupleSet();
-				compilation.hooks.fullHash.tap("HotModuleReplacementPlugin", hash => {
+				compilation.hooks.fullHash.tap(PLUGIN_NAME, hash => {
 					const chunkGraph = compilation.chunkGraph;
 					const records = compilation.records;
 					for (const chunk of compilation.chunks) {
@@ -412,7 +417,7 @@ class HotModuleReplacementPlugin {
 				});
 				compilation.hooks.processAssets.tap(
 					{
-						name: "HotModuleReplacementPlugin",
+						name: PLUGIN_NAME,
 						stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
 					},
 					() => {
@@ -734,7 +739,7 @@ To fix this, make sure to include [runtime] in the output.hotUpdateMainFilename 
 				);
 
 				compilation.hooks.additionalTreeRuntimeRequirements.tap(
-					"HotModuleReplacementPlugin",
+					PLUGIN_NAME,
 					(chunk, runtimeRequirements) => {
 						runtimeRequirements.add(RuntimeGlobals.hmrDownloadManifest);
 						runtimeRequirements.add(RuntimeGlobals.hmrDownloadUpdateHandlers);
@@ -748,24 +753,24 @@ To fix this, make sure to include [runtime] in the output.hotUpdateMainFilename 
 				);
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("HotModuleReplacementPlugin", parser => {
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, parser => {
 						applyModuleHot(parser);
 						applyImportMetaHot(parser);
 					});
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("HotModuleReplacementPlugin", parser => {
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, parser => {
 						applyModuleHot(parser);
 					});
 				normalModuleFactory.hooks.parser
-					.for("javascript/esm")
-					.tap("HotModuleReplacementPlugin", parser => {
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, parser => {
 						applyImportMetaHot(parser);
 					});
 
 				NormalModule.getCompilationHooks(compilation).loader.tap(
-					"HotModuleReplacementPlugin",
+					PLUGIN_NAME,
 					context => {
 						context.hot = true;
 					}

--- a/lib/JavascriptMetaInfoPlugin.js
+++ b/lib/JavascriptMetaInfoPlugin.js
@@ -5,10 +5,17 @@
 
 "use strict";
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("./ModuleTypeConstants");
 const InnerGraph = require("./optimize/InnerGraph");
 
 /** @typedef {import("./Compiler")} Compiler */
 /** @typedef {import("./javascript/JavascriptParser")} JavascriptParser */
+
+const PLUGIN_NAME = "JavascriptMetaInfoPlugin";
 
 class JavascriptMetaInfoPlugin {
 	/**
@@ -18,14 +25,14 @@ class JavascriptMetaInfoPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"JavascriptMetaInfoPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				/**
 				 * @param {JavascriptParser} parser the parser
 				 * @returns {void}
 				 */
 				const handler = parser => {
-					parser.hooks.call.for("eval").tap("JavascriptMetaInfoPlugin", () => {
+					parser.hooks.call.for("eval").tap(PLUGIN_NAME, () => {
 						parser.state.module.buildInfo.moduleConcatenationBailout = "eval()";
 						parser.state.module.buildInfo.usingEval = true;
 						const currentSymbol = InnerGraph.getTopLevelSymbol(parser.state);
@@ -35,7 +42,7 @@ class JavascriptMetaInfoPlugin {
 							InnerGraph.bailout(parser.state);
 						}
 					});
-					parser.hooks.finish.tap("JavascriptMetaInfoPlugin", () => {
+					parser.hooks.finish.tap(PLUGIN_NAME, () => {
 						let topLevelDeclarations =
 							parser.state.module.buildInfo.topLevelDeclarations;
 						if (topLevelDeclarations === undefined) {
@@ -52,14 +59,14 @@ class JavascriptMetaInfoPlugin {
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("JavascriptMetaInfoPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("JavascriptMetaInfoPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/esm")
-					.tap("JavascriptMetaInfoPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/ModuleTypeConstants.js
+++ b/lib/ModuleTypeConstants.js
@@ -9,10 +9,12 @@
  * @type {Readonly<"javascript/auto">}
  */
 const JAVASCRIPT_MODULE_TYPE_AUTO = "javascript/auto";
+
 /**
  * @type {Readonly<"javascript/dynamic">}
  */
 const JAVASCRIPT_MODULE_TYPE_DYNAMIC = "javascript/dynamic";
+
 /**
  * @type {Readonly<"javascript/esm">}
  * This is the module type used for _strict_ ES Module syntax. This means that all legacy formats
@@ -26,7 +28,23 @@ const JAVASCRIPT_MODULE_TYPE_ESM = "javascript/esm";
  */
 const JSON_MODULE_TYPE = "json";
 
+/**
+ * @type {Readonly<"webassembly/async">}
+ * This is the module type used for WebAssembly modules. In webpack 5 they are always treated as async modules.
+ *
+ */
+const WEBASSEMBLY_MODULE_TYPE_ASYNC = "webassembly/async";
+
+/**
+ * @type {Readonly<"webassembly/sync">}
+ * This is the module type used for WebAssembly modules. In webpack 4 they are always treated as sync modules.
+ * There is a legacy option to support this usage in webpack 5 and up.
+ */
+const WEBASSEMBLY_MODULE_TYPE_SYNC = "webassembly/sync";
+
 exports.JAVASCRIPT_MODULE_TYPE_AUTO = JAVASCRIPT_MODULE_TYPE_AUTO;
 exports.JAVASCRIPT_MODULE_TYPE_DYNAMIC = JAVASCRIPT_MODULE_TYPE_DYNAMIC;
 exports.JAVASCRIPT_MODULE_TYPE_ESM = JAVASCRIPT_MODULE_TYPE_ESM;
 exports.JSON_MODULE_TYPE = JSON_MODULE_TYPE;
+exports.WEBASSEMBLY_MODULE_TYPE_ASYNC = WEBASSEMBLY_MODULE_TYPE_ASYNC;
+exports.WEBASSEMBLY_MODULE_TYPE_SYNC = WEBASSEMBLY_MODULE_TYPE_SYNC;

--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC
+} = require("./ModuleTypeConstants");
 const NodeStuffInWebError = require("./NodeStuffInWebError");
 const RuntimeGlobals = require("./RuntimeGlobals");
 const CachedConstDependency = require("./dependencies/CachedConstDependency");
@@ -22,6 +26,8 @@ const { parseResource } = require("./util/identifier");
 /** @typedef {import("./DependencyTemplates")} DependencyTemplates */
 /** @typedef {import("./RuntimeTemplate")} RuntimeTemplate */
 
+const PLUGIN_NAME = "NodeStuffPlugin";
+
 class NodeStuffPlugin {
 	constructor(options) {
 		this.options = options;
@@ -35,7 +41,7 @@ class NodeStuffPlugin {
 	apply(compiler) {
 		const options = this.options;
 		compiler.hooks.compilation.tap(
-			"NodeStuffPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				const handler = (parser, parserOptions) => {
 					if (parserOptions.node === false) return;
@@ -47,29 +53,27 @@ class NodeStuffPlugin {
 
 					if (localOptions.global !== false) {
 						const withWarning = localOptions.global === "warn";
-						parser.hooks.expression
-							.for("global")
-							.tap("NodeStuffPlugin", expr => {
-								const dep = new ConstDependency(
-									RuntimeGlobals.global,
-									expr.range,
-									[RuntimeGlobals.global]
-								);
-								dep.loc = expr.loc;
-								parser.state.module.addPresentationalDependency(dep);
+						parser.hooks.expression.for("global").tap(PLUGIN_NAME, expr => {
+							const dep = new ConstDependency(
+								RuntimeGlobals.global,
+								expr.range,
+								[RuntimeGlobals.global]
+							);
+							dep.loc = expr.loc;
+							parser.state.module.addPresentationalDependency(dep);
 
-								// TODO webpack 6 remove
-								if (withWarning) {
-									parser.state.module.addWarning(
-										new NodeStuffInWebError(
-											dep.loc,
-											"global",
-											"The global namespace object is a Node.js feature and isn't available in browsers."
-										)
-									);
-								}
-							});
-						parser.hooks.rename.for("global").tap("NodeStuffPlugin", expr => {
+							// TODO webpack 6 remove
+							if (withWarning) {
+								parser.state.module.addWarning(
+									new NodeStuffInWebError(
+										dep.loc,
+										"global",
+										"The global namespace object is a Node.js feature and isn't available in browsers."
+									)
+								);
+							}
+						});
+						parser.hooks.rename.for("global").tap(PLUGIN_NAME, expr => {
 							const dep = new ConstDependency(
 								RuntimeGlobals.global,
 								expr.range,
@@ -84,7 +88,7 @@ class NodeStuffPlugin {
 					const setModuleConstant = (expressionName, fn, warning) => {
 						parser.hooks.expression
 							.for(expressionName)
-							.tap("NodeStuffPlugin", expr => {
+							.tap(PLUGIN_NAME, expr => {
 								const dep = new CachedConstDependency(
 									JSON.stringify(fn(parser.state.module)),
 									expr.range,
@@ -129,7 +133,7 @@ class NodeStuffPlugin {
 
 						parser.hooks.evaluateIdentifier
 							.for("__filename")
-							.tap("NodeStuffPlugin", expr => {
+							.tap(PLUGIN_NAME, expr => {
 								if (!parser.state.module) return;
 								const resource = parseResource(parser.state.module.resource);
 								return evaluateToString(resource.path)(expr);
@@ -156,7 +160,7 @@ class NodeStuffPlugin {
 
 						parser.hooks.evaluateIdentifier
 							.for("__dirname")
-							.tap("NodeStuffPlugin", expr => {
+							.tap(PLUGIN_NAME, expr => {
 								if (!parser.state.module) return;
 								return evaluateToString(parser.state.module.context)(expr);
 							});
@@ -164,7 +168,7 @@ class NodeStuffPlugin {
 					parser.hooks.expression
 						.for("require.extensions")
 						.tap(
-							"NodeStuffPlugin",
+							PLUGIN_NAME,
 							expressionIsUnsupported(
 								parser,
 								"require.extensions is not supported by webpack. Use a loader instead."
@@ -173,11 +177,11 @@ class NodeStuffPlugin {
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("NodeStuffPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("NodeStuffPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -22,6 +22,7 @@ const ModuleBuildError = require("./ModuleBuildError");
 const ModuleError = require("./ModuleError");
 const ModuleGraphConnection = require("./ModuleGraphConnection");
 const ModuleParseError = require("./ModuleParseError");
+const { JAVASCRIPT_MODULE_TYPE_AUTO } = require("./ModuleTypeConstants");
 const ModuleWarning = require("./ModuleWarning");
 const RuntimeGlobals = require("./RuntimeGlobals");
 const UnhandledSchemeError = require("./UnhandledSchemeError");
@@ -339,7 +340,7 @@ class NormalModule extends Module {
 	 */
 	identifier() {
 		if (this.layer === null) {
-			if (this.type === "javascript/auto") {
+			if (this.type === JAVASCRIPT_MODULE_TYPE_AUTO) {
 				return this.request;
 			} else {
 				return `${this.type}|${this.request}`;

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -18,6 +18,7 @@ const ChunkGraph = require("./ChunkGraph");
 const Module = require("./Module");
 const ModuleFactory = require("./ModuleFactory");
 const ModuleGraph = require("./ModuleGraph");
+const { JAVASCRIPT_MODULE_TYPE_AUTO } = require("./ModuleTypeConstants");
 const NormalModule = require("./NormalModule");
 const BasicEffectRulePlugin = require("./rules/BasicEffectRulePlugin");
 const BasicMatcherRulePlugin = require("./rules/BasicMatcherRulePlugin");
@@ -489,7 +490,7 @@ class NormalModuleFactory extends ModuleFactory {
 							-settings.type.length - 10
 						);
 					} else {
-						settings.type = "javascript/auto";
+						settings.type = JAVASCRIPT_MODULE_TYPE_AUTO;
 						const resourceDataForRules = matchResourceData || resourceData;
 						const result = this.ruleSet.exec({
 							resource: resourceDataForRules.path,

--- a/lib/ProvidePlugin.js
+++ b/lib/ProvidePlugin.js
@@ -5,11 +5,18 @@
 
 "use strict";
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("./ModuleTypeConstants");
 const ConstDependency = require("./dependencies/ConstDependency");
 const ProvidedDependency = require("./dependencies/ProvidedDependency");
 const { approve } = require("./javascript/JavascriptParserHelpers");
 
 /** @typedef {import("./Compiler")} Compiler */
+
+const PLUGIN_NAME = "ProvidePlugin";
 
 class ProvidePlugin {
 	/**
@@ -27,7 +34,7 @@ class ProvidePlugin {
 	apply(compiler) {
 		const definitions = this.definitions;
 		compiler.hooks.compilation.tap(
-			"ProvidePlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				compilation.dependencyTemplates.set(
 					ConstDependency,
@@ -48,11 +55,11 @@ class ProvidePlugin {
 						if (splittedName.length > 0) {
 							splittedName.slice(1).forEach((_, i) => {
 								const name = splittedName.slice(0, i + 1).join(".");
-								parser.hooks.canRename.for(name).tap("ProvidePlugin", approve);
+								parser.hooks.canRename.for(name).tap(PLUGIN_NAME, approve);
 							});
 						}
 
-						parser.hooks.expression.for(name).tap("ProvidePlugin", expr => {
+						parser.hooks.expression.for(name).tap(PLUGIN_NAME, expr => {
 							const nameIdentifier = name.includes(".")
 								? `__webpack_provided_${name.replace(/\./g, "_dot_")}`
 								: name;
@@ -67,7 +74,7 @@ class ProvidePlugin {
 							return true;
 						});
 
-						parser.hooks.call.for(name).tap("ProvidePlugin", expr => {
+						parser.hooks.call.for(name).tap(PLUGIN_NAME, expr => {
 							const nameIdentifier = name.includes(".")
 								? `__webpack_provided_${name.replace(/\./g, "_dot_")}`
 								: name;
@@ -85,14 +92,14 @@ class ProvidePlugin {
 					});
 				};
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("ProvidePlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("ProvidePlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/esm")
-					.tap("ProvidePlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/RawModule.js
+++ b/lib/RawModule.js
@@ -7,6 +7,7 @@
 
 const { OriginalSource, RawSource } = require("webpack-sources");
 const Module = require("./Module");
+const { JAVASCRIPT_MODULE_TYPE_DYNAMIC } = require("./ModuleTypeConstants");
 const makeSerializable = require("./util/makeSerializable");
 
 /** @typedef {import("webpack-sources").Source} Source */
@@ -35,7 +36,7 @@ class RawModule extends Module {
 	 * @param {ReadonlySet<string>=} runtimeRequirements runtime requirements needed for the source code
 	 */
 	constructor(source, identifier, readableIdentifier, runtimeRequirements) {
-		super("javascript/dynamic", null);
+		super(JAVASCRIPT_MODULE_TYPE_DYNAMIC, null);
 		this.sourceStr = source;
 		this.identifierStr = identifier || this.sourceStr;
 		this.readableIdentifierStr = readableIdentifier || this.identifierStr;

--- a/lib/RequireJsStuffPlugin.js
+++ b/lib/RequireJsStuffPlugin.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC
+} = require("./ModuleTypeConstants");
 const RuntimeGlobals = require("./RuntimeGlobals");
 const ConstDependency = require("./dependencies/ConstDependency");
 const {
@@ -12,6 +16,8 @@ const {
 } = require("./javascript/JavascriptParserHelpers");
 
 /** @typedef {import("./Compiler")} Compiler */
+
+const PLUGIN_NAME = "RequireJsStuffPlugin";
 
 module.exports = class RequireJsStuffPlugin {
 	/**
@@ -21,7 +27,7 @@ module.exports = class RequireJsStuffPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"RequireJsStuffPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				compilation.dependencyTemplates.set(
 					ConstDependency,
@@ -37,27 +43,21 @@ module.exports = class RequireJsStuffPlugin {
 
 					parser.hooks.call
 						.for("require.config")
-						.tap(
-							"RequireJsStuffPlugin",
-							toConstantDependency(parser, "undefined")
-						);
+						.tap(PLUGIN_NAME, toConstantDependency(parser, "undefined"));
 					parser.hooks.call
 						.for("requirejs.config")
-						.tap(
-							"RequireJsStuffPlugin",
-							toConstantDependency(parser, "undefined")
-						);
+						.tap(PLUGIN_NAME, toConstantDependency(parser, "undefined"));
 
 					parser.hooks.expression
 						.for("require.version")
 						.tap(
-							"RequireJsStuffPlugin",
+							PLUGIN_NAME,
 							toConstantDependency(parser, JSON.stringify("0.0.0"))
 						);
 					parser.hooks.expression
 						.for("requirejs.onError")
 						.tap(
-							"RequireJsStuffPlugin",
+							PLUGIN_NAME,
 							toConstantDependency(
 								parser,
 								RuntimeGlobals.uncaughtErrorHandler,
@@ -66,11 +66,11 @@ module.exports = class RequireJsStuffPlugin {
 						);
 				};
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("RequireJsStuffPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("RequireJsStuffPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/UseStrictPlugin.js
+++ b/lib/UseStrictPlugin.js
@@ -5,9 +5,16 @@
 
 "use strict";
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("./ModuleTypeConstants");
 const ConstDependency = require("./dependencies/ConstDependency");
 
 /** @typedef {import("./Compiler")} Compiler */
+
+const PLUGIN_NAME = "UseStrictPlugin";
 
 class UseStrictPlugin {
 	/**
@@ -17,10 +24,10 @@ class UseStrictPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"UseStrictPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				const handler = parser => {
-					parser.hooks.program.tap("UseStrictPlugin", ast => {
+					parser.hooks.program.tap(PLUGIN_NAME, ast => {
 						const firstNode = ast.body[0];
 						if (
 							firstNode &&
@@ -40,14 +47,14 @@ class UseStrictPlugin {
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("UseStrictPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("UseStrictPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/esm")
-					.tap("UseStrictPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/WebpackIsIncludedPlugin.js
+++ b/lib/WebpackIsIncludedPlugin.js
@@ -6,6 +6,11 @@
 "use strict";
 
 const IgnoreErrorModuleFactory = require("./IgnoreErrorModuleFactory");
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("./ModuleTypeConstants");
 const WebpackIsIncludedDependency = require("./dependencies/WebpackIsIncludedDependency");
 const {
 	toConstantDependency
@@ -16,6 +21,8 @@ const {
 /** @typedef {import("./Module")} Module */
 /** @typedef {import("./javascript/JavascriptParser")} JavascriptParser */
 
+const PLUGIN_NAME = "WebpackIsIncludedPlugin";
+
 class WebpackIsIncludedPlugin {
 	/**
 	 * @param {Compiler} compiler the compiler instance
@@ -23,7 +30,7 @@ class WebpackIsIncludedPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"WebpackIsIncludedPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				compilation.dependencyFactories.set(
 					WebpackIsIncludedDependency,
@@ -41,7 +48,7 @@ class WebpackIsIncludedPlugin {
 				const handler = parser => {
 					parser.hooks.call
 						.for("__webpack_is_included__")
-						.tap("WebpackIsIncludedPlugin", expr => {
+						.tap(PLUGIN_NAME, expr => {
 							if (
 								expr.type !== "CallExpression" ||
 								expr.arguments.length !== 1 ||
@@ -64,19 +71,19 @@ class WebpackIsIncludedPlugin {
 					parser.hooks.typeof
 						.for("__webpack_is_included__")
 						.tap(
-							"WebpackIsIncludedPlugin",
+							PLUGIN_NAME,
 							toConstantDependency(parser, JSON.stringify("function"))
 						);
 				};
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("WebpackIsIncludedPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("WebpackIsIncludedPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/esm")
-					.tap("WebpackIsIncludedPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -7,6 +7,14 @@
 
 const fs = require("fs");
 const path = require("path");
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JSON_MODULE_TYPE,
+	WEBASSEMBLY_MODULE_TYPE_ASYNC,
+	JAVASCRIPT_MODULE_TYPE_ESM,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
+	WEBASSEMBLY_MODULE_TYPE_SYNC
+} = require("../ModuleTypeConstants");
 const Template = require("../Template");
 const { cleverMerge } = require("../util/cleverMerge");
 const {
@@ -517,7 +525,7 @@ const applyModuleDefaults = (
 
 	A(module, "defaultRules", () => {
 		const esm = {
-			type: "javascript/esm",
+			type: JAVASCRIPT_MODULE_TYPE_ESM,
 			resolve: {
 				byDependency: {
 					esm: {
@@ -527,21 +535,21 @@ const applyModuleDefaults = (
 			}
 		};
 		const commonjs = {
-			type: "javascript/dynamic"
+			type: JAVASCRIPT_MODULE_TYPE_DYNAMIC
 		};
 		/** @type {RuleSetRules} */
 		const rules = [
 			{
 				mimetype: "application/node",
-				type: "javascript/auto"
+				type: JAVASCRIPT_MODULE_TYPE_AUTO
 			},
 			{
 				test: /\.json$/i,
-				type: "json"
+				type: JSON_MODULE_TYPE
 			},
 			{
 				mimetype: "application/json",
-				type: "json"
+				type: JSON_MODULE_TYPE
 			},
 			{
 				test: /\.mjs$/i,
@@ -574,7 +582,7 @@ const applyModuleDefaults = (
 		];
 		if (asyncWebAssembly) {
 			const wasm = {
-				type: "webassembly/async",
+				type: WEBASSEMBLY_MODULE_TYPE_ASYNC,
 				rules: [
 					{
 						descriptionData: {
@@ -596,7 +604,7 @@ const applyModuleDefaults = (
 			});
 		} else if (syncWebAssembly) {
 			const wasm = {
-				type: "webassembly/sync",
+				type: WEBASSEMBLY_MODULE_TYPE_SYNC,
 				rules: [
 					{
 						descriptionData: {
@@ -667,7 +675,7 @@ const applyModuleDefaults = (
 			},
 			{
 				assert: { type: "json" },
-				type: "json"
+				type: JSON_MODULE_TYPE
 			}
 		);
 		return rules;

--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -8,6 +8,7 @@
 const { OriginalSource, RawSource } = require("webpack-sources");
 const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
 const Module = require("../Module");
+const { JAVASCRIPT_MODULE_TYPE_DYNAMIC } = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
 const StaticExportsDependency = require("../dependencies/StaticExportsDependency");
@@ -44,7 +45,7 @@ class ContainerEntryModule extends Module {
 	 * @param {string} shareScope name of the share scope
 	 */
 	constructor(name, exposes, shareScope) {
-		super("javascript/dynamic", null);
+		super(JAVASCRIPT_MODULE_TYPE_DYNAMIC, null);
 		this._name = name;
 		this._exposes = exposes;
 		this._shareScope = shareScope;

--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -5,6 +5,14 @@
 "use strict";
 
 const { Tracer } = require("chrome-trace-event");
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
+	JAVASCRIPT_MODULE_TYPE_ESM,
+	WEBASSEMBLY_MODULE_TYPE_ASYNC,
+	WEBASSEMBLY_MODULE_TYPE_SYNC,
+	JSON_MODULE_TYPE
+} = require("../ModuleTypeConstants");
 const createSchemaValidation = require("../util/create-schema-validation");
 const { dirname, mkdirpSync } = require("../util/fs");
 
@@ -182,7 +190,7 @@ const createTrace = (fs, outputPath) => {
 	};
 };
 
-const pluginName = "ProfilingPlugin";
+const PLUGIN_NAME = "ProfilingPlugin";
 
 class ProfilingPlugin {
 	/**
@@ -216,7 +224,7 @@ class ProfilingPlugin {
 		});
 
 		compiler.hooks.compilation.tap(
-			pluginName,
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory, contextModuleFactory }) => {
 				interceptAllHooksFor(compilation, tracer, "Compilation");
 				interceptAllHooksFor(
@@ -237,7 +245,7 @@ class ProfilingPlugin {
 		// We need to write out the CPU profile when we are all done.
 		compiler.hooks.done.tapAsync(
 			{
-				name: pluginName,
+				name: PLUGIN_NAME,
 				stage: Infinity
 			},
 			(stats, callback) => {
@@ -312,18 +320,18 @@ const interceptAllHooksFor = (instance, tracer, logLabel) => {
 
 const interceptAllParserHooks = (moduleFactory, tracer) => {
 	const moduleTypes = [
-		"javascript/auto",
-		"javascript/dynamic",
-		"javascript/esm",
-		"json",
-		"webassembly/async",
-		"webassembly/sync"
+		JAVASCRIPT_MODULE_TYPE_AUTO,
+		JAVASCRIPT_MODULE_TYPE_DYNAMIC,
+		JAVASCRIPT_MODULE_TYPE_ESM,
+		JSON_MODULE_TYPE,
+		WEBASSEMBLY_MODULE_TYPE_ASYNC,
+		WEBASSEMBLY_MODULE_TYPE_SYNC
 	];
 
 	moduleTypes.forEach(moduleType => {
 		moduleFactory.hooks.parser
 			.for(moduleType)
-			.tap("ProfilingPlugin", (parser, parserOpts) => {
+			.tap(PLUGIN_NAME, (parser, parserOpts) => {
 				interceptAllHooksFor(parser, tracer, "Parser");
 			});
 	});
@@ -347,7 +355,7 @@ const makeInterceptorFor = (instance, tracer) => hookName => ({
 		const { name, type, fn } = tapInfo;
 		const newFn =
 			// Don't tap our own hooks to ensure stream can close cleanly
-			name === pluginName
+			name === PLUGIN_NAME
 				? fn
 				: makeNewProfiledTapFn(hookName, tracer, {
 						name,
@@ -418,7 +426,7 @@ const makeNewProfiledTapFn = (hookName, tracer, { name, type, fn }) => {
 				const id = ++tracer.counter;
 				// Do not instrument ourself due to the CPU
 				// profile needing to be the last event in the trace.
-				if (name === pluginName) {
+				if (name === PLUGIN_NAME) {
 					return fn(...args);
 				}
 

--- a/lib/dependencies/AMDPlugin.js
+++ b/lib/dependencies/AMDPlugin.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC
+} = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const {
 	approve,
@@ -31,6 +35,8 @@ const UnsupportedDependency = require("./UnsupportedDependency");
 /** @typedef {import("../../declarations/WebpackOptions").ModuleOptionsNormalized} ModuleOptions */
 /** @typedef {import("../Compiler")} Compiler */
 
+const PLUGIN_NAME = "AMDPlugin";
+
 class AMDPlugin {
 	/**
 	 * @param {Record<string, any>} amdOptions the AMD options
@@ -47,7 +53,7 @@ class AMDPlugin {
 	apply(compiler) {
 		const amdOptions = this.amdOptions;
 		compiler.hooks.compilation.tap(
-			"AMDPlugin",
+			PLUGIN_NAME,
 			(compilation, { contextModuleFactory, normalModuleFactory }) => {
 				compilation.dependencyTemplates.set(
 					AMDRequireDependency,
@@ -94,25 +100,25 @@ class AMDPlugin {
 
 				compilation.hooks.runtimeRequirementInModule
 					.for(RuntimeGlobals.amdDefine)
-					.tap("AMDPlugin", (module, set) => {
+					.tap(PLUGIN_NAME, (module, set) => {
 						set.add(RuntimeGlobals.require);
 					});
 
 				compilation.hooks.runtimeRequirementInModule
 					.for(RuntimeGlobals.amdOptions)
-					.tap("AMDPlugin", (module, set) => {
+					.tap(PLUGIN_NAME, (module, set) => {
 						set.add(RuntimeGlobals.requireScope);
 					});
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.amdDefine)
-					.tap("AMDPlugin", (chunk, set) => {
+					.tap(PLUGIN_NAME, (chunk, set) => {
 						compilation.addRuntimeModule(chunk, new AMDDefineRuntimeModule());
 					});
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.amdOptions)
-					.tap("AMDPlugin", (chunk, set) => {
+					.tap(PLUGIN_NAME, (chunk, set) => {
 						compilation.addRuntimeModule(
 							chunk,
 							new AMDOptionsRuntimeModule(amdOptions)
@@ -126,7 +132,7 @@ class AMDPlugin {
 						parser.hooks.expression
 							.for(optionExpr)
 							.tap(
-								"AMDPlugin",
+								PLUGIN_NAME,
 								toConstantDependency(parser, RuntimeGlobals.amdOptions, [
 									RuntimeGlobals.amdOptions
 								])
@@ -134,16 +140,16 @@ class AMDPlugin {
 						parser.hooks.evaluateIdentifier
 							.for(optionExpr)
 							.tap(
-								"AMDPlugin",
+								PLUGIN_NAME,
 								evaluateToIdentifier(optionExpr, rootName, getMembers, true)
 							);
 						parser.hooks.evaluateTypeof
 							.for(optionExpr)
-							.tap("AMDPlugin", evaluateToString("object"));
+							.tap(PLUGIN_NAME, evaluateToString("object"));
 						parser.hooks.typeof
 							.for(optionExpr)
 							.tap(
-								"AMDPlugin",
+								PLUGIN_NAME,
 								toConstantDependency(parser, JSON.stringify("object"))
 							);
 					};
@@ -161,7 +167,7 @@ class AMDPlugin {
 						() => []
 					);
 
-					parser.hooks.expression.for("define").tap("AMDPlugin", expr => {
+					parser.hooks.expression.for("define").tap(PLUGIN_NAME, expr => {
 						const dep = new ConstDependency(
 							RuntimeGlobals.amdDefine,
 							expr.range,
@@ -174,14 +180,14 @@ class AMDPlugin {
 					parser.hooks.typeof
 						.for("define")
 						.tap(
-							"AMDPlugin",
+							PLUGIN_NAME,
 							toConstantDependency(parser, JSON.stringify("function"))
 						);
 					parser.hooks.evaluateTypeof
 						.for("define")
-						.tap("AMDPlugin", evaluateToString("function"));
-					parser.hooks.canRename.for("define").tap("AMDPlugin", approve);
-					parser.hooks.rename.for("define").tap("AMDPlugin", expr => {
+						.tap(PLUGIN_NAME, evaluateToString("function"));
+					parser.hooks.canRename.for("define").tap(PLUGIN_NAME, approve);
+					parser.hooks.rename.for("define").tap(PLUGIN_NAME, expr => {
 						const dep = new ConstDependency(
 							RuntimeGlobals.amdDefine,
 							expr.range,
@@ -194,20 +200,20 @@ class AMDPlugin {
 					parser.hooks.typeof
 						.for("require")
 						.tap(
-							"AMDPlugin",
+							PLUGIN_NAME,
 							toConstantDependency(parser, JSON.stringify("function"))
 						);
 					parser.hooks.evaluateTypeof
 						.for("require")
-						.tap("AMDPlugin", evaluateToString("function"));
+						.tap(PLUGIN_NAME, evaluateToString("function"));
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("AMDPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("AMDPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/dependencies/CommonJsPlugin.js
+++ b/lib/dependencies/CommonJsPlugin.js
@@ -25,15 +25,21 @@ const CommonJsExportsParserPlugin = require("./CommonJsExportsParserPlugin");
 const CommonJsImportsParserPlugin = require("./CommonJsImportsParserPlugin");
 
 const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC
+} = require("../ModuleTypeConstants");
+const {
 	evaluateToIdentifier,
 	toConstantDependency
 } = require("../javascript/JavascriptParserHelpers");
 const CommonJsExportRequireDependency = require("./CommonJsExportRequireDependency");
 
+const PLUGIN_NAME = "CommonJsPlugin";
+
 class CommonJsPlugin {
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"CommonJsPlugin",
+			PLUGIN_NAME,
 			(compilation, { contextModuleFactory, normalModuleFactory }) => {
 				compilation.dependencyFactories.set(
 					CommonJsRequireDependency,
@@ -126,21 +132,21 @@ class CommonJsPlugin {
 
 				compilation.hooks.runtimeRequirementInModule
 					.for(RuntimeGlobals.harmonyModuleDecorator)
-					.tap("CommonJsPlugin", (module, set) => {
+					.tap(PLUGIN_NAME, (module, set) => {
 						set.add(RuntimeGlobals.module);
 						set.add(RuntimeGlobals.requireScope);
 					});
 
 				compilation.hooks.runtimeRequirementInModule
 					.for(RuntimeGlobals.nodeModuleDecorator)
-					.tap("CommonJsPlugin", (module, set) => {
+					.tap(PLUGIN_NAME, (module, set) => {
 						set.add(RuntimeGlobals.module);
 						set.add(RuntimeGlobals.requireScope);
 					});
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.harmonyModuleDecorator)
-					.tap("CommonJsPlugin", (chunk, set) => {
+					.tap(PLUGIN_NAME, (chunk, set) => {
 						compilation.addRuntimeModule(
 							chunk,
 							new HarmonyModuleDecoratorRuntimeModule()
@@ -149,7 +155,7 @@ class CommonJsPlugin {
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.nodeModuleDecorator)
-					.tap("CommonJsPlugin", (chunk, set) => {
+					.tap(PLUGIN_NAME, (chunk, set) => {
 						compilation.addRuntimeModule(
 							chunk,
 							new NodeModuleDecoratorRuntimeModule()
@@ -162,14 +168,14 @@ class CommonJsPlugin {
 					parser.hooks.typeof
 						.for("module")
 						.tap(
-							"CommonJsPlugin",
+							PLUGIN_NAME,
 							toConstantDependency(parser, JSON.stringify("object"))
 						);
 
 					parser.hooks.expression
 						.for("require.main")
 						.tap(
-							"CommonJsPlugin",
+							PLUGIN_NAME,
 							toConstantDependency(
 								parser,
 								`${RuntimeGlobals.moduleCache}[${RuntimeGlobals.entryModuleId}]`,
@@ -178,7 +184,7 @@ class CommonJsPlugin {
 						);
 					parser.hooks.expression
 						.for("module.loaded")
-						.tap("CommonJsPlugin", expr => {
+						.tap(PLUGIN_NAME, expr => {
 							parser.state.module.buildInfo.moduleConcatenationBailout =
 								"module.loaded";
 							const dep = new RuntimeRequirementsDependency([
@@ -189,21 +195,19 @@ class CommonJsPlugin {
 							return true;
 						});
 
-					parser.hooks.expression
-						.for("module.id")
-						.tap("CommonJsPlugin", expr => {
-							parser.state.module.buildInfo.moduleConcatenationBailout =
-								"module.id";
-							const dep = new RuntimeRequirementsDependency([
-								RuntimeGlobals.moduleId
-							]);
-							dep.loc = expr.loc;
-							parser.state.module.addPresentationalDependency(dep);
-							return true;
-						});
+					parser.hooks.expression.for("module.id").tap(PLUGIN_NAME, expr => {
+						parser.state.module.buildInfo.moduleConcatenationBailout =
+							"module.id";
+						const dep = new RuntimeRequirementsDependency([
+							RuntimeGlobals.moduleId
+						]);
+						dep.loc = expr.loc;
+						parser.state.module.addPresentationalDependency(dep);
+						return true;
+					});
 
 					parser.hooks.evaluateIdentifier.for("module.hot").tap(
-						"CommonJsPlugin",
+						PLUGIN_NAME,
 						evaluateToIdentifier("module.hot", "module", () => ["hot"], null)
 					);
 
@@ -214,11 +218,11 @@ class CommonJsPlugin {
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("CommonJsPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("CommonJsPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/dependencies/HarmonyDetectionParserPlugin.js
+++ b/lib/dependencies/HarmonyDetectionParserPlugin.js
@@ -5,6 +5,7 @@
 
 "use strict";
 
+const { JAVASCRIPT_MODULE_TYPE_ESM } = require("../ModuleTypeConstants");
 const DynamicExports = require("./DynamicExports");
 const HarmonyCompatibilityDependency = require("./HarmonyCompatibilityDependency");
 const HarmonyExports = require("./HarmonyExports");
@@ -17,7 +18,8 @@ module.exports = class HarmonyDetectionParserPlugin {
 
 	apply(parser) {
 		parser.hooks.program.tap("HarmonyDetectionParserPlugin", ast => {
-			const isStrictHarmony = parser.state.module.type === "javascript/esm";
+			const isStrictHarmony =
+				parser.state.module.type === JAVASCRIPT_MODULE_TYPE_ESM;
 			const isHarmony =
 				isStrictHarmony ||
 				ast.body.some(

--- a/lib/dependencies/HarmonyModulesPlugin.js
+++ b/lib/dependencies/HarmonyModulesPlugin.js
@@ -16,12 +16,18 @@ const HarmonyExportSpecifierDependency = require("./HarmonyExportSpecifierDepend
 const HarmonyImportSideEffectDependency = require("./HarmonyImportSideEffectDependency");
 const HarmonyImportSpecifierDependency = require("./HarmonyImportSpecifierDependency");
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("../ModuleTypeConstants");
 const HarmonyDetectionParserPlugin = require("./HarmonyDetectionParserPlugin");
 const HarmonyExportDependencyParserPlugin = require("./HarmonyExportDependencyParserPlugin");
 const HarmonyImportDependencyParserPlugin = require("./HarmonyImportDependencyParserPlugin");
 const HarmonyTopLevelThisParserPlugin = require("./HarmonyTopLevelThisParserPlugin");
 
 /** @typedef {import("../Compiler")} Compiler */
+
+const PLUGIN_NAME = "HarmonyModulesPlugin";
 
 class HarmonyModulesPlugin {
 	constructor(options) {
@@ -35,7 +41,7 @@ class HarmonyModulesPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"HarmonyModulesPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				compilation.dependencyTemplates.set(
 					HarmonyCompatibilityDependency,
@@ -119,11 +125,11 @@ class HarmonyModulesPlugin {
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("HarmonyModulesPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/esm")
-					.tap("HarmonyModulesPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/dependencies/ImportMetaContextPlugin.js
+++ b/lib/dependencies/ImportMetaContextPlugin.js
@@ -5,12 +5,18 @@
 
 "use strict";
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("../ModuleTypeConstants");
 const ContextElementDependency = require("./ContextElementDependency");
 const ImportMetaContextDependency = require("./ImportMetaContextDependency");
 const ImportMetaContextDependencyParserPlugin = require("./ImportMetaContextDependencyParserPlugin");
 
 /** @typedef {import("../../declarations/WebpackOptions").ResolveOptions} ResolveOptions */
 /** @typedef {import("../Compiler")} Compiler */
+
+const PLUGIN_NAME = "ImportMetaContextPlugin";
 
 class ImportMetaContextPlugin {
 	/**
@@ -20,7 +26,7 @@ class ImportMetaContextPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"RequireContextPlugin",
+			PLUGIN_NAME,
 			(compilation, { contextModuleFactory, normalModuleFactory }) => {
 				compilation.dependencyFactories.set(
 					ImportMetaContextDependency,
@@ -46,11 +52,11 @@ class ImportMetaContextPlugin {
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("ImportMetaContextPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/esm")
-					.tap("ImportMetaContextPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/dependencies/ImportMetaPlugin.js
+++ b/lib/dependencies/ImportMetaPlugin.js
@@ -7,6 +7,10 @@
 
 const { pathToFileURL } = require("url");
 const ModuleDependencyWarning = require("../ModuleDependencyWarning");
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("../ModuleTypeConstants");
 const Template = require("../Template");
 const BasicEvaluatedExpression = require("../javascript/BasicEvaluatedExpression");
 const {
@@ -29,13 +33,15 @@ const getCriticalDependencyWarning = memoize(() =>
 	require("./CriticalDependencyWarning")
 );
 
+const PLUGIN_NAME = "ImportMetaPlugin";
+
 class ImportMetaPlugin {
 	/**
 	 * @param {Compiler} compiler compiler
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"ImportMetaPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				/**
 				 * @param {NormalModule} module module
@@ -56,7 +62,7 @@ class ImportMetaPlugin {
 
 						parser.hooks.expression
 							.for("import.meta")
-							.tap("ImportMetaPlugin", metaProperty => {
+							.tap(PLUGIN_NAME, metaProperty => {
 								const dep = new ConstDependency(
 									importMetaName,
 									metaProperty.range
@@ -72,12 +78,12 @@ class ImportMetaPlugin {
 					parser.hooks.typeof
 						.for("import.meta")
 						.tap(
-							"ImportMetaPlugin",
+							PLUGIN_NAME,
 							toConstantDependency(parser, JSON.stringify("object"))
 						);
 					parser.hooks.expression
 						.for("import.meta")
-						.tap("ImportMetaPlugin", metaProperty => {
+						.tap(PLUGIN_NAME, metaProperty => {
 							const CriticalDependencyWarning = getCriticalDependencyWarning();
 							parser.state.module.addWarning(
 								new ModuleDependencyWarning(
@@ -98,9 +104,9 @@ class ImportMetaPlugin {
 						});
 					parser.hooks.evaluateTypeof
 						.for("import.meta")
-						.tap("ImportMetaPlugin", evaluateToString("object"));
+						.tap(PLUGIN_NAME, evaluateToString("object"));
 					parser.hooks.evaluateIdentifier.for("import.meta").tap(
-						"ImportMetaPlugin",
+						PLUGIN_NAME,
 						evaluateToIdentifier("import.meta", "import.meta", () => [], true)
 					);
 
@@ -108,12 +114,12 @@ class ImportMetaPlugin {
 					parser.hooks.typeof
 						.for("import.meta.url")
 						.tap(
-							"ImportMetaPlugin",
+							PLUGIN_NAME,
 							toConstantDependency(parser, JSON.stringify("string"))
 						);
 					parser.hooks.expression
 						.for("import.meta.url")
-						.tap("ImportMetaPlugin", expr => {
+						.tap(PLUGIN_NAME, expr => {
 							const dep = new ConstDependency(
 								JSON.stringify(getUrl(parser.state.module)),
 								expr.range
@@ -124,10 +130,10 @@ class ImportMetaPlugin {
 						});
 					parser.hooks.evaluateTypeof
 						.for("import.meta.url")
-						.tap("ImportMetaPlugin", evaluateToString("string"));
+						.tap(PLUGIN_NAME, evaluateToString("string"));
 					parser.hooks.evaluateIdentifier
 						.for("import.meta.url")
-						.tap("ImportMetaPlugin", expr => {
+						.tap(PLUGIN_NAME, expr => {
 							return new BasicEvaluatedExpression()
 								.setString(getUrl(parser.state.module))
 								.setRange(expr.range);
@@ -141,26 +147,26 @@ class ImportMetaPlugin {
 					parser.hooks.typeof
 						.for("import.meta.webpack")
 						.tap(
-							"ImportMetaPlugin",
+							PLUGIN_NAME,
 							toConstantDependency(parser, JSON.stringify("number"))
 						);
 					parser.hooks.expression
 						.for("import.meta.webpack")
 						.tap(
-							"ImportMetaPlugin",
+							PLUGIN_NAME,
 							toConstantDependency(parser, JSON.stringify(webpackVersion))
 						);
 					parser.hooks.evaluateTypeof
 						.for("import.meta.webpack")
-						.tap("ImportMetaPlugin", evaluateToString("number"));
+						.tap(PLUGIN_NAME, evaluateToString("number"));
 					parser.hooks.evaluateIdentifier
 						.for("import.meta.webpack")
-						.tap("ImportMetaPlugin", evaluateToNumber(webpackVersion));
+						.tap(PLUGIN_NAME, evaluateToNumber(webpackVersion));
 
 					/// Unknown properties ///
 					parser.hooks.unhandledExpressionMemberChain
 						.for("import.meta")
-						.tap("ImportMetaPlugin", (expr, members) => {
+						.tap(PLUGIN_NAME, (expr, members) => {
 							const dep = new ConstDependency(
 								`${Template.toNormalComment(
 									"unsupported import.meta." + members.join(".")
@@ -173,7 +179,7 @@ class ImportMetaPlugin {
 						});
 					parser.hooks.evaluate
 						.for("MemberExpression")
-						.tap("ImportMetaPlugin", expression => {
+						.tap(PLUGIN_NAME, expression => {
 							const expr = /** @type {MemberExpression} */ (expression);
 							if (
 								expr.object.type === "MetaProperty" &&
@@ -190,11 +196,11 @@ class ImportMetaPlugin {
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("ImportMetaPlugin", parserHandler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, parserHandler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/esm")
-					.tap("ImportMetaPlugin", parserHandler);
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, parserHandler);
 			}
 		);
 	}

--- a/lib/dependencies/ImportPlugin.js
+++ b/lib/dependencies/ImportPlugin.js
@@ -5,6 +5,11 @@
 
 "use strict";
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("../ModuleTypeConstants");
 const ImportContextDependency = require("./ImportContextDependency");
 const ImportDependency = require("./ImportDependency");
 const ImportEagerDependency = require("./ImportEagerDependency");
@@ -12,6 +17,8 @@ const ImportParserPlugin = require("./ImportParserPlugin");
 const ImportWeakDependency = require("./ImportWeakDependency");
 
 /** @typedef {import("../Compiler")} Compiler */
+
+const PLUGIN_NAME = "ImportPlugin";
 
 class ImportPlugin {
 	/**
@@ -21,7 +28,7 @@ class ImportPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"ImportPlugin",
+			PLUGIN_NAME,
 			(compilation, { contextModuleFactory, normalModuleFactory }) => {
 				compilation.dependencyFactories.set(
 					ImportDependency,
@@ -67,14 +74,14 @@ class ImportPlugin {
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("ImportPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("ImportPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/esm")
-					.tap("ImportPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/dependencies/RequireContextPlugin.js
+++ b/lib/dependencies/RequireContextPlugin.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC
+} = require("../ModuleTypeConstants");
 const { cachedSetProperty } = require("../util/cleverMerge");
 const ContextElementDependency = require("./ContextElementDependency");
 const RequireContextDependency = require("./RequireContextDependency");
@@ -16,6 +20,8 @@ const RequireContextDependencyParserPlugin = require("./RequireContextDependency
 /** @type {ResolveOptions} */
 const EMPTY_RESOLVE_OPTIONS = {};
 
+const PLUGIN_NAME = "RequireContextPlugin";
+
 class RequireContextPlugin {
 	/**
 	 * Apply the plugin
@@ -24,7 +30,7 @@ class RequireContextPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"RequireContextPlugin",
+			PLUGIN_NAME,
 			(compilation, { contextModuleFactory, normalModuleFactory }) => {
 				compilation.dependencyFactories.set(
 					RequireContextDependency,
@@ -51,14 +57,14 @@ class RequireContextPlugin {
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("RequireContextPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("RequireContextPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 
 				contextModuleFactory.hooks.alternativeRequests.tap(
-					"RequireContextPlugin",
+					PLUGIN_NAME,
 					(items, options) => {
 						if (items.length === 0) return items;
 

--- a/lib/dependencies/RequireEnsurePlugin.js
+++ b/lib/dependencies/RequireEnsurePlugin.js
@@ -11,14 +11,20 @@ const RequireEnsureItemDependency = require("./RequireEnsureItemDependency");
 const RequireEnsureDependenciesBlockParserPlugin = require("./RequireEnsureDependenciesBlockParserPlugin");
 
 const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC
+} = require("../ModuleTypeConstants");
+const {
 	evaluateToString,
 	toConstantDependency
 } = require("../javascript/JavascriptParserHelpers");
 
+const PLUGIN_NAME = "RequireEnsurePlugin";
+
 class RequireEnsurePlugin {
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"RequireEnsurePlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				compilation.dependencyFactories.set(
 					RequireEnsureItemDependency,
@@ -44,21 +50,21 @@ class RequireEnsurePlugin {
 					new RequireEnsureDependenciesBlockParserPlugin().apply(parser);
 					parser.hooks.evaluateTypeof
 						.for("require.ensure")
-						.tap("RequireEnsurePlugin", evaluateToString("function"));
+						.tap(PLUGIN_NAME, evaluateToString("function"));
 					parser.hooks.typeof
 						.for("require.ensure")
 						.tap(
-							"RequireEnsurePlugin",
+							PLUGIN_NAME,
 							toConstantDependency(parser, JSON.stringify("function"))
 						);
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("RequireEnsurePlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("RequireEnsurePlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/dependencies/RequireIncludePlugin.js
+++ b/lib/dependencies/RequireIncludePlugin.js
@@ -5,13 +5,19 @@
 
 "use strict";
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC
+} = require("../ModuleTypeConstants");
 const RequireIncludeDependency = require("./RequireIncludeDependency");
 const RequireIncludeDependencyParserPlugin = require("./RequireIncludeDependencyParserPlugin");
+
+const PLUGIN_NAME = "RequireIncludePlugin";
 
 class RequireIncludePlugin {
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"RequireIncludePlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				compilation.dependencyFactories.set(
 					RequireIncludeDependency,
@@ -30,11 +36,11 @@ class RequireIncludePlugin {
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("RequireIncludePlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("RequireIncludePlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/dependencies/SystemPlugin.js
+++ b/lib/dependencies/SystemPlugin.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC
+} = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const WebpackError = require("../WebpackError");
 const {
@@ -18,6 +22,8 @@ const SystemRuntimeModule = require("./SystemRuntimeModule");
 
 /** @typedef {import("../Compiler")} Compiler */
 
+const PLUGIN_NAME = "SystemPlugin";
+
 class SystemPlugin {
 	/**
 	 * Apply the plugin
@@ -26,17 +32,17 @@ class SystemPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"SystemPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				compilation.hooks.runtimeRequirementInModule
 					.for(RuntimeGlobals.system)
-					.tap("SystemPlugin", (module, set) => {
+					.tap(PLUGIN_NAME, (module, set) => {
 						set.add(RuntimeGlobals.requireScope);
 					});
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.system)
-					.tap("SystemPlugin", (chunk, set) => {
+					.tap(PLUGIN_NAME, (chunk, set) => {
 						compilation.addRuntimeModule(chunk, new SystemRuntimeModule());
 					});
 
@@ -48,11 +54,11 @@ class SystemPlugin {
 					const setNotSupported = name => {
 						parser.hooks.evaluateTypeof
 							.for(name)
-							.tap("SystemPlugin", evaluateToString("undefined"));
+							.tap(PLUGIN_NAME, evaluateToString("undefined"));
 						parser.hooks.expression
 							.for(name)
 							.tap(
-								"SystemPlugin",
+								PLUGIN_NAME,
 								expressionIsUnsupported(
 									parser,
 									name + " is not supported by webpack."
@@ -63,27 +69,27 @@ class SystemPlugin {
 					parser.hooks.typeof
 						.for("System.import")
 						.tap(
-							"SystemPlugin",
+							PLUGIN_NAME,
 							toConstantDependency(parser, JSON.stringify("function"))
 						);
 					parser.hooks.evaluateTypeof
 						.for("System.import")
-						.tap("SystemPlugin", evaluateToString("function"));
+						.tap(PLUGIN_NAME, evaluateToString("function"));
 					parser.hooks.typeof
 						.for("System")
 						.tap(
-							"SystemPlugin",
+							PLUGIN_NAME,
 							toConstantDependency(parser, JSON.stringify("object"))
 						);
 					parser.hooks.evaluateTypeof
 						.for("System")
-						.tap("SystemPlugin", evaluateToString("object"));
+						.tap(PLUGIN_NAME, evaluateToString("object"));
 
 					setNotSupported("System.set");
 					setNotSupported("System.get");
 					setNotSupported("System.register");
 
-					parser.hooks.expression.for("System").tap("SystemPlugin", expr => {
+					parser.hooks.expression.for("System").tap(PLUGIN_NAME, expr => {
 						const dep = new ConstDependency(RuntimeGlobals.system, expr.range, [
 							RuntimeGlobals.system
 						]);
@@ -92,7 +98,7 @@ class SystemPlugin {
 						return true;
 					});
 
-					parser.hooks.call.for("System.import").tap("SystemPlugin", expr => {
+					parser.hooks.call.for("System.import").tap(PLUGIN_NAME, expr => {
 						parser.state.module.addWarning(
 							new SystemImportDeprecationWarning(expr.loc)
 						);
@@ -107,11 +113,11 @@ class SystemPlugin {
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("SystemPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/dynamic")
-					.tap("SystemPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, handler);
 			}
 		);
 	}

--- a/lib/dependencies/URLPlugin.js
+++ b/lib/dependencies/URLPlugin.js
@@ -6,6 +6,10 @@
 "use strict";
 
 const { pathToFileURL } = require("url");
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("../ModuleTypeConstants");
 const BasicEvaluatedExpression = require("../javascript/BasicEvaluatedExpression");
 const { approve } = require("../javascript/JavascriptParserHelpers");
 const InnerGraph = require("../optimize/InnerGraph");
@@ -16,13 +20,15 @@ const URLDependency = require("./URLDependency");
 /** @typedef {import("../NormalModule")} NormalModule */
 /** @typedef {import("../javascript/JavascriptParser")} JavascriptParser */
 
+const PLUGIN_NAME = "URLPlugin";
+
 class URLPlugin {
 	/**
 	 * @param {Compiler} compiler compiler
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"URLPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				compilation.dependencyFactories.set(URLDependency, normalModuleFactory);
 				compilation.dependencyTemplates.set(
@@ -76,10 +82,10 @@ class URLPlugin {
 						return request;
 					};
 
-					parser.hooks.canRename.for("URL").tap("URLPlugin", approve);
+					parser.hooks.canRename.for("URL").tap(PLUGIN_NAME, approve);
 					parser.hooks.evaluateNewExpression
 						.for("URL")
-						.tap("URLPlugin", expr => {
+						.tap(PLUGIN_NAME, expr => {
 							const request = getUrlRequest(expr);
 							if (!request) return;
 							const url = new URL(request, getUrl(parser.state.module));
@@ -88,7 +94,7 @@ class URLPlugin {
 								.setString(url.toString())
 								.setRange(expr.range);
 						});
-					parser.hooks.new.for("URL").tap("URLPlugin", _expr => {
+					parser.hooks.new.for("URL").tap(PLUGIN_NAME, _expr => {
 						const expr = /** @type {NewExpressionNode} */ (_expr);
 
 						const request = getUrlRequest(expr);
@@ -107,7 +113,7 @@ class URLPlugin {
 						InnerGraph.onUsage(parser.state, e => (dep.usedByExports = e));
 						return true;
 					});
-					parser.hooks.isPure.for("NewExpression").tap("URLPlugin", _expr => {
+					parser.hooks.isPure.for("NewExpression").tap(PLUGIN_NAME, _expr => {
 						const expr = /** @type {NewExpressionNode} */ (_expr);
 						const { callee } = expr;
 						if (callee.type !== "Identifier") return;
@@ -121,12 +127,12 @@ class URLPlugin {
 				};
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("URLPlugin", parserCallback);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, parserCallback);
 
 				normalModuleFactory.hooks.parser
-					.for("javascript/esm")
-					.tap("URLPlugin", parserCallback);
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, parserCallback);
 			}
 		);
 	}

--- a/lib/dependencies/WorkerPlugin.js
+++ b/lib/dependencies/WorkerPlugin.js
@@ -8,6 +8,10 @@
 const { pathToFileURL } = require("url");
 const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
 const CommentCompilationWarning = require("../CommentCompilationWarning");
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("../ModuleTypeConstants");
 const UnsupportedFeatureWarning = require("../UnsupportedFeatureWarning");
 const EnableChunkLoadingPlugin = require("../javascript/EnableChunkLoadingPlugin");
 const { equals } = require("../util/ArrayHelpers");
@@ -47,6 +51,8 @@ const DEFAULT_SYNTAX = [
 /** @type {WeakMap<ParserState, number>} */
 const workerIndexMap = new WeakMap();
 
+const PLUGIN_NAME = "WorkerPlugin";
+
 class WorkerPlugin {
 	constructor(chunkLoading, wasmLoading, module, workerPublicPath) {
 		this._chunkLoading = chunkLoading;
@@ -71,7 +77,7 @@ class WorkerPlugin {
 			compiler.root
 		);
 		compiler.hooks.thisCompilation.tap(
-			"WorkerPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				compilation.dependencyFactories.set(
 					WorkerDependency,
@@ -375,7 +381,7 @@ class WorkerPlugin {
 						if (item.endsWith("()")) {
 							parser.hooks.call
 								.for(item.slice(0, -2))
-								.tap("WorkerPlugin", handleNewWorker);
+								.tap(PLUGIN_NAME, handleNewWorker);
 						} else {
 							const match = /^(.+?)(\(\))?\s+from\s+(.+)$/.exec(item);
 							if (match) {
@@ -384,7 +390,7 @@ class WorkerPlugin {
 								const source = match[3];
 								(call ? parser.hooks.call : parser.hooks.new)
 									.for(harmonySpecifierTag)
-									.tap("WorkerPlugin", expr => {
+									.tap(PLUGIN_NAME, expr => {
 										const settings = /** @type {HarmonySettings} */ (
 											parser.currentTagData
 										);
@@ -398,7 +404,7 @@ class WorkerPlugin {
 										return handleNewWorker(expr);
 									});
 							} else {
-								parser.hooks.new.for(item).tap("WorkerPlugin", handleNewWorker);
+								parser.hooks.new.for(item).tap(PLUGIN_NAME, handleNewWorker);
 							}
 						}
 					};
@@ -409,11 +415,11 @@ class WorkerPlugin {
 					}
 				};
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("WorkerPlugin", parserPlugin);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, parserPlugin);
 				normalModuleFactory.hooks.parser
-					.for("javascript/esm")
-					.tap("WorkerPlugin", parserPlugin);
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, parserPlugin);
 			}
 		);
 	}

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -18,6 +18,11 @@ const Compilation = require("../Compilation");
 const { tryRunOrWebpackError } = require("../HookWebpackError");
 const HotUpdateChunk = require("../HotUpdateChunk");
 const InitFragment = require("../InitFragment");
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
 const { last, someInIterable } = require("../util/IterableHelpers");
@@ -133,6 +138,8 @@ const printGeneratedCodeForStack = (module, code) => {
 /** @type {WeakMap<Compilation, CompilationHooks>} */
 const compilationHooksMap = new WeakMap();
 
+const PLUGIN_NAME = "JavascriptModulesPlugin";
+
 class JavascriptModulesPlugin {
 	/**
 	 * @param {Compilation} compilation the compilation
@@ -196,154 +203,147 @@ class JavascriptModulesPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"JavascriptModulesPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				const hooks = JavascriptModulesPlugin.getCompilationHooks(compilation);
 				normalModuleFactory.hooks.createParser
-					.for("javascript/auto")
-					.tap("JavascriptModulesPlugin", options => {
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, options => {
 						return new JavascriptParser("auto");
 					});
 				normalModuleFactory.hooks.createParser
-					.for("javascript/dynamic")
-					.tap("JavascriptModulesPlugin", options => {
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, options => {
 						return new JavascriptParser("script");
 					});
 				normalModuleFactory.hooks.createParser
-					.for("javascript/esm")
-					.tap("JavascriptModulesPlugin", options => {
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, options => {
 						return new JavascriptParser("module");
 					});
 				normalModuleFactory.hooks.createGenerator
-					.for("javascript/auto")
-					.tap("JavascriptModulesPlugin", () => {
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, () => {
 						return new JavascriptGenerator();
 					});
 				normalModuleFactory.hooks.createGenerator
-					.for("javascript/dynamic")
-					.tap("JavascriptModulesPlugin", () => {
+					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
+					.tap(PLUGIN_NAME, () => {
 						return new JavascriptGenerator();
 					});
 				normalModuleFactory.hooks.createGenerator
-					.for("javascript/esm")
-					.tap("JavascriptModulesPlugin", () => {
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, () => {
 						return new JavascriptGenerator();
 					});
-				compilation.hooks.renderManifest.tap(
-					"JavascriptModulesPlugin",
-					(result, options) => {
-						const {
-							hash,
+				compilation.hooks.renderManifest.tap(PLUGIN_NAME, (result, options) => {
+					const {
+						hash,
+						chunk,
+						chunkGraph,
+						moduleGraph,
+						runtimeTemplate,
+						dependencyTemplates,
+						outputOptions,
+						codeGenerationResults
+					} = options;
+
+					const hotUpdateChunk = chunk instanceof HotUpdateChunk ? chunk : null;
+
+					let render;
+					const filenameTemplate =
+						JavascriptModulesPlugin.getChunkFilenameTemplate(
 							chunk,
-							chunkGraph,
-							moduleGraph,
-							runtimeTemplate,
-							dependencyTemplates,
-							outputOptions,
-							codeGenerationResults
-						} = options;
-
-						const hotUpdateChunk =
-							chunk instanceof HotUpdateChunk ? chunk : null;
-
-						let render;
-						const filenameTemplate =
-							JavascriptModulesPlugin.getChunkFilenameTemplate(
-								chunk,
-								outputOptions
-							);
-						if (hotUpdateChunk) {
-							render = () =>
-								this.renderChunk(
-									{
-										chunk,
-										dependencyTemplates,
-										runtimeTemplate,
-										moduleGraph,
-										chunkGraph,
-										codeGenerationResults,
-										strictMode: runtimeTemplate.isModule()
-									},
-									hooks
-								);
-						} else if (chunk.hasRuntime()) {
-							render = () =>
-								this.renderMain(
-									{
-										hash,
-										chunk,
-										dependencyTemplates,
-										runtimeTemplate,
-										moduleGraph,
-										chunkGraph,
-										codeGenerationResults,
-										strictMode: runtimeTemplate.isModule()
-									},
-									hooks,
-									compilation
-								);
-						} else {
-							if (!chunkHasJs(chunk, chunkGraph)) {
-								return result;
-							}
-
-							render = () =>
-								this.renderChunk(
-									{
-										chunk,
-										dependencyTemplates,
-										runtimeTemplate,
-										moduleGraph,
-										chunkGraph,
-										codeGenerationResults,
-										strictMode: runtimeTemplate.isModule()
-									},
-									hooks
-								);
-						}
-
-						result.push({
-							render,
-							filenameTemplate,
-							pathOptions: {
-								hash,
-								runtime: chunk.runtime,
-								chunk,
-								contentHashType: "javascript"
-							},
-							info: {
-								javascriptModule: compilation.runtimeTemplate.isModule()
-							},
-							identifier: hotUpdateChunk
-								? `hotupdatechunk${chunk.id}`
-								: `chunk${chunk.id}`,
-							hash: chunk.contentHash.javascript
-						});
-
-						return result;
-					}
-				);
-				compilation.hooks.chunkHash.tap(
-					"JavascriptModulesPlugin",
-					(chunk, hash, context) => {
-						hooks.chunkHash.call(chunk, hash, context);
-						if (chunk.hasRuntime()) {
-							this.updateHashWithBootstrap(
-								hash,
+							outputOptions
+						);
+					if (hotUpdateChunk) {
+						render = () =>
+							this.renderChunk(
 								{
-									hash: "0000",
 									chunk,
-									codeGenerationResults: context.codeGenerationResults,
-									chunkGraph: context.chunkGraph,
-									moduleGraph: context.moduleGraph,
-									runtimeTemplate: context.runtimeTemplate
+									dependencyTemplates,
+									runtimeTemplate,
+									moduleGraph,
+									chunkGraph,
+									codeGenerationResults,
+									strictMode: runtimeTemplate.isModule()
 								},
 								hooks
 							);
+					} else if (chunk.hasRuntime()) {
+						render = () =>
+							this.renderMain(
+								{
+									hash,
+									chunk,
+									dependencyTemplates,
+									runtimeTemplate,
+									moduleGraph,
+									chunkGraph,
+									codeGenerationResults,
+									strictMode: runtimeTemplate.isModule()
+								},
+								hooks,
+								compilation
+							);
+					} else {
+						if (!chunkHasJs(chunk, chunkGraph)) {
+							return result;
 						}
+
+						render = () =>
+							this.renderChunk(
+								{
+									chunk,
+									dependencyTemplates,
+									runtimeTemplate,
+									moduleGraph,
+									chunkGraph,
+									codeGenerationResults,
+									strictMode: runtimeTemplate.isModule()
+								},
+								hooks
+							);
 					}
-				);
-				compilation.hooks.contentHash.tap("JavascriptModulesPlugin", chunk => {
+
+					result.push({
+						render,
+						filenameTemplate,
+						pathOptions: {
+							hash,
+							runtime: chunk.runtime,
+							chunk,
+							contentHashType: "javascript"
+						},
+						info: {
+							javascriptModule: compilation.runtimeTemplate.isModule()
+						},
+						identifier: hotUpdateChunk
+							? `hotupdatechunk${chunk.id}`
+							: `chunk${chunk.id}`,
+						hash: chunk.contentHash.javascript
+					});
+
+					return result;
+				});
+				compilation.hooks.chunkHash.tap(PLUGIN_NAME, (chunk, hash, context) => {
+					hooks.chunkHash.call(chunk, hash, context);
+					if (chunk.hasRuntime()) {
+						this.updateHashWithBootstrap(
+							hash,
+							{
+								hash: "0000",
+								chunk,
+								codeGenerationResults: context.codeGenerationResults,
+								chunkGraph: context.chunkGraph,
+								moduleGraph: context.moduleGraph,
+								runtimeTemplate: context.runtimeTemplate
+							},
+							hooks
+						);
+					}
+				});
+				compilation.hooks.contentHash.tap(PLUGIN_NAME, chunk => {
 					const {
 						chunkGraph,
 						codeGenerationResults,
@@ -410,7 +410,7 @@ class JavascriptModulesPlugin {
 					);
 				});
 				compilation.hooks.additionalTreeRuntimeRequirements.tap(
-					"JavascriptModulesPlugin",
+					PLUGIN_NAME,
 					(chunk, set, { chunkGraph }) => {
 						if (
 							!set.has(RuntimeGlobals.startupNoDefault) &&
@@ -421,58 +421,51 @@ class JavascriptModulesPlugin {
 						}
 					}
 				);
-				compilation.hooks.executeModule.tap(
-					"JavascriptModulesPlugin",
-					(options, context) => {
-						const source =
-							options.codeGenerationResult.sources.get("javascript");
-						if (source === undefined) return;
-						const { module, moduleObject } = options;
-						const code = source.source();
+				compilation.hooks.executeModule.tap(PLUGIN_NAME, (options, context) => {
+					const source = options.codeGenerationResult.sources.get("javascript");
+					if (source === undefined) return;
+					const { module, moduleObject } = options;
+					const code = source.source();
 
-						const fn = vm.runInThisContext(
-							`(function(${module.moduleArgument}, ${module.exportsArgument}, __webpack_require__) {\n${code}\n/**/})`,
-							{
-								filename: module.identifier(),
-								lineOffset: -1
-							}
-						);
-						try {
-							fn.call(
-								moduleObject.exports,
-								moduleObject,
-								moduleObject.exports,
-								context.__webpack_require__
-							);
-						} catch (e) {
-							e.stack += printGeneratedCodeForStack(options.module, code);
-							throw e;
+					const fn = vm.runInThisContext(
+						`(function(${module.moduleArgument}, ${module.exportsArgument}, __webpack_require__) {\n${code}\n/**/})`,
+						{
+							filename: module.identifier(),
+							lineOffset: -1
 						}
+					);
+					try {
+						fn.call(
+							moduleObject.exports,
+							moduleObject,
+							moduleObject.exports,
+							context.__webpack_require__
+						);
+					} catch (e) {
+						e.stack += printGeneratedCodeForStack(options.module, code);
+						throw e;
 					}
-				);
-				compilation.hooks.executeModule.tap(
-					"JavascriptModulesPlugin",
-					(options, context) => {
-						const source = options.codeGenerationResult.sources.get("runtime");
-						if (source === undefined) return;
-						let code = source.source();
-						if (typeof code !== "string") code = code.toString();
+				});
+				compilation.hooks.executeModule.tap(PLUGIN_NAME, (options, context) => {
+					const source = options.codeGenerationResult.sources.get("runtime");
+					if (source === undefined) return;
+					let code = source.source();
+					if (typeof code !== "string") code = code.toString();
 
-						const fn = vm.runInThisContext(
-							`(function(__webpack_require__) {\n${code}\n/**/})`,
-							{
-								filename: options.module.identifier(),
-								lineOffset: -1
-							}
-						);
-						try {
-							fn.call(null, context.__webpack_require__);
-						} catch (e) {
-							e.stack += printGeneratedCodeForStack(options.module, code);
-							throw e;
+					const fn = vm.runInThisContext(
+						`(function(__webpack_require__) {\n${code}\n/**/})`,
+						{
+							filename: options.module.identifier(),
+							lineOffset: -1
 						}
+					);
+					try {
+						fn.call(null, context.__webpack_require__);
+					} catch (e) {
+						e.stack += printGeneratedCodeForStack(options.module, code);
+						throw e;
 					}
-				);
+				});
 			}
 		);
 	}

--- a/lib/node/ReadFileCompileAsyncWasmPlugin.js
+++ b/lib/node/ReadFileCompileAsyncWasmPlugin.js
@@ -5,6 +5,7 @@
 
 "use strict";
 
+const { WEBASSEMBLY_MODULE_TYPE_ASYNC } = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
 const AsyncWasmLoadingRuntimeModule = require("../wasm-async/AsyncWasmLoadingRuntimeModule");
@@ -85,7 +86,7 @@ class ReadFileCompileAsyncWasmPlugin {
 						if (
 							!chunkGraph.hasModuleInGraph(
 								chunk,
-								m => m.type === "webassembly/async"
+								m => m.type === WEBASSEMBLY_MODULE_TYPE_ASYNC
 							)
 						) {
 							return;

--- a/lib/node/ReadFileCompileWasmPlugin.js
+++ b/lib/node/ReadFileCompileWasmPlugin.js
@@ -5,6 +5,7 @@
 
 "use strict";
 
+const { WEBASSEMBLY_MODULE_TYPE_SYNC } = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
 const WasmChunkLoadingRuntimeModule = require("../wasm-sync/WasmChunkLoadingRuntimeModule");
@@ -69,7 +70,7 @@ class ReadFileCompileWasmPlugin {
 						if (
 							!chunkGraph.hasModuleInGraph(
 								chunk,
-								m => m.type === "webassembly/sync"
+								m => m.type === WEBASSEMBLY_MODULE_TYPE_SYNC
 							)
 						) {
 							return;

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -15,6 +15,7 @@ const {
 const ConcatenationScope = require("../ConcatenationScope");
 const { UsageState } = require("../ExportsInfo");
 const Module = require("../Module");
+const { JAVASCRIPT_MODULE_TYPE_ESM } = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
 const HarmonyImportDependency = require("../dependencies/HarmonyImportDependency");
@@ -683,7 +684,7 @@ class ConcatenatedModule extends Module {
 	 * @param {Set<Module>=} options.modules all concatenated modules
 	 */
 	constructor({ identifier, rootModule, modules, runtime }) {
-		super("javascript/esm", null, rootModule && rootModule.layer);
+		super(JAVASCRIPT_MODULE_TYPE_ESM, null, rootModule && rootModule.layer);
 
 		// Info from Factory
 		/** @type {string} */

--- a/lib/optimize/InnerGraphPlugin.js
+++ b/lib/optimize/InnerGraphPlugin.js
@@ -5,6 +5,10 @@
 
 "use strict";
 
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_ESM
+} = require("../ModuleTypeConstants");
 const PureExpressionDependency = require("../dependencies/PureExpressionDependency");
 const InnerGraph = require("./InnerGraph");
 
@@ -21,6 +25,8 @@ const InnerGraph = require("./InnerGraph");
 
 const { topLevelSymbolTag } = InnerGraph;
 
+const PLUGIN_NAME = "InnerGraphPlugin";
+
 class InnerGraphPlugin {
 	/**
 	 * Apply the plugin
@@ -29,7 +35,7 @@ class InnerGraphPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"InnerGraphPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				const logger = compilation.getLogger("webpack.InnerGraphPlugin");
 
@@ -61,11 +67,11 @@ class InnerGraphPlugin {
 						});
 					};
 
-					parser.hooks.program.tap("InnerGraphPlugin", () => {
+					parser.hooks.program.tap(PLUGIN_NAME, () => {
 						InnerGraph.enable(parser.state);
 					});
 
-					parser.hooks.finish.tap("InnerGraphPlugin", () => {
+					parser.hooks.finish.tap(PLUGIN_NAME, () => {
 						if (!InnerGraph.isEnabled(parser.state)) return;
 
 						logger.time("infer dependency usage");
@@ -97,7 +103,7 @@ class InnerGraphPlugin {
 
 					// The following hooks are used during prewalking:
 
-					parser.hooks.preStatement.tap("InnerGraphPlugin", statement => {
+					parser.hooks.preStatement.tap(PLUGIN_NAME, statement => {
 						if (!InnerGraph.isEnabled(parser.state)) return;
 
 						if (parser.scope.topLevelScope === true) {
@@ -110,7 +116,7 @@ class InnerGraphPlugin {
 						}
 					});
 
-					parser.hooks.blockPreStatement.tap("InnerGraphPlugin", statement => {
+					parser.hooks.blockPreStatement.tap(PLUGIN_NAME, statement => {
 						if (!InnerGraph.isEnabled(parser.state)) return;
 
 						if (parser.scope.topLevelScope === true) {
@@ -143,33 +149,30 @@ class InnerGraphPlugin {
 						}
 					});
 
-					parser.hooks.preDeclarator.tap(
-						"InnerGraphPlugin",
-						(decl, statement) => {
-							if (!InnerGraph.isEnabled(parser.state)) return;
-							if (
-								parser.scope.topLevelScope === true &&
-								decl.init &&
-								decl.id.type === "Identifier"
-							) {
-								const name = decl.id.name;
-								if (decl.init.type === "ClassExpression") {
-									const fn = InnerGraph.tagTopLevelSymbol(parser, name);
-									classWithTopLevelSymbol.set(decl.init, fn);
-								} else if (parser.isPure(decl.init, decl.id.range[1])) {
-									const fn = InnerGraph.tagTopLevelSymbol(parser, name);
-									declWithTopLevelSymbol.set(decl, fn);
-									if (
-										!decl.init.type.endsWith("FunctionExpression") &&
-										decl.init.type !== "Literal"
-									) {
-										pureDeclarators.add(decl);
-									}
-									return true;
+					parser.hooks.preDeclarator.tap(PLUGIN_NAME, (decl, statement) => {
+						if (!InnerGraph.isEnabled(parser.state)) return;
+						if (
+							parser.scope.topLevelScope === true &&
+							decl.init &&
+							decl.id.type === "Identifier"
+						) {
+							const name = decl.id.name;
+							if (decl.init.type === "ClassExpression") {
+								const fn = InnerGraph.tagTopLevelSymbol(parser, name);
+								classWithTopLevelSymbol.set(decl.init, fn);
+							} else if (parser.isPure(decl.init, decl.id.range[1])) {
+								const fn = InnerGraph.tagTopLevelSymbol(parser, name);
+								declWithTopLevelSymbol.set(decl, fn);
+								if (
+									!decl.init.type.endsWith("FunctionExpression") &&
+									decl.init.type !== "Literal"
+								) {
+									pureDeclarators.add(decl);
 								}
+								return true;
 							}
 						}
-					);
+					});
 
 					// During real walking we set the TopLevelSymbol state to the assigned
 					// TopLevelSymbol by using the fill datastructures.
@@ -187,7 +190,7 @@ class InnerGraphPlugin {
 
 					// The following hooks are called during walking:
 
-					parser.hooks.statement.tap("InnerGraphPlugin", statement => {
+					parser.hooks.statement.tap(PLUGIN_NAME, statement => {
 						if (!InnerGraph.isEnabled(parser.state)) return;
 						if (parser.scope.topLevelScope === true) {
 							InnerGraph.setTopLevelSymbol(parser.state, undefined);
@@ -219,7 +222,7 @@ class InnerGraphPlugin {
 					});
 
 					parser.hooks.classExtendsExpression.tap(
-						"InnerGraphPlugin",
+						PLUGIN_NAME,
 						(expr, statement) => {
 							if (!InnerGraph.isEnabled(parser.state)) return;
 							if (parser.scope.topLevelScope === true) {
@@ -239,7 +242,7 @@ class InnerGraphPlugin {
 					);
 
 					parser.hooks.classBodyElement.tap(
-						"InnerGraphPlugin",
+						PLUGIN_NAME,
 						(element, classDefinition) => {
 							if (!InnerGraph.isEnabled(parser.state)) return;
 							if (parser.scope.topLevelScope === true) {
@@ -252,7 +255,7 @@ class InnerGraphPlugin {
 					);
 
 					parser.hooks.classBodyValue.tap(
-						"InnerGraphPlugin",
+						PLUGIN_NAME,
 						(expression, element, classDefinition) => {
 							if (!InnerGraph.isEnabled(parser.state)) return;
 							if (parser.scope.topLevelScope === true) {
@@ -292,7 +295,7 @@ class InnerGraphPlugin {
 						}
 					);
 
-					parser.hooks.declarator.tap("InnerGraphPlugin", (decl, statement) => {
+					parser.hooks.declarator.tap(PLUGIN_NAME, (decl, statement) => {
 						if (!InnerGraph.isEnabled(parser.state)) return;
 						const fn = declWithTopLevelSymbol.get(decl);
 
@@ -330,7 +333,7 @@ class InnerGraphPlugin {
 
 					parser.hooks.expression
 						.for(topLevelSymbolTag)
-						.tap("InnerGraphPlugin", () => {
+						.tap(PLUGIN_NAME, () => {
 							const topLevelSymbol = /** @type {TopLevelSymbol} */ (
 								parser.currentTagData
 							);
@@ -343,21 +346,19 @@ class InnerGraphPlugin {
 								currentTopLevelSymbol || true
 							);
 						});
-					parser.hooks.assign
-						.for(topLevelSymbolTag)
-						.tap("InnerGraphPlugin", expr => {
-							if (!InnerGraph.isEnabled(parser.state)) return;
-							if (expr.operator === "=") return true;
-						});
+					parser.hooks.assign.for(topLevelSymbolTag).tap(PLUGIN_NAME, expr => {
+						if (!InnerGraph.isEnabled(parser.state)) return;
+						if (expr.operator === "=") return true;
+					});
 				};
 				normalModuleFactory.hooks.parser
-					.for("javascript/auto")
-					.tap("InnerGraphPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
+					.tap(PLUGIN_NAME, handler);
 				normalModuleFactory.hooks.parser
-					.for("javascript/esm")
-					.tap("InnerGraphPlugin", handler);
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, handler);
 
-				compilation.hooks.finishModules.tap("InnerGraphPlugin", () => {
+				compilation.hooks.finishModules.tap(PLUGIN_NAME, () => {
 					logger.timeAggregateEnd("infer dependency usage");
 				});
 			}

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -6,6 +6,11 @@
 "use strict";
 
 const glob2regexp = require("glob-to-regexp");
+const {
+	JAVASCRIPT_MODULE_TYPE_AUTO,
+	JAVASCRIPT_MODULE_TYPE_ESM,
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC
+} = require("../ModuleTypeConstants");
 const { STAGE_DEFAULT } = require("../OptimizationStages");
 const HarmonyExportImportedSpecifierDependency = require("../dependencies/HarmonyExportImportedSpecifierDependency");
 const HarmonyImportSpecifierDependency = require("../dependencies/HarmonyImportSpecifierDependency");
@@ -50,6 +55,8 @@ const globToRegexp = (glob, cache) => {
 	return regexp;
 };
 
+const PLUGIN_NAME = "SideEffectsFlagPlugin";
+
 class SideEffectsFlagPlugin {
 	/**
 	 * @param {boolean} analyseSource analyse source code for side effects
@@ -69,48 +76,41 @@ class SideEffectsFlagPlugin {
 			globToRegexpCache.set(compiler.root, cache);
 		}
 		compiler.hooks.compilation.tap(
-			"SideEffectsFlagPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				const moduleGraph = compilation.moduleGraph;
-				normalModuleFactory.hooks.module.tap(
-					"SideEffectsFlagPlugin",
-					(module, data) => {
-						const resolveData = data.resourceResolveData;
-						if (
-							resolveData &&
-							resolveData.descriptionFileData &&
-							resolveData.relativePath
-						) {
-							const sideEffects = resolveData.descriptionFileData.sideEffects;
-							if (sideEffects !== undefined) {
-								if (module.factoryMeta === undefined) {
-									module.factoryMeta = {};
-								}
-								const hasSideEffects =
-									SideEffectsFlagPlugin.moduleHasSideEffects(
-										resolveData.relativePath,
-										sideEffects,
-										cache
-									);
-								module.factoryMeta.sideEffectFree = !hasSideEffects;
-							}
-						}
-
-						return module;
-					}
-				);
-				normalModuleFactory.hooks.module.tap(
-					"SideEffectsFlagPlugin",
-					(module, data) => {
-						if (typeof data.settings.sideEffects === "boolean") {
+				normalModuleFactory.hooks.module.tap(PLUGIN_NAME, (module, data) => {
+					const resolveData = data.resourceResolveData;
+					if (
+						resolveData &&
+						resolveData.descriptionFileData &&
+						resolveData.relativePath
+					) {
+						const sideEffects = resolveData.descriptionFileData.sideEffects;
+						if (sideEffects !== undefined) {
 							if (module.factoryMeta === undefined) {
 								module.factoryMeta = {};
 							}
-							module.factoryMeta.sideEffectFree = !data.settings.sideEffects;
+							const hasSideEffects = SideEffectsFlagPlugin.moduleHasSideEffects(
+								resolveData.relativePath,
+								sideEffects,
+								cache
+							);
+							module.factoryMeta.sideEffectFree = !hasSideEffects;
 						}
-						return module;
 					}
-				);
+
+					return module;
+				});
+				normalModuleFactory.hooks.module.tap(PLUGIN_NAME, (module, data) => {
+					if (typeof data.settings.sideEffects === "boolean") {
+						if (module.factoryMeta === undefined) {
+							module.factoryMeta = {};
+						}
+						module.factoryMeta.sideEffectFree = !data.settings.sideEffects;
+					}
+					return module;
+				});
 				if (this._analyseSource) {
 					/**
 					 * @param {JavascriptParser} parser the parser
@@ -118,11 +118,11 @@ class SideEffectsFlagPlugin {
 					 */
 					const parserHandler = parser => {
 						let sideEffectsStatement;
-						parser.hooks.program.tap("SideEffectsFlagPlugin", () => {
+						parser.hooks.program.tap(PLUGIN_NAME, () => {
 							sideEffectsStatement = undefined;
 						});
 						parser.hooks.statement.tap(
-							{ name: "SideEffectsFlagPlugin", stage: -100 },
+							{ name: PLUGIN_NAME, stage: -100 },
 							statement => {
 								if (sideEffectsStatement) return;
 								if (parser.scope.topLevelScope !== true) return;
@@ -203,7 +203,7 @@ class SideEffectsFlagPlugin {
 								}
 							}
 						);
-						parser.hooks.finish.tap("SideEffectsFlagPlugin", () => {
+						parser.hooks.finish.tap(PLUGIN_NAME, () => {
 							if (sideEffectsStatement === undefined) {
 								parser.state.module.buildMeta.sideEffectFree = true;
 							} else {
@@ -220,18 +220,18 @@ class SideEffectsFlagPlugin {
 						});
 					};
 					for (const key of [
-						"javascript/auto",
-						"javascript/esm",
-						"javascript/dynamic"
+						JAVASCRIPT_MODULE_TYPE_AUTO,
+						JAVASCRIPT_MODULE_TYPE_ESM,
+						JAVASCRIPT_MODULE_TYPE_DYNAMIC
 					]) {
 						normalModuleFactory.hooks.parser
 							.for(key)
-							.tap("SideEffectsFlagPlugin", parserHandler);
+							.tap(PLUGIN_NAME, parserHandler);
 					}
 				}
 				compilation.hooks.optimizeDependencies.tap(
 					{
-						name: "SideEffectsFlagPlugin",
+						name: PLUGIN_NAME,
 						stage: STAGE_DEFAULT
 					},
 					modules => {

--- a/lib/wasm-async/AsyncWebAssemblyModulesPlugin.js
+++ b/lib/wasm-async/AsyncWebAssemblyModulesPlugin.js
@@ -9,6 +9,7 @@ const { SyncWaterfallHook } = require("tapable");
 const Compilation = require("../Compilation");
 const Generator = require("../Generator");
 const { tryRunOrWebpackError } = require("../HookWebpackError");
+const { WEBASSEMBLY_MODULE_TYPE_ASYNC } = require("../ModuleTypeConstants");
 const WebAssemblyImportDependency = require("../dependencies/WebAssemblyImportDependency");
 const { compareModulesByIdentifier } = require("../util/comparators");
 const memoize = require("../util/memoize");
@@ -53,6 +54,8 @@ const getAsyncWebAssemblyParser = memoize(() =>
 /** @type {WeakMap<Compilation, CompilationHooks>} */
 const compilationHooksMap = new WeakMap();
 
+const PLUGIN_NAME = "AsyncWebAssemblyModulesPlugin";
+
 class AsyncWebAssemblyModulesPlugin {
 	/**
 	 * @param {Compilation} compilation the compilation
@@ -89,7 +92,7 @@ class AsyncWebAssemblyModulesPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"AsyncWebAssemblyModulesPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				const hooks =
 					AsyncWebAssemblyModulesPlugin.getCompilationHooks(compilation);
@@ -99,15 +102,15 @@ class AsyncWebAssemblyModulesPlugin {
 				);
 
 				normalModuleFactory.hooks.createParser
-					.for("webassembly/async")
-					.tap("AsyncWebAssemblyModulesPlugin", () => {
+					.for(WEBASSEMBLY_MODULE_TYPE_ASYNC)
+					.tap(PLUGIN_NAME, () => {
 						const AsyncWebAssemblyParser = getAsyncWebAssemblyParser();
 
 						return new AsyncWebAssemblyParser();
 					});
 				normalModuleFactory.hooks.createGenerator
-					.for("webassembly/async")
-					.tap("AsyncWebAssemblyModulesPlugin", () => {
+					.for(WEBASSEMBLY_MODULE_TYPE_ASYNC)
+					.tap(PLUGIN_NAME, () => {
 						const AsyncWebAssemblyJavascriptGenerator =
 							getAsyncWebAssemblyJavascriptGenerator();
 						const AsyncWebAssemblyGenerator = getAsyncWebAssemblyGenerator();
@@ -135,7 +138,7 @@ class AsyncWebAssemblyModulesPlugin {
 							chunk,
 							compareModulesByIdentifier
 						)) {
-							if (module.type === "webassembly/async") {
+							if (module.type === WEBASSEMBLY_MODULE_TYPE_ASYNC) {
 								const filenameTemplate =
 									outputOptions.webassemblyModuleFilename;
 

--- a/lib/wasm-sync/WebAssemblyModulesPlugin.js
+++ b/lib/wasm-sync/WebAssemblyModulesPlugin.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const Generator = require("../Generator");
+const { WEBASSEMBLY_MODULE_TYPE_SYNC } = require("../ModuleTypeConstants");
 const WebAssemblyExportImportedDependency = require("../dependencies/WebAssemblyExportImportedDependency");
 const WebAssemblyImportDependency = require("../dependencies/WebAssemblyImportDependency");
 const { compareModulesByIdentifier } = require("../util/comparators");
@@ -26,6 +27,8 @@ const getWebAssemblyJavascriptGenerator = memoize(() =>
 );
 const getWebAssemblyParser = memoize(() => require("./WebAssemblyParser"));
 
+const PLUGIN_NAME = "WebAssemblyModulesPlugin";
+
 class WebAssemblyModulesPlugin {
 	constructor(options) {
 		this.options = options;
@@ -38,7 +41,7 @@ class WebAssemblyModulesPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compilation.tap(
-			"WebAssemblyModulesPlugin",
+			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
 				compilation.dependencyFactories.set(
 					WebAssemblyImportDependency,
@@ -51,16 +54,16 @@ class WebAssemblyModulesPlugin {
 				);
 
 				normalModuleFactory.hooks.createParser
-					.for("webassembly/sync")
-					.tap("WebAssemblyModulesPlugin", () => {
+					.for(WEBASSEMBLY_MODULE_TYPE_SYNC)
+					.tap(PLUGIN_NAME, () => {
 						const WebAssemblyParser = getWebAssemblyParser();
 
 						return new WebAssemblyParser();
 					});
 
 				normalModuleFactory.hooks.createGenerator
-					.for("webassembly/sync")
-					.tap("WebAssemblyModulesPlugin", () => {
+					.for(WEBASSEMBLY_MODULE_TYPE_SYNC)
+					.tap(PLUGIN_NAME, () => {
 						const WebAssemblyJavascriptGenerator =
 							getWebAssemblyJavascriptGenerator();
 						const WebAssemblyGenerator = getWebAssemblyGenerator();
@@ -71,53 +74,49 @@ class WebAssemblyModulesPlugin {
 						});
 					});
 
-				compilation.hooks.renderManifest.tap(
-					"WebAssemblyModulesPlugin",
-					(result, options) => {
-						const { chunkGraph } = compilation;
-						const { chunk, outputOptions, codeGenerationResults } = options;
+				compilation.hooks.renderManifest.tap(PLUGIN_NAME, (result, options) => {
+					const { chunkGraph } = compilation;
+					const { chunk, outputOptions, codeGenerationResults } = options;
 
-						for (const module of chunkGraph.getOrderedChunkModulesIterable(
-							chunk,
-							compareModulesByIdentifier
-						)) {
-							if (module.type === "webassembly/sync") {
-								const filenameTemplate =
-									outputOptions.webassemblyModuleFilename;
+					for (const module of chunkGraph.getOrderedChunkModulesIterable(
+						chunk,
+						compareModulesByIdentifier
+					)) {
+						if (module.type === WEBASSEMBLY_MODULE_TYPE_SYNC) {
+							const filenameTemplate = outputOptions.webassemblyModuleFilename;
 
-								result.push({
-									render: () =>
-										codeGenerationResults.getSource(
-											module,
-											chunk.runtime,
-											"webassembly"
-										),
-									filenameTemplate,
-									pathOptions: {
+							result.push({
+								render: () =>
+									codeGenerationResults.getSource(
 										module,
-										runtime: chunk.runtime,
-										chunkGraph
-									},
-									auxiliary: true,
-									identifier: `webassemblyModule${chunkGraph.getModuleId(
-										module
-									)}`,
-									hash: chunkGraph.getModuleHash(module, chunk.runtime)
-								});
-							}
+										chunk.runtime,
+										"webassembly"
+									),
+								filenameTemplate,
+								pathOptions: {
+									module,
+									runtime: chunk.runtime,
+									chunkGraph
+								},
+								auxiliary: true,
+								identifier: `webassemblyModule${chunkGraph.getModuleId(
+									module
+								)}`,
+								hash: chunkGraph.getModuleHash(module, chunk.runtime)
+							});
 						}
-
-						return result;
 					}
-				);
 
-				compilation.hooks.afterChunks.tap("WebAssemblyModulesPlugin", () => {
+					return result;
+				});
+
+				compilation.hooks.afterChunks.tap(PLUGIN_NAME, () => {
 					const chunkGraph = compilation.chunkGraph;
 					const initialWasmModules = new Set();
 					for (const chunk of compilation.chunks) {
 						if (chunk.canBeInitial()) {
 							for (const module of chunkGraph.getChunkModulesIterable(chunk)) {
-								if (module.type === "webassembly/sync") {
+								if (module.type === WEBASSEMBLY_MODULE_TYPE_SYNC) {
 									initialWasmModules.add(module);
 								}
 							}

--- a/lib/web/FetchCompileAsyncWasmPlugin.js
+++ b/lib/web/FetchCompileAsyncWasmPlugin.js
@@ -5,6 +5,7 @@
 
 "use strict";
 
+const { WEBASSEMBLY_MODULE_TYPE_ASYNC } = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const AsyncWasmLoadingRuntimeModule = require("../wasm-async/AsyncWasmLoadingRuntimeModule");
 
@@ -40,7 +41,7 @@ class FetchCompileAsyncWasmPlugin {
 						if (
 							!chunkGraph.hasModuleInGraph(
 								chunk,
-								m => m.type === "webassembly/async"
+								m => m.type === WEBASSEMBLY_MODULE_TYPE_ASYNC
 							)
 						) {
 							return;

--- a/lib/web/FetchCompileWasmPlugin.js
+++ b/lib/web/FetchCompileWasmPlugin.js
@@ -5,12 +5,15 @@
 
 "use strict";
 
+const { WEBASSEMBLY_MODULE_TYPE_SYNC } = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const WasmChunkLoadingRuntimeModule = require("../wasm-sync/WasmChunkLoadingRuntimeModule");
 
 /** @typedef {import("../Compiler")} Compiler */
 
 // TODO webpack 6 remove
+
+const PLUGIN_NAME = "FetchCompileWasmPlugin";
 
 class FetchCompileWasmPlugin {
 	constructor(options) {
@@ -23,48 +26,45 @@ class FetchCompileWasmPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
-		compiler.hooks.thisCompilation.tap(
-			"FetchCompileWasmPlugin",
-			compilation => {
-				const globalWasmLoading = compilation.outputOptions.wasmLoading;
-				const isEnabledForChunk = chunk => {
-					const options = chunk.getEntryOptions();
-					const wasmLoading =
-						options && options.wasmLoading !== undefined
-							? options.wasmLoading
-							: globalWasmLoading;
-					return wasmLoading === "fetch";
-				};
-				const generateLoadBinaryCode = path =>
-					`fetch(${RuntimeGlobals.publicPath} + ${path})`;
+		compiler.hooks.thisCompilation.tap(PLUGIN_NAME, compilation => {
+			const globalWasmLoading = compilation.outputOptions.wasmLoading;
+			const isEnabledForChunk = chunk => {
+				const options = chunk.getEntryOptions();
+				const wasmLoading =
+					options && options.wasmLoading !== undefined
+						? options.wasmLoading
+						: globalWasmLoading;
+				return wasmLoading === "fetch";
+			};
+			const generateLoadBinaryCode = path =>
+				`fetch(${RuntimeGlobals.publicPath} + ${path})`;
 
-				compilation.hooks.runtimeRequirementInTree
-					.for(RuntimeGlobals.ensureChunkHandlers)
-					.tap("FetchCompileWasmPlugin", (chunk, set) => {
-						if (!isEnabledForChunk(chunk)) return;
-						const chunkGraph = compilation.chunkGraph;
-						if (
-							!chunkGraph.hasModuleInGraph(
-								chunk,
-								m => m.type === "webassembly/sync"
-							)
-						) {
-							return;
-						}
-						set.add(RuntimeGlobals.moduleCache);
-						set.add(RuntimeGlobals.publicPath);
-						compilation.addRuntimeModule(
+			compilation.hooks.runtimeRequirementInTree
+				.for(RuntimeGlobals.ensureChunkHandlers)
+				.tap(PLUGIN_NAME, (chunk, set) => {
+					if (!isEnabledForChunk(chunk)) return;
+					const chunkGraph = compilation.chunkGraph;
+					if (
+						!chunkGraph.hasModuleInGraph(
 							chunk,
-							new WasmChunkLoadingRuntimeModule({
-								generateLoadBinaryCode,
-								supportsStreaming: true,
-								mangleImports: this.options.mangleImports,
-								runtimeRequirements: set
-							})
-						);
-					});
-			}
-		);
+							m => m.type === WEBASSEMBLY_MODULE_TYPE_SYNC
+						)
+					) {
+						return;
+					}
+					set.add(RuntimeGlobals.moduleCache);
+					set.add(RuntimeGlobals.publicPath);
+					compilation.addRuntimeModule(
+						chunk,
+						new WasmChunkLoadingRuntimeModule({
+							generateLoadBinaryCode,
+							supportsStreaming: true,
+							mangleImports: this.options.mangleImports,
+							runtimeRequirements: set
+						})
+					);
+				});
+		});
 	}
 }
 


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary 
<!-- cspell:disable-next-line -->
This PR adds "webassembly/async" and "webassembly/sync" and "json" module types to the ModuleTypes Constants and implements them across all of webpack's internal APIs.

## Details 
<!-- cspell:disable-next-line -->
* This PR (similar to #16896) takes and replaces all string literals of module types in webpack with constants from `ModuleTypeConstants`. This should reduce overall memory footprint of webpack, in addition to making code slightly easier to read. 
* This PR also hoists duplicate plugin name string literals to a single `PLUGIN_NAME` constant above each plugin declaration.