### PR TITLE
support destructuring assignment with AwaitExpression

### DIFF
--- a/lib/dependencies/ImportParserPlugin.js
+++ b/lib/dependencies/ImportParserPlugin.js
@@ -27,6 +27,8 @@ class ImportParserPlugin {
 	}
 
 	apply(parser) {
+		const exportsFromEnumerable = enumerable =>
+			Array.from(enumerable, e => [e]);
 		parser.hooks.importCall.tap("ImportParserPlugin", expr => {
 			const param = parser.evaluateExpression(expr.source);
 
@@ -184,7 +186,7 @@ class ImportParserPlugin {
 						if (typeof importOptions.webpackExports === "string") {
 							exports = [[importOptions.webpackExports]];
 						} else {
-							exports = Array.from(importOptions.webpackExports, e => [e]);
+							exports = exportsFromEnumerable(importOptions.webpackExports);
 						}
 					}
 				}
@@ -203,6 +205,20 @@ class ImportParserPlugin {
 					)
 				);
 				mode = "lazy";
+			}
+
+			const referencedPropertiesInDestructuring =
+				parser.destructuringAssignmentPropertiesFor(expr);
+			if (referencedPropertiesInDestructuring) {
+				if (exports) {
+					parser.state.module.addWarning(
+						new UnsupportedFeatureWarning(
+							`\`webpackExports\` could not be used with destructuring assignment.`,
+							expr.loc
+						)
+					);
+				}
+				exports = exportsFromEnumerable(referencedPropertiesInDestructuring);
 			}
 
 			if (param.isString()) {

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -1927,7 +1927,12 @@ class JavascriptParser extends Parser {
 			for (const id of set) keys.add(id);
 		}
 
-		this.destructuringAssignmentProperties.set(expression.right, keys);
+		this.destructuringAssignmentProperties.set(
+			expression.right.type === "AwaitExpression"
+				? expression.right.argument
+				: expression.right,
+			keys
+		);
 
 		if (expression.right.type === "AssignmentExpression") {
 			this.preWalkAssignmentExpression(expression.right);
@@ -2183,7 +2188,12 @@ class JavascriptParser extends Parser {
 		const keys = this._preWalkObjectPattern(declarator.id);
 
 		if (!keys) return;
-		this.destructuringAssignmentProperties.set(declarator.init, keys);
+		this.destructuringAssignmentProperties.set(
+			declarator.init.type === "AwaitExpression"
+				? declarator.init.argument
+				: declarator.init,
+			keys
+		);
 
 		if (declarator.init.type === "AssignmentExpression") {
 			this.preWalkAssignmentExpression(declarator.init);

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -1840,9 +1840,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for output-module 1`] = `
-"asset main.mjs 10 KiB [emitted] [javascript module] (name: main)
-asset 52.mjs 402 bytes [emitted] [javascript module]
-runtime modules 6.07 KiB 8 modules
+"asset main.mjs 9.57 KiB [emitted] [javascript module] (name: main)
+asset 52.mjs 358 bytes [emitted] [javascript module]
+runtime modules 5.8 KiB 7 modules
 orphan modules 38 bytes [orphan] 1 module
 cacheable modules 263 bytes
   ./index.js + 1 modules 225 bytes [built] [code generated]

--- a/test/cases/chunks/destructuring-assignment/dir1/a.js
+++ b/test/cases/chunks/destructuring-assignment/dir1/a.js
@@ -1,0 +1,3 @@
+export const a = 1;
+export default 3;
+export const usedExports = __webpack_exports_info__.usedExports;

--- a/test/cases/chunks/destructuring-assignment/index.js
+++ b/test/cases/chunks/destructuring-assignment/index.js
@@ -1,0 +1,12 @@
+it("should load only used exports", async (done) => {
+	const { default: def, usedExports } = await import("./dir1/a");
+	expect(def).toBe(3);
+	expect(usedExports).toEqual(["default", "usedExports"]);
+	done();
+});
+
+it("should get warning on using 'webpackExports' with destructuring assignment", async (done) => {
+	const { default: def } = await import(/* webpackExports: ["a"] */"./dir1/a?2");
+	expect(def).toBe(3);
+	done();
+});

--- a/test/cases/chunks/destructuring-assignment/test.filter.js
+++ b/test/cases/chunks/destructuring-assignment/test.filter.js
@@ -1,0 +1,4 @@
+module.exports = function(config) {
+	// This test can't run in development mode
+	return config.mode !== "development";
+};

--- a/test/cases/chunks/destructuring-assignment/test.filter.js
+++ b/test/cases/chunks/destructuring-assignment/test.filter.js
@@ -1,4 +1,4 @@
-module.exports = function(config) {
+module.exports = function (config) {
 	// This test can't run in development mode
 	return config.mode !== "development";
 };

--- a/test/cases/chunks/destructuring-assignment/warnings.js
+++ b/test/cases/chunks/destructuring-assignment/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[/`webpackExports` could not be used with destructuring assignment./]
+];


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

related to https://github.com/webpack/webpack/issues/14800

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3824bee</samp>

This pull request adds support for import statements with destructuring assignment in the `ImportParserPlugin` and fixes a bug in the `JavascriptParser` that affected dynamic imports with `await`. It also adds new test cases and warnings to cover the new functionality and the incompatible option.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3824bee</samp>

*  Add a helper function `exportsFromEnumerable` to the `ImportParserPlugin` class to format the requested exports from an import statement ([link](https://github.com/webpack/webpack/pull/16995/files?diff=unified&w=0#diff-391177474567b080c642e311989bb34a9a82be71c4d65e15fc2ca97e73caaf5aR30-R31))
* Refactor the use of `Array.from` with `exportsFromEnumerable` to avoid code duplication and improve readability ([link](https://github.com/webpack/webpack/pull/16995/files?diff=unified&w=0#diff-391177474567b080c642e311989bb34a9a82be71c4d65e15fc2ca97e73caaf5aL187-R189))
* Handle the case of import statements using destructuring assignment, such as `const { default: def } = await import("./dir1/a");`, by using the `destructuringAssignmentPropertiesFor` method from the `JavascriptParser` class and adding a warning if the `webpackExports` option is used ([link](https://github.com/webpack/webpack/pull/16995/files?diff=unified&w=0#diff-391177474567b080c642e311989bb34a9a82be71c4d65e15fc2ca97e73caaf5aR210-R223), [link](https://github.com/webpack/webpack/pull/16995/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L1930-R1935), [link](https://github.com/webpack/webpack/pull/16995/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L2186-R2196))
* Add test case files `test/cases/chunks/destructuring-assignment/dir1/a.js`, `test/cases/chunks/destructuring-assignment/index.js`, and `test/cases/chunks/destructuring-assignment/warnings.js` to verify the functionality and warnings of the `ImportParserPlugin` and the `destructuringAssignmentPropertiesFor` method ([link](https://github.com/webpack/webpack/pull/16995/files?diff=unified&w=0#diff-a93bb0815745d943d09a9f8a863240a1d95118e109b093011b9537e64ec7a5fcR1-R3), [link](https://github.com/webpack/webpack/pull/16995/files?diff=unified&w=0#diff-fe3ed91e3bfc710e89e7b9efdd642650fec58f5c8f6b20cc0bd05bdc8f369e38R1-R12), [link](https://github.com/webpack/webpack/pull/16995/files?diff=unified&w=0#diff-dbe205d5e1f7b8a30c691744474c3ea53dac5d0abffaf220a5ad74b5cc10b96eR1-R3))
