### PR TITLE
fix: use Math.imul in fnv1a32 to avoid loss of precision, directly hash UTF16 values

### DIFF
--- a/lib/util/numberHash.js
+++ b/lib/util/numberHash.js
@@ -48,6 +48,7 @@ function fnv1a32(str) {
 	let hash = FNV_OFFSET_32;
 	for (let i = 0, len = str.length; i < len; i++) {
 		hash ^= str.charCodeAt(i);
+		// Use Math.imul to do c-style 32-bit multiplication and keep only the 32 least significant bits
 		hash = Math.imul(hash, FNV_PRIME_32);
 	}
 	// Force the result to be positive

--- a/lib/util/numberHash.js
+++ b/lib/util/numberHash.js
@@ -47,14 +47,8 @@ const FNV_PRIME_64 = BigInt("0x100000001B3");
 function fnv1a32(str) {
 	let hash = FNV_OFFSET_32;
 	for (let i = 0, len = str.length; i < len; i++) {
-		let code = str.charCodeAt(i);
-		if (code > 0xff) {
-			hash ^= code & 0xff;
-			hash = (hash * FNV_PRIME_32) | 0;
-			code >>= 8;
-		}
-		hash ^= code;
-		hash = (hash * FNV_PRIME_32) | 0;
+		hash ^= str.charCodeAt(i);
+		hash = Math.imul(hash, FNV_PRIME_32);
 	}
 	// Force the result to be positive
 	return hash & MASK_31;
@@ -69,13 +63,7 @@ function fnv1a32(str) {
 function fnv1a64(str) {
 	let hash = FNV_OFFSET_64;
 	for (let i = 0, len = str.length; i < len; i++) {
-		let code = str.charCodeAt(i);
-		if (code > 0xff) {
-			hash ^= BigInt(code & 0xff);
-			hash = BigInt.asUintN(64, hash * FNV_PRIME_64);
-			code >>= 8;
-		}
-		hash ^= BigInt(code);
+		hash ^= BigInt(str.charCodeAt(i));
 		hash = BigInt.asUintN(64, hash * FNV_PRIME_64);
 	}
 	return hash;

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -163,9 +163,9 @@ describe("Compiler", () => {
 	it("should compile a file with multiple chunks", done => {
 		compile("./chunks", {}, (stats, files) => {
 			expect(stats.chunks).toHaveLength(2);
-			expect(Object.keys(files)).toEqual(["/main.js", "/272.js"]);
+			expect(Object.keys(files)).toEqual(["/main.js", "/78.js"]);
 			const bundle = files["/main.js"];
-			const chunk = files["/272.js"];
+			const chunk = files["/78.js"];
 			expect(bundle).toMatch("function __webpack_require__(");
 			expect(bundle).toMatch("__webpack_require__(/*! ./b */");
 			expect(chunk).not.toMatch("__webpack_require__(/* ./b */");

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -318,7 +318,7 @@ it("should emit errors for missingFile for production", async () => {
 		    Object {
 		      "loc": "4:0-20",
 		      "message": "Module not found: Error: Can't resolve './missing' in '<cwd>/test/fixtures/errors'",
-		      "moduleId": 96,
+		      "moduleId": 915,
 		      "moduleIdentifier": "<cwd>/test/fixtures/errors/missingFile.js",
 		      "moduleName": "./missingFile.js",
 		      "moduleTrace": Array [],
@@ -327,7 +327,7 @@ it("should emit errors for missingFile for production", async () => {
 		    Object {
 		      "loc": "12:9-34",
 		      "message": "Module not found: Error: Can't resolve './dir/missing2' in '<cwd>/test/fixtures/errors'",
-		      "moduleId": 96,
+		      "moduleId": 915,
 		      "moduleIdentifier": "<cwd>/test/fixtures/errors/missingFile.js",
 		      "moduleName": "./missingFile.js",
 		      "moduleTrace": Array [],

--- a/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
+++ b/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
@@ -1901,29 +1901,29 @@ head{--webpack-use-style_js:class/local1/local2/local3/local4/local5/local6/loca
 `;
 
 exports[`ConfigCacheTestCases css css-modules exported tests should allow to create css modules 2`] = `
-".my-app-539-SM {
+".my-app-235-zg {
 	color: red;
 }
 
-.my-app-539-ry,
-.my-app-539-kW .global,
-.my-app-539-rZ {
+.my-app-235-Hi,
+.my-app-235-OB .global,
+.my-app-235-VE {
 	color: green;
 }
 
-.global .my-app-539-yg {
+.global .my-app-235-O2 {
 	color: yellow;
 }
 
-.my-app-539-rE.global.my-app-539-k2 {
+.my-app-235-Vj.global.my-app-235-OH {
 	color: blue;
 }
 
-.my-app-539-do div:not(.disabled, .mButtonDisabled, .tipOnly) {
+.my-app-235-H5 div:not(.disabled, .mButtonDisabled, .tipOnly) {
     pointer-events: initial !important;
 }
 
-.my-app-539-yK :is(div.parent1.child1.vertical-tiny,
+.my-app-235-aq :is(div.parent1.child1.vertical-tiny,
     div.parent1.child1.vertical-small,
     div.otherDiv.horizontal-tiny,
     div.otherDiv.horizontal-small div.description) {
@@ -1932,7 +1932,7 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
   overflow: hidden;
 }
 
-.my-app-539-r8 :matches(div.parent1.child1.vertical-tiny,
+.my-app-235-VN :matches(div.parent1.child1.vertical-tiny,
     div.parent1.child1.vertical-small,
     div.otherDiv.horizontal-tiny,
     div.otherDiv.horizontal-small div.description) {
@@ -1941,7 +1941,7 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
   overflow: hidden;
 }
 
-.my-app-539-ui :where(div.parent1.child1.vertical-tiny,
+.my-app-235-VM :where(div.parent1.child1.vertical-tiny,
     div.parent1.child1.vertical-small,
     div.otherDiv.horizontal-tiny,
     div.otherDiv.horizontal-small div.description) {
@@ -1950,31 +1950,31 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
   overflow: hidden;
 }
 
-.my-app-539-kf div:has(.disabled, .mButtonDisabled, .tipOnly) {
+.my-app-235-AO div:has(.disabled, .mButtonDisabled, .tipOnly) {
     pointer-events: initial !important;
 }
 
-.my-app-539-eY div:current(p, span) {
+.my-app-235-Hq div:current(p, span) {
 	background-color: yellow;
 }
 
-.my-app-539-mA div:past(p, span) {
+.my-app-235-O4 div:past(p, span) {
 	display: none;
 }
 
-.my-app-539-gJ div:future(p, span) {
+.my-app-235-Hb div:future(p, span) {
 	background-color: yellow;
 }
 
-.my-app-539-ol div:-moz-any(ol, ul, menu, dir) {
+.my-app-235-OP div:-moz-any(ol, ul, menu, dir) {
 	list-style-type: square;
 }
 
-.my-app-539-sZ li:-webkit-any(:first-child, :last-child) {
+.my-app-235-Hw li:-webkit-any(:first-child, :last-child) {
 	background-color: aquamarine;
 }
 
-.my-app-539-r8 :matches(div.parent1.child1.vertical-tiny,
+.my-app-235-VN :matches(div.parent1.child1.vertical-tiny,
     div.parent1.child1.vertical-small,
     div.otherDiv.horizontal-tiny,
     div.otherDiv.horizontal-small div.description) {
@@ -1983,28 +1983,28 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 	overflow: hidden;
 }
 
-.my-app-539-KY.nested2.my-app-539-c7 {
+.my-app-235-nb.nested2.my-app-235-\\\\$Q {
 	color: pink;
 }
 
-#my-app-539-AB {
+#my-app-235-bD {
 	color: purple;
 }
 
-@keyframes my-app-539-Yf{
+@keyframes my-app-235-\\\\$t{
 	0% {
-		left: var(--my-app-539-Gw);
-		top: var(--my-app-539-uc);
+		left: var(--my-app-235-qi);
+		top: var(--my-app-235-xB);
 		color: var(--theme-color1);
 	}
 	100% {
-		left: var(--my-app-539-cP);
-		top: var(--my-app-539-EP);
+		left: var(--my-app-235-\\\\$6);
+		top: var(--my-app-235-gJ);
 		color: var(--theme-color2);
 	}
 }
 
-@keyframes my-app-539-kB{
+@keyframes my-app-235-x{
 	0% {
 		left: 0;
 	}
@@ -2013,13 +2013,13 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 	}
 }
 
-.my-app-539-OH {
-	animation-name: my-app-539-Yf;
-	animation: 3s ease-in 1s 2 reverse both paused my-app-539-Yf, my-app-539-kB;
-	--my-app-539-Gw: 0px;
-	--my-app-539-uc: 0px;
-	--my-app-539-cP: 10px;
-	--my-app-539-EP: 20px;
+.my-app-235-lY {
+	animation-name: my-app-235-\\\\$t;
+	animation: 3s ease-in 1s 2 reverse both paused my-app-235-\\\\$t, my-app-235-x;
+	--my-app-235-qi: 0px;
+	--my-app-235-xB: 0px;
+	--my-app-235-\\\\$6: 10px;
+	--my-app-235-gJ: 20px;
 }
 
 /* .composed {
@@ -2027,45 +2027,45 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 	composes: local2;
 } */
 
-.my-app-539-ag {
-	color: var(--my-app-539-S4);
-	--my-app-539-S4: red;
+.my-app-235-f {
+	color: var(--my-app-235-uz);
+	--my-app-235-uz: red;
 }
 
-.my-app-539-WW {
+.my-app-235-aK {
 	color: var(--global-color);
 	--global-color: red;
 }
 
 @media (min-width: 1600px) {
-	.my-app-539-qi {
-		color: var(--my-app-539-S4);
-		--my-app-539-S4: green;
+	.my-app-235-a7 {
+		color: var(--my-app-235-uz);
+		--my-app-235-uz: green;
 	}
 }
 
 @media screen and (max-width: 600px) {
-	.my-app-539-mI {
-		color: var(--my-app-539-S4);
-		--my-app-539-S4: purple;
+	.my-app-235-uf {
+		color: var(--my-app-235-uz);
+		--my-app-235-uz: purple;
 	}
 }
 
 @supports (display: grid) {
-	.my-app-539-OQ {
+	.my-app-235-sW {
 		display: grid;
 	}
 }
 
 @supports not (display: grid) {
-  .my-app-539-AZ {
+  .my-app-235-TZ {
     float: right;
   }
 }
 
 @supports (display: flex) {
   @media screen and (min-width: 900px) {
-    .my-app-539-s9 {
+    .my-app-235-aY {
       display: flex;
     }
   }
@@ -2073,7 +2073,7 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 
 @media screen and (min-width: 900px) {
 	@supports (display: flex) {
-    .my-app-539-I\\\\$ {
+    .my-app-235-II {
       display: flex;
     }
   }
@@ -2081,35 +2081,35 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 
 @MEDIA screen and (min-width: 900px) {
 	@SUPPORTS (display: flex) {
-		.my-app-539-Wu {
+		.my-app-235-ij {
 			display: flex;
 		}
 	}
 }
 
 .animationUpperCase {
-	ANIMATION-NAME: my-app-539-ec;
-	ANIMATION: 3s ease-in 1s 2 reverse both paused my-app-539-ec, my-app-539-mQ;
-	--my-app-539-Gw: 0px;
-	--my-app-539-uc: 0px;
-	--my-app-539-cP: 10px;
-	--my-app-539-EP: 20px;
+	ANIMATION-NAME: my-app-235-zG;
+	ANIMATION: 3s ease-in 1s 2 reverse both paused my-app-235-zG, my-app-235-Dk;
+	--my-app-235-qi: 0px;
+	--my-app-235-xB: 0px;
+	--my-app-235-\\\\$6: 10px;
+	--my-app-235-gJ: 20px;
 }
 
-@KEYFRAMES my-app-539-ec{
+@KEYFRAMES my-app-235-zG{
 	0% {
-		left: VAR(--my-app-539-Gw);
-		top: VAR(--my-app-539-uc);
+		left: VAR(--my-app-235-qi);
+		top: VAR(--my-app-235-xB);
 		color: VAR(--theme-color1);
 	}
 	100% {
-		left: VAR(--my-app-539-cP);
-		top: VAR(--my-app-539-EP);
+		left: VAR(--my-app-235-\\\\$6);
+		top: VAR(--my-app-235-gJ);
 		color: VAR(--theme-color2);
 	}
 }
 
-@KEYframes my-app-539-mQ{
+@KEYframes my-app-235-Dk{
 	0% {
 		left: 0;
 	}
@@ -2122,42 +2122,42 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 	color: yellow;
 }
 
-.my-app-539-YL {
-	color: VAR(--my-app-539-KA);
-	--my-app-539-KA: red;
+.my-app-235-XE {
+	color: VAR(--my-app-235-I0);
+	--my-app-235-I0: red;
 }
 
-.my-app-539-ak {
+.my-app-235-wt {
 	COLOR: VAR(--GLOBAR-COLOR);
 	--GLOBAR-COLOR: red;
 }
 
 @supports (top: env(safe-area-inset-top, 0)) {
-	.my-app-539-y_ {
+	.my-app-235-nc {
 		color: red;
 	}
 }
 
 .a {
-	animation: 3s my-app-539-es;
-	-webkit-animation: 3s my-app-539-es;
+	animation: 3s my-app-235-iZ;
+	-webkit-animation: 3s my-app-235-iZ;
 }
 
 .b {
-	animation: my-app-539-es 3s;
-	-webkit-animation: my-app-539-es 3s;
+	animation: my-app-235-iZ 3s;
+	-webkit-animation: my-app-235-iZ 3s;
 }
 
 .c {
-	animation-name: my-app-539-es;
-	-webkit-animation-name: my-app-539-es;
+	animation-name: my-app-235-iZ;
+	-webkit-animation-name: my-app-235-iZ;
 }
 
 .d {
-	--my-app-539-mW: animationName;
+	--my-app-235-ZP: animationName;
 }
 
-@keyframes my-app-539-es{
+@keyframes my-app-235-iZ{
 	0% {
 		background: white;
 	}
@@ -2166,7 +2166,7 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 	}
 }
 
-@-webkit-keyframes my-app-539-es{
+@-webkit-keyframes my-app-235-iZ{
 	0% {
 		background: white;
 	}
@@ -2175,7 +2175,7 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 	}
 }
 
-@-moz-keyframes my-app-539-kl{
+@-moz-keyframes my-app-235-M6{
 	0% {
 		background: white;
 	}
@@ -2203,27 +2203,27 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 	}
 }
 
-@property --my-app-539-iI{
+@property --my-app-235-rX{
 	syntax: \\"<color>\\";
 	inherits: false;
 	initial-value: #c0ffee;
 }
 
-.my-app-539-SM {
-	color: var(--my-app-539-iI);
+.my-app-235-zg {
+	color: var(--my-app-235-rX);
 }
 
 @layer utilities {
-	.my-app-539-Cg {
+	.my-app-235-dW {
 		padding: 0.5rem;
 	}
 
-	.my-app-539-sr {
+	.my-app-235-cD {
 		padding: 0.8rem;
 	}
 }
 
-.my-app-539-SM {
+.my-app-235-zg {
 	color: red;
 
 	.nested-pure {
@@ -2284,7 +2284,7 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 
 .nested-var {
 	.again {
-		color: var(--my-app-539-S4);
+		color: var(--my-app-235-uz);
 	}
 }
 
@@ -2329,7 +2329,7 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 }
 
 .nested-parens {
-	.my-app-539-r8 div:has(.vertical-tiny, .vertical-small) {
+	.my-app-235-VN div:has(.vertical-tiny, .vertical-small) {
 		max-height: 0;
 		margin: 0;
 		overflow: hidden;
@@ -2354,21 +2354,21 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 	}
 }
 
-.class .my-app-539-_y,
-.class .my-app-539-_y,
-.my-app-539-sX .in-local-global-scope {
+.class .my-app-235-V0,
+.class .my-app-235-V0,
+.my-app-235-Ci .in-local-global-scope {
 	color: red;
 }
 
 @container (width > 400px) {
-	.my-app-539-SU {
+	.my-app-235-bK {
 		font-size: 1.5em;
 	}
 }
 
 @container summary (min-width: 400px) {
 	@container (width > 400px) {
-		.my-app-539-ay {
+		.my-app-235-Y1 {
 			font-size: 1.5em;
 		}
 	}
@@ -2379,32 +2379,32 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 }
 
 .placeholder-gray-700:-ms-input-placeholder {
-	--my-app-539-qe: 1;
+	--my-app-235-Y: 1;
 	color: #4a5568;
-	color: rgba(74, 85, 104, var(--my-app-539-qe));
+	color: rgba(74, 85, 104, var(--my-app-235-Y));
 }
 .placeholder-gray-700::-ms-input-placeholder {
-	--my-app-539-qe: 1;
+	--my-app-235-Y: 1;
 	color: #4a5568;
-	color: rgba(74, 85, 104, var(--my-app-539-qe));
+	color: rgba(74, 85, 104, var(--my-app-235-Y));
 }
 .placeholder-gray-700::placeholder {
-	--my-app-539-qe: 1;
+	--my-app-235-Y: 1;
 	color: #4a5568;
-	color: rgba(74, 85, 104, var(--my-app-539-qe));
+	color: rgba(74, 85, 104, var(--my-app-235-Y));
 }
 
 :root {
-	--my-app-539-GM: dark;
+	--my-app-235-t6: dark;
 }
 
-@media screen and (prefers-color-scheme: var(--my-app-539-GM)) {
-	.my-app-539-qE {
+@media screen and (prefers-color-scheme: var(--my-app-235-t6)) {
+	.my-app-235-KR {
 		color: white;
 	}
 }
 
-@keyframes my-app-539-S0{
+@keyframes my-app-235-Fk{
 	from {
 		margin-left: 100%;
 		width: 300%;
@@ -2416,20 +2416,20 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 	}
 }
 
-.my-app-539-SM {
+.my-app-235-zg {
 	animation:
-		foo var(--my-app-539-mW) 3s,
-		var(--my-app-539-mW) 3s,
-		3s linear 1s infinite running my-app-539-S0,
-		3s linear env(foo, var(--my-app-539-qE)) infinite running my-app-539-S0;
+		foo var(--my-app-235-ZP) 3s,
+		var(--my-app-235-ZP) 3s,
+		3s linear 1s infinite running my-app-235-Fk,
+		3s linear env(foo, var(--my-app-235-KR)) infinite running my-app-235-Fk;
 }
 
 :root {
-	--my-app-539-qE: 10px;
+	--my-app-235-KR: 10px;
 }
 
-.my-app-539-SM {
-	bar: env(foo, var(--my-app-539-qE));
+.my-app-235-zg {
+	bar: env(foo, var(--my-app-235-KR));
 }
 
 .global-foo, .bar {
@@ -2484,12 +2484,12 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 .again-again-global {
 	animation: slidein 3s;
 
-	.again-again-global, .my-app-539-SM, .my-app-539-KY.nested2.my-app-539-c7 {
-		animation: my-app-539-S0 3s;
+	.again-again-global, .my-app-235-zg, .my-app-235-nb.nested2.my-app-235-\\\\$Q {
+		animation: my-app-235-Fk 3s;
 	}
 
-  .my-app-539-kW .global,
-	.my-app-539-rZ {
+  .my-app-235-OB .global,
+	.my-app-235-VE {
 		color: red;
 	}
 }
@@ -2498,38 +2498,38 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 	color: red;
 }
 
-.my-app-539-SM {
-	.my-app-539-SM {
-		.my-app-539-SM {
-			.my-app-539-SM {}
+.my-app-235-zg {
+	.my-app-235-zg {
+		.my-app-235-zg {
+			.my-app-235-zg {}
 		}
 	}
 }
 
-.my-app-539-SM {
-	.my-app-539-SM {
-		.my-app-539-SM {
-			.my-app-539-SM {
-				animation: my-app-539-S0 3s;
+.my-app-235-zg {
+	.my-app-235-zg {
+		.my-app-235-zg {
+			.my-app-235-zg {
+				animation: my-app-235-Fk 3s;
 			}
 		}
 	}
 }
 
-.my-app-539-SM {
-	animation: my-app-539-S0 3s;
-	.my-app-539-SM {
-		animation: my-app-539-S0 3s;
-		.my-app-539-SM {
-			animation: my-app-539-S0 3s;
-			.my-app-539-SM {
-				animation: my-app-539-S0 3s;
+.my-app-235-zg {
+	animation: my-app-235-Fk 3s;
+	.my-app-235-zg {
+		animation: my-app-235-Fk 3s;
+		.my-app-235-zg {
+			animation: my-app-235-Fk 3s;
+			.my-app-235-zg {
+				animation: my-app-235-Fk 3s;
 			}
 		}
 	}
 }
 
-.my-app-248-u {
+.my-app-666-k {
     color: red;
 }
 
@@ -2539,17 +2539,17 @@ exports[`ConfigCacheTestCases css css-modules exported tests should allow to cre
 
 .UnusedClassName{
     color: red;
-    padding: var(--my-app-816-or);
-    --my-app-816-or: 10px;
+    padding: var(--my-app-194-RJ);
+    --my-app-194-RJ: 10px;
 }
 
-.my-app-816-sZ {
+.my-app-194-ZL {
     color: green;
-    padding: var(--my-app-816-cP);
-    --my-app-816-cP: 10px;
+    padding: var(--my-app-194-c5);
+    --my-app-194-c5: 10px;
 }
 
-head{--webpack-my-app-848:SM/ry/kW/rZ/yg/rE/k2/do/yK/r8/ui/kf/eY/mA/gJ/ol/sZ/KY/c7/AB/Yf/Gw%uc%cP%EP%kB/OH/ag/S4%WW/qi/mI/OQ/AZ/s9/I\\\\$/Wu/ec/mQ/YL/KA%ak/y_/es/mW%kl/iI%Cg/sr/__y/sX/SU/ay/qe%GM%qE%S0/_539,u/_248,_535,or%sZ/cP%_816;}"
+head{--webpack-my-app-226:zg/Hi/OB/VE/O2/Vj/OH/H5/aq/VN/VM/AO/Hq/O4/Hb/OP/Hw/nb/\\\\$Q/bD/\\\\$t/qi%xB%\\\\$6%gJ%x/lY/f/uz%aK/a7/uf/sW/TZ/aY/II/ij/zG/Dk/XE/I0%wt/nc/iZ/ZP%M6/rX%dW/cD/V0/Ci/bK/Y1/Y%t6%KR%Fk/_235,k/_666,_816,RJ%ZL/c5%_194;}"
 `;
 
 exports[`ConfigCacheTestCases css css-modules exported tests should allow to create css modules: dev 1`] = `
@@ -2601,54 +2601,54 @@ Object {
 
 exports[`ConfigCacheTestCases css css-modules exported tests should allow to create css modules: prod 1`] = `
 Object {
-  "UsedClassName": "my-app-816-sZ",
-  "VARS": "--my-app-539-KA my-app-539-YL undefined my-app-539-ak",
-  "animation": "my-app-539-OH",
-  "animationName": "my-app-539-es",
-  "class": "my-app-539-SM",
-  "classInContainer": "my-app-539-SU",
-  "classLocalScope": "my-app-539-sX",
-  "cssModuleWithCustomFileExtension": "my-app-248-u",
-  "currentWmultiParams": "my-app-539-eY",
-  "deepClassInContainer": "my-app-539-ay",
-  "displayFlexInSupportsInMediaUpperCase": "my-app-539-Wu",
-  "futureWmultiParams": "my-app-539-gJ",
+  "UsedClassName": "my-app-194-ZL",
+  "VARS": "--my-app-235-I0 my-app-235-XE undefined my-app-235-wt",
+  "animation": "my-app-235-lY",
+  "animationName": "my-app-235-iZ",
+  "class": "my-app-235-zg",
+  "classInContainer": "my-app-235-bK",
+  "classLocalScope": "my-app-235-Ci",
+  "cssModuleWithCustomFileExtension": "my-app-666-k",
+  "currentWmultiParams": "my-app-235-Hq",
+  "deepClassInContainer": "my-app-235-Y1",
+  "displayFlexInSupportsInMediaUpperCase": "my-app-235-ij",
+  "futureWmultiParams": "my-app-235-Hb",
   "global": undefined,
-  "hasWmultiParams": "my-app-539-kf",
-  "ident": "my-app-539-AB",
-  "inLocalGlobalScope": "my-app-539-_y",
-  "inSupportScope": "my-app-539-y_",
-  "isWmultiParams": "my-app-539-yK",
-  "keyframes": "my-app-539-Yf",
-  "keyframesUPPERCASE": "my-app-539-ec",
-  "local": "my-app-539-ry my-app-539-kW my-app-539-rZ my-app-539-yg",
-  "local2": "my-app-539-rE my-app-539-k2",
-  "localkeyframes2UPPPERCASE": "my-app-539-mQ",
-  "matchesWmultiParams": "my-app-539-r8",
-  "media": "my-app-539-qi",
-  "mediaInSupports": "my-app-539-s9",
-  "mediaWithOperator": "my-app-539-mI",
-  "mozAnimationName": "my-app-539-kl",
-  "mozAnyWmultiParams": "my-app-539-ol",
-  "myColor": "--my-app-539-iI",
-  "nested": "my-app-539-KY undefined my-app-539-c7",
+  "hasWmultiParams": "my-app-235-AO",
+  "ident": "my-app-235-bD",
+  "inLocalGlobalScope": "my-app-235-V0",
+  "inSupportScope": "my-app-235-nc",
+  "isWmultiParams": "my-app-235-aq",
+  "keyframes": "my-app-235-$t",
+  "keyframesUPPERCASE": "my-app-235-zG",
+  "local": "my-app-235-Hi my-app-235-OB my-app-235-VE my-app-235-O2",
+  "local2": "my-app-235-Vj my-app-235-OH",
+  "localkeyframes2UPPPERCASE": "my-app-235-Dk",
+  "matchesWmultiParams": "my-app-235-VN",
+  "media": "my-app-235-a7",
+  "mediaInSupports": "my-app-235-aY",
+  "mediaWithOperator": "my-app-235-uf",
+  "mozAnimationName": "my-app-235-M6",
+  "mozAnyWmultiParams": "my-app-235-OP",
+  "myColor": "--my-app-235-rX",
+  "nested": "my-app-235-nb undefined my-app-235-$Q",
   "notAValidCssModuleExtension": true,
-  "notWmultiParams": "my-app-539-do",
-  "paddingLg": "my-app-539-sr",
-  "paddingSm": "my-app-539-Cg",
-  "pastWmultiParams": "my-app-539-mA",
-  "supports": "my-app-539-OQ",
-  "supportsInMedia": "my-app-539-I$",
-  "supportsWithOperator": "my-app-539-AZ",
-  "vars": "--my-app-539-S4 my-app-539-ag undefined my-app-539-WW",
-  "webkitAnyWmultiParams": "my-app-539-sZ",
-  "whereWmultiParams": "my-app-539-ui",
+  "notWmultiParams": "my-app-235-H5",
+  "paddingLg": "my-app-235-cD",
+  "paddingSm": "my-app-235-dW",
+  "pastWmultiParams": "my-app-235-O4",
+  "supports": "my-app-235-sW",
+  "supportsInMedia": "my-app-235-II",
+  "supportsWithOperator": "my-app-235-TZ",
+  "vars": "--my-app-235-uz my-app-235-f undefined my-app-235-aK",
+  "webkitAnyWmultiParams": "my-app-235-Hw",
+  "whereWmultiParams": "my-app-235-VM",
 }
 `;
 
 exports[`ConfigCacheTestCases css css-modules-broken-keyframes exported tests should allow to create css modules: prod 1`] = `
 Object {
-  "class": "my-app-539-S",
+  "class": "my-app-235-z",
 }
 `;
 
@@ -2701,127 +2701,127 @@ Object {
 
 exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to create css modules: prod 1`] = `
 Object {
-  "UsedClassName": "my-app-816-sZ",
-  "VARS": "--my-app-539-KA my-app-539-YL undefined my-app-539-ak",
-  "animation": "my-app-539-OH",
-  "animationName": "my-app-539-es",
-  "class": "my-app-539-SM",
-  "classInContainer": "my-app-539-SU",
-  "classLocalScope": "my-app-539-sX",
-  "cssModuleWithCustomFileExtension": "my-app-248-u",
-  "currentWmultiParams": "my-app-539-eY",
-  "deepClassInContainer": "my-app-539-ay",
-  "displayFlexInSupportsInMediaUpperCase": "my-app-539-Wu",
-  "futureWmultiParams": "my-app-539-gJ",
+  "UsedClassName": "my-app-194-ZL",
+  "VARS": "--my-app-235-I0 my-app-235-XE undefined my-app-235-wt",
+  "animation": "my-app-235-lY",
+  "animationName": "my-app-235-iZ",
+  "class": "my-app-235-zg",
+  "classInContainer": "my-app-235-bK",
+  "classLocalScope": "my-app-235-Ci",
+  "cssModuleWithCustomFileExtension": "my-app-666-k",
+  "currentWmultiParams": "my-app-235-Hq",
+  "deepClassInContainer": "my-app-235-Y1",
+  "displayFlexInSupportsInMediaUpperCase": "my-app-235-ij",
+  "futureWmultiParams": "my-app-235-Hb",
   "global": undefined,
-  "hasWmultiParams": "my-app-539-kf",
-  "ident": "my-app-539-AB",
-  "inLocalGlobalScope": "my-app-539-_y",
-  "inSupportScope": "my-app-539-y_",
-  "isWmultiParams": "my-app-539-yK",
-  "keyframes": "my-app-539-Yf",
-  "keyframesUPPERCASE": "my-app-539-ec",
-  "local": "my-app-539-ry my-app-539-kW my-app-539-rZ my-app-539-yg",
-  "local2": "my-app-539-rE my-app-539-k2",
-  "localkeyframes2UPPPERCASE": "my-app-539-mQ",
-  "matchesWmultiParams": "my-app-539-r8",
-  "media": "my-app-539-qi",
-  "mediaInSupports": "my-app-539-s9",
-  "mediaWithOperator": "my-app-539-mI",
-  "mozAnimationName": "my-app-539-kl",
-  "mozAnyWmultiParams": "my-app-539-ol",
-  "myColor": "--my-app-539-iI",
-  "nested": "my-app-539-KY undefined my-app-539-c7",
+  "hasWmultiParams": "my-app-235-AO",
+  "ident": "my-app-235-bD",
+  "inLocalGlobalScope": "my-app-235-V0",
+  "inSupportScope": "my-app-235-nc",
+  "isWmultiParams": "my-app-235-aq",
+  "keyframes": "my-app-235-$t",
+  "keyframesUPPERCASE": "my-app-235-zG",
+  "local": "my-app-235-Hi my-app-235-OB my-app-235-VE my-app-235-O2",
+  "local2": "my-app-235-Vj my-app-235-OH",
+  "localkeyframes2UPPPERCASE": "my-app-235-Dk",
+  "matchesWmultiParams": "my-app-235-VN",
+  "media": "my-app-235-a7",
+  "mediaInSupports": "my-app-235-aY",
+  "mediaWithOperator": "my-app-235-uf",
+  "mozAnimationName": "my-app-235-M6",
+  "mozAnyWmultiParams": "my-app-235-OP",
+  "myColor": "--my-app-235-rX",
+  "nested": "my-app-235-nb undefined my-app-235-$Q",
   "notAValidCssModuleExtension": true,
-  "notWmultiParams": "my-app-539-do",
-  "paddingLg": "my-app-539-sr",
-  "paddingSm": "my-app-539-Cg",
-  "pastWmultiParams": "my-app-539-mA",
-  "supports": "my-app-539-OQ",
-  "supportsInMedia": "my-app-539-I$",
-  "supportsWithOperator": "my-app-539-AZ",
-  "vars": "--my-app-539-S4 my-app-539-ag undefined my-app-539-WW",
-  "webkitAnyWmultiParams": "my-app-539-sZ",
-  "whereWmultiParams": "my-app-539-ui",
+  "notWmultiParams": "my-app-235-H5",
+  "paddingLg": "my-app-235-cD",
+  "paddingSm": "my-app-235-dW",
+  "pastWmultiParams": "my-app-235-O4",
+  "supports": "my-app-235-sW",
+  "supportsInMedia": "my-app-235-II",
+  "supportsWithOperator": "my-app-235-TZ",
+  "vars": "--my-app-235-uz my-app-235-f undefined my-app-235-aK",
+  "webkitAnyWmultiParams": "my-app-235-Hw",
+  "whereWmultiParams": "my-app-235-VM",
 }
 `;
 
 exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to create css modules: prod 2`] = `
 Object {
-  "UsedClassName": "my-app-816-sZ",
-  "VARS": "--my-app-539-KA my-app-539-YL undefined my-app-539-ak",
-  "animation": "my-app-539-OH",
-  "animationName": "my-app-539-es",
-  "class": "my-app-539-SM",
-  "classInContainer": "my-app-539-SU",
-  "classLocalScope": "my-app-539-sX",
-  "cssModuleWithCustomFileExtension": "my-app-248-u",
-  "currentWmultiParams": "my-app-539-eY",
-  "deepClassInContainer": "my-app-539-ay",
-  "displayFlexInSupportsInMediaUpperCase": "my-app-539-Wu",
-  "futureWmultiParams": "my-app-539-gJ",
+  "UsedClassName": "my-app-194-ZL",
+  "VARS": "--my-app-235-I0 my-app-235-XE undefined my-app-235-wt",
+  "animation": "my-app-235-lY",
+  "animationName": "my-app-235-iZ",
+  "class": "my-app-235-zg",
+  "classInContainer": "my-app-235-bK",
+  "classLocalScope": "my-app-235-Ci",
+  "cssModuleWithCustomFileExtension": "my-app-666-k",
+  "currentWmultiParams": "my-app-235-Hq",
+  "deepClassInContainer": "my-app-235-Y1",
+  "displayFlexInSupportsInMediaUpperCase": "my-app-235-ij",
+  "futureWmultiParams": "my-app-235-Hb",
   "global": undefined,
-  "hasWmultiParams": "my-app-539-kf",
-  "ident": "my-app-539-AB",
-  "inLocalGlobalScope": "my-app-539-_y",
-  "inSupportScope": "my-app-539-y_",
-  "isWmultiParams": "my-app-539-yK",
-  "keyframes": "my-app-539-Yf",
-  "keyframesUPPERCASE": "my-app-539-ec",
-  "local": "my-app-539-ry my-app-539-kW my-app-539-rZ my-app-539-yg",
-  "local2": "my-app-539-rE my-app-539-k2",
-  "localkeyframes2UPPPERCASE": "my-app-539-mQ",
-  "matchesWmultiParams": "my-app-539-r8",
-  "media": "my-app-539-qi",
-  "mediaInSupports": "my-app-539-s9",
-  "mediaWithOperator": "my-app-539-mI",
-  "mozAnimationName": "my-app-539-kl",
-  "mozAnyWmultiParams": "my-app-539-ol",
-  "myColor": "--my-app-539-iI",
-  "nested": "my-app-539-KY undefined my-app-539-c7",
+  "hasWmultiParams": "my-app-235-AO",
+  "ident": "my-app-235-bD",
+  "inLocalGlobalScope": "my-app-235-V0",
+  "inSupportScope": "my-app-235-nc",
+  "isWmultiParams": "my-app-235-aq",
+  "keyframes": "my-app-235-$t",
+  "keyframesUPPERCASE": "my-app-235-zG",
+  "local": "my-app-235-Hi my-app-235-OB my-app-235-VE my-app-235-O2",
+  "local2": "my-app-235-Vj my-app-235-OH",
+  "localkeyframes2UPPPERCASE": "my-app-235-Dk",
+  "matchesWmultiParams": "my-app-235-VN",
+  "media": "my-app-235-a7",
+  "mediaInSupports": "my-app-235-aY",
+  "mediaWithOperator": "my-app-235-uf",
+  "mozAnimationName": "my-app-235-M6",
+  "mozAnyWmultiParams": "my-app-235-OP",
+  "myColor": "--my-app-235-rX",
+  "nested": "my-app-235-nb undefined my-app-235-$Q",
   "notAValidCssModuleExtension": true,
-  "notWmultiParams": "my-app-539-do",
-  "paddingLg": "my-app-539-sr",
-  "paddingSm": "my-app-539-Cg",
-  "pastWmultiParams": "my-app-539-mA",
-  "supports": "my-app-539-OQ",
-  "supportsInMedia": "my-app-539-I$",
-  "supportsWithOperator": "my-app-539-AZ",
-  "vars": "--my-app-539-S4 my-app-539-ag undefined my-app-539-WW",
-  "webkitAnyWmultiParams": "my-app-539-sZ",
-  "whereWmultiParams": "my-app-539-ui",
+  "notWmultiParams": "my-app-235-H5",
+  "paddingLg": "my-app-235-cD",
+  "paddingSm": "my-app-235-dW",
+  "pastWmultiParams": "my-app-235-O4",
+  "supports": "my-app-235-sW",
+  "supportsInMedia": "my-app-235-II",
+  "supportsWithOperator": "my-app-235-TZ",
+  "vars": "--my-app-235-uz my-app-235-f undefined my-app-235-aK",
+  "webkitAnyWmultiParams": "my-app-235-Hw",
+  "whereWmultiParams": "my-app-235-VM",
 }
 `;
 
 exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: class-dev 1`] = `"./style.module.css-class"`;
 
-exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: class-prod 1`] = `"my-app-539-SM"`;
+exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: class-prod 1`] = `"my-app-235-zg"`;
 
-exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: class-prod 2`] = `"my-app-539-SM"`;
+exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: class-prod 2`] = `"my-app-235-zg"`;
 
 exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local1-dev 1`] = `"./style.module.css-local1"`;
 
-exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local1-prod 1`] = `"my-app-539-ry"`;
+exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local1-prod 1`] = `"my-app-235-Hi"`;
 
-exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local1-prod 2`] = `"my-app-539-ry"`;
+exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local1-prod 2`] = `"my-app-235-Hi"`;
 
 exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local2-dev 1`] = `"./style.module.css-local2"`;
 
-exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local2-prod 1`] = `"my-app-539-kW"`;
+exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local2-prod 1`] = `"my-app-235-OB"`;
 
-exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local2-prod 2`] = `"my-app-539-kW"`;
+exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local2-prod 2`] = `"my-app-235-OB"`;
 
 exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local3-dev 1`] = `"./style.module.css-local3"`;
 
-exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local3-prod 1`] = `"my-app-539-rZ"`;
+exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local3-prod 1`] = `"my-app-235-VE"`;
 
-exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local3-prod 2`] = `"my-app-539-rZ"`;
+exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local3-prod 2`] = `"my-app-235-VE"`;
 
 exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local4-dev 1`] = `"./style.module.css-local4"`;
 
-exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local4-prod 1`] = `"my-app-539-yg"`;
+exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local4-prod 1`] = `"my-app-235-O2"`;
 
-exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local4-prod 2`] = `"my-app-539-yg"`;
+exports[`ConfigCacheTestCases css css-modules-in-node exported tests should allow to import css modules: local4-prod 2`] = `"my-app-235-O2"`;
 
 exports[`ConfigCacheTestCases css large exported tests should allow to create css modules: dev 1`] = `
 Object {
@@ -2831,7 +2831,7 @@ Object {
 
 exports[`ConfigCacheTestCases css large exported tests should allow to create css modules: prod 1`] = `
 Object {
-  "placeholder": "512-UB7V",
+  "placeholder": "144-Oh6j",
 }
 `;
 
@@ -3788,27 +3788,27 @@ exports[`ConfigCacheTestCases records issue-2991 exported tests should write rel
 "{
   \\"chunks\\": {
     \\"byName\\": {
-      \\"main\\": 590
+      \\"main\\": 792
     },
     \\"bySource\\": {
-      \\"0 main\\": 590
+      \\"0 main\\": 792
     },
     \\"usedIds\\": [
-      590
+      792
     ]
   },
   \\"modules\\": {
     \\"byIdentifier\\": {
-      \\"./test.js\\": 844,
-      \\"external node-commonjs \\\\\\"fs\\\\\\"\\": 58,
-      \\"external node-commonjs \\\\\\"path\\\\\\"\\": 72,
-      \\"ignored|./.|pkgs/somepackage/foo\\": 128
+      \\"./test.js\\": 329,
+      \\"external node-commonjs \\\\\\"fs\\\\\\"\\": 896,
+      \\"external node-commonjs \\\\\\"path\\\\\\"\\": 928,
+      \\"ignored|./.|pkgs/somepackage/foo\\": 835
     },
     \\"usedIds\\": [
-      58,
-      72,
-      128,
-      844
+      329,
+      835,
+      896,
+      928
     ]
   }
 }"
@@ -3818,31 +3818,31 @@ exports[`ConfigCacheTestCases records issue-7339 exported tests should write rel
 "{
   \\"chunks\\": {
     \\"byName\\": {
-      \\"main\\": 590
+      \\"main\\": 792
     },
     \\"bySource\\": {
-      \\"0 main\\": 590
+      \\"0 main\\": 792
     },
     \\"usedIds\\": [
-      590
+      792
     ]
   },
   \\"modules\\": {
     \\"byIdentifier\\": {
-      \\"./dependencies/bar.js\\": 664,
-      \\"./dependencies/foo.js\\": 396,
-      \\"./dependencies|sync|/^\\\\\\\\.\\\\\\\\/.*$/\\": 660,
-      \\"./test.js\\": 844,
-      \\"external node-commonjs \\\\\\"fs\\\\\\"\\": 58,
-      \\"external node-commonjs \\\\\\"path\\\\\\"\\": 72
+      \\"./dependencies/bar.js\\": 666,
+      \\"./dependencies/foo.js\\": 147,
+      \\"./dependencies|sync|/^\\\\\\\\.\\\\\\\\/.*$/\\": 239,
+      \\"./test.js\\": 329,
+      \\"external node-commonjs \\\\\\"fs\\\\\\"\\": 896,
+      \\"external node-commonjs \\\\\\"path\\\\\\"\\": 928
     },
     \\"usedIds\\": [
-      58,
-      72,
-      396,
-      660,
-      664,
-      844
+      147,
+      239,
+      329,
+      666,
+      896,
+      928
     ]
   }
 }"

--- a/test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -1901,29 +1901,29 @@ head{--webpack-use-style_js:class/local1/local2/local3/local4/local5/local6/loca
 `;
 
 exports[`ConfigTestCases css css-modules exported tests should allow to create css modules 2`] = `
-".my-app-539-SM {
+".my-app-235-zg {
 	color: red;
 }
 
-.my-app-539-ry,
-.my-app-539-kW .global,
-.my-app-539-rZ {
+.my-app-235-Hi,
+.my-app-235-OB .global,
+.my-app-235-VE {
 	color: green;
 }
 
-.global .my-app-539-yg {
+.global .my-app-235-O2 {
 	color: yellow;
 }
 
-.my-app-539-rE.global.my-app-539-k2 {
+.my-app-235-Vj.global.my-app-235-OH {
 	color: blue;
 }
 
-.my-app-539-do div:not(.disabled, .mButtonDisabled, .tipOnly) {
+.my-app-235-H5 div:not(.disabled, .mButtonDisabled, .tipOnly) {
     pointer-events: initial !important;
 }
 
-.my-app-539-yK :is(div.parent1.child1.vertical-tiny,
+.my-app-235-aq :is(div.parent1.child1.vertical-tiny,
     div.parent1.child1.vertical-small,
     div.otherDiv.horizontal-tiny,
     div.otherDiv.horizontal-small div.description) {
@@ -1932,7 +1932,7 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
   overflow: hidden;
 }
 
-.my-app-539-r8 :matches(div.parent1.child1.vertical-tiny,
+.my-app-235-VN :matches(div.parent1.child1.vertical-tiny,
     div.parent1.child1.vertical-small,
     div.otherDiv.horizontal-tiny,
     div.otherDiv.horizontal-small div.description) {
@@ -1941,7 +1941,7 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
   overflow: hidden;
 }
 
-.my-app-539-ui :where(div.parent1.child1.vertical-tiny,
+.my-app-235-VM :where(div.parent1.child1.vertical-tiny,
     div.parent1.child1.vertical-small,
     div.otherDiv.horizontal-tiny,
     div.otherDiv.horizontal-small div.description) {
@@ -1950,31 +1950,31 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
   overflow: hidden;
 }
 
-.my-app-539-kf div:has(.disabled, .mButtonDisabled, .tipOnly) {
+.my-app-235-AO div:has(.disabled, .mButtonDisabled, .tipOnly) {
     pointer-events: initial !important;
 }
 
-.my-app-539-eY div:current(p, span) {
+.my-app-235-Hq div:current(p, span) {
 	background-color: yellow;
 }
 
-.my-app-539-mA div:past(p, span) {
+.my-app-235-O4 div:past(p, span) {
 	display: none;
 }
 
-.my-app-539-gJ div:future(p, span) {
+.my-app-235-Hb div:future(p, span) {
 	background-color: yellow;
 }
 
-.my-app-539-ol div:-moz-any(ol, ul, menu, dir) {
+.my-app-235-OP div:-moz-any(ol, ul, menu, dir) {
 	list-style-type: square;
 }
 
-.my-app-539-sZ li:-webkit-any(:first-child, :last-child) {
+.my-app-235-Hw li:-webkit-any(:first-child, :last-child) {
 	background-color: aquamarine;
 }
 
-.my-app-539-r8 :matches(div.parent1.child1.vertical-tiny,
+.my-app-235-VN :matches(div.parent1.child1.vertical-tiny,
     div.parent1.child1.vertical-small,
     div.otherDiv.horizontal-tiny,
     div.otherDiv.horizontal-small div.description) {
@@ -1983,28 +1983,28 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 	overflow: hidden;
 }
 
-.my-app-539-KY.nested2.my-app-539-c7 {
+.my-app-235-nb.nested2.my-app-235-\\\\$Q {
 	color: pink;
 }
 
-#my-app-539-AB {
+#my-app-235-bD {
 	color: purple;
 }
 
-@keyframes my-app-539-Yf{
+@keyframes my-app-235-\\\\$t{
 	0% {
-		left: var(--my-app-539-Gw);
-		top: var(--my-app-539-uc);
+		left: var(--my-app-235-qi);
+		top: var(--my-app-235-xB);
 		color: var(--theme-color1);
 	}
 	100% {
-		left: var(--my-app-539-cP);
-		top: var(--my-app-539-EP);
+		left: var(--my-app-235-\\\\$6);
+		top: var(--my-app-235-gJ);
 		color: var(--theme-color2);
 	}
 }
 
-@keyframes my-app-539-kB{
+@keyframes my-app-235-x{
 	0% {
 		left: 0;
 	}
@@ -2013,13 +2013,13 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 	}
 }
 
-.my-app-539-OH {
-	animation-name: my-app-539-Yf;
-	animation: 3s ease-in 1s 2 reverse both paused my-app-539-Yf, my-app-539-kB;
-	--my-app-539-Gw: 0px;
-	--my-app-539-uc: 0px;
-	--my-app-539-cP: 10px;
-	--my-app-539-EP: 20px;
+.my-app-235-lY {
+	animation-name: my-app-235-\\\\$t;
+	animation: 3s ease-in 1s 2 reverse both paused my-app-235-\\\\$t, my-app-235-x;
+	--my-app-235-qi: 0px;
+	--my-app-235-xB: 0px;
+	--my-app-235-\\\\$6: 10px;
+	--my-app-235-gJ: 20px;
 }
 
 /* .composed {
@@ -2027,45 +2027,45 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 	composes: local2;
 } */
 
-.my-app-539-ag {
-	color: var(--my-app-539-S4);
-	--my-app-539-S4: red;
+.my-app-235-f {
+	color: var(--my-app-235-uz);
+	--my-app-235-uz: red;
 }
 
-.my-app-539-WW {
+.my-app-235-aK {
 	color: var(--global-color);
 	--global-color: red;
 }
 
 @media (min-width: 1600px) {
-	.my-app-539-qi {
-		color: var(--my-app-539-S4);
-		--my-app-539-S4: green;
+	.my-app-235-a7 {
+		color: var(--my-app-235-uz);
+		--my-app-235-uz: green;
 	}
 }
 
 @media screen and (max-width: 600px) {
-	.my-app-539-mI {
-		color: var(--my-app-539-S4);
-		--my-app-539-S4: purple;
+	.my-app-235-uf {
+		color: var(--my-app-235-uz);
+		--my-app-235-uz: purple;
 	}
 }
 
 @supports (display: grid) {
-	.my-app-539-OQ {
+	.my-app-235-sW {
 		display: grid;
 	}
 }
 
 @supports not (display: grid) {
-  .my-app-539-AZ {
+  .my-app-235-TZ {
     float: right;
   }
 }
 
 @supports (display: flex) {
   @media screen and (min-width: 900px) {
-    .my-app-539-s9 {
+    .my-app-235-aY {
       display: flex;
     }
   }
@@ -2073,7 +2073,7 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 
 @media screen and (min-width: 900px) {
 	@supports (display: flex) {
-    .my-app-539-I\\\\$ {
+    .my-app-235-II {
       display: flex;
     }
   }
@@ -2081,35 +2081,35 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 
 @MEDIA screen and (min-width: 900px) {
 	@SUPPORTS (display: flex) {
-		.my-app-539-Wu {
+		.my-app-235-ij {
 			display: flex;
 		}
 	}
 }
 
 .animationUpperCase {
-	ANIMATION-NAME: my-app-539-ec;
-	ANIMATION: 3s ease-in 1s 2 reverse both paused my-app-539-ec, my-app-539-mQ;
-	--my-app-539-Gw: 0px;
-	--my-app-539-uc: 0px;
-	--my-app-539-cP: 10px;
-	--my-app-539-EP: 20px;
+	ANIMATION-NAME: my-app-235-zG;
+	ANIMATION: 3s ease-in 1s 2 reverse both paused my-app-235-zG, my-app-235-Dk;
+	--my-app-235-qi: 0px;
+	--my-app-235-xB: 0px;
+	--my-app-235-\\\\$6: 10px;
+	--my-app-235-gJ: 20px;
 }
 
-@KEYFRAMES my-app-539-ec{
+@KEYFRAMES my-app-235-zG{
 	0% {
-		left: VAR(--my-app-539-Gw);
-		top: VAR(--my-app-539-uc);
+		left: VAR(--my-app-235-qi);
+		top: VAR(--my-app-235-xB);
 		color: VAR(--theme-color1);
 	}
 	100% {
-		left: VAR(--my-app-539-cP);
-		top: VAR(--my-app-539-EP);
+		left: VAR(--my-app-235-\\\\$6);
+		top: VAR(--my-app-235-gJ);
 		color: VAR(--theme-color2);
 	}
 }
 
-@KEYframes my-app-539-mQ{
+@KEYframes my-app-235-Dk{
 	0% {
 		left: 0;
 	}
@@ -2122,42 +2122,42 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 	color: yellow;
 }
 
-.my-app-539-YL {
-	color: VAR(--my-app-539-KA);
-	--my-app-539-KA: red;
+.my-app-235-XE {
+	color: VAR(--my-app-235-I0);
+	--my-app-235-I0: red;
 }
 
-.my-app-539-ak {
+.my-app-235-wt {
 	COLOR: VAR(--GLOBAR-COLOR);
 	--GLOBAR-COLOR: red;
 }
 
 @supports (top: env(safe-area-inset-top, 0)) {
-	.my-app-539-y_ {
+	.my-app-235-nc {
 		color: red;
 	}
 }
 
 .a {
-	animation: 3s my-app-539-es;
-	-webkit-animation: 3s my-app-539-es;
+	animation: 3s my-app-235-iZ;
+	-webkit-animation: 3s my-app-235-iZ;
 }
 
 .b {
-	animation: my-app-539-es 3s;
-	-webkit-animation: my-app-539-es 3s;
+	animation: my-app-235-iZ 3s;
+	-webkit-animation: my-app-235-iZ 3s;
 }
 
 .c {
-	animation-name: my-app-539-es;
-	-webkit-animation-name: my-app-539-es;
+	animation-name: my-app-235-iZ;
+	-webkit-animation-name: my-app-235-iZ;
 }
 
 .d {
-	--my-app-539-mW: animationName;
+	--my-app-235-ZP: animationName;
 }
 
-@keyframes my-app-539-es{
+@keyframes my-app-235-iZ{
 	0% {
 		background: white;
 	}
@@ -2166,7 +2166,7 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 	}
 }
 
-@-webkit-keyframes my-app-539-es{
+@-webkit-keyframes my-app-235-iZ{
 	0% {
 		background: white;
 	}
@@ -2175,7 +2175,7 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 	}
 }
 
-@-moz-keyframes my-app-539-kl{
+@-moz-keyframes my-app-235-M6{
 	0% {
 		background: white;
 	}
@@ -2203,27 +2203,27 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 	}
 }
 
-@property --my-app-539-iI{
+@property --my-app-235-rX{
 	syntax: \\"<color>\\";
 	inherits: false;
 	initial-value: #c0ffee;
 }
 
-.my-app-539-SM {
-	color: var(--my-app-539-iI);
+.my-app-235-zg {
+	color: var(--my-app-235-rX);
 }
 
 @layer utilities {
-	.my-app-539-Cg {
+	.my-app-235-dW {
 		padding: 0.5rem;
 	}
 
-	.my-app-539-sr {
+	.my-app-235-cD {
 		padding: 0.8rem;
 	}
 }
 
-.my-app-539-SM {
+.my-app-235-zg {
 	color: red;
 
 	.nested-pure {
@@ -2284,7 +2284,7 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 
 .nested-var {
 	.again {
-		color: var(--my-app-539-S4);
+		color: var(--my-app-235-uz);
 	}
 }
 
@@ -2329,7 +2329,7 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 }
 
 .nested-parens {
-	.my-app-539-r8 div:has(.vertical-tiny, .vertical-small) {
+	.my-app-235-VN div:has(.vertical-tiny, .vertical-small) {
 		max-height: 0;
 		margin: 0;
 		overflow: hidden;
@@ -2354,21 +2354,21 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 	}
 }
 
-.class .my-app-539-_y,
-.class .my-app-539-_y,
-.my-app-539-sX .in-local-global-scope {
+.class .my-app-235-V0,
+.class .my-app-235-V0,
+.my-app-235-Ci .in-local-global-scope {
 	color: red;
 }
 
 @container (width > 400px) {
-	.my-app-539-SU {
+	.my-app-235-bK {
 		font-size: 1.5em;
 	}
 }
 
 @container summary (min-width: 400px) {
 	@container (width > 400px) {
-		.my-app-539-ay {
+		.my-app-235-Y1 {
 			font-size: 1.5em;
 		}
 	}
@@ -2379,32 +2379,32 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 }
 
 .placeholder-gray-700:-ms-input-placeholder {
-	--my-app-539-qe: 1;
+	--my-app-235-Y: 1;
 	color: #4a5568;
-	color: rgba(74, 85, 104, var(--my-app-539-qe));
+	color: rgba(74, 85, 104, var(--my-app-235-Y));
 }
 .placeholder-gray-700::-ms-input-placeholder {
-	--my-app-539-qe: 1;
+	--my-app-235-Y: 1;
 	color: #4a5568;
-	color: rgba(74, 85, 104, var(--my-app-539-qe));
+	color: rgba(74, 85, 104, var(--my-app-235-Y));
 }
 .placeholder-gray-700::placeholder {
-	--my-app-539-qe: 1;
+	--my-app-235-Y: 1;
 	color: #4a5568;
-	color: rgba(74, 85, 104, var(--my-app-539-qe));
+	color: rgba(74, 85, 104, var(--my-app-235-Y));
 }
 
 :root {
-	--my-app-539-GM: dark;
+	--my-app-235-t6: dark;
 }
 
-@media screen and (prefers-color-scheme: var(--my-app-539-GM)) {
-	.my-app-539-qE {
+@media screen and (prefers-color-scheme: var(--my-app-235-t6)) {
+	.my-app-235-KR {
 		color: white;
 	}
 }
 
-@keyframes my-app-539-S0{
+@keyframes my-app-235-Fk{
 	from {
 		margin-left: 100%;
 		width: 300%;
@@ -2416,20 +2416,20 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 	}
 }
 
-.my-app-539-SM {
+.my-app-235-zg {
 	animation:
-		foo var(--my-app-539-mW) 3s,
-		var(--my-app-539-mW) 3s,
-		3s linear 1s infinite running my-app-539-S0,
-		3s linear env(foo, var(--my-app-539-qE)) infinite running my-app-539-S0;
+		foo var(--my-app-235-ZP) 3s,
+		var(--my-app-235-ZP) 3s,
+		3s linear 1s infinite running my-app-235-Fk,
+		3s linear env(foo, var(--my-app-235-KR)) infinite running my-app-235-Fk;
 }
 
 :root {
-	--my-app-539-qE: 10px;
+	--my-app-235-KR: 10px;
 }
 
-.my-app-539-SM {
-	bar: env(foo, var(--my-app-539-qE));
+.my-app-235-zg {
+	bar: env(foo, var(--my-app-235-KR));
 }
 
 .global-foo, .bar {
@@ -2484,12 +2484,12 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 .again-again-global {
 	animation: slidein 3s;
 
-	.again-again-global, .my-app-539-SM, .my-app-539-KY.nested2.my-app-539-c7 {
-		animation: my-app-539-S0 3s;
+	.again-again-global, .my-app-235-zg, .my-app-235-nb.nested2.my-app-235-\\\\$Q {
+		animation: my-app-235-Fk 3s;
 	}
 
-  .my-app-539-kW .global,
-	.my-app-539-rZ {
+  .my-app-235-OB .global,
+	.my-app-235-VE {
 		color: red;
 	}
 }
@@ -2498,38 +2498,38 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 	color: red;
 }
 
-.my-app-539-SM {
-	.my-app-539-SM {
-		.my-app-539-SM {
-			.my-app-539-SM {}
+.my-app-235-zg {
+	.my-app-235-zg {
+		.my-app-235-zg {
+			.my-app-235-zg {}
 		}
 	}
 }
 
-.my-app-539-SM {
-	.my-app-539-SM {
-		.my-app-539-SM {
-			.my-app-539-SM {
-				animation: my-app-539-S0 3s;
+.my-app-235-zg {
+	.my-app-235-zg {
+		.my-app-235-zg {
+			.my-app-235-zg {
+				animation: my-app-235-Fk 3s;
 			}
 		}
 	}
 }
 
-.my-app-539-SM {
-	animation: my-app-539-S0 3s;
-	.my-app-539-SM {
-		animation: my-app-539-S0 3s;
-		.my-app-539-SM {
-			animation: my-app-539-S0 3s;
-			.my-app-539-SM {
-				animation: my-app-539-S0 3s;
+.my-app-235-zg {
+	animation: my-app-235-Fk 3s;
+	.my-app-235-zg {
+		animation: my-app-235-Fk 3s;
+		.my-app-235-zg {
+			animation: my-app-235-Fk 3s;
+			.my-app-235-zg {
+				animation: my-app-235-Fk 3s;
 			}
 		}
 	}
 }
 
-.my-app-248-u {
+.my-app-666-k {
     color: red;
 }
 
@@ -2539,17 +2539,17 @@ exports[`ConfigTestCases css css-modules exported tests should allow to create c
 
 .UnusedClassName{
     color: red;
-    padding: var(--my-app-816-or);
-    --my-app-816-or: 10px;
+    padding: var(--my-app-194-RJ);
+    --my-app-194-RJ: 10px;
 }
 
-.my-app-816-sZ {
+.my-app-194-ZL {
     color: green;
-    padding: var(--my-app-816-cP);
-    --my-app-816-cP: 10px;
+    padding: var(--my-app-194-c5);
+    --my-app-194-c5: 10px;
 }
 
-head{--webpack-my-app-848:SM/ry/kW/rZ/yg/rE/k2/do/yK/r8/ui/kf/eY/mA/gJ/ol/sZ/KY/c7/AB/Yf/Gw%uc%cP%EP%kB/OH/ag/S4%WW/qi/mI/OQ/AZ/s9/I\\\\$/Wu/ec/mQ/YL/KA%ak/y_/es/mW%kl/iI%Cg/sr/__y/sX/SU/ay/qe%GM%qE%S0/_539,u/_248,_535,or%sZ/cP%_816;}"
+head{--webpack-my-app-226:zg/Hi/OB/VE/O2/Vj/OH/H5/aq/VN/VM/AO/Hq/O4/Hb/OP/Hw/nb/\\\\$Q/bD/\\\\$t/qi%xB%\\\\$6%gJ%x/lY/f/uz%aK/a7/uf/sW/TZ/aY/II/ij/zG/Dk/XE/I0%wt/nc/iZ/ZP%M6/rX%dW/cD/V0/Ci/bK/Y1/Y%t6%KR%Fk/_235,k/_666,_816,RJ%ZL/c5%_194;}"
 `;
 
 exports[`ConfigTestCases css css-modules exported tests should allow to create css modules: dev 1`] = `
@@ -2601,54 +2601,54 @@ Object {
 
 exports[`ConfigTestCases css css-modules exported tests should allow to create css modules: prod 1`] = `
 Object {
-  "UsedClassName": "my-app-816-sZ",
-  "VARS": "--my-app-539-KA my-app-539-YL undefined my-app-539-ak",
-  "animation": "my-app-539-OH",
-  "animationName": "my-app-539-es",
-  "class": "my-app-539-SM",
-  "classInContainer": "my-app-539-SU",
-  "classLocalScope": "my-app-539-sX",
-  "cssModuleWithCustomFileExtension": "my-app-248-u",
-  "currentWmultiParams": "my-app-539-eY",
-  "deepClassInContainer": "my-app-539-ay",
-  "displayFlexInSupportsInMediaUpperCase": "my-app-539-Wu",
-  "futureWmultiParams": "my-app-539-gJ",
+  "UsedClassName": "my-app-194-ZL",
+  "VARS": "--my-app-235-I0 my-app-235-XE undefined my-app-235-wt",
+  "animation": "my-app-235-lY",
+  "animationName": "my-app-235-iZ",
+  "class": "my-app-235-zg",
+  "classInContainer": "my-app-235-bK",
+  "classLocalScope": "my-app-235-Ci",
+  "cssModuleWithCustomFileExtension": "my-app-666-k",
+  "currentWmultiParams": "my-app-235-Hq",
+  "deepClassInContainer": "my-app-235-Y1",
+  "displayFlexInSupportsInMediaUpperCase": "my-app-235-ij",
+  "futureWmultiParams": "my-app-235-Hb",
   "global": undefined,
-  "hasWmultiParams": "my-app-539-kf",
-  "ident": "my-app-539-AB",
-  "inLocalGlobalScope": "my-app-539-_y",
-  "inSupportScope": "my-app-539-y_",
-  "isWmultiParams": "my-app-539-yK",
-  "keyframes": "my-app-539-Yf",
-  "keyframesUPPERCASE": "my-app-539-ec",
-  "local": "my-app-539-ry my-app-539-kW my-app-539-rZ my-app-539-yg",
-  "local2": "my-app-539-rE my-app-539-k2",
-  "localkeyframes2UPPPERCASE": "my-app-539-mQ",
-  "matchesWmultiParams": "my-app-539-r8",
-  "media": "my-app-539-qi",
-  "mediaInSupports": "my-app-539-s9",
-  "mediaWithOperator": "my-app-539-mI",
-  "mozAnimationName": "my-app-539-kl",
-  "mozAnyWmultiParams": "my-app-539-ol",
-  "myColor": "--my-app-539-iI",
-  "nested": "my-app-539-KY undefined my-app-539-c7",
+  "hasWmultiParams": "my-app-235-AO",
+  "ident": "my-app-235-bD",
+  "inLocalGlobalScope": "my-app-235-V0",
+  "inSupportScope": "my-app-235-nc",
+  "isWmultiParams": "my-app-235-aq",
+  "keyframes": "my-app-235-$t",
+  "keyframesUPPERCASE": "my-app-235-zG",
+  "local": "my-app-235-Hi my-app-235-OB my-app-235-VE my-app-235-O2",
+  "local2": "my-app-235-Vj my-app-235-OH",
+  "localkeyframes2UPPPERCASE": "my-app-235-Dk",
+  "matchesWmultiParams": "my-app-235-VN",
+  "media": "my-app-235-a7",
+  "mediaInSupports": "my-app-235-aY",
+  "mediaWithOperator": "my-app-235-uf",
+  "mozAnimationName": "my-app-235-M6",
+  "mozAnyWmultiParams": "my-app-235-OP",
+  "myColor": "--my-app-235-rX",
+  "nested": "my-app-235-nb undefined my-app-235-$Q",
   "notAValidCssModuleExtension": true,
-  "notWmultiParams": "my-app-539-do",
-  "paddingLg": "my-app-539-sr",
-  "paddingSm": "my-app-539-Cg",
-  "pastWmultiParams": "my-app-539-mA",
-  "supports": "my-app-539-OQ",
-  "supportsInMedia": "my-app-539-I$",
-  "supportsWithOperator": "my-app-539-AZ",
-  "vars": "--my-app-539-S4 my-app-539-ag undefined my-app-539-WW",
-  "webkitAnyWmultiParams": "my-app-539-sZ",
-  "whereWmultiParams": "my-app-539-ui",
+  "notWmultiParams": "my-app-235-H5",
+  "paddingLg": "my-app-235-cD",
+  "paddingSm": "my-app-235-dW",
+  "pastWmultiParams": "my-app-235-O4",
+  "supports": "my-app-235-sW",
+  "supportsInMedia": "my-app-235-II",
+  "supportsWithOperator": "my-app-235-TZ",
+  "vars": "--my-app-235-uz my-app-235-f undefined my-app-235-aK",
+  "webkitAnyWmultiParams": "my-app-235-Hw",
+  "whereWmultiParams": "my-app-235-VM",
 }
 `;
 
 exports[`ConfigTestCases css css-modules-broken-keyframes exported tests should allow to create css modules: prod 1`] = `
 Object {
-  "class": "my-app-539-S",
+  "class": "my-app-235-z",
 }
 `;
 
@@ -2701,127 +2701,127 @@ Object {
 
 exports[`ConfigTestCases css css-modules-in-node exported tests should allow to create css modules: prod 1`] = `
 Object {
-  "UsedClassName": "my-app-816-sZ",
-  "VARS": "--my-app-539-KA my-app-539-YL undefined my-app-539-ak",
-  "animation": "my-app-539-OH",
-  "animationName": "my-app-539-es",
-  "class": "my-app-539-SM",
-  "classInContainer": "my-app-539-SU",
-  "classLocalScope": "my-app-539-sX",
-  "cssModuleWithCustomFileExtension": "my-app-248-u",
-  "currentWmultiParams": "my-app-539-eY",
-  "deepClassInContainer": "my-app-539-ay",
-  "displayFlexInSupportsInMediaUpperCase": "my-app-539-Wu",
-  "futureWmultiParams": "my-app-539-gJ",
+  "UsedClassName": "my-app-194-ZL",
+  "VARS": "--my-app-235-I0 my-app-235-XE undefined my-app-235-wt",
+  "animation": "my-app-235-lY",
+  "animationName": "my-app-235-iZ",
+  "class": "my-app-235-zg",
+  "classInContainer": "my-app-235-bK",
+  "classLocalScope": "my-app-235-Ci",
+  "cssModuleWithCustomFileExtension": "my-app-666-k",
+  "currentWmultiParams": "my-app-235-Hq",
+  "deepClassInContainer": "my-app-235-Y1",
+  "displayFlexInSupportsInMediaUpperCase": "my-app-235-ij",
+  "futureWmultiParams": "my-app-235-Hb",
   "global": undefined,
-  "hasWmultiParams": "my-app-539-kf",
-  "ident": "my-app-539-AB",
-  "inLocalGlobalScope": "my-app-539-_y",
-  "inSupportScope": "my-app-539-y_",
-  "isWmultiParams": "my-app-539-yK",
-  "keyframes": "my-app-539-Yf",
-  "keyframesUPPERCASE": "my-app-539-ec",
-  "local": "my-app-539-ry my-app-539-kW my-app-539-rZ my-app-539-yg",
-  "local2": "my-app-539-rE my-app-539-k2",
-  "localkeyframes2UPPPERCASE": "my-app-539-mQ",
-  "matchesWmultiParams": "my-app-539-r8",
-  "media": "my-app-539-qi",
-  "mediaInSupports": "my-app-539-s9",
-  "mediaWithOperator": "my-app-539-mI",
-  "mozAnimationName": "my-app-539-kl",
-  "mozAnyWmultiParams": "my-app-539-ol",
-  "myColor": "--my-app-539-iI",
-  "nested": "my-app-539-KY undefined my-app-539-c7",
+  "hasWmultiParams": "my-app-235-AO",
+  "ident": "my-app-235-bD",
+  "inLocalGlobalScope": "my-app-235-V0",
+  "inSupportScope": "my-app-235-nc",
+  "isWmultiParams": "my-app-235-aq",
+  "keyframes": "my-app-235-$t",
+  "keyframesUPPERCASE": "my-app-235-zG",
+  "local": "my-app-235-Hi my-app-235-OB my-app-235-VE my-app-235-O2",
+  "local2": "my-app-235-Vj my-app-235-OH",
+  "localkeyframes2UPPPERCASE": "my-app-235-Dk",
+  "matchesWmultiParams": "my-app-235-VN",
+  "media": "my-app-235-a7",
+  "mediaInSupports": "my-app-235-aY",
+  "mediaWithOperator": "my-app-235-uf",
+  "mozAnimationName": "my-app-235-M6",
+  "mozAnyWmultiParams": "my-app-235-OP",
+  "myColor": "--my-app-235-rX",
+  "nested": "my-app-235-nb undefined my-app-235-$Q",
   "notAValidCssModuleExtension": true,
-  "notWmultiParams": "my-app-539-do",
-  "paddingLg": "my-app-539-sr",
-  "paddingSm": "my-app-539-Cg",
-  "pastWmultiParams": "my-app-539-mA",
-  "supports": "my-app-539-OQ",
-  "supportsInMedia": "my-app-539-I$",
-  "supportsWithOperator": "my-app-539-AZ",
-  "vars": "--my-app-539-S4 my-app-539-ag undefined my-app-539-WW",
-  "webkitAnyWmultiParams": "my-app-539-sZ",
-  "whereWmultiParams": "my-app-539-ui",
+  "notWmultiParams": "my-app-235-H5",
+  "paddingLg": "my-app-235-cD",
+  "paddingSm": "my-app-235-dW",
+  "pastWmultiParams": "my-app-235-O4",
+  "supports": "my-app-235-sW",
+  "supportsInMedia": "my-app-235-II",
+  "supportsWithOperator": "my-app-235-TZ",
+  "vars": "--my-app-235-uz my-app-235-f undefined my-app-235-aK",
+  "webkitAnyWmultiParams": "my-app-235-Hw",
+  "whereWmultiParams": "my-app-235-VM",
 }
 `;
 
 exports[`ConfigTestCases css css-modules-in-node exported tests should allow to create css modules: prod 2`] = `
 Object {
-  "UsedClassName": "my-app-816-sZ",
-  "VARS": "--my-app-539-KA my-app-539-YL undefined my-app-539-ak",
-  "animation": "my-app-539-OH",
-  "animationName": "my-app-539-es",
-  "class": "my-app-539-SM",
-  "classInContainer": "my-app-539-SU",
-  "classLocalScope": "my-app-539-sX",
-  "cssModuleWithCustomFileExtension": "my-app-248-u",
-  "currentWmultiParams": "my-app-539-eY",
-  "deepClassInContainer": "my-app-539-ay",
-  "displayFlexInSupportsInMediaUpperCase": "my-app-539-Wu",
-  "futureWmultiParams": "my-app-539-gJ",
+  "UsedClassName": "my-app-194-ZL",
+  "VARS": "--my-app-235-I0 my-app-235-XE undefined my-app-235-wt",
+  "animation": "my-app-235-lY",
+  "animationName": "my-app-235-iZ",
+  "class": "my-app-235-zg",
+  "classInContainer": "my-app-235-bK",
+  "classLocalScope": "my-app-235-Ci",
+  "cssModuleWithCustomFileExtension": "my-app-666-k",
+  "currentWmultiParams": "my-app-235-Hq",
+  "deepClassInContainer": "my-app-235-Y1",
+  "displayFlexInSupportsInMediaUpperCase": "my-app-235-ij",
+  "futureWmultiParams": "my-app-235-Hb",
   "global": undefined,
-  "hasWmultiParams": "my-app-539-kf",
-  "ident": "my-app-539-AB",
-  "inLocalGlobalScope": "my-app-539-_y",
-  "inSupportScope": "my-app-539-y_",
-  "isWmultiParams": "my-app-539-yK",
-  "keyframes": "my-app-539-Yf",
-  "keyframesUPPERCASE": "my-app-539-ec",
-  "local": "my-app-539-ry my-app-539-kW my-app-539-rZ my-app-539-yg",
-  "local2": "my-app-539-rE my-app-539-k2",
-  "localkeyframes2UPPPERCASE": "my-app-539-mQ",
-  "matchesWmultiParams": "my-app-539-r8",
-  "media": "my-app-539-qi",
-  "mediaInSupports": "my-app-539-s9",
-  "mediaWithOperator": "my-app-539-mI",
-  "mozAnimationName": "my-app-539-kl",
-  "mozAnyWmultiParams": "my-app-539-ol",
-  "myColor": "--my-app-539-iI",
-  "nested": "my-app-539-KY undefined my-app-539-c7",
+  "hasWmultiParams": "my-app-235-AO",
+  "ident": "my-app-235-bD",
+  "inLocalGlobalScope": "my-app-235-V0",
+  "inSupportScope": "my-app-235-nc",
+  "isWmultiParams": "my-app-235-aq",
+  "keyframes": "my-app-235-$t",
+  "keyframesUPPERCASE": "my-app-235-zG",
+  "local": "my-app-235-Hi my-app-235-OB my-app-235-VE my-app-235-O2",
+  "local2": "my-app-235-Vj my-app-235-OH",
+  "localkeyframes2UPPPERCASE": "my-app-235-Dk",
+  "matchesWmultiParams": "my-app-235-VN",
+  "media": "my-app-235-a7",
+  "mediaInSupports": "my-app-235-aY",
+  "mediaWithOperator": "my-app-235-uf",
+  "mozAnimationName": "my-app-235-M6",
+  "mozAnyWmultiParams": "my-app-235-OP",
+  "myColor": "--my-app-235-rX",
+  "nested": "my-app-235-nb undefined my-app-235-$Q",
   "notAValidCssModuleExtension": true,
-  "notWmultiParams": "my-app-539-do",
-  "paddingLg": "my-app-539-sr",
-  "paddingSm": "my-app-539-Cg",
-  "pastWmultiParams": "my-app-539-mA",
-  "supports": "my-app-539-OQ",
-  "supportsInMedia": "my-app-539-I$",
-  "supportsWithOperator": "my-app-539-AZ",
-  "vars": "--my-app-539-S4 my-app-539-ag undefined my-app-539-WW",
-  "webkitAnyWmultiParams": "my-app-539-sZ",
-  "whereWmultiParams": "my-app-539-ui",
+  "notWmultiParams": "my-app-235-H5",
+  "paddingLg": "my-app-235-cD",
+  "paddingSm": "my-app-235-dW",
+  "pastWmultiParams": "my-app-235-O4",
+  "supports": "my-app-235-sW",
+  "supportsInMedia": "my-app-235-II",
+  "supportsWithOperator": "my-app-235-TZ",
+  "vars": "--my-app-235-uz my-app-235-f undefined my-app-235-aK",
+  "webkitAnyWmultiParams": "my-app-235-Hw",
+  "whereWmultiParams": "my-app-235-VM",
 }
 `;
 
 exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: class-dev 1`] = `"./style.module.css-class"`;
 
-exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: class-prod 1`] = `"my-app-539-SM"`;
+exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: class-prod 1`] = `"my-app-235-zg"`;
 
-exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: class-prod 2`] = `"my-app-539-SM"`;
+exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: class-prod 2`] = `"my-app-235-zg"`;
 
 exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local1-dev 1`] = `"./style.module.css-local1"`;
 
-exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local1-prod 1`] = `"my-app-539-ry"`;
+exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local1-prod 1`] = `"my-app-235-Hi"`;
 
-exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local1-prod 2`] = `"my-app-539-ry"`;
+exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local1-prod 2`] = `"my-app-235-Hi"`;
 
 exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local2-dev 1`] = `"./style.module.css-local2"`;
 
-exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local2-prod 1`] = `"my-app-539-kW"`;
+exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local2-prod 1`] = `"my-app-235-OB"`;
 
-exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local2-prod 2`] = `"my-app-539-kW"`;
+exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local2-prod 2`] = `"my-app-235-OB"`;
 
 exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local3-dev 1`] = `"./style.module.css-local3"`;
 
-exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local3-prod 1`] = `"my-app-539-rZ"`;
+exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local3-prod 1`] = `"my-app-235-VE"`;
 
-exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local3-prod 2`] = `"my-app-539-rZ"`;
+exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local3-prod 2`] = `"my-app-235-VE"`;
 
 exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local4-dev 1`] = `"./style.module.css-local4"`;
 
-exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local4-prod 1`] = `"my-app-539-yg"`;
+exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local4-prod 1`] = `"my-app-235-O2"`;
 
-exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local4-prod 2`] = `"my-app-539-yg"`;
+exports[`ConfigTestCases css css-modules-in-node exported tests should allow to import css modules: local4-prod 2`] = `"my-app-235-O2"`;
 
 exports[`ConfigTestCases css large exported tests should allow to create css modules: dev 1`] = `
 Object {
@@ -2831,7 +2831,7 @@ Object {
 
 exports[`ConfigTestCases css large exported tests should allow to create css modules: prod 1`] = `
 Object {
-  "placeholder": "512-UB7V",
+  "placeholder": "144-Oh6j",
 }
 `;
 
@@ -3788,27 +3788,27 @@ exports[`ConfigTestCases records issue-2991 exported tests should write relative
 "{
   \\"chunks\\": {
     \\"byName\\": {
-      \\"main\\": 590
+      \\"main\\": 792
     },
     \\"bySource\\": {
-      \\"0 main\\": 590
+      \\"0 main\\": 792
     },
     \\"usedIds\\": [
-      590
+      792
     ]
   },
   \\"modules\\": {
     \\"byIdentifier\\": {
-      \\"./test.js\\": 844,
-      \\"external node-commonjs \\\\\\"fs\\\\\\"\\": 58,
-      \\"external node-commonjs \\\\\\"path\\\\\\"\\": 72,
-      \\"ignored|./.|pkgs/somepackage/foo\\": 128
+      \\"./test.js\\": 329,
+      \\"external node-commonjs \\\\\\"fs\\\\\\"\\": 896,
+      \\"external node-commonjs \\\\\\"path\\\\\\"\\": 928,
+      \\"ignored|./.|pkgs/somepackage/foo\\": 835
     },
     \\"usedIds\\": [
-      58,
-      72,
-      128,
-      844
+      329,
+      835,
+      896,
+      928
     ]
   }
 }"
@@ -3818,31 +3818,31 @@ exports[`ConfigTestCases records issue-7339 exported tests should write relative
 "{
   \\"chunks\\": {
     \\"byName\\": {
-      \\"main\\": 590
+      \\"main\\": 792
     },
     \\"bySource\\": {
-      \\"0 main\\": 590
+      \\"0 main\\": 792
     },
     \\"usedIds\\": [
-      590
+      792
     ]
   },
   \\"modules\\": {
     \\"byIdentifier\\": {
-      \\"./dependencies/bar.js\\": 664,
-      \\"./dependencies/foo.js\\": 396,
-      \\"./dependencies|sync|/^\\\\\\\\.\\\\\\\\/.*$/\\": 660,
-      \\"./test.js\\": 844,
-      \\"external node-commonjs \\\\\\"fs\\\\\\"\\": 58,
-      \\"external node-commonjs \\\\\\"path\\\\\\"\\": 72
+      \\"./dependencies/bar.js\\": 666,
+      \\"./dependencies/foo.js\\": 147,
+      \\"./dependencies|sync|/^\\\\\\\\.\\\\\\\\/.*$/\\": 239,
+      \\"./test.js\\": 329,
+      \\"external node-commonjs \\\\\\"fs\\\\\\"\\": 896,
+      \\"external node-commonjs \\\\\\"path\\\\\\"\\": 928
     },
     \\"usedIds\\": [
-      58,
-      72,
-      396,
-      660,
-      664,
-      844
+      147,
+      239,
+      329,
+      666,
+      896,
+      928
     ]
   }
 }"

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -3,54 +3,54 @@
 exports[`StatsTestCases should print correct stats for aggressive-splitting-entry 1`] = `
 "fitting:
   PublicPath: auto
-  asset fitting-3b78c68321bf412aed86.js 16.1 KiB [emitted] [immutable]
-  asset fitting-1bdd45b6b0cd79821d9f.js 1.9 KiB [emitted] [immutable]
-  asset fitting-a683ff01042aa0fe4264.js 1.9 KiB [emitted] [immutable]
-  asset fitting-92c9ac7e1bce8bcb0401.js 1.08 KiB [emitted] [immutable]
-  Entrypoint main 20 KiB = fitting-a683ff01042aa0fe4264.js 1.9 KiB fitting-1bdd45b6b0cd79821d9f.js 1.9 KiB fitting-3b78c68321bf412aed86.js 16.1 KiB
-  chunk (runtime: main) fitting-3b78c68321bf412aed86.js 1.87 KiB (javascript) 8.67 KiB (runtime) [entry] [rendered]
+  asset fitting-88c67e9a622643e4602f.js 16.2 KiB [emitted] [immutable]
+  asset fitting-52d3948410d6d699beab.js 1.9 KiB [emitted] [immutable]
+  asset fitting-e8b3e5c8abf4f4ba97f4.js 1.9 KiB [emitted] [immutable]
+  asset fitting-afff25c30483e7bf86fd.js 1.08 KiB [emitted] [immutable]
+  Entrypoint main 20 KiB = fitting-e8b3e5c8abf4f4ba97f4.js 1.9 KiB fitting-52d3948410d6d699beab.js 1.9 KiB fitting-88c67e9a622643e4602f.js 16.2 KiB
+  chunk (runtime: main) fitting-e8b3e5c8abf4f4ba97f4.js 1.76 KiB [initial] [rendered] [recorded] aggressive splitted
+    > ./index main
+    ./a.js 899 bytes [built] [code generated]
+    ./b.js 899 bytes [built] [code generated]
+  chunk (runtime: main) fitting-88c67e9a622643e4602f.js 1.87 KiB (javascript) 8.67 KiB (runtime) [entry] [rendered]
     > ./index main
     runtime modules 8.67 KiB 11 modules
     cacheable modules 1.87 KiB
       ./e.js 899 bytes [dependent] [built] [code generated]
       ./f.js 900 bytes [dependent] [built] [code generated]
       ./index.js 111 bytes [built] [code generated]
-  chunk (runtime: main) fitting-a683ff01042aa0fe4264.js 1.76 KiB [initial] [rendered] [recorded] aggressive splitted
-    > ./index main
-    ./a.js 899 bytes [built] [code generated]
-    ./b.js 899 bytes [built] [code generated]
-  chunk (runtime: main) fitting-1bdd45b6b0cd79821d9f.js 1.76 KiB [initial] [rendered] [recorded] aggressive splitted
+  chunk (runtime: main) fitting-52d3948410d6d699beab.js 1.76 KiB [initial] [rendered] [recorded] aggressive splitted
     > ./index main
     ./c.js 899 bytes [built] [code generated]
     ./d.js 899 bytes [built] [code generated]
-  chunk (runtime: main) fitting-92c9ac7e1bce8bcb0401.js 916 bytes [rendered]
+  chunk (runtime: main) fitting-afff25c30483e7bf86fd.js 916 bytes [rendered]
     > ./g ./index.js 7:0-13
     ./g.js 916 bytes [built] [code generated]
   fitting (webpack x.x.x) compiled successfully in X ms
 
 content-change:
   PublicPath: auto
-  asset content-change-f6f257a792b670897d94.js 16.2 KiB [emitted] [immutable]
-  asset content-change-1bdd45b6b0cd79821d9f.js 1.9 KiB [emitted] [immutable]
-  asset content-change-a683ff01042aa0fe4264.js 1.9 KiB [emitted] [immutable]
-  asset content-change-92c9ac7e1bce8bcb0401.js 1.08 KiB [emitted] [immutable]
-  Entrypoint main 20 KiB = content-change-a683ff01042aa0fe4264.js 1.9 KiB content-change-1bdd45b6b0cd79821d9f.js 1.9 KiB content-change-f6f257a792b670897d94.js 16.2 KiB
-  chunk (runtime: main) content-change-f6f257a792b670897d94.js 1.87 KiB (javascript) 8.68 KiB (runtime) [entry] [rendered]
+  asset content-change-03bd4a715d93f7c15570.js 16.2 KiB [emitted] [immutable]
+  asset content-change-52d3948410d6d699beab.js 1.9 KiB [emitted] [immutable]
+  asset content-change-e8b3e5c8abf4f4ba97f4.js 1.9 KiB [emitted] [immutable]
+  asset content-change-afff25c30483e7bf86fd.js 1.08 KiB [emitted] [immutable]
+  Entrypoint main 20 KiB = content-change-e8b3e5c8abf4f4ba97f4.js 1.9 KiB content-change-52d3948410d6d699beab.js 1.9 KiB content-change-03bd4a715d93f7c15570.js 16.2 KiB
+  chunk (runtime: main) content-change-e8b3e5c8abf4f4ba97f4.js 1.76 KiB [initial] [rendered] [recorded] aggressive splitted
+    > ./index main
+    ./a.js 899 bytes [built] [code generated]
+    ./b.js 899 bytes [built] [code generated]
+  chunk (runtime: main) content-change-03bd4a715d93f7c15570.js 1.87 KiB (javascript) 8.68 KiB (runtime) [entry] [rendered]
     > ./index main
     runtime modules 8.68 KiB 11 modules
     cacheable modules 1.87 KiB
       ./e.js 899 bytes [dependent] [built] [code generated]
       ./f.js 900 bytes [dependent] [built] [code generated]
       ./index.js 111 bytes [built] [code generated]
-  chunk (runtime: main) content-change-a683ff01042aa0fe4264.js 1.76 KiB [initial] [rendered] [recorded] aggressive splitted
-    > ./index main
-    ./a.js 899 bytes [built] [code generated]
-    ./b.js 899 bytes [built] [code generated]
-  chunk (runtime: main) content-change-1bdd45b6b0cd79821d9f.js 1.76 KiB [initial] [rendered] [recorded] aggressive splitted
+  chunk (runtime: main) content-change-52d3948410d6d699beab.js 1.76 KiB [initial] [rendered] [recorded] aggressive splitted
     > ./index main
     ./c.js 899 bytes [built] [code generated]
     ./d.js 899 bytes [built] [code generated]
-  chunk (runtime: main) content-change-92c9ac7e1bce8bcb0401.js 916 bytes [rendered]
+  chunk (runtime: main) content-change-afff25c30483e7bf86fd.js 916 bytes [rendered]
     > ./g ./index.js 7:0-13
     ./g.js 916 bytes [built] [code generated]
   content-change (webpack x.x.x) compiled successfully in X ms"
@@ -58,68 +58,68 @@ content-change:
 
 exports[`StatsTestCases should print correct stats for aggressive-splitting-on-demand 1`] = `
 "PublicPath: auto
-asset 16ca32384a212bc3b465.js 11.7 KiB [emitted] [immutable] (name: main)
-asset 71ad3f62ab9a64895d10.js 1.91 KiB [emitted] [immutable]
-asset f9e1f6de2d4ac490beb1.js 1.91 KiB [emitted] [immutable]
-asset 6c733908f765f3741821.js 1.9 KiB [emitted] [immutable]
-asset 6134764dd7848a594803.js 1.9 KiB [emitted] [immutable]
-asset 1bdd45b6b0cd79821d9f.js 1.9 KiB [emitted] [immutable]
-asset 8ba565b2a3e2152cd4b5.js 1.9 KiB [emitted] [immutable]
-asset bb51a622bc5553a0c0f2.js 1.9 KiB [emitted] [immutable]
-asset d1cf17096ddb15afa9cb.js 1.9 KiB [emitted] [immutable]
-asset 29dce45a2156f57119f4.js 1010 bytes [emitted] [immutable]
-asset c4d308d93346ba777236.js 1010 bytes [emitted] [immutable]
-asset 335a14a5066e3135ba0f.js 1010 bytes [emitted] [immutable]
-Entrypoint main 11.7 KiB = 16ca32384a212bc3b465.js
-chunk (runtime: main) 6134764dd7848a594803.js 1.76 KiB [rendered] [recorded] aggressive splitted
+asset bf2a1674f4cf7c432d0d.js 11.7 KiB [emitted] [immutable] (name: main)
+asset 4e31ba0003de4d9e6a34.js 1.91 KiB [emitted] [immutable]
+asset 4621a1b3e7e9dee5c95e.js 1.91 KiB [emitted] [immutable]
+asset 36106fe51c66f112bde8.js 1.9 KiB [emitted] [immutable]
+asset 246e7963e7c35857d1f7.js 1.9 KiB [emitted] [immutable]
+asset 0d89cc5975645d61d461.js 1.9 KiB [emitted] [immutable]
+asset 15ed68d6abf60f27b217.js 1.9 KiB [emitted] [immutable]
+asset 52d3948410d6d699beab.js 1.9 KiB [emitted] [immutable]
+asset 79faa36c188f17b70a7d.js 1.9 KiB [emitted] [immutable]
+asset ba4de2cddb85aadda61c.js 1010 bytes [emitted] [immutable]
+asset ccab63c0f89844ec6d75.js 1010 bytes [emitted] [immutable]
+asset d81e08cf64f052c3f6c9.js 1010 bytes [emitted] [immutable]
+Entrypoint main 11.7 KiB = bf2a1674f4cf7c432d0d.js
+chunk (runtime: main) ba4de2cddb85aadda61c.js 899 bytes [rendered]
+  > ./c ./d ./e ./index.js 3:0-30
+  > ./b ./d ./e ./f ./g ./index.js 5:0-44
+  ./e.js 899 bytes [built] [code generated]
+chunk (runtime: main) 0d89cc5975645d61d461.js 1.76 KiB [rendered]
+  > ./b ./c ./index.js 2:0-23
+  ./b.js 899 bytes [built] [code generated]
+  ./c.js 899 bytes [built] [code generated]
+chunk (runtime: main) 52d3948410d6d699beab.js 1.76 KiB [rendered] [recorded] aggressive splitted
+  > ./c ./d ./e ./index.js 3:0-30
+  ./c.js 899 bytes [built] [code generated]
+  ./d.js 899 bytes [built] [code generated]
+chunk (runtime: main) ccab63c0f89844ec6d75.js 899 bytes [rendered]
+  > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
+  ./k.js 899 bytes [built] [code generated]
+chunk (runtime: main) 15ed68d6abf60f27b217.js 1.76 KiB [rendered] [recorded] aggressive splitted
+  > ./f ./g ./h ./i ./j ./k ./index.js 4:0-51
+  ./h.js 899 bytes [built] [code generated]
+  ./i.js 899 bytes [built] [code generated]
+chunk (runtime: main) 246e7963e7c35857d1f7.js 1.76 KiB [rendered] [recorded] aggressive splitted
   > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
   ./i.js 899 bytes [built] [code generated]
   ./j.js 901 bytes [built] [code generated]
-chunk (runtime: main) 335a14a5066e3135ba0f.js 899 bytes [rendered]
+chunk (runtime: main) 4e31ba0003de4d9e6a34.js 1.76 KiB [rendered]
+  > ./f ./g ./h ./i ./j ./k ./index.js 4:0-51
+  ./j.js 901 bytes [built] [code generated]
+  ./k.js 899 bytes [built] [code generated]
+chunk (runtime: main) d81e08cf64f052c3f6c9.js 899 bytes [rendered]
   > ./a ./index.js 1:0-16
   ./a.js 899 bytes [built] [code generated]
-chunk (runtime: main) bb51a622bc5553a0c0f2.js 1.76 KiB [rendered] [recorded] aggressive splitted
+chunk (runtime: main) 4621a1b3e7e9dee5c95e.js 1.76 KiB [rendered] [recorded] aggressive splitted
+  > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
+  ./e.js 899 bytes [built] [code generated]
+  ./h.js 899 bytes [built] [code generated]
+chunk (runtime: main) 79faa36c188f17b70a7d.js 1.76 KiB [rendered] [recorded] aggressive splitted
   > ./b ./d ./e ./f ./g ./index.js 5:0-44
   > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
   ./b.js 899 bytes [built] [code generated]
   ./d.js 899 bytes [built] [code generated]
-chunk (runtime: main) 6c733908f765f3741821.js 1.76 KiB [rendered] [recorded] aggressive splitted
+chunk (runtime: main) bf2a1674f4cf7c432d0d.js (main) 248 bytes (javascript) 6.33 KiB (runtime) [entry] [rendered]
+  > ./index main
+  runtime modules 6.33 KiB 7 modules
+  ./index.js 248 bytes [built] [code generated]
+chunk (runtime: main) 36106fe51c66f112bde8.js 1.76 KiB [rendered] [recorded] aggressive splitted
   > ./f ./g ./h ./i ./j ./k ./index.js 4:0-51
   > ./b ./d ./e ./f ./g ./index.js 5:0-44
   > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
   ./f.js 899 bytes [built] [code generated]
   ./g.js 901 bytes [built] [code generated]
-chunk (runtime: main) c4d308d93346ba777236.js 899 bytes [rendered]
-  > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
-  ./k.js 899 bytes [built] [code generated]
-chunk (runtime: main) d1cf17096ddb15afa9cb.js 1.76 KiB [rendered]
-  > ./b ./c ./index.js 2:0-23
-  ./b.js 899 bytes [built] [code generated]
-  ./c.js 899 bytes [built] [code generated]
-chunk (runtime: main) f9e1f6de2d4ac490beb1.js 1.76 KiB [rendered] [recorded] aggressive splitted
-  > ./b ./d ./e ./f ./g ./h ./i ./j ./k ./index.js 6:0-72
-  ./e.js 899 bytes [built] [code generated]
-  ./h.js 899 bytes [built] [code generated]
-chunk (runtime: main) 1bdd45b6b0cd79821d9f.js 1.76 KiB [rendered] [recorded] aggressive splitted
-  > ./c ./d ./e ./index.js 3:0-30
-  ./c.js 899 bytes [built] [code generated]
-  ./d.js 899 bytes [built] [code generated]
-chunk (runtime: main) 16ca32384a212bc3b465.js (main) 248 bytes (javascript) 6.33 KiB (runtime) [entry] [rendered]
-  > ./index main
-  runtime modules 6.33 KiB 7 modules
-  ./index.js 248 bytes [built] [code generated]
-chunk (runtime: main) 71ad3f62ab9a64895d10.js 1.76 KiB [rendered]
-  > ./f ./g ./h ./i ./j ./k ./index.js 4:0-51
-  ./j.js 901 bytes [built] [code generated]
-  ./k.js 899 bytes [built] [code generated]
-chunk (runtime: main) 8ba565b2a3e2152cd4b5.js 1.76 KiB [rendered] [recorded] aggressive splitted
-  > ./f ./g ./h ./i ./j ./k ./index.js 4:0-51
-  ./h.js 899 bytes [built] [code generated]
-  ./i.js 899 bytes [built] [code generated]
-chunk (runtime: main) 29dce45a2156f57119f4.js 899 bytes [rendered]
-  > ./c ./d ./e ./index.js 3:0-30
-  > ./b ./d ./e ./f ./g ./index.js 5:0-44
-  ./e.js 899 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms"
 `;
 
@@ -191,19 +191,19 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for async-commons-chunk 1`] = `
-"chunk (runtime: main) 80.js 21 bytes <{590}> ={636}= ={720}= [rendered] reused as split chunk (cache group: default)
+"chunk (runtime: main) 670.js 21 bytes <{792}> ={899}= ={964}= [rendered] reused as split chunk (cache group: default)
   > ./index.js 17:1-21:3
   > ./index.js 2:1-5:3
   > ./a ./b ./index.js 9:1-13:3
   ./a.js 21 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 515 bytes (javascript) 6.02 KiB (runtime) >{80}< >{636}< >{720}< [entry] [rendered]
+chunk (runtime: main) main.js (main) 515 bytes (javascript) 6.02 KiB (runtime) >{670}< >{899}< >{964}< [entry] [rendered]
   > ./ main
   runtime modules 6.02 KiB 7 modules
   ./index.js 515 bytes [built] [code generated]
-chunk (runtime: main) 636.js 21 bytes <{590}> ={80}= [rendered]
+chunk (runtime: main) 899.js 21 bytes <{792}> ={670}= [rendered]
   > ./a ./b ./index.js 9:1-13:3
   ./b.js 21 bytes [built] [code generated]
-chunk (runtime: main) 720.js 21 bytes <{590}> ={80}= [rendered]
+chunk (runtime: main) 964.js 21 bytes <{792}> ={670}= [rendered]
   > ./index.js 17:1-21:3
   ./c.js 21 bytes [built] [code generated]
 webpack x.x.x compiled successfully"
@@ -215,32 +215,32 @@ exports[`StatsTestCases should print correct stats for async-commons-chunk-auto 
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: c) disabled/c.js (c) 196 bytes (javascript) 396 bytes (runtime) [entry] [rendered]
-    > ./c c
-    dependent modules 60 bytes [dependent] 3 modules
-    runtime modules 396 bytes 2 modules
-    ./c.js + 1 modules 136 bytes [built] [code generated]
   chunk (runtime: main) disabled/async-b.js (async-b) 196 bytes [rendered]
     > ./b ./index.js 2:0-47
     dependent modules 80 bytes [dependent] 4 modules
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) disabled/async-c.js (async-c) 196 bytes [rendered]
-    > ./c ./index.js 3:0-47
-    dependent modules 60 bytes [dependent] 3 modules
-    ./c.js + 1 modules 136 bytes [built] [code generated]
-  chunk (runtime: main) disabled/async-a.js (async-a) 245 bytes [rendered]
-    > ./a ./index.js 1:0-47
-    dependent modules 60 bytes [dependent] 3 modules
-    ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: b) disabled/b.js (b) 196 bytes (javascript) 396 bytes (runtime) [entry] [rendered]
     > ./b b
     dependent modules 80 bytes [dependent] 4 modules
     runtime modules 396 bytes 2 modules
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) disabled/main.js (main) 147 bytes (javascript) 6.67 KiB (runtime) [entry] [rendered]
+  chunk (runtime: main) disabled/async-a.js (async-a) 245 bytes [rendered]
+    > ./a ./index.js 1:0-47
+    dependent modules 60 bytes [dependent] 3 modules
+    ./a.js + 1 modules 185 bytes [built] [code generated]
+  chunk (runtime: c) disabled/c.js (c) 196 bytes (javascript) 396 bytes (runtime) [entry] [rendered]
+    > ./c c
+    dependent modules 60 bytes [dependent] 3 modules
+    runtime modules 396 bytes 2 modules
+    ./c.js + 1 modules 136 bytes [built] [code generated]
+  chunk (runtime: main) disabled/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) [entry] [rendered]
     > ./ main
-    runtime modules 6.67 KiB 9 modules
+    runtime modules 6.66 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
+  chunk (runtime: main) disabled/async-c.js (async-c) 196 bytes [rendered]
+    > ./c ./index.js 3:0-47
+    dependent modules 60 bytes [dependent] 3 modules
+    ./c.js + 1 modules 136 bytes [built] [code generated]
   chunk (runtime: a) disabled/a.js (a) 245 bytes (javascript) 6.61 KiB (runtime) [entry] [rendered]
     > ./a a
     runtime modules 6.61 KiB 9 modules
@@ -252,51 +252,51 @@ default:
   chunk (runtime: a, main) default/async-g.js (async-g) 45 bytes [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: a, main) default/144.js 20 bytes [rendered] split chunk (cache group: default)
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
-    > ./g ./a.js 6:0-47
-    ./f.js 20 bytes [built] [code generated]
-  chunk (runtime: c) default/c.js (c) 196 bytes (javascript) 396 bytes (runtime) [entry] [rendered]
-    > ./c c
-    dependent modules 80 bytes [dependent] 4 modules
-    runtime modules 396 bytes 2 modules
-    ./c.js 116 bytes [built] [code generated]
   chunk (runtime: main) default/async-b.js (async-b) 116 bytes [rendered]
     > ./b ./index.js 2:0-47
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) default/async-c.js (async-c) 116 bytes [rendered]
-    > ./c ./index.js 3:0-47
-    ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: main) default/388.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
-    > ./c ./index.js 3:0-47
-    ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: main) default/async-a.js (async-a) 185 bytes [rendered]
-    > ./a ./index.js 1:0-47
-    ./a.js + 1 modules 185 bytes [built] [code generated]
-  chunk (runtime: main) default/472.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
-    ./node_modules/x.js 20 bytes [built] [code generated]
   chunk (runtime: b) default/b.js (b) 196 bytes (javascript) 396 bytes (runtime) [entry] [rendered]
     > ./b b
     dependent modules 80 bytes [dependent] 4 modules
     runtime modules 396 bytes 2 modules
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.68 KiB (runtime) [entry] [rendered]
-    > ./ main
-    runtime modules 6.68 KiB 9 modules
-    ./index.js 147 bytes [built] [code generated]
-  chunk (runtime: main) default/616.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
+  chunk (runtime: main) default/async-a.js (async-a) 185 bytes [rendered]
     > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    ./node_modules/y.js 20 bytes [built] [code generated]
-  chunk (runtime: main) default/744.js 20 bytes [rendered] split chunk (cache group: default)
+    ./a.js + 1 modules 185 bytes [built] [code generated]
+  chunk (runtime: c) default/c.js (c) 196 bytes (javascript) 396 bytes (runtime) [entry] [rendered]
+    > ./c c
+    dependent modules 80 bytes [dependent] 4 modules
+    runtime modules 396 bytes 2 modules
+    ./c.js 116 bytes [built] [code generated]
+  chunk (runtime: main) default/425.js 20 bytes [rendered] split chunk (cache group: default)
     > ./a ./index.js 1:0-47
     > ./b ./index.js 2:0-47
     > ./c ./index.js 3:0-47
     ./d.js 20 bytes [built] [code generated]
+  chunk (runtime: main) default/628.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
+    > ./a ./index.js 1:0-47
+    > ./b ./index.js 2:0-47
+    > ./c ./index.js 3:0-47
+    ./node_modules/x.js 20 bytes [built] [code generated]
+  chunk (runtime: main) default/723.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
+    > ./a ./index.js 1:0-47
+    > ./b ./index.js 2:0-47
+    ./node_modules/y.js 20 bytes [built] [code generated]
+  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.68 KiB (runtime) [entry] [rendered]
+    > ./ main
+    runtime modules 6.68 KiB 9 modules
+    ./index.js 147 bytes [built] [code generated]
+  chunk (runtime: main) default/862.js (id hint: vendors) 20 bytes [rendered] split chunk (cache group: defaultVendors)
+    > ./c ./index.js 3:0-47
+    ./node_modules/z.js 20 bytes [built] [code generated]
+  chunk (runtime: main) default/async-c.js (async-c) 116 bytes [rendered]
+    > ./c ./index.js 3:0-47
+    ./c.js 116 bytes [built] [code generated]
+  chunk (runtime: a, main) default/935.js 20 bytes [rendered] split chunk (cache group: default)
+    > ./b ./index.js 2:0-47
+    > ./c ./index.js 3:0-47
+    > ./g ./a.js 6:0-47
+    ./f.js 20 bytes [built] [code generated]
   chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.67 KiB (runtime) [entry] [rendered]
     > ./a a
     runtime modules 6.67 KiB 9 modules
@@ -313,11 +313,6 @@ vendors:
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: c) vendors/c.js (c) 156 bytes (javascript) 2.75 KiB (runtime) [entry] [rendered]
-    > ./c c
-    runtime modules 2.75 KiB 4 modules
-    dependent modules 40 bytes [dependent] 2 modules
-    ./c.js 116 bytes [built] [code generated]
   chunk (runtime: main) vendors/async-b.js (async-b) 196 bytes [rendered]
     > ./b ./index.js 2:0-47
     dependent modules 80 bytes [dependent] 4 modules
@@ -329,23 +324,28 @@ vendors:
     ./node_modules/x.js 20 bytes [built] [code generated]
     ./node_modules/y.js 20 bytes [built] [code generated]
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: main) vendors/async-c.js (async-c) 196 bytes [rendered]
-    > ./c ./index.js 3:0-47
-    dependent modules 80 bytes [dependent] 4 modules
-    ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: main) vendors/async-a.js (async-a) 245 bytes [rendered]
-    > ./a ./index.js 1:0-47
-    dependent modules 60 bytes [dependent] 3 modules
-    ./a.js + 1 modules 185 bytes [built] [code generated]
   chunk (runtime: b) vendors/b.js (b) 156 bytes (javascript) 2.75 KiB (runtime) [entry] [rendered]
     > ./b b
     runtime modules 2.75 KiB 4 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./b.js 116 bytes [built] [code generated]
+  chunk (runtime: main) vendors/async-a.js (async-a) 245 bytes [rendered]
+    > ./a ./index.js 1:0-47
+    dependent modules 60 bytes [dependent] 3 modules
+    ./a.js + 1 modules 185 bytes [built] [code generated]
+  chunk (runtime: c) vendors/c.js (c) 156 bytes (javascript) 2.75 KiB (runtime) [entry] [rendered]
+    > ./c c
+    runtime modules 2.75 KiB 4 modules
+    dependent modules 40 bytes [dependent] 2 modules
+    ./c.js 116 bytes [built] [code generated]
   chunk (runtime: main) vendors/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) [entry] [rendered]
     > ./ main
     runtime modules 6.66 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
+  chunk (runtime: main) vendors/async-c.js (async-c) 196 bytes [rendered]
+    > ./c ./index.js 3:0-47
+    dependent modules 80 bytes [dependent] 4 modules
+    ./c.js 116 bytes [built] [code generated]
   chunk (runtime: a) vendors/a.js (a) 205 bytes (javascript) 7.55 KiB (runtime) [entry] [rendered]
     > ./a a
     runtime modules 7.55 KiB 10 modules
@@ -355,62 +355,30 @@ vendors:
 
 multiple-vendors:
   Entrypoint main 11.5 KiB = multiple-vendors/main.js
-  Entrypoint a 15 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/616.js 412 bytes multiple-vendors/744.js 412 bytes multiple-vendors/928.js 412 bytes multiple-vendors/a.js 13.4 KiB
-  Entrypoint b 8.13 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/616.js 412 bytes multiple-vendors/744.js 412 bytes multiple-vendors/144.js 412 bytes multiple-vendors/b.js 6.52 KiB
-  Entrypoint c 8.13 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/388.js 412 bytes multiple-vendors/744.js 412 bytes multiple-vendors/144.js 412 bytes multiple-vendors/c.js 6.52 KiB
+  Entrypoint a 15 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/723.js 412 bytes multiple-vendors/425.js 412 bytes multiple-vendors/210.js 412 bytes multiple-vendors/a.js 13.4 KiB
+  Entrypoint b 8.13 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/723.js 412 bytes multiple-vendors/425.js 412 bytes multiple-vendors/935.js 412 bytes multiple-vendors/b.js 6.52 KiB
+  Entrypoint c 8.13 KiB = multiple-vendors/libs-x.js 412 bytes multiple-vendors/862.js 412 bytes multiple-vendors/425.js 412 bytes multiple-vendors/935.js 412 bytes multiple-vendors/c.js 6.52 KiB
   chunk (runtime: a, main) multiple-vendors/async-g.js (async-g) 45 bytes [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: a, b, c, main) multiple-vendors/144.js 20 bytes [initial] [rendered] split chunk (cache group: default)
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
-    > ./g ./a.js 6:0-47
-    > ./b b
-    > ./c c
-    ./f.js 20 bytes [built] [code generated]
-  chunk (runtime: c) multiple-vendors/c.js (c) 116 bytes (javascript) 2.76 KiB (runtime) [entry] [rendered]
-    > ./c c
-    runtime modules 2.76 KiB 4 modules
-    ./c.js 116 bytes [built] [code generated]
   chunk (runtime: main) multiple-vendors/async-b.js (async-b) 116 bytes [rendered]
     > ./b ./index.js 2:0-47
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) multiple-vendors/async-c.js (async-c) 116 bytes [rendered]
-    > ./c ./index.js 3:0-47
-    ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: c, main) multiple-vendors/388.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
-    > ./c ./index.js 3:0-47
-    > ./c c
-    ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: main) multiple-vendors/async-a.js (async-a) 165 bytes [rendered]
-    > ./a ./index.js 1:0-47
-    ./a.js 165 bytes [built] [code generated]
   chunk (runtime: b) multiple-vendors/b.js (b) 116 bytes (javascript) 2.76 KiB (runtime) [entry] [rendered]
     > ./b b
     runtime modules 2.76 KiB 4 modules
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) multiple-vendors/main.js (main) 147 bytes (javascript) 6.7 KiB (runtime) [entry] [rendered]
-    > ./ main
-    runtime modules 6.7 KiB 9 modules
-    ./index.js 147 bytes [built] [code generated]
-  chunk (runtime: a, b, main) multiple-vendors/616.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    > ./a a
-    > ./b b
-    ./node_modules/y.js 20 bytes [built] [code generated]
-  chunk (runtime: a, b, c, main) multiple-vendors/744.js 20 bytes [initial] [rendered] split chunk (cache group: default)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
-    > ./a a
-    > ./b b
-    > ./c c
-    ./d.js 20 bytes [built] [code generated]
-  chunk (runtime: a, main) multiple-vendors/928.js 20 bytes [initial] [rendered] split chunk (cache group: default)
+  chunk (runtime: a, main) multiple-vendors/210.js 20 bytes [initial] [rendered] split chunk (cache group: default)
     > ./a ./index.js 1:0-47
     > ./a a
     ./e.js 20 bytes [built] [code generated]
+  chunk (runtime: main) multiple-vendors/async-a.js (async-a) 165 bytes [rendered]
+    > ./a ./index.js 1:0-47
+    ./a.js 165 bytes [built] [code generated]
+  chunk (runtime: c) multiple-vendors/c.js (c) 116 bytes (javascript) 2.76 KiB (runtime) [entry] [rendered]
+    > ./c c
+    runtime modules 2.76 KiB 4 modules
+    ./c.js 116 bytes [built] [code generated]
   chunk (runtime: a, b, c, main) multiple-vendors/libs-x.js (libs-x) (id hint: libs) 20 bytes [initial] [rendered] split chunk (cache group: libs) (name: libs-x)
     > ./a ./index.js 1:0-47
     > ./b ./index.js 2:0-47
@@ -419,6 +387,38 @@ multiple-vendors:
     > ./b b
     > ./c c
     ./node_modules/x.js 20 bytes [built] [code generated]
+  chunk (runtime: a, b, c, main) multiple-vendors/425.js 20 bytes [initial] [rendered] split chunk (cache group: default)
+    > ./a ./index.js 1:0-47
+    > ./b ./index.js 2:0-47
+    > ./c ./index.js 3:0-47
+    > ./a a
+    > ./b b
+    > ./c c
+    ./d.js 20 bytes [built] [code generated]
+  chunk (runtime: a, b, main) multiple-vendors/723.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
+    > ./a ./index.js 1:0-47
+    > ./b ./index.js 2:0-47
+    > ./a a
+    > ./b b
+    ./node_modules/y.js 20 bytes [built] [code generated]
+  chunk (runtime: main) multiple-vendors/main.js (main) 147 bytes (javascript) 6.7 KiB (runtime) [entry] [rendered]
+    > ./ main
+    runtime modules 6.7 KiB 9 modules
+    ./index.js 147 bytes [built] [code generated]
+  chunk (runtime: c, main) multiple-vendors/862.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
+    > ./c ./index.js 3:0-47
+    > ./c c
+    ./node_modules/z.js 20 bytes [built] [code generated]
+  chunk (runtime: main) multiple-vendors/async-c.js (async-c) 116 bytes [rendered]
+    > ./c ./index.js 3:0-47
+    ./c.js 116 bytes [built] [code generated]
+  chunk (runtime: a, b, c, main) multiple-vendors/935.js 20 bytes [initial] [rendered] split chunk (cache group: default)
+    > ./b ./index.js 2:0-47
+    > ./c ./index.js 3:0-47
+    > ./g ./a.js 6:0-47
+    > ./b b
+    > ./c c
+    ./f.js 20 bytes [built] [code generated]
   chunk (runtime: a) multiple-vendors/a.js (a) 165 bytes (javascript) 7.6 KiB (runtime) [entry] [rendered]
     > ./a a
     runtime modules 7.6 KiB 10 modules
@@ -427,59 +427,31 @@ multiple-vendors:
 
 all:
   Entrypoint main 11.5 KiB = all/main.js
-  Entrypoint a 15 KiB = all/472.js 412 bytes all/616.js 412 bytes all/744.js 412 bytes all/928.js 412 bytes all/a.js 13.4 KiB
-  Entrypoint b 8.13 KiB = all/472.js 412 bytes all/616.js 412 bytes all/744.js 412 bytes all/144.js 412 bytes all/b.js 6.52 KiB
-  Entrypoint c 8.13 KiB = all/472.js 412 bytes all/388.js 412 bytes all/744.js 412 bytes all/144.js 412 bytes all/c.js 6.52 KiB
+  Entrypoint a 15 KiB = all/628.js 412 bytes all/723.js 412 bytes all/425.js 412 bytes all/210.js 412 bytes all/a.js 13.4 KiB
+  Entrypoint b 8.13 KiB = all/628.js 412 bytes all/723.js 412 bytes all/425.js 412 bytes all/935.js 412 bytes all/b.js 6.52 KiB
+  Entrypoint c 8.13 KiB = all/628.js 412 bytes all/862.js 412 bytes all/425.js 412 bytes all/935.js 412 bytes all/c.js 6.52 KiB
   chunk (runtime: a, main) all/async-g.js (async-g) 45 bytes [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: a, b, c, main) all/144.js 20 bytes [initial] [rendered] split chunk (cache group: default)
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
-    > ./g ./a.js 6:0-47
-    > ./b b
-    > ./c c
-    ./f.js 20 bytes [built] [code generated]
-  chunk (runtime: c) all/c.js (c) 116 bytes (javascript) 2.76 KiB (runtime) [entry] [rendered]
-    > ./c c
-    runtime modules 2.76 KiB 4 modules
-    ./c.js 116 bytes [built] [code generated]
   chunk (runtime: main) all/async-b.js (async-b) 116 bytes [rendered]
     > ./b ./index.js 2:0-47
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) all/async-c.js (async-c) 116 bytes [rendered]
-    > ./c ./index.js 3:0-47
-    ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: c, main) all/388.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
-    > ./c ./index.js 3:0-47
-    > ./c c
-    ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: main) all/async-a.js (async-a) 165 bytes [rendered]
-    > ./a ./index.js 1:0-47
-    ./a.js 165 bytes [built] [code generated]
-  chunk (runtime: a, b, c, main) all/472.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
-    > ./a a
-    > ./b b
-    > ./c c
-    ./node_modules/x.js 20 bytes [built] [code generated]
   chunk (runtime: b) all/b.js (b) 116 bytes (javascript) 2.76 KiB (runtime) [entry] [rendered]
     > ./b b
     runtime modules 2.76 KiB 4 modules
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) all/main.js (main) 147 bytes (javascript) 6.67 KiB (runtime) [entry] [rendered]
-    > ./ main
-    runtime modules 6.67 KiB 9 modules
-    ./index.js 147 bytes [built] [code generated]
-  chunk (runtime: a, b, main) all/616.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
+  chunk (runtime: a, main) all/210.js 20 bytes [initial] [rendered] split chunk (cache group: default)
     > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
     > ./a a
-    > ./b b
-    ./node_modules/y.js 20 bytes [built] [code generated]
-  chunk (runtime: a, b, c, main) all/744.js 20 bytes [initial] [rendered] split chunk (cache group: default)
+    ./e.js 20 bytes [built] [code generated]
+  chunk (runtime: main) all/async-a.js (async-a) 165 bytes [rendered]
+    > ./a ./index.js 1:0-47
+    ./a.js 165 bytes [built] [code generated]
+  chunk (runtime: c) all/c.js (c) 116 bytes (javascript) 2.76 KiB (runtime) [entry] [rendered]
+    > ./c c
+    runtime modules 2.76 KiB 4 modules
+    ./c.js 116 bytes [built] [code generated]
+  chunk (runtime: a, b, c, main) all/425.js 20 bytes [initial] [rendered] split chunk (cache group: default)
     > ./a ./index.js 1:0-47
     > ./b ./index.js 2:0-47
     > ./c ./index.js 3:0-47
@@ -487,10 +459,38 @@ all:
     > ./b b
     > ./c c
     ./d.js 20 bytes [built] [code generated]
-  chunk (runtime: a, main) all/928.js 20 bytes [initial] [rendered] split chunk (cache group: default)
+  chunk (runtime: a, b, c, main) all/628.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
     > ./a ./index.js 1:0-47
+    > ./b ./index.js 2:0-47
+    > ./c ./index.js 3:0-47
     > ./a a
-    ./e.js 20 bytes [built] [code generated]
+    > ./b b
+    > ./c c
+    ./node_modules/x.js 20 bytes [built] [code generated]
+  chunk (runtime: a, b, main) all/723.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
+    > ./a ./index.js 1:0-47
+    > ./b ./index.js 2:0-47
+    > ./a a
+    > ./b b
+    ./node_modules/y.js 20 bytes [built] [code generated]
+  chunk (runtime: main) all/main.js (main) 147 bytes (javascript) 6.67 KiB (runtime) [entry] [rendered]
+    > ./ main
+    runtime modules 6.67 KiB 9 modules
+    ./index.js 147 bytes [built] [code generated]
+  chunk (runtime: c, main) all/862.js (id hint: vendors) 20 bytes [initial] [rendered] split chunk (cache group: vendors)
+    > ./c ./index.js 3:0-47
+    > ./c c
+    ./node_modules/z.js 20 bytes [built] [code generated]
+  chunk (runtime: main) all/async-c.js (async-c) 116 bytes [rendered]
+    > ./c ./index.js 3:0-47
+    ./c.js 116 bytes [built] [code generated]
+  chunk (runtime: a, b, c, main) all/935.js 20 bytes [initial] [rendered] split chunk (cache group: default)
+    > ./b ./index.js 2:0-47
+    > ./c ./index.js 3:0-47
+    > ./g ./a.js 6:0-47
+    > ./b b
+    > ./c c
+    ./f.js 20 bytes [built] [code generated]
   chunk (runtime: a) all/a.js (a) 165 bytes (javascript) 7.59 KiB (runtime) [entry] [rendered]
     > ./a a
     runtime modules 7.59 KiB 10 modules
@@ -547,10 +547,22 @@ webpack x.x.x compiled successfully in X ms"
 exports[`StatsTestCases should print correct stats for chunks 1`] = `
 "PublicPath: auto
 asset bundle.js 10.3 KiB [emitted] (name: main)
-asset 720.bundle.js 323 bytes [emitted]
-asset 804.bundle.js 206 bytes [emitted]
-asset 636.bundle.js 138 bytes [emitted]
-chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 6.02 KiB (runtime) >{636}< >{720}< [entry] [rendered]
+asset 964.bundle.js 323 bytes [emitted]
+asset 226.bundle.js 206 bytes [emitted]
+asset 899.bundle.js 138 bytes [emitted]
+chunk (runtime: main) 226.bundle.js 44 bytes <{964}> [rendered]
+  > ./c.js 1:0-52
+  ./d.js 22 bytes [built] [code generated]
+    require.ensure item ./d ./c.js 1:0-52
+    cjs self exports reference ./d.js 1:0-14
+    X ms -> X ms ->
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+  ./e.js 22 bytes [built] [code generated]
+    require.ensure item ./e ./c.js 1:0-52
+    cjs self exports reference ./e.js 1:0-14
+    X ms -> X ms ->
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 6.02 KiB (runtime) >{899}< >{964}< [entry] [rendered]
   > ./index main
   runtime modules 6.02 KiB 7 modules
   cacheable modules 73 bytes
@@ -562,30 +574,18 @@ chunk (runtime: main) bundle.js (main) 73 bytes (javascript) 6.02 KiB (runtime) 
     ./index.js 51 bytes [built] [code generated]
       entry ./index main
       X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
-chunk (runtime: main) 636.bundle.js 22 bytes <{590}> [rendered]
+chunk (runtime: main) 899.bundle.js 22 bytes <{792}> [rendered]
   > ./b ./index.js 2:0-16
   ./b.js 22 bytes [built] [code generated]
     cjs self exports reference ./b.js 1:0-14
     amd require ./b ./index.js 2:0-16
     X ms ->
     X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
-chunk (runtime: main) 720.bundle.js 54 bytes <{590}> >{804}< [rendered]
+chunk (runtime: main) 964.bundle.js 54 bytes <{792}> >{226}< [rendered]
   > ./c ./index.js 3:0-16
   ./c.js 54 bytes [built] [code generated]
     amd require ./c ./index.js 3:0-16
     X ms ->
-    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
-chunk (runtime: main) 804.bundle.js 44 bytes <{720}> [rendered]
-  > ./c.js 1:0-52
-  ./d.js 22 bytes [built] [code generated]
-    require.ensure item ./d ./c.js 1:0-52
-    cjs self exports reference ./d.js 1:0-14
-    X ms -> X ms ->
-    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
-  ./e.js 22 bytes [built] [code generated]
-    require.ensure item ./e ./c.js 1:0-52
-    cjs self exports reference ./e.js 1:0-14
-    X ms -> X ms ->
     X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
 webpack x.x.x compiled successfully in X ms"
 `;
@@ -638,14 +638,14 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for circular-correctness 1`] = `
-"chunk (runtime: main) 152.bundle.js (c) 98 bytes <{580}> <{996}> >{580}< >{996}< [rendered]
-  ./module-c.js 98 bytes [built] [code generated]
-chunk (runtime: main) 580.bundle.js (b) 49 bytes <{152}> <{590}> >{152}< [rendered]
+"chunk (runtime: main) 199.bundle.js (b) 49 bytes <{390}> <{792}> >{390}< [rendered]
   ./module-b.js 49 bytes [built] [code generated]
-chunk (runtime: main) bundle.js (main) 98 bytes (javascript) 7.71 KiB (runtime) >{580}< >{996}< [entry] [rendered]
+chunk (runtime: main) 390.bundle.js (c) 98 bytes <{199}> <{996}> >{199}< >{996}< [rendered]
+  ./module-c.js 98 bytes [built] [code generated]
+chunk (runtime: main) bundle.js (main) 98 bytes (javascript) 7.71 KiB (runtime) >{199}< >{996}< [entry] [rendered]
   runtime modules 7.71 KiB 10 modules
   ./index.js 98 bytes [built] [code generated]
-chunk (runtime: main) 996.bundle.js (a) 49 bytes <{152}> <{590}> >{152}< [rendered]
+chunk (runtime: main) 996.bundle.js (a) 49 bytes <{390}> <{792}> >{390}< [rendered]
   ./module-a.js 49 bytes [built] [code generated]
 webpack x.x.x compiled successfully"
 `;
@@ -678,8 +678,8 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for commons-chunk-min-size-0 1`] = `
 "asset entry-1.js 5.7 KiB [emitted] (name: entry-1)
-asset 516.js 273 bytes [emitted] (id hint: vendor-1)
-Entrypoint entry-1 5.96 KiB = 516.js 273 bytes entry-1.js 5.7 KiB
+asset 903.js 273 bytes [emitted] (id hint: vendor-1)
+Entrypoint entry-1 5.97 KiB = 903.js 273 bytes entry-1.js 5.7 KiB
 runtime modules 2.45 KiB 3 modules
 modules by path ./modules/*.js 132 bytes
   ./modules/a.js 22 bytes [built] [code generated]
@@ -695,7 +695,7 @@ webpack x.x.x compiled successfully in X ms"
 exports[`StatsTestCases should print correct stats for commons-chunk-min-size-Infinity 1`] = `
 "asset entry-1.js 5.7 KiB [emitted] (name: entry-1)
 asset vendor-1.js 273 bytes [emitted] (name: vendor-1) (id hint: vendor-1)
-Entrypoint entry-1 5.96 KiB = vendor-1.js 273 bytes entry-1.js 5.7 KiB
+Entrypoint entry-1 5.97 KiB = vendor-1.js 273 bytes entry-1.js 5.7 KiB
 runtime modules 2.45 KiB 3 modules
 modules by path ./modules/*.js 132 bytes
   ./modules/a.js 22 bytes [built] [code generated]
@@ -709,9 +709,9 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for commons-plugin-issue-4980 1`] = `
-"asset app.881ddede50a0f4f1a84d-1.js 6.24 KiB [emitted] [immutable] (name: app)
-asset vendor.42497005e3eb0e0885c6-1.js 611 bytes [emitted] [immutable] (name: vendor) (id hint: vendor)
-Entrypoint app 6.84 KiB = vendor.42497005e3eb0e0885c6-1.js 611 bytes app.881ddede50a0f4f1a84d-1.js 6.24 KiB
+"asset app.48e429216e0893bd9794-1.js 6.24 KiB [emitted] [immutable] (name: app)
+asset vendor.ffd8f46aef708713412d-1.js 611 bytes [emitted] [immutable] (name: vendor) (id hint: vendor)
+Entrypoint app 6.84 KiB = vendor.ffd8f46aef708713412d-1.js 611 bytes app.48e429216e0893bd9794-1.js 6.24 KiB
 runtime modules 2.75 KiB 4 modules
 orphan modules 118 bytes [orphan] 2 modules
 cacheable modules 272 bytes
@@ -719,9 +719,9 @@ cacheable modules 272 bytes
   ./constants.js 87 bytes [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset app.9b0e3b5c1a486885d9e3-2.js 6.25 KiB [emitted] [immutable] (name: app)
-asset vendor.42497005e3eb0e0885c6-2.js 611 bytes [emitted] [immutable] (name: vendor) (id hint: vendor)
-Entrypoint app 6.85 KiB = vendor.42497005e3eb0e0885c6-2.js 611 bytes app.9b0e3b5c1a486885d9e3-2.js 6.25 KiB
+asset app.c3b5c1b67e97388633da-2.js 6.25 KiB [emitted] [immutable] (name: app)
+asset vendor.ffd8f46aef708713412d-2.js 611 bytes [emitted] [immutable] (name: vendor) (id hint: vendor)
+Entrypoint app 6.85 KiB = vendor.ffd8f46aef708713412d-2.js 611 bytes app.c3b5c1b67e97388633da-2.js 6.25 KiB
 runtime modules 2.75 KiB 4 modules
 orphan modules 125 bytes [orphan] 2 modules
 cacheable modules 279 bytes
@@ -751,10 +751,10 @@ exports[`StatsTestCases should print correct stats for concat-and-sideeffects 1`
 `;
 
 exports[`StatsTestCases should print correct stats for context-independence 1`] = `
-"asset main-aad85b6637f75e68879b.js 12.8 KiB [emitted] [immutable] (name: main)
-  sourceMap main-aad85b6637f75e68879b.js.map 11.1 KiB [emitted] [dev] (auxiliary name: main)
-asset 792-7da7e525de513668b46d.js 455 bytes [emitted] [immutable]
-  sourceMap 792-7da7e525de513668b46d.js.map 347 bytes [emitted] [dev]
+"asset main-090b45621f069497c687.js 12.8 KiB [emitted] [immutable] (name: main)
+  sourceMap main-090b45621f069497c687.js.map 11.1 KiB [emitted] [dev] (auxiliary name: main)
+asset 977-227b7a831ee2d3e84c54.js 455 bytes [emitted] [immutable]
+  sourceMap 977-227b7a831ee2d3e84c54.js.map 347 bytes [emitted] [dev]
 runtime modules 6.61 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
@@ -767,10 +767,10 @@ built modules 500 bytes [built]
   ./a/cc/b.js (in my-layer) 18 bytes [optional] [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-aad85b6637f75e68879b.js 12.8 KiB [emitted] [immutable] (name: main)
-  sourceMap main-aad85b6637f75e68879b.js.map 11.1 KiB [emitted] [dev] (auxiliary name: main)
-asset 792-7da7e525de513668b46d.js 455 bytes [emitted] [immutable]
-  sourceMap 792-7da7e525de513668b46d.js.map 347 bytes [emitted] [dev]
+asset main-090b45621f069497c687.js 12.8 KiB [emitted] [immutable] (name: main)
+  sourceMap main-090b45621f069497c687.js.map 11.1 KiB [emitted] [dev] (auxiliary name: main)
+asset 977-227b7a831ee2d3e84c54.js 455 bytes [emitted] [immutable]
+  sourceMap 977-227b7a831ee2d3e84c54.js.map 347 bytes [emitted] [dev]
 runtime modules 6.61 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
@@ -783,8 +783,8 @@ built modules 500 bytes [built]
   ./b/cc/b.js (in my-layer) 18 bytes [optional] [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-d63a8ae46492b244e5ac.js 14.9 KiB [emitted] [immutable] (name: main)
-asset 792-a8053be35470e98e3013.js 1.51 KiB [emitted] [immutable]
+asset main-3e3b19898e20390fe5ef.js 14.9 KiB [emitted] [immutable] (name: main)
+asset 977-6d35f1717980b629b883.js 1.51 KiB [emitted] [immutable]
 runtime modules 6.61 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
@@ -797,8 +797,8 @@ built modules 500 bytes [built]
   ./a/cc/b.js (in my-layer) 18 bytes [optional] [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-d63a8ae46492b244e5ac.js 14.9 KiB [emitted] [immutable] (name: main)
-asset 792-a8053be35470e98e3013.js 1.51 KiB [emitted] [immutable]
+asset main-3e3b19898e20390fe5ef.js 14.9 KiB [emitted] [immutable] (name: main)
+asset 977-6d35f1717980b629b883.js 1.51 KiB [emitted] [immutable]
 runtime modules 6.61 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
@@ -811,8 +811,8 @@ built modules 500 bytes [built]
   ./b/cc/b.js (in my-layer) 18 bytes [optional] [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-0db27f873118aeb76b22.js 13.8 KiB [emitted] [immutable] (name: main)
-asset 792-0ad33733a0e2cc02288f.js 1.01 KiB [emitted] [immutable]
+asset main-5309722c0fef9e0be101.js 13.8 KiB [emitted] [immutable] (name: main)
+asset 977-f918f071346b7b0f2bf2.js 1.01 KiB [emitted] [immutable]
 runtime modules 6.61 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
@@ -825,8 +825,8 @@ built modules 500 bytes [built]
   ./a/cc/b.js (in my-layer) 18 bytes [optional] [built] [code generated]
 webpack x.x.x compiled successfully in X ms
 
-asset main-0db27f873118aeb76b22.js 13.8 KiB [emitted] [immutable] (name: main)
-asset 792-0ad33733a0e2cc02288f.js 1.01 KiB [emitted] [immutable]
+asset main-5309722c0fef9e0be101.js 13.8 KiB [emitted] [immutable] (name: main)
+asset 977-f918f071346b7b0f2bf2.js 1.01 KiB [emitted] [immutable]
 runtime modules 6.61 KiB 9 modules
 orphan modules 19 bytes [orphan] 1 module
 built modules 500 bytes [built]
@@ -841,7 +841,7 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for custom-terser 1`] = `
-"asset bundle.js 584 bytes [emitted] [minimized] (name: main)
+"asset bundle.js 586 bytes [emitted] [minimized] (name: main)
 ./index.js 128 bytes [built] [code generated]
   [no exports used]
 ./a.js 49 bytes [built] [code generated]
@@ -1040,8 +1040,8 @@ webpack x.x.x compiled with 2 errors in X ms"
 
 exports[`StatsTestCases should print correct stats for entry-filename 1`] = `
 "PublicPath: auto
-asset c.js 1.4 KiB [emitted] (name: b)
 asset a.js 1.4 KiB [emitted] (name: a)
+asset c.js 1.4 KiB [emitted] (name: b)
 chunk (runtime: b) c.js (b) 22 bytes [entry] [rendered]
   > ./b.js b
   ./b.js 22 bytes [built] [code generated]
@@ -1181,22 +1181,22 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for graph-correctness-entries 1`] = `
-"chunk (runtime: e2) e2.js (e2) 49 bytes (javascript) 7.73 KiB (runtime) >{152}< [entry] [rendered]
+"chunk (runtime: e2) e2.js (e2) 49 bytes (javascript) 7.73 KiB (runtime) >{390}< [entry] [rendered]
   runtime modules 7.73 KiB 10 modules
   ./e2.js 49 bytes [built] [code generated]
     entry ./e2 e2
-chunk (runtime: e1, e2) c.js (c) 49 bytes <{128}> <{580}> >{996}< [rendered]
-  ./module-c.js 49 bytes [built] [code generated]
-    import() ./module-c ./e2.js 1:0-47
-    import() ./module-c ./module-b.js 1:0-47
+chunk (runtime: e1, e2) b.js (b) 49 bytes <{996}> >{390}< [rendered]
+  ./module-b.js 49 bytes [built] [code generated]
+    import() ./module-b ./module-a.js 1:0-47
 chunk (runtime: e1) e1.js (e1) 49 bytes (javascript) 7.73 KiB (runtime) >{996}< [entry] [rendered]
   runtime modules 7.73 KiB 10 modules
   ./e1.js 49 bytes [built] [code generated]
     entry ./e1 e1
-chunk (runtime: e1, e2) b.js (b) 49 bytes <{996}> >{152}< [rendered]
-  ./module-b.js 49 bytes [built] [code generated]
-    import() ./module-b ./module-a.js 1:0-47
-chunk (runtime: e1, e2) a.js (a) 49 bytes <{152}> <{320}> >{580}< [rendered]
+chunk (runtime: e1, e2) c.js (c) 49 bytes <{130}> <{199}> >{996}< [rendered]
+  ./module-c.js 49 bytes [built] [code generated]
+    import() ./module-c ./e2.js 1:0-47
+    import() ./module-c ./module-b.js 1:0-47
+chunk (runtime: e1, e2) a.js (a) 49 bytes <{321}> <{390}> >{199}< [rendered]
   ./module-a.js 49 bytes [built] [code generated]
     import() ./module-a ./e1.js 1:0-47
     import() ./module-a ./module-c.js 1:0-47
@@ -1204,7 +1204,7 @@ webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for graph-correctness-modules 1`] = `
-"chunk (runtime: e2) e2.js (e2) 119 bytes (javascript) 8 KiB (runtime) >{152}< >{460}< [entry] [rendered]
+"chunk (runtime: e2) e2.js (e2) 119 bytes (javascript) 8 KiB (runtime) >{390}< >{460}< [entry] [rendered]
   runtime modules 8 KiB 11 modules
   cacheable modules 119 bytes
     ./e2.js 70 bytes [built] [code generated]
@@ -1213,10 +1213,9 @@ exports[`StatsTestCases should print correct stats for graph-correctness-modules
       harmony side effect evaluation ./module-x ./e1.js 1:0-20
       harmony side effect evaluation ./module-x ./e2.js 1:0-20
       import() ./module-x ./module-b.js 2:0-20
-chunk (runtime: e1, e2) c.js (c) 49 bytes <{128}> <{580}> >{996}< [rendered]
-  ./module-c.js 49 bytes [built] [code generated]
-    import() ./module-c ./e2.js 2:0-47
-    import() ./module-c ./module-b.js 1:0-47
+chunk (runtime: e1, e2) b.js (b) 179 bytes <{996}> >{390}< [rendered]
+  ./module-b.js 179 bytes [built] [code generated]
+    import() ./module-b ./module-a.js 1:0-47
 chunk (runtime: e1) e1.js (e1) 119 bytes (javascript) 8 KiB (runtime) >{460}< >{996}< [entry] [rendered]
   runtime modules 8 KiB 11 modules
   cacheable modules 119 bytes
@@ -1226,13 +1225,14 @@ chunk (runtime: e1) e1.js (e1) 119 bytes (javascript) 8 KiB (runtime) >{460}< >{
       harmony side effect evaluation ./module-x ./e1.js 1:0-20
       harmony side effect evaluation ./module-x ./e2.js 1:0-20
       import() ./module-x ./module-b.js 2:0-20
-chunk (runtime: e1, e2) y.js (y) 1 bytes <{128}> <{320}> [rendered]
+chunk (runtime: e1, e2) c.js (c) 49 bytes <{130}> <{199}> >{996}< [rendered]
+  ./module-c.js 49 bytes [built] [code generated]
+    import() ./module-c ./e2.js 2:0-47
+    import() ./module-c ./module-b.js 1:0-47
+chunk (runtime: e1, e2) y.js (y) 1 bytes <{130}> <{321}> [rendered]
   ./module-y.js 1 bytes [built] [code generated]
     import() ./module-y ./module-x.js 1:0-47
-chunk (runtime: e1, e2) b.js (b) 179 bytes <{996}> >{152}< [rendered]
-  ./module-b.js 179 bytes [built] [code generated]
-    import() ./module-b ./module-a.js 1:0-47
-chunk (runtime: e1, e2) a.js (a) 49 bytes <{152}> <{320}> >{580}< [rendered]
+chunk (runtime: e1, e2) a.js (a) 49 bytes <{321}> <{390}> >{199}< [rendered]
   ./module-a.js 49 bytes [built] [code generated]
     import() ./module-a ./e1.js 2:0-47
     import() ./module-a ./module-c.js 1:0-47
@@ -1296,9 +1296,9 @@ asset 22c24a3b26d46118dc06.js 809 bytes [emitted] [immutable]"
 
 exports[`StatsTestCases should print correct stats for import-context-filter 1`] = `
 "asset entry.js 12 KiB [emitted] (name: entry)
-asset 576.js 482 bytes [emitted]
-asset 835.js 482 bytes [emitted]
-asset 30.js 480 bytes [emitted]
+asset 717.js 482 bytes [emitted]
+asset 776.js 482 bytes [emitted]
+asset 0.js 475 bytes [emitted]
 runtime modules 6.58 KiB 9 modules
 built modules 724 bytes [built]
   modules by path ./templates/*.js 114 bytes
@@ -1312,7 +1312,7 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for import-weak 1`] = `
 "asset entry.js 13.1 KiB [emitted] (name: entry)
-asset 979.js 138 bytes [emitted]
+asset 237.js 138 bytes [emitted]
 runtime modules 7.7 KiB 10 modules
 orphan modules 37 bytes [orphan] 1 module
 cacheable modules 142 bytes
@@ -1323,7 +1323,7 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for import-weak-parser-option 1`] = `
 "asset entry.js 13.1 KiB [emitted] (name: entry)
-asset 979.js 138 bytes [emitted]
+asset 237.js 138 bytes [emitted]
 runtime modules 7.7 KiB 10 modules
 orphan modules 37 bytes [orphan] 1 module
 cacheable modules 116 bytes
@@ -1333,7 +1333,7 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for import-with-invalid-options-comments 1`] = `
-"runtime modules 8.62 KiB 12 modules
+"runtime modules 8.63 KiB 12 modules
 cacheable modules 559 bytes
   ./index.js 50 bytes [built] [code generated]
   ./chunk.js 401 bytes [built] [code generated] [3 warnings]
@@ -1395,7 +1395,7 @@ webpack x.x.x compiled successfully in X ms"
 exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 1`] = `
 "1 chunks:
   asset bundle1.js 4.85 KiB [emitted] (name: main)
-  chunk (runtime: main) bundle1.js (main) 219 bytes (javascript) 1.77 KiB (runtime) <{590}> >{590}< [entry] [rendered]
+  chunk (runtime: main) bundle1.js (main) 219 bytes (javascript) 1.77 KiB (runtime) <{792}> >{792}< [entry] [rendered]
     runtime modules 1.77 KiB 4 modules
     cacheable modules 219 bytes
       ./a.js 22 bytes [dependent] [built] [code generated]
@@ -1408,51 +1408,51 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
 
 2 chunks:
   asset bundle2.js 12.6 KiB [emitted] (name: main)
-  asset 152.bundle2.js 663 bytes [emitted] (name: c)
-  chunk (runtime: main) 152.bundle2.js (c) 118 bytes <{152}> <{590}> >{152}< [rendered]
+  asset 390.bundle2.js 664 bytes [emitted] (name: c)
+  chunk (runtime: main) 390.bundle2.js (c) 118 bytes <{390}> <{792}> >{390}< [rendered]
     dependent modules 44 bytes [dependent]
       ./d.js 22 bytes [dependent] [built] [code generated]
       ./e.js 22 bytes [dependent] [built] [code generated]
     ./a.js 22 bytes [built] [code generated]
     ./b.js 22 bytes [built] [code generated]
     ./c.js 30 bytes [built] [code generated]
-  chunk (runtime: main) bundle2.js (main) 101 bytes (javascript) 7.71 KiB (runtime) >{152}< [entry] [rendered]
+  chunk (runtime: main) bundle2.js (main) 101 bytes (javascript) 7.71 KiB (runtime) >{390}< [entry] [rendered]
     runtime modules 7.71 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
   2 chunks (webpack x.x.x) compiled successfully in X ms
 
 3 chunks:
   asset bundle3.js 12.6 KiB [emitted] (name: main)
-  asset 152.bundle3.js 527 bytes [emitted] (name: c)
-  asset 804.bundle3.js 206 bytes [emitted]
-  chunk (runtime: main) 152.bundle3.js (c) 74 bytes <{590}> >{804}< [rendered]
+  asset 390.bundle3.js 528 bytes [emitted] (name: c)
+  asset 226.bundle3.js 206 bytes [emitted]
+  chunk (runtime: main) 226.bundle3.js 44 bytes <{390}> [rendered]
+    ./d.js 22 bytes [built] [code generated]
+    ./e.js 22 bytes [built] [code generated]
+  chunk (runtime: main) 390.bundle3.js (c) 74 bytes <{792}> >{226}< [rendered]
     ./a.js 22 bytes [built] [code generated]
     ./b.js 22 bytes [built] [code generated]
     ./c.js 30 bytes [built] [code generated]
-  chunk (runtime: main) bundle3.js (main) 101 bytes (javascript) 7.71 KiB (runtime) >{152}< [entry] [rendered]
+  chunk (runtime: main) bundle3.js (main) 101 bytes (javascript) 7.71 KiB (runtime) >{390}< [entry] [rendered]
     runtime modules 7.71 KiB 10 modules
     ./index.js 101 bytes [built] [code generated]
-  chunk (runtime: main) 804.bundle3.js 44 bytes <{152}> [rendered]
-    ./d.js 22 bytes [built] [code generated]
-    ./e.js 22 bytes [built] [code generated]
   3 chunks (webpack x.x.x) compiled successfully in X ms
 
 4 chunks:
   asset bundle4.js 12.6 KiB [emitted] (name: main)
-  asset 152.bundle4.js 392 bytes [emitted] (name: c)
-  asset 804.bundle4.js 206 bytes [emitted]
-  asset 272.bundle4.js 205 bytes [emitted]
-  chunk (runtime: main) 152.bundle4.js (c) 30 bytes <{590}> >{804}< [rendered]
-    ./c.js 30 bytes [built] [code generated]
-  chunk (runtime: main) 272.bundle4.js 44 bytes <{590}> [rendered]
+  asset 390.bundle4.js 392 bytes [emitted] (name: c)
+  asset 226.bundle4.js 206 bytes [emitted]
+  asset 78.bundle4.js 205 bytes [emitted]
+  chunk (runtime: main) 78.bundle4.js 44 bytes <{792}> [rendered]
     ./a.js 22 bytes [built] [code generated]
     ./b.js 22 bytes [built] [code generated]
-  chunk (runtime: main) bundle4.js (main) 101 bytes (javascript) 7.71 KiB (runtime) >{152}< >{272}< [entry] [rendered]
-    runtime modules 7.71 KiB 10 modules
-    ./index.js 101 bytes [built] [code generated]
-  chunk (runtime: main) 804.bundle4.js 44 bytes <{152}> [rendered]
+  chunk (runtime: main) 226.bundle4.js 44 bytes <{390}> [rendered]
     ./d.js 22 bytes [built] [code generated]
     ./e.js 22 bytes [built] [code generated]
+  chunk (runtime: main) 390.bundle4.js (c) 30 bytes <{792}> >{226}< [rendered]
+    ./c.js 30 bytes [built] [code generated]
+  chunk (runtime: main) bundle4.js (main) 101 bytes (javascript) 7.71 KiB (runtime) >{78}< >{390}< [entry] [rendered]
+    runtime modules 7.71 KiB 10 modules
+    ./index.js 101 bytes [built] [code generated]
   4 chunks (webpack x.x.x) compiled successfully in X ms"
 `;
 
@@ -1554,7 +1554,7 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for max-modules 1`] = `
-"asset main.js 5.47 KiB [emitted] (name: main)
+"asset main.js 5.46 KiB [emitted] (name: main)
 ./index.js 181 bytes [built] [code generated]
 ./a.js?1 33 bytes [built] [code generated]
 ./a.js?2 33 bytes [built] [code generated]
@@ -1579,7 +1579,7 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for max-modules-default 1`] = `
-"asset main.js 5.47 KiB [emitted] (name: main)
+"asset main.js 5.46 KiB [emitted] (name: main)
 ./index.js 181 bytes [built] [code generated]
 ./a.js?1 33 bytes [built] [code generated]
 ./a.js?2 33 bytes [built] [code generated]
@@ -1630,42 +1630,42 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for module-deduplication 1`] = `
-"asset e1.js 12.2 KiB [emitted] (name: e1)
-asset e2.js 12.2 KiB [emitted] (name: e2)
+"asset e2.js 12.2 KiB [emitted] (name: e2)
 asset e3.js 12.2 KiB [emitted] (name: e3)
-asset 192.js 856 bytes [emitted]
-asset 512.js 856 bytes [emitted]
-asset 843.js 856 bytes [emitted]
-asset 132.js 524 bytes [emitted]
-asset 224.js 524 bytes [emitted]
-asset 572.js 524 bytes [emitted]
+asset e1.js 12.2 KiB [emitted] (name: e1)
+asset 471.js 856 bytes [emitted]
+asset 752.js 856 bytes [emitted]
+asset 637.js 854 bytes [emitted]
+asset 371.js 524 bytes [emitted]
+asset 852.js 524 bytes [emitted]
+asset 18.js 522 bytes [emitted]
+chunk (runtime: e1) 18.js 61 bytes [rendered]
+  ./async1.js 61 bytes [built] [code generated]
 chunk (runtime: e2) e2.js (e2) 249 bytes (javascript) 6.58 KiB (runtime) [entry] [rendered]
   runtime modules 6.58 KiB 9 modules
   cacheable modules 249 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e2.js + 2 modules 209 bytes [built] [code generated]
     ./f.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e3) 132.js 61 bytes [rendered]
-  ./async3.js 61 bytes [built] [code generated]
-chunk (runtime: e2, e3) 192.js 81 bytes [rendered]
-  ./async1.js 61 bytes [built] [code generated]
-  ./d.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e2) 224.js 61 bytes [rendered]
-  ./async2.js 61 bytes [built] [code generated]
 chunk (runtime: e1) e1.js (e1) 249 bytes (javascript) 6.58 KiB (runtime) [entry] [rendered]
   runtime modules 6.58 KiB 9 modules
   cacheable modules 249 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./d.js 20 bytes [dependent] [built] [code generated]
     ./e1.js + 2 modules 209 bytes [built] [code generated]
-chunk (runtime: e1, e2) 512.js 81 bytes [rendered]
+chunk (runtime: e3) 371.js 61 bytes [rendered]
   ./async3.js 61 bytes [built] [code generated]
-  ./h.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e1) 572.js 61 bytes [rendered]
-  ./async1.js 61 bytes [built] [code generated]
-chunk (runtime: e1, e3) 843.js 81 bytes [rendered]
+chunk (runtime: e1, e3) 471.js 81 bytes [rendered]
   ./async2.js 61 bytes [built] [code generated]
   ./f.js 20 bytes [dependent] [built] [code generated]
+chunk (runtime: e2, e3) 637.js 81 bytes [rendered]
+  ./async1.js 61 bytes [built] [code generated]
+  ./d.js 20 bytes [dependent] [built] [code generated]
+chunk (runtime: e1, e2) 752.js 81 bytes [rendered]
+  ./async3.js 61 bytes [built] [code generated]
+  ./h.js 20 bytes [dependent] [built] [code generated]
+chunk (runtime: e2) 852.js 61 bytes [rendered]
+  ./async2.js 61 bytes [built] [code generated]
 chunk (runtime: e3) e3.js (e3) 249 bytes (javascript) 6.58 KiB (runtime) [entry] [rendered]
   runtime modules 6.58 KiB 9 modules
   cacheable modules 249 bytes
@@ -1676,39 +1676,39 @@ webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for module-deduplication-named 1`] = `
-"asset e1.js 12.1 KiB [emitted] (name: e1)
-asset e2.js 12.1 KiB [emitted] (name: e2)
+"asset e2.js 12.1 KiB [emitted] (name: e2)
+asset e1.js 12.1 KiB [emitted] (name: e1)
 asset e3.js 12.1 KiB [emitted] (name: e3)
 asset async1.js 961 bytes [emitted] (name: async1)
-asset async3.js 961 bytes [emitted] (name: async3)
-asset async2.js 960 bytes [emitted] (name: async2)
+asset async2.js 961 bytes [emitted] (name: async2)
+asset async3.js 960 bytes [emitted] (name: async3)
 chunk (runtime: e1, e2, e3) async3.js (async3) 135 bytes [rendered]
   ./async3.js 115 bytes [built] [code generated]
   ./h.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e1, e2, e3) async2.js (async2) 135 bytes [rendered]
-  ./async2.js 115 bytes [built] [code generated]
-  ./f.js 20 bytes [dependent] [built] [code generated]
 chunk (runtime: e2) e2.js (e2) 242 bytes (javascript) 6.63 KiB (runtime) [entry] [rendered]
   runtime modules 6.63 KiB 9 modules
   cacheable modules 242 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e2.js + 2 modules 202 bytes [built] [code generated]
     ./f.js 20 bytes [dependent] [built] [code generated]
+chunk (runtime: e1, e2, e3) async1.js (async1) 135 bytes [rendered]
+  ./async1.js 115 bytes [built] [code generated]
+  ./d.js 20 bytes [dependent] [built] [code generated]
 chunk (runtime: e1) e1.js (e1) 242 bytes (javascript) 6.63 KiB (runtime) [entry] [rendered]
   runtime modules 6.63 KiB 9 modules
   cacheable modules 242 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./d.js 20 bytes [dependent] [built] [code generated]
     ./e1.js + 2 modules 202 bytes [built] [code generated]
+chunk (runtime: e1, e2, e3) async2.js (async2) 135 bytes [rendered]
+  ./async2.js 115 bytes [built] [code generated]
+  ./f.js 20 bytes [dependent] [built] [code generated]
 chunk (runtime: e3) e3.js (e3) 242 bytes (javascript) 6.63 KiB (runtime) [entry] [rendered]
   runtime modules 6.63 KiB 9 modules
   cacheable modules 242 bytes
     ./b.js 20 bytes [dependent] [built] [code generated]
     ./e3.js + 2 modules 202 bytes [built] [code generated]
     ./h.js 20 bytes [dependent] [built] [code generated]
-chunk (runtime: e1, e2, e3) async1.js (async1) 135 bytes [rendered]
-  ./async1.js 115 bytes [built] [code generated]
-  ./d.js 20 bytes [dependent] [built] [code generated]
 webpack x.x.x compiled successfully"
 `;
 
@@ -1814,10 +1814,10 @@ webpack x.x.x compiled with 2 errors in X ms"
 
 exports[`StatsTestCases should print correct stats for named-chunk-groups 1`] = `
 "Chunk Group main 11.7 KiB = a-main.js
-Chunk Group async-a 1.07 KiB = a-164.js 259 bytes a-async-a.js 836 bytes
-Chunk Group async-b 1.07 KiB = a-164.js 259 bytes a-async-b.js 837 bytes
-Chunk Group async-c 1.45 KiB = a-vendors.js 740 bytes a-async-c.js 741 bytes
-chunk (runtime: main) a-164.js 149 bytes [rendered] split chunk (cache group: default)
+Chunk Group async-a 1.07 KiB = a-48.js 257 bytes a-async-a.js 836 bytes
+Chunk Group async-b 1.07 KiB = a-48.js 257 bytes a-async-b.js 835 bytes
+Chunk Group async-c 1.45 KiB = a-vendors.js 739 bytes a-async-c.js 741 bytes
+chunk (runtime: main) a-48.js 149 bytes [rendered] split chunk (cache group: default)
   > ./a ./index.js 1:0-47
   > ./b ./index.js 2:0-47
   ./shared.js 149 bytes [built] [code generated]
@@ -1828,9 +1828,6 @@ chunk (runtime: main) a-vendors.js (vendors) (id hint: vendors) 40 bytes [render
   > ./c ./index.js 3:0-47
   ./node_modules/x.js 20 bytes [built] [code generated]
   ./node_modules/y.js 20 bytes [built] [code generated]
-chunk (runtime: main) a-async-c.js (async-c) 67 bytes [rendered]
-  > ./c ./index.js 3:0-47
-  ./c.js 67 bytes [built] [code generated]
 chunk (runtime: main) a-async-a.js (async-a) 175 bytes [rendered]
   > ./a ./index.js 1:0-47
   ./a.js 175 bytes [built] [code generated]
@@ -1838,13 +1835,16 @@ chunk (runtime: main) a-main.js (main) 146 bytes (javascript) 6.92 KiB (runtime)
   > ./ main
   runtime modules 6.92 KiB 10 modules
   ./index.js 146 bytes [built] [code generated]
+chunk (runtime: main) a-async-c.js (async-c) 67 bytes [rendered]
+  > ./c ./index.js 3:0-47
+  ./c.js 67 bytes [built] [code generated]
 webpack x.x.x compiled successfully
 
 Entrypoint main 11.7 KiB = b-main.js
-Chunk Group async-a 1.07 KiB = b-164.js 259 bytes b-async-a.js 836 bytes
-Chunk Group async-b 1.07 KiB = b-164.js 259 bytes b-async-b.js 837 bytes
-Chunk Group async-c 1.45 KiB = b-vendors.js 740 bytes b-async-c.js 741 bytes
-chunk (runtime: main) b-164.js 149 bytes [rendered] split chunk (cache group: default)
+Chunk Group async-a 1.07 KiB = b-48.js 257 bytes b-async-a.js 836 bytes
+Chunk Group async-b 1.07 KiB = b-48.js 257 bytes b-async-b.js 835 bytes
+Chunk Group async-c 1.45 KiB = b-vendors.js 739 bytes b-async-c.js 741 bytes
+chunk (runtime: main) b-48.js 149 bytes [rendered] split chunk (cache group: default)
   > ./a ./index.js 1:0-47
   > ./b ./index.js 2:0-47
   ./shared.js 149 bytes [built] [code generated]
@@ -1855,9 +1855,6 @@ chunk (runtime: main) b-vendors.js (vendors) (id hint: vendors) 40 bytes [render
   > ./c ./index.js 3:0-47
   ./node_modules/x.js 20 bytes [built] [code generated]
   ./node_modules/y.js 20 bytes [built] [code generated]
-chunk (runtime: main) b-async-c.js (async-c) 67 bytes [rendered]
-  > ./c ./index.js 3:0-47
-  ./c.js 67 bytes [built] [code generated]
 chunk (runtime: main) b-async-a.js (async-a) 175 bytes [rendered]
   > ./a ./index.js 1:0-47
   ./a.js 175 bytes [built] [code generated]
@@ -1865,6 +1862,9 @@ chunk (runtime: main) b-main.js (main) 146 bytes (javascript) 6.92 KiB (runtime)
   > ./ main
   runtime modules 6.92 KiB 10 modules
   ./index.js 146 bytes [built] [code generated]
+chunk (runtime: main) b-async-c.js (async-c) 67 bytes [rendered]
+  > ./c ./index.js 3:0-47
+  ./c.js 67 bytes [built] [code generated]
 webpack x.x.x compiled successfully"
 `;
 
@@ -1883,7 +1883,7 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for named-chunks-plugin-async 1`] = `
 "asset entry.js 12.5 KiB [emitted] (name: entry)
-asset modules_a_js.js 313 bytes [emitted]
+asset modules_a_js.js 312 bytes [emitted]
 asset modules_b_js.js 149 bytes [emitted]
 runtime modules 7.7 KiB 10 modules
 cacheable modules 106 bytes
@@ -1907,54 +1907,54 @@ webpack x.x.x compiled with 1 error and 1 warning in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for optimize-chunks 1`] = `
-"asset main.js 11.1 KiB {590} [emitted] (name: main)
-asset cir2 from cir1.js 376 bytes {112}, {684} [emitted] (name: cir2 from cir1)
-asset cir1.js 333 bytes {948} [emitted] (name: cir1)
-asset cir2.js 333 bytes {112} [emitted] (name: cir2)
-asset abd.js 194 bytes {280}, {472} [emitted] (name: abd)
-asset chunk.js 152 bytes {60}, {312} [emitted] (name: chunk)
-asset ab.js 150 bytes {472} [emitted] (name: ab)
-asset ac in ab.js 109 bytes {312} [emitted] (name: ac in ab)
-chunk {60} (runtime: main) chunk.js (chunk) 2 bytes <{280}> <{312}> [rendered]
-  > [39] ./index.js 3:2-4:13
-  > [39] ./index.js 9:1-10:12
-  ./modules/c.js [80] 1 bytes {60} {312} [built] [code generated]
-  ./modules/d.js [640] 1 bytes {60} {280} [built] [code generated]
-chunk {112} (runtime: main) cir2.js (cir2) 81 bytes <{590}> >{948}< [rendered]
-  > [39] ./index.js 14:0-54
-  ./circular2.js [596] 81 bytes {112} {684} [built] [code generated]
-chunk {280} (runtime: main) abd.js (abd) 3 bytes <{590}> >{60}< [rendered]
-  > [39] ./index.js 8:0-11:9
-  ./modules/a.js [976] 1 bytes {280} {472} [built] [code generated]
-  ./modules/b.js [979] 1 bytes {280} {472} [built] [code generated]
-  ./modules/d.js [640] 1 bytes {60} {280} [built] [code generated]
-chunk {312} (runtime: main) ac in ab.js (ac in ab) 1 bytes <{472}> >{60}< [rendered]
-  > [39] ./index.js 2:1-5:15
-  ./modules/c.js [80] 1 bytes {60} {312} [built] [code generated]
-chunk {472} (runtime: main) ab.js (ab) 2 bytes <{590}> >{312}< [rendered]
-  > [39] ./index.js 1:0-6:8
-  ./modules/a.js [976] 1 bytes {280} {472} [built] [code generated]
-  ./modules/b.js [979] 1 bytes {280} {472} [built] [code generated]
-chunk {590} (runtime: main) main.js (main) 524 bytes (javascript) 6.12 KiB (runtime) >{112}< >{280}< >{472}< >{948}< [entry] [rendered]
+"asset main.js 11.1 KiB {792} [emitted] (name: main)
+asset cir2 from cir1.js 377 bytes {816}, {915} [emitted] (name: cir2 from cir1)
+asset cir1.js 333 bytes {712} [emitted] (name: cir1)
+asset cir2.js 333 bytes {915} [emitted] (name: cir2)
+asset abd.js 193 bytes {470}, {518} [emitted] (name: abd)
+asset chunk.js 154 bytes {125}, {982} [emitted] (name: chunk)
+asset ab.js 149 bytes {470} [emitted] (name: ab)
+asset ac in ab.js 110 bytes {125} [emitted] (name: ac in ab)
+chunk {125} (runtime: main) ac in ab.js (ac in ab) 1 bytes <{470}> >{982}< [rendered]
+  > [237] ./index.js 2:1-5:15
+  ./modules/c.js [494] 1 bytes {125} {982} [built] [code generated]
+chunk {470} (runtime: main) ab.js (ab) 2 bytes <{792}> >{125}< [rendered]
+  > [237] ./index.js 1:0-6:8
+  ./modules/a.js [36] 1 bytes {470} {518} [built] [code generated]
+  ./modules/b.js [618] 1 bytes {470} {518} [built] [code generated]
+chunk {518} (runtime: main) abd.js (abd) 3 bytes <{792}> >{982}< [rendered]
+  > [237] ./index.js 8:0-11:9
+  ./modules/a.js [36] 1 bytes {470} {518} [built] [code generated]
+  ./modules/b.js [618] 1 bytes {470} {518} [built] [code generated]
+  ./modules/d.js [503] 1 bytes {518} {982} [built] [code generated]
+chunk {712} (runtime: main) cir1.js (cir1) 81 bytes <{792}> <{816}> <{915}> >{816}< [rendered]
+  > [237] ./index.js 13:0-54
+  > [448] ./circular2.js 1:0-79
+  ./circular1.js [985] 81 bytes {712} [built] [code generated]
+chunk {792} (runtime: main) main.js (main) 524 bytes (javascript) 6.12 KiB (runtime) >{470}< >{518}< >{712}< >{915}< [entry] [rendered]
   > ./index main
   runtime modules 6.12 KiB 7 modules
   cacheable modules 524 bytes
-    ./index.js [39] 523 bytes {590} [built] [code generated]
-    ./modules/f.js [224] 1 bytes {590} [dependent] [built] [code generated]
-chunk {684} (runtime: main) cir2 from cir1.js (cir2 from cir1) 82 bytes <{948}> >{948}< [rendered]
-  > [980] ./circular1.js 1:0-79
-  ./circular2.js [596] 81 bytes {112} {684} [built] [code generated]
-  ./modules/e.js [44] 1 bytes {684} [built] [code generated]
-chunk {948} (runtime: main) cir1.js (cir1) 81 bytes <{112}> <{590}> <{684}> >{684}< [rendered]
-  > [39] ./index.js 13:0-54
-  > [596] ./circular2.js 1:0-79
-  ./circular1.js [980] 81 bytes {948} [built] [code generated]
+    ./index.js [237] 523 bytes {792} [built] [code generated]
+    ./modules/f.js [633] 1 bytes {792} [dependent] [built] [code generated]
+chunk {816} (runtime: main) cir2 from cir1.js (cir2 from cir1) 82 bytes <{712}> >{712}< [rendered]
+  > [985] ./circular1.js 1:0-79
+  ./circular2.js [448] 81 bytes {816} {915} [built] [code generated]
+  ./modules/e.js [888] 1 bytes {816} [built] [code generated]
+chunk {915} (runtime: main) cir2.js (cir2) 81 bytes <{792}> >{712}< [rendered]
+  > [237] ./index.js 14:0-54
+  ./circular2.js [448] 81 bytes {816} {915} [built] [code generated]
+chunk {982} (runtime: main) chunk.js (chunk) 2 bytes <{125}> <{518}> [rendered]
+  > [237] ./index.js 3:2-4:13
+  > [237] ./index.js 9:1-10:12
+  ./modules/c.js [494] 1 bytes {125} {982} [built] [code generated]
+  ./modules/d.js [503] 1 bytes {518} {982} [built] [code generated]
 webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for output-module 1`] = `
 "asset main.mjs 9.55 KiB [emitted] [javascript module] (name: main)
-asset 632.mjs 358 bytes [emitted] [javascript module]
+asset 936.mjs 358 bytes [emitted] [javascript module]
 runtime modules 5.76 KiB 7 modules
 orphan modules 38 bytes [orphan] 1 module
 cacheable modules 263 bytes
@@ -2060,9 +2060,9 @@ webpack x.x.x compiled with 3 warnings in X ms"
 
 exports[`StatsTestCases should print correct stats for performance-disabled 1`] = `
 "asset <CLR=32,BOLD>main.js</CLR> 303 KiB <CLR=32,BOLD>[emitted]</CLR> (name: main)
-asset <CLR=32,BOLD>720.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
-asset <CLR=32,BOLD>804.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
-asset <CLR=32,BOLD>636.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
+asset <CLR=32,BOLD>964.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
+asset <CLR=32,BOLD>226.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
+asset <CLR=32,BOLD>899.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
 runtime modules 6.02 KiB 7 modules
 cacheable modules 293 KiB
@@ -2077,9 +2077,9 @@ webpack x.x.x compiled <CLR=32,BOLD>successfully</CLR> in X ms"
 
 exports[`StatsTestCases should print correct stats for performance-error 1`] = `
 "asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>303 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main)
-asset <CLR=32,BOLD>720.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
-asset <CLR=32,BOLD>804.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
-asset <CLR=32,BOLD>636.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
+asset <CLR=32,BOLD>964.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
+asset <CLR=32,BOLD>226.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
+asset <CLR=32,BOLD>899.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
 runtime modules 6.02 KiB 7 modules
 cacheable modules 293 KiB
@@ -2136,9 +2136,9 @@ webpack x.x.x compiled with <CLR=33,BOLD>3 warnings</CLR> in X ms"
 
 exports[`StatsTestCases should print correct stats for performance-no-hints 1`] = `
 "asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>303 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main)
-asset <CLR=32,BOLD>720.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
-asset <CLR=32,BOLD>804.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
-asset <CLR=32,BOLD>636.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
+asset <CLR=32,BOLD>964.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
+asset <CLR=32,BOLD>226.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
+asset <CLR=32,BOLD>899.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 Entrypoint <CLR=BOLD>main</CLR> <CLR=33,BOLD>[big]</CLR> 303 KiB = <CLR=32,BOLD>main.js</CLR>
 runtime modules 6.02 KiB 7 modules
 cacheable modules 293 KiB
@@ -2182,55 +2182,55 @@ webpack x.x.x compiled with <CLR=31,BOLD>3 errors</CLR> in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for prefetch 1`] = `
-"asset main.js 16.9 KiB {590} [emitted] (name: main)
-asset prefetched.js 555 bytes {364} [emitted] (name: prefetched)
-asset inner2.js 150 bytes {804} [emitted] (name: inner2)
-asset normal.js 110 bytes {448} [emitted] (name: normal)
-asset prefetched2.js 110 bytes {944} [emitted] (name: prefetched2)
-asset inner.js 109 bytes {776} [emitted] (name: inner)
-asset prefetched3.js 109 bytes {372} [emitted] (name: prefetched3)
+"asset main.js 16.9 KiB {792} [emitted] (name: main)
+asset prefetched.js 556 bytes {529} [emitted] (name: prefetched)
+asset inner2.js 150 bytes {573} [emitted] (name: inner2)
+asset inner.js 110 bytes {253} [emitted] (name: inner)
+asset normal.js 110 bytes {574} [emitted] (name: normal)
+asset prefetched2.js 110 bytes {337} [emitted] (name: prefetched2)
+asset prefetched3.js 110 bytes {528} [emitted] (name: prefetched3)
 Entrypoint main 16.9 KiB = main.js
-  prefetch: prefetched2.js {944} (name: prefetched2), prefetched.js {364} (name: prefetched), prefetched3.js {372} (name: prefetched3)
-chunk {364} (runtime: main) prefetched.js (prefetched) 228 bytes <{590}> >{776}< >{804}< (prefetch: {804} {776}) [rendered]
-chunk {372} (runtime: main) prefetched3.js (prefetched3) 1 bytes <{590}> [rendered]
-chunk {448} (runtime: main) normal.js (normal) 1 bytes <{590}> [rendered]
-chunk {590} (runtime: main) main.js (main) 436 bytes (javascript) 9.96 KiB (runtime) >{364}< >{372}< >{448}< >{944}< (prefetch: {944} {364} {372}) [entry] [rendered]
-chunk {776} (runtime: main) inner.js (inner) 1 bytes <{364}> [rendered]
-chunk {804} (runtime: main) inner2.js (inner2) 2 bytes <{364}> [rendered]
-chunk {944} (runtime: main) prefetched2.js (prefetched2) 1 bytes <{590}> [rendered]"
+  prefetch: prefetched2.js {337} (name: prefetched2), prefetched.js {529} (name: prefetched), prefetched3.js {528} (name: prefetched3)
+chunk {253} (runtime: main) inner.js (inner) 1 bytes <{529}> [rendered]
+chunk {337} (runtime: main) prefetched2.js (prefetched2) 1 bytes <{792}> [rendered]
+chunk {528} (runtime: main) prefetched3.js (prefetched3) 1 bytes <{792}> [rendered]
+chunk {529} (runtime: main) prefetched.js (prefetched) 228 bytes <{792}> >{253}< >{573}< (prefetch: {573} {253}) [rendered]
+chunk {573} (runtime: main) inner2.js (inner2) 2 bytes <{529}> [rendered]
+chunk {574} (runtime: main) normal.js (normal) 1 bytes <{792}> [rendered]
+chunk {792} (runtime: main) main.js (main) 436 bytes (javascript) 9.96 KiB (runtime) >{337}< >{528}< >{529}< >{574}< (prefetch: {337} {529} {528}) [entry] [rendered]"
 `;
 
 exports[`StatsTestCases should print correct stats for prefetch-preload-mixed 1`] = `
-"chunk (runtime: main) c2.js (c2) 1 bytes <{152}> [rendered]
-chunk (runtime: main) a2.js (a2) 1 bytes <{996}> [rendered]
-chunk (runtime: main) c.js (c) 134 bytes <{590}> >{96}< >{704}< (preload: {704} {96}) [rendered]
+"chunk (runtime: main) a2.js (a2) 1 bytes <{996}> [rendered]
+chunk (runtime: main) b.js (b) 203 bytes <{792}> >{364}< >{567}< >{758}< (prefetch: {364} {758}) (preload: {567}) [rendered]
 chunk (runtime: main) a1.js (a1) 1 bytes <{996}> [rendered]
-chunk (runtime: main) b3.js (b3) 1 bytes <{580}> [rendered]
-chunk (runtime: main) b.js (b) 203 bytes <{590}> >{568}< >{756}< >{760}< (prefetch: {756} {568}) (preload: {760}) [rendered]
-chunk (runtime: main) main.js (main) 195 bytes (javascript) 10.6 KiB (runtime) >{152}< >{580}< >{996}< (prefetch: {996} {580} {152}) [entry] [rendered]
-chunk (runtime: main) c1.js (c1) 1 bytes <{152}> [rendered]
-chunk (runtime: main) b1.js (b1) 1 bytes <{580}> [rendered]
-chunk (runtime: main) b2.js (b2) 1 bytes <{580}> [rendered]
-chunk (runtime: main) a.js (a) 136 bytes <{590}> >{150}< >{341}< (prefetch: {341} {150}) [rendered]"
+chunk (runtime: main) b1.js (b1) 1 bytes <{199}> [rendered]
+chunk (runtime: main) c.js (c) 134 bytes <{792}> >{896}< >{907}< (preload: {907} {896}) [rendered]
+chunk (runtime: main) b2.js (b2) 1 bytes <{199}> [rendered]
+chunk (runtime: main) b3.js (b3) 1 bytes <{199}> [rendered]
+chunk (runtime: main) main.js (main) 195 bytes (javascript) 10.6 KiB (runtime) >{199}< >{390}< >{996}< (prefetch: {996} {199} {390}) [entry] [rendered]
+chunk (runtime: main) c2.js (c2) 1 bytes <{390}> [rendered]
+chunk (runtime: main) c1.js (c1) 1 bytes <{390}> [rendered]
+chunk (runtime: main) a.js (a) 136 bytes <{792}> >{150}< >{341}< (prefetch: {341} {150}) [rendered]"
 `;
 
 exports[`StatsTestCases should print correct stats for preload 1`] = `
 "asset main.js 15.2 KiB [emitted] (name: main)
-asset preloaded.js 555 bytes [emitted] (name: preloaded)
+asset preloaded.js 556 bytes [emitted] (name: preloaded)
 asset inner2.js 150 bytes [emitted] (name: inner2)
+asset inner.js 110 bytes [emitted] (name: inner)
 asset normal.js 110 bytes [emitted] (name: normal)
-asset preloaded2.js 110 bytes [emitted] (name: preloaded2)
-asset inner.js 109 bytes [emitted] (name: inner)
-asset preloaded3.js 109 bytes [emitted] (name: preloaded3)
+asset preloaded3.js 110 bytes [emitted] (name: preloaded3)
+asset preloaded2.js 109 bytes [emitted] (name: preloaded2)
 Entrypoint main 15.2 KiB = main.js
   preload: preloaded2.js (name: preloaded2), preloaded.js (name: preloaded), preloaded3.js (name: preloaded3)
-chunk (runtime: main) preloaded3.js (preloaded3) 1 bytes [rendered]
-chunk (runtime: main) preloaded.js (preloaded) 226 bytes (preload: {804} {776}) [rendered]
-chunk (runtime: main) normal.js (normal) 1 bytes [rendered]
-chunk (runtime: main) main.js (main) 424 bytes (javascript) 8.9 KiB (runtime) (preload: {832} {260} {68}) [entry] [rendered]
+chunk (runtime: main) preloaded.js (preloaded) 226 bytes (preload: {573} {253}) [rendered]
 chunk (runtime: main) inner.js (inner) 1 bytes [rendered]
+chunk (runtime: main) preloaded2.js (preloaded2) 1 bytes [rendered]
 chunk (runtime: main) inner2.js (inner2) 2 bytes [rendered]
-chunk (runtime: main) preloaded2.js (preloaded2) 1 bytes [rendered]"
+chunk (runtime: main) normal.js (normal) 1 bytes [rendered]
+chunk (runtime: main) preloaded3.js (preloaded3) 1 bytes [rendered]
+chunk (runtime: main) main.js (main) 424 bytes (javascript) 8.9 KiB (runtime) (preload: {485} {165} {676}) [entry] [rendered]"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-detailed 1`] = `
@@ -2243,66 +2243,66 @@ exports[`StatsTestCases should print correct stats for preset-detailed 1`] = `
       [LogTestPlugin] Log
     [LogTestPlugin] End
 PublicPath: auto
-asset main.js 10.3 KiB {590} [emitted] (name: main)
-asset 720.js 323 bytes {720} [emitted]
-asset 804.js 206 bytes {804} [emitted]
-asset 636.js 138 bytes {636} [emitted]
+asset main.js 10.3 KiB {792} [emitted] (name: main)
+asset 964.js 323 bytes {964} [emitted]
+asset 226.js 206 bytes {226} [emitted]
+asset 899.js 138 bytes {899} [emitted]
 Entrypoint main 10.3 KiB = main.js
-chunk {590} (runtime: main) main.js (main) 73 bytes (javascript) 6.02 KiB (runtime) >{636}< >{720}< [entry] [rendered]
+chunk {226} (runtime: main) 226.js 44 bytes <{964}> [rendered]
+  > [964] ./c.js 1:0-52
+chunk {792} (runtime: main) main.js (main) 73 bytes (javascript) 6.02 KiB (runtime) >{899}< >{964}< [entry] [rendered]
   > ./index main
-chunk {636} (runtime: main) 636.js 22 bytes <{590}> [rendered]
-  > ./b [39] ./index.js 2:0-16
-chunk {720} (runtime: main) 720.js 54 bytes <{590}> >{804}< [rendered]
-  > ./c [39] ./index.js 3:0-16
-chunk {804} (runtime: main) 804.js 44 bytes <{720}> [rendered]
-  > [720] ./c.js 1:0-52
+chunk {899} (runtime: main) 899.js 22 bytes <{792}> [rendered]
+  > ./b [237] ./index.js 2:0-16
+chunk {964} (runtime: main) 964.js 54 bytes <{792}> >{226}< [rendered]
+  > ./c [237] ./index.js 3:0-16
 runtime modules 6.02 KiB
-  webpack/runtime/ensure chunk 326 bytes {590} [code generated]
+  webpack/runtime/ensure chunk 326 bytes {792} [code generated]
     [no exports]
     [used exports unknown]
-  webpack/runtime/get javascript chunk filename 167 bytes {590} [code generated]
+  webpack/runtime/get javascript chunk filename 167 bytes {792} [code generated]
     [no exports]
     [used exports unknown]
-  webpack/runtime/global 221 bytes {590} [code generated]
+  webpack/runtime/global 221 bytes {792} [code generated]
     [no exports]
     [used exports unknown]
-  webpack/runtime/hasOwnProperty shorthand 88 bytes {590} [code generated]
+  webpack/runtime/hasOwnProperty shorthand 88 bytes {792} [code generated]
     [no exports]
     [used exports unknown]
-  webpack/runtime/jsonp chunk loading 2.97 KiB {590} [code generated]
+  webpack/runtime/jsonp chunk loading 2.97 KiB {792} [code generated]
     [no exports]
     [used exports unknown]
-  webpack/runtime/load script 1.36 KiB {590} [code generated]
+  webpack/runtime/load script 1.36 KiB {792} [code generated]
     [no exports]
     [used exports unknown]
-  webpack/runtime/publicPath 923 bytes {590} [code generated]
+  webpack/runtime/publicPath 923 bytes {792} [code generated]
     [no exports]
     [used exports unknown]
 cacheable modules 193 bytes
-  ./index.js [39] 51 bytes {590} [depth 0] [built] [code generated]
+  ./index.js [237] 51 bytes {792} [depth 0] [built] [code generated]
     [no exports used]
     Statement (ExpressionStatement) with side effects in source code at 1:0-15
     ModuleConcatenation bailout: Module is not an ECMAScript module
-  ./a.js [80] 22 bytes {590} [depth 1] [built] [code generated]
+  ./a.js [670] 22 bytes {792} [depth 1] [built] [code generated]
     [used exports unknown]
     CommonJS bailout: module.exports is used directly at 1:0-14
     Statement (ExpressionStatement) with side effects in source code at 1:0-21
     ModuleConcatenation bailout: Module is not an ECMAScript module
-  ./b.js [636] 22 bytes {636} [depth 1] [built] [code generated]
+  ./b.js [899] 22 bytes {899} [depth 1] [built] [code generated]
     [used exports unknown]
     CommonJS bailout: module.exports is used directly at 1:0-14
     Statement (ExpressionStatement) with side effects in source code at 1:0-21
     ModuleConcatenation bailout: Module is not an ECMAScript module
-  ./c.js [720] 54 bytes {720} [depth 1] [built] [code generated]
+  ./c.js [964] 54 bytes {964} [depth 1] [built] [code generated]
     [used exports unknown]
     Statement (ExpressionStatement) with side effects in source code at 1:0-53
     ModuleConcatenation bailout: Module is not an ECMAScript module
-  ./d.js [744] 22 bytes {804} [depth 2] [built] [code generated]
+  ./d.js [425] 22 bytes {226} [depth 2] [built] [code generated]
     [used exports unknown]
     CommonJS bailout: module.exports is used directly at 1:0-14
     Statement (ExpressionStatement) with side effects in source code at 1:0-21
     ModuleConcatenation bailout: Module is not an ECMAScript module
-  ./e.js [928] 22 bytes {804} [depth 2] [built] [code generated]
+  ./e.js [210] 22 bytes {226} [depth 2] [built] [code generated]
     [used exports unknown]
     CommonJS bailout: module.exports is used directly at 1:0-14
     Statement (ExpressionStatement) with side effects in source code at 1:0-21
@@ -2346,7 +2346,7 @@ LOG from webpack.FileSystemInfo
     Directory info in cache: 0 timestamps 0 hashes 0 timestamp hash combinations
     Managed items info in cache: 0 items
 
-1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (8fe0e0dcc6f8c10a1eb4)"
+1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (a0ffd0f99a704988d428)"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-errors-only 1`] = `""`;
@@ -2422,9 +2422,9 @@ exports[`StatsTestCases should print correct stats for preset-normal 1`] = `
 <w> [LogTestPlugin] Warning
 <i> [LogTestPlugin] Info
 asset main.js 10.3 KiB [emitted] (name: main)
-asset 720.js 323 bytes [emitted]
-asset 804.js 206 bytes [emitted]
-asset 636.js 138 bytes [emitted]
+asset 964.js 323 bytes [emitted]
+asset 226.js 206 bytes [emitted]
+asset 899.js 138 bytes [emitted]
 runtime modules 6.02 KiB 7 modules
 cacheable modules 193 bytes
   ./index.js 51 bytes [built] [code generated]
@@ -2445,9 +2445,9 @@ webpack x.x.x compiled successfully in X ms"
 
 exports[`StatsTestCases should print correct stats for preset-normal-performance 1`] = `
 "asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>303 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main)
-asset <CLR=32,BOLD>720.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
-asset <CLR=32,BOLD>804.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
-asset <CLR=32,BOLD>636.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
+asset <CLR=32,BOLD>964.js</CLR> 323 bytes <CLR=32,BOLD>[emitted]</CLR>
+asset <CLR=32,BOLD>226.js</CLR> 206 bytes <CLR=32,BOLD>[emitted]</CLR>
+asset <CLR=32,BOLD>899.js</CLR> 138 bytes <CLR=32,BOLD>[emitted]</CLR>
 runtime modules 6.02 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2473,9 +2473,9 @@ webpack x.x.x compiled with <CLR=33,BOLD>2 warnings</CLR> in X ms"
 
 exports[`StatsTestCases should print correct stats for preset-normal-performance-ensure-filter-sourcemaps 1`] = `
 "asset <CLR=33,BOLD>main.js</CLR> <CLR=33,BOLD>303 KiB</CLR> <CLR=32,BOLD>[emitted]</CLR> <CLR=33,BOLD>[big]</CLR> (name: main) 1 related asset
-asset <CLR=32,BOLD>720.js</CLR> 355 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
-asset <CLR=32,BOLD>804.js</CLR> 238 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
-asset <CLR=32,BOLD>636.js</CLR> 170 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
+asset <CLR=32,BOLD>964.js</CLR> 355 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
+asset <CLR=32,BOLD>226.js</CLR> 238 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
+asset <CLR=32,BOLD>899.js</CLR> 170 bytes <CLR=32,BOLD>[emitted]</CLR> 1 related asset
 runtime modules 6.02 KiB 7 modules
 cacheable modules 293 KiB
   <CLR=BOLD>./index.js</CLR> 52 bytes <CLR=33,BOLD>[built]</CLR> <CLR=33,BOLD>[code generated]</CLR>
@@ -2519,90 +2519,90 @@ exports[`StatsTestCases should print correct stats for preset-verbose 1`] = `
       [LogTestPlugin] Log
     [LogTestPlugin] End
 PublicPath: auto
-asset main.js 10.3 KiB {590} [emitted] (name: main)
-asset 720.js 323 bytes {720} [emitted]
-asset 804.js 206 bytes {804} [emitted]
-asset 636.js 138 bytes {636} [emitted]
+asset main.js 10.3 KiB {792} [emitted] (name: main)
+asset 964.js 323 bytes {964} [emitted]
+asset 226.js 206 bytes {226} [emitted]
+asset 899.js 138 bytes {899} [emitted]
 Entrypoint main 10.3 KiB = main.js
-chunk {590} (runtime: main) main.js (main) 73 bytes (javascript) 6.02 KiB (runtime) >{636}< >{720}< [entry] [rendered]
+chunk {226} (runtime: main) 226.js 44 bytes <{964}> [rendered]
+  > [964] ./c.js 1:0-52
+  ./d.js [425] 22 bytes {226} [depth 2] [built] [code generated]
+    [used exports unknown]
+    CommonJS bailout: module.exports is used directly at 1:0-14
+    Statement (ExpressionStatement) with side effects in source code at 1:0-21
+    ModuleConcatenation bailout: Module is not an ECMAScript module
+    require.ensure item ./d [964] ./c.js 1:0-52
+    cjs self exports reference [425] ./d.js 1:0-14
+    X ms [237] -> X ms [964] ->
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+  ./e.js [210] 22 bytes {226} [depth 2] [built] [code generated]
+    [used exports unknown]
+    CommonJS bailout: module.exports is used directly at 1:0-14
+    Statement (ExpressionStatement) with side effects in source code at 1:0-21
+    ModuleConcatenation bailout: Module is not an ECMAScript module
+    require.ensure item ./e [964] ./c.js 1:0-52
+    cjs self exports reference [210] ./e.js 1:0-14
+    X ms [237] -> X ms [964] ->
+    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
+chunk {792} (runtime: main) main.js (main) 73 bytes (javascript) 6.02 KiB (runtime) >{899}< >{964}< [entry] [rendered]
   > ./index main
   runtime modules 6.02 KiB
-    webpack/runtime/ensure chunk 326 bytes {590} [code generated]
+    webpack/runtime/ensure chunk 326 bytes {792} [code generated]
       [no exports]
       [used exports unknown]
-    webpack/runtime/get javascript chunk filename 167 bytes {590} [code generated]
+    webpack/runtime/get javascript chunk filename 167 bytes {792} [code generated]
       [no exports]
       [used exports unknown]
-    webpack/runtime/global 221 bytes {590} [code generated]
+    webpack/runtime/global 221 bytes {792} [code generated]
       [no exports]
       [used exports unknown]
-    webpack/runtime/hasOwnProperty shorthand 88 bytes {590} [code generated]
+    webpack/runtime/hasOwnProperty shorthand 88 bytes {792} [code generated]
       [no exports]
       [used exports unknown]
-    webpack/runtime/jsonp chunk loading 2.97 KiB {590} [code generated]
+    webpack/runtime/jsonp chunk loading 2.97 KiB {792} [code generated]
       [no exports]
       [used exports unknown]
-    webpack/runtime/load script 1.36 KiB {590} [code generated]
+    webpack/runtime/load script 1.36 KiB {792} [code generated]
       [no exports]
       [used exports unknown]
-    webpack/runtime/publicPath 923 bytes {590} [code generated]
+    webpack/runtime/publicPath 923 bytes {792} [code generated]
       [no exports]
       [used exports unknown]
   cacheable modules 73 bytes
-    ./a.js [80] 22 bytes {590} [depth 1] [dependent] [built] [code generated]
+    ./a.js [670] 22 bytes {792} [depth 1] [dependent] [built] [code generated]
       [used exports unknown]
       CommonJS bailout: module.exports is used directly at 1:0-14
       Statement (ExpressionStatement) with side effects in source code at 1:0-21
       ModuleConcatenation bailout: Module is not an ECMAScript module
-      cjs self exports reference [80] ./a.js 1:0-14
-      cjs require ./a [39] ./index.js 1:0-14
-      X ms [39] ->
+      cjs self exports reference [670] ./a.js 1:0-14
+      cjs require ./a [237] ./index.js 1:0-14
+      X ms [237] ->
       X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
-    ./index.js [39] 51 bytes {590} [depth 0] [built] [code generated]
+    ./index.js [237] 51 bytes {792} [depth 0] [built] [code generated]
       [no exports used]
       Statement (ExpressionStatement) with side effects in source code at 1:0-15
       ModuleConcatenation bailout: Module is not an ECMAScript module
       entry ./index main
       X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
-chunk {636} (runtime: main) 636.js 22 bytes <{590}> [rendered]
-  > ./b [39] ./index.js 2:0-16
-  ./b.js [636] 22 bytes {636} [depth 1] [built] [code generated]
+chunk {899} (runtime: main) 899.js 22 bytes <{792}> [rendered]
+  > ./b [237] ./index.js 2:0-16
+  ./b.js [899] 22 bytes {899} [depth 1] [built] [code generated]
     [used exports unknown]
     CommonJS bailout: module.exports is used directly at 1:0-14
     Statement (ExpressionStatement) with side effects in source code at 1:0-21
     ModuleConcatenation bailout: Module is not an ECMAScript module
-    cjs self exports reference [636] ./b.js 1:0-14
-    amd require ./b [39] ./index.js 2:0-16
-    X ms [39] ->
+    cjs self exports reference [899] ./b.js 1:0-14
+    amd require ./b [237] ./index.js 2:0-16
+    X ms [237] ->
     X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
-chunk {720} (runtime: main) 720.js 54 bytes <{590}> >{804}< [rendered]
-  > ./c [39] ./index.js 3:0-16
-  ./c.js [720] 54 bytes {720} [depth 1] [built] [code generated]
+chunk {964} (runtime: main) 964.js 54 bytes <{792}> >{226}< [rendered]
+  > ./c [237] ./index.js 3:0-16
+  ./c.js [964] 54 bytes {964} [depth 1] [built] [code generated]
     [used exports unknown]
     Statement (ExpressionStatement) with side effects in source code at 1:0-53
     ModuleConcatenation bailout: Module is not an ECMAScript module
-    amd require ./c [39] ./index.js 3:0-16
-    X ms [39] ->
-    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
-chunk {804} (runtime: main) 804.js 44 bytes <{720}> [rendered]
-  > [720] ./c.js 1:0-52
-  ./d.js [744] 22 bytes {804} [depth 2] [built] [code generated]
-    [used exports unknown]
-    CommonJS bailout: module.exports is used directly at 1:0-14
-    Statement (ExpressionStatement) with side effects in source code at 1:0-21
-    ModuleConcatenation bailout: Module is not an ECMAScript module
-    require.ensure item ./d [720] ./c.js 1:0-52
-    cjs self exports reference [744] ./d.js 1:0-14
-    X ms [39] -> X ms [720] ->
-    X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
-  ./e.js [928] 22 bytes {804} [depth 2] [built] [code generated]
-    [used exports unknown]
-    CommonJS bailout: module.exports is used directly at 1:0-14
-    Statement (ExpressionStatement) with side effects in source code at 1:0-21
-    ModuleConcatenation bailout: Module is not an ECMAScript module
-    require.ensure item ./e [720] ./c.js 1:0-52
-    cjs self exports reference [928] ./e.js 1:0-14
-    X ms [39] -> X ms [720] ->
+    amd require ./c [237] ./index.js 3:0-16
+    X ms [237] ->
     X ms (resolving: X ms, restoring: X ms, integration: X ms, building: X ms, storing: X ms)
   
 
@@ -2722,21 +2722,21 @@ LOG from webpack.FileSystemInfo
     Directory info in cache: 0 timestamps 0 hashes 0 timestamp hash combinations
     Managed items info in cache: 0 items
 
-1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (8fe0e0dcc6f8c10a1eb4)"
+1970-04-20 12:42:42: webpack x.x.x compiled successfully in X ms (a0ffd0f99a704988d428)"
 `;
 
 exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
 "a-normal:
   assets by path *.js 3.23 KiB
-    asset 6cca84209a011d8f4e3e-6cca84.js 2.77 KiB [emitted] [immutable] [minimized] (name: runtime)
-    asset dc9fe55325071ffe06cc-dc9fe5.js 232 bytes [emitted] [immutable] [minimized] (name: lazy)
-    asset d0a1503542397868f61b-d0a150.js 212 bytes [emitted] [immutable] [minimized] (name: index)
+    asset 95cc93edf1ad69f23c2d-95cc93.js 2.77 KiB [emitted] [immutable] [minimized] (name: runtime)
+    asset 0a1b2c7ae2cee5086d70-0a1b2c.js 232 bytes [emitted] [immutable] [minimized] (name: lazy)
+    asset fdf80674ac46a61ff9fe-fdf806.js 213 bytes [emitted] [immutable] [minimized] (name: index)
     asset 666f2b8847021ccc7608-666f2b.js 21 bytes [emitted] [immutable] [minimized] (name: a, b)
   assets by chunk 20.4 KiB (auxiliary name: lazy)
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
     asset 7382fad5b015914e0811.jpg?query 5.89 KiB [cached] [immutable] [from: file.jpg?query] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: index)
-  Entrypoint index 2.98 KiB (5.89 KiB) = 6cca84209a011d8f4e3e-6cca84.js 2.77 KiB d0a1503542397868f61b-d0a150.js 212 bytes 1 auxiliary asset
+  Entrypoint index 2.98 KiB (5.89 KiB) = 95cc93edf1ad69f23c2d-95cc93.js 2.77 KiB fdf80674ac46a61ff9fe-fdf806.js 213 bytes 1 auxiliary asset
   Entrypoint a 21 bytes = 666f2b8847021ccc7608-666f2b.js
   Entrypoint b 21 bytes = 666f2b8847021ccc7608-666f2b.js
   runtime modules 7.34 KiB 9 modules
@@ -2755,15 +2755,15 @@ exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
 
 b-normal:
   assets by path *.js 3.23 KiB
-    asset 6cca84209a011d8f4e3e-6cca84.js 2.77 KiB [emitted] [immutable] [minimized] (name: runtime)
-    asset dc9fe55325071ffe06cc-dc9fe5.js 232 bytes [emitted] [immutable] [minimized] (name: lazy)
-    asset d0a1503542397868f61b-d0a150.js 212 bytes [emitted] [immutable] [minimized] (name: index)
+    asset b2610145f4e37f6cceb9-b26101.js 2.77 KiB [emitted] [immutable] [minimized] (name: runtime)
+    asset 0a1b2c7ae2cee5086d70-0a1b2c.js 232 bytes [emitted] [immutable] [minimized] (name: lazy)
+    asset fdf80674ac46a61ff9fe-fdf806.js 213 bytes [emitted] [immutable] [minimized] (name: index)
     asset 666f2b8847021ccc7608-666f2b.js 21 bytes [emitted] [immutable] [minimized] (name: a, b)
   assets by chunk 20.4 KiB (auxiliary name: lazy)
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
     asset 7382fad5b015914e0811.jpg?query 5.89 KiB [cached] [immutable] [from: file.jpg?query] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: index)
-  Entrypoint index 2.98 KiB (5.89 KiB) = 6cca84209a011d8f4e3e-6cca84.js 2.77 KiB d0a1503542397868f61b-d0a150.js 212 bytes 1 auxiliary asset
+  Entrypoint index 2.98 KiB (5.89 KiB) = b2610145f4e37f6cceb9-b26101.js 2.77 KiB fdf80674ac46a61ff9fe-fdf806.js 213 bytes 1 auxiliary asset
   Entrypoint a 21 bytes = 666f2b8847021ccc7608-666f2b.js
   Entrypoint b 21 bytes = 666f2b8847021ccc7608-666f2b.js
   runtime modules 7.34 KiB 9 modules
@@ -2781,20 +2781,20 @@ b-normal:
   b-normal (webpack x.x.x) compiled successfully in X ms
 
 a-source-map:
-  assets by path *.js 3.44 KiB
-    asset fbf67d352fd9e6b257e7-fbf67d.js 2.83 KiB [emitted] [immutable] [minimized] (name: runtime)
-      sourceMap fbf67d352fd9e6b257e7-fbf67d.js.map 14.7 KiB [emitted] [dev] (auxiliary name: runtime)
-    asset 8b05840021929aacd839-8b0584.js 288 bytes [emitted] [immutable] [minimized] (name: lazy)
-      sourceMap 8b05840021929aacd839-8b0584.js.map 409 bytes [emitted] [dev] (auxiliary name: lazy)
-    asset 791c32443320ca0384d1-791c32.js 268 bytes [emitted] [immutable] [minimized] (name: index)
-      sourceMap 791c32443320ca0384d1-791c32.js.map 366 bytes [emitted] [dev] (auxiliary name: index)
+  assets by path *.js 3.45 KiB
+    asset 2122a471734cae15098c-2122a4.js 2.83 KiB [emitted] [immutable] [minimized] (name: runtime)
+      sourceMap 2122a471734cae15098c-2122a4.js.map 14.7 KiB [emitted] [dev] (auxiliary name: runtime)
+    asset 5f97639daffeace56533-5f9763.js 288 bytes [emitted] [immutable] [minimized] (name: lazy)
+      sourceMap 5f97639daffeace56533-5f9763.js.map 409 bytes [emitted] [dev] (auxiliary name: lazy)
+    asset 46504ddf1bd748642c76-46504d.js 269 bytes [emitted] [immutable] [minimized] (name: index)
+      sourceMap 46504ddf1bd748642c76-46504d.js.map 366 bytes [emitted] [dev] (auxiliary name: index)
     asset 222c2acc68675174e6b2-222c2a.js 77 bytes [emitted] [immutable] [minimized] (name: a, b)
       sourceMap 222c2acc68675174e6b2-222c2a.js.map 254 bytes [emitted] [dev] (auxiliary name: a, b)
   assets by chunk 20.4 KiB (auxiliary name: lazy)
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
     asset 7382fad5b015914e0811.jpg?query 5.89 KiB [cached] [immutable] [from: file.jpg?query] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: index)
-  Entrypoint index 3.09 KiB (20.9 KiB) = fbf67d352fd9e6b257e7-fbf67d.js 2.83 KiB 791c32443320ca0384d1-791c32.js 268 bytes 3 auxiliary assets
+  Entrypoint index 3.09 KiB (20.9 KiB) = 2122a471734cae15098c-2122a4.js 2.83 KiB 46504ddf1bd748642c76-46504d.js 269 bytes 3 auxiliary assets
   Entrypoint a 77 bytes (254 bytes) = 222c2acc68675174e6b2-222c2a.js 1 auxiliary asset
   Entrypoint b 77 bytes (254 bytes) = 222c2acc68675174e6b2-222c2a.js 1 auxiliary asset
   runtime modules 7.34 KiB 9 modules
@@ -2812,20 +2812,20 @@ a-source-map:
   a-source-map (webpack x.x.x) compiled successfully in X ms
 
 b-source-map:
-  assets by path *.js 3.44 KiB
-    asset b96bcf32c92db07c833f-b96bcf.js 2.83 KiB [emitted] [immutable] [minimized] (name: runtime)
-      sourceMap b96bcf32c92db07c833f-b96bcf.js.map 14.7 KiB [emitted] [dev] (auxiliary name: runtime)
-    asset 8b05840021929aacd839-8b0584.js 288 bytes [emitted] [immutable] [minimized] (name: lazy)
-      sourceMap 8b05840021929aacd839-8b0584.js.map 405 bytes [emitted] [dev] (auxiliary name: lazy)
-    asset 791c32443320ca0384d1-791c32.js 268 bytes [emitted] [immutable] [minimized] (name: index)
-      sourceMap 791c32443320ca0384d1-791c32.js.map 323 bytes [emitted] [dev] (auxiliary name: index)
+  assets by path *.js 3.45 KiB
+    asset 94f4cb82b81597cdb748-94f4cb.js 2.83 KiB [emitted] [immutable] [minimized] (name: runtime)
+      sourceMap 94f4cb82b81597cdb748-94f4cb.js.map 14.7 KiB [emitted] [dev] (auxiliary name: runtime)
+    asset 5f97639daffeace56533-5f9763.js 288 bytes [emitted] [immutable] [minimized] (name: lazy)
+      sourceMap 5f97639daffeace56533-5f9763.js.map 405 bytes [emitted] [dev] (auxiliary name: lazy)
+    asset 46504ddf1bd748642c76-46504d.js 269 bytes [emitted] [immutable] [minimized] (name: index)
+      sourceMap 46504ddf1bd748642c76-46504d.js.map 323 bytes [emitted] [dev] (auxiliary name: index)
     asset 222c2acc68675174e6b2-222c2a.js 77 bytes [emitted] [immutable] [minimized] (name: a, b)
       sourceMap 222c2acc68675174e6b2-222c2a.js.map 254 bytes [emitted] [dev] (auxiliary name: a, b)
   assets by chunk 20.4 KiB (auxiliary name: lazy)
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
     asset 7382fad5b015914e0811.jpg?query 5.89 KiB [cached] [immutable] [from: file.jpg?query] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: index)
-  Entrypoint index 3.09 KiB (20.9 KiB) = b96bcf32c92db07c833f-b96bcf.js 2.83 KiB 791c32443320ca0384d1-791c32.js 268 bytes 3 auxiliary assets
+  Entrypoint index 3.09 KiB (20.9 KiB) = 94f4cb82b81597cdb748-94f4cb.js 2.83 KiB 46504ddf1bd748642c76-46504d.js 269 bytes 3 auxiliary assets
   Entrypoint a 77 bytes (254 bytes) = 222c2acc68675174e6b2-222c2a.js 1 auxiliary asset
   Entrypoint b 77 bytes (254 bytes) = 222c2acc68675174e6b2-222c2a.js 1 auxiliary asset
   runtime modules 7.34 KiB 9 modules
@@ -2957,7 +2957,7 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for reverse-sort-modules 1`] = `
-"asset main.js 5.47 KiB [emitted] (name: main)
+"asset main.js 5.46 KiB [emitted] (name: main)
 ./index.js 181 bytes [built] [code generated]
 ./c.js?9 33 bytes [built] [code generated]
 ./c.js?8 33 bytes [built] [code generated]
@@ -3001,9 +3001,9 @@ webpack x.x.x compiled successfully"
 exports[`StatsTestCases should print correct stats for runtime-chunk-integration 1`] = `
 "base:
   asset without-runtime.js 12.1 KiB [emitted] (name: runtime)
-  asset without-340.js 1.2 KiB [emitted]
-  asset without-main1.js 816 bytes [emitted] (name: main1)
-  Entrypoint main1 12.9 KiB = without-runtime.js 12.1 KiB without-main1.js 816 bytes
+  asset without-580.js 1.2 KiB [emitted]
+  asset without-main1.js 817 bytes [emitted] (name: main1)
+  Entrypoint main1 12.9 KiB = without-runtime.js 12.1 KiB without-main1.js 817 bytes
   runtime modules 7.57 KiB 10 modules
   cacheable modules 126 bytes
     ./main1.js 66 bytes [built] [code generated]
@@ -3014,12 +3014,12 @@ exports[`StatsTestCases should print correct stats for runtime-chunk-integration
 
 static custom name:
   asset with-manifest.js 12.1 KiB [emitted] (name: manifest)
-  asset with-340.js 1.2 KiB [emitted]
-  asset with-main1.js 816 bytes [emitted] (name: main1)
+  asset with-580.js 1.2 KiB [emitted]
+  asset with-main1.js 817 bytes [emitted] (name: main1)
+  asset with-main2.js 434 bytes [emitted] (name: main2)
   asset with-main3.js 434 bytes [emitted] (name: main3)
-  asset with-main2.js 433 bytes [emitted] (name: main2)
-  Entrypoint main1 12.9 KiB = with-manifest.js 12.1 KiB with-main1.js 816 bytes
-  Entrypoint main2 12.5 KiB = with-manifest.js 12.1 KiB with-main2.js 433 bytes
+  Entrypoint main1 12.9 KiB = with-manifest.js 12.1 KiB with-main1.js 817 bytes
+  Entrypoint main2 12.5 KiB = with-manifest.js 12.1 KiB with-main2.js 434 bytes
   Entrypoint main3 12.5 KiB = with-manifest.js 12.1 KiB with-main3.js 434 bytes
   runtime modules 7.56 KiB 10 modules
   cacheable modules 166 bytes
@@ -3034,12 +3034,12 @@ static custom name:
 dynamic custom name:
   asset func-b.js 12.1 KiB [emitted] (name: b)
   asset func-a.js 4.91 KiB [emitted] (name: a)
-  asset func-340.js 1.2 KiB [emitted]
-  asset func-main1.js 816 bytes [emitted] (name: main1)
+  asset func-580.js 1.2 KiB [emitted]
+  asset func-main1.js 817 bytes [emitted] (name: main1)
+  asset func-main2.js 434 bytes [emitted] (name: main2)
   asset func-main3.js 434 bytes [emitted] (name: main3)
-  asset func-main2.js 433 bytes [emitted] (name: main2)
-  Entrypoint main1 12.9 KiB = func-b.js 12.1 KiB func-main1.js 816 bytes
-  Entrypoint main2 12.5 KiB = func-b.js 12.1 KiB func-main2.js 433 bytes
+  Entrypoint main1 12.9 KiB = func-b.js 12.1 KiB func-main1.js 817 bytes
+  Entrypoint main2 12.5 KiB = func-b.js 12.1 KiB func-main2.js 434 bytes
   Entrypoint main3 5.33 KiB = func-a.js 4.91 KiB func-main3.js 434 bytes
   runtime modules 10 KiB 13 modules
   cacheable modules 166 bytes
@@ -3572,55 +3572,55 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
   Entrypoint a 12.6 KiB = default/a.js
   Entrypoint b 3.93 KiB = default/b.js
   Entrypoint c 3.93 KiB = default/c.js
-  chunk (runtime: a, main) default/async-g.js (async-g) 45 bytes <{464}> <{472}> <{616}> <{744}> <{996}> ={144}= [rendered]
+  chunk (runtime: a, main) default/async-g.js (async-g) 45 bytes <{263}> <{425}> <{628}> <{723}> <{996}> ={935}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: a, main) default/144.js 20 bytes <{464}> <{472}> <{590}> <{616}> <{744}> <{996}> ={96}= ={272}= ={276}= ={388}= ={472}= ={616}= ={744}= [rendered] split chunk (cache group: default)
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
-    > ./g ./a.js 6:0-47
-    ./f.js 20 bytes [built] [code generated]
-  chunk (runtime: c) default/c.js (c) 196 bytes (javascript) 396 bytes (runtime) [entry] [rendered]
-    > ./c c
-    dependent modules 80 bytes [dependent] 4 modules
-    runtime modules 396 bytes 2 modules
-    ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: main) default/async-b.js (async-b) 116 bytes <{590}> ={144}= ={472}= ={616}= ={744}= [rendered]
+  chunk (runtime: main) default/async-b.js (async-b) 116 bytes <{792}> ={425}= ={628}= ={723}= ={935}= [rendered]
     > ./b ./index.js 2:0-47
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) default/async-c.js (async-c) 116 bytes <{590}> ={144}= ={388}= ={472}= ={744}= [rendered]
-    > ./c ./index.js 3:0-47
-    ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: main) default/388.js (id hint: vendors) 20 bytes <{590}> ={144}= ={276}= ={472}= ={744}= [rendered] split chunk (cache group: defaultVendors)
-    > ./c ./index.js 3:0-47
-    ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: main) default/async-a.js (async-a) 185 bytes <{590}> ={472}= ={616}= ={744}= >{96}< >{144}< [rendered]
-    > ./a ./index.js 1:0-47
-    ./a.js + 1 modules 185 bytes [built] [code generated]
-  chunk (runtime: main) default/472.js (id hint: vendors) 20 bytes <{590}> ={144}= ={272}= ={276}= ={388}= ={464}= ={616}= ={744}= >{96}< >{144}< [rendered] split chunk (cache group: defaultVendors)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
-    ./node_modules/x.js 20 bytes [built] [code generated]
   chunk (runtime: b) default/b.js (b) 196 bytes (javascript) 396 bytes (runtime) [entry] [rendered]
     > ./b b
     dependent modules 80 bytes [dependent] 4 modules
     runtime modules 396 bytes 2 modules
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.68 KiB (runtime) >{144}< >{272}< >{276}< >{388}< >{464}< >{472}< >{616}< >{744}< [entry] [rendered]
-    > ./ main
-    runtime modules 6.68 KiB 9 modules
-    ./index.js 147 bytes [built] [code generated]
-  chunk (runtime: main) default/616.js (id hint: vendors) 20 bytes <{590}> ={144}= ={272}= ={464}= ={472}= ={744}= >{96}< >{144}< [rendered] split chunk (cache group: defaultVendors)
+  chunk (runtime: main) default/async-a.js (async-a) 185 bytes <{792}> ={425}= ={628}= ={723}= >{49}< >{935}< [rendered]
     > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    ./node_modules/y.js 20 bytes [built] [code generated]
-  chunk (runtime: main) default/744.js 20 bytes <{590}> ={144}= ={272}= ={276}= ={388}= ={464}= ={472}= ={616}= >{96}< >{144}< [rendered] split chunk (cache group: default)
+    ./a.js + 1 modules 185 bytes [built] [code generated]
+  chunk (runtime: c) default/c.js (c) 196 bytes (javascript) 396 bytes (runtime) [entry] [rendered]
+    > ./c c
+    dependent modules 80 bytes [dependent] 4 modules
+    runtime modules 396 bytes 2 modules
+    ./c.js 116 bytes [built] [code generated]
+  chunk (runtime: main) default/425.js 20 bytes <{792}> ={60}= ={263}= ={628}= ={723}= ={862}= ={869}= ={935}= >{49}< >{935}< [rendered] split chunk (cache group: default)
     > ./a ./index.js 1:0-47
     > ./b ./index.js 2:0-47
     > ./c ./index.js 3:0-47
     ./d.js 20 bytes [built] [code generated]
-  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.67 KiB (runtime) >{96}< >{144}< [entry] [rendered]
+  chunk (runtime: main) default/628.js (id hint: vendors) 20 bytes <{792}> ={60}= ={263}= ={425}= ={723}= ={862}= ={869}= ={935}= >{49}< >{935}< [rendered] split chunk (cache group: defaultVendors)
+    > ./a ./index.js 1:0-47
+    > ./b ./index.js 2:0-47
+    > ./c ./index.js 3:0-47
+    ./node_modules/x.js 20 bytes [built] [code generated]
+  chunk (runtime: main) default/723.js (id hint: vendors) 20 bytes <{792}> ={60}= ={263}= ={425}= ={628}= ={935}= >{49}< >{935}< [rendered] split chunk (cache group: defaultVendors)
+    > ./a ./index.js 1:0-47
+    > ./b ./index.js 2:0-47
+    ./node_modules/y.js 20 bytes [built] [code generated]
+  chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.68 KiB (runtime) >{60}< >{263}< >{425}< >{628}< >{723}< >{862}< >{869}< >{935}< [entry] [rendered]
+    > ./ main
+    runtime modules 6.68 KiB 9 modules
+    ./index.js 147 bytes [built] [code generated]
+  chunk (runtime: main) default/862.js (id hint: vendors) 20 bytes <{792}> ={425}= ={628}= ={869}= ={935}= [rendered] split chunk (cache group: defaultVendors)
+    > ./c ./index.js 3:0-47
+    ./node_modules/z.js 20 bytes [built] [code generated]
+  chunk (runtime: main) default/async-c.js (async-c) 116 bytes <{792}> ={425}= ={628}= ={862}= ={935}= [rendered]
+    > ./c ./index.js 3:0-47
+    ./c.js 116 bytes [built] [code generated]
+  chunk (runtime: a, main) default/935.js 20 bytes <{263}> <{425}> <{628}> <{723}> <{792}> <{996}> ={49}= ={60}= ={425}= ={628}= ={723}= ={862}= ={869}= [rendered] split chunk (cache group: default)
+    > ./b ./index.js 2:0-47
+    > ./c ./index.js 3:0-47
+    > ./g ./a.js 6:0-47
+    ./f.js 20 bytes [built] [code generated]
+  chunk (runtime: a) default/a.js (a) 245 bytes (javascript) 6.67 KiB (runtime) >{49}< >{935}< [entry] [rendered]
     > ./a a
     runtime modules 6.67 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
@@ -3629,59 +3629,31 @@ exports[`StatsTestCases should print correct stats for split-chunks 1`] = `
 
 all-chunks:
   Entrypoint main 11.5 KiB = all-chunks/main.js
-  Entrypoint a 15 KiB = all-chunks/472.js 412 bytes all-chunks/616.js 412 bytes all-chunks/744.js 412 bytes all-chunks/928.js 412 bytes all-chunks/a.js 13.4 KiB
-  Entrypoint b 8.13 KiB = all-chunks/472.js 412 bytes all-chunks/616.js 412 bytes all-chunks/744.js 412 bytes all-chunks/144.js 412 bytes all-chunks/b.js 6.52 KiB
-  Entrypoint c 8.13 KiB = all-chunks/472.js 412 bytes all-chunks/388.js 412 bytes all-chunks/744.js 412 bytes all-chunks/144.js 412 bytes all-chunks/c.js 6.52 KiB
-  chunk (runtime: a, main) all-chunks/async-g.js (async-g) 45 bytes <{464}> <{472}> <{616}> <{744}> <{928}> <{996}> ={144}= [rendered]
+  Entrypoint a 15 KiB = all-chunks/628.js 412 bytes all-chunks/723.js 412 bytes all-chunks/425.js 412 bytes all-chunks/210.js 412 bytes all-chunks/a.js 13.4 KiB
+  Entrypoint b 8.13 KiB = all-chunks/628.js 412 bytes all-chunks/723.js 412 bytes all-chunks/425.js 412 bytes all-chunks/935.js 412 bytes all-chunks/b.js 6.52 KiB
+  Entrypoint c 8.13 KiB = all-chunks/628.js 412 bytes all-chunks/862.js 412 bytes all-chunks/425.js 412 bytes all-chunks/935.js 412 bytes all-chunks/c.js 6.52 KiB
+  chunk (runtime: a, main) all-chunks/async-g.js (async-g) 45 bytes <{210}> <{263}> <{425}> <{628}> <{723}> <{996}> ={935}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: a, b, c, main) all-chunks/144.js 20 bytes <{464}> <{472}> <{590}> <{616}> <{744}> <{928}> <{996}> ={96}= ={152}= ={272}= ={276}= ={388}= ={472}= ={580}= ={616}= ={744}= [initial] [rendered] split chunk (cache group: default)
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
-    > ./g ./a.js 6:0-47
-    > ./b b
-    > ./c c
-    ./f.js 20 bytes [built] [code generated]
-  chunk (runtime: c) all-chunks/c.js (c) 116 bytes (javascript) 2.76 KiB (runtime) ={144}= ={388}= ={472}= ={744}= [entry] [rendered]
-    > ./c c
-    runtime modules 2.76 KiB 4 modules
-    ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: main) all-chunks/async-b.js (async-b) 116 bytes <{590}> ={144}= ={472}= ={616}= ={744}= [rendered]
+  chunk (runtime: main) all-chunks/async-b.js (async-b) 116 bytes <{792}> ={425}= ={628}= ={723}= ={935}= [rendered]
     > ./b ./index.js 2:0-47
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) all-chunks/async-c.js (async-c) 116 bytes <{590}> ={144}= ={388}= ={472}= ={744}= [rendered]
-    > ./c ./index.js 3:0-47
-    ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: c, main) all-chunks/388.js (id hint: vendors) 20 bytes <{590}> ={144}= ={152}= ={276}= ={472}= ={744}= [initial] [rendered] split chunk (cache group: defaultVendors)
-    > ./c ./index.js 3:0-47
-    > ./c c
-    ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: main) all-chunks/async-a.js (async-a) 165 bytes <{590}> ={472}= ={616}= ={744}= ={928}= >{96}< >{144}< [rendered]
+  chunk (runtime: b) all-chunks/b.js (b) 116 bytes (javascript) 2.76 KiB (runtime) ={425}= ={628}= ={723}= ={935}= [entry] [rendered]
+    > ./b b
+    runtime modules 2.76 KiB 4 modules
+    ./b.js 116 bytes [built] [code generated]
+  chunk (runtime: a, main) all-chunks/210.js 20 bytes <{792}> ={263}= ={425}= ={628}= ={723}= ={996}= >{49}< >{935}< [initial] [rendered] split chunk (cache group: default)
+    > ./a ./index.js 1:0-47
+    > ./a a
+    ./e.js 20 bytes [built] [code generated]
+  chunk (runtime: main) all-chunks/async-a.js (async-a) 165 bytes <{792}> ={210}= ={425}= ={628}= ={723}= >{49}< >{935}< [rendered]
     > ./a ./index.js 1:0-47
     ./a.js 165 bytes [built] [code generated]
-  chunk (runtime: a, b, c, main) all-chunks/472.js (id hint: vendors) 20 bytes <{590}> ={144}= ={152}= ={272}= ={276}= ={388}= ={464}= ={580}= ={616}= ={744}= ={928}= ={996}= >{96}< >{144}< [initial] [rendered] split chunk (cache group: defaultVendors)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
-    > ./a a
-    > ./b b
+  chunk (runtime: c) all-chunks/c.js (c) 116 bytes (javascript) 2.76 KiB (runtime) ={425}= ={628}= ={862}= ={935}= [entry] [rendered]
     > ./c c
-    ./node_modules/x.js 20 bytes [built] [code generated]
-  chunk (runtime: b) all-chunks/b.js (b) 116 bytes (javascript) 2.76 KiB (runtime) ={144}= ={472}= ={616}= ={744}= [entry] [rendered]
-    > ./b b
     runtime modules 2.76 KiB 4 modules
-    ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) all-chunks/main.js (main) 147 bytes (javascript) 6.68 KiB (runtime) >{144}< >{272}< >{276}< >{388}< >{464}< >{472}< >{616}< >{744}< >{928}< [entry] [rendered]
-    > ./ main
-    runtime modules 6.68 KiB 9 modules
-    ./index.js 147 bytes [built] [code generated]
-  chunk (runtime: a, b, main) all-chunks/616.js (id hint: vendors) 20 bytes <{590}> ={144}= ={272}= ={464}= ={472}= ={580}= ={744}= ={928}= ={996}= >{96}< >{144}< [initial] [rendered] split chunk (cache group: defaultVendors)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    > ./a a
-    > ./b b
-    ./node_modules/y.js 20 bytes [built] [code generated]
-  chunk (runtime: a, b, c, main) all-chunks/744.js 20 bytes <{590}> ={144}= ={152}= ={272}= ={276}= ={388}= ={464}= ={472}= ={580}= ={616}= ={928}= ={996}= >{96}< >{144}< [initial] [rendered] split chunk (cache group: default)
+    ./c.js 116 bytes [built] [code generated]
+  chunk (runtime: a, b, c, main) all-chunks/425.js 20 bytes <{792}> ={60}= ={199}= ={210}= ={263}= ={390}= ={628}= ={723}= ={862}= ={869}= ={935}= ={996}= >{49}< >{935}< [initial] [rendered] split chunk (cache group: default)
     > ./a ./index.js 1:0-47
     > ./b ./index.js 2:0-47
     > ./c ./index.js 3:0-47
@@ -3689,11 +3661,39 @@ all-chunks:
     > ./b b
     > ./c c
     ./d.js 20 bytes [built] [code generated]
-  chunk (runtime: a, main) all-chunks/928.js 20 bytes <{590}> ={464}= ={472}= ={616}= ={744}= ={996}= >{96}< >{144}< [initial] [rendered] split chunk (cache group: default)
+  chunk (runtime: a, b, c, main) all-chunks/628.js (id hint: vendors) 20 bytes <{792}> ={60}= ={199}= ={210}= ={263}= ={390}= ={425}= ={723}= ={862}= ={869}= ={935}= ={996}= >{49}< >{935}< [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
+    > ./b ./index.js 2:0-47
+    > ./c ./index.js 3:0-47
     > ./a a
-    ./e.js 20 bytes [built] [code generated]
-  chunk (runtime: a) all-chunks/a.js (a) 165 bytes (javascript) 7.59 KiB (runtime) ={472}= ={616}= ={744}= ={928}= >{96}< >{144}< [entry] [rendered]
+    > ./b b
+    > ./c c
+    ./node_modules/x.js 20 bytes [built] [code generated]
+  chunk (runtime: a, b, main) all-chunks/723.js (id hint: vendors) 20 bytes <{792}> ={60}= ={199}= ={210}= ={263}= ={425}= ={628}= ={935}= ={996}= >{49}< >{935}< [initial] [rendered] split chunk (cache group: defaultVendors)
+    > ./a ./index.js 1:0-47
+    > ./b ./index.js 2:0-47
+    > ./a a
+    > ./b b
+    ./node_modules/y.js 20 bytes [built] [code generated]
+  chunk (runtime: main) all-chunks/main.js (main) 147 bytes (javascript) 6.68 KiB (runtime) >{60}< >{210}< >{263}< >{425}< >{628}< >{723}< >{862}< >{869}< >{935}< [entry] [rendered]
+    > ./ main
+    runtime modules 6.68 KiB 9 modules
+    ./index.js 147 bytes [built] [code generated]
+  chunk (runtime: c, main) all-chunks/862.js (id hint: vendors) 20 bytes <{792}> ={390}= ={425}= ={628}= ={869}= ={935}= [initial] [rendered] split chunk (cache group: defaultVendors)
+    > ./c ./index.js 3:0-47
+    > ./c c
+    ./node_modules/z.js 20 bytes [built] [code generated]
+  chunk (runtime: main) all-chunks/async-c.js (async-c) 116 bytes <{792}> ={425}= ={628}= ={862}= ={935}= [rendered]
+    > ./c ./index.js 3:0-47
+    ./c.js 116 bytes [built] [code generated]
+  chunk (runtime: a, b, c, main) all-chunks/935.js 20 bytes <{210}> <{263}> <{425}> <{628}> <{723}> <{792}> <{996}> ={49}= ={60}= ={199}= ={390}= ={425}= ={628}= ={723}= ={862}= ={869}= [initial] [rendered] split chunk (cache group: default)
+    > ./b ./index.js 2:0-47
+    > ./c ./index.js 3:0-47
+    > ./g ./a.js 6:0-47
+    > ./b b
+    > ./c c
+    ./f.js 20 bytes [built] [code generated]
+  chunk (runtime: a) all-chunks/a.js (a) 165 bytes (javascript) 7.59 KiB (runtime) ={210}= ={425}= ={628}= ={723}= >{49}< >{935}< [entry] [rendered]
     > ./a a
     runtime modules 7.59 KiB 10 modules
     ./a.js 165 bytes [built] [code generated]
@@ -3702,25 +3702,17 @@ all-chunks:
 manual:
   Entrypoint main 11.3 KiB = manual/main.js
   Entrypoint a 14.8 KiB = manual/vendors.js 1.04 KiB manual/a.js 13.7 KiB
-  Entrypoint b 8.44 KiB = manual/vendors.js 1.04 KiB manual/b.js 7.39 KiB
-  Entrypoint c 8.44 KiB = manual/vendors.js 1.04 KiB manual/c.js 7.39 KiB
-  chunk (runtime: a, main) manual/async-g.js (async-g) 65 bytes <{275}> <{464}> <{996}> [rendered]
+  Entrypoint b 8.43 KiB = manual/vendors.js 1.04 KiB manual/b.js 7.39 KiB
+  Entrypoint c 8.43 KiB = manual/vendors.js 1.04 KiB manual/c.js 7.39 KiB
+  chunk (runtime: a, main) manual/async-g.js (async-g) 65 bytes <{96}> <{263}> <{996}> [rendered]
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: c) manual/c.js (c) 156 bytes (javascript) 2.76 KiB (runtime) ={275}= [entry] [rendered]
-    > ./c c
-    > x c
-    > y c
-    > z c
-    runtime modules 2.76 KiB 4 modules
-    dependent modules 40 bytes [dependent] 2 modules
-    ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: main) manual/async-b.js (async-b) 156 bytes <{590}> ={275}= [rendered]
+  chunk (runtime: main) manual/async-b.js (async-b) 156 bytes <{792}> ={96}= [rendered]
     > ./b ./index.js 2:0-47
     dependent modules 40 bytes [dependent] 2 modules
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: a, b, c, main) manual/vendors.js (vendors) (id hint: vendors) 60 bytes <{590}> ={152}= ={272}= ={276}= ={464}= ={580}= ={996}= >{96}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
+  chunk (runtime: a, b, c, main) manual/vendors.js (vendors) (id hint: vendors) 60 bytes <{792}> ={60}= ={199}= ={263}= ={390}= ={869}= ={996}= >{49}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
     > ./a ./index.js 1:0-47
     > ./b ./index.js 2:0-47
     > ./c ./index.js 3:0-47
@@ -3739,15 +3731,7 @@ manual:
     ./node_modules/x.js 20 bytes [built] [code generated]
     ./node_modules/y.js 20 bytes [built] [code generated]
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: main) manual/async-c.js (async-c) 156 bytes <{590}> ={275}= [rendered]
-    > ./c ./index.js 3:0-47
-    dependent modules 40 bytes [dependent] 2 modules
-    ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: main) manual/async-a.js (async-a) 205 bytes <{590}> ={275}= >{96}< [rendered]
-    > ./a ./index.js 1:0-47
-    dependent modules 20 bytes [dependent] 1 module
-    ./a.js + 1 modules 185 bytes [built] [code generated]
-  chunk (runtime: b) manual/b.js (b) 156 bytes (javascript) 2.76 KiB (runtime) ={275}= [entry] [rendered]
+  chunk (runtime: b) manual/b.js (b) 156 bytes (javascript) 2.76 KiB (runtime) ={96}= [entry] [rendered]
     > ./b b
     > x b
     > y b
@@ -3755,11 +3739,27 @@ manual:
     runtime modules 2.76 KiB 4 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) manual/main.js (main) 147 bytes (javascript) 6.68 KiB (runtime) >{272}< >{275}< >{276}< >{464}< [entry] [rendered]
+  chunk (runtime: main) manual/async-a.js (async-a) 205 bytes <{792}> ={96}= >{49}< [rendered]
+    > ./a ./index.js 1:0-47
+    dependent modules 20 bytes [dependent] 1 module
+    ./a.js + 1 modules 185 bytes [built] [code generated]
+  chunk (runtime: c) manual/c.js (c) 156 bytes (javascript) 2.76 KiB (runtime) ={96}= [entry] [rendered]
+    > ./c c
+    > x c
+    > y c
+    > z c
+    runtime modules 2.76 KiB 4 modules
+    dependent modules 40 bytes [dependent] 2 modules
+    ./c.js 116 bytes [built] [code generated]
+  chunk (runtime: main) manual/main.js (main) 147 bytes (javascript) 6.68 KiB (runtime) >{60}< >{96}< >{263}< >{869}< [entry] [rendered]
     > ./ main
     runtime modules 6.68 KiB 9 modules
     ./index.js 147 bytes [built] [code generated]
-  chunk (runtime: a) manual/a.js (a) 205 bytes (javascript) 7.56 KiB (runtime) ={275}= >{96}< [entry] [rendered]
+  chunk (runtime: main) manual/async-c.js (async-c) 156 bytes <{792}> ={96}= [rendered]
+    > ./c ./index.js 3:0-47
+    dependent modules 40 bytes [dependent] 2 modules
+    ./c.js 116 bytes [built] [code generated]
+  chunk (runtime: a) manual/a.js (a) 205 bytes (javascript) 7.56 KiB (runtime) ={96}= >{49}< [entry] [rendered]
     > ./a a
     > x a
     > y a
@@ -3771,55 +3771,31 @@ manual:
 
 name-too-long:
   Entrypoint main 11.5 KiB = name-too-long/main.js
-  Entrypoint aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 15 KiB = name-too-long/472.js 412 bytes name-too-long/616.js 412 bytes name-too-long/744.js 412 bytes name-too-long/928.js 412 bytes name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js 13.4 KiB
-  Entrypoint bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb 8.13 KiB = name-too-long/472.js 412 bytes name-too-long/616.js 412 bytes name-too-long/744.js 412 bytes name-too-long/144.js 412 bytes name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js 6.52 KiB
-  Entrypoint cccccccccccccccccccccccccccccc 8.13 KiB = name-too-long/472.js 412 bytes name-too-long/388.js 412 bytes name-too-long/744.js 412 bytes name-too-long/144.js 412 bytes name-too-long/cccccccccccccccccccccccccccccc.js 6.52 KiB
-  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, main) name-too-long/async-g.js (async-g) 45 bytes <{464}> <{472}> <{616}> <{744}> <{820}> <{928}> ={144}= [rendered]
+  Entrypoint aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 15 KiB = name-too-long/628.js 412 bytes name-too-long/723.js 412 bytes name-too-long/425.js 412 bytes name-too-long/210.js 412 bytes name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js 13.4 KiB
+  Entrypoint bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb 8.13 KiB = name-too-long/628.js 412 bytes name-too-long/723.js 412 bytes name-too-long/425.js 412 bytes name-too-long/935.js 412 bytes name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js 6.52 KiB
+  Entrypoint cccccccccccccccccccccccccccccc 8.13 KiB = name-too-long/628.js 412 bytes name-too-long/862.js 412 bytes name-too-long/425.js 412 bytes name-too-long/935.js 412 bytes name-too-long/cccccccccccccccccccccccccccccc.js 6.52 KiB
+  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, main) name-too-long/async-g.js (async-g) 45 bytes <{210}> <{263}> <{425}> <{505}> <{628}> <{723}> ={935}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc, main) name-too-long/144.js 20 bytes <{464}> <{472}> <{590}> <{616}> <{744}> <{820}> <{928}> ={96}= ={272}= ={276}= ={388}= ={416}= ={472}= ={616}= ={744}= ={856}= [initial] [rendered] split chunk (cache group: default)
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
-    > ./g ./a.js 6:0-47
-    > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-    > ./c cccccccccccccccccccccccccccccc
-    ./f.js 20 bytes [built] [code generated]
-  chunk (runtime: main) name-too-long/async-b.js (async-b) 116 bytes <{590}> ={144}= ={472}= ={616}= ={744}= [rendered]
+  chunk (runtime: main) name-too-long/async-b.js (async-b) 116 bytes <{792}> ={425}= ={628}= ={723}= ={935}= [rendered]
     > ./b ./index.js 2:0-47
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) name-too-long/async-c.js (async-c) 116 bytes <{590}> ={144}= ={388}= ={472}= ={744}= [rendered]
-    > ./c ./index.js 3:0-47
-    ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: cccccccccccccccccccccccccccccc, main) name-too-long/388.js (id hint: vendors) 20 bytes <{590}> ={144}= ={276}= ={416}= ={472}= ={744}= [initial] [rendered] split chunk (cache group: defaultVendors)
-    > ./c ./index.js 3:0-47
-    > ./c cccccccccccccccccccccccccccccc
-    ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: cccccccccccccccccccccccccccccc) name-too-long/cccccccccccccccccccccccccccccc.js (cccccccccccccccccccccccccccccc) 116 bytes (javascript) 2.76 KiB (runtime) ={144}= ={388}= ={472}= ={744}= [entry] [rendered]
+  chunk (runtime: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) 116 bytes (javascript) 2.76 KiB (runtime) ={425}= ={628}= ={723}= ={935}= [entry] [rendered]
+    > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    runtime modules 2.76 KiB 4 modules
+    ./b.js 116 bytes [built] [code generated]
+  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, main) name-too-long/210.js 20 bytes <{792}> ={263}= ={425}= ={505}= ={628}= ={723}= >{49}< >{935}< [initial] [rendered] split chunk (cache group: default)
+    > ./a ./index.js 1:0-47
+    > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ./e.js 20 bytes [built] [code generated]
+  chunk (runtime: main) name-too-long/async-a.js (async-a) 165 bytes <{792}> ={210}= ={425}= ={628}= ={723}= >{49}< >{935}< [rendered]
+    > ./a ./index.js 1:0-47
+    ./a.js 165 bytes [built] [code generated]
+  chunk (runtime: cccccccccccccccccccccccccccccc) name-too-long/cccccccccccccccccccccccccccccc.js (cccccccccccccccccccccccccccccc) 116 bytes (javascript) 2.76 KiB (runtime) ={425}= ={628}= ={862}= ={935}= [entry] [rendered]
     > ./c cccccccccccccccccccccccccccccc
     runtime modules 2.76 KiB 4 modules
     ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: main) name-too-long/async-a.js (async-a) 165 bytes <{590}> ={472}= ={616}= ={744}= ={928}= >{96}< >{144}< [rendered]
-    > ./a ./index.js 1:0-47
-    ./a.js 165 bytes [built] [code generated]
-  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc, main) name-too-long/472.js (id hint: vendors) 20 bytes <{590}> ={144}= ={272}= ={276}= ={388}= ={416}= ={464}= ={616}= ={744}= ={820}= ={856}= ={928}= >{96}< >{144}< [initial] [rendered] split chunk (cache group: defaultVendors)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
-    > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-    > ./c cccccccccccccccccccccccccccccc
-    ./node_modules/x.js 20 bytes [built] [code generated]
-  chunk (runtime: main) name-too-long/main.js (main) 147 bytes (javascript) 6.68 KiB (runtime) >{144}< >{272}< >{276}< >{388}< >{464}< >{472}< >{616}< >{744}< >{928}< [entry] [rendered]
-    > ./ main
-    runtime modules 6.68 KiB 9 modules
-    ./index.js 147 bytes [built] [code generated]
-  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, main) name-too-long/616.js (id hint: vendors) 20 bytes <{590}> ={144}= ={272}= ={464}= ={472}= ={744}= ={820}= ={856}= ={928}= >{96}< >{144}< [initial] [rendered] split chunk (cache group: defaultVendors)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-    ./node_modules/y.js 20 bytes [built] [code generated]
-  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc, main) name-too-long/744.js 20 bytes <{590}> ={144}= ={272}= ={276}= ={388}= ={416}= ={464}= ={472}= ={616}= ={820}= ={856}= ={928}= >{96}< >{144}< [initial] [rendered] split chunk (cache group: default)
+  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc, main) name-too-long/425.js 20 bytes <{792}> ={60}= ={63}= ={210}= ={263}= ={349}= ={505}= ={628}= ={723}= ={862}= ={869}= ={935}= >{49}< >{935}< [initial] [rendered] split chunk (cache group: default)
     > ./a ./index.js 1:0-47
     > ./b ./index.js 2:0-47
     > ./c ./index.js 3:0-47
@@ -3827,80 +3803,104 @@ name-too-long:
     > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     > ./c cccccccccccccccccccccccccccccc
     ./d.js 20 bytes [built] [code generated]
-  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) 165 bytes (javascript) 7.6 KiB (runtime) ={472}= ={616}= ={744}= ={928}= >{96}< >{144}< [entry] [rendered]
+  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) name-too-long/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.js (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) 165 bytes (javascript) 7.6 KiB (runtime) ={210}= ={425}= ={628}= ={723}= >{49}< >{935}< [entry] [rendered]
     > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     runtime modules 7.6 KiB 10 modules
     ./a.js 165 bytes [built] [code generated]
-  chunk (runtime: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) name-too-long/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.js (bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb) 116 bytes (javascript) 2.76 KiB (runtime) ={144}= ={472}= ={616}= ={744}= [entry] [rendered]
-    > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-    runtime modules 2.76 KiB 4 modules
-    ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, main) name-too-long/928.js 20 bytes <{590}> ={464}= ={472}= ={616}= ={744}= ={820}= >{96}< >{144}< [initial] [rendered] split chunk (cache group: default)
+  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc, main) name-too-long/628.js (id hint: vendors) 20 bytes <{792}> ={60}= ={63}= ={210}= ={263}= ={349}= ={425}= ={505}= ={723}= ={862}= ={869}= ={935}= >{49}< >{935}< [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./a ./index.js 1:0-47
+    > ./b ./index.js 2:0-47
+    > ./c ./index.js 3:0-47
     > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    ./e.js 20 bytes [built] [code generated]
+    > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    > ./c cccccccccccccccccccccccccccccc
+    ./node_modules/x.js 20 bytes [built] [code generated]
+  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, main) name-too-long/723.js (id hint: vendors) 20 bytes <{792}> ={60}= ={63}= ={210}= ={263}= ={425}= ={505}= ={628}= ={935}= >{49}< >{935}< [initial] [rendered] split chunk (cache group: defaultVendors)
+    > ./a ./index.js 1:0-47
+    > ./b ./index.js 2:0-47
+    > ./a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ./node_modules/y.js 20 bytes [built] [code generated]
+  chunk (runtime: main) name-too-long/main.js (main) 147 bytes (javascript) 6.68 KiB (runtime) >{60}< >{210}< >{263}< >{425}< >{628}< >{723}< >{862}< >{869}< >{935}< [entry] [rendered]
+    > ./ main
+    runtime modules 6.68 KiB 9 modules
+    ./index.js 147 bytes [built] [code generated]
+  chunk (runtime: cccccccccccccccccccccccccccccc, main) name-too-long/862.js (id hint: vendors) 20 bytes <{792}> ={349}= ={425}= ={628}= ={869}= ={935}= [initial] [rendered] split chunk (cache group: defaultVendors)
+    > ./c ./index.js 3:0-47
+    > ./c cccccccccccccccccccccccccccccc
+    ./node_modules/z.js 20 bytes [built] [code generated]
+  chunk (runtime: main) name-too-long/async-c.js (async-c) 116 bytes <{792}> ={425}= ={628}= ={862}= ={935}= [rendered]
+    > ./c ./index.js 3:0-47
+    ./c.js 116 bytes [built] [code generated]
+  chunk (runtime: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc, main) name-too-long/935.js 20 bytes <{210}> <{263}> <{425}> <{505}> <{628}> <{723}> <{792}> ={49}= ={60}= ={63}= ={349}= ={425}= ={628}= ={723}= ={862}= ={869}= [initial] [rendered] split chunk (cache group: default)
+    > ./b ./index.js 2:0-47
+    > ./c ./index.js 3:0-47
+    > ./g ./a.js 6:0-47
+    > ./b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    > ./c cccccccccccccccccccccccccccccc
+    ./f.js 20 bytes [built] [code generated]
   name-too-long (webpack x.x.x) compiled successfully
 
 custom-chunks-filter:
   Entrypoint main 11.5 KiB = custom-chunks-filter/main.js
   Entrypoint a 12.6 KiB = custom-chunks-filter/a.js
-  Entrypoint b 8.13 KiB = custom-chunks-filter/472.js 412 bytes custom-chunks-filter/616.js 412 bytes custom-chunks-filter/144.js 412 bytes custom-chunks-filter/744.js 412 bytes custom-chunks-filter/b.js 6.52 KiB
-  Entrypoint c 8.13 KiB = custom-chunks-filter/472.js 412 bytes custom-chunks-filter/388.js 412 bytes custom-chunks-filter/144.js 412 bytes custom-chunks-filter/744.js 412 bytes custom-chunks-filter/c.js 6.52 KiB
-  chunk (runtime: a, main) custom-chunks-filter/async-g.js (async-g) 45 bytes <{464}> <{472}> <{616}> <{744}> <{996}> ={144}= [rendered]
+  Entrypoint b 8.13 KiB = custom-chunks-filter/628.js 412 bytes custom-chunks-filter/723.js 412 bytes custom-chunks-filter/935.js 412 bytes custom-chunks-filter/425.js 412 bytes custom-chunks-filter/b.js 6.52 KiB
+  Entrypoint c 8.13 KiB = custom-chunks-filter/628.js 412 bytes custom-chunks-filter/862.js 412 bytes custom-chunks-filter/935.js 412 bytes custom-chunks-filter/425.js 412 bytes custom-chunks-filter/c.js 6.52 KiB
+  chunk (runtime: a, main) custom-chunks-filter/async-g.js (async-g) 45 bytes <{263}> <{425}> <{628}> <{723}> <{996}> ={935}= [rendered]
     > ./g ./a.js 6:0-47
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: a, b, c, main) custom-chunks-filter/144.js 20 bytes <{464}> <{472}> <{590}> <{616}> <{744}> <{996}> ={96}= ={152}= ={272}= ={276}= ={388}= ={472}= ={580}= ={616}= ={744}= [initial] [rendered] split chunk (cache group: default)
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
-    > ./g ./a.js 6:0-47
-    > ./b b
-    > ./c c
-    ./f.js 20 bytes [built] [code generated]
-  chunk (runtime: c) custom-chunks-filter/c.js (c) 116 bytes (javascript) 2.76 KiB (runtime) ={144}= ={388}= ={472}= ={744}= [entry] [rendered]
-    > ./c c
-    runtime modules 2.76 KiB 4 modules
-    ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: main) custom-chunks-filter/async-b.js (async-b) 116 bytes <{590}> ={144}= ={472}= ={616}= ={744}= [rendered]
+  chunk (runtime: main) custom-chunks-filter/async-b.js (async-b) 116 bytes <{792}> ={425}= ={628}= ={723}= ={935}= [rendered]
     > ./b ./index.js 2:0-47
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) custom-chunks-filter/async-c.js (async-c) 116 bytes <{590}> ={144}= ={388}= ={472}= ={744}= [rendered]
-    > ./c ./index.js 3:0-47
-    ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: c, main) custom-chunks-filter/388.js (id hint: vendors) 20 bytes <{590}> ={144}= ={152}= ={276}= ={472}= ={744}= [initial] [rendered] split chunk (cache group: defaultVendors)
-    > ./c ./index.js 3:0-47
-    > ./c c
-    ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: main) custom-chunks-filter/async-a.js (async-a) 185 bytes <{590}> ={472}= ={616}= ={744}= >{96}< >{144}< [rendered]
+  chunk (runtime: b) custom-chunks-filter/b.js (b) 116 bytes (javascript) 2.76 KiB (runtime) ={425}= ={628}= ={723}= ={935}= [entry] [rendered]
+    > ./b b
+    runtime modules 2.76 KiB 4 modules
+    ./b.js 116 bytes [built] [code generated]
+  chunk (runtime: main) custom-chunks-filter/async-a.js (async-a) 185 bytes <{792}> ={425}= ={628}= ={723}= >{49}< >{935}< [rendered]
     > ./a ./index.js 1:0-47
     ./a.js + 1 modules 185 bytes [built] [code generated]
-  chunk (runtime: b, c, main) custom-chunks-filter/472.js (id hint: vendors) 20 bytes <{590}> ={144}= ={152}= ={272}= ={276}= ={388}= ={464}= ={580}= ={616}= ={744}= >{96}< >{144}< [initial] [rendered] split chunk (cache group: defaultVendors)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    > ./c ./index.js 3:0-47
-    > ./b b
+  chunk (runtime: c) custom-chunks-filter/c.js (c) 116 bytes (javascript) 2.76 KiB (runtime) ={425}= ={628}= ={862}= ={935}= [entry] [rendered]
     > ./c c
-    ./node_modules/x.js 20 bytes [built] [code generated]
-  chunk (runtime: b) custom-chunks-filter/b.js (b) 116 bytes (javascript) 2.76 KiB (runtime) ={144}= ={472}= ={616}= ={744}= [entry] [rendered]
-    > ./b b
     runtime modules 2.76 KiB 4 modules
-    ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) custom-chunks-filter/main.js (main) 147 bytes (javascript) 6.69 KiB (runtime) >{144}< >{272}< >{276}< >{388}< >{464}< >{472}< >{616}< >{744}< [entry] [rendered]
-    > ./ main
-    runtime modules 6.69 KiB 9 modules
-    ./index.js 147 bytes [built] [code generated]
-  chunk (runtime: b, main) custom-chunks-filter/616.js (id hint: vendors) 20 bytes <{590}> ={144}= ={272}= ={464}= ={472}= ={580}= ={744}= >{96}< >{144}< [initial] [rendered] split chunk (cache group: defaultVendors)
-    > ./a ./index.js 1:0-47
-    > ./b ./index.js 2:0-47
-    > ./b b
-    ./node_modules/y.js 20 bytes [built] [code generated]
-  chunk (runtime: b, c, main) custom-chunks-filter/744.js 20 bytes <{590}> ={144}= ={152}= ={272}= ={276}= ={388}= ={464}= ={472}= ={580}= ={616}= >{96}< >{144}< [initial] [rendered] split chunk (cache group: default)
+    ./c.js 116 bytes [built] [code generated]
+  chunk (runtime: b, c, main) custom-chunks-filter/425.js 20 bytes <{792}> ={60}= ={199}= ={263}= ={390}= ={628}= ={723}= ={862}= ={869}= ={935}= >{49}< >{935}< [initial] [rendered] split chunk (cache group: default)
     > ./a ./index.js 1:0-47
     > ./b ./index.js 2:0-47
     > ./c ./index.js 3:0-47
     > ./b b
     > ./c c
     ./d.js 20 bytes [built] [code generated]
-  chunk (runtime: a) custom-chunks-filter/a.js (a) 245 bytes (javascript) 6.68 KiB (runtime) >{96}< >{144}< [entry] [rendered]
+  chunk (runtime: b, c, main) custom-chunks-filter/628.js (id hint: vendors) 20 bytes <{792}> ={60}= ={199}= ={263}= ={390}= ={425}= ={723}= ={862}= ={869}= ={935}= >{49}< >{935}< [initial] [rendered] split chunk (cache group: defaultVendors)
+    > ./a ./index.js 1:0-47
+    > ./b ./index.js 2:0-47
+    > ./c ./index.js 3:0-47
+    > ./b b
+    > ./c c
+    ./node_modules/x.js 20 bytes [built] [code generated]
+  chunk (runtime: b, main) custom-chunks-filter/723.js (id hint: vendors) 20 bytes <{792}> ={60}= ={199}= ={263}= ={425}= ={628}= ={935}= >{49}< >{935}< [initial] [rendered] split chunk (cache group: defaultVendors)
+    > ./a ./index.js 1:0-47
+    > ./b ./index.js 2:0-47
+    > ./b b
+    ./node_modules/y.js 20 bytes [built] [code generated]
+  chunk (runtime: main) custom-chunks-filter/main.js (main) 147 bytes (javascript) 6.69 KiB (runtime) >{60}< >{263}< >{425}< >{628}< >{723}< >{862}< >{869}< >{935}< [entry] [rendered]
+    > ./ main
+    runtime modules 6.69 KiB 9 modules
+    ./index.js 147 bytes [built] [code generated]
+  chunk (runtime: c, main) custom-chunks-filter/862.js (id hint: vendors) 20 bytes <{792}> ={390}= ={425}= ={628}= ={869}= ={935}= [initial] [rendered] split chunk (cache group: defaultVendors)
+    > ./c ./index.js 3:0-47
+    > ./c c
+    ./node_modules/z.js 20 bytes [built] [code generated]
+  chunk (runtime: main) custom-chunks-filter/async-c.js (async-c) 116 bytes <{792}> ={425}= ={628}= ={862}= ={935}= [rendered]
+    > ./c ./index.js 3:0-47
+    ./c.js 116 bytes [built] [code generated]
+  chunk (runtime: a, b, c, main) custom-chunks-filter/935.js 20 bytes <{263}> <{425}> <{628}> <{723}> <{792}> <{996}> ={49}= ={60}= ={199}= ={390}= ={425}= ={628}= ={723}= ={862}= ={869}= [initial] [rendered] split chunk (cache group: default)
+    > ./b ./index.js 2:0-47
+    > ./c ./index.js 3:0-47
+    > ./g ./a.js 6:0-47
+    > ./b b
+    > ./c c
+    ./f.js 20 bytes [built] [code generated]
+  chunk (runtime: a) custom-chunks-filter/a.js (a) 245 bytes (javascript) 6.68 KiB (runtime) >{49}< >{935}< [entry] [rendered]
     > ./a a
     runtime modules 6.68 KiB 9 modules
     dependent modules 60 bytes [dependent] 3 modules
@@ -3909,26 +3909,18 @@ custom-chunks-filter:
 
 custom-chunks-filter-in-cache-groups:
   Entrypoint main 11.3 KiB = custom-chunks-filter-in-cache-groups/main.js
-  Entrypoint a 14.6 KiB = custom-chunks-filter-in-cache-groups/892.js 860 bytes custom-chunks-filter-in-cache-groups/a.js 13.8 KiB
+  Entrypoint a 14.6 KiB = custom-chunks-filter-in-cache-groups/765.js 859 bytes custom-chunks-filter-in-cache-groups/a.js 13.8 KiB
   Entrypoint b 8.44 KiB = custom-chunks-filter-in-cache-groups/vendors.js 1.05 KiB custom-chunks-filter-in-cache-groups/b.js 7.39 KiB
   Entrypoint c 8.44 KiB = custom-chunks-filter-in-cache-groups/vendors.js 1.05 KiB custom-chunks-filter-in-cache-groups/c.js 7.39 KiB
-  chunk (runtime: a, main) custom-chunks-filter-in-cache-groups/async-g.js (async-g) 65 bytes <{275}> <{464}> <{892}> <{996}> [rendered]
+  chunk (runtime: a, main) custom-chunks-filter-in-cache-groups/async-g.js (async-g) 65 bytes <{96}> <{263}> <{765}> <{996}> [rendered]
     > ./g ./a.js 6:0-47
     dependent modules 20 bytes [dependent] 1 module
     ./g.js 45 bytes [built] [code generated]
-  chunk (runtime: c) custom-chunks-filter-in-cache-groups/c.js (c) 156 bytes (javascript) 2.76 KiB (runtime) ={275}= [entry] [rendered]
-    > ./c c
-    > x c
-    > y c
-    > z c
-    runtime modules 2.76 KiB 4 modules
-    dependent modules 40 bytes [dependent] 2 modules
-    ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: main) custom-chunks-filter-in-cache-groups/async-b.js (async-b) 156 bytes <{590}> ={275}= [rendered]
+  chunk (runtime: main) custom-chunks-filter-in-cache-groups/async-b.js (async-b) 156 bytes <{792}> ={96}= [rendered]
     > ./b ./index.js 2:0-47
     dependent modules 40 bytes [dependent] 2 modules
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: b, c, main) custom-chunks-filter-in-cache-groups/vendors.js (vendors) (id hint: vendors) 60 bytes <{590}> ={152}= ={272}= ={276}= ={464}= ={580}= >{96}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
+  chunk (runtime: b, c, main) custom-chunks-filter-in-cache-groups/vendors.js (vendors) (id hint: vendors) 60 bytes <{792}> ={60}= ={199}= ={263}= ={390}= ={869}= >{49}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
     > ./a ./index.js 1:0-47
     > ./b ./index.js 2:0-47
     > ./c ./index.js 3:0-47
@@ -3943,15 +3935,7 @@ custom-chunks-filter-in-cache-groups:
     ./node_modules/x.js 20 bytes [built] [code generated]
     ./node_modules/y.js 20 bytes [built] [code generated]
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: main) custom-chunks-filter-in-cache-groups/async-c.js (async-c) 156 bytes <{590}> ={275}= [rendered]
-    > ./c ./index.js 3:0-47
-    dependent modules 40 bytes [dependent] 2 modules
-    ./c.js 116 bytes [built] [code generated]
-  chunk (runtime: main) custom-chunks-filter-in-cache-groups/async-a.js (async-a) 205 bytes <{590}> ={275}= >{96}< [rendered]
-    > ./a ./index.js 1:0-47
-    dependent modules 20 bytes [dependent] 1 module
-    ./a.js + 1 modules 185 bytes [built] [code generated]
-  chunk (runtime: b) custom-chunks-filter-in-cache-groups/b.js (b) 156 bytes (javascript) 2.76 KiB (runtime) ={275}= [entry] [rendered]
+  chunk (runtime: b) custom-chunks-filter-in-cache-groups/b.js (b) 156 bytes (javascript) 2.76 KiB (runtime) ={96}= [entry] [rendered]
     > ./b b
     > x b
     > y b
@@ -3959,11 +3943,19 @@ custom-chunks-filter-in-cache-groups:
     runtime modules 2.76 KiB 4 modules
     dependent modules 40 bytes [dependent] 2 modules
     ./b.js 116 bytes [built] [code generated]
-  chunk (runtime: main) custom-chunks-filter-in-cache-groups/main.js (main) 147 bytes (javascript) 6.71 KiB (runtime) >{272}< >{275}< >{276}< >{464}< [entry] [rendered]
-    > ./ main
-    runtime modules 6.71 KiB 9 modules
-    ./index.js 147 bytes [built] [code generated]
-  chunk (runtime: a) custom-chunks-filter-in-cache-groups/892.js (id hint: vendors) 60 bytes ={996}= >{96}< [initial] [rendered] split chunk (cache group: defaultVendors)
+  chunk (runtime: main) custom-chunks-filter-in-cache-groups/async-a.js (async-a) 205 bytes <{792}> ={96}= >{49}< [rendered]
+    > ./a ./index.js 1:0-47
+    dependent modules 20 bytes [dependent] 1 module
+    ./a.js + 1 modules 185 bytes [built] [code generated]
+  chunk (runtime: c) custom-chunks-filter-in-cache-groups/c.js (c) 156 bytes (javascript) 2.76 KiB (runtime) ={96}= [entry] [rendered]
+    > ./c c
+    > x c
+    > y c
+    > z c
+    runtime modules 2.76 KiB 4 modules
+    dependent modules 40 bytes [dependent] 2 modules
+    ./c.js 116 bytes [built] [code generated]
+  chunk (runtime: a) custom-chunks-filter-in-cache-groups/765.js (id hint: vendors) 60 bytes ={996}= >{49}< [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./a a
     > x a
     > y a
@@ -3971,7 +3963,15 @@ custom-chunks-filter-in-cache-groups:
     ./node_modules/x.js 20 bytes [built] [code generated]
     ./node_modules/y.js 20 bytes [built] [code generated]
     ./node_modules/z.js 20 bytes [built] [code generated]
-  chunk (runtime: a) custom-chunks-filter-in-cache-groups/a.js (a) 205 bytes (javascript) 7.59 KiB (runtime) ={892}= >{96}< [entry] [rendered]
+  chunk (runtime: main) custom-chunks-filter-in-cache-groups/main.js (main) 147 bytes (javascript) 6.71 KiB (runtime) >{60}< >{96}< >{263}< >{869}< [entry] [rendered]
+    > ./ main
+    runtime modules 6.71 KiB 9 modules
+    ./index.js 147 bytes [built] [code generated]
+  chunk (runtime: main) custom-chunks-filter-in-cache-groups/async-c.js (async-c) 156 bytes <{792}> ={96}= [rendered]
+    > ./c ./index.js 3:0-47
+    dependent modules 40 bytes [dependent] 2 modules
+    ./c.js 116 bytes [built] [code generated]
+  chunk (runtime: a) custom-chunks-filter-in-cache-groups/a.js (a) 205 bytes (javascript) 7.59 KiB (runtime) ={765}= >{49}< [entry] [rendered]
     > ./a a
     > x a
     > y a
@@ -4023,17 +4023,17 @@ production (webpack x.x.x) compiled successfully"
 
 exports[`StatsTestCases should print correct stats for split-chunks-chunk-name 1`] = `
 "Entrypoint main 11.2 KiB = default/main.js
-chunk (runtime: main) default/async-c-1.js (async-c-1) (id hint: vendors) 122 bytes <{590}> [rendered] reused as split chunk (cache group: defaultVendors)
+chunk (runtime: main) default/async-b.js (async-b) (id hint: vendors) 122 bytes <{792}> [rendered] reused as split chunk (cache group: defaultVendors)
+  > b ./index.js 2:0-45
+  ./node_modules/b.js 122 bytes [built] [code generated]
+chunk (runtime: main) default/async-a.js (async-a) 20 bytes <{792}> [rendered]
+  > a ./index.js 1:0-45
+  ./node_modules/a.js 20 bytes [built] [code generated]
+chunk (runtime: main) default/async-c-1.js (async-c-1) (id hint: vendors) 122 bytes <{792}> [rendered] reused as split chunk (cache group: defaultVendors)
   > c ./index.js 3:0-47
   > c ./index.js 4:0-47
   ./node_modules/c.js 122 bytes [built] [code generated]
-chunk (runtime: main) default/async-b.js (async-b) (id hint: vendors) 122 bytes <{590}> [rendered] reused as split chunk (cache group: defaultVendors)
-  > b ./index.js 2:0-45
-  ./node_modules/b.js 122 bytes [built] [code generated]
-chunk (runtime: main) default/async-a.js (async-a) 20 bytes <{590}> [rendered]
-  > a ./index.js 1:0-45
-  ./node_modules/a.js 20 bytes [built] [code generated]
-chunk (runtime: main) default/main.js (main) 192 bytes (javascript) 6.65 KiB (runtime) >{136}< >{272}< >{464}< [entry] [rendered]
+chunk (runtime: main) default/main.js (main) 192 bytes (javascript) 6.65 KiB (runtime) >{60}< >{263}< >{511}< [entry] [rendered]
   > ./ main
   runtime modules 6.65 KiB 9 modules
   ./index.js 192 bytes [built] [code generated]
@@ -4042,37 +4042,37 @@ webpack x.x.x compiled successfully"
 
 exports[`StatsTestCases should print correct stats for split-chunks-combinations 1`] = `
 "Entrypoint main 11.7 KiB = main.js
-chunk (runtime: main) async-g.js (async-g) 132 bytes <{590}> [rendered]
+chunk (runtime: main) async-g.js (async-g) 132 bytes <{792}> [rendered]
   > ./g ./index.js 7:0-47
   dependent modules 87 bytes [dependent] 1 module
   ./g.js 45 bytes [built] [code generated]
-chunk (runtime: main) async-b.js (async-b) 70 bytes <{590}> ={712}= [rendered]
+chunk (runtime: main) async-b.js (async-b) 70 bytes <{792}> ={914}= [rendered]
   > ./b ./index.js 2:0-47
   ./b.js 70 bytes [built] [code generated]
-chunk (runtime: main) async-c.js (async-c) 132 bytes <{590}> [rendered]
-  > ./c ./index.js 3:0-47
-  dependent modules 87 bytes [dependent] 1 module
-  ./c.js 45 bytes [built] [code generated]
-chunk (runtime: main) async-f.js (async-f) 132 bytes <{590}> [rendered]
+chunk (runtime: main) async-f.js (async-f) 132 bytes <{792}> [rendered]
   > ./f ./index.js 6:0-47
   dependent modules 87 bytes [dependent] 1 module
   ./f.js 45 bytes [built] [code generated]
-chunk (runtime: main) async-a.js (async-a) 70 bytes <{590}> ={712}= [rendered]
-  > ./a ./index.js 1:0-47
-  ./a.js 70 bytes [built] [code generated]
-chunk (runtime: main) async-e.js (async-e) 132 bytes <{590}> [rendered]
+chunk (runtime: main) async-e.js (async-e) 132 bytes <{792}> [rendered]
   > ./e ./index.js 5:0-47
   dependent modules 87 bytes [dependent] 1 module
   ./e.js 45 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 343 bytes (javascript) 6.71 KiB (runtime) >{96}< >{272}< >{276}< >{288}< >{464}< >{476}< >{668}< >{712}< [entry] [rendered]
-  > ./ main
-  runtime modules 6.71 KiB 9 modules
-  ./index.js 343 bytes [built] [code generated]
-chunk (runtime: main) async-d.js (async-d) 132 bytes <{590}> [rendered]
+chunk (runtime: main) async-a.js (async-a) 70 bytes <{792}> ={914}= [rendered]
+  > ./a ./index.js 1:0-47
+  ./a.js 70 bytes [built] [code generated]
+chunk (runtime: main) async-d.js (async-d) 132 bytes <{792}> [rendered]
   > ./d ./index.js 4:0-47
   dependent modules 87 bytes [dependent] 1 module
   ./d.js 45 bytes [built] [code generated]
-chunk (runtime: main) 712.js 174 bytes <{590}> ={272}= ={464}= [rendered] split chunk (cache group: default)
+chunk (runtime: main) main.js (main) 343 bytes (javascript) 6.71 KiB (runtime) >{49}< >{60}< >{240}< >{251}< >{263}< >{442}< >{869}< >{914}< [entry] [rendered]
+  > ./ main
+  runtime modules 6.71 KiB 9 modules
+  ./index.js 343 bytes [built] [code generated]
+chunk (runtime: main) async-c.js (async-c) 132 bytes <{792}> [rendered]
+  > ./c ./index.js 3:0-47
+  dependent modules 87 bytes [dependent] 1 module
+  ./c.js 45 bytes [built] [code generated]
+chunk (runtime: main) 914.js 174 bytes <{792}> ={60}= ={263}= [rendered] split chunk (cache group: default)
   > ./a ./index.js 1:0-47
   > ./b ./index.js 2:0-47
   ./x.js 87 bytes [built] [code generated]
@@ -4082,46 +4082,46 @@ webpack x.x.x compiled successfully"
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-6413 1`] = `
 "Entrypoint main 11.3 KiB = main.js
-chunk (runtime: main) 176.js 45 bytes <{590}> ={272}= ={276}= ={464}= ={472}= [rendered] split chunk (cache group: default)
+chunk (runtime: main) async-b.js (async-b) 36 bytes <{792}> ={476}= ={628}= [rendered]
+  > ./b ./index.js 2:0-47
+  ./b.js 36 bytes [built] [code generated]
+chunk (runtime: main) async-a.js (async-a) 36 bytes <{792}> ={476}= ={628}= [rendered]
+  > ./a ./index.js 1:0-47
+  ./a.js 36 bytes [built] [code generated]
+chunk (runtime: main) 476.js 45 bytes <{792}> ={60}= ={263}= ={628}= ={869}= [rendered] split chunk (cache group: default)
   > ./a ./index.js 1:0-47
   > ./b ./index.js 2:0-47
   > ./c ./index.js 3:0-47
   ./common.js 45 bytes [built] [code generated]
-chunk (runtime: main) async-b.js (async-b) 36 bytes <{590}> ={176}= ={472}= [rendered]
-  > ./b ./index.js 2:0-47
-  ./b.js 36 bytes [built] [code generated]
-chunk (runtime: main) async-c.js (async-c) 36 bytes <{590}> ={176}= ={472}= [rendered]
-  > ./c ./index.js 3:0-47
-  ./c.js 36 bytes [built] [code generated]
-chunk (runtime: main) async-a.js (async-a) 36 bytes <{590}> ={176}= ={472}= [rendered]
-  > ./a ./index.js 1:0-47
-  ./a.js 36 bytes [built] [code generated]
-chunk (runtime: main) 472.js (id hint: vendors) 20 bytes <{590}> ={176}= ={272}= ={276}= ={464}= [rendered] split chunk (cache group: defaultVendors)
+chunk (runtime: main) 628.js (id hint: vendors) 20 bytes <{792}> ={60}= ={263}= ={476}= ={869}= [rendered] split chunk (cache group: defaultVendors)
   > ./a ./index.js 1:0-47
   > ./b ./index.js 2:0-47
   > ./c ./index.js 3:0-47
   ./node_modules/x.js 20 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.65 KiB (runtime) >{176}< >{272}< >{276}< >{464}< >{472}< [entry] [rendered]
+chunk (runtime: main) main.js (main) 147 bytes (javascript) 6.65 KiB (runtime) >{60}< >{263}< >{476}< >{628}< >{869}< [entry] [rendered]
   > ./ main
   runtime modules 6.65 KiB 9 modules
   ./index.js 147 bytes [built] [code generated]
+chunk (runtime: main) async-c.js (async-c) 36 bytes <{792}> ={476}= ={628}= [rendered]
+  > ./c ./index.js 3:0-47
+  ./c.js 36 bytes [built] [code generated]
 default (webpack x.x.x) compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-6696 1`] = `
-"Entrypoint main 13.4 KiB = vendors.js 412 bytes main.js 13 KiB
-chunk (runtime: main) async-b.js (async-b) 49 bytes <{275}> <{590}> [rendered]
+"Entrypoint main 13.4 KiB = vendors.js 411 bytes main.js 13 KiB
+chunk (runtime: main) async-b.js (async-b) 49 bytes <{96}> <{792}> [rendered]
   > ./b ./index.js 3:0-47
   dependent modules 20 bytes [dependent] 1 module
   ./b.js 29 bytes [built] [code generated]
-chunk (runtime: main) vendors.js (vendors) (id hint: vendors) 20 bytes ={590}= >{272}< >{464}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
+chunk (runtime: main) vendors.js (vendors) (id hint: vendors) 20 bytes ={792}= >{60}< >{263}< [initial] [rendered] split chunk (cache group: vendors) (name: vendors)
   > ./ main
   ./node_modules/y.js 20 bytes [built] [code generated]
-chunk (runtime: main) async-a.js (async-a) 49 bytes <{275}> <{590}> [rendered]
+chunk (runtime: main) async-a.js (async-a) 49 bytes <{96}> <{792}> [rendered]
   > ./a ./index.js 2:0-47
   dependent modules 20 bytes [dependent] 1 module
   ./a.js 29 bytes [built] [code generated]
-chunk (runtime: main) main.js (main) 134 bytes (javascript) 7.57 KiB (runtime) ={275}= >{272}< >{464}< [entry] [rendered]
+chunk (runtime: main) main.js (main) 134 bytes (javascript) 7.57 KiB (runtime) ={96}= >{60}< >{263}< [entry] [rendered]
   > ./ main
   runtime modules 7.57 KiB 10 modules
   ./index.js 134 bytes [built] [code generated]
@@ -4129,21 +4129,21 @@ default (webpack x.x.x) compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-issue-7401 1`] = `
-"Entrypoint a 6.42 KiB = 472.js 412 bytes a.js 6.02 KiB
+"Entrypoint a 6.42 KiB = 628.js 412 bytes a.js 6.02 KiB
 Entrypoint b 10.9 KiB = b.js
-Chunk Group c 795 bytes = 472.js 412 bytes c.js 383 bytes
-chunk (runtime: b) c.js (c) 35 bytes <{580}> ={472}= [rendered]
-  > ./c ./b.js 1:0-41
-  ./c.js 35 bytes [built] [code generated]
-chunk (runtime: a, b) 472.js (id hint: vendors) 20 bytes <{580}> ={152}= ={996}= [initial] [rendered] split chunk (cache group: defaultVendors)
-  > ./c ./b.js 1:0-41
-  > ./a a
-  ./node_modules/x.js 20 bytes [built] [code generated]
-chunk (runtime: b) b.js (b) 43 bytes (javascript) 6.61 KiB (runtime) >{152}< >{472}< [entry] [rendered]
+Chunk Group c 795 bytes = 628.js 412 bytes c.js 383 bytes
+chunk (runtime: b) b.js (b) 43 bytes (javascript) 6.61 KiB (runtime) >{390}< >{628}< [entry] [rendered]
   > ./b b
   runtime modules 6.61 KiB 9 modules
   ./b.js 43 bytes [built] [code generated]
-chunk (runtime: a) a.js (a) 35 bytes (javascript) 2.75 KiB (runtime) ={472}= [entry] [rendered]
+chunk (runtime: b) c.js (c) 35 bytes <{199}> ={628}= [rendered]
+  > ./c ./b.js 1:0-41
+  ./c.js 35 bytes [built] [code generated]
+chunk (runtime: a, b) 628.js (id hint: vendors) 20 bytes <{199}> ={390}= ={996}= [initial] [rendered] split chunk (cache group: defaultVendors)
+  > ./c ./b.js 1:0-41
+  > ./a a
+  ./node_modules/x.js 20 bytes [built] [code generated]
+chunk (runtime: a) a.js (a) 35 bytes (javascript) 2.75 KiB (runtime) ={628}= [entry] [rendered]
   > ./a a
   runtime modules 2.75 KiB 4 modules
   ./a.js 35 bytes [built] [code generated]
@@ -4152,82 +4152,54 @@ default (webpack x.x.x) compiled successfully"
 
 exports[`StatsTestCases should print correct stats for split-chunks-keep-remaining-size 1`] = `
 "Entrypoint main 11.4 KiB = default/main.js
-chunk (runtime: main) default/76.js (id hint: vendors) 252 bytes <{590}> ={668}= [rendered] split chunk (cache group: defaultVendors)
+chunk (runtime: main) default/async-b.js (async-b) 50 bytes <{792}> ={784}= [rendered]
+  > ./b ./index.js 2:0-47
+  ./b.js 50 bytes [built] [code generated]
+chunk (runtime: main) default/async-a.js (async-a) 176 bytes <{792}> [rendered]
+  > ./a ./index.js 1:0-47
+  ./a.js + 1 modules 176 bytes [built] [code generated]
+chunk (runtime: main) default/async-d.js (async-d) 84 bytes <{792}> ={670}= [rendered]
+  > ./d ./index.js 4:0-47
+  ./d.js 84 bytes [built] [code generated]
+chunk (runtime: main) default/670.js (id hint: vendors) 252 bytes <{792}> ={442}= [rendered] split chunk (cache group: defaultVendors)
   > ./d ./index.js 4:0-47
   ./node_modules/shared.js?3 126 bytes [built] [code generated]
   ./node_modules/shared.js?4 126 bytes [built] [code generated]
-chunk (runtime: main) default/async-b.js (async-b) 50 bytes <{590}> ={916}= [rendered]
-  > ./b ./index.js 2:0-47
-  ./b.js 50 bytes [built] [code generated]
-chunk (runtime: main) default/async-c.js (async-c) 50 bytes <{590}> ={916}= [rendered]
-  > ./c ./index.js 3:0-47
-  ./c.js 50 bytes [built] [code generated]
-chunk (runtime: main) default/async-a.js (async-a) 176 bytes <{590}> [rendered]
-  > ./a ./index.js 1:0-47
-  ./a.js + 1 modules 176 bytes [built] [code generated]
-chunk (runtime: main) default/main.js (main) 196 bytes (javascript) 6.68 KiB (runtime) >{76}< >{272}< >{276}< >{464}< >{668}< >{916}< [entry] [rendered]
-  > ./ main
-  runtime modules 6.68 KiB 9 modules
-  ./index.js 196 bytes [built] [code generated]
-chunk (runtime: main) default/async-d.js (async-d) 84 bytes <{590}> ={76}= [rendered]
-  > ./d ./index.js 4:0-47
-  ./d.js 84 bytes [built] [code generated]
-chunk (runtime: main) default/916.js (id hint: vendors) 126 bytes <{590}> ={272}= ={276}= [rendered] split chunk (cache group: defaultVendors)
+chunk (runtime: main) default/784.js (id hint: vendors) 126 bytes <{792}> ={60}= ={869}= [rendered] split chunk (cache group: defaultVendors)
   > ./b ./index.js 2:0-47
   > ./c ./index.js 3:0-47
   ./node_modules/shared.js?2 126 bytes [built] [code generated]
+chunk (runtime: main) default/main.js (main) 196 bytes (javascript) 6.68 KiB (runtime) >{60}< >{263}< >{442}< >{670}< >{784}< >{869}< [entry] [rendered]
+  > ./ main
+  runtime modules 6.68 KiB 9 modules
+  ./index.js 196 bytes [built] [code generated]
+chunk (runtime: main) default/async-c.js (async-c) 50 bytes <{792}> ={784}= [rendered]
+  > ./c ./index.js 3:0-47
+  ./c.js 50 bytes [built] [code generated]
 webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-max-size 1`] = `
 "production:
   Entrypoint main 31.8 KiB = 13 assets
-  chunk (runtime: main) prod-main-1443e336.js (main-1443e336) 594 bytes ={96}= ={216}= ={384}= ={392}= ={480}= ={496}= ={536}= ={592}= ={728}= ={876}= ={968}= ={976}= [initial] [rendered]
-    > ./ main
-    ./subfolder/small.js?1 66 bytes [built] [code generated]
-    ./subfolder/small.js?2 66 bytes [built] [code generated]
-    ./subfolder/small.js?3 66 bytes [built] [code generated]
-    ./subfolder/small.js?4 66 bytes [built] [code generated]
-    ./subfolder/small.js?5 66 bytes [built] [code generated]
-    ./subfolder/small.js?6 66 bytes [built] [code generated]
-    ./subfolder/small.js?7 66 bytes [built] [code generated]
-    ./subfolder/small.js?8 66 bytes [built] [code generated]
-    ./subfolder/small.js?9 66 bytes [built] [code generated]
-  chunk (runtime: main) prod-96.js (id hint: vendors) 399 bytes ={91}= ={216}= ={384}= ={392}= ={480}= ={496}= ={536}= ={592}= ={728}= ={876}= ={968}= ={976}= [initial] [rendered] split chunk (cache group: defaultVendors)
-    > ./ main
-    ./node_modules/big.js?1 267 bytes [built] [code generated]
-    ./node_modules/small.js?1 66 bytes [built] [code generated]
-    ./node_modules/small.js?2 66 bytes [built] [code generated]
-  chunk (runtime: main) prod-main-6bb16544.js (main-6bb16544) 1.57 KiB ={91}= ={96}= ={384}= ={392}= ={480}= ={496}= ={536}= ={592}= ={728}= ={876}= ={968}= ={976}= [initial] [rendered]
+  chunk (runtime: main) prod-main-6bb16544.js (main-6bb16544) 1.57 KiB ={59}= ={121}= ={124}= ={161}= ={181}= ={241}= ={273}= ={382}= ={409}= ={808}= ={942}= ={945}= [initial] [rendered]
     > ./ main
     ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
-  chunk (runtime: main) prod-main-2f7dcf2e.js (main-2f7dcf2e) 594 bytes ={91}= ={96}= ={216}= ={392}= ={480}= ={496}= ={536}= ={592}= ={728}= ={876}= ={968}= ={976}= [initial] [rendered]
+  chunk (runtime: main) prod-main-1df31ce3.js (main-1df31ce3) 1.19 KiB ={37}= ={121}= ={124}= ={161}= ={181}= ={241}= ={273}= ={382}= ={409}= ={808}= ={942}= ={945}= [initial] [rendered]
     > ./ main
-    ./inner-module/small.js?1 66 bytes [built] [code generated]
-    ./inner-module/small.js?2 66 bytes [built] [code generated]
-    ./inner-module/small.js?3 66 bytes [built] [code generated]
-    ./inner-module/small.js?4 66 bytes [built] [code generated]
-    ./inner-module/small.js?5 66 bytes [built] [code generated]
-    ./inner-module/small.js?6 66 bytes [built] [code generated]
-    ./inner-module/small.js?7 66 bytes [built] [code generated]
-    ./inner-module/small.js?8 66 bytes [built] [code generated]
-    ./inner-module/small.js?9 66 bytes [built] [code generated]
-  chunk (runtime: main) prod-main-89a43a0f.js (main-89a43a0f) 1.57 KiB ={91}= ={96}= ={216}= ={384}= ={480}= ={496}= ={536}= ={592}= ={728}= ={876}= ={968}= ={976}= [initial] [rendered]
-    > ./ main
-    ./very-big.js?3 1.57 KiB [built] [code generated]
-  chunk (runtime: main) prod-main-10f51d07.js (main-10f51d07) 534 bytes ={91}= ={96}= ={216}= ={384}= ={392}= ={496}= ={536}= ={592}= ={728}= ={876}= ={968}= ={976}= [initial] [rendered]
+    ./index.js 1.19 KiB [built] [code generated]
+  chunk (runtime: main) prod-main-10f51d07.js (main-10f51d07) 534 bytes ={37}= ={59}= ={124}= ={161}= ={181}= ={241}= ={273}= ={382}= ={409}= ={808}= ={942}= ={945}= [initial] [rendered]
     > ./ main
     ./big.js?1 267 bytes [built] [code generated]
     ./big.js?2 267 bytes [built] [code generated]
-  chunk (runtime: main) prod-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.01 KiB (runtime) ={91}= ={96}= ={216}= ={384}= ={392}= ={480}= ={536}= ={592}= ={728}= ={876}= ={968}= ={976}= [entry] [rendered]
+  chunk (runtime: main) prod-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.01 KiB (runtime) ={37}= ={59}= ={121}= ={161}= ={181}= ={241}= ={273}= ={382}= ={409}= ={808}= ={942}= ={945}= [entry] [rendered]
     > ./ main
     runtime modules 3.01 KiB 5 modules
     ./very-big.js?1 1.57 KiB [built] [code generated]
-  chunk (runtime: main) prod-main-5cfff2c6.js (main-5cfff2c6) 534 bytes ={91}= ={96}= ={216}= ={384}= ={392}= ={480}= ={496}= ={592}= ={728}= ={876}= ={968}= ={976}= [initial] [rendered]
+  chunk (runtime: main) prod-main-77a8c116.js (main-77a8c116) 1.57 KiB ={37}= ={59}= ={121}= ={124}= ={181}= ={241}= ={273}= ={382}= ={409}= ={808}= ={942}= ={945}= [initial] [rendered]
     > ./ main
-    ./subfolder/big.js?1 267 bytes [built] [code generated]
-    ./subfolder/big.js?2 267 bytes [built] [code generated]
-  chunk (runtime: main) prod-main-e7c5ace7.js (main-e7c5ace7) 594 bytes ={91}= ={96}= ={216}= ={384}= ={392}= ={480}= ={496}= ={536}= ={728}= ={876}= ={968}= ={976}= [initial] [rendered]
+    ./very-big.js?2 1.57 KiB [built] [code generated]
+  chunk (runtime: main) prod-main-e7c5ace7.js (main-e7c5ace7) 594 bytes ={37}= ={59}= ={121}= ={124}= ={161}= ={241}= ={273}= ={382}= ={409}= ={808}= ={942}= ={945}= [initial] [rendered]
     > ./ main
     ./small.js?1 66 bytes [built] [code generated]
     ./small.js?2 66 bytes [built] [code generated]
@@ -4238,22 +4210,50 @@ exports[`StatsTestCases should print correct stats for split-chunks-max-size 1`]
     ./small.js?7 66 bytes [built] [code generated]
     ./small.js?8 66 bytes [built] [code generated]
     ./small.js?9 66 bytes [built] [code generated]
-  chunk (runtime: main) prod-main-3c98d7c3.js (main-3c98d7c3) 531 bytes ={91}= ={96}= ={216}= ={384}= ={392}= ={480}= ={496}= ={536}= ={592}= ={876}= ={968}= ={976}= [initial] [rendered]
+  chunk (runtime: main) prod-241.js (id hint: vendors) 399 bytes ={37}= ={59}= ={121}= ={124}= ={161}= ={181}= ={273}= ={382}= ={409}= ={808}= ={942}= ={945}= [initial] [rendered] split chunk (cache group: defaultVendors)
+    > ./ main
+    ./node_modules/big.js?1 267 bytes [built] [code generated]
+    ./node_modules/small.js?1 66 bytes [built] [code generated]
+    ./node_modules/small.js?2 66 bytes [built] [code generated]
+  chunk (runtime: main) prod-273.js (id hint: vendors) 1.57 KiB ={37}= ={59}= ={121}= ={124}= ={161}= ={181}= ={241}= ={382}= ={409}= ={808}= ={942}= ={945}= [initial] [rendered] split chunk (cache group: defaultVendors)
+    > ./ main
+    ./node_modules/very-big.js?1 1.57 KiB [built] [code generated]
+  chunk (runtime: main) prod-main-5cfff2c6.js (main-5cfff2c6) 534 bytes ={37}= ={59}= ={121}= ={124}= ={161}= ={181}= ={241}= ={273}= ={409}= ={808}= ={942}= ={945}= [initial] [rendered]
+    > ./ main
+    ./subfolder/big.js?1 267 bytes [built] [code generated]
+    ./subfolder/big.js?2 267 bytes [built] [code generated]
+  chunk (runtime: main) prod-main-3c98d7c3.js (main-3c98d7c3) 531 bytes ={37}= ={59}= ={121}= ={124}= ={161}= ={181}= ={241}= ={273}= ={382}= ={808}= ={942}= ={945}= [initial] [rendered]
     > ./ main
     ./in-some-directory/big.js?1 267 bytes [built] [code generated]
     ./in-some-directory/small.js?1 66 bytes [built] [code generated]
     ./in-some-directory/small.js?2 66 bytes [built] [code generated]
     ./in-some-directory/small.js?3 66 bytes [built] [code generated]
     ./in-some-directory/small.js?4 66 bytes [built] [code generated]
-  chunk (runtime: main) prod-876.js (id hint: vendors) 1.57 KiB ={91}= ={96}= ={216}= ={384}= ={392}= ={480}= ={496}= ={536}= ={592}= ={728}= ={968}= ={976}= [initial] [rendered] split chunk (cache group: defaultVendors)
+  chunk (runtime: main) prod-main-2f7dcf2e.js (main-2f7dcf2e) 594 bytes ={37}= ={59}= ={121}= ={124}= ={161}= ={181}= ={241}= ={273}= ={382}= ={409}= ={942}= ={945}= [initial] [rendered]
     > ./ main
-    ./node_modules/very-big.js?1 1.57 KiB [built] [code generated]
-  chunk (runtime: main) prod-main-1df31ce3.js (main-1df31ce3) 1.19 KiB ={91}= ={96}= ={216}= ={384}= ={392}= ={480}= ={496}= ={536}= ={592}= ={728}= ={876}= ={976}= [initial] [rendered]
+    ./inner-module/small.js?1 66 bytes [built] [code generated]
+    ./inner-module/small.js?2 66 bytes [built] [code generated]
+    ./inner-module/small.js?3 66 bytes [built] [code generated]
+    ./inner-module/small.js?4 66 bytes [built] [code generated]
+    ./inner-module/small.js?5 66 bytes [built] [code generated]
+    ./inner-module/small.js?6 66 bytes [built] [code generated]
+    ./inner-module/small.js?7 66 bytes [built] [code generated]
+    ./inner-module/small.js?8 66 bytes [built] [code generated]
+    ./inner-module/small.js?9 66 bytes [built] [code generated]
+  chunk (runtime: main) prod-main-1443e336.js (main-1443e336) 594 bytes ={37}= ={59}= ={121}= ={124}= ={161}= ={181}= ={241}= ={273}= ={382}= ={409}= ={808}= ={945}= [initial] [rendered]
     > ./ main
-    ./index.js 1.19 KiB [built] [code generated]
-  chunk (runtime: main) prod-main-77a8c116.js (main-77a8c116) 1.57 KiB ={91}= ={96}= ={216}= ={384}= ={392}= ={480}= ={496}= ={536}= ={592}= ={728}= ={876}= ={968}= [initial] [rendered]
+    ./subfolder/small.js?1 66 bytes [built] [code generated]
+    ./subfolder/small.js?2 66 bytes [built] [code generated]
+    ./subfolder/small.js?3 66 bytes [built] [code generated]
+    ./subfolder/small.js?4 66 bytes [built] [code generated]
+    ./subfolder/small.js?5 66 bytes [built] [code generated]
+    ./subfolder/small.js?6 66 bytes [built] [code generated]
+    ./subfolder/small.js?7 66 bytes [built] [code generated]
+    ./subfolder/small.js?8 66 bytes [built] [code generated]
+    ./subfolder/small.js?9 66 bytes [built] [code generated]
+  chunk (runtime: main) prod-main-89a43a0f.js (main-89a43a0f) 1.57 KiB ={37}= ={59}= ={121}= ={124}= ={161}= ={181}= ={241}= ={273}= ={382}= ={409}= ={808}= ={942}= [initial] [rendered]
     > ./ main
-    ./very-big.js?2 1.57 KiB [built] [code generated]
+    ./very-big.js?3 1.57 KiB [built] [code generated]
   production (webpack x.x.x) compiled successfully
 
 development:
@@ -4334,30 +4334,20 @@ development:
 
 switched:
   Entrypoint main 31.5 KiB = 9 assets
-  chunk (runtime: main) switched-96.js (id hint: vendors) 399 bytes ={192}= ={216}= ={392}= ={476}= ={496}= ={876}= ={968}= ={976}= [initial] [rendered] split chunk (cache group: defaultVendors)
-    > ./ main
-    ./node_modules/big.js?1 267 bytes [built] [code generated]
-    ./node_modules/small.js?1 66 bytes [built] [code generated]
-    ./node_modules/small.js?2 66 bytes [built] [code generated]
-  chunk (runtime: main) switched-main-879072e3.js (main-879072e3) 1.68 KiB ={96}= ={216}= ={392}= ={476}= ={496}= ={876}= ={968}= ={976}= [initial] [rendered]
-    > ./ main
-    modules by path ./subfolder/*.js 1.1 KiB
-      ./subfolder/big.js?1 267 bytes [built] [code generated]
-      ./subfolder/big.js?2 267 bytes [built] [code generated]
-      ./subfolder/small.js?1 66 bytes [built] [code generated]
-      + 8 modules
-    modules by path ./*.js 594 bytes
-      ./small.js?1 66 bytes [built] [code generated]
-      ./small.js?2 66 bytes [built] [code generated]
-      ./small.js?3 66 bytes [built] [code generated]
-      + 6 modules
-  chunk (runtime: main) switched-main-6bb16544.js (main-6bb16544) 1.57 KiB ={96}= ={192}= ={392}= ={476}= ={496}= ={876}= ={968}= ={976}= [initial] [rendered]
+  chunk (runtime: main) switched-main-6bb16544.js (main-6bb16544) 1.57 KiB ={59}= ={124}= ={161}= ={210}= ={241}= ={273}= ={866}= ={945}= [initial] [rendered]
     > ./ main
     ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
-  chunk (runtime: main) switched-main-89a43a0f.js (main-89a43a0f) 1.57 KiB ={96}= ={192}= ={216}= ={476}= ={496}= ={876}= ={968}= ={976}= [initial] [rendered]
+  chunk (runtime: main) switched-main-1df31ce3.js (main-1df31ce3) 1.19 KiB ={37}= ={124}= ={161}= ={210}= ={241}= ={273}= ={866}= ={945}= [initial] [rendered]
     > ./ main
-    ./very-big.js?3 1.57 KiB [built] [code generated]
-  chunk (runtime: main) switched-main-7aeafcb2.js (main-7aeafcb2) 1.62 KiB ={96}= ={192}= ={216}= ={392}= ={496}= ={876}= ={968}= ={976}= [initial] [rendered]
+    ./index.js 1.19 KiB [built] [code generated]
+  chunk (runtime: main) switched-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.01 KiB (runtime) ={37}= ={59}= ={161}= ={210}= ={241}= ={273}= ={866}= ={945}= [entry] [rendered]
+    > ./ main
+    runtime modules 3.01 KiB 5 modules
+    ./very-big.js?1 1.57 KiB [built] [code generated]
+  chunk (runtime: main) switched-main-77a8c116.js (main-77a8c116) 1.57 KiB ={37}= ={59}= ={124}= ={210}= ={241}= ={273}= ={866}= ={945}= [initial] [rendered]
+    > ./ main
+    ./very-big.js?2 1.57 KiB [built] [code generated]
+  chunk (runtime: main) switched-main-7aeafcb2.js (main-7aeafcb2) 1.62 KiB ={37}= ={59}= ={124}= ={161}= ={241}= ={273}= ={866}= ={945}= [initial] [rendered]
     > ./ main
     modules by path ./inner-module/*.js 594 bytes
       ./inner-module/small.js?1 66 bytes [built] [code generated]
@@ -4369,19 +4359,29 @@ switched:
     modules by path ./*.js 534 bytes
       ./big.js?1 267 bytes [built] [code generated]
       ./big.js?2 267 bytes [built] [code generated]
-  chunk (runtime: main) switched-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.01 KiB (runtime) ={96}= ={192}= ={216}= ={392}= ={476}= ={876}= ={968}= ={976}= [entry] [rendered]
+  chunk (runtime: main) switched-241.js (id hint: vendors) 399 bytes ={37}= ={59}= ={124}= ={161}= ={210}= ={273}= ={866}= ={945}= [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./ main
-    runtime modules 3.01 KiB 5 modules
-    ./very-big.js?1 1.57 KiB [built] [code generated]
-  chunk (runtime: main) switched-876.js (id hint: vendors) 1.57 KiB ={96}= ={192}= ={216}= ={392}= ={476}= ={496}= ={968}= ={976}= [initial] [rendered] split chunk (cache group: defaultVendors)
+    ./node_modules/big.js?1 267 bytes [built] [code generated]
+    ./node_modules/small.js?1 66 bytes [built] [code generated]
+    ./node_modules/small.js?2 66 bytes [built] [code generated]
+  chunk (runtime: main) switched-273.js (id hint: vendors) 1.57 KiB ={37}= ={59}= ={124}= ={161}= ={210}= ={241}= ={866}= ={945}= [initial] [rendered] split chunk (cache group: defaultVendors)
     > ./ main
     ./node_modules/very-big.js?1 1.57 KiB [built] [code generated]
-  chunk (runtime: main) switched-main-1df31ce3.js (main-1df31ce3) 1.19 KiB ={96}= ={192}= ={216}= ={392}= ={476}= ={496}= ={876}= ={976}= [initial] [rendered]
+  chunk (runtime: main) switched-main-879072e3.js (main-879072e3) 1.68 KiB ={37}= ={59}= ={124}= ={161}= ={210}= ={241}= ={273}= ={945}= [initial] [rendered]
     > ./ main
-    ./index.js 1.19 KiB [built] [code generated]
-  chunk (runtime: main) switched-main-77a8c116.js (main-77a8c116) 1.57 KiB ={96}= ={192}= ={216}= ={392}= ={476}= ={496}= ={876}= ={968}= [initial] [rendered]
+    modules by path ./subfolder/*.js 1.1 KiB
+      ./subfolder/big.js?1 267 bytes [built] [code generated]
+      ./subfolder/big.js?2 267 bytes [built] [code generated]
+      ./subfolder/small.js?1 66 bytes [built] [code generated]
+      + 8 modules
+    modules by path ./*.js 594 bytes
+      ./small.js?1 66 bytes [built] [code generated]
+      ./small.js?2 66 bytes [built] [code generated]
+      ./small.js?3 66 bytes [built] [code generated]
+      + 6 modules
+  chunk (runtime: main) switched-main-89a43a0f.js (main-89a43a0f) 1.57 KiB ={37}= ={59}= ={124}= ={161}= ={210}= ={241}= ={273}= ={866}= [initial] [rendered]
     > ./ main
-    ./very-big.js?2 1.57 KiB [built] [code generated]
+    ./very-big.js?3 1.57 KiB [built] [code generated]
 
   WARNING in SplitChunksPlugin
   Cache group defaultVendors
@@ -4397,52 +4397,24 @@ switched:
 
 zero-min:
   Entrypoint main 31.8 KiB = 13 assets
-  chunk (runtime: main) zero-min-main-1443e336.js (main-1443e336) 594 bytes ={96}= ={216}= ={384}= ={392}= ={480}= ={496}= ={536}= ={592}= ={728}= ={876}= ={968}= ={976}= [initial] [rendered]
-    > ./ main
-    ./subfolder/small.js?1 66 bytes [built] [code generated]
-    ./subfolder/small.js?2 66 bytes [built] [code generated]
-    ./subfolder/small.js?3 66 bytes [built] [code generated]
-    ./subfolder/small.js?4 66 bytes [built] [code generated]
-    ./subfolder/small.js?5 66 bytes [built] [code generated]
-    ./subfolder/small.js?6 66 bytes [built] [code generated]
-    ./subfolder/small.js?7 66 bytes [built] [code generated]
-    ./subfolder/small.js?8 66 bytes [built] [code generated]
-    ./subfolder/small.js?9 66 bytes [built] [code generated]
-  chunk (runtime: main) zero-min-96.js (id hint: vendors) 399 bytes ={91}= ={216}= ={384}= ={392}= ={480}= ={496}= ={536}= ={592}= ={728}= ={876}= ={968}= ={976}= [initial] [rendered] split chunk (cache group: defaultVendors)
-    > ./ main
-    ./node_modules/big.js?1 267 bytes [built] [code generated]
-    ./node_modules/small.js?1 66 bytes [built] [code generated]
-    ./node_modules/small.js?2 66 bytes [built] [code generated]
-  chunk (runtime: main) zero-min-main-6bb16544.js (main-6bb16544) 1.57 KiB ={91}= ={96}= ={384}= ={392}= ={480}= ={496}= ={536}= ={592}= ={728}= ={876}= ={968}= ={976}= [initial] [rendered]
+  chunk (runtime: main) zero-min-main-6bb16544.js (main-6bb16544) 1.57 KiB ={59}= ={121}= ={124}= ={161}= ={181}= ={241}= ={273}= ={382}= ={409}= ={808}= ={942}= ={945}= [initial] [rendered]
     > ./ main
     ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
-  chunk (runtime: main) zero-min-main-2f7dcf2e.js (main-2f7dcf2e) 594 bytes ={91}= ={96}= ={216}= ={392}= ={480}= ={496}= ={536}= ={592}= ={728}= ={876}= ={968}= ={976}= [initial] [rendered]
+  chunk (runtime: main) zero-min-main-1df31ce3.js (main-1df31ce3) 1.19 KiB ={37}= ={121}= ={124}= ={161}= ={181}= ={241}= ={273}= ={382}= ={409}= ={808}= ={942}= ={945}= [initial] [rendered]
     > ./ main
-    ./inner-module/small.js?1 66 bytes [built] [code generated]
-    ./inner-module/small.js?2 66 bytes [built] [code generated]
-    ./inner-module/small.js?3 66 bytes [built] [code generated]
-    ./inner-module/small.js?4 66 bytes [built] [code generated]
-    ./inner-module/small.js?5 66 bytes [built] [code generated]
-    ./inner-module/small.js?6 66 bytes [built] [code generated]
-    ./inner-module/small.js?7 66 bytes [built] [code generated]
-    ./inner-module/small.js?8 66 bytes [built] [code generated]
-    ./inner-module/small.js?9 66 bytes [built] [code generated]
-  chunk (runtime: main) zero-min-main-89a43a0f.js (main-89a43a0f) 1.57 KiB ={91}= ={96}= ={216}= ={384}= ={480}= ={496}= ={536}= ={592}= ={728}= ={876}= ={968}= ={976}= [initial] [rendered]
-    > ./ main
-    ./very-big.js?3 1.57 KiB [built] [code generated]
-  chunk (runtime: main) zero-min-main-10f51d07.js (main-10f51d07) 534 bytes ={91}= ={96}= ={216}= ={384}= ={392}= ={496}= ={536}= ={592}= ={728}= ={876}= ={968}= ={976}= [initial] [rendered]
+    ./index.js 1.19 KiB [built] [code generated]
+  chunk (runtime: main) zero-min-main-10f51d07.js (main-10f51d07) 534 bytes ={37}= ={59}= ={124}= ={161}= ={181}= ={241}= ={273}= ={382}= ={409}= ={808}= ={942}= ={945}= [initial] [rendered]
     > ./ main
     ./big.js?1 267 bytes [built] [code generated]
     ./big.js?2 267 bytes [built] [code generated]
-  chunk (runtime: main) zero-min-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.01 KiB (runtime) ={91}= ={96}= ={216}= ={384}= ={392}= ={480}= ={536}= ={592}= ={728}= ={876}= ={968}= ={976}= [entry] [rendered]
+  chunk (runtime: main) zero-min-main-12217e1d.js (main-12217e1d) 1.57 KiB (javascript) 3.01 KiB (runtime) ={37}= ={59}= ={121}= ={161}= ={181}= ={241}= ={273}= ={382}= ={409}= ={808}= ={942}= ={945}= [entry] [rendered]
     > ./ main
     runtime modules 3.01 KiB 5 modules
     ./very-big.js?1 1.57 KiB [built] [code generated]
-  chunk (runtime: main) zero-min-main-5cfff2c6.js (main-5cfff2c6) 534 bytes ={91}= ={96}= ={216}= ={384}= ={392}= ={480}= ={496}= ={592}= ={728}= ={876}= ={968}= ={976}= [initial] [rendered]
+  chunk (runtime: main) zero-min-main-77a8c116.js (main-77a8c116) 1.57 KiB ={37}= ={59}= ={121}= ={124}= ={181}= ={241}= ={273}= ={382}= ={409}= ={808}= ={942}= ={945}= [initial] [rendered]
     > ./ main
-    ./subfolder/big.js?1 267 bytes [built] [code generated]
-    ./subfolder/big.js?2 267 bytes [built] [code generated]
-  chunk (runtime: main) zero-min-main-e7c5ace7.js (main-e7c5ace7) 594 bytes ={91}= ={96}= ={216}= ={384}= ={392}= ={480}= ={496}= ={536}= ={728}= ={876}= ={968}= ={976}= [initial] [rendered]
+    ./very-big.js?2 1.57 KiB [built] [code generated]
+  chunk (runtime: main) zero-min-main-e7c5ace7.js (main-e7c5ace7) 594 bytes ={37}= ={59}= ={121}= ={124}= ={161}= ={241}= ={273}= ={382}= ={409}= ={808}= ={942}= ={945}= [initial] [rendered]
     > ./ main
     ./small.js?1 66 bytes [built] [code generated]
     ./small.js?2 66 bytes [built] [code generated]
@@ -4453,112 +4425,83 @@ zero-min:
     ./small.js?7 66 bytes [built] [code generated]
     ./small.js?8 66 bytes [built] [code generated]
     ./small.js?9 66 bytes [built] [code generated]
-  chunk (runtime: main) zero-min-main-3c98d7c3.js (main-3c98d7c3) 531 bytes ={91}= ={96}= ={216}= ={384}= ={392}= ={480}= ={496}= ={536}= ={592}= ={876}= ={968}= ={976}= [initial] [rendered]
+  chunk (runtime: main) zero-min-241.js (id hint: vendors) 399 bytes ={37}= ={59}= ={121}= ={124}= ={161}= ={181}= ={273}= ={382}= ={409}= ={808}= ={942}= ={945}= [initial] [rendered] split chunk (cache group: defaultVendors)
+    > ./ main
+    ./node_modules/big.js?1 267 bytes [built] [code generated]
+    ./node_modules/small.js?1 66 bytes [built] [code generated]
+    ./node_modules/small.js?2 66 bytes [built] [code generated]
+  chunk (runtime: main) zero-min-273.js (id hint: vendors) 1.57 KiB ={37}= ={59}= ={121}= ={124}= ={161}= ={181}= ={241}= ={382}= ={409}= ={808}= ={942}= ={945}= [initial] [rendered] split chunk (cache group: defaultVendors)
+    > ./ main
+    ./node_modules/very-big.js?1 1.57 KiB [built] [code generated]
+  chunk (runtime: main) zero-min-main-5cfff2c6.js (main-5cfff2c6) 534 bytes ={37}= ={59}= ={121}= ={124}= ={161}= ={181}= ={241}= ={273}= ={409}= ={808}= ={942}= ={945}= [initial] [rendered]
+    > ./ main
+    ./subfolder/big.js?1 267 bytes [built] [code generated]
+    ./subfolder/big.js?2 267 bytes [built] [code generated]
+  chunk (runtime: main) zero-min-main-3c98d7c3.js (main-3c98d7c3) 531 bytes ={37}= ={59}= ={121}= ={124}= ={161}= ={181}= ={241}= ={273}= ={382}= ={808}= ={942}= ={945}= [initial] [rendered]
     > ./ main
     ./in-some-directory/big.js?1 267 bytes [built] [code generated]
     ./in-some-directory/small.js?1 66 bytes [built] [code generated]
     ./in-some-directory/small.js?2 66 bytes [built] [code generated]
     ./in-some-directory/small.js?3 66 bytes [built] [code generated]
     ./in-some-directory/small.js?4 66 bytes [built] [code generated]
-  chunk (runtime: main) zero-min-876.js (id hint: vendors) 1.57 KiB ={91}= ={96}= ={216}= ={384}= ={392}= ={480}= ={496}= ={536}= ={592}= ={728}= ={968}= ={976}= [initial] [rendered] split chunk (cache group: defaultVendors)
+  chunk (runtime: main) zero-min-main-2f7dcf2e.js (main-2f7dcf2e) 594 bytes ={37}= ={59}= ={121}= ={124}= ={161}= ={181}= ={241}= ={273}= ={382}= ={409}= ={942}= ={945}= [initial] [rendered]
     > ./ main
-    ./node_modules/very-big.js?1 1.57 KiB [built] [code generated]
-  chunk (runtime: main) zero-min-main-1df31ce3.js (main-1df31ce3) 1.19 KiB ={91}= ={96}= ={216}= ={384}= ={392}= ={480}= ={496}= ={536}= ={592}= ={728}= ={876}= ={976}= [initial] [rendered]
+    ./inner-module/small.js?1 66 bytes [built] [code generated]
+    ./inner-module/small.js?2 66 bytes [built] [code generated]
+    ./inner-module/small.js?3 66 bytes [built] [code generated]
+    ./inner-module/small.js?4 66 bytes [built] [code generated]
+    ./inner-module/small.js?5 66 bytes [built] [code generated]
+    ./inner-module/small.js?6 66 bytes [built] [code generated]
+    ./inner-module/small.js?7 66 bytes [built] [code generated]
+    ./inner-module/small.js?8 66 bytes [built] [code generated]
+    ./inner-module/small.js?9 66 bytes [built] [code generated]
+  chunk (runtime: main) zero-min-main-1443e336.js (main-1443e336) 594 bytes ={37}= ={59}= ={121}= ={124}= ={161}= ={181}= ={241}= ={273}= ={382}= ={409}= ={808}= ={945}= [initial] [rendered]
     > ./ main
-    ./index.js 1.19 KiB [built] [code generated]
-  chunk (runtime: main) zero-min-main-77a8c116.js (main-77a8c116) 1.57 KiB ={91}= ={96}= ={216}= ={384}= ={392}= ={480}= ={496}= ={536}= ={592}= ={728}= ={876}= ={968}= [initial] [rendered]
+    ./subfolder/small.js?1 66 bytes [built] [code generated]
+    ./subfolder/small.js?2 66 bytes [built] [code generated]
+    ./subfolder/small.js?3 66 bytes [built] [code generated]
+    ./subfolder/small.js?4 66 bytes [built] [code generated]
+    ./subfolder/small.js?5 66 bytes [built] [code generated]
+    ./subfolder/small.js?6 66 bytes [built] [code generated]
+    ./subfolder/small.js?7 66 bytes [built] [code generated]
+    ./subfolder/small.js?8 66 bytes [built] [code generated]
+    ./subfolder/small.js?9 66 bytes [built] [code generated]
+  chunk (runtime: main) zero-min-main-89a43a0f.js (main-89a43a0f) 1.57 KiB ={37}= ={59}= ={121}= ={124}= ={161}= ={181}= ={241}= ={273}= ={382}= ={409}= ={808}= ={942}= [initial] [rendered]
     > ./ main
-    ./very-big.js?2 1.57 KiB [built] [code generated]
+    ./very-big.js?3 1.57 KiB [built] [code generated]
   zero-min (webpack x.x.x) compiled successfully
 
 max-async-size:
   Entrypoint main 15.9 KiB = max-async-size-main.js
-  chunk (runtime: main) max-async-size-async-b-77a8c116.js (async-b-77a8c116) 1.57 KiB <{590}> ={324}= ={440}= ={560}= [rendered]
-    > ./b ./async/index.js 10:2-49
-    > ./a ./async/index.js 9:2-49
-    ./very-big.js?2 1.57 KiB [built] [code generated]
-  chunk (runtime: main) max-async-size-async-b-12217e1d.js (async-b-12217e1d) 1.57 KiB <{590}> ={24}= ={440}= ={560}= [rendered]
-    > ./b ./async/index.js 10:2-49
-    > ./a ./async/index.js 9:2-49
-    ./very-big.js?1 1.57 KiB [built] [code generated]
-  chunk (runtime: main) max-async-size-async-b-bde52cb3.js (async-b-bde52cb3) 855 bytes <{590}> ={24}= ={324}= ={560}= [rendered]
+  chunk (runtime: main) max-async-size-async-b-bde52cb3.js (async-b-bde52cb3) 855 bytes <{792}> ={565}= ={664}= ={901}= [rendered]
     > ./b ./async/index.js 10:2-49
     > ./a ./async/index.js 9:2-49
     dependent modules 594 bytes [dependent] 9 modules
     cacheable modules 261 bytes
       ./async/a.js 189 bytes [built] [code generated]
       ./async/b.js 72 bytes [built] [code generated]
-  chunk (runtime: main) max-async-size-async-b-89a43a0f.js (async-b-89a43a0f) 1.57 KiB <{590}> ={24}= ={324}= ={440}= [rendered]
+  chunk (runtime: main) max-async-size-async-b-89a43a0f.js (async-b-89a43a0f) 1.57 KiB <{792}> ={265}= ={664}= ={901}= [rendered]
     > ./b ./async/index.js 10:2-49
     > ./a ./async/index.js 9:2-49
     ./very-big.js?3 1.57 KiB [built] [code generated]
-  chunk (runtime: main) max-async-size-main.js (main) 2.46 KiB (javascript) 6.96 KiB (runtime) >{24}< >{324}< >{440}< >{560}< [entry] [rendered]
+  chunk (runtime: main) max-async-size-async-b-12217e1d.js (async-b-12217e1d) 1.57 KiB <{792}> ={265}= ={565}= ={901}= [rendered]
+    > ./b ./async/index.js 10:2-49
+    > ./a ./async/index.js 9:2-49
+    ./very-big.js?1 1.57 KiB [built] [code generated]
+  chunk (runtime: main) max-async-size-main.js (main) 2.46 KiB (javascript) 6.96 KiB (runtime) >{265}< >{565}< >{664}< >{901}< [entry] [rendered]
     > ./async main
     runtime modules 6.96 KiB 10 modules
     dependent modules 2.09 KiB [dependent] 6 modules
     ./async/index.js 386 bytes [built] [code generated]
+  chunk (runtime: main) max-async-size-async-b-77a8c116.js (async-b-77a8c116) 1.57 KiB <{792}> ={265}= ={565}= ={664}= [rendered]
+    > ./b ./async/index.js 10:2-49
+    > ./a ./async/index.js 9:2-49
+    ./very-big.js?2 1.57 KiB [built] [code generated]
   max-async-size (webpack x.x.x) compiled successfully
 
 enforce-min-size:
   Entrypoint main 31.9 KiB = 14 assets
-  chunk (runtime: main) enforce-min-size-16.js (id hint: all) 1.57 KiB ={39}= ={79}= ={80}= ={96}= ={192}= ={552}= ={590}= ={624}= ={700}= ={832}= ={836}= ={876}= ={980}= [initial] [rendered] split chunk (cache group: all)
-    > ./ main
-    ./very-big.js?1 1.57 KiB [built] [code generated]
-  chunk (runtime: main) enforce-min-size-39.js (id hint: all) 1.19 KiB ={16}= ={79}= ={80}= ={96}= ={192}= ={552}= ={590}= ={624}= ={700}= ={832}= ={836}= ={876}= ={980}= [initial] [rendered] split chunk (cache group: all)
-    > ./ main
-    ./index.js 1.19 KiB [built] [code generated]
-  chunk (runtime: main) enforce-min-size-79.js (id hint: all) 534 bytes ={16}= ={39}= ={80}= ={96}= ={192}= ={552}= ={590}= ={624}= ={700}= ={832}= ={836}= ={876}= ={980}= [initial] [rendered] split chunk (cache group: all)
-    > ./ main
-    ./subfolder/big.js?1 267 bytes [built] [code generated]
-    ./subfolder/big.js?2 267 bytes [built] [code generated]
-  chunk (runtime: main) enforce-min-size-80.js (id hint: all) 594 bytes ={16}= ={39}= ={79}= ={96}= ={192}= ={552}= ={590}= ={624}= ={700}= ={832}= ={836}= ={876}= ={980}= [initial] [rendered] split chunk (cache group: all)
-    > ./ main
-    ./inner-module/small.js?1 66 bytes [built] [code generated]
-    ./inner-module/small.js?2 66 bytes [built] [code generated]
-    ./inner-module/small.js?3 66 bytes [built] [code generated]
-    ./inner-module/small.js?4 66 bytes [built] [code generated]
-    ./inner-module/small.js?5 66 bytes [built] [code generated]
-    ./inner-module/small.js?6 66 bytes [built] [code generated]
-    ./inner-module/small.js?7 66 bytes [built] [code generated]
-    ./inner-module/small.js?8 66 bytes [built] [code generated]
-    ./inner-module/small.js?9 66 bytes [built] [code generated]
-  chunk (runtime: main) enforce-min-size-96.js (id hint: all) 399 bytes ={16}= ={39}= ={79}= ={80}= ={192}= ={552}= ={590}= ={624}= ={700}= ={832}= ={836}= ={876}= ={980}= [initial] [rendered] split chunk (cache group: all)
-    > ./ main
-    ./node_modules/big.js?1 267 bytes [built] [code generated]
-    ./node_modules/small.js?1 66 bytes [built] [code generated]
-    ./node_modules/small.js?2 66 bytes [built] [code generated]
-  chunk (runtime: main) enforce-min-size-192.js (id hint: all) 534 bytes ={16}= ={39}= ={79}= ={80}= ={96}= ={552}= ={590}= ={624}= ={700}= ={832}= ={836}= ={876}= ={980}= [initial] [rendered] split chunk (cache group: all)
-    > ./ main
-    ./big.js?1 267 bytes [built] [code generated]
-    ./big.js?2 267 bytes [built] [code generated]
-  chunk (runtime: main) enforce-min-size-552.js (id hint: all) 1.57 KiB ={16}= ={39}= ={79}= ={80}= ={96}= ={192}= ={590}= ={624}= ={700}= ={832}= ={836}= ={876}= ={980}= [initial] [rendered] split chunk (cache group: all)
-    > ./ main
-    ./very-big.js?2 1.57 KiB [built] [code generated]
-  chunk (runtime: main) enforce-min-size-main.js (main) 3.01 KiB ={16}= ={39}= ={79}= ={80}= ={96}= ={192}= ={552}= ={624}= ={700}= ={832}= ={836}= ={876}= ={980}= [entry] [rendered]
-    > ./ main
-    runtime modules 3.01 KiB 5 modules
-  chunk (runtime: main) enforce-min-size-624.js (id hint: all) 1.57 KiB ={16}= ={39}= ={79}= ={80}= ={96}= ={192}= ={552}= ={590}= ={700}= ={832}= ={836}= ={876}= ={980}= [initial] [rendered] split chunk (cache group: all)
-    > ./ main
-    ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
-  chunk (runtime: main) enforce-min-size-700.js (id hint: all) 594 bytes ={16}= ={39}= ={79}= ={80}= ={96}= ={192}= ={552}= ={590}= ={624}= ={832}= ={836}= ={876}= ={980}= [initial] [rendered] split chunk (cache group: all)
-    > ./ main
-    ./small.js?1 66 bytes [built] [code generated]
-    ./small.js?2 66 bytes [built] [code generated]
-    ./small.js?3 66 bytes [built] [code generated]
-    ./small.js?4 66 bytes [built] [code generated]
-    ./small.js?5 66 bytes [built] [code generated]
-    ./small.js?6 66 bytes [built] [code generated]
-    ./small.js?7 66 bytes [built] [code generated]
-    ./small.js?8 66 bytes [built] [code generated]
-    ./small.js?9 66 bytes [built] [code generated]
-  chunk (runtime: main) enforce-min-size-832.js (id hint: all) 531 bytes ={16}= ={39}= ={79}= ={80}= ={96}= ={192}= ={552}= ={590}= ={624}= ={700}= ={836}= ={876}= ={980}= [initial] [rendered] split chunk (cache group: all)
-    > ./ main
-    ./in-some-directory/big.js?1 267 bytes [built] [code generated]
-    ./in-some-directory/small.js?1 66 bytes [built] [code generated]
-    ./in-some-directory/small.js?2 66 bytes [built] [code generated]
-    ./in-some-directory/small.js?3 66 bytes [built] [code generated]
-    ./in-some-directory/small.js?4 66 bytes [built] [code generated]
-  chunk (runtime: main) enforce-min-size-836.js (id hint: all) 594 bytes ={16}= ={39}= ={79}= ={80}= ={96}= ={192}= ={552}= ={590}= ={624}= ={700}= ={832}= ={876}= ={980}= [initial] [rendered] split chunk (cache group: all)
+  chunk (runtime: main) enforce-min-size-35.js (id hint: all) 594 bytes ={90}= ={120}= ={237}= ={241}= ={262}= ={273}= ={411}= ={491}= ={792}= ={858}= ={928}= ={929}= ={962}= [initial] [rendered] split chunk (cache group: all)
     > ./ main
     ./subfolder/small.js?1 66 bytes [built] [code generated]
     ./subfolder/small.js?2 66 bytes [built] [code generated]
@@ -4569,12 +4512,69 @@ enforce-min-size:
     ./subfolder/small.js?7 66 bytes [built] [code generated]
     ./subfolder/small.js?8 66 bytes [built] [code generated]
     ./subfolder/small.js?9 66 bytes [built] [code generated]
-  chunk (runtime: main) enforce-min-size-876.js (id hint: all) 1.57 KiB ={16}= ={39}= ={79}= ={80}= ={96}= ={192}= ={552}= ={590}= ={624}= ={700}= ={832}= ={836}= ={980}= [initial] [rendered] split chunk (cache group: all)
+  chunk (runtime: main) enforce-min-size-90.js (id hint: all) 1.57 KiB ={35}= ={120}= ={237}= ={241}= ={262}= ={273}= ={411}= ={491}= ={792}= ={858}= ={928}= ={929}= ={962}= [initial] [rendered] split chunk (cache group: all)
     > ./ main
-    ./node_modules/very-big.js?1 1.57 KiB [built] [code generated]
-  chunk (runtime: main) enforce-min-size-980.js (id hint: all) 1.57 KiB ={16}= ={39}= ={79}= ={80}= ={96}= ={192}= ={552}= ={590}= ={624}= ={700}= ={832}= ={836}= ={876}= [initial] [rendered] split chunk (cache group: all)
+    ./very-big.js?1 1.57 KiB [built] [code generated]
+  chunk (runtime: main) enforce-min-size-120.js (id hint: all) 1.57 KiB ={35}= ={90}= ={237}= ={241}= ={262}= ={273}= ={411}= ={491}= ={792}= ={858}= ={928}= ={929}= ={962}= [initial] [rendered] split chunk (cache group: all)
     > ./ main
     ./very-big.js?3 1.57 KiB [built] [code generated]
+  chunk (runtime: main) enforce-min-size-237.js (id hint: all) 1.19 KiB ={35}= ={90}= ={120}= ={241}= ={262}= ={273}= ={411}= ={491}= ={792}= ={858}= ={928}= ={929}= ={962}= [initial] [rendered] split chunk (cache group: all)
+    > ./ main
+    ./index.js 1.19 KiB [built] [code generated]
+  chunk (runtime: main) enforce-min-size-241.js (id hint: all) 399 bytes ={35}= ={90}= ={120}= ={237}= ={262}= ={273}= ={411}= ={491}= ={792}= ={858}= ={928}= ={929}= ={962}= [initial] [rendered] split chunk (cache group: all)
+    > ./ main
+    ./node_modules/big.js?1 267 bytes [built] [code generated]
+    ./node_modules/small.js?1 66 bytes [built] [code generated]
+    ./node_modules/small.js?2 66 bytes [built] [code generated]
+  chunk (runtime: main) enforce-min-size-262.js (id hint: all) 594 bytes ={35}= ={90}= ={120}= ={237}= ={241}= ={273}= ={411}= ={491}= ={792}= ={858}= ={928}= ={929}= ={962}= [initial] [rendered] split chunk (cache group: all)
+    > ./ main
+    ./small.js?1 66 bytes [built] [code generated]
+    ./small.js?2 66 bytes [built] [code generated]
+    ./small.js?3 66 bytes [built] [code generated]
+    ./small.js?4 66 bytes [built] [code generated]
+    ./small.js?5 66 bytes [built] [code generated]
+    ./small.js?6 66 bytes [built] [code generated]
+    ./small.js?7 66 bytes [built] [code generated]
+    ./small.js?8 66 bytes [built] [code generated]
+    ./small.js?9 66 bytes [built] [code generated]
+  chunk (runtime: main) enforce-min-size-273.js (id hint: all) 1.57 KiB ={35}= ={90}= ={120}= ={237}= ={241}= ={262}= ={411}= ={491}= ={792}= ={858}= ={928}= ={929}= ={962}= [initial] [rendered] split chunk (cache group: all)
+    > ./ main
+    ./node_modules/very-big.js?1 1.57 KiB [built] [code generated]
+  chunk (runtime: main) enforce-min-size-411.js (id hint: all) 534 bytes ={35}= ={90}= ={120}= ={237}= ={241}= ={262}= ={273}= ={491}= ={792}= ={858}= ={928}= ={929}= ={962}= [initial] [rendered] split chunk (cache group: all)
+    > ./ main
+    ./subfolder/big.js?1 267 bytes [built] [code generated]
+    ./subfolder/big.js?2 267 bytes [built] [code generated]
+  chunk (runtime: main) enforce-min-size-491.js (id hint: all) 1.57 KiB ={35}= ={90}= ={120}= ={237}= ={241}= ={262}= ={273}= ={411}= ={792}= ={858}= ={928}= ={929}= ={962}= [initial] [rendered] split chunk (cache group: all)
+    > ./ main
+    ./in-some-directory/very-big.js?1 1.57 KiB [built] [code generated]
+  chunk (runtime: main) enforce-min-size-main.js (main) 3.01 KiB ={35}= ={90}= ={120}= ={237}= ={241}= ={262}= ={273}= ={411}= ={491}= ={858}= ={928}= ={929}= ={962}= [entry] [rendered]
+    > ./ main
+    runtime modules 3.01 KiB 5 modules
+  chunk (runtime: main) enforce-min-size-858.js (id hint: all) 594 bytes ={35}= ={90}= ={120}= ={237}= ={241}= ={262}= ={273}= ={411}= ={491}= ={792}= ={928}= ={929}= ={962}= [initial] [rendered] split chunk (cache group: all)
+    > ./ main
+    ./inner-module/small.js?1 66 bytes [built] [code generated]
+    ./inner-module/small.js?2 66 bytes [built] [code generated]
+    ./inner-module/small.js?3 66 bytes [built] [code generated]
+    ./inner-module/small.js?4 66 bytes [built] [code generated]
+    ./inner-module/small.js?5 66 bytes [built] [code generated]
+    ./inner-module/small.js?6 66 bytes [built] [code generated]
+    ./inner-module/small.js?7 66 bytes [built] [code generated]
+    ./inner-module/small.js?8 66 bytes [built] [code generated]
+    ./inner-module/small.js?9 66 bytes [built] [code generated]
+  chunk (runtime: main) enforce-min-size-928.js (id hint: all) 531 bytes ={35}= ={90}= ={120}= ={237}= ={241}= ={262}= ={273}= ={411}= ={491}= ={792}= ={858}= ={929}= ={962}= [initial] [rendered] split chunk (cache group: all)
+    > ./ main
+    ./in-some-directory/big.js?1 267 bytes [built] [code generated]
+    ./in-some-directory/small.js?1 66 bytes [built] [code generated]
+    ./in-some-directory/small.js?2 66 bytes [built] [code generated]
+    ./in-some-directory/small.js?3 66 bytes [built] [code generated]
+    ./in-some-directory/small.js?4 66 bytes [built] [code generated]
+  chunk (runtime: main) enforce-min-size-929.js (id hint: all) 1.57 KiB ={35}= ={90}= ={120}= ={237}= ={241}= ={262}= ={273}= ={411}= ={491}= ={792}= ={858}= ={928}= ={962}= [initial] [rendered] split chunk (cache group: all)
+    > ./ main
+    ./very-big.js?2 1.57 KiB [built] [code generated]
+  chunk (runtime: main) enforce-min-size-962.js (id hint: all) 534 bytes ={35}= ={90}= ={120}= ={237}= ={241}= ={262}= ={273}= ={411}= ={491}= ={792}= ={858}= ={928}= ={929}= [initial] [rendered] split chunk (cache group: all)
+    > ./ main
+    ./big.js?1 267 bytes [built] [code generated]
+    ./big.js?2 267 bytes [built] [code generated]
   enforce-min-size (webpack x.x.x) compiled successfully
 
 only-async:
@@ -4589,57 +4589,57 @@ only-async:
 
 exports[`StatsTestCases should print correct stats for split-chunks-min-size-reduction 1`] = `
 "Entrypoint main 11.5 KiB = default/main.js
-chunk (runtime: main) default/async-b.js (async-b) 176 bytes <{590}> [rendered]
+chunk (runtime: main) default/async-b.js (async-b) 176 bytes <{792}> [rendered]
   > ./b ./index.js 2:0-47
   ./b.js 50 bytes [built] [code generated]
   ./node_modules/shared.js?1 126 bytes [dependent] [built] [code generated]
-chunk (runtime: main) default/async-c.js (async-c) 50 bytes <{590}> ={916}= [rendered]
-  > ./c ./index.js 3:0-47
-  ./c.js 50 bytes [built] [code generated]
-chunk (runtime: main) default/async-a.js (async-a) 176 bytes <{590}> [rendered]
+chunk (runtime: main) default/async-e.js (async-e) 50 bytes <{792}> ={784}= [rendered]
+  > ./e ./index.js 5:0-47
+  ./e.js 50 bytes [built] [code generated]
+chunk (runtime: main) default/async-a.js (async-a) 176 bytes <{792}> [rendered]
   > ./a ./index.js 1:0-47
   ./a.js 50 bytes [built] [code generated]
   ./node_modules/shared.js?1 126 bytes [dependent] [built] [code generated]
-chunk (runtime: main) default/async-e.js (async-e) 50 bytes <{590}> ={916}= [rendered]
-  > ./e ./index.js 5:0-47
-  ./e.js 50 bytes [built] [code generated]
-chunk (runtime: main) default/main.js (main) 245 bytes (javascript) 6.69 KiB (runtime) >{272}< >{276}< >{464}< >{476}< >{668}< >{916}< [entry] [rendered]
-  > ./ main
-  runtime modules 6.69 KiB 9 modules
-  ./index.js 245 bytes [built] [code generated]
-chunk (runtime: main) default/async-d.js (async-d) 50 bytes <{590}> ={916}= [rendered]
+chunk (runtime: main) default/async-d.js (async-d) 50 bytes <{792}> ={784}= [rendered]
   > ./d ./index.js 4:0-47
   ./d.js 50 bytes [built] [code generated]
-chunk (runtime: main) default/916.js (id hint: vendors) 126 bytes <{590}> ={276}= ={476}= ={668}= [rendered] split chunk (cache group: defaultVendors)
+chunk (runtime: main) default/784.js (id hint: vendors) 126 bytes <{792}> ={251}= ={442}= ={869}= [rendered] split chunk (cache group: defaultVendors)
   > ./c ./index.js 3:0-47
   > ./d ./index.js 4:0-47
   > ./e ./index.js 5:0-47
   ./node_modules/shared.js?2 126 bytes [built] [code generated]
+chunk (runtime: main) default/main.js (main) 245 bytes (javascript) 6.69 KiB (runtime) >{60}< >{251}< >{263}< >{442}< >{784}< >{869}< [entry] [rendered]
+  > ./ main
+  runtime modules 6.69 KiB 9 modules
+  ./index.js 245 bytes [built] [code generated]
+chunk (runtime: main) default/async-c.js (async-c) 50 bytes <{792}> ={784}= [rendered]
+  > ./c ./index.js 3:0-47
+  ./c.js 50 bytes [built] [code generated]
 webpack x.x.x compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-prefer-bigger-splits 1`] = `
 "Entrypoint main 11.2 KiB = default/main.js
-chunk (runtime: main) default/128.js 150 bytes <{590}> ={272}= ={276}= [rendered] split chunk (cache group: default)
+chunk (runtime: main) default/async-b.js (async-b) 158 bytes <{792}> ={415}= [rendered]
+  > ./b ./index.js 2:0-47
+  dependent modules 63 bytes [dependent] 1 module
+  ./b.js 95 bytes [built] [code generated]
+chunk (runtime: main) default/async-a.js (async-a) 196 bytes <{792}> [rendered]
+  > ./a ./index.js 1:0-47
+  dependent modules 126 bytes [dependent] 2 modules
+  ./a.js 70 bytes [built] [code generated]
+chunk (runtime: main) default/415.js 150 bytes <{792}> ={60}= ={869}= [rendered] split chunk (cache group: default)
   > ./b ./index.js 2:0-47
   > ./c ./index.js 3:0-47
   ./d.js 63 bytes [built] [code generated]
   ./f.js 87 bytes [built] [code generated]
-chunk (runtime: main) default/async-b.js (async-b) 158 bytes <{590}> ={128}= [rendered]
-  > ./b ./index.js 2:0-47
-  dependent modules 63 bytes [dependent] 1 module
-  ./b.js 95 bytes [built] [code generated]
-chunk (runtime: main) default/async-c.js (async-c) 70 bytes <{590}> ={128}= [rendered]
-  > ./c ./index.js 3:0-47
-  ./c.js 70 bytes [built] [code generated]
-chunk (runtime: main) default/async-a.js (async-a) 196 bytes <{590}> [rendered]
-  > ./a ./index.js 1:0-47
-  dependent modules 126 bytes [dependent] 2 modules
-  ./a.js 70 bytes [built] [code generated]
-chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) >{128}< >{272}< >{276}< >{464}< [entry] [rendered]
+chunk (runtime: main) default/main.js (main) 147 bytes (javascript) 6.66 KiB (runtime) >{60}< >{263}< >{415}< >{869}< [entry] [rendered]
   > ./ main
   runtime modules 6.66 KiB 9 modules
   ./index.js 147 bytes [built] [code generated]
+chunk (runtime: main) default/async-c.js (async-c) 70 bytes <{792}> ={415}= [rendered]
+  > ./c ./index.js 3:0-47
+  ./c.js 70 bytes [built] [code generated]
 webpack x.x.x compiled successfully"
 `;
 
@@ -4647,39 +4647,39 @@ exports[`StatsTestCases should print correct stats for split-chunks-runtime-spec
 "used-exports:
   asset used-exports-c.js 6.04 KiB [emitted] (name: c)
   asset used-exports-b.js 6.03 KiB [emitted] (name: b)
-  asset used-exports-356.js 422 bytes [emitted]
+  asset used-exports-637.js 422 bytes [emitted]
   asset used-exports-a.js 257 bytes [emitted] (name: a)
   Entrypoint a 257 bytes = used-exports-a.js
-  Entrypoint b 6.44 KiB = used-exports-356.js 422 bytes used-exports-b.js 6.03 KiB
-  Entrypoint c 6.45 KiB = used-exports-356.js 422 bytes used-exports-c.js 6.04 KiB
-  chunk (runtime: c) used-exports-c.js (c) 59 bytes (javascript) 2.75 KiB (runtime) [entry] [rendered]
-    runtime modules 2.75 KiB 4 modules
-    ./c.js 59 bytes [built] [code generated]
-  chunk (runtime: b, c) used-exports-356.js 72 bytes [initial] [rendered] split chunk (cache group: default)
-    ./objects.js 72 bytes [built] [code generated]
+  Entrypoint b 6.44 KiB = used-exports-637.js 422 bytes used-exports-b.js 6.03 KiB
+  Entrypoint c 6.45 KiB = used-exports-637.js 422 bytes used-exports-c.js 6.04 KiB
   chunk (runtime: b) used-exports-b.js (b) 54 bytes (javascript) 2.75 KiB (runtime) [entry] [rendered]
     runtime modules 2.75 KiB 4 modules
     ./b.js 54 bytes [built] [code generated]
+  chunk (runtime: c) used-exports-c.js (c) 59 bytes (javascript) 2.75 KiB (runtime) [entry] [rendered]
+    runtime modules 2.75 KiB 4 modules
+    ./c.js 59 bytes [built] [code generated]
+  chunk (runtime: b, c) used-exports-637.js 72 bytes [initial] [rendered] split chunk (cache group: default)
+    ./objects.js 72 bytes [built] [code generated]
   chunk (runtime: a) used-exports-a.js (a) 126 bytes [entry] [rendered]
     ./a.js + 1 modules 126 bytes [built] [code generated]
   used-exports (webpack x.x.x) compiled successfully in X ms
 
 no-used-exports:
   asset no-used-exports-c.js 6.04 KiB [emitted] (name: c)
-  asset no-used-exports-b.js 6.03 KiB [emitted] (name: b)
   asset no-used-exports-a.js 6.03 KiB [emitted] (name: a)
-  asset no-used-exports-356.js 443 bytes [emitted]
-  Entrypoint a 6.46 KiB = no-used-exports-356.js 443 bytes no-used-exports-a.js 6.03 KiB
-  Entrypoint b 6.46 KiB = no-used-exports-356.js 443 bytes no-used-exports-b.js 6.03 KiB
-  Entrypoint c 6.47 KiB = no-used-exports-356.js 443 bytes no-used-exports-c.js 6.04 KiB
-  chunk (runtime: c) no-used-exports-c.js (c) 59 bytes (javascript) 2.75 KiB (runtime) [entry] [rendered]
-    runtime modules 2.75 KiB 4 modules
-    ./c.js 59 bytes [built] [code generated]
-  chunk (runtime: a, b, c) no-used-exports-356.js 72 bytes [initial] [rendered] split chunk (cache group: default)
-    ./objects.js 72 bytes [built] [code generated]
+  asset no-used-exports-b.js 6.03 KiB [emitted] (name: b)
+  asset no-used-exports-637.js 443 bytes [emitted]
+  Entrypoint a 6.46 KiB = no-used-exports-637.js 443 bytes no-used-exports-a.js 6.03 KiB
+  Entrypoint b 6.46 KiB = no-used-exports-637.js 443 bytes no-used-exports-b.js 6.03 KiB
+  Entrypoint c 6.47 KiB = no-used-exports-637.js 443 bytes no-used-exports-c.js 6.04 KiB
   chunk (runtime: b) no-used-exports-b.js (b) 54 bytes (javascript) 2.75 KiB (runtime) [entry] [rendered]
     runtime modules 2.75 KiB 4 modules
     ./b.js 54 bytes [built] [code generated]
+  chunk (runtime: c) no-used-exports-c.js (c) 59 bytes (javascript) 2.75 KiB (runtime) [entry] [rendered]
+    runtime modules 2.75 KiB 4 modules
+    ./c.js 59 bytes [built] [code generated]
+  chunk (runtime: a, b, c) no-used-exports-637.js 72 bytes [initial] [rendered] split chunk (cache group: default)
+    ./objects.js 72 bytes [built] [code generated]
   chunk (runtime: a) no-used-exports-a.js (a) 54 bytes (javascript) 2.75 KiB (runtime) [entry] [rendered]
     runtime modules 2.75 KiB 4 modules
     ./a.js 54 bytes [built] [code generated]
@@ -4687,20 +4687,20 @@ no-used-exports:
 
 global:
   asset global-c.js 6.04 KiB [emitted] (name: c)
-  asset global-b.js 6.03 KiB [emitted] (name: b)
   asset global-a.js 6.03 KiB [emitted] (name: a)
-  asset global-356.js 443 bytes [emitted]
-  Entrypoint a 6.46 KiB = global-356.js 443 bytes global-a.js 6.03 KiB
-  Entrypoint b 6.46 KiB = global-356.js 443 bytes global-b.js 6.03 KiB
-  Entrypoint c 6.47 KiB = global-356.js 443 bytes global-c.js 6.04 KiB
-  chunk (runtime: c) global-c.js (c) 59 bytes (javascript) 2.75 KiB (runtime) [entry] [rendered]
-    runtime modules 2.75 KiB 4 modules
-    ./c.js 59 bytes [built] [code generated]
-  chunk (runtime: a, b, c) global-356.js 72 bytes [initial] [rendered] split chunk (cache group: default)
-    ./objects.js 72 bytes [built] [code generated]
+  asset global-b.js 6.03 KiB [emitted] (name: b)
+  asset global-637.js 443 bytes [emitted]
+  Entrypoint a 6.46 KiB = global-637.js 443 bytes global-a.js 6.03 KiB
+  Entrypoint b 6.46 KiB = global-637.js 443 bytes global-b.js 6.03 KiB
+  Entrypoint c 6.47 KiB = global-637.js 443 bytes global-c.js 6.04 KiB
   chunk (runtime: b) global-b.js (b) 54 bytes (javascript) 2.75 KiB (runtime) [entry] [rendered]
     runtime modules 2.75 KiB 4 modules
     ./b.js 54 bytes [built] [code generated]
+  chunk (runtime: c) global-c.js (c) 59 bytes (javascript) 2.75 KiB (runtime) [entry] [rendered]
+    runtime modules 2.75 KiB 4 modules
+    ./c.js 59 bytes [built] [code generated]
+  chunk (runtime: a, b, c) global-637.js 72 bytes [initial] [rendered] split chunk (cache group: default)
+    ./objects.js 72 bytes [built] [code generated]
   chunk (runtime: a) global-a.js (a) 54 bytes (javascript) 2.75 KiB (runtime) [entry] [rendered]
     runtime modules 2.75 KiB 4 modules
     ./a.js 54 bytes [built] [code generated]
@@ -4708,7 +4708,7 @@ global:
 `;
 
 exports[`StatsTestCases should print correct stats for tree-shaking 1`] = `
-"asset bundle.js 6.87 KiB [emitted] (name: main)
+"asset bundle.js 6.88 KiB [emitted] (name: main)
 runtime modules 663 bytes 3 modules
 orphan modules 14 bytes [orphan] 1 module
 cacheable modules 782 bytes
@@ -4760,36 +4760,36 @@ webpack x.x.x compiled with 1 warning in X ms"
 exports[`StatsTestCases should print correct stats for wasm-explorer-examples-sync 1`] = `
 "assets by path *.js 22.3 KiB
   asset bundle.js 16.8 KiB [emitted] (name: main)
-  asset 88.bundle.js 3.89 KiB [emitted]
-  asset 536.bundle.js 557 bytes [emitted]
-  asset 296.bundle.js 364 bytes [emitted] (id hint: vendors)
-  asset 344.bundle.js 243 bytes [emitted]
-  asset 532.bundle.js 243 bytes [emitted]
-  asset 48.bundle.js 241 bytes [emitted]
+  asset 836.bundle.js 3.89 KiB [emitted]
+  asset 946.bundle.js 557 bytes [emitted]
+  asset 787.bundle.js 364 bytes [emitted] (id hint: vendors)
+  asset 573.bundle.js 243 bytes [emitted]
+  asset 672.bundle.js 243 bytes [emitted]
+  asset 989.bundle.js 243 bytes [emitted]
 assets by path *.wasm 1.37 KiB
-  asset c75f9deff2c326ca999c.module.wasm 531 bytes [emitted] [immutable]
-  asset da46f9cd53d21065ba9c.module.wasm 290 bytes [emitted] [immutable]
-  asset b89f6d5281b41d173041.module.wasm 156 bytes [emitted] [immutable]
-  asset 2903ad30d0c24ad32500.module.wasm 154 bytes [emitted] [immutable]
-  asset 74e49d7e028be61b9158.module.wasm 154 bytes [emitted] [immutable]
-  asset 5d4899f8ed85806fc14d.module.wasm 120 bytes [emitted] [immutable]
-chunk (runtime: main) 48.bundle.js 50 bytes (javascript) 156 bytes (webassembly) [rendered]
+  asset e1527dcfebc470eb04bc.module.wasm 531 bytes [emitted] [immutable]
+  asset 2cbe6ce83117ed67f4f5.module.wasm 290 bytes [emitted] [immutable]
+  asset a5af96dad00b07242c9d.module.wasm 156 bytes [emitted] [immutable]
+  asset e3561de65684e530d698.module.wasm 154 bytes [emitted] [immutable]
+  asset f3a44d9771697ed7a52a.module.wasm 154 bytes [emitted] [immutable]
+  asset c63174dd4e2ffd7ad76d.module.wasm 120 bytes [emitted] [immutable]
+chunk (runtime: main) 573.bundle.js 50 bytes (javascript) 156 bytes (webassembly) [rendered]
   ./Q_rsqrt.wasm 50 bytes (javascript) 156 bytes (webassembly) [built] [code generated]
-chunk (runtime: main) 88.bundle.js 1.45 KiB (javascript) 154 bytes (webassembly) [rendered]
-  ./testFunction.wasm 50 bytes (javascript) 154 bytes (webassembly) [dependent] [built] [code generated]
-  ./tests.js 1.4 KiB [built] [code generated]
-chunk (runtime: main) 296.bundle.js (id hint: vendors) 34 bytes [rendered] split chunk (cache group: defaultVendors)
-  ./node_modules/env.js 34 bytes [built] [code generated]
-chunk (runtime: main) 344.bundle.js 50 bytes (javascript) 120 bytes (webassembly) [rendered]
-  ./popcnt.wasm 50 bytes (javascript) 120 bytes (webassembly) [built] [code generated]
-chunk (runtime: main) 532.bundle.js 50 bytes (javascript) 531 bytes (webassembly) [rendered]
+chunk (runtime: main) 672.bundle.js 50 bytes (javascript) 531 bytes (webassembly) [rendered]
   ./duff.wasm 50 bytes (javascript) 531 bytes (webassembly) [built] [code generated]
-chunk (runtime: main) 536.bundle.js 110 bytes (javascript) 444 bytes (webassembly) [rendered]
-  ./fact.wasm 50 bytes (javascript) 154 bytes (webassembly) [built] [code generated]
-  ./fast-math.wasm 60 bytes (javascript) 290 bytes (webassembly) [built] [code generated]
+chunk (runtime: main) 787.bundle.js (id hint: vendors) 34 bytes [rendered] split chunk (cache group: defaultVendors)
+  ./node_modules/env.js 34 bytes [built] [code generated]
 chunk (runtime: main) bundle.js (main) 586 bytes (javascript) 9.59 KiB (runtime) [entry] [rendered]
   runtime modules 9.59 KiB 11 modules
   ./index.js 586 bytes [built] [code generated]
+chunk (runtime: main) 836.bundle.js 1.45 KiB (javascript) 154 bytes (webassembly) [rendered]
+  ./testFunction.wasm 50 bytes (javascript) 154 bytes (webassembly) [dependent] [built] [code generated]
+  ./tests.js 1.4 KiB [built] [code generated]
+chunk (runtime: main) 946.bundle.js 110 bytes (javascript) 444 bytes (webassembly) [rendered]
+  ./fact.wasm 50 bytes (javascript) 154 bytes (webassembly) [built] [code generated]
+  ./fast-math.wasm 60 bytes (javascript) 290 bytes (webassembly) [built] [code generated]
+chunk (runtime: main) 989.bundle.js 50 bytes (javascript) 120 bytes (webassembly) [rendered]
+  ./popcnt.wasm 50 bytes (javascript) 120 bytes (webassembly) [built] [code generated]
 runtime modules 9.59 KiB 11 modules
 cacheable modules 2.31 KiB (javascript) 1.37 KiB (webassembly)
   webassembly modules 310 bytes (javascript) 1.37 KiB (webassembly)
@@ -4807,8 +4807,8 @@ webpack x.x.x compiled successfully in X ms"
 `;
 
 exports[`StatsTestCases should print correct stats for worker-public-path 1`] = `
-"asset main-9c3c04147b0478dd8ad5.js 3.59 KiB [emitted] [immutable] (name: main)
-asset 560-579eebb6602aecc20b13.js 219 bytes [emitted] [immutable]
+"asset main-a126663da1e325d86ca3.js 3.59 KiB [emitted] [immutable] (name: main)
+asset 447-579eebb6602aecc20b13.js 219 bytes [emitted] [immutable]
 runtime modules 1.81 KiB 5 modules
 cacheable modules 250 bytes
   ./index.js 115 bytes [built] [code generated]

--- a/test/configCases/asset-emitted/normal/webpack.config.js
+++ b/test/configCases/asset-emitted/normal/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = {
 			compiler.hooks.afterEmit.tap("Test", () => {
 				expect(files).toMatchInlineSnapshot(`
 			Object {
-			  "324.bundle0.js": true,
+			  "93.bundle0.js": true,
 			  "bundle0.js": true,
 			}
 		`);

--- a/test/configCases/code-generation/re-export-namespace-concat/index.js
+++ b/test/configCases/code-generation/re-export-namespace-concat/index.js
@@ -69,9 +69,9 @@ it("should use/preserve accessor form for import object and namespaces", functio
 
 	expectSourceToContain(source, 'const bb = module1.obj1.up.down?.left.right;');
 
-	expectSourceToContain(source, 'const ww = (__webpack_require__(/*! ./module1 */ 688).obj1)["bing"]?.bang;');
-	expectSourceToContain(source, 'const xx = (__webpack_require__(/*! ./module1 */ 688).obj1)["pip"].pop();');
-	expectSourceToContain(source, 'const yy = (__webpack_require__(/*! ./module3 */ 989)/* .m_2.m_1.obj1 */ .a.a.obj1)["tip"].top();');
+	expectSourceToContain(source, 'const ww = (__webpack_require__(/*! ./module1 */ 602).obj1)["bing"]?.bang;');
+	expectSourceToContain(source, 'const xx = (__webpack_require__(/*! ./module1 */ 602).obj1)["pip"].pop();');
+	expectSourceToContain(source, 'const yy = (__webpack_require__(/*! ./module3 */ 144)/* .m_2.m_1.obj1 */ .a.a.obj1)["tip"].top();');
 
 	expectSourceToContain(source, 'data_namespaceObject.a.a["unknownProperty"].depth = "deep";');
 

--- a/test/configCases/code-generation/re-export-namespace/index.js
+++ b/test/configCases/code-generation/re-export-namespace/index.js
@@ -69,9 +69,9 @@ it("should use/preserve accessor form for import object and namespaces", functio
 
 	expectSourceToContain(source, 'const bb = _module1__WEBPACK_IMPORTED_MODULE_0__.obj1.up.down?.left.right;');
 
-	expectSourceToContain(source, 'const ww = (__webpack_require__(/*! ./module1 */ 688).obj1)["bing"]?.bang;');
-	expectSourceToContain(source, 'const xx = (__webpack_require__(/*! ./module1 */ 688).obj1)["pip"].pop();');
-	expectSourceToContain(source, 'const yy = (__webpack_require__(/*! ./module3 */ 989).m_2.m_1.obj1)["tip"].top();');
+	expectSourceToContain(source, 'const ww = (__webpack_require__(/*! ./module1 */ 602).obj1)["bing"]?.bang;');
+	expectSourceToContain(source, 'const xx = (__webpack_require__(/*! ./module1 */ 602).obj1)["pip"].pop();');
+	expectSourceToContain(source, 'const yy = (__webpack_require__(/*! ./module3 */ 144).m_2.m_1.obj1)["tip"].top();');
 
 	expectSourceToContain(source, '_data__WEBPACK_IMPORTED_MODULE_3__.nested.object3["unknownProperty"].depth = "deep";');
 

--- a/test/configCases/css/css-modules-broken-keyframes/index.js
+++ b/test/configCases/css/css-modules-broken-keyframes/index.js
@@ -2,7 +2,7 @@ const prod = process.env.NODE_ENV === "production";
 
 it("should allow to create css modules", done => {
 	prod
-		? __non_webpack_require__("./848.bundle0.js")
+		? __non_webpack_require__("./226.bundle0.js")
 		: __non_webpack_require__("./use-style_js.bundle0.js");
 	import("./use-style.js").then(({ default: x }) => {
 		try {

--- a/test/configCases/css/css-modules/index.js
+++ b/test/configCases/css/css-modules/index.js
@@ -2,7 +2,7 @@ const prod = process.env.NODE_ENV === "production";
 
 it("should allow to create css modules", done => {
 	prod
-		? __non_webpack_require__("./848.bundle1.js")
+		? __non_webpack_require__("./226.bundle1.js")
 		: __non_webpack_require__("./use-style_js.bundle0.js");
 	import("./use-style.js").then(({ default: x }) => {
 		try {
@@ -10,7 +10,7 @@ it("should allow to create css modules", done => {
 
 			const fs = __non_webpack_require__("fs");
 			const path = __non_webpack_require__("path");
-			const cssOutputFilename = prod ? "848.bundle1.css" : "use-style_js.bundle0.css";
+			const cssOutputFilename = prod ? "226.bundle1.css" : "use-style_js.bundle0.css";
 
 			const cssContent = fs.readFileSync(
 				path.join(__dirname, cssOutputFilename),

--- a/test/configCases/css/css-modules/test.config.js
+++ b/test/configCases/css/css-modules/test.config.js
@@ -2,6 +2,6 @@ module.exports = {
 	findBundle: function (i, options) {
 		return i === 0
 			? ["./use-style_js.bundle0.js", "bundle0.js"]
-			: ["./848.bundle1.js", "bundle1.js"];
+			: ["./226.bundle1.js", "bundle1.js"];
 	}
 };

--- a/test/configCases/css/large/index.js
+++ b/test/configCases/css/large/index.js
@@ -2,7 +2,7 @@ const prod = process.env.NODE_ENV === "production";
 
 it("should allow to create css modules", done => {
 	prod
-		? __non_webpack_require__("./848.bundle1.js")
+		? __non_webpack_require__("./226.bundle1.js")
 		: __non_webpack_require__("./use-style_js.bundle0.js");
 	import("./use-style.js").then(({ default: x }) => {
 		try {

--- a/test/configCases/custom-source-type/localization/index.js
+++ b/test/configCases/custom-source-type/localization/index.js
@@ -4,13 +4,13 @@ it("should generate the correct output files", () => {
 		__STATS__.children[INDEX].assets.map(asset => asset.name).sort()
 	).toEqual(
 		[
-			NORMAL2 && `220.bundle${INDEX}.js`,
-			NORMAL1 && `752.bundle${INDEX}.js`,
+			NORMAL1 && `286.bundle${INDEX}.js`,
+			NORMAL2 && `678.bundle${INDEX}.js`,
 			`bundle${INDEX}.js`,
-			NORMAL2 && "localization-220.js",
-			CONTENT2 && "localization-372.js",
-			NORMAL1 && "localization-752.js",
-			"localization-832.js"
+			"localization-248.js",
+			NORMAL1 && "localization-286.js",
+			NORMAL2 && "localization-678.js",
+			CONTENT2 && "localization-702.js"
 		].filter(Boolean)
 	);
 });
@@ -37,7 +37,7 @@ if (NORMAL1) {
 	it("should still load normal chunks", () => {
 		if (TARGET === "web") {
 			Promise.resolve().then(() => {
-				__non_webpack_require__(`./752.bundle${INDEX}.js`);
+				__non_webpack_require__(`./286.bundle${INDEX}.js`);
 			});
 		}
 
@@ -51,7 +51,7 @@ if (NORMAL2) {
 	it("should still another load normal chunks", () => {
 		if (TARGET === "web") {
 			Promise.resolve().then(() => {
-				__non_webpack_require__(`./220.bundle${INDEX}.js`);
+				__non_webpack_require__(`./678.bundle${INDEX}.js`);
 			});
 		}
 

--- a/test/configCases/mangle/mangle-with-object-prop/index.js
+++ b/test/configCases/mangle/mangle-with-object-prop/index.js
@@ -22,7 +22,7 @@ it("should mangle names and remove exports even with toString named export (ESM)
 			.sort()
 	).toEqual(
 		OPTIMIZATION === "deterministic"
-			? [1, 1, 2, 2, 2, 2, 2]
+			? [1, 2, 2, 2, 2, 2, 2]
 			: [1, 1, 1, 1, 1, 1, 1]
 	);
 });
@@ -43,7 +43,7 @@ it("should mangle names and remove exports even with toString named export (CJS)
 			.sort()
 	).toEqual(
 		OPTIMIZATION === "deterministic"
-			? [1, 1, 2, 2, 2, 2, 2, 8]
+			? [1, 2, 2, 2, 2, 2, 2, 8]
 			: [1, 1, 1, 1, 1, 1, 1, 8]
 	);
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
This is a bugfix for a couple issues with #18034:
- The implementation there suffered from loss of precision in the hash multiplication if the current value of the hash exceeded 536858016, since the product would then exceed `Number.MAX_SAFE_INTEGER`. This loss of precision is addressed by switching to the `Math.imul` function, which explicitly performs 32-bit integer multiplication and returns the 32 least significant bits.
- A modification of the reference algorithm to always operate on 8-bit input units introduced the likelihood of collisions between strings with two ASCII characters vs. a single higher Unicode code point. This modification was reverted to simply take the 16-bit Unicode character as a single input value.
 
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Existing tests covered this. Existing implementation worked but was less than ideal.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
Breaks the hashes again. Hopefully combines with the #18034 before that one ships so that it doesn't do so twice.

**What needs to be documented once your changes are merged?**
Same as #18034.