### PR TITLE
fix: avoid intented comma operator in BinaryMiddleware test

### DIFF
--- a/test/BinaryMiddleware.unittest.js
+++ b/test/BinaryMiddleware.unittest.js
@@ -69,7 +69,7 @@ describe("BinaryMiddleware", () => {
 
 	const cases = [
 		...itemsWithLazy.map((item) => [item]),
-		[(true, true)],
+		[true, true],
 		[false, true],
 		[true, false],
 		[false, false],


### PR DESCRIPTION
This change fixes an unintended use of the JavaScript comma operator in a test case.

The expression `[(true, true)]` evaluates to `[true]`, which is misleading and not equivalent to the intended two-boolean array. Replacing it with `[true, true]` makes the test case explicit and correct.

