### PR TITLE
test: added `with { type: "json" }`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@webassemblyjs/wasm-edit": "^1.11.5",
     "@webassemblyjs/wasm-parser": "^1.11.5",
     "acorn": "^8.7.1",
-    "acorn-import-assertions": "^1.7.6",
+    "acorn-import-assertions": "^1.9.0",
     "browserslist": "^4.14.5",
     "chrome-trace-event": "^1.0.2",
     "enhanced-resolve": "^5.14.0",

--- a/test/cases/json/import-with-type-json/errors.js
+++ b/test/cases/json/import-with-type-json/errors.js
@@ -1,0 +1,3 @@
+module.exports = [
+	[{ moduleName: /data.poison/, message: /Unexpected token .+ JSON/ }]
+];

--- a/test/cases/json/import-with-type-json/import-poison.js
+++ b/test/cases/json/import-with-type-json/import-poison.js
@@ -1,0 +1,3 @@
+import poison from "../data/poison" with { type: "json" };
+
+export default poison;

--- a/test/cases/json/import-with-type-json/index.js
+++ b/test/cases/json/import-with-type-json/index.js
@@ -1,0 +1,21 @@
+import c from "../data/c.json" with { type: "json" };
+import unknownJson from "../data/unknown" with { type: "json" };
+import unknownJs from "../data/unknown";
+
+it("should be possible to import json data with import assertion", function () {
+	expect(c).toEqual([1, 2, 3, 4]);
+});
+
+it("should be possible to import json data without extension with import assertion", function () {
+	expect(unknownJson).toEqual([1, 2, 3, 4]);
+});
+
+it("should be possible to import js without extension without import assertion in the same file", function () {
+	expect(unknownJs).toEqual({});
+});
+
+it("should not be possible to import js with import assertion", function () {
+	expect(() => {
+		require("./import-poison.js");
+	}).toThrowError();
+});

--- a/test/cases/json/import-with-type-json/infrastructure-log.js
+++ b/test/cases/json/import-with-type-json/infrastructure-log.js
@@ -1,0 +1,3 @@
+module.exports = [
+	/^Pack got invalid because of write to: Compilation\/modules|json.+json\/data\/poison$/
+];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,10 +1406,10 @@ abbrev@1.0.x:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
   integrity sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==
 
-acorn-import-assertions@^1.7.6:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9"
-  integrity sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==
+acorn-import-assertions@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"
+  integrity sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"


### PR DESCRIPTION
fixes #17191 with tests

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 456a811</samp>

Updated `acorn-import-assertions` dependency to support import assertions for JSON modules. Added test cases and log files to verify the feature and the error handling.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 456a811</samp>

* Update `acorn-import-assertions` dependency to support import assertions syntax for JSON modules ([link](https://github.com/webpack/webpack/pull/17230/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14-R14))
* Add test cases for importing JSON data with and without type assertions and extensions ([link](https://github.com/webpack/webpack/pull/17230/files?diff=unified&w=0#diff-af701f28ee560da320339ef841d523d40e47b68f0982b66d237ea6d410b74d22R1-R21))
  - Check that importing a JS file with a JSON type assertion throws an error ([link](https://github.com/webpack/webpack/pull/17230/files?diff=unified&w=0#diff-19f820034fbe03333047af7531880a5f829aefbf1ef6a09cce434710ead4c90eR1-R3), [link](https://github.com/webpack/webpack/pull/17230/files?diff=unified&w=0#diff-2f10eb7fc2369a73f49189e88b7f49172b320fbc9691372db8c184c94de12072R1-R3), [link](https://github.com/webpack/webpack/pull/17230/files?diff=unified&w=0#diff-fc10ce23a74c9470c0187471176cd14da3b8035e5ec5d9f3d27dc61485def552R1-R3))
  - Use `infrastructure-log.js` to capture the expected error message from webpack ([link](https://github.com/webpack/webpack/pull/17230/files?diff=unified&w=0#diff-fc10ce23a74c9470c0187471176cd14da3b8035e5ec5d9f3d27dc61485def552R1-R3))
