### PR TITLE
feat(VirtualUrlPlugin): allow loaders to register virtual modules dyn…

### DIFF
--- a/.changeset/virtual-url-plugin-loader-registration.md
+++ b/.changeset/virtual-url-plugin-loader-registration.md
@@ -1,0 +1,26 @@
+---
+"webpack": minor
+---
+
+Add `VirtualUrlPlugin.getPlugin()` static method and `addModule()` instance method to allow loaders to register virtual modules dynamically without requiring a pre-configured plugin in `webpack.config.js`.
+
+Previously, calling `new VirtualUrlPlugin(...).apply(compiler)` from a loader had no effect because the plugin's `compiler.hooks.compilation` tap fired too late—the compilation was already in progress. Now, `apply()` detects an in-progress compilation via `compiler._lastCompilation` and immediately sets up scheme-handling hooks for it.
+
+**New API:**
+
+```js
+// In a loader — no VirtualUrlPlugin needed in webpack.config.js
+const { VirtualUrlPlugin } = require("webpack").experiments.schemes;
+
+module.exports = function myLoader(content) {
+	let plugin = VirtualUrlPlugin.getPlugin(this._compiler);
+	if (!plugin) {
+		plugin = new VirtualUrlPlugin({});
+		plugin.apply(this._compiler);
+	}
+	plugin.addModule("my-module.js", `export const value = 42;`);
+	return `export { value } from "virtual:my-module.js";`;
+};
+```
+
+`addModule(id, config)` accepts the same content formats as the `modules` constructor option (string, function, or `VirtualModule` object), with or without the `virtual:` prefix.

