### PR TITLE
fix: avoid empty block for unused statement

### DIFF
--- a/lib/ConstPlugin.js
+++ b/lib/ConstPlugin.js
@@ -180,7 +180,7 @@ class ConstPlugin {
 								? statement.alternate
 								: statement.consequent;
 							if (branchToRemove) {
-								this.eliminateUnusedStatement(parser, branchToRemove);
+								this.eliminateUnusedStatement(parser, branchToRemove, true);
 							}
 							return bool;
 						}
@@ -193,7 +193,7 @@ class ConstPlugin {
 						) {
 							return;
 						}
-						this.eliminateUnusedStatement(parser, statement);
+						this.eliminateUnusedStatement(parser, statement, false);
 						return true;
 					});
 					parser.hooks.expressionConditionalOperator.tap(
@@ -509,9 +509,10 @@ class ConstPlugin {
 	 * Eliminate an unused statement.
 	 * @param {JavascriptParser} parser the parser
 	 * @param {Statement} statement the statement to remove
+	 * @param {boolean} alwaysInBlock whether to always generate curly brackets
 	 * @returns {void}
 	 */
-	eliminateUnusedStatement(parser, statement) {
+	eliminateUnusedStatement(parser, statement, alwaysInBlock) {
 		// Before removing the unused branch, the hoisted declarations
 		// must be collected.
 		//
@@ -545,8 +546,14 @@ class ConstPlugin {
 		const declarations = parser.scope.isStrict
 			? getHoistedDeclarations(statement, false)
 			: getHoistedDeclarations(statement, true);
-		const replacement =
-			declarations.length > 0 ? `{ var ${declarations.join(", ")}; }` : "{}";
+
+		const inBlock = alwaysInBlock || statement.type === "BlockStatement";
+
+		let replacement = inBlock ? "{" : "";
+		replacement +=
+			declarations.length > 0 ? ` var ${declarations.join(", ")}; ` : "";
+		replacement += inBlock ? "}" : "";
+
 		const dep = new ConstDependency(
 			`// removed by dead control flow\n${replacement}`,
 			/** @type {Range} */ (statement.range)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fixes https://github.com/webpack/webpack/issues/19806.

We now only generate empty block when unreachable/unused statement is `BlockStatement`,  preventing the `unreachable code` warning in `Firefox`.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Existing
<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

No
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
