### PR TITLE
Fixed issue 18615

### DIFF
--- a/lib/webworker/ImportScriptsChunkLoadingPlugin.js
+++ b/lib/webworker/ImportScriptsChunkLoadingPlugin.js
@@ -21,7 +21,7 @@ class ImportScriptsChunkLoadingPlugin {
 	apply(compiler) {
 		new StartupChunkDependenciesPlugin({
 			chunkLoading: "import-scripts",
-			asyncChunkLoading: true
+			asyncChunkLoading: false
 		}).apply(compiler);
 		compiler.hooks.thisCompilation.tap(
 			"ImportScriptsChunkLoadingPlugin",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

Fix: Worker entry points using importScripts should load synchronously
This PR fixes issue #18615 where webpack unnecessarily makes loading additional chunks in worker entrypoints asynchronous.

Problem
The ImportScriptsChunkLoadingPlugin sets asyncChunkLoading to true by default, but importScripts is a synchronous API. This causes issues when code expects definitions to be available immediately after importScripts returns.

Solution
Change the default value of asyncChunkLoading to false in the ImportScriptsChunkLoadingPlugin to match the actual behaviour of importScripts.

Testing
Added a test case that verifies worker chunks are loaded synchronously with importScripts.

**What kind of change does this PR introduce?**

This PR introduces a bugfix using importScripts should load synchronously. 

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes, I added a testcase. 

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No, this PR doesn't introduces a breaking change.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

Change the default value of asyncChunkLoading to false in the ImportScriptsChunkLoadingPlugin to match the actual behaviour of importScripts.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->



