### PR TITLE
fix: add return value to `subtractRuntime` fn

### DIFF
--- a/lib/util/runtime.js
+++ b/lib/util/runtime.js
@@ -390,6 +390,7 @@ const subtractRuntime = (a, b) => {
 			}
 			const set = new SortableSet(a);
 			set.delete(b);
+			return set;
 		} else {
 			const set = new SortableSet();
 			for (const item of a) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
fixes `subtractRuntime` returns `undefined` when params `a` is `Set<runtime~a, runtime~b,runtime~c>` and params `b` is `runtime~a` but it is expected to return `Set<runtime~b,runtime~c>`
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
No
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
