### PR TITLE
fix: keep consistent CSS order for Merged dependencies

### DIFF
--- a/lib/ModuleGraph.js
+++ b/lib/ModuleGraph.js
@@ -10,6 +10,13 @@ const ExportsInfo = require("./ExportsInfo");
 const ModuleGraphConnection = require("./ModuleGraphConnection");
 const SortableSet = require("./util/SortableSet");
 const WeakTupleMap = require("./util/WeakTupleMap");
+const {
+	compareLocations,
+	compareNumbers,
+	compareSelect,
+	concatComparators,
+	keepOriginalOrder
+} = require("./util/comparators");
 
 /** @typedef {import("./Compilation").ModuleMemCaches} ModuleMemCaches */
 /** @typedef {import("./DependenciesBlock")} DependenciesBlock */
@@ -19,6 +26,8 @@ const WeakTupleMap = require("./util/WeakTupleMap");
 /** @typedef {import("./ModuleProfile")} ModuleProfile */
 /** @typedef {import("./RequestShortener")} RequestShortener */
 /** @typedef {import("./util/runtime").RuntimeSpec} RuntimeSpec */
+/** @typedef {import("./dependencies/HarmonyImportSideEffectDependency")} HarmonyImportSideEffectDependency */
+/** @typedef {import("./dependencies/HarmonyImportSpecifierDependency")} HarmonyImportSpecifierDependency */
 
 /**
  * @callback OptimizationBailoutFunction
@@ -27,6 +36,17 @@ const WeakTupleMap = require("./util/WeakTupleMap");
  */
 
 const EMPTY_SET = new Set();
+
+/**
+ * @param {number} num the input number (should be less than or equal to total)
+ * @param {number} total the total number used to determine decimal places
+ * @returns {number} the decimal representation of num
+ */
+function numberToDecimal(num, total) {
+	const totalDigitCount = total.toString().length;
+	const divisor = 10 ** totalDigitCount;
+	return num / divisor;
+}
 
 /**
  * @param {SortableSet<ModuleGraphConnection>} set input
@@ -158,6 +178,12 @@ class ModuleGraph {
 		 * @private
 		 */
 		this._cacheStage = undefined;
