### PR TITLE
fix: excessive calls of getAllReferences

### DIFF
--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1606,12 +1606,6 @@ class JavascriptModulesPlugin {
 			}
 
 			for (const variable of info.variables) {
-				allUsedNames.add(variable.name);
-				const references = getAllReferences(variable);
-				const allIdentifiers = new Set(
-					references.map(r => r.identifier).concat(variable.identifiers)
-				);
-
 				const usedNamesInScopeInfo = new Map();
 				const ignoredScopes = new Set();
 
@@ -1624,6 +1618,9 @@ class JavascriptModulesPlugin {
 
 				if (allUsedNames.has(name) || usedNames.has(name)) {
 					const references = getAllReferences(variable);
+					const allIdentifiers = new Set(
+						references.map(r => r.identifier).concat(variable.identifiers)
+					);
 					for (const ref of references) {
 						addScopeSymbols(
 							ref.from,
@@ -1658,9 +1655,8 @@ class JavascriptModulesPlugin {
 						}
 						source.replace(r[0], r[1] - 1, newName);
 					}
-				} else {
-					allUsedNames.add(name);
 				}
+				allUsedNames.add(name);
 			}
 
 			renamedInlinedModules.set(m, source);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR fixes excessive calls of getAllReferences, which is an issue observed in #18917. In the discussion was not yet clear what causes the issue. But my project suffered since version 5.96.0, too. I was able to git-bisect and profile the issue. The issue appeared first in #18845 / 18d6cb5afe4528f4fa168aa9aab733b934f2351e. The profiles are too large, I'll just show screenshots.

Before this change my project did a release build in about 36s:

<img width="1558" alt="before" src="https://github.com/user-attachments/assets/7547ba97-9624-4d42-9b23-e322403cf187" />

After that, the performance regressed to about 130s. You can see, getAllReferences is called now excessively:

<img width="1557" alt="regression" src="https://github.com/user-attachments/assets/6c37b54b-c7d0-4617-b5f5-e9a4ed0445df" />

To fix this, the PR does two things.

First, improve `allUsedNames.add(variable.name)` handling, otherwise all variables would be renamed, which causes many getAllReferences calls.

Second, move  `allIdentifiers` to the branch which uses it, which makes it possible to remove one `getAllReferences` call completely.

**Did you add tests for your changes?**

Yes. The performance is nearly back to as before. Not quite, but this is expected, because it checks more variables.
In my case to around 40s:

<img width="1557" alt="after" src="https://github.com/user-attachments/assets/441d1f5a-8c4b-470c-921b-eb538cb26cea" />

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

Nothing.
