### PR TITLE
ci: add ci to test with main branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,11 @@ jobs:
           - os: ubuntu-latest
             node-version: 12.x
             part: a
+          # Test with main branches of webpack dependencies
+          - os: ubuntu-latest
+            node-version: 16.x
+            part: [a, b]
+            use_main_branches: 1
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -118,6 +123,10 @@ jobs:
           yarn upgrade jest@^27.5.0 jest-circus@^27.5.0 jest-cli@^27.5.0 jest-diff@^27.5.0 jest-environment-node@^27.5.0 jest-junit@^13.0.0 @types/jest@^27.4.0 pretty-format@^27.0.2 --ignore-engines
           yarn --frozen-lockfile --ignore-engines
         if: matrix.node-version == '10.x' || matrix.node-version == '12.x' || matrix.node-version == '14.x'
+      # Install main version of our deps
+      - run: yarn upgrade enhanced-resolve@webpack/enhanced-resolve#main loader-runner@webpack/loader-runner#main schema-utils@webpack/schema-utils#master webpack-sources@webpack/webpack-sources#main watchpack@webpack/watchpack#main tapable@webpack/tapable#master
+        if: matrix.use_main_branches == '1'
+      # Install dependencies for LTS node versions
       - run: yarn --frozen-lockfile
         if: matrix.node-version != '10.x' && matrix.node-version != '12.x' && matrix.node-version != '14.x'
       - run: yarn link --frozen-lockfile || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,7 +128,7 @@ jobs:
           yarn --frozen-lockfile --ignore-engines
         if: matrix.node-version == '10.x' || matrix.node-version == '12.x' || matrix.node-version == '14.x'
       # Install main version of our deps
-      - run: yarn upgrade enhanced-resolve@webpack/enhanced-resolve#main loader-runner@webpack/loader-runner#main schema-utils@webpack/schema-utils#master webpack-sources@webpack/webpack-sources#main watchpack@webpack/watchpack#main tapable@webpack/tapable#master
+      - run: yarn upgrade enhanced-resolve@webpack/enhanced-resolve#main loader-runner@webpack/loader-runner#main webpack-sources@webpack/webpack-sources#main watchpack@webpack/watchpack#main tapable@webpack/tapable#master
         if: matrix.use_main_branches == '1'
       # Install dependencies for LTS node versions
       - run: yarn --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,11 @@ jobs:
           # Test with main branches of webpack dependencies
           - os: ubuntu-latest
             node-version: 16.x
-            part: [a, b]
+            part: a
+            use_main_branches: 1
+          - os: ubuntu-latest
+            node-version: 16.x
+            part: b
             use_main_branches: 1
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
New CI to test webpack together with main branches of own packages to catch potential regressions and incompatibilities before future releases

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef6e7db</samp>

This pull request enhances the test workflow by adding a new scenario to test webpack with the latest dependencies. It uses `.github/workflows/test.yml` to configure the matrix and the upgrade step.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ef6e7db</samp>

* Add a new test matrix entry to run on Ubuntu with Node 16.x and main branches of dependencies ([link](https://github.com/webpack/webpack/pull/17020/files?diff=unified&w=0#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R108-R112))
* Upgrade dependencies to main branches if `use_main_branches` is set to 1 in the test workflow ([link](https://github.com/webpack/webpack/pull/17020/files?diff=unified&w=0#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R126-R129))
