### PR TITLE
feat: Improve access to resolver data in module.rules and rule.use

### DIFF
--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -596,7 +596,8 @@ class NormalModuleFactory extends ModuleFactory {
 								: resourceData.data.descriptionFileData,
 							issuer: contextInfo.issuer,
 							compiler: contextInfo.compiler,
-							issuerLayer: contextInfo.issuerLayer || ""
+							issuerLayer: contextInfo.issuerLayer || "",
+							relativePath: resourceData.data.relativePath
 						});
 						for (const r of result) {
 							// https://github.com/webpack/webpack/issues/16466

--- a/lib/rules/BasicMatcherRulePlugin.js
+++ b/lib/rules/BasicMatcherRulePlugin.js
@@ -43,7 +43,7 @@ class BasicMatcherRulePlugin {
 						matchWhenEmpty: this.invert
 							? !condition.matchWhenEmpty
 							: condition.matchWhenEmpty,
-						fn: this.invert ? v => !fn(v) : fn
+						fn: this.invert ? (v, r) => !fn(v, r) : fn
 					});
 				}
 			}

--- a/lib/rules/RuleSetCompiler.js
+++ b/lib/rules/RuleSetCompiler.js
@@ -10,7 +10,12 @@ const { SyncHook } = require("tapable");
 /** @typedef {import("../../declarations/WebpackOptions").RuleSetRule} RuleSetRule */
 /** @typedef {import("../../declarations/WebpackOptions").RuleSetRules} RuleSetRules */
 
-/** @typedef {function(string | EffectData): boolean} RuleConditionFunction */
+/**
+ * @typedef {{ 
+ *descriptionData?: { name?: string, version?: string, [key: string]: any },
+ *relativePath?: string
+}} ResourceData */
+/** @typedef {function(string | EffectData, ResourceData): boolean} RuleConditionFunction */
 
 /**
  * @typedef {object} RuleCondition
@@ -106,13 +111,25 @@ class RuleSetCompiler {
 						}
 					}
 					if (current !== undefined) {
-						if (!condition.fn(current)) return false;
+						if (
+							!condition.fn(current, {
+								descriptionData: data.descriptionData,
+								relativePath: data.relativePath
+							})
+						)
+							return false;
 						continue;
 					}
 				} else if (p in data) {
 					const value = data[p];
 					if (value !== undefined) {
-						if (!condition.fn(value)) return false;
+						if (
+							!condition.fn(value, {
+								descriptionData: data.descriptionData,
+								relativePath: data.relativePath
+							})
+						)
+							return false;
 						continue;
 					}
 				}
@@ -254,8 +271,11 @@ class RuleSetCompiler {
 		if (typeof condition === "function") {
 			try {
 				return {
-					matchWhenEmpty: condition(""),
-					fn: condition
+					matchWhenEmpty: condition("", {
+						descriptionData: {},
+						relativePath: ""
+					}),
+					fn: (str, resourceData) => condition(str, resourceData)
 				};
 			} catch (_err) {
 				throw this.error(
@@ -324,7 +344,9 @@ class RuleSetCompiler {
 						const fn = matcher.fn;
 						conditions.push({
 							matchWhenEmpty: !matcher.matchWhenEmpty,
-							fn: /** @type {RuleConditionFunction} */ (v => !fn(v))
+							fn: /** @type {RuleConditionFunction} */ (
+								(v, resourceData) => !fn(v, resourceData)
+							)
 						});
 					}
 					break;
@@ -361,7 +383,7 @@ class RuleSetCompiler {
 		}
 		return {
 			matchWhenEmpty: conditions.some(c => c.matchWhenEmpty),
-			fn: v => conditions.some(c => c.fn(v))
+			fn: (v, resourceData) => conditions.some(c => c.fn(v, resourceData))
 		};
 	}
 
@@ -380,7 +402,7 @@ class RuleSetCompiler {
 		}
 		return {
 			matchWhenEmpty: conditions.every(c => c.matchWhenEmpty),
-			fn: v => conditions.every(c => c.fn(v))
+			fn: (v, resourceData) => conditions.every(c => c.fn(v, resourceData))
 		};
 	}
 

--- a/test/configCases/rule-set/relative-path/index.js
+++ b/test/configCases/rule-set/relative-path/index.js
@@ -3,10 +3,17 @@ it("should match modules by package", function() {
   expect(package).toEqual("matched-by-package");
 });
 
-
 it("should match modules by relative path within package", function() {
     var button = require("fake-package/lib/button.js");
     expect(button).toEqual("matched-by-relative-path");
 });
 
+it("should match modules by exclude", function() {
+    var excluded = require("fake-package/lib/excluded.js");
+    expect(excluded).toEqual("excluded");
+});
 
+it("should match modules by use", function() {
+    var test = require("fake-package/lib/test.js");
+    expect(test).toEqual("matched-by-test");
+});

