### PR TITLE
docs: fix broken link & typo in examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -50,8 +50,6 @@
 [two-explicit-vendor-chunks](two-explicit-vendor-chunks)
 
 ## Code Splitted
-[code-splitted-css-bundle](code-splitted-css-bundle)
-
 [code-splitted-require.context-amd](code-splitted-require.context-amd) example demonstrating contexts in a code-split environment with AMD.
 
 [code-splitted-require.context](code-splitted-require.context) example demonstrating contexts in a code-split environment.
@@ -59,7 +57,7 @@
 ## Code Splitting
 [code-splitting](code-splitting) example demonstrating a very simple case of Code Splitting.
 
-[code-splitting-bundle-loader](code-splitting-bundle-loader) example demonstrating Code Splitting through the builder loader
+[code-splitting-bundle-loader](code-splitting-bundle-loader) example demonstrating Code Splitting through the bunlde loader
 
 [code-splitting-harmony](code-splitting-harmony)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -57,7 +57,7 @@
 ## Code Splitting
 [code-splitting](code-splitting) example demonstrating a very simple case of Code Splitting.
 
-[code-splitting-bundle-loader](code-splitting-bundle-loader) example demonstrating Code Splitting through the bunlde loader
+[code-splitting-bundle-loader](code-splitting-bundle-loader) example demonstrating Code Splitting through the bundle loader
 
 [code-splitting-harmony](code-splitting-harmony)
 


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary 

Fixes #15316
<!-- cspell:disable-next-line -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8d7dc5e</samp>

This pull request improves the documentation of the examples in `webpack/webpack`. It fixes a broken link and a typo in the `examples/README.md` file.

## Details 
<!-- cspell:disable-next-line -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8d7dc5e</samp>

* Remove a broken link to a non-existing example from the Chunk section of the README ([link](https://github.com/webpack/webpack/pull/16937/files?diff=unified&w=0#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9L53-L54))
* Fix a typo in the Code Splitting section of the README, replacing "builder" with "bundle" to match the `bundle-loader` used in the example ([link](https://github.com/webpack/webpack/pull/16937/files?diff=unified&w=0#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9L62-R60))
