### PR TITLE
fix:  library module without export statement

### DIFF
--- a/lib/FlagDependencyExportsPlugin.js
+++ b/lib/FlagDependencyExportsPlugin.js
@@ -15,11 +15,38 @@ const Queue = require("./util/Queue");
 /** @typedef {import("./Dependency").ExportsSpec} ExportsSpec */
 /** @typedef {import("./ExportsInfo")} ExportsInfo */
 /** @typedef {import("./Module")} Module */
+/** @typedef {import("./ModuleGraph")} ModuleGraph */
+/** @typedef {import("../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
 
 const PLUGIN_NAME = "FlagDependencyExportsPlugin";
 const PLUGIN_LOGGER_NAME = `webpack.${PLUGIN_NAME}`;
 
 class FlagDependencyExportsPlugin {
+	/**
+	 * @param {WebpackOptions} webpackOptions webpack options
+	 */
+	constructor(webpackOptions) {
+		this._webpackOptions = webpackOptions;
+	}
+
+	/**
+	 *
+	 * @param {Module} module module
+	 * @param {ModuleGraph} moduleGraph module graph
+	 * @returns {boolean} need flag exportsInfo
+	 */
+	needFlagModuleExports(module, moduleGraph) {
+		const { optimization, output } = this._webpackOptions;
+		const { providedExports } = optimization;
+		const { library } = output;
+		if (providedExports === false && library && library.type === "module") {
+			// only flag the entry module
+			let connection = Array.from(moduleGraph.getIncomingConnections(module));
+			return connection.length === 1 && connection[0].originModule === null;
+		}
+		return providedExports;
+	}
+
 	/**
 	 * Apply the plugin
 	 * @param {Compiler} compiler the compiler instance
@@ -32,6 +59,9 @@ class FlagDependencyExportsPlugin {
 			compilation.hooks.finishModules.tapAsync(
 				PLUGIN_NAME,
 				(modules, callback) => {
+					const _modules = Array.from(modules).filter(module =>
+						this.needFlagModuleExports(module, moduleGraph)
+					);
 					const logger = compilation.getLogger(PLUGIN_LOGGER_NAME);
 					let statRestoredFromMemCache = 0;
 					let statRestoredFromCache = 0;
@@ -48,7 +78,7 @@ class FlagDependencyExportsPlugin {
 					// Step 1: Try to restore cached provided export info from cache
 					logger.time("restore cached provided exports");
 					asyncLib.each(
-						modules,
+						_modules,
 						(module, callback) => {
 							const exportsInfo = moduleGraph.getExportsInfo(module);
 							// If the module doesn't have an exportsType, it's a module
@@ -388,12 +418,16 @@ class FlagDependencyExportsPlugin {
 			/** @type {WeakMap<Module, any>} */
 			const providedExportsCache = new WeakMap();
 			compilation.hooks.rebuildModule.tap(PLUGIN_NAME, module => {
+				if (!this.needFlagModuleExports(module, compilation.moduleGraph))
+					return;
 				providedExportsCache.set(
 					module,
 					moduleGraph.getExportsInfo(module).getRestoreProvidedData()
 				);
 			});
 			compilation.hooks.finishRebuildingModule.tap(PLUGIN_NAME, module => {
+				if (!this.needFlagModuleExports(module, compilation.moduleGraph))
+					return;
 				moduleGraph
 					.getExportsInfo(module)
 					.restoreProvided(providedExportsCache.get(module));

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -425,9 +425,14 @@ class WebpackOptionsApply extends OptionsApply {
 				options.optimization.sideEffects === true
 			).apply(compiler);
 		}
-		if (options.optimization.providedExports) {
+		if (
+			options.optimization.providedExports ||
+			(options.optimization.providedExports === false &&
+				options.output.library &&
+				options.output.library.type === "module")
+		) {
 			const FlagDependencyExportsPlugin = require("./FlagDependencyExportsPlugin");
-			new FlagDependencyExportsPlugin().apply(compiler);
+			new FlagDependencyExportsPlugin(options).apply(compiler);
 		}
 		if (options.optimization.usedExports) {
 			const FlagDependencyUsagePlugin = require("./FlagDependencyUsagePlugin");

--- a/test/configCases/output-module/issue-18056/index.js
+++ b/test/configCases/output-module/issue-18056/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+const m = true
+
+export default 'issue-18056'
+export { React, m }
+
+it("should compile and run", () => {
+});
+

--- a/test/configCases/output-module/issue-18056/run.js
+++ b/test/configCases/output-module/issue-18056/run.js
@@ -1,0 +1,6 @@
+it("should compile and run", () => {
+	expect(issue18056.default).toBe('issue-18056');
+	expect(issue18056.m).toBe(true);
+});
+
+

--- a/test/configCases/output-module/issue-18056/webpack.config.js
+++ b/test/configCases/output-module/issue-18056/webpack.config.js
@@ -1,0 +1,42 @@
+var webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = [
+	{
+		target: "node",
+		entry: {
+			import: "./index.js"
+		},
+		optimization: {
+			providedExports: false,
+			usedExports: true
+		},
+		output: {
+			libraryTarget: "module",
+			module: true,
+			chunkFormat: "module"
+		},
+		experiments: {
+			outputModule: true
+		},
+		externals: ["react"],
+		externalsType: "module"
+	},
+	{
+		entry: "./run.js",
+		plugins: [
+			new webpack.BannerPlugin({
+				raw: true,
+				banner:
+					"import mod, { m } from './bundle0.mjs';\nlet issue18056 = { default: mod, m };"
+			})
+		],
+		output: {
+			module: true,
+			chunkFormat: "module"
+		},
+		experiments: {
+			outputModule: true
+		}
+	}
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
fixes https://github.com/webpack/webpack/issues/18056

<!-- In addition to that please answer these questions: -->


**What kind of change does this PR introduce?**

When library === module and providedExport === false we also flag exportsInfo by FlagDependencyExportsPlugin but only for the entry module. Not sure if this is the optimal solution, but I tested it and it is indeed feasible.


<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
No
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
