### PR TITLE
fix: detection automatic public path

### DIFF
--- a/lib/runtime/AutoPublicPathRuntimeModule.js
+++ b/lib/runtime/AutoPublicPathRuntimeModule.js
@@ -47,7 +47,12 @@ class AutoPublicPathRuntimeModule extends RuntimeModule {
 							"if (!scriptUrl) {",
 							Template.indent([
 								'var scripts = document.getElementsByTagName("script");',
-								"if(scripts.length) scriptUrl = scripts[scripts.length - 1].src"
+								"if(scripts.length) {",
+								Template.indent([
+									"var i = scripts.length - 1;",
+									"while (i > -1 && !scriptUrl) scriptUrl = scripts[i--].src;"
+								]),
+								"}"
 							]),
 							"}"
 						]),

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -175,10 +175,10 @@ describe("Stats", () => {
 			      "assets": Array [
 			        Object {
 			          "name": "entryB.js",
-			          "size": 2961,
+			          "size": 2985,
 			        },
 			      ],
-			      "assetsSize": 2961,
+			      "assetsSize": 2985,
 			      "auxiliaryAssets": undefined,
 			      "auxiliaryAssetsSize": 0,
 			      "childAssets": undefined,
@@ -223,10 +223,10 @@ describe("Stats", () => {
 			      "info": Object {
 			        "javascriptModule": false,
 			        "minimized": true,
-			        "size": 2961,
+			        "size": 2985,
 			      },
 			      "name": "entryB.js",
-			      "size": 2961,
+			      "size": 2985,
 			      "type": "asset",
 			    },
 			    Object {

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -3,14 +3,14 @@
 exports[`StatsTestCases should print correct stats for aggressive-splitting-entry 1`] = `
 "fitting:
   PublicPath: auto
-  asset fitting-27df06fdbf7adbff38d6.js 16.1 KiB [emitted] [immutable]
+  asset fitting-27df06fdbf7adbff38d6.js 16.2 KiB [emitted] [immutable]
   asset fitting-50595d23e8f97d7ccd2a.js 1.9 KiB [emitted] [immutable]
   asset fitting-5bc77880fdc9e2bf09ee.js 1.9 KiB [emitted] [immutable]
   asset fitting-72afdc913f6cf884b457.js 1.08 KiB [emitted] [immutable]
-  Entrypoint main 19.9 KiB = fitting-50595d23e8f97d7ccd2a.js 1.9 KiB fitting-5bc77880fdc9e2bf09ee.js 1.9 KiB fitting-27df06fdbf7adbff38d6.js 16.1 KiB
-  chunk (runtime: main) fitting-27df06fdbf7adbff38d6.js 1.87 KiB (javascript) 8.65 KiB (runtime) [entry] [rendered]
+  Entrypoint main 20 KiB = fitting-50595d23e8f97d7ccd2a.js 1.9 KiB fitting-5bc77880fdc9e2bf09ee.js 1.9 KiB fitting-27df06fdbf7adbff38d6.js 16.2 KiB
+  chunk (runtime: main) fitting-27df06fdbf7adbff38d6.js 1.87 KiB (javascript) 8.7 KiB (runtime) [entry] [rendered]
     > ./index main
-    runtime modules 8.65 KiB 11 modules
+    runtime modules 8.7 KiB 11 modules
     cacheable modules 1.87 KiB
       ./e.js 899 bytes [dependent] [built] [code generated]
       ./f.js 900 bytes [dependent] [built] [code generated]
@@ -30,14 +30,14 @@ exports[`StatsTestCases should print correct stats for aggressive-splitting-entr
 
 content-change:
   PublicPath: auto
-  asset content-change-ea14516bfb79836da4ae.js 16.1 KiB [emitted] [immutable]
+  asset content-change-ea14516bfb79836da4ae.js 16.2 KiB [emitted] [immutable]
   asset content-change-50595d23e8f97d7ccd2a.js 1.9 KiB [emitted] [immutable]
   asset content-change-5bc77880fdc9e2bf09ee.js 1.9 KiB [emitted] [immutable]
   asset content-change-72afdc913f6cf884b457.js 1.08 KiB [emitted] [immutable]
-  Entrypoint main 19.9 KiB = content-change-50595d23e8f97d7ccd2a.js 1.9 KiB content-change-5bc77880fdc9e2bf09ee.js 1.9 KiB content-change-ea14516bfb79836da4ae.js 16.1 KiB
-  chunk (runtime: main) content-change-ea14516bfb79836da4ae.js 1.87 KiB (javascript) 8.66 KiB (runtime) [entry] [rendered]
+  Entrypoint main 20 KiB = content-change-50595d23e8f97d7ccd2a.js 1.9 KiB content-change-5bc77880fdc9e2bf09ee.js 1.9 KiB content-change-ea14516bfb79836da4ae.js 16.2 KiB
+  chunk (runtime: main) content-change-ea14516bfb79836da4ae.js 1.87 KiB (javascript) 8.71 KiB (runtime) [entry] [rendered]
     > ./index main
-    runtime modules 8.66 KiB 11 modules
+    runtime modules 8.71 KiB 11 modules
     cacheable modules 1.87 KiB
       ./e.js 899 bytes [dependent] [built] [code generated]
       ./f.js 900 bytes [dependent] [built] [code generated]
@@ -58,7 +58,7 @@ content-change:
 
 exports[`StatsTestCases should print correct stats for aggressive-splitting-on-demand 1`] = `
 "PublicPath: auto
-asset abdecc928f4f9878244e.js 11.6 KiB [emitted] [immutable] (name: main)
+asset abdecc928f4f9878244e.js 11.7 KiB [emitted] [immutable] (name: main)
 asset 3fc6535262efa7e4fa3b.js 1.91 KiB [emitted] [immutable]
 asset 56815935c535fbc0e462.js 1.91 KiB [emitted] [immutable]
 asset 2b8c8882bd4326b27013.js 1.9 KiB [emitted] [immutable]
@@ -70,14 +70,14 @@ asset f79c60cc3faba968a476.js 1.9 KiB [emitted] [immutable]
 asset 7294786e49319a98f5af.js 1010 bytes [emitted] [immutable]
 asset c5861419d7f3f6ea6c19.js 1010 bytes [emitted] [immutable]
 asset f897ac9956540163d002.js 1010 bytes [emitted] [immutable]
-Entrypoint main 11.6 KiB = abdecc928f4f9878244e.js
+Entrypoint main 11.7 KiB = abdecc928f4f9878244e.js
 chunk (runtime: main) 5bc77880fdc9e2bf09ee.js 1.76 KiB [rendered] [recorded] aggressive splitted
   > ./c ./d ./e ./index.js 3:0-30
   ./c.js 899 bytes [built] [code generated]
   ./d.js 899 bytes [built] [code generated]
-chunk (runtime: main) abdecc928f4f9878244e.js (main) 248 bytes (javascript) 6.31 KiB (runtime) [entry] [rendered]
+chunk (runtime: main) abdecc928f4f9878244e.js (main) 248 bytes (javascript) 6.36 KiB (runtime) [entry] [rendered]
   > ./index main
-  runtime modules 6.31 KiB 7 modules
+  runtime modules 6.36 KiB 7 modules
   ./index.js 248 bytes [built] [code generated]
 chunk (runtime: main) 3fc6535262efa7e4fa3b.js 1.76 KiB [rendered]
   > ./f ./g ./h ./i ./j ./k ./index.js 4:0-51
@@ -157,9 +157,9 @@ webpack/runtime/make namespace object 274 bytes {main} [code generated]
 
 exports[`StatsTestCases should print correct stats for asset 1`] = `
 "asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: images/file.png] (auxiliary name: main)
-asset bundle.js 13.4 KiB [emitted] (name: main)
+asset bundle.js 13.5 KiB [emitted] (name: main)
 asset static/file.html 12 bytes [emitted] [from: static/file.html] (auxiliary name: main)
-runtime modules 1.06 KiB 2 modules
+runtime modules 1.12 KiB 2 modules
 modules by path ./ 9.36 KiB (javascript) 14.6 KiB (asset)
   modules by path ./images/ 8.86 KiB (javascript) 14.6 KiB (asset)
     ./images/file.png 42 bytes (javascript) 14.6 KiB (asset) [built] [code generated]
@@ -179,10 +179,10 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for asset-concat 1`] = `
 "asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: images/file.png] (auxiliary name: main)
-asset bundle.js 11.7 KiB [emitted] (name: main)
+asset bundle.js 11.8 KiB [emitted] (name: main)
 asset static/file.html 12 bytes [emitted] [from: static/file.html] (auxiliary name: main)
 orphan modules 9.05 KiB [orphan] 7 modules
-runtime modules 1.06 KiB 2 modules
+runtime modules 1.12 KiB 2 modules
 cacheable modules 9.6 KiB (javascript) 14.6 KiB (asset)
   ./index.js + 9 modules 9.52 KiB [built] [code generated]
   ./images/file.png 42 bytes (javascript) 14.6 KiB (asset) [built] [code generated]
@@ -191,9 +191,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for async-commons-chunk 1`] = `
-"chunk (runtime: main) main.js (main) 515 bytes (javascript) 6 KiB (runtime) >{460}< >{847}< >{996}< [entry] [rendered]
+"chunk (runtime: main) main.js (main) 515 bytes (javascript) 6.05 KiB (runtime) >{460}< >{847}< >{996}< [entry] [rendered]
   > ./ main
-  runtime modules 6 KiB 7 modules
+  runtime modules 6.05 KiB 7 modules
   ./index.js 515 bytes [built] [code generated]
 chunk (runtime: main) 460.js 21 bytes <{179}> ={847}= [rendered]
   > ./index.js 17:1-21:3
@@ -220,9 +220,9 @@ exports[`StatsTestCases should print correct stats for async-commons-chunk-auto 
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) disabled/main.js (main) 147 bytes (javascript) 6.65 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) disabled/main.js (main) 147 bytes (javascript) 6.7 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.65 KiB 9 modules
+    runtime modules 6.7 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) disabled/async-b.js (async-b) 196 bytes [rendered]
     > ./b ./index.js 2:0-47
@@ -237,9 +237,9 @@ exports[`StatsTestCases should print correct stats for async-commons-chunk-auto 
     dependent modules 60 bytes [dependent] 3 modules
     runtime modules 396 bytes 2 modules
     ./c.js + 1 modules 136 bytes [built] [code generated]
-  chunk (runtime: a) disabled/a.js (a) 245 bytes (javascript) 6.59 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) disabled/a.js (a) 245 bytes (javascript) 6.64 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 6.59 KiB 9 modules
+    runtime modules 6.64 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) disabled/async-a.js (async-a) 245 bytes [rendered]
@@ -257,9 +257,9 @@ default:
   chunk (runtime: a, main) default/async-g.js (async-g) 45 bytes [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.71 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.66 KiB 9 modules
+    runtime modules 6.71 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) default/282.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -290,9 +290,9 @@ default:
   chunk (runtime: main) default/769.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
     > ./c ./index.js 3:0-47
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.65 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.7 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 6.65 KiB 9 modules
+    runtime modules 6.7 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) default/async-a.js (async-a) 185 bytes [rendered]
@@ -305,8 +305,8 @@ default:
   default (webpack x.x.x) compiled successfully
 
 vendors:
-  Entrypoint main 11.1 KiB = vendors/main.js
-  Entrypoint a 14.5 KiB = vendors/vendors.js 1.05 KiB vendors/a.js 13.4 KiB
+  Entrypoint main 11.2 KiB = vendors/main.js
+  Entrypoint a 14.5 KiB = vendors/vendors.js 1.05 KiB vendors/a.js 13.5 KiB
   Entrypoint b 8.18 KiB = vendors/vendors.js 1.05 KiB vendors/b.js 7.13 KiB
   Entrypoint c 8.18 KiB = vendors/vendors.js 1.05 KiB vendors/c.js 7.13 KiB
   chunk (runtime: b) vendors/b.js (b) 156 bytes (javascript) 2.75 KiB (runtime) [entry] [rendered]
@@ -318,9 +318,9 @@ vendors:
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) vendors/main.js (main) 147 bytes (javascript) 6.64 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) vendors/main.js (main) 147 bytes (javascript) 6.7 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.64 KiB 9 modules
+    runtime modules 6.7 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: a, b, c) vendors/vendors.js (vendors) (id hint: vendors) 60 bytes [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
     > ./a a
@@ -342,9 +342,9 @@ vendors:
     runtime modules 2.75 KiB 4 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: a) vendors/a.js (a) 205 bytes (javascript) 7.53 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) vendors/a.js (a) 205 bytes (javascript) 7.59 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 7.53 KiB 10 modules
+    runtime modules 7.59 KiB 10 modules
     dependent modules 20 bytes [dependent] 1 module
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) vendors/async-a.js (async-a) 245 bytes [rendered]
@@ -354,8 +354,8 @@ vendors:
   vendors (webpack x.x.x) compiled successfully
 
 multiple-vendors:
-  Entrypoint main 11.5 KiB = multiple-vendors/main.js
-  Entrypoint a 15 KiB = multiple-vendors/libs-x.js 414 bytes multiple-vendors/954.js 414 bytes multiple-vendors/767.js 414 bytes multiple-vendors/390.js 414 bytes multiple-vendors/a.js 13.4 KiB
+  Entrypoint main 11.6 KiB = multiple-vendors/main.js
+  Entrypoint a 15.1 KiB = multiple-vendors/libs-x.js 414 bytes multiple-vendors/954.js 414 bytes multiple-vendors/767.js 414 bytes multiple-vendors/390.js 414 bytes multiple-vendors/a.js 13.4 KiB
   Entrypoint b 8.14 KiB = multiple-vendors/libs-x.js 414 bytes multiple-vendors/954.js 414 bytes multiple-vendors/767.js 414 bytes multiple-vendors/568.js 414 bytes multiple-vendors/b.js 6.52 KiB
   Entrypoint c 8.14 KiB = multiple-vendors/libs-x.js 414 bytes multiple-vendors/769.js 414 bytes multiple-vendors/767.js 414 bytes multiple-vendors/568.js 414 bytes multiple-vendors/c.js 6.52 KiB
   chunk (runtime: a, b, c, main) multiple-vendors/libs-x.js (libs-x) (id hint: libs) 20 bytes [initial] [rendered] split chunk (cache group: libs) (name: libs-x)