--- a/test/configCases/rule-set/relative-path/index.js
+++ b/test/configCases/rule-set/relative-path/index.js
@@ -1,0 +1,12 @@
+it("should match modules by package", function() {
+  var package = require("fake-package");
+  expect(package).toEqual("matched-by-package");
+});
+
+
+it("should match modules by relative path within package", function() {
+    var button = require("fake-package/lib/button.js");
+    expect(button).toEqual("matched-by-relative-path");
+});
+
+

--- a/test/configCases/rule-set/relative-path/loader.js
+++ b/test/configCases/rule-set/relative-path/loader.js
@@ -1,0 +1,5 @@
+/** @type {import("../../../../").LoaderDefinition<{value: string}>} */
+module.exports = function(source) {
+  const options = this.getOptions();
+  return `module.exports = ${JSON.stringify(options.value)};`
+};

--- a/test/configCases/rule-set/relative-path/node_modules/fake-package/lib/button.js
+++ b/test/configCases/rule-set/relative-path/node_modules/fake-package/lib/button.js
@@ -1,0 +1,1 @@
+module.exports = "button";

--- a/test/configCases/rule-set/relative-path/node_modules/fake-package/lib/excluded.js
+++ b/test/configCases/rule-set/relative-path/node_modules/fake-package/lib/excluded.js
@@ -1,0 +1,1 @@
+module.exports = "excluded";

--- a/test/configCases/rule-set/relative-path/node_modules/fake-package/lib/index.js
+++ b/test/configCases/rule-set/relative-path/node_modules/fake-package/lib/index.js
@@ -1,0 +1,1 @@
+module.exports = "fake-package";

--- a/test/configCases/rule-set/relative-path/node_modules/fake-package/lib/test.js
+++ b/test/configCases/rule-set/relative-path/node_modules/fake-package/lib/test.js
@@ -1,0 +1,1 @@
+module.exports = "test";

--- a/test/configCases/rule-set/relative-path/node_modules/fake-package/package.json
+++ b/test/configCases/rule-set/relative-path/node_modules/fake-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fake-package",
+  "version": "1.0.0",
+  "main": "lib/index.js"
+}

--- a/test/configCases/rule-set/relative-path/webpack.config.js
+++ b/test/configCases/rule-set/relative-path/webpack.config.js
@@ -3,7 +3,7 @@ module.exports = {
 	module: {
 		rules: [
 			{
-				test: /\.js$/,
+				test: /button.js$/,
 				include: (resource, { descriptionData, relativePath }) =>
 					descriptionData &&
 					descriptionData.name === "fake-package" &&
@@ -15,12 +15,43 @@ module.exports = {
 				}
 			},
 			{
-				test: /\.js$/,
+				test: /index.js$/,
 				include: (resource, { descriptionData, relativePath }) =>
 					descriptionData && descriptionData.name === "fake-package",
 				loader: "./loader",
 				options: {
 					value: "matched-by-package"
+				}
+			},
+			{
+				test: /excluded.js$/,
+				exclude: (resource, { descriptionData, relativePath }) =>
+					descriptionData &&
+					descriptionData.name === "fake-package" &&
+					descriptionData.version === "1.0.0" &&
+					relativePath === "./lib/excluded.js",
+				loader: "./loader",
+				options: {
+					value: "matched-by-excluded"
+				}
+			},
+			{
+				test: /test.js$/,
+				use: ({ descriptionData, relativePath }) => {
+					if (
+						descriptionData &&
+						descriptionData.name === "fake-package" &&
+						descriptionData.version === "1.0.0" &&
+						relativePath === "./lib/test.js"
+					) {
+						return {
+							loader: "./loader",
+							options: {
+								value: "matched-by-test"
+							}
+						};
+					}
+					return null;
 				}
 			}
 		]

--- a/test/configCases/rule-set/relative-path/webpack.config.js
+++ b/test/configCases/rule-set/relative-path/webpack.config.js
@@ -1,0 +1,28 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				include: (resource, { descriptionData, relativePath }) =>
+					descriptionData &&
+					descriptionData.name === "fake-package" &&
+					descriptionData.version === "1.0.0" &&
+					relativePath === "./lib/button.js",
+				loader: "./loader",
+				options: {
+					value: "matched-by-relative-path"
+				}
+			},
+			{
+				test: /\.js$/,
+				include: (resource, { descriptionData, relativePath }) =>
+					descriptionData && descriptionData.name === "fake-package",
+				loader: "./loader",
+				options: {
+					value: "matched-by-package"
+				}
+			}
+		]
+	}
+};


### PR DESCRIPTION
Closes #18562

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
This PR introduces a feature enhancement for loader criteria matching. It improves the way modules from npm dependencies can be selected by allowing matching based on both:
1. Package name (already supported via `descriptionData.name`)
2. Relative path within the package 

This enhancement provides a more ergonomic way to specify module matching criteria, especially since the relative paths are normalized to use POSIX-style separators (/), making them cross-platform compatible, unlike the current `resourcePath` which uses platform-specific disk paths.<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
 Yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
The second parameter in Rule Conditions
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
