### PR TITLE
fix(types): Correct chunkgroup.groupsIterable return type

### DIFF
--- a/lib/Chunk.js
+++ b/lib/Chunk.js
@@ -505,7 +505,7 @@ class Chunk {
 	}
 
 	/**
-	 * @returns {Iterable<ChunkGroup>} the chunkGroups that the said chunk is referenced in
+	 * @returns {SortableSet<ChunkGroup>} the chunkGroups that the said chunk is referenced in
 	 */
 	get groupsIterable() {
 		this._groups.sort();

--- a/types.d.ts
+++ b/types.d.ts
@@ -839,7 +839,7 @@ declare class Chunk {
 	removeGroup(chunkGroup: ChunkGroup): void;
 	isInGroup(chunkGroup: ChunkGroup): boolean;
 	getNumberOfGroups(): number;
-	get groupsIterable(): Iterable<ChunkGroup>;
+	get groupsIterable(): SortableSet<ChunkGroup>;
 	disconnectFromGroups(): void;
 	split(newChunk: Chunk): void;
 	updateHash(hash: Hash, chunkGraph: ChunkGraph): void;


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

copilot:summary

## Details

<!-- cspell:disable-next-line -->

copilot:walkthrough
