### PR TITLE
fix: external module hard code arrow function

### DIFF
--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -217,7 +217,12 @@ register(
 	}
 );
 
-const generateModuleRemapping = (input, exportsInfo, runtime) => {
+const generateModuleRemapping = (
+	input,
+	exportsInfo,
+	runtime,
+	runtimeTemplate
+) => {
 	if (exportsInfo.otherExportsInfo.getUsed(runtime) === UsageState.Unused) {
 		const properties = [];
 		for (const exportInfo of exportsInfo.orderedExports) {
@@ -235,9 +240,9 @@ const generateModuleRemapping = (input, exportsInfo, runtime) => {
 				}
 			}
 			properties.push(
-				`[${JSON.stringify(used)}]: () => ${input}${propertyAccess([
-					exportInfo.name
-				])}`
+				`[${JSON.stringify(used)}]: ${runtimeTemplate.returningFunction(
+					`${input}${propertyAccess([exportInfo.name])}`
+				)}`
 			);
 		}
 		return `x({ ${properties.join(", ")} })`;
@@ -248,21 +253,21 @@ const generateModuleRemapping = (input, exportsInfo, runtime) => {
  * @param {string|string[]} moduleAndSpecifiers the module request
  * @param {ExportsInfo} exportsInfo exports info of this module
  * @param {RuntimeSpec} runtime the runtime
- * @param {string | HashConstructor=} hashFunction the hash function to use
+ * @param {RuntimeTemplate} runtimeTemplate the runtime template
  * @returns {SourceData} the generated source
  */
 const getSourceForModuleExternal = (
 	moduleAndSpecifiers,
 	exportsInfo,
 	runtime,
-	hashFunction
+	runtimeTemplate
 ) => {
 	if (!Array.isArray(moduleAndSpecifiers))
 		moduleAndSpecifiers = [moduleAndSpecifiers];
 	const initFragment = new ModuleExternalInitFragment(
 		moduleAndSpecifiers[0],
 		undefined,
-		hashFunction
+		runtimeTemplate.outputOptions.hashFunction
 	);
 	const baseAccess = `${initFragment.getNamespaceIdentifier()}${propertyAccess(
 		moduleAndSpecifiers,
@@ -271,12 +276,19 @@ const getSourceForModuleExternal = (
 	const moduleRemapping = generateModuleRemapping(
 		baseAccess,
 		exportsInfo,
-		runtime
+		runtime,
+		runtimeTemplate
 	);
 	let expression = moduleRemapping || baseAccess;
 	return {
 		expression,
-		init: `var x = y => { var x = {}; ${RuntimeGlobals.definePropertyGetters}(x, y); return x; }\nvar y = x => () => x`,
+		init: `var x = ${runtimeTemplate.basicFunction(
+			"y",
+			`var x = {}; ${RuntimeGlobals.definePropertyGetters}(x, y); return x`
+		)} \nvar y = ${runtimeTemplate.returningFunction(
+			runtimeTemplate.returningFunction("x"),
+			"x"
+		)}`,
 		runtimeRequirements: moduleRemapping
 			? RUNTIME_REQUIREMENTS_FOR_MODULE
 			: undefined,
@@ -610,7 +622,7 @@ class ExternalModule extends Module {
 					request,
 					moduleGraph.getExportsInfo(this),
 					runtime,
-					runtimeTemplate.outputOptions.hashFunction
+					runtimeTemplate
 				);
 			}
 			case "var":


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary

<!-- cspell:disable-next-line -->

Some hard code arrow function in generateModuleRemapping and getSourceForModuleExternal

## Fixes([17861](https://github.com/webpack/webpack/issues/17861))

## Details

<!-- cspell:disable-next-line -->

use helper functions to replace arrow functions 


fixes https://github.com/webpack/webpack/issues/17861