### PR TITLE
test: fix typos in dynamic reexports fixture comments

### DIFF
--- a/test/configCases/externals/dynamic-reexports/index.js
+++ b/test/configCases/externals/dynamic-reexports/index.js
@@ -1,6 +1,6 @@
 import * as ns from './lib'
 
-it('should have correect reexport', () => {
+it('should have correct reexport', () => {
   expect(ns).toHaveProperty('readFile');
   expect(ns).toHaveProperty('resolve');
 

--- a/test/configCases/externals/dynamic-reexports/lib.js
+++ b/test/configCases/externals/dynamic-reexports/lib.js
@@ -1,4 +1,4 @@
-// 2 external modules, the external module exportsType is unkown
+// 2 external modules, the external module exportsType is unknown
 // so the exports of current module can only be known at runtime
 export * from 'path'
 


### PR DESCRIPTION
## Summary
- fix typo in test title: "correect" -> "correct"
- fix typo in fixture comment: "unkown" -> "unknown"

## Why
- improves readability of test fixtures without changing behavior