### PR TITLE
prevent reading directories as files when building fs cache #16417

### DIFF
--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -3265,34 +3265,44 @@ class FileSystemInfo {
 	 * @private
 	 */
 	_readFileHash(path, callback) {
-		this.fs.readFile(path, (err, content) => {
+		this.fs.stat(path, (err, _stat) => {
 			if (err) {
-				if (err.code === "EISDIR") {
-					this._fileHashes.set(path, "directory");
-					return callback(null, "directory");
-				}
 				if (err.code === "ENOENT") {
 					this._fileHashes.set(path, null);
 					return callback(null, null);
 				}
-				if (err.code === "ERR_FS_FILE_TOO_LARGE") {
-					/** @type {Logger} */
-					(this.logger).warn(`Ignoring ${path} for hashing as it's very large`);
-					this._fileHashes.set(path, "too large");
-					return callback(null, "too large");
-				}
 				return callback(/** @type {WebpackError} */ (err));
 			}
 
-			const hash = createHash(this._hashFunction);
+			const stat = /** @type {IStats} */ (_stat);
+			if (stat.isDirectory()) {
+				this._fileHashes.set(path, "directory");
+				return callback(null, "directory");
+			}
 
-			hash.update(/** @type {string | Buffer} */ (content));
+			this.fs.readFile(path, (err, content) => {
+				if (err) {
+					if (err.code === "ERR_FS_FILE_TOO_LARGE") {
+						/** @type {Logger} */
+						(this.logger).warn(
+							`Ignoring ${path} for hashing as it's very large`
+						);
+						this._fileHashes.set(path, "too large");
+						return callback(null, "too large");
+					}
+					return callback(/** @type {WebpackError} */ (err));
+				}
 
-			const digest = /** @type {string} */ (hash.digest("hex"));
+				const hash = createHash(this._hashFunction);
 
-			this._fileHashes.set(path, digest);
+				hash.update(/** @type {string | Buffer} */ (content));
 
-			callback(null, digest);
+				const digest = /** @type {string} */ (hash.digest("hex"));
+
+				this._fileHashes.set(path, digest);
+
+				callback(null, digest);
+			});
 		});
 	}
 

--- a/test/FileSystemInfo.unittest.js
+++ b/test/FileSystemInfo.unittest.js
@@ -500,4 +500,40 @@ ${details(snapshot)}`)
 			);
 		});
 	});
+
+	describe("getFileHash", () => {
+		const fs = createFs();
+		const fsInfo = createFsInfo(fs);
+		it("should error reporting that memfs root is a directory", done => {
+			fsInfo.getFileHash("/", function (err, hash) {
+				// TODO: getFileHash - maybe "directory" should be err
+				expect(hash).toBe("directory");
+				done();
+			});
+		});
+
+		it("should not error on regular files", done => {
+			fsInfo.getFileHash("/path/file.txt", function (err, hash) {
+				expect(err).toBe(null);
+				expect(hash).not.toBe(null);
+				done();
+			});
+		});
+
+		it("should error on missing files", done => {
+			fsInfo.getFileHash("/this/path/does/not.exist", function (err, hash) {
+				expect(hash).toBe(null);
+				done();
+			});
+		});
+
+		it("should error reporting that system root is a directory", done => {
+			const fs = require("fs");
+			const fsInfo = createFsInfo(fs);
+			fsInfo.getFileHash("/", function (err, hash) {
+				expect(hash).toBe("directory");
+				done();
+			});
+		});
+	});
 });


### PR DESCRIPTION
fixes #16417
check to see if path passed into `FileSystemInfo._readFileHash` is actually a file

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
no

**Does this PR introduce a breaking change?**
no

**What needs to be documented once your changes are merged?**
nothing