### PR TITLE
feat: add automated API documentation generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 .eslintcache
 .cspellcache
 package-lock.json
+api-docs/

--- a/tooling/generate-api-docs.js
+++ b/tooling/generate-api-docs.js
@@ -1,0 +1,365 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+
+const doWrite = process.argv.includes("--write");
+
+const DEFAULT_TARGETS = [
+	"lib/Compiler.js",
+	"lib/Compilation.js",
+	"lib/NormalModule.js",
+	"lib/Module.js"
+];
+
+const targets = process.argv.slice(2).filter((a) => !a.startsWith("--"));
+
+const filePaths =
+	targets.length > 0
+		? targets.map((f) => path.resolve(f))
+		: DEFAULT_TARGETS.map((f) => path.resolve(__dirname, "..", f));
+
+const program = ts.createProgram(filePaths, {
+	allowJs: true,
+	checkJs: true
+});
+const checker = program.getTypeChecker();
+
+/**
+ * @param {ts.Node} node node to get JSDoc from
+ * @returns {string} the extracted type string, or empty string if not found
+ */
+function getJSDocInfo(node) {
+	const jsDocTags = ts.getJSDocTags(node);
+	let type = "";
+	for (const tag of jsDocTags) {
+		if (tag.tagName && tag.tagName.text === "type" && tag.comment) {
+			type =
+				typeof tag.comment === "string" ? tag.comment : String(tag.comment);
+		}
+	}
+
+	// fall back to inline @type {T} in leading comment
+	const fullText = node.getSourceFile().getFullText();
+	const commentRanges = ts.getLeadingCommentRanges(
+		fullText,
+		node.getFullStart()
+	);
+	if (commentRanges) {
+		for (const range of commentRanges) {
+			const typeMatch = fullText
+				.slice(range.pos, range.end)
+				.match(/@type\s*\{([^}]+)\}/);
+			if (typeMatch) {
+				type = typeMatch[1];
+			}
+		}
+	}
+
+	return type;
+}
+
+/** @typedef {{ name: string, documentation: string, params: { name: string, description: string }[], returns: string }} ExtractedMethod */
+/** @typedef {{ name: string, type: string, documentation: string }} ExtractedProperty */
+/** @typedef {{ name: string, type: string, documentation: string }} ExtractedHook */
+/** @typedef {{ className: string, description: string, methods: ExtractedMethod[], properties: ExtractedProperty[], hooks: ExtractedHook[] }} ExtractedData */
+
+/**
+ * @param {string} filePath absolute path to the source file
+ * @returns {ExtractedData} extracted data
+ */
+function extractFromFile(filePath) {
+	const sourceFile = program.getSourceFile(filePath);
+	if (!sourceFile) {
+		throw new Error(`Could not parse: ${filePath}`);
+	}
+
+	const className = path.basename(filePath, ".js");
+	/** @type {ExtractedMethod[]} */
+	const methods = [];
+	/** @type {ExtractedProperty[]} */
+	const properties = [];
+	/** @type {ExtractedHook[]} */
+	const hooks = [];
+
+	let classDescription = "";
+	const fullText = sourceFile.getFullText();
+	const seenProps = new Set();
+	let insideConstructor = false;
+
+	/**
+	 * @param {ts.Node} node ast node to visit
+	 */
+	function visit(node) {
+		if (!node) return;
+
+		// Class declaration — get description
+		if (ts.isClassDeclaration(node) && node.name) {
+			const symbol = checker.getSymbolAtLocation(node.name);
+			if (symbol) {
+				classDescription = ts.displayPartsToString(
+					symbol.getDocumentationComment(checker)
+				);
+			}
+		}
+
+		// Track constructor scope
+		const isConstructor =
+			ts.isConstructorDeclaration(node) ||
+			(ts.isMethodDeclaration(node) &&
+				node.name &&
+				ts.isIdentifier(node.name) &&
+				node.name.text === "constructor");
+
+		if (isConstructor) {
+			insideConstructor = true;
+			ts.forEachChild(node, visit);
+			insideConstructor = false;
+			return;
+		}
+
+		// Method declarations
+		if (ts.isMethodDeclaration(node) && node.name) {
+			const symbol = checker.getSymbolAtLocation(node.name);
+			if (symbol) {
+				const name = symbol.getName();
+				if (name.startsWith("_")) {
+					ts.forEachChild(node, visit);
+					return;
+				}
+				const doc = ts.displayPartsToString(
+					symbol.getDocumentationComment(checker)
+				);
+				const tags = symbol.getJsDocTags();
+
+				const params = tags
+					.filter((t) => t.name === "param")
+					.map((t) => {
+						const text = t.text ? ts.displayPartsToString(t.text) : "";
+						const parts = text.split(" ");
+						return {
+							name: parts[0] || "",
+							description: parts.slice(1).join(" ")
+						};
+					});
+
+				const returnsTag = tags.find((t) => t.name === "returns");
+				const returns =
+					returnsTag && returnsTag.text
+						? ts.displayPartsToString(returnsTag.text)
+						: "";
+
+				methods.push({ name, documentation: doc, params, returns });
+			}
+		}
+
+		// this.hooks = { ... } — extract hook names and types from JSDoc
+		if (
+			ts.isPropertyAssignment(node) &&
+			node.name &&
+			ts.isIdentifier(node.name)
+		) {
+			const propName = node.name.text;
+
+			const parent = node.parent;
+			if (parent && ts.isObjectLiteralExpression(parent)) {
+				const grandParent = parent.parent;
+				let isHooksObject = false;
+
+				if (
+					grandParent &&
+					ts.isCallExpression(grandParent) &&
+					grandParent.expression &&
+					ts.isPropertyAccessExpression(grandParent.expression) &&
+					grandParent.expression.name.text === "freeze"
+				) {
+					const greatGrandParent = grandParent.parent;
+					if (
+						greatGrandParent &&
+						ts.isBinaryExpression(greatGrandParent) &&
+						ts.isPropertyAccessExpression(greatGrandParent.left) &&
+						greatGrandParent.left.name.text === "hooks"
+					) {
+						isHooksObject = true;
+					}
+				}
+
+				if (
+					grandParent &&
+					ts.isBinaryExpression(grandParent) &&
+					ts.isPropertyAccessExpression(grandParent.left) &&
+					grandParent.left.name.text === "hooks"
+				) {
+					isHooksObject = true;
+				}
+
+				if (isHooksObject) {
+					const type = getJSDocInfo(node);
+					hooks.push({
+						name: propName,
+						type: type || "Hook",
+						documentation: ""
+					});
+				}
+			}
+		}
+
+		// this.xxx = ... inside constructor only — extract properties
+		if (
+			insideConstructor &&
+			ts.isExpressionStatement(node) &&
+			ts.isBinaryExpression(node.expression) &&
+			node.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+			ts.isPropertyAccessExpression(node.expression.left) &&
+			node.expression.left.expression.kind === ts.SyntaxKind.ThisKeyword
+		) {
+			const propName = node.expression.left.name.text;
+			if (
+				propName === "hooks" ||
+				propName.startsWith("_") ||
+				seenProps.has(propName)
+			) {
+				ts.forEachChild(node, visit);
+				return;
+			}
+			seenProps.add(propName);
+
+			const type = getJSDocInfo(node);
+			const commentRanges2 = ts.getLeadingCommentRanges(
+				fullText,
+				node.getFullStart()
+			);
+			let description = "";
+			if (commentRanges2) {
+				for (const range of commentRanges2) {
+					const cleaned = fullText
+						.slice(range.pos, range.end)
+						.replace(/\/\*\*|\*\/|\*/g, "")
+						.replace(/@type\s*\{[^}]+\}/g, "")
+						.trim();
+					if (cleaned) description = cleaned;
+				}
+			}
+
+			properties.push({
+				name: propName,
+				type: type || "unknown",
+				documentation: description
+			});
+		}
+
+		ts.forEachChild(node, visit);
+	}
+
+	visit(sourceFile);
+
+	return {
+		className,
+		description: classDescription,
+		methods,
+		properties,
+		hooks
+	};
+}
+
+/**
+ * @param {ExtractedData} data extracted data
+ * @returns {string} mdx content
+ */
+function toMDX(data) {
+	const lines = [];
+
+	lines.push("---");
+	lines.push(`title: ${data.className}`);
+	lines.push(`description: API reference for webpack ${data.className}`);
+	lines.push("---");
+	lines.push("");
+	lines.push(`# ${data.className}`);
+	lines.push("");
+
+	if (data.description) {
+		lines.push(data.description);
+		lines.push("");
+	}
+
+	// Hooks
+	if (data.hooks.length > 0) {
+		lines.push("## Hooks");
+		lines.push("");
+		lines.push("| Hook | Type |");
+		lines.push("| --- | --- |");
+		for (const hook of data.hooks) {
+			const escapedType = hook.type.replace(/\|/g, "\\|");
+			lines.push(`| \`${hook.name}\` | \`${escapedType}\` |`);
+		}
+		lines.push("");
+	}
+
+	// Properties
+	if (data.properties.length > 0) {
+		lines.push("## Properties");
+		lines.push("");
+		lines.push("| Property | Type | Description |");
+		lines.push("| --- | --- | --- |");
+		for (const prop of data.properties) {
+			const escapedType = (prop.type || "").replace(/\|/g, "\\|");
+			lines.push(
+				`| \`${prop.name}\` | \`${escapedType}\` | ${prop.documentation || "-"} |`
+			);
+		}
+		lines.push("");
+	}
+
+	// Methods
+	if (data.methods.length > 0) {
+		lines.push("## Methods");
+		lines.push("");
+		for (const method of data.methods) {
+			lines.push(`### \`${method.name}()\``);
+			lines.push("");
+			if (method.documentation) {
+				lines.push(method.documentation);
+				lines.push("");
+			}
+			if (method.params.length > 0) {
+				lines.push("**Parameters:**");
+				lines.push("");
+				for (const p of method.params) {
+					lines.push(`- \`${p.name}\` — ${p.description || ""}`);
+				}
+				lines.push("");
+			}
+			if (method.returns) {
+				lines.push(`**Returns:** ${method.returns}`);
+				lines.push("");
+			}
+			lines.push("---");
+			lines.push("");
+		}
+	}
+
+	return lines.join("\n");
+}
+
+// Run
+const outputDir = path.resolve(__dirname, "..", "api-docs");
+
+if (doWrite) fs.mkdirSync(outputDir, { recursive: true });
+
+for (const filePath of filePaths) {
+	const data = extractFromFile(filePath);
+	const mdx = toMDX(data);
+	const outFile = path.join(outputDir, `${data.className}.mdx`);
+
+	if (doWrite) {
+		fs.writeFileSync(outFile, mdx);
+		console.log(`Written: ${outFile}`);
+	} else {
+		console.log(`--- ${data.className} ---`);
+		console.log(
+			`  ${data.hooks.length} hooks, ${data.properties.length} properties, ${data.methods.length} methods`
+		);
+		console.log(`  Would write to: ${outFile}`);
+	}
+}


