### PR TITLE
Issue cleared: #18119 (dynamic remote-entry loading with promise remotes where __webpack_require__.l could be missing).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 
 - Preserve star exports for dependencies in ECMA module output. (by [@hai-x](https://github.com/hai-x) in [#20293](https://github.com/webpack/webpack/pull/20293))
 
-- Consider asset modulem to be side-effect free. (by [@hai-x](https://github.com/hai-x) in [#20352](https://github.com/webpack/webpack/pull/20352))
+- Consider asset modules to be side-effect free. (by [@hai-x](https://github.com/hai-x) in [#20352](https://github.com/webpack/webpack/pull/20352))
 
 - Avoid generating JavaScript modules for CSS exports that are not used, reducing unnecessary output and bundle size. (by [@xiaoxiaojx](https://github.com/xiaoxiaojx) in [#20337](https://github.com/webpack/webpack/pull/20337))
 

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -95,6 +95,7 @@ const RUNTIME_REQUIREMENTS_FOR_MODULE = new Set([
 ]);
 /** @type {RuntimeRequirements} */
 const EMPTY_RUNTIME_REQUIREMENTS = new Set();
+const LOAD_SCRIPT_REQUIRE = `${RuntimeGlobals.require}.l`;
 
 /**
  * @param {string | string[]} variableName the variable name or path
@@ -930,6 +931,20 @@ class ExternalModule extends Module {
 				);
 			case "script":
 				return getSourceForScriptExternal(request, runtimeTemplate);
+			case "promise": {
+				const sourceData = getSourceForDefaultCase(
+					this.isOptional(moduleGraph),
+					request,
+					runtimeTemplate
+				);
+				if (
+					typeof request === "string" &&
+					request.includes(LOAD_SCRIPT_REQUIRE)
+				) {
+					sourceData.runtimeRequirements = RUNTIME_REQUIREMENTS_FOR_SCRIPT;
+				}
+				return sourceData;
+			}
 			case "module": {
 				if (!(/** @type {BuildInfo} */ (this.buildInfo).javascriptModule)) {
 					if (!runtimeTemplate.supportsDynamicImport()) {
@@ -962,7 +977,6 @@ class ExternalModule extends Module {
 				);
 			}
 			case "var":
-			case "promise":
 			case "assign":
 			default:
 				return getSourceForDefaultCase(

--- a/test/configCases/container/issue-18119/index.js
+++ b/test/configCases/container/issue-18119/index.js
@@ -1,0 +1,4 @@
+it("should allow promise remotes to reference __webpack_require__.l", async () => {
+	const remote = await import("remote/test");
+	expect(remote.default).toBe("./test");
+});

--- a/test/configCases/container/issue-18119/webpack.config.js
+++ b/test/configCases/container/issue-18119/webpack.config.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const { ModuleFederationPlugin } = require("../../../../").container;
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	plugins: [
+		new ModuleFederationPlugin({
+			name: "app",
+			remotes: {
+				remote: `promise new Promise((resolve) => {
+					if (typeof __webpack_require__.l !== "function") {
+						throw new Error("Expected __webpack_require__.l to be defined");
+					}
+					resolve({
+						get: (request) => Promise.resolve(() => request),
+						init: () => {}
+					});
+				})`
+			}
+		})
+	]
+};


### PR DESCRIPTION
Fixes #18119.
Summary
This PR fixes a Module Federation runtime gap for promise-based remotes that reference `__webpack_require__.l` to dynamically load remote entries.

Previously, `externalType: "promise"` did not always add the runtime requirement for `loadScript`, so `__webpack_require__.l` could be undefined unless users forced runtime generation with workarounds (for example, importing a fake module).

This change updates `ExternalModule` to detect `__webpack_require__.l` usage in promise externals and include the `RuntimeGlobals.loadScript` runtime requirement automatically.

What kind of change does this PR introduce?
- fix
- test

Did you add tests for your changes?
Yes. Added a regression config case:
- `test/configCases/container/issue-18119/webpack.config.js`
- `test/configCases/container/issue-18119/index.js`

The test validates that promise remotes can reference `__webpack_require__.l` and load successfully.

Does this PR introduce a breaking change?
No.

If relevant, what needs to be documented once your changes are merged or what have you already documented?**
No documentation changes required.
