### PR TITLE
fix(commonjs-static): export unprovided variables

### DIFF
--- a/lib/library/AssignLibraryPlugin.js
+++ b/lib/library/AssignLibraryPlugin.js
@@ -302,13 +302,42 @@ class AssignLibraryPlugin extends AbstractLibraryPlugin {
 				this._getPrefix(compilation).length,
 				true
 			);
+
+			/** @type {string[]} */
+			const provided = [];
 			for (const exportInfo of exportsInfo.orderedExports) {
 				if (!exportInfo.provided) continue;
 				const nameAccess = propertyAccess([exportInfo.name]);
 				result.add(
 					`${exportTarget}${nameAccess} = ${RuntimeGlobals.exports}${exportAccess}${nameAccess};\n`
 				);
+				provided.push(exportInfo.name);
 			}
+
+			const webpackExportTarget = accessWithInit(
+				fullNameResolved,
+				this._getPrefix(compilation).length,
+				true
+			);
+			/** @type {string} */
+			let exports = RuntimeGlobals.exports;
+			if (exportAccess) {
+				result.add(
+					`var __webpack_exports_export__ = ${RuntimeGlobals.exports}${exportAccess};\n`
+				);
+				exports = "__webpack_exports_export__";
+			}
+			result.add(`for(var __webpack_i__ in ${exports}) {\n`);
+			const hasProvided = provided.length > 0;
+			if (hasProvided) {
+				result.add(
+					`  if (${JSON.stringify(provided)}.indexOf(__webpack_i__) === -1) {\n`
+				);
+			}
+			result.add(
+				`  ${hasProvided ? "  " : ""}${webpackExportTarget}[__webpack_i__] = ${exports}[__webpack_i__];\n`
+			);
+			result.add(hasProvided ? "  }\n}\n" : "\n");
 			result.add(
 				`Object.defineProperty(${exportTarget}, "__esModule", { value: true });\n`
 			);

--- a/test/configCases/library/0-create-library/index.js
+++ b/test/configCases/library/0-create-library/index.js
@@ -2,6 +2,7 @@ export * from "./a";
 export default "default-value";
 export var b = "b";
 export { default as external } from "external";
+export * from "external-named";
 
 var module = "should not conflict",
 	define = "should not conflict",

--- a/test/configCases/library/0-create-library/non-external-named.js
+++ b/test/configCases/library/0-create-library/non-external-named.js
@@ -1,0 +1,1 @@
+export const nonExternalA =  "non-external-a";

--- a/test/configCases/library/0-create-library/webpack.config.js
+++ b/test/configCases/library/0-create-library/webpack.config.js
@@ -11,7 +11,8 @@ module.exports = (env, { testPath }) => [
 		target: "node14",
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		},
 		experiments: {
@@ -27,7 +28,8 @@ module.exports = (env, { testPath }) => [
 		target: "node14",
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		},
 		experiments: {
@@ -43,7 +45,8 @@ module.exports = (env, { testPath }) => [
 		target: "node14",
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		},
 		optimization: {
@@ -62,7 +65,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		}
 	},
@@ -75,7 +79,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		}
 	},
@@ -88,7 +93,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		}
 	},
@@ -101,7 +107,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		}
 	},
@@ -116,7 +123,8 @@ module.exports = (env, { testPath }) => [
 		target: "web",
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		},
 		optimization: {
@@ -134,7 +142,8 @@ module.exports = (env, { testPath }) => [
 		target: "web",
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		},
 		optimization: {
@@ -149,7 +158,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		}
 	},
@@ -164,7 +174,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		}
 	},
@@ -179,7 +190,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		},
 		ignoreWarnings: [error => error.name === "FalseIIFEUmdWarning"]
@@ -195,7 +207,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		},
 		ignoreWarnings: [error => error.name === "FalseIIFEUmdWarning"]
@@ -209,7 +222,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		}
 	},
@@ -222,7 +236,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		}
 	},
@@ -235,7 +250,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		}
 	},
@@ -248,7 +264,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		},
 		plugins: [
@@ -267,7 +284,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		},
 		plugins: [
@@ -288,7 +306,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		}
 	},
@@ -303,7 +322,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		}
 	},
@@ -314,7 +334,7 @@ module.exports = (env, { testPath }) => [
 			libraryTarget: "commonjs2",
 			iife: false
 		},
