### PR TITLE
fix bug in `SideEffectsFlagPlugin` with namespace re-exports

### DIFF
--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -263,11 +263,11 @@ class SideEffectsFlagPlugin {
 										(dep instanceof HarmonyImportSpecifierDependency &&
 											!dep.namespaceObjectAsContext)
 									) {
+										if (connection.originModule !== null) {
+											optimizeIncomingConnections(connection.originModule);
+										}
 										// TODO improve for export *
 										if (isReexport && dep.name) {
-											if (connection.originModule !== null) {
-												optimizeIncomingConnections(connection.originModule);
-											}
 											const exportInfo = moduleGraph.getExportInfo(
 												/** @type {Module} */ (connection.originModule),
 												dep.name

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -243,7 +243,11 @@ class SideEffectsFlagPlugin {
 						);
 
 						logger.time("update dependencies");
-						for (const module of modules) {
+
+						const optimizedModules = new Set();
+
+						const optimizeIncomingConnections = module => {
+							optimizedModules.add(module);
 							if (module.getSideEffectsConnectionState(moduleGraph) === false) {
 								const exportsInfo = moduleGraph.getExportsInfo(module);
 								for (const connection of moduleGraph.getIncomingConnections(
@@ -260,6 +264,12 @@ class SideEffectsFlagPlugin {
 									) {
 										// TODO improve for export *
 										if (isReexport && dep.name) {
+											if (
+												connection.originModule !== null &&
+												!optimizedModules.has(connection.originModule)
+											) {
+												optimizeIncomingConnections(connection.originModule);
+											}
 											const exportInfo = moduleGraph.getExportInfo(
 												/** @type {Module} */ (connection.originModule),
 												dep.name
@@ -314,6 +324,11 @@ class SideEffectsFlagPlugin {
 									}
 								}
 							}
+						};
+
+						for (const module of modules) {
+							if (optimizedModules.has(module)) continue;
+							optimizeIncomingConnections(module);
 						}
 						logger.timeEnd("update dependencies");
 					}

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -247,6 +247,7 @@ class SideEffectsFlagPlugin {
 						const optimizedModules = new Set();
 
 						const optimizeIncomingConnections = module => {
+							if (optimizedModules.has(module)) return;
 							optimizedModules.add(module);
 							if (module.getSideEffectsConnectionState(moduleGraph) === false) {
 								const exportsInfo = moduleGraph.getExportsInfo(module);
@@ -264,10 +265,7 @@ class SideEffectsFlagPlugin {
 									) {
 										// TODO improve for export *
 										if (isReexport && dep.name) {
-											if (
-												connection.originModule !== null &&
-												!optimizedModules.has(connection.originModule)
-											) {
+											if (connection.originModule !== null) {
 												optimizeIncomingConnections(connection.originModule);
 											}
 											const exportInfo = moduleGraph.getExportInfo(
@@ -327,7 +325,6 @@ class SideEffectsFlagPlugin {
 						};
 
 						for (const module of modules) {
-							if (optimizedModules.has(module)) continue;
 							optimizeIncomingConnections(module);
 						}
 						logger.timeEnd("update dependencies");

--- a/test/configCases/side-effects/side-effects-unsorted-modules/index.js
+++ b/test/configCases/side-effects/side-effects-unsorted-modules/index.js
@@ -1,0 +1,9 @@
+import { b } from "dep";
+
+b.c();
+
+import { modules } from "dep/trackModules.js";
+
+it("should not contain side-effect-free modules", () => {
+	expect(modules).toEqual(["c"]);
+});

--- a/test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/a.js
+++ b/test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/a.js
@@ -1,0 +1,3 @@
+import { track } from "./trackModules.js";
+track("a");
+export * as b from "./b.js";

--- a/test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/b.js
+++ b/test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/b.js
@@ -1,0 +1,3 @@
+import { track } from "./trackModules.js";
+track("b");
+export * from "./c.js";

--- a/test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/c.js
+++ b/test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/c.js
@@ -1,0 +1,3 @@
+import { track } from "./trackModules.js";
+track("c");
+export function c() {}

--- a/test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/index.js
+++ b/test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/index.js
@@ -1,0 +1,3 @@
+import { track } from "./trackModules.js";
+track("index");
+export * from "./a.js"

--- a/test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/package.json
+++ b/test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dep",
+  "version": "1.0.0",
+  "type": "module",
+  "sideEffects": false
+}

--- a/test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/trackModules.js
+++ b/test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/trackModules.js
@@ -1,0 +1,4 @@
+export const modules = [];
+export function track(name) {
+	modules.push(name);
+}

--- a/test/configCases/side-effects/side-effects-unsorted-modules/webpack.config.js
+++ b/test/configCases/side-effects/side-effects-unsorted-modules/webpack.config.js
@@ -1,0 +1,23 @@
+/** @type {import("../../../../").Configuration} */
+
+class ReorderModulesPlugin {
+	constructor() {}
+
+	apply(compiler) {
+		compiler.hooks.compilation.tap("ReorderModulesPlugin", compilation => {
+			compilation.hooks.seal.tap("ReorderModulesPlugin", () => {
+				const sortedModules = Array.from(compilation.modules).sort((a, _b) =>
+					a.request.includes("b.js") ? -1 : 1
+				);
+				compilation.modules = new Set(sortedModules);
+			});
+		});
+	}
+}
+
+module.exports = {
+	plugins: [new ReorderModulesPlugin()],
+	optimization: {
+		sideEffects: true
+	}
+};


### PR DESCRIPTION
Fixes #17607

Explanation in comment: https://github.com/webpack/webpack/pull/17595#issuecomment-1681608016

<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 65599db</samp>

This pull request enhances the `SideEffectsFlagPlugin` by using a recursive function and a cache to optimize module connections more effectively. This improves the performance and quality of the webpack output.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 65599db</samp>

*  Introduce a new optimization logic to eliminate unused exports from modules based on the `sideEffects` flag ([link](https://github.com/webpack/webpack/pull/17595/files?diff=unified&w=0#diff-9a6c6f708e678a6d207b65f843d7f91f4d4f734c040c4b8ea5282e3efe27e25bL246-R250), [link](https://github.com/webpack/webpack/pull/17595/files?diff=unified&w=0#diff-9a6c6f708e678a6d207b65f843d7f91f4d4f734c040c4b8ea5282e3efe27e25bR267-R272), [link](https://github.com/webpack/webpack/pull/17595/files?diff=unified&w=0#diff-9a6c6f708e678a6d207b65f843d7f91f4d4f734c040c4b8ea5282e3efe27e25bR327-R331))
  * Declare a new variable `optimizedModules` to store the modules that have been processed by the optimization ([link](https://github.com/webpack/webpack/pull/17595/files?diff=unified&w=0#diff-9a6c6f708e678a6d207b65f843d7f91f4d4f734c040c4b8ea5282e3efe27e25bL246-R250))
  * Define a new function `optimizeIncomingConnections` that recursively applies the optimization to the incoming connections of a given module ([link](https://github.com/webpack/webpack/pull/17595/files?diff=unified&w=0#diff-9a6c6f708e678a6d207b65f843d7f91f4d4f734c040c4b8ea5282e3efe27e25bL246-R250))
  * Check if the origin module of a connection has already been optimized, and if not, call `optimizeIncomingConnections` for it ([link](https://github.com/webpack/webpack/pull/17595/files?diff=unified&w=0#diff-9a6c6f708e678a6d207b65f843d7f91f4d4f734c040c4b8ea5282e3efe27e25bR267-R272))
  * Loop over all the modules and call `optimizeIncomingConnections` for each one that has not been optimized yet ([link](https://github.com/webpack/webpack/pull/17595/files?diff=unified&w=0#diff-9a6c6f708e678a6d207b65f843d7f91f4d4f734c040c4b8ea5282e3efe27e25bR327-R331))
