### PR TITLE
Fix layer is missing in dynamic import with dynamic resource

### DIFF
--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -64,6 +64,7 @@ const makeSerializable = require("./util/makeSerializable");
  * @property {string=} typePrefix
  * @property {string=} category
  * @property {string[][]=} referencedExports exports referenced from modules (won't be mangled)
+ * @property {string=} layer
  */
 
 /**
@@ -107,8 +108,9 @@ class ContextModule extends Module {
 			const resourceQuery = (options && options.resourceQuery) || parsed.query;
 			const resourceFragment =
 				(options && options.resourceFragment) || parsed.fragment;
+			const layer = options && options.layer;
 
-			super(JAVASCRIPT_MODULE_TYPE_DYNAMIC, resource);
+			super(JAVASCRIPT_MODULE_TYPE_DYNAMIC, resource, layer);
 			/** @type {ContextModuleOptions} */
 			this.options = {
 				...options,
@@ -117,7 +119,7 @@ class ContextModule extends Module {
 				resourceFragment
 			};
 		} else {
-			super(JAVASCRIPT_MODULE_TYPE_DYNAMIC);
+			super(JAVASCRIPT_MODULE_TYPE_DYNAMIC, undefined, options.layer);
 			/** @type {ContextModuleOptions} */
 			this.options = {
 				...options,

--- a/lib/ContextModuleFactory.js
+++ b/lib/ContextModuleFactory.js
@@ -95,6 +95,7 @@ module.exports = class ContextModuleFactory extends ModuleFactory {
 			{
 				context: context,
 				dependencies: dependencies,
+				layer: data.contextInfo.issuerLayer,
 				resolveOptions,
 				fileDependencies,
 				missingDependencies,

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -751,92 +751,92 @@ exports[`StatsTestCases should print correct stats for concat-and-sideeffects 1`
 `;
 
 exports[`StatsTestCases should print correct stats for context-independence 1`] = `
-"asset main-5a998235f48a10c7522b.js 12.8 KiB [emitted] [immutable] (name: main)
-  sourceMap main-5a998235f48a10c7522b.js.map 11.1 KiB [emitted] [dev] (auxiliary name: main)
+"asset main-6bdf116ffeb138753a9a.js 12.8 KiB [emitted] [immutable] (name: main)
+  sourceMap main-6bdf116ffeb138753a9a.js.map 11.1 KiB [emitted] [dev] (auxiliary name: main)
 asset 695-d9846ea7920868a759cd.js 455 bytes [emitted] [immutable]
   sourceMap 695-d9846ea7920868a759cd.js.map 347 bytes [emitted] [dev]
 runtime modules 6.61 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
-  modules by layer 234 bytes
-    ./a/c/ ./a/cc/ eager ^\\\\.\\\\/.*$ namespace object 198 bytes [built] [code generated]
-    ./a/c/a.js 18 bytes [optional] [built] [code generated]
-    ./a/cc/b.js 18 bytes [optional] [built] [code generated]
-  modules by layer (in Xdir/context-independence/a) 266 bytes
+  modules by path ./a/*.js 266 bytes
     ./a/index.js (in Xdir/context-independence/a) 200 bytes [built] [code generated]
     ./a/chunk.js + 1 modules (in Xdir/context-independence/a) 66 bytes [built] [code generated]
+  modules by path ./a/c/ 216 bytes
+    ./a/c/ ./a/cc/ eager ^\\\\.\\\\/.*$ namespace object (in Xdir/context-independence/a) 198 bytes [built] [code generated]
+    ./a/c/a.js (in Xdir/context-independence/a) 18 bytes [optional] [built] [code generated]
+  ./a/cc/b.js (in Xdir/context-independence/a) 18 bytes [optional] [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-5a998235f48a10c7522b.js 12.8 KiB [emitted] [immutable] (name: main)
-  sourceMap main-5a998235f48a10c7522b.js.map 11.1 KiB [emitted] [dev] (auxiliary name: main)
+asset main-6bdf116ffeb138753a9a.js 12.8 KiB [emitted] [immutable] (name: main)
+  sourceMap main-6bdf116ffeb138753a9a.js.map 11.1 KiB [emitted] [dev] (auxiliary name: main)
 asset 695-d9846ea7920868a759cd.js 455 bytes [emitted] [immutable]
   sourceMap 695-d9846ea7920868a759cd.js.map 347 bytes [emitted] [dev]
 runtime modules 6.61 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
-  modules by layer 234 bytes
-    ./b/c/ ./b/cc/ eager ^\\\\.\\\\/.*$ namespace object 198 bytes [built] [code generated]
-    ./b/c/a.js 18 bytes [optional] [built] [code generated]
-    ./b/cc/b.js 18 bytes [optional] [built] [code generated]
-  modules by layer (in Xdir/context-independence/b) 266 bytes
+  modules by path ./b/*.js 266 bytes
     ./b/index.js (in Xdir/context-independence/b) 200 bytes [built] [code generated]
     ./b/chunk.js + 1 modules (in Xdir/context-independence/b) 66 bytes [built] [code generated]
+  modules by path ./b/c/ 216 bytes
+    ./b/c/ ./b/cc/ eager ^\\\\.\\\\/.*$ namespace object (in Xdir/context-independence/b) 198 bytes [built] [code generated]
+    ./b/c/a.js (in Xdir/context-independence/b) 18 bytes [optional] [built] [code generated]
+  ./b/cc/b.js (in Xdir/context-independence/b) 18 bytes [optional] [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-21184090ed4ef75bcb88.js 14.9 KiB [emitted] [immutable] (name: main)
+asset main-0a98b6dc7990e85a9e88.js 14.9 KiB [emitted] [immutable] (name: main)
 asset 695-3a54289b6e0375f1e753.js 1.51 KiB [emitted] [immutable]
 runtime modules 6.61 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
-  modules by layer 234 bytes
-    ./a/c/ ./a/cc/ eager ^\\\\.\\\\/.*$ namespace object 198 bytes [built] [code generated]
-    ./a/c/a.js 18 bytes [optional] [built] [code generated]
-    ./a/cc/b.js 18 bytes [optional] [built] [code generated]
-  modules by layer (in Xdir/context-independence/a) 266 bytes
+  modules by path ./a/*.js 266 bytes
     ./a/index.js (in Xdir/context-independence/a) 200 bytes [built] [code generated]
     ./a/chunk.js + 1 modules (in Xdir/context-independence/a) 66 bytes [built] [code generated]
+  modules by path ./a/c/ 216 bytes
+    ./a/c/ ./a/cc/ eager ^\\\\.\\\\/.*$ namespace object (in Xdir/context-independence/a) 198 bytes [built] [code generated]
+    ./a/c/a.js (in Xdir/context-independence/a) 18 bytes [optional] [built] [code generated]
+  ./a/cc/b.js (in Xdir/context-independence/a) 18 bytes [optional] [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-21184090ed4ef75bcb88.js 14.9 KiB [emitted] [immutable] (name: main)
+asset main-0a98b6dc7990e85a9e88.js 14.9 KiB [emitted] [immutable] (name: main)
 asset 695-3a54289b6e0375f1e753.js 1.51 KiB [emitted] [immutable]
 runtime modules 6.61 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
-  modules by layer 234 bytes
-    ./b/c/ ./b/cc/ eager ^\\\\.\\\\/.*$ namespace object 198 bytes [built] [code generated]
-    ./b/c/a.js 18 bytes [optional] [built] [code generated]
-    ./b/cc/b.js 18 bytes [optional] [built] [code generated]
-  modules by layer (in Xdir/context-independence/b) 266 bytes
+  modules by path ./b/*.js 266 bytes
     ./b/index.js (in Xdir/context-independence/b) 200 bytes [built] [code generated]
     ./b/chunk.js + 1 modules (in Xdir/context-independence/b) 66 bytes [built] [code generated]
+  modules by path ./b/c/ 216 bytes
+    ./b/c/ ./b/cc/ eager ^\\\\.\\\\/.*$ namespace object (in Xdir/context-independence/b) 198 bytes [built] [code generated]
+    ./b/c/a.js (in Xdir/context-independence/b) 18 bytes [optional] [built] [code generated]
+  ./b/cc/b.js (in Xdir/context-independence/b) 18 bytes [optional] [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-bd73ac146ff966959dfc.js 13.8 KiB [emitted] [immutable] (name: main)
+asset main-691f05a68a2fe9729db1.js 13.8 KiB [emitted] [immutable] (name: main)
 asset 695-ace208366ce0ce2556ef.js 1.01 KiB [emitted] [immutable]
 runtime modules 6.61 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
-  modules by layer 234 bytes
-    ./a/c/ ./a/cc/ eager ^\\\\.\\\\/.*$ namespace object 198 bytes [built] [code generated]
-    ./a/c/a.js 18 bytes [optional] [built] [code generated]
-    ./a/cc/b.js 18 bytes [optional] [built] [code generated]
-  modules by layer (in Xdir/context-independence/a) 266 bytes
+  modules by path ./a/*.js 266 bytes
     ./a/index.js (in Xdir/context-independence/a) 200 bytes [built] [code generated]
     ./a/chunk.js + 1 modules (in Xdir/context-independence/a) 66 bytes [built] [code generated]
+  modules by path ./a/c/ 216 bytes
+    ./a/c/ ./a/cc/ eager ^\\\\.\\\\/.*$ namespace object (in Xdir/context-independence/a) 198 bytes [built] [code generated]
+    ./a/c/a.js (in Xdir/context-independence/a) 18 bytes [optional] [built] [code generated]
+  ./a/cc/b.js (in Xdir/context-independence/a) 18 bytes [optional] [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-bd73ac146ff966959dfc.js 13.8 KiB [emitted] [immutable] (name: main)
+asset main-691f05a68a2fe9729db1.js 13.8 KiB [emitted] [immutable] (name: main)
 asset 695-ace208366ce0ce2556ef.js 1.01 KiB [emitted] [immutable]
 runtime modules 6.61 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
-  modules by layer 234 bytes
-    ./b/c/ ./b/cc/ eager ^\\\\.\\\\/.*$ namespace object 198 bytes [built] [code generated]
-    ./b/c/a.js 18 bytes [optional] [built] [code generated]
-    ./b/cc/b.js 18 bytes [optional] [built] [code generated]
-  modules by layer (in Xdir/context-independence/b) 266 bytes
+  modules by path ./b/*.js 266 bytes
     ./b/index.js (in Xdir/context-independence/b) 200 bytes [built] [code generated]
     ./b/chunk.js + 1 modules (in Xdir/context-independence/b) 66 bytes [built] [code generated]
+  modules by path ./b/c/ 216 bytes
+    ./b/c/ ./b/cc/ eager ^\\\\.\\\\/.*$ namespace object (in Xdir/context-independence/b) 198 bytes [built] [code generated]
+    ./b/c/a.js (in Xdir/context-independence/b) 18 bytes [optional] [built] [code generated]
+  ./b/cc/b.js (in Xdir/context-independence/b) 18 bytes [optional] [built] [code generated]
 webpack x.x.x compiled successfully in X ms"
 `;
 

--- a/test/configCases/layer/rules/dynamic-module-layer.js
+++ b/test/configCases/layer/rules/dynamic-module-layer.js
@@ -1,0 +1,13 @@
+async function main(name) {
+  const { object: dynamicModuleObject } = await import(`./dynamic/${name}`);
+  return dynamicModuleObject;
+}
+
+export const object = {
+  name: 'module entry',
+  layer: __webpack_layer__,
+  modules: [
+    main('module1'),
+    main('module2'),
+  ]
+};

--- a/test/configCases/layer/rules/dynamic/module1.js
+++ b/test/configCases/layer/rules/dynamic/module1.js
@@ -1,0 +1,4 @@
+export const object = {
+  name: 'module1',
+  layer: __webpack_layer__,
+};

--- a/test/configCases/layer/rules/dynamic/module2.js
+++ b/test/configCases/layer/rules/dynamic/module2.js
@@ -1,0 +1,4 @@
+export const object = {
+  name: 'module2',
+  layer: __webpack_layer__
+};

--- a/test/configCases/layer/rules/index.js
+++ b/test/configCases/layer/rules/index.js
@@ -14,6 +14,8 @@ import { direct as otherLayerDirect } from "./module-other-layer-change";
 import { reexported as otherLayerReexported } from "./module-other-layer-change";
 import { __loaderValue as otherLayerValue } from "./module-other-layer-change";
 
+import { object as dynamicModules } from "./dynamic-module-layer"
+
 it("should allow to duplicate modules with layers", () => {
 	expect(direct).toBe(reexported);
 	expect(layerDirect).toBe(layerReexported);
@@ -36,3 +38,10 @@ it("apply externals based on layer", () => {
 	expect(layerExternal1).toBe(43);
 	expect(layerExternal2).toBe(43);
 });
+
+it("apply layer for dynamic imports with dynamic resources", async () => {
+	const mods = await Promise.all(dynamicModules.modules)
+	expect(dynamicModules.layer).toBe('dynamic-layer')
+	expect(mods[0]).toMatchObject({ layer: 'dynamic-layer', name: 'module1' })
+	expect(mods[1]).toMatchObject({ layer: 'dynamic-layer', name: 'module2' })
+})

--- a/test/configCases/layer/rules/webpack.config.js
+++ b/test/configCases/layer/rules/webpack.config.js
@@ -42,6 +42,10 @@ module.exports = {
 				options: {
 					value: "entry"
 				}
+			},
+			{
+				test: /dynamic-module-layer/,
+				layer: "dynamic-layer"
 			}
 		]
 	},

--- a/types.d.ts
+++ b/types.d.ts
@@ -2682,6 +2682,7 @@ declare interface ContextModuleOptions {
 	 * exports referenced from modules (won't be mangled)
 	 */
 	referencedExports?: string[][];
+	layer?: string;
 	resource: string | false | string[];
 	resourceQuery?: string;
 	resourceFragment?: string;


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

When you're using dynamic import with dynamic resource name with feature `layers` enabled, the dynamic imported files didn't inherit with the parent layer

related issue on next.js side: https://github.com/vercel/next.js/issues/49382

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8422d51</samp>

This pull request adds support for layers in `ContextModule` and tests the feature with different scenarios of dynamic imports and resources. It also adds a new rule to the webpack configuration file for assigning modules to layers based on their names.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8422d51</samp>

*  Add `layer` property to `ContextModule` class and its serialization and deserialization methods ([link](https://github.com/webpack/webpack/pull/17310/files?diff=unified&w=0#diff-7381096418ac5ce93b8514a7bf323d891937e3fdabda8628d8bbc0ce46f6db10R67), [link](https://github.com/webpack/webpack/pull/17310/files?diff=unified&w=0#diff-7381096418ac5ce93b8514a7bf323d891937e3fdabda8628d8bbc0ce46f6db10L110-R113), [link](https://github.com/webpack/webpack/pull/17310/files?diff=unified&w=0#diff-7381096418ac5ce93b8514a7bf323d891937e3fdabda8628d8bbc0ce46f6db10L120-R122))
*  Set `layer` property of `data` object in `ContextModuleFactory` class from `contextInfo` object populated by `ContextDependency` class ([link](https://github.com/webpack/webpack/pull/17310/files?diff=unified&w=0#diff-07b3ce5a333eb3bc0650c8b9cb8895a187dcccde5c400f2f1971dddc73045d62R98))
*  Add new rule to webpack configuration file to assign `dynamic-layer` layer to files matching `dynamic-module-layer` in name (`test/configCases/layer/rules/webpack.config.js`, [link](https://github.com/webpack/webpack/pull/17310/files?diff=unified&w=0#diff-d27e4051caa2959f1c291b6a458774f9524f7aac9e476de45a335fbb22117833R45-R48))
*  Add new test case file `dynamic-module-layer.js` to export an object with name, layer, and modules properties, where modules is an array of promises resolving to dynamic modules imported with dynamic resources (`test/configCases/layer/rules/dynamic-module-layer.js`, [link](https://github.com/webpack/webpack/pull/17310/files?diff=unified&w=0#diff-eb9f0b99bcb4dc6773547f3006133b40ddd66d608f149f5db2e8e42f61769ab8L1-R12))
*  Add new test case files `module1.js` and `module2.js` to export objects with name and layer properties, where layer is a special variable `__webpack_layer__` replaced by webpack at runtime (`test/configCases/layer/rules/dynamic/module1.js`, [link](https://github.com/webpack/webpack/pull/17310/files?diff=unified&w=0#diff-d8522eed6108fa14371144db5026ba9662b6ae15cda99fd6cd8cc685de35124eL1-R3); `test/configCases/layer/rules/dynamic/module2.js`, [link](https://github.com/webpack/webpack/pull/17310/files?diff=unified&w=0#diff-82624c4d866be0d787b8f1ca1ac544037f80d884d03b992c3479001bb94c8096L1-R3))
*  Import object from `dynamic-module-layer.js` and add new test case to assert that layer property of object and dynamic modules match `dynamic-layer` (`test/configCases/layer/rules/index.js`, [link](https://github.com/webpack/webpack/pull/17310/files?diff=unified&w=0#diff-17fc094c802df96eed6bbf42f47eab6ac480998d872400e906f148f1fe1f0f6cR17-R18), [link](https://github.com/webpack/webpack/pull/17310/files?diff=unified&w=0#diff-17fc094c802df96eed6bbf42f47eab6ac480998d872400e906f148f1fe1f0f6cR41-R47))
