### PR TITLE
feat: added support for `import file from "./file.ext" with { type: "text" }` to get text content

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -11,6 +11,7 @@ const {
 	ASSET_MODULE_TYPE,
 	ASSET_MODULE_TYPE_INLINE,
 	ASSET_MODULE_TYPE_RESOURCE,
+	ASSET_MODULE_TYPE_SOURCE,
 	CSS_MODULE_TYPE,
 	CSS_MODULE_TYPE_AUTO,
 	CSS_MODULE_TYPE_GLOBAL,
@@ -1055,12 +1056,16 @@ const applyModuleDefaults = (
 				]
 			},
 			{
+				with: { type: JSON_MODULE_TYPE },
+				type: JSON_MODULE_TYPE
+			},
+			{
 				assert: { type: JSON_MODULE_TYPE },
 				type: JSON_MODULE_TYPE
 			},
 			{
-				with: { type: JSON_MODULE_TYPE },
-				type: JSON_MODULE_TYPE
+				with: { type: "text" },
+				type: ASSET_MODULE_TYPE_SOURCE
 			}
 		);
 		return rules;

--- a/test/Defaults.unittest.js
+++ b/test/Defaults.unittest.js
@@ -215,15 +215,21 @@ describe("snapshots", () => {
 		        ],
 		      },
 		      Object {
+		        "type": "json",
+		        "with": Object {
+		          "type": "json",
+		        },
+		      },
+		      Object {
 		        "assert": Object {
 		          "type": "json",
 		        },
 		        "type": "json",
 		      },
 		      Object {
-		        "type": "json",
+		        "type": "asset/source",
 		        "with": Object {
-		          "type": "json",
+		          "type": "text",
 		        },
 		      },
 		    ],

--- a/test/configCases/asset-modules/type-text/index.js
+++ b/test/configCases/asset-modules/type-text/index.js
@@ -1,0 +1,5 @@
+import svg from "../_images/file.svg" with { type: "text" };
+
+it("should receive asset source", () => {
+	expect(svg).toMatch(/^<svg.+<\/svg>\s*$/);
+});

--- a/test/configCases/asset-modules/type-text/webpack.config.js
+++ b/test/configCases/asset-modules/type-text/webpack.config.js
@@ -1,0 +1,4 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {};


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

feat - https://github.com/whatwg/html/issues/9444 and https://github.com/tc39/proposal-import-bytes?tab=readme-ov-file#is-there-any-prior-art

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Yes we need to add an example on the asset modules page
