### PR TITLE
chore: throw error when dll-plugin needs to generate multiple manifest files but the path config is incorrect.

### DIFF
--- a/lib/LibManifestPlugin.js
+++ b/lib/LibManifestPlugin.js
@@ -53,6 +53,8 @@ class LibManifestPlugin {
 			},
 			(compilation, callback) => {
 				const moduleGraph = compilation.moduleGraph;
+				// store used paths to detect issue and output an error. #18200
+				const usedPaths = new Set();
 				asyncLib.forEach(
 					Array.from(compilation.chunks),
 					(chunk, callback) => {
@@ -64,6 +66,11 @@ class LibManifestPlugin {
 						const targetPath = compilation.getPath(this.options.path, {
 							chunk
 						});
+						if (usedPaths.has(targetPath)) {
+							callback(new Error(`each chunk must have a unique path`));
+							return;
+						}
+						usedPaths.add(targetPath);
 						const name =
 							this.options.name &&
 							compilation.getPath(this.options.name, {

--- a/test/configCases/dll-plugin/5-issue-18200/a.js
+++ b/test/configCases/dll-plugin/5-issue-18200/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/test/configCases/dll-plugin/5-issue-18200/b.js
+++ b/test/configCases/dll-plugin/5-issue-18200/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/test/configCases/dll-plugin/5-issue-18200/errors.js
+++ b/test/configCases/dll-plugin/5-issue-18200/errors.js
@@ -1,0 +1,1 @@
+module.exports = [[/each chunk must have a unique path/]];

--- a/test/configCases/dll-plugin/5-issue-18200/webpack.config.js
+++ b/test/configCases/dll-plugin/5-issue-18200/webpack.config.js
@@ -1,0 +1,22 @@
+var path = require("path");
+var webpack = require("../../../../");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		a: "./a",
+		b: "./b"
+	},
+	output: {
+		filename: "MyDll.[name].js",
+		library: "[name]_[fullhash]"
+	},
+	plugins: [
+		new webpack.DllPlugin({
+			path: path.resolve(
+				__dirname,
+				"../../../js/config/dll-plugin/manifest_without_string_template.json"
+			)
+		})
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Output error information in specific dll-plugin usage scenarios. related to #18200.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Not yet, If necessary, I will add test cases after getting familiar with the test code.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

I will send another PR to document repo later.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
