### PR TITLE
fix: incorrect identifier of import binding for module externals

### DIFF
--- a/lib/ConcatenationScope.js
+++ b/lib/ConcatenationScope.js
@@ -113,18 +113,6 @@ class ConcatenationScope {
 	}
 
 	/**
-	 * @param {string} symbol identifier of the export in source code
-	 * @returns {boolean} registered success
-	 */
-	registerUsedName(symbol) {
-		if (this.usedNames.has(symbol)) {
-			return false;
-		}
-		this.usedNames.add(symbol);
-		return true;
-	}
-
-	/**
 	 * @param {Module} module the referenced module
 	 * @param {Partial<ModuleReferenceOptions>} options options
 	 * @returns {string} the reference as identifier
@@ -188,8 +176,5 @@ class ConcatenationScope {
 
 ConcatenationScope.DEFAULT_EXPORT = DEFAULT_EXPORT;
 ConcatenationScope.NAMESPACE_OBJECT_EXPORT = NAMESPACE_OBJECT_EXPORT;
-
-/** @type {WeakMap<Chunk, Set<string>>} */
-ConcatenationScope.chunkUsedNames = new WeakMap();
 
 module.exports = ConcatenationScope;

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -474,22 +474,6 @@ const getSourceForModuleExternal = (
 		runtimeTemplate.outputOptions.hashFunction
 	);
 	const normalizedImported = initFragment.getImported();
-	const specifiers =
-		normalizedImported === true
-			? undefined
-			: /** @type {[string, string][]} */ (
-					normalizedImported.map(([name, rawFinalName]) => {
-						let finalName = rawFinalName;
-						let counter = 0;
-
-						if (concatenationScope) {
-							while (!concatenationScope.registerUsedName(finalName)) {
-								finalName = `${finalName}_${counter++}`;
-							}
-						}
-						return [name, finalName];
-					})
-				);
 
 	const baseAccess = `${initFragment.getNamespaceIdentifier()}${propertyAccess(
 		moduleAndSpecifiers,
@@ -519,7 +503,7 @@ const getSourceForModuleExternal = (
 					"x"
 				)}`
 			: undefined,
-		specifiers,
+		specifiers: normalizedImported === true ? undefined : normalizedImported,
 		runtimeRequirements: moduleRemapping
 			? RUNTIME_REQUIREMENTS_FOR_MODULE
 			: undefined,

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -224,8 +224,6 @@ const compareNumbers = (a, b) => {
 const bySourceOrder = createComparator("sourceOrder", compareNumbers);
 const byRangeStart = createComparator("rangeStart", compareNumbers);
 
-const INITIAL_USED_NAMES = new Set(RESERVED_NAMES);
-
 /**
  * @param {Iterable<string>} iterable iterable object
  * @returns {string} joined iterable object
@@ -1276,18 +1274,8 @@ class ConcatenatedModule extends Module {
 		/** @type {NeededNamespaceObjects} */
 		const neededNamespaceObjects = new Set();
 
-		// Default disallowed names
-		const allUsedNames = new Set(INITIAL_USED_NAMES);
-		const chunks = chunkGraph.getModuleChunks(this);
-
-		// Add names already used in the current chunk scope
-		for (const chunk of chunks) {
-			if (ConcatenationScope.chunkUsedNames.has(chunk)) {
-				for (const name of ConcatenationScope.chunkUsedNames.get(chunk) || []) {
-					allUsedNames.add(name);
-				}
-			}
-		}
+		// List of all used names to avoid conflicts
+		const allUsedNames = new Set(RESERVED_NAMES);
 
 		// Generate source code and analyse scopes
 		// Prepare a ReplaceSource for the final source
@@ -1304,23 +1292,6 @@ class ConcatenatedModule extends Module {
 				(codeGenerationResults),
 				allUsedNames
 			);
-		}
-
-		// Record the names registered by the current ConcatenatedModule into the chunk scope
-		if (INITIAL_USED_NAMES.size !== allUsedNames.size) {
-			for (const name of allUsedNames) {
-				if (INITIAL_USED_NAMES.has(name)) continue;
-
-				for (const chunk of chunks) {
-					if (!ConcatenationScope.chunkUsedNames.has(chunk)) {
-						ConcatenationScope.chunkUsedNames.set(chunk, new Set([name]));
-					} else {
-						/** @type {Set<string>} */ (
-							ConcatenationScope.chunkUsedNames.get(chunk)
-						).add(name);
-					}
-				}
-			}
 		}
 
 		// Updated Top level declarations are created by renaming

--- a/test/configCases/library/module-external-multi-entry/cjs-concat.js
+++ b/test/configCases/library/module-external-multi-entry/cjs-concat.js
@@ -1,0 +1,1 @@
+module.exports = require("./foo1").foo;

--- a/test/configCases/library/module-external-multi-entry/concat1.js
+++ b/test/configCases/library/module-external-multi-entry/concat1.js
@@ -1,0 +1,5 @@
+import { a as concat2_a, b as concat2_b, c as concat2_c } from "./concat2";
+
+export const a = "concat1~" + concat2_a;
+export const b = "concat1~" + concat2_b;
+export const c = "concat1~" + concat2_c;

--- a/test/configCases/library/module-external-multi-entry/concat2.js
+++ b/test/configCases/library/module-external-multi-entry/concat2.js
@@ -1,0 +1,5 @@
+import { a as external_a, b as external_b, c as external_c } from "external";
+
+export const a = "concat2~" + external_a;
+export const b = "concat2~" + external_b;
+export const c = "concat2~" + external_c;

