### PR TITLE
fix: module external need return to namespace in specific case

### DIFF
--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -443,10 +443,6 @@ const getSourceForModuleExternal = (
 	dependencyMeta,
 	concatenationScope
 ) => {
-	if (!Array.isArray(moduleAndSpecifiers)) {
-		moduleAndSpecifiers = [moduleAndSpecifiers];
-	}
-
 	/** @type {Imported} */
 	let imported = true;
 	if (concatenationScope) {
@@ -464,6 +460,15 @@ const getSourceForModuleExternal = (
 			default:
 				imported = [...usedExports.entries()];
 		}
+	}
+
+	if (!Array.isArray(moduleAndSpecifiers)) {
+		moduleAndSpecifiers = [moduleAndSpecifiers];
+	}
+
+	// Return to `namespace` when the external request includes a specific export
+	if (moduleAndSpecifiers.length > 1) {
+		imported = true;
 	}
 
 	const initFragment = new ModuleExternalInitFragment(

--- a/test/configCases/library/module-external-array-request/external.mjs
+++ b/test/configCases/library/module-external-array-request/external.mjs
@@ -1,0 +1,4 @@
+export const inner = {
+	foo: "foo",
+	bar: "bar"
+};

--- a/test/configCases/library/module-external-array-request/index.js
+++ b/test/configCases/library/module-external-array-request/index.js
@@ -1,0 +1,6 @@
+import { foo, bar } from "external";
+
+it("should have the correct export for array-style external request (e.g. external: ['./external.mjs', 'inner'])", function () {
+	expect(foo).toBe("foo");
+	expect(bar).toBe("bar");
+});

--- a/test/configCases/library/module-external-array-request/webpack.config.js
+++ b/test/configCases/library/module-external-array-request/webpack.config.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const webpack = require("../../../../");
+
+/** @type {webpack.Configuration} */
+module.exports = {
+	mode: "production",
+	entry: "./index.js",
+	output: {
+		module: true,
+		library: {
+			type: "module"
+		}
+	},
+	experiments: {
+		outputModule: true
+	},
+	externals: {
+		external: ["./external.mjs", "inner"]
+	},
+	externalsType: "module",
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.compilation.tap("Test", (compilation) => {
+					compilation.hooks.processAssets.tap(
+						{
+							name: "copy-webpack-plugin",
+							stage:
+								compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+						},
+						() => {
+							const data = fs.readFileSync(
+								path.resolve(__dirname, "./external.mjs")
+							);
+							compilation.emitAsset(
+								"external.mjs",
+								new webpack.sources.RawSource(data)
+							);
+						}
+					);
+				});
+			}
+		}
+	]
+};


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fixes https://github.com/webpack/webpack/issues/20125.

Ideally, for this test case, we should generate an import statement like the following:
```
import { inner as __WEBPACK_EXTERNAL_MODULE__external_mjs_d0ca6eb5_inner__ } from "./external.mjs";

// for reference only, in reality we need consider potential variable name conflicts in the chunk
const foo =  __WEBPACK_EXTERNAL_MODULE__external_mjs_d0ca6eb5_inner__.foo;
const bar = __WEBPACK_EXTERNAL_MODULE__external_mjs_d0ca6eb5_inner__.bar;
```

We need more work to implement it properly (e.g., generating extra export info for external modules and ensuring the correct final binding names). For now, I’m opting out of this optimization and will revisit it later if we find a better approach.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
