### PR TITLE
[RFC] feat: native HTML file support as webpack entry points

### DIFF
--- a/lib/HtmlEntryPlugin.js
+++ b/lib/HtmlEntryPlugin.js
@@ -1,0 +1,33 @@
+"use strict";
+
+const EntryDependency = require("./dependencies/EntryDependency");
+
+/** @typedef {import("./Compiler")} Compiler */
+
+class HtmlEntryPlugin {
+  /**
+   * @param {string} context context path
+   * @param {string} entry entry path (.html file)
+   * @param {object} options entry options
+   */
+  constructor(context, entry, options) {
+    this.context = context;
+    this.entry = entry;
+    this.options = options || {};
+  }
+
+  /** @param {Compiler} compiler */
+  apply(compiler) {
+    compiler.hooks.make.tapAsync("HtmlEntryPlugin", (compilation, callback) => {
+      // Scaffold: using EntryDependency as placeholder.
+      // Will be replaced with HtmlDependency once HtmlModuleFactory
+      // and HtmlParser are implemented.
+      // See: https://github.com/webpack/webpack/issues/536
+      const dep = new EntryDependency(this.entry);
+      dep.loc = { name: this.entry };
+      compilation.addEntry(this.context, dep, this.options, callback);
+    });
+  }
+}
+
+module.exports = HtmlEntryPlugin;


### PR DESCRIPTION
## What this is
RFC scaffold submitted as part of my GSoC 2026 proposal for the "Entry Points as HTML" idea. Introduces the skeleton of `HtmlEntryPlugin` — first of four planned components.

## Planned architecture
- `HtmlEntryPlugin` — hooks `compiler.hooks.make`, registers HTML entries
- `HtmlModuleFactory` — resolves `.html` → `HtmlModule`
- `HtmlParser` — parse5-based DOM walker emitting `ScriptSrcDependency`, `LinkHrefDependency`, `ImgSrcDependency`
- `HtmlGenerator` — rewrites asset URLs in emitted HTML

## Current state
Skeleton only. `HtmlDependency` and `HtmlModuleFactory` are next steps pending mentor feedback on the module factory approach.

##Comment on issue #536
Hi — I'm working on a GSoC 2026 proposal for this feature. I've studied 
the EntryPlugin → NormalModuleFactory → Compilation.addEntry() pipeline 
and designed a 4-component architecture: HtmlEntryPlugin, HtmlModuleFactory, 
HtmlParser (parse5), and HtmlGenerator.
