### PR TITLE
fix: handle vendor prefixed keyframes and animation in CSS modules

### DIFF
--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -30,6 +30,9 @@ const STRING_MULTILINE = /\\[\n\r\f]/g;
 const TRIM_WHITE_SPACES = /(^[ \t\n\r\f]*|[ \t\n\r\f]*$)/g;
 const UNESCAPE = /\\([0-9a-fA-F]{1,6}[ \t\n\r\f]?|[\s\S])/g;
 const IMAGE_SET_FUNCTION = /^(-\w+-)?image-set$/i;
+const OPTIONALLY_VENDOR_PREFIXED_KEYFRAMES_AT_RULE = /^@(-\w+-)?keyframes$/;
+const OPTIONALLY_VENDOR_PREFIXED_ANIMATION_PROPERTY =
+	/^(-\w+-)?animation(-name)?$/i;
 
 const normalizeUrl = (str, isString) => {
 	// Remove extra spaces and newlines:
@@ -314,7 +317,9 @@ class CssParser extends Parser {
 				dep.setLoc(sl, sc, el, ec);
 				module.addDependency(dep);
 				declaredCssVariables.add(name);
-			} else if (/^(-\w+-)?animation(-name)?$/i.test(propertyName)) {
+			} else if (
+				OPTIONALLY_VENDOR_PREFIXED_ANIMATION_PROPERTY.test(propertyName)
+			) {
 				modeData = "animation";
 				lastIdentifier = undefined;
 			}
@@ -440,7 +445,7 @@ class CssParser extends Parser {
 						supports: undefined
 					};
 				}
