### PR TITLE
refactor(types): more

### DIFF
--- a/lib/RecordIdsPlugin.js
+++ b/lib/RecordIdsPlugin.js
@@ -69,7 +69,7 @@ class RecordIdsPlugin {
 			compilation.hooks.recordModules.tap(
 				"RecordIdsPlugin",
 				/**
-				 * @param {Module[]} modules the modules array
+				 * @param {Iterable<Module>} modules the modules array
 				 * @param {Records} records the records object
 				 * @returns {void}
 				 */
@@ -92,7 +92,7 @@ class RecordIdsPlugin {
 			compilation.hooks.reviveModules.tap(
 				"RecordIdsPlugin",
 				/**
-				 * @param {Module[]} modules the modules array
+				 * @param {Iterable<Module>} modules the modules array
 				 * @param {Records} records the records object
 				 * @returns {void}
 				 */
@@ -166,7 +166,7 @@ class RecordIdsPlugin {
 			compilation.hooks.recordChunks.tap(
 				"RecordIdsPlugin",
 				/**
-				 * @param {Chunk[]} chunks the chunks array
+				 * @param {Iterable<Chunk>} chunks the chunks array
 				 * @param {Records} records the records object
 				 * @returns {void}
 				 */
@@ -192,7 +192,7 @@ class RecordIdsPlugin {
 			compilation.hooks.reviveChunks.tap(
 				"RecordIdsPlugin",
 				/**
-				 * @param {Chunk[]} chunks the chunks array
+				 * @param {Iterable<Chunk>} chunks the chunks array
 				 * @param {Records} records the records object
 				 * @returns {void}
 				 */

--- a/lib/RuntimeModule.js
+++ b/lib/RuntimeModule.js
@@ -38,15 +38,15 @@ class RuntimeModule extends Module {
 		this.stage = stage;
 		this.buildMeta = {};
 		this.buildInfo = {};
-		/** @type {Compilation} */
+		/** @type {Compilation | undefined} */
 		this.compilation = undefined;
-		/** @type {Chunk} */
+		/** @type {Chunk | undefined} */
 		this.chunk = undefined;
-		/** @type {ChunkGraph} */
+		/** @type {ChunkGraph | undefined} */
 		this.chunkGraph = undefined;
 		this.fullHash = false;
 		this.dependentHash = false;
-		/** @type {string} */
+		/** @type {string | undefined} */
 		this._cachedGeneratedCode = undefined;
 	}
 
@@ -117,7 +117,7 @@ class RuntimeModule extends Module {
 				hash.update(this.getGeneratedCode());
 			}
 		} catch (err) {
-			hash.update(err.message);
+			hash.update(/** @type {Error} */ (err).message);
 		}
 		super.updateHash(hash, context);
 	}

--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -99,6 +99,10 @@ class RuntimePlugin {
 	apply(compiler) {
 		compiler.hooks.compilation.tap("RuntimePlugin", compilation => {
 			const globalChunkLoading = compilation.outputOptions.chunkLoading;
+			/**
+			 * @param {Chunk} chunk chunk
+			 * @returns {boolean} true, when chunk loading is disabled for the chunk
+			 */
 			const isChunkLoadingDisabledForChunk = chunk => {
 				const options = chunk.getEntryOptions();
 				const chunkLoading =

--- a/lib/javascript/EnableChunkLoadingPlugin.js
+++ b/lib/javascript/EnableChunkLoadingPlugin.js
@@ -11,6 +11,10 @@
 /** @type {WeakMap<Compiler, Set<ChunkLoadingType>>} */
 const enabledTypes = new WeakMap();
 
+/**
+ * @param {Compiler} compiler compiler
+ * @returns {Set<ChunkLoadingType>} enabled types
+ */
 const getEnabledTypes = compiler => {
 	let set = enabledTypes.get(compiler);
 	if (set === undefined) {

--- a/lib/runtime/AutoPublicPathRuntimeModule.js
+++ b/lib/runtime/AutoPublicPathRuntimeModule.js
@@ -31,7 +31,11 @@ class AutoPublicPathRuntimeModule extends RuntimeModule {
 				contentHashType: "javascript"
 			}
 		);
-		const undoPath = getUndoPath(chunkName, path, false);
+		const undoPath = getUndoPath(
+			chunkName,
+			/** @type {string} */ (path),
+			false
+		);
 
 		return Template.asString([
 			"var scriptUrl;",

--- a/lib/runtime/BaseUriRuntimeModule.js
+++ b/lib/runtime/BaseUriRuntimeModule.js
@@ -8,6 +8,8 @@
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 
+/** @typedef {import("../../declarations/WebpackOptions").EntryDescriptionNormalized} EntryDescriptionNormalized */
+
 class BaseUriRuntimeModule extends RuntimeModule {
 	constructor() {
 		super("base uri", RuntimeModule.STAGE_ATTACH);
@@ -19,7 +21,9 @@ class BaseUriRuntimeModule extends RuntimeModule {
 	generate() {
 		const { chunk } = this;
 
-		const options = chunk.getEntryOptions();
+		const options =
+			/** @type {EntryDescriptionNormalized} */
+			(chunk.getEntryOptions());
 		return `${RuntimeGlobals.baseURI} = ${
 			options.baseUri === undefined
 				? "undefined"

--- a/lib/runtime/EnsureChunkRuntimeModule.js
+++ b/lib/runtime/EnsureChunkRuntimeModule.js
@@ -9,6 +9,9 @@ const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
 
 class EnsureChunkRuntimeModule extends RuntimeModule {
+	/**
+	 * @param {ReadonlySet<string>} runtimeRequirements runtime requirements
+	 */
 	constructor(runtimeRequirements) {
 		super("ensure chunk");
 		this.runtimeRequirements = runtimeRequirements;

--- a/lib/runtime/GetChunkFilenameRuntimeModule.js
+++ b/lib/runtime/GetChunkFilenameRuntimeModule.js
@@ -51,7 +51,7 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 		/** @type {Map<string | FilenameFunction, Set<Chunk>>} */
 		const chunkFilenames = new Map();
 		let maxChunks = 0;
-		/** @type {string} */
+		/** @type {string | undefined} */
 		let dynamicFilename;
 
 		/**
@@ -69,9 +69,20 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 				if (typeof chunkFilename === "string") {
 					if (set.size < maxChunks) return;
 					if (set.size === maxChunks) {
-						if (chunkFilename.length < dynamicFilename.length) return;
-						if (chunkFilename.length === dynamicFilename.length) {
-							if (chunkFilename < dynamicFilename) return;
+						if (
+							chunkFilename.length <
+							/** @type {string} */ (dynamicFilename).length
+						) {
+							return;
+						}
+
+						if (
+							chunkFilename.length ===
+							/** @type {string} */ (dynamicFilename).length
+						) {
+							if (chunkFilename < /** @type {string} */ (dynamicFilename)) {
+								return;
+							}
 						}
 					}
 					maxChunks = set.size;
@@ -108,7 +119,7 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 			addChunk(entrypoint.chunks[entrypoint.chunks.length - 1]);
 		}
 
-		/** @type {Map<string, Set<string | number>>} */
+		/** @type {Map<string, Set<string | number | null>>} */
 		const staticUrls = new Map();
 		/** @type {Set<Chunk>} */
 		const dynamicUrlChunks = new Set();
@@ -152,10 +163,14 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 				hashWithLength: length =>
 					`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,
 				chunk: {
-					id: unquotedStringify(c.id),
-					hash: unquotedStringify(c.renderedHash),
-					hashWithLength: unquotedStringifyWithLength(c.renderedHash),
-					name: unquotedStringify(c.name || c.id),
+					id: unquotedStringify(/** @type {number | string} */ (c.id)),
+					hash: unquotedStringify(/** @type {string} */ (c.renderedHash)),
+					hashWithLength: unquotedStringifyWithLength(
+						/** @type {string} */ (c.renderedHash)
+					),
+					name: unquotedStringify(
+						c.name || /** @type {number | string} */ (c.id)
+					),
 					contentHash: {
 						[contentType]: unquotedStringify(c.contentHash[contentType])
 					},
@@ -187,8 +202,10 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 		 * @returns {string} code with static mapping of results of fn
 		 */
 		const createMap = fn => {
+			/** @type {Record<number | string, number | string>} */
 			const obj = {};
 			let useId = false;
+			/** @type {number | string | undefined} */
 			let lastKey;
 			let entries = 0;
 			for (const c of dynamicUrlChunks) {
@@ -196,8 +213,8 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 				if (value === c.id) {
 					useId = true;
 				} else {
-					obj[c.id] = value;
-					lastKey = c.id;
+					obj[/** @type {number | string} */ (c.id)] = value;
+					lastKey = /** @type {number | string} */ (c.id);
 					entries++;
 				}
 			}
@@ -205,9 +222,9 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 			if (entries === 1) {
 				return useId
 					? `(chunkId === ${JSON.stringify(lastKey)} ? ${JSON.stringify(
-							obj[lastKey]
+							obj[/** @type {number | string} */ (lastKey)]
 					  )} : chunkId)`
-					: JSON.stringify(obj[lastKey]);
+					: JSON.stringify(obj[/** @type {number | string} */ (lastKey)]);
 			}
 			return useId
 				? `(${JSON.stringify(obj)}[chunkId] || chunkId)`
@@ -238,9 +255,11 @@ class GetChunkFilenameRuntimeModule extends RuntimeModule {
 					`" + ${RuntimeGlobals.getFullHash}().slice(0, ${length}) + "`,
 				chunk: {
 					id: `" + chunkId + "`,
-					hash: mapExpr(c => c.renderedHash),
-					hashWithLength: mapExprWithLength(c => c.renderedHash),
-					name: mapExpr(c => c.name || c.id),
+					hash: mapExpr(c => /** @type {string} */ (c.renderedHash)),
+					hashWithLength: mapExprWithLength(
+						c => /** @type {string} */ (c.renderedHash)
+					),
+					name: mapExpr(c => c.name || /** @type {number | string} */ (c.id)),
 					contentHash: {
 						[contentType]: mapExpr(c => c.contentHash[contentType])
 					},

--- a/lib/runtime/GetTrustedTypesPolicyRuntimeModule.js
+++ b/lib/runtime/GetTrustedTypesPolicyRuntimeModule.js
@@ -10,7 +10,7 @@ const HelperRuntimeModule = require("./HelperRuntimeModule");
 
 class GetTrustedTypesPolicyRuntimeModule extends HelperRuntimeModule {
 	/**
-	 * @param {Set<string>} runtimeRequirements runtime requirements
+	 * @param {ReadonlySet<string>} runtimeRequirements runtime requirements
 	 */
 	constructor(runtimeRequirements) {
 		super("trusted types policy");

--- a/lib/runtime/LoadScriptRuntimeModule.js
+++ b/lib/runtime/LoadScriptRuntimeModule.js
@@ -72,7 +72,7 @@ class LoadScriptRuntimeModule extends HelperRuntimeModule {
 			"script = document.createElement('script');",
 			scriptType ? `script.type = ${JSON.stringify(scriptType)};` : "",
 			charset ? "script.charset = 'utf-8';" : "",
-			`script.timeout = ${loadTimeout / 1000};`,
+			`script.timeout = ${/** @type {number} */ (loadTimeout) / 1000};`,
 			`if (${RuntimeGlobals.scriptNonce}) {`,
 			Template.indent(
 				`script.setAttribute("nonce", ${RuntimeGlobals.scriptNonce});`

--- a/lib/runtime/PublicPathRuntimeModule.js
+++ b/lib/runtime/PublicPathRuntimeModule.js
@@ -7,7 +7,12 @@
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 
+/** @typedef {import("../../declarations/WebpackOptions").OutputNormalized} OutputOptions */
+
 class PublicPathRuntimeModule extends RuntimeModule {
+	/**
+	 * @param {OutputOptions["publicPath"]} publicPath public path
+	 */
 	constructor(publicPath) {
 		super("publicPath", RuntimeModule.STAGE_BASIC);
 		this.publicPath = publicPath;

--- a/lib/runtime/StartupChunkDependenciesPlugin.js
+++ b/lib/runtime/StartupChunkDependenciesPlugin.js
@@ -8,9 +8,20 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 const StartupChunkDependenciesRuntimeModule = require("./StartupChunkDependenciesRuntimeModule");
 const StartupEntrypointRuntimeModule = require("./StartupEntrypointRuntimeModule");
 
+/** @typedef {import("../../declarations/WebpackOptions").ChunkLoadingType} ChunkLoadingType */
+/** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Compiler")} Compiler */
 
+/**
+ * @typedef {Object} Options
+ * @property {ChunkLoadingType} chunkLoading
+ * @property {boolean=} asyncChunkLoading
+ */
+
 class StartupChunkDependenciesPlugin {
+	/**
+	 * @param {Options} options options
+	 */
 	constructor(options) {
 		this.chunkLoading = options.chunkLoading;
 		this.asyncChunkLoading =
@@ -29,6 +40,10 @@ class StartupChunkDependenciesPlugin {
 			"StartupChunkDependenciesPlugin",
 			compilation => {
 				const globalChunkLoading = compilation.outputOptions.chunkLoading;
+				/**
+				 * @param {Chunk} chunk chunk to check
+				 * @returns {boolean} true, when the plugin is enabled for the chunk
+				 */
 				const isEnabledForChunk = chunk => {
 					const options = chunk.getEntryOptions();
 					const chunkLoading =

--- a/lib/runtime/StartupChunkDependenciesRuntimeModule.js
+++ b/lib/runtime/StartupChunkDependenciesRuntimeModule.js
@@ -10,6 +10,9 @@ const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
 
 class StartupChunkDependenciesRuntimeModule extends RuntimeModule {
+	/**
+	 * @param {boolean} asyncChunkLoading use async chunk loading
+	 */
 	constructor(asyncChunkLoading) {
 		super("startup chunk dependencies", RuntimeModule.STAGE_TRIGGER);
 		this.asyncChunkLoading = asyncChunkLoading;

--- a/lib/runtime/StartupEntrypointRuntimeModule.js
+++ b/lib/runtime/StartupEntrypointRuntimeModule.js
@@ -10,6 +10,9 @@ const RuntimeModule = require("../RuntimeModule");
 /** @typedef {import("../MainTemplate")} MainTemplate */
 
 class StartupEntrypointRuntimeModule extends RuntimeModule {
+	/**
+	 * @param {boolean} asyncChunkLoading use async chunk loading
+	 */
 	constructor(asyncChunkLoading) {
 		super("startup entrypoint");
 		this.asyncChunkLoading = asyncChunkLoading;

--- a/types.d.ts
+++ b/types.d.ts
@@ -10883,9 +10883,9 @@ declare class RuntimeModule extends Module {
 	constructor(name: string, stage?: number);
 	name: string;
 	stage: number;
-	compilation: Compilation;
-	chunk: Chunk;
-	chunkGraph: ChunkGraph;
+	compilation?: Compilation;
+	chunk?: Chunk;
+	chunkGraph?: ChunkGraph;
 	fullHash: boolean;
 	dependentHash: boolean;
 	attach(compilation: Compilation, chunk: Chunk, chunkGraph?: ChunkGraph): void;


### PR DESCRIPTION
Strict types for runtime modules

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8fceed0</samp>

The pull request improves the TypeScript compatibility and type safety of various runtime modules and plugins in the `lib` directory, by adding or modifying type annotations and assertions for parameters, properties, and variables that deal with chunks, modules, filenames, options, and other types. The pull request mainly affects the files `lib/RecordIdsPlugin.js`, `lib/runtime/*.js`, and `lib/RuntimePlugin.js`.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8fceed0</samp>

*  Add or change type annotations and assertions for various parameters and variables to avoid TypeScript errors and reflect the actual types used in the code ([link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-a84c781c3046093cc63e02a9206c90dd88e335f2d80605e898d95fbdf28364ccL72-R72), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-a84c781c3046093cc63e02a9206c90dd88e335f2d80605e898d95fbdf28364ccL95-R95), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-a84c781c3046093cc63e02a9206c90dd88e335f2d80605e898d95fbdf28364ccL169-R169), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-a84c781c3046093cc63e02a9206c90dd88e335f2d80605e898d95fbdf28364ccL195-R195), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-83eda80f5150d99b579941d897913abc69e14ad0d2cfe8df8446403fef912125L41-R49), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-83eda80f5150d99b579941d897913abc69e14ad0d2cfe8df8446403fef912125L120-R120), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606R102-R105), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-2c25bb29a8ce4a5479829a72a8a5c7b8134e4de678a0fbae9387cdd75274592aR14-R17), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-5b68f78763cd59ef3491990ef44d952823d13073cc43b0b3bb9301c693c7c88aL34-R38), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-09627c7635b27048c7c3d98ed53e5f0cee568f0ca2c0d79b0f6246a75ce94f3aR11-R12), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-09627c7635b27048c7c3d98ed53e5f0cee568f0ca2c0d79b0f6246a75ce94f3aL22-R26), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-67c80f6901340ba0f2a77f9ab9190bff6ce58cdd5ca4995cd9485fffc26a7cc9R12-R14), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-a0d29299e49ebfe4ecc49fdfea6dc9164ad753e2fe3a62629ae01a98d3c2988cL54-R54), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-a0d29299e49ebfe4ecc49fdfea6dc9164ad753e2fe3a62629ae01a98d3c2988cL72-R86), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-a0d29299e49ebfe4ecc49fdfea6dc9164ad753e2fe3a62629ae01a98d3c2988cL111-R122), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-a0d29299e49ebfe4ecc49fdfea6dc9164ad753e2fe3a62629ae01a98d3c2988cL155-R173), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-a0d29299e49ebfe4ecc49fdfea6dc9164ad753e2fe3a62629ae01a98d3c2988cL190-R208), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-a0d29299e49ebfe4ecc49fdfea6dc9164ad753e2fe3a62629ae01a98d3c2988cL199-R217), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-a0d29299e49ebfe4ecc49fdfea6dc9164ad753e2fe3a62629ae01a98d3c2988cL208-R227), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-a0d29299e49ebfe4ecc49fdfea6dc9164ad753e2fe3a62629ae01a98d3c2988cL241-R262), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-eab2f2ec28ba995308ad37351b95f00b753b37cc97769432b9ade097b8ad77abL13-R13), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-848f7b6e954a1b22b9b6541b6ae06f778f4fd0b4b95c44ee86c2b1c43f7f0b90L75-R75), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-2e5db5ef0fb5546960c1549da25f2d358d51466cb17ce273b062145c67f1f68cL10-R15), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-1f6c9dd2a670408f845477b54bae6d20edd21b5304a7bfc8313eb904f844e4b3L11-R24), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-1f6c9dd2a670408f845477b54bae6d20edd21b5304a7bfc8313eb904f844e4b3R43-R46), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-68dc122e61a2f4ca1c2e86fb23cb0cefb643d6c1c353631414c1275f5224ec69R13-R15), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-c358782a9bc2c316cdb48d379b2a68b67fcd6c260984c9fdf88e379ad1526c8aR13-R15))
* Import type definitions from other modules using `@typedef` comments in `lib/runtime/BaseUriRuntimeModule.js`, `lib/runtime/PublicPathRuntimeModule.js`, and `lib/runtime/StartupChunkDependenciesPlugin.js` ([link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-09627c7635b27048c7c3d98ed53e5f0cee568f0ca2c0d79b0f6246a75ce94f3aR11-R12), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-2e5db5ef0fb5546960c1549da25f2d358d51466cb17ce273b062145c67f1f68cL10-R15), [link](https://github.com/webpack/webpack/pull/17261/files?diff=unified&w=0#diff-1f6c9dd2a670408f845477b54bae6d20edd21b5304a7bfc8313eb904f844e4b3L11-R24))
