### PR TITLE
fix: decide processBlock by input block

### DIFF
--- a/lib/buildChunkGraph.js
+++ b/lib/buildChunkGraph.js
@@ -38,7 +38,7 @@ const { getEntryRuntime, mergeRuntime } = require("./util/runtime");
  * @typedef {object} ChunkGroupInfo
  * @property {ChunkGroup} chunkGroup the chunk group
  * @property {RuntimeSpec} runtime the runtimes
- * @property {boolean} init is this chunk group initialized
+ * @property {boolean} initialized is this chunk group initialized
  * @property {bigint | undefined} minAvailableModules current minimal set of modules available at this point
  * @property {bigint[]} availableModulesToBeMerged enqueued updates to the minimal set of available modules
  * @property {Set<Module>=} skippedItems modules that were skipped because module is already available in parent chunks (need to reconsider when minAvailableModules is shrinking)
@@ -368,7 +368,7 @@ const visitModules = (
 	/** @type {QueueItem[]} */
 	let queue = [];
 
-	/** @type {Map<ChunkGroupInfo, Set<[ChunkGroupInfo, ChunkGroup, Module | null]>>} */
+	/** @type {Map<ChunkGroupInfo, Set<[ChunkGroupInfo, QueueItem | null]>>} */
 	const queueConnect = new Map();
 	/** @type {Set<ChunkGroupInfo>} */
 	const chunkGroupsForCombining = new Set();
@@ -383,7 +383,7 @@ const visitModules = (
 		);
 		/** @type {ChunkGroupInfo} */
 		const chunkGroupInfo = {
-			init: false,
+			initialized: false,
 			chunkGroup,
 			runtime,
 			minAvailableModules: undefined,
@@ -454,7 +454,7 @@ const visitModules = (
 
 	/** @type {Set<ChunkGroupInfo>} */
 	const outdatedChunkGroupInfo = new Set();
-	/** @type {Set<[ChunkGroupInfo, ChunkGroup, Module | null]>} */
+	/** @type {Set<[ChunkGroupInfo, QueueItem]>} */
 	const chunkGroupsForMerging = new Set();
 	/** @type {QueueItem[]} */
 	let queueDelayed = [];
@@ -507,7 +507,7 @@ const visitModules = (
 					entrypoint.index = nextChunkGroupIndex++;
 					cgi = {
 						chunkGroup: entrypoint,
-						init: false,
+						initialized: false,
 						runtime: entrypoint.options.runtime || entrypoint.name,
 						minAvailableModules: ZERO_BIGINT,
 						availableModulesToBeMerged: [],
@@ -575,7 +575,7 @@ const visitModules = (
 					maskByChunk.set(c.chunks[0], ZERO_BIGINT);
 					c.index = nextChunkGroupIndex++;
 					cgi = {
-						init: false,
+						initialized: false,
 						chunkGroup: c,
 						runtime: chunkGroupInfo.runtime,
 						minAvailableModules: undefined,
@@ -618,14 +618,6 @@ const visitModules = (
 				blockConnections.set(b, []);
 			}
 			blockChunkGroups.set(b, /** @type {ChunkGroupInfo} */ (cgi));
-			let blocks = blocksByChunkGroups.get(/** @type {ChunkGroupInfo} */ (cgi));
-			if (!blocks) {
-				blocksByChunkGroups.set(
-					/** @type {ChunkGroupInfo} */ (cgi),
-					(blocks = new Set())
-				);
-			}
-			blocks.add(b);
 		} else if (entryOptions) {
 			entrypoint = /** @type {Entrypoint} */ (cgi.chunkGroup);
 		} else {
@@ -647,9 +639,17 @@ const visitModules = (
 				connectList = new Set();
 				queueConnect.set(chunkGroupInfo, connectList);
 			}
-			connectList.add(
-				/** @type {[ChunkGroupInfo, ChunkGroup, Module]} */ ([cgi, c, module])
-			);
+			connectList.add([
+				cgi,
+				{
+					action: PROCESS_BLOCK,
+					block: b,
+					module,
+					chunk: c.chunks[0],
+					chunkGroup: c,
+					chunkGroupInfo: /** @type {ChunkGroupInfo} */ (cgi)
+				}
+			]);
 		} else if (entrypoint !== undefined) {
 			chunkGroupInfo.chunkGroup.addAsyncEntrypoint(entrypoint);
 		}
@@ -915,9 +915,9 @@ const visitModules = (
 			const runtime = chunkGroupInfo.runtime;
 
 			// 3. Update chunk group info
-			for (const [target, chunkGroup, module] of targets) {
+			for (const [target, processBlock] of targets) {
 				target.availableModulesToBeMerged.push(resultingAvailableModules);
-				chunkGroupsForMerging.add([target, chunkGroup, module]);
+				chunkGroupsForMerging.add([target, processBlock]);
 				const oldRuntime = target.runtime;
 				const newRuntime = mergeRuntime(oldRuntime, runtime);
 				if (oldRuntime !== newRuntime) {
@@ -935,7 +935,7 @@ const visitModules = (
 		statProcessedChunkGroupsForMerging += chunkGroupsForMerging.size;
 
 		// Execute the merge
-		for (const [info, chunkGroup, module] of chunkGroupsForMerging) {
+		for (const [info, processBlock] of chunkGroupsForMerging) {
 			const availableModulesToBeMerged = info.availableModulesToBeMerged;
 			const cachedMinAvailableModules = info.minAvailableModules;
 			let minAvailableModules = cachedMinAvailableModules;
@@ -959,17 +959,24 @@ const visitModules = (
 				outdatedChunkGroupInfo.add(info);
 			}
 
-			if ((!info.init || changed) && module) {
-				info.init = true;
-				for (const b of blocksByChunkGroups.get(info)) {
-					queueDelayed.push({
-						action: PROCESS_BLOCK,
-						block: b,
-						module,
-						chunk: chunkGroup.chunks[0],
-						chunkGroup,
-						chunkGroupInfo: info
-					});
+			if (processBlock) {
+				let blocks = blocksByChunkGroups.get(info);
+				if (!blocks) {
+					blocksByChunkGroups.set(info, (blocks = new Set()));
+				}
+
+				// Whether to walk block depends on minAvailableModules and input block.
+				// We can treat creating chunk group as a function with 2 input, entry block and minAvailableModules
+				// If input is the same, we can skip re-walk
+				let needWalkBlock = !info.initialized || changed;
+				if (!blocks.has(processBlock.block)) {
+					needWalkBlock = true;
+					blocks.add(processBlock.block);
+				}
+
+				if (needWalkBlock) {
+					info.initialized = true;
+					queueDelayed.push(processBlock);
 				}
 			}
 		}
@@ -1071,7 +1078,7 @@ const visitModules = (
 						connectList = new Set();
 						queueConnect.set(info, connectList);
 					}
-					connectList.add([cgi, cgi.chunkGroup, module]);
+					connectList.add([cgi, null]);
 				}
 			}
 

--- a/test/configCases/chunk-graph/rewalk-chunk/index.js
+++ b/test/configCases/chunk-graph/rewalk-chunk/index.js
@@ -1,0 +1,7 @@
+it('should load module c', async () => {
+	const m1 = await (await import('./module-b')).default
+	const m2 = await import(/*webpackChunkName: 'module'*/ './module-a')
+
+	expect(m1.default).toBe('module-c')
+	expect(m2.default).toBe('module-a')
+})

--- a/test/configCases/chunk-graph/rewalk-chunk/module-a.js
+++ b/test/configCases/chunk-graph/rewalk-chunk/module-a.js
@@ -1,0 +1,1 @@
+export default 'module-a'

--- a/test/configCases/chunk-graph/rewalk-chunk/module-b.js
+++ b/test/configCases/chunk-graph/rewalk-chunk/module-b.js
@@ -1,0 +1,1 @@
+export default import(/*webpackChunkName: 'module'*/ './module-c')

--- a/test/configCases/chunk-graph/rewalk-chunk/module-c.js
+++ b/test/configCases/chunk-graph/rewalk-chunk/module-c.js
@@ -1,0 +1,1 @@
+export default 'module-c'

--- a/test/configCases/chunk-graph/rewalk-chunk/shared.js
+++ b/test/configCases/chunk-graph/rewalk-chunk/shared.js
@@ -1,0 +1,1 @@
+export default import(/* webpackChunkName: "module" */ "./module-a");

--- a/test/configCases/chunk-graph/rewalk-chunk/test.config.js
+++ b/test/configCases/chunk-graph/rewalk-chunk/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["main.js"];
+	}
+};

--- a/test/configCases/chunk-graph/rewalk-chunk/webpack.config.js
+++ b/test/configCases/chunk-graph/rewalk-chunk/webpack.config.js
@@ -1,0 +1,9 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		main: "./index.js"
+	},
+	output: {
+		filename: "[name].js"
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Sorry in #18730 I introduced a bug

Whether to iterate block depends on 2 input, block and minAvailableModules. But in the old pr, I just take minAvailableModules into consideration

If entry block and minAvailableModules are the same, the result should the same. (Runtime changes will cause chunkGroupInfo to be pushed into outdatedQueue, and reconsider skipped connections)

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
