### PR TITLE
fix: prevent empty JS file generation for CSS-only entry points

### DIFF
--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -81,7 +81,13 @@ const JavascriptParser = require("./JavascriptParser");
  * @returns {boolean} true, when a JS file is needed for this chunk
  */
 const chunkHasJs = (chunk, chunkGraph) => {
-	if (chunkGraph.getNumberOfEntryModules(chunk) > 0) return true;
+	if (chunkGraph.getNumberOfEntryModules(chunk) > 0) {
+		for (const module of chunkGraph.getChunkEntryModulesIterable(chunk)) {
+			if (chunkGraph.getModuleSourceTypes(module).has(JAVASCRIPT_TYPE)) {
+				return true;
+			}
+		}
+	}
 
 	return Boolean(
 		chunkGraph.getChunkModulesIterableBySourceType(chunk, JAVASCRIPT_TYPE)
@@ -377,6 +383,17 @@ class JavascriptModulesPlugin {
 							);
 					} else if (chunk.hasRuntime()) {
 						if (!chunkHasRuntimeOrJs(chunk, chunkGraph)) {
+							return result;
+						}
+
+						// Skip JS generation for CSS-only entry chunks
+						// Even though runtime modules exist (e.g. CSS loading),
+						// CSS-only entries don't need a JS file - initial CSS is
+						// loaded via <link> tags, not webpack runtime
+						if (
+							chunkGraph.getNumberOfEntryModules(chunk) > 0 &&
+							!chunkHasJs(chunk, chunkGraph)
+						) {
 							return result;
 						}
 

--- a/test/configCases/css/css-only-entry-no-runtime-chunk/index.js
+++ b/test/configCases/css/css-only-entry-no-runtime-chunk/index.js
@@ -1,0 +1,12 @@
+it("should not generate a JS file for CSS-only entry points without runtimeChunk", () => {
+	const assets = __STATS__.assets.map(a => a.name);
+
+	// CSS entry should produce a CSS file
+	expect(assets).toContain("styles.css");
+
+	// CSS entry should NOT produce a JS file
+	expect(assets).not.toContain("styles.js");
+
+	// JS entry should still produce a JS file
+	expect(assets).toContain("main.js");
+});

--- a/test/configCases/css/css-only-entry-no-runtime-chunk/style.css
+++ b/test/configCases/css/css-only-entry-no-runtime-chunk/style.css
@@ -1,0 +1,9 @@
+.header {
+	color: red;
+	background: blue;
+}
+
+.footer {
+	color: green;
+	background: yellow;
+}

--- a/test/configCases/css/css-only-entry-no-runtime-chunk/test.config.js
+++ b/test/configCases/css/css-only-entry-no-runtime-chunk/test.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+module.exports = {
+	findBundle(i, options) {
+		return "./main.js";
+	},
+	moduleScope(scope) {
+		const link = scope.window.document.createElement("link");
+		link.rel = "stylesheet";
+		link.href = "styles.css";
+		scope.window.document.head.appendChild(link);
+	}
+};

--- a/test/configCases/css/css-only-entry-no-runtime-chunk/webpack.config.js
+++ b/test/configCases/css/css-only-entry-no-runtime-chunk/webpack.config.js
@@ -1,0 +1,20 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	entry: {
+		main: "./index.js",
+		styles: "./style.css"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		minimize: false
+	},
+	experiments: {
+		css: true
+	}
+};

--- a/test/configCases/css/css-only-entry/index.js
+++ b/test/configCases/css/css-only-entry/index.js
@@ -1,0 +1,12 @@
+it("should not generate a JS file for CSS-only entry points", () => {
+	const assets = __STATS__.assets.map(a => a.name);
+
+	// CSS entry should produce a CSS file
+	expect(assets).toContain("styles.css");
+
+	// CSS entry should NOT produce a JS file
+	expect(assets).not.toContain("styles.js");
+
+	// JS entry should still produce a JS file
+	expect(assets).toContain("main.js");
+});

--- a/test/configCases/css/css-only-entry/style.css
+++ b/test/configCases/css/css-only-entry/style.css
@@ -1,0 +1,9 @@
+.header {
+	color: red;
+	background: blue;
+}
+
+.footer {
+	color: green;
+	background: yellow;
+}

--- a/test/configCases/css/css-only-entry/test.config.js
+++ b/test/configCases/css/css-only-entry/test.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+module.exports = {
+	findBundle(i, options) {
+		return ["./runtime.js", "./main.js"];
+	},
+	moduleScope(scope) {
+		const link = scope.window.document.createElement("link");
+		link.rel = "stylesheet";
+		link.href = "styles.css";
+		scope.window.document.head.appendChild(link);
+	}
+};

--- a/test/configCases/css/css-only-entry/webpack.config.js
+++ b/test/configCases/css/css-only-entry/webpack.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "production",
+	entry: {
+		main: "./index.js",
+		styles: "./style.css"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		minimize: false,
+		runtimeChunk: "single"
+	},
+	experiments: {
+		css: true
+	}
+};


### PR DESCRIPTION
## Summary

When using native CSS support (`experiments.css: true`) with a CSS file as the sole entry point, webpack incorrectly generates an empty/near-empty JS file alongside the CSS output. This is a long-standing issue (#11671, 82+ reactions) that causes unnecessary file bloat and confusion.

### Root Cause

Two functions in `JavascriptModulesPlugin.js` incorrectly determine that a JS file is needed:

1. **`chunkHasJs()`** returns `true` for any chunk with entry modules, without checking if those entry modules actually produce JavaScript. CSS-only entries have CSS source types, not JavaScript.

2. **`renderManifest` hook** for runtime chunks: even when entry modules are CSS-only, the presence of CSS loading runtime modules causes `chunkHasRuntimeOrJs()` to return `true`, triggering JS file generation with only bootstrap code and no meaningful entry execution.

### Fix

- **`chunkHasJs()`**: Instead of blindly returning `true` when `getNumberOfEntryModules(chunk) > 0`, iterate entry modules and check if any actually have `"javascript"` source type via `getModuleSourceTypes()`.

- **`renderManifest` hook**: For runtime chunks that have entry modules but where `chunkHasJs()` returns `false` (i.e., all entry modules are CSS-only), skip JS file generation entirely. This correctly preserves JS generation for:
  - Dedicated runtime chunks (no entry modules, only runtime modules)
  - Mixed entry chunks (JS + CSS entries)
  - Pure JS entry chunks

### Test Cases

Two new config test cases added:
- `css/css-only-entry` — CSS-only entry with `optimization.runtimeChunk: 'single'` (runtime separated)
- `css/css-only-entry-no-runtime-chunk` — CSS-only entry without `runtimeChunk` (runtime in entry chunk)

Both verify that:
-  CSS file is generated for the CSS entry
-  No JS file is generated for the CSS entry  
-  JS entries still work correctly alongside CSS entries

Fixes #11671