### PR TITLE
refactor(types): Expose ChunkGroup to type definitions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,7 @@ const memoize = require("./util/memoize");
 /** @typedef {import("../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptionsNormalized */
 /** @typedef {import("../declarations/WebpackOptions").WebpackPluginFunction} WebpackPluginFunction */
 /** @typedef {import("../declarations/WebpackOptions").WebpackPluginInstance} WebpackPluginInstance */
+/** @typedef {import("./ChunkGroup")} ChunkGroup */
 /** @typedef {import("./Compilation").Asset} Asset */
 /** @typedef {import("./Compilation").AssetInfo} AssetInfo */
 /** @typedef {import("./Compilation").EntryOptions} EntryOptions */

--- a/types.d.ts
+++ b/types.d.ts
@@ -13426,6 +13426,7 @@ declare namespace exports {
 		Configuration,
 		WebpackOptionsNormalized,
 		WebpackPluginInstance,
+		ChunkGroup,
 		Asset,
 		AssetInfo,
 		EntryOptions,


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 53eccc3</samp>

Add type definition for `ChunkGroup` class in `lib/index.js`. This improves code quality and readability.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 53eccc3</samp>

*  Add type definition for `ChunkGroup` class ([link](https://github.com/webpack/webpack/pull/17201/files?diff=unified&w=0#diff-92bbac9a308cd5fcf9db165841f2d90ce981baddcb2b1e26cfff170929af3bd1R34)) to improve code documentation and type checking
