### PR TITLE
Feature/container entry module/add has method

### DIFF
--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -224,7 +224,7 @@ class ContainerEntryModule extends Module {
 				"return getScope;"
 			])};`,
 			`var has = ${runtimeTemplate.basicFunction("module, getScope", [
-				`return ${RuntimeGlobals.hasOwnProperty}(moduleMap, module);`;
+				`return ${RuntimeGlobals.hasOwnProperty}(moduleMap, module);`
 			])};`,
 			`var init = ${runtimeTemplate.basicFunction("shareScope, initScope", [
 				`if (!${RuntimeGlobals.shareScopeMap}) return;`,

--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -108,7 +108,7 @@ class ContainerEntryModule extends Module {
 		this.buildMeta = {};
 		this.buildInfo = {
 			strict: true,
-			topLevelDeclarations: new Set(["moduleMap", "get", "init"])
+			topLevelDeclarations: new Set(["moduleMap", "get", "init", "has"])
 		};
 		this.buildMeta.exportsType = "namespace";
 
@@ -134,7 +134,7 @@ class ContainerEntryModule extends Module {
 			}
 			this.addBlock(block);
 		}
-		this.addDependency(new StaticExportsDependency(["get", "init"], false));
+		this.addDependency(new StaticExportsDependency(["get", "init", "has"], false));
 
 		callback();
 	}
@@ -224,7 +224,7 @@ class ContainerEntryModule extends Module {
 				"return getScope;"
 			])};`,
 			`var has = ${runtimeTemplate.basicFunction("module, getScope", [
-				`return ${RuntimeGlobals.hasOwnProperty}(moduleMap, module);`
+				`return ${RuntimeGlobals.hasOwnProperty}(moduleMap, module);`;
 			])};`,
 			`var init = ${runtimeTemplate.basicFunction("shareScope, initScope", [
 				`if (!${RuntimeGlobals.shareScopeMap}) return;`,
@@ -238,7 +238,7 @@ class ContainerEntryModule extends Module {
 			"// This exports getters to disallow modifications",
 			`${RuntimeGlobals.definePropertyGetters}(exports, {`,
 			Template.indent([
-				`has: ${runtimeTemplate.returningFunction("has")},`
+				`has: ${runtimeTemplate.returningFunction("has")},`,
 				`get: ${runtimeTemplate.returningFunction("get")},`,
 				`init: ${runtimeTemplate.returningFunction("init")}`
 			]),

--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -224,7 +224,7 @@ class ContainerEntryModule extends Module {
 				"return getScope;"
 			])};`,
 			`var has = ${runtimeTemplate.basicFunction("module, getScope", [
-				`return ${RuntimeGlobals.hasOwnProperty}(moduleMap, module)`
+				`return ${RuntimeGlobals.hasOwnProperty}(moduleMap, module);`
 			])};`,
 			`var init = ${runtimeTemplate.basicFunction("shareScope, initScope", [
 				`if (!${RuntimeGlobals.shareScopeMap}) return;`,

--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -223,6 +223,9 @@ class ContainerEntryModule extends Module {
 				`${RuntimeGlobals.currentRemoteGetScope} = undefined;`,
 				"return getScope;"
 			])};`,
+			`var has = ${runtimeTemplate.basicFunction("module, getScope", [
+				`return ${RuntimeGlobals.hasOwnProperty}(moduleMap, module)`
+			])};`,
 			`var init = ${runtimeTemplate.basicFunction("shareScope, initScope", [
 				`if (!${RuntimeGlobals.shareScopeMap}) return;`,
 				`var name = ${JSON.stringify(this._shareScope)}`,
@@ -235,6 +238,7 @@ class ContainerEntryModule extends Module {
 			"// This exports getters to disallow modifications",
 			`${RuntimeGlobals.definePropertyGetters}(exports, {`,
 			Template.indent([
+				`has: ${runtimeTemplate.returningFunction("has")},`
 				`get: ${runtimeTemplate.returningFunction("get")},`,
 				`init: ${runtimeTemplate.returningFunction("init")}`
 			]),


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

Added a method to check if a module is present in a container without downloading all the module's dependencies.


<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77e4521</samp>

This pull request enhances the `ContainerEntryModule` to support module existence checks. It adds a `has` function to the runtime code and exposes it as a `get.has` property.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 77e4521</samp>

*  Add `has` function to check module availability in container ([link](https://github.com/webpack/webpack/pull/17722/files?diff=unified&w=0#diff-c798734f94334ac7c470ee7fe7966504acc68e5b4bf0d5e3a6080e189202f189R226-R228), [link](https://github.com/webpack/webpack/pull/17722/files?diff=unified&w=0#diff-c798734f94334ac7c470ee7fe7966504acc68e5b4bf0d5e3a6080e189202f189R241))
  - Define `has` function in runtime code of `ContainerEntryModule` ([link](https://github.com/webpack/webpack/pull/17722/files?diff=unified&w=0#diff-c798734f94334ac7c470ee7fe7966504acc68e5b4bf0d5e3a6080e189202f189R226-R228))
  - Attach `has` function as property of `get` function ([link](https://github.com/webpack/webpack/pull/17722/files?diff=unified&w=0#diff-c798734f94334ac7c470ee7fe7966504acc68e5b4bf0d5e3a6080e189202f189R241))
