### PR TITLE
fix: matcher type

### DIFF
--- a/lib/ModuleFilenameHelpers.js
+++ b/lib/ModuleFilenameHelpers.js
@@ -14,7 +14,7 @@ const memoize = require("./util/memoize");
 /** @typedef {import("./RequestShortener")} RequestShortener */
 /** @typedef {typeof import("./util/Hash")} Hash */
 
-/** @typedef {string | RegExp | string[] | RegExp[]} Matcher */
+/** @typedef {string | RegExp | (string | RegExp)[]} Matcher */
 /** @typedef {{test?: Matcher, include?: Matcher, exclude?: Matcher }} MatchObject */
 
 const ModuleFilenameHelpers = exports;

--- a/types.d.ts
+++ b/types.d.ts
@@ -6818,11 +6818,11 @@ declare interface MapOptions {
 	module?: boolean;
 }
 declare interface MatchObject {
-	test?: string | RegExp | string[] | RegExp[];
-	include?: string | RegExp | string[] | RegExp[];
-	exclude?: string | RegExp | string[] | RegExp[];
+	test?: string | RegExp | (string | RegExp)[];
+	include?: string | RegExp | (string | RegExp)[];
+	exclude?: string | RegExp | (string | RegExp)[];
 }
-type Matcher = string | RegExp | string[] | RegExp[];
+type Matcher = string | RegExp | (string | RegExp)[];
 
 /**
  * Options object for in-memory caching.


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3b80086</samp>

Simplified the `Matcher` type definition in `lib/ModuleFilenameHelpers.js` to improve readability and consistency. Refactored the module filename helpers module.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3b80086</samp>

*  Simplify `Matcher` type definition to avoid nested arrays ([link](https://github.com/webpack/webpack/pull/17207/files?diff=unified&w=0#diff-8615ef447094606b57dfda96ea402f3cd719db42311729c66776a50cabef1445L17-R17))
