### PR TITLE
fix: mangle destruction incorrect with export named default

### DIFF
--- a/lib/dependencies/HarmonyImportSpecifierDependency.js
+++ b/lib/dependencies/HarmonyImportSpecifierDependency.js
@@ -343,7 +343,27 @@ HarmonyImportSpecifierDependency.Template = class HarmonyImportSpecifierDependen
 		}
 
 		if (dep.referencedPropertiesInDestructuring) {
-			const prefixedIds = ids[0] === "default" ? ids.slice(1) : ids;
+			let prefixedIds = ids;
+
+			if (ids[0] === "default") {
+				const selfModule = moduleGraph.getParentModule(dep);
+				const importedModule =
+					/** @type {Module} */
+					(moduleGraph.getModule(dep));
+				const exportsType = importedModule.getExportsType(
+					moduleGraph,
+					/** @type {BuildMeta} */
+					(selfModule.buildMeta).strictHarmonyModule
+				);
+				if (
+					(exportsType === "default-only" ||
+						exportsType === "default-with-named") &&
+					ids.length >= 1
+				) {
+					prefixedIds = ids.slice(1);
+				}
+			}
+
 			for (const {
 				id,
 				shorthand,

--- a/test/configCases/mangle/mangle-with-re-export-as-default/index.js
+++ b/test/configCases/mangle/mangle-with-re-export-as-default/index.js
@@ -1,0 +1,6 @@
+import namespace from "./re-exports";
+
+it("should mangle exports imported", () => {
+	const { foo } = namespace;
+	expect(foo).toBe('foo')
+});

--- a/test/configCases/mangle/mangle-with-re-export-as-default/module.js
+++ b/test/configCases/mangle/mangle-with-re-export-as-default/module.js
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/test/configCases/mangle/mangle-with-re-export-as-default/re-exports.js
+++ b/test/configCases/mangle/mangle-with-re-export-as-default/re-exports.js
@@ -1,0 +1,3 @@
+import * as namespace from './module';
+
+export { namespace as default };

--- a/test/configCases/mangle/mangle-with-re-export-as-default/webpack.config.js
+++ b/test/configCases/mangle/mangle-with-re-export-as-default/webpack.config.js
@@ -1,0 +1,9 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	optimization: {
+		mangleExports: true,
+		usedExports: true,
+		providedExports: true,
+		sideEffects: false // disable reexports optimization
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Webpack introduces mangle exports in destruction in #18319, there is an edge case can break user code

```js
// index.js
import foo from './re-exports'
const { value } = foo;
```

```js
// re-exports.js
import * as foo from './re-exports'
export { foo as default }
```

`const { value } = foo` can become invalid after mangle.

For more details you can see tests in this pr.

The reason is JSON module has no exportInfo with 'default', for example:

```json{ "foo": 1 }```

If I import json above, I get a JSON module with exportsInfo `{ "foo": ExportInfo }`, there is no ExportInfo for 'default', but user import json using default import, how does this be ?

Turns out there is a special case in `HarmonyImportSpecifierDependency` that will remove the 'default' from 'ids', and I don't know why

```js
getReferencedExports(moduleGraph, runtime) {
    let ids = this.getIds(moduleGraph);
    if (ids.length === 0) return this._getReferencedExportsInDestructuring();
    let namespaceObjectAsContext = this.namespaceObjectAsContext;
    if (ids[0] === "default") {
	    const selfModule = moduleGraph.getParentModule(this);
	    const importedModule =
		    (moduleGraph.getModule(this));
	    switch (
		    importedModule.getExportsType(
			    moduleGraph,
			    (selfModule.buildMeta).strictHarmonyModule
		    )
	    ) {
		    case "default-only":
		    case "default-with-named":
			    if (ids.length === 1)
				    return this._getReferencedExportsInDestructuring();
			    ids = ids.slice(1); // 👈 here, ids: ['default', 'foo'] becomes ids: ['foo']
			    namespaceObjectAsContext = true;
			    break;
		    case "dynamic":
			    return Dependency.EXPORTS_OBJECT_REFERENCED;
	    }
    }
    //... more code
}
```

Though I don't know why, I can tell that always remove 'default' in `ids` is not a good idea, so I changed the logic based on which in `getReferencedExports`.

**Did you add tests for your changes?**

Yep

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**
