### PR TITLE
chore: refactor getRequiredVersionFromDescriptionFile in utils.js

### DIFF
--- a/lib/sharing/utils.js
+++ b/lib/sharing/utils.js
@@ -373,24 +373,27 @@ exports.getDescriptionFile = getDescriptionFile;
 
 /**
  *
- * @param {object} Description file data i.e.: package.json
- * @param {string} name of the dependency
+ * @param {object} data description file data i.e.: package.json
+ * @param {string} packageName name of the dependency
  * @returns {string} normalized version
  */
 const getRequiredVersionFromDescriptionFile = (data, packageName) => {
-  const dependencyTypes = [
+	const dependencyTypes = [
 		"optionalDependencies",
 		"dependencies",
 		"peerDependencies",
 		"devDependencies"
 	];
 
-  for (const dependencyType of dependencyTypes) {
-    if (data[dependencyType] &&
-				typeof data[dependencyType] === "object" &&
-				packageName in data[dependencyType]) {
-      return normalizeVersion(data[dependencyType][packageName]);
-    }
-  }
+	for (const dependencyType of dependencyTypes) {
+		if (
+			data[dependencyType] &&
+			typeof data[dependencyType] === "object" &&
+			packageName in data[dependencyType]
+		) {
+			return normalizeVersion(data[dependencyType][packageName]);
+		}
+	}
 };
-exports.getRequiredVersionFromDescriptionFile = getRequiredVersionFromDescriptionFile;
+exports.getRequiredVersionFromDescriptionFile =
+	getRequiredVersionFromDescriptionFile;

--- a/lib/sharing/utils.js
+++ b/lib/sharing/utils.js
@@ -371,33 +371,26 @@ const getDescriptionFile = (fs, directory, descriptionFiles, callback) => {
 };
 exports.getDescriptionFile = getDescriptionFile;
 
-exports.getRequiredVersionFromDescriptionFile = (data, packageName) => {
-	if (
-		data.optionalDependencies &&
-		typeof data.optionalDependencies === "object" &&
-		packageName in data.optionalDependencies
-	) {
-		return normalizeVersion(data.optionalDependencies[packageName]);
-	}
-	if (
-		data.dependencies &&
-		typeof data.dependencies === "object" &&
-		packageName in data.dependencies
-	) {
-		return normalizeVersion(data.dependencies[packageName]);
-	}
-	if (
-		data.peerDependencies &&
-		typeof data.peerDependencies === "object" &&
-		packageName in data.peerDependencies
-	) {
-		return normalizeVersion(data.peerDependencies[packageName]);
-	}
-	if (
-		data.devDependencies &&
-		typeof data.devDependencies === "object" &&
-		packageName in data.devDependencies
-	) {
-		return normalizeVersion(data.devDependencies[packageName]);
-	}
+/**
+ *
+ * @param {object} Description file data i.e.: package.json
+ * @param {string} name of the dependency
+ * @returns {string} normalized version
+ */
+const getRequiredVersionFromDescriptionFile = (data, packageName) => {
+  const dependencyTypes = [
+		"optionalDependencies",
+		"dependencies",
+		"peerDependencies",
+		"devDependencies"
+	];
+
+  for (const dependencyType of dependencyTypes) {
+    if (data[dependencyType] &&
+				typeof data[dependencyType] === "object" &&
+				packageName in data[dependencyType]) {
+      return normalizeVersion(data[dependencyType][packageName]);
+    }
+  }
 };
+exports.getRequiredVersionFromDescriptionFile = getRequiredVersionFromDescriptionFile;


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6618bd</samp>

Refactor and document `getRequiredVersionFromDescriptionFile` function in `lib/sharing/utils.js`. Simplify the logic for finding the required version of a shared module from its description file.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a6618bd</samp>

* Refactor `getRequiredVersionFromDescriptionFile` function to use a loop and add JSDoc comment ([link](https://github.com/webpack/webpack/pull/17665/files?diff=unified&w=0#diff-260b12729ec74ae844ab979b5bb4344874cd0a89eeb39dc78a66d284a44a2919L374-R396))
