### PR TITLE
fix: update terser and the plugin to fix perf regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "neo-async": "^2.6.2",
     "schema-utils": "^3.2.0",
     "tapable": "^2.1.1",
-    "terser-webpack-plugin": "^5.3.7",
+    "terser-webpack-plugin": "^5.3.9",
     "watchpack": "^2.4.0",
     "webpack-sources": "^3.2.3"
   },
@@ -95,7 +95,7 @@
     "simple-git": "^3.17.0",
     "strip-ansi": "^6.0.0",
     "style-loader": "^2.0.0",
-    "terser": "^5.17.0",
+    "terser": "^5.18.1",
     "toml": "^3.0.0",
     "tooling": "webpack/tooling#v1.23.0",
     "ts-loader": "^9.4.2",

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -2728,7 +2728,7 @@ LOG from webpack.FileSystemInfo
 exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
 "a-normal:
   assets by path *.js 3.23 KiB
-    asset 48e1a25a11a7b9397e41-48e1a2.js 2.77 KiB [emitted] [immutable] [minimized] (name: runtime)
+    asset b7437eb81cc90a5539f0-b7437e.js 2.77 KiB [emitted] [immutable] [minimized] (name: runtime)
     asset f96e917feecf51c4fc5c-f96e91.js 232 bytes [emitted] [immutable] [minimized] (name: lazy)
     asset f17033ffbf027f2d71b7-f17033.js 212 bytes [emitted] [immutable] [minimized] (name: index)
     asset 666f2b8847021ccc7608-666f2b.js 21 bytes [emitted] [immutable] [minimized] (name: a, b)
@@ -2736,7 +2736,7 @@ exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
     asset 7382fad5b015914e0811.jpg?query 5.89 KiB [cached] [immutable] [from: file.jpg?query] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: index)
-  Entrypoint index 2.98 KiB (5.89 KiB) = 48e1a25a11a7b9397e41-48e1a2.js 2.77 KiB f17033ffbf027f2d71b7-f17033.js 212 bytes 1 auxiliary asset
+  Entrypoint index 2.98 KiB (5.89 KiB) = b7437eb81cc90a5539f0-b7437e.js 2.77 KiB f17033ffbf027f2d71b7-f17033.js 212 bytes 1 auxiliary asset
   Entrypoint a 21 bytes = 666f2b8847021ccc7608-666f2b.js
   Entrypoint b 21 bytes = 666f2b8847021ccc7608-666f2b.js
   runtime modules 7.34 KiB 9 modules
@@ -2755,7 +2755,7 @@ exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
 
 b-normal:
   assets by path *.js 3.23 KiB
-    asset f64fdaf8571eaf5e2680-f64fda.js 2.77 KiB [emitted] [immutable] [minimized] (name: runtime)
+    asset c145af2be45ae24fde2e-c145af.js 2.77 KiB [emitted] [immutable] [minimized] (name: runtime)
     asset f96e917feecf51c4fc5c-f96e91.js 232 bytes [emitted] [immutable] [minimized] (name: lazy)
     asset f17033ffbf027f2d71b7-f17033.js 212 bytes [emitted] [immutable] [minimized] (name: index)
     asset 666f2b8847021ccc7608-666f2b.js 21 bytes [emitted] [immutable] [minimized] (name: a, b)
@@ -2763,7 +2763,7 @@ b-normal:
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
     asset 7382fad5b015914e0811.jpg?query 5.89 KiB [cached] [immutable] [from: file.jpg?query] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: index)
-  Entrypoint index 2.98 KiB (5.89 KiB) = f64fdaf8571eaf5e2680-f64fda.js 2.77 KiB f17033ffbf027f2d71b7-f17033.js 212 bytes 1 auxiliary asset
+  Entrypoint index 2.98 KiB (5.89 KiB) = c145af2be45ae24fde2e-c145af.js 2.77 KiB f17033ffbf027f2d71b7-f17033.js 212 bytes 1 auxiliary asset
   Entrypoint a 21 bytes = 666f2b8847021ccc7608-666f2b.js
   Entrypoint b 21 bytes = 666f2b8847021ccc7608-666f2b.js
   runtime modules 7.34 KiB 9 modules
@@ -2782,8 +2782,8 @@ b-normal:
 
 a-source-map:
   assets by path *.js 3.44 KiB
-    asset 018715e3bf7c960ef754-018715.js 2.83 KiB [emitted] [immutable] [minimized] (name: runtime)
-      sourceMap 018715e3bf7c960ef754-018715.js.map 14.7 KiB [emitted] [dev] (auxiliary name: runtime)
+    asset e1bac0f66c401917d379-e1bac0.js 2.83 KiB [emitted] [immutable] [minimized] (name: runtime)
+      sourceMap e1bac0f66c401917d379-e1bac0.js.map 14.7 KiB [emitted] [dev] (auxiliary name: runtime)
     asset 0a8aef384737d9f64f44-0a8aef.js 288 bytes [emitted] [immutable] [minimized] (name: lazy)
       sourceMap 0a8aef384737d9f64f44-0a8aef.js.map 409 bytes [emitted] [dev] (auxiliary name: lazy)
     asset da629d4acf5998c06668-da629d.js 268 bytes [emitted] [immutable] [minimized] (name: index)
@@ -2794,7 +2794,7 @@ a-source-map:
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
     asset 7382fad5b015914e0811.jpg?query 5.89 KiB [cached] [immutable] [from: file.jpg?query] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: index)
