### PR TITLE
fix: Module Federation should track all referenced chunks

### DIFF
--- a/lib/container/RemoteRuntimeModule.js
+++ b/lib/container/RemoteRuntimeModule.js
@@ -32,7 +32,9 @@ class RemoteRuntimeModule extends RuntimeModule {
 		const chunkToRemotesMapping = {};
 		/** @type {Record<ModuleId, [string, string, string | number | null]>} */
 		const idToExternalAndNameMapping = {};
-		for (const chunk of /** @type {Chunk} */ (this.chunk).getAllAsyncChunks()) {
+		for (const chunk of /** @type {Chunk} */ (
+			this.chunk
+		).getAllReferencedChunks()) {
 			const modules = chunkGraph.getChunkModulesIterableBySourceType(
 				chunk,
 				"remote"

--- a/lib/sharing/ConsumeSharedRuntimeModule.js
+++ b/lib/sharing/ConsumeSharedRuntimeModule.js
@@ -67,7 +67,9 @@ class ConsumeSharedRuntimeModule extends RuntimeModule {
 				);
 			}
 		};
-		for (const chunk of /** @type {Chunk} */ (this.chunk).getAllAsyncChunks()) {
+		for (const chunk of /** @type {Chunk} */ (
+			this.chunk
+		).getAllReferencedChunks()) {
 			const modules = chunkGraph.getChunkModulesIterableBySourceType(
 				chunk,
 				"consume-shared"

--- a/test/configCases/container/track-initial-chunks/App.js
+++ b/test/configCases/container/track-initial-chunks/App.js
@@ -1,0 +1,6 @@
+import React from "react";
+import ComponentA from "containerA/ComponentA";
+
+export default () => {
+	return `App rendered with [${React()}] and [${ComponentA()}]`;
+};

--- a/test/configCases/container/track-initial-chunks/ComponentA.js
+++ b/test/configCases/container/track-initial-chunks/ComponentA.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default () => {
+	return `ComponentA rendered with [${React()}]`;
+};

--- a/test/configCases/container/track-initial-chunks/index-2.js
+++ b/test/configCases/container/track-initial-chunks/index-2.js
@@ -1,0 +1,2 @@
+import React from "react"
+console.log(React)

--- a/test/configCases/container/track-initial-chunks/index.js
+++ b/test/configCases/container/track-initial-chunks/index.js
@@ -1,0 +1,35 @@
+it("should have the hoisted container references", async () => {
+	const before = __webpack_modules__;
+	debugger;
+
+	// Initialize tracker array
+	const tracker = [];
+
+	// Call the consumes function to populate tracker with hoisted container references
+	__webpack_require__.f.consumes("other", tracker);
+
+	// Ensure all references in tracker are resolved
+	await Promise.all(tracker);
+
+	const after = __webpack_modules__;
+	debugger;
+
+	// Verify that tracker contains hoisted container references
+	expect(tracker).not.toHaveLength(0);
+});
+
+it("should load the component from container", () => {
+	return import("./App").then(({ default: App }) => {
+		const rendered = App();
+		expect(rendered).toBe(
+			"App rendered with [This is react 0.1.2] and [ComponentA rendered with [This is react 0.1.2]]"
+		);
+		return import("./upgrade-react").then(({ default: upgrade }) => {
+			upgrade();
+			const rendered = App();
+			expect(rendered).toBe(
+				"App rendered with [This is react 1.2.3] and [ComponentA rendered with [This is react 1.2.3]]"
+			);
+		});
+	});
+});

--- a/test/configCases/container/track-initial-chunks/node_modules/react.js
+++ b/test/configCases/container/track-initial-chunks/node_modules/react.js
@@ -1,0 +1,3 @@
+let version = "0.1.2";
+export default () => `This is react ${version}`;
+export function setVersion(v) { version = v; }

--- a/test/configCases/container/track-initial-chunks/test.config.js
+++ b/test/configCases/container/track-initial-chunks/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return i === 0 ? "./main.js" : "./module/main.mjs";
+	}
+};

--- a/test/configCases/container/track-initial-chunks/upgrade-react.js
+++ b/test/configCases/container/track-initial-chunks/upgrade-react.js
@@ -1,0 +1,5 @@
+import { setVersion } from "react";
+
+export default function upgrade() {
+	setVersion("1.2.3");
+}

--- a/test/configCases/container/track-initial-chunks/webpack.config.js
+++ b/test/configCases/container/track-initial-chunks/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = [
 		optimization: {
 			runtimeChunk: "single",
 			moduleIds: "named",
-			chunkIds: "named",
+			chunkIds: "named"
 		},
 		plugins: [
 			new ModuleFederationPlugin({
@@ -60,7 +60,7 @@ module.exports = [
 		optimization: {
 			runtimeChunk: "single",
 			moduleIds: "named",
-			chunkIds: "named",
+			chunkIds: "named"
 		},
 		output: {
 			filename: "module/[name].mjs",

--- a/test/configCases/container/track-initial-chunks/webpack.config.js
+++ b/test/configCases/container/track-initial-chunks/webpack.config.js
@@ -1,0 +1,87 @@
+const { ModuleFederationPlugin } = require("../../../../").container;
+
+/** @type {ConstructorParameters<typeof ModuleFederationPlugin>[0]} */
+const common = {
+	name: "container",
+	exposes: {
+		"./ComponentA": {
+			import: "./ComponentA"
+		}
+	},
+	shared: {
+		react: {
+			version: false,
+			requiredVersion: false
+		}
+	}
+};
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{
+		entry: {
+			main: "./index.js",
+			other: "./index-2.js"
+		},
+		output: {
+			filename: "[name].js",
+			uniqueName: "ref-hoist"
+		},
+		optimization: {
+			runtimeChunk: "single",
+			moduleIds: "named",
+			chunkIds: "named",
+		},
+		plugins: [
+			new ModuleFederationPlugin({
+				runtime: false,
+				library: { type: "commonjs-module" },
+				filename: "container.js",
+				remotes: {
+					containerA: {
+						external: "./container.js"
+					},
+					containerB: {
+						external: "../0-container-full/container.js"
+					}
+				},
+				...common
+			})
+		]
+	},
+	{
+		entry: {
+			main: "./index.js",
+			other: "./index-2.js"
+		},
+		experiments: {
+			outputModule: true
+		},
+		optimization: {
+			runtimeChunk: "single",
+			moduleIds: "named",
+			chunkIds: "named",
+		},
+		output: {
+			filename: "module/[name].mjs",
+			uniqueName: "ref-hoist-mjs"
+		},
+		plugins: [
+			new ModuleFederationPlugin({
+				runtime: false,
+				library: { type: "module" },
+				filename: "module/container.mjs",
+				remotes: {
+					containerA: {
+						external: "./container.mjs"
+					},
+					containerB: {
+						external: "../../0-container-full/module/container.mjs"
+					}
+				},
+				...common
+			})
+		],
+		target: "node14"
+	}
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

ref: https://github.com/webpack/webpack/issues/18812
ref: https://github.com/webpack/webpack/issues/16173

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Module Federation should track ALL referenced chunks, not just async chunks. 

This also resolves split chunks issues where initial chunks on an entry are code split

This also allows federation to track and call load handlers on any chunk associated with the runtime. 

Tracking async chunks only causes several problems. 
- initial split chunks wont work
- dependOn of entrypoint wont work
- multiple entrypoints have issues
- things like workers etc will not work as they depend on shared code but federation has no import map for the chunk to module ids in `require.f.consumes/remotes`

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix

**Did you add tests for your changes?**
not needed

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
no doc needed
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
