### PR TITLE
docs: use https links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ or packaging just about any resource or asset.
 
 **TL;DR**
 
-- Bundles [ES Modules](https://www.2ality.com/2014/09/es6-modules-final.html), [CommonJS](http://wiki.commonjs.org/), and [AMD](https://github.com/amdjs/amdjs-api/wiki/AMD) modules (even combined).
+- Bundles [ES Modules](https://www.2ality.com/2014/09/es6-modules-final.html), [CommonJS](https://wiki.commonjs.org/), and [AMD](https://github.com/amdjs/amdjs-api/wiki/AMD) modules (even combined).
 - Can create a single bundle or multiple chunks that are asynchronously loaded at runtime (to reduce initial loading time).
 - Dependencies are resolved during compilation, reducing the runtime size.
 - Loaders can preprocess files while compiling, e.g. TypeScript to JavaScript, Handlebars strings to compiled functions, images to Base64, etc.
@@ -636,7 +636,7 @@ Before we started using OpenCollective, donations were made anonymously. Now tha
 
 <p>(In chronological order)</p>
 
-- [@google](https://github.com/google) for [Google Web Toolkit (GWT)](http://www.gwtproject.org/), which aims to compile Java to JavaScript. It features a similar [Code Splitting](http://www.gwtproject.org/doc/latest/DevGuideCodeSplitting.html) as webpack.
+- [@google](https://github.com/google) for [Google Web Toolkit (GWT)](https://www.gwtproject.org/), which aims to compile Java to JavaScript. It features a similar [Code Splitting](https://www.gwtproject.org/doc/latest/DevGuideCodeSplitting.html) as webpack.
 - [@medikoo](https://github.com/medikoo) for [modules-webmake](https://github.com/medikoo/modules-webmake), which is a similar project. webpack was born because of the desire for code splitting for modules such as Webmake. Interestingly, the [Code Splitting issue is still open](https://github.com/medikoo/modules-webmake/issues/7) (thanks also to @Phoscur for the discussion).
 - [@substack](https://github.com/substack) for [browserify](https://browserify.org/), which is a similar project and source for many ideas.
 - [@jrburke](https://github.com/jrburke) for [require.js](https://requirejs.org/), which is a similar project and source for many ideas.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary
<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
The README contains a few `http://` links (CommonJS wiki + GWT references) that redirect to `https://`. This updates them to use `https://` directly to avoid unnecessary redirects and keep the docs consistent.

<!-- Try to link to an open issue for more information. -->
N/A (docs-only cleanup)

<!-- Any other information related to changes. -->
No functional/runtime changes.

## What kind of change does this PR introduce?
Docs

## Did you add tests for your changes?
Not applicable (documentation-only change)

## Does this PR introduce a breaking change?
No

## If relevant, what needs to be documented once your changes are merged or what have you already documented?
Already documented in README by updating the links.