### PR TITLE
fix: improve types for NormalModule

### DIFF
--- a/lib/CssModule.js
+++ b/lib/CssModule.js
@@ -8,21 +8,41 @@
 const NormalModule = require("./NormalModule");
 const makeSerializable = require("./util/makeSerializable");
 
+/** @typedef {import("../declarations/WebpackOptions").CssParserExportType} CssParserExportType */
+/** @typedef {import("../declarations/WebpackOptions").CssParserOptions} CssParserOptions */
+/** @typedef {import("../declarations/WebpackOptions").CssModuleParserOptions} CssModuleParserOptions */
+/** @typedef {import("../declarations/WebpackOptions").CssGeneratorOptions} CssGeneratorOptions */
+/** @typedef {import("../declarations/WebpackOptions").CssModuleGeneratorOptions} CssModuleGeneratorOptions */
+/** @typedef {import("./Parser")} Parser */
+/** @typedef {import("./NormalModule").ParserOptions} ParserOptions */
+/** @typedef {import("./NormalModule").GeneratorOptions} GeneratorOptions */
+/** @typedef {import("./Generator")} Generator */
 /** @typedef {import("./Module")} Module */
-/** @typedef {import("./NormalModule").NormalModuleCreateData} NormalModuleCreateData */
+/**
+ * @template {Parser} [P=Parser]
+ * @template {ParserOptions} [PO=ParserOptions]
+ * @template {Generator} [G=Generator]
+ * @template {GeneratorOptions} [GO=GeneratorOptions]
+ * @typedef {import("./NormalModule").NormalModuleCreateData<P, PO, G, GO>} NormalModuleCreateData
+ */
 /** @typedef {import("./RequestShortener")} RequestShortener */
 /** @typedef {import("./serialization/ObjectMiddleware").ObjectDeserializerContext} ObjectDeserializerContext */
 /** @typedef {import("./serialization/ObjectMiddleware").ObjectSerializerContext} ObjectSerializerContext */
-/** @typedef {import("../declarations/WebpackOptions").CssParserExportType} CssParserExportType */
-
+/** @typedef {import("./css/CssParser")} CssParser */
+/** @typedef {import("./css/CssGenerator")} CssGenerator */
 /** @typedef {string | undefined} CssLayer */
 /** @typedef {string | undefined} Supports */
 /** @typedef {string | undefined} Media */
 /** @typedef {[CssLayer, Supports, Media]} InheritanceItem */
 /** @typedef {InheritanceItem[]} Inheritance */
 
-/** @typedef {NormalModuleCreateData & { cssLayer: CssLayer, supports: Supports, media: Media, inheritance?: Inheritance, exportType?: CssParserExportType }} CSSModuleCreateData */
+/**
+ * @typedef {NormalModuleCreateData<CssParser, CssParserOptions | CssModuleParserOptions, CssGenerator, CssGeneratorOptions | CssModuleGeneratorOptions> & { cssLayer: CssLayer, supports: Supports, media: Media, inheritance?: Inheritance, exportType?: CssParserExportType }} CSSModuleCreateData
+ */
 
