### PR TITLE
docs: clarify ContainerEntryDependency semantics

### DIFF
--- a/lib/container/ContainerEntryDependency.js
+++ b/lib/container/ContainerEntryDependency.js
@@ -24,7 +24,7 @@ class ContainerEntryDependency extends Dependency {
 	}
 
 	/**
-	 * @returns {string | null} an identifier used to merge container entry dependencies
+	 * @returns {string | null} an identifier used to merge equal container entry requests
 	 */
 	getResourceIdentifier() {
 		return `container-entry-${this.name}`;


### PR DESCRIPTION
This change clarifies the intent of ContainerEntryDependency by improving
documentation around two areas:

- The meaning of `shareScope` in the context of Module Federation.
- The purpose of `getResourceIdentifier`, specifically how it is used
  to merge equal container entry requests during dependency graph creation.

This is a documentation-only change and does not affect runtime behavior.
