### PR TITLE
fix: non amd externals break amd library

### DIFF
--- a/lib/library/AmdLibraryPlugin.js
+++ b/lib/library/AmdLibraryPlugin.js
@@ -87,7 +87,11 @@ class AmdLibraryPlugin extends AbstractLibraryPlugin {
 		const modern = runtimeTemplate.supportsArrowFunction();
 		const modules = chunkGraph
 			.getChunkModules(chunk)
-			.filter(m => m instanceof ExternalModule);
+			.filter(
+				m =>
+					m instanceof ExternalModule &&
+					(m.externalType === "amd" || m.externalType === "amd-require")
+			);
 		const externals = /** @type {ExternalModule[]} */ (modules);
 		const externalsDepsArray = JSON.stringify(
 			externals.map(m =>

--- a/test/configCases/externals/non-amd-externals-amd/index.js
+++ b/test/configCases/externals/non-amd-externals-amd/index.js
@@ -1,0 +1,33 @@
+var fs = require("fs");
+var path = require("path");
+
+var dependencyArrayRegex = /define\((\[[^\]]*\]), (function)?\(/;
+var source = fs.readFileSync(path.join(__dirname, "bundle0.js"), "utf-8");
+var [, deps] = dependencyArrayRegex.exec(source);
+
+it("should correctly import a AMD external", function() {
+	var external = require("external0");
+	expect(external).toBe("module 0");
+});
+
+it("should contain the AMD external in the dependency array", function() {
+	expect(deps).toContain("\"external0\"");
+});
+
+it("should correctly import a non-AMD external", function() {
+	var external = require("external1");
+	expect(external).toBe("abc");
+});
+
+it("should not contain the non-AMD external in the dependency array", function() {
+	expect(deps).not.toContain("\"external1\"");
+});
+
+it("should correctly import a asset external", function() {
+	var asset = new URL("#hash", import.meta.url);
+	expect(asset.href).toBe(__webpack_base_uri__ + "#hash");
+});
+
+it("should not contain asset external in the dependency array", function() {
+	expect(deps).not.toContain("\"#hash\"");
+});

--- a/test/configCases/externals/non-amd-externals-amd/test.config.js
+++ b/test/configCases/externals/non-amd-externals-amd/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	modules: {
+		external0: "module 0"
+	}
+};

--- a/test/configCases/externals/non-amd-externals-amd/webpack.config.js
+++ b/test/configCases/externals/non-amd-externals-amd/webpack.config.js
@@ -4,14 +4,23 @@ module.exports = {
 	output: {
 		libraryTarget: "amd"
 	},
+	externals: {
+		external0: "external0",
+		external1: "var 'abc'"
+	},
 	node: {
 		__dirname: false,
 		__filename: false
 	},
+	target: "web",
+	externalsPresets: {
+		node: true
+	},
 	plugins: [
 		new webpack.BannerPlugin({
 			raw: true,
-			banner: "function define(fn) { fn(); }\n"
+			banner:
+				"function define(deps, fn) { fn(...deps.map(dep => require(dep))); }\n"
 		})
 	]
 };

--- a/test/configCases/target/amd-container-unnamed/index.js
+++ b/test/configCases/target/amd-container-unnamed/index.js
@@ -4,5 +4,5 @@ it("should name define", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename, "utf-8");
 
-	expect(source).toMatch(/window\['clientContainer'\]\.define\(\[[^\]]*\], (function)?\(/);
+	expect(source).toMatch(/window\['clientContainer'\]\.define\((function)?\(/);
 });

--- a/test/configCases/target/amd-container-unnamed/webpack.config.js
+++ b/test/configCases/target/amd-container-unnamed/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
 		new webpack.BannerPlugin({
 			raw: true,
 			banner:
-				"function define(deps, fn) { fn(); }\nconst window = {};\nwindow['clientContainer'] = { define };\n"
+				"function define(fn) { fn(); }\nconst window = {};\nwindow['clientContainer'] = { define };\n"
 		})
 	]
 };

--- a/test/configCases/target/amd-unnamed/index.js
+++ b/test/configCases/target/amd-unnamed/index.js
@@ -4,5 +4,5 @@ it("should name define", function() {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename, "utf-8");
 
-	expect(source).toMatch(/define\(\[[^\]]*\], (function)?\(/);
+	expect(source).toMatch(/define\((function)?\(/);
 });


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

fix #17464 

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19028dc</samp>

This pull request fixes a bug in the `AmdLibraryPlugin` that caused non-AMD externals to be added to the dependency array of the define call. It also adds a test case and a test configuration for this scenario. Additionally, it updates the test cases and configurations for the unnamed AMD modules to reflect the fact that they do not have a dependency array.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 19028dc</samp>

*  Filter non-AMD externals in AMD library plugin to avoid errors or unexpected behavior ([link](https://github.com/webpack/webpack/pull/17466/files?diff=unified&w=0#diff-5a47b03762f668789809804a02d7086e28c8ea8269351e1238b6abf69f10f67dL90-R94))
*  Add test case and configuration for non-AMD externals in AMD library plugin ([link](https://github.com/webpack/webpack/pull/17466/files?diff=unified&w=0#diff-acb054663a24c73837159b4c3685402527bc60a70d268d1bc21f926a9f21a7cfR1-R33), [link](https://github.com/webpack/webpack/pull/17466/files?diff=unified&w=0#diff-d011ed4ee5e4cc3c5e096fc0750038b081fa62910c3498c6a9c19413a8e7adf3R1-R5), [link](https://github.com/webpack/webpack/pull/17466/files?diff=unified&w=0#diff-b5e8aa6f596c9e3230a815b4f67006011b3b5713cbd2509ca7f2aee9b0ea0304R1-R26))
*  Update test case and configuration for AMD container unnamed library plugin to reflect that no dependency array is generated for unnamed modules ([link](https://github.com/webpack/webpack/pull/17466/files?diff=unified&w=0#diff-c374b86cd27b3d4d4ff7b7aeb9d4a4025017345e2731846ba4a3862180b51071L7-R7), [link](https://github.com/webpack/webpack/pull/17466/files?diff=unified&w=0#diff-fc9dacbcad5b977c2c67546e489d897b9b6dbfda7fe6eb59085a098034ff7d6bL18-R18))
*  Update test case and configuration for AMD unnamed library plugin to reflect that no dependency array is generated for unnamed modules ([link](https://github.com/webpack/webpack/pull/17466/files?diff=unified&w=0#diff-3bab143b066a4fb8382a7088389db1f90ce801f314850aa0f4a319f52bc1f25dL7-R7), [link](https://github.com/webpack/webpack/pull/17466/files?diff=unified&w=0#diff-feb8a410a221554738b5743d818ddb1b58c1d6c64f3c9569b2738cf791099c06L14-R14))
