### PR TITLE
add allowNumericOnlyHash option for asset/resource

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -2802,6 +2802,12 @@ export interface AssetResourceGeneratorOptions {
 	 * The 'publicPath' specifies the public URL address of the output files when referenced in a browser.
 	 */
 	publicPath?: RawPublicPath;
+	/**
+	 * when false, if hash has only numeric char, the returned hash will be prefixed with character `a` to make it has at least one non numeric char.
+	 * when true, the returned hash may not contain any non-numeric characters.
+	 * default false.
+	 */
+	allowNumericOnlyHash?: boolean;
 }
 /**
  * Options for css handling.

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -138,14 +138,23 @@ class AssetGenerator extends Generator {
 	 * @param {RawPublicPath=} publicPath override for output.assetModulePublicPath
 	 * @param {AssetModuleOutputPath=} outputPath the output path for the emitted file which is not included in the runtime import
 	 * @param {boolean=} emit generate output asset
+	 * @param {boolean=} allowNumericOnlyHash allow numeric only hash, disable nonNumericOnlyHash
 	 */
-	constructor(dataUrlOptions, filename, publicPath, outputPath, emit) {
+	constructor(
+		dataUrlOptions,
+		filename,
+		publicPath,
+		outputPath,
+		emit,
+		allowNumericOnlyHash
+	) {
 		super();
 		this.dataUrlOptions = dataUrlOptions;
 		this.filename = filename;
 		this.publicPath = publicPath;
 		this.outputPath = outputPath;
 		this.emit = emit;
+		this.allowNumericOnlyHash = allowNumericOnlyHash;
 	}
 
 	/**
@@ -300,10 +309,18 @@ class AssetGenerator extends Generator {
 					const fullHash = /** @type {string} */ (
 						hash.digest(runtimeTemplate.outputOptions.hashDigest)
 					);
-					const contentHash = nonNumericOnlyHash(
-						fullHash,
-						runtimeTemplate.outputOptions.hashDigestLength
-					);
+					let contentHash = fullHash;
+					if (this.allowNumericOnlyHash) {
+						contentHash = fullHash.slice(
+							0,
+							runtimeTemplate.outputOptions.hashDigestLength
+						);
+					} else {
+						contentHash = nonNumericOnlyHash(
+							fullHash,
+							runtimeTemplate.outputOptions.hashDigestLength
+						);
+					}
 					module.buildInfo.fullContentHash = fullHash;
 					const sourceFilename = this.getSourceFileName(
 						module,

--- a/lib/asset/AssetModulesPlugin.js
+++ b/lib/asset/AssetModulesPlugin.js
@@ -165,7 +165,8 @@ class AssetModulesPlugin {
 								filename,
 								publicPath,
 								outputPath,
-								generatorOptions.emit !== false
+								generatorOptions.emit !== false,
+								generatorOptions.allowNumericOnlyHash === true
 							);
 						});
 				}

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -208,6 +208,10 @@
         },
         "publicPath": {
           "$ref": "#/definitions/RawPublicPath"
+        },
+        "allowNumericOnlyHash": {
+          "description": "Hash may not contain any non-numeric characters when true. Hash may prefixed with character 'a' when false.",
+          "type": "boolean"
         }
       }
     },

--- a/test/__snapshots__/Cli.basictest.js.snap
+++ b/test/__snapshots__/Cli.basictest.js.snap
@@ -1374,6 +1374,19 @@ Object {
     "multiple": false,
     "simpleType": "string",
   },
