### PR TITLE
test: add edge case coverage for cjs require destructuring tree shaking

### DIFF
--- a/test/cases/cjs-tree-shaking/require-destructuring/index.js
+++ b/test/cases/cjs-tree-shaking/require-destructuring/index.js
@@ -10,3 +10,28 @@ it("should support require context destructuring assignment", () => {
 	expect(a).toBe("a/a");
 	expect(usedExports).toEqual(["a", "usedExports"]);
 });
+
+it("should static analyze aliased require destructuring", () => {
+	const { a: renamedA, usedExports } = require("./module");
+	expect(renamedA).toBe("a");
+	expect(usedExports).toEqual(["a", "usedExports"]);
+});
+
+it("should support require context aliased destructuring assignment", () => {
+	const file = "a";
+	const { a: renamedA, usedExports } = require(`./dir/${file}.js`);
+	expect(renamedA).toBe("a/a");
+	expect(usedExports).toEqual(["a", "usedExports"]);
+});
+
+it("should static analyze require destructuring with default values", () => {
+	const { a = "fallback", usedExports } = require("./module");
+	expect(a).toBe("a");
+	expect(usedExports).toEqual(["a", "usedExports"]);
+});
+
+it("should bail on rest element in require destructuring", () => {
+	const { usedExports, ...rest } = require("./module-rest");
+	expect(usedExports).toBe(true);
+	expect(rest).toEqual({ a: "a", b: "b" });
+});

--- a/test/cases/cjs-tree-shaking/require-destructuring/module-rest.js
+++ b/test/cases/cjs-tree-shaking/require-destructuring/module-rest.js
@@ -1,0 +1,3 @@
+exports.a = "a";
+exports.b = "b";
+exports.usedExports = __webpack_exports_info__.usedExports;


### PR DESCRIPTION
Adds three missing test assertions for the feature introduced in #20548:

- aliased destructuring (`{ a: renamedA }`) marks the original key as used
- aliased context require (template literal) same behavior
- default value destructuring (`{ a = 'fallback' }`) still marks the key as used
- rest element (`{ a, ...rest }`) bails the analysis, all exports kept

A separate `module-rest.js` fixture is used for the rest element test to avoid contaminating other tests — rest bail-out affects all `require()` calls to the same module within a file.

**Summary**

#20548 added CJS require destructuring tree shaking but shipped with only two basic tests. These edge cases (aliased keys, default values, rest element bail-out) were untested and represent distinct code paths in `_preWalkObjectPattern`.

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

This PR is only tests.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

N/A

**Use of AI**

No AI was used.