### PR TITLE
test: Add tests for web and webworker target compatibility and auto public path handling

### DIFF
--- a/test/configCases/target/web-webworker-auto-public-path/chunk.js
+++ b/test/configCases/target/web-webworker-auto-public-path/chunk.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/test/configCases/target/web-webworker-auto-public-path/index.js
+++ b/test/configCases/target/web-webworker-auto-public-path/index.js
@@ -1,0 +1,9 @@
+it("should resolve public path automatically in web+webworker target", () => {
+	expect(__webpack_public_path__).toBe("https://test.cases/path/");
+});
+
+it("should load a dynamic import with auto public path", () => {
+	return import("./chunk").then(({ value }) => {
+		expect(value).toBe(42);
+	});
+});

--- a/test/configCases/target/web-webworker-auto-public-path/webpack.config.js
+++ b/test/configCases/target/web-webworker-auto-public-path/webpack.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: ["web", "webworker"],
+	output: {
+		filename: "bundle0.js",
+		publicPath: "auto",
+		chunkLoading: "import-scripts",
+		chunkFormat: "array-push"
+	}
+};

--- a/test/configCases/target/web-webworker/chunk.js
+++ b/test/configCases/target/web-webworker/chunk.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/test/configCases/target/web-webworker/index.js
+++ b/test/configCases/target/web-webworker/index.js
@@ -1,0 +1,9 @@
+it("should compile with web+webworker target", () => {
+	expect(typeof self).toBe("object");
+});
+
+it("should load a dynamic import", () => {
+	return import("./chunk").then(({ value }) => {
+		expect(value).toBe(42);
+	});
+});

--- a/test/configCases/target/web-webworker/webpack.config.js
+++ b/test/configCases/target/web-webworker/webpack.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: ["web", "webworker"],
+	output: {
+		filename: "bundle0.js",
+		publicPath: "https://test.cases/path/",
+		chunkLoading: "import-scripts",
+		chunkFormat: "array-push"
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

This PR adds two new test cases to verify webpack’s behavior when the target is set to both "web" and "webworker". The first test checks that webpack correctly bundles code so it runs seamlessly in both browser and web worker environments. The second test ensures that when code is running inside a web worker, webpack automatically sets the public path for loading additional chunks, so dynamic imports and code splitting work without manual configuration. These tests help guarantee that webpack’s output is reliable and compatible for advanced use cases involving web workers.

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

Yes, this PR only adds new tests.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation changes needed; this PR only adds tests.

**Use of AI**

No AI was used in writing these tests or this PR.