### PR TITLE
Add experimental option to skip loader options schema checking

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -581,7 +581,7 @@ class NormalModule extends Module {
 					options = {};
 				}
 
-				if (schema) {
+				if (schema && !compilation.options.skipLoaderOptionsSchemaChecking) {
 					let name = "Loader";
 					let baseDataPath = "options";
 					let match;

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -833,6 +833,10 @@
           "description": "Allow output javascript files as module source type.",
           "type": "boolean"
         },
+        "skipLoaderOptionsSchemaChecking": {
+          "description": "Skip schema checking of loader options which can be expensive.",
+          "type": "boolean"
+        },
         "syncWebAssembly": {
           "description": "Support WebAssembly as synchronous EcmaScript Module (outdated).",
           "type": "boolean"


### PR DESCRIPTION
Found this saves quite a bit of time for each call to the loader, but especially the first time as it skips loading ajv

<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

copilot:summary

## Details

<!-- cspell:disable-next-line -->

copilot:walkthrough
