### PR TITLE
ci: pin Node.js 24.x to 24.5.0 to fix CI failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,7 +173,8 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          # TODO: Remove version override when https://github.com/nodejs/node/issues/59480 is fixed
+          node-version: ${{ matrix.node-version == '24.x' && '24.5.0' || matrix.node-version }}
           architecture: ${{ steps.calculate_architecture.outputs.result }}
           cache: "yarn"
       # Install old `jest` version and deps for legacy node versions


### PR DESCRIPTION
PR Description:
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This PR pins Node.js 24.6 (=24.x) to version 24.5.0 in the CI workflow as a temporary workaround for a Node.js regression that causes CI failures.

Related to Node.js issue: https://github.com/nodejs/node/issues/59480

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

CI/build configuration fix

**Did you add tests for your changes?**

N/A

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

None