### PR TITLE
test: add coverage for CSS modules with target webworker

### DIFF
--- a/test/configCases/css/webworker/base.modules.css
+++ b/test/configCases/css/webworker/base.modules.css
@@ -1,0 +1,3 @@
+.base {
+	display: block;
+}

--- a/test/configCases/css/webworker/index.js
+++ b/test/configCases/css/webworker/index.js
@@ -1,0 +1,6 @@
+import * as style from "./style.modules.css";
+
+it("should allow to import a css module", () => {
+	expect(style.header).toContain("header");
+	expect(style.header).toContain("base");
+});

--- a/test/configCases/css/webworker/style.modules.css
+++ b/test/configCases/css/webworker/style.modules.css
@@ -1,0 +1,4 @@
+.header {
+	composes: base from "./base.modules.css";
+	color: red;
+}

--- a/test/configCases/css/webworker/webpack.config.js
+++ b/test/configCases/css/webworker/webpack.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "webworker",
+	mode: "development",
+	devtool: false,
+	experiments: {
+		css: true
+	}
+};


### PR DESCRIPTION
**Summary**

There was no test coverage for webpack's native CSS module support (`experiments.css`) when `target: "webworker"` is set. Web Workers run in a background thread with no access to the DOM  no `document`, no `<head>`, no place to inject stylesheets. Because of this, `CssLoadingRuntimeModule` is intentionally skipped for the `webworker` target (it only activates for `jsonp` and `import` chunk loading). However, CSS module **exports** (class names as JS values) should still work correctly.

This PR adds a configCase that verifies exactly that: a CSS module with `composes:` can be imported in a worker-targeted build, its export is a valid string, and webpack does not attempt any DOM interaction.

Previously we had:
- `css/node` — CSS modules with `target: "node"` 
- `css/basic-esm-target-web` — CSS modules with `target: "web"` 
- `css/webworker` — CSS modules with `target: "webworker"` (this PR fills this gap)

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

Yes this PR is entirely a test addition. Four files added under `test/configCases/css/webworker/`.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation changes needed