### PR TITLE
made outputOptions.environment.arrowFunction to false to generate fun…

### DIFF
--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -137,6 +137,7 @@ class RuntimeTemplate {
 	}
 
 	basicFunction(args, body) {
+		this.outputOptions.environment.arrowFunction = false;
 		return this.supportsArrowFunction()
 			? `(${args}) => {\n${Template.indent(body)}\n}`
 			: `function(${args}) {\n${Template.indent(body)}\n}`;


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

When libraryTarget is set to module, the externals configuration appends hardcoded arrow functions that cannot be transformed 

## Fixes (#17861)

## Details

<!-- cspell:disable-next-line -->

Inorder to rectify this issue `outputOptions.environment.arrowFunction` is made to false in the `basicFunction`
