### PR TITLE
Fix for chrome-extension:// script urls

### DIFF
--- a/lib/runtime/AutoPublicPathRuntimeModule.js
+++ b/lib/runtime/AutoPublicPathRuntimeModule.js
@@ -56,7 +56,7 @@ class AutoPublicPathRuntimeModule extends RuntimeModule {
 								"if(scripts.length) {",
 								Template.indent([
 									"var i = scripts.length - 1;",
-									"while (i > -1 && !scriptUrl) scriptUrl = scripts[i--].src;"
+									"while (i > -1 && (!scriptUrl || !scriptUrl.startsWith('http'))) scriptUrl = scripts[i--].src;"
 								]),
 								"}"
 							]),

--- a/lib/runtime/AutoPublicPathRuntimeModule.js
+++ b/lib/runtime/AutoPublicPathRuntimeModule.js
@@ -56,7 +56,7 @@ class AutoPublicPathRuntimeModule extends RuntimeModule {
 								"if(scripts.length) {",
 								Template.indent([
 									"var i = scripts.length - 1;",
-									"while (i > -1 && (!scriptUrl || !scriptUrl.startsWith('http'))) scriptUrl = scripts[i--].src;"
+									"while (i > -1 && (!scriptUrl || scriptUrl.substr(0, 4) != 'http')) scriptUrl = scripts[i--].src;"
 								]),
 								"}"
 							]),


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary
Certain chrome extensions can inject a script src referencing a chrome-extension:// url. This breaks the public path resolution.

<!-- cspell:disable-next-line -->

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b5646f8</samp>

Fix auto public path feature for blob URLs by filtering out non-http script URLs in `lib/runtime/AutoPublicPathRuntimeModule.js`.

## Details

<!-- cspell:disable-next-line -->

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b5646f8</samp>

* Filter out non-http script URLs in the auto public path feature ([link](https://github.com/webpack/webpack/pull/17860/files?diff=unified&w=0#diff-5b68f78763cd59ef3491990ef44d952823d13073cc43b0b3bb9301c693c7c88aL59-R59))
