### PR TITLE
fix: circle deps when require `RawModule` and condition of `isDeferred`

### DIFF
--- a/lib/Dependency.js
+++ b/lib/Dependency.js
@@ -5,7 +5,6 @@
 
 "use strict";
 
-const RawModule = require("./RawModule");
 const memoize = require("./util/memoize");
 
 /** @typedef {import("webpack-sources").Source} Source */
@@ -86,6 +85,8 @@ const memoize = require("./util/memoize");
 const TRANSITIVE = Symbol("transitive");
 
 const getIgnoredModule = memoize(() => {
+	const RawModule = require("./RawModule");
+
 	const module = new RawModule("/* (ignored) */", "ignored", "(ignored)");
 	module.factoryMeta = { sideEffectFree: true };
 	return module;

--- a/lib/ModuleGraph.js
+++ b/lib/ModuleGraph.js
@@ -8,10 +8,10 @@
 const util = require("util");
 const ExportsInfo = require("./ExportsInfo");
 const ModuleGraphConnection = require("./ModuleGraphConnection");
+const HarmonyImportDependency = require("./dependencies/HarmonyImportDependency");
 const SortableSet = require("./util/SortableSet");
 const WeakTupleMap = require("./util/WeakTupleMap");
 const { sortWithSourceOrder } = require("./util/comparators");
-const memoize = require("./util/memoize");
 
 /** @typedef {import("./Compilation").ModuleMemCaches} ModuleMemCaches */
 /** @typedef {import("./DependenciesBlock")} DependenciesBlock */
@@ -24,10 +24,6 @@ const memoize = require("./util/memoize");
 /** @typedef {import("./dependencies/HarmonyImportSideEffectDependency")} HarmonyImportSideEffectDependency */
 /** @typedef {import("./dependencies/HarmonyImportSpecifierDependency")} HarmonyImportSpecifierDependency */
 /** @typedef {import("./util/comparators").DependencySourceOrder} DependencySourceOrder */
-
-const getCommonJsSelfReferenceDependency = memoize(() =>
-	require("./dependencies/CommonJsSelfReferenceDependency")
-);
 
 /**
  * @callback OptimizationBailoutFunction
@@ -845,7 +841,7 @@ class ModuleGraph {
 		for (const connection of connections) {
 			if (
 				!connection.dependency ||
-				connection.dependency instanceof getCommonJsSelfReferenceDependency()
+				!(connection.dependency instanceof HarmonyImportDependency)
 			) {
 				continue;
 			}

--- a/lib/dependencies/ModuleDependency.js
+++ b/lib/dependencies/ModuleDependency.js
@@ -7,7 +7,6 @@
 
 const Dependency = require("../Dependency");
 const DependencyTemplate = require("../DependencyTemplate");
-const RawModule = require("../RawModule");
 
 /** @typedef {import("../Dependency").TRANSITIVE} TRANSITIVE */
 /** @typedef {import("../Module")} Module */
@@ -61,6 +60,8 @@ class ModuleDependency extends Dependency {
 	 * @returns {Module} ignored module
 	 */
 	createIgnoredModule(context) {
+		const RawModule = require("../RawModule");
+
 		const module = new RawModule(
 			"/* (ignored) */",
 			`ignored|${context}|${this.request}`,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fix circle deps:

`Dependency.js`/`ModuleDependency.js` -> `RawModule.js` -> `ModuleGraph.js` -> `CommonJsSelfReferenceDependency.js`/`HarmonyImportDependency.js` -> `Dependency.js`/`ModuleDependency.js`

Fixes the condition of `moduleGraph.isDeferred`:

Should return `true` only when incoming modules include `HarmonyImportDependency` (not `CommonJsSelfReferenceDependency`) and its `defer` is set to true.


<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Existing
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

No
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
