### PR TITLE
fix: Incorrect argument type in `Watching.js`

### DIFF
--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -241,8 +241,8 @@ class Watching {
 
 		const logger = compilation && compilation.getLogger("webpack.Watching");
 
-		/** @type {Stats | null} */
-		let stats = null;
+		/** @type {Stats | undefined} */
+		let stats = undefined;
 
 		/**
 		 * @param {Error} err error


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9f605a</samp>

Fixed a type annotation mismatch in `lib/Watching.js` and made the code more consistent.

Fixed incorrect parameter value in `watching.js` to prevent errors in other dependencies.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c9f605a</samp>

* Change the type annotation of `stats` from `Stats | null` to `Stats | undefined` to match the initial value and avoid type errors ([link](https://github.com/webpack/webpack/pull/17557/files?diff=unified&w=0#diff-13cf5374edb5eced5f3770d5f346c59252f87a90de91bc57306077693c8b95e2L244-R245))

In this code, the type of `this.handler` is 
```ts
/**
 * @template T
 * @callback Callback
 * @param {(Error | null)=} err
 * @param {T=} result
 */
```

 which extends to `(err?: null | Error, result?: T) => any`. The result parameter here accepts the `T|undefined` type, but a `null` type was mistakenly passed instead:
https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/Watching.js#L244-L261

This inconsistent type usage could potentially lead to errors in other dependencies, such as in nestjs-cli:
https://github.com/nestjs/nest-cli/blob/5fa917e7693b238e47a82923a753300d75ab4ec7/lib/compiler/webpack-compiler.ts#L141-L156
