### PR TITLE
getSize to return sum of all CSS sizes when no type specified

### DIFF
--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -515,6 +515,10 @@ class CssGenerator extends Generator {
 	 * @returns {number} estimate size of the module
 	 */
 	getSize(module, type) {
+		if (!type) {
+			return this.getSize(module, JAVASCRIPT_TYPE) + this.getSize(module, CSS_TYPE);
+		}
+		
 		switch (type) {
 			case JAVASCRIPT_TYPE: {
 				const cssData = /** @type {BuildInfo} */ (module.buildInfo).cssData;


### PR DESCRIPTION
Currently getSize on a CSS module will return 1 unless you pass in "css" explicitly as type.  This change will return the sum total JS + CSS size when no type is specified.

Resolves https://github.com/webpack/webpack/issues/20495.