### PR TITLE
test: fix ModuleDependencyError.unittest.js on Windows

### DIFF
--- a/test/ModuleDependencyError.unittest.js
+++ b/test/ModuleDependencyError.unittest.js
@@ -37,8 +37,8 @@ describe("ModuleDependencyError", () => {
 		});
 
 		it("has a details property", () => {
-			expect(env.moduleDependencyError.details).toMatch(
-				path.join("test", "ModuleDependencyError.unittest.js:")
+			expect(env.moduleDependencyError.details).toContain(
+				path.join("test", "ModuleDependencyError.unittest.js") + ":"
 			);
 		});
 


### PR DESCRIPTION
Fixes a unit test failure on Windows where path.join with a trailing colon caused incorrect path normalization and 	oMatch failed due to backslash escaping.