### PR TITLE
chore: remove redundant `this.idle = true` assignment

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -491,7 +491,6 @@ class Compiler {
 			if (logger) logger.time("beginIdle");
 			this.idle = true;
 			this.cache.beginIdle();
-			this.idle = true;
 			if (logger) logger.timeEnd("beginIdle");
 			this.running = false;
 			if (err) {


### PR DESCRIPTION
The second this.idle = true assignment is redundant because this.cache.beginIdle() does not modify the idle state