### PR TITLE
fix(css): add processContent hook and async code generation support

### DIFF
--- a/.changeset/process-content-hook.md
+++ b/.changeset/process-content-hook.md
@@ -1,0 +1,5 @@
+---
+"webpack": minor
+---
+
+Add `processContent` AsyncSeriesHook on Compilation for plugins to process module content (e.g., CSS minimization) before it is embedded into JS bundles. Support async code generation in Generator and NormalModule.

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -411,7 +411,7 @@ const { isSourceEqual } = require("./util/source");
 
 /** @typedef {CodeGenerationJob[]} CodeGenerationJobs */
 
-/** @typedef {[string | Buffer, import("webpack-sources").RawSourceMap | undefined]} ProcessContentEntry */
+/** @typedef {import("webpack-sources").Source} ProcessContentSource */
 
 /** @typedef {{ javascript: ModuleTemplate }} ModuleTemplates */
 
@@ -914,8 +914,8 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			/** @type {SyncHook<[]>} */
 			afterCodeGeneration: new SyncHook([]),
 
-			/** @type {AsyncSeriesWaterfallHook<[ProcessContentEntry, string]>} */
-			processContent: new AsyncSeriesWaterfallHook(["content", "name"]),
+			/** @type {AsyncSeriesWaterfallHook<[ProcessContentSource, string]>} */
+			processContent: new AsyncSeriesWaterfallHook(["source", "name"]),
 
 			/** @type {SyncHook<[]>} */
 			beforeRuntimeRequirements: new SyncHook([]),

