### PR TITLE
Fix non-deterministic moduleId assignment

### DIFF
--- a/lib/ids/OccurrenceModuleIdsPlugin.js
+++ b/lib/ids/OccurrenceModuleIdsPlugin.js
@@ -81,7 +81,7 @@ class OccurrenceModuleIdsPlugin {
 					] of moduleGraph.getIncomingConnectionsByOriginModule(module)) {
 						if (!originModule) continue;
 						if (!connections.some(c => c.isTargetActive(undefined))) continue;
-						sum += initialChunkChunkMap.get(originModule);
+						sum += (initialChunkChunkMap.get(originModule) || 0);
 					}
 					return sum;
 				};

--- a/lib/ids/OccurrenceModuleIdsPlugin.js
+++ b/lib/ids/OccurrenceModuleIdsPlugin.js
@@ -136,9 +136,6 @@ class OccurrenceModuleIdsPlugin {
 					if (prioritiseInitial) {
 						const aEntryOccurs = occursInInitialChunksMap.get(a);
 						const bEntryOccurs = occursInInitialChunksMap.get(b);
-						if (Number.isNaN(aEntryOccurs) || Number.isNaN(bEntryOccurs)) {
-							console.log("SCOTT: found occurrence");
-						}
 						if (aEntryOccurs > bEntryOccurs) return -1;
 						if (aEntryOccurs < bEntryOccurs) return 1;
 					}

--- a/lib/ids/OccurrenceModuleIdsPlugin.js
+++ b/lib/ids/OccurrenceModuleIdsPlugin.js
@@ -81,7 +81,7 @@ class OccurrenceModuleIdsPlugin {
 					] of moduleGraph.getIncomingConnectionsByOriginModule(module)) {
 						if (!originModule) continue;
 						if (!connections.some(c => c.isTargetActive(undefined))) continue;
-						sum += (initialChunkChunkMap.get(originModule) || 0);
+						sum += initialChunkChunkMap.get(originModule) || 0;
 					}
 					return sum;
 				};