-		externals: ["external"]
+		externals: ["external", "external-named"]
 	},
 	{
 		output: {
@@ -326,7 +346,7 @@ module.exports = (env, { testPath }) => [
 		optimization: {
 			concatenateModules: false
 		},
-		externals: ["external"]
+		externals: ["external", "external-named"]
 	},
 	{
 		output: {
@@ -335,7 +355,7 @@ module.exports = (env, { testPath }) => [
 			libraryTarget: "commonjs2",
 			iife: true
 		},
-		externals: ["external"]
+		externals: ["external", "external-named"]
 	},
 	{
 		mode: "development",
@@ -344,7 +364,7 @@ module.exports = (env, { testPath }) => [
 			filename: "commonjs2-external-eval.js",
 			libraryTarget: "commonjs2"
 		},
-		externals: ["external"]
+		externals: ["external", "external-named"]
 	},
 	{
 		mode: "development",
@@ -354,7 +374,7 @@ module.exports = (env, { testPath }) => [
 			libraryTarget: "commonjs2"
 		},
 		devtool: "eval-source-map",
-		externals: ["external"]
+		externals: ["external", "external-named"]
 	},
 	{
 		output: {
@@ -363,7 +383,7 @@ module.exports = (env, { testPath }) => [
 			libraryTarget: "commonjs-static",
 			iife: false
 		},
-		externals: ["external"]
+		externals: ["external", "external-named"]
 	},
 	{
 		output: {
@@ -387,7 +407,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		}
 	},
@@ -400,7 +421,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		},
 		optimization: {
@@ -416,7 +438,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		},
 		optimization: {
@@ -434,7 +457,8 @@ module.exports = (env, { testPath }) => [
 		target: "web",
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		},
 		optimization: {
@@ -452,7 +476,8 @@ module.exports = (env, { testPath }) => [
 		target: "web",
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		},
 		optimization: {
@@ -487,7 +512,8 @@ module.exports = (env, { testPath }) => [
 		},
 		resolve: {
 			alias: {
-				external: "./non-external"
+				external: "./non-external",
+				"external-named": "./non-external-named"
 			}
 		}
 	}

--- a/test/configCases/library/1-use-library/index.js
+++ b/test/configCases/library/1-use-library/index.js
@@ -1,5 +1,6 @@
 import d from "library";
 import { a, b, external } from "library";
+import * as imoprtStar from "library";
 
 it(
 	"should be able to import harmony exports from library (" + NAME + ")",
@@ -10,8 +11,12 @@ it(
 		if (typeof TEST_EXTERNAL !== "undefined" && TEST_EXTERNAL) {
 			expect(external).toEqual(["external"]);
 			expect(external).toBe(require("external"));
+			const { externalA } = imoprtStar
+			expect(externalA).toEqual(["external-a"]);
 		} else {
 			expect(external).toBe("non-external");
+			const { nonExternalA } = imoprtStar;
+			expect(nonExternalA).toBe("non-external-a");
 		}
 	}
 );

--- a/test/configCases/library/1-use-library/node_modules/external-named.js
+++ b/test/configCases/library/1-use-library/node_modules/external-named.js
@@ -1,0 +1,1 @@
+module.exports['externalA'] = ["external-a"];

--- a/test/configCases/library/1-use-library/webpack.config.js
+++ b/test/configCases/library/1-use-library/webpack.config.js
@@ -293,7 +293,11 @@ module.exports = (env, { testPath }) => [
 					testPath,
 					"../0-create-library/commonjs2-external.js"
 				),
-				external: path.resolve(__dirname, "node_modules/external.js")
+				external: path.resolve(__dirname, "node_modules/external.js"),
+				"external-named": path.resolve(
+					__dirname,
+					"node_modules/external-named.js"
+				)
 			}
 		},
 		plugins: [
@@ -310,7 +314,11 @@ module.exports = (env, { testPath }) => [
 					testPath,
 					"../0-create-library/commonjs2-iife-external.js"
 				),
-				external: path.resolve(__dirname, "node_modules/external.js")
+				external: path.resolve(__dirname, "node_modules/external.js"),
+				"external-named": path.resolve(
+					__dirname,
+					"node_modules/external-named.js"
+				)
 			}
 		},
 		plugins: [
@@ -327,7 +335,11 @@ module.exports = (env, { testPath }) => [
 					testPath,
 					"../0-create-library/commonjs2-external-eval.js"
 				),
-				external: path.resolve(__dirname, "node_modules/external.js")
+				external: path.resolve(__dirname, "node_modules/external.js"),
+				"external-named": path.resolve(
+					__dirname,
+					"node_modules/external-named.js"
+				)
 			}
 		},
 		plugins: [
@@ -344,7 +356,11 @@ module.exports = (env, { testPath }) => [
 					testPath,
 					"../0-create-library/commonjs2-external-eval-source-map.js"
 				),
-				external: path.resolve(__dirname, "node_modules/external.js")
+				external: path.resolve(__dirname, "node_modules/external.js"),
+				"external-named": path.resolve(
+					__dirname,
+					"node_modules/external-named.js"
+				)
 			}
 		},
 		plugins: [
@@ -363,7 +379,11 @@ module.exports = (env, { testPath }) => [
 					testPath,
 					"../0-create-library/commonjs-static-external.js"
 				),
-				external: path.resolve(__dirname, "node_modules/external.js")
+				external: path.resolve(__dirname, "node_modules/external.js"),
+				"external-named": path.resolve(
+					__dirname,
+					"node_modules/external-named.js"
+				)
 			}
 		},
 		plugins: [
@@ -380,7 +400,11 @@ module.exports = (env, { testPath }) => [
 					testPath,
 					"../0-create-library/commonjs2-split-chunks/"
 				),
-				external: path.resolve(__dirname, "node_modules/external.js")
+				external: path.resolve(__dirname, "node_modules/external.js"),
+				"external-named": path.resolve(
+					__dirname,
+					"node_modules/external-named.js"
+				)
 			}
 		},
 		plugins: [

--- a/test/configCases/library/cjs-static/index.js
+++ b/test/configCases/library/cjs-static/index.js
@@ -6,5 +6,5 @@ export default bar
 
 it("should success compile and work",()=>{
 	const output = fs.readFileSync(__filename).toString();
-	expect(output.match(/exports(\[|\.)/g).length).toBe(3)
+	expect(output.match(/exports(\[|\.)/g).length).toBe(4)
 })


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Previously, any unprovided export will be skipped directly, which will lost export in the following common library usage:

```js
// reexport from an external module in the index file of a package
export * from 'external-module'
```

In this PR, I added a loop to assign exports in the ⁠way of `commonjs`  to ensure nothing is lost.

**Did you add tests for your changes?**

Yes.

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

I don't think so.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

No.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