--- a/test/configCases/library/module-external-multi-entry/entry1.js
+++ b/test/configCases/library/module-external-multi-entry/entry1.js
@@ -1,0 +1,12 @@
+// This concat module has size `4`
+import { a, b, c } from "./concat1";
+
+// Create one shared concat module that exist in multiple chunks
+import cjs from "./cjs-concat";
+
+it("should generate correct specifier pointed to import binding / 1", function () {
+	expect(a).toBe("concat1~concat2~external-a");
+	expect(b).toBe("concat1~concat2~external-b");
+	expect(c).toBe("concat1~concat2~external-c");
+	expect(cjs).toBe("foo1~foo2~foo3~foo4");
+});

--- a/test/configCases/library/module-external-multi-entry/entry2.js
+++ b/test/configCases/library/module-external-multi-entry/entry2.js
@@ -1,0 +1,12 @@
+// This concat module has size `3`
+import { a, b, c } from "./concat2";
+
+// Create one shared concat module that exist in multiple chunks
+import cjs from "./cjs-concat";
+
+it("should generate correct specifier pointed to import binding / 2", function () {
+	expect(a).toBe("concat2~external-a");
+	expect(b).toBe("concat2~external-b");
+	expect(c).toBe("concat2~external-c");
+	expect(cjs).toBe("foo1~foo2~foo3~foo4");
+});

--- a/test/configCases/library/module-external-multi-entry/external.mjs
+++ b/test/configCases/library/module-external-multi-entry/external.mjs
@@ -1,0 +1,3 @@
+export const a = "external-a"
+export const b = "external-b"
+export const c = "external-c"

--- a/test/configCases/library/module-external-multi-entry/foo1.js
+++ b/test/configCases/library/module-external-multi-entry/foo1.js
@@ -1,0 +1,4 @@
+// This concat module has size `4`
+import foo2 from "./foo2";
+
+export const foo = "foo1~" + foo2;

--- a/test/configCases/library/module-external-multi-entry/foo2.js
+++ b/test/configCases/library/module-external-multi-entry/foo2.js
@@ -1,0 +1,3 @@
+import foo3 from "./foo3";
+
+export default "foo2~" + foo3;

--- a/test/configCases/library/module-external-multi-entry/foo3.js
+++ b/test/configCases/library/module-external-multi-entry/foo3.js
@@ -1,0 +1,3 @@
+import foo4 from "./foo4";
+
+export default "foo3~" + foo4;

--- a/test/configCases/library/module-external-multi-entry/foo4.js
+++ b/test/configCases/library/module-external-multi-entry/foo4.js
@@ -1,0 +1,1 @@
+export default "foo4"

--- a/test/configCases/library/module-external-multi-entry/test.config.js
+++ b/test/configCases/library/module-external-multi-entry/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["entry1.mjs", "entry2.mjs"];
+	}
+};

--- a/test/configCases/library/module-external-multi-entry/webpack.config.js
+++ b/test/configCases/library/module-external-multi-entry/webpack.config.js
@@ -1,0 +1,53 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {webpack.Configuration} */
+module.exports = {
+	mode: "production",
+	entry: { entry1: "./entry1.js", entry2: "./entry2.js" },
+	output: {
+		module: true,
+		library: {
+			type: "module"
+		},
+		filename: "[name].mjs"
+	},
+	experiments: {
+		outputModule: true
+	},
+	externals: {
+		external: "./external.mjs"
+	},
+	externalsType: "module",
+	optimization: {
+		concatenateModules: true,
+		usedExports: true
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.compilation.tap("Test", (compilation) => {
+					compilation.hooks.processAssets.tap(
+						{
+							name: "copy-webpack-plugin",
+							stage:
+								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+						},
+						() => {
+							const data = fs.readFileSync(
+								path.resolve(__dirname, "./external.mjs")
+							);
+							compilation.emitAsset(
+								"external.mjs",
+								new webpack.sources.RawSource(data)
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};

--- a/test/configCases/library/render-order-issue/webpack.config.js
+++ b/test/configCases/library/render-order-issue/webpack.config.js
@@ -2,7 +2,7 @@
 
 /** @type {import("../../../../types").Configuration} */
 module.exports = {
-	mode: "development",
+	mode: "production",
 	devtool: false,
 	optimization: {
 		minimize: false,

--- a/types.d.ts
+++ b/types.d.ts
@@ -2970,7 +2970,6 @@ declare class ConcatenationScope {
 	getRawExport(exportName: string): undefined | string;
 	setRawExportMap(exportName: string, expression: string): void;
 	registerNamespaceExport(symbol: string): void;
-	registerUsedName(symbol: string): boolean;
 	createModuleReference(
 		module: Module,
 		__1: Partial<ModuleReferenceOptions>
@@ -2981,7 +2980,6 @@ declare class ConcatenationScope {
 	): null | (ModuleReferenceOptions & { index: number });
 	static DEFAULT_EXPORT: string;
 	static NAMESPACE_OBJECT_EXPORT: string;
-	static chunkUsedNames: WeakMap<Chunk, Set<string>>;
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fixes part of https://github.com/webpack/webpack/issues/20088. We need to ensure consistent binding names.

We now construct the import binding name using the `module identifier` and `export name`, resolving the binding name conflict issue described in [#19867](https://github.com/webpack/webpack/pull/19867)￼. As a result, recording `chunkUsedNames` and the binding usage counter is no longer necessary.

cc @xiaoxiaojx 

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
