### PR TITLE
Improve webpack-cli auto-install error reporting

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -20,11 +20,25 @@ const runCommand = (command, args) => {
 			reject(error);
 		});
 
-		executedCommand.on("exit", (code) => {
+		executedCommand.on("exit", (code, signal) => {
 			if (code === 0) {
 				resolve();
 			} else {
-				reject();
+				const details =
+					code !== null ? `exit code ${code}` : `signal ${signal}`;
+				const error =
+					/** @type {Error & { command?: string, args?: string[], exitCode?: number | null, signal?: NodeJS.Signals | null }} */ (
+						new Error(
+							`Command "${command} ${args.join(" ")}" failed with ${details}.`
+						)
+					);
+
+				error.command = command;
+				error.args = args;
+				error.exitCode = code;
+				error.signal = signal;
+
+				reject(error);
 			}
 		});
 	});
@@ -187,7 +201,19 @@ if (!cli.installed) {
 				runCli(cli);
 			})
 			.catch((err) => {
-				console.error(err);
+				console.error(
+					`Failed to install '${cli.package}'. ` +
+						`Please install it manually using:\n  ${packageManager} ${installOptions.join(
+							" "
+						)} ${cli.package}\n`
+				);
+
+				if (err instanceof Error) {
+					console.error(err.message);
+				} else if (err) {
+					console.error(err);
+				}
+
 				process.exitCode = 1;
 			});
 	});

--- a/test/Cli.basictest.js
+++ b/test/Cli.basictest.js
@@ -316,7 +316,7 @@ describe("Cli", () => {
 		`)
 		);
 
-		// cspell:ignore filsystem
+		// cspell:ignore filsystem dontMock
 		test(
 			"errors",
 			{
@@ -422,6 +422,81 @@ describe("Cli", () => {
 			]
 		`)
 		);
+	});
+
+	describe("bin/webpack.js", () => {
+		const flushPromises = () =>
+			new Promise((resolve) => {
+				setImmediate(resolve);
+			});
+		const originalExitCode = process.exitCode;
+
+		beforeEach(() => {
+			jest.resetModules();
+			process.exitCode = undefined;
+		});
+
+		afterEach(() => {
+			jest.dontMock("child_process");
+			jest.dontMock("graceful-fs");
+			jest.dontMock("readline");
+			jest.restoreAllMocks();
+			process.exitCode = originalExitCode;
+		});
+
+		it("should show a helpful message when webpack-cli auto-install fails", async () => {
+			const stderr = jest.spyOn(console, "error").mockImplementation(() => {});
+			const stdout = jest.spyOn(console, "log").mockImplementation(() => {});
+
+			jest.doMock("graceful-fs", () => ({
+				statSync: jest.fn(() => {
+					throw new Error("not installed");
+				}),
+				existsSync: jest.fn((file) => file.endsWith("yarn.lock"))
+			}));
+			jest.doMock("readline", () => ({
+				createInterface: jest.fn(() => ({
+					question: (question, callback) => callback("yes"),
+					close: jest.fn()
+				}))
+			}));
+			jest.doMock("child_process", () => ({
+				spawn: jest.fn(() => {
+					const { EventEmitter } = require("events");
+
+					const emitter = new EventEmitter();
+
+					process.nextTick(() => {
+						emitter.emit("exit", 1, null);
+					});
+
+					return emitter;
+				})
+			}));
+
+			jest.isolateModules(() => {
+				require("../bin/webpack");
+			});
+
+			await flushPromises();
+			await flushPromises();
+
+			expect(stdout).toHaveBeenCalledWith(
+				"Installing 'webpack-cli' (running 'yarn add -D webpack-cli')..."
+			);
+
+			const stderrOutput = stderr.mock.calls
+				.map((args) => args.join(" "))
+				.join("\n");
+
+			expect(stderrOutput).toContain(
+				"Failed to install 'webpack-cli'. Please install it manually using:\n  yarn add -D webpack-cli"
+			);
+			expect(stderrOutput).toContain(
+				'Command "yarn add -D webpack-cli" failed with exit code 1.'
+			);
+			expect(process.exitCode).toBe(1);
+		});
 	});
 
 	describe("isColorSupported", () => {


### PR DESCRIPTION
**Summary**

When `webpack` is run without `webpack-cli` installed, `bin/webpack.js` offers to install it automatically. If that install fails, the current error reporting is not very helpful because the spawned command can reject without a proper error object, which makes the final output harder to understand.

This change improves that failure path by returning a descriptive error from `runCommand()` and showing a clearer manual-install message when the `webpack-cli` install fails. The goal is to make the CLI output more actionable for users who hit this flow for the first time.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes. I added a regression test in `test/Cli.basictest.js` that covers the failed `webpack-cli` auto-install flow and checks that the improved error output is shown.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No additional documentation should be needed. This change only improves the error reporting for an existing CLI flow.

**Use of AI**

I used AI tool as a support  during development to help review parts of the existing codebase and assist in drafting the initial implementation and PR description. 