### PR TITLE
fix: sub define key should't be renamed when it's a defined variable

### DIFF
--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -14,7 +14,7 @@ const RuntimeGlobals = require("./RuntimeGlobals");
 const WebpackError = require("./WebpackError");
 const ConstDependency = require("./dependencies/ConstDependency");
 const BasicEvaluatedExpression = require("./javascript/BasicEvaluatedExpression");
-
+const { VariableInfo } = require("./javascript/JavascriptParser");
 const {
 	evaluateToString,
 	toConstantDependency
@@ -455,10 +455,16 @@ class DefinePlugin {
 					 */
 					const applyDefineKey = (prefix, key) => {
 						const splittedKey = key.split(".");
+						const firstKey = splittedKey[0];
 						for (const [i, _] of splittedKey.slice(1).entries()) {
 							const fullKey = prefix + splittedKey.slice(0, i + 1).join(".");
 							parser.hooks.canRename.for(fullKey).tap(PLUGIN_NAME, () => {
 								addValueDependency(key);
+								if (
+									parser.scope.definitions.get(firstKey) instanceof VariableInfo
+								) {
+									return false;
+								}
 								return true;
 							});
 						}

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -5004,3 +5004,4 @@ module.exports.ALLOWED_MEMBER_TYPES_EXPRESSION =
 module.exports.ALLOWED_MEMBER_TYPES_CALL_EXPRESSION =
 	ALLOWED_MEMBER_TYPES_CALL_EXPRESSION;
 module.exports.getImportAttributes = getImportAttributes;
+module.exports.VariableInfo = VariableInfo;

--- a/test/configCases/plugins/define-plugin-sub-key/foo.js
+++ b/test/configCases/plugins/define-plugin-sub-key/foo.js
@@ -1,0 +1,4 @@
+
+export default {
+	bar: "test"
+}

--- a/test/configCases/plugins/define-plugin-sub-key/index.js
+++ b/test/configCases/plugins/define-plugin-sub-key/index.js
@@ -1,0 +1,22 @@
+
+import foo from './foo.js';
+
+function works1() {
+  return foo.bar;
+}
+
+function works2() {
+  const v = foo.bar;
+  return v;
+}
+
+function works3() {
+  const v = foo.bar.baz;
+  return v;
+}
+
+it("should compile and run", () => {
+  expect(works1()).toBe("test");
+  expect(works2()).toBe("test");
+  expect(works3()).toBe("test");
+});

--- a/test/configCases/plugins/define-plugin-sub-key/webpack.config.js
+++ b/test/configCases/plugins/define-plugin-sub-key/webpack.config.js
@@ -1,0 +1,10 @@
+var DefinePlugin = require("../../../../").DefinePlugin;
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	plugins: [
+		new DefinePlugin({
+			"foo.bar.baz": '"test"'
+		})
+	]
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -4546,7 +4546,7 @@ declare interface ExportSpec {
 	 */
 	hidden?: boolean;
 }
-type ExportedVariableInfo = string | ScopeInfo | VariableInfo;
+type ExportedVariableInfo = string | VariableInfo | ScopeInfo;
 declare abstract class ExportsInfo {
 	get ownedExports(): Iterable<ExportInfo>;
 	get orderedOwnedExports(): Iterable<ExportInfo>;
@@ -6810,7 +6810,7 @@ declare class JavascriptParser extends Parser {
 			| undefined
 			| ((
 					arg0: string,
-					arg1: string | ScopeInfo | VariableInfo,
+					arg1: string | VariableInfo | ScopeInfo,
 					arg2: () => string[]
 			  ) => any),
 		defined: undefined | ((arg0: string) => any),
@@ -7143,6 +7143,7 @@ declare class JavascriptParser extends Parser {
 			| ExportAllDeclarationJavascriptParser
 			| ImportExpressionJavascriptParser
 	) => undefined | ImportAttributes;
+	static VariableInfo: typeof VariableInfo;
 }
 
 /**
@@ -13918,7 +13919,7 @@ declare interface RuntimeValueOptions {
  * to create the range of the _parent node_.
  */
 declare interface ScopeInfo {
-	definitions: StackedMap<string, ScopeInfo | VariableInfo>;
+	definitions: StackedMap<string, VariableInfo | ScopeInfo>;
 	topLevelScope: boolean | "arrow";
 	inShorthand: string | boolean;
 	inTaggedTemplateTag: boolean;
@@ -15249,7 +15250,12 @@ type UsageStateType = 0 | 1 | 2 | 3 | 4;
 type UsedName = string | false | string[];
 type Value = string | number | boolean | RegExp;
 type ValueCacheVersion = string | Set<string>;
-declare abstract class VariableInfo {
+declare class VariableInfo {
+	constructor(
+		declaredScope: ScopeInfo,
+		freeName?: string | true,
+		tagInfo?: TagInfo
+	);
 	declaredScope: ScopeInfo;
 	freeName?: string | true;
 	tagInfo?: TagInfo;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fixes https://github.com/webpack/webpack/issues/18573


```javascript
import foo from './foo.js';

function works() {
  return foo.bar;
}

function broken() {
  const bar = foo.bar;
  return bar;
}

works(); // does not throw
broken(); // throws ReferenceError
```

error output

```javascript
/* harmony import */ var _foo_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(686);
function works() {
    return _foo_js__WEBPACK_IMPORTED_MODULE_0__/* ["default"] */ .A.bar;
}
function broken() {
    const bar = foo.bar;
    return bar;
}
works(); // does not throw
broken(); // throws ReferenceError
```

expected output

```javascript
/* harmony import */ var _foo_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(686);
function works() {
    return _foo_js__WEBPACK_IMPORTED_MODULE_0__/* ["default"] */ .A.bar;
}
function broken() {
    const bar = _foo_js__WEBPACK_IMPORTED_MODULE_0__/* ["default"] */ .A.bar;
    return bar;
}
works(); // does not throw
broken(); // throws ReferenceError
```

Found that ReferenceError is because `const bar = foo.bar` is not converted to `HarmonyImportSpecifierDependency`.

After look into this issue in depth.

For `return foo.bar`, parser will do `walkExpression` which includes `new HarmonyImportSpecifierDependency` logic.

And for `const bar = foo.bar`, parser will do `walkVariableDeclaration` which includes `walkExpression` logic.

`walkVariableDeclaration` first do `rename`. If `canRename` and `rename` hook both return true, `walkExpression` can not be executed that causes `const bar = foo.bar` can not converted to `HarmonyImportSpecifierDependency`.

So the root cause is `foo.bar` can't be renamed.

For `DefinePlugin({"foo.bar.baz": "baz"})`, it will applyDefineKey that make `foo.bar` canRenamed. I think it's bug and guess that `canRename` hook is only be used to `addValueDependency`.

```js
const applyDefineKey = (prefix, key) => {
	const splittedKey = key.split(".");
	splittedKey.slice(1).forEach((_, i) => {
		const fullKey = prefix + splittedKey.slice(0, i + 1).join(".");
		parser.hooks.canRename.for(fullKey).tap(PLUGIN_NAME, () => {
			addValueDependency(key);
			return true;
		});
	});
};
```


<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
No
