### PR TITLE
chore: remove `finializer` from cspell.json

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -85,7 +85,6 @@
     "fileoverview",
     "filepath",
     "finalizer",
-    "finializer",
     "fsevents",
     "fullhash",
     "funcindex",


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

Fix https://github.com/webpack/webpack/issues/17021
<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63c1601</samp>

Fixed a spelling mistake in `cspell.json` by removing the word "finializer" from the ignore list. This improves the code quality and documentation.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 63c1601</samp>

* Remove typo "finializer" from cspell ignore list ([link](https://github.com/webpack/webpack/pull/17022/files?diff=unified&w=0#diff-77519f787fe7e051a14c588f101d61e4d8f0d3b01bf8e16cb65d3838243d4e68L88))
