### PR TITLE
fix: ignore import failure during HMR update with esm output

### DIFF
--- a/lib/esm/ModuleChunkLoadingRuntimeModule.js
+++ b/lib/esm/ModuleChunkLoadingRuntimeModule.js
@@ -411,7 +411,7 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 								RuntimeGlobals.getUpdateManifestFilename
 							}()).then(${runtimeTemplate.basicFunction("obj", [
 								"return obj.default;"
-							])});`
+							])}, ${runtimeTemplate.basicFunction("", "")});`
 						])};`
 					])
 				: "// no HMR manifest"


### PR DESCRIPTION
This fixes an issue with hot module replacement when using `experiments.outputModule: true`.

To reproduce the issue:

1. Create `src/index.js` containing:

```javascript
import 'webpack/hot/signal.js'

let count = 0;
const interval = setInterval(() => {
  console.log('label 1', { count: count++ })
}, 1000);

if (import.meta.webpackHot) {
  import.meta.webpackHot.accept()
  import.meta.webpackHot.dispose(() => {
    clearInterval(interval);
  });
}
```

2. Create `webpack.config.js`:

```javascript
import { ChildProcess, fork } from 'node:child_process';
import webpack from 'webpack';

export default /** @satisfies {import('webpack').Configuration} */ ({
  devtool: 'source-map',
  target: ['node'],
  experiments: {
    outputModule: true
  },
  plugins: [
    new webpack.HotModuleReplacementPlugin(),
    /** @this {webpack.Compiler} */
    function hmrPlugin() {
      /** @type {ChildProcess} */
      let child

      this.hooks.afterEmit.tapPromise('node-hmr', async () => {
        if (child) {
          process.kill(child.pid, 'SIGUSR2');
        } else {
          child = fork('.', {
            execArgv: ['--enable-source-maps', '--inspect=9229'],
            stdio: 'inherit',
          });
        }
      });
    },
  ],
});
```

3. Start the build, which will run the build result as well:

```sh
./node_modules/.bin/webpack watch --config-node-env=development
```

4. Output is like `label 1 { count: ... }`
5. Change `'label 1'` to `'label 2'` in `src/index.js`.
6. Note an error like this:

```
[HMR] Update failed: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../dist/main.2e437604cc341588feda.hot-update.json.mjs' imported from .../dist/main.mjs
```

7. Output is now `label 2 { count: ... }`, so it did actually apply that update.
8. Change `'label 2'` back to `'label 1'` in `src/index.js`
9. Note the output:

```
[HMR] Got signal but currently in check state.
[HMR] Need to be in idle state to start hot update.
```

11. And output continues to be `label 2 { count: ... }`. From this point on updates are not applied anymore, since it's stuck in check state.

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

I couldn't figure out how to reproduce this issue in tests. I'll appreciate any help with that.

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing