### PR TITLE
chore: tidy

### DIFF
--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -199,14 +199,12 @@ class HotModuleReplacementPlugin {
 					name: PLUGIN_NAME,
 					before: "NodeStuffPlugin"
 				},
-				expr => {
-					return evaluateToIdentifier(
-						"module.hot",
-						"module",
-						() => ["hot"],
-						true
-					)(expr);
-				}
+				evaluateToIdentifier(
+					"module.hot",
+					"module",
+					() => ["hot"],
+					true
+				)
 			);
 			parser.hooks.call
 				.for("module.hot.accept")
@@ -232,14 +230,12 @@ class HotModuleReplacementPlugin {
 		const applyImportMetaHot = parser => {
 			parser.hooks.evaluateIdentifier
 				.for("import.meta.webpackHot")
-				.tap(PLUGIN_NAME, expr => {
-					return evaluateToIdentifier(
-						"import.meta.webpackHot",
-						"import.meta",
-						() => ["webpackHot"],
-						true
-					)(expr);
-				});
+				.tap(PLUGIN_NAME, evaluateToIdentifier(
+					"import.meta.webpackHot",
+					"import.meta",
+					() => ["webpackHot"],
+					true
+				));
 			parser.hooks.call
 				.for("import.meta.webpackHot.accept")
 				.tap(


### PR DESCRIPTION
Noticed this unnecessary closure creation when browsing the code :) Just thought I'd pop in and write this up.

<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f29b4d2</samp>

Simplify parser hooks in `HotModuleReplacementPlugin.js` by passing `evaluateToIdentifier` directly. This makes the code more readable and consistent.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f29b4d2</samp>

*  Simplify code by passing `evaluateToIdentifier` function directly to `parser.hooks.evaluate.for` and `parser.hooks.evaluateIdentifier.for` methods in `lib/HotModuleReplacementPlugin.js` ([link](https://github.com/webpack/webpack/pull/17850/files?diff=unified&w=0#diff-a51a7d4ed3bdf6b771fd5d055c9a8a2d71ebc1c65f3b4968e8af32dcd36f24e2L202-R207), [link](https://github.com/webpack/webpack/pull/17850/files?diff=unified&w=0#diff-a51a7d4ed3bdf6b771fd5d055c9a8a2d71ebc1c65f3b4968e8af32dcd36f24e2L235-R238))
