### PR TITLE
feat: support `webpackIgnore` for `new URL()` construction

### DIFF
--- a/lib/dependencies/URLPlugin.js
+++ b/lib/dependencies/URLPlugin.js
@@ -6,13 +6,17 @@
 "use strict";
 
 const { pathToFileURL } = require("url");
+const CommentCompilationWarning = require("../CommentCompilationWarning");
 const {
 	JAVASCRIPT_MODULE_TYPE_AUTO,
 	JAVASCRIPT_MODULE_TYPE_ESM
 } = require("../ModuleTypeConstants");
+const RuntimeGlobals = require("../RuntimeGlobals");
+const UnsupportedFeatureWarning = require("../UnsupportedFeatureWarning");
 const BasicEvaluatedExpression = require("../javascript/BasicEvaluatedExpression");
 const { approve } = require("../javascript/JavascriptParserHelpers");
 const InnerGraph = require("../optimize/InnerGraph");
+const ConstDependency = require("./ConstDependency");
 const URLDependency = require("./URLDependency");
 
 /** @typedef {import("estree").NewExpression} NewExpressionNode */
@@ -46,6 +50,21 @@ class URLPlugin {
 				 */
 				const getUrl = module => pathToFileURL(module.resource);
 
+				const isMetaUrl = (parser, arg) => {
+					const chain = parser.extractMemberExpressionChain(arg);
+
+					if (
+						chain.members.length !== 1 ||
+						chain.object.type !== "MetaProperty" ||
+						chain.object.meta.name !== "import" ||
+						chain.object.property.name !== "meta" ||
+						chain.members[0] !== "url"
+					)
+						return false;
+
+					return true;
+				};
+
 				/**
 				 * @param {Parser} parser parser parser
 				 * @param {JavascriptParserOptions} parserOptions parserOptions
@@ -70,16 +89,7 @@ class URLPlugin {
 						)
 							return;
 
-						const chain = parser.extractMemberExpressionChain(arg2);
-
-						if (
-							chain.members.length !== 1 ||
-							chain.object.type !== "MetaProperty" ||
-							chain.object.meta.name !== "import" ||
-							chain.object.property.name !== "meta" ||
-							chain.members[0] !== "url"
-						)
-							return;
+						if (!isMetaUrl(parser, arg2)) return;
 
 						return parser.evaluateExpression(arg1).asString();
 					};
@@ -98,6 +108,52 @@ class URLPlugin {
 						});
 					parser.hooks.new.for("URL").tap(PLUGIN_NAME, _expr => {
 						const expr = /** @type {NewExpressionNode} */ (_expr);
+						const { options: importOptions, errors: commentErrors } =
+							parser.parseCommentOptions(/** @type {Range} */ (expr.range));
+
+						if (commentErrors) {
+							for (const e of commentErrors) {
+								const { comment } = e;
+								parser.state.module.addWarning(
+									new CommentCompilationWarning(
+										`Compilation error while processing magic comment(-s): /*${comment.value}*/: ${e.message}`,
+										comment.loc
+									)
+								);
+							}
+						}
+
+						if (importOptions && importOptions.webpackIgnore !== undefined) {
+							if (typeof importOptions.webpackIgnore !== "boolean") {
+								parser.state.module.addWarning(
+									new UnsupportedFeatureWarning(
+										`\`webpackIgnore\` expected a boolean, but received: ${importOptions.webpackIgnore}.`,
+										/** @type {DependencyLocation} */ (expr.loc)
+									)
+								);
+								return;
+							} else if (importOptions.webpackIgnore) {
+								if (expr.arguments.length !== 2) return;
+
+								const [, arg2] = expr.arguments;
+
+								if (
+									arg2.type !== "MemberExpression" ||
+									!isMetaUrl(parser, arg2)
+								)
+									return;
+
+								const dep = new ConstDependency(
+									RuntimeGlobals.baseURI,
+									/** @type {Range} */ (arg2.range),
+									[RuntimeGlobals.baseURI]
+								);
+								dep.loc = /** @type {DependencyLocation} */ (expr.loc);
+								parser.state.module.addPresentationalDependency(dep);
+
+								return true;
+							}
+						}
 
 						const request = getUrlRequest(expr);
 

--- a/test/ConfigTestCases.template.js
+++ b/test/ConfigTestCases.template.js
@@ -449,7 +449,10 @@ const describeCases = config => {
 										let runInNewContext = false;
 										if (
 											options.target === "web" ||
-											options.target === "webworker"
+											options.target === "webworker" ||
+											(Array.isArray(options.target) &&
+												(options.target.includes("web") ||
+													options.target.includes("webworker")))
 										) {
 											baseModuleScope.window = globalContext;
 											baseModuleScope.self = globalContext;

--- a/test/configCases/parsing/url-ignore/file2.css
+++ b/test/configCases/parsing/url-ignore/file2.css
@@ -1,0 +1,3 @@
+a {
+	color: red;
+}

--- a/test/configCases/parsing/url-ignore/file4.css
+++ b/test/configCases/parsing/url-ignore/file4.css
@@ -1,0 +1,3 @@
+a {
+	color: red;
+}

--- a/test/configCases/parsing/url-ignore/index.js
+++ b/test/configCases/parsing/url-ignore/index.js
@@ -20,4 +20,8 @@ it("should ignore", function() {
 	expect(url8.toString()).toBe(document.baseURI || self.location.href);
 	const url9 = new URL(self.location.href);
 	expect(url9.toString()).toBe(self.location.href);
+	const url10 = new URL(/* webpackIgnore: true */ self.location.href);
+	expect(url10.toString()).toBe(self.location.href);
+	const url11 = new URL(/* webpackIgnore: true */ ...args);
+	expect(url11.pathname.endsWith("file3.css")).toBe(true);
 });

--- a/test/configCases/parsing/url-ignore/index.js
+++ b/test/configCases/parsing/url-ignore/index.js
@@ -1,0 +1,23 @@
+it("should ignore", function() {
+	const url = new URL(/* webpackIgnore: true */ "file1.css", import.meta.url);
+	expect(url.pathname.endsWith("file1.css")).toBe(true);
+	expect(url.pathname.includes("/public/")).toBe(false);
+	const url2 = new URL(/* webpackIgnore: false */ "file2.css", import.meta.url);
+	expect(/\/public\/.+\.css/.test(url2.pathname)).toBe(true);
+	const url3 = new URL(/* webpackIgnore: true */ "fil" + "e3.css", import.meta.url);
+	expect(url3.pathname.endsWith("file3.css")).toBe(true);
+	const url4 = new URL(/* webpackIgnore: false */ "fil" + "e4.css", import.meta.url);
+	expect(/\/public\/.+\.css/.test(url4.pathname)).toBe(true);
+	const url5 = new URL(/* webpackIgnore: "test" */ "file5.css", import.meta.url);
+	expect(url5.pathname.endsWith("file5.css")).toBe(true);
+	const value = "file5.css";
+	const url6 = new URL(/* webpackIgnore: true */ "/dir/" + value, import.meta.url);
+	expect(url6.pathname.endsWith("file5.css")).toBe(true);
+	const args = ["file3.css", document.baseURI || self.location.href];
+	const url7 = new URL(...args);
+	expect(url7.pathname.endsWith("file3.css")).toBe(true);
+	const url8 = new URL(document.baseURI || self.location.href);
+	expect(url8.toString()).toBe(document.baseURI || self.location.href);
+	const url9 = new URL(self.location.href);
+	expect(url9.toString()).toBe(self.location.href);
+});

--- a/test/configCases/parsing/url-ignore/warnings.js
+++ b/test/configCases/parsing/url-ignore/warnings.js
@@ -1,0 +1,1 @@
+module.exports = [/`webpackIgnore` expected a boolean, but received: test./];

--- a/test/configCases/parsing/url-ignore/webpack.config.js
+++ b/test/configCases/parsing/url-ignore/webpack.config.js
@@ -1,0 +1,10 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		publicPath: "/public/"
+	},
+	experiments: {
+		outputModule: true
+	},
+	target: ["web", "es2020"]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Feature:

```js
new URL(/* webpackIgnore: true */ "file1.css", import.meta.url)
```

Because we support `import(/* webpackIgnore: true */ "./file.css");` we need support for this in `new URL()` too, otherwise it is imposible to migrate on `new URL` from `import(...);` (what we actually recommend). 

Also `import.meta.url` is not keeping as is, it will be replaced on `baseURI` in such case (for modules it is `new URL("./", import.meta.url)`, for other cases it is `document.baseURI`), so relative URLs will work correctly.

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Need improve our docs about this feature
