### PR TITLE
fix: es export generation for multiple module entries

### DIFF
--- a/lib/library/ModuleLibraryPlugin.js
+++ b/lib/library/ModuleLibraryPlugin.js
@@ -82,7 +82,10 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 				for (const chunk of compilation.chunkGraph.getModuleChunksIterable(
 					module
 				)) {
-					if (!chunk.hasRuntime()) {
+					if (
+						!chunk.hasRuntime() ||
+						compilation.chunkGraph.getNumberOfEntryModules(chunk) > 1
+					) {
 						return false;
 					}
 				}

--- a/test/configCases/library/0-create-library/foo.js
+++ b/test/configCases/library/0-create-library/foo.js
@@ -1,0 +1,1 @@
+export const foo = "bar";

--- a/test/configCases/library/0-create-library/webpack.config.js
+++ b/test/configCases/library/0-create-library/webpack.config.js
@@ -256,6 +256,26 @@ module.exports = (env, { testPath }) => [
 		}
 	},
 	{
+		entry: ["./foo.js", "./index.js"],
+		output: {
+			uniqueName: "esm-multiple-entry-modules",
+			filename: "esm-multiple-entry-modules.js",
+			library: {
+				type: "module"
+			}
+		},
+		target: "node14",
+		resolve: {
+			alias: {
+				external: "./non-external",
+				"external-named": "./non-external-named"
+			}
+		},
+		experiments: {
+			outputModule: true
+		}
+	},
+	{
 		output: {
 			uniqueName: "commonjs",
 			filename: "commonjs.js",

--- a/test/configCases/library/1-use-library/webpack.config.js
+++ b/test/configCases/library/1-use-library/webpack.config.js
@@ -200,6 +200,21 @@ module.exports = (env, { testPath }) => [
 	{
 		resolve: {
 			alias: {
+				library: path.resolve(
+					testPath,
+					"../0-create-library/esm-multiple-entry-modules.js"
+				)
+			}
+		},
+		plugins: [
+			new webpack.DefinePlugin({
+				NAME: JSON.stringify("esm-multiple-entry-modules")
+			})
+		]
+	},
+	{
+		resolve: {
+			alias: {
 				library: path.resolve(testPath, "../0-create-library/commonjs.js")
 			}
 		},


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fixes https://github.com/webpack/webpack/issues/19511

Currently we don't support all inlined modules for multiple module entry, we have TODO - https://github.com/webpack/webpack/blob/main/lib/javascript/JavascriptModulesPlugin.js#L1525

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

No