### PR TITLE
fix: should not mangle when destructuring a reexport

### DIFF
--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -143,7 +143,8 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 	 */
 	getReferencedExports(moduleGraph, runtime) {
 		let ids = this.getIds(moduleGraph);
-		if (ids.length === 0) return this._getReferencedExportsInDestructuring();
+		if (ids.length === 0)
+			return this._getReferencedExportsInDestructuring(moduleGraph);
 		let namespaceObjectAsContext = this.namespaceObjectAsContext;
 		if (ids[0] === "default") {
 			const selfModule = moduleGraph.getParentModule(this);
@@ -160,7 +161,7 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 				case "default-only":
 				case "default-with-named":
 					if (ids.length === 1)
-						return this._getReferencedExportsInDestructuring();
+						return this._getReferencedExportsInDestructuring(moduleGraph);
 					ids = ids.slice(1);
 					namespaceObjectAsContext = true;
 					break;
@@ -178,21 +179,30 @@ class HarmonyImportSpecifierDependency extends HarmonyImportDependency {
 			ids = ids.slice(0, -1);
 		}
 
-		return this._getReferencedExportsInDestructuring(ids);
+		return this._getReferencedExportsInDestructuring(moduleGraph, ids);
 	}
 
 	/**
+	 * @param {ModuleGraph} moduleGraph module graph
 	 * @param {string[]=} ids ids
 	 * @returns {(string[] | ReferencedExport)[]} referenced exports
 	 */
-	_getReferencedExportsInDestructuring(ids) {
+	_getReferencedExportsInDestructuring(moduleGraph, ids) {
 		if (this.referencedPropertiesInDestructuring) {
 			/** @type {ReferencedExport[]} */
 			const refs = [];
+			const importedModule = moduleGraph.getModule(this);
+			const canMangle =
+				Array.isArray(ids) &&
+				ids.length > 0 &&
+				!moduleGraph
+					.getExportsInfo(importedModule)
+					.getExportInfo(ids[0])
+					.isReexport();
 			for (const key of this.referencedPropertiesInDestructuring) {
 				refs.push({
 					name: ids ? ids.concat([key]) : [key],
-					canMangle: Array.isArray(ids) && ids.length > 0
+					canMangle
 				});
 			}
 			return refs;

--- a/test/configCases/mangle/mangle-with-destructuring-assignment/index.js
+++ b/test/configCases/mangle/mangle-with-destructuring-assignment/index.js
@@ -1,4 +1,5 @@
 import * as module from "./module";
+import { obj3, obj3CanMangle, obj4, obj4CanMangle } from "./reexport?side-effects" // enable side effects to ensure reexport is not skipped
 
 it("should not mangle export when destructuring module", () => {
 	const { obj: { a, b }, objCanMangle } = module
@@ -18,4 +19,19 @@ it("should mangle export when destructuring module's porperty", () => {
 it("should mangle export when using module dot property", () => {
 	expect(module.aaa).toBe("aaa");
 	expect(module.aaaCanMangle).toBe(true)
+});
+
+it("should not mangle export when destructuring module's property is a module", () => {
+	const { aaa, bbb } = obj3;
+	expect(aaa).toBe("a");
+	expect(bbb).toBe("b");
+	expect(obj3CanMangle).toBe(false)
+});
+
+it("should not mangle export when destructuring module's nested property is a module", () => {
+	const { nested: { obj5, obj5CanMangle } } = obj4;
+	expect(obj5.aaa).toBe("a");
+	expect(obj5.bbb).toBe("b");
+	expect(obj4CanMangle).toBe(true);
+	expect(obj5CanMangle).toBe(false)
 });

--- a/test/configCases/mangle/mangle-with-destructuring-assignment/module2.js
+++ b/test/configCases/mangle/mangle-with-destructuring-assignment/module2.js
@@ -1,0 +1,2 @@
+export const aaa = "a";
+export const bbb = "b";

--- a/test/configCases/mangle/mangle-with-destructuring-assignment/module3.js
+++ b/test/configCases/mangle/mangle-with-destructuring-assignment/module3.js
@@ -1,0 +1,2 @@
+export const aaa = "a";
+export const bbb = "b";

--- a/test/configCases/mangle/mangle-with-destructuring-assignment/reexport.js
+++ b/test/configCases/mangle/mangle-with-destructuring-assignment/reexport.js
@@ -1,0 +1,6 @@
+export * as obj3 from "./module2"
+export const obj3CanMangle = __webpack_exports_info__.obj3.canMangle;
+
+import * as reexport2 from "./reexport2?side-effects"
+export const obj4 = { nested: reexport2 }
+export const obj4CanMangle = __webpack_exports_info__.reexport2.canMangle;

--- a/test/configCases/mangle/mangle-with-destructuring-assignment/reexport2.js
+++ b/test/configCases/mangle/mangle-with-destructuring-assignment/reexport2.js
@@ -1,0 +1,2 @@
+export * as obj5 from "./module3"
+export const obj5CanMangle = __webpack_exports_info__.obj5.canMangle;

--- a/test/configCases/mangle/mangle-with-destructuring-assignment/webpack.config.js
+++ b/test/configCases/mangle/mangle-with-destructuring-assignment/webpack.config.js
@@ -1,5 +1,13 @@
 /** @type {import("../../../../").Configuration} */
 module.exports = {
+	module: {
+		rules: [
+			{
+				resourceQuery: /side-effects/,
+				sideEffects: true
+			}
+		]
+	},
 	optimization: {
 		mangleExports: true,
 		usedExports: true,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

fix #18091

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

should not mangle the export name when export is an reexport

```js
// module1.js
export * as module2 from "./module2"

// index.js
import { module2 } from "./module1"
const { a } = module2
```

since `const { a } = m2` is not destructing module1, it's destructing module1's property, so before the canMangle is set to true, but in this case, m2 is a reexport of module2, even though module2 is module1's property, but module2 is still a module, so it can't be mangled

This PR disable mangle reexport

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

added

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

none
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
