### PR TITLE
fix: node async wasm loader generation

### DIFF
--- a/lib/wasm/EnableWasmLoadingPlugin.js
+++ b/lib/wasm/EnableWasmLoadingPlugin.js
@@ -99,7 +99,7 @@ class EnableWasmLoadingPlugin {
 						new ReadFileCompileWasmPlugin({
 							mangleImports: compiler.options.optimization.mangleWasmImports,
 							import:
-								compiler.options.output.environment.module &&
+								compiler.options.output.module &&
 								compiler.options.output.environment.dynamicImport
 						}).apply(compiler);
 					}
@@ -108,7 +108,7 @@ class EnableWasmLoadingPlugin {
 						const ReadFileCompileAsyncWasmPlugin = require("../node/ReadFileCompileAsyncWasmPlugin");
 						new ReadFileCompileAsyncWasmPlugin({
 							import:
-								compiler.options.output.environment.module &&
+								compiler.options.output.module &&
 								compiler.options.output.environment.dynamicImport
 						}).apply(compiler);
 					}


### PR DESCRIPTION
node async wasm loader was incorrectly using output.environment.module
to determine if import.meta statement should be used. Which may not match
the output flavor defined by output.module.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
no

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

Fixes #19209