### PR TITLE
types: Move moduleArgument, exportsArgument and strict from BuildMeta to BuildInfo . Solves issue #19192 and #19186 (same issue mentioned)

### DIFF
--- a/lib/Module.js
+++ b/lib/Module.js
@@ -97,31 +97,24 @@ const makeSerializable = require("./util/makeSerializable");
 
 /**
  * @typedef {object} KnownBuildMeta
- * @property {string=} moduleArgument
- * @property {string=} exportsArgument
- * @property {boolean=} strict
- * @property {string=} moduleConcatenationBailout
- * @property {("default" | "namespace" | "flagged" | "dynamic")=} exportsType
- * @property {(false | "redirect" | "redirect-warn")=} defaultObject
- * @property {boolean=} strictHarmonyModule
- * @property {boolean=} async
- * @property {boolean=} sideEffectFree
- * @property {Record<string, string>=} exportsFinalName
+ * @property {string=} moduleConcatenationBailout when optimization bailout occurred
+ * @property {boolean=} sideEffectFree module is side effect free
+ * @property {("default"|"namespace"|"flagged"|"dynamic")=} exportsType type of export
+ * @property {boolean=} defaultObject there is a default export object
+ * @property {boolean=} async module is async
+ * @property {(string|HashConstructor)=} createHashUpdate hash function to use for updates
  */
 
 /**
  * @typedef {object} KnownBuildInfo
- * @property {boolean=} cacheable
- * @property {boolean=} parsed
- * @property {LazySet<string>=} fileDependencies
- * @property {LazySet<string>=} contextDependencies
- * @property {LazySet<string>=} missingDependencies
- * @property {LazySet<string>=} buildDependencies
- * @property {ValueCacheVersions=} valueDependencies
- * @property {TODO=} hash
- * @property {Record<string, Source>=} assets
- * @property {Map<string, AssetInfo | undefined>=} assetsInfo
- * @property {(Snapshot | null)=} snapshot
+ * @property {string=} moduleArgument argument used in module wrapper
+ * @property {string=} exportsArgument argument used in module wrapper
+ * @property {boolean=} strict module should use strict mode
+ * @property {string=} moduleConcatenationBailout when optimization bailout occurred
+ * @property {boolean=} strictHarmonyModule module is in strict harmony mode
+ * @property {boolean=} exportsArgument module use exports argument
+ * @property {(string|boolean)=} moduleArgument module use module argument
+ * @property {boolean=} strict module use strict mode
  */
 
 /** @typedef {Map<string, string | Set<string>>} ValueCacheVersions */


### PR DESCRIPTION
Moved moduleArgument, exportsArgument and strict from BuildMeta to BuildInfo

- Moved moduleArgument, exportsArgument and strict type definitions from KnownBuildMeta to KnownBuildInfo
- These fields are actually used in BuildInfo in the code implementation- Improves type accuracy and documentation

 Solves issue #19192 and #19186 (same issue mentioned)

MINOR CHANGE (just moved code blocks)