### PR TITLE
feat: Support accept asyncModule

### DIFF
--- a/lib/dependencies/HarmonyAcceptDependency.js
+++ b/lib/dependencies/HarmonyAcceptDependency.js
@@ -116,13 +116,13 @@ HarmonyAcceptDependency.Template = class HarmonyAcceptDependencyTemplate extends
 			if (runtimeTemplate.supportsArrowFunction()) {
 				source.insert(
 					dep.range[0],
-					`__WEBPACK_OUTDATED_DEPENDENCIES__ => { ${content}(`
+					`__WEBPACK_OUTDATED_DEPENDENCIES__ => { ${content} return (`
 				);
 				source.insert(dep.range[1], ")(__WEBPACK_OUTDATED_DEPENDENCIES__); }");
 			} else {
 				source.insert(
 					dep.range[0],
-					`function(__WEBPACK_OUTDATED_DEPENDENCIES__) { ${content}(`
+					`function(__WEBPACK_OUTDATED_DEPENDENCIES__) { ${content} return (`
 				);
 				source.insert(
 					dep.range[1],

--- a/lib/hmr/HotModuleReplacement.runtime.js
+++ b/lib/hmr/HotModuleReplacement.runtime.js
@@ -354,38 +354,50 @@ module.exports = function () {
 		};
 
 		var outdatedModules = [];
-		results.forEach(function (result) {
-			if (result.apply) {
-				var modules = result.apply(reportError);
-				if (modules) {
-					for (var i = 0; i < modules.length; i++) {
-						outdatedModules.push(modules[i]);
-					}
-				}
-			}
-		});
 
-		return Promise.all([disposePromise, applyPromise]).then(function () {
-			// handle errors in accept handlers and self accepted module load
-			if (error) {
-				return setStatus("fail").then(function () {
-					throw error;
-				});
-			}
-
-			if (queuedInvalidatedModules) {
-				return internalApply(options).then(function (list) {
-					outdatedModules.forEach(function (moduleId) {
-						if (list.indexOf(moduleId) < 0) list.push(moduleId);
+		var onAccepted = function () {
+			return Promise.all([disposePromise, applyPromise]).then(function () {
+				// handle errors in accept handlers and self accepted module load
+				if (error) {
+					return setStatus("fail").then(function () {
+						throw error;
 					});
-					return list;
-				});
-			}
+				}
 
-			return setStatus("idle").then(function () {
-				return outdatedModules;
+				if (queuedInvalidatedModules) {
+					return internalApply(options).then(function (list) {
+						outdatedModules.forEach(function (moduleId) {
+							if (list.indexOf(moduleId) < 0) list.push(moduleId);
+						});
+						return list;
+					});
+				}
+
+				return setStatus("idle").then(function () {
+					return outdatedModules;
+				});
 			});
-		});
+		};
+
+		return Promise.all(
+			results
+				.filter(function (result) {
+					return result.apply;
+				})
+				.map(function (result) {
+					return result.apply(reportError);
+				})
+		)
+			.then(function (applyResults) {
+				applyResults.forEach(function (modules) {
+					if (modules) {
+						for (var i = 0; i < modules.length; i++) {
+							outdatedModules.push(modules[i]);
+						}
+					}
+				});
+			})
+			.then(onAccepted);
 	}
 
 	function applyInvalidatedModules() {

--- a/lib/hmr/JavascriptHotModuleReplacement.runtime.js
+++ b/lib/hmr/JavascriptHotModuleReplacement.runtime.js
@@ -281,6 +281,7 @@ module.exports = function () {
 				}
 			},
 			apply: function (reportError) {
+				var acceptPromises = [];
 				// insert new code
 				for (var updateModuleId in appliedUpdate) {
 					if ($hasOwnProperty$(appliedUpdate, updateModuleId)) {
@@ -317,8 +318,9 @@ module.exports = function () {
 								}
 							}
 							for (var k = 0; k < callbacks.length; k++) {
+								var result;
 								try {
-									callbacks[k].call(null, moduleOutdatedDependencies);
+									result = callbacks[k].call(null, moduleOutdatedDependencies);
 								} catch (err) {
 									if (typeof errorHandlers[k] === "function") {
 										try {
@@ -355,54 +357,63 @@ module.exports = function () {
 										}
 									}
 								}
+								if (result && typeof result.then === "function") {
+									acceptPromises.push(result);
+								}
 							}
 						}
 					}
 				}
 
-				// Load self accepted modules
-				for (var o = 0; o < outdatedSelfAcceptedModules.length; o++) {
-					var item = outdatedSelfAcceptedModules[o];
-					var moduleId = item.module;
-					try {
-						item.require(moduleId);
-					} catch (err) {
-						if (typeof item.errorHandler === "function") {
-							try {
-								item.errorHandler(err, {
-									moduleId: moduleId,
-									module: $moduleCache$[moduleId]
-								});
-							} catch (err1) {
+				var onAccepted = function () {
+					// Load self accepted modules
+					for (var o = 0; o < outdatedSelfAcceptedModules.length; o++) {
+						var item = outdatedSelfAcceptedModules[o];
+						var moduleId = item.module;
+						try {
+							item.require(moduleId);
+						} catch (err) {
+							if (typeof item.errorHandler === "function") {
+								try {
+									item.errorHandler(err, {
+										moduleId: moduleId,
+										module: $moduleCache$[moduleId]
+									});
+								} catch (err1) {
+									if (options.onErrored) {
+										options.onErrored({
+											type: "self-accept-error-handler-errored",
+											moduleId: moduleId,
+											error: err1,
+											originalError: err
+										});
+									}
+									if (!options.ignoreErrored) {
+										reportError(err1);
+										reportError(err);
+									}
+								}
+							} else {
 								if (options.onErrored) {
 									options.onErrored({
-										type: "self-accept-error-handler-errored",
+										type: "self-accept-errored",
 										moduleId: moduleId,
-										error: err1,
-										originalError: err
+										error: err
 									});
 								}
 								if (!options.ignoreErrored) {
-									reportError(err1);
 									reportError(err);
 								}
 							}
-						} else {
-							if (options.onErrored) {
-								options.onErrored({
-									type: "self-accept-errored",
-									moduleId: moduleId,
-									error: err
-								});
-							}
-							if (!options.ignoreErrored) {
-								reportError(err);
-							}
 						}
 					}
-				}
+				};
 
-				return outdatedModules;
+				return Promise.all(acceptPromises)
+					.then(onAccepted)
+					.then(function () {
+						return outdatedModules;
+					});
 			}
 		};
 	}

--- a/test/hotCases/async-module/async-accept/index.js
+++ b/test/hotCases/async-module/async-accept/index.js
@@ -1,0 +1,28 @@
+import update from "../../update";
+import a from "./module-a";
+
+it("should support async accept", (done) => {
+	let test = 0;
+	expect(a).toEqual(1);
+
+	import.meta.webpackHot.accept(["./module-a"], () => {
+		debugger
+		return new Promise((resolve) => {
+			setTimeout(() => {
+				debugger
+				test = 1;
+				resolve();
+			}, 3000);
+		});
+	});
+
+	NEXT(update(done));
+
+	import.meta.webpackHot.addStatusHandler((status) => {
+		if (status === "idle") {
+			expect(test).toEqual(1);
+			expect(a).toEqual(2);
+			done();
+		}
+	});
+});

--- a/test/hotCases/async-module/async-accept/module-a.js
+++ b/test/hotCases/async-module/async-accept/module-a.js
@@ -1,0 +1,3 @@
+export default 1;
+---
+export default 2;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Fixes https://github.com/webpack/webpack/pull/19739

If there are async modules in accept, the acceptCallback becomes asynchronous. Therefore, we should wait for its async execution to finish before calling setStatus("idle").
```js
module.hot.accept(/*! ./module */ "./module.js", async () => { /* harmony import */  _module__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./module */ "./module.js");
var __webpack_async_dependencies__ = __webpack_handle_async_dependencies__([_module__WEBPACK_IMPORTED_MODULE_1__]);
_module__WEBPACK_IMPORTED_MODULE_1__ = (__webpack_async_dependencies__.then ? (await __webpack_async_dependencies__)() : __webpack_async_dependencies__)[0];
 });
```

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
No
