### PR TITLE
updated readme text lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,7 @@ or are automatically applied via regex from your webpack configuration.
 
 ### Performance
 
-Webpack uses async I/O and has multiple caching levels. This makes webpack fast
-and incredibly **fast** on incremental compilations.
+Webpack uses async I/O and has multiple caching levels.This makes webpack fast and incredibly efficient on incremental compilations.
 
 ### Module Formats
 


### PR DESCRIPTION
What was changed? I have updated the Performance section in the README.md. Specifically, I changed the redundant phrase: "This makes webpack fast and incredibly fast..." to: "This makes webpack fast and incredibly efficient..."

Why was it changed? The original sentence used the word "fast" twice in a very short span. In professional documentation, this is considered a linguistic redundancy (tautology). By changing the second "fast" to "efficient", the sentence now:

Improves readability: It sounds more natural and less repetitive.

Enhances accuracy: Webpack's speed on incremental builds is largely due to its efficiency in caching and I/O handling, so this word is technically more descriptive.

Maintains professionalism: It aligns with the high-quality standards of the webpack documentation.

✅ Checklist
[x] Fixed a typo/redundancy in README.

[x] No breaking changes.

[x] Followed the project's tone and style.