### PR TITLE
refactor: add JSDoc to runtime module constructors

### DIFF
--- a/lib/runtime/GlobalRuntimeModule.js
+++ b/lib/runtime/GlobalRuntimeModule.js
@@ -9,6 +9,9 @@ const RuntimeModule = require("../RuntimeModule");
 const Template = require("../Template");
 
 class GlobalRuntimeModule extends RuntimeModule {
+	/**
+	 * Creates an instance of GlobalRuntimeModule.
+	 */
 	constructor() {
 		super("global");
 	}

--- a/lib/runtime/NonceRuntimeModule.js
+++ b/lib/runtime/NonceRuntimeModule.js
@@ -9,6 +9,9 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 
 class NonceRuntimeModule extends RuntimeModule {
+	/**
+	 * Creates an instance of NonceRuntimeModule.
+	 */
 	constructor() {
 		super("nonce", RuntimeModule.STAGE_ATTACH);
 	}

--- a/lib/runtime/RuntimeIdRuntimeModule.js
+++ b/lib/runtime/RuntimeIdRuntimeModule.js
@@ -11,6 +11,9 @@ const RuntimeModule = require("../RuntimeModule");
 /** @typedef {import("../ChunkGraph")} ChunkGraph */
 
 class RuntimeIdRuntimeModule extends RuntimeModule {
+	/**
+	 * Creates an instance of RuntimeIdRuntimeModule.
+	 */
 	constructor() {
 		super("runtimeId");
 	}

--- a/lib/runtime/SystemContextRuntimeModule.js
+++ b/lib/runtime/SystemContextRuntimeModule.js
@@ -8,6 +8,9 @@ const RuntimeGlobals = require("../RuntimeGlobals");
 const RuntimeModule = require("../RuntimeModule");
 
 class SystemContextRuntimeModule extends RuntimeModule {
+	/**
+	 * Creates an instance of SystemContextRuntimeModule.
+	 */
 	constructor() {
 		super("__system_context__");
 	}

--- a/lib/runtime/ToBinaryRuntimeModule.js
+++ b/lib/runtime/ToBinaryRuntimeModule.js
@@ -12,6 +12,9 @@ const Template = require("../Template");
 /** @typedef {import("../Compilation")} Compilation */
 
 class ToBinaryRuntimeModule extends RuntimeModule {
+	/**
+	 * Creates an instance of ToBinaryRuntimeModule.
+	 */
 	constructor() {
 		super("to binary");
 	}


### PR DESCRIPTION
**Summary**

This PR adds JSDoc documentation to runtime module constructors for consistency with other modules in the codebase.

Several runtime modules had constructors without JSDoc comments while similar modules like `ChunkNameRuntimeModule` and `BuildCycleError` already had them documented. This follows the pattern established in #20361 which corrected JSDoc for `BuildCycleError`.

Files updated:

- `lib/runtime/GlobalRuntimeModule.js`
- `lib/runtime/NonceRuntimeModule.js`
- `lib/runtime/RuntimeIdRuntimeModule.js`
- `lib/runtime/SystemContextRuntimeModule.js`
- `lib/runtime/ToBinaryRuntimeModule.js`

**What kind of change does this PR introduce?**

refactor - Adding JSDoc documentation for consistency across runtime modules.

**Did you add tests for your changes?**

No tests needed - these are documentation-only changes. Verified by `yarn lint:types`.

**Does this PR introduce a breaking change?**

No. JSDoc comments are purely for documentation and have no runtime impact.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

N/A - This is internal code documentation.
