### PR TITLE
fix: strip slash for pretty regexp

### DIFF
--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -185,13 +185,15 @@ class ContextModule extends Module {
 
 	/**
 	 * @private
-	 * @param {RegExp} regex RegExp
+	 * @param {RegExp} regexString RegExp as a string
 	 * @param {boolean=} stripSlash do we need to strip a slsh
 	 * @returns {string} pretty RegExp
 	 */
-	_prettyRegExp(regex, stripSlash = true) {
-		const regexString = stripSlash ? regex.source + regex.flags : regex + "";
-		return regexString.replace(/!/g, "%21").replace(/\|/g, "%7C");
+	_prettyRegExp(regexString, stripSlash = true) {
+		const str = stripSlash
+			? regexString.source + regexString.flags
+			: regexString + "";
+		return str.replace(/!/g, "%21").replace(/\|/g, "%7C");
 	}
 
 	_createIdentifier() {

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -185,13 +185,13 @@ class ContextModule extends Module {
 
 	/**
 	 * @private
-	 * @param {RegExp} regexString RegExp as a string
+	 * @param {RegExp} regex RegExp
 	 * @param {boolean=} stripSlash do we need to strip a slsh
 	 * @returns {string} pretty RegExp
 	 */
-	_prettyRegExp(regexString, stripSlash = true) {
-		const str = (regexString + "").replace(/!/g, "%21").replace(/\|/g, "%7C");
-		return stripSlash ? str.substring(1, str.length - 1) : str;
+	_prettyRegExp(regex, stripSlash = true) {
+		const regexString = stripSlash ? regex.source + regex.flags : regex + "";
+		return regexString.replace(/!/g, "%21").replace(/\|/g, "%7C");
 	}
 
 	_createIdentifier() {

--- a/test/cases/context/issue-10969/index.js
+++ b/test/cases/context/issue-10969/index.js
@@ -7,6 +7,6 @@ it("should replace ! with %21 in the module id string of the context module", fu
 	).id;
 	if (typeof moduleId !== "number")
 		expect(moduleId).toBe(
-			"./context/issue-10969/folder lazy recursive ^(?%21file1\\.js$).*$/"
+			"./context/issue-10969/folder lazy recursive ^(?%21file1\\.js$).*$i"
 		);
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix pretty regexp when stripSlash is true

for example: `_prettyRegExp(/\.js$/ig)` should be `\\.js$ig` instead of `\\.js$/i`

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Updated

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

None

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
