### PR TITLE
feat: improve serialization for errors and bigints

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -109,6 +109,9 @@ module.exports = {
 			env: {
 				"jest/globals": true
 			},
+			parserOptions: {
+				ecmaVersion: 2020
+			},
 			globals: {
 				nsObj: false,
 				jasmine: false

--- a/lib/serialization/BinaryMiddleware.js
+++ b/lib/serialization/BinaryMiddleware.js
@@ -84,6 +84,7 @@ const I8_HEADER = 0x60;
 const I32_HEADER = 0x40;
 const F64_HEADER = 0x20;
 const SHORT_STRING_HEADER = 0x80;
+const BIGINT_HEADER = 0x32;
 
 /** Uplift high-order bits */
 const NUMBERS_HEADER_MASK = 0xe0;
@@ -329,6 +330,16 @@ class BinaryMiddleware extends SerializerMiddleware {
 							currentBuffer[currentPosition++] = thing.charCodeAt(i);
 						}
 					}
+					break;
+				}
+				case "bigint": {
+					const value = thing.toString();
+					const len = Buffer.byteLength(value);
+					allocate(len + HEADER_SIZE + I32_SIZE);
+					writeU8(BIGINT_HEADER);
+					writeU32(len);
+					currentBuffer.write(value, currentPosition);
+					currentPosition += len;
 					break;
 				}
 				case "number": {
@@ -847,6 +858,25 @@ class BinaryMiddleware extends SerializerMiddleware {
 							result.push(read(1).readInt8(0));
 						}
 					};
