### PR TITLE
fix: make AddBuildDependenciesPlugin handle empty dependencies safely

### DIFF
--- a/lib/cache/AddBuildDependenciesPlugin.js
+++ b/lib/cache/AddBuildDependenciesPlugin.js
@@ -13,12 +13,13 @@ class AddBuildDependenciesPlugin {
 	/**
 	 * @param {Iterable<string>} buildDependencies list of build dependencies
 	 */
-	constructor(buildDependencies) {
+	constructor(buildDependencies = []) {
 		this.buildDependencies = new Set(buildDependencies);
 	}
 
 	/**
-	 * Apply the plugin
+	 * Adds additional build dependencies to the compilation.
+	 * These dependencies are used to invalidate builds when they change.
 	 * @param {Compiler} compiler the compiler instance
 	 * @returns {void}
 	 */


### PR DESCRIPTION
Add a defensive default for buildDependencies to prevent crashes
when the plugin is instantiated without an iterable.

This change preserves existing behavior for valid inputs and
improves robustness without affecting runtime semantics.
