### PR TITLE
fix: Dependency without the sourceOrder attribute must keep their original index

### DIFF
--- a/lib/ModuleGraph.js
+++ b/lib/ModuleGraph.js
@@ -10,7 +10,7 @@ const ExportsInfo = require("./ExportsInfo");
 const ModuleGraphConnection = require("./ModuleGraphConnection");
 const SortableSet = require("./util/SortableSet");
 const WeakTupleMap = require("./util/WeakTupleMap");
-const { compareNumbers, compareSelect } = require("./util/comparators");
+const { sortWithSourceOrder } = require("./util/comparators");
 
 /** @typedef {import("./Compilation").ModuleMemCaches} ModuleMemCaches */
 /** @typedef {import("./DependenciesBlock")} DependenciesBlock */
@@ -22,6 +22,7 @@ const { compareNumbers, compareSelect } = require("./util/comparators");
 /** @typedef {import("./util/runtime").RuntimeSpec} RuntimeSpec */
 /** @typedef {import("./dependencies/HarmonyImportSideEffectDependency")} HarmonyImportSideEffectDependency */
 /** @typedef {import("./dependencies/HarmonyImportSpecifierDependency")} HarmonyImportSpecifierDependency */
+/** @typedef {import("./util/comparators").DependencySourceOrder} DependencySourceOrder */
 
 /**
  * @callback OptimizationBailoutFunction
@@ -30,17 +31,6 @@ const { compareNumbers, compareSelect } = require("./util/comparators");
  */
 
 const EMPTY_SET = new Set();
-
-/**
- * @param {number} num the input number (should be less than or equal to total)
- * @param {number} total the total number used to determine decimal places
- * @returns {number} the decimal representation of num
- */
-function numberToDecimal(num, total) {
-	const totalDigitCount = total.toString().length;
-	const divisor = 10 ** totalDigitCount;
-	return num / divisor;
-}
 
 /**
  * @param {SortableSet<ModuleGraphConnection>} set input
@@ -174,7 +164,7 @@ class ModuleGraph {
 		this._cacheStage = undefined;
 
 		/**
-		 * @type {WeakMap<Dependency, number>}
+		 * @type {WeakMap<Dependency, DependencySourceOrder>}
 		 * @private
 		 */
 		this._dependencySourceOrderMap = new WeakMap();
@@ -308,14 +298,17 @@ class ModuleGraph {
 			return;
 		}
 		const originDependency = connection.dependency;
+
 		// src/index.js
 		// import { c } from "lib/c" -> c = 0
-		// import { a, b } from "lib": a and b have the same source order -> a = b = 1
+		// import { a, b } from "lib" -> a and b have the same source order -> a = b = 1
+		// import { d } from "lib/d" -> d = 2
 		const currentSourceOrder =
 			/** @type { HarmonyImportSideEffectDependency | HarmonyImportSpecifierDependency} */ (
 				dependency
 			).sourceOrder;
-		// lib/index.js
+
+		// lib/index.js (reexport)
 		// import { a } from "lib/a" -> a = 0
 		// import { b } from "lib/b" -> b = 1
 		const originSourceOrder =
