### PR TITLE
fix: reexport module for default import when no used exports for systemjs library

### DIFF
--- a/lib/library/SystemLibraryPlugin.js
+++ b/lib/library/SystemLibraryPlugin.js
@@ -164,6 +164,10 @@ class SystemLibraryPlugin extends AbstractLibraryPlugin {
 												`Object.defineProperty(${external}, "__esModule", { value: true });`
 											);
 										}
+										// See comment above
+										instructions.push(
+											`${external}["default"] = module["default"] || module;`
+										);
 										if (handledNames.length > 0) {
 											const name = `${external}handledNames`;
 											externalVarInitialization.push(

--- a/test/configCases/library/1-systemjs-external-commonjs-used-exports-false/system-external-commonjs.js
+++ b/test/configCases/library/1-systemjs-external-commonjs-used-exports-false/system-external-commonjs.js
@@ -1,0 +1,7 @@
+import MyClass, {a, b} from "library-commonjs";
+
+it("should get exports from systemjs library (" + NAME + ")", function() {
+	expect(new MyClass().getValue()).toBe("my-class")
+	expect(a).toBe(10);
+	expect(b).toBe(20);
+});

--- a/test/configCases/library/1-systemjs-external-commonjs-used-exports-false/test.config.js
+++ b/test/configCases/library/1-systemjs-external-commonjs-used-exports-false/test.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const System = require("../../../helpers/fakeSystem");
+
+module.exports = {
+	beforeExecute: () => {
+		System.init();
+	},
+	moduleScope(scope) {
+		scope.System = System;
+		scope.System.setRequire(scope.require);
+	},
+	afterExecute() {
+		delete global.webpackChunk;
+		System.execute("(anonym)");
+	}
+};

--- a/test/configCases/library/1-systemjs-external-commonjs-used-exports-false/webpack.config.js
+++ b/test/configCases/library/1-systemjs-external-commonjs-used-exports-false/webpack.config.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {(env: Env, options: TestOptions) => import("../../../../").Configuration[]} */
+module.exports = (env, { testPath }) => [
+	{
+		entry: "./system-external-commonjs.js",
+		output: {
+			library: {
+				type: "system"
+			}
+		},
+		externals: {
+			"library-commonjs": path.resolve(
+				testPath,
+				"../0-create-library/system-commonjs.js"
+			)
+		},
+		optimization: {
+			usedExports: false
+		},
+		plugins: [
+			new webpack.DefinePlugin({
+				NAME: JSON.stringify("systemjs with external from commonjs format")
+			})
+		]
+	}
+];

--- a/test/configCases/library/1-systemjs-external-esm-used-exports-false/system-external-esm.js
+++ b/test/configCases/library/1-systemjs-external-esm-used-exports-false/system-external-esm.js
@@ -1,0 +1,7 @@
+import MyClass, {a, b} from "library-esm";
+
+it("should get exports from systemjs library (" + NAME + ")", function() {
+	expect(new MyClass().getValue()).toBe("my-class")
+	expect(a).toBe(10);
+	expect(b).toBe(20);
+});

--- a/test/configCases/library/1-systemjs-external-esm-used-exports-false/test.config.js
+++ b/test/configCases/library/1-systemjs-external-esm-used-exports-false/test.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const System = require("../../../helpers/fakeSystem");
+
+module.exports = {
+	beforeExecute: () => {
+		System.init();
+	},
+	moduleScope(scope) {
+		scope.System = System;
+		scope.System.setRequire(scope.require);
+	},
+	afterExecute() {
+		delete global.webpackChunk;
+		System.execute("(anonym)");
+	}
+};

--- a/test/configCases/library/1-systemjs-external-esm-used-exports-false/webpack.config.js
+++ b/test/configCases/library/1-systemjs-external-esm-used-exports-false/webpack.config.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {(env: Env, options: TestOptions) => import("../../../../").Configuration[]} */
+module.exports = (env, { testPath }) => [
+	{
+		entry: "./system-external-esm.js",
+		output: {
+			library: {
+				type: "system"
+			}
+		},
+		externals: {
+			"library-esm": path.resolve(testPath, "../0-create-library/system-esm.js")
+		},
+		optimization: {
+			usedExports: false
+		},
+		plugins: [
+			new webpack.DefinePlugin({
+				NAME: JSON.stringify("systemjs with external from ES module format")
+			})
+		]
+	}
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

fixes https://github.com/orgs/webpack/discussions/19922#discussioncomment-14662046


**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Nothing

/cc @xiaoxiaojx @hai-x Let's make this change when `usedExports: false`, but to be honestly we need an option for such behavior like typescript has...
