### PR TITLE
docs: clarify npm audit warnings for dev dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,15 @@ If you are still having difficulty after looking over your configuration careful
 a question to [Discussions](https://github.com/webpack/webpack/discussions), [StackOverflow with the webpack tag](https://stackoverflow.com/tags/webpack) or ask this in our [Discord](https://discord.gg/5sxFZPdx2k). Questions
 that include your webpack.config.js, relevant files, and the full error message are more likely to receive responses.
 
+> ⚠️ Note on dependency vulnerability warnings
+>
+> Tools like `npm audit` may report vulnerabilities originating from development-only dependencies
+> (for example `webpack-dev-server`). These warnings do not always indicate a security issue
+> in your production bundle.
+>
+> Before opening an issue, please check whether the warning comes from a dev dependency
+> and whether an update or workaround already exists.
+
 **If you have discovered a bug or have a feature suggestion, please [create an issue on GitHub](https://github.com/webpack/webpack/issues/new).**
 
 Do you want to fix an issue? Look at the issues with a tag of [Send a PR](https://github.com/webpack/webpack/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Send%20a%20PR%22). Here are some of the key labels you may encounter:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

This PR clarifies CONTRIBUTING.md regarding npm audit warnings. It explains that 
warnings from tools like `npm audit` may originate from development-only dependencies 
and do not necessarily indicate a security issue in production.

This PR replaces the previous PR (#20282), which was closed because the commits 
used an unverified email that prevented CLA approval. All commits in this PR are now 
linked to my verified GitHub account.

**What kind of change does this PR introduce?**

- Documentation (docs)

**Did you add tests for your changes?**

- No

**Does this PR introduce a breaking change?**

- No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

- No additional documentation is required beyond the updates to CONTRIBUTING.md.
