### PR TITLE
fix: only absolutify paths before pipe separators in source maps (#16…

### DIFF
--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -199,7 +199,9 @@ class ContextModule extends Module {
 		const str = stripSlash
 			? regexString.source + regexString.flags
 			: `${regexString}`;
-		return str.replace(/!/g, "%21").replace(/\|/g, "%7C");
+		return str
+			.replace(/[#&!?\\/]/g, (s) => encodeURIComponent(s))
+			.replace(/\|/g, "%7C");
 	}
 
 	_createIdentifier() {

--- a/lib/util/identifier.js
+++ b/lib/util/identifier.js
@@ -288,17 +288,14 @@ const _makePathsRelative = (context, identifier) =>
  */
 const _makePathsAbsolute = (context, identifier) => {
 	const segments = identifier.split(SEGMENTS_SPLIT_REGEXP);
-	let inPipeSeparatedSection = false;
 	return segments
 		.map((str) => {
-			if (str === "|") {
-				inPipeSeparatedSection = true;
+			if (str === "|" || str === "!") {
 				return str;
 			}
-			if (str === "!") {
-				return str;
-			}
-			if (inPipeSeparatedSection) {
+			// Skip making paths absolute for regex patterns (used in context module identifiers)
+			// Regex patterns typically start with ^ or contain regex metacharacters
+			if (/^\^|[*+?{}[\]$]/.test(str)) {
 				return str;
 			}
 			return requestToAbsolute(context, str);

--- a/test/configCases/source-map/context-module-regex-identifier/index.js
+++ b/test/configCases/source-map/context-module-regex-identifier/index.js
@@ -1,0 +1,18 @@
+const name = Math.random() > 0.5 ? "a" : "b";
+require(`./modules/${name}.js`);
+
+it("context module regex identifier should not be absolutified in source map", () => {
+	const fs = require("fs");
+	const source = fs.readFileSync(__filename + ".map", "utf-8");
+	const map = JSON.parse(source);
+
+	// Find the context module source entry
+	const contextModuleSource = map.sources.find(s => s.includes("sync"));
+
+	// The regex pattern should remain as-is, not converted to absolute path
+	// Before fix: regex like "^\./.*$" would be wrongly absolutified
+	// After fix: regex patterns are preserved correctly
+	expect(contextModuleSource).toEqual(
+		"webpack:///./modules/ sync ^%5C.%5C%2F.*%5C.js$"
+	);
+});

--- a/test/configCases/source-map/context-module-regex-identifier/modules/a.js
+++ b/test/configCases/source-map/context-module-regex-identifier/modules/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/test/configCases/source-map/context-module-regex-identifier/modules/b.js
+++ b/test/configCases/source-map/context-module-regex-identifier/modules/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/test/configCases/source-map/context-module-regex-identifier/webpack.config.js
+++ b/test/configCases/source-map/context-module-regex-identifier/webpack.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = {
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	devtool: "source-map"
+};

--- a/test/configCases/source-map/context-module-source-path/index.js
+++ b/test/configCases/source-map/context-module-source-path/index.js
@@ -5,5 +5,5 @@ it("context module should use relative path in source map file", () => {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename + ".map", "utf-8");
 	var map = JSON.parse(source);
-	expect(map.sources).toContain("webpack:///./foo/ sync ^\\.\\/.*\\.js$");
+	expect(map.sources).toContain("webpack:///./foo/ sync ^%5C.%5C%2F.*%5C.js$");
 });

--- a/test/identifier.unittest.js
+++ b/test/identifier.unittest.js
@@ -91,15 +91,14 @@ describe("util/identifier", () => {
 	});
 
 	describe("makePathsAbsolute", () => {
-		describe("should only absolutify paths before pipe separators", () => {
-			it("should not absolutify regex patterns after pipe separator", () => {
+		describe("should not absolutify regex patterns", () => {
+			it("should not absolutify regex patterns in context module identifiers", () => {
 				// Issue #16259: Context module identifiers with regex patterns
 				// containing ./ should not have regex patterns made absolute
 				const context = "/project";
 				const identifier = "./src|sync|^\\.\\/.*\\.js$";
 				const result = identifierUtil.makePathsAbsolute(context, identifier);
 				// Only ./src should be made absolute, regex pattern should remain unchanged
-				// The result should end with the unchanged regex pattern
 				expect(result).toMatch(
 					/[/\\]project[/\\]src\|sync\|\^\\\.\\\/\.\*\\\.js\$$/
 				);
@@ -114,15 +113,12 @@ describe("util/identifier", () => {
 				);
 			});
 
-			it("should handle mixed ! and | separators correctly", () => {
+			it("should absolutify paths after pipe separators when not regex", () => {
 				const context = "/project";
-				const identifier = "./loader!./context|sync|./pattern";
+				const identifier = "css/auto|./bar.css";
 				const result = identifierUtil.makePathsAbsolute(context, identifier);
-				// ./loader and ./context should be made absolute (before |)
-				// ./pattern after | should NOT be made absolute
-				expect(result).toMatch(
-					/[/\\]project[/\\]loader![/\\]project[/\\]context\|sync\|\.\/pattern$/
-				);
+				// ./bar.css should be made absolute since it's not a regex pattern
+				expect(result).toMatch(/css\/auto\|[/\\]project[/\\]bar\.css$/);
 			});
 
 			it("should handle identifiers without separators", () => {
@@ -132,7 +128,7 @@ describe("util/identifier", () => {
 				expect(result).toMatch(/[/\\]project[/\\]src[/\\]file\.js$/);
 			});
 
-			it("should not modify non-relative paths", () => {
+			it("should not modify regex patterns with metacharacters", () => {
 				const context = "/project";
 				const identifier = "module-name|sync|^\\.\\/.*$";
 				const result = identifierUtil.makePathsAbsolute(context, identifier);


### PR DESCRIPTION
**Summary**

Fixes #16259: In context module identifiers, regex patterns after pipe separators (e.g., './src|sync|^\\.\\/.*\\.js$') should not have their relative paths made absolute, as this would break the regex matching. This change modifies the _makePathsAbsolute function to only absolutify path segments before the first pipe separator, preserving regex patterns unchanged.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No