### PR TITLE
Fix queue iterator state in dequeue method to ensure correct behavior after item removal

### DIFF
--- a/lib/util/Queue.js
+++ b/lib/util/Queue.js
@@ -18,11 +18,6 @@ class Queue {
 		 * @type {Set<T>}
 		 */
 		this._set = new Set(items);
-		/**
-		 * @private
-		 * @type {Iterator<T>}
-		 */
-		this._iterator = this._set[Symbol.iterator]();
 	}
 
 	/**
@@ -47,7 +42,7 @@ class Queue {
 	 * @returns {T | undefined} The head of the queue of `undefined` if this queue is empty.
 	 */
 	dequeue() {
-		const result = this._iterator.next();
+		const result = this._set[Symbol.iterator]().next();
 		if (result.done) return;
 		this._set.delete(result.value);
 		return result.value;


### PR DESCRIPTION
## Motivation:

This PR addresses an issue in the Queue class where the dequeuing functionality was not handling the state of the queue correctly after an item was dequeued. The iterator for the Set inside the queue was not updated properly, which caused the dequeue method to always return undefined after the first iteration, even if new items were enqueued.

This change ensures that the iterator is reset each time an element is dequeued, allowing new elements to be dequeued properly after others are removed.

**What kind of change does this PR introduce?**
Bugfix: Corrects the behavior of the dequeue method to ensure that the iterator is correctly updated and the queue behaves as expected after dequeuing an element.

**Did you add tests for your changes?**
Not yet: Tests will be added if this change is likely to be merged.

**Does this PR introduce a breaking change?**
No: This fix does not introduce any breaking changes to the existing functionality.


**What needs to be documented once your changes are merged?**
No additional documentation is required, as this is a bug fix that restores expected behavior.

**Additional Notes:**
This fix ensures that the queue operates properly even after items are dequeued and new items are enqueued. It maintains compatibility with the existing API and should not affect other parts of the codebase.
