### PR TITLE
Clean up child compilation chunk graph to avoid memory leak

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -382,6 +382,11 @@ class Compiler {
 	_cleanupLastCompilation() {
 		if (this._lastCompilation !== undefined) {
 			for (const childCompilation of this._lastCompilation.children) {
+				for (const module of childCompilation.modules) {
+					ChunkGraph.clearChunkGraphForModule(module);
+					ModuleGraph.clearModuleGraphForModule(module);
+					module.cleanupForCache();
+				}
 				for (const chunk of childCompilation.chunks) {
 					ChunkGraph.clearChunkGraphForChunk(chunk);
 				}


### PR DESCRIPTION
Fixes https://github.com/webpack/webpack/issues/17851

Cleans up child compilation chunk graph which includes references to the compiler and parent compiler, causing a memory leak. It looks to me like child compilers were accidentally overlooked when this change was made to clean up modules/chunks in the parent:  https://github.com/webpack/webpack/pull/12894/files#diff-732395f8fcd972919381425c80194bb0def0a2af50c0940762299605a81c0006R360-R372

Details in the reproduction repo here: https://github.com/helloitsjoe/webpack-memory-leak (let me know if you want me to add more detail inline in this PR description)

Heap diff before | Heap diff after
--- | ---
<img width="986" alt="Heap diff before" src="https://github.com/helloitsjoe/webpack-memory-leak/assets/8823810/c9cc3c09-7943-4bb6-b26b-a2c310569103"> | <img width="986" alt="Heap diff after" src="https://github.com/helloitsjoe/webpack-memory-leak/assets/8823810/fac5b4f9-d14d-4965-a1ea-9ab751898e86">

<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0f517fd</samp>

Refactor `Compiler` class to clear chunk graph data of child compilations in `close` method. This prevents memory leaks and improves performance.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0f517fd</samp>

* Clear chunk graph data for child compilation chunks to prevent memory leaks and improve performance ([link](https://github.com/webpack/webpack/pull/17853/files?diff=unified&w=0#diff-732395f8fcd972919381425c80194bb0def0a2af50c0940762299605a81c0006R384-R389))
