### PR TITLE
feat: introduce a new syntax for worklets - `*context.audioWorklet.addModule()`

### DIFF
--- a/lib/dependencies/WorkerPlugin.js
+++ b/lib/dependencies/WorkerPlugin.js
@@ -41,7 +41,7 @@ const getUrl = module => {
 	return pathToFileURL(module.resource).toString();
 };
 
-const WorkerSpecifierTag = Symbol("createRequire");
+const WorkerSpecifierTag = Symbol("worker specifier tag");
 
 const DEFAULT_SYNTAX = [
 	"Worker",

--- a/lib/dependencies/WorkerPlugin.js
+++ b/lib/dependencies/WorkerPlugin.js
@@ -41,6 +41,8 @@ const getUrl = module => {
 	return pathToFileURL(module.resource).toString();
 };
 
+const WorkerSpecifierTag = Symbol("createRequire");
+
 const DEFAULT_SYNTAX = [
 	"Worker",
 	"SharedWorker",
@@ -378,7 +380,29 @@ class WorkerPlugin {
 						return true;
 					};
 					const processItem = item => {
-						if (item.endsWith("()")) {
+						if (
+							item.startsWith("*") &&
+							item.includes(".") &&
+							item.endsWith("()")
+						) {
+							const firstDot = item.indexOf(".");
+							const pattern = item.slice(1, firstDot);
+							const itemMembers = item.slice(firstDot + 1, -2);
+
+							parser.hooks.pattern.for(pattern).tap(PLUGIN_NAME, pattern => {
+								parser.tagVariable(pattern.name, WorkerSpecifierTag);
+								return true;
+							});
+							parser.hooks.callMemberChain
+								.for(WorkerSpecifierTag)
+								.tap(PLUGIN_NAME, (expression, members) => {
+									if (itemMembers !== members.join(".")) {
+										return;
+									}
+
+									return handleNewWorker(expression);
+								});
+						} else if (item.endsWith("()")) {
 							parser.hooks.call
 								.for(item.slice(0, -2))
 								.tap(PLUGIN_NAME, handleNewWorker);

--- a/test/configCases/worker/worklet/index.js
+++ b/test/configCases/worker/worklet/index.js
@@ -1,0 +1,178 @@
+// This is a pseudo-worklet, it is not a real worklet, but it is used to test the worker logic.
+// Real worklets do not have this API.
+
+it("should allow to create a paintWorklet worklet", async () => {
+	let pseudoWorklet = await CSS.paintWorklet.addModule(new URL("./worklet.js", import.meta.url));
+
+	pseudoWorklet = new pseudoWorklet();
+
+	expect(pseudoWorklet.url).not.toContain("asset-");
+
+	pseudoWorklet.postMessage("ok");
+
+	const result = await new Promise(resolve => {
+		pseudoWorklet.onmessage = event => {
+			resolve(event.data);
+		};
+	});
+	expect(result).toBe("data: OK, thanks");
+
+	await pseudoWorklet.terminate();
+});
+
+it("should allow to create a layoutWorklet worklet", async () => {
+	let pseudoWorklet = await CSS.layoutWorklet.addModule(new URL("./worklet.js", import.meta.url));
+
+	pseudoWorklet = new pseudoWorklet();
+
+	expect(pseudoWorklet.url).not.toContain("asset-");
+
+	pseudoWorklet.postMessage("ok");
+
+	const result = await new Promise(resolve => {
+		pseudoWorklet.onmessage = event => {
+			resolve(event.data);
+		};
+	});
+	expect(result).toBe("data: OK, thanks");
+
+	await pseudoWorklet.terminate();
+});
+
+it("should allow to create a animationWorklet worklet", async () => {
+	let pseudoWorklet = await CSS.animationWorklet.addModule(new URL("./worklet.js", import.meta.url));
+
+	pseudoWorklet = new pseudoWorklet();
+
+	expect(pseudoWorklet.url).not.toContain("asset-");
+
+	pseudoWorklet.postMessage("ok");
+
+	const result = await new Promise(resolve => {
+		pseudoWorklet.onmessage = event => {
+			resolve(event.data);
+		};
+	});
+	expect(result).toBe("data: OK, thanks");
+
+	await pseudoWorklet.terminate();
+});
+
+it("should allow to create a audioWorklet worklet", async () => {
+	let context = new AudioContext();
+	let pseudoWorklet = await context.audioWorklet.addModule(new URL("./worklet.js", import.meta.url));
+
+	pseudoWorklet = new pseudoWorklet();
+
+	expect(pseudoWorklet.url).not.toContain("asset-");
+
+	pseudoWorklet.postMessage("ok");
+
+	const result = await new Promise(resolve => {
+		pseudoWorklet.onmessage = event => {
+			resolve(event.data);
+		};
+	});
+	expect(result).toBe("data: OK, thanks");
+
+	await pseudoWorklet.terminate();
+});
+
+it("should allow to create a paintWorklet worklet using '?.'", async () => {
+	let pseudoWorklet = await CSS?.paintWorklet?.addModule(new URL("./worklet.js", import.meta.url));
+
+	pseudoWorklet = new pseudoWorklet();
+
+	expect(pseudoWorklet.url).not.toContain("asset-");
+
+	pseudoWorklet.postMessage("ok");
+
+	const result = await new Promise(resolve => {
+		pseudoWorklet.onmessage = event => {
+			resolve(event.data);
+		};
+	});
+	expect(result).toBe("data: OK, thanks");
+
+	await pseudoWorklet.terminate();
+});
+
+it("should allow to create a audioWorklet worklet #2", async () => {
+	let audioWorklet = (new AudioContext()).audioWorklet;
+	let pseudoWorklet = await audioWorklet.addModule(new URL("./worklet.js", import.meta.url));
+
+	pseudoWorklet = new pseudoWorklet();
+
+	expect(pseudoWorklet.url).not.toContain("asset-");
+
+	pseudoWorklet.postMessage("ok");
+
+	const result = await new Promise(resolve => {
+		pseudoWorklet.onmessage = event => {
+			resolve(event.data);
+		};
+	});
+	expect(result).toBe("data: OK, thanks");
+
+	await pseudoWorklet.terminate();
+});
+
+it("should allow to create a audioWorklet worklet using '?.'", async () => {
+	let context = new AudioContext();
+	let pseudoWorklet = await context?.audioWorklet?.addModule(new URL("./worklet.js", import.meta.url));
+
+	pseudoWorklet = new pseudoWorklet();
+
+	expect(pseudoWorklet.url).not.toContain("asset-");
+
+	pseudoWorklet.postMessage("ok");
+
+	const result = await new Promise(resolve => {
+		pseudoWorklet.onmessage = event => {
+			resolve(event.data);
+		};
+	});
+	expect(result).toBe("data: OK, thanks");
+
+	await pseudoWorklet.terminate();
+});
+
+it("should not create a audioWorklet worklet", async () => {
+	let workletURL;
+
+	const barContext = new class Foo {
+		constructor() {
+			this.audioWorklet = {
+				addModule(url) {
+					workletURL = url.toString();
+
+					return undefined;
+				}
+			}
+		}
+	}
+
+	await barContext.audioWorklet.addModule(new URL("./worklet-asset-1.js", import.meta.url));
+
+	expect(workletURL).toContain("asset-");
+});
+
+it("should not create a audioWorklet worklet", async () => {
+	let workletURL;
+
+	const barContext = new class Foo {
+		constructor() {
+			this.unknownWorklet = {
+				addModule(url) {
+					workletURL = url.toString();
+
+					return undefined;
+				}
+			}
+		}
+	}
+
+	await barContext.unknownWorklet.addModule(new URL("./worklet-asset-2.js", import.meta.url));
+
+	expect(workletURL).toContain("asset-");
+});

--- a/test/configCases/worker/worklet/index.js
+++ b/test/configCases/worker/worklet/index.js
@@ -117,6 +117,30 @@ it("should allow to create a audioWorklet worklet #2", async () => {
 	await pseudoWorklet.terminate();
 });
 
+it("should allow to create a audioWorklet worklet #3", async () => {
+	let context = {
+		foo: {
+			bar: new AudioContext()
+		}
+	};
+	let pseudoWorklet = await context.foo.bar.audioWorklet.addModule(new URL("./worklet.js", import.meta.url));
+
+	pseudoWorklet = new pseudoWorklet();
+
+	expect(pseudoWorklet.url).not.toContain("asset-");
+
+	pseudoWorklet.postMessage("ok");
+
+	const result = await new Promise(resolve => {
+		pseudoWorklet.onmessage = event => {
+			resolve(event.data);
+		};
+	});
+	expect(result).toBe("data: OK, thanks");
+
+	await pseudoWorklet.terminate();
+});
+
 it("should allow to create a audioWorklet worklet using '?.'", async () => {
 	let context = new AudioContext();
 	let pseudoWorklet = await context?.audioWorklet?.addModule(new URL("./worklet.js", import.meta.url));

--- a/test/configCases/worker/worklet/module.js
+++ b/test/configCases/worker/worklet/module.js
@@ -1,0 +1,3 @@
+export function upper(str) {
+	return str.toUpperCase();
+}

--- a/test/configCases/worker/worklet/test.config.js
+++ b/test/configCases/worker/worklet/test.config.js
@@ -1,0 +1,33 @@
+let outputDirectory;
+
+module.exports = {
+	moduleScope(scope) {
+		const FakeWorker = require("../../../helpers/createFakeWorker")({
+			outputDirectory
+		});
+
+		// Pseudo code
+		scope.AudioContext = class AudioContext {
+			constructor() {
+				this.audioWorklet = {
+					addModule: url => Promise.resolve(FakeWorker.bind(null, url))
+				};
+			}
+		};
+		scope.CSS = {
+			paintWorklet: {
+				addModule: url => Promise.resolve(FakeWorker.bind(null, url))
+			},
+			layoutWorklet: {
+				addModule: url => Promise.resolve(FakeWorker.bind(null, url))
+			},
+			animationWorklet: {
+				addModule: url => Promise.resolve(FakeWorker.bind(null, url))
+			}
+		};
+	},
+	findBundle: function (i, options) {
+		outputDirectory = options.output.path;
+		return ["main.js"];
+	}
+};

--- a/test/configCases/worker/worklet/test.filter.js
+++ b/test/configCases/worker/worklet/test.filter.js
@@ -1,0 +1,5 @@
+var supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = function (config) {
+	return supportsWorker();
+};

--- a/test/configCases/worker/worklet/test.filter.js
+++ b/test/configCases/worker/worklet/test.filter.js
@@ -1,5 +1,6 @@
 var supportsWorker = require("../../../helpers/supportsWorker");
+var supportsOptionalChaining = require("../../../helpers/supportsOptionalChaining");
 
 module.exports = function (config) {
-	return supportsWorker();
+	return supportsWorker() && supportsOptionalChaining();
 };

--- a/test/configCases/worker/worklet/webpack.config.js
+++ b/test/configCases/worker/worklet/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = {
 						"CSS.layoutWorklet.addModule()",
 						"CSS.animationWorklet.addModule()",
 						"*context.audioWorklet.addModule()",
+						"*context.foo.bar.audioWorklet.addModule()",
 						"*audioWorklet.addModule()",
 						// *addModule() is not valid syntax
 						"..."

--- a/test/configCases/worker/worklet/webpack.config.js
+++ b/test/configCases/worker/worklet/webpack.config.js
@@ -1,0 +1,26 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		assetModuleFilename: "asset-[name][ext]",
+		filename: "[name].js"
+	},
+	target: "web",
+	module: {
+		rules: [
+			{
+				test: /\.[cm]?js$/,
+				parser: {
+					worker: [
+						"CSS.paintWorklet.addModule()",
+						"CSS.layoutWorklet.addModule()",
+						"CSS.animationWorklet.addModule()",
+						"*context.audioWorklet.addModule()",
+						"*audioWorklet.addModule()",
+						// *addModule() is not valid syntax
+						"..."
+					]
+				}
+			}
+		]
+	}
+};

--- a/test/configCases/worker/worklet/worklet-asset-1.js
+++ b/test/configCases/worker/worklet/worklet-asset-1.js
@@ -1,0 +1,1 @@
+function test1() {}

--- a/test/configCases/worker/worklet/worklet-asset-2.js
+++ b/test/configCases/worker/worklet/worklet-asset-2.js
@@ -1,0 +1,1 @@
+function test2() {}

--- a/test/configCases/worker/worklet/worklet.js
+++ b/test/configCases/worker/worklet/worklet.js
@@ -1,0 +1,4 @@
+onmessage = async event => {
+	const { upper } = await import("./module");
+	postMessage(`data: ${upper(event.data)}, thanks`);
+};

--- a/test/helpers/createFakeWorker.js
+++ b/test/helpers/createFakeWorker.js
@@ -6,6 +6,7 @@ module.exports = ({ outputDirectory }) =>
 			expect(url).toBeInstanceOf(URL);
 			expect(url.origin).toBe("https://test.cases");
 			expect(url.pathname.startsWith("/path/")).toBe(true);
+			this.url = url;
 			const file = url.pathname.slice(6);
 			const workerBootstrap = `
 const { parentPort } = require("worker_threads");


### PR DESCRIPTION
Part of https://github.com/webpack/webpack/issues/11543, currently you can't use 
```js
myAudioContext.audioWorklet.addModule('./audio-worklet.js')
```

But now you can use:
```js
module.exports = {
	output: {
		filename: "[name].js"
	},
	target: "web",
	module: {
		rules: [
			{
				test: /\.[cm]?js$/,
				parser: {
					worker: [
						"*context.audioWorklet.addModule()",
						"*audioWorklet.addModule()",
						// *addModule() is not valid syntax
						"..."
					]
				}
			}
		]
	}
};
```

Using `*` allow to build worklet from a variable (i.e. `*context` means take `context` variable and check members after it, it **works** only on start of line, i.e. `context.foo*.addModule()` doesn't supported), i.e.

```js
const context = new AudioContext();
context.audioWorklet.addModule(new URL("./worklet.js", import.meta.url));

let audioWorklet = (new AudioContext()).audioWorklet;
audioWorklet.addModule(new URL("./worklet.js", import.meta.url));
```

Note - you can use it not only for worklets, for any custom syntax with call and member expressions

<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 20c6900</samp>

This pull request adds a new feature to the `WorkerPlugin` that allows using a special syntax for worker specifiers that match a worklet API. It also adds several test files and helpers to verify the functionality and compatibility of the feature.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 20c6900</samp>

*  Introduce `WorkerSpecifierTag` symbol to mark variables as worker specifiers ([link](https://github.com/webpack/webpack/pull/17212/files?diff=unified&w=0#diff-7f82993596b7ab3f7c6041783c839bb008d4929cf454d47b0ccc4df065da59fdR44-R45))
*  Handle new syntax for worker specifiers with pattern and member chain ([link](https://github.com/webpack/webpack/pull/17212/files?diff=unified&w=0#diff-7f82993596b7ab3f7c6041783c839bb008d4929cf454d47b0ccc4df065da59fdL381-R405))
*  Add test cases for new worklet syntax using pseudo-worklet API ([link](https://github.com/webpack/webpack/pull/17212/files?diff=unified&w=0#diff-a3726a140ebd88f464d0d87a12dce3f3df073ff95cb70df3b5fafabe65f769b1R1-R178), [link](https://github.com/webpack/webpack/pull/17212/files?diff=unified&w=0#diff-ac03d2cadd44cdab28074b6896403af65d20dab9cd0c7a48e72bc05ffbd24318R1-R4), [link](https://github.com/webpack/webpack/pull/17212/files?diff=unified&w=0#diff-004812fd81a24156f2807312b80c5ef36bbe1b7837630636426a7840723e5e8fR1), [link](https://github.com/webpack/webpack/pull/17212/files?diff=unified&w=0#diff-4d4eca7a4b94df99a4e8562fcdb2c0409d0506a2cf377c4eced345d7a1e78addR1))
*  Add module file for dynamic import inside worklet ([link](https://github.com/webpack/webpack/pull/17212/files?diff=unified&w=0#diff-f9a9674efd643906a2a65c422cc618319e78c2575bae61ee78d79cc297073f01R1-R3))
*  Add test configuration file with custom module scope and fake worklet implementations ([link](https://github.com/webpack/webpack/pull/17212/files?diff=unified&w=0#diff-8e3773767f496592320989a23a99a9e3d7f962a250db848293b29663c494d373R1-R33))
*  Add test filter file to check worker support ([link](https://github.com/webpack/webpack/pull/17212/files?diff=unified&w=0#diff-3bc710227632cede47c97611c92ac0fe0a1273772a92b453b6b90cfe195ebfe2R1-R5))
*  Add webpack configuration file with output and parser options ([link](https://github.com/webpack/webpack/pull/17212/files?diff=unified&w=0#diff-1d898f016024ab8de7b4084c6f4f30220fbdeec651476c8ea9d841a63fb8ae96R1-R26))
*  Add `url` property to `Worker` class in `createFakeWorker` helper ([link](https://github.com/webpack/webpack/pull/17212/files?diff=unified&w=0#diff-38feca23e5572bd7f9163ee93af22070f12cc7e844be58201a793fac6609e5e0R9))
