### PR TITLE
fix: use `module` chunk format as a fallback when `environment.dynami…

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -922,186 +922,6 @@ const applyOutputDefaults = (
 	});
 
 	F(output, "module", () => Boolean(outputModule));
-	D(output, "filename", output.module ? "[name].mjs" : "[name].js");
-	F(output, "iife", () => !output.module);
-	D(output, "importFunctionName", "import");
-	D(output, "importMetaName", "import.meta");
-	F(output, "chunkFilename", () => {
-		const filename =
-			/** @type {NonNullable<Output["chunkFilename"]>} */
-			(output.filename);
-		if (typeof filename !== "function") {
-			const hasName = filename.includes("[name]");
-			const hasId = filename.includes("[id]");
-			const hasChunkHash = filename.includes("[chunkhash]");
-			const hasContentHash = filename.includes("[contenthash]");
-			// Anything changing depending on chunk is fine
-			if (hasChunkHash || hasContentHash || hasName || hasId) return filename;
-			// Otherwise prefix "[id]." in front of the basename to make it changing
-			return filename.replace(/(^|\/)([^/]*(?:\?|$))/, "$1[id].$2");
-		}
-		return output.module ? "[id].mjs" : "[id].js";
-	});
-	F(output, "cssFilename", () => {
-		const filename =
-			/** @type {NonNullable<Output["cssFilename"]>} */
-			(output.filename);
-		if (typeof filename !== "function") {
-			return filename.replace(/\.[mc]?js(\?|$)/, ".css$1");
-		}
-		return "[id].css";
-	});
-	F(output, "cssChunkFilename", () => {
-		const chunkFilename =
-			/** @type {NonNullable<Output["cssChunkFilename"]>} */
-			(output.chunkFilename);
-		if (typeof chunkFilename !== "function") {
-			return chunkFilename.replace(/\.[mc]?js(\?|$)/, ".css$1");
-		}
-		return "[id].css";
-	});
-	D(output, "cssHeadDataCompression", !development);
-	D(output, "assetModuleFilename", "[hash][ext][query]");
-	D(output, "webassemblyModuleFilename", "[hash].module.wasm");
-	D(output, "compareBeforeEmit", true);
-	D(output, "charset", true);
-	const uniqueNameId = Template.toIdentifier(
-		/** @type {NonNullable<Output["uniqueName"]>} */ (output.uniqueName)
-	);
-	F(output, "hotUpdateGlobal", () => `webpackHotUpdate${uniqueNameId}`);
-	F(output, "chunkLoadingGlobal", () => `webpackChunk${uniqueNameId}`);
-	F(output, "globalObject", () => {
-		if (tp) {
-			if (tp.global) return "global";
-			if (tp.globalThis) return "globalThis";
-		}
-		return "self";
-	});
-	F(output, "chunkFormat", () => {
-		if (tp) {
-			const helpMessage = isAffectedByBrowserslist
-				? "Make sure that your 'browserslist' includes only platforms that support these features or select an appropriate 'target' to allow selecting a chunk format by default. Alternatively specify the 'output.chunkFormat' directly."
-				: "Select an appropriate 'target' to allow selecting one by default, or specify the 'output.chunkFormat' directly.";
-			if (output.module) {
-				if (tp.dynamicImport) return "module";
-				if (tp.document) return "array-push";
-				throw new Error(
-					"For the selected environment is no default ESM chunk format available:\n" +
-						"ESM exports can be chosen when 'import()' is available.\n" +
-						`JSONP Array push can be chosen when 'document' is available.\n${
-							helpMessage
-						}`
-				);
-			} else {
-				if (tp.document) return "array-push";
-				if (tp.require) return "commonjs";
-				if (tp.nodeBuiltins) return "commonjs";
-				if (tp.importScripts) return "array-push";
-				throw new Error(
-					"For the selected environment is no default script chunk format available:\n" +
-						"JSONP Array push can be chosen when 'document' or 'importScripts' is available.\n" +
-						`CommonJs exports can be chosen when 'require' or node builtins are available.\n${
-							helpMessage
-						}`
-				);
-			}
-		}
-		throw new Error(
-			"Chunk format can't be selected by default when no target is specified"
-		);
-	});
-	D(output, "asyncChunks", true);
-	F(output, "chunkLoading", () => {
-		if (tp) {
-			switch (output.chunkFormat) {
-				case "array-push":
-					if (tp.document) return "jsonp";
-					if (tp.importScripts) return "import-scripts";
-					break;
-				case "commonjs":
-					if (tp.require) return "require";
-					if (tp.nodeBuiltins) return "async-node";
-					break;
-				case "module":
-					if (tp.dynamicImport || output.module) return "import";
-					break;
-			}
-			if (
-				tp.require === null ||
-				tp.nodeBuiltins === null ||
-				tp.document === null ||
-				tp.importScripts === null
-			) {
-				return "universal";
-			}
-		}
-		return false;
-	});
-	F(output, "workerChunkLoading", () => {
-		if (tp) {
-			switch (output.chunkFormat) {
-				case "array-push":
-					if (tp.importScriptsInWorker) return "import-scripts";
-					break;
-				case "commonjs":
-					if (tp.require) return "require";
-					if (tp.nodeBuiltins) return "async-node";
-					break;
-				case "module":
-					if (tp.dynamicImportInWorker || output.module) return "import";
-					break;
-			}
-			if (
-				tp.require === null ||
-				tp.nodeBuiltins === null ||
-				tp.importScriptsInWorker === null
-			) {
-				return "universal";
-			}
-		}
-		return false;
-	});
-	F(output, "wasmLoading", () => {
-		if (tp) {
-			if (tp.fetchWasm) return "fetch";
-			if (tp.nodeBuiltins)
-				return output.module ? "async-node-module" : "async-node";
-			if (tp.nodeBuiltins === null || tp.fetchWasm === null) {
-				return "universal";
-			}
-		}
-		return false;
-	});
-	F(output, "workerWasmLoading", () => output.wasmLoading);
-	F(output, "devtoolNamespace", () => output.uniqueName);
-	if (output.library) {
-		F(output.library, "type", () => (output.module ? "module" : "var"));
-	}
-	F(output, "path", () => path.join(process.cwd(), "dist"));
-	F(output, "pathinfo", () => development);
-	D(output, "sourceMapFilename", "[file].map[query]");
-	D(
-		output,
-		"hotUpdateChunkFilename",
-		`[id].[fullhash].hot-update.${output.module ? "mjs" : "js"}`
-	);
-	D(output, "hotUpdateMainFilename", "[runtime].[fullhash].hot-update.json");
-	D(output, "crossOriginLoading", false);
-	F(output, "scriptType", () => (output.module ? "module" : false));
-	D(
-		output,
-		"publicPath",
-		(tp && (tp.document || tp.importScripts)) || output.scriptType === "module"
-			? "auto"
-			: ""
-	);
-	D(output, "workerPublicPath", "");
-	D(output, "chunkLoadTimeout", 120000);
-	D(output, "hashFunction", futureDefaults ? "xxhash64" : "md4");
-	D(output, "hashDigest", "hex");
-	D(output, "hashDigestLength", futureDefaults ? 16 : 20);
-	D(output, "strictModuleErrorHandling", false);
-	D(output, "strictModuleExceptionHandling", false);
 
 	const environment = /** @type {Environment} */ (output.environment);
 	/**
@@ -1199,6 +1019,187 @@ const applyOutputDefaults = (
 		"document",
 		() => tp && optimistic(/** @type {boolean | undefined} */ (tp.document))
 	);
+
+	D(output, "filename", output.module ? "[name].mjs" : "[name].js");
+	F(output, "iife", () => !output.module);
+	D(output, "importFunctionName", "import");
+	D(output, "importMetaName", "import.meta");
+	F(output, "chunkFilename", () => {
+		const filename =
+			/** @type {NonNullable<Output["chunkFilename"]>} */
+			(output.filename);
+		if (typeof filename !== "function") {
+			const hasName = filename.includes("[name]");
+			const hasId = filename.includes("[id]");
+			const hasChunkHash = filename.includes("[chunkhash]");
+			const hasContentHash = filename.includes("[contenthash]");
+			// Anything changing depending on chunk is fine
+			if (hasChunkHash || hasContentHash || hasName || hasId) return filename;
+			// Otherwise prefix "[id]." in front of the basename to make it changing
+			return filename.replace(/(^|\/)([^/]*(?:\?|$))/, "$1[id].$2");
+		}
+		return output.module ? "[id].mjs" : "[id].js";
+	});
+	F(output, "cssFilename", () => {
+		const filename =
+			/** @type {NonNullable<Output["cssFilename"]>} */
+			(output.filename);
+		if (typeof filename !== "function") {
+			return filename.replace(/\.[mc]?js(\?|$)/, ".css$1");
+		}
+		return "[id].css";
+	});
+	F(output, "cssChunkFilename", () => {
+		const chunkFilename =
+			/** @type {NonNullable<Output["cssChunkFilename"]>} */
+			(output.chunkFilename);
+		if (typeof chunkFilename !== "function") {
+			return chunkFilename.replace(/\.[mc]?js(\?|$)/, ".css$1");
+		}
+		return "[id].css";
+	});
+	D(output, "cssHeadDataCompression", !development);
+	D(output, "assetModuleFilename", "[hash][ext][query]");
+	D(output, "webassemblyModuleFilename", "[hash].module.wasm");
+	D(output, "compareBeforeEmit", true);
+	D(output, "charset", true);
+	const uniqueNameId = Template.toIdentifier(
+		/** @type {NonNullable<Output["uniqueName"]>} */ (output.uniqueName)
+	);
+	F(output, "hotUpdateGlobal", () => `webpackHotUpdate${uniqueNameId}`);
+	F(output, "chunkLoadingGlobal", () => `webpackChunk${uniqueNameId}`);
+	F(output, "globalObject", () => {
+		if (tp) {
+			if (tp.global) return "global";
+			if (tp.globalThis) return "globalThis";
+		}
+		return "self";
+	});
+	F(output, "chunkFormat", () => {
+		if (tp) {
+			const helpMessage = isAffectedByBrowserslist
+				? "Make sure that your 'browserslist' includes only platforms that support these features or select an appropriate 'target' to allow selecting a chunk format by default. Alternatively specify the 'output.chunkFormat' directly."
+				: "Select an appropriate 'target' to allow selecting one by default, or specify the 'output.chunkFormat' directly.";
+			if (output.module) {
+				if (environment.dynamicImport) return "module";
+				if (tp.document) return "array-push";
+				throw new Error(
+					"For the selected environment is no default ESM chunk format available:\n" +
+						"ESM exports can be chosen when 'import()' is available.\n" +
+						`JSONP Array push can be chosen when 'document' is available.\n${
+							helpMessage
+						}`
+				);
+			} else {
+				if (tp.document) return "array-push";
+				if (tp.require) return "commonjs";
+				if (tp.nodeBuiltins) return "commonjs";
+				if (tp.importScripts) return "array-push";
+				throw new Error(
+					"For the selected environment is no default script chunk format available:\n" +
+						"JSONP Array push can be chosen when 'document' or 'importScripts' is available.\n" +
+						`CommonJs exports can be chosen when 'require' or node builtins are available.\n${
+							helpMessage
+						}`
+				);
+			}
+		}
+		throw new Error(
+			"Chunk format can't be selected by default when no target is specified"
+		);
+	});
+	D(output, "asyncChunks", true);
+	F(output, "chunkLoading", () => {
+		if (tp) {
+			switch (output.chunkFormat) {
+				case "array-push":
+					if (tp.document) return "jsonp";
+					if (tp.importScripts) return "import-scripts";
+					break;
+				case "commonjs":
+					if (tp.require) return "require";
+					if (tp.nodeBuiltins) return "async-node";
+					break;
+				case "module":
+					if (environment.dynamicImport) return "import";
+					break;
+			}
+			if (
+				tp.require === null ||
+				tp.nodeBuiltins === null ||
+				tp.document === null ||
+				tp.importScripts === null
+			) {
+				return "universal";
+			}
+		}
+		return false;
+	});
+	F(output, "workerChunkLoading", () => {
+		if (tp) {
+			switch (output.chunkFormat) {
+				case "array-push":
+					if (tp.importScriptsInWorker) return "import-scripts";
+					break;
+				case "commonjs":
+					if (tp.require) return "require";
+					if (tp.nodeBuiltins) return "async-node";
+					break;
+				case "module":
+					if (environment.dynamicImportInWorker) return "import";
+					break;
+			}
+			if (
+				tp.require === null ||
+				tp.nodeBuiltins === null ||
+				tp.importScriptsInWorker === null
+			) {
+				return "universal";
+			}
+		}
+		return false;
+	});
+	F(output, "wasmLoading", () => {
+		if (tp) {
+			if (tp.fetchWasm) return "fetch";
+			if (tp.nodeBuiltins)
+				return output.module ? "async-node-module" : "async-node";
+			if (tp.nodeBuiltins === null || tp.fetchWasm === null) {
+				return "universal";
+			}
+		}
+		return false;
+	});
+	F(output, "workerWasmLoading", () => output.wasmLoading);
+	F(output, "devtoolNamespace", () => output.uniqueName);
+	if (output.library) {
+		F(output.library, "type", () => (output.module ? "module" : "var"));
+	}
+	F(output, "path", () => path.join(process.cwd(), "dist"));
+	F(output, "pathinfo", () => development);
+	D(output, "sourceMapFilename", "[file].map[query]");
+	D(
+		output,
+		"hotUpdateChunkFilename",
+		`[id].[fullhash].hot-update.${output.module ? "mjs" : "js"}`
+	);
+	D(output, "hotUpdateMainFilename", "[runtime].[fullhash].hot-update.json");
+	D(output, "crossOriginLoading", false);
+	F(output, "scriptType", () => (output.module ? "module" : false));
+	D(
+		output,
+		"publicPath",
+		(tp && (tp.document || tp.importScripts)) || output.scriptType === "module"
+			? "auto"
+			: ""
+	);
+	D(output, "workerPublicPath", "");
+	D(output, "chunkLoadTimeout", 120000);
+	D(output, "hashFunction", futureDefaults ? "xxhash64" : "md4");
+	D(output, "hashDigest", "hex");
+	D(output, "hashDigestLength", futureDefaults ? 16 : 20);
+	D(output, "strictModuleErrorHandling", false);
+	D(output, "strictModuleExceptionHandling", false);
 
 	const { trustedTypes } = output;
 	if (trustedTypes) {

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -936,7 +936,16 @@ describe("snapshots", () => {
 		+       "module": true,
 		@@ ... @@
 		-     "chunkFilename": "[name].js",
+		-     "chunkFormat": "array-push",
 		+     "chunkFilename": "[name].mjs",
+		+     "chunkFormat": "module",
+		@@ ... @@
+		-     "chunkLoading": "jsonp",
+		+     "chunkLoading": "import",
+		@@ ... @@
+		-       "jsonp",
+		-       "import-scripts",
+		+       "import",
 		@@ ... @@
 		-       "dynamicImport": undefined,
 		-       "dynamicImportInWorker": undefined,
@@ -960,6 +969,9 @@ describe("snapshots", () => {
 		@@ ... @@
 		-     "scriptType": false,
 		+     "scriptType": "module",
+		@@ ... @@
+		-     "workerChunkLoading": "import-scripts",
+		+     "workerChunkLoading": "import",
 	`)
 	);
 	test("async wasm", { experiments: { asyncWebAssembly: true } }, e =>

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -1967,7 +1967,7 @@ webpack x.x.x compiled successfully in X ms"
 exports[`StatsTestCases should print correct stats for output-module 1`] = `
 "asset main.mjs X KiB [emitted] [javascript module] (name: main)
 asset 936.mjs X bytes [emitted] [javascript module]
-runtime modules X KiB 7 modules
+runtime modules X KiB 5 modules
 orphan modules X bytes [orphan] 1 module
 cacheable modules X bytes
   ./index.js + 1 modules X bytes [built] [code generated]

--- a/test/configCases/output-module/chunk-format-fallback/dep.js
+++ b/test/configCases/output-module/chunk-format-fallback/dep.js
@@ -1,0 +1,1 @@
+export const main = 'MAIN';

--- a/test/configCases/output-module/chunk-format-fallback/index.js
+++ b/test/configCases/output-module/chunk-format-fallback/index.js
@@ -1,0 +1,5 @@
+import { main } from "./dep.js";
+
+it("should work by default", () => {
+	expect(main).toBe("MAIN");
+});

--- a/test/configCases/output-module/chunk-format-fallback/test.config.js
+++ b/test/configCases/output-module/chunk-format-fallback/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return ["runtime.mjs", "./main.mjs"];
+	}
+};

--- a/test/configCases/output-module/chunk-format-fallback/webpack.config.js
+++ b/test/configCases/output-module/chunk-format-fallback/webpack.config.js
@@ -1,0 +1,20 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		main: {
+			import: "./index.js",
+			library: { type: "module" }
+		}
+	},
+	output: {
+		filename: "[name].mjs"
+	},
+	optimization: {
+		runtimeChunk: "single"
+	},
+	experiments: {
+		outputModule: true
+	},
+	mode: "development",
+	devtool: false
+};

--- a/test/configCases/web/prefetch-preload-module-jsonp/webpack.config.js
+++ b/test/configCases/web/prefetch-preload-module-jsonp/webpack.config.js
@@ -12,7 +12,8 @@ module.exports = {
 		module: true,
 		filename: "bundle0.mjs",
 		chunkFilename: "[name].js",
-		crossOriginLoading: "anonymous"
+		crossOriginLoading: "anonymous",
+		chunkFormat: "array-push"
 	},
 	performance: {
 		hints: false


### PR DESCRIPTION
…cImport` is optimistically supported

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fixes https://github.com/webpack/webpack/issues/18819

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

Yes, but only when:
- `output.target` doesn't support dynamic import
- you don't have `browserslist` and your browsers don't support dynamic import
- you don't specify `chunkFormat` directly


Before - `chunkFormat: "array-push"` when `experiments.outputModule: true` 
Now - `chunkFormat: "module"` when `experiments.outputModule: true`

**What needs to be documented once your changes are merged?**

No
