### PR TITLE
test: add test case for ESM circular dependencies

### DIFF
--- a/test/configCases/module/circular-externals/external-a.mjs
+++ b/test/configCases/module/circular-externals/external-a.mjs
@@ -1,0 +1,7 @@
+import { externalValue as valueB } from "./external-b.mjs";
+
+export const externalValue = "external-A";
+
+export function getOtherExternal() {
+	return valueB;
+}

--- a/test/configCases/module/circular-externals/external-b.mjs
+++ b/test/configCases/module/circular-externals/external-b.mjs
@@ -1,0 +1,7 @@
+import { externalValue as valueA } from "./external-a.mjs";
+
+export const externalValue = "external-B";
+
+export function getOtherExternal() {
+	return valueA;
+}

--- a/test/configCases/module/circular-externals/index.js
+++ b/test/configCases/module/circular-externals/index.js
@@ -1,0 +1,21 @@
+import { valueA, getFromExternalA, callB } from "./module-a.js";
+import { valueB, getFromExternalB, callA } from "./module-b.js";
+import { externalValue as directExternalA } from "external-module-a";
+import { externalValue as directExternalB } from "external-module-b";
+
+it("should handle circular dependencies between internal modules", () => {
+	expect(valueA).toBe("module-A");
+	expect(valueB).toBe("module-B");
+	expect(callB()).toBe("module-B");
+	expect(callA()).toBe("module-A");
+});
+
+it("should handle imports from external modules", () => {
+	expect(getFromExternalA()).toBe("external-A");
+	expect(getFromExternalB()).toBe("external-B");
+});
+
+it("should handle direct imports from external modules", () => {
+	expect(directExternalA).toBe("external-A");
+	expect(directExternalB).toBe("external-B");
+});

--- a/test/configCases/module/circular-externals/module-a.js
+++ b/test/configCases/module/circular-externals/module-a.js
@@ -1,0 +1,12 @@
+import { valueB } from "./module-b.js";
+import { externalValue } from "external-module-a";
+
+export const valueA = "module-A";
+
+export function getFromExternalA() {
+	return externalValue;
+}
+
+export function callB() {
+	return valueB;
+}

--- a/test/configCases/module/circular-externals/module-b.js
+++ b/test/configCases/module/circular-externals/module-b.js
@@ -1,0 +1,12 @@
+import { valueA } from "./module-a.js";
+import { externalValue } from "external-module-b";
+
+export const valueB = "module-B";
+
+export function getFromExternalB() {
+	return externalValue;
+}
+
+export function callA() {
+	return valueA;
+}

--- a/test/configCases/module/circular-externals/test.config.js
+++ b/test/configCases/module/circular-externals/test.config.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	noTests: false,
+	findBundle(i, options) {
+		return ["main.mjs"];
+	},
+	beforeExecute() {
+		// Copy external module files to the test output directory
+		const testDirectory = path.join(
+			__dirname,
+			"../../../js/ConfigTestCases/module/circular-externals"
+		);
+		fs.mkdirSync(testDirectory, { recursive: true });
+		fs.copyFileSync(
+			path.join(__dirname, "external-a.mjs"),
+			path.join(testDirectory, "external-a.mjs")
+		);
+		fs.copyFileSync(
+			path.join(__dirname, "external-b.mjs"),
+			path.join(testDirectory, "external-b.mjs")
+		);
+	}
+};

--- a/test/configCases/module/circular-externals/webpack.config.js
+++ b/test/configCases/module/circular-externals/webpack.config.js
@@ -1,0 +1,23 @@
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	entry: "./index.js",
+	experiments: {
+		outputModule: true
+	},
+	output: {
+		module: true,
+		library: {
+			type: "module"
+		},
+		filename: "[name].mjs",
+		chunkFormat: "module"
+	},
+	externals: {
+		"external-module-a": "module ./external-a.mjs",
+		"external-module-b": "module ./external-b.mjs"
+	},
+	externalsType: "module",
+	optimization: {
+		concatenateModules: false
+	}
+};


### PR DESCRIPTION
This PR adds a test case to verify that webpack correctly handles circular dependencies when using ESM format with external modules.
