### PR TITLE
fix: add `strict: true` to ContextModule

### DIFF
--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -435,6 +435,7 @@ class ContextModule extends Module {
 			defaultObject: "redirect-warn"
 		};
 		this.buildInfo = {
+			strict: true,
 			snapshot: undefined
 		};
 		this.dependencies.length = 0;

--- a/test/configCases/concatenate-modules/context-module/index.mjs
+++ b/test/configCases/concatenate-modules/context-module/index.mjs
@@ -1,0 +1,41 @@
+/** @type {import('fs')} */
+const fs = __non_webpack_require__("fs");
+
+it("should import", async () => {
+	const n = "a.js";
+	const { default: a1 } = await import(`./sub/${n}`);
+	expect(a1).toBe("a");
+});
+
+it("should startsWith use strict", async () => {
+	const source = fs.readFileSync(__filename, "utf-8");
+	expect(source.length).not.toBe(0);
+	expect(source.startsWith('/******/ "use strict"')).toBeTruthy();
+});
+
+it("should have all strict modules", () => {
+	const source = fs.readFileSync(__filename, "utf-8");
+	expect(source.length).not.toBe(0);
+
+	expect(source).not.toContain(
+		[
+			"This",
+			"entry",
+			"needs",
+			"to",
+			"be",
+			"wrapped",
+			"in",
+			"an",
+			"IIFE",
+			"because",
+			"it",
+			"needs",
+			"to",
+			"be",
+			"in",
+			"strict",
+			"mode."
+		].join(" ")
+	);
+});

--- a/test/configCases/concatenate-modules/context-module/infrastructure-log.js
+++ b/test/configCases/concatenate-modules/context-module/infrastructure-log.js
@@ -1,0 +1,7 @@
+module.exports = options => {
+	if (options.cache && options.cache.type === "filesystem") {
+		return [/Pack got invalid because of write to/];
+	}
+
+	return [];
+};

--- a/test/configCases/concatenate-modules/context-module/sub/a.js
+++ b/test/configCases/concatenate-modules/context-module/sub/a.js
@@ -1,0 +1,1 @@
+export default "a"

--- a/test/configCases/concatenate-modules/context-module/webpack.config.js
+++ b/test/configCases/concatenate-modules/context-module/webpack.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: "./index.mjs",
+	output: { iife: false },
+	optimization: { concatenateModules: true }
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Following up on https://github.com/webpack/webpack/discussions/18367#discussion-6580398, we aim to enforce strict mode across all modules to eliminate the entry IIFE.

But the `module.parser.javascript.overrideStrict` option cannot apply to `ContextModule`s.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
