### PR TITLE
minimize redundant `Template.toIdentifier` calls

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -870,22 +870,11 @@ const applyOutputDefaults = (
 	D(output, "webassemblyModuleFilename", "[hash].module.wasm");
 	D(output, "compareBeforeEmit", true);
 	D(output, "charset", true);
-	F(output, "hotUpdateGlobal", () =>
-		Template.toIdentifier(
-			"webpackHotUpdate" +
-				Template.toIdentifier(
-					/** @type {NonNullable<Output["uniqueName"]>} */ (output.uniqueName)
-				)
-		)
+	const uniqueNameId = Template.toIdentifier(
+		/** @type {NonNullable<Output["uniqueName"]>} */ (output.uniqueName)
 	);
-	F(output, "chunkLoadingGlobal", () =>
-		Template.toIdentifier(
-			"webpackChunk" +
-				Template.toIdentifier(
-					/** @type {NonNullable<Output["uniqueName"]>} */ (output.uniqueName)
-				)
-		)
-	);
+	F(output, "hotUpdateGlobal", () => "webpackHotUpdate" + uniqueNameId);
+	F(output, "chunkLoadingGlobal", () => "webpackChunk" + uniqueNameId);
 	F(output, "globalObject", () => {
 		if (tp) {
 			if (tp.global) return "global";


### PR DESCRIPTION
There's no need to compute `﻿Template.toIdentifier(output.uniqueName)` twice or execute it for `﻿${webpackHotUpdate}${result}` and `﻿${webpackChunk}${result}`.