### PR TITLE
fix: The `setStatus()` of the HMR module should not return an array, which may cause infinite recursion.

### DIFF
--- a/lib/hmr/HotModuleReplacement.runtime.js
+++ b/lib/hmr/HotModuleReplacement.runtime.js
@@ -216,7 +216,7 @@ module.exports = function () {
 		for (var i = 0; i < registeredStatusHandlers.length; i++)
 			results[i] = registeredStatusHandlers[i].call(null, newStatus);
 
-		return Promise.all(results);
+		return Promise.all(results).then(function(){});
 	}
 
 	function unblock() {

--- a/lib/hmr/HotModuleReplacement.runtime.js
+++ b/lib/hmr/HotModuleReplacement.runtime.js
@@ -216,7 +216,7 @@ module.exports = function () {
 		for (var i = 0; i < registeredStatusHandlers.length; i++)
 			results[i] = registeredStatusHandlers[i].call(null, newStatus);
 
-		return Promise.all(results).then(function(){});
+		return Promise.all(results).then(function () {});
 	}
 
 	function unblock() {


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d293083</samp>

Fix unhandled promise rejections in `HotModuleReplacement.runtime.js`. Add an empty callback to `Promise.all` in `setStatus` to handle any status without handlers.

The `setStatus()` of the HMR module should not return an array, which may cause infinite recursion.

## Related issues

Fixes #16972, #13857, #13876, #13877

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d293083</samp>

* Add an empty callback to `Promise.all` in `setStatus` to prevent unhandled rejections ([link](https://github.com/webpack/webpack/pull/17556/files?diff=unified&w=0#diff-f8c14e898e7f9ed32eb227fe1ef43868a94cd6b2d7dc1bcabd48225c225af91bL219-R219))

PR #13576 Incorrectly makes the `setStatus` method in the HMR module return an array. 
https://github.com/webpack/webpack/blob/e852415cd515f421f82dc3be56eb6e9dae192757/lib/hmr/HotModuleReplacement.runtime.js#L211-L219
before that:
https://github.com/webpack/webpack/blob/795b4b7b5055c4978cd52c382f149a3108dbfe6a/lib/hmr/HotModuleReplacement.runtime.js#L210-L214

In the absence of `$hmrDownloadManifest$`, this array will be passed to the next then function, causing the `if(!update)` condition to fail, 
https://github.com/webpack/webpack/blob/e852415cd515f421f82dc3be56eb6e9dae192757/lib/hmr/HotModuleReplacement.runtime.js#L251-L257
![image](https://github.com/webpack/webpack/assets/20336040/f78cafd7-b24d-4ab8-b5fb-35899e88389c)
![image](https://github.com/webpack/webpack/assets/20336040/6d3fc1c4-6cdc-4083-bfa5-134fab08cdb4)
resulting in infinite recursion in here:
https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/hot/poll.js#L13-L24


Furthermore, since `updatedModules` is an empty array, this code will endlessly print `[HMR] Nothing hot updated.` to the console: 
https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/hot/log-apply-result.js#L26-L28
![image](https://github.com/webpack/webpack/assets/20336040/2bb2f4fd-9e03-4c7a-9cb1-dcd32fc70404)




