### PR TITLE
fix: resolve execution order issue from extra await in async modules

### DIFF
--- a/lib/async-modules/AwaitDependenciesInitFragment.js
+++ b/lib/async-modules/AwaitDependenciesInitFragment.js
@@ -62,9 +62,12 @@ class AwaitDependenciesInitFragment extends InitFragment {
 			this.dependencies.size === 1 ||
 			!runtimeTemplate.supportsDestructuring()
 		) {
+			templateInput.push(
+				"var __webpack_async_dependencies_result__ = (__webpack_async_dependencies__.then ? (await __webpack_async_dependencies__)() : __webpack_async_dependencies__);"
+			);
 			for (const [index, importVar] of importVars.entries()) {
 				templateInput.push(
-					`${importVar} = (__webpack_async_dependencies__.then ? (await __webpack_async_dependencies__)() : __webpack_async_dependencies__)[${index}];`
+					`${importVar} = __webpack_async_dependencies_result__[${index}];`
 				);
 			}
 		} else {

--- a/test/configCases/async-module/issue-19803/a.js
+++ b/test/configCases/async-module/issue-19803/a.js
@@ -1,0 +1,2 @@
+await 1;
+export const a = "a"

--- a/test/configCases/async-module/issue-19803/b.js
+++ b/test/configCases/async-module/issue-19803/b.js
@@ -1,0 +1,2 @@
+await 1;
+export const b = "b"

--- a/test/configCases/async-module/issue-19803/c.js
+++ b/test/configCases/async-module/issue-19803/c.js
@@ -1,0 +1,4 @@
+import {a} from "./a";
+import {b} from "./b";
+
+export const c = a + b

--- a/test/configCases/async-module/issue-19803/d.js
+++ b/test/configCases/async-module/issue-19803/d.js
@@ -1,0 +1,3 @@
+import {c} from "./c";
+
+export const d = c

--- a/test/configCases/async-module/issue-19803/index.js
+++ b/test/configCases/async-module/issue-19803/index.js
@@ -1,0 +1,5 @@
+it("should work", () => {
+	return import("./d").then(d => {
+		expect(d.d).toBe("ab");
+	});
+});

--- a/test/configCases/async-module/issue-19803/webpack.config.js
+++ b/test/configCases/async-module/issue-19803/webpack.config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		environment: {
+			destructuring: false
+		}
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Fixes https://github.com/webpack/webpack/issues/19803

```bash
  ● ConfigTestCases › async-module › issue-19803 › issue-19803 should compile

    ReferenceError: Cannot access 'c' before initialization

      at Object.c (undefined-issue-19803-0-/Users/x/webpack/test/js/ConfigTestCases/async-module/issue-19803/bundle0.mjs:86:48)
      at undefined-issue-19803-0-/Users/x/webpack/test/js/ConfigTestCases/async-module/issue-19803/bundle0.mjs:38:43
```
**Did you add tests for your changes?**
No

**Does this PR introduce a breaking change?**
No

**What needs to be documented once your changes are merged?**
No
