### PR TITLE
fix: produces correct code when 'output.iife' is false & 'output.library.type' is 'umd', & it gives a warning to the users.

### DIFF
--- a/lib/RuntimeTemplate.js
+++ b/lib/RuntimeTemplate.js
@@ -98,7 +98,10 @@ class RuntimeTemplate {
 	}
 
 	isIIFE() {
-		return this.outputOptions.iife;
+		return (
+			this.outputOptions.iife ||
+			(this.outputOptions.library && this.outputOptions.library.type === "umd")
+		);
 	}
 
 	isModule() {

--- a/lib/WarnFalseIifeUmdPlugin.js
+++ b/lib/WarnFalseIifeUmdPlugin.js
@@ -1,0 +1,31 @@
+/*
+    MIT License http://www.opensource.org/licenses/mit-license.php
+    Author Arka Pratim Chaudhuri @arkapratimc
+*/
+
+"use strict";
+
+const WebpackError = require("./WebpackError");
+
+class FalseIifeUmdWarning extends WebpackError {
+	constructor() {
+		super();
+		this.name = "FalseIifeUmdWarning";
+		this.message =
+			"configuration\n" +
+			"Setting 'output.iife' to 'false' is incompatible with 'output.library.type' set to 'umd'. This configuration may cause unexpected behavior, as UMD libraries are expected to use an IIFE (Immediately Invoked Function Expression) to support various module formats. Consider setting 'output.iife' to 'true' or choosing a different 'library.type' to ensure compatibility.\nLearn more: https://webpack.js.org/configuration/output/";
+	}
+}
+
+class WarnFalseIifeUmdPlugin {
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap(
+			"WarnFalseIifeUmdPlugin",
+			compilation => {
+				compilation.warnings.push(new FalseIifeUmdWarning());
+			}
+		);
+	}
+}
+
+module.exports = WarnFalseIifeUmdPlugin;

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -209,6 +209,15 @@ class WebpackOptionsApply extends OptionsApply {
 			}
 		}
 
+		if (
+			options.output.iife === false &&
+			options.output.library &&
+			options.output.library.type === "umd"
+		) {
+			const WarnFalseIifeUmdPlugin = require("./WarnFalseIifeUmdPlugin");
+			new WarnFalseIifeUmdPlugin().apply(compiler);
+		}
+
 		const enabledChunkLoadingTypes =
 			/** @type {NonNullable<WebpackOptions["output"]["enabledChunkLoadingTypes"]>} */
 			(options.output.enabledChunkLoadingTypes);

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -373,6 +373,26 @@ it("should bao; thrown sync error from plugin", async () => {
 				`);
 });
 
+it("should emit warning when 'output.iife'=false is used with 'output.library.type'='umd'", async () => {
+	await expect(
+		compile({
+			mode: "production",
+			entry: "./false-iife-umd.js",
+			output: { library: { type: "umd" }, iife: false }
+		})
+	).resolves.toMatchInlineSnapshot(`
+		Object {
+		  "errors": Array [],
+		  "warnings": Array [
+		    Object {
+		      "message": "configuration\\nSetting 'output.iife' to 'false' is incompatible with 'output.library.type' set to 'umd'. This configuration may cause unexpected behavior, as UMD libraries are expected to use an IIFE (Immediately Invoked Function Expression) to support various module formats. Consider setting 'output.iife' to 'true' or choosing a different 'library.type' to ensure compatibility.\\nLearn more: https://webpack.js.org/configuration/output/",
+		      "stack": "FalseIifeUmdWarning: configuration\\nSetting 'output.iife' to 'false' is incompatible with 'output.library.type' set to 'umd'. This configuration may cause unexpected behavior, as UMD libraries are expected to use an IIFE (Immediately Invoked Function Expression) to support various module formats. Consider setting 'output.iife' to 'true' or choosing a different 'library.type' to ensure compatibility.\\nLearn more: https://webpack.js.org/configuration/output/",
+		    },
+		  ],
+		}
+	`);
+});
+
 describe("loaders", () => {
 	it("should emit error thrown at module level", async () => {
 		await expect(

--- a/test/configCases/library/0-create-library/webpack.config.js
+++ b/test/configCases/library/0-create-library/webpack.config.js
@@ -155,6 +155,22 @@ module.exports = (env, { testPath }) => [
 	},
 	{
 		output: {
+			uniqueName: "false-iife-umd",
+			filename: "false-iife-umd.js",
+			library: {
+				type: "umd"
+			},
+			iife: false
+		},
+		resolve: {
+			alias: {
+				external: "./non-external"
+			}
+		},
+		ignoreWarnings: [error => error.name === "FalseIifeUmdWarning"]
+	},
+	{
+		output: {
 			uniqueName: "umd-default",
 			filename: "umd-default.js",
 			libraryTarget: "umd",

--- a/test/configCases/library/1-use-library/webpack.config.js
+++ b/test/configCases/library/1-use-library/webpack.config.js
@@ -166,6 +166,18 @@ module.exports = (env, { testPath }) => [
 		]
 	},
 	{
+		resolve: {
+			alias: {
+				library: path.resolve(testPath, "../0-create-library/false-iife-umd.js")
+			}
+		},
+		plugins: [
+			new webpack.DefinePlugin({
+				NAME: JSON.stringify("false-iife-umd")
+			})
+		]
+	},
+	{
 		entry: "./this-test.js",
 		resolve: {
 			alias: {

--- a/test/fixtures/errors/false-iife-umd.js
+++ b/test/fixtures/errors/false-iife-umd.js
@@ -1,0 +1,1 @@
+export const answer = 42;


### PR DESCRIPTION
fixes: #18687 

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
This PR adds an IIFE wrapper around the returned code when a user sets `output.iife = false` & `output.library.type = "umd"`. 
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
A warning note under https://webpack.js.org/configuration/output/#type-umd
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
