### PR TITLE
docs: add example for stats detailed  output

### DIFF
--- a/examples/stats-detailed/README.md
+++ b/examples/stats-detailed/README.md
@@ -1,0 +1,83 @@
+This configuration will enable the detailed output for the stats report.
+
+You see that everything is working nicely together.
+
+# example.js
+
+```javascript
+console.log("Hello World!");
+```
+
+# webpack.config.js
+
+```javascript
+const path = require("path");
+
+module.exports = {
+    output: {
+		path: path.join(__dirname, "dist"),
+		filename: "output.js"
+	},
+	stats: "detailed"
+};
+```
+
+# dist/output.js
+
+```javascript
+/******/ (() => { // webpackBootstrap
+var __webpack_exports__ = {};
+/*!********************!*\
+  !*** ./example.js ***!
+  \********************/
+/*! unknown exports (runtime-defined) */
+/*! runtime requirements:  */
+console.log("Hello World!");
+
+/******/ })()
+;
+```
+
+# Info
+
+## Production mode
+
+```
+PublicPath: dist/
+asset output.js 28 bytes {179} [emitted] [minimized] (name: main)
+Entrypoint main 28 bytes = output.js
+chunk {179} (runtime: main) output.js (main) 29 bytes [entry] [rendered]
+  > ./example.js main
+./example.js [144] 29 bytes {179} [depth 0] [built] [code generated]
+  [no exports used]
+  Statement (ExpressionStatement) with side effects in source code at 1:0-28
+  ModuleConcatenation bailout: Module is not an ECMAScript module
+
+LOG from webpack.Compilation
+    1 modules hashed, 0 from cache (1 variants per module in average)
+    100% code generated (1 generated, 0 from cache)
++ 24 hidden lines
+
+LOG from webpack.FlagDependencyExportsPlugin
+    0% of exports of modules have been determined (1 no declared exports, 0 not cached, 0 flagged uncacheable, 0 from cache, 0 from mem cache, 0 additional calculations due to dependencies)
++ 3 hidden lines
+
+LOG from webpack.buildChunkGraph
+    2 queue items processed (1 blocks)
+    0 chunk groups connected
+    0 chunk groups processed for merging (0 module sets, 0 forked, 0 + 0 modules forked, 0 + 0 modules merged into fork, 0 resulting modules)
+    0 chunk group info updated (0 already connected chunk groups reconnected)
++ 5 hidden lines
+
+LOG from webpack.FileSystemInfo
+    1 new snapshots created
+    0% root snapshot uncached (0 / 0)
+    0% children snapshot uncached (0 / 0)
+    0 entries tested
+    File info in cache: 1 timestamps 1 hashes 1 timestamp hash combinations
+    File timestamp hash combination snapshot optimization: 0% (0/1) entries shared via 0 shared snapshots (0 times referenced)
+    Directory info in cache: 0 timestamps 0 hashes 0 timestamp hash combinations
+    Managed items info in cache: 0 items
+
+2023-06-23 22:57:08: webpack 5.88.0 compiled successfully (208f5e6e78a48d3e157f)
+```

--- a/examples/stats-detailed/build.js
+++ b/examples/stats-detailed/build.js
@@ -1,0 +1,4 @@
+global.NO_REASONS = true;
+global.NO_STATS_OPTIONS = true;
+global.STATS_COLORS = true;
+require("../build-common");

--- a/examples/stats-detailed/example.js
+++ b/examples/stats-detailed/example.js
@@ -1,0 +1,1 @@
+console.log("Hello World!");

--- a/examples/stats-detailed/template.md
+++ b/examples/stats-detailed/template.md
@@ -1,0 +1,29 @@
+This configuration will enable the detailed output for the stats report.
+
+You see that everything is working nicely together.
+
+# example.js
+
+```javascript
+_{{example.js}}_
+```
+
+# webpack.config.js
+
+```javascript
+_{{webpack.config.js}}_
+```
+
+# dist/output.js
+
+```javascript
+_{{dist/output.js}}_
+```
+
+# Info
+
+## Production mode
+
+```
+_{{production:stdout}}_
+```

