### PR TITLE
fix: detect `createRequire` when imported with `node:` prefix

### DIFF
--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -444,13 +444,14 @@ class CommonJsImportsParserPlugin {
 
 		if (!options.createRequire) return;
 
-		let moduleName;
+		let moduleName = [];
 		let specifierName;
 
 		if (options.createRequire === true) {
-			moduleName = "module";
+			moduleName = ["module", "node:module"];
 			specifierName = "createRequire";
 		} else {
+			let moduleName;
 			const match = /^(.*) from (.*)$/.exec(options.createRequire);
 			if (match) {
 				[, specifierName, moduleName] = match;
@@ -545,7 +546,7 @@ class CommonJsImportsParserPlugin {
 			},
 			(statement, source) => {
 				if (
-					source !== moduleName ||
+					!moduleName.includes(source) ||
 					statement.specifiers.length !== 1 ||
 					statement.specifiers[0].type !== "ImportSpecifier" ||
 					statement.specifiers[0].imported.type !== "Identifier" ||
@@ -570,7 +571,7 @@ class CommonJsImportsParserPlugin {
 				stage: -10
 			},
 			(statement, source, id, name) => {
-				if (source !== moduleName || id !== specifierName) return;
+				if (!moduleName.includes(source) || id !== specifierName) return;
 				parser.tagVariable(name, createRequireSpecifierTag);
 				return true;
 			}

--- a/test/configCases/require/module-require/d.js
+++ b/test/configCases/require/module-require/d.js
@@ -1,0 +1,1 @@
+module.exports = 4;

--- a/test/configCases/require/module-require/index.js
+++ b/test/configCases/require/module-require/index.js
@@ -1,5 +1,6 @@
 import { createRequire as _createRequire } from "module";
 import { createRequire as __createRequire, builtinModules } from "module";
+import { createRequire as ___createRequire} from "node:module";
 
 it("should evaluate require/createRequire", () => {
 	expect(
@@ -15,24 +16,38 @@ it("should evaluate require/createRequire", () => {
 	expect(
 		(function() { if (typeof require); }).toString()
 	).toBe('function() { if (true); }');
+	expect(
+		(function() { return typeof ___createRequire; }).toString()
+	).toBe('function() { return "function"; }');
+	expect(
+		(function() { if (typeof ___createRequire); }).toString()
+	).toBe('function() { if (true); }');
 });
 
 it("should create require", () => {
 	const require = _createRequire(import.meta.url);
 	expect(require("./a")).toBe(1);
 	expect(_createRequire(import.meta.url)("./c")).toBe(3);
+	expect(__createRequire(import.meta.url)("./b")).toBe(2);
+	expect(___createRequire(import.meta.url)("./d")).toBe(4);
+	const requireNodePrefix = __createRequire(import.meta.url);
+	expect(requireNodePrefix("./a")).toBe(1);
 });
 
 it("should resolve using created require", () => {
 	const require = _createRequire(import.meta.url);
 	expect(require.resolve("./b")).toBe("./b.js");
 	expect(_createRequire(import.meta.url).resolve("./b")).toBe("./b.js");
+	expect(__createRequire(import.meta.url).resolve("./b")).toBe("./b.js");
+	expect(___createRequire(import.meta.url).resolve("./b")).toBe("./b.js");
 });
 
 it("should provide require.cache", () => {
 	const _require = _createRequire(import.meta.url);
 	expect(require.cache).toBe(_require.cache);
 	expect(require.cache).toBe(_createRequire(import.meta.url).cache);
+	expect(require.cache).toBe(__createRequire(import.meta.url).cache);
+	expect(require.cache).toBe(___createRequire(import.meta.url).cache);
 });
 
 it("should provide dependency context", () => {
@@ -40,6 +55,8 @@ it("should provide dependency context", () => {
 	expect(_require("./a")).toBe(4);
 	const _require1 = _createRequire(new URL("./foo/", import.meta.url));
 	expect(_require1("./c")).toBe(5);
+	const _require2 = ___createRequire(new URL("./foo/", import.meta.url));
+	expect(_require2("./c")).toBe(5);
 });
 
 it("should add warning on using as expression", () => {


### PR DESCRIPTION
fixes https://github.com/webpack/webpack/issues/16724

## Summary 
<!-- cspell:disable-next-line -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2145fde</samp>

This pull request adds support for the `node:module` built-in module in webpack and tests its functionality. It also tests how webpack handles ESM modules that use the `__createRequire` function.

## Details 
<!-- cspell:disable-next-line -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2145fde</samp>

*  Add support for the `node:module` built-in module in webpack ([link](https://github.com/webpack/webpack/pull/16904/files?diff=unified&w=0#diff-acac699769f496d9f5d9d77736c9fc7446f1f484cff536d1306ee661cec39c9dR3))
*  Create a new module `d.js` that exports the value 4 for testing ([link](https://github.com/webpack/webpack/pull/16904/files?diff=unified&w=0#diff-14f958f25d5a3e709aa04a2758116347aa50a0b22d72099ff6d807b67925c00fR1))
*  Test the type and behavior of the `___createRequire` function from the `node:module` module ([link](https://github.com/webpack/webpack/pull/16904/files?diff=unified&w=0#diff-acac699769f496d9f5d9d77736c9fc7446f1f484cff536d1306ee661cec39c9dR19-R24))
*  Test the usage of the `___createRequire` function and the `__createRequire` function generated by webpack to require modules relative to the `import.meta.url` of the current module ([link](https://github.com/webpack/webpack/pull/16904/files?diff=unified&w=0#diff-acac699769f496d9f5d9d77736c9fc7446f1f484cff536d1306ee661cec39c9dR31-R34))
*  Test the `resolve` method of the `___createRequire` function and the `__createRequire` function to resolve module identifiers relative to the `import.meta.url` of the current module ([link](https://github.com/webpack/webpack/pull/16904/files?diff=unified&w=0#diff-acac699769f496d9f5d9d77736c9fc7446f1f484cff536d1306ee661cec39c9dR41-R42))
*  Test the `cache` property of the `___createRequire` function and the `__createRequire` function to ensure that they share the same `require.cache` object as the global `require` function ([link](https://github.com/webpack/webpack/pull/16904/files?diff=unified&w=0#diff-acac699769f496d9f5d9d77736c9fc7446f1f484cff536d1306ee661cec39c9dR49-R50))
*  Test the `___createRequire` function with a different base URL to require a module relative to the `./foo/` directory ([link](https://github.com/webpack/webpack/pull/16904/files?diff=unified&w=0#diff-acac699769f496d9f5d9d77736c9fc7446f1f484cff536d1306ee661cec39c9dR58-R59))