+  "module-generator-asset-resource-allow-numeric-only-hash": Object {
+    "configs": Array [
+      Object {
+        "description": "Hash may not contain any non-numeric characters when true. Hash may prefixed with character 'a' when false.",
+        "multiple": false,
+        "path": "module.generator.asset/resource.allowNumericOnlyHash",
+        "type": "boolean",
+      },
+    ],
+    "description": "Hash may not contain any non-numeric characters when true. Hash may prefixed with character 'a' when false.",
+    "multiple": false,
+    "simpleType": "boolean",
+  },
   "module-generator-asset-resource-emit": Object {
     "configs": Array [
       Object {

--- a/test/configCases/asset-modules/allow-numeric-only-hash/index.js
+++ b/test/configCases/asset-modules/allow-numeric-only-hash/index.js
@@ -1,0 +1,24 @@
+import url from "../_images/file.png";
+import url2 from "../_images/file_copy.png";
+
+it("should import asset with module.generator.asset.allowNumericOnlyHash", () => {
+	expect(url).toMatch(/images\/file\.[a-f0-9]{6}\.png$/);
+	expect(url2).toMatch(/images\/file_copy\.[a-f0-9]{6}\.png$/);
+	const assetInfo1 = __STATS__.assets.find(
+		a => a.info.sourceFilename === "../_images/file.png"
+	).info;
+	const assetInfo2 = __STATS__.assets.find(
+		a => a.info.sourceFilename === "../_images/file_copy.png"
+	).info;
+
+	expect(assetInfo1.contenthash.length).toBe(2);
+	expect(assetInfo1.contenthash[0].length).toBe(6);
+	expect(assetInfo1.contenthash[1].length).toBe(6);
+	expect(assetInfo2.contenthash.length).toBe(2);
+	expect(assetInfo2.contenthash[0].length).toBe(6);
+	expect(assetInfo2.contenthash[1].length).toBe(6);
+
+	expect(assetInfo1.fullhash).toBe(assetInfo2.fullhash);
+	expect(assetInfo1.contenthash[0]).not.toEqual(assetInfo2.contenthash[0]);
+	expect(assetInfo1.contenthash[0].slice(1)).toEqual(assetInfo2.contenthash[0].slice(1));
+});

--- a/test/configCases/asset-modules/allow-numeric-only-hash/webpack.config.js
+++ b/test/configCases/asset-modules/allow-numeric-only-hash/webpack.config.js
@@ -1,0 +1,29 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	output: {
+		hashDigestLength: 6
+	},
+	module: {
+		rules: [
+			{
+				test: /file.png$/,
+				type: "asset/resource",
+				generator: {
+					emit: false,
+					filename: "[name].[contenthash:6][ext]",
+					allowNumericOnlyHash: false
+				}
+			},
+			{
+				test: /file_copy.png$/,
+				type: "asset/resource",
+				generator: {
+					emit: false,
+					filename: "[name].[contenthash:6][ext]",
+					allowNumericOnlyHash: true
+				}
+			}
+		]
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -348,6 +348,13 @@ declare interface AssetResourceGeneratorOptions {
 	 * The 'publicPath' specifies the public URL address of the output files when referenced in a browser.
 	 */
 	publicPath?: string | ((pathData: PathData, assetInfo?: AssetInfo) => string);
+
+	/**
+	 * when false, if hash has only numeric char, the returned hash will be prefixed with character `a` to make it has at least one non numeric char.
+	 * when true, the returned hash may not contain any non-numeric characters.
+	 * default false.
+	 */
+	allowNumericOnlyHash?: boolean;
 }
 declare class AsyncDependenciesBlock extends DependenciesBlock {
 	constructor(


### PR DESCRIPTION
fixes https://github.com/webpack/webpack/issues/13628#issuecomment-1870026048

#### What kind of change does this PR introduce?
feature

#### Did you add tests for your changes?
yes

#### Does this PR introduce a breaking change?
no

#### What needs to be documented once your changes are merged?

the generator options for asset/resource have a new `allowNumericOnlyHash` option. Defaults to false. Setting it to true will opt-out from prefixed numeric hash with character `a`（bypass [nonNumericOnlyHash](https://github.com/webpack/webpack/blob/main/lib/util/nonNumericOnlyHash.js) when `emit` is false）.


#### Related problem
using `generator.emit: false` result in incorrect content hash of specific gif

Using a [gif](https://static.arkread.com/ark/pics/author-annual/2023/no-data/woman-1.63269829.gif) which hash using the hashing algorithm SHA-1 is: `63269829566710439434dae6582fa16f9345afbf`.

In React jsx
```
import gif1 from '**/gif-1.gif'

...

<img src={gif1} />
```

In `webpack.config.js`
```
...
output: {
  ...
  hashFunction: 'sha1',
  ...
},
module: {
  ...
  rules: [
    ...
   {
      test: /\.(png|jpg|gif)(?:[?#].+)?$/,
      issuer: /\.(jsx?|tsx?)$/,
      type: 'asset/resource',
      generator: {
        filename: '[name].[contenthash:8][ext]',
        emit: false,
      },
    },
    ...
  ]
  ...
}
```