@@ -373,9 +373,9 @@ multiple-vendors:
   chunk (runtime: a, main) multiple-vendors/async-g.js (async-g) 45 bytes [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) multiple-vendors/main.js (main) 147 bytes (javascript) 6.68 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) multiple-vendors/main.js (main) 147 bytes (javascript) 6.73 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.68 KiB 9 modules
+    runtime modules 6.73 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) multiple-vendors/async-b.js (async-b) 116 bytes [rendered]
     > ./b ./index.js 2:0-47
@@ -410,9 +410,9 @@ multiple-vendors:
     > ./c ./index.js 3:0-47
     > ./c c
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) multiple-vendors/a.js (a) 165 bytes (javascript) 7.58 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) multiple-vendors/a.js (a) 165 bytes (javascript) 7.63 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 7.58 KiB 10 modules
+    runtime modules 7.63 KiB 10 modules
     ./a.js 165 bytes [built] [code generated]
   chunk (runtime: main) multiple-vendors/async-a.js (async-a) 165 bytes [rendered]
     > ./a ./index.js 1:0-47
@@ -427,7 +427,7 @@ multiple-vendors:
 
 all:
   Entrypoint main 11.5 KiB = all/main.js
-  Entrypoint a 15 KiB = all/282.js 414 bytes all/954.js 414 bytes all/767.js 414 bytes all/390.js 414 bytes all/a.js 13.3 KiB
+  Entrypoint a 15.1 KiB = all/282.js 414 bytes all/954.js 414 bytes all/767.js 414 bytes all/390.js 414 bytes all/a.js 13.4 KiB
   Entrypoint b 8.14 KiB = all/282.js 414 bytes all/954.js 414 bytes all/767.js 414 bytes all/568.js 414 bytes all/b.js 6.52 KiB
   Entrypoint c 8.14 KiB = all/282.js 414 bytes all/769.js 414 bytes all/767.js 414 bytes all/568.js 414 bytes all/c.js 6.52 KiB
   chunk (runtime: b) all/b.js (b) 116 bytes (javascript) 2.76 KiB (runtime) [entry] [rendered]
@@ -437,9 +437,9 @@ all:
   chunk (runtime: a, main) all/async-g.js (async-g) 45 bytes [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) all/main.js (main) 147 bytes (javascript) 6.65 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) all/main.js (main) 147 bytes (javascript) 6.71 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.65 KiB 9 modules
+    runtime modules 6.71 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) all/282.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
     > ./a ./index.js 1:0-47
@@ -482,9 +482,9 @@ all:
     > ./c ./index.js 3:0-47
     > ./c c
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) all/a.js (a) 165 bytes (javascript) 7.57 KiB (runtime) [entry] [rendered]
+  chunk (runtime: a) all/a.js (a) 165 bytes (javascript) 7.62 KiB (runtime) [entry] [rendered]
     > ./a a
-    runtime modules 7.57 KiB 10 modules
+    runtime modules 7.62 KiB 10 modules
     ./a.js 165 bytes [built] [code generated]
   chunk (runtime: main) all/async-a.js (async-a) 165 bytes [rendered]
     > ./a ./index.js 1:0-47
@@ -546,13 +546,13 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for chunks 1`] = `
 "PublicPath: auto
-asset bundle.js 10.2 KiB [emitted] (name: main)
+asset bundle.js 10.3 KiB [emitted] (name: main)
 asset 460.bundle.js 323 bytes [emitted]
 asset 524.bundle.js 206 bytes [emitted]
 asset 996.bundle.js 138 bytes [emitted]
-chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 6 KiB (runtime) >{460}< >{996}< [entry] [rendered]
+chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 6.06 KiB (runtime) >{460}< >{996}< [entry] [rendered]
   > ./index main
-  runtime modules 6 KiB 7 modules
+  runtime modules 6.06 KiB 7 modules
   cacheable modules 73 bytes
     ./a.js 22 bytes [dependent] [built] [code generated]
       cjs self exports reference ./a.js 1:0-14
@@ -592,7 +592,7 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for chunks-development 1`] = `
 "PublicPath: auto
-asset bundle.js 11.3 KiB [emitted] (name: main)
+asset bundle.js 11.4 KiB [emitted] (name: main)
 asset d_js-e_js.bundle.js 1.07 KiB [emitted]
 asset c_js.bundle.js 1010 bytes [emitted]
 asset b_js.bundle.js 816 bytes [emitted]
@@ -621,9 +621,9 @@ chunk (runtime: main) d_js-e_js.bundle.js 60 bytes <{c_js}> [rendered]
     cjs self exports reference ./e.js 2:0-14
     X ms -> X ms ->
     X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
-chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 6 KiB (runtime) >{b_js}< >{c_js}< [entry] [rendered]
+chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 6.06 KiB (runtime) >{b_js}< >{c_js}< [entry] [rendered]
   > ./index main
-  runtime modules 6 KiB 7 modules
+  runtime modules 6.06 KiB 7 modules
   cacheable modules 73 bytes
     ./a.js 22 bytes [dependent] [built] [code generated]
       cjs self exports reference ./a.js 1:0-14
@@ -640,8 +640,8 @@ webpack x.x.x compiled successfully in X ms"
 exports[`StatsTestCases should print correct stats for circular-correctness 1`] = `
 "chunk (runtime: main) 128.bundle.js (b) 49 bytes <{179}> <{459}> >{459}< [rendered]
   ./module-b.js 49 bytes [built] [code generated]
-chunk (runtime: main) bundle.js (main) 98 bytes (javascript) 7.68 KiB (runtime) >{128}< >{786}< [entry] [rendered]
-  runtime modules 7.68 KiB 10 modules
+chunk (runtime: main) bundle.js (main) 98 bytes (javascript) 7.74 KiB (runtime) >{128}< >{786}< [entry] [rendered]
+  runtime modules 7.74 KiB 10 modules
   ./index.js 98 bytes [built] [code generated]
 chunk (runtime: main) 459.bundle.js (c) 98 bytes <{128}> <{786}> >{128}< >{786}< [rendered]
   ./module-c.js 98 bytes [built] [code generated]
@@ -751,11 +751,11 @@ exports[`StatsTestCases should print correct stats for concat-and-sideeffects 1`
 `;
 
 exports[`StatsTestCases should print correct stats for context-independence 1`] = `
-"asset main-5479233a626f640195f9.js 12.7 KiB [emitted] [immutable] (name: main)
-  sourceMap main-5479233a626f640195f9.js.map 11 KiB [emitted] [dev] (auxiliary name: main)
+"asset main-5479233a626f640195f9.js 12.8 KiB [emitted] [immutable] (name: main)
+  sourceMap main-5479233a626f640195f9.js.map 11.1 KiB [emitted] [dev] (auxiliary name: main)
 asset 695-d9846ea7920868a759cd.js 455 bytes [emitted] [immutable]
   sourceMap 695-d9846ea7920868a759cd.js.map 347 bytes [emitted] [dev]
-runtime modules 6.59 KiB 9 modules
+runtime modules 6.65 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
   modules by layer 234 bytes
@@ -767,11 +767,11 @@ built modules 500 bytes [built]
     ./a/chunk.js + 1 modules (in Xdir/context-independence/a) 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-5479233a626f640195f9.js 12.7 KiB [emitted] [immutable] (name: main)
-  sourceMap main-5479233a626f640195f9.js.map 11 KiB [emitted] [dev] (auxiliary name: main)
+asset main-5479233a626f640195f9.js 12.8 KiB [emitted] [immutable] (name: main)
+  sourceMap main-5479233a626f640195f9.js.map 11.1 KiB [emitted] [dev] (auxiliary name: main)
 asset 695-d9846ea7920868a759cd.js 455 bytes [emitted] [immutable]
   sourceMap 695-d9846ea7920868a759cd.js.map 347 bytes [emitted] [dev]
-runtime modules 6.59 KiB 9 modules
+runtime modules 6.65 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
   modules by layer 234 bytes
@@ -783,9 +783,9 @@ built modules 500 bytes [built]
     ./b/chunk.js + 1 modules (in Xdir/context-independence/b) 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-afc6c97c5c3aafd6f882.js 14.8 KiB [emitted] [immutable] (name: main)
+asset main-afc6c97c5c3aafd6f882.js 14.9 KiB [emitted] [immutable] (name: main)
 asset 695-3a54289b6e0375f1e753.js 1.51 KiB [emitted] [immutable]
-runtime modules 6.59 KiB 9 modules
+runtime modules 6.65 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
   modules by layer 234 bytes
@@ -797,9 +797,9 @@ built modules 500 bytes [built]
     ./a/chunk.js + 1 modules (in Xdir/context-independence/a) 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-afc6c97c5c3aafd6f882.js 14.8 KiB [emitted] [immutable] (name: main)
+asset main-afc6c97c5c3aafd6f882.js 14.9 KiB [emitted] [immutable] (name: main)
 asset 695-3a54289b6e0375f1e753.js 1.51 KiB [emitted] [immutable]
-runtime modules 6.59 KiB 9 modules
+runtime modules 6.65 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
   modules by layer 234 bytes
@@ -811,9 +811,9 @@ built modules 500 bytes [built]
     ./b/chunk.js + 1 modules (in Xdir/context-independence/b) 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-7dd3306e33267a41ff55.js 13.7 KiB [emitted] [immutable] (name: main)
+asset main-7dd3306e33267a41ff55.js 13.8 KiB [emitted] [immutable] (name: main)
 asset 695-ace208366ce0ce2556ef.js 1.01 KiB [emitted] [immutable]
-runtime modules 6.59 KiB 9 modules
+runtime modules 6.65 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
   modules by layer 234 bytes
@@ -825,9 +825,9 @@ built modules 500 bytes [built]
     ./a/chunk.js + 1 modules (in Xdir/context-independence/a) 66 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-7dd3306e33267a41ff55.js 13.7 KiB [emitted] [immutable] (name: main)
+asset main-7dd3306e33267a41ff55.js 13.8 KiB [emitted] [immutable] (name: main)
 asset 695-ace208366ce0ce2556ef.js 1.01 KiB [emitted] [immutable]
-runtime modules 6.59 KiB 9 modules
+runtime modules 6.65 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
   modules by layer 234 bytes
@@ -1156,8 +1156,8 @@ webpack x.x.x compiled with 2 errors in X ms"
 
 exports[`StatsTestCases should print correct stats for exclude-with-loader 1`] = `
 "hidden assets 34 bytes 1 asset
-asset bundle.js 5.25 KiB [emitted] (name: main)
-runtime modules 1.72 KiB 5 modules
+asset bundle.js 5.34 KiB [emitted] (name: main)
+runtime modules 1.77 KiB 5 modules
 hidden modules 99 bytes 2 modules
 cacheable modules 119 bytes
   ./index.js 77 bytes [built] [code generated]
