### PR TITLE
fix attempt: enable export mangling for modules used only as export objects

### DIFF
--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -410,8 +410,7 @@ class ExportsInfo {
 			if (this._redirectTo.setUsedAsExportObject(runtime)) {
 				changed = true;
 			}
-		} 
-		else if (
+		} else if (
 			this._otherExportsInfo.setUsedConditionally(
 				used => used !== UsageState.Used,
 				UsageState.Used,

--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -399,6 +399,36 @@ class ExportsInfo {
 	 * @param {RuntimeSpec} runtime the runtime
 	 * @returns {boolean} true, when something changed
 	 */
+	setUsedAsExportObject(runtime) {
+		let changed = false;
+		for (const exportInfo of this._exports.values()) {
+			if (exportInfo.setUsedAsExportObject(runtime)) {
+				changed = true;
+			}
+		}
+		if (this._redirectTo !== undefined) {
+			if (this._redirectTo.setUsedAsExportObject(runtime)) {
+				changed = true;
+			}
+		} 
+		else {
+			if (
+				this._otherExportsInfo.setUsedConditionally(
+					used => used !== UsageState.Used,
+					UsageState.Used,
+					runtime
+				)
+			) {
+				changed = true;
+			}
+		}
+		return changed;
+	}
+
+	/**
+	 * @param {RuntimeSpec} runtime the runtime
+	 * @returns {boolean} true, when something changed
+	 */
 	setUsedWithoutInfo(runtime) {
 		let changed = false;
 		for (const exportInfo of this._exports.values()) {
@@ -961,6 +991,24 @@ class ExportInfo {
 		}
 		if (this.canMangleUse !== false) {
 			this.canMangleUse = false;
+			changed = true;
+		}
+		return changed;
+	}
+
+	/**
+	 * @param {RuntimeSpec} runtime only apply to this runtime
+	 * @returns {boolean} true, when something changed
+	 */
+	setUsedAsExportObject(runtime) {
+		let changed = false;
+		if (
+			this.setUsedConditionally(
+				used => used !== UsageState.Used,
+				UsageState.Used,
+				runtime
+			)
+		) {
 			changed = true;
 		}
 		return changed;

--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -411,16 +411,14 @@ class ExportsInfo {
 				changed = true;
 			}
 		} 
-		else {
-			if (
-				this._otherExportsInfo.setUsedConditionally(
-					used => used !== UsageState.Used,
-					UsageState.Used,
-					runtime
-				)
-			) {
-				changed = true;
-			}
+		else if (
+			this._otherExportsInfo.setUsedConditionally(
+				used => used !== UsageState.Used,
+				UsageState.Used,
+				runtime
+			)
+		) {
+			changed = true;
 		}
 		return changed;
 	}

--- a/lib/FlagDependencyUsagePlugin.js
+++ b/lib/FlagDependencyUsagePlugin.js
@@ -90,7 +90,7 @@ class FlagDependencyUsagePlugin {
 									canMangle = usedExportInfo.canMangle !== false;
 								}
 								if (usedExport.length === 0) {
-									if (exportsInfo.setUsedInUnknownWay(runtime)) {
+									if (exportsInfo.setUsedAsExportObject(runtime)) {
 										queue.enqueue(module, runtime);
 									}
 								} else {

--- a/lib/optimize/MangleExportsPlugin.js
+++ b/lib/optimize/MangleExportsPlugin.js
@@ -23,8 +23,6 @@ const { compareSelect, compareStringsNumeric } = require("../util/comparators");
  * @returns {boolean} mangle is possible
  */
 const canMangle = exportsInfo => {
-	if (exportsInfo.otherExportsInfo.getUsed(undefined) !== UsageState.Unused)
-		return false;
 	let hasSomethingToMangle = false;
 	for (const exportInfo of exportsInfo.exports) {
 		if (exportInfo.canMangle === true) {


### PR DESCRIPTION
This is a first attempt at a fix for issue https://github.com/webpack/webpack/issues/19153.  I'm almost certain that this is wrong, but it seems to work in my case.  The hope is that running this through the automated tests will show more info about specifically what is wrong with this.

I tried this in my full production build and it succeeds there as well.  The chunk size is reduced by nearly 3MB overall after this change (in an enormous 484MB build, but still).

**What kind of change does this PR introduce?**

In cases where a depency has no specific used exports, but instead is used as an "export object" via an export of `import *`,  we no longer mark the usage as "unknown" but instead mark it as used.

**Did you add tests for your changes?**

No new tests.  This is an experiment to see what existing tests break.

**Does this PR introduce a breaking change?**

Not sure yet...

**What needs to be documented once your changes are merged?**

No documentation
