### PR TITLE
build: enforce Node.js >=16 for runtime code generation

### DIFF
--- a/tooling/generate-runtime-code.js
+++ b/tooling/generate-runtime-code.js
@@ -1,5 +1,10 @@
 "use strict";
 
+const major = Number(process.versions.node.split(".")[0]);
+if (major < 16) {
+	throw new Error("Node.js 16+ required to build embedded WASM");
+}
+
 const fs = require("fs");
 const path = require("path");
 const prettier = require("prettier");


### PR DESCRIPTION
Adds a Node.js version guard (>=16) to the runtime code generation script and regenerates outdated runtime code.

This prevents confusing failures on unsupported Node versions. No runtime behavior is affected.
