### PR TITLE
fix: use variable `type` instead of constant `RBDT_RESOLVE_INITIAL`

### DIFF
--- a/.changeset/fix-resolve-initial-condition.md
+++ b/.changeset/fix-resolve-initial-condition.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix incorrect condition in FileSystemInfo that always evaluated to false, preventing trailing slash removal from directory paths during build dependency resolution.

--- a/lib/FileSystemInfo.js
+++ b/lib/FileSystemInfo.js
@@ -1805,7 +1805,9 @@ class FileSystemInfo {
 						break;
 					}
 					case RBDT_RESOLVE_DIRECTORY: {
-						resolveDirectory(RBDT_RESOLVE_INITIAL ? path.slice(0, -1) : path);
+						resolveDirectory(
+							type === RBDT_RESOLVE_INITIAL ? path.slice(0, -1) : path
+						);
 						break;
 					}
 					case RBDT_RESOLVE_CJS_FILE: {


### PR DESCRIPTION
**Summary**
Fix incorrect condition in FileSystemInfo that always evaluated to false, preventing trailing slash removal from directory paths during build dependency resolution.

**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
Existing

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing

**Use of AI**
Partial