### PR TITLE
ci: use x64 arch node 10.x for macos-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,10 +139,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        id: calculate_architecture
+        with:
+          result-encoding: string
+          script: |
+            if ('${{ matrix.os }}' === 'macos-latest' && '${{ matrix['node-version'] }}' === '10.x') {
+              return "x64"
+            } else {
+              return ''
+            }
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          architecture: ${{ steps.calculate_architecture.outputs.result }}
           cache: "yarn"
       # Install old `jest` version and deps for legacy node versions
       - run: |


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix the integration CI fails on node 10.x running on `macos-latest` lately.

some context:
- `macos-latest` now runs on ARM chips https://github.com/actions/runner-images/issues/9741#issuecomment-2075259811.
- no ARM version for node 10.x is [available](https://github.com/actions/node-versions/releases/tag/10.24.1-725060485), also see https://github.com/actions/setup-node/issues/1017#issuecomment-2077362713.

so this PR specify architecture for node 10.x on ARM64 macos-latest as a workaround.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
