### PR TITLE
feat: allow multiple runtime instances to receive HMR updates

### DIFF
--- a/lib/web/JsonpChunkLoadingRuntimeModule.js
+++ b/lib/web/JsonpChunkLoadingRuntimeModule.js
@@ -338,9 +338,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 						]),
 						"}",
 						"",
-						`${globalObject}[${JSON.stringify(
-							hotUpdateGlobal
-						)}] = ${runtimeTemplate.basicFunction(
+						`var hmrGlobalJsonpLoader = ${runtimeTemplate.basicFunction(
 							"chunkId, moreModules, runtime",
 							[
 								"for(var moduleId in moreModules) {",
@@ -360,6 +358,18 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 									"waitingUpdateResolves[chunkId] = undefined;"
 								]),
 								"}"
+							]
+						)};`,
+						`var oldHmrGlobalJsonpLoader = ${globalObject}[${JSON.stringify(
+							hotUpdateGlobal
+						)}] || (${runtimeTemplate.basicFunction("", [])});`,
+						`${globalObject}[${JSON.stringify(
+							hotUpdateGlobal
+						)}] = ${runtimeTemplate.basicFunction(
+							"chunkId, moreModules, runtime",
+							[
+								`oldHmrGlobalJsonpLoader(chunkId, moreModules, runtime);`,
+								`hmrGlobalJsonpLoader(chunkId, moreModules, runtime);`
 							]
 						)};`,
 						"",

--- a/test/hotCases/multiple-runtime-instances/child/index.js
+++ b/test/hotCases/multiple-runtime-instances/child/index.js
@@ -1,0 +1,10 @@
+import { value } from './value.js';
+
+const div = document.createElement('div');
+div.innerHTML = value
+document.body.appendChild(div);
+
+module.hot.accept('./value.js', () => {
+	const newValue = require('./value.js').value;
+	div.innerHTML = newValue;
+})

--- a/test/hotCases/multiple-runtime-instances/child/value.js
+++ b/test/hotCases/multiple-runtime-instances/child/value.js
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/test/hotCases/multiple-runtime-instances/child/webpack.config.js
+++ b/test/hotCases/multiple-runtime-instances/child/webpack.config.js
@@ -1,0 +1,17 @@
+const path = require("path");
+
+/** @type import('webpack').Configuration */
+module.exports = {
+	mode: "development",
+	entry: "./index.js",
+	output: {
+		path: path.resolve(__dirname, "dist"),
+		filename: "bundle.js"
+	},
+	devServer: {
+		port: 8000,
+		headers: {
+			"Access-Control-Allow-Origin": "*"
+		}
+	}
+};

--- a/test/hotCases/multiple-runtime-instances/parent/index.html
+++ b/test/hotCases/multiple-runtime-instances/parent/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+	<body>
+		<script src="index.js"></script>
+	</body>
+</html>

--- a/test/hotCases/multiple-runtime-instances/parent/index.js
+++ b/test/hotCases/multiple-runtime-instances/parent/index.js
@@ -1,0 +1,23 @@
+function loadScript(url) {
+	return new Promise((resolve, reject) => {
+		const script = document.createElement('script')
+		script.src = url
+		if (url.endsWith('.mjs')) {
+			script.type = 'module'
+		}
+
+		script.onerror = (error) => {
+			document.body.removeChild(script)
+			reject(error)
+		}
+
+		script.onload = () => {
+			resolve()
+			document.body.removeChild(script)
+		}
+
+		document.body.append(script)
+	})
+}
+
+loadScript('http://localhost:8000/bundle.js').then(() => loadScript('http://localhost:8000/bundle.js'))


### PR DESCRIPTION
**What kind of change does this PR introduce?**

The current webpack runtime assigns a global HMR JSONP loader that replaces any existing loader with the same name. While usually a single instance of the same runtime is running on the same context, we found some cases in Module Federation where running the same remoteEntry more than once (and therefore the webpack runtime) in the same page allows to have coexisting instances of the same runtime. However, since the HMR JSONP loader is overwritten by the latest instance, only the latest instance gets the updates, causing errors in the earlier instances.

The changes aim to implement a way to propagate HMR updates through all instances of the same runtime, if they exist.

**Did you add tests for your changes?**

Yes. There's a new hotCase at `hotCases/multiple-runtime-instances`. I used webpack-dev-server to run it, but since I couldn't find any similar example, my testing approach might not be appropriate for the repo, in which case I'll be glad to help making it suitable.

Before feat:

https://github.com/user-attachments/assets/05a9cc52-af8f-49cb-8d5f-ea2703c1a87f

After feat:

https://github.com/user-attachments/assets/53cfa91d-dcfc-4ba5-8e4b-a279efec918f

**Does this PR introduce a breaking change?**

No, runtime keeps its current behavior, except HMR updates are propagated in the singular case where more than one instance of the same runtime is running.

**What needs to be documented once your changes are merged?**

Since I couldn't find this behavior mentioned anywhere, no changes to the documentation are needed, AFAIK.
