### PR TITLE
refactor: use global runtime constants for webpack exports

### DIFF
--- a/lib/CompatibilityPlugin.js
+++ b/lib/CompatibilityPlugin.js
@@ -113,7 +113,7 @@ class CompatibilityPlugin {
 							return true;
 						});
 					parser.hooks.pattern
-						.for("__webpack_exports__")
+						.for(RuntimeGlobals.exports)
 						.tap(PLUGIN_NAME, pattern => {
 							parser.tagVariable(pattern.name, nestedWebpackIdentifierTag, {
 								name: "__nested_webpack_exports__",

--- a/lib/dependencies/CommonJsPlugin.js
+++ b/lib/dependencies/CommonJsPlugin.js
@@ -197,10 +197,10 @@ class CommonJsPlugin {
 							)
 						);
 					parser.hooks.expression
-						.for("module.loaded")
+						.for(RuntimeGlobals.moduleLoaded)
 						.tap(PLUGIN_NAME, expr => {
 							parser.state.module.buildInfo.moduleConcatenationBailout =
-								"module.loaded";
+								RuntimeGlobals.moduleLoaded;
 							const dep = new RuntimeRequirementsDependency([
 								RuntimeGlobals.moduleLoaded
 							]);

--- a/lib/dependencies/CommonJsPlugin.js
+++ b/lib/dependencies/CommonJsPlugin.js
@@ -209,16 +209,18 @@ class CommonJsPlugin {
 							return true;
 						});
 
-					parser.hooks.expression.for("module.id").tap(PLUGIN_NAME, expr => {
-						parser.state.module.buildInfo.moduleConcatenationBailout =
-							"module.id";
-						const dep = new RuntimeRequirementsDependency([
-							RuntimeGlobals.moduleId
-						]);
-						dep.loc = expr.loc;
-						parser.state.module.addPresentationalDependency(dep);
-						return true;
-					});
+					parser.hooks.expression
+						.for(RuntimeGlobals.moduleId)
+						.tap(PLUGIN_NAME, expr => {
+							parser.state.module.buildInfo.moduleConcatenationBailout =
+								RuntimeGlobals.moduleId;
+							const dep = new RuntimeRequirementsDependency([
+								RuntimeGlobals.moduleId
+							]);
+							dep.loc = expr.loc;
+							parser.state.module.addPresentationalDependency(dep);
+							return true;
+						});
 
 					parser.hooks.evaluateIdentifier.for("module.hot").tap(
 						PLUGIN_NAME,

--- a/lib/dependencies/HarmonyExports.js
+++ b/lib/dependencies/HarmonyExports.js
@@ -5,6 +5,8 @@
 
 "use strict";
 
+const RuntimeGlobals = require("../RuntimeGlobals");
+
 /** @typedef {import("../Parser").ParserState} ParserState */
 
 /** @type {WeakMap<ParserState, boolean>} */
@@ -22,7 +24,7 @@ exports.enable = (parserState, isStrictHarmony) => {
 	if (value !== true) {
 		parserState.module.buildMeta.exportsType = "namespace";
 		parserState.module.buildInfo.strict = true;
-		parserState.module.buildInfo.exportsArgument = "__webpack_exports__";
+		parserState.module.buildInfo.exportsArgument = RuntimeGlobals.exports;
 		if (isStrictHarmony) {
 			parserState.module.buildMeta.strictHarmonyModule = true;
 			parserState.module.buildInfo.moduleArgument = "__webpack_module__";

--- a/lib/esm/ModuleChunkFormatPlugin.js
+++ b/lib/esm/ModuleChunkFormatPlugin.js
@@ -166,7 +166,7 @@ class ModuleChunkFormatPlugin {
 									}
 									startupSource.add(
 										`${
-											final ? "var __webpack_exports__ = " : ""
+											final ? `var ${RuntimeGlobals.exports} = ` : ""
 										}__webpack_exec__(${JSON.stringify(moduleId)});\n`
 									);
 								}

--- a/lib/javascript/ArrayPushCallbackChunkFormatPlugin.js
+++ b/lib/javascript/ArrayPushCallbackChunkFormatPlugin.js
@@ -121,7 +121,7 @@ class ArrayPushCallbackChunkFormatPlugin {
 											.getChunkRuntimeRequirements(chunk)
 											.has(RuntimeGlobals.returnExportsFromRuntime)
 									) {
-										runtime.add("return __webpack_exports__;\n");
+										runtime.add(`return ${RuntimeGlobals.exports};\n`);
 									}
 								}
 								runtime.add("}\n");

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1351,7 +1351,7 @@ class JavascriptModulesPlugin {
 				? Template.asString([
 						"",
 						"// Flag the module as loaded",
-						"module.loaded = true;",
+						`${RuntimeGlobals.moduleLoaded} = true;`,
 						""
 				  ])
 				: "",

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -801,7 +801,7 @@ class JavascriptModulesPlugin {
 			}
 			const lastInlinedModule = last(inlinedModules);
 			const startupSource = new ConcatSource();
-			startupSource.add(`var __webpack_exports__ = {};\n`);
+			startupSource.add(`var ${RuntimeGlobals.exports} = {};\n`);
 			for (const m of inlinedModules) {
 				const renderedModule = this.renderModule(
 					m,
@@ -817,7 +817,7 @@ class JavascriptModulesPlugin {
 					);
 					const exports = runtimeRequirements.has(RuntimeGlobals.exports);
 					const webpackExports =
-						exports && m.exportsArgument === "__webpack_exports__";
+						exports && m.exportsArgument === RuntimeGlobals.exports;
 					let iife = innerStrict
 						? "it need to be in strict mode."
 						: inlinedModules.size > 1
@@ -849,9 +849,9 @@ class JavascriptModulesPlugin {
 					if (exports) {
 						if (m !== lastInlinedModule)
 							startupSource.add(`var ${m.exportsArgument} = {};\n`);
-						else if (m.exportsArgument !== "__webpack_exports__")
+						else if (m.exportsArgument !== RuntimeGlobals.exports)
 							startupSource.add(
-								`var ${m.exportsArgument} = __webpack_exports__;\n`
+								`var ${m.exportsArgument} = ${RuntimeGlobals.exports};\n`
 							);
 					}
 					startupSource.add(renderedModule);
@@ -860,7 +860,7 @@ class JavascriptModulesPlugin {
 			}
 			if (runtimeRequirements.has(RuntimeGlobals.onChunksLoaded)) {
 				startupSource.add(
-					`__webpack_exports__ = ${RuntimeGlobals.onChunksLoaded}(__webpack_exports__);\n`
+					`${RuntimeGlobals.exports} = ${RuntimeGlobals.onChunksLoaded}(${RuntimeGlobals.exports});\n`
 				);
 			}
 			source.add(
@@ -912,7 +912,7 @@ class JavascriptModulesPlugin {
 			hasEntryModules &&
 			runtimeRequirements.has(RuntimeGlobals.returnExportsFromRuntime)
 		) {
-			source.add(`${prefix}return __webpack_exports__;\n`);
+			source.add(`${prefix}return ${RuntimeGlobals.exports};\n`);
 		}
 		if (iife) {
 			source.add("/******/ })()\n");
@@ -1161,7 +1161,7 @@ class JavascriptModulesPlugin {
 					}
 					if (chunks.length > 0) {
 						buf2.push(
-							`${i === 0 ? "var __webpack_exports__ = " : ""}${
+							`${i === 0 ? `var ${RuntimeGlobals.exports} = ` : ""}${
 								RuntimeGlobals.onChunksLoaded
 							}(undefined, ${JSON.stringify(
 								chunks.map(c => c.id)
@@ -1171,22 +1171,22 @@ class JavascriptModulesPlugin {
 						);
 					} else if (useRequire) {
 						buf2.push(
-							`${i === 0 ? "var __webpack_exports__ = " : ""}${
+							`${i === 0 ? `var ${RuntimeGlobals.exports} = ` : ""}${
 								RuntimeGlobals.require
 							}(${moduleIdExpr});`
 						);
 					} else {
-						if (i === 0) buf2.push("var __webpack_exports__ = {};");
+						if (i === 0) buf2.push(`var ${RuntimeGlobals.exports} = {};`);
 						if (requireScopeUsed) {
 							buf2.push(
 								`__webpack_modules__[${moduleIdExpr}](0, ${
-									i === 0 ? "__webpack_exports__" : "{}"
+									i === 0 ? RuntimeGlobals.exports : "{}"
 								}, ${RuntimeGlobals.require});`
 							);
 						} else if (entryRuntimeRequirements.has(RuntimeGlobals.exports)) {
 							buf2.push(
 								`__webpack_modules__[${moduleIdExpr}](0, ${
-									i === 0 ? "__webpack_exports__" : "{}"
+									i === 0 ? RuntimeGlobals.exports : "{}"
 								});`
 							);
 						} else {
@@ -1196,7 +1196,7 @@ class JavascriptModulesPlugin {
 				}
 				if (runtimeRequirements.has(RuntimeGlobals.onChunksLoaded)) {
 					buf2.push(
-						`__webpack_exports__ = ${RuntimeGlobals.onChunksLoaded}(__webpack_exports__);`
+						`${RuntimeGlobals.exports} = ${RuntimeGlobals.onChunksLoaded}(${RuntimeGlobals.exports});`
 					);
 				}
 				if (
@@ -1209,13 +1209,13 @@ class JavascriptModulesPlugin {
 					buf.push(
 						`${RuntimeGlobals.startup} = ${runtimeTemplate.basicFunction("", [
 							...buf2,
-							"return __webpack_exports__;"
+							`return ${RuntimeGlobals.exports};`
 						])};`
 					);
 					buf.push("");
 					startup.push("// run startup");
 					startup.push(
-						`var __webpack_exports__ = ${RuntimeGlobals.startup}();`
+						`var ${RuntimeGlobals.exports} = ${RuntimeGlobals.startup}();`
 					);
 				} else if (runtimeRequirements.has(RuntimeGlobals.startupOnlyBefore)) {
 					buf.push("// the startup function");
@@ -1263,7 +1263,9 @@ class JavascriptModulesPlugin {
 				`${RuntimeGlobals.startup} = ${runtimeTemplate.emptyFunction()};`
 			);
 			startup.push("// run startup");
-			startup.push(`var __webpack_exports__ = ${RuntimeGlobals.startup}();`);
+			startup.push(
+				`var ${RuntimeGlobals.exports} = ${RuntimeGlobals.startup}();`
+			);
 		}
 		return result;
 	}

--- a/lib/javascript/StartupHelpers.js
+++ b/lib/javascript/StartupHelpers.js
@@ -19,7 +19,7 @@ const { getAllChunks } = require("./ChunkHelpers");
 /** @typedef {import("../RuntimeTemplate")} RuntimeTemplate */
 /** @typedef {(string|number)[]} EntryItem */
 
-const EXPORT_PREFIX = "var __webpack_exports__ = ";
+const EXPORT_PREFIX = `var ${RuntimeGlobals.exports} = `;
 
 /**
  * @param {ChunkGraph} chunkGraph chunkGraph

--- a/lib/library/AssignLibraryPlugin.js
+++ b/lib/library/AssignLibraryPlugin.js
@@ -11,6 +11,7 @@ const Template = require("../Template");
 const propertyAccess = require("../util/propertyAccess");
 const { getEntryRuntime } = require("../util/runtime");
 const AbstractLibraryPlugin = require("./AbstractLibraryPlugin");
+const RuntimeGlobals = require("../RuntimeGlobals");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../../declarations/WebpackOptions").LibraryOptions} LibraryOptions */
@@ -296,7 +297,7 @@ class AssignLibraryPlugin extends AbstractLibraryPlugin {
 				if (!exportInfo.provided) continue;
 				const nameAccess = propertyAccess([exportInfo.name]);
 				result.add(
-					`${exportTarget}${nameAccess} = __webpack_exports__${exportAccess}${nameAccess};\n`
+					`${exportTarget}${nameAccess} = ${RuntimeGlobals.exports}${exportAccess}${nameAccess};\n`
 				);
 			}
 			result.add(
@@ -310,10 +311,11 @@ class AssignLibraryPlugin extends AbstractLibraryPlugin {
 					true
 				)};\n`
 			);
-			let exports = "__webpack_exports__";
+			/** @type {String} */
+			let exports = RuntimeGlobals.exports;
 			if (exportAccess) {
 				result.add(
-					`var __webpack_exports_export__ = __webpack_exports__${exportAccess};\n`
+					`var __webpack_exports_export__ = ${RuntimeGlobals.exports}${exportAccess};\n`
 				);
 				exports = "__webpack_exports_export__";
 			}
@@ -329,7 +331,7 @@ class AssignLibraryPlugin extends AbstractLibraryPlugin {
 					fullNameResolved,
 					this._getPrefix(compilation).length,
 					false
-				)} = __webpack_exports__${exportAccess};\n`
+				)} = ${RuntimeGlobals.exports}${exportAccess};\n`
 			);
 		}
 		return result;

--- a/lib/library/AssignLibraryPlugin.js
+++ b/lib/library/AssignLibraryPlugin.js
@@ -7,11 +7,11 @@
 
 const { ConcatSource } = require("webpack-sources");
 const { UsageState } = require("../ExportsInfo");
+const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
 const propertyAccess = require("../util/propertyAccess");
 const { getEntryRuntime } = require("../util/runtime");
 const AbstractLibraryPlugin = require("./AbstractLibraryPlugin");
-const RuntimeGlobals = require("../RuntimeGlobals");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../../declarations/WebpackOptions").LibraryOptions} LibraryOptions */

--- a/lib/library/ExportPropertyLibraryPlugin.js
+++ b/lib/library/ExportPropertyLibraryPlugin.js
@@ -10,6 +10,7 @@ const { UsageState } = require("../ExportsInfo");
 const propertyAccess = require("../util/propertyAccess");
 const { getEntryRuntime } = require("../util/runtime");
 const AbstractLibraryPlugin = require("./AbstractLibraryPlugin");
+const RuntimeGlobals = require("../RuntimeGlobals");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../../declarations/WebpackOptions").LibraryOptions} LibraryOptions */
@@ -103,7 +104,9 @@ class ExportPropertyLibraryPlugin extends AbstractLibraryPlugin {
 	 */
 	renderStartup(source, module, renderContext, { options }) {
 		if (!options.export) return source;
-		const postfix = `__webpack_exports__ = __webpack_exports__${propertyAccess(
+		const postfix = `${RuntimeGlobals.exports} = ${
+			RuntimeGlobals.exports
+		}${propertyAccess(
 			Array.isArray(options.export) ? options.export : [options.export]
 		)};\n`;
 		return new ConcatSource(source, postfix);

--- a/lib/library/ExportPropertyLibraryPlugin.js
+++ b/lib/library/ExportPropertyLibraryPlugin.js
@@ -7,10 +7,10 @@
 
 const { ConcatSource } = require("webpack-sources");
 const { UsageState } = require("../ExportsInfo");
+const RuntimeGlobals = require("../RuntimeGlobals");
 const propertyAccess = require("../util/propertyAccess");
 const { getEntryRuntime } = require("../util/runtime");
 const AbstractLibraryPlugin = require("./AbstractLibraryPlugin");
-const RuntimeGlobals = require("../RuntimeGlobals");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../../declarations/WebpackOptions").LibraryOptions} LibraryOptions */

--- a/lib/library/ModuleLibraryPlugin.js
+++ b/lib/library/ModuleLibraryPlugin.js
@@ -6,10 +6,10 @@
 "use strict";
 
 const { ConcatSource } = require("webpack-sources");
+const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
 const propertyAccess = require("../util/propertyAccess");
 const AbstractLibraryPlugin = require("./AbstractLibraryPlugin");
-const RuntimeGlobals = require("../RuntimeGlobals");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../../declarations/WebpackOptions").LibraryOptions} LibraryOptions */

--- a/lib/library/ModuleLibraryPlugin.js
+++ b/lib/library/ModuleLibraryPlugin.js
@@ -9,6 +9,7 @@ const { ConcatSource } = require("webpack-sources");
 const Template = require("../Template");
 const propertyAccess = require("../util/propertyAccess");
 const AbstractLibraryPlugin = require("./AbstractLibraryPlugin");
+const RuntimeGlobals = require("../RuntimeGlobals");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../../declarations/WebpackOptions").LibraryOptions} LibraryOptions */
@@ -80,15 +81,17 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 		const exports = [];
 		const isAsync = moduleGraph.isAsync(module);
 		if (isAsync) {
-			result.add(`__webpack_exports__ = await __webpack_exports__;\n`);
+			result.add(
+				`${RuntimeGlobals.exports} = await ${RuntimeGlobals.exports};\n`
+			);
 		}
 		for (const exportInfo of exportsInfo.orderedExports) {
 			if (!exportInfo.provided) continue;
-			const varName = `__webpack_exports__${Template.toIdentifier(
+			const varName = `${RuntimeGlobals.exports}${Template.toIdentifier(
 				exportInfo.name
 			)}`;
 			result.add(
-				`var ${varName} = __webpack_exports__${propertyAccess([
+				`var ${varName} = ${RuntimeGlobals.exports}${propertyAccess([
 					/** @type {string} */
 					(exportInfo.getUsedName(exportInfo.name, chunk.runtime))
 				])};\n`

--- a/lib/runtime/AsyncModuleRuntimeModule.js
+++ b/lib/runtime/AsyncModuleRuntimeModule.js
@@ -21,7 +21,7 @@ class AsyncModuleRuntimeModule extends HelperRuntimeModule {
 		const fn = RuntimeGlobals.asyncModule;
 		return Template.asString([
 			'var webpackQueues = typeof Symbol === "function" ? Symbol("webpack queues") : "__webpack_queues__";',
-			'var webpackExports = typeof Symbol === "function" ? Symbol("webpack exports") : "__webpack_exports__";',
+			`var webpackExports = typeof Symbol === "function" ? Symbol("webpack exports") : "${RuntimeGlobals.exports}";`,
 			'var webpackError = typeof Symbol === "function" ? Symbol("webpack error") : "__webpack_error__";',
 			`var resolveQueue = ${runtimeTemplate.basicFunction("queue", [
 				"if(queue && !queue.d) {",


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

part of https://github.com/webpack/webpack/issues/16897

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8bf6d59</samp>

This pull request refactors the codebase to use the `RuntimeGlobals` module for accessing common runtime constants, such as `RuntimeGlobals.exports`, instead of hardcoded strings. This improves the readability, consistency, and maintainability of the code. It also uses template literals instead of string concatenation for generating source code in various modules. The changes affect several files in the `lib` directory, mostly related to the module system and the library output.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8bf6d59</samp>

*  Replace hardcoded strings with constants from `RuntimeGlobals` module for readability and maintainability ([link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-4503ec469779b28b7570b16bff111949383eeb0226b7ce34b43f2cf33e538ffaL116-R116), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-46cdc2408ceac339f6b00fee887c067946010d6451160b038b35dfbc2126e78bL200-R203), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-46cdc2408ceac339f6b00fee887c067946010d6451160b038b35dfbc2126e78bL212-R223), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-f6c9cabfcda50adb1b5a8f35f298676038ae4d742c356f8fd82c619382aeafb5L25-R27), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-c5d4f993897e06b2577f256473c37db962d87ba30de1d3d2c631d6eb68d7c95cL169-R169), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-30ab5813509bfcbb82b3f51a1d6901b198ca3e82c0e19d23f5c25b4117f00decL124-R124), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-820a04017e95cec05fd58ca44cd7f6c9cfa5b698a144471d5a0f523932486c56L804-R804), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-820a04017e95cec05fd58ca44cd7f6c9cfa5b698a144471d5a0f523932486c56L820-R820), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-820a04017e95cec05fd58ca44cd7f6c9cfa5b698a144471d5a0f523932486c56L852-R854), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-820a04017e95cec05fd58ca44cd7f6c9cfa5b698a144471d5a0f523932486c56L863-R863), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-820a04017e95cec05fd58ca44cd7f6c9cfa5b698a144471d5a0f523932486c56L915-R915), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-820a04017e95cec05fd58ca44cd7f6c9cfa5b698a144471d5a0f523932486c56L1164-R1164), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-820a04017e95cec05fd58ca44cd7f6c9cfa5b698a144471d5a0f523932486c56L1174-R1183), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-820a04017e95cec05fd58ca44cd7f6c9cfa5b698a144471d5a0f523932486c56L1189-R1189), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-820a04017e95cec05fd58ca44cd7f6c9cfa5b698a144471d5a0f523932486c56L1199-R1199), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-820a04017e95cec05fd58ca44cd7f6c9cfa5b698a144471d5a0f523932486c56L1212-R1212), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-820a04017e95cec05fd58ca44cd7f6c9cfa5b698a144471d5a0f523932486c56L1218-R1218), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-820a04017e95cec05fd58ca44cd7f6c9cfa5b698a144471d5a0f523932486c56L1266-R1268), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-c74e578899a9886d00d18e6054bb9f7da1d1b7fe262bcd75bafba7658d4e70b5L22-R22), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-92b29e2c348d249df619ba539fbeb4780144acac0210b24c38235af8b660172eL313-R318), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-cadd081f0e31821bde38f690014d37a75ef5fc3e91e871eddd05b7b07ea44fe9L24-R24))
*  Use template literals instead of string concatenation for generating source code in various modules ([link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-c5d4f993897e06b2577f256473c37db962d87ba30de1d3d2c631d6eb68d7c95cL169-R169), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-30ab5813509bfcbb82b3f51a1d6901b198ca3e82c0e19d23f5c25b4117f00decL124-R124), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-820a04017e95cec05fd58ca44cd7f6c9cfa5b698a144471d5a0f523932486c56L804-R804), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-92b29e2c348d249df619ba539fbeb4780144acac0210b24c38235af8b660172eL299-R300), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-92b29e2c348d249df619ba539fbeb4780144acac0210b24c38235af8b660172eL332-R334), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-917d85215f2609a0314b369552ce2791c69017d6c41383d4006544d5ea37f041L106-R109), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-642ce1778565851de2cada98b086a959fe839c46dfdf7107a71dc34f98732d9bL83-R94))
*  Add require statements to import `RuntimeGlobals` module in modules that use its constants ([link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-f6c9cabfcda50adb1b5a8f35f298676038ae4d742c356f8fd82c619382aeafb5R8-R9), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-92b29e2c348d249df619ba539fbeb4780144acac0210b24c38235af8b660172eR14), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-917d85215f2609a0314b369552ce2791c69017d6c41383d4006544d5ea37f041R13), [link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-642ce1778565851de2cada98b086a959fe839c46dfdf7107a71dc34f98732d9bR12))
*  Replace hardcoded string with constant from `RuntimeGlobals` module for comparing and assigning `module.loaded` property ([link](https://github.com/webpack/webpack/pull/17270/files?diff=unified&w=0#diff-820a04017e95cec05fd58ca44cd7f6c9cfa5b698a144471d5a0f523932486c56L1352-R1354))
