### PR TITLE
test: add test case for circular dependency with externals

### DIFF
--- a/test/configCases/module/circular-externals/external-a.mjs
+++ b/test/configCases/module/circular-externals/external-a.mjs
@@ -1,0 +1,10 @@
+import { externalValue as valueB, getOtherExternal as getB } from "./external-b.mjs";
+
+export const externalValue = "external-A";
+
+export function getOtherExternal() {
+	return valueB;
+}
+
+// Re-export to test circular re-exports
+export { getB as getOtherValue };

--- a/test/configCases/module/circular-externals/external-b.mjs
+++ b/test/configCases/module/circular-externals/external-b.mjs
@@ -1,0 +1,10 @@
+import { externalValue as valueA, getOtherExternal as getA } from "./external-a.mjs";
+
+export const externalValue = "external-B";
+
+export function getOtherExternal() {
+	return valueA;
+}
+
+// Re-export to test circular re-exports
+export { getA as getOtherValue };

--- a/test/configCases/module/circular-externals/index.js
+++ b/test/configCases/module/circular-externals/index.js
@@ -1,0 +1,51 @@
+import { valueA, getFromExternalA, callB } from "./module-a.js";
+import { valueB, getFromExternalB, callA } from "./module-b.js";
+import { externalValue as directExternalA } from "external-module-a";
+import { externalValue as directExternalB } from "external-module-b";
+
+it("should handle circular dependencies between internal modules", () => {
+	expect(valueA).toBe("module-A");
+	expect(valueB).toBe("module-B");
+	expect(callB()).toBe("module-B");
+	expect(callA()).toBe("module-A");
+});
+
+it("should handle imports from external modules", () => {
+	expect(getFromExternalA()).toBe("external-A");
+	expect(getFromExternalB()).toBe("external-B");
+});
+
+it("should handle direct imports from external modules", () => {
+	expect(directExternalA).toBe("external-A");
+	expect(directExternalB).toBe("external-B");
+});
+
+// ESM external modules with circular dependencies
+it("should maintain live bindings for ESM external modules", async () => {
+	// Import external modules that have circular dependencies
+	const moduleA = await import("external-module-a");
+	const moduleB = await import("external-module-b");
+
+	// Verify that circular dependencies are resolved correctly
+	expect(moduleA.externalValue).toBe("external-A");
+	expect(moduleB.externalValue).toBe("external-B");
+
+	// Verify that re-exports work correctly in circular scenarios
+	expect(moduleA.getOtherValue).toBeDefined();
+	expect(moduleB.getOtherValue).toBeDefined();
+
+	// Test that the modules maintain their identity (live bindings)
+	expect(await import("external-module-a")).toBe(moduleA);
+	expect(await import("external-module-b")).toBe(moduleB);
+});
+
+// Edge case: Multiple imports of the same external module
+it("should handle multiple imports of circular external modules", () => {
+	// This tests that the runtime module correctly caches external modules
+	const firstImportA = directExternalA;
+	const secondImportA = getFromExternalA();
+
+	// Both should reference the same value
+	expect(firstImportA).toBe(secondImportA);
+	expect(firstImportA).toBe("external-A");
+});

--- a/test/configCases/module/circular-externals/module-a.js
+++ b/test/configCases/module/circular-externals/module-a.js
@@ -1,0 +1,12 @@
+import { valueB } from "./module-b.js";
+import { externalValue } from "external-module-a";
+
+export const valueA = "module-A";
+
+export function getFromExternalA() {
+	return externalValue;
+}
+
+export function callB() {
+	return valueB;
+}

--- a/test/configCases/module/circular-externals/module-b.js
+++ b/test/configCases/module/circular-externals/module-b.js
@@ -1,0 +1,12 @@
+import { valueA } from "./module-a.js";
+import { externalValue } from "external-module-b";
+
+export const valueB = "module-B";
+
+export function getFromExternalB() {
+	return externalValue;
+}
+
+export function callA() {
+	return valueA;
+}

