### PR TITLE
docs: update grammar  mistakes in examples

### DIFF
--- a/examples/scope-hoisting/README.md
+++ b/examples/scope-hoisting/README.md
@@ -4,17 +4,17 @@ This is the dependency graph for the example: (solid lines express sync imports,
 
 ![](graph.png)
 
-All modules except `cjs` are EcmaScript modules. `cjs` is a CommonJs module.
+All modules except `cjs` are EcmaScript modules. `cjs` is a CommonJS module.
 
-The interesting thing here is that putting all modules in single scope won't work, because of multiple reasons:
+The interesting thing here is that putting all modules in a single scope won't work, because of multiple reasons:
 
 - Modules `lazy`, `c`, `d` and `cjs` need to be in a separate chunk
 - Module `shared` is accessed by two chunks (different scopes)
-- Module `cjs` is a CommonJs module
+- Module `cjs` is a CommonJS module
 
 ![](graph2.png)
 
-webpack therefore uses a approach called **"Partial Scope Hoisting"** or "Module concatenation", which chooses the largest possible subsets of ES modules which can be scope hoisted and combines them with the default webpack primitives.
+Webpack, therefore, uses an approach called **"Partial Scope Hoisting"** or "Module concatenation", which chooses the largest possible subsets of ES modules which can be scope hoisted and combines them with the default webpack primitives.
 
 ![](graph3.png)
 

--- a/examples/scope-hoisting/template.md
+++ b/examples/scope-hoisting/template.md
@@ -4,9 +4,9 @@ This is the dependency graph for the example: (solid lines express sync imports,
 
 ![](graph.png)
 
-All modules except `cjs` are EcmaScript modules. `cjs` is a CommonJs module.
+All modules except `cjs` are EcmaScript modules. `cjs` is a CommonJS module.
 
-The interesting thing here is that putting all modules in single scope won't work, because of multiple reasons:
+The interesting thing here is that putting all modules in a single scope won't work, because of multiple reasons:
 
 - Modules `lazy`, `c`, `d` and `cjs` need to be in a separate chunk
 - Module `shared` is accessed by two chunks (different scopes)
@@ -14,7 +14,7 @@ The interesting thing here is that putting all modules in single scope won't wor
 
 ![](graph2.png)
 
-webpack therefore uses a approach called **"Partial Scope Hoisting"** or "Module concatenation", which chooses the largest possible subsets of ES modules which can be scope hoisted and combines them with the default webpack primitives.
+Webpack, therefore, uses a approach called **"Partial Scope Hoisting"** or "Module concatenation", which chooses the largest possible subsets of ES modules which can be scope hoisted and combines them with the default webpack primitives.
 
 ![](graph3.png)
 

--- a/examples/side-effects/README.md
+++ b/examples/side-effects/README.md
@@ -1,4 +1,4 @@
-This example shows how the `sideEffects` flag for library authors works.
+This example shows how the `sideEffects` flag works for library authors.
 
 The example contains a large library, `big-module`. `big-module` contains multiple child modules: `a`, `b` and `c`. The exports from the child modules are re-exported in the entry module (`index.js`) of the library. A consumer uses **some** of the exports, importing them from the library via `import { a, b } from "big-module"`. According to the EcmaScript spec, all child modules _must_ be evaluated because they could contain side effects.
 

--- a/examples/side-effects/template.md
+++ b/examples/side-effects/template.md
@@ -1,4 +1,4 @@
-This example shows how the `sideEffects` flag for library authors works.
+This example shows how the `sideEffects` flag works for library authors.
 
 The example contains a large library, `big-module`. `big-module` contains multiple child modules: `a`, `b` and `c`. The exports from the child modules are re-exported in the entry module (`index.js`) of the library. A consumer uses **some** of the exports, importing them from the library via `import { a, b } from "big-module"`. According to the EcmaScript spec, all child modules _must_ be evaluated because they could contain side effects.
 


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->
fix  #10781
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary 
<!-- cspell:disable-next-line -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eb817d5</samp>

This pull request updates the documentation of some examples related to scope hoisting and side effects. It fixes some typos, improves consistency, and simplifies wording.

## Details 
<!-- cspell:disable-next-line -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eb817d5</samp>

* Fix typo in "CommonJS" for consistency and accuracy ([link](https://github.com/webpack/webpack/pull/16988/files?diff=unified&w=0#diff-e3d21a18cf29f31f42279044d7df960c5d109995ab72f8160ec5deec63148e3bL7-R17),[link](https://github.com/webpack/webpack/pull/16988/files?diff=unified&w=0#diff-9e1b9ccb63a110df2122d20367466e397a427f16fef4bf43ade27b63ac16e7c5L7-R9))
* Capitalize "webpack" for consistency and branding ([link](https://github.com/webpack/webpack/pull/16988/files?diff=unified&w=0#diff-9e1b9ccb63a110df2122d20367466e397a427f16fef4bf43ade27b63ac16e7c5L17-R17))
* Simplify wording of first sentence in `side-effects` example ([link](https://github.com/webpack/webpack/pull/16988/files?diff=unified&w=0#diff-b2175df69189cdac7a28d1a8d607774033129174d075d895a52423db33b59515L1-R1),[link](https://github.com/webpack/webpack/pull/16988/files?diff=unified&w=0#diff-c72dd95cb3dea3b0a6b186cf5f00ad18ef3c20bd5e9156bf02caaaddf63e3409L1-R1))
