### PR TITLE
Make CommonJS import preserve chained expressions

### DIFF
--- a/lib/dependencies/CommonJsFullRequireDependency.js
+++ b/lib/dependencies/CommonJsFullRequireDependency.js
@@ -7,6 +7,7 @@
 
 const Template = require("../Template");
 const { equals } = require("../util/ArrayHelpers");
+const { getTrimmedIdsAndRange } = require("../util/chainedImports");
 const makeSerializable = require("../util/makeSerializable");
 const propertyAccess = require("../util/propertyAccess");
 const ModuleDependency = require("./ModuleDependency");
@@ -127,30 +128,16 @@ CommonJsFullRequireDependency.Template = class CommonJsFullRequireDependencyTemp
 			runtimeRequirements
 		});
 
-		const ids = dep.names;
-		let trimmedIds = this._trimIdsToThoseImported(ids, moduleGraph, dep);
-
-		let [rangeStart, rangeEnd] = dep.range;
-		if (trimmedIds.length !== ids.length) {
-			// The array returned from dep.idRanges is right-aligned with the array returned from dep.names.
-			// Meaning, the two arrays may not always have the same number of elements, but the last element of
-			// dep.idRanges corresponds to [the expression fragment to the left of] the last element of dep.names.
-			// Use this to find the correct replacement range based on the number of ids that were trimmed.
-			const idx =
-				dep.idRanges === undefined
-					? -1 /* trigger failure case below */
-					: dep.idRanges.length + (trimmedIds.length - ids.length);
-			if (idx < 0 || idx >= dep.idRanges.length) {
-				// cspell:ignore minifiers
-				// Should not happen but we can't throw an error here because of backward compatibility with
-				// external plugins in wp5.  Instead, we just disable trimming for now.  This may break some minifiers.
-				trimmedIds = ids;
-				// TODO webpack 6 remove the "trimmedIds = ids" above and uncomment the following line instead.
-				// throw new Error("Missing range starts data for id replacement trimming.");
-			} else {
-				[rangeStart, rangeEnd] = dep.idRanges[idx];
-			}
-		}
+		const {
+			trimmedRange: [trimmedRangeStart, trimmedRangeEnd],
+			trimmedIds
+		} = getTrimmedIdsAndRange(
+			dep.names,
+			dep.range,
+			dep.idRanges,
+			moduleGraph,
+			dep
+		);
 
 		if (importedModule) {
 			const usedImported = moduleGraph
@@ -167,43 +154,7 @@ CommonJsFullRequireDependency.Template = class CommonJsFullRequireDependencyTemp
 						: `${requireExpr}${access}`;
 			}
 		}
-		source.replace(rangeStart, rangeEnd - 1, requireExpr);
-	}
-
-	/**
-	 * @summary Determine which IDs in the id chain are actually referring to namespaces or imports,
-	 * and which are deeper member accessors on the imported object.  Only the former should be re-rendered.
-	 * @param {string[]} ids ids
-	 * @param {ModuleGraph} moduleGraph moduleGraph
-	 * @param {CommonJsFullRequireDependency} dependency dependency
-	 * @returns {string[]} generated code
-	 */
-	_trimIdsToThoseImported(ids, moduleGraph, dependency) {
-		let trimmedIds = [];
-		const exportsInfo = moduleGraph.getExportsInfo(
-			moduleGraph.getModule(dependency)
-		);
-		let currentExportsInfo = /** @type {ExportsInfo=} */ exportsInfo;
-		for (let i = 0; i < ids.length; i++) {
-			if (i === 0 && ids[i] === "default") {
-				continue; // ExportInfo for the next level under default is still at the root ExportsInfo, so don't advance currentExportsInfo
-			}
-			const exportInfo = currentExportsInfo.getExportInfo(ids[i]);
-			if (exportInfo.provided === false) {
-				// json imports have nested ExportInfo for elements that things that are not actually exported, so check .provided
-				trimmedIds = ids.slice(0, i);
-				break;
-			}
-			const nestedInfo = exportInfo.getNestedExportsInfo();
-			if (!nestedInfo) {
-				// once all nested exports are traversed, the next item is the actual import so stop there
-				trimmedIds = ids.slice(0, i + 1);
-				break;
-			}
-			currentExportsInfo = nestedInfo;
-		}
-		// Never trim to nothing.  This can happen for invalid imports (e.g. import { notThere } from "./module", or import { anything } from "./missingModule")
-		return trimmedIds.length ? trimmedIds : ids;
+		source.replace(trimmedRangeStart, trimmedRangeEnd - 1, requireExpr);
 	}
 };
 