-  Entrypoint index 3.09 KiB (20.9 KiB) = 018715e3bf7c960ef754-018715.js 2.83 KiB da629d4acf5998c06668-da629d.js 268 bytes 3 auxiliary assets
+  Entrypoint index 3.09 KiB (20.9 KiB) = e1bac0f66c401917d379-e1bac0.js 2.83 KiB da629d4acf5998c06668-da629d.js 268 bytes 3 auxiliary assets
   Entrypoint a 77 bytes (254 bytes) = 222c2acc68675174e6b2-222c2a.js 1 auxiliary asset
   Entrypoint b 77 bytes (254 bytes) = 222c2acc68675174e6b2-222c2a.js 1 auxiliary asset
   runtime modules 7.34 KiB 9 modules
@@ -2813,8 +2813,8 @@ a-source-map:
 
 b-source-map:
   assets by path *.js 3.44 KiB
-    asset 487b2e232adae9b3ff8b-487b2e.js 2.83 KiB [emitted] [immutable] [minimized] (name: runtime)
-      sourceMap 487b2e232adae9b3ff8b-487b2e.js.map 14.7 KiB [emitted] [dev] (auxiliary name: runtime)
+    asset c456a6bf36a9ae130b4e-c456a6.js 2.83 KiB [emitted] [immutable] [minimized] (name: runtime)
+      sourceMap c456a6bf36a9ae130b4e-c456a6.js.map 14.7 KiB [emitted] [dev] (auxiliary name: runtime)
     asset 0a8aef384737d9f64f44-0a8aef.js 288 bytes [emitted] [immutable] [minimized] (name: lazy)
       sourceMap 0a8aef384737d9f64f44-0a8aef.js.map 405 bytes [emitted] [dev] (auxiliary name: lazy)
     asset da629d4acf5998c06668-da629d.js 268 bytes [emitted] [immutable] [minimized] (name: index)
@@ -2825,7 +2825,7 @@ b-source-map:
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
     asset 7382fad5b015914e0811.jpg?query 5.89 KiB [cached] [immutable] [from: file.jpg?query] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: index)
-  Entrypoint index 3.09 KiB (20.9 KiB) = 487b2e232adae9b3ff8b-487b2e.js 2.83 KiB da629d4acf5998c06668-da629d.js 268 bytes 3 auxiliary assets
+  Entrypoint index 3.09 KiB (20.9 KiB) = c456a6bf36a9ae130b4e-c456a6.js 2.83 KiB da629d4acf5998c06668-da629d.js 268 bytes 3 auxiliary assets
   Entrypoint a 77 bytes (254 bytes) = 222c2acc68675174e6b2-222c2a.js 1 auxiliary asset
   Entrypoint b 77 bytes (254 bytes) = 222c2acc68675174e6b2-222c2a.js 1 auxiliary asset
   runtime modules 7.34 KiB 9 modules

--- a/yarn.lock
+++ b/yarn.lock
@@ -969,7 +969,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
 
-"@jridgewell/source-map@^0.3.2":
+"@jridgewell/source-map@^0.3.2", "@jridgewell/source-map@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.3.tgz#8108265659d4c33e72ffe14e33d6cc5eb59f2fda"
   integrity sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==
@@ -1421,7 +1421,7 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.5.0, acorn@^8.7.1, acorn@^8.8.0:
+acorn@^8.5.0, acorn@^8.7.1, acorn@^8.8.0, acorn@^8.8.2:
   version "8.9.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.9.0.tgz#78a16e3b2bcc198c10822786fa6679e245db5b59"
   integrity sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==
@@ -5924,24 +5924,24 @@ tempy@^3.0.0:
     type-fest "^2.12.2"
     unique-string "^3.0.0"
 
-terser-webpack-plugin@^5.3.7:
-  version "5.3.7"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz#ef760632d24991760f339fe9290deb936ad1ffc7"
-  integrity sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==
+terser-webpack-plugin@^5.3.9:
+  version "5.3.9"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz#832536999c51b46d468067f9e37662a3b96adfe1"
+  integrity sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.17"
     jest-worker "^27.4.5"
     schema-utils "^3.1.1"
     serialize-javascript "^6.0.1"
-    terser "^5.16.5"
+    terser "^5.16.8"
 
-terser@^5.16.5, terser@^5.17.0, terser@^5.6.1:
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.17.0.tgz#2b1bc90b5917e09ecffbcd2ff911f6922a4f5743"
-  integrity sha512-3die3+pYW4mta4xF6K8Wtf7id8+oYyfqtAhjwzqY01+CfDSDMx/VA1Sp8sXWs5AVNIoAKoUfmp/gnPqRjBxuDA==
+terser@^5.16.8, terser@^5.18.1, terser@^5.6.1:
+  version "5.18.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.18.1.tgz#6d8642508ae9fb7b48768e48f16d675c89a78460"
+  integrity sha512-j1n0Ao919h/Ai5r43VAnfV/7azUYW43GPxK7qSATzrsERfW7+y2QW9Cp9ufnRF5CQUWbnLSo7UJokSWCqg4tsQ==
   dependencies:
-    "@jridgewell/source-map" "^0.3.2"
-    acorn "^8.5.0"
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.8.2"
     commander "^2.20.0"
     source-map-support "~0.5.20"
 


### PR DESCRIPTION
Fixes https://github.com/webpack/webpack/issues/17322

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c3fb09</samp>

This pull request improves code minification and optimization by upgrading `terser` and `terser-webpack-plugin` in `package.json`. This fixes some bugs and boosts performance.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c3fb09</samp>

* Update the `terser` and `terser-webpack-plugin` dependencies to the latest versions ([link](https://github.com/webpack/webpack/pull/17405/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L29-R29), [link](https://github.com/webpack/webpack/pull/17405/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L98-R98))
