### PR TITLE
shard unit and integration tests in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shards: [1, 2, 3, 4, 5, 6, 7, 8]
+        shards: [1, 2, 3, 4]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -48,7 +48,7 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn link --frozen-lockfile || true
       - run: yarn link webpack --frozen-lockfile
-      - run: yarn test:basic --ci --shard ${{ matrix.shards }}/8
+      - run: yarn test:basic --ci --shard ${{ matrix.shards }}/4
       - uses: codecov/codecov-action@v3
         with:
           flags: basic

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,11 @@ jobs:
           path: .jest-cache
           key: jest-integration-${{ env.GITHUB_SHA }}
           restore-keys: jest-integration-
+      # Jest sharding for modern node versions
       - run: yarn cover:integration --ci --shard ${{ matrix.shards }}/8 --cacheDirectory .jest-cache
+      # Sharding using parts for legacy node versions
+      - run: yarn cover:integration:${{ matrix.part }} --ci --cacheDirectory .jest-cache || yarn cover:integration:${{ matrix.part }} --ci --cacheDirectory .jest-cache -f
+        if: matrix.node-version != '10.x' && matrix.node-version != '12.x' && matrix.node-version != '14.x'
       - run: yarn cover:merge
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,7 @@ jobs:
           path: .jest-cache
           key: jest-integration-${{ env.GITHUB_SHA }}
           restore-keys: jest-integration-
-      - run: yarn cover:integration --ci --shard ${{ matrix.shards }}/8 --cacheDirectory .jest-cache --shard ${{ matrix.shards }}/8 || yarn cover:integration --ci --cacheDirectory .jest-cache -f
+      - run: yarn cover:integration --ci --shard ${{ matrix.shards }}/8 --cacheDirectory .jest-cache
       - run: yarn cover:merge
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,7 @@ jobs:
           path: .jest-cache
           key: jest-integration-${{ env.GITHUB_SHA }}
           restore-keys: jest-integration-
-      - run: yarn cover:integration:${{ matrix.part }} --ci --cacheDirectory .jest-cache --shard ${{ matrix.shards }}/8 || yarn cover:integration:${{ matrix.part }} --ci --cacheDirectory .jest-cache --shard ${{ matrix.shards }}/8 -f
+      - run: yarn cover:integration --ci --shard ${{ matrix.shards }}/8 --cacheDirectory .jest-cache --shard ${{ matrix.shards }}/8 || yarn cover:integration --ci --cacheDirectory .jest-cache -f
       - run: yarn cover:merge
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [10.x, 20.x]
         part: [a, b]
-        shards: [1, 2, 3, 4, 5, 6, 7, 8]
         include:
           - os: ubuntu-latest
             node-version: 18.x
@@ -144,11 +143,7 @@ jobs:
           path: .jest-cache
           key: jest-integration-${{ env.GITHUB_SHA }}
           restore-keys: jest-integration-
-      # Jest sharding for modern node versions
-      - run: yarn cover:integration --ci --shard ${{ matrix.shards }}/8 --cacheDirectory .jest-cache
-      # Sharding using parts for legacy node versions
       - run: yarn cover:integration:${{ matrix.part }} --ci --cacheDirectory .jest-cache || yarn cover:integration:${{ matrix.part }} --ci --cacheDirectory .jest-cache -f
-        if: matrix.node-version != '10.x' && matrix.node-version != '12.x' && matrix.node-version != '14.x'
       - run: yarn cover:merge
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,10 @@ jobs:
           restore-keys: lint-
       - run: yarn lint
   basic:
+    strategy:
+      fail-fast: false
+      matrix:
+        shards: [1, 2, 3, 4, 5, 6, 7, 8]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -44,7 +48,7 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn link --frozen-lockfile || true
       - run: yarn link webpack --frozen-lockfile
-      - run: yarn test:basic --ci
+      - run: yarn test:basic --ci --shard ${{ matrix.shards }}/8
       - uses: codecov/codecov-action@v3
         with:
           flags: basic
@@ -91,6 +95,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [10.x, 20.x]
         part: [a, b]
+        shards: [1, 2, 3, 4, 5, 6, 7, 8]
         include:
           - os: ubuntu-latest
             node-version: 18.x
@@ -139,7 +144,7 @@ jobs:
           path: .jest-cache
           key: jest-integration-${{ env.GITHUB_SHA }}
           restore-keys: jest-integration-
