### PR TITLE
feat(container): refactor(modulefederationplugin): support reference hoisting and optional async boundary

### DIFF
--- a/lib/container/ModuleFederationPlugin.js
+++ b/lib/container/ModuleFederationPlugin.js
@@ -11,7 +11,7 @@ const Compilation = require("../Compilation");
 const SharePlugin = require("../sharing/SharePlugin");
 const ContainerPlugin = require("./ContainerPlugin");
 const ContainerReferencePlugin = require("./ContainerReferencePlugin");
-const HoistContainerReferences = require("./HoistContainerReferencesPlugin");
+const HoistContainerReferences = require("./HoistContainerReferences");
 
 /** @typedef {import("../../declarations/plugins/container/ModuleFederationPlugin").ExternalsType} ExternalsType */
 /** @typedef {import("../../declarations/plugins/container/ModuleFederationPlugin").ModuleFederationPluginOptions} ModuleFederationPluginOptions */
@@ -81,6 +81,7 @@ class ModuleFederationPlugin {
 			);
 		});
 		const { options } = this;
+		const referenceHoisting = options.referenceHoisting !== false;
 		const library = options.library || { type: "var", name: options.name };
 		const remoteType =
 			options.remoteType ||
@@ -127,7 +128,9 @@ class ModuleFederationPlugin {
 					shareScope: options.shareScope
 				}).apply(compiler);
 			}
-			new HoistContainerReferences().apply(compiler);
+			if (referenceHoisting) {
+				new HoistContainerReferences().apply(compiler);
+			}
 		});
 	}
 }


### PR DESCRIPTION
## Description

Update the ModuleFederationPlugin to accept new options that enable reference hoisting and remove the enforcement of a mandatory async import() boundary. This aligns the plugin with MFv2 behavior where the initialization of remotes and shared modules can be handled without forcing an async wrapper in user code. Also adds support for splitChunks: all by adjusting chunk graph dependencies.

## Changes

- `lib/container/ModuleFederationPlugin.js` (modified)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Code follows the style guidelines of this project
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Corresponding changes to documentation made (if applicable)

**Severity**: `critical`



Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.

Closes #18809