### PR TITLE
fix: __webpack_exports_info__.xxx.canMangle shouldn't always same as default

### DIFF
--- a/lib/dependencies/ExportsInfoDependency.js
+++ b/lib/dependencies/ExportsInfoDependency.js
@@ -25,7 +25,7 @@ const NullDependency = require("./NullDependency");
 /**
  * @param {ModuleGraph} moduleGraph the module graph
  * @param {Module} module the module
- * @param {string | null} exportName name of the export if any
+ * @param {string[] | null} exportName name of the export if any
  * @param {string | null} property name of the requested property
  * @param {RuntimeSpec} runtime for which runtime
  * @returns {any} value of the property
@@ -51,23 +51,19 @@ const getProperty = (moduleGraph, module, exportName, property, runtime) => {
 	switch (property) {
 		case "canMangle": {
 			const exportsInfo = moduleGraph.getExportsInfo(module);
-			const exportInfo = exportsInfo.getExportInfo(
-				/** @type {string} */ (exportName)
-			);
+			const exportInfo = exportsInfo.getExportInfo(exportName[0]);
 			if (exportInfo) return exportInfo.canMangle;
 			return exportsInfo.otherExportsInfo.canMangle;
 		}
 		case "used":
 			return (
-				moduleGraph
-					.getExportsInfo(module)
-					.getUsed(/** @type {string} */ (exportName), runtime) !==
+				moduleGraph.getExportsInfo(module).getUsed(exportName, runtime) !==
 				UsageState.Unused
 			);
 		case "useInfo": {
 			const state = moduleGraph
 				.getExportsInfo(module)
-				.getUsed(/** @type {string} */ (exportName), runtime);
+				.getUsed(exportName, runtime);
 			switch (state) {
 				case UsageState.Used:
 				case UsageState.OnlyPropertiesUsed:
@@ -83,9 +79,7 @@ const getProperty = (moduleGraph, module, exportName, property, runtime) => {
 			}
 		}
 		case "provideInfo":
-			return moduleGraph
-				.getExportsInfo(module)
-				.isExportProvided(/** @type {string} */ (exportName));
+			return moduleGraph.getExportsInfo(module).isExportProvided(exportName);
 	}
 	return undefined;
 };
@@ -93,7 +87,7 @@ const getProperty = (moduleGraph, module, exportName, property, runtime) => {
 class ExportsInfoDependency extends NullDependency {
 	/**
 	 * @param {Range} range range
-	 * @param {TODO} exportName export name
+	 * @param {string[] | null} exportName export name
 	 * @param {string | null} property property
 	 */
 	constructor(range, exportName, property) {

--- a/test/configCases/mangle/exports-info-can-mangle/a.js
+++ b/test/configCases/mangle/exports-info-can-mangle/a.js
@@ -1,0 +1,2 @@
+export const aaa = "aaa";
+export const aaaCanMangle = __webpack_exports_info__.aaa.canMangle;

--- a/test/configCases/mangle/exports-info-can-mangle/b.js
+++ b/test/configCases/mangle/exports-info-can-mangle/b.js
@@ -1,0 +1,2 @@
+export const bbb = "bbb";
+export const bbbCanMangle = __webpack_exports_info__.bbb.canMangle;

--- a/test/configCases/mangle/exports-info-can-mangle/index.js
+++ b/test/configCases/mangle/exports-info-can-mangle/index.js
@@ -1,0 +1,10 @@
+import { aaa, aaaCanMangle } from "./a";
+import * as b from "./b"
+
+it("__webpack_exports_info__.xxx.canMangle should be correct", () => {
+	expect(aaa).toBe("aaa");
+	expect(aaaCanMangle).toBe(true);
+	const { bbb, bbbCanMangle } = b;
+	expect(bbb).toBe("bbb");
+	expect(bbbCanMangle).toBe(false);
+});

--- a/test/configCases/mangle/exports-info-can-mangle/webpack.config.js
+++ b/test/configCases/mangle/exports-info-can-mangle/webpack.config.js
@@ -1,0 +1,8 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	optimization: {
+		mangleExports: true,
+		usedExports: true,
+		providedExports: true
+	}
+};


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix canMangle on __webpack_exports_info__

before `exportName` is always an Array, so `exportsInfo.getExportInfo(exportName)` will always create a new export info, instead of getting the exist export info

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

added

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

none

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