--- a/test/configCases/module/circular-externals/test.config.js
+++ b/test/configCases/module/circular-externals/test.config.js
@@ -1,24 +1,5 @@
-const fs = require("fs");
-const path = require("path");
-
 module.exports = {
 	findBundle() {
 		return "./main.mjs";
-	},
-	beforeExecute() {
-		// Copy external module files to the test output directory
-		const testDirectory = path.join(
-			__dirname,
-			"../../../js/ConfigTestCases/module/circular-externals"
-		);
-		fs.mkdirSync(testDirectory, { recursive: true });
-		fs.copyFileSync(
-			path.join(__dirname, "external-a.mjs"),
-			path.join(testDirectory, "external-a.mjs")
-		);
-		fs.copyFileSync(
-			path.join(__dirname, "external-b.mjs"),
-			path.join(testDirectory, "external-b.mjs")
-		);
 	}
 };

--- a/test/configCases/module/circular-externals/test.config.js
+++ b/test/configCases/module/circular-externals/test.config.js
@@ -1,0 +1,24 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	findBundle() {
+		return "./main.mjs";
+	},
+	beforeExecute() {
+		// Copy external module files to the test output directory
+		const testDirectory = path.join(
+			__dirname,
+			"../../../js/ConfigTestCases/module/circular-externals"
+		);
+		fs.mkdirSync(testDirectory, { recursive: true });
+		fs.copyFileSync(
+			path.join(__dirname, "external-a.mjs"),
+			path.join(testDirectory, "external-a.mjs")
+		);
+		fs.copyFileSync(
+			path.join(__dirname, "external-b.mjs"),
+			path.join(testDirectory, "external-b.mjs")
+		);
+	}
+};

--- a/test/configCases/module/circular-externals/webpack.config.js
+++ b/test/configCases/module/circular-externals/webpack.config.js
@@ -1,0 +1,23 @@
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	entry: "./index.js",
+	experiments: {
+		outputModule: true
+	},
+	output: {
+		module: true,
+		library: {
+			type: "module"
+		},
+		filename: "[name].mjs",
+		chunkFormat: "module"
+	},
+	externals: {
+		"external-module-a": "module ./external-a.mjs",
+		"external-module-b": "module ./external-b.mjs"
+	},
+	externalsType: "module",
+	optimization: {
+		concatenateModules: false
+	}
+};

--- a/test/configCases/module/circular-externals/webpack.config.js
+++ b/test/configCases/module/circular-externals/webpack.config.js
@@ -1,3 +1,6 @@
+const fs = require("fs");
+const path = require("path");
+
 /** @type {import("../../../../types").Configuration} */
 module.exports = {
 	entry: "./index.js",
@@ -19,5 +22,44 @@ module.exports = {
 	externalsType: "module",
 	optimization: {
 		concatenateModules: false
-	}
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.thisCompilation.tap(
+					"copy-external-files",
+					compilation => {
+						compilation.hooks.processAssets.tap(
+							{
+								name: "copy-external-files",
+								stage:
+									compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+							},
+							() => {
+								// Read the external module files
+								const externalA = fs.readFileSync(
+									path.join(__dirname, "external-a.mjs"),
+									"utf-8"
+								);
+								const externalB = fs.readFileSync(
+									path.join(__dirname, "external-b.mjs"),
+									"utf-8"
+								);
+
+								// Emit them as assets
+								compilation.emitAsset(
+									"external-a.mjs",
+									new compiler.webpack.sources.RawSource(externalA)
+								);
+								compilation.emitAsset(
+									"external-b.mjs",
+									new compiler.webpack.sources.RawSource(externalB)
+								);
+							}
+						);
+					}
+				);
+			}
+		}
+	]
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->





**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Tests verify that webpack correctly handles:
- Circular dependencies between ESM external modules (`external-a.mjs` ⇄ `external-b.mjs`)
- Live bindings preservation in circular scenarios
- Re-exports within circular dependencies
- Multiple imports of the same circular external module


Rel: #17121

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
yes

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
no

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
no need