### PR TITLE
fix: add /*#__PURE__*/ to generated JSON.parse() call in JsonGenerator

### DIFF
--- a/lib/json/JsonGenerator.js
+++ b/lib/json/JsonGenerator.js
@@ -183,7 +183,7 @@ class JsonGenerator extends Generator {
 		const jsonStr = /** @type {string} */ (stringifySafe(finalJson));
 		const jsonExpr =
 			jsonStr.length > 20 && typeof finalJson === "object"
-				? `JSON.parse('${jsonStr.replace(/[\\']/g, "\\$&")}')`
+				? `/*#__PURE__*/JSON.parse('${jsonStr.replace(/[\\']/g, "\\$&")}')`
 				: jsonStr;
 		/** @type {string} */
 		let content;

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -1274,7 +1274,7 @@ chunk (runtime: main) trees.js (trees) 215 bytes [rendered]
 `;
 
 exports[`StatsTestCases should print correct stats for ignore-warnings 1`] = `
-"asset main.js 989 bytes [emitted] (name: main)
+"asset main.js 1000 bytes [emitted] (name: main)
 orphan modules 617 bytes [orphan] 9 modules
 ./index.js + 9 modules 790 bytes [built] [code generated]
 


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

When importing JSON files in webpack, in non trivial cases, the JSON payloads will be accidentally included in the final bundle even when it's actually not used. To help the dead code elimination, this PR just adds `/*#__PURE__*/` to `JSON.parse(..)`, which is definitely "pure" and when the return value is unused it should be dropped by, say, Terser.

This is the reproduction repo of the issue: https://github.com/naruaway-sandbox/webpack-json-import-tree-shake-demo and it also explains more details. I confirmed that this PR fixes the issue.
## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2053d2d</samp>

Add a comment to mark `JSON.parse` as pure in `JsonGenerator.js`. This helps webpack to tree-shake unused JSON modules.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2053d2d</samp>

* Add `/*#__PURE__*/` comment before `JSON.parse` calls to mark them as side-effect-free ([link](https://github.com/webpack/webpack/pull/17637/files?diff=unified&w=0#diff-b3ced1cb3f771e00183c51f63de07daf5384a5d538b4ae46a9213dcfc73d11b0L186-R186),                            F0
