### PR TITLE
Remove duplicate assign to _otherExportsInfo.canMangleUse

### DIFF
--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -207,9 +207,6 @@ class ExportsInfo {
 			this._redirectTo.setHasUseInfo();
 		} else {
 			this._otherExportsInfo.setHasUseInfo();
-			if (this._otherExportsInfo.canMangleUse === undefined) {
-				this._otherExportsInfo.canMangleUse = true;
-			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Remove duplicate assign to _otherExportsInfo.canMangleUse, as `this._otherExportsInfo.setHasUseInfo()` already assign `canMangle` https://github.com/webpack/webpack/blob/c39a24c34f3dbb9fc2b7e445bac6bb0a45b261a2/lib/ExportsInfo.js#L957

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

no

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Not applied

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
