### PR TITLE
Fix importScripts typo

### DIFF
--- a/lib/webworker/ImportScriptsChunkLoadingRuntimeModule.js
+++ b/lib/webworker/ImportScriptsChunkLoadingRuntimeModule.js
@@ -196,7 +196,7 @@ class ImportScriptsChunkLoadingRuntimeModule extends RuntimeModule {
 						Template.getFunctionContent(
 							require("../hmr/JavascriptHotModuleReplacement.runtime.js")
 						)
-							.replace(/\$key\$/g, "importScrips")
+							.replace(/\$key\$/g, "importScripts")
 							.replace(/\$installedChunks\$/g, "installedChunks")
 							.replace(/\$loadUpdateChunk\$/g, "loadUpdateChunk")
 							.replace(/\$moduleCache\$/g, RuntimeGlobals.moduleCache)


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
While developing a custom Plugin to import chunks I noticed a typo on the `ImportScriptsChunkLoadingRuntimeModule.js` file.

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4e8f3f6</samp>

Fix a typo in the `importScripts` chunk loading logic for web workers. This improves the reliability and correctness of hot module replacement with web workers.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4e8f3f6</samp>

* Fix typo in placeholder replacement for `importScripts` API ([link](https://github.com/webpack/webpack/pull/17450/files?diff=unified&w=0#diff-9d5aff1909abc0972f843b068dff78f0e91826b7b066fcf80ccf55dc15e7f6acL199-R199))
