### PR TITLE
fix: module library export definitions when multiple runtimes

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -3744,6 +3744,7 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 						dependencyTemplates,
 						runtimeTemplate,
 						runtime,
+						runtimes,
 						codeGenerationResults: results,
 						compilation: this
 					});

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -87,6 +87,7 @@ const makeSerializable = require("./util/makeSerializable");
  * @property {ModuleGraph} moduleGraph the module graph
  * @property {ChunkGraph} chunkGraph the chunk graph
  * @property {RuntimeSpec} runtime the runtimes code should be generated for
+ * @property {RuntimeSpec[]} runtimes all runtimes code should be generated for
  * @property {ConcatenationScope=} concatenationScope when in concatenated module, information about other concatenated modules
  * @property {CodeGenerationResults | undefined} codeGenerationResults code generation results of other modules (need to have a codeGenerationDependency to use that)
  * @property {Compilation=} compilation the compilation
@@ -133,8 +134,8 @@ const makeSerializable = require("./util/makeSerializable");
  * @property {boolean=} sideEffectFree
  * @property {boolean=} isCSSModule
  * @property {Record<string, string>=} jsIncompatibleExports
- * @property {Record<string, string>=} exportsFinalName
- * @property {string=} factoryExportsBinding
+ * @property {Map<RuntimeSpec, Record<string, string>>=} exportsFinalNameByRuntime
+ * @property {Map<RuntimeSpec, string>=} exportsSourceByRuntime
  */
 
 /** @typedef {LazySet<string>} FileSystemDependencies */
@@ -965,6 +966,7 @@ class Module extends DependenciesBlock {
 			moduleGraph: chunkGraph.moduleGraph,
 			chunkGraph,
 			runtime: undefined,
+			runtimes: [],
 			codeGenerationResults: undefined
 		};
 		const sources = this.codeGeneration(codeGenContext).sources;

--- a/lib/Template.js
+++ b/lib/Template.js
@@ -373,6 +373,7 @@ class Template {
 					moduleGraph: renderContext.moduleGraph,
 					runtimeTemplate: renderContext.runtimeTemplate,
 					runtime: renderContext.chunk.runtime,
+					runtimes: [renderContext.chunk.runtime],
 					codeGenerationResults
 				});
 				if (!codeGenResult) continue;

--- a/lib/library/ModuleLibraryPlugin.js
+++ b/lib/library/ModuleLibraryPlugin.js
@@ -21,6 +21,7 @@ const AbstractLibraryPlugin = require("./AbstractLibraryPlugin");
 /** @typedef {import("../Chunk")} Chunk */
 /** @typedef {import("../Compiler")} Compiler */
 /** @typedef {import("../Module")} Module */
+/** @typedef {import("../Module").BuildMeta} BuildMeta */
 /** @typedef {import("../Module").RuntimeRequirements} RuntimeRequirements */
 /** @typedef {import("../javascript/JavascriptModulesPlugin").StartupRenderContext} StartupRenderContext */
 /** @typedef {import("../javascript/JavascriptModulesPlugin").ModuleRenderContext} ModuleRenderContext */
@@ -69,7 +70,28 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 		compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
 			const { onDemandExportsGeneration } =
 				ConcatenatedModule.getCompilationHooks(compilation);
-			onDemandExportsGeneration.tap(PLUGIN_NAME, (_module) => true);
+			onDemandExportsGeneration.tap(
+				PLUGIN_NAME,
+				(module, runtimes, source, finalName) => {
+					/** @type {BuildMeta} */
+					const buildMeta = module.buildMeta || (module.buildMeta = {});
+
+					const exportsSourceByRuntime =
+						buildMeta.exportsSourceByRuntime ||
+						(buildMeta.exportsSourceByRuntime = new Map());
+
+					const exportsFinalNameByRuntime =
+						buildMeta.exportsFinalNameByRuntime ||
+						(buildMeta.exportsFinalNameByRuntime = new Map());
+
+					for (const runtime of runtimes) {
+						exportsSourceByRuntime.set(runtime, source);
+						exportsFinalNameByRuntime.set(runtime, finalName);
+					}
+
+					return true;
+				}
+			);
 		});
 	}
 
