### PR TITLE
Fix a typo in an error message for the top-level-await experiment

### DIFF
--- a/lib/dependencies/HarmonyDetectionParserPlugin.js
+++ b/lib/dependencies/HarmonyDetectionParserPlugin.js
@@ -65,7 +65,7 @@ module.exports = class HarmonyDetectionParserPlugin {
 			const module = parser.state.module;
 			if (!this.topLevelAwait) {
 				throw new Error(
-					"The top-level-await experiment is not enabled (set experiments.topLevelAwait: true to enabled it)"
+					"The top-level-await experiment is not enabled (set experiments.topLevelAwait: true to enable it)"
 				);
 			}
 			if (!HarmonyExports.isEnabled(parser.state)) {


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2bc0db</samp>

Fix a typo in an error message for the `top-level-await` experiment in `HarmonyDetectionParserPlugin`. This change makes the message more clear and correct for the users of the plugin.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f2bc0db</samp>

* Fix typo in error message for top-level-await experiment ([link](https://github.com/webpack/webpack/pull/17627/files?diff=unified&w=0#diff-f899586ef6673968961557491245d48c757e76c7c2f71bec9e45f530b2e0e71aL68-R68))
