### PR TITLE
fix(library): aggregate exports from all entry modules (fixes #15936)

### DIFF
--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -984,6 +984,9 @@ class JavascriptModulesPlugin {
 				startupSource.add(`var ${RuntimeGlobals.exports} = {};\n`);
 			}
 
+			const mergeLibraryEntryExports = Boolean(
+				compilation.outputOptions.library && inlinedModules.size > 1
+			);
 			const avoidEntryIife = compilation.options.optimization.avoidEntryIife;
 			/** @type {Map<Module, Source> | false} */
 			let renamedInlinedModule = false;
@@ -1063,7 +1066,16 @@ class JavascriptModulesPlugin {
 					}
 					if (exports) {
 						if (m !== lastInlinedModule) {
-							startupSource.add(`var ${m.exportsArgument} = {};\n`);
+							if (mergeLibraryEntryExports) {
+								if (m.exportsArgument !== RuntimeGlobals.exports) {
+									startupSource.add(
+										`var ${m.exportsArgument} = ${RuntimeGlobals.exports};\n`
+									);
+								}
+								// else: module uses __webpack_exports__ from outer scope
+							} else {
+								startupSource.add(`var ${m.exportsArgument} = {};\n`);
+							}
 						} else if (m.exportsArgument !== RuntimeGlobals.exports) {
 							startupSource.add(
 								`var ${m.exportsArgument} = ${RuntimeGlobals.exports};\n`
@@ -1311,6 +1323,10 @@ class JavascriptModulesPlugin {
 				const buf2 = [];
 				const runtimeRequirements =
 					chunkGraph.getTreeRuntimeRequirements(chunk);
+				const mergeLibraryEntryExports = Boolean(
+					runtimeTemplate.compilation.outputOptions.library &&
+					chunkGraph.getNumberOfEntryModules(chunk) > 1
+				);
 				buf2.push("// Load entry module and return exports");
 				let i = chunkGraph.getNumberOfEntryModules(chunk);
 				for (const [
@@ -1439,7 +1455,10 @@ class JavascriptModulesPlugin {
 							requireScopeUsed ||
 							entryRuntimeRequirements.has(RuntimeGlobals.exports)
 						) {
-							const exportsArg = i === 0 ? RuntimeGlobals.exports : "{}";
+							const exportsArg =
+								i === 0 || mergeLibraryEntryExports
+									? RuntimeGlobals.exports
+									: "{}";
 							args.push("0", exportsArg);
 							if (requireScopeUsed) {
 								args.push(RuntimeGlobals.require);

--- a/lib/library/AbstractLibraryPlugin.js
+++ b/lib/library/AbstractLibraryPlugin.js
@@ -80,15 +80,16 @@ class AbstractLibraryPlugin {
 								: compilation.outputOptions.library
 						);
 						if (options !== false) {
-							const dep = deps[deps.length - 1];
-							if (dep) {
-								const module = compilation.moduleGraph.getModule(dep);
-								if (module) {
-									this.finishEntryModule(module, name, {
-										options,
-										compilation,
-										chunkGraph: compilation.chunkGraph
-									});
+							for (const dep of deps) {
+								if (dep) {
+									const module = compilation.moduleGraph.getModule(dep);
+									if (module) {
+										this.finishEntryModule(module, name, {
+											options,
+											compilation,
+											chunkGraph: compilation.chunkGraph
+										});
+									}
 								}
 							}
 						}

--- a/test/configCases/library/multiple-entry-exports-15936/a.js
+++ b/test/configCases/library/multiple-entry-exports-15936/a.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/test/configCases/library/multiple-entry-exports-15936/b.js
+++ b/test/configCases/library/multiple-entry-exports-15936/b.js
@@ -1,0 +1,1 @@
+export const b = 2;

--- a/test/configCases/library/multiple-entry-exports-15936/c.js
+++ b/test/configCases/library/multiple-entry-exports-15936/c.js
@@ -1,0 +1,7 @@
+export const c = 3;
+
+it("should aggregate exports from all entry modules (issue #15936)", function () {
+	expect(MyLib.a).toBe(1);
+	expect(MyLib.b).toBe(2);
+	expect(MyLib.c).toBe(3);
+});

--- a/test/configCases/library/multiple-entry-exports-15936/test.config.js
+++ b/test/configCases/library/multiple-entry-exports-15936/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	afterExecute() {
+		delete global.MyLib;
+	}
+};

--- a/test/configCases/library/multiple-entry-exports-15936/webpack.config.js
+++ b/test/configCases/library/multiple-entry-exports-15936/webpack.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: ["./a.js", "./b.js", "./c.js"],
+	output: {
+		library: {
+			name: "MyLib",
+			type: "assign"
+		}
+	}
+};


### PR DESCRIPTION
# Pull request body for #15936 (copy into GitHub when opening the PR)

## What does this PR do?

Fixes #15936

**Problem:** With `entry: ["a", "b", "c"]` and `output.library: { type: "global" }` (or `assign`), only exports from the last entry module (`c`) were exposed on the library. Exports from `a` and `b` were lost.

**Cause:**
1. **AbstractLibraryPlugin** only called `finishEntryModule` for `deps[deps.length - 1]`, so only the last entry module was marked as "used as library export"; the others could be tree-shaken or not wired for export.
2. **Bootstrap / inlined startup** gave each entry module its own exports object (`{}`) except the last, so only the last module’s exports were assigned to the library target.

**Fix:**
1. **lib/library/AbstractLibraryPlugin.js:** Call `finishEntryModule` for every entry dependency in `deps`, not only the last one, so all entry modules are marked as used for library export.
2. **lib/javascript/JavascriptModulesPlugin.js (bootstrap):** When `output.library` is set and there are multiple entry modules, pass the same exports object (`RuntimeGlobals.exports`) to every entry module in the non-inlined startup path so they all merge into one object.
3. **lib/javascript/JavascriptModulesPlugin.js (inlined):** When `output.library` is set and multiple entry modules are inlined, use the shared `__webpack_exports__` for all of them (no per-module `{}`) so they merge; avoid adding a self-referential `var __webpack_exports__ = __webpack_exports__` when the module already uses `RuntimeGlobals.exports`.

**Test:** Added `test/configCases/library/multiple-entry-exports-15936/` with `entry: ["./a.js", "./b.js", "./c.js"]` and `output.library: { name: "MyLib", type: "assign" }`. The test asserts that `MyLib.a`, `MyLib.b`, and `MyLib.c` are all defined correctly.

## Checklist

- [x] Fix is minimal and targeted
- [x] New test case added (configCases/library/multiple-entry-exports-15936)
- [x] No breaking change
