### PR TITLE
Skip webpackPrefetch if the module is already preloaded

### DIFF
--- a/lib/web/JsonpChunkLoadingRuntimeModule.js
+++ b/lib/web/JsonpChunkLoadingRuntimeModule.js
@@ -225,27 +225,55 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 							hasJsMatcher === true ? "true" : hasJsMatcher("chunkId")
 						}) {`,
 						Template.indent([
-							"installedChunks[chunkId] = null;",
-							linkPrefetch.call(
-								Template.asString([
-									"var link = document.createElement('link');",
-									crossOriginLoading
-										? `link.crossOrigin = ${JSON.stringify(
-												crossOriginLoading
-										  )};`
-										: "",
-									`if (${RuntimeGlobals.scriptNonce}) {`,
-									Template.indent(
-										`link.setAttribute("nonce", ${RuntimeGlobals.scriptNonce});`
-									),
-									"}",
-									'link.rel = "prefetch";',
-									'link.as = "script";',
-									`link.href = ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId);`
+							`var getLinkElements = function (rel, as) {`,
+							Template.indent([
+								`var links = document.getElementsByTagName("link");`,
+								`var loadedLinks = [];`,
+								`for (var i = 0; i < links.length; i++) {`,
+								Template.indent([
+									`if (`,
+									Template.indent([
+										`links[i].getAttribute("rel") === rel &&`,
+										`links[i].getAttribute("as") === as`
+									]),
+									`) {`,
+									Template.indent([
+										`loadedLinks.push(links[i].getAttribute("href"));`
+									]),
+									`}`
 								]),
-								chunk
-							),
-							"document.head.appendChild(link);"
+								`}`,
+								`return loadedLinks;`
+							]),
+							`};`,
+							"",
+							`var loadedPreloadLinkElements = getLinkElements("preload", "script");`,
+							`var chunkIdHref = ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId);`,
+							`if(!loadedPreloadLinkElements.includes(chunkIdHref)) {`,
+							Template.indent([
+								"installedChunks[chunkId] = null;",
+								linkPrefetch.call(
+									Template.asString([
+										"var link = document.createElement('link');",
+										crossOriginLoading
+											? `link.crossOrigin = ${JSON.stringify(
+													crossOriginLoading
+											  )};`
+											: "",
+										`if (${RuntimeGlobals.scriptNonce}) {`,
+										Template.indent(
+											`link.setAttribute("nonce", ${RuntimeGlobals.scriptNonce});`
+										),
+										"}",
+										'link.rel = "prefetch";',
+										'link.as = "script";',
+										`link.href = ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId);`
+									]),
+									chunk
+								),
+								"document.head.appendChild(link);"
+							]),
+							`}`
 						]),
 						"}"
 				  ])};`


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Motivation / Use-Case

It prevents an additional network request for prefetching (webpackPrefetch) when the module is already preloaded.

It fixes the issue https://github.com/webpack/webpack/issues/17496.

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f5dab1b</samp>

Avoid duplicate prefetch links for JSONP chunks. Check existing preload link elements in `lib/web/JsonpChunkLoadingRuntimeModule.js` before creating and appending prefetch links.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f5dab1b</samp>

*  Prevent duplicate prefetch links for the same chunk ([link](https://github.com/webpack/webpack/pull/17497/files?diff=unified&w=0#diff-99b22d1932803b7795bbe843d01cdf63d32e52a247610bfd9cffb95170227cc6L228-R276))
