### PR TITLE
Repro for issue #17740

### DIFF
--- a/test/configCases/inner-graph/extends/index.js
+++ b/test/configCases/inner-graph/extends/index.js
@@ -1,0 +1,23 @@
+
+import { ExtendedError, a } from "./library";
+
+const { expectSourceToContain } = require("../../../helpers/expectSource");
+
+it("should not create an invalid extends clause", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8").toString();
+
+	// Reference the imports to generate uses in the source.
+
+	const f = false;
+	if (f) {
+		console.log(a);
+	}
+
+	/************ DO NOT MATCH BELOW THIS LINE ************/
+
+	// This currently fails because webpack generates invalid JS: "class ExtendedError extends (/* unused pure expression or super */ null && (Error)) {"
+	expectSourceToContain(source, 'export class ExtendedError extends Error');
+});
+
+

--- a/test/configCases/inner-graph/extends/library.js
+++ b/test/configCases/inner-graph/extends/library.js
@@ -1,0 +1,7 @@
+export class ExtendedError extends Error {
+	constructor(message = 'ExtendedError') {
+			super(message);
+	}
+}
+
+export const a = 42;

--- a/test/configCases/inner-graph/extends/webpack.config.js
+++ b/test/configCases/inner-graph/extends/webpack.config.js
@@ -1,0 +1,8 @@
+const getConfig = concatenateModules => ({
+	mode: "production",
+	optimization: {
+		concatenateModules
+	}
+});
+
+module.exports = [getConfig(false), getConfig(true)];


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d89bc01</samp>

This pull request adds a new test case to verify that webpack handles class inheritance correctly when concatenating modules. It uses a library module that exports a class that extends `Error` and a test file that imports and uses the class. It also adds a webpack configuration file that toggles the `concatenateModules` option.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d89bc01</samp>

* Add a test case to verify that webpack does not generate an invalid extends clause when concatenating modules ([link](https://github.com/webpack/webpack/pull/17739/files?diff=unified&w=0#diff-6bf01dd3399c79ea8e961d4376e478962a8ef1f0e5f2b29f4188f774365a8ec5R1-R23), [link](https://github.com/webpack/webpack/pull/17739/files?diff=unified&w=0#diff-6da5aa31836d6bb587df62e2ae9a2a7a1e02dabf953066e92df962bac890e99cR1-R7), [link](https://github.com/webpack/webpack/pull/17739/files?diff=unified&w=0#diff-c9848667bbd1bcc49b2d8d910c29cf85d6154253590fb955f72dd0d3d2bf0c9fR1-R8))
  - Import a class that extends `Error` from `library.js` and expect the source code to contain `export { MyError }` ([link](https://github.com/webpack/webpack/pull/17739/files?diff=unified&w=0#diff-6bf01dd3399c79ea8e961d4376e478962a8ef1f0e5f2b29f4188f774365a8ec5R1-R23))
  - Use a helper function to assert that the source code contains a given string ([link](https://github.com/webpack/webpack/pull/17739/files?diff=unified&w=0#diff-6bf01dd3399c79ea8e961d4376e478962a8ef1f0e5f2b29f4188f774365a8ec5R1-R23))
  - Export a class that extends `Error` and a constant value from `library.js` to create a reference to the module ([link](https://github.com/webpack/webpack/pull/17739/files?diff=unified&w=0#diff-6da5aa31836d6bb587df62e2ae9a2a7a1e02dabf953066e92df962bac890e99cR1-R7))
  - Export two configurations with `concatenateModules` set to `false` and `true` respectively from `webpack.config.js` and run the test with both ([link](https://github.com/webpack/webpack/pull/17739/files?diff=unified&w=0#diff-c9848667bbd1bcc49b2d8d910c29cf85d6154253590fb955f72dd0d3d2bf0c9fR1-R8))
