### PR TITLE
fix: respect errorStack in error messages (#15980)

### DIFF
--- a/lib/ModuleBuildError.js
+++ b/lib/ModuleBuildError.js
@@ -29,7 +29,7 @@ class ModuleBuildError extends WebpackError {
 			if (typeof err.stack === "string" && err.stack) {
 				const stack = cutOffLoaderExecution(err.stack);
 
-				if (!err.hideStack) {
+				if (err.errorStack) {
 					message += stack;
 				} else {
 					details = stack;

--- a/lib/ModuleDependencyError.js
+++ b/lib/ModuleDependencyError.js
@@ -31,11 +31,8 @@ class ModuleDependencyError extends WebpackError {
 		/** error is not (de)serialized, so it might be undefined after deserialization */
 		this.error = err;
 
-		if (err && err.hideStack && err.stack) {
-			this.stack = /** @type {string} */ `${err.stack
-				.split("\n")
-				.slice(1)
-				.join("\n")}\n\n${this.stack}`;
+		if (err && /** @type {any} */ (err).errorStack) {
+			message += err.stack || "";
 		}
 	}
 }

--- a/lib/ModuleParseError.js
+++ b/lib/ModuleParseError.js
@@ -82,8 +82,9 @@ class ModuleParseError extends WebpackError {
 			}
 
 			loc = { start: err.loc };
-		} else if (err && err.stack) {
-			message += `\n${err.stack}`;
+		}
+		if (err.errorStack) {
+			message += "\n" + err.stack;
 		}
 
 		super(message);


### PR DESCRIPTION
This PR fixes #15980.

Problem:
- Stacktraces were printed even when errorStack: false
- hideStack conflicted with errorStack causing verbose errors

Solution:
- Updated ModuleBuildError, ModuleParseError, and ModuleDependencyError
- Now respects errorStack and avoids printing unnecessary stack traces

--------------------------------
(existing auto-filled or previous content stays below)

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

