### PR TITLE
fix(externals): throw when object external is missing selected type mapping

### DIFF
--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -985,6 +985,11 @@ class ExternalModule extends Module {
 		concatenationScope
 	}) {
 		const { request, externalType } = this._getRequestAndExternalType();
+		if (request === undefined) {
+			throw new Error(
+				`Missing external configuration for type:${externalType}`
+			);
+		}
 		switch (externalType) {
 			case "asset": {
 				/** @type {Sources} */

--- a/test/configCases/externals/amd-only-non-amd-target/errors.js
+++ b/test/configCases/externals/amd-only-non-amd-target/errors.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = [[/Missing external configuration for type:commonjs2/]];

--- a/test/configCases/externals/amd-only-non-amd-target/index.js
+++ b/test/configCases/externals/amd-only-non-amd-target/index.js
@@ -1,0 +1,3 @@
+const amdModule = require("amd-module");
+
+module.exports = amdModule;

--- a/test/configCases/externals/amd-only-non-amd-target/webpack.config.js
+++ b/test/configCases/externals/amd-only-non-amd-target/webpack.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		libraryTarget: "commonjs2"
+	},
+	externals: {
+		"amd-module": {
+			amd: "amd-module"
+		}
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};


### PR DESCRIPTION
### **Summary**

I worked on this PR to fix a silent externals failure reported in #8079.

The issue happens when an external is configured as an object with only an AMD mapping (for example, an [amd] key), but webpack is building with a different external type (like commonjs2). Before this change, webpack could continue and generate undefined output instead of failing clearly.

In this PR, I added a validation so webpack throws an explicit error when the selected external type mapping is missing. This makes the behavior safer and easier to debug.
Closes #8079.

**What kind of change does this PR introduce?**

This is a fix (bug fix), plus a test addition for regression coverage.

**Did you add tests for your changes?**

Yes. I added a new config-case regression test that reproduces the AMD-only external + non-AMD target scenario and asserts the expected error.

**Does this PR introduce a breaking change?**

No. This does not change supported configuration behavior; it changes a silent invalid output into an explicit build error for misconfigured externals.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

I don’t think this needs major docs updates. If needed, we can add a short note in externals configuration docs that object-form externals must include the active external type mapping.

