### PR TITLE
fix: keep module traversal consistent across reexport scenarios

### DIFF
--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -320,8 +320,17 @@ class SideEffectsFlagPlugin {
 												({ module }) =>
 													module.getSideEffectsConnectionState(moduleGraph) ===
 													false,
-												({ module: newModule, export: exportName }) => {
+												({
+													module: newModule,
+													export: exportName,
+													connection: targetConnection
+												}) => {
 													moduleGraph.updateModule(dep, newModule);
+													moduleGraph.updateParent(
+														dep,
+														targetConnection,
+														/** @type {Module} */ (connection.originModule)
+													);
 													moduleGraph.addExplanation(
 														dep,
 														"(skipped side-effect-free modules)"

--- a/lib/util/comparators.js
+++ b/lib/util/comparators.js
@@ -556,7 +556,7 @@ const sortWithSourceOrder = (dependencies, dependencySourceOrderMap) => {
 		}
 	}
 
-	if (withSourceOrder.length === 0) {
+	if (withSourceOrder.length <= 1) {
 		return;
 	}
 

--- a/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
+++ b/test/__snapshots__/ConfigCacheTestCases.longtest.js.snap
@@ -3498,6 +3498,8 @@ exports[`ConfigCacheTestCases css css-modules-no-space exported tests should all
 
 exports[`ConfigCacheTestCases css css-order exported tests keep consistent css order 1`] = `".button-module {  padding: 8px 16px;  background-color: #007bff;  color: white;  border: none;  border-radius: 4px;}.teaser-module {  padding: 20px;  border: 1px solid #ddd;  border-radius: 8px;  margin: 16px;}.teaser-module {  background-color: orange;}"`;
 
+exports[`ConfigCacheTestCases css css-order-reexport exported tests keep consistent css order 1`] = `".dependency2::before {	content: \\"dependency2\\";}.dependency::before {	content: \\"dependency\\";}"`;
+
 exports[`ConfigCacheTestCases css css-order2 exported tests keep consistent css order 1`] = `".dependency2::before {	content: \\"dependency2\\";}.dependency::before {	content: \\"dependency\\";}"`;
 
 exports[`ConfigCacheTestCases css css-order3 exported tests keep consistent css order 1`] = `".dependency3::before {	content: \\"dependency3\\";}.dependency2::before {	content: \\"dependency2\\";}.dependency::before {	content: \\"dependency\\";}"`;

--- a/test/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/test/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -3498,6 +3498,8 @@ exports[`ConfigTestCases css css-modules-no-space exported tests should allow to
 
 exports[`ConfigTestCases css css-order exported tests keep consistent css order 1`] = `".button-module {  padding: 8px 16px;  background-color: #007bff;  color: white;  border: none;  border-radius: 4px;}.teaser-module {  padding: 20px;  border: 1px solid #ddd;  border-radius: 8px;  margin: 16px;}.teaser-module {  background-color: orange;}"`;
 
+exports[`ConfigTestCases css css-order-reexport exported tests keep consistent css order 1`] = `".dependency2::before {	content: \\"dependency2\\";}.dependency::before {	content: \\"dependency\\";}"`;
+
 exports[`ConfigTestCases css css-order2 exported tests keep consistent css order 1`] = `".dependency2::before {	content: \\"dependency2\\";}.dependency::before {	content: \\"dependency\\";}"`;
 
 exports[`ConfigTestCases css css-order3 exported tests keep consistent css order 1`] = `".dependency3::before {	content: \\"dependency3\\";}.dependency2::before {	content: \\"dependency2\\";}.dependency::before {	content: \\"dependency\\";}"`;

--- a/test/configCases/css/css-order-reexport/component.js
+++ b/test/configCases/css/css-order-reexport/component.js
@@ -1,0 +1,5 @@
+export { dependency, dependency2 } from "./dependency";
+
+export function component(...args) {
+	console.log(args);
+}

--- a/test/configCases/css/css-order-reexport/dependency/dependency.css
+++ b/test/configCases/css/css-order-reexport/dependency/dependency.css
@@ -1,0 +1,3 @@
+.dependency::before {
+	content: "dependency";
+}

--- a/test/configCases/css/css-order-reexport/dependency/dependency.js
+++ b/test/configCases/css/css-order-reexport/dependency/dependency.js
@@ -1,0 +1,5 @@
+import styles from "./dependency.css";
+
+export function dependency() {
+	return styles !== undefined;
+}

--- a/test/configCases/css/css-order-reexport/dependency/dependency2.css
+++ b/test/configCases/css/css-order-reexport/dependency/dependency2.css
@@ -1,0 +1,3 @@
+.dependency2::before {
+	content: "dependency2";
+}

--- a/test/configCases/css/css-order-reexport/dependency/dependency2.js
+++ b/test/configCases/css/css-order-reexport/dependency/dependency2.js
@@ -1,0 +1,5 @@
+import styles from "./dependency2.css";
+
+export function dependency2() {
+	return styles !== undefined;
+}

--- a/test/configCases/css/css-order-reexport/dependency/index.js
+++ b/test/configCases/css/css-order-reexport/dependency/index.js
@@ -1,0 +1,2 @@
+export * from "./dependency2";
+export * from "./dependency";

--- a/test/configCases/css/css-order-reexport/dependency/package.json
+++ b/test/configCases/css/css-order-reexport/dependency/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "dependency",
+  "version": "1.0.0",
+  "private": true,
+  "sideEffects": false,
+  "main": "index.js"
+}

--- a/test/configCases/css/css-order-reexport/index.js
+++ b/test/configCases/css/css-order-reexport/index.js
@@ -1,0 +1,14 @@
+import { component, dependency, dependency2 } from "./component";
+component(dependency, dependency2);
+
+// https://github.com/webpack/webpack/issues/18961
+// https://github.com/jantimon/reproduction-webpack-css-order
+it("keep consistent css order", function() {
+	const fs = __non_webpack_require__("fs");
+	let source = fs.readFileSync(__dirname + "/main.css", "utf-8");
+	expect(removeComments(source)).toMatchSnapshot()
+});
+
+function removeComments(source) {
+	return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\n/g, "");
+}

--- a/test/configCases/css/css-order-reexport/package.json
+++ b/test/configCases/css/css-order-reexport/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "css-order2",
+    "version": "1.0.0",
+    "sideEffects": false,
+    "devDependencies": {
+      "mini-css-extract-plugin": "^2.9.0"
+    }
+  }

--- a/test/configCases/css/css-order-reexport/webpack.config.js
+++ b/test/configCases/css/css-order-reexport/webpack.config.js
@@ -1,0 +1,43 @@
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	devtool: false,
+	target: "web",
+	entry: "./index.js",
+	mode: "development",
+	optimization: {
+		concatenateModules: false
+	},
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				use: [
+					{
+						loader: MiniCssExtractPlugin.loader
+					},
+					{
+						loader: "css-loader",
+						options: {
+							esModule: true,
+							modules: {
+								namedExport: false,
+								localIdentName: "[name]"
+							}
+						}
+					}
+				]
+			}
+		]
+	},
+	plugins: [
+		new MiniCssExtractPlugin({
+			filename: "[name].css"
+		})
+	],
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Fixes https://github.com/webpack/webpack/pull/19686

