### PR TITLE
fix: crash with importModule when CSS enabled

### DIFF
--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -302,12 +302,20 @@ class CssModulesPlugin {
 					}
 					return result;
 				});
-				const enabledChunks = new WeakSet();
+				const globalChunkLoading = compilation.outputOptions.chunkLoading;
+				const isEnabledForChunk = chunk => {
+					const options = chunk.getEntryOptions();
+					const chunkLoading =
+						options && options.chunkLoading !== undefined
+							? options.chunkLoading
+							: globalChunkLoading;
+					return chunkLoading === "jsonp";
+				};
+				const onceForChunkSet = new WeakSet();
 				const handler = (chunk, set) => {
-					if (enabledChunks.has(chunk)) {
-						return;
-					}
-					enabledChunks.add(chunk);
+					if (onceForChunkSet.has(chunk)) return;
+					onceForChunkSet.add(chunk);
+					if (!isEnabledForChunk(chunk)) return;
 
 					set.add(RuntimeGlobals.publicPath);
 					set.add(RuntimeGlobals.getChunkCssFilename);

--- a/test/configCases/css/import-module/a-pitching-loader.js
+++ b/test/configCases/css/import-module/a-pitching-loader.js
@@ -1,0 +1,8 @@
+exports.pitch = async function (remaining) {
+	const result = await this.importModule(
+    this.resourcePath + '.webpack[javascript/auto]' + '!=!' + remaining, {
+    publicPath: ''
+    });
+
+	return result.default || result;
+};

--- a/test/configCases/css/import-module/a-pitching-loader.js
+++ b/test/configCases/css/import-module/a-pitching-loader.js
@@ -1,3 +1,4 @@
+/** @type {import("../../../../").PitchLoaderDefinitionFunction} */
 exports.pitch = async function (remaining) {
 	const result = await this.importModule(
     this.resourcePath + '.webpack[javascript/auto]' + '!=!' + remaining, {

--- a/test/configCases/css/import-module/colors.js
+++ b/test/configCases/css/import-module/colors.js
@@ -1,0 +1,2 @@
+export const red = '#f00';
+export const green = '#0f0';

--- a/test/configCases/css/import-module/index.js
+++ b/test/configCases/css/import-module/index.js
@@ -1,0 +1,6 @@
+import stylesheet from './stylesheet.js';
+
+it("should compile", () => {
+	expect(stylesheet).toBe("body { background: #f00; color: #0f0; }");
+});
+

--- a/test/configCases/css/import-module/stylesheet.js
+++ b/test/configCases/css/import-module/stylesheet.js
@@ -1,0 +1,3 @@
+import { green, red } from './colors.js';
+
+export default `body { background: ${red}; color: ${green}; }`;

--- a/test/configCases/css/import-module/webpack.config.js
+++ b/test/configCases/css/import-module/webpack.config.js
@@ -1,0 +1,19 @@
+const webpack = require("../../../../");
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	plugins: [new webpack.HotModuleReplacementPlugin()],
+	target: "web",
+	mode: "development",
+	module: {
+		rules: [
+			{
+				test: /stylesheet\.js$/i,
+				use: ["./a-pitching-loader.js"],
+				type: "asset/source"
+			}
+		]
+	},
+	experiments: {
+		css: true
+	}
+};


### PR DESCRIPTION
fixes https://github.com/webpack/webpack/issues/17139

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f8637c</samp>

Improve CSS modules plugin by adding a function to check chunk loading mode and skipping chunks that are not enabled for CSS modules. Refactor `enabledChunks` to `onceForChunkSet` in `lib/css/CssModulesPlugin.js`.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f8637c</samp>

*  Add a new function `isEnabledForChunk` to check the chunk loading mode ([link](https://github.com/webpack/webpack/pull/17140/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bL305-R318))