### PR DESCRIPTION

Adds [tooling/generate-api-docs.js](cci:7://file:///Users/rajaryan/Projects/Web%20pack/webpack/tooling/generate-api-docs.js:0:0-0:0) — a script that parses Webpack source files using the TypeScript Compiler API and generates structured MDX documentation for the new documentation website.

**Summary**

The new documentation website (webpack.js.org redesign) requires API reference pages for core classes like [Compiler](cci:2://file:///Users/rajaryan/Projects/Web%20pack/webpack/lib/Compiler.js:157:0-1410:1), [Compilation](cci:2://file:///Users/rajaryan/Projects/Web%20pack/webpack/lib/Compilation.js:504:0-5735:1), [NormalModule](cci:2://file:///Users/rajaryan/Projects/Web%20pack/webpack/lib/NormalModule.js:270:0-1793:1), and [Module](cci:1://file:///Users/rajaryan/Projects/Web%20pack/webpack/lib/Compilation.js:1516:1-1524:2). Writing these by hand is error-prone and gets stale quickly. This tool automates that by extracting directly from the JSDoc already present in the source.

It extracts:
- **Hooks** — from `this.hooks = Object.freeze({...})` patterns, including tapable hook types
- **Properties** — from constructor `this.xxx = ...` assignments (deduplicated, private props skipped)
- **Methods** — with `@param` and `@returns` descriptions

Usage:
```sh
# Dry run (preview counts)
node tooling/generate-api-docs.js

# Write MDX files to api-docs/
node tooling/generate-api-docs.js --write

# Target a specific file
node tooling/generate-api-docs.js lib/Chunk.js --write

```
Example output for Compiler
: 32 hooks, 33 properties, 18 methods — all structured as MDX with frontmatter.

What kind of change does this PR introduce?

feat — new internal tooling script. No runtime code changed. No existing behavior affected.

Did you add tests for your changes?

Not applicable — this is a code generation tool, not a runtime module. The output can be visually verified by running node tooling/generate-api-docs.js.

Does this PR introduce a breaking change?

No.

If relevant, what needs to be documented once your changes are merged?

The api-docs/ output directory (gitignored) would feed into the documentation site pipeline. Next step would be wiring this into the docs build for https://webpack.js.org/.

Before((dry run output))
<img width="" height="" alt="image" src="https://github.com/user-attachments/assets/2e5f4e92-f72a-40ba-8db3-603ce0e28a45" />

After (actual MDX output with hooks table)
<img width="" height="" alt="image" src="https://github.com/user-attachments/assets/120dace0-4e1e-41b0-ae57-6a40a61f8ca5" />



