### PR TITLE
reference RuntimeGlobal require

### DIFF
--- a/lib/CompatibilityPlugin.js
+++ b/lib/CompatibilityPlugin.js
@@ -10,6 +10,7 @@ const {
 	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
 	JAVASCRIPT_MODULE_TYPE_ESM
 } = require("./ModuleTypeConstants");
+const RuntimeGlobals = require("./RuntimeGlobals");
 const ConstDependency = require("./dependencies/ConstDependency");
 
 /** @typedef {import("./Compiler")} Compiler */
@@ -79,7 +80,7 @@ class CompatibilityPlugin {
 						if (
 							statement.type === "FunctionDeclaration" &&
 							statement.id &&
-							statement.id.name === "__webpack_require__"
+							statement.id.name === RuntimeGlobals.require
 						) {
 							const newName = `__nested_webpack_require_${statement.range[0]}__`;
 							parser.tagVariable(
@@ -98,7 +99,7 @@ class CompatibilityPlugin {
 						}
 					});
 					parser.hooks.pattern
-						.for("__webpack_require__")
+						.for(RuntimeGlobals.require)
 						.tap(PLUGIN_NAME, pattern => {
 							const newName = `__nested_webpack_require_${pattern.range[0]}__`;
 							parser.tagVariable(pattern.name, nestedWebpackIdentifierTag, {

--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -300,8 +300,10 @@ const PLUGIN_NAME = "DefinePlugin";
 const VALUE_DEP_PREFIX = `webpack/${PLUGIN_NAME} `;
 const VALUE_DEP_MAIN = `webpack/${PLUGIN_NAME}_hash`;
 const TYPEOF_OPERATOR_REGEXP = /^typeof\s+/;
-const WEBPACK_REQUIRE_FUNCTION_REGEXP = /__webpack_require__\s*(!?\.)/;
-const WEBPACK_REQUIRE_IDENTIFIER_REGEXP = /__webpack_require__/;
+const WEBPACK_REQUIRE_FUNCTION_REGEXP = new RegExp(
+	`${RuntimeGlobals.require}` + "\\s*(!?\\.)"
+);
+const WEBPACK_REQUIRE_IDENTIFIER_REGEXP = new RegExp(RuntimeGlobals.require);
 
 class DefinePlugin {
 	/**


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary
This helps address issue #16897 
<!-- cspell:disable-next-line -->

copilot:summary

## Details
In PR is only replacing exactly `__webpack_require__` string literals

<!-- cspell:disable-next-line -->

copilot:walkthrough