--- a/lib/schemes/VirtualUrlPlugin.js
+++ b/lib/schemes/VirtualUrlPlugin.js
@@ -17,6 +17,13 @@ const DEFAULT_SCHEME = "virtual";
 const PLUGIN_NAME = "VirtualUrlPlugin";
 
 /**
+ * Maps compiler instances to their registered VirtualUrlPlugin instances (per scheme).
+ * Enables cross-loader access via VirtualUrlPlugin.getPlugin(compiler).
+ * @type {WeakMap<import("../Compiler"), Map<string, VirtualUrlPlugin>>}
+ */
+const schemePluginMap = new WeakMap();
+
+/**
  * @typedef {import("../Compiler")} Compiler
  * @typedef {import("../../declarations/plugins/schemes/VirtualUrlPlugin").VirtualModule} VirtualModuleConfig
  * @typedef {import("../../declarations/plugins/schemes/VirtualUrlPlugin").VirtualModuleContent} VirtualModuleInput
@@ -124,11 +131,168 @@ class VirtualUrlPlugin {
 	}
 
 	/**
+	 * Add a virtual module dynamically. Can be called after the plugin has been applied,
+	 * including from within a loader. Modules added this way are available to all
+	 * subsequent module resolutions in the current compilation.
+	 * @param {string} id The module id (e.g. "username.js" or "virtual:username.js")
+	 * @param {VirtualModuleInput} moduleConfig The virtual module content or configuration
+	 * @returns {void}
+	 */
+	addModule(id, moduleConfig) {
+		const vid = id.startsWith(`${this.scheme}:`) ? id : toVid(id, this.scheme);
+		this.modules[vid] = normalizeModule(moduleConfig);
+	}
+
+	/**
+	 * Get the VirtualUrlPlugin instance registered for a scheme on a compiler.
+	 * Use this from loaders to access or add virtual modules without needing a
+	 * pre-registered plugin in the webpack config.
+	 * @param {Compiler} compiler The compiler instance (available as `this._compiler` in loaders)
+	 * @param {string=} scheme The URL scheme (defaults to "virtual")
+	 * @returns {VirtualUrlPlugin | undefined} The plugin instance, or undefined if not registered
+	 */
+	static getPlugin(compiler, scheme) {
+		const map = schemePluginMap.get(compiler);
+		if (!map) return undefined;
+		return map.get(scheme || DEFAULT_SCHEME);
+	}
+
+	/**
+	 * Set up scheme-handling hooks on a specific compilation. Extracted so it can
+	 * be called both from the `compiler.hooks.compilation` callback (for compilations
+	 * that start after apply() is called) and immediately (for an already-in-progress
+	 * compilation when apply() is called from a loader).
+	 * @param {import("../Compilation")} compilation the compilation instance
+	 * @param {import("../NormalModuleFactory")} normalModuleFactory the normal module factory
+	 * @param {Compiler} compiler the compiler instance
+	 * @param {ReturnType<typeof parseResourceWithoutFragment.bindCache>} cachedParseResourceWithoutFragment cached resource parser
+	 * @returns {void}
+	 */
+	_setupCompilationHooks(
+		compilation,
+		normalModuleFactory,
+		compiler,
+		cachedParseResourceWithoutFragment
+	) {
+		const scheme = this.scheme;
+
+		compilation.hooks.assetPath.tap(
+			{ name: PLUGIN_NAME, before: "TemplatedPathPlugin" },
+			(path, data) => {
+				if (data.filename && this.modules[data.filename]) {
+					/**
+					 * @param {string} str path
+					 * @returns {string} safe path
+					 */
+					const toSafePath = (str) =>
+						`__${str
+							.replace(/:/g, "__")
+							.replace(/^[^a-z0-9]+|[^a-z0-9]+$/gi, "")
+							.replace(/[^a-z0-9._-]+/gi, "_")}`;
+
+					// filename: virtual:logo.svg -> __virtual__logo.svg
+					data.filename = toSafePath(data.filename);
+				}
+				return path;
+			}
+		);
+
+		normalModuleFactory.hooks.resolveForScheme
+			.for(scheme)
+			.tap(PLUGIN_NAME, (resourceData) => {
+				const virtualConfig = this.findVirtualModuleConfigById(
+					resourceData.resource
+				);
+				const url = cachedParseResourceWithoutFragment(resourceData.resource);
+				const path = url.path;
+				const type = virtualConfig.type || "";
+				const context = virtualConfig.context || this.context;
+
+				resourceData.path = path + type;
+				resourceData.resource = path;
+
+				if (context === "auto") {
+					const context = getContext(path);
+					if (context === path) {
+						resourceData.context = compiler.context;
+					} else {
+						const resolvedContext = fromVid(context, scheme);
+						resourceData.context = isAbsolute(resolvedContext)
+							? resolvedContext
+							: join(
+									/** @type {import("..").InputFileSystem} */
+									(compiler.inputFileSystem),
+									compiler.context,
+									resolvedContext
+								);
+					}
+				} else if (context && typeof context === "string") {
+					resourceData.context = context;
+				} else {
+					resourceData.context = compiler.context;
+				}
+
+				if (virtualConfig.version) {
+					const cacheKey = toCacheKey(resourceData.resource, scheme);
+					const cacheVersion = this.getCacheVersion(virtualConfig.version);
+					compilation.valueCacheVersions.set(
+						cacheKey,
+						/** @type {string} */ (cacheVersion)
+					);
+				}
+
+				return true;
+			});
+
+		const hooks = NormalModule.getCompilationHooks(compilation);
+		hooks.readResource
+			.for(scheme)
+			.tapAsync(PLUGIN_NAME, async (loaderContext, callback) => {
+				const { resourcePath } = loaderContext;
+				const module = /** @type {NormalModule} */ (loaderContext._module);
+				const cacheKey = toCacheKey(resourcePath, scheme);
+
+				const addVersionValueDependency = () => {
+					if (!module || !module.buildInfo) return;
+
+					const buildInfo = module.buildInfo;
+					if (!buildInfo.valueDependencies) {
+						buildInfo.valueDependencies = new Map();
+					}
+
+					const cacheVersion = compilation.valueCacheVersions.get(cacheKey);
+					if (compilation.valueCacheVersions.has(cacheKey)) {
+						buildInfo.valueDependencies.set(
+							cacheKey,
+							/** @type {string} */ (cacheVersion)
+						);
+					}
+				};
+
+				try {
+					const virtualConfig = this.findVirtualModuleConfigById(resourcePath);
+					const content = await virtualConfig.source(loaderContext);
+					addVersionValueDependency();
+					callback(null, content);
+				} catch (err) {
+					callback(/** @type {Error} */ (err));
+				}
+			});
+	}
+
+	/**
 	 * Apply the plugin
 	 * @param {Compiler} compiler the compiler instance
 	 * @returns {void}
 	 */
 	apply(compiler) {
+		// Register this instance so loaders can retrieve it via VirtualUrlPlugin.getPlugin(compiler)
+		if (!schemePluginMap.has(compiler)) {
+			schemePluginMap.set(compiler, new Map());
+		}
+		/** @type {Map<string, VirtualUrlPlugin>} */
+		(schemePluginMap.get(compiler)).set(this.scheme, this);
+
 		compiler.hooks.validate.tap(PLUGIN_NAME, () => {
 			compiler.validate(
 				() => require("../../schemas/plugins/schemes/VirtualUrlPlugin.json"),
@@ -144,120 +308,32 @@ class VirtualUrlPlugin {
 			);
 		});
 
-		const scheme = this.scheme;
 		const cachedParseResourceWithoutFragment =
 			parseResourceWithoutFragment.bindCache(compiler.root);
 
 		compiler.hooks.compilation.tap(
 			PLUGIN_NAME,
 			(compilation, { normalModuleFactory }) => {
-				compilation.hooks.assetPath.tap(
-					{ name: PLUGIN_NAME, before: "TemplatedPathPlugin" },
-					(path, data) => {
-						if (data.filename && this.modules[data.filename]) {
-							/**
-							 * @param {string} str path
-							 * @returns {string} safe path
-							 */
-							const toSafePath = (str) =>
-								`__${str
-									.replace(/:/g, "__")
-									.replace(/^[^a-z0-9]+|[^a-z0-9]+$/gi, "")
-									.replace(/[^a-z0-9._-]+/gi, "_")}`;
-
-							// filename: virtual:logo.svg -> __virtual__logo.svg
-							data.filename = toSafePath(data.filename);
-						}
-						return path;
-					}
+				this._setupCompilationHooks(
+					compilation,
+					normalModuleFactory,
+					compiler,
+					cachedParseResourceWithoutFragment
 				);
-
-				normalModuleFactory.hooks.resolveForScheme
-					.for(scheme)
-					.tap(PLUGIN_NAME, (resourceData) => {
-						const virtualConfig = this.findVirtualModuleConfigById(
-							resourceData.resource
-						);
-						const url = cachedParseResourceWithoutFragment(
-							resourceData.resource
-						);
-						const path = url.path;
-						const type = virtualConfig.type || "";
-						const context = virtualConfig.context || this.context;
-
-						resourceData.path = path + type;
-						resourceData.resource = path;
-
-						if (context === "auto") {
-							const context = getContext(path);
-							if (context === path) {
-								resourceData.context = compiler.context;
-							} else {
-								const resolvedContext = fromVid(context, scheme);
-								resourceData.context = isAbsolute(resolvedContext)
-									? resolvedContext
-									: join(
-											/** @type {import("..").InputFileSystem} */
-											(compiler.inputFileSystem),
-											compiler.context,
-											resolvedContext
-										);
-							}
-						} else if (context && typeof context === "string") {
-							resourceData.context = context;
-						} else {
-							resourceData.context = compiler.context;
-						}
-
-						if (virtualConfig.version) {
-							const cacheKey = toCacheKey(resourceData.resource, scheme);
-							const cacheVersion = this.getCacheVersion(virtualConfig.version);
-							compilation.valueCacheVersions.set(
-								cacheKey,
-								/** @type {string} */ (cacheVersion)
-							);
-						}
-
-						return true;
-					});
-
-				const hooks = NormalModule.getCompilationHooks(compilation);
-				hooks.readResource
-					.for(scheme)
-					.tapAsync(PLUGIN_NAME, async (loaderContext, callback) => {
-						const { resourcePath } = loaderContext;
-						const module = /** @type {NormalModule} */ (loaderContext._module);
-						const cacheKey = toCacheKey(resourcePath, scheme);
-
-						const addVersionValueDependency = () => {
-							if (!module || !module.buildInfo) return;
-
-							const buildInfo = module.buildInfo;
-							if (!buildInfo.valueDependencies) {
-								buildInfo.valueDependencies = new Map();
-							}
-
-							const cacheVersion = compilation.valueCacheVersions.get(cacheKey);
-							if (compilation.valueCacheVersions.has(cacheKey)) {
-								buildInfo.valueDependencies.set(
-									cacheKey,
-									/** @type {string} */ (cacheVersion)
-								);
-							}
-						};
-
-						try {
-							const virtualConfig =
-								this.findVirtualModuleConfigById(resourcePath);
-							const content = await virtualConfig.source(loaderContext);
-							addVersionValueDependency();
-							callback(null, content);
-						} catch (err) {
-							callback(/** @type {Error} */ (err));
-						}
-					});
 			}
 		);
+
+		// If apply() is called while a compilation is already in progress (e.g. from a loader),
+		// tap into the current compilation immediately so that virtual modules registered now
+		// are resolved when subsequent imports are processed.
+		if (compiler._lastCompilation && compiler._lastNormalModuleFactory) {
+			this._setupCompilationHooks(
+				compiler._lastCompilation,
+				compiler._lastNormalModuleFactory,
+				compiler,
+				cachedParseResourceWithoutFragment
+			);
+		}
 	}
 
 	/**

--- a/test/configCases/plugins/virtual-url-plugin-from-loader/index.js
+++ b/test/configCases/plugins/virtual-url-plugin-from-loader/index.js
@@ -1,0 +1,9 @@
+import { a, b } from "./source.js";
+
+it("should load a virtual module registered by a loader (no pre-existing plugin)", () => {
+	expect(a).toBe("registered-by-loader-a");
+});
+
+it("should load a virtual module registered by a different loader (cross-loader getPlugin access)", () => {
+	expect(b).toBe("registered-by-loader-b");
+});

--- a/test/configCases/plugins/virtual-url-plugin-from-loader/loader-a.js
+++ b/test/configCases/plugins/virtual-url-plugin-from-loader/loader-a.js
@@ -1,0 +1,34 @@
+"use strict";
+
+/**
+ * Loader A — runs second in the chain (right-to-left).
+ *
+ * Demonstrates cross-loader access: uses VirtualUrlPlugin.getPlugin() to retrieve
+ * the plugin instance created by loader-b, adds its own virtual module, then
+ * returns an export that imports from both virtual modules.
+ */
+const webpack = require("../../../../");
+
+const { VirtualUrlPlugin } = webpack.experiments.schemes;
+
+/** @this {import("../../../../").LoaderContext<{}>} */
+module.exports = function loaderA(content) {
+	// Cross-loader access: retrieve the plugin created by loader-b.
+	const plugin = VirtualUrlPlugin.getPlugin(this._compiler);
+	if (!plugin) {
+		throw new Error(
+			"VirtualUrlPlugin not found — loader-b should have created it"
+		);
+	}
+
+	// Add another virtual module from this loader.
+	plugin.addModule("module-a.js", `export const a = "registered-by-loader-a";`);
+
+	// Return a module that imports from both virtual modules (one registered by
+	// each loader). Resolution of these imports happens after all loaders finish,
+	// by which point both modules are in the plugin's registry.
+	return `
+export { a } from "virtual:module-a.js";
+export { b } from "virtual:module-b.js";
+`;
+};

--- a/test/configCases/plugins/virtual-url-plugin-from-loader/loader-b.js
+++ b/test/configCases/plugins/virtual-url-plugin-from-loader/loader-b.js
@@ -1,0 +1,31 @@
+"use strict";
+
+/**
+ * Loader B — runs first in the chain (right-to-left).
+ *
+ * Demonstrates creating a VirtualUrlPlugin from scratch mid-compilation and
+ * registering a virtual module. The plugin is applied to the already-in-progress
+ * compilation so subsequent module resolutions can use the "virtual:" scheme.
+ */
+const webpack = require("../../../../");
+
+const { VirtualUrlPlugin } = webpack.experiments.schemes;
+
+/** @this {import("../../../../").LoaderContext<{}>} */
+module.exports = function loaderB(content) {
+	// Create and apply a VirtualUrlPlugin if one isn't already registered.
+	// After this call, resolveForScheme.for("virtual") is hooked into the
+	// current compilation even though the compilation has already started.
+	let plugin = VirtualUrlPlugin.getPlugin(this._compiler);
+	if (!plugin) {
+		plugin = new VirtualUrlPlugin({});
+		plugin.apply(this._compiler);
+	}
+
+	// Register a virtual module from this loader.
+	// Loader-a (which runs after loader-b) will also add modules and consume both.
+	plugin.addModule("module-b.js", `export const b = "registered-by-loader-b";`);
+
+	// Pass content through unchanged — loader-a will replace it.
+	return content;
+};

--- a/test/configCases/plugins/virtual-url-plugin-from-loader/source.js
+++ b/test/configCases/plugins/virtual-url-plugin-from-loader/source.js
@@ -1,0 +1,2 @@
+// This file is replaced entirely by the loader chain (loader-b then loader-a).
+// Its content doesn't matter.

--- a/test/configCases/plugins/virtual-url-plugin-from-loader/webpack.config.js
+++ b/test/configCases/plugins/virtual-url-plugin-from-loader/webpack.config.js
@@ -1,0 +1,21 @@
+"use strict";
+
+/** @type {import("webpack").Configuration} */
+const config = {
+	// No VirtualUrlPlugin in config — loaders register it dynamically
+	plugins: [],
+	module: {
+		rules: [
+			{
+				test: /source\.js$/,
+				// Webpack applies use[] right-to-left: loader-b runs first, loader-a second
+				use: [
+					require.resolve("./loader-a.js"),
+					require.resolve("./loader-b.js")
+				]
+			}
+		]
+	}
+};
+
+module.exports = config;


### PR DESCRIPTION
…amically

Add VirtualUrlPlugin.getPlugin(compiler, scheme?) and addModule(id, config) to support registering virtual modules from within a loader, without requiring a pre-configured plugin in webpack.config.js.

Previously, calling new VirtualUrlPlugin().apply(compiler) from a loader had no effect because compiler.hooks.compilation had already fired. Now, apply() detects an in-progress compilation via compiler._lastCompilation and immediately sets up scheme-handling hooks for it via _setupCompilationHooks().

Closes #20692

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->