### PR TITLE
feat: Removing the need for async Import for #18812

### DIFF
--- a/lib/RuntimeGlobals.js
+++ b/lib/RuntimeGlobals.js
@@ -198,6 +198,18 @@ module.exports.hasFetchPriority = "has fetch priority";
  * the chunk name of the chunk with the runtime
  */
 module.exports.chunkName = "__webpack_require__.cn";
+/**
+ * a initialize js for the chunk
+ */
+module.exports.chunkHasJs= "__webpack_require__.ch"
+/**
+ * 
+ */
+module.exports.federationStartup="__webpack_require__.fs"
+/**
+ * 
+ */
+module.exports.generateESMEntryStartup="__webpack_require__.ge" 
 
 /**
  * the runtime id of the current runtime

--- a/lib/javascript/StartupHelpers.js
+++ b/lib/javascript/StartupHelpers.js
@@ -5,10 +5,17 @@
 
 "use strict";
 
+import { HotUpdateChunk, Chunk } from "..";
+import { getUndoPath } from "../util/identifier";
+
 const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
 const { isSubset } = require("../util/SetHelpers");
 const { getAllChunks } = require("./ChunkHelpers");
+const {chunkHasJs} =require("../RuntimeGlobals");
+const {federationStartup} = require("../RuntimeGlobals");
+
+
 
 /** @typedef {import("../util/Hash")} Hash */
 /** @typedef {import("../Chunk")} Chunk */
