### PR TITLE
fix: reuse the same async entrypoint for different worker URLs in a module

### DIFF
--- a/.changeset/fix-worker-new-url-import-meta.md
+++ b/.changeset/fix-worker-new-url-import-meta.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fixed Worker self-import handling to support various URL patterns (e.g., `import.meta.url`, `new URL(import.meta.url)`, `new URL(import.meta.url, import.meta.url)`, `new URL("./index.js", import.meta.url)`). Workers that resolve to the same module are now properly deduplicated, regardless of the URL syntax used.

--- a/lib/AsyncDependenciesBlock.js
+++ b/lib/AsyncDependenciesBlock.js
@@ -16,7 +16,7 @@ const makeSerializable = require("./util/makeSerializable");
 /** @typedef {import("./serialization/ObjectMiddleware").ObjectSerializerContext} ObjectSerializerContext */
 /** @typedef {import("./util/Hash")} Hash */
 
-/** @typedef {(ChunkGroupOptions & { entryOptions?: EntryOptions } & { key?: string | boolean }) | string} GroupOptions */
+/** @typedef {(ChunkGroupOptions & { entryOptions?: EntryOptions } & { circular?: boolean }) | string} GroupOptions */
 
 class AsyncDependenciesBlock extends DependenciesBlock {
 	/**
@@ -30,6 +30,10 @@ class AsyncDependenciesBlock extends DependenciesBlock {
 			groupOptions = { name: groupOptions };
 		} else if (!groupOptions) {
 			groupOptions = { name: undefined };
+		}
+		if (typeof groupOptions.circular !== "boolean") {
+			// default allow circular references
+			groupOptions.circular = true;
 		}
 		this.groupOptions = groupOptions;
 		this.loc = loc;
@@ -57,30 +61,10 @@ class AsyncDependenciesBlock extends DependenciesBlock {
 	}
 
 	/**
-	 * @returns {boolean} Whether to deduplicate to avoid circular references
+	 * @returns {boolean} Whether circular references are allowed
 	 */
 	get circular() {
-		if (this.groupOptions.key) {
-			return false;
-		}
-		return true;
-	}
-
-	/**
-	 * @returns {string} the identifier of the block
-	 */
-	identifier() {
-		let identifier = `entry-${Boolean(this.groupOptions.entryOptions)}`;
-		if (this.groupOptions.name) {
-			identifier += `|${this.groupOptions.name}`;
-		}
-		if (this.request) {
-			identifier += `|${this.request}`;
-		}
-		if (typeof this.groupOptions.key === "string") {
-			identifier += `|${this.groupOptions.key}`;
-		}
-		return identifier;
+		return Boolean(this.groupOptions.circular);
 	}
 
 	/**

--- a/lib/buildChunkGraph.js
+++ b/lib/buildChunkGraph.js
@@ -50,7 +50,7 @@ const { getEntryRuntime, mergeRuntime } = require("./util/runtime");
  * @property {number} postOrderIndex next post order index
  * @property {boolean} chunkLoading has a chunk loading mechanism
  * @property {boolean} asyncChunks create async chunks
- * @property {string} blockId is the block key
+ * @property {Module | null} depModule the module that is the dependency of the block
  * @property {boolean} circular Whether to deduplicate to avoid circular references
  */
 
@@ -363,8 +363,8 @@ const visitModules = (
 	/** @type {NamedChunkGroup} */
 	const namedAsyncEntrypoints = new Map();
 
-	/** @type {Map<string, ChunkGroupInfo>} */
-	const idAsyncEntrypoints = new Map();
+	/** @type {Map<Module, ChunkGroupInfo>} */
+	const depModuleAsyncEntrypoints = new Map();
 
 	/** @type {Set<ChunkGroupInfo>} */
 	const outdatedOrderIndexChunkGroups = new Set();
@@ -395,7 +395,7 @@ const visitModules = (
 		);
 		/** @type {ChunkGroupInfo} */
 		const chunkGroupInfo = {
-			blockId: "",
+			depModule: null,
 			circular: false,
 			initialized: false,
 			chunkGroup,
@@ -505,13 +505,16 @@ const visitModules = (
 		let c;
 		/** @type {Entrypoint | undefined} */
 		let entrypoint;
+		/** @type {Module | null} */
+		const depModule = moduleGraph.getModule(b.dependencies[0]);
 		const entryOptions = b.groupOptions && b.groupOptions.entryOptions;
 		if (cgi === undefined) {
 			const chunkName = (b.groupOptions && b.groupOptions.name) || b.chunkName;
 			if (entryOptions) {
-				cgi =
-					namedAsyncEntrypoints.get(/** @type {string} */ (chunkName)) ||
-					idAsyncEntrypoints.get(/** @type {string} */ (b.identifier()));
+				cgi = namedAsyncEntrypoints.get(/** @type {string} */ (chunkName));
+				if (!cgi && !b.circular && depModule) {
+					cgi = depModuleAsyncEntrypoints.get(depModule);
+				}
 				if (!cgi) {
 					entrypoint = compilation.addAsyncEntrypoint(
 						entryOptions,
@@ -522,7 +525,7 @@ const visitModules = (
 					maskByChunk.set(entrypoint.chunks[0], ZERO_BIGINT);
 					entrypoint.index = nextChunkGroupIndex++;
 					cgi = {
-						blockId: b.identifier(),
+						depModule,
 						circular: b.circular,
 						chunkGroup: entrypoint,
 						initialized: false,
@@ -561,9 +564,9 @@ const visitModules = (
 							(cgi)
 						);
 					}
-					if (b.circular) {
-						idAsyncEntrypoints.set(
-							b.identifier(),
+					if (!b.circular && depModule) {
+						depModuleAsyncEntrypoints.set(
+							depModule,
 							/** @type {ChunkGroupInfo} */ (cgi)
 						);
 					}
@@ -609,7 +612,7 @@ const visitModules = (
 					maskByChunk.set(c.chunks[0], ZERO_BIGINT);
 					c.index = nextChunkGroupIndex++;
 					cgi = {
-						blockId: b.identifier(),
+						depModule,
 						circular: b.circular,
 						initialized: false,
 						chunkGroup: c,
@@ -689,7 +692,7 @@ const visitModules = (
 			]);
 		} else if (
 			entrypoint !== undefined &&
-			(chunkGroupInfo.circular || chunkGroupInfo.blockId !== b.identifier())
+			(chunkGroupInfo.circular || chunkGroupInfo.depModule !== depModule)
 		) {
 			chunkGroupInfo.chunkGroup.addAsyncEntrypoint(entrypoint);
 		}

--- a/lib/dependencies/WorkerPlugin.js
+++ b/lib/dependencies/WorkerPlugin.js
@@ -387,7 +387,7 @@ class WorkerPlugin {
 
 						const block = new AsyncDependenciesBlock({
 							name: entryOptions.name,
-							key: url,
+							circular: false,
 							entryOptions: {
 								chunkLoading: this._chunkLoading,
 								wasmLoading: this._wasmLoading,

--- a/test/configCases/worker/self-import/index.js
+++ b/test/configCases/worker/self-import/index.js
@@ -1,7 +1,7 @@
 const isMain = typeof window !== "undefined";
 
 if (isMain) {
-	it("should allow to import itself", async () => {
+	it("should allow to import itself with import.meta.url directly", async () => {
 		const worker = new Worker(import.meta.url);
 		worker.postMessage("ok");
 		const result = await new Promise(resolve => {
@@ -13,8 +13,44 @@ if (isMain) {
 		await worker.terminate();
 	});
 
-	it("should allow to import itself", async () => {
+	it("should allow to import itself with new URL(import.meta.url)", async () => {
 		const worker = new Worker(new URL(import.meta.url));
+		worker.postMessage("ok");
+		const result = await new Promise(resolve => {
+			worker.onmessage = event => {
+				resolve(event.data);
+			};
+		});
+		expect(result).toBe("data: OK, thanks");
+		await worker.terminate();
+	});
+
+	it("should allow to import itself with new URL(import.meta.url, import.meta.url)", async () => {
+		const worker = new Worker(new URL(import.meta.url, import.meta.url));
+		worker.postMessage("ok");
+		const result = await new Promise(resolve => {
+			worker.onmessage = event => {
+				resolve(event.data);
+			};
+		});
+		expect(result).toBe("data: OK, thanks");
+		await worker.terminate();
+	});
+
+	it("should allow to import itself with new URL relative path and import.meta.url as base", async () => {
+		const worker = new Worker(new URL("./index.js", import.meta.url));
+		worker.postMessage("ok");
+		const result = await new Promise(resolve => {
+			worker.onmessage = event => {
+				resolve(event.data);
+			};
+		});
+		expect(result).toBe("data: OK, thanks");
+		await worker.terminate();
+	});
+
+	it("should allow to import itself with new URL relative path without extension and import.meta.url as base", async () => {
+		const worker = new Worker(new URL("./index", import.meta.url));
 		worker.postMessage("ok");
 		const result = await new Promise(resolve => {
 			worker.onmessage = event => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -458,18 +458,17 @@ declare class AsyncDependenciesBlock extends DependenciesBlock {
 			| string
 			| (RawChunkGroupOptions & { name?: null | string } & {
 					entryOptions?: EntryOptions;
-			  } & { key?: string | boolean }),
+			  } & { circular?: boolean }),
 		loc?: null | SyntheticDependencyLocation | RealDependencyLocation,
 		request?: null | string
 	);
 	groupOptions: RawChunkGroupOptions & { name?: null | string } & {
 		entryOptions?: EntryOptions;
-	} & { key?: string | boolean };
+	} & { circular?: boolean };
 	loc?: null | SyntheticDependencyLocation | RealDependencyLocation;
 	request?: null | string;
 	chunkName?: null | string;
 	get circular(): boolean;
-	identifier(): string;
 	module: any;
 }
 declare abstract class AsyncQueue<T, K, R> {


### PR DESCRIPTION

**Summary**
fix: reuse the same async entrypoint for different worker URLs in a module

**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing