### PR TITLE
fix: skip non-runtime chunks in createHash to prevent crash with workers

### DIFF
--- a/.changeset/fix-worker-createhash-crash.md
+++ b/.changeset/fix-worker-createhash-crash.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix crash in createHash when using Web Workers with runtimeChunk optimization. The async entrypoint's chunk may not be a runtime chunk, so skip non-runtime chunks when building the runtime chunk dependency graph.

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -4531,12 +4531,12 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 					(e) => e.chunks[e.chunks.length - 1]
 				)
 			)) {
-				const otherInfo =
-					/** @type {RuntimeChunkInfo} */
-					(runtimeChunksMap.get(other));
-				otherInfo.referencedBy.push(info);
-				info.remaining++;
-				remaining++;
+				const otherInfo = runtimeChunksMap.get(other);
+				if (otherInfo !== undefined) {
+					otherInfo.referencedBy.push(info);
+					info.remaining++;
+					remaining++;
+				}
 			}
 		}
 		/** @type {Chunk[]} */

--- a/test/configCases/worker/web-worker-runtime-chunk/index.js
+++ b/test/configCases/worker/web-worker-runtime-chunk/index.js
@@ -1,0 +1,9 @@
+it("should not crash when using workers with runtimeChunk", function (done) {
+	const worker = new Worker(new URL("./worker.js", import.meta.url));
+	worker.onmessage = function (event) {
+		expect(event.data).toBe("worker response: hello");
+		worker.terminate();
+		done();
+	};
+	worker.postMessage("hello");
+});

--- a/test/configCases/worker/web-worker-runtime-chunk/test.config.js
+++ b/test/configCases/worker/web-worker-runtime-chunk/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["runtime.js", "main.js"];
+	}
+};

--- a/test/configCases/worker/web-worker-runtime-chunk/test.filter.js
+++ b/test/configCases/worker/web-worker-runtime-chunk/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsWorker = require("../../../helpers/supportsWorker");
+
+module.exports = () => supportsWorker();

--- a/test/configCases/worker/web-worker-runtime-chunk/webpack.config.js
+++ b/test/configCases/worker/web-worker-runtime-chunk/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		filename: "[name].js"
+	},
+	target: "web",
+	optimization: {
+		runtimeChunk: { name: "runtime" },
+		splitChunks: {
+			cacheGroups: {
+				vendor: {
+					test(mod) {
+						return mod.context && mod.context.includes("node_modules");
+					},
+					chunks: "all",
+					name: "vendor",
+					priority: 10,
+					enforce: true
+				}
+			}
+		}
+	}
+};

--- a/test/configCases/worker/web-worker-runtime-chunk/worker.js
+++ b/test/configCases/worker/web-worker-runtime-chunk/worker.js
@@ -1,0 +1,3 @@
+onmessage = function (event) {
+	postMessage("worker response: " + event.data);
+};


### PR DESCRIPTION
## Summary

When using Web Workers (via `new URL('./worker.js', import.meta.url)`) together with `optimization.runtimeChunk`, webpack crashes during the hashing phase:

```
TypeError: Cannot read properties of undefined (reading 'referencedBy')
    at Compilation.createHash (lib/Compilation.js)
```

The issue is in `createHash` where the code iterates over async entrypoints referenced by runtime chunks and looks up the entrypoint's last chunk in `runtimeChunksMap`. When `runtimeChunk` is enabled, the async entrypoint's last chunk (e.g. the worker chunk) may not have its own runtime (since runtime was extracted), so it's not present in `runtimeChunksMap`. The `get()` call returns `undefined`, and accessing `.referencedBy` on it crashes.

The fix simply checks whether the referenced chunk is actually a runtime chunk before adding it to the dependency graph. Non-runtime chunks are already hashed separately in the `initialChunks`/`asyncChunks` phase and don't need ordering.

## Reproduction

```js
module.exports = {
  entry: {
    app: ['./app.js'],
    'my-worker': ['./worker.js'],
  },
  optimization: {
    runtimeChunk: { name: 'runtime' },
    splitChunks: {
      cacheGroups: {
        vendor: {
          test: (mod) => mod.context && mod.context.includes('node_modules'),
          chunks: 'all', name: 'vendor', priority: 10, enforce: true
        }
      }
    }
  }
};
```

Where `app.js` creates a worker via `new Worker(new URL('./worker.js', import.meta.url))`.

## Test plan

- Added a new configCase test `worker/web-worker-runtime-chunk` that verifies compilation succeeds when using workers with `runtimeChunk`
- Verified existing worker and runtime-chunk tests continue to pass

Fixes #17105