### PR TITLE
fix: esm with splitChunks

### DIFF
--- a/lib/esm/ModuleChunkLoadingPlugin.js
+++ b/lib/esm/ModuleChunkLoadingPlugin.js
@@ -8,6 +8,7 @@
 const RuntimeGlobals = require("../RuntimeGlobals");
 const ExportWebpackRequireRuntimeModule = require("./ExportWebpackRequireRuntimeModule");
 const ModuleChunkLoadingRuntimeModule = require("./ModuleChunkLoadingRuntimeModule");
+const StartupChunkDependenciesPlugin = require("../runtime/StartupChunkDependenciesPlugin");
 
 /** @typedef {import("../Compiler")} Compiler */
 
@@ -18,6 +19,10 @@ class ModuleChunkLoadingPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
+		new StartupChunkDependenciesPlugin({
+			chunkLoading: "import",
+			asyncChunkLoading: true
+		}).apply(compiler);
 		compiler.hooks.thisCompilation.tap(
 			"ModuleChunkLoadingPlugin",
 			compilation => {


### PR DESCRIPTION
fixes #17014, I think before was valid fix, want to investigate why our tests failed

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 57cdb41</samp>

Added `import` function as a new way to load chunks for ESM modules. Enabled startup dependencies optimization for `import` and async chunks.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 57cdb41</samp>

* Enable `import` function as a chunk loading mechanism for ESM modules by:
  - Importing `StartupChunkDependenciesPlugin` module ([link](https://github.com/webpack/webpack/pull/17015/files?diff=unified&w=0#diff-c22f77f8ec671e00d7d4e997e1d17ad7524c295d65acc6994be3b83287999122R11))
  - Applying `StartupChunkDependenciesPlugin` to the compiler with `import` function and async chunk loading options ([link](https://github.com/webpack/webpack/pull/17015/files?diff=unified&w=0#diff-c22f77f8ec671e00d7d4e997e1d17ad7524c295d65acc6994be3b83287999122R22-R25))
