### PR TITLE
Use `acorn-import-phases` plugin

### DIFF
--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -7,6 +7,7 @@
 
 const vm = require("vm");
 const { Parser: AcornParser, tokTypes } = require("acorn");
+const acornImportPhases = require("acorn-import-phases");
 const { HookMap, SyncBailHook } = require("tapable");
 const Parser = require("../Parser");
 const StackedMap = require("../util/StackedMap");
@@ -180,147 +181,11 @@ const importAssertions = Parser =>
 		}
 	};
 
-// follow https://www.npmjs.com/acorn-import-defer if possible
-/** @type {(BaseParser: typeof AcornParser) => typeof AcornParser} */
-const importDefer = Parser =>
-	class extends Parser {
-		/**
-		 * @this {InstanceType<AcornParser>}
-		 * @param {ImportDeclaration} node import declaration
-		 * @returns {ImportDeclaration} import declaration
-		 */
-		parseImport(node) {
-			this._defer = false;
-			// eslint-disable-next-line no-warning-comments
-			// @ts-ignore
-			const result = super.parseImport(node);
-			if (this._defer) {
-				node.phase = "defer";
-			}
-			return result;
-		}
-
-		/**
-		 * @this {InstanceType<AcornParser>}
-		 * @returns {ImportSpecifier[]} import specifiers
-		 */
-		parseImportSpecifiers() {
-			// eslint-disable-next-line no-warning-comments
-			// @ts-ignore
-			if (!this.isContextual("defer")) return super.parseImportSpecifiers();
-
-			const deferId = this.parseIdent();
-			if (this.isContextual("from") || this.type === tokTypes.comma) {
-				const defaultSpecifier = this.startNodeAt(
-					deferId.start,
-					deferId.loc.start
-				);
-				defaultSpecifier.local = deferId;
-				this.checkLValSimple(deferId, /* BIND_LEXICAL */ 2);
-
-				const nodes = [
-					this.finishNode(defaultSpecifier, "ImportDefaultSpecifier")
-				];
-				if (this.eat(tokTypes.comma)) {
-					if (this.type !== tokTypes.star && this.type !== tokTypes.braceL) {
-						this.unexpected();
-					}
-					// eslint-disable-next-line no-warning-comments
-					// @ts-ignore
-					nodes.push(...super.parseImportSpecifiers());
-				}
-				return nodes;
-			}
-
-			this._defer = true;
-
-			if (this.type !== tokTypes.star) {
-				this.raiseRecoverable(
-					deferId.start,
-					"'import defer' can only be used with namespace imports."
-				);
-			}
-
-			// eslint-disable-next-line no-warning-comments
-			// @ts-ignore
-			return super.parseImportSpecifiers();
-		}
-
-		/**
-		 * @this {InstanceType<AcornParser>}
-		 * @param {boolean} forNew forNew
-		 * @returns {ImportExpression} import expression
-		 */
-		parseExprImport(forNew) {
-			// eslint-disable-next-line no-warning-comments
-			// @ts-ignore
-			const node = super.parseExprImport(forNew);
-
-			if (node.type === "MetaProperty" && node.property.name === "defer") {
-				if (this.type === tokTypes.parenL) {
-					const dynImport = this.parseDynamicImport(
-						this.startNodeAt(node.start, node.loc.start)
-					);
-					dynImport.phase = "defer";
-					return dynImport;
-				}
-				this.raiseRecoverable(
-					node.start,
-					"'import.defer' can only be used in a dynamic import."
-				);
-			}
-
-			return node;
-		}
-
-		/**
-		 * @this {InstanceType<AcornParser>}
-		 * @param {MetaProperty} node node
-		 * @returns {MetaProperty} import.meta
-		 */
-		parseImportMeta(node) {
-			this.next();
-
-			const containsEsc = this.containsEsc;
-			node.property = this.parseIdent(true);
-
-			const { name } = node.property;
-
-			if (name !== "meta" && name !== "defer") {
-				this.raiseRecoverable(
-					// eslint-disable-next-line no-warning-comments
-					// @ts-ignore
-					node.property.start,
-					"The only valid meta property for import is 'import.meta'"
-				);
-			}
-			if (containsEsc) {
-				this.raiseRecoverable(
-					// eslint-disable-next-line no-warning-comments
-					// @ts-ignore
-					node.start,
-					`'import.${name}' must not contain escaped characters`
-				);
-			}
-			if (
-				name === "meta" &&
-				this.options.sourceType !== "module" &&
-				!this.options.allowImportExportEverywhere
-			) {
-				this.raiseRecoverable(
-					// eslint-disable-next-line no-warning-comments
-					// @ts-ignore
-					node.start,
-					"Cannot use 'import.meta' outside a module"
-				);
-			}
-
-			return this.finishNode(node, "MetaProperty");
-		}
-	};
-
 // Syntax: https://developer.mozilla.org/en/SpiderMonkey/Parser_API
-const parser = AcornParser.extend(importAssertions, importDefer);
+const parser = AcornParser.extend(
+	importAssertions,
+	acornImportPhases({ source: false })
+);
 
 /** @typedef {Record<string, string> & { _isLegacyAssert?: boolean }} ImportAttributes */
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@webassemblyjs/wasm-edit": "^1.14.1",
     "@webassemblyjs/wasm-parser": "^1.14.1",
     "acorn": "^8.15.0",
+    "acorn-import-phases": "^1.0.3",
     "browserslist": "^4.24.0",
     "chrome-trace-event": "^1.0.2",
     "enhanced-resolve": "^5.17.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1851,6 +1851,11 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
+acorn-import-phases@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/acorn-import-phases/-/acorn-import-phases-1.0.3.tgz#30394a1dccee5f380aecb8205b8c69b4f7ae688e"
+  integrity sha512-jtKLnfoOzm28PazuQ4dVBcE9Jeo6ha1GAJvq3N0LlNOszmTfx+wSycBehn+FN0RnyeR77IBxN/qVYMw0Rlj0Xw==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

The parsing logic for `import defer` was copy-pasted from the https://www.npmjs.com/acorn-import-defer. I now:
- updated that package to also support parsing the `import source` proposal (https://github.com/tc39/proposal-source-phase-imports)
- renamed it to `acorn-import-phases`
- it's tested on Node.js 10.x+
- added proper type definitions, so that it can be easily used in the Webpack codebase.

My goal with that package was to share an implementation for `import defer` parsing across tools, so that parsing bugs don't need to be fixed across multiple repos. Let's use it? :)

Note that this PR explicitly disables `import source` parsing in that plugin, since webpack doesn't support it yet. It will make however implementing `import source` simpler, since you don't have to think about how to parse it.

**Did you add tests for your changes?**

Not needed

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing