### PR TITLE
fix: should create export for external

### DIFF
--- a/lib/library/ModernModuleLibraryPlugin.js
+++ b/lib/library/ModernModuleLibraryPlugin.js
@@ -96,6 +96,7 @@ class ModernModuleLibraryPlugin extends AbstractLibraryPlugin {
 		const definitions =
 			/** @type {BuildMeta} */
 			(module.buildMeta).exportsFinalName;
+		const shortHandedExports = [];
 		const exports = [];
 
 		for (const exportInfo of exportsInfo.orderedExports) {
@@ -107,7 +108,7 @@ class ModernModuleLibraryPlugin extends AbstractLibraryPlugin {
 
 				for (const reexportInfo of exp.orderedExports) {
 					if (
-						!reexportInfo.provided &&
+						reexportInfo.provided === false &&
 						reexportInfo.name === /** @type {string[]} */ (reexport.export)[0]
 					) {
 						shouldContinue = true;
@@ -127,15 +128,26 @@ class ModernModuleLibraryPlugin extends AbstractLibraryPlugin {
 					/** @type {string} */
 					(webpackExportsProperty)
 				];
-			exports.push(
-				finalName === exportInfo.name
-					? finalName
-					: `${finalName} as ${exportInfo.name}`
-			);
+
+			if (finalName && (finalName.includes(".") || finalName.includes("["))) {
+				exports.push([exportInfo.name, finalName]);
+			} else {
+				shortHandedExports.push(
+					finalName === exportInfo.name
+						? finalName
+						: `${finalName} as ${exportInfo.name}`
+				);
+			}
 		}
 
-		if (exports.length > 0) {
-			result.add(`export { ${exports.join(", ")} };\n`);
+		if (shortHandedExports.length > 0) {
+			result.add(`export { ${shortHandedExports.join(", ")} };\n`);
+		}
+
+		for (const [exportName, final] of exports) {
+			result.add(
+				`export ${compilation.outputOptions.environment.const ? "const" : "var"} ${exportName} = ${final};\n`
+			);
 		}
 
 		return result;

--- a/test/configCases/library/modern-module-reexport-external/index.js
+++ b/test/configCases/library/modern-module-reexport-external/index.js
@@ -1,0 +1,1 @@
+it('should compile', () => {})

--- a/test/configCases/library/modern-module-reexport-external/test.config.js
+++ b/test/configCases/library/modern-module-reexport-external/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return ["main.js"];
+	}
+};

--- a/test/configCases/library/modern-module-reexport-external/test.js
+++ b/test/configCases/library/modern-module-reexport-external/test.js
@@ -1,0 +1,1 @@
+export { value } from 'external0'

--- a/test/configCases/library/modern-module-reexport-external/webpack.config.js
+++ b/test/configCases/library/modern-module-reexport-external/webpack.config.js
@@ -1,0 +1,35 @@
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	mode: "none",
+	entry: { main: "./index.js", test: "./test" },
+	output: {
+		module: true,
+		library: {
+			type: "modern-module"
+		},
+		filename: "[name].js",
+		chunkFormat: "module"
+	},
+	experiments: {
+		outputModule: true
+	},
+	resolve: {
+		extensions: [".js"]
+	},
+	externalsType: "module",
+	externals: ["external0"],
+	optimization: {
+		concatenateModules: true
+	},
+	plugins: [
+		function () {
+			const handler = compilation => {
+				compilation.hooks.afterProcessAssets.tap("testcase", assets => {
+					const source = assets["test.js"].source();
+					expect(source).toContain("export const value");
+				});
+			};
+			this.hooks.compilation.tap("testcase", handler);
+		}
+	]
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

For library type 'modern-module', should not ignore exports with `unknown` exports info.

The exportsInfo of `ExternalModule` is `unknown` exports info, we should keep the export for it

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes
