### PR TITLE
fix:optimize asset caching

### DIFF
--- a/lib/cache/IdleFileCachePlugin.js
+++ b/lib/cache/IdleFileCachePlugin.js
@@ -12,6 +12,7 @@ const ProgressPlugin = require("../ProgressPlugin");
 /** @typedef {import("./PackFileCacheStrategy")} PackFileCacheStrategy */
 
 const BUILD_DEPENDENCIES_KEY = Symbol("build dependencies key");
+const cachedAssets = new Set();
 
 class IdleFileCachePlugin {
 	/**
@@ -57,6 +58,13 @@ class IdleFileCachePlugin {
 		compiler.cache.hooks.store.tap(
 			{ name: "IdleFileCachePlugin", stage: Cache.STAGE_DISK },
 			(identifier, etag, data) => {
+				if (identifier.includes("|asset/")) {
+					const assetHash = identifier.split("|asset/")[1];
+					if (cachedAssets.has(assetHash)) {
+						return;
+					}
+					cachedAssets.add(assetHash);
+				}
 				pendingIdleTasks.set(identifier, () =>
 					strategy.store(identifier, etag, data)
 				);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Previously ,webpack stored binary assets multiple times ,once during parsing and once during final asset generation leading to huge cache sizes and slower builds
This PR solves it by :  
-deduplicating assets before storing them in cache
-Stores each asset only once using hash based check

resolves https://github.com/webpack/webpack/issues/19359
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix
**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Developers should be aware that large assets won’t be redundantly cached, improving efficiency
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
