### PR TITLE
Support strictBuiltinIteratorReturn

### DIFF
--- a/lib/ChunkGraph.js
+++ b/lib/ChunkGraph.js
@@ -1696,7 +1696,9 @@ Caller might not support runtime-dependent code generation (opt-out via optimiza
 				hash.update(xor.toString(16));
 			};
 			if (activeNamespaceModules.size === 1)
-				addModuleToHash(/** @type {Module} */(activeNamespaceModules.values().next().value));
+				addModuleToHash(
+					/** @type {Module} */ (activeNamespaceModules.values().next().value)
+				);
 			else if (activeNamespaceModules.size > 1)
 				addModulesToHash(activeNamespaceModules);
 			for (const [stateInfo, modules] of connectedModulesInOrder) {

--- a/lib/ChunkGraph.js
+++ b/lib/ChunkGraph.js
@@ -1696,7 +1696,7 @@ Caller might not support runtime-dependent code generation (opt-out via optimiza
 				hash.update(xor.toString(16));
 			};
 			if (activeNamespaceModules.size === 1)
-				addModuleToHash(activeNamespaceModules.values().next().value);
+				addModuleToHash(/** @type {Module} */(activeNamespaceModules.values().next().value));
 			else if (activeNamespaceModules.size > 1)
 				addModulesToHash(activeNamespaceModules);
 			for (const [stateInfo, modules] of connectedModulesInOrder) {

--- a/lib/CodeGenerationResults.js
+++ b/lib/CodeGenerationResults.js
@@ -55,7 +55,7 @@ Caller might not support runtime-dependent code generation (opt-out via optimiza
 				}
 				return first(results);
 			}
-			return /** @type {CodeGenerationResult} */(entry.values().next().value);
+			return /** @type {CodeGenerationResult} */ (entry.values().next().value);
 		}
 		const result = entry.get(runtime);
 		if (result === undefined) {

--- a/lib/CodeGenerationResults.js
+++ b/lib/CodeGenerationResults.js
@@ -55,7 +55,7 @@ Caller might not support runtime-dependent code generation (opt-out via optimiza
 				}
 				return first(results);
 			}
-			return entry.values().next().value;
+			return /** @type {CodeGenerationResult} */(entry.values().next().value);
 		}
 		const result = entry.get(runtime);
 		if (result === undefined) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This updates the `webpack` build to be forwards compatible with microsoft/TypeScript#58243, which uses a stricter return type for built-in iterators under the new `strictBuiltinIteratorReturn` option, which is enabled by default when building with `strict`.

**Did you add tests for your changes?**

Tests should not be necessary for this change.

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing, this is purely related to TypeScript type checking of the `webpack` project itself.