### PR TITLE
(fix) Correct behavior of __webpack_exports_info__.a.b.canMangle

### DIFF
--- a/lib/dependencies/ExportsInfoDependency.js
+++ b/lib/dependencies/ExportsInfoDependency.js
@@ -52,7 +52,7 @@ const getProperty = (moduleGraph, module, _exportName, property, runtime) => {
 	switch (property) {
 		case "canMangle": {
 			const exportsInfo = moduleGraph.getExportsInfo(module);
-			const exportInfo = exportsInfo.getExportInfo(exportName[0]);
+			const exportInfo = exportsInfo.getReadOnlyExportInfoRecursive(exportName);
 			if (exportInfo) return exportInfo.canMangle;
 			return exportsInfo.otherExportsInfo.canMangle;
 		}

--- a/test/configCases/mangle/exports-info-can-mangle/c.js
+++ b/test/configCases/mangle/exports-info-can-mangle/c.js
@@ -1,3 +1,6 @@
-export * as c from "./b";
-export const cCanMangle = __webpack_exports_info__.c.canMangle;
-export const c_bbbCanMangle = __webpack_exports_info__.c.bbb.canMangle;
+export * as ca from "./a";
+export * as cb from "./b";
+export const caCanMangle = __webpack_exports_info__.ca.canMangle;
+export const cbCanMangle = __webpack_exports_info__.cb.canMangle;
+export const ca_aaaCanMangle = __webpack_exports_info__.ca.aaa.canMangle;
+export const cb_bbbCanMangle = __webpack_exports_info__.cb.bbb.canMangle;

--- a/test/configCases/mangle/exports-info-can-mangle/c.js
+++ b/test/configCases/mangle/exports-info-can-mangle/c.js
@@ -1,0 +1,3 @@
+export * as c from "./b";
+export const cCanMangle = __webpack_exports_info__.c.canMangle;
+export const c_bbbCanMangle = __webpack_exports_info__.c.bbb.canMangle;

--- a/test/configCases/mangle/exports-info-can-mangle/index.js
+++ b/test/configCases/mangle/exports-info-can-mangle/index.js
@@ -1,5 +1,6 @@
 import { aaa, aaaCanMangle } from "./a";
 import * as b from "./b"
+import { c_bbbCanMangle, c, cCanMangle } from "./c";
 
 it("__webpack_exports_info__.xxx.canMangle should be correct", () => {
 	expect(aaa).toBe("aaa");
@@ -7,4 +8,8 @@ it("__webpack_exports_info__.xxx.canMangle should be correct", () => {
 	const { bbb, bbbCanMangle } = b;
 	expect(bbb).toBe("bbb");
 	expect(bbbCanMangle).toBe(false);
+
+	expect(cCanMangle).toBe(true);
+	expect(c.bbb).toBe("bbb");
+	expect(c_bbbCanMangle).toBe(bbbCanMangle);
 });

--- a/test/configCases/mangle/exports-info-can-mangle/index.js
+++ b/test/configCases/mangle/exports-info-can-mangle/index.js
@@ -1,15 +1,23 @@
 import { aaa, aaaCanMangle } from "./a";
 import * as b from "./b"
-import { c_bbbCanMangle, c, cCanMangle } from "./c";
+import { ca, cb, caCanMangle, cbCanMangle, ca_aaaCanMangle, cb_bbbCanMangle } from "./c";
 
 it("__webpack_exports_info__.xxx.canMangle should be correct", () => {
 	expect(aaa).toBe("aaa");
 	expect(aaaCanMangle).toBe(true);
+
 	const { bbb, bbbCanMangle } = b;
 	expect(bbb).toBe("bbb");
 	expect(bbbCanMangle).toBe(false);
+	
+	expect(caCanMangle).toBe(true);
+	expect(cbCanMangle).toBe(true);
+});
 
-	expect(cCanMangle).toBe(true);
-	expect(c.bbb).toBe("bbb");
-	expect(c_bbbCanMangle).toBe(bbbCanMangle);
+it("__webpack_exports_info__.xxx.yyy.canMangle should be correct", () => {
+	expect(ca.aaa).toBe("aaa");
+	expect(ca_aaaCanMangle).toBe(aaaCanMangle);
+
+	expect(cb.bbb).toBe("bbb");
+	expect(cb_bbbCanMangle).toBe(b.bbbCanMangle);
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->
This PR fixes a gap in #18060 , which only handled the case of a single level of property access in `__webpack_exports_info__.a.canMangle` and would ignore any subsequent properties, i.e. `__webpack_exports_info__.a.b.canMangle` would return the same value as the former, regardless of the ability to mangle the nested property `b`.

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes, added a unit test to verify that `__webpack_exports_info__.a.canMangle` and `__webpack_exports_info__.a.b.canMangle` return different results if `a` cannot be mangled but `b` can.
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
This makes the `__webpack_exports_info__.a.b...c.canMangle` property act as documented.
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
