### PR TITLE
feat(import.meta): add dirname and filename

### DIFF
--- a/lib/NodeStuffPlugin.js
+++ b/lib/NodeStuffPlugin.js
@@ -1,13 +1,15 @@
 /*
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
+	Author Aviv Keller @avivkeller
 */
 
 "use strict";
 
 const {
 	JAVASCRIPT_MODULE_TYPE_AUTO,
-	JAVASCRIPT_MODULE_TYPE_DYNAMIC
+	JAVASCRIPT_MODULE_TYPE_DYNAMIC,
+	JAVASCRIPT_MODULE_TYPE_ESM
 } = require("./ModuleTypeConstants");
 const NodeStuffInWebError = require("./NodeStuffInWebError");
 const RuntimeGlobals = require("./RuntimeGlobals");
@@ -16,7 +18,8 @@ const ConstDependency = require("./dependencies/ConstDependency");
 const ExternalModuleDependency = require("./dependencies/ExternalModuleDependency");
 const {
 	evaluateToString,
-	expressionIsUnsupported
+	expressionIsUnsupported,
+	toConstantDependency
 } = require("./javascript/JavascriptParserHelpers");
 const { relative } = require("./util/fs");
 const { parseResource } = require("./util/identifier");
@@ -25,9 +28,10 @@ const { parseResource } = require("./util/identifier");
 /** @typedef {import("../declarations/WebpackOptions").NodeOptions} NodeOptions */
 /** @typedef {import("./Compiler")} Compiler */
 /** @typedef {import("./Dependency").DependencyLocation} DependencyLocation */
+/** @typedef {import("./javascript/BasicEvaluatedExpression")} BasicEvaluatedExpression */
+/** @typedef {import("estree").Expression} Expression */
 /** @typedef {import("./NormalModule")} NormalModule */
 /** @typedef {import("./javascript/JavascriptParser")} JavascriptParser */
-/** @typedef {import("./javascript/JavascriptParser").Expression} Expression */
 /** @typedef {import("./javascript/JavascriptParser").Range} Range */
 /** @typedef {import("./util/fs").InputFileSystem} InputFileSystem */
 
@@ -57,11 +61,12 @@ class NodeStuffPlugin {
 				);
 
 				/**
+				 * @param {string} mode mode
 				 * @param {JavascriptParser} parser the parser
 				 * @param {JavascriptParserOptions} parserOptions options
 				 * @returns {void}
 				 */
