### PR TITLE
fix #10537: support dependOn chunks in UMD library output

### DIFF
--- a/lib/library/UmdLibraryPlugin.js
+++ b/lib/library/UmdLibraryPlugin.js
@@ -1,5 +1,5 @@
 /*
-	MIT License http://www.opensource.org/licenses/mit-license.php
+    MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
 
@@ -133,15 +133,26 @@ class UmdLibraryPlugin extends AbstractLibraryPlugin {
 					m instanceof ExternalModule &&
 					(m.externalType === "umd" || m.externalType === "umd2")
 			);
-		let externals = /** @type {ExternalModule[]} */ (modules);
-		/** @type {ExternalModule[]} */
+		/** @type {(ExternalModule | string)[]} */
+		let externals = /** @type {ExternalModule[]} */ ([...modules]);
+
+		for (const chunkGroup of chunk.groupsIterable) {
+			for (const parentGroup of chunkGroup.parentsIterable) {
+				for (const parentChunk of parentGroup.chunks) {
+					if (parentChunk.name && parentChunk.name !== chunk.name) {
+						externals.push(parentChunk.name);
+					}
+				}
+			}
+		}
+		/** @type {(ExternalModule | string)[]} */
 		const optionalExternals = [];
-		/** @type {ExternalModule[]} */
+		/** @type {(ExternalModule | string)[]} */
 		let requiredExternals = [];
 		if (this.optionalAmdExternalAsGlobal) {
 			for (const m of externals) {
-				if (m.isOptional(moduleGraph)) {
-					optionalExternals.push(m);
+				if (typeof m !== "string" && m.isOptional(moduleGraph)) {
+					optionalExternals.push(/** @type {ExternalModule} */ (m));
 				} else {
 					requiredExternals.push(m);
 				}
@@ -167,14 +178,15 @@ class UmdLibraryPlugin extends AbstractLibraryPlugin {
 		const externalsDepsArray = (modules) =>
 			`[${replaceKeys(
 				modules
-					.map((m) =>
-						JSON.stringify(
+					.map((m) => {
+						if (typeof m === "string") return JSON.stringify(m);
+						return JSON.stringify(
 							typeof m.request === "object"
 								? /** @type {RequestRecord} */
 									(m.request).amd
 								: m.request
-						)
-					)
+						);
+					})
 					.join(", ")
 			)}]`;
 
@@ -186,7 +198,8 @@ class UmdLibraryPlugin extends AbstractLibraryPlugin {
 			replaceKeys(
 				modules
 					.map((m) => {
-						let request = m.request;
+						let request = typeof m === "string" ? m : m.request;
+
 						if (typeof request === "object") {
 							request =
 								/** @type {RequestRecord} */
@@ -208,7 +221,8 @@ class UmdLibraryPlugin extends AbstractLibraryPlugin {
 				externals
 					.map((m) => {
 						let expr;
-						let request = m.request;
+						let request = typeof m === "string" ? m : m.request;
+
 						if (typeof request === "object") {
 							request =
 								/** @type {RequestRecord} */
@@ -224,7 +238,8 @@ class UmdLibraryPlugin extends AbstractLibraryPlugin {
 									request[0]
 								)})${accessorToObjectAccess(request.slice(1))}`
 							: `require(${JSON.stringify(request)})`;
-						if (m.isOptional(moduleGraph)) {
+
+						if (typeof m !== "string" && m.isOptional(moduleGraph)) {
 							expr = `(function webpackLoadOptionalExternalModule() { try { return ${expr}; } catch(e) {} }())`;
 						}
 						return expr;
@@ -238,12 +253,14 @@ class UmdLibraryPlugin extends AbstractLibraryPlugin {
 		 */
 		const externalsArguments = (modules) =>
 			modules
-				.map(
-					(m) =>
-						`__WEBPACK_EXTERNAL_MODULE_${Template.toIdentifier(
-							`${chunkGraph.getModuleId(m)}`
-						)}__`
-				)
+				.map((m) => {
+					if (typeof m === "string") {
+						return `__WEBPACK_EXTERNAL_MODULE_${Template.toIdentifier(m)}__`;
+					}
+					return `__WEBPACK_EXTERNAL_MODULE_${Template.toIdentifier(
+						`${chunkGraph.getModuleId(m)}`
+					)}__`;
+				})
 				.join(", ");
 
 		/**
@@ -260,13 +277,15 @@ class UmdLibraryPlugin extends AbstractLibraryPlugin {
 
 		let amdFactory;
 		if (optionalExternals.length > 0) {
-			const wrapperArguments = externalsArguments(requiredExternals);
+			const wrapperArguments = externalsArguments(
+				/** @type {ExternalModule[]} */ (requiredExternals)
+			);
 			const factoryArguments =
 				requiredExternals.length > 0
-					? `${externalsArguments(requiredExternals)}, ${externalsRootArray(
-							optionalExternals
-						)}`
-					: externalsRootArray(optionalExternals);
+					? `${externalsArguments(/** @type {ExternalModule[]} */ (requiredExternals))}, ${externalsRootArray(/** @type {ExternalModule[]} */ (optionalExternals))}`
+					: externalsRootArray(
+							/** @type {ExternalModule[]} */ (optionalExternals)
+						);
 			amdFactory =
 				`function webpackLoadOptionalExternalModuleAmd(${wrapperArguments}) {\n` +
 				`			return factory(${factoryArguments});\n` +
@@ -304,9 +323,9 @@ class UmdLibraryPlugin extends AbstractLibraryPlugin {
 						requiredExternals.length > 0
 							? names.amd && namedDefine === true
 								? `		define(${libraryName(names.amd)}, ${externalsDepsArray(
-										requiredExternals
+										/** @type {ExternalModule[]} */ (requiredExternals)
 									)}, ${amdFactory});\n`
-								: `		define(${externalsDepsArray(requiredExternals)}, ${
+								: `		define(${externalsDepsArray(/** @type {ExternalModule[]} */ (requiredExternals))}, ${
 										amdFactory
 									});\n`
 							: names.amd && namedDefine === true
@@ -329,19 +348,19 @@ class UmdLibraryPlugin extends AbstractLibraryPlugin {
 										/** @type {Accessor} */
 										(names.root || names.commonjs)
 									)
-								)} = factory(${externalsRootArray(externals)});\n`
+								)} = factory(${externalsRootArray(/** @type {ExternalModule[]} */ (externals))});\n`
 							: `	else {\n${
 									externals.length > 0
 										? `		var a = typeof exports === 'object' ? factory(${externalsRequireArray(
 												"commonjs"
-											)}) : factory(${externalsRootArray(externals)});\n`
+											)}) : factory(${externalsRootArray(/** @type {ExternalModule[]} */ (externals))});\n`
 										: "		var a = factory();\n"
 								}		for(var i in a) (typeof exports === 'object' ? exports : root)[i] = a[i];\n` +
 								"	}\n"
 					}})(${runtimeTemplate.globalObject}, ${
 						runtimeTemplate.supportsArrowFunction()
-							? `(${externalsArguments(externals)}) =>`
-							: `function(${externalsArguments(externals)})`
+							? `(${externalsArguments(/** @type {ExternalModule[]} */ (externals))}) =>`
+							: `function(${externalsArguments(/** @type {ExternalModule[]} */ (externals))})`
 					} {\nreturn `,
 				"webpack/universalModuleDefinition"
 			),


### PR DESCRIPTION
Closes #10537

Previously, the UmdLibraryPlugin only considered explicit externals defined in the configuration. It ignored chunks defined via dependOn, leading to runtime errors in UMD bundles because the required dependencies weren't declared in the AMD/CommonJS/Global wrappers.

The Implementation Journey
Step 1: Initial Attempt with referencedChunks

           Experiment: First, I tried using chunk.getAllReferencedChunks() to gather dependencies.

           Result: This didn't work as expected because it was capturing the current chunk itself or sub-chunks, rather than the "parent" chunks that dependOn creates.

Step 2: Exploring groupsIterable

            Experiment: I then shifted to chunk.groupsIterable to find siblings.

            Result: While closer, it wasn't consistently identifying the dependOn relationship across different entrypoint configurations.

Step 3: Successful Path via parentsIterable

             Experiment: I used the relationship where dependOn makes one chunk a parent of another in the ChunkGroup hierarchy.

             Solution: By traversing chunk.groupsIterable -> parentsIterable -> chunks, I successfully identified the exact chunk names (like "base") that need to be treated as externals.

Step 4: The any Typecasting Experiment

             Challenge: Adding raw strings (chunk names) into a list of ExternalModule objects caused TypeError and validation crashes.

              Experiment: To verify if the logic was sound, I temporarily updated the externals array to any[].

Result: The logic worked perfectly! The UMD bundle was generated correctly with all dependencies. However, I realized this wasn't commit-ready as it bypassed Webpack's strict type safety and linting rules.

Step 5: Final Refinement (Proper Typing & Safety)

             Fix: Instead of using any, I properly updated the JSDoc types to (ExternalModule | string)[] and used explicit type casting /** @type {ExternalModule[]} */ where the compiler expected only modules.

Safety Guards: Added typeof m === "string" guards in externalsArguments, externalsDepsArray, and all wrapper generators.

Template Support: Used Template.toIdentifier(m) to safely convert chunk names into valid JavaScript variable names for the factory arguments.

Verification:

             Tested with a multi-entry configuration using dependOn.

             Before: define([], factory) (Empty dependencies).

             After: define(["base"], factory) (Correctly injected dependency).

Manual build was verified using a custom run-test.js and all ESLint rules were passed after npx eslint --fix