### PR TITLE
fix: make EnvironmentPlugin defaultValues types less strict

### DIFF
--- a/lib/EnvironmentPlugin.js
+++ b/lib/EnvironmentPlugin.js
@@ -17,6 +17,7 @@ class EnvironmentPlugin {
 	 */
 	constructor(...keys) {
 		if (keys.length === 1 && Array.isArray(keys[0])) {
+			/** @type {string[]} */
 			this.keys = keys[0];
 			this.defaultValues = {};
 		} else if (keys.length === 1 && keys[0] && typeof keys[0] === "object") {

--- a/lib/EnvironmentPlugin.js
+++ b/lib/EnvironmentPlugin.js
@@ -13,7 +13,7 @@ const WebpackError = require("./WebpackError");
 
 class EnvironmentPlugin {
 	/**
-	 * @param {(string | string[] | Record<string, string>)[]} keys keys
+	 * @param {(string | string[] | Record<string, any>)[]} keys keys
 	 */
 	constructor(...keys) {
 		if (keys.length === 1 && Array.isArray(keys[0])) {
@@ -21,7 +21,7 @@ class EnvironmentPlugin {
 			this.defaultValues = {};
 		} else if (keys.length === 1 && keys[0] && typeof keys[0] === "object") {
 			this.keys = Object.keys(keys[0]);
-			this.defaultValues = /** @type {Record<string, string>} */ (keys[0]);
+			this.defaultValues = /** @type {Record<string, any>} */ (keys[0]);
 		} else {
 			this.keys = /** @type {string[]} */ (keys);
 			this.defaultValues = {};

--- a/types.d.ts
+++ b/types.d.ts
@@ -4048,8 +4048,8 @@ declare interface Environment {
 	templateLiteral?: boolean;
 }
 declare class EnvironmentPlugin {
-	constructor(...keys: (string | string[] | Record<string, string>)[]);
-	keys: string[];
+	constructor(...keys: (string | string[] | Record<string, any>)[]);
+	keys: any[];
 	defaultValues: Record<string, any>;
 
 	/**

--- a/types.d.ts
+++ b/types.d.ts
@@ -4050,7 +4050,7 @@ declare interface Environment {
 declare class EnvironmentPlugin {
 	constructor(...keys: (string | string[] | Record<string, string>)[]);
 	keys: string[];
-	defaultValues: Record<string, string>;
+	defaultValues: Record<string, any>;
 
 	/**
 	 * Apply the plugin

--- a/types.d.ts
+++ b/types.d.ts
@@ -4049,7 +4049,7 @@ declare interface Environment {
 }
 declare class EnvironmentPlugin {
 	constructor(...keys: (string | string[] | Record<string, any>)[]);
-	keys: any[];
+	keys: string[];
 	defaultValues: Record<string, any>;
 
 	/**


### PR DESCRIPTION
Changes introduced in https://github.com/webpack/webpack/commit/adf2a6b7c6077fd806ea0e378c1450cccecc9ed0#diff-a150fb53afee945f23f3fe7c176007111f3ba81bb0d188af4077d4a0fc4caa37R3993 prevents updating webpack to 5.94.0 in some cases because previously EnvironmentPlugin/defaultValues could be initiated with any types (as it is being also documented), but now with types update it could only be `Record<string, string>`.

There are checks in code that stringify value & explicitly check if `undefined` was a value, so it might make sense to keep this as `Record<string, any>`: https://github.com/webpack/webpack/blob/94aba382eccf3de1004d235045d4462918dfdbb7/lib/EnvironmentPlugin.js#L40-L59 (which is also a documented behavior in https://webpack.js.org/plugins/environment-plugin/)

Closes #18719

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

I'm not sure if type changes are covered by tests

**Does this PR introduce a breaking change?**

this PR relaxes type requirements, so there should be no breaking changes

**What needs to be documented once your changes are merged?**

The behavior is already documented, so there will be no requirements for documentation changes