-				const handler = (parser, parserOptions) => {
+				const handler = (mode, parser, parserOptions) => {
 					if (parserOptions.node === false) return;
 
 					let localOptions = options;
@@ -69,220 +74,301 @@ class NodeStuffPlugin {
 						localOptions = { ...localOptions, ...parserOptions.node };
 					}
 
-					if (localOptions.global !== false) {
-						/**
-						 * @param {Expression} expr expression
-						 * @returns {ConstDependency} const dependency
-						 */
-						const getGlobalDep = (expr) => {
-							if (compilation.outputOptions.environment.globalThis) {
-								return new ConstDependency(
-									"globalThis",
-									/** @type {Range} */ (expr.range)
-								);
-							}
+					const isESM =
+						mode === JAVASCRIPT_MODULE_TYPE_DYNAMIC ||
+						mode === JAVASCRIPT_MODULE_TYPE_AUTO;
 
-							return new ConstDependency(
-								RuntimeGlobals.global,
+					const isCJS =
+						mode === JAVASCRIPT_MODULE_TYPE_DYNAMIC ||
+						mode === JAVASCRIPT_MODULE_TYPE_AUTO;
+
+					const context = compiler.context;
+					const inputFileSystem = /** @type {InputFileSystem} */ (
+						compiler.inputFileSystem
+					);
+
+					/**
+					 * Get path value based on option type
+					 * @param {string | boolean} type Option value
+					 * @param {string} mockPath Mock path to return
+					 * @param {() => string} realPath Function to get real path
+					 * @returns {string} path
+					 */
+					const getPathValue = (type, mockPath, realPath) => {
+						if (type === true) {
+							return JSON.stringify(realPath());
+						}
+
+						return JSON.stringify(mockPath);
+					};
+
+					/**
+					 * Get filename value
+					 * @param {string | boolean} type Option value
+					 * @param {NormalModule} module Module
+					 * @returns {string} filename
+					 */
+					const getFilename = (type, module) =>
+						getPathValue(type, "/index.js", () =>
+							relative(inputFileSystem, context, module.resource)
+						);
+
+					/**
+					 * Get dirname value
+					 * @param {string | boolean} type Option value
+					 * @param {NormalModule} module Module
+					 * @returns {string} directory name
+					 */
+					const getDirname = (type, module) =>
+						getPathValue(type, "/", () =>
+							relative(
+								inputFileSystem,
+								context,
+								/** @type {string} */ (module.context)
+							)
+						);
+
+					/**
+					 * Create expression handler that adds a dependency
+					 * @param {string | boolean} optionValue Option value
+					 * @param {(module: NormalModule) => string} valueGetter Value getter
+					 * @param {string} propertyName Property name
+					 * @param {boolean=} cache cache
+					 * @returns {(expr: Expression, allowEmits?: boolean) => boolean} handler
+					 */
+					const createDependencyHandler = (
+						optionValue,
+						valueGetter,
+						propertyName,
+						cache = true
+					) => {
+						const DepClass = cache ? CachedConstDependency : ConstDependency;
+						const prop = cache ? propertyName : [propertyName];
+
+						const withWarning =
+							optionValue === "warn-mock" || optionValue === "warn";
+
+						return (expr, allowEmits = true) => {
+							const dep = new DepClass(
+								valueGetter(parser.state.module),
 								/** @type {Range} */ (expr.range),
-								[RuntimeGlobals.global]
+								/** @type {EXPECTED_ANY} */ (prop)
 							);
-						};
-
-						const withWarning = localOptions.global === "warn";
-						parser.hooks.expression.for("global").tap(PLUGIN_NAME, (expr) => {
-							const dep = getGlobalDep(expr);
 							dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 							parser.state.module.addPresentationalDependency(dep);
 
 							// TODO webpack 6 remove
-							if (withWarning) {
+							if (withWarning && allowEmits) {
+								const isGlobalObject = propertyName === RuntimeGlobals.global;
+
 								parser.state.module.addWarning(
 									new NodeStuffInWebError(
 										dep.loc,
-										"global",
-										"The global namespace object is a Node.js feature and isn't available in browsers."
+										isGlobalObject ? "global" : propertyName,
+										`${isGlobalObject ? "The global namespace" : propertyName} is a Node.js feature and isn't available in browsers.`
 									)
 								);
 							}
-						});
-						parser.hooks.rename.for("global").tap(PLUGIN_NAME, (expr) => {
-							const dep = getGlobalDep(expr);
+
+							return true;
+						};
+					};
+
+					/**
+					 * Create expression handler for node-module mode
+					 * @param {string} propertyName Property name
+					 * @returns {(expr: Expression) => boolean} handler
+					 */
+					const createNodeModuleHandler = (propertyName) => {
+						const importMetaName = compilation.outputOptions.importMetaName;
+						const expression =
+							propertyName === "__filename"
+								? `__webpack_fileURLToPath__(${importMetaName}.url)`
+								: `__webpack_fileURLToPath__(${importMetaName}.url + "/..").slice(0, -1)`;
+
+						return (expr) => {
+							const dep = new ExternalModuleDependency(
+								"url",
+								[{ name: "fileURLToPath", value: "__webpack_fileURLToPath__" }],
+								undefined,
+								expression,
+								/** @type {Range} */ (expr.range),
+								propertyName
+							);
 							dep.loc = /** @type {DependencyLocation} */ (expr.loc);
 							parser.state.module.addPresentationalDependency(dep);
-							return false;
-						});
-					}
+							return true;
+						};
+					};
 
 					/**
-					 * @param {string} expressionName expression name
-					 * @param {(module: NormalModule) => string} fn function
-					 * @param {string=} warning warning
-					 * @returns {void}
+					 * Create evaluateIdentifier handler for global properties
+					 * @param {string} propertyName Property name
+					 * @returns {(expr: Expression) => BasicEvaluatedExpression} handler
 					 */
-					const setModuleConstant = (expressionName, fn, warning) => {
-						parser.hooks.expression
-							.for(expressionName)
+					const createEvaluateIdentifierHandler = (propertyName) => {
+						if (propertyName === "__filename") {
+							return (expr) => {
+								const { path } = parseResource(parser.state.module.resource);
+								return evaluateToString(path)(expr);
+							};
+						}
+
+						return (expr) =>
+							evaluateToString(
+								/** @type {string} */ (parser.state.module.context)
+							)(expr);
+					};
+
+					/**
+					 * Define import.meta properties
+					 * @param {string} propertyName Property name (e.g., "filename", "dirname")
+					 * @param {string | boolean} optionValue Option value
+					 * @param {(type: string | boolean, module: NormalModule) => string} getter Value getter
+					 */
+					const defineImportMetaProperty = (
+						propertyName,
+						optionValue,
+						getter
+					) => {
+						const fullName = `import.meta.${propertyName}`;
+
+						if (propertyName !== "eval-only") {
+							parser.hooks.expression.for(fullName).tap(
+								PLUGIN_NAME,
+								createDependencyHandler(
+									optionValue,
+									(module) => getter(optionValue, module),
+									fullName,
+									false
+								)
+							);
+						}
+
+						parser.hooks.typeof
+							.for(fullName)
+							.tap(
+								PLUGIN_NAME,
+								toConstantDependency(parser, JSON.stringify("string"))
+							);
+						parser.hooks.evaluateTypeof
+							.for(fullName)
+							.tap(PLUGIN_NAME, evaluateToString("string"));
+						parser.hooks.evaluateIdentifier
+							.for(fullName)
 							.tap(PLUGIN_NAME, (expr) => {
-								const dep = new CachedConstDependency(
-									JSON.stringify(fn(parser.state.module)),
-									/** @type {Range} */
-									(expr.range),
-									expressionName
-								);
-								dep.loc = /** @type {DependencyLocation} */ (expr.loc);
-								parser.state.module.addPresentationalDependency(dep);
-
-								// TODO webpack 6 remove
-								if (warning) {
-									parser.state.module.addWarning(
-										new NodeStuffInWebError(dep.loc, expressionName, warning)
-									);
-								}
-
-								return true;
+								const value = getter(optionValue, parser.state.module);
+								return evaluateToString(value)(expr);
 							});
 					};
 
 					/**
-					 * @param {string} expressionName expression name
-					 * @param {(value: string) => string} fn function
-					 * @returns {void}
+					 * Define global properties like __filename and __dirname
+					 * @param {string} propertyName Property name
+					 * @param {string | boolean} optionValue Option value
+					 * @param {(type: string | boolean, module: NormalModule) => string} getter Value getter
 					 */
-					const setUrlModuleConstant = (expressionName, fn) => {
-						parser.hooks.expression
-							.for(expressionName)
-							.tap(PLUGIN_NAME, (expr) => {
-								const dep = new ExternalModuleDependency(
-									"url",
-									[
-										{
-											name: "fileURLToPath",
-											value: "__webpack_fileURLToPath__"
-										}
-									],
-									undefined,
-									fn("__webpack_fileURLToPath__"),
-									/** @type {Range} */ (expr.range),
-									expressionName
+					const defineGlobalProperty = (propertyName, optionValue, getter) => {
+						if (optionValue !== "eval-only") {
+							parser.hooks.expression
+								.for(propertyName)
+								.tap(
+									PLUGIN_NAME,
+									optionValue === "node-module"
+										? createNodeModuleHandler(propertyName)
+										: createDependencyHandler(
+												optionValue,
+												(module) => getter(optionValue, module),
+												propertyName
+											)
 								);
-								dep.loc = /** @type {DependencyLocation} */ (expr.loc);
-								parser.state.module.addPresentationalDependency(dep);
+						}
 
-								return true;
-							});
+						parser.hooks.evaluateIdentifier
+							.for(propertyName)
+							.tap(PLUGIN_NAME, createEvaluateIdentifierHandler(propertyName));
 					};
 
 					/**
-					 * @param {string} expressionName expression name
-					 * @param {string} value value
-					 * @param {string=} warning warning
-					 * @returns {void}
+					 * Setup property handlers
+					 * @param {keyof NodeOptions} propertyName Property name (e.g., "__filename", "__dirname")
+					 * @param {(type: string | boolean, module: NormalModule) => string} getter Value getter
 					 */
-					const setConstant = (expressionName, value, warning) =>
-						setModuleConstant(expressionName, () => value, warning);
+					const setupProperty = (propertyName, getter) => {
+						const optionValue = localOptions[propertyName];
+						if (!optionValue) return;
 
-					const context = compiler.context;
-					if (localOptions.__filename) {
-						switch (localOptions.__filename) {
-							case "mock":
-								setConstant("__filename", "/index.js");
-								break;
-							case "warn-mock":
-								setConstant(
-									"__filename",
-									"/index.js",
-									"__filename is a Node.js feature and isn't available in browsers."
-								);
-								break;
-							case "node-module": {
-								const importMetaName = compilation.outputOptions.importMetaName;
-
-								setUrlModuleConstant(
-									"__filename",
-									(functionName) => `${functionName}(${importMetaName}.url)`
-								);
-								break;
-							}
-							case true:
-								setModuleConstant("__filename", (module) =>
-									relative(
-										/** @type {InputFileSystem} */ (compiler.inputFileSystem),
-										context,
-										module.resource
-									)
-								);
-								break;
+						if (isCJS) {
+							defineGlobalProperty(propertyName, optionValue, getter);
 						}
 
-						parser.hooks.evaluateIdentifier
-							.for("__filename")
-							.tap(PLUGIN_NAME, (expr) => {
-								if (!parser.state.module) return;
-								const resource = parseResource(parser.state.module.resource);
-								return evaluateToString(resource.path)(expr);
-							});
-					}
-					if (localOptions.__dirname) {
-						switch (localOptions.__dirname) {
-							case "mock":
-								setConstant("__dirname", "/");
-								break;
-							case "warn-mock":
-								setConstant(
-									"__dirname",
-									"/",
-									"__dirname is a Node.js feature and isn't available in browsers."
-								);
-								break;
-							case "node-module": {
-								const importMetaName = compilation.outputOptions.importMetaName;
+						// Handle import.meta version
+						if (isESM) {
+							const importMetaPropertyName = propertyName.slice(2); // Remove "__" prefix
+							defineImportMetaProperty(
+								importMetaPropertyName,
+								optionValue,
+								getter
+							);
+						}
+					};
 
-								setUrlModuleConstant(
-									"__dirname",
-									(functionName) =>
-										`${functionName}(${importMetaName}.url + "/..").slice(0, -1)`
-								);
-								break;
-							}
-							case true:
-								setModuleConstant("__dirname", (module) =>
-									relative(
-										/** @type {InputFileSystem} */ (compiler.inputFileSystem),
-										context,
-										/** @type {string} */ (module.context)
-									)
-								);
-								break;
+					if (isCJS) {
+						// Handle global
+						if (localOptions.global !== false) {
+							const global = compilation.outputOptions.environment.globalThis
+								? "globalThis"
+								: RuntimeGlobals.global;
+
+							const renameHandler = createDependencyHandler(
+								/** @type {string} */ (localOptions.global),
+								() => global,
+								global,
+								false
+							);
+
+							parser.hooks.expression
+								.for("global")
+								.tap(PLUGIN_NAME, renameHandler);
+							parser.hooks.rename.for("global").tap(PLUGIN_NAME, (expr) => {
+								renameHandler(expr, false);
+								return false;
+							});
 						}
 
-						parser.hooks.evaluateIdentifier
-							.for("__dirname")
-							.tap(PLUGIN_NAME, (expr) => {
-								if (!parser.state.module) return;
-								return evaluateToString(
-									/** @type {string} */
-									(parser.state.module.context)
-								)(expr);
-							});
+						// Handle require.extensions
+						parser.hooks.expression
+							.for("require.extensions")
+							.tap(
+								PLUGIN_NAME,
+								expressionIsUnsupported(
+									parser,
+									"require.extensions is not supported by webpack. Use a loader instead."
+								)
+							);
 					}
-					parser.hooks.expression
-						.for("require.extensions")
-						.tap(
-							PLUGIN_NAME,
-							expressionIsUnsupported(
-								parser,
-								"require.extensions is not supported by webpack. Use a loader instead."
-							)
-						);
+
+					// Setup __filename and __dirname
+					setupProperty("__filename", getFilename);
+					setupProperty("__dirname", getDirname);
 				};
 
+				// Register handlers
 				normalModuleFactory.hooks.parser
 					.for(JAVASCRIPT_MODULE_TYPE_AUTO)
-					.tap(PLUGIN_NAME, handler);
+					.tap(PLUGIN_NAME, (a, b) =>
+						handler(JAVASCRIPT_MODULE_TYPE_AUTO, a, b)
+					);
+				normalModuleFactory.hooks.parser
+					.for(JAVASCRIPT_MODULE_TYPE_ESM)
+					.tap(PLUGIN_NAME, (a, b) =>
+						handler(JAVASCRIPT_MODULE_TYPE_ESM, a, b)
+					);
 				normalModuleFactory.hooks.parser
 					.for(JAVASCRIPT_MODULE_TYPE_DYNAMIC)
-					.tap(PLUGIN_NAME, handler);
+					.tap(PLUGIN_NAME, (a, b) =>
+						handler(JAVASCRIPT_MODULE_TYPE_DYNAMIC, a, b)
+					);
 			}
 		);
 	}

--- a/test/cases/parsing/filename/index.js
+++ b/test/cases/parsing/filename/index.js
@@ -9,3 +9,15 @@ it("should be a string (__dirname)", function() {
 	var d = __dirname;
 	expect(d).toBeTypeOf("string");
 });
+
+it("should be a string (import.meta.filename)", function() {
+	expect(import.meta.filename).toBeTypeOf("string");
+	var f = import.meta.filename;
+	expect(f).toBeTypeOf("string");
+});
+
+it("should be a string (import.meta.dirname)", function() {
+	expect(import.meta.dirname).toBeTypeOf("string");
+	var d = import.meta.dirname;
+	expect(d).toBeTypeOf("string");
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Fixes #18320 by adding the requested `import.meta` properties.

**What kind of change does this PR introduce?**

This PR adds support for `import.meta.{dirname,filename}`, having them return the identical data that `__dirname` and `__filename` return.

**Did you add tests for your changes?**

Yes. I verified that `import.meta.dirname + [filename] === import.meta.filename === an existing file`.
**Does this PR introduce a breaking change?**

No, this is a **semver-minor** change.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

Once merged, the additional properties must be documented accordingly.