@@ -328,26 +321,19 @@ class ModuleGraph {
 		) {
 			// src/index.js
 			// import { c } from "lib/c" -> c = 0
-			// import { a } from "lib/a" -> a = 1 + 0.0
-			// import { b } from "lib/b" -> b = 1 + 0.1
-			const newSourceOrder =
-				currentSourceOrder +
-				numberToDecimal(originSourceOrder, parentModule.dependencies.length);
-
-			this._dependencySourceOrderMap.set(dependency, newSourceOrder);
+			// import { a } from "lib/a" -> a = 1.0 = 1(main) + 0.0(sub)
+			// import { b } from "lib/b" -> b = 1.1 = 1(main) + 0.1(sub)
+			// import { d } from "lib/d" -> d = 2
+			this._dependencySourceOrderMap.set(dependency, {
+				main: currentSourceOrder,
+				sub: originSourceOrder
+			});
 
 			// If dependencies like HarmonyImportSideEffectDependency and HarmonyImportSpecifierDependency have a SourceOrder,
 			// we sort based on it; otherwise, we preserve the original order.
-			parentModule.dependencies.sort(
-				compareSelect(
-					a =>
-						this._dependencySourceOrderMap.has(a)
-							? this._dependencySourceOrderMap.get(a)
-							: /** @type { HarmonyImportSideEffectDependency | HarmonyImportSpecifierDependency} */ (
-									a
-								).sourceOrder,
-					compareNumbers
-				)
+			sortWithSourceOrder(
+				parentModule.dependencies,
+				this._dependencySourceOrderMap
 			);
 
 			for (const [index, dep] of parentModule.dependencies.entries()) {

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -38,10 +38,10 @@ const { isSubset } = require("./util/SetHelpers");
 const { getScheme } = require("./util/URLAbsoluteSpecifier");
 const {
 	compareLocations,
-	compareNumbers,
 	compareSelect,
 	concatComparators,
-	keepOriginalOrder
+	keepOriginalOrder,
+	sortWithSourceOrder
 } = require("./util/comparators");
 const createHash = require("./util/createHash");
 const { createFakeHook } = require("./util/deprecation");
@@ -1220,20 +1220,11 @@ class NormalModule extends Module {
 			const handleParseResult = () => {
 				this.dependencies.sort(
 					concatComparators(
-						// For HarmonyImportSideEffectDependency and HarmonyImportSpecifierDependency, we should prioritize import order to match the behavior of running modules directly in a JS engine without a bundler.
-						// For other types like ConstDependency, we can instead prioritize usage order.
-						// https://github.com/webpack/webpack/pull/19686
-						compareSelect(
-							a =>
-								/** @type {HarmonyImportSideEffectDependency | HarmonyImportSpecifierDependency} */ (
-									a
-								).sourceOrder,
-							compareNumbers
-						),
 						compareSelect(a => a.loc, compareLocations),
 						keepOriginalOrder(this.dependencies)
 					)
 				);
+				sortWithSourceOrder(this.dependencies, new WeakMap());
 				this._initBuildHash(compilation);
 				this._lastSuccessfulBuildMeta =
 					/** @type {BuildMeta} */

--- a/lib/util/comparators.js
+++ b/lib/util/comparators.js
@@ -13,8 +13,17 @@ const { compareRuntime } = require("./runtime");
 /** @typedef {import("../ChunkGraph").ModuleId} ModuleId */
 /** @typedef {import("../ChunkGroup")} ChunkGroup */
 /** @typedef {import("../Dependency").DependencyLocation} DependencyLocation */
+/** @typedef {import("../Dependency")} Dependency */
+/** @typedef {import("../dependencies/HarmonyImportSideEffectDependency")} HarmonyImportSideEffectDependency */
+/** @typedef {import("../dependencies/HarmonyImportSpecifierDependency")} HarmonyImportSpecifierDependency */
 /** @typedef {import("../Module")} Module */
 /** @typedef {import("../ModuleGraph")} ModuleGraph */
+
+/**
+ * @typedef {object} DependencySourceOrder
+ * @property {number} main the main source order
+ * @property {number} sub the sub source order
+ */
 
 /**
  * @template T
@@ -497,6 +506,95 @@ const compareChunksNatural = chunkGraph => {
 	);
 };
 
+/**
+ * For HarmonyImportSideEffectDependency and HarmonyImportSpecifierDependency, we should prioritize import order to match the behavior of running modules directly in a JS engine without a bundler.
+ * For other types like ConstDependency, we can instead prioritize usage order.
+ * https://github.com/webpack/webpack/pull/19686
+ * @param {Dependency[]} dependencies dependencies
+ * @param {WeakMap<Dependency, DependencySourceOrder>} dependencySourceOrderMap dependency source order map
+ * @returns {void}
+ */
+const sortWithSourceOrder = (dependencies, dependencySourceOrderMap) => {
+	/**
+	 * @param {Dependency} dep dependency
+	 * @returns {number} source order
+	 */
+	const getSourceOrder = dep => {
+		if (dependencySourceOrderMap.has(dep)) {
+			const { main } = /** @type {DependencySourceOrder} */ (
+				dependencySourceOrderMap.get(dep)
+			);
+			return main;
+		}
+		return /** @type { HarmonyImportSideEffectDependency | HarmonyImportSpecifierDependency} */ (
+			dep
+		).sourceOrder;
+	};
+
+	/**
+	 * If the sourceOrder is a number, it means the dependency needs to be sorted.
+	 * @param {number | undefined} sourceOrder sourceOrder
+	 * @returns {boolean} needReSort
+	 */
+	const needReSort = sourceOrder => {
+		if (typeof sourceOrder === "number") {
+			return true;
+		}
+		return false;
+	};
+
+	// Extract dependencies with sourceOrder and sort them
+	const withSourceOrder = [];
+
+	// First pass: collect dependencies with sourceOrder
+	for (let i = 0; i < dependencies.length; i++) {
+		const dep = dependencies[i];
+		const sourceOrder = getSourceOrder(dep);
+
+		if (needReSort(sourceOrder)) {
+			withSourceOrder.push({ dep, sourceOrder, originalIndex: i });
+		}
+	}
+
+	if (withSourceOrder.length === 0) {
+		return;
+	}
+
+	// Sort dependencies with sourceOrder
+	withSourceOrder.sort((a, b) => {
+		// Handle both dependencies in map case
+		if (
+			dependencySourceOrderMap.has(a.dep) &&
+			dependencySourceOrderMap.has(b.dep)
+		) {
+			const { main: mainA, sub: subA } = /** @type {DependencySourceOrder} */ (
+				dependencySourceOrderMap.get(a.dep)
+			);
+			const { main: mainB, sub: subB } = /** @type {DependencySourceOrder} */ (
+				dependencySourceOrderMap.get(b.dep)
+			);
+			if (mainA === mainB) {
+				return compareNumbers(subA, subB);
+			}
+			return compareNumbers(mainA, mainB);
+		}
+
+		return compareNumbers(a.sourceOrder, b.sourceOrder);
+	});
+
+	// Second pass: build result array
+	let sortedIndex = 0;
+	for (let i = 0; i < dependencies.length; i++) {
+		const dep = dependencies[i];
+		const sourceOrder = getSourceOrder(dep);
+
+		if (needReSort(sourceOrder)) {
+			dependencies[i] = withSourceOrder[sortedIndex].dep;
+			sortedIndex++;
+		}
+	}
+};
+
 module.exports.compareChunkGroupsByIndex = compareChunkGroupsByIndex;
 /** @type {ParameterizedComparator<ChunkGraph, Chunk>} */
 module.exports.compareChunks =
@@ -548,3 +646,4 @@ module.exports.compareStringsNumeric = compareStringsNumeric;
 module.exports.concatComparators = concatComparators;
 
 module.exports.keepOriginalOrder = keepOriginalOrder;
+module.exports.sortWithSourceOrder = sortWithSourceOrder;

--- a/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
+++ b/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
@@ -3500,6 +3500,8 @@ exports[`ConfigCacheTestCases css css-order exported tests keep consistent css o
 
 exports[`ConfigCacheTestCases css css-order2 exported tests keep consistent css order 1`] = `".dependency2::before {	content: \\"dependency2\\";}.dependency::before {	content: \\"dependency\\";}"`;
 
+exports[`ConfigCacheTestCases css css-order3 exported tests keep consistent css order 1`] = `".dependency3::before {	content: \\"dependency3\\";}.dependency2::before {	content: \\"dependency2\\";}.dependency::before {	content: \\"dependency\\";}"`;
+
 exports[`ConfigCacheTestCases css escape-unescape exported tests should work with URLs in CSS: classes 1`] = `
 Object {
   "#": "_style_modules_css-#",

--- a/test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -3500,6 +3500,8 @@ exports[`ConfigTestCases css css-order exported tests keep consistent css order 
 
 exports[`ConfigTestCases css css-order2 exported tests keep consistent css order 1`] = `".dependency2::before {	content: \\"dependency2\\";}.dependency::before {	content: \\"dependency\\";}"`;
 
+exports[`ConfigTestCases css css-order3 exported tests keep consistent css order 1`] = `".dependency3::before {	content: \\"dependency3\\";}.dependency2::before {	content: \\"dependency2\\";}.dependency::before {	content: \\"dependency\\";}"`;
+
 exports[`ConfigTestCases css escape-unescape exported tests should work with URLs in CSS: classes 1`] = `
 Object {
   "#": "_style_modules_css-#",

--- a/test/compareSourceOrder.unittest.js
+++ b/test/compareSourceOrder.unittest.js
@@ -1,0 +1,123 @@
+"use strict";
+
+const { sortWithSourceOrder } = require("../lib/util/comparators");
+
+describe("sortWithSourceOrder", () => {
+	let dependencySourceOrderMap;
+
+	beforeEach(() => {
+		dependencySourceOrderMap = new WeakMap();
+	});
+
+	it("dependency without the sourceOrder attribute must keep their original index in the array", () => {
+		const deps = [
+			// HarmonyImportSpecifierDependency
+			{ name: "b", sourceOrder: 10 },
+			// CommonJSRequireDependency
+			{ name: "a" },
+			// CommonJSRequireDependency
+			{ name: "d" },
+			// HarmonyImportSpecifierDependency
+			{ name: "c", sourceOrder: 5 }
+		];
+
+		sortWithSourceOrder(deps, dependencySourceOrderMap);
+
+		expect(deps.map(d => d.name)).toEqual(["c", "a", "d", "b"]);
+	});
+
+	it("should sort dependencies by main order when both in map", () => {
+		const deps = [
+			{ name: "b", sourceOrder: 5 },
+			{ name: "a", sourceOrder: 10 },
+			{ name: "c", sourceOrder: 3 }
+		];
+
+		// Add to map with main and sub orders
+		dependencySourceOrderMap.set(deps[0], { main: 5, sub: 0 });
+		dependencySourceOrderMap.set(deps[1], { main: 10, sub: 0 });
+		dependencySourceOrderMap.set(deps[2], { main: 3, sub: 0 });
+
+		sortWithSourceOrder(deps, dependencySourceOrderMap);
+
+		expect(deps.map(d => d.name)).toEqual(["c", "b", "a"]);
+	});
+
+	it("should sort by sub order when main order is same", () => {
+		const deps = [
+			{ name: "b", sourceOrder: 5 },
+			{ name: "a", sourceOrder: 5 },
+			{ name: "c", sourceOrder: 5 }
+		];
+
+		// Add to map with same main but different sub orders
+		dependencySourceOrderMap.set(deps[0], { main: 5, sub: 3 });
+		dependencySourceOrderMap.set(deps[1], { main: 5, sub: 1 });
+		dependencySourceOrderMap.set(deps[2], { main: 5, sub: 2 });
+
+		sortWithSourceOrder(deps, dependencySourceOrderMap);
+
+		expect(deps.map(d => d.name)).toEqual(["a", "c", "b"]);
+	});
+
+	it("should sort mixed dependencies - some in map, some not", () => {
+		const deps = [
+			{ name: "b", sourceOrder: 10 },
+			{ name: "a", sourceOrder: 5 },
+			{ name: "c", sourceOrder: 15 }
+		];
+
+		// Only add one to map
+		dependencySourceOrderMap.set(deps[0], { main: 10, sub: 0 });
+
+		sortWithSourceOrder(deps, dependencySourceOrderMap);
+
+		expect(deps.map(d => d.name)).toEqual(["a", "b", "c"]);
+	});
+
+	it("should sort by sourceOrder when none in map", () => {
+		const deps = [
+			{ name: "b", sourceOrder: 10 },
+			{ name: "a", sourceOrder: 5 },
+			{ name: "c", sourceOrder: 15 }
+		];
+
+		sortWithSourceOrder(deps, dependencySourceOrderMap);
+
+		expect(deps.map(d => d.name)).toEqual(["a", "b", "c"]);
+	});
+
+	it("should sort complex scenario with negative and decimal values", () => {
+		const deps = [
+			{ name: "f", sourceOrder: 10 },
+			{ name: "e", sourceOrder: 5 },
+			{ name: "d", sourceOrder: 20 },
+			{ name: "c", sourceOrder: 10 },
+			{ name: "b", sourceOrder: 5 },
+			{ name: "a", sourceOrder: 3 }
+		];
+
+		dependencySourceOrderMap.set(deps[0], { main: 10, sub: 0.5 });
+		dependencySourceOrderMap.set(deps[1], { main: 5, sub: 0.5 });
+		dependencySourceOrderMap.set(deps[2], { main: 20, sub: 0 });
+		dependencySourceOrderMap.set(deps[3], { main: 10, sub: 0.25 });
+		dependencySourceOrderMap.set(deps[4], { main: 5, sub: 0.25 });
+		dependencySourceOrderMap.set(deps[5], { main: 3, sub: 0 });
+
+		sortWithSourceOrder(deps, dependencySourceOrderMap);
+
+		expect(deps.map(d => d.name)).toEqual(["a", "b", "e", "c", "f", "d"]);
+	});
+
+	it("should maintain stable sort for equal values", () => {
+		const deps = [
+			{ name: "b", sourceOrder: 5 },
+			{ name: "a", sourceOrder: 5 },
+			{ name: "c", sourceOrder: 5 }
+		];
+
+		sortWithSourceOrder(deps, dependencySourceOrderMap);
+
+		expect(deps.map(d => d.name)).toEqual(["b", "a", "c"]);
+	});
+});

--- a/test/configCases/css/css-order3/component.js
+++ b/test/configCases/css/css-order3/component.js
@@ -1,0 +1,8 @@
+const { dependency3 } = require("./dependency/dependency3");
+import { dependency, dependency2 } from "./dependency";
+
+export function component() {
+	dependency();
+	dependency2();
+	dependency3();
+}

--- a/test/configCases/css/css-order3/dependency/dependency.css
+++ b/test/configCases/css/css-order3/dependency/dependency.css
@@ -1,0 +1,3 @@
+.dependency::before {
+	content: "dependency";
+}

--- a/test/configCases/css/css-order3/dependency/dependency.js
+++ b/test/configCases/css/css-order3/dependency/dependency.js
@@ -1,0 +1,5 @@
+import styles from "./dependency.css";
+
+export function dependency() {
+	return styles !== undefined;
+}

--- a/test/configCases/css/css-order3/dependency/dependency2.css
+++ b/test/configCases/css/css-order3/dependency/dependency2.css
@@ -1,0 +1,3 @@
+.dependency2::before {
+	content: "dependency2";
+}

--- a/test/configCases/css/css-order3/dependency/dependency2.js
+++ b/test/configCases/css/css-order3/dependency/dependency2.js
@@ -1,0 +1,5 @@
+import styles from "./dependency2.css";
+
+export function dependency2() {
+	return styles !== undefined;
+}

--- a/test/configCases/css/css-order3/dependency/dependency3.css
+++ b/test/configCases/css/css-order3/dependency/dependency3.css
@@ -1,0 +1,3 @@
+.dependency3::before {
+	content: "dependency3";
+}

--- a/test/configCases/css/css-order3/dependency/dependency3.js
+++ b/test/configCases/css/css-order3/dependency/dependency3.js
@@ -1,0 +1,5 @@
+import styles from "./dependency3.css";
+
+export function dependency3() {
+	return styles !== undefined;
+}

--- a/test/configCases/css/css-order3/dependency/index.js
+++ b/test/configCases/css/css-order3/dependency/index.js
@@ -1,0 +1,2 @@
+export * from "./dependency2";
+export * from "./dependency";

--- a/test/configCases/css/css-order3/dependency/package.json
+++ b/test/configCases/css/css-order3/dependency/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "dependency",
+  "version": "1.0.0",
+  "private": true,
+  "sideEffects": false,
+  "main": "index.js"
+}

--- a/test/configCases/css/css-order3/index.js
+++ b/test/configCases/css/css-order3/index.js
@@ -1,0 +1,14 @@
+const { component } = require("./component");
+component()
+
+// https://github.com/webpack/webpack/issues/18961
+// https://github.com/jantimon/reproduction-webpack-css-order
+it("keep consistent css order", function() {
+	const fs = __non_webpack_require__("fs");
+	let source = fs.readFileSync(__dirname + "/main.css", "utf-8");
+	expect(removeComments(source)).toMatchSnapshot()
+});
+
+function removeComments(source) {
+	return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\n/g, "");
+}

--- a/test/configCases/css/css-order3/package.json
+++ b/test/configCases/css/css-order3/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "css-order2",
+    "version": "1.0.0",
+    "sideEffects": false,
+    "devDependencies": {
+      "mini-css-extract-plugin": "^2.9.0"
+    }
+  }

--- a/test/configCases/css/css-order3/webpack.config.js
+++ b/test/configCases/css/css-order3/webpack.config.js
@@ -1,0 +1,43 @@
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	devtool: false,
+	target: "web",
+	entry: "./index.js",
+	mode: "development",
+	optimization: {
+		concatenateModules: false
+	},
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				use: [
+					{
+						loader: MiniCssExtractPlugin.loader
+					},
+					{
+						loader: "css-loader",
+						options: {
+							esModule: true,
+							modules: {
+								namedExport: false,
+								localIdentName: "[name]"
+							}
+						}
+					}
+				]
+			}
+		]
+	},
+	plugins: [
+		new MiniCssExtractPlugin({
+			filename: "[name].css"
+		})
+	],
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -3720,6 +3720,17 @@ declare interface DependencyConstructor {
 	new (...args: any[]): Dependency;
 }
 type DependencyLocation = SyntheticDependencyLocation | RealDependencyLocation;
+declare interface DependencySourceOrder {
+	/**
+	 * the main source order
+	 */
+	main: number;
+
+	/**
+	 * the sub source order
+	 */
+	sub: number;
+}
 declare class DependencyTemplate {
 	constructor();
 	apply(
@@ -17801,6 +17812,10 @@ declare namespace exports {
 				...cRest: Comparator<T>[]
 			) => Comparator<T>;
 			export let keepOriginalOrder: <T>(iterable: Iterable<T>) => Comparator<T>;
+			export let sortWithSourceOrder: (
+				dependencies: Dependency[],
+				dependencySourceOrderMap: WeakMap<Dependency, DependencySourceOrder>
+			) => void;
 		}
 		export namespace runtime {
 			export let compareRuntime: (a: RuntimeSpec, b: RuntimeSpec) => 0 | 1 | -1;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Fixes https://github.com/webpack/webpack/pull/19686

```diff
it("dependency without the sourceOrder attribute must keep their original index in the array", () => {
    const deps = [
	    // HarmonyImportSpecifierDependency
	    { name: "b", sourceOrder: 10 },
	    // CommonJSRequireDependency
	    { name: "a" },
	    // CommonJSRequireDependency
	    { name: "d" },
	    // HarmonyImportSpecifierDependency
	    { name: "c", sourceOrder: 5 }
    ];
    
    sortWithSourceOrder(deps, dependencySourceOrderMap);

+   expect(deps.map(d => d.name)).toEqual(["c", "a", "d", "b"]); // ✅
-   expect(deps.map(d => d.name)).toEqual(["c", "b", "a", "d"]); // ❌
});
```


**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
No