### PR TITLE
fix: replace uninformative TODO error in CommonJsExportRequireDependency with descriptive message

### DIFF
--- a/.changeset/fix-commonjs-export-require-define-property.md
+++ b/.changeset/fix-commonjs-export-require-define-property.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Replace uninformative `throw new Error("TODO")` in `CommonJsExportRequireDependency.Template` with a descriptive error message. The `Object.defineProperty` case appears unreachable as the parser never creates a `CommonJsExportRequireDependency` with that base, but the error now clearly identifies the unsupported case if it is ever reached.

--- a/lib/dependencies/CommonJsExportRequireDependency.js
+++ b/lib/dependencies/CommonJsExportRequireDependency.js
@@ -405,7 +405,9 @@ CommonJsExportRequireDependency.Template = class CommonJsExportRequireDependency
 				);
 				return;
 			case "Object.defineProperty":
-				throw new Error("TODO");
+				throw new Error(
+					"Object.defineProperty is not supported as base for CommonJsExportRequireDependency"
+				);
 			default:
 				throw new Error("Unexpected type");
 		}


### PR DESCRIPTION
**Summary**

While investigating the `throw new Error("TODO")` in `CommonJsExportRequireDependency.Template`, I traced the parser code and found this case appears to be unreachable: the parser never creates a `CommonJsExportRequireDependency` with an `Object.defineProperty` base. The `Object.defineProperty` hook in `CommonJsExportsParserPlugin` intercepts those calls, creates a `CommonJsExportsDependency` instead, and returns `true` before `handleAssignExport` ever sees them.

This PR replaces the silent `throw new Error("TODO")` with a descriptive error message so that if this case is ever reached through a future code path, the failure is immediately understandable rather than cryptic.

Opened #20663 to discuss whether the case should be removed entirely.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

No, the code path appears unreachable based on the current parser implementation, so a meaningful test cannot be written to trigger it without modifying the parser. This is documented in #20663.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged?**

Nothing, this is an internal error message improvement with no public API impact.

**Use of AI**

I used Claude as a reference while navigating the codebase. The investigation, analysis, and decisions are my own.