### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     labels:
       - dependencies
     versioning-strategy: widen
+    groups:
+      dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Add `groups` to group updates dependencies instead of one PR for each update.

We'll see PRs like https://github.com/webpack/webpack.js.org/pull/7321 instead of https://github.com/webpack/webpack/pull/18596

Does it make sense to enable it for `webpack` repository?
