### PR TITLE
fix: consider runtime for pure expression dependency update hash

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -3466,7 +3466,6 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 						dependencyTemplates,
 						runtimeTemplate,
 						runtime,
-						runtimes,
 						codeGenerationResults: results,
 						compilation: this
 					});

--- a/lib/DependencyTemplate.js
+++ b/lib/DependencyTemplate.js
@@ -31,8 +31,7 @@
  * @property {ChunkGraph} chunkGraph the chunk graph
  * @property {RuntimeRequirements} runtimeRequirements the requirements for runtime
  * @property {Module} module current module
- * @property {RuntimeSpec} runtime current runtime, for which code is generated
- * @property {RuntimeSpec[]} [runtimes] current runtimes, for which code is generated
+ * @property {RuntimeSpec} runtime current runtimes, for which code is generated
  * @property {InitFragment<GenerateContext>[]} initFragments mutable array of init fragments for the current module
  * @property {ConcatenationScope=} concatenationScope when in a concatenated module, information about other concatenated modules
  * @property {CodeGenerationResults} codeGenerationResults the code generation results

--- a/lib/Generator.js
+++ b/lib/Generator.js
@@ -28,7 +28,6 @@
  * @property {ChunkGraph} chunkGraph the chunk graph
  * @property {RuntimeRequirements} runtimeRequirements the requirements for runtime
  * @property {RuntimeSpec} runtime the runtime
- * @property {RuntimeSpec[]} [runtimes] the runtimes
  * @property {ConcatenationScope=} concatenationScope when in concatenated module, information about other concatenated modules
  * @property {CodeGenerationResults=} codeGenerationResults code generation results of other modules (need to have a codeGenerationDependency to use that)
  * @property {string} type which kind of code should be generated

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -61,8 +61,7 @@ const makeSerializable = require("./util/makeSerializable");
  * @property {RuntimeTemplate} runtimeTemplate the runtime template
  * @property {ModuleGraph} moduleGraph the module graph
  * @property {ChunkGraph} chunkGraph the chunk graph
