### PR TITLE
fix: always add semicolon in concaten module and tweak

### DIFF
--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -146,7 +146,6 @@ if (!ReferencerClass.prototype.PropertyDefinition) {
  * @property {string | undefined} interopNamespaceObject2Name
  * @property {boolean} interopDefaultAccessUsed
  * @property {string | undefined} interopDefaultAccessName
- * @property {boolean} prefixAsi
  */
 
 /**
@@ -173,7 +172,6 @@ if (!ReferencerClass.prototype.PropertyDefinition) {
 
 /** @typedef {Set<string>} UsedNames */
 
-const CHARS_REQUIRING_SEMICOLON = ["[", "(", "+", "-", "/"];
 const RESERVED_NAMES = new Set(
 	[
 		// internal names (should always be renamed)
@@ -1469,12 +1467,6 @@ class ConcatenatedModule extends Module {
 						);
 						const r = /** @type {Range} */ (reference.identifier.range);
 						const source = info.source;
-
-						// in case finalName starts with a character that requires a semicolon
-						if (CHARS_REQUIRING_SEMICOLON.includes(finalName[0])) {
-							info.prefixAsi = true;
-						}
-
 						// range is extended by 2 chars to cover the appended "._"
 						source.replace(r[0], r[1] + 1, finalName);
 					}
@@ -1668,13 +1660,8 @@ ${defineGetters}`
 			switch (info.type) {
 				case "concatenated": {
 					result.add(
-						`\n// CONCATENATED MODULE: ${info.module.readableIdentifier(
-							requestShortener
-						)}\n`
+						`\n;// ${info.module.readableIdentifier(requestShortener)}\n`
 					);
-					if (/** @type {ConcatenatedModuleInfo} */ (rawInfo).prefixAsi) {
-						result.add(";");
-					}
 					result.add(info.source);
 					if (info.chunkInitFragments) {
 						for (const f of info.chunkInitFragments) chunkInitFragments.push(f);
@@ -1836,7 +1823,6 @@ ${defineGetters}`
 				info.chunkInitFragments = chunkInitFragments;
 				info.globalScope = globalScope;
 				info.moduleScope = moduleScope;
-				info.prefixAsi = CHARS_REQUIRING_SEMICOLON.includes(code[0]);
 			} catch (err) {
 				/** @type {Error} */
 				(err).message +=
@@ -1885,8 +1871,7 @@ ${defineGetters}`
 							interopNamespaceObject2Used: false,
 							interopNamespaceObject2Name: undefined,
 							interopDefaultAccessUsed: false,
-							interopDefaultAccessName: undefined,
-							prefixAsi: false
+							interopDefaultAccessName: undefined
 						};
 						break;
 					case "external":

--- a/test/configCases/scope-hoisting/issue-11897/index.js
+++ b/test/configCases/scope-hoisting/issue-11897/index.js
@@ -4,6 +4,10 @@ obj.flag = true
 import { value } from "./module";
 import { value as value2 } from "./iife";
 import { value as value3 } from "./module?2";
+import { value as value4 } from "./module2";
+import { value as value5 } from "./module3";
+import { value as value6 } from "./module4";
+import { value as value7 } from "./module5";
 obj.flag = true;
 
 it("should not break on ASI-code", () => {
@@ -11,4 +15,8 @@ it("should not break on ASI-code", () => {
 	expect(value).toBe(true);
 	expect(value2).toBe(true);
 	expect(value3).toBe(true);
+	expect(value4).toBe(true);
+	expect(value5).toBe(true);
+	expect(value6).toBe(true);
+	expect(value7).toBe(true);
 });

--- a/test/configCases/scope-hoisting/issue-11897/module2.js
+++ b/test/configCases/scope-hoisting/issue-11897/module2.js
@@ -1,0 +1,3 @@
+[].forEach(()=> {})
+
+export let value = true

--- a/test/configCases/scope-hoisting/issue-11897/module3.js
+++ b/test/configCases/scope-hoisting/issue-11897/module3.js
@@ -1,0 +1,4 @@
+ // comment
+/d+/
+
+export let value = true

--- a/test/configCases/scope-hoisting/issue-11897/module4.js
+++ b/test/configCases/scope-hoisting/issue-11897/module4.js
@@ -1,0 +1,5 @@
+   /** comment */ ++x;
+
+var x = 1;
+
+export let value = true

--- a/test/configCases/scope-hoisting/issue-11897/module5.js
+++ b/test/configCases/scope-hoisting/issue-11897/module5.js
@@ -1,0 +1,5 @@
+/** comment */--x;
+
+var x = 1;
+
+export let value = true


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Revert the source change in https://github.com/webpack/webpack/pull/18709, the test cases are reserved. Resolve https://github.com/web-infra-dev/rspack/issues/7591.

After adding new tests cases in this PR, I found it's hard to determine when to add the leading semicolon, as comments may appear before real code. Considering the risks and benefits of implementation, I decide to revert #18709 until we found a cheap and safe implementation. I also added new test cases by the way.

There's still a little change I made to resolve https://github.com/web-infra-dev/rspack/issues/7591: remove `CONCATENATED MODULE: ` prefix to make it easier for users to understand.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

No.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
