### PR TITLE
feat(ci): anti-slop

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,0 +1,19 @@
+name: PR Quality
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  anti-slop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peakoss/anti-slop@85daca1880e9e1af197fc06ea03349daf08f4202 # v0.2.1
+        with:
+          require-pr-template: true
+          max-failures: 4


### PR DESCRIPTION
As I mentioned in Discord (https://discord.com/channels/1180618526436888586/1371080839341019237/1488565849462931496), GitHub's AI moderator doesn't support PRs yet, so in the mean time, this is an alternative action which uses a number of checks rather than an LLM to detect 'slop'

See https://github.com/peakoss/anti-slop.