### PR TITLE
feat: optimize regex generation using character ranges

### DIFF
--- a/lib/util/compileBooleanMatcher.js
+++ b/lib/util/compileBooleanMatcher.js
@@ -147,8 +147,32 @@ const itemsToRegexp = (itemsArr) => {
 		}
 	}
 	// special case for only single char items
+	// optimize by using character ranges: e.g., [1-4a] instead of [1234a]
 	if (countOfSingleCharItems === itemsArr.length) {
-		return `[${quoteMeta(itemsArr.sort().join(""))}]`;
+		const sorted = itemsArr.sort();
+		const ranges = [];
+		let start = sorted[0];
+		let prev = sorted[0];
+		for (let i = 1; i < sorted.length; i++) {
+			const current = sorted[i];
+			if (current.charCodeAt(0) === prev.charCodeAt(0) + 1) {
+				prev = current;
+			} else {
+				if (start === prev) {
+					ranges.push(quoteMeta(start));
+				} else {
+					ranges.push(`${quoteMeta(start)}-${quoteMeta(prev)}`);
+				}
+				start = current;
+				prev = current;
+			}
+		}
+		if (start === prev) {
+			ranges.push(quoteMeta(start));
+		} else {
+			ranges.push(`${quoteMeta(start)}-${quoteMeta(prev)}`);
+		}
+		return `[${ranges.join("")}]`;
 	}
 	/** @type {Set<string>} */
 	const items = new Set(itemsArr.sort());


### PR DESCRIPTION
**Summary**

This PR optimizes regex generation in compileBooleanMatcher by using character ranges for better performance.

**Changes:**
- Convert consecutive single characters to ranges: `[1-4a]` instead of `[1234a]`
- Improves regex performance and reduces size
- Resolves TODO comment for further regex optimization

**What kind of change does this PR introduce?**

- [x] Feature
- [x] Performance

**Did you add tests for your changes?**

- [ ] Yes
- [x] No (changes are internal optimizations that don't require new tests - existing test suite covers the functionality)

**Does this PR introduce a breaking change?**

- [x] No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

- [x] Nothing - these are internal improvements that don't affect public APIs
