### PR TITLE
fix(warnings): update import.meta warning messages for clarity

### DIFF
--- a/lib/dependencies/ImportMetaPlugin.js
+++ b/lib/dependencies/ImportMetaPlugin.js
@@ -115,7 +115,7 @@ class ImportMetaPlugin {
 									new ModuleDependencyWarning(
 										parser.state.module,
 										new CriticalDependencyWarning(
-											"Accessing import.meta directly is unsupported (only property access or destructuring is supported)"
+											"'import.meta' cannot be used as a standalone expression. For static analysis, its properties must be accessed directly (e.g., 'import.meta.url') or through destructuring."
 										),
 										/** @type {DependencyLocation} */ (metaProperty.loc)
 									)

--- a/test/cases/parsing/asi/warnings.js
+++ b/test/cases/parsing/asi/warnings.js
@@ -1,3 +1,7 @@
 "use strict";
 
-module.exports = [[/Critical dependency: Accessing import\.meta/]];
+module.exports = [
+	[
+		/Critical dependency: 'import\.meta' cannot be used as a standalone expression\. For static analysis, its properties must be accessed directly \(e\.g\., 'import\.meta\.url'\) or through destructuring\./
+	]
+];

--- a/test/cases/parsing/import-meta/warnings.js
+++ b/test/cases/parsing/import-meta/warnings.js
@@ -2,6 +2,6 @@
 
 module.exports = [
 	[
-		/Accessing import.meta directly is unsupported \(only property access or destructuring is supported\)/
+		/'import\.meta' cannot be used as a standalone expression\. For static analysis, its properties must be accessed directly \(e\.g\., 'import\.meta\.url'\) or through destructuring\./
 	]
 ];


### PR DESCRIPTION

**Summary**

This improves the `import.meta` direct access warning. I find the current warning is sorta unclear as to what "Accessing import.meta directly" means in this context. I've updated it to clarify that `import.meta` cannot be used as a standalone expression because of static analysis requirements and provides clear examples of correct usage.

**What kind of change does this PR introduce?**

Just logs/docs.

**Did you add tests for your changes?**

Updated. None added

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Not relevant.