### PR TITLE
fix(esm): fix the failure export of internal function

### DIFF
--- a/lib/esm/ExportWebpackRequireRuntimeModule.js
+++ b/lib/esm/ExportWebpackRequireRuntimeModule.js
@@ -6,6 +6,10 @@
 
 const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
+const Template = require("../Template");
+
+// CompatibilityPlugin renames `__webpack_require__` but doesn’t account for `export { __webpack_require__ }`, so we create a temporary variable to handle it.
+const EXPORT_TEMP_NAME = "__webpack_require_temp__";
 
 class ExportWebpackRequireRuntimeModule extends RuntimeModule {
 	constructor() {
@@ -23,7 +27,10 @@ class ExportWebpackRequireRuntimeModule extends RuntimeModule {
 	 * @returns {string | null} runtime code
 	 */
 	generate() {
-		return `export default ${RuntimeGlobals.require};`;
+		return Template.asString([
+			`var ${EXPORT_TEMP_NAME} = ${RuntimeGlobals.require};`,
+			`export { ${EXPORT_TEMP_NAME} as ${RuntimeGlobals.require} };`
+		]);
 	}
 }
 

--- a/lib/esm/ModuleChunkFormatPlugin.js
+++ b/lib/esm/ModuleChunkFormatPlugin.js
@@ -97,7 +97,7 @@ const getRelativePath = (compilation, chunk, runtimeChunk) => {
  * @returns {string} the import source
  */
 function renderChunkImport(compilation, chunk, namedImport, runtimeChunk) {
-	return `import ${namedImport ? `* as ${namedImport}` : RuntimeGlobals.require} from ${JSON.stringify(
+	return `import ${namedImport ? `* as ${namedImport}` : `{ ${RuntimeGlobals.require} }`} from ${JSON.stringify(
 		getRelativePath(compilation, chunk, runtimeChunk || chunk)
 	)};\n`;
 }

--- a/lib/esm/ModuleChunkLoadingPlugin.js
+++ b/lib/esm/ModuleChunkLoadingPlugin.js
@@ -71,11 +71,8 @@ class ModuleChunkLoadingPlugin {
 				.tap(PLUGIN_NAME, handler);
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.externalInstallChunk)
-				.tap(PLUGIN_NAME, (chunk, set, { chunkGraph }) => {
+				.tap(PLUGIN_NAME, (chunk) => {
 					if (!isEnabledForChunk(chunk)) return;
-					// If a chunk contains an entryModule, all exports are determined by the entryModule.
-					// The ExportWebpackRequireRuntimeModule is for internal use only and not exposed to users.
-					if (chunkGraph.getNumberOfEntryModules(chunk) > 0) return;
 					compilation.addRuntimeModule(
 						chunk,
 						new ExportWebpackRequireRuntimeModule()

--- a/test/configCases/module/issue-19767/common.js
+++ b/test/configCases/module/issue-19767/common.js
@@ -1,0 +1,1 @@
+export default "common";

--- a/test/configCases/module/issue-19767/index.js
+++ b/test/configCases/module/issue-19767/index.js
@@ -1,0 +1,6 @@
+import common from "./common";
+
+it("should compile", () => {
+	expect(common).toBe("common");
+});
+export default "main";

--- a/test/configCases/module/issue-19767/test.config.js
+++ b/test/configCases/module/issue-19767/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./main.mjs"];
+	}
+};

--- a/test/configCases/module/issue-19767/webpack.config.js
+++ b/test/configCases/module/issue-19767/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = () => ({
+	devtool: false,
+	mode: "development",
+	entry: {
+		main: {
+			import: "./index.js",
+			dependOn: "shared"
+		},
+		shared: "./common.js"
+	},
+	output: {
+		filename: "[name].mjs",
+		library: {
+			type: "module"
+		}
+	},
+	target: ["web", "es2020"],
+	experiments: {
+		outputModule: true
+	},
+	optimization: {
+		minimize: false,
+		runtimeChunk: false,
+		concatenateModules: true
+	}
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Fixes https://github.com/webpack/webpack/issues/19767 The naming of functions exported within webpack cannot use "default" because the entryModule may have a default export.

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
No
