### PR TITLE
ModuleConcatenationPlugin: allow safe parent-child async concatenatio…

### DIFF
--- a/lib/optimize/ModuleConcatenationPlugin.js
+++ b/lib/optimize/ModuleConcatenationPlugin.js
@@ -52,6 +52,27 @@ const formatBailoutReason = (msg) => `ModuleConcatenation bailout: ${msg}`;
 
 const PLUGIN_NAME = "ModuleConcatenationPlugin";
 
+/**
+ * Check if chunk a is guaranteed to be available before chunk b executes.
+ * Mirrors the internal isAvailableChunk(a, b) function from ChunkGraph.js:
+ * walks up b's chunk-group parents; if a is in every path up, b will always
+ * have a available.
+ * @param {import("../Chunk")} a the chunk that must be available
+ * @param {import("../Chunk")} b the chunk that depends on a
+ * @returns {boolean} true if a is always an ancestor of b
+ */
+const isAvailableChunkHelper = (a, b) => {
+	const queue = new Set(b.groupsIterable);
+	for (const chunkGroup of queue) {
+		if (a.isInGroup(chunkGroup)) continue;
+		if (chunkGroup.isInitial()) return false;
+		for (const parent of chunkGroup.parentsIterable) {
+			queue.add(parent);
+		}
+	}
+	return true;
+};
+
 class ModuleConcatenationPlugin {
 	/**
 	 * Apply the plugin
@@ -458,10 +479,14 @@ class ModuleConcatenationPlugin {
 													modules.has(c.module)
 												)
 										);
-										// remove module from chunk
+										// Step 3: Only disconnect inner module m from chunks that also
+										// contain the rootModule. Parent-chunk modules (available via
+										// isAvailableChunk) are NOT in root chunks and must NOT be disconnected.
 										for (const chunk of chunkGraph.getModuleChunksIterable(
 											rootModule
 										)) {
+											// Guard: skip chunks that do not contain this inner module
+											if (!chunkGraph.isModuleInChunk(m, chunk)) continue;
 											const sourceTypes = chunkGraph.getChunkModuleSourceTypes(
 												chunk,
 												m
@@ -607,33 +632,78 @@ class ModuleConcatenationPlugin {
 			return module;
 		}
 
-		// Module must be in the correct chunks
-		const missingChunks = [
+		// Availability cache: avoid repeated O(n²) chunkGraph.isAvailableChunk calls
+		/** @type {Map<string, boolean>} */
+		/** @type {Map<string, boolean>} */
+		const availabilityCache = new Map();
+		/**
+		 * @param {import("../Chunk")} a chunk a
+		 * @param {import("../Chunk")} b chunk b
+		 * @returns {boolean} whether a is available in b
+		 */
+		const isAvailableCached = (a, b) => {
+			const key = `${a.id}|${b.id}`;
+			if (availabilityCache.has(key)) {
+				return /** @type {boolean} */ (availabilityCache.get(key));
+			}
+			const result = isAvailableChunkHelper(a, b);
+			availabilityCache.set(key, result);
+			return result;
+		};
+
+		// Step 1 + Step 4: Module must be execution-compatible with root module chunks.
+		// We allow the module to live in a *parent* chunk (guaranteed available before root chunk)
+		// instead of requiring strict co-chunk membership.
+		const rootChunks = [
 			...chunkGraph.getModuleChunksIterable(config.rootModule)
-		].filter((chunk) => !chunkGraph.isModuleInChunk(module, chunk));
-		if (missingChunks.length > 0) {
+		];
+		const moduleChunks = [...chunkGraph.getModuleChunksIterable(module)];
+
+		let isExecutionCompatible = true;
+
+		outer: for (const rootChunk of rootChunks) {
+			for (const moduleChunk of moduleChunks) {
+				if (moduleChunk === rootChunk) continue;
+
+				// Step 4: Prevent cross-runtime inlining (e.g. optimization.runtimeChunk: "single")
+				if (
+					rootChunk.runtime !== undefined &&
+					moduleChunk.runtime !== undefined &&
+					rootChunk.runtime !== moduleChunk.runtime
+				) {
+					isExecutionCompatible = false;
+					break outer;
+				}
+
+				// Core invariant: moduleChunk must be available (already loaded) when rootChunk executes
+				if (!isAvailableCached(moduleChunk, rootChunk)) {
+					isExecutionCompatible = false;
+					break outer;
+				}
+			}
+		}
+
+		if (!isExecutionCompatible) {
 			/**
 			 * @param {RequestShortener} requestShortener request shortener
 			 * @returns {string} problem description
 			 */
 			const problem = (requestShortener) => {
-				const missingChunksList = [
+				const moduleChunkNames = [
 					...new Set(
-						missingChunks.map((chunk) => chunk.name || "unnamed chunk(s)")
+						moduleChunks.map((chunk) => chunk.name || "unnamed chunk(s)")
 					)
 				].sort();
-				const chunks = [
+				const rootChunkNames = [
 					...new Set(
-						[...chunkGraph.getModuleChunksIterable(module)].map(
-							(chunk) => chunk.name || "unnamed chunk(s)"
-						)
+						rootChunks.map((chunk) => chunk.name || "unnamed chunk(s)")
 					)
 				].sort();
 				return `Module ${module.readableIdentifier(
 					requestShortener
-				)} is not in the same chunk(s) (expected in chunk(s) ${missingChunksList.join(
+				)} is not in the same chunk(s) (expected in chunk(s) ${rootChunkNames.join(
 					", "
-				)}, module is in chunk(s) ${chunks.join(", ")})`;
+				)}, module is in chunk(s) ${moduleChunkNames.join(", ")})`;
 			};
 			statistics.incorrectChunks++;
 			failureCache.set(module, problem); // cache failures for performance
@@ -709,13 +779,23 @@ class ModuleConcatenationPlugin {
 
 		const incomingModules = [...incomingConnectionsFromModules.keys()];
 
-		// Module must be in the same chunks like the referencing module
+		// Step 2: Importer compatibility check.
+		// For each importer of module M, for every chunk C_r containing root R:
+		//   - either the importer is in C_r, OR
+		//   - every chunk C_i of the importer is available (loaded before) C_r.
+		// This prevents sibling, descendant, or unrelated-runtime importers.
 		const otherChunkModules = incomingModules.filter((originModule) => {
-			for (const chunk of chunkGraph.getModuleChunksIterable(
-				config.rootModule
-			)) {
-				if (!chunkGraph.isModuleInChunk(originModule, chunk)) {
-					return true;
+			const originChunks = [
+				...chunkGraph.getModuleChunksIterable(originModule)
+			];
+			for (const rootChunk of rootChunks) {
+				if (chunkGraph.isModuleInChunk(originModule, rootChunk)) continue;
+				// Importer is not in this root chunk — check that every chunk of importer
+				// is available (i.e. guaranteed to be loaded before the root chunk)
+				for (const originChunk of originChunks) {
+					if (!isAvailableCached(originChunk, rootChunk)) {
+						return true; // incompatible importer
+					}
 				}
 			}
 			return false;

--- a/test/configCases/concatenation/multi-entry-unsafe/entry-a.js
+++ b/test/configCases/concatenation/multi-entry-unsafe/entry-a.js
@@ -1,0 +1,8 @@
+// entry-a: imports shared THEN page-a
+// This path sees shared before page-a, so it would be fine alone ...
+import "./shared"; // establishes shared in this entry's chunk
+import { pageA } from "./page-a";
+
+it("entry-a: shared is loaded before page-a", () => {
+    expect(pageA()).toBe("shared-multi-entry:unsafe-concat");
+});

--- a/test/configCases/concatenation/multi-entry-unsafe/entry-b.js
+++ b/test/configCases/concatenation/multi-entry-unsafe/entry-b.js
@@ -1,0 +1,11 @@
+// entry-b: imports page-a WITHOUT going through shared.
+// This means "shared" is NOT in entry-b's chunk group ancestors —
+// so isAvailableChunk(sharedChunk, pageAChunk) = false when viewed from entry-b.
+// The plugin MUST bail out on concatenating shared into page-a.
+import { pageA } from "./page-a";
+
+it("entry-b: page-a still works without shared being pre-loaded", () => {
+    // page-a must use the normal require() path to load shared,
+    // not assume it was already concatenated/inlined
+    expect(pageA()).toBe("shared-multi-entry:unsafe-concat");
+});

--- a/test/configCases/concatenation/multi-entry-unsafe/page-a.js
+++ b/test/configCases/concatenation/multi-entry-unsafe/page-a.js
@@ -1,0 +1,5 @@
+import { sharedValue, sharedHelper } from "./shared";
+
+export function pageA() {
+    return sharedValue + ":" + sharedHelper();
+}

--- a/test/configCases/concatenation/multi-entry-unsafe/shared.js
+++ b/test/configCases/concatenation/multi-entry-unsafe/shared.js
@@ -1,0 +1,11 @@
+// Shared module that is imported by two different entry points.
+// entry-a: entry-a → shared → page-a
+// entry-b: entry-b → page-a  (does NOT go through shared)
+//
+// This means "shared" is NOT guaranteed to be available for all paths
+// that reach page-a, so concatenation of "shared" into page-a is UNSAFE.
+export const sharedValue = "shared-multi-entry";
+
+export function sharedHelper() {
+    return "unsafe-concat";
+}

--- a/test/configCases/concatenation/multi-entry-unsafe/webpack.config.js
+++ b/test/configCases/concatenation/multi-entry-unsafe/webpack.config.js
@@ -1,0 +1,35 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	// Two separate entry points — critical for the negative test.
+	// entry-a goes through shared → page-a.
+	// entry-b goes directly to page-a, bypassing shared.
+	// This means shared is NOT guaranteed available before page-a in all paths.
+	entry: {
+		"entry-a": "./entry-a.js",
+		"entry-b": "./entry-b.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		concatenateModules: true,
+		splitChunks: {
+			chunks: "all",
+			minSize: 0,
+			cacheGroups: {
+				shared: {
+					test: /shared\.js/,
+					name: "shared",
+					enforce: true
+				},
+				pageA: {
+					test: /page-a\.js/,
+					name: "page-a-chunk",
+					enforce: true
+				}
+			}
+		}
+	}
+};

--- a/test/configCases/concatenation/parent-child-async/index.js
+++ b/test/configCases/concatenation/parent-child-async/index.js
@@ -1,0 +1,8 @@
+it("should concatenate parent-chunk module into child async chunk", async () => {
+    // shared is loaded first as a separate chunk, then page-a as a child chunk
+    const { sharedValue } = await import("./shared");
+    const { pageA } = await import("./page-a");
+
+    expect(sharedValue).toBe("shared-value");
+    expect(pageA()).toBe("shared-value-from-shared");
+});

--- a/test/configCases/concatenation/parent-child-async/page-a.js
+++ b/test/configCases/concatenation/parent-child-async/page-a.js
@@ -1,0 +1,5 @@
+import { sharedValue, sharedHelper } from "./shared";
+
+export function pageA() {
+    return sharedValue + "-" + sharedHelper();
+}

--- a/test/configCases/concatenation/parent-child-async/shared.js
+++ b/test/configCases/concatenation/parent-child-async/shared.js
@@ -1,0 +1,8 @@
+// This module lives in a shared (parent) chunk.
+// It should be concatenatable into page-a (child chunk) because
+// the parent chunk is guaranteed to be loaded before the child chunk.
+export const sharedValue = "shared-value";
+
+export function sharedHelper() {
+    return "from-shared";
+}

--- a/test/configCases/concatenation/parent-child-async/webpack.config.js
+++ b/test/configCases/concatenation/parent-child-async/webpack.config.js
@@ -1,0 +1,23 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: "./index.js",
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		concatenateModules: true,
+		splitChunks: {
+			chunks: "all",
+			minSize: 0,
+			cacheGroups: {
+				shared: {
+					test: /shared\.js/,
+					name: "shared",
+					enforce: true
+				}
+			}
+		}
+	}
+};

--- a/test/configCases/concatenation/runtime-chunk-separated/index.js
+++ b/test/configCases/concatenation/runtime-chunk-separated/index.js
@@ -1,0 +1,9 @@
+it("should not violate runtime boundaries when runtimeChunk is single", async () => {
+    const [modA, modShared] = await Promise.all([
+        import("./page-a"),
+        import("./shared")
+    ]);
+
+    expect(modShared.sharedValue).toBe("shared-runtime-safe");
+    expect(modA.pageA()).toBe("shared-runtime-safe-runtime-separated");
+});

--- a/test/configCases/concatenation/runtime-chunk-separated/page-a.js
+++ b/test/configCases/concatenation/runtime-chunk-separated/page-a.js
@@ -1,0 +1,5 @@
+import { sharedValue, sharedHelper } from "./shared";
+
+export function pageA() {
+    return sharedValue + "-" + sharedHelper();
+}

--- a/test/configCases/concatenation/runtime-chunk-separated/shared.js
+++ b/test/configCases/concatenation/runtime-chunk-separated/shared.js
@@ -1,0 +1,5 @@
+export const sharedValue = "shared-runtime-safe";
+
+export function sharedHelper() {
+    return "runtime-separated";
+}

--- a/test/configCases/concatenation/runtime-chunk-separated/webpack.config.js
+++ b/test/configCases/concatenation/runtime-chunk-separated/webpack.config.js
@@ -1,0 +1,24 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: "./index.js",
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		concatenateModules: true,
+		runtimeChunk: "single",
+		splitChunks: {
+			chunks: "all",
+			minSize: 0,
+			cacheGroups: {
+				shared: {
+					test: /shared\.js/,
+					name: "shared",
+					enforce: true
+				}
+			}
+		}
+	}
+};

--- a/test/configCases/concatenation/shared-two-children/index.js
+++ b/test/configCases/concatenation/shared-two-children/index.js
@@ -1,0 +1,11 @@
+it("should concatenate shared parent-chunk module into two independent child chunks", async () => {
+    const [modA, modB, modShared] = await Promise.all([
+        import("./page-a"),
+        import("./page-b"),
+        import("./shared")
+    ]);
+
+    expect(modShared.sharedValue).toBe("shared-value");
+    expect(modA.pageA()).toBe("page-a:shared-value:from-shared");
+    expect(modB.pageB()).toBe("page-b:shared-value:from-shared");
+});

--- a/test/configCases/concatenation/shared-two-children/page-a.js
+++ b/test/configCases/concatenation/shared-two-children/page-a.js
@@ -1,0 +1,5 @@
+import { sharedValue, sharedHelper } from "./shared";
+
+export function pageA() {
+    return "page-a:" + sharedValue + ":" + sharedHelper();
+}

--- a/test/configCases/concatenation/shared-two-children/page-b.js
+++ b/test/configCases/concatenation/shared-two-children/page-b.js
@@ -1,0 +1,5 @@
+import { sharedValue, sharedHelper } from "./shared";
+
+export function pageB() {
+    return "page-b:" + sharedValue + ":" + sharedHelper();
+}

--- a/test/configCases/concatenation/shared-two-children/shared.js
+++ b/test/configCases/concatenation/shared-two-children/shared.js
@@ -1,0 +1,7 @@
+// Shared module that will be split into its own chunk.
+// Both page-a and page-b import this module.
+export const sharedValue = "shared-value";
+
+export function sharedHelper() {
+    return "from-shared";
+}

--- a/test/configCases/concatenation/shared-two-children/webpack.config.js
+++ b/test/configCases/concatenation/shared-two-children/webpack.config.js
@@ -1,0 +1,23 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: "./index.js",
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		concatenateModules: true,
+		splitChunks: {
+			chunks: "all",
+			minSize: 0,
+			cacheGroups: {
+				shared: {
+					test: /shared\.js/,
+					name: "shared",
+					enforce: true
+				}
+			}
+		}
+	}
+};

--- a/test/configCases/concatenation/side-effects-no-dup/consumer.js
+++ b/test/configCases/concatenation/side-effects-no-dup/consumer.js
@@ -1,0 +1,5 @@
+import { sideEffectValue } from "./side-effect";
+
+export function consume() {
+    return "consumed:" + sideEffectValue;
+}

--- a/test/configCases/concatenation/side-effects-no-dup/index.js
+++ b/test/configCases/concatenation/side-effects-no-dup/index.js
@@ -1,0 +1,14 @@
+it("should not duplicate side-effectful modules during concatenation", async () => {
+    // Reset counter before test
+    global.__sideEffectCounter = 0;
+
+    const [modConsumer, modSideEffect] = await Promise.all([
+        import("./consumer"),
+        import("./side-effect")
+    ]);
+
+    // side-effect.js should only have been executed once, not duplicated
+    expect(global.__sideEffectCounter).toBe(1);
+    expect(modSideEffect.sideEffectValue).toBe("executed");
+    expect(modConsumer.consume()).toBe("consumed:executed");
+});

--- a/test/configCases/concatenation/side-effects-no-dup/side-effect.js
+++ b/test/configCases/concatenation/side-effects-no-dup/side-effect.js
@@ -1,0 +1,8 @@
+// This module has a side-effect: it increments a counter on `global`.
+// When concatenated, it must only execute ONCE even if imported by multiple modules.
+if (typeof global.__sideEffectCounter === "undefined") {
+    global.__sideEffectCounter = 0;
+}
+global.__sideEffectCounter++;
+
+export const sideEffectValue = "executed";

--- a/test/configCases/concatenation/side-effects-no-dup/webpack.config.js
+++ b/test/configCases/concatenation/side-effects-no-dup/webpack.config.js
@@ -1,0 +1,23 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: "./index.js",
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		concatenateModules: true,
+		splitChunks: {
+			chunks: "all",
+			minSize: 0,
+			cacheGroups: {
+				sideEffect: {
+					test: /side-effect\.js/,
+					name: "side-effect",
+					enforce: true
+				}
+			}
+		}
+	}
+};

--- a/test/configCases/concatenation/split-chunks-cache-groups/feature-a.js
+++ b/test/configCases/concatenation/split-chunks-cache-groups/feature-a.js
@@ -1,0 +1,5 @@
+import { utilHelper } from "./util";
+
+export function featureA() {
+    return utilHelper("feature-a");
+}

--- a/test/configCases/concatenation/split-chunks-cache-groups/index.js
+++ b/test/configCases/concatenation/split-chunks-cache-groups/index.js
@@ -1,0 +1,12 @@
+it("should allow concatenation across splitChunks cacheGroups boundaries", async () => {
+    // util is placed in a shared cacheGroup chunk (parent).
+    // feature-a is an async child chunk that imports util.
+    // After the fix, util should concatenate into feature-a without bailout.
+    const [modA, modUtil] = await Promise.all([
+        import("./feature-a"),
+        import("./util")
+    ]);
+
+    expect(modUtil.utilValue).toBe("util-from-cache-group");
+    expect(modA.featureA()).toBe("util-from-cache-group:feature-a");
+});

--- a/test/configCases/concatenation/split-chunks-cache-groups/util.js
+++ b/test/configCases/concatenation/split-chunks-cache-groups/util.js
@@ -1,0 +1,5 @@
+export const utilValue = "util-from-cache-group";
+
+export function utilHelper(x) {
+    return utilValue + ":" + x;
+}

--- a/test/configCases/concatenation/split-chunks-cache-groups/webpack.config.js
+++ b/test/configCases/concatenation/split-chunks-cache-groups/webpack.config.js
@@ -1,0 +1,25 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: "./index.js",
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		concatenateModules: true,
+		splitChunks: {
+			chunks: "all",
+			minSize: 0,
+			cacheGroups: {
+				utils: {
+					test: /util\.js/,
+					name: "utils",
+					enforce: true,
+					priority: 10
+				},
+				default: false
+			}
+		}
+	}
+};


### PR DESCRIPTION
This PR relaxes an overly strict bailout condition in ModuleConcatenationPlugin to allow safe parent-child async concatenation when execution order guarantees module availability.
Concatenation now proceeds only if:
1. Both chunks share the same runtime (no cross-runtime inlining), and
2. The module’s chunk is guaranteed to be available when the root chunk executes.
This preserves execution correctness while enabling additional safe optimisation opportunities.