### PR TITLE
tests: add universal test for `fetchPriority` in both node and web target

### DIFF
--- a/test/configCases/target/universal-fetch-priority/chunk1.mjs
+++ b/test/configCases/target/universal-fetch-priority/chunk1.mjs
@@ -1,0 +1,1 @@
+export default "chunk1";

--- a/test/configCases/target/universal-fetch-priority/chunk2.mjs
+++ b/test/configCases/target/universal-fetch-priority/chunk2.mjs
@@ -1,0 +1,1 @@
+export default "chunk2";

--- a/test/configCases/target/universal-fetch-priority/index.mjs
+++ b/test/configCases/target/universal-fetch-priority/index.mjs
@@ -1,0 +1,85 @@
+__webpack_public_path__ = "https://example.com/public/path/";
+
+it("should handle low fetchPriority for direct dynamic import in universal target", async() => {
+	const hasBrowser = typeof document !== "undefined";
+	const before = hasBrowser ? document.head._children.length : 0;
+	const originalEnsure = __webpack_require__.e;
+	/** @type {undefined | false | "auto" | "low" | "high"} */
+	let capturedFetchPriority;
+
+	__webpack_require__.e = (chunkId, fetchPriority) => {
+		capturedFetchPriority = fetchPriority;
+		return originalEnsure(chunkId, fetchPriority);
+	};
+
+	return import(
+		/* webpackChunkName: "chunk1", webpackFetchPriority: "low" */ "./chunk1.mjs"
+	).then(() => {
+		__webpack_require__.e = originalEnsure;
+		expect(capturedFetchPriority).toBe("low");
+
+		if (hasBrowser) {
+			const after = document.head._children.length;
+			expect(after).toBeGreaterThanOrEqual(before);
+
+			const insertedNodes = document.head._children.slice(before, after);
+			const node = insertedNodes.find(item => {
+				const srcOrHref = item.src || item.href;
+				return (
+					item._attributes.fetchpriority === "low" &&
+					typeof srcOrHref === "string" &&
+					/chunk1\.mjs$/.test(srcOrHref)
+				);
+			});
+
+			if (after > before) {
+				expect(node).toBeDefined();
+			}
+		}
+	}).catch(err => {
+		__webpack_require__.e = originalEnsure;
+		throw err;
+		});
+});
+
+it("should handle high fetchPriority for direct dynamic import in universal target", async() => {
+	const hasBrowser = typeof document !== "undefined";
+	const before = hasBrowser ? document.head._children.length : 0;
+	const originalEnsure = __webpack_require__.e;
+	/** @type {undefined | false | "auto" | "low" | "high"} */
+	let capturedFetchPriority;
+
+	__webpack_require__.e = (chunkId, fetchPriority) => {
+		capturedFetchPriority = fetchPriority;
+		return originalEnsure(chunkId, fetchPriority);
+	};
+
+	return import(
+		/* webpackChunkName: "chunk2", webpackFetchPriority: "high" */ "./chunk2.mjs"
+	).then(() => {
+		__webpack_require__.e = originalEnsure;
+		expect(capturedFetchPriority).toBe("high");
+
+		if (hasBrowser) {
+			const after = document.head._children.length;
+			expect(after).toBeGreaterThanOrEqual(before);
+
+			const insertedNodes = document.head._children.slice(before, after);
+			const node = insertedNodes.find(item => {
+				const srcOrHref = item.src || item.href;
+				return (
+					item._attributes.fetchpriority === "high" &&
+					typeof srcOrHref === "string" &&
+					/chunk2\.mjs$/.test(srcOrHref)
+				);
+			});
+
+			if (after > before) {
+				expect(node).toBeDefined();
+			}
+		}
+	}).catch(err => {
+		__webpack_require__.e = originalEnsure;
+		throw err;
+	});
+});

--- a/test/configCases/target/universal-fetch-priority/test.config.js
+++ b/test/configCases/target/universal-fetch-priority/test.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+module.exports = {
+	moduleScope(scope, options) {
+		if (options.name.includes("node")) {
+			delete scope.window;
+			delete scope.document;
+			delete scope.self;
+		}
+	},
+	findBundle() {
+		return "./bundle0.mjs";
+	}
+};

--- a/test/configCases/target/universal-fetch-priority/test.filter.js
+++ b/test/configCases/target/universal-fetch-priority/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const supportsGlobalThis = require("../../../helpers/supportsGlobalThis");
+
+module.exports = () => supportsGlobalThis();

--- a/test/configCases/target/universal-fetch-priority/webpack.config.js
+++ b/test/configCases/target/universal-fetch-priority/webpack.config.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const base = {
+	target: ["web", "node"],
+	entry: "./index.mjs",
+	experiments: {
+		outputModule: true
+	},
+	output: {
+		publicPath: "",
+		module: true,
+		filename: "bundle0.mjs",
+		chunkFilename: "[name].mjs",
+		crossOriginLoading: "anonymous"
+	},
+	optimization: {
+		minimize: false,
+		chunkIds: "named"
+	}
+};
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{ name: "web", ...base },
+	{ name: "node", ...base }
+];


### PR DESCRIPTION

<img width="856" height="90" alt="Screenshot 2026-02-24 at 12 56 58 PM" src="https://github.com/user-attachments/assets/fa5b3074-1b74-4b89-9629-a0020a61573a" />


**What kind of change does this PR introduce?**
Adds test for `fetchPriority` in both node and web target. Making sure test return early in Node environments.


**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
NO 
