### PR TITLE
fix: don't optimize `extends` when class has constructor

### DIFF
--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -4026,7 +4026,7 @@ class JavascriptParser extends Parser {
 	}
 
 	/**
-	 * @param {Expression | Declaration | PrivateIdentifier | null | undefined} expr an expression
+	 * @param {Expression | Declaration | PrivateIdentifier | MethodDefinition | ExpressionStatement | null | undefined} expr an expression
 	 * @param {number} commentsStartPos source position from which annotation comments are checked
 	 * @returns {boolean} true, when the expression is pure
 	 */
@@ -4068,6 +4068,14 @@ class JavascriptParser extends Parser {
 					}
 
 					if (item.type === "StaticBlock") {
+						return false;
+					}
+
+					if (
+						expr.superClass &&
+						item.type === "MethodDefinition" &&
+						item.kind === "constructor"
+					) {
 						return false;
 					}
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fixes https://github.com/webpack/webpack/issues/17740

**Did you add tests for your changes?**

WIP

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

No

Also we still can improve some cases for better optimization, but we already has TODO for it
