### PR TITLE
fix: using chunkGraph from hook context

### DIFF
--- a/lib/APIPlugin.js
+++ b/lib/APIPlugin.js
@@ -163,18 +163,23 @@ class APIPlugin {
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.chunkName)
-					.tap(PLUGIN_NAME, chunk => {
+					.tap(PLUGIN_NAME, (chunk, _, { chunkGraph }) => {
 						compilation.addRuntimeModule(
 							chunk,
-							new ChunkNameRuntimeModule(chunk.name)
+							new ChunkNameRuntimeModule(chunk.name),
+							chunkGraph
 						);
 						return true;
 					});
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.getFullHash)
-					.tap(PLUGIN_NAME, (chunk, set) => {
-						compilation.addRuntimeModule(chunk, new GetFullHashRuntimeModule());
+					.tap(PLUGIN_NAME, (chunk, set, { chunkGraph }) => {
+						compilation.addRuntimeModule(
+							chunk,
+							new GetFullHashRuntimeModule(),
+							chunkGraph
+						);
 						return true;
 					});
 

--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -749,14 +749,15 @@ To fix this, make sure to include [runtime] in the output.hotUpdateMainFilename 
 
 				compilation.hooks.additionalTreeRuntimeRequirements.tap(
 					PLUGIN_NAME,
-					(chunk, runtimeRequirements) => {
+					(chunk, runtimeRequirements, { chunkGraph }) => {
 						runtimeRequirements.add(RuntimeGlobals.hmrDownloadManifest);
 						runtimeRequirements.add(RuntimeGlobals.hmrDownloadUpdateHandlers);
 						runtimeRequirements.add(RuntimeGlobals.interceptModuleExecution);
 						runtimeRequirements.add(RuntimeGlobals.moduleCache);
 						compilation.addRuntimeModule(
 							chunk,
-							new HotModuleReplacementRuntimeModule()
+							new HotModuleReplacementRuntimeModule(),
+							chunkGraph
 						);
 					}
 				);

--- a/lib/RuntimePlugin.js
+++ b/lib/RuntimePlugin.js
@@ -147,58 +147,67 @@ class RuntimePlugin {
 			}
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.definePropertyGetters)
-				.tap("RuntimePlugin", chunk => {
+				.tap("RuntimePlugin", (chunk, _, { chunkGraph }) => {
 					compilation.addRuntimeModule(
 						chunk,
-						new DefinePropertyGettersRuntimeModule()
+						new DefinePropertyGettersRuntimeModule(),
+						chunkGraph
 					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.makeNamespaceObject)
-				.tap("RuntimePlugin", chunk => {
+				.tap("RuntimePlugin", (chunk, _, { chunkGraph }) => {
 					compilation.addRuntimeModule(
 						chunk,
-						new MakeNamespaceObjectRuntimeModule()
+						new MakeNamespaceObjectRuntimeModule(),
+						chunkGraph
 					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.createFakeNamespaceObject)
-				.tap("RuntimePlugin", chunk => {
+				.tap("RuntimePlugin", (chunk, _, { chunkGraph }) => {
 					compilation.addRuntimeModule(
 						chunk,
-						new CreateFakeNamespaceObjectRuntimeModule()
+						new CreateFakeNamespaceObjectRuntimeModule(),
+						chunkGraph
 					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.hasOwnProperty)
-				.tap("RuntimePlugin", chunk => {
+				.tap("RuntimePlugin", (chunk, _, { chunkGraph }) => {
 					compilation.addRuntimeModule(
 						chunk,
-						new HasOwnPropertyRuntimeModule()
+						new HasOwnPropertyRuntimeModule(),
+						chunkGraph
 					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.compatGetDefaultExport)
-				.tap("RuntimePlugin", chunk => {
+				.tap("RuntimePlugin", (chunk, _, { chunkGraph }) => {
 					compilation.addRuntimeModule(
 						chunk,
-						new CompatGetDefaultExportRuntimeModule()
+						new CompatGetDefaultExportRuntimeModule(),
+						chunkGraph
 					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.runtimeId)
-				.tap("RuntimePlugin", chunk => {
-					compilation.addRuntimeModule(chunk, new RuntimeIdRuntimeModule());
+				.tap("RuntimePlugin", (chunk, _, { chunkGraph }) => {
+					compilation.addRuntimeModule(
+						chunk,
+						new RuntimeIdRuntimeModule(),
+						chunkGraph
+					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.publicPath)
-				.tap("RuntimePlugin", (chunk, set) => {
+				.tap("RuntimePlugin", (chunk, set, { chunkGraph }) => {
 					const { outputOptions } = compilation;
 					const { publicPath: globalPublicPath, scriptType } = outputOptions;
 					const entryOptions = chunk.getEntryOptions();
@@ -210,7 +219,7 @@ class RuntimePlugin {
 					if (publicPath === "auto") {
 						const module = new AutoPublicPathRuntimeModule();
 						if (scriptType !== "module") set.add(RuntimeGlobals.global);
-						compilation.addRuntimeModule(chunk, module);
+						compilation.addRuntimeModule(chunk, module, chunkGraph);
 					} else {
 						const module = new PublicPathRuntimeModule(publicPath);
 
@@ -221,25 +230,33 @@ class RuntimePlugin {
 							module.fullHash = true;
 						}
 
-						compilation.addRuntimeModule(chunk, module);
+						compilation.addRuntimeModule(chunk, module, chunkGraph);
 					}
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.global)
-				.tap("RuntimePlugin", chunk => {
-					compilation.addRuntimeModule(chunk, new GlobalRuntimeModule());
+				.tap("RuntimePlugin", (chunk, _, { chunkGraph }) => {
+					compilation.addRuntimeModule(
+						chunk,
+						new GlobalRuntimeModule(),
+						chunkGraph
+					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.asyncModule)
-				.tap("RuntimePlugin", chunk => {
-					compilation.addRuntimeModule(chunk, new AsyncModuleRuntimeModule());
+				.tap("RuntimePlugin", (chunk, _, { chunkGraph }) => {
+					compilation.addRuntimeModule(
+						chunk,
+						new AsyncModuleRuntimeModule(),
+						chunkGraph
+					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.systemContext)
-				.tap("RuntimePlugin", chunk => {
+				.tap("RuntimePlugin", (chunk, _, { chunkGraph }) => {
 					const { outputOptions } = compilation;
 					const { library: globalLibrary } = outputOptions;
 					const entryOptions = chunk.getEntryOptions();
@@ -251,14 +268,15 @@ class RuntimePlugin {
 					if (libraryType === "system") {
 						compilation.addRuntimeModule(
 							chunk,
-							new SystemContextRuntimeModule()
+							new SystemContextRuntimeModule(),
+							chunkGraph
 						);
 					}
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.getChunkScriptFilename)
-				.tap("RuntimePlugin", (chunk, set) => {
+				.tap("RuntimePlugin", (chunk, set, { chunkGraph }) => {
 					if (
 						typeof compilation.outputOptions.chunkFilename === "string" &&
 						/\[(full)?hash(:\d+)?\]/.test(
@@ -279,13 +297,14 @@ class RuntimePlugin {
 									? compilation.outputOptions.filename
 									: compilation.outputOptions.chunkFilename),
 							false
-						)
+						),
+						chunkGraph
 					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.getChunkCssFilename)
-				.tap("RuntimePlugin", (chunk, set) => {
+				.tap("RuntimePlugin", (chunk, set, { chunkGraph }) => {
 					if (
 						typeof compilation.outputOptions.cssChunkFilename === "string" &&
 						/\[(full)?hash(:\d+)?\]/.test(
@@ -303,13 +322,14 @@ class RuntimePlugin {
 							chunk =>
 								getChunkFilenameTemplate(chunk, compilation.outputOptions),
 							set.has(RuntimeGlobals.hmrDownloadUpdateHandlers)
-						)
+						),
+						chunkGraph
 					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.getChunkUpdateScriptFilename)
-				.tap("RuntimePlugin", (chunk, set) => {
+				.tap("RuntimePlugin", (chunk, set, { chunkGraph }) => {
 					if (
 						/\[(full)?hash(:\d+)?\]/.test(
 							compilation.outputOptions.hotUpdateChunkFilename
@@ -324,13 +344,14 @@ class RuntimePlugin {
 							RuntimeGlobals.getChunkUpdateScriptFilename,
 							c => compilation.outputOptions.hotUpdateChunkFilename,
 							true
-						)
+						),
+						chunkGraph
 					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.getUpdateManifestFilename)
-				.tap("RuntimePlugin", (chunk, set) => {
+				.tap("RuntimePlugin", (chunk, set, { chunkGraph }) => {
 					if (
 						/\[(full)?hash(:\d+)?\]/.test(
 							compilation.outputOptions.hotUpdateMainFilename
@@ -344,20 +365,22 @@ class RuntimePlugin {
 							"update manifest",
 							RuntimeGlobals.getUpdateManifestFilename,
 							compilation.outputOptions.hotUpdateMainFilename
-						)
+						),
+						chunkGraph
 					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.ensureChunk)
-				.tap("RuntimePlugin", (chunk, set) => {
+				.tap("RuntimePlugin", (chunk, set, { chunkGraph }) => {
 					const hasAsyncChunks = chunk.hasAsyncChunks();
 					if (hasAsyncChunks) {
 						set.add(RuntimeGlobals.ensureChunkHandlers);
 					}
 					compilation.addRuntimeModule(
 						chunk,
-						new EnsureChunkRuntimeModule(set)
+						new EnsureChunkRuntimeModule(set),
+						chunkGraph
 					);
 					return true;
 				});
@@ -368,13 +391,17 @@ class RuntimePlugin {
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.shareScopeMap)
-				.tap("RuntimePlugin", (chunk, set) => {
-					compilation.addRuntimeModule(chunk, new ShareRuntimeModule());
+				.tap("RuntimePlugin", (chunk, set, { chunkGraph }) => {
+					compilation.addRuntimeModule(
+						chunk,
+						new ShareRuntimeModule(),
+						chunkGraph
+					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.loadScript)
-				.tap("RuntimePlugin", (chunk, set) => {
+				.tap("RuntimePlugin", (chunk, set, { chunkGraph }) => {
 					const withCreateScriptUrl = !!compilation.outputOptions.trustedTypes;
 					if (withCreateScriptUrl) {
 						set.add(RuntimeGlobals.createScriptUrl);
@@ -382,73 +409,93 @@ class RuntimePlugin {
 					const withFetchPriority = set.has(RuntimeGlobals.hasFetchPriority);
 					compilation.addRuntimeModule(
 						chunk,
-						new LoadScriptRuntimeModule(withCreateScriptUrl, withFetchPriority)
+						new LoadScriptRuntimeModule(withCreateScriptUrl, withFetchPriority),
+						chunkGraph
 					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.createScript)
-				.tap("RuntimePlugin", (chunk, set) => {
-					if (compilation.outputOptions.trustedTypes) {
-						set.add(RuntimeGlobals.getTrustedTypesPolicy);
-					}
-					compilation.addRuntimeModule(chunk, new CreateScriptRuntimeModule());
-					return true;
-				});
-			compilation.hooks.runtimeRequirementInTree
-				.for(RuntimeGlobals.createScriptUrl)
-				.tap("RuntimePlugin", (chunk, set) => {
+				.tap("RuntimePlugin", (chunk, set, { chunkGraph }) => {
 					if (compilation.outputOptions.trustedTypes) {
 						set.add(RuntimeGlobals.getTrustedTypesPolicy);
 					}
 					compilation.addRuntimeModule(
 						chunk,
-						new CreateScriptUrlRuntimeModule()
+						new CreateScriptRuntimeModule(),
+						chunkGraph
+					);
+					return true;
+				});
+			compilation.hooks.runtimeRequirementInTree
+				.for(RuntimeGlobals.createScriptUrl)
+				.tap("RuntimePlugin", (chunk, set, { chunkGraph }) => {
+					if (compilation.outputOptions.trustedTypes) {
+						set.add(RuntimeGlobals.getTrustedTypesPolicy);
+					}
+					compilation.addRuntimeModule(
+						chunk,
+						new CreateScriptUrlRuntimeModule(),
+						chunkGraph
 					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.getTrustedTypesPolicy)
-				.tap("RuntimePlugin", (chunk, set) => {
+				.tap("RuntimePlugin", (chunk, set, { chunkGraph }) => {
 					compilation.addRuntimeModule(
 						chunk,
-						new GetTrustedTypesPolicyRuntimeModule(set)
+						new GetTrustedTypesPolicyRuntimeModule(set),
+						chunkGraph
 					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.relativeUrl)
-				.tap("RuntimePlugin", (chunk, set) => {
-					compilation.addRuntimeModule(chunk, new RelativeUrlRuntimeModule());
+				.tap("RuntimePlugin", (chunk, set, { chunkGraph }) => {
+					compilation.addRuntimeModule(
+						chunk,
+						new RelativeUrlRuntimeModule(),
+						chunkGraph
+					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.onChunksLoaded)
-				.tap("RuntimePlugin", (chunk, set) => {
+				.tap("RuntimePlugin", (chunk, set, { chunkGraph }) => {
 					compilation.addRuntimeModule(
 						chunk,
-						new OnChunksLoadedRuntimeModule()
+						new OnChunksLoadedRuntimeModule(),
+						chunkGraph
 					);
 					return true;
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.baseURI)
-				.tap("RuntimePlugin", chunk => {
+				.tap("RuntimePlugin", (chunk, _, { chunkGraph }) => {
 					if (isChunkLoadingDisabledForChunk(chunk)) {
-						compilation.addRuntimeModule(chunk, new BaseUriRuntimeModule());
+						compilation.addRuntimeModule(
+							chunk,
+							new BaseUriRuntimeModule(),
+							chunkGraph
+						);
 						return true;
 					}
 				});
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.scriptNonce)
-				.tap("RuntimePlugin", chunk => {
-					compilation.addRuntimeModule(chunk, new NonceRuntimeModule());
+				.tap("RuntimePlugin", (chunk, _, { chunkGraph }) => {
+					compilation.addRuntimeModule(
+						chunk,
+						new NonceRuntimeModule(),
+						chunkGraph
+					);
 					return true;
 				});
 			// TODO webpack 6: remove CompatRuntimeModule
 			compilation.hooks.additionalTreeRuntimeRequirements.tap(
 				"RuntimePlugin",
-				(chunk, set) => {
+				(chunk, set, { chunkGraph }) => {
 					const { mainTemplate } = compilation;
 					if (
 						mainTemplate.hooks.bootstrap.isUsed() ||
@@ -456,7 +503,11 @@ class RuntimePlugin {
 						mainTemplate.hooks.requireEnsure.isUsed() ||
 						mainTemplate.hooks.requireExtensions.isUsed()
 					) {
-						compilation.addRuntimeModule(chunk, new CompatRuntimeModule());
+						compilation.addRuntimeModule(
+							chunk,
+							new CompatRuntimeModule(),
+							chunkGraph
+						);
 					}
 				}
 			);

--- a/lib/container/ContainerReferencePlugin.js
+++ b/lib/container/ContainerReferencePlugin.js
@@ -126,13 +126,17 @@ class ContainerReferencePlugin {
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.ensureChunkHandlers)
-					.tap("ContainerReferencePlugin", (chunk, set) => {
+					.tap("ContainerReferencePlugin", (chunk, set, { chunkGraph }) => {
 						set.add(RuntimeGlobals.module);
 						set.add(RuntimeGlobals.moduleFactoriesAddOnly);
 						set.add(RuntimeGlobals.hasOwnProperty);
 						set.add(RuntimeGlobals.initializeSharing);
 						set.add(RuntimeGlobals.shareScopeMap);
-						compilation.addRuntimeModule(chunk, new RemoteRuntimeModule());
+						compilation.addRuntimeModule(
+							chunk,
+							new RemoteRuntimeModule(),
+							chunkGraph
+						);
 					});
 			}
 		);

--- a/lib/css/CssLoadingRuntimeModule.js
+++ b/lib/css/CssLoadingRuntimeModule.js
@@ -15,7 +15,6 @@ const { chunkHasCss } = require("./CssModulesPlugin");
 
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
-/** @typedef {import("../Compilation").RuntimeRequirementsContext} RuntimeRequirementsContext */
 
 /**
  * @typedef {Object} JsonpCompilationPluginHooks

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -39,6 +39,7 @@ const CssParser = require("./CssParser");
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
 /** @typedef {import("../CodeGenerationResults")} CodeGenerationResults */
 /** @typedef {import("../Compilation")} Compilation */
+/** @typedef {import("../Compilation").RuntimeRequirementsContext} RuntimeRequirementsContext */
 /** @typedef {import("../Compiler")} Compiler */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../util/memoize")} Memoize */
@@ -325,8 +326,9 @@ class CssModulesPlugin {
 				/**
 				 * @param {Chunk} chunk chunk to check
 				 * @param {Set<string>} set runtime requirements
+				 * @param {RuntimeRequirementsContext} context runtime requirements context
 				 */
-				const handler = (chunk, set) => {
+				const handler = (chunk, set, { chunkGraph }) => {
 					if (onceForChunkSet.has(chunk)) return;
 					onceForChunkSet.add(chunk);
 					if (!isEnabledForChunk(chunk)) return;
@@ -338,7 +340,11 @@ class CssModulesPlugin {
 					set.add(RuntimeGlobals.makeNamespaceObject);
 
 					const CssLoadingRuntimeModule = getCssLoadingRuntimeModule();
-					compilation.addRuntimeModule(chunk, new CssLoadingRuntimeModule(set));
+					compilation.addRuntimeModule(
+						chunk,
+						new CssLoadingRuntimeModule(set),
+						chunkGraph
+					);
 				};
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.hasCssModules)

--- a/lib/dependencies/AMDPlugin.js
+++ b/lib/dependencies/AMDPlugin.js
@@ -114,16 +114,21 @@ class AMDPlugin {
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.amdDefine)
-					.tap(PLUGIN_NAME, (chunk, set) => {
-						compilation.addRuntimeModule(chunk, new AMDDefineRuntimeModule());
+					.tap(PLUGIN_NAME, (chunk, set, { chunkGraph }) => {
+						compilation.addRuntimeModule(
+							chunk,
+							new AMDDefineRuntimeModule(),
+							chunkGraph
+						);
 					});
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.amdOptions)
-					.tap(PLUGIN_NAME, (chunk, set) => {
+					.tap(PLUGIN_NAME, (chunk, set, { chunkGraph }) => {
 						compilation.addRuntimeModule(
 							chunk,
-							new AMDOptionsRuntimeModule(amdOptions)
+							new AMDOptionsRuntimeModule(amdOptions),
+							chunkGraph
 						);
 					});
 

--- a/lib/dependencies/CommonJsPlugin.js
+++ b/lib/dependencies/CommonJsPlugin.js
@@ -158,19 +158,21 @@ class CommonJsPlugin {
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.harmonyModuleDecorator)
-					.tap(PLUGIN_NAME, (chunk, set) => {
+					.tap(PLUGIN_NAME, (chunk, set, { chunkGraph }) => {
 						compilation.addRuntimeModule(
 							chunk,
-							new HarmonyModuleDecoratorRuntimeModule()
+							new HarmonyModuleDecoratorRuntimeModule(),
+							chunkGraph
 						);
 					});
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.nodeModuleDecorator)
-					.tap(PLUGIN_NAME, (chunk, set) => {
+					.tap(PLUGIN_NAME, (chunk, set, { chunkGraph }) => {
 						compilation.addRuntimeModule(
 							chunk,
-							new NodeModuleDecoratorRuntimeModule()
+							new NodeModuleDecoratorRuntimeModule(),
+							chunkGraph
 						);
 					});
 

--- a/lib/dependencies/SystemPlugin.js
+++ b/lib/dependencies/SystemPlugin.js
@@ -46,8 +46,12 @@ class SystemPlugin {
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.system)
-					.tap(PLUGIN_NAME, (chunk, set) => {
-						compilation.addRuntimeModule(chunk, new SystemRuntimeModule());
+					.tap(PLUGIN_NAME, (chunk, set, { chunkGraph }) => {
+						compilation.addRuntimeModule(
+							chunk,
+							new SystemRuntimeModule(),
+							chunkGraph
+						);
 					});
 
 				/**

--- a/lib/esm/ModuleChunkFormatPlugin.js
+++ b/lib/esm/ModuleChunkFormatPlugin.js
@@ -33,9 +33,9 @@ class ModuleChunkFormatPlugin {
 			compilation => {
 				compilation.hooks.additionalChunkRuntimeRequirements.tap(
 					"ModuleChunkFormatPlugin",
-					(chunk, set) => {
+					(chunk, set, { chunkGraph }) => {
 						if (chunk.hasRuntime()) return;
-						if (compilation.chunkGraph.getNumberOfEntryModules(chunk) > 0) {
+						if (chunkGraph.getNumberOfEntryModules(chunk) > 0) {
 							set.add(RuntimeGlobals.require);
 							set.add(RuntimeGlobals.startupEntrypoint);
 							set.add(RuntimeGlobals.externalInstallChunk);

--- a/lib/esm/ModuleChunkLoadingPlugin.js
+++ b/lib/esm/ModuleChunkLoadingPlugin.js
@@ -10,6 +10,7 @@ const ExportWebpackRequireRuntimeModule = require("./ExportWebpackRequireRuntime
 const ModuleChunkLoadingRuntimeModule = require("./ModuleChunkLoadingRuntimeModule");
 
 /** @typedef {import("../Chunk")} Chunk */
+/** @typedef {import("../Compilation").RuntimeRequirementsContext} RuntimeRequirementsContext */
 /** @typedef {import("../Compiler")} Compiler */
 
 class ModuleChunkLoadingPlugin {
@@ -39,8 +40,9 @@ class ModuleChunkLoadingPlugin {
 				/**
 				 * @param {Chunk} chunk chunk to check
 				 * @param {Set<string>} set runtime requirements
+				 * @param {RuntimeRequirementsContext} context runtime requirements context
 				 */
-				const handler = (chunk, set) => {
+				const handler = (chunk, set, { chunkGraph }) => {
 					if (onceForChunkSet.has(chunk)) return;
 					onceForChunkSet.add(chunk);
 					if (!isEnabledForChunk(chunk)) return;
@@ -48,7 +50,8 @@ class ModuleChunkLoadingPlugin {
 					set.add(RuntimeGlobals.hasOwnProperty);
 					compilation.addRuntimeModule(
 						chunk,
-						new ModuleChunkLoadingRuntimeModule(set)
+						new ModuleChunkLoadingRuntimeModule(set),
+						chunkGraph
 					);
 				};
 				compilation.hooks.runtimeRequirementInTree
@@ -65,11 +68,12 @@ class ModuleChunkLoadingPlugin {
 					.tap("ModuleChunkLoadingPlugin", handler);
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.externalInstallChunk)
-					.tap("ModuleChunkLoadingPlugin", (chunk, set) => {
+					.tap("ModuleChunkLoadingPlugin", (chunk, set, { chunkGraph }) => {
 						if (!isEnabledForChunk(chunk)) return;
 						compilation.addRuntimeModule(
 							chunk,
-							new ExportWebpackRequireRuntimeModule()
+							new ExportWebpackRequireRuntimeModule(),
+							chunkGraph
 						);
 					});
 

--- a/lib/node/CommonJsChunkLoadingPlugin.js
+++ b/lib/node/CommonJsChunkLoadingPlugin.js
@@ -9,6 +9,7 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 const StartupChunkDependenciesPlugin = require("../runtime/StartupChunkDependenciesPlugin");
 
 /** @typedef {import("../Chunk")} Chunk */
+/** @typedef {import("../Compilation").RuntimeRequirementsContext} RuntimeRequirementsContext */
 /** @typedef {import("../Compiler")} Compiler */
 
 /** @typedef {Object} CommonJsChunkLoadingPluginOptions
@@ -59,8 +60,9 @@ class CommonJsChunkLoadingPlugin {
 				/**
 				 * @param {Chunk} chunk chunk
 				 * @param {Set<string>} set runtime requirements
+				 * @param {RuntimeRequirementsContext} context runtime requirements context
 				 */
-				const handler = (chunk, set) => {
+				const handler = (chunk, set, { chunkGraph }) => {
 					if (onceForChunkSet.has(chunk)) return;
 					onceForChunkSet.add(chunk);
 					if (!isEnabledForChunk(chunk)) return;
@@ -68,7 +70,8 @@ class CommonJsChunkLoadingPlugin {
 					set.add(RuntimeGlobals.hasOwnProperty);
 					compilation.addRuntimeModule(
 						chunk,
-						new ChunkLoadingRuntimeModule(set)
+						new ChunkLoadingRuntimeModule(set),
+						chunkGraph
 					);
 				};
 

--- a/lib/node/ReadFileCompileAsyncWasmPlugin.js
+++ b/lib/node/ReadFileCompileAsyncWasmPlugin.js
@@ -89,26 +89,29 @@ class ReadFileCompileAsyncWasmPlugin {
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.instantiateWasm)
-					.tap("ReadFileCompileAsyncWasmPlugin", (chunk, set) => {
-						if (!isEnabledForChunk(chunk)) return;
-						const chunkGraph = compilation.chunkGraph;
-						if (
-							!chunkGraph.hasModuleInGraph(
+					.tap(
+						"ReadFileCompileAsyncWasmPlugin",
+						(chunk, set, { chunkGraph }) => {
+							if (!isEnabledForChunk(chunk)) return;
+							if (
+								!chunkGraph.hasModuleInGraph(
+									chunk,
+									m => m.type === WEBASSEMBLY_MODULE_TYPE_ASYNC
+								)
+							) {
+								return;
+							}
+							set.add(RuntimeGlobals.publicPath);
+							compilation.addRuntimeModule(
 								chunk,
-								m => m.type === WEBASSEMBLY_MODULE_TYPE_ASYNC
-							)
-						) {
-							return;
+								new AsyncWasmLoadingRuntimeModule({
+									generateLoadBinaryCode,
+									supportsStreaming: false
+								}),
+								chunkGraph
+							);
 						}
-						set.add(RuntimeGlobals.publicPath);
-						compilation.addRuntimeModule(
-							chunk,
-							new AsyncWasmLoadingRuntimeModule({
-								generateLoadBinaryCode,
-								supportsStreaming: false
-							})
-						);
-					});
+					);
 			}
 		);
 	}

--- a/lib/node/ReadFileCompileWasmPlugin.js
+++ b/lib/node/ReadFileCompileWasmPlugin.js
@@ -81,9 +81,8 @@ class ReadFileCompileWasmPlugin {
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.ensureChunkHandlers)
-					.tap("ReadFileCompileWasmPlugin", (chunk, set) => {
+					.tap("ReadFileCompileWasmPlugin", (chunk, set, { chunkGraph }) => {
 						if (!isEnabledForChunk(chunk)) return;
-						const chunkGraph = compilation.chunkGraph;
 						if (
 							!chunkGraph.hasModuleInGraph(
 								chunk,
@@ -100,7 +99,8 @@ class ReadFileCompileWasmPlugin {
 								supportsStreaming: false,
 								mangleImports: this.options.mangleImports,
 								runtimeRequirements: set
-							})
+							}),
+							chunkGraph
 						);
 					});
 			}

--- a/lib/prefetch/ChunkPrefetchPreloadPlugin.js
+++ b/lib/prefetch/ChunkPrefetchPreloadPlugin.js
@@ -37,7 +37,8 @@ class ChunkPrefetchPreloadPlugin {
 							set.add(RuntimeGlobals.onChunksLoaded);
 							compilation.addRuntimeModule(
 								chunk,
-								new ChunkPrefetchStartupRuntimeModule(startupChildChunks)
+								new ChunkPrefetchStartupRuntimeModule(startupChildChunks),
+								chunkGraph
 							);
 						}
 					}
@@ -51,41 +52,45 @@ class ChunkPrefetchPreloadPlugin {
 							set.add(RuntimeGlobals.prefetchChunk);
 							compilation.addRuntimeModule(
 								chunk,
-								new ChunkPrefetchTriggerRuntimeModule(chunkMap.prefetch)
+								new ChunkPrefetchTriggerRuntimeModule(chunkMap.prefetch),
+								chunkGraph
 							);
 						}
 						if (chunkMap.preload) {
 							set.add(RuntimeGlobals.preloadChunk);
 							compilation.addRuntimeModule(
 								chunk,
-								new ChunkPreloadTriggerRuntimeModule(chunkMap.preload)
+								new ChunkPreloadTriggerRuntimeModule(chunkMap.preload),
+								chunkGraph
 							);
 						}
 					}
 				);
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.prefetchChunk)
-					.tap("ChunkPrefetchPreloadPlugin", (chunk, set) => {
+					.tap("ChunkPrefetchPreloadPlugin", (chunk, set, { chunkGraph }) => {
 						compilation.addRuntimeModule(
 							chunk,
 							new ChunkPrefetchFunctionRuntimeModule(
 								"prefetch",
 								RuntimeGlobals.prefetchChunk,
 								RuntimeGlobals.prefetchChunkHandlers
-							)
+							),
+							chunkGraph
 						);
 						set.add(RuntimeGlobals.prefetchChunkHandlers);
 					});
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.preloadChunk)
-					.tap("ChunkPrefetchPreloadPlugin", (chunk, set) => {
+					.tap("ChunkPrefetchPreloadPlugin", (chunk, set, { chunkGraph }) => {
 						compilation.addRuntimeModule(
 							chunk,
 							new ChunkPrefetchFunctionRuntimeModule(
 								"preload",
 								RuntimeGlobals.preloadChunk,
 								RuntimeGlobals.preloadChunkHandlers
-							)
+							),
+							chunkGraph
 						);
 						set.add(RuntimeGlobals.preloadChunkHandlers);
 					});

--- a/lib/runtime/StartupChunkDependenciesPlugin.js
+++ b/lib/runtime/StartupChunkDependenciesPlugin.js
@@ -64,23 +64,28 @@ class StartupChunkDependenciesPlugin {
 								chunk,
 								new StartupChunkDependenciesRuntimeModule(
 									this.asyncChunkLoading
-								)
+								),
+								chunkGraph
 							);
 						}
 					}
 				);
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.startupEntrypoint)
-					.tap("StartupChunkDependenciesPlugin", (chunk, set) => {
-						if (!isEnabledForChunk(chunk)) return;
-						set.add(RuntimeGlobals.require);
-						set.add(RuntimeGlobals.ensureChunk);
-						set.add(RuntimeGlobals.ensureChunkIncludeEntries);
-						compilation.addRuntimeModule(
-							chunk,
-							new StartupEntrypointRuntimeModule(this.asyncChunkLoading)
-						);
-					});
+					.tap(
+						"StartupChunkDependenciesPlugin",
+						(chunk, set, { chunkGraph }) => {
+							if (!isEnabledForChunk(chunk)) return;
+							set.add(RuntimeGlobals.require);
+							set.add(RuntimeGlobals.ensureChunk);
+							set.add(RuntimeGlobals.ensureChunkIncludeEntries);
+							compilation.addRuntimeModule(
+								chunk,
+								new StartupEntrypointRuntimeModule(this.asyncChunkLoading),
+								chunkGraph
+							);
+						}
+					);
 			}
 		);
 	}

--- a/lib/sharing/ConsumeSharedPlugin.js
+++ b/lib/sharing/ConsumeSharedPlugin.js
@@ -302,7 +302,7 @@ class ConsumeSharedPlugin {
 				);
 				compilation.hooks.additionalTreeRuntimeRequirements.tap(
 					PLUGIN_NAME,
-					(chunk, set) => {
+					(chunk, set, { chunkGraph }) => {
 						set.add(RuntimeGlobals.module);
 						set.add(RuntimeGlobals.moduleCache);
 						set.add(RuntimeGlobals.moduleFactoriesAddOnly);
@@ -311,7 +311,8 @@ class ConsumeSharedPlugin {
 						set.add(RuntimeGlobals.hasOwnProperty);
 						compilation.addRuntimeModule(
 							chunk,
-							new ConsumeSharedRuntimeModule(set)
+							new ConsumeSharedRuntimeModule(set),
+							chunkGraph
 						);
 					}
 				);

--- a/lib/web/FetchCompileAsyncWasmPlugin.js
+++ b/lib/web/FetchCompileAsyncWasmPlugin.js
@@ -44,9 +44,8 @@ class FetchCompileAsyncWasmPlugin {
 
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.instantiateWasm)
-					.tap("FetchCompileAsyncWasmPlugin", (chunk, set) => {
+					.tap("FetchCompileAsyncWasmPlugin", (chunk, set, { chunkGraph }) => {
 						if (!isEnabledForChunk(chunk)) return;
-						const chunkGraph = compilation.chunkGraph;
 						if (
 							!chunkGraph.hasModuleInGraph(
 								chunk,
@@ -61,7 +60,8 @@ class FetchCompileAsyncWasmPlugin {
 							new AsyncWasmLoadingRuntimeModule({
 								generateLoadBinaryCode,
 								supportsStreaming: true
-							})
+							}),
+							chunkGraph
 						);
 					});
 			}

--- a/lib/web/FetchCompileWasmPlugin.js
+++ b/lib/web/FetchCompileWasmPlugin.js
@@ -58,9 +58,8 @@ class FetchCompileWasmPlugin {
 
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.ensureChunkHandlers)
-				.tap(PLUGIN_NAME, (chunk, set) => {
+				.tap(PLUGIN_NAME, (chunk, set, { chunkGraph }) => {
 					if (!isEnabledForChunk(chunk)) return;
-					const chunkGraph = compilation.chunkGraph;
 					if (
 						!chunkGraph.hasModuleInGraph(
 							chunk,
@@ -78,7 +77,8 @@ class FetchCompileWasmPlugin {
 							supportsStreaming: true,
 							mangleImports: this.options.mangleImports,
 							runtimeRequirements: set
-						})
+						}),
+						chunkGraph
 					);
 				});
 		});

--- a/lib/web/JsonpChunkLoadingPlugin.js
+++ b/lib/web/JsonpChunkLoadingPlugin.js
@@ -9,6 +9,7 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 const JsonpChunkLoadingRuntimeModule = require("./JsonpChunkLoadingRuntimeModule");
 
 /** @typedef {import("../Chunk")} Chunk */
+/** @typedef {import("../Compilation").RuntimeRequirementsContext} RuntimeRequirementsContext */
 /** @typedef {import("../Compiler")} Compiler */
 
 class JsonpChunkLoadingPlugin {
@@ -38,8 +39,9 @@ class JsonpChunkLoadingPlugin {
 				/**
 				 * @param {Chunk} chunk chunk
 				 * @param {Set<string>} set runtime requirements
+				 * @param {RuntimeRequirementsContext} context runtime requirements context
 				 */
-				const handler = (chunk, set) => {
+				const handler = (chunk, set, { chunkGraph }) => {
 					if (onceForChunkSet.has(chunk)) return;
 					onceForChunkSet.add(chunk);
 					if (!isEnabledForChunk(chunk)) return;
@@ -47,7 +49,8 @@ class JsonpChunkLoadingPlugin {
 					set.add(RuntimeGlobals.hasOwnProperty);
 					compilation.addRuntimeModule(
 						chunk,
-						new JsonpChunkLoadingRuntimeModule(set)
+						new JsonpChunkLoadingRuntimeModule(set),
+						chunkGraph
 					);
 				};
 				compilation.hooks.runtimeRequirementInTree

--- a/lib/webworker/ImportScriptsChunkLoadingPlugin.js
+++ b/lib/webworker/ImportScriptsChunkLoadingPlugin.js
@@ -10,6 +10,7 @@ const StartupChunkDependenciesPlugin = require("../runtime/StartupChunkDependenc
 const ImportScriptsChunkLoadingRuntimeModule = require("./ImportScriptsChunkLoadingRuntimeModule");
 
 /** @typedef {import("../Chunk")} Chunk */
+/** @typedef {import("../Compilation").RuntimeRequirementsContext} RuntimeRequirementsContext */
 /** @typedef {import("../Compiler")} Compiler */
 
 class ImportScriptsChunkLoadingPlugin {
@@ -43,8 +44,9 @@ class ImportScriptsChunkLoadingPlugin {
 				/**
 				 * @param {Chunk} chunk chunk
 				 * @param {Set<string>} set runtime requirements
+				 * @param {RuntimeRequirementsContext} context runtime requirements context
 				 */
-				const handler = (chunk, set) => {
+				const handler = (chunk, set, { chunkGraph }) => {
 					if (onceForChunkSet.has(chunk)) return;
 					onceForChunkSet.add(chunk);
 					if (!isEnabledForChunk(chunk)) return;
@@ -56,7 +58,11 @@ class ImportScriptsChunkLoadingPlugin {
 					}
 					compilation.addRuntimeModule(
 						chunk,
-						new ImportScriptsChunkLoadingRuntimeModule(set, withCreateScriptUrl)
+						new ImportScriptsChunkLoadingRuntimeModule(
+							set,
+							withCreateScriptUrl
+						),
+						chunkGraph
 					);
 				};
 				compilation.hooks.runtimeRequirementInTree

--- a/test/configCases/custom-source-type/localization/webpack.config.js
+++ b/test/configCases/custom-source-type/localization/webpack.config.js
@@ -171,8 +171,7 @@ module.exports = definitions.map((defs, i) => ({
 
 					compilation.hooks.runtimeRequirementInTree
 						.for(RuntimeGlobals.ensureChunkHandlers)
-						.tap("LocalizationPlugin", (chunk, set) => {
-							const chunkGraph = compilation.chunkGraph;
+						.tap("LocalizationPlugin", (chunk, set, { chunkGraph }) => {
 							if (
 								!chunkGraph.hasModuleInGraph(chunk, m =>
 									m.type.startsWith("localization")
@@ -183,7 +182,8 @@ module.exports = definitions.map((defs, i) => ({
 							set.add(RuntimeGlobals.moduleCache);
 							compilation.addRuntimeModule(
 								chunk,
-								new LocalizationLoadingRuntimeModule()
+								new LocalizationLoadingRuntimeModule(),
+								chunkGraph
 							);
 						});
 				}


### PR DESCRIPTION
Use chunkGraph from hook context instead of compilation

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc6d740</samp>

This pull request refactors and improves the runtime module system for webpack. It adds support for new features such as container references, CSS modules, WebAssembly compilation, and chunk prefetching and preloading. It also updates the plugin API to use the new `chunkGraph` argument and the `RuntimeRequirementsContext` type. It modifies various plugins and hooks to use the new runtime modules and runtime requirement hooks. It removes some redundant or deprecated code and adds type annotations for better type checking and documentation.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc6d740</samp>

*  Refactor `compilation` hooks to use `chunkGraph` as an argument instead of accessing the deprecated `compilation.chunkGraph` property ([link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-0b8525fd4794c93b31dd9e959e7e664fc6a79c68091046764063e3eace891764L166-R170), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-0b8525fd4794c93b31dd9e959e7e664fc6a79c68091046764063e3eace891764L176-R182), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-0d3f79e9df5c6a7bb0d571e576adba0ba29f0cdcc8d2f2c0335f810ada6c37f8L129-R129), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-5ed91987d44d425c1ee78a765f3851da329b41a9c2b9d9b5379ac4e3f1209030L117-R131), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-46cdc2408ceac339f6b00fee887c067946010d6451160b038b35dfbc2126e78bL161-R165), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-46cdc2408ceac339f6b00fee887c067946010d6451160b038b35dfbc2126e78bL170-R175), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-eeceb01bb42e9f84c137db6e29d94ee3559f93933375f2677dc0dec8d29ac6f6L49-R54), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-c22f77f8ec671e00d7d4e997e1d17ad7524c295d65acc6994be3b83287999122L68-R76), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-64a44d3330656769cf90fe1216471a86ff8e5e242a6b52e7fdf072bb2c584b4cL92-R114), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-a662d3c68335d196f97f0c88c5c0f84719b7a3b069f8581fab0419b837da71e7L84-R85), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-cdcce88f2f19b714e7763e61ac874b2fcf63ee41649a9179db8b388c0ee9b688L68-R71), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-cdcce88f2f19b714e7763e61ac874b2fcf63ee41649a9179db8b388c0ee9b688L81-R85), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-1f6c9dd2a670408f845477b54bae6d20edd21b5304a7bfc8313eb904f844e4b3L74-R88), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L150-R154), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L159-R164), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L168-R174), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L177-R184), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L186-R194), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L195-R210), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L261-R279), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L288-R307), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L312-R332), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L333-R354), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L353-R375), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L371-R404), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L391-R432), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L412-R449), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L436-R481), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L451-R498), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-95295794507032fb0378671d31c45acbdc88b14a3dbf0ec52301226c47e3a02fL47-R48), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-0e5a4b4a7d04870bb1427e804465eb6c422de2536c9cd7f27f0af7b7bbf12c6eL61-R62))
*  Add `context` argument to `additionalTreeRuntimeRequirements` hook to access `chunkGraph` and other properties ([link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-a51a7d4ed3bdf6b771fd5d055c9a8a2d71ebc1c65f3b4968e8af32dcd36f24e2L752-R752), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L230-R259), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L459-R510), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bL328-R331), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-c22f77f8ec671e00d7d4e997e1d17ad7524c295d65acc6994be3b83287999122L42-R45), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-72fc90cd1227eb7a5e625ed217abf5afe2b965668c785b4f3fab0cc58bf49984L62-R65), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-cdcce88f2f19b714e7763e61ac874b2fcf63ee41649a9179db8b388c0ee9b688L40-R41), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-545c55d1798dd44e1dc934ab0180669a92c2672369c08fcac5cb5a217edf9a8aL305-R305), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-048ba0f5a4029383ab14c69739f5777aaec9a7074805d0b5d49b1af17d1bafe0L41-R44))
*  Add various runtime modules to handle different runtime requirements, such as `hot module replacement`, `chunk loading`, `wasm compilation`, `shared modules`, etc. ([link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-a51a7d4ed3bdf6b771fd5d055c9a8a2d71ebc1c65f3b4968e8af32dcd36f24e2L759-R760), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L213-R222), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L224-R233), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L254-R272), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L282-R301), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L306-R326), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L327-R348), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L347-R369), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L360-R383), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L385-R413), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L406-R439), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L421-R469), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-8ca568ebcc2831549e2d258ee4a9aeeb1b84ca32394824ac94c3de622c1f6606L444-R492), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-0d3f79e9df5c6a7bb0d571e576adba0ba29f0cdcc8d2f2c0335f810ada6c37f8L135-R139), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bL341-R347), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-c22f77f8ec671e00d7d4e997e1d17ad7524c295d65acc6994be3b83287999122L51-R54), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-72fc90cd1227eb7a5e625ed217abf5afe2b965668c785b4f3fab0cc58bf49984L71-R74), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-a662d3c68335d196f97f0c88c5c0f84719b7a3b069f8581fab0419b837da71e7L103-R103), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-cdcce88f2f19b714e7763e61ac874b2fcf63ee41649a9179db8b388c0ee9b688L54-R56), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-cdcce88f2f19b714e7763e61ac874b2fcf63ee41649a9179db8b388c0ee9b688L61-R64), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-cdcce88f2f19b714e7763e61ac874b2fcf63ee41649a9179db8b388c0ee9b688L75-R79), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-cdcce88f2f19b714e7763e61ac874b2fcf63ee41649a9179db8b388c0ee9b688L88-R93), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-1f6c9dd2a670408f845477b54bae6d20edd21b5304a7bfc8313eb904f844e4b3L67-R68), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-545c55d1798dd44e1dc934ab0180669a92c2672369c08fcac5cb5a217edf9a8aL314-R315), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-95295794507032fb0378671d31c45acbdc88b14a3dbf0ec52301226c47e3a02fL64-R64), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-0e5a4b4a7d04870bb1427e804465eb6c422de2536c9cd7f27f0af7b7bbf12c6eL81-R81), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-048ba0f5a4029383ab14c69739f5777aaec9a7074805d0b5d49b1af17d1bafe0L50-R53))
*  Import `RuntimeRequirementsContext` type definition from `lib/APIPlugin.js` in files that use it ([link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-1ede558d550bf27773fff6d4f110076dc6e187ddccbea0645a66c67742b689dbL18), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-48300ec9215ae0f99dcfc8a85080f12e464793b6e855f7e0687f74aad4fc7c1bR42), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-c5d4f993897e06b2577f256473c37db962d87ba30de1d3d2c631d6eb68d7c95cL36-R38), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-c22f77f8ec671e00d7d4e997e1d17ad7524c295d65acc6994be3b83287999122R13), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-72fc90cd1227eb7a5e625ed217abf5afe2b965668c785b4f3fab0cc58bf49984R12), [link](https://github.com/webpack/webpack/pull/17778/files?diff=unified&w=0#diff-048ba0f5a4029383ab14c69739f5777aaec9a7074805d0b5d49b1af17d1bafe0R12))
