### PR TITLE
refactor: errors and lazy loading

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -381,6 +381,11 @@ declare module "browserslist" {
 	export = browserslist;
 }
 
+declare module "json-parse-even-better-errors" {
+	function parseJson(text: string, reviver?: (this: any, key: string, value: any) => any, context?: number): any;
+	export = parseJson;
+}
+
 // TODO remove that when @types/estree is updated
 interface ImportAttributeNode {
 	type: "ImportAttribute";

--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -1011,8 +1011,7 @@ ${other}`);
 				try {
 					this.records = parseJson(content.toString("utf-8"));
 				} catch (e) {
-					e.message = "Cannot parse records: " + e.message;
-					return callback(e);
+					return callback(new Error(`Cannot parse records: ${e.message}`));
 				}
 
 				return callback();

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -107,6 +107,7 @@ const makeSerializable = require("./util/makeSerializable");
  */
 
 /** @typedef {KnownBuildMeta & Record<string, any>} BuildMeta */
+/** @typedef {Record<string, any>} BuildInfo */
 
 const EMPTY_RESOLVE_OPTIONS = {};
 
@@ -116,6 +117,11 @@ const DEFAULT_TYPES_UNKNOWN = new Set(["unknown"]);
 const DEFAULT_TYPES_JS = new Set(["javascript"]);
 
 const deprecatedNeedRebuild = util.deprecate(
+	/**
+	 * @param {Module} module the module
+	 * @param {NeedBuildContext} context context info
+	 * @returns {boolean} true, when rebuild is needed
+	 */
 	(module, context) => {
 		return module.needRebuild(
 			context.fileSystemInfo.getDeprecatedFileTimestamps(),
@@ -169,7 +175,7 @@ class Module extends DependenciesBlock {
 		this._errors = undefined;
 		/** @type {BuildMeta | undefined} */
 		this.buildMeta = undefined;
-		/** @type {Record<string, any> | undefined} */
+		/** @type {BuildInfo | undefined} */
 		this.buildInfo = undefined;
 		/** @type {Dependency[] | undefined} */
 		this.presentationalDependencies = undefined;

--- a/lib/dependencies/JsonExportsDependency.js
+++ b/lib/dependencies/JsonExportsDependency.js
@@ -47,7 +47,7 @@ const getExportsFromData = data => {
 
 class JsonExportsDependency extends NullDependency {
 	/**
-	 * @param {JsonData=} data json data
+	 * @param {JsonData} data json data
 	 */
 	constructor(data) {
 		super();

--- a/lib/json/JsonData.js
+++ b/lib/json/JsonData.js
@@ -40,14 +40,14 @@ class JsonData {
 
 	/**
 	 * @param {Hash} hash hash to be updated
-	 * @returns {Hash} the updated hash
+	 * @returns {void} the updated hash
 	 */
 	updateHash(hash) {
 		if (this._buffer === undefined && this._data !== undefined) {
 			this._buffer = Buffer.from(JSON.stringify(this._data));
 		}
 
-		if (this._buffer) return hash.update(this._buffer);
+		if (this._buffer) hash.update(this._buffer);
 	}
 }
 

--- a/lib/json/JsonParser.js
+++ b/lib/json/JsonParser.js
@@ -5,15 +5,19 @@
 
 "use strict";
 
-const parseJson = require("json-parse-even-better-errors");
 const Parser = require("../Parser");
 const JsonExportsDependency = require("../dependencies/JsonExportsDependency");
+const memoize = require("../util/memoize");
 const JsonData = require("./JsonData");
 
 /** @typedef {import("../../declarations/plugins/JsonModulesPluginParser").JsonModulesPluginParserOptions} JsonModulesPluginParserOptions */
+/** @typedef {import("../Module").BuildInfo} BuildInfo */
+/** @typedef {import("../Module").BuildMeta} BuildMeta */
 /** @typedef {import("../Parser").ParserState} ParserState */
 /** @typedef {import("../Parser").PreparsedAst} PreparsedAst */
 /** @typedef {import("./JsonModulesPlugin").RawJsonData} RawJsonData */
+
+const getParseJson = memoize(() => require("json-parse-even-better-errors"));
 
 class JsonParser extends Parser {
 	/**
@@ -36,17 +40,26 @@ class JsonParser extends Parser {
 
 		/** @type {NonNullable<JsonModulesPluginParserOptions["parse"]>} */
 		const parseFn =
-			typeof this.options.parse === "function" ? this.options.parse : parseJson;
-		/** @type {Buffer | RawJsonData} */
-		const data =
-			typeof source === "object"
-				? source
-				: parseFn(source[0] === "\ufeff" ? source.slice(1) : source);
-		const jsonData = new JsonData(data);
-		state.module.buildInfo.jsonData = jsonData;
-		state.module.buildInfo.strict = true;
-		state.module.buildMeta.exportsType = "default";
-		state.module.buildMeta.defaultObject =
+			typeof this.options.parse === "function"
+				? this.options.parse
+				: getParseJson();
+		/** @type {Buffer | RawJsonData | undefined} */
+		let data;
+		try {
+			data =
+				typeof source === "object"
+					? source
+					: parseFn(source[0] === "\ufeff" ? source.slice(1) : source);
+		} catch (e) {
+			throw new Error(`Cannot parse JSON: ${/** @type {Error} */ (e).message}`);
+		}
+		const jsonData = new JsonData(/** @type {Buffer | RawJsonData} */ (data));
+		const buildInfo = /** @type {BuildInfo} */ (state.module.buildInfo);
+		buildInfo.jsonData = jsonData;
+		buildInfo.strict = true;
+		const buildMeta = /** @type {BuildMeta} */ (state.module.buildMeta);
+		buildMeta.exportsType = "default";
+		buildMeta.defaultObject =
 			typeof data === "object" ? "redirect-warn" : false;
 		state.module.addDependency(new JsonExportsDependency(jsonData));
 		return state;

--- a/types.d.ts
+++ b/types.d.ts
@@ -658,6 +658,9 @@ declare abstract class BasicEvaluatedExpression {
 	 */
 	setExpression(expression: NodeEstreeIndex): BasicEvaluatedExpression;
 }
+declare interface BuildInfo {
+	[index: string]: any;
+}
 type BuildMeta = KnownBuildMeta & Record<string, any>;
 declare abstract class ByTypeGenerator extends Generator {
 	map: any;
@@ -7264,7 +7267,7 @@ declare class Module extends DependenciesBlock {
 	useSourceMap: boolean;
 	useSimpleSourceMap: boolean;
 	buildMeta?: BuildMeta;
-	buildInfo?: Record<string, any>;
+	buildInfo?: BuildInfo;
 	presentationalDependencies?: Dependency[];
 	codeGenerationDependencies?: Dependency[];
 	id: string | number;


### PR DESCRIPTION
Here:
- Handle `JsonParseError` https://github.com/webpack/webpack/pull/16567/#issuecomment-1572428979, now we have standard `Error`, but and keep good message
- lazy loading `json-parse-even-better-errors`, because developer can provide own functions
- fix more types

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e0c7b6c</samp>

This pull request improves the JSON handling and module rebuilding features of webpack. It refactors and documents some classes and methods, adds type definitions and error handling, and fixes a bug with the records parsing error message. The files affected are `lib/json/JsonData.js`, `lib/json/JsonParser.js`, `lib/Module.js`, `lib/Compiler.js`, and `lib/dependencies/JsonExportsDependency.js`.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e0c7b6c</samp>

*  Change the type of the data parameter of the `JsonExportsDependency` constructor to make it non-optional ([link](https://github.com/webpack/webpack/pull/17301/files?diff=unified&w=0#diff-c0050e77a5245c1b0d623ec6f664e787636017347b03eba066b5551204eace29L50-R50))
*  Change the return type of the `updateHash` method of the `JsonData` class to void and remove the return statement, to indicate that it does not return anything and only mutates the hash argument ([link](https://github.com/webpack/webpack/pull/17301/files?diff=unified&w=0#diff-59399597ac04b33c6be4e2d028d2761341836b13e45edfcd0c26d9e3b71e4ff7L43-R43), [link](https://github.com/webpack/webpack/pull/17301/files?diff=unified&w=0#diff-59399597ac04b33c6be4e2d028d2761341836b13e45edfcd0c26d9e3b71e4ff7L50-R50))
*  Wrap the error message for failing to parse records in a new `Error` object, to preserve the stack trace and avoid mutating the original error object ([link](https://github.com/webpack/webpack/pull/17301/files?diff=unified&w=0#diff-732395f8fcd972919381425c80194bb0def0a2af50c0940762299605a81c0006L1014-R1014))
*  Catch and rethrow any errors from parsing JSON in the `parseSource` method of the `JsonParser` class, to provide a more informative error message and avoid crashing the parser ([link](https://github.com/webpack/webpack/pull/17301/files?diff=unified&w=0#diff-073b8678c5b8c2fb1935972c32347d8775a9c2e1a0f800c137cf4eacf7438760L39-R62))
*  Move the require statement for the `parseJson` function to a memoized function, to avoid loading the module until it is needed and improve performance ([link](https://github.com/webpack/webpack/pull/17301/files?diff=unified&w=0#diff-073b8678c5b8c2fb1935972c32347d8775a9c2e1a0f800c137cf4eacf7438760L8-R21))
*  Add a type definition for `BuildInfo` to document the shape of the `buildInfo` property of `Module` instances ([link](https://github.com/webpack/webpack/pull/17301/files?diff=unified&w=0#diff-44156fd0f9b801a0114774f05283caff3069ad67f663ad53f886f08472868c7dR110))
*  Change the type of the `buildInfo` property of `Module` instances to `BuildInfo`, to use the newly defined type and improve type checking and readability ([link](https://github.com/webpack/webpack/pull/17301/files?diff=unified&w=0#diff-44156fd0f9b801a0114774f05283caff3069ad67f663ad53f886f08472868c7dL172-R178))
*  Add a JSDoc comment to describe the parameters and return value of the `DEFAULT_TYPES_JS` function, which is used to determine if a module needs to be rebuilt based on its type ([link](https://github.com/webpack/webpack/pull/17301/files?diff=unified&w=0#diff-44156fd0f9b801a0114774f05283caff3069ad67f663ad53f886f08472868c7dR120-R124))
