### PR TITLE
dropped the handling of classes in the InnerGraphPlugin

### DIFF
--- a/lib/optimize/InnerGraphPlugin.js
+++ b/lib/optimize/InnerGraphPlugin.js
@@ -93,10 +93,6 @@ class InnerGraphPlugin {
 					const statementWithTopLevelSymbol = new WeakMap();
 					/** @type {WeakMap<Node, Node>} */
 					const statementPurePart = new WeakMap();
-
-					/** @type {WeakMap<ClassExpressionNode | ClassDeclarationNode, TopLevelSymbol>} */
-					const classWithTopLevelSymbol = new WeakMap();
-
 					/** @type {WeakMap<VariableDeclaratorNode, TopLevelSymbol>} */
 					const declWithTopLevelSymbol = new WeakMap();
 					/** @type {WeakSet<VariableDeclaratorNode>} */
@@ -117,43 +113,6 @@ class InnerGraphPlugin {
 						}
 					});
 
-					parser.hooks.blockPreStatement.tap(PLUGIN_NAME, statement => {
-						if (!InnerGraph.isEnabled(parser.state)) return;
-
-						if (parser.scope.topLevelScope === true) {
-							if (
-								statement.type === "ClassDeclaration" &&
-								parser.isPure(statement, statement.range[0])
-							) {
-								const name = statement.id ? statement.id.name : "*default*";
-								const fn = InnerGraph.tagTopLevelSymbol(parser, name);
-								classWithTopLevelSymbol.set(statement, fn);
-								return true;
-							}
-							if (statement.type === "ExportDefaultDeclaration") {
-								const name = "*default*";
-								const fn = InnerGraph.tagTopLevelSymbol(parser, name);
-								const decl = statement.declaration;
-								if (
-									(decl.type === "ClassExpression" ||
-										decl.type === "ClassDeclaration") &&
-									parser.isPure(decl, decl.range[0])
-								) {
-									classWithTopLevelSymbol.set(decl, fn);
-								} else if (parser.isPure(decl, statement.range[0])) {
-									statementWithTopLevelSymbol.set(statement, fn);
-									if (
-										!decl.type.endsWith("FunctionExpression") &&
-										!decl.type.endsWith("Declaration") &&
-										decl.type !== "Literal"
-									) {
-										statementPurePart.set(statement, decl);
-									}
-								}
-							}
-						}
-					});
-
 					parser.hooks.preDeclarator.tap(PLUGIN_NAME, (decl, statement) => {
 						if (!InnerGraph.isEnabled(parser.state)) return;
 						if (
@@ -162,13 +121,7 @@ class InnerGraphPlugin {
 							decl.id.type === "Identifier"
 						) {
 							const name = decl.id.name;
-							if (
-								decl.init.type === "ClassExpression" &&
-								parser.isPure(decl.init, decl.id.range[1])
-							) {
-								const fn = InnerGraph.tagTopLevelSymbol(parser, name);
-								classWithTopLevelSymbol.set(decl.init, fn);
-							} else if (parser.isPure(decl.init, decl.id.range[1])) {
+							if (parser.isPure(decl.init, decl.id.range[1])) {
 								const fn = InnerGraph.tagTopLevelSymbol(parser, name);
 								declWithTopLevelSymbol.set(decl, fn);
 								if (
@@ -228,80 +181,6 @@ class InnerGraphPlugin {
 							}
 						}
 					});
-
-					parser.hooks.classExtendsExpression.tap(
-						PLUGIN_NAME,
-						(expr, statement) => {
-							if (!InnerGraph.isEnabled(parser.state)) return;
-							if (parser.scope.topLevelScope === true) {
-								const fn = classWithTopLevelSymbol.get(statement);
-								if (
-									fn &&
-									parser.isPure(
-										expr,
-										statement.id ? statement.id.range[1] : statement.range[0]
-									)
-								) {
-									InnerGraph.setTopLevelSymbol(parser.state, fn);
-									onUsageSuper(expr);
-								}
-							}
-						}
-					);
-
-					parser.hooks.classBodyElement.tap(
-						PLUGIN_NAME,
-						(element, classDefinition) => {
-							if (!InnerGraph.isEnabled(parser.state)) return;
-							if (parser.scope.topLevelScope === true) {
-								const fn = classWithTopLevelSymbol.get(classDefinition);
-								if (fn) {
-									InnerGraph.setTopLevelSymbol(parser.state, undefined);
-								}
-							}
-						}
-					);
-
-					parser.hooks.classBodyValue.tap(
-						PLUGIN_NAME,
-						(expression, element, classDefinition) => {
-							if (!InnerGraph.isEnabled(parser.state)) return;
-							if (parser.scope.topLevelScope === true) {
-								const fn = classWithTopLevelSymbol.get(classDefinition);
-								if (fn) {
-									if (
-										!element.static ||
-										parser.isPure(
-											expression,
-											element.key ? element.key.range[1] : element.range[0]
-										)
-									) {
-										InnerGraph.setTopLevelSymbol(parser.state, fn);
-										if (element.type !== "MethodDefinition" && element.static) {
-											InnerGraph.onUsage(parser.state, usedByExports => {
-												switch (usedByExports) {
-													case undefined:
-													case true:
-														return;
-													default: {
-														const dep = new PureExpressionDependency(
-															expression.range
-														);
-														dep.loc = expression.loc;
-														dep.usedByExports = usedByExports;
-														parser.state.module.addDependency(dep);
-														break;
-													}
-												}
-											});
-										}
-									} else {
-										InnerGraph.setTopLevelSymbol(parser.state, undefined);
-									}
-								}
-							}
-						}
-					);
 
 					parser.hooks.declarator.tap(PLUGIN_NAME, (decl, statement) => {
 						if (!InnerGraph.isEnabled(parser.state)) return;


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

## Summary
dropped the handling of classes in the InnerGraphPlugin which rectifies the issue of replacement of `superclass` with null
<!-- cspell:disable-next-line -->

copilot:summary

## Issue
Solves #17711 
## Details

<!-- cspell:disable-next-line -->


copilot:walkthrough
