### PR TITLE
feat: support passing `RegExp` to `splitChunks.chunks`

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -1782,7 +1782,7 @@ export interface OptimizationSplitChunksOptions {
 	 */
 	chunks?:
 		| ("initial" | "async" | "all")
-		| ((chunk: import("../lib/Chunk")) => boolean);
+		| ((chunk: import("../lib/Chunk")) => boolean) | RegExp;
 	/**
 	 * Sets the size types which are used when a number is used for sizes.
 	 */
@@ -1804,7 +1804,7 @@ export interface OptimizationSplitChunksOptions {
 		 */
 		chunks?:
 			| ("initial" | "async" | "all")
-			| ((chunk: import("../lib/Chunk")) => boolean);
+			| ((chunk: import("../lib/Chunk")) => boolean) | RegExp;
 		/**
 		 * Maximal size hint for the on-demand chunks.
 		 */
@@ -1897,7 +1897,7 @@ export interface OptimizationSplitChunksCacheGroup {
 	 */
 	chunks?:
 		| ("initial" | "async" | "all")
-		| ((chunk: import("../lib/Chunk")) => boolean);
+		| ((chunk: import("../lib/Chunk")) => boolean) | RegExp;
 	/**
 	 * Ignore minimum size, minimum chunks and maximum requests and always create chunks for this cache group.
 	 */

--- a/lib/optimize/SplitChunksPlugin.js
+++ b/lib/optimize/SplitChunksPlugin.js
@@ -424,6 +424,11 @@ const normalizeChunksFilter = chunks => {
 	if (chunks === "all") {
 		return ALL_CHUNK_FILTER;
 	}
+	if (chunks instanceof RegExp) {
+		return chunk => {
+			return chunk.name ? chunks.test(chunk.name) : false;
+		};
+	}
 	if (typeof chunks === "function") {
 		return chunks;
 	}

--- a/types.d.ts
+++ b/types.d.ts
@@ -8691,7 +8691,7 @@ declare interface OptimizationSplitChunksCacheGroup {
 	/**
 	 * Select chunks for determining cache group content (defaults to "initial", "initial" and "all" requires adding these chunks to the HTML).
 	 */
-	chunks?: "all" | "initial" | "async" | ((chunk: Chunk) => boolean);
+	chunks?: "all" | "initial" | "async" | ((chunk: Chunk) => boolean) | RegExp;
 
 	/**
 	 * Ignore minimum size, minimum chunks and maximum requests and always create chunks for this cache group.
@@ -8818,7 +8818,7 @@ declare interface OptimizationSplitChunksOptions {
 	/**
 	 * Select chunks for determining shared modules (defaults to "async", "initial" and "all" requires adding these chunks to the HTML).
 	 */
-	chunks?: "all" | "initial" | "async" | ((chunk: Chunk) => boolean);
+	chunks?: "all" | "initial" | "async" | ((chunk: Chunk) => boolean) | RegExp;
 
 	/**
 	 * Sets the size types which are used when a number is used for sizes.


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

- support passing `RegExp` on `splitChunks.chunks`, `splitChunks.{cacheGroup}.chunks` and `splitChunks.fallbackCacheGroup.chunks`

<!-- cspell:disable-next-line -->

copilot:summary

## Details

<!-- cspell:disable-next-line -->

copilot:walkthrough
