### PR TITLE
perf: remove useless startupEntrypoint for ESM

### DIFF
--- a/lib/esm/ModuleChunkFormatPlugin.js
+++ b/lib/esm/ModuleChunkFormatPlugin.js
@@ -126,7 +126,6 @@ class ModuleChunkFormatPlugin {
 					if (chunk.hasRuntime()) return;
 					if (compilation.chunkGraph.getNumberOfEntryModules(chunk) > 0) {
 						set.add(RuntimeGlobals.require);
-						set.add(RuntimeGlobals.startupEntrypoint);
 						set.add(RuntimeGlobals.externalInstallChunk);
 					}
 				}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
perf: EntryStartup has been replaced by this [commit](https://github.com/webpack/webpack/commit/c69e37c39d12c8e3c761c883069d89f90cac817c#diff-c5d4f993897e06b2577f256473c37db962d87ba30de1d3d2c631d6eb68d7c95cL135)  because it does not support ESM scenarios.

**Did you add tests for your changes?**
No

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
No
