### PR TITLE
fix: support nesting in CSS modules and bug fixes

### DIFF
--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -157,7 +157,6 @@ class CssModulesPlugin {
 									return new CssParser();
 								case CSS_MODULE_TYPE_GLOBAL:
 									return new CssParser({
-										allowPseudoBlocks: false,
 										allowModeSwitch: false
 									});
 								case CSS_MODULE_TYPE_MODULE:

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -172,7 +172,7 @@ class CssParser extends Parser {
 		/** @type {Set<string>}*/
 		const declaredCssVariables = new Set();
 		/** @type {number} */
-		let mode = CSS_MODE_TOP_LEVEL;
+		let scope = CSS_MODE_TOP_LEVEL;
 		/** @type {number} */
 		let blockNestingLevel = 0;
 		/** @type {boolean} */
@@ -191,7 +191,7 @@ class CssParser extends Parser {
 		let isNestedSyntax = false;
 
 		/**
-		 * @returns {boolean} true, when in local mode
+		 * @returns {boolean} true, when in local scope
 		 */
 		const isLocalMode = () =>
 			modeData === "local" ||
@@ -382,15 +382,15 @@ class CssParser extends Parser {
 		const eatNameInVar = eatUntil(",)};/");
 		walkCssTokens(source, {
 			isSelector: () => {
-				return mode === CSS_MODE_TOP_LEVEL || isNestedSyntax;
+				return scope === CSS_MODE_TOP_LEVEL || isNestedSyntax;
 			},
 			url: (input, start, end, contentStart, contentEnd) => {
 				let value = normalizeUrl(input.slice(contentStart, contentEnd), false);
-				switch (mode) {
+				switch (scope) {
 					case CSS_MODE_AT_IMPORT_EXPECT_URL: {
 						importData.url = value;
 						importData.end = end;
-						mode = CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA;
+						scope = CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA;
 						break;
 					}
 					// Do not parse URLs in `supports(...)`
@@ -420,7 +420,7 @@ class CssParser extends Parser {
 				return end;
 			},
 			string: (input, start, end) => {
-				switch (mode) {
+				switch (scope) {
 					case CSS_MODE_AT_IMPORT_EXPECT_URL: {
 						importData.url = normalizeUrl(
 							input.slice(start + 1, end - 1),
@@ -432,7 +432,7 @@ class CssParser extends Parser {
 							balanced[balanced.length - 1][0] === "url";
 
 						if (!insideURLFunction) {
-							mode = CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA;
+							scope = CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA;
 						}
 						break;
 					}
@@ -475,7 +475,7 @@ class CssParser extends Parser {
 			atKeyword: (input, start, end) => {
 				const name = input.slice(start, end).toLowerCase();
 				if (name === "@namespace") {
-					mode = CSS_MODE_AT_NAMESPACE_INVALID;
+					scope = CSS_MODE_AT_NAMESPACE_INVALID;
 					this._emitWarning(
 						state,
 						"@namespace is not supported in bundled CSS",
@@ -486,7 +486,7 @@ class CssParser extends Parser {
 					return end;
 				} else if (name === "@import") {
 					if (!allowImportAtRule) {
-						mode = CSS_MODE_AT_IMPORT_INVALID;
+						scope = CSS_MODE_AT_IMPORT_INVALID;
 						this._emitWarning(
 							state,
 							"Any @import rules must precede all other rules",
@@ -497,7 +497,7 @@ class CssParser extends Parser {
 						return end;
 					}
 
-					mode = CSS_MODE_AT_IMPORT_EXPECT_URL;
+					scope = CSS_MODE_AT_IMPORT_EXPECT_URL;
 					importData = { start, end };
 				} else if (
 					isLocalMode() &&
@@ -579,12 +579,12 @@ class CssParser extends Parser {
 					return end;
 				} else {
 					modeData = undefined;
-					mode = CSS_MODE_IN_BLOCK;
+					scope = CSS_MODE_IN_BLOCK;
 				}
 				return end;
 			},
 			semicolon: (input, start, end) => {
-				switch (mode) {
+				switch (scope) {
 					case CSS_MODE_AT_IMPORT_EXPECT_URL: {
 						this._emitWarning(
 							state,
@@ -632,7 +632,7 @@ class CssParser extends Parser {
 						dep.setLoc(sl, sc, el, ec);
 						module.addDependency(dep);
 						importData = undefined;
-						mode = CSS_MODE_TOP_LEVEL;
+						scope = CSS_MODE_TOP_LEVEL;
 						break;
 					}
 					case CSS_MODE_IN_BLOCK: {
@@ -661,10 +661,10 @@ class CssParser extends Parser {
 				return end;
 			},
 			leftCurlyBracket: (input, start, end) => {
-				switch (mode) {
+				switch (scope) {
 					case CSS_MODE_TOP_LEVEL:
 						allowImportAtRule = false;
-						mode = CSS_MODE_IN_BLOCK;
+						scope = CSS_MODE_IN_BLOCK;
 						blockNestingLevel = 1;
 						break;
 					case CSS_MODE_IN_BLOCK:
@@ -674,14 +674,14 @@ class CssParser extends Parser {
 				return end;
 			},
 			rightCurlyBracket: (input, start, end) => {
-				switch (mode) {
+				switch (scope) {
 					case CSS_MODE_IN_BLOCK: {
 						if (isLocalMode()) {
 							processDeclarationValueDone(input);
 							inAnimationProperty = false;
 						}
 						if (--blockNestingLevel === 0) {
-							mode = CSS_MODE_TOP_LEVEL;
+							scope = CSS_MODE_TOP_LEVEL;
 							isNestedSyntax = false;
 							modeData = undefined;
 						}
@@ -691,7 +691,7 @@ class CssParser extends Parser {
 				return end;
 			},
 			identifier: (input, start, end) => {
-				switch (mode) {
+				switch (scope) {
 					case CSS_MODE_IN_BLOCK: {
 						if (isLocalMode()) {
 							// Handle only top level values and not inside functions
@@ -794,11 +794,11 @@ class CssParser extends Parser {
 					return end;
 				}
 
-				switch (mode) {
+				switch (scope) {
 					case CSS_MODE_AT_IMPORT_EXPECT_URL: {
 						if (last && last[0] === "url") {
 							importData.end = end;
-							mode = CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA;
+							scope = CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA;
 						}
 						break;
 					}
@@ -836,7 +836,7 @@ class CssParser extends Parser {
 						return end;
 					}
 
-					switch (mode) {
+					switch (scope) {
 						case CSS_MODE_TOP_LEVEL: {
 							if (name === ":export") {
 								const pos = parseExports(input, end);
@@ -874,7 +874,7 @@ class CssParser extends Parser {
 			},
 			comma: (input, start, end) => {
 				if (this.allowModeSwitch) {
-					switch (mode) {
+					switch (scope) {
 						case CSS_MODE_IN_BLOCK: {
 							if (isLocalMode()) {
 								processDeclarationValueDone(input);

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -188,7 +188,7 @@ class CssParser extends Parser {
 		/** @type {boolean} */
 		let inAnimationProperty = false;
 		/** @type {boolean} */
-		let isNestedSyntax = false;
+		let isNextRulePrelude = true;
 
 		/**
 		 * @param {string} input input
@@ -401,7 +401,7 @@ class CssParser extends Parser {
 		const eatNameInVar = eatUntil(",)};/");
 		walkCssTokens(source, {
 			isSelector: () => {
-				return scope === CSS_MODE_TOP_LEVEL || isNestedSyntax;
+				return isNextRulePrelude;
 			},
 			url: (input, start, end, contentStart, contentEnd) => {
 				let value = normalizeUrl(input.slice(contentStart, contentEnd), false);
@@ -546,7 +546,7 @@ class CssParser extends Parser {
 					pos = newPos;
 					modeData = "local";
 					blockNestingLevel = 1;
-					isNestedSyntax = true;
+					isNextRulePrelude = true;
 					return pos + 1;
 				} else if (isLocalMode() && name === "@property") {
 					let pos = end;
@@ -584,7 +584,7 @@ class CssParser extends Parser {
 					declaredCssVariables.add(name);
 					pos = propertyNameEnd;
 					modeData = "local";
-					isNestedSyntax = true;
+					isNextRulePrelude = true;
 					blockNestingLevel = 1;
 					return pos + 1;
 				} else if (
@@ -594,11 +594,11 @@ class CssParser extends Parser {
 					name === "@container"
 				) {
 					modeData = isLocalMode() ? "local" : "global";
-					isNestedSyntax = true;
+					isNextRulePrelude = true;
 					return end;
-				} else {
+				} else if (this.allowModeSwitch) {
 					modeData = undefined;
-					scope = CSS_MODE_IN_BLOCK;
+					isNextRulePrelude = false;
 				}
 				return end;
 			},
@@ -658,7 +658,7 @@ class CssParser extends Parser {
 						if (this.allowModeSwitch) {
 							processDeclarationValueDone(input);
 							inAnimationProperty = false;
-							isNestedSyntax = isNextNestedSyntax(input, end);
+							isNextRulePrelude = isNextNestedSyntax(input, end);
 						}
 						return end;
 					}
@@ -673,7 +673,7 @@ class CssParser extends Parser {
 						blockNestingLevel = 1;
 
 						if (this.allowModeSwitch) {
-							isNestedSyntax = isNextNestedSyntax(input, end);
+							isNextRulePrelude = isNextNestedSyntax(input, end);
 						}
 
 						break;
@@ -695,11 +695,11 @@ class CssParser extends Parser {
 							scope = CSS_MODE_TOP_LEVEL;
 
 							if (this.allowModeSwitch) {
-								isNestedSyntax = false;
+								isNextRulePrelude = true;
 								modeData = undefined;
 							}
 						} else if (this.allowModeSwitch) {
-							isNestedSyntax = isNextNestedSyntax(input, end);
+							isNextRulePrelude = isNextNestedSyntax(input, end);
 						}
 						break;
 					}

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -884,6 +884,9 @@ class CssParser extends Parser {
 			},
 			comma: (input, start, end) => {
 				if (this.allowModeSwitch) {
+					// Reset stack for `:global .class :local .class-other` selector after
+					modeData = undefined;
+
 					switch (scope) {
 						case CSS_MODE_IN_BLOCK: {
 							if (isLocalMode()) {
@@ -893,9 +896,6 @@ class CssParser extends Parser {
 							break;
 						}
 					}
-
-					// Reset stack for `:global .class :local .class-other` selector after
-					modeData = undefined;
 				}
 				return end;
 			}

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -306,9 +306,8 @@ class CssParser extends Parser {
 			return pos;
 		};
 		const eatPropertyName = eatUntil(":{};");
-		const processLocalDeclaration = (input, pos) => {
+		const processLocalDeclaration = (input, pos, end) => {
 			modeData = undefined;
-			const start = pos;
 			pos = walkCssTokens.eatWhitespaceAndComments(input, pos);
 			const propertyNameStart = pos;
 			const [propertyNameEnd, propertyName] = eatText(
@@ -316,7 +315,7 @@ class CssParser extends Parser {
 				pos,
 				eatPropertyName
 			);
-			if (input.charCodeAt(propertyNameEnd) !== CC_COLON) return start;
+			if (input.charCodeAt(propertyNameEnd) !== CC_COLON) return end;
 			pos = propertyNameEnd + 1;
 			if (propertyName.startsWith("--")) {
 				// CSS Variable
@@ -673,7 +672,7 @@ class CssParser extends Parser {
 						if (modeData === "animation") {
 							lastIdentifier = [start, end];
 						} else {
-							return processLocalDeclaration(input, start) + 1;
+							return processLocalDeclaration(input, start, end);
 						}
 						break;
 					}

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -631,12 +631,7 @@ class CssParser extends Parser {
 						processDeclarationValueDone(input, start);
 						return processLocalDeclaration(input, end);
 					}
-					case CSS_MODE_IN_RULE: {
-						return end;
-					}
 				}
-				mode = CSS_MODE_TOP_LEVEL;
-				modeData = undefined;
 				return end;
 			},
 			leftCurlyBracket: (input, start, end) => {

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -188,6 +188,8 @@ class CssParser extends Parser {
 		let importData = undefined;
 		/** @type {boolean} */
 		let inAnimationProperty = false;
+		/** @type {boolean} */
+		let isNestedSyntax = false;
 
 		/**
 		 * @returns {boolean} true, when in local mode
@@ -382,14 +384,7 @@ class CssParser extends Parser {
 		const eatNameInVar = eatUntil(",)};/");
 		walkCssTokens(source, {
 			isSelector: () => {
-				return (
-					mode !== CSS_MODE_IN_RULE &&
-					mode !== CSS_MODE_IN_LOCAL_RULE &&
-					mode !== CSS_MODE_AT_IMPORT_EXPECT_URL &&
-					mode !== CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA &&
-					mode !== CSS_MODE_AT_IMPORT_INVALID &&
-					mode !== CSS_MODE_AT_NAMESPACE_INVALID
-				);
+				return mode === CSS_MODE_TOP_LEVEL || isNestedSyntax;
 			},
 			url: (input, start, end, contentStart, contentEnd) => {
 				let value = normalizeUrl(input.slice(contentStart, contentEnd), false);
@@ -654,7 +649,21 @@ class CssParser extends Parser {
 					}
 					case CSS_MODE_IN_LOCAL_RULE: {
 						processDeclarationValueDone(input);
-						modeData = undefined;
+						// Handle nested syntax
+						let pos = walkCssTokens.eatWhitespaceAndComments(input, end);
+
+						// Nested block
+						if (input[pos] !== "}") {
+							// According spec only identifier can be used as a property name
+							const isIdentifier = walkCssTokens.isIdentStartCodePoint(
+								input.charCodeAt(pos)
+							);
+
+							if (!isIdentifier) {
+								isNestedSyntax = true;
+							}
+						}
+
 						inAnimationProperty = false;
 						return end;
 					}
@@ -684,6 +693,7 @@ class CssParser extends Parser {
 					case CSS_MODE_IN_RULE:
 						if (--modeNestingLevel === 0) {
 							mode = CSS_MODE_TOP_LEVEL;
+							isNestedSyntax = false;
 							modeData = undefined;
 						}
 						break;

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -184,6 +184,8 @@ class CssParser extends Parser {
 		let lastIdentifier = undefined;
 		/** @type [string, number, number][] */
 		let balanced = [];
+		/** @type {boolean} */
+		let inAnimationProperty = false;
 
 		/**
 		 * @returns {boolean} true, when in local mode
@@ -334,19 +336,22 @@ class CssParser extends Parser {
 				!propertyName.startsWith("--") &&
 				OPTIONALLY_VENDOR_PREFIXED_ANIMATION_PROPERTY.test(propertyName)
 			) {
-				modeData = "animation";
-				lastIdentifier = undefined;
+				inAnimationProperty = true;
 			}
 			return pos;
 		};
-		const processDeclarationValueDone = (input, pos) => {
-			if (modeData === "animation" && lastIdentifier) {
+		/**
+		 * @param {string} input input
+		 */
+		const processDeclarationValueDone = input => {
+			if (inAnimationProperty && lastIdentifier) {
 				const { line: sl, column: sc } = locConverter.get(lastIdentifier[0]);
 				const { line: el, column: ec } = locConverter.get(lastIdentifier[1]);
 				const name = input.slice(lastIdentifier[0], lastIdentifier[1]);
 				const dep = new CssSelfLocalIdentifierDependency(name, lastIdentifier);
 				dep.setLoc(sl, sc, el, ec);
 				module.addDependency(dep);
+				lastIdentifier = undefined;
 			}
 		};
 		const eatAtRuleNested = eatUntil("{};/");
@@ -631,8 +636,9 @@ class CssParser extends Parser {
 						break;
 					}
 					case CSS_MODE_IN_LOCAL_RULE: {
-						processDeclarationValueDone(input, start);
+						processDeclarationValueDone(input);
 						modeData = undefined;
+						inAnimationProperty = false;
 						return end;
 					}
 				}
@@ -655,7 +661,8 @@ class CssParser extends Parser {
 			rightCurlyBracket: (input, start, end) => {
 				switch (mode) {
 					case CSS_MODE_IN_LOCAL_RULE:
-						processDeclarationValueDone(input, start);
+						processDeclarationValueDone(input);
+						inAnimationProperty = false;
 					/* falls through */
 					case CSS_MODE_IN_RULE:
 						if (--modeNestingLevel === 0) {
@@ -670,7 +677,7 @@ class CssParser extends Parser {
 				switch (mode) {
 					case CSS_MODE_IN_LOCAL_RULE: {
 						// Handle only top level values and not inside functions
-						if (modeData === "animation" && balanced.length === 0) {
+						if (inAnimationProperty && balanced.length === 0) {
 							lastIdentifier = [start, end];
 						} else {
 							return processLocalDeclaration(input, start, end);
@@ -731,6 +738,11 @@ class CssParser extends Parser {
 
 				if (isLocalMode()) {
 					name = name.toLowerCase();
+
+					// Don't rename animation name when we have `var()` function
+					if (inAnimationProperty && balanced.length === 1) {
+						lastIdentifier = undefined;
+					}
 
 					if (name === "var") {
 						let pos = walkCssTokens.eatWhitespaceAndComments(input, end);
@@ -856,7 +868,7 @@ class CssParser extends Parser {
 							modeData = undefined;
 							break;
 						case CSS_MODE_IN_LOCAL_RULE:
-							processDeclarationValueDone(input, start);
+							processDeclarationValueDone(input);
 							break;
 					}
 				}

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -527,7 +527,7 @@ class CssParser extends Parser {
 					dep.setLoc(sl, sc, el, ec);
 					module.addDependency(dep);
 					pos = newPos;
-					mode = CSS_MODE_IN_LOCAL_RULE;
+					modeData = "local";
 					modeNestingLevel = 1;
 					return pos + 1;
 				} else if (isLocalMode() && name === "@property") {
@@ -565,7 +565,7 @@ class CssParser extends Parser {
 					module.addDependency(dep);
 					declaredCssVariables.add(name);
 					pos = propertyNameEnd;
-					mode = CSS_MODE_IN_LOCAL_RULE;
+					modeData = "local";
 					modeNestingLevel = 1;
 					return pos + 1;
 				} else if (
@@ -574,6 +574,7 @@ class CssParser extends Parser {
 					name === "@layer" ||
 					name === "@container"
 				) {
+					modeData = "local";
 					// TODO handle nested CSS syntax
 					let pos = end;
 					const [newPos] = eatText(input, pos, eatAtRuleNested);
@@ -789,6 +790,7 @@ class CssParser extends Parser {
 
 				if (
 					this.allowModeSwitch &&
+					popped &&
 					(popped[0] === ":local" || popped[0] === ":global")
 				) {
 					modeData = balanced[balanced.length - 1]

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -666,24 +666,6 @@ class CssParser extends Parser {
 				}
 				return end;
 			},
-			id: (input, start, end) => {
-				switch (mode) {
-					case CSS_MODE_TOP_LEVEL:
-						if (isTopLevelLocal()) {
-							const name = input.slice(start + 1, end);
-							const dep = new CssLocalIdentifierDependency(name, [
-								start + 1,
-								end
-							]);
-							const { line: sl, column: sc } = locConverter.get(start);
-							const { line: el, column: ec } = locConverter.get(end);
-							dep.setLoc(sl, sc, el, ec);
-							module.addDependency(dep);
-						}
-						break;
-				}
-				return end;
-			},
 			identifier: (input, start, end) => {
 				switch (mode) {
 					case CSS_MODE_IN_LOCAL_RULE:
@@ -717,6 +699,24 @@ class CssParser extends Parser {
 						}
 						break;
 					}
+				}
+				return end;
+			},
+			id: (input, start, end) => {
+				switch (mode) {
+					case CSS_MODE_TOP_LEVEL:
+						if (isTopLevelLocal()) {
+							const name = input.slice(start + 1, end);
+							const dep = new CssLocalIdentifierDependency(name, [
+								start + 1,
+								end
+							]);
+							const { line: sl, column: sc } = locConverter.get(start);
+							const { line: el, column: ec } = locConverter.get(end);
+							dep.setLoc(sl, sc, el, ec);
+							module.addDependency(dep);
+						}
+						break;
 				}
 				return end;
 			},

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -518,6 +518,44 @@ class CssParser extends Parser {
 					mode = CSS_MODE_IN_LOCAL_RULE;
 					modeNestingLevel = 1;
 					return pos + 1;
+				} else if (isTopLevelLocal() && name === "@property") {
+					let pos = end;
+					pos = walkCssTokens.eatWhitespaceAndComments(input, pos);
+					if (pos === input.length) return pos;
+					const propertyNameStart = pos;
+					const [propertyNameEnd, propertyName] = eatText(
+						input,
+						pos,
+						eatKeyframes
+					);
+					if (propertyNameEnd === input.length) return propertyNameEnd;
+					if (!propertyName.startsWith("--")) return propertyNameEnd;
+					if (input.charCodeAt(propertyNameEnd) !== CC_LEFT_CURLY) {
+						this._emitWarning(
+							state,
+							`Unexpected '${input[propertyNameEnd]}' at ${propertyNameEnd} during parsing of @property (expected '{')`,
+							locConverter,
+							start,
+							end
+						);
+
+						return propertyNameEnd;
+					}
+					const { line: sl, column: sc } = locConverter.get(pos);
+					const { line: el, column: ec } = locConverter.get(propertyNameEnd);
+					const name = propertyName.slice(2);
+					const dep = new CssLocalIdentifierDependency(
+						name,
+						[propertyNameStart, propertyNameEnd],
+						"--"
+					);
+					dep.setLoc(sl, sc, el, ec);
+					module.addDependency(dep);
+					declaredCssVariables.add(name);
+					pos = propertyNameEnd;
+					mode = CSS_MODE_IN_LOCAL_RULE;
+					modeNestingLevel = 1;
+					return pos + 1;
 				} else if (
 					name === "@media" ||
 					name === "@supports" ||

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -179,11 +179,14 @@ class CssParser extends Parser {
 		let modeNestingLevel = 0;
 		/** @type {boolean} */
 		let allowImportAtRule = true;
+		/** @type {"local" | "global" | undefined} */
 		let modeData = undefined;
 		/** @type {[number, number] | undefined} */
 		let lastIdentifier = undefined;
 		/** @type [string, number, number][] */
 		let balanced = [];
+		/** @type {undefined | { start: number, end: number, url?: string, media?: string, supports?: string, layer?: string  }} */
+		let importData = undefined;
 		/** @type {boolean} */
 		let inAnimationProperty = false;
 
@@ -308,6 +311,12 @@ class CssParser extends Parser {
 			return pos;
 		};
 		const eatPropertyName = eatUntil(":{};");
+		/**
+		 * @param {string} input input
+		 * @param {number} pos name start position
+		 * @param {number} end name end position
+		 * @returns {number} position after handling
+		 */
 		const processLocalDeclaration = (input, pos, end) => {
 			modeData = undefined;
 			pos = walkCssTokens.eatWhitespaceAndComments(input, pos);
@@ -372,8 +381,8 @@ class CssParser extends Parser {
 				let value = normalizeUrl(input.slice(contentStart, contentEnd), false);
 				switch (mode) {
 					case CSS_MODE_AT_IMPORT_EXPECT_URL: {
-						modeData.url = value;
-						modeData.lastPos = end;
+						importData.url = value;
+						importData.end = end;
 						mode = CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA;
 						break;
 					}
@@ -406,8 +415,11 @@ class CssParser extends Parser {
 			string: (input, start, end) => {
 				switch (mode) {
 					case CSS_MODE_AT_IMPORT_EXPECT_URL: {
-						modeData.url = normalizeUrl(input.slice(start + 1, end - 1), true);
-						modeData.lastPos = end;
+						importData.url = normalizeUrl(
+							input.slice(start + 1, end - 1),
+							true
+						);
+						importData.end = end;
 						const insideURLFunction =
 							balanced[balanced.length - 1] &&
 							balanced[balanced.length - 1][0] === "url";
@@ -479,14 +491,7 @@ class CssParser extends Parser {
 					}
 
 					mode = CSS_MODE_AT_IMPORT_EXPECT_URL;
-					modeData = {
-						atRuleStart: start,
-						lastPos: end,
-						url: undefined,
-						layer: undefined,
-						supports: undefined,
-						media: undefined
-					};
+					importData = { start, end };
 				} else if (
 					isLocalMode() &&
 					OPTIONALLY_VENDOR_PREFIXED_KEYFRAMES_AT_RULE.test(name)
@@ -594,44 +599,42 @@ class CssParser extends Parser {
 						return end;
 					}
 					case CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA: {
-						if (modeData.url === undefined) {
+						if (!importData.url === undefined) {
 							this._emitWarning(
 								state,
-								`Expected URL for @import at ${modeData.atRuleStart}`,
+								`Expected URL for @import at ${importData.start}`,
 								locConverter,
-								modeData.atRuleStart,
-								modeData.lastPos
+								importData.start,
+								importData.end
 							);
 							return end;
 						}
 						const semicolonPos = end;
 						end = walkCssTokens.eatWhiteLine(input, end + 1);
-						const { line: sl, column: sc } = locConverter.get(
-							modeData.atRuleStart
-						);
+						const { line: sl, column: sc } = locConverter.get(importData.start);
 						const { line: el, column: ec } = locConverter.get(end);
 						const pos = walkCssTokens.eatWhitespaceAndComments(
 							input,
-							modeData.lastPos
+							importData.end
 						);
 						// Prevent to consider comments as a part of media query
 						if (pos !== semicolonPos - 1) {
-							modeData.media = input
-								.slice(modeData.lastPos, semicolonPos - 1)
+							importData.media = input
+								.slice(importData.end, semicolonPos - 1)
 								.trim();
 						}
 						const dep = new CssImportDependency(
-							modeData.url.trim(),
-							[modeData.start, end],
-							modeData.layer,
-							modeData.supports,
-							modeData.media && modeData.media.length > 0
-								? modeData.media
+							importData.url.trim(),
+							[importData.start, end],
+							importData.layer,
+							importData.supports,
+							importData.media && importData.media.length > 0
+								? importData.media
 								: undefined
 						);
 						dep.setLoc(sl, sc, el, ec);
 						module.addDependency(dep);
-						modeData = undefined;
+						importData = undefined;
 						mode = CSS_MODE_TOP_LEVEL;
 						break;
 					}
@@ -686,8 +689,8 @@ class CssParser extends Parser {
 					}
 					case CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA: {
 						if (input.slice(start, end).toLowerCase() === "layer") {
-							modeData.layer = "";
-							modeData.lastPos = end;
+							importData.layer = "";
+							importData.end = end;
 						}
 						break;
 					}
@@ -781,7 +784,8 @@ class CssParser extends Parser {
 							(popped[0] === ":local" || popped[0] === ":global")
 						) {
 							modeData = balanced[balanced.length - 1]
-								? balanced[balanced.length - 1][0]
+								? /** @type {"local" | "global"} */
+								  (balanced[balanced.length - 1][0])
 								: undefined;
 							const dep = new ConstDependency("", [start, end]);
 							module.addPresentationalDependency(dep);
@@ -790,18 +794,18 @@ class CssParser extends Parser {
 					}
 					case CSS_MODE_AT_IMPORT_EXPECT_URL: {
 						if (last && last[0] === "url") {
-							modeData.lastPos = end;
+							importData.end = end;
 							mode = CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA;
 						}
 						break;
 					}
 					case CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA: {
 						if (last && last[0].toLowerCase() === "layer") {
-							modeData.layer = input.slice(last[2], end - 1).trim();
-							modeData.lastPos = end;
+							importData.layer = input.slice(last[2], end - 1).trim();
+							importData.end = end;
 						} else if (last && last[0].toLowerCase() === "supports") {
-							modeData.supports = input.slice(last[2], end - 1).trim();
-							modeData.lastPos = end;
+							importData.supports = input.slice(last[2], end - 1).trim();
+							importData.end = end;
 						}
 						break;
 					}

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -185,7 +185,10 @@ class CssParser extends Parser {
 		/** @type [string, number, number][] */
 		let balanced = [];
 
-		const isTopLevelLocal = () =>
+		/**
+		 * @returns {boolean} true, when in local mode
+		 */
+		const isLocalMode = () =>
 			modeData === "local" ||
 			(this.defaultMode === "local" && modeData === undefined);
 		const eatUntil = chars => {
@@ -480,7 +483,7 @@ class CssParser extends Parser {
 						media: undefined
 					};
 				} else if (
-					isTopLevelLocal() &&
+					isLocalMode() &&
 					OPTIONALLY_VENDOR_PREFIXED_KEYFRAMES_AT_RULE.test(name)
 				) {
 					let pos = end;
@@ -508,7 +511,7 @@ class CssParser extends Parser {
 					mode = CSS_MODE_IN_LOCAL_RULE;
 					modeNestingLevel = 1;
 					return pos + 1;
-				} else if (isTopLevelLocal() && name === "@property") {
+				} else if (isLocalMode() && name === "@property") {
 					let pos = end;
 					pos = walkCssTokens.eatWhitespaceAndComments(input, pos);
 					if (pos === input.length) return pos;
@@ -638,9 +641,7 @@ class CssParser extends Parser {
 				switch (mode) {
 					case CSS_MODE_TOP_LEVEL:
 						allowImportAtRule = false;
-						mode = isTopLevelLocal()
-							? CSS_MODE_IN_LOCAL_RULE
-							: CSS_MODE_IN_RULE;
+						mode = isLocalMode() ? CSS_MODE_IN_LOCAL_RULE : CSS_MODE_IN_RULE;
 						modeNestingLevel = 1;
 						if (mode === CSS_MODE_IN_LOCAL_RULE)
 							return processLocalDeclaration(input, end);
@@ -686,7 +687,7 @@ class CssParser extends Parser {
 			class: (input, start, end) => {
 				switch (mode) {
 					case CSS_MODE_TOP_LEVEL: {
-						if (isTopLevelLocal()) {
+						if (isLocalMode()) {
 							const name = input.slice(start + 1, end);
 							const dep = new CssLocalIdentifierDependency(name, [
 								start + 1,
@@ -705,7 +706,7 @@ class CssParser extends Parser {
 			id: (input, start, end) => {
 				switch (mode) {
 					case CSS_MODE_TOP_LEVEL:
-						if (isTopLevelLocal()) {
+						if (isLocalMode()) {
 							const name = input.slice(start + 1, end);
 							const dep = new CssLocalIdentifierDependency(name, [
 								start + 1,

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -829,12 +829,18 @@ class CssParser extends Parser {
 
 					if (name === ":global") {
 						modeData = "global";
+						// Eat extra whitespace and comments
+						end = walkCssTokens.eatWhitespace(input, end);
 						const dep = new ConstDependency("", [start, end]);
 						module.addPresentationalDependency(dep);
+						return end;
 					} else if (name === ":local") {
 						modeData = "local";
+						// Eat extra whitespace and comments
+						end = walkCssTokens.eatWhitespace(input, end);
 						const dep = new ConstDependency("", [start, end]);
 						module.addPresentationalDependency(dep);
+						return end;
 					}
 
 					switch (mode) {

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -662,11 +662,28 @@ class CssParser extends Parser {
 			},
 			leftCurlyBracket: (input, start, end) => {
 				switch (scope) {
-					case CSS_MODE_TOP_LEVEL:
+					case CSS_MODE_TOP_LEVEL: {
 						allowImportAtRule = false;
 						scope = CSS_MODE_IN_BLOCK;
 						blockNestingLevel = 1;
+
+						// Handle nested syntax
+						const pos = walkCssTokens.eatWhitespaceAndComments(input, end);
+
+						// Nested block
+						if (input[pos] !== "}") {
+							// According spec only identifier can be used as a property name
+							const isIdentifier = walkCssTokens.isIdentStartCodePoint(
+								input.charCodeAt(pos)
+							);
+
+							if (!isIdentifier) {
+								isNestedSyntax = true;
+							}
+						}
+
 						break;
+					}
 					case CSS_MODE_IN_BLOCK:
 						blockNestingLevel++;
 						break;

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -169,10 +169,9 @@ class CssParser extends Parser {
 		}
 
 		const module = state.module;
-
-		const declaredCssVariables = new Set();
-
 		const locConverter = new LocConverter(source);
+		/** @type {Set<string>}*/
+		const declaredCssVariables = new Set();
 		/** @type {number} */
 		let mode = CSS_MODE_TOP_LEVEL;
 		/** @type {number} */
@@ -196,6 +195,10 @@ class CssParser extends Parser {
 		const isLocalMode = () =>
 			modeData === "local" ||
 			(this.defaultMode === "local" && modeData === undefined);
+		/**
+		 * @param {string} chars characters
+		 * @returns {(input: string, pos: number) => number} function to eat characters
+		 */
 		const eatUntil = chars => {
 			const charCodes = Array.from({ length: chars.length }, (_, i) =>
 				chars.charCodeAt(i)
@@ -216,6 +219,12 @@ class CssParser extends Parser {
 				}
 			};
 		};
+		/**
+		 * @param {string} input input
+		 * @param {number} pos start position
+		 * @param {(input: string, pos: number) => number} eater eater
+		 * @returns {[number,string]} new position and text
+		 */
 		const eatText = (input, pos, eater) => {
 			let text = "";
 			for (;;) {
@@ -243,6 +252,11 @@ class CssParser extends Parser {
 		};
 		const eatExportName = eatUntil(":};/");
 		const eatExportValue = eatUntil("};/");
+		/**
+		 * @param {string} input input
+		 * @param {number} pos start position
+		 * @returns {number} position after parse
+		 */
 		const parseExports = (input, pos) => {
 			pos = walkCssTokens.eatWhitespaceAndComments(input, pos);
 			const cc = input.charCodeAt(pos);

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -191,6 +191,25 @@ class CssParser extends Parser {
 		let isNestedSyntax = false;
 
 		/**
+		 * @param {string} input input
+		 * @param {number} pos position
+		 * @returns {boolean} true, when next is nested syntax
+		 */
+		const isNextNestedSyntax = (input, pos) => {
+			pos = walkCssTokens.eatWhitespaceAndComments(input, pos);
+
+			if (input[pos] === "}") {
+				return false;
+			}
+
+			// According spec only identifier can be used as a property name
+			const isIdentifier = walkCssTokens.isIdentStartCodePoint(
+				input.charCodeAt(pos)
+			);
+
+			return !isIdentifier;
+		};
+		/**
 		 * @returns {boolean} true, when in local scope
 		 */
 		const isLocalMode = () =>
@@ -636,24 +655,10 @@ class CssParser extends Parser {
 						break;
 					}
 					case CSS_MODE_IN_BLOCK: {
-						processDeclarationValueDone(input);
-						inAnimationProperty = false;
-
-						if (isLocalMode()) {
-							// Handle nested syntax
-							let pos = walkCssTokens.eatWhitespaceAndComments(input, end);
-
-							// Nested block
-							if (input[pos] !== "}") {
-								// According spec only identifier can be used as a property name
-								const isIdentifier = walkCssTokens.isIdentStartCodePoint(
-									input.charCodeAt(pos)
-								);
-
-								if (!isIdentifier) {
-									isNestedSyntax = true;
-								}
-							}
+						if (this.allowModeSwitch) {
+							processDeclarationValueDone(input);
+							inAnimationProperty = false;
+							isNestedSyntax = isNextNestedSyntax(input, end);
 						}
 						return end;
 					}
@@ -667,19 +672,8 @@ class CssParser extends Parser {
 						scope = CSS_MODE_IN_BLOCK;
 						blockNestingLevel = 1;
 
-						// Handle nested syntax
-						const pos = walkCssTokens.eatWhitespaceAndComments(input, end);
-
-						// Nested block
-						if (input[pos] !== "}") {
-							// According spec only identifier can be used as a property name
-							const isIdentifier = walkCssTokens.isIdentStartCodePoint(
-								input.charCodeAt(pos)
-							);
-
-							if (!isIdentifier) {
-								isNestedSyntax = true;
-							}
+						if (this.allowModeSwitch) {
+							isNestedSyntax = isNextNestedSyntax(input, end);
 						}
 
 						break;
@@ -699,8 +693,13 @@ class CssParser extends Parser {
 						}
 						if (--blockNestingLevel === 0) {
 							scope = CSS_MODE_TOP_LEVEL;
-							isNestedSyntax = false;
-							modeData = undefined;
+
+							if (this.allowModeSwitch) {
+								isNestedSyntax = false;
+								modeData = undefined;
+							}
+						} else if (this.allowModeSwitch) {
+							isNestedSyntax = isNextNestedSyntax(input, end);
 						}
 						break;
 					}
@@ -901,7 +900,7 @@ class CssParser extends Parser {
 						}
 					}
 
-					// Reset stack for `:global .class :local .class-other` selector after `,`
+					// Reset stack for `:global .class :local .class-other` selector after
 					modeData = undefined;
 				}
 				return end;

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -722,39 +722,25 @@ class CssParser extends Parser {
 				return end;
 			},
 			class: (input, start, end) => {
-				switch (mode) {
-					case CSS_MODE_TOP_LEVEL: {
-						if (isLocalMode()) {
-							const name = input.slice(start + 1, end);
-							const dep = new CssLocalIdentifierDependency(name, [
-								start + 1,
-								end
-							]);
-							const { line: sl, column: sc } = locConverter.get(start);
-							const { line: el, column: ec } = locConverter.get(end);
-							dep.setLoc(sl, sc, el, ec);
-							module.addDependency(dep);
-						}
-						break;
-					}
+				if (isLocalMode()) {
+					const name = input.slice(start + 1, end);
+					const dep = new CssLocalIdentifierDependency(name, [start + 1, end]);
+					const { line: sl, column: sc } = locConverter.get(start);
+					const { line: el, column: ec } = locConverter.get(end);
+					dep.setLoc(sl, sc, el, ec);
+					module.addDependency(dep);
 				}
+
 				return end;
 			},
 			id: (input, start, end) => {
-				switch (mode) {
-					case CSS_MODE_TOP_LEVEL:
-						if (isLocalMode()) {
-							const name = input.slice(start + 1, end);
-							const dep = new CssLocalIdentifierDependency(name, [
-								start + 1,
-								end
-							]);
-							const { line: sl, column: sc } = locConverter.get(start);
-							const { line: el, column: ec } = locConverter.get(end);
-							dep.setLoc(sl, sc, el, ec);
-							module.addDependency(dep);
-						}
-						break;
+				if (isLocalMode()) {
+					const name = input.slice(start + 1, end);
+					const dep = new CssLocalIdentifierDependency(name, [start + 1, end]);
+					const { line: sl, column: sc } = locConverter.get(start);
+					const { line: el, column: ec } = locConverter.get(end);
+					dep.setLoc(sl, sc, el, ec);
+					module.addDependency(dep);
 				}
 				return end;
 			},
@@ -801,21 +787,21 @@ class CssParser extends Parser {
 				const last = balanced[balanced.length - 1];
 				const popped = balanced.pop();
 
+				if (
+					this.allowModeSwitch &&
+					(popped[0] === ":local" || popped[0] === ":global")
+				) {
+					modeData = balanced[balanced.length - 1]
+						? /** @type {"local" | "global"} */
+						  (balanced[balanced.length - 1][0])
+						: undefined;
+					const dep = new ConstDependency("", [start, end]);
+					module.addPresentationalDependency(dep);
+
+					return end;
+				}
+
 				switch (mode) {
-					case CSS_MODE_TOP_LEVEL: {
-						if (
-							this.allowModeSwitch &&
-							(popped[0] === ":local" || popped[0] === ":global")
-						) {
-							modeData = balanced[balanced.length - 1]
-								? /** @type {"local" | "global"} */
-								  (balanced[balanced.length - 1][0])
-								: undefined;
-							const dep = new ConstDependency("", [start, end]);
-							module.addPresentationalDependency(dep);
-						}
-						break;
-					}
 					case CSS_MODE_AT_IMPORT_EXPECT_URL: {
 						if (last && last[0] === "url") {
 							importData.end = end;
@@ -839,19 +825,21 @@ class CssParser extends Parser {
 			},
 			pseudoClass: (input, start, end) => {
 				if (this.allowModeSwitch) {
+					const name = input.slice(start, end).toLowerCase();
+
+					if (name === ":global") {
+						modeData = "global";
+						const dep = new ConstDependency("", [start, end]);
+						module.addPresentationalDependency(dep);
+					} else if (name === ":local") {
+						modeData = "local";
+						const dep = new ConstDependency("", [start, end]);
+						module.addPresentationalDependency(dep);
+					}
+
 					switch (mode) {
 						case CSS_MODE_TOP_LEVEL: {
-							const name = input.slice(start, end).toLowerCase();
-
-							if (name === ":global") {
-								modeData = "global";
-								const dep = new ConstDependency("", [start, end]);
-								module.addPresentationalDependency(dep);
-							} else if (name === ":local") {
-								modeData = "local";
-								const dep = new ConstDependency("", [start, end]);
-								module.addPresentationalDependency(dep);
-							} else if (name === ":export") {
+							if (name === ":export") {
 								const pos = parseExports(input, end);
 								const dep = new ConstDependency("", [start, pos]);
 								module.addPresentationalDependency(dep);
@@ -861,6 +849,7 @@ class CssParser extends Parser {
 						}
 					}
 				}
+
 				return end;
 			},
 			pseudoFunction: (input, start, end) => {
@@ -869,32 +858,27 @@ class CssParser extends Parser {
 				balanced.push([name, start, end]);
 
 				if (this.allowModeSwitch) {
-					switch (mode) {
-						case CSS_MODE_TOP_LEVEL: {
-							name = name.toLowerCase();
+					name = name.toLowerCase();
 
-							if (name === ":global") {
-								modeData = "global";
-								const dep = new ConstDependency("", [start, end]);
-								module.addPresentationalDependency(dep);
-							} else if (name === ":local") {
-								modeData = "local";
-								const dep = new ConstDependency("", [start, end]);
-								module.addPresentationalDependency(dep);
-							}
-							break;
-						}
+					if (name === ":global") {
+						modeData = "global";
+						const dep = new ConstDependency("", [start, end]);
+						module.addPresentationalDependency(dep);
+					} else if (name === ":local") {
+						modeData = "local";
+						const dep = new ConstDependency("", [start, end]);
+						module.addPresentationalDependency(dep);
 					}
 				}
+
 				return end;
 			},
 			comma: (input, start, end) => {
 				if (this.allowModeSwitch) {
+					// Reset stack for `:global .class :local .class-other` selector after `,`
+					modeData = undefined;
+
 					switch (mode) {
-						case CSS_MODE_TOP_LEVEL:
-							// Reset stack for `:global .class :local .class-other` selector after `,`
-							modeData = undefined;
-							break;
 						case CSS_MODE_IN_LOCAL_RULE:
 							processDeclarationValueDone(input);
 							break;

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -128,13 +128,8 @@ const CSS_MODE_AT_IMPORT_INVALID = 5;
 const CSS_MODE_AT_NAMESPACE_INVALID = 6;
 
 class CssParser extends Parser {
-	constructor({
-		allowPseudoBlocks = true,
-		allowModeSwitch = true,
-		defaultMode = "global"
-	} = {}) {
+	constructor({ allowModeSwitch = true, defaultMode = "global" } = {}) {
 		super();
-		this.allowPseudoBlocks = allowPseudoBlocks;
 		this.allowModeSwitch = allowModeSwitch;
 		this.defaultMode = defaultMode;
 	}
@@ -189,7 +184,6 @@ class CssParser extends Parser {
 		let lastIdentifier = undefined;
 		/** @type [string, number, number][] */
 		let balanced = [];
-		const modeStack = [];
 
 		const isTopLevelLocal = () =>
 			modeData === "local" ||
@@ -762,29 +756,23 @@ class CssParser extends Parser {
 			leftParenthesis: (input, start, end) => {
 				balanced.push(["(", start, end]);
 
-				switch (mode) {
-					case CSS_MODE_TOP_LEVEL: {
-						modeStack.push(false);
-						break;
-					}
-				}
 				return end;
 			},
 			rightParenthesis: (input, start, end) => {
 				const last = balanced[balanced.length - 1];
-
-				balanced.pop();
+				const popped = balanced.pop();
 
 				switch (mode) {
 					case CSS_MODE_TOP_LEVEL: {
-						if (modeStack.length > 0) {
-							const newModeData = modeStack.pop();
-
-							if (newModeData !== false) {
-								modeData = newModeData;
-								const dep = new ConstDependency("", [start, end]);
-								module.addPresentationalDependency(dep);
-							}
+						if (
+							this.allowModeSwitch &&
+							(popped[0] === ":local" || popped[0] === ":global")
+						) {
+							modeData = balanced[balanced.length - 1]
+								? balanced[balanced.length - 1][0]
+								: undefined;
+							const dep = new ConstDependency("", [start, end]);
+							module.addPresentationalDependency(dep);
 						}
 						break;
 					}
@@ -846,12 +834,10 @@ class CssParser extends Parser {
 							name = name.toLowerCase();
 
 							if (name === ":global") {
-								modeStack.push(modeData);
 								modeData = "global";
 								const dep = new ConstDependency("", [start, end]);
 								module.addPresentationalDependency(dep);
 							} else if (name === ":local") {
-								modeStack.push(modeData);
 								modeData = "local";
 								const dep = new ConstDependency("", [start, end]);
 								module.addPresentationalDependency(dep);
@@ -863,15 +849,16 @@ class CssParser extends Parser {
 				return end;
 			},
 			comma: (input, start, end) => {
-				switch (mode) {
-					case CSS_MODE_TOP_LEVEL:
-						// Reset stack for `:global .class :local .class-other` selector after `,`
-						modeData = undefined;
-						modeStack.length = 0;
-						break;
-					case CSS_MODE_IN_LOCAL_RULE:
-						processDeclarationValueDone(input, start);
-						break;
+				if (this.allowModeSwitch) {
+					switch (mode) {
+						case CSS_MODE_TOP_LEVEL:
+							// Reset stack for `:global .class :local .class-other` selector after `,`
+							modeData = undefined;
+							break;
+						case CSS_MODE_IN_LOCAL_RULE:
+							processDeclarationValueDone(input, start);
+							break;
+					}
 				}
 				return end;
 			}

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -549,7 +549,8 @@ class CssParser extends Parser {
 				} else if (
 					name === "@media" ||
 					name === "@supports" ||
-					name === "@layer"
+					name === "@layer" ||
+					name === "@container"
 				) {
 					// TODO handle nested CSS syntax
 					let pos = end;
@@ -567,6 +568,8 @@ class CssParser extends Parser {
 						return pos;
 					}
 					return pos + 1;
+				} else {
+					mode = CSS_MODE_IN_RULE;
 				}
 				return end;
 			},

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -591,7 +591,7 @@ class CssParser extends Parser {
 					isNextRulePrelude = true;
 					return end;
 				} else if (this.allowModeSwitch) {
-					modeData = undefined;
+					modeData = "global";
 					isNextRulePrelude = false;
 				}
 				return end;
@@ -672,9 +672,14 @@ class CssParser extends Parser {
 
 						break;
 					}
-					case CSS_MODE_IN_BLOCK:
+					case CSS_MODE_IN_BLOCK: {
 						blockNestingLevel++;
+
+						if (this.allowModeSwitch) {
+							isNextRulePrelude = isNextNestedSyntax(input, end);
+						}
 						break;
+					}
 				}
 				return end;
 			},

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -560,7 +560,7 @@ class CssParser extends Parser {
 					if (input.charCodeAt(pos) !== CC_LEFT_CURLY) {
 						this._emitWarning(
 							state,
-							`Unexpected ${input[pos]} at ${pos} during parsing of @media, @supports or @layer (expected '{')`,
+							`Unexpected ${input[pos]} at ${pos} during parsing of @media, @supports, @layer or @container (expected '{')`,
 							locConverter,
 							start,
 							pos

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -519,7 +519,7 @@ class CssParser extends Parser {
 					scope = CSS_MODE_AT_IMPORT_EXPECT_URL;
 					importData = { start, end };
 				} else if (
-					isLocalMode() &&
+					this.allowModeSwitch &&
 					OPTIONALLY_VENDOR_PREFIXED_KEYFRAMES_AT_RULE.test(name)
 				) {
 					let pos = end;
@@ -544,11 +544,8 @@ class CssParser extends Parser {
 					dep.setLoc(sl, sc, el, ec);
 					module.addDependency(dep);
 					pos = newPos;
-					modeData = "local";
-					blockNestingLevel = 1;
-					isNextRulePrelude = true;
 					return pos + 1;
-				} else if (isLocalMode() && name === "@property") {
+				} else if (this.allowModeSwitch && name === "@property") {
 					let pos = end;
 					pos = walkCssTokens.eatWhitespaceAndComments(input, pos);
 					if (pos === input.length) return pos;
@@ -583,9 +580,6 @@ class CssParser extends Parser {
 					module.addDependency(dep);
 					declaredCssVariables.add(name);
 					pos = propertyNameEnd;
-					modeData = "local";
-					isNextRulePrelude = true;
-					blockNestingLevel = 1;
 					return pos + 1;
 				} else if (
 					name === "@media" ||

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -654,7 +654,7 @@ class CssParser extends Parser {
 							inAnimationProperty = false;
 							isNextRulePrelude = isNextNestedSyntax(input, end);
 						}
-						return end;
+						break;
 					}
 				}
 				return end;

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -518,7 +518,11 @@ class CssParser extends Parser {
 					mode = CSS_MODE_IN_LOCAL_RULE;
 					modeNestingLevel = 1;
 					return pos + 1;
-				} else if (name === "@media" || name === "@supports") {
+				} else if (
+					name === "@media" ||
+					name === "@supports" ||
+					name === "@layer"
+				) {
 					// TODO handle nested CSS syntax
 					let pos = end;
 					const [newPos] = eatText(input, pos, eatAtRuleNested);
@@ -527,7 +531,7 @@ class CssParser extends Parser {
 					if (input.charCodeAt(pos) !== CC_LEFT_CURLY) {
 						this._emitWarning(
 							state,
-							`Unexpected ${input[pos]} at ${pos} during parsing of @media or @supports (expected '{')`,
+							`Unexpected ${input[pos]} at ${pos} during parsing of @media, @supports or @layer (expected '{')`,
 							locConverter,
 							start,
 							pos

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -187,8 +187,6 @@ class CssParser extends Parser {
 		let modeData = undefined;
 		/** @type {[number, number] | undefined} */
 		let lastIdentifier = undefined;
-		/** @type {boolean} */
-		let awaitRightParenthesis = false;
 		/** @type [string, number, number][] */
 		let balanced = [];
 		const modeStack = [];
@@ -779,14 +777,14 @@ class CssParser extends Parser {
 
 				switch (mode) {
 					case CSS_MODE_TOP_LEVEL: {
-						if (awaitRightParenthesis) {
-							awaitRightParenthesis = false;
-						}
-						const newModeData = modeStack.pop();
-						if (newModeData !== false) {
-							modeData = newModeData;
-							const dep = new ConstDependency("", [start, end]);
-							module.addPresentationalDependency(dep);
+						if (modeStack.length > 0) {
+							const newModeData = modeStack.pop();
+
+							if (newModeData !== false) {
+								modeData = newModeData;
+								const dep = new ConstDependency("", [start, end]);
+								module.addPresentationalDependency(dep);
+							}
 						}
 						break;
 					}
@@ -816,6 +814,7 @@ class CssParser extends Parser {
 					switch (mode) {
 						case CSS_MODE_TOP_LEVEL: {
 							const name = input.slice(start, end).toLowerCase();
+
 							if (name === ":global") {
 								modeData = "global";
 								const dep = new ConstDependency("", [start, end]);
@@ -841,25 +840,24 @@ class CssParser extends Parser {
 
 				balanced.push([name, start, end]);
 
-				switch (mode) {
-					case CSS_MODE_TOP_LEVEL: {
-						name = name.toLowerCase();
+				if (this.allowModeSwitch) {
+					switch (mode) {
+						case CSS_MODE_TOP_LEVEL: {
+							name = name.toLowerCase();
 
-						if (this.allowModeSwitch && name === ":global") {
-							modeStack.push(modeData);
-							modeData = "global";
-							const dep = new ConstDependency("", [start, end]);
-							module.addPresentationalDependency(dep);
-						} else if (this.allowModeSwitch && name === ":local") {
-							modeStack.push(modeData);
-							modeData = "local";
-							const dep = new ConstDependency("", [start, end]);
-							module.addPresentationalDependency(dep);
-						} else {
-							awaitRightParenthesis = true;
-							modeStack.push(false);
+							if (name === ":global") {
+								modeStack.push(modeData);
+								modeData = "global";
+								const dep = new ConstDependency("", [start, end]);
+								module.addPresentationalDependency(dep);
+							} else if (name === ":local") {
+								modeStack.push(modeData);
+								modeData = "local";
+								const dep = new ConstDependency("", [start, end]);
+								module.addPresentationalDependency(dep);
+							}
+							break;
 						}
-						break;
 					}
 				}
 				return end;
@@ -867,10 +865,9 @@ class CssParser extends Parser {
 			comma: (input, start, end) => {
 				switch (mode) {
 					case CSS_MODE_TOP_LEVEL:
-						if (!awaitRightParenthesis) {
-							modeData = undefined;
-							modeStack.length = 0;
-						}
+						// Reset stack for `:global .class :local .class-other` selector after `,`
+						modeData = undefined;
+						modeStack.length = 0;
 						break;
 					case CSS_MODE_IN_LOCAL_RULE:
 						processDeclarationValueDone(input, start);

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -728,30 +728,28 @@ class CssParser extends Parser {
 
 				balanced.push([name, start, end]);
 
-				switch (mode) {
-					case CSS_MODE_IN_LOCAL_RULE: {
-						name = name.toLowerCase();
+				if (isLocalMode()) {
+					name = name.toLowerCase();
 
-						if (name === "var") {
-							let pos = walkCssTokens.eatWhitespaceAndComments(input, end);
-							if (pos === input.length) return pos;
-							const [newPos, name] = eatText(input, pos, eatNameInVar);
-							if (!name.startsWith("--")) return end;
-							const { line: sl, column: sc } = locConverter.get(pos);
-							const { line: el, column: ec } = locConverter.get(newPos);
-							const dep = new CssSelfLocalIdentifierDependency(
-								name.slice(2),
-								[pos, newPos],
-								"--",
-								declaredCssVariables
-							);
-							dep.setLoc(sl, sc, el, ec);
-							module.addDependency(dep);
-							return newPos;
-						}
-						break;
+					if (name === "var") {
+						let pos = walkCssTokens.eatWhitespaceAndComments(input, end);
+						if (pos === input.length) return pos;
+						const [newPos, name] = eatText(input, pos, eatNameInVar);
+						if (!name.startsWith("--")) return end;
+						const { line: sl, column: sc } = locConverter.get(pos);
+						const { line: el, column: ec } = locConverter.get(newPos);
+						const dep = new CssSelfLocalIdentifierDependency(
+							name.slice(2),
+							[pos, newPos],
+							"--",
+							declaredCssVariables
+						);
+						dep.setLoc(sl, sc, el, ec);
+						module.addDependency(dep);
+						return newPos;
 					}
 				}
+
 				return end;
 			},
 			leftParenthesis: (input, start, end) => {

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -185,8 +185,6 @@ class CssParser extends Parser {
 		/** @type {boolean} */
 		let allowImportAtRule = true;
 		let modeData = undefined;
-		/** @type {string | boolean | undefined} */
-		let singleClassSelector = undefined;
 		/** @type {[number, number] | undefined} */
 		let lastIdentifier = undefined;
 		/** @type {boolean} */
@@ -644,7 +642,6 @@ class CssParser extends Parser {
 				}
 				mode = CSS_MODE_TOP_LEVEL;
 				modeData = undefined;
-				singleClassSelector = undefined;
 				return end;
 			},
 			leftCurlyBracket: (input, start, end) => {
@@ -674,14 +671,12 @@ class CssParser extends Parser {
 						if (--modeNestingLevel === 0) {
 							mode = CSS_MODE_TOP_LEVEL;
 							modeData = undefined;
-							singleClassSelector = undefined;
 						}
 						break;
 				}
 				return end;
 			},
 			id: (input, start, end) => {
-				singleClassSelector = false;
 				switch (mode) {
 					case CSS_MODE_TOP_LEVEL:
 						if (isTopLevelLocal()) {
@@ -700,7 +695,6 @@ class CssParser extends Parser {
 				return end;
 			},
 			identifier: (input, start, end) => {
-				singleClassSelector = false;
 				switch (mode) {
 					case CSS_MODE_IN_LOCAL_RULE:
 						if (modeData === "animation") {
@@ -730,9 +724,6 @@ class CssParser extends Parser {
 							const { line: el, column: ec } = locConverter.get(end);
 							dep.setLoc(sl, sc, el, ec);
 							module.addDependency(dep);
-							if (singleClassSelector === undefined) singleClassSelector = name;
-						} else {
-							singleClassSelector = false;
 						}
 						break;
 					}
@@ -821,7 +812,6 @@ class CssParser extends Parser {
 				return end;
 			},
 			pseudoClass: (input, start, end) => {
-				singleClassSelector = false;
 				switch (mode) {
 					case CSS_MODE_TOP_LEVEL: {
 						const name = input.slice(start, end).toLowerCase();

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -120,12 +120,11 @@ class LocConverter {
 }
 
 const CSS_MODE_TOP_LEVEL = 0;
-const CSS_MODE_IN_RULE = 1;
-const CSS_MODE_IN_LOCAL_RULE = 2;
-const CSS_MODE_AT_IMPORT_EXPECT_URL = 3;
-const CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA = 4;
-const CSS_MODE_AT_IMPORT_INVALID = 5;
-const CSS_MODE_AT_NAMESPACE_INVALID = 6;
+const CSS_MODE_IN_BLOCK = 1;
+const CSS_MODE_AT_IMPORT_EXPECT_URL = 2;
+const CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA = 3;
+const CSS_MODE_AT_IMPORT_INVALID = 4;
+const CSS_MODE_AT_NAMESPACE_INVALID = 5;
 
 class CssParser extends Parser {
 	constructor({ allowModeSwitch = true, defaultMode = "global" } = {}) {
@@ -175,7 +174,7 @@ class CssParser extends Parser {
 		/** @type {number} */
 		let mode = CSS_MODE_TOP_LEVEL;
 		/** @type {number} */
-		let modeNestingLevel = 0;
+		let blockNestingLevel = 0;
 		/** @type {boolean} */
 		let allowImportAtRule = true;
 		/** @type {"local" | "global" | undefined} */
@@ -527,7 +526,7 @@ class CssParser extends Parser {
 					module.addDependency(dep);
 					pos = newPos;
 					modeData = "local";
-					modeNestingLevel = 1;
+					blockNestingLevel = 1;
 					isNestedSyntax = true;
 					return pos + 1;
 				} else if (isLocalMode() && name === "@property") {
@@ -567,7 +566,7 @@ class CssParser extends Parser {
 					pos = propertyNameEnd;
 					modeData = "local";
 					isNestedSyntax = true;
-					modeNestingLevel = 1;
+					blockNestingLevel = 1;
 					return pos + 1;
 				} else if (
 					name === "@media" ||
@@ -579,7 +578,8 @@ class CssParser extends Parser {
 					isNestedSyntax = true;
 					return end;
 				} else {
-					mode = CSS_MODE_IN_RULE;
+					modeData = undefined;
+					mode = CSS_MODE_IN_BLOCK;
 				}
 				return end;
 			},
@@ -635,24 +635,26 @@ class CssParser extends Parser {
 						mode = CSS_MODE_TOP_LEVEL;
 						break;
 					}
-					case CSS_MODE_IN_LOCAL_RULE: {
+					case CSS_MODE_IN_BLOCK: {
 						processDeclarationValueDone(input);
-						// Handle nested syntax
-						let pos = walkCssTokens.eatWhitespaceAndComments(input, end);
+						inAnimationProperty = false;
 
-						// Nested block
-						if (input[pos] !== "}") {
-							// According spec only identifier can be used as a property name
-							const isIdentifier = walkCssTokens.isIdentStartCodePoint(
-								input.charCodeAt(pos)
-							);
+						if (isLocalMode()) {
+							// Handle nested syntax
+							let pos = walkCssTokens.eatWhitespaceAndComments(input, end);
 
-							if (!isIdentifier) {
-								isNestedSyntax = true;
+							// Nested block
+							if (input[pos] !== "}") {
+								// According spec only identifier can be used as a property name
+								const isIdentifier = walkCssTokens.isIdentStartCodePoint(
+									input.charCodeAt(pos)
+								);
+
+								if (!isIdentifier) {
+									isNestedSyntax = true;
+								}
 							}
 						}
-
-						inAnimationProperty = false;
 						return end;
 					}
 				}
@@ -662,40 +664,42 @@ class CssParser extends Parser {
 				switch (mode) {
 					case CSS_MODE_TOP_LEVEL:
 						allowImportAtRule = false;
-						mode = isLocalMode() ? CSS_MODE_IN_LOCAL_RULE : CSS_MODE_IN_RULE;
-						modeNestingLevel = 1;
+						mode = CSS_MODE_IN_BLOCK;
+						blockNestingLevel = 1;
 						break;
-					case CSS_MODE_IN_RULE:
-					case CSS_MODE_IN_LOCAL_RULE:
-						modeNestingLevel++;
+					case CSS_MODE_IN_BLOCK:
+						blockNestingLevel++;
 						break;
 				}
 				return end;
 			},
 			rightCurlyBracket: (input, start, end) => {
 				switch (mode) {
-					case CSS_MODE_IN_LOCAL_RULE:
-						processDeclarationValueDone(input);
-						inAnimationProperty = false;
-					/* falls through */
-					case CSS_MODE_IN_RULE:
-						if (--modeNestingLevel === 0) {
+					case CSS_MODE_IN_BLOCK: {
+						if (isLocalMode()) {
+							processDeclarationValueDone(input);
+							inAnimationProperty = false;
+						}
+						if (--blockNestingLevel === 0) {
 							mode = CSS_MODE_TOP_LEVEL;
 							isNestedSyntax = false;
 							modeData = undefined;
 						}
 						break;
+					}
 				}
 				return end;
 			},
 			identifier: (input, start, end) => {
 				switch (mode) {
-					case CSS_MODE_IN_LOCAL_RULE: {
-						// Handle only top level values and not inside functions
-						if (inAnimationProperty && balanced.length === 0) {
-							lastIdentifier = [start, end];
-						} else {
-							return processLocalDeclaration(input, start, end);
+					case CSS_MODE_IN_BLOCK: {
+						if (isLocalMode()) {
+							// Handle only top level values and not inside functions
+							if (inAnimationProperty && balanced.length === 0) {
+								lastIdentifier = [start, end];
+							} else {
+								return processLocalDeclaration(input, start, end);
+							}
 						}
 						break;
 					}
@@ -870,14 +874,18 @@ class CssParser extends Parser {
 			},
 			comma: (input, start, end) => {
 				if (this.allowModeSwitch) {
+					switch (mode) {
+						case CSS_MODE_IN_BLOCK: {
+							if (isLocalMode()) {
+								processDeclarationValueDone(input);
+							}
+
+							break;
+						}
+					}
+
 					// Reset stack for `:global .class :local .class-other` selector after `,`
 					modeData = undefined;
-
-					switch (mode) {
-						case CSS_MODE_IN_LOCAL_RULE:
-							processDeclarationValueDone(input);
-							break;
-					}
 				}
 				return end;
 			}

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -669,7 +669,8 @@ class CssParser extends Parser {
 			identifier: (input, start, end) => {
 				switch (mode) {
 					case CSS_MODE_IN_LOCAL_RULE: {
-						if (modeData === "animation") {
+						// Handle only top level values and not inside functions
+						if (modeData === "animation" && balanced.length === 0) {
 							lastIdentifier = [start, end];
 						} else {
 							return processLocalDeclaration(input, start, end);

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -332,6 +332,7 @@ class CssParser extends Parser {
 				module.addDependency(dep);
 				declaredCssVariables.add(name);
 			} else if (
+				!propertyName.startsWith("--") &&
 				OPTIONALLY_VENDOR_PREFIXED_ANIMATION_PROPERTY.test(propertyName)
 			) {
 				modeData = "animation";
@@ -632,7 +633,8 @@ class CssParser extends Parser {
 					}
 					case CSS_MODE_IN_LOCAL_RULE: {
 						processDeclarationValueDone(input, start);
-						return processLocalDeclaration(input, end);
+						modeData = undefined;
+						return end;
 					}
 				}
 				return end;
@@ -667,13 +669,14 @@ class CssParser extends Parser {
 			},
 			identifier: (input, start, end) => {
 				switch (mode) {
-					case CSS_MODE_IN_LOCAL_RULE:
+					case CSS_MODE_IN_LOCAL_RULE: {
 						if (modeData === "animation") {
 							lastIdentifier = [start, end];
 						} else {
-							processLocalDeclaration(input, start);
+							return processLocalDeclaration(input, start) + 1;
 						}
 						break;
+					}
 					case CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA: {
 						if (input.slice(start, end).toLowerCase() === "layer") {
 							modeData.layer = "";

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -402,7 +402,7 @@ class CssParser extends Parser {
 					case CSS_MODE_AT_IMPORT_INVALID: {
 						break;
 					}
-					default: {
+					case CSS_MODE_IN_BLOCK: {
 						// Ignore `url()`, `url('')` and `url("")`, they are valid by spec
 						if (value.length === 0) {
 							break;
@@ -440,7 +440,7 @@ class CssParser extends Parser {
 					case CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA: {
 						break;
 					}
-					default: {
+					case CSS_MODE_IN_BLOCK: {
 						// TODO move escaped parsing to tokenizer
 						const last = balanced[balanced.length - 1];
 

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -643,8 +643,6 @@ class CssParser extends Parser {
 						allowImportAtRule = false;
 						mode = isLocalMode() ? CSS_MODE_IN_LOCAL_RULE : CSS_MODE_IN_RULE;
 						modeNestingLevel = 1;
-						if (mode === CSS_MODE_IN_LOCAL_RULE)
-							return processLocalDeclaration(input, end);
 						break;
 					case CSS_MODE_IN_RULE:
 					case CSS_MODE_IN_LOCAL_RULE:
@@ -672,6 +670,8 @@ class CssParser extends Parser {
 					case CSS_MODE_IN_LOCAL_RULE:
 						if (modeData === "animation") {
 							lastIdentifier = [start, end];
+						} else {
+							processLocalDeclaration(input, start);
 						}
 						break;
 					case CSS_MODE_AT_IMPORT_EXPECT_LAYER_OR_SUPPORTS_OR_MEDIA: {

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -574,7 +574,7 @@ class CssParser extends Parser {
 					name === "@layer" ||
 					name === "@container"
 				) {
-					modeData = "local";
+					modeData = isLocalMode() ? "local" : "global";
 					isNestedSyntax = true;
 					return end;
 				} else {

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -379,7 +379,6 @@ class CssParser extends Parser {
 				lastIdentifier = undefined;
 			}
 		};
-		const eatAtRuleNested = eatUntil("{};/");
 		const eatKeyframes = eatUntil("{};/");
 		const eatNameInVar = eatUntil(",)};/");
 		walkCssTokens(source, {
@@ -529,6 +528,7 @@ class CssParser extends Parser {
 					pos = newPos;
 					modeData = "local";
 					modeNestingLevel = 1;
+					isNestedSyntax = true;
 					return pos + 1;
 				} else if (isLocalMode() && name === "@property") {
 					let pos = end;
@@ -566,6 +566,7 @@ class CssParser extends Parser {
 					declaredCssVariables.add(name);
 					pos = propertyNameEnd;
 					modeData = "local";
+					isNestedSyntax = true;
 					modeNestingLevel = 1;
 					return pos + 1;
 				} else if (
@@ -575,22 +576,8 @@ class CssParser extends Parser {
 					name === "@container"
 				) {
 					modeData = "local";
-					// TODO handle nested CSS syntax
-					let pos = end;
-					const [newPos] = eatText(input, pos, eatAtRuleNested);
-					pos = newPos;
-					if (pos === input.length) return pos;
-					if (input.charCodeAt(pos) !== CC_LEFT_CURLY) {
-						this._emitWarning(
-							state,
-							`Unexpected ${input[pos]} at ${pos} during parsing of @media, @supports, @layer or @container (expected '{')`,
-							locConverter,
-							start,
-							pos
-						);
-						return pos;
-					}
-					return pos + 1;
+					isNestedSyntax = true;
+					return end;
 				} else {
 					mode = CSS_MODE_IN_RULE;
 				}

--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -812,24 +812,26 @@ class CssParser extends Parser {
 				return end;
 			},
 			pseudoClass: (input, start, end) => {
-				switch (mode) {
-					case CSS_MODE_TOP_LEVEL: {
-						const name = input.slice(start, end).toLowerCase();
-						if (this.allowModeSwitch && name === ":global") {
-							modeData = "global";
-							const dep = new ConstDependency("", [start, end]);
-							module.addPresentationalDependency(dep);
-						} else if (this.allowModeSwitch && name === ":local") {
-							modeData = "local";
-							const dep = new ConstDependency("", [start, end]);
-							module.addPresentationalDependency(dep);
-						} else if (this.allowPseudoBlocks && name === ":export") {
-							const pos = parseExports(input, end);
-							const dep = new ConstDependency("", [start, pos]);
-							module.addPresentationalDependency(dep);
-							return pos;
+				if (this.allowModeSwitch) {
+					switch (mode) {
+						case CSS_MODE_TOP_LEVEL: {
+							const name = input.slice(start, end).toLowerCase();
+							if (name === ":global") {
+								modeData = "global";
+								const dep = new ConstDependency("", [start, end]);
+								module.addPresentationalDependency(dep);
+							} else if (name === ":local") {
+								modeData = "local";
+								const dep = new ConstDependency("", [start, end]);
+								module.addPresentationalDependency(dep);
+							} else if (name === ":export") {
+								const pos = parseExports(input, end);
+								const dep = new ConstDependency("", [start, pos]);
+								module.addPresentationalDependency(dep);
+								return pos;
+							}
+							break;
 						}
-						break;
 					}
 				}
 				return end;

--- a/lib/css/walkCssTokens.js
+++ b/lib/css/walkCssTokens.js
@@ -124,10 +124,14 @@ const _isWhiteSpace = cc => {
 };
 
 /**
+ * ident-start code point
+ *
+ * A letter, a non-ASCII code point, or U+005F LOW LINE (_).
+ *
  * @param {number} cc char code
  * @returns {boolean} true, if cc is a start code point of an identifier
  */
-const _isIdentStartCodePoint = cc => {
+const isIdentStartCodePoint = cc => {
 	return (
 		(cc >= CC_LOWER_A && cc <= CC_LOWER_Z) ||
 		(cc >= CC_UPPER_A && cc <= CC_UPPER_Z) ||
@@ -679,7 +683,7 @@ const CHAR_MAP = Array.from({ length: 0x80 }, (_, cc) => {
 			// digit
 			if (_isDigit(cc)) return consumeNumericToken;
 			// ident-start code point
-			if (_isIdentStartCodePoint(cc)) {
+			if (isIdentStartCodePoint(cc)) {
 				return consumeOtherIdentifier;
 			}
 			// EOF, but we don't have it
@@ -710,6 +714,8 @@ module.exports = (input, callbacks) => {
 		}
 	}
 };
+
+module.exports.isIdentStartCodePoint = isIdentStartCodePoint;
 
 /**
  * @param {string} input input

--- a/lib/css/walkCssTokens.js
+++ b/lib/css/walkCssTokens.js
@@ -737,6 +737,19 @@ module.exports.eatComments = (input, pos) => {
 /**
  * @param {string} input input
  * @param {number} pos position
+ * @returns {number} position after whitespace
+ */
+module.exports.eatWhitespace = (input, pos) => {
+	while (_isWhiteSpace(input.charCodeAt(pos))) {
+		pos++;
+	}
+
+	return pos;
+};
+
+/**
+ * @param {string} input input
+ * @param {number} pos position
  * @returns {number} position after whitespace and comments
  */
 module.exports.eatWhitespaceAndComments = (input, pos) => {

--- a/lib/css/walkCssTokens.js
+++ b/lib/css/walkCssTokens.js
@@ -341,11 +341,7 @@ const consumeNumericToken = (input, pos, callbacks) => {
 const consumeOtherIdentifier = (input, pos, callbacks) => {
 	const start = pos;
 	pos = _consumeIdentifier(input, pos, callbacks);
-	if (
-		pos !== input.length &&
-		!callbacks.isSelector(input, pos) &&
-		input.charCodeAt(pos) === CC_LEFT_PARENTHESIS
-	) {
+	if (pos !== input.length && input.charCodeAt(pos) === CC_LEFT_PARENTHESIS) {
 		pos++;
 		if (callbacks.function !== undefined) {
 			return callbacks.function(input, start, pos);

--- a/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
+++ b/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
@@ -1641,6 +1641,45 @@ Array [
 	}
 }
 
+:global .again-global {
+	color:red;
+}
+
+:global .again-again-global {
+	:global .again-again-global {
+		color: red;
+	}
+}
+
+:root {
+	--foo: red;
+}
+
+:global .again-again-global {
+	color: var(--foo);
+
+	:global .again-again-global {
+		color: var(--foo);
+	}
+}
+
+:global .again-again-global {
+	animation: slidein 3s;
+
+	:global .again-again-global, .class, :global(:global(:local(.nested1)).nested2).nested3 {
+		animation: slidein 3s;
+	}
+
+  .local2 :global .global,
+	.local3 {
+		color: red;
+	}
+}
+
+@unknown var(--foo) {
+	color: red;
+}
+
 .class {
 	color: red;
 	background: var(--color);

--- a/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
+++ b/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
@@ -1,1089 +1,552 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ConfigCacheTestCases css css-import exported tests should compile 1`] = `
+exports[`ConfigCacheTestCases css pure-css exported tests should compile 1`] = `
 Array [
-  "body {
-	externally-imported: true;
-}
-
-body {
-	externally-imported1: true;
-}
-
-body {
-	externally-imported2: true;
-}
-
-body {
-	background: black;
-}
-
-body {
-	background: black;
-}
-
-@layer default {
-	body {
-		background: black;
-	}
-}
-
-@layer default {
-	body {
-		background: black;
-	}
-}
-
-@supports (display: flex) {
-	body {
-		background: black;
-	}
-}
-
-@supports (display: flex) {
-	body {
-		background: black;
-	}
-}
-
-@media screen and (min-width: 400px) {
-	body {
-		background: black;
-	}
-}
-
-@media screen and (min-width: 400px) {
-	body {
-		background: black;
-	}
-}
-
-@layer default {
-	@supports (display: flex) {
-		body {
-			background: black;
-		}
-	}
-}
-
-@layer default {
-	@media screen and (min-width: 400px) {
-		body {
-			background: black;
-		}
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (min-width: 400px) {
-		body {
-			background: black;
-		}
-	}
-}
-
-@layer default {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			body {
-				background: black;
-			}
-		}
-	}
-}
-
-@layer default {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			body {
-				background: black;
-			}
-		}
-	}
-}
-
-@layer default {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			body {
-				background: black;
-			}
-		}
-	}
-}
-
-@layer default {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			body {
-				background: black;
-			}
-		}
-	}
-}
-
-@layer default {
-	@supports (background: url(./img.png)) {
-		@media screen and (min-width: 400px) {
-			body {
-				background: black;
-			}
-		}
-	}
-}
-
-@layer default {
-	@supports (background: url(\\"./img.png\\")) {
-		@media screen and (min-width: 400px) {
-			body {
-				background: black;
-			}
-		}
-	}
-}
-
-@media screen {
-	body {
-		background: black;
-	}
-}
-
-@media screen {
-	body {
-		background: black;
-	}
-}
-
-@media screen {
-	body {
-		background: black;
-	}
-}
-
-body {
-	background: black;
-}
-
-body {
-	background: green;
-}
-
-@layer base {
-	body {
-		background: green;
-	}
-}
-
-@supports (display: flex) {
-	body {
-		background: green;
-	}
-}
-
-@media screen, print {
-	body {
-		background: green;
-	}
-}
-
-a {
+  ".class {
 	color: red;
 }
 
-a {
-	color: red;
+.local1,
+.local2 :global .global,
+.local3 {
+	color: green;
 }
 
-a {
-	color: red;
+:global .global :local .local4 {
+	color: yellow;
 }
 
-a {
-	color: red;
+.local5:global(.global).local6 {
+	color: blue;
 }
 
-a {
-	color: red;
+.local7 div:not(.disabled, .mButtonDisabled, .tipOnly) {
+    pointer-events: initial !important;
 }
 
-a {
-	color: red;
+.local8 :is(div.parent1.child1.vertical-tiny,
+    div.parent1.child1.vertical-small,
+    div.otherDiv.horizontal-tiny,
+    div.otherDiv.horizontal-small div.description) {
+  max-height: 0;
+  margin: 0;
+  overflow: hidden;
 }
 
-a {
-	color: red;
+.local9 :matches(div.parent1.child1.vertical-tiny,
+    div.parent1.child1.vertical-small,
+    div.otherDiv.horizontal-tiny,
+    div.otherDiv.horizontal-small div.description) {
+  max-height: 0;
+  margin: 0;
+  overflow: hidden;
 }
 
-a {
-	color: red;
+.local10 :where(div.parent1.child1.vertical-tiny,
+    div.parent1.child1.vertical-small,
+    div.otherDiv.horizontal-tiny,
+    div.otherDiv.horizontal-small div.description) {
+  max-height: 0;
+  margin: 0;
+  overflow: hidden;
 }
 
-a {
-	color: red;
+.local11 div:has(.disabled, .mButtonDisabled, .tipOnly) {
+    pointer-events: initial !important;
 }
 
-@media screen and (orientation:landscape) {
-	a {
-		color: red;
+.local12 div:current(p, span) {
+	background-color: yellow;
+}
+
+.local13 div:past(p, span) {
+	display: none;
+}
+
+.local14 div:future(p, span) {
+	background-color: yellow;
+}
+
+.local15 div:-moz-any(ol, ul, menu, dir) {
+	list-style-type: square;
+}
+
+.local16 li:-webkit-any(:first-child, :last-child) {
+	background-color: aquamarine;
+}
+
+.local9 :matches(div.parent1.child1.vertical-tiny,
+    div.parent1.child1.vertical-small,
+    div.otherDiv.horizontal-tiny,
+    div.otherDiv.horizontal-small div.description) {
+	max-height: 0;
+	margin: 0;
+	overflow: hidden;
+}
+
+:global(:global(:local(.nested1)).nested2).nested3 {
+	color: pink;
+}
+
+#ident {
+	color: purple;
+}
+
+@keyframes localkeyframes {
+	0% {
+		left: var(--pos1x);
+		top: var(--pos1y);
+		color: var(--theme-color1);
+	}
+	100% {
+		left: var(--pos2x);
+		top: var(--pos2y);
+		color: var(--theme-color2);
 	}
 }
 
-@media SCREEN AND (ORIENTATION: LANDSCAPE) {
-	a {
-		color: red;
+@keyframes localkeyframes2 {
+	0% {
+		left: 0;
+	}
+	100% {
+		left: 100px;
 	}
 }
 
-@media (min-width: 100px) {
-	a {
-		color: red;
+.animation {
+	animation-name: localkeyframes;
+	animation: 3s ease-in 1s 2 reverse both paused localkeyframes, localkeyframes2;
+	--pos1x: 0px;
+	--pos1y: 0px;
+	--pos2x: 10px;
+	--pos2y: 20px;
+}
+
+/* .composed {
+	composes: local1;
+	composes: local2;
+} */
+
+.vars {
+	color: var(--local-color);
+	--local-color: red;
+}
+
+.globalVars :global {
+	color: var(--global-color);
+	--global-color: red;
+}
+
+@media (min-width: 1600px) {
+	.wideScreenClass {
+		color: var(--local-color);
+		--local-color: green;
 	}
 }
 
-.class {
-	content: \\"style.css\\";
-	color: red;
-}
-
-.class {
-	content: \\"style.css\\";
-	color: red;
-}
-
-.class {
-	content: \\"style.css\\";
-	color: red;
-}
-
-.class {
-	content: \\"style.css\\";
-	color: red;
-}
-
-.class {
-	content: \\"style7.css\\";
-}
-
-.class {
-	content: \\"style7.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test.css\\";
-}
-
-.class {
-	content: \\"test.css\\";
-}
-
-.class {
-	content: \\"test.css\\";
-}
-
-.class {
-	content: \\"test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"style6.css\\";
-}
-
-.class {
-	content: \\"style4.css\\";
-}
-
-.class {
-	content: \\"style4.css\\";
-}
-
-.class {
-	content: \\"style4.css\\";
-}
-
-@supports (display: flex) {
-	.class {
-		content: \\"style4.css\\";
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (orientation:landscape) {
-		.class {
-			content: \\"style4.css\\";
-		}
-	}
-}
-
-.class {
-	content: \\"style4.css\\";
-}
-
-.class {
-	content: \\"style4.css\\";
-}
-
-.class {
-	content: \\"style4.css\\";
-}
-
-a {
-  color: red;
-}
-@media screen and (orientation:landscape) {
-	a {
-	  color: blue;
-	}}
-
-.class {
-	content: \\"style5.css\\";
-}
-
-.class {
-	content: \\"style5.css\\";
-}
-
-@supports (unknown) {
-	.class {
-		content: \\"style5.css\\";
-	}
-}
-
-@supports (display: flex) {
-	.class {
-		content: \\"style5.css\\";
-	}
-}
-
-@supports (display: flex !important) {
-	.class {
-		content: \\"style5.css\\";
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (min-width: 400px) {
-		.class {
-			content: \\"style5.css\\";
-		}
-	}
-}
-
-@supports (selector(a b)) {
-	.class {
-		content: \\"style5.css\\";
-	}
-}
-
-@supports (display: flex) {
-	.class {
-		content: \\"style5.css\\";
-	}
-}
-
-@layer {
-	.class {
-		content: \\"layer.css\\";
-	}
-}
-
-@layer default {
-	.class {
-		content: \\"layer.css\\";
-	}
-}
-
-@layer default {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			.class {
-				content: \\"layer.css\\";
-			}
-		}
-	}
-}
-
-@layer {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			.class {
-				content: \\"layer.css\\";
-			}
-		}
-	}
-}
-
-@layer {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			.class {
-				content: \\"layer.css\\";
-			}
-		}
-	}
-}
-
-@layer {
-	.class {
-		content: \\"layer.css\\";
-	}
-}
-
-@layer foo.bar.baz {
-	.class {
-		content: \\"layer.css\\";
-	}
-}
-
-@layer {
-	.class {
-		content: \\"layer.css\\";
-	}
-}
-
-@layer default {
-	@supports (display: flex) {
-		@media screen and (min-width:400px) {
-			.class {
-				content: \\"style6.css\\";
-			}
-		}
-	}
-}
-
-@layer default {
-	@supports (display: flex) {
-		@media screen and (min-width:400px) {
-			.class {
-				content: \\"style6.css\\";
-			}
-		}
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (min-width:400px) {
-		.class {
-			content: \\"style6.css\\";
-		}
-	}
-}
-
-@media screen and (min-width:400px) {
-	.class {
-		content: \\"style6.css\\";
-	}
-}
-
-@media screen and (min-width:400px) {
-	.class {
-		content: \\"style6.css\\";
-	}
-}
-
-@media screen and (min-width:400px) {
-	.class {
-		content: \\"style6.css\\";
-	}
-}
-
-@layer default {
-	@supports (display     :     flex) {
-		@media screen     and     (     min-width     :     400px     ) {
-			.class {
-				content: \\"style6.css\\";
-			}
-		}
-	}
-}
-
-@layer DEFAULT {
-	@supports (DISPLAY: FLEX) {
-		@media SCREEN AND (MIN-WIDTH: 400PX) {
-			.class {
-				content: \\"style6.css\\";
-			}
-		}
-	}
-}
-
-@layer {
-	@supports (DISPLAY: FLEX) {
-		@media SCREEN AND (MIN-WIDTH: 400PX) {
-			.class {
-				content: \\"style6.css\\";
-			}
-		}
-	}
-}
-
-@layer /* Comment */default/* Comment */ {
-	@supports (/* Comment */display/* Comment */:/* Comment */ flex/* Comment */) {
-		@media /* Comment */ screen/* Comment */ and/* Comment */ (/* Comment */min-width/* Comment */: /* Comment */400px/* Comment */) {
-			.class {
-				content: \\"style6.css\\";
-			}
-		}
-	}
-}
-
-.class {
-	content: \\"style6.css\\";
-}
-
-.class {
-	content: \\"style6.css\\";
-}
-
-.class {
-	content: \\"style6.css\\";
-}
-
-.class {
-	content: \\"style6.css\\";
-}
-
-.class {
-	content: \\"style6.css\\";
-}
-
-.class {
-	content: \\"style6.css\\";
-}
-
-@media /* Comment */ print and (orientation:landscape) {
-	.class {
-		content: \\"style6.css\\";
-	}
-}
-
-@media /* Comment */print and (orientation:landscape)/* Comment */ {
-	.class {
-		content: \\"style6.css\\";
-	}
-}
-
-@media /* Comment */ print and (orientation:landscape) {
-	.class {
-		content: \\"style6.css\\";
-	}
-}
-
-@media screen and (min-width: 400px) {
-	.class {
-		content: \\"style8.css\\";
-	}
-}
-
-@media (prefers-color-scheme: dark) {
-	.class {
-		content: \\"style8.css\\";
-	}
-}
-
-@supports (display: flex) {
-	.class {
-		content: \\"style8.css\\";
-	}
-}
-
-@supports (((display: flex))) {
-	.class {
-		content: \\"style8.css\\";
-	}
-}
-
-@supports (((display: inline-grid))) {
-	@media screen and (((min-width: 400px))) {
-		.class {
-			content: \\"style8.css\\";
-		}
+@media screen and (max-width: 600px) {
+	.narrowScreenClass {
+		color: var(--local-color);
+		--local-color: purple;
 	}
 }
 
 @supports (display: grid) {
-	.class {
-		content: \\"style8.css\\";
+	.displayGridInSupports {
+		display: grid;
 	}
+}
+
+@supports not (display: grid) {
+  .floatRightInNegativeSupports {
+    float: right;
+  }
 }
 
 @supports (display: flex) {
-	@media screen and (min-width: 400px) {
-		.class {
-			content: \\"style8.css\\";
-		}
-	}
+  @media screen and (min-width: 900px) {
+    .displayFlexInMediaInSupports {
+      display: flex;
+    }
+  }
 }
 
-@layer framework {
-	.class {
-		content: \\"style8.css\\";
-	}
-}
-
-@layer default {
-	.class {
-		content: \\"style8.css\\";
-	}
-}
-
-@layer base {
-	.class {
-		content: \\"style8.css\\";
-	}
-}
-
-@layer default {
+@media screen and (min-width: 900px) {
 	@supports (display: flex) {
-		.class {
-			content: \\"style8.css\\";
+    .displayFlexInSupportsInMedia {
+      display: flex;
+    }
+  }
+}
+
+@MEDIA screen and (min-width: 900px) {
+	@SUPPORTS (display: flex) {
+		.displayFlexInSupportsInMediaUpperCase {
+			display: flex;
 		}
 	}
 }
 
-@layer default {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			.class {
-				content: \\"style8.css\\";
-			}
-		}
+.animationUpperCase {
+	ANIMATION-NAME: localkeyframesUPPERCASE;
+	ANIMATION: 3s ease-in 1s 2 reverse both paused localkeyframesUPPERCASE, localkeyframes2UPPPERCASE;
+	--pos1x: 0px;
+	--pos1y: 0px;
+	--pos2x: 10px;
+	--pos2y: 20px;
+}
+
+@KEYFRAMES localkeyframesUPPERCASE {
+	0% {
+		left: VAR(--pos1x);
+		top: VAR(--pos1y);
+		color: VAR(--theme-color1);
+	}
+	100% {
+		left: VAR(--pos2x);
+		top: VAR(--pos2y);
+		color: VAR(--theme-color2);
 	}
 }
 
-@layer {
-	a {
+@KEYframes localkeyframes2UPPPERCASE {
+	0% {
+		left: 0;
+	}
+	100% {
+		left: 100px;
+	}
+}
+
+:GLOBAL .globalUpperCase :LOCAL .localUpperCase {
+	color: yellow;
+}
+
+.VARS {
+	color: VAR(--LOCAL-COLOR);
+	--LOCAL-COLOR: red;
+}
+
+.globalVarsUpperCase :GLOBAL {
+	COLOR: VAR(--GLOBAR-COLOR);
+	--GLOBAR-COLOR: red;
+}
+
+@supports (top: env(safe-area-inset-top, 0)) {
+	.inSupportScope {
 		color: red;
 	}
 }
 
-@media unknown(default) unknown(display: flex) unknown {
-	.class {
-		content: \\"style9.css\\";
+.a {
+	animation: 3s animationName;
+	-webkit-animation: 3s animationName;
+}
+
+.b {
+	animation: animationName 3s;
+	-webkit-animation: animationName 3s;
+}
+
+.c {
+	animation-name: animationName;
+	-webkit-animation-name: animationName;
+}
+
+.d {
+	--animation-name: animationName;
+}
+
+@keyframes animationName {
+	0% {
+		background: white;
+	}
+	100% {
+		background: red;
 	}
 }
 
-@media unknown(default) {
-	.class {
-		content: \\"style9.css\\";
+@-webkit-keyframes animationName {
+	0% {
+		background: white;
+	}
+	100% {
+		background: red;
 	}
 }
 
-.style11 {
+@-moz-keyframes mozAnimationName {
+	0% {
+		background: white;
+	}
+	100% {
+		background: red;
+	}
+}
+
+@counter-style thumbs {
+	system: cyclic;
+	symbols: \\"\\\\1F44D\\";
+	suffix: \\" \\";
+}
+
+@font-feature-values Font One {
+	@styleset {
+		nice-style: 12;
+	}
+}
+
+/* At-rule for \\"nice-style\\" in Font Two */
+@font-feature-values Font Two {
+	@styleset {
+		nice-style: 4;
+	}
+}
+
+@property --my-color {
+	syntax: \\"<color>\\";
+	inherits: false;
+	initial-value: #c0ffee;
+}
+
+.class {
+	color: var(--my-color);
+}
+
+@layer utilities {
+	.padding-sm {
+		padding: 0.5rem;
+	}
+
+	.padding-lg {
+		padding: 0.8rem;
+	}
+}
+
+.class {
+	color: red;
+
+	.nested-pure {
+		color: red;
+	}
+
+	@media screen and (min-width: 200px) {
+		color: blue;
+
+		.nested-media {
+			color: blue;
+		}
+	}
+
+	@supports (display: flex) {
+		display: flex;
+
+		.nested-supports {
+			display: flex;
+		}
+	}
+
+	@layer foo {
+		background: red;
+
+		.nested-layer {
+			background: red;
+		}
+	}
+
+	@container foo {
+		background: red;
+
+		.nested-layer {
+			background: red;
+		}
+	}
+}
+
+.not-selector-inside {
+	color: #fff;
+	opacity: 0.12;
+	padding: .5px;
+	unknown: :local(.test);
+	unknown1: :local .test;
+	unknown2: :global .test;
+	unknown3: :global .test;
+	unknown4: .foo, .bar, #bar;
+}
+
+@unknown :local .local :global .global {
 	color: red;
 }
 
-.style12 {
+@unknown :local(.local) :global(.global) {
 	color: red;
 }
 
-.style10 {
+.nested-var {
+	.again {
+		color: var(--local-color);
+	}
+}
+
+.nested-with-local-pseudo {
+	color: red;
+
+	:local .local-nested {
+		color: red;
+	}
+
+	:global .global-nested {
+		color: red;
+	}
+
+	:local(.local-nested) {
+		color: red;
+	}
+
+	:global(.global-nested) {
+		color: red;
+	}
+
+	:local .local-nested, :global .global-nested-next {
+		color: red;
+	}
+
+	:local(.local-nested), :global(.global-nested-next) {
+		color: red;
+	}
+
+	:global .foo, .bar {
+		color: red;
+	}
+}
+
+#id-foo {
+	color: red;
+
+	#id-bar {
+		color: red;
+	}
+}
+
+.nested-parens {
+	.local9 div:has(.vertical-tiny, .vertical-small) {
+		max-height: 0;
+		margin: 0;
+		overflow: hidden;
+	}
+}
+
+:global .global-foo {
+	.nested-global {
+		color: red;
+	}
+
+	:local .local-in-global {
+		color: blue;
+	}
+}
+
+@unknown .class {
+	color: red;
+
+	.class {
+		color: red;
+	}
+}
+
+:global .class :local .in-local-global-scope,
+:global .class :local .in-local-global-scope,
+:local .class-local-scope :global .in-local-global-scope {
 	color: red;
 }
 
-@media screen and (min-width: 400px) {
-	@media screen and (max-width: 500px) {
-		@media screen and (orientation: portrait) {
-			.class {
-				deep-deep-nested: 1;
-			}
+@container (width > 400px) {
+	.class-in-container {
+		font-size: 1.5em;
+	}
+}
+
+@container summary (min-width: 400px) {
+	@container (width > 400px) {
+		.deep-class-in-container {
+			font-size: 1.5em;
 		}
 	}
 }
 
-@media screen and (min-width: 400px) {
-	@media screen and (max-width: 500px) {
-		.class {
-			deep-nested: 1;
+:scope {
+	color: red;
+}
+
+.placeholder-gray-700:-ms-input-placeholder {
+	--placeholder-opacity: 1;
+	color: #4a5568;
+	color: rgba(74, 85, 104, var(--placeholder-opacity));
+}
+.placeholder-gray-700::-ms-input-placeholder {
+	--placeholder-opacity: 1;
+	color: #4a5568;
+	color: rgba(74, 85, 104, var(--placeholder-opacity));
+}
+.placeholder-gray-700::placeholder {
+	--placeholder-opacity: 1;
+	color: #4a5568;
+	color: rgba(74, 85, 104, var(--placeholder-opacity));
+}
+
+:root {
+	--test: dark;
+}
+
+@media screen and (prefers-color-scheme: var(--test)) {
+	.baz {
+		color: white;
+	}
+}
+
+@keyframes slidein {
+	from {
+		margin-left: 100%;
+		width: 300%;
+	}
+
+	to {
+		margin-left: 0%;
+		width: 100%;
+	}
+}
+
+.class {
+	animation:
+		foo var(--animation-name) 3s,
+		var(--animation-name) 3s,
+		3s linear 1s infinite running slidein,
+		3s linear env(foo, var(--baz)) infinite running slidein;
+}
+
+:root {
+	--baz: 10px;
+}
+
+.class {
+	bar: env(foo, var(--baz));
+}
+
+:global      .global-foo, :local        .bar {
+	:local      .local-in-global       {
+		color: blue;
+	}
+
+	@media screen {
+		:global .my-global-class-again,
+		:local .my-global-class-again {
+			color: red;
 		}
 	}
 }
 
-@media screen and (min-width: 400px) {
-	.class {
-		nested: 1;
-	}
-}
-
-@supports (display: flex) {
-	@supports (display: grid) {
-		@supports (display: table) {
-			.class {
-				deep-deep-nested: 1;
-			}
-		}
-	}
-}
-
-@supports (display: flex) {
-	@supports (display: grid) {
-		.class {
-			deep-nested: 1;
-		}
-	}
-}
-
-@supports (display: flex) {
-	.class {
-		nested: 1;
-	}
-}
-
-@layer foo {
-	@layer bar {
-		@layer baz {
-			.class {
-				deep-deep-nested: 1;
-			}
-		}
-	}
-}
-
-@layer foo {
-	@layer bar {
-		.class {
-			deep-nested: 1;
-		}
-	}
-}
-
-@layer foo {
-	.class {
-		nested: 1;
-	}
-}
-
-@layer foo {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			@layer bar {
-				@supports (display: grid) {
-					@media screen and (min-width: 500px) {
-						@layer baz {
-							@supports (display: table) {
-								@media screen and (min-width: 600px) {
-									.class {
-										deep-deep-nested: 1;
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-}
-
-@layer foo {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			@layer bar {
-				@supports (display: grid) {
-					@media screen and (min-width: 500px) {
-						.class {
-							deep-nested: 1;
-						}
-					}
-				}
-			}
-		}
-	}
-}
-
-@layer foo {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			.class {
-				nested: 1;
-			}
-		}
-	}
-}
-
-@media screen and (min-width: 400px) {
-	@supports (display: flex) {
-		@layer bar {
-			.class {
-				deep-deep-nested: 1;
-			}
-		}
-	}
-}
-
-@media screen and (min-width: 400px) {
-	@supports (display: flex) {
-		.class {
-			deep-nested: 1;
-		}
-	}
-}
-
-@media screen and (min-width: 400px) {
-	.class {
-		nested: 1;
-	}
-}
-
-@layer {
-	@layer {
-		@layer {
-			.class {
-				deep-deep-nested: 1;
-			}
-		}
-	}
-}
-
-@layer {
-	@layer {
-		.class {
-			deep-nested: 1;
-		}
-	}
-}
-
-@layer {
-	@layer base {
-		@layer baz {
-			.class {
-				deep-deep-nested: 1;
-			}
-		}
-	}
-}
-
-@layer {
-	@layer base {
-		.class {
-			deep-nested: 1;
-		}
-	}
-}
-
-@layer {
-	.class {
-		deep-nested: 1;
-	}
-}
-
-@media screen and (orientation: portrait) {
-	.class {
-		deep-deep-nested: 1;
-	}
-}
-
-@media screen and (orientation: portrait) {
-	@supports (display: flex) {
-		.class {
-			content: \\"style8.css\\";
-		}
-	}
-}
-
-@media screen and (orientation: portrait) {
-	.class {
-		duplicate-nested: true;
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (orientation: portrait) {
-		@layer {
-			@layer {
-				.class {
-					deep-deep-nested: 1;
-				}
-			}
-		}
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (orientation: portrait) {
-		@layer {
-			.class {
-				deep-nested: 1;
-			}
-		}
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (orientation: portrait) {
-		@layer base {
-			@layer baz {
-				.class {
-					deep-deep-nested: 1;
-				}
-			}
-		}
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (orientation: portrait) {
-		@layer base {
-			.class {
-				deep-nested: 1;
-			}
-		}
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (orientation: portrait) {
-		.class {
-			deep-nested: 1;
-		}
-	}
-}
-
-@layer super.foo {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			@layer bar {
-				@supports (display: grid) {
-					@media screen and (min-width: 500px) {
-						@layer baz {
-							@supports (display: table) {
-								@media screen and (min-width: 600px) {
-									.class {
-										deep-deep-nested: 1;
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-}
-
-@layer super.foo {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			@layer bar {
-				@supports (display: grid) {
-					@media screen and (min-width: 500px) {
-						.class {
-							deep-nested: 1;
-						}
-					}
-				}
-			}
-		}
-	}
-}
-
-@layer super.foo {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			.class {
-				nested: 1;
-			}
-		}
-	}
-}
-
-/* Has the same URL */
-/*@import url();
-@import url('');
-@import url(\\"\\");
-@import '';
-@import \\"\\";
-@import \\"   \\";
-@import \\"\\\\
-\\";
-@import url();
-@import url('');
-@import url(\\"\\");*/
-/*@import url(https://test.cases/path/../../../../configCases/css/css-import/external.css) screen and (orientation:landscape);
-@import url(https://test.cases/path/../../../../configCases/css/css-import/external.css) screen and (orientation:landscape);*/
-/*@import \\"//example.com/style.css\\";*/
-/*@import url(~package/test.css);*/
-/*@import ;*/
-/*@import foo-bar;*/
-/*@import-normalize;*/
-/*@import url('http://') :root {}*/
-/*@import url('query.css?foo=1&bar=1');*/
-/*@import url('other-query.css?foo=1&bar=1#hash');*/
-/*@import url('other-query.css?foo=1&bar=1#hash') screen and (orientation:landscape);*/
-/*@import url('https://fonts.googleapis.com/css?family=Roboto');*/
-/*@import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC');*/
-/*@import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto');*/
-
-/*@import nourl(test.css);
-@import '\\\\
-\\\\
-\\\\
-';
-@import url('!!../../helpers/string-loader.js?esModule=false!~package/tilde.css');*/
-/*@import url('   https://fonts.googleapis.com/css?family=Roboto   ');*/
-/*@import url('!!../../helpers/string-loader.js?esModule=false!');*/
-/*@import url('   !!../../helpers/string-loader.js?esModule=false!~package/tilde.css   ');*/
-/*@import \\"http://example.com/style.css\\" supports(display: flex) screen and (min-width: 400px);*/
-/* anonymous */
-/* All unknown parse as media for compatibility */
-body {
-	background: red;
-}
-
-head{--webpack-main:https\\\\:\\\\/\\\\/test\\\\.cases\\\\/path\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/configCases\\\\/css\\\\/css-import\\\\/external\\\\.css,https\\\\:\\\\/\\\\/test\\\\.cases\\\\/path\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/configCases\\\\/css\\\\/css-import\\\\/external1\\\\.css,https\\\\:\\\\/\\\\/test\\\\.cases\\\\/path\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/configCases\\\\/css\\\\/css-import\\\\/external2\\\\.css,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=9,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=10,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=11,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=12,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=13,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=14,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=15,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=16,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=17,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=18,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=19,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=20,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=21,\\\\.\\\\/imported\\\\.css\\\\?2fc7,\\\\.\\\\/imported\\\\.css\\\\?8e23,\\\\.\\\\/imported\\\\.css\\\\?daf4,\\\\.\\\\/imported\\\\.css\\\\?7a8d,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=9,\\\\.\\\\/style2\\\\.css\\\\?3989,\\\\.\\\\/style2\\\\.css\\\\?1933,\\\\.\\\\/style2\\\\.css\\\\?6611,\\\\.\\\\/style3\\\\.css\\\\?bar\\\\=1,\\\\.\\\\/style3\\\\.css\\\\?bar\\\\=2,\\\\.\\\\/style3\\\\.css\\\\?bar\\\\=3,\\\\.\\\\/style3\\\\.css\\\\?\\\\=bar4,\\\\.\\\\/styl\\\\'le7\\\\.css,\\\\.\\\\/styl\\\\'le7\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/test\\\\ test\\\\.css,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/test\\\\.css,\\\\.\\\\/test\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/test\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/test\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=9,\\\\.\\\\/test\\\\ test\\\\.css\\\\?fpp\\\\=10,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=11,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=bazz,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=bar,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=bar\\\\#hash,\\\\.\\\\/style4\\\\.css\\\\?\\\\#hash,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=5,data\\\\:text\\\\/css\\\\;charset\\\\=utf-8\\\\,a\\\\%20\\\\%7B\\\\%0D\\\\%0A\\\\%20\\\\%20color\\\\%3A\\\\%20red\\\\%3B\\\\%0D\\\\%0A\\\\%7D,data\\\\:text\\\\/css\\\\;charset\\\\=utf-8\\\\,a\\\\%20\\\\%7B\\\\%0D\\\\%0A\\\\%20\\\\%20color\\\\%3A\\\\%20blue\\\\%3B\\\\%0D\\\\%0A\\\\%7D,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=3\\\\?14ba,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=3\\\\?0e0d,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/style6\\\\.css,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=9,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=10,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=11,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=12,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=13,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=14,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=15,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=16,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=17,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=18,\\\\.\\\\/style8\\\\.css\\\\?5018,\\\\.\\\\/style8\\\\.css\\\\?204b,\\\\.\\\\/style8\\\\.css\\\\?63b0,\\\\.\\\\/style8\\\\.css\\\\?edb8,\\\\.\\\\/style8\\\\.css\\\\?6154,\\\\.\\\\/style8\\\\.css\\\\?8c51,\\\\.\\\\/style8\\\\.css\\\\?ced0,\\\\.\\\\/style8\\\\.css\\\\?d3b8,\\\\.\\\\/style8\\\\.css\\\\?3557,\\\\.\\\\/style8\\\\.css\\\\?ae6e,\\\\.\\\\/style8\\\\.css\\\\?d078,\\\\.\\\\/style8\\\\.css\\\\?ae8b,\\\\.\\\\/style2\\\\.css\\\\?ee8c,\\\\.\\\\/style9\\\\.css\\\\?5f26,\\\\.\\\\/style9\\\\.css\\\\?6536,\\\\.\\\\/style11\\\\.css,\\\\.\\\\/style12\\\\.css,\\\\.\\\\/style10\\\\.css,\\\\.\\\\/media-deep-deep-nested\\\\.css\\\\?1b5b,\\\\.\\\\/media-deep-nested\\\\.css,\\\\.\\\\/media-nested\\\\.css,\\\\.\\\\/supports-deep-deep-nested\\\\.css,\\\\.\\\\/supports-deep-nested\\\\.css,\\\\.\\\\/supports-nested\\\\.css,\\\\.\\\\/layer-deep-deep-nested\\\\.css\\\\?2bf1,\\\\.\\\\/layer-deep-nested\\\\.css\\\\?3469,\\\\.\\\\/layer-nested\\\\.css,\\\\.\\\\/all-deep-deep-nested\\\\.css\\\\?a7dd,\\\\.\\\\/all-deep-nested\\\\.css\\\\?5612,\\\\.\\\\/all-nested\\\\.css\\\\?a3fd,\\\\.\\\\/mixed-deep-deep-nested\\\\.css,\\\\.\\\\/mixed-deep-nested\\\\.css,\\\\.\\\\/mixed-nested\\\\.css,\\\\.\\\\/anonymous-deep-deep-nested\\\\.css\\\\?8f95,\\\\.\\\\/anonymous-deep-nested\\\\.css\\\\?40b5,\\\\.\\\\/layer-deep-deep-nested\\\\.css\\\\?e681,\\\\.\\\\/layer-deep-nested\\\\.css\\\\?dc2a,\\\\.\\\\/anonymous-nested\\\\.css\\\\?8aa8,\\\\.\\\\/media-deep-deep-nested\\\\.css\\\\?3aba,\\\\.\\\\/style8\\\\.css\\\\?83bd,\\\\.\\\\/duplicate-nested\\\\.css,\\\\.\\\\/anonymous-deep-deep-nested\\\\.css\\\\?384f,\\\\.\\\\/anonymous-deep-nested\\\\.css\\\\?8c49,\\\\.\\\\/layer-deep-deep-nested\\\\.css\\\\?17f5,\\\\.\\\\/layer-deep-nested\\\\.css\\\\?c345,\\\\.\\\\/anonymous-nested\\\\.css\\\\?d028,\\\\.\\\\/all-deep-deep-nested\\\\.css\\\\?220a,\\\\.\\\\/all-deep-nested\\\\.css\\\\?7c65,\\\\.\\\\/all-nested\\\\.css\\\\?5ae5,\\\\.\\\\/style\\\\.css;}",
-]
-`;
-
-exports[`ConfigCacheTestCases css pure-css exported tests should compile 1`] = `
-Array [
-  ".class {
+.class {
 	color: red;
 	background: var(--color);
 }
@@ -1121,7 +584,7 @@ Array [
 	animation: test 1s, test;
 }
 
-head{--webpack-main:\\\\.\\\\/style\\\\.css;}",
+head{--webpack-main:\\\\.\\\\.\\\\/css-modules\\\\/style\\\\.module\\\\.css,\\\\.\\\\/style\\\\.css;}",
 ]
 `;
 

--- a/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
+++ b/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
@@ -1681,6 +1681,37 @@ Array [
 }
 
 .class {
+	.class {
+		.class {
+			.class {}
+		}
+	}
+}
+
+.class {
+	.class {
+		.class {
+			.class {
+				animation: slidein 3s;
+			}
+		}
+	}
+}
+
+.class {
+	animation: slidein 3s;
+	.class {
+		animation: slidein 3s;
+		.class {
+			animation: slidein 3s;
+			.class {
+				animation: slidein 3s;
+			}
+		}
+	}
+}
+
+.class {
 	color: red;
 	background: var(--color);
 }

--- a/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
+++ b/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
@@ -1,5 +1,1086 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ConfigCacheTestCases css css-import exported tests should compile 1`] = `
+Array [
+  "body {
+	externally-imported: true;
+}
+
+body {
+	externally-imported1: true;
+}
+
+body {
+	externally-imported2: true;
+}
+
+body {
+	background: black;
+}
+
+body {
+	background: black;
+}
+
+@layer default {
+	body {
+		background: black;
+	}
+}
+
+@layer default {
+	body {
+		background: black;
+	}
+}
+
+@supports (display: flex) {
+	body {
+		background: black;
+	}
+}
+
+@supports (display: flex) {
+	body {
+		background: black;
+	}
+}
+
+@media screen and (min-width: 400px) {
+	body {
+		background: black;
+	}
+}
+
+@media screen and (min-width: 400px) {
+	body {
+		background: black;
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		body {
+			background: black;
+		}
+	}
+}
+
+@layer default {
+	@media screen and (min-width: 400px) {
+		body {
+			background: black;
+		}
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (min-width: 400px) {
+		body {
+			background: black;
+		}
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			body {
+				background: black;
+			}
+		}
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			body {
+				background: black;
+			}
+		}
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			body {
+				background: black;
+			}
+		}
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			body {
+				background: black;
+			}
+		}
+	}
+}
+
+@layer default {
+	@supports (background: url(./img.png)) {
+		@media screen and (min-width: 400px) {
+			body {
+				background: black;
+			}
+		}
+	}
+}
+
+@layer default {
+	@supports (background: url(\\"./img.png\\")) {
+		@media screen and (min-width: 400px) {
+			body {
+				background: black;
+			}
+		}
+	}
+}
+
+@media screen {
+	body {
+		background: black;
+	}
+}
+
+@media screen {
+	body {
+		background: black;
+	}
+}
+
+@media screen {
+	body {
+		background: black;
+	}
+}
+
+body {
+	background: black;
+}
+
+body {
+	background: green;
+}
+
+@layer base {
+	body {
+		background: green;
+	}
+}
+
+@supports (display: flex) {
+	body {
+		background: green;
+	}
+}
+
+@media screen, print {
+	body {
+		background: green;
+	}
+}
+
+a {
+	color: red;
+}
+
+a {
+	color: red;
+}
+
+a {
+	color: red;
+}
+
+a {
+	color: red;
+}
+
+a {
+	color: red;
+}
+
+a {
+	color: red;
+}
+
+a {
+	color: red;
+}
+
+a {
+	color: red;
+}
+
+a {
+	color: red;
+}
+
+@media screen and (orientation:landscape) {
+	a {
+		color: red;
+	}
+}
+
+@media SCREEN AND (ORIENTATION: LANDSCAPE) {
+	a {
+		color: red;
+	}
+}
+
+@media (min-width: 100px) {
+	a {
+		color: red;
+	}
+}
+
+.class {
+	content: \\"style.css\\";
+	color: red;
+}
+
+.class {
+	content: \\"style.css\\";
+	color: red;
+}
+
+.class {
+	content: \\"style.css\\";
+	color: red;
+}
+
+.class {
+	content: \\"style.css\\";
+	color: red;
+}
+
+.class {
+	content: \\"style7.css\\";
+}
+
+.class {
+	content: \\"style7.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test.css\\";
+}
+
+.class {
+	content: \\"test.css\\";
+}
+
+.class {
+	content: \\"test.css\\";
+}
+
+.class {
+	content: \\"test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"style6.css\\";
+}
+
+.class {
+	content: \\"style4.css\\";
+}
+
+.class {
+	content: \\"style4.css\\";
+}
+
+.class {
+	content: \\"style4.css\\";
+}
+
+@supports (display: flex) {
+	.class {
+		content: \\"style4.css\\";
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (orientation:landscape) {
+		.class {
+			content: \\"style4.css\\";
+		}
+	}
+}
+
+.class {
+	content: \\"style4.css\\";
+}
+
+.class {
+	content: \\"style4.css\\";
+}
+
+.class {
+	content: \\"style4.css\\";
+}
+
+a {
+  color: red;
+}
+@media screen and (orientation:landscape) {
+	a {
+	  color: blue;
+	}}
+
+.class {
+	content: \\"style5.css\\";
+}
+
+.class {
+	content: \\"style5.css\\";
+}
+
+@supports (unknown) {
+	.class {
+		content: \\"style5.css\\";
+	}
+}
+
+@supports (display: flex) {
+	.class {
+		content: \\"style5.css\\";
+	}
+}
+
+@supports (display: flex !important) {
+	.class {
+		content: \\"style5.css\\";
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (min-width: 400px) {
+		.class {
+			content: \\"style5.css\\";
+		}
+	}
+}
+
+@supports (selector(a b)) {
+	.class {
+		content: \\"style5.css\\";
+	}
+}
+
+@supports (display: flex) {
+	.class {
+		content: \\"style5.css\\";
+	}
+}
+
+@layer {
+	.class {
+		content: \\"layer.css\\";
+	}
+}
+
+@layer default {
+	.class {
+		content: \\"layer.css\\";
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			.class {
+				content: \\"layer.css\\";
+			}
+		}
+	}
+}
+
+@layer {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			.class {
+				content: \\"layer.css\\";
+			}
+		}
+	}
+}
+
+@layer {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			.class {
+				content: \\"layer.css\\";
+			}
+		}
+	}
+}
+
+@layer {
+	.class {
+		content: \\"layer.css\\";
+	}
+}
+
+@layer foo.bar.baz {
+	.class {
+		content: \\"layer.css\\";
+	}
+}
+
+@layer {
+	.class {
+		content: \\"layer.css\\";
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		@media screen and (min-width:400px) {
+			.class {
+				content: \\"style6.css\\";
+			}
+		}
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		@media screen and (min-width:400px) {
+			.class {
+				content: \\"style6.css\\";
+			}
+		}
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (min-width:400px) {
+		.class {
+			content: \\"style6.css\\";
+		}
+	}
+}
+
+@media screen and (min-width:400px) {
+	.class {
+		content: \\"style6.css\\";
+	}
+}
+
+@media screen and (min-width:400px) {
+	.class {
+		content: \\"style6.css\\";
+	}
+}
+
+@media screen and (min-width:400px) {
+	.class {
+		content: \\"style6.css\\";
+	}
+}
+
+@layer default {
+	@supports (display     :     flex) {
+		@media screen     and     (     min-width     :     400px     ) {
+			.class {
+				content: \\"style6.css\\";
+			}
+		}
+	}
+}
+
+@layer DEFAULT {
+	@supports (DISPLAY: FLEX) {
+		@media SCREEN AND (MIN-WIDTH: 400PX) {
+			.class {
+				content: \\"style6.css\\";
+			}
+		}
+	}
+}
+
+@layer {
+	@supports (DISPLAY: FLEX) {
+		@media SCREEN AND (MIN-WIDTH: 400PX) {
+			.class {
+				content: \\"style6.css\\";
+			}
+		}
+	}
+}
+
+@layer /* Comment */default/* Comment */ {
+	@supports (/* Comment */display/* Comment */:/* Comment */ flex/* Comment */) {
+		@media /* Comment */ screen/* Comment */ and/* Comment */ (/* Comment */min-width/* Comment */: /* Comment */400px/* Comment */) {
+			.class {
+				content: \\"style6.css\\";
+			}
+		}
+	}
+}
+
+.class {
+	content: \\"style6.css\\";
+}
+
+.class {
+	content: \\"style6.css\\";
+}
+
+.class {
+	content: \\"style6.css\\";
+}
+
+.class {
+	content: \\"style6.css\\";
+}
+
+.class {
+	content: \\"style6.css\\";
+}
+
+.class {
+	content: \\"style6.css\\";
+}
+
+@media /* Comment */ print and (orientation:landscape) {
+	.class {
+		content: \\"style6.css\\";
+	}
+}
+
+@media /* Comment */print and (orientation:landscape)/* Comment */ {
+	.class {
+		content: \\"style6.css\\";
+	}
+}
+
+@media /* Comment */ print and (orientation:landscape) {
+	.class {
+		content: \\"style6.css\\";
+	}
+}
+
+@media screen and (min-width: 400px) {
+	.class {
+		content: \\"style8.css\\";
+	}
+}
+
+@media (prefers-color-scheme: dark) {
+	.class {
+		content: \\"style8.css\\";
+	}
+}
+
+@supports (display: flex) {
+	.class {
+		content: \\"style8.css\\";
+	}
+}
+
+@supports (((display: flex))) {
+	.class {
+		content: \\"style8.css\\";
+	}
+}
+
+@supports (((display: inline-grid))) {
+	@media screen and (((min-width: 400px))) {
+		.class {
+			content: \\"style8.css\\";
+		}
+	}
+}
+
+@supports (display: grid) {
+	.class {
+		content: \\"style8.css\\";
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (min-width: 400px) {
+		.class {
+			content: \\"style8.css\\";
+		}
+	}
+}
+
+@layer framework {
+	.class {
+		content: \\"style8.css\\";
+	}
+}
+
+@layer default {
+	.class {
+		content: \\"style8.css\\";
+	}
+}
+
+@layer base {
+	.class {
+		content: \\"style8.css\\";
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		.class {
+			content: \\"style8.css\\";
+		}
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			.class {
+				content: \\"style8.css\\";
+			}
+		}
+	}
+}
+
+@layer {
+	a {
+		color: red;
+	}
+}
+
+@media unknown(default) unknown(display: flex) unknown {
+	.class {
+		content: \\"style9.css\\";
+	}
+}
+
+@media unknown(default) {
+	.class {
+		content: \\"style9.css\\";
+	}
+}
+
+.style11 {
+	color: red;
+}
+
+.style12 {
+	color: red;
+}
+
+.style10 {
+	color: red;
+}
+
+@media screen and (min-width: 400px) {
+	@media screen and (max-width: 500px) {
+		@media screen and (orientation: portrait) {
+			.class {
+				deep-deep-nested: 1;
+			}
+		}
+	}
+}
+
+@media screen and (min-width: 400px) {
+	@media screen and (max-width: 500px) {
+		.class {
+			deep-nested: 1;
+		}
+	}
+}
+
+@media screen and (min-width: 400px) {
+	.class {
+		nested: 1;
+	}
+}
+
+@supports (display: flex) {
+	@supports (display: grid) {
+		@supports (display: table) {
+			.class {
+				deep-deep-nested: 1;
+			}
+		}
+	}
+}
+
+@supports (display: flex) {
+	@supports (display: grid) {
+		.class {
+			deep-nested: 1;
+		}
+	}
+}
+
+@supports (display: flex) {
+	.class {
+		nested: 1;
+	}
+}
+
+@layer foo {
+	@layer bar {
+		@layer baz {
+			.class {
+				deep-deep-nested: 1;
+			}
+		}
+	}
+}
+
+@layer foo {
+	@layer bar {
+		.class {
+			deep-nested: 1;
+		}
+	}
+}
+
+@layer foo {
+	.class {
+		nested: 1;
+	}
+}
+
+@layer foo {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			@layer bar {
+				@supports (display: grid) {
+					@media screen and (min-width: 500px) {
+						@layer baz {
+							@supports (display: table) {
+								@media screen and (min-width: 600px) {
+									.class {
+										deep-deep-nested: 1;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+@layer foo {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			@layer bar {
+				@supports (display: grid) {
+					@media screen and (min-width: 500px) {
+						.class {
+							deep-nested: 1;
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+@layer foo {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			.class {
+				nested: 1;
+			}
+		}
+	}
+}
+
+@media screen and (min-width: 400px) {
+	@supports (display: flex) {
+		@layer bar {
+			.class {
+				deep-deep-nested: 1;
+			}
+		}
+	}
+}
+
+@media screen and (min-width: 400px) {
+	@supports (display: flex) {
+		.class {
+			deep-nested: 1;
+		}
+	}
+}
+
+@media screen and (min-width: 400px) {
+	.class {
+		nested: 1;
+	}
+}
+
+@layer {
+	@layer {
+		@layer {
+			.class {
+				deep-deep-nested: 1;
+			}
+		}
+	}
+}
+
+@layer {
+	@layer {
+		.class {
+			deep-nested: 1;
+		}
+	}
+}
+
+@layer {
+	@layer base {
+		@layer baz {
+			.class {
+				deep-deep-nested: 1;
+			}
+		}
+	}
+}
+
+@layer {
+	@layer base {
+		.class {
+			deep-nested: 1;
+		}
+	}
+}
+
+@layer {
+	.class {
+		deep-nested: 1;
+	}
+}
+
+@media screen and (orientation: portrait) {
+	.class {
+		deep-deep-nested: 1;
+	}
+}
+
+@media screen and (orientation: portrait) {
+	@supports (display: flex) {
+		.class {
+			content: \\"style8.css\\";
+		}
+	}
+}
+
+@media screen and (orientation: portrait) {
+	.class {
+		duplicate-nested: true;
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (orientation: portrait) {
+		@layer {
+			@layer {
+				.class {
+					deep-deep-nested: 1;
+				}
+			}
+		}
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (orientation: portrait) {
+		@layer {
+			.class {
+				deep-nested: 1;
+			}
+		}
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (orientation: portrait) {
+		@layer base {
+			@layer baz {
+				.class {
+					deep-deep-nested: 1;
+				}
+			}
+		}
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (orientation: portrait) {
+		@layer base {
+			.class {
+				deep-nested: 1;
+			}
+		}
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (orientation: portrait) {
+		.class {
+			deep-nested: 1;
+		}
+	}
+}
+
+@layer super.foo {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			@layer bar {
+				@supports (display: grid) {
+					@media screen and (min-width: 500px) {
+						@layer baz {
+							@supports (display: table) {
+								@media screen and (min-width: 600px) {
+									.class {
+										deep-deep-nested: 1;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+@layer super.foo {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			@layer bar {
+				@supports (display: grid) {
+					@media screen and (min-width: 500px) {
+						.class {
+							deep-nested: 1;
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+@layer super.foo {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			.class {
+				nested: 1;
+			}
+		}
+	}
+}
+
+/* Has the same URL */
+/*@import url();
+@import url('');
+@import url(\\"\\");
+@import '';
+@import \\"\\";
+@import \\"   \\";
+@import \\"\\\\
+\\";
+@import url();
+@import url('');
+@import url(\\"\\");*/
+/*@import url(https://test.cases/path/../../../../configCases/css/css-import/external.css) screen and (orientation:landscape);
+@import url(https://test.cases/path/../../../../configCases/css/css-import/external.css) screen and (orientation:landscape);*/
+/*@import \\"//example.com/style.css\\";*/
+/*@import url(~package/test.css);*/
+/*@import ;*/
+/*@import foo-bar;*/
+/*@import-normalize;*/
+/*@import url('http://') :root {}*/
+/*@import url('query.css?foo=1&bar=1');*/
+/*@import url('other-query.css?foo=1&bar=1#hash');*/
+/*@import url('other-query.css?foo=1&bar=1#hash') screen and (orientation:landscape);*/
+/*@import url('https://fonts.googleapis.com/css?family=Roboto');*/
+/*@import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC');*/
+/*@import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto');*/
+
+/*@import nourl(test.css);
+@import '\\\\
+\\\\
+\\\\
+';
+@import url('!!../../helpers/string-loader.js?esModule=false!~package/tilde.css');*/
+/*@import url('   https://fonts.googleapis.com/css?family=Roboto   ');*/
+/*@import url('!!../../helpers/string-loader.js?esModule=false!');*/
+/*@import url('   !!../../helpers/string-loader.js?esModule=false!~package/tilde.css   ');*/
+/*@import \\"http://example.com/style.css\\" supports(display: flex) screen and (min-width: 400px);*/
+/* anonymous */
+/* All unknown parse as media for compatibility */
+body {
+	background: red;
+}
+
+head{--webpack-main:https\\\\:\\\\/\\\\/test\\\\.cases\\\\/path\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/configCases\\\\/css\\\\/css-import\\\\/external\\\\.css,https\\\\:\\\\/\\\\/test\\\\.cases\\\\/path\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/configCases\\\\/css\\\\/css-import\\\\/external1\\\\.css,https\\\\:\\\\/\\\\/test\\\\.cases\\\\/path\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/configCases\\\\/css\\\\/css-import\\\\/external2\\\\.css,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=9,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=10,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=11,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=12,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=13,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=14,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=15,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=16,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=17,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=18,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=19,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=20,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=21,\\\\.\\\\/imported\\\\.css\\\\?2fc7,\\\\.\\\\/imported\\\\.css\\\\?8e23,\\\\.\\\\/imported\\\\.css\\\\?daf4,\\\\.\\\\/imported\\\\.css\\\\?7a8d,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=9,\\\\.\\\\/style2\\\\.css\\\\?3989,\\\\.\\\\/style2\\\\.css\\\\?1933,\\\\.\\\\/style2\\\\.css\\\\?6611,\\\\.\\\\/style3\\\\.css\\\\?bar\\\\=1,\\\\.\\\\/style3\\\\.css\\\\?bar\\\\=2,\\\\.\\\\/style3\\\\.css\\\\?bar\\\\=3,\\\\.\\\\/style3\\\\.css\\\\?\\\\=bar4,\\\\.\\\\/styl\\\\'le7\\\\.css,\\\\.\\\\/styl\\\\'le7\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/test\\\\ test\\\\.css,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/test\\\\.css,\\\\.\\\\/test\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/test\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/test\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=9,\\\\.\\\\/test\\\\ test\\\\.css\\\\?fpp\\\\=10,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=11,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=bazz,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=bar,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=bar\\\\#hash,\\\\.\\\\/style4\\\\.css\\\\?\\\\#hash,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=5,data\\\\:text\\\\/css\\\\;charset\\\\=utf-8\\\\,a\\\\%20\\\\%7B\\\\%0D\\\\%0A\\\\%20\\\\%20color\\\\%3A\\\\%20red\\\\%3B\\\\%0D\\\\%0A\\\\%7D,data\\\\:text\\\\/css\\\\;charset\\\\=utf-8\\\\,a\\\\%20\\\\%7B\\\\%0D\\\\%0A\\\\%20\\\\%20color\\\\%3A\\\\%20blue\\\\%3B\\\\%0D\\\\%0A\\\\%7D,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=3\\\\?14ba,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=3\\\\?0e0d,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/style6\\\\.css,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=9,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=10,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=11,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=12,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=13,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=14,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=15,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=16,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=17,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=18,\\\\.\\\\/style8\\\\.css\\\\?5018,\\\\.\\\\/style8\\\\.css\\\\?204b,\\\\.\\\\/style8\\\\.css\\\\?63b0,\\\\.\\\\/style8\\\\.css\\\\?edb8,\\\\.\\\\/style8\\\\.css\\\\?6154,\\\\.\\\\/style8\\\\.css\\\\?8c51,\\\\.\\\\/style8\\\\.css\\\\?ced0,\\\\.\\\\/style8\\\\.css\\\\?d3b8,\\\\.\\\\/style8\\\\.css\\\\?3557,\\\\.\\\\/style8\\\\.css\\\\?ae6e,\\\\.\\\\/style8\\\\.css\\\\?d078,\\\\.\\\\/style8\\\\.css\\\\?ae8b,\\\\.\\\\/style2\\\\.css\\\\?ee8c,\\\\.\\\\/style9\\\\.css\\\\?5f26,\\\\.\\\\/style9\\\\.css\\\\?6536,\\\\.\\\\/style11\\\\.css,\\\\.\\\\/style12\\\\.css,\\\\.\\\\/style10\\\\.css,\\\\.\\\\/media-deep-deep-nested\\\\.css\\\\?1b5b,\\\\.\\\\/media-deep-nested\\\\.css,\\\\.\\\\/media-nested\\\\.css,\\\\.\\\\/supports-deep-deep-nested\\\\.css,\\\\.\\\\/supports-deep-nested\\\\.css,\\\\.\\\\/supports-nested\\\\.css,\\\\.\\\\/layer-deep-deep-nested\\\\.css\\\\?2bf1,\\\\.\\\\/layer-deep-nested\\\\.css\\\\?3469,\\\\.\\\\/layer-nested\\\\.css,\\\\.\\\\/all-deep-deep-nested\\\\.css\\\\?a7dd,\\\\.\\\\/all-deep-nested\\\\.css\\\\?5612,\\\\.\\\\/all-nested\\\\.css\\\\?a3fd,\\\\.\\\\/mixed-deep-deep-nested\\\\.css,\\\\.\\\\/mixed-deep-nested\\\\.css,\\\\.\\\\/mixed-nested\\\\.css,\\\\.\\\\/anonymous-deep-deep-nested\\\\.css\\\\?8f95,\\\\.\\\\/anonymous-deep-nested\\\\.css\\\\?40b5,\\\\.\\\\/layer-deep-deep-nested\\\\.css\\\\?e681,\\\\.\\\\/layer-deep-nested\\\\.css\\\\?dc2a,\\\\.\\\\/anonymous-nested\\\\.css\\\\?8aa8,\\\\.\\\\/media-deep-deep-nested\\\\.css\\\\?3aba,\\\\.\\\\/style8\\\\.css\\\\?83bd,\\\\.\\\\/duplicate-nested\\\\.css,\\\\.\\\\/anonymous-deep-deep-nested\\\\.css\\\\?384f,\\\\.\\\\/anonymous-deep-nested\\\\.css\\\\?8c49,\\\\.\\\\/layer-deep-deep-nested\\\\.css\\\\?17f5,\\\\.\\\\/layer-deep-nested\\\\.css\\\\?c345,\\\\.\\\\/anonymous-nested\\\\.css\\\\?d028,\\\\.\\\\/all-deep-deep-nested\\\\.css\\\\?220a,\\\\.\\\\/all-deep-nested\\\\.css\\\\?7c65,\\\\.\\\\/all-nested\\\\.css\\\\?5ae5,\\\\.\\\\/style\\\\.css;}",
+]
+`;
+
 exports[`ConfigCacheTestCases css pure-css exported tests should compile 1`] = `
 Array [
   ".class {
@@ -541,6 +1622,20 @@ Array [
 	@media screen {
 		:global .my-global-class-again,
 		:local .my-global-class-again {
+			color: red;
+		}
+	}
+}
+
+.first-nested {
+	.first-nested-nested {
+		color: red;
+	}
+}
+
+.first-nested-at-rule {
+	@media screen {
+		.first-nested-nested-at-rule-deep {
 			color: red;
 		}
 	}

--- a/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
+++ b/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
@@ -1034,6 +1034,45 @@ a {
 	}
 }
 
+/* Has the same URL */
+/*@import url();
+@import url('');
+@import url(\\"\\");
+@import '';
+@import \\"\\";
+@import \\"   \\";
+@import \\"\\\\
+\\";
+@import url();
+@import url('');
+@import url(\\"\\");*/
+/*@import url(https://test.cases/path/../../../../configCases/css/css-import/external.css) screen and (orientation:landscape);
+@import url(https://test.cases/path/../../../../configCases/css/css-import/external.css) screen and (orientation:landscape);*/
+/*@import \\"//example.com/style.css\\";*/
+/*@import url(~package/test.css);*/
+/*@import ;*/
+/*@import foo-bar;*/
+/*@import-normalize;*/
+/*@import url('http://') :root {}*/
+/*@import url('query.css?foo=1&bar=1');*/
+/*@import url('other-query.css?foo=1&bar=1#hash');*/
+/*@import url('other-query.css?foo=1&bar=1#hash') screen and (orientation:landscape);*/
+/*@import url('https://fonts.googleapis.com/css?family=Roboto');*/
+/*@import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC');*/
+/*@import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto');*/
+
+/*@import nourl(test.css);
+@import '\\\\
+\\\\
+\\\\
+';
+@import url('!!../../helpers/string-loader.js?esModule=false!~package/tilde.css');*/
+/*@import url('   https://fonts.googleapis.com/css?family=Roboto   ');*/
+/*@import url('!!../../helpers/string-loader.js?esModule=false!');*/
+/*@import url('   !!../../helpers/string-loader.js?esModule=false!~package/tilde.css   ');*/
+/*@import \\"http://example.com/style.css\\" supports(display: flex) screen and (min-width: 400px);*/
+/* anonymous */
+/* All unknown parse as media for compatibility */
 body {
 	background: red;
 }

--- a/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
+++ b/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
@@ -1078,6 +1078,10 @@ Array [
 	foo: bar;
 }
 
+.class {
+	animation: test 1s, test;
+}
+
 head{--webpack-main:\\\\.\\\\/style\\\\.css;}",
 ]
 `;

--- a/test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -1,5 +1,1086 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ConfigTestCases css css-import exported tests should compile 1`] = `
+Array [
+  "body {
+	externally-imported: true;
+}
+
+body {
+	externally-imported1: true;
+}
+
+body {
+	externally-imported2: true;
+}
+
+body {
+	background: black;
+}
+
+body {
+	background: black;
+}
+
+@layer default {
+	body {
+		background: black;
+	}
+}
+
+@layer default {
+	body {
+		background: black;
+	}
+}
+
+@supports (display: flex) {
+	body {
+		background: black;
+	}
+}
+
+@supports (display: flex) {
+	body {
+		background: black;
+	}
+}
+
+@media screen and (min-width: 400px) {
+	body {
+		background: black;
+	}
+}
+
+@media screen and (min-width: 400px) {
+	body {
+		background: black;
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		body {
+			background: black;
+		}
+	}
+}
+
+@layer default {
+	@media screen and (min-width: 400px) {
+		body {
+			background: black;
+		}
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (min-width: 400px) {
+		body {
+			background: black;
+		}
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			body {
+				background: black;
+			}
+		}
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			body {
+				background: black;
+			}
+		}
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			body {
+				background: black;
+			}
+		}
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			body {
+				background: black;
+			}
+		}
+	}
+}
+
+@layer default {
+	@supports (background: url(./img.png)) {
+		@media screen and (min-width: 400px) {
+			body {
+				background: black;
+			}
+		}
+	}
+}
+
+@layer default {
+	@supports (background: url(\\"./img.png\\")) {
+		@media screen and (min-width: 400px) {
+			body {
+				background: black;
+			}
+		}
+	}
+}
+
+@media screen {
+	body {
+		background: black;
+	}
+}
+
+@media screen {
+	body {
+		background: black;
+	}
+}
+
+@media screen {
+	body {
+		background: black;
+	}
+}
+
+body {
+	background: black;
+}
+
+body {
+	background: green;
+}
+
+@layer base {
+	body {
+		background: green;
+	}
+}
+
+@supports (display: flex) {
+	body {
+		background: green;
+	}
+}
+
+@media screen, print {
+	body {
+		background: green;
+	}
+}
+
+a {
+	color: red;
+}
+
+a {
+	color: red;
+}
+
+a {
+	color: red;
+}
+
+a {
+	color: red;
+}
+
+a {
+	color: red;
+}
+
+a {
+	color: red;
+}
+
+a {
+	color: red;
+}
+
+a {
+	color: red;
+}
+
+a {
+	color: red;
+}
+
+@media screen and (orientation:landscape) {
+	a {
+		color: red;
+	}
+}
+
+@media SCREEN AND (ORIENTATION: LANDSCAPE) {
+	a {
+		color: red;
+	}
+}
+
+@media (min-width: 100px) {
+	a {
+		color: red;
+	}
+}
+
+.class {
+	content: \\"style.css\\";
+	color: red;
+}
+
+.class {
+	content: \\"style.css\\";
+	color: red;
+}
+
+.class {
+	content: \\"style.css\\";
+	color: red;
+}
+
+.class {
+	content: \\"style.css\\";
+	color: red;
+}
+
+.class {
+	content: \\"style7.css\\";
+}
+
+.class {
+	content: \\"style7.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test.css\\";
+}
+
+.class {
+	content: \\"test.css\\";
+}
+
+.class {
+	content: \\"test.css\\";
+}
+
+.class {
+	content: \\"test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"test test.css\\";
+}
+
+.class {
+	content: \\"style6.css\\";
+}
+
+.class {
+	content: \\"style4.css\\";
+}
+
+.class {
+	content: \\"style4.css\\";
+}
+
+.class {
+	content: \\"style4.css\\";
+}
+
+@supports (display: flex) {
+	.class {
+		content: \\"style4.css\\";
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (orientation:landscape) {
+		.class {
+			content: \\"style4.css\\";
+		}
+	}
+}
+
+.class {
+	content: \\"style4.css\\";
+}
+
+.class {
+	content: \\"style4.css\\";
+}
+
+.class {
+	content: \\"style4.css\\";
+}
+
+a {
+  color: red;
+}
+@media screen and (orientation:landscape) {
+	a {
+	  color: blue;
+	}}
+
+.class {
+	content: \\"style5.css\\";
+}
+
+.class {
+	content: \\"style5.css\\";
+}
+
+@supports (unknown) {
+	.class {
+		content: \\"style5.css\\";
+	}
+}
+
+@supports (display: flex) {
+	.class {
+		content: \\"style5.css\\";
+	}
+}
+
+@supports (display: flex !important) {
+	.class {
+		content: \\"style5.css\\";
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (min-width: 400px) {
+		.class {
+			content: \\"style5.css\\";
+		}
+	}
+}
+
+@supports (selector(a b)) {
+	.class {
+		content: \\"style5.css\\";
+	}
+}
+
+@supports (display: flex) {
+	.class {
+		content: \\"style5.css\\";
+	}
+}
+
+@layer {
+	.class {
+		content: \\"layer.css\\";
+	}
+}
+
+@layer default {
+	.class {
+		content: \\"layer.css\\";
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			.class {
+				content: \\"layer.css\\";
+			}
+		}
+	}
+}
+
+@layer {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			.class {
+				content: \\"layer.css\\";
+			}
+		}
+	}
+}
+
+@layer {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			.class {
+				content: \\"layer.css\\";
+			}
+		}
+	}
+}
+
+@layer {
+	.class {
+		content: \\"layer.css\\";
+	}
+}
+
+@layer foo.bar.baz {
+	.class {
+		content: \\"layer.css\\";
+	}
+}
+
+@layer {
+	.class {
+		content: \\"layer.css\\";
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		@media screen and (min-width:400px) {
+			.class {
+				content: \\"style6.css\\";
+			}
+		}
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		@media screen and (min-width:400px) {
+			.class {
+				content: \\"style6.css\\";
+			}
+		}
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (min-width:400px) {
+		.class {
+			content: \\"style6.css\\";
+		}
+	}
+}
+
+@media screen and (min-width:400px) {
+	.class {
+		content: \\"style6.css\\";
+	}
+}
+
+@media screen and (min-width:400px) {
+	.class {
+		content: \\"style6.css\\";
+	}
+}
+
+@media screen and (min-width:400px) {
+	.class {
+		content: \\"style6.css\\";
+	}
+}
+
+@layer default {
+	@supports (display     :     flex) {
+		@media screen     and     (     min-width     :     400px     ) {
+			.class {
+				content: \\"style6.css\\";
+			}
+		}
+	}
+}
+
+@layer DEFAULT {
+	@supports (DISPLAY: FLEX) {
+		@media SCREEN AND (MIN-WIDTH: 400PX) {
+			.class {
+				content: \\"style6.css\\";
+			}
+		}
+	}
+}
+
+@layer {
+	@supports (DISPLAY: FLEX) {
+		@media SCREEN AND (MIN-WIDTH: 400PX) {
+			.class {
+				content: \\"style6.css\\";
+			}
+		}
+	}
+}
+
+@layer /* Comment */default/* Comment */ {
+	@supports (/* Comment */display/* Comment */:/* Comment */ flex/* Comment */) {
+		@media /* Comment */ screen/* Comment */ and/* Comment */ (/* Comment */min-width/* Comment */: /* Comment */400px/* Comment */) {
+			.class {
+				content: \\"style6.css\\";
+			}
+		}
+	}
+}
+
+.class {
+	content: \\"style6.css\\";
+}
+
+.class {
+	content: \\"style6.css\\";
+}
+
+.class {
+	content: \\"style6.css\\";
+}
+
+.class {
+	content: \\"style6.css\\";
+}
+
+.class {
+	content: \\"style6.css\\";
+}
+
+.class {
+	content: \\"style6.css\\";
+}
+
+@media /* Comment */ print and (orientation:landscape) {
+	.class {
+		content: \\"style6.css\\";
+	}
+}
+
+@media /* Comment */print and (orientation:landscape)/* Comment */ {
+	.class {
+		content: \\"style6.css\\";
+	}
+}
+
+@media /* Comment */ print and (orientation:landscape) {
+	.class {
+		content: \\"style6.css\\";
+	}
+}
+
+@media screen and (min-width: 400px) {
+	.class {
+		content: \\"style8.css\\";
+	}
+}
+
+@media (prefers-color-scheme: dark) {
+	.class {
+		content: \\"style8.css\\";
+	}
+}
+
+@supports (display: flex) {
+	.class {
+		content: \\"style8.css\\";
+	}
+}
+
+@supports (((display: flex))) {
+	.class {
+		content: \\"style8.css\\";
+	}
+}
+
+@supports (((display: inline-grid))) {
+	@media screen and (((min-width: 400px))) {
+		.class {
+			content: \\"style8.css\\";
+		}
+	}
+}
+
+@supports (display: grid) {
+	.class {
+		content: \\"style8.css\\";
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (min-width: 400px) {
+		.class {
+			content: \\"style8.css\\";
+		}
+	}
+}
+
+@layer framework {
+	.class {
+		content: \\"style8.css\\";
+	}
+}
+
+@layer default {
+	.class {
+		content: \\"style8.css\\";
+	}
+}
+
+@layer base {
+	.class {
+		content: \\"style8.css\\";
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		.class {
+			content: \\"style8.css\\";
+		}
+	}
+}
+
+@layer default {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			.class {
+				content: \\"style8.css\\";
+			}
+		}
+	}
+}
+
+@layer {
+	a {
+		color: red;
+	}
+}
+
+@media unknown(default) unknown(display: flex) unknown {
+	.class {
+		content: \\"style9.css\\";
+	}
+}
+
+@media unknown(default) {
+	.class {
+		content: \\"style9.css\\";
+	}
+}
+
+.style11 {
+	color: red;
+}
+
+.style12 {
+	color: red;
+}
+
+.style10 {
+	color: red;
+}
+
+@media screen and (min-width: 400px) {
+	@media screen and (max-width: 500px) {
+		@media screen and (orientation: portrait) {
+			.class {
+				deep-deep-nested: 1;
+			}
+		}
+	}
+}
+
+@media screen and (min-width: 400px) {
+	@media screen and (max-width: 500px) {
+		.class {
+			deep-nested: 1;
+		}
+	}
+}
+
+@media screen and (min-width: 400px) {
+	.class {
+		nested: 1;
+	}
+}
+
+@supports (display: flex) {
+	@supports (display: grid) {
+		@supports (display: table) {
+			.class {
+				deep-deep-nested: 1;
+			}
+		}
+	}
+}
+
+@supports (display: flex) {
+	@supports (display: grid) {
+		.class {
+			deep-nested: 1;
+		}
+	}
+}
+
+@supports (display: flex) {
+	.class {
+		nested: 1;
+	}
+}
+
+@layer foo {
+	@layer bar {
+		@layer baz {
+			.class {
+				deep-deep-nested: 1;
+			}
+		}
+	}
+}
+
+@layer foo {
+	@layer bar {
+		.class {
+			deep-nested: 1;
+		}
+	}
+}
+
+@layer foo {
+	.class {
+		nested: 1;
+	}
+}
+
+@layer foo {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			@layer bar {
+				@supports (display: grid) {
+					@media screen and (min-width: 500px) {
+						@layer baz {
+							@supports (display: table) {
+								@media screen and (min-width: 600px) {
+									.class {
+										deep-deep-nested: 1;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+@layer foo {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			@layer bar {
+				@supports (display: grid) {
+					@media screen and (min-width: 500px) {
+						.class {
+							deep-nested: 1;
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+@layer foo {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			.class {
+				nested: 1;
+			}
+		}
+	}
+}
+
+@media screen and (min-width: 400px) {
+	@supports (display: flex) {
+		@layer bar {
+			.class {
+				deep-deep-nested: 1;
+			}
+		}
+	}
+}
+
+@media screen and (min-width: 400px) {
+	@supports (display: flex) {
+		.class {
+			deep-nested: 1;
+		}
+	}
+}
+
+@media screen and (min-width: 400px) {
+	.class {
+		nested: 1;
+	}
+}
+
+@layer {
+	@layer {
+		@layer {
+			.class {
+				deep-deep-nested: 1;
+			}
+		}
+	}
+}
+
+@layer {
+	@layer {
+		.class {
+			deep-nested: 1;
+		}
+	}
+}
+
+@layer {
+	@layer base {
+		@layer baz {
+			.class {
+				deep-deep-nested: 1;
+			}
+		}
+	}
+}
+
+@layer {
+	@layer base {
+		.class {
+			deep-nested: 1;
+		}
+	}
+}
+
+@layer {
+	.class {
+		deep-nested: 1;
+	}
+}
+
+@media screen and (orientation: portrait) {
+	.class {
+		deep-deep-nested: 1;
+	}
+}
+
+@media screen and (orientation: portrait) {
+	@supports (display: flex) {
+		.class {
+			content: \\"style8.css\\";
+		}
+	}
+}
+
+@media screen and (orientation: portrait) {
+	.class {
+		duplicate-nested: true;
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (orientation: portrait) {
+		@layer {
+			@layer {
+				.class {
+					deep-deep-nested: 1;
+				}
+			}
+		}
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (orientation: portrait) {
+		@layer {
+			.class {
+				deep-nested: 1;
+			}
+		}
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (orientation: portrait) {
+		@layer base {
+			@layer baz {
+				.class {
+					deep-deep-nested: 1;
+				}
+			}
+		}
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (orientation: portrait) {
+		@layer base {
+			.class {
+				deep-nested: 1;
+			}
+		}
+	}
+}
+
+@supports (display: flex) {
+	@media screen and (orientation: portrait) {
+		.class {
+			deep-nested: 1;
+		}
+	}
+}
+
+@layer super.foo {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			@layer bar {
+				@supports (display: grid) {
+					@media screen and (min-width: 500px) {
+						@layer baz {
+							@supports (display: table) {
+								@media screen and (min-width: 600px) {
+									.class {
+										deep-deep-nested: 1;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+@layer super.foo {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			@layer bar {
+				@supports (display: grid) {
+					@media screen and (min-width: 500px) {
+						.class {
+							deep-nested: 1;
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+@layer super.foo {
+	@supports (display: flex) {
+		@media screen and (min-width: 400px) {
+			.class {
+				nested: 1;
+			}
+		}
+	}
+}
+
+/* Has the same URL */
+/*@import url();
+@import url('');
+@import url(\\"\\");
+@import '';
+@import \\"\\";
+@import \\"   \\";
+@import \\"\\\\
+\\";
+@import url();
+@import url('');
+@import url(\\"\\");*/
+/*@import url(https://test.cases/path/../../../../configCases/css/css-import/external.css) screen and (orientation:landscape);
+@import url(https://test.cases/path/../../../../configCases/css/css-import/external.css) screen and (orientation:landscape);*/
+/*@import \\"//example.com/style.css\\";*/
+/*@import url(~package/test.css);*/
+/*@import ;*/
+/*@import foo-bar;*/
+/*@import-normalize;*/
+/*@import url('http://') :root {}*/
+/*@import url('query.css?foo=1&bar=1');*/
+/*@import url('other-query.css?foo=1&bar=1#hash');*/
+/*@import url('other-query.css?foo=1&bar=1#hash') screen and (orientation:landscape);*/
+/*@import url('https://fonts.googleapis.com/css?family=Roboto');*/
+/*@import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC');*/
+/*@import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto');*/
+
+/*@import nourl(test.css);
+@import '\\\\
+\\\\
+\\\\
+';
+@import url('!!../../helpers/string-loader.js?esModule=false!~package/tilde.css');*/
+/*@import url('   https://fonts.googleapis.com/css?family=Roboto   ');*/
+/*@import url('!!../../helpers/string-loader.js?esModule=false!');*/
+/*@import url('   !!../../helpers/string-loader.js?esModule=false!~package/tilde.css   ');*/
+/*@import \\"http://example.com/style.css\\" supports(display: flex) screen and (min-width: 400px);*/
+/* anonymous */
+/* All unknown parse as media for compatibility */
+body {
+	background: red;
+}
+
+head{--webpack-main:https\\\\:\\\\/\\\\/test\\\\.cases\\\\/path\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/configCases\\\\/css\\\\/css-import\\\\/external\\\\.css,https\\\\:\\\\/\\\\/test\\\\.cases\\\\/path\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/configCases\\\\/css\\\\/css-import\\\\/external1\\\\.css,https\\\\:\\\\/\\\\/test\\\\.cases\\\\/path\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/configCases\\\\/css\\\\/css-import\\\\/external2\\\\.css,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=9,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=10,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=11,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=12,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=13,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=14,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=15,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=16,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=17,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=18,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=19,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=20,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=21,\\\\.\\\\/imported\\\\.css\\\\?2fc7,\\\\.\\\\/imported\\\\.css\\\\?8e23,\\\\.\\\\/imported\\\\.css\\\\?daf4,\\\\.\\\\/imported\\\\.css\\\\?7a8d,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=9,\\\\.\\\\/style2\\\\.css\\\\?3989,\\\\.\\\\/style2\\\\.css\\\\?1933,\\\\.\\\\/style2\\\\.css\\\\?6611,\\\\.\\\\/style3\\\\.css\\\\?bar\\\\=1,\\\\.\\\\/style3\\\\.css\\\\?bar\\\\=2,\\\\.\\\\/style3\\\\.css\\\\?bar\\\\=3,\\\\.\\\\/style3\\\\.css\\\\?\\\\=bar4,\\\\.\\\\/styl\\\\'le7\\\\.css,\\\\.\\\\/styl\\\\'le7\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/test\\\\ test\\\\.css,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/test\\\\.css,\\\\.\\\\/test\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/test\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/test\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=9,\\\\.\\\\/test\\\\ test\\\\.css\\\\?fpp\\\\=10,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=11,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=bazz,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=bar,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=bar\\\\#hash,\\\\.\\\\/style4\\\\.css\\\\?\\\\#hash,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=5,data\\\\:text\\\\/css\\\\;charset\\\\=utf-8\\\\,a\\\\%20\\\\%7B\\\\%0D\\\\%0A\\\\%20\\\\%20color\\\\%3A\\\\%20red\\\\%3B\\\\%0D\\\\%0A\\\\%7D,data\\\\:text\\\\/css\\\\;charset\\\\=utf-8\\\\,a\\\\%20\\\\%7B\\\\%0D\\\\%0A\\\\%20\\\\%20color\\\\%3A\\\\%20blue\\\\%3B\\\\%0D\\\\%0A\\\\%7D,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=3\\\\?14ba,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=3\\\\?0e0d,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/style6\\\\.css,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=9,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=10,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=11,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=12,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=13,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=14,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=15,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=16,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=17,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=18,\\\\.\\\\/style8\\\\.css\\\\?5018,\\\\.\\\\/style8\\\\.css\\\\?204b,\\\\.\\\\/style8\\\\.css\\\\?63b0,\\\\.\\\\/style8\\\\.css\\\\?edb8,\\\\.\\\\/style8\\\\.css\\\\?6154,\\\\.\\\\/style8\\\\.css\\\\?8c51,\\\\.\\\\/style8\\\\.css\\\\?ced0,\\\\.\\\\/style8\\\\.css\\\\?d3b8,\\\\.\\\\/style8\\\\.css\\\\?3557,\\\\.\\\\/style8\\\\.css\\\\?ae6e,\\\\.\\\\/style8\\\\.css\\\\?d078,\\\\.\\\\/style8\\\\.css\\\\?ae8b,\\\\.\\\\/style2\\\\.css\\\\?ee8c,\\\\.\\\\/style9\\\\.css\\\\?5f26,\\\\.\\\\/style9\\\\.css\\\\?6536,\\\\.\\\\/style11\\\\.css,\\\\.\\\\/style12\\\\.css,\\\\.\\\\/style10\\\\.css,\\\\.\\\\/media-deep-deep-nested\\\\.css\\\\?1b5b,\\\\.\\\\/media-deep-nested\\\\.css,\\\\.\\\\/media-nested\\\\.css,\\\\.\\\\/supports-deep-deep-nested\\\\.css,\\\\.\\\\/supports-deep-nested\\\\.css,\\\\.\\\\/supports-nested\\\\.css,\\\\.\\\\/layer-deep-deep-nested\\\\.css\\\\?2bf1,\\\\.\\\\/layer-deep-nested\\\\.css\\\\?3469,\\\\.\\\\/layer-nested\\\\.css,\\\\.\\\\/all-deep-deep-nested\\\\.css\\\\?a7dd,\\\\.\\\\/all-deep-nested\\\\.css\\\\?5612,\\\\.\\\\/all-nested\\\\.css\\\\?a3fd,\\\\.\\\\/mixed-deep-deep-nested\\\\.css,\\\\.\\\\/mixed-deep-nested\\\\.css,\\\\.\\\\/mixed-nested\\\\.css,\\\\.\\\\/anonymous-deep-deep-nested\\\\.css\\\\?8f95,\\\\.\\\\/anonymous-deep-nested\\\\.css\\\\?40b5,\\\\.\\\\/layer-deep-deep-nested\\\\.css\\\\?e681,\\\\.\\\\/layer-deep-nested\\\\.css\\\\?dc2a,\\\\.\\\\/anonymous-nested\\\\.css\\\\?8aa8,\\\\.\\\\/media-deep-deep-nested\\\\.css\\\\?3aba,\\\\.\\\\/style8\\\\.css\\\\?83bd,\\\\.\\\\/duplicate-nested\\\\.css,\\\\.\\\\/anonymous-deep-deep-nested\\\\.css\\\\?384f,\\\\.\\\\/anonymous-deep-nested\\\\.css\\\\?8c49,\\\\.\\\\/layer-deep-deep-nested\\\\.css\\\\?17f5,\\\\.\\\\/layer-deep-nested\\\\.css\\\\?c345,\\\\.\\\\/anonymous-nested\\\\.css\\\\?d028,\\\\.\\\\/all-deep-deep-nested\\\\.css\\\\?220a,\\\\.\\\\/all-deep-nested\\\\.css\\\\?7c65,\\\\.\\\\/all-nested\\\\.css\\\\?5ae5,\\\\.\\\\/style\\\\.css;}",
+]
+`;
+
 exports[`ConfigTestCases css pure-css exported tests should compile 1`] = `
 Array [
   ".class {
@@ -586,345 +1667,4 @@ Array [
 
 head{--webpack-main:\\\\.\\\\.\\\\/css-modules\\\\/style\\\\.module\\\\.css,\\\\.\\\\/style\\\\.css;}",
 ]
-`;
-
-exports[`ConfigTestCases css urls exported tests should be able to handle styles in div.css 1`] = `
-Object {
-  "--foo": " url(img.09a1a1112c577c279435.png)",
-  "--foo-bar": " \\"http://www.example.com/pinkish.gif\\"",
-  "/* TODO fix me */
-	/*a146": " url('./img.png', 'foo', './img.png', url('./img.png'));*/
-	/*a147: image-set(url('./img.png', 'foo', './img.png', url('./img.png')) 1x, url(\\"./img2x.png\\") 2x);*/
-",
-  "a": " url(img.09a1a1112c577c279435.png)",
-  "a1": " url(img.09a1a1112c577c279435.png)",
-  "a10": " green url( img\\\\ img.09a1a1112c577c279435.png ) xyz",
-  "a100": " url(img\\\\)img.09a1a1112c577c279435.png)",
-  "a101": " url(img\\\\ img.09a1a1112c577c279435.png)",
-  "a102": " url(img\\\\ img.09a1a1112c577c279435.png)",
-  "a103": " url(img\\\\(img.09a1a1112c577c279435.png)",
-  "a104": " url(img\\\\(img.09a1a1112c577c279435.png)",
-  "a105": " url(img\\\\(img.09a1a1112c577c279435.png)",
-  "a106": " url(img\\\\(img.09a1a1112c577c279435.png)",
-  "a107": " url(img\\\\'\\\\'\\\\'img.09a1a1112c577c279435.png)",
-  "a108": " url(\\"img'() img.09a1a1112c577c279435.png\\")",
-  "a109": " url(img\\\\'img.09a1a1112c577c279435.png)",
-  "a11": " green url( img\\\\ img.09a1a1112c577c279435.png ) xyz",
-  "a110": " url(img\\\\(img.09a1a1112c577c279435.png)",
-  "a111": " url(img\\\\)img.09a1a1112c577c279435.png)",
-  "a112": " url(img\\\\ img.09a1a1112c577c279435.png)",
-  "a113": " url(img\\\\'\\\\'\\\\'img.09a1a1112c577c279435.png)",
-  "a114": " url(\\"img'() img.09a1a1112c577c279435.png\\")",
-  "a115": " url(img\\\\'img.09a1a1112c577c279435.png)",
-  "a116": " url(img\\\\(img.09a1a1112c577c279435.png)",
-  "a117": " url(img\\\\)img.09a1a1112c577c279435.png)",
-  "a118": " url(img\\\\ img.09a1a1112c577c279435.png)",
-  "a119": " url(img.09a1a1112c577c279435.png)",
-  "a12": " green url(img.09a1a1112c577c279435.png) xyz",
-  "a120": " url(img\\\\'\\\\'\\\\'img.09a1a1112c577c279435.png)",
-  "a121": " url(\\"img'() img.09a1a1112c577c279435.png\\")",
-  "a122": " url(img\\\\'img.09a1a1112c577c279435.png)",
-  "a123": " url(img\\\\(img.09a1a1112c577c279435.png)",
-  "a124": " url(img\\\\)img.09a1a1112c577c279435.png)",
-  "a125": " url(img\\\\ img.09a1a1112c577c279435.png)",
-  "a126": " url(img.09a1a1112c577c279435.png)",
-  "a127": " url(img.09a1a1112c577c279435.png)",
-  "a128": " url(img\\\\'img.09a1a1112c577c279435.png)",
-  "a129": " url(\\"img'() img.09a1a1112c577c279435.png\\")",
-  "a13": " green url(data:image/png;base64,AAA) url(http://example.com/image.jpg) url(//example.com/image.png) xyz",
-  "a130": " url(\\"img'() img.09a1a1112c577c279435.png\\")",
-  "a131": " url(img.09a1a1112c577c279435.png)",
-  "a132": " url(img.09a1a1112c577c279435.png)",
-  "a133": " url(img.09a1a1112c577c279435.png?foo=bar)",
-  "a134": " url(img.09a1a1112c577c279435.png?foo=bar)",
-  "a135": " url(img.09a1a1112c577c279435.png?foo=bar#hash)",
-  "a136": " url(img.09a1a1112c577c279435.png?foo=bar#hash)",
-  "a137": " url(img.09a1a1112c577c279435.png?foo=bar)",
-  "a138": " url(img.09a1a1112c577c279435.png?bar=foo)",
-  "a139": " url(img.09a1a1112c577c279435.png?foo=bar#foo)",
-  "a14": " url(\\"data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 26' fill='%23007aff'><rect width='4' height='4'/><rect x='8' y='1' width='34' height='2'/><rect y='11' width='4' height='4'/><rect x='8' y='12' width='34' height='2'/><rect y='22' width='4' height='4'/><rect x='8' y='23' width='34' height='2'/></svg>\\")",
-  "a140": " url(img.09a1a1112c577c279435.png?bar=foo#bar)",
-  "a141": " url(img.09a1a1112c577c279435.png?foo=1&bar=2)",
-  "a142": " url(img.09a1a1112c577c279435.png?foo=2&bar=1)",
-  "a143": " url(data:image/svg+xml;charset=UTF-8,%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22utf-8%22%3F%3E%0A%3C!DOCTYPE%20svg%20PUBLIC%20%22-%2F%2FW3C%2F%2FDTD%20SVG%201.1%2F%2FEN%22%20%22http%3A%2F%2Fwww.w3.org%2FGraphics%2FSVG%2F1.1%2FDTD%2Fsvg11.dtd%22%3E%0A%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20width%3D%22191px%22%20height%3D%22191px%22%20viewBox%3D%220%200%20191%20191%22%20enable-background%3D%22new%200%200%20191%20191%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cpath%20fill%3D%22%23636363%22%20d%3D%22M95.5%2C0C42.8%2C0%2C0%2C42.8%2C0%2C95.5S42.8%2C191%2C95.5%2C191S191%2C148.2%2C191%2C95.5S148.2%2C0%2C95.5%2C0z%20M95.5%2C187.6%0A%09c-50.848%2C0-92.1-41.25-92.1-92.1c0-50.848%2C41.252-92.1%2C92.1-92.1c50.85%2C0%2C92.1%2C41.252%2C92.1%2C92.1%0A%09C187.6%2C146.35%2C146.35%2C187.6%2C95.5%2C187.6z%22%2F%3E%0A%3Cg%3E%0A%09%3Cpath%20fill%3D%22%23636363%22%20d%3D%22M92.9%2C10v8.6H91v-6.5c-0.1%2C0.1-0.2%2C0.2-0.4%2C0.3c-0.2%2C0.1-0.3%2C0.2-0.4%2C0.2c-0.1%2C0-0.3%2C0.1-0.5%2C0.2%0A%09%09c-0.2%2C0.1-0.3%2C0.1-0.5%2C0.1v-1.6c0.5-0.1%2C0.9-0.3%2C1.4-0.5c0.5-0.2%2C0.8-0.5%2C1.2-0.7h1.1V10z%22%2F%3E%0A%09%3Cpath%20fill%3D%22%23636363%22%20d%3D%22M97.1%2C17.1h3.602v1.5h-5.6V18c0-0.4%2C0.1-0.8%2C0.2-1.2c0.1-0.4%2C0.3-0.6%2C0.5-0.9c0.2-0.3%2C0.5-0.5%2C0.7-0.7%0A%09%09c0.2-0.2%2C0.5-0.4%2C0.7-0.6c0.199-0.2%2C0.5-0.3%2C0.6-0.5c0.102-0.2%2C0.301-0.3%2C0.5-0.5c0.2-0.2%2C0.2-0.3%2C0.301-0.5%0A%09%09c0.101-0.2%2C0.101-0.3%2C0.101-0.5c0-0.4-0.101-0.6-0.3-0.8c-0.2-0.2-0.4-0.3-0.801-0.3c-0.699%2C0-1.399%2C0.3-2.101%2C0.9v-1.6%0A%09%09c0.7-0.5%2C1.5-0.7%2C2.5-0.7c0.399%2C0%2C0.8%2C0.1%2C1.101%2C0.2c0.301%2C0.1%2C0.601%2C0.3%2C0.899%2C0.5c0.3%2C0.2%2C0.399%2C0.5%2C0.5%2C0.8%0A%09%09c0.101%2C0.3%2C0.2%2C0.6%2C0.2%2C1s-0.102%2C0.7-0.2%2C1c-0.099%2C0.3-0.3%2C0.6-0.5%2C0.8c-0.2%2C0.2-0.399%2C0.5-0.7%2C0.7c-0.3%2C0.2-0.5%2C0.4-0.8%2C0.6%0A%09%09c-0.2%2C0.1-0.399%2C0.3-0.5%2C0.4s-0.3%2C0.3-0.5%2C0.4s-0.2%2C0.3-0.3%2C0.4C97.1%2C17%2C97.1%2C17%2C97.1%2C17.1z%22%2F%3E%0A%3C%2Fg%3E%0A%3Cg%3E%0A%09%3Cpath%20fill%3D%22%23636363%22%20d%3D%22M15%2C95.4c0%2C0.7-0.1%2C1.4-0.2%2C2c-0.1%2C0.6-0.4%2C1.1-0.7%2C1.5C13.8%2C99.3%2C13.4%2C99.6%2C12.9%2C99.8s-1%2C0.3-1.5%2C0.3%0A%09%09c-0.7%2C0-1.3-0.1-1.8-0.3v-1.5c0.4%2C0.3%2C1%2C0.4%2C1.6%2C0.4c0.6%2C0%2C1.1-0.2%2C1.5-0.7c0.4-0.5%2C0.5-1.1%2C0.5-1.9l0%2C0%0A%09%09C12.8%2C96.7%2C12.3%2C96.9%2C11.5%2C96.9c-0.3%2C0-0.7-0.102-1-0.2c-0.3-0.101-0.5-0.3-0.8-0.5c-0.3-0.2-0.4-0.5-0.5-0.8%0A%09%09c-0.1-0.3-0.2-0.7-0.2-1c0-0.4%2C0.1-0.8%2C0.2-1.2c0.1-0.4%2C0.3-0.7%2C0.6-0.9c0.3-0.2%2C0.6-0.5%2C0.9-0.6c0.3-0.1%2C0.8-0.2%2C1.2-0.2%0A%09%09c0.5%2C0%2C0.9%2C0.1%2C1.2%2C0.3c0.3%2C0.2%2C0.7%2C0.4%2C0.9%2C0.8s0.5%2C0.7%2C0.6%2C1.2S15%2C94.8%2C15%2C95.4z%20M13.1%2C94.4c0-0.2%2C0-0.4-0.1-0.6%0A%09%09c-0.1-0.2-0.1-0.4-0.2-0.5c-0.1-0.1-0.2-0.2-0.4-0.3c-0.2-0.1-0.3-0.1-0.5-0.1c-0.2%2C0-0.3%2C0-0.4%2C0.1s-0.3%2C0.2-0.3%2C0.3%0A%09%09c0%2C0.1-0.2%2C0.3-0.2%2C0.4c0%2C0.1-0.1%2C0.4-0.1%2C0.6c0%2C0.2%2C0%2C0.4%2C0.1%2C0.6c0.1%2C0.2%2C0.1%2C0.3%2C0.2%2C0.4c0.1%2C0.1%2C0.2%2C0.2%2C0.4%2C0.3%0A%09%09c0.2%2C0.1%2C0.3%2C0.1%2C0.5%2C0.1c0.2%2C0%2C0.3%2C0%2C0.4-0.1s0.2-0.2%2C0.3-0.3c0.1-0.1%2C0.2-0.2%2C0.2-0.4C13%2C94.7%2C13.1%2C94.6%2C13.1%2C94.4z%22%2F%3E%0A%3C%2Fg%3E%0A%3Cg%3E%0A%09%3Cpath%20fill%3D%22%23636363%22%20d%3D%22M176%2C99.7V98.1c0.6%2C0.4%2C1.2%2C0.602%2C2%2C0.602c0.5%2C0%2C0.8-0.102%2C1.1-0.301c0.301-0.199%2C0.4-0.5%2C0.4-0.801%0A%09%09c0-0.398-0.2-0.699-0.5-0.898c-0.3-0.2-0.8-0.301-1.3-0.301h-0.802V95h0.701c1.101%2C0%2C1.601-0.4%2C1.601-1.1c0-0.7-0.4-1-1.302-1%0A%09%09c-0.6%2C0-1.1%2C0.2-1.6%2C0.5v-1.5c0.6-0.3%2C1.301-0.4%2C2.1-0.4c0.9%2C0%2C1.5%2C0.2%2C2%2C0.6s0.701%2C0.9%2C0.701%2C1.5c0%2C1.1-0.601%2C1.8-1.701%2C2.1l0%2C0%0A%09%09c0.602%2C0.1%2C1.102%2C0.3%2C1.4%2C0.6s0.5%2C0.8%2C0.5%2C1.3c0%2C0.801-0.3%2C1.4-0.9%2C1.9c-0.6%2C0.5-1.398%2C0.7-2.398%2C0.7%0A%09%09C177.2%2C100.1%2C176.5%2C100%2C176%2C99.7z%22%2F%3E%0A%3C%2Fg%3E%0A%3Cg%3E%0A%09%3Cpath%20fill%3D%22%23636363%22%20d%3D%22M98.5%2C179.102c0%2C0.398-0.1%2C0.799-0.2%2C1.199C98.2%2C180.7%2C98%2C181%2C97.7%2C181.2s-0.601%2C0.5-0.9%2C0.601%0A%09%09c-0.3%2C0.1-0.7%2C0.199-1.2%2C0.199c-0.5%2C0-0.9-0.1-1.3-0.3c-0.4-0.2-0.7-0.399-0.9-0.8c-0.2-0.4-0.5-0.7-0.6-1.2%0A%09%09c-0.1-0.5-0.2-1-0.2-1.601c0-0.699%2C0.1-1.399%2C0.3-2c0.2-0.601%2C0.4-1.101%2C0.8-1.5c0.4-0.399%2C0.7-0.699%2C1.2-1c0.5-0.3%2C1-0.3%2C1.6-0.3%0A%09%09c0.6%2C0%2C1.2%2C0.101%2C1.5%2C0.199v1.5c-0.4-0.199-0.9-0.399-1.4-0.399c-0.3%2C0-0.6%2C0.101-0.8%2C0.2c-0.2%2C0.101-0.5%2C0.3-0.7%2C0.5%0A%09%09c-0.2%2C0.199-0.3%2C0.5-0.4%2C0.8c-0.1%2C0.301-0.2%2C0.7-0.2%2C1.101l0%2C0c0.4-0.601%2C1-0.8%2C1.8-0.8c0.3%2C0%2C0.7%2C0.1%2C0.9%2C0.199%0A%09%09c0.2%2C0.101%2C0.5%2C0.301%2C0.7%2C0.5c0.199%2C0.2%2C0.398%2C0.5%2C0.5%2C0.801C98.5%2C178.2%2C98.5%2C178.7%2C98.5%2C179.102z%20M96.7%2C179.2%0A%09%09c0-0.899-0.4-1.399-1.1-1.399c-0.2%2C0-0.3%2C0-0.5%2C0.1c-0.2%2C0.101-0.3%2C0.201-0.4%2C0.301c-0.1%2C0.101-0.2%2C0.199-0.2%2C0.4%0A%09%09c0%2C0.199-0.1%2C0.299-0.1%2C0.5c0%2C0.199%2C0%2C0.398%2C0.1%2C0.6s0.1%2C0.3%2C0.2%2C0.5c0.1%2C0.199%2C0.2%2C0.199%2C0.4%2C0.3c0.2%2C0.101%2C0.3%2C0.101%2C0.5%2C0.101%0A%09%09c0.2%2C0%2C0.3%2C0%2C0.5-0.101c0.2-0.101%2C0.301-0.199%2C0.301-0.3c0-0.1%2C0.199-0.301%2C0.199-0.399C96.6%2C179.7%2C96.7%2C179.4%2C96.7%2C179.2z%22%2F%3E%0A%3C%2Fg%3E%0A%3Ccircle%20fill%3D%22%23636363%22%20cx%3D%2295%22%20cy%3D%2295%22%20r%3D%227%22%2F%3E%0A%3C%2Fsvg%3E%0A) 50% 50%/191px no-repeat",
-  "a144": " url(img.09a1a1112c577c279435.png)",
-  "a145": " url(img.09a1a1112c577c279435.png)",
-  "a148": " url('data:image/svg+xml,%3Csvg xmlns=\\"http://www.w3.org/2000/svg\\"%3E%3Crect width=\\"100%25\\" height=\\"100%25\\" style=\\"stroke: rgb(223,224,225); stroke-width: 2px; fill: none; stroke-dasharray: 6px 3px\\" /%3E%3C/svg%3E')",
-  "a149": " url('data:image/svg+xml,%3Csvg xmlns=\\"http://www.w3.org/2000/svg\\"%3E%3Crect width=\\"100%25\\" height=\\"100%25\\" style=\\"stroke: rgb(223,224,225); stroke-width: 2px; fill: none; stroke-dasharray: 6px 3px\\" /%3E%3C/svg%3E')",
-  "a15": " url(data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2042%2026%27%20fill%3D%27%2523007aff%27%3E%3Crect%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%271%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3Crect%20y%3D%2711%27%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%2712%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3Crect%20y%3D%2722%27%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%2723%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3C%2Fsvg%3E)",
-  "a150": " url('data:image/svg+xml,%3Csvg xmlns=\\"http://www.w3.org/2000/svg\\"%3E%3Crect width=\\"100%25\\" height=\\"100%25\\" style=\\"stroke: rgb(223,224,225); stroke-width: 2px; fill: none; stroke-dasharray: 6px 3px\\" /%3E%3C/svg%3E')",
-  "a151": " url('data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\"><rect width=\\"100%\\" height=\\"100%\\" style=\\"stroke: rgb(223,224,225); stroke-width: 2px; fill: none; stroke-dasharray: 6px 3px\\" /></svg>')",
-  "a152": " url(img.09a1a1112c577c279435.png)",
-  "a153": " url(img.09a1a1112c577c279435.png)",
-  "a154": " url(other.09a1a1112c577c279435.png)",
-  "a155": " url(img.09a1a1112c577c279435.png)",
-  "a156": " url(\\"data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e\\")",
-  "a157": " url('data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"10\\" height=\\"10\\"><rect fill=\\"gray\\" width=\\"5\\" height=\\"5\\" y=\\"0\\" x=\\"0\\" /></svg>')",
-  "a158": " src(\\"http://www.example.com/pinkish.gif\\")",
-  "a159": " src(var(--foo))",
-  "a16": " url('data:image/svg+xml;charset=utf-8,<svg xmlns=\\"http://www.w3.org/2000/svg\\"><filter id=\\"filter\\"><feGaussianBlur in=\\"SourceAlpha\\" stdDeviation=\\"0\\" /><feOffset dx=\\"1\\" dy=\\"2\\" result=\\"offsetblur\\" /><feFlood flood-color=\\"rgba(255,255,255,1)\\" /><feComposite in2=\\"offsetblur\\" operator=\\"in\\" /><feMerge><feMergeNode /><feMergeNode in=\\"SourceGraphic\\" /></feMerge></filter></svg>#filter')",
-  "a160": " url(img.09a1a1112c577c279435.png param(--color var(--primary-color)))",
-  "a161": " src(\\"img.png\\" param(--color var(--primary-color)))",
-  "a162": " url(img\\\\ img.09a1a1112c577c279435.png)",
-  "a163": " url(img.09a1a1112c577c279435.png)",
-  "a164": " url( img.png bug)",
-  "a165": " url(imgn.09a1a1112c577c279435.png)",
-  "a166": " url('data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\"	                width=\\"10\\" height=\\"10\\"><rect fill=\\"gray\\" width=\\"5\\" height=\\"5\\" y=\\"0\\" x=\\"0\\" /></svg>')",
-  "a167": " url(http://example.com/image.jpg)",
-  "a168": " url(http://example.com/image.jpg)",
-  "a169": " url(data:,)",
-  "a17": " url(\\"data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%5C%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%5C%22%3E%3Cfilter%20id%3D%5C%22filter%5C%22%3E%3CfeGaussianBlur%20in%3D%5C%22SourceAlpha%5C%22%20stdDeviation%3D%5C%220%5C%22%20%2F%3E%3CfeOffset%20dx%3D%5C%221%5C%22%20dy%3D%5C%222%5C%22%20result%3D%5C%22offsetblur%5C%22%20%2F%3E%3CfeFlood%20flood-color%3D%5C%22rgba(255%2C255%2C255%2C1)%5C%22%20%2F%3E%3CfeComposite%20in2%3D%5C%22offsetblur%5C%22%20operator%3D%5C%22in%5C%22%20%2F%3E%3CfeMerge%3E%3CfeMergeNode%20%2F%3E%3CfeMergeNode%20in%3D%5C%22SourceGraphic%5C%22%20%2F%3E%3C%2FfeMerge%3E%3C%2Ffilter%3E%3C%2Fsvg%3E%23filter\\")",
-  "a170": " url(data:,)",
-  "a171": " image(ltr 'img.png#xywh=0,0,16,16', red)",
-  "a172": " image-set(
-		linear-gradient(blue, white) 1x,
-		linear-gradient(blue, green) 2x
-	)",
-  "a173": " image-set(
-		url(img.09a1a1112c577c279435.png) type(\\"image/png\\"),
-		url(img.09a1a1112c577c279435.png) type(\\"image/png\\")
-	)",
-  "a174": " image-set(
-		url(img.09a1a1112c577c279435.png) 1x,
-		url(img.09a1a1112c577c279435.png) 2x
-	)",
-  "a175": " image-set(
-		url(img.09a1a1112c577c279435.png) 1x,
-		url(img.09a1a1112c577c279435.png) 2x,
-		url(img.09a1a1112c577c279435.png) 3x
-	)",
-  "a176": " image-set(
-		url(img.09a1a1112c577c279435.png) type(\\"image/png\\"),
-		url(img.09a1a1112c577c279435.png) type(\\"image/png\\")
-	) \\"img.png\\"",
-  "a177": " image-set(
-		url(img.09a1a1112c577c279435.png) 1x type(\\"image/png\\"),
-		url(img.09a1a1112c577c279435.png) 2x type(\\"image/png\\")
-	)",
-  "a178": " image-set(
-		url(img.09a1a1112c577c279435.png) type(\\"image/png\\") 1x,
-		url(img.09a1a1112c577c279435.png) type(\\"image/png\\") 2x
-	)",
-  "a179": " -webkit-image-set(
-		url(img.09a1a1112c577c279435.png) 1x
-	)",
-  "a18": " url(#highlight)",
-  "a180": " -webkit-image-set(
-		url(img.09a1a1112c577c279435.png var(--foo, \\"test.png\\")) 1x
-	)",
-  "a181": " src(   \\"img.png\\"   )",
-  "a182": " src('img.png')",
-  "a183": " src('img.png' var(--foo, \\"test.png\\"))",
-  "a184": " src(var(--foo, \\"test.png\\"))",
-  "a185": " src(\\"   img.png   \\")",
-  "a186": " image-set(url(img.09a1a1112c577c279435.png)1x,url(img.09a1a1112c577c279435.png)2x,url(img.09a1a1112c577c279435.png)3x)",
-  "a187": " image-set(url(img.09a1a1112c577c279435.png)1x,url(img.09a1a1112c577c279435.png)2x,url(img.09a1a1112c577c279435.png)3x)",
-  "a188": " image-set(url(img.09a1a1112c577c279435.png)1x,url(img.09a1a1112c577c279435.png)2x,url(img.09a1a1112c577c279435.png)3x)",
-  "a189": " image-set(url(img.09a1a1112c577c279435.png)1x,url(img.09a1a1112c577c279435.png)2x,url(img.09a1a1112c577c279435.png)3x)",
-  "a19": " url(#line-marker)",
-  "a190": " image-set(url(img.09a1a1112c577c279435.png)1x)",
-  "a191": " image-set(url(img.09a1a1112c577c279435.png)1x/* test*/,/* test*/url(img.09a1a1112c577c279435.png)2x)",
-  "a197": " \\\\u\\\\r\\\\l(img.09a1a1112c577c279435.png)",
-  "a198": " \\\\image-\\\\set(url(img.09a1a1112c577c279435.png)1x,url(img.09a1a1112c577c279435.png)2x,url(img.09a1a1112c577c279435.png)3x)",
-  "a199": " \\\\-webk\\\\it-image-set(url(img.09a1a1112c577c279435.png)1x)",
-  "a2": " url(img.09a1a1112c577c279435.png)",
-  "a200": "-webkit-image-set(url(img.09a1a1112c577c279435.png)1x)",
-  "a22": " \\"do not use url(path)\\"",
-  "a23": " 'do not \\"use\\" url(path)'",
-  "a24": " -webkit-image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x)
-",
-  "a25": " image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x)
-",
-  "a26": " green url() xyz",
-  "a27": " green url('') xyz",
-  "a28": " green url(\\"\\") xyz",
-  "a29": " green url('   ') xyz",
-  "a3": " url(img.09a1a1112c577c279435.png)",
-  "a30": " green url(
-	) xyz",
-  "a4": " url(img.09a1a1112c577c279435.png#hash)",
-  "a40": " green url(https://raw.githubusercontent.com/webpack/media/master/logo/icon.png) xyz",
-  "a41": " green url(//raw.githubusercontent.com/webpack/media/master/logo/icon.png) xyz",
-  "a42": " url(img.09a1a1112c577c279435.png?foo)",
-  "a43": " url(img.09a1a1112c577c279435.png?foo=bar)",
-  "a44": " url(img.09a1a1112c577c279435.png?foo=bar#hash)",
-  "a45": " url(img.09a1a1112c577c279435.png?foo=bar#hash)",
-  "a46": " url(img.09a1a1112c577c279435.png?)",
-  "a47": " url(img.09a1a1112c577c279435.png) url(\\"data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 26' fill='%23007aff'><rect width='4' height='4'/><rect x='8' y='1' width='34' height='2'/><rect y='11' width='4' height='4'/><rect x='8' y='12' width='34' height='2'/><rect y='22' width='4' height='4'/><rect x='8' y='23' width='34' height='2'/></svg>\\") url(img.09a1a1112c577c279435.png)",
-  "a48": " __URL__()",
-  "a49": " url(img-simple.09a1a1112c577c279435.png)",
-  "a5": " url(
-	img.09a1a1112c577c279435.png
-	)",
-  "a50": " url(img-simple.09a1a1112c577c279435.png)",
-  "a51": " url(img-simple.09a1a1112c577c279435.png)",
-  "a52": " url(img.09a1a1112c577c279435.png)",
-  "a53": " url(img.09a1a1112c577c279435.png)",
-  "a55": " -webkit-image-set()",
-  "a56": " image-set()",
-  "a58": " image-set('')",
-  "a59": " image-set(\\"\\")",
-  "a6": " green url( img.09a1a1112c577c279435.png ) xyz",
-  "a60": " image-set(\\"\\" 1x)",
-  "a61": " image-set(url())",
-  "a62": " image-set(
-		url()
-	)",
-  "a63": " image-set(URL())",
-  "a64": " image-set(url(''))",
-  "a65": " image-set(url(\\"\\"))",
-  "a66": " image-set(url('') 1x)",
-  "a67": " image-set(1x)",
-  "a68": " image-set(
-		1x
-	)",
-  "a69": " image-set(calc(1rem + 1px) 1x)",
-  "a7": " green url( img.09a1a1112c577c279435.png ) xyz",
-  "a70": " -webkit-image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x)",
-  "a71": " image-set(url(img1x.09a1a1112c577c279435.png) 1x)",
-  "a72": " image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x)",
-  "a73": " image-set(url(img\\\\ img.09a1a1112c577c279435.png) 1x, url(img\\\\ img.09a1a1112c577c279435.png) 2x)",
-  "a74": " image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x),
-		image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x)",
-  "a75": " image-set(
-		url(img1x.09a1a1112c577c279435.png) 1x,
-		url(img2x.09a1a1112c577c279435.png) 2x,
-		url(img3x.09a1a1112c577c279435.png) 600dpi
-	)",
-  "a76": " image-set(url(img1x.09a1a1112c577c279435.png?foo=bar) 1x)",
-  "a77": " image-set(url(img1x.09a1a1112c577c279435.png#hash) 1x)",
-  "a78": " image-set(url(img1x.09a1a1112c577c279435.png?#iefix) 1x)",
-  "a79": " -webkit-image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x)",
-  "a8": " green url(img.09a1a1112c577c279435.png) xyz",
-  "a80": " -webkit-image-set(url(img1x.09a1a1112c577c279435.png) 1x)",
-  "a81": " -webkit-image-set(
-		url(img1x.09a1a1112c577c279435.png) 1x
-	)",
-  "a82": " image-set(url(img1x.09a1a1112c577c279435.png) 1x)",
-  "a83": " image-set(
-		url(img1x.09a1a1112c577c279435.png) 1x
-	)",
-  "a84": " image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x)",
-  "a85": " image-set(
-		url(img1x.09a1a1112c577c279435.png) 1x,
-		url(img2x.09a1a1112c577c279435.png) 2x,
-		url(img3x.09a1a1112c577c279435.png) 600dpi
-	)",
-  "a86": " image-set(url(img\\\\ img.09a1a1112c577c279435.png) 1x, url(img\\\\ img.09a1a1112c577c279435.png) 2x)",
-  "a87": " image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x)",
-  "a88": " url(imgimg.09a1a1112c577c279435.png)",
-  "a89": " url(img\\\\'img.09a1a1112c577c279435.png)",
-  "a9": " green url(img.09a1a1112c577c279435.png) url(other-img.09a1a1112c577c279435.png) xyz",
-  "a90": " url(img\\\\'\\\\'\\\\'img.09a1a1112c577c279435.png)",
-  "a91": " url(img\\\\(img.09a1a1112c577c279435.png)",
-  "a92": " url(img\\\\)img.09a1a1112c577c279435.png)",
-  "a93": " url(img\\\\ img.09a1a1112c577c279435.png)",
-  "a94": " url(\\"img'() img.09a1a1112c577c279435.png\\")",
-  "a95": " image-set(
-		url(imgimg.09a1a1112c577c279435.png) 1x,
-		url(img\\\\'\\\\'\\\\'img.09a1a1112c577c279435.png) 2x,
-		url(img\\\\'img.09a1a1112c577c279435.png) 3x,
-		url(img\\\\(img.09a1a1112c577c279435.png) 4x,
-		url(img\\\\)img.09a1a1112c577c279435.png) 5x,
-		url(img\\\\ img.09a1a1112c577c279435.png) 6x,
-		url(\\"img'() img.09a1a1112c577c279435.png\\") 7x
-	)",
-  "a96": " url(img\\\\'\\\\'\\\\'img.09a1a1112c577c279435.png)",
-  "a97": " url(\\"img'() img.09a1a1112c577c279435.png\\")",
-  "a98": " url(img\\\\'img.09a1a1112c577c279435.png)",
-  "a99": " url(img\\\\(img.09a1a1112c577c279435.png)",
-  "b": " url(img.09a1a1112c577c279435.png)",
-  "c": " url(img.09a1a1112c577c279435.png)",
-  "d": " url(img.09a1a1112c577c279435.png#hash)",
-  "e": " url(
-    img.09a1a1112c577c279435.png
-  )",
-  "f": " green url( img.09a1a1112c577c279435.png ) xyz",
-  "g": " green url( img.09a1a1112c577c279435.png ) xyz",
-  "getPropertyValue": [Function],
-  "h": " green url(img.09a1a1112c577c279435.png) xyz",
-  "i": " green url(img.09a1a1112c577c279435.png) url(img.09a1a1112c577c279435.png) xyz",
-  "j": " green url( img\\\\ img.09a1a1112c577c279435.png ) xyz",
-  "k": " green url( img\\\\ img.09a1a1112c577c279435.png ) xyz",
-  "l": " green url(img.09a1a1112c577c279435.png) xyz",
-  "m": " green url(img.09a1a1112c577c279435.png) xyz",
-  "n": " green url(img.09a1a1112c577c279435.png) xyz",
-}
-`;
-
-exports[`ConfigTestCases custom-modules json-custom exported tests should transform toml to json 1`] = `
-Object {
-  "owner": Object {
-    "bio": "GitHub Cofounder & CEO
-Likes tater tots and beer.",
-    "dob": "1979-05-27T07:32:00.000Z",
-    "name": "Tom Preston-Werner",
-    "organization": "GitHub",
-  },
-  "title": "TOML Example",
-}
-`;
-
-exports[`ConfigTestCases records issue-2991 exported tests should write relative paths to records 1`] = `
-"{
-  \\"chunks\\": {
-    \\"byName\\": {
-      \\"main\\": 179
-    },
-    \\"bySource\\": {
-      \\"0 main\\": 179
-    },
-    \\"usedIds\\": [
-      179
-    ]
-  },
-  \\"modules\\": {
-    \\"byIdentifier\\": {
-      \\"./test.js\\": 393,
-      \\"external node-commonjs \\\\\\"fs\\\\\\"\\": 147,
-      \\"external node-commonjs \\\\\\"path\\\\\\"\\": 17,
-      \\"ignored|./.|pkgs/somepackage/foo\\": 802
-    },
-    \\"usedIds\\": [
-      17,
-      147,
-      393,
-      802
-    ]
-  }
-}"
-`;
-
-exports[`ConfigTestCases records issue-7339 exported tests should write relative dynamic-require paths to records 1`] = `
-"{
-  \\"chunks\\": {
-    \\"byName\\": {
-      \\"main\\": 179
-    },
-    \\"bySource\\": {
-      \\"0 main\\": 179
-    },
-    \\"usedIds\\": [
-      179
-    ]
-  },
-  \\"modules\\": {
-    \\"byIdentifier\\": {
-      \\"./dependencies/bar.js\\": 379,
-      \\"./dependencies/foo.js\\": 117,
-      \\"./dependencies|sync|/^\\\\\\\\.\\\\\\\\/.*$/\\": 412,
-      \\"./test.js\\": 393,
-      \\"external node-commonjs \\\\\\"fs\\\\\\"\\": 147,
-      \\"external node-commonjs \\\\\\"path\\\\\\"\\": 17
-    },
-    \\"usedIds\\": [
-      17,
-      117,
-      147,
-      379,
-      393,
-      412
-    ]
-  }
-}"
 `;

--- a/test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -1,1089 +1,552 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ConfigTestCases css css-import exported tests should compile 1`] = `
+exports[`ConfigTestCases css pure-css exported tests should compile 1`] = `
 Array [
-  "body {
-	externally-imported: true;
-}
-
-body {
-	externally-imported1: true;
-}
-
-body {
-	externally-imported2: true;
-}
-
-body {
-	background: black;
-}
-
-body {
-	background: black;
-}
-
-@layer default {
-	body {
-		background: black;
-	}
-}
-
-@layer default {
-	body {
-		background: black;
-	}
-}
-
-@supports (display: flex) {
-	body {
-		background: black;
-	}
-}
-
-@supports (display: flex) {
-	body {
-		background: black;
-	}
-}
-
-@media screen and (min-width: 400px) {
-	body {
-		background: black;
-	}
-}
-
-@media screen and (min-width: 400px) {
-	body {
-		background: black;
-	}
-}
-
-@layer default {
-	@supports (display: flex) {
-		body {
-			background: black;
-		}
-	}
-}
-
-@layer default {
-	@media screen and (min-width: 400px) {
-		body {
-			background: black;
-		}
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (min-width: 400px) {
-		body {
-			background: black;
-		}
-	}
-}
-
-@layer default {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			body {
-				background: black;
-			}
-		}
-	}
-}
-
-@layer default {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			body {
-				background: black;
-			}
-		}
-	}
-}
-
-@layer default {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			body {
-				background: black;
-			}
-		}
-	}
-}
-
-@layer default {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			body {
-				background: black;
-			}
-		}
-	}
-}
-
-@layer default {
-	@supports (background: url(./img.png)) {
-		@media screen and (min-width: 400px) {
-			body {
-				background: black;
-			}
-		}
-	}
-}
-
-@layer default {
-	@supports (background: url(\\"./img.png\\")) {
-		@media screen and (min-width: 400px) {
-			body {
-				background: black;
-			}
-		}
-	}
-}
-
-@media screen {
-	body {
-		background: black;
-	}
-}
-
-@media screen {
-	body {
-		background: black;
-	}
-}
-
-@media screen {
-	body {
-		background: black;
-	}
-}
-
-body {
-	background: black;
-}
-
-body {
-	background: green;
-}
-
-@layer base {
-	body {
-		background: green;
-	}
-}
-
-@supports (display: flex) {
-	body {
-		background: green;
-	}
-}
-
-@media screen, print {
-	body {
-		background: green;
-	}
-}
-
-a {
+  ".class {
 	color: red;
 }
 
-a {
-	color: red;
+.local1,
+.local2 :global .global,
+.local3 {
+	color: green;
 }
 
-a {
-	color: red;
+:global .global :local .local4 {
+	color: yellow;
 }
 
-a {
-	color: red;
+.local5:global(.global).local6 {
+	color: blue;
 }
 
-a {
-	color: red;
+.local7 div:not(.disabled, .mButtonDisabled, .tipOnly) {
+    pointer-events: initial !important;
 }
 
-a {
-	color: red;
+.local8 :is(div.parent1.child1.vertical-tiny,
+    div.parent1.child1.vertical-small,
+    div.otherDiv.horizontal-tiny,
+    div.otherDiv.horizontal-small div.description) {
+  max-height: 0;
+  margin: 0;
+  overflow: hidden;
 }
 
-a {
-	color: red;
+.local9 :matches(div.parent1.child1.vertical-tiny,
+    div.parent1.child1.vertical-small,
+    div.otherDiv.horizontal-tiny,
+    div.otherDiv.horizontal-small div.description) {
+  max-height: 0;
+  margin: 0;
+  overflow: hidden;
 }
 
-a {
-	color: red;
+.local10 :where(div.parent1.child1.vertical-tiny,
+    div.parent1.child1.vertical-small,
+    div.otherDiv.horizontal-tiny,
+    div.otherDiv.horizontal-small div.description) {
+  max-height: 0;
+  margin: 0;
+  overflow: hidden;
 }
 
-a {
-	color: red;
+.local11 div:has(.disabled, .mButtonDisabled, .tipOnly) {
+    pointer-events: initial !important;
 }
 
-@media screen and (orientation:landscape) {
-	a {
-		color: red;
+.local12 div:current(p, span) {
+	background-color: yellow;
+}
+
+.local13 div:past(p, span) {
+	display: none;
+}
+
+.local14 div:future(p, span) {
+	background-color: yellow;
+}
+
+.local15 div:-moz-any(ol, ul, menu, dir) {
+	list-style-type: square;
+}
+
+.local16 li:-webkit-any(:first-child, :last-child) {
+	background-color: aquamarine;
+}
+
+.local9 :matches(div.parent1.child1.vertical-tiny,
+    div.parent1.child1.vertical-small,
+    div.otherDiv.horizontal-tiny,
+    div.otherDiv.horizontal-small div.description) {
+	max-height: 0;
+	margin: 0;
+	overflow: hidden;
+}
+
+:global(:global(:local(.nested1)).nested2).nested3 {
+	color: pink;
+}
+
+#ident {
+	color: purple;
+}
+
+@keyframes localkeyframes {
+	0% {
+		left: var(--pos1x);
+		top: var(--pos1y);
+		color: var(--theme-color1);
+	}
+	100% {
+		left: var(--pos2x);
+		top: var(--pos2y);
+		color: var(--theme-color2);
 	}
 }
 
-@media SCREEN AND (ORIENTATION: LANDSCAPE) {
-	a {
-		color: red;
+@keyframes localkeyframes2 {
+	0% {
+		left: 0;
+	}
+	100% {
+		left: 100px;
 	}
 }
 
-@media (min-width: 100px) {
-	a {
-		color: red;
+.animation {
+	animation-name: localkeyframes;
+	animation: 3s ease-in 1s 2 reverse both paused localkeyframes, localkeyframes2;
+	--pos1x: 0px;
+	--pos1y: 0px;
+	--pos2x: 10px;
+	--pos2y: 20px;
+}
+
+/* .composed {
+	composes: local1;
+	composes: local2;
+} */
+
+.vars {
+	color: var(--local-color);
+	--local-color: red;
+}
+
+.globalVars :global {
+	color: var(--global-color);
+	--global-color: red;
+}
+
+@media (min-width: 1600px) {
+	.wideScreenClass {
+		color: var(--local-color);
+		--local-color: green;
 	}
 }
 
-.class {
-	content: \\"style.css\\";
-	color: red;
-}
-
-.class {
-	content: \\"style.css\\";
-	color: red;
-}
-
-.class {
-	content: \\"style.css\\";
-	color: red;
-}
-
-.class {
-	content: \\"style.css\\";
-	color: red;
-}
-
-.class {
-	content: \\"style7.css\\";
-}
-
-.class {
-	content: \\"style7.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test.css\\";
-}
-
-.class {
-	content: \\"test.css\\";
-}
-
-.class {
-	content: \\"test.css\\";
-}
-
-.class {
-	content: \\"test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"test test.css\\";
-}
-
-.class {
-	content: \\"style6.css\\";
-}
-
-.class {
-	content: \\"style4.css\\";
-}
-
-.class {
-	content: \\"style4.css\\";
-}
-
-.class {
-	content: \\"style4.css\\";
-}
-
-@supports (display: flex) {
-	.class {
-		content: \\"style4.css\\";
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (orientation:landscape) {
-		.class {
-			content: \\"style4.css\\";
-		}
-	}
-}
-
-.class {
-	content: \\"style4.css\\";
-}
-
-.class {
-	content: \\"style4.css\\";
-}
-
-.class {
-	content: \\"style4.css\\";
-}
-
-a {
-  color: red;
-}
-@media screen and (orientation:landscape) {
-	a {
-	  color: blue;
-	}}
-
-.class {
-	content: \\"style5.css\\";
-}
-
-.class {
-	content: \\"style5.css\\";
-}
-
-@supports (unknown) {
-	.class {
-		content: \\"style5.css\\";
-	}
-}
-
-@supports (display: flex) {
-	.class {
-		content: \\"style5.css\\";
-	}
-}
-
-@supports (display: flex !important) {
-	.class {
-		content: \\"style5.css\\";
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (min-width: 400px) {
-		.class {
-			content: \\"style5.css\\";
-		}
-	}
-}
-
-@supports (selector(a b)) {
-	.class {
-		content: \\"style5.css\\";
-	}
-}
-
-@supports (display: flex) {
-	.class {
-		content: \\"style5.css\\";
-	}
-}
-
-@layer {
-	.class {
-		content: \\"layer.css\\";
-	}
-}
-
-@layer default {
-	.class {
-		content: \\"layer.css\\";
-	}
-}
-
-@layer default {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			.class {
-				content: \\"layer.css\\";
-			}
-		}
-	}
-}
-
-@layer {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			.class {
-				content: \\"layer.css\\";
-			}
-		}
-	}
-}
-
-@layer {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			.class {
-				content: \\"layer.css\\";
-			}
-		}
-	}
-}
-
-@layer {
-	.class {
-		content: \\"layer.css\\";
-	}
-}
-
-@layer foo.bar.baz {
-	.class {
-		content: \\"layer.css\\";
-	}
-}
-
-@layer {
-	.class {
-		content: \\"layer.css\\";
-	}
-}
-
-@layer default {
-	@supports (display: flex) {
-		@media screen and (min-width:400px) {
-			.class {
-				content: \\"style6.css\\";
-			}
-		}
-	}
-}
-
-@layer default {
-	@supports (display: flex) {
-		@media screen and (min-width:400px) {
-			.class {
-				content: \\"style6.css\\";
-			}
-		}
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (min-width:400px) {
-		.class {
-			content: \\"style6.css\\";
-		}
-	}
-}
-
-@media screen and (min-width:400px) {
-	.class {
-		content: \\"style6.css\\";
-	}
-}
-
-@media screen and (min-width:400px) {
-	.class {
-		content: \\"style6.css\\";
-	}
-}
-
-@media screen and (min-width:400px) {
-	.class {
-		content: \\"style6.css\\";
-	}
-}
-
-@layer default {
-	@supports (display     :     flex) {
-		@media screen     and     (     min-width     :     400px     ) {
-			.class {
-				content: \\"style6.css\\";
-			}
-		}
-	}
-}
-
-@layer DEFAULT {
-	@supports (DISPLAY: FLEX) {
-		@media SCREEN AND (MIN-WIDTH: 400PX) {
-			.class {
-				content: \\"style6.css\\";
-			}
-		}
-	}
-}
-
-@layer {
-	@supports (DISPLAY: FLEX) {
-		@media SCREEN AND (MIN-WIDTH: 400PX) {
-			.class {
-				content: \\"style6.css\\";
-			}
-		}
-	}
-}
-
-@layer /* Comment */default/* Comment */ {
-	@supports (/* Comment */display/* Comment */:/* Comment */ flex/* Comment */) {
-		@media /* Comment */ screen/* Comment */ and/* Comment */ (/* Comment */min-width/* Comment */: /* Comment */400px/* Comment */) {
-			.class {
-				content: \\"style6.css\\";
-			}
-		}
-	}
-}
-
-.class {
-	content: \\"style6.css\\";
-}
-
-.class {
-	content: \\"style6.css\\";
-}
-
-.class {
-	content: \\"style6.css\\";
-}
-
-.class {
-	content: \\"style6.css\\";
-}
-
-.class {
-	content: \\"style6.css\\";
-}
-
-.class {
-	content: \\"style6.css\\";
-}
-
-@media /* Comment */ print and (orientation:landscape) {
-	.class {
-		content: \\"style6.css\\";
-	}
-}
-
-@media /* Comment */print and (orientation:landscape)/* Comment */ {
-	.class {
-		content: \\"style6.css\\";
-	}
-}
-
-@media /* Comment */ print and (orientation:landscape) {
-	.class {
-		content: \\"style6.css\\";
-	}
-}
-
-@media screen and (min-width: 400px) {
-	.class {
-		content: \\"style8.css\\";
-	}
-}
-
-@media (prefers-color-scheme: dark) {
-	.class {
-		content: \\"style8.css\\";
-	}
-}
-
-@supports (display: flex) {
-	.class {
-		content: \\"style8.css\\";
-	}
-}
-
-@supports (((display: flex))) {
-	.class {
-		content: \\"style8.css\\";
-	}
-}
-
-@supports (((display: inline-grid))) {
-	@media screen and (((min-width: 400px))) {
-		.class {
-			content: \\"style8.css\\";
-		}
+@media screen and (max-width: 600px) {
+	.narrowScreenClass {
+		color: var(--local-color);
+		--local-color: purple;
 	}
 }
 
 @supports (display: grid) {
-	.class {
-		content: \\"style8.css\\";
+	.displayGridInSupports {
+		display: grid;
 	}
+}
+
+@supports not (display: grid) {
+  .floatRightInNegativeSupports {
+    float: right;
+  }
 }
 
 @supports (display: flex) {
-	@media screen and (min-width: 400px) {
-		.class {
-			content: \\"style8.css\\";
-		}
-	}
+  @media screen and (min-width: 900px) {
+    .displayFlexInMediaInSupports {
+      display: flex;
+    }
+  }
 }
 
-@layer framework {
-	.class {
-		content: \\"style8.css\\";
-	}
-}
-
-@layer default {
-	.class {
-		content: \\"style8.css\\";
-	}
-}
-
-@layer base {
-	.class {
-		content: \\"style8.css\\";
-	}
-}
-
-@layer default {
+@media screen and (min-width: 900px) {
 	@supports (display: flex) {
-		.class {
-			content: \\"style8.css\\";
+    .displayFlexInSupportsInMedia {
+      display: flex;
+    }
+  }
+}
+
+@MEDIA screen and (min-width: 900px) {
+	@SUPPORTS (display: flex) {
+		.displayFlexInSupportsInMediaUpperCase {
+			display: flex;
 		}
 	}
 }
 
-@layer default {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			.class {
-				content: \\"style8.css\\";
-			}
-		}
+.animationUpperCase {
+	ANIMATION-NAME: localkeyframesUPPERCASE;
+	ANIMATION: 3s ease-in 1s 2 reverse both paused localkeyframesUPPERCASE, localkeyframes2UPPPERCASE;
+	--pos1x: 0px;
+	--pos1y: 0px;
+	--pos2x: 10px;
+	--pos2y: 20px;
+}
+
+@KEYFRAMES localkeyframesUPPERCASE {
+	0% {
+		left: VAR(--pos1x);
+		top: VAR(--pos1y);
+		color: VAR(--theme-color1);
+	}
+	100% {
+		left: VAR(--pos2x);
+		top: VAR(--pos2y);
+		color: VAR(--theme-color2);
 	}
 }
 
-@layer {
-	a {
+@KEYframes localkeyframes2UPPPERCASE {
+	0% {
+		left: 0;
+	}
+	100% {
+		left: 100px;
+	}
+}
+
+:GLOBAL .globalUpperCase :LOCAL .localUpperCase {
+	color: yellow;
+}
+
+.VARS {
+	color: VAR(--LOCAL-COLOR);
+	--LOCAL-COLOR: red;
+}
+
+.globalVarsUpperCase :GLOBAL {
+	COLOR: VAR(--GLOBAR-COLOR);
+	--GLOBAR-COLOR: red;
+}
+
+@supports (top: env(safe-area-inset-top, 0)) {
+	.inSupportScope {
 		color: red;
 	}
 }
 
-@media unknown(default) unknown(display: flex) unknown {
-	.class {
-		content: \\"style9.css\\";
+.a {
+	animation: 3s animationName;
+	-webkit-animation: 3s animationName;
+}
+
+.b {
+	animation: animationName 3s;
+	-webkit-animation: animationName 3s;
+}
+
+.c {
+	animation-name: animationName;
+	-webkit-animation-name: animationName;
+}
+
+.d {
+	--animation-name: animationName;
+}
+
+@keyframes animationName {
+	0% {
+		background: white;
+	}
+	100% {
+		background: red;
 	}
 }
 
-@media unknown(default) {
-	.class {
-		content: \\"style9.css\\";
+@-webkit-keyframes animationName {
+	0% {
+		background: white;
+	}
+	100% {
+		background: red;
 	}
 }
 
-.style11 {
+@-moz-keyframes mozAnimationName {
+	0% {
+		background: white;
+	}
+	100% {
+		background: red;
+	}
+}
+
+@counter-style thumbs {
+	system: cyclic;
+	symbols: \\"\\\\1F44D\\";
+	suffix: \\" \\";
+}
+
+@font-feature-values Font One {
+	@styleset {
+		nice-style: 12;
+	}
+}
+
+/* At-rule for \\"nice-style\\" in Font Two */
+@font-feature-values Font Two {
+	@styleset {
+		nice-style: 4;
+	}
+}
+
+@property --my-color {
+	syntax: \\"<color>\\";
+	inherits: false;
+	initial-value: #c0ffee;
+}
+
+.class {
+	color: var(--my-color);
+}
+
+@layer utilities {
+	.padding-sm {
+		padding: 0.5rem;
+	}
+
+	.padding-lg {
+		padding: 0.8rem;
+	}
+}
+
+.class {
+	color: red;
+
+	.nested-pure {
+		color: red;
+	}
+
+	@media screen and (min-width: 200px) {
+		color: blue;
+
+		.nested-media {
+			color: blue;
+		}
+	}
+
+	@supports (display: flex) {
+		display: flex;
+
+		.nested-supports {
+			display: flex;
+		}
+	}
+
+	@layer foo {
+		background: red;
+
+		.nested-layer {
+			background: red;
+		}
+	}
+
+	@container foo {
+		background: red;
+
+		.nested-layer {
+			background: red;
+		}
+	}
+}
+
+.not-selector-inside {
+	color: #fff;
+	opacity: 0.12;
+	padding: .5px;
+	unknown: :local(.test);
+	unknown1: :local .test;
+	unknown2: :global .test;
+	unknown3: :global .test;
+	unknown4: .foo, .bar, #bar;
+}
+
+@unknown :local .local :global .global {
 	color: red;
 }
 
-.style12 {
+@unknown :local(.local) :global(.global) {
 	color: red;
 }
 
-.style10 {
+.nested-var {
+	.again {
+		color: var(--local-color);
+	}
+}
+
+.nested-with-local-pseudo {
+	color: red;
+
+	:local .local-nested {
+		color: red;
+	}
+
+	:global .global-nested {
+		color: red;
+	}
+
+	:local(.local-nested) {
+		color: red;
+	}
+
+	:global(.global-nested) {
+		color: red;
+	}
+
+	:local .local-nested, :global .global-nested-next {
+		color: red;
+	}
+
+	:local(.local-nested), :global(.global-nested-next) {
+		color: red;
+	}
+
+	:global .foo, .bar {
+		color: red;
+	}
+}
+
+#id-foo {
+	color: red;
+
+	#id-bar {
+		color: red;
+	}
+}
+
+.nested-parens {
+	.local9 div:has(.vertical-tiny, .vertical-small) {
+		max-height: 0;
+		margin: 0;
+		overflow: hidden;
+	}
+}
+
+:global .global-foo {
+	.nested-global {
+		color: red;
+	}
+
+	:local .local-in-global {
+		color: blue;
+	}
+}
+
+@unknown .class {
+	color: red;
+
+	.class {
+		color: red;
+	}
+}
+
+:global .class :local .in-local-global-scope,
+:global .class :local .in-local-global-scope,
+:local .class-local-scope :global .in-local-global-scope {
 	color: red;
 }
 
-@media screen and (min-width: 400px) {
-	@media screen and (max-width: 500px) {
-		@media screen and (orientation: portrait) {
-			.class {
-				deep-deep-nested: 1;
-			}
+@container (width > 400px) {
+	.class-in-container {
+		font-size: 1.5em;
+	}
+}
+
+@container summary (min-width: 400px) {
+	@container (width > 400px) {
+		.deep-class-in-container {
+			font-size: 1.5em;
 		}
 	}
 }
 
-@media screen and (min-width: 400px) {
-	@media screen and (max-width: 500px) {
-		.class {
-			deep-nested: 1;
+:scope {
+	color: red;
+}
+
+.placeholder-gray-700:-ms-input-placeholder {
+	--placeholder-opacity: 1;
+	color: #4a5568;
+	color: rgba(74, 85, 104, var(--placeholder-opacity));
+}
+.placeholder-gray-700::-ms-input-placeholder {
+	--placeholder-opacity: 1;
+	color: #4a5568;
+	color: rgba(74, 85, 104, var(--placeholder-opacity));
+}
+.placeholder-gray-700::placeholder {
+	--placeholder-opacity: 1;
+	color: #4a5568;
+	color: rgba(74, 85, 104, var(--placeholder-opacity));
+}
+
+:root {
+	--test: dark;
+}
+
+@media screen and (prefers-color-scheme: var(--test)) {
+	.baz {
+		color: white;
+	}
+}
+
+@keyframes slidein {
+	from {
+		margin-left: 100%;
+		width: 300%;
+	}
+
+	to {
+		margin-left: 0%;
+		width: 100%;
+	}
+}
+
+.class {
+	animation:
+		foo var(--animation-name) 3s,
+		var(--animation-name) 3s,
+		3s linear 1s infinite running slidein,
+		3s linear env(foo, var(--baz)) infinite running slidein;
+}
+
+:root {
+	--baz: 10px;
+}
+
+.class {
+	bar: env(foo, var(--baz));
+}
+
+:global      .global-foo, :local        .bar {
+	:local      .local-in-global       {
+		color: blue;
+	}
+
+	@media screen {
+		:global .my-global-class-again,
+		:local .my-global-class-again {
+			color: red;
 		}
 	}
 }
 
-@media screen and (min-width: 400px) {
-	.class {
-		nested: 1;
-	}
-}
-
-@supports (display: flex) {
-	@supports (display: grid) {
-		@supports (display: table) {
-			.class {
-				deep-deep-nested: 1;
-			}
-		}
-	}
-}
-
-@supports (display: flex) {
-	@supports (display: grid) {
-		.class {
-			deep-nested: 1;
-		}
-	}
-}
-
-@supports (display: flex) {
-	.class {
-		nested: 1;
-	}
-}
-
-@layer foo {
-	@layer bar {
-		@layer baz {
-			.class {
-				deep-deep-nested: 1;
-			}
-		}
-	}
-}
-
-@layer foo {
-	@layer bar {
-		.class {
-			deep-nested: 1;
-		}
-	}
-}
-
-@layer foo {
-	.class {
-		nested: 1;
-	}
-}
-
-@layer foo {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			@layer bar {
-				@supports (display: grid) {
-					@media screen and (min-width: 500px) {
-						@layer baz {
-							@supports (display: table) {
-								@media screen and (min-width: 600px) {
-									.class {
-										deep-deep-nested: 1;
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-}
-
-@layer foo {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			@layer bar {
-				@supports (display: grid) {
-					@media screen and (min-width: 500px) {
-						.class {
-							deep-nested: 1;
-						}
-					}
-				}
-			}
-		}
-	}
-}
-
-@layer foo {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			.class {
-				nested: 1;
-			}
-		}
-	}
-}
-
-@media screen and (min-width: 400px) {
-	@supports (display: flex) {
-		@layer bar {
-			.class {
-				deep-deep-nested: 1;
-			}
-		}
-	}
-}
-
-@media screen and (min-width: 400px) {
-	@supports (display: flex) {
-		.class {
-			deep-nested: 1;
-		}
-	}
-}
-
-@media screen and (min-width: 400px) {
-	.class {
-		nested: 1;
-	}
-}
-
-@layer {
-	@layer {
-		@layer {
-			.class {
-				deep-deep-nested: 1;
-			}
-		}
-	}
-}
-
-@layer {
-	@layer {
-		.class {
-			deep-nested: 1;
-		}
-	}
-}
-
-@layer {
-	@layer base {
-		@layer baz {
-			.class {
-				deep-deep-nested: 1;
-			}
-		}
-	}
-}
-
-@layer {
-	@layer base {
-		.class {
-			deep-nested: 1;
-		}
-	}
-}
-
-@layer {
-	.class {
-		deep-nested: 1;
-	}
-}
-
-@media screen and (orientation: portrait) {
-	.class {
-		deep-deep-nested: 1;
-	}
-}
-
-@media screen and (orientation: portrait) {
-	@supports (display: flex) {
-		.class {
-			content: \\"style8.css\\";
-		}
-	}
-}
-
-@media screen and (orientation: portrait) {
-	.class {
-		duplicate-nested: true;
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (orientation: portrait) {
-		@layer {
-			@layer {
-				.class {
-					deep-deep-nested: 1;
-				}
-			}
-		}
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (orientation: portrait) {
-		@layer {
-			.class {
-				deep-nested: 1;
-			}
-		}
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (orientation: portrait) {
-		@layer base {
-			@layer baz {
-				.class {
-					deep-deep-nested: 1;
-				}
-			}
-		}
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (orientation: portrait) {
-		@layer base {
-			.class {
-				deep-nested: 1;
-			}
-		}
-	}
-}
-
-@supports (display: flex) {
-	@media screen and (orientation: portrait) {
-		.class {
-			deep-nested: 1;
-		}
-	}
-}
-
-@layer super.foo {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			@layer bar {
-				@supports (display: grid) {
-					@media screen and (min-width: 500px) {
-						@layer baz {
-							@supports (display: table) {
-								@media screen and (min-width: 600px) {
-									.class {
-										deep-deep-nested: 1;
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-}
-
-@layer super.foo {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			@layer bar {
-				@supports (display: grid) {
-					@media screen and (min-width: 500px) {
-						.class {
-							deep-nested: 1;
-						}
-					}
-				}
-			}
-		}
-	}
-}
-
-@layer super.foo {
-	@supports (display: flex) {
-		@media screen and (min-width: 400px) {
-			.class {
-				nested: 1;
-			}
-		}
-	}
-}
-
-/* Has the same URL */
-/*@import url();
-@import url('');
-@import url(\\"\\");
-@import '';
-@import \\"\\";
-@import \\"   \\";
-@import \\"\\\\
-\\";
-@import url();
-@import url('');
-@import url(\\"\\");*/
-/*@import url(https://test.cases/path/../../../../configCases/css/css-import/external.css) screen and (orientation:landscape);
-@import url(https://test.cases/path/../../../../configCases/css/css-import/external.css) screen and (orientation:landscape);*/
-/*@import \\"//example.com/style.css\\";*/
-/*@import url(~package/test.css);*/
-/*@import ;*/
-/*@import foo-bar;*/
-/*@import-normalize;*/
-/*@import url('http://') :root {}*/
-/*@import url('query.css?foo=1&bar=1');*/
-/*@import url('other-query.css?foo=1&bar=1#hash');*/
-/*@import url('other-query.css?foo=1&bar=1#hash') screen and (orientation:landscape);*/
-/*@import url('https://fonts.googleapis.com/css?family=Roboto');*/
-/*@import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC');*/
-/*@import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto');*/
-
-/*@import nourl(test.css);
-@import '\\\\
-\\\\
-\\\\
-';
-@import url('!!../../helpers/string-loader.js?esModule=false!~package/tilde.css');*/
-/*@import url('   https://fonts.googleapis.com/css?family=Roboto   ');*/
-/*@import url('!!../../helpers/string-loader.js?esModule=false!');*/
-/*@import url('   !!../../helpers/string-loader.js?esModule=false!~package/tilde.css   ');*/
-/*@import \\"http://example.com/style.css\\" supports(display: flex) screen and (min-width: 400px);*/
-/* anonymous */
-/* All unknown parse as media for compatibility */
-body {
-	background: red;
-}
-
-head{--webpack-main:https\\\\:\\\\/\\\\/test\\\\.cases\\\\/path\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/configCases\\\\/css\\\\/css-import\\\\/external\\\\.css,https\\\\:\\\\/\\\\/test\\\\.cases\\\\/path\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/configCases\\\\/css\\\\/css-import\\\\/external1\\\\.css,https\\\\:\\\\/\\\\/test\\\\.cases\\\\/path\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/\\\\.\\\\.\\\\/configCases\\\\/css\\\\/css-import\\\\/external2\\\\.css,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=9,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=10,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=11,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=12,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=13,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=14,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=15,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=16,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=17,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=18,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=19,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=20,\\\\.\\\\/print\\\\.css\\\\?foo\\\\=21,\\\\.\\\\/imported\\\\.css\\\\?2fc7,\\\\.\\\\/imported\\\\.css\\\\?8e23,\\\\.\\\\/imported\\\\.css\\\\?daf4,\\\\.\\\\/imported\\\\.css\\\\?7a8d,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/style2\\\\.css\\\\?foo\\\\=9,\\\\.\\\\/style2\\\\.css\\\\?3989,\\\\.\\\\/style2\\\\.css\\\\?1933,\\\\.\\\\/style2\\\\.css\\\\?6611,\\\\.\\\\/style3\\\\.css\\\\?bar\\\\=1,\\\\.\\\\/style3\\\\.css\\\\?bar\\\\=2,\\\\.\\\\/style3\\\\.css\\\\?bar\\\\=3,\\\\.\\\\/style3\\\\.css\\\\?\\\\=bar4,\\\\.\\\\/styl\\\\'le7\\\\.css,\\\\.\\\\/styl\\\\'le7\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/test\\\\ test\\\\.css,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/test\\\\.css,\\\\.\\\\/test\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/test\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/test\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=9,\\\\.\\\\/test\\\\ test\\\\.css\\\\?fpp\\\\=10,\\\\.\\\\/test\\\\ test\\\\.css\\\\?foo\\\\=11,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=bazz,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=bar,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=bar\\\\#hash,\\\\.\\\\/style4\\\\.css\\\\?\\\\#hash,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/style4\\\\.css\\\\?foo\\\\=5,data\\\\:text\\\\/css\\\\;charset\\\\=utf-8\\\\,a\\\\%20\\\\%7B\\\\%0D\\\\%0A\\\\%20\\\\%20color\\\\%3A\\\\%20red\\\\%3B\\\\%0D\\\\%0A\\\\%7D,data\\\\:text\\\\/css\\\\;charset\\\\=utf-8\\\\,a\\\\%20\\\\%7B\\\\%0D\\\\%0A\\\\%20\\\\%20color\\\\%3A\\\\%20blue\\\\%3B\\\\%0D\\\\%0A\\\\%7D,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/style5\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=3\\\\?14ba,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=3\\\\?0e0d,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/layer\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/style6\\\\.css,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=1,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=2,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=3,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=4,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=5,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=6,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=7,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=8,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=9,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=10,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=11,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=12,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=13,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=14,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=15,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=16,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=17,\\\\.\\\\/style6\\\\.css\\\\?foo\\\\=18,\\\\.\\\\/style8\\\\.css\\\\?5018,\\\\.\\\\/style8\\\\.css\\\\?204b,\\\\.\\\\/style8\\\\.css\\\\?63b0,\\\\.\\\\/style8\\\\.css\\\\?edb8,\\\\.\\\\/style8\\\\.css\\\\?6154,\\\\.\\\\/style8\\\\.css\\\\?8c51,\\\\.\\\\/style8\\\\.css\\\\?ced0,\\\\.\\\\/style8\\\\.css\\\\?d3b8,\\\\.\\\\/style8\\\\.css\\\\?3557,\\\\.\\\\/style8\\\\.css\\\\?ae6e,\\\\.\\\\/style8\\\\.css\\\\?d078,\\\\.\\\\/style8\\\\.css\\\\?ae8b,\\\\.\\\\/style2\\\\.css\\\\?ee8c,\\\\.\\\\/style9\\\\.css\\\\?5f26,\\\\.\\\\/style9\\\\.css\\\\?6536,\\\\.\\\\/style11\\\\.css,\\\\.\\\\/style12\\\\.css,\\\\.\\\\/style10\\\\.css,\\\\.\\\\/media-deep-deep-nested\\\\.css\\\\?1b5b,\\\\.\\\\/media-deep-nested\\\\.css,\\\\.\\\\/media-nested\\\\.css,\\\\.\\\\/supports-deep-deep-nested\\\\.css,\\\\.\\\\/supports-deep-nested\\\\.css,\\\\.\\\\/supports-nested\\\\.css,\\\\.\\\\/layer-deep-deep-nested\\\\.css\\\\?2bf1,\\\\.\\\\/layer-deep-nested\\\\.css\\\\?3469,\\\\.\\\\/layer-nested\\\\.css,\\\\.\\\\/all-deep-deep-nested\\\\.css\\\\?a7dd,\\\\.\\\\/all-deep-nested\\\\.css\\\\?5612,\\\\.\\\\/all-nested\\\\.css\\\\?a3fd,\\\\.\\\\/mixed-deep-deep-nested\\\\.css,\\\\.\\\\/mixed-deep-nested\\\\.css,\\\\.\\\\/mixed-nested\\\\.css,\\\\.\\\\/anonymous-deep-deep-nested\\\\.css\\\\?8f95,\\\\.\\\\/anonymous-deep-nested\\\\.css\\\\?40b5,\\\\.\\\\/layer-deep-deep-nested\\\\.css\\\\?e681,\\\\.\\\\/layer-deep-nested\\\\.css\\\\?dc2a,\\\\.\\\\/anonymous-nested\\\\.css\\\\?8aa8,\\\\.\\\\/media-deep-deep-nested\\\\.css\\\\?3aba,\\\\.\\\\/style8\\\\.css\\\\?83bd,\\\\.\\\\/duplicate-nested\\\\.css,\\\\.\\\\/anonymous-deep-deep-nested\\\\.css\\\\?384f,\\\\.\\\\/anonymous-deep-nested\\\\.css\\\\?8c49,\\\\.\\\\/layer-deep-deep-nested\\\\.css\\\\?17f5,\\\\.\\\\/layer-deep-nested\\\\.css\\\\?c345,\\\\.\\\\/anonymous-nested\\\\.css\\\\?d028,\\\\.\\\\/all-deep-deep-nested\\\\.css\\\\?220a,\\\\.\\\\/all-deep-nested\\\\.css\\\\?7c65,\\\\.\\\\/all-nested\\\\.css\\\\?5ae5,\\\\.\\\\/style\\\\.css;}",
-]
-`;
-
-exports[`ConfigTestCases css pure-css exported tests should compile 1`] = `
-Array [
-  ".class {
+.class {
 	color: red;
 	background: var(--color);
 }
@@ -1121,7 +584,7 @@ Array [
 	animation: test 1s, test;
 }
 
-head{--webpack-main:\\\\.\\\\/style\\\\.css;}",
+head{--webpack-main:\\\\.\\\\.\\\\/css-modules\\\\/style\\\\.module\\\\.css,\\\\.\\\\/style\\\\.css;}",
 ]
 `;
 

--- a/test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -1641,6 +1641,45 @@ Array [
 	}
 }
 
+:global .again-global {
+	color:red;
+}
+
+:global .again-again-global {
+	:global .again-again-global {
+		color: red;
+	}
+}
+
+:root {
+	--foo: red;
+}
+
+:global .again-again-global {
+	color: var(--foo);
+
+	:global .again-again-global {
+		color: var(--foo);
+	}
+}
+
+:global .again-again-global {
+	animation: slidein 3s;
+
+	:global .again-again-global, .class, :global(:global(:local(.nested1)).nested2).nested3 {
+		animation: slidein 3s;
+	}
+
+  .local2 :global .global,
+	.local3 {
+		color: red;
+	}
+}
+
+@unknown var(--foo) {
+	color: red;
+}
+
 .class {
 	color: red;
 	background: var(--color);

--- a/test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -1668,3 +1668,301 @@ Array [
 head{--webpack-main:\\\\.\\\\.\\\\/css-modules\\\\/style\\\\.module\\\\.css,\\\\.\\\\/style\\\\.css;}",
 ]
 `;
+
+exports[`ConfigTestCases css urls exported tests should be able to handle styles in div.css 1`] = `
+Object {
+  "--foo": " url(img.09a1a1112c577c279435.png)",
+  "--foo-bar": " \\"http://www.example.com/pinkish.gif\\"",
+  "/* TODO fix me */
+	/*a146": " url('./img.png', 'foo', './img.png', url('./img.png'));*/
+	/*a147: image-set(url('./img.png', 'foo', './img.png', url('./img.png')) 1x, url(\\"./img2x.png\\") 2x);*/
+",
+  "a": " url(img.09a1a1112c577c279435.png)",
+  "a1": " url(img.09a1a1112c577c279435.png)",
+  "a10": " green url( img\\\\ img.09a1a1112c577c279435.png ) xyz",
+  "a100": " url(img\\\\)img.09a1a1112c577c279435.png)",
+  "a101": " url(img\\\\ img.09a1a1112c577c279435.png)",
+  "a102": " url(img\\\\ img.09a1a1112c577c279435.png)",
+  "a103": " url(img\\\\(img.09a1a1112c577c279435.png)",
+  "a104": " url(img\\\\(img.09a1a1112c577c279435.png)",
+  "a105": " url(img\\\\(img.09a1a1112c577c279435.png)",
+  "a106": " url(img\\\\(img.09a1a1112c577c279435.png)",
+  "a107": " url(img\\\\'\\\\'\\\\'img.09a1a1112c577c279435.png)",
+  "a108": " url(\\"img'() img.09a1a1112c577c279435.png\\")",
+  "a109": " url(img\\\\'img.09a1a1112c577c279435.png)",
+  "a11": " green url( img\\\\ img.09a1a1112c577c279435.png ) xyz",
+  "a110": " url(img\\\\(img.09a1a1112c577c279435.png)",
+  "a111": " url(img\\\\)img.09a1a1112c577c279435.png)",
+  "a112": " url(img\\\\ img.09a1a1112c577c279435.png)",
+  "a113": " url(img\\\\'\\\\'\\\\'img.09a1a1112c577c279435.png)",
+  "a114": " url(\\"img'() img.09a1a1112c577c279435.png\\")",
+  "a115": " url(img\\\\'img.09a1a1112c577c279435.png)",
+  "a116": " url(img\\\\(img.09a1a1112c577c279435.png)",
+  "a117": " url(img\\\\)img.09a1a1112c577c279435.png)",
+  "a118": " url(img\\\\ img.09a1a1112c577c279435.png)",
+  "a119": " url(img.09a1a1112c577c279435.png)",
+  "a12": " green url(img.09a1a1112c577c279435.png) xyz",
+  "a120": " url(img\\\\'\\\\'\\\\'img.09a1a1112c577c279435.png)",
+  "a121": " url(\\"img'() img.09a1a1112c577c279435.png\\")",
+  "a122": " url(img\\\\'img.09a1a1112c577c279435.png)",
+  "a123": " url(img\\\\(img.09a1a1112c577c279435.png)",
+  "a124": " url(img\\\\)img.09a1a1112c577c279435.png)",
+  "a125": " url(img\\\\ img.09a1a1112c577c279435.png)",
+  "a126": " url(img.09a1a1112c577c279435.png)",
+  "a127": " url(img.09a1a1112c577c279435.png)",
+  "a128": " url(img\\\\'img.09a1a1112c577c279435.png)",
+  "a129": " url(\\"img'() img.09a1a1112c577c279435.png\\")",
+  "a13": " green url(data:image/png;base64,AAA) url(http://example.com/image.jpg) url(//example.com/image.png) xyz",
+  "a130": " url(\\"img'() img.09a1a1112c577c279435.png\\")",
+  "a131": " url(img.09a1a1112c577c279435.png)",
+  "a132": " url(img.09a1a1112c577c279435.png)",
+  "a133": " url(img.09a1a1112c577c279435.png?foo=bar)",
+  "a134": " url(img.09a1a1112c577c279435.png?foo=bar)",
+  "a135": " url(img.09a1a1112c577c279435.png?foo=bar#hash)",
+  "a136": " url(img.09a1a1112c577c279435.png?foo=bar#hash)",
+  "a137": " url(img.09a1a1112c577c279435.png?foo=bar)",
+  "a138": " url(img.09a1a1112c577c279435.png?bar=foo)",
+  "a139": " url(img.09a1a1112c577c279435.png?foo=bar#foo)",
+  "a14": " url(\\"data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 26' fill='%23007aff'><rect width='4' height='4'/><rect x='8' y='1' width='34' height='2'/><rect y='11' width='4' height='4'/><rect x='8' y='12' width='34' height='2'/><rect y='22' width='4' height='4'/><rect x='8' y='23' width='34' height='2'/></svg>\\")",
+  "a140": " url(img.09a1a1112c577c279435.png?bar=foo#bar)",
+  "a141": " url(img.09a1a1112c577c279435.png?foo=1&bar=2)",
+  "a142": " url(img.09a1a1112c577c279435.png?foo=2&bar=1)",
+  "a143": " url(data:image/svg+xml;charset=UTF-8,%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22utf-8%22%3F%3E%0A%3C!DOCTYPE%20svg%20PUBLIC%20%22-%2F%2FW3C%2F%2FDTD%20SVG%201.1%2F%2FEN%22%20%22http%3A%2F%2Fwww.w3.org%2FGraphics%2FSVG%2F1.1%2FDTD%2Fsvg11.dtd%22%3E%0A%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20width%3D%22191px%22%20height%3D%22191px%22%20viewBox%3D%220%200%20191%20191%22%20enable-background%3D%22new%200%200%20191%20191%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cpath%20fill%3D%22%23636363%22%20d%3D%22M95.5%2C0C42.8%2C0%2C0%2C42.8%2C0%2C95.5S42.8%2C191%2C95.5%2C191S191%2C148.2%2C191%2C95.5S148.2%2C0%2C95.5%2C0z%20M95.5%2C187.6%0A%09c-50.848%2C0-92.1-41.25-92.1-92.1c0-50.848%2C41.252-92.1%2C92.1-92.1c50.85%2C0%2C92.1%2C41.252%2C92.1%2C92.1%0A%09C187.6%2C146.35%2C146.35%2C187.6%2C95.5%2C187.6z%22%2F%3E%0A%3Cg%3E%0A%09%3Cpath%20fill%3D%22%23636363%22%20d%3D%22M92.9%2C10v8.6H91v-6.5c-0.1%2C0.1-0.2%2C0.2-0.4%2C0.3c-0.2%2C0.1-0.3%2C0.2-0.4%2C0.2c-0.1%2C0-0.3%2C0.1-0.5%2C0.2%0A%09%09c-0.2%2C0.1-0.3%2C0.1-0.5%2C0.1v-1.6c0.5-0.1%2C0.9-0.3%2C1.4-0.5c0.5-0.2%2C0.8-0.5%2C1.2-0.7h1.1V10z%22%2F%3E%0A%09%3Cpath%20fill%3D%22%23636363%22%20d%3D%22M97.1%2C17.1h3.602v1.5h-5.6V18c0-0.4%2C0.1-0.8%2C0.2-1.2c0.1-0.4%2C0.3-0.6%2C0.5-0.9c0.2-0.3%2C0.5-0.5%2C0.7-0.7%0A%09%09c0.2-0.2%2C0.5-0.4%2C0.7-0.6c0.199-0.2%2C0.5-0.3%2C0.6-0.5c0.102-0.2%2C0.301-0.3%2C0.5-0.5c0.2-0.2%2C0.2-0.3%2C0.301-0.5%0A%09%09c0.101-0.2%2C0.101-0.3%2C0.101-0.5c0-0.4-0.101-0.6-0.3-0.8c-0.2-0.2-0.4-0.3-0.801-0.3c-0.699%2C0-1.399%2C0.3-2.101%2C0.9v-1.6%0A%09%09c0.7-0.5%2C1.5-0.7%2C2.5-0.7c0.399%2C0%2C0.8%2C0.1%2C1.101%2C0.2c0.301%2C0.1%2C0.601%2C0.3%2C0.899%2C0.5c0.3%2C0.2%2C0.399%2C0.5%2C0.5%2C0.8%0A%09%09c0.101%2C0.3%2C0.2%2C0.6%2C0.2%2C1s-0.102%2C0.7-0.2%2C1c-0.099%2C0.3-0.3%2C0.6-0.5%2C0.8c-0.2%2C0.2-0.399%2C0.5-0.7%2C0.7c-0.3%2C0.2-0.5%2C0.4-0.8%2C0.6%0A%09%09c-0.2%2C0.1-0.399%2C0.3-0.5%2C0.4s-0.3%2C0.3-0.5%2C0.4s-0.2%2C0.3-0.3%2C0.4C97.1%2C17%2C97.1%2C17%2C97.1%2C17.1z%22%2F%3E%0A%3C%2Fg%3E%0A%3Cg%3E%0A%09%3Cpath%20fill%3D%22%23636363%22%20d%3D%22M15%2C95.4c0%2C0.7-0.1%2C1.4-0.2%2C2c-0.1%2C0.6-0.4%2C1.1-0.7%2C1.5C13.8%2C99.3%2C13.4%2C99.6%2C12.9%2C99.8s-1%2C0.3-1.5%2C0.3%0A%09%09c-0.7%2C0-1.3-0.1-1.8-0.3v-1.5c0.4%2C0.3%2C1%2C0.4%2C1.6%2C0.4c0.6%2C0%2C1.1-0.2%2C1.5-0.7c0.4-0.5%2C0.5-1.1%2C0.5-1.9l0%2C0%0A%09%09C12.8%2C96.7%2C12.3%2C96.9%2C11.5%2C96.9c-0.3%2C0-0.7-0.102-1-0.2c-0.3-0.101-0.5-0.3-0.8-0.5c-0.3-0.2-0.4-0.5-0.5-0.8%0A%09%09c-0.1-0.3-0.2-0.7-0.2-1c0-0.4%2C0.1-0.8%2C0.2-1.2c0.1-0.4%2C0.3-0.7%2C0.6-0.9c0.3-0.2%2C0.6-0.5%2C0.9-0.6c0.3-0.1%2C0.8-0.2%2C1.2-0.2%0A%09%09c0.5%2C0%2C0.9%2C0.1%2C1.2%2C0.3c0.3%2C0.2%2C0.7%2C0.4%2C0.9%2C0.8s0.5%2C0.7%2C0.6%2C1.2S15%2C94.8%2C15%2C95.4z%20M13.1%2C94.4c0-0.2%2C0-0.4-0.1-0.6%0A%09%09c-0.1-0.2-0.1-0.4-0.2-0.5c-0.1-0.1-0.2-0.2-0.4-0.3c-0.2-0.1-0.3-0.1-0.5-0.1c-0.2%2C0-0.3%2C0-0.4%2C0.1s-0.3%2C0.2-0.3%2C0.3%0A%09%09c0%2C0.1-0.2%2C0.3-0.2%2C0.4c0%2C0.1-0.1%2C0.4-0.1%2C0.6c0%2C0.2%2C0%2C0.4%2C0.1%2C0.6c0.1%2C0.2%2C0.1%2C0.3%2C0.2%2C0.4c0.1%2C0.1%2C0.2%2C0.2%2C0.4%2C0.3%0A%09%09c0.2%2C0.1%2C0.3%2C0.1%2C0.5%2C0.1c0.2%2C0%2C0.3%2C0%2C0.4-0.1s0.2-0.2%2C0.3-0.3c0.1-0.1%2C0.2-0.2%2C0.2-0.4C13%2C94.7%2C13.1%2C94.6%2C13.1%2C94.4z%22%2F%3E%0A%3C%2Fg%3E%0A%3Cg%3E%0A%09%3Cpath%20fill%3D%22%23636363%22%20d%3D%22M176%2C99.7V98.1c0.6%2C0.4%2C1.2%2C0.602%2C2%2C0.602c0.5%2C0%2C0.8-0.102%2C1.1-0.301c0.301-0.199%2C0.4-0.5%2C0.4-0.801%0A%09%09c0-0.398-0.2-0.699-0.5-0.898c-0.3-0.2-0.8-0.301-1.3-0.301h-0.802V95h0.701c1.101%2C0%2C1.601-0.4%2C1.601-1.1c0-0.7-0.4-1-1.302-1%0A%09%09c-0.6%2C0-1.1%2C0.2-1.6%2C0.5v-1.5c0.6-0.3%2C1.301-0.4%2C2.1-0.4c0.9%2C0%2C1.5%2C0.2%2C2%2C0.6s0.701%2C0.9%2C0.701%2C1.5c0%2C1.1-0.601%2C1.8-1.701%2C2.1l0%2C0%0A%09%09c0.602%2C0.1%2C1.102%2C0.3%2C1.4%2C0.6s0.5%2C0.8%2C0.5%2C1.3c0%2C0.801-0.3%2C1.4-0.9%2C1.9c-0.6%2C0.5-1.398%2C0.7-2.398%2C0.7%0A%09%09C177.2%2C100.1%2C176.5%2C100%2C176%2C99.7z%22%2F%3E%0A%3C%2Fg%3E%0A%3Cg%3E%0A%09%3Cpath%20fill%3D%22%23636363%22%20d%3D%22M98.5%2C179.102c0%2C0.398-0.1%2C0.799-0.2%2C1.199C98.2%2C180.7%2C98%2C181%2C97.7%2C181.2s-0.601%2C0.5-0.9%2C0.601%0A%09%09c-0.3%2C0.1-0.7%2C0.199-1.2%2C0.199c-0.5%2C0-0.9-0.1-1.3-0.3c-0.4-0.2-0.7-0.399-0.9-0.8c-0.2-0.4-0.5-0.7-0.6-1.2%0A%09%09c-0.1-0.5-0.2-1-0.2-1.601c0-0.699%2C0.1-1.399%2C0.3-2c0.2-0.601%2C0.4-1.101%2C0.8-1.5c0.4-0.399%2C0.7-0.699%2C1.2-1c0.5-0.3%2C1-0.3%2C1.6-0.3%0A%09%09c0.6%2C0%2C1.2%2C0.101%2C1.5%2C0.199v1.5c-0.4-0.199-0.9-0.399-1.4-0.399c-0.3%2C0-0.6%2C0.101-0.8%2C0.2c-0.2%2C0.101-0.5%2C0.3-0.7%2C0.5%0A%09%09c-0.2%2C0.199-0.3%2C0.5-0.4%2C0.8c-0.1%2C0.301-0.2%2C0.7-0.2%2C1.101l0%2C0c0.4-0.601%2C1-0.8%2C1.8-0.8c0.3%2C0%2C0.7%2C0.1%2C0.9%2C0.199%0A%09%09c0.2%2C0.101%2C0.5%2C0.301%2C0.7%2C0.5c0.199%2C0.2%2C0.398%2C0.5%2C0.5%2C0.801C98.5%2C178.2%2C98.5%2C178.7%2C98.5%2C179.102z%20M96.7%2C179.2%0A%09%09c0-0.899-0.4-1.399-1.1-1.399c-0.2%2C0-0.3%2C0-0.5%2C0.1c-0.2%2C0.101-0.3%2C0.201-0.4%2C0.301c-0.1%2C0.101-0.2%2C0.199-0.2%2C0.4%0A%09%09c0%2C0.199-0.1%2C0.299-0.1%2C0.5c0%2C0.199%2C0%2C0.398%2C0.1%2C0.6s0.1%2C0.3%2C0.2%2C0.5c0.1%2C0.199%2C0.2%2C0.199%2C0.4%2C0.3c0.2%2C0.101%2C0.3%2C0.101%2C0.5%2C0.101%0A%09%09c0.2%2C0%2C0.3%2C0%2C0.5-0.101c0.2-0.101%2C0.301-0.199%2C0.301-0.3c0-0.1%2C0.199-0.301%2C0.199-0.399C96.6%2C179.7%2C96.7%2C179.4%2C96.7%2C179.2z%22%2F%3E%0A%3C%2Fg%3E%0A%3Ccircle%20fill%3D%22%23636363%22%20cx%3D%2295%22%20cy%3D%2295%22%20r%3D%227%22%2F%3E%0A%3C%2Fsvg%3E%0A) 50% 50%/191px no-repeat",
+  "a144": " url(img.09a1a1112c577c279435.png)",
+  "a145": " url(img.09a1a1112c577c279435.png)",
+  "a148": " url('data:image/svg+xml,%3Csvg xmlns=\\"http://www.w3.org/2000/svg\\"%3E%3Crect width=\\"100%25\\" height=\\"100%25\\" style=\\"stroke: rgb(223,224,225); stroke-width: 2px; fill: none; stroke-dasharray: 6px 3px\\" /%3E%3C/svg%3E')",
+  "a149": " url('data:image/svg+xml,%3Csvg xmlns=\\"http://www.w3.org/2000/svg\\"%3E%3Crect width=\\"100%25\\" height=\\"100%25\\" style=\\"stroke: rgb(223,224,225); stroke-width: 2px; fill: none; stroke-dasharray: 6px 3px\\" /%3E%3C/svg%3E')",
+  "a15": " url(data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2042%2026%27%20fill%3D%27%2523007aff%27%3E%3Crect%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%271%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3Crect%20y%3D%2711%27%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%2712%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3Crect%20y%3D%2722%27%20width%3D%274%27%20height%3D%274%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%2723%27%20width%3D%2734%27%20height%3D%272%27%2F%3E%3C%2Fsvg%3E)",
+  "a150": " url('data:image/svg+xml,%3Csvg xmlns=\\"http://www.w3.org/2000/svg\\"%3E%3Crect width=\\"100%25\\" height=\\"100%25\\" style=\\"stroke: rgb(223,224,225); stroke-width: 2px; fill: none; stroke-dasharray: 6px 3px\\" /%3E%3C/svg%3E')",
+  "a151": " url('data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\"><rect width=\\"100%\\" height=\\"100%\\" style=\\"stroke: rgb(223,224,225); stroke-width: 2px; fill: none; stroke-dasharray: 6px 3px\\" /></svg>')",
+  "a152": " url(img.09a1a1112c577c279435.png)",
+  "a153": " url(img.09a1a1112c577c279435.png)",
+  "a154": " url(other.09a1a1112c577c279435.png)",
+  "a155": " url(img.09a1a1112c577c279435.png)",
+  "a156": " url(\\"data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e\\")",
+  "a157": " url('data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"10\\" height=\\"10\\"><rect fill=\\"gray\\" width=\\"5\\" height=\\"5\\" y=\\"0\\" x=\\"0\\" /></svg>')",
+  "a158": " src(\\"http://www.example.com/pinkish.gif\\")",
+  "a159": " src(var(--foo))",
+  "a16": " url('data:image/svg+xml;charset=utf-8,<svg xmlns=\\"http://www.w3.org/2000/svg\\"><filter id=\\"filter\\"><feGaussianBlur in=\\"SourceAlpha\\" stdDeviation=\\"0\\" /><feOffset dx=\\"1\\" dy=\\"2\\" result=\\"offsetblur\\" /><feFlood flood-color=\\"rgba(255,255,255,1)\\" /><feComposite in2=\\"offsetblur\\" operator=\\"in\\" /><feMerge><feMergeNode /><feMergeNode in=\\"SourceGraphic\\" /></feMerge></filter></svg>#filter')",
+  "a160": " url(img.09a1a1112c577c279435.png param(--color var(--primary-color)))",
+  "a161": " src(\\"img.png\\" param(--color var(--primary-color)))",
+  "a162": " url(img\\\\ img.09a1a1112c577c279435.png)",
+  "a163": " url(img.09a1a1112c577c279435.png)",
+  "a164": " url( img.png bug)",
+  "a165": " url(imgn.09a1a1112c577c279435.png)",
+  "a166": " url('data:image/svg+xml;utf8,<svg xmlns=\\"http://www.w3.org/2000/svg\\"	                width=\\"10\\" height=\\"10\\"><rect fill=\\"gray\\" width=\\"5\\" height=\\"5\\" y=\\"0\\" x=\\"0\\" /></svg>')",
+  "a167": " url(http://example.com/image.jpg)",
+  "a168": " url(http://example.com/image.jpg)",
+  "a169": " url(data:,)",
+  "a17": " url(\\"data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%5C%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%5C%22%3E%3Cfilter%20id%3D%5C%22filter%5C%22%3E%3CfeGaussianBlur%20in%3D%5C%22SourceAlpha%5C%22%20stdDeviation%3D%5C%220%5C%22%20%2F%3E%3CfeOffset%20dx%3D%5C%221%5C%22%20dy%3D%5C%222%5C%22%20result%3D%5C%22offsetblur%5C%22%20%2F%3E%3CfeFlood%20flood-color%3D%5C%22rgba(255%2C255%2C255%2C1)%5C%22%20%2F%3E%3CfeComposite%20in2%3D%5C%22offsetblur%5C%22%20operator%3D%5C%22in%5C%22%20%2F%3E%3CfeMerge%3E%3CfeMergeNode%20%2F%3E%3CfeMergeNode%20in%3D%5C%22SourceGraphic%5C%22%20%2F%3E%3C%2FfeMerge%3E%3C%2Ffilter%3E%3C%2Fsvg%3E%23filter\\")",
+  "a170": " url(data:,)",
+  "a171": " image(ltr 'img.png#xywh=0,0,16,16', red)",
+  "a172": " image-set(
+		linear-gradient(blue, white) 1x,
+		linear-gradient(blue, green) 2x
+	)",
+  "a173": " image-set(
+		url(img.09a1a1112c577c279435.png) type(\\"image/png\\"),
+		url(img.09a1a1112c577c279435.png) type(\\"image/png\\")
+	)",
+  "a174": " image-set(
+		url(img.09a1a1112c577c279435.png) 1x,
+		url(img.09a1a1112c577c279435.png) 2x
+	)",
+  "a175": " image-set(
+		url(img.09a1a1112c577c279435.png) 1x,
+		url(img.09a1a1112c577c279435.png) 2x,
+		url(img.09a1a1112c577c279435.png) 3x
+	)",
+  "a176": " image-set(
+		url(img.09a1a1112c577c279435.png) type(\\"image/png\\"),
+		url(img.09a1a1112c577c279435.png) type(\\"image/png\\")
+	) \\"img.png\\"",
+  "a177": " image-set(
+		url(img.09a1a1112c577c279435.png) 1x type(\\"image/png\\"),
+		url(img.09a1a1112c577c279435.png) 2x type(\\"image/png\\")
+	)",
+  "a178": " image-set(
+		url(img.09a1a1112c577c279435.png) type(\\"image/png\\") 1x,
+		url(img.09a1a1112c577c279435.png) type(\\"image/png\\") 2x
+	)",
+  "a179": " -webkit-image-set(
+		url(img.09a1a1112c577c279435.png) 1x
+	)",
+  "a18": " url(#highlight)",
+  "a180": " -webkit-image-set(
+		url(img.09a1a1112c577c279435.png var(--foo, \\"test.png\\")) 1x
+	)",
+  "a181": " src(   \\"img.png\\"   )",
+  "a182": " src('img.png')",
+  "a183": " src('img.png' var(--foo, \\"test.png\\"))",
+  "a184": " src(var(--foo, \\"test.png\\"))",
+  "a185": " src(\\"   img.png   \\")",
+  "a186": " image-set(url(img.09a1a1112c577c279435.png)1x,url(img.09a1a1112c577c279435.png)2x,url(img.09a1a1112c577c279435.png)3x)",
+  "a187": " image-set(url(img.09a1a1112c577c279435.png)1x,url(img.09a1a1112c577c279435.png)2x,url(img.09a1a1112c577c279435.png)3x)",
+  "a188": " image-set(url(img.09a1a1112c577c279435.png)1x,url(img.09a1a1112c577c279435.png)2x,url(img.09a1a1112c577c279435.png)3x)",
+  "a189": " image-set(url(img.09a1a1112c577c279435.png)1x,url(img.09a1a1112c577c279435.png)2x,url(img.09a1a1112c577c279435.png)3x)",
+  "a19": " url(#line-marker)",
+  "a190": " image-set(url(img.09a1a1112c577c279435.png)1x)",
+  "a191": " image-set(url(img.09a1a1112c577c279435.png)1x/* test*/,/* test*/url(img.09a1a1112c577c279435.png)2x)",
+  "a197": " \\\\u\\\\r\\\\l(img.09a1a1112c577c279435.png)",
+  "a198": " \\\\image-\\\\set(url(img.09a1a1112c577c279435.png)1x,url(img.09a1a1112c577c279435.png)2x,url(img.09a1a1112c577c279435.png)3x)",
+  "a199": " \\\\-webk\\\\it-image-set(url(img.09a1a1112c577c279435.png)1x)",
+  "a2": " url(img.09a1a1112c577c279435.png)",
+  "a200": "-webkit-image-set(url(img.09a1a1112c577c279435.png)1x)",
+  "a22": " \\"do not use url(path)\\"",
+  "a23": " 'do not \\"use\\" url(path)'",
+  "a24": " -webkit-image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x)
+",
+  "a25": " image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x)
+",
+  "a26": " green url() xyz",
+  "a27": " green url('') xyz",
+  "a28": " green url(\\"\\") xyz",
+  "a29": " green url('   ') xyz",
+  "a3": " url(img.09a1a1112c577c279435.png)",
+  "a30": " green url(
+	) xyz",
+  "a4": " url(img.09a1a1112c577c279435.png#hash)",
+  "a40": " green url(https://raw.githubusercontent.com/webpack/media/master/logo/icon.png) xyz",
+  "a41": " green url(//raw.githubusercontent.com/webpack/media/master/logo/icon.png) xyz",
+  "a42": " url(img.09a1a1112c577c279435.png?foo)",
+  "a43": " url(img.09a1a1112c577c279435.png?foo=bar)",
+  "a44": " url(img.09a1a1112c577c279435.png?foo=bar#hash)",
+  "a45": " url(img.09a1a1112c577c279435.png?foo=bar#hash)",
+  "a46": " url(img.09a1a1112c577c279435.png?)",
+  "a47": " url(img.09a1a1112c577c279435.png) url(\\"data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 26' fill='%23007aff'><rect width='4' height='4'/><rect x='8' y='1' width='34' height='2'/><rect y='11' width='4' height='4'/><rect x='8' y='12' width='34' height='2'/><rect y='22' width='4' height='4'/><rect x='8' y='23' width='34' height='2'/></svg>\\") url(img.09a1a1112c577c279435.png)",
+  "a48": " __URL__()",
+  "a49": " url(img-simple.09a1a1112c577c279435.png)",
+  "a5": " url(
+	img.09a1a1112c577c279435.png
+	)",
+  "a50": " url(img-simple.09a1a1112c577c279435.png)",
+  "a51": " url(img-simple.09a1a1112c577c279435.png)",
+  "a52": " url(img.09a1a1112c577c279435.png)",
+  "a53": " url(img.09a1a1112c577c279435.png)",
+  "a55": " -webkit-image-set()",
+  "a56": " image-set()",
+  "a58": " image-set('')",
+  "a59": " image-set(\\"\\")",
+  "a6": " green url( img.09a1a1112c577c279435.png ) xyz",
+  "a60": " image-set(\\"\\" 1x)",
+  "a61": " image-set(url())",
+  "a62": " image-set(
+		url()
+	)",
+  "a63": " image-set(URL())",
+  "a64": " image-set(url(''))",
+  "a65": " image-set(url(\\"\\"))",
+  "a66": " image-set(url('') 1x)",
+  "a67": " image-set(1x)",
+  "a68": " image-set(
+		1x
+	)",
+  "a69": " image-set(calc(1rem + 1px) 1x)",
+  "a7": " green url( img.09a1a1112c577c279435.png ) xyz",
+  "a70": " -webkit-image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x)",
+  "a71": " image-set(url(img1x.09a1a1112c577c279435.png) 1x)",
+  "a72": " image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x)",
+  "a73": " image-set(url(img\\\\ img.09a1a1112c577c279435.png) 1x, url(img\\\\ img.09a1a1112c577c279435.png) 2x)",
+  "a74": " image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x),
+		image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x)",
+  "a75": " image-set(
+		url(img1x.09a1a1112c577c279435.png) 1x,
+		url(img2x.09a1a1112c577c279435.png) 2x,
+		url(img3x.09a1a1112c577c279435.png) 600dpi
+	)",
+  "a76": " image-set(url(img1x.09a1a1112c577c279435.png?foo=bar) 1x)",
+  "a77": " image-set(url(img1x.09a1a1112c577c279435.png#hash) 1x)",
+  "a78": " image-set(url(img1x.09a1a1112c577c279435.png?#iefix) 1x)",
+  "a79": " -webkit-image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x)",
+  "a8": " green url(img.09a1a1112c577c279435.png) xyz",
+  "a80": " -webkit-image-set(url(img1x.09a1a1112c577c279435.png) 1x)",
+  "a81": " -webkit-image-set(
+		url(img1x.09a1a1112c577c279435.png) 1x
+	)",
+  "a82": " image-set(url(img1x.09a1a1112c577c279435.png) 1x)",
+  "a83": " image-set(
+		url(img1x.09a1a1112c577c279435.png) 1x
+	)",
+  "a84": " image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x)",
+  "a85": " image-set(
+		url(img1x.09a1a1112c577c279435.png) 1x,
+		url(img2x.09a1a1112c577c279435.png) 2x,
+		url(img3x.09a1a1112c577c279435.png) 600dpi
+	)",
+  "a86": " image-set(url(img\\\\ img.09a1a1112c577c279435.png) 1x, url(img\\\\ img.09a1a1112c577c279435.png) 2x)",
+  "a87": " image-set(url(img1x.09a1a1112c577c279435.png) 1x, url(img2x.09a1a1112c577c279435.png) 2x)",
+  "a88": " url(imgimg.09a1a1112c577c279435.png)",
+  "a89": " url(img\\\\'img.09a1a1112c577c279435.png)",
+  "a9": " green url(img.09a1a1112c577c279435.png) url(other-img.09a1a1112c577c279435.png) xyz",
+  "a90": " url(img\\\\'\\\\'\\\\'img.09a1a1112c577c279435.png)",
+  "a91": " url(img\\\\(img.09a1a1112c577c279435.png)",
+  "a92": " url(img\\\\)img.09a1a1112c577c279435.png)",
+  "a93": " url(img\\\\ img.09a1a1112c577c279435.png)",
+  "a94": " url(\\"img'() img.09a1a1112c577c279435.png\\")",
+  "a95": " image-set(
+		url(imgimg.09a1a1112c577c279435.png) 1x,
+		url(img\\\\'\\\\'\\\\'img.09a1a1112c577c279435.png) 2x,
+		url(img\\\\'img.09a1a1112c577c279435.png) 3x,
+		url(img\\\\(img.09a1a1112c577c279435.png) 4x,
+		url(img\\\\)img.09a1a1112c577c279435.png) 5x,
+		url(img\\\\ img.09a1a1112c577c279435.png) 6x,
+		url(\\"img'() img.09a1a1112c577c279435.png\\") 7x
+	)",
+  "a96": " url(img\\\\'\\\\'\\\\'img.09a1a1112c577c279435.png)",
+  "a97": " url(\\"img'() img.09a1a1112c577c279435.png\\")",
+  "a98": " url(img\\\\'img.09a1a1112c577c279435.png)",
+  "a99": " url(img\\\\(img.09a1a1112c577c279435.png)",
+  "b": " url(img.09a1a1112c577c279435.png)",
+  "c": " url(img.09a1a1112c577c279435.png)",
+  "d": " url(img.09a1a1112c577c279435.png#hash)",
+  "e": " url(
+    img.09a1a1112c577c279435.png
+  )",
+  "f": " green url( img.09a1a1112c577c279435.png ) xyz",
+  "g": " green url( img.09a1a1112c577c279435.png ) xyz",
+  "getPropertyValue": [Function],
+  "h": " green url(img.09a1a1112c577c279435.png) xyz",
+  "i": " green url(img.09a1a1112c577c279435.png) url(img.09a1a1112c577c279435.png) xyz",
+  "j": " green url( img\\\\ img.09a1a1112c577c279435.png ) xyz",
+  "k": " green url( img\\\\ img.09a1a1112c577c279435.png ) xyz",
+  "l": " green url(img.09a1a1112c577c279435.png) xyz",
+  "m": " green url(img.09a1a1112c577c279435.png) xyz",
+  "n": " green url(img.09a1a1112c577c279435.png) xyz",
+}
+`;
+
+exports[`ConfigTestCases records issue-7339 exported tests should write relative dynamic-require paths to records 1`] = `
+"{
+  \\"chunks\\": {
+    \\"byName\\": {
+      \\"main\\": 179
+    },
+    \\"bySource\\": {
+      \\"0 main\\": 179
+    },
+    \\"usedIds\\": [
+      179
+    ]
+  },
+  \\"modules\\": {
+    \\"byIdentifier\\": {
+      \\"./dependencies/bar.js\\": 379,
+      \\"./dependencies/foo.js\\": 117,
+      \\"./dependencies|sync|/^\\\\\\\\.\\\\\\\\/.*$/\\": 412,
+      \\"./test.js\\": 393,
+      \\"external node-commonjs \\\\\\"fs\\\\\\"\\": 147,
+      \\"external node-commonjs \\\\\\"path\\\\\\"\\": 17
+    },
+    \\"usedIds\\": [
+      17,
+      117,
+      147,
+      379,
+      393,
+      412
+    ]
+  }
+}"
+`;

--- a/test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -1627,6 +1627,20 @@ Array [
 	}
 }
 
+.first-nested {
+	.first-nested-nested {
+		color: red;
+	}
+}
+
+.first-nested-at-rule {
+	@media screen {
+		.first-nested-nested-at-rule-deep {
+			color: red;
+		}
+	}
+}
+
 .class {
 	color: red;
 	background: var(--color);

--- a/test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -1681,6 +1681,37 @@ Array [
 }
 
 .class {
+	.class {
+		.class {
+			.class {}
+		}
+	}
+}
+
+.class {
+	.class {
+		.class {
+			.class {
+				animation: slidein 3s;
+			}
+		}
+	}
+}
+
+.class {
+	animation: slidein 3s;
+	.class {
+		animation: slidein 3s;
+		.class {
+			animation: slidein 3s;
+			.class {
+				animation: slidein 3s;
+			}
+		}
+	}
+}
+
+.class {
 	color: red;
 	background: var(--color);
 }

--- a/test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -1034,6 +1034,45 @@ a {
 	}
 }
 
+/* Has the same URL */
+/*@import url();
+@import url('');
+@import url(\\"\\");
+@import '';
+@import \\"\\";
+@import \\"   \\";
+@import \\"\\\\
+\\";
+@import url();
+@import url('');
+@import url(\\"\\");*/
+/*@import url(https://test.cases/path/../../../../configCases/css/css-import/external.css) screen and (orientation:landscape);
+@import url(https://test.cases/path/../../../../configCases/css/css-import/external.css) screen and (orientation:landscape);*/
+/*@import \\"//example.com/style.css\\";*/
+/*@import url(~package/test.css);*/
+/*@import ;*/
+/*@import foo-bar;*/
+/*@import-normalize;*/
+/*@import url('http://') :root {}*/
+/*@import url('query.css?foo=1&bar=1');*/
+/*@import url('other-query.css?foo=1&bar=1#hash');*/
+/*@import url('other-query.css?foo=1&bar=1#hash') screen and (orientation:landscape);*/
+/*@import url('https://fonts.googleapis.com/css?family=Roboto');*/
+/*@import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC');*/
+/*@import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto');*/
+
+/*@import nourl(test.css);
+@import '\\\\
+\\\\
+\\\\
+';
+@import url('!!../../helpers/string-loader.js?esModule=false!~package/tilde.css');*/
+/*@import url('   https://fonts.googleapis.com/css?family=Roboto   ');*/
+/*@import url('!!../../helpers/string-loader.js?esModule=false!');*/
+/*@import url('   !!../../helpers/string-loader.js?esModule=false!~package/tilde.css   ');*/
+/*@import \\"http://example.com/style.css\\" supports(display: flex) screen and (min-width: 400px);*/
+/* anonymous */
+/* All unknown parse as media for compatibility */
 body {
 	background: red;
 }

--- a/test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -1078,6 +1078,10 @@ Array [
 	foo: bar;
 }
 
+.class {
+	animation: test 1s, test;
+}
+
 head{--webpack-main:\\\\.\\\\/style\\\\.css;}",
 ]
 `;

--- a/test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -1933,6 +1933,49 @@ Object {
 }
 `;
 
+exports[`ConfigTestCases custom-modules json-custom exported tests should transform toml to json 1`] = `
+Object {
+  "owner": Object {
+    "bio": "GitHub Cofounder & CEO
+Likes tater tots and beer.",
+    "dob": "1979-05-27T07:32:00.000Z",
+    "name": "Tom Preston-Werner",
+    "organization": "GitHub",
+  },
+  "title": "TOML Example",
+}
+`;
+
+exports[`ConfigTestCases records issue-2991 exported tests should write relative paths to records 1`] = `
+"{
+  \\"chunks\\": {
+    \\"byName\\": {
+      \\"main\\": 179
+    },
+    \\"bySource\\": {
+      \\"0 main\\": 179
+    },
+    \\"usedIds\\": [
+      179
+    ]
+  },
+  \\"modules\\": {
+    \\"byIdentifier\\": {
+      \\"./test.js\\": 393,
+      \\"external node-commonjs \\\\\\"fs\\\\\\"\\": 147,
+      \\"external node-commonjs \\\\\\"path\\\\\\"\\": 17,
+      \\"ignored|./.|pkgs/somepackage/foo\\": 802
+    },
+    \\"usedIds\\": [
+      17,
+      147,
+      393,
+      802
+    ]
+  }
+}"
+`;
+
 exports[`ConfigTestCases records issue-7339 exported tests should write relative dynamic-require paths to records 1`] = `
 "{
   \\"chunks\\": {

--- a/test/configCases/css/css-import/style.css
+++ b/test/configCases/css/css-import/style.css
@@ -60,7 +60,7 @@ style2.css?foo=9
 @import url(https://test.cases/path/../../../../configCases/css/css-import/external.css);
 /*@import url(https://test.cases/path/../../../../configCases/css/css-import/external.css) screen and (orientation:landscape);
 @import url(https://test.cases/path/../../../../configCases/css/css-import/external.css) screen and (orientation:landscape);*/
-/*@import url("//example.com/style.css");*/
+/*@import "//example.com/style.css";*/
 /*@import url(~package/test.css);*/
 /*@import ;*/
 /*@import foo-bar;*/
@@ -145,7 +145,7 @@ le3.css?=bar4');
 @import url("./layer.css?foo=5") layer();
 @import url("./layer.css?foo=6") layer(   foo.bar.baz   );
 @import url("./layer.css?foo=7") layer(      );
-/*@import url("http://example.com/style.css") supports(display: flex) screen and (min-width: 400px);*/
+/*@import "http://example.com/style.css" supports(display: flex) screen and (min-width: 400px);*/
 @import url("./style6.css")layer(default)supports(display: flex)screen and (min-width:400px);
 @import "./style6.css?foo=1"layer(default)supports(display: flex)screen and (min-width:400px);
 @import "./style6.css?foo=2"supports(display: flex)screen and (min-width:400px);

--- a/test/configCases/css/css-modules-in-node/index.js
+++ b/test/configCases/css/css-modules-in-node/index.js
@@ -89,6 +89,12 @@ it("should allow to create css modules", done => {
 				inLocalGlobalScope: prod
 					? "my-app-491-Zv"
 					: "./style.module.css-in-local-global-scope",
+				classInContainer: prod
+					? "my-app-491-Gp"
+					: "./style.module.css-class-in-container",
+				deepClassInContainer: prod
+					? "my-app-491-rn"
+					: "./style.module.css-deep-class-in-container",
 			});
 		} catch (e) {
 			return done(e);

--- a/test/configCases/css/css-modules-in-node/index.js
+++ b/test/configCases/css/css-modules-in-node/index.js
@@ -83,6 +83,12 @@ it("should allow to create css modules", done => {
 				paddingSm: prod
 					? "my-app-491-zE"
 					: "./style.module.css-padding-sm",
+				classLocalScope: prod
+					? "my-app-491-gz"
+					: "./style.module.css-class-local-scope",
+				inLocalGlobalScope: prod
+					? "my-app-491-Zv"
+					: "./style.module.css-in-local-global-scope",
 			});
 		} catch (e) {
 			return done(e);

--- a/test/configCases/css/css-modules-in-node/index.js
+++ b/test/configCases/css/css-modules-in-node/index.js
@@ -73,7 +73,16 @@ it("should allow to create css modules", done => {
 					: "./style.module.css-animationName",
 				mozAnimationName: prod
 					? "my-app-491-t6"
-					: "./style.module.css-mozAnimationName"
+					: "./style.module.css-mozAnimationName",
+				myColor: prod
+					? "--my-app-491-lC"
+					: "--./style.module.css-my-color",
+				paddingLg: prod
+					? "my-app-491-FP"
+					: "./style.module.css-padding-lg",
+				paddingSm: prod
+					? "my-app-491-zE"
+					: "./style.module.css-padding-sm",
 			});
 		} catch (e) {
 			return done(e);

--- a/test/configCases/css/css-modules/index.js
+++ b/test/configCases/css/css-modules/index.js
@@ -98,6 +98,12 @@ it("should allow to create css modules", done => {
 				paddingSm: prod
 					? "my-app-491-zE"
 					: "./style.module.css-padding-sm",
+				classLocalScope: prod
+					? "my-app-491-gz"
+					: "./style.module.css-class-local-scope",
+				inLocalGlobalScope: prod
+					? "my-app-491-Zv"
+					: "./style.module.css-in-local-global-scope",
 			});
 		} catch (e) {
 			return done(e);

--- a/test/configCases/css/css-modules/index.js
+++ b/test/configCases/css/css-modules/index.js
@@ -104,6 +104,12 @@ it("should allow to create css modules", done => {
 				inLocalGlobalScope: prod
 					? "my-app-491-Zv"
 					: "./style.module.css-in-local-global-scope",
+				classInContainer: prod
+					? "my-app-491-Gp"
+					: "./style.module.css-class-in-container",
+				deepClassInContainer: prod
+					? "my-app-491-rn"
+					: "./style.module.css-deep-class-in-container",
 			});
 		} catch (e) {
 			return done(e);

--- a/test/configCases/css/css-modules/index.js
+++ b/test/configCases/css/css-modules/index.js
@@ -88,7 +88,16 @@ it("should allow to create css modules", done => {
 					: "./style.module.css-animationName",
 				mozAnimationName: prod
 					? "my-app-491-t6"
-					: "./style.module.css-mozAnimationName"
+					: "./style.module.css-mozAnimationName",
+				myColor: prod
+					? "--my-app-491-lC"
+					: "--./style.module.css-my-color",
+				paddingLg: prod
+					? "my-app-491-FP"
+					: "./style.module.css-padding-lg",
+				paddingSm: prod
+					? "my-app-491-zE"
+					: "./style.module.css-padding-sm",
 			});
 		} catch (e) {
 			return done(e);

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -541,3 +541,17 @@
 		}
 	}
 }
+
+.first-nested {
+	.first-nested-nested {
+		color: red;
+	}
+}
+
+.first-nested-at-rule {
+	@media screen {
+		.first-nested-nested-at-rule-deep {
+			color: red;
+		}
+	}
+}

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -584,6 +584,11 @@
 	:global .again-again-global, .class, :global(:global(:local(.nested1)).nested2).nested3 {
 		animation: slidein 3s;
 	}
+
+  .local2 :global .global,
+	.local3 {
+		color: red;
+	}
 }
 
 @unknown var(--foo) {

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -443,3 +443,19 @@
 :scope {
 	color: red;
 }
+
+.placeholder-gray-700:-ms-input-placeholder {
+	--placeholder-opacity: 1;
+	color: #4a5568;
+	color: rgba(74, 85, 104, var(--placeholder-opacity));
+}
+.placeholder-gray-700::-ms-input-placeholder {
+	--placeholder-opacity: 1;
+	color: #4a5568;
+	color: rgba(74, 85, 104, var(--placeholder-opacity));
+}
+.placeholder-gray-700::placeholder {
+	--placeholder-opacity: 1;
+	color: #4a5568;
+	color: rgba(74, 85, 104, var(--placeholder-opacity));
+}

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -291,10 +291,14 @@
 	}
 }
 
-@property --property-name {
+@property --my-color {
 	syntax: "<color>";
 	inherits: false;
 	initial-value: #c0ffee;
+}
+
+.class {
+	color: var(--my-color);
 }
 
 @layer utilities {

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -271,3 +271,44 @@
 		background: red;
 	}
 }
+
+@counter-style thumbs {
+	system: cyclic;
+	symbols: "\1F44D";
+	suffix: " ";
+}
+
+@font-feature-values Font One {
+	@styleset {
+		nice-style: 12;
+	}
+}
+
+/* At-rule for "nice-style" in Font Two */
+@font-feature-values Font Two {
+	@styleset {
+		nice-style: 4;
+	}
+}
+
+@property --property-name {
+	syntax: "<color>";
+	inherits: false;
+	initial-value: #c0ffee;
+}
+
+@layer utilities {
+	.padding-sm {
+		padding: 0.5rem;
+	}
+
+	.padding-lg {
+		padding: 0.8rem;
+	}
+}
+
+.class {
+	.nested {
+		color: red;
+	}
+}

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -343,12 +343,56 @@
 	}
 }
 
-.not-selector {
+.not-selector-inside {
 	color: #fff;
 	opacity: 0.12;
 	padding: .5px;
 	unknown: :local(.test);
 	unknown1: .foo, .bar, #bar;
+}
+
+.nested-var {
+	.again {
+		color: var(--local-color);
+	}
+}
+
+.nested-with-local-pseudo {
+	color: red;
+
+	:local .local-nested {
+		color: red;
+	}
+
+	:global .global-nested {
+		color: red;
+	}
+
+	:local(.local-nested) {
+		color: red;
+	}
+
+	:global(.global-nested) {
+		color: red;
+	}
+}
+
+.nested-parens {
+	.local9 div:has(.vertical-tiny, .vertical-small) {
+		max-height: 0;
+		margin: 0;
+		overflow: hidden;
+	}
+}
+
+:global .global-foo {
+	.nested-global {
+		color: red;
+	}
+
+	:local .local-in-global {
+		color: blue;
+	}
 }
 
 :scope {

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -470,6 +470,18 @@
 	}
 }
 
+@keyframes slidein {
+	from {
+		margin-left: 100%;
+		width: 300%;
+	}
+
+	to {
+		margin-left: 0%;
+		width: 100%;
+	}
+}
+
 .class {
 	animation:
 		foo var(--animation-name) 3s,

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -470,6 +470,14 @@
 	}
 }
 
+.class {
+	animation:
+		foo var(--animation-name) 3s,
+		var(--animation-name) 3s,
+		3s linear 1s infinite running slidein,
+		3s linear env(foo, var(--baz)) infinite running slidein;
+}
+
 :root {
 	--baz: 10px;
 }

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -594,3 +594,34 @@
 @unknown var(--foo) {
 	color: red;
 }
+
+.class {
+	.class {
+		.class {
+			.class {}
+		}
+	}
+}
+
+.class {
+	.class {
+		.class {
+			.class {
+				animation: slidein 3s;
+			}
+		}
+	}
+}
+
+.class {
+	animation: slidein 3s;
+	.class {
+		animation: slidein 3s;
+		.class {
+			animation: slidein 3s;
+			.class {
+				animation: slidein 3s;
+			}
+		}
+	}
+}

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -555,3 +555,37 @@
 		}
 	}
 }
+
+:global .again-global {
+	color:red;
+}
+
+:global .again-again-global {
+	:global .again-again-global {
+		color: red;
+	}
+}
+
+:root {
+	--foo: red;
+}
+
+:global .again-again-global {
+	color: var(--foo);
+
+	:global .again-again-global {
+		color: var(--foo);
+	}
+}
+
+:global .again-again-global {
+	animation: slidein 3s;
+
+	:global .again-again-global {
+		animation: slidein 3s;
+	}
+}
+
+@unknown var(--foo) {
+	color: red;
+}

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -395,6 +395,10 @@
 	}
 }
 
+@unknown .class {
+	color: red;
+}
+
 :scope {
 	color: red;
 }

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -365,7 +365,18 @@
 	opacity: 0.12;
 	padding: .5px;
 	unknown: :local(.test);
-	unknown1: .foo, .bar, #bar;
+	unknown1: :local .test;
+	unknown2: :global .test;
+	unknown3: :global .test;
+	unknown4: .foo, .bar, #bar;
+}
+
+@unknown :local .local :global .global {
+	color: red;
+}
+
+@unknown :local(.local) :global(.global) {
+	color: red;
 }
 
 .nested-var {
@@ -390,6 +401,14 @@
 	}
 
 	:global(.global-nested) {
+		color: red;
+	}
+
+	:local .local-nested, :global .global-nested-next {
+		color: red;
+	}
+
+	:local(.local-nested), :global(.global-nested-next) {
 		color: red;
 	}
 }

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -528,3 +528,16 @@
 .class {
 	bar: env(foo, var(--baz));
 }
+
+:global      .global-foo, :local        .bar {
+	:local      .local-in-global       {
+		color: blue;
+	}
+
+	@media screen {
+		:global .my-global-class-again,
+		:local .my-global-class-again {
+			color: red;
+		}
+	}
+}

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -459,3 +459,13 @@
 	color: #4a5568;
 	color: rgba(74, 85, 104, var(--placeholder-opacity));
 }
+
+:root {
+	--test: dark;
+}
+
+@media screen and (prefers-color-scheme: var(--test)) {
+	.test {
+		color: white;
+	}
+}

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -71,6 +71,15 @@
 	background-color: aquamarine;
 }
 
+.local9 :matches(div.parent1.child1.vertical-tiny,
+    div.parent1.child1.vertical-small,
+    div.otherDiv.horizontal-tiny,
+    div.otherDiv.horizontal-small div.description) {
+	max-height: 0;
+	margin: 0;
+	overflow: hidden;
+}
+
 :global(:global(:local(.nested1)).nested2).nested3 {
 	color: pink;
 }
@@ -396,6 +405,16 @@
 }
 
 @unknown .class {
+	color: red;
+
+	.class {
+		color: red;
+	}
+}
+
+:global .class :local .in-local-global-scope,
+:global .class :local .in-local-global-scope,
+:local .class-local-scope :global .in-local-global-scope {
 	color: red;
 }
 

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -312,7 +312,38 @@
 }
 
 .class {
-	.nested {
+	color: red;
+
+	.nested-pure {
 		color: red;
 	}
+
+	@media screen and (min-width: 200px) {
+		color: blue;
+
+		.nested-media {
+			color: blue;
+		}
+	}
+
+	@supports (display: flex) {
+		display: flex;
+
+		.nested-supports {
+			display: flex;
+		}
+	}
+
+	@layer foo {
+		background: red;
+
+		.nested-layer {
+			background: red;
+		}
+	}
+}
+
+
+:scope {
+	color: red;
 }

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -350,6 +350,14 @@
 			background: red;
 		}
 	}
+
+	@container foo {
+		background: red;
+
+		.nested-layer {
+			background: red;
+		}
+	}
 }
 
 .not-selector-inside {
@@ -416,6 +424,20 @@
 :global .class :local .in-local-global-scope,
 :local .class-local-scope :global .in-local-global-scope {
 	color: red;
+}
+
+@container (width > 400px) {
+	.class-in-container {
+		font-size: 1.5em;
+	}
+}
+
+@container summary (min-width: 400px) {
+	@container (width > 400px) {
+		.deep-class-in-container {
+			font-size: 1.5em;
+		}
+	}
 }
 
 :scope {

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -343,6 +343,13 @@
 	}
 }
 
+.not-selector {
+	color: #fff;
+	opacity: 0.12;
+	padding: .5px;
+	unknown: :local(.test);
+	unknown1: .foo, .bar, #bar;
+}
 
 :scope {
 	color: red;

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -496,7 +496,7 @@
 }
 
 @media screen and (prefers-color-scheme: var(--test)) {
-	.test {
+	.baz {
 		color: white;
 	}
 }

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -411,6 +411,18 @@
 	:local(.local-nested), :global(.global-nested-next) {
 		color: red;
 	}
+
+	:global .foo, .bar {
+		color: red;
+	}
+}
+
+#id-foo {
+	color: red;
+
+	#id-bar {
+		color: red;
+	}
 }
 
 .nested-parens {

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -581,7 +581,7 @@
 :global .again-again-global {
 	animation: slidein 3s;
 
-	:global .again-again-global {
+	:global .again-again-global, .class, :global(:global(:local(.nested1)).nested2).nested3 {
 		animation: slidein 3s;
 	}
 }

--- a/test/configCases/css/css-modules/style.module.css
+++ b/test/configCases/css/css-modules/style.module.css
@@ -469,3 +469,11 @@
 		color: white;
 	}
 }
+
+:root {
+	--baz: 10px;
+}
+
+.class {
+	bar: env(foo, var(--baz));
+}

--- a/test/configCases/css/css-modules/use-style.js
+++ b/test/configCases/css/css-modules/use-style.js
@@ -37,4 +37,6 @@ export default {
 	myColor: style['my-color'],
 	paddingSm: style['padding-sm'],
 	paddingLg: style['padding-lg'],
+	inLocalGlobalScope: style['in-local-global-scope'],
+	classLocalScope: style['class-local-scope'],
 };

--- a/test/configCases/css/css-modules/use-style.js
+++ b/test/configCases/css/css-modules/use-style.js
@@ -34,4 +34,7 @@ export default {
 	inSupportScope: style.inSupportScope,
 	animationName: style.animationName,
 	mozAnimationName: style.mozAnimationName,
+	myColor: style['my-color'],
+	paddingSm: style['padding-sm'],
+	paddingLg: style['padding-lg'],
 };

--- a/test/configCases/css/css-modules/use-style.js
+++ b/test/configCases/css/css-modules/use-style.js
@@ -39,4 +39,6 @@ export default {
 	paddingLg: style['padding-lg'],
 	inLocalGlobalScope: style['in-local-global-scope'],
 	classLocalScope: style['class-local-scope'],
+	classInContainer: style['class-in-container'],
+	deepClassInContainer: style['deep-class-in-container'],
 };

--- a/test/configCases/css/pure-css/style.css
+++ b/test/configCases/css/pure-css/style.css
@@ -31,3 +31,7 @@
 :export {
 	foo: bar;
 }
+
+.class {
+	animation: test 1s, test;
+}

--- a/test/configCases/css/pure-css/style.css
+++ b/test/configCases/css/pure-css/style.css
@@ -1,3 +1,5 @@
+@import url("../css-modules/style.module.css");
+
 .class {
 	color: red;
 	background: var(--color);


### PR DESCRIPTION
A lot of CSS bug fixes:
- handle `@container`
- handle `@property`
- refactor
- simplify code
- a lot of tests 
- on nested syntax support
- bug with `var`
- bug with nested `var`
- don't rename unknown at-rules
- handle nested at-rules
- and a lot...

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5379952</samp>

This pull request refactors the `CssParser` class and the `walkCssTokens` module to improve the support for some advanced CSS features, such as the `@property`, `@layer`, and `@container` at-rules, and the `:local` and `:global` pseudo-classes. It also removes some unused options from the `CssModulesPlugin` and updates the test cases and files to verify the new functionality. Additionally, it adds a new rule to the `pure-css` test case to demonstrate the use of the `animation` property.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5379952</samp>

*  Remove `allowPseudoBlocks` option from `CssModulesPlugin` and `CssParser` constructors, as it is no longer needed after refactoring the CSS parser logic ([link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bL160), [link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L131-R132))
*  Remove unused variables from `CssParser` class, such as `singleClassSelector`, `lastIdentifier`, `awaitRightParenthesis` and `modeStack`, as they are no longer needed after refactoring the CSS parser logic ([link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L188-R186))
*  Simplify the logic for handling different tokens in `CssParser` class, by removing the `modeStack` variable and the `awaitRightParenthesis` flag, and using the `balanced` array to track the mode data instead ([link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L734-R776), [link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L810-R849))
*  Simplify the logic for handling the pseudo-class token in `CssParser` class, by removing the `singleClassSelector` variable and the `allowPseudoBlocks` option, and checking the `allowModeSwitch` option instead ([link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L782-R824))
*  Simplify the logic for handling the comma token in `CssParser` class, by removing the `modeStack` variable and the `awaitRightParenthesis` flag, and checking the `allowModeSwitch` option instead ([link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L834-R864))
*  Simplify the logic for handling the other identifier token in `walkCssTokens` module, by removing the unnecessary check for the selector callback ([link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-c883a58529823c292f9110ad330b07ef920f2a3c4c284b5c52edac6ea9baba9fL344-R344))
*  Add support for the `@property` at-rule in `CssParser` class, which allows defining custom CSS properties with syntax and inheritance information ([link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L521-R554))
*  Update the warning message in `CssParser` class to include the `@layer` and `@container` at-rules, which are also handled by the same logic as `@media` and `@supports` ([link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L530-R563))
*  Add a missing `else` branch in `CssParser` class, which sets the mode to `CSS_MODE_IN_RULE` for any other at-rule that is not handled by the previous cases ([link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054R571-R572))
*  Add support for switching modes with `:local` and `:global` pseudo-classes inside parentheses and functions in `CssParser` class ([link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L734-R776), [link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-37ddc51f6c610706a74ec7aa006cbe834fb0d9ef9d69e58af824c5ac0f32a054L810-R849))
*  Add some new at-rules and selectors to the `style.module.css` file, which use the `@counter-style`, `@font-feature-values`, `@property`, `@layer`, `@container` and `:matches` syntaxes, as well as some nested rules and custom properties ([link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-f1ab2491081397824e85ddcad488c80b5ac0c735ceb3ab20a12c112ceb8e9c1fR74-R82), [link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-f1ab2491081397824e85ddcad488c80b5ac0c735ceb3ab20a12c112ceb8e9c1fR283-R445))
*  Update the test cases for the `css-modules` and `css-modules-in-node` configurations, by adding some assertions for the custom properties and the classes defined with the `@layer` and `@container` at-rules ([link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-1b175262035431aa8325c23bbc618a9514db1a48e89b8a3fa13677e4a61a8852L76-R97), [link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-7e6a377fab710fb1ce571b4bc797ae71c536cd2831927694cc7d66b1c965f513L91-R112), [link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-12a119096dd115b993b18e3634ec30c383e6316db0bf4a290549c8d7467640deR37-R43))
*  Add a new rule to the `style.css` file, which uses the `animation` property with multiple values ([link](https://github.com/webpack/webpack/pull/17133/files?diff=unified&w=0#diff-297356113f83bb6682b30f28843ccef070d0ccd97c56c56f2f60c002f8be7cb9R34-R37))
