### PR TITLE
docs: fix various typos in comments and documentation

### DIFF
--- a/declarations/WebpackOptions.d.ts
+++ b/declarations/WebpackOptions.d.ts
@@ -2001,7 +2001,7 @@ export interface OptimizationSplitChunksOptions {
 	 */
 	filename?: string | import("../lib/TemplatedPathPlugin").TemplatePathFn;
 	/**
-	 * Prevents exposing path info when creating names for parts splitted by maxSize.
+	 * Prevents exposing path info when creating names for parts split by maxSize.
 	 */
 	hidePathInfo?: boolean;
 	/**

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
 
 1. [Aggressive Merging](#aggressive-merging)
 2. [Chunk](#chunk)
-3. [Code Splitted](#code-splitted)
+3. [Code Split](#code-splitted)
 4. [Code Splitting](#code-splitting)
 5. [Coffee Script](#coffee-script)
 6. [CommonJS](#commonjs)
@@ -50,7 +50,7 @@
 
 [two-explicit-vendor-chunks](two-explicit-vendor-chunks)
 
-## Code Splitted
+## Code Split
 
 [code-splitted-require.context-amd](code-splitted-require.context-amd) example demonstrating contexts in a code-split environment with AMD.
 

--- a/examples/build-http/webpack.lock.data/https_jspm.dev/npm_jspm_core_2.0.0-beta_12b8110471722e74fcb6.11_nodelibs_process
+++ b/examples/build-http/webpack.lock.data/https_jspm.dev/npm_jspm_core_2.0.0-beta_12b8110471722e74fcb6.11_nodelibs_process
@@ -53,7 +53,7 @@ function nextTick (fun) {
   if (queue.length === 1 && !draining)
     setTimeout(drainQueue, 0);
 }
-// v8 likes predictible objects
+// v8 likes predictable objects
 function Item(fun, array) {
   this.fun = fun;
   this.array = array;

--- a/examples/http2-aggressive-splitting/README.md
+++ b/examples/http2-aggressive-splitting/README.md
@@ -2,7 +2,7 @@ This example demonstrates the AggressiveSplittingPlugin for splitting the bundle
 
 AggressiveSplittingPlugin splits every chunk until it reaches the specified `maxSize`. In this example, it tries to create chunks with <50kB raw code, which typically minimizes to ~10kB. It groups modules by folder structure, because modules in the same folder are likely to have similar repetitive text, making them gzip efficiently together. They are also likely to change together.
 
-AggressiveSplittingPlugin records its splitting in the webpack records. When it is next run, it tries to use the last recorded splitting. Since changes to application code between one run and the next are usually in only a few modules (or just one), re-using the old splittings (and chunks, which are probably still in the client's cache), is highly advantageous.
+AggressiveSplittingPlugin records its splitting in the webpack records. When it is next run, it tries to use the last recorded splitting. Since changes to application code between one run and the next are usually in only a few modules (or just one), reusing the old splittings (and chunks, which are probably still in the client's cache), is highly advantageous.
 
 Only chunks that are bigger than the specified `minSize` are stored into the records. This ensures that these chunks fill up as your application grows, instead of creating many records of small chunks for every change.
 

--- a/examples/http2-aggressive-splitting/template.md
+++ b/examples/http2-aggressive-splitting/template.md
@@ -2,7 +2,7 @@ This example demonstrates the AggressiveSplittingPlugin for splitting the bundle
 
 AggressiveSplittingPlugin splits every chunk until it reaches the specified `maxSize`. In this example, it tries to create chunks with <50kB raw code, which typically minimizes to ~10kB. It groups modules by folder structure, because modules in the same folder are likely to have similar repetitive text, making them gzip efficiently together. They are also likely to change together.
 
-AggressiveSplittingPlugin records its splitting in the webpack records. When it is next run, it tries to use the last recorded splitting. Since changes to application code between one run and the next are usually in only a few modules (or just one), re-using the old splittings (and chunks, which are probably still in the client's cache), is highly advantageous.
+AggressiveSplittingPlugin records its splitting in the webpack records. When it is next run, it tries to use the last recorded splitting. Since changes to application code between one run and the next are usually in only a few modules (or just one), reusing the old splittings (and chunks, which are probably still in the client's cache), is highly advantageous.
 
 Only chunks that are bigger than the specified `minSize` are stored into the records. This ensures that these chunks fill up as your application grows, instead of creating many records of small chunks for every change.
 

--- a/lib/cache/PackFileCacheStrategy.js
+++ b/lib/cache/PackFileCacheStrategy.js
@@ -494,7 +494,7 @@ class Pack {
 						new Set(usedItems),
 						async () => {
 							await content.unpack(
-								"it should be splitted into used and unused items"
+								"it should be split into used and unused items"
 							);
 							/** @type {Content} */
 							const map = new Map();
@@ -527,7 +527,7 @@ class Pack {
 						usedOfUnusedItems,
 						async () => {
 							await content.unpack(
-								"it should be splitted into used and unused items"
+								"it should be split into used and unused items"
 							);
 							/** @type {Content} */
 							const map = new Map();

--- a/lib/optimize/AggressiveSplittingPlugin.js
+++ b/lib/optimize/AggressiveSplittingPlugin.js
@@ -185,7 +185,7 @@ class AggressiveSplittingPlugin {
 
 						// split the chunk into two parts
 						const newChunk = compilation.addChunk();
-						newChunk.chunkReason = "aggressive splitted";
+						newChunk.chunkReason = "aggressive split";
 						for (const chunk of selectedChunks) {
 							for (const module of selectedModules) {
 								moveModuleBetween(chunkGraph, chunk, newChunk)(module);
@@ -210,7 +210,7 @@ class AggressiveSplittingPlugin {
 						if (applySplit(splitData)) changed = true;
 					}
 
-					// for any chunk which isn't splitted yet, split it and create a new entry
+					// for any chunk which isn't split yet, split it and create a new entry
 					// start with the biggest chunk
 					const cmpFn = compareChunks(chunkGraph);
 					const sortedChunks = [...chunks].sort((a, b) => {

--- a/lib/optimize/SplitChunksPlugin.js
+++ b/lib/optimize/SplitChunksPlugin.js
@@ -1584,7 +1584,7 @@ module.exports = class SplitChunksPlugin {
 						}
 						// Walk through all chunks
 						for (const chunk of usedChunks) {
-							// Add graph connections for splitted chunk
+							// Add graph connections for split chunk
 							chunk.split(newChunk);
 						}
 

--- a/lib/stats/DefaultStatsFactoryPlugin.js
+++ b/lib/stats/DefaultStatsFactoryPlugin.js
@@ -2001,8 +2001,8 @@ const errorsSpaceLimit = (errors, max) => {
 	for (; i < errors.length; i++) {
 		const error = errors[i];
 		if (typeof error !== "string" && error.details) {
-			const splitted = error.details.split("\n");
-			const len = splitted.length;
+			const split = error.details.split("\n");
+			const len = split.length;
 			fullLength += len;
 			if (fullLength > max) {
 				result = i > 0 ? errors.slice(0, i) : [];

--- a/lib/util/deterministicGrouping.js
+++ b/lib/util/deterministicGrouping.js
@@ -388,7 +388,7 @@ module.exports = ({ maxSize, minSize, items, getSize, getKey }) => {
 
 			while (queue.length) {
 				const group = /** @type {Group<T>} */ (queue.pop());
-				// only groups bigger than maxSize need to be splitted
+				// only groups bigger than maxSize need to be split
 				if (!isTooBig(group.size, maxSize)) {
 					result.push(group);
 					continue;

--- a/lib/wasm-sync/WasmChunkLoadingRuntimeModule.js
+++ b/lib/wasm-sync/WasmChunkLoadingRuntimeModule.js
@@ -319,7 +319,7 @@ class WasmChunkLoadingRuntimeModule extends RuntimeModule {
 			"",
 			// This function is used to delay reading the installed wasm module promises
 			// by a microtask. Sorting them doesn't help because there are edge cases where
-			// sorting is not possible (modules splitted into different chunks).
+			// sorting is not possible (modules split into different chunks).
 			// So we not even trying and solve this by a microtask delay.
 			"function promiseResolve() { return Promise.resolve(); }",
 			"",

--- a/types.d.ts
+++ b/types.d.ts
@@ -13194,7 +13194,7 @@ declare interface OptimizationSplitChunksOptions {
 	filename?: string | ((pathData: PathData, assetInfo?: AssetInfo) => string);
 
 	/**
-	 * Prevents exposing path info when creating names for parts splitted by maxSize.
+	 * Prevents exposing path info when creating names for parts split by maxSize.
 	 */
 	hidePathInfo?: boolean;
 


### PR DESCRIPTION
Fixes a few minor typos across the codebase (e.g. 'splitted' -> 'split', 'predictible' -> 'predictable').