### PR TITLE
fix: module-import get fallback from externalsPresets

### DIFF
--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -22,6 +22,7 @@ const propertyAccess = require("./util/propertyAccess");
 const { register } = require("./util/serialization");
 
 /** @typedef {import("webpack-sources").Source} Source */
+/** @typedef {import("../declarations/WebpackOptions").ExternalsPresets} ExternalsPresets */
 /** @typedef {import("../declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
 /** @typedef {import("./Chunk")} Chunk */
 /** @typedef {import("./ChunkGraph")} ChunkGraph */
@@ -53,7 +54,7 @@ const { register } = require("./util/serialization");
 /** @typedef {import("./util/fs").InputFileSystem} InputFileSystem */
 /** @typedef {import("./util/runtime").RuntimeSpec} RuntimeSpec */
 
-/** @typedef {{ attributes?: ImportAttributes, externalType: "import" | "module" | undefined }} ImportDependencyMeta */
+/** @typedef {{ attributes?: ImportAttributes, externalType: "import" | "module" | undefined, externalsPresets: ExternalsPresets | undefined }} ImportDependencyMeta */
 /** @typedef {{ layer?: string, supports?: string, media?: string }} CssImportDependencyMeta */
 
 /** @typedef {ImportDependencyMeta | CssImportDependencyMeta} DependencyMeta */
