### PR TITLE
docs: add new html-bundler-webpack-plugin to plugins list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ within webpack itself use this plugin interface. This makes webpack very
 | :---------------------------------------: | :----------------: | :-----------------: | :-------------------------------------------------------------------------------------- |
 |    [mini-css-extract-plugin][mini-css]    |  ![mini-css-npm]   |  ![mini-css-size]   | Extracts CSS into separate files. It creates a CSS file per JS file which contains CSS. |
 | [compression-webpack-plugin][compression] | ![compression-npm] | ![compression-size] | Prepares compressed versions of assets to serve them with Content-Encoding              |
+|  [html-bundler-webpack-plugin][bundler]   |   ![bundler-npm]   |   ![bundler-size]   | Renders a template (EJS, Handlebars, Pug) with referenced source asset files into HTML. |
 |    [html-webpack-plugin][html-plugin]     | ![html-plugin-npm] | ![html-plugin-size] | Simplifies creation of HTML files (`index.html`) to serve your bundles                  |
 |         [pug-plugin][pug-plugin]          | ![pug-plugin-npm]  | ![pug-plugin-size]  | Renders Pug files to HTML, extracts JS and CSS from sources specified directly in Pug.  |
 
@@ -127,6 +128,9 @@ within webpack itself use this plugin interface. This makes webpack very
 [compression]: https://github.com/webpack-contrib/compression-webpack-plugin
 [compression-npm]: https://img.shields.io/npm/v/compression-webpack-plugin.svg
 [compression-size]: https://packagephobia.com/badge?p=compression-webpack-plugin
+[bundler]: https://github.com/webdiscus/html-bundler-webpack-plugin
+[bundler-npm]: https://img.shields.io/npm/v/html-bundler-webpack-plugin.svg
+[bundler-size]: https://packagephobia.com/badge?p=html-bundler-webpack-plugin
 [html-plugin]: https://github.com/jantimon/html-webpack-plugin
 [html-plugin-npm]: https://img.shields.io/npm/v/html-webpack-plugin.svg
 [html-plugin-size]: https://packagephobia.com/badge?p=html-webpack-plugin


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
- Update README.md

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
- Yes

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
- No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

## Summary

Hallo @sokra, hello @alexander-akait,

I have added the new modern [html-bundler-webpack-plugin](https://github.com/webdiscus/html-bundler-webpack-plugin) to the Plugin's list in the README.

## Details

This plugin allows using a template file as an [entry point](https://github.com/webdiscus/html-bundler-webpack-plugin#option-entry).

The HTML Bundler generates static HTML or template function from [any template](https://github.com/webdiscus/html-bundler-webpack-plugin#template-engine) (EJS, Handlebars, Nunjucks, Pug, etc.) containing source files of scripts, styles, images, fonts and other resources, similar to how it works in [Vite](https://vitejs.dev/guide/#index-html-and-project-root).

> **Note**
> 
> This plugin should increase the popularity of Webpack as it simplifies the creation of websites similar to `Vite`.\
> It is also a huge developer experience improvement as many things can be inferred from the HTML.

For example, the template contains references to source assets:
```html
<html>
<head>
  <!-- source SCSS file -->
  <link href="./style.scss" rel="stylesheet">
  <!-- source TypeScript file -->
  <script src="./App.ts" defer="defer"></script>
</head>
<body>
  <!-- source image file -->
  <img src="./map.png">
</body>
</html>
```

The generated HTML contains the output filenames of the processed source files:

```html
<html>
<head>
  <link href="assets/css/style.05e4dd86.css" rel="stylesheet">
  <script src="assets/js/app.f4b855d8.js" defer="defer"></script>
</head>
<body>
  <img src="assets/img/map.58b43bd8.png">
</body>
</html>
```

Very simple config using only one plugin:
```js
const HtmlBundlerPlugin = require('html-bundler-webpack-plugin');

module.exports = {
  pugins: [
    new HtmlBundlerPlugin({
      // define a relative or absolute path to template pages
      entry: 'src/views/',
      
      // OR define templates manually
      entry: {
        index: {
          import: 'src/views/home.ejs', // EJS template => dist/index.html
          data: { title: 'Homepage' } // pass variables into template
        },
        'news/sport': 'src/views/news/sport/index.html', // => dist/news/sport.html
      },
      
      js: {
        // output filename of JS extracted from source script specified in `<script>`
        filename: 'assets/js/[name].[contenthash:8].js',
        inline: 'auto', // inline JS in dev mode, extract to file in production mode
      },

      css: {
        // output filename of CSS extracted from source file specified in `<link>`
        filename: 'assets/css/[name].[contenthash:8].css',
        inline: 'auto', // inline CSS in dev mode, extract to file in production mode
      },
    }),
  ],
};
```

The plugin supports template engines such as  Eta, EJS, Handlebars, Nunjucks, LiquidJS and others "out of the box" without additional plugins and loaders.

The plugin extracts JS and CSS form source files referenced in HTML into output files.  Compiled JS and CSS can be inlined into generated HTML using the `ìnline` plugin option.
