### PR TITLE
Fix createRequire support for CommonJS destructuring patterns

### DIFF
--- a/lib/dependencies/CreateRequireParserPlugin.js
+++ b/lib/dependencies/CreateRequireParserPlugin.js
@@ -261,26 +261,55 @@ class CreateRequireParserPlugin {
 		);
 		parser.hooks.preDeclarator.tap(PLUGIN_NAME, (declarator) => {
 			if (
-				declarator.id.type !== "Identifier" ||
 				!declarator.init ||
 				declarator.init.type !== "CallExpression" ||
 				declarator.init.callee.type !== "Identifier"
 			) {
 				return;
 			}
+
 			const variableInfo = parser.getVariableInfo(declarator.init.callee.name);
+
+			// Handle simple identifier: const x = createRequire(...)
+			if (declarator.id.type === "Identifier") {
+				if (
+					variableInfo instanceof VariableInfo &&
+					variableInfo.tagInfo &&
+					variableInfo.tagInfo.tag === createRequireSpecifierTag
+				) {
+					const context = parseCreateRequireArguments(declarator.init);
+					if (context === undefined) return;
+					parser.tagVariable(declarator.id.name, createdRequireIdentifierTag, {
+						name: declarator.id.name,
+						context
+					});
+					return true;
+				}
+			}
+
+			// Handle destructuring: const { createRequire } = require('module')
 			if (
-				variableInfo instanceof VariableInfo &&
-				variableInfo.tagInfo &&
-				variableInfo.tagInfo.tag === createRequireSpecifierTag
+				declarator.id.type === "ObjectPattern" &&
+				declarator.init.callee.name === "require" &&
+				declarator.init.arguments.length === 1
 			) {
-				const context = parseCreateRequireArguments(declarator.init);
-				if (context === undefined) return;
-				parser.tagVariable(declarator.id.name, createdRequireIdentifierTag, {
-					name: declarator.id.name,
-					context
-				});
-				return true;
+				const arg = declarator.init.arguments[0];
+				const evaluated = parser.evaluateExpression(arg);
+				if (
+					evaluated.isString() &&
+					moduleNames.includes(/** @type {string} */ (evaluated.string))
+				) {
+					for (const property of declarator.id.properties) {
+						if (
+							property.type === "Property" &&
+							property.key.type === "Identifier" &&
+							property.key.name === specifierName &&
+							property.value.type === "Identifier"
+						) {
+							parser.tagVariable(property.value.name, createRequireSpecifierTag);
+						}
+					}
+				}
 			}
 		});
 

--- a/test/configCases/require/create-require-cjs-destructuring/a.cjs
+++ b/test/configCases/require/create-require-cjs-destructuring/a.cjs
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = 1;

--- a/test/configCases/require/create-require-cjs-destructuring/index.cjs
+++ b/test/configCases/require/create-require-cjs-destructuring/index.cjs
@@ -1,0 +1,17 @@
+"use strict";
+
+const { createRequire } = require("module");
+const { createRequire: createRequireNode } = require("node:module");
+
+const require1 = createRequire(__filename);
+const require2 = createRequireNode(__filename);
+
+it("should handle createRequire destructured from require('module')", () => {
+	expect(require1("./a.cjs")).toBe(1);
+	expect(require2("./a.cjs")).toBe(1);
+});
+
+it("should resolve using createRequire destructured from require", () => {
+	expect(require1.resolve("./a.cjs")).toBe("./a.cjs");
+	expect(require2.resolve("./a.cjs")).toBe("./a.cjs");
+});

--- a/test/configCases/require/create-require-cjs-destructuring/webpack.config.js
+++ b/test/configCases/require/create-require-cjs-destructuring/webpack.config.js
@@ -1,0 +1,17 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	entry: "./index.cjs",
+	optimization: {
+		moduleIds: "named"
+	},
+	module: {
+		parser: {
+			javascript: {
+				createRequire: true
+			}
+		}
+	}
+};


### PR DESCRIPTION
Fixes #20544. The CreateRequireParserPlugin was only handling ESM imports and simple identifier declarations. This fix adds support for CommonJS destructuring patterns like `const { createRequire } = require('module')`, which was causing `ReferenceError: createRequire is not defined` at runtime.