### PR TITLE
test: stability for define

### DIFF
--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -862,7 +862,7 @@ asset both.js 1.4 KiB [emitted] (name: main)
 ./index.js 24 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset 123.js 1.4 KiB [emitted] (name: main)
+asset log.js 1.4 KiB [emitted] (name: main)
 ./index.js 24 bytes [built] [code generated]
 
 DEBUG LOG from webpack.DefinePlugin

--- a/test/statsCases/define-plugin/webpack.config.js
+++ b/test/statsCases/define-plugin/webpack.config.js
@@ -62,7 +62,7 @@ module.exports = [
 		mode: "production",
 		entry: "./index",
 		output: {
-			filename: "123.js"
+			filename: "log.js"
 		},
 		infrastructureLogging: {
 			debug: /DefinePlugin/,


### PR DESCRIPTION
Fix usntable test for `define` plugin (my bad)

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed0738d</samp>

Changed output filename for DefinePlugin test case to `log.js`. This avoids confusion and conflicts with other tests.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ed0738d</samp>

* Change output filename to `log.js` for consistency with test case name ([link](https://github.com/webpack/webpack/pull/17062/files?diff=unified&w=0#diff-53235f4b934ab40dfce04e68b524c2fc305f359f090f78f823b3f35cf5586697L65-R65))
