### PR TITLE
perf: use startsWith for matching instead of converting the string to a regex

### DIFF
--- a/lib/ModuleFilenameHelpers.js
+++ b/lib/ModuleFilenameHelpers.js
@@ -88,28 +88,6 @@ const getHash =
 	};
 
 /**
- * Returns a function that returns the string with the token replaced with the replacement
- * @param {string|RegExp} test A regular expression string or Regular Expression object
- * @returns	{RegExp} A regular expression object
- * @example
- * ```js
- * const test = asRegExp("test");
- * test.test("test"); // true
- *
- * const test2 = asRegExp(/test/);
- * test2.test("test"); // true
- * ```
- */
-const asRegExp = test => {
-	if (typeof test === "string") {
-		// Escape special characters in the string to prevent them from being interpreted as special characters in a regular expression. Do this by
-		// adding a backslash before each special character
-		test = new RegExp(`^${test.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")}`);
-	}
-	return test;
-};
-
-/**
  * @template T
  * Returns a lazy object. The object is lazy in the sense that the properties are
  * only evaluated when they are accessed. This is only obtained by setting a function as the value for each key.
@@ -335,14 +313,18 @@ ModuleFilenameHelpers.replaceDuplicates = (array, fn, comparator) => {
  * ModuleFilenameHelpers.matchPart("foo.js", [/^baz/, /^bar/]); // false
  * ```
  */
-ModuleFilenameHelpers.matchPart = (str, test) => {
+const matchPart = (str, test) => {
 	if (!test) return true;
-
 	if (Array.isArray(test)) {
-		return test.map(asRegExp).some(regExp => regExp.test(str));
+		return test.some(test => matchPart(str, test));
 	}
-	return asRegExp(test).test(str);
+	if (typeof test === "string") {
+		return str.startsWith(test);
+	}
+	return test.test(str);
 };
+
+ModuleFilenameHelpers.matchPart = matchPart;
 
 /**
  * Tests if a string matches a match object. The match object can have the following properties:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Tested in local Node environment, this change is 7–8× faster than before.

Why not use indexOf:
1. startsWith offers better semantics and cleaner code.
2. [Existing code](https://github.com/webpack/webpack/blob/fab79c1b5dc0b596929187c1bcfd90c08d9e4fbc/lib/NormalModule.js#L1058C1-L1069C3) and many other bundler libraries already use startsWith.
3. Converting a string into a regex is more time-consuming, while the performance difference in matching is minimal.

Given that Node continues to optimize startsWith, I believe this approach is sufficient for now.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Existing
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
No
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
