### PR TITLE
refactor: fix types in hot

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -21,6 +21,7 @@ coverage/
 
 # Ignore not supported files
 *.d.ts
+!module.d.ts
 
 # Ignore precompiled schemas
 schemas/**/*.check.js

--- a/hot/dev-server.js
+++ b/hot/dev-server.js
@@ -4,9 +4,10 @@
 */
 /* globals __webpack_hash__ */
 if (module.hot) {
+	/** @type {undefined|string} */
 	var lastHash;
 	var upToDate = function upToDate() {
-		return lastHash.indexOf(__webpack_hash__) >= 0;
+		return /** @type {string} */ (lastHash).indexOf(__webpack_hash__) >= 0;
 	};
 	var log = require("./log");
 	var check = function check() {

--- a/hot/lazy-compilation-node.js
+++ b/hot/lazy-compilation-node.js
@@ -3,11 +3,17 @@
 "use strict";
 
 var urlBase = decodeURIComponent(__resourceQuery.slice(1));
+
+/**
+ * @param {{ data: string, onError: (err: Error) => void, active: boolean, module: module }} options options
+ * @returns {() => void} function to destroy response
+ */
 exports.keepAlive = function (options) {
 	var data = options.data;
 	var onError = options.onError;
 	var active = options.active;
 	var module = options.module;
+	/** @type {import("http").IncomingMessage} */
 	var response;
 	var request = (
 		urlBase.startsWith("https") ? require("https") : require("http")
@@ -27,6 +33,10 @@ exports.keepAlive = function (options) {
 			}
 		}
 	);
+
+	/**
+	 * @param {Error} err error
+	 */
 	function errorHandler(err) {
 		err.message =
 			"Problem communicating active modules to the server: " + err.message;

--- a/hot/lazy-compilation-web.js
+++ b/hot/lazy-compilation-web.js
@@ -9,6 +9,7 @@ if (typeof EventSource !== "function") {
 }
 
 var urlBase = decodeURIComponent(__resourceQuery.slice(1));
+/** @type {EventSource | undefined} */
 var activeEventSource;
 var activeKeys = new Map();
 var errorHandlers = new Set();
@@ -19,6 +20,10 @@ var updateEventSource = function updateEventSource() {
 		activeEventSource = new EventSource(
 			urlBase + Array.from(activeKeys.keys()).join("@")
 		);
+		/**
+		 * @this {EventSource}
+		 * @param {Event & { message?: string, filename?: string, lineno?: number, colno?: number, error?: Error }} event event
+		 */
 		activeEventSource.onerror = function (event) {
 			errorHandlers.forEach(function (onError) {
 				onError(
@@ -42,6 +47,10 @@ var updateEventSource = function updateEventSource() {
 	}
 };
 
+/**
+ * @param {{ data: string, onError: (err: Error) => void, active: boolean, module: module }} options options
+ * @returns {() => void} function to destroy response
+ */
 exports.keepAlive = function (options) {
 	var data = options.data;
 	var onError = options.onError;

--- a/hot/log-apply-result.js
+++ b/hot/log-apply-result.js
@@ -2,6 +2,11 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+
+/**
+ * @param {(string | number)[]} updatedModules updated modules
+ * @param {(string | number)[] | null} renewedModules renewed modules
+ */
 module.exports = function (updatedModules, renewedModules) {
 	var unacceptedModules = updatedModules.filter(function (moduleId) {
 		return renewedModules && renewedModules.indexOf(moduleId) < 0;

--- a/hot/log.js
+++ b/hot/log.js
@@ -1,7 +1,14 @@
+/** @typedef {"info" | "warning" | "error"} LogLevel */
+
+/** @type {LogLevel} */
 var logLevel = "info";
 
 function dummy() {}
 
+/**
+ * @param {LogLevel} level log level
+ * @returns {boolean} true, if should log
+ */
 function shouldLog(level) {
 	var shouldLog =
 		(logLevel === "info" && level === "info") ||
@@ -10,6 +17,10 @@ function shouldLog(level) {
 	return shouldLog;
 }
 
+/**
+ * @param {(msg?: string) => void} logFn log function
+ * @returns {(level: LogLevel, msg?: string) => void} function that logs when log level is sufficient
+ */
 function logGroup(logFn) {
 	return function (level, msg) {
 		if (shouldLog(level)) {
@@ -18,6 +29,10 @@ function logGroup(logFn) {
 	};
 }
 
+/**
+ * @param {LogLevel} level log level
+ * @param {string|Error} msg message
+ */
 module.exports = function (level, msg) {
 	if (shouldLog(level)) {
 		if (level === "info") {
@@ -42,10 +57,17 @@ module.exports.groupCollapsed = logGroup(groupCollapsed);
 
 module.exports.groupEnd = logGroup(groupEnd);
 
+/**
+ * @param {LogLevel} level log level
+ */
 module.exports.setLogLevel = function (level) {
 	logLevel = level;
 };
 
+/**
+ * @param {Error} err error
+ * @returns {string} formatted error
+ */
 module.exports.formatError = function (err) {
 	var message = err.message;
 	var stack = err.stack;

--- a/hot/only-dev-server.js
+++ b/hot/only-dev-server.js
@@ -4,9 +4,10 @@
 */
 /*globals __webpack_hash__ */
 if (module.hot) {
+	/** @type {undefined|string} */
 	var lastHash;
 	var upToDate = function upToDate() {
-		return lastHash.indexOf(__webpack_hash__) >= 0;
+		return /** @type {string} */ (lastHash).indexOf(__webpack_hash__) >= 0;
 	};
 	var log = require("./log");
 	var check = function check() {

--- a/hot/poll.js
+++ b/hot/poll.js
@@ -7,6 +7,9 @@ if (module.hot) {
 	var hotPollInterval = +__resourceQuery.slice(1) || 10 * 60 * 1000;
 	var log = require("./log");
 
+	/**
+	 * @param {boolean=} fromUpdate true when called from update
+	 */
 	var checkForUpdate = function checkForUpdate(fromUpdate) {
 		if (module.hot.status() === "idle") {
 			module.hot

--- a/hot/signal.js
+++ b/hot/signal.js
@@ -5,6 +5,10 @@
 /*globals __resourceQuery */
 if (module.hot) {
 	var log = require("./log");
+
+	/**
+	 * @param {boolean=} fromUpdate true when called from update
+	 */
 	var checkForUpdate = function checkForUpdate(fromUpdate) {
 		module.hot
 			.check()

--- a/module.d.ts
+++ b/module.d.ts
@@ -3,47 +3,44 @@ declare namespace webpack {
 		| {
 				type: "declined";
 				/** The module in question. */
-				moduleId: number;
-				/** the chain from where the update was propagated. */
-				chain: number[];
-				/** the module id of the declining parent */
-				parentId: number;
 				moduleId: number | string;
+				/** the chain from where the update was propagated. */
+				chain: (number | string)[];
+				/** the module id of the declining parent */
+				parentId: number | string;
 		  }
 		| {
 				type: "self-declined";
 				/** The module in question. */
 				moduleId: number | string;
 				/** the chain from where the update was propagated. */
-				chain: number[];
+				chain: (number | string)[];
 		  };
 
 	type UnacceptedEvent = {
 		type: "unaccepted";
 		/** The module in question. */
-		moduleId: number;
+		moduleId: number | string;
 		/** the chain from where the update was propagated. */
-		chain: number[];
+		chain: (number | string)[];
 	};
 
 	type AcceptedEvent = {
 		type: "accepted";
 		/** The module in question. */
-		moduleId: number;
-		/** the chain from where the update was propagated. */
-		chain: number[];
+		moduleId: number | string;
 		/** the modules that are outdated and will be disposed */
-		outdatedModules: number[];
+		outdatedModules: (number | string)[];
 		/** the accepted dependencies that are outdated */
 		outdatedDependencies: {
-			[id: number]: number[];
+			[id: number]: (number | string)[];
 		};
 	};
 
 	type DisposedEvent = {
 		type: "disposed";
 		/** The module in question. */
-		moduleId: number;
+		moduleId: number | string;
 	};
 
 	type ErroredEvent =

--- a/module.d.ts
+++ b/module.d.ts
@@ -8,11 +8,12 @@ declare namespace webpack {
 				chain: number[];
 				/** the module id of the declining parent */
 				parentId: number;
+				moduleId: number | string;
 		  }
 		| {
 				type: "self-declined";
 				/** The module in question. */
-				moduleId: number;
+				moduleId: number | string;
 				/** the chain from where the update was propagated. */
 				chain: number[];
 		  };
@@ -49,9 +50,9 @@ declare namespace webpack {
 		| {
 				type: "accept-error-handler-errored";
 				/** The module in question. */
-				moduleId: number;
+				moduleId: number | string;
 				/** the module id owning the accept handler. */
-				dependencyId: number;
+				dependencyId: number | string;
 				/** the thrown error */
 				error: Error;
 				/** the error thrown by the module before the error handler tried to handle it. */
@@ -60,7 +61,7 @@ declare namespace webpack {
 		| {
 				type: "self-accept-error-handler-errored";
 				/** The module in question. */
-				moduleId: number;
+				moduleId: number | string;
 				/** the thrown error */
 				error: Error;
 				/** the error thrown by the module before the error handler tried to handle it. */
@@ -69,16 +70,16 @@ declare namespace webpack {
 		| {
 				type: "accept-errored";
 				/** The module in question. */
-				moduleId: number;
+				moduleId: number | string;
 				/** the module id owning the accept handler. */
-				dependencyId: number;
+				dependencyId: number | string;
 				/** the thrown error */
 				error: Error;
 		  }
 		| {
 				type: "self-accept-errored";
 				/** The module in question. */
-				moduleId: number;
+				moduleId: number | string;
 				/** the thrown error */
 				error: Error;
 		  };

--- a/test/typesCases/hot/index.ts
+++ b/test/typesCases/hot/index.ts
@@ -16,4 +16,10 @@ module.hot.apply({
 	ignoreDeclined: true,
 	ignoreErrored: true,
 }).then(() => {});
+module.hot.apply({
+	ignoreUnaccepted: true,
+	ignoreDeclined: true,
+	ignoreErrored: true,
+	onDeclined: (event) => { console.log(event.moduleId) },
+}).then(() => {});
 module.hot.apply().then(() => {});

--- a/tsconfig.module.test.json
+++ b/tsconfig.module.test.json
@@ -10,5 +10,8 @@
     "types": ["node", "./module"],
     "esModuleInterop": true
   },
-  "include": ["test/typesCases/**/*"]
+  "include": [
+    "hot/**/*",
+    "test/typesCases/**/*"
+  ]
 }

--- a/tsconfig.module.test.json
+++ b/tsconfig.module.test.json
@@ -10,8 +10,5 @@
     "types": ["node", "./module"],
     "esModuleInterop": true
   },
-  "include": [
-    "hot/**/*",
-    "test/typesCases/**/*"
-  ]
+  "include": ["hot/**/*", "test/typesCases/**/*"]
 }


### PR DESCRIPTION
Types for `hot` + fix types for moduleId (and more) + enable type checker there, need to merge after https://github.com/webpack/webpack/pull/16094

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2dd770a</samp>

This pull request adds type annotations and JSDoc comments to several files in the `hot` folder that implement the hot module replacement feature. This improves the TypeScript support and the code readability of the feature. It also adds a test case and a configuration change to verify the functionality of the new feature that allows handling declined modules in lazy compilation mode.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2dd770a</samp>

*  Annotate `lastHash` variable with `undefined|string` type to improve type inference for `upToDate` function ([link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-be8518048bd9c0a2c4733684eab2170904168e2ffd7676012b454371489d675cL7-R10), [link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-a706f03e4672a3e47076a5fe491cbf1bc81282669b25059427d80c556eacaca0L7-R10))
*  Document `options` parameter of `createResponse` function with JSDoc comment in `hot/lazy-compilation-node.js` and `hot/lazy-compilation-web.js` files to describe its properties and types ([link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-2d9e00f35b4d123241dc979f4b344fff5578971712603c407c59ca815196b68eR6-R10), [link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-3a6ed396e6f46dd870c39c01db2cd054f2fed37fbabb21f4b1e0298fa0d95612R50-R53))
*  Annotate `req` variable with `import("http").IncomingMessage` type to access its properties and methods in `hot/lazy-compilation-node.js` file ([link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-2d9e00f35b4d123241dc979f4b344fff5578971712603c407c59ca815196b68eR16))
*  Document `onError` parameter of `createResponse` function with JSDoc comment in `hot/lazy-compilation-node.js` file to describe its type and purpose ([link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-2d9e00f35b4d123241dc979f4b344fff5578971712603c407c59ca815196b68eR36-R39))
*  Annotate `source` variable with `EventSource | undefined` type to improve type inference for `createResponse` function in `hot/lazy-compilation-web.js` file ([link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-3a6ed396e6f46dd870c39c01db2cd054f2fed37fbabb21f4b1e0298fa0d95612R12))
*  Document `onMessage` function with JSDoc comment in `hot/lazy-compilation-web.js` file to describe its context, parameter and type ([link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-3a6ed396e6f46dd870c39c01db2cd054f2fed37fbabb21f4b1e0298fa0d95612R23-R26))
*  Document `updatedModules` and `renewedModules` parameters of `logApplyResult` function with JSDoc comment in `hot/log-apply-result.js` file to describe their types ([link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-73cb4e7618194b045f4a1e7a1d373d3d1c1007a54f09e0a7eccd513d4cc36227R5-R9))
*  Annotate `logLevel` variable with `LogLevel` type and define `LogLevel` type with JSDoc comment in `hot/log.js` file to represent possible values of log level ([link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-a20efb2d907f3490f50c3a395eedb3ab99c6cbb0344bace96ebd867adfbdfa3fL1-R11))
*  Document `logGroup`, `log`, `setLogLevel` and `formatError` functions with JSDoc comments in `hot/log.js` file to describe their parameters and return types ([link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-a20efb2d907f3490f50c3a395eedb3ab99c6cbb0344bace96ebd867adfbdfa3fR20-R23), [link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-a20efb2d907f3490f50c3a395eedb3ab99c6cbb0344bace96ebd867adfbdfa3fR32-R35), [link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-a20efb2d907f3490f50c3a395eedb3ab99c6cbb0344bace96ebd867adfbdfa3fL45-R70))
*  Document `fromUpdate` parameter of `check` function with JSDoc comment in `hot/poll.js` and `hot/signal.js` files to describe its type and purpose ([link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-70d4e1a34c328c1dc93d81448f205b8922e118efb2a0d1ba9edb94edc66dc0c0R10-R12), [link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-2765b0b7dfdbfd28ba7ce3a9a137faa32ceca1dab24215c65fd6522e108a99eaR8-R11))
*  Add `onDeclined` property to `options` object passed to `module.hot.apply` function in `test/typesCases/hot/index.ts` file to demonstrate usage of new feature that allows handling declined modules in lazy compilation mode ([link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-7f90502b0eaf3c5f829b1394c87bdeda7bc4812ff71f2e32c6b3fb2ada713ff1R19-R24))
*  Modify `include` property of `tsconfig.module.test.json` file to include `hot` folder that contains files related to hot module replacement feature ([link](https://github.com/webpack/webpack/pull/17193/files?diff=unified&w=0#diff-3e64756c1b7ab1d306eea90753d5fc84851aa0ea364707d7e8a84d15886ec2b6L13-R16))