-				if (/^@(-\w+-)?keyframes$/.test(name)) {
+				if (OPTIONALLY_VENDOR_PREFIXED_KEYFRAMES_AT_RULE.test(name)) {
 					let pos = end;
 					pos = walkCssTokens.eatWhitespaceAndComments(input, pos);
 					if (pos === input.length) return pos;

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -314,10 +314,7 @@ class CssParser extends Parser {
 				dep.setLoc(sl, sc, el, ec);
 				module.addDependency(dep);
 				declaredCssVariables.add(name);
-			} else if (
-				propertyName.toLowerCase() === "animation-name" ||
-				propertyName.toLowerCase() === "animation"
-			) {
+			} else if (/^(-\w+-)?animation(-name)?$/i.test(propertyName)) {
 				modeData = "animation";
 				lastIdentifier = undefined;
 			}
@@ -443,7 +440,7 @@ class CssParser extends Parser {
 						supports: undefined
 					};
 				}
-				if (name === "@keyframes") {
+				if (/^@(-\w+-)?keyframes$/.test(name)) {
 					let pos = end;
 					pos = walkCssTokens.eatWhitespaceAndComments(input, pos);
 					if (pos === input.length) return pos;

--- a/test/configCases/css/css-modules-in-node/index.js
+++ b/test/configCases/css/css-modules-in-node/index.js
@@ -68,6 +68,9 @@ it("should allow to create css modules", done => {
 				inSupportScope: prod
 					? "my-app-491-FO"
 					: "./style.module.css-inSupportScope",
+				animationName: prod
+					? "my-app-491-w3"
+					: "./style.module.css-animationName",
 			});
 		} catch (e) {
 			return done(e);

--- a/test/configCases/css/css-modules-in-node/index.js
+++ b/test/configCases/css/css-modules-in-node/index.js
@@ -71,6 +71,9 @@ it("should allow to create css modules", done => {
 				animationName: prod
 					? "my-app-491-w3"
 					: "./style.module.css-animationName",
+				mozAnimationName: prod
+					? "my-app-491-t6"
+					: "./style.module.css-mozAnimationName"
 			});
 		} catch (e) {
 			return done(e);

--- a/test/configCases/css/css-modules/index.js
+++ b/test/configCases/css/css-modules/index.js
@@ -9,14 +9,26 @@ it("should allow to create css modules", done => {
 			expect(x).toEqual({
 				global: undefined,
 				class: prod ? "my-app-491-S" : "./style.module.css-class",
-				currentWmultiParams: prod ? "my-app-491-yK" : "./style.module.css-local12",
-				futureWmultiParams:  prod ? "my-app-491-Y4" : "./style.module.css-local14",
-				hasWmultiParams:  prod ? "my-app-491-PK" : "./style.module.css-local11",
-				matchesWmultiParams:  prod ? "my-app-491-$Y" : "./style.module.css-local9",
-				mozAnyWmultiParams:  prod ? "my-app-491-TT" : "./style.module.css-local15",
-				pastWmultiParams:  prod ? "my-app-491-P_" : "./style.module.css-local13",
-				webkitAnyWmultiParams:  prod ? "my-app-491-rT" : "./style.module.css-local16",
-				whereWmultiParams:  prod ? "my-app-491-ie" : "./style.module.css-local10",
+				currentWmultiParams: prod
+					? "my-app-491-yK"
+					: "./style.module.css-local12",
+				futureWmultiParams: prod
+					? "my-app-491-Y4"
+					: "./style.module.css-local14",
+				hasWmultiParams: prod ? "my-app-491-PK" : "./style.module.css-local11",
+				matchesWmultiParams: prod
+					? "my-app-491-$Y"
+					: "./style.module.css-local9",
+				mozAnyWmultiParams: prod
+					? "my-app-491-TT"
+					: "./style.module.css-local15",
+				pastWmultiParams: prod ? "my-app-491-P_" : "./style.module.css-local13",
+				webkitAnyWmultiParams: prod
+					? "my-app-491-rT"
+					: "./style.module.css-local16",
+				whereWmultiParams: prod
+					? "my-app-491-ie"
+					: "./style.module.css-local10",
 				local: prod
 					? "my-app-491-Zw my-app-491-yl my-app-491-J_ my-app-491-gc"
 					: "./style.module.css-local1 ./style.module.css-local2 ./style.module.css-local3 ./style.module.css-local4",
@@ -74,6 +86,9 @@ it("should allow to create css modules", done => {
 				animationName: prod
 					? "my-app-491-w3"
 					: "./style.module.css-animationName",
+				mozAnimationName: prod
+					? "my-app-491-t6"
+					: "./style.module.css-mozAnimationName"
 			});
 		} catch (e) {
 			return done(e);

--- a/test/configCases/css/css-modules/index.js
+++ b/test/configCases/css/css-modules/index.js
@@ -71,6 +71,9 @@ it("should allow to create css modules", done => {
 				inSupportScope: prod
 					? "my-app-491-FO"
 					: "./style.module.css-inSupportScope",
+				animationName: prod
+					? "my-app-491-w3"
+					: "./style.module.css-animationName",
 			});
 		} catch (e) {
 			return done(e);

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -262,3 +262,12 @@
 		background: red;
 	}
 }
+
+@-moz-keyframes mozAnimationName {
+	0% {
+		background: white;
+	}
+	100% {
+		background: red;
+	}
+}

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -225,3 +225,40 @@
 		color: red;
 	}
 }
+
+.a {
+	animation: 3s animationName;
+	-webkit-animation: 3s animationName;
+}
+
+.b {
+	animation: animationName 3s;
+	-webkit-animation: animationName 3s;
+}
+
+.c {
+	animation-name: animationName;
+	-webkit-animation-name: animationName;
+}
+
+.d {
+	--animation-name: animationName;
+}
+
+@keyframes animationName {
+	0% {
+		background: white;
+	}
+	100% {
+		background: red;
+	}
+}
+
+@-webkit-keyframes animationName {
+	0% {
+		background: white;
+	}
+	100% {
+		background: red;
+	}
+}

--- a/test/configCases/css/css-modules/use-style.js
+++ b/test/configCases/css/css-modules/use-style.js
@@ -33,4 +33,5 @@ export default {
 	VARS: `${style["LOCAL-COLOR"]} ${style.VARS} ${style["GLOBAL-COLOR"]} ${style.globalVarsUpperCase}`,
 	inSupportScope: style.inSupportScope,
 	animationName: style.animationName,
+	mozAnimationName: style.mozAnimationName,
 };

--- a/test/configCases/css/css-modules/use-style.js
+++ b/test/configCases/css/css-modules/use-style.js
@@ -32,4 +32,5 @@ export default {
 	displayFlexInSupportsInMediaUpperCase: style.displayFlexInSupportsInMediaUpperCase,
 	VARS: `${style["LOCAL-COLOR"]} ${style.VARS} ${style["GLOBAL-COLOR"]} ${style.globalVarsUpperCase}`,
 	inSupportScope: style.inSupportScope,
+	animationName: style.animationName,
 };


### PR DESCRIPTION
bug fix, port from css-loader

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary 
<!-- cspell:disable-next-line -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f84a051</samp>

This pull request enhances the CSS parser to handle animation-related properties and at-rules with vendor prefixes, and adds test cases for using animation names in CSS modules in different environments and scenarios.

## Details 
<!-- cspell:disable-next-line -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f84a051</samp>

*  Simplify detection of animation properties and keyframes at-rules in `CssParser.js` using regular expressions ([link](https://github.com/webpack/webpack/pull/16975/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L281-R281),[link](https://github.com/webpack/webpack/pull/16975/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L364-R361))
*  Add test cases for using animation names in CSS modules in node and web environments ([link](https://github.com/webpack/webpack/pull/16975/files?diff=unified&w=0#diff-1b175262035431aa8325c23bbc618a9514db1a48e89b8a3fa13677e4a61a8852R68-R70),[link](https://github.com/webpack/webpack/pull/16975/files?diff=unified&w=0#diff-7e6a377fab710fb1ce571b4bc797ae71c536cd2831927694cc7d66b1c965f513R71-R73))
*  Add CSS rules with animation names to `style.module.css` for testing purposes ([link](https://github.com/webpack/webpack/pull/16975/files?diff=unified&w=0#diff-f1ab2491081397824e85ddcad488c80b5ac0c735ceb3ab20a12c112ceb8e9c1fR222-R258))
*  Add animation name property to `useStyle` function in `use-style.js` to access transformed animation name from style module ([link](https://github.com/webpack/webpack/pull/16975/files?diff=unified&w=0#diff-12a119096dd115b993b18e3634ec30c383e6316db0bf4a290549c8d7467640deR34))
