### PR TITLE
fix(docs): correct JSDoc for BuildCycleError

### DIFF
--- a/lib/errors/BuildCycleError.js
+++ b/lib/errors/BuildCycleError.js
@@ -11,7 +11,7 @@ const WebpackError = require("../WebpackError");
 
 class BuildCycleError extends WebpackError {
 	/**
-	 * Creates an instance of ModuleDependencyError.
+	 * Creates an instance of BuildCycleError.
 	 * @param {Module} module the module starting the cycle
 	 */
 	constructor(module) {


### PR DESCRIPTION
The JSDoc comment incorrectly referenced ModuleDependencyError.
This updates the documentation to correctly refer to BuildCycleError.
No runtime behavior is affected.
