### PR TITLE
fix: preserve filenameTemplate in new split chunk

### DIFF
--- a/lib/optimize/SplitChunksPlugin.js
+++ b/lib/optimize/SplitChunksPlugin.js
@@ -1743,6 +1743,9 @@ module.exports = class SplitChunksPlugin {
 								);
 								chunk.split(newPart);
 								newPart.chunkReason = chunk.chunkReason;
+								if (chunk.filenameTemplate) {
+									newPart.filenameTemplate = chunk.filenameTemplate;
+								}
 								// Add all modules to the new chunk
 								for (const module of group.items) {
 									if (!module.chunkCondition(newPart, compilation)) {

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -4062,10 +4062,10 @@ production (webpack x.x.x) compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for split-chunks-cache-group-filename 1`] = `
-"Entrypoint main X KiB = 587.js X bytes 414.js X bytes 605.vendors.js X bytes main.js X KiB
-chunk (runtime: main) 414.js (id hint: vendors) X bytes [initial] [rendered] split chunk (cache group: vendors)
+"Entrypoint main X KiB = 587.vendors.js X bytes 414.vendors.js X bytes 605.vendors.js X bytes main.js X KiB
+chunk (runtime: main) 414.vendors.js (id hint: vendors) X bytes [initial] [rendered] split chunk (cache group: vendors)
   ./node_modules/b.js X bytes [built] [code generated]
-chunk (runtime: main) 587.js (id hint: vendors) X bytes [initial] [rendered] split chunk (cache group: vendors)
+chunk (runtime: main) 587.vendors.js (id hint: vendors) X bytes [initial] [rendered] split chunk (cache group: vendors)
   ./node_modules/a.js X bytes [built] [code generated]
 chunk (runtime: main) 605.vendors.js (id hint: vendors) X bytes [initial] [rendered] split chunk (cache group: vendors)
   ./node_modules/c.js X bytes [built] [code generated]

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -4061,6 +4061,20 @@ chunk (runtime: main) main.js (main) X bytes (javascript) X KiB (runtime) >{asyn
 production (webpack x.x.x) compiled successfully"
 `;
 
+exports[`StatsTestCases should print correct stats for split-chunks-cache-group-filename 1`] = `
+"Entrypoint main X KiB = 587.js X bytes 414.js X bytes 605.vendors.js X bytes main.js X KiB
+chunk (runtime: main) 414.js (id hint: vendors) X bytes [initial] [rendered] split chunk (cache group: vendors)
+  ./node_modules/b.js X bytes [built] [code generated]
+chunk (runtime: main) 587.js (id hint: vendors) X bytes [initial] [rendered] split chunk (cache group: vendors)
+  ./node_modules/a.js X bytes [built] [code generated]
+chunk (runtime: main) 605.vendors.js (id hint: vendors) X bytes [initial] [rendered] split chunk (cache group: vendors)
+  ./node_modules/c.js X bytes [built] [code generated]
+chunk (runtime: main) main.js (main) X bytes (javascript) X KiB (runtime) [entry] [rendered]
+  runtime modules X KiB 4 modules
+  ./index.js X bytes [built] [code generated]
+webpack x.x.x compiled successfully in X ms"
+`;
+
 exports[`StatsTestCases should print correct stats for split-chunks-chunk-name 1`] = `
 "Entrypoint main X KiB = default/main.js
 chunk (runtime: main) default/async-b.js (async-b) (id hint: vendors) X bytes <{792}> [rendered] reused as split chunk (cache group: defaultVendors)

--- a/test/statsCases/split-chunks-cache-group-filename/index.js
+++ b/test/statsCases/split-chunks-cache-group-filename/index.js
@@ -1,0 +1,5 @@
+import a from "a";
+import b from "b";
+import c from "c";
+
+console.log(a, b, c);

--- a/test/statsCases/split-chunks-cache-group-filename/node_modules/a.js
+++ b/test/statsCases/split-chunks-cache-group-filename/node_modules/a.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/test/statsCases/split-chunks-cache-group-filename/node_modules/b.js
+++ b/test/statsCases/split-chunks-cache-group-filename/node_modules/b.js
@@ -1,0 +1,1 @@
+export default "b";

--- a/test/statsCases/split-chunks-cache-group-filename/node_modules/c.js
+++ b/test/statsCases/split-chunks-cache-group-filename/node_modules/c.js
@@ -1,0 +1,1 @@
+export default "c";

--- a/test/statsCases/split-chunks-cache-group-filename/webpack.config.js
+++ b/test/statsCases/split-chunks-cache-group-filename/webpack.config.js
@@ -1,0 +1,25 @@
+/** @type {import("../../../types").Configuration} */
+module.exports = {
+	mode: "production",
+	entry: {
+		main: "./"
+	},
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				default: false,
+				vendors: {
+					chunks: "initial",
+					filename: "[name].vendors.js",
+					minSize: 1,
+					maxInitialSize: 1,
+					test: /[\\/]node_modules[\\/]/
+				}
+			}
+		}
+	},
+	stats: {
+		assets: false,
+		chunks: true
+	}
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR fixes a bug that we encountered with the `SplitChunksPlugin`: If you provide a `splitChunks.cacheGroups.{cacheGroup}.filename` option it will only be respected for first chunk in the group and not for any other chunks that might be created like those split based on `maxSize`. The fix is to copy over `filenameTemplate` for any new chunks that are created based on `deterministicGroupingForModules` results. 

One alternative I considered is to move the `filenameTemplate` copying to the `Chunk.split()` method: https://github.com/webpack/webpack/blob/3919c844eca394d73ca930e4fc5506fb86e2b094/lib/Chunk.js#L540

**Did you add tests for your changes?**

I added the `split-chunks-cache-group-filename` stats test case in ad3fb02e76673e9cadea7c8449ab18919c9b09ef showing the broken behavior where some of the chunks are not following the template. In c92ecd1927aa8108a0d06392e05889d46d7a9265 I implement the fix and updated the snapshots. The significant part is highlighted in the diff below where three chunks have the `.vendors.js` extension as expected.

```diff
-Entrypoint main X KiB = 587.js X bytes 414.js X bytes 605.vendors.js X bytes main.js X KiB
+Entrypoint main X KiB = 587.vendors.js X bytes 414.vendors.js X bytes 605.vendors.js X bytes main.js X KiB
```

**Does this PR introduce a breaking change?**

No but there might be people relying in some way on the quirk of the current behavior. Unless you are splitting initial chunks and tweaking `filename` config there should be no noticeable differences.

**What needs to be documented once your changes are merged?**

No. In my opinion the new behavior more closely matched the [documented behavior](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkscachegroupscachegroupfilename).

