### PR TITLE
fix: don't check context timestampHash in watch mode

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -1042,6 +1042,9 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			logger: this.getLogger("webpack.FileSystemInfo"),
 			hashFunction: compiler.options.output.hashFunction
 		});
+		if (compiler.watchMode) {
+			this.fileSystemInfo._checkContextTimestampHash = false;
+		}
 		if (compiler.fileTimestamps) {
 			this.fileSystemInfo.addFileTimestamps(compiler.fileTimestamps, true);
 		}

--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -1248,6 +1248,7 @@ class FileSystemInfo {
 		this._cachedDeprecatedContextTimestamps = undefined;
 
 		this._warnAboutExperimentalEsmTracking = false;
+		this._checkContextTimestampHash = true;
 
 		this._statCreatedSnapshots = 0;
 		this._statTestedSnapshotsCached = 0;
@@ -2919,6 +2920,7 @@ class FileSystemInfo {
 				}
 				const snap = /** @type {ResolvedContextFileSystemInfoEntry} */ (s);
 				if (
+					this._checkContextTimestampHash &&
 					snap.timestampHash !== undefined &&
 					c.timestampHash !== snap.timestampHash
 				) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fixes https://github.com/webpack/webpack/issues/16886.

The `timestampHash` is only generated when `context entry` is `undefined` on `webpack` side (i.e. first compilation without time info from `watchpack`). On `watchpack` side, it only generate `{ safeTime: x }` or `{}` (without `timestampHash`) for existing `context/dir` when collecting time information. The absence of `timestampHash` will  cause the `snapshot` to be invalid.

Additionally, when files inside a directory are updated, the `safeTime` of the directory will be updated accordingly. Therefore, I believe it's safe to skip checking timestampHash in watch mode.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

TODO

<!-- Note that we won't merge your changes if you don't add tests -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

No

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
