### PR TITLE
return ResolveRequest object from async resolver

### DIFF
--- a/lib/ExternalModuleFactoryPlugin.js
+++ b/lib/ExternalModuleFactoryPlugin.js
@@ -283,7 +283,7 @@ class ExternalModuleFactoryPlugin {
 													context,
 													request,
 													resolveContext,
-													(err, result) => {
+													(err, _, result) => {
 														if (err) reject(err);
 														else resolve(result);
 													}

--- a/test/configCases/externals/resolve/index.js
+++ b/test/configCases/externals/resolve/index.js
@@ -1,5 +1,5 @@
 it("should allow functions as externals with promise and resolver", function () {
 	const result = require("external");
-	expect(result).toMatch(/^[a-z]:\\|\//i);
-	expect(result).toMatch(/resolve.node_modules.external\.js$/);
+	expect(result.relativePath).toMatch(/^[a-z]:\\|\//i);
+	expect(result.relativePath).toMatch(/resolve.node_modules.external\.js$/);
 });


### PR DESCRIPTION
The function returned from `ctx.getResolve` factory available in ["externals function"](https://webpack.js.org/configuration/externals/#function) supports callback-style as well as promise-style API. 

For callback, besides of an error, two parameters are available — 
`res?: string | false` and `req?: ResolveRequest`.
In case of promise only string value is being returned.

It looks like a bug but at this point this could be also a breaking change.

For sake of API parity the promise flavour should return the `ResolveRequest` object with all data.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Bugfix, but it depends.

**Did you add tests for your changes?**
Modified one.

**Does this PR introduce a breaking change?**
This is a breaking change to undocumented API. 

**What needs to be documented once your changes are merged?**
This API doesn't have much docs.
