### PR TITLE
feat: added logging to define plugin

### DIFF
--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -26,6 +26,7 @@ const createHash = require("./util/createHash");
 /** @typedef {import("./NormalModule")} NormalModule */
 /** @typedef {import("./RuntimeTemplate")} RuntimeTemplate */
 /** @typedef {import("./javascript/JavascriptParser")} JavascriptParser */
+/** @typedef {import("./logging/Logger").Logger} Logger */
 
 /** @typedef {null|undefined|RegExp|Function|string|number|boolean|bigint|undefined} CodeValuePrimitive */
 /** @typedef {RecursiveArrayOrRecord<CodeValuePrimitive|RuntimeValue>} CodeValue */
@@ -117,6 +118,7 @@ class RuntimeValue {
  * @param {Map<string, string | Set<string>>} valueCacheVersions valueCacheVersions
  * @param {string} key the defined key
  * @param {RuntimeTemplate} runtimeTemplate the runtime template
+ * @param {Logger} logger the logger object
  * @param {boolean|undefined|null=} asiSafe asi safe (undefined: unknown, null: unneeded)
  * @param {Set<string>|undefined=} objKeys used keys
  * @returns {string} code converted to string that evaluates
@@ -127,6 +129,7 @@ const stringifyObj = (
 	valueCacheVersions,
 	key,
 	runtimeTemplate,
+	logger,
 	asiSafe,
 	objKeys
 ) => {
@@ -135,7 +138,15 @@ const stringifyObj = (
 	if (arr) {
 		code = `[${obj
 			.map(code =>
-				toCode(code, parser, valueCacheVersions, key, runtimeTemplate, null)
+				toCode(
+					code,
+					parser,
+					valueCacheVersions,
+					key,
+					runtimeTemplate,
+					logger,
+					null
+				)
 			)
 			.join(",")}]`;
 	} else {
@@ -150,7 +161,15 @@ const stringifyObj = (
 				return (
 					JSON.stringify(key) +
 					":" +
-					toCode(code, parser, valueCacheVersions, key, runtimeTemplate, null)
+					toCode(
+						code,
+						parser,
+						valueCacheVersions,
+						key,
+						runtimeTemplate,
+						logger,
+						null
+					)
 				);
 			})
 			.join(",")}}`;
@@ -175,6 +194,7 @@ const stringifyObj = (
  * @param {Map<string, string | Set<string>>} valueCacheVersions valueCacheVersions
  * @param {string} key the defined key
  * @param {RuntimeTemplate} runtimeTemplate the runtime template
+ * @param {Logger} logger the logger object
  * @param {boolean|undefined|null=} asiSafe asi safe (undefined: unknown, null: unneeded)
  * @param {Set<string>|undefined=} objKeys used keys
  * @returns {string} code converted to string that evaluates
@@ -185,51 +205,62 @@ const toCode = (
 	valueCacheVersions,
 	key,
 	runtimeTemplate,
+	logger,
 	asiSafe,
 	objKeys
 ) => {
-	if (code === null) {
-		return "null";
-	}
-	if (code === undefined) {
-		return "undefined";
-	}
-	if (Object.is(code, -0)) {
-		return "-0";
-	}
-	if (code instanceof RuntimeValue) {
-		return toCode(
-			code.exec(parser, valueCacheVersions, key),
-			parser,
-			valueCacheVersions,
-			key,
-			runtimeTemplate,
-			asiSafe
-		);
-	}
-	if (code instanceof RegExp && code.toString) {
-		return code.toString();
-	}
-	if (typeof code === "function" && code.toString) {
-		return "(" + code.toString() + ")";
-	}
-	if (typeof code === "object") {
-		return stringifyObj(
-			code,
-			parser,
-			valueCacheVersions,
-			key,
-			runtimeTemplate,
-			asiSafe,
-			objKeys
-		);
-	}
-	if (typeof code === "bigint") {
-		return runtimeTemplate.supportsBigIntLiteral()
-			? `${code}n`
-			: `BigInt("${code}")`;
-	}
-	return code + "";
+	const transformToCode = () => {
+		if (code === null) {
+			return "null";
+		}
+		if (code === undefined) {
+			return "undefined";
+		}
+		if (Object.is(code, -0)) {
+			return "-0";
+		}
+		if (code instanceof RuntimeValue) {
+			return toCode(
+				code.exec(parser, valueCacheVersions, key),
+				parser,
+				valueCacheVersions,
+				key,
+				runtimeTemplate,
+				logger,
+				asiSafe
+			);
+		}
+		if (code instanceof RegExp && code.toString) {
+			return code.toString();
+		}
+		if (typeof code === "function" && code.toString) {
+			return "(" + code.toString() + ")";
+		}
+		if (typeof code === "object") {
+			return stringifyObj(
+				code,
+				parser,
+				valueCacheVersions,
+				key,
+				runtimeTemplate,
+				logger,
+				asiSafe,
+				objKeys
+			);
+		}
+		if (typeof code === "bigint") {
+			return runtimeTemplate.supportsBigIntLiteral()
+				? `${code}n`
+				: `BigInt("${code}")`;
+		}
+		return code + "";
+	};
+
+	const strCode = transformToCode();
+
+	logger.log(`Replaced "${key}" with "${strCode}"`);
+
+	return strCode;
 };
 
 const toCacheVersion = code => {
@@ -300,6 +331,7 @@ class DefinePlugin {
 		compiler.hooks.compilation.tap(
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
+				const logger = compilation.getLogger("webpack.DefinePlugin");
 				compilation.dependencyTemplates.set(
 					ConstDependency,
 					new ConstDependency.Template()
@@ -421,6 +453,7 @@ class DefinePlugin {
 											compilation.valueCacheVersions,
 											key,
 											runtimeTemplate,
+											logger,
 											null
 										)
 									);
@@ -436,6 +469,7 @@ class DefinePlugin {
 									compilation.valueCacheVersions,
 									originalKey,
 									runtimeTemplate,
+									logger,
 									!parser.isAsiPosition(expr.range[0]),
 									parser.destructuringAssignmentPropertiesFor(expr)
 								);
@@ -470,6 +504,7 @@ class DefinePlugin {
 								compilation.valueCacheVersions,
 								originalKey,
 								runtimeTemplate,
+								logger,
 								null
 							);
 							const typeofCode = isTypeof
@@ -488,6 +523,7 @@ class DefinePlugin {
 								compilation.valueCacheVersions,
 								originalKey,
 								runtimeTemplate,
+								logger,
 								null
 							);
 							const typeofCode = isTypeof
@@ -534,6 +570,7 @@ class DefinePlugin {
 								compilation.valueCacheVersions,
 								key,
 								runtimeTemplate,
+								logger,
 								!parser.isAsiPosition(expr.range[0]),
 								parser.destructuringAssignmentPropertiesFor(expr)
 							);

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -860,6 +860,14 @@ webpack x.x.x compiled successfully in X ms
 
 asset both.js 1.4 KiB [emitted] (name: main)
 ./index.js 24 bytes [built] [code generated]
+webpack x.x.x compiled successfully in X ms
+
+asset 123.js 1.4 KiB [emitted] (name: main)
+./index.js 24 bytes [built] [code generated]
+
+DEBUG LOG from webpack.DefinePlugin
+    Replaced \\"VALUE\\" with \\"123\\"
+
 webpack x.x.x compiled successfully in X ms"
 `;
 

--- a/test/statsCases/define-plugin/webpack.config.js
+++ b/test/statsCases/define-plugin/webpack.config.js
@@ -56,5 +56,26 @@ module.exports = [
 				)
 			})
 		]
