### PR TITLE
feat: enable topLevelAwait by default

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -289,7 +289,6 @@ const applyExperimentsDefaults = (
 ) => {
 	D(experiments, "futureDefaults", false);
 	D(experiments, "backCompat", !experiments.futureDefaults);
-	D(experiments, "topLevelAwait", experiments.futureDefaults);
 	D(experiments, "syncWebAssembly", false);
 	D(experiments, "asyncWebAssembly", experiments.futureDefaults);
 	D(experiments, "outputModule", false);
@@ -298,6 +297,12 @@ const applyExperimentsDefaults = (
 	D(experiments, "buildHttp", undefined);
 	D(experiments, "cacheUnaffected", experiments.futureDefaults);
 	F(experiments, "css", () => (experiments.futureDefaults ? {} : undefined));
+
+	let shouldEnableTopLevelAwait = true;
+	if (typeof experiments.topLevelAwait === "boolean") {
+		shouldEnableTopLevelAwait = experiments.topLevelAwait;
+	}
+	D(experiments, "topLevelAwait", shouldEnableTopLevelAwait);
 
 	if (typeof experiments.buildHttp === "object") {
 		D(experiments.buildHttp, "frozen", production);

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -298,6 +298,7 @@ const applyExperimentsDefaults = (
 	D(experiments, "cacheUnaffected", experiments.futureDefaults);
 	F(experiments, "css", () => (experiments.futureDefaults ? {} : undefined));
 
+	// TODO webpack 6: remove this. topLevelAwait should be enabled by default
 	let shouldEnableTopLevelAwait = true;
 	if (typeof experiments.topLevelAwait === "boolean") {
 		shouldEnableTopLevelAwait = experiments.topLevelAwait;

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -101,7 +101,7 @@ describe("snapshots", () => {
 		    "lazyCompilation": undefined,
 		    "outputModule": false,
 		    "syncWebAssembly": false,
-		    "topLevelAwait": false,
+		    "topLevelAwait": true,
 		  },
 		  "externals": undefined,
 		  "externalsPresets": Object {
@@ -2146,9 +2146,6 @@ describe("snapshots", () => {
 			+     },
 			+     "futureDefaults": true,
 			@@ ... @@
-			-     "topLevelAwait": false,
-			+     "topLevelAwait": true,
-			@@ ... @@
 			+       },
 			+       Object {
 			+         "rules": Array [
@@ -2203,14 +2200,15 @@ describe("snapshots", () => {
 			+           "fullySpecified": true,
 			+         },
 			+         "type": "css/module",
-			+       },
-			+       Object {
+			@@ ... @@
 			+         "mimetype": "text/css",
 			+         "resolve": Object {
 			+           "fullySpecified": true,
 			+           "preferRelative": true,
 			+         },
 			+         "type": "css",
+			+       },
+			+       Object {
 			@@ ... @@
 			+         "exportsPresence": "error",
 			@@ ... @@
@@ -2259,13 +2257,9 @@ describe("snapshots", () => {
 			+     "css": false,
 			+     "futureDefaults": true,
 			@@ ... @@
-			-     "topLevelAwait": false,
-			+     "topLevelAwait": true,
-			@@ ... @@
-			+       },
 			+       Object {
 			+         "rules": Array [
-			+           Object {
+			@@ ... @@
 			+             "descriptionData": Object {
 			+               "type": "module",
 			+             },
@@ -2276,7 +2270,8 @@ describe("snapshots", () => {
 			+         ],
 			+         "test": /\\.wasm$/i,
 			+         "type": "webassembly/async",
-			@@ ... @@
+			+       },
+			+       Object {
 			+         "mimetype": "application/wasm",
 			+         "rules": Array [
 			+           Object {


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Closes https://github.com/webpack/webpack/issues/16738

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ace1d93</samp>

This pull request enables the `topLevelAwait` feature by default in webpack 5.4.0, and updates the tests accordingly. It also allows users to override the `topLevelAwait` option and prepares for its removal in webpack 6.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ace1d93</samp>

*  Enable `topLevelAwait` experiment by default in webpack 5.4.0 ([link](https://github.com/webpack/webpack/pull/17192/files?diff=unified&w=0#diff-c0078e4713a0e7a24dbc56d6dfda3cf139376325fc65ea70a8389d4d30b27f04L292), [link](https://github.com/webpack/webpack/pull/17192/files?diff=unified&w=0#diff-c0078e4713a0e7a24dbc56d6dfda3cf139376325fc65ea70a8389d4d30b27f04R301-R307), [link](https://github.com/webpack/webpack/pull/17192/files?diff=unified&w=0#diff-2ca9058acdbb297c64353f1f82fdd9828c21911ce176861026c6a0bea93fb5c2L104-R104), [link](https://github.com/webpack/webpack/pull/17192/files?diff=unified&w=0#diff-2ca9058acdbb297c64353f1f82fdd9828c21911ce176861026c6a0bea93fb5c2L2149-L2151), [link](https://github.com/webpack/webpack/pull/17192/files?diff=unified&w=0#diff-2ca9058acdbb297c64353f1f82fdd9828c21911ce176861026c6a0bea93fb5c2L2262-R2262))
*  Add conditional logic to `applyExperimentsDefaults` function to check if `topLevelAwait` option is explicitly set by user ([link](https://github.com/webpack/webpack/pull/17192/files?diff=unified&w=0#diff-c0078e4713a0e7a24dbc56d6dfda3cf139376325fc65ea70a8389d4d30b27f04R301-R307))
*  Add TODO comment to remove `topLevelAwait` option and logic in webpack 6 ([link](https://github.com/webpack/webpack/pull/17192/files?diff=unified&w=0#diff-c0078e4713a0e7a24dbc56d6dfda3cf139376325fc65ea70a8389d4d30b27f04R301-R307))
*  Update `test/Defaults.unittest.js` file to reflect the default value of `topLevelAwait` experiment and remove unnecessary diff line ([link](https://github.com/webpack/webpack/pull/17192/files?diff=unified&w=0#diff-2ca9058acdbb297c64353f1f82fdd9828c21911ce176861026c6a0bea93fb5c2L104-R104), [link](https://github.com/webpack/webpack/pull/17192/files?diff=unified&w=0#diff-2ca9058acdbb297c64353f1f82fdd9828c21911ce176861026c6a0bea93fb5c2L2149-L2151))
*  Add new line to `test/Defaults.unittest.js` file to show the expected output when `futureDefaults` experiment is enabled, which includes a new object in `module.rules` array with `mimetype` property set to `text/css` for `asset` module type ([link](https://github.com/webpack/webpack/pull/17192/files?diff=unified&w=0#diff-2ca9058acdbb297c64353f1f82fdd9828c21911ce176861026c6a0bea93fb5c2L2206-R2203))
*  Add another new line to `test/Defaults.unittest.js` file to show the expected output when `futureDefaults` experiment is enabled, which includes another new object in `module.rules` array with `test` property set to a regular expression that matches `.wasm` files for `webassembly/async` module type ([link](https://github.com/webpack/webpack/pull/17192/files?diff=unified&w=0#diff-2ca9058acdbb297c64353f1f82fdd9828c21911ce176861026c6a0bea93fb5c2R2210-R2211))
*  Update `test/Defaults.unittest.js` file to show the expected output when `futureDefaults` experiment is enabled, which includes a new object in `module.rules` array with `descriptionData` property set to an object with `type` property set to `module` for `outputModule` feature ([link](https://github.com/webpack/webpack/pull/17192/files?diff=unified&w=0#diff-2ca9058acdbb297c64353f1f82fdd9828c21911ce176861026c6a0bea93fb5c2L2262-R2262))
*  Update `test/Defaults.unittest.js` file to show the expected output when `futureDefaults` experiment is enabled, which includes a `type` property set to `webassembly/async` for the object that matches `.wasm` files and another new object in `module.rules` array with `mimetype` property set to `application/wasm` for `asset` module type ([link](https://github.com/webpack/webpack/pull/17192/files?diff=unified&w=0#diff-2ca9058acdbb297c64353f1f82fdd9828c21911ce176861026c6a0bea93fb5c2L2279-R2274))
