### PR TITLE
fix: hotUpdate chunk modified with new runtime should have correct runtime

### DIFF
--- a/lib/HotModuleReplacementPlugin.js
+++ b/lib/HotModuleReplacementPlugin.js
@@ -686,7 +686,9 @@ class HotModuleReplacementPlugin {
 								if (backCompat)
 									ChunkGraph.setChunkGraphForChunk(hotUpdateChunk, chunkGraph);
 								hotUpdateChunk.id = chunkId;
-								hotUpdateChunk.runtime = newRuntime;
+								hotUpdateChunk.runtime = currentChunk
+									? currentChunk.runtime
+									: newRuntime;
 								if (currentChunk) {
 									for (const group of currentChunk.groupsIterable)
 										hotUpdateChunk.addGroup(group);

--- a/test/hotCases/runtime/add-runtime/index.js
+++ b/test/hotCases/runtime/add-runtime/index.js
@@ -1,0 +1,13 @@
+let value = require("./module.js");
+import {a} from "./lib/a.js";
+
+it("should compile", (done) => {
+	expect(value).toBe(1);
+	expect(a).toBe(1);
+	module.hot.accept("./module.js", () => {
+		value = require("./module");
+		expect(value).toBe(2);
+		done();
+	});
+	NEXT(require("../../update")(done));
+});

--- a/test/hotCases/runtime/add-runtime/lib/a.js
+++ b/test/hotCases/runtime/add-runtime/lib/a.js
@@ -1,0 +1,1 @@
+export const a = 1

--- a/test/hotCases/runtime/add-runtime/lib/b.js
+++ b/test/hotCases/runtime/add-runtime/lib/b.js
@@ -1,0 +1,1 @@
+export const b = 1

--- a/test/hotCases/runtime/add-runtime/lib/package.json
+++ b/test/hotCases/runtime/add-runtime/lib/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": true
+}

--- a/test/hotCases/runtime/add-runtime/module.js
+++ b/test/hotCases/runtime/add-runtime/module.js
@@ -1,0 +1,4 @@
+module.exports = 1;
+---
+new Worker(new URL('./worker.js', import.meta.url))
+module.exports = 2;

--- a/test/hotCases/runtime/add-runtime/test.filter.js
+++ b/test/hotCases/runtime/add-runtime/test.filter.js
@@ -1,0 +1,8 @@
+var supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = function (config) {
+	if (config.target !== "web") {
+		return false;
+	}
+	return supportsWorker();
+};

--- a/test/hotCases/runtime/add-runtime/webpack.config.js
+++ b/test/hotCases/runtime/add-runtime/webpack.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+	optimization: {
+		usedExports: true,
+		// make 'lib' chunk runtime to be worker + entry
+		splitChunks: {
+			minSize: 0,
+			chunks: "all",
+			cacheGroups: {
+				lib: {
+					test: /[/\\]lib[/\\](a|b|index).js$/,
+					name: "lib",
+					filename: "bundle-lib.js"
+				}
+			}
+		}
+	}
+};

--- a/test/hotCases/runtime/add-runtime/worker.js
+++ b/test/hotCases/runtime/add-runtime/worker.js
@@ -1,0 +1,2 @@
+import {b} from "./lib/b.js";
+b;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Initial compile we have only entry runtime, and we split a module 'lib' into separate chunk, then we modify some of entry module, make it imports a worker, the worker contains the module 'lib' as well.

We have 2 runtime: entry and worker

if one module exist both in entry and worker, and we split it into separate chunk, the chunk has runtime entry and worker, but the HotUpdate chunk only have runtime in the previous compilation, which is entry only, so it cannot render module 'lib', because 'lib' is generated using runtime entry + worker

For the detailed repro, you could check my test case

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
