### PR TITLE
fix: injected debugId is corrupted if hidden-source-map is used

### DIFF
--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -496,7 +496,12 @@ class SourceMapDevToolPlugin {
 									if (options.debugIds) {
 										const debugId = generateDebugId(source, sourceMap.file);
 										sourceMap.debugId = debugId;
-										currentSourceMappingURLComment = `\n//# debugId=${debugId}${currentSourceMappingURLComment}`;
+
+										const debugIdComment = `\n//# debugId=${debugId}`;
+										currentSourceMappingURLComment =
+											currentSourceMappingURLComment
+												? `${debugIdComment}${currentSourceMappingURLComment}`
+												: debugIdComment;
 									}
 
 									const sourceMapString = JSON.stringify(sourceMap);

--- a/test/configCases/source-map/hidden-source-map-debugids/index.js
+++ b/test/configCases/source-map/hidden-source-map-debugids/index.js
@@ -1,0 +1,15 @@
+const fs = require("fs");
+
+it("source should include only debugId comment", function() {
+	const debugIdRegex = new RegExp('[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}', 'i');
+	const debugIdCommentRegex = new RegExp(`\n\/\/# debugId\s*=\s*${debugIdRegex.source}$`);
+
+	const source = fs.readFileSync(__filename, "utf-8");
+	console.log('SOURCE matches', source.match(debugIdCommentRegex));
+	expect(debugIdCommentRegex.test(source)).toBe(true);
+
+	const sourceMap = fs.readFileSync(__filename + ".map", "utf-8");
+	const map = JSON.parse(sourceMap);
+	expect(map.debugId).toBeDefined();
+	expect(debugIdRegex.test(map.debugId)).toBe(true);
+});

--- a/test/configCases/source-map/hidden-source-map-debugids/webpack.config.js
+++ b/test/configCases/source-map/hidden-source-map-debugids/webpack.config.js
@@ -1,0 +1,6 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	devtool: "hidden-source-map-debugids"
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

This PR fixes issue #20133.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

This is a bugfix.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

I've added a test case for the configuration of the source-maps generation which causes issues.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No, this PR does not introduce any breaking changes.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

There's nothing to be documented.
