### PR TITLE
fix: strictModuleErrorHandling is not working

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -1014,6 +1014,7 @@ const applyOutputDefaults = (
 	D(output, "hashFunction", futureDefaults ? "xxhash64" : "md4");
 	D(output, "hashDigest", "hex");
 	D(output, "hashDigestLength", futureDefaults ? 16 : 20);
+	D(output, "strictModuleErrorHandling", false);
 	D(output, "strictModuleExceptionHandling", false);
 
 	const environment = /** @type {Environment} */ (output.environment);

--- a/lib/config/normalization.js
+++ b/lib/config/normalization.js
@@ -382,6 +382,7 @@ const getNormalizedWebpackOptions = config => {
 				publicPath: output.publicPath,
 				sourceMapFilename: output.sourceMapFilename,
 				sourcePrefix: output.sourcePrefix,
+				strictModuleErrorHandling: output.strictModuleErrorHandling,
 				strictModuleExceptionHandling: output.strictModuleExceptionHandling,
 				trustedTypes: optionalNestedConfig(
 					output.trustedTypes,

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -373,6 +373,7 @@ describe("snapshots", () => {
 		    "scriptType": false,
 		    "sourceMapFilename": "[file].map[query]",
 		    "sourcePrefix": undefined,
+		    "strictModuleErrorHandling": false,
 		    "strictModuleExceptionHandling": false,
 		    "trustedTypes": undefined,
 		    "uniqueName": "webpack",

--- a/test/configCases/runtime/opt-in-finally2/exception.js
+++ b/test/configCases/runtime/opt-in-finally2/exception.js
@@ -1,0 +1,1 @@
+throw new Error("Exception");

--- a/test/configCases/runtime/opt-in-finally2/index.js
+++ b/test/configCases/runtime/opt-in-finally2/index.js
@@ -1,0 +1,8 @@
+it("should throw exception on every try to load a module", function() {
+	expect(function() {
+		require("./exception");
+	}).toThrowError();
+	expect(function() {
+		require("./exception");
+	}).toThrowError();
+});

--- a/test/configCases/runtime/opt-in-finally2/webpack.config.js
+++ b/test/configCases/runtime/opt-in-finally2/webpack.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		strictModuleErrorHandling: true
+	}
+};


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

`output.strictModuleErrorHandling = true` is not working since it is not passed in normalization.js, I think this is not intentional since it's on the docs https://webpack.js.org/configuration/output/#outputstrictmoduleerrorhandling

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b94741d</samp>

This pull request introduces a new output option `strictModuleErrorHandling` that allows webpack to rethrow module loading errors instead of trying to recover from them. It also adds tests to verify the default and opt-in behavior of this option.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b94741d</samp>

*  Add a new output option `strictModuleErrorHandling` to control whether webpack should rethrow module loading errors or not ([link](https://github.com/webpack/webpack/pull/17840/files?diff=unified&w=0#diff-c0078e4713a0e7a24dbc56d6dfda3cf139376325fc65ea70a8389d4d30b27f04R1017))
*  Pass the `strictModuleErrorHandling` option to the normalized webpack options object ([link](https://github.com/webpack/webpack/pull/17840/files?diff=unified&w=0#diff-cabfbdeecf612ff3fd25c03f2f6ff1ba78765ee15717e6ff2a42ee61bcf89da2R385))
*  Test that the default value of `strictModuleErrorHandling` is `false` in the normalized webpack options object ([link](https://github.com/webpack/webpack/pull/17840/files?diff=unified&w=0#diff-2ca9058acdbb297c64353f1f82fdd9828c21911ce176861026c6a0bea93fb5c2R376))
*  Create a module that throws an error when loaded (`exception.js`) and a test suite that expects webpack to throw an error when trying to load it (`index.js`) ([link](https://github.com/webpack/webpack/pull/17840/files?diff=unified&w=0#diff-74045026352622646a0e4f18ff26796c80bf67b7e1e97e976555c8ee4c819abcR1), [link](https://github.com/webpack/webpack/pull/17840/files?diff=unified&w=0#diff-9236af3a85a87d6ff9df2650416332e053f8d2eb6bcd8d17521c67d49a5ca5b1R1-R8))
*  Set the `strictModuleErrorHandling` option to `true` in the webpack configuration for the test suite (`webpack.config.js`) ([link](https://github.com/webpack/webpack/pull/17840/files?diff=unified&w=0#diff-6d338dfc2b2fc8aa21c4aff07b9ae1eb4db8c0ffc69938896bad0403a8f59e19R1-R6))
