### PR TITLE
add fetchPriority to hmr runtime's ensureChunk function

### DIFF
--- a/lib/hmr/HotModuleReplacement.runtime.js
+++ b/lib/hmr/HotModuleReplacement.runtime.js
@@ -96,8 +96,8 @@ module.exports = function () {
 				Object.defineProperty(fn, name, createPropertyDescriptor(name));
 			}
 		}
-		fn.e = function (chunkId) {
-			return trackBlockingPromise(require.e(chunkId));
+		fn.e = function (chunkId, fetchPriority) {
+			return trackBlockingPromise(require.e(chunkId, fetchPriority));
 		};
 		return fn;
 	}


### PR DESCRIPTION
<!-- The webpack team is currently a beta pilot for GitHub Copilot for Pull Requests, please leave this template unchanged for now -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This code adds `fetchPriority` as an argument to the ensureChunk function.

https://github.com/webpack/webpack/blob/e381884115df2e7b8acd651d3bc2ee6fc35b188e/lib/RuntimeTemplate.js#L962-L964

We're missing that argument in the hmr runtime and this PR adds that in. Ideally this means that we are able to test webpackFetchPriority while using hmr.

## Summary

<!-- cspell:disable-next-line -->

copilot:summary

## Details

<!-- cspell:disable-next-line -->

copilot:walkthrough