- * @property {RuntimeSpec} runtime the runtime code should be generated for
- * @property {RuntimeSpec[]} [runtimes] the runtimes code should be generated for
+ * @property {RuntimeSpec} runtime the runtimes code should be generated for
  * @property {ConcatenationScope=} concatenationScope when in concatenated module, information about other concatenated modules
  * @property {CodeGenerationResults | undefined} codeGenerationResults code generation results of other modules (need to have a codeGenerationDependency to use that)
  * @property {Compilation=} compilation the compilation

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -1327,7 +1327,6 @@ class NormalModule extends Module {
 		moduleGraph,
 		chunkGraph,
 		runtime,
-		runtimes,
 		concatenationScope,
 		codeGenerationResults,
 		sourceTypes
@@ -1361,7 +1360,6 @@ class NormalModule extends Module {
 						chunkGraph,
 						runtimeRequirements,
 						runtime,
-						runtimes,
 						concatenationScope,
 						codeGenerationResults,
 						getData,

--- a/lib/dependencies/PureExpressionDependency.js
+++ b/lib/dependencies/PureExpressionDependency.js
@@ -7,12 +7,13 @@
 
 const { UsageState } = require("../ExportsInfo");
 const makeSerializable = require("../util/makeSerializable");
-const { filterRuntime, deepMergeRuntime } = require("../util/runtime");
+const { filterRuntime, runtimeToString } = require("../util/runtime");
 const NullDependency = require("./NullDependency");
 
 /** @typedef {import("webpack-sources").ReplaceSource} ReplaceSource */
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
 /** @typedef {import("../Dependency")} Dependency */
+/** @typedef {import("../Dependency").RuntimeSpec} RuntimeSpec */
 /** @typedef {import("../Dependency").UpdateHashContext} UpdateHashContext */
 /** @typedef {import("../DependencyTemplate").DependencyTemplateContext} DependencyTemplateContext */
 /** @typedef {import("../Module")} Module */
@@ -32,7 +33,31 @@ class PureExpressionDependency extends NullDependency {
 		this.range = range;
 		/** @type {Set<string> | false} */
 		this.usedByExports = false;
-		this._hashUpdate = undefined;
+	}
+
+	/**
+	 * @param {ModuleGraph} moduleGraph module graph
+	 * @param {RuntimeSpec} runtime current runtimes
+	 * @returns {boolean | RuntimeSpec} runtime condition
+	 */
+	_getRuntimeCondition(moduleGraph, runtime) {
+		const usedByExports = this.usedByExports;
+		if (usedByExports !== false) {
+			const selfModule =
+				/** @type {Module} */
+				(moduleGraph.getParentModule(this));
+			const exportsInfo = moduleGraph.getExportsInfo(selfModule);
+			const runtimeCondition = filterRuntime(runtime, runtime => {
+				for (const exportName of usedByExports) {
+					if (exportsInfo.getUsed(exportName, runtime) !== UsageState.Unused) {
+						return true;
+					}
+				}
+				return false;
+			});
+			return runtimeCondition;
+		}
+		return false;
 	}
 
 	/**
@@ -42,10 +67,22 @@ class PureExpressionDependency extends NullDependency {
 	 * @returns {void}
 	 */
 	updateHash(hash, context) {
-		if (this._hashUpdate === undefined) {
-			this._hashUpdate = this.range + "";
+		const runtimeCondition = this._getRuntimeCondition(
+			context.chunkGraph.moduleGraph,
+			context.runtime
+		);
+		if (runtimeCondition === true) {
+			return;
+		} else if (runtimeCondition === false) {
+			hash.update("null");
+		} else {
+			hash.update(
+				runtimeToString(runtimeCondition) +
+					"|" +
+					runtimeToString(context.runtime)
+			);
 		}
-		hash.update(this._hashUpdate);
+		hash.update(this.range + "");
 	}
 
 	/**
@@ -94,54 +131,31 @@ PureExpressionDependency.Template = class PureExpressionDependencyTemplate exten
 	apply(
 		dependency,
 		source,
-		{
-			chunkGraph,
-			moduleGraph,
-			runtime,
-			runtimes,
-			runtimeTemplate,
-			runtimeRequirements
-		}
+		{ chunkGraph, moduleGraph, runtime, runtimeTemplate, runtimeRequirements }
 	) {
 		const dep = /** @type {PureExpressionDependency} */ (dependency);
-
-		const usedByExports = dep.usedByExports;
-		if (usedByExports !== false) {
-			const selfModule =
-				/** @type {Module} */
-				(moduleGraph.getParentModule(dep));
-			const exportsInfo = moduleGraph.getExportsInfo(selfModule);
-			const merged = deepMergeRuntime(runtimes, runtime);
-			const runtimeCondition = filterRuntime(merged, runtime => {
-				for (const exportName of usedByExports) {
-					if (exportsInfo.getUsed(exportName, runtime) !== UsageState.Unused) {
-						return true;
-					}
-				}
-				return false;
+		const runtimeCondition = dep._getRuntimeCondition(moduleGraph, runtime);
+		if (runtimeCondition === true) {
+			return;
+		} else if (runtimeCondition === false) {
+			source.insert(
+				dep.range[0],
+				`(/* unused pure expression or super */ null && (`
+			);
+			source.insert(dep.range[1], "))");
+		} else {
+			const condition = runtimeTemplate.runtimeConditionExpression({
+				chunkGraph,
+				runtime,
+				runtimeCondition,
+				runtimeRequirements
 			});
-			if (runtimeCondition === true) return;
-			if (runtimeCondition !== false) {
-				const condition = runtimeTemplate.runtimeConditionExpression({
-					chunkGraph,
-					runtime: merged,
-					runtimeCondition,
-					runtimeRequirements
-				});
-				source.insert(
-					dep.range[0],
-					`(/* runtime-dependent pure expression or super */ ${condition} ? (`
-				);
-				source.insert(dep.range[1], ") : null)");
-				return;
-			}
+			source.insert(
+				dep.range[0],
+				`(/* runtime-dependent pure expression or super */ ${condition} ? (`
+			);
+			source.insert(dep.range[1], ") : null)");
 		}
-
-		source.insert(
-			dep.range[0],
-			`(/* unused pure expression or super */ null && (`
-		);
-		source.insert(dep.range[1], "))");
 	}
 };
 

--- a/lib/javascript/JavascriptGenerator.js
+++ b/lib/javascript/JavascriptGenerator.js
@@ -199,7 +199,6 @@ class JavascriptGenerator extends Generator {
 			chunkGraph: generateContext.chunkGraph,
 			module,
 			runtime: generateContext.runtime,
-			runtimes: generateContext.runtimes,
 			runtimeRequirements: generateContext.runtimeRequirements,
 			concatenationScope: generateContext.concatenationScope,
 			codeGenerationResults: generateContext.codeGenerationResults,

--- a/lib/util/runtime.js
+++ b/lib/util/runtime.js
@@ -230,22 +230,6 @@ const mergeRuntime = (a, b) => {
 exports.mergeRuntime = mergeRuntime;
 
 /**
- * @param {RuntimeSpec[] | undefined} runtimes first
- * @param {RuntimeSpec} runtime second
- * @returns {RuntimeSpec} merged
- */
-exports.deepMergeRuntime = (runtimes, runtime) => {
-	if (!Array.isArray(runtimes)) {
-		return runtime;
-	}
-	let merged = runtime;
-	for (const r of runtimes) {
-		merged = mergeRuntime(runtime, r);
-	}
-	return merged;
-};
-
-/**
  * @param {RuntimeCondition} a first
  * @param {RuntimeCondition} b second
  * @param {RuntimeSpec} runtime full runtime

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -2728,7 +2728,7 @@ LOG from webpack.FileSystemInfo
 exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
 "a-normal:
   assets by path *.js 3.25 KiB
-    asset 790fbdece493cc5b9f3f-790fbd.js 2.8 KiB [emitted] [immutable] [minimized] (name: runtime)
+    asset 98ebf2ab4f5380884cdf-98ebf2.js 2.8 KiB [emitted] [immutable] [minimized] (name: runtime)
     asset 0a1b2c7ae2cee5086d70-0a1b2c.js 232 bytes [emitted] [immutable] [minimized] (name: lazy)
     asset fdf80674ac46a61ff9fe-fdf806.js 213 bytes [emitted] [immutable] [minimized] (name: index)
     asset 666f2b8847021ccc7608-666f2b.js 21 bytes [emitted] [immutable] [minimized] (name: a, b)
@@ -2736,7 +2736,7 @@ exports[`StatsTestCases should print correct stats for real-content-hash 1`] = `
     asset 89a353e9c515885abd8e.png 14.6 KiB [emitted] [immutable] [from: file.png] (auxiliary name: lazy)
     asset 7382fad5b015914e0811.jpg?query 5.89 KiB [cached] [immutable] [from: file.jpg?query] (auxiliary name: lazy)
   asset 7382fad5b015914e0811.jpg 5.89 KiB [emitted] [immutable] [from: file.jpg] (auxiliary name: index)
-  Entrypoint index 3 KiB (5.89 KiB) = 790fbdece493cc5b9f3f-790fbd.js 2.8 KiB fdf80674ac46a61ff9fe-fdf806.js 213 bytes 1 auxiliary asset
+  Entrypoint index 3 KiB (5.89 KiB) = 98ebf2ab4f5380884cdf-98ebf2.js 2.8 KiB fdf80674ac46a61ff9fe-fdf806.js 213 bytes 1 auxiliary asset
   Entrypoint a 21 bytes = 666f2b8847021ccc7608-666f2b.js
   Entrypoint b 21 bytes = 666f2b8847021ccc7608-666f2b.js
   runtime modules 7.37 KiB 9 modules

--- a/types.d.ts
+++ b/types.d.ts
@@ -1564,14 +1564,9 @@ declare interface CodeGenerationContext {
 	chunkGraph: ChunkGraph;
 
 	/**
-	 * the runtime code should be generated for
-	 */
-	runtime: RuntimeSpec;
-
-	/**
 	 * the runtimes code should be generated for
 	 */
-	runtimes?: RuntimeSpec[];
+	runtime: RuntimeSpec;
 
 	/**
 	 * when in concatenated module, information about other concatenated modules
@@ -3251,14 +3246,9 @@ declare interface DependencyTemplateContext {
 	module: Module;
 
 	/**
-	 * current runtime, for which code is generated
-	 */
-	runtime: RuntimeSpec;
-
-	/**
 	 * current runtimes, for which code is generated
 	 */
-	runtimes?: RuntimeSpec[];
+	runtime: RuntimeSpec;
 
 	/**
 	 * mutable array of init fragments for the current module
@@ -4901,11 +4891,6 @@ declare interface GenerateContext {
 	 * the runtime
 	 */
 	runtime: RuntimeSpec;
-
-	/**
-	 * the runtimes
-	 */
-	runtimes?: RuntimeSpec[];
 
 	/**
 	 * when in concatenated module, information about other concatenated modules
@@ -15281,10 +15266,6 @@ declare namespace exports {
 			export let runtimeEqual: (a: RuntimeSpec, b: RuntimeSpec) => boolean;
 			export let compareRuntime: (a: RuntimeSpec, b: RuntimeSpec) => 0 | 1 | -1;
 			export let mergeRuntime: (a: RuntimeSpec, b: RuntimeSpec) => RuntimeSpec;
-			export let deepMergeRuntime: (
-				runtimes: undefined | RuntimeSpec[],
-				runtime: RuntimeSpec
-			) => RuntimeSpec;
 			export let mergeRuntimeCondition: (
 				a: RuntimeCondition,
 				b: RuntimeCondition,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

This should be a more reasonable fix compared to #16701 

`runtimes` means: in these `runtimes`, the code generation result should be the same as `runtime`, if the chunk graph module's hash are the same, the `runtime` will added to `runtimes`

https://github.com/webpack/webpack/blob/400db90db807d630b6c9f5e7ccde2b8f01690f3b/lib/Compilation.js#L3298-L3306

For example, the test case added in #18343:

The `codeGenerationJobs` generated for `module(pure.js)` should be:

```js
[
  {
    module: "pure.js",
    runtime: [runtime~entry1],
    runtimes: [[runtime~entry1]]
  },
  {
    module: "pure.js",
    runtime: [runtime~entry2, runtime~entry3],
    runtimes: [[runtime~entry2, runtime~entry3]]
  },
]
```

instead of:

```js
[
  {
    module: "pure.js",
    runtime: [runtime~entry2, runtime~entry3],
    runtimes: [[runtime~entry2, runtime~entry3], [runtime~entry1]]
  },
]
```

`PureExpressionDependency.updateHash` didn't consider `runtime`, different `runtime` will have different `runtimeCondition`, which will have different code generation result. Therefore, fixing `PureExpressionDependency.updateHash` will also correct the `codeGenerationJobs`.

This also brings additional benefits:

The generated `runtimeCondition` for `pure.js`:

```js
[
  {
    module: "pure.js",
    runtime: [runtime~entry1], // In runtime~entry1 is used, so runtimeCondition is `true`
    runtimes: [[runtime~entry1]]
  },
  {
    module: "pure.js",
    runtime: [runtime~entry2, runtime~entry3], // Only in runtime~entry2 is used, so runtimeCondition is `"runtime~entry2" == __webpack_require__.j`
    runtimes: [[runtime~entry2, runtime~entry3]]
  },
]
```

before it will deep merge `runtime` and `runtimes`, since `runtime` is always the first of `runtimes`, so basically it uses `runtimes` to generate the `runtimeCondition`:

```js
[
  {
    module: "pure.js",
    runtime: [runtime~entry2, runtime~entry3],
    runtimes: [[runtime~entry2, runtime~entry3], [runtime~entry1]] // In runtime~entry2 and runtime~entry1 are used, so runtimeCondition is `"runtime~entry3" != __webpack_require__.j`
  },
]
```

Since `pure.js (runtime~entry1)` will only appear in runtime~entry1, so `runtimeCondition: true` should be more performance than `runtimeCondition: "runtime~entry3" != __webpack_require__.j` (avoid one `!=`)

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

The test case added in #18343 should be enough

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

None

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
