### PR TITLE
fix: regression with location

### DIFF
--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -131,23 +131,22 @@ class Dependency {
 	 */
 	get loc() {
 		if (this._loc !== undefined) return this._loc;
+
 		/** @type {SyntheticDependencyLocation & RealDependencyLocation} */
-		const loc = {
-			start: { line: 0, column: 0 },
-			end: { line: 0, column: 0 },
-			name: "",
-			index: -1
-		};
+		const loc = {};
+
 		if (this._locSL > 0) {
 			loc.start = { line: this._locSL, column: this._locSC };
 		}
 		if (this._locEL > 0) {
 			loc.end = { line: this._locEL, column: this._locEC };
 		}
-
-		loc.name = this._locN;
-
-		loc.index = this._locI;
+		if (this._locN !== undefined) {
+			loc.name = this._locN;
+		}
+		if (this._locI !== undefined) {
+			loc.index = this._locI;
+		}
 
 		return (this._loc = loc);
 	}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fixes https://github.com/webpack/webpack/discussions/19523

Shorty - some (including in our codebase) compactors are using `if ("start" in loc) {}` (for example for order of dependencies) and in 5.98.0 version it was `false`, after https://github.com/webpack/webpack/commit/87b203b27eb8d32101e75f1e589d2d162781120b it is always `true` and so we start compare with `0`, before we don't compare such deps, so because we start compare with `0` order become wrong

**Did you add tests for your changes?**

Hard to create good valid test, tried, but they are syntactical and don't provide a real fix 

**Does this PR introduce a breaking change?**

Return old behaviour 

**What needs to be documented once your changes are merged?**

No need