--- a/lib/ids/OccurrenceModuleIdsPlugin.js
+++ b/lib/ids/OccurrenceModuleIdsPlugin.js
@@ -136,6 +136,9 @@ class OccurrenceModuleIdsPlugin {
 					if (prioritiseInitial) {
 						const aEntryOccurs = occursInInitialChunksMap.get(a);
 						const bEntryOccurs = occursInInitialChunksMap.get(b);
+						if (Number.isNaN(aEntryOccurs) || Number.isNaN(bEntryOccurs)) {
+							console.log("SCOTT: found occurrence");
+						}
 						if (aEntryOccurs > bEntryOccurs) return -1;
 						if (aEntryOccurs < bEntryOccurs) return 1;
 					}

--- a/test/configCases/contenthash/module-ids-size/async.js
+++ b/test/configCases/contenthash/module-ids-size/async.js
@@ -1,0 +1,10 @@
+export default function test() {
+	const a = 1;
+	const b = 2;
+	const c = 3;
+	const d = 4;
+	const f = 5;
+	const e = 6;
+
+	return a + b + c + d + f + e;
+}

--- a/test/configCases/contenthash/module-ids-size/file-1.js
+++ b/test/configCases/contenthash/module-ids-size/file-1.js
@@ -1,0 +1,19 @@
+async function test() {
+	const a = 1;
+	const b = 2;
+	const c = 3;
+	const d = 4;
+	const f = 5;
+	const e = 6;
+
+	await import("./async.js");
+
+	return a + b + c + d + f + e;
+}
+
+test();
+
+export { test }
+export default test;
+
+test();

--- a/test/configCases/contenthash/module-ids-size/file-2.js
+++ b/test/configCases/contenthash/module-ids-size/file-2.js
@@ -1,0 +1,5 @@
+import { test } from "./file-1.js";
+
+export default function foobar() {
+	return "test" + test();
+}

--- a/test/configCases/contenthash/module-ids-size/file-3.js
+++ b/test/configCases/contenthash/module-ids-size/file-3.js
@@ -1,0 +1,7 @@
+function test() {
+	return "test";
+}
+
+test();
+
+module.exports = "test";

--- a/test/configCases/contenthash/module-ids-size/file.js
+++ b/test/configCases/contenthash/module-ids-size/file.js
@@ -1,0 +1,25 @@
+import file from "./file-1.js";
+import file2 from "./file-2.js";
+
+async function test() {
+	const a = 1;
+	const b = 2;
+	const c = 3;
+	const d = 4;
+	const f = 5;
+	const e = 6;
+
+	await import(/* webpackMode: "eager" */"./async.js");
+	await import(/* webpackMode: "eager" */"./file-3.js");
+
+	return a + b + c + d + f + e;
+}
+
+test();
+
+export { test, file, file2 }
+export default function foo() {
+	return "test";
+}
+
+test();

--- a/test/configCases/contenthash/module-ids-size/index.js
+++ b/test/configCases/contenthash/module-ids-size/index.js
@@ -1,0 +1,7 @@
+import img from "./1.jpg";
+import file from "./file.js";
+
+it("should compile", () => {
+	expect(typeof img).toBe("string");
+	expect(typeof file).toBe("function");
+});

--- a/test/configCases/contenthash/module-ids-size/test.config.js
+++ b/test/configCases/contenthash/module-ids-size/test.config.js
@@ -19,7 +19,6 @@ module.exports = {
 
 		if (asset) allAssets.add(asset);
 
-
 		return `./${bundle}`;
 	},
 	afterExecute: () => {

--- a/test/configCases/contenthash/module-ids-size/test.config.js
+++ b/test/configCases/contenthash/module-ids-size/test.config.js
@@ -1,0 +1,29 @@
+const findOutputFiles = require("../../../helpers/findOutputFiles");
+
+const allAssets = new Set();
+const allBundles = new Set();
+
+module.exports = {
+	findBundle: function (i, options) {
+		const bundle = findOutputFiles(options, new RegExp(`^bundle${i}`))[0];
+
+		allBundles.add(/\.([^.]+)\./.exec(bundle)[1]);
+
+		let asset;
+
+		switch (i) {
+			case 0:
+				asset = findOutputFiles(options, /^1\.[^\.]*\.jpg$/, "img")[0];
+				break;
+		}
+
+		if (asset) allAssets.add(asset);
+
+
+		return `./${bundle}`;
+	},
+	afterExecute: () => {
+		// Bundles have the same contenthash
+		expect(allBundles.size).toBe(1);
+	}
+};

--- a/test/configCases/contenthash/module-ids-size/test.config.js
+++ b/test/configCases/contenthash/module-ids-size/test.config.js
@@ -13,7 +13,7 @@ module.exports = {
 
 		switch (i) {
 			case 0:
-				asset = findOutputFiles(options, /^1\.[^\.]*\.jpg$/, "img")[0];
+				asset = findOutputFiles(options, /^1\.[^.]*\.jpg$/, "img")[0];
 				break;
 		}
 

--- a/test/configCases/contenthash/module-ids-size/webpack.config.js
+++ b/test/configCases/contenthash/module-ids-size/webpack.config.js
@@ -1,0 +1,37 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = [
+	{
+		output: {
+			filename: "bundle0.[contenthash].a.js",
+			assetModuleFilename: "img/[name].a.[contenthash][ext]"
+		},
+		optimization: {
+			moduleIds: "size"
+		},
+		module: {
+			rules: [
+				{
+					test: /\.jpg$/,
+					type: "asset/resource"
+				}
+			]
+		}
+	},
+	{
+		output: {
+			filename: "bundle1.[contenthash].b.js",
+			assetModuleFilename: "img/[name].a.[contenthash][ext]"
+		},
+		optimization: {
+			moduleIds: "size"
+		},
+		module: {
+			rules: [
+				{
+					test: /\.jpg$/,
+					type: "asset/resource"
+				}
+			]
+		}
+	}
+];


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary 

Refactor occurrence order module ids algorithm (used when `moduleIds: "size"`) and fix a possible `NaN` bug in `OccurrenceModuleIdsPlugin.js`.

## Details 

See discussion https://github.com/webpack/webpack/discussions/16899 for more details.

The module sort was encountering NaN values, causing the sort to be non-deterministic, resulting in a different moduleId assignment being used in each build run when moduleIds: "size" is configured.  This causes the build to be slightly different in size each time it's run.

Fix is to ensure that a number is always used when constructing a sum value.  If a module is not found in the initial chunk map, use a `0` instead of `undefined`.
