### PR TITLE
Correct the verb "to need" for the singular form "he", "she" & "it": lacking the "s" at "it needs"

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -2368,7 +2368,7 @@ export interface PerformanceOptions {
  */
 export interface SnapshotOptions {
 	/**
-	 * Options for snapshotting build dependencies to determine if the whole cache need to be invalidated.
+	 * Options for snapshotting build dependencies to determine if the whole cache needs to be invalidated.
 	 */
 	buildDependencies?: {
 		/**

--- a/examples/asset-advanced/README.md
+++ b/examples/asset-advanced/README.md
@@ -137,7 +137,7 @@ module.exports = "data:image/svg+xml,%3csvg xmlns='http://www.w3.or...3c/svg%3e"
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/asset-simple/README.md
+++ b/examples/asset-simple/README.md
@@ -153,7 +153,7 @@ module.exports = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDo...vc3ZnPgo="
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/cjs-tree-shaking/README.md
+++ b/examples/cjs-tree-shaking/README.md
@@ -151,7 +151,7 @@ __webpack_unused_export__ = function multiply() {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/code-splitting-bundle-loader/README.md
+++ b/examples/code-splitting-bundle-loader/README.md
@@ -256,7 +256,7 @@ __webpack_require__.e(/*! require.ensure */ 929).then((function(require) {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/code-splitting-harmony/README.md
+++ b/examples/code-splitting-harmony/README.md
@@ -361,7 +361,7 @@ module.exports = webpackAsyncContext;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be in strict mode.
+// This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
 (() => {
 "use strict";
 /*!********************!*\

--- a/examples/code-splitting-native-import-context-filter/README.md
+++ b/examples/code-splitting-native-import-context-filter/README.md
@@ -335,7 +335,7 @@ module.exports = webpackAsyncContext;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/code-splitting-native-import-context/README.md
+++ b/examples/code-splitting-native-import-context/README.md
@@ -324,7 +324,7 @@ module.exports = webpackAsyncContext;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/code-splitting-specify-chunk-name/README.md
+++ b/examples/code-splitting-specify-chunk-name/README.md
@@ -316,7 +316,7 @@ module.exports = webpackAsyncContext;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/code-splitting/README.md
+++ b/examples/code-splitting/README.md
@@ -271,7 +271,7 @@ require.ensure(["c"], function(require) {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/coffee-script/README.md
+++ b/examples/coffee-script/README.md
@@ -99,7 +99,7 @@ module.exports = 42;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/commonjs/README.md
+++ b/examples/commonjs/README.md
@@ -115,7 +115,7 @@ exports.add = function() {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/css/README.md
+++ b/examples/css/README.md
@@ -382,7 +382,7 @@ module.exports = __webpack_require__.p + "89a353e9c515885abd8e.png";
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/custom-json-modules/README.md
+++ b/examples/custom-json-modules/README.md
@@ -211,7 +211,7 @@ module.exports = JSON.parse('{"title":"JSON5 Example","owner":{"name":"Tom Prest
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/dll-app-and-vendor/1-app/README.md
+++ b/examples/dll-app-and-vendor/1-app/README.md
@@ -127,7 +127,7 @@ module.exports = vendor_lib_bef1463383efb1c65306;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be in strict mode.
+// This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
 (() => {
 "use strict";
 /*!************************!*\

--- a/examples/dll-user/README.md
+++ b/examples/dll-user/README.md
@@ -174,7 +174,7 @@ module.exports = (__webpack_require__(/*! dll-reference alpha_a53f6ab3ecd4de1831
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/externals/README.md
+++ b/examples/externals/README.md
@@ -126,7 +126,7 @@ module.exports = __WEBPACK_EXTERNAL_MODULE__2__;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 var exports = __webpack_exports__;
 /*!********************!*\

--- a/examples/harmony-interop/README.md
+++ b/examples/harmony-interop/README.md
@@ -235,7 +235,7 @@ var named = "named";
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be in strict mode.
+// This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
 (() => {
 "use strict";
 /*!********************!*\

--- a/examples/harmony-unused/README.md
+++ b/examples/harmony-unused/README.md
@@ -213,7 +213,7 @@ function c() { console.log("c"); }
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/harmony/README.md
+++ b/examples/harmony/README.md
@@ -305,7 +305,7 @@ function add() {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/loader/README.md
+++ b/examples/loader/README.md
@@ -236,7 +236,7 @@ module.exports = function (cssWithMappingToString) {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/mixed/README.md
+++ b/examples/mixed/README.md
@@ -369,7 +369,7 @@ __webpack_require__.r(__webpack_exports__);
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/module-federation/README.md
+++ b/examples/module-federation/README.md
@@ -313,7 +313,7 @@ import React from "react";
 import { formatRelative, subDays } from "date-fns";
 // date-fns is a shared module, but used as usual
 // exposing modules act as async boundary,
-// so no additional async boundary need to be added here
+// so no additional async boundary needs to be added here
 // As data-fns is an shared module, it will be placed in a separate file
 // It will be loaded in parallel to the code of this module
 

--- a/examples/module-federation/src-b/Component.js
+++ b/examples/module-federation/src-b/Component.js
@@ -2,7 +2,7 @@ import React from "react";
 import { formatRelative, subDays } from "date-fns";
 // date-fns is a shared module, but used as usual
 // exposing modules act as async boundary,
-// so no additional async boundary need to be added here
+// so no additional async boundary needs to be added here
 // As data-fns is an shared module, it will be placed in a separate file
 // It will be loaded in parallel to the code of this module
 

--- a/examples/multi-compiler/README.md
+++ b/examples/multi-compiler/README.md
@@ -116,7 +116,7 @@ console.log("Running " + "desktop" + " build");
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/named-chunks/README.md
+++ b/examples/named-chunks/README.md
@@ -249,7 +249,7 @@ require.ensure(["b"], function(require) {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/require.context/README.md
+++ b/examples/require.context/README.md
@@ -153,7 +153,7 @@ module.exports = function() {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/scope-hoisting/README.md
+++ b/examples/scope-hoisting/README.md
@@ -376,7 +376,7 @@ var x = "x";
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************************!*\
   !*** ./example.js + 2 modules ***!

--- a/examples/side-effects/README.md
+++ b/examples/side-effects/README.md
@@ -248,7 +248,7 @@ const b = "b";
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/top-level-await/README.md
+++ b/examples/top-level-await/README.md
@@ -467,7 +467,7 @@ const AlternativeCreateUserAction = async name => {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -119,7 +119,7 @@ console.log(getArray(1, 2, 3));
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -365,7 +365,7 @@ class AssetGenerator extends Generator {
 					module.buildInfo.assetInfo = assetInfo;
 					if (getData) {
 						// Due to code generation caching module.buildInfo.XXX can't used to store such information
-						// It need to be stored in the code generation results instead, where it's cached too
+						// It needs to be stored in the code generation results instead, where it's cached too
 						// TODO webpack 6 For back-compat reasons we also store in on module.buildInfo
 						const data = getData();
 						data.set("fullContentHash", fullHash);

--- a/lib/buildChunkGraph.js
+++ b/lib/buildChunkGraph.js
@@ -449,7 +449,7 @@ const visitModules = (
 		}
 	}
 	// pop() is used to read from the queue
-	// so it need to be reversed to be iterated in
+	// so it needs to be reversed to be iterated in
 	// correct order
 	queue.reverse();
 
@@ -641,7 +641,7 @@ const visitModules = (
 			}
 			connectList.add(/** @type {ChunkGroupInfo} */ (cgi));
 
-			// TODO check if this really need to be done for each traversal
+			// TODO check if this really needs to be done for each traversal
 			// or if it is enough when it's queued when created
 			// 4. We enqueue the DependenciesBlock for traversal
 			queueDelayed.push({
@@ -670,7 +670,7 @@ const visitModules = (
 			const minAvailableModules =
 				/** @type {bigint} */
 				(chunkGroupInfo.minAvailableModules);
-			// Buffer items because order need to be reversed to get indices correct
+			// Buffer items because order needs to be reversed to get indices correct
 			// Traverse all referenced modules
 			for (let i = 0, len = blockModules.length; i < len; i += 3) {
 				const refModule = /** @type {Module} */ (blockModules[i]);

--- a/lib/javascript/EnableChunkLoadingPlugin.js
+++ b/lib/javascript/EnableChunkLoadingPlugin.js
@@ -50,7 +50,7 @@ class EnableChunkLoadingPlugin {
 		if (!getEnabledTypes(compiler).has(type)) {
 			throw new Error(
 				`Chunk loading type "${type}" is not enabled. ` +
-					"EnableChunkLoadingPlugin need to be used to enable this type of chunk loading. " +
+					"EnableChunkLoadingPlugin needs to be used to enable this type of chunk loading. " +
 					'This usually happens through the "output.enabledChunkLoadingTypes" option. ' +
 					'If you are using a function as entry which sets "chunkLoading", you need to add all potential chunk loading types to "output.enabledChunkLoadingTypes". ' +
 					"These types are enabled: " +

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -845,18 +845,18 @@ class JavascriptModulesPlugin {
 					const webpackExports =
 						exports && m.exportsArgument === RuntimeGlobals.exports;
 					let iife = innerStrict
-						? "it need to be in strict mode."
+						? "it needs to be in strict mode."
 						: inlinedModules.size > 1
 							? // TODO check globals and top-level declarations of other entries and chunk modules
 								// to make a better decision
-								"it need to be isolated against other entry modules."
+								"it needs to be isolated against other entry modules."
 							: exports && !webpackExports
 								? `it uses a non-standard name for the exports (${m.exportsArgument}).`
 								: hooks.embedInRuntimeBailout.call(m, renderContext);
 					let footer;
 					if (iife !== undefined) {
 						startupSource.add(
-							`// This entry need to be wrapped in an IIFE because ${iife}\n`
+							`// This entry needs to be wrapped in an IIFE because ${iife}\n`
 						);
 						const arrow = runtimeTemplate.supportsArrowFunction();
 						if (arrow) {

--- a/lib/sharing/ConsumeSharedPlugin.js
+++ b/lib/sharing/ConsumeSharedPlugin.js
@@ -242,7 +242,7 @@ class ConsumeSharedPlugin {
 									);
 									if (typeof requiredVersion !== "string") {
 										requiredVersionWarning(
-											`Unable to find required version for "${packageName}" in description file (${descriptionPath}). It need to be in dependencies, devDependencies or peerDependencies.`
+											`Unable to find required version for "${packageName}" in description file (${descriptionPath}). It needs to be in dependencies, devDependencies or peerDependencies.`
 										);
 										return resolve();
 									}

--- a/lib/util/deterministicGrouping.js
+++ b/lib/util/deterministicGrouping.js
@@ -396,7 +396,7 @@ module.exports = ({ maxSize, minSize, items, getSize, getKey }) => {
 
 				// find unsplittable area from left and right
 				// going minSize from left and right
-				// at least one node need to be included otherwise we get stuck
+				// at least one node needs to be included otherwise we get stuck
 				let left = 1;
 				let leftSize = Object.create(null);
 				addSizeTo(leftSize, group.nodes[0].size);

--- a/lib/wasm/EnableWasmLoadingPlugin.js
+++ b/lib/wasm/EnableWasmLoadingPlugin.js
@@ -51,7 +51,7 @@ class EnableWasmLoadingPlugin {
 		if (!getEnabledTypes(compiler).has(type)) {
 			throw new Error(
 				`Library type "${type}" is not enabled. ` +
-					"EnableWasmLoadingPlugin need to be used to enable this type of wasm loading. " +
+					"EnableWasmLoadingPlugin needs to be used to enable this type of wasm loading. " +
 					'This usually happens through the "output.enabledWasmLoadingTypes" option. ' +
 					'If you are using a function as entry which sets "wasmLoading", you need to add all potential library types to "output.enabledWasmLoadingTypes". ' +
 					"These types are enabled: " +

--- a/open-bot.yaml
+++ b/open-bot.yaml
@@ -264,7 +264,7 @@ rules:
           * [ ] <!-- document --> This needs to be documented (issue in webpack/webpack.js.org will be filed when merged)
           * [ ] <!-- webpack-4-backport --> This needs to be backported to webpack 4 (issue will be created when merged)
 
-  # When a pull request need to be documented, create an issue in webpack/webpack.js.org when merged
+  # When a pull request needs to be documented, create an issue in webpack/webpack.js.org when merged
   - filters:
       pull_request:
         merged: true
@@ -294,7 +294,7 @@ rules:
         message: |-
           I've created an issue to document this in webpack/webpack.js.org.
 
-  # When a pull request need to be backported, create an issue in webpack/webpack when merged
+  # When a pull request needs to be backported, create an issue in webpack/webpack when merged
   - filters:
       pull_request:
         merged: true

--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -4670,7 +4670,7 @@
       "additionalProperties": false,
       "properties": {
         "buildDependencies": {
-          "description": "Options for snapshotting build dependencies to determine if the whole cache need to be invalidated.",
+          "description": "Options for snapshotting build dependencies to determine if the whole cache needs to be invalidated.",
           "type": "object",
           "additionalProperties": false,
           "properties": {

--- a/test/configCases/css/prefetch-preload-module/index.mjs
+++ b/test/configCases/css/prefetch-preload-module/index.mjs
@@ -1,4 +1,4 @@
-// This config need to be set on initial evaluation to be effective
+// This config needs to be set on initial evaluation to be effective
 __webpack_nonce__ = "nonce";
 __webpack_public_path__ = "https://example.com/public/path/";
 

--- a/test/configCases/output-module/reuse-webpack-esm-library/lib.js
+++ b/test/configCases/output-module/reuse-webpack-esm-library/lib.js
@@ -70,7 +70,7 @@ import * as __WEBPACK_EXTERNAL_MODULE_react__ from "react";
 /******/
 /************************************************************************/
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 	/*!***************************!*\
 		!*** ./src/store/call.ts ***!

--- a/test/configCases/web/prefetch-preload-module-jsonp/index.mjs
+++ b/test/configCases/web/prefetch-preload-module-jsonp/index.mjs
@@ -1,4 +1,4 @@
-// This config need to be set on initial evaluation to be effective
+// This config needs to be set on initial evaluation to be effective
 __webpack_nonce__ = "nonce";
 __webpack_public_path__ = "https://example.com/public/path/";
 

--- a/test/configCases/web/prefetch-preload-module/index.mjs
+++ b/test/configCases/web/prefetch-preload-module/index.mjs
@@ -1,4 +1,4 @@
-// This config need to be set on initial evaluation to be effective
+// This config needs to be set on initial evaluation to be effective
 __webpack_nonce__ = "nonce";
 __webpack_public_path__ = "https://example.com/public/path/";
 

--- a/test/configCases/web/prefetch-preload/index.js
+++ b/test/configCases/web/prefetch-preload/index.js
@@ -1,4 +1,4 @@
-// This config need to be set on initial evaluation to be effective
+// This config needs to be set on initial evaluation to be effective
 __webpack_nonce__ = "nonce";
 __webpack_public_path__ = "https://example.com/public/path/";
 

--- a/tooling/generate-runtime-code.js
+++ b/tooling/generate-runtime-code.js
@@ -86,7 +86,7 @@ exports.${name}RuntimeCode = runtimeTemplate => \`var ${name} = \${runtimeTempla
 				fs.writeFileSync(filePath, newContent, "utf-8");
 				console.error(`${file} updated`);
 			} else {
-				console.error(`${file} need to be updated`);
+				console.error(`${file} needs to be updated`);
 				process.exitCode = 1;
 			}
 		}

--- a/tooling/generate-wasm-code.js
+++ b/tooling/generate-wasm-code.js
@@ -82,7 +82,7 @@ const ${identifier} = new WebAssembly.Module(
 				fs.writeFileSync(filePath, newContent, "utf-8");
 				console.error(`${file} updated`);
 			} else {
-				console.error(`${file} need to be updated`);
+				console.error(`${file} needs to be updated`);
 				process.exitCode = 1;
 			}
 		}

--- a/types.d.ts
+++ b/types.d.ts
@@ -13122,7 +13122,7 @@ declare interface SnapshotOptionsFileSystemInfo {
  */
 declare interface SnapshotOptionsWebpackOptions {
 	/**
-	 * Options for snapshotting build dependencies to determine if the whole cache need to be invalidated.
+	 * Options for snapshotting build dependencies to determine if the whole cache needs to be invalidated.
 	 */
 	buildDependencies?: {
 		/**


### PR DESCRIPTION
Hi,

I know that it has nothing to do with coding and the way this powerful bundler works, but I was just reading the comments in some of my bundled JS files and noticed that the verb "to need" was often missing a "s" for the singular form "he needs" or "it needs to ...".

Typical example: "_**This entry need** to be wrapped in an IIFE because **it need** to be in strict mode._"

Conjugation of the verb "to need": https://www.theconjugator.com/english/verb/to+need.html

I effectively notice that some online dictionaries do not detect the mistake if the subject isn't the word "he", "she" or "it".
So "_This salad needs to be washed before eating it_" would be correct, but if you remove the "s", some dictionaries won't necessarily see the mistake. Or perhaps I'm totally wrong, and some new English rules allow removing the "s" in some situations?