### PR TITLE
(fix) forward semicolons from meta.webpackAST

### DIFF
--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -4379,6 +4379,13 @@ class JavascriptParser extends Parser {
 		if (typeof source === "object") {
 			ast = /** @type {Program} */ (source);
 			comments = source.comments;
+			if (source.semicolons) {
+				// Forward semicolon information from the preparsed AST if present
+				// This ensures the output is consistent with that of a fresh AST
+				for (const pos of source.semicolons) {
+					semicolons.add(pos);
+				}
+			}
 		} else {
 			comments = [];
 			ast = JavascriptParser._parse(source, {

--- a/test/cases/parsing/precreated-ast/ast-loader.js
+++ b/test/cases/parsing/precreated-ast/ast-loader.js
@@ -7,12 +7,14 @@ const acornParser = acorn.Parser;
 module.exports = function (source) {
 	const comments = [];
 
+	const semicolons = new Set();
 	const ast = acornParser.parse(source, {
 		ranges: true,
 		locations: true,
 		ecmaVersion: 11,
 		sourceType: "module",
-		onComment: comments
+		onComment: comments,
+		onInsertedSemicolon: (pos) => semicolons.add(pos)
 	});
 
 	// change something to test if it's really used
@@ -23,6 +25,8 @@ module.exports = function (source) {
 
 	//@ts-ignore
 	ast.comments = comments;
+	//@ts-ignore
+	ast.semicolons = semicolons;
 	this.callback(null, source, null, {
 		webpackAST: ast
 	});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
If there's a good way to unit test this I'm open to suggestions. The impact is observable in how exported functions get invoked, but there is no runtime behavior, only the exact text of emit.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
The schema of the `meta.webpackAST` loader callback property now supports an additional `semicolons` property of type `Iterable<number>`.
