### PR TITLE
fix: parser hook calls for compiler plugins

### DIFF
--- a/lib/optimize/InnerGraph.js
+++ b/lib/optimize/InnerGraph.js
@@ -266,12 +266,11 @@ exports.tagTopLevelSymbol = (parser, name) => {
 	const innerGraphState = getState(parser.state);
 	if (!innerGraphState) return;
 
-	parser.defineVariable(name);
-
 	const existingTag = /** @type {TopLevelSymbol} */ (
 		parser.getTagData(name, topLevelSymbolTag)
 	);
 	if (existingTag) {
+		parser.defineVariable(name);
 		return existingTag;
 	}
 

--- a/test/CompilerParserHooks.test.js
+++ b/test/CompilerParserHooks.test.js
@@ -1,0 +1,76 @@
+"use strict";
+
+require("./helpers/warmup-webpack");
+
+const path = require("path");
+const { createFsFromVolume, Volume } = require("memfs");
+const { JAVASCRIPT_MODULE_TYPE_ESM } = require("../lib/ModuleTypeConstants");
+const pluginName = "CompilerParserHooksTest";
+
+describe("Compiler Parser Plugin", () => {
+	function runWebpackWithEntry(entry, setupParser) {
+		return new Promise((resolve, reject) => {
+			const webpack = require("..");
+			const compiler = webpack({
+				context: path.join(__dirname, "fixtures"),
+				entry: entry,
+				output: {
+					path: "/directory",
+					filename: "bundle.js"
+				},
+				plugins: [
+					{
+						apply(compiler) {
+							compiler.hooks.thisCompilation.tap(
+								pluginName,
+								(_, { normalModuleFactory }) => {
+									normalModuleFactory.hooks.parser
+										.for(JAVASCRIPT_MODULE_TYPE_ESM)
+										.tap(pluginName, parser => {
+											setupParser(parser);
+										});
+								}
+							);
+						}
+					}
+				]
+			});
+			compiler.outputFileSystem = createFsFromVolume(new Volume());
+			compiler.run(err => {
+				if (err) {
+					reject(err);
+				} else {
+					resolve();
+				}
+			});
+		});
+	}
+
+	describe("top level symbol", () => {
+		it("should trigger new hook for classes", async () => {
+			let foundExpression;
+			await runWebpackWithEntry("./top-level-symbols.mjs", parser => {
+				parser.hooks.new.for("TopLevelClass").tap(pluginName, expr => {
+					foundExpression = expr;
+				});
+			});
+			expect(foundExpression).toBeTruthy();
+			expect(foundExpression.type).toBe("NewExpression");
+			expect(foundExpression.callee.type).toBe("Identifier");
+			expect(foundExpression.callee.name).toBe("TopLevelClass");
+		});
+
+		it("should trigger call hooks for functions", async () => {
+			let foundExpression;
+			await runWebpackWithEntry("./top-level-symbols.mjs", parser => {
+				parser.hooks.call.for("topLevelFunction").tap(pluginName, expr => {
+					foundExpression = expr;
+				});
+			});
+			expect(foundExpression).toBeTruthy();
+			expect(foundExpression.type).toBe("CallExpression");
+			expect(foundExpression.callee.type).toBe("Identifier");
+			expect(foundExpression.callee.name).toBe("topLevelFunction");
+		});
+	});
+});

--- a/test/fixtures/top-level-symbols.mjs
+++ b/test/fixtures/top-level-symbols.mjs
@@ -1,0 +1,4 @@
+class TopLevelClass { }
+function topLevelFunction() { }
+new TopLevelClass();
+topLevelFunction();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fixes #18113

**Did you add tests for your changes?**

Yes, I added some new tests to ensure that the hooks are called. Needed to use the whole compiler to ensure all plugins (like InnerGraphPlugin) are registered as expected. 

I tried first to extend the JavaScriptParser.unittest.js but it didn't behave like the whole compiler. 

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

No special docs needed I'd say. 