### PR TITLE
fix: rename HarmonyExportDependencyParserPlugin exported id to CompatibilityPlugin tagged id

### DIFF
--- a/lib/CompatibilityPlugin.js
+++ b/lib/CompatibilityPlugin.js
@@ -37,7 +37,6 @@ const nestedWebpackIdentifierTag = Symbol("nested webpack identifier");
 const PLUGIN_NAME = "CompatibilityPlugin";
 
 class CompatibilityPlugin {
-	static nestedWebpackIdentifierTag = nestedWeb1packIdentifierTag
 	/**
 	 * Apply the plugin
 	 * @param {Compiler} compiler the compiler instance
@@ -212,3 +211,4 @@ class CompatibilityPlugin {
 }
 
 module.exports = CompatibilityPlugin;
+module.exports.nestedWebpackIdentifierTag = nestedWebpackIdentifierTag;

--- a/lib/dependencies/HarmonyExportDependencyParserPlugin.js
+++ b/lib/dependencies/HarmonyExportDependencyParserPlugin.js
@@ -27,6 +27,7 @@ const HarmonyImportSideEffectDependency = require("./HarmonyImportSideEffectDepe
 /** @typedef {import("../javascript/JavascriptParser").FunctionDeclaration} FunctionDeclaration */
 /** @typedef {import("../javascript/JavascriptParser").Range} Range */
 /** @typedef {import("./HarmonyImportDependencyParserPlugin").HarmonySettings} HarmonySettings */
+/** @typedef {import("../CompatibilityPlugin").CompatibilitySettings} CompatibilitySettings */
 
 const { HarmonyStarExportsList } = HarmonyExportImportedSpecifierDependency;
 
@@ -158,10 +159,16 @@ module.exports = class HarmonyExportDependencyParserPlugin {
 		parser.hooks.exportSpecifier.tap(
 			PLUGIN_NAME,
 			(statement, id, name, idx) => {
-				const variable = parser.getTagData(id, CompatibilityPlugin.nestedWebpackIdentifierTag);
-
-				if (variable && variable.name) {
-					id = variable.name
+				// CompatibilityPlugin may change exports name
+				// not handle re-export or import then export situation as current CompatibilityPlugin only
+				// rename symbol in declaration module, not change exported symbol
+				const variable = parser.getTagData(
+					id,
+					CompatibilityPlugin.nestedWebpackIdentifierTag
+				);
+				if (variable && /** @type {CompatibilitySettings} */ (variable).name) {
+					// CompatibilityPlugin changes exports to a new name, should updates exports name
+					id = /** @type {CompatibilitySettings} */ (variable).name;
 				}
 
 				const settings =

--- a/test/configCases/module/consume-webpack-runtime/index.js
+++ b/test/configCases/module/consume-webpack-runtime/index.js
@@ -1,0 +1,23 @@
+import { __webpack_require__ as namedUse } from './runtime-export-named'
+import defaultUse from './runtime-export-default'
+import { __webpack_require__ as namedDeclUse } from './runtime-export-decl'
+
+it("should compile and run", () => {
+	expect(namedUse()).toBe(42);
+	expect(defaultUse()).toBe(42);
+	expect(namedDeclUse()).toBe(42);
+
+	const path = __non_webpack_require__('path')
+	const fs = __non_webpack_require__('fs')
+	{
+		const content = fs.readFileSync(path.resolve(__dirname, './bundle0.js'), 'utf-8')
+		const NESTED_RE = /__nestede_webpack_require_(.+)__/
+		expect(content.match(NESTED_RE)[1].length).toBeGreaterThan(1)
+	}
+
+	{
+		const content = fs.readFileSync(path.resolve(__dirname, './bundle1.js'), 'utf-8')
+		const NESTED_RE = /__nestede_webpack_require_(.+)__/
+		expect(content.match(NESTED_RE)[1].length).toBeGreaterThan(1)
+	}
+});

--- a/test/configCases/module/consume-webpack-runtime/runtime-export-decl.js
+++ b/test/configCases/module/consume-webpack-runtime/runtime-export-decl.js
@@ -1,0 +1,3 @@
+export function __webpack_require__() {	return 42}
+__webpack_require__.m = () => {}
+

--- a/test/configCases/module/consume-webpack-runtime/runtime-export-default.js
+++ b/test/configCases/module/consume-webpack-runtime/runtime-export-default.js
@@ -1,0 +1,3 @@
+function __webpack_require__() {return 42}
+__webpack_require__.m = () => {}
+export default __webpack_require__

--- a/test/configCases/module/consume-webpack-runtime/runtime-export-named.js
+++ b/test/configCases/module/consume-webpack-runtime/runtime-export-named.js
@@ -1,0 +1,4 @@
+
+function __webpack_require__() {return 42}
+__webpack_require__.m = () => {}
+export {__webpack_require__}

--- a/test/configCases/module/consume-webpack-runtime/webpack.config.js
+++ b/test/configCases/module/consume-webpack-runtime/webpack.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+/** @type {import("../../../../types").Configuration} */
+module.exports = [
+	{
+		node: false,
+		mode: "production",
+		devtool: false,
+		optimization: {
+			concatenateModules: true
+		}
+	},
+	{
+		node: false,
+		mode: "production",
+		devtool: false,
+		optimization: {
+			concatenateModules: false
+		}
+	}
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

fix #20030

ParserPlugin should not change the AST itself, it should only read, not mutate the AST structure. As we lack of the machanism to make a transform to the AST, CompatibilityPlugin use tag to rename the local symbol of webpack runtime, but it cannot modify the exported symbol. 

So I made a change that let HarmonyExportDependencyParserPlugin get the tagged data from CompatibilityPlugin, and change the id coordinately

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
