### PR TITLE
fix: don't warn about dynamic import for build dependencies

### DIFF
--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -729,7 +729,8 @@ class SnapshotOptimization {
 }
 
 const parseString = str => {
-	if (str[0] === "'") str = `"${str.slice(1, -1).replace(/"/g, '\\"')}"`;
+	if (str[0] === "'" || str[0] === "`")
+		str = `"${str.slice(1, -1).replace(/"/g, '\\"')}"`;
 	return JSON.parse(str);
 };
 
@@ -1743,7 +1744,7 @@ class FileSystemInfo {
 													type: RBDT_RESOLVE_ESM_FILE,
 													context,
 													path: dependency,
-													expected: undefined,
+													expected: imp.d > -1 ? false : undefined,
 													issuer: job
 												});
 											} catch (e) {

--- a/test/BuildDependencies.longtest.js
+++ b/test/BuildDependencies.longtest.js
@@ -133,7 +133,18 @@ describe("BuildDependencies", () => {
 		);
 		fs.writeFileSync(
 			path.resolve(inputDirectory, "esm-async-dependency.mjs"),
-			'import path from "node:path"; import vm from "vm"; export default 0;'
+			`import path from "node:path";
+import vm from "vm";
+
+async function preload() {
+  await import(\`markdown-wasm/dist/markdown-node.js\`);
+  await import("markdown-wasm/dist/markdown-node.js");
+  await import('markdown-wasm/dist/markdown-node.js');
+  await import('test-"/test');
+  await import(\`test-"/test\`);
+}
+
+export default 0;`
 		);
 		await exec("0", {
 			invalidBuildDependencies: true,


### PR DESCRIPTION
fixes https://github.com/webpack/webpack/pull/15688

## Summary

<!-- cspell:disable-next-line -->

copilot:summary

## Details

<!-- cspell:disable-next-line -->

copilot:walkthrough
