### PR TITLE
added loose autocomplete for output.publicPath

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -143,11 +143,11 @@ export type PublicPath = "auto" | RawPublicPath;
  * The 'publicPath' specifies the public URL address of the output files when referenced in a browser.
  */
 export type RawPublicPath =
-	| string
+	| (string & {})
 	| ((
 			pathData: import("../lib/Compilation").PathData,
 			assetInfo?: import("../lib/Compilation").AssetInfo
-	  ) => string);
+	  ) => "auto" | (string & {});
 /**
  * The name of the runtime chunk. If set a runtime chunk with this name is created or an existing entrypoint is used as runtime.
  */

--- a/types.d.ts
+++ b/types.d.ts
@@ -387,7 +387,7 @@ declare interface AssetResourceGeneratorOptions {
 	/**
 	 * The 'publicPath' specifies the public URL address of the output files when referenced in a browser.
 	 */
-	publicPath?: string | ((pathData: PathData, assetInfo?: AssetInfo) => string);
+	publicPath?: 'auto' | (string & {}) | ((pathData: PathData, assetInfo?: AssetInfo) => 'auto' | (string & {}));
 }
 declare class AsyncDependenciesBlock extends DependenciesBlock {
 	constructor(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->
when I am configuring my webpack, some values are of type string because they accept all strings. however, there are special cases where a value will have unique behavior.

A great example of this is output.publicPath. it is of type string but can also accept 'auto' for a specific use case.
I want to have autocomplete for auto while also letting the user pass any string.

**What kind of change does this PR introduce?**
Better typescript support
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
nothing
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
