### PR TITLE
refactor: add Module.getSourceBasicTypes for basic JS type detection

### DIFF
--- a/.changeset/add-module-basic-source-types.md
+++ b/.changeset/add-module-basic-source-types.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Add `Module.getSourceBasicTypes` to distinguish basic source types and clarify how modules with non-basic source types like `remote` still produce JavaScript output.

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -80,6 +80,8 @@ const makeSerializable = require("./util/makeSerializable");
 /** @typedef {KnownSourceType | string} SourceType */
 /** @typedef {ReadonlySet<SourceType>} SourceTypes */
 
+/** @typedef {ReadonlySet<typeof JAVASCRIPT_TYPE | string>} BasicSourceTypes */
+
 // TODO webpack 6: compilation will be required in CodeGenerationContext
 /**
  * @typedef {object} CodeGenerationContext
@@ -964,6 +966,19 @@ class Module extends DependenciesBlock {
 			return DEFAULT_TYPES_UNKNOWN;
 		}
 		return JAVASCRIPT_TYPES;
+	}
+
+	/**
+	 * Basic source types are high-level categories like javascript, css, webassembly, etc.
+	 * We only have built-in knowledge about the javascript basic type here; other basic types may be
+	 * added or changed over time by generators and do not need to be handled or detected here.
+	 *
+	 * Some modules, e.g. RemoteModule, may return non-basic source types like "remote" and "share-init"
+	 * from getSourceTypes(), but their generated output is still JavaScript, i.e. their basic type is JS.
+	 * @returns {BasicSourceTypes} types available (do not mutate)
+	 */
+	getSourceBasicTypes() {
+		return this.getSourceTypes();
 	}
 
 	/**

--- a/lib/RuntimeModule.js
+++ b/lib/RuntimeModule.js
@@ -8,7 +8,10 @@
 const { RawSource } = require("webpack-sources");
 const OriginalSource = require("webpack-sources").OriginalSource;
 const Module = require("./Module");
-const { RUNTIME_TYPES } = require("./ModuleSourceTypeConstants");
+const {
+	JAVASCRIPT_TYPES,
+	RUNTIME_TYPES
+} = require("./ModuleSourceTypeConstants");
 const { WEBPACK_MODULE_TYPE_RUNTIME } = require("./ModuleTypeConstants");
 
 /** @typedef {import("./config/defaults").WebpackOptionsNormalizedWithDefaults} WebpackOptions */
@@ -29,6 +32,7 @@ const { WEBPACK_MODULE_TYPE_RUNTIME } = require("./ModuleTypeConstants");
 /** @typedef {import("./ResolverFactory").ResolverWithOptions} ResolverWithOptions */
 /** @typedef {import("./util/Hash")} Hash */
 /** @typedef {import("./util/fs").InputFileSystem} InputFileSystem */
