### PR TITLE
fix: any @import rules must precede all other rules

### DIFF
--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -509,7 +509,10 @@ class CssParser extends Parser {
 						supports: undefined,
 						media: undefined
 					};
-				} else if (OPTIONALLY_VENDOR_PREFIXED_KEYFRAMES_AT_RULE.test(name)) {
+				} else if (
+					isTopLevelLocal() &&
+					OPTIONALLY_VENDOR_PREFIXED_KEYFRAMES_AT_RULE.test(name)
+				) {
 					let pos = end;
 					pos = walkCssTokens.eatWhitespaceAndComments(input, pos);
 					if (pos === input.length) return pos;

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -125,6 +125,7 @@ const CSS_MODE_IN_LOCAL_RULE = 2;
 const CSS_MODE_AT_IMPORT_EXPECT_URL = 3;
 const CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA = 4;
 const CSS_MODE_AT_IMPORT_INVALID = 5;
+const CSS_MODE_AT_NAMESPACE_INVALID = 6;
 
 class CssParser extends Parser {
 	constructor({
@@ -361,7 +362,8 @@ class CssParser extends Parser {
 					mode !== CSS_MODE_IN_LOCAL_RULE &&
 					mode !== CSS_MODE_AT_IMPORT_EXPECT_URL &&
 					mode !== CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA &&
-					mode !== CSS_MODE_AT_IMPORT_INVALID
+					mode !== CSS_MODE_AT_IMPORT_INVALID &&
+					mode !== CSS_MODE_AT_NAMESPACE_INVALID
 				);
 			},
 			url: (input, start, end, contentStart, contentEnd) => {
@@ -378,6 +380,7 @@ class CssParser extends Parser {
 						break;
 					}
 					// Do not parse URLs in import between rules
+					case CSS_MODE_AT_NAMESPACE_INVALID:
 					case CSS_MODE_AT_IMPORT_INVALID: {
 						break;
 					}
@@ -459,6 +462,7 @@ class CssParser extends Parser {
 			atKeyword: (input, start, end) => {
 				const name = input.slice(start, end).toLowerCase();
 				if (name === "@namespace") {
+					mode = CSS_MODE_AT_NAMESPACE_INVALID;
 					this._emitWarning(
 						state,
 						"@namespace is not supported in bundled CSS",

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -14,6 +14,8 @@ const CssSelfLocalIdentifierDependency = require("../dependencies/CssSelfLocalId
 const CssUrlDependency = require("../dependencies/CssUrlDependency");
 const StaticExportsDependency = require("../dependencies/StaticExportsDependency");
 const walkCssTokens = require("./walkCssTokens");
+const WebpackError = require("../WebpackError");
+const ModuleDependencyWarning = require("../ModuleDependencyWarning");
 
 /** @typedef {import("../Parser").ParserState} ParserState */
 /** @typedef {import("../Parser").PreparsedAst} PreparsedAst */
@@ -122,30 +124,7 @@ const CSS_MODE_IN_RULE = 1;
 const CSS_MODE_IN_LOCAL_RULE = 2;
 const CSS_MODE_AT_IMPORT_EXPECT_URL = 3;
 const CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA = 4;
-const CSS_MODE_AT_OTHER = 5;
-
-/**
- * @param {number} mode current mode
- * @returns {string} description of mode
- */
-const explainMode = mode => {
-	switch (mode) {
-		case CSS_MODE_TOP_LEVEL:
-			return "parsing top level css";
-		case CSS_MODE_IN_RULE:
-			return "parsing css rule content (global)";
-		case CSS_MODE_IN_LOCAL_RULE:
-			return "parsing css rule content (local)";
-		case CSS_MODE_AT_IMPORT_EXPECT_URL:
-			return "parsing @import (expecting url)";
-		case CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA:
-			return "parsing @import (expecting optionally layer, supports or media query)";
-		case CSS_MODE_AT_OTHER:
-			return "parsing at-rule";
-		default:
-			return "parsing css";
-	}
-};
+const CSS_MODE_AT_IMPORT_INVALID = 5;
 
 class CssParser extends Parser {
 	constructor({
@@ -157,6 +136,25 @@ class CssParser extends Parser {
 		this.allowPseudoBlocks = allowPseudoBlocks;
 		this.allowModeSwitch = allowModeSwitch;
 		this.defaultMode = defaultMode;
+	}
+
+	/**
+	 * @param {ParserState} state parser state
+	 * @param {string} message warning message
+	 * @param {LocConverter} locConverter location converter
+	 * @param {number} start start offset
+	 * @param {number} end end offset
+	 */
+	_emitWarning(state, message, locConverter, start, end) {
+		const { line: sl, column: sc } = locConverter.get(start);
+		const { line: el, column: ec } = locConverter.get(end);
+
+		state.current.addWarning(
+			new ModuleDependencyWarning(state.module, new WebpackError(message), {
+				start: { line: sl, column: sc },
+				end: { line: el, column: ec }
+			})
+		);
 	}
 
 	/**
@@ -183,6 +181,8 @@ class CssParser extends Parser {
 		let mode = CSS_MODE_TOP_LEVEL;
 		/** @type {number} */
 		let modeNestingLevel = 0;
+		/** @type {boolean} */
+		let allowImportAtRule = true;
 		let modeData = undefined;
 		/** @type {string | boolean | undefined} */
 		let singleClassSelector = undefined;
@@ -360,14 +360,12 @@ class CssParser extends Parser {
 					mode !== CSS_MODE_IN_RULE &&
 					mode !== CSS_MODE_IN_LOCAL_RULE &&
 					mode !== CSS_MODE_AT_IMPORT_EXPECT_URL &&
-					mode !== CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA
+					mode !== CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA &&
+					mode !== CSS_MODE_AT_IMPORT_INVALID
 				);
 			},
-			url: (input, start, end, contentStart, contentEnd, isString) => {
-				let value = normalizeUrl(
-					input.slice(contentStart, contentEnd),
-					isString
-				);
+			url: (input, start, end, contentStart, contentEnd) => {
+				let value = normalizeUrl(input.slice(contentStart, contentEnd), false);
 				switch (mode) {
 					case CSS_MODE_AT_IMPORT_EXPECT_URL: {
 						modeData.url = value;
@@ -377,6 +375,10 @@ class CssParser extends Parser {
 					}
 					// Do not parse URLs in `supports(...)`
 					case CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA: {
+						break;
+					}
+					// Do not parse URLs in import between rules
+					case CSS_MODE_AT_IMPORT_INVALID: {
 						break;
 					}
 					default: {
@@ -457,14 +459,27 @@ class CssParser extends Parser {
 			atKeyword: (input, start, end) => {
 				const name = input.slice(start, end).toLowerCase();
 				if (name === "@namespace") {
-					throw new Error("@namespace is not supported in bundled CSS");
-				}
-				if (name === "@import") {
-					if (mode !== CSS_MODE_TOP_LEVEL) {
-						throw new Error(
-							`Unexpected @import at ${start} during ${explainMode(mode)}`
+					this._emitWarning(
+						state,
+						"@namespace is not supported in bundled CSS",
+						locConverter,
+						start,
+						end
+					);
+					return end;
+				} else if (name === "@import") {
+					if (!allowImportAtRule) {
+						mode = CSS_MODE_AT_IMPORT_INVALID;
+						this._emitWarning(
+							state,
+							"Any @import rules must precede all other rules",
+							locConverter,
+							start,
+							end
 						);
+						return end;
 					}
+
 					mode = CSS_MODE_AT_IMPORT_EXPECT_URL;
 					modeData = {
 						atRuleStart: start,
@@ -474,8 +489,7 @@ class CssParser extends Parser {
 						supports: undefined,
 						media: undefined
 					};
-				}
-				if (OPTIONALLY_VENDOR_PREFIXED_KEYFRAMES_AT_RULE.test(name)) {
+				} else if (OPTIONALLY_VENDOR_PREFIXED_KEYFRAMES_AT_RULE.test(name)) {
 					let pos = end;
 					pos = walkCssTokens.eatWhitespaceAndComments(input, pos);
 					if (pos === input.length) return pos;
@@ -495,8 +509,7 @@ class CssParser extends Parser {
 					mode = CSS_MODE_IN_LOCAL_RULE;
 					modeNestingLevel = 1;
 					return pos + 1;
-				}
-				if (name === "@media" || name === "@supports") {
+				} else if (name === "@media" || name === "@supports") {
 					let pos = end;
 					const [newPos] = eatText(input, pos, eatAtRuleNested);
 					pos = newPos;
@@ -566,6 +579,7 @@ class CssParser extends Parser {
 			leftCurlyBracket: (input, start, end) => {
 				switch (mode) {
 					case CSS_MODE_TOP_LEVEL:
+						allowImportAtRule = false;
 						mode = isTopLevelLocal()
 							? CSS_MODE_IN_LOCAL_RULE
 							: CSS_MODE_IN_RULE;

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -260,10 +260,16 @@ class CssParser extends Parser {
 		const parseExports = (input, pos) => {
 			pos = walkCssTokens.eatWhitespaceAndComments(input, pos);
 			const cc = input.charCodeAt(pos);
-			if (cc !== CC_LEFT_CURLY)
-				throw new Error(
-					`Unexpected ${input[pos]} at ${pos} during parsing of ':export' (expected '{')`
+			if (cc !== CC_LEFT_CURLY) {
+				this._emitWarning(
+					state,
+					`Unexpected '${input[pos]}' at ${pos} during parsing of ':export' (expected '{')`,
+					locConverter,
+					pos,
+					pos
 				);
+				return pos;
+			}
 			pos++;
 			pos = walkCssTokens.eatWhitespaceAndComments(input, pos);
 			for (;;) {
@@ -275,9 +281,14 @@ class CssParser extends Parser {
 				[pos, name] = eatText(input, pos, eatExportName);
 				if (pos === input.length) return pos;
 				if (input.charCodeAt(pos) !== CC_COLON) {
-					throw new Error(
-						`Unexpected ${input[pos]} at ${pos} during parsing of export name in ':export' (expected ':')`
+					this._emitWarning(
+						state,
+						`Unexpected '${input[pos]}' at ${pos} during parsing of export name in ':export' (expected ':')`,
+						locConverter,
+						start,
+						pos
 					);
+					return pos;
 				}
 				pos++;
 				if (pos === input.length) return pos;
@@ -293,9 +304,14 @@ class CssParser extends Parser {
 					pos = walkCssTokens.eatWhitespaceAndComments(input, pos);
 					if (pos === input.length) return pos;
 				} else if (cc !== CC_RIGHT_CURLY) {
-					throw new Error(
-						`Unexpected ${input[pos]} at ${pos} during parsing of export value in ':export' (expected ';' or '}')`
+					this._emitWarning(
+						state,
+						`Unexpected '${input[pos]}' at ${pos} during parsing of export value in ':export' (expected ';' or '}')`,
+						locConverter,
+						start,
+						pos
 					);
+					return pos;
 				}
 				const dep = new CssExportDependency(name, value);
 				const { line: sl, column: sc } = locConverter.get(start);
@@ -526,9 +542,14 @@ class CssParser extends Parser {
 					pos = newPos;
 					if (pos === input.length) return pos;
 					if (input.charCodeAt(pos) !== CC_LEFT_CURLY) {
-						throw new Error(
-							`Unexpected ${input[pos]} at ${pos} during parsing of @media or @supports (expected '{')`
+						this._emitWarning(
+							state,
+							`Unexpected ${input[pos]} at ${pos} during parsing of @media or @supports (expected '{')`,
+							locConverter,
+							start,
+							pos
 						);
+						return pos;
 					}
 					return pos + 1;
 				}
@@ -536,13 +557,26 @@ class CssParser extends Parser {
 			},
 			semicolon: (input, start, end) => {
 				switch (mode) {
-					case CSS_MODE_AT_IMPORT_EXPECT_URL:
-						throw new Error(`Expected URL for @import at ${start}`);
+					case CSS_MODE_AT_IMPORT_EXPECT_URL: {
+						this._emitWarning(
+							state,
+							`Expected URL for @import at ${start}`,
+							locConverter,
+							start,
+							end
+						);
+						return end;
+					}
 					case CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA: {
 						if (modeData.url === undefined) {
-							throw new Error(
-								`Expected URL for @import at ${modeData.atRuleStart}`
+							this._emitWarning(
+								state,
+								`Expected URL for @import at ${modeData.atRuleStart}`,
+								locConverter,
+								modeData.atRuleStart,
+								modeData.lastPos
 							);
+							return end;
 						}
 						const semicolonPos = end;
 						const { line: sl, column: sc } = locConverter.get(

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -498,22 +498,29 @@ class CssParser extends Parser {
 					pos = walkCssTokens.eatWhitespaceAndComments(input, pos);
 					if (pos === input.length) return pos;
 					const [newPos, name] = eatText(input, pos, eatKeyframes);
+					if (newPos === input.length) return newPos;
+					if (input.charCodeAt(newPos) !== CC_LEFT_CURLY) {
+						this._emitWarning(
+							state,
+							`Unexpected '${input[newPos]}' at ${newPos} during parsing of @keyframes (expected '{')`,
+							locConverter,
+							start,
+							end
+						);
+
+						return newPos;
+					}
 					const { line: sl, column: sc } = locConverter.get(pos);
 					const { line: el, column: ec } = locConverter.get(newPos);
 					const dep = new CssLocalIdentifierDependency(name, [pos, newPos]);
 					dep.setLoc(sl, sc, el, ec);
 					module.addDependency(dep);
 					pos = newPos;
-					if (pos === input.length) return pos;
-					if (input.charCodeAt(pos) !== CC_LEFT_CURLY) {
-						throw new Error(
-							`Unexpected ${input[pos]} at ${pos} during parsing of @keyframes (expected '{')`
-						);
-					}
 					mode = CSS_MODE_IN_LOCAL_RULE;
 					modeNestingLevel = 1;
 					return pos + 1;
 				} else if (name === "@media" || name === "@supports") {
+					// TODO handle nested CSS syntax
 					let pos = end;
 					const [newPos] = eatText(input, pos, eatAtRuleNested);
 					pos = newPos;

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -5,7 +5,9 @@
 
 "use strict";
 
+const ModuleDependencyWarning = require("../ModuleDependencyWarning");
 const Parser = require("../Parser");
+const WebpackError = require("../WebpackError");
 const ConstDependency = require("../dependencies/ConstDependency");
 const CssExportDependency = require("../dependencies/CssExportDependency");
 const CssImportDependency = require("../dependencies/CssImportDependency");
@@ -14,8 +16,6 @@ const CssSelfLocalIdentifierDependency = require("../dependencies/CssSelfLocalId
 const CssUrlDependency = require("../dependencies/CssUrlDependency");
 const StaticExportsDependency = require("../dependencies/StaticExportsDependency");
 const walkCssTokens = require("./walkCssTokens");
-const WebpackError = require("../WebpackError");
-const ModuleDependencyWarning = require("../ModuleDependencyWarning");
 
 /** @typedef {import("../Parser").ParserState} ParserState */
 /** @typedef {import("../Parser").PreparsedAst} PreparsedAst */

--- a/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
+++ b/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
@@ -632,6 +632,46 @@ head{--webpack-main:https\\\\:\\\\/\\\\/test\\\\.cases\\\\/path\\\\/\\\\.\\\\.\\
 ]
 `;
 
+exports[`ConfigCacheTestCases css pure-css exported tests should compile 1`] = `
+Array [
+  ".class {
+	color: red;
+	background: var(--color);
+}
+
+@keyframes test {
+	0% {
+		color: red;
+	}
+	100% {
+		color: blue;
+	}
+}
+
+:local(.class) {
+	color: red;
+}
+
+:local .class {
+	color: green;
+}
+
+:global(.class) {
+	color: blue;
+}
+
+:global .class {
+	color: white;
+}
+
+:export {
+	foo: bar;
+}
+
+head{--webpack-main:\\\\.\\\\/style\\\\.css;}",
+]
+`;
+
 exports[`ConfigCacheTestCases css urls exported tests should be able to handle styles in div.css 1`] = `
 Object {
   "--foo": " url(img.09a1a1112c577c279435.png)",

--- a/test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -632,6 +632,46 @@ head{--webpack-main:https\\\\:\\\\/\\\\/test\\\\.cases\\\\/path\\\\/\\\\.\\\\.\\
 ]
 `;
 
+exports[`ConfigTestCases css pure-css exported tests should compile 1`] = `
+Array [
+  ".class {
+	color: red;
+	background: var(--color);
+}
+
+@keyframes test {
+	0% {
+		color: red;
+	}
+	100% {
+		color: blue;
+	}
+}
+
+:local(.class) {
+	color: red;
+}
+
+:local .class {
+	color: green;
+}
+
+:global(.class) {
+	color: blue;
+}
+
+:global .class {
+	color: white;
+}
+
+:export {
+	foo: bar;
+}
+
+head{--webpack-main:\\\\.\\\\/style\\\\.css;}",
+]
+`;
+
 exports[`ConfigTestCases css urls exported tests should be able to handle styles in div.css 1`] = `
 Object {
   "--foo": " url(img.09a1a1112c577c279435.png)",

--- a/test/configCases/css/css-import-at-middle/a.css
+++ b/test/configCases/css/css-import-at-middle/a.css
@@ -1,0 +1,3 @@
+body {
+	background: red;
+}

--- a/test/configCases/css/css-import-at-middle/b.css
+++ b/test/configCases/css/css-import-at-middle/b.css
@@ -1,0 +1,10 @@
+body {
+	background: blue;
+}
+
+@import "./a.css";
+@import url(./a.css);
+
+body {
+	color: green;
+}

--- a/test/configCases/css/css-import-at-middle/c.css
+++ b/test/configCases/css/css-import-at-middle/c.css
@@ -1,0 +1,9 @@
+body {
+	background: red;
+}
+@import "./a.css";
+@import "./b.css";
+
+body {
+	color: yellow;
+}

--- a/test/configCases/css/css-import-at-middle/index.js
+++ b/test/configCases/css/css-import-at-middle/index.js
@@ -2,7 +2,6 @@ import "./style.css";
 
 it("should compile with warnings", done => {
 	const style = getComputedStyle(document.body);
-	console.log(style)
 	expect(style.getPropertyValue("background")).toBe(" blue");
 	expect(style.getPropertyValue("color")).toBe(" green");
 

--- a/test/configCases/css/css-import-at-middle/index.js
+++ b/test/configCases/css/css-import-at-middle/index.js
@@ -1,0 +1,10 @@
+import "./style.css";
+
+it("should compile with warnings", done => {
+	const style = getComputedStyle(document.body);
+	console.log(style)
+	expect(style.getPropertyValue("background")).toBe(" blue");
+	expect(style.getPropertyValue("color")).toBe(" green");
+
+	done();
+});

--- a/test/configCases/css/css-import-at-middle/style.css
+++ b/test/configCases/css/css-import-at-middle/style.css
@@ -1,0 +1,2 @@
+@import "./c.css";
+@import "./b.css";

--- a/test/configCases/css/css-import-at-middle/test.config.js
+++ b/test/configCases/css/css-import-at-middle/test.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	moduleScope(scope) {
+		const link = scope.window.document.createElement("link");
+		link.rel = "stylesheet";
+		link.href = "bundle0.css";
+		scope.window.document.head.appendChild(link);
+	}
+};

--- a/test/configCases/css/css-import-at-middle/warnings.js
+++ b/test/configCases/css/css-import-at-middle/warnings.js
@@ -1,0 +1,6 @@
+module.exports = [
+	/Any @import rules must precede all other rules/,
+	/Any @import rules must precede all other rules/,
+	/Any @import rules must precede all other rules/,
+	/Any @import rules must precede all other rules/
+];

--- a/test/configCases/css/css-import-at-middle/webpack.config.js
+++ b/test/configCases/css/css-import-at-middle/webpack.config.js
@@ -1,0 +1,8 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	experiments: {
+		css: true
+	}
+};

--- a/test/configCases/css/css-modules-broken-keyframes/index.js
+++ b/test/configCases/css/css-modules-broken-keyframes/index.js
@@ -1,0 +1,17 @@
+const prod = process.env.NODE_ENV === "production";
+
+it("should allow to create css modules", done => {
+	prod
+		? __non_webpack_require__("./249.bundle0.js")
+		: __non_webpack_require__("./use-style_js.bundle0.js");
+	import("./use-style.js").then(({ default: x }) => {
+		try {
+			expect(x).toEqual({
+				class: prod ? "my-app-491-S" : "./style.module.css-class",
+			});
+		} catch (e) {
+			return done(e);
+		}
+		done();
+	}, done);
+});

--- a/test/configCases/css/css-modules-broken-keyframes/style.module.css
+++ b/test/configCases/css/css-modules-broken-keyframes/style.module.css
@@ -1,0 +1,15 @@
+@keyframes broken;
+
+.class {
+	color: red;
+}
+
+@keyframes/*test*/animationName/*test*/{
+	0% {
+		background: white;
+	}
+	100% {
+		background: red;
+	}
+}
+

--- a/test/configCases/css/css-modules-broken-keyframes/use-style.js
+++ b/test/configCases/css/css-modules-broken-keyframes/use-style.js
@@ -1,0 +1,5 @@
+import * as style from "./style.module.css";
+
+export default {
+	class: style.class,
+};

--- a/test/configCases/css/css-modules-broken-keyframes/warnings.js
+++ b/test/configCases/css/css-modules-broken-keyframes/warnings.js
@@ -1,0 +1,3 @@
+module.exports = [
+	/Unexpected ';' at 17 during parsing of @keyframes \(expected '{'\)/
+];

--- a/test/configCases/css/css-modules-broken-keyframes/webpack.config.js
+++ b/test/configCases/css/css-modules-broken-keyframes/webpack.config.js
@@ -1,7 +1,7 @@
 const webpack = require("../../../../");
 const path = require("path");
 
-/** @type {function(any, any): import("../../../../").Configuration[]} */
+/** @type {function(any, any): import("../../../../").Configuration} */
 module.exports = (env, { testPath }) => ({
 	target: "web",
 	mode: "production",

--- a/test/configCases/css/css-modules-broken-keyframes/webpack.config.js
+++ b/test/configCases/css/css-modules-broken-keyframes/webpack.config.js
@@ -1,0 +1,27 @@
+const webpack = require("../../../../");
+const path = require("path");
+
+/** @type {function(any, any): import("../../../../").Configuration[]} */
+module.exports = (env, { testPath }) => ({
+	target: "web",
+	mode: "production",
+	output: {
+		uniqueName: "my-app"
+	},
+	experiments: {
+		css: true
+	},
+	plugins: [
+		new webpack.ids.DeterministicModuleIdsPlugin({
+			maxLength: 3,
+			failOnConflict: true,
+			fixedLength: true,
+			test: m => m.type.startsWith("css")
+		}),
+		new webpack.experiments.ids.SyncModuleIdsPlugin({
+			test: m => m.type.startsWith("css"),
+			path: path.resolve(testPath, "module-ids.json"),
+			mode: "create"
+		})
+	]
+});

--- a/test/configCases/css/namespace/index.js
+++ b/test/configCases/css/namespace/index.js
@@ -1,0 +1,7 @@
+import "./style.css";
+
+it("should compile with warning", done => {
+	const style = getComputedStyle(document.body);
+	expect(style.getPropertyValue("background")).toBe(" red");
+	done();
+});

--- a/test/configCases/css/namespace/style.css
+++ b/test/configCases/css/namespace/style.css
@@ -1,0 +1,5 @@
+@namespace svg url('http://www.w3.org/2000/svg');
+
+body {
+	background: red;
+}

--- a/test/configCases/css/namespace/test.config.js
+++ b/test/configCases/css/namespace/test.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	moduleScope(scope) {
+		const link = scope.window.document.createElement("link");
+		link.rel = "stylesheet";
+		link.href = "bundle0.css";
+		scope.window.document.head.appendChild(link);
+	}
+};

--- a/test/configCases/css/namespace/warnings.js
+++ b/test/configCases/css/namespace/warnings.js
@@ -1,0 +1,1 @@
+module.exports = [/@namespace is not supported in bundled CSS/];

--- a/test/configCases/css/namespace/webpack.config.js
+++ b/test/configCases/css/namespace/webpack.config.js
@@ -1,0 +1,8 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	experiments: {
+		css: true
+	}
+};

--- a/test/configCases/css/pure-css/index.js
+++ b/test/configCases/css/pure-css/index.js
@@ -1,0 +1,14 @@
+import "./style.css";
+
+it("should compile", done => {
+	const links = document.getElementsByTagName("link");
+	const css = [];
+
+	// Skip first because import it by default
+	for (const link of links.slice(1)) {
+		css.push(link.sheet.css);
+	}
+
+	expect(css).toMatchSnapshot();
+	done();
+});

--- a/test/configCases/css/pure-css/style.css
+++ b/test/configCases/css/pure-css/style.css
@@ -1,0 +1,33 @@
+.class {
+	color: red;
+	background: var(--color);
+}
+
+@keyframes test {
+	0% {
+		color: red;
+	}
+	100% {
+		color: blue;
+	}
+}
+
+:local(.class) {
+	color: red;
+}
+
+:local .class {
+	color: green;
+}
+
+:global(.class) {
+	color: blue;
+}
+
+:global .class {
+	color: white;
+}
+
+:export {
+	foo: bar;
+}

--- a/test/configCases/css/pure-css/test.config.js
+++ b/test/configCases/css/pure-css/test.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	moduleScope(scope) {
+		const link = scope.window.document.createElement("link");
+		link.rel = "stylesheet";
+		link.href = "bundle0.css";
+		scope.window.document.head.appendChild(link);
+	}
+};

--- a/test/configCases/css/pure-css/webpack.config.js
+++ b/test/configCases/css/pure-css/webpack.config.js
@@ -1,0 +1,20 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	module: {
+		rules: [
+			{
+				test: /\.css$/i,
+				type: "css/global",
+				resolve: {
+					fullySpecified: true,
+					preferRelative: true
+				}
+			}
+		]
+	},
+	experiments: {
+		css: true
+	}
+};


### PR DESCRIPTION
Here:
- error tolerance refactor for CSS parser, because in CSS spec eveyrthing is error tolerance and recoverable (esbuild does the same)
- fixes #16095 
- fix `@keyframs` logic - now we always rename it, it is wrong for `css/global` 
- added `TODO` for future nested CSS syntax

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4d54455</samp>

This pull request adds several new test cases and improves the error handling of the CssParser class for unsupported or invalid CSS syntax. It introduces a new `_emitWarning` method and uses the `WebpackError` and `ModuleDependencyWarning` classes to emit warnings instead of throwing errors. It also adds new files in the `test/configCases/css` folder that test the behavior of the CssParser for various CSS features, such as `@import`, `@keyframes`, and `@namespace` rules. It also updates the webpack configuration files for the test cases to enable the css experiment and set the appropriate target and mode.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4d54455</samp>

*  Add warning handling for invalid or unsupported CSS syntax in `CssParser.js` ([link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054R17-R18), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L125-R129), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054R143-R161), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054R185-R186), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L262-R272), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L277-R291), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L295-R314), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L363-R386), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054R398-R402), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L460-R502), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L477-R528), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L489-R539), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L505-R552), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L515-R579), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054R627))
*  Add test cases for CSS import rules in the middle of other rules in `css-import-at-middle` folder ([link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-8e58891d538698ebe9d2bcd82fcea2d42e8652cfe42e4f09940e03b90e9384f7R1-R3), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-dd65eca2967b7f1859868317f43f62fa0a1c663f8205b5b37b06e0f775c24c87R1-R10), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-36e4c64f25bfcdc53551d14fbeb6470e2b0a547d11e1129a607bb29bb913be5cR1-R9), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-b2fcbbac5b5229bc7a6f563486749db98f3397faf61e72b649844e69da2d7166R1-R10), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-c1921329cd05a90c29fefd24f4af6e9b90d350148f13b293bdf1c60ece0f06e6R1-R2), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-e48ac3889422a1b43db364dbc737d06dd7f338880a89d534185f28f813d6d511R1-R8), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-ef4688ff8cb16b6a9148e81a74870c846ba0d6b16ca70e2da8af7a624428cb33R1-R6), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-97b2835787d9e6f2aefc52d2a32fefe445926fb96f6d4532b4fa595e3663abd8R1-R8))
*  Add test cases for CSS modules with broken keyframes rules in `css-modules-broken-keyframes` folder ([link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-f6eeecef19ad4573a5c2353b35421cd952aa990240cfd1070da3a5e998c4723dR1-R17), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-3bf9dec5a46080e6632d5808ab2494ebe2ed91a3256ab729e3b0989929a0bcfaR1-R15), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-da55c1fa5c533c4f8f450aa312f94c210e3d73485494bb6ff8b1891e9040e616R1-R5), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-74bbeff102ca8a76796ea3139ded018eabf9c7966e56ac39a13b0b6bfd22da86R1-R3), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-22882ee5a27de5c757b67c0f7469b09d1bacd3ccd3e3f073977b3737719c132fR1-R27))
*  Add test cases for CSS namespace rules in `namespace` folder ([link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-c4fc29408fe679f493b344d4047ab2a206f113da87dee4460b647103861c1531R1-R7), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-9742a3e0f51ef620cf5c638a1c15618d3cdcea10351697a3721583591cb2e819R1-R5), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-330c1513fb33c9d819420a6921224cad1fd661d291b7bbd29c9955e2aea91257R1-R8), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-a4079718573cc16a66287a0221249eb7fe79f83496075bdd069a3ab84722c447R1), [link](https://github.com/webpack/webpack/pull/17118/files?diff=unified&w=0#diff-ee156ac3667a69be96578e0390a08fb1c171f906c3b9bb3368a41e2f14e8dc0eR1-R8))