+
+		/**
+		 * @type {WeakMap<Dependency, number>}
+		 * @private
+		 */
+		this._depsUpdateParentMap = new WeakMap();
 	}
 
 	/**
@@ -184,6 +210,15 @@ class ModuleGraph {
 		dependency._parentDependenciesBlockIndex = indexInBlock;
 		dependency._parentDependenciesBlock = block;
 		dependency._parentModule = module;
+	}
+
+	/**
+	 * @param {Dependency} dependency the dependency
+	 * @param {number} index the index
+	 * @returns {void}
+	 */
+	setParentsIndex(dependency, index) {
+		dependency._parentDependenciesBlockIndex = index;
 	}
 
 	/**
@@ -263,6 +298,71 @@ class ModuleGraph {
 		(originMgm.outgoingConnections).add(newConnection);
 		const targetMgm = this._getModuleGraphModule(module);
 		targetMgm.incomingConnections.add(newConnection);
+	}
+
+	/**
+	 * @param {Dependency} dependency the referencing dependency
+	 * @param {ModuleGraphConnection=} connection the origin dependency
+	 * @param {Module=} parentModule the referenced module
+	 * @returns {void}
+	 */
+	updateParent(dependency, connection, parentModule) {
+		if (this._depsUpdateParentMap.has(dependency)) {
+			return;
+		}
+		if (!connection || !parentModule) {
+			return;
+		}
+		const originDependency = connection.dependency;
+		// src/index.js
+		// import { c } from "lib/c" -> c = 0
+		// import { a, b } from "lib": a and b have the same source order -> a = b = 1
+		const currentSourceOrder =
+			/** @type { HarmonyImportSideEffectDependency | HarmonyImportSpecifierDependency} */ (
+				dependency
+			).sourceOrder;
+		// lib/index.js
+		// import { a } from "lib/a" -> a = 0
+		// import { b } from "lib/b" -> b = 1
+		const originSourceOrder =
+			/** @type { HarmonyImportSideEffectDependency | HarmonyImportSpecifierDependency} */ (
+				originDependency
+			).sourceOrder;
+		if (
+			typeof currentSourceOrder === "number" &&
+			typeof originSourceOrder === "number"
+		) {
+			// src/index.js
+			// import { c } from "lib/c" -> c = 0
+			// import { a } from "lib/a" -> a = 1 + 0.0
+			// import { b } from "lib/b" -> b = 1 + 0.1
+			const newSourceOrder =
+				currentSourceOrder +
+				numberToDecimal(originSourceOrder, parentModule.dependencies.length);
+
+			this._depsUpdateParentMap.set(dependency, newSourceOrder);
+
+			// TODO: extract this to a separate function
+			parentModule.dependencies.sort(
+				concatComparators(
+					compareSelect(
+						a =>
+							this._depsUpdateParentMap.has(a)
+								? this._depsUpdateParentMap.get(a)
+								: /** @type { HarmonyImportSideEffectDependency | HarmonyImportSpecifierDependency} */ (
+										a
+									).sourceOrder,
+						compareNumbers
+					),
+					compareSelect(a => a.loc, compareLocations),
+					keepOriginalOrder(parentModule.dependencies)
+				)
+			);
+
+			for (const [index, dep] of parentModule.dependencies.entries()) {
+				this.setParentsIndex(dep, index);
+			}
+		}
 	}
 
 	/**

--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -353,6 +353,13 @@ class SideEffectsFlagPlugin {
 											if (!target) continue;
 
 											moduleGraph.updateModule(dep, target.module);
+											moduleGraph.updateParent(
+												dep,
+												/** @type {ModuleGraphConnection} */ (
+													target.connection
+												),
+												/** @type {Module} */ (connection.originModule)
+											);
 											moduleGraph.addExplanation(
 												dep,
 												"(skipped side-effect-free modules)"

--- a/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
+++ b/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
@@ -3496,6 +3496,8 @@ exports[`ConfigCacheTestCases css css-modules-no-space exported tests should all
 "
 `;
 
+exports[`ConfigCacheTestCases css css-order2 exported tests keep consistent css order 1`] = `".dependency2::before {	content: \\"dependency2\\";}.dependency::before {	content: \\"dependency\\";}"`;
+
 exports[`ConfigCacheTestCases css escape-unescape exported tests should work with URLs in CSS: classes 1`] = `
 Object {
   "#": "_style_modules_css-#",

--- a/test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -3496,6 +3496,8 @@ exports[`ConfigTestCases css css-modules-no-space exported tests should allow to
 "
 `;
 
+exports[`ConfigTestCases css css-order2 exported tests keep consistent css order 1`] = `".dependency2::before {	content: \\"dependency2\\";}.dependency::before {	content: \\"dependency\\";}"`;
+
 exports[`ConfigTestCases css escape-unescape exported tests should work with URLs in CSS: classes 1`] = `
 Object {
   "#": "_style_modules_css-#",

--- a/test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -3446,8 +3446,8 @@ cacheable modules X bytes
   ./first.js X bytes [built] [code generated]
   ./second.js X bytes [built] [code generated]
   ./vendor.js X bytes [built] [code generated]
-  ./module_first.js X bytes [built] [code generated]
   ./common2.js X bytes [built] [code generated]
+  ./module_first.js X bytes [built] [code generated]
   ./lazy_first.js X bytes [built] [code generated]
   ./lazy_shared.js X bytes [built] [code generated]
   ./lazy_second.js X bytes [built] [code generated]
@@ -3473,8 +3473,8 @@ cacheable modules X bytes
       ModuleConcatenation bailout: Cannot concat with ./common_lazy_shared.js: Module ./common_lazy_shared.js is referenced from different chunks by these modules: ./lazy_shared.js
     ./common_lazy_shared.js X bytes [built] [code generated]
   orphan modules X bytes [orphan]
-    ./module_first.js X bytes [orphan] [built]
     ./common2.js X bytes [orphan] [built]
+    ./module_first.js X bytes [orphan] [built]
     ./common.js X bytes [orphan] [built]
       ModuleConcatenation bailout: Module is not in any chunk
     ./common_lazy.js X bytes [orphan] [built]
@@ -3548,10 +3548,10 @@ cacheable modules X KiB
     |   [no exports]
     |   [no exports used]
     |   Statement (ExpressionStatement) with side effects in source code at 4:0-30
-    | ./node_modules/module-with-export/index.js X KiB [built]
-    |   [only some exports used: smallVar]
     | ./node_modules/big-module/a.js X bytes [built]
     |   [only some exports used: a]
+    | ./node_modules/module-with-export/index.js X KiB [built]
+    |   [only some exports used: smallVar]
   ./node_modules/module-with-export/emptyModule.js X bytes [built] [code generated]
     [used exports unknown]
     ModuleConcatenation bailout: Module is not an ECMAScript module

--- a/test/configCases/css/css-order2/component.js
+++ b/test/configCases/css/css-order2/component.js
@@ -1,0 +1,6 @@
+import { dependency, dependency2 } from "./dependency";
+
+export function component() {
+	dependency();
+	dependency2();
+}

--- a/test/configCases/css/css-order2/dependency/dependency.css
+++ b/test/configCases/css/css-order2/dependency/dependency.css
@@ -1,0 +1,3 @@
+.dependency::before {
+	content: "dependency";
+}

--- a/test/configCases/css/css-order2/dependency/dependency.js
+++ b/test/configCases/css/css-order2/dependency/dependency.js
@@ -1,0 +1,5 @@
+import styles from "./dependency.css";
+
+export function dependency() {
+	return styles !== undefined;
+}

--- a/test/configCases/css/css-order2/dependency/dependency2.css
+++ b/test/configCases/css/css-order2/dependency/dependency2.css
@@ -1,0 +1,3 @@
+.dependency2::before {
+	content: "dependency2";
+}

--- a/test/configCases/css/css-order2/dependency/dependency2.js
+++ b/test/configCases/css/css-order2/dependency/dependency2.js
@@ -1,0 +1,5 @@
+import styles from "./dependency2.css";
+
+export function dependency2() {
+	return styles !== undefined;
+}

--- a/test/configCases/css/css-order2/dependency/index.js
+++ b/test/configCases/css/css-order2/dependency/index.js
@@ -1,0 +1,2 @@
+export * from "./dependency2";
+export * from "./dependency";

--- a/test/configCases/css/css-order2/dependency/package.json
+++ b/test/configCases/css/css-order2/dependency/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "dependency",
+  "version": "1.0.0",
+  "private": true,
+  "sideEffects": false,
+  "main": "index.js"
+}

--- a/test/configCases/css/css-order2/index.js
+++ b/test/configCases/css/css-order2/index.js
@@ -1,0 +1,14 @@
+const { component } = require("./component");
+component()
+
+// https://github.com/webpack/webpack/issues/18961
+// https://github.com/jantimon/reproduction-webpack-css-order
+it("keep consistent css order", function() {
+	const fs = __non_webpack_require__("fs");
+	let source = fs.readFileSync(__dirname + "/main.css", "utf-8");
+	expect(removeComments(source)).toMatchSnapshot()
+});
+
+function removeComments(source) {
+	return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\n/g, "");
+}

--- a/test/configCases/css/css-order2/package.json
+++ b/test/configCases/css/css-order2/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "css-order2",
+    "version": "1.0.0",
+    "sideEffects": false,
+    "devDependencies": {
+      "mini-css-extract-plugin": "^2.9.0"
+    }
+  }

