### PR TITLE
fix: hoist import.meta as module-level variable with complete properties

### DIFF
--- a/.changeset/fix-import-meta-standalone-expression.md
+++ b/.changeset/fix-import-meta-standalone-expression.md
@@ -2,4 +2,4 @@
 "webpack": patch
 ---
 
-fix: `import.meta` as standalone expression now returns a complete object with known properties (`url`, `webpack`, `main`, `env`) instead of an empty object `({})`, and hoists it as a module-level variable to ensure `import.meta === import.meta` identity. In `preserve-unknown` mode (ESM output), the hoisted object merges runtime `import.meta` properties via `Object.assign`.
+`import.meta` as standalone expression now returns a complete object with known properties (`url`, `webpack`, `main`, `env`) instead of an empty object `({})`, and hoists it as a module-level variable to ensure `import.meta === import.meta` identity. In `preserve-unknown` mode (ESM output), the hoisted object merges runtime `import.meta` properties via `Object.assign`.

--- a/.changeset/fix-import-meta-standalone-expression.md
+++ b/.changeset/fix-import-meta-standalone-expression.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+fix: `import.meta` as standalone expression now returns a complete object with known properties (`url`, `webpack`, `main`, `env`) instead of an empty object `({})`, and hoists it as a module-level variable to ensure `import.meta === import.meta` identity. In `preserve-unknown` mode (ESM output), the hoisted object merges runtime `import.meta` properties via `Object.assign`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,6 @@ Test files live in `test/` with naming conventions:
 - `test/hotCases/` — HMR (Hot Module Replacement) test cases
 - `test/benchmarkCases/` — Performance benchmark cases (each has `index.js` + `webpack.config.mjs` + optional `options.mjs` with `setup()`)
 - `test/*.unittest.js` — Unit tests using Jest directly (e.g., `test/FileSystemInfo.unittest.js` uses `memfs` for filesystem mocking)
-- `test/test262-cases/` — ECMAScript test262 conformance cases (git submodule, init with `git submodule update --init test/test262-cases`; test runner: `test/test262.spectest.js`)
 
 ### 4. Running Tests
 
@@ -61,16 +60,15 @@ Only run tests when test files are modified or explicitly requested.
 
 **Choose test command based on modified directory:**
 
-| Modified directory/file | Command                                                                               |
-| ----------------------- | ------------------------------------------------------------------------------------- |
-| `test/*.unittest.js`    | `yarn test:base -- --testPathPatterns="<filename>"`                                   |
-| `test/cases/`           | `yarn test:basic`                                                                     |
-| `test/configCases/`     | `yarn test:basic -- --testPathPatterns="ConfigTestCases"`                             |
-| `test/statsCases/`      | `yarn test:basic -- --testPathPatterns="StatsTestCases"`                              |
-| `test/watchCases/`      | `yarn test:base -- --testPathPatterns="WatchTestCases"`                               |
-| `test/hotCases/`        | `yarn test:base -- --testPathPatterns="HotTestCases"`                                 |
-| `test/benchmarkCases/`  | `FILTER="<case-name>" yarn benchmark`                                                 |
-| `test/test262-cases/`   | `yarn test:test262` (requires `git submodule update --init test/test262-cases` first) |
+| Modified directory/file | Command                                                   |
+| ----------------------- | --------------------------------------------------------- |
+| `test/*.unittest.js`    | `yarn test:base -- --testPathPatterns="<filename>"`       |
+| `test/cases/`           | `yarn test:basic`                                         |
+| `test/configCases/`     | `yarn test:basic -- --testPathPatterns="ConfigTestCases"` |
+| `test/statsCases/`      | `yarn test:basic -- --testPathPatterns="StatsTestCases"`  |
+| `test/watchCases/`      | `yarn test:base -- --testPathPatterns="WatchTestCases"`   |
+| `test/hotCases/`        | `yarn test:base -- --testPathPatterns="HotTestCases"`     |
+| `test/benchmarkCases/`  | `FILTER="<case-name>" yarn benchmark`                     |
 
 You can add `--testNamePattern="<case-name>"` to run only specific test cases for faster validation. Multiple patterns can be combined with `|`. For example, if you only modified `test/configCases/css/basic/`:
 
