### PR TITLE
fix: handle callback correctly in the `readRecords` compiler hook

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -970,10 +970,13 @@ ${other}`);
 	readRecords(callback) {
 		if (this.hooks.readRecords.isUsed()) {
 			if (this.recordsInputPath) {
-				asyncLib.parallel([
-					cb => this.hooks.readRecords.callAsync(cb),
-					this._readRecords.bind(this)
-				]);
+				asyncLib.parallel(
+					[
+						cb => this.hooks.readRecords.callAsync(cb),
+						this._readRecords.bind(this)
+					],
+					err => callback(err)
+				);
 			} else {
 				this.records = {};
 				this.hooks.readRecords.callAsync(callback);

--- a/test/configCases/records/with-readRecords-hook/ReadRecordsPlugin.js
+++ b/test/configCases/records/with-readRecords-hook/ReadRecordsPlugin.js
@@ -1,0 +1,12 @@
+class ReadRecordsPlugin {
+	apply(compiler) {
+		compiler.hooks.readRecords.tapAsync("ReadRecordsPlugin", callback => {
+			setTimeout(() => {
+				console.log("Done with reading records.");
+				callback();
+			}, 1000);
+		});
+	}
+}
+
+module.exports = ReadRecordsPlugin;

--- a/test/configCases/records/with-readRecords-hook/async.js
+++ b/test/configCases/records/with-readRecords-hook/async.js
@@ -1,0 +1,1 @@
+import "vendor";

--- a/test/configCases/records/with-readRecords-hook/index.js
+++ b/test/configCases/records/with-readRecords-hook/index.js
@@ -1,0 +1,3 @@
+it("should load fine", () => {
+	return import(/* webpackChunkName: "async" */"./async");
+});

--- a/test/configCases/records/with-readRecords-hook/records.json
+++ b/test/configCases/records/with-readRecords-hook/records.json
@@ -1,0 +1,10 @@
+{
+  "chunks": {
+    "byName": {
+      "vendors~async": 123
+    },
+    "bySource": {
+      "1 index.js ./async": 123
+    }
+  }
+}

--- a/test/configCases/records/with-readRecords-hook/webpack.config.js
+++ b/test/configCases/records/with-readRecords-hook/webpack.config.js
@@ -1,0 +1,17 @@
+const path = require("path");
+const ReadRecordsPlugin = require("./ReadRecordsPlugin");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: "./index",
+	recordsInputPath: path.resolve(__dirname, "records.json"),
+	output: {
+		chunkFilename: "[name]-[chunkhash].js"
+	},
+	plugins: [new ReadRecordsPlugin()],
+	optimization: {
+		splitChunks: {
+			minSize: 0
+		}
+	}
+};


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary
Fixes https://github.com/webpack/webpack/pull/16301
<!-- cspell:disable-next-line -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d011d86</samp>

This pull request fixes a bug that caused the compiler to hang when using the `readRecords` hook, and adds a new test case to verify the chunk splitting and naming based on the records. The test case uses a new plugin and a mock records file to simulate the `readRecords` hook functionality.

## Details 
<!-- cspell:disable-next-line -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d011d86</samp>

* Fix a bug that caused the compiler to hang when using the `readRecords` hook ([link](https://github.com/webpack/webpack/pull/16944/files?diff=unified&w=0#diff-732395f8fcd972919381425c80194bb0def0a2af50c0940762299605a81c0006L973-R979))
* Add a new plugin class `ReadRecordsPlugin` that simulates some asynchronous work before reading the records ([link](https://github.com/webpack/webpack/pull/16944/files?diff=unified&w=0#diff-1a380c894e2848b904f574fcf84ad18ec64655f0a159e570f1988da838fcb33aR1-R12))
* Add a new test case in `index.js` that dynamically imports `async.js` and expects it to load fine ([link](https://github.com/webpack/webpack/pull/16944/files?diff=unified&w=0#diff-abece936e3f8ac69d429557292343698bc5211f895ab5f5b768b8555f8efdf7fR1-R3))
* Add a new module `async.js` that imports a vendor module for testing the chunk splitting and naming based on the records ([link](https://github.com/webpack/webpack/pull/16944/files?diff=unified&w=0#diff-615fa3fa5607bc53ed22a0518fd44023d70ea3c41b9e0d4c62c46576dd7f2099R1))
* Add a new file `records.json` that contains some mock records for the chunks ([link](https://github.com/webpack/webpack/pull/16944/files?diff=unified&w=0#diff-09eb8d024aa5aef80c2fed8aeafc827f5c0556c2c3df3ad576b1fb60e37752e7R1-R10))
* Add a new webpack configuration file that sets the entry point, the records input path, the output chunk filename, the `ReadRecordsPlugin` and the split chunks optimization ([link](https://github.com/webpack/webpack/pull/16944/files?diff=unified&w=0#diff-bc6d6480980ac4ad9d321786428c57cf2612eb8e9d2c9e89965578732cebb410R1-R17))
