### PR TITLE
refactor: add AppendOnlyStackedSet iteration support and tests

### DIFF
--- a/lib/util/AppendOnlyStackedSet.js
+++ b/lib/util/AppendOnlyStackedSet.js
@@ -43,7 +43,9 @@ class AppendOnlyStackedSet {
 
 	clear() {
 		this._sets = [];
-		if (this._current) this._current.clear();
+		if (this._current) {
+			this._current = undefined;
+		}
 	}
 
 	/**
@@ -51,6 +53,25 @@ class AppendOnlyStackedSet {
 	 */
 	createChild() {
 		return new AppendOnlyStackedSet(this._sets.length ? [...this._sets] : []);
+	}
+
+	/**
+	 * @returns {Iterator<T>} iterable iterator
+	 */
+	[Symbol.iterator]() {
+		const iterators = this._sets.map((map) => map[Symbol.iterator]());
+		let current = iterators.pop();
+		return {
+			next() {
+				if (!current) return { done: true, value: undefined };
+				let result = current.next();
+				while (result.done && iterators.length > 0) {
+					current = /** @type {SetIterator<T>} */ (iterators.pop());
+					result = current.next();
+				}
+				return result;
+			}
+		};
 	}
 }
 

--- a/test/AppendOnlyStackedSet.unittest.js
+++ b/test/AppendOnlyStackedSet.unittest.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const AppendOnlyStackedSet = require("../lib/util/AppendOnlyStackedSet");
+
+describe("AppendOnlyStackedSet", () => {
+	it("iterates empty instances", () => {
+		const set = new AppendOnlyStackedSet();
+
+		expect([...set]).toEqual([]);
+	});
+
+	it("keeps parent and child append layers separate", () => {
+		const parent = new AppendOnlyStackedSet();
+		parent.add("a");
+		parent.add("b");
+		const child = parent.createChild();
+
+		child.add("c");
+
+		expect([...parent]).toEqual(["a", "b"]);
+		expect([...child]).toEqual(["c", "a", "b"]);
+	});
+
+	it("clear detaches current stack without mutating shared sets", () => {
+		const parent = new AppendOnlyStackedSet();
+		parent.add("a");
+		const child = parent.createChild();
+
+		parent.clear();
+
+		expect([...parent]).toEqual([]);
+		expect(parent.has("a")).toBe(false);
+		expect([...child]).toEqual(["a"]);
+		expect(child.has("a")).toBe(true);
+
+		parent.add("b");
+
+		expect([...parent]).toEqual(["b"]);
+	});
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -311,6 +311,7 @@ declare abstract class AppendOnlyStackedSet<T> {
 	has(el: T): boolean;
 	clear(): void;
 	createChild(): AppendOnlyStackedSet<T>;
+	[Symbol.iterator](): Iterator<T>;
 }
 declare interface Argument {
 	description?: string;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Fix an issue where `this._current` could retain a reference to a cleared set after calling `AppendOnlyStackedSet.clear()`, which might cause unexpected bugs. Also add tests for `AppendOnlyStackedSet`.<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

Yes

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

No
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->