### PR TITLE
fix: SyntaxError when setting runtimeChunk and module chunkFormat

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -242,9 +242,7 @@ const applyWebpackOptionsDefaults = options => {
 			(options.experiments.outputModule),
 		development,
 		entry: options.entry,
-		module: options.module,
-		futureDefaults,
-		optimization: options.optimization
+		futureDefaults
 	});
 
 	applyExternalsPresetsDefaults(options.externalsPresets, {
@@ -820,9 +818,7 @@ const applyModuleDefaults = (
  * @param {boolean} options.outputModule is outputModule experiment enabled
  * @param {boolean} options.development is development mode
  * @param {Entry} options.entry entry option
- * @param {ModuleOptions} options.module module option
  * @param {boolean} options.futureDefaults is future defaults enabled
- * @param {Optimization} options.optimization is future defaults enabled
  * @returns {void}
  */
 const applyOutputDefaults = (
@@ -834,9 +830,7 @@ const applyOutputDefaults = (
 		outputModule,
 		development,
 		entry,
-		module,
-		futureDefaults,
-		optimization
+		futureDefaults
 	}
 ) => {
 	/**
@@ -987,7 +981,7 @@ const applyOutputDefaults = (
 					if (tp.nodeBuiltins) return "async-node";
 					break;
 				case "module":
-					if (tp.dynamicImport || optimization.runtimeChunk) return "import";
+					if (tp.dynamicImport || output.module) return "import";
 					break;
 			}
 			if (
@@ -1012,8 +1006,7 @@ const applyOutputDefaults = (
 					if (tp.nodeBuiltins) return "async-node";
 					break;
 				case "module":
-					if (tp.dynamicImportInWorker || optimization.runtimeChunk)
-						return "import";
+					if (tp.dynamicImportInWorker || output.module) return "import";
 					break;
 			}
 			if (

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -243,7 +243,8 @@ const applyWebpackOptionsDefaults = options => {
 		development,
 		entry: options.entry,
 		module: options.module,
-		futureDefaults
+		futureDefaults,
+		optimization: options.optimization
 	});
 
 	applyExternalsPresetsDefaults(options.externalsPresets, {
@@ -821,6 +822,7 @@ const applyModuleDefaults = (
  * @param {Entry} options.entry entry option
  * @param {ModuleOptions} options.module module option
  * @param {boolean} options.futureDefaults is future defaults enabled
+ * @param {Optimization} options.optimization is future defaults enabled
  * @returns {void}
  */
 const applyOutputDefaults = (
@@ -833,7 +835,8 @@ const applyOutputDefaults = (
 		development,
 		entry,
 		module,
-		futureDefaults
+		futureDefaults,
+		optimization
 	}
 ) => {
 	/**
@@ -984,7 +987,7 @@ const applyOutputDefaults = (
 					if (tp.nodeBuiltins) return "async-node";
 					break;
 				case "module":
-					if (tp.dynamicImport) return "import";
+					if (tp.dynamicImport || optimization.runtimeChunk) return "import";
 					break;
 			}
 			if (
@@ -1009,7 +1012,8 @@ const applyOutputDefaults = (
 					if (tp.nodeBuiltins) return "async-node";
 					break;
 				case "module":
-					if (tp.dynamicImportInWorker) return "import";
+					if (tp.dynamicImportInWorker || optimization.runtimeChunk)
+						return "import";
 					break;
 			}
 			if (

--- a/test/configCases/output/chunk-format-with-runtimeChunk/index.js
+++ b/test/configCases/output/chunk-format-with-runtimeChunk/index.js
@@ -1,0 +1,4 @@
+it("should compile and run", () => {
+	const synaticError = 'SyntaxError: The requested module ./runtime.mjs does not provide an export named default'
+	expect(!synaticError).toBe(false);
+});

--- a/test/configCases/output/chunk-format-with-runtimeChunk/index.js
+++ b/test/configCases/output/chunk-format-with-runtimeChunk/index.js
@@ -1,4 +1,3 @@
 it("should compile and run", () => {
-	const synaticError = 'SyntaxError: The requested module ./runtime.mjs does not provide an export named default'
-	expect(!synaticError).toBe(false);
+	expect(true).toBe(true)
 });

--- a/test/configCases/output/chunk-format-with-runtimeChunk/test.config.js
+++ b/test/configCases/output/chunk-format-with-runtimeChunk/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function () {
+		return ["runtime.mjs", "main.mjs"];
+	}
+};

--- a/test/configCases/output/chunk-format-with-runtimeChunk/webpack.config.js
+++ b/test/configCases/output/chunk-format-with-runtimeChunk/webpack.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+	mode: "production",
+	target: "node",
+	entry: {
+		main: "./index.js"
+	},
+	optimization: {
+		runtimeChunk: "single"
+	},
+	output: {
+		filename: "[name].mjs",
+		module: true,
+		chunkFormat: "module"
+	},
+	experiments: {
+		outputModule: true
+	}
+};

--- a/test/configCases/output/chunk-format-with-runtimeChunk/webpack.config.js
+++ b/test/configCases/output/chunk-format-with-runtimeChunk/webpack.config.js
@@ -1,6 +1,5 @@
 module.exports = {
 	mode: "production",
-	target: "node",
 	entry: {
 		main: "./index.js"
 	},


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Set default value of `chunkLoading` to `import`(ESM) that fix runtimeChunk has no exports which causes syntaxError when setting `runtimeChunk` and `chunkFormat: module`


webpack.config.js
```javascript
module.exports = {
	// ...
    target: "node",
    optimization: {
        runtimeChunk: "single",
		minimize: false
    },
    output: {
        module: true,
        chunkFormat: 'module',
    },
    experiments: {
        outputModule: true,
    }
}
````

output:
- main.mjs
```javascript
// ...
// load runtime
import __webpack_require__ from "./runtime.mjs";
var __webpack_exec__ = (moduleId) => (__webpack_require__(__webpack_require__.s = moduleId))
import * as __webpack_chunk_0__ from "./main.mjs";
__webpack_require__.C(__webpack_chunk_0__);
var __webpack_exports__ = __webpack_exec__(463);
```
- runtime.mjs
```javascript
/******/ var __webpack_modules__ = ({});
/************************************************************************/
/******/ // The module cache
/******/ var __webpack_module_cache__ = {};
/******/ 
/******/ // The require function
/******/ function __webpack_require__(moduleId) {
/******/ 	// Check if module is in cache
/******/ 	var cachedModule = __webpack_module_cache__[moduleId];
/******/ 	if (cachedModule !== undefined) {
/******/ 		return cachedModule.exports;
/******/ 	}
/******/ 	// Create a new module (and put it into the cache)
/******/ 	var module = __webpack_module_cache__[moduleId] = {
/******/ 		// no module.id needed
/******/ 		// no module.loaded needed
/******/ 		exports: {}
/******/ 	};
/******/ 
/******/ 	// Execute the module function
/******/ 	__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
/******/ 
/******/ 	// Return the exports of the module
/******/ 	return module.exports;
/******/ }
/******/ 
/************************************************************************/
/******/ 
/******/ 
```

- node main.js
```javascript
import __webpack_require__ from "./runtime.mjs";
       ^^^^^^^^^^^^^^^^^^^
SyntaxError: The requested module './runtime.mjs' does not provide an export named 'default'
```


As seen, syntaxError happened because runtimeChunk doesn't contains following runtimeModule which added by `ModuleChunkLoadingPlugin`:

- webpack/runtime/export `export default __webpack_require__` 
- externalInstallChunk `__webpack_require__.c`

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
No

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
