### PR TITLE
Add collectDestructuringAasignmentProperties hook to only collect for specific expression

### DIFF
--- a/lib/DefinePlugin.js
+++ b/lib/DefinePlugin.js
@@ -489,6 +489,13 @@ class DefinePlugin {
 								if (nested && !hooked.has(nested)) {
 									// only detect the same nested key once
 									hooked.add(nested);
+									parser.hooks.collectDestructuringAssignmentProperties.tap(
+										PLUGIN_NAME,
+										(expr) => {
+											const nameInfo = parser.getNameForExpression(expr);
+											if (nameInfo && nameInfo.name === nested) return true;
+										}
+									);
 									parser.hooks.expression.for(nested).tap(
 										{
 											name: PLUGIN_NAME,
@@ -687,6 +694,13 @@ class DefinePlugin {
 								PLUGIN_NAME,
 								withValueDependency(key, evaluateToString("object"))
 							);
+						parser.hooks.collectDestructuringAssignmentProperties.tap(
+							PLUGIN_NAME,
+							(expr) => {
+								const nameInfo = parser.getNameForExpression(expr);
+								if (nameInfo && nameInfo.name === key) return true;
+							}
+						);
 						parser.hooks.expression.for(key).tap(PLUGIN_NAME, (expr) => {
 							addValueDependency(key);
 							let strCode = stringifyObj(

--- a/lib/dependencies/HarmonyImportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyImportDependencyParserPlugin.js
@@ -8,7 +8,10 @@
 const CommentCompilationWarning = require("../CommentCompilationWarning");
 const HotModuleReplacementPlugin = require("../HotModuleReplacementPlugin");
 const WebpackError = require("../WebpackError");
-const { getImportAttributes } = require("../javascript/JavascriptParser");
+const {
+	VariableInfo,
+	getImportAttributes
+} = require("../javascript/JavascriptParser");
 const InnerGraph = require("../optimize/InnerGraph");
 const ConstDependency = require("./ConstDependency");
 const HarmonyAcceptDependency = require("./HarmonyAcceptDependency");
@@ -211,6 +214,20 @@ module.exports = class HarmonyImportDependencyParserPlugin {
 			InnerGraph.onUsage(parser.state, (e) => (dep.usedByExports = e));
 			return true;
 		});
+		parser.hooks.collectDestructuringAssignmentProperties.tap(
+			PLUGIN_NAME,
+			(expr) => {
+				const nameInfo = parser.getNameForExpression(expr);
+				if (
+					nameInfo &&
+					nameInfo.rootInfo instanceof VariableInfo &&
+					nameInfo.rootInfo.name &&
+					parser.getTagData(nameInfo.rootInfo.name, harmonySpecifierTag)
+				) {
+					return true;
+				}
+			}
+		);
 		parser.hooks.expression
 			.for(harmonySpecifierTag)
 			.tap(PLUGIN_NAME, (expr) => {

--- a/lib/dependencies/ImportMetaPlugin.js
+++ b/lib/dependencies/ImportMetaPlugin.js
@@ -96,6 +96,12 @@ class ImportMetaPlugin {
 							PLUGIN_NAME,
 							toConstantDependency(parser, JSON.stringify("object"))
 						);
+					parser.hooks.collectDestructuringAssignmentProperties.tap(
+						PLUGIN_NAME,
+						(expr) => {
+							if (expr.type === "MetaProperty") return true;
+						}
+					);
 					parser.hooks.expression
 						.for("import.meta")
 						.tap(PLUGIN_NAME, (metaProperty) => {

--- a/lib/dependencies/ImportParserPlugin.js
+++ b/lib/dependencies/ImportParserPlugin.js
@@ -46,6 +46,12 @@ class ImportParserPlugin {
 		 */
 		const exportsFromEnumerable = (enumerable) =>
 			Array.from(enumerable, (e) => [e]);
+		parser.hooks.collectDestructuringAssignmentProperties.tap(
+			PLUGIN_NAME,
+			(expr) => {
+				if (expr.type === "ImportExpression") return true;
+			}
+		);
 		parser.hooks.importCall.tap(PLUGIN_NAME, (expr) => {
 			const param = parser.evaluateExpression(expr.source);
 

--- a/lib/javascript/JavascriptParser.js
+++ b/lib/javascript/JavascriptParser.js
@@ -522,6 +522,10 @@ class JavascriptParser extends Parser {
 			varDeclarationVar: new HookMap(() => new SyncBailHook(["declaration"])),
 			/** @type {HookMap<SyncBailHook<[Identifier], boolean | void>>} */
 			pattern: new HookMap(() => new SyncBailHook(["pattern"])),
+			/** @type {SyncBailHook<[Expression], boolean | void>} */
+			collectDestructuringAssignmentProperties: new SyncBailHook([
+				"expression"
+			]),
 			/** @type {HookMap<SyncBailHook<[Expression], boolean | void>>} */
 			canRename: new HookMap(() => new SyncBailHook(["initExpression"])),
 			/** @type {HookMap<SyncBailHook<[Expression], boolean | void>>} */
@@ -2607,34 +2611,48 @@ class JavascriptParser extends Parser {
 	 * @param {AssignmentExpression} expression assignment expression
 	 */
 	preWalkAssignmentExpression(expression) {
+		this.enterDestructuringAssignment(expression.left, expression.right);
+	}
+
+	/**
+	 * @param {Pattern} pattern pattern
+	 * @param {Expression} expression assignment expression
+	 * @returns {Expression | undefined} destructuring expression
+	 */
+	enterDestructuringAssignment(pattern, expression) {
 		if (
-			expression.left.type !== "ObjectPattern" ||
+			pattern.type !== "ObjectPattern" ||
 			!this.destructuringAssignmentProperties
 		) {
 			return;
 		}
-		const keys = this._preWalkObjectPattern(expression.left);
-		if (!keys) return;
 
-		// check multiple assignments
-		if (this.destructuringAssignmentProperties.has(expression)) {
-			const set =
-				/** @type {Set<DestructuringAssignmentProperty>} */
-				(this.destructuringAssignmentProperties.get(expression));
-			this.destructuringAssignmentProperties.delete(expression);
-			for (const id of set) keys.add(id);
+		const expr =
+			expression.type === "AwaitExpression" ? expression.argument : expression;
+
+		const destructuring =
+			expr.type === "AssignmentExpression"
+				? this.enterDestructuringAssignment(expr.left, expr.right)
+				: this.hooks.collectDestructuringAssignmentProperties.call(expr)
+					? expr
+					: undefined;
+
+		if (destructuring) {
+			const keys = this._preWalkObjectPattern(pattern);
+			if (!keys) return;
+
+			// check multiple assignments
+			if (this.destructuringAssignmentProperties.has(destructuring)) {
+				const set =
+					/** @type {Set<DestructuringAssignmentProperty>} */
+					(this.destructuringAssignmentProperties.get(destructuring));
+				for (const id of keys) set.add(id);
+			} else {
+				this.destructuringAssignmentProperties.set(destructuring, keys);
+			}
 		}
 
-		this.destructuringAssignmentProperties.set(
-			expression.right.type === "AwaitExpression"
-				? expression.right.argument
-				: expression.right,
-			keys
-		);
-
-		if (expression.right.type === "AssignmentExpression") {
-			this.preWalkAssignmentExpression(expression.right);
-		}
+		return destructuring;
 	}
 
 	/**
@@ -2995,25 +3013,8 @@ class JavascriptParser extends Parser {
 	 * @param {VariableDeclarator} declarator variable declarator
 	 */
 	preWalkVariableDeclarator(declarator) {
-		if (
-			!declarator.init ||
-			declarator.id.type !== "ObjectPattern" ||
-			!this.destructuringAssignmentProperties
-		) {
-			return;
-		}
-		const keys = this._preWalkObjectPattern(declarator.id);
-
-		if (!keys) return;
-		this.destructuringAssignmentProperties.set(
-			declarator.init.type === "AwaitExpression"
-				? declarator.init.argument
-				: declarator.init,
-			keys
-		);
-
-		if (declarator.init.type === "AssignmentExpression") {
-			this.preWalkAssignmentExpression(declarator.init);
+		if (declarator.init) {
+			this.enterDestructuringAssignment(declarator.id, declarator.init);
 		}
 	}
 
@@ -5179,7 +5180,7 @@ class JavascriptParser extends Parser {
 	}
 
 	/**
-	 * @param {MemberExpression} expression an expression
+	 * @param {Expression} expression an expression
 	 * @returns {{ name: string, rootInfo: ExportedVariableInfo, getMembers: () => string[]} | undefined} name info
 	 */
 	getNameForExpression(expression) {

--- a/test/cases/esm/import-meta/index.js
+++ b/test/cases/esm/import-meta/index.js
@@ -48,10 +48,16 @@ it("should add warning on direct import.meta usage", () => {
 	expect(Object.keys(import.meta)).toHaveLength(0);
 });
 
-it("should support destructuring assignment", () => {
+it("should support destructuring assignment", async () => {
 	let version, url2, c;
 	({ webpack: version } = { url: url2 } = { c } = import.meta);
 	expect(version).toBeTypeOf("number");
 	expect(url2).toBe(url);
 	expect(c).toBe(undefined);
+
+	let version2, url3, d;
+	({ webpack: version2 } = await ({ url: url3 } = ({ d } = await import.meta)));
+	expect(version2).toBeTypeOf("number");
+	expect(url3).toBe(url);
+	expect(d).toBe(undefined);
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -663,12 +663,12 @@ declare abstract class BasicEvaluatedExpression {
 		| MethodDefinition
 		| PropertyDefinition
 		| VariableDeclarator
-		| SwitchCase
-		| CatchClause
 		| ObjectPattern
 		| ArrayPattern
 		| RestElement
 		| AssignmentPattern
+		| SwitchCase
+		| CatchClause
 		| Property
 		| AssignmentProperty
 		| ClassBody
@@ -894,12 +894,12 @@ declare abstract class BasicEvaluatedExpression {
 			| MethodDefinition
 			| PropertyDefinition
 			| VariableDeclarator
-			| SwitchCase
-			| CatchClause
 			| ObjectPattern
 			| ArrayPattern
 			| RestElement
 			| AssignmentPattern
+			| SwitchCase
+			| CatchClause
 			| Property
 			| AssignmentProperty
 			| ClassBody
@@ -6855,6 +6855,10 @@ declare class JavascriptParser extends ParserClass {
 		varDeclarationUsing: HookMap<SyncBailHook<[Identifier], boolean | void>>;
 		varDeclarationVar: HookMap<SyncBailHook<[Identifier], boolean | void>>;
 		pattern: HookMap<SyncBailHook<[Identifier], boolean | void>>;
+		collectDestructuringAssignmentProperties: SyncBailHook<
+			[Expression],
+			boolean | void
+		>;
 		canRename: HookMap<SyncBailHook<[Expression], boolean | void>>;
 		rename: HookMap<SyncBailHook<[Expression], boolean | void>>;
 		assign: HookMap<SyncBailHook<[AssignmentExpression], boolean | void>>;
@@ -7329,6 +7333,38 @@ declare class JavascriptParser extends ParserClass {
 	): void;
 	blockPreWalkExpressionStatement(statement: ExpressionStatement): void;
 	preWalkAssignmentExpression(expression: AssignmentExpression): void;
+	enterDestructuringAssignment(
+		pattern: Pattern,
+		expression: Expression
+	):
+		| undefined
+		| ImportExpressionImport
+		| UnaryExpression
+		| ArrayExpression
+		| ArrowFunctionExpression
+		| AssignmentExpression
+		| AwaitExpression
+		| BinaryExpression
+		| SimpleCallExpression
+		| NewExpression
+		| ChainExpression
+		| ClassExpression
+		| ConditionalExpression
+		| FunctionExpression
+		| Identifier
+		| SimpleLiteral
+		| RegExpLiteral
+		| BigIntLiteral
+		| LogicalExpression
+		| MemberExpression
+		| MetaProperty
+		| ObjectExpression
+		| SequenceExpression
+		| TaggedTemplateExpression
+		| TemplateLiteral
+		| ThisExpression
+		| UpdateExpression
+		| YieldExpression;
 	modulePreWalkImportDeclaration(
 		statement: ImportDeclarationJavascriptParser
 	): void;
@@ -7874,7 +7910,7 @@ declare class JavascriptParser extends ParserClass {
 		allowedTypes: number
 	): undefined | CallExpressionInfo | ExpressionExpressionInfo;
 	getNameForExpression(
-		expression: MemberExpression
+		expression: Expression
 	):
 		| undefined
 		| {


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Add `collectDestructuringAasignmentProperties` hook to only collect `destructuringAssignmentProperties` for specific expression.

Before all `Expression` in `ObjectPattern = Expression` were collected into destructuringAssignmentProperties, but actually we only need to collect some specific expressions: `harmonyImportSpecifier`, `import.meta`, `import()`, and the `key of DefinePlugin options`, so this PR add a new hook that identify these expressions and only collect `destructuringAssignmentProperties` for them.

https://github.com/webpack/webpack/pull/18319#discussion_r1625967353 And duo to performance reason that `destructuringAssignmentProperties` only collect properties for simple cases like `{ a, b: c } = d`, after this we can also collect the nested properties: `{ a: { b: {c} } } = d`

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

refactoring, and bugfix for `({ webpack } = await ({ url } = import.meta));`

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

No

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