@@ -1176,16 +1176,16 @@ exports[`StatsTestCases should print correct stats for graph-correctness-entries
 "chunk (runtime: e1, e2) b.js (b) 49 bytes <{786}> >{459}< [rendered]
   ./module-b.js 49 bytes [built] [code generated]
     import() ./module-b ./module-a.js 1:0-47
-chunk (runtime: e1) e1.js (e1) 49 bytes (javascript) 7.71 KiB (runtime) >{786}< [entry] [rendered]
-  runtime modules 7.71 KiB 10 modules
+chunk (runtime: e1) e1.js (e1) 49 bytes (javascript) 7.76 KiB (runtime) >{786}< [entry] [rendered]
+  runtime modules 7.76 KiB 10 modules
   ./e1.js 49 bytes [built] [code generated]
     entry ./e1 e1
 chunk (runtime: e1, e2) c.js (c) 49 bytes <{128}> <{621}> >{786}< [rendered]
   ./module-c.js 49 bytes [built] [code generated]
     import() ./module-c ./e2.js 1:0-47
     import() ./module-c ./module-b.js 1:0-47
-chunk (runtime: e2) e2.js (e2) 49 bytes (javascript) 7.71 KiB (runtime) >{459}< [entry] [rendered]
-  runtime modules 7.71 KiB 10 modules
+chunk (runtime: e2) e2.js (e2) 49 bytes (javascript) 7.76 KiB (runtime) >{459}< [entry] [rendered]
+  runtime modules 7.76 KiB 10 modules
   ./e2.js 49 bytes [built] [code generated]
     entry ./e2 e2
 chunk (runtime: e1, e2) a.js (a) 49 bytes <{257}> <{459}> >{128}< [rendered]
@@ -1199,8 +1199,8 @@ exports[`StatsTestCases should print correct stats for graph-correctness-modules
 "chunk (runtime: e1, e2) b.js (b) 179 bytes <{786}> >{459}< [rendered]
   ./module-b.js 179 bytes [built] [code generated]
     import() ./module-b ./module-a.js 1:0-47
-chunk (runtime: e1) e1.js (e1) 119 bytes (javascript) 7.98 KiB (runtime) >{786}< >{892}< [entry] [rendered]
-  runtime modules 7.98 KiB 11 modules
+chunk (runtime: e1) e1.js (e1) 119 bytes (javascript) 8.03 KiB (runtime) >{786}< >{892}< [entry] [rendered]
+  runtime modules 8.03 KiB 11 modules
   cacheable modules 119 bytes
     ./e1.js 70 bytes [built] [code generated]
       entry ./e1 e1
@@ -1212,8 +1212,8 @@ chunk (runtime: e1, e2) c.js (c) 49 bytes <{128}> <{621}> >{786}< [rendered]
   ./module-c.js 49 bytes [built] [code generated]
     import() ./module-c ./e2.js 2:0-47
     import() ./module-c ./module-b.js 1:0-47
-chunk (runtime: e2) e2.js (e2) 119 bytes (javascript) 7.98 KiB (runtime) >{459}< >{892}< [entry] [rendered]
-  runtime modules 7.98 KiB 11 modules
+chunk (runtime: e2) e2.js (e2) 119 bytes (javascript) 8.03 KiB (runtime) >{459}< >{892}< [entry] [rendered]
+  runtime modules 8.03 KiB 11 modules
   cacheable modules 119 bytes
     ./e2.js 70 bytes [built] [code generated]
       entry ./e2 e2
@@ -1252,8 +1252,8 @@ chunk (runtime: main) id-equals-name_js0.js 21 bytes [rendered]
   ./id-equals-name.js 21 bytes [built] [code generated]
 chunk (runtime: main) id-equals-name_js_3.js 21 bytes [rendered]
   ./id-equals-name.js?3 21 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 639 bytes (javascript) 6.57 KiB (runtime) [entry] [rendered]
-  runtime modules 6.57 KiB 9 modules
+chunk (runtime: main) main.js (main) 639 bytes (javascript) 6.62 KiB (runtime) [entry] [rendered]
+  runtime modules 6.62 KiB 9 modules
   ./index.js 639 bytes [built] [code generated]
 chunk (runtime: main) tree.js (tree) 137 bytes [rendered]
   dependent modules 98 bytes [dependent] 3 modules
@@ -1282,16 +1282,16 @@ webpack x.x.x compiled with 2 warnings in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for immutable 1`] = `
-"asset 5d45ce8c58c0be47d4b1.js 13.3 KiB [emitted] [immutable] (name: main)
+"asset 5d45ce8c58c0be47d4b1.js 13.4 KiB [emitted] [immutable] (name: main)
 asset 22c24a3b26d46118dc06.js 809 bytes [emitted] [immutable]"
 `;
 
 exports[`StatsTestCases should print correct stats for import-context-filter 1`] = `
-"asset entry.js 11.9 KiB [emitted] (name: entry)
+"asset entry.js 12 KiB [emitted] (name: entry)
 asset 398.js 482 bytes [emitted]
 asset 544.js 482 bytes [emitted]
 asset 718.js 482 bytes [emitted]
-runtime modules 6.56 KiB 9 modules
+runtime modules 6.62 KiB 9 modules
 built modules 724 bytes [built]
   modules by path ./templates/*.js 114 bytes
     ./templates/bar.js 38 bytes [optional] [built] [code generated]
@@ -1303,9 +1303,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for import-weak 1`] = `
-"asset entry.js 13 KiB [emitted] (name: entry)
+"asset entry.js 13.1 KiB [emitted] (name: entry)
 asset 836.js 138 bytes [emitted]
-runtime modules 7.68 KiB 10 modules
+runtime modules 7.73 KiB 10 modules
 orphan modules 37 bytes [orphan] 1 module
 cacheable modules 142 bytes
   ./entry.js 120 bytes [built] [code generated]
@@ -1314,9 +1314,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for import-weak-parser-option 1`] = `
-"asset entry.js 13 KiB [emitted] (name: entry)
+"asset entry.js 13.1 KiB [emitted] (name: entry)
 asset 836.js 138 bytes [emitted]
-runtime modules 7.68 KiB 10 modules
+runtime modules 7.73 KiB 10 modules
 orphan modules 37 bytes [orphan] 1 module
 cacheable modules 116 bytes
   ./entry.js 94 bytes [built] [code generated]
@@ -1325,7 +1325,7 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for import-with-invalid-options-comments 1`] = `
-"runtime modules 8.6 KiB 12 modules
+"runtime modules 8.66 KiB 12 modules
 cacheable modules 559 bytes
   ./index.js 50 bytes [built] [code generated]
   ./chunk.js 401 bytes [built] [code generated] [3 warnings]
@@ -1372,11 +1372,11 @@ webpack x.x.x compiled successfully in X ms
 assets by chunk 895 bytes (id hint: all)
   asset c-all-b_js-d2d64fdaadbf1936503b.js 502 bytes [emitted] [immutable] (id hint: all)
   asset c-all-c_js-0552c7cbb8c1a12b6b9c.js 393 bytes [emitted] [immutable] (id hint: all)
-asset c-runtime~main-39696e33891b24e372db.js 13.5 KiB [emitted] [immutable] (name: runtime~main)
+asset c-runtime~main-39696e33891b24e372db.js 13.6 KiB [emitted] [immutable] (name: runtime~main)
 asset c-main-463838c803f48fe97bb6.js 680 bytes [emitted] [immutable] (name: main)
 asset c-vendors-node_modules_vendor_js-7320f018dbab7e34ead5.js 185 bytes [emitted] [immutable] (id hint: vendors)
-Entrypoint main 14.6 KiB = c-runtime~main-39696e33891b24e372db.js 13.5 KiB c-all-c_js-0552c7cbb8c1a12b6b9c.js 393 bytes c-main-463838c803f48fe97bb6.js 680 bytes
-runtime modules 8.66 KiB 13 modules
+Entrypoint main 14.7 KiB = c-runtime~main-39696e33891b24e372db.js 13.6 KiB c-all-c_js-0552c7cbb8c1a12b6b9c.js 393 bytes c-main-463838c803f48fe97bb6.js 680 bytes
+runtime modules 8.72 KiB 13 modules
 cacheable modules 101 bytes
   ./c.js 61 bytes [built] [code generated]
   ./b.js 17 bytes [built] [code generated]
@@ -1399,10 +1399,10 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   1 chunks (webpack x.x.x) compiled successfully in X ms
 
 2 chunks:
-  asset bundle2.js 12.5 KiB [emitted] (name: main)
+  asset bundle2.js 12.6 KiB [emitted] (name: main)
   asset 459.bundle2.js 664 bytes [emitted] (name: c)
-  chunk (runtime: main) bundle2.js (main) 101 bytes (javascript) 7.69 KiB (runtime) >{459}< [entry] [rendered]
-    runtime modules 7.69 KiB 10 modules
+  chunk (runtime: main) bundle2.js (main) 101 bytes (javascript) 7.74 KiB (runtime) >{459}< [entry] [rendered]
+    runtime modules 7.74 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
   chunk (runtime: main) 459.bundle2.js (c) 118 bytes <{179}> <{459}> >{459}< [rendered]
     dependent modules 44 bytes [dependent]
@@ -1414,11 +1414,11 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   2 chunks (webpack x.x.x) compiled successfully in X ms
 
 3 chunks:
-  asset bundle3.js 12.5 KiB [emitted] (name: main)
+  asset bundle3.js 12.6 KiB [emitted] (name: main)
   asset 459.bundle3.js 528 bytes [emitted] (name: c)
   asset 524.bundle3.js 206 bytes [emitted]
-  chunk (runtime: main) bundle3.js (main) 101 bytes (javascript) 7.69 KiB (runtime) >{459}< [entry] [rendered]
-    runtime modules 7.69 KiB 10 modules
+  chunk (runtime: main) bundle3.js (main) 101 bytes (javascript) 7.74 KiB (runtime) >{459}< [entry] [rendered]
+    runtime modules 7.74 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
   chunk (runtime: main) 459.bundle3.js (c) 74 bytes <{179}> >{524}< [rendered]
     ./a.js 22 bytes [built] [code generated]
@@ -1430,12 +1430,12 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   3 chunks (webpack x.x.x) compiled successfully in X ms
 
 4 chunks:
-  asset bundle4.js 12.5 KiB [emitted] (name: main)
+  asset bundle4.js 12.6 KiB [emitted] (name: main)
   asset 459.bundle4.js 392 bytes [emitted] (name: c)
   asset 394.bundle4.js 206 bytes [emitted]
   asset 524.bundle4.js 206 bytes [emitted]
-  chunk (runtime: main) bundle4.js (main) 101 bytes (javascript) 7.69 KiB (runtime) >{394}< >{459}< [entry] [rendered]
-    runtime modules 7.69 KiB 10 modules
+  chunk (runtime: main) bundle4.js (main) 101 bytes (javascript) 7.74 KiB (runtime) >{394}< >{459}< [entry] [rendered]
+    runtime modules 7.74 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
   chunk (runtime: main) 394.bundle4.js 44 bytes <{179}> [rendered]
     ./a.js 22 bytes [built] [code generated]
@@ -1591,26 +1591,26 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for module-assets 1`] = `
-"assets by path *.js 11.7 KiB
-  asset main.js 10.4 KiB [emitted] (name: main)
+"assets by path *.js 11.8 KiB
+  asset main.js 10.5 KiB [emitted] (name: main)
   asset a.js 732 bytes [emitted] (name: a)
   asset b.js 549 bytes [emitted] (name: b)
 assets by path *.png 42 KiB
   asset 1.png 21 KiB [emitted] [from: node_modules/a/1.png] (auxiliary name: a)
   asset 2.png 21 KiB [emitted] [from: node_modules/a/2.png] (auxiliary name: a, b)
-Entrypoint main 10.4 KiB = main.js
+Entrypoint main 10.5 KiB = main.js
 Chunk Group a 732 bytes (42 KiB) = a.js 732 bytes (1.png 21 KiB 2.png 21 KiB)
 Chunk Group b 549 bytes (21 KiB) = b.js 549 bytes (2.png 21 KiB)
 chunk (runtime: main) b.js (b) 67 bytes [rendered]
   ./node_modules/a/2.png 49 bytes [dependent] [built] [code generated] [1 asset]
   ./node_modules/b/index.js 18 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 82 bytes (javascript) 6.29 KiB (runtime) [entry] [rendered]
-  runtime modules 6.29 KiB 8 modules
+chunk (runtime: main) main.js (main) 82 bytes (javascript) 6.34 KiB (runtime) [entry] [rendered]
+  runtime modules 6.34 KiB 8 modules
   ./index.js 82 bytes [built] [code generated]
 chunk (runtime: main) a.js (a) 134 bytes [rendered]
   ./node_modules/a/2.png 49 bytes [dependent] [built] [code generated] [1 asset]
   ./node_modules/a/index.js + 1 modules 85 bytes [built] [code generated] [1 asset]
-runtime modules 6.29 KiB 8 modules
+runtime modules 6.34 KiB 8 modules
 orphan modules 49 bytes [orphan] 1 module
 modules with assets 234 bytes
   modules by path ./node_modules/a/ 134 bytes
@@ -1622,9 +1622,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for module-deduplication 1`] = `
-"asset e1.js 12.1 KiB [emitted] (name: e1)
-asset e2.js 12.1 KiB [emitted] (name: e2)
-asset e3.js 12.1 KiB [emitted] (name: e3)
+"asset e1.js 12.2 KiB [emitted] (name: e1)
+asset e2.js 12.2 KiB [emitted] (name: e2)
+asset e3.js 12.2 KiB [emitted] (name: e3)
 asset 172.js 858 bytes [emitted]
 asset 326.js 858 bytes [emitted]
 asset 923.js 858 bytes [emitted]
@@ -1633,8 +1633,8 @@ asset 593.js 524 bytes [emitted]
 asset 716.js 524 bytes [emitted]
 chunk (runtime: e1) 114.js 61 bytes [rendered]
   ./async1.js 61 bytes [built] [code generated]
-chunk (runtime: e3) e3.js (e3) 249 bytes (javascript) 6.56 KiB (runtime) [entry] [rendered]
-  runtime modules 6.56 KiB 9 modules
+chunk (runtime: e3) e3.js (e3) 249 bytes (javascript) 6.62 KiB (runtime) [entry] [rendered]
+  runtime modules 6.62 KiB 9 modules
   cacheable modules 249 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e3.js + 2 modules 209 bytes [built] [code generated]
@@ -1642,8 +1642,8 @@ chunk (runtime: e3) e3.js (e3) 249 bytes (javascript) 6.56 KiB (runtime) [entry]
 chunk (runtime: e1, e3) 172.js 81 bytes [rendered]
   ./async2.js 61 bytes [built] [code generated]
   ./f.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e1) e1.js (e1) 249 bytes (javascript) 6.56 KiB (runtime) [entry] [rendered]
-  runtime modules 6.56 KiB 9 modules
+chunk (runtime: e1) e1.js (e1) 249 bytes (javascript) 6.62 KiB (runtime) [entry] [rendered]
+  runtime modules 6.62 KiB 9 modules
   cacheable modules 249 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./d.js 20 bytes [dependent] [built] [code generated]
@@ -1653,8 +1653,8 @@ chunk (runtime: e1, e2) 326.js 81 bytes [rendered]
   ./h.js 20 bytes [dependent] [built] [code generated]
 chunk (runtime: e3) 593.js 61 bytes [rendered]
   ./async3.js 61 bytes [built] [code generated]
-chunk (runtime: e2) e2.js (e2) 249 bytes (javascript) 6.56 KiB (runtime) [entry] [rendered]
-  runtime modules 6.56 KiB 9 modules
+chunk (runtime: e2) e2.js (e2) 249 bytes (javascript) 6.62 KiB (runtime) [entry] [rendered]
+  runtime modules 6.62 KiB 9 modules
   cacheable modules 249 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e2.js + 2 modules 209 bytes [built] [code generated]
@@ -1668,20 +1668,20 @@ webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for module-deduplication-named 1`] = `
-"asset e1.js 12 KiB [emitted] (name: e1)
-asset e2.js 12 KiB [emitted] (name: e2)
-asset e3.js 12 KiB [emitted] (name: e3)
+"asset e1.js 12.1 KiB [emitted] (name: e1)
+asset e2.js 12.1 KiB [emitted] (name: e2)
+asset e3.js 12.1 KiB [emitted] (name: e3)
 asset async1.js 964 bytes [emitted] (name: async1)
 asset async2.js 964 bytes [emitted] (name: async2)
 asset async3.js 964 bytes [emitted] (name: async3)
-chunk (runtime: e3) e3.js (e3) 242 bytes (javascript) 6.61 KiB (runtime) [entry] [rendered]
-  runtime modules 6.61 KiB 9 modules
+chunk (runtime: e3) e3.js (e3) 242 bytes (javascript) 6.66 KiB (runtime) [entry] [rendered]
+  runtime modules 6.66 KiB 9 modules
   cacheable modules 242 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e3.js + 2 modules 202 bytes [built] [code generated]
     ./h.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e1) e1.js (e1) 242 bytes (javascript) 6.61 KiB (runtime) [entry] [rendered]
-  runtime modules 6.61 KiB 9 modules
+chunk (runtime: e1) e1.js (e1) 242 bytes (javascript) 6.66 KiB (runtime) [entry] [rendered]
+  runtime modules 6.66 KiB 9 modules
   cacheable modules 242 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./d.js 20 bytes [dependent] [built] [code generated]
@@ -1692,8 +1692,8 @@ chunk (runtime: e1, e2, e3) async1.js (async1) 135 bytes [rendered]
 chunk (runtime: e1, e2, e3) async3.js (async3) 135 bytes [rendered]
   ./async3.js 115 bytes [built] [code generated]
   ./h.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e2) e2.js (e2) 242 bytes (javascript) 6.61 KiB (runtime) [entry] [rendered]
-  runtime modules 6.61 KiB 9 modules
+chunk (runtime: e2) e2.js (e2) 242 bytes (javascript) 6.66 KiB (runtime) [entry] [rendered]
+  runtime modules 6.66 KiB 9 modules
   cacheable modules 242 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e2.js + 2 modules 202 bytes [built] [code generated]
@@ -1705,10 +1705,10 @@ webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for module-federation-custom-exposed-module-name 1`] = `
-"asset container_bundle.js 11.9 KiB [emitted] (name: container)
+"asset container_bundle.js 12 KiB [emitted] (name: container)
 asset custom-entry_bundle.js 414 bytes [emitted] (name: custom-entry)
 asset main_bundle.js 84 bytes [emitted] (name: main)
-runtime modules 6.58 KiB 9 modules
+runtime modules 6.63 KiB 9 modules
 built modules 82 bytes [built]
   ./index.js 1 bytes [built] [code generated]
   container entry 42 bytes [built] [code generated]
@@ -1813,9 +1813,9 @@ chunk (runtime: main) a-52.js 149 bytes [rendered] split chunk (cache group: def
   > ./a ./index.js 1:0-47
   > ./b ./index.js 2:0-47
   ./shared.js 149 bytes [built] [code generated]
-chunk (runtime: main) a-main.js (main) 146 bytes (javascript) 6.9 KiB (runtime) [entry] [rendered]
+chunk (runtime: main) a-main.js (main) 146 bytes (javascript) 6.96 KiB (runtime) [entry] [rendered]
   > ./ main
-  runtime modules 6.9 KiB 10 modules
+  runtime modules 6.96 KiB 10 modules
   ./index.js 146 bytes [built] [code generated]
 chunk (runtime: main) a-vendors.js (vendors) (id hint: vendors) 40 bytes [rendered] split chunk (cache group: vendors) (name: vendors)
   > ./c ./index.js 3:0-47
@@ -1840,9 +1840,9 @@ chunk (runtime: main) b-52.js 149 bytes [rendered] split chunk (cache group: def
   > ./a ./index.js 1:0-47
   > ./b ./index.js 2:0-47
   ./shared.js 149 bytes [built] [code generated]
-chunk (runtime: main) b-main.js (main) 146 bytes (javascript) 6.9 KiB (runtime) [entry] [rendered]
+chunk (runtime: main) b-main.js (main) 146 bytes (javascript) 6.96 KiB (runtime) [entry] [rendered]
   > ./ main
-  runtime modules 6.9 KiB 10 modules
+  runtime modules 6.96 KiB 10 modules
   ./index.js 146 bytes [built] [code generated]
 chunk (runtime: main) b-vendors.js (vendors) (id hint: vendors) 40 bytes [rendered] split chunk (cache group: vendors) (name: vendors)
   > ./c ./index.js 3:0-47
@@ -1874,10 +1874,10 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for named-chunks-plugin-async 1`] = `
-"asset entry.js 12.4 KiB [emitted] (name: entry)
+"asset entry.js 12.5 KiB [emitted] (name: entry)
 asset modules_a_js.js 313 bytes [emitted]
 asset modules_b_js.js 149 bytes [emitted]
-runtime modules 7.68 KiB 10 modules
+runtime modules 7.74 KiB 10 modules
 cacheable modules 106 bytes
   ./entry.js 47 bytes [built] [code generated]
   ./modules/a.js 37 bytes [built] [code generated]
@@ -1899,7 +1899,7 @@ webpack x.x.x compiled with 1 error and 1 warning in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for optimize-chunks 1`] = `
-"asset main.js 11 KiB {179} [emitted] (name: main)
+"asset main.js 11.1 KiB {179} [emitted] (name: main)
 asset cir2 from cir1.js 377 bytes {288}, {289} [emitted] (name: cir2 from cir1)
 asset cir1.js 333 bytes {592} [emitted] (name: cir1)
 asset cir2.js 333 bytes {289} [emitted] (name: cir2)
@@ -1911,9 +1911,9 @@ chunk {90} (runtime: main) ab.js (ab) 2 bytes <{179}> >{753}< [rendered]
   > [10] ./index.js 1:0-6:8
   ./modules/a.js [839] 1 bytes {90} {374} [built] [code generated]
   ./modules/b.js [836] 1 bytes {90} {374} [built] [code generated]
-chunk {179} (runtime: main) main.js (main) 524 bytes (javascript) 6.1 KiB (runtime) >{90}< >{289}< >{374}< >{592}< [entry] [rendered]
+chunk {179} (runtime: main) main.js (main) 524 bytes (javascript) 6.15 KiB (runtime) >{90}< >{289}< >{374}< >{592}< [entry] [rendered]
   > ./index main
-  runtime modules 6.1 KiB 7 modules
+  runtime modules 6.15 KiB 7 modules
   cacheable modules 524 bytes
     ./index.js [10] 523 bytes {179} [built] [code generated]
     ./modules/f.js [544] 1 bytes {179} [dependent] [built] [code generated]
@@ -2056,7 +2056,7 @@ asset <CLR=32,BOLD>460.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
-runtime modules 6 KiB 7 modules
+runtime modules 6.05 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2073,7 +2073,7 @@ asset <CLR=32,BOLD>460.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
-runtime modules 6 KiB 7 modules
+runtime modules 6.05 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2132,7 +2132,7 @@ asset <CLR=32,BOLD>460.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
-runtime modules 6 KiB 7 modules
+runtime modules 6.05 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2174,17 +2174,17 @@ webpack x.x.x compiled with <CLR=31,BOLD>3 errors</CLR> in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for prefetch 1`] = `
-"asset main.js 16.8 KiB {179} [emitted] (name: main)
+"asset main.js 16.9 KiB {179} [emitted] (name: main)
 asset prefetched.js 556 bytes {505} [emitted] (name: prefetched)
 asset inner2.js 150 bytes {641} [emitted] (name: inner2)
 asset inner.js 110 bytes {746} [emitted] (name: inner)
 asset prefetched2.js 110 bytes {379} [emitted] (name: prefetched2)
 asset prefetched3.js 110 bytes {220} [emitted] (name: prefetched3)
 asset normal.js 109 bytes {30} [emitted] (name: normal)
-Entrypoint main 16.8 KiB = main.js
+Entrypoint main 16.9 KiB = main.js
   prefetch: prefetched2.js {379} (name: prefetched2), prefetched.js {505} (name: prefetched), prefetched3.js {220} (name: prefetched3)
 chunk {30} (runtime: main) normal.js (normal) 1 bytes <{179}> [rendered]
-chunk {179} (runtime: main) main.js (main) 436 bytes (javascript) 9.94 KiB (runtime) >{30}< >{220}< >{379}< >{505}< (prefetch: {379} {505} {220}) [entry] [rendered]
+chunk {179} (runtime: main) main.js (main) 436 bytes (javascript) 9.99 KiB (runtime) >{30}< >{220}< >{379}< >{505}< (prefetch: {379} {505} {220}) [entry] [rendered]
 chunk {220} (runtime: main) prefetched3.js (prefetched3) 1 bytes <{179}> [rendered]
 chunk {379} (runtime: main) prefetched2.js (prefetched2) 1 bytes <{179}> [rendered]
 chunk {505} (runtime: main) prefetched.js (prefetched) 228 bytes <{179}> >{641}< >{746}< (prefetch: {641} {746}) [rendered]
@@ -2217,7 +2217,7 @@ asset preloaded3.js 108 bytes [emitted] (name: preloaded3)
 Entrypoint main 15.2 KiB = main.js
   preload: preloaded2.js (name: preloaded2), preloaded.js (name: preloaded), preloaded3.js (name: preloaded3)
 chunk (runtime: main) normal.js (normal) 1 bytes [rendered]
-chunk (runtime: main) main.js (main) 424 bytes (javascript) 8.88 KiB (runtime) (preload: {363} {851} {355}) [entry] [rendered]
+chunk (runtime: main) main.js (main) 424 bytes (javascript) 8.93 KiB (runtime) (preload: {363} {851} {355}) [entry] [rendered]
 chunk (runtime: main) preloaded3.js (preloaded3) 1 bytes [rendered]
 chunk (runtime: main) preloaded2.js (preloaded2) 1 bytes [rendered]
 chunk (runtime: main) inner2.js (inner2) 2 bytes [rendered]
@@ -2235,12 +2235,12 @@ exports[`StatsTestCases should print correct stats for preset-detailed 1`] = `
       [LogTestPlugin] Log
     [LogTestPlugin] End
 PublicPath: auto
-asset main.js 10.2 KiB {179} [emitted] (name: main)
+asset main.js 10.3 KiB {179} [emitted] (name: main)
 asset 460.js 323 bytes {460} [emitted]
 asset 524.js 206 bytes {524} [emitted]
 asset 996.js 138 bytes {996} [emitted]
-Entrypoint main 10.2 KiB = main.js
-chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 6 KiB (runtime) >{460}< >{996}< [entry] [rendered]
+Entrypoint main 10.3 KiB = main.js
+chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 6.05 KiB (runtime) >{460}< >{996}< [entry] [rendered]
   > ./index main
 chunk {460} (runtime: main) 460.js 54 bytes <{179}> >{524}< [rendered]
   > ./c [10] ./index.js 3:0-16
@@ -2248,7 +2248,7 @@ chunk {524} (runtime: main) 524.js 44 bytes <{460}> [rendered]
   > [460] ./c.js 1:0-52
 chunk {996} (runtime: main) 996.js 22 bytes <{179}> [rendered]
   > ./b [10] ./index.js 2:0-16
-runtime modules 6 KiB
+runtime modules 6.05 KiB
   webpack/runtime/ensure chunk 326 bytes {179} [code generated]
     [no exports]
     [used exports unknown]
@@ -2267,7 +2267,7 @@ runtime modules 6 KiB
   webpack/runtime/load script 1.36 KiB {179} [code generated]
     [no exports]
     [used exports unknown]
-  webpack/runtime/publicPath 868 bytes {179} [code generated]
+  webpack/runtime/publicPath 923 bytes {179} [code generated]
     [no exports]
     [used exports unknown]
 cacheable modules 193 bytes
@@ -2338,7 +2338,7 @@ LOG from webpack.FileSystemInfo
     Directory info in cache: 0 timestamps 0 hashes 0 timestamp hash combinations
     Managed items info in cache: 0 items
 
-1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (44c013196446a1259957)"
+1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (b5dd2f2a91faf2c4143f)"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-errors-only 1`] = `""`;
@@ -2413,11 +2413,11 @@ exports[`StatsTestCases should print correct stats for preset-normal 1`] = `
 "<e> [LogTestPlugin] Error
 <w> [LogTestPlugin] Warning
 <i> [LogTestPlugin] Info
-asset main.js 10.2 KiB [emitted] (name: main)
+asset main.js 10.3 KiB [emitted] (name: main)
 asset 460.js 323 bytes [emitted]
 asset 524.js 206 bytes [emitted]
 asset 996.js 138 bytes [emitted]
-runtime modules 6 KiB 7 modules
+runtime modules 6.05 KiB 7 modules
 cacheable modules 193 bytes
   ./index.js 51 bytes [built] [code generated]
   ./a.js 22 bytes [built] [code generated]
@@ -2440,7 +2440,7 @@ exports[`StatsTestCases should print correct stats for preset-normal-performance
 asset <CLR=32,BOLD>460.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>524.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
 asset <CLR=32,BOLD>996.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
-runtime modules 6 KiB 7 modules
+runtime modules 6.05 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2468,7 +2468,7 @@ exports[`StatsTestCases should print correct stats for preset-normal-performance
 asset <CLR=32,BOLD>460.js</CLR> 355 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
 asset <CLR=32,BOLD>524.js</CLR> 238 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
 asset <CLR=32,BOLD>996.js</CLR> 170 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
-runtime modules 6 KiB 7 modules
+runtime modules 6.05 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
   <CLR=BOLD>./a.js</CLR> 293 KiB <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2511,14 +2511,14 @@ exports[`StatsTestCases should print correct stats for preset-verbose 1`] = `
       [LogTestPlugin] Log
     [LogTestPlugin] End
 PublicPath: auto
-asset main.js 10.2 KiB {179} [emitted] (name: main)
+asset main.js 10.3 KiB {179} [emitted] (name: main)
 asset 460.js 323 bytes {460} [emitted]
 asset 524.js 206 bytes {524} [emitted]
 asset 996.js 138 bytes {996} [emitted]
-Entrypoint main 10.2 KiB = main.js
-chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 6 KiB (runtime) >{460}< >{996}< [entry] [rendered]
+Entrypoint main 10.3 KiB = main.js
+chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 6.05 KiB (runtime) >{460}< >{996}< [entry] [rendered]
   > ./index main
-  runtime modules 6 KiB
+  runtime modules 6.05 KiB
     webpack/runtime/ensure chunk 326 bytes {179} [code generated]
       [no exports]
       [used exports unknown]
@@ -2537,7 +2537,7 @@ chunk {179} (runtime: main) main.js (main) 73 bytes (javascript) 6 KiB (runtime)
     webpack/runtime/load script 1.36 KiB {179} [code generated]
       [no exports]
       [used exports unknown]
-    webpack/runtime/publicPath 868 bytes {179} [code generated]
+    webpack/runtime/publicPath 923 bytes {179} [code generated]
       [no exports]
       [used exports unknown]
   cacheable modules 73 bytes
@@ -2714,13 +2714,13 @@ LOG from webpack.FileSystemInfo
     Directory info in cache: 0 timestamps 0 hashes 0 timestamp hash combinations
     Managed items info in cache: 0 items
 
-1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (44c013196446a1259957)"
+1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (b5dd2f2a91faf2c4143f)"
 `;
 
 exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
 "a-normal:
-  assets by path *.js 3.2 KiB
-    asset 3d07a728e82c0ce8f5a8-3d07a7.js 2.75 KiB [emitted] [immutable] [minimized] (name: runtime)
+  assets by path *.js 3.23 KiB
+    asset 48e1a25a11a7b9397e41-48e1a2.js 2.77 KiB [emitted] [immutable] [minimized] (name: runtime)
     asset f96e917feecf51c4fc5c-f96e91.js 232 bytes [emitted] [immutable] [minimized] (name: lazy)
     asset f17033ffbf027f2d71b7-f17033.js 212 bytes [emitted] [immutable] [minimized] (name: index)
     asset 666f2b8847021ccc7608-666f2b.js 21 bytes [emitted] [immutable] [minimized] (name: a, b)
@@ -2728,10 +2728,10 @@ exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
     asset 7382fad5b015914e0811.jpg?query 5.89 KiB [cached] [immutable] [from: file.jpg?query] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: index)
-  Entrypoint index 2.96 KiB (5.89 KiB) = 3d07a728e82c0ce8f5a8-3d07a7.js 2.75 KiB f17033ffbf027f2d71b7-f17033.js 212 bytes 1 auxiliary asset
+  Entrypoint index 2.98 KiB (5.89 KiB) = 48e1a25a11a7b9397e41-48e1a2.js 2.77 KiB f17033ffbf027f2d71b7-f17033.js 212 bytes 1 auxiliary asset
   Entrypoint a 21 bytes = 666f2b8847021ccc7608-666f2b.js
   Entrypoint b 21 bytes = 666f2b8847021ccc7608-666f2b.js
-  runtime modules 7.28 KiB 9 modules
+  runtime modules 7.34 KiB 9 modules
   orphan modules 23 bytes [orphan] 1 module
   cacheable modules 556 bytes (javascript) 26.3 KiB (asset)
     javascript modules 430 bytes
@@ -2746,8 +2746,8 @@ exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
   a-normal (webpack x.x.x) compiled successfully in X ms
 
 b-normal:
-  assets by path *.js 3.2 KiB
-    asset e9785128a82e17f93bc4-e97851.js 2.75 KiB [emitted] [immutable] [minimized] (name: runtime)
+  assets by path *.js 3.23 KiB
+    asset f64fdaf8571eaf5e2680-f64fda.js 2.77 KiB [emitted] [immutable] [minimized] (name: runtime)
     asset f96e917feecf51c4fc5c-f96e91.js 232 bytes [emitted] [immutable] [minimized] (name: lazy)
     asset f17033ffbf027f2d71b7-f17033.js 212 bytes [emitted] [immutable] [minimized] (name: index)
     asset 666f2b8847021ccc7608-666f2b.js 21 bytes [emitted] [immutable] [minimized] (name: a, b)
@@ -2755,10 +2755,10 @@ b-normal:
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
     asset 7382fad5b015914e0811.jpg?query 5.89 KiB [cached] [immutable] [from: file.jpg?query] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: index)
-  Entrypoint index 2.96 KiB (5.89 KiB) = e9785128a82e17f93bc4-e97851.js 2.75 KiB f17033ffbf027f2d71b7-f17033.js 212 bytes 1 auxiliary asset
+  Entrypoint index 2.98 KiB (5.89 KiB) = f64fdaf8571eaf5e2680-f64fda.js 2.77 KiB f17033ffbf027f2d71b7-f17033.js 212 bytes 1 auxiliary asset
   Entrypoint a 21 bytes = 666f2b8847021ccc7608-666f2b.js
   Entrypoint b 21 bytes = 666f2b8847021ccc7608-666f2b.js
-  runtime modules 7.28 KiB 9 modules
+  runtime modules 7.34 KiB 9 modules
   orphan modules 19 bytes [orphan] 1 module
   cacheable modules 511 bytes (javascript) 26.3 KiB (asset)
     javascript modules 385 bytes
@@ -2773,9 +2773,9 @@ b-normal:
   b-normal (webpack x.x.x) compiled successfully in X ms
 
 a-source-map:
-  assets by path *.js 3.42 KiB
-    asset 34764f712e482b1264f9-34764f.js 2.8 KiB [emitted] [immutable] [minimized] (name: runtime)
-      sourceMap 34764f712e482b1264f9-34764f.js.map 14.6 KiB [emitted] [dev] (auxiliary name: runtime)
+  assets by path *.js 3.44 KiB
+    asset 018715e3bf7c960ef754-018715.js 2.83 KiB [emitted] [immutable] [minimized] (name: runtime)
+      sourceMap 018715e3bf7c960ef754-018715.js.map 14.7 KiB [emitted] [dev] (auxiliary name: runtime)
     asset 0a8aef384737d9f64f44-0a8aef.js 288 bytes [emitted] [immutable] [minimized] (name: lazy)
       sourceMap 0a8aef384737d9f64f44-0a8aef.js.map 409 bytes [emitted] [dev] (auxiliary name: lazy)
     asset da629d4acf5998c06668-da629d.js 268 bytes [emitted] [immutable] [minimized] (name: index)
@@ -2786,10 +2786,10 @@ a-source-map:
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
     asset 7382fad5b015914e0811.jpg?query 5.89 KiB [cached] [immutable] [from: file.jpg?query] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: index)
-  Entrypoint index 3.06 KiB (20.8 KiB) = 34764f712e482b1264f9-34764f.js 2.8 KiB da629d4acf5998c06668-da629d.js 268 bytes 3 auxiliary assets
+  Entrypoint index 3.09 KiB (20.9 KiB) = 018715e3bf7c960ef754-018715.js 2.83 KiB da629d4acf5998c06668-da629d.js 268 bytes 3 auxiliary assets
   Entrypoint a 77 bytes (254 bytes) = 222c2acc68675174e6b2-222c2a.js 1 auxiliary asset
   Entrypoint b 77 bytes (254 bytes) = 222c2acc68675174e6b2-222c2a.js 1 auxiliary asset
-  runtime modules 7.28 KiB 9 modules
+  runtime modules 7.34 KiB 9 modules
   orphan modules 23 bytes [orphan] 1 module
   cacheable modules 556 bytes (javascript) 26.3 KiB (asset)
     javascript modules 430 bytes
@@ -2804,9 +2804,9 @@ a-source-map:
   a-source-map (webpack x.x.x) compiled successfully in X ms
 
 b-source-map:
-  assets by path *.js 3.42 KiB
-    asset 1289a35df2e6455ef167-1289a3.js 2.8 KiB [emitted] [immutable] [minimized] (name: runtime)
-      sourceMap 1289a35df2e6455ef167-1289a3.js.map 14.6 KiB [emitted] [dev] (auxiliary name: runtime)
+  assets by path *.js 3.44 KiB
+    asset 487b2e232adae9b3ff8b-487b2e.js 2.83 KiB [emitted] [immutable] [minimized] (name: runtime)
+      sourceMap 487b2e232adae9b3ff8b-487b2e.js.map 14.7 KiB [emitted] [dev] (auxiliary name: runtime)
     asset 0a8aef384737d9f64f44-0a8aef.js 288 bytes [emitted] [immutable] [minimized] (name: lazy)
       sourceMap 0a8aef384737d9f64f44-0a8aef.js.map 405 bytes [emitted] [dev] (auxiliary name: lazy)
     asset da629d4acf5998c06668-da629d.js 268 bytes [emitted] [immutable] [minimized] (name: index)
@@ -2817,10 +2817,10 @@ b-source-map:
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
     asset 7382fad5b015914e0811.jpg?query 5.89 KiB [cached] [immutable] [from: file.jpg?query] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: index)
-  Entrypoint index 3.06 KiB (20.8 KiB) = 1289a35df2e6455ef167-1289a3.js 2.8 KiB da629d4acf5998c06668-da629d.js 268 bytes 3 auxiliary assets
+  Entrypoint index 3.09 KiB (20.9 KiB) = 487b2e232adae9b3ff8b-487b2e.js 2.83 KiB da629d4acf5998c06668-da629d.js 268 bytes 3 auxiliary assets
   Entrypoint a 77 bytes (254 bytes) = 222c2acc68675174e6b2-222c2a.js 1 auxiliary asset
   Entrypoint b 77 bytes (254 bytes) = 222c2acc68675174e6b2-222c2a.js 1 auxiliary asset
-  runtime modules 7.28 KiB 9 modules
+  runtime modules 7.34 KiB 9 modules
   orphan modules 19 bytes [orphan] 1 module
   cacheable modules 511 bytes (javascript) 26.3 KiB (asset)
     javascript modules 385 bytes
@@ -2837,21 +2837,21 @@ b-source-map:
 
 exports[`StatsTestCases should print correct stats for related-assets 1`] = `
 "default:
-  assets by path *.js 15.2 KiB
-    asset default-main.js 14.4 KiB [emitted] (name: main) 3 related assets
+  assets by path *.js 15.3 KiB
+    asset default-main.js 14.5 KiB [emitted] (name: main) 3 related assets
     asset default-chunk_js.js 803 bytes [emitted] 3 related assets
   assets by path *.css 142 bytes
     asset default-chunk_js.css 73 bytes [emitted] 3 related assets
     asset default-main.css 69 bytes [emitted] (name: main) 3 related assets
 
 relatedAssets:
-  assets by path *.js 15.2 KiB
+  assets by path *.js 15.3 KiB
     asset relatedAssets-main.js 14.5 KiB [emitted] (name: main)
       compressed relatedAssets-main.js.br 14.5 KiB [emitted]
       compressed relatedAssets-main.js.gz 14.5 KiB [emitted]
-      sourceMap relatedAssets-main.js.map 12.5 KiB [emitted] [dev] (auxiliary name: main)
-        compressed relatedAssets-main.js.map.br 12.5 KiB [emitted]
-        compressed relatedAssets-main.js.map.gz 12.5 KiB [emitted]
+      sourceMap relatedAssets-main.js.map 12.6 KiB [emitted] [dev] (auxiliary name: main)
+        compressed relatedAssets-main.js.map.br 12.6 KiB [emitted]
+        compressed relatedAssets-main.js.map.gz 12.6 KiB [emitted]
     asset relatedAssets-chunk_js.js 809 bytes [emitted]
       compressed relatedAssets-chunk_js.js.br 809 bytes [emitted]
       compressed relatedAssets-chunk_js.js.gz 809 bytes [emitted]
@@ -2873,11 +2873,11 @@ relatedAssets:
       compressed relatedAssets-main.css.gz 75 bytes [emitted]
 
 exclude1:
-  assets by path *.js 15.2 KiB
-    asset exclude1-main.js 14.4 KiB [emitted] (name: main)
-      hidden assets 28.9 KiB 2 assets
+  assets by path *.js 15.3 KiB
+    asset exclude1-main.js 14.5 KiB [emitted] (name: main)
+      hidden assets 29 KiB 2 assets
       sourceMap exclude1-main.js.map 12.5 KiB [emitted] [dev] (auxiliary name: main)
-        hidden assets 24.9 KiB 2 assets
+        hidden assets 25.1 KiB 2 assets
         + 1 related asset
       + 1 related asset
     asset exclude1-chunk_js.js 804 bytes [emitted]
@@ -2901,11 +2901,11 @@ exclude1:
       + 1 related asset
 
 exclude2:
-  assets by path *.js 15.2 KiB
-    asset exclude2-main.js 14.4 KiB [emitted] (name: main)
+  assets by path *.js 15.3 KiB
+    asset exclude2-main.js 14.5 KiB [emitted] (name: main)
       hidden assets 12.5 KiB 1 asset
-      compressed exclude2-main.js.br 14.4 KiB [emitted]
-      compressed exclude2-main.js.gz 14.4 KiB [emitted]
+      compressed exclude2-main.js.br 14.5 KiB [emitted]
+      compressed exclude2-main.js.gz 14.5 KiB [emitted]
     asset exclude2-chunk_js.js 804 bytes [emitted]
       hidden assets 295 bytes 1 asset
       compressed exclude2-chunk_js.js.br 804 bytes [emitted]
@@ -2922,10 +2922,10 @@ exclude2:
 
 exclude3:
   hidden assets 878 bytes 2 assets
-  assets by status 14.5 KiB [emitted]
-    asset exclude3-main.js 14.4 KiB [emitted] (name: main)
-      compressed exclude3-main.js.br 14.4 KiB [emitted]
-      compressed exclude3-main.js.gz 14.4 KiB [emitted]
+  assets by status 14.6 KiB [emitted]
+    asset exclude3-main.js 14.5 KiB [emitted] (name: main)
+      compressed exclude3-main.js.br 14.5 KiB [emitted]
+      compressed exclude3-main.js.gz 14.5 KiB [emitted]
       sourceMap exclude3-main.js.map 12.5 KiB [emitted] [dev] (auxiliary name: main)
         compressed exclude3-main.js.map.br 12.5 KiB [emitted]
         compressed exclude3-main.js.map.gz 12.5 KiB [emitted]
@@ -2992,11 +2992,11 @@ webpack x.x.x compiled successfully"
 
 exports[`StatsTestCases should print correct stats for runtime-chunk-integration 1`] = `
 "base:
-  asset without-runtime.js 12 KiB [emitted] (name: runtime)
+  asset without-runtime.js 12.1 KiB [emitted] (name: runtime)
   asset without-505.js 1.2 KiB [emitted]
   asset without-main1.js 815 bytes [emitted] (name: main1)
-  Entrypoint main1 12.8 KiB = without-runtime.js 12 KiB without-main1.js 815 bytes
-  runtime modules 7.51 KiB 10 modules
+  Entrypoint main1 12.9 KiB = without-runtime.js 12.1 KiB without-main1.js 815 bytes
+  runtime modules 7.56 KiB 10 modules
   cacheable modules 126 bytes
     ./main1.js 66 bytes [built] [code generated]
     ./b.js 20 bytes [built] [code generated]
@@ -3005,15 +3005,15 @@ exports[`StatsTestCases should print correct stats for runtime-chunk-integration
   base (webpack x.x.x) compiled successfully
 
 static custom name:
-  asset with-manifest.js 12 KiB [emitted] (name: manifest)
+  asset with-manifest.js 12.1 KiB [emitted] (name: manifest)
   asset with-505.js 1.2 KiB [emitted]
   asset with-main1.js 815 bytes [emitted] (name: main1)
   asset with-main2.js 434 bytes [emitted] (name: main2)
   asset with-main3.js 434 bytes [emitted] (name: main3)
-  Entrypoint main1 12.8 KiB = with-manifest.js 12 KiB with-main1.js 815 bytes
-  Entrypoint main2 12.5 KiB = with-manifest.js 12 KiB with-main2.js 434 bytes
-  Entrypoint main3 12.5 KiB = with-manifest.js 12 KiB with-main3.js 434 bytes
-  runtime modules 7.51 KiB 10 modules
+  Entrypoint main1 12.9 KiB = with-manifest.js 12.1 KiB with-main1.js 815 bytes
+  Entrypoint main2 12.5 KiB = with-manifest.js 12.1 KiB with-main2.js 434 bytes
+  Entrypoint main3 12.5 KiB = with-manifest.js 12.1 KiB with-main3.js 434 bytes
+  runtime modules 7.56 KiB 10 modules
   cacheable modules 166 bytes
     ./main1.js 66 bytes [built] [code generated]
     ./main2.js 20 bytes [built] [code generated]
@@ -3024,16 +3024,16 @@ static custom name:
   static custom name (webpack x.x.x) compiled successfully
 
 dynamic custom name:
-  asset func-b.js 12 KiB [emitted] (name: b)
+  asset func-b.js 12.1 KiB [emitted] (name: b)
   asset func-a.js 4.91 KiB [emitted] (name: a)
   asset func-505.js 1.2 KiB [emitted]
   asset func-main1.js 815 bytes [emitted] (name: main1)
   asset func-main2.js 434 bytes [emitted] (name: main2)
   asset func-main3.js 434 bytes [emitted] (name: main3)
-  Entrypoint main1 12.8 KiB = func-b.js 12 KiB func-main1.js 815 bytes
-  Entrypoint main2 12.5 KiB = func-b.js 12 KiB func-main2.js 434 bytes
+  Entrypoint main1 12.9 KiB = func-b.js 12.1 KiB func-main1.js 815 bytes
+  Entrypoint main2 12.5 KiB = func-b.js 12.1 KiB func-main2.js 434 bytes
   Entrypoint main3 5.33 KiB = func-a.js 4.91 KiB func-main3.js 434 bytes
-  runtime modules 9.96 KiB 13 modules
+  runtime modules 10 KiB 13 modules
   cacheable modules 166 bytes
     ./main1.js 66 bytes [built] [code generated]
     ./main2.js 20 bytes [built] [code generated]
@@ -3058,16 +3058,16 @@ webpack x.x.x compiled successfully"
 
 exports[`StatsTestCases should print correct stats for runtime-specific-used-exports 1`] = `
 "production:
-  asset production-a.js 13.1 KiB [emitted] (name: a)
-  asset production-b.js 13.1 KiB [emitted] (name: b)
+  asset production-a.js 13.2 KiB [emitted] (name: a)
+  asset production-b.js 13.2 KiB [emitted] (name: b)
   asset production-dx_js.js 1.16 KiB [emitted]
   asset production-dw_js-_a6170.js 1.16 KiB [emitted]
   asset production-dw_js-_a6171.js 1.16 KiB [emitted]
   asset production-dy_js.js 1.14 KiB [emitted]
   asset production-dz_js.js 1.14 KiB [emitted]
   asset production-c.js 93 bytes [emitted] (name: c)
-  chunk (runtime: a) production-a.js (a) 605 bytes (javascript) 6.57 KiB (runtime) [entry] [rendered]
-    runtime modules 6.57 KiB 9 modules
+  chunk (runtime: a) production-a.js (a) 605 bytes (javascript) 6.63 KiB (runtime) [entry] [rendered]
+    runtime modules 6.63 KiB 9 modules
     cacheable modules 605 bytes
       ./a.js 261 bytes [built] [code generated]
         [no exports used]
@@ -3079,8 +3079,8 @@ exports[`StatsTestCases should print correct stats for runtime-specific-used-exp
         [only some exports used: x]
       ./reexport.js 37 bytes [dependent] [built] [code generated]
         [only some exports used: x]
-  chunk (runtime: b) production-b.js (b) 605 bytes (javascript) 6.57 KiB (runtime) [entry] [rendered]
-    runtime modules 6.57 KiB 9 modules
+  chunk (runtime: b) production-b.js (b) 605 bytes (javascript) 6.63 KiB (runtime) [entry] [rendered]
+    runtime modules 6.63 KiB 9 modules
     cacheable modules 605 bytes
       ./b.js 261 bytes [built] [code generated]
         [no exports used]
@@ -3115,7 +3115,7 @@ exports[`StatsTestCases should print correct stats for runtime-specific-used-exp
     ./dz.js 46 bytes [built] [code generated]
     ./module.js?chunk 122 bytes [dependent] [built] [code generated]
       [only some exports used: identity, w, x, z]
-  runtime modules 13.1 KiB 18 modules
+  runtime modules 13.3 KiB 18 modules
   cacheable modules 1.15 KiB
     ./a.js 261 bytes [built] [code generated]
       [no exports used]
@@ -3147,8 +3147,8 @@ development:
   asset development-dy_js.js 2.11 KiB [emitted]
   asset development-dz_js.js 2.11 KiB [emitted]
   asset development-c.js 1.13 KiB [emitted] (name: c)
-  chunk (runtime: a) development-a.js (a) 605 bytes (javascript) 6.58 KiB (runtime) [entry] [rendered]
-    runtime modules 6.58 KiB 9 modules
+  chunk (runtime: a) development-a.js (a) 605 bytes (javascript) 6.63 KiB (runtime) [entry] [rendered]
+    runtime modules 6.63 KiB 9 modules
     cacheable modules 605 bytes
       ./a.js 261 bytes [built] [code generated]
         [used exports unknown]
@@ -3160,8 +3160,8 @@ development:
         [used exports unknown]
       ./reexport.js 37 bytes [dependent] [built] [code generated]
         [used exports unknown]
-  chunk (runtime: b) development-b.js (b) 605 bytes (javascript) 6.58 KiB (runtime) [entry] [rendered]
-    runtime modules 6.58 KiB 9 modules
+  chunk (runtime: b) development-b.js (b) 605 bytes (javascript) 6.63 KiB (runtime) [entry] [rendered]
+    runtime modules 6.63 KiB 9 modules
     cacheable modules 605 bytes
       ./b.js 261 bytes [built] [code generated]
         [used exports unknown]
@@ -3196,7 +3196,7 @@ development:
       [used exports unknown]
     ./module.js?chunk 122 bytes [dependent] [built] [code generated]
       [used exports unknown]
-  runtime modules 13.2 KiB 18 modules
+  runtime modules 13.3 KiB 18 modules
   cacheable modules 1.15 KiB
     ./a.js 261 bytes [built] [code generated]
       [used exports unknown]
@@ -3225,15 +3225,15 @@ development:
   development (webpack x.x.x) compiled successfully in X ms
 
 global:
-  asset global-a.js 13.3 KiB [emitted] (name: a)
-  asset global-b.js 13.3 KiB [emitted] (name: b)
+  asset global-a.js 13.4 KiB [emitted] (name: a)
+  asset global-b.js 13.4 KiB [emitted] (name: b)
   asset global-dw_js.js 1.16 KiB [emitted]
   asset global-dx_js.js 1.16 KiB [emitted]
   asset global-dy_js.js 1.16 KiB [emitted]
   asset global-dz_js.js 1.16 KiB [emitted]
   asset global-c.js 93 bytes [emitted] (name: c)
-  chunk (runtime: a) global-a.js (a) 605 bytes (javascript) 6.57 KiB (runtime) [entry] [rendered]
-    runtime modules 6.57 KiB 9 modules
+  chunk (runtime: a) global-a.js (a) 605 bytes (javascript) 6.62 KiB (runtime) [entry] [rendered]
+    runtime modules 6.62 KiB 9 modules
     cacheable modules 605 bytes
       ./a.js 261 bytes [built] [code generated]
         [no exports used]
@@ -3245,8 +3245,8 @@ global:
         [only some exports used: x, y]
       ./reexport.js 37 bytes [dependent] [built] [code generated]
         [only some exports used: x, y]
-  chunk (runtime: b) global-b.js (b) 605 bytes (javascript) 6.57 KiB (runtime) [entry] [rendered]
-    runtime modules 6.57 KiB 9 modules
+  chunk (runtime: b) global-b.js (b) 605 bytes (javascript) 6.62 KiB (runtime) [entry] [rendered]
+    runtime modules 6.62 KiB 9 modules
     cacheable modules 605 bytes
       ./b.js 261 bytes [built] [code generated]
         [no exports used]
@@ -3277,7 +3277,7 @@ global:
     ./dz.js 46 bytes [built] [code generated]
     ./module.js?chunk 122 bytes [dependent] [built] [code generated]
       [only some exports used: identity, w, x, y, z]
-  runtime modules 13.1 KiB 18 modules
+  runtime modules 13.2 KiB 18 modules
   cacheable modules 1.15 KiB
     ./a.js 261 bytes [built] [code generated]
       [no exports used]
@@ -3303,7 +3303,7 @@ global:
 `;
 
 exports[`StatsTestCases should print correct stats for scope-hoisting-bailouts 1`] = `
-"runtime modules 6.82 KiB 10 modules
+"runtime modules 6.88 KiB 10 modules
 built modules 615 bytes [built]
   code generated modules 530 bytes [code generated]
     ./index.js 150 bytes [built] [code generated]
@@ -3340,8 +3340,8 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for scope-hoisting-multi 1`] = `
 "Entrypoint first 14.4 KiB = a-vendor.js 419 bytes a-first.js 14 KiB
-Entrypoint second 13.9 KiB = a-vendor.js 419 bytes a-second.js 13.5 KiB
-runtime modules 15.1 KiB 20 modules
+Entrypoint second 14 KiB = a-vendor.js 419 bytes a-second.js 13.5 KiB
+runtime modules 15.2 KiB 20 modules
 orphan modules 37 bytes [orphan] 1 module
 cacheable modules 807 bytes
   ./first.js 236 bytes [built] [code generated]
@@ -3356,9 +3356,9 @@ cacheable modules 807 bytes
   ./common_lazy_shared.js 25 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-Entrypoint first 13.6 KiB = b-vendor.js 419 bytes b-first.js 13.2 KiB
-Entrypoint second 13.5 KiB = b-vendor.js 419 bytes b-second.js 13.1 KiB
-runtime modules 15.1 KiB 20 modules
+Entrypoint first 13.7 KiB = b-vendor.js 419 bytes b-first.js 13.3 KiB
+Entrypoint second 13.6 KiB = b-vendor.js 419 bytes b-second.js 13.2 KiB
+runtime modules 15.2 KiB 20 modules
 cacheable modules 975 bytes
   code generated modules 857 bytes [code generated]
     ./first.js + 2 modules 292 bytes [built] [code generated]
@@ -3383,9 +3383,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for side-effects-issue-7428 1`] = `
-"asset main.js 12.3 KiB [emitted] (name: main)
+"asset main.js 12.4 KiB [emitted] (name: main)
 asset 1.js 643 bytes [emitted]
-runtime modules 6.56 KiB 9 modules
+runtime modules 6.62 KiB 9 modules
 cacheable modules 823 bytes
   modules by path ./components/src/ 501 bytes
     orphan modules 315 bytes [orphan]
@@ -3560,8 +3560,8 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
 "default:
-  Entrypoint main 11.4 KiB = default/main.js
-  Entrypoint a 12.5 KiB = default/a.js
+  Entrypoint main 11.5 KiB = default/main.js
+  Entrypoint a 12.6 KiB = default/a.js
   Entrypoint b 3.94 KiB = default/b.js
   Entrypoint c 3.94 KiB = default/c.js
   chunk (runtime: b) default/b.js (b) 196 bytes (javascript) 396 bytes (runtime) [entry] [rendered]
@@ -3572,9 +3572,9 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
   chunk (runtime: a, main) default/async-g.js (async-g) 45 bytes <{282}> <{767}> <{786}> <{794}> <{954}> ={568}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
+  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.71 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
     > ./ main
-    runtime modules 6.66 KiB 9 modules
+    runtime modules 6.71 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: main) default/282.js (id hint: vendors) 20 bytes <{179}> ={334}= ={383}= ={568}= ={767}= ={769}= ={794}= ={954}= >{137}< >{568}< [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -3605,9 +3605,9 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
   chunk (runtime: main) default/769.js (id hint: vendors) 20 bytes <{179}> ={282}= ={383}= ={568}= ={767}= [rendered] split chunk (cache group: defaultVendors)
     > ./c ./index.js 3:0-47
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.65 KiB (runtime) >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.7 KiB (runtime) >{137}< >{568}< [entry] [rendered]
     > ./a a
-    runtime modules 6.65 KiB 9 modules
+    runtime modules 6.7 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) default/async-a.js (async-a) 185 bytes <{179}> ={282}= ={767}= ={954}= >{137}< >{568}< [rendered]
@@ -3620,8 +3620,8 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
   default (webpack x.x.x) compiled successfully
 
 all-chunks:
-  Entrypoint main 11.5 KiB = all-chunks/main.js
-  Entrypoint a 15 KiB = all-chunks/282.js 414 bytes all-chunks/954.js 414 bytes all-chunks/767.js 414 bytes all-chunks/390.js 414 bytes all-chunks/a.js 13.4 KiB
+  Entrypoint main 11.6 KiB = all-chunks/main.js
+  Entrypoint a 15.1 KiB = all-chunks/282.js 414 bytes all-chunks/954.js 414 bytes all-chunks/767.js 414 bytes all-chunks/390.js 414 bytes all-chunks/a.js 13.4 KiB
   Entrypoint b 8.14 KiB = all-chunks/282.js 414 bytes all-chunks/954.js 414 bytes all-chunks/767.js 414 bytes all-chunks/568.js 414 bytes all-chunks/b.js 6.52 KiB
   Entrypoint c 8.14 KiB = all-chunks/282.js 414 bytes all-chunks/769.js 414 bytes all-chunks/767.js 414 bytes all-chunks/568.js 414 bytes all-chunks/c.js 6.52 KiB
   chunk (runtime: b) all-chunks/b.js (b) 116 bytes (javascript) 2.76 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
@@ -3631,9 +3631,9 @@ all-chunks:
   chunk (runtime: a, main) all-chunks/async-g.js (async-g) 45 bytes <{282}> <{390}> <{767}> <{786}> <{794}> <{954}> ={568}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) all-chunks/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
+  chunk (runtime: main) all-chunks/main.js (main) 147 bytes (javascript) 6.71 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
     > ./ main
-    runtime modules 6.66 KiB 9 modules
+    runtime modules 6.71 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) all-chunks/282.js (id hint: vendors) 20 bytes <{179}> ={128}= ={334}= ={383}= ={390}= ={459}= ={568}= ={767}= ={769}= ={786}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -3676,9 +3676,9 @@ all-chunks:
     > ./c ./index.js 3:0-47
     > ./c c
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) all-chunks/a.js (a) 165 bytes (javascript) 7.57 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: a) all-chunks/a.js (a) 165 bytes (javascript) 7.63 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
     > ./a a
-    runtime modules 7.57 KiB 10 modules
+    runtime modules 7.63 KiB 10 modules
     ./a.js 165 bytes [built] [code generated]
   chunk (runtime: main) all-chunks/async-a.js (async-a) 165 bytes <{179}> ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [rendered]
     > ./a ./index.js 1:0-47
@@ -3692,8 +3692,8 @@ all-chunks:
   all-chunks (webpack x.x.x) compiled successfully
 
 manual:
-  Entrypoint main 11.2 KiB = manual/main.js
-  Entrypoint a 14.7 KiB = manual/vendors.js 1.05 KiB manual/a.js 13.7 KiB
+  Entrypoint main 11.3 KiB = manual/main.js
+  Entrypoint a 14.8 KiB = manual/vendors.js 1.05 KiB manual/a.js 13.8 KiB
   Entrypoint b 8.45 KiB = manual/vendors.js 1.05 KiB manual/b.js 7.4 KiB
   Entrypoint c 8.45 KiB = manual/vendors.js 1.05 KiB manual/c.js 7.4 KiB
   chunk (runtime: b) manual/b.js (b) 156 bytes (javascript) 2.76 KiB (runtime) ={216}= [entry] [rendered]
@@ -3708,9 +3708,9 @@ manual:
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) manual/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
+  chunk (runtime: main) manual/main.js (main) 147 bytes (javascript) 6.71 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
     > ./ main
-    runtime modules 6.66 KiB 9 modules
+    runtime modules 6.71 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) manual/vendors.js (vendors) (id hint: vendors) 60 bytes <{179}> ={128}= ={334}= ={383}= ={459}= ={786}= ={794}= >{137}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
     > ./a ./index.js 1:0-47
@@ -3747,12 +3747,12 @@ manual:
     runtime modules 2.76 KiB 4 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: a) manual/a.js (a) 205 bytes (javascript) 7.54 KiB (runtime) ={216}= >{137}< [entry] [rendered]
+  chunk (runtime: a) manual/a.js (a) 205 bytes (javascript) 7.59 KiB (runtime) ={216}= >{137}< [entry] [rendered]
     > ./a a
     > x a
     > y a
     > z a
-    runtime modules 7.54 KiB 10 modules
+    runtime modules 7.59 KiB 10 modules
     dependent modules 20 bytes [dependent] 1 module
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) manual/async-a.js (async-a) 205 bytes <{179}> ={216}= >{137}< [rendered]
@@ -3762,16 +3762,16 @@ manual:
   manual (webpack x.x.x) compiled successfully
 
 name-too-long:
-  Entrypoint main 11.5 KiB = name-too-long/main.js
-  Entrypoint aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 15 KiB = name-too-long/282.js 414 bytes name-too-long/954.js 414 bytes name-too-long/767.js 414 bytes name-too-long/390.js 414 bytes name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js 13.4 KiB
+  Entrypoint main 11.6 KiB = name-too-long/main.js
+  Entrypoint aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 15.1 KiB = name-too-long/282.js 414 bytes name-too-long/954.js 414 bytes name-too-long/767.js 414 bytes name-too-long/390.js 414 bytes name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js 13.4 KiB
   Entrypoint bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb 8.14 KiB = name-too-long/282.js 414 bytes name-too-long/954.js 414 bytes name-too-long/767.js 414 bytes name-too-long/568.js 414 bytes name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js 6.52 KiB
   Entrypoint cccccccccccccccccccccccccccccc 8.14 KiB = name-too-long/282.js 414 bytes name-too-long/769.js 414 bytes name-too-long/767.js 414 bytes name-too-long/568.js 414 bytes name-too-long/cccccccccccccccccccccccccccccc.js 6.52 KiB
   chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, main) name-too-long/async-g.js (async-g) 45 bytes <{282}> <{390}> <{751}> <{767}> <{794}> <{954}> ={568}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) name-too-long/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
+  chunk (runtime: main) name-too-long/main.js (main) 147 bytes (javascript) 6.72 KiB (runtime) >{282}< >{334}< >{383}< >{390}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
     > ./ main
-    runtime modules 6.66 KiB 9 modules
+    runtime modules 6.72 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc, main) name-too-long/282.js (id hint: vendors) 20 bytes <{179}> ={334}= ={383}= ={390}= ={568}= ={658}= ={751}= ={766}= ={767}= ={769}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -3802,9 +3802,9 @@ name-too-long:
     > ./c cccccccccccccccccccccccccccccc
     runtime modules 2.76 KiB 4 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) 165 bytes (javascript) 7.58 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) 165 bytes (javascript) 7.63 KiB (runtime) ={282}= ={390}= ={767}= ={954}= >{137}< >{568}< [entry] [rendered]
     > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    runtime modules 7.58 KiB 10 modules
+    runtime modules 7.63 KiB 10 modules
     ./a.js 165 bytes [built] [code generated]
   chunk (runtime: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) 116 bytes (javascript) 2.76 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
     > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
@@ -3834,8 +3834,8 @@ name-too-long:
   name-too-long (webpack x.x.x) compiled successfully
 
 custom-chunks-filter:
-  Entrypoint main 11.4 KiB = custom-chunks-filter/main.js
-  Entrypoint a 12.5 KiB = custom-chunks-filter/a.js
+  Entrypoint main 11.5 KiB = custom-chunks-filter/main.js
+  Entrypoint a 12.6 KiB = custom-chunks-filter/a.js
   Entrypoint b 8.14 KiB = custom-chunks-filter/282.js 414 bytes custom-chunks-filter/954.js 414 bytes custom-chunks-filter/568.js 414 bytes custom-chunks-filter/767.js 414 bytes custom-chunks-filter/b.js 6.52 KiB
   Entrypoint c 8.14 KiB = custom-chunks-filter/282.js 414 bytes custom-chunks-filter/769.js 414 bytes custom-chunks-filter/568.js 414 bytes custom-chunks-filter/767.js 414 bytes custom-chunks-filter/c.js 6.52 KiB
   chunk (runtime: b) custom-chunks-filter/b.js (b) 116 bytes (javascript) 2.76 KiB (runtime) ={282}= ={568}= ={767}= ={954}= [entry] [rendered]
@@ -3845,9 +3845,9 @@ custom-chunks-filter:
   chunk (runtime: a, main) custom-chunks-filter/async-g.js (async-g) 45 bytes <{282}> <{767}> <{786}> <{794}> <{954}> ={568}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: main) custom-chunks-filter/main.js (main) 147 bytes (javascript) 6.67 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
+  chunk (runtime: main) custom-chunks-filter/main.js (main) 147 bytes (javascript) 6.72 KiB (runtime) >{282}< >{334}< >{383}< >{568}< >{767}< >{769}< >{794}< >{954}< [entry] [rendered]
     > ./ main
-    runtime modules 6.67 KiB 9 modules
+    runtime modules 6.72 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: b, c, main) custom-chunks-filter/282.js (id hint: vendors) 20 bytes <{179}> ={128}= ={334}= ={383}= ={459}= ={568}= ={767}= ={769}= ={794}= ={954}= >{137}< >{568}< [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
@@ -3884,9 +3884,9 @@ custom-chunks-filter:
     > ./c ./index.js 3:0-47
     > ./c c
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) custom-chunks-filter/a.js (a) 245 bytes (javascript) 6.66 KiB (runtime) >{137}< >{568}< [entry] [rendered]
+  chunk (runtime: a) custom-chunks-filter/a.js (a) 245 bytes (javascript) 6.71 KiB (runtime) >{137}< >{568}< [entry] [rendered]
     > ./a a
-    runtime modules 6.66 KiB 9 modules
+    runtime modules 6.71 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) custom-chunks-filter/async-a.js (async-a) 185 bytes <{179}> ={282}= ={767}= ={954}= >{137}< >{568}< [rendered]
@@ -3900,8 +3900,8 @@ custom-chunks-filter:
   custom-chunks-filter (webpack x.x.x) compiled successfully
 
 custom-chunks-filter-in-cache-groups:
-  Entrypoint main 11.2 KiB = custom-chunks-filter-in-cache-groups/main.js
-  Entrypoint a 14.5 KiB = custom-chunks-filter-in-cache-groups/176.js 864 bytes custom-chunks-filter-in-cache-groups/a.js 13.7 KiB
+  Entrypoint main 11.3 KiB = custom-chunks-filter-in-cache-groups/main.js
+  Entrypoint a 14.6 KiB = custom-chunks-filter-in-cache-groups/176.js 864 bytes custom-chunks-filter-in-cache-groups/a.js 13.8 KiB
   Entrypoint b 8.45 KiB = custom-chunks-filter-in-cache-groups/vendors.js 1.05 KiB custom-chunks-filter-in-cache-groups/b.js 7.4 KiB
   Entrypoint c 8.45 KiB = custom-chunks-filter-in-cache-groups/vendors.js 1.05 KiB custom-chunks-filter-in-cache-groups/c.js 7.4 KiB
   chunk (runtime: b) custom-chunks-filter-in-cache-groups/b.js (b) 156 bytes (javascript) 2.76 KiB (runtime) ={216}= [entry] [rendered]
@@ -3924,9 +3924,9 @@ custom-chunks-filter-in-cache-groups:
     ./node_modules/x.js 20 bytes [built] [code generated]
     ./node_modules/y.js 20 bytes [built] [code generated]
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: main) custom-chunks-filter-in-cache-groups/main.js (main) 147 bytes (javascript) 6.69 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
+  chunk (runtime: main) custom-chunks-filter-in-cache-groups/main.js (main) 147 bytes (javascript) 6.74 KiB (runtime) >{216}< >{334}< >{383}< >{794}< [entry] [rendered]
     > ./ main
-    runtime modules 6.69 KiB 9 modules
+    runtime modules 6.74 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
   chunk (runtime: b, c, main) custom-chunks-filter-in-cache-groups/vendors.js (vendors) (id hint: vendors) 60 bytes <{179}> ={128}= ={334}= ={383}= ={459}= ={794}= >{137}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
     > ./a ./index.js 1:0-47
@@ -3959,12 +3959,12 @@ custom-chunks-filter-in-cache-groups:
     runtime modules 2.76 KiB 4 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: a) custom-chunks-filter-in-cache-groups/a.js (a) 205 bytes (javascript) 7.57 KiB (runtime) ={176}= >{137}< [entry] [rendered]
+  chunk (runtime: a) custom-chunks-filter-in-cache-groups/a.js (a) 205 bytes (javascript) 7.62 KiB (runtime) ={176}= >{137}< [entry] [rendered]
     > ./a a
     > x a
     > y a
     > z a
-    runtime modules 7.57 KiB 10 modules
+    runtime modules 7.62 KiB 10 modules
     dependent modules 20 bytes [dependent] 1 module
     ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: main) custom-chunks-filter-in-cache-groups/async-a.js (async-a) 205 bytes <{179}> ={216}= >{137}< [rendered]
@@ -3975,7 +3975,7 @@ custom-chunks-filter-in-cache-groups:
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-automatic-name 1`] = `
-"Entrypoint main 11.5 KiB = main.js
+"Entrypoint main 11.6 KiB = main.js
 chunk (runtime: main) async-a.js (async-a) 136 bytes <{main}> ={common-d_js}= ={common-node_modules_x_js}= ={common-node_modules_y_js}= [rendered]
   > ./a ./index.js 1:0-47
   ./a.js + 1 modules 136 bytes [built] [code generated]
@@ -4006,18 +4006,18 @@ chunk (runtime: main) common-node_modules_y_js.js (id hint: common) 20 bytes <{m
 chunk (runtime: main) common-node_modules_z_js.js (id hint: common) 20 bytes <{main}> ={async-c}= ={common-d_js}= ={common-f_js}= ={common-node_modules_x_js}= [rendered] split chunk (cache group: b)
   > ./c ./index.js 3:0-47
   ./node_modules/z.js 20 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.57 KiB (runtime) >{async-a}< >{async-b}< >{async-c}< >{common-d_js}< >{common-f_js}< >{common-node_modules_x_js}< >{common-node_modules_y_js}< >{common-node_modules_z_js}< [entry] [rendered]
+chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.62 KiB (runtime) >{async-a}< >{async-b}< >{async-c}< >{common-d_js}< >{common-f_js}< >{common-node_modules_x_js}< >{common-node_modules_y_js}< >{common-node_modules_z_js}< [entry] [rendered]
   > ./ main
-  runtime modules 6.57 KiB 9 modules
+  runtime modules 6.62 KiB 9 modules
   ./index.js 147 bytes [built] [code generated]
 production (webpack x.x.x) compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-chunk-name 1`] = `
-"Entrypoint main 11.2 KiB = default/main.js
-chunk (runtime: main) default/main.js (main) 192 bytes (javascript) 6.63 KiB (runtime) >{334}< >{709}< >{794}< [entry] [rendered]
+"Entrypoint main 11.3 KiB = default/main.js
+chunk (runtime: main) default/main.js (main) 192 bytes (javascript) 6.68 KiB (runtime) >{334}< >{709}< >{794}< [entry] [rendered]
   > ./ main
-  runtime modules 6.63 KiB 9 modules
+  runtime modules 6.68 KiB 9 modules
   ./index.js 192 bytes [built] [code generated]
 chunk (runtime: main) default/async-b.js (async-b) (id hint: vendors) 122 bytes <{179}> [rendered] reused as split chunk (cache group: defaultVendors)
   > b ./index.js 2:0-45
@@ -4033,7 +4033,7 @@ webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-combinations 1`] = `
-"Entrypoint main 11.6 KiB = main.js
+"Entrypoint main 11.7 KiB = main.js
 chunk (runtime: main) async-d.js (async-d) 132 bytes <{179}> [rendered]
   > ./d ./index.js 4:0-47
   dependent modules 87 bytes [dependent] 1 module
@@ -4042,9 +4042,9 @@ chunk (runtime: main) async-g.js (async-g) 132 bytes <{179}> [rendered]
   > ./g ./index.js 7:0-47
   dependent modules 87 bytes [dependent] 1 module
   ./g.js 45 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 343 bytes (javascript) 6.69 KiB (runtime) >{31}< >{137}< >{206}< >{334}< >{383}< >{449}< >{794}< >{804}< [entry] [rendered]
+chunk (runtime: main) main.js (main) 343 bytes (javascript) 6.74 KiB (runtime) >{31}< >{137}< >{206}< >{334}< >{383}< >{449}< >{794}< >{804}< [entry] [rendered]
   > ./ main
-  runtime modules 6.69 KiB 9 modules
+  runtime modules 6.74 KiB 9 modules
   ./index.js 343 bytes [built] [code generated]
 chunk (runtime: main) async-f.js (async-f) 132 bytes <{179}> [rendered]
   > ./f ./index.js 6:0-47
@@ -4073,10 +4073,10 @@ webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-6413 1`] = `
-"Entrypoint main 11.3 KiB = main.js
-chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.63 KiB (runtime) >{282}< >{334}< >{383}< >{543}< >{794}< [entry] [rendered]
+"Entrypoint main 11.4 KiB = main.js
+chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.68 KiB (runtime) >{282}< >{334}< >{383}< >{543}< >{794}< [entry] [rendered]
   > ./ main
-  runtime modules 6.63 KiB 9 modules
+  runtime modules 6.68 KiB 9 modules
   ./index.js 147 bytes [built] [code generated]
 chunk (runtime: main) 282.js (id hint: vendors) 20 bytes <{179}> ={334}= ={383}= ={543}= ={794}= [rendered] split chunk (cache group: defaultVendors)
   > ./a ./index.js 1:0-47
@@ -4101,10 +4101,10 @@ default (webpack x.x.x) compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-6696 1`] = `
-"Entrypoint main 13.3 KiB = vendors.js 414 bytes main.js 12.9 KiB
-chunk (runtime: main) main.js (main) 134 bytes (javascript) 7.55 KiB (runtime) ={216}= >{334}< >{794}< [entry] [rendered]
+"Entrypoint main 13.4 KiB = vendors.js 414 bytes main.js 13 KiB
+chunk (runtime: main) main.js (main) 134 bytes (javascript) 7.6 KiB (runtime) ={216}= >{334}< >{794}< [entry] [rendered]
   > ./ main
-  runtime modules 7.55 KiB 10 modules
+  runtime modules 7.6 KiB 10 modules
   ./index.js 134 bytes [built] [code generated]
 chunk (runtime: main) vendors.js (vendors) (id hint: vendors) 20 bytes ={179}= >{334}< >{794}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
   > ./ main
@@ -4122,11 +4122,11 @@ default (webpack x.x.x) compiled successfully"
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-7401 1`] = `
 "Entrypoint a 6.42 KiB = 282.js 414 bytes a.js 6.02 KiB
-Entrypoint b 10.8 KiB = b.js
+Entrypoint b 10.9 KiB = b.js
 Chunk Group c 797 bytes = 282.js 414 bytes c.js 383 bytes
-chunk (runtime: b) b.js (b) 43 bytes (javascript) 6.59 KiB (runtime) >{282}< >{459}< [entry] [rendered]
+chunk (runtime: b) b.js (b) 43 bytes (javascript) 6.64 KiB (runtime) >{282}< >{459}< [entry] [rendered]
   > ./b b
-  runtime modules 6.59 KiB 9 modules
+  runtime modules 6.64 KiB 9 modules
   ./b.js 43 bytes [built] [code generated]
 chunk (runtime: a, b) 282.js (id hint: vendors) 20 bytes <{128}> ={459}= ={786}= [initial] [rendered] split chunk (cache group: defaultVendors)
   > ./c ./b.js 1:0-41
@@ -4143,13 +4143,13 @@ default (webpack x.x.x) compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-keep-remaining-size 1`] = `
-"Entrypoint main 11.3 KiB = default/main.js
+"Entrypoint main 11.4 KiB = default/main.js
 chunk (runtime: main) default/async-d.js (async-d) 84 bytes <{179}> ={782}= [rendered]
   > ./d ./index.js 4:0-47
   ./d.js 84 bytes [built] [code generated]
-chunk (runtime: main) default/main.js (main) 196 bytes (javascript) 6.66 KiB (runtime) >{31}< >{334}< >{383}< >{782}< >{794}< >{821}< [entry] [rendered]
+chunk (runtime: main) default/main.js (main) 196 bytes (javascript) 6.71 KiB (runtime) >{31}< >{334}< >{383}< >{782}< >{794}< >{821}< [entry] [rendered]
   > ./ main
-  runtime modules 6.66 KiB 9 modules
+  runtime modules 6.71 KiB 9 modules
   ./index.js 196 bytes [built] [code generated]
 chunk (runtime: main) default/async-b.js (async-b) 50 bytes <{179}> ={821}= [rendered]
   > ./b ./index.js 2:0-47
@@ -4464,10 +4464,10 @@ zero-min:
   zero-min (webpack x.x.x) compiled successfully
 
 max-async-size:
-  Entrypoint main 15.9 KiB = max-async-size-main.js
-  chunk (runtime: main) max-async-size-main.js (main) 2.46 KiB (javascript) 6.94 KiB (runtime) >{342}< >{385}< >{820}< >{920}< [entry] [rendered]
+  Entrypoint main 16 KiB = max-async-size-main.js
+  chunk (runtime: main) max-async-size-main.js (main) 2.46 KiB (javascript) 6.99 KiB (runtime) >{342}< >{385}< >{820}< >{920}< [entry] [rendered]
     > ./async main
-    runtime modules 6.94 KiB 10 modules
+    runtime modules 6.99 KiB 10 modules
     dependent modules 2.09 KiB [dependent] 6 modules
     ./async/index.js 386 bytes [built] [code generated]
   chunk (runtime: main) max-async-size-async-b-77a8c116.js (async-b-77a8c116) 1.57 KiB <{179}> ={385}= ={820}= ={920}= [rendered]
@@ -4580,13 +4580,13 @@ only-async:
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-min-size-reduction 1`] = `
-"Entrypoint main 11.4 KiB = default/main.js
+"Entrypoint main 11.5 KiB = default/main.js
 chunk (runtime: main) default/async-d.js (async-d) 50 bytes <{179}> ={821}= [rendered]
   > ./d ./index.js 4:0-47
   ./d.js 50 bytes [built] [code generated]
-chunk (runtime: main) default/main.js (main) 245 bytes (javascript) 6.67 KiB (runtime) >{31}< >{334}< >{383}< >{449}< >{794}< >{821}< [entry] [rendered]
+chunk (runtime: main) default/main.js (main) 245 bytes (javascript) 6.73 KiB (runtime) >{31}< >{334}< >{383}< >{449}< >{794}< >{821}< [entry] [rendered]
   > ./ main
-  runtime modules 6.67 KiB 9 modules
+  runtime modules 6.73 KiB 9 modules
   ./index.js 245 bytes [built] [code generated]
 chunk (runtime: main) default/async-b.js (async-b) 176 bytes <{179}> [rendered]
   > ./b ./index.js 2:0-47
@@ -4617,9 +4617,9 @@ chunk (runtime: main) default/118.js 150 bytes <{179}> ={334}= ={383}= [rendered
   > ./c ./index.js 3:0-47
   ./d.js 63 bytes [built] [code generated]
   ./f.js 87 bytes [built] [code generated]
-chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.64 KiB (runtime) >{118}< >{334}< >{383}< >{794}< [entry] [rendered]
+chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.7 KiB (runtime) >{118}< >{334}< >{383}< >{794}< [entry] [rendered]
   > ./ main
-  runtime modules 6.64 KiB 9 modules
+  runtime modules 6.7 KiB 9 modules
   ./index.js 147 bytes [built] [code generated]
 chunk (runtime: main) default/async-b.js (async-b) 158 bytes <{179}> ={118}= [rendered]
   > ./b ./index.js 2:0-47
@@ -4750,8 +4750,8 @@ webpack x.x.x compiled with 1 warning in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for wasm-explorer-examples-sync 1`] = `
-"assets by path *.js 21.7 KiB
-  asset bundle.js 16.2 KiB [emitted] (name: main)
+"assets by path *.js 21.8 KiB
+  asset bundle.js 16.3 KiB [emitted] (name: main)
   asset 325.bundle.js 3.9 KiB [emitted]
   asset 795.bundle.js 557 bytes [emitted]
   asset 526.bundle.js 366 bytes [emitted] (id hint: vendors)
@@ -4767,8 +4767,8 @@ assets by path *.wasm 1.37 KiB
   asset 0301cb3f9f4151b567f5.module.wasm 120 bytes [emitted] [immutable]
 chunk (runtime: main) 20.bundle.js 50 bytes (javascript) 531 bytes (webassembly) [rendered]
   ./duff.wasm 50 bytes (javascript) 531 bytes (webassembly) [built] [code generated]
-chunk (runtime: main) bundle.js (main) 586 bytes (javascript) 9.12 KiB (runtime) [entry] [rendered]
-  runtime modules 9.12 KiB 11 modules
+chunk (runtime: main) bundle.js (main) 586 bytes (javascript) 9.18 KiB (runtime) [entry] [rendered]
+  runtime modules 9.18 KiB 11 modules
   ./index.js 586 bytes [built] [code generated]
 chunk (runtime: main) 189.bundle.js 50 bytes (javascript) 156 bytes (webassembly) [rendered]
   ./Q_rsqrt.wasm 50 bytes (javascript) 156 bytes (webassembly) [built] [code generated]
@@ -4782,7 +4782,7 @@ chunk (runtime: main) 526.bundle.js (id hint: vendors) 34 bytes [rendered] split
 chunk (runtime: main) 795.bundle.js 110 bytes (javascript) 444 bytes (webassembly) [rendered]
   ./fact.wasm 50 bytes (javascript) 154 bytes (webassembly) [built] [code generated]
   ./fast-math.wasm 60 bytes (javascript) 290 bytes (webassembly) [built] [code generated]
-runtime modules 9.12 KiB 11 modules
+runtime modules 9.18 KiB 11 modules
 cacheable modules 2.31 KiB (javascript) 1.37 KiB (webassembly)
   webassembly modules 310 bytes (javascript) 1.37 KiB (webassembly)
     ./Q_rsqrt.wasm 50 bytes (javascript) 156 bytes (webassembly) [built] [code generated]
@@ -4799,9 +4799,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for worker-public-path 1`] = `
-"asset main-27d65b836727f9226214.js 3.51 KiB [emitted] [immutable] (name: main)
+"asset main-96fbc03a7e45e354f81a.js 3.59 KiB [emitted] [immutable] (name: main)
 asset 442-579eebb6602aecc20b13.js 219 bytes [emitted] [immutable]
-runtime modules 1.75 KiB 5 modules
+runtime modules 1.81 KiB 5 modules
 cacheable modules 250 bytes
   ./index.js 115 bytes [built] [code generated]
   ./worker.js 135 bytes [built] [code generated]


### PR DESCRIPTION
fixes #16041 fixes #16078

I don't know why we don't merge it

Here comment https://github.com/webpack/webpack/issues/16041#issuecomment-1193666941, but the problem is not related to `module`, for example you have

```html
<script type="module" src="./main.js"></script>
<script>console.log("test")</script>
```

so the latest `script` tag doesn't have `src` and our detection is failed (because `type="module"` is `defer` by default and the latest script without `src` and yes, you can have `module` and non module scripts on the same page)

i.e.

you have:
```
HTMLCollection(2) [script, script]
```

where the latest `script` without `src`

Will be great to test it, but we don't have tests on it at all (because our test system doesn't support testing in HTML pages, yeah we need to improve it in future when we will work on HTML entrypoints), so I tested manually, you can see there is no something strange here

I used #16078 solution and just update snapshots



## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4454576</samp>

This pull request refactors and enhances the `AutoPublicPathRuntimeModule` to set the public path more reliably and efficiently. It uses a new variable `runtimeTemplate` to generate runtime code, and it improves the logic for finding the current script URL in browsers.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4454576</samp>

*  Add a variable `runtimeTemplate` to access the `RuntimeTemplate` instance ([link](https://github.com/webpack/webpack/pull/17047/files?diff=unified&w=0#diff-5b68f78763cd59ef3491990ef44d952823d13073cc43b0b3bb9301c693c7c88aR23))
*  Modify the logic to find the current script URL in the browser by filtering script elements with a `src` attribute ([link](https://github.com/webpack/webpack/pull/17047/files?diff=unified&w=0#diff-5b68f78763cd59ef3491990ef44d952823d13073cc43b0b3bb9301c693c7c88aL49-R53))
*  Use the `RuntimeTemplate.returningFunction` method to create a function expression that returns the `src` property of a given node ([link](https://github.com/webpack/webpack/pull/17047/files?diff=unified&w=0#diff-5b68f78763cd59ef3491990ef44d952823d13073cc43b0b3bb9301c693c7c88aL49-R53))
