### PR TITLE
docs: add GitHub discussions badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@
 	<a href="https://github.com/webpack/webpack/graphs/contributors">
 		<img src="https://img.shields.io/github/contributors/webpack/webpack.svg">
 	</a>
-	<a href="https://gitter.im/webpack/webpack">
-		<img src="https://badges.gitter.im/webpack/webpack.svg">
+	<a href="https://github.com/webpack/webpack/discussions">
+		<img src="https://img.shields.io/github/discussions/webpack/webpack">
 	</a>
   <a href="https://twitter.com/Webpack">
 		<img src="https://img.shields.io/twitter/follow/Webpack?style=social">


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a38bc8</samp>

This pull request updates the `README.md` file to point users to GitHub discussions instead of Gitter chat for webpack community support.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4a38bc8</samp>

* Replace Gitter chat badge with GitHub discussions badge in `README.md` ([link](https://github.com/webpack/webpack/pull/17251/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R36))
