### PR TITLE
fix: do not emit "var __webpack_exports__ = {};" when it's the only use (fixes #20146)

### DIFF
--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1019,8 +1019,16 @@ class JavascriptModulesPlugin {
 			const lastInlinedModule = /** @type {Module} */ (last(inlinedModules));
 			const startupSource = new ConcatSource();
 
-			if (runtimeRequirements.has(RuntimeGlobals.exports)) {
+			// Only declare __webpack_exports__ when it's used beyond the initial assignment
+			// (e.g. by a module body, or by onChunksLoaded). Avoids emitting redundant
+			// "var __webpack_exports__ = {};" when no code references it (issue #20146).
+			let exportsVariableDeclared = false;
+			if (
+				runtimeRequirements.has(RuntimeGlobals.exports) &&
+				runtimeRequirements.has(RuntimeGlobals.onChunksLoaded)
+			) {
 				startupSource.add(`var ${RuntimeGlobals.exports} = {};\n`);
+				exportsVariableDeclared = true;
 			}
 
 			const avoidEntryIife = compilation.options.optimization.avoidEntryIife;
@@ -1101,6 +1109,17 @@ class JavascriptModulesPlugin {
 						footer = "\n";
 					}
 					if (exports) {
+						const moduleUsesExports = renderedModule
+							.source()
+							.includes(RuntimeGlobals.exports);
+						if (
+							!exportsVariableDeclared &&
+							(m.exportsArgument !== RuntimeGlobals.exports ||
+								moduleUsesExports)
+						) {
+							startupSource.add(`var ${RuntimeGlobals.exports} = {};\n`);
+							exportsVariableDeclared = true;
+						}
 						if (m !== lastInlinedModule) {
 							startupSource.add(`var ${m.exportsArgument} = {};\n`);
 						} else if (m.exportsArgument !== RuntimeGlobals.exports) {
@@ -1472,10 +1491,34 @@ class JavascriptModulesPlugin {
 							}(${moduleIdExpr});`
 						);
 					} else {
-						if (i === 0) buf2.push(`var ${RuntimeGlobals.exports} = {};`);
 						const needThisAsExports = entryRuntimeRequirements.has(
 							RuntimeGlobals.thisAsExports
 						);
+						let entryUsesExports = needThisAsExports;
+						if (
+							!entryUsesExports &&
+							i === 0 &&
+							entryRuntimeRequirements.has(RuntimeGlobals.exports)
+						) {
+							const entryCodeGen = codeGenerationResults.get(
+								entryModule,
+								chunk.runtime
+							);
+							const entryJsSource =
+								entryCodeGen && entryCodeGen.sources.get(JAVASCRIPT_TYPE);
+							if (entryJsSource) {
+								const src =
+									typeof entryJsSource.source === "function"
+										? entryJsSource.source()
+										: String(entryJsSource);
+								entryUsesExports = src.includes(RuntimeGlobals.exports);
+							} else {
+								entryUsesExports = true;
+							}
+						}
+						if (i === 0 && entryUsesExports) {
+							buf2.push(`var ${RuntimeGlobals.exports} = {};`);
+						}
 
 						/** @type {string[]} */
 						const args = [];
@@ -1483,7 +1526,8 @@ class JavascriptModulesPlugin {
 							requireScopeUsed ||
 							entryRuntimeRequirements.has(RuntimeGlobals.exports)
 						) {
-							const exportsArg = i === 0 ? RuntimeGlobals.exports : "{}";
+							const exportsArg =
+								i === 0 && entryUsesExports ? RuntimeGlobals.exports : "{}";
 							args.push("0", exportsArg);
 							if (requireScopeUsed) {
 								args.push(RuntimeGlobals.require);

--- a/test/configCases/optimization/no-redundant-exports-declaration/index.js
+++ b/test/configCases/optimization/no-redundant-exports-declaration/index.js
@@ -1,0 +1,5 @@
+// Entry with no exports - __webpack_exports__ is only ever the initial empty object (issue #20146)
+global.__entryRan__ = true;
+it("should have run the entry", () => {
+	expect(global.__entryRan__).toBe(true);
+});

--- a/test/configCases/optimization/no-redundant-exports-declaration/test.config.js
+++ b/test/configCases/optimization/no-redundant-exports-declaration/test.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+	afterExecute(options) {
+		const outputPath = options.output.path;
+		const bundlePath = path.join(outputPath, "bundle0.mjs");
+		// When entry has no exports, we must not emit redundant "var __webpack_exports__ = {};"
+		const content = fs.readFileSync(bundlePath, "utf8");
+		expect(content).not.toMatch(/var __webpack_exports__ = \{\};/);
+	}
+};

--- a/test/configCases/optimization/no-redundant-exports-declaration/webpack.config.js
+++ b/test/configCases/optimization/no-redundant-exports-declaration/webpack.config.js
@@ -1,0 +1,19 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: false,
+	optimization: {
+		minimize: false,
+		concatenateModules: true
+	},
+	experiments: {
+		outputModule: true
+	},
+	output: {
+		library: {
+			type: "module"
+		}
+	}
+};


### PR DESCRIPTION
## Summary
When the only usage of `__webpack_exports__` in the generated chunk is the initial `var __webpack_exports__ = {};`, that declaration is now omitted and `{}` is passed at call sites instead. This reduces redundant output (issue #20146).

## Changes
- **Inlined entry path** (`lib/javascript/JavascriptModulesPlugin.js`): Only declare `__webpack_exports__` when it is used by a module body or by `onChunksLoaded`; otherwise declare it lazily when the first module that references it is rendered, or omit it and use `{}` for the last module.
- **Non-inlined startup path** (`renderBootstrap`): Only push `var __webpack_exports__ = {};` when the entry module's generated code actually contains `__webpack_exports__` (or when `thisAsExports` is used). Otherwise pass `"{}"` as the exports argument.
- **Test**: New config case `optimization/no-redundant-exports-declaration` with an entry that has no exports; `afterExecute` asserts the bundle does not contain the redundant declaration.

**Note:** The implementation in `lib/javascript/JavascriptModulesPlugin.js` is in the local branch; if this PR shows only the test files, please push the branch from your machine: `git push fork fix/20146-no-redundant-exports-declaration`

Fixes #20146