--- a/examples/stats-detailed/webpack.config.js
+++ b/examples/stats-detailed/webpack.config.js
@@ -1,0 +1,9 @@
+const path = require("path");
+
+module.exports = {
+    output: {
+		path: path.join(__dirname, "dist"),
+		filename: "output.js"
+	},
+	stats: "detailed"
+};


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aab745c</samp>

This pull request adds a new example to the webpack repository, demonstrating how to use the detailed stats option for the webpack bundle. It includes a build.js script that controls the stats output, an example.js file that is the entry point for the bundle, a webpack.config.js file that sets the output and stats options, and a template.md file that generates a README.md file with the source code, output, and stats report.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aab745c</samp>

*  Add a new example folder `stats-detailed` to demonstrate the detailed stats option for webpack ([link](https://github.com/webpack/webpack/pull/17420/files?diff=unified&w=0#diff-90c4633da92e1d2226c848dc16d42b0c68565016ab51a1a441f49e08697c932dR1-R4), [link](https://github.com/webpack/webpack/pull/17420/files?diff=unified&w=0#diff-26bf0e2a2124aa20b4a1bea3bbb5e44351517247debcba53322f1e7eef6c8cf8R1), [link](https://github.com/webpack/webpack/pull/17420/files?diff=unified&w=0#diff-5add3002240d3ad4fab15ad6d2aec64c34daee20480aeeb65b2c339d1cfccd38R1-R29), [link](https://github.com/webpack/webpack/pull/17420/files?diff=unified&w=0#diff-e5991f3622522caf8c20eb75b578fd700ac5bb0cb7953ee4456f91ec3c649bb1R1-R9), [link](https://github.com/webpack/webpack/pull/17420/files?diff=unified&w=0#diff-659792f9494c82dde8ac66a95e0d4f75eb20e57f6e504b1084ac6e337858e8c3R1-R83))
*  Create a `build.js` file to set some global variables for the stats report and require the common build script `build-common.js` ([link](https://github.com/webpack/webpack/pull/17420/files?diff=unified&w=0#diff-90c4633da92e1d2226c848dc16d42b0c68565016ab51a1a441f49e08697c932dR1-R4))
*  Create an `example.js` file as the entry point for the webpack bundle, which logs "Hello World!" to the console ([link](https://github.com/webpack/webpack/pull/17420/files?diff=unified&w=0#diff-26bf0e2a2124aa20b4a1bea3bbb5e44351517247debcba53322f1e7eef6c8cf8R1))
*  Create a `webpack.config.js` file to configure the output path and filename for the bundle, and enable the detailed stats option ([link](https://github.com/webpack/webpack/pull/17420/files?diff=unified&w=0#diff-e5991f3622522caf8c20eb75b578fd700ac5bb0cb7953ee4456f91ec3c649bb1R1-R9))
*  Create a `template.md` file to contain the markdown content for the example, using placeholders for the files and the console output ([link](https://github.com/webpack/webpack/pull/17420/files?diff=unified&w=0#diff-5add3002240d3ad4fab15ad6d2aec64c34daee20480aeeb65b2c339d1cfccd38R1-R29))
*  Generate a `README.md` file dynamically from the `template.md` file, using the `_{{file}}_` and `_{{mode:stdout}}_` syntax to insert the content of the files and the console output when the example is built ([link](https://github.com/webpack/webpack/pull/17420/files?diff=unified&w=0#diff-659792f9494c82dde8ac66a95e0d4f75eb20e57f6e504b1084ac6e337858e8c3R1-R83), [link](https://github.com/webpack/webpack/pull/17420/files?diff=unified&w=0#diff-5add3002240d3ad4fab15ad6d2aec64c34daee20480aeeb65b2c339d1cfccd38R1-R29))
