### PR TITLE
chore: fix command

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "cover:unit": "node --max-old-space-size=4096 --experimental-vm-modules node_modules/jest-cli/bin/jest --testMatch \"<rootDir>/test/*.unittest.js\" --coverage",
     "cover:types": "node node_modules/tooling/type-coverage",
     "cover:merge": "yarn mkdirp .nyc_output && nyc merge .nyc_output coverage/coverage-nyc.json && rimraf .nyc_output",
-    "cover:report": "nyc report -t coverage"
+    "cover:report": "nyc report --reporter=lcov  --reporter=text -t coverage"
   },
   "lint-staged": {
     "*.{js,cjs,mjs}": [


### PR DESCRIPTION
We have:
```
"type-report": "rimraf coverage && yarn cover:types && yarn cover:report && open-cli coverage/lcov-report/index.html",
```

so we are awaiting `lcov` generation, but default reporter for nyc is text, so I added more and now you can see the result in a browser

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6076945</samp>

Added HTML report for code coverage. The `package.json` file was updated to use the `lcov` reporter along with the `text` reporter in the `cover:report` script.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6076945</samp>

*  Add `lcov` reporter to `cover:report` script to generate HTML code coverage report ([link](https://github.com/webpack/webpack/pull/17154/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L176-R176))
