### PR TITLE
test: add integration test for universal target CSS loading

### DIFF
--- a/test/configCases/target/universal-css/index.js
+++ b/test/configCases/target/universal-css/index.js
@@ -1,0 +1,25 @@
+import * as pureStyle from "./style.css";
+import * as styles from "./style.modules.css";
+import * as pureStyle2 from "./style2.css";
+import * as styles2 from "./style2.modules.css";
+
+it("should load initial CSS", () => {
+	expect(pureStyle).toEqual({});
+
+	if (typeof document !== "undefined") {
+		const style = getComputedStyle(document.body);
+		expect(style.getPropertyValue("background")).toBe(" red");
+	}
+});
+
+it("should load CSS modules", () => {
+	expect(styles.foo).toBe("style_modules_css-foo");
+});
+
+it("should load split CSS chunk", () => {
+	expect(pureStyle2).toEqual({});
+});
+
+it("should load split CSS modules", () => {
+	expect(styles2.bar).toBe("style2_modules_css-bar");
+});

--- a/test/configCases/target/universal-css/style.css
+++ b/test/configCases/target/universal-css/style.css
@@ -1,0 +1,3 @@
+body {
+	background: red;
+}

--- a/test/configCases/target/universal-css/style.modules.css
+++ b/test/configCases/target/universal-css/style.modules.css
@@ -1,0 +1,3 @@
+.foo {
+    color: red;
+}

--- a/test/configCases/target/universal-css/style2.css
+++ b/test/configCases/target/universal-css/style2.css
@@ -1,0 +1,3 @@
+body {
+    color: blue;
+}

--- a/test/configCases/target/universal-css/style2.modules.css
+++ b/test/configCases/target/universal-css/style2.modules.css
@@ -1,0 +1,3 @@
+.bar {
+    background: blue;
+}

--- a/test/configCases/target/universal-css/test.config.js
+++ b/test/configCases/target/universal-css/test.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+module.exports = {
+	moduleScope(scope, options) {
+		if (options.name.includes("node")) {
+			delete scope.window;
+			delete scope.document;
+			delete scope.self;
+		} else {
+			const link = scope.window.document.createElement("link");
+			link.rel = "stylesheet";
+			link.href = "main.css";
+			scope.window.document.head.appendChild(link);
+		}
+	},
+	findBundle() {
+		return ["./separate.mjs", "./main.mjs"];
+	}
+};

--- a/test/configCases/target/universal-css/test.filter.js
+++ b/test/configCases/target/universal-css/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsGlobalThis = require("../../../helpers/supportsGlobalThis");
+
+module.exports = () => supportsGlobalThis();

--- a/test/configCases/target/universal-css/webpack.config.js
+++ b/test/configCases/target/universal-css/webpack.config.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const base = {
+	target: ["web", "node"],
+	devtool: false,
+	mode: "development",
+	experiments: {
+		css: true,
+		outputModule: true
+	},
+	output: {
+		module: true,
+		filename: "[name].mjs",
+		chunkFilename: "[name].mjs"
+	},
+	optimization: {
+		minimize: false,
+		splitChunks: {
+			cacheGroups: {
+				separate: {
+					test: /style2/,
+					chunks: "all",
+					filename: "separate.mjs",
+					enforce: true
+				}
+			}
+		}
+	}
+};
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{ name: "web", ...base },
+	{ name: "node", ...base }
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

[CssLoadingRuntimeModule](cci:2://file:///Users/rajaryan/Projects/Web%20pack/webpack/lib/css/CssLoadingRuntimeModule.js:31:0-510:1) has several code paths gated behind `isNeutralPlatform` that handle CSS chunk loading when the build targets both `web` and `node` simultaneously. These paths generate runtime guards like `if (typeof document !== 'undefined')` to prevent crashes in environments without a DOM.

Currently, the existing `css/universal` test covers basic CSS imports and workers, but doesn't exercise the **split chunk CSS loading path** — the one where `loadStylesheet()` is wrapped in the neutral platform check (lines 315-324 of [CssLoadingRuntimeModule.js](cci:7://file:///Users/rajaryan/Projects/Web%20pack/webpack/lib/css/CssLoadingRuntimeModule.js:0:0-0:0)). This means a regression in that guard could silently break CSS loading for universal builds without any test catching it.

This PR adds a dedicated `target/universal-css` config test case that:
- Uses `target: ["web", "node"]` with `experiments.css` and ESM output
- Forces CSS into a separate chunk via `splitChunks`, triggering the full CSS chunk loading runtime
- Runs the same code in two scopes one with DOM globals (web) and one without (node) — to verify both sides of the `isNeutralPlatform` branch
- Tests both plain CSS and CSS Modules across initial and split chunks

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

test

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — this PR is the test itself. 8 files, 10 assertions across 2 build variants (web scope + node scope).

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

N/A — test only, no user-facing changes.