-      - run: yarn cover:integration:${{ matrix.part }} --ci --cacheDirectory .jest-cache || yarn cover:integration:${{ matrix.part }} --ci --cacheDirectory .jest-cache -f
+      - run: yarn cover:integration:${{ matrix.part }} --ci --cacheDirectory .jest-cache --shard ${{ matrix.shards }}/8 || yarn cover:integration:${{ matrix.part }} --ci --cacheDirectory .jest-cache --shard ${{ matrix.shards }}/8 -f
       - run: yarn cover:merge
       - uses: codecov/codecov-action@v3
         with:

--- a/package.json
+++ b/package.json
@@ -168,6 +168,8 @@
     "cover:all": "node --expose-gc --max-old-space-size=4096 --experimental-vm-modules node_modules/jest-cli/bin/jest --logHeapUsage --coverage",
     "cover:basic": "node --expose-gc --max-old-space-size=4096 --experimental-vm-modules node_modules/jest-cli/bin/jest --logHeapUsage --testMatch \"<rootDir>/test/*.basictest.js\" --coverage",
     "cover:integration": "node --expose-gc --max-old-space-size=4096 --experimental-vm-modules node_modules/jest-cli/bin/jest --logHeapUsage --testMatch \"<rootDir>/test/*.{basictest,longtest,test}.js\" --coverage",
+    "cover:integration:a": "node --expose-gc --max-old-space-size=4096 --experimental-vm-modules node_modules/jest-cli/bin/jest --logHeapUsage --testMatch \"<rootDir>/test/*.{basictest,test}.js\" --coverage",
+    "cover:integration:b": "node --expose-gc --max-old-space-size=4096 --experimental-vm-modules node_modules/jest-cli/bin/jest --logHeapUsage --testMatch \"<rootDir>/test/*.longtest.js\" --coverage",
     "cover:unit": "node --max-old-space-size=4096 --experimental-vm-modules node_modules/jest-cli/bin/jest --testMatch \"<rootDir>/test/*.unittest.js\" --coverage",
     "cover:types": "node node_modules/tooling/type-coverage",
     "cover:merge": "yarn mkdirp .nyc_output && nyc merge .nyc_output coverage/coverage-nyc.json && rimraf .nyc_output",

--- a/package.json
+++ b/package.json
@@ -168,8 +168,6 @@
     "cover:all": "node --expose-gc --max-old-space-size=4096 --experimental-vm-modules node_modules/jest-cli/bin/jest --logHeapUsage --coverage",
     "cover:basic": "node --expose-gc --max-old-space-size=4096 --experimental-vm-modules node_modules/jest-cli/bin/jest --logHeapUsage --testMatch \"<rootDir>/test/*.basictest.js\" --coverage",
     "cover:integration": "node --expose-gc --max-old-space-size=4096 --experimental-vm-modules node_modules/jest-cli/bin/jest --logHeapUsage --testMatch \"<rootDir>/test/*.{basictest,longtest,test}.js\" --coverage",
-    "cover:integration:a": "node --expose-gc --max-old-space-size=4096 --experimental-vm-modules node_modules/jest-cli/bin/jest --logHeapUsage --testMatch \"<rootDir>/test/*.{basictest,test}.js\" --coverage",
-    "cover:integration:b": "node --expose-gc --max-old-space-size=4096 --experimental-vm-modules node_modules/jest-cli/bin/jest --logHeapUsage --testMatch \"<rootDir>/test/*.longtest.js\" --coverage",
     "cover:unit": "node --max-old-space-size=4096 --experimental-vm-modules node_modules/jest-cli/bin/jest --testMatch \"<rootDir>/test/*.unittest.js\" --coverage",
     "cover:types": "node node_modules/tooling/type-coverage",
     "cover:merge": "yarn mkdirp .nyc_output && nyc merge .nyc_output coverage/coverage-nyc.json && rimraf .nyc_output",


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed3139a</samp>

This pull request improves the integration test workflow by using the `--shard` option to run tests in parallel and removes unused scripts from `package.json`.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ed3139a</samp>

*  Add and modify test commands to use `--shard` option for parallelization ([link](https://github.com/webpack/webpack/pull/17098/files?diff=unified&w=0#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L47-R51), [link](https://github.com/webpack/webpack/pull/17098/files?diff=unified&w=0#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L142-R147))
*  Increase the number of shards for the test workflow in `.github/workflows/test.yml` to speed up execution and avoid timeouts ([link](https://github.com/webpack/webpack/pull/17098/files?diff=unified&w=0#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R36-R39), [link](https://github.com/webpack/webpack/pull/17098/files?diff=unified&w=0#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R98))
*  Remove unused scripts from `package.json` for simplicity and clarity ([link](https://github.com/webpack/webpack/pull/17098/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L171-L172))