+/** @typedef {import("./Module").BasicSourceTypes} BasicSourceTypes */
 
 class RuntimeModule extends Module {
 	/**
@@ -136,6 +140,19 @@ class RuntimeModule extends Module {
 	 */
 	getSourceTypes() {
 		return RUNTIME_TYPES;
+	}
+
+	/**
+	 * Basic source types are high-level categories like javascript, css, webassembly, etc.
+	 * We only have built-in knowledge about the javascript basic type here; other basic types may be
+	 * added or changed over time by generators and do not need to be handled or detected here.
+	 *
+	 * Some modules, e.g. RemoteModule, may return non-basic source types like "remote" and "share-init"
+	 * from getSourceTypes(), but their generated output is still JavaScript, i.e. their basic type is JS.
+	 * @returns {BasicSourceTypes} types available (do not mutate)
+	 */
+	getSourceBasicTypes() {
+		return JAVASCRIPT_TYPES;
 	}
 
 	/**

--- a/lib/container/RemoteModule.js
+++ b/lib/container/RemoteModule.js
@@ -7,7 +7,10 @@
 
 const { RawSource } = require("webpack-sources");
 const Module = require("../Module");
-const { REMOTE_AND_SHARE_INIT_TYPES } = require("../ModuleSourceTypeConstants");
+const {
+	JAVASCRIPT_TYPES,
+	REMOTE_AND_SHARE_INIT_TYPES
+} = require("../ModuleSourceTypeConstants");
 const { WEBPACK_MODULE_TYPE_REMOTE } = require("../ModuleTypeConstants");
 const RuntimeGlobals = require("../RuntimeGlobals");
 const makeSerializable = require("../util/makeSerializable");
@@ -34,6 +37,7 @@ const RemoteToExternalDependency = require("./RemoteToExternalDependency");
 /** @typedef {import("../serialization/ObjectMiddleware").ObjectDeserializerContext} ObjectDeserializerContext */
 /** @typedef {import("../serialization/ObjectMiddleware").ObjectSerializerContext} ObjectSerializerContext */
 /** @typedef {import("../util/fs").InputFileSystem} InputFileSystem */
+/** @typedef {import("../Module").BasicSourceTypes} BasicSourceTypes */
 
 const RUNTIME_REQUIREMENTS = new Set([RuntimeGlobals.module]);
 
@@ -135,6 +139,19 @@ class RemoteModule extends Module {
 	 */
 	getSourceTypes() {
 		return REMOTE_AND_SHARE_INIT_TYPES;
+	}
+
+	/**
+	 * Basic source types are high-level categories like javascript, css, webassembly, etc.
+	 * We only have built-in knowledge about the javascript basic type here; other basic types may be
+	 * added or changed over time by generators and do not need to be handled or detected here.
+	 *
+	 * Some modules, e.g. RemoteModule, may return non-basic source types like "remote" and "share-init"
+	 * from getSourceTypes(), but their generated output is still JavaScript, i.e. their basic type is JS.
+	 * @returns {BasicSourceTypes} types available (do not mutate)
+	 */
+	getSourceBasicTypes() {
+		return JAVASCRIPT_TYPES;
 	}
 
 	/**

--- a/lib/dependencies/HarmonyImportSideEffectDependency.js
+++ b/lib/dependencies/HarmonyImportSideEffectDependency.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-const { CSS_TYPE } = require("../ModuleSourceTypeConstants");
+const { JAVASCRIPT_TYPE } = require("../ModuleSourceTypeConstants");
 const makeSerializable = require("../util/makeSerializable");
 const HarmonyImportDependency = require("./HarmonyImportDependency");
 
@@ -62,14 +62,6 @@ makeSerializable(
 	"webpack/lib/dependencies/HarmonyImportSideEffectDependency"
 );
 
-/**
- * @param {string[]} sourceTypes the source type of referencing module
- * @returns {boolean} returns if need to render executing js code
- */
-function noNeedJs(sourceTypes) {
-	return sourceTypes.every((sourceType) => sourceType === CSS_TYPE);
-}
-
 HarmonyImportSideEffectDependency.Template = class HarmonyImportSideEffectDependencyTemplate extends (
 	HarmonyImportDependency.Template
 ) {
@@ -84,7 +76,7 @@ HarmonyImportSideEffectDependency.Template = class HarmonyImportSideEffectDepend
 
 		const module = /** @type {Module} */ (moduleGraph.getModule(dependency));
 
-		if (module && noNeedJs([...module.getSourceTypes()])) {
+		if (module && !module.getSourceBasicTypes().has(JAVASCRIPT_TYPE)) {
 			// no need to render import
 			return;
 		}

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -17,7 +17,6 @@ const ConcatenationScope = require("../ConcatenationScope");
 const { UsageState } = require("../ExportsInfo");
 const Module = require("../Module");
 const {
-	CSS_TYPE,
 	JAVASCRIPT_TYPE,
 	JAVASCRIPT_TYPES
 } = require("../ModuleSourceTypeConstants");
@@ -1005,11 +1004,7 @@ class ConcatenatedModule extends Module {
 					if (!(connection.dependency instanceof HarmonyImportDependency)) {
 						return false;
 					}
-					if (
-						[...connection.module.getSourceTypes()].every(
-							(sourceType) => sourceType === CSS_TYPE
-						)
-					) {
+					if (!connection.module.getSourceBasicTypes().has(JAVASCRIPT_TYPE)) {
 						return false;
 					}
 					return (

--- a/lib/sharing/ConsumeSharedModule.js
+++ b/lib/sharing/ConsumeSharedModule.js
@@ -8,7 +8,10 @@
 const { RawSource } = require("webpack-sources");
 const AsyncDependenciesBlock = require("../AsyncDependenciesBlock");
 const Module = require("../Module");
-const { CONSUME_SHARED_TYPES } = require("../ModuleSourceTypeConstants");
+const {
+	CONSUME_SHARED_TYPES,
+	JAVASCRIPT_TYPES
+} = require("../ModuleSourceTypeConstants");
 const {
 	WEBPACK_MODULE_TYPE_CONSUME_SHARED_MODULE
 } = require("../ModuleTypeConstants");
@@ -41,6 +44,7 @@ const fallbackModuleCache = new WeakMap();
 /** @typedef {import("../util/Hash")} Hash */
 /** @typedef {import("../util/fs").InputFileSystem} InputFileSystem */
 /** @typedef {import("../util/semver").SemVerRange} SemVerRange */
+/** @typedef {import("../Module").BasicSourceTypes} BasicSourceTypes */
 
 /**
  * @typedef {object} ConsumeOptions
@@ -157,6 +161,19 @@ class ConsumeSharedModule extends Module {
 	 */
 	getSourceTypes() {
 		return CONSUME_SHARED_TYPES;
+	}
+
+	/**
+	 * Basic source types are high-level categories like javascript, css, webassembly, etc.
+	 * We only have built-in knowledge about the javascript basic type here; other basic types may be
+	 * added or changed over time by generators and do not need to be handled or detected here.
+	 *
+	 * Some modules, e.g. RemoteModule, may return non-basic source types like "remote" and "share-init"
+	 * from getSourceTypes(), but their generated output is still JavaScript, i.e. their basic type is JS.
+	 * @returns {BasicSourceTypes} types available (do not mutate)
+	 */
+	getSourceBasicTypes() {
+		return JAVASCRIPT_TYPES;
 	}
 
 	/**

--- a/types.d.ts
+++ b/types.d.ts
@@ -10647,6 +10647,15 @@ declare class Module extends DependenciesBlock {
 		callback: (err?: WebpackError) => void
 	): void;
 	getSourceTypes(): ReadonlySet<string>;
+
+	/**
+	 * Basic source types are high-level categories like javascript, css, webassembly, etc.
+	 * We only have built-in knowledge about the javascript basic type here; other basic types may be
+	 * added or changed over time by generators and do not need to be handled or detected here.
+	 * Some modules, e.g. RemoteModule, may return non-basic source types like "remote" and "share-init"
+	 * from getSourceTypes(), but their generated output is still JavaScript, i.e. their basic type is JS.
+	 */
+	getSourceBasicTypes(): ReadonlySet<string>;
 	source(
 		dependencyTemplates: DependencyTemplates,
 		runtimeTemplate: RuntimeTemplate,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Add `Module.getSourceBasicTypes` to distinguish basic source types and clarify how modules with non-basic source types like `remote` still produce JavaScript output.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
refactor

**Did you add tests for your changes?**
Existing

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing