### PR TITLE
feat: add webpack/globals export for ESLint configuration (#20308)

### DIFF
--- a/.changeset/eslint-globals-export.md
+++ b/.changeset/eslint-globals-export.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+feat: add `webpack/globals` export for ESLint configuration

--- a/globals.js
+++ b/globals.js
@@ -1,0 +1,81 @@
+"use strict";
+
+/**
+ * Webpack global variables for ESLint configuration.
+ *
+ * This export provides webpack's global identifiers in the same format
+ * as the `globals` package (https://github.com/sindresorhus/globals).
+ *
+ * Each global is given a value of `true` (writable) or `false` (read-only).
+ * Variables declared with `var` are writable, `const` are read-only.
+ * @example
+ * // eslint.config.js (flat config)
+ * import webpackGlobals from "webpack/globals";
+ *
+ * export default [
+ *   {
+ *     languageOptions: {
+ *       globals: webpackGlobals
+ *     }
+ *   }
+ * ];
+ * @example
+ * // .eslintrc.js (legacy config)
+ * const webpackGlobals = require("webpack/globals");
+ *
+ * module.exports = {
+ *   globals: webpackGlobals
+ * };
+ */
+module.exports = {
+	// The resource query of the current module
+	__resourceQuery: false,
+
+	// The public path as configured via output.publicPath
+	__webpack_public_path__: true,
+
+	// The nonce for script tags
+	__webpack_nonce__: true,
+
+	// The name of the current chunk
+	__webpack_chunkname__: false,
+
+	// The base URI for resolving relative URLs
+	__webpack_base_uri__: true,
+
+	// The runtime id of the current runtime
+	__webpack_runtime_id__: true,
+
+	// The compilation hash
+	__webpack_hash__: false,
+
+	// An object containing all modules
+	__webpack_modules__: false,
+
+	// The raw require function
+	__webpack_require__: false,
+
+	// Function to load a chunk
+	__webpack_chunk_load__: true,
+
+	// Function to get the filename for a chunk
+	__webpack_get_script_filename__: true,
+
+	// Function to check if a module is included
+	__webpack_is_included__: true,
+
+	// Information about exports
+	__webpack_exports_info__: true,
+
+	// Share scopes for Module Federation
+	__webpack_share_scopes__: false,
+
+	// Function to initialize sharing
+	__webpack_init_sharing__: true,
+
+	// Access to native require (bypassing webpack)
+	__non_webpack_require__: true,
+
+	// The System.js context object
+	__system_context__: false
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,12 @@
   },
   "license": "MIT",
   "author": "Tobias Koppers @sokra",
+  "exports": {
+    ".": "./lib/index.js",
+    "./globals": "./globals.js",
+    "./hot/*": "./hot/*.js",
+    "./package.json": "./package.json"
+  },
   "main": "lib/index.js",
   "types": "types.d.ts",
   "bin": {
@@ -26,7 +32,8 @@
     "schemas/",
     "SECURITY.md",
     "module.d.ts",
-    "types.d.ts"
+    "types.d.ts",
+    "globals.js"
   ],
   "scripts": {
     "prepare": "husky",


### PR DESCRIPTION
**Summary**

This PR adds a `webpack/globals` export that provides webpack's global identifiers in ESLint-compatible format, addressing issue #20308.

Webpack provides several global variables like `__webpack_public_path__`, `__webpack_require__`, etc. that are available in bundled code. Currently, developers must manually configure these globals in their ESLint config to avoid "undefined variable" errors.

This PR adds a convenient export that can be directly used in ESLint configuration:

```js
// eslint.config.js (flat config)
import webpackGlobals from "webpack/globals";

export default [
  {
    languageOptions: {
      globals: webpackGlobals
    }
  }
];
```

Closes #20308

**What kind of change does this PR introduce?**

feat - New feature providing webpack globals export for ESLint

**Did you add tests for your changes?**

The globals file is a simple static export. Verified it loads correctly and exports all 17 webpack globals in the correct format (variable name → writable boolean).

**Does this PR introduce a breaking change?**

No. This is a purely additive feature with a new export path.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Documentation should mention the new `webpack/globals` export for ESLint configuration, with examples for both flat config and legacy `.eslintrc` formats.