@@ -48,7 +55,19 @@ module.exports.generateEntryStartup = (
 			`${RuntimeGlobals.require}(${RuntimeGlobals.entryModuleId} = moduleId)`,
 			"moduleId"
 		)}`
+		,
+    '',
+    '\n',
+    'var promises = [];',
 	];
+
+	const treeRuntimeRequirements = chunkGraph.getTreeRuntimeRequirements(chunk);
+  const chunkRuntimeRequirements =
+    chunkGraph.getChunkRuntimeRequirements(chunk);
+  const federation =
+    chunkRuntimeRequirements.has(federationStartup) ||
+    treeRuntimeRequirements.has(federationStartup);
+
 
 	/**
 	 * @param {ModuleId} id id
@@ -69,8 +88,36 @@ module.exports.generateEntryStartup = (
 			const fn = runtimeTemplate.returningFunction(
 				moduleIds.map(runModule).join(", ")
 			);
+			if (federation) {
+				const chunkIds = Array.from(chunks, (c) => c.id);
+		
+				const wrappedInit = (/** @type {string} */ body) =>
+				  Template.asString([
+					'Promise.all([',
+					Template.indent([
+					  // may have other chunks who depend on federation, so best to just fallback
+					  // instead of try to figure out if consumes or remotes exists during build
+					  `${RuntimeGlobals.ensureChunkHandlers}.consumes || function(chunkId, promises) {},`,
+					  `${RuntimeGlobals.ensureChunkHandlers}.remotes || function(chunkId, promises) {},`,
+					]),
+					`].reduce(${runtimeTemplate.returningFunction(`handler('${chunk.id}', p), p`, 'p, handler')}, promises)`,
+					`).then(${runtimeTemplate.returningFunction(body)});`,
+				  ]);
+	
+				const wrap = wrappedInit(
+				  `${
+					passive
+					  ? RuntimeGlobals.onChunksLoaded
+					  : RuntimeGlobals.startupEntrypoint
+				  }(0, ${JSON.stringify(chunkIds)}, ${fn})`,
+				);
+
+				runtime.push(`${final && !passive ? EXPORT_PREFIX : ''}${wrap}`);
+      } else {
+        
+        const chunkIds = Array.from(chunks, (c) => c.id);
 			runtime.push(
-				`${final && !passive ? EXPORT_PREFIX : ""}${
+				`${final && !passive ? EXPORT_PREFIX : ""}$
 					passive
 						? RuntimeGlobals.onChunksLoaded
 						: RuntimeGlobals.startupEntrypoint
@@ -80,6 +127,7 @@ module.exports.generateEntryStartup = (
 				runtime.push(`${EXPORT_PREFIX}${RuntimeGlobals.onChunksLoaded}();`);
 			}
 		}
+	}	
 	};
 
 	/** @type {Chunks | undefined} */
@@ -159,6 +207,115 @@ module.exports.updateHashForEntryStartup = (
 	}
 };
 
+export const generateESMEntryStartup = (
+	/** @type {{ compiler: { webpack: { JavascriptModulesPlugin: { chunkHasJs: any; getChunkFilenameTemplate: any; }; sources: { ConcatSource: any; }; }; }; getPath: (arg0: any, arg1: { chunk: any; contentHashType: string; }) => string; outputOptions: any; }} */ compilation,
+	// @ts-ignore
+	/** @type {{ getTreeRuntimeRequirements: (arg0: any) => any; getChunkRuntimeRequirements: (arg0: any) => any; getModuleId: (arg0: any) => string; }} */ chunkGraph,
+	/** @type {{ returningFunction: (arg0: string, arg1: string) => any; }} */ runtimeTemplate,
+	/** @type {string | any[]} */ entries,
+	/** @type {import("../Chunk")} */ chunk,
+	/** @type {any} */ passive,
+  ) => {
+	const { chunkHasJs, getChunkFilenameTemplate } =
+	  compilation.compiler.webpack.JavascriptModulesPlugin;
+	const { ConcatSource } = compilation.compiler.webpack.sources;
+	const hotUpdateChunk = chunk instanceof HotUpdateChunk ? chunk : null;
+	if (hotUpdateChunk) {
+	  throw new Error('HMR is not implemented for module chunk format yet');
+	} else {
+	  const treeRuntimeRequirements =
+		chunkGraph.getTreeRuntimeRequirements(chunk);
+	  const chunkRuntimeRequirements =
+		chunkGraph.getChunkRuntimeRequirements(chunk);
+	  const federation =
+		chunkRuntimeRequirements.has(federationStartup) ||
+		treeRuntimeRequirements.has(federationStartup);
+	  if (entries.length > 0) {
+		const runtimeChunk = entries[0]?.[1]?.getRuntimeChunk?.();
+		if (!runtimeChunk) {
+		  throw new Error('Runtime chunk is undefined');
+		}
+		const currentOutputName = compilation
+		  .getPath(getChunkFilenameTemplate(chunk, compilation.outputOptions), {
+			chunk,
+			contentHashType: 'javascript',
+		  })
+		  .replace(/^\/+/g, '')
+		  .split('/');
+  
+		/**
+		 * @param {Chunk} chunk the chunk
+		 * @returns {string} the relative path
+		 */
+		const getRelativePath = (chunk) => {
+		  const baseOutputName = currentOutputName.slice();
+		  const chunkOutputName = compilation
+			.getPath(getChunkFilenameTemplate(chunk, compilation.outputOptions), {
+			  chunk,
+			  contentHashType: 'javascript',
+			})
+			.replace(/^\/+/g, '')
+			.split('/');
+  
+		  // remove common parts except filename
+		  while (
+			baseOutputName.length > 1 &&
+			chunkOutputName.length > 1 &&
+			baseOutputName[0] === chunkOutputName[0]
+		  ) {
+			baseOutputName.shift();
+			chunkOutputName.shift();
+		  }
+		  const last = chunkOutputName.join('/');
+		  // create final path
+		  return getUndoPath(baseOutputName.join('/'), last, true) + last;
+		};
+  
+		const startupSource = new ConcatSource();
+		startupSource.add(
+		  `var __webpack_exec__ = ${runtimeTemplate.returningFunction(
+			`${RuntimeGlobals.require}(${RuntimeGlobals.entryModuleId} = moduleId)`,
+			'moduleId',
+		  )}\n`,
+		);
+  
+		// @ts-ignore
+		const loadedChunks = new Set(chunk);;
+		let index = 0;
+		for (let i = 0; i < entries.length; i++) {
+		  const [module, entrypoint] = entries[i];
+		  if (!entrypoint) continue;
+		  const final = i + 1 === entries.length;
+		  const moduleId = chunkGraph.getModuleId(module);
+		  const chunks = getAllChunks(entrypoint, runtimeChunk, undefined);
+		  for (const chunk of chunks) {
+			if (loadedChunks.has(chunk) || !chunkHasJs(chunk, chunkGraph))
+			  continue;
+			loadedChunks.add(chunk);
+			startupSource.add(
+			  `import * as __webpack_chunk_${index}__ from ${JSON.stringify(
+				getRelativePath(chunk),
+			  )};\n`,
+			);
+			startupSource.add(
+			  `${RuntimeGlobals.externalInstallChunk}(__webpack_chunk_${index}__);\n`,
+			);
+			index++;
+		  }
+		  // generateEntryStartup handles calling require and execution of the entry module.
+		  if (!federation) {
+			startupSource.add(
+			  `${
+				final ? EXPORT_PREFIX : ''
+			  }__webpack_exec__(${JSON.stringify(moduleId)});\n`,
+			);
+		  }
+		}
+	}
+ }
+  };
+  
+  
 /**
  * @param {Chunk} chunk the chunk
  * @param {ChunkGraph} chunkGraph the chunk graph

--- a/lib/runtime/StartupChunkDependenciesPlugin.js
+++ b/lib/runtime/StartupChunkDependenciesPlugin.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /*
 	MIT License http://www.opensource.org/licenses/mit-license.php
 */
@@ -7,6 +8,9 @@
 const RuntimeGlobals = require("../RuntimeGlobals");
 const StartupChunkDependenciesRuntimeModule = require("./StartupChunkDependenciesRuntimeModule");
 const StartupEntrypointRuntimeModule = require("./StartupEntrypointRuntimeModule");
+const federationStartup = require("../RuntimeGlobals");
+const { generateESMEntryStartup } = require("../RuntimeGlobals");
+
 
 /** @typedef {import("../../declarations/WebpackOptions").ChunkLoadingType} ChunkLoadingType */
 /** @typedef {import("../Chunk")} Chunk */
@@ -37,8 +41,13 @@ class StartupChunkDependenciesPlugin {
 	 */
 	apply(compiler) {
 		compiler.hooks.thisCompilation.tap(
+			'MfStartupChunkDependenciesPlugin',
+			(/** @type {import("../Compilation")} */ compilation) => {
+			  const isEnabledForChunk = (/** @type {any} */ chunk) =>
+				this.isEnabledForChunk(chunk, compilation);
+		compiler.hooks.thisCompilation.tap(
 			"StartupChunkDependenciesPlugin",
-			compilation => {
+			(			/** @type {{ outputOptions: { chunkLoading: any; }; hooks: { additionalTreeRuntimeRequirements: { tap: (arg0: string, arg1: (chunk: import("../Chunk"), set: { add: (arg0: string) => void; }, { chunkGraph }: { chunkGraph: any; }) => void) => void; }; additionalChunkRuntimeRequirements: { tap: (arg0: string, arg1: (chunk: import("../Chunk"), set: { add: (arg0: typeof RuntimeGlobals) => void; }, { chunkGraph }: { chunkGraph: any; }) => void) => void; }; runtimeRequirementInTree: { for: (arg0: string) => { (): any; new (): any; tap: { (arg0: string, arg1: (chunk: any, set: any) => void): void; new (): any; }; }; }; }; addRuntimeModule: (arg0: import("../Chunk"), arg1: StartupChunkDependenciesRuntimeModule | StartupEntrypointRuntimeModule) => void; }} */ compilation) => {
 				const globalChunkLoading = compilation.outputOptions.chunkLoading;
 				/**
 				 * @param {Chunk} chunk chunk to check
@@ -54,7 +63,7 @@ class StartupChunkDependenciesPlugin {
 				};
 				compilation.hooks.additionalTreeRuntimeRequirements.tap(
 					"StartupChunkDependenciesPlugin",
-					(chunk, set, { chunkGraph }) => {
+					(/** @type {import("../Chunk")} */ chunk, /** @type {{ add: (arg0: string) => void; }} */ set, { chunkGraph }) => {
 						if (!isEnabledForChunk(chunk)) return;
 						if (chunkGraph.hasChunkEntryDependentChunks(chunk)) {
 							set.add(RuntimeGlobals.startup);
@@ -69,6 +78,14 @@ class StartupChunkDependenciesPlugin {
 						}
 					}
 				);
+				compilation.hooks.additionalChunkRuntimeRequirements.tap(
+					'MfStartupChunkDependenciesPlugin',
+					(/** @type {import("../Chunk")} */ chunk, /** @type {{ add: (arg0: typeof RuntimeGlobals) => void; }} */ set, { chunkGraph }) => {
+					  if (!isEnabledForChunk(chunk)) return;
+					  if (chunkGraph.getNumberOfEntryModules(chunk) === 0) return;
+					  set.add(federationStartup);
+					},
+				  );
 				compilation.hooks.runtimeRequirementInTree
 					.for(RuntimeGlobals.startupEntrypoint)
 					.tap("StartupChunkDependenciesPlugin", (chunk, set) => {
@@ -83,6 +100,56 @@ class StartupChunkDependenciesPlugin {
 					});
 			}
 		);
+		const { renderStartup } =
+          compiler.webpack.javascript.JavascriptModulesPlugin.getCompilationHooks(
+            compilation,
+          );
+
+		renderStartup.tap(
+			'MfStartupChunkDependenciesPlugin',
+			(/** @type {any} */ startupSource, /** @type {any} */ lastInlinedModule, /** @type {{ chunk: any; chunkGraph: any; runtimeTemplate: any; }} */ renderContext) => {
+			  const { chunk, chunkGraph, runtimeTemplate } = renderContext;
+  
+			  if (!isEnabledForChunk(chunk)) {
+				return startupSource;
+			  }
+  
+			  const treeRuntimeRequirements =
+				chunkGraph.getTreeRuntimeRequirements(chunk);
+			  const chunkRuntimeRequirements =
+				chunkGraph.getChunkRuntimeRequirements(chunk);
+  
+			  const federation =
+				chunkRuntimeRequirements.has(federationStartup) ||
+				treeRuntimeRequirements.has(federationStartup);
+  
+			  if (!federation) {
+				return startupSource;
+			  }
+  
+			  const entryModules = Array.from(
+				chunkGraph.getChunkEntryModulesWithChunkGroupIterable(chunk),
+			  );
+  
+			  const entryGeneration = runtimeTemplate.outputOptions.module
+				? generateESMEntryStartup
+				// @ts-ignore
+				: generateEntryStartup;
+  
+			  return new compiler.webpack.sources.ConcatSource(
+				entryGeneration(
+				  compilation,
+				  chunkGraph,
+				  runtimeTemplate,
+				  entryModules,
+				  chunk,
+				  false,
+				),
+			  );
+			},
+		  );
+		},
+	  );
 	}
 }
 

--- a/test/configCases/library/0-create-library/webpack.config.js
+++ b/test/configCases/library/0-create-library/webpack.config.js
@@ -271,6 +271,24 @@ module.exports = (env, { testPath }) => [
 	},
 	{
 		output: {
+			uniqueName: "startupHelpers",
+			filename: "startupHelpers.js",
+			libraryTarget: "startupHelpers",
+			iife: false
+		},
+		externals: ["external"]
+	},
+	{
+		output: {
+			uniqueName: "StartupChunkDependenciesPlugin",
+			filename: "StartupChunkDependenciesPlugin.js",
+			libraryTarget: "StartupChunkDependenciesPlugin",
+			iife: false
+		},
+		externals: ["external"]
+	},
+	{
+		output: {
 			uniqueName: "commonjs2-external-no-concat",
 			filename: "commonjs2-external-no-concat.js",
 			libraryTarget: "commonjs2",


### PR DESCRIPTION
Fixes:-#18812

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

This pr adds a logic to remove the need for async import in `StartupHelpers.js` and `StartupChunkDependenciesPlugin.js` .
Additionally referencing all the plugins to `Runtimeglobals.js`.

**Did you add tests for your changes?**

yes

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

No
