### PR TITLE
keep consistent css order

### DIFF
--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -277,12 +277,117 @@ class SideEffectsFlagPlugin {
 
 						logger.time("update dependencies");
 
-						const optimizedModules = new Set();
+						/**
+						 * Restore module dependency order after tree-shaking to maintain
+						 * correct ordering (especially for CSS)
+						 * @param {Module} module module being processed
+						 * @param {Set<Module>} updatedDependencies dependencies that were updated during tree-shaking
+						 */
+						const restoreModuleDependencyOrder = (
+							module,
+							updatedDependencies
+						) => {
+							// Early exit if no dependencies to reorder
+							if (updatedDependencies.size === 0) return;
 
+							for (const incomingConnection of moduleGraph.getIncomingConnections(
+								module
+							)) {
+								const directIncomingConnections =
+									moduleGraph.getOutgoingConnections(
+										incomingConnection.originModule
+									);
+								/** @type Map<Module, ModuleGraphConnection[]> */
+								const directIncomingConnectionGroups = new Map();
+								/** @type Map<number, Module> */
+								const dependencyBlockIndexMap = new Map();
+								let needsSorting = false;
+
+								// Group connections to their barrel file connection
+								for (const directIncomingConnection of directIncomingConnections) {
+									const dependencyBlockIndex = moduleGraph.getParentBlockIndex(
+										directIncomingConnection.dependency
+									);
+									let groupModule = directIncomingConnection.module;
+									if (dependencyBlockIndexMap.has(dependencyBlockIndex)) {
+										// Use the barrel file as key
+										groupModule =
+											dependencyBlockIndexMap.get(dependencyBlockIndex);
+									} else {
+										// The first occurrence is always the barrel file
+										dependencyBlockIndexMap.set(
+											dependencyBlockIndex,
+											groupModule
+										);
+									}
+									if (
+										updatedDependencies.delete(directIncomingConnection.module)
+									) {
+										needsSorting = true;
+									}
+									let group = directIncomingConnectionGroups.get(groupModule);
+									if (!group) {
+										group = [];
+										directIncomingConnectionGroups.set(groupModule, group);
+									}
+									group.push(directIncomingConnection);
+								}
+
+								if (!needsSorting) {
+									continue;
+								}
+								// Sort connections within each group
+								for (const directIncomingConnectionGroup of directIncomingConnectionGroups.values()) {
+									directIncomingConnectionGroup.sort(
+										(a, b) =>
+											moduleGraph.getParentBlockIndex(a.dependency) -
+											moduleGraph.getParentBlockIndex(b.dependency)
+									);
+								}
+								// Sort groups by their first connection's index
+								const sortedIncomingGroups = [
+									...directIncomingConnectionGroups.values()
+								].sort((groupA, groupB) => {
+									const blockIndexA = moduleGraph.getParentBlockIndex(
+										groupA[0].dependency
+									);
+									const blockIndexB = moduleGraph.getParentBlockIndex(
+										groupB[0].dependency
+									);
+									return blockIndexA - blockIndexB;
+								});
+								const sortedOriginalBlockIndexes = [
+									...dependencyBlockIndexMap.keys()
+								].sort();
+								// Update dependency indices to restore original order
+								/** @type Set<Dependency> */
+								const dependenciesToSort = new Set();
+								for (const group of sortedIncomingGroups) {
+									for (const connection of group) {
+										dependenciesToSort.add(connection.dependency);
+									}
+								}
+								let indexPosition = 0;
+								for (const dependency of dependenciesToSort) {
+									dependency._parentDependenciesBlockIndex =
+										sortedOriginalBlockIndexes[indexPosition];
+									indexPosition++;
+								}
+								// Stop processing if all dependencies have been reordered
+								if (!updatedDependencies.size) {
+									break;
+								}
+							}
+						};
+
+						/** @type Set<Module> */
+						const optimizedModules = new Set();
 						/**
 						 * @param {Module} module module
 						 */
 						const optimizeIncomingConnections = module => {
+							/** @type Set<Module> */
+							const updatedDependencies = new Set();
 							if (optimizedModules.has(module)) return;
 							optimizedModules.add(module);
 							if (module.getSideEffectsConnectionState(moduleGraph) === false) {
@@ -314,6 +419,7 @@ class SideEffectsFlagPlugin {
 													module.getSideEffectsConnectionState(moduleGraph) ===
 													false,
 												({ module: newModule, export: exportName }) => {
+													updatedDependencies.add(newModule);
 													moduleGraph.updateModule(dep, newModule);
 													moduleGraph.addExplanation(
 														dep,
@@ -345,6 +451,7 @@ class SideEffectsFlagPlugin {
 											);
 											if (!target) continue;
 
+											updatedDependencies.add(target.module);
 											moduleGraph.updateModule(dep, target.module);
 											moduleGraph.addExplanation(
 												dep,
@@ -359,6 +466,10 @@ class SideEffectsFlagPlugin {
 										}
 									}
 								}
+							}
+
+							if (updatedDependencies.size) {
+								restoreModuleDependencyOrder(module, updatedDependencies);
 							}
 						};
 

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -3497,10 +3497,10 @@ cacheable modules X KiB
     |   [no exports]
     |   [no exports used]
     |   Statement (ExpressionStatement) with side effects in source code at 4:0-30
-    | ./node_modules/module-with-export/index.js X KiB [built]
-    |   [only some exports used: smallVar]
     | ./node_modules/big-module/a.js X bytes [built]
     |   [only some exports used: a]
+    | ./node_modules/module-with-export/index.js X KiB [built]
+    |   [only some exports used: smallVar]
   ./node_modules/module-with-export/emptyModule.js X bytes [built] [code generated]
     [used exports unknown]
     ModuleConcatenation bailout: Module is not an ECMAScript module


### PR DESCRIPTION
**What kind of change does this PR introduce?**

We were struggling with the problem that the CSS ordering becomes unpredictable when webpack's side effects optimization removes barrel files (for `sideEffects: false` in package.json)

Looking at webpack's buildChunkGraph.js, I traced this down to how module graph building and tree-shaking interact. When webpack finds a module marked as side effect free, it tries to optimize by skipping over barrel files  (`activeState`: false`) and connecting directly to implementation files. While great for JS tree-shaking, this changes the dependency order which affects CSS since mini-css-extract-plugin relies on postOrderIndex for ordering

Here's a concrete example from the reproduction repo I set up:
```ts
// @libraries/teaser/src/teaser.ts
import { CarouselButton } from '@segments/carousel'; // via barrel file
import styles from './teaser.module.css';
```

When building with `sideEffects: false`, webpack removes the barrel file but loses the original ordering, resulting in incorrect CSS:
```css
.teaser { ... }  /* Should be last */
.carousel { ... } /* Should be first */ 
```

I've found this is happening because dependency indices get rewritten during side effects optimization

My fix in SideEffectsFlagPlugin.js maintains the original ordering by sorting the direct imports after their barrel files position

BEFORE THE FIX:

```
Initial import order in parent module:
index: 0 -> @segments/carousel/index.ts (barrel file)
index: 1 -> ./teaser.module.css

After tree-shaking removes barrel file:
index: 0 -> @segments/carousel (inactive)
index: 1 -> ./teaser.module.css
index: 2 -> @segments/carousel/slide.ts  (lost original order from barrel)
```

Result: CSS order is wrong because slide.ts lost its original 
position relative to teaser.module.css

WITH THE FIX:

```
Initial import order in parent module:
index: 0 -> @segments/carousel/index.ts (barrel file)
index: 1 -> ./teaser.module.css

After tree-shaking + fix:
index: 0 -> @segments/carousel (inactive)
index: 1 -> @segments/carousel/slide.ts  (sorted next to its barrel file)
index: 2 -> ./teaser.module.css
```

Result: CSS ordering preserved because we restored the barrel file's position
and internal ordering before removing it

I tested this fix for the reproduction repo at: https://github.com/jantimon/reproduction-webpack-css-order

With the fix the CSS order is the same as for other bundlers like Parcel or Vite

All changes happen only inside the `SideEffectsFlagPlugin` and only if a barrel file was removed by that plugin
