### PR TITLE
fix: ABSOLUTE_PATH_REGEXES should also accept forward slashes

### DIFF
--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -124,7 +124,7 @@ const getExtractSourceMap = memoize(() => require("./util/extractSourceMap"));
 
 const getValidate = memoize(() => require("schema-utils").validate);
 
-const ABSOLUTE_PATH_REGEX = /^(?:[a-z]:\\|\\\\|\/)/i;
+const ABSOLUTE_PATH_REGEX = /^(?:[a-z]:[\\\/]|[\\\/][\\\/]|\/)/i;
 
 /**
  * @typedef {object} LoaderItem


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Latest version of webpack warns when it sees paths like C:/Users/..., despite those paths being valid for windows.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Both forward and back slashes are valid on Windows, this patch makes this warning go away, those paths are not affected by the normalization step below.

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

<!-- **Did you add tests for your changes?** -->

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

<!-- **Does this PR introduce a breaking change?** -->

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

<!-- **If relevant, what needs to be documented once your changes are merged or what have you already documented?** -->

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
