### PR TITLE
refactor(cache): make needCalls decrement flow explicit

### DIFF
--- a/lib/Cache.js
+++ b/lib/Cache.js
@@ -42,11 +42,12 @@ const {
  * @returns {(err?: Error | null) => void} callback
  */
 const needCalls = (times, callback) => (err) => {
-	if (--times === 0) {
-		return callback(err);
-	}
 	if (err && times > 0) {
 		times = 0;
+		return callback(err);
+	}
+	times--;
+	if (times === 0) {
 		return callback(err);
 	}
 };

--- a/test/Cache.unittest.js
+++ b/test/Cache.unittest.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const Cache = require("../lib/Cache");
+
+describe("Cache", () => {
+	it("calls callback once when multiple got handlers receive an error", (done) => {
+		const cache = new Cache();
+		cache.hooks.get.tapAsync(
+			"DataReturner",
+			(_identifier, _etag, gotHandlers, callback) => {
+				gotHandlers.push((_result, done) => {
+					done(new Error("first got handler error"));
+				});
+				gotHandlers.push((_result, done) => {
+					done();
+				});
+				callback(undefined, "ok");
+			}
+		);
+
+		let callbackCalls = 0;
+		cache.get("id", null, (err, result) => {
+			callbackCalls++;
+			expect(callbackCalls).toBe(1);
+			expect(err).toBeNull();
+			expect(result).toBe("ok");
+			done();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

This PR addresses a low-severity code quality issue in `Cache.js` by making the `needCalls` helper logic more explicit and easier to reason about.

Previously, `needCalls` used an inline decrement inside a condition (`if (--times === 0)`), which can be harder to read and reason about in edge cases.

This PR refactors the flow to:

- Handle the error-first early return.
- Decrement `times` explicitly.
- Check completion using `if (times === 0)`.

The behavior remains unchanged while improving clarity and maintainability.

---

## What kind of change does this PR introduce?

- [x] Refactor
- [x] Tests added (internal code quality improvement with added unit coverage)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---

## Changes Made

- Refactored the `needCalls` helper in `Cache.js` to avoid inline decrement logic.
- Improved readability and maintainability of the control flow.
- Added a focused unit test to verify callback behavior when multiple `gotHandlers` are involved in `Cache.get()`.

---

## Did you add tests for your changes?

Yes.

Added `Cache.unittest.js` with a unit test that verifies the correct callback behavior when multiple handlers participate in a `Cache.get()` operation.

---

## Does this PR introduce a breaking change?

No.

This is a non-breaking internal refactor and test addition.

---

## Documentation

No public-facing documentation updates are required.

The change is internal and does not modify external APIs or user-facing behavior.

---

## Use of AI

Yes. AI assistance was used **only to help draft the unit test**.  
