### PR TITLE
docs: fix duplicate word in Compilation JSDoc

### DIFF
--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -4019,7 +4019,7 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 	 * @param {string | ChunkGroupOptions} groupOptions options for the chunk group
 	 * @param {Module=} module the module the references the chunk group
 	 * @param {DependencyLocation=} loc the location from with the chunk group is referenced (inside of module)
-	 * @param {string=} request the request from which the the chunk group is referenced
+	 * @param {string=} request the request from which the chunk group is referenced
 	 * @returns {ChunkGroup} the new or existing chunk group
 	 */
 	addChunkInGroup(groupOptions, module, loc, request) {
@@ -4067,7 +4067,7 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 	 * @param {EntryOptions} options options for the entrypoint
 	 * @param {Module} module the module the references the chunk group
 	 * @param {DependencyLocation} loc the location from with the chunk group is referenced (inside of module)
-	 * @param {string} request the request from which the the chunk group is referenced
+	 * @param {string} request the request from which the chunk group is referenced
 	 * @returns {Entrypoint} the new or existing entrypoint
 	 */
 	addAsyncEntrypoint(options, module, loc, request) {


### PR DESCRIPTION
## Summary
- remove duplicated word in two JSDoc parameter descriptions in `lib/Compilation.js`

## Guideline alignment
- guideline reference: https://github.com/webpack/webpack/blob/main/CONTRIBUTING.md
- issue-first guidance applies to major fixes/features; this PR is a minor comment-only cleanup
- no behavior changes

## Validation
- comment-only change
