### PR TITLE
docs: fix duplicated wording in max chunk type docs

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -9817,7 +9817,7 @@ declare interface LimitChunkCountPluginOptions {
 	entryChunkMultiplicator?: number;
 
 	/**
-	 * Limit the maximum number of chunks using a value greater greater than or equal to 1.
+	 * Limit the maximum number of chunks using a value greater than or equal to 1.
 	 */
 	maxChunks: number;
 }


### PR DESCRIPTION
## Summary
- fix duplicated wording in `types.d.ts` (`greater greater than` -> `greater than`)

## Guideline alignment
- guideline reference: https://github.com/webpack/webpack/blob/main/CONTRIBUTING.md
- this is a minor documentation/comment-quality fix in type docs
- no functional changes

## Validation
- docs/comment-only change