### PR TITLE
(fix) Use module ids for final render order

### DIFF
--- a/lib/asset/AssetModulesPlugin.js
+++ b/lib/asset/AssetModulesPlugin.js
@@ -12,7 +12,7 @@ const {
 	ASSET_MODULE_TYPE_SOURCE
 } = require("../ModuleTypeConstants");
 const { cleverMerge } = require("../util/cleverMerge");
-const { compareModulesByIdentifier } = require("../util/comparators");
+const { compareModulesByIdOrIdentifier } = require("../util/comparators");
 const createSchemaValidation = require("../util/create-schema-validation");
 const memoize = require("../util/memoize");
 
@@ -189,7 +189,7 @@ class AssetModulesPlugin {
 					const modules = chunkGraph.getOrderedChunkModulesIterableBySourceType(
 						chunk,
 						ASSET_MODULE_TYPE,
-						compareModulesByIdentifier
+						compareModulesByIdOrIdentifier(chunkGraph)
 					);
 					if (modules) {
 						for (const module of modules) {

--- a/lib/css/CssModulesPlugin.js
+++ b/lib/css/CssModulesPlugin.js
@@ -36,7 +36,7 @@ const CssSelfLocalIdentifierDependency = require("../dependencies/CssSelfLocalId
 const CssUrlDependency = require("../dependencies/CssUrlDependency");
 const StaticExportsDependency = require("../dependencies/StaticExportsDependency");
 const JavascriptModulesPlugin = require("../javascript/JavascriptModulesPlugin");
-const { compareModulesByIdentifier } = require("../util/comparators");
+const { compareModulesByIdOrIdentifier } = require("../util/comparators");
 const createSchemaValidation = require("../util/create-schema-validation");
 const createHash = require("../util/createHash");
 const { getUndoPath } = require("../util/identifier");
@@ -598,6 +598,10 @@ class CssModulesPlugin {
 		if (modulesByChunkGroup.length === 1)
 			return modulesByChunkGroup[0].list.reverse();
 
+		const boundCompareModulesByIdOrIdentifier = compareModulesByIdOrIdentifier(
+			compilation.chunkGraph
+		);
+
 		/**
 		 * @param {{ list: Module[] }} a a
 		 * @param {{ list: Module[] }} b b
@@ -608,7 +612,10 @@ class CssModulesPlugin {
 				return b.length === 0 ? 0 : 1;
 			}
 			if (b.length === 0) return -1;
-			return compareModulesByIdentifier(a[a.length - 1], b[b.length - 1]);
+			return boundCompareModulesByIdOrIdentifier(
+				a[a.length - 1],
+				b[b.length - 1]
+			);
 		};
 
 		modulesByChunkGroup.sort(compareModuleLists);
@@ -690,7 +697,7 @@ class CssModulesPlugin {
 					chunkGraph.getOrderedChunkModulesIterableBySourceType(
 						chunk,
 						"css-import",
-						compareModulesByIdentifier
+						compareModulesByIdOrIdentifier(chunkGraph)
 					)
 				),
 				compilation
@@ -702,7 +709,7 @@ class CssModulesPlugin {
 					chunkGraph.getOrderedChunkModulesIterableBySourceType(
 						chunk,
 						"css",
-						compareModulesByIdentifier
+						compareModulesByIdOrIdentifier(chunkGraph)
 					)
 				),
 				compilation

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -30,7 +30,7 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 const Template = require("../Template");
 const { last, someInIterable } = require("../util/IterableHelpers");
 const StringXor = require("../util/StringXor");
-const { compareModulesByIdentifier } = require("../util/comparators");
+const { compareModulesByIdOrIdentifier } = require("../util/comparators");
 const {
 	getPathInAst,
 	getAllReferences,
@@ -678,7 +678,7 @@ class JavascriptModulesPlugin {
 		const modules = chunkGraph.getOrderedChunkModulesIterableBySourceType(
 			chunk,
 			"javascript",
-			compareModulesByIdentifier
+			compareModulesByIdOrIdentifier(chunkGraph)
 		);
 		const allModules = modules ? Array.from(modules) : [];
 		let strictHeader;
@@ -757,7 +757,7 @@ class JavascriptModulesPlugin {
 			chunkGraph.getOrderedChunkModulesIterableBySourceType(
 				chunk,
 				"javascript",
-				compareModulesByIdentifier
+				compareModulesByIdOrIdentifier(chunkGraph)
 			) || []
 		);
 

--- a/lib/wasm-async/AsyncWebAssemblyModulesPlugin.js
+++ b/lib/wasm-async/AsyncWebAssemblyModulesPlugin.js
@@ -11,7 +11,7 @@ const Generator = require("../Generator");
 const { tryRunOrWebpackError } = require("../HookWebpackError");
 const { WEBASSEMBLY_MODULE_TYPE_ASYNC } = require("../ModuleTypeConstants");
 const WebAssemblyImportDependency = require("../dependencies/WebAssemblyImportDependency");
-const { compareModulesByIdentifier } = require("../util/comparators");
+const { compareModulesByIdOrIdentifier } = require("../util/comparators");
 const memoize = require("../util/memoize");
 
 /** @typedef {import("webpack-sources").Source} Source */
@@ -146,7 +146,7 @@ class AsyncWebAssemblyModulesPlugin {
 
 						for (const module of chunkGraph.getOrderedChunkModulesIterable(
 							chunk,
-							compareModulesByIdentifier
+							compareModulesByIdOrIdentifier(chunkGraph)
 						)) {
 							if (module.type === WEBASSEMBLY_MODULE_TYPE_ASYNC) {
 								const filenameTemplate =

--- a/lib/wasm-sync/WebAssemblyModulesPlugin.js
+++ b/lib/wasm-sync/WebAssemblyModulesPlugin.js
@@ -9,7 +9,7 @@ const Generator = require("../Generator");
 const { WEBASSEMBLY_MODULE_TYPE_SYNC } = require("../ModuleTypeConstants");
 const WebAssemblyExportImportedDependency = require("../dependencies/WebAssemblyExportImportedDependency");
 const WebAssemblyImportDependency = require("../dependencies/WebAssemblyImportDependency");
-const { compareModulesByIdentifier } = require("../util/comparators");
+const { compareModulesByIdOrIdentifier } = require("../util/comparators");
 const memoize = require("../util/memoize");
 const WebAssemblyInInitialChunkError = require("./WebAssemblyInInitialChunkError");
 
@@ -89,7 +89,7 @@ class WebAssemblyModulesPlugin {
 
 					for (const module of chunkGraph.getOrderedChunkModulesIterable(
 						chunk,
-						compareModulesByIdentifier
+						compareModulesByIdOrIdentifier(chunkGraph)
 					)) {
 						if (module.type === WEBASSEMBLY_MODULE_TYPE_SYNC) {
 							const filenameTemplate =

--- a/test/configCases/optimization/issue-19184/files/file1.js
+++ b/test/configCases/optimization/issue-19184/files/file1.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/optimization/issue-19184/files/file2.js
+++ b/test/configCases/optimization/issue-19184/files/file2.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/optimization/issue-19184/files/file3.js
+++ b/test/configCases/optimization/issue-19184/files/file3.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/optimization/issue-19184/files/file4.js
+++ b/test/configCases/optimization/issue-19184/files/file4.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/optimization/issue-19184/files/file5.js
+++ b/test/configCases/optimization/issue-19184/files/file5.js
@@ -1,0 +1,1 @@
+module.exports = module.id;

--- a/test/configCases/optimization/issue-19184/index.js
+++ b/test/configCases/optimization/issue-19184/index.js
@@ -1,0 +1,10 @@
+it("should have module ids defined in sorted order", function() {
+	for (var i = 1; i <= 5; i++) {
+		var unusedModuleId = require("./files/file" + i + ".js");
+	}
+
+	const moduleIds = Object.keys(__webpack_modules__);
+
+	const sortedIds = moduleIds.slice().sort();
+	expect(moduleIds).toEqual(sortedIds);
+});

--- a/test/configCases/optimization/issue-19184/warnings.js
+++ b/test/configCases/optimization/issue-19184/warnings.js
@@ -1,0 +1,1 @@
+module.exports = [[/hashed/, /deprecated/]];

--- a/test/configCases/optimization/issue-19184/webpack.config.js
+++ b/test/configCases/optimization/issue-19184/webpack.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	optimization: {
+		moduleIds: "hashed"
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Fixes #19141 

Specifically, addresses determinism of sort order across platforms by leveraging the fact that a developer who desires stable output cross-platform will have already ensured that module ids are stable, so it necessarily follows that sorting by module id will result in a deterministic sort order.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Added a unit test that verifies that Javascript modules are rendered in sorted order.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

The sort order of modules in rendered output will change, but a one-time alteration to that order is no different than changing a salt value.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
