### PR TITLE
Fix typo in test comment

### DIFF
--- a/test/configCases/code-generation/import-export-format/index.js
+++ b/test/configCases/code-generation/import-export-format/index.js
@@ -10,7 +10,7 @@ const { expectSourceToContain, expectSourceToMatch } = require("../../../helpers
 const regexEscape = require("../../../helpers/regexEscape.js");
 
 // It's important to use propertyName when generating object members to ensure that the exported property name
-// uses the same accessor syntax (quotes vs. dot notatation) as the imported property name on the other end
+// uses the same accessor syntax (quotes vs. dot notation) as the imported property name on the other end
 // (which needs to use propertyAccess).  Else, minifiers such as Closure Compiler will not be able to minify correctly.
 it("should use the same accessor syntax for import and export", function() {
 


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

While reading this pr #17214 I noticed that there is a typo in the comment section for the `index.js` file 

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b5a5d47</samp>

Fix a typo in a comment in `test/configCases/code-generation/import-export-format/index.js`. The comment clarifies the code generation logic for import and export statements.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b5a5d47</samp>

* Fix a typo in a comment about import and export syntax ([link](https://github.com/webpack/webpack/pull/17551/files?diff=unified&w=0#diff-8f8e0d42a1a273f5eb69b922ee5970bd3e454da7ed35286de4e1588df4c9889fL13-R13))
