### PR TITLE
fix: crossOriginLoading anonymous not work when loading styles

### DIFF
--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -111,7 +111,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 				? crossOriginLoading === "use-credentials"
 					? 'link.crossOrigin = "use-credentials";'
 					: Template.asString([
-							"if (link.src.indexOf(window.location.origin + '/') !== 0) {",
+							"if (link.href.indexOf(window.location.origin + '/') !== 0) {",
 							Template.indent(
 								`link.crossOrigin = ${JSON.stringify(crossOriginLoading)};`
 							),

--- a/test/configCases/crossorigin/set-crossorigin/index.js
+++ b/test/configCases/crossorigin/set-crossorigin/index.js
@@ -65,3 +65,17 @@ it("should load script with crossorigin attribute anonymous (different origin)",
 
 	return promise;
 });
+
+it("should load style with crossorigin attribute anonymous (different origin)", function() {
+	var originalValue = __webpack_public_path__;
+	__webpack_public_path__ = "https://example.com/";
+	const promise = import("./style.css?e" /* webpackChunkName: "crossorigin-different-origin" */);
+	__webpack_public_path__ = originalValue;
+
+	var link = document.head._children[0];
+
+	expect(link.href).toBe("https://example.com/crossorigin-different-origin.web.css");
+	expect(link.crossOrigin).toBe("anonymous");
+
+	return promise;
+});

--- a/test/configCases/crossorigin/set-crossorigin/style.css
+++ b/test/configCases/crossorigin/set-crossorigin/style.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/test/configCases/crossorigin/set-crossorigin/webpack.config.js
+++ b/test/configCases/crossorigin/set-crossorigin/webpack.config.js
@@ -10,5 +10,8 @@ module.exports = {
 	},
 	optimization: {
 		minimize: false
+	},
+	experiments: {
+		css: true
 	}
 };

--- a/test/helpers/FakeDocument.js
+++ b/test/helpers/FakeDocument.js
@@ -160,7 +160,9 @@ class FakeSheet {
 		let css = fs.readFileSync(
 			path.resolve(
 				this._basePath,
-				this._element.href.replace(/^https:\/\/test\.cases\/path\//, "")
+				this._element.href
+					.replace(/^https:\/\/test\.cases\/path\//, "")
+					.replace(/^https:\/\/example\.com\//, "")
 			),
 			"utf-8"
 		);


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary 

Fix crossOriginLoading anonymous not work when loading styles.

The `<link`> tag provides `href` attribute instead of `src` attribute, see [MDN - link](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link).

<!-- cspell:disable-next-line -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at be63915</samp>

This pull request fixes a bug in the css loading runtime module that handles the crossorigin attribute of link elements. It also adds a test case and updates the test helper module to cover the different origin scenario.

## Details 
<!-- cspell:disable-next-line -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at be63915</samp>

* Fix crossorigin attribute bug for relative URLs in css loading ([link](https://github.com/webpack/webpack/pull/16925/files?diff=unified&w=0#diff-1ede558d550bf27773fff6d4f110076dc6e187ddccbea0645a66c67742b689dbL114-R114))
* Add test case for loading style with crossorigin anonymous from different origin ([link](https://github.com/webpack/webpack/pull/16925/files?diff=unified&w=0#diff-cfea4967db0569f43edebf23299aef0f6a97cb2c606d4ef68bb02fd9a3d32d81R68-R81), [link](https://github.com/webpack/webpack/pull/16925/files?diff=unified&w=0#diff-ca564776cf7db2e1a3c6fb493008be7612def908646d6c3c42650083b55d6bb7R1-R3), [link](https://github.com/webpack/webpack/pull/16925/files?diff=unified&w=0#diff-7d661d07f1d5cc218f9872e31deff58a32075dd014fb2fbfb6951bf17fd01911R13-R15), [link](https://github.com/webpack/webpack/pull/16925/files?diff=unified&w=0#diff-898bb73d863040206e826fb36cae95d94b8df314d2203e0fc6da7ee7971b5affL163-R165))
