### PR TITLE
fix: miss passing errors array

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -4927,7 +4927,8 @@ This prevents using hashes of each other and should be avoided.`);
 							hashFunction,
 							runtimeTemplate,
 							hashDigest,
-							hashDigestLength
+							hashDigestLength,
+							errors
 						);
 					}
 


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 211c4b1</samp>

Refactor `getEntryInfo` function to accept and report `errors` parameter. Improve error handling of compilation entry points in `lib/Compilation.js`.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 211c4b1</samp>

* Pass `errors` parameter to `getEntryInfo` function to report entry errors ([link](https://github.com/webpack/webpack/pull/17641/files?diff=unified&w=0#diff-9206962f55a69b69a39e73a803e2be04b10d454f270e35b482f3f70a74f472a6L4930-R4931))
