### PR TITLE
chore: remove deprecated ExportsInfo properties

### DIFF
--- a/lib/ExportsInfo.js
+++ b/lib/ExportsInfo.js
@@ -933,36 +933,6 @@ class ExportInfo {
 		this._maxTarget = undefined;
 	}
 
-	// TODO webpack 5 remove
-	/**
-	 * @private
-	 * @param {EXPECTED_ANY} v v
-	 */
-	set used(v) {
-		throw new Error("REMOVED");
-	}
-
-	// TODO webpack 5 remove
-	/** @private */
-	get used() {
-		throw new Error("REMOVED");
-	}
-
-	// TODO webpack 5 remove
-	/**
-	 * @private
-	 * @param {EXPECTED_ANY} v v
-	 */
-	set usedName(v) {
-		throw new Error("REMOVED");
-	}
-
-	// TODO webpack 5 remove
-	/** @private */
-	get usedName() {
-		throw new Error("REMOVED");
-	}
-
 	get canMangle() {
 		switch (this.canMangleProvide) {
 			case undefined:


### PR DESCRIPTION
This PR removes the used and usedName getters and setters in 
lib/ExportsInfo.js
. These methods were explicitly marked with TODO webpack 5 remove and their implementation consisted solely of throwing an Error("REMOVED"). Removing them cleans up dead code and reduces technical debt in the codebase.

What kind of change does this PR introduce?

refactor

Did you add tests for your changes?

No new tests were added as this is dead code removal. I verified that yarn test:unit passes (specifically 
ExportsInfo.js
 related tests) to ensure no regressions.

Does this PR introduce a breaking change?

Technicially yes, as the properties are removed entirely. However, since accessing these properties previously threw a runtime Error("REMOVED"), any code relying on them was already broken. This change just finalizes their removal.
