### PR TITLE
test: fix ModuleDependencyError unit test failing on Windows

### DIFF
--- a/test/ModuleDependencyError.unittest.js
+++ b/test/ModuleDependencyError.unittest.js
@@ -38,7 +38,7 @@ describe("ModuleDependencyError", () => {
 
 		it("has a details property", () => {
 			expect(env.moduleDependencyError.details).toMatch(
-				path.join("test", "ModuleDependencyError.unittest.js:")
+				`${path.join("test", "ModuleDependencyError.unittest.js")}:`
 			);
 		});
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

This fixes an issue where [test/ModuleDependencyError.unittest.js](cci:7://file:///c:/Users/Sejal%20Kumari/web/pack/webpack/test/ModuleDependencyError.unittest.js:0:0-0:0) was consistently failing on Windows environments.
When `path.join` receives a string ending with a colon (`:`), such as `path.join("test", "ModuleDependencyError.unittest.js:")`, Node.js on Windows interprets it as a potential drive letter or Alternate Data Stream and automatically prepends a `.\` to "normalize" it safely. 
This caused the expected string to be `.\test\ModuleDependencyError.unittest.js:`, which fails to match the substring in the actual error stack trace generated by Jest (`C:\...\test\Module...:15:16`).
By moving the colon outside `path.join` and using template literals (`${path.join("test", "ModuleDependencyError.unittest.js")}:`), it outputs a clean relative path [test\ModuleDependencyError.unittest.js](cci:7://file:///c:/Users/Sejal%20Kumari/web/pack/webpack/test/ModuleDependencyError.unittest.js:0:0-0:0). Appending `:` manually produces a string that strictly matches the expected substring stack trace.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->
test

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->
N/A (this PR fixes an existing test)

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
N/A

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->

Yes, I used AI to help debug the test failure on the Windows environment and to formulate the explanation of why path.join behaves differently on Windows when a colon (:) is present. The AI also helped me format the code using template literals to resolve the issue nicely.