### PR TITLE
Export InitFragment class for plugins

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -221,6 +221,9 @@ module.exports = mergeExports(fn, {
 	get HotModuleReplacementPlugin() {
 		return require("./HotModuleReplacementPlugin");
 	},
+	get InitFragment() {
+		return require("./InitFragment");
+	},
 	get IgnorePlugin() {
 		return require("./IgnorePlugin");
 	},

--- a/types.d.ts
+++ b/types.d.ts
@@ -5368,7 +5368,14 @@ declare interface InfrastructureLogging {
 	 */
 	stream?: NodeJS.WritableStream;
 }
-declare abstract class InitFragment<GenerateContext> {
+declare class InitFragment<GenerateContext> {
+	constructor(
+		content: undefined | string | Source,
+		stage: number,
+		position: number,
+		key?: string,
+		endContent?: string | Source
+	);
 	content?: string | Source;
 	stage: number;
 	position: number;
@@ -5379,6 +5386,18 @@ declare abstract class InitFragment<GenerateContext> {
 	serialize(context: ObjectSerializerContext): void;
 	deserialize(context: ObjectDeserializerContext): void;
 	merge: any;
+	static addToSource<Context, T>(
+		source: Source,
+		initFragments: InitFragment<T>[],
+		context: Context
+	): Source;
+	static STAGE_CONSTANTS: number;
+	static STAGE_ASYNC_BOUNDARY: number;
+	static STAGE_HARMONY_EXPORTS: number;
+	static STAGE_HARMONY_IMPORTS: number;
+	static STAGE_PROVIDES: number;
+	static STAGE_ASYNC_DEPENDENCIES: number;
+	static STAGE_ASYNC_HARMONY_IMPORTS: number;
 }
 declare interface InputFileSystem {
 	readFile: ReadFileFs;
@@ -15343,6 +15362,7 @@ declare namespace exports {
 		Generator,
 		HotUpdateChunk,
 		HotModuleReplacementPlugin,
+		InitFragment,
 		IgnorePlugin,
 		JavascriptModulesPlugin,
 		LibManifestPlugin,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Simply adds the `InitFragment` class to exports so that plugins can utilize it for creating custom dependencies.  See discussion in #18230.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Refactor
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
n/a
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
n/a
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
