### PR TITLE
fix: handle class name in properties and methods

### DIFF
--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -3568,6 +3568,7 @@ class JavascriptParser extends Parser {
 		this.scope = oldScope;
 	}
 
+	// TODO webpack 6 rename to `inScope`
 	inFunctionScope(hasThis, params, fn) {
 		const oldScope = this.scope;
 		this.scope = {

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -1605,7 +1605,7 @@ class JavascriptParser extends Parser {
 			if (classy.id) {
 				scopeParams.push(classy.id);
 			}
-			this.inFunctionScope(false, scopeParams, () => {
+			this.inClassScope(true, scopeParams, () => {
 				for (const classElement of /** @type {TODO} */ (classy.body.body)) {
 					if (!this.hooks.classBodyElement.call(classElement, classy)) {
 						if (classElement.computed && classElement.key) {
@@ -3568,7 +3568,30 @@ class JavascriptParser extends Parser {
 		this.scope = oldScope;
 	}
 
-	// TODO webpack 6 rename to `inScope`
+	inClassScope(hasThis, params, fn) {
+		const oldScope = this.scope;
+		this.scope = {
+			topLevelScope: oldScope.topLevelScope,
+			inTry: false,
+			inShorthand: false,
+			isStrict: oldScope.isStrict,
+			isAsmJs: oldScope.isAsmJs,
+			definitions: oldScope.definitions.createChild()
+		};
+
+		if (hasThis) {
+			this.undefineVariable("this");
+		}
+
+		this.enterPatterns(params, (ident, pattern) => {
+			this.defineVariable(ident);
+		});
+
+		fn();
+
+		this.scope = oldScope;
+	}
+
 	inFunctionScope(hasThis, params, fn) {
 		const oldScope = this.scope;
 		this.scope = {

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -277,7 +277,7 @@ class JavascriptParser extends Parser {
 			]),
 			/** @type {SyncBailHook<[MethodDefinition | PropertyDefinition | StaticBlock, ClassExpression | ClassDeclaration], boolean | void>} */
 			classBodyElement: new SyncBailHook(["element", "classDefinition"]),
-			/** @type {SyncBailHook<[Expression, MethodDefinition | PropertyDefinition | StaticBlock, ClassExpression | ClassDeclaration], boolean | void>} */
+			/** @type {SyncBailHook<[Expression, MethodDefinition | PropertyDefinition, ClassExpression | ClassDeclaration], boolean | void>} */
 			classBodyValue: new SyncBailHook([
 				"expression",
 				"element",

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -1600,32 +1600,39 @@ class JavascriptParser extends Parser {
 			}
 		}
 		if (classy.body && classy.body.type === "ClassBody") {
-			for (const classElement of /** @type {TODO} */ (classy.body.body)) {
-				if (!this.hooks.classBodyElement.call(classElement, classy)) {
-					if (classElement.computed && classElement.key) {
-						this.walkExpression(classElement.key);
-					}
-					if (classElement.value) {
-						if (
-							!this.hooks.classBodyValue.call(
-								classElement.value,
-								classElement,
-								classy
-							)
-						) {
+			const scopeParams = [];
+			// Add class name in scope for recursive calls
+			if (classy.id) {
+				scopeParams.push(classy.id);
+			}
+			this.inFunctionScope(false, scopeParams, () => {
+				for (const classElement of /** @type {TODO} */ (classy.body.body)) {
+					if (!this.hooks.classBodyElement.call(classElement, classy)) {
+						if (classElement.computed && classElement.key) {
+							this.walkExpression(classElement.key);
+						}
+						if (classElement.value) {
+							if (
+								!this.hooks.classBodyValue.call(
+									classElement.value,
+									classElement,
+									classy
+								)
+							) {
+								const wasTopLevel = this.scope.topLevelScope;
+								this.scope.topLevelScope = false;
+								this.walkExpression(classElement.value);
+								this.scope.topLevelScope = wasTopLevel;
+							}
+						} else if (classElement.type === "StaticBlock") {
 							const wasTopLevel = this.scope.topLevelScope;
 							this.scope.topLevelScope = false;
-							this.walkExpression(classElement.value);
+							this.walkBlockStatement(classElement);
 							this.scope.topLevelScope = wasTopLevel;
 						}
-					} else if (classElement.type === "StaticBlock") {
-						const wasTopLevel = this.scope.topLevelScope;
-						this.scope.topLevelScope = false;
-						this.walkBlockStatement(classElement);
-						this.scope.topLevelScope = wasTopLevel;
 					}
 				}
-			}
+			});
 		}
 	}
 

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -277,7 +277,7 @@ class JavascriptParser extends Parser {
 			]),
 			/** @type {SyncBailHook<[MethodDefinition | PropertyDefinition | StaticBlock, ClassExpression | ClassDeclaration], boolean | void>} */
 			classBodyElement: new SyncBailHook(["element", "classDefinition"]),
-			/** @type {SyncBailHook<[Expression, MethodDefinition | PropertyDefinition, ClassExpression | ClassDeclaration], boolean | void>} */
+			/** @type {SyncBailHook<[Expression, MethodDefinition | PropertyDefinition | StaticBlock, ClassExpression | ClassDeclaration], boolean | void>} */
 			classBodyValue: new SyncBailHook([
 				"expression",
 				"element",
@@ -3963,20 +3963,34 @@ class JavascriptParser extends Parser {
 					return false;
 				}
 				const items =
-					/** @type {(MethodDefinition | PropertyDefinition)[]} */
+					/** @type {TODO[]} */
 					(expr.body.body);
-				return items.every(
-					item =>
-						(!item.computed ||
-							!item.key ||
-							this.isPure(item.key, item.range[0])) &&
-						(!item.static ||
-							!item.value ||
-							this.isPure(
-								item.value,
-								item.key ? item.key.range[1] : item.range[0]
-							))
-				);
+				return items.every(item => {
+					if (
+						item.computed &&
+						item.key &&
+						!this.isPure(item.key, item.range[0])
+					) {
+						return false;
+					}
+
+					if (
+						item.static &&
+						item.value &&
+						!this.isPure(
+							item.value,
+							item.key ? item.key.range[1] : item.range[0]
+						)
+					) {
+						return false;
+					}
+
+					if (item.type === "StaticBlock") {
+						return false;
+					}
+
+					return true;
+				});
 			}
 
 			case "FunctionDeclaration":

--- a/lib/optimize/InnerGraphPlugin.js
+++ b/lib/optimize/InnerGraphPlugin.js
@@ -134,8 +134,9 @@ class InnerGraphPlugin {
 								const fn = InnerGraph.tagTopLevelSymbol(parser, name);
 								const decl = statement.declaration;
 								if (
-									decl.type === "ClassExpression" ||
-									decl.type === "ClassDeclaration"
+									(decl.type === "ClassExpression" ||
+										decl.type === "ClassDeclaration") &&
+									parser.isPure(decl, decl.range[0])
 								) {
 									classWithTopLevelSymbol.set(decl, fn);
 								} else if (parser.isPure(decl, statement.range[0])) {

--- a/lib/optimize/InnerGraphPlugin.js
+++ b/lib/optimize/InnerGraphPlugin.js
@@ -120,7 +120,10 @@ class InnerGraphPlugin {
 						if (!InnerGraph.isEnabled(parser.state)) return;
 
 						if (parser.scope.topLevelScope === true) {
-							if (statement.type === "ClassDeclaration") {
+							if (
+								statement.type === "ClassDeclaration" &&
+								parser.isPure(statement, statement.range[0])
+							) {
 								const name = statement.id ? statement.id.name : "*default*";
 								const fn = InnerGraph.tagTopLevelSymbol(parser, name);
 								classWithTopLevelSymbol.set(statement, fn);
@@ -157,7 +160,10 @@ class InnerGraphPlugin {
 							decl.id.type === "Identifier"
 						) {
 							const name = decl.id.name;
-							if (decl.init.type === "ClassExpression") {
+							if (
+								decl.init.type === "ClassExpression" &&
+								parser.isPure(decl.init, decl.id.range[1])
+							) {
 								const fn = InnerGraph.tagTopLevelSymbol(parser, name);
 								classWithTopLevelSymbol.set(decl.init, fn);
 							} else if (parser.isPure(decl.init, decl.id.range[1])) {

--- a/test/cases/inner-graph/extend-class/a.js
+++ b/test/cases/inner-graph/extend-class/a.js
@@ -1,0 +1,14 @@
+import B from "./b.js";
+import { A1 } from "./dep1";
+
+export default class A extends B {
+	constructor() {
+		super();
+	}
+	test() {
+		super.test();
+
+		this.b = new B();
+		this.a1 = new A1();
+	}
+}

--- a/test/cases/inner-graph/extend-class/b.js
+++ b/test/cases/inner-graph/extend-class/b.js
@@ -1,0 +1,10 @@
+import A from "./a.js";
+import { A1 } from "./dep1";
+
+export default class B {
+	constructor() {}
+	test() {
+		this.a = new A();
+		this.a2 = new A1();
+	}
+}

--- a/test/cases/inner-graph/extend-class/dep2.js
+++ b/test/cases/inner-graph/extend-class/dep2.js
@@ -6,6 +6,8 @@ export class Z {}
 export function mixin1(_class) {return _class}
 export function mixin2(_class) {return _class}
 export function mixin3(_class) {return _class}
+export function mixin4(_class) {return _class}
+export function getField() { return "test" }
 
 export const exportsInfoForA = __webpack_exports_info__.A.used;
 export const exportsInfoForB = __webpack_exports_info__.B.used;
@@ -15,3 +17,5 @@ export const exportsInfoForZ = __webpack_exports_info__.Z.used;
 export const exportsInfoForMixin1 = __webpack_exports_info__.mixin1.used;
 export const exportsInfoForMixin2 = __webpack_exports_info__.mixin2.used;
 export const exportsInfoForMixin3 = __webpack_exports_info__.mixin3.used;
+export const exportsInfoForMixin4 = __webpack_exports_info__.mixin4.used;
+export const exportsInfoForgetField = __webpack_exports_info__.getField.used;

--- a/test/cases/inner-graph/extend-class/dep3.js
+++ b/test/cases/inner-graph/extend-class/dep3.js
@@ -1,4 +1,4 @@
-import {mixin1, mixin2, mixin3, A, B, C, Y} from "./dep2";
+import {mixin1, mixin2, mixin3, getField, A, B, C, Y, mixin4} from "./dep2";
 
 export const A1 = class A1 extends A {
 	render() {return new E();}
@@ -20,6 +20,10 @@ export class Y1 extends /*#__PURE__*/ mixin2(Y) {
 	}
 
 	render() {return new D();}
+}
+
+export class Bar extends /*#__PURE__*/ mixin4(A) {
+	[/*#__PURE__*/ getField()] = 12;
 }
 
 export class E {}

--- a/test/cases/inner-graph/extend-class/dep3.js
+++ b/test/cases/inner-graph/extend-class/dep3.js
@@ -12,7 +12,7 @@ export const C1 = class C1 extends mixin2(Y, /*#__PURE__*/ mixin3(C)) {
 	render() {return new D();}
 };
 
-export class Y1 extends mixin2(Y) {
+export class Y1 extends /*#__PURE__*/ mixin2(Y) {
 	constructor() {
 		super();
 

--- a/test/cases/inner-graph/extend-class/index.js
+++ b/test/cases/inner-graph/extend-class/index.js
@@ -6,7 +6,8 @@ import {
 	exportsInfoForZ,
 	exportsInfoForMixin1,
 	exportsInfoForMixin2,
-	exportsInfoForMixin3
+	exportsInfoForMixin3,
+	exportsInfoForMixin4
 } from "./dep2";
 
 it("should load modules correctly", () => {
@@ -31,6 +32,7 @@ it("Z used, inner graph can not determine const usage", () => {
 it("Pure super expression should be unused, another used", () => {
 	if (process.env.NODE_ENV === "production") {
 		expect(exportsInfoForMixin1).toBe(false);
+		expect(exportsInfoForMixin4).toBe(false);
 	}
 
 	expect(exportsInfoForMixin2).toBe(true);

--- a/test/cases/inner-graph/extend-class/index.js
+++ b/test/cases/inner-graph/extend-class/index.js
@@ -13,6 +13,7 @@ import {
 it("should load modules correctly", () => {
 	require("./module1");
 	require("./module2");
+	require("./module3");
 });
 
 if (process.env.NODE_ENV === "production") {

--- a/test/cases/inner-graph/extend-class/module3.js
+++ b/test/cases/inner-graph/extend-class/module3.js
@@ -1,0 +1,3 @@
+import A from "./a.js";
+let a = new A();
+a.test();

--- a/test/cases/inner-graph/extend-class/test.filter.js
+++ b/test/cases/inner-graph/extend-class/test.filter.js
@@ -1,0 +1,5 @@
+var supportsClassStaticBlock = require("../../../helpers/supportsClassStaticBlock");
+
+module.exports = function (config) {
+	return supportsClassStaticBlock();
+};

--- a/test/cases/inner-graph/extend-class2/dep-decl.js
+++ b/test/cases/inner-graph/extend-class2/dep-decl.js
@@ -58,6 +58,36 @@ class Bar extends Foo {
 	}
 }
 
+class BarA extends Foo {
+	static prop = 42;
+	static a = foo(this).prop;
+}
+
+class BarB extends Foo {
+	static prop = 42;
+	static b = foo(Bar).prop;
+}
+
+class BarC extends Foo {
+	static prop = 42;
+	static c = foo(super.Bar).prop;
+}
+
+class BarPA extends Foo {
+	static prop = 42;
+	static #a = foo(this).prop;
+}
+
+class BarPB extends Foo {
+	static prop = 42;
+	static #b = foo(Bar).prop;
+}
+
+class BarPC extends Foo {
+	static prop = 42;
+	static #c = foo(super.Bar).prop;
+}
+
 const ExpressionFoo = class Bar extends Foo {
 	static prop = 42;
 	static a = foo(this).prop;

--- a/test/cases/inner-graph/extend-class2/dep-decl.js
+++ b/test/cases/inner-graph/extend-class2/dep-decl.js
@@ -1,4 +1,4 @@
-import { A, B, getC, getD, getE, getF } from "./dep2?decl";
+import { A, B, getC, getD, getE, getF, Foo } from "./dep2?decl";
 import { A3, B3, C3, D3, E3, F3 } from "./dep3?decl";
 
 export class A1 extends A {
@@ -36,6 +36,70 @@ export class E1 extends getE() {
 export class F1 extends getF() {
 	render() {
 		return new F2();
+	}
+}
+
+function foo(instance) {
+	return new instance()
+}
+
+class Bar extends Foo {
+	static prop = 42;
+	static a = foo(this).prop;
+	static b = foo(Bar).prop;
+	static c = foo(super.Bar).prop;
+	static inStatic1;
+	static inStatic2;
+	static inStatic3;
+	static {
+		this.inStatic1 = new Bar().prop;
+		this.inStatic2 = new super.Bar().prop;
+		this.inStatic3 = (new this).prop;
+	}
+}
+
+const ExpressionFoo = class Bar extends Foo {
+	static prop = 42;
+	static a = foo(this).prop;
+	static b = foo(Bar).prop;
+	static c = foo(super.Bar).prop;
+	static inStatic1;
+	static inStatic2;
+	static inStatic3;
+	static {
+		this.inStatic1 = new Bar().prop;
+		this.inStatic2 = new super.Bar().prop;
+		this.inStatic3 = (new this).prop;
+	}
+}
+
+export class Baz extends Foo {
+	static prop = 42;
+	static a = foo(this).prop;
+	static b = foo(Bar).prop;
+	static c = foo(super.Bar).prop;
+	static inStatic1;
+	static inStatic2;
+	static inStatic3;
+	static {
+		this.inStatic1 = new Bar().prop;
+		this.inStatic2 = new super.Bar().prop;
+		this.inStatic3 = (new this).prop;
+	}
+}
+
+export default class DefaultBar extends Foo {
+	static prop = 42;
+	static a = foo(this).prop;
+	static b = foo(Bar).prop;
+	static c = foo(super.Bar).prop;
+	static inStatic1;
+	static inStatic2;
+	static inStatic3;
+	static {
+		this.inStatic1 = new Bar().prop;
+		this.inStatic2 = new super.Bar().prop;
+		this.inStatic3 = (new this).prop;
 	}
 }
 

--- a/test/cases/inner-graph/extend-class2/dep2.js
+++ b/test/cases/inner-graph/extend-class2/dep2.js
@@ -4,6 +4,7 @@ export const getC = () => class C {};
 export const getD = () => class D {};
 export const getE = () => class E {};
 export const getF = () => class F {};
+export class Foo { static Bar = Foo; }
 
 export const exportsInfoForA = __webpack_exports_info__.A.used;
 export const exportsInfoForB = __webpack_exports_info__.B.used;
@@ -11,3 +12,4 @@ export const exportsInfoForC = __webpack_exports_info__.getC.used;
 export const exportsInfoForD = __webpack_exports_info__.getD.used;
 export const exportsInfoForE = __webpack_exports_info__.getE.used;
 export const exportsInfoForF = __webpack_exports_info__.getF.used;
+export const exportsInfoForFoo = __webpack_exports_info__.Foo.used;

--- a/test/cases/inner-graph/extend-class2/index.js
+++ b/test/cases/inner-graph/extend-class2/index.js
@@ -4,7 +4,8 @@ import {
 	exportsInfoForC as declC,
 	exportsInfoForD as declD,
 	exportsInfoForE as declE,
-	exportsInfoForF as declF
+	exportsInfoForF as declF,
+	exportsInfoForFoo as declFoo
 } from "./dep2?decl";
 import {
 	exportsInfoForA as exprA,
@@ -12,7 +13,7 @@ import {
 	exportsInfoForC as exprC,
 	exportsInfoForD as exprD,
 	exportsInfoForE as exprE,
-	exportsInfoForF as exprF
+	exportsInfoForF as exprF,
 } from "./dep2?expr";
 
 it("should load module correctly", () => {
@@ -52,5 +53,6 @@ it("E should be used", () => {
 it("F should be used", () => {
 	// Note: it has side-effects and is not affected by usage of the class
 	expect(declF).toBe(true);
+	expect(declFoo).toBe(true);
 	expect(exprF).toBe(true);
 });

--- a/test/cases/inner-graph/extend-class2/test.filter.js
+++ b/test/cases/inner-graph/extend-class2/test.filter.js
@@ -1,0 +1,5 @@
+var supportsClassStaticBlock = require("../../../helpers/supportsClassStaticBlock");
+
+module.exports = function (config) {
+	return supportsClassStaticBlock();
+};

--- a/test/cases/parsing/issue-16763/a.js
+++ b/test/cases/parsing/issue-16763/a.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/test/cases/parsing/issue-16763/class.js
+++ b/test/cases/parsing/issue-16763/class.js
@@ -1,0 +1,37 @@
+import { a as C } from "./a.js";
+
+let staticBlockValue;
+
+let A = class C {
+	static name = "test";
+	static otherName = C.name;
+	otherName = C.name;
+	test() {
+		return { className: C.name,  propertyValue: this.otherName };
+	}
+	static test() {
+		return C.name;
+	}
+	static {
+		staticBlockValue = C.name;
+	}
+};
+
+const b = function C() {
+	return C.name;
+}
+
+const staticProperty = A.otherName;
+const staticMethod = A.test();
+const method = new A().test();
+const reexport = C;
+const functionName = b()
+
+export {
+	staticBlockValue,
+	staticProperty,
+	staticMethod,
+	reexport,
+	method,
+	functionName
+};

--- a/test/cases/parsing/issue-16763/class.js
+++ b/test/cases/parsing/issue-16763/class.js
@@ -4,6 +4,7 @@ let staticBlockValue;
 let staticPrivateBlockValue;
 let valueInStaticBlock;
 let staticPrivateMethod;
+let staticThis;
 
 let A = class C {
 	static name = "test";
@@ -17,6 +18,8 @@ let A = class C {
 	static #staticPrivateName = C.name;
 	static staticB = B;
 	static #staticB = B;
+	static #this = this;
+	static #thisAndC = C.#this;
 
 	#privateMethod() {
 		return { privateName: this.#privateName, B }
@@ -47,6 +50,7 @@ let A = class C {
 		staticPrivateBlockValue = C.#staticPrivateName;
 		valueInStaticBlock = B;
 		staticPrivateMethod = C.#staticPrivateMethod();
+		staticThis = C.#thisAndC;
 	}
 };
 
@@ -73,5 +77,6 @@ export {
 	publicMethod,
 	valueInStaticBlock,
 	staticB,
-	staticPrivateMethod
+	staticPrivateMethod,
+	staticThis
 };

--- a/test/cases/parsing/issue-16763/class.js
+++ b/test/cases/parsing/issue-16763/class.js
@@ -1,21 +1,55 @@
-import { a as C } from "./a.js";
+import { a as C, a as B } from "./a.js";
 
 let staticBlockValue;
+let staticPrivateBlockValue;
+let valueInStaticBlock;
+let staticPrivateMethod;
 
 let A = class C {
 	static name = "test";
-	static otherName = C.name;
+
 	otherName = C.name;
+	#privateName = C.name;
+	propertyB = B;
+	#propertyB = B;
+
+	static otherName = C.name;
+	static #staticPrivateName = C.name;
+	static staticB = B;
+	static #staticB = B;
+
+	#privateMethod() {
+		return { privateName: this.#privateName, B }
+	}
+	publicMethod() {
+		const privateMethod = this.#privateMethod();
+
+		return { B, privateMethod, propertyB: this.propertyB, privatePropertyB: this.#propertyB }
+	}
 	test() {
 		return { className: C.name,  propertyValue: this.otherName };
 	}
 	static test() {
 		return C.name;
 	}
+	static getB() {
+		return B;
+	}
+	static #staticPrivateMethod() {
+		return {
+			staticB: this.staticB,
+			privateStaticB: this.#staticB,
+			B
+		};
+	}
 	static {
 		staticBlockValue = C.name;
+		staticPrivateBlockValue = C.#staticPrivateName;
+		valueInStaticBlock = B;
+		staticPrivateMethod = C.#staticPrivateMethod();
 	}
 };
+
 
 const b = function C() {
 	return C.name;
@@ -23,9 +57,11 @@ const b = function C() {
 
 const staticProperty = A.otherName;
 const staticMethod = A.test();
+const staticB = A.getB();
 const method = new A().test();
+const publicMethod = new A().publicMethod();
 const reexport = C;
-const functionName = b()
+const functionName = b();
 
 export {
 	staticBlockValue,
@@ -33,5 +69,9 @@ export {
 	staticMethod,
 	reexport,
 	method,
-	functionName
+	functionName,
+	publicMethod,
+	valueInStaticBlock,
+	staticB,
+	staticPrivateMethod
 };

--- a/test/cases/parsing/issue-16763/index.js
+++ b/test/cases/parsing/issue-16763/index.js
@@ -1,0 +1,11 @@
+import * as mod from "./class.js";
+
+it('should correctly handle class methods and properties (include static)', () => {
+	expect(mod.staticBlockValue).toBe("test");
+	expect(mod.staticProperty).toBe("test");
+	expect(mod.staticMethod).toBe("test");
+	expect(mod.reexport).toBe(1);
+	expect(mod.method.className).toBe("test");
+	expect(mod.method.propertyValue).toBe("test");
+	expect(mod.functionName).toBe("C");
+});

--- a/test/cases/parsing/issue-16763/index.js
+++ b/test/cases/parsing/issue-16763/index.js
@@ -7,7 +7,7 @@ it('should correctly handle class methods and properties (include static)', () =
 	expect(mod.reexport).toBe(1);
 	expect(mod.method.className).toBe("test");
 	expect(mod.method.propertyValue).toBe("test");
-	expect(mod.functionName).toBe("C");
+	expect(typeof mod.functionName).toBe("string");
 	expect(mod.publicMethod.B).toBe(1);
 	expect(mod.publicMethod.propertyB).toBe(1);
 	expect(mod.publicMethod.privatePropertyB).toBe(1);

--- a/test/cases/parsing/issue-16763/index.js
+++ b/test/cases/parsing/issue-16763/index.js
@@ -8,4 +8,14 @@ it('should correctly handle class methods and properties (include static)', () =
 	expect(mod.method.className).toBe("test");
 	expect(mod.method.propertyValue).toBe("test");
 	expect(mod.functionName).toBe("C");
+	expect(mod.publicMethod.B).toBe(1);
+	expect(mod.publicMethod.propertyB).toBe(1);
+	expect(mod.publicMethod.privatePropertyB).toBe(1);
+	expect(mod.publicMethod.privateMethod.privateName).toBe("test");
+	expect(mod.publicMethod.privateMethod.B).toBe(1);
+	expect(mod.valueInStaticBlock).toBe(1);
+	expect(mod.staticB).toBe(1);
+	expect(mod.staticPrivateMethod.B).toBe(1);
+	expect(mod.staticPrivateMethod.staticB).toBe(1);
+	expect(mod.staticPrivateMethod.privateStaticB).toBe(1);
 });

--- a/test/cases/parsing/issue-16763/index.js
+++ b/test/cases/parsing/issue-16763/index.js
@@ -18,4 +18,5 @@ it('should correctly handle class methods and properties (include static)', () =
 	expect(mod.staticPrivateMethod.B).toBe(1);
 	expect(mod.staticPrivateMethod.staticB).toBe(1);
 	expect(mod.staticPrivateMethod.privateStaticB).toBe(1);
+	expect(mod.staticThis.name).toBe("test");
 });

--- a/test/cases/parsing/issue-16763/test.filter.js
+++ b/test/cases/parsing/issue-16763/test.filter.js
@@ -1,0 +1,5 @@
+var supportsClassStaticBlock = require("../../../helpers/supportsClassStaticBlock");
+
+module.exports = function (config) {
+	return supportsClassStaticBlock();
+};

--- a/test/helpers/supportsClassStaticBlock.js
+++ b/test/helpers/supportsClassStaticBlock.js
@@ -1,0 +1,8 @@
+module.exports = function supportsClassStaticBLock() {
+	try {
+		eval("(function f({x, y}) { class Foo { static {} } })");
+		return true;
+	} catch (e) {
+		return false;
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -5795,6 +5795,7 @@ declare class JavascriptParser extends Parser {
 		...args: AsArray<T>
 	): R;
 	inScope(params: any, fn: () => void): void;
+	inClassScope(hasThis?: any, params?: any, fn?: any): void;
 	inFunctionScope(hasThis?: any, params?: any, fn?: any): void;
 	inBlockScope(fn?: any): void;
 	detectMode(statements?: any): void;


### PR DESCRIPTION
fixes #16763
fixes #16330
fixes #16262
fixes #17239

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a2cef7</samp>

Fix scope bug for recursive class methods by wrapping class body in a function. Add support for static blocks in classes.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0a2cef7</samp>

* Fix scope bug for recursive class methods by wrapping class body loop in a function scope and passing class name as a parameter if it exists ([link](https://github.com/webpack/webpack/pull/17233/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L1564-R1596))
