### PR TITLE
docs: add new powerful html-bundler-webpack-plugin to Plugins in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,13 @@ interface](https://webpack.js.org/plugins/). Most of the features
 within webpack itself use this plugin interface. This makes webpack very
 **flexible**.
 
-|                   Name                    |       Status       |    Install Size     | Description                                                                             |
-| :---------------------------------------: | :----------------: | :-----------------: | :-------------------------------------------------------------------------------------- |
-|    [mini-css-extract-plugin][mini-css]    |  ![mini-css-npm]   |  ![mini-css-size]   | Extracts CSS into separate files. It creates a CSS file per JS file which contains CSS. |
-| [compression-webpack-plugin][compression] | ![compression-npm] | ![compression-size] | Prepares compressed versions of assets to serve them with Content-Encoding              |
-|    [html-webpack-plugin][html-plugin]     | ![html-plugin-npm] | ![html-plugin-size] | Simplifies creation of HTML files (`index.html`) to serve your bundles                  |
-|         [pug-plugin][pug-plugin]          | ![pug-plugin-npm]  | ![pug-plugin-size]  | Renders Pug files to HTML, extracts JS and CSS from sources specified directly in Pug.  |
+|                   Name                    |       Status       |    Install Size     | Description                                                                                                                                                                                                                      |
+| :---------------------------------------: | :----------------: | :-----------------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    [mini-css-extract-plugin][mini-css]    |  ![mini-css-npm]   |  ![mini-css-size]   | Extracts CSS into separate files. It creates a CSS file per JS file which contains CSS.                                                                                                                                          |
+| [compression-webpack-plugin][compression] | ![compression-npm] | ![compression-size] | Prepares compressed versions of assets to serve them with Content-Encoding                                                                                                                                                       |
+|  [html-bundler-webpack-plugin][bundler]   |   ![bundler-npm]   |   ![bundler-size]   | Allows HTML as entrypoint. Renders templates with references to source scripts, styles, images. Supports template engines Eta, EJS, Handlebars, Nunjucks. Extracts JS, CSS into output files. Inline compiled JS, CSS into HTML. |
+|    [html-webpack-plugin][html-plugin]     | ![html-plugin-npm] | ![html-plugin-size] | Simplifies creation of HTML files (`index.html`) to serve your bundles                                                                                                                                                           |
+|         [pug-plugin][pug-plugin]          | ![pug-plugin-npm]  | ![pug-plugin-size]  | Renders Pug files to HTML, extracts JS and CSS from sources specified directly in Pug.                                                                                                                                           |
 
 [common-npm]: https://img.shields.io/npm/v/webpack.svg
 [mini-css]: https://github.com/webpack-contrib/mini-css-extract-plugin
@@ -124,6 +125,9 @@ within webpack itself use this plugin interface. This makes webpack very
 [compression]: https://github.com/webpack-contrib/compression-webpack-plugin
 [compression-npm]: https://img.shields.io/npm/v/compression-webpack-plugin.svg
 [compression-size]: https://packagephobia.com/badge?p=compression-webpack-plugin
+[bundler]: https://github.com/webdiscus/html-bundler-webpack-plugin
+[bundler-npm]: https://img.shields.io/npm/v/html-bundler-webpack-plugin.svg
+[bundler-size]: https://packagephobia.com/badge?p=html-bundler-webpack-plugin
 [html-plugin]: https://github.com/jantimon/html-webpack-plugin
 [html-plugin-npm]: https://img.shields.io/npm/v/html-webpack-plugin.svg
 [html-plugin-size]: https://packagephobia.com/badge?p=html-webpack-plugin


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

Hallo @sokra,

I have added the new modern [html-bundler-webpack-plugin](https://github.com/webdiscus/html-bundler-webpack-plugin) to the Plugin's list in the README.

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a63935d</samp>

This pull request adds support for HTML entrypoints to webpack with a new plugin, `html-bundler-webpack-plugin`. It also updates the `README.md` file to showcase the plugin and provide relevant information.

## Details

The HTML bundler plugin allows to use HTML templates as entry points. Source style and script files can be referenced directly in HTML. 

For example:
```html
<html>
<head>
  <!-- specify source style files -->
  <link href="./style.scss" rel="stylesheet">
  <!-- specify source script files here and/or in body -->
  <script src="./App.ts" defer="defer"></script>
</head>
<body>
  <!-- specify source image files -->
  <img src="./map.png">
</body>
</html>
```

The generated HTML contains the output filenames of the processed source files:

```html
<html>
<head>
  <link href="assets/css/style.05e4dd86.css" rel="stylesheet">
  <script src="assets/js/app.f4b855d8.js" defer="defer"></script>
</head>
<body>
  <img src="assets/img/map.58b43bd8.png">
</body>
</html>
```

Very easy to define templates as entry points:
```js
const HtmlBundlerPlugin = require('html-bundler-webpack-plugin');
module.exports = {
  entry: {
    index: 'src/views/home.html', // => dist/index.html
    'news/sport': 'src/views/news/sport/index.html', // => dist/news/sport.html
  },
  plugins: [
    new HtmlBundlerPlugin(),
  ],
  // no loaders are required for template configuration
};
```

For more control you can define templates in the [entry](https://github.com/webdiscus/html-bundler-webpack-plugin#option-entry) plugin options:

```js
const HtmlBundlerPlugin = require('html-bundler-webpack-plugin');
module.exports = {
  pugins: [
    new HtmlBundlerPlugin({
      // define a relative or absolute path to template pages
      entry: 'src/views/',
      
      // OR define templates manually
      entry: {
        index: {
          import: 'src/views/home.ejs', // EJS template => dist/index.html
          data: { title: 'Homepage' } // pass variables into template
        },
        'news/sport': 'src/views/news/sport/index.html', // => dist/news/sport.html
      },
      
      js: {
        // output filename of JS extracted from source script specified in `<script>`
        filename: 'assets/js/[name].[contenthash:8].js',
        inline: 'auto', // inline JS in dev mode, extract to file in production mode
      },

      css: {
        // output filename of CSS extracted from source file specified in `<link>`
        filename: 'assets/css/[name].[contenthash:8].css',
        inline: 'auto', // inline CSS in dev mode, extract to file in production mode
      },
    }),
  ],
};
```

The plugin supports template engines such as  Eta, EJS, Handlebars, Nunjucks, LiquidJS and others "out of the box" without additional plugins and loaders.

The plugin extracts JS and CSS form source files referenced in HTML into output files.  Compiled JS and CSS can be inlined into generated HTML using the `ìnline` plugin option.

> "It is also a huge developer experience improvement as many things can be inferred from the HTML."

P.S. Please, help to promote/popularize this plugin as the `Number One` plugin for the Webpack.

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a63935d</samp>

*  Add html-bundler-webpack-plugin to the list of plugins in `README.md` ([link](https://github.com/webpack/webpack/pull/17544/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R114), [link](https://github.com/webpack/webpack/pull/17544/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R128-R130))
