### PR TITLE
Moved moduleArgument, exportsArgument and strict from BuildMeta to BuildInfo. 

### DIFF
--- a/lib/Module.js
+++ b/lib/Module.js
@@ -97,9 +97,6 @@ const makeSerializable = require("./util/makeSerializable");
 
 /**
  * @typedef {object} KnownBuildMeta
- * @property {string=} moduleArgument
- * @property {string=} exportsArgument
- * @property {boolean=} strict
  * @property {string=} moduleConcatenationBailout
  * @property {("default" | "namespace" | "flagged" | "dynamic")=} exportsType
  * @property {(false | "redirect" | "redirect-warn")=} defaultObject
@@ -113,6 +110,9 @@ const makeSerializable = require("./util/makeSerializable");
  * @typedef {object} KnownBuildInfo
  * @property {boolean=} cacheable
  * @property {boolean=} parsed
+ * @property {string=} moduleArgument
+ * @property {string=} exportsArgument
+ * @property {boolean=} strict
  * @property {LazySet<string>=} fileDependencies
  * @property {LazySet<string>=} contextDependencies
  * @property {LazySet<string>=} missingDependencies


### PR DESCRIPTION
In webpack/lib/Module.js

Moved moduleArgument, exportsArgument and strict from BuildMeta to BuildInfo

-Moved moduleArgument, exportsArgument and strict type definitions from KnownBuildMeta to KnownBuildInfo
-These fields are actually used in BuildInfo in the code implementation
- Improves type accuracy and documentation

Solves issue https://github.com/webpack/webpack/issues/19192 and https://github.com/webpack/webpack/discussions/19186 (same issue discussed)