### PR TITLE
feat: hoisting for "module-import" externals should be present in dynamic chunk

### DIFF
--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -682,7 +682,8 @@ class ExternalModule extends Module {
 	 * @returns {boolean} true, if the chunk is ok for the module
 	 */
 	chunkCondition(chunk, { chunkGraph }) {
-		return this.externalType === "css-import"
+		return this.externalType === "css-import" ||
+			this.externalType === "module-import"
 			? true
 			: chunkGraph.getNumberOfEntryModules(chunk) > 0;
 	}

--- a/test/configCases/externals/module-import-hoist-async-chunk/chunk.js
+++ b/test/configCases/externals/module-import-hoist-async-chunk/chunk.js
@@ -1,0 +1,3 @@
+import "external-lib";
+
+export default 1;

--- a/test/configCases/externals/module-import-hoist-async-chunk/index.js
+++ b/test/configCases/externals/module-import-hoist-async-chunk/index.js
@@ -1,0 +1,1 @@
+export const load = () => import("./chunk");

--- a/test/configCases/externals/module-import-hoist-async-chunk/test.config.js
+++ b/test/configCases/externals/module-import-hoist-async-chunk/test.config.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+	noTests: true
+};

--- a/test/configCases/externals/module-import-hoist-async-chunk/webpack.config.js
+++ b/test/configCases/externals/module-import-hoist-async-chunk/webpack.config.js
@@ -1,0 +1,71 @@
+"use strict";
+
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	mode: "none",
+	devtool: false,
+	entry: "./index.js",
+	target: ["web", "es2020"],
+	experiments: {
+		outputModule: true
+	},
+	output: {
+		module: true,
+		chunkFormat: "module",
+		filename: "bundle0.mjs",
+		chunkFilename: "dynamic.mjs"
+	},
+	externalsType: "module-import",
+	externals: {
+		"external-lib": "external-lib"
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.thisCompilation.tap(
+					"module-import-hoist-async-chunk-check",
+					(compilation) => {
+						compilation.hooks.processAssets.tap(
+							{
+								name: "module-import-hoist-async-chunk-check",
+								stage:
+									compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE
+							},
+							() => {
+								const mainAsset = compilation.getAsset("bundle0.mjs");
+								const dynamicAsset = compilation.getAsset("dynamic.mjs");
+								if (!mainAsset || !dynamicAsset) {
+									compilation.errors.push(
+										new Error(
+											"Expected emitted assets bundle0.mjs and dynamic.mjs to exist"
+										)
+									);
+									return;
+								}
+
+								const externalImportRegex = /from\s+["']external-lib["']/;
+								const mainSource = mainAsset.source.source().toString();
+								const dynamicSource = dynamicAsset.source.source().toString();
+
+								if (externalImportRegex.test(mainSource)) {
+									compilation.errors.push(
+										new Error(
+											'Unexpected hoist: bundle0.mjs contains `from "external-lib"`'
+										)
+									);
+								}
+								if (!externalImportRegex.test(dynamicSource)) {
+									compilation.errors.push(
+										new Error(
+											'Missing hoist: dynamic.mjs does not contain `from "external-lib"`'
+										)
+									);
+								}
+							}
+						);
+					}
+				);
+			}
+		}
+	]
+};


### PR DESCRIPTION
fixes #20362 

<table>
<tr>
<th>Before (main branch)</th>
<th>After (new branch)</th>
</tr>
<tr>
<td>
<img width="765" height="91" alt="Screenshot 2026-02-25 at 7 25 38 AM" src="https://github.com/user-attachments/assets/b91da03a-a0cf-4ace-a432-6af541204677" />

</td>
<td>
<img width="746" height="91" alt="Screenshot 2026-02-25 at 8 21 37 AM" src="https://github.com/user-attachments/assets/8f04e2cc-305f-473f-b21c-c0ab66309ba1" />


</td>
</tr>
</table>


**What kind of change does this PR introduce?**
Previously while having `externalsType: 'module-import'` and one `external: external-lib` this external-lib was hoisted in the entry point of bundled output. This PR aims to hoist this external-lib to the dynamic chunk where importing of this package was done

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
I think so, since it is a feat request

Also take a look at this [repo](https://github.com/stefanbinoj/webpack-external-chunks-fix) the `org_dist/` shows previously generated bundles with hoisting in main entry point while `dist/` shows new bundle that have been ran with this new branch it has hoisted only in dynamic chunk! 