### PR TITLE
fix: add `@types/json-schema` as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@types/eslint-scope": "^3.7.7",
     "@types/estree": "^1.0.6",
+    "@types/json-schema": "^7.0.15",
     "@webassemblyjs/ast": "^1.14.1",
     "@webassemblyjs/wasm-edit": "^1.14.1",
     "@webassemblyjs/wasm-parser": "^1.14.1",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

This ensures that all the types required for using Webpack with TypeScript are present, and making package managers like Yarn Berry running with pnp mode happy.

These types are used here: https://github.com/webpack/webpack/blob/main/types.d.ts#L91

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
No, because that'd be a lot of work 😅

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

None