### PR TITLE
fix: fix spell error

### DIFF
--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -1730,7 +1730,7 @@ class JavascriptParser extends Parser {
 	preWalkTryStatement(statement) {
 		this.preWalkStatement(statement.block);
 		if (statement.handler) this.preWalkCatchClause(statement.handler);
-		if (statement.finializer) this.preWalkStatement(statement.finializer);
+		if (statement.finalizer) this.preWalkStatement(statement.finalizer);
 	}
 
 	walkTryStatement(statement) {


### PR DESCRIPTION
## Summary

<!-- cspell:disable-next-line -->

when I read webpack source, i find this spell error:

https://github.com/webpack/webpack/blob/8ce07a13b7418bb63ec568110825ca92ebb870e3/lib/javascript/JavascriptParser.js#L1746

`finializer` is a incorrect word, the correct one should be `finalizer`.

## Details

<!-- cspell:disable-next-line -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a01d2d5</samp>

Fix a typo in `JavascriptParser.js` that could affect try-catch-finally parsing. Rename `finializer` to `finalizer` throughout the file. 
