### PR TITLE
refactor: remove extra param

### DIFF
--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -2388,7 +2388,7 @@ class DefaultStatsFactoryPlugin {
 		compiler.hooks.compilation.tap("DefaultStatsFactoryPlugin", compilation => {
 			compilation.hooks.statsFactory.tap(
 				"DefaultStatsFactoryPlugin",
-				(stats, options, context) => {
+				(stats, options) => {
 					iterateConfig(SIMPLE_EXTRACTORS, options, (hookFor, fn) => {
 						stats.hooks.extract
 							.for(hookFor)
@@ -2448,16 +2448,13 @@ class DefaultStatsFactoryPlugin {
 								.tap("DefaultStatsFactoryPlugin", (comp, { _index: idx }) => {
 									if (idx < options.children.length) {
 										return compilation.createStatsFactory(
-											compilation.createStatsOptions(
-												options.children[idx],
-												context
-											)
+											compilation.createStatsOptions(options.children[idx])
 										);
 									}
 								});
 						} else if (options.children !== true) {
 							const childFactory = compilation.createStatsFactory(
-								compilation.createStatsOptions(options.children, context)
+								compilation.createStatsOptions(options.children)
 							);
 							stats.hooks.getItemFactory
 								.for("compilation.children[].compilation")


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Hi~ based on `statsFactory` hook signature and the way its called. I thinke the param `context` is redundant. so I just removed it.



signature
```js
statsFactory: new SyncHook(["statsFactory", "options"]),
```

call hook 
```js
createStatsFactory(options) {
  const statsFactory = new StatsFactory();
  this.hooks.statsFactory.call(statsFactory, options);
  return statsFactory;
}
```

And this is my first pr,  feel free to close it if it's inappropriate.

## Summary

<!-- cspell:disable-next-line -->

copilot:summary

## Details

<!-- cspell:disable-next-line -->

copilot:walkthrough
