### PR TITLE
fix: allow DefinePlugin shorthand property

### DIFF
--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -463,7 +463,7 @@ class DefinePlugin {
 								});
 							parser.hooks.expression.for(key).tap(PLUGIN_NAME, expr => {
 								addValueDependency(originalKey);
-								const strCode = toCode(
+								let strCode = toCode(
 									code,
 									parser,
 									compilation.valueCacheVersions,
@@ -473,6 +473,11 @@ class DefinePlugin {
 									!parser.isAsiPosition(expr.range[0]),
 									parser.destructuringAssignmentPropertiesFor(expr)
 								);
+
+								if (parser.scope.inShorthand) {
+									strCode = parser.scope.inShorthand + ":" + strCode;
+								}
+
 								if (WEBPACK_REQUIRE_FUNCTION_REGEXP.test(strCode)) {
 									return toConstantDependency(parser, strCode, [
 										RuntimeGlobals.require
@@ -564,7 +569,7 @@ class DefinePlugin {
 							);
 						parser.hooks.expression.for(key).tap(PLUGIN_NAME, expr => {
 							addValueDependency(key);
-							const strCode = stringifyObj(
+							let strCode = stringifyObj(
 								obj,
 								parser,
 								compilation.valueCacheVersions,
@@ -574,6 +579,10 @@ class DefinePlugin {
 								!parser.isAsiPosition(expr.range[0]),
 								parser.destructuringAssignmentPropertiesFor(expr)
 							);
+
+							if (parser.scope.inShorthand) {
+								strCode = parser.scope.inShorthand + ":" + strCode;
+							}
 
 							if (WEBPACK_REQUIRE_FUNCTION_REGEXP.test(strCode)) {
 								return toConstantDependency(parser, strCode, [

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -283,11 +283,15 @@ it('should allow shorthand property (issue #16764)', () => {
 	const nested = { OBJECT }
 	expect(nested.OBJECT.SUB.FUNCTION(7)).toBe(8);
 	expect(nested.OBJECT.SUB.CODE).toBe(3);
-	expect(nested.OBJECT.SUB.UNDEFINED).toBe(undefined);
+	expect(nested.OBJECT.SUB.UNDEFINED).toBeUndefined();
 	expect(nested.OBJECT.SUB.REGEXP.toString()).toBe("/abc/i");
 	expect(nested.OBJECT.SUB.STRING).toBe("string");
 
 
 	const array = { ARRAY }
 	expect(array).toStrictEqual({ ARRAY: [2, ['six']] })
+})
+
+it("fails for unknown property", () => {
+	expect(() => ({ UNKNOWN })).toThrowError("UNKNOWN is not defined")
 })

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -255,3 +255,8 @@ it("destructuring assignment", () => {
 	expect(used).toBe(used2);
 	expect(used).toBe(used3);
 });
+
+it('should allow shorthand property (issue #16764)', () => {
+	const obj = {ONE, TRUE };
+	expect(obj).toStrictEqual({ONE: 1, TRUE: true})
+})

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -257,6 +257,6 @@ it("destructuring assignment", () => {
 });
 
 it('should allow shorthand property (issue #16764)', () => {
-	const obj = {ONE, TRUE };
-	expect(obj).toStrictEqual({ONE: 1, TRUE: true})
+	const obj = { ONE, TRUE };
+	expect(obj).toStrictEqual({ ONE: 1, TRUE: true })
 })

--- a/test/configCases/plugins/define-plugin/index.js
+++ b/test/configCases/plugins/define-plugin/index.js
@@ -257,6 +257,37 @@ it("destructuring assignment", () => {
 });
 
 it('should allow shorthand property (issue #16764)', () => {
-	const obj = { ONE, TRUE };
-	expect(obj).toStrictEqual({ ONE: 1, TRUE: true })
+	const simple = { ONE, TRUE, NULL, STRING, BIGINT, NEGATIVE_NUMBER };
+	expect(simple).toStrictEqual({ 
+		ONE: 1, 
+		TRUE: true,
+		NULL: null, 
+		STRING: "string", 
+		BIGINT: BigInt("9007199254740993"), 
+		NEGATIVE_NUMBER: -100.25 
+	})
+
+	const func = { FUNCTION };
+	expect(func.FUNCTION(3)).toBe(4);
+	expect(typeof func.FUNCTION).toBe("function");
+	
+	const code = { CODE };
+	expect(code.CODE).toBe(3);
+	expect(typeof code.CODE).toBe("number");
+	
+	
+	const regex = { REGEXP };
+	expect(regex.REGEXP.toString()).toBe("/abc/i");
+	expect(typeof regex.REGEXP).toBe("object");
+	
+	const nested = { OBJECT }
+	expect(nested.OBJECT.SUB.FUNCTION(7)).toBe(8);
+	expect(nested.OBJECT.SUB.CODE).toBe(3);
+	expect(nested.OBJECT.SUB.UNDEFINED).toBe(undefined);
+	expect(nested.OBJECT.SUB.REGEXP.toString()).toBe("/abc/i");
+	expect(nested.OBJECT.SUB.STRING).toBe("string");
+
+
+	const array = { ARRAY }
+	expect(array).toStrictEqual({ ARRAY: [2, ['six']] })
 })


### PR DESCRIPTION
closes #16764 

<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at af7126c</samp>

The pull request enhances the `DefinePlugin` to support a new syntax for defining object properties. It also adds a test case to ensure the functionality works as expected.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at af7126c</samp>

*  Allow DefinePlugin to handle shorthand property syntax by prepending the property name to the code string ([link](https://github.com/webpack/webpack/pull/17231/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fL466-R466), [link](https://github.com/webpack/webpack/pull/17231/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR476-R480), [link](https://github.com/webpack/webpack/pull/17231/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fL567-R572), [link](https://github.com/webpack/webpack/pull/17231/files?diff=unified&w=0#diff-b2f38a9feff6ea16533eae094a99e8ded8ed19dcbb721a7b716f35ee6bc0cf2fR583-R586)) in `lib/DefinePlugin.js`
* Add a test case in `test/configCases/plugins/define-plugin/index.js` to verify the correct behavior of DefinePlugin with shorthand property syntax ([link](https://github.com/webpack/webpack/pull/17231/files?diff=unified&w=0#diff-bd719cd6133b58bf9097aa2433aec65afc238089a8a26de1ca429f3de5a78e42R258-R262))