@@ -152,10 +174,16 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 					)
 				]
 			: moduleGraph.getExportsInfo(module).orderedExports;
+
+		const exportsFinalNameByRuntime =
+			(module.buildMeta &&
+				module.buildMeta.exportsFinalNameByRuntime &&
+				module.buildMeta.exportsFinalNameByRuntime.get(chunk.runtime)) ||
+			{};
+
 		const definitions =
-			inlined && !inlinedInIIFE
-				? (module.buildMeta && module.buildMeta.exportsFinalName) || {}
-				: {};
+			inlined && !inlinedInIIFE ? exportsFinalNameByRuntime : {};
+
 		/** @type {string[]} */
 		const shortHandedExports = [];
 		/** @type {[string, string][]} */
@@ -274,17 +302,17 @@ class ModuleLibraryPlugin extends AbstractLibraryPlugin {
 	renderModuleContent(
 		source,
 		module,
-		{ factory, inlinedInIIFE },
+		{ factory, inlinedInIIFE, chunk },
 		libraryContext
 	) {
-		// Re-add `factoryExportsBinding` to the source
-		// when the module is rendered as a factory or treated as an inlined (startup) module but wrapped in an IIFE
-		if (
-			(inlinedInIIFE || factory) &&
+		const exportsSource =
 			module.buildMeta &&
-			module.buildMeta.factoryExportsBinding
-		) {
-			return new ConcatSource(module.buildMeta.factoryExportsBinding, source);
+			module.buildMeta.exportsSourceByRuntime &&
+			module.buildMeta.exportsSourceByRuntime.get(chunk.runtime);
+
+		// Re-add the module's exports source when rendered in factory or as an inlined startup module wrapped in an IIFE
+		if ((inlinedInIIFE || factory) && exportsSource) {
+			return new ConcatSource(exportsSource, source);
 		}
 		return source;
 	}

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -687,7 +687,7 @@ const getFinalName = (
 
 /**
  * @typedef {object} ConcatenateModuleHooks
- * @property {SyncBailHook<[ConcatenatedModule], boolean>} onDemandExportsGeneration
+ * @property {SyncBailHook<[ConcatenatedModule, RuntimeSpec[], string, Record<string,string>], boolean>} onDemandExportsGeneration
  * @property {SyncBailHook<[Partial<ConcatenatedModuleInfo>, ConcatenatedModuleInfo], boolean | void>} concatenatedModuleInfo
  */
 
@@ -737,7 +737,12 @@ class ConcatenatedModule extends Module {
 		let hooks = compilationHooksMap.get(compilation);
 		if (hooks === undefined) {
 			hooks = {
-				onDemandExportsGeneration: new SyncBailHook(["module"]),
+				onDemandExportsGeneration: new SyncBailHook([
+					"module",
+					"runtimes",
+					"exportsFinalName",
+					"exportsSource"
+				]),
 				concatenatedModuleInfo: new SyncBailHook([
 					"updatedInfo",
 					"concatenatedModuleInfo"
@@ -1257,6 +1262,7 @@ class ConcatenatedModule extends Module {
 		moduleGraph,
 		chunkGraph,
 		runtime: generationRuntime,
+		runtimes,
 		codeGenerationResults
 	}) {
 		const { concatenatedModuleInfo } = ConcatenatedModule.getCompilationHooks(
@@ -1292,6 +1298,7 @@ class ConcatenatedModule extends Module {
 				moduleGraph,
 				chunkGraph,
 				runtime,
+				runtimes,
 				/** @type {CodeGenerationResults} */
 				(codeGenerationResults),
 				allUsedNames
@@ -1775,9 +1782,6 @@ class ConcatenatedModule extends Module {
 				);
 			}
 
-			const { onDemandExportsGeneration } =
-				ConcatenatedModule.getCompilationHooks(this.compilation);
-
 			runtimeRequirements.add(RuntimeGlobals.exports);
 			runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
 
@@ -1791,21 +1795,24 @@ class ConcatenatedModule extends Module {
 				);
 			}
 
-			if (onDemandExportsGeneration.call(this)) {
-				/** @type {BuildMeta} */ (this.buildMeta).factoryExportsBinding =
-					"\n// EXPORTS\n" +
-					`${RuntimeGlobals.definePropertyGetters}(${
-						this.exportsArgument
-					}, {${definitions.join(",")}\n});\n`;
-				/** @type {BuildMeta} */ (this.buildMeta).exportsFinalName =
-					exportsFinalName;
-			} else {
-				result.add("\n// EXPORTS\n");
-				result.add(
-					`${RuntimeGlobals.definePropertyGetters}(${
-						this.exportsArgument
-					}, {${definitions.join(",")}\n});\n`
-				);
+			const exportsSource =
+				"\n// EXPORTS\n" +
+				`${RuntimeGlobals.definePropertyGetters}(${this.exportsArgument}, {${definitions.join(
+					","
+				)}\n});\n`;
+
+			const { onDemandExportsGeneration } =
+				ConcatenatedModule.getCompilationHooks(this.compilation);
+
+			if (
+				!onDemandExportsGeneration.call(
+					this,
+					runtimes,
+					exportsSource,
+					exportsFinalName
+				)
+			) {
+				result.add(exportsSource);
 			}
 		}
 
@@ -2027,6 +2034,7 @@ ${defineGetters}`
 	 * @param {ModuleGraph} moduleGraph moduleGraph
 	 * @param {ChunkGraph} chunkGraph chunkGraph
 	 * @param {RuntimeSpec} runtime runtime
+	 * @param {RuntimeSpec[]} runtimes runtimes
 	 * @param {CodeGenerationResults} codeGenerationResults codeGenerationResults
 	 * @param {Set<string>} usedNames used names
 	 */
@@ -2038,6 +2046,7 @@ ${defineGetters}`
 		moduleGraph,
 		chunkGraph,
 		runtime,
+		runtimes,
 		codeGenerationResults,
 		usedNames
 	) {
@@ -2058,6 +2067,7 @@ ${defineGetters}`
 					moduleGraph,
 					chunkGraph,
 					runtime,
+					runtimes,
 					concatenationScope,
 					codeGenerationResults,
 					sourceTypes: JAVASCRIPT_TYPES

--- a/test/configCases/library/module-multi-runtime/bar.js
+++ b/test/configCases/library/module-multi-runtime/bar.js
@@ -1,0 +1,3 @@
+export * from "./baz"
+
+export const bar = "bar"

--- a/test/configCases/library/module-multi-runtime/baz.js
+++ b/test/configCases/library/module-multi-runtime/baz.js
@@ -1,0 +1,1 @@
+export const baz = "baz"

--- a/test/configCases/library/module-multi-runtime/cjs-concat.js
+++ b/test/configCases/library/module-multi-runtime/cjs-concat.js
@@ -1,0 +1,1 @@
+module.exports = require("./concat");

--- a/test/configCases/library/module-multi-runtime/concat.js
+++ b/test/configCases/library/module-multi-runtime/concat.js
@@ -1,0 +1,6 @@
+import concat2 from "./concat2";
+
+export const baz = "baz";
+export const foo = "foo";
+export const bar = "bar";
+export const concat = "concat~" + concat2;

--- a/test/configCases/library/module-multi-runtime/concat2.js
+++ b/test/configCases/library/module-multi-runtime/concat2.js
@@ -1,0 +1,1 @@
+export default "concat2";

--- a/test/configCases/library/module-multi-runtime/entry1.js
+++ b/test/configCases/library/module-multi-runtime/entry1.js
@@ -1,0 +1,5 @@
+import { foo } from "./cjs-concat";
+
+it("should generate correct export definition / 1", function () {
+	expect(foo).toBe("foo")
+});

--- a/test/configCases/library/module-multi-runtime/entry2.js
+++ b/test/configCases/library/module-multi-runtime/entry2.js
@@ -1,0 +1,5 @@
+import { bar } from "./cjs-concat";
+
+it("should generate correct export definition / 2", function () {
+	expect(bar).toBe("bar")
+});

--- a/test/configCases/library/module-multi-runtime/entry3.js
+++ b/test/configCases/library/module-multi-runtime/entry3.js
@@ -1,0 +1,6 @@
+import { baz, concat } from "./cjs-concat";
+
+it("should generate correct export definition / 3", function () {
+	expect(baz).toBe("baz");
+	expect(concat).toBe("concat~concat2");
+});

--- a/test/configCases/library/module-multi-runtime/test.config.js
+++ b/test/configCases/library/module-multi-runtime/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["entry1.mjs", "entry2.mjs", "entry3.mjs"];
+	}
+};

--- a/test/configCases/library/module-multi-runtime/webpack.config.js
+++ b/test/configCases/library/module-multi-runtime/webpack.config.js
@@ -1,0 +1,26 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	entry: {
+		entry1: "./entry1.js",
+		entry2: "./entry2.js",
+		entry3: "./entry3.js"
+	},
+	output: {
+		module: true,
+		library: {
+			type: "module"
+		},
+		filename: "[name].mjs"
+	},
+	experiments: {
+		outputModule: true
+	},
+	externalsType: "module",
+	optimization: {
+		concatenateModules: true,
+		usedExports: true
+	}
+};

--- a/test/configCases/library/module-useless-export-requirement/entry3.js
+++ b/test/configCases/library/module-useless-export-requirement/entry3.js
@@ -10,7 +10,7 @@ const RuntimeGlobals_Exports = "__webpack_exports__";
 const reg = new RegExp("var\\s" + RuntimeGlobals_Exports + "\\s=");
 
 it("should compile and run", () => {
-	const content = getFile("bundle1.mjs");
+	const content = getFile("bundle2.mjs");
 	expect(concat).toBe("concat");
 
 	// `__webpack_exports__` must be rendered when the entry module is inlined and wrapped in an IIFE,

--- a/types.d.ts
+++ b/types.d.ts
@@ -1946,6 +1946,11 @@ declare interface CodeGenerationContext {
 	runtime: RuntimeSpec;
 
 	/**
+	 * all runtimes code should be generated for
+	 */
+	runtimes: RuntimeSpec[];
+
+	/**
 	 * when in concatenated module, information about other concatenated modules
 	 */
 	concatenationScope?: ConcatenationScope;
@@ -8779,8 +8784,8 @@ declare interface KnownBuildMeta {
 	sideEffectFree?: boolean;
 	isCSSModule?: boolean;
 	jsIncompatibleExports?: Record<string, string>;
-	exportsFinalName?: Record<string, string>;
-	factoryExportsBinding?: string;
+	exportsFinalNameByRuntime?: Map<RuntimeSpec, Record<string, string>>;
+	exportsSourceByRuntime?: Map<RuntimeSpec, string>;
 }
 declare interface KnownCreateStatsOptionsContext {
 	forToString?: boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fixes https://github.com/webpack/webpack/issues/20164. 

We should consider different runtimes during code generation. When the module hash varies between runtimes, the code generation will run multiple times. To prevent exports from being overwritten, we should store export sources and finalNames in `Map` instead of using `string`.

The PR also 
1. Moves the on-demand generation logic into `ModuleLibraryPlugin` to make it clearer and library-specific.
2.	Fixes a typo in `test/configCases/library/module-useless-export-requirement/entry3.js`.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
