### PR TITLE
Fixed publicPath issue

### DIFF
--- a/lib/esm/ModuleChunkLoadingRuntimeModule.js
+++ b/lib/esm/ModuleChunkLoadingRuntimeModule.js
@@ -216,9 +216,9 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 													"// setup Promise in chunk cache",
 													`var promise = ${importFunctionName}(${
 														compilation.outputOptions.publicPath === "auto"
-															? ""
-															: `${RuntimeGlobals.publicPath} + `
-													}${JSON.stringify(rootOutputDir)} + ${
+															? JSON.stringify(rootOutputDir)
+															: RuntimeGlobals.publicPath
+													} + ${
 														RuntimeGlobals.getChunkScriptFilename
 													}(chunkId)).then(installChunk, ${runtimeTemplate.basicFunction(
 														"e",

--- a/test/ConfigTestCases.template.js
+++ b/test/ConfigTestCases.template.js
@@ -498,11 +498,15 @@ const describeCases = config => {
 											esmMode,
 											parentModule
 										) => {
+											if (testConfig.resolveModule) {
+												module = testConfig.resolveModule(module, i, options);
+											}
 											if (testConfig === undefined) {
 												throw new Error(
 													`_require(${module}) called after all tests from ${category.name} ${testName} have completed`
 												);
 											}
+
 											if (Array.isArray(module) || /^\.\.?\//.test(module)) {
 												let content;
 												let p;

--- a/test/configCases/output-module/public-path/test.config.js
+++ b/test/configCases/output-module/public-path/test.config.js
@@ -1,4 +1,29 @@
+const path = require("path");
+
 module.exports = {
+	resolveModule(module, i) {
+		if (/^\.\/bundle/.test(module)) {
+			return module;
+		}
+
+		if (i === 4 || i === 5) {
+			return `./${module}`;
+		}
+
+		if (i === 6 || i === 7 || i === 10 || i === 11) {
+			if (/async/.test(module)) {
+				return `../${module}`;
+			}
+
+			return `./${module}`;
+		}
+
+		if (i === 15) {
+			return `./${path.basename(module)}`;
+		}
+
+		return module;
+	},
 	findBundle(i, options) {
 		switch (i) {
 			case 2:
@@ -11,7 +36,8 @@ module.exports = {
 			case 11:
 			case 12:
 			case 13:
-			case 14: {
+			case 14:
+			case 15: {
 				return `./bundle${i}/${options.output.filename}`;
 			}
 			default: {

--- a/test/configCases/output-module/public-path/test.config.js
+++ b/test/configCases/output-module/public-path/test.config.js
@@ -9,8 +9,9 @@ module.exports = {
 			case 3:
 			case 7:
 			case 11:
+			case 12:
 			case 13:
-			case 12: {
+			case 14: {
 				return `./bundle${i}/${options.output.filename}`;
 			}
 			default: {

--- a/test/configCases/output-module/public-path/webpack.config.js
+++ b/test/configCases/output-module/public-path/webpack.config.js
@@ -186,9 +186,22 @@ module.exports = (env, { testPath }) => [
 		output: {
 			path: path.resolve(testPath, "./bundle14"),
 			module: true,
-			publicPath: "/bundle14/",
-			filename: "initial/bundle14.mjs",
-			chunkFilename: "async/[id].bundle14.mjs"
+			filename: "js/bundle14.mjs",
+			chunkFilename: "js/[id].bundle14.mjs"
+		},
+		experiments: {
+			outputModule: true
+		}
+	},
+	{
+		devtool: false,
+		target: "web",
+		output: {
+			publicPath: "https://example.com/public/path/",
+			path: path.resolve(testPath, "./bundle15"),
+			module: true,
+			filename: "js/bundle15.mjs",
+			chunkFilename: "js/[id].bundle15.mjs",
 		},
 		experiments: {
 			outputModule: true

--- a/test/configCases/output-module/public-path/webpack.config.js
+++ b/test/configCases/output-module/public-path/webpack.config.js
@@ -179,5 +179,19 @@ module.exports = (env, { testPath }) => [
 		experiments: {
 			outputModule: true
 		}
+	},
+	{
+		devtool: false,
+		target: "web",
+		output: {
+			path: path.resolve(testPath, "./bundle14"),
+			module: true,
+			publicPath: "/bundle14/",
+			filename: "initial/bundle14.mjs",
+			chunkFilename: "async/[id].bundle14.mjs"
+		},
+		experiments: {
+			outputModule: true
+		}
 	}
 ];

--- a/test/configCases/output-module/public-path/webpack.config.js
+++ b/test/configCases/output-module/public-path/webpack.config.js
@@ -201,7 +201,7 @@ module.exports = (env, { testPath }) => [
 			path: path.resolve(testPath, "./bundle15"),
 			module: true,
 			filename: "js/bundle15.mjs",
-			chunkFilename: "js/[id].bundle15.mjs",
+			chunkFilename: "js/[id].bundle15.mjs"
 		},
 		experiments: {
 			outputModule: true


### PR DESCRIPTION
This fixes an issue for esm modules where they incorrectly used publicPath to locate the module. See https://github.com/webpack/webpack/issues/19495#issuecomment-2890514344 and https://github.com/webpack/webpack/issues/19432#issuecomment-2890205522. It was introduced in https://github.com/webpack/webpack/pull/19434

fixes https://github.com/webpack/webpack/issues/19547