--- a/lib/dependencies/CommonJsFullRequireDependency.js
+++ b/lib/dependencies/CommonJsFullRequireDependency.js
@@ -26,11 +26,18 @@ class CommonJsFullRequireDependency extends ModuleDependency {
 	 * @param {string} request the request string
 	 * @param {Range} range location in source code
 	 * @param {string[]} names accessed properties on module
+	 * @param {Range[]=} idRanges ranges for members of ids; the two arrays are right-aligned
 	 */
-	constructor(request, range, names) {
+	constructor(
+		request,
+		range,
+		names,
+		idRanges /* TODO webpack 6 make this non-optional. It must always be set to properly trim ids. */
+	) {
 		super(request);
 		this.range = range;
 		this.names = names;
+		this.idRanges = idRanges;
 		this.call = false;
 		this.asiSafe = undefined;
 	}
@@ -60,6 +67,7 @@ class CommonJsFullRequireDependency extends ModuleDependency {
 	serialize(context) {
 		const { write } = context;
 		write(this.names);
+		write(this.idRanges);
 		write(this.call);
 		write(this.asiSafe);
 		super.serialize(context);
@@ -71,6 +79,7 @@ class CommonJsFullRequireDependency extends ModuleDependency {
 	deserialize(context) {
 		const { read } = context;
 		this.names = read();
+		this.idRanges = read();
 		this.call = read();
 		this.asiSafe = read();
 		super.deserialize(context);
@@ -117,15 +126,40 @@ CommonJsFullRequireDependency.Template = class CommonJsFullRequireDependencyTemp
 			weak: dep.weak,
 			runtimeRequirements
 		});
+
+		const ids = dep.names;
+		let trimmedIds = this._trimIdsToThoseImported(ids, moduleGraph, dep);
+
+		let [rangeStart, rangeEnd] = dep.range;
+		if (trimmedIds.length !== ids.length) {
+			// The array returned from dep.idRanges is right-aligned with the array returned from dep.names.
+			// Meaning, the two arrays may not always have the same number of elements, but the last element of
+			// dep.idRanges corresponds to [the expression fragment to the left of] the last element of dep.names.
+			// Use this to find the correct replacement range based on the number of ids that were trimmed.
+			const idx =
+				dep.idRanges === undefined
+					? -1 /* trigger failure case below */
+					: dep.idRanges.length + (trimmedIds.length - ids.length);
+			if (idx < 0 || idx >= dep.idRanges.length) {
+				// cspell:ignore minifiers
+				// Should not happen but we can't throw an error here because of backward compatibility with
+				// external plugins in wp5.  Instead, we just disable trimming for now.  This may break some minifiers.
+				trimmedIds = ids;
+				// TODO webpack 6 remove the "trimmedIds = ids" above and uncomment the following line instead.
+				// throw new Error("Missing range starts data for id replacement trimming.");
+			} else {
+				[rangeStart, rangeEnd] = dep.idRanges[idx];
+			}
+		}
+
 		if (importedModule) {
-			const ids = dep.names;
 			const usedImported = moduleGraph
 				.getExportsInfo(importedModule)
-				.getUsedName(ids, runtime);
+				.getUsedName(trimmedIds, runtime);
 			if (usedImported) {
-				const comment = equals(usedImported, ids)
+				const comment = equals(usedImported, trimmedIds)
 					? ""
-					: Template.toNormalComment(propertyAccess(ids)) + " ";
+					: Template.toNormalComment(propertyAccess(trimmedIds)) + " ";
 				const access = `${comment}${propertyAccess(usedImported)}`;
 				requireExpr =
 					dep.asiSafe === true
@@ -133,7 +167,43 @@ CommonJsFullRequireDependency.Template = class CommonJsFullRequireDependencyTemp
 						: `${requireExpr}${access}`;
 			}
 		}
-		source.replace(dep.range[0], dep.range[1] - 1, requireExpr);
+		source.replace(rangeStart, rangeEnd - 1, requireExpr);
+	}
+
+	/**
+	 * @summary Determine which IDs in the id chain are actually referring to namespaces or imports,
+	 * and which are deeper member accessors on the imported object.  Only the former should be re-rendered.
+	 * @param {string[]} ids ids
+	 * @param {ModuleGraph} moduleGraph moduleGraph
+	 * @param {CommonJsFullRequireDependency} dependency dependency
+	 * @returns {string[]} generated code
+	 */
+	_trimIdsToThoseImported(ids, moduleGraph, dependency) {
+		let trimmedIds = [];
+		const exportsInfo = moduleGraph.getExportsInfo(
+			moduleGraph.getModule(dependency)
+		);
+		let currentExportsInfo = /** @type {ExportsInfo=} */ exportsInfo;
+		for (let i = 0; i < ids.length; i++) {
+			if (i === 0 && ids[i] === "default") {
+				continue; // ExportInfo for the next level under default is still at the root ExportsInfo, so don't advance currentExportsInfo
+			}
+			const exportInfo = currentExportsInfo.getExportInfo(ids[i]);
+			if (exportInfo.provided === false) {
+				// json imports have nested ExportInfo for elements that things that are not actually exported, so check .provided
+				trimmedIds = ids.slice(0, i);
+				break;
+			}
+			const nestedInfo = exportInfo.getNestedExportsInfo();
+			if (!nestedInfo) {
+				// once all nested exports are traversed, the next item is the actual import so stop there
+				trimmedIds = ids.slice(0, i + 1);
+				break;
+			}
+			currentExportsInfo = nestedInfo;
+		}
+		// Never trim to nothing.  This can happen for invalid imports (e.g. import { notThere } from "./module", or import { anything } from "./missingModule")
+		return trimmedIds.length ? trimmedIds : ids;
 	}
 };
 

--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -379,9 +379,16 @@ class CommonJsImportsParserPlugin {
 		 * @param {string[]} calleeMembers callee members
 		 * @param {CallExpression} callExpr call expression
 		 * @param {string[]} members members
+		 * @param {Range[]} memberRanges member ranges
 		 * @returns {boolean | void} true when handled
 		 */
-		const chainHandler = (expr, calleeMembers, callExpr, members) => {
+		const chainHandler = (
+			expr,
+			calleeMembers,
+			callExpr,
+			members,
+			memberRanges
+		) => {
 			if (callExpr.arguments.length !== 1) return;
 			const param = parser.evaluateExpression(callExpr.arguments[0]);
 			if (
@@ -391,7 +398,8 @@ class CommonJsImportsParserPlugin {
 				const dep = new CommonJsFullRequireDependency(
 					/** @type {string} */ (param.string),
 					/** @type {Range} */ (expr.range),
-					members
+					members,
+					/** @type {Range[]} */ memberRanges
 				);
 				dep.asiSafe = !parser.isAsiPosition(
 					/** @type {Range} */ (expr.range)[0]
@@ -407,9 +415,16 @@ class CommonJsImportsParserPlugin {
 		 * @param {string[]} calleeMembers callee members
 		 * @param {CallExpression} callExpr call expression
 		 * @param {string[]} members members
+		 * @param {Range[]} memberRanges member ranges
 		 * @returns {boolean | void} true when handled
 		 */
-		const callChainHandler = (expr, calleeMembers, callExpr, members) => {
+		const callChainHandler = (
+			expr,
+			calleeMembers,
+			callExpr,
+			members,
+			memberRanges
+		) => {
 			if (callExpr.arguments.length !== 1) return;
 			const param = parser.evaluateExpression(callExpr.arguments[0]);
 			if (
@@ -419,7 +434,8 @@ class CommonJsImportsParserPlugin {
 				const dep = new CommonJsFullRequireDependency(
 					/** @type {string} */ (param.string),
 					/** @type {Range} */ (expr.callee.range),
-					members
+					members,
+					/** @type {Range[]} */ memberRanges
 				);
 				dep.call = true;
 				dep.asiSafe = !parser.isAsiPosition(

--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -9,6 +9,7 @@ const Dependency = require("../Dependency");
 const {
 	getDependencyUsedByExportsCondition
 } = require("../optimize/InnerGraph");
+const { getTrimmedIdsAndRange } = require("../util/chainedImports");
 const makeSerializable = require("../util/makeSerializable");
 const propertyAccess = require("../util/propertyAccess");
 const HarmonyImportDependency = require("./HarmonyImportDependency");
@@ -324,30 +325,16 @@ HarmonyImportSpecifierDependency.Template = class HarmonyImportSpecifierDependen
 		// Skip rendering depending when dependency is conditional
 		if (connection && !connection.isTargetActive(runtime)) return;
 
-		const ids = dep.getIds(moduleGraph); // determine minimal set of IDs.
-		let trimmedIds = this._trimIdsToThoseImported(ids, moduleGraph, dep);
-
-		let [rangeStart, rangeEnd] = dep.range;
-		if (trimmedIds.length !== ids.length) {
-			// The array returned from dep.idRanges is right-aligned with the array returned from dep.getIds.
-			// Meaning, the two arrays may not always have the same number of elements, but the last element of
-			// dep.idRanges corresponds to [the expression fragment to the left of] the last element of dep.getIds.
-			// Use this to find the correct replacement range based on the number of ids that were trimmed.
-			const idx =
-				dep.idRanges === undefined
-					? -1 /* trigger failure case below */
-					: dep.idRanges.length + (trimmedIds.length - ids.length);
-			if (idx < 0 || idx >= dep.idRanges.length) {
-				// cspell:ignore minifiers
-				// Should not happen but we can't throw an error here because of backward compatibility with
-				// external plugins in wp5.  Instead, we just disable trimming for now.  This may break some minifiers.
-				trimmedIds = ids;
-				// TODO webpack 6 remove the "trimmedIds = ids" above and uncomment the following line instead.
-				// throw new Error("Missing range starts data for id replacement trimming.");
-			} else {
-				[rangeStart, rangeEnd] = dep.idRanges[idx];
-			}
-		}
+		const {
+			trimmedRange: [trimmedRangeStart, trimmedRangeEnd],
+			trimmedIds
+		} = getTrimmedIdsAndRange(
+			dep.getIds(moduleGraph),
+			dep.range,
+			dep.idRanges,
+			moduleGraph,
+			dep
+		);
 
 		const exportExpr = this._getCodeForIds(
 			dep,
@@ -356,47 +343,10 @@ HarmonyImportSpecifierDependency.Template = class HarmonyImportSpecifierDependen
 			trimmedIds
 		);
 		if (dep.shorthand) {
-			source.insert(rangeEnd, `: ${exportExpr}`);
+			source.insert(trimmedRangeEnd, `: ${exportExpr}`);
 		} else {
-			source.replace(rangeStart, rangeEnd - 1, exportExpr);
+			source.replace(trimmedRangeStart, trimmedRangeEnd - 1, exportExpr);
 		}
-	}
-
-	/**
-	 * @summary Determine which IDs in the id chain are actually referring to namespaces or imports,
-	 * and which are deeper member accessors on the imported object.  Only the former should be re-rendered.
-	 * @param {string[]} ids ids
-	 * @param {ModuleGraph} moduleGraph moduleGraph
-	 * @param {HarmonyImportSpecifierDependency} dependency dependency
-	 * @returns {string[]} generated code
-	 */
-	_trimIdsToThoseImported(ids, moduleGraph, dependency) {
-		/** @type {string[]} */
-		let trimmedIds = [];
-		const exportsInfo = moduleGraph.getExportsInfo(
-			/** @type {Module} */ (moduleGraph.getModule(dependency))
-		);
-		let currentExportsInfo = /** @type {ExportsInfo=} */ exportsInfo;
-		for (let i = 0; i < ids.length; i++) {
-			if (i === 0 && ids[i] === "default") {
-				continue; // ExportInfo for the next level under default is still at the root ExportsInfo, so don't advance currentExportsInfo
-			}
-			const exportInfo = currentExportsInfo.getExportInfo(ids[i]);
-			if (exportInfo.provided === false) {
-				// json imports have nested ExportInfo for elements that things that are not actually exported, so check .provided
-				trimmedIds = ids.slice(0, i);
-				break;
-			}
-			const nestedInfo = exportInfo.getNestedExportsInfo();
-			if (!nestedInfo) {
-				// once all nested exports are traversed, the next item is the actual import so stop there
-				trimmedIds = ids.slice(0, i + 1);
-				break;
-			}
-			currentExportsInfo = nestedInfo;
-		}
-		// Never trim to nothing.  This can happen for invalid imports (e.g. import { notThere } from "./module", or import { anything } from "./missingModule")
-		return trimmedIds.length ? trimmedIds : ids;
 	}
 
 	/**

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -363,25 +363,27 @@ class JavascriptParser extends Parser {
 					])
 			),
 			/** Something like "a.b().c.d" */
-			/** @type {HookMap<SyncBailHook<[Expression, string[], CallExpression, string[]], boolean | void>>} */
+			/** @type {HookMap<SyncBailHook<[Expression, string[], CallExpression, string[], Range[]], boolean | void>>} */
 			memberChainOfCallMemberChain: new HookMap(
 				() =>
 					new SyncBailHook([
 						"expression",
 						"calleeMembers",
 						"callExpression",
-						"members"
+						"members",
+						"memberRanges"
 					])
 			),
 			/** Something like "a.b().c.d()"" */
-			/** @type {HookMap<SyncBailHook<[CallExpression, string[], CallExpression, string[]], boolean | void>>} */
+			/** @type {HookMap<SyncBailHook<[CallExpression, string[], CallExpression, string[], Range[]], boolean | void>>} */
 			callMemberChainOfCallMemberChain: new HookMap(
 				() =>
 					new SyncBailHook([
 						"expression",
 						"calleeMembers",
 						"innerCallExpression",
-						"members"
+						"members",
+						"memberRanges"
 					])
 			),
 			/** @type {SyncBailHook<[ChainExpression], boolean | void>} */
@@ -3274,7 +3276,8 @@ class JavascriptParser extends Parser {
 						expression,
 						exprInfo.getCalleeMembers(),
 						exprInfo.call,
-						exprInfo.getMembers()
+						exprInfo.getMembers(),
+						exprInfo.getMemberRanges()
 					);
 					if (result === true) return;
 				}
@@ -3365,7 +3368,8 @@ class JavascriptParser extends Parser {
 						expression,
 						exprInfo.getCalleeMembers(),
 						exprInfo.call,
-						exprInfo.getMembers()
+						exprInfo.getMembers(),
+						exprInfo.getMemberRanges()
 					);
 					if (result === true) return;
 					// Fast skip over the member chain as we already called memberChainOfCallMemberChain

--- a/lib/util/chainedImports.js
+++ b/lib/util/chainedImports.js
@@ -1,0 +1,96 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+/** @typedef {import("../Dependency")} Dependency */
+/** @typedef {import("../ModuleGraph")} ModuleGraph */
+/** @typedef {import("../javascript/JavascriptParser").Range} Range */
+
+/**
+ * @summary Get the subset of ids and their corresponding range in an id chain that should be re-rendered by webpack.
+ * Only those in the chain that are actually referring to namespaces or imports should be re-rendered.
+ * Deeper member accessors on the imported object should not be re-rendered.  If deeper member accessors are re-rendered,
+ * there is a potential loss of meaning with rendering a quoted accessor as an unquoted accessor, or vice versa,
+ * because minifiers treat quoted accessors differently.  e.g. import { a } from "./module"; a["b"] vs a.b
+ * @param {string[]} untrimmedIds chained ids
+ * @param {Range} untrimmedRange range encompassing allIds
+ * @param {Range[]} ranges cumulative range of ids for each of allIds
+ * @param {ModuleGraph} moduleGraph moduleGraph
+ * @param {Dependency} dependency dependency
+ * @returns {{trimmedIds: string[], trimmedRange: Range}} computed trimmed ids and cumulative range of those ids
+ */
+exports.getTrimmedIdsAndRange = (
+	untrimmedIds,
+	untrimmedRange,
+	ranges,
+	moduleGraph,
+	dependency
+) => {
+	let trimmedIds = trimIdsToThoseImported(
+		untrimmedIds,
+		moduleGraph,
+		dependency
+	);
+	let trimmedRange = untrimmedRange;
+	if (trimmedIds.length !== untrimmedIds.length) {
+		// The array returned from dep.idRanges is right-aligned with the array returned from dep.names.
+		// Meaning, the two arrays may not always have the same number of elements, but the last element of
+		// dep.idRanges corresponds to [the expression fragment to the left of] the last element of dep.names.
+		// Use this to find the correct replacement range based on the number of ids that were trimmed.
+		const idx =
+			ranges === undefined
+				? -1 /* trigger failure case below */
+				: ranges.length + (trimmedIds.length - untrimmedIds.length);
+		if (idx < 0 || idx >= ranges.length) {
+			// cspell:ignore minifiers
+			// Should not happen but we can't throw an error here because of backward compatibility with
+			// external plugins in wp5.  Instead, we just disable trimming for now.  This may break some minifiers.
+			trimmedIds = untrimmedIds;
+			// TODO webpack 6 remove the "trimmedIds = ids" above and uncomment the following line instead.
+			// throw new Error("Missing range starts data for id replacement trimming.");
+		} else {
+			trimmedRange = ranges[idx];
+		}
+	}
+
+	return { trimmedIds, trimmedRange };
+};
+
+/**
+ * @summary Determine which IDs in the id chain are actually referring to namespaces or imports,
+ * and which are deeper member accessors on the imported object.
+ * @param {string[]} ids untrimmed ids
+ * @param {ModuleGraph} moduleGraph moduleGraph
+ * @param {Dependency} dependency dependency
+ * @returns {string[]} trimmed ids
+ */
+function trimIdsToThoseImported(ids, moduleGraph, dependency) {
+	let trimmedIds = [];
+	const exportsInfo = moduleGraph.getExportsInfo(
+		moduleGraph.getModule(dependency)
+	);
+	let currentExportsInfo = /** @type {ExportsInfo=} */ exportsInfo;
+	for (let i = 0; i < ids.length; i++) {
+		if (i === 0 && ids[i] === "default") {
+			continue; // ExportInfo for the next level under default is still at the root ExportsInfo, so don't advance currentExportsInfo
+		}
+		const exportInfo = currentExportsInfo.getExportInfo(ids[i]);
+		if (exportInfo.provided === false) {
+			// json imports have nested ExportInfo for elements that things that are not actually exported, so check .provided
+			trimmedIds = ids.slice(0, i);
+			break;
+		}
+		const nestedInfo = exportInfo.getNestedExportsInfo();
+		if (!nestedInfo) {
+			// once all nested exports are traversed, the next item is the actual import so stop there
+			trimmedIds = ids.slice(0, i + 1);
+			break;
+		}
+		currentExportsInfo = nestedInfo;
+	}
+	// Never trim to nothing.  This can happen for invalid imports (e.g. import { notThere } from "./module", or import { anything } from "./missingModule")
+	return trimmedIds.length ? trimmedIds : ids;
+}

--- a/test/configCases/code-generation/re-export-namespace-concat/index.js
+++ b/test/configCases/code-generation/re-export-namespace-concat/index.js
@@ -34,6 +34,10 @@ it("should use/preserve accessor form for import object and namespaces", functio
 
 		const bb = obj1.up.down?.left.right;
 
+		const ww = require('./module1').obj1["bing"]?.bang;
+		const xx = require('./module1').obj1["pip"].pop();
+		const yy = require('./module3')["m_2"]["m_1"]["obj1"]["tip"].top();
+
 		data.nested.object3["unknownProperty"].depth = "deep";
 
 		(obj1)["aaa"].bbb;
@@ -48,28 +52,32 @@ it("should use/preserve accessor form for import object and namespaces", functio
 	// Imported objects and import namespaces should use dot notation.  Any references to the properties of exports
 	// should be preserved as either quotes or dot notation, depending on the original source.
 
-	expectSourceToContain(source, 'const x1 = module1_namespaceObject;');
-	expectSourceToContain(source, 'const x2 = obj1;');
+	expectSourceToContain(source, 'const x1 = module1;');
+	expectSourceToContain(source, 'const x2 = module1.obj1;');
 
-	expectSourceToContain(source, 'const z1 = obj1["plants"];');
-	expectSourceToContain(source, 'const z2 = obj1["funcs"]();');
-	expectSourceToContain(source, 'const z3 = obj1["pots"];');
-	expectSourceToContain(source, 'const z4 = obj1["subs"]();');
+	expectSourceToContain(source, 'const z1 = module1.obj1["plants"];');
+	expectSourceToContain(source, 'const z2 = module1.obj1["funcs"]();');
+	expectSourceToContain(source, 'const z3 = module1.obj1["pots"];');
+	expectSourceToContain(source, 'const z4 = module1.obj1["subs"]();');
 
-	expectSourceToContain(source, 'const a = obj1["flip"].flap;');
-	expectSourceToContain(source, 'const b = obj1.zip["zap"];');
-	expectSourceToContain(source, 'const c = obj1["ding"].dong();');
-	expectSourceToContain(source, 'const d = obj1.sing["song"]();');
+	expectSourceToContain(source, 'const a = module2/* m_1.obj1 */.a.obj1["flip"].flap;');
+	expectSourceToContain(source, 'const b = module2/* m_1.obj1 */.a.obj1.zip["zap"];');
+	expectSourceToContain(source, 'const c = module2/* m_1.obj1 */.a.obj1["ding"].dong();');
+	expectSourceToContain(source, 'const d = module2/* m_1.obj1 */.a.obj1.sing["song"]();');
 
-	expectSourceToContain(source, 'const aa = obj1["zoom"];');
+	expectSourceToContain(source, 'const aa = module3/* m_2.m_1.obj1 */.a.a.obj1["zoom"];');
 
-	expectSourceToContain(source, 'const bb = obj1.up.down?.left.right;');
+	expectSourceToContain(source, 'const bb = module1.obj1.up.down?.left.right;');
+
+	expectSourceToContain(source, 'const ww = (__webpack_require__(/*! ./module1 */ 960).obj1)["bing"]?.bang;');
+	expectSourceToContain(source, 'const xx = (__webpack_require__(/*! ./module1 */ 960).obj1)["pip"].pop();');
+	expectSourceToContain(source, 'const yy = (__webpack_require__(/*! ./module3 */ 834)/* .m_2.m_1.obj1 */ .a.a.obj1)["tip"].top();');
 
 	expectSourceToContain(source, 'data_namespaceObject.a.a["unknownProperty"].depth = "deep";');
 
-	expectSourceToContain(source, '(obj1)["aaa"].bbb;');
-	expectSourceToContain(source, '(obj1)["ccc"].ddd;');
-	expectSourceToContain(source, '(obj1["eee"]).fff;');
-	expectSourceToContain(source, '(obj1["ggg"]).hhh;');
-	expectSourceToContain(source, '((obj1)["iii"]).jjj;');
+	expectSourceToContain(source, '(module1.obj1)["aaa"].bbb;');
+	expectSourceToContain(source, '(module1.obj1)["ccc"].ddd;');
+	expectSourceToContain(source, '(module1.obj1["eee"]).fff;');
+	expectSourceToContain(source, '(module1.obj1["ggg"]).hhh;');
+	expectSourceToContain(source, '((module1.obj1)["iii"]).jjj;');
 });

--- a/test/configCases/code-generation/re-export-namespace/index.js
+++ b/test/configCases/code-generation/re-export-namespace/index.js
@@ -34,6 +34,10 @@ it("should use/preserve accessor form for import object and namespaces", functio
 
 		const bb = obj1.up.down?.left.right;
 
+		const ww = require('./module1').obj1["bing"]?.bang;
+		const xx = require('./module1').obj1["pip"].pop();
+		const yy = require('./module3')["m_2"]["m_1"]["obj1"]["tip"].top();
+
 		data.nested.object3["unknownProperty"].depth = "deep";
 
 		(obj1)["aaa"].bbb;
@@ -64,6 +68,10 @@ it("should use/preserve accessor form for import object and namespaces", functio
 	expectSourceToContain(source, 'const aa = _module3__WEBPACK_IMPORTED_MODULE_2__.m_2.m_1.obj1["zoom"];');
 
 	expectSourceToContain(source, 'const bb = _module1__WEBPACK_IMPORTED_MODULE_0__.obj1.up.down?.left.right;');
+
+	expectSourceToContain(source, 'const ww = (__webpack_require__(/*! ./module1 */ 960).obj1)["bing"]?.bang;');
+	expectSourceToContain(source, 'const xx = (__webpack_require__(/*! ./module1 */ 960).obj1)["pip"].pop();');
+	expectSourceToContain(source, 'const yy = (__webpack_require__(/*! ./module3 */ 834).m_2.m_1.obj1)["tip"].top();');
 
 	expectSourceToContain(source, '_data__WEBPACK_IMPORTED_MODULE_3__.nested.object3["unknownProperty"].depth = "deep";');
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -7282,7 +7282,6 @@ declare interface LoaderRunnerLoaderContext<OptionsType> {
 	/**
 	 * An array of all the loaders. It is writeable in the pitch phase.
 	 * loaders = [{request: string, path: string, query: string, module: function}]
-	 *
 	 * In the example:
 	 * [
 	 *   { request: "/abc/loader1.js?xyz",

--- a/types.d.ts
+++ b/types.d.ts
@@ -5521,13 +5521,13 @@ declare class JavascriptParser extends Parser {
 		>;
 		memberChainOfCallMemberChain: HookMap<
 			SyncBailHook<
-				[Expression, string[], CallExpression, string[]],
+				[Expression, string[], CallExpression, string[], [number, number][]],
 				boolean | void
 			>
 		>;
 		callMemberChainOfCallMemberChain: HookMap<
 			SyncBailHook<
-				[CallExpression, string[], CallExpression, string[]],
+				[CallExpression, string[], CallExpression, string[], [number, number][]],
 				boolean | void
 			>
 		>;

--- a/types.d.ts
+++ b/types.d.ts
@@ -5527,7 +5527,13 @@ declare class JavascriptParser extends Parser {
 		>;
 		callMemberChainOfCallMemberChain: HookMap<
 			SyncBailHook<
-				[CallExpression, string[], CallExpression, string[], [number, number][]],
+				[
+					CallExpression,
+					string[],
+					CallExpression,
+					string[],
+					[number, number][]
+				],
 				boolean | void
 			>
 		>;
@@ -7276,6 +7282,7 @@ declare interface LoaderRunnerLoaderContext<OptionsType> {
 	/**
 	 * An array of all the loaders. It is writeable in the pitch phase.
 	 * loaders = [{request: string, path: string, query: string, module: function}]
+	 *
 	 * In the example:
 	 * [
 	 *   { request: "/abc/loader1.js?xyz",


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

This is a follow-on to #17203 which handled harmony imports.  This PR handles commonjs imports.  This chained expression handling is required for Closure Compiler operation in ADVANCED mode.  Fixes #17723.

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b14922c</samp>

This pull request refactors the code generation and dependency handling of webpack for commonjs and harmony imports with chained ids. It introduces a new utility function `getTrimmedIdsAndRange` in `lib/util/chainedImports.js` to simplify and unify the logic for trimming ids. It also updates and adds test cases to verify the output quality and coverage.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b14922c</samp>

*  Refactor the logic for trimming ids from different types of dependencies into a separate module and a common function `getTrimmedIdsAndRange` ([link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-909547cbc1eb47fcb0acb526ef7425db14f5db8fd245f905101087da9662b9c6R10), [link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-96335405b47eef62b17ba6fe88f6b35a1e37c9cf98fd762fe74599aca1c65d94R12), [link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-87b948b29d0fac0f4f8eb8d2ce9e38685cf285a3fa2fb605886d586fe3606b7eR1-R96))
*  Add a new parameter `idRanges` to the `CommonJsFullRequireDependency` constructor and the related hook handlers, and make it optional for backward compatibility ([link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-909547cbc1eb47fcb0acb526ef7425db14f5db8fd245f905101087da9662b9c6L29-R41), [link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-5d5dfc7dd1201960b7b86251175d7f0e85343b05f6528bcd4da0cd4ba9398e59L382-R391), [link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-5d5dfc7dd1201960b7b86251175d7f0e85343b05f6528bcd4da0cd4ba9398e59L410-R427), [link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L366-R366), [link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L373-R378), [link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L384-R386))
*  Update the serialization and deserialization logic of the `CommonJsFullRequireDependency` class to include the `idRanges` property ([link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-909547cbc1eb47fcb0acb526ef7425db14f5db8fd245f905101087da9662b9c6R71), [link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-909547cbc1eb47fcb0acb526ef7425db14f5db8fd245f905101087da9662b9c6R83))
*  Update the `apply` method of the `CommonJsFullRequireDependency` class to use the `getTrimmedIdsAndRange` function and the `idRanges` property for computing and replacing the trimmed ids and range ([link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-909547cbc1eb47fcb0acb526ef7425db14f5db8fd245f905101087da9662b9c6L120-R149), [link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-909547cbc1eb47fcb0acb526ef7425db14f5db8fd245f905101087da9662b9c6L136-R157))
*  Update the `chainHandler` and `callChainHandler` functions in the `CommonJsImportsParserPlugin` class to pass the `idRanges` parameter to the `CommonJsFullRequireDependency` constructor ([link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-5d5dfc7dd1201960b7b86251175d7f0e85343b05f6528bcd4da0cd4ba9398e59L394-R402), [link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-5d5dfc7dd1201960b7b86251175d7f0e85343b05f6528bcd4da0cd4ba9398e59L422-R438))
*  Update the `apply` method of the `HarmonyImportSpecifierDependency` class to use the `getTrimmedIdsAndRange` function for computing the trimmed ids and range ([link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-96335405b47eef62b17ba6fe88f6b35a1e37c9cf98fd762fe74599aca1c65d94L327-R338))
*  Remove the unused `_trimIdsToThoseImported` method from the `HarmonyImportSpecifierDependency` class ([link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-96335405b47eef62b17ba6fe88f6b35a1e37c9cf98fd762fe74599aca1c65d94L359-R352))
*  Update the `walkMemberExpression` and `walkCallExpression` methods of the `JavascriptParser` class to pass the `memberRanges` parameter to the hook handlers ([link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L3277-R3280), [link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-561daa0feb66d49c350f9f8296e8f9bfe50a7ed5efbb4226d2b512aa20d201f2L3368-R3372))
*  Add some new test cases to the `test/configCases/code-generation/re-export-namespace-concat/index.js` and `test/configCases/code-generation/re-export-namespace/index.js` files to check the behavior of webpack when re-exporting namespaces with concatenated ids ([link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-f7c761df47d625cac2713c4a49ef486cefbc53234bcff9a30bb218cb82f73d46R37-R40), [link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-3dd97285b143466099ecf4d1cd0740fcc727d814dde7b199e4a0a66782acab80R37-R40))
*  Update the expected output of the test cases in the `test/configCases/code-generation/re-export-namespace-concat/index.js` and `test/configCases/code-generation/re-export-namespace/index.js` files to reflect the changes made by the refactoring and the feature of trimming ids ([link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-f7c761df47d625cac2713c4a49ef486cefbc53234bcff9a30bb218cb82f73d46L51-R82), [link](https://github.com/webpack/webpack/pull/17718/files?diff=unified&w=0#diff-3dd97285b143466099ecf4d1cd0740fcc727d814dde7b199e4a0a66782acab80R72-R75))
