### PR TITLE
fix: apply resolve.alias and resolve.fallback to node: prefixed imports

### DIFF
--- a/.changeset/fix-node-prefix-resolve-fallback.md
+++ b/.changeset/fix-node-prefix-resolve-fallback.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix `resolve.fallback` and `resolve.alias` not applying to `node:` prefixed imports (e.g. `import fs from "node:fs"`). The `node:` scheme is now stripped before alias/fallback resolution so that entries like `resolve.fallback: { fs: false }` correctly apply to both `"fs"` and `"node:fs"` imports.

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -912,6 +912,15 @@ class NormalModuleFactory extends ModuleFactory {
 
 				// resource with scheme
 				if (scheme) {
+					// The "node:" scheme marks Node.js built-in module specifiers
+					// (e.g. "node:fs"). Strip the prefix and run normal resolution so
+					// that resolve.alias and resolve.fallback are applied correctly.
+					if (scheme === "node") {
+						unresolvedResource = unresolvedResource.slice(5);
+						scheme = undefined;
+						defaultResolve(context);
+						return;
+					}
 					resourceData = {
 						resource: unresolvedResource,
 						data: {},

--- a/test/configCases/resolve/node-prefix-fallback/index.js
+++ b/test/configCases/resolve/node-prefix-fallback/index.js
@@ -1,0 +1,14 @@
+// node: prefixed imports should respect resolve.fallback and resolve.alias.
+// Previously webpack threw "Reading from 'node:...' is not handled by plugins
+// (Unhandled scheme)" for these imports on non-node targets.
+
+const withFallback = require("node:crypto");
+const withAlias = require("node:fs");
+
+it("should apply resolve.fallback to node: prefixed imports", () => {
+	expect(withFallback.polyfilled).toBe(true);
+});
+
+it("should apply resolve.alias to node: prefixed imports", () => {
+	expect(withAlias.polyfilled).toBe(true);
+});

--- a/test/configCases/resolve/node-prefix-fallback/polyfill.js
+++ b/test/configCases/resolve/node-prefix-fallback/polyfill.js
@@ -1,0 +1,1 @@
+module.exports = { polyfilled: true };

--- a/test/configCases/resolve/node-prefix-fallback/webpack.config.js
+++ b/test/configCases/resolve/node-prefix-fallback/webpack.config.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const path = require("path");
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	// Use web target so node: built-ins are NOT auto-externalized.
+	// This is the primary use case: browser builds that need to polyfill node modules.
+	target: "web",
+	resolve: {
+		// "node:crypto" → stripped to "crypto" → fallback applies
+		fallback: {
+			crypto: path.resolve(__dirname, "polyfill.js")
+		},
+		// "node:fs" → stripped to "fs" → alias applies
+		alias: {
+			fs: path.resolve(__dirname, "polyfill.js")
+		}
+	}
+};


### PR DESCRIPTION
## Summary

Fixes #14166

`import fs from "node:fs"` and similar `node:` prefixed imports threw an `UnhandledSchemeError` on non-node targets because webpack routed them to `resolveForScheme.for("node")` — which has no registered handler — bypassing `resolve.alias` and `resolve.fallback` entirely.

## Root cause

In `NormalModuleFactory`, any request starting with a URI scheme goes through `this.hooks.resolveForScheme.for(scheme)`. No handler is registered for the `node:` scheme, so resolution fails. Meanwhile the alias/fallback logic lives in enhanced-resolve's normal resolution path, which is never reached.

## Fix

When `scheme === "node"`, strip the five-character `"node:"` prefix from `unresolvedResource` and fall through to normal resolution. This lets enhanced-resolve apply `resolve.alias` and `resolve.fallback` rules using the unprefixed module name.

On node targets, `NodeTargetPlugin` externalizes `node:*` imports at the `factorize` stage (earlier in the pipeline), so this change has no effect there.

## Before / After

```js
// webpack.config.js
{
  target: "web",
  resolve: {
    fallback: { fs: false },   // previously didn't match "node:fs"
    alias: { crypto: require.resolve("crypto-browserify") }
  }
}

// source code
import fs from "node:fs";     // Before: UnhandledSchemeError
                               // After: respects resolve.fallback correctly

import crypto from "node:crypto"; // Before: UnhandledSchemeError
                                   // After: resolves to crypto-browserify
```

## Test

Added `test/configCases/resolve/node-prefix-fallback/` with a `target: "web"` build that verifies both `resolve.fallback` and `resolve.alias` apply correctly to `node:` prefixed imports.