### PR TITLE
test: add coverage for empty exports with outputModule

### DIFF
--- a/test/configCases/library/empty-webpack-exports/index.js
+++ b/test/configCases/library/empty-webpack-exports/index.js
@@ -1,0 +1,2 @@
+const value = 1;
+export default value;

--- a/test/configCases/library/empty-webpack-exports/webpack.config.js
+++ b/test/configCases/library/empty-webpack-exports/webpack.config.js
@@ -1,0 +1,16 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	experiments: {
+		outputModule: true
+	},
+	output: {
+		library: {
+			type: "module"
+		},
+		module: true,
+		filename: "bundle.js"
+	}
+};


### PR DESCRIPTION
### What
Adds a configCases test for ESM library output using `experiments.outputModule`
where the entry only has a default export and no runtime usage.

### Why
Covers the scenario discussed in #20146 and guards against regressions
in outputModule library builds.

### Related
#20146
