### PR TITLE
Docs: clarify runtime behavior of dynamic imports in Code Splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ simple expressions. This allows you to **support most existing libraries** out o
 Webpack allows you to split your codebase into multiple chunks. Chunks are
 loaded asynchronously at runtime. This reduces the initial loading time.
 > **Note**
-> A dynamic import (`import()`) does not create a new runtime.
+> A dynamic import (`import()`) does not create new runtime.
 > Async chunks share the same runtime as their parent entry.
 > Modules already instantiated in the parent runtime will not be duplicated or partially emitted into async chunks.
 


### PR DESCRIPTION
Adds a short clarification to the Code Splitting section explaining that
dynamic imports do not create a new runtime and that async chunks share
the parent runtime.

This helps set expectations and explains why some modules remain in the
main bundle.
