### PR TITLE
fix: handle directory URL paths in new URL(path, import.meta.url)

### DIFF
--- a/.changeset/fix-url-directory-path-resolution.md
+++ b/.changeset/fix-url-directory-path-resolution.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix `new URL('./', import.meta.url)` and other directory URL paths throwing "Can't resolve" errors. Directory paths (trailing slash) are not module assets and are now handled at runtime relative to the bundle base URI, matching the behavior of `/* webpackIgnore: true */`.

--- a/lib/url/URLParserPlugin.js
+++ b/lib/url/URLParserPlugin.js
@@ -172,6 +172,19 @@ class URLParserPlugin {
 			// static URL
 			if ((request = evaluatedExpr.asString())) {
 				const [arg1, arg2] = expr.arguments;
+				// Directory paths (trailing slash) cannot be resolved as module assets.
+				// Treat them like webpackIgnore by replacing import.meta.url with
+				// __webpack_base_uri__ so the expression evaluates at runtime.
+				if (request.endsWith("/")) {
+					const dep = new ConstDependency(
+						RuntimeGlobals.baseURI,
+						/** @type {Range} */ (arg2.range),
+						[RuntimeGlobals.baseURI]
+					);
+					dep.loc = /** @type {DependencyLocation} */ (expr.loc);
+					parser.state.module.addPresentationalDependency(dep);
+					return true;
+				}
 				const dep = new URLDependency(
 					request,
 					[

--- a/test/configCases/url/directory-url/index.js
+++ b/test/configCases/url/directory-url/index.js
@@ -1,0 +1,14 @@
+it("should handle new URL('./', import.meta.url) without module resolution error", () => {
+	// Previously threw: "Can't resolve './' in '/path/to/dir'"
+	// Directory paths are not module assets; they should resolve at runtime relative to bundle base URI.
+	const dirUrl = new URL("./", import.meta.url);
+	expect(dirUrl).toBeInstanceOf(URL);
+	// Should be a valid URL ending with '/' (a directory URL)
+	expect(dirUrl.href).toMatch(/\/$/);
+});
+
+it("should handle new URL('subdir/', import.meta.url) without module resolution error", () => {
+	const subdirUrl = new URL("subdir/", import.meta.url);
+	expect(subdirUrl).toBeInstanceOf(URL);
+	expect(subdirUrl.href).toMatch(/subdir\/$/);
+});

--- a/test/configCases/url/directory-url/webpack.config.js
+++ b/test/configCases/url/directory-url/webpack.config.js
@@ -1,0 +1,4 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {};


### PR DESCRIPTION
## Summary

Fixes #16878

`new URL('./', import.meta.url)` and other directory URLs (trailing slash) caused a compilation error:

```
Module not found: Error: Can't resolve './' in '/path/to/dir'
```

This happened because webpack tried to resolve the path as a module asset, but directory paths don't map to any bundleable file.

## Root cause

In `lib/url/URLParserPlugin.js`, the static URL handler created a `URLDependency` for every string URL, triggering normal module resolution. The resolver found no file at `./` and threw.

## Fix

When the URL path ends with `/`, skip module resolution entirely and replace `import.meta.url` with `__webpack_base_uri__`, giving `new URL('./', __webpack_base_uri__)` at runtime. This is the same behavior users were already getting with `/* webpackIgnore: true */` as a workaround.

## Before / After

```js
// Before — compilation error: "Can't resolve './' in '...'"
const dir = new URL("./", import.meta.url);

// Workaround users had to use
const dir = new URL(/* webpackIgnore: true */ "./", import.meta.url);

// After — works without any magic comment
const dir = new URL("./", import.meta.url);
```

## Test

Added `test/configCases/url/directory-url/` which verifies that `./` and `subdir/` paths compile and produce valid directory URL objects at runtime.