--- a/test/configCases/css/css-order2/webpack.config.js
+++ b/test/configCases/css/css-order2/webpack.config.js
@@ -1,0 +1,43 @@
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	devtool: false,
+	target: "web",
+	entry: "./index.js",
+	mode: "development",
+	optimization: {
+		concatenateModules: false
+	},
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				use: [
+					{
+						loader: MiniCssExtractPlugin.loader
+					},
+					{
+						loader: "css-loader",
+						options: {
+							esModule: true,
+							modules: {
+								namedExport: false,
+								localIdentName: "[name]"
+							}
+						}
+					}
+				]
+			}
+		]
+	},
+	plugins: [
+		new MiniCssExtractPlugin({
+			filename: "[name].css"
+		})
+	],
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -9874,6 +9874,7 @@ declare class ModuleGraph {
 		module: Module,
 		indexInBlock?: number
 	): void;
+	setParentsIndex(dependency: Dependency, index: number): void;
 	getParentModule(dependency: Dependency): undefined | Module;
 	getParentBlock(dependency: Dependency): undefined | DependenciesBlock;
 	getParentBlockIndex(dependency: Dependency): number;
@@ -9883,6 +9884,11 @@ declare class ModuleGraph {
 		module: Module
 	): void;
 	updateModule(dependency: Dependency, module: Module): void;
+	updateParent(
+		dependency: Dependency,
+		connection?: ModuleGraphConnection,
+		parentModule?: Module
+	): void;
 	removeConnection(dependency: Dependency): void;
 	addExplanation(dependency: Dependency, explanation: string): void;
 	cloneModuleAttributes(sourceModule: Module, targetModule: Module): void;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Fixes [webpack-side-effects-optimization-keep-connections-order](https://github.com/ahabhgk/webpack-side-effects-optimization-keep-connections-order/blob/main/reexports/webpack.config.js#L18)

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
No