### PR TITLE
Reuse VM context across webpack magic comments

### DIFF
--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -435,6 +435,10 @@ class JavascriptParser extends Parser {
 		/** @type {WeakMap<Expression, Set<string>> | undefined} */
 		this.destructuringAssignmentProperties = undefined;
 		this.currentTagData = undefined;
+		this.magicCommentContext = vm.createContext(undefined, {
+			name: "Webpack Magic Comment Parser",
+			codeGeneration: { strings: false, wasm: false }
+		});
 		this._initializeEvaluating();
 	}
 
@@ -4465,7 +4469,10 @@ class JavascriptParser extends Parser {
 				// try compile only if webpack options comment is present
 				try {
 					for (let [key, val] of Object.entries(
-						vm.runInNewContext(`(function(){return {${value}};})()`)
+						vm.runInContext(
+							`(function(){return {${value}};})()`,
+							this.magicCommentContext
+						)
 					)) {
 						if (typeof val === "object" && val !== null) {
 							if (val.constructor.name === "RegExp") val = new RegExp(val);

--- a/types.d.ts
+++ b/types.d.ts
@@ -106,6 +106,7 @@ import {
 	SyncWaterfallHook
 } from "tapable";
 import { SecureContextOptions, TlsOptions } from "tls";
+import { Context } from "vm";
 
 declare class AbstractLibraryPlugin<T> {
 	constructor(__0: {
@@ -5739,6 +5740,7 @@ declare class JavascriptParser extends Parser {
 		| ExportAllDeclaration;
 	destructuringAssignmentProperties?: WeakMap<Expression, Set<string>>;
 	currentTagData: any;
+	magicCommentContext: Context;
 	destructuringAssignmentPropertiesFor(
 		node: Expression
 	): undefined | Set<string>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Performance optimization. Reuses a single VM context for evaluating all webpack magic comments, instead of a fresh context for each comment.

Reduces time spent in the magic comment parser by ~75% while still maintaining the same degree of sandboxing from the main process.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
Feature already covered by several test cases.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.
**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
No documentation changes.