### PR TITLE
fix: indirect call for tagged template expressions

### DIFF
--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -204,6 +204,7 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 				dep.directImport = true;
 				dep.asiSafe = !parser.isAsiPosition(expr.range[0]);
 				dep.loc = expr.loc;
+				dep.call = parser.scope.inTaggedTemplateTag;
 				parser.state.module.addDependency(dep);
 				InnerGraph.onUsage(parser.state, e => (dep.usedByExports = e));
 				return true;

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -132,9 +132,10 @@ class VariableInfo {
  * @property {StackedMap<string, VariableInfo | ScopeInfo>} definitions
  * @property {boolean | "arrow"} topLevelScope
  * @property {boolean | string} inShorthand
+ * @property {boolean} inTaggedTemplateTag
+ * @property {boolean} inTry
  * @property {boolean} isStrict
  * @property {boolean} isAsmJs
- * @property {boolean} inTry
  */
 
 /** @typedef {[number, number]} Range */
@@ -3126,7 +3127,9 @@ class JavascriptParser extends Parser {
 	 */
 	walkTaggedTemplateExpression(expression) {
 		if (expression.tag) {
+			this.scope.inTaggedTemplateTag = true;
 			this.walkExpression(expression.tag);
+			this.scope.inTaggedTemplateTag = false;
 		}
 		if (expression.quasi && expression.quasi.expressions) {
 			this.walkExpressions(expression.quasi.expressions);
@@ -3588,6 +3591,7 @@ class JavascriptParser extends Parser {
 			topLevelScope: oldScope.topLevelScope,
 			inTry: false,
 			inShorthand: false,
+			inTaggedTemplateTag: false,
 			isStrict: oldScope.isStrict,
 			isAsmJs: oldScope.isAsmJs,
 			definitions: oldScope.definitions.createChild()
@@ -3616,6 +3620,7 @@ class JavascriptParser extends Parser {
 			topLevelScope: oldScope.topLevelScope,
 			inTry: false,
 			inShorthand: false,
+			inTaggedTemplateTag: false,
 			isStrict: oldScope.isStrict,
 			isAsmJs: oldScope.isAsmJs,
 			definitions: oldScope.definitions.createChild()
@@ -3646,6 +3651,7 @@ class JavascriptParser extends Parser {
 			topLevelScope: oldScope.topLevelScope,
 			inTry: false,
 			inShorthand: false,
+			inTaggedTemplateTag: false,
 			isStrict: oldScope.isStrict,
 			isAsmJs: oldScope.isAsmJs,
 			definitions: oldScope.definitions.createChild()
@@ -3674,6 +3680,7 @@ class JavascriptParser extends Parser {
 			topLevelScope: oldScope.topLevelScope,
 			inTry: oldScope.inTry,
 			inShorthand: false,
+			inTaggedTemplateTag: false,
 			isStrict: oldScope.isStrict,
 			isAsmJs: oldScope.isAsmJs,
 			definitions: oldScope.definitions.createChild()
@@ -3963,6 +3970,7 @@ class JavascriptParser extends Parser {
 			topLevelScope: true,
 			inTry: false,
 			inShorthand: false,
+			inTaggedTemplateTag: false,
 			isStrict: false,
 			isAsmJs: false,
 			definitions: new StackedMap()

--- a/test/cases/indirect-call/call/dep.js
+++ b/test/cases/indirect-call/call/dep.js
@@ -1,0 +1,3 @@
+export default function dep() {
+	return this;
+};

--- a/test/cases/indirect-call/call/index.js
+++ b/test/cases/indirect-call/call/index.js
@@ -1,0 +1,10 @@
+import a from "./dep.js"
+
+const global = a();
+
+it("should generate indirect call", () => {
+	expect(a()).toBeUndefined();
+	expect((a)()).toBeUndefined();
+	expect((a())).toBeUndefined();
+	expect(global).toBeUndefined();
+});

--- a/test/cases/indirect-call/tagged-template-expression/dep.js
+++ b/test/cases/indirect-call/tagged-template-expression/dep.js
@@ -1,0 +1,3 @@
+export default function dep() {
+	return this;
+};

--- a/test/cases/indirect-call/tagged-template-expression/dep1.js
+++ b/test/cases/indirect-call/tagged-template-expression/dep1.js
@@ -1,0 +1,5 @@
+export default function dep() {
+	return () => {
+		return this;
+	};
+};

--- a/test/cases/indirect-call/tagged-template-expression/index.js
+++ b/test/cases/indirect-call/tagged-template-expression/index.js
@@ -1,0 +1,12 @@
+import a from "./dep.js"
+import b from "./dep1.js"
+
+const global = a``;
+
+it("should generate indirect call", () => {
+	expect(a``).toBeUndefined();
+	expect(a`${{a}}`).toBeUndefined();
+	expect((a)``).toBeUndefined();
+	expect(b()``).toBeUndefined();
+	expect(global).toBeUndefined();
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -11653,9 +11653,10 @@ declare interface ScopeInfo {
 	definitions: StackedMap<string, ScopeInfo | VariableInfo>;
 	topLevelScope: boolean | "arrow";
 	inShorthand: string | boolean;
+	inTaggedTemplateTag: boolean;
+	inTry: boolean;
 	isStrict: boolean;
 	isAsmJs: boolean;
-	inTry: boolean;
 }
 declare interface Selector<A, B> {
 	(input: A): B;


### PR DESCRIPTION
fixes https://github.com/webpack/webpack/issues/17390

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7515141</samp>

This pull request adds a feature that allows indirect calls to imported modules, such as `(import("module"))()` or `import("module")``. It introduces a new scope flag `inTaggedTemplateTag` to the `JavascriptParser` class, and a new property `call` to the `HarmonyImportDependency` class. It also adds test cases for various scenarios of indirect calls in the `test/cases/indirect-call` folder.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7515141</samp>

*  Add support for indirect calls to imported modules ([link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-7f2abd7b8a95b9356fbe87f124e363afd555eec6001ead1dac148ad4a0f84198R207), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L135-R138), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L3129-R3132), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R3594), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R3623), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R3654), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R3683), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R3973))
  * Add a `call` property to `HarmonyImportDependency` to indicate whether the import is called as a function or a tagged template expression ([link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-7f2abd7b8a95b9356fbe87f124e363afd555eec6001ead1dac148ad4a0f84198R207))
  * Add an `inTaggedTemplateTag` property to `VariableInfo` and `parser.scope` to track the scope of tagged template expressions ([link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L135-R138), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R3594), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R3623), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R3654), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R3683), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2R3973))
  * Set and reset the `parser.scope.inTaggedTemplateTag` flag when walking the tag expression of a tagged template expression in `walkTaggedTemplateExpression` ([link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L3129-R3132))
* Add test cases for indirect calls to imported modules in `test/cases/indirect-call` ([link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-93880ef7bf0978f2b86180f58b65eb500eeba26e033471abc07819e780cc0e86R1-R3), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-969b013e7e1ca64a5ebe14b53e36edf5767fc3f7582bbce7829ca4cd69d8e430R1-R10), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-6e00a043007e89dca71060e4672b7912f2a659ca902b68891104b6a7c08cac45R1-R3), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-2acf2122a8d483f8e172897f59b15157ab57d9e314e6a6ebf2e1e5283a45ed12R1-R5), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-61a3c98fb8388051c9ec876bfbd26ae9fccb122ab2c8229a616188b3ae68bba5R1-R12))
  * Add `dep.js` and `index.js` in `test/cases/indirect-call/call` to test calling imported functions as regular functions ([link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-93880ef7bf0978f2b86180f58b65eb500eeba26e033471abc07819e780cc0e86R1-R3), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-969b013e7e1ca64a5ebe14b53e36edf5767fc3f7582bbce7829ca4cd69d8e430R1-R10))
  * Add `dep.js`, `dep1.js` and `index.js` in `test/cases/indirect-call/tagged-template-expression` to test calling imported functions as tagged template expressions ([link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-6e00a043007e89dca71060e4672b7912f2a659ca902b68891104b6a7c08cac45R1-R3), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-2acf2122a8d483f8e172897f59b15157ab57d9e314e6a6ebf2e1e5283a45ed12R1-R5), [link](https://github.com/webpack/webpack/pull/17397/files?diff=unified&w=0#diff-61a3c98fb8388051c9ec876bfbd26ae9fccb122ab2c8229a616188b3ae68bba5R1-R12))
