### PR TITLE
fix: avoid modify ast params object reference

### DIFF
--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -2482,7 +2482,7 @@ class JavascriptParser extends Parser {
 	walkFunctionExpression(expression) {
 		const wasTopLevel = this.scope.topLevelScope;
 		this.scope.topLevelScope = false;
-		const scopeParams = expression.params;
+		const scopeParams = [...expression.params];
 
 		// Add function name in scope for recursive calls
 		if (expression.id) {


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

close #17030 

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8c59f89</samp>

Fix a bug in `JavascriptParser` that caused wrong variable declarations. Use a new array to avoid mutating the `scopeParams` array when adding scope variables.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8c59f89</samp>

*  Fix scopeParams mutation bug in addScopeVariables method (`[link](https://github.com/webpack/webpack/pull/17032/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L2485-R2485)`)
