### PR TITLE
fix: add startup chunk dependencies plugin for module format

### DIFF
--- a/lib/esm/ModuleChunkLoadingPlugin.js
+++ b/lib/esm/ModuleChunkLoadingPlugin.js
@@ -8,6 +8,7 @@
 const RuntimeGlobals = require("../RuntimeGlobals");
 const ExportWebpackRequireRuntimeModule = require("./ExportWebpackRequireRuntimeModule");
 const ModuleChunkLoadingRuntimeModule = require("./ModuleChunkLoadingRuntimeModule");
+const StartupChunkDependenciesPlugin = require("../runtime/StartupChunkDependenciesPlugin");
 
 /** @typedef {import("../Compiler")} Compiler */
 
@@ -18,6 +19,10 @@ class ModuleChunkLoadingPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
+		new StartupChunkDependenciesPlugin({
+			chunkLoading: "import",
+			asyncChunkLoading: true
+		}).apply(compiler);
 		compiler.hooks.thisCompilation.tap(
 			"ModuleChunkLoadingPlugin",
 			compilation => {

--- a/test/configCases/output-module/startup-chunk-dependencies/a.common.js
+++ b/test/configCases/output-module/startup-chunk-dependencies/a.common.js
@@ -1,0 +1,1 @@
+export const loaded = true

--- a/test/configCases/output-module/startup-chunk-dependencies/index.js
+++ b/test/configCases/output-module/startup-chunk-dependencies/index.js
@@ -1,0 +1,5 @@
+import * as a from './a.common.js'
+
+it("should load startup chunk dependency a.common.js", () => {
+	expect(a.loaded).toBe(true);
+});

--- a/test/configCases/output-module/startup-chunk-dependencies/webpack.config.js
+++ b/test/configCases/output-module/startup-chunk-dependencies/webpack.config.js
@@ -1,0 +1,18 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	experiments: {
+		outputModule: true
+	},
+	target: "es2020",
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				commons: {
+					test: /\.common/,
+					minSize: 0,
+					chunks: "all"
+				}
+			}
+		}
+	}
+};


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This PR add StartupChunkDependenciesPlugin for ModuleChunkLoadingPlugin, before the following code is missing for `output: "module"`, which will cause entry chunk not running when entry chunk dependent other vendor chunks.

```js
/******/ /* webpack/runtime/startup chunk dependencies */
/******/ (() => {
/******/ 	var next = __webpack_require__.x;
/******/ 	__webpack_require__.x = () => {
/******/ 		return __webpack_require__.e("commons-src_a_common_js").then(next);
/******/ 	};
/******/ })();
```

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8f49b83</samp>

Added a new plugin and a test case for esm chunk loading with `import()`. The plugin ensures that common chunk dependencies are loaded before the module execution. The test case verifies the plugin functionality with a simple `outputModule` configuration.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8f49b83</samp>

* Import and apply `StartupChunkDependenciesPlugin` to enable async loading of startup chunk dependencies with `import()` ([link](https://github.com/webpack/webpack/pull/17012/files?diff=unified&w=0#diff-c22f77f8ec671e00d7d4e997e1d17ad7524c295d65acc6994be3b83287999122R11),[link](https://github.com/webpack/webpack/pull/17012/files?diff=unified&w=0#diff-c22f77f8ec671e00d7d4e997e1d17ad7524c295d65acc6994be3b83287999122R22-R25))
* Add `outputModule` experiment and `splitChunks` optimization to create a common chunk for modules matching `/.common/` pattern in `webpack.config.js` ([link](https://github.com/webpack/webpack/pull/17012/files?diff=unified&w=0#diff-cc2327fd6e7a0237c3279d8a3ba86b4a7b53c720bcad597a4fd0fe246c7a849eR1-R18))
* Add `a.common.js` module that exports a `loaded` property ([link](https://github.com/webpack/webpack/pull/17012/files?diff=unified&w=0#diff-29a011de2fde907327b928b1754f36ce2a2d6fe1bd0a24f4efa3ccd33c3c607dR1))
* Add `index.js` module that imports `a.common.js` and tests that its `loaded` property is `true` ([link](https://github.com/webpack/webpack/pull/17012/files?diff=unified&w=0#diff-dc3685e38f89c8baf0458792d5245661e188daf51ae6e7a2c65fc63a7191165cR1-R5))
