### PR TITLE
devtool(eval): coerce createScript result to string before eval

### DIFF
--- a/lib/EvalDevToolModulePlugin.js
+++ b/lib/EvalDevToolModulePlugin.js
@@ -95,9 +95,9 @@ class EvalDevToolModulePlugin {
 					const result = new RawSource(
 						`eval(${
 							compilation.outputOptions.trustedTypes
-								? `${RuntimeGlobals.createScript}(${JSON.stringify(
+								? `String(${RuntimeGlobals.createScript}(${JSON.stringify(
 										`{${content + footer}\n}`
-									)})`
+									)}))`
 								: JSON.stringify(`{${content + footer}\n}`)
 						});`
 					);

--- a/lib/EvalSourceMapDevToolPlugin.js
+++ b/lib/EvalSourceMapDevToolPlugin.js
@@ -205,9 +205,9 @@ class EvalSourceMapDevToolPlugin {
 						new RawSource(
 							`eval(${
 								compilation.outputOptions.trustedTypes
-									? `${RuntimeGlobals.createScript}(${JSON.stringify(
+									? `String(${RuntimeGlobals.createScript}(${JSON.stringify(
 											`{${content + footer}\n}`
-										)})`
+										)}))`
 									: JSON.stringify(`{${content + footer}\n}`)
 							});`
 						)

--- a/test/configCases/trusted-types/devtool-eval/index.js
+++ b/test/configCases/trusted-types/devtool-eval/index.js
@@ -15,9 +15,7 @@ it("should pass TrustedScript to eval", function () {
 		expect.stringMatching(testPattern)
 	);
 	expect(window.eval).toHaveBeenCalledWith(
-		expect.objectContaining({
-			_script: expect.stringMatching(testPattern)
-		})
+		expect.stringMatching(testPattern)
 	);
 });
 
@@ -32,8 +30,8 @@ beforeEach(done => {
 	globalEval = eval;
 	window.module = {};
 	window.eval = jest.fn(x => {
-		expect(x).toBeInstanceOf(TrustedScript);
-		return globalEval(x._script);
+		expect(typeof x).toEqual("string");
+		return globalEval(x);
 	});
 	done();
 });


### PR DESCRIPTION
Coerce RuntimeGlobals.createScript(...) to a string before passing it to global eval in eval-based devtools. This avoids issues where TrustedScript-like objects can cause TypeErrors in certain browsers or break libraries such as pdf.js and react-pdf.

Changes:

lib/EvalDevToolModulePlugin.js: Wraps createScript(...) in String(...) when Trusted Types are enabled.

lib/EvalSourceMapDevToolPlugin.js: Makes the same update for the eval-source-map devtool.

test/configCases/trusted-types/devtool-eval/index.js: Updates tests to expect a string argument to eval.

Rationale:
Some browsers and libraries do not accept TrustedScript objects directly in eval. By coercing the value to a string, we ensure broader compatibility and avoid potential runtime errors, while keeping the intended behavior unchanged.

I’m happy to adapt this fix with a feature flag or runtime detection if maintainers prefer.
Please review—thanks for your time!