### PR TITLE
fix: types of _preWalkVariableDeclaration

### DIFF
--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -481,13 +481,13 @@ class JavascriptParser extends Parser {
 			preDeclarator: new SyncBailHook(["declarator", "statement"]),
 			/** @type {SyncBailHook<[VariableDeclarator, Statement], boolean | void>} */
 			declarator: new SyncBailHook(["declarator", "statement"]),
-			/** @type {HookMap<SyncBailHook<[Declaration], boolean | void>>} */
+			/** @type {HookMap<SyncBailHook<[Pattern], boolean | void>>} */
 			varDeclaration: new HookMap(() => new SyncBailHook(["declaration"])),
-			/** @type {HookMap<SyncBailHook<[Declaration], boolean | void>>} */
+			/** @type {HookMap<SyncBailHook<[Pattern], boolean | void>>} */
 			varDeclarationLet: new HookMap(() => new SyncBailHook(["declaration"])),
-			/** @type {HookMap<SyncBailHook<[Declaration], boolean | void>>} */
+			/** @type {HookMap<SyncBailHook<[Pattern], boolean | void>>} */
 			varDeclarationConst: new HookMap(() => new SyncBailHook(["declaration"])),
-			/** @type {HookMap<SyncBailHook<[Declaration], boolean | void>>} */
+			/** @type {HookMap<SyncBailHook<[Pattern], boolean | void>>} */
 			varDeclarationVar: new HookMap(() => new SyncBailHook(["declaration"])),
 			/** @type {HookMap<SyncBailHook<[Identifier], boolean | void>>} */
 			pattern: new HookMap(() => new SyncBailHook(["pattern"])),
@@ -2786,7 +2786,7 @@ class JavascriptParser extends Parser {
 
 	/**
 	 * @param {VariableDeclaration} statement variable declaration
-	 * @param {TODO} hookMap map of hooks
+	 * @param {HookMap<SyncBailHook<[Pattern], boolean | void>>} hookMap map of hooks
 	 */
 	_preWalkVariableDeclaration(statement, hookMap) {
 		for (const declarator of statement.declarations) {

--- a/types.d.ts
+++ b/types.d.ts
@@ -621,12 +621,12 @@ declare abstract class BasicEvaluatedExpression {
 		| MethodDefinition
 		| PropertyDefinition
 		| VariableDeclarator
-		| SwitchCase
-		| CatchClause
 		| ObjectPattern
 		| ArrayPattern
 		| RestElement
 		| AssignmentPattern
+		| SwitchCase
+		| CatchClause
 		| Property
 		| Super
 		| AssignmentProperty
@@ -844,12 +844,12 @@ declare abstract class BasicEvaluatedExpression {
 			| MethodDefinition
 			| PropertyDefinition
 			| VariableDeclarator
-			| SwitchCase
-			| CatchClause
 			| ObjectPattern
 			| ArrayPattern
 			| RestElement
 			| AssignmentPattern
+			| SwitchCase
+			| CatchClause
 			| Property
 			| Super
 			| AssignmentProperty
@@ -6211,10 +6211,10 @@ declare class JavascriptParser extends Parser {
 			boolean | void
 		>;
 		declarator: SyncBailHook<[VariableDeclarator, Statement], boolean | void>;
-		varDeclaration: HookMap<SyncBailHook<[Declaration], boolean | void>>;
-		varDeclarationLet: HookMap<SyncBailHook<[Declaration], boolean | void>>;
-		varDeclarationConst: HookMap<SyncBailHook<[Declaration], boolean | void>>;
-		varDeclarationVar: HookMap<SyncBailHook<[Declaration], boolean | void>>;
+		varDeclaration: HookMap<SyncBailHook<[Pattern], boolean | void>>;
+		varDeclarationLet: HookMap<SyncBailHook<[Pattern], boolean | void>>;
+		varDeclarationConst: HookMap<SyncBailHook<[Pattern], boolean | void>>;
+		varDeclarationVar: HookMap<SyncBailHook<[Pattern], boolean | void>>;
 		pattern: HookMap<SyncBailHook<[Identifier], boolean | void>>;
 		canRename: HookMap<SyncBailHook<[Expression], boolean | void>>;
 		rename: HookMap<SyncBailHook<[Expression], boolean | void>>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Adds a type to the 2nd parameter of `_preWalkVariableDeclaration`. The [hook.call](https://github.com/webpack/webpack/blob/9abab772eafba77673e07cf264d833716e33492f/lib/javascript/JavascriptParser.js#L2799) function accepts a parameter of type [`Pattern`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/da70d4aee37cd531df1fc030c1e068fe51d3b5e9/types/estree/index.d.ts#L411). That's why I think `Pattern` would be a more suitable type than [`Declaration`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/da70d4aee37cd531df1fc030c1e068fe51d3b5e9/types/estree/index.d.ts#L232)(which is the old one).
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
No
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
