### PR TITLE
fix: tree-shake unused default export in dynamic-reexport mode

### DIFF
--- a/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
+++ b/lib/dependencies/HarmonyExportImportedSpecifierDependency.js
@@ -619,8 +619,24 @@ class HarmonyExportImportedSpecifierDependency extends HarmonyImportDependency {
 				return referencedExports;
 			}
 
-			case "dynamic-reexport":
-				return Dependency.EXPORTS_OBJECT_REFERENCED;
+			case "dynamic-reexport": {
+				const referencedExports = [];
+				const importedModule = moduleGraph.getModule(this);
+				if (importedModule) {
+					const importedExportsInfo =
+						moduleGraph.getExportsInfo(importedModule);
+					for (const exportInfo of importedExportsInfo.orderedExports) {
+						if (mode.ignored && mode.ignored.has(exportInfo.name)) continue;
+						referencedExports.push([exportInfo.name]);
+					}
+					if (importedExportsInfo.otherExportsInfo.provided !== false) {
+						return Dependency.EXPORTS_OBJECT_REFERENCED;
+					}
+				} else {
+					return Dependency.EXPORTS_OBJECT_REFERENCED;
+				}
+				return referencedExports;
+			}
 
 			case "normal-reexport": {
 				/** @type {RawReferencedExports} */

--- a/test/cases/optimize/tree-shaking-unused-default-export/index.js
+++ b/test/cases/optimize/tree-shaking-unused-default-export/index.js
@@ -1,0 +1,16 @@
+import { opts } from "./intermediary";
+
+it("should tree-shake unused default export when only named export is used", function() {
+	expect(opts).toEqual({
+		route: "/test",
+		title: "I am a test"
+	});
+});
+
+it("should still be accessible via dynamic import", function(done) {
+	import("./intermediary").then(m => {
+		expect(m.default).toBeDefined();
+		expect(m.default.__processed).toBe(true);
+		done();
+	});
+});

--- a/test/cases/optimize/tree-shaking-unused-default-export/intermediary.js
+++ b/test/cases/optimize/tree-shaking-unused-default-export/intermediary.js
@@ -1,0 +1,5 @@
+import script from "./module";
+export * from "./module";
+
+const __exports__ = Object.assign({}, script, { __processed: true });
+export default __exports__;

--- a/test/cases/optimize/tree-shaking-unused-default-export/module.js
+++ b/test/cases/optimize/tree-shaking-unused-default-export/module.js
@@ -1,0 +1,12 @@
+export const opts = {
+	route: "/test",
+	title: "I am a test"
+};
+
+export default {
+	data() {
+		return {
+			I: "Should not be inside the initial bundle"
+		};
+	}
+};


### PR DESCRIPTION
this fixes the issue #20537, i:e,

when vue-loader generates an intermediary file that does export * from "./module", webpack falls into dynamic-reexport mode because it can't statically determine all exports. In this mode, it was returning EXPORTS_OBJECT_REFERENCED — marking ALL exports as used, including default.
But export * never re-exports default per the ES spec. The code already had mode.ignored which contains "default", but getReferencedExports wasn't checking it in the dynamic-reexport case.

**What kind of change does this PR introduce?**
Bug fix

**Did you add tests for your changes?**
Yes, added `test/cases/optimize/tree-shaking-unused-default-export/`

**Does this PR introduce a breaking change?**
Shouldn't be — this makes webpack correctly exclude default from export * re-exports, which is what the ES spec requires.