keep the import order of dependency and dependency2 in the reexport within component.js
#### input
```js
// ./component.js
export { dependency, dependency2 } from "./dependency";

export function component(...args) {
	console.log(args);
}

// ./dependency/index.js
export * from "./dependency2";
export * from "./dependency";
```
#### output
```diff
// output

/***/ "./component.js":
/*!**********************!*\
  !*** ./component.js ***!
  \**********************/
/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {

__webpack_require__.r(__webpack_exports__);
/* harmony export */ __webpack_require__.d(__webpack_exports__, {
/* harmony export */   component: () => (/* binding */ component),
/* harmony export */   dependency: () => (/* reexport safe */ _dependency__WEBPACK_IMPORTED_MODULE_1__.dependency),
/* harmony export */   dependency2: () => (/* reexport safe */ _dependency__WEBPACK_IMPORTED_MODULE_0__.dependency2)
/* harmony export */ });
+ /* harmony import */ var _dependency__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./dependency */ "./dependency/dependency2.js");
+ /* harmony import */ var _dependency__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./dependency */ "./dependency/dependency.js");
- /* harmony import */ var _dependency__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./dependency */ "./dependency/dependency.js");
- /* harmony import */ var _dependency__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./dependency */ "./dependency/dependency2.js");

function component(...args) {
	console.log(args);
}
```

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
No
