### PR TITLE
fix: failed with debug hash

### DIFF
--- a/lib/util/createHash.js
+++ b/lib/util/createHash.js
@@ -121,7 +121,7 @@ class DebugHash extends Hash {
 	 * @returns {string|Buffer} digest
 	 */
 	digest(encoding) {
-		return Buffer.from(this.string + "@webpack-debug-digest@").toString("hex");
+		return Buffer.from("@webpack-debug-digest@" + this.string).toString("hex");
 	}
 }
 

--- a/lib/util/createHash.js
+++ b/lib/util/createHash.js
@@ -107,8 +107,9 @@ class DebugHash extends Hash {
 	 */
 	update(data, inputEncoding) {
 		if (typeof data !== "string") data = data.toString("utf-8");
-		if (data.startsWith("debug-digest-")) {
-			data = Buffer.from(data.slice("debug-digest-".length), "hex").toString();
+		const prefix = Buffer.from("@webpack-debug-digest@").toString("hex");
+		if (data.startsWith(prefix)) {
+			data = Buffer.from(data.slice(prefix.length), "hex").toString();
 		}
 		this.string += `[${data}](${new Error().stack.split("\n", 3)[2]})\n`;
 		return this;
@@ -120,7 +121,7 @@ class DebugHash extends Hash {
 	 * @returns {string|Buffer} digest
 	 */
 	digest(encoding) {
-		return "debug-digest-" + Buffer.from(this.string).toString("hex");
+		return Buffer.from(this.string + "@webpack-debug-digest@").toString("hex");
 	}
 }
 

--- a/test/configCases/custom-hash-function/debug-hash/files/file1.js
+++ b/test/configCases/custom-hash-function/debug-hash/files/file1.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/custom-hash-function/debug-hash/files/file10.js
+++ b/test/configCases/custom-hash-function/debug-hash/files/file10.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/custom-hash-function/debug-hash/files/file11.js
+++ b/test/configCases/custom-hash-function/debug-hash/files/file11.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/custom-hash-function/debug-hash/files/file12.js
+++ b/test/configCases/custom-hash-function/debug-hash/files/file12.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/custom-hash-function/debug-hash/files/file13.js
+++ b/test/configCases/custom-hash-function/debug-hash/files/file13.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/custom-hash-function/debug-hash/files/file14.js
+++ b/test/configCases/custom-hash-function/debug-hash/files/file14.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/custom-hash-function/debug-hash/files/file15.js
+++ b/test/configCases/custom-hash-function/debug-hash/files/file15.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/custom-hash-function/debug-hash/files/file2.js
+++ b/test/configCases/custom-hash-function/debug-hash/files/file2.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/custom-hash-function/debug-hash/files/file3.js
+++ b/test/configCases/custom-hash-function/debug-hash/files/file3.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/custom-hash-function/debug-hash/files/file4.js
+++ b/test/configCases/custom-hash-function/debug-hash/files/file4.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/custom-hash-function/debug-hash/files/file5.js
+++ b/test/configCases/custom-hash-function/debug-hash/files/file5.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/custom-hash-function/debug-hash/files/file6.js
+++ b/test/configCases/custom-hash-function/debug-hash/files/file6.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/custom-hash-function/debug-hash/files/file7.js
+++ b/test/configCases/custom-hash-function/debug-hash/files/file7.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/custom-hash-function/debug-hash/files/file8.js
+++ b/test/configCases/custom-hash-function/debug-hash/files/file8.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/custom-hash-function/debug-hash/files/file9.js
+++ b/test/configCases/custom-hash-function/debug-hash/files/file9.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/custom-hash-function/debug-hash/index.js
+++ b/test/configCases/custom-hash-function/debug-hash/index.js
@@ -1,0 +1,8 @@
+it("debug hash should works", function () {
+	var ids = [];
+	for(var i = 1; i <= 15; i++) {
+		var id = require("./files/file" + i + ".js");
+		expect(ids.indexOf(id)).toBe(-1);
+		ids.push(id);
+	}
+});

--- a/test/configCases/custom-hash-function/debug-hash/webpack.config.js
+++ b/test/configCases/custom-hash-function/debug-hash/webpack.config.js
@@ -1,0 +1,8 @@
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		output: {
+			hashFunction: "debug"
+		}
+	}
+];


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary 

It was failed at https://github.com/webpack/webpack/blob/5695e98d05101df142909c01e5cbe07c5e4573f3/lib/ChunkGraph.js#L1564

<!-- cspell:disable-next-line -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6689026</samp>

Add a hex prefix for debug hashes in `createHash` utility. This enhances the debug mode and prevents hash conflicts.

## Details 
<!-- cspell:disable-next-line -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6689026</samp>

* Change the debug hash prefix to `@webpack-debug-digest@` in hex for more uniqueness and consistency ([link](https://github.com/webpack/webpack/pull/16950/files?diff=unified&w=0#diff-367809774077aa963dfccd23717f9ab3eebe493f40f242ae5168ef5c4d8613e3L110-R112), [link](https://github.com/webpack/webpack/pull/16950/files?diff=unified&w=0#diff-367809774077aa963dfccd23717f9ab3eebe493f40f242ae5168ef5c4d8613e3L123-R124))
* Update the `update` method in `createHash.js` to check for and remove the new prefix before appending the data to the internal string ([link](https://github.com/webpack/webpack/pull/16950/files?diff=unified&w=0#diff-367809774077aa963dfccd23717f9ab3eebe493f40f242ae5168ef5c4d8613e3L110-R112))
* Update the `digest` method in `createHash.js` to append the new prefix to the internal string before encoding it in hex ([link](https://github.com/webpack/webpack/pull/16950/files?diff=unified&w=0#diff-367809774077aa963dfccd23717f9ab3eebe493f40f242ae5168ef5c4d8613e3L123-R124))
