### PR TITLE
fix(types): regression with unknown types

### DIFF
--- a/lib/Module.js
+++ b/lib/Module.js
@@ -130,14 +130,14 @@ const deprecatedNeedRebuild = util.deprecate(
 
 class Module extends DependenciesBlock {
 	/**
-	 * @param {ModuleTypes | ""} type the module type, when deserializing the type is not known and is an empty string
+	 * @param {ModuleTypes} type the module type, when deserializing the type is not known and is an empty string
 	 * @param {string=} context an optional context
 	 * @param {string=} layer an optional layer in which the module is
 	 */
 	constructor(type, context = null, layer = null) {
 		super();
 
-		/** @type {ModuleTypes | ""} */
+		/** @type {ModuleTypes} */
 		this.type = type;
 		/** @type {string | null} */
 		this.context = context;

--- a/lib/ModuleTypeConstants.js
+++ b/lib/ModuleTypeConstants.js
@@ -135,7 +135,8 @@ const WEBPACK_MODULE_TYPE_LAZY_COMPILATION_PROXY = "lazy-compilation-proxy";
 /** @typedef {"css" | "css/global" | "css/module"} CSSModuleTypes */
 /** @typedef {"asset" | "asset/inline" | "asset/resource" | "asset/source" | "asset/raw-data-url"} AssetModuleTypes */
 /** @typedef {"runtime" | "fallback-module" | "remote-module" | "provide-module" | "consume-shared-module" | "lazy-compilation-proxy"} WebpackModuleTypes */
-/** @typedef {JavaScriptModuleTypes | JSONModuleType | WebAssemblyModuleTypes | CSSModuleTypes | AssetModuleTypes | WebpackModuleTypes} ModuleTypes */
+/** @typedef {string} UnknownModuleTypes */
+/** @typedef {JavaScriptModuleTypes | JSONModuleType | WebAssemblyModuleTypes | CSSModuleTypes | AssetModuleTypes | WebpackModuleTypes | UnknownModuleTypes} ModuleTypes */
 
 exports.ASSET_MODULE_TYPE = ASSET_MODULE_TYPE;
 exports.ASSET_MODULE_TYPE_RAW_DATA_URL = ASSET_MODULE_TYPE_RAW_DATA_URL;

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -14,7 +14,8 @@ const {
 	JAVASCRIPT_MODULE_TYPE_ESM,
 	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
 	WEBASSEMBLY_MODULE_TYPE_SYNC,
-	ASSET_MODULE_TYPE
+	ASSET_MODULE_TYPE,
+	CSS_MODULE_TYPE
 } = require("../ModuleTypeConstants");
 const Template = require("../Template");
 const { cleverMerge } = require("../util/cleverMerge");
@@ -703,7 +704,7 @@ const applyModuleDefaults = (
 		}
 		if (css) {
 			const cssRule = {
-				type: "css",
+				type: CSS_MODULE_TYPE,
 				resolve: {
 					fullySpecified: true,
 					preferRelative: true

--- a/types.d.ts
+++ b/types.d.ts
@@ -7191,54 +7191,8 @@ declare interface MinChunkSizePluginOptions {
 	minChunkSize: number;
 }
 declare class Module extends DependenciesBlock {
-	constructor(
-		type:
-			| ""
-			| "runtime"
-			| "javascript/auto"
-			| "javascript/dynamic"
-			| "javascript/esm"
-			| "json"
-			| "webassembly/async"
-			| "webassembly/sync"
-			| "css"
-			| "css/global"
-			| "css/module"
-			| "asset"
-			| "asset/inline"
-			| "asset/resource"
-			| "asset/source"
-			| "asset/raw-data-url"
-			| "fallback-module"
-			| "remote-module"
-			| "provide-module"
-			| "consume-shared-module"
-			| "lazy-compilation-proxy",
-		context?: string,
-		layer?: string
-	);
-	type:
-		| ""
-		| "runtime"
-		| "javascript/auto"
-		| "javascript/dynamic"
-		| "javascript/esm"
-		| "json"
-		| "webassembly/async"
-		| "webassembly/sync"
-		| "css"
-		| "css/global"
-		| "css/module"
-		| "asset"
-		| "asset/inline"
-		| "asset/resource"
-		| "asset/source"
-		| "asset/raw-data-url"
-		| "fallback-module"
-		| "remote-module"
-		| "provide-module"
-		| "consume-shared-module"
-		| "lazy-compilation-proxy";
+	constructor(type: string, context?: string, layer?: string);
+	type: string;
 	context: null | string;
 	layer: null | string;
 	needId: boolean;


### PR DESCRIPTION
@TheLarkInn We have regression here:
- `mini-css-extract-plugin` register own type `css/mini-extract`
- we have API to register own types and generate what you need in custom plugins
- so `type` should be `string`, because developers can use any name

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c55c19</samp>

Refactored the module type system to use constants and a new type `UnknownModuleTypes` for modules with unknown types. This improves consistency, readability, and type safety of the module system.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5c55c19</samp>

*  Refactor module type handling to use constants and avoid empty strings ([link](https://github.com/webpack/webpack/pull/17266/files?diff=unified&w=0#diff-44156fd0f9b801a0114774f05283caff3069ad67f663ad53f886f08472868c7dL133-R133), [link](https://github.com/webpack/webpack/pull/17266/files?diff=unified&w=0#diff-44156fd0f9b801a0114774f05283caff3069ad67f663ad53f886f08472868c7dL140-R140), [link](https://github.com/webpack/webpack/pull/17266/files?diff=unified&w=0#diff-a8ed0714a146f257cf6814153af29d3733a2da0b22804cf7df16130fe6afaa76L138-R139), [link](https://github.com/webpack/webpack/pull/17266/files?diff=unified&w=0#diff-c0078e4713a0e7a24dbc56d6dfda3cf139376325fc65ea70a8389d4d30b27f04L17-R18), [link](https://github.com/webpack/webpack/pull/17266/files?diff=unified&w=0#diff-c0078e4713a0e7a24dbc56d6dfda3cf139376325fc65ea70a8389d4d30b27f04L706-R707))
  - Import `CSS_MODULE_TYPE` constant from `ModuleTypeConstants.js` in `defaults.js` and use it for the default CSS rule type ([link](https://github.com/webpack/webpack/pull/17266/files?diff=unified&w=0#diff-c0078e4713a0e7a24dbc56d6dfda3cf139376325fc65ea70a8389d4d30b27f04L17-R18), [link](https://github.com/webpack/webpack/pull/17266/files?diff=unified&w=0#diff-c0078e4713a0e7a24dbc56d6dfda3cf139376325fc65ea70a8389d4d30b27f04L706-R707))
  - Replace `ModuleTypes | ""` with `ModuleTypes` for the `type` parameter and property of the `Module` class in `Module.js` ([link](https://github.com/webpack/webpack/pull/17266/files?diff=unified&w=0#diff-44156fd0f9b801a0114774f05283caff3069ad67f663ad53f886f08472868c7dL133-R133), [link](https://github.com/webpack/webpack/pull/17266/files?diff=unified&w=0#diff-44156fd0f9b801a0114774f05283caff3069ad67f663ad53f886f08472868c7dL140-R140))
  - Add `UnknownModuleTypes` type to `ModuleTypeConstants.js` and include it in the `ModuleTypes` union type ([link](https://github.com/webpack/webpack/pull/17266/files?diff=unified&w=0#diff-a8ed0714a146f257cf6814153af29d3733a2da0b22804cf7df16130fe6afaa76L138-R139))