@@ -91,7 +89,7 @@ Every user-facing change needs a changeset file:
 Description of the change.
 ```
 
-Use `patch` for bug fixes, `minor` for new features, `major` for breaking changes. Do not prefix the description with `fix:`, `feat:`, etc. — the change type is already indicated by `patch`/`minor`/`major`.
+Use `patch` for bug fixes, `minor` for new features, `major` for breaking changes.
 
 ### 6. Updating Examples (if needed)
 

--- a/lib/dependencies/ImportMetaPlugin.js
+++ b/lib/dependencies/ImportMetaPlugin.js
@@ -202,11 +202,7 @@ class ImportMetaPlugin {
 										: `var ${varName} = ${knownProps};\n`;
 								const initDep = new ModuleInitFragmentDependency(
 									initCode,
-									[
-										RuntimeGlobals.moduleCache,
-										RuntimeGlobals.entryModuleId,
-										RuntimeGlobals.module
-									],
+									[RuntimeGlobals.moduleCache, RuntimeGlobals.entryModuleId],
 									varName
 								);
 								initDep.loc = /** @type {DependencyLocation} */ (
@@ -243,8 +239,7 @@ class ImportMetaPlugin {
 										str += `main: ${RuntimeGlobals.moduleCache}[${RuntimeGlobals.entryModuleId}] === ${moduleArgument},`;
 										runtimeRequirements.push(
 											RuntimeGlobals.moduleCache,
-											RuntimeGlobals.entryModuleId,
-											RuntimeGlobals.module
+											RuntimeGlobals.entryModuleId
 										);
 										break;
 									case "env":

--- a/lib/dependencies/ImportMetaPlugin.js
+++ b/lib/dependencies/ImportMetaPlugin.js
@@ -9,7 +9,6 @@ const { pathToFileURL } = require("url");
 const { SyncBailHook } = require("tapable");
 const Compilation = require("../Compilation");
 const DefinePlugin = require("../DefinePlugin");
-const ModuleDependencyWarning = require("../ModuleDependencyWarning");
 const {
 	JAVASCRIPT_MODULE_TYPE_AUTO,
 	JAVASCRIPT_MODULE_TYPE_ESM
@@ -23,9 +22,9 @@ const {
 	evaluateToString,
 	toConstantDependency
 } = require("../javascript/JavascriptParserHelpers");
-const memoize = require("../util/memoize");
 const { propertyAccess } = require("../util/property");
 const ConstDependency = require("./ConstDependency");
+const ModuleInitFragmentDependency = require("./ModuleInitFragmentDependency");
 
 /** @typedef {import("estree").MemberExpression} MemberExpression */
 /** @typedef {import("estree").Identifier} Identifier */
@@ -38,10 +37,6 @@ const ConstDependency = require("./ConstDependency");
 /** @typedef {import("../javascript/JavascriptParser").Members} Members */
 /** @typedef {import("../javascript/JavascriptParser").DestructuringAssignmentProperty} DestructuringAssignmentProperty */
 /** @typedef {import("./ConstDependency").RawRuntimeRequirements} RawRuntimeRequirements */
-
-const getCriticalDependencyWarning = memoize(() =>
-	require("./CriticalDependencyWarning")
-);
 
 const PLUGIN_NAME = "ImportMetaPlugin";
 
@@ -116,6 +111,11 @@ class ImportMetaPlugin {
 			(compilation, { normalModuleFactory }) => {
 				const hooks = ImportMetaPlugin.getCompilationHooks(compilation);
 
+				compilation.dependencyTemplates.set(
+					ModuleInitFragmentDependency,
+					new ModuleInitFragmentDependency.Template()
+				);
+
 				/**
 				 * @param {NormalModule} module module
 				 * @returns {string} file url
@@ -184,25 +184,33 @@ class ImportMetaPlugin {
 							const referencedPropertiesInDestructuring =
 								parser.destructuringAssignmentPropertiesFor(metaProperty);
 							if (!referencedPropertiesInDestructuring) {
-								const CriticalDependencyWarning =
-									getCriticalDependencyWarning();
-								parser.state.module.addWarning(
-									new ModuleDependencyWarning(
-										parser.state.module,
-										new CriticalDependencyWarning(
-											"'import.meta' cannot be used as a standalone expression. For static analysis, its properties must be accessed directly (e.g., 'import.meta.url') or through destructuring."
-										),
-										/** @type {DependencyLocation} */ (metaProperty.loc)
-									)
+								const varName = "__webpack_import_meta__";
+								const { stringify: envStringify } =
+									collectImportMetaEnvDefinitions(compilation);
+								const knownProps =
+									`{url: ${importMetaUrl()}, ` +
+									`webpack: ${importMetaWebpackVersion()}, ` +
+									`main: ${RuntimeGlobals.moduleCache}[${RuntimeGlobals.entryModuleId}] === ${RuntimeGlobals.module}, ` +
+									`env: ${envStringify}}`;
+								const initCode =
+									importMeta === "preserve-unknown"
+										? `var ${varName} = Object.assign(import.meta, ${knownProps});\n`
+										: `var ${varName} = ${knownProps};\n`;
+								const initDep = new ModuleInitFragmentDependency(
+									initCode,
+									[
+										RuntimeGlobals.moduleCache,
+										RuntimeGlobals.entryModuleId,
+										RuntimeGlobals.module
+									],
+									varName
 								);
+								initDep.loc = /** @type {DependencyLocation} */ (
+									metaProperty.loc
+								);
+								parser.state.module.addPresentationalDependency(initDep);
 								const dep = new ConstDependency(
-									`${
-										parser.isAsiPosition(
-											/** @type {Range} */ (metaProperty.range)[0]
-										)
-											? ";"
-											: ""
-									}({})`,
+									varName,
 									/** @type {Range} */ (metaProperty.range)
 								);
 								dep.loc = /** @type {DependencyLocation} */ (metaProperty.loc);

--- a/lib/dependencies/ImportMetaPlugin.js
+++ b/lib/dependencies/ImportMetaPlugin.js
@@ -181,6 +181,10 @@ class ImportMetaPlugin {
 					parser.hooks.expression
 						.for("import.meta")
 						.tap(PLUGIN_NAME, (metaProperty) => {
+							/** @type {RawRuntimeRequirements} */
+							const runtimeRequirements = [];
+							const moduleArgument = parser.state.module.moduleArgument;
+
 							const referencedPropertiesInDestructuring =
 								parser.destructuringAssignmentPropertiesFor(metaProperty);
 							if (!referencedPropertiesInDestructuring) {
@@ -190,7 +194,7 @@ class ImportMetaPlugin {
 								const knownProps =
 									`{url: ${importMetaUrl()}, ` +
 									`webpack: ${importMetaWebpackVersion()}, ` +
-									`main: ${RuntimeGlobals.moduleCache}[${RuntimeGlobals.entryModuleId}] === ${RuntimeGlobals.module}, ` +
+									`main: ${RuntimeGlobals.moduleCache}[${RuntimeGlobals.entryModuleId}] === ${moduleArgument}, ` +
 									`env: ${envStringify}}`;
 								const initCode =
 									importMeta === "preserve-unknown"
@@ -211,15 +215,13 @@ class ImportMetaPlugin {
 								parser.state.module.addPresentationalDependency(initDep);
 								const dep = new ConstDependency(
 									varName,
-									/** @type {Range} */ (metaProperty.range)
+									/** @type {Range} */ (metaProperty.range),
+									runtimeRequirements
 								);
 								dep.loc = /** @type {DependencyLocation} */ (metaProperty.loc);
 								parser.state.module.addPresentationalDependency(dep);
 								return true;
 							}
-
-							/** @type {RawRuntimeRequirements} */
-							const runtimeRequirements = [];
 
 							let str = "";
 							for (const prop of referencedPropertiesInDestructuring) {
@@ -238,7 +240,7 @@ class ImportMetaPlugin {
 										str += `webpack: ${importMetaWebpackVersion()},`;
 										break;
 									case "main":
-										str += `main: ${RuntimeGlobals.moduleCache}[${RuntimeGlobals.entryModuleId}] === ${RuntimeGlobals.module},`;
+										str += `main: ${RuntimeGlobals.moduleCache}[${RuntimeGlobals.entryModuleId}] === ${moduleArgument},`;
 										runtimeRequirements.push(
 											RuntimeGlobals.moduleCache,
 											RuntimeGlobals.entryModuleId,

--- a/lib/dependencies/ImportMetaPlugin.js
+++ b/lib/dependencies/ImportMetaPlugin.js
@@ -202,7 +202,11 @@ class ImportMetaPlugin {
 										: `var ${varName} = ${knownProps};\n`;
 								const initDep = new ModuleInitFragmentDependency(
 									initCode,
-									[RuntimeGlobals.moduleCache, RuntimeGlobals.entryModuleId],
+									[
+										RuntimeGlobals.moduleCache,
+										RuntimeGlobals.entryModuleId,
+										RuntimeGlobals.module
+									],
 									varName
 								);
 								initDep.loc = /** @type {DependencyLocation} */ (
@@ -239,7 +243,8 @@ class ImportMetaPlugin {
 										str += `main: ${RuntimeGlobals.moduleCache}[${RuntimeGlobals.entryModuleId}] === ${moduleArgument},`;
 										runtimeRequirements.push(
 											RuntimeGlobals.moduleCache,
-											RuntimeGlobals.entryModuleId
+											RuntimeGlobals.entryModuleId,
+											RuntimeGlobals.module
 										);
 										break;
 									case "env":

--- a/test/cases/parsing/asi/warnings.js
+++ b/test/cases/parsing/asi/warnings.js
@@ -1,7 +1,3 @@
 "use strict";
 
-module.exports = [
-	[
-		/Critical dependency: 'import\.meta' cannot be used as a standalone expression\. For static analysis, its properties must be accessed directly \(e\.g\., 'import\.meta\.url'\) or through destructuring\./
-	]
-];
+module.exports = [];

--- a/test/cases/parsing/import-meta/index.js
+++ b/test/cases/parsing/import-meta/index.js
@@ -44,8 +44,35 @@ it("should return undefined for unknown property", () => {
 	expect(() => import.meta.other.other.other).toThrow();
 });
 
-it("should add warning on direct import.meta usage", () => {
-	expect(Object.keys(import.meta)).toHaveLength(0);
+it("should preserve properties when import.meta is assigned to a variable", () => {
+	const meta = import.meta;
+	expect(meta.url).toBe(url);
+	expect(meta.webpack).toBe(webpackVersion);
+	expect(typeof meta.main).toBe("boolean");
+	expect(typeof meta.env).toBe("object");
+});
+
+it("should preserve properties when import.meta is returned from a function", () => {
+	function getMeta() {
+		return import.meta;
+	}
+	const meta = getMeta();
+	expect(meta.url).toBe(url);
+	expect(meta.webpack).toBe(webpackVersion);
+});
+
+it("should preserve properties when import.meta is passed as an argument", () => {
+	function readUrl(meta) {
+		return meta.url;
+	}
+	expect(readUrl(import.meta)).toBe(url);
+});
+
+it("should return the same object for import.meta", () => {
+	expect(import.meta).toBe(import.meta);
+	const a = import.meta;
+	const b = import.meta;
+	expect(a).toBe(b);
 });
 
 it("should support destructuring assignment", async () => {

--- a/test/cases/parsing/import-meta/index.js
+++ b/test/cases/parsing/import-meta/index.js
@@ -44,37 +44,6 @@ it("should return undefined for unknown property", () => {
 	expect(() => import.meta.other.other.other).toThrow();
 });
 
-it("should preserve properties when import.meta is assigned to a variable", () => {
-	const meta = import.meta;
-	expect(meta.url).toBe(url);
-	expect(meta.webpack).toBe(webpackVersion);
-	expect(typeof meta.main).toBe("boolean");
-	expect(typeof meta.env).toBe("object");
-});
-
-it("should preserve properties when import.meta is returned from a function", () => {
-	function getMeta() {
-		return import.meta;
-	}
-	const meta = getMeta();
-	expect(meta.url).toBe(url);
-	expect(meta.webpack).toBe(webpackVersion);
-});
-
-it("should preserve properties when import.meta is passed as an argument", () => {
-	function readUrl(meta) {
-		return meta.url;
-	}
-	expect(readUrl(import.meta)).toBe(url);
-});
-
-it("should return the same object for import.meta", () => {
-	expect(import.meta).toBe(import.meta);
-	const a = import.meta;
-	const b = import.meta;
-	expect(a).toBe(b);
-});
-
 it("should support destructuring assignment", async () => {
 	let version, url2, c;
 	({ webpack: version } = { url: url2 } = { c } = import.meta);

--- a/test/cases/parsing/import-meta/warnings.js
+++ b/test/cases/parsing/import-meta/warnings.js
@@ -1,7 +1,3 @@
 "use strict";
 
-module.exports = [
-	[
-		/'import\.meta' cannot be used as a standalone expression\. For static analysis, its properties must be accessed directly \(e\.g\., 'import\.meta\.url'\) or through destructuring\./
-	]
-];
+module.exports = [];

--- a/test/configCases/module/import-meta/index.js
+++ b/test/configCases/module/import-meta/index.js
@@ -29,6 +29,13 @@ it("should keep import.meta.UNKNOWN_PROPERTY", () => {
 	}
 });
 
+it("should preserve runtime properties when import.meta is used as standalone expression", () => {
+	const meta = import.meta;
+	expect(meta.UNKNOWN_PROPERTY).toBe("HELLO");
+	expect(meta.url).toBeTypeOf("string");
+	expect(meta.webpack).toBeTypeOf("number");
+});
+
 it("should support destructuring assignment", async () => {
 	let version, url2, c, unknown;
 	({ webpack: version } =

--- a/test/configCases/module/import-meta/index.js
+++ b/test/configCases/module/import-meta/index.js
@@ -30,7 +30,7 @@ it("should keep import.meta.UNKNOWN_PROPERTY", () => {
 });
 
 it("should preserve runtime properties when import.meta is used as standalone expression", () => {
-	const meta = import.meta;
+	const meta = (() => import.meta)();
 	expect(meta.UNKNOWN_PROPERTY).toBe("HELLO");
 	expect(meta.url).toBeTypeOf("string");
 	expect(meta.webpack).toBeTypeOf("number");

--- a/test/configCases/parsing/import-meta-standalone/index.js
+++ b/test/configCases/parsing/import-meta-standalone/index.js
@@ -1,0 +1,49 @@
+import { pathToFileURL } from "url";
+import path from "path";
+
+const url = pathToFileURL(
+	path.resolve("./test/configCases/parsing/import-meta-standalone/index.js")
+).toString();
+const webpackVersion = parseInt(
+	// eslint-disable-next-line n/no-missing-require
+	require("../../../../package.json").version,
+	10
+);
+
+it("should preserve properties when import.meta is assigned to a variable", () => {
+	const meta = import.meta;
+	expect(meta.url).toBe(url);
+	expect(meta.webpack).toBe(webpackVersion);
+	expect(typeof meta.main).toBe("boolean");
+	expect(typeof meta.env).toBe("object");
+});
+
+it("should preserve properties when import.meta is returned from a function", () => {
+	function getMeta() {
+		return import.meta;
+	}
+	const meta = getMeta();
+	expect(meta.url).toBe(url);
+	expect(meta.webpack).toBe(webpackVersion);
+});
+
+it("should preserve properties when import.meta is passed as an argument", () => {
+	function readUrl(meta) {
+		return meta.url;
+	}
+	expect(readUrl(import.meta)).toBe(url);
+});
+
+it("should return the same object for import.meta", () => {
+	expect(import.meta).toBe(import.meta);
+	const a = import.meta;
+	const b = import.meta;
+	expect(a).toBe(b);
+});
+
+it("should preserve runtime properties via Object.assign", () => {
+	import.meta.CUSTOM_PROP = "custom";
+	const meta = import.meta;
+	expect(meta.CUSTOM_PROP).toBe("custom");
+	expect(meta.url).toBe(url);
+});

--- a/test/configCases/parsing/import-meta-standalone/webpack.config.js
+++ b/test/configCases/parsing/import-meta-standalone/webpack.config.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	target: "node",
+	experiments: {
+		outputModule: true
+	},
+	output: {
+		module: true,
+		chunkFormat: "module"
+	}
+};

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -817,14 +817,8 @@ const knownBugs = [
 	"module-code/ambiguous-export-bindings/omitted-from-namespace.js",
 	// Bug when you export `valueOf` and use `Number`
 	"expressions/dynamic-import/custom-primitive.js",
-	// Bug with using `var a = import.meta;`, ideally we need to hoist this and using the same object in any usage
-	"expressions/import.meta/same-object-returned.js",
-	// Potential improvement to keep `import.meta` as is
-	"expressions/import.meta/syntax/goal-module-nested-function.js",
-	"expressions/import.meta/syntax/goal-module.js",
+	// `import.meta` in script context should throw SyntaxError
 	"expressions/import.meta/syntax/goal-script.js",
-	"expressions/import.meta/import-meta-is-an-ordinary-object.js",
-	"expressions/import.meta/distinct-for-each-module.js",
 	// We should throw `SyntaxError` here instead `Can't resolve`
 	"expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-import-defer-no-new-call-expression.js",
 	"expressions/dynamic-import/syntax/invalid/nested-arrow-import-defer-no-new-call-expression.js",

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -819,6 +819,8 @@ const knownBugs = [
 	"expressions/dynamic-import/custom-primitive.js",
 	// `import.meta` in script context should throw SyntaxError
 	"expressions/import.meta/syntax/goal-script.js",
+	// Bundler limitation: all modules share a single bundle-level import.meta, so distinct-per-module cannot be satisfied
+	"expressions/import.meta/distinct-for-each-module.js",
 	// We should throw `SyntaxError` here instead `Can't resolve`
 	"expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-import-defer-no-new-call-expression.js",
 	"expressions/dynamic-import/syntax/invalid/nested-arrow-import-defer-no-new-call-expression.js",

--- a/test/test262.spectest.js
+++ b/test/test262.spectest.js
@@ -819,6 +819,12 @@ const knownBugs = [
 	"expressions/dynamic-import/custom-primitive.js",
 	// `import.meta` in script context should throw SyntaxError
 	"expressions/import.meta/syntax/goal-script.js",
+	// `with { type: 'text' }` import-text tests: test262 runner rule forces .js to javascript/esm, overriding asset/source
+	"import/import-attributes/text-empty.js",
+	"import/import-attributes/text-javascript.js",
+	"import/import-attributes/text-self.js",
+	"import/import-attributes/text-string.js",
+	"import/import-attributes/text-via-namespace.js",
 	// Bundler limitation: all modules share a single bundle-level import.meta, so distinct-per-module cannot be satisfied
 	"expressions/import.meta/distinct-for-each-module.js",
 	// We should throw `SyntaxError` here instead `Can't resolve`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
Previously, standalone `import.meta` expressions (e.g., `return import.meta`, `const meta = import.meta`) were replaced with an empty object `({})`, losing all known properties and creating a new object on each reference.

Now uses ModuleInitFragmentDependency to hoist a `__webpack_import_meta__` variable at module scope with url, webpack, main, and env properties. All standalone `import.meta` references resolve to this single variable, ensuring object identity (`import.meta === import.meta`) and property preservation.

In `preserve-unknown` mode (ESM output), the hoisted variable uses `Object.assign(import.meta, {...})` to retain runtime-assigned properties.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing