### PR TITLE
Handle barrel imports (#17305)

### DIFF
--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -212,7 +212,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			.for(harmonySpecifierTag)
 			.tap(
 				"HarmonyImportDependencyParserPlugin",
-				(expression, members, membersOptionals, memberRangeStarts) => {
+				(expression, members, membersOptionals, memberRanges) => {
 					const settings = /** @type {HarmonySettings} */ (
 						parser.currentTagData
 					);
@@ -220,10 +220,9 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 						members,
 						membersOptionals
 					);
-					const rangeStarts = memberRangeStarts.slice(
+					const ranges = memberRanges.slice(
 						0,
-						memberRangeStarts.length -
-							(members.length - nonOptionalMembers.length)
+						memberRanges.length - (members.length - nonOptionalMembers.length)
 					);
 					const expr =
 						nonOptionalMembers !== members
@@ -241,7 +240,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 						expr.range,
 						exportPresenceMode,
 						settings.assertions,
-						rangeStarts
+						ranges
 					);
 					dep.referencedPropertiesInDestructuring =
 						parser.destructuringAssignmentPropertiesFor(expr);
@@ -256,7 +255,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			.for(harmonySpecifierTag)
 			.tap(
 				"HarmonyImportDependencyParserPlugin",
-				(expression, members, membersOptionals, memberRangeStarts) => {
+				(expression, members, membersOptionals, memberRanges) => {
 					const { arguments: args, callee } = expression;
 					const settings = /** @type {HarmonySettings} */ (
 						parser.currentTagData
@@ -265,10 +264,9 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 						members,
 						membersOptionals
 					);
-					const rangeStarts = memberRangeStarts.slice(
+					const ranges = memberRanges.slice(
 						0,
-						memberRangeStarts.length -
-							(members.length - nonOptionalMembers.length)
+						memberRanges.length - (members.length - nonOptionalMembers.length)
 					);
 					const expr =
 						nonOptionalMembers !== members
@@ -286,7 +284,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 						expr.range,
 						exportPresenceMode,
 						settings.assertions,
-						rangeStarts
+						ranges
 					);
 					dep.directImport = members.length === 0;
 					dep.call = true;

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -43,7 +43,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 	 * @param {Range} range range
 	 * @param {TODO} exportPresenceMode export presence mode
 	 * @param {Assertions=} assertions assertions
-	 * @param {number[]=} idRangeStarts range starts for members of ids; the two arrays are right-aligned
+	 * @param {Range[]=} idRanges ranges for members of ids; the two arrays are right-aligned
 	 */
 	constructor(
 		request,
@@ -53,13 +53,13 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		range,
 		exportPresenceMode,
 		assertions,
-		idRangeStarts // TODO webpack 6 make this non-optional. It must always be set to properly trim ids.
+		idRanges // TODO webpack 6 make this non-optional. It must always be set to properly trim ids.
 	) {
 		super(request, sourceOrder, assertions);
 		this.ids = ids;
 		this.name = name;
 		this.range = range;
-		this.idRangeStarts = idRangeStarts;
+		this.idRanges = idRanges;
 		this.exportPresenceMode = exportPresenceMode;
 		this.namespaceObjectAsContext = false;
 		this.call = undefined;
@@ -261,7 +261,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		write(this.ids);
 		write(this.name);
 		write(this.range);
-		write(this.idRangeStarts);
+		write(this.idRanges);
 		write(this.exportPresenceMode);
 		write(this.namespaceObjectAsContext);
 		write(this.call);
@@ -281,7 +281,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 		this.ids = read();
 		this.name = read();
 		this.range = read();
-		this.idRangeStarts = read();
+		this.idRanges = read();
 		this.exportPresenceMode = read();
 		this.namespaceObjectAsContext = read();
 		this.call = read();
@@ -320,15 +320,15 @@ HarmonyImportSpecifierDependency.Template = class HarmonyImportSpecifierDependen
 
 		let [rangeStart, rangeEnd] = dep.range;
 		if (trimmedIds.length !== ids.length) {
-			// The array returned from dep.idRangeStarts is right-aligned with the array returned from dep.getIds.
+			// The array returned from dep.idRanges is right-aligned with the array returned from dep.getIds.
 			// Meaning, the two arrays may not always have the same number of elements, but the last element of
-			// dep.idRangeStarts corresponds to [the starting range position of] the last element of dep.getIds.
-			// Use this to find the correct range end position based on the number of ids that were trimmed.
+			// dep.idRanges corresponds to [the expression fragment to the left of] the last element of dep.getIds.
+			// Use this to find the correct replacement range based on the number of ids that were trimmed.
 			const idx =
-				dep.idRangeStarts === undefined
+				dep.idRanges === undefined
 					? -1 /* trigger failure case below */
-					: dep.idRangeStarts.length + (trimmedIds.length - ids.length);
-			if (idx < 0 || idx >= dep.idRangeStarts.length) {
+					: dep.idRanges.length + (trimmedIds.length - ids.length);
+			if (idx < 0 || idx >= dep.idRanges.length) {
 				// cspell:ignore minifiers
 				// Should not happen but we can't throw an error here because of backward compatibility with
 				// external plugins in wp5.  Instead, we just disable trimming for now.  This may break some minifiers.
@@ -336,7 +336,7 @@ HarmonyImportSpecifierDependency.Template = class HarmonyImportSpecifierDependen
 				// TODO webpack 6 remove the "trimmedIds = ids" above and uncomment the following line instead.
 				// throw new Error("Missing range starts data for id replacement trimming.");
 			} else {
-				rangeEnd = dep.idRangeStarts[idx];
+				[rangeStart, rangeEnd] = dep.idRanges[idx];
 			}
 		}
 

--- a/lib/javascript/BasicEvaluatedExpression.js
+++ b/lib/javascript/BasicEvaluatedExpression.js
@@ -6,6 +6,7 @@
 "use strict";
 
 /** @typedef {import("estree").Node} EsTreeNode */
+/** @typedef {import("./JavascriptParser").Range} Range */
 /** @typedef {import("./JavascriptParser").VariableInfoInterface} VariableInfoInterface */
 
 const TypeUnknown = 0;
@@ -70,8 +71,8 @@ class BasicEvaluatedExpression {
 		this.getMembers = undefined;
 		/** @type {() => boolean[]} */
 		this.getMembersOptionals = undefined;
-		/** @type {() => number[]} */
-		this.getMemberRangeStarts = undefined;
+		/** @type {() => Range[]} */
+		this.getMemberRanges = undefined;
 		/** @type {EsTreeNode} */
 		this.expression = undefined;
 	}
@@ -386,7 +387,7 @@ class BasicEvaluatedExpression {
 	 * @param {string | VariableInfoInterface} rootInfo root info
 	 * @param {() => string[]} getMembers members
 	 * @param {() => boolean[]=} getMembersOptionals optional members
-	 * @param {() => number[]=} getMemberRangeStarts range start of progressively increasing sub-expressions
+	 * @param {() => Range[]=} getMemberRanges ranges of progressively increasing sub-expressions
 	 * @returns {this} this
 	 */
 	setIdentifier(
@@ -394,14 +395,14 @@ class BasicEvaluatedExpression {
 		rootInfo,
 		getMembers,
 		getMembersOptionals,
-		getMemberRangeStarts
+		getMemberRanges
 	) {
 		this.type = TypeIdentifier;
 		this.identifier = identifier;
 		this.rootInfo = rootInfo;
 		this.getMembers = getMembers;
 		this.getMembersOptionals = getMembersOptionals;
-		this.getMemberRangeStarts = getMemberRangeStarts;
+		this.getMemberRanges = getMemberRanges;
 		this.sideEffects = true;
 		return this;
 	}

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -91,7 +91,7 @@ const BasicEvaluatedExpression = require("./BasicEvaluatedExpression");
 /** @typedef {import("../Parser").ParserState} ParserState */
 /** @typedef {import("../Parser").PreparsedAst} PreparsedAst */
 /** @typedef {{declaredScope: ScopeInfo, freeName: string | true, tagInfo: TagInfo | undefined}} VariableInfoInterface */
-/** @typedef {{ name: string | VariableInfo, rootInfo: string | VariableInfo, getMembers: () => string[], getMembersOptionals: () => boolean[], getMemberRangeStarts: () => number[] }} GetInfoResult */
+/** @typedef {{ name: string | VariableInfo, rootInfo: string | VariableInfo, getMembers: () => string[], getMembersOptionals: () => boolean[], getMemberRanges: () => Range[] }} GetInfoResult */
 
 const EMPTY_ARRAY = [];
 const ALLOWED_MEMBER_TYPES_CALL_EXPRESSION = 0b01;
@@ -350,14 +350,14 @@ class JavascriptParser extends Parser {
 			/** @type {HookMap<SyncBailHook<[BaseCallExpression], boolean | void>>} */
 			call: new HookMap(() => new SyncBailHook(["expression"])),
 			/** Something like "a.b()" */
-			/** @type {HookMap<SyncBailHook<[CallExpression, string[], boolean[], number[]], boolean | void>>} */
+			/** @type {HookMap<SyncBailHook<[CallExpression, string[], boolean[], Range[]], boolean | void>>} */
 			callMemberChain: new HookMap(
 				() =>
 					new SyncBailHook([
 						"expression",
 						"members",
 						"membersOptionals",
-						"memberRangeStarts"
+						"memberRanges"
 					])
 			),
 			/** Something like "a.b().c.d" */
@@ -390,14 +390,14 @@ class JavascriptParser extends Parser {
 			binaryExpression: new SyncBailHook(["binaryExpression"]),
 			/** @type {HookMap<SyncBailHook<[Expression], boolean | void>>} */
 			expression: new HookMap(() => new SyncBailHook(["expression"])),
-			/** @type {HookMap<SyncBailHook<[Expression, string[], boolean[], number[]], boolean | void>>} */
+			/** @type {HookMap<SyncBailHook<[Expression, string[], boolean[], Range[]], boolean | void>>} */
 			expressionMemberChain: new HookMap(
 				() =>
 					new SyncBailHook([
 						"expression",
 						"members",
 						"membersOptionals",
-						"memberRangeStarts"
+						"memberRanges"
 					])
 			),
 			/** @type {HookMap<SyncBailHook<[Expression, string[]], boolean | void>>} */
@@ -1163,7 +1163,7 @@ class JavascriptParser extends Parser {
 								info.rootInfo,
 								info.getMembers,
 								info.getMembersOptionals,
-								info.getMemberRangeStarts
+								info.getMemberRanges
 							)
 							.setRange(expr.range);
 					}
@@ -1184,7 +1184,7 @@ class JavascriptParser extends Parser {
 					rootInfo: info,
 					getMembers: () => [],
 					getMembersOptionals: () => [],
-					getMemberRangeStarts: () => []
+					getMemberRanges: () => []
 				};
 			}
 		});
@@ -1199,7 +1199,7 @@ class JavascriptParser extends Parser {
 					rootInfo: info,
 					getMembers: () => [],
 					getMembersOptionals: () => [],
-					getMemberRangeStarts: () => []
+					getMemberRanges: () => []
 				};
 			}
 		});
@@ -3264,7 +3264,7 @@ class JavascriptParser extends Parser {
 					callee.getMembersOptionals
 						? callee.getMembersOptionals()
 						: callee.getMembers().map(() => false),
-					callee.getMemberRangeStarts ? callee.getMemberRangeStarts() : []
+					callee.getMemberRanges ? callee.getMemberRanges() : []
 				);
 				if (result1 === true) return;
 				const result2 = this.callHooksForInfo(
@@ -3308,14 +3308,14 @@ class JavascriptParser extends Parser {
 					if (result1 === true) return;
 					const members = exprInfo.getMembers();
 					const membersOptionals = exprInfo.getMembersOptionals();
-					const memberRangeStarts = exprInfo.getMemberRangeStarts();
+					const memberRanges = exprInfo.getMemberRanges();
 					const result2 = this.callHooksForInfo(
 						this.hooks.expressionMemberChain,
 						exprInfo.rootInfo,
 						expression,
 						members,
 						membersOptionals,
-						memberRangeStarts
+						memberRanges
 					);
 					if (result2 === true) return;
 					this.walkMemberExpressionWithExpressionName(
@@ -4271,23 +4271,23 @@ class JavascriptParser extends Parser {
 
 	/**
 	 * @param {MemberExpression} expression a member expression
-	 * @returns {{ members: string[], object: Expression | Super, membersOptionals: boolean[], memberRangeStarts: number[] }} member names (reverse order) and remaining object
+	 * @returns {{ members: string[], object: Expression | Super, membersOptionals: boolean[], memberRanges: Range[] }} member names (reverse order) and remaining object
 	 */
 	extractMemberExpressionChain(expression) {
 		/** @type {AnyNode} */
 		let expr = expression;
 		const members = [];
 		const membersOptionals = [];
-		const memberRangeStarts = [];
+		const memberRanges = [];
 		while (expr.type === "MemberExpression") {
 			if (expr.computed) {
 				if (expr.property.type !== "Literal") break;
-				members.push(`${expr.property.value}`);
-				memberRangeStarts.push(expr.object.range[1]);
+				members.push(`${expr.property.value}`); // the literal
+				memberRanges.push(expr.object.range); // the range of the expression fragment before the literal
 			} else {
 				if (expr.property.type !== "Identifier") break;
-				members.push(expr.property.name);
-				memberRangeStarts.push(expr.object.range[1]);
+				members.push(expr.property.name); // the identifier
+				memberRanges.push(expr.object.range); // the range of the expression fragment before the identifier
 			}
 			membersOptionals.push(expr.optional);
 			expr = expr.object;
@@ -4296,7 +4296,7 @@ class JavascriptParser extends Parser {
 		return {
 			members,
 			membersOptionals,
-			memberRangeStarts,
+			memberRanges,
 			object: expr
 		};
 	}
@@ -4319,8 +4319,8 @@ class JavascriptParser extends Parser {
 		return { info, name };
 	}
 
-	/** @typedef {{ type: "call", call: CallExpression, calleeName: string, rootInfo: string | VariableInfo, getCalleeMembers: () => string[], name: string, getMembers: () => string[], getMembersOptionals: () => boolean[], getMemberRangeStarts: () => number[]}} CallExpressionInfo */
-	/** @typedef {{ type: "expression", rootInfo: string | VariableInfo, name: string, getMembers: () => string[], getMembersOptionals: () => boolean[], getMemberRangeStarts: () => number[]}} ExpressionExpressionInfo */
+	/** @typedef {{ type: "call", call: CallExpression, calleeName: string, rootInfo: string | VariableInfo, getCalleeMembers: () => string[], name: string, getMembers: () => string[], getMembersOptionals: () => boolean[], getMemberRanges: () => Range[]}} CallExpressionInfo */
+	/** @typedef {{ type: "expression", rootInfo: string | VariableInfo, name: string, getMembers: () => string[], getMembersOptionals: () => boolean[], getMemberRanges: () => Range[]}} ExpressionExpressionInfo */
 
 	/**
 	 * @param {MemberExpression} expression a member expression
@@ -4328,7 +4328,7 @@ class JavascriptParser extends Parser {
 	 * @returns {CallExpressionInfo | ExpressionExpressionInfo | undefined} expression info
 	 */
 	getMemberExpressionInfo(expression, allowedTypes) {
-		const { object, members, membersOptionals, memberRangeStarts } =
+		const { object, members, membersOptionals, memberRanges } =
 			this.extractMemberExpressionChain(expression);
 		switch (object.type) {
 			case "CallExpression": {
@@ -4355,7 +4355,7 @@ class JavascriptParser extends Parser {
 					name: objectAndMembersToName(`${calleeName}()`, members),
 					getMembers: memoize(() => members.reverse()),
 					getMembersOptionals: memoize(() => membersOptionals.reverse()),
-					getMemberRangeStarts: memoize(() => memberRangeStarts.reverse())
+					getMemberRanges: memoize(() => memberRanges.reverse())
 				};
 			}
 			case "Identifier":
@@ -4375,7 +4375,7 @@ class JavascriptParser extends Parser {
 					rootInfo,
 					getMembers: memoize(() => members.reverse()),
 					getMembersOptionals: memoize(() => membersOptionals.reverse()),
-					getMemberRangeStarts: memoize(() => memberRangeStarts.reverse())
+					getMemberRanges: memoize(() => memberRanges.reverse())
 				};
 			}
 		}

--- a/test/configCases/code-generation/re-export-namespace-concat/index.js
+++ b/test/configCases/code-generation/re-export-namespace-concat/index.js
@@ -35,6 +35,12 @@ it("should use/preserve accessor form for import object and namespaces", functio
 		const bb = obj1.up.down?.left.right;
 
 		data.nested.object3["unknownProperty"].depth = "deep";
+
+		(obj1)["aaa"].bbb;
+		(m_1.obj1)["ccc"].ddd;
+		(obj1["eee"]).fff;
+		(m_1.obj1["ggg"]).hhh;
+		(((m_1).obj1)["iii"]).jjj;
 	}
 
 	/************ DO NOT MATCH BELOW THIS LINE ************/
@@ -60,4 +66,10 @@ it("should use/preserve accessor form for import object and namespaces", functio
 	expectSourceToContain(source, 'const bb = obj1.up.down?.left.right;');
 
 	expectSourceToContain(source, 'data_namespaceObject.a.a["unknownProperty"].depth = "deep";');
+
+	expectSourceToContain(source, '(obj1)["aaa"].bbb;');
+	expectSourceToContain(source, '(obj1)["ccc"].ddd;');
+	expectSourceToContain(source, '(obj1["eee"]).fff;');
+	expectSourceToContain(source, '(obj1["ggg"]).hhh;');
+	expectSourceToContain(source, '((obj1)["iii"]).jjj;');
 });

--- a/test/configCases/code-generation/re-export-namespace/index.js
+++ b/test/configCases/code-generation/re-export-namespace/index.js
@@ -35,6 +35,12 @@ it("should use/preserve accessor form for import object and namespaces", functio
 		const bb = obj1.up.down?.left.right;
 
 		data.nested.object3["unknownProperty"].depth = "deep";
+
+		(obj1)["aaa"].bbb;
+		(m_1.obj1)["ccc"].ddd;
+		(obj1["eee"]).fff;
+		(m_1.obj1["ggg"]).hhh;
+		(((m_1).obj1)["iii"]).jjj;
 	}
 
 	/************ DO NOT MATCH BELOW THIS LINE ************/
@@ -61,4 +67,9 @@ it("should use/preserve accessor form for import object and namespaces", functio
 
 	expectSourceToContain(source, '_data__WEBPACK_IMPORTED_MODULE_3__.nested.object3["unknownProperty"].depth = "deep";');
 
+	expectSourceToContain(source, '(_module1__WEBPACK_IMPORTED_MODULE_0__.obj1)["aaa"].bbb;');
+	expectSourceToContain(source, '(_module1__WEBPACK_IMPORTED_MODULE_0__.obj1)["ccc"].ddd;');
+	expectSourceToContain(source, '(_module1__WEBPACK_IMPORTED_MODULE_0__.obj1["eee"]).fff;');
+	expectSourceToContain(source, '(_module1__WEBPACK_IMPORTED_MODULE_0__.obj1["ggg"]).hhh;');
+	expectSourceToContain(source, '((_module1__WEBPACK_IMPORTED_MODULE_0__.obj1)["iii"]).jjj;');
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -507,7 +507,7 @@ declare abstract class BasicEvaluatedExpression {
 	rootInfo: string | VariableInfoInterface;
 	getMembers: () => string[];
 	getMembersOptionals: () => boolean[];
-	getMemberRangeStarts: () => number[];
+	getMemberRanges: () => [number, number][];
 	expression: NodeEstreeIndex;
 	isUnknown(): boolean;
 	isNull(): boolean;
@@ -593,7 +593,7 @@ declare abstract class BasicEvaluatedExpression {
 		rootInfo: string | VariableInfoInterface,
 		getMembers: () => string[],
 		getMembersOptionals?: () => boolean[],
-		getMemberRangeStarts?: () => number[]
+		getMemberRanges?: () => [number, number][]
 	): BasicEvaluatedExpression;
 
 	/**
@@ -788,7 +788,7 @@ declare interface CallExpressionInfo {
 	name: string;
 	getMembers: () => string[];
 	getMembersOptionals: () => boolean[];
-	getMemberRangeStarts: () => number[];
+	getMemberRanges: () => [number, number][];
 }
 declare interface CallbackAsyncQueue<T> {
 	(err?: null | WebpackError, result?: T): any;
@@ -3991,7 +3991,7 @@ declare interface ExpressionExpressionInfo {
 	name: string;
 	getMembers: () => string[];
 	getMembersOptionals: () => boolean[];
-	getMemberRangeStarts: () => number[];
+	getMemberRanges: () => [number, number][];
 }
 declare interface ExtensionAliasOption {
 	alias: string | string[];
@@ -5344,7 +5344,7 @@ declare class JavascriptParser extends Parser {
 		call: HookMap<SyncBailHook<[BaseCallExpression], boolean | void>>;
 		callMemberChain: HookMap<
 			SyncBailHook<
-				[CallExpression, string[], boolean[], number[]],
+				[CallExpression, string[], boolean[], [number, number][]],
 				boolean | void
 			>
 		>;
@@ -5365,7 +5365,10 @@ declare class JavascriptParser extends Parser {
 		binaryExpression: SyncBailHook<[BinaryExpression], boolean | void>;
 		expression: HookMap<SyncBailHook<[Expression], boolean | void>>;
 		expressionMemberChain: HookMap<
-			SyncBailHook<[Expression, string[], boolean[], number[]], boolean | void>
+			SyncBailHook<
+				[Expression, string[], boolean[], [number, number][]],
+				boolean | void
+			>
 		>;
 		unhandledExpressionMemberChain: HookMap<
 			SyncBailHook<[Expression, string[]], boolean | void>
@@ -5954,7 +5957,7 @@ declare class JavascriptParser extends Parser {
 			| YieldExpression
 			| Super;
 		membersOptionals: boolean[];
-		memberRangeStarts: number[];
+		memberRanges: [number, number][];
 	};
 	getFreeInfoFromVariable(varName: string): {
 		name: string;


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

fixes #17305.

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c8dc5fa</samp>

This pull request refactors and improves the code that handles harmony import dependencies and member expressions. It uses `Range` objects instead of `number` values to represent the source code ranges of import specifiers and member expressions. It also adds more tests to verify the code generation for re-exporting namespaces with various syntax features.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c8dc5fa</samp>

*  Rename and retype parameters, variables, properties, and hooks related to member ranges in harmony import dependencies and javascript parser ([link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-7f2abd7b8a95b9356fbe87f124e363afd555eec6001ead1dac148ad4a0f84198L215-R215), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-7f2abd7b8a95b9356fbe87f124e363afd555eec6001ead1dac148ad4a0f84198L223-R225), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-7f2abd7b8a95b9356fbe87f124e363afd555eec6001ead1dac148ad4a0f84198L244-R243), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-7f2abd7b8a95b9356fbe87f124e363afd555eec6001ead1dac148ad4a0f84198L259-R258), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-7f2abd7b8a95b9356fbe87f124e363afd555eec6001ead1dac148ad4a0f84198L268-R269), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-7f2abd7b8a95b9356fbe87f124e363afd555eec6001ead1dac148ad4a0f84198L289-R287), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-96335405b47eef62b17ba6fe88f6b35a1e37c9cf98fd762fe74599aca1c65d94L46-R46), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-96335405b47eef62b17ba6fe88f6b35a1e37c9cf98fd762fe74599aca1c65d94L56-R56), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-96335405b47eef62b17ba6fe88f6b35a1e37c9cf98fd762fe74599aca1c65d94L62-R62), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-96335405b47eef62b17ba6fe88f6b35a1e37c9cf98fd762fe74599aca1c65d94L264-R264), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-96335405b47eef62b17ba6fe88f6b35a1e37c9cf98fd762fe74599aca1c65d94L284-R284), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-96335405b47eef62b17ba6fe88f6b35a1e37c9cf98fd762fe74599aca1c65d94L323-R331), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-96335405b47eef62b17ba6fe88f6b35a1e37c9cf98fd762fe74599aca1c65d94L339-R339), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-5059a8f5a078630e6d1a2f751349f83f201e63c3c4ae9d2b9d1d4f274696c6cdL73-R75), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-5059a8f5a078630e6d1a2f751349f83f201e63c3c4ae9d2b9d1d4f274696c6cdL389-R390), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-5059a8f5a078630e6d1a2f751349f83f201e63c3c4ae9d2b9d1d4f274696c6cdL397-R398), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-5059a8f5a078630e6d1a2f751349f83f201e63c3c4ae9d2b9d1d4f274696c6cdL404-R405), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L94-R94), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L353-R353), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L360-R360), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L393-R393), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L400-R400), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L1166-R1166), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L1187-R1187), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L1202-R1202), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L3267-R3267), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L3311-R3311), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L3318-R3318), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L4274-R4274), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L4281-R4290), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L4299-R4299), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L4322-R4323), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L4331-R4331), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L4358-R4358), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L4378-R4378))
* Add a type definition for `Range` in `BasicEvaluatedExpression.js` and import it from `JavascriptParser.js` ([link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-5059a8f5a078630e6d1a2f751349f83f201e63c3c4ae9d2b9d1d4f274696c6cdR9))
* Change the range values to include the expression fragment before the member in `extractMemberExpressionChain` ([link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L4281-R4290))
* Add test cases and assertions for code generation of member expressions with optional chaining and computed properties in `re-export-namespace-concat` and `re-export-namespace` ([link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-f7c761df47d625cac2713c4a49ef486cefbc53234bcff9a30bb218cb82f73d46R38-R43), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-f7c761df47d625cac2713c4a49ef486cefbc53234bcff9a30bb218cb82f73d46R69-R74), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-3dd97285b143466099ecf4d1cd0740fcc727d814dde7b199e4a0a66782acab80R38-R43), [link](https://github.com/webpack/webpack/pull/17307/files?diff=unified&w=0#diff-3dd97285b143466099ecf4d1cd0740fcc727d814dde7b199e4a0a66782acab80R70-R74))
