### PR TITLE
fix(types): Remove useless SortableSet iterator

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -13604,11 +13604,6 @@ declare abstract class SortableSet<T> extends Set<T> {
 	 */
 	getFromUnorderedCache<R>(fn: (arg0: SortableSet<T>) => R): R;
 	toJSON(): T[];
-
-	/**
-	 * Iterates over values in the set.
-	 */
-	[Symbol.iterator](): IterableIterator<T>;
 }
 declare class Source {
 	constructor();


### PR DESCRIPTION
Fix TypeScript 5.6 typing problem due to Iterator changes:

![CleanShot 2024-09-10 at 12 51 57@2x](https://github.com/user-attachments/assets/8aa071d9-6b3f-429e-a8ef-d5bcef116520)

Useful links:
- TypeScript release: https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/
- SortableSet source code:https://github.com/webpack/webpack/blob/main/lib/util/SortableSet.js
- Fix https://github.com/webpack/webpack/issues/18748

**What kind of change does this PR introduce?**

Remove custom iterator type for `SortableSet`: 

```ts
declare abstract class SortableSet<T> extends Set<T> {
	/**
	 * Iterates over values in the set.
	 */
	[Symbol.iterator](): IterableIterator<T>;
}
```


The implementation does not create a custom iterator so IMHO this declaration could be removed to use the built-in parent Set iterator.

```ts
interface Set<T> {
    /** Iterates over values in the set. */
    [Symbol.iterator](): SetIterator<T>;
}
```

Note: the iterator type you previously used was the former built-in type. But that built-in type changed in TS 5.6. Refs:
- https://github.com/microsoft/TypeScript/blob/release-5.6/src/lib/es2015.iterable.d.ts#L178
- https://github.com/microsoft/TypeScript/pull/59506
- https://github.com/microsoft/TypeScript/pull/58222


**Did you add tests for your changes?**

Not sure how to test this, apart from upgrading the whole repo to TS 5.6


**Does this PR introduce a breaking change?**

It shouldn't?

**What needs to be documented once your changes are merged?**

Nothing?
