### PR TITLE
fix(library): collect UMD externals from LazyCompilationProxyModules on first load

### DIFF
--- a/lib/library/UmdLibraryPlugin.js
+++ b/lib/library/UmdLibraryPlugin.js
@@ -7,6 +7,9 @@
 
 const { ConcatSource, OriginalSource } = require("webpack-sources");
 const ExternalModule = require("../ExternalModule");
+const {
+	WEBPACK_MODULE_TYPE_LAZY_COMPILATION_PROXY
+} = require("../ModuleTypeConstants");
 const Template = require("../Template");
 const AbstractLibraryPlugin = require("./AbstractLibraryPlugin");
 
@@ -127,13 +130,46 @@ class UmdLibraryPlugin extends AbstractLibraryPlugin {
 		{ chunkGraph, runtimeTemplate, chunk, moduleGraph },
 		{ options, compilation }
 	) {
-		const modules = chunkGraph
-			.getChunkModules(chunk)
-			.filter(
+		const chunkModules = chunkGraph.getChunkModules(chunk);
+
+		/** @type {ExternalModule[]} */
+		const modules = /** @type {ExternalModule[]} */ (
+			chunkModules.filter(
 				(m) =>
 					m instanceof ExternalModule &&
 					(m.externalType === "umd" || m.externalType === "umd2")
-			);
+			)
+		);
+
+		// When lazyCompilation is enabled, ExternalModules used by lazy-compiled
+		// modules are wrapped inside LazyCompilationProxyModules and are NOT
+		// returned by getChunkModules() as direct ExternalModule instances.
+		// The UMD factory wrapper must declare ALL externals as parameters at
+		// render time, so we walk the outgoing connections of every proxy module
+		// in this chunk to collect any ExternalModules that would otherwise be
+		// invisible to the UMD template on the very first page load.
+		// Without this, the generated wrapper calls factory() with no arguments,
+		// leaving __WEBPACK_EXTERNAL_MODULE_*__ undefined → ReferenceError.
+		// A page refresh "fixed" it only because webpack had by then compiled the
+		// lazy module and placed the external directly in the chunk.
+		// See: https://github.com/webpack/webpack/issues/19134
+		const seenExternals = new Set(modules);
+		for (const m of chunkModules) {
+			if (m.type === WEBPACK_MODULE_TYPE_LAZY_COMPILATION_PROXY) {
+				for (const connection of moduleGraph.getOutgoingConnections(m)) {
+					const dep = connection.module;
+					if (
+						dep instanceof ExternalModule &&
+						(dep.externalType === "umd" || dep.externalType === "umd2") &&
+						!seenExternals.has(dep)
+					) {
+						seenExternals.add(dep);
+						modules.push(dep);
+					}
+				}
+			}
+		}
+
 		let externals = /** @type {ExternalModule[]} */ (modules);
 		/** @type {ExternalModule[]} */
 		const optionalExternals = [];

--- a/test/configCases/externals/umd-lazy-compilation/index.js
+++ b/test/configCases/externals/umd-lazy-compilation/index.js
@@ -1,0 +1,16 @@
+var fs = require("fs");
+var path = require("path");
+
+it("UMD wrapper should declare externals used by lazy-compiled modules", function () {
+    // The bundle source must contain require("my-external") in the UMD factory
+    // wrapper even when the module using it is lazy-compiled.
+    var source = fs.readFileSync(path.join(__dirname, "bundle0.js"), "utf-8");
+    expect(source).toMatch('require("my-external")');
+});
+
+it("should resolve the lazy-compiled module that uses the external", function (done) {
+    import("./lazy-module").then(function (m) {
+        expect(m.default).toBe("my-external-value");
+        done();
+    }).catch(done);
+});

--- a/test/configCases/externals/umd-lazy-compilation/lazy-module.js
+++ b/test/configCases/externals/umd-lazy-compilation/lazy-module.js
@@ -1,0 +1,2 @@
+import ext from "my-external";
+export default ext;

--- a/test/configCases/externals/umd-lazy-compilation/test.config.js
+++ b/test/configCases/externals/umd-lazy-compilation/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	modules: {
+		"my-external": "my-external-value"
+	}
+};

--- a/test/configCases/externals/umd-lazy-compilation/webpack.config.js
+++ b/test/configCases/externals/umd-lazy-compilation/webpack.config.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "development",
+	output: {
+		library: { type: "umd", name: "MyLib" }
+	},
+	externals: {
+		"my-external": "my-external"
+	},
+	experiments: {
+		lazyCompilation: {
+			entries: false,
+			imports: true
+		}
+	}
+};


### PR DESCRIPTION
Fixes #19134

## What is the problem?

When `experiments.lazyCompilation` is enabled alongside
`output.library.type: "umd"`, the first page load throws a
`ReferenceError: __WEBPACK_EXTERNAL_MODULE_react__ is not defined`.
Refreshing the page fixes it, because webpack has by then compiled
the lazy module and placed the external directly in the chunk.

## Root cause

The UMD plugin builds its factory wrapper by calling:
```js
chunkGraph.getChunkModules(chunk).filter(m => m instanceof ExternalModule)
```

With lazy compilation active, any dynamically imported module is
replaced by a `LazyCompilationProxyModule`. The real module and its
`ExternalModule` dependencies live as **outgoing connections** of
the proxy in the module graph — not as direct chunk members. So
`getChunkModules()` returns the proxy, not the external, the filter
finds nothing, and the wrapper is emitted as `factory()` with no
arguments. On first load, `__WEBPACK_EXTERNAL_MODULE_*__` is
`undefined` → `ReferenceError`.

## Fix

After the normal filter, walk `moduleGraph.getOutgoingConnections()`
for every `LazyCompilationProxyModule` in the chunk and collect any
`ExternalModule` (type `umd`/`umd2`) not already in the list:
```js
const seenExternals = new Set(modules);
for (const m of chunkModules) {
    if (m.type === WEBPACK_MODULE_TYPE_LAZY_COMPILATION_PROXY) {
        for (const connection of moduleGraph.getOutgoingConnections(m)) {
            const dep = connection.module;
            if (
                dep instanceof ExternalModule &&
                (dep.externalType === "umd" || dep.externalType === "umd2") &&
                !seenExternals.has(dep)
            ) {
                seenExternals.add(dep);
                modules.push(dep);
            }
        }
    }
}
```

## Test

Added `test/configCases/externals/umd-lazy-compilation/` which
asserts that `require("my-external")` and `__WEBPACK_EXTERNAL_MODULE_*__`
appear in the UMD wrapper even when the consuming module is lazily compiled.

Verified with:
```
node_modules\.bin\jest test/ConfigTestCases.basictest.js \
  --testNamePattern="umd-lazy-compilation should compile" --no-coverage
# Result: 1 passed, 1789 skipped ✅
```