### PR TITLE
chore: harden Windows symlink detection in setup script

### DIFF
--- a/setup/setup.js
+++ b/setup/setup.js
@@ -44,13 +44,17 @@ async function runSetupSymlinkAsync() {
  */
 function checkSymlinkExistsAsync() {
 	return new Promise((resolve) => {
-		if (
-			fs.existsSync(nodeModulesFolder) &&
-			fs.existsSync(webpackDependencyFolder) &&
-			fs.lstatSync(webpackDependencyFolder).isSymbolicLink()
-		) {
-			resolve(true);
-		} else {
+		try {
+			if (
+				fs.existsSync(nodeModulesFolder) &&
+				fs.existsSync(webpackDependencyFolder) &&
+				fs.lstatSync(webpackDependencyFolder).isSymbolicLink()
+			) {
+				resolve(true);
+			} else {
+				resolve(false);
+			}
+		} catch {
 			resolve(false);
 		}
 	});


### PR DESCRIPTION
This change improves the robustness of the Windows setup script by hardening the
symlink detection logic.

Previously, the script assumed that node_modules/webpack could always be
stat-ed safely. In cases where the path existed but was broken, partially created,
or in an inconsistent filesystem state (which can happen on Windows due to
permission issues, interrupted installs, or developer mode configuration),
fs.lstatSync could throw and abort the setup process.

The updated logic safely handles filesystem errors during symlink detection and
treats such cases as “symlink not present”, allowing the setup script to continue
and repair the environment instead of failing early.

This does not change behavior for correctly configured environments, but makes
the setup process more resilient and self-healing in edge cases.