--- a/lib/Compilation.js
+++ b/lib/Compilation.js
@@ -11,6 +11,7 @@ const {
 	AsyncParallelHook,
 	AsyncSeriesBailHook,
 	AsyncSeriesHook,
+	AsyncSeriesWaterfallHook,
 	HookMap,
 	SyncBailHook,
 	SyncHook,
@@ -409,6 +410,8 @@ const { isSourceEqual } = require("./util/source");
 /** @typedef {{ module: Module, hash: string, runtime: RuntimeSpec, runtimes: RuntimeSpec[] }} CodeGenerationJob */
 
 /** @typedef {CodeGenerationJob[]} CodeGenerationJobs */
+
+/** @typedef {[string | Buffer, import("webpack-sources").RawSourceMap | undefined]} ProcessContentEntry */
 
 /** @typedef {{ javascript: ModuleTemplate }} ModuleTemplates */
 
@@ -910,6 +913,9 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			beforeCodeGeneration: new SyncHook([]),
 			/** @type {SyncHook<[]>} */
 			afterCodeGeneration: new SyncHook([]),
+
+			/** @type {AsyncSeriesWaterfallHook<[ProcessContentEntry, string]>} */
+			processContent: new AsyncSeriesWaterfallHook(["content", "name"]),
 
 			/** @type {SyncHook<[]>} */
 			beforeRuntimeRequirements: new SyncHook([]),
@@ -3774,43 +3780,64 @@ Or do you want to use the entrypoints '${name}' and '${runtime}' independently o
 		);
 		cache.get((err, cachedResult) => {
 			if (err) return callback(/** @type {WebpackError} */ (err));
-			/** @type {CodeGenerationResult} */
-			let result;
-			if (!cachedResult) {
-				try {
-					codeGenerated = true;
-					this.codeGeneratedModules.add(module);
-					result = module.codeGeneration({
-						chunkGraph,
-						moduleGraph,
-						dependencyTemplates,
-						runtimeTemplate,
-						runtime,
-						runtimes,
-						codeGenerationResults: results,
-						compilation: this
-					});
-				} catch (err) {
-					errors.push(
-						new CodeGenerationError(module, /** @type {Error} */ (err))
-					);
-					result = cachedResult = {
-						sources: new Map(),
-						runtimeRequirements: null
-					};
+
+			/**
+			 * @param {CodeGenerationResult} result result
+			 */
+			const finish = (result) => {
+				for (const runtime of runtimes) {
+					results.add(module, runtime, result);
 				}
-			} else {
-				result = cachedResult;
-			}
-			for (const runtime of runtimes) {
-				results.add(module, runtime, result);
-			}
-			if (!cachedResult) {
-				cache.store(result, (err) =>
-					callback(/** @type {WebpackError} */ (err), codeGenerated)
-				);
-			} else {
+				if (!cachedResult) {
+					cache.store(result, (err) =>
+						callback(/** @type {WebpackError} */ (err), codeGenerated)
+					);
+				} else {
+					callback(null, codeGenerated);
+				}
+			};
+
+			if (cachedResult) return finish(cachedResult);
+
+			codeGenerated = true;
+			this.codeGeneratedModules.add(module);
+
+			/**
+			 * @param {Error} err error from code generation
+			 */
+			const handleError = (err) => {
+				errors.push(new CodeGenerationError(module, err));
+				/** @type {CodeGenerationResult} */
+				const errResult = {
+					sources: new Map(),
+					runtimeRequirements: null
+				};
+				for (const runtime of runtimes) {
+					results.add(module, runtime, errResult);
+				}
+				// Don't cache error results — errors must be
+				// regenerated on the next compilation
 				callback(null, codeGenerated);
+			};
+
+			try {
+				const result = module.codeGeneration({
+					chunkGraph,
+					moduleGraph,
+					dependencyTemplates,
+					runtimeTemplate,
+					runtime,
+					runtimes,
+					codeGenerationResults: results,
+					compilation: this
+				});
+				if (result instanceof Promise) {
+					result.then(finish, handleError);
+				} else {
+					finish(result);
+				}
+			} catch (err) {
+				handleError(/** @type {Error} */ (err));
 			}
 		});
 	}

--- a/lib/ContextModule.js
+++ b/lib/ContextModule.js
@@ -1312,7 +1312,7 @@ module.exports = webpackEmptyAsyncContext;`;
 
 	/**
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration(context) {
 		const { chunkGraph, compilation } = context;

--- a/lib/DelegatedModule.js
+++ b/lib/DelegatedModule.js
@@ -150,7 +150,7 @@ class DelegatedModule extends Module {
 
 	/**
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ runtimeTemplate, moduleGraph, chunkGraph }) {
 		const dep = /** @type {DelegatedSourceDependency} */ (this.dependencies[0]);

--- a/lib/DllModule.js
+++ b/lib/DllModule.js
@@ -91,7 +91,7 @@ class DllModule extends Module {
 
 	/**
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration(context) {
 		/** @type {Sources} */

--- a/lib/ExternalModule.js
+++ b/lib/ExternalModule.js
@@ -1008,7 +1008,7 @@ class ExternalModule extends Module {
 
 	/**
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({
 		runtimeTemplate,

--- a/lib/Generator.js
+++ b/lib/Generator.js
@@ -92,7 +92,7 @@ class Generator {
 	 * @abstract
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {Source | null | Promise<Source | null>} generated code
 	 */
 	generate(
 		module,
@@ -173,7 +173,7 @@ class ByTypeGenerator extends Generator {
 	/**
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {Source | null | Promise<Source | null>} generated code
 	 */
 	generate(module, generateContext) {
 		const type = generateContext.type;

--- a/lib/Module.js
+++ b/lib/Module.js
@@ -117,14 +117,11 @@ const makeSerializable = require("./util/makeSerializable");
  * @property {[{ shareScope: string, initStage: number, init: string }]} share-init share-init for modules federation
  */
 
-/* eslint-disable jsdoc/type-formatting */
 /**
  * @template {string} K
  * @typedef {K extends keyof AllCodeGenerationSchemas ? AllCodeGenerationSchemas[K] : EXPECTED_ANY} CodeGenValue
  */
-/* eslint-enable jsdoc/type-formatting */
 
-/* eslint-disable jsdoc/require-template */
 /**
  * @typedef {object} CodeGenMapOverloads
  * @property {<K extends string>(key: K) => CodeGenValue<K> | undefined} get
@@ -1010,7 +1007,9 @@ class Module extends DependenciesBlock {
 			runtimes: [],
 			codeGenerationResults: undefined
 		};
-		const sources = this.codeGeneration(codeGenContext).sources;
+		const sources =
+			/** @type {CodeGenerationResult} */
+			(this.codeGeneration(codeGenContext)).sources;
 
 		return /** @type {Source} */ (
 			type
@@ -1064,7 +1063,7 @@ class Module extends DependenciesBlock {
 
 	/**
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration(context) {
 		// Best override this method

--- a/lib/NormalModule.js
+++ b/lib/NormalModule.js
@@ -1519,7 +1519,7 @@ class NormalModule extends Module {
 
 	/**
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({
 		dependencyTemplates,
@@ -1546,6 +1546,8 @@ class NormalModule extends Module {
 
 		/** @type {Sources} */
 		const sources = new Map();
+		/** @type {Promise<void>[] | undefined} */
+		let promises;
 		for (const type of sourceTypes || chunkGraph.getModuleSourceTypes(this)) {
 			// TODO webpack@6 make generateError required
 			const generator =
@@ -1581,8 +1583,21 @@ class NormalModule extends Module {
 						type
 					});
 
-			if (source) {
-				sources.set(type, new CachedSource(source));
+			if (
+				source !== null &&
+				source !== undefined &&
+				typeof (/** @type {EXPECTED_ANY} */ (source).then) === "function"
+			) {
+				if (promises === undefined) promises = [];
+				promises.push(
+					/** @type {Promise<Source | null>} */ (
+						/** @type {unknown} */ (source)
+					).then((s) => {
+						if (s) sources.set(type, new CachedSource(s));
+					})
+				);
+			} else if (source) {
+				sources.set(type, new CachedSource(/** @type {Source} */ (source)));
 			}
 		}
 
@@ -1592,6 +1607,11 @@ class NormalModule extends Module {
 			runtimeRequirements,
 			data: this._codeGeneratorData
 		};
+
+		if (promises !== undefined) {
+			return Promise.all(promises).then(() => resultEntry);
+		}
+
 		return resultEntry;
 	}
 

--- a/lib/RawModule.js
+++ b/lib/RawModule.js
@@ -120,7 +120,7 @@ class RawModule extends Module {
 
 	/**
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration(context) {
 		/** @type {Sources} */

--- a/lib/RuntimeModule.js
+++ b/lib/RuntimeModule.js
@@ -157,7 +157,7 @@ class RuntimeModule extends Module {
 
 	/**
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration(context) {
 		/** @type {Sources} */

--- a/lib/Template.js
+++ b/lib/Template.js
@@ -382,7 +382,9 @@ class Template {
 					codeGenerationResults
 				});
 				if (!codeGenResult) continue;
-				runtimeSource = codeGenResult.sources.get("runtime");
+				runtimeSource =
+					/** @type {import("./Module").CodeGenerationResult} */
+					(codeGenResult).sources.get("runtime");
 			}
 			if (runtimeSource) {
 				source.add(`${Template.toNormalComment(module.identifier())}\n`);

--- a/lib/asset/AssetBytesGenerator.js
+++ b/lib/asset/AssetBytesGenerator.js
@@ -40,7 +40,7 @@ class AssetSourceGenerator extends Generator {
 	/**
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {Source | null | Promise<Source | null>} generated code
 	 */
 	generate(
 		module,

--- a/lib/asset/AssetGenerator.js
+++ b/lib/asset/AssetGenerator.js
@@ -524,7 +524,7 @@ class AssetGenerator extends Generator {
 	/**
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {Source | null | Promise<Source | null>} generated code
 	 */
 	generate(module, generateContext) {
 		const {

--- a/lib/asset/AssetSourceGenerator.js
+++ b/lib/asset/AssetSourceGenerator.js
@@ -40,7 +40,7 @@ class AssetSourceGenerator extends Generator {
 	/**
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {Source | null | Promise<Source | null>} generated code
 	 */
 	generate(
 		module,

--- a/lib/asset/RawDataUrlModule.js
+++ b/lib/asset/RawDataUrlModule.js
@@ -114,7 +114,7 @@ class RawDataUrlModule extends Module {
 
 	/**
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration(context) {
 		if (this.url === undefined) {

--- a/lib/container/ContainerEntryModule.js
+++ b/lib/container/ContainerEntryModule.js
@@ -148,7 +148,7 @@ class ContainerEntryModule extends Module {
 
 	/**
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ moduleGraph, chunkGraph, runtimeTemplate }) {
 		/** @type {Sources} */

--- a/lib/container/FallbackModule.js
+++ b/lib/container/FallbackModule.js
@@ -133,7 +133,7 @@ class FallbackModule extends Module {
 
 	/**
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ runtimeTemplate, moduleGraph, chunkGraph }) {
 		const ids = this.dependencies.map((dep) =>

--- a/lib/container/RemoteModule.js
+++ b/lib/container/RemoteModule.js
@@ -176,7 +176,7 @@ class RemoteModule extends Module {
 
 	/**
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ moduleGraph, chunkGraph }) {
 		const module = moduleGraph.getModule(this.dependencies[0]);

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -180,11 +180,12 @@ class CssGenerator extends Generator {
 	 */
 	_processContent(cssSource, module, compilation) {
 		/**
-		 * @param {string} content CSS content
-		 * @param {import("webpack-sources").RawSourceMap | null} map source map
+		 * @param {Source} source processed CSS source
 		 * @returns {Source} JS string literal source
 		 */
-		const toJsLiteral = (content, map) => {
+		const toJsLiteral = (source) => {
+			const { source: raw, map } = source.sourceAndMap();
+			const content = /** @type {string} */ (raw);
 			const escaped = JSON.stringify(content);
 			if (map) {
 				return new SourceMapSource(escaped, module.identifier(), map, content);
@@ -192,21 +193,14 @@ class CssGenerator extends Generator {
 			return new RawSource(escaped);
 		};
 
-		const { source: raw, map } = cssSource.sourceAndMap();
-		const content = /** @type {string} */ (raw);
-
 		if (!compilation.hooks.processContent.isUsed()) {
-			return toJsLiteral(content, map);
+			return toJsLiteral(cssSource);
 		}
 
 		const name = /** @type {string} */ (module.resource);
-		/** @type {import("../Compilation").ProcessContentEntry} */
-		const entry = [content, map || undefined];
 		return compilation.hooks.processContent
-			.promise(entry, name)
-			.then((result) =>
-				toJsLiteral(/** @type {string} */ (result[0]), result[1] || null)
-			);
+			.promise(cssSource, name)
+			.then(toJsLiteral);
 	}
 
 	/**

--- a/lib/css/CssGenerator.js
+++ b/lib/css/CssGenerator.js
@@ -171,20 +171,42 @@ class CssGenerator extends Generator {
 	}
 
 	/**
-	 * Convert a CSS Source to a JS string literal Source, preserving source map.
-	 * Wraps the CSS content with JSON.stringify so it can be embedded in JS code.
+	 * Process CSS source through the processContent hook, then convert to a
+	 * JS string literal Source preserving source map.
 	 * @param {Source} cssSource the CSS source
 	 * @param {NormalModule} module the module
-	 * @returns {Source} a Source representing a JS string literal
+	 * @param {Compilation} compilation the compilation
+	 * @returns {Source | Promise<Source>} a Source representing a JS string literal
 	 */
-	_cssSourceToJsStringLiteral(cssSource, module) {
-		const { source, map } = cssSource.sourceAndMap();
-		const content = /** @type {string} */ (source);
-		const escaped = JSON.stringify(content);
-		if (map) {
-			return new SourceMapSource(escaped, module.identifier(), map, content);
+	_processContent(cssSource, module, compilation) {
+		/**
+		 * @param {string} content CSS content
+		 * @param {import("webpack-sources").RawSourceMap | null} map source map
+		 * @returns {Source} JS string literal source
+		 */
+		const toJsLiteral = (content, map) => {
+			const escaped = JSON.stringify(content);
+			if (map) {
+				return new SourceMapSource(escaped, module.identifier(), map, content);
+			}
+			return new RawSource(escaped);
+		};
+
+		const { source: raw, map } = cssSource.sourceAndMap();
+		const content = /** @type {string} */ (raw);
+
+		if (!compilation.hooks.processContent.isUsed()) {
+			return toJsLiteral(content, map);
 		}
-		return new RawSource(escaped);
+
+		const name = /** @type {string} */ (module.resource);
+		/** @type {import("../Compilation").ProcessContentEntry} */
+		const entry = [content, map || undefined];
+		return compilation.hooks.processContent
+			.promise(entry, name)
+			.then((result) =>
+				toJsLiteral(/** @type {string} */ (result[0]), result[1] || null)
+			);
 	}
 
 	/**
@@ -278,7 +300,7 @@ class CssGenerator extends Generator {
 	/**
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {Source | null | Promise<Source | null>} generated code
 	 */
 	generate(module, generateContext) {
 		const exportType = /** @type {CssModule} */ (module).exportType || "link";
@@ -315,11 +337,25 @@ class CssGenerator extends Generator {
 								RuntimeGlobals.cssInjectStyle
 							);
 
-							return new ConcatSource(
-								`${RuntimeGlobals.cssInjectStyle}(${JSON.stringify(moduleId || "")}, `,
-								this._cssSourceToJsStringLiteral(cssSource, module),
-								");"
+							const jsLiteral = this._processContent(
+								cssSource,
+								module,
+								generateContext.runtimeTemplate.compilation
 							);
+							/**
+							 * @param {Source} literal JS string literal
+							 * @returns {Source} style injection code
+							 */
+							const buildStyle = (literal) =>
+								new ConcatSource(
+									`${RuntimeGlobals.cssInjectStyle}(${JSON.stringify(moduleId || "")}, `,
+									literal,
+									");"
+								);
+							if (jsLiteral instanceof Promise) {
+								return jsLiteral.then(buildStyle);
+							}
+							return buildStyle(jsLiteral);
 						}
 
 						default:
@@ -338,7 +374,7 @@ class CssGenerator extends Generator {
 					}
 				};
 				const generateExportCode = () => {
-					/** @returns {Source} generated CSS text as JS expression */
+					/** @returns {Source | Promise<Source>} generated CSS text as JS expression */
 					const generateCssText = () => {
 						const importCode = this._generateImportCode(
 							module,
@@ -348,38 +384,51 @@ class CssGenerator extends Generator {
 							module,
 							generateContext
 						);
-						const jsLiteral = cssSource
-							? this._cssSourceToJsStringLiteral(cssSource, module)
-							: new RawSource('""');
 
-						if (importCode.length > 0) {
-							if (
-								exportType === "css-style-sheet" ||
-								importCode.some((part) => part.type !== exportType)
-							) {
-								generateContext.runtimeRequirements.add(
-									RuntimeGlobals.cssMergeStyleSheets
-								);
+						/**
+						 * @param {Source} literal JS string literal
+						 * @returns {Source} CSS text expression
+						 */
+						const buildCssText = (literal) => {
+							if (importCode.length > 0) {
+								if (
+									exportType === "css-style-sheet" ||
+									importCode.some((part) => part.type !== exportType)
+								) {
+									generateContext.runtimeRequirements.add(
+										RuntimeGlobals.cssMergeStyleSheets
+									);
 
-								const args = importCode.map((part) => part.expr);
+									const args = importCode.map((part) => part.expr);
+									return new ConcatSource(
+										`${RuntimeGlobals.cssMergeStyleSheets}([${args.join(", ")}, `,
+										literal,
+										"])"
+									);
+								}
 								return new ConcatSource(
-									`${RuntimeGlobals.cssMergeStyleSheets}([${args.join(", ")}, `,
-									jsLiteral,
-									"])"
+									`${generateContext.runtimeTemplate.concatenation(
+										...importCode
+									)} + `,
+									literal
 								);
 							}
-							return new ConcatSource(
-								`${generateContext.runtimeTemplate.concatenation(
-									...importCode
-								)} + `,
-								jsLiteral
-							);
+							return literal;
+						};
+
+						if (!cssSource) return buildCssText(new RawSource('""'));
+
+						const jsLiteral = this._processContent(
+							cssSource,
+							module,
+							generateContext.runtimeTemplate.compilation
+						);
+						if (jsLiteral instanceof Promise) {
+							return jsLiteral.then(buildCssText);
 						}
-						return jsLiteral;
+						return buildCssText(jsLiteral);
 					};
-					/**
-					 * @returns {Source | null} the default export
-					 */
+					/** @returns {Source | null | Promise<Source | null>} the default export */
 					const generateJSDefaultExport = () => {
 						switch (exportType) {
 							case "text": {
@@ -397,11 +446,20 @@ class CssGenerator extends Generator {
 									`${constOrVar} sheet = new CSSStyleSheet();\n` +
 									"sheet.replaceSync(cssText);\n" +
 									"return sheet;\n";
-								return new ConcatSource(
-									`(${fnPrefix}${constOrVar} cssText = `,
-									cssText,
-									`;\n${body}})()`
-								);
+								/**
+								 * @param {Source} resolvedCssText resolved CSS text source
+								 * @returns {Source} css-style-sheet factory code
+								 */
+								const buildSheet = (resolvedCssText) =>
+									new ConcatSource(
+										`(${fnPrefix}${constOrVar} cssText = `,
+										resolvedCssText,
+										`;\n${body}})()`
+									);
+								if (cssText instanceof Promise) {
+									return cssText.then(buildSheet);
+								}
+								return buildSheet(cssText);
 							}
 							default:
 								return null;
@@ -410,8 +468,6 @@ class CssGenerator extends Generator {
 
 					const isCSSModule = /** @type {BuildMeta} */ (module.buildMeta)
 						.isCSSModule;
-					/** @type {Source | null} */
-					const defaultExport = generateJSDefaultExport();
 
 					/** @type {BuildInfo} */
 					(module.buildInfo).cssData = cssData;
@@ -421,132 +477,159 @@ class CssGenerator extends Generator {
 						generateContext.runtimeRequirements.add(RuntimeGlobals.module);
 					}
 
-					if (!defaultExport && cssData.exports.size === 0 && !isCSSModule) {
-						return new RawSource("");
-					}
+					/**
+					 * @param {Source | null} defaultExport resolved default export
+					 * @returns {Source} export code
+					 */
+					const buildExportCode = (defaultExport) => {
+						if (!defaultExport && cssData.exports.size === 0 && !isCSSModule) {
+							return new RawSource("");
+						}
 
-					if (generateContext.concatenationScope) {
-						const source = new ConcatSource();
-						/** @type {Set<string>} */
-						const usedIdentifiers = new Set();
-						const { RESERVED_IDENTIFIER } = getPropertyName();
+						if (generateContext.concatenationScope) {
+							const source = new ConcatSource();
+							/** @type {Set<string>} */
+							const usedIdentifiers = new Set();
+							const { RESERVED_IDENTIFIER } = getPropertyName();
 
-						if (defaultExport) {
-							const usedName = generateContext.moduleGraph
-								.getExportInfo(module, "default")
-								.getUsedName("default", generateContext.runtime);
-							if (usedName) {
+							if (defaultExport) {
+								const usedName = generateContext.moduleGraph
+									.getExportInfo(module, "default")
+									.getUsedName("default", generateContext.runtime);
+								if (usedName) {
+									let identifier = Template.toIdentifier(usedName);
+									if (RESERVED_IDENTIFIER.has(identifier)) {
+										identifier = `_${identifier}`;
+									}
+									usedIdentifiers.add(identifier);
+									generateContext.concatenationScope.registerExport(
+										"default",
+										identifier
+									);
+									source.add(
+										`${generateContext.runtimeTemplate.renderConst()} ${identifier} = `
+									);
+									source.add(defaultExport);
+									source.add(";\n");
+								}
+							}
+
+							for (const [name, v] of cssData.exports) {
+								const usedName = generateContext.moduleGraph
+									.getExportInfo(module, name)
+									.getUsedName(name, generateContext.runtime);
+								if (!usedName) {
+									continue;
+								}
+
 								let identifier = Template.toIdentifier(usedName);
 								if (RESERVED_IDENTIFIER.has(identifier)) {
 									identifier = `_${identifier}`;
 								}
+								let i = 0;
+								while (usedIdentifiers.has(identifier)) {
+									identifier = Template.toIdentifier(name + i);
+									i += 1;
+								}
 								usedIdentifiers.add(identifier);
 								generateContext.concatenationScope.registerExport(
-									"default",
+									name,
 									identifier
 								);
 								source.add(
-									`${generateContext.runtimeTemplate.renderConst()} ${identifier} = `
+									`${generateContext.runtimeTemplate.renderConst()} ${identifier} = ${JSON.stringify(v)};\n`
 								);
-								source.add(defaultExport);
-								source.add(";\n");
+							}
+							return source;
+						}
+
+						const needNsObj =
+							this._esModule &&
+							generateContext.moduleGraph
+								.getExportsInfo(module)
+								.otherExportsInfo.getUsed(generateContext.runtime) !==
+								UsageState.Unused;
+
+						if (needNsObj) {
+							generateContext.runtimeRequirements.add(
+								RuntimeGlobals.makeNamespaceObject
+							);
+						}
+
+						// Should be after `concatenationScope` to allow module inlining
+						generateContext.runtimeRequirements.add(RuntimeGlobals.module);
+
+						if (!isCSSModule && !needNsObj) {
+							return new ConcatSource(
+								`${module.moduleArgument}.exports = `,
+								/** @type {Source} */ (defaultExport)
+							);
+						}
+
+						const result = new ConcatSource();
+						result.add(
+							`${needNsObj ? `${RuntimeGlobals.makeNamespaceObject}(` : ""}${
+								module.moduleArgument
+							}.exports = {\n`
+						);
+
+						if (defaultExport) {
+							result.add('\t"default": ');
+							result.add(defaultExport);
+							if (cssData.exports.size > 0) {
+								result.add(",\n");
 							}
 						}
 
+						/** @type {string[]} */
+						const exportEntries = [];
 						for (const [name, v] of cssData.exports) {
-							const usedName = generateContext.moduleGraph
-								.getExportInfo(module, name)
-								.getUsedName(name, generateContext.runtime);
-							if (!usedName) {
-								continue;
-							}
-
-							let identifier = Template.toIdentifier(usedName);
-							if (RESERVED_IDENTIFIER.has(identifier)) {
-								identifier = `_${identifier}`;
-							}
-							let i = 0;
-							while (usedIdentifiers.has(identifier)) {
-								identifier = Template.toIdentifier(name + i);
-								i += 1;
-							}
-							usedIdentifiers.add(identifier);
-							generateContext.concatenationScope.registerExport(
-								name,
-								identifier
-							);
-							source.add(
-								`${generateContext.runtimeTemplate.renderConst()} ${identifier} = ${JSON.stringify(v)};\n`
+							exportEntries.push(
+								`\t${JSON.stringify(name)}: ${JSON.stringify(v)}`
 							);
 						}
-						return source;
-					}
-
-					const needNsObj =
-						this._esModule &&
-						generateContext.moduleGraph
-							.getExportsInfo(module)
-							.otherExportsInfo.getUsed(generateContext.runtime) !==
-							UsageState.Unused;
-
-					if (needNsObj) {
-						generateContext.runtimeRequirements.add(
-							RuntimeGlobals.makeNamespaceObject
-						);
-					}
-
-					// Should be after `concatenationScope` to allow module inlining
-					generateContext.runtimeRequirements.add(RuntimeGlobals.module);
-
-					if (!isCSSModule && !needNsObj) {
-						return new ConcatSource(
-							`${module.moduleArgument}.exports = `,
-							/** @type {Source} */ (defaultExport)
-						);
-					}
-
-					const result = new ConcatSource();
-					result.add(
-						`${needNsObj ? `${RuntimeGlobals.makeNamespaceObject}(` : ""}${
-							module.moduleArgument
-						}.exports = {\n`
-					);
-
-					if (defaultExport) {
-						result.add('\t"default": ');
-						result.add(defaultExport);
-						if (cssData.exports.size > 0) {
-							result.add(",\n");
+						if (exportEntries.length > 0) {
+							result.add(exportEntries.join(",\n"));
 						}
-					}
 
-					/** @type {string[]} */
-					const exportEntries = [];
-					for (const [name, v] of cssData.exports) {
-						exportEntries.push(
-							`\t${JSON.stringify(name)}: ${JSON.stringify(v)}`
-						);
-					}
-					if (exportEntries.length > 0) {
-						result.add(exportEntries.join(",\n"));
-					}
+						result.add(`\n}${needNsObj ? ")" : ""};`);
+						return result;
+					};
 
-					result.add(`\n}${needNsObj ? ")" : ""};`);
-					return result;
+					const defaultExportResult = generateJSDefaultExport();
+					if (defaultExportResult instanceof Promise) {
+						return defaultExportResult.then(buildExportCode);
+					}
+					return buildExportCode(defaultExportResult);
 				};
 
 				const codeParts = this._exportsOnly
 					? [generateExportCode()]
 					: [generateImportCode(), generateContentCode(), generateExportCode()];
 
-				const source = new ConcatSource();
-				for (const part of codeParts) {
-					if (part) {
-						source.add(part);
-						source.add("\n");
+				/**
+				 * @param {(Source | string | "")[]} parts resolved code parts
+				 * @returns {Source} assembled source
+				 */
+				const assemble = (parts) => {
+					const source = new ConcatSource();
+					for (const part of parts) {
+						if (part) {
+							source.add(part);
+							source.add("\n");
+						}
 					}
+					return source;
+				};
+
+				if (codeParts.some((p) => p instanceof Promise)) {
+					return Promise.all(codeParts).then(
+						/** @type {(parts: (Source | string | "")[]) => Source} */ (
+							assemble
+						)
+					);
 				}
-				return source;
+				return assemble(/** @type {(Source | string | "")[]} */ (codeParts));
 			}
 			case CSS_TYPE: {
 				if (

--- a/lib/hmr/LazyCompilationPlugin.js
+++ b/lib/hmr/LazyCompilationPlugin.js
@@ -224,7 +224,7 @@ class LazyCompilationProxyModule extends Module {
 
 	/**
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ runtimeTemplate, chunkGraph, moduleGraph }) {
 		/** @type {Sources} */

--- a/lib/javascript/JavascriptGenerator.js
+++ b/lib/javascript/JavascriptGenerator.js
@@ -246,7 +246,7 @@ class JavascriptGenerator extends Generator {
 	/**
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {Source | null | Promise<Source | null>} generated code
 	 */
 	generate(module, generateContext) {
 		const originalSource = module.originalSource();

--- a/lib/json/JsonGenerator.js
+++ b/lib/json/JsonGenerator.js
@@ -164,7 +164,7 @@ class JsonGenerator extends Generator {
 	/**
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {Source | null | Promise<Source | null>} generated code
 	 */
 	generate(
 		module,

--- a/lib/optimize/ConcatenatedModule.js
+++ b/lib/optimize/ConcatenatedModule.js
@@ -1266,7 +1266,7 @@ class ConcatenatedModule extends Module {
 
 	/**
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({
 		dependencyTemplates,
@@ -1301,8 +1301,10 @@ class ConcatenatedModule extends Module {
 
 		// Generate source code and analyse scopes
 		// Prepare a ReplaceSource for the final source
+		/** @type {Promise<void>[] | undefined} */
+		let analysisPromises;
 		for (const info of moduleToInfoMap.values()) {
-			this._analyseModule(
+			const result = this._analyseModule(
 				moduleToInfoMap,
 				info,
 				dependencyTemplates,
@@ -1315,73 +1317,392 @@ class ConcatenatedModule extends Module {
 				(codeGenerationResults),
 				allUsedNames
 			);
+			if (result instanceof Promise) {
+				if (analysisPromises === undefined) analysisPromises = [];
+				analysisPromises.push(result);
+			}
 		}
 
-		// Updated Top level declarations are created by renaming
-		/** @type {TopLevelDeclarations} */
-		const topLevelDeclarations = new Set();
+		/**
+		 * @returns {CodeGenerationResult} the code generation result
+		 */
+		const continueCodeGeneration = () => {
+			// Updated Top level declarations are created by renaming
+			/** @type {TopLevelDeclarations} */
+			const topLevelDeclarations = new Set();
 
-		// List of additional names in scope for module references
-		/** @type {Map<string, ScopeInfo>} */
-		const usedNamesInScopeInfo = new Map();
+			// List of additional names in scope for module references
+			/** @type {Map<string, ScopeInfo>} */
+			const usedNamesInScopeInfo = new Map();
 
-		// Set of already checked scopes
-		/** @type {Set<Scope>} */
-		const ignoredScopes = new Set();
+			// Set of already checked scopes
+			/** @type {Set<Scope>} */
+			const ignoredScopes = new Set();
 
-		// get all global names
-		for (const info of modulesWithInfo) {
-			if (info.type === "concatenated") {
-				// ignore symbols from moduleScope
-				if (info.moduleScope) {
-					ignoredScopes.add(info.moduleScope);
-				}
+			// get all global names
+			for (const info of modulesWithInfo) {
+				if (info.type === "concatenated") {
+					// ignore symbols from moduleScope
+					if (info.moduleScope) {
+						ignoredScopes.add(info.moduleScope);
+					}
 
-				// The super class expression in class scopes behaves weird
-				// We get ranges of all super class expressions to make
-				// renaming to work correctly
-				/** @typedef {{ range: Range, variables: Variable[] }} ClassInfo */
-				/** @type {WeakMap<Scope, ClassInfo[]>} */
-				const superClassCache = new WeakMap();
-				/**
-				 * @param {Scope} scope scope
-				 * @returns {ClassInfo[]} result
-				 */
-				const getSuperClassExpressions = (scope) => {
-					const cacheEntry = superClassCache.get(scope);
-					if (cacheEntry !== undefined) return cacheEntry;
-					/** @type {ClassInfo[]} */
-					const superClassExpressions = [];
-					for (const childScope of scope.childScopes) {
-						if (childScope.type !== "class") continue;
-						const block = childScope.block;
-						if (
-							(block.type === "ClassDeclaration" ||
-								block.type === "ClassExpression") &&
-							block.superClass
-						) {
-							superClassExpressions.push({
-								range: /** @type {Range} */ (block.superClass.range),
-								variables: childScope.variables
-							});
+					// The super class expression in class scopes behaves weird
+					// We get ranges of all super class expressions to make
+					// renaming to work correctly
+					/** @typedef {{ range: Range, variables: Variable[] }} ClassInfo */
+					/** @type {WeakMap<Scope, ClassInfo[]>} */
+					const superClassCache = new WeakMap();
+					/**
+					 * @param {Scope} scope scope
+					 * @returns {ClassInfo[]} result
+					 */
+					const getSuperClassExpressions = (scope) => {
+						const cacheEntry = superClassCache.get(scope);
+						if (cacheEntry !== undefined) return cacheEntry;
+						/** @type {ClassInfo[]} */
+						const superClassExpressions = [];
+						for (const childScope of scope.childScopes) {
+							if (childScope.type !== "class") continue;
+							const block = childScope.block;
+							if (
+								(block.type === "ClassDeclaration" ||
+									block.type === "ClassExpression") &&
+								block.superClass
+							) {
+								superClassExpressions.push({
+									range: /** @type {Range} */ (block.superClass.range),
+									variables: childScope.variables
+								});
+							}
+						}
+						superClassCache.set(scope, superClassExpressions);
+						return superClassExpressions;
+					};
+
+					// add global symbols
+					if (info.globalScope) {
+						for (const reference of info.globalScope.through) {
+							const name = reference.identifier.name;
+							if (ConcatenationScope.isModuleReference(name)) {
+								const match = ConcatenationScope.matchModuleReference(name);
+								if (!match) continue;
+								const referencedInfo = modulesWithInfo[match.index];
+								if (referencedInfo.type === "reference") {
+									throw new Error(
+										"Module reference can't point to a reference"
+									);
+								}
+								const binding = getFinalBinding(
+									moduleGraph,
+									referencedInfo,
+									match.ids,
+									moduleToInfoMap,
+									runtime,
+									requestShortener,
+									runtimeTemplate,
+									neededNamespaceObjects,
+									false,
+									match.deferredImport,
+									/** @type {BuildMeta} */
+									(info.module.buildMeta).strictHarmonyModule,
+									true
+								);
+								if (!binding.ids) continue;
+								const { usedNames, alreadyCheckedScopes } =
+									getUsedNamesInScopeInfo(
+										usedNamesInScopeInfo,
+										binding.info.module.identifier(),
+										"name" in binding ? binding.name : ""
+									);
+								for (const expr of getSuperClassExpressions(reference.from)) {
+									if (
+										expr.range[0] <=
+											/** @type {Range} */ (reference.identifier.range)[0] &&
+										expr.range[1] >=
+											/** @type {Range} */ (reference.identifier.range)[1]
+									) {
+										for (const variable of expr.variables) {
+											usedNames.add(variable.name);
+										}
+									}
+								}
+								addScopeSymbols(
+									reference.from,
+									usedNames,
+									alreadyCheckedScopes,
+									ignoredScopes
+								);
+							} else {
+								allUsedNames.add(name);
+							}
 						}
 					}
-					superClassCache.set(scope, superClassExpressions);
-					return superClassExpressions;
-				};
+				}
+			}
 
-				// add global symbols
-				if (info.globalScope) {
-					for (const reference of info.globalScope.through) {
+			/**
+			 * @param {string} name the name to find a new name for
+			 * @param {ConcatenatedModuleInfo} info the info of the module
+			 * @param {Reference[]} references the references to the name
+			 * @returns {string | undefined} the new name or undefined if the name is not found
+			 */
+			const _findNewName = (name, info, references) => {
+				const { usedNames, alreadyCheckedScopes } = getUsedNamesInScopeInfo(
+					usedNamesInScopeInfo,
+					info.module.identifier(),
+					name
+				);
+				if (allUsedNames.has(name) || usedNames.has(name)) {
+					for (const ref of references) {
+						addScopeSymbols(
+							ref.from,
+							usedNames,
+							alreadyCheckedScopes,
+							ignoredScopes
+						);
+					}
+					const newName = findNewName(
+						name,
+						allUsedNames,
+						usedNames,
+						info.module.readableIdentifier(requestShortener)
+					);
+					allUsedNames.add(newName);
+					info.internalNames.set(name, newName);
+					topLevelDeclarations.add(newName);
+					return newName;
+				}
+			};
+
+			/**
+			 * @param {string} name the name to find a new name for
+			 * @param {ConcatenatedModuleInfo} info the info of the module
+			 * @param {Reference[]} references the references to the name
+			 * @returns {string | undefined} the new name or undefined if the name is not found
+			 */
+			const _findNewNameForSpecifier = (name, info, references) => {
+				const { usedNames: moduleUsedNames, alreadyCheckedScopes } =
+					getUsedNamesInScopeInfo(
+						usedNamesInScopeInfo,
+						info.module.identifier(),
+						name
+					);
+				/** @type {UsedNames} */
+				const referencesUsedNames = new Set();
+				for (const ref of references) {
+					addScopeSymbols(
+						ref.from,
+						referencesUsedNames,
+						alreadyCheckedScopes,
+						ignoredScopes
+					);
+				}
+				if (moduleUsedNames.has(name) || referencesUsedNames.has(name)) {
+					const newName = findNewName(
+						name,
+						allUsedNames,
+						new Set([...moduleUsedNames, ...referencesUsedNames]),
+						info.module.readableIdentifier(requestShortener)
+					);
+					allUsedNames.add(newName);
+					topLevelDeclarations.add(newName);
+					return newName;
+				}
+			};
+
+			// generate names for symbols
+			for (const info of moduleToInfoMap.values()) {
+				const { usedNames: namespaceObjectUsedNames } = getUsedNamesInScopeInfo(
+					usedNamesInScopeInfo,
+					info.module.identifier(),
+					""
+				);
+				switch (info.type) {
+					case "concatenated": {
+						const variables = /** @type {Scope} */ (info.moduleScope).variables;
+						for (const variable of variables) {
+							const name = variable.name;
+							const references = getAllReferences(variable);
+							const newName = _findNewName(name, info, references);
+							if (newName) {
+								const source = /** @type {ReplaceSource} */ (info.source);
+								const allIdentifiers = new Set([
+									...references.map((r) => r.identifier),
+									...variable.identifiers
+								]);
+								for (const identifier of allIdentifiers) {
+									const r = /** @type {Range} */ (identifier.range);
+									const path = getPathInAst(
+										/** @type {NonNullable<ConcatenatedModuleInfo["ast"]>} */
+										(info.ast),
+										identifier
+									);
+									if (path && path.length > 1) {
+										const maybeProperty =
+											path[1].type === "AssignmentPattern" &&
+											path[1].left === path[0]
+												? path[2]
+												: path[1];
+										if (
+											maybeProperty.type === "Property" &&
+											maybeProperty.shorthand
+										) {
+											source.insert(r[1], `: ${newName}`);
+											continue;
+										}
+									}
+									source.replace(r[0], r[1] - 1, newName);
+								}
+							} else {
+								allUsedNames.add(name);
+								info.internalNames.set(name, name);
+								topLevelDeclarations.add(name);
+							}
+						}
+						/** @type {string} */
+						let namespaceObjectName;
+						if (info.namespaceExportSymbol) {
+							namespaceObjectName =
+								/** @type {string} */
+								(info.internalNames.get(info.namespaceExportSymbol));
+						} else {
+							namespaceObjectName = findNewName(
+								"namespaceObject",
+								allUsedNames,
+								namespaceObjectUsedNames,
+								info.module.readableIdentifier(requestShortener)
+							);
+							allUsedNames.add(namespaceObjectName);
+						}
+						info.namespaceObjectName = namespaceObjectName;
+						topLevelDeclarations.add(namespaceObjectName);
+						break;
+					}
+					case "external": {
+						const externalName = findNewName(
+							"",
+							allUsedNames,
+							namespaceObjectUsedNames,
+							info.module.readableIdentifier(requestShortener)
+						);
+						allUsedNames.add(externalName);
+						info.name = externalName;
+						topLevelDeclarations.add(externalName);
+
+						if (info.deferred) {
+							const externalName = findNewName(
+								"deferred",
+								allUsedNames,
+								namespaceObjectUsedNames,
+								info.module.readableIdentifier(requestShortener)
+							);
+							allUsedNames.add(externalName);
+							info.deferredName = externalName;
+							topLevelDeclarations.add(externalName);
+
+							const externalNameInterop = findNewName(
+								"deferredNamespaceObject",
+								allUsedNames,
+								namespaceObjectUsedNames,
+								info.module.readableIdentifier(requestShortener)
+							);
+							allUsedNames.add(externalNameInterop);
+							info.deferredNamespaceObjectName = externalNameInterop;
+							topLevelDeclarations.add(externalNameInterop);
+						}
+						break;
+					}
+				}
+				const buildMeta = /** @type {BuildMeta} */ (info.module.buildMeta);
+				if (buildMeta.exportsType !== "namespace") {
+					const externalNameInterop = findNewName(
+						"namespaceObject",
+						allUsedNames,
+						namespaceObjectUsedNames,
+						info.module.readableIdentifier(requestShortener)
+					);
+					allUsedNames.add(externalNameInterop);
+					info.interopNamespaceObjectName = externalNameInterop;
+					topLevelDeclarations.add(externalNameInterop);
+				}
+				if (
+					buildMeta.exportsType === "default" &&
+					buildMeta.defaultObject !== "redirect" &&
+					info.interopNamespaceObject2Used
+				) {
+					const externalNameInterop = findNewName(
+						"namespaceObject2",
+						allUsedNames,
+						namespaceObjectUsedNames,
+						info.module.readableIdentifier(requestShortener)
+					);
+					allUsedNames.add(externalNameInterop);
+					info.interopNamespaceObject2Name = externalNameInterop;
+					topLevelDeclarations.add(externalNameInterop);
+				}
+				if (buildMeta.exportsType === "dynamic" || !buildMeta.exportsType) {
+					const externalNameInterop = findNewName(
+						"default",
+						allUsedNames,
+						namespaceObjectUsedNames,
+						info.module.readableIdentifier(requestShortener)
+					);
+					allUsedNames.add(externalNameInterop);
+					info.interopDefaultAccessName = externalNameInterop;
+					topLevelDeclarations.add(externalNameInterop);
+				}
+			}
+
+			// Find and replace references to modules
+			for (const info of moduleToInfoMap.values()) {
+				if (info.type === "concatenated") {
+					const globalScope = /** @type {Scope} */ (info.globalScope);
+					// group references by name
+					/** @type {Map<string, Reference[]>} */
+					const referencesByName = new Map();
+					for (const reference of globalScope.through) {
 						const name = reference.identifier.name;
-						if (ConcatenationScope.isModuleReference(name)) {
-							const match = ConcatenationScope.matchModuleReference(name);
-							if (!match) continue;
+						if (!referencesByName.has(name)) {
+							referencesByName.set(name, []);
+						}
+						/** @type {Reference[]} */
+						(referencesByName.get(name)).push(reference);
+					}
+					for (const [name, references] of referencesByName) {
+						const match = ConcatenationScope.matchModuleReference(name);
+						if (match) {
 							const referencedInfo = modulesWithInfo[match.index];
 							if (referencedInfo.type === "reference") {
 								throw new Error("Module reference can't point to a reference");
 							}
-							const binding = getFinalBinding(
+							const concatenationScope = /** @type {ConcatenatedModuleInfo} */ (
+								referencedInfo
+							).concatenationScope;
+							const exportId = match.ids[0];
+							const specifier =
+								concatenationScope && concatenationScope.getRawExport(exportId);
+							if (specifier) {
+								const newName = _findNewNameForSpecifier(
+									specifier,
+									info,
+									references
+								);
+								const initFragmentChanged =
+									newName &&
+									concatenatedModuleInfo.call(
+										{
+											rawExportMap: new Map([
+												[exportId, /** @type {string} */ (newName)]
+											])
+										},
+										/** @type {ConcatenatedModuleInfo} */ (referencedInfo)
+									);
+								if (initFragmentChanged) {
+									concatenationScope.setRawExportMap(exportId, newName);
+								}
+							}
+							const finalName = getFinalName(
 								moduleGraph,
 								referencedInfo,
 								match.ids,
@@ -1390,660 +1711,365 @@ class ConcatenatedModule extends Module {
 								requestShortener,
 								runtimeTemplate,
 								neededNamespaceObjects,
-								false,
+								match.call,
 								match.deferredImport,
+								!match.directImport,
 								/** @type {BuildMeta} */
 								(info.module.buildMeta).strictHarmonyModule,
-								true
+								match.asiSafe
 							);
-							if (!binding.ids) continue;
-							const { usedNames, alreadyCheckedScopes } =
-								getUsedNamesInScopeInfo(
-									usedNamesInScopeInfo,
-									binding.info.module.identifier(),
-									"name" in binding ? binding.name : ""
-								);
-							for (const expr of getSuperClassExpressions(reference.from)) {
-								if (
-									expr.range[0] <=
-										/** @type {Range} */ (reference.identifier.range)[0] &&
-									expr.range[1] >=
-										/** @type {Range} */ (reference.identifier.range)[1]
-								) {
-									for (const variable of expr.variables) {
-										usedNames.add(variable.name);
-									}
-								}
-							}
-							addScopeSymbols(
-								reference.from,
-								usedNames,
-								alreadyCheckedScopes,
-								ignoredScopes
-							);
-						} else {
-							allUsedNames.add(name);
-						}
-					}
-				}
-			}
-		}
 
-		/**
-		 * @param {string} name the name to find a new name for
-		 * @param {ConcatenatedModuleInfo} info the info of the module
-		 * @param {Reference[]} references the references to the name
-		 * @returns {string | undefined} the new name or undefined if the name is not found
-		 */
-		const _findNewName = (name, info, references) => {
-			const { usedNames, alreadyCheckedScopes } = getUsedNamesInScopeInfo(
-				usedNamesInScopeInfo,
-				info.module.identifier(),
-				name
-			);
-			if (allUsedNames.has(name) || usedNames.has(name)) {
-				for (const ref of references) {
-					addScopeSymbols(
-						ref.from,
-						usedNames,
-						alreadyCheckedScopes,
-						ignoredScopes
-					);
-				}
-				const newName = findNewName(
-					name,
-					allUsedNames,
-					usedNames,
-					info.module.readableIdentifier(requestShortener)
-				);
-				allUsedNames.add(newName);
-				info.internalNames.set(name, newName);
-				topLevelDeclarations.add(newName);
-				return newName;
-			}
-		};
-
-		/**
-		 * @param {string} name the name to find a new name for
-		 * @param {ConcatenatedModuleInfo} info the info of the module
-		 * @param {Reference[]} references the references to the name
-		 * @returns {string | undefined} the new name or undefined if the name is not found
-		 */
-		const _findNewNameForSpecifier = (name, info, references) => {
-			const { usedNames: moduleUsedNames, alreadyCheckedScopes } =
-				getUsedNamesInScopeInfo(
-					usedNamesInScopeInfo,
-					info.module.identifier(),
-					name
-				);
-			/** @type {UsedNames} */
-			const referencesUsedNames = new Set();
-			for (const ref of references) {
-				addScopeSymbols(
-					ref.from,
-					referencesUsedNames,
-					alreadyCheckedScopes,
-					ignoredScopes
-				);
-			}
-			if (moduleUsedNames.has(name) || referencesUsedNames.has(name)) {
-				const newName = findNewName(
-					name,
-					allUsedNames,
-					new Set([...moduleUsedNames, ...referencesUsedNames]),
-					info.module.readableIdentifier(requestShortener)
-				);
-				allUsedNames.add(newName);
-				topLevelDeclarations.add(newName);
-				return newName;
-			}
-		};
-
-		// generate names for symbols
-		for (const info of moduleToInfoMap.values()) {
-			const { usedNames: namespaceObjectUsedNames } = getUsedNamesInScopeInfo(
-				usedNamesInScopeInfo,
-				info.module.identifier(),
-				""
-			);
-			switch (info.type) {
-				case "concatenated": {
-					const variables = /** @type {Scope} */ (info.moduleScope).variables;
-					for (const variable of variables) {
-						const name = variable.name;
-						const references = getAllReferences(variable);
-						const newName = _findNewName(name, info, references);
-						if (newName) {
-							const source = /** @type {ReplaceSource} */ (info.source);
-							const allIdentifiers = new Set([
-								...references.map((r) => r.identifier),
-								...variable.identifiers
-							]);
-							for (const identifier of allIdentifiers) {
-								const r = /** @type {Range} */ (identifier.range);
-								const path = getPathInAst(
-									/** @type {NonNullable<ConcatenatedModuleInfo["ast"]>} */
-									(info.ast),
-									identifier
-								);
-								if (path && path.length > 1) {
-									const maybeProperty =
-										path[1].type === "AssignmentPattern" &&
-										path[1].left === path[0]
-											? path[2]
-											: path[1];
-									if (
-										maybeProperty.type === "Property" &&
-										maybeProperty.shorthand
-									) {
-										source.insert(r[1], `: ${newName}`);
-										continue;
-									}
-								}
-								source.replace(r[0], r[1] - 1, newName);
-							}
-						} else {
-							allUsedNames.add(name);
-							info.internalNames.set(name, name);
-							topLevelDeclarations.add(name);
-						}
-					}
-					/** @type {string} */
-					let namespaceObjectName;
-					if (info.namespaceExportSymbol) {
-						namespaceObjectName =
-							/** @type {string} */
-							(info.internalNames.get(info.namespaceExportSymbol));
-					} else {
-						namespaceObjectName = findNewName(
-							"namespaceObject",
-							allUsedNames,
-							namespaceObjectUsedNames,
-							info.module.readableIdentifier(requestShortener)
-						);
-						allUsedNames.add(namespaceObjectName);
-					}
-					info.namespaceObjectName = namespaceObjectName;
-					topLevelDeclarations.add(namespaceObjectName);
-					break;
-				}
-				case "external": {
-					const externalName = findNewName(
-						"",
-						allUsedNames,
-						namespaceObjectUsedNames,
-						info.module.readableIdentifier(requestShortener)
-					);
-					allUsedNames.add(externalName);
-					info.name = externalName;
-					topLevelDeclarations.add(externalName);
-
-					if (info.deferred) {
-						const externalName = findNewName(
-							"deferred",
-							allUsedNames,
-							namespaceObjectUsedNames,
-							info.module.readableIdentifier(requestShortener)
-						);
-						allUsedNames.add(externalName);
-						info.deferredName = externalName;
-						topLevelDeclarations.add(externalName);
-
-						const externalNameInterop = findNewName(
-							"deferredNamespaceObject",
-							allUsedNames,
-							namespaceObjectUsedNames,
-							info.module.readableIdentifier(requestShortener)
-						);
-						allUsedNames.add(externalNameInterop);
-						info.deferredNamespaceObjectName = externalNameInterop;
-						topLevelDeclarations.add(externalNameInterop);
-					}
-					break;
-				}
-			}
-			const buildMeta = /** @type {BuildMeta} */ (info.module.buildMeta);
-			if (buildMeta.exportsType !== "namespace") {
-				const externalNameInterop = findNewName(
-					"namespaceObject",
-					allUsedNames,
-					namespaceObjectUsedNames,
-					info.module.readableIdentifier(requestShortener)
-				);
-				allUsedNames.add(externalNameInterop);
-				info.interopNamespaceObjectName = externalNameInterop;
-				topLevelDeclarations.add(externalNameInterop);
-			}
-			if (
-				buildMeta.exportsType === "default" &&
-				buildMeta.defaultObject !== "redirect" &&
-				info.interopNamespaceObject2Used
-			) {
-				const externalNameInterop = findNewName(
-					"namespaceObject2",
-					allUsedNames,
-					namespaceObjectUsedNames,
-					info.module.readableIdentifier(requestShortener)
-				);
-				allUsedNames.add(externalNameInterop);
-				info.interopNamespaceObject2Name = externalNameInterop;
-				topLevelDeclarations.add(externalNameInterop);
-			}
-			if (buildMeta.exportsType === "dynamic" || !buildMeta.exportsType) {
-				const externalNameInterop = findNewName(
-					"default",
-					allUsedNames,
-					namespaceObjectUsedNames,
-					info.module.readableIdentifier(requestShortener)
-				);
-				allUsedNames.add(externalNameInterop);
-				info.interopDefaultAccessName = externalNameInterop;
-				topLevelDeclarations.add(externalNameInterop);
-			}
-		}
-
-		// Find and replace references to modules
-		for (const info of moduleToInfoMap.values()) {
-			if (info.type === "concatenated") {
-				const globalScope = /** @type {Scope} */ (info.globalScope);
-				// group references by name
-				/** @type {Map<string, Reference[]>} */
-				const referencesByName = new Map();
-				for (const reference of globalScope.through) {
-					const name = reference.identifier.name;
-					if (!referencesByName.has(name)) {
-						referencesByName.set(name, []);
-					}
-					/** @type {Reference[]} */
-					(referencesByName.get(name)).push(reference);
-				}
-				for (const [name, references] of referencesByName) {
-					const match = ConcatenationScope.matchModuleReference(name);
-					if (match) {
-						const referencedInfo = modulesWithInfo[match.index];
-						if (referencedInfo.type === "reference") {
-							throw new Error("Module reference can't point to a reference");
-						}
-						const concatenationScope = /** @type {ConcatenatedModuleInfo} */ (
-							referencedInfo
-						).concatenationScope;
-						const exportId = match.ids[0];
-						const specifier =
-							concatenationScope && concatenationScope.getRawExport(exportId);
-						if (specifier) {
-							const newName = _findNewNameForSpecifier(
-								specifier,
-								info,
-								references
-							);
-							const initFragmentChanged =
-								newName &&
-								concatenatedModuleInfo.call(
-									{
-										rawExportMap: new Map([
-											[exportId, /** @type {string} */ (newName)]
-										])
-									},
-									/** @type {ConcatenatedModuleInfo} */ (referencedInfo)
-								);
-							if (initFragmentChanged) {
-								concatenationScope.setRawExportMap(exportId, newName);
+							for (const reference of references) {
+								const r = /** @type {Range} */ (reference.identifier.range);
+								const source = /** @type {ReplaceSource} */ (info.source);
+								// range is extended by 2 chars to cover the appended "._"
+								source.replace(r[0], r[1] + 1, finalName);
 							}
 						}
+					}
+				}
+			}
+
+			// Map with all root exposed used exports
+			/** @type {Map<string, (requestShortener: RequestShortener) => string>} */
+			const exportsMap = new Map();
+
+			// Set with all root exposed unused exports
+			/** @type {Set<string>} */
+			const unusedExports = new Set();
+
+			const rootInfo =
+				/** @type {ConcatenatedModuleInfo} */
+				(moduleToInfoMap.get(this.rootModule));
+			const strictHarmonyModule =
+				/** @type {BuildMeta} */
+				(rootInfo.module.buildMeta).strictHarmonyModule;
+			const exportsInfo = moduleGraph.getExportsInfo(rootInfo.module);
+			/** @type {Record<string, string>} */
+			const exportsFinalName = {};
+			for (const exportInfo of exportsInfo.orderedExports) {
+				const name = exportInfo.name;
+				if (exportInfo.provided === false) continue;
+				const used = exportInfo.getUsedName(undefined, runtime);
+				if (!used) {
+					unusedExports.add(name);
+					continue;
+				}
+				exportsMap.set(used, (requestShortener) => {
+					try {
 						const finalName = getFinalName(
 							moduleGraph,
-							referencedInfo,
-							match.ids,
+							rootInfo,
+							[name],
 							moduleToInfoMap,
 							runtime,
 							requestShortener,
 							runtimeTemplate,
 							neededNamespaceObjects,
-							match.call,
-							match.deferredImport,
-							!match.directImport,
-							/** @type {BuildMeta} */
-							(info.module.buildMeta).strictHarmonyModule,
-							match.asiSafe
+							false,
+							false,
+							false,
+							strictHarmonyModule,
+							true
 						);
-
-						for (const reference of references) {
-							const r = /** @type {Range} */ (reference.identifier.range);
-							const source = /** @type {ReplaceSource} */ (info.source);
-							// range is extended by 2 chars to cover the appended "._"
-							source.replace(r[0], r[1] + 1, finalName);
-						}
+						exportsFinalName[used] = finalName;
+						return `/* ${
+							exportInfo.isReexport() ? "reexport" : "binding"
+						} */ ${finalName}`;
+					} catch (err) {
+						/** @type {Error} */
+						(err).message +=
+							`\nwhile generating the root export '${name}' (used name: '${used}')`;
+						throw err;
 					}
-				}
-			}
-		}
-
-		// Map with all root exposed used exports
-		/** @type {Map<string, (requestShortener: RequestShortener) => string>} */
-		const exportsMap = new Map();
-
-		// Set with all root exposed unused exports
-		/** @type {Set<string>} */
-		const unusedExports = new Set();
-
-		const rootInfo =
-			/** @type {ConcatenatedModuleInfo} */
-			(moduleToInfoMap.get(this.rootModule));
-		const strictHarmonyModule =
-			/** @type {BuildMeta} */
-			(rootInfo.module.buildMeta).strictHarmonyModule;
-		const exportsInfo = moduleGraph.getExportsInfo(rootInfo.module);
-		/** @type {Record<string, string>} */
-		const exportsFinalName = {};
-		for (const exportInfo of exportsInfo.orderedExports) {
-			const name = exportInfo.name;
-			if (exportInfo.provided === false) continue;
-			const used = exportInfo.getUsedName(undefined, runtime);
-			if (!used) {
-				unusedExports.add(name);
-				continue;
-			}
-			exportsMap.set(used, (requestShortener) => {
-				try {
-					const finalName = getFinalName(
-						moduleGraph,
-						rootInfo,
-						[name],
-						moduleToInfoMap,
-						runtime,
-						requestShortener,
-						runtimeTemplate,
-						neededNamespaceObjects,
-						false,
-						false,
-						false,
-						strictHarmonyModule,
-						true
-					);
-					exportsFinalName[used] = finalName;
-					return `/* ${
-						exportInfo.isReexport() ? "reexport" : "binding"
-					} */ ${finalName}`;
-				} catch (err) {
-					/** @type {Error} */
-					(err).message +=
-						`\nwhile generating the root export '${name}' (used name: '${used}')`;
-					throw err;
-				}
-			});
-		}
-
-		const result = new ConcatSource();
-
-		// add harmony compatibility flag (must be first because of possible circular dependencies)
-		let shouldAddHarmonyFlag = false;
-		const rootExportsInfo = moduleGraph.getExportsInfo(this);
-		if (
-			rootExportsInfo.otherExportsInfo.getUsed(runtime) !== UsageState.Unused ||
-			rootExportsInfo.getReadOnlyExportInfo("__esModule").getUsed(runtime) !==
-				UsageState.Unused
-		) {
-			shouldAddHarmonyFlag = true;
-		}
-
-		// define exports
-		if (exportsMap.size > 0) {
-			/** @type {string[]} */
-			const definitions = [];
-			for (const [key, value] of exportsMap) {
-				definitions.push(
-					`\n  ${propertyName(key)}: ${runtimeTemplate.returningFunction(
-						value(requestShortener)
-					)}`
-				);
+				});
 			}
 
-			runtimeRequirements.add(RuntimeGlobals.exports);
-			runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
+			const result = new ConcatSource();
 
-			if (shouldAddHarmonyFlag) {
-				result.add("// ESM COMPAT FLAG\n");
-				result.add(
-					runtimeTemplate.defineEsModuleFlagStatement({
-						exportsArgument: this.exportsArgument,
-						runtimeRequirements
-					})
-				);
-			}
-
-			const exportsSource =
-				"\n// EXPORTS\n" +
-				`${RuntimeGlobals.definePropertyGetters}(${this.exportsArgument}, {${definitions.join(
-					","
-				)}\n});\n`;
-
-			const { onDemandExportsGeneration } =
-				ConcatenatedModule.getCompilationHooks(this.compilation);
-
+			// add harmony compatibility flag (must be first because of possible circular dependencies)
+			let shouldAddHarmonyFlag = false;
+			const rootExportsInfo = moduleGraph.getExportsInfo(this);
 			if (
-				!onDemandExportsGeneration.call(
-					this,
-					runtimes,
-					exportsSource,
-					exportsFinalName
-				)
+				rootExportsInfo.otherExportsInfo.getUsed(runtime) !==
+					UsageState.Unused ||
+				rootExportsInfo.getReadOnlyExportInfo("__esModule").getUsed(runtime) !==
+					UsageState.Unused
 			) {
-				result.add(exportsSource);
+				shouldAddHarmonyFlag = true;
 			}
-		}
 
-		// list unused exports
-		if (unusedExports.size > 0) {
-			result.add(
-				`\n// UNUSED EXPORTS: ${joinIterableWithComma(unusedExports)}\n`
-			);
-		}
-
-		// generate namespace objects
-		/** @type {Map<ConcatenatedModuleInfo, string>} */
-		const namespaceObjectSources = new Map();
-		for (const info of neededNamespaceObjects) {
-			if (info.namespaceExportSymbol) continue;
-			/** @type {string[]} */
-			const nsObj = [];
-			const exportsInfo = moduleGraph.getExportsInfo(info.module);
-			for (const exportInfo of exportsInfo.orderedExports) {
-				if (exportInfo.provided === false) continue;
-				const usedName = exportInfo.getUsedName(undefined, runtime);
-				if (usedName) {
-					const finalName = getFinalName(
-						moduleGraph,
-						info,
-						[exportInfo.name],
-						moduleToInfoMap,
-						runtime,
-						requestShortener,
-						runtimeTemplate,
-						neededNamespaceObjects,
-						false,
-						false,
-						undefined,
-						/** @type {BuildMeta} */
-						(info.module.buildMeta).strictHarmonyModule,
-						true
-					);
-					nsObj.push(
-						`\n  ${propertyName(usedName)}: ${runtimeTemplate.returningFunction(
-							finalName
+			// define exports
+			if (exportsMap.size > 0) {
+				/** @type {string[]} */
+				const definitions = [];
+				for (const [key, value] of exportsMap) {
+					definitions.push(
+						`\n  ${propertyName(key)}: ${runtimeTemplate.returningFunction(
+							value(requestShortener)
 						)}`
 					);
 				}
-			}
-			const name = info.namespaceObjectName;
-			const defineGetters =
-				nsObj.length > 0
-					? `${RuntimeGlobals.definePropertyGetters}(${name}, {${nsObj.join(
-							","
-						)}\n});\n`
-					: "";
-			if (nsObj.length > 0) {
+
+				runtimeRequirements.add(RuntimeGlobals.exports);
 				runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
+
+				if (shouldAddHarmonyFlag) {
+					result.add("// ESM COMPAT FLAG\n");
+					result.add(
+						runtimeTemplate.defineEsModuleFlagStatement({
+							exportsArgument: this.exportsArgument,
+							runtimeRequirements
+						})
+					);
+				}
+
+				const exportsSource =
+					"\n// EXPORTS\n" +
+					`${RuntimeGlobals.definePropertyGetters}(${this.exportsArgument}, {${definitions.join(
+						","
+					)}\n});\n`;
+
+				const { onDemandExportsGeneration } =
+					ConcatenatedModule.getCompilationHooks(this.compilation);
+
+				if (
+					!onDemandExportsGeneration.call(
+						this,
+						runtimes,
+						exportsSource,
+						exportsFinalName
+					)
+				) {
+					result.add(exportsSource);
+				}
 			}
-			namespaceObjectSources.set(
-				info,
-				`
+
+			// list unused exports
+			if (unusedExports.size > 0) {
+				result.add(
+					`\n// UNUSED EXPORTS: ${joinIterableWithComma(unusedExports)}\n`
+				);
+			}
+
+			// generate namespace objects
+			/** @type {Map<ConcatenatedModuleInfo, string>} */
+			const namespaceObjectSources = new Map();
+			for (const info of neededNamespaceObjects) {
+				if (info.namespaceExportSymbol) continue;
+				/** @type {string[]} */
+				const nsObj = [];
+				const exportsInfo = moduleGraph.getExportsInfo(info.module);
+				for (const exportInfo of exportsInfo.orderedExports) {
+					if (exportInfo.provided === false) continue;
+					const usedName = exportInfo.getUsedName(undefined, runtime);
+					if (usedName) {
+						const finalName = getFinalName(
+							moduleGraph,
+							info,
+							[exportInfo.name],
+							moduleToInfoMap,
+							runtime,
+							requestShortener,
+							runtimeTemplate,
+							neededNamespaceObjects,
+							false,
+							false,
+							undefined,
+							/** @type {BuildMeta} */
+							(info.module.buildMeta).strictHarmonyModule,
+							true
+						);
+						nsObj.push(
+							`\n  ${propertyName(usedName)}: ${runtimeTemplate.returningFunction(
+								finalName
+							)}`
+						);
+					}
+				}
+				const name = info.namespaceObjectName;
+				const defineGetters =
+					nsObj.length > 0
+						? `${RuntimeGlobals.definePropertyGetters}(${name}, {${nsObj.join(
+								","
+							)}\n});\n`
+						: "";
+				if (nsObj.length > 0) {
+					runtimeRequirements.add(RuntimeGlobals.definePropertyGetters);
+				}
+				namespaceObjectSources.set(
+					info,
+					`
 // NAMESPACE OBJECT: ${info.module.readableIdentifier(requestShortener)}
 var ${name} = {};
 ${RuntimeGlobals.makeNamespaceObject}(${name});
 ${defineGetters}`
-			);
-			runtimeRequirements.add(RuntimeGlobals.makeNamespaceObject);
-		}
-
-		// define required namespace objects (must be before evaluation modules)
-		for (const info of modulesWithInfo) {
-			if (info.type === "concatenated") {
-				const source = namespaceObjectSources.get(info);
-				if (!source) continue;
-				result.add(source);
+				);
+				runtimeRequirements.add(RuntimeGlobals.makeNamespaceObject);
 			}
 
-			if (info.type === "external" && info.deferred) {
-				const moduleId = JSON.stringify(chunkGraph.getModuleId(info.module));
-				const loader = getOptimizedDeferredModule(
-					moduleId,
-					info.module.getExportsType(
-						moduleGraph,
-						/** @type {BuildMeta} */
-						(this.rootModule.buildMeta).strictHarmonyModule
-					),
-					// an async module will opt-out of the concat module optimization.
-					[],
-					runtimeRequirements
-				);
-				runtimeRequirements.add(RuntimeGlobals.require);
-				result.add(
-					`\n// DEFERRED EXTERNAL MODULE: ${info.module.readableIdentifier(requestShortener)}\nvar ${info.deferredName} = ${loader};`
-				);
-				if (info.deferredNamespaceObjectUsed) {
-					runtimeRequirements.add(RuntimeGlobals.makeDeferredNamespaceObject);
-					result.add(
-						`\nvar ${info.deferredNamespaceObjectName} = /*#__PURE__*/${
-							RuntimeGlobals.makeDeferredNamespaceObject
-						}(${JSON.stringify(
-							chunkGraph.getModuleId(info.module)
-						)}, ${getMakeDeferredNamespaceModeFromExportsType(
-							info.module.getExportsType(moduleGraph, strictHarmonyModule)
-						)});`
-					);
+			// define required namespace objects (must be before evaluation modules)
+			for (const info of modulesWithInfo) {
+				if (info.type === "concatenated") {
+					const source = namespaceObjectSources.get(info);
+					if (!source) continue;
+					result.add(source);
 				}
-			}
-		}
 
-		/** @type {InitFragment<ChunkRenderContext>[]} */
-		const chunkInitFragments = [];
-
-		// evaluate modules in order
-		for (const rawInfo of modulesWithInfo) {
-			/** @type {undefined | string} */
-			let name;
-			let isConditional = false;
-			const info = rawInfo.type === "reference" ? rawInfo.target : rawInfo;
-			switch (info.type) {
-				case "concatenated": {
-					result.add(
-						`\n;// ${info.module.readableIdentifier(requestShortener)}\n`
+				if (info.type === "external" && info.deferred) {
+					const moduleId = JSON.stringify(chunkGraph.getModuleId(info.module));
+					const loader = getOptimizedDeferredModule(
+						moduleId,
+						info.module.getExportsType(
+							moduleGraph,
+							/** @type {BuildMeta} */
+							(this.rootModule.buildMeta).strictHarmonyModule
+						),
+						// an async module will opt-out of the concat module optimization.
+						[],
+						runtimeRequirements
 					);
-					result.add(/** @type {ReplaceSource} */ (info.source));
-					if (info.chunkInitFragments) {
-						for (const f of info.chunkInitFragments) chunkInitFragments.push(f);
-					}
-					if (info.runtimeRequirements) {
-						for (const r of info.runtimeRequirements) {
-							runtimeRequirements.add(r);
-						}
-					}
-					name = info.namespaceObjectName;
-					break;
-				}
-				case "external": {
-					// deferred case is handled in the "const info of modulesWithInfo" loop above
-					if (!info.deferred) {
+					runtimeRequirements.add(RuntimeGlobals.require);
+					result.add(
+						`\n// DEFERRED EXTERNAL MODULE: ${info.module.readableIdentifier(requestShortener)}\nvar ${info.deferredName} = ${loader};`
+					);
+					if (info.deferredNamespaceObjectUsed) {
+						runtimeRequirements.add(RuntimeGlobals.makeDeferredNamespaceObject);
 						result.add(
-							`\n// EXTERNAL MODULE: ${info.module.readableIdentifier(
-								requestShortener
-							)}\n`
+							`\nvar ${info.deferredNamespaceObjectName} = /*#__PURE__*/${
+								RuntimeGlobals.makeDeferredNamespaceObject
+							}(${JSON.stringify(
+								chunkGraph.getModuleId(info.module)
+							)}, ${getMakeDeferredNamespaceModeFromExportsType(
+								info.module.getExportsType(moduleGraph, strictHarmonyModule)
+							)});`
 						);
-						runtimeRequirements.add(RuntimeGlobals.require);
-						const { runtimeCondition } =
+					}
+				}
+			}
+
+			/** @type {InitFragment<ChunkRenderContext>[]} */
+			const chunkInitFragments = [];
+
+			// evaluate modules in order
+			for (const rawInfo of modulesWithInfo) {
+				/** @type {undefined | string} */
+				let name;
+				let isConditional = false;
+				const info = rawInfo.type === "reference" ? rawInfo.target : rawInfo;
+				switch (info.type) {
+					case "concatenated": {
+						result.add(
+							`\n;// ${info.module.readableIdentifier(requestShortener)}\n`
+						);
+						result.add(/** @type {ReplaceSource} */ (info.source));
+						if (info.chunkInitFragments) {
+							for (const f of info.chunkInitFragments) {
+								chunkInitFragments.push(f);
+							}
+						}
+						if (info.runtimeRequirements) {
+							for (const r of info.runtimeRequirements) {
+								runtimeRequirements.add(r);
+							}
+						}
+						name = info.namespaceObjectName;
+						break;
+					}
+					case "external": {
+						// deferred case is handled in the "const info of modulesWithInfo" loop above
+						if (!info.deferred) {
+							result.add(
+								`\n// EXTERNAL MODULE: ${info.module.readableIdentifier(
+									requestShortener
+								)}\n`
+							);
+							runtimeRequirements.add(RuntimeGlobals.require);
+							const { runtimeCondition } =
+								/** @type {ExternalModuleInfo | ReferenceToModuleInfo} */
+								(rawInfo);
+							const condition = runtimeTemplate.runtimeConditionExpression({
+								chunkGraph,
+								runtimeCondition,
+								runtime,
+								runtimeRequirements
+							});
+							if (condition !== "true") {
+								isConditional = true;
+								result.add(`if (${condition}) {\n`);
+							}
+							const moduleId = JSON.stringify(
+								chunkGraph.getModuleId(info.module)
+							);
+							result.add(
+								`var ${info.name} = __webpack_require__(${moduleId});`
+							);
+							name = info.name;
+						}
+						// If a module is deferred in other places, but used as non-deferred here,
+						// the module itself will be emitted as mod_deferred (in the case "external"),
+						// we need to emit an extra import declaration to evaluate it in order.
+						const { nonDeferAccess } =
 							/** @type {ExternalModuleInfo | ReferenceToModuleInfo} */
 							(rawInfo);
-						const condition = runtimeTemplate.runtimeConditionExpression({
-							chunkGraph,
-							runtimeCondition,
-							runtime,
-							runtimeRequirements
-						});
-						if (condition !== "true") {
-							isConditional = true;
-							result.add(`if (${condition}) {\n`);
+						if (info.deferred && nonDeferAccess) {
+							result.add(
+								`\n// non-deferred import to a deferred module (${info.module.readableIdentifier(requestShortener)})\nvar ${info.name} = ${info.deferredName}.a;`
+							);
 						}
-						const moduleId = JSON.stringify(
-							chunkGraph.getModuleId(info.module)
-						);
-						result.add(`var ${info.name} = __webpack_require__(${moduleId});`);
-						name = info.name;
+						break;
 					}
-					// If a module is deferred in other places, but used as non-deferred here,
-					// the module itself will be emitted as mod_deferred (in the case "external"),
-					// we need to emit an extra import declaration to evaluate it in order.
-					const { nonDeferAccess } =
-						/** @type {ExternalModuleInfo | ReferenceToModuleInfo} */
-						(rawInfo);
-					if (info.deferred && nonDeferAccess) {
-						result.add(
-							`\n// non-deferred import to a deferred module (${info.module.readableIdentifier(requestShortener)})\nvar ${info.name} = ${info.deferredName}.a;`
+					default: {
+						const /** @type {never} */ _exhaustiveCheck = info;
+						throw new Error(
+							`Unsupported concatenation entry type ${String(_exhaustiveCheck)}`
 						);
 					}
-					break;
 				}
-				default:
-					// @ts-expect-error never is expected here
-					throw new Error(`Unsupported concatenation entry type ${info.type}`);
+				if (info.interopNamespaceObjectUsed) {
+					runtimeRequirements.add(RuntimeGlobals.createFakeNamespaceObject);
+					result.add(
+						`\nvar ${info.interopNamespaceObjectName} = /*#__PURE__*/${RuntimeGlobals.createFakeNamespaceObject}(${name}, 2);`
+					);
+				}
+				if (info.interopNamespaceObject2Used) {
+					runtimeRequirements.add(RuntimeGlobals.createFakeNamespaceObject);
+					result.add(
+						`\nvar ${info.interopNamespaceObject2Name} = /*#__PURE__*/${RuntimeGlobals.createFakeNamespaceObject}(${name});`
+					);
+				}
+				if (info.interopDefaultAccessUsed) {
+					runtimeRequirements.add(RuntimeGlobals.compatGetDefaultExport);
+					result.add(
+						`\nvar ${info.interopDefaultAccessName} = /*#__PURE__*/${RuntimeGlobals.compatGetDefaultExport}(${name});`
+					);
+				}
+				if (isConditional) {
+					result.add("\n}");
+				}
 			}
-			if (info.interopNamespaceObjectUsed) {
-				runtimeRequirements.add(RuntimeGlobals.createFakeNamespaceObject);
-				result.add(
-					`\nvar ${info.interopNamespaceObjectName} = /*#__PURE__*/${RuntimeGlobals.createFakeNamespaceObject}(${name}, 2);`
-				);
-			}
-			if (info.interopNamespaceObject2Used) {
-				runtimeRequirements.add(RuntimeGlobals.createFakeNamespaceObject);
-				result.add(
-					`\nvar ${info.interopNamespaceObject2Name} = /*#__PURE__*/${RuntimeGlobals.createFakeNamespaceObject}(${name});`
-				);
-			}
-			if (info.interopDefaultAccessUsed) {
-				runtimeRequirements.add(RuntimeGlobals.compatGetDefaultExport);
-				result.add(
-					`\nvar ${info.interopDefaultAccessName} = /*#__PURE__*/${RuntimeGlobals.compatGetDefaultExport}(${name});`
-				);
-			}
-			if (isConditional) {
-				result.add("\n}");
-			}
-		}
 
-		/** @type {CodeGenerationResultData} */
-		const data = new Map();
-		if (chunkInitFragments.length > 0) {
-			data.set("chunkInitFragments", chunkInitFragments);
-		}
-		data.set("topLevelDeclarations", topLevelDeclarations);
+			/** @type {CodeGenerationResultData} */
+			const data = new Map();
+			if (chunkInitFragments.length > 0) {
+				data.set("chunkInitFragments", chunkInitFragments);
+			}
+			data.set("topLevelDeclarations", topLevelDeclarations);
 
-		/** @type {CodeGenerationResult} */
-		const resultEntry = {
-			sources: new Map([[JAVASCRIPT_TYPE, new CachedSource(result)]]),
-			data,
-			runtimeRequirements
+			/** @type {CodeGenerationResult} */
+			const resultEntry = {
+				sources: new Map([[JAVASCRIPT_TYPE, new CachedSource(result)]]),
+				data,
+				runtimeRequirements
+			};
+
+			return resultEntry;
 		};
 
-		return resultEntry;
+		if (analysisPromises !== undefined) {
+			return Promise.all(analysisPromises).then(continueCodeGeneration);
+		}
+		return continueCodeGeneration();
 	}
 
 	/**
@@ -2057,6 +2083,7 @@ ${defineGetters}`
 	 * @param {RuntimeSpec[]} runtimes runtimes
 	 * @param {CodeGenerationResults} codeGenerationResults codeGenerationResults
 	 * @param {UsedNames} usedNames used names
+	 * @returns {void | Promise<void>} void or promise for async modules
 	 */
 	_analyseModule(
 		modulesMap,
@@ -2080,6 +2107,68 @@ ${defineGetters}`
 					usedNames
 				);
 
+				/**
+				 * @param {import("../Module").CodeGenerationResult} codeGenResult result
+				 */
+				const processResult = (codeGenResult) => {
+					const source =
+						/** @type {Source} */
+						(codeGenResult.sources.get(JAVASCRIPT_TYPE));
+					const data = codeGenResult.data;
+					const chunkInitFragments = data && data.get("chunkInitFragments");
+					const code = source.source().toString();
+
+					/** @type {Program} */
+					let ast;
+
+					try {
+						({ ast } = JavascriptParser._parse(
+							code,
+							{
+								sourceType: "module",
+								ranges: true
+							},
+							JavascriptParser._getModuleParseFunction(this.compilation, m)
+						));
+					} catch (_err) {
+						const err =
+							/** @type {Error & { loc?: { line: number, column: number } }} */
+							(_err);
+						if (
+							err.loc &&
+							typeof err.loc === "object" &&
+							typeof err.loc.line === "number"
+						) {
+							const lineNumber = err.loc.line;
+							const lines = code.split("\n");
+							err.message += `\n| ${lines
+								.slice(Math.max(0, lineNumber - 3), lineNumber + 2)
+								.join("\n| ")}`;
+						}
+						throw err;
+					}
+					const scopeManager = eslintScope.analyze(ast, {
+						ecmaVersion: 6,
+						sourceType: "module",
+						optimistic: true,
+						ignoreEval: true,
+						impliedStrict: true
+					});
+					const globalScope = /** @type {Scope} */ (scopeManager.acquire(ast));
+					const moduleScope = globalScope.childScopes[0];
+					const resultSource = new ReplaceSource(source);
+					info.runtimeRequirements =
+						/** @type {ReadOnlyRuntimeRequirements} */
+						(codeGenResult.runtimeRequirements);
+					info.ast = ast;
+					info.internalSource = source;
+					info.source = resultSource;
+					info.chunkInitFragments = chunkInitFragments;
+					info.globalScope = globalScope;
+					info.moduleScope = moduleScope;
+					info.concatenationScope = concatenationScope;
+				};
+
 				// TODO cache codeGeneration results
 				const codeGenResult = m.codeGeneration({
 					dependencyTemplates,
@@ -2092,62 +2181,15 @@ ${defineGetters}`
 					codeGenerationResults,
 					sourceTypes: JAVASCRIPT_TYPES
 				});
-				const source =
-					/** @type {Source} */
-					(codeGenResult.sources.get(JAVASCRIPT_TYPE));
-				const data = codeGenResult.data;
-				const chunkInitFragments = data && data.get("chunkInitFragments");
-				const code = source.source().toString();
-
-				/** @type {Program} */
-				let ast;
-
-				try {
-					({ ast } = JavascriptParser._parse(
-						code,
-						{
-							sourceType: "module",
-							ranges: true
-						},
-						JavascriptParser._getModuleParseFunction(this.compilation, m)
-					));
-				} catch (_err) {
-					const err =
-						/** @type {Error & { loc?: { line: number, column: number } }} */
-						(_err);
-					if (
-						err.loc &&
-						typeof err.loc === "object" &&
-						typeof err.loc.line === "number"
-					) {
-						const lineNumber = err.loc.line;
-						const lines = code.split("\n");
-						err.message += `\n| ${lines
-							.slice(Math.max(0, lineNumber - 3), lineNumber + 2)
-							.join("\n| ")}`;
-					}
-					throw err;
+				if (codeGenResult instanceof Promise) {
+					return codeGenResult.then(processResult).catch((err) => {
+						/** @type {Error} */
+						(err).message +=
+							`\nwhile analyzing module ${m.identifier()} for concatenation`;
+						throw err;
+					});
 				}
-				const scopeManager = eslintScope.analyze(ast, {
-					ecmaVersion: 6,
-					sourceType: "module",
-					optimistic: true,
-					ignoreEval: true,
-					impliedStrict: true
-				});
-				const globalScope = /** @type {Scope} */ (scopeManager.acquire(ast));
-				const moduleScope = globalScope.childScopes[0];
-				const resultSource = new ReplaceSource(source);
-				info.runtimeRequirements =
-					/** @type {ReadOnlyRuntimeRequirements} */
-					(codeGenResult.runtimeRequirements);
-				info.ast = ast;
-				info.internalSource = source;
-				info.source = resultSource;
-				info.chunkInitFragments = chunkInitFragments;
-				info.globalScope = globalScope;
-				info.moduleScope = moduleScope;
-				info.concatenationScope = concatenationScope;
+				processResult(codeGenResult);
 			} catch (err) {
 				/** @type {Error} */
 				(err).message +=

--- a/lib/sharing/ConsumeSharedModule.js
+++ b/lib/sharing/ConsumeSharedModule.js
@@ -247,7 +247,7 @@ class ConsumeSharedModule extends Module {
 
 	/**
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ chunkGraph, runtimeTemplate }) {
 		const runtimeRequirements = new Set([RuntimeGlobals.shareScopeMap]);

--- a/lib/sharing/ProvideSharedModule.js
+++ b/lib/sharing/ProvideSharedModule.js
@@ -128,7 +128,7 @@ class ProvideSharedModule extends Module {
 
 	/**
 	 * @param {CodeGenerationContext} context context for code generation
-	 * @returns {CodeGenerationResult} result
+	 * @returns {CodeGenerationResult | Promise<CodeGenerationResult>} result
 	 */
 	codeGeneration({ runtimeTemplate, chunkGraph }) {
 		const runtimeRequirements = new Set([RuntimeGlobals.initializeSharing]);

--- a/lib/wasm-async/AsyncWebAssemblyGenerator.js
+++ b/lib/wasm-async/AsyncWebAssemblyGenerator.js
@@ -54,7 +54,7 @@ class AsyncWebAssemblyGenerator extends Generator {
 	/**
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {Source | null | Promise<Source | null>} generated code
 	 */
 	generate(module, generateContext) {
 		return /** @type {Source} */ (module.originalSource());

--- a/lib/wasm-async/AsyncWebAssemblyJavascriptGenerator.js
+++ b/lib/wasm-async/AsyncWebAssemblyJavascriptGenerator.js
@@ -45,7 +45,7 @@ class AsyncWebAssemblyJavascriptGenerator extends Generator {
 	/**
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {Source | null | Promise<Source | null>} generated code
 	 */
 	generate(module, generateContext) {
 		const {

--- a/lib/wasm-sync/WebAssemblyGenerator.js
+++ b/lib/wasm-sync/WebAssemblyGenerator.js
@@ -443,7 +443,7 @@ class WebAssemblyGenerator extends Generator {
 	/**
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {Source | null | Promise<Source | null>} generated code
 	 */
 	generate(module, { moduleGraph, runtime }) {
 		const bin =

--- a/lib/wasm-sync/WebAssemblyJavascriptGenerator.js
+++ b/lib/wasm-sync/WebAssemblyJavascriptGenerator.js
@@ -44,7 +44,7 @@ class WebAssemblyJavascriptGenerator extends Generator {
 	/**
 	 * @param {NormalModule} module module for which the code should be generated
 	 * @param {GenerateContext} generateContext context for generate
-	 * @returns {Source | null} generated code
+	 * @returns {Source | null | Promise<Source | null>} generated code
 	 */
 	generate(module, generateContext) {
 		const {

--- a/test/configCases/css/process-content-hook/index.js
+++ b/test/configCases/css/process-content-hook/index.js
@@ -1,0 +1,26 @@
+it("should process CSS content via processContent hook", () => {
+	const exportType = EXPORT_TYPE;
+
+	if (exportType === "text") {
+		const text = require("./style.css").default;
+		// rgba(255, 0, 0, 1) should be replaced with "red"
+		expect(text).not.toMatch(/rgba/);
+		expect(text).toMatch(/color:\s*red/);
+
+		const moduleText = require("./style.module.css").default;
+		expect(moduleText).not.toMatch(/rgba/);
+		expect(moduleText).toMatch(/color:\s*red/);
+	} else if (exportType === "css-style-sheet") {
+		const style = require("./style.css");
+		expect(style["test-class"]).toBeTruthy();
+
+		const moduleStyle = require("./style.module.css");
+		expect(moduleStyle["module-class"]).toBeTruthy();
+	} else if (exportType === "style") {
+		const style = require("./style.css");
+		expect(style["test-class"]).toBeTruthy();
+
+		const moduleStyle = require("./style.module.css");
+		expect(moduleStyle["module-class"]).toBeTruthy();
+	}
+});

--- a/test/configCases/css/process-content-hook/style.css
+++ b/test/configCases/css/process-content-hook/style.css
@@ -1,0 +1,3 @@
+.test-class {
+	color: rgba(255, 0, 0, 1);
+}

--- a/test/configCases/css/process-content-hook/style.module.css
+++ b/test/configCases/css/process-content-hook/style.module.css
@@ -1,0 +1,3 @@
+.module-class {
+	color: rgba(255, 0, 0, 1);
+}

--- a/test/configCases/css/process-content-hook/webpack.config.js
+++ b/test/configCases/css/process-content-hook/webpack.config.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const { RawSource } = require("webpack-sources");
 const webpack = require("../../../../");
 
 class MyCssMinimizerPlugin {
@@ -15,22 +16,16 @@ class MyCssMinimizerPlugin {
 				compilation.hooks.processContent.tapPromise(
 					"MyCssMinimizerPlugin",
 					async (
-						/** @type {[string | Buffer, import("webpack-sources").RawSourceMap | undefined]} */ [
-							content,
-							sourceMap
-						],
+						/** @type {import("webpack-sources").Source} */ source,
 						/** @type {string} */ name
 					) => {
 						if (matchObject({ test: /\.css$/ }, name)) {
-							return [
-								/** @type {string} */ (content).replace(
-									/rgba\(255,\s*0,\s*0,\s*1\)/g,
-									"red"
-								),
-								sourceMap
-							];
+							const content = source.source().toString();
+							return new RawSource(
+								content.replace(/rgba\(255,\s*0,\s*0,\s*1\)/g, "red")
+							);
 						}
-						return [content, sourceMap];
+						return source;
 					}
 				);
 			}

--- a/test/configCases/css/process-content-hook/webpack.config.js
+++ b/test/configCases/css/process-content-hook/webpack.config.js
@@ -1,0 +1,83 @@
+"use strict";
+
+const webpack = require("../../../../");
+
+class MyCssMinimizerPlugin {
+	/**
+	 * @param {import("../../../../").Compiler} compiler the compiler
+	 */
+	apply(compiler) {
+		const { matchObject } = compiler.webpack.ModuleFilenameHelpers;
+
+		compiler.hooks.compilation.tap(
+			"MyCssMinimizerPlugin",
+			(/** @type {import("../../../../").Compilation} */ compilation) => {
+				compilation.hooks.processContent.tapPromise(
+					"MyCssMinimizerPlugin",
+					async (
+						/** @type {[string | Buffer, import("webpack-sources").RawSourceMap | undefined]} */ [
+							content,
+							sourceMap
+						],
+						/** @type {string} */ name
+					) => {
+						if (matchObject({ test: /\.css$/ }, name)) {
+							return [
+								/** @type {string} */ (content).replace(
+									/rgba\(255,\s*0,\s*0,\s*1\)/g,
+									"red"
+								),
+								sourceMap
+							];
+						}
+						return [content, sourceMap];
+					}
+				);
+			}
+		);
+	}
+}
+
+/**
+ * @param {string} exportType export type
+ * @param {boolean=} concatenate whether to enable concatenateModules
+ * @returns {import("../../../../").Configuration} webpack configuration
+ */
+function createConfig(exportType, concatenate) {
+	return {
+		name: concatenate ? `${exportType}-concatenated` : exportType,
+		target: "web",
+		mode: "development",
+		devtool: false,
+		module: {
+			rules: [
+				{
+					test: /\.css$/,
+					type: "css/module",
+					parser: {
+						exportType
+					}
+				}
+			]
+		},
+		optimization: {
+			concatenateModules: Boolean(concatenate)
+		},
+		experiments: {
+			css: true
+		},
+		plugins: [
+			new MyCssMinimizerPlugin(),
+			new webpack.DefinePlugin({
+				EXPORT_TYPE: JSON.stringify(exportType)
+			})
+		]
+	};
+}
+
+module.exports = [
+	createConfig("text"),
+	createConfig("style"),
+	createConfig("css-style-sheet"),
+	createConfig("text", true)
+];

--- a/types.d.ts
+++ b/types.d.ts
@@ -2317,10 +2317,7 @@ declare class Compilation {
 		afterModuleHash: SyncHook<[]>;
 		beforeCodeGeneration: SyncHook<[]>;
 		afterCodeGeneration: SyncHook<[]>;
-		processContent: AsyncSeriesWaterfallHook<
-			[[string | Buffer, undefined | RawSourceMap], string],
-			[string | Buffer, undefined | RawSourceMap]
-		>;
+		processContent: AsyncSeriesWaterfallHook<[Source, string], Source>;
 		beforeRuntimeRequirements: SyncHook<[]>;
 		afterRuntimeRequirements: SyncHook<[]>;
 		beforeHash: SyncHook<[]>;

--- a/types.d.ts
+++ b/types.d.ts
@@ -2317,6 +2317,10 @@ declare class Compilation {
 		afterModuleHash: SyncHook<[]>;
 		beforeCodeGeneration: SyncHook<[]>;
 		afterCodeGeneration: SyncHook<[]>;
+		processContent: AsyncSeriesWaterfallHook<
+			[[string | Buffer, undefined | RawSourceMap], string],
+			[string | Buffer, undefined | RawSourceMap]
+		>;
 		beforeRuntimeRequirements: SyncHook<[]>;
 		afterRuntimeRequirements: SyncHook<[]>;
 		beforeHash: SyncHook<[]>;
@@ -6335,7 +6339,10 @@ declare class Generator {
 	constructor();
 	getTypes(module: NormalModule): ReadonlySet<string>;
 	getSize(module: NormalModule, type?: string): number;
-	generate(module: NormalModule, __1: GenerateContext): null | Source;
+	generate(
+		module: NormalModule,
+		__1: GenerateContext
+	): null | Source | Promise<null | Source>;
 	getConcatenationBailoutReason(
 		module: NormalModule,
 		context: ConcatenationBailoutReasonContext
@@ -10792,7 +10799,9 @@ declare class Module extends DependenciesBlock {
 		context: ConcatenationBailoutReasonContext
 	): undefined | string;
 	getSideEffectsConnectionState(moduleGraph: ModuleGraph): ConnectionState;
-	codeGeneration(context: CodeGenerationContext): CodeGenerationResult;
+	codeGeneration(
+		context: CodeGenerationContext
+	): CodeGenerationResult | Promise<CodeGenerationResult>;
 	chunkCondition(chunk: Chunk, compilation: Compilation): boolean;
 	hasChunkCondition(): boolean;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
https://github.com/webpack/css-minimizer-webpack-plugin/pull/311 Add compilation.hooks.processContent AsyncSeriesWaterfallHook for plugins to transform module content (e.g., CSS minimization) during code generation. The hook uses a pure functional waterfall design — plugins receive `[content, sourceMap]` and return a new tuple, avoiding in-place mutation. Designed as async to support minimizers that leverage `worker threads` for parallel processing.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
Yes

**Does this PR introduce a breaking change?**
No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
Nothing