### PR TITLE
test(target): add config case coverage for electron-main and electron-preload

### DIFF
--- a/test/configCases/target/electron-main/index.js
+++ b/test/configCases/target/electron-main/index.js
@@ -1,0 +1,5 @@
+const foo = require("foo");
+
+it("should use main field", () => {
+	expect(foo).toBe("main");
+});

--- a/test/configCases/target/electron-main/node_modules/foo/browser.js
+++ b/test/configCases/target/electron-main/node_modules/foo/browser.js
@@ -1,0 +1,1 @@
+module.exports = "browser";

--- a/test/configCases/target/electron-main/node_modules/foo/main.js
+++ b/test/configCases/target/electron-main/node_modules/foo/main.js
@@ -1,0 +1,1 @@
+module.exports = "main";

--- a/test/configCases/target/electron-main/node_modules/foo/package.json
+++ b/test/configCases/target/electron-main/node_modules/foo/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "foo",
+	"version": "1.0.0",
+	"browser": "./browser.js",
+	"main": "./main.js"
+}

--- a/test/configCases/target/electron-main/webpack.config.js
+++ b/test/configCases/target/electron-main/webpack.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "electron-main",
+	optimization: {
+		minimize: false
+	}
+};

--- a/test/configCases/target/electron-preload/index.js
+++ b/test/configCases/target/electron-preload/index.js
@@ -1,0 +1,5 @@
+const foo = require("foo");
+
+it("should use main field", () => {
+	expect(foo).toBe("main");
+});

--- a/test/configCases/target/electron-preload/node_modules/foo/browser.js
+++ b/test/configCases/target/electron-preload/node_modules/foo/browser.js
@@ -1,0 +1,1 @@
+module.exports = "browser";

--- a/test/configCases/target/electron-preload/node_modules/foo/main.js
+++ b/test/configCases/target/electron-preload/node_modules/foo/main.js
@@ -1,0 +1,1 @@
+module.exports = "main";

--- a/test/configCases/target/electron-preload/node_modules/foo/package.json
+++ b/test/configCases/target/electron-preload/node_modules/foo/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "foo",
+	"version": "1.0.0",
+	"browser": "./browser.js",
+	"main": "./main.js"
+}

--- a/test/configCases/target/electron-preload/webpack.config.js
+++ b/test/configCases/target/electron-preload/webpack.config.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "electron-preload",
+	optimization: {
+		minimize: false
+	}
+};


### PR DESCRIPTION
**Summary**

This PR adds config case coverage for the missing Electron target contexts:
- `electron-main`
- `electron-preload`
webpack already has a config case for `electron-renderer` under `test/configCases/target/electron-renderer`, but there was no dedicated config case coverage for the other two supported Electron target contexts.
The new test cases use a small local fixture package with both `main` and `browser` fields and assert that:
- `electron-renderer` prefers the `browser` field (existing behavior)
- `electron-main` prefers the `main` field
- `electron-preload` prefers the `main` field
This helps verify the target-specific resolution behavior and improves regression coverage around Electron target handling.

Fixes: #20629

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

Yes

Added two new config case test folders:
- `test/configCases/target/electron-main`
- `test/configCases/target/electron-preload`

I also ran targeted local verification for these config cases. The new electron cases compiled successfully.

**Does this PR introduce a breaking change?**

No.
This only adds test coverage.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No additional documentation is needed because this PR only adds tests.


**Use of AI**

I used AI for planning and drafting some text. I reviewed the repo structure, issue scope, test setup, and final code changes manually before preparing this PR.
