### PR TITLE
fix(library): correct export aggregation for multiple library entries (#15936)

### DIFF
--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1275,6 +1275,7 @@ class JavascriptModulesPlugin {
 				const runtimeRequirements =
 					chunkGraph.getTreeRuntimeRequirements(chunk);
 				buf2.push("// Load entry module and return exports");
+				if (useRequire) buf2.push(`var ${RuntimeGlobals.exports} = {};`);
 				let i = chunkGraph.getNumberOfEntryModules(chunk);
 				for (const [
 					entryModule,
@@ -1383,9 +1384,7 @@ class JavascriptModulesPlugin {
 						);
 					} else if (useRequire) {
 						buf2.push(
-							`${i === 0 ? `var ${RuntimeGlobals.exports} = ` : ""}${
-								RuntimeGlobals.require
-							}(${moduleIdExpr});`
+							`Object.assign(${RuntimeGlobals.exports}, ${RuntimeGlobals.require}(${moduleIdExpr}));`
 						);
 					} else {
 						if (i === 0) buf2.push(`var ${RuntimeGlobals.exports} = {};`);


### PR DESCRIPTION
Fixes #15936


**What kind of change does this PR introduce?**
A bugfix.

**Did you add tests for your changes?**
No, I have not added a new test case because I am still learning the project's complex testing structure, but I have verified the fix with the original reproduction repository (TGRHavoc/webpack-mvp) and confirmed it passes the full test suite without new failures.

**Does this PR introduce a breaking change?**
No, this PR fixes unintended behavior; it ensures exports from multiple entry points work as expected when using the library feature.


**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
N/A - This is a bug fix in core functionality and does not require new documentation, only that the existing documentation now works correctly.

