### PR TITLE
feat: support webpackPrefetch and webpackPreload for Worker chunks (#19373)

### DIFF
--- a/lib/dependencies/WorkerPlugin.js
+++ b/lib/dependencies/WorkerPlugin.js
@@ -316,6 +316,8 @@ class WorkerPlugin {
 
 						/** @type {EntryOptions} */
 						const entryOptions = {};
+						/** @type {{ prefetchOrder?: number, preloadOrder?: number }} */
+						const groupOptions = {};
 
 						if (importOptions) {
 							if (importOptions.webpackIgnore !== undefined) {
@@ -360,6 +362,34 @@ class WorkerPlugin {
 									entryOptions.name = importOptions.webpackChunkName;
 								}
 							}
+							if (importOptions.webpackPrefetch !== undefined) {
+								if (importOptions.webpackPrefetch === true) {
+									groupOptions.prefetchOrder = 0;
+								} else if (typeof importOptions.webpackPrefetch === "number") {
+									groupOptions.prefetchOrder = importOptions.webpackPrefetch;
+								} else {
+									parser.state.module.addWarning(
+										new UnsupportedFeatureWarning(
+											`\`webpackPrefetch\` expected true or a number, but received: ${importOptions.webpackPrefetch}.`,
+											/** @type {DependencyLocation} */ (expr.loc)
+										)
+									);
+								}
+							}
+							if (importOptions.webpackPreload !== undefined) {
+								if (importOptions.webpackPreload === true) {
+									groupOptions.preloadOrder = 0;
+								} else if (typeof importOptions.webpackPreload === "number") {
+									groupOptions.preloadOrder = importOptions.webpackPreload;
+								} else {
+									parser.state.module.addWarning(
+										new UnsupportedFeatureWarning(
+											`\`webpackPreload\` expected true or a number, but received: ${importOptions.webpackPreload}.`,
+											/** @type {DependencyLocation} */ (expr.loc)
+										)
+									);
+								}
+							}
 						}
 
 						if (
@@ -387,6 +417,7 @@ class WorkerPlugin {
 
 						const block = new AsyncDependenciesBlock({
 							name: entryOptions.name,
+							...groupOptions,
 							entryOptions: {
 								chunkLoading: this._chunkLoading,
 								wasmLoading: this._wasmLoading,

--- a/test/configCases/worker/worker-prefetch-preload/index.js
+++ b/test/configCases/worker/worker-prefetch-preload/index.js
@@ -1,0 +1,63 @@
+it("should support webpackPrefetch for Worker", async () => {
+	const worker = new Worker(
+		/* webpackPrefetch: true */
+		new URL("./worker.js", import.meta.url),
+		{ type: "module" }
+	);
+	worker.postMessage("prefetch test");
+	const result = await new Promise(resolve => {
+		worker.onmessage = event => {
+			resolve(event.data);
+		};
+	});
+	expect(result).toBe("worker received: prefetch test");
+	await worker.terminate();
+});
+
+it("should support webpackPreload for Worker", async () => {
+	const worker = new Worker(
+		/* webpackPreload: true */
+		new URL("./worker.js", import.meta.url),
+		{ type: "module" }
+	);
+	worker.postMessage("preload test");
+	const result = await new Promise(resolve => {
+		worker.onmessage = event => {
+			resolve(event.data);
+		};
+	});
+	expect(result).toBe("worker received: preload test");
+	await worker.terminate();
+});
+
+it("should support webpackPrefetch with numeric order for Worker", async () => {
+	const worker = new Worker(
+		/* webpackPrefetch: 5 */
+		new URL("./worker.js", import.meta.url),
+		{ type: "module" }
+	);
+	worker.postMessage("prefetch order test");
+	const result = await new Promise(resolve => {
+		worker.onmessage = event => {
+			resolve(event.data);
+		};
+	});
+	expect(result).toBe("worker received: prefetch order test");
+	await worker.terminate();
+});
+
+it("should support webpackPreload with numeric order for Worker", async () => {
+	const worker = new Worker(
+		/* webpackPreload: 10 */
+		new URL("./worker.js", import.meta.url),
+		{ type: "module" }
+	);
+	worker.postMessage("preload order test");
+	const result = await new Promise(resolve => {
+		worker.onmessage = event => {
+			resolve(event.data);
+		};
+	});
+	expect(result).toBe("worker received: preload order test");
+	await worker.terminate();
+});

--- a/test/configCases/worker/worker-prefetch-preload/test.config.js
+++ b/test/configCases/worker/worker-prefetch-preload/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["main.js"];
+	}
+};

--- a/test/configCases/worker/worker-prefetch-preload/test.filter.js
+++ b/test/configCases/worker/worker-prefetch-preload/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = () => supportsWorker();

--- a/test/configCases/worker/worker-prefetch-preload/webpack.config.js
+++ b/test/configCases/worker/worker-prefetch-preload/webpack.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		filename: "[name].js"
+	},
+	target: "web"
+};

--- a/test/configCases/worker/worker-prefetch-preload/worker.js
+++ b/test/configCases/worker/worker-prefetch-preload/worker.js
@@ -1,0 +1,3 @@
+onmessage = async event => {
+	postMessage("worker received: " + event.data);
+};


### PR DESCRIPTION
**Summary**

This PR adds support for `webpackPrefetch` and `webpackPreload` magic comments for `new Worker()` chunks, addressing issue #19373.

Currently, dynamic imports support `webpackPrefetch` and `webpackPreload` magic comments to hint the browser to prefetch/preload chunks for better performance. This PR extends the same functionality to Worker chunks.

Example usage:
```js
const worker = new Worker(
  /* webpackPrefetch: true */
  new URL("./worker.js", import.meta.url)
);

const worker2 = new Worker(
  /* webpackPreload: 5 */
  new URL("./heavy-worker.js", import.meta.url)
);
```

Closes #19373

**What kind of change does this PR introduce?**

feat - New feature extending prefetch/preload support to Worker chunks

**Did you add tests for your changes?**

Yes, added test case in `test/configCases/worker/worker-prefetch-preload/`:
- `should support webpackPrefetch for Worker`
- `should support webpackPreload for Worker`
- `should support webpackPrefetch with numeric order for Worker`
- `should support webpackPreload with numeric order for Worker`

**Does this PR introduce a breaking change?**

No. This is an additive feature using existing magic comment syntax.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Documentation should be updated to mention that `webpackPrefetch` and `webpackPreload` magic comments now work with `new Worker()` syntax, similar to dynamic `import()`.