### PR TITLE
cleanup unnecessary return

### DIFF
--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -344,7 +344,6 @@ class CommonJsImportsParserPlugin {
 				);
 				dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 				parser.state.module.addPresentationalDependency(dep);
-				return true;
 			} else {
 				const result = processRequireItem(expr, param);
 				if (result === undefined) {
@@ -356,8 +355,8 @@ class CommonJsImportsParserPlugin {
 					dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 					parser.state.module.addPresentationalDependency(dep);
 				}
-				return true;
 			}
+			return true;
 		};
 		parser.hooks.call
 			.for("require")


### PR DESCRIPTION
This is merely a minor lint: it's unnecessary to maintain redundant return values.