### PR TITLE
fix: regression

### DIFF
--- a/lib/dependencies/HarmonyExportExpressionDependency.js
+++ b/lib/dependencies/HarmonyExportExpressionDependency.js
@@ -174,7 +174,7 @@ HarmonyExportExpressionDependency.Template = class HarmonyExportDependencyTempla
 					runtimeRequirements.add(RuntimeGlobals.exports);
 					// This is a little bit incorrect as TDZ is not correct, but we can't use const.
 					content = `/* harmony default export */ ${exportsName}${propertyAccess(
-						used
+						typeof used === "string" ? [used] : used
 					)} = `;
 				} else {
 					content = `/* unused harmony default export */ var ${name} = `;

--- a/lib/util/propertyAccess.js
+++ b/lib/util/propertyAccess.js
@@ -11,7 +11,7 @@ const {
 } = require("../util/propertyName");
 
 /**
- * @param {Array<string>} properties properties
+ * @param {ArrayLike<string>} properties properties
  * @param {number} start start index
  * @returns {string} chain of property accesses
  */

--- a/lib/util/propertyAccess.js
+++ b/lib/util/propertyAccess.js
@@ -11,7 +11,7 @@ const {
 } = require("../util/propertyName");
 
 /**
- * @param {ArrayLike<string>} properties properties
+ * @param {Array<string>} properties properties
  * @param {number} start start index
  * @returns {string} chain of property accesses
  */

--- a/test/configCases/code-generation/import-export-format-2/cjs-module.js
+++ b/test/configCases/code-generation/import-export-format-2/cjs-module.js
@@ -1,0 +1,3 @@
+const foo = 42;
+
+module.exports = { foo };

--- a/test/configCases/code-generation/import-export-format-2/export-default-expression.js
+++ b/test/configCases/code-generation/import-export-format-2/export-default-expression.js
@@ -1,0 +1,3 @@
+const ___CSS_LOADER_EXPORT___ = {};
+___CSS_LOADER_EXPORT___.locals = {};
+export default ___CSS_LOADER_EXPORT___;

--- a/test/configCases/code-generation/import-export-format-2/harmony-module-2.js
+++ b/test/configCases/code-generation/import-export-format-2/harmony-module-2.js
@@ -1,0 +1,5 @@
+export const baz = 11;
+
+import { mod3 } from "./index";
+console.log(mod3.apple);
+

--- a/test/configCases/code-generation/import-export-format-2/harmony-module-3.js
+++ b/test/configCases/code-generation/import-export-format-2/harmony-module-3.js
@@ -1,0 +1,1 @@
+export var apple = 45;

--- a/test/configCases/code-generation/import-export-format-2/harmony-module.js
+++ b/test/configCases/code-generation/import-export-format-2/harmony-module.js
@@ -1,0 +1,5 @@
+export const bar = 42;
+
+const def = -12;
+export default def;
+

--- a/test/configCases/code-generation/import-export-format-2/index.js
+++ b/test/configCases/code-generation/import-export-format-2/index.js
@@ -1,0 +1,50 @@
+import { foo as cjsexport_harmonyimport } from "./cjs-module";
+import theDefault, { bar as harmonyexport_harmonyimport } from "./harmony-module";
+import theDefaultExpression from "./export-default-expression";
+const { harmonyexport_cjsimport } = require("./harmony-module").bar;
+const harmonyexport_cjsimportdefault = require("./export-default-expression").default;
+import { baz as harmonyexport_harmonyimport_2 } from "./harmony-module-2";
+
+import * as mod3 from "./harmony-module-3";
+export { mod3 };
+export { theDefaultExpression }
+
+const { expectSourceToContain, expectSourceToMatch } = require("../../../helpers/expectSource");
+const regexEscape = require("../../../helpers/regexEscape.js");
+
+// It's important to use propertyName when generating object members to ensure that the exported property name
+// uses the same accessor syntax (quotes vs. dot notatation) as the imported property name on the other end
+// (which needs to use propertyAccess).  Else, minifiers such as Closure Compiler will not be able to minify correctly.
+it("should use the same accessor syntax for import and export", function() {
+
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8").toString();
+
+	// Reference these imports to generate uses in the source.
+
+	cjsexport_harmonyimport;
+	harmonyexport_harmonyimport;
+	harmonyexport_cjsimport;
+	harmonyexport_harmonyimport_2;
+	theDefault;
+	theDefaultExpression;
+	harmonyexport_cjsimportdefault;
+
+	/*********** DO NOT MATCH BELOW THIS LINE ***********/
+
+	// Checking harmonyexportinitfragment.js formation of standard export fragment
+	expectSourceToContain(source, "/* harmony export */   bar: () => (/* binding */ bar)");
+
+	// Checking formation of imports
+	expectSourceToMatch(source, `${regexEscape("const { harmonyexport_cjsimport } = (__webpack_require__(/*! ./harmony-module */ ")}\\d+${regexEscape(").bar);")}`);
+	expectSourceToMatch(source, `${regexEscape("const harmonyexport_cjsimportdefault = (__webpack_require__(/*! ./export-default-expression */ ")}\\d+${regexEscape(")[\"default\"]);")}`);
+
+	// Checking concatenatedmodule.js formation of exports
+	expectSourceToContain(source, "mod3: () => (/* reexport */ harmony_module_3_namespaceObject)");
+
+	// Checking concatenatedmodule.js formation of namespace objects
+	expectSourceToContain(source, "apple: () => (apple)");
+
+	// Do not break default option
+	expectSourceToContain(source, "[\"default\"] = (___CSS_LOADER_EXPORT___)");
+});

--- a/test/configCases/code-generation/import-export-format-2/webpack.config.js
+++ b/test/configCases/code-generation/import-export-format-2/webpack.config.js
@@ -1,0 +1,25 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		environment: {
+			arrowFunction: true,
+			bigIntLiteral: false,
+			const: false,
+			destructuring: false,
+			forOf: false,
+			dynamicImport: true,
+			module: false
+		}
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	optimization: {
+		concatenateModules: true,
+		usedExports: true,
+		providedExports: true,
+		minimize: false,
+		mangleExports: false
+	}
+};


### PR DESCRIPTION
fixes https://github.com/webpack/webpack/issues/17213

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b8e0bcf</samp>

This pull request fixes a harmony export bug and updates a JSDoc comment. It ensures that the property access helper function receives a valid array of properties and documents its parameter type correctly.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b8e0bcf</samp>

* Fix a bug in harmony default export code generation for modules with named exports ([link](https://github.com/webpack/webpack/pull/17214/files?diff=unified&w=0#diff-a589af16bdcbd682b34e532fe49dc23a5c831c5313d229de7b1817c98319c11fL177-R177))
* Update JSDoc comment of property access helper function to match actual parameter type ([link](https://github.com/webpack/webpack/pull/17214/files?diff=unified&w=0#diff-ea95106ee448a96b949a56b3f8ba4c90dbb69789a4e3d47f35a388a66278c70eL14-R14))
* Improve readability and consistency of code documentation in `lib/util/propertyAccess.js` ([link](https://github.com/webpack/webpack/pull/17214/files?diff=unified&w=0#diff-ea95106ee448a96b949a56b3f8ba4c90dbb69789a4e3d47f35a388a66278c70eL14-R14))
