### PR TITLE
test: added test case

### DIFF
--- a/test/configCases/css/css-modules-in-node/index.js
+++ b/test/configCases/css/css-modules-in-node/index.js
@@ -65,6 +65,9 @@ it("should allow to create css modules", done => {
 				VARS: prod
 					? "--my-app-491-DJ my-app-491-ms undefined my-app-491-cU"
 					: "--./style.module.css-LOCAL-COLOR ./style.module.css-VARS undefined ./style.module.css-globalVarsUpperCase",
+				inSupportScope: prod
+					? "my-app-491-FO"
+					: "./style.module.css-inSupportScope",
 			});
 		} catch (e) {
 			return done(e);

--- a/test/configCases/css/css-modules/index.js
+++ b/test/configCases/css/css-modules/index.js
@@ -68,6 +68,9 @@ it("should allow to create css modules", done => {
 				VARS: prod
 					? "--my-app-491-DJ my-app-491-ms undefined my-app-491-cU"
 					: "--./style.module.css-LOCAL-COLOR ./style.module.css-VARS undefined ./style.module.css-globalVarsUpperCase",
+				inSupportScope: prod
+					? "my-app-491-FO"
+					: "./style.module.css-inSupportScope",
 			});
 		} catch (e) {
 			return done(e);

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -219,3 +219,9 @@
 	COLOR: VAR(--GLOBAR-COLOR);
 	--GLOBAR-COLOR: red;
 }
+
+@supports (top: env(safe-area-inset-top, 0)) {
+	.inSupportScope {
+		color: red;
+	}
+}

--- a/test/configCases/css/css-modules/use-style.js
+++ b/test/configCases/css/css-modules/use-style.js
@@ -31,4 +31,5 @@ export default {
 	supportsInMedia: style.displayFlexInSupportsInMedia,
 	displayFlexInSupportsInMediaUpperCase: style.displayFlexInSupportsInMediaUpperCase,
 	VARS: `${style["LOCAL-COLOR"]} ${style.VARS} ${style["GLOBAL-COLOR"]} ${style.globalVarsUpperCase}`,
+	inSupportScope: style.inSupportScope,
 };


### PR DESCRIPTION
Fixed https://github.com/webpack/webpack/issues/16155, just a test case

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 50bb0c2</samp>

Add a new `inSupportScope` property to the `css-loader` options and the `use-style.js` module to test the `@supports` feature query and the `env()` function in CSS modules. Modify the `style.module.css` file to use the `@supports` syntax and the `env()` function.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 50bb0c2</samp>

*  Add `inSupportScope` property to `css-loader` options in `css-modules` and `css-modules-in-node` test cases to specify the CSS class name for the `@supports` rule ([link](https://github.com/webpack/webpack/pull/17011/files?diff=unified&w=0#diff-1b175262035431aa8325c23bbc618a9514db1a48e89b8a3fa13677e4a61a8852R68-R70), [link](https://github.com/webpack/webpack/pull/17011/files?diff=unified&w=0#diff-7e6a377fab710fb1ce571b4bc797ae71c536cd2831927694cc7d66b1c965f513R71-R73))
*  Add `@supports` rule to `style.module.css` file to test `css-loader` compatibility with `env()` function and feature queries ([link](https://github.com/webpack/webpack/pull/17011/files?diff=unified&w=0#diff-f1ab2491081397824e85ddcad488c80b5ac0c735ceb3ab20a12c112ceb8e9c1fR222-R227))
*  Export `inSupportScope` class name from `use-style.js` module to use it in the HTML elements of the test cases ([link](https://github.com/webpack/webpack/pull/17011/files?diff=unified&w=0#diff-12a119096dd115b993b18e3634ec30c383e6316db0bf4a290549c8d7467640deR34))
