### PR TITLE
Removed the need for Async import

### DIFF
--- a/lib/javascript/StartupHelpers.js
+++ b/lib/javascript/StartupHelpers.js
@@ -10,6 +10,8 @@ const Template = require("../Template");
 const { isSubset } = require("../util/SetHelpers");
 const { getAllChunks } = require("./ChunkHelpers");
 
+const federationStartup = 'federation-entry-startup';
+
 /** @typedef {import("../util/Hash")} Hash */
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Chunk").ChunkId} ChunkId */
@@ -35,6 +37,8 @@ const EXPORT_PREFIX = `var ${RuntimeGlobals.exports} = `;
  * @param {boolean} passive true: passive startup with on chunks loaded
  * @returns {string} runtime code
  */
+
+
 module.exports.generateEntryStartup = (
 	chunkGraph,
 	runtimeTemplate,
@@ -49,7 +53,12 @@ module.exports.generateEntryStartup = (
 			"moduleId"
 		)}`
 	];
-
+	const treeRuntimeRequirements = chunkGraph.getTreeRuntimeRequirements(chunk);
+	const chunkRuntimeRequirements =
+	  chunkGraph.getChunkRuntimeRequirements(chunk);
+	const federation =
+	  chunkRuntimeRequirements.has(federationStartup) ||
+	  treeRuntimeRequirements.has(federationStartup);
 	/**
 	 * @param {ModuleId} id id
 	 * @returns {string} fn to execute
@@ -60,6 +69,7 @@ module.exports.generateEntryStartup = (
 	 * @param {ModuleIds} moduleIds module ids
 	 * @param {boolean=} final true when final, otherwise false
 	 */
+	
 	const outputCombination = (chunks, moduleIds, final) => {
 		if (chunks.size === 0) {
 			runtime.push(
@@ -69,18 +79,33 @@ module.exports.generateEntryStartup = (
 			const fn = runtimeTemplate.returningFunction(
 				moduleIds.map(runModule).join(", ")
 			);
-			runtime.push(
-				`${final && !passive ? EXPORT_PREFIX : ""}${
+			
+				const chunkIds = Array.from(chunks, (c) => c.id);
+		
+				const wrappedInit = (body) =>
+				  Template.asString([
+					'Promise.all([',
+					Template.indent([
+					  // may have other chunks who depend on federation, so best to just fallback
+					  // instead of try to figure out if consumes or remotes exists during build
+					  `${RuntimeGlobals.ensureChunkHandlers}.consumes || function(chunkId, promises) {},`,
+					  `${RuntimeGlobals.ensureChunkHandlers}.remotes || function(chunkId, promises) {},`,
+					]),
+					`].reduce(${runtimeTemplate.returningFunction(`handler('${chunk.id}', p), p`, 'p, handler')}, promises)`,
+					`).then(${runtimeTemplate.returningFunction(body)});`,
+				  ]);
+		
+				const wrap = wrappedInit(
+				  `${
 					passive
-						? RuntimeGlobals.onChunksLoaded
-						: RuntimeGlobals.startupEntrypoint
-				}(0, ${JSON.stringify(Array.from(chunks, c => c.id))}, ${fn});`
-			);
-			if (final && passive) {
-				runtime.push(`${EXPORT_PREFIX}${RuntimeGlobals.onChunksLoaded}();`);
-			}
-		}
-	};
+					  ? RuntimeGlobals.onChunksLoaded
+					  : RuntimeGlobals.startupEntrypoint
+				  }(0, ${JSON.stringify(chunkIds)}, ${fn})`,
+				);
+		
+				runtime.push(`${final && !passive ? EXPORT_PREFIX : ''}${wrap}`);
+			  }
+		};
 
 	/** @type {Chunks | undefined} */
 	let currentChunks;

--- a/lib/runtime/StartupChunkDependenciesPlugin.js
+++ b/lib/runtime/StartupChunkDependenciesPlugin.js
@@ -7,6 +7,7 @@
 const RuntimeGlobals = require("../RuntimeGlobals");
 const StartupChunkDependenciesRuntimeModule = require("./StartupChunkDependenciesRuntimeModule");
 const StartupEntrypointRuntimeModule = require("./StartupEntrypointRuntimeModule");
+const federationStartup=RuntimeGlobals.require;
 
 /** @typedef {import("../../declarations/WebpackOptions").ChunkLoadingType} ChunkLoadingType */
 /** @typedef {import("../Chunk")} Chunk */
@@ -69,6 +70,14 @@ class StartupChunkDependenciesPlugin {
 						}
 					}
 				);
+				compilation.hooks.additionalChunkRuntimeRequirements.tap(
+					'MfStartupChunkDependenciesPlugin',
+					(chunk, set, { chunkGraph }) => {
+					  if (!isEnabledForChunk(chunk)) return;
+					  if (chunkGraph.getNumberOfEntryModules(chunk) === 0) return;
+					  set.add(federationStartup);
+					},
+				  );
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.startupEntrypoint)
 					.tap("StartupChunkDependenciesPlugin", (chunk, set) => {


### PR DESCRIPTION
Following changes are made to the code base:-

1)Generalizing ensureChunkHandlers: For this I used ensureChunkHandlers for both federated and non-federated chunks by adding it in the wrappedInit function, ensuring that all chunks are processed asynchronously.

2)The distinction between passive execution (loading chunks on-demand) and final execution (evaluating the entry point and its dependencies) is retained, and the appropriate method (onChunksLoaded or startupEntrypoint) is invoked based on the state.

3)The entry point and its dependent chunks are all loaded asynchronously, ensuring that ensureChunkHandlers are invoked before executing the modules.
