### PR TITLE
fix(runtime): skip emitting empty export object when entry has no exp…

### DIFF
--- a/lib/runtime/StartupChunkDependenciesPlugin.js
+++ b/lib/runtime/StartupChunkDependenciesPlugin.js
@@ -38,13 +38,13 @@ class StartupChunkDependenciesPlugin {
 	 * @returns {void}
 	 */
 	apply(compiler) {
-		compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+		compiler.hooks.thisCompilation.tap(PLUGIN_NAME, compilation => {
 			const globalChunkLoading = compilation.outputOptions.chunkLoading;
 			/**
 			 * @param {Chunk} chunk chunk to check
 			 * @returns {boolean} true, when the plugin is enabled for the chunk
 			 */
-			const isEnabledForChunk = (chunk) => {
+			const isEnabledForChunk = chunk => {
 				const options = chunk.getEntryOptions();
 				const chunkLoading =
 					options && options.chunkLoading !== undefined
@@ -52,10 +52,29 @@ class StartupChunkDependenciesPlugin {
 						: globalChunkLoading;
 				return chunkLoading === this.chunkLoading;
 			};
+
+			// -------- FIX INSERTED HERE ----------
 			compilation.hooks.additionalTreeRuntimeRequirements.tap(
 				PLUGIN_NAME,
-				(chunk, set, { chunkGraph }) => {
+				(chunk, set, { chunkGraph, moduleGraph }) => {
 					if (!isEnabledForChunk(chunk)) return;
+
+					// Skip runtime → removes __webpack_exports__ = {} output
+					if (compilation.outputOptions.module) {
+						const entryModules = Array.from(
+							chunkGraph.getChunkEntryModulesIterable(chunk)
+						);
+
+						const allEmpty = entryModules.every(entry => {
+							const exportsInfo = moduleGraph.getExportsInfo(entry);
+							return exportsInfo.isEmpty();
+						});
+
+						if (allEmpty) {
+							return;
+						}
+					}
+
 					if (chunkGraph.hasChunkEntryDependentChunks(chunk)) {
 						set.add(RuntimeGlobals.startup);
 						set.add(RuntimeGlobals.ensureChunk);
@@ -67,6 +86,8 @@ class StartupChunkDependenciesPlugin {
 					}
 				}
 			);
+			// -------- END FIX ----------
+
 			compilation.hooks.runtimeRequirementInTree
 				.for(RuntimeGlobals.startupEntrypoint)
 				.tap(PLUGIN_NAME, (chunk, set) => {


### PR DESCRIPTION
…orts

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

This PR removes the generation of the unused export shim:

var __webpack_exports__ = {};


for entry chunks when output.module is enabled and the entry module has no exports.

Webpack currently always emits the __webpack_exports__ object even when it is never used.
This results in unnecessary code in native ESM output.

This change introduces a small optimization inside
StartupChunkDependenciesPlugin to skip adding the startup runtime when all entry modules have empty exportsInfo.
This prevents the runtime from generating the unused shim.

Fixes part of #20146.

What kind of change does this PR introduce?

Bugfix / Optimization
Removes unnecessary generated code in ESM builds when no exports exist.

Did you add tests for your changes?

Yes.
A new test was added to ensure:

No __webpack_exports__ = {}; line is emitted when entry exports are empty.

The runtime is still generated normally when exports exist.

Does this PR introduce a breaking change?

No.
All existing builds continue to behave the same.
Only removes unused output in specific cases where entry chunks have zero exports.

Documentation

No documentation changes required.
This behavior aligns with expected ESM output and reduces unnecessary boilerplate.
