### PR TITLE
fix: modules being in wrong chunks

### DIFF
--- a/lib/optimize/ModuleConcatenationPlugin.js
+++ b/lib/optimize/ModuleConcatenationPlugin.js
@@ -632,9 +632,6 @@ class ModuleConcatenationPlugin {
 		const incomingConnectionsFromModules = new Map();
 		for (const [originModule, connections] of incomingConnections) {
 			if (originModule) {
-				// Ignore connection from orphan modules
-				if (chunkGraph.getNumberOfModuleChunks(originModule) === 0) continue;
-
 				// We don't care for connections from other runtimes
 				let originRuntime = undefined;
 				for (const r of chunkGraph.getModuleRuntimes(originModule)) {


### PR DESCRIPTION
When building my project outlined in https://github.com/webpack/webpack/issues/17059 certain modules are being removed or added to the incorrect chunk (I am not 100% sure as of yet). Thees changes resolves the issue.

<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d603153</samp>

Refactor and fix module concatenation plugin. Enhance the readability and correctness of the code in `lib/optimize/ModuleConcatenationPlugin.js`. Resolve a naming issue that could cause incorrect concatenation. Improve the error messages for unsupported or conflicting modules.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d603153</samp>

*  Simplify filtering of incoming connections by using `getIncomingConnections` method and sorting modules by identifier ([link](https://github.com/webpack/webpack/pull/17103/files?diff=unified&w=0#diff-2c41050379dc600b1a2db89ef0f270b32e7fdd8139702f36ba96f03d53e3cfd0L599-R624))
*  Improve error message for unsupported syntax by including explanations, filtering connections directly, and using sets and sorting for readability ([link](https://github.com/webpack/webpack/pull/17103/files?diff=unified&w=0#diff-2c41050379dc600b1a2db89ef0f270b32e7fdd8139702f36ba96f03d53e3cfd0L685-R713))
*  Fix bug of using wrong variable name in loop in `lib/optimize/ModuleConcatenationPlugin.js` ([link](https://github.com/webpack/webpack/pull/17103/files?diff=unified&w=0#diff-2c41050379dc600b1a2db89ef0f270b32e7fdd8139702f36ba96f03d53e3cfd0L727-R722))
