### PR TITLE
test: add missing coverage for formatLocation and formatSize

### DIFF
--- a/test/SizeFormatHelpers.unittest.js
+++ b/test/SizeFormatHelpers.unittest.js
@@ -8,6 +8,10 @@ describe("SizeFormatHelpers", () => {
 			expect(formatSize(0)).toBe("0 bytes");
 		});
 
+		it("should handle negative size", () => {
+			expect(formatSize(-1)).toBe("0 bytes");
+		});
+
 		it("should handle bytes", () => {
 			expect(formatSize(1000)).toBe("1000 bytes");
 		});

--- a/test/formatLocation.unittest.js
+++ b/test/formatLocation.unittest.js
@@ -71,6 +71,16 @@ describe("formatLocation", () => {
 				end: /f/
 			},
 			result: ""
+		},
+		{
+			name: "name with index",
+			loc: { name: "foo", index: 3 },
+			result: "foo[3]"
+		},
+		{
+			name: "name only",
+			loc: { name: "bar" },
+			result: "bar"
 		}
 	];
 	for (const testCase of testCases) {


### PR DESCRIPTION
Adds tests for two previously uncovered code branches:
- formatLocation: name+index branch (returns "foo[3]") and name-only branch (returns "bar")
- formatSize: negative size input (returns "0 bytes", same as zero — because size <= 0)

No production code was changed.

