### PR TITLE
test: fix import attributes external target

### DIFF
--- a/test/configCases/externals/import-assertion/webpack.config.js
+++ b/test/configCases/externals/import-assertion/webpack.config.js
@@ -58,7 +58,7 @@ module.exports = {
 		"./eager.json": "import ./eager.json",
 		"./weak.json": "import ./weak.json",
 		"./pkg.json": "import ./pkg.json",
-		"./pkg": "import ./pkg",
+		"./pkg": "import ./pkg.json",
 		"./re-export.json": "module ./re-export.json",
 		"./re-export-directly.json": "module ./re-export-directly.json",
 		"./static-package-module-import.json":

--- a/test/configCases/externals/import-attributes/webpack.config.js
+++ b/test/configCases/externals/import-attributes/webpack.config.js
@@ -58,7 +58,7 @@ module.exports = {
 		"./eager.json": "import ./eager.json",
 		"./weak.json": "import ./weak.json",
 		"./pkg.json": "import ./pkg.json",
-		"./pkg": "import ./pkg",
+		"./pkg": "import ./pkg.json",
 		"./re-export.json": "module ./re-export.json",
 		"./re-export-directly.json": "module ./re-export-directly.json",
 		"./static-package-module-import.json":


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Previously, the bundled result of `test/js/ConfigTestCases/externals/import-attributes/bundle0.mjs` was incorrect as below. It should be `./pkg.json` because ESM requires a fully specified path.

```js
/***/ ((module) => {

module.exports = import("./pkg", { with: {"type":"json"} });;

/***/ }),
```

I'm not sure the reason it's not panicked in webpack test, as webpack test is simulating many stuff like the runtime. But it did panic in Rspack ported webpack test (they're not fully aligned). However, according to the output code, it should be fixed this way.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

No.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
