### PR TITLE
fix: deprecation warning

### DIFF
--- a/test/JavascriptParser.unittest.js
+++ b/test/JavascriptParser.unittest.js
@@ -322,7 +322,7 @@ describe("JavascriptParser", () => {
 					testParser.state.expressions.push(expr.name);
 					return true;
 				});
-			testParser.hooks.new.tap("xyz", "JavascriptParserTest", expr => {
+			testParser.hooks.new.for("xyz").tap("JavascriptParserTest", expr => {
 				if (!testParser.state.xyz) testParser.state.xyz = [];
 				testParser.state.xyz.push(testParser.parseString(expr.arguments[0]));
 				return true;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
This PR fixes the `HookMap#tap` deprecation warning by replacing it with `HookMap#for(...).tap(...)`. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Updated the internal hook usage to use `for(...)` instead of `tap(key, ...)` cause previously it was showing deprecation warning while running tests. I have explained everything in the below mentioned issue.
<!-- Try to link to an open issue for more information. -->
RESOLVES #19304 

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Updated /webpack/test/JavascriptParser.unittest.js
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
NA
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
