### PR TITLE
feat: allow CLI to be ESM

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,6 +78,13 @@ module.exports = {
 	},
 	overrides: [
 		{
+			// Allow to use `dynamic` import
+			files: ["bin/**/*.js"],
+			parserOptions: {
+				ecmaVersion: 2020
+			}
+		},
+		{
 			files: ["lib/**/*.runtime.js", "hot/*.js"],
 			env: {
 				es6: false,

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -78,8 +78,19 @@ const runCli = cli => {
 	const pkgPath = require.resolve(`${cli.package}/package.json`);
 	// eslint-disable-next-line node/no-missing-require
 	const pkg = require(pkgPath);
-	// eslint-disable-next-line node/no-missing-require
-	require(path.resolve(path.dirname(pkgPath), pkg.bin[cli.binName]));
+
+	if (pkg.type === "module" || /\.mjs/i.test(pkg.bin[cli.binName])) {
+		// eslint-disable-next-line node/no-unsupported-features/es-syntax
+		import(path.resolve(path.dirname(pkgPath), pkg.bin[cli.binName])).catch(
+			error => {
+				console.error(error);
+				process.exitCode = 1;
+			}
+		);
+	} else {
+		// eslint-disable-next-line node/no-missing-require
+		require(path.resolve(path.dirname(pkgPath), pkg.bin[cli.binName]));
+	}
 };
 
 /**


### PR DESCRIPTION
Allow CLI to be ESM

fixes #16448

@snitin315 we should port this to webpack-dev-server too  

## Summary

<!-- cspell:disable-next-line -->

copilot:summary

## Details

<!-- cspell:disable-next-line -->

copilot:walkthrough
