### PR TITLE
fix: only render init code when need moduleRemapping

### DIFF
--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -284,13 +284,15 @@ const getSourceForModuleExternal = (
 	let expression = moduleRemapping || baseAccess;
 	return {
 		expression,
-		init: `var x = ${runtimeTemplate.basicFunction(
-			"y",
-			`var x = {}; ${RuntimeGlobals.definePropertyGetters}(x, y); return x`
-		)} \nvar y = ${runtimeTemplate.returningFunction(
-			runtimeTemplate.returningFunction("x"),
-			"x"
-		)}`,
+		init: moduleRemapping
+			? `var x = ${runtimeTemplate.basicFunction(
+					"y",
+					`var x = {}; ${RuntimeGlobals.definePropertyGetters}(x, y); return x`
+				)} \nvar y = ${runtimeTemplate.returningFunction(
+					runtimeTemplate.returningFunction("x"),
+					"x"
+				)}`
+			: undefined,
 		runtimeRequirements: moduleRemapping
 			? RUNTIME_REQUIREMENTS_FOR_MODULE
 			: undefined,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

For `ExternalModule`, render `init` code only when needing `moduleRemapping`, which will reduce useless code. Although the `init` code could be removed when minimizing, but this will help in some scenario, for example, we are using webpack to building bundleless package without running minimizing, this will help.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
No, the test code is not minimized, they should sufficient so far. Feel free to let me what kind of case should be added. :)

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

No.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
