### PR TITLE
fix: optimize export * from side-effect-free modules

### DIFF
--- a/lib/optimize/SideEffectsFlagPlugin.js
+++ b/lib/optimize/SideEffectsFlagPlugin.js
@@ -305,7 +305,31 @@ class SideEffectsFlagPlugin {
 										if (connection.originModule !== null) {
 											optimizeIncomingConnections(connection.originModule);
 										}
-										// TODO improve for export *
+										if (isReexport && !dep.name) {
+											// export * from side-effect-free module
+											for (const exportInfo of exportsInfo.orderedExports) {
+												if (exportInfo.provided !== true) continue;
+												const originExportInfo = moduleGraph.getExportInfo(
+													/** @type {Module} */ (connection.originModule),
+													exportInfo.name
+												);
+												originExportInfo.moveTarget(
+													moduleGraph,
+													({ module }) =>
+														module.getSideEffectsConnectionState(
+															moduleGraph
+														) === false,
+													({ connection: targetConnection }) => {
+														moduleGraph.addExplanation(
+															dep,
+															"(skipped side-effect-free modules)"
+														);
+														return targetConnection;
+													}
+												);
+											}
+											continue;
+										}
 										if (isReexport && dep.name) {
 											const exportInfo = moduleGraph.getExportInfo(
 												/** @type {Module} */ (connection.originModule),


### PR DESCRIPTION
## Summary
- `SideEffectsFlagPlugin` previously skipped the optimization for `export *` (star re-exports) because `dep.name` is `null` for star exports
- This meant intermediate side-effect-free modules were not bypassed when re-exporting via `export *`, resulting in suboptimal tree-shaking
- Now iterates all provided exports from the side-effect-free module and calls `moveTarget` on each corresponding export info in the origin module, allowing webpack to skip the intermediate module

Addresses the `TODO improve for export *` in `lib/optimize/SideEffectsFlagPlugin.js` (line 308).

### Example
```js
// index.js
import { foo } from './a';

// a.js (sideEffects: false)
export * from './b';

// b.js
export const foo = 1;
export const bar = 2;
```

**Before:** `a.js` was included in the bundle as an intermediary.  
**After:** `index.js` imports `foo` directly from `b.js`, skipping `a.js` entirely.

## Test plan
- [ ] Existing `SideEffectsFlagPlugin` unit tests pass
- [ ] Verify `export *` from side-effect-free modules correctly redirects individual exports
- [ ] Verify named re-exports (`export { foo } from`) still work as before
- [ ] Verify no regressions in tree-shaking behavior