### PR TITLE
updated parseRange/satisfy

### DIFF
--- a/lib/util/semver.js
+++ b/lib/util/semver.js
@@ -156,7 +156,7 @@ exports.parseRange = str => {
 				if (remainder.length > 1 && remainder[1] === 0) {
 					return [2, ...remainder.slice(1)];
 				  }
-				  return [1, ...remainder.slice(1)];
+				return [1, ...remainder.slice(1)];
 			case ">=":
 				return remainder;
 			case "=":

--- a/lib/util/semver.js
+++ b/lib/util/semver.js
@@ -153,7 +153,10 @@ exports.parseRange = str => {
 				}
 				return [1, ...remainder.slice(1)];
 			case "~":
-				return [2, ...remainder.slice(1)];
+				if (remainder.length > 1 && remainder[1] === 0) {
+					return [2, ...remainder.slice(1)];
+				  }
+				  return [1, ...remainder.slice(1)];
 			case ">=":
 				return remainder;
 			case "=":


### PR DESCRIPTION
This change resolves #17756 by adding edge case for "~" 
We will get *satisfy(parseRange('~1'), '1.2.3') === true*
Signed-off-by: Sharjidh <sharjidh2003@gmail.com>