### PR TITLE
fix: add warning for async external

### DIFF
--- a/lib/EnvironmentNotSupportAsyncWarning.js
+++ b/lib/EnvironmentNotSupportAsyncWarning.js
@@ -9,24 +9,38 @@ const WebpackError = require("./WebpackError");
 const makeSerializable = require("./util/makeSerializable");
 
 /** @typedef {import("./Module")} Module */
+/** @typedef {import("./Compilation")} Compilation */
+/** @typedef {import("./RuntimeTemplate")} RuntimeTemplate */
 /** @typedef {import("./serialization/ObjectMiddleware").ObjectDeserializerContext} ObjectDeserializerContext */
 /** @typedef {import("./serialization/ObjectMiddleware").ObjectSerializerContext} ObjectSerializerContext */
+/** @typedef {"asyncWebAssembly" | "topLevelAwait" | "external promise" | "external script" | "external import" | "external module"} Feature */
 
 class EnvironmentNotSupportAsyncWarning extends WebpackError {
 	/**
 	 * Creates an instance of EnvironmentNotSupportAsyncWarning.
 	 * @param {Module} module module
-	 * @param {string} moduleName module name
-	 * @param {"asyncWebAssembly" | "topLevelAwait"} feature feature
+	 * @param {Feature} feature feature
 	 */
-	constructor(module, moduleName, feature) {
-		const message = `The generated code contains 'async/await' because '${moduleName}' is using ${feature}.
+	constructor(module, feature) {
+		const message = `The generated code contains 'async/await' because this module is using "${feature}".
 However, your target environment does not appear to support 'async/await'.
 As a result, the code may not run as expected or may cause runtime errors.`;
 		super(message);
 
 		this.name = "EnvironmentNotSupportAsyncWarning";
 		this.module = module;
+	}
+
+	/**
+	 * Creates an instance of EnvironmentNotSupportAsyncWarning.
+	 * @param {Module} module module
+	 * @param {RuntimeTemplate} runtimeTemplate compilation
+	 * @param {Feature} feature feature
+	 */
+	static check(module, runtimeTemplate, feature) {
+		if (!runtimeTemplate.supportsAsyncFunction()) {
+			module.addWarning(new EnvironmentNotSupportAsyncWarning(module, feature));
+		}
 	}
 }
 

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -7,6 +7,7 @@
 
 const { OriginalSource, RawSource } = require("webpack-sources");
 const ConcatenationScope = require("./ConcatenationScope");
+const EnvironmentNotSupportAsyncWarning = require("./EnvironmentNotSupportAsyncWarning");
 const { UsageState } = require("./ExportsInfo");
 const InitFragment = require("./InitFragment");
 const Module = require("./Module");
@@ -19,7 +20,6 @@ const extractUrlAndGlobal = require("./util/extractUrlAndGlobal");
 const makeSerializable = require("./util/makeSerializable");
 const propertyAccess = require("./util/propertyAccess");
 const { register } = require("./util/serialization");
-const EnvironmentNotSupportAsyncWarning = require("./EnvironmentNotSupportAsyncWarning");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -19,6 +19,7 @@ const extractUrlAndGlobal = require("./util/extractUrlAndGlobal");
 const makeSerializable = require("./util/makeSerializable");
 const propertyAccess = require("./util/propertyAccess");
 const { register } = require("./util/serialization");
+const EnvironmentNotSupportAsyncWarning = require("./EnvironmentNotSupportAsyncWarning");
 
 /** @typedef {import("webpack-sources").Source} Source */
 /** @typedef {import("../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
@@ -503,6 +504,11 @@ class ExternalModule extends Module {
 					}
 				} else {
 					this.buildMeta.async = true;
+					EnvironmentNotSupportAsyncWarning.check(
+						this,
+						compilation.runtimeTemplate,
+						"external module"
+					);
 					if (!Array.isArray(request) || request.length === 1) {
 						this.buildMeta.exportsType = "namespace";
 						canMangle = false;
@@ -510,11 +516,28 @@ class ExternalModule extends Module {
 				}
 				break;
 			case "script":
+				this.buildMeta.async = true;
+				EnvironmentNotSupportAsyncWarning.check(
+					this,
+					compilation.runtimeTemplate,
+					"external script"
+				);
+				break;
 			case "promise":
 				this.buildMeta.async = true;
+				EnvironmentNotSupportAsyncWarning.check(
+					this,
+					compilation.runtimeTemplate,
+					"external promise"
+				);
 				break;
 			case "import":
 				this.buildMeta.async = true;
+				EnvironmentNotSupportAsyncWarning.check(
+					this,
+					compilation.runtimeTemplate,
+					"external import"
+				);
 				if (!Array.isArray(request) || request.length === 1) {
 					this.buildMeta.exportsType = "namespace";
 					canMangle = false;

--- a/lib/config/target.js
+++ b/lib/config/target.js
@@ -61,7 +61,7 @@ const getDefaultTarget = context => {
  * @property {boolean | null} module ESM syntax is available (when in module)
  * @property {boolean | null} optionalChaining optional chaining is available
  * @property {boolean | null} templateLiteral template literal is available
- * @property {boolean | null} asyncFunction async functions and await is available
+ * @property {boolean | null} asyncFunction async functions and await are available
  */
 
 ///** @typedef {PlatformTargetProperties | ApiTargetProperties | EcmaTargetProperties | PlatformTargetProperties & ApiTargetProperties | PlatformTargetProperties & EcmaTargetProperties | ApiTargetProperties & EcmaTargetProperties} TargetProperties */
@@ -193,6 +193,7 @@ You can also more options via the 'target' option: 'browserslist' / 'browserslis
 				templateLiteral: v(4),
 				optionalChaining: v(14),
 				arrowFunction: v(6),
+				asyncFunction: v(7, 6),
 				forOf: v(5),
 				destructuring: v(6),
 				bigIntLiteral: v(10, 4),
@@ -234,6 +235,7 @@ You can also more options via the 'target' option: 'browserslist' / 'browserslis
 				templateLiteral: v(1, 1),
 				optionalChaining: v(8),
 				arrowFunction: v(1, 1),
+				asyncFunction: v(1, 7),
 				forOf: v(0, 36),
 				destructuring: v(1, 1),
 				bigIntLiteral: v(4),
@@ -271,6 +273,7 @@ You can also more options via the 'target' option: 'browserslist' / 'browserslis
 				templateLiteral: v(0, 13),
 				optionalChaining: v(0, 44),
 				arrowFunction: v(0, 15),
+				asyncFunction: v(0, 21),
 				forOf: v(0, 13),
 				destructuring: v(0, 15),
 				bigIntLiteral: v(0, 32),

--- a/lib/dependencies/HarmonyDetectionParserPlugin.js
+++ b/lib/dependencies/HarmonyDetectionParserPlugin.js
@@ -76,15 +76,11 @@ module.exports = class HarmonyDetectionParserPlugin {
 			}
 			/** @type {BuildMeta} */
 			(module.buildMeta).async = true;
-			if (!parser.state.compilation.runtimeTemplate.supportsAsyncFunction()) {
-				module.addWarning(
-					new EnvironmentNotSupportAsyncWarning(
-						module,
-						module.nameForCondition(),
-						"topLevelAwait"
-					)
-				);
-			}
+			EnvironmentNotSupportAsyncWarning.check(
+				module,
+				parser.state.compilation.runtimeTemplate,
+				"topLevelAwait"
+			);
 		});
 
 		/**

--- a/lib/wasm-async/AsyncWebAssemblyParser.js
+++ b/lib/wasm-async/AsyncWebAssemblyParser.js
@@ -51,6 +51,11 @@ class WebAssemblyParser extends Parser {
 		const BuildMeta = /** @type {BuildMeta} */ (state.module.buildMeta);
 		BuildMeta.exportsType = "namespace";
 		BuildMeta.async = true;
+		EnvironmentNotSupportAsyncWarning.check(
+			state.module,
+			state.compilation.runtimeTemplate,
+			"asyncWebAssembly"
+		);
 
 		// parse it
 		const program = decode(source, decoderOpts);
@@ -75,16 +80,6 @@ class WebAssemblyParser extends Parser {
 		});
 
 		state.module.addDependency(new StaticExportsDependency(exports, false));
-
-		if (!state.compilation.runtimeTemplate.supportsAsyncFunction()) {
-			state.module.addWarning(
-				new EnvironmentNotSupportAsyncWarning(
-					state.module,
-					state.module.nameForCondition(),
-					"asyncWebAssembly"
-				)
-			);
-		}
 
 		return state;
 	}

--- a/test/configCases/async-module/environment-not-support-async-warning/index.js
+++ b/test/configCases/async-module/environment-not-support-async-warning/index.js
@@ -1,6 +1,9 @@
-it("should allow to use top-level-await", () => {
-	return import("./reexport").then(({ number, getNumber }) => {
+it("should have warnings for environment not support async/await when using asyncModule", () => {
+	return import("./reexport").then(({ number, getNumber, importRequest, moduleRequest, promiseRequest }) => {
 		expect(number).toBe(1);
 		expect(getNumber()).toBe(42);
+		expect(importRequest).toBe("import.js");
+		expect(moduleRequest).toBe("module.js");
+		expect(promiseRequest).toBe("promise.js");
 	});
 });

--- a/test/configCases/async-module/environment-not-support-async-warning/reexport.js
+++ b/test/configCases/async-module/environment-not-support-async-warning/reexport.js
@@ -1,2 +1,5 @@
 export { default as number } from "./tla";
 export { getNumber } from "./wasm.wat"
+export { default as moduleRequest } from "external-module"
+export { default as importRequest } from "external-import"
+export { default as promiseRequest } from "external-promise"

--- a/test/configCases/async-module/environment-not-support-async-warning/warnings.js
+++ b/test/configCases/async-module/environment-not-support-async-warning/warnings.js
@@ -1,10 +1,27 @@
 module.exports = [
 	[
+		{ moduleName: /tla\.js/ },
 		/The generated code contains 'async\/await'/,
-		/[\\/]tla\.js' is using topLevelAwait\./
+		/"topLevelAwait"/
 	],
 	[
+		{ moduleName: /external \["import\.js","request"\]/ },
 		/The generated code contains 'async\/await'/,
-		/[\\/]wasm\.wat' is using asyncWebAssembly\./
+		/"external import"/
+	],
+	[
+		{ moduleName: /external \["module\.js","request"\]/ },
+		/The generated code contains 'async\/await'/,
+		/"external module"/
+	],
+	[
+		{ moduleName: /external "Promise\.resolve\('promise\.js'\)"/ },
+		/The generated code contains 'async\/await'/,
+		/"external promise"/
+	],
+	[
+		{ moduleName: /wasm\.wat/ },
+		/The generated code contains 'async\/await'/,
+		/"asyncWebAssembly"/
 	]
 ];

--- a/test/configCases/async-module/environment-not-support-async-warning/webpack.config.js
+++ b/test/configCases/async-module/environment-not-support-async-warning/webpack.config.js
@@ -9,7 +9,18 @@ module.exports = {
 			}
 		]
 	},
-	target: ["node", "es5"],
+	output: {
+		environment: {
+			dynamicImport: true,
+			asyncFunction: false
+		},
+		importFunctionName: "((name) => Promise.resolve({ request: name }))"
+	},
+	externals: {
+		"external-module": ["module module.js", "request"],
+		"external-import": ["import import.js", "request"],
+		"external-promise": "promise Promise.resolve('promise.js')"
+	},
 	experiments: {
 		asyncWebAssembly: true
 	}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

related to #17958, also add the warning for async external (`external import`, `external module`, `external promise`, `external script`)

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Add EnvironmentNotSupportAsync warning for async external (`external import`, `external module`, `external promise`, `external script`)

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

update `configCases/async-module/environment-not-support-async-warning`

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

none

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
