### PR TITLE
feat: expose importAttributes to loaders via _importAttributes

### DIFF
--- a/declarations/LoaderContext.d.ts
+++ b/declarations/LoaderContext.d.ts
@@ -118,7 +118,7 @@ export interface NormalModuleLoaderContext<OptionsType> {
 	_module?: NormalModule;
 	_compilation?: Compilation;
 	_compiler?: Compiler;
-	_importAttributes?: Record<string, unknown>;
+	importAttributes?: Record<string, unknown>;
 }
 
 /** These properties are added by the HotModuleReplacementPlugin */

--- a/declarations/LoaderContext.d.ts
+++ b/declarations/LoaderContext.d.ts
@@ -118,6 +118,7 @@ export interface NormalModuleLoaderContext<OptionsType> {
 	_module?: NormalModule;
 	_compilation?: Compilation;
 	_compiler?: Compiler;
+	_importAttributes?: Record<string, unknown>;
 }
 
 /** These properties are added by the HotModuleReplacementPlugin */

--- a/generate-types-config.js
+++ b/generate-types-config.js
@@ -8,7 +8,5 @@ module.exports = {
 		MultiConfiguration: /^MultiWebpackOptions /
 	},
 	exclude: [/^devServer in WebpackOptions /],
-	include: [
-		/^(_module|_compilation|_compiler|_importAttributes) in NormalModuleLoaderContext /
-	]
+	include: [/^(_module|_compilation|_compiler) in NormalModuleLoaderContext /]
 };

--- a/generate-types-config.js
+++ b/generate-types-config.js
@@ -8,5 +8,7 @@ module.exports = {
 		MultiConfiguration: /^MultiWebpackOptions /
 	},
 	exclude: [/^devServer in WebpackOptions /],
-	include: [/^(_module|_compilation|_compiler) in NormalModuleLoaderContext /]
+	include: [
+		/^(_module|_compilation|_compiler|_importAttributes) in NormalModuleLoaderContext /
+	]
 };

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -2059,6 +2059,7 @@ class NormalModule extends Module {
 		write(this._forceBuild);
 		write(this._codeGeneratorData);
 		write(this.hot);
+		write(this.importAttributes);
 		super.serialize(context);
 	}
 
@@ -2103,6 +2104,7 @@ class NormalModule extends Module {
 		this._forceBuild = read();
 		this._codeGeneratorData = read();
 		this.hot = read();
+		this.importAttributes = read();
 		super.deserialize(context);
 	}
 }

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -109,6 +109,7 @@ const parseJson = require("./util/parseJson");
 /** @typedef {import("./util/fs").InputFileSystem} InputFileSystem */
 /** @typedef {import("../declarations/WebpackOptions").HashFunction} HashFunction */
 /** @typedef {import("./util/identifier").AssociatedObjectForCache} AssociatedObjectForCache */
+/** @typedef {import("./javascript/JavascriptParser").ImportAttributes} ImportAttributes */
 /**
  * @template T
  * @typedef {import("./util/deprecation").FakeHook<T>} FakeHook
@@ -502,6 +503,7 @@ const asBuffer = (input) => {
  * @property {GeneratorOptionsByType[T]=} generatorOptions the options of the generator used
  * @property {ResolveOptions=} resolveOptions options used for resolving requests from this module
  * @property {boolean} extractSourceMap enable/disable extracting source map
+ * @property {ImportAttributes=} importAttributes import attributes from the import statement
  */
 
 /**
@@ -599,7 +601,8 @@ class NormalModule extends Module {
 		generator,
 		generatorOptions,
 		resolveOptions,
-		extractSourceMap
+		extractSourceMap,
+		importAttributes
 	}) {
 		super(type, context || getContext(resource), layer);
 
@@ -635,6 +638,8 @@ class NormalModule extends Module {
 		}
 		/** @type {NormalModuleCreateData['extractSourceMap']} */
 		this.extractSourceMap = extractSourceMap;
+		/** @type {NormalModuleCreateData['importAttributes']} */
+		this.importAttributes = importAttributes;
 
 		// Set by HotModuleReplacementPlugin via NormalModuleFactory's `module` hook
 		/** @type {boolean} */
