### PR TITLE
perf: clear TopLevelSymbols weak caches after parse

### DIFF
--- a/lib/optimize/InnerGraphPlugin.js
+++ b/lib/optimize/InnerGraphPlugin.js
@@ -78,6 +78,12 @@ class InnerGraphPlugin {
 
 					parser.hooks.program.tap(PLUGIN_NAME, () => {
 						InnerGraph.enable(parser.state);
+
+						statementWithTopLevelSymbol = new WeakMap();
+						statementPurePart = new WeakMap();
+						classWithTopLevelSymbol = new WeakMap();
+						declWithTopLevelSymbol = new WeakMap();
+						pureDeclarators = new WeakSet();
 					});
 
 					parser.hooks.finish.tap(PLUGIN_NAME, () => {
@@ -98,17 +104,17 @@ class InnerGraphPlugin {
 					// 3. variable declarators (const x = ...)
 
 					/** @type {WeakMap<Node | MaybeNamedFunctionDeclaration | MaybeNamedClassDeclaration, TopLevelSymbol>} */
-					const statementWithTopLevelSymbol = new WeakMap();
+					let statementWithTopLevelSymbol = new WeakMap();
 					/** @type {WeakMap<Node | MaybeNamedFunctionDeclaration | MaybeNamedClassDeclaration, Node>} */
-					const statementPurePart = new WeakMap();
+					let statementPurePart = new WeakMap();
 
 					/** @type {WeakMap<ClassExpression | ClassDeclaration | MaybeNamedClassDeclaration, TopLevelSymbol>} */
-					const classWithTopLevelSymbol = new WeakMap();
+					let classWithTopLevelSymbol = new WeakMap();
 
 					/** @type {WeakMap<VariableDeclarator, TopLevelSymbol>} */
-					const declWithTopLevelSymbol = new WeakMap();
+					let declWithTopLevelSymbol = new WeakMap();
 					/** @type {WeakSet<VariableDeclarator>} */
-					const pureDeclarators = new WeakSet();
+					let pureDeclarators = new WeakSet();
 
 					// The following hooks are used during prewalking:
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

`InnerGraphPlugin` keeps `WeakMap`/`WeakSet` caches in parser hook closures. Since `JavascriptParser` instances are reused by `NormalModuleFactory`, those cache objects can live longer than a single module parse. This change recreates those weak caches in `finish` hook.

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

No
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No 
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

No
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->