### PR TITLE
Moveterser-webpack-plugin from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "neo-async": "^2.6.2",
     "schema-utils": "^4.3.3",
     "tapable": "^2.3.0",
-    "terser-webpack-plugin": "^5.3.17",
     "watchpack": "^2.5.1",
     "webpack-sources": "^3.3.4"
   },
@@ -186,6 +185,7 @@
     "strip-ansi": "^6.0.0",
     "style-loader": "^4.0.0",
     "terser": "^5.43.1",
+    "terser-webpack-plugin": "^5.3.17",
     "three": "^0.183.1",
     "tinybench": "^6.0.0",
     "toml": "^3.0.0",


### PR DESCRIPTION
terser-webpack-plugin is mainly used during the build process and should be classified as a development dependency. To better reflect its usage, it would be ideal to move it from dependencies to devDependencies.

#20585 