### PR TITLE
perf: improve FlagDependencyExportsPlugin for large JSON by depth

### DIFF
--- a/declarations/plugins/JsonModulesPluginParser.d.ts
+++ b/declarations/plugins/JsonModulesPluginParser.d.ts
@@ -6,6 +6,10 @@
 
 export interface JsonModulesPluginParserOptions {
 	/**
+	 * The depth of json dependency flagged as `exportInfo`.
+	 */
+	exportsDepth?: number;
+	/**
 	 * Function that executes for a module source string and should return json-compatible data.
 	 */
 	parse?: (input: string) => any;

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -78,6 +78,8 @@ class WebpackOptionsApply extends OptionsApply {
 		compiler.recordsOutputPath = options.recordsOutputPath || null;
 		compiler.name = options.name;
 
+		const development = options.mode === "development";
+
 		if (options.externals) {
 			// @ts-expect-error https://github.com/microsoft/TypeScript/issues/41697
 			const ExternalsPlugin = require("./ExternalsPlugin");
@@ -290,7 +292,9 @@ class WebpackOptionsApply extends OptionsApply {
 		}
 
 		new JavascriptModulesPlugin().apply(compiler);
-		new JsonModulesPlugin().apply(compiler);
+		new JsonModulesPlugin({
+			depth: development ? 1 : Infinity
+		}).apply(compiler);
 		new AssetModulesPlugin().apply(compiler);
 
 		if (!options.experiments.outputModule) {

--- a/lib/WebpackOptionsApply.js
+++ b/lib/WebpackOptionsApply.js
@@ -78,8 +78,6 @@ class WebpackOptionsApply extends OptionsApply {
 		compiler.recordsOutputPath = options.recordsOutputPath || null;
 		compiler.name = options.name;
 
-		const development = options.mode === "development";
-
 		if (options.externals) {
 			// @ts-expect-error https://github.com/microsoft/TypeScript/issues/41697
 			const ExternalsPlugin = require("./ExternalsPlugin");
@@ -292,9 +290,7 @@ class WebpackOptionsApply extends OptionsApply {
 		}
 
 		new JavascriptModulesPlugin().apply(compiler);
-		new JsonModulesPlugin({
-			depth: development ? 1 : Infinity
-		}).apply(compiler);
+		new JsonModulesPlugin().apply(compiler);
 		new AssetModulesPlugin().apply(compiler);
 
 		if (!options.experiments.outputModule) {

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -262,7 +262,8 @@ const applyWebpackOptionsDefaults = (options, compilerIndex) => {
 		futureDefaults,
 		isNode: targetProperties && targetProperties.node === true,
 		uniqueName: options.output.uniqueName,
-		targetProperties
+		targetProperties,
+		mode: options.mode
 	});
 
 	applyExternalsPresetsDefaults(options.externalsPresets, {
@@ -609,6 +610,7 @@ const applyCssGeneratorOptionsDefaults = (
  * @param {string} options.uniqueName the unique name
  * @param {boolean} options.isNode is node target platform
  * @param {TargetProperties | false} options.targetProperties target properties
+ * @param {Mode} options.mode mode
  * @returns {void}
  */
 const applyModuleDefaults = (
@@ -621,7 +623,8 @@ const applyModuleDefaults = (
 		futureDefaults,
 		isNode,
 		uniqueName,
-		targetProperties
+		targetProperties,
+		mode
 	}
 ) => {
 	if (cache) {
@@ -663,6 +666,12 @@ const applyModuleDefaults = (
 	}
 
 	F(module.parser, "javascript", () => ({}));
+	F(module.parser, JSON_MODULE_TYPE, () => ({}));
+	D(
+		module.parser[JSON_MODULE_TYPE],
+		"exportsDepth",
+		mode === "development" ? 1 : Infinity
+	);
 
 	applyJavascriptParserOptionsDefaults(
 		/** @type {NonNullable<ParserOptionsByModuleTypeKnown["javascript"]>} */

--- a/lib/dependencies/JsonExportsDependency.js
+++ b/lib/dependencies/JsonExportsDependency.js
@@ -19,15 +19,15 @@ const NullDependency = require("./NullDependency");
 /** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext} ObjectSerializerContext */
 /** @typedef {import("../util/Hash")} Hash */
 
-/** @typedef {{depth:number}} JsonDependencyOptions */
+/** @typedef {{exportsDepth:number}} JsonDependencyOptions */
 
 /**
- * @param {number} depth depth
+ * @param {number} exportsDepth exportsDepth
  * @returns {((data: RawJsonData, curDepth?: number) => ExportSpec[] | undefined)} value
  */
-const getExportsWithDepth = depth =>
+const getExportsWithDepth = exportsDepth =>
 	function getExportsFromData(data, curDepth = 1) {
-		if (curDepth > depth) return undefined;
+		if (curDepth > exportsDepth) return undefined;
 		if (data && typeof data === "object") {
 			if (Array.isArray(data)) {
 				return data.length < 100
@@ -54,12 +54,12 @@ const getExportsWithDepth = depth =>
 class JsonExportsDependency extends NullDependency {
 	/**
 	 * @param {JsonData} data json data
-	 * @param {JsonDependencyOptions} dependencyOptions dependency options
+	 * @param {JsonDependencyOptions} options options
 	 */
-	constructor(data, dependencyOptions) {
+	constructor(data, options) {
 		super();
 		this.data = data;
-		this.options = dependencyOptions;
+		this.options = options;
 	}
 
 	get type() {
@@ -73,7 +73,7 @@ class JsonExportsDependency extends NullDependency {
 	 */
 	getExports(moduleGraph) {
 		return {
-			exports: getExportsWithDepth(this.options.depth)(
+			exports: getExportsWithDepth(this.options.exportsDepth)(
 				this.data && /** @type {RawJsonData} */ (this.data.get())
 			),
 			dependencies: undefined

--- a/lib/dependencies/JsonExportsDependency.js
+++ b/lib/dependencies/JsonExportsDependency.js
@@ -19,8 +19,6 @@ const NullDependency = require("./NullDependency");
 /** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext} ObjectSerializerContext */
 /** @typedef {import("../util/Hash")} Hash */
 
-/** @typedef {{exportsDepth:number}} JsonDependencyOptions */
-
 /**
  * @param {number} exportsDepth exportsDepth
  * @returns {((data: RawJsonData, curDepth?: number) => ExportSpec[] | undefined)} value
@@ -54,12 +52,12 @@ const getExportsWithDepth = exportsDepth =>
 class JsonExportsDependency extends NullDependency {
 	/**
 	 * @param {JsonData} data json data
-	 * @param {JsonDependencyOptions} options options
+	 * @param {number} exportsDepth the depth of json exports to analyze
 	 */
-	constructor(data, options) {
+	constructor(data, exportsDepth) {
 		super();
 		this.data = data;
-		this.options = options;
+		this.exportsDepth = exportsDepth;
 	}
 
 	get type() {
@@ -73,7 +71,7 @@ class JsonExportsDependency extends NullDependency {
 	 */
 	getExports(moduleGraph) {
 		return {
-			exports: getExportsWithDepth(this.options.exportsDepth)(
+			exports: getExportsWithDepth(this.exportsDepth)(
 				this.data && /** @type {RawJsonData} */ (this.data.get())
 			),
 			dependencies: undefined
@@ -96,6 +94,7 @@ class JsonExportsDependency extends NullDependency {
 	serialize(context) {
 		const { write } = context;
 		write(this.data);
+		write(this.exportsDepth);
 		super.serialize(context);
 	}
 
@@ -105,6 +104,7 @@ class JsonExportsDependency extends NullDependency {
 	deserialize(context) {
 		const { read } = context;
 		this.data = read();
+		this.exportsDepth = read();
 		super.deserialize(context);
 	}
 }

--- a/lib/dependencies/JsonExportsDependency.js
+++ b/lib/dependencies/JsonExportsDependency.js
@@ -19,41 +19,47 @@ const NullDependency = require("./NullDependency");
 /** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext} ObjectSerializerContext */
 /** @typedef {import("../util/Hash")} Hash */
 
+/** @typedef {{depth:number}} JsonDependencyOptions */
+
 /**
- * @param {RawJsonData} data data
- * @returns {TODO} value
+ * @param {number} depth depth
+ * @returns {((data: RawJsonData, curDepth?: number) => ExportSpec[] | undefined)} value
  */
-const getExportsFromData = data => {
-	if (data && typeof data === "object") {
-		if (Array.isArray(data)) {
-			return data.length < 100
-				? data.map((item, idx) => ({
-						name: `${idx}`,
-						canMangle: true,
-						exports: getExportsFromData(item)
-					}))
-				: undefined;
+const getExportsWithDepth = depth =>
+	function getExportsFromData(data, curDepth = 1) {
+		if (curDepth > depth) return undefined;
+		if (data && typeof data === "object") {
+			if (Array.isArray(data)) {
+				return data.length < 100
+					? data.map((item, idx) => ({
+							name: `${idx}`,
+							canMangle: true,
+							exports: getExportsFromData(item, curDepth + 1)
+						}))
+					: undefined;
+			}
+			const exports = [];
+			for (const key of Object.keys(data)) {
+				exports.push({
+					name: key,
+					canMangle: true,
+					exports: getExportsFromData(data[key], curDepth + 1)
+				});
+			}
+			return exports;
 		}
-		const exports = [];
-		for (const key of Object.keys(data)) {
-			exports.push({
-				name: key,
-				canMangle: true,
-				exports: getExportsFromData(data[key])
-			});
-		}
-		return exports;
-	}
-	return undefined;
-};
+		return undefined;
+	};
 
 class JsonExportsDependency extends NullDependency {
 	/**
 	 * @param {JsonData} data json data
+	 * @param {JsonDependencyOptions} dependencyOptions dependency options
 	 */
-	constructor(data) {
+	constructor(data, dependencyOptions) {
 		super();
 		this.data = data;
+		this.options = dependencyOptions;
 	}
 
 	get type() {
@@ -67,7 +73,7 @@ class JsonExportsDependency extends NullDependency {
 	 */
 	getExports(moduleGraph) {
 		return {
-			exports: getExportsFromData(
+			exports: getExportsWithDepth(this.options.depth)(
 				this.data && /** @type {RawJsonData} */ (this.data.get())
 			),
 			dependencies: undefined

--- a/lib/json/JsonModulesPlugin.js
+++ b/lib/json/JsonModulesPlugin.js
@@ -11,6 +11,7 @@ const JsonGenerator = require("./JsonGenerator");
 const JsonParser = require("./JsonParser");
 
 /** @typedef {import("../Compiler")} Compiler */
+/** @typedef {import("../dependencies/JsonExportsDependency").JsonDependencyOptions} JsonDependencyOptions */
 /** @typedef {Record<string, any>} RawJsonData */
 
 const validate = createSchemaValidation(
@@ -30,6 +31,13 @@ const PLUGIN_NAME = "JsonModulesPlugin";
  */
 class JsonModulesPlugin {
 	/**
+	 * @param {JsonDependencyOptions} dependencyOptions  dependency options
+	 */
+	constructor(dependencyOptions) {
+		this.dependencyOptions = dependencyOptions;
+	}
+
+	/**
 	 * Apply the plugin
 	 * @param {Compiler} compiler the compiler instance
 	 * @returns {void}
@@ -43,7 +51,7 @@ class JsonModulesPlugin {
 					.tap(PLUGIN_NAME, parserOptions => {
 						validate(parserOptions);
 
-						return new JsonParser(parserOptions);
+						return new JsonParser(parserOptions, this.dependencyOptions);
 					});
 				normalModuleFactory.hooks.createGenerator
 					.for(JSON_MODULE_TYPE)

--- a/lib/json/JsonModulesPlugin.js
+++ b/lib/json/JsonModulesPlugin.js
@@ -11,7 +11,6 @@ const JsonGenerator = require("./JsonGenerator");
 const JsonParser = require("./JsonParser");
 
 /** @typedef {import("../Compiler")} Compiler */
-/** @typedef {import("../dependencies/JsonExportsDependency").JsonDependencyOptions} JsonDependencyOptions */
 /** @typedef {Record<string, any>} RawJsonData */
 
 const validate = createSchemaValidation(
@@ -31,13 +30,6 @@ const PLUGIN_NAME = "JsonModulesPlugin";
  */
 class JsonModulesPlugin {
 	/**
-	 * @param {JsonDependencyOptions} dependencyOptions  dependency options
-	 */
-	constructor(dependencyOptions) {
-		this.dependencyOptions = dependencyOptions;
-	}
-
-	/**
 	 * Apply the plugin
 	 * @param {Compiler} compiler the compiler instance
 	 * @returns {void}
@@ -50,8 +42,7 @@ class JsonModulesPlugin {
 					.for(JSON_MODULE_TYPE)
 					.tap(PLUGIN_NAME, parserOptions => {
 						validate(parserOptions);
-
-						return new JsonParser(parserOptions, this.dependencyOptions);
+						return new JsonParser(parserOptions);
 					});
 				normalModuleFactory.hooks.createGenerator
 					.for(JSON_MODULE_TYPE)

--- a/lib/json/JsonParser.js
+++ b/lib/json/JsonParser.js
@@ -15,20 +15,17 @@ const JsonData = require("./JsonData");
 /** @typedef {import("../Module").BuildMeta} BuildMeta */
 /** @typedef {import("../Parser").ParserState} ParserState */
 /** @typedef {import("../Parser").PreparsedAst} PreparsedAst */
-/** @typedef {import("../dependencies/JsonExportsDependency").JsonDependencyOptions} JsonDependencyOptions */
 /** @typedef {import("./JsonModulesPlugin").RawJsonData} RawJsonData */
 
 const getParseJson = memoize(() => require("json-parse-even-better-errors"));
 
 class JsonParser extends Parser {
 	/**
-	 * @param {JsonModulesPluginParserOptions} parserOptions parser options
-	 * @param {JsonDependencyOptions} dependencyOptions dependency options
+	 * @param {JsonModulesPluginParserOptions} options parser options
 	 */
-	constructor(parserOptions, dependencyOptions) {
+	constructor(options) {
 		super();
-		this.options = parserOptions || {};
-		this.dependencyOptions = dependencyOptions;
+		this.options = options || {};
 	}
 
 	/**
@@ -67,7 +64,9 @@ class JsonParser extends Parser {
 		buildMeta.defaultObject =
 			typeof data === "object" ? "redirect-warn" : false;
 		state.module.addDependency(
-			new JsonExportsDependency(jsonData, this.dependencyOptions)
+			new JsonExportsDependency(jsonData, {
+				exportsDepth: this.options.exportsDepth
+			})
 		);
 		return state;
 	}

--- a/lib/json/JsonParser.js
+++ b/lib/json/JsonParser.js
@@ -64,9 +64,7 @@ class JsonParser extends Parser {
 		buildMeta.defaultObject =
 			typeof data === "object" ? "redirect-warn" : false;
 		state.module.addDependency(
-			new JsonExportsDependency(jsonData, {
-				exportsDepth: this.options.exportsDepth
-			})
+			new JsonExportsDependency(jsonData, this.options.exportsDepth)
 		);
 		return state;
 	}

--- a/lib/json/JsonParser.js
+++ b/lib/json/JsonParser.js
@@ -15,17 +15,20 @@ const JsonData = require("./JsonData");
 /** @typedef {import("../Module").BuildMeta} BuildMeta */
 /** @typedef {import("../Parser").ParserState} ParserState */
 /** @typedef {import("../Parser").PreparsedAst} PreparsedAst */
+/** @typedef {import("../dependencies/JsonExportsDependency").JsonDependencyOptions} JsonDependencyOptions */
 /** @typedef {import("./JsonModulesPlugin").RawJsonData} RawJsonData */
 
 const getParseJson = memoize(() => require("json-parse-even-better-errors"));
 
 class JsonParser extends Parser {
 	/**
-	 * @param {JsonModulesPluginParserOptions} options parser options
+	 * @param {JsonModulesPluginParserOptions} parserOptions parser options
+	 * @param {JsonDependencyOptions} dependencyOptions dependency options
 	 */
-	constructor(options) {
+	constructor(parserOptions, dependencyOptions) {
 		super();
-		this.options = options || {};
+		this.options = parserOptions || {};
+		this.dependencyOptions = dependencyOptions;
 	}
 
 	/**
@@ -63,7 +66,9 @@ class JsonParser extends Parser {
 		buildMeta.exportsType = "default";
 		buildMeta.defaultObject =
 			typeof data === "object" ? "redirect-warn" : false;
-		state.module.addDependency(new JsonExportsDependency(jsonData));
+		state.module.addDependency(
+			new JsonExportsDependency(jsonData, this.dependencyOptions)
+		);
 		return state;
 	}
 }

--- a/schemas/plugins/JsonModulesPluginParser.check.js
+++ b/schemas/plugins/JsonModulesPluginParser.check.js
@@ -3,4 +3,4 @@
  * DO NOT MODIFY BY HAND.
  * Run `yarn special-lint-fix` to update
  */
-"use strict";function r(t,{instancePath:e="",parentData:a,parentDataProperty:o,rootData:n=t}={}){if(!t||"object"!=typeof t||Array.isArray(t))return r.errors=[{params:{type:"object"}}],!1;{const e=0;for(const e in t)if("parse"!==e)return r.errors=[{params:{additionalProperty:e}}],!1;if(0===e&&void 0!==t.parse&&!(t.parse instanceof Function))return r.errors=[{params:{}}],!1}return r.errors=null,!0}module.exports=r,module.exports.default=r;
+"use strict";function r(e,{instancePath:t="",parentData:o,parentDataProperty:a,rootData:s=e}={}){if(!e||"object"!=typeof e||Array.isArray(e))return r.errors=[{params:{type:"object"}}],!1;{const t=0;for(const t in e)if("exportsDepth"!==t&&"parse"!==t)return r.errors=[{params:{additionalProperty:t}}],!1;if(0===t){if(void 0!==e.exportsDepth){const t=0;if("number"!=typeof e.exportsDepth)return r.errors=[{params:{type:"number"}}],!1;var n=0===t}else n=!0;if(n)if(void 0!==e.parse){const t=0;if(!(e.parse instanceof Function))return r.errors=[{params:{}}],!1;n=0===t}else n=!0}}return r.errors=null,!0}module.exports=r,module.exports.default=r;

--- a/schemas/plugins/JsonModulesPluginParser.json
+++ b/schemas/plugins/JsonModulesPluginParser.json
@@ -3,6 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "exportsDepth": {
+      "description": "The depth of json dependency flagged as `exportInfo`.",
+      "type": "number"
+    },
     "parse": {
       "description": "Function that executes for a module source string and should return json-compatible data.",
       "instanceof": "Function",

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -254,6 +254,9 @@ describe("snapshots", () => {
 		        "wrappedContextRecursive": true,
 		        "wrappedContextRegExp": /\\.\\*/,
 		      },
+		      "json": Object {
+		        "exportsDepth": Infinity,
+		      },
 		    },
 		    "rules": Array [],
 		    "unsafeCache": false,
@@ -844,6 +847,9 @@ describe("snapshots", () => {
 		@@ ... @@
 		-   "mode": "none",
 		+   "mode": "development",
+		@@ ... @@
+		-         "exportsDepth": Infinity,
+		+         "exportsDepth": 1,
 		@@ ... @@
 		-     "unsafeCache": false,
 		+     "unsafeCache": [Function anonymous],
@@ -1904,6 +1910,9 @@ describe("snapshots", () => {
 			@@ ... @@
 			-   "mode": "none",
 			+   "mode": "development",
+			@@ ... @@
+			-         "exportsDepth": Infinity,
+			+         "exportsDepth": 1,
 			@@ ... @@
 			-     "unsafeCache": false,
 			+     "unsafeCache": [Function anonymous],

--- a/test/configCases/json/bailout-flag-dep-export-perf/data.json
+++ b/test/configCases/json/bailout-flag-dep-export-perf/data.json
@@ -1,0 +1,27 @@
+{
+  "depth_1": {
+    "depth_2": {
+      "depth_3": {
+        "depth_4": {
+          "depth_5": {
+            "depth_6": "depth_6"
+          }
+        }
+      }
+    }
+  },
+  "_depth_1": {
+    "_depth_2": {
+      "_depth_3": {
+        "_depth_4": {
+          "_depth_5": {
+            "_depth_6": "_depth_6"
+          }
+        }
+      }
+    }
+  },
+  "__depth_1": [
+    { "__depth_3": [{ "__depth_5": [{ "__depth_7": ["__depth_8"] }] }] }
+  ]
+}

--- a/test/configCases/json/bailout-flag-dep-export-perf/index.js
+++ b/test/configCases/json/bailout-flag-dep-export-perf/index.js
@@ -1,0 +1,11 @@
+export * from './data.json';
+
+it("should compile and run", () => {
+	expect(__webpack_exports_info__.depth_1.provideInfo).toBe(true)
+	expect(__webpack_exports_info__._depth_1.provideInfo).toBe(true)
+	expect(__webpack_exports_info__.__depth_1.provideInfo).toBe(true)
+
+	expect(__webpack_exports_info__.depth_1.depth_2.provideInfo).toBe(true)
+	expect(__webpack_exports_info__._depth_1._depth_2._depth_3._depth_4.provideInfo).toBe(true)
+	expect(__webpack_exports_info__.__depth_1[0].__depth_3[0].__depth_5.provideInfo).toBe(true)
+});

--- a/test/configCases/json/bailout-flag-dep-export-perf/webpack.config.js
+++ b/test/configCases/json/bailout-flag-dep-export-perf/webpack.config.js
@@ -1,0 +1,11 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	module: {
+		parser: {
+			json: {
+				exportsDepth: Infinity
+			}
+		}
+	}
+};

--- a/test/configCases/json/flag-dep-export-perf/data.json
+++ b/test/configCases/json/flag-dep-export-perf/data.json
@@ -1,0 +1,27 @@
+{
+  "depth_1": {
+    "depth_2": {
+      "depth_3": {
+        "depth_4": {
+          "depth_5": {
+            "depth_6": "depth_6"
+          }
+        }
+      }
+    }
+  },
+  "_depth_1": {
+    "_depth_2": {
+      "_depth_3": {
+        "_depth_4": {
+          "_depth_5": {
+            "_depth_6": "_depth_6"
+          }
+        }
+      }
+    }
+  },
+  "__depth_1": [
+    { "__depth_3": [{ "__depth_5": [{ "__depth_7": ["__depth_8"] }] }] }
+  ]
+}

--- a/test/configCases/json/flag-dep-export-perf/index.js
+++ b/test/configCases/json/flag-dep-export-perf/index.js
@@ -1,0 +1,11 @@
+export * from './data.json';
+
+it("should compile and run", () => {
+	expect(__webpack_exports_info__.depth_1.provideInfo).toBe(true)
+	expect(__webpack_exports_info__._depth_1.provideInfo).toBe(true)
+	expect(__webpack_exports_info__.__depth_1.provideInfo).toBe(true)
+
+	expect(__webpack_exports_info__.depth_1.depth_2.provideInfo).toBe(undefined)
+	expect(__webpack_exports_info__._depth_1._depth_2._depth_3._depth_4.provideInfo).toBe(undefined)
+	expect(__webpack_exports_info__.__depth_1[0].__depth_3[0].__depth_5.provideInfo).toBe(undefined)
+});

--- a/test/configCases/json/flag-dep-export-perf/webpack.config.js
+++ b/test/configCases/json/flag-dep-export-perf/webpack.config.js
@@ -1,0 +1,4 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development"
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

perf only for `development` mode

Fixes https://github.com/webpack/webpack/issues/18458

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… --> 

**Did you add tests for your changes?**
Yes

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Add two options to https://webpack.js.org/configuration/module/#moduleparser

for `json`

- `parse` - Function that executes for a module source string and should return json-compatible data.  Type `((input: string) => any)`, for For example we can use toml parser 

```js
const toml = require("toml");
 
module.exports = [
	{ 
		module: {
			rules: [
				{
					test: /\.toml$/,
					type: "json",
					parser: {
						parse(input) { 
							return toml.parse(input);
						}
					}
				}
			]
		}
	}
];
```
 
- `exportsDepth` - The depth of json dependency flagged as `exportInfo`. In dev mode - 1, in prod - Infinity, Type `number`
