### PR TITLE
test: add CSS test case with no dependencies

### DIFF
--- a/test/configCases/css/no-deps/index.js
+++ b/test/configCases/css/no-deps/index.js
@@ -1,0 +1,7 @@
+import "./style.css";
+
+it("should handle CSS modules with no dependencies", () => {
+	expect(
+		getComputedStyle(document.body).getPropertyValue("background-color").trim()
+	).toBe("rgb(1, 2, 3)");
+});

--- a/test/configCases/css/no-deps/style.css
+++ b/test/configCases/css/no-deps/style.css
@@ -1,0 +1,3 @@
+body {
+    background-color: rgb(1, 2, 3);
+}

--- a/test/configCases/css/no-deps/test.config.js
+++ b/test/configCases/css/no-deps/test.config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+module.exports = {
+	moduleScope(scope) {
+		const link = scope.window.document.createElement("link");
+		link.rel = "stylesheet";
+		link.href = "bundle0.css";
+		scope.window.document.head.appendChild(link);
+	}
+};

--- a/test/configCases/css/no-deps/webpack.config.js
+++ b/test/configCases/css/no-deps/webpack.config.js
@@ -1,0 +1,10 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	mode: "development",
+	experiments: {
+		css: true
+	}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
This PR adds a missing integration test case under test/configCases/css/no-deps/ to ensure the native CSS experiment correctly handles modules with zero dependencies (files with only selectors and no @import or 
url()).
 Currently, most CSS tests involve complex dependency graphs. Adding an isolated "leaf" module test ensures the pipeline is robust at its simplest level
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
test
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
yes
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**
no 
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->