### PR TITLE
docs: fix typo in CONTRIBUTING.md link text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ that include your webpack.config.js, relevant files, and the full error message 
 
 **If you have discovered a bug or have a feature suggestion, please [create an issue on GitHub](https://github.com/webpack/webpack/issues/new).**
 
-Do you want to fix an issue? Look at the issues with a tag of [Send a PR)](https://github.com/webpack/webpack/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Send%20a%20PR%22). Here are some of the key labels you may encounter:
+Do you want to fix an issue? Look at the issues with a tag of [Send a PR](https://github.com/webpack/webpack/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Send%20a%20PR%22). Here are some of the key labels you may encounter:
 
 - **bug**: An unexpected problem or unintended behavior.
 - **enhancement**: A suggestion for a new feature or improvement.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

This PR fixes a small typo in [CONTRIBUTING.md](cci:7://file:///c:/Users/Samarthsinh/Desktop/Work/contri/webpack/CONTRIBUTING.md:0:0-0:0).

The markdown link text for the “Send a PR” label previously contained an extra closing parenthesis:

- Before: `[Send a PR)](...)`
- After: `[Send a PR](...)`

The link target remains the same; only the link text is corrected to improve readability for contributors.

**What kind of change does this PR introduce?**

- [x] Documentation update
- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring
- [ ] Build-related change
- [ ] Other

**Did you add tests for your changes?**

- [ ] Yes
- [x] No – this PR only updates documentation (CONTRIBUTING.md) and does not touch runtime code.

**Does this PR introduce a breaking change?**

- [x] No
- [ ] Yes (please describe below)

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

This PR only fixes a typo in [CONTRIBUTING.md](cci:7://file:///c:/Users/Samarthsinh/Desktop/Work/contri/webpack/CONTRIBUTING.md:0:0-0:0); no additional documentation changes are required.