### PR TITLE
docs: use GitHub discussions instead of Gitter in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,9 @@
 
 **Do you want to request a _feature_ or report a _bug_?**
 
-<!-- Please ask questions on StackOverflow or the webpack Gitter (https://gitter.im/webpack/webpack). -->
+<!-- Please ask questions on StackOverflow or the GitHub Discussions. -->
+<!-- https://github.com/webpack/webpack/discussions -->
+<!-- https://stackoverflow.com/questions/ask?tags=webpack -->
 <!-- Issues which contain questions or support requests will be closed. -->
 
 **What is the current behavior?**

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -8,9 +8,9 @@ about: Create a report to help us improve
 
 # Bug report
 
-<!-- Please ask questions on StackOverflow or the webpack Gitter. -->
+<!-- Please ask questions on StackOverflow or the GitHub Discussions. -->
+<!-- https://github.com/webpack/webpack/discussions -->
 <!-- https://stackoverflow.com/questions/ask?tags=webpack -->
-<!-- https://gitter.im/webpack/webpack -->
 <!-- Issues which contain questions or support requests will be closed. -->
 
 **What is the current behavior?**

--- a/.github/ISSUE_TEMPLATE/Other.md
+++ b/.github/ISSUE_TEMPLATE/Other.md
@@ -4,5 +4,7 @@ about: Something else
 ---
 
 <!-- Bug reports and Feature requests must use other templates, or will be closed -->
-<!-- Please ask questions on StackOverflow or the webpack Gitter (https://gitter.im/webpack/webpack). -->
+<!-- Please ask questions on StackOverflow or the GitHub Discussions. -->
+<!-- https://github.com/webpack/webpack/discussions -->
+<!-- https://stackoverflow.com/questions/ask?tags=webpack -->
 <!-- Issues which contain questions or support requests will be closed. -->


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 200ceb7</samp>

Update issue templates to use GitHub Discussions instead of Gitter chat. Replace the Gitter chat link with the Discussions link in `.github/ISSUE_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/Bug_report.md`, and `.github/ISSUE_TEMPLATE/Other.md`.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 200ceb7</samp>

* Replace references to Gitter chat with GitHub Discussions link in issue templates ([link](https://github.com/webpack/webpack/pull/17293/files?diff=unified&w=0#diff-c25d576890a32eb1483dee2edf4fdc1529816b846bf76ef565f577cb433c1f79L7-R9), [link](https://github.com/webpack/webpack/pull/17293/files?diff=unified&w=0#diff-f3af6f2611f6d67e0111cb0e1ca7b3db7b920e1d352d58eda32e4514ba65eb1cL11-R13), [link](https://github.com/webpack/webpack/pull/17293/files?diff=unified&w=0#diff-e020b4f990ec207d5684231bd66fd3b5cd06b3af19f1afcb83ab5e7e6f80a6b9L7-R9))
