### PR TITLE
fix: export in library works only for last entry module

### DIFF
--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1101,7 +1101,7 @@ class JavascriptModulesPlugin {
 						footer = "\n";
 					}
 					if (exports) {
-						if (m !== lastInlinedModule) {
+						if (m !== lastInlinedModule && !chunkGraph.isEntryModule(m)) {
 							startupSource.add(`var ${m.exportsArgument} = {};\n`);
 						} else if (m.exportsArgument !== RuntimeGlobals.exports) {
 							startupSource.add(
@@ -1457,7 +1457,7 @@ class JavascriptModulesPlugin {
 
 					if (chunks.length > 0) {
 						buf2.push(
-							`${i === 0 ? `var ${RuntimeGlobals.exports} = ` : ""}${
+							`${i === jsEntries.length - 1 ? `var ${RuntimeGlobals.exports} = ` : ""}${
 								RuntimeGlobals.onChunksLoaded
 							}(undefined, ${JSON.stringify(
 								chunks.map((c) => c.id)
@@ -1465,11 +1465,17 @@ class JavascriptModulesPlugin {
 								`${RuntimeGlobals.require}(${moduleIdExpr})`
 							)})`
 						);
+
+						buf2.push(
+							`${RuntimeGlobals.exports} = Object.assign({...${RuntimeGlobals.exports}},{...${RuntimeGlobals.onChunksLoaded}(${RuntimeGlobals.exports})});`
+						);
 					} else if (useRequire) {
 						buf2.push(
-							`${i === 0 ? `var ${RuntimeGlobals.exports} = ` : ""}${
-								RuntimeGlobals.require
-							}(${moduleIdExpr});`
+							`${i === jsEntries.length - 1 ? `var ${RuntimeGlobals.exports} = ` : `${RuntimeGlobals.exports} = `}${
+								i === jsEntries.length - 1
+									? `${RuntimeGlobals.require}(${moduleIdExpr});`
+									: `Object.assign({...${RuntimeGlobals.exports}},{...${RuntimeGlobals.require}(${moduleIdExpr})});`
+							}`
 						);
 					} else {
 						if (i === 0) buf2.push(`var ${RuntimeGlobals.exports} = {};`);

--- a/test/configCases/entry/issue-15936/index.js
+++ b/test/configCases/entry/issue-15936/index.js
@@ -1,0 +1,5 @@
+
+
+export function indexMethod(){
+    
+}

--- a/test/configCases/entry/issue-15936/node_modules/react.js
+++ b/test/configCases/entry/issue-15936/node_modules/react.js
@@ -1,0 +1,1 @@
+module.exports = "react"

--- a/test/configCases/entry/issue-15936/scriptA.js
+++ b/test/configCases/entry/issue-15936/scriptA.js
@@ -1,0 +1,3 @@
+export function scriptAMethod(){
+    
+}

--- a/test/configCases/entry/issue-15936/scriptB.js
+++ b/test/configCases/entry/issue-15936/scriptB.js
@@ -1,0 +1,7 @@
+
+
+export function scriptBMethod(){
+
+}
+
+

--- a/test/configCases/entry/issue-15936/test.config.js
+++ b/test/configCases/entry/issue-15936/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle() {
+		return ["./index.js"];
+	}
+};

--- a/test/configCases/entry/issue-15936/test.js
+++ b/test/configCases/entry/issue-15936/test.js
@@ -1,0 +1,10 @@
+import {indexMethod} from "./index.js";
+import {scriptAMethod} from "./scriptA.js";
+import {scriptBMethod} from "./scriptB.js";
+import react from "react";
+it("exports from all entry modules should be present", function () {
+    expect(indexMethod).toBeDefined();
+    expect(scriptAMethod).toBeDefined();
+    expect(scriptBMethod).toBeDefined();
+    
+});

--- a/test/configCases/entry/issue-15936/test2.js
+++ b/test/configCases/entry/issue-15936/test2.js
@@ -1,0 +1,4 @@
+import react from "react";
+it("should have exports from all entry modules", function () {
+    expect(react).toBe("react");
+})

--- a/test/configCases/entry/issue-15936/webpack.config.js
+++ b/test/configCases/entry/issue-15936/webpack.config.js
@@ -1,0 +1,43 @@
+"use strict";
+
+/** @type {import("../../../../types").Configuration} */
+module.exports = [
+	{
+		entry: {
+			index: {
+				import: ["./index.js", "./scriptA.js", "./scriptB.js", "./test.js"]
+			}
+		},
+		target: "web",
+		output: {
+			library: {
+				type: "global"
+			},
+
+			filename: "[name].js"
+		}
+	},
+	{
+		entry: {
+			index: {
+				import: ["./index.js", "./scriptA.js", "./scriptB.js", "./test2.js"]
+			},
+			vendors: ["react"]
+		},
+
+		target: "web",
+		output: {
+			library: {
+				type: "global"
+			},
+
+			filename: "[name].js"
+		},
+		optimization: {
+			usedExports: false,
+			splitChunks: {
+				chunks: "all"
+			}
+		}
+	}
+];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

fixes https://github.com/webpack/webpack/issues/15936

Until now when we were doing multiple imports in entry point as array, only the exports from the last entry would be available.With this PR, the exports should work for all the entry points.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
This PR fixes the problem of exports only available from the last entry. They are fixed in three stages

### 1) when entry points is refrenced by other modules

**Before**

```
> ******/ 	// startup
> /******/ 	// Load entry module and return exports
> /******/ 	// This entry module is referenced by other modules so it can't be inlined
> /******/ 	__webpack_require__("./src/index.js");
> /******/ 	__webpack_require__("./src/scriptB.js");
> /******/ 	var __webpack_exports__ = __webpack_require__("./src/scriptC.js");
> /******/ 	var __webpack_export_target__ = self;
> /******/ 	for(var __webpack_i__ in __webpack_exports__) __webpack_export_target__[__webpack_i__] = __webpack_exports__[__webpack_i__];
> /******/ 	if(__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, "__esModule", { value: true });
> /******/ 
```

	
**After**
```

> `/******/ 	
> /******/ 	// startup
> /******/ 	// Load entry module and return exports
> /******/ 	// This entry module is referenced by other modules so it can't be inlined
> /******/ 	var __webpack_exports__ = __webpack_require__("./src/index.js");
> /******/ 	__webpack_exports__ = Object.assign({...__webpack_exports__},{...__webpack_require__("./src/scriptB.js")});
> /******/ 	__webpack_exports__ = Object.assign({...__webpack_exports__},{...__webpack_require__("./src/scriptC.js")});
> /******/ 	var __webpack_export_target__ = self;
> /******/ 	for(var __webpack_i__ in __webpack_exports__) __webpack_export_target__[__webpack_i__] = __webpack_exports__[__webpack_i__];
> /******/ 	if(__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, "__esModule", { value: true });
> /******/ 	
> /******/ })()`

```

### 2) When entry points depend on other chunks
**Before**

```
> /******/ 	// startup
> /******/ 	// Load entry module and return exports
> /******/ 	// This entry module depends on other loaded chunks and execution need to be delayed
> /******/ 	__webpack_require__.O(undefined, ["vendors-node_modules_jquery_dist_jquery_js"], () => (__webpack_require__("./src/index.js")))
> /******/ 	__webpack_require__.O(undefined, ["vendors-node_modules_jquery_dist_jquery_js"], () => (__webpack_require__("./src/scriptB.js")))
> /******/ 	var __webpack_exports__ = __webpack_require__.O(undefined, ["vendors-node_modules_jquery_dist_jquery_js"], () => (__webpack_require__("./src/scriptC.js")))
> /******/ 	__webpack_exports__ = __webpack_require__.O(__webpack_exports__);
> /******/ 	var __webpack_export_target__ = self;
> /******/ 	for(var __webpack_i__ in __webpack_exports__) __webpack_export_target__[__webpack_i__] = __webpack_exports__[__webpack_i__];
> /******/ 	if(__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, "__esModule", { value: true });
> /******/ 
```

	
**After**

```
> /******/ 	// startup
> /******/ 	// Load entry module and return exports
> /******/ 	// This entry module depends on other loaded chunks and execution need to be delayed
> /******/ 	var __webpack_exports__ = __webpack_require__.O(undefined, ["vendors-node_modules_jquery_dist_jquery_js"], () => (__webpack_require__("./src/index.js")))
> /******/ 	__webpack_exports__ = Object.assign({...__webpack_exports__},{...__webpack_require__.O(__webpack_exports__)});
> /******/ 	__webpack_require__.O(undefined, ["vendors-node_modules_jquery_dist_jquery_js"], () => (__webpack_require__("./src/scriptB.js")))
> /******/ 	__webpack_exports__ = Object.assign({...__webpack_exports__},{...__webpack_require__.O(__webpack_exports__)});
> /******/ 	__webpack_require__.O(undefined, ["vendors-node_modules_jquery_dist_jquery_js"], () => (__webpack_require__("./src/scriptC.js")))
> /******/ 	__webpack_exports__ = Object.assign({...__webpack_exports__},{...__webpack_require__.O(__webpack_exports__)});
> /******/ 	__webpack_exports__ = __webpack_require__.O(__webpack_exports__);
> /******/ 	var __webpack_export_target__ = self;
> /******/ 	for(var __webpack_i__ in __webpack_exports__) __webpack_export_target__[__webpack_i__] = __webpack_exports__[__webpack_i__];
> /******/ 	if(__webpack_exports__.__esModule) Object.defineProperty(__webpack_export_target__, "__esModule", { value: true });
> /******/ 	
```

### 3) When there are Inline entry modules

In this case , i avoid writing the exports variable inside iife for inline entry modules, this way all the entry modules use the global exports variable and thus exports from all extry points would be available.



<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
yes i have added tests
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
No Breaking Change
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Since exports from all the entry points will be available, we have to update the document in places where it says only exports 
from last entry point will be available like [here](https://webpack.js.org/configuration/output/#outputlibrary).
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

I have never used AI for this PR, it took me literally a week to understand and come to this solution.

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->