### PR TITLE
fix: expose exports from all entry modules in library output

### DIFF
--- a/.changeset/fix-library-multi-entry-exports.md
+++ b/.changeset/fix-library-multi-entry-exports.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix library output only exposing exports from the last entry module when multiple entry files are specified. All entry modules now contribute their exports to the library.

--- a/lib/javascript/JavascriptModulesPlugin.js
+++ b/lib/javascript/JavascriptModulesPlugin.js
@@ -1019,6 +1019,9 @@ class JavascriptModulesPlugin {
 			}
 			const lastInlinedModule = /** @type {Module} */ (last(inlinedModules));
 			const startupSource = new ConcatSource();
+			const mergeLibraryEntryExports = Boolean(
+				compilation.outputOptions.library && inlinedModules.size > 1
+			);
 
 			const avoidEntryIife = compilation.options.optimization.avoidEntryIife;
 			/** @type {Map<Module, Source> | false} */
@@ -1099,7 +1102,16 @@ class JavascriptModulesPlugin {
 					}
 					if (exports) {
 						if (m !== lastInlinedModule) {
-							startupSource.add(`var ${m.exportsArgument} = {};\n`);
+							if (
+								mergeLibraryEntryExports &&
+								m.exportsArgument !== RuntimeGlobals.exports
+							) {
+								startupSource.add(
+									`var ${m.exportsArgument} = ${RuntimeGlobals.exports};\n`
+								);
+							} else if (!mergeLibraryEntryExports) {
+								startupSource.add(`var ${m.exportsArgument} = {};\n`);
+							}
 						} else if (m.exportsArgument !== RuntimeGlobals.exports) {
 							startupSource.add(
 								`var ${m.exportsArgument} = ${RuntimeGlobals.exports};\n`
@@ -1392,6 +1404,10 @@ class JavascriptModulesPlugin {
 					}
 				}
 				let i = jsEntries.length;
+				const mergeLibraryEntryExports = Boolean(
+					runtimeTemplate.compilation.outputOptions.library &&
+					jsEntries.length > 1
+				);
 				for (const [entryModule, entrypoint] of jsEntries) {
 					const chunks =
 						/** @type {Entrypoint} */
@@ -1509,7 +1525,10 @@ class JavascriptModulesPlugin {
 							requireScopeUsed ||
 							entryRuntimeRequirements.has(RuntimeGlobals.exports)
 						) {
-							const exportsArg = i === 0 ? RuntimeGlobals.exports : "{}";
+							const exportsArg =
+								i === 0 || mergeLibraryEntryExports
+									? RuntimeGlobals.exports
+									: "{}";
 							args.push("0", exportsArg);
 							if (requireScopeUsed) {
 								args.push(RuntimeGlobals.require);

--- a/lib/library/AbstractLibraryPlugin.js
+++ b/lib/library/AbstractLibraryPlugin.js
@@ -80,15 +80,16 @@ class AbstractLibraryPlugin {
 								: compilation.outputOptions.library
 						);
 						if (options !== false) {
-							const dep = deps[deps.length - 1];
-							if (dep) {
-								const module = compilation.moduleGraph.getModule(dep);
-								if (module) {
-									this.finishEntryModule(module, name, {
-										options,
-										compilation,
-										chunkGraph: compilation.chunkGraph
-									});
+							for (const dep of deps) {
+								if (dep) {
+									const module = compilation.moduleGraph.getModule(dep);
+									if (module) {
+										this.finishEntryModule(module, name, {
+											options,
+											compilation,
+											chunkGraph: compilation.chunkGraph
+										});
+									}
 								}
 							}
 						}

--- a/test/configCases/library/issue-15936/a.js
+++ b/test/configCases/library/issue-15936/a.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/test/configCases/library/issue-15936/b.js
+++ b/test/configCases/library/issue-15936/b.js
@@ -1,0 +1,1 @@
+export const b = 2;

--- a/test/configCases/library/issue-15936/c.js
+++ b/test/configCases/library/issue-15936/c.js
@@ -1,0 +1,7 @@
+export const c = 3;
+
+it("should export from all entry modules", function () {
+	expect(MultiEntryLib.a).toBe(1);
+	expect(MultiEntryLib.b).toBe(2);
+	expect(MultiEntryLib.c).toBe(3);
+});

--- a/test/configCases/library/issue-15936/test.config.js
+++ b/test/configCases/library/issue-15936/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	afterExecute() {
+		delete global.MultiEntryLib;
+	}
+};

--- a/test/configCases/library/issue-15936/webpack.config.js
+++ b/test/configCases/library/issue-15936/webpack.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: ["./a.js", "./b.js", "./c.js"],
+	output: {
+		library: {
+			name: "MultiEntryLib",
+			type: "assign"
+		}
+	}
+};


### PR DESCRIPTION
## Summary

Fixes #15936

When using an array entry with `output.library`, only the last entry module's exports were accessible on the library object. The remaining entry modules had their exports silently discarded.

### Root cause

Two separate issues:

1. **`AbstractLibraryPlugin`** (`lib/library/AbstractLibraryPlugin.js`): `finishEntryModule` was only called for the last dependency in the entry deps array instead of all of them.

2. **`JavascriptModulesPlugin`** (`lib/javascript/JavascriptModulesPlugin.js`): Non-last inlined entry modules were given an isolated `{}` as their `exportsArgument`, so their exports never merged into `__webpack_exports__`. With a library config and multiple entries, all entry modules now share the same `__webpack_exports__` object.

### Fix

- Loop over all entry deps in `AbstractLibraryPlugin.finishEntryModule`
- Introduce `mergeLibraryEntryExports` flag — when a library is configured with multiple entries, all inlined entry modules share `RuntimeGlobals.exports` instead of `{}`

## Test

Added `test/configCases/library/issue-15936/` which bundles three entry files (`a.js`, `b.js`, `c.js`) with `output.library: { type: "assign", name: "MultiEntryLib" }` and asserts that exports from all three are present on the global library object.