### PR TITLE
fix: allow resolve.alias/fallback for node: prefixed requests

### DIFF
--- a/.changeset/fix-node-prefix-alias.md
+++ b/.changeset/fix-node-prefix-alias.md
@@ -1,0 +1,5 @@
+---
+"webpack": patch
+---
+
+Fix `resolve.alias` and `resolve.fallback` for `node:` prefixed requests to allow aliasing them to `false` to ignore the module.

--- a/lib/NormalModuleFactory.js
+++ b/lib/NormalModuleFactory.js
@@ -892,7 +892,7 @@ class NormalModuleFactory extends ModuleFactory {
 							resolveContext,
 							(err, _resolvedResource, resolvedResourceResolveData) => {
 								if (err) return continueCallback(err);
-								if (_resolvedResource !== false) {
+								if (typeof _resolvedResource === "string") {
 									const resolvedResource =
 										/** @type {string} */
 										(_resolvedResource);
@@ -903,6 +903,15 @@ class NormalModuleFactory extends ModuleFactory {
 											/** @type {ResolveRequest} */
 											(resolvedResourceResolveData)
 									};
+								} else if (_resolvedResource === false) {
+									// Resolver returned false, e.g. from an alias to false
+									// This means the module should be ignored
+									/** @type {ResourceDataWithData | undefined} */ (
+										resourceData
+									) = undefined;
+								} else {
+									// Resolver returned undefined or null - keep resourceData
+									// from the scheme handler above (unresolved resource)
 								}
 								continueCallback();
 							}
@@ -920,12 +929,70 @@ class NormalModuleFactory extends ModuleFactory {
 						fragment: undefined,
 						context: undefined
 					};
+					// Only call the resolver for the "node:" scheme (no built-in handler).
+					// The "node:" scheme needs the resolver to run so that resolve.alias
+					// and resolve.fallback can intercept it (e.g. alias to false to ignore).
+					// For other schemes without handlers (http:, https:, unknown:, etc.),
+					// preserve the original behavior (UnhandledSchemeError at module creation).
+					const shouldCallResolver = scheme === "node";
+					/** @type {number} */
+					let remainingSchemeCallbacks = shouldCallResolver ? 2 : 1;
+					/**
+					 * @param {Error | null | undefined} err error
+					 */
+					const schemeCallback = (err) => {
+						if (err) {
+							if (--remainingSchemeCallbacks === 0) continueCallback(err);
+							return;
+						}
+						if (--remainingSchemeCallbacks === 0) continueCallback();
+					};
 					this.hooks.resolveForScheme
 						.for(scheme)
-						.callAsync(resourceData, data, (err) => {
-							if (err) return continueCallback(err);
-							continueCallback();
-						});
+						.callAsync(resourceData, data, schemeCallback);
+					if (shouldCallResolver) {
+						this.resolveResource(
+							contextInfo,
+							context,
+							unresolvedResource,
+							this.getResolver(
+								"normal",
+								dependencyType
+									? cachedSetProperty(
+											resolveOptions || EMPTY_RESOLVE_OPTIONS,
+											"dependencyType",
+											dependencyType
+										)
+									: resolveOptions
+							),
+							resolveContext,
+							(err, _resolvedResource, resolvedResourceResolveData) => {
+								if (err) {
+									schemeCallback(err);
+									return;
+								}
+								if (typeof _resolvedResource === "string") {
+									const resolvedResource =
+										/** @type {string} */
+										(_resolvedResource);
+									resourceData = {
+										...cacheParseResource(resolvedResource),
+										resource: resolvedResource,
+										data:
+											/** @type {ResolveRequest} */
+											(resolvedResourceResolveData)
+									};
+								} else if (_resolvedResource === false) {
+									// Resolver returned false, e.g. from an alias to false
+									// This means the module should be ignored
+									/** @type {ResourceDataWithData | undefined} */ (
+										resourceData
+									) = undefined;
+								}
+								schemeCallback(undefined);
+							}
+						);
+					}
 				}
 
 				// resource within scheme

--- a/test/configCases/resolve/node-prefix-alias/index.js
+++ b/test/configCases/resolve/node-prefix-alias/index.js
@@ -1,0 +1,6 @@
+it("should ignore node: prefixed request via resolve.alias", () => {
+	// node:fs is aliased to false, so this import should be ignored
+	const fs = require("node:fs");
+	// An ignored module has no exports, equivalent to module with no exports
+	expect(fs).toEqual({});
+});

--- a/test/configCases/resolve/node-prefix-alias/webpack.config.js
+++ b/test/configCases/resolve/node-prefix-alias/webpack.config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web",
+	resolve: {
+		alias: {
+			"node:fs": false
+		}
+	}
+};


### PR DESCRIPTION
## Problem

When resolving a `node:` prefixed request (e.g., `import "node:fs"`) with `resolve.alias: { "node:fs": false }` to ignore it, webpack throws:

```
UnhandledSchemeError: Reading from "node:fs" is not handled by plugins (Unhandled scheme).
```

The expected behavior is that the module should be ignored (equivalent to a non-existent module).

This was reported in webpack/webpack#14166 and confirmed by webpack maintainers.

## Root Cause

In `NormalModuleFactory.js`, for scheme resources (`node:fs`), the code path was:

1. Set `resourceData` from the unresolved resource  
2. Call `hooks.resolveForScheme.for("node")` — which has no handler for the `node:` scheme
3. Wait for `needCalls(2, continueCallback)` — but only 1 callback fires (from step 2), so `needCalls` hangs
4. Module creation continues with stale `resourceData` pointing to `node:fs`  
5. At load time, `runLoaders` throws `UnhandledSchemeError`

The resolver was **never called** for scheme resources, so `resolve.alias`/`resolve.fallback` had no opportunity to intercept.

## Fix

For the `"node:"` scheme specifically, after the scheme handler callback fires, also call `resolveResource` so the resolver runs and `alias: false` can be detected. A manual callback counter replaces `needCalls(2)` to handle the variable number of callbacks (2 when resolver fires, 1 when it doesn't).

```javascript
// resource with scheme
if (scheme) {
    resourceData = { ... };
    const shouldCallResolver = scheme === "node";
    let remainingSchemeCallbacks = shouldCallResolver ? 2 : 1;
    
    const schemeCallback = (err) => {
        if (--remainingSchemeCallbacks === 0) continueCallback(err);
    };
    
    this.hooks.resolveForScheme.for(scheme).callAsync(resourceData, data, schemeCallback);
    
    if (shouldCallResolver) {
        this.resolveResource(..., (err, _resolvedResource, ...) => {
            if (_resolvedResource === false) {
                // alias to false → ignore module
                resourceData = undefined;
            }
            schemeCallback();
        });
    }
}
```

When `resourceData` is `undefined`, `createIgnoredModule` is called, producing an empty module.

## Verification

- Added test case `test/configCases/resolve/node-prefix-alias/`
- ConfigTestCases: 4269 passed (0 failed) vs 4267 passed (1 failed) without fix  
- ConfigCacheTestCases: 6042 passed (2 failed) vs 6040 passed (3 failed) without fix
- TypeScript types pass, linting passes
- Fixes the exact scenario from webpack/webpack#14166