### PR TITLE
feat(css): allow to use default and named export

### DIFF
--- a/lib/css/CssParser.js
+++ b/lib/css/CssParser.js
@@ -1030,6 +1030,11 @@ class CssParser extends Parser {
 
 		module.buildInfo.strict = true;
 		module.buildMeta.exportsType = this.namedExports ? "namespace" : "default";
+
+		if (!this.namedExports) {
+			module.buildMeta.defaultObject = "redirect";
+		}
+
 		module.addDependency(new StaticExportsDependency([], true));
 		return state;
 	}

--- a/test/configCases/css/default-exports-parser-options/index.js
+++ b/test/configCases/css/default-exports-parser-options/index.js
@@ -1,0 +1,19 @@
+import * as style1 from "./style.module.css?namespace";
+import style2 from "./style.module.css?default";
+import { foo } from "./style.module.css?named";
+
+it("should able to import with default and named exports", () => {
+	expect(style1.default).toEqual(nsObj({ foo: '-_style_module_css_namespace-foo' }));
+	expect(style1.foo).toEqual("-_style_module_css_namespace-foo");
+	expect(style2).toEqual(nsObj({ foo: '-_style_module_css_default-foo' }));
+	expect(foo).toEqual("-_style_module_css_named-foo");
+});
+
+it("should able to import with different default and namex dynamic export", (done) => {
+	import("./style.module.css?namespace").then((style1) => {
+		expect(style1.default).toEqual(nsObj({ foo: '-_style_module_css_namespace-foo' }));
+		expect(style1.foo).toEqual('-_style_module_css_namespace-foo');
+
+		done();
+	}, done)
+});

--- a/test/configCases/css/default-exports-parser-options/style.module.css
+++ b/test/configCases/css/default-exports-parser-options/style.module.css
@@ -1,0 +1,3 @@
+.foo {
+	color: red;
+}

--- a/test/configCases/css/default-exports-parser-options/webpack.config.js
+++ b/test/configCases/css/default-exports-parser-options/webpack.config.js
@@ -1,0 +1,20 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	mode: "development",
+	devtool: false,
+	module: {
+		rules: [
+			{
+				test: /\.css/,
+				parser: {
+					namedExports: false
+				},
+				type: "css/module"
+			}
+		]
+	},
+	experiments: {
+		css: true
+	}
+};

--- a/test/configCases/css/named-exports-parser-options/index.js
+++ b/test/configCases/css/named-exports-parser-options/index.js
@@ -15,7 +15,10 @@ it("should able to import with different namedExports (async)", (done) => {
 		import("./style.module.css?named"),
 	]).then(([style1, style2, style3]) => {
 		expect(style1).toEqual(nsObj({ class: '-_style_module_css-class' }));
-		expect(style2).toEqual(nsObj({ default: nsObj({ class: '-_style_module_css_default-class' }) }));
+		expect(style2).toEqual(nsObj({
+			class: "-_style_module_css_default-class",
+			default: nsObj({ class: '-_style_module_css_default-class' })
+		}));
 		expect(style3).toEqual(nsObj({ class: '-_style_module_css_named-class' }));
 		done()
 	}, done)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feature - allow to use default and named export

The same as requested here - https://github.com/webpack-contrib/mini-css-extract-plugin/pull/1084

/cc @ahabhgk What do you think about it?

The main idea - allow to easy migrate from default to named, by default it is disabled (because we use only named export), but if developers have a lot of code, it is not easy to migrate fast, so developer can disable named export and use both of them

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

When named export is disabled for CSS modules you can get classes using (we redirect named export for better DX, it will allow to migrate from default export to named smoothly):
```js
import * as styles from "./styles.css";
import styles1 from "./styles.css";
import { foo } from "./styles.css";

console.log(styles.default.foo);
console.log(styles.foo);
console.log(styles1.foo);
console.log(foo);
```

When `namedExport: true`, you can use **only named export**.