### PR TITLE
CI: Upgrade from Node v10 to v12 and Jest v27 to v28

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,7 @@ jobs:
         with:
           result-encoding: string
           script: |
-            if ('${{ matrix.os }}' === 'macos-latest' && '${{ matrix['node-version'] }}' === '10.x') {
+            if ('${{ matrix.os }}' === 'macos-latest' && '${{ matrix['node-version'] }}' === '12.x') {
               return "x64"
             } else {
               return ''

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 10.x
+          node-version: 12.x
           cache: "yarn"
       # Remove `devDependencies` from `package.json` to avoid `yarn install` compatibility error
       - run: node -e "const content = require('./package.json');delete content.devDependencies;require('fs').writeFileSync('package.json', JSON.stringify(content, null, 2));"
@@ -100,7 +100,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [10.x, 20.x]
+        node-version: [12.x, 20.x]
         part: [a, b]
         include:
           # Test with main branches of webpack dependencies
@@ -157,7 +157,7 @@ jobs:
           cache: "yarn"
       # Install old `jest` version and deps for legacy node versions
       - run: |
-          yarn upgrade jest@^27.5.0 jest-circus@^27.5.0 jest-cli@^27.5.0 jest-diff@^27.5.0 jest-environment-node@^27.5.0 jest-junit@^13.0.0 @types/jest@^27.4.0 pretty-format@^27.0.2 husky@^8.0.3 lint-staged@^13.2.1 cspell@^6.31.1 open-cli@^7.2.0 --ignore-engines
+          yarn upgrade jest@^28.1.3 jest-circus@^28.1.3 jest-cli@^28.1.3 jest-diff@^28.1.3 jest-environment-node@^28.1.3 jest-junit@^13.0.0 @types/jest@^28.1.1 pretty-format@^27.0.2 husky@^8.0.3 lint-staged@^13.2.1 cspell@^6.31.1 open-cli@^7.2.0 --ignore-engines
           yarn --frozen-lockfile --ignore-engines
         if: matrix.node-version == '10.x' || matrix.node-version == '12.x' || matrix.node-version == '14.x'
       - run: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,10 +107,10 @@ jobs:
       maxParallel: 6
       matrix:
         node-10-a:
-          node_version: ^10.13.0
+          node_version: ^12.22.12
           part: a
         node-10-b:
-          node_version: ^10.13.0
+          node_version: ^12.22.12
           part: b
         node-12-a:
           node_version: ^18.0.0
@@ -143,13 +143,13 @@ jobs:
         displayName: "Cache Yarn packages"
       # Install old `jest` version and ignore platform problem for legacy node versions
       - script: |
-          yarn upgrade jest@^27.5.0 jest-circus@^27.5.0 jest-cli@^27.5.0 jest-diff@^27.5.0 jest-environment-node@^27.5.0 jest-junit@^13.0.0 @types/jest@^27.4.0 pretty-format@^27.0.2 husky@^8.0.3 lint-staged@^13.2.1 cspell@^6.31.1 open-cli@^7.2.0 --ignore-engines
+          yarn upgrade jest@^28.1.3 jest-circus@^28.1.3 jest-cli@^28.1.3 jest-diff@^28.1.3 jest-environment-node@^28.1.3 jest-junit@^13.0.0 @types/jest@^28.1.1 pretty-format@^27.0.2 husky@^8.0.3 lint-staged@^13.2.1 cspell@^6.31.1 open-cli@^7.2.0 --ignore-engines
           yarn --frozen-lockfile --ignore-engines
         displayName: "Install dependencies (old node.js version)"
-        condition: eq(variables['node_version'], '^10.13.0')
+        condition: eq(variables['node_version'], '^12.22.12')
       - script: yarn --frozen-lockfile
         displayName: "Install dependencies"
-        condition: not(eq(variables['node_version'], '^10.13.0'))
+        condition: not(eq(variables['node_version'], '^12.22.12'))
       - script: yarn link --frozen-lockfile || true
         displayName: "Link webpack"
         continueOnError: true
@@ -178,10 +178,10 @@ jobs:
       maxParallel: 6
       matrix:
         node-10-a:
-          node_version: ^10.13.0
+          node_version: ^12.22.12
           part: a
         node-10-b:
-          node_version: ^10.13.0
+          node_version: ^12.22.12
           part: b
         node-12-a:
           node_version: ^18.0.0
@@ -218,12 +218,12 @@ jobs:
       - script: |
           set -e
           export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
-          yarn upgrade jest@^27.5.0 jest-circus@^27.5.0 jest-cli@^27.5.0 jest-diff@^27.5.0 jest-environment-node@^27.5.0 jest-junit@^13.0.0 @types/jest@^27.4.0 pretty-format@^27.0.2 husky@^8.0.3 lint-staged@^13.2.1 cspell@^6.31.1 open-cli@^7.2.0 --ignore-engines
+          yarn upgrade jest@^28.1.3 jest-circus@^28.1.3 jest-cli@^28.1.3 jest-diff@^28.1.3 jest-environment-node@^28.1.3 jest-junit@^13.0.0 @types/jest@^28.1.1 pretty-format@^27.0.2 husky@^8.0.3 lint-staged@^13.2.1 cspell@^6.31.1 open-cli@^7.2.0 --ignore-engines
           yarn --frozen-lockfile --ignore-engines
           yarn link --frozen-lockfile || true
           yarn link webpack --frozen-lockfile
         displayName: "Install dependencies (old node.js version)"
-        condition: eq(variables['node_version'], '^10.13.0')
+        condition: eq(variables['node_version'], '^12.22.12')
       - script: |
           set -e
           export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
@@ -231,7 +231,7 @@ jobs:
           yarn link --frozen-lockfile || true
           yarn link webpack --frozen-lockfile
         displayName: "Install dependencies"
-        condition: not(eq(variables['node_version'], '^10.13.0'))
+        condition: not(eq(variables['node_version'], '^12.22.12'))
       - script: |
           set -e
           export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
@@ -257,10 +257,10 @@ jobs:
       maxParallel: 6
       matrix:
         node-10-a:
-          node_version: ^10.13.0
+          node_version: ^12.22.12
           part: a
         node-10-b:
-          node_version: ^10.13.0
+          node_version: ^12.22.12
           part: b
         node-12-a:
           node_version: ^18.0.0
@@ -296,12 +296,12 @@ jobs:
       - script: |
           set -e
           export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
-          yarn upgrade jest@^27.5.0 jest-circus@^27.5.0 jest-cli@^27.5.0 jest-diff@^27.5.0 jest-environment-node@^27.5.0 jest-junit@^13.0.0 @types/jest@^27.4.0 pretty-format@^27.0.2 husky@^8.0.3 lint-staged@^13.2.1 cspell@^6.31.1 open-cli@^7.2.0 --ignore-engines
+          yarn upgrade jest@^28.1.3 jest-circus@^28.1.3 jest-cli@^28.1.3 jest-diff@^28.1.3 jest-environment-node@^28.1.3 jest-junit@^13.0.0 @types/jest@^28.1.1 pretty-format@^27.0.2 husky@^8.0.3 lint-staged@^13.2.1 cspell@^6.31.1 open-cli@^7.2.0 --ignore-engines
           yarn --frozen-lockfile --ignore-engines
           yarn link --frozen-lockfile || true
           yarn link webpack --frozen-lockfile
         displayName: "Install dependencies (old node.js version)"
-        condition: eq(variables['node_version'], '^10.13.0')
+        condition: eq(variables['node_version'], '^12.22.12')
       - script: |
           set -e
           export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
@@ -309,7 +309,7 @@ jobs:
           yarn link --frozen-lockfile || true
           yarn link webpack --frozen-lockfile
         displayName: "Install dependencies"
-        condition: not(eq(variables['node_version'], '^10.13.0'))
+        condition: not(eq(variables['node_version'], '^12.22.12'))
       - script: |
           set -e
           export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Update CI to run against Node v12 instead of v10 and with Jest 28 instead of Jest 27.

Node v10 is [EOL since April 2021](https://github.com/nodejs/release?tab=readme-ov-file#end-of-life-releases), and prevents newer versions of Jest (28+) from being used in CI. A different, old version of Jest is installed in CI for Node v10 runs, which means tests using newer Jest APIs break in Node v10 CI unexpectedly.

Per this comment: https://github.com/webpack/webpack/pull/18572#discussion_r1677173885 Node v10 is not supported

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

N/A

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No, not directly. But it means CI is no longer tested against Node v10, which means future changes could break usage with Node v10.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Update documented minimum supported Node version

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
