### PR TITLE
fix: using shared default export in mjs module

### DIFF
--- a/lib/sharing/ConsumeSharedModule.js
+++ b/lib/sharing/ConsumeSharedModule.js
@@ -26,6 +26,7 @@ const ConsumeSharedFallbackDependency = require("./ConsumeSharedFallbackDependen
 /** @typedef {import("../Module").LibIdentOptions} LibIdentOptions */
 /** @typedef {import("../Module").NeedBuildContext} NeedBuildContext */
 /** @typedef {import("../Module").SourceTypes} SourceTypes */
+/** @typedef {import("../ModuleGraph")} ModuleGraph */
 /** @typedef {import("../RequestShortener")} RequestShortener */
 /** @typedef {import("../ResolverFactory").ResolverWithOptions} ResolverWithOptions */
 /** @typedef {import("../WebpackError")} WebpackError */
@@ -76,6 +77,19 @@ class ConsumeSharedModule extends Module {
 		return `${WEBPACK_MODULE_TYPE_CONSUME_SHARED_MODULE}|${shareScope}|${shareKey}|${
 			requiredVersion && rangeToString(requiredVersion)
 		}|${strictVersion}|${importResolved}|${singleton}|${eager}`;
+	}
+
+	/**
+	 * @param {ModuleGraph} moduleGraph the module graph
+	 * @param {boolean | undefined} strict the importing module is strict
+	 * @returns {"namespace" | "default-only" | "default-with-named" | "dynamic"} export type
+	 * "namespace": Exports is already a namespace object. namespace = exports.
+	 * "dynamic": Check at runtime if __esModule is set. When set: namespace = { ...exports, default: exports }. When not set: namespace = { default: exports }.
+	 * "default-only": Provide a namespace object with only default export. namespace = { default: exports }
+	 * "default-with-named": Provide a namespace object with named and default export. namespace = { ...exports, default: exports }
+	 */
+	getExportsType(moduleGraph, strict) {
+		return "dynamic";
 	}
 
 	/**

--- a/test/configCases/container/strict-module/index.js
+++ b/test/configCases/container/strict-module/index.js
@@ -1,0 +1,7 @@
+it("should use default export", () => {
+	return import('./main.mjs').then(res => {
+		const { React, setVersion } = res.get();
+		expect(typeof React).toBe('function');
+		expect(setVersion).toBeTruthy();
+	});
+});

--- a/test/configCases/container/strict-module/main.mjs
+++ b/test/configCases/container/strict-module/main.mjs
@@ -1,0 +1,6 @@
+import "containerA/ComponentA";
+import React, { setVersion } from "react";
+
+export function get() {
+	return { React, setVersion };
+}

--- a/test/configCases/container/strict-module/webpack.config.js
+++ b/test/configCases/container/strict-module/webpack.config.js
@@ -1,0 +1,20 @@
+// eslint-disable-next-line n/no-unpublished-require
+const { ModuleFederationPlugin } = require("../../../../").container;
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	plugins: [
+		new ModuleFederationPlugin({
+			remoteType: "commonjs-module",
+			remotes: {
+				containerA: "../0-container-full/container.js"
+			},
+			shared: {
+				react: {
+					import: false,
+					requiredVersion: false
+				}
+			}
+		})
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
yes

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
no

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

When importing a shared module from `.mjs`, the default variable refers to the module object instead of the default exported value.

This [codesandbox](https://codesandbox.io/p/devbox/webpack-module-federation-forked-w4pcrq?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clt5ka0eg00063b6ly6xh692v%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clt5ka0ef00023b6lfhjajj4x%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clt5ka0ef00043b6lf1hkau23%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clt5ka0ef00053b6l5m82bk58%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clt5ka0ef00023b6lfhjajj4x%2522%253A%257B%2522id%2522%253A%2522clt5ka0ef00023b6lfhjajj4x%2522%252C%2522activeTabId%2522%253A%2522clt5kntrp01si3b6l79mm7h6l%2522%252C%2522tabs%2522%253A%255B%257B%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252F.codesandbox%252Ftasks.json%2522%252C%2522id%2522%253A%2522clt5kntrp01si3b6l79mm7h6l%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%257D%252C%2522clt5ka0ef00053b6l5m82bk58%2522%253A%257B%2522id%2522%253A%2522clt5ka0ef00053b6l5m82bk58%2522%252C%2522activeTabId%2522%253A%2522clt5l8cm004py3b6lrksrwmth%2522%252C%2522tabs%2522%253A%255B%257B%2522type%2522%253A%2522TASK_PORT%2522%252C%2522port%2522%253A8080%252C%2522taskId%2522%253A%2522start%2522%252C%2522id%2522%253A%2522clt5l8cm004py3b6lrksrwmth%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522path%2522%253A%2522%252F%2522%257D%255D%257D%252C%2522clt5ka0ef00043b6lf1hkau23%2522%253A%257B%2522id%2522%253A%2522clt5ka0ef00043b6lf1hkau23%2522%252C%2522tabs%2522%253A%255B%257B%2522type%2522%253A%2522TASK_LOG%2522%252C%2522taskId%2522%253A%2522start%2522%252C%2522id%2522%253A%2522clt5kbncz009a3b6lld2xdqqh%2522%252C%2522mode%2522%253A%2522permanent%2522%257D%255D%252C%2522activeTabId%2522%253A%2522clt5kbncz009a3b6lld2xdqqh%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D) shows a minimal repro. The console shows that `Vue` points to the module object, which should have been `Vue.default` instead.

<img width="693" alt="image" src="https://github.com/webpack/webpack/assets/5051221/97dacf88-fd36-462f-ba03-875eff87f9cc">
