### PR TITLE
docs(types): Add docs for compilation.afterChunks hook

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -647,7 +647,12 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 
 			/** @type {SyncHook<[]>} */
 			beforeChunks: new SyncHook([]),
-			/** @type {SyncHook<[Iterable<Chunk>]>} */
+			/**
+			 * The `afterChunks` hook is called directly after the chunks and module graph have
+			 * been created and before the chunks and modules have been optimized. This hook is useful to
+			 * inspect, analyze, and/or modify the chunk graph.
+			 * @type {SyncHook<[Iterable<Chunk>]>}
+			 */
 			afterChunks: new SyncHook(["chunks"]),
 
 			/** @type {SyncBailHook<[Iterable<Module>]>} */

--- a/types.d.ts
+++ b/types.d.ts
@@ -1452,6 +1452,11 @@ declare class Compilation {
 		unseal: SyncHook<[]>;
 		seal: SyncHook<[]>;
 		beforeChunks: SyncHook<[]>;
+		/**
+		 * The `afterChunks` hook is called directly after the chunks and module graph have
+		 * been created and before the chunks and modules have been optimized. This hook is useful to
+		 * inspect, analyze, and/or modify the chunk graph.
+		 */
 		afterChunks: SyncHook<[Iterable<Chunk>]>;
 		optimizeDependencies: SyncBailHook<[Iterable<Module>], any>;
 		afterOptimizeDependencies: SyncHook<[Iterable<Module>]>;


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1b6b741</samp>

Document the `afterChunks` hook in `lib/Compilation.js` with a JSDoc comment. This improves code quality and helps developers who use the hook.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1b6b741</samp>

* Document the `afterChunks` hook in `lib/Compilation.js` with a JSDoc comment ([link](https://github.com/webpack/webpack/pull/17202/files?diff=unified&w=0#diff-9206962f55a69b69a39e73a803e2be04b10d454f270e35b482f3f70a74f472a6L650-R655))
