### PR TITLE
refactor: avoid using nonstandard the `readJson` function

### DIFF
--- a/lib/sharing/utils.js
+++ b/lib/sharing/utils.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-const { join, dirname, readJson } = require("../util/fs");
+const { join, dirname } = require("../util/fs");
 
 /** @typedef {import("../util/fs").InputFileSystem} InputFileSystem */
 
@@ -351,7 +351,7 @@ const getDescriptionFile = (fs, directory, descriptionFiles, callback) => {
 			);
 		}
 		const filePath = join(fs, directory, descriptionFiles[i]);
-		readJson(fs, filePath, (err, data) => {
+		const innerCallback = (err, data) => {
 			if (err) {
 				if ("code" in err && err.code === "ENOENT") {
 					i++;
@@ -365,6 +365,16 @@ const getDescriptionFile = (fs, directory, descriptionFiles, callback) => {
 				);
 			}
 			callback(null, { data, path: filePath });
+		};
+		fs.readFile(filePath, (err, buf) => {
+			if (err) return innerCallback(err);
+			let data;
+			try {
+				data = JSON.parse(/** @type {Buffer} */ (buf).toString("utf-8"));
+			} catch (e) {
+				return innerCallback(/** @type {Error} */ (e));
+			}
+			return innerCallback(null, data);
 		});
 	};
 	tryLoadCurrent();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

refactoring

for webpack@6 we should be align with node.js `fs` types and methods (not all, just minimum which we required for working) 

**Did you add tests for your changes?**

Existing

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

No
