### PR TITLE
Fix get source basic types guard

### DIFF
--- a/lib/dependencies/HarmonyImportSideEffectDependency.js
+++ b/lib/dependencies/HarmonyImportSideEffectDependency.js
@@ -76,9 +76,15 @@ HarmonyImportSideEffectDependency.Template = class HarmonyImportSideEffectDepend
 
 		const module = /** @type {Module} */ (moduleGraph.getModule(dependency));
 
-		if (module && !module.getSourceBasicTypes().has(JAVASCRIPT_TYPE)) {
-			// no need to render import
-			return;
+		if (module) {
+			const sourceTypes =
+				typeof module.getSourceBasicTypes === "function"
+					? module.getSourceBasicTypes()
+					: undefined;
+
+			if (sourceTypes && !sourceTypes.has(JAVASCRIPT_TYPE)) {
+				return;
+			}
 		}
 
 		if (concatenationScope && concatenationScope.isModuleInScope(module)) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->
Fix TypeError: module.getSourceBasicTypes is not a function in HarmonyImportSideEffectDependencyTemplate.

Some modules do not implement getSourceBasicTypes(). This patch adds a guard to ensure the method exists before calling it.

Testing

Verified using a minimal webpack project.

Before fix:

TypeError: module.getSourceBasicTypes is not a function

After fix:

webpack compiled successfully

Fixes #20597