### PR TITLE
fix: generate library manifest after clean plugin

### DIFF
--- a/lib/LibManifestPlugin.js
+++ b/lib/LibManifestPlugin.js
@@ -46,7 +46,10 @@ class LibManifestPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.emit.tapAsync(
-			"LibManifestPlugin",
+			{
+				name: "LibManifestPlugin",
+				stage: 110
+			},
 			(compilation, callback) => {
 				const moduleGraph = compilation.moduleGraph;
 				asyncLib.forEach(

--- a/test/configCases/clean/lib-manifest-plugin/index.js
+++ b/test/configCases/clean/lib-manifest-plugin/index.js
@@ -1,0 +1,1 @@
+it("should compile and run the test", function() {});

--- a/test/configCases/clean/lib-manifest-plugin/readdir.js
+++ b/test/configCases/clean/lib-manifest-plugin/readdir.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+function handlePath(path) {
+	return path.replace(/\\/g, "/");
+}
+
+module.exports = function readDir(from) {
+	const collectedFiles = [];
+	const collectedDirectories = [];
+	const stack = [from];
+	let cursor;
+
+	while ((cursor = stack.pop())) {
+		const stat = fs.statSync(cursor);
+
+		if (stat.isDirectory()) {
+			const items = fs.readdirSync(cursor);
+
+			if (from !== cursor) {
+				const relative = path.relative(from, cursor);
+				collectedDirectories.push(handlePath(relative));
+			}
+
+			for (let i = 0; i < items.length; i++) {
+				stack.push(path.join(cursor, items[i]));
+			}
+		} else {
+			const relative = path.relative(from, cursor);
+			collectedFiles.push(handlePath(relative));
+		}
+	}
+
+	return {
+		files: collectedFiles,
+		directories: collectedDirectories
+	};
+}

--- a/test/configCases/clean/lib-manifest-plugin/webpack.config.js
+++ b/test/configCases/clean/lib-manifest-plugin/webpack.config.js
@@ -1,0 +1,33 @@
+const path = require("path");
+const readDir = require("./readdir");
+const webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		clean: true
+	},
+	plugins: [
+		compiler => {
+			compiler.hooks.thisCompilation.tap("Test", compilation => {
+				const outputPath = compilation.getPath(compiler.outputPath, {});
+				new webpack.DllPlugin({
+					name: "[name]_dll",
+					path: path.resolve(outputPath, "manifest.json")
+				}).apply(compiler);
+			});
+			compiler.hooks.afterEmit.tap("Test", compilation => {
+				const outputPath = compilation.getPath(compiler.outputPath, {});
+				expect(readDir(outputPath)).toMatchInlineSnapshot(`
+			Object {
+			  "directories": Array [],
+			  "files": Array [
+			    "manifest.json",
+			    "bundle0.js",
+			  ],
+			}
+		`);
+			});
+		}
+	]
+};


### PR DESCRIPTION
Fixes https://github.com/webpack/webpack/issues/17787

## Summary

<!-- cspell:disable-next-line -->

copilot:summary

## Details

<!-- cspell:disable-next-line -->

copilot:walkthrough
