### PR TITLE
support destructuring assignment in parser

### DIFF
--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -118,6 +118,7 @@ class RuntimeValue {
  * @param {string} key the defined key
  * @param {RuntimeTemplate} runtimeTemplate the runtime template
  * @param {boolean|undefined|null=} asiSafe asi safe (undefined: unknown, null: unneeded)
+ * @param {Set<string>|undefined=} objKeys used keys
  * @returns {string} code converted to string that evaluates
  */
 const stringifyObj = (
@@ -126,7 +127,8 @@ const stringifyObj = (
 	valueCacheVersions,
 	key,
 	runtimeTemplate,
-	asiSafe
+	asiSafe,
+	objKeys
 ) => {
 	let code;
 	let arr = Array.isArray(obj);
@@ -137,7 +139,12 @@ const stringifyObj = (
 			)
 			.join(",")}]`;
 	} else {
-		code = `{${Object.keys(obj)
+		let keys = Object.keys(obj);
+		if (objKeys) {
+			if (objKeys.size === 0) keys = [];
+			keys = keys.filter(k => objKeys.has(k));
+		}
+		code = `{${keys
 			.map(key => {
 				const code = obj[key];
 				return (
@@ -169,6 +176,7 @@ const stringifyObj = (
  * @param {string} key the defined key
  * @param {RuntimeTemplate} runtimeTemplate the runtime template
  * @param {boolean|undefined|null=} asiSafe asi safe (undefined: unknown, null: unneeded)
+ * @param {Set<string>|undefined=} objKeys used keys
  * @returns {string} code converted to string that evaluates
  */
 const toCode = (
@@ -177,7 +185,8 @@ const toCode = (
 	valueCacheVersions,
 	key,
 	runtimeTemplate,
-	asiSafe
+	asiSafe,
+	objKeys
 ) => {
 	if (code === null) {
 		return "null";
@@ -211,7 +220,8 @@ const toCode = (
 			valueCacheVersions,
 			key,
 			runtimeTemplate,
-			asiSafe
+			asiSafe,
+			objKeys
 		);
 	}
 	if (typeof code === "bigint") {
@@ -426,7 +436,8 @@ class DefinePlugin {
 									compilation.valueCacheVersions,
 									originalKey,
 									runtimeTemplate,
-									!parser.isAsiPosition(expr.range[0])
+									!parser.isAsiPosition(expr.range[0]),
+									parser.destructuringAssignmentKeysFor(expr)
 								);
 								if (WEBPACK_REQUIRE_FUNCTION_REGEXP.test(strCode)) {
 									return toConstantDependency(parser, strCode, [
@@ -523,7 +534,8 @@ class DefinePlugin {
 								compilation.valueCacheVersions,
 								key,
 								runtimeTemplate,
-								!parser.isAsiPosition(expr.range[0])
+								!parser.isAsiPosition(expr.range[0]),
+								parser.destructuringAssignmentKeysFor(expr)
 							);
 
 							if (WEBPACK_REQUIRE_FUNCTION_REGEXP.test(strCode)) {

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -142,7 +142,7 @@ const stringifyObj = (
 		let keys = Object.keys(obj);
 		if (objKeys) {
 			if (objKeys.size === 0) keys = [];
-			keys = keys.filter(k => objKeys.has(k));
+			else keys = keys.filter(k => objKeys.has(k));
 		}
 		code = `{${keys
 			.map(key => {
@@ -437,7 +437,7 @@ class DefinePlugin {
 									originalKey,
 									runtimeTemplate,
 									!parser.isAsiPosition(expr.range[0]),
-									parser.destructuringAssignmentKeysFor(expr)
+									parser.destructuringAssignmentPropertiesFor(expr)
 								);
 								if (WEBPACK_REQUIRE_FUNCTION_REGEXP.test(strCode)) {
 									return toConstantDependency(parser, strCode, [
@@ -535,7 +535,7 @@ class DefinePlugin {
 								key,
 								runtimeTemplate,
 								!parser.isAsiPosition(expr.range[0]),
-								parser.destructuringAssignmentKeysFor(expr)
+								parser.destructuringAssignmentPropertiesFor(expr)
 							);
 
 							if (WEBPACK_REQUIRE_FUNCTION_REGEXP.test(strCode)) {

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -187,7 +187,6 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			.for(harmonySpecifierTag)
 			.tap("HarmonyImportDependencyParserPlugin", expr => {
 				const settings = /** @type {HarmonySettings} */ (parser.currentTagData);
-				const keys = parser.destructuringAssignmentKeysFor(expr);
 				const dep = new HarmonyImportSpecifierDependency(
 					settings.source,
 					settings.sourceOrder,
@@ -197,7 +196,8 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 					exportPresenceMode,
 					settings.assertions
 				);
-				dep.referencedKeys = keys;
+				dep.referencedPropertiesInDestructuring =
+					parser.destructuringAssignmentPropertiesFor(expr);
 				dep.shorthand = parser.scope.inShorthand;
 				dep.directImport = true;
 				dep.asiSafe = !parser.isAsiPosition(expr.range[0]);
@@ -225,7 +225,6 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 									members.length - nonOptionalMembers.length
 							  )
 							: expression;
-					const keys = parser.destructuringAssignmentKeysFor(expr);
 					const ids = settings.ids.concat(nonOptionalMembers);
 					const dep = new HarmonyImportSpecifierDependency(
 						settings.source,
@@ -236,7 +235,8 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 						exportPresenceMode,
 						settings.assertions
 					);
-					dep.referencedKeys = keys;
+					dep.referencedPropertiesInDestructuring =
+						parser.destructuringAssignmentPropertiesFor(expr);
 					dep.asiSafe = !parser.isAsiPosition(expr.range[0]);
 					dep.loc = expr.loc;
 					parser.state.module.addDependency(dep);

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -187,6 +187,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			.for(harmonySpecifierTag)
 			.tap("HarmonyImportDependencyParserPlugin", expr => {
 				const settings = /** @type {HarmonySettings} */ (parser.currentTagData);
+				const keys = parser.destructuringAssignmentKeysFor(expr);
 				const dep = new HarmonyImportSpecifierDependency(
 					settings.source,
 					settings.sourceOrder,
@@ -196,6 +197,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 					exportPresenceMode,
 					settings.assertions
 				);
+				dep.referencedKeys = keys;
 				dep.shorthand = parser.scope.inShorthand;
 				dep.directImport = true;
 				dep.asiSafe = !parser.isAsiPosition(expr.range[0]);
@@ -223,6 +225,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 									members.length - nonOptionalMembers.length
 							  )
 							: expression;
+					const keys = parser.destructuringAssignmentKeysFor(expr);
 					const ids = settings.ids.concat(nonOptionalMembers);
 					const dep = new HarmonyImportSpecifierDependency(
 						settings.source,
@@ -233,6 +236,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 						exportPresenceMode,
 						settings.assertions
 					);
+					dep.referencedKeys = keys;
 					dep.asiSafe = !parser.isAsiPosition(expr.range[0]);
 					dep.loc = expr.loc;
 					parser.state.module.addDependency(dep);

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -265,7 +265,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		this.shorthand = read();
 		this.asiSafe = read();
 		this.usedByExports = read();
-		this.referencedKeys = read();
+		this.referencedPropertiesInDestructuring = read();
 		super.deserialize(context);
 	}
 }

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -53,7 +53,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		/** @type {Set<string> | boolean} */
 		this.usedByExports = undefined;
 		/** @type {Set<string>} */
-		this.referencedKeys = undefined;
+		this.referencedPropertiesInDestructuring = undefined;
 	}
 
 	// TODO webpack 6 remove
@@ -123,7 +123,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 	 */
 	getReferencedExports(moduleGraph, runtime) {
 		let ids = this.getIds(moduleGraph);
-		if (ids.length === 0) return this._getReferencedKeysExports();
+		if (ids.length === 0) return this._getReferencedExportsInDestructuring();
 		let namespaceObjectAsContext = this.namespaceObjectAsContext;
 		if (ids[0] === "default") {
 			const selfModule = moduleGraph.getParentModule(this);
@@ -136,7 +136,8 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 			) {
 				case "default-only":
 				case "default-with-named":
-					if (ids.length === 1) return this._getReferencedKeysExports();
+					if (ids.length === 1)
+						return this._getReferencedExportsInDestructuring();
 					ids = ids.slice(1);
 					namespaceObjectAsContext = true;
 					break;
@@ -154,18 +155,18 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 			ids = ids.slice(0, -1);
 		}
 
-		return this._getReferencedKeysExports(ids);
+		return this._getReferencedExportsInDestructuring(ids);
 	}
 
 	/**
 	 * @param {string[]=} ids ids
 	 * @returns {(string[] | ReferencedExport)[]} referenced exports
 	 */
-	_getReferencedKeysExports(ids) {
-		if (this.referencedKeys) {
+	_getReferencedExportsInDestructuring(ids) {
+		if (this.referencedPropertiesInDestructuring) {
 			/** @type {ReferencedExport[]} */
 			const refs = [];
-			for (const key of this.referencedKeys) {
+			for (const key of this.referencedPropertiesInDestructuring) {
 				refs.push({
 					name: ids ? ids.concat([key]) : [key],
 					canMangle: false
@@ -248,7 +249,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		write(this.shorthand);
 		write(this.asiSafe);
 		write(this.usedByExports);
-		write(this.referencedKeys);
+		write(this.referencedPropertiesInDestructuring);
 		super.serialize(context);
 	}
 

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -52,6 +52,8 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		this.asiSafe = undefined;
 		/** @type {Set<string> | boolean} */
 		this.usedByExports = undefined;
+		/** @type {Set<string>} */
+		this.referencedKeys = undefined;
 	}
 
 	// TODO webpack 6 remove
@@ -121,7 +123,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 	 */
 	getReferencedExports(moduleGraph, runtime) {
 		let ids = this.getIds(moduleGraph);
-		if (ids.length === 0) return Dependency.EXPORTS_OBJECT_REFERENCED;
+		if (ids.length === 0) return this._getReferencedKeysExports();
 		let namespaceObjectAsContext = this.namespaceObjectAsContext;
 		if (ids[0] === "default") {
 			const selfModule = moduleGraph.getParentModule(this);
@@ -134,7 +136,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 			) {
 				case "default-only":
 				case "default-with-named":
-					if (ids.length === 1) return Dependency.EXPORTS_OBJECT_REFERENCED;
+					if (ids.length === 1) return this._getReferencedKeysExports();
 					ids = ids.slice(1);
 					namespaceObjectAsContext = true;
 					break;
@@ -152,7 +154,27 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 			ids = ids.slice(0, -1);
 		}
 
-		return [ids];
+		return this._getReferencedKeysExports(ids);
+	}
+
+	/**
+	 * @param {string[]=} ids ids
+	 * @returns {(string[] | ReferencedExport)[]} referenced exports
+	 */
+	_getReferencedKeysExports(ids) {
+		if (this.referencedKeys) {
+			/** @type {ReferencedExport[]} */
+			const refs = [];
+			for (const key of this.referencedKeys) {
+				refs.push({
+					name: ids ? ids.concat([key]) : [key],
+					canMangle: false
+				});
+			}
+			return refs;
+		} else {
+			return ids ? [ids] : Dependency.EXPORTS_OBJECT_REFERENCED;
+		}
 	}
 
 	/**
@@ -226,6 +248,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		write(this.shorthand);
 		write(this.asiSafe);
 		write(this.usedByExports);
+		write(this.referencedKeys);
 		super.serialize(context);
 	}
 
@@ -241,6 +264,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		this.shorthand = read();
 		this.asiSafe = read();
 		this.usedByExports = read();
+		this.referencedKeys = read();
 		super.deserialize(context);
 	}
 }

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -2153,7 +2153,9 @@ class JavascriptParser extends Parser {
 		const ids = new Set();
 		const properties = objectPattern.properties;
 		for (let i = 0; i < properties.length; i++) {
-			const key = properties[i].key;
+			const property = properties[i];
+			if (property.type !== "Property") return;
+			const key = property.key;
 			if (key.type === "Identifier") {
 				ids.add(key.name);
 			} else {

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -331,6 +331,8 @@ class JavascriptParser extends Parser {
 		/** @type {(StatementNode|ExpressionNode)[]} */
 		this.statementPath = undefined;
 		this.prevStatement = undefined;
+		/** @type {WeakMap<ExpressionNode, Set<string>>} */
+		this.destructuringAssignmentKeys = undefined;
 		this.currentTagData = undefined;
 		this._initializeEvaluating();
 	}
@@ -1411,6 +1413,15 @@ class JavascriptParser extends Parser {
 			});
 	}
 
+	/**
+	 * @param {ExpressionNode} node node
+	 * @returns {Set<string>|undefined} destructured identifiers
+	 */
+	destructuringAssignmentKeysFor(node) {
+		if (!this.destructuringAssignmentKeys) return undefined;
+		return this.destructuringAssignmentKeys.get(node);
+	}
+
 	getRenameIdentifier(expr) {
 		const result = this.evaluateExpression(expr);
 		if (result.isIdentifier()) {
@@ -1557,6 +1568,8 @@ class JavascriptParser extends Parser {
 			case "ClassDeclaration":
 				this.blockPreWalkClassDeclaration(statement);
 				break;
+			case "ExpressionStatement":
+				this.blockPreWalkExpressionStatement(statement);
 		}
 		this.prevStatement = this.statementPath.pop();
 	}
@@ -1890,6 +1903,35 @@ class JavascriptParser extends Parser {
 		this.scope.topLevelScope = wasTopLevel;
 	}
 
+	blockPreWalkExpressionStatement(statement) {
+		const expression = statement.expression;
+		switch (expression.type) {
+			case "AssignmentExpression":
+				this.preWalkAssignmentExpression(expression);
+		}
+	}
+
+	preWalkAssignmentExpression(expression) {
+		if (
+			expression.left.type !== "ObjectPattern" ||
+			!this.destructuringAssignmentKeys
+		)
+			return;
+		const ids = this._preWalkObjectPattern(expression.left);
+		// check multiple assignments
+		if (this.destructuringAssignmentKeys.has(expression)) {
+			const set = this.destructuringAssignmentKeys.get(expression);
+			this.destructuringAssignmentKeys.delete(expression);
+			for (const id of set) ids.add(id);
+		}
+
+		this.destructuringAssignmentKeys.set(expression.right, ids);
+
+		if (expression.right.type === "AssignmentExpression") {
+			this.preWalkAssignmentExpression(expression.right);
+		}
+	}
+
 	blockPreWalkImportDeclaration(statement) {
 		const source = statement.source.value;
 		this.hooks.import.call(statement, source);
@@ -2087,6 +2129,7 @@ class JavascriptParser extends Parser {
 		for (const declarator of statement.declarations) {
 			switch (declarator.type) {
 				case "VariableDeclarator": {
+					this.preWalkVariableDeclarator(declarator);
 					if (!this.hooks.preDeclarator.call(declarator, statement)) {
 						this.enterPattern(declarator.id, (name, decl) => {
 							let hook = hookMap.get(name);
@@ -2101,6 +2144,49 @@ class JavascriptParser extends Parser {
 					break;
 				}
 			}
+		}
+	}
+
+	_preWalkObjectPattern(objectPattern) {
+		const ids = new Set();
+		const properties = objectPattern.properties;
+		for (let i = 0; i < properties.length; i++) {
+			const id = this.evaluateExpression(properties[i].key);
+			if (id.isIdentifier()) {
+				ids.add(
+					typeof id.identifier === "string"
+						? id.identifier
+						: /** @type {string} should be type string here otherwise syntax error */ (
+								id.identifier.freeName
+						  )
+				);
+			} else {
+				const str = id.asString();
+				if (str) {
+					ids.add(str);
+				} else {
+					// could not evaluate key
+					return;
+				}
+			}
+		}
+
+		return ids;
+	}
+
+	preWalkVariableDeclarator(declarator) {
+		if (
+			declarator.id.type !== "ObjectPattern" ||
+			!this.destructuringAssignmentKeys
+		)
+			return;
+		this.destructuringAssignmentKeys.set(
+			declarator.init,
+			this._preWalkObjectPattern(declarator.id)
+		);
+
+		if (declarator.init.type === "AssignmentExpression") {
+			this.preWalkAssignmentExpression(declarator.init);
 		}
 	}
 
@@ -3367,12 +3453,14 @@ class JavascriptParser extends Parser {
 		this.statementPath = [];
 		this.prevStatement = undefined;
 		if (this.hooks.program.call(ast, comments) === undefined) {
+			this.destructuringAssignmentKeys = new WeakMap();
 			this.detectMode(ast.body);
 			this.preWalkStatements(ast.body);
 			this.prevStatement = undefined;
 			this.blockPreWalkStatements(ast.body);
 			this.prevStatement = undefined;
 			this.walkStatements(ast.body);
+			this.destructuringAssignmentKeys = undefined;
 		}
 		this.hooks.finish.call(ast, comments);
 		this.scope = oldScope;

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -1917,15 +1917,17 @@ class JavascriptParser extends Parser {
 			!this.destructuringAssignmentKeys
 		)
 			return;
-		const ids = this._preWalkObjectPattern(expression.left);
+		const keys = this._preWalkObjectPattern(expression.left);
+		if (!keys) return;
+
 		// check multiple assignments
 		if (this.destructuringAssignmentKeys.has(expression)) {
 			const set = this.destructuringAssignmentKeys.get(expression);
 			this.destructuringAssignmentKeys.delete(expression);
-			for (const id of set) ids.add(id);
+			for (const id of set) keys.add(id);
 		}
 
-		this.destructuringAssignmentKeys.set(expression.right, ids);
+		this.destructuringAssignmentKeys.set(expression.right, keys);
 
 		if (expression.right.type === "AssignmentExpression") {
 			this.preWalkAssignmentExpression(expression.right);
@@ -2151,16 +2153,11 @@ class JavascriptParser extends Parser {
 		const ids = new Set();
 		const properties = objectPattern.properties;
 		for (let i = 0; i < properties.length; i++) {
-			const id = this.evaluateExpression(properties[i].key);
-			if (id.isIdentifier()) {
-				ids.add(
-					typeof id.identifier === "string"
-						? id.identifier
-						: /** @type {string} should be type string here otherwise syntax error */ (
-								id.identifier.freeName
-						  )
-				);
+			const key = properties[i].key;
+			if (key.type === "Identifier") {
+				ids.add(key.name);
 			} else {
+				const id = this.evaluateExpression(key);
 				const str = id.asString();
 				if (str) {
 					ids.add(str);
@@ -2180,10 +2177,10 @@ class JavascriptParser extends Parser {
 			!this.destructuringAssignmentKeys
 		)
 			return;
-		this.destructuringAssignmentKeys.set(
-			declarator.init,
-			this._preWalkObjectPattern(declarator.id)
-		);
+		const keys = this._preWalkObjectPattern(declarator.id);
+
+		if (!keys) return;
+		this.destructuringAssignmentKeys.set(declarator.init, keys);
 
 		if (declarator.init.type === "AssignmentExpression") {
 			this.preWalkAssignmentExpression(declarator.init);

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -2173,6 +2173,7 @@ class JavascriptParser extends Parser {
 
 	preWalkVariableDeclarator(declarator) {
 		if (
+			!declarator.init ||
 			declarator.id.type !== "ObjectPattern" ||
 			!this.destructuringAssignmentKeys
 		)

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -332,7 +332,7 @@ class JavascriptParser extends Parser {
 		this.statementPath = undefined;
 		this.prevStatement = undefined;
 		/** @type {WeakMap<ExpressionNode, Set<string>>} */
-		this.destructuringAssignmentKeys = undefined;
+		this.destructuringAssignmentProperties = undefined;
 		this.currentTagData = undefined;
 		this._initializeEvaluating();
 	}
@@ -1417,9 +1417,9 @@ class JavascriptParser extends Parser {
 	 * @param {ExpressionNode} node node
 	 * @returns {Set<string>|undefined} destructured identifiers
 	 */
-	destructuringAssignmentKeysFor(node) {
-		if (!this.destructuringAssignmentKeys) return undefined;
-		return this.destructuringAssignmentKeys.get(node);
+	destructuringAssignmentPropertiesFor(node) {
+		if (!this.destructuringAssignmentProperties) return undefined;
+		return this.destructuringAssignmentProperties.get(node);
 	}
 
 	getRenameIdentifier(expr) {
@@ -1914,20 +1914,20 @@ class JavascriptParser extends Parser {
 	preWalkAssignmentExpression(expression) {
 		if (
 			expression.left.type !== "ObjectPattern" ||
-			!this.destructuringAssignmentKeys
+			!this.destructuringAssignmentProperties
 		)
 			return;
 		const keys = this._preWalkObjectPattern(expression.left);
 		if (!keys) return;
 
 		// check multiple assignments
-		if (this.destructuringAssignmentKeys.has(expression)) {
-			const set = this.destructuringAssignmentKeys.get(expression);
-			this.destructuringAssignmentKeys.delete(expression);
+		if (this.destructuringAssignmentProperties.has(expression)) {
+			const set = this.destructuringAssignmentProperties.get(expression);
+			this.destructuringAssignmentProperties.delete(expression);
 			for (const id of set) keys.add(id);
 		}
 
-		this.destructuringAssignmentKeys.set(expression.right, keys);
+		this.destructuringAssignmentProperties.set(expression.right, keys);
 
 		if (expression.right.type === "AssignmentExpression") {
 			this.preWalkAssignmentExpression(expression.right);
@@ -2177,13 +2177,13 @@ class JavascriptParser extends Parser {
 		if (
 			!declarator.init ||
 			declarator.id.type !== "ObjectPattern" ||
-			!this.destructuringAssignmentKeys
+			!this.destructuringAssignmentProperties
 		)
 			return;
 		const keys = this._preWalkObjectPattern(declarator.id);
 
 		if (!keys) return;
-		this.destructuringAssignmentKeys.set(declarator.init, keys);
+		this.destructuringAssignmentProperties.set(declarator.init, keys);
 
 		if (declarator.init.type === "AssignmentExpression") {
 			this.preWalkAssignmentExpression(declarator.init);
@@ -3453,14 +3453,14 @@ class JavascriptParser extends Parser {
 		this.statementPath = [];
 		this.prevStatement = undefined;
 		if (this.hooks.program.call(ast, comments) === undefined) {
-			this.destructuringAssignmentKeys = new WeakMap();
+			this.destructuringAssignmentProperties = new WeakMap();
 			this.detectMode(ast.body);
 			this.preWalkStatements(ast.body);
 			this.prevStatement = undefined;
 			this.blockPreWalkStatements(ast.body);
 			this.prevStatement = undefined;
 			this.walkStatements(ast.body);
-			this.destructuringAssignmentKeys = undefined;
+			this.destructuringAssignmentProperties = undefined;
 		}
 		this.hooks.finish.call(ast, comments);
 		this.scope = oldScope;

--- a/test/cases/parsing/harmony-destructuring-assignment/counter.js
+++ b/test/cases/parsing/harmony-destructuring-assignment/counter.js
@@ -1,0 +1,7 @@
+export let counter = 0;
+export const d = 1;
+
+export const exportsInfo = {
+	counter: __webpack_exports_info__.counter.used,
+	d: __webpack_exports_info__.d.used
+};

--- a/test/cases/parsing/harmony-destructuring-assignment/counter2.js
+++ b/test/cases/parsing/harmony-destructuring-assignment/counter2.js
@@ -1,0 +1,7 @@
+export let counter = 0;
+export const d = 1;
+
+export const exportsInfo = {
+	counter: __webpack_exports_info__.counter.used,
+	d: __webpack_exports_info__.d.used
+};

--- a/test/cases/parsing/harmony-destructuring-assignment/counter3.js
+++ b/test/cases/parsing/harmony-destructuring-assignment/counter3.js
@@ -1,9 +1,7 @@
 export let counter = 0;
 export const d = 1;
-export const c = 1;
 
 export const exportsInfo = {
 	counter: __webpack_exports_info__.counter.used,
-	d: __webpack_exports_info__.d.used,
-	c: __webpack_exports_info__.c.used
+	d: __webpack_exports_info__.d.used
 };

--- a/test/cases/parsing/harmony-destructuring-assignment/counter4.js
+++ b/test/cases/parsing/harmony-destructuring-assignment/counter4.js
@@ -1,0 +1,15 @@
+export let counter = 0;
+export const d = 1;
+export const c = 1;
+export const e = 1;
+export const f = 1;
+export const g = 1;
+
+export const exportsInfo = {
+	counter: __webpack_exports_info__.counter.used,
+	d: __webpack_exports_info__.d.used,
+	c: __webpack_exports_info__.c.used,
+	e: __webpack_exports_info__.e.used,
+	f: __webpack_exports_info__.f.used,
+	g: __webpack_exports_info__.g.used
+};

--- a/test/cases/parsing/harmony-destructuring-assignment/index.js
+++ b/test/cases/parsing/harmony-destructuring-assignment/index.js
@@ -3,6 +3,7 @@ import { counter } from "./reexport-namespace";
 import { exportsInfo } from "./counter";
 import { exportsInfo as exportsInfo2 } from "./counter2";
 import * as counter3 from "./counter3";
+import * as counter4 from "./counter4";
 
 it("expect tree-shake unused exports #1", () => {
 	const { D } = C;
@@ -20,6 +21,23 @@ it("expect tree-shake unused exports #2", () => {
 	expect(exportsInfo.d).toBe(true);
 	expect(exportsInfo.c).toBe(true);
 	expect(exportsInfo.counter).toBe(false);
+});
+
+it("expect multiple assignment work correctly", () => {
+	const { e, d: d1 } = counter4;
+	let c1;
+	const { f, d: d2 } = { c: c1 } = counter4;
+	expect(c1).toBe(1);
+	expect(d1).toBe(1);
+	expect(d2).toBe(1);
+	expect(e).toBe(1);
+	expect(f).toBe(1);
+	expect(counter4.exportsInfo.c).toBe(true);
+	expect(counter4.exportsInfo.d).toBe(true);
+	expect(counter4.exportsInfo.e).toBe(true);
+	expect(counter4.exportsInfo.f).toBe(true);
+	expect(counter4.exportsInfo.g).toBe(false);
+	expect(counter4.exportsInfo.counter).toBe(false);
 });
 
 it("expect tree-shake bailout when rest element is used", () => {

--- a/test/cases/parsing/harmony-destructuring-assignment/index.js
+++ b/test/cases/parsing/harmony-destructuring-assignment/index.js
@@ -1,0 +1,27 @@
+import * as C from "./reexport-namespace";
+import { counter } from "./reexport-namespace";
+import { exportsInfo } from "./counter";
+import { exportsInfo as exportsInfo2 } from "./counter2";
+
+it("expect tree-shake unused exports #1", () => {
+	const { D } = C;
+	expect(D).toBe(1);
+	expect(C.exportsInfo.D).toBe(true);
+	expect(C.exportsInfo.E).toBe(false);
+});
+
+it("expect tree-shake unused exports #2", () => {
+	const { d } = C.counter;
+	const { ['d']: d1 } = counter;
+	expect(d).toBe(1);
+	expect(d1).toBe(1);
+	expect(exportsInfo.d).toBe(true);
+	expect(exportsInfo.counter).toBe(false);
+});
+
+it("expect no support of \"deep\" tree-shaking", () => {
+	const { counter2: { d } } = C;
+	expect(d).toBe(1);
+	expect(exportsInfo2.d).toBe(true);
+	expect(exportsInfo2.counter).toBe(true);
+});

--- a/test/cases/parsing/harmony-destructuring-assignment/index.js
+++ b/test/cases/parsing/harmony-destructuring-assignment/index.js
@@ -2,6 +2,7 @@ import * as C from "./reexport-namespace";
 import { counter } from "./reexport-namespace";
 import { exportsInfo } from "./counter";
 import { exportsInfo as exportsInfo2 } from "./counter2";
+import * as counter3 from "./counter3";
 
 it("expect tree-shake unused exports #1", () => {
 	const { D } = C;
@@ -11,12 +12,21 @@ it("expect tree-shake unused exports #1", () => {
 });
 
 it("expect tree-shake unused exports #2", () => {
-	const { d } = C.counter;
+	const { d, c } = C.counter;
 	const { ['d']: d1 } = counter;
 	expect(d).toBe(1);
+	expect(c).toBe(1);
 	expect(d1).toBe(1);
 	expect(exportsInfo.d).toBe(true);
+	expect(exportsInfo.c).toBe(true);
 	expect(exportsInfo.counter).toBe(false);
+});
+
+it("expect tree-shake bailout when rest element is used", () => {
+	const { d, ...rest } = counter3;
+	expect(d).toBe(1);
+	expect(rest.exportsInfo.d).toBe(true);
+	expect(rest.exportsInfo.counter).toBe(true);
 });
 
 it("expect no support of \"deep\" tree-shaking", () => {

--- a/test/cases/parsing/harmony-destructuring-assignment/reexport-namespace.js
+++ b/test/cases/parsing/harmony-destructuring-assignment/reexport-namespace.js
@@ -1,0 +1,14 @@
+import * as counter from "./counter";
+export { counter };
+import * as counter2 from "./counter2";
+export { counter2 };
+
+export const D = 1;
+export const E = 1;
+
+export const exportsInfo = {
+	D: __webpack_exports_info__.D.used,
+	E: __webpack_exports_info__.E.used,
+	counter: __webpack_exports_info__.counter.used,
+	counter2: __webpack_exports_info__.counter2.used,
+};

--- a/test/cases/parsing/harmony-destructuring-assignment/test.filter.js
+++ b/test/cases/parsing/harmony-destructuring-assignment/test.filter.js
@@ -1,0 +1,4 @@
+module.exports = function(config) {
+	// This test can't run in development mode
+	return config.mode !== "development";
+};

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -248,3 +248,9 @@ it("should expand properly", function() {
 	expect(require("./dir/" + (tmp + A_DOT_J + tmp) + "s")).toBe(a);
 	expect(require("./dir/" + (tmp + A_DOT_J) + tmp + "s")).toBe(a);
 });
+
+it("destructuring assignment", () => {
+	const {used} = OBJECT2;
+	const {['used']: used2} = OBJECT2.sub;
+	expect(used).toBe(used2);
+});

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -251,6 +251,7 @@ it("should expand properly", function() {
 
 it("destructuring assignment", () => {
 	const {used} = OBJECT2;
-	const {['used']: used2} = OBJECT2.sub;
+	const {['used']: used2, used: used3} = OBJECT2.sub;
 	expect(used).toBe(used2);
+	expect(used).toBe(used3);
 });

--- a/test/configCases/plugins/define-plugin/webpack.config.js
+++ b/test/configCases/plugins/define-plugin/webpack.config.js
@@ -47,7 +47,15 @@ module.exports = {
 					return module instanceof Module;
 				}
 			),
-			A_DOT_J: '"a.j"'
+			A_DOT_J: '"a.j"',
+			OBJECT2: {
+				used: 1,
+				unused: "(() => throw new Error('unused property was rendered'))()",
+				sub: {
+					used: 1,
+					unused: "(() => throw new Error('unused property was rendered'))()"
+				}
+			}
 		})
 	]
 };

--- a/types.d.ts
+++ b/types.d.ts
@@ -5277,9 +5277,11 @@ declare class JavascriptParser extends Parser {
 		| ForOfStatement
 	)[];
 	prevStatement: any;
-	destructuringAssignmentKeys: WeakMap<Expression, Set<string>>;
+	destructuringAssignmentProperties: WeakMap<Expression, Set<string>>;
 	currentTagData: any;
-	destructuringAssignmentKeysFor(node: Expression): undefined | Set<string>;
+	destructuringAssignmentPropertiesFor(
+		node: Expression
+	): undefined | Set<string>;
 	getRenameIdentifier(expr?: any): undefined | string | VariableInfoInterface;
 	walkClass(classy: ClassExpression | ClassDeclaration): void;
 	preWalkStatements(statements?: any): void;

--- a/types.d.ts
+++ b/types.d.ts
@@ -5277,7 +5277,9 @@ declare class JavascriptParser extends Parser {
 		| ForOfStatement
 	)[];
 	prevStatement: any;
+	destructuringAssignmentKeys: WeakMap<Expression, Set<string>>;
 	currentTagData: any;
+	destructuringAssignmentKeysFor(node: Expression): undefined | Set<string>;
 	getRenameIdentifier(expr?: any): undefined | string | VariableInfoInterface;
 	walkClass(classy: ClassExpression | ClassDeclaration): void;
 	preWalkStatements(statements?: any): void;
@@ -5321,6 +5323,8 @@ declare class JavascriptParser extends Parser {
 	walkForOfStatement(statement?: any): void;
 	preWalkFunctionDeclaration(statement?: any): void;
 	walkFunctionDeclaration(statement?: any): void;
+	blockPreWalkExpressionStatement(statement?: any): void;
+	preWalkAssignmentExpression(expression?: any): void;
 	blockPreWalkImportDeclaration(statement?: any): void;
 	enterDeclaration(declaration?: any, onIdent?: any): void;
 	blockPreWalkExportNamedDeclaration(statement?: any): void;
@@ -5330,6 +5334,7 @@ declare class JavascriptParser extends Parser {
 	blockPreWalkExportAllDeclaration(statement?: any): void;
 	preWalkVariableDeclaration(statement?: any): void;
 	blockPreWalkVariableDeclaration(statement?: any): void;
+	preWalkVariableDeclarator(declarator?: any): void;
 	walkVariableDeclaration(statement?: any): void;
 	blockPreWalkClassDeclaration(statement?: any): void;
 	walkClassDeclaration(statement?: any): void;


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->






related to https://github.com/webpack/webpack/issues/14800

## TODO

Other features like async/await could be added in another PR

## Summary 
<!-- cspell:disable-next-line -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9bb35fb</samp>

This pull request enhances the `DefinePlugin` class to optimize the code generation for object expressions that are replaced by `RuntimeValue` instances. It also adds support for tracking the used keys of destructuring assignment expressions in object patterns, and updates the `JavascriptParser` class accordingly. It includes a new test case to verify the functionality of the `DefinePlugin` with `RuntimeValue` instances.

## Details 
<!-- cspell:disable-next-line -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9bb35fb</samp>

*  Add a new parameter `objKeys` to the `RuntimeValue` class and its methods to optimize the code generation for object expressions ([link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR121), [link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fL129-R131), [link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fL140-R147), [link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR179), [link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fL180-R189), [link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fL214-R224))
*  Pass the `objKeys` parameter to the `toCode` function call in the `DefinePlugin` class, where it replaces expressions with `RuntimeValue` instances ([link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fL429-R440), [link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fL526-R538))
*  Obtain the `objKeys` parameter from the `parser.destructuringAssignmentKeysFor` method, which returns the set of used keys for a destructuring assignment expression ([link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fL429-R440), [link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fL526-R538))
*  Add a new property `destructuringAssignmentKeys` and a new method `destructuringAssignmentKeysFor` to the `JavascriptParser` class to store and retrieve the used keys for each destructuring assignment expression node ([link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R334-R335), [link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R1416-R1424))
*  Update the `blockPreWalkStatements`, `preWalkStatements`, and `preWalkAssignmentExpression` methods of the `JavascriptParser` class to handle expression statements, variable declarators, and assignment expressions with object patterns, and set the `destructuringAssignmentKeys` property accordingly ([link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R1571-R1572), [link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R1906-R1934), [link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R2132), [link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R2150-R2192))
*  Initialize and reset the `destructuringAssignmentKeys` property of the `JavascriptParser` class in the `enterBlock` and `leaveBlock` methods, which are called when entering and leaving a block scope ([link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R3456), [link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R3463))
*  Add a new test case to the `define-plugin` config case in `test/configCases/plugins/define-plugin/index.js` and `test/configCases/plugins/define-plugin/webpack.config.js` to check the functionality and optimization of the `DefinePlugin` with object expressions and destructuring assignments ([link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-bd719cd6133b58bf9097aa2433aec65afc238089a8a26de1ca429f3de5a78e42R251-R256), [link](https://github.com/webpack/webpack/pull/16941/files?diff=unified&w=0#diff-ccf559fb3a2b0889614c0039c51adb3f5721a9e24508103dcedffad009441e41L50-R58))
