### PR TITLE
fix: handle git merge conflicts in lockfile parsing

### DIFF
--- a/lib/schemes/HttpUriPlugin.js
+++ b/lib/schemes/HttpUriPlugin.js
@@ -237,7 +237,12 @@ class Lockfile {
 	 * @returns {Lockfile} lockfile
 	 */
 	static parse(content) {
-		// TODO handle merge conflicts
+		if (content.includes("<<<<<<<")) {
+			content = content.replace(
+				/^<<<<<<<[^\n]*\n|^=======\n|^>>>>>>>[^\n]*\n/gm,
+				""
+			);
+		}
 		const data = JSON.parse(content);
 		if (data.version !== 1) {
 			throw new Error(`Unsupported lockfile version ${data.version}`);


### PR DESCRIPTION
## Summary
- When a webpack lockfile (`webpack.lock`) has been through a git merge that resulted in conflict markers, `JSON.parse` fails with an unhelpful error
- This strips `<<<<<<<`, `=======`, and `>>>>>>>` conflict markers before parsing, preserving entries from both sides of the conflict
- The lockfile will be refreshed on the next build regardless, so keeping both sides is the safest resolution strategy

Addresses the `TODO handle merge conflicts` in `lib/schemes/HttpUriPlugin.js` (line 240).

## Test plan
- [ ] Verify lockfile with merge conflict markers is parsed correctly
- [ ] Verify normal lockfile parsing is unaffected (fast path: `includes` check avoids regex when no conflicts)
- [ ] Verify entries from both sides of the conflict are preserved in the parsed result