### PR TITLE
fix: use `needs` in message to mach with documentation

### DIFF
--- a/examples/asset-advanced/README.md
+++ b/examples/asset-advanced/README.md
@@ -137,7 +137,7 @@ module.exports = "data:image/svg+xml,%3csvg xmlns='http://www.w3.or...3c/svg%3e"
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/asset-advanced/README.md
+++ b/examples/asset-advanced/README.md
@@ -137,7 +137,7 @@ module.exports = "data:image/svg+xml,%3csvg xmlns='http://www.w3.or...3c/svg%3e"
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/asset-simple/README.md
+++ b/examples/asset-simple/README.md
@@ -153,7 +153,7 @@ module.exports = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDo...vc3ZnPgo="
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/asset-simple/README.md
+++ b/examples/asset-simple/README.md
@@ -153,7 +153,7 @@ module.exports = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDo...vc3ZnPgo="
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/cjs-tree-shaking/README.md
+++ b/examples/cjs-tree-shaking/README.md
@@ -151,7 +151,7 @@ __webpack_unused_export__ = function multiply() {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/cjs-tree-shaking/README.md
+++ b/examples/cjs-tree-shaking/README.md
@@ -151,7 +151,7 @@ __webpack_unused_export__ = function multiply() {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/code-splitting-bundle-loader/README.md
+++ b/examples/code-splitting-bundle-loader/README.md
@@ -256,7 +256,7 @@ __webpack_require__.e(/*! require.ensure */ 929).then((function(require) {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/code-splitting-bundle-loader/README.md
+++ b/examples/code-splitting-bundle-loader/README.md
@@ -256,7 +256,7 @@ __webpack_require__.e(/*! require.ensure */ 929).then((function(require) {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/code-splitting-harmony/README.md
+++ b/examples/code-splitting-harmony/README.md
@@ -361,7 +361,7 @@ module.exports = webpackAsyncContext;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be in strict mode.
+// This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
 (() => {
 "use strict";
 /*!********************!*\

--- a/examples/code-splitting-native-import-context-filter/README.md
+++ b/examples/code-splitting-native-import-context-filter/README.md
@@ -335,7 +335,7 @@ module.exports = webpackAsyncContext;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/code-splitting-native-import-context-filter/README.md
+++ b/examples/code-splitting-native-import-context-filter/README.md
@@ -335,7 +335,7 @@ module.exports = webpackAsyncContext;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/code-splitting-native-import-context/README.md
+++ b/examples/code-splitting-native-import-context/README.md
@@ -324,7 +324,7 @@ module.exports = webpackAsyncContext;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/code-splitting-native-import-context/README.md
+++ b/examples/code-splitting-native-import-context/README.md
@@ -324,7 +324,7 @@ module.exports = webpackAsyncContext;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/code-splitting-specify-chunk-name/README.md
+++ b/examples/code-splitting-specify-chunk-name/README.md
@@ -316,7 +316,7 @@ module.exports = webpackAsyncContext;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/code-splitting-specify-chunk-name/README.md
+++ b/examples/code-splitting-specify-chunk-name/README.md
@@ -316,7 +316,7 @@ module.exports = webpackAsyncContext;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/code-splitting/README.md
+++ b/examples/code-splitting/README.md
@@ -271,7 +271,7 @@ require.ensure(["c"], function(require) {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/code-splitting/README.md
+++ b/examples/code-splitting/README.md
@@ -271,7 +271,7 @@ require.ensure(["c"], function(require) {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/coffee-script/README.md
+++ b/examples/coffee-script/README.md
@@ -99,7 +99,7 @@ module.exports = 42;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/coffee-script/README.md
+++ b/examples/coffee-script/README.md
@@ -99,7 +99,7 @@ module.exports = 42;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/commonjs/README.md
+++ b/examples/commonjs/README.md
@@ -115,7 +115,7 @@ exports.add = function() {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/commonjs/README.md
+++ b/examples/commonjs/README.md
@@ -115,7 +115,7 @@ exports.add = function() {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/css/README.md
+++ b/examples/css/README.md
@@ -382,7 +382,7 @@ module.exports = __webpack_require__.p + "89a353e9c515885abd8e.png";
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/css/README.md
+++ b/examples/css/README.md
@@ -382,7 +382,7 @@ module.exports = __webpack_require__.p + "89a353e9c515885abd8e.png";
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/custom-json-modules/README.md
+++ b/examples/custom-json-modules/README.md
@@ -211,7 +211,7 @@ module.exports = JSON.parse('{"title":"JSON5 Example","owner":{"name":"Tom Prest
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/custom-json-modules/README.md
+++ b/examples/custom-json-modules/README.md
@@ -211,7 +211,7 @@ module.exports = JSON.parse('{"title":"JSON5 Example","owner":{"name":"Tom Prest
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/dll-app-and-vendor/1-app/README.md
+++ b/examples/dll-app-and-vendor/1-app/README.md
@@ -127,7 +127,7 @@ module.exports = vendor_lib_bef1463383efb1c65306;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be in strict mode.
+// This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
 (() => {
 "use strict";
 /*!************************!*\

--- a/examples/dll-user/README.md
+++ b/examples/dll-user/README.md
@@ -174,7 +174,7 @@ module.exports = (__webpack_require__(/*! dll-reference alpha_a53f6ab3ecd4de1831
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/dll-user/README.md
+++ b/examples/dll-user/README.md
@@ -174,7 +174,7 @@ module.exports = (__webpack_require__(/*! dll-reference alpha_a53f6ab3ecd4de1831
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/externals/README.md
+++ b/examples/externals/README.md
@@ -126,7 +126,7 @@ module.exports = __WEBPACK_EXTERNAL_MODULE__2__;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 var exports = __webpack_exports__;
 /*!********************!*\

--- a/examples/externals/README.md
+++ b/examples/externals/README.md
@@ -126,7 +126,7 @@ module.exports = __WEBPACK_EXTERNAL_MODULE__2__;
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 var exports = __webpack_exports__;
 /*!********************!*\

--- a/examples/harmony-interop/README.md
+++ b/examples/harmony-interop/README.md
@@ -235,7 +235,7 @@ var named = "named";
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be in strict mode.
+// This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
 (() => {
 "use strict";
 /*!********************!*\

--- a/examples/harmony-unused/README.md
+++ b/examples/harmony-unused/README.md
@@ -213,7 +213,7 @@ function c() { console.log("c"); }
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/harmony-unused/README.md
+++ b/examples/harmony-unused/README.md
@@ -213,7 +213,7 @@ function c() { console.log("c"); }
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/harmony/README.md
+++ b/examples/harmony/README.md
@@ -305,7 +305,7 @@ function add() {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/harmony/README.md
+++ b/examples/harmony/README.md
@@ -305,7 +305,7 @@ function add() {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/loader/README.md
+++ b/examples/loader/README.md
@@ -236,7 +236,7 @@ module.exports = function (cssWithMappingToString) {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/loader/README.md
+++ b/examples/loader/README.md
@@ -236,7 +236,7 @@ module.exports = function (cssWithMappingToString) {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/mixed/README.md
+++ b/examples/mixed/README.md
@@ -369,7 +369,7 @@ __webpack_require__.r(__webpack_exports__);
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/mixed/README.md
+++ b/examples/mixed/README.md
@@ -369,7 +369,7 @@ __webpack_require__.r(__webpack_exports__);
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/multi-compiler/README.md
+++ b/examples/multi-compiler/README.md
@@ -116,7 +116,7 @@ console.log("Running " + "desktop" + " build");
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/multi-compiler/README.md
+++ b/examples/multi-compiler/README.md
@@ -116,7 +116,7 @@ console.log("Running " + "desktop" + " build");
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/named-chunks/README.md
+++ b/examples/named-chunks/README.md
@@ -249,7 +249,7 @@ require.ensure(["b"], function(require) {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/named-chunks/README.md
+++ b/examples/named-chunks/README.md
@@ -249,7 +249,7 @@ require.ensure(["b"], function(require) {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/require.context/README.md
+++ b/examples/require.context/README.md
@@ -153,7 +153,7 @@ module.exports = function() {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/require.context/README.md
+++ b/examples/require.context/README.md
@@ -153,7 +153,7 @@ module.exports = function() {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/scope-hoisting/README.md
+++ b/examples/scope-hoisting/README.md
@@ -376,7 +376,7 @@ var x = "x";
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************************!*\
   !*** ./example.js + 2 modules ***!

--- a/examples/scope-hoisting/README.md
+++ b/examples/scope-hoisting/README.md
@@ -376,7 +376,7 @@ var x = "x";
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************************!*\
   !*** ./example.js + 2 modules ***!

--- a/examples/side-effects/README.md
+++ b/examples/side-effects/README.md
@@ -248,7 +248,7 @@ const b = "b";
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/side-effects/README.md
+++ b/examples/side-effects/README.md
@@ -248,7 +248,7 @@ const b = "b";
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/top-level-await/README.md
+++ b/examples/top-level-await/README.md
@@ -467,7 +467,7 @@ const AlternativeCreateUserAction = async name => {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/top-level-await/README.md
+++ b/examples/top-level-await/README.md
@@ -467,7 +467,7 @@ const AlternativeCreateUserAction = async name => {
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -119,7 +119,7 @@ console.log(getArray(1, 2, 3));
 
 ``` js
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -119,7 +119,7 @@ console.log(getArray(1, 2, 3));
 
 ``` js
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 /*!********************!*\
   !*** ./example.js ***!

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -874,9 +874,9 @@ class JavascriptModulesPlugin {
 						: inlinedModules.size > 1
 							? // TODO check globals and top-level declarations of other entries and chunk modules
 								// to make a better decision
-								"it need to be isolated against other entry modules."
+								"it needs to be isolated against other entry modules."
 							: chunkModules && !renamedInlinedModule
-								? "it need to be isolated against other modules in the chunk."
+								? "it needs to be isolated against other modules in the chunk."
 								: exports && !webpackExports
 									? `it uses a non-standard name for the exports (${m.exportsArgument}).`
 									: hooks.embedInRuntimeBailout.call(m, renderContext);

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -870,7 +870,7 @@ class JavascriptModulesPlugin {
 					const webpackExports =
 						exports && m.exportsArgument === RuntimeGlobals.exports;
 					const iife = innerStrict
-						? "it need to be in strict mode."
+						? "it needs to be in strict mode."
 						: inlinedModules.size > 1
 							? // TODO check globals and top-level declarations of other entries and chunk modules
 								// to make a better decision
@@ -883,7 +883,7 @@ class JavascriptModulesPlugin {
 					let footer;
 					if (iife !== undefined) {
 						startupSource.add(
-							`// This entry need to be wrapped in an IIFE because ${iife}\n`
+							`// This entry needs to be wrapped in an IIFE because ${iife}\n`
 						);
 						const arrow = runtimeTemplate.supportsArrowFunction();
 						if (arrow) {

--- a/test/configCases/output-module/iife-entry-module-with-others/test.js
+++ b/test/configCases/output-module/iife-entry-module-with-others/test.js
@@ -5,5 +5,5 @@ it("IIFE should present when `avoidEntryIife` is disabled, and avoided when true
 	const trueSource = fs.readFileSync(path.join(__dirname, "module-avoidEntryIife-true.mjs"), "utf-8");
 	const falseSource = fs.readFileSync(path.join(__dirname, "module-avoidEntryIife-false.mjs"), "utf-8");
 	expect(trueSource).not.toContain('This entry needs to be wrapped in an IIFE');
-	expect(falseSource).toContain('This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.');
+	expect(falseSource).toContain('This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.');
 });

--- a/test/configCases/output-module/iife-entry-module-with-others/test.js
+++ b/test/configCases/output-module/iife-entry-module-with-others/test.js
@@ -4,6 +4,6 @@ const path = require("path");
 it("IIFE should present when `avoidEntryIife` is disabled, and avoided when true", () => {
 	const trueSource = fs.readFileSync(path.join(__dirname, "module-avoidEntryIife-true.mjs"), "utf-8");
 	const falseSource = fs.readFileSync(path.join(__dirname, "module-avoidEntryIife-false.mjs"), "utf-8");
-	expect(trueSource).not.toContain('This entry need to be wrapped in an IIFE');
-	expect(falseSource).toContain('This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.');
+	expect(trueSource).not.toContain('This entry needs to be wrapped in an IIFE');
+	expect(falseSource).toContain('This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.');
 });

--- a/test/configCases/output-module/iife-innter-strict/test.js
+++ b/test/configCases/output-module/iife-innter-strict/test.js
@@ -3,5 +3,5 @@ const path = require("path");
 
 it("IIFE should present for inner strict", () => {
 	const source = fs.readFileSync(path.join(__dirname, "bundle0.js"), "utf-8");
-	expect(source).toContain(`This entry need to be wrapped in an IIFE because it need to be in strict mode.`);
+	expect(source).toContain(`This entry needs to be wrapped in an IIFE because it needs to be in strict mode.`);
 });

--- a/test/configCases/output-module/iife-multiple-entry-modules/test.js
+++ b/test/configCases/output-module/iife-multiple-entry-modules/test.js
@@ -3,5 +3,5 @@ const path = require("path");
 
 it("IIFE should present for multiple entires", () => {
 	const source = fs.readFileSync(path.join(__dirname, "bundle0.mjs"), "utf-8");
-	expect(source).toContain(`This entry need to be wrapped in an IIFE because it need to be isolated against other entry modules.`);
+	expect(source).toContain(`This entry needs to be wrapped in an IIFE because it need to be isolated against other entry modules.`);
 });

--- a/test/configCases/output-module/iife-multiple-entry-modules/test.js
+++ b/test/configCases/output-module/iife-multiple-entry-modules/test.js
@@ -3,5 +3,5 @@ const path = require("path");
 
 it("IIFE should present for multiple entires", () => {
 	const source = fs.readFileSync(path.join(__dirname, "bundle0.mjs"), "utf-8");
-	expect(source).toContain(`This entry needs to be wrapped in an IIFE because it need to be isolated against other entry modules.`);
+	expect(source).toContain(`This entry needs to be wrapped in an IIFE because it needs to be isolated against other entry modules.`);
 });

--- a/test/configCases/output-module/reuse-webpack-esm-library/lib.js
+++ b/test/configCases/output-module/reuse-webpack-esm-library/lib.js
@@ -70,7 +70,7 @@ import * as __WEBPACK_EXTERNAL_MODULE_react__ from "react";
 /******/
 /************************************************************************/
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 	/*!***************************!*\
 		!*** ./src/store/call.ts ***!

--- a/test/configCases/output-module/reuse-webpack-esm-library/lib.js
+++ b/test/configCases/output-module/reuse-webpack-esm-library/lib.js
@@ -70,7 +70,7 @@ import * as __WEBPACK_EXTERNAL_MODULE_react__ from "react";
 /******/
 /************************************************************************/
 var __webpack_exports__ = {};
-// This entry needs to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
 	/*!***************************!*\
 		!*** ./src/store/call.ts ***!

--- a/test/configCases/parsing/override-strict/strict.js
+++ b/test/configCases/parsing/override-strict/strict.js
@@ -3,6 +3,6 @@ import fs from "fs";
 
 it("should not have iife for entry module when modules strict is different", () => {
   const code = fs.readFileSync(__filename, 'utf-8');
-  const iifeComment = ["This entry need to be wrapped in an IIFE", "because it need to be in strict mode."].join(' ');
+  const iifeComment = ["This entry needs to be wrapped in an IIFE", "because it needs to be in strict mode."].join(' ');
   expect(code).not.toMatch(iifeComment);
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Fix https://github.com/webpack/webpack/pull/18814

Refer https://github.com/webpack/webpack.js.org/pull/7402#discussion_r1776441677

`needs` is grammatically correct.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
No
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
