### PR TITLE
fix: propagate strictModuleErrorHandling through option normalization

### DIFF
--- a/lib/config/normalization.js
+++ b/lib/config/normalization.js
@@ -382,6 +382,7 @@ const getNormalizedWebpackOptions = config => {
 				publicPath: output.publicPath,
 				sourceMapFilename: output.sourceMapFilename,
 				sourcePrefix: output.sourcePrefix,
+				strictModuleErrorHandling: output.strictModuleErrorHandling,
 				strictModuleExceptionHandling: output.strictModuleExceptionHandling,
 				trustedTypes: optionalNestedConfig(
 					output.trustedTypes,

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -373,6 +373,7 @@ describe("snapshots", () => {
 		    "scriptType": false,
 		    "sourceMapFilename": "[file].map[query]",
 		    "sourcePrefix": undefined,
+		    "strictModuleErrorHandling": undefined,
 		    "strictModuleExceptionHandling": false,
 		    "trustedTypes": undefined,
 		    "uniqueName": "webpack",


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Fixes https://github.com/webpack/webpack/issues/17727

## Summary

Found after running into https://github.com/webpack/webpack/issues/17714, I saw from webpack's source that there are two options, `strictModuleErrorHandling` and `strictModuleExceptionHandling`,  that solve the issue where an error being thrown on a module would result in a partially-incomplete loaded module.

When I tried using those options, `strictModuleExceptionHandling` worked but it's marked as deprecated, pointing to use `strictModuleErrorHandling` instead. However, using `strictModuleErrorHandling` generated the same code as if none of those options was active

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8452a92</samp>

Add `strictModuleErrorHandling` option to control error handling in modules. This option is normalized from the user output configuration in `lib/config/normalization.js`.

## Details

The issue happens to be on option normalisation, the property `strictModuleErrorHandling` was not brought over to the normalised options. This PR fixes this by adding it.

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8452a92</samp>

* Add a new option `strictModuleErrorHandling` to control how webpack handles errors in modules ([link](https://github.com/webpack/webpack/pull/17728/files?diff=unified&w=0#diff-cabfbdeecf612ff3fd25c03f2f6ff1ba78765ee15717e6ff2a42ee61bcf89da2R385),                            F0L411R
