### PR TITLE
fix: use new URL() for ESM chunk loading to fix cross-project imports

### DIFF
--- a/lib/esm/ModuleChunkLoadingRuntimeModule.js
+++ b/lib/esm/ModuleChunkLoadingRuntimeModule.js
@@ -221,13 +221,11 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 													: `if(${hasJsMatcher("chunkId")}) {`,
 												Template.indent([
 													"// setup Promise in chunk cache",
-													`var promise = ${importFunctionName}(${
+													`var promise = ${importFunctionName}(/* webpackIgnore: true */ new URL(${
 														compilation.outputOptions.publicPath === "auto"
-															? JSON.stringify(rootOutputDir)
-															: RuntimeGlobals.publicPath
-													} + ${
-														RuntimeGlobals.getChunkScriptFilename
-													}(chunkId)).then(installChunk, ${runtimeTemplate.basicFunction(
+															? `${JSON.stringify(rootOutputDir)} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId)`
+															: `${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId)`
+													}, ${compilation.outputOptions.importMetaName}.url)).then(installChunk, ${runtimeTemplate.basicFunction(
 														"e",
 														[
 															"if(installedChunks[chunkId] !== 0) installedChunks[chunkId] = undefined;",
@@ -364,7 +362,7 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 								"resolve, reject",
 								[
 									"// start update chunk loading",
-									`var url = ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkUpdateScriptFilename}(chunkId);`,
+									`var url = new URL(${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkUpdateScriptFilename}(chunkId), ${compilation.outputOptions.importMetaName}.url);`,
 									`var onResolve = ${runtimeTemplate.basicFunction("obj", [
 										`var updatedModules = obj.${RuntimeGlobals.esmModules};`,
 										`var updatedRuntime = obj.${RuntimeGlobals.esmRuntime};`,
@@ -407,11 +405,12 @@ class ModuleChunkLoadingRuntimeModule extends RuntimeModule {
 						`${
 							RuntimeGlobals.hmrDownloadManifest
 						} = ${runtimeTemplate.basicFunction("", [
-							`return ${importFunctionName}(/* webpackIgnore: true */ ${RuntimeGlobals.publicPath} + ${
+							`return ${importFunctionName}(/* webpackIgnore: true */ new URL(${RuntimeGlobals.publicPath} + ${
 								RuntimeGlobals.getUpdateManifestFilename
-							}()).then(${runtimeTemplate.basicFunction("obj", [
-								"return obj.default;"
-							])}, ${runtimeTemplate.basicFunction("error", [
+							}(), ${compilation.outputOptions.importMetaName}.url)).then(${runtimeTemplate.basicFunction(
+								"obj",
+								["return obj.default;"]
+							)}, ${runtimeTemplate.basicFunction("error", [
 								"if(['MODULE_NOT_FOUND', 'ENOENT'].includes(error.code)) return;",
 								"throw error;"
 							])});`


### PR DESCRIPTION
## Summary

- Fixes chunk loading failure when a webpack library with `library.type: 'module'` and code-splitting is consumed by another webpack project
- Uses `new URL(path, import.meta.url)` instead of string concatenation for chunk URL resolution
- Applies fix to dynamic chunk loading, HMR chunk loading, and HMR manifest loading

## Problem

When a webpack library configured with `library.type: 'module'` and code-splitting was imported into another webpack project, chunk loading failed with:

Not allowed to load local resource: file:///path/to/chunk.js

The issue was that chunk URLs were constructed using string concatenation (`publicPath + chunkFilename`), which produced absolute file paths.

## Solution

Use `new URL(path, import.meta.url)` to resolve chunk URLs relative to the current module's location, which works correctly regardless of how the library is consumed.

## Test plan

- [x] Verified `new URL()` pattern appears in compiled output
- [x] Tested with `publicPath: 'auto'`
- [x] Tested with explicit `publicPath`
- [x] Confirmed `import.meta.url` is used as the base URL

Fixes #15947