### PR TITLE
fix(compiler): remove duplicate idle assignment in run()

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -518,7 +518,6 @@ class Compiler {
 			if (logger) logger.time("beginIdle");
 			this.idle = true;
 			this.cache.beginIdle();
-			this.idle = true;
 			if (logger) logger.timeEnd("beginIdle");
 			this.running = false;
 			if (err) {

--- a/test/Compiler.test.js
+++ b/test/Compiler.test.js
@@ -568,6 +568,39 @@ describe("Compiler", () => {
 		});
 	});
 
+	it("should set idle state once when run finishes", (done) => {
+		const webpack = require("..");
+
+		compiler = webpack({
+			context: __dirname,
+			mode: "production",
+			entry: "./c",
+			output: {
+				path: "/directory",
+				filename: "bundle.js"
+			}
+		});
+		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		let idle = compiler.idle;
+		let idleWriteCount = 0;
+		Object.defineProperty(compiler, "idle", {
+			configurable: true,
+			enumerable: true,
+			get() {
+				return idle;
+			},
+			set(value) {
+				idleWriteCount++;
+				idle = value;
+			}
+		});
+		compiler.run((err, _stats) => {
+			if (err) return done(err);
+			expect(idleWriteCount).toBe(1);
+			done();
+		});
+	});
+
 	it("should watch again correctly after first compilation", (done) => {
 		const webpack = require("..");
 


### PR DESCRIPTION
## Summary

This PR fixes #20616 a small state-management issue in `Compiler.run()` where `compiler.idle` was being assigned `true` twice in succession inside `finalCallback`, around the `cache.beginIdle()` call.

The redundant assignment has been removed to make the lifecycle state transition clearer and to avoid unnecessary duplicate state writes.

## Type of Change

- [x] Bug fix
- [x] Tests added
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- Removed the duplicate `compiler.idle = true` assignment in `Compiler.run()`.
- Ensured the compiler lifecycle state transition remains correct.
- Added a unit test verifying that `compiler.idle` is written only once when `run()` completes.

## Testing

A new unit test has been added to confirm that the `compiler.idle` state is updated exactly once when the `run()` execution finishes.

## Breaking Changes

No breaking changes.

## Documentation

No documentation updates are required.

## Use of AI

AI assistance (Codex) was used to help identify the location of the issue in the codebase.