+				case BIGINT_HEADER: {
+					return () => {
+						const len = readU32();
+						if (isInCurrentBuffer(len) && currentPosition + len < 0x7fffffff) {
+							const value = currentBuffer.toString(
+								undefined,
+								currentPosition,
+								currentPosition + len
+							);
+
+							result.push(BigInt(value));
+							currentPosition += len;
+							checkOverflow();
+						} else {
+							const value = read(len).toString();
+							result.push(BigInt(value));
+						}
+					};
+				}
 				default:
 					if (header <= 10) {
 						return () => result.push(header);

--- a/lib/serialization/BinaryMiddleware.js
+++ b/lib/serialization/BinaryMiddleware.js
@@ -21,6 +21,9 @@ Section -> NullsSection |
 					 I32NumbersSection |
 					 I8NumbersSection |
 					 ShortStringSection |
+					 BigIntSection |
+					 I32BigIntSection |
+					 I8BigIntSection
 					 StringSection |
 					 BufferSection |
 					 NopSection
@@ -39,6 +42,9 @@ ShortStringSection -> ShortStringSectionHeaderByte ascii-byte*
 StringSection -> StringSectionHeaderByte i32:length utf8-byte*
 BufferSection -> BufferSectionHeaderByte i32:length byte*
 NopSection --> NopSectionHeaderByte
+BigIntSection -> BigIntSectionHeaderByte i32:length ascii-byte*
+I32BigIntSection -> I32BigIntSectionHeaderByte i32
+I8BigIntSection -> I8BigIntSectionHeaderByte i8
 
 ShortStringSectionHeaderByte -> 0b1nnn_nnnn (n:length)
 
@@ -58,6 +64,9 @@ BooleansCountAndBitsByte ->
 StringSectionHeaderByte -> 0b0000_1110
 BufferSectionHeaderByte -> 0b0000_1111
 NopSectionHeaderByte -> 0b0000_1011
+BigIntSectionHeaderByte -> 0b0001_1010
+I32BigIntSectionHeaderByte -> 0b0001_1100
+I8BigIntSectionHeaderByte -> 0b0001_1011
 FalseHeaderByte -> 0b0000_1100
 TrueHeaderByte -> 0b0000_1101
 

--- a/lib/serialization/BinaryMiddleware.js
+++ b/lib/serialization/BinaryMiddleware.js
@@ -78,17 +78,18 @@ const NULL_AND_I8_HEADER = 0x15;
 const NULL_AND_I32_HEADER = 0x16;
 const NULL_AND_TRUE_HEADER = 0x17;
 const NULL_AND_FALSE_HEADER = 0x18;
+const BIGINT_HEADER = 0x1a;
+const BIGINT_I8_HEADER = 0x1b;
+const BIGINT_I32_HEADER = 0x1c;
 const STRING_HEADER = 0x1e;
 const BUFFER_HEADER = 0x1f;
 const I8_HEADER = 0x60;
 const I32_HEADER = 0x40;
 const F64_HEADER = 0x20;
 const SHORT_STRING_HEADER = 0x80;
-const BIGINT_HEADER = 0x50;
-const SHORT_BIGINT_HEADER = 0x70;
 
 /** Uplift high-order bits */
-const NUMBERS_HEADER_MASK = 0xe0; // 0b1110_0000
+const NUMBERS_HEADER_MASK = 0xe0; // 0b1010_0000
 const NUMBERS_COUNT_MASK = 0x1f; // 0b0001_1111
 const SHORT_STRING_LENGTH_MASK = 0x7f; // 0b0111_1111
 
@@ -120,9 +121,8 @@ const identifyNumber = n => {
  * @returns {0 | 1 | 2} type of bigint for serialization
  */
 const identifyBigInt = n => {
-	if (n <= 127 && n >= -128) return 0;
-	if (n <= 2147483647 && n >= -2147483648) return 1;
-
+	if (n <= BigInt(127) && n >= BigInt(-128)) return 0;
+	if (n <= BigInt(2147483647) && n >= BigInt(-2147483648)) return 1;
 	return 2;
 };
 
@@ -349,18 +349,55 @@ class BinaryMiddleware extends SerializerMiddleware {
 					if (type === 0 && thing >= 0 && thing <= BigInt(10)) {
 						// shortcut for very small bigints
 						allocate(HEADER_SIZE + I8_SIZE);
-						writeU8(SHORT_BIGINT_HEADER);
+						writeU8(BIGINT_I8_HEADER);
 						writeU8(Number(thing));
 						break;
 					}
 
-					const value = thing.toString();
-					const len = Buffer.byteLength(value);
-					allocate(len + HEADER_SIZE + I32_SIZE);
-					writeU8(BIGINT_HEADER);
-					writeU32(len);
-					currentBuffer.write(value, currentPosition);
-					currentPosition += len;
+					switch (type) {
+						case 0: {
+							let n = 1;
+							allocate(HEADER_SIZE + I8_SIZE * n);
+							writeU8(BIGINT_I8_HEADER | (n - 1));
+							while (n > 0) {
+								currentBuffer.writeInt8(
+									Number(/** @type {bigint} */ (data[i])),
+									currentPosition
+								);
+								currentPosition += I8_SIZE;
+								n--;
+								i++;
+							}
+							i--;
+							break;
+						}
+						case 1: {
+							let n = 1;
+							allocate(HEADER_SIZE + I32_SIZE * n);
+							writeU8(BIGINT_I32_HEADER | (n - 1));
+							while (n > 0) {
+								currentBuffer.writeInt32LE(
+									Number(/** @type {bigint} */ (data[i])),
+									currentPosition
+								);
+								currentPosition += I32_SIZE;
+								n--;
+								i++;
+							}
+							i--;
+							break;
+						}
+						default: {
+							const value = thing.toString();
+							const len = Buffer.byteLength(value);
+							allocate(len + HEADER_SIZE + I32_SIZE);
+							writeU8(BIGINT_HEADER);
+							writeU32(len);
+							currentBuffer.write(value, currentPosition);
+							currentPosition += len;
+							break;
+						}
+					}
 					break;
 				}
 				case "number": {
@@ -879,7 +916,7 @@ class BinaryMiddleware extends SerializerMiddleware {
 							result.push(read(1).readInt8(0));
 						}
 					};
-				case SHORT_BIGINT_HEADER: {
+				case BIGINT_I8_HEADER: {
 					const len = 1;
 					return () => {
 						const need = I8_SIZE * len;
@@ -897,6 +934,28 @@ class BinaryMiddleware extends SerializerMiddleware {
 							const buf = read(need);
 							for (let i = 0; i < len; i++) {
 								const value = buf.readInt8(i * I8_SIZE);
+								result.push(BigInt(value));
+							}
+						}
+					};
+				}
+				case BIGINT_I32_HEADER: {
+					const len = 1;
+					return () => {
+						const need = I32_SIZE * len;
+						if (isInCurrentBuffer(need)) {
+							for (let i = 0; i < len; i++) {
+								const value = /** @type {Buffer} */ (currentBuffer).readInt32LE(
+									currentPosition
+								);
+								result.push(BigInt(value));
+								currentPosition += I32_SIZE;
+							}
+							checkOverflow();
+						} else {
+							const buf = read(need);
+							for (let i = 0; i < len; i++) {
+								const value = buf.readInt32LE(i * I32_SIZE);
 								result.push(BigInt(value));
 							}
 						}

--- a/lib/serialization/BinaryMiddleware.js
+++ b/lib/serialization/BinaryMiddleware.js
@@ -84,10 +84,11 @@ const I8_HEADER = 0x60;
 const I32_HEADER = 0x40;
 const F64_HEADER = 0x20;
 const SHORT_STRING_HEADER = 0x80;
-const BIGINT_HEADER = 0x32;
+const BIGINT_HEADER = 0x50;
+const SHORT_BIGINT_HEADER = 0x70;
 
 /** Uplift high-order bits */
-const NUMBERS_HEADER_MASK = 0xe0;
+const NUMBERS_HEADER_MASK = 0xe0; // 0b1110_0000
 const NUMBERS_COUNT_MASK = 0x1f; // 0b0001_1111
 const SHORT_STRING_LENGTH_MASK = 0x7f; // 0b0111_1111
 
@@ -111,6 +112,17 @@ const identifyNumber = n => {
 		if (n <= 127 && n >= -128) return 0;
 		if (n <= 2147483647 && n >= -2147483648) return 1;
 	}
+	return 2;
+};
+
+/**
+ * @param {bigint} n bigint
+ * @returns {0 | 1 | 2} type of bigint for serialization
+ */
+const identifyBigInt = n => {
+	if (n <= 127 && n >= -128) return 0;
+	if (n <= 2147483647 && n >= -2147483648) return 1;
+
 	return 2;
 };
 
@@ -333,6 +345,15 @@ class BinaryMiddleware extends SerializerMiddleware {
 					break;
 				}
 				case "bigint": {
+					const type = identifyBigInt(thing);
+					if (type === 0 && thing >= 0 && thing <= BigInt(10)) {
+						// shortcut for very small bigints
+						allocate(HEADER_SIZE + I8_SIZE);
+						writeU8(SHORT_BIGINT_HEADER);
+						writeU8(Number(thing));
+						break;
+					}
+
 					const value = thing.toString();
 					const len = Buffer.byteLength(value);
 					allocate(len + HEADER_SIZE + I32_SIZE);
@@ -858,6 +879,29 @@ class BinaryMiddleware extends SerializerMiddleware {
 							result.push(read(1).readInt8(0));
 						}
 					};
+				case SHORT_BIGINT_HEADER: {
+					const len = 1;
+					return () => {
+						const need = I8_SIZE * len;
+
+						if (isInCurrentBuffer(need)) {
+							for (let i = 0; i < len; i++) {
+								const value =
+									/** @type {Buffer} */
+									(currentBuffer).readInt8(currentPosition);
+								result.push(BigInt(value));
+								currentPosition += I8_SIZE;
+							}
+							checkOverflow();
+						} else {
+							const buf = read(need);
+							for (let i = 0; i < len; i++) {
+								const value = buf.readInt8(i * I8_SIZE);
+								result.push(BigInt(value));
+							}
+						}
+					};
+				}
 				case BIGINT_HEADER: {
 					return () => {
 						const len = readU32();

--- a/lib/serialization/ErrorObjectSerializer.js
+++ b/lib/serialization/ErrorObjectSerializer.js
@@ -21,6 +21,7 @@ class ErrorObjectSerializer {
 	serialize(obj, context) {
 		context.write(obj.message);
 		context.write(obj.stack);
+		context.write(/** @type {Error & { cause: "unknown" }} */ (obj).cause);
 	}
 	/**
 	 * @param {ObjectDeserializerContext} context context
@@ -31,6 +32,8 @@ class ErrorObjectSerializer {
 
 		err.message = context.read();
 		err.stack = context.read();
+		/** @type {Error & { cause: "unknown" }} */
+		(err).cause = context.read();
 
 		return err;
 	}

--- a/lib/serialization/ObjectMiddleware.js
+++ b/lib/serialization/ObjectMiddleware.js
@@ -689,8 +689,6 @@ class ObjectMiddleware extends SerializerMiddleware {
 						const end1 = read();
 
 						if (end1 !== ESCAPE) {
-							console.log("END" + end1);
-
 							throw new Error("Expected end of object");
 						}
 

--- a/lib/serialization/ObjectMiddleware.js
+++ b/lib/serialization/ObjectMiddleware.js
@@ -397,6 +397,9 @@ class ObjectMiddleware extends SerializerMiddleware {
 							", "
 						)} }`;
 					}
+					if (typeof item === "bigint") {
+						return `BigInt ${item}n`;
+					}
 					try {
 						return `${item}`;
 					} catch (e) {
@@ -686,6 +689,8 @@ class ObjectMiddleware extends SerializerMiddleware {
 						const end1 = read();
 
 						if (end1 !== ESCAPE) {
+							console.log("END" + end1);
+
 							throw new Error("Expected end of object");
 						}
 

--- a/lib/serialization/types.js
+++ b/lib/serialization/types.js
@@ -6,7 +6,7 @@
 
 /** @typedef {undefined|null|number|string|boolean|Buffer|Object|(() => ComplexSerializableType[] | Promise<ComplexSerializableType[]>)} ComplexSerializableType */
 
-/** @typedef {undefined|null|number|string|boolean|Buffer|(() => PrimitiveSerializableType[] | Promise<PrimitiveSerializableType[]>)} PrimitiveSerializableType */
+/** @typedef {undefined|null|number|bigint|string|boolean|Buffer|(() => PrimitiveSerializableType[] | Promise<PrimitiveSerializableType[]>)} PrimitiveSerializableType */
 
 /** @typedef {Buffer|(() => BufferSerializableType[] | Promise<BufferSerializableType[]>)} BufferSerializableType */
 

--- a/test/Compiler-filesystem-caching.test.js
+++ b/test/Compiler-filesystem-caching.test.js
@@ -41,6 +41,8 @@ describe("Compiler (filesystem caching)", () => {
 			]
 		};
 
+		const isBigIntSupported = typeof BigInt !== "undefined";
+
 		options.plugins = [
 			{
 				apply(compiler) {
@@ -63,22 +65,50 @@ describe("Compiler (filesystem caching)", () => {
 
 								if (result) {
 									expect(result.number).toEqual(42);
+									expect(result.number1).toEqual(3.14);
+									expect(result.number2).toEqual(6.2);
 									expect(result.string).toEqual("string");
 									expect(result.error.cause.message).toEqual("cause");
 									expect(result.error1.cause.string).toBe("string");
 									expect(result.error1.cause.number).toBe(42);
 
+									if (isBigIntSupported) {
+										expect(result.bigint).toEqual(BigInt(123));
+										expect(result.bigint1).toEqual(
+											99999999999999999999999999999999999999999999999999991n
+										);
+										expect(result.obj.foo).toBe(BigInt(-10));
+										expect(Array.from(result.set)).toEqual([
+											BigInt(1),
+											BigInt(2)
+										]);
+									}
+
 									return;
 								}
 
-								const number = 42;
-								const string = "string";
-								const error = new Error("error", { cause: new Error("cause") });
-								const error1 = new Error("error", {
-									cause: { string, number }
-								});
+								const storeValue = {};
 
-								await cacheItem.storePromise({ number, string, error, error1 });
+								storeValue.number = 42;
+								storeValue.string = "string";
+								storeValue.error = new Error("error", {
+									cause: new Error("cause")
+								});
+								storeValue.error1 = new Error("error", {
+									cause: { string: "string", number: 42 }
+								});
+								storeValue.number1 = 3.14;
+								storeValue.number2 = 6.2;
+
+								if (isBigIntSupported) {
+									storeValue.bigint = BigInt(123);
+									storeValue.bigint1 =
+										99999999999999999999999999999999999999999999999999991n;
+									storeValue.obj = { foo: BigInt(-10) };
+									storeValue.set = new Set([BigInt(1), BigInt(2)]);
+								}
+
+								await cacheItem.storePromise(storeValue);
 							}
 						);
 					});

--- a/test/Compiler-filesystem-caching.test.js
+++ b/test/Compiler-filesystem-caching.test.js
@@ -42,6 +42,9 @@ describe("Compiler (filesystem caching)", () => {
 		};
 
 		const isBigIntSupported = typeof BigInt !== "undefined";
+		const isErrorCaseSupported =
+			typeof new Error("test", { cause: new Error("cause") }).cause !==
+			"undefined";
 
 		options.plugins = [
 			{
@@ -68,15 +71,18 @@ describe("Compiler (filesystem caching)", () => {
 									expect(result.number1).toEqual(3.14);
 									expect(result.number2).toEqual(6.2);
 									expect(result.string).toEqual("string");
-									expect(result.error.cause.message).toEqual("cause");
-									expect(result.error1.cause.string).toBe("string");
-									expect(result.error1.cause.number).toBe(42);
+
+									if (isErrorCaseSupported) {
+										expect(result.error.cause.message).toEqual("cause");
+										expect(result.error1.cause.string).toBe("string");
+										expect(result.error1.cause.number).toBe(42);
+									}
 
 									if (isBigIntSupported) {
 										expect(result.bigint).toEqual(BigInt(123));
-										expect(result.bigint1).toEqual(
-											99999999999999999999999999999999999999999999999999991n
-										);
+										expect(result.bigint1).toEqual(12345678901234567890n);
+										expect(result.bigint2).toEqual(5n);
+										expect(result.bigint3).toEqual(1000000n);
 										expect(result.obj.foo).toBe(BigInt(-10));
 										expect(Array.from(result.set)).toEqual([
 											BigInt(1),
@@ -90,20 +96,24 @@ describe("Compiler (filesystem caching)", () => {
 								const storeValue = {};
 
 								storeValue.number = 42;
-								storeValue.string = "string";
-								storeValue.error = new Error("error", {
-									cause: new Error("cause")
-								});
-								storeValue.error1 = new Error("error", {
-									cause: { string: "string", number: 42 }
-								});
 								storeValue.number1 = 3.14;
 								storeValue.number2 = 6.2;
+								storeValue.string = "string";
+
+								if (isErrorCaseSupported) {
+									storeValue.error = new Error("error", {
+										cause: new Error("cause")
+									});
+									storeValue.error1 = new Error("error", {
+										cause: { string: "string", number: 42 }
+									});
+								}
 
 								if (isBigIntSupported) {
 									storeValue.bigint = BigInt(123);
-									storeValue.bigint1 =
-										99999999999999999999999999999999999999999999999999991n;
+									storeValue.bigint1 = 12345678901234567890n;
+									storeValue.bigint2 = 5n;
+									storeValue.bigint3 = 1000000n;
 									storeValue.obj = { foo: BigInt(-10) };
 									storeValue.set = new Set([BigInt(1), BigInt(2)]);
 								}

--- a/test/Compiler-filesystem-caching.test.js
+++ b/test/Compiler-filesystem-caching.test.js
@@ -85,6 +85,8 @@ describe("Compiler (filesystem caching)", () => {
 										expect(result.bigint3).toEqual(12345678901234567890n);
 										expect(result.bigint4).toEqual(5n);
 										expect(result.bigint5).toEqual(1000000n);
+										expect(result.bigint6).toEqual(128n);
+										expect(result.bigint7).toEqual(2147483647n);
 										expect(result.obj.foo).toBe(BigInt(-10));
 										expect(Array.from(result.set)).toEqual([
 											BigInt(1),
@@ -119,6 +121,8 @@ describe("Compiler (filesystem caching)", () => {
 									storeValue.bigint3 = 12345678901234567890n;
 									storeValue.bigint4 = 5n;
 									storeValue.bigint5 = 1000000n;
+									storeValue.bigint6 = 128n;
+									storeValue.bigint7 = 2147483647n;
 									storeValue.obj = { foo: BigInt(-10) };
 									storeValue.set = new Set([BigInt(1), BigInt(2)]);
 									storeValue.arr = [256n, 257n, 258n];

--- a/test/Compiler-filesystem-caching.test.js
+++ b/test/Compiler-filesystem-caching.test.js
@@ -79,15 +79,18 @@ describe("Compiler (filesystem caching)", () => {
 									}
 
 									if (isBigIntSupported) {
-										expect(result.bigint).toEqual(BigInt(123));
-										expect(result.bigint1).toEqual(12345678901234567890n);
-										expect(result.bigint2).toEqual(5n);
-										expect(result.bigint3).toEqual(1000000n);
+										expect(result.bigint).toEqual(5n);
+										expect(result.bigint1).toEqual(124n);
+										expect(result.bigint2).toEqual(125n);
+										expect(result.bigint3).toEqual(12345678901234567890n);
+										expect(result.bigint4).toEqual(5n);
+										expect(result.bigint5).toEqual(1000000n);
 										expect(result.obj.foo).toBe(BigInt(-10));
 										expect(Array.from(result.set)).toEqual([
 											BigInt(1),
 											BigInt(2)
 										]);
+										expect(result.arr).toEqual([256n, 257n, 258n]);
 									}
 
 									return;
@@ -110,12 +113,15 @@ describe("Compiler (filesystem caching)", () => {
 								}
 
 								if (isBigIntSupported) {
-									storeValue.bigint = BigInt(123);
-									storeValue.bigint1 = 12345678901234567890n;
-									storeValue.bigint2 = 5n;
-									storeValue.bigint3 = 1000000n;
+									storeValue.bigint = BigInt(5);
+									storeValue.bigint1 = BigInt(124);
+									storeValue.bigint2 = BigInt(125);
+									storeValue.bigint3 = 12345678901234567890n;
+									storeValue.bigint4 = 5n;
+									storeValue.bigint5 = 1000000n;
 									storeValue.obj = { foo: BigInt(-10) };
 									storeValue.set = new Set([BigInt(1), BigInt(2)]);
+									storeValue.arr = [256n, 257n, 258n];
 								}
 
 								await cacheItem.storePromise(storeValue);


### PR DESCRIPTION
feat:
- support `case` for errors (we will use it in future to provide original error from loader)
- support bigint

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b1dac04</samp>

This pull request adds `bigint` support to the serialization system, which allows webpack to handle large integer values in its data structures. It modifies the `BinaryMiddleware`, `ObjectMiddleware`, `ErrorObjectSerializer`, and `types.js` modules to handle the `bigint` type, and adds the `parserOptions` property to the `.eslintrc.js` file to enable linting for ECMAScript 2020. It also adds a test case to the `Compiler-filesystem-caching.test.js` module to verify the serialization and deserialization of `bigint` values.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b1dac04</samp>

*  Add `bigint` support to the serialization system ([link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-e2954b558f2aa82baff0e30964490d12942e0e251c1aa56c3294de6ec67b7cf5R112-R114), [link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-276033679497d08f13669fab20cfcd1de13ec0bb36792d71404a15ab59627f29R87), [link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-276033679497d08f13669fab20cfcd1de13ec0bb36792d71404a15ab59627f29R335-R344), [link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-276033679497d08f13669fab20cfcd1de13ec0bb36792d71404a15ab59627f29R861-R879), [link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-a7a17d233126cd636c2f953911efa1c4872c84fe7255cab8878b1237a180c5e9R400-R402), [link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-4c5780a135e9a531231c1d6b54849b7c0efbfa6373a8b760cbeb0b6bff233da0L9-R9))
  * Define the header byte for `bigint` values in `BinaryMiddleware.js` ([link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-276033679497d08f13669fab20cfcd1de13ec0bb36792d71404a15ab59627f29R87))
  * Handle the conversion of `bigint` values to and from binary buffers in `BinaryMiddleware.js` ([link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-276033679497d08f13669fab20cfcd1de13ec0bb36792d71404a15ab59627f29R335-R344), [link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-276033679497d08f13669fab20cfcd1de13ec0bb36792d71404a15ab59627f29R861-R879))
  * Handle the serialization of objects with circular references that contain `bigint` values in `ObjectMiddleware.js` ([link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-a7a17d233126cd636c2f953911efa1c4872c84fe7255cab8878b1237a180c5e9R400-R402))
  * Add `bigint` to the type definition of `PrimitiveSerializableType` in `types.js` ([link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-4c5780a135e9a531231c1d6b54849b7c0efbfa6373a8b760cbeb0b6bff233da0L9-R9))
  * Add a test case for `bigint` values and edge cases in `Compiler-filesystem-caching.test.js` ([link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-35817f6d3958df306aef88203a15f24dd7348e0ea8993740d329bd4f068b5b1eR44-R118))
* Fix the type error for error objects with a custom `cause` property in `ErrorObjectSerializer.js` ([link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-6ee65ea18a780a266c1e0a9525ad2d975b8db9cbb2bc7a1c07130861672aba8cR24), [link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-6ee65ea18a780a266c1e0a9525ad2d975b8db9cbb2bc7a1c07130861672aba8cR35-R36))
  * Add type casts to the `write` and `read` methods of `ErrorObjectSerializer.js` to avoid the type error ([link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-6ee65ea18a780a266c1e0a9525ad2d975b8db9cbb2bc7a1c07130861672aba8cR24), [link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-6ee65ea18a780a266c1e0a9525ad2d975b8db9cbb2bc7a1c07130861672aba8cR35-R36))
* Remove the console log statement in `ObjectMiddleware.js` ([link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-a7a17d233126cd636c2f953911efa1c4872c84fe7255cab8878b1237a180c5e9R692-R693))
  * Delete the debugging statement in the `deserialize` method of `ObjectMiddleware.js` ([link](https://github.com/webpack/webpack/pull/17282/files?diff=unified&w=0#diff-a7a17d233126cd636c2f953911efa1c4872c84fe7255cab8878b1237a180c5e9R692-R693))
