### PR TITLE
docs: add link to svelte loader for webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ or are automatically applied via regex from your webpack configuration.
 |   <a href="https://github.com/webpack-contrib/polymer-webpack-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/polymer.svg"></a>   | ![polymer-npm] | ![polymer-size] | Process HTML & CSS with preprocessor of choice and `require()` Web Components like first-class modules |
 | <a href="https://github.com/TheLarkInn/angular2-template-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/angular-icon-1.svg"></a> | ![angular-npm] | ![angular-size] | Loads and compiles Angular 2 Components                                                                |
 |              <a href="https://github.com/riot/webpack-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/riot.svg"></a>              |  ![riot-npm]   |  ![riot-size]   | Riot official webpack loader                                                                           |
+|          <a href="https://github.com/sveltejs/svelte-loader"><img width="48" height="48" src="https://worldvectorlogo.com/logos/svelte-1.svg"></a>           | ![svelte-npm]  | ![svelte-size]  | Official Svelte loader                                                                                 |
 
 [vue-npm]: https://img.shields.io/npm/v/vue-loader.svg
 [vue-size]: https://packagephobia.com/badge?p=vue-loader
@@ -241,6 +242,8 @@ or are automatically applied via regex from your webpack configuration.
 [angular-size]: https://packagephobia.com/badge?p=angular2-template-loader
 [riot-npm]: https://img.shields.io/npm/v/riot-tag-loader.svg
 [riot-size]: https://packagephobia.com/badge?p=riot-tag-loader
+[svelte-npm]: https://img.shields.io/npm/v/svelte-loader.svg
+[svelte-size]: https://packagephobia.com/badge?p=svelte-loader
 
 ### Performance
 


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6216d6d</samp>

This pull request adds support for the Svelte framework by introducing the `svelte-loader` in the `README.md` file. It also updates the documentation with the relevant badges for the loader.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6216d6d</samp>

*  Add svelte-loader to the list of supported frameworks in `README.md` ([link](https://github.com/webpack/webpack/pull/17369/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R235), [link](https://github.com/webpack/webpack/pull/17369/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R245-R246))
