### PR TITLE
fix: `ContextModule` should respect `snapshot` options

### DIFF
--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -103,8 +103,6 @@ const makeSerializable = require("./util/makeSerializable");
 
 /** @typedef {Record<ModuleId, FakeMapType>} FakeMap */
 
-const SNAPSHOT_OPTIONS = { timestamp: true };
-
 class ContextModule extends Module {
 	/**
 	 * @param {ResolveDependencies} resolveDependencies function to get dependencies in this context
@@ -537,7 +535,7 @@ class ContextModule extends Module {
 						? [this.options.resource]
 						: /** @type {string[]} */ (this.options.resource),
 				null,
-				SNAPSHOT_OPTIONS,
+				compilation.options.snapshot.module,
 				(err, snapshot) => {
 					if (err) return callback(err);
 					/** @type {BuildInfo} */

--- a/test/configCases/custom-hash-function/debug-hash/webpack.config.js
+++ b/test/configCases/custom-hash-function/debug-hash/webpack.config.js
@@ -3,6 +3,9 @@ module.exports = [
 	{
 		output: {
 			hashFunction: "debug"
+		},
+		snapshot: {
+			module: { timestamp: true }
 		}
 	}
 ];


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Unlike normal modules, `ContextModule` (which is used for dynamic `import()`s and `require.context()`) won't respect the `snapshot`s options when generating a snapshot, and always uses timestamps for validation. This is a problem when using persistent caching in a CI environment where timestamps get updated every run, since it means the cache will get invalidated every time.
**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No, unless somebody is relying on the buggy behavior. The `test/configCases/custom-hash-function/debug-hash/` test case is an example of that, since I had to change the config to use `{ timestamp: true }` because the "debug" hash it uses is non-deterministic. But using a non-deterministic hash function is extremely unusual and likely to cause bugs anyway.
**What needs to be documented once your changes are merged?**

Nothing, this brings the behavior in line with https://webpack.js.org/configuration/other-options/#module