### PR TITLE
refactor: pass extractSourceMap correctly when build from cache

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -487,6 +487,7 @@ class NormalModule extends Module {
 		this.context = m.context;
 		this.matchResource = m.matchResource;
 		this.loaders = m.loaders;
+		this.extractSourceMap = m.extractSourceMap;
 	}
 
 	/**
@@ -1721,7 +1722,6 @@ class NormalModule extends Module {
 		write(this._lastSuccessfulBuildMeta);
 		write(this._forceBuild);
 		write(this._codeGeneratorData);
-		write(this.extractSourceMap);
 		super.serialize(context);
 	}
 
@@ -1746,7 +1746,8 @@ class NormalModule extends Module {
 			parserOptions: /** @type {EXPECTED_ANY} */ (null),
 			generator: /** @type {EXPECTED_ANY} */ (null),
 			generatorOptions: /** @type {EXPECTED_ANY} */ (null),
-			resolveOptions: /** @type {EXPECTED_ANY} */ (null)
+			resolveOptions: /** @type {EXPECTED_ANY} */ (null),
+			extractSourceMap: /** @type {EXPECTED_ANY} */ (null)
 		});
 		obj.deserialize(context);
 		return obj;
@@ -1762,7 +1763,6 @@ class NormalModule extends Module {
 		this._lastSuccessfulBuildMeta = read();
 		this._forceBuild = read();
 		this._codeGeneratorData = read();
-		this.extractSourceMap = read();
 		super.deserialize(context);
 	}
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

It’s better to populate `extractSourceMap` by `cacheModule.updateCacheModule(module)` when `addModule` instead of performing direct `serialization/deserialization`.
 
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

I believe it already exists in `ConfigCacheTest`, but feel free to request more.

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
