### PR TITLE
feat: attach original event to ChunkLoadError for better diagnostics

### DIFF
--- a/lib/web/JsonpChunkLoadingRuntimeModule.js
+++ b/lib/web/JsonpChunkLoadingRuntimeModule.js
@@ -193,6 +193,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 																	"error.name = 'ChunkLoadError';",
 																	"error.type = errorType;",
 																	"error.request = realSrc;",
+																	"error.event = event;",
 																	"installedChunkData[1](error);"
 																]),
 																"}"
@@ -331,6 +332,7 @@ class JsonpChunkLoadingRuntimeModule extends RuntimeModule {
 											"error.name = 'ChunkLoadError';",
 											"error.type = errorType;",
 											"error.request = realSrc;",
+											"error.event = event;",
 											"reject(error);"
 										]),
 										"}"

--- a/test/configCases/web/retry-failed-import/index.js
+++ b/test/configCases/web/retry-failed-import/index.js
@@ -8,7 +8,8 @@ it("should be able to retry a failed import()", () => {
 	const script = document.head._children[0];
 	expect(script.onerror).toBeTypeOf("function");
 
-	script.onerror({ type: "load", target: script });
+	const firstErrorEvent = { type: "load", target: script };
+	script.onerror(firstErrorEvent);
 
 	return promise.catch(err => {
 		expect(err).toBeInstanceOf(Error);
@@ -18,6 +19,7 @@ it("should be able to retry a failed import()", () => {
 		expect(err.message).toMatch(
 			/^Loading chunk .+ failed\.\n\(missing: https:\/\/test\.cases\/path\/the-chunk\.js\)$/
 		);
+		expect(err.event).toBe(firstErrorEvent);
 
 		const promise = doImport();
 
@@ -36,6 +38,7 @@ it("should be able to retry a failed import()", () => {
 			expect(err.message).toMatch(
 				/^Loading chunk .+ failed\.\n\(undefined: undefined\)$/
 			);
+			expect(err.event).toBe(undefined);
 
 			const promise = doImport();
 


### PR DESCRIPTION
**Summary**

This PR improves the diagnostics for failed chunk loading by attaching the original DOM event to `ChunkLoadError`.

Currently, when a lazy-loaded chunk or a hot update chunk fails to load, webpack throws a `ChunkLoadError` with a message, `type`, and `request` (URL). However, the original browser event that triggered the failure is not available on the error object. That makes it harder to debug intermittent or environment-specific loading issues, where additional context from the event may be useful.

This change extends `ChunkLoadError` so that it carries the original event via a new `error.event` property, while keeping the existing fields and behavior unchanged.

---

**What kind of change does this PR introduce?**

Feature / developer-experience improvement.

It enhances the runtime error information exposed by webpack when chunk loading fails, without altering the public API surface or configuration options.

---

**Did you add tests for your changes?**

Yes.

I updated the existing config case:

- `test/configCases/web/retry-failed-import/index.js`

The test now additionally asserts that:

- For a simulated failed import where `script.onerror` is called with an event object, the resulting `ChunkLoadError` includes `error.event` pointing to that original event.
- For a failure simulated via `script.onload()` (where no extra event data is provided), `error.event` is `undefined`, preserving the previous behavior while making the absence of event information explicit.

All tests in `web/retry-failed-import` pass.

---

**Does this PR introduce a breaking change?**

No.

- Existing properties on `ChunkLoadError` (`message`, `name`, `type`, `request`) are unchanged.
- The new `error.event` property is additive and only provides extra context.
- There is no change to webpack’s configuration, plugin/loader APIs, or generated chunk URLs.

Code that does not look at `error.event` continues to behave exactly as before.