@@ -1137,7 +1142,8 @@ class NormalModule extends Module {
 			_module: this,
 			_compilation: compilation,
 			_compiler: compilation.compiler,
-			fs
+			fs,
+			_importAttributes: this.importAttributes
 		};
 
 		Object.assign(loaderContext, options.loader);

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -1143,7 +1143,7 @@ class NormalModule extends Module {
 			_compilation: compilation,
 			_compiler: compilation.compiler,
 			fs,
-			_importAttributes: this.importAttributes
+			importAttributes: this.importAttributes
 		};
 
 		Object.assign(loaderContext, options.loader);

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -876,7 +876,8 @@ class NormalModuleFactory extends ModuleFactory {
 								generator: this.getGenerator(type, settings.generator),
 								generatorOptions: settings.generator,
 								resolveOptions,
-								extractSourceMap: settings.extractSourceMap || false
+								extractSourceMap: settings.extractSourceMap || false,
+								importAttributes: data.attributes
 							});
 						} catch (createDataErr) {
 							return callback(/** @type {Error} */ (createDataErr));

--- a/test/configCases/loaders/import-attributes-loader-context/data.data.js
+++ b/test/configCases/loaders/import-attributes-loader-context/data.data.js
@@ -1,0 +1,2 @@
+// This file will be processed by the loader
+// The content doesn't matter - the loader will replace it with the import attributes

--- a/test/configCases/loaders/import-attributes-loader-context/data2.data.js
+++ b/test/configCases/loaders/import-attributes-loader-context/data2.data.js
@@ -1,0 +1,1 @@
+// This file will be processed by the loader without import attributes

--- a/test/configCases/loaders/import-attributes-loader-context/index.js
+++ b/test/configCases/loaders/import-attributes-loader-context/index.js
@@ -1,0 +1,10 @@
+import attributesWithType from "./data.data.js" with { type: "custom", preload: "true" };
+import attributesEmpty from "./data2.data.js";
+
+it("should expose import attributes to loaders via _importAttributes", function() {
+	expect(attributesWithType).toEqual({ type: "custom", preload: "true" });
+});
+
+it("should return undefined when no import attributes are present", function() {
+	expect(attributesEmpty).toBeUndefined();
+});

--- a/test/configCases/loaders/import-attributes-loader-context/loader.js
+++ b/test/configCases/loaders/import-attributes-loader-context/loader.js
@@ -1,5 +1,5 @@
 /** @type {import("../../../../").LoaderDefinition} */
 module.exports = function (source) {
-	const attributes = this._importAttributes;
+	const attributes = this.importAttributes;
 	return `module.exports = ${JSON.stringify(attributes)};`;
 };

--- a/test/configCases/loaders/import-attributes-loader-context/loader.js
+++ b/test/configCases/loaders/import-attributes-loader-context/loader.js
@@ -1,0 +1,5 @@
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function (source) {
+	const attributes = this._importAttributes;
+	return `module.exports = ${JSON.stringify(attributes)};`;
+};

--- a/test/configCases/loaders/import-attributes-loader-context/webpack.config.js
+++ b/test/configCases/loaders/import-attributes-loader-context/webpack.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /\.data\.js$/,
+				loader: require.resolve("./loader.js")
+			}
+		]
+	}
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -18125,6 +18125,7 @@ declare interface NormalModuleLoaderContext<OptionsType> {
 	_module?: NormalModule;
 	_compilation?: Compilation;
 	_compiler?: Compiler;
+	_importAttributes?: Record<string, unknown>;
 }
 declare class NormalModuleReplacementPlugin {
 	/**

--- a/types.d.ts
+++ b/types.d.ts
@@ -18125,7 +18125,7 @@ declare interface NormalModuleLoaderContext<OptionsType> {
 	_module?: NormalModule;
 	_compilation?: Compilation;
 	_compiler?: Compiler;
-	_importAttributes?: Record<string, unknown>;
+	importAttributes?: Record<string, unknown>;
 }
 declare class NormalModuleReplacementPlugin {
 	/**

--- a/types.d.ts
+++ b/types.d.ts
@@ -5291,6 +5291,11 @@ declare interface CreateData {
 	 * enable/disable extracting source map
 	 */
 	extractSourceMap: boolean;
+
+	/**
+	 * import attributes from the import statement
+	 */
+	importAttributes?: ImportAttributes;
 	settings: ModuleSettings;
 }
 type CreateReadStreamFSImplementation = FSImplementation & {
@@ -17396,6 +17401,7 @@ declare class NormalModule extends Module {
 	matchResource?: string;
 	loaders: LoaderItem[];
 	extractSourceMap: boolean;
+	importAttributes?: ImportAttributes;
 	hot: boolean;
 	error: null | Error;
 	getResource(): null | string;
@@ -17630,6 +17636,11 @@ declare interface NormalModuleCreateDataNormalModuleObject_1<
 	 * enable/disable extracting source map
 	 */
 	extractSourceMap: boolean;
+
+	/**
+	 * import attributes from the import statement
+	 */
+	importAttributes?: ImportAttributes;
 }
 declare abstract class NormalModuleFactory extends ModuleFactory {
 	hooks: Readonly<{


### PR DESCRIPTION

**Summary**

This PR exposes `importAttributes` to the loader interface so loaders can react to metadata on `import`/`import()` statements, as requested in [#20228](https://github.com/webpack/webpack/issues/20228).

Today, the parser already understands import attributes, and they are used for things like rule matching, but loaders cannot see them. This change threads the parsed `ImportAttributes` from the dependency/resolve data into [NormalModule](cci:2://file:///c:/Users/Samarthsinh/Desktop/Work/contri/webpack/lib/NormalModule.js:269:0-1771:1) and then into the loader context as `_importAttributes`, so loaders can read them via `this._importAttributes`.

High-level implementation:

- Extend [NormalModuleFactory](cci:2://file:///c:/Users/Samarthsinh/Desktop/Work/contri/webpack/lib/NormalModuleFactory.js:338:0-1437:1) to include `importAttributes` in the `createData` passed to [NormalModule](cci:2://file:///c:/Users/Samarthsinh/Desktop/Work/contri/webpack/lib/NormalModule.js:269:0-1771:1).
- Store `importAttributes` on [NormalModule](cci:2://file:///c:/Users/Samarthsinh/Desktop/Work/contri/webpack/lib/NormalModule.js:269:0-1771:1) instances.
- Expose the stored attributes on the loader context as `_importAttributes`, following the pattern of other internal context fields like `_module`, `_compilation`, etc.
- Update [declarations/LoaderContext.d.ts](cci:7://file:///c:/Users/Samarthsinh/Desktop/Work/contri/webpack/declarations/LoaderContext.d.ts:0:0-0:0) to include `_importAttributes?: Record<string, unknown>`.
- Add a `configCases` test case under `test/configCases/loaders/import-attributes-loader-context`:
  - A custom loader reads `this._importAttributes` and exports it.
  - One import with attributes and one without, asserting:
    - Attributes object is passed through when present.
    - `undefined` is produced when no attributes are present.

**What kind of change does this PR introduce?**

Feature.

It adds a new capability for loaders to inspect the import attributes of the module they are processing (via `_importAttributes` on the loader context).

**Did you add tests for your changes?**

Yes.

- Added a new config test:
  - [test/configCases/loaders/import-attributes-loader-context/webpack.config.js](cci:7://file:///c:/Users/Samarthsinh/Desktop/Work/contri/webpack/test/configCases/loaders/import-attributes-loader-context/webpack.config.js:0:0-0:0)
  - [test/configCases/loaders/import-attributes-loader-context/loader.js](cci:7://file:///c:/Users/Samarthsinh/Desktop/Work/contri/webpack/test/configCases/loaders/import-attributes-loader-context/loader.js:0:0-0:0)
  - [test/configCases/loaders/import-attributes-loader-context/index.js](cci:7://file:///c:/Users/Samarthsinh/Desktop/Work/contri/webpack/test/configCases/loaders/import-attributes-loader-context/index.js:0:0-0:0)
- Ran targeted Jest tests for this case:
  - `node node_modules/jest/bin/jest.js test/ConfigTestCases.basictest.js --no-coverage --runInBand --testNamePattern=import-attributes-loader-context`
- Also ran loader/import-attributes related config tests via `--testNamePattern="loaders import-attributes"` to ensure existing cases still pass.

On my Windows environment, running the full Jest suite surfaces unrelated snapshot differences (absolute paths vs `<cwd>`) and missing optional dependencies like `@swc/core` / `esbuild`, which appear to be environment-specific and not related to this change.

**Does this PR introduce a breaking change?**

No.

- The change only adds a new internal property `_importAttributes` on the loader context.
- Existing loaders and configurations continue to work as before.
- No existing public APIs are removed or changed.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

- Loader API docs should mention that the loader context now provides `_importAttributes` (an object of import attributes when present, otherwise `undefined`) for modules that were imported with attributes.
- It may be worth adding:
  - A short example of a loader that branches behavior based on `_importAttributes` (e.g., treating assets differently when `with { type: "image", preload: true }` is used).
  - A note that this is populated only when the module is reached via an import with attributes and is otherwise `undefined`.