### PR TITLE
fix: LoaderContext type

### DIFF
--- a/declarations/LoaderContext.d.ts
+++ b/declarations/LoaderContext.d.ts
@@ -195,19 +195,19 @@ export interface LoaderRunnerLoaderContext<OptionsType> {
 	 * The resource path.
 	 * In the example: "/abc/resource.js"
 	 */
-	resourcePath: string;
+	resourcePath?: string;
 
 	/**
 	 * The resource query string.
 	 * Example: "?query"
 	 */
-	resourceQuery: string;
+	resourceQuery?: string;
 
 	/**
 	 * The resource fragment.
 	 * Example: "#frag"
 	 */
-	resourceFragment: string;
+	resourceFragment?: string;
 
 	/**
 	 * The resource inclusive query and fragment.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Type wrong.

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

The `resourcePath`, `resourceQuery`, and `resourceFragment` properties within `LoaderRunnerLoaderContext` may not be defined if a loader is invoked without an associated resource.

For evidence of this behavior, refer to the test case located in `test/cases/loaders/query/index.js`. The test titled "should pass query to loader without resource" confirms this scenario.

However, this behavior could lead to type errors for loaders written in TypeScript. To address this, the `loader-runner` can be updated to assign an empty string as a default value for these properties.

Which plan do you think is better?

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
