### PR TITLE
fix: use codecov badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,5 +714,5 @@ src="https://static.monei.net/monei-logo.svg" height="30" alt="MONEI"></a>
 [builds2-url]: https://dev.azure.com/webpack/webpack/_build/latest?definitionId=3
 [licenses-url]: https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack%2Fwebpack?ref=badge_shield
 [licenses]: https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack%2Fwebpack.svg?type=shield
-[cover]: https://img.shields.io/coveralls/webpack/webpack.svg
-[cover-url]: https://coveralls.io/r/webpack/webpack/
+[cover]: https://codecov.io/gh/webpack/webpack/branch/master/graph/badge.svg?token=mDP3mQJNnn
+[cover-url]: https://codecov.io/gh/webpack/webpack


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

Fixed the badge to use codecov

<img width="585" alt="image" src="https://github.com/webpack/webpack/assets/25934701/e8474beb-62aa-4b3e-b647-784771c80cb7">


<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad71e55</samp>

Updated code coverage tool and badge in `README.md`. Replaced coveralls with codecov for more accurate and reliable coverage reports.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ad71e55</samp>

* Migrate code coverage tool from coveralls to codecov ([link](https://github.com/webpack/webpack/pull/17353/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L717-R718),                             F29L3R
