### PR TITLE
refactor(type): css

### DIFF
--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -32,6 +32,7 @@ class CssGenerator extends Generator {
 	generate(module, generateContext) {
 		const originalSource = module.originalSource();
 		const source = new ReplaceSource(originalSource);
+		/** @type {InitFragment[]} */
 		const initFragments = [];
 		const cssExports = new Map();
 
@@ -51,6 +52,9 @@ class CssGenerator extends Generator {
 			cssExports
 		};
 
+		/**
+		 * @param {Dependency} dependency dependency
+		 */
 		const handleDependency = dependency => {
 			const constructor = /** @type {new (...args: any[]) => Dependency} */ (
 				dependency.constructor

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -14,6 +14,7 @@ const compileBooleanMatcher = require("../util/compileBooleanMatcher");
 const { chunkHasCss } = require("./CssModulesPlugin");
 
 /** @typedef {import("../Chunk")} Chunk */
+/** @typedef {import("../Compilation").RuntimeRequirementsContext} RuntimeRequirementsContext */
 
 /**
  * @typedef {Object} JsonpCompilationPluginHooks
@@ -44,11 +45,13 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 		return hooks;
 	}
 
-	constructor(runtimeRequirements, runtimeOptions) {
+	/**
+	 * @param {Set<string>} runtimeRequirements runtime requirements
+	 */
+	constructor(runtimeRequirements) {
 		super("css loading", 10);
 
 		this._runtimeRequirements = runtimeRequirements;
-		this.runtimeOptions = runtimeOptions;
 	}
 
 	/**
@@ -76,10 +79,13 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 		const withLoading =
 			_runtimeRequirements.has(RuntimeGlobals.ensureChunkHandlers) &&
 			hasCssMatcher !== false;
+		/** @type {boolean} */
 		const withHmr = _runtimeRequirements.has(
 			RuntimeGlobals.hmrDownloadUpdateHandlers
 		);
+		/** @type {Set<number | string | null>} */
 		const initialChunkIdsWithCss = new Set();
+		/** @type {Set<number | string | null>} */
 		const initialChunkIdsWithoutCss = new Set();
 		for (const c of chunk.getAllInitialChunks()) {
 			(chunkHasCss(c, chunkGraph)
@@ -120,6 +126,7 @@ class CssLoadingRuntimeModule extends RuntimeModule {
 				: ""
 		]);
 
+		/** @type {(str: string) => number} */
 		const cc = str => str.charCodeAt(0);
 
 		return Template.asString([

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -29,10 +29,13 @@ const nonNumericOnlyHash = require("../util/nonNumericOnlyHash");
 const CssExportsGenerator = require("./CssExportsGenerator");
 const CssGenerator = require("./CssGenerator");
 const CssParser = require("./CssParser");
+const WebpackError = require("../WebpackError");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../../declarations/WebpackOptions").CssExperimentOptions} CssExperimentOptions */
 /** @typedef {import("../Chunk")} Chunk */
+/** @typedef {import("../Compilation")} Compilation */
+/** @typedef {import("../ChunkGraph")} ChunkGraph */
 /** @typedef {import("../Compiler")} Compiler */
 /** @typedef {import("../Module")} Module */
 
@@ -275,6 +278,12 @@ class CssModulesPlugin {
 		);
 	}
 
+	/**
+	 * @param {Chunk} chunk chunk
+	 * @param {Iterable<Module>} modules unordered modules
+	 * @param {Compilation} compilation compilation
+	 * @returns {Module[]} ordered modules
+	 */
 	getModulesInOrder(chunk, modules, compilation) {
 		if (!modules) return [];
 
@@ -320,6 +329,7 @@ class CssModulesPlugin {
 				// done, everything empty
 				break;
 			}
+			/** @type {Module} */
 			let selectedModule = list[list.length - 1];
 			let hasFailed = undefined;
 			outer: for (;;) {
@@ -345,18 +355,17 @@ class CssModulesPlugin {
 				if (compilation) {
 					// TODO print better warning
 					compilation.warnings.push(
-						new Error(
-							`chunk ${
-								chunk.name || chunk.id
-							}\nConflicting order between ${hasFailed.readableIdentifier(
-								compilation.requestShortener
-							)} and ${selectedModule.readableIdentifier(
+						new WebpackError(
+							`chunk ${chunk.name || chunk.id}\nConflicting order between ${
+								/** @type {Module} */
+								(hasFailed).readableIdentifier(compilation.requestShortener)
+							} and ${selectedModule.readableIdentifier(
 								compilation.requestShortener
 							)}`
 						)
 					);
 				}
-				selectedModule = hasFailed;
+				selectedModule = /** @type {Module} */ (hasFailed);
 			}
 			// Insert the selected module into the final modules list
 			finalModules.push(selectedModule);
@@ -374,6 +383,12 @@ class CssModulesPlugin {
 		return finalModules;
 	}
 
+	/**
+	 * @param {Chunk} chunk chunk
+	 * @param {ChunkGraph} chunkGraph chunk graph
+	 * @param {Compilation} compilation compilation
+	 * @returns {Module[]} ordered css modules
+	 */
 	getOrderedChunkCssModules(chunk, chunkGraph, compilation) {
 		return [
 			...this.getModulesInOrder(
@@ -492,6 +507,11 @@ class CssModulesPlugin {
 		}
 	}
 
+	/**
+	 * @param {Chunk} chunk chunk
+	 * @param {ChunkGraph} chunkGraph chunk graph
+	 * @returns {boolean} true, when the chunk has css
+	 */
 	static chunkHasCss(chunk, chunkGraph) {
 		return (
 			!!chunkGraph.getChunkModulesIterableBySourceType(chunk, "css") ||

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -15,6 +15,7 @@ const {
 } = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const SelfModuleFactory = require("../SelfModuleFactory");
+const WebpackError = require("../WebpackError");
 const CssExportDependency = require("../dependencies/CssExportDependency");
 const CssImportDependency = require("../dependencies/CssImportDependency");
 const CssLocalIdentifierDependency = require("../dependencies/CssLocalIdentifierDependency");
@@ -29,15 +30,17 @@ const nonNumericOnlyHash = require("../util/nonNumericOnlyHash");
 const CssExportsGenerator = require("./CssExportsGenerator");
 const CssGenerator = require("./CssGenerator");
 const CssParser = require("./CssParser");
-const WebpackError = require("../WebpackError");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../../declarations/WebpackOptions").CssExperimentOptions} CssExperimentOptions */
+/** @typedef {import("../../declarations/WebpackOptions").Output} OutputOptions */
 /** @typedef {import("../Chunk")} Chunk */
-/** @typedef {import("../Compilation")} Compilation */
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
+/** @typedef {import("../CodeGenerationResults")} CodeGenerationResults */
+/** @typedef {import("../Compilation")} Compilation */
 /** @typedef {import("../Compiler")} Compiler */
 /** @typedef {import("../Module")} Module */
+/** @typedef {import("../util/memoize")} Memoize */
 
 const getCssLoadingRuntimeModule = memoize(() =>
 	require("./CssLoadingRuntimeModule")
@@ -68,6 +71,11 @@ const validateParserOptions = createSchemaValidation(
 	}
 );
 
+/**
+ * @param {string} str string
+ * @param {boolean=} omitOptionalUnderscore if true, optional underscore is not added
+ * @returns {string} escaped string
+ */
 const escapeCss = (str, omitOptionalUnderscore) => {
 	const escaped = `${str}`.replace(
 		// cspell:word uffff
@@ -222,6 +230,7 @@ class CssModulesPlugin {
 
 					if (chunk instanceof HotUpdateChunk) return result;
 
+					/** @type {CssModule[] | undefined} */
 					const modules = orderedCssModulesPerChunk.get(chunk);
 					if (modules !== undefined) {
 						result.push({
@@ -287,6 +296,7 @@ class CssModulesPlugin {
 	getModulesInOrder(chunk, modules, compilation) {
 		if (!modules) return [];
 
+		/** @type {Module[]} */
 		const modulesList = [...modules];
 
 		// Get ordered list of modules per chunk group
@@ -320,6 +330,7 @@ class CssModulesPlugin {
 
 		modulesByChunkGroup.sort(compareModuleLists);
 
+		/** @type {Module[]} */
 		const finalModules = [];
 
 		for (;;) {
@@ -412,6 +423,15 @@ class CssModulesPlugin {
 		];
 	}
 
+	/**
+	 * @param {Object} options options
+	 * @param {string | undefined} options.uniqueName unique name
+	 * @param {Chunk} options.chunk chunk
+	 * @param {ChunkGraph} options.chunkGraph chunk graph
+	 * @param {CodeGenerationResults} options.codeGenerationResults code generation results
+	 * @param {CssModule[]} options.modules ordered css modules
+	 * @returns {Source} generated source
+	 */
 	renderChunk({
 		uniqueName,
 		chunk,
@@ -420,6 +440,7 @@ class CssModulesPlugin {
 		modules
 	}) {
 		const source = new ConcatSource();
+		/** @type {string[]} */
 		const metaData = [];
 		for (const module of modules) {
 			try {
@@ -458,6 +479,7 @@ class CssModulesPlugin {
 					source.add(moduleSource);
 					source.add("\n");
 				}
+				/** @type {Map<string, string> | undefined} */
 				const exports =
 					codeGenResult.data && codeGenResult.data.get("css-exports");
 				let moduleId = chunkGraph.getModuleId(module) + "";
@@ -497,6 +519,11 @@ class CssModulesPlugin {
 		return source;
 	}
 
+	/**
+	 * @param {Chunk} chunk chunk
+	 * @param {OutputOptions} outputOptions output options
+	 * @returns {Chunk["cssFilenameTemplate"] | OutputOptions["cssFilename"] | OutputOptions["cssChunkFilename"]} used filename template
+	 */
 	static getChunkFilenameTemplate(chunk, outputOptions) {
 		if (chunk.cssFilenameTemplate) {
 			return chunk.cssFilenameTemplate;

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -34,6 +34,11 @@ const OPTIONALLY_VENDOR_PREFIXED_KEYFRAMES_AT_RULE = /^@(-\w+-)?keyframes$/;
 const OPTIONALLY_VENDOR_PREFIXED_ANIMATION_PROPERTY =
 	/^(-\w+-)?animation(-name)?$/i;
 
+/**
+ * @param {string} str url string
+ * @param {boolean} isString is url wrapped in quotes
+ * @returns {string} normalized url
+ */
 const normalizeUrl = (str, isString) => {
 	// Remove extra spaces and newlines:
 	// `url("im\
@@ -71,6 +76,9 @@ const normalizeUrl = (str, isString) => {
 };
 
 class LocConverter {
+	/**
+	 * @param {string} input input
+	 */
 	constructor(input) {
 		this._input = input;
 		this.line = 1;
@@ -78,6 +86,10 @@ class LocConverter {
 		this.pos = 0;
 	}
 
+	/**
+	 * @param {number} pos position
+	 * @returns {LocConverter} location converter
+	 */
 	get(pos) {
 		if (this.pos !== pos) {
 			if (this.pos < pos) {
@@ -112,6 +124,10 @@ const CSS_MODE_AT_IMPORT_EXPECT_URL = 3;
 const CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA = 4;
 const CSS_MODE_AT_OTHER = 5;
 
+/**
+ * @param {number} mode current mode
+ * @returns {string} description of mode
+ */
 const explainMode = mode => {
 	switch (mode) {
 		case CSS_MODE_TOP_LEVEL:
@@ -127,7 +143,7 @@ const explainMode = mode => {
 		case CSS_MODE_AT_OTHER:
 			return "parsing at-rule";
 		default:
-			return mode;
+			return "parsing css";
 	}
 };
 
@@ -163,11 +179,16 @@ class CssParser extends Parser {
 		const declaredCssVariables = new Set();
 
 		const locConverter = new LocConverter(source);
+		/** @type {number} */
 		let mode = CSS_MODE_TOP_LEVEL;
+		/** @type {number} */
 		let modeNestingLevel = 0;
 		let modeData = undefined;
+		/** @type {string | boolean | undefined} */
 		let singleClassSelector = undefined;
+		/** @type {[number, number] | undefined} */
 		let lastIdentifier = undefined;
+		/** @type {boolean} */
 		let awaitRightParenthesis = false;
 		/** @type [string, number, number][] */
 		let balanced = [];

--- a/lib/css/walkCssTokens.js
+++ b/lib/css/walkCssTokens.js
@@ -76,6 +76,10 @@ const CC_HYPHEN_MINUS = "-".charCodeAt(0);
 const CC_LESS_THAN_SIGN = "<".charCodeAt(0);
 const CC_GREATER_THAN_SIGN = ">".charCodeAt(0);
 
+/**
+ * @param {number} cc char code
+ * @returns {boolean} true, if cc is a newline
+ */
 const _isNewLine = cc => {
 	return (
 		cc === CC_LINE_FEED || cc === CC_CARRIAGE_RETURN || cc === CC_FORM_FEED
@@ -84,6 +88,7 @@ const _isNewLine = cc => {
 
 /** @type {CharHandler} */
 const consumeSpace = (input, pos, callbacks) => {
+	/** @type {number} */
 	let cc;
 	do {
 		pos++;
@@ -92,6 +97,10 @@ const consumeSpace = (input, pos, callbacks) => {
 	return pos;
 };
 
+/**
+ * @param {number} cc char code
+ * @returns {boolean} true, if cc is a whitespace
+ */
 const _isWhiteSpace = cc => {
 	return (
 		cc === CC_LINE_FEED ||
@@ -102,6 +111,10 @@ const _isWhiteSpace = cc => {
 	);
 };
 
+/**
+ * @param {number} cc char code
+ * @returns {boolean} true, if cc is a start code point of an identifier
+ */
 const _isIdentStartCodePoint = cc => {
 	return (
 		(cc >= CC_LOWER_A && cc <= CC_LOWER_Z) ||
@@ -145,21 +158,27 @@ const consumeComments = (input, pos, callbacks) => {
 };
 
 /** @type {function(number): CharHandler} */
-const consumeString = end => (input, pos, callbacks) => {
+const consumeString = quote_cc => (input, pos, callbacks) => {
 	const start = pos;
-	pos = _consumeString(input, pos, end);
+	pos = _consumeString(input, pos, quote_cc);
 	if (callbacks.string !== undefined) {
 		pos = callbacks.string(input, start, pos);
 	}
 	return pos;
 };
 
-const _consumeString = (input, pos, end) => {
+/**
+ * @param {string} input input
+ * @param {number} pos position
+ * @param {number} quote_cc quote char code
+ * @returns {number} new position
+ */
+const _consumeString = (input, pos, quote_cc) => {
 	pos++;
 	for (;;) {
 		if (pos === input.length) return pos;
 		const cc = input.charCodeAt(pos);
-		if (cc === end) return pos + 1;
+		if (cc === quote_cc) return pos + 1;
 		if (_isNewLine(cc)) {
 			// bad string
 			return pos;
@@ -176,6 +195,10 @@ const _consumeString = (input, pos, end) => {
 	}
 };
 
+/**
+ * @param {number} cc char code
+ * @returns {boolean} is identifier start code
+ */
 const _isIdentifierStartCode = cc => {
 	return (
 		cc === CC_LOW_LINE ||
@@ -185,16 +208,30 @@ const _isIdentifierStartCode = cc => {
 	);
 };
 
+/**
+ * @param {number} first first code point
+ * @param {number} second second code point
+ * @returns {boolean} true if two code points are a valid escape
+ */
 const _isTwoCodePointsAreValidEscape = (first, second) => {
 	if (first !== CC_REVERSE_SOLIDUS) return false;
 	if (_isNewLine(second)) return false;
 	return true;
 };
 
+/**
+ * @param {number} cc char code
+ * @returns {boolean} is digit
+ */
 const _isDigit = cc => {
 	return cc >= CC_0 && cc <= CC_9;
 };
 
+/**
+ * @param {string} input input
+ * @param {number} pos position
+ * @returns {boolean} true, if input at pos starts an identifier
+ */
 const _startsIdentifier = (input, pos) => {
 	const cc = input.charCodeAt(pos);
 	if (cc === CC_HYPHEN_MINUS) {
@@ -220,7 +257,7 @@ const consumeNumberSign = (input, pos, callbacks) => {
 	pos++;
 	if (pos === input.length) return pos;
 	if (callbacks.isSelector(input, pos) && _startsIdentifier(input, pos)) {
-		pos = _consumeIdentifier(input, pos);
+		pos = _consumeIdentifier(input, pos, callbacks);
 		if (callbacks.id !== undefined) {
 			return callbacks.id(input, start, pos);
 		}
@@ -244,7 +281,7 @@ const consumeMinus = (input, pos, callbacks) => {
 		if (cc === CC_GREATER_THAN_SIGN) {
 			return pos + 1;
 		} else {
-			pos = _consumeIdentifier(input, pos);
+			pos = _consumeIdentifier(input, pos, callbacks);
 			if (callbacks.identifier !== undefined) {
 				return callbacks.identifier(input, start, pos);
 			}
@@ -253,7 +290,7 @@ const consumeMinus = (input, pos, callbacks) => {
 		if (pos + 1 === input.length) return pos;
 		const cc = input.charCodeAt(pos + 1);
 		if (_isNewLine(cc)) return pos;
-		pos = _consumeIdentifier(input, pos);
+		pos = _consumeIdentifier(input, pos, callbacks);
 		if (callbacks.identifier !== undefined) {
 			return callbacks.identifier(input, start, pos);
 		}
@@ -272,16 +309,17 @@ const consumeDot = (input, pos, callbacks) => {
 	if (_isDigit(cc)) return consumeNumericToken(input, pos - 2, callbacks);
 	if (!callbacks.isSelector(input, pos) || !_startsIdentifier(input, pos))
 		return pos;
-	pos = _consumeIdentifier(input, pos);
+	pos = _consumeIdentifier(input, pos, callbacks);
 	if (callbacks.class !== undefined) return callbacks.class(input, start, pos);
 	return pos;
 };
 
 /** @type {CharHandler} */
 const consumeNumericToken = (input, pos, callbacks) => {
-	pos = _consumeNumber(input, pos);
+	pos = _consumeNumber(input, pos, callbacks);
 	if (pos === input.length) return pos;
-	if (_startsIdentifier(input, pos)) return _consumeIdentifier(input, pos);
+	if (_startsIdentifier(input, pos))
+		return _consumeIdentifier(input, pos, callbacks);
 	const cc = input.charCodeAt(pos);
 	if (cc === CC_PERCENTAGE) return pos + 1;
 	return pos;
@@ -290,7 +328,7 @@ const consumeNumericToken = (input, pos, callbacks) => {
 /** @type {CharHandler} */
 const consumeOtherIdentifier = (input, pos, callbacks) => {
 	const start = pos;
-	pos = _consumeIdentifier(input, pos);
+	pos = _consumeIdentifier(input, pos, callbacks);
 	if (
 		pos !== input.length &&
 		!callbacks.isSelector(input, pos) &&
@@ -311,7 +349,7 @@ const consumeOtherIdentifier = (input, pos, callbacks) => {
 /** @type {CharHandler} */
 const consumePotentialUrl = (input, pos, callbacks) => {
 	const start = pos;
-	pos = _consumeIdentifier(input, pos);
+	pos = _consumeIdentifier(input, pos, callbacks);
 	const nextPos = pos + 1;
 	if (
 		pos === start + 3 &&
@@ -331,6 +369,7 @@ const consumePotentialUrl = (input, pos, callbacks) => {
 			return nextPos;
 		} else {
 			const contentStart = pos;
+			/** @type {number} */
 			let contentEnd;
 			for (;;) {
 				if (cc === CC_REVERSE_SOLIDUS) {
@@ -380,7 +419,7 @@ const consumePotentialPseudo = (input, pos, callbacks) => {
 	pos++;
 	if (!callbacks.isSelector(input, pos) || !_startsIdentifier(input, pos))
 		return pos;
-	pos = _consumeIdentifier(input, pos);
+	pos = _consumeIdentifier(input, pos, callbacks);
 	let cc = input.charCodeAt(pos);
 	if (cc === CC_LEFT_PARENTHESIS) {
 		pos++;
@@ -449,6 +488,7 @@ const consumeComma = (input, pos, callbacks) => {
 	return pos;
 };
 
+/** @type {CharHandler} */
 const _consumeIdentifier = (input, pos) => {
 	for (;;) {
 		const cc = input.charCodeAt(pos);
@@ -468,6 +508,7 @@ const _consumeIdentifier = (input, pos) => {
 	}
 };
 
+/** @type {CharHandler} */
 const _consumeNumber = (input, pos) => {
 	pos++;
 	if (pos === input.length) return pos;
@@ -526,12 +567,13 @@ const consumeLessThan = (input, pos, callbacks) => {
 	return pos + 1;
 };
 
+/** @type {CharHandler} */
 const consumeAt = (input, pos, callbacks) => {
 	const start = pos;
 	pos++;
 	if (pos === input.length) return pos;
 	if (_startsIdentifier(input, pos)) {
-		pos = _consumeIdentifier(input, pos);
+		pos = _consumeIdentifier(input, pos, callbacks);
 		if (callbacks.atKeyword !== undefined) {
 			pos = callbacks.atKeyword(input, start, pos);
 		}


### PR DESCRIPTION
Not all, but many types for CSS

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dbca487</samp>

This pull request enhances the type safety, documentation, and readability of the code related to CSS generation and loading in webpack. It adds type definitions, JSDoc comments, and consistent error classes to various classes and functions in `lib/css/*.js` files, and introduces a new parameter to customize the token walking logic in `walkCssTokens.js`.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dbca487</samp>

*  Add type annotations, JSDoc comments, and type definition imports for various variables, parameters, and methods in the `CssGenerator`, `CssLoadingRuntimeModule`, `CssModulesPlugin`, and `CssParser` classes to improve documentation, type checking, and code completion ([link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-abf37be5f4da612a2e9e8a53c789e4f1a98f248ec73ee05496392c3556fb7222R35), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-abf37be5f4da612a2e9e8a53c789e4f1a98f248ec73ee05496392c3556fb7222R55-R57), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-1ede558d550bf27773fff6d4f110076dc6e187ddccbea0645a66c67742b689dbR17), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-1ede558d550bf27773fff6d4f110076dc6e187ddccbea0645a66c67742b689dbL47-R54), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-1ede558d550bf27773fff6d4f110076dc6e187ddccbea0645a66c67742b689dbL79-R88), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-1ede558d550bf27773fff6d4f110076dc6e187ddccbea0645a66c67742b689dbR129), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bR18), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bL35-R43), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bR74-R78), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bR233), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bL278-R299), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bR333), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bR343), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bL348-R379), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bR397-R402), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bR426-R434), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bR443), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bR482), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bR522-R526), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bR537-R541), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054R79-R81), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L166-R191))
*  Replace the `Error` class with the `WebpackError` class for creating a warning for conflicting order between css modules in the `getModulesInOrder` method of the `CssModulesPlugin` class to use a consistent and descriptive error class for webpack-related errors ([link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bR18), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bL348-R379))
*  Remove the unused `runtimeOptions` parameter from the constructor of the `CssLoadingRuntimeModule` class to simplify the signature and avoid confusion ([link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-1ede558d550bf27773fff6d4f110076dc6e187ddccbea0645a66c67742b689dbL47-R54))
*  Modify the default case of the `explainMode` function in the `CssParser` class to return "parsing css" instead of the mode number to improve the readability and clarity of the function output ([link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L130-R146))
*  Rename the `end` parameter of the `consumeString` function in the `walkCssTokens` module to `quote_cc` to be more descriptive and consistent with the `_consumeString` function ([link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-c883a58529823c292f9110ad330b07ef920f2a3c4c284b5c52edac6ea9baba9fL148-R163))
*  Add a `callbacks` parameter to various char handler and helper functions in the `walkCssTokens` module to enable custom handling of identifier and number parts, such as class names, ids, pseudo selectors, exponent, or fraction, and avoid duplication of logic and code ([link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-c883a58529823c292f9110ad330b07ef920f2a3c4c284b5c52edac6ea9baba9fL223-R260), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-c883a58529823c292f9110ad330b07ef920f2a3c4c284b5c52edac6ea9baba9fL247-R284), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-c883a58529823c292f9110ad330b07ef920f2a3c4c284b5c52edac6ea9baba9fL256-R293), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-c883a58529823c292f9110ad330b07ef920f2a3c4c284b5c52edac6ea9baba9fL275-R312), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-c883a58529823c292f9110ad330b07ef920f2a3c4c284b5c52edac6ea9baba9fL282-R322), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-c883a58529823c292f9110ad330b07ef920f2a3c4c284b5c52edac6ea9baba9fL293-R331), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-c883a58529823c292f9110ad330b07ef920f2a3c4c284b5c52edac6ea9baba9fL314-R352), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-c883a58529823c292f9110ad330b07ef920f2a3c4c284b5c52edac6ea9baba9fL383-R422), [link](https://github.com/webpack/webpack/pull/17097/files?diff=unified&w=0#diff-c883a58529823c292f9110ad330b07ef920f2a3c4c284b5c52edac6ea9baba9fL534-R576))