@@ -166,7 +167,7 @@ const getSourceForImportExternal = (
 	const importName = runtimeTemplate.outputOptions.importFunctionName;
 	if (
 		!runtimeTemplate.supportsDynamicImport() &&
-		(importName === "import" || importName !== "module-import")
+		(importName === "import" || importName === "module-import")
 	) {
 		throw new Error(
 			"The target environment doesn't support 'import()' so it's not possible to use external type 'import'"
@@ -578,6 +579,25 @@ class ExternalModule extends Module {
 					canMangle = true;
 				}
 				break;
+			case "module":
+				if (this.buildInfo.module) {
+					if (!Array.isArray(request) || request.length === 1) {
+						this.buildMeta.exportsType = "namespace";
+						canMangle = true;
+					}
+				} else {
+					this.buildMeta.async = true;
+					EnvironmentNotSupportAsyncWarning.check(
+						this,
+						compilation.runtimeTemplate,
+						"external module"
+					);
+					if (!Array.isArray(request) || request.length === 1) {
+						this.buildMeta.exportsType = "namespace";
+						canMangle = false;
+					}
+				}
+				break;
 			case "script":
 				this.buildMeta.async = true;
 				EnvironmentNotSupportAsyncWarning.check(
@@ -594,52 +614,18 @@ class ExternalModule extends Module {
 					"external promise"
 				);
 				break;
-			case "module":
 			case "import":
-			case "module-import": {
-				const type =
-					externalType === "module-import" &&
-					this.dependencyMeta &&
-					/** @type {ImportDependencyMeta} */ (this.dependencyMeta).externalType
-						? /** @type {ImportDependencyMeta} */ (this.dependencyMeta)
-								.externalType
-						: externalType;
-
-				if (type === "module") {
-					if (this.buildInfo.module) {
-						if (!Array.isArray(request) || request.length === 1) {
-							this.buildMeta.exportsType = "namespace";
-							canMangle = true;
-						}
-					} else {
-						this.buildMeta.async = true;
-						EnvironmentNotSupportAsyncWarning.check(
-							this,
-							compilation.runtimeTemplate,
-							"external module"
-						);
-						if (!Array.isArray(request) || request.length === 1) {
-							this.buildMeta.exportsType = "namespace";
-							canMangle = false;
-						}
-					}
+				this.buildMeta.async = true;
+				EnvironmentNotSupportAsyncWarning.check(
+					this,
+					compilation.runtimeTemplate,
+					"external import"
+				);
+				if (!Array.isArray(request) || request.length === 1) {
+					this.buildMeta.exportsType = "namespace";
+					canMangle = false;
 				}
-
-				if (type === "import") {
-					this.buildMeta.async = true;
-					EnvironmentNotSupportAsyncWarning.check(
-						this,
-						compilation.runtimeTemplate,
-						"external import"
-					);
-					if (!Array.isArray(request) || request.length === 1) {
-						this.buildMeta.exportsType = "namespace";
-						canMangle = false;
-					}
-				}
-
 				break;
-			}
 		}
 		this.addDependency(new StaticExportsDependency(true, canMangle));
 		callback();
@@ -673,6 +659,36 @@ class ExternalModule extends Module {
 
 	_getRequestAndExternalType() {
 		let { request, externalType } = this;
+
+		if (externalType === "module-import") {
+			const dependencyMeta = /** @type {ImportDependencyMeta} */ (
+				this.dependencyMeta
+			);
+
+			if (dependencyMeta && dependencyMeta.externalType) {
+				externalType = dependencyMeta.externalType;
+			} else if (dependencyMeta && dependencyMeta.externalsPresets) {
+				const presets = dependencyMeta.externalsPresets;
+				// TODO: what if user set multiple presets?
+				if (presets.web) {
+					externalType = "module";
+				} else if (presets.webAsync) {
+					externalType = "import";
+				} else if (
+					presets.electron ||
+					presets.electronMain ||
+					presets.electronPreload ||
+					presets.electronRenderer ||
+					presets.node ||
+					presets.nwjs
+				) {
+					externalType = "node-commonjs";
+				}
+			} else {
+				externalType = "commonjs";
+			}
+		}
+
 		if (typeof request === "object" && !Array.isArray(request))
 			request = request[externalType];
 		return { request, externalType };
@@ -737,58 +753,43 @@ class ExternalModule extends Module {
 					runtimeTemplate
 				);
 			}
+			case "import":
+				return getSourceForImportExternal(
+					request,
+					runtimeTemplate,
+					/** @type {ImportDependencyMeta} */ (dependencyMeta)
+				);
 			case "script":
 				return getSourceForScriptExternal(request, runtimeTemplate);
-			case "module":
-			case "import":
-			case "module-import": {
-				const type =
-					externalType === "module-import" &&
-					dependencyMeta &&
-					/** @type {ImportDependencyMeta} */ (dependencyMeta).externalType
-						? /** @type {ImportDependencyMeta} */ (dependencyMeta).externalType
-						: externalType;
-
-				if (type === "import") {
+			case "module": {
+				if (!(/** @type {BuildInfo} */ (this.buildInfo).module)) {
+					if (!runtimeTemplate.supportsDynamicImport()) {
+						throw new Error(
+							`The target environment doesn't support dynamic import() syntax so it's not possible to use external type 'module' within a script${
+								runtimeTemplate.supportsEcmaScriptModuleSyntax()
+									? "\nDid you mean to build a EcmaScript Module ('output.module: true')?"
+									: ""
+							}`
+						);
+					}
 					return getSourceForImportExternal(
 						request,
 						runtimeTemplate,
 						/** @type {ImportDependencyMeta} */ (dependencyMeta)
 					);
 				}
-
-				if (type === "module") {
-					if (!(/** @type {BuildInfo} */ (this.buildInfo).module)) {
-						if (!runtimeTemplate.supportsDynamicImport()) {
-							throw new Error(
-								`The target environment doesn't support dynamic import() syntax so it's not possible to use external type 'module' within a script${
-									runtimeTemplate.supportsEcmaScriptModuleSyntax()
-										? "\nDid you mean to build a EcmaScript Module ('output.module: true')?"
-										: ""
-								}`
-							);
-						}
-						return getSourceForImportExternal(
-							request,
-							runtimeTemplate,
-							/** @type {ImportDependencyMeta} */ (dependencyMeta)
-						);
-					}
-					if (!runtimeTemplate.supportsEcmaScriptModuleSyntax()) {
-						throw new Error(
-							"The target environment doesn't support EcmaScriptModule syntax so it's not possible to use external type 'module'"
-						);
-					}
-					return getSourceForModuleExternal(
-						request,
-						moduleGraph.getExportsInfo(this),
-						runtime,
-						runtimeTemplate,
-						/** @type {ImportDependencyMeta} */ (dependencyMeta)
+				if (!runtimeTemplate.supportsEcmaScriptModuleSyntax()) {
+					throw new Error(
+						"The target environment doesn't support EcmaScriptModule syntax so it's not possible to use external type 'module'"
 					);
 				}
-
-				break;
+				return getSourceForModuleExternal(
+					request,
+					moduleGraph.getExportsInfo(this),
+					runtime,
+					runtimeTemplate,
+					/** @type {ImportDependencyMeta} */ (dependencyMeta)
+				);
 			}
 			case "var":
 			case "promise":

--- a/lib/ExternalModuleFactoryPlugin.js
+++ b/lib/ExternalModuleFactoryPlugin.js
@@ -14,6 +14,7 @@ const ImportDependency = require("./dependencies/ImportDependency");
 const { resolveByProperty, cachedSetProperty } = require("./util/cleverMerge");
 
 /** @typedef {import("../declarations/WebpackOptions").Externals} Externals */
+/** @typedef {import("../declarations/WebpackOptions").ExternalsPresets} ExternalsPresets */
 /** @typedef {import("./Compilation").DepConstructor} DepConstructor */
 /** @typedef {import("./ExternalModule").DependencyMeta} DependencyMeta */
 /** @typedef {import("./Module")} Module */
@@ -60,10 +61,12 @@ class ExternalModuleFactoryPlugin {
 	/**
 	 * @param {string | undefined} type default external type
 	 * @param {Externals} externals externals config
+	 * @param {ExternalsPresets} [externalsPresets] externals preset config
 	 */
-	constructor(type, externals) {
+	constructor(type, externals, externalsPresets) {
 		this.type = type;
 		this.externals = externals;
+		this.externalsPresets = externalsPresets;
 	}
 
 	/**
@@ -72,6 +75,7 @@ class ExternalModuleFactoryPlugin {
 	 */
 	apply(normalModuleFactory) {
 		const globalType = this.type;
+		const externalsPresets = this.externalsPresets;
 		normalModuleFactory.hooks.factorize.tapAsync(
 			"ExternalModuleFactoryPlugin",
 			(data, callback) => {
@@ -135,13 +139,20 @@ class ExternalModuleFactoryPlugin {
 
 						dependencyMeta = {
 							attributes: dependency.assertions,
-							externalType
+							externalType,
+							externalsPresets
 						};
 					} else if (dependency instanceof CssImportDependency) {
 						dependencyMeta = {
 							layer: dependency.layer,
 							supports: dependency.supports,
 							media: dependency.media
+						};
+					} else {
+						dependencyMeta = {
+							attributes: undefined,
+							externalType: undefined,
+							externalsPresets
 						};
 					}
 

--- a/lib/ExternalsPlugin.js
+++ b/lib/ExternalsPlugin.js
@@ -27,9 +27,11 @@ class ExternalsPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.compile.tap("ExternalsPlugin", ({ normalModuleFactory }) => {
-			new ExternalModuleFactoryPlugin(this.type, this.externals).apply(
-				normalModuleFactory
-			);
+			new ExternalModuleFactoryPlugin(
+				this.type,
+				this.externals,
+				compiler.options.externalsPresets
+			).apply(normalModuleFactory);
 		});
 	}
 }

--- a/test/configCases/externals/module-import-externals-presets/index.js
+++ b/test/configCases/externals/module-import-externals-presets/index.js
@@ -1,0 +1,6 @@
+import fs from 'fs'
+
+it("require should use `node-commonjs` when externalsPresets.node is true", () => {
+	const nodeCommonjsFs = require("node-commonjs-fs");
+	expect(nodeCommonjsFs).toBe(fs);
+});

--- a/test/configCases/externals/module-import-externals-presets/test.filter.js
+++ b/test/configCases/externals/module-import-externals-presets/test.filter.js
@@ -1,0 +1,2 @@
+module.exports = () =>
+	!process.version.startsWith("v10.") && !process.version.startsWith("v12.");

--- a/test/configCases/externals/module-import-externals-presets/webpack.config.js
+++ b/test/configCases/externals/module-import-externals-presets/webpack.config.js
@@ -1,0 +1,37 @@
+/** @typedef {import("../../../../").Compilation} Compilation */
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	externals: {
+		"node-commonjs-fs": "fs",
+		"node-commonjs-url": "url"
+	},
+	externalsType: "module-import",
+	externalsPresets: {
+		node: true
+	},
+	output: {
+		module: true
+	},
+	target: "node14",
+	experiments: {
+		outputModule: true
+	},
+	plugins: [
+		function () {
+			/**
+			 * @param {Compilation} compilation compilation
+			 * @returns {void}
+			 */
+			const handler = compilation => {
+				compilation.hooks.afterProcessAssets.tap("testcase", assets => {
+					const output = assets["bundle0.mjs"].source();
+					expect(output).toContain(
+						`module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("fs");`
+					);
+				});
+			};
+			this.hooks.compilation.tap("testcase", handler);
+		}
+	]
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -5399,6 +5399,7 @@ type ImportAttributes = Record<string, string> & {};
 declare interface ImportDependencyMeta {
 	attributes?: ImportAttributes;
 	externalType?: "import" | "module";
+	externalsPresets?: ExternalsPresets;
 }
 declare interface ImportModuleOptions {
 	/**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Adding fallback external type for `"module-import"` type when `"module"` and `"import"` are neither applicable.

In https://github.com/webpack/webpack/pull/18620, implement "module-import", but the premise is that we're using `import` or `import()` for external request, However, for example, if we use `require('...')`, "module-import" will failed to know which externals type to adopt ("import", "module", or even "node-commonjs"), and it will crash.

The possible options we may want to fall back to:

1. `node-commonjs`: to let `require('path')` code could run in Node.js + ESM (this is widely used).
2. `import`: possibly for some specific reason.
3. `module`: possibly for some specific reason.
4. `commonjs`: level the `require` there, to be bundled by a bundler.

In this PR, using `externalsPresets` to indicate which external to use as the fallback:

1. when the `exteranlsPresets` is node.js related (electrons, node, nwjs): use `node-commonjs`
2. when the `exteranlsPresets` is web: use `module`
3. when the `exteranlsPresets` is webAsync: use `import`
4. when `exteranlsPresets` is not assigned or derived, use `commonjs`

Since the implementation coupled the fallback with externalsPresets, when users want to set all ESM import/import() to `module-import` and leave other CJS require to `node-commonjs`, they need to override the node.js built-in externals type to `module-import` defined by `externalsPresets`.

There's a left TODO is when user setting multiple `externalsPresets` category, e.g. `{ node: true, web: true }`. Which one should we choose to use as fallback. Currently using a simple prioritization `module > import > node-commonjs`.


**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

Yes.

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Update https://github.com/webpack/webpack.js.org/pull/7345 after merged.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
