### PR TITLE
feat: implement `/* webpackIgnore: true */` for `require.resolve`

### DIFF
--- a/lib/dependencies/CommonJsImportsParserPlugin.js
+++ b/lib/dependencies/CommonJsImportsParserPlugin.js
@@ -464,6 +464,36 @@ class CommonJsImportsParserPlugin {
 		 * @returns {boolean | void} true when handled
 		 */
 		const processResolve = (expr, weak) => {
+			if (!weak && options.commonjsMagicComments) {
+				const { options: requireOptions, errors: commentErrors } =
+					parser.parseCommentOptions(/** @type {Range} */ (expr.range));
+
+				if (commentErrors) {
+					for (const e of commentErrors) {
+						const { comment } = e;
+						parser.state.module.addWarning(
+							new CommentCompilationWarning(
+								`Compilation error while processing magic comment(-s): /*${comment.value}*/: ${e.message}`,
+								/** @type {DependencyLocation} */ (comment.loc)
+							)
+						);
+					}
+				}
+				if (requireOptions && requireOptions.webpackIgnore !== undefined) {
+					if (typeof requireOptions.webpackIgnore !== "boolean") {
+						parser.state.module.addWarning(
+							new UnsupportedFeatureWarning(
+								`\`webpackIgnore\` expected a boolean, but received: ${requireOptions.webpackIgnore}.`,
+								/** @type {DependencyLocation} */ (expr.loc)
+							)
+						);
+					} else if (requireOptions.webpackIgnore) {
+						// Do not instrument `require()` if `webpackIgnore` is `true`
+						return true;
+					}
+				}
+			}
+
 			if (expr.arguments.length !== 1) return;
 			const param = parser.evaluateExpression(expr.arguments[0]);
 			if (param.isConditional()) {

--- a/test/configCases/parsing/require-resolve-ignore/index.js
+++ b/test/configCases/parsing/require-resolve-ignore/index.js
@@ -1,0 +1,9 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should be able to ignore require.resolve()", () => {
+	const source = fs.readFileSync(path.join(__dirname, "bundle1.js"), "utf-8");
+	expect(source).toMatch(`require.resolve(/* webpackIgnore: true */ "./non-exists")`);
+	expect(source).toMatch(`createRequire(import.meta.url).resolve(/* webpackIgnore: true */ "./non-exists")`);
+	expect(source).toMatch(`require.resolve(/* webpackIgnore: true */ "./non-exists")`);
+});

--- a/test/configCases/parsing/require-resolve-ignore/other.js
+++ b/test/configCases/parsing/require-resolve-ignore/other.js
@@ -1,0 +1,8 @@
+import { createRequire } from 'node:module';
+
+const resolve = require.resolve(/* webpackIgnore: true */ "./non-exists");
+const createRequireResolve1 = createRequire(import.meta.url).resolve(/* webpackIgnore: true */ "./non-exists");
+const require = createRequire(import.meta.url);
+const createRequireResolve2 = require.resolve(/* webpackIgnore: true */ "./non-exists");
+
+export { resolve, createRequireResolve1, createRequireResolve2 }

--- a/test/configCases/parsing/require-resolve-ignore/webpack.config.js
+++ b/test/configCases/parsing/require-resolve-ignore/webpack.config.js
@@ -1,0 +1,20 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		bundle0: "./index.js",
+		bundle1: "./other.js"
+	},
+	module: {
+		parser: {
+			javascript: {
+				commonjsMagicComments: true
+			}
+		}
+	},
+	output: {
+		filename: "[name].js"
+	},
+	node: {
+		__dirname: false
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feature, allow to ignore `reqiore.resolve` using `/* webpackIgnore: true */` comment

fixes https://github.com/webpack/webpack/issues/19132

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Yes, need to show an example

```js
const x = require.resolve(/* webpackIgnore: true */ 'x');
```

https://webpack.js.org/configuration/module/#moduleparserjavascriptcommonjsmagiccomments