+	},
+
+	{
+		mode: "production",
+		entry: "./index",
+		output: {
+			filename: "123.js"
+		},
+		infrastructureLogging: {
+			debug: /DefinePlugin/,
+			level: "none"
+		},
+		stats: {
+			loggingDebug: /DefinePlugin/,
+			logging: "none"
+		},
+		plugins: [
+			new webpack.DefinePlugin({
+				VALUE: "123"
+			})
+		]
 	}
 ];


### PR DESCRIPTION
fixes #15778 fixes #16463

Different with https://github.com/webpack/webpack/pull/16463/
- rebased with latest changes
- different order of arguments (logger can't be optional, because it always created by webpack)
- test added


## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7a60896</samp>

This pull request enhances the `DefinePlugin` with logging capabilities, which can help debug the plugin's behavior and output. It also adds a new test case to verify that the logging options work as expected. The main changes are in `lib/DefinePlugin.js` and `test/statsCases/define-plugin/webpack.config.js`.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7a60896</samp>

*  Add logging functionality to DefinePlugin ([link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR29), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR121), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR132), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fL138-R149), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fL153-R172), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR197), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fL188-R263), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR334), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR456), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR472), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR507), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR526), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR573))
  * Define `Logger` type from `logging` module ([link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR29))
  * Pass `logger` object to `RuntimeValue` class and `toCode` function ([link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR121), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR132), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fL138-R149), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fL153-R172), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR197), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR456), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR472), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR507), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR526), [link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR573))
  * Log the key and the code string that are replaced by the plugin ([link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fL188-R263))
  * Create `logger` object from `compilation` object in `DefinePlugin` constructor ([link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR334))
* Add test case for DefinePlugin with logging options in `test/statsCases/define-plugin/webpack.config.js` ([link](https://github.com/webpack/webpack/pull/17048/files?diff=unified&w=0#diff-53235f4b934ab40dfce04e68b524c2fc305f359f090f78f823b3f35cf5586697R59-R79))
