### PR TITLE
Test/add async dependencies block test

### DIFF
--- a/test/AsyncDependenciesBlock.unittest.js
+++ b/test/AsyncDependenciesBlock.unittest.js
@@ -1,0 +1,63 @@
+"use strict";
+
+const AsyncDependenciesBlock = require("../lib/AsyncDependenciesBlock");
+
+describe("AsyncDependenciesBlock", () => {
+	it("initializes with string group options", () => {
+		const block = new AsyncDependenciesBlock("my-chunk", null, "request");
+		expect(block.groupOptions).toEqual({
+			name: "my-chunk",
+			circular: true
+		});
+		expect(block.chunkName).toBe("my-chunk");
+		expect(block.loc).toBeNull();
+		expect(block.request).toBe("request");
+	});
+
+	it("initializes with object group options", () => {
+		const options = { name: "custom-chunk" };
+		const loc = { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } };
+		const block = new AsyncDependenciesBlock(options, loc, "req");
+
+		expect(block.groupOptions).toBe(options);
+		expect(block.groupOptions.circular).toBe(true);
+		expect(block.chunkName).toBe("custom-chunk");
+		expect(block.loc).toBe(loc);
+		expect(block.request).toBe("req");
+	});
+
+	it("initializes with empty group options", () => {
+		const block = new AsyncDependenciesBlock(undefined, null, null);
+		expect(block.groupOptions).toEqual({
+			name: undefined,
+			circular: true
+		});
+		expect(block.chunkName).toBeUndefined();
+	});
+
+	it("handles circular option correctly", () => {
+		const block = new AsyncDependenciesBlock({ circular: false }, null, null);
+		expect(block.groupOptions.circular).toBe(false);
+		expect(block.circular).toBe(false);
+
+		const defaultBlock = new AsyncDependenciesBlock({}, null, null);
+		expect(defaultBlock.circular).toBe(true);
+	});
+
+	it("allows setting chunkName", () => {
+		const block = new AsyncDependenciesBlock("initial");
+		expect(block.chunkName).toBe("initial");
+
+		block.chunkName = "updated";
+		expect(block.chunkName).toBe("updated");
+		expect(block.groupOptions.name).toBe("updated");
+	});
+
+	it("throws when accessing removed module property", () => {
+		const block = new AsyncDependenciesBlock("test");
+		expect(() => block.module).toThrow(/module property was removed/);
+		expect(() => {
+			block.module = "foo";
+		}).toThrow(/module property was removed/);
+	});
+});


### PR DESCRIPTION
Summary

Added a new unit test file 
test/AsyncDependenciesBlock.unittest.js
 to provide direct test coverage for the 
AsyncDependenciesBlock
 class.

Previously, this core library file relied solely on integration tests. This PR adds explicit unit tests covering:

Constructor initialization (handling string vs object vs undefined group options).
Property accessors (getters/setters for 
chunkName
, 
circular
).
Verification that accessing the deprecated/removed 
module
 property correctly throws an error.
This improves the test coverage and ensures the foundational logic of 
AsyncDependenciesBlock
 is robust against regressions.

What kind of change does this PR introduce?

test

Did you add tests for your changes?

Yes, this PR is the addition of tests. I added 
test/AsyncDependenciesBlock.unittest.js
 and verified it passes with yarn test:unit.

Does this PR introduce a breaking change?

No.