### PR TITLE
fix: should emit assets even if invalidation occurs again

### DIFF
--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -187,8 +187,6 @@ class Watching {
 
 					const compilation = /** @type {Compilation} */ (_compilation);
 
-					if (this.invalid) return this._done(null, compilation);
-
 					if (this.compiler.hooks.shouldEmit.call(compilation) === false) {
 						return this._done(null, compilation);
 					}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fixes https://github.com/webpack/webpack/issues/15541. The issue is about two `invalidations` in quick succession.

We should emit assets even if invalidation occurs again. 

In the case of above issue, `hot update manifest` is only generated during the first compilation triggered by the initial invalidation.

If we skip emitting assets (in particular `hot update manifest` ) in the first compilation, it will cause HMR failed, resulting in a full reload.

**_Assets of first compilation_**

```
0 = {name: 'bundle.js', source: CachedSource, info: {…}}
1 = {name: 'simple-entry_js.bundle.js', source: CachedSource, info: {…}}
2 = {name: 'a_js_lazy-compilation-proxy.bundle.js', source: CachedSource, info: {…}}
3 = {name: 'b_js_lazy-compilation-proxy.bundle.js', source: CachedSource, info: {…}}
4 = {name: 'c_js_lazy-compilation-proxy.bundle.js', source: CachedSource, info: {…}}
5 = {name: 'a_js.bundle.js', source: CachedSource, info: {…}}
6 = {name: 'b_js.bundle.js', source: CachedSource, info: {…}}
7 = {name: 'c_js.bundle.js', source: CachedSource, info: {…}}
8 = {name: 'main.88504f5b514c1ccfba96.hot-update.js', source: ConcatSource, info: {…}}
9 = {name: 'a_js_lazy-compilation-proxy.88504f5b514c1ccfba96.hot-update.js', source: ConcatSource, info: {…}}
10 = {name: 'b_js_lazy-compilation-proxy.88504f5b514c1ccfba96.hot-update.js', source: ConcatSource, info: {…}}
11 = {name: 'c_js_lazy-compilation-proxy.88504f5b514c1ccfba96.hot-update.js', source: ConcatSource, info: {…}}
12 = {name: 'main.88504f5b514c1ccfba96.hot-update.json', source: RawSource, info: {…}}
```

_**Assets of second compilation**_
```
0 = {name: 'bundle.js', source: CachedSource, info: {…}}
1 = {name: 'simple-entry_js.bundle.js', source: CachedSource, info: {…}}
2 = {name: 'a_js_lazy-compilation-proxy.bundle.js', source: CachedSource, info: {…}}
3 = {name: 'b_js_lazy-compilation-proxy.bundle.js', source: CachedSource, info: {…}}
4 = {name: 'c_js_lazy-compilation-proxy.bundle.js', source: CachedSource, info: {…}}
5 = {name: 'a_js.bundle.js', source: CachedSource, info: {…}}
6 = {name: 'b_js.bundle.js', source: CachedSource, info: {…}}
7 = {name: 'c_js.bundle.js', source: CachedSource, info: {…}}
```


<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->


**Did you add tests for your changes?**


Yes 


<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->


**What needs to be documented once your changes are merged?**

No
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
