### PR TITLE
New feature: implement `__non_webpack_import__()`

### DIFF
--- a/examples/import-http/README.md
+++ b/examples/import-http/README.md
@@ -1,0 +1,75 @@
+# example.js
+
+```javascript
+async function main() {
+	const pMap1 = await __non_webpack_import__("https://cdn.skypack.dev/p-map");
+	const pMap2 = await __non_webpack_import__("https://cdn.esm.sh/p-map");
+	const pMap3 = await __non_webpack_import__("https://jspm.dev/p-map");
+	const pMap4 = await __non_webpack_import__("https://unpkg.com/p-map-series?module"); // unpkg doesn't support p-map :(
+	console.log(pMap1);
+	console.log(pMap2);
+	console.log(pMap3);
+	console.log(pMap4);
+}
+
+main()
+```
+
+# webpack.config.js
+
+```javascript
+module.exports = {};
+```
+
+# dist/output.js
+
+```javascript
+/******/ (() => { // webpackBootstrap
+var __webpack_exports__ = {};
+/*!********************!*\
+  !*** ./example.js ***!
+  \********************/
+/*! unknown exports (runtime-defined) */
+/*! runtime requirements:  */
+async function main() {
+	const pMap1 = await import("https://cdn.skypack.dev/p-map");
+	const pMap2 = await import("https://cdn.esm.sh/p-map");
+	const pMap3 = await import("https://jspm.dev/p-map");
+	const pMap4 = await import("https://unpkg.com/p-map-series?module"); // unpkg doesn't support p-map :(
+	console.log(pMap1);
+	console.log(pMap2);
+	console.log(pMap3);
+	console.log(pMap4);
+}
+
+main()
+
+/******/ })()
+;
+```
+
+# Info
+
+## Unoptimized
+
+```
+asset output.js 628 bytes [emitted] (name: main)
+chunk (runtime: main) output.js (main) 460 bytes [entry] [rendered]
+  > ./example.js main
+  ./example.js 460 bytes [built] [code generated]
+    [used exports unknown]
+    entry ./example.js main
+webpack 5.88.2 compiled successfully
+```
+
+## Production mode
+
+```
+asset output.js 275 bytes [emitted] [minimized] (name: main)
+chunk (runtime: main) output.js (main) 460 bytes [entry] [rendered]
+  > ./example.js main
+  ./example.js 460 bytes [built] [code generated]
+    [no exports used]
+    entry ./example.js main
+webpack 5.88.2 compiled successfully
+```

--- a/examples/import-http/build.js
+++ b/examples/import-http/build.js
@@ -1,0 +1,1 @@
+require("../build-common");

--- a/examples/import-http/example.js
+++ b/examples/import-http/example.js
@@ -1,0 +1,12 @@
+async function main() {
+	const pMap1 = await __non_webpack_import__("https://cdn.skypack.dev/p-map");
+	const pMap2 = await __non_webpack_import__("https://cdn.esm.sh/p-map");
+	const pMap3 = await __non_webpack_import__("https://jspm.dev/p-map");
+	const pMap4 = await __non_webpack_import__("https://unpkg.com/p-map-series?module"); // unpkg doesn't support p-map :(
+	console.log(pMap1);
+	console.log(pMap2);
+	console.log(pMap3);
+	console.log(pMap4);
+}
+
+main()

--- a/examples/import-http/template.md
+++ b/examples/import-http/template.md
@@ -1,0 +1,31 @@
+# example.js
+
+```javascript
+_{{example.js}}_
+```
+
+# webpack.config.js
+
+```javascript
+_{{webpack.config.js}}_
+```
+
+# dist/output.js
+
+```javascript
+_{{dist/output.js}}_
+```
+
+# Info
+
+## Unoptimized
+
+```
+_{{stdout}}_
+```
+
+## Production mode
+
+```
+_{{production:stdout}}_
+```

--- a/examples/import-http/webpack.config.js
+++ b/examples/import-http/webpack.config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -71,6 +71,12 @@ function getReplacements(module, importMetaName) {
 			type: undefined, // type is not known, depends on environment
 			assign: true
 		},
+		__non_webpack_import__: {
+			expr: "import",
+			req: null,
+			type: undefined, // shouldn't be able to run "typeof import"
+			assign: false
+		},
 		__webpack_nonce__: {
 			expr: RuntimeGlobals.scriptNonce,
 			req: [RuntimeGlobals.scriptNonce],

--- a/module.d.ts
+++ b/module.d.ts
@@ -206,6 +206,7 @@ declare const __webpack_share_scopes__: Record<
 >;
 declare var __webpack_init_sharing__: (scope: string) => Promise<void>;
 declare var __non_webpack_require__: (id: any) => unknown;
+declare var __non_webpack_import__: (id: any) => Promise<unknown>;
 declare const __system_context__: object;
 
 declare namespace NodeJS {


### PR DESCRIPTION
## Summary

Fixes: https://github.com/webpack/webpack/issues/17597

Add a new `__non_webpack_import__()` that would behave exactly as the native `import()` (dynamic async import) in ECMAScript (that works in both CJS & ESM in node) (exactly as `__non_webpack_require__` for CJS)

## Details

As `import()` is natively supported in ESM & CJS, we can just tell webpack to compile `__non_webpack_import__` to `import` and it should just work.

I also added an example.
I tried to add a test but I couldn't see any test for `__non_webpack_require__`, a lot of tests are using it but not testing it.
And also most tests are running within a `vm` that need `importModuleDynamically` to be properly defined. So I couldn't make it work the way I wanted (I could need help on that if you want to add a test)
