### PR TITLE
fix: VirtualUrlPlugin absolute-path virtual module IDs getting concatenated with compiler context

### DIFF
--- a/.changeset/fix-virtual-url-plugin-absolute-path-context.md
+++ b/.changeset/fix-virtual-url-plugin-absolute-path-context.md
@@ -1,0 +1,7 @@
+---
+"webpack": patch
+---
+
+fix: VirtualUrlPlugin absolute path virtual module IDs getting concatenated with compiler context
+
+When a virtual module ID is an absolute path (e.g. `virtual:C:/project/user.js`), the auto-derived context was incorrectly joined with `compiler.context`, producing a concatenated path like `C:\cwd\C:\project`. Now absolute-path contexts are used directly.

--- a/lib/schemes/VirtualUrlPlugin.js
+++ b/lib/schemes/VirtualUrlPlugin.js
@@ -9,7 +9,7 @@ const { getContext } = require("loader-runner");
 
 const ModuleNotFoundError = require("../ModuleNotFoundError");
 const NormalModule = require("../NormalModule");
-const { join } = require("../util/fs");
+const { isAbsolute, join } = require("../util/fs");
 const { parseResourceWithoutFragment } = require("../util/identifier");
 
 const DEFAULT_SCHEME = "virtual";
@@ -190,15 +190,19 @@ class VirtualUrlPlugin {
 
 						if (context === "auto") {
 							const context = getContext(path);
-							resourceData.context =
-								context === path
-									? compiler.context
+							if (context === path) {
+								resourceData.context = compiler.context;
+							} else {
+								const resolvedContext = fromVid(context, scheme);
+								resourceData.context = isAbsolute(resolvedContext)
+									? resolvedContext
 									: join(
 											/** @type {import("..").InputFileSystem} */
 											(compiler.inputFileSystem),
 											compiler.context,
-											fromVid(context, scheme)
+											resolvedContext
 										);
+							}
 						} else if (context && typeof context === "string") {
 							resourceData.context = context;
 						} else {

--- a/test/configCases/plugins/virtual-url-plugin-absolute-context/helper.js
+++ b/test/configCases/plugins/virtual-url-plugin-absolute-context/helper.js
@@ -1,0 +1,1 @@
+export const value = "helper-value";

--- a/test/configCases/plugins/virtual-url-plugin-absolute-context/webpack.config.js
+++ b/test/configCases/plugins/virtual-url-plugin-absolute-context/webpack.config.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const path = require("path");
+const webpack = require("../../../../");
+
+const { VirtualUrlPlugin } = webpack.experiments.schemes;
+
+// The virtual module ID is an absolute path.
+// When context is "auto", the plugin should derive the context from that
+// absolute path directly, not concatenate it with compiler.context.
+const virtualModulePath = path.join(__dirname, "virtual-entry.js");
+
+/** @type {import("webpack").Configuration} */
+const config = {
+	entry: `virtual:${virtualModulePath}`,
+	plugins: [
+		new VirtualUrlPlugin({
+			[virtualModulePath]: {
+				context: "auto",
+				source() {
+					return "import { value } from './helper.js'; it('should resolve relative imports from absolute-path virtual modules', (done) => { expect(value).toBe('helper-value'); done(); });";
+				}
+			}
+		})
+	],
+	validate: true
+};
+
+module.exports = config;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
fixes https://github.com/webpack/webpack/issues/20421#issuecomment-4063800184

When a virtual module ID is an absolute path (e.g. `virtual:C:/project/user.js`), context "auto" incorrectly joined the derived context with `compiler.context` via `path.join`, producing a concatenated path like `C:\cwd\C:\project`. Now absolute contexts are detected via `isAbsolute` (from `lib/util/fs`) and used directly.

**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing

**Use of AI**
Partial