### PR TITLE
refactor: cache fs calls

### DIFF
--- a/lib/DotenvPlugin.js
+++ b/lib/DotenvPlugin.js
@@ -448,9 +448,9 @@ class DotenvPlugin {
 	 */
 	_loadFile(fs, file) {
 		return new Promise((resolve, reject) => {
-			fs.readFile(file, "utf8", (err, content) => {
+			fs.readFile(file, (err, content) => {
 				if (err) reject(err);
-				else resolve(content || "");
+				else resolve(/** @type {Buffer} */ (content).toString() || "");
 			});
 		});
 	}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

cache fs calls, by default webpack caches all fs calls without options

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

Existing

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No
