### PR TITLE
refactor: ignore unstable coverage

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -2578,6 +2578,8 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			p.calculate();
 
 			const logger = this.getLogger("webpack.Compilation.ModuleProfile");
+			// Avoid coverage problems due indirect changes
+			/* istanbul ignore next */
 			const logByValue = (value, msg) => {
 				if (value > 1000) {
 					logger.error(msg);

--- a/lib/cache/MemoryWithGcCachePlugin.js
+++ b/lib/cache/MemoryWithGcCachePlugin.js
@@ -34,6 +34,8 @@ class MemoryWithGcCachePlugin {
 			generation++;
 			let clearedEntries = 0;
 			let lastClearedIdentifier;
+			// Avoid coverage problems due indirect changes
+			/* istanbul ignore next */
 			for (const [identifier, entry] of oldCache) {
 				if (entry.until > generation) break;
 

--- a/lib/debug/ProfilingPlugin.js
+++ b/lib/debug/ProfilingPlugin.js
@@ -100,6 +100,8 @@ class Profiler {
 		return this.sendCommand("Profiler.stop").then(({ profile }) => {
 			const hrtime = process.hrtime();
 			const endTime = hrtime[0] * 1000000 + Math.round(hrtime[1] / 1000);
+			// Avoid coverage problems due indirect changes
+			/* istanbul ignore next */
 			if (profile.startTime < this._startTime || profile.endTime > endTime) {
 				// In some cases timestamps mismatch and we need to adjust them
 				// Both process.hrtime and the inspector timestamps claim to be relative


### PR DESCRIPTION
We ignore unstable coverage areas, because they may or may not occur, in theory we can use unit tests here, but I feel them useless

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f066d9</samp>

The pull request adds comments to ignore some `return` statements for code coverage purposes in `lib/cache/MemoryWithGcCachePlugin.js` and `lib/Compilation.js`. These statements may not be reached depending on the logic of some `if` conditions that are influenced by other parts of the code.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2f066d9</samp>

*  Add comments to ignore `return` statements for code coverage in `MemoryWithGcCachePlugin` and `Compilation` classes ([link](https://github.com/webpack/webpack/pull/17106/files?diff=unified&w=0#diff-01d29bde7e83df8c4b73a03e2605088d1d574234c5da05de38b00cfd0e02dc8aR37-R38), [link](https://github.com/webpack/webpack/pull/17106/files?diff=unified&w=0#diff-9206962f55a69b69a39e73a803e2be04b10d454f270e35b482f3f70a74f472a6R2581-R2582))
