### PR TITLE
fix: prevent empty JS file generation for CSS-only entry points

### DIFF
--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -81,7 +81,13 @@ const JavascriptParser = require("./JavascriptParser");
  * @returns {boolean} true, when a JS file is needed for this chunk
  */
 const chunkHasJs = (chunk, chunkGraph) => {
-	if (chunkGraph.getNumberOfEntryModules(chunk) > 0) return true;
+	if (chunkGraph.getNumberOfEntryModules(chunk) > 0) {
+		for (const module of chunkGraph.getChunkEntryModulesIterable(chunk)) {
+			if (chunkGraph.getModuleSourceTypes(module).has(JAVASCRIPT_TYPE)) {
+				return true;
+			}
+		}
+	}
 
 	return Boolean(
 		chunkGraph.getChunkModulesIterableBySourceType(chunk, JAVASCRIPT_TYPE)
@@ -94,18 +100,32 @@ const chunkHasJs = (chunk, chunkGraph) => {
  * @returns {boolean} true, when a JS file is needed for this chunk
  */
 const chunkHasRuntimeOrJs = (chunk, chunkGraph) => {
+	if (chunkGraph.getChunkModulesIterableBySourceType(chunk, JAVASCRIPT_TYPE)) {
+		return true;
+	}
+
 	if (
 		chunkGraph.getChunkModulesIterableBySourceType(
 			chunk,
 			WEBPACK_MODULE_TYPE_RUNTIME
 		)
 	) {
-		return true;
+		const numEntryModules = chunkGraph.getNumberOfEntryModules(chunk);
+		if (numEntryModules === 0) {
+			// Runtime-only chunk (e.g. optimization.runtimeChunk: true) —
+			// keep JS for bootstrap code that loads other entry chunks
+			return true;
+		}
+		// Entry modules exist in this chunk — only emit JS if any need JavaScript
+		for (const module of chunkGraph.getChunkEntryModulesIterable(chunk)) {
+			if (chunkGraph.getModuleSourceTypes(module).has(JAVASCRIPT_TYPE)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
-	return Boolean(
-		chunkGraph.getChunkModulesIterableBySourceType(chunk, JAVASCRIPT_TYPE)
-	);
+	return false;
 };
 
 /**

--- a/test/configCases/asset-modules/only-entry/test.js
+++ b/test/configCases/asset-modules/only-entry/test.js
@@ -26,12 +26,13 @@ it("should work", () => {
 			break;
 		}
 		case 2: {
-			expect(stats.assets.length).toBe(4);
+			// CSS-only entry should NOT generate an empty .js file (#11671)
+			expect(stats.assets.length).toBe(3);
 
 			const cssEntryInJs = stats.assets.find(
 				a => a.name.endsWith("css-entry.js")
 			);
-			expect(Boolean(cssEntryInJs)).toBe(true);
+			expect(Boolean(cssEntryInJs)).toBe(false);
 
 			const cssEntry = stats.assets.find(
 				a => a.name.endsWith("css-entry.css")
@@ -40,7 +41,8 @@ it("should work", () => {
 			break;
 		}
 		case 3: {
-			expect(stats.assets.length).toBe(5);
+			// JS entry keeps .js, CSS-only entry should NOT generate .js (#11671)
+			expect(stats.assets.length).toBe(4);
 
 			const jsEntry = stats.assets.find(
 				a => a.name.endsWith("js-entry.js")
@@ -50,7 +52,7 @@ it("should work", () => {
 			const cssEntryInJs = stats.assets.find(
 				a => a.name.endsWith("css-entry.js")
 			);
-			expect(Boolean(cssEntryInJs)).toBe(true);
+			expect(Boolean(cssEntryInJs)).toBe(false);
 
 			const cssEntry = stats.assets.find(
 				a => a.name.endsWith("css-entry.css")
@@ -59,6 +61,7 @@ it("should work", () => {
 			break;
 		}
 		case 4: {
+			// Node target: CSS entry generates JS (exports class names, no CSS output)
 			expect(stats.assets.length).toBe(4);
 
 			const jsEntry = stats.assets.find(


### PR DESCRIPTION
## Human View

### Summary

Fixes #11671 (5+ years old, 82 reactions).

When CSS files are used as webpack entry points, an unnecessary empty `.js` file is generated in the output alongside the CSS. This forces users to rely on third-party plugins like `webpack-remove-empty-scripts`.

#### Before

```js
// webpack.config.js
entry: { styles: './src/styles.css' }
// Output: dist/styles.js (EMPTY) + dist/styles.css
```

#### After

```js
// Output: dist/styles.css (only)
```

### Root Cause

Two functions in `JavascriptModulesPlugin.js` cause this:

1. **`chunkHasJs()`** (line 83) returns `true` for any chunk with entry modules, without checking their source types. CSS-only entry modules have source type `"css"`, not `"javascript"`.

2. **`chunkHasRuntimeOrJs()`** (line 96) returns `true` when runtime modules exist. But runtime modules are always added to entry chunks — for CSS-only entries, the runtime has nothing to bootstrap.

### Fix

- **`chunkHasJs()`**: Iterate entry modules and check their source types. Only return `true` when at least one entry module has `JAVASCRIPT_TYPE`.

- **`chunkHasRuntimeOrJs()`**: When runtime modules exist, check for JS non-entry modules first. If only runtime + entry modules, verify entry modules have JS source type. For standalone runtime chunks (`optimization.runtimeChunk: true`), keep JS emission since the bootstrap code is needed.

### Changes

| File | Change |
|------|--------|
| `lib/javascript/JavascriptModulesPlugin.js` | Fix `chunkHasJs` and `chunkHasRuntimeOrJs` to check entry module source types |
| `test/configCases/asset-modules/only-entry/test.js` | Update expectations: CSS-only entries no longer generate `.js` files |

### Edge Cases Verified

- CSS-only entry (web target): No JS file emitted
- CSS-only entry (node target): JS file still emitted (CSS modules export class names as JS on node)
- JS entry: Still emits JS normally
- Mixed JS+CSS entries: JS entry keeps `.js`, CSS entry drops empty `.js`
- `optimization.runtimeChunk: true`: Standalone runtime chunk keeps JS for bootstrap
- `chunkHasJs` as public API: Used by 5+ chunk loading modules — the change makes it more correct (CSS chunks truly don't have JS)
- All existing split-chunks, runtime, and CSS tests pass

### Testing

- All `only-entry` test cases pass (7 configs)
- `vendor-only-entrypoint` (runtimeChunk: true) passes
- `pure-css` passes
- `no-extra-runtime-with-asset-modules` passes
- 0 new regressions (pre-existing failures are ESM infrastructure issues on main)

---

## AI View (DCCE Protocol v1.0)

### Metadata
- **Generator**: Claude (Anthropic) via Cursor IDE
- **Methodology**: AI-assisted development with human oversight and review

### AI Contribution Summary
- Root cause analysis through code tracing
- Solution design and implementation
- Edge case analysis and verification

### Verification Steps Performed
1. Reproduced the reported issue
2. Analyzed source code to identify root cause
3. Implemented and tested the fix

### Human Review Guidance
- Verify the root cause analysis matches your understanding of the codebase
- Core changes are in: `JavascriptModulesPlugin.js`, `lib/javascript/JavascriptModulesPlugin.js`, `test/configCases/asset-modules/only-entry/test.js`
- Verify edge case coverage is complete

Made with M7 [Cursor](https://cursor.com)
