### PR TITLE
test: add coverage for nwjs exports condition

### DIFF
--- a/test/configCases/css/webworker/base.modules.css
+++ b/test/configCases/css/webworker/base.modules.css
@@ -1,0 +1,3 @@
+.base {
+	display: block;
+}

--- a/test/configCases/css/webworker/index.js
+++ b/test/configCases/css/webworker/index.js
@@ -1,0 +1,6 @@
+import * as style from "./style.modules.css";
+
+it("should allow to import a css module", () => {
+	expect(style.header).toContain("header");
+	expect(style.header).toContain("base");
+});

--- a/test/configCases/css/webworker/style.modules.css
+++ b/test/configCases/css/webworker/style.modules.css
@@ -1,0 +1,4 @@
+.header {
+	composes: base from "./base.modules.css";
+	color: red;
+}

--- a/test/configCases/css/webworker/webpack.config.js
+++ b/test/configCases/css/webworker/webpack.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "webworker",
+	mode: "development",
+	devtool: false,
+	experiments: {
+		css: true
+	}
+};

--- a/test/configCases/target/nwjs/index.js
+++ b/test/configCases/target/nwjs/index.js
@@ -1,0 +1,5 @@
+const foo = require("foo");
+
+it("should resolve the nwjs exports condition", () => {
+	expect(foo).toBe("nwjs");
+});

--- a/test/configCases/target/nwjs/node_modules/foo/default.js
+++ b/test/configCases/target/nwjs/node_modules/foo/default.js
@@ -1,0 +1,1 @@
+module.exports = "default";

--- a/test/configCases/target/nwjs/node_modules/foo/nwjs.js
+++ b/test/configCases/target/nwjs/node_modules/foo/nwjs.js
@@ -1,0 +1,1 @@
+module.exports = "nwjs";

--- a/test/configCases/target/nwjs/node_modules/foo/package.json
+++ b/test/configCases/target/nwjs/node_modules/foo/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "foo",
+	"version": "1.0.0",
+	"exports": {
+		"nwjs": "./nwjs.js",
+		"default": "./default.js"
+	}
+}

--- a/test/configCases/target/nwjs/webpack.config.js
+++ b/test/configCases/target/nwjs/webpack.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "nwjs",
+	optimization: {
+		minimize: false
+	}
+};


### PR DESCRIPTION
**Summary**

This PR adds two configCases that had no test coverage:

1. **`test/configCases/target/nwjs/`** -`target: "nwjs"` injects the `"nwjs"` condition into webpack's resolver (via `conditions.push("nwjs")` in `lib/config/defaults.js`), but there was no test verifying this condition is actually applied during module resolution. The test requires a package with an `exports` field containing a `"nwjs"` condition and asserts the correct file is resolved.

2. **`test/configCases/css/webworker/`** — `CssModulesPlugin` skips emitting a CSS file when `chunkLoading` is `"import-scripts"` (webworker target), but CSS module JS exports still work. The test verifies that `composes:` is correctly resolved and the generated class names are present in the export.

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

This PR is the tests. It adds `test/configCases/target/nwjs/` and `test/configCases/css/webworker/`.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation needed.