### PR TITLE
feat: add import.meta.DEBUG

### DIFF
--- a/lib/dependencies/ImportMetaPlugin.js
+++ b/lib/dependencies/ImportMetaPlugin.js
@@ -16,6 +16,7 @@ const BasicEvaluatedExpression = require("../javascript/BasicEvaluatedExpression
 const {
 	evaluateToIdentifier,
 	toConstantDependency,
+	evaluateToBoolean,
 	evaluateToString,
 	evaluateToNumber
 } = require("../javascript/JavascriptParserHelpers");
@@ -79,9 +80,12 @@ class ImportMetaPlugin {
 						require("../../package.json").version,
 						10
 					);
+					const hasDevelopmentCondition =
+						compilation.options.mode === "development";
 					const importMetaUrl = () =>
 						JSON.stringify(getUrl(parser.state.module));
 					const importMetaWebpackVersion = () => JSON.stringify(webpackVersion);
+					const importMetaDebug = () => JSON.stringify(hasDevelopmentCondition);
 					/**
 					 * @param {string[]} members members
 					 * @returns {string} error message
@@ -136,6 +140,9 @@ class ImportMetaPlugin {
 										break;
 									case "webpack":
 										str += `webpack: ${importMetaWebpackVersion()},`;
+										break;
+									case "DEBUG":
+										str += `DEBUG: ${importMetaDebug()},`;
 										break;
 									default:
 										str += `[${JSON.stringify(
@@ -208,6 +215,23 @@ class ImportMetaPlugin {
 					parser.hooks.evaluateIdentifier
 						.for("import.meta.webpack")
 						.tap(PLUGIN_NAME, evaluateToNumber(webpackVersion));
+
+					// import.meta.DEBUG
+					parser.hooks.typeof
+						.for("import.meta.DEBUG")
+						.tap(
+							PLUGIN_NAME,
+							toConstantDependency(parser, JSON.stringify("boolean"))
+						);
+					parser.hooks.expression
+						.for("import.meta.DEBUG")
+						.tap(PLUGIN_NAME, toConstantDependency(parser, importMetaDebug()));
+					parser.hooks.evaluateTypeof
+						.for("import.meta.DEBUG")
+						.tap(PLUGIN_NAME, evaluateToString("boolean"));
+					parser.hooks.evaluateIdentifier
+						.for("import.meta.DEBUG")
+						.tap(PLUGIN_NAME, evaluateToBoolean(hasDevelopmentCondition));
 
 					// Unknown properties
 					parser.hooks.unhandledExpressionMemberChain

--- a/test/cases/esm/import-meta/index.js
+++ b/test/cases/esm/import-meta/index.js
@@ -6,6 +6,7 @@ const webpackVersion = parseInt(
 	require("../../../../package.json").version,
 	10
 );
+const devProdCondition = require('echo-dev-condition').default;
 
 it('typeof import.meta === "object"', () => {
 	expect(typeof import.meta).toBe("object");
@@ -27,6 +28,18 @@ it("should return correct import.meta.url", () => {
 	expect(import.meta["url"]).toBe(url);
 	expect("my" + import.meta.url).toBe("my" + url);
 	if (import.meta.url.indexOf("index.js") === -1) require("fail");
+});
+
+it("should return correct import.meta.DEBUG", () => {
+	if (devProdCondition === '<unset>') {
+		// If nothing else, import.meta.DEBUG should be falsey (e.g. undefined).
+		expect(import.meta.DEBUG).toBeFalsy();
+	} else {
+		expect(import.meta.DEBUG).toBe(devProdCondition === '<dev>');
+	}
+	expect(!!import.meta.DEBUG).toBe(process.env.NODE_ENV === 'development');
+	if (typeof import.meta.DEBUG !== "boolean") require("fail");
+	if (import.meta.DEBUG !== false && import.meta.DEBUG !== true) require("fail");
 });
 
 it("should return correct import.meta.webpack", () => {

--- a/test/cases/esm/import-meta/node_modules/echo-dev-condition/dev.js
+++ b/test/cases/esm/import-meta/node_modules/echo-dev-condition/dev.js
@@ -1,0 +1,1 @@
+export default '<dev>';

--- a/test/cases/esm/import-meta/node_modules/echo-dev-condition/package.json
+++ b/test/cases/esm/import-meta/node_modules/echo-dev-condition/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "echo-dev-condition",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    "development": "./dev.js",
+    "production": "./prod.js",
+    "default": "./unset.js"
+  }
+}

--- a/test/cases/esm/import-meta/node_modules/echo-dev-condition/prod.js
+++ b/test/cases/esm/import-meta/node_modules/echo-dev-condition/prod.js
@@ -1,0 +1,1 @@
+export default '<prod>';

--- a/test/cases/esm/import-meta/node_modules/echo-dev-condition/unset.js
+++ b/test/cases/esm/import-meta/node_modules/echo-dev-condition/unset.js
@@ -1,0 +1,1 @@
+export default '<unset>';


### PR DESCRIPTION
Adds an alternative to `process.env.NODE_ENV`-based guards. It's a simple boolean and doesn't require the use of node-specific APIs in non-node code.

See: https://github.com/jkrems/md/blob/main/import-meta-debug.md
Or just skip ahead to the section that defines this new property: https://github.com/jkrems/md/blob/main/import-meta-debug.md#importmetaDEBUG.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

The goal is to have this property reliably available across tools. PRs across bundlers:

* Parcel: TBD
* Rspack: TBD
* Vite: https://github.com/vitejs/vite/pull/18417
* webpack: https://github.com/webpack/webpack/pull/18876

I wouldn't be surprised if there's some bikeshedding on the name (`.DEBUG` vs `.DEV` vs `.development` vs ..?). So it's likely a good idea to hold off on landing it in any of the tools before there's a broader consensus on the name. The API itself seems simple enough that I'm not expecting a _lot_ of churn.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Feature: It's a new `import.meta` property.

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

Tests are included.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

This shouldn't break any code _unless_ somebody currently depends on `import.meta.DEBUG` being false in development. I'm not aware of any use of this property though.

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

This should be added to the properties on https://webpack.js.org/api/module-variables/.
