### PR TITLE
ci: declare explicit permissions for release announcement workflow

### DIFF
--- a/.github/workflows/release-announcement.yml
+++ b/.github/workflows/release-announcement.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   github-releases-to-discord:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add explicit `permissions` to `.github/workflows/release-announcement.yml`
- scope workflow token to `contents: read`

## Why
This workflow only checks out the repo and reads release metadata (`gh release view`) before posting to Discord. Declaring explicit read-only permissions applies least privilege and avoids relying on default token scopes.

## Validation
- verified workflow steps only require read access to repository/release data
- no write operations to repository resources in this workflow