+/**
+ * @extends {NormalModule<CssParser, CssParserOptions | CssModuleParserOptions, CssGenerator, CssGeneratorOptions | CssModuleGeneratorOptions>}
+ */
 class CssModule extends NormalModule {
 	/**
 	 * @param {CSSModuleCreateData} options options object

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -247,6 +247,10 @@ makeSerializable(
  */
 
 /**
+ * @template {Parser} [P=Parser]
+ * @template {ParserOptions} [PO=ParserOptions]
+ * @template {Generator} [G=Generator]
+ * @template {GeneratorOptions} [GO=GeneratorOptions]
  * @typedef {object} NormalModuleCreateData
  * @property {string=} layer an optional layer in which the module is
  * @property {NormalModuleTypes | ""} type module type. When deserializing, this is set to an empty string "".
@@ -258,10 +262,10 @@ makeSerializable(
  * @property {(ResourceSchemeData & Partial<ResolveRequest>)=} resourceResolveData resource resolve data
  * @property {string} context context directory for resolving
  * @property {string=} matchResource path + query of the matched resource (virtual)
- * @property {Parser} parser the parser used
- * @property {ParserOptions=} parserOptions the options of the parser used
- * @property {Generator} generator the generator used
- * @property {GeneratorOptions=} generatorOptions the options of the generator used
+ * @property {P} parser the parser used
+ * @property {PO | undefined} parserOptions the options of the parser used
+ * @property {G} generator the generator used
+ * @property {GO | undefined} generatorOptions the options of the generator used
  * @property {ResolveOptions=} resolveOptions options used for resolving requests from this module
  * @property {boolean} extractSourceMap enable/disable extracting source map
  */
@@ -273,6 +277,12 @@ makeSerializable(
 /** @type {WeakMap<Compilation, NormalModuleCompilationHooks>} */
 const compilationHooksMap = new WeakMap();
 
+/**
+ * @template {Parser} [P=Parser]
+ * @template {ParserOptions} [PO=ParserOptions]
+ * @template {Generator} [G=Generator]
+ * @template {GeneratorOptions} [GO=GeneratorOptions]
+ */
 class NormalModule extends Module {
 	/**
 	 * @param {Compilation} compilation the compilation
@@ -338,7 +348,7 @@ class NormalModule extends Module {
 	}
 
 	/**
-	 * @param {NormalModuleCreateData} options options object
+	 * @param {NormalModuleCreateData<P, PO, G, GO>} options options object
 	 */
 	constructor({
 		layer,
@@ -369,13 +379,13 @@ class NormalModule extends Module {
 		this.rawRequest = rawRequest;
 		/** @type {boolean} */
 		this.binary = /^(?:asset|webassembly)\b/.test(type);
-		/** @type {NormalModuleCreateData['parser'] | undefined} */
+		/** @type {P | undefined} */
 		this.parser = parser;
-		/** @type {NormalModuleCreateData['parserOptions']} */
+		/** @type {PO | undefined} */
 		this.parserOptions = parserOptions;
-		/** @type {NormalModuleCreateData['generator'] | undefined} */
+		/** @type {G | undefined} */
 		this.generator = generator;
-		/** @type {NormalModuleCreateData['generatorOptions']} */
+		/** @type {GO | undefined} */
 		this.generatorOptions = generatorOptions;
 		/** @type {NormalModuleCreateData['resource']} */
 		this.resource = resource;
@@ -500,7 +510,7 @@ class NormalModule extends Module {
 	 */
 	updateCacheModule(module) {
 		super.updateCacheModule(module);
-		const m = /** @type {NormalModule} */ (module);
+		const m = /** @type {NormalModule<P, PO, G, GO>} */ (module);
 		this.binary = m.binary;
 		this.request = m.request;
 		this.userRequest = m.userRequest;
@@ -565,13 +575,18 @@ class NormalModule extends Module {
 	 */
 	_restoreFromUnsafeCache(unsafeCacheData, normalModuleFactory) {
 		super._restoreFromUnsafeCache(unsafeCacheData, normalModuleFactory);
-		this.parserOptions = unsafeCacheData.parserOptions;
-		this.parser = normalModuleFactory.getParser(this.type, this.parserOptions);
-		this.generatorOptions = unsafeCacheData.generatorOptions;
-		this.generator = normalModuleFactory.getGenerator(
-			this.type,
-			this.generatorOptions
-		);
+		this.parserOptions =
+			/** @type {PO} */
+			(unsafeCacheData.parserOptions);
+		this.parser =
+			/** @type {P} */
+			(normalModuleFactory.getParser(this.type, this.parserOptions));
+		this.generatorOptions =
+			/** @type {GO} */
+			(unsafeCacheData.generatorOptions);
+		this.generator =
+			/** @type {G} */
+			(normalModuleFactory.getGenerator(this.type, this.generatorOptions));
 		// we assume the generator behaves identically and keep cached sourceTypes/Sizes
 	}
 
@@ -1431,7 +1446,7 @@ class NormalModule extends Module {
 
 			try {
 				const source = /** @type {Source} */ (this._source).source();
-				/** @type {Parser} */
+				/** @type {P} */
 				(this.parser).parse(this._ast || source, {
 					source,
 					current: this,
@@ -1452,9 +1467,10 @@ class NormalModule extends Module {
 	 * @returns {string | undefined} reason why this module can't be concatenated, undefined when it can be concatenated
 	 */
 	getConcatenationBailoutReason(context) {
-		return /** @type {Generator} */ (
-			this.generator
-		).getConcatenationBailoutReason(this, context);
+		return /** @type {G} */ (this.generator).getConcatenationBailoutReason(
+			this,
+			context
+		);
 	}
 
 	/**
@@ -1510,9 +1526,7 @@ class NormalModule extends Module {
 	 */
 	getSourceTypes() {
 		if (this._sourceTypes === undefined) {
-			this._sourceTypes = /** @type {Generator} */ (this.generator).getTypes(
-				this
-			);
+			this._sourceTypes = /** @type {G} */ (this.generator).getTypes(this);
 		}
 		return this._sourceTypes;
 	}
@@ -1549,7 +1563,7 @@ class NormalModule extends Module {
 		for (const type of sourceTypes || chunkGraph.getModuleSourceTypes(this)) {
 			// TODO webpack@6 make generateError required
 			const generator =
-				/** @type {Generator & { generateError?: GenerateErrorFn }} */
+				/** @type {G & { generateError?: GenerateErrorFn }} */
 				(this.generator);
 			const source = this.error
 				? generator.generateError
@@ -1680,7 +1694,7 @@ class NormalModule extends Module {
 		}
 		const size = Math.max(
 			1,
-			/** @type {Generator} */ (this.generator).getSize(this, type)
+			/** @type {G} */ (this.generator).getSize(this, type)
 		);
 		if (this._sourceSizes === undefined) {
 			this._sourceSizes = new Map();
@@ -1733,7 +1747,7 @@ class NormalModule extends Module {
 			/** @type {string} */
 			(buildInfo.hash)
 		);
-		/** @type {Generator} */
+		/** @type {G} */
 		(this.generator).updateHash(hash, {
 			module: this,
 			...context

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -1357,9 +1357,10 @@ If changing the source code is not an option there is also a resolve options cal
 	}
 
 	/**
+	 * @template {Parser} [P=Parser]
 	 * @param {string} type type
 	 * @param {ParserOptions} parserOptions parser options
-	 * @returns {Parser} parser
+	 * @returns {P} parser
 	 */
 	getParser(type, parserOptions = EMPTY_PARSER_OPTIONS) {
 		let cache = this.parserCache.get(type);
@@ -1376,13 +1377,14 @@ If changing the source code is not an option there is also a resolve options cal
 			cache.set(parserOptions, parser);
 		}
 
-		return parser;
+		return /** @type {P} */ (parser);
 	}
 
 	/**
+	 * @template {Parser} [P=Parser]
 	 * @param {string} type type
 	 * @param {ParserOptions} parserOptions parser options
-	 * @returns {Parser} parser
+	 * @returns {P} parser
 	 */
 	createParser(type, parserOptions = {}) {
 		parserOptions = mergeGlobalOptions(
@@ -1390,7 +1392,9 @@ If changing the source code is not an option there is also a resolve options cal
 			type,
 			parserOptions
 		);
-		const parser = this.hooks.createParser.for(type).call(parserOptions);
+		const parser =
+			/** @type {P} */
+			(this.hooks.createParser.for(type).call(parserOptions));
 		if (!parser) {
 			throw new Error(`No parser registered for ${type}`);
 		}
@@ -1399,9 +1403,10 @@ If changing the source code is not an option there is also a resolve options cal
 	}
 
 	/**
+	 * @template {Generator} [G=Generator]
 	 * @param {string} type type of generator
 	 * @param {GeneratorOptions} generatorOptions generator options
-	 * @returns {Generator} generator
+	 * @returns {G} generator
 	 */
 	getGenerator(type, generatorOptions = EMPTY_GENERATOR_OPTIONS) {
 		let cache = this.generatorCache.get(type);
@@ -1418,13 +1423,14 @@ If changing the source code is not an option there is also a resolve options cal
 			cache.set(generatorOptions, generator);
 		}
 
-		return generator;
+		return /** @type {G} */ (generator);
 	}
 
 	/**
+	 * @template {Generator} [G=Generator]
 	 * @param {string} type type of generator
 	 * @param {GeneratorOptions} generatorOptions generator options
-	 * @returns {Generator} generator
+	 * @returns {G} generator
 	 */
 	createGenerator(type, generatorOptions = {}) {
 		generatorOptions = mergeGlobalOptions(
@@ -1432,9 +1438,9 @@ If changing the source code is not an option there is also a resolve options cal
 			type,
 			generatorOptions
 		);
-		const generator = this.hooks.createGenerator
-			.for(type)
-			.call(generatorOptions);
+		const generator =
+			/** @type {G} */
+			(this.hooks.createGenerator.for(type).call(generatorOptions));
 		if (!generator) {
 			throw new Error(`No generator registered for ${type}`);
 		}

--- a/types.d.ts
+++ b/types.d.ts
@@ -347,7 +347,7 @@ declare interface Asset {
 declare abstract class AssetBytesGenerator extends Generator {
 	generateError(
 		error: Error,
-		module: NormalModule,
+		module: NormalModule<ParserClass>,
 		generateContext: GenerateContext
 	): null | Source;
 }
@@ -377,11 +377,11 @@ declare abstract class AssetGenerator extends Generator {
 	publicPath?: string | ((pathData: PathData, assetInfo?: AssetInfo) => string);
 	outputPath?: string | ((pathData: PathData, assetInfo?: AssetInfo) => string);
 	emit?: boolean;
-	getMimeType(module: NormalModule): string;
-	generateDataUri(module: NormalModule): string;
+	getMimeType(module: NormalModule<ParserClass>): string;
+	generateDataUri(module: NormalModule<ParserClass>): string;
 	generateError(
 		error: Error,
-		module: NormalModule,
+		module: NormalModule<ParserClass>,
 		generateContext: GenerateContext
 	): null | Source;
 }
@@ -490,7 +490,7 @@ declare interface AssetResourceGeneratorOptions {
 declare abstract class AssetSourceGenerator extends Generator {
 	generateError(
 		error: Error,
-		module: NormalModule,
+		module: NormalModule<ParserClass>,
 		generateContext: GenerateContext
 	): null | Source;
 }
@@ -1091,7 +1091,7 @@ declare abstract class ByTypeGenerator extends Generator {
 	map: { [index: string]: undefined | Generator };
 	generateError?: (
 		error: Error,
-		module: NormalModule,
+		module: NormalModule<ParserClass>,
 		generateContext: GenerateContext
 	) => null | Source;
 }
@@ -2407,7 +2407,9 @@ declare class Compilation {
 		/**
 		 * @deprecated
 		 */
-		get normalModuleLoader(): SyncHook<[AnyLoaderContext, NormalModule]>;
+		get normalModuleLoader(): SyncHook<
+			[AnyLoaderContext, NormalModule<ParserClass>]
+		>;
 	}>;
 	name?: string;
 	startTime?: number;
@@ -3766,21 +3768,21 @@ declare interface CssData {
 declare abstract class CssGenerator extends Generator {
 	options: CssModuleGeneratorOptions;
 	sourceDependency(
-		module: NormalModule,
+		module: NormalModule<ParserClass>,
 		dependency: Dependency,
 		initFragments: InitFragment<GenerateContext>[],
 		source: ReplaceSource,
 		generateContext: GenerateContext & { cssData: CssData }
 	): void;
 	sourceModule(
-		module: NormalModule,
+		module: NormalModule<ParserClass>,
 		initFragments: InitFragment<GenerateContext>[],
 		source: ReplaceSource,
 		generateContext: GenerateContext & { cssData: CssData }
 	): void;
 	generateError(
 		error: Error,
-		module: NormalModule,
+		module: NormalModule<ParserClass>,
 		generateContext: GenerateContext
 	): null | Source;
 }
@@ -3842,7 +3844,12 @@ declare interface CssLoadingRuntimeModulePluginHooks {
 	linkPreload: SyncWaterfallHook<[string, Chunk], string>;
 	linkPrefetch: SyncWaterfallHook<[string, Chunk], string>;
 }
-declare abstract class CssModule extends NormalModule {
+declare abstract class CssModule extends NormalModule<
+	CssParser,
+	CssParserOptions | CssModuleParserOptions,
+	CssGenerator,
+	CssGeneratorOptions | CssModuleGeneratorOptions
+> {
 	cssLayer: CssLayer;
 	supports: Supports;
 	media: Media;
@@ -4093,7 +4100,7 @@ declare class DefinePlugin {
 	static getCompilationHooks(compilation: Compilation): DefinePluginHooks;
 	static runtimeValue(
 		fn: (value: {
-			module: NormalModule;
+			module: NormalModule<ParserClass>;
 			key: string;
 			readonly version: ValueCacheVersion;
 		}) => CodeValuePrimitive,
@@ -6333,11 +6340,14 @@ declare interface GeneratedSourceInfo {
 }
 declare class Generator {
 	constructor();
-	getTypes(module: NormalModule): ReadonlySet<string>;
-	getSize(module: NormalModule, type?: string): number;
-	generate(module: NormalModule, __1: GenerateContext): null | Source;
+	getTypes(module: NormalModule<ParserClass>): ReadonlySet<string>;
+	getSize(module: NormalModule<ParserClass>, type?: string): number;
+	generate(
+		module: NormalModule<ParserClass>,
+		__1: GenerateContext
+	): null | Source;
 	getConcatenationBailoutReason(
-		module: NormalModule,
+		module: NormalModule<ParserClass>,
 		context: ConcatenationBailoutReasonContext
 	): undefined | string;
 	updateHash(hash: Hash, __1: UpdateHashContextGenerator): void;
@@ -7146,7 +7156,7 @@ declare abstract class JavascriptGenerator extends Generator {
 	): void;
 	generateError(
 		error: Error,
-		module: NormalModule,
+		module: NormalModule<ParserClass>,
 		generateContext: GenerateContext
 	): null | Source;
 }
@@ -8871,7 +8881,7 @@ declare abstract class JsonGenerator extends Generator {
 	options: JsonGeneratorOptions;
 	generateError(
 		error: Error,
-		module: NormalModule,
+		module: NormalModule<ParserClass>,
 		generateContext: GenerateContext
 	): null | Source;
 }
@@ -11603,6 +11613,16 @@ declare interface ModuleSettings {
 	type?: string;
 
 	/**
+	 * Options for the resolver.
+	 */
+	resolve?: ResolveOptions;
+
+	/**
+	 * Enable/Disable extracting source map.
+	 */
+	extractSourceMap?: boolean;
+
+	/**
 	 * Options for parsing.
 	 */
 	parser?: { [index: string]: any };
@@ -11611,16 +11631,6 @@ declare interface ModuleSettings {
 	 * The options for the module generator.
 	 */
 	generator?: { [index: string]: any };
-
-	/**
-	 * Enable/Disable extracting source map.
-	 */
-	extractSourceMap?: boolean;
-
-	/**
-	 * Options for the resolver.
-	 */
-	resolve?: ResolveOptions;
 
 	/**
 	 * Flags a module as with or without side effects.
@@ -11924,16 +11934,21 @@ declare interface NodeTemplatePluginOptions {
 	asyncChunkLoading?: boolean;
 }
 type NonNullable<T> = T & {};
-declare class NormalModule extends Module {
-	constructor(__0: NormalModuleCreateData);
+declare class NormalModule<
+	P extends ParserClass = ParserClass,
+	PO extends ParserOptions = ParserOptions,
+	G extends Generator = Generator,
+	GO extends GeneratorOptions = GeneratorOptions
+> extends Module {
+	constructor(__0: NormalModuleCreateDataNormalModuleObject_1<P, PO, G, GO>);
 	request: string;
 	userRequest: string;
 	rawRequest: string;
 	binary: boolean;
-	parser?: ParserClass;
-	parserOptions?: ParserOptions;
-	generator?: Generator;
-	generatorOptions?: GeneratorOptions;
+	parser?: P;
+	parserOptions?: PO;
+	generator?: G;
+	generatorOptions?: GO;
 	resource: string;
 	resourceResolveData?: ResourceSchemeData & Partial<ResolveRequest>;
 	matchResource?: string;
@@ -11983,7 +11998,9 @@ declare class NormalModule extends Module {
 	static getCompilationHooks(
 		compilation: Compilation
 	): NormalModuleCompilationHooks;
-	static deserialize(context: ObjectDeserializerContext): NormalModule;
+	static deserialize(
+		context: ObjectDeserializerContext
+	): NormalModule<ParserClass>;
 
 	/**
 	 * In webpack 6, call getSourceBasicTypes() directly on the module instance instead of using this static method.
@@ -11992,13 +12009,18 @@ declare class NormalModule extends Module {
 	static getSourceBasicTypes(module: Module): ReadonlySet<string>;
 }
 declare interface NormalModuleCompilationHooks {
-	loader: SyncHook<[AnyLoaderContext, NormalModule]>;
-	beforeLoaders: SyncHook<[LoaderItem[], NormalModule, AnyLoaderContext]>;
-	beforeParse: SyncHook<[NormalModule]>;
-	beforeSnapshot: SyncHook<[NormalModule]>;
+	loader: SyncHook<[AnyLoaderContext, NormalModule<ParserClass>]>;
+	beforeLoaders: SyncHook<
+		[LoaderItem[], NormalModule<ParserClass>, AnyLoaderContext]
+	>;
+	beforeParse: SyncHook<[NormalModule<ParserClass>]>;
+	beforeSnapshot: SyncHook<[NormalModule<ParserClass>]>;
 	readResourceForScheme: HookMap<
 		FakeHook<
-			AsyncSeriesBailHook<[string, NormalModule], null | string | Buffer>
+			AsyncSeriesBailHook<
+				[string, NormalModule<ParserClass>],
+				null | string | Buffer
+			>
 		>
 	>;
 	readResource: HookMap<
@@ -12011,7 +12033,7 @@ declare interface NormalModuleCompilationHooks {
 				undefined | string | RawSourceMap,
 				undefined | PreparsedAst
 			],
-			NormalModule
+			NormalModule<ParserClass>
 		],
 		[
 			string | Buffer,
@@ -12019,9 +12041,17 @@ declare interface NormalModuleCompilationHooks {
 			undefined | PreparsedAst
 		]
 	>;
-	needBuild: AsyncSeriesBailHook<[NormalModule, NeedBuildContext], boolean>;
+	needBuild: AsyncSeriesBailHook<
+		[NormalModule<ParserClass>, NeedBuildContext],
+		boolean
+	>;
 }
-declare interface NormalModuleCreateData {
+declare interface NormalModuleCreateDataNormalModuleObject_1<
+	P extends ParserClass = ParserClass,
+	PO extends ParserOptions = ParserOptions,
+	G extends Generator = Generator,
+	GO extends GeneratorOptions = GeneratorOptions
+> {
 	/**
 	 * an optional layer in which the module is
 	 */
@@ -12075,22 +12105,22 @@ declare interface NormalModuleCreateData {
 	/**
 	 * the parser used
 	 */
-	parser: ParserClass;
+	parser: P;
 
 	/**
 	 * the options of the parser used
 	 */
-	parserOptions?: ParserOptions;
+	parserOptions?: PO;
 
 	/**
 	 * the generator used
 	 */
-	generator: Generator;
+	generator: G;
 
 	/**
 	 * the options of the generator used
 	 */
-	generatorOptions?: GeneratorOptions;
+	generatorOptions?: GO;
 
 	/**
 	 * options used for resolving requests from this module
@@ -12116,7 +12146,73 @@ declare abstract class NormalModuleFactory extends ModuleFactory {
 		afterResolve: AsyncSeriesBailHook<[ResolveData], false | void>;
 		createModule: AsyncSeriesBailHook<
 			[
-				Partial<NormalModuleCreateData & { settings: ModuleSettings }>,
+				Partial<{
+					/**
+					 * an optional layer in which the module is
+					 */
+					layer?: string;
+					/**
+					 * module type. When deserializing, this is set to an empty string "".
+					 */
+					type: string;
+					/**
+					 * request string
+					 */
+					request: string;
+					/**
+					 * request intended by user (without loaders from config)
+					 */
+					userRequest: string;
+					/**
+					 * request without resolving
+					 */
+					rawRequest: string;
+					/**
+					 * list of loaders
+					 */
+					loaders: LoaderItem[];
+					/**
+					 * path + query of the real resource
+					 */
+					resource: string;
+					/**
+					 * resource resolve data
+					 */
+					resourceResolveData?: ResourceSchemeData & Partial<ResolveRequest>;
+					/**
+					 * context directory for resolving
+					 */
+					context: string;
+					/**
+					 * path + query of the matched resource (virtual)
+					 */
+					matchResource?: string;
+					/**
+					 * the parser used
+					 */
+					parser: ParserClass;
+					/**
+					 * the options of the parser used
+					 */
+					parserOptions?: ParserOptions;
+					/**
+					 * the generator used
+					 */
+					generator: Generator;
+					/**
+					 * the options of the generator used
+					 */
+					generatorOptions?: GeneratorOptions;
+					/**
+					 * options used for resolving requests from this module
+					 */
+					resolveOptions?: ResolveOptions;
+					/**
+					 * enable/disable extracting source map
+					 */
+					extractSourceMap: boolean;
+					settings: ModuleSettings;
+				}>,
 				ResolveData
 			],
 			void | Module
@@ -12124,7 +12220,73 @@ declare abstract class NormalModuleFactory extends ModuleFactory {
 		module: SyncWaterfallHook<
 			[
 				Module,
-				Partial<NormalModuleCreateData & { settings: ModuleSettings }>,
+				Partial<{
+					/**
+					 * an optional layer in which the module is
+					 */
+					layer?: string;
+					/**
+					 * module type. When deserializing, this is set to an empty string "".
+					 */
+					type: string;
+					/**
+					 * request string
+					 */
+					request: string;
+					/**
+					 * request intended by user (without loaders from config)
+					 */
+					userRequest: string;
+					/**
+					 * request without resolving
+					 */
+					rawRequest: string;
+					/**
+					 * list of loaders
+					 */
+					loaders: LoaderItem[];
+					/**
+					 * path + query of the real resource
+					 */
+					resource: string;
+					/**
+					 * resource resolve data
+					 */
+					resourceResolveData?: ResourceSchemeData & Partial<ResolveRequest>;
+					/**
+					 * context directory for resolving
+					 */
+					context: string;
+					/**
+					 * path + query of the matched resource (virtual)
+					 */
+					matchResource?: string;
+					/**
+					 * the parser used
+					 */
+					parser: ParserClass;
+					/**
+					 * the options of the parser used
+					 */
+					parserOptions?: ParserOptions;
+					/**
+					 * the generator used
+					 */
+					generator: Generator;
+					/**
+					 * the options of the generator used
+					 */
+					generatorOptions?: GeneratorOptions;
+					/**
+					 * options used for resolving requests from this module
+					 */
+					resolveOptions?: ResolveOptions;
+					/**
+					 * enable/disable extracting source map
+					 */
+					extractSourceMap: boolean;
+					settings: ModuleSettings;
+				}>,
 				ResolveData
 			],
 			Module
@@ -12351,7 +12513,73 @@ declare abstract class NormalModuleFactory extends ModuleFactory {
 		createModuleClass: HookMap<
 			SyncBailHook<
 				[
-					Partial<NormalModuleCreateData & { settings: ModuleSettings }>,
+					Partial<{
+						/**
+						 * an optional layer in which the module is
+						 */
+						layer?: string;
+						/**
+						 * module type. When deserializing, this is set to an empty string "".
+						 */
+						type: string;
+						/**
+						 * request string
+						 */
+						request: string;
+						/**
+						 * request intended by user (without loaders from config)
+						 */
+						userRequest: string;
+						/**
+						 * request without resolving
+						 */
+						rawRequest: string;
+						/**
+						 * list of loaders
+						 */
+						loaders: LoaderItem[];
+						/**
+						 * path + query of the real resource
+						 */
+						resource: string;
+						/**
+						 * resource resolve data
+						 */
+						resourceResolveData?: ResourceSchemeData & Partial<ResolveRequest>;
+						/**
+						 * context directory for resolving
+						 */
+						context: string;
+						/**
+						 * path + query of the matched resource (virtual)
+						 */
+						matchResource?: string;
+						/**
+						 * the parser used
+						 */
+						parser: ParserClass;
+						/**
+						 * the options of the parser used
+						 */
+						parserOptions?: ParserOptions;
+						/**
+						 * the generator used
+						 */
+						generator: Generator;
+						/**
+						 * the options of the generator used
+						 */
+						generatorOptions?: GeneratorOptions;
+						/**
+						 * options used for resolving requests from this module
+						 */
+						resolveOptions?: ResolveOptions;
+						/**
+						 * enable/disable extracting source map
+						 */
+						extractSourceMap: boolean;
+						settings: ModuleSettings;
+					}>,
 					ResolveData
 				],
 				void | Module
@@ -12385,10 +12613,22 @@ declare abstract class NormalModuleFactory extends ModuleFactory {
 		resolveContext: ResolveContext,
 		callback: CallbackWebpackFunction_1<LoaderItem[]>
 	): void;
-	getParser(type: string, parserOptions?: ParserOptions): ParserClass;
-	createParser(type: string, parserOptions?: ParserOptions): ParserClass;
-	getGenerator(type: string, generatorOptions?: GeneratorOptions): Generator;
-	createGenerator(type: string, generatorOptions?: GeneratorOptions): Generator;
+	getParser<P extends ParserClass = ParserClass>(
+		type: string,
+		parserOptions?: ParserOptions
+	): P;
+	createParser<P extends ParserClass = ParserClass>(
+		type: string,
+		parserOptions?: ParserOptions
+	): P;
+	getGenerator<G extends Generator = Generator>(
+		type: string,
+		generatorOptions?: GeneratorOptions
+	): G;
+	createGenerator<G extends Generator = Generator>(
+		type: string,
+		generatorOptions?: GeneratorOptions
+	): G;
 	getResolver(
 		type: string,
 		resolveOptions?: ResolveOptionsWithDependencyType
@@ -12447,7 +12687,7 @@ declare interface NormalModuleLoaderContext<OptionsType> {
 	hashDigest: string;
 	hashDigestLength: number;
 	hashSalt?: string;
-	_module?: NormalModule;
+	_module?: NormalModule<ParserClass>;
 	_compilation?: Compilation;
 	_compiler?: Compiler;
 }
@@ -14129,8 +14369,8 @@ declare interface ParserOptionsByModuleTypeUnknown {
 type ParserState = ParserStateBase & Record<string, any>;
 declare interface ParserStateBase {
 	source: string | Buffer;
-	current: NormalModule;
-	module: NormalModule;
+	current: NormalModule<ParserClass>;
+	module: NormalModule<ParserClass>;
 	compilation: Compilation;
 	options: WebpackOptionsNormalizedWithDefaults;
 }
@@ -15501,7 +15741,73 @@ declare interface ResolveData {
 	attributes?: ImportAttributes;
 	dependencies: ModuleDependency[];
 	dependencyType: string;
-	createData: Partial<NormalModuleCreateData & { settings: ModuleSettings }>;
+	createData: Partial<{
+		/**
+		 * an optional layer in which the module is
+		 */
+		layer?: string;
+		/**
+		 * module type. When deserializing, this is set to an empty string "".
+		 */
+		type: string;
+		/**
+		 * request string
+		 */
+		request: string;
+		/**
+		 * request intended by user (without loaders from config)
+		 */
+		userRequest: string;
+		/**
+		 * request without resolving
+		 */
+		rawRequest: string;
+		/**
+		 * list of loaders
+		 */
+		loaders: LoaderItem[];
+		/**
+		 * path + query of the real resource
+		 */
+		resource: string;
+		/**
+		 * resource resolve data
+		 */
+		resourceResolveData?: ResourceSchemeData & Partial<ResolveRequest>;
+		/**
+		 * context directory for resolving
+		 */
+		context: string;
+		/**
+		 * path + query of the matched resource (virtual)
+		 */
+		matchResource?: string;
+		/**
+		 * the parser used
+		 */
+		parser: ParserClass;
+		/**
+		 * the options of the parser used
+		 */
+		parserOptions?: ParserOptions;
+		/**
+		 * the generator used
+		 */
+		generator: Generator;
+		/**
+		 * the options of the generator used
+		 */
+		generatorOptions?: GeneratorOptions;
+		/**
+		 * options used for resolving requests from this module
+		 */
+		resolveOptions?: ResolveOptions;
+		/**
+		 * enable/disable extracting source map
+		 */
+		extractSourceMap: boolean;
+		settings: ModuleSettings;
+	}>;
 	fileDependencies: LazySet<string>;
 	missingDependencies: LazySet<string>;
 	contextDependencies: LazySet<string>;
@@ -17128,7 +17434,7 @@ declare abstract class RuntimeTemplate {
 }
 declare abstract class RuntimeValue {
 	fn: (value: {
-		module: NormalModule;
+		module: NormalModule<ParserClass>;
 		key: string;
 		readonly version: ValueCacheVersion;
 	}) => CodeValuePrimitive;
@@ -18821,7 +19127,7 @@ declare interface UpdateHashContextGenerator {
 	/**
 	 * the module
 	 */
-	module: NormalModule;
+	module: NormalModule<ParserClass>;
 	chunkGraph: ChunkGraph;
 	runtime: RuntimeSpec;
 	runtimeTemplate?: RuntimeTemplate;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

this is a part of future improvement when we will have right parser and parser options, generator and generator options in parse/generate step (and so the right module), also it will help in future `AssetModule`/`JsonModule` and etc improvements

Also in future we will split builtMeta and builtInfo by module types, now we store all properties into two types, but for example js module will never have css related properties

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Existing

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Noting

**Use of AI**

No