### PR TITLE
support destructuring assignment in import.meta

### DIFF
--- a/lib/dependencies/ImportMetaPlugin.js
+++ b/lib/dependencies/ImportMetaPlugin.js
@@ -104,7 +104,7 @@ class ImportMetaPlugin {
 									new ModuleDependencyWarning(
 										parser.state.module,
 										new CriticalDependencyWarning(
-											"Accessing import.meta directly is unsupported (only property access is supported)"
+											"Accessing import.meta directly is unsupported (only property access or destructuring is supported)"
 										),
 										metaProperty.loc
 									)

--- a/lib/dependencies/ImportMetaPlugin.js
+++ b/lib/dependencies/ImportMetaPlugin.js
@@ -75,6 +75,17 @@ class ImportMetaPlugin {
 					}
 
 					/// import.meta direct ///
+					const webpackVersion = parseInt(
+						require("../../package.json").version,
+						10
+					);
+					const importMetaUrl = () =>
+						JSON.stringify(getUrl(parser.state.module));
+					const importMetaWebpackVersion = () => JSON.stringify(webpackVersion);
+					const importMetaUnknownProperty = members =>
+						`${Template.toNormalComment(
+							"unsupported import.meta." + members.join(".")
+						)} undefined${propertyAccess(members, 1)}`;
 					parser.hooks.typeof
 						.for("import.meta")
 						.tap(
@@ -84,20 +95,48 @@ class ImportMetaPlugin {
 					parser.hooks.expression
 						.for("import.meta")
 						.tap(PLUGIN_NAME, metaProperty => {
-							const CriticalDependencyWarning = getCriticalDependencyWarning();
-							parser.state.module.addWarning(
-								new ModuleDependencyWarning(
-									parser.state.module,
-									new CriticalDependencyWarning(
-										"Accessing import.meta directly is unsupported (only property access is supported)"
-									),
-									metaProperty.loc
-								)
-							);
-							const dep = new ConstDependency(
-								`${parser.isAsiPosition(metaProperty.range[0]) ? ";" : ""}({})`,
-								metaProperty.range
-							);
+							const referencedPropertiesInDestructuring =
+								parser.destructuringAssignmentPropertiesFor(metaProperty);
+							if (!referencedPropertiesInDestructuring) {
+								const CriticalDependencyWarning =
+									getCriticalDependencyWarning();
+								parser.state.module.addWarning(
+									new ModuleDependencyWarning(
+										parser.state.module,
+										new CriticalDependencyWarning(
+											"Accessing import.meta directly is unsupported (only property access is supported)"
+										),
+										metaProperty.loc
+									)
+								);
+								const dep = new ConstDependency(
+									`${
+										parser.isAsiPosition(metaProperty.range[0]) ? ";" : ""
+									}({})`,
+									metaProperty.range
+								);
+								dep.loc = metaProperty.loc;
+								parser.state.module.addPresentationalDependency(dep);
+								return true;
+							}
+
+							let str = "";
+							for (const prop of referencedPropertiesInDestructuring) {
+								switch (prop) {
+									case "url":
+										str += `url: ${importMetaUrl()},`;
+										break;
+									case "webpack":
+										str += `webpack: ${importMetaWebpackVersion()},`;
+										break;
+									default:
+										str += `[${JSON.stringify(
+											prop
+										)}]: ${importMetaUnknownProperty([prop])},`;
+										break;
+								}
+							}
+							const dep = new ConstDependency(`({${str}})`, metaProperty.range);
 							dep.loc = metaProperty.loc;
 							parser.state.module.addPresentationalDependency(dep);
 							return true;
@@ -120,10 +159,7 @@ class ImportMetaPlugin {
 					parser.hooks.expression
 						.for("import.meta.url")
 						.tap(PLUGIN_NAME, expr => {
-							const dep = new ConstDependency(
-								JSON.stringify(getUrl(parser.state.module)),
-								expr.range
-							);
+							const dep = new ConstDependency(importMetaUrl(), expr.range);
 							dep.loc = expr.loc;
 							parser.state.module.addPresentationalDependency(dep);
 							return true;
@@ -140,10 +176,6 @@ class ImportMetaPlugin {
 						});
 
 					/// import.meta.webpack ///
-					const webpackVersion = parseInt(
-						require("../../package.json").version,
-						10
-					);
 					parser.hooks.typeof
 						.for("import.meta.webpack")
 						.tap(
@@ -154,7 +186,7 @@ class ImportMetaPlugin {
 						.for("import.meta.webpack")
 						.tap(
 							PLUGIN_NAME,
-							toConstantDependency(parser, JSON.stringify(webpackVersion))
+							toConstantDependency(parser, importMetaWebpackVersion())
 						);
 					parser.hooks.evaluateTypeof
 						.for("import.meta.webpack")
@@ -168,9 +200,7 @@ class ImportMetaPlugin {
 						.for("import.meta")
 						.tap(PLUGIN_NAME, (expr, members) => {
 							const dep = new ConstDependency(
-								`${Template.toNormalComment(
-									"unsupported import.meta." + members.join(".")
-								)} undefined${propertyAccess(members, 1)}`,
+								importMetaUnknownProperty(members),
 								expr.range
 							);
 							dep.loc = expr.loc;

--- a/test/cases/esm/import-meta/index.js
+++ b/test/cases/esm/import-meta/index.js
@@ -42,5 +42,16 @@ it("should return undefined for unknown property", () => {
 	expect(import.meta.other).toBe(undefined);
 	if (typeof import.meta.other !== "undefined") require("fail");
 	expect(() => import.meta.other.other.other).toThrowError();
-	// if (typeof import.meta.other.other.other !== "undefined") require("fail");
+});
+
+it("should add warning on direct import.meta usage", () => {
+	expect(Object.keys(import.meta)).toHaveLength(0);
+});
+
+it("should support destructuring assignment", () => {
+	let version, url2, c;
+	({ webpack: version } = { url: url2 } = { c } = import.meta);
+	expect(version).toBeTypeOf("number");
+	expect(url2).toBe(url);
+	expect(c).toBe(undefined);
 });

--- a/test/cases/esm/import-meta/warnings.js
+++ b/test/cases/esm/import-meta/warnings.js
@@ -1,3 +1,3 @@
 module.exports = [
-	[/Accessing import.meta directly is unsupported \(only property access is supported\)/]
+	[/Accessing import.meta directly is unsupported \(only property access or destructuring is supported\)/]
 ];

--- a/test/cases/esm/import-meta/warnings.js
+++ b/test/cases/esm/import-meta/warnings.js
@@ -1,3 +1,5 @@
 module.exports = [
-	[/Accessing import.meta directly is unsupported \(only property access or destructuring is supported\)/]
+	[
+		/Accessing import.meta directly is unsupported \(only property access or destructuring is supported\)/
+	]
 ];

--- a/test/cases/esm/import-meta/warnings.js
+++ b/test/cases/esm/import-meta/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[/Accessing import.meta directly is unsupported \(only property access is supported\)/]
+];


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

other plugins?

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 730dab9</samp>

This pull request improves the `ImportMetaPlugin` class to handle import.meta properties more accurately and efficiently, and adds tests for the new features and the existing behavior. It also warns users when they access import.meta directly, which is not supported by webpack.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 730dab9</samp>

*  Add helper functions for generating import.meta code ([link](https://github.com/webpack/webpack/pull/16996/files?diff=unified&w=0#diff-a265dcfd4104a4b8e394b2085074667c0e575e8cb3e55e476d85c5457137d7b2R78-R88))
*  Support destructuring assignment for import.meta properties ([link](https://github.com/webpack/webpack/pull/16996/files?diff=unified&w=0#diff-a265dcfd4104a4b8e394b2085074667c0e575e8cb3e55e476d85c5457137d7b2L87-R139), [link](https://github.com/webpack/webpack/pull/16996/files?diff=unified&w=0#diff-08f253d98887ffd5d963f1506dee0106dac095c0a8a36a3071dcf990ad5cb780L45-R57), [link](https://github.com/webpack/webpack/pull/16996/files?diff=unified&w=0#diff-ece069395dfb97f35640cbf04fe22351689a5c7fd6fda4055b0359ebf9413f11R1-R3))
*  Simplify import.meta expression handling by using helper functions ([link](https://github.com/webpack/webpack/pull/16996/files?diff=unified&w=0#diff-a265dcfd4104a4b8e394b2085074667c0e575e8cb3e55e476d85c5457137d7b2L123-R162), [link](https://github.com/webpack/webpack/pull/16996/files?diff=unified&w=0#diff-a265dcfd4104a4b8e394b2085074667c0e575e8cb3e55e476d85c5457137d7b2L143-L146), [link](https://github.com/webpack/webpack/pull/16996/files?diff=unified&w=0#diff-a265dcfd4104a4b8e394b2085074667c0e575e8cb3e55e476d85c5457137d7b2L157-R189), [link](https://github.com/webpack/webpack/pull/16996/files?diff=unified&w=0#diff-a265dcfd4104a4b8e394b2085074667c0e575e8cb3e55e476d85c5457137d7b2L171-R203))
*  Move `webpackVersion` variable to the top of `ImportMetaPlugin.js` ([link](https://github.com/webpack/webpack/pull/16996/files?diff=unified&w=0#diff-a265dcfd4104a4b8e394b2085074667c0e575e8cb3e55e476d85c5457137d